### PR TITLE
feat(dashboard): named perspective store — atomic CRUD over the landed collection schema (#14669)

### DIFF
--- a/src/dashboard/DockPerspectiveStore.mjs
+++ b/src/dashboard/DockPerspectiveStore.mjs
@@ -1,0 +1,395 @@
+import Base          from '../core/Base.mjs';
+import DockZoneModel from './DockZoneModel.mjs';
+import Observable    from '../core/Observable.mjs';
+
+/**
+ * @summary The named perspective store: CRUD + list + lifecycle over ONE `dockLayoutCollection.v1`
+ * document — the home that turns captured perspectives from one-shot values into named, durable,
+ * switchable state.
+ *
+ * The store deliberately introduces NO new persisted shape (the docking ADR's anti-anchor): it
+ * operates on the landed collection schema through `DockZoneModel`'s validators and constructors,
+ * and every read or write crosses its boundary as plain JSON clones — no live component refs, no
+ * functions, no window state can enter or leave (guardrail-specced). Mutations are atomic and
+ * fail closed: the CANDIDATE collection validates as a whole before it replaces the current one,
+ * so a rejected operation leaves the store byte-identical.
+ *
+ * Contracts (binding):
+ *
+ * - **Name collision is a USER decision, never silent.** `savePerspective` against an existing
+ *   name returns a structured `collision` verdict (who holds the name, under which layoutId) and
+ *   saves nothing unless the caller explicitly passes `replace: true`. `renamePerspective` obeys
+ *   the same rule.
+ * - **Loads migrate honestly.** `loadPerspective` runs the stored record through the landed
+ *   `restoreSavedLayout` seam — legacy v1 records gain the perspective fields with honest
+ *   defaults, invalid records fail closed with the validator's own errors, and the MIGRATED
+ *   record is what the store hands back (and re-commits, so the collection converges forward).
+ * - **Persistence is a caller-injected seam.** The optional `persistenceAdapter`
+ *   (`{read(): Promise<Object|null>, write(collection): Promise}`) keeps storage tech app-side
+ *   (LocalStorage, files, remote) — the store guarantees only that plain validated JSON crosses
+ *   it, in both directions.
+ * - **Names resolve against `perspectiveName` first, `layoutId` second** — the product-facing
+ *   key wins; the technical key stays addressable.
+ *
+ * Lifecycle events for UI binding (the switcher consumes these): `perspectiveSaved`,
+ * `perspectiveLoaded`, `perspectiveRemoved`, `perspectiveRenamed`, `collectionChange` — each
+ * fires AFTER the atomic commit, carrying plain-JSON payloads only.
+ *
+ * @class Neo.dashboard.DockPerspectiveStore
+ * @extends Neo.core.Base
+ * @mixes Neo.core.Observable
+ * @see Neo.dashboard.DockZoneModel
+ * @see learn/agentos/HarnessDockZoneModel.md
+ */
+class DockPerspectiveStore extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockPerspectiveStore'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockPerspectiveStore',
+        /**
+         * @member {String} ntype='dock-perspective-store'
+         * @protected
+         */
+        ntype: 'dock-perspective-store',
+        /**
+         * @member {Array} mixins=[Observable]
+         */
+        mixins: [Observable],
+        /**
+         * The managed `dockLayoutCollection.v1` document. Assignments validate as a whole and
+         * FAIL CLOSED: an invalid candidate is rejected (the previous collection stays) with the
+         * validator errors surfaced on {@link #lastErrors}.
+         * @member {Object|null} collection_=null
+         * @reactive
+         */
+        collection_: null,
+        /**
+         * Optional storage seam: `{read(): Promise<Object|null>, write(collection): Promise}`.
+         * The store passes plain validated JSON clones through it — never live references. A
+         * non-reactive config: the adapter is wiring, not state.
+         * @member {Object|null} persistenceAdapter=null
+         */
+        persistenceAdapter: null
+    }
+
+    /**
+     * Validator errors of the most recent rejected operation or assignment — empty after every
+     * successful commit. Plain runtime state for UI binding; never persisted.
+     * @member {String[]} lastErrors=[]
+     */
+    lastErrors = []
+
+    /**
+     * Fail-closed whole-collection validation on every assignment: `null` stays allowed (an
+     * empty store); anything else must validate as a `dockLayoutCollection.v1` or the previous
+     * value survives.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @returns {Object|null}
+     * @protected
+     */
+    beforeSetCollection(value, oldValue) {
+        if (value === null || value === undefined) {
+            this.lastErrors = [];
+            return null
+        }
+
+        let errors = DockZoneModel.validateSavedLayoutCollection(value);
+
+        if (errors.length) {
+            this.lastErrors = errors;
+            return oldValue ?? null
+        }
+
+        this.lastErrors = [];
+        return DockZoneModel.clone(value)
+    }
+
+    /**
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetCollection(value, oldValue) {
+        oldValue !== undefined && this.fire('collectionChange', {collection: DockZoneModel.clone(value)})
+    }
+
+    /**
+     * Resolves a perspective entry by product name first (`perspectiveName`), technical id
+     * second (`layoutId`).
+     * @param {String} name
+     * @returns {{layoutId: String, layout: Object}|null}
+     * @protected
+     */
+    resolveEntry(name) {
+        let layouts = this.collection?.layouts || {};
+
+        for (const [layoutId, layout] of Object.entries(layouts)) {
+            if (layout?.perspectiveName === name) return {layout, layoutId}
+        }
+
+        return layouts[name] ? {layout: layouts[name], layoutId: name} : null
+    }
+
+    /**
+     * @param {String} name
+     * @returns {Boolean}
+     */
+    exists(name) {
+        return !!this.resolveEntry(name)
+    }
+
+    /**
+     * Plain-JSON summaries of every stored perspective, in insertion order — the switcher's
+     * list model. Never exposes the records themselves.
+     * @returns {Object[]} `[{layoutId, title, perspectiveName, captureScope, revision}]`
+     */
+    list() {
+        return Object.entries(this.collection?.layouts || {}).map(([layoutId, layout]) => ({
+            captureScope   : layout?.captureScope ?? null,
+            layoutId,
+            perspectiveName: layout?.perspectiveName ?? null,
+            revision       : layout?.revision ?? null,
+            title          : layout?.title ?? null
+        }))
+    }
+
+    /**
+     * Saves one v2 saved-layout record under its name. The record must validate through the
+     * landed restore seam (which also migrates legacy inputs forward). An existing holder of the
+     * name (or layoutId) yields the structured collision verdict — nothing saves unless the
+     * caller decides with `replace: true`.
+     * @param {Object} layout A `dockLayout.v1` saved-layout record.
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.replace=false] The caller's explicit collision decision.
+     * @param {Boolean} [options.activate=true] Point `activeLayoutId` at the saved record.
+     * @returns {{saved: Boolean, layoutId: String|null, collision: Object|null, errors: String[]}}
+     */
+    savePerspective(layout, {replace = false, activate = true} = {}) {
+        let me        = this,
+            validated = DockZoneModel.restoreSavedLayout(layout);
+
+        if (validated.errors.length) {
+            me.lastErrors = validated.errors;
+            return {collision: null, errors: validated.errors, layoutId: null, saved: false}
+        }
+
+        let record   = DockZoneModel.clone(layout),
+            name     = record.perspectiveName ?? record.layoutId,
+            existing = me.resolveEntry(name);
+
+        // Collision means a DIFFERENT record holds the name — re-saving your own layoutId under
+        // its own name is the normal update flow, not a name dispute.
+        if (existing && existing.layoutId !== record.layoutId && !replace) {
+            return {
+                collision: {holderLayoutId: existing.layoutId, holderTitle: existing.layout?.title ?? null, name},
+                errors   : [],
+                layoutId : null,
+                saved    : false
+            }
+        }
+
+        let base      = me.collection ?? DockZoneModel.createSavedLayoutCollection([], {}).collection,
+            candidate = DockZoneModel.clone(base);
+
+        // an explicit replace under a DIFFERENT layoutId retires the previous holder — one name,
+        // one record, never two entries answering to it
+        if (existing && existing.layoutId !== record.layoutId) {
+            delete candidate.layouts[existing.layoutId]
+        }
+
+        candidate.layouts[record.layoutId] = record;
+        activate && (candidate.activeLayoutId = record.layoutId);
+
+        return me.commit(candidate, 'perspectiveSaved', {layoutId: record.layoutId, name}) ?
+            {collision: null, errors: [], layoutId: record.layoutId, saved: true} :
+            {collision: null, errors: me.lastErrors, layoutId: null, saved: false}
+    }
+
+    /**
+     * Loads a stored perspective by name: the record runs the landed restore seam (validation +
+     * honest v1→v2 migration), the MIGRATED record re-commits so the collection converges
+     * forward, and both the record and its restored primary document return to the caller.
+     * @param {String} name
+     * @returns {{layout: Object|null, document: Object|null, errors: String[]}}
+     */
+    loadPerspective(name) {
+        let me    = this,
+            entry = me.resolveEntry(name);
+
+        if (!entry) {
+            return {document: null, errors: [`no perspective named "${name}"`], layout: null}
+        }
+
+        let restored = DockZoneModel.restoreSavedLayout(entry.layout);
+
+        if (restored.errors.length) {
+            me.lastErrors = restored.errors;
+            return {document: null, errors: restored.errors, layout: null}
+        }
+
+        let migrated  = DockZoneModel.migrateSavedLayout(DockZoneModel.clone(entry.layout)),
+            candidate = DockZoneModel.clone(me.collection);
+
+        candidate.layouts[entry.layoutId] = migrated;
+        candidate.activeLayoutId          = entry.layoutId;
+
+        if (!me.commit(candidate, 'perspectiveLoaded', {layoutId: entry.layoutId, name})) {
+            return {document: null, errors: me.lastErrors, layout: null}
+        }
+
+        return {document: restored.document, errors: [], layout: DockZoneModel.clone(migrated)}
+    }
+
+    /**
+     * Renames a stored perspective — collision-explicit like `savePerspective`: an existing
+     * holder of the target name blocks the rename with the structured verdict.
+     * @param {String} from
+     * @param {String} to
+     * @returns {{renamed: Boolean, collision: Object|null, errors: String[]}}
+     */
+    renamePerspective(from, to) {
+        let me    = this,
+            entry = me.resolveEntry(from);
+
+        if (!entry) {
+            return {collision: null, errors: [`no perspective named "${from}"`], renamed: false}
+        }
+
+        if (typeof to !== 'string' || !to.trim()) {
+            return {collision: null, errors: ['the new name must be a non-empty string'], renamed: false}
+        }
+
+        let holder = me.resolveEntry(to);
+
+        if (holder && holder.layoutId !== entry.layoutId) {
+            return {
+                collision: {holderLayoutId: holder.layoutId, holderTitle: holder.layout?.title ?? null, name: to},
+                errors   : [],
+                renamed  : false
+            }
+        }
+
+        let candidate = DockZoneModel.clone(me.collection);
+
+        candidate.layouts[entry.layoutId].perspectiveName = to;
+
+        return me.commit(candidate, 'perspectiveRenamed', {from, layoutId: entry.layoutId, to}) ?
+            {collision: null, errors: [], renamed: true} :
+            {collision: null, errors: me.lastErrors, renamed: false}
+    }
+
+    /**
+     * Removes a stored perspective by name — fail-closed on a missing name (a structured error,
+     * never a silent no-op), and an `activeLayoutId` pointing at the removed record clears to
+     * null rather than dangling.
+     * @param {String} name
+     * @returns {{removed: Boolean, errors: String[]}}
+     */
+    removePerspective(name) {
+        let me    = this,
+            entry = me.resolveEntry(name);
+
+        if (!entry) {
+            return {errors: [`no perspective named "${name}"`], removed: false}
+        }
+
+        let candidate = DockZoneModel.clone(me.collection);
+
+        delete candidate.layouts[entry.layoutId];
+
+        if (candidate.activeLayoutId === entry.layoutId) {
+            candidate.activeLayoutId = null
+        }
+
+        return me.commit(candidate, 'perspectiveRemoved', {layoutId: entry.layoutId, name}) ?
+            {errors: [], removed: true} :
+            {errors: me.lastErrors, removed: false}
+    }
+
+    /**
+     * Writes the current collection through the injected adapter as a plain validated clone.
+     * Fail-closed without an adapter or a collection.
+     * @returns {Promise<{persisted: Boolean, errors: String[]}>}
+     */
+    async persist() {
+        let me = this;
+
+        if (typeof me.persistenceAdapter?.write !== 'function') {
+            return {errors: ['no persistence adapter with a write() seam is configured'], persisted: false}
+        }
+
+        if (!me.collection) {
+            return {errors: ['nothing to persist: the store holds no collection'], persisted: false}
+        }
+
+        try {
+            await me.persistenceAdapter.write(DockZoneModel.clone(me.collection));
+            return {errors: [], persisted: true}
+        } catch (error) {
+            return {errors: [error?.message || 'the persistence adapter rejected the write'], persisted: false}
+        }
+    }
+
+    /**
+     * Reads a collection through the injected adapter and adopts it ONLY when it validates —
+     * a corrupt payload leaves the store untouched with the validator errors returned.
+     * @returns {Promise<{hydrated: Boolean, errors: String[]}>}
+     */
+    async hydrate() {
+        let me = this;
+
+        if (typeof me.persistenceAdapter?.read !== 'function') {
+            return {errors: ['no persistence adapter with a read() seam is configured'], hydrated: false}
+        }
+
+        let payload;
+
+        try {
+            payload = await me.persistenceAdapter.read()
+        } catch (error) {
+            return {errors: [error?.message || 'the persistence adapter rejected the read'], hydrated: false}
+        }
+
+        if (payload === null || payload === undefined) {
+            return {errors: [], hydrated: false}
+        }
+
+        let errors = DockZoneModel.validateSavedLayoutCollection(payload);
+
+        if (errors.length) {
+            me.lastErrors = errors;
+            return {errors, hydrated: false}
+        }
+
+        me.collection = payload;
+        return {errors: [], hydrated: true}
+    }
+
+    /**
+     * The single atomic commit seam every mutation funnels through: whole-candidate validation,
+     * fail-closed rejection, then the lifecycle event AFTER the new collection is live.
+     * @param {Object} candidate The next collection document.
+     * @param {String} eventName Lifecycle event to fire on success.
+     * @param {Object} payload Plain-JSON event payload.
+     * @returns {Boolean} committed
+     * @protected
+     */
+    commit(candidate, eventName, payload) {
+        let me     = this,
+            errors = DockZoneModel.validateSavedLayoutCollection(candidate);
+
+        if (errors.length) {
+            me.lastErrors = errors;
+            return false
+        }
+
+        me.collection = candidate;
+        me.fire(eventName, payload);
+        return true
+    }
+}
+
+export default Neo.setupClass(DockPerspectiveStore);

--- a/src/dashboard/DockPerspectiveStore.mjs
+++ b/src/dashboard/DockPerspectiveStore.mjs
@@ -2,6 +2,12 @@ import Base          from '../core/Base.mjs';
 import DockZoneModel from './DockZoneModel.mjs';
 import Observable    from '../core/Observable.mjs';
 
+// Prototype-shaped keys are rejected at the write boundary: `layouts[key]` assignment with
+// '__proto__' mutates the object's prototype instead of adding a record, and inherited
+// function keys ('constructor') satisfy truthy lookups with garbage. Fail closed at entry —
+// no read-side special-casing can stay complete.
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 /**
  * @summary The named perspective store: CRUD + list + lifecycle over ONE `dockLayoutCollection.v1`
  * document — the home that turns captured perspectives from one-shot values into named, durable,
@@ -16,10 +22,23 @@ import Observable    from '../core/Observable.mjs';
  *
  * Contracts (binding):
  *
+ * - **Public reads are isolated.** The `collection` getter hands out a deep clone — no caller
+ *   can reach the held document, so state changes only ever enter through the atomic commit
+ *   seam (whole-candidate validation + lifecycle events). `persist()` additionally revalidates
+ *   before writing: bytes that do not validate never reach the adapter as `persisted: true`.
  * - **Name collision is a USER decision, never silent.** `savePerspective` against an existing
  *   name returns a structured `collision` verdict (who holds the name, under which layoutId) and
- *   saves nothing unless the caller explicitly passes `replace: true`. `renamePerspective` obeys
- *   the same rule.
+ *   saves nothing unless the caller explicitly passes `replace: true`. `renamePerspective(from,
+ *   to, {replace})` obeys the same rule with the same atomic retire-the-holder semantics.
+ * - **One namespace, both keys reachable.** `perspectiveName` and `layoutId` share one
+ *   resolution namespace: a save whose layoutId an OTHER record's perspectiveName would shadow
+ *   (or vice versa) is a collision, so every stored record stays addressable through both
+ *   documented paths. Prototype-shaped keys (`__proto__`, `constructor`, `prototype`) are
+ *   rejected at the write boundary.
+ * - **Removing the active perspective repoints, never dangles.** With siblings present the
+ *   successor is the caller's `replacementName` or the first remaining record (insertion
+ *   order), reusing the landed `removeSavedLayout` invariant; removing the last record clears
+ *   `activeLayoutId` to null.
  * - **Loads migrate honestly.** `loadPerspective` runs the stored record through the landed
  *   `restoreSavedLayout` seam — legacy v1 records gain the perspective fields with honest
  *   defaults, invalid records fail closed with the validator's own errors, and the MIGRATED
@@ -117,20 +136,33 @@ class DockPerspectiveStore extends Base {
     }
 
     /**
+     * Public reads are isolated: the getter hands out a deep clone, so no caller can mutate the
+     * held document behind the commit seam (no validation bypass, no silent event-less state).
+     * Internal code reads the raw `_collection` backing field on purpose.
+     * @param {Object|null} value
+     * @returns {Object|null}
+     * @protected
+     */
+    beforeGetCollection(value) {
+        return value ? DockZoneModel.clone(value) : value
+    }
+
+    /**
      * Resolves a perspective entry by product name first (`perspectiveName`), technical id
-     * second (`layoutId`).
+     * second (`layoutId`) — own-property lookup only, so inherited keys can never satisfy the
+     * id path.
      * @param {String} name
      * @returns {{layoutId: String, layout: Object}|null}
      * @protected
      */
     resolveEntry(name) {
-        let layouts = this.collection?.layouts || {};
+        let layouts = this._collection?.layouts || {};
 
         for (const [layoutId, layout] of Object.entries(layouts)) {
             if (layout?.perspectiveName === name) return {layout, layoutId}
         }
 
-        return layouts[name] ? {layout: layouts[name], layoutId: name} : null
+        return Object.hasOwn(layouts, name) ? {layout: layouts[name], layoutId: name} : null
     }
 
     /**
@@ -147,7 +179,7 @@ class DockPerspectiveStore extends Base {
      * @returns {Object[]} `[{layoutId, title, perspectiveName, captureScope, revision}]`
      */
     list() {
-        return Object.entries(this.collection?.layouts || {}).map(([layoutId, layout]) => ({
+        return Object.entries(this._collection?.layouts || {}).map(([layoutId, layout]) => ({
             captureScope   : layout?.captureScope ?? null,
             layoutId,
             perspectiveName: layout?.perspectiveName ?? null,
@@ -176,31 +208,60 @@ class DockPerspectiveStore extends Base {
             return {collision: null, errors: validated.errors, layoutId: null, saved: false}
         }
 
-        let record   = DockZoneModel.clone(layout),
-            name     = record.perspectiveName ?? record.layoutId,
-            existing = me.resolveEntry(name);
+        let record = DockZoneModel.clone(layout),
+            unsafe = [record.layoutId, record.perspectiveName].filter(key => UNSAFE_KEYS.has(key));
 
-        // Collision means a DIFFERENT record holds the name — re-saving your own layoutId under
-        // its own name is the normal update flow, not a name dispute.
-        if (existing && existing.layoutId !== record.layoutId && !replace) {
-            return {
-                collision: {holderLayoutId: existing.layoutId, holderTitle: existing.layout?.title ?? null, name},
-                errors   : [],
-                layoutId : null,
-                saved    : false
+        if (unsafe.length) {
+            let errors = unsafe.map(key => `"${key}" is not a usable perspective key`);
+            me.lastErrors = errors;
+            return {collision: null, errors, layoutId: null, saved: false}
+        }
+
+        let name     = record.perspectiveName ?? record.layoutId,
+            existing = me.resolveEntry(name),
+            // the technical id must STAY reachable after the save: another record's
+            // perspectiveName shadowing the incoming layoutId would win the name-first scan
+            // and make this record unaddressable by id — same collision, other namespace
+            shadow   = name === record.layoutId ? null : me.resolveEntry(record.layoutId);
+
+        shadow?.layoutId === record.layoutId && (shadow = null);
+
+        // Collision means a DIFFERENT record holds the name (or shadows the id) — re-saving
+        // your own layoutId under its own name is the normal update flow, not a name dispute.
+        for (const dispute of [existing, shadow]) {
+            if (dispute && dispute.layoutId !== record.layoutId && !replace) {
+                return {
+                    collision: {
+                        holderLayoutId: dispute.layoutId,
+                        holderTitle   : dispute.layout?.title ?? null,
+                        name          : dispute === existing ? name : record.layoutId
+                    },
+                    errors  : [],
+                    layoutId: null,
+                    saved   : false
+                }
             }
         }
 
-        let base      = me.collection ?? DockZoneModel.createSavedLayoutCollection([], {}).collection,
+        let base      = me._collection ?? DockZoneModel.createSavedLayoutCollection([], {}).collection,
             candidate = DockZoneModel.clone(base);
 
-        // an explicit replace under a DIFFERENT layoutId retires the previous holder — one name,
-        // one record, never two entries answering to it
-        if (existing && existing.layoutId !== record.layoutId) {
-            delete candidate.layouts[existing.layoutId]
+        // an explicit replace retires every previous holder — one name, one record, never two
+        // entries answering to it (in either namespace)
+        for (const dispute of [existing, shadow]) {
+            if (dispute && dispute.layoutId !== record.layoutId) {
+                delete candidate.layouts[dispute.layoutId]
+            }
         }
 
         candidate.layouts[record.layoutId] = record;
+
+        // a retired holder may have been the active record: the replacement inherits activeness
+        // rather than leaving the pointer dangling (the whole-candidate validator would reject)
+        if (candidate.activeLayoutId !== null && !Object.hasOwn(candidate.layouts, candidate.activeLayoutId)) {
+            candidate.activeLayoutId = record.layoutId
+        }
+
         activate && (candidate.activeLayoutId = record.layoutId);
 
         return me.commit(candidate, 'perspectiveSaved', {layoutId: record.layoutId, name}) ?
@@ -231,7 +292,7 @@ class DockPerspectiveStore extends Base {
         }
 
         let migrated  = DockZoneModel.migrateSavedLayout(DockZoneModel.clone(entry.layout)),
-            candidate = DockZoneModel.clone(me.collection);
+            candidate = DockZoneModel.clone(me._collection);
 
         candidate.layouts[entry.layoutId] = migrated;
         candidate.activeLayoutId          = entry.layoutId;
@@ -244,13 +305,16 @@ class DockPerspectiveStore extends Base {
     }
 
     /**
-     * Renames a stored perspective — collision-explicit like `savePerspective`: an existing
-     * holder of the target name blocks the rename with the structured verdict.
+     * Renames a stored perspective — collision-explicit like `savePerspective`, with the same
+     * atomic decision path: an existing holder of the target name blocks the rename with the
+     * structured verdict, and `replace: true` retires that holder and renames in ONE commit.
      * @param {String} from
      * @param {String} to
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.replace=false] The caller's explicit collision decision.
      * @returns {{renamed: Boolean, collision: Object|null, errors: String[]}}
      */
-    renamePerspective(from, to) {
+    renamePerspective(from, to, {replace = false} = {}) {
         let me    = this,
             entry = me.resolveEntry(from);
 
@@ -262,9 +326,17 @@ class DockPerspectiveStore extends Base {
             return {collision: null, errors: ['the new name must be a non-empty string'], renamed: false}
         }
 
+        if (UNSAFE_KEYS.has(to)) {
+            let errors = [`"${to}" is not a usable perspective key`];
+            me.lastErrors = errors;
+            return {collision: null, errors, renamed: false}
+        }
+
         let holder = me.resolveEntry(to);
 
-        if (holder && holder.layoutId !== entry.layoutId) {
+        holder?.layoutId === entry.layoutId && (holder = null);
+
+        if (holder && !replace) {
             return {
                 collision: {holderLayoutId: holder.layoutId, holderTitle: holder.layout?.title ?? null, name: to},
                 errors   : [],
@@ -272,7 +344,17 @@ class DockPerspectiveStore extends Base {
             }
         }
 
-        let candidate = DockZoneModel.clone(me.collection);
+        let candidate = DockZoneModel.clone(me._collection);
+
+        if (holder) {
+            delete candidate.layouts[holder.layoutId];
+
+            // the retired holder may have been active: the renamed record inherits activeness
+            // rather than leaving the pointer dangling
+            if (candidate.activeLayoutId !== null && !Object.hasOwn(candidate.layouts, candidate.activeLayoutId)) {
+                candidate.activeLayoutId = entry.layoutId
+            }
+        }
 
         candidate.layouts[entry.layoutId].perspectiveName = to;
 
@@ -283,12 +365,18 @@ class DockPerspectiveStore extends Base {
 
     /**
      * Removes a stored perspective by name — fail-closed on a missing name (a structured error,
-     * never a silent no-op), and an `activeLayoutId` pointing at the removed record clears to
-     * null rather than dangling.
+     * never a silent no-op). Removing the ACTIVE record with siblings present repoints
+     * `activeLayoutId` to the caller's `replacementName` or the first remaining record
+     * (insertion order), through the landed `removeSavedLayout` invariant; removing the last
+     * record clears it to null.
      * @param {String} name
+     * @param {Object} [options={}]
+     * @param {String} [options.replacementName] Explicit successor for the active pointer. Always
+     * validated when provided (must name a remaining record) — never a silently ignored option;
+     * consulted for repointing only when the removed record was active.
      * @returns {{removed: Boolean, errors: String[]}}
      */
-    removePerspective(name) {
+    removePerspective(name, {replacementName} = {}) {
         let me    = this,
             entry = me.resolveEntry(name);
 
@@ -296,7 +384,38 @@ class DockPerspectiveStore extends Base {
             return {errors: [`no perspective named "${name}"`], removed: false}
         }
 
-        let candidate = DockZoneModel.clone(me.collection);
+        let layouts        = me._collection.layouts,
+            removingActive = me._collection.activeLayoutId === entry.layoutId,
+            siblings       = Object.keys(layouts).filter(layoutId => layoutId !== entry.layoutId),
+            successorId    = null;
+
+        // a provided successor validates unconditionally (never a silently ignored option),
+        // even when the removal would not need one
+        if (replacementName !== undefined) {
+            let successor = me.resolveEntry(replacementName);
+
+            if (!successor || successor.layoutId === entry.layoutId) {
+                return {errors: [`no remaining perspective named "${replacementName}" to activate`], removed: false}
+            }
+
+            successorId = successor.layoutId
+        }
+
+        if (removingActive && siblings.length) {
+            let replacementLayoutId = successorId ?? siblings[0],
+                result              = DockZoneModel.removeSavedLayout(me._collection, {layoutId: entry.layoutId, replacementLayoutId});
+
+            if (result.errors.length) {
+                me.lastErrors = result.errors;
+                return {errors: result.errors, removed: false}
+            }
+
+            return me.commit(result.collection, 'perspectiveRemoved', {layoutId: entry.layoutId, name}) ?
+                {errors: [], removed: true} :
+                {errors: me.lastErrors, removed: false}
+        }
+
+        let candidate = DockZoneModel.clone(me._collection);
 
         delete candidate.layouts[entry.layoutId];
 
@@ -311,7 +430,9 @@ class DockPerspectiveStore extends Base {
 
     /**
      * Writes the current collection through the injected adapter as a plain validated clone.
-     * Fail-closed without an adapter or a collection.
+     * Fail-closed without an adapter or a collection — and REVALIDATED at the boundary: bytes
+     * that do not validate as a collection never reach the adapter, so `persisted: true` is a
+     * validity claim, not just an I/O result.
      * @returns {Promise<{persisted: Boolean, errors: String[]}>}
      */
     async persist() {
@@ -321,12 +442,19 @@ class DockPerspectiveStore extends Base {
             return {errors: ['no persistence adapter with a write() seam is configured'], persisted: false}
         }
 
-        if (!me.collection) {
+        if (!me._collection) {
             return {errors: ['nothing to persist: the store holds no collection'], persisted: false}
         }
 
+        let errors = DockZoneModel.validateSavedLayoutCollection(me._collection);
+
+        if (errors.length) {
+            me.lastErrors = errors;
+            return {errors, persisted: false}
+        }
+
         try {
-            await me.persistenceAdapter.write(DockZoneModel.clone(me.collection));
+            await me.persistenceAdapter.write(DockZoneModel.clone(me._collection));
             return {errors: [], persisted: true}
         } catch (error) {
             return {errors: [error?.message || 'the persistence adapter rejected the write'], persisted: false}

--- a/test/playwright/unit/dashboard/DockPerspectiveStore.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPerspectiveStore.spec.mjs
@@ -1,0 +1,196 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockPerspectiveStoreTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+test.describe('Neo.dashboard.DockPerspectiveStore (B6 — the named perspective store)', () => {
+    let DockPerspectiveStore, DockZoneModel, store;
+
+    const doc = ids => ({
+        schema: 'neo.harness.dockZone.v1',
+        root  : 'r',
+        items : Object.fromEntries(ids.map(id => [id, {componentRef: id, title: id}])),
+        nodes : {r: {type: 'tabs', items: [...ids], activeItemId: ids[0]}}
+    });
+
+    const makeLayout = (layoutId, name, ids = ['alpha']) => {
+        const {layout, errors} = DockZoneModel.createSavedLayout(doc(ids), {
+            layoutId,
+            perspectiveName: name,
+            title          : `${name} title`
+        });
+
+        expect(errors).toEqual([]);
+        return layout;
+    };
+
+    test.beforeAll(async () => {
+        DockPerspectiveStore = (await import('../../../../src/dashboard/DockPerspectiveStore.mjs')).default;
+        DockZoneModel        = (await import('../../../../src/dashboard/DockZoneModel.mjs')).default
+    });
+
+    test.beforeEach(() => {
+        store = Neo.create(DockPerspectiveStore)
+    });
+
+    test.afterEach(() => {
+        store?.destroy();
+        store = null
+    });
+
+    test('CRUD round-trip: save → list → load → rename → remove, lifecycle events firing after commit', () => {
+        const events = [];
+
+        ['perspectiveSaved', 'perspectiveLoaded', 'perspectiveRenamed', 'perspectiveRemoved'].forEach(name =>
+            store.on(name, data => events.push([name, data.name ?? data.to])));
+
+        const saved = store.savePerspective(makeLayout('l-1', 'Coding'));
+        expect(saved).toMatchObject({saved: true, layoutId: 'l-1', collision: null});
+
+        expect(store.list()).toEqual([{
+            captureScope   : 'window',
+            layoutId       : 'l-1',
+            perspectiveName: 'Coding',
+            revision       : null,
+            title          : 'Coding title'
+        }]);
+        expect(store.exists('Coding')).toBe(true);
+        expect(store.exists('l-1')).toBe(true);        // technical key stays addressable
+        expect(store.exists('Nope')).toBe(false);
+
+        const loaded = store.loadPerspective('Coding');
+        expect(loaded.errors).toEqual([]);
+        expect(loaded.layout.perspectiveName).toBe('Coding');
+        expect(DockZoneModel.validate(loaded.document)).toEqual([]);   // a restorable primary document
+        expect(store.collection.activeLayoutId).toBe('l-1');
+
+        const renamed = store.renamePerspective('Coding', 'Review');
+        expect(renamed).toMatchObject({renamed: true, collision: null});
+        expect(store.exists('Coding')).toBe(false);
+        expect(store.exists('Review')).toBe(true);
+
+        const removed = store.removePerspective('Review');
+        expect(removed).toEqual({errors: [], removed: true});
+        expect(store.list()).toEqual([]);
+        expect(store.collection.activeLayoutId).toBeNull();           // no dangling active pointer
+
+        expect(events).toEqual([
+            ['perspectiveSaved',   'Coding'],
+            ['perspectiveLoaded',  'Coding'],
+            ['perspectiveRenamed', 'Review'],
+            ['perspectiveRemoved', 'Review']
+        ])
+    });
+
+    test('name collision returns the structured choice and saves NOTHING unless the caller decides', () => {
+        store.savePerspective(makeLayout('l-1', 'Coding'));
+
+        // a DIFFERENT record wants the same product name
+        const verdict = store.savePerspective(makeLayout('l-2', 'Coding', ['beta']));
+        expect(verdict.saved).toBe(false);
+        expect(verdict.collision).toEqual({holderLayoutId: 'l-1', holderTitle: 'Coding title', name: 'Coding'});
+        expect(Object.keys(store.collection.layouts)).toEqual(['l-1']);   // byte-untouched
+
+        // the caller's explicit decision: replace retires the previous holder — one name, one record
+        const replaced = store.savePerspective(makeLayout('l-2', 'Coding', ['beta']), {replace: true});
+        expect(replaced.saved).toBe(true);
+        expect(Object.keys(store.collection.layouts)).toEqual(['l-2']);
+
+        // re-saving your OWN record under its own name is an update, not a dispute
+        const selfUpdate = store.savePerspective(makeLayout('l-2', 'Coding', ['gamma']));
+        expect(selfUpdate.saved).toBe(true);
+
+        // rename obeys the same contract
+        store.savePerspective(makeLayout('l-3', 'Scratch', ['delta']));
+        const renameVerdict = store.renamePerspective('Scratch', 'Coding');
+        expect(renameVerdict.renamed).toBe(false);
+        expect(renameVerdict.collision).toMatchObject({holderLayoutId: 'l-2', name: 'Coding'})
+    });
+
+    test('loads migrate legacy v1 records honestly and converge the stored record forward', () => {
+        // a legacy record: no perspective fields at all (pre-v2)
+        const legacy = {
+            dockZone: doc(['alpha']),
+            layoutId: 'legacy-1',
+            schema  : 'neo.harness.dockLayout.v1',
+            title   : 'Legacy'
+        };
+
+        // adopt a collection carrying the legacy record as-is
+        const {collection, errors} = DockZoneModel.createSavedLayoutCollection([legacy], {});
+        expect(errors).toEqual([]);
+        store.collection = collection;
+
+        const loaded = store.loadPerspective('legacy-1');
+        expect(loaded.errors).toEqual([]);
+        // honest migration defaults: v1 could only capture one window's document
+        expect(loaded.layout.captureScope).toBe('window');
+        expect(loaded.layout.windowFingerprint).toBeNull();
+
+        // the STORED record converged forward too — the migration is not a read-time illusion
+        expect(store.collection.layouts['legacy-1'].captureScope).toBe('window')
+    });
+
+    test('fail-closed everywhere: invalid saves, unknown loads, missing removes, corrupt collection assignments', () => {
+        // an invalid layout never enters
+        const bad = store.savePerspective({schema: 'nope'});
+        expect(bad.saved).toBe(false);
+        expect(bad.errors.length).toBeGreaterThan(0);
+        expect(store.collection).toBeNull();
+
+        // unknown name loads/removes are structured errors, never silent
+        expect(store.loadPerspective('ghost').errors.join(' ')).toContain('no perspective named');
+        expect(store.removePerspective('ghost')).toMatchObject({removed: false});
+
+        // a corrupt collection assignment is rejected; the previous value survives
+        store.savePerspective(makeLayout('l-1', 'Coding'));
+        const before = JSON.stringify(store.collection);
+
+        store.collection = {schema: 'garbage'};
+        expect(JSON.stringify(store.collection)).toBe(before);
+        expect(store.lastErrors.length).toBeGreaterThan(0)
+    });
+
+    test('the persistence seam passes plain validated JSON both ways and adopts nothing corrupt', async () => {
+        const written = [];
+
+        store.persistenceAdapter = {
+            read : async () => written[written.length - 1] ?? null,
+            write: async payload => written.push(payload)
+        };
+
+        // nothing to persist yet — fail-closed, structured
+        expect((await store.persist()).persisted).toBe(false);
+
+        store.savePerspective(makeLayout('l-1', 'Coding'));
+        const {persisted} = await store.persist();
+        expect(persisted).toBe(true);
+
+        // the payload is a PLAIN JSON clone: no functions, no live refs, not the store's own object
+        const payload = written[0];
+        expect(payload).not.toBe(store.collection);
+        expect(JSON.stringify(payload)).toBe(JSON.stringify(store.collection));
+        expect(DockZoneModel.findNonJsonValue(payload)).toBeNull();
+
+        // hydrate round-trips...
+        const fresh = Neo.create(DockPerspectiveStore, {persistenceAdapter: store.persistenceAdapter});
+        expect((await fresh.hydrate()).hydrated).toBe(true);
+        expect(fresh.exists('Coding')).toBe(true);
+
+        // ...and a corrupt payload is refused with the store untouched
+        written.push({schema: 'garbage'});
+        const verdict = await fresh.hydrate();
+        expect(verdict.hydrated).toBe(false);
+        expect(verdict.errors.length).toBeGreaterThan(0);
+        expect(fresh.exists('Coding')).toBe(true);
+
+        fresh.destroy()
+    });
+});

--- a/test/playwright/unit/dashboard/DockPerspectiveStore.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPerspectiveStore.spec.mjs
@@ -193,4 +193,136 @@ test.describe('Neo.dashboard.DockPerspectiveStore (B6 — the named perspective 
 
         fresh.destroy()
     });
+
+    test('public reads are ISOLATED: getter mutations never reach held state, and persist() revalidates at the boundary', async () => {
+        const written = [];
+        const events  = [];
+
+        store.persistenceAdapter = {read: async () => null, write: async payload => written.push(payload)};
+        store.savePerspective(makeLayout('l-1', 'Coding'));
+
+        const before = JSON.stringify(store.collection);
+        store.on('collectionChange', () => events.push('change'));
+
+        // attack the returned document every way a careless caller could
+        const leaked = store.collection;
+        leaked.layouts['l-1'].title = 'hacked';
+        leaked.activeLayoutId       = 'ghost';
+        leaked.layouts.injected     = {schema: 'garbage'};
+        delete leaked.layouts['l-1'];
+
+        // internal bytes unchanged, zero events, summaries untouched
+        expect(JSON.stringify(store.collection)).toBe(before);
+        expect(events).toEqual([]);
+        expect(store.list()[0].title).toBe('Coding title');
+
+        // persist writes the UNCORRUPTED bytes
+        const {persisted} = await store.persist();
+        expect(persisted).toBe(true);
+        expect(JSON.stringify(written[0])).toBe(before);
+
+        // the boundary revalidation itself (whitebox: force-corrupt the raw backing field) —
+        // persist fails closed and the adapter never sees invalid bytes as persisted truth
+        store._collection = {schema: 'garbage'};
+        const refused = await store.persist();
+        expect(refused.persisted).toBe(false);
+        expect(refused.errors.length).toBeGreaterThan(0);
+        expect(written.length).toBe(1)
+    });
+
+    test('removing the ACTIVE perspective repoints to a valid successor — derived, explicit, or null on the last record', () => {
+        store.savePerspective(makeLayout('l-1', 'Coding'));
+        store.savePerspective(makeLayout('l-2', 'Review',  ['beta']),  {activate: false});
+        store.savePerspective(makeLayout('l-3', 'Scratch', ['gamma']), {activate: false});
+        expect(store.collection.activeLayoutId).toBe('l-1');
+
+        // derived successor: the first remaining record in insertion order
+        expect(store.removePerspective('Coding')).toEqual({errors: [], removed: true});
+        expect(store.collection.activeLayoutId).toBe('l-2');
+        expect(DockZoneModel.validateSavedLayoutCollection(store.collection)).toEqual([]);
+
+        // an explicit successor wins over derivation
+        store.savePerspective(makeLayout('l-4', 'Deep', ['delta']));
+        expect(store.collection.activeLayoutId).toBe('l-4');
+        expect(store.removePerspective('Deep', {replacementName: 'Scratch'})).toEqual({errors: [], removed: true});
+        expect(store.collection.activeLayoutId).toBe('l-3');
+
+        // a bogus successor fails closed — provided options are never silently ignored
+        const bogus = store.removePerspective('Review', {replacementName: 'ghost'});
+        expect(bogus.removed).toBe(false);
+        expect(bogus.errors.join(' ')).toContain('no remaining perspective named');
+        expect(store.exists('Review')).toBe(true);
+
+        // draining the store: the last record clears the pointer to null
+        expect(store.removePerspective('Review').removed).toBe(true);
+        expect(store.removePerspective('Scratch').removed).toBe(true);
+        expect(store.list()).toEqual([]);
+        expect(store.collection.activeLayoutId).toBeNull()
+    });
+
+    test('one namespace: cross-key shadowing is a collision, prototype-shaped keys fail closed, both paths stay reachable', () => {
+        store.savePerspective(makeLayout('alpha', 'Alpha'));
+
+        // an incoming layoutId equal to an existing perspectiveName would win the name-first
+        // scan and make the new record unaddressable by id — a collision, not a save
+        const shadowed = store.savePerspective(makeLayout('Alpha', 'Boards', ['beta']));
+        expect(shadowed.saved).toBe(false);
+        expect(shadowed.collision).toMatchObject({holderLayoutId: 'alpha'});
+
+        // replace retires the shadow holder; the new record is reachable through BOTH paths
+        const replaced = store.savePerspective(makeLayout('Alpha', 'Boards', ['beta']), {replace: true});
+        expect(replaced.saved).toBe(true);
+        expect(Object.keys(store.collection.layouts)).toEqual(['Alpha']);
+        expect(store.loadPerspective('Boards').errors).toEqual([]);
+        expect(store.loadPerspective('Alpha').errors).toEqual([]);
+
+        // symmetric: an incoming perspectiveName equal to an existing layoutId collides too
+        const nameVsId = store.savePerspective(makeLayout('l-9', 'Alpha', ['gamma']));
+        expect(nameVsId.saved).toBe(false);
+        expect(nameVsId.collision).toMatchObject({holderLayoutId: 'Alpha'});
+
+        // prototype-shaped keys are rejected at the write boundary, store byte-identical
+        const before = JSON.stringify(store.collection);
+
+        for (const evil of ['__proto__', 'constructor', 'prototype']) {
+            const asName = store.savePerspective(makeLayout('safe-id', evil, ['delta']));
+            expect(asName.saved).toBe(false);
+            expect(asName.errors.join(' ')).toContain('not a usable perspective key');
+        }
+
+        const asId = store.savePerspective(makeLayout('__proto__', 'Fine', ['delta']));
+        expect(asId.saved).toBe(false);
+
+        expect(JSON.stringify(store.collection)).toBe(before);
+        expect(store.exists('constructor')).toBe(false);   // inherited keys never satisfy lookups
+
+        const evilRename = store.renamePerspective('Boards', '__proto__');
+        expect(evilRename.renamed).toBe(false);
+        expect(evilRename.errors.join(' ')).toContain('not a usable perspective key')
+    });
+
+    test('rename with replace retires the target holder atomically and inherits its activeness', () => {
+        store.savePerspective(makeLayout('l-1', 'Coding'));
+        store.savePerspective(makeLayout('l-2', 'Review', ['beta']));   // active via the default
+        expect(store.collection.activeLayoutId).toBe('l-2');
+
+        const changes = [];
+        store.on('collectionChange', () => changes.push(1));
+
+        // ONE commit: the ACTIVE holder of the target name retires, the renamed record
+        // inherits its activeness, and the collection stays whole-valid throughout
+        const verdict = store.renamePerspective('Coding', 'Review', {replace: true});
+        expect(verdict).toMatchObject({renamed: true, collision: null});
+        expect(changes.length).toBe(1);
+        expect(Object.keys(store.collection.layouts)).toEqual(['l-1']);
+        expect(store.collection.layouts['l-1'].perspectiveName).toBe('Review');
+        expect(store.collection.activeLayoutId).toBe('l-1');
+        expect(DockZoneModel.validateSavedLayoutCollection(store.collection)).toEqual([]);
+
+        // without replace, the same rename stays the structured verdict (contract unchanged)
+        store.savePerspective(makeLayout('l-3', 'Scratch', ['gamma']), {activate: false});
+        const blocked = store.renamePerspective('Scratch', 'Review');
+        expect(blocked.renamed).toBe(false);
+        expect(blocked.collision).toMatchObject({holderLayoutId: 'l-1', name: 'Review'})
+    });
 });


### PR DESCRIPTION
Resolves #14669

Tree line B6: the named perspective store — the home that turns captured perspectives from one-shot values into named, durable, switchable state, for the B7 switcher, the NL tools, and the demos to consume.

**No new persisted shape** (the docking ADR's anti-anchor): `Neo.dashboard.DockPerspectiveStore` operates on the landed `dockLayoutCollection.v1` through `DockZoneModel`'s own validators and constructors. Every mutation funnels through ONE atomic commit seam — the whole candidate collection validates before it replaces the current one, so a rejected operation leaves the store byte-identical. Every boundary crossing (reads, writes, events, the persistence seam) is a plain JSON clone: no live refs, no functions, guardrail-specced with `findNonJsonValue`.

Contracts delivered as the ticket binds them, hardened through Euclid's review cycle (all four gates addressed at `a9d971315`):

- **Public reads are ISOLATED** *(review gate 1)*: the `collection` getter hands out a deep clone via the sanctioned `beforeGet` hook — no caller can reach the held document, so state changes only enter through the commit seam (validation + events). `persist()` additionally REVALIDATES at the boundary: bytes that do not validate never reach the adapter, making `persisted: true` a validity claim, not just an I/O result. Internal code reads the raw `_collection` backing field.
- **Removing the active perspective repoints, never dangles** *(review gate 2)*: with siblings present the successor is the caller's `replacementName` or the first remaining record (insertion order), executed through the landed `DockZoneModel.removeSavedLayout()` invariant; removing the last record clears the pointer to null. A provided `replacementName` is ALWAYS validated — never a silently ignored option.
- **One collision-safe namespace, both keys reachable** *(review gate 3)*: `perspectiveName` and `layoutId` share one resolution namespace — an incoming layoutId that an existing perspectiveName would shadow (or vice versa) is a structured collision, so every stored record stays addressable through both documented paths. Technical-id lookup is own-property only (`Object.hasOwn`), and prototype-shaped keys (`__proto__`, `constructor`, `prototype`) are rejected at the write boundary before any assignment can touch object internals.
- **Collision is a USER decision, never silent — now with full rename parity** *(review gate 4)*: `savePerspective` and `renamePerspective(from, to, {replace})` both return the structured verdict (`{holderLayoutId, holderTitle, name}`) and mutate nothing without an explicit `replace: true`; replace retires every previous holder atomically in ONE commit, and a retired ACTIVE holder's activeness transfers to the surviving record rather than dangling (the whole-candidate validator would reject a dangling pointer — the transfer keeps replace-with-`activate: false` valid too).
- **Loads migrate honestly**: `loadPerspective` runs the stored record through the landed `restoreSavedLayout` seam (legacy v1 gains the honest defaults; invalid records fail closed with the validator's own errors) and re-commits the MIGRATED record — the collection converges forward, not a read-time illusion (spec-pinned).
- **Persistence stays a caller-injected seam**: optional `{read, write}` adapter — storage tech stays app-side; `hydrate()` adopts nothing that does not validate.
- **Lifecycle events after commit** for UI binding: `perspectiveSaved/Loaded/Removed/Renamed` + `collectionChange`, plain-JSON payloads only.

Evidence: L2 (nine specs: the five contract specs — CRUD round-trip with event ordering, structured collision incl. replace-retires-holder + self-update, honest v1 migration with forward convergence, fail-closed everywhere, persistence-seam JSON purity — plus the four review-gate falsifiers: getter-mutation attack with byte-identical internals + whitebox persist-revalidation refusal, active-succession derived/explicit/last-record + bogus-successor fail-closed, cross-namespace shadowing + prototype-shaped keys both directions, atomic rename-replace with activeness inheritance in one commit; 235/235 dashboard suite) → L2 required (pure JSON logic; the consuming surfaces — B7 switcher, NL exposure — are the ticket's own Out-of-Scope). Residual: none.

## Deltas

- `src/dashboard/DockPerspectiveStore.mjs` (new) — instance sibling (core.Base + Observable mixin), fail-closed reactive `collection_` with clone-isolated reads, the atomic commit seam, unified name/id namespace with unsafe-key rejection, active-succession through the landed reducer invariant, rename replace-parity, revalidating persistence
- `test/playwright/unit/dashboard/DockPerspectiveStore.spec.mjs` (new) — the five contract specs + the four review-gate falsifiers

## Test Evidence

At head `a9d971315` (cycle 2):

```
npm run test-unit -- test/playwright/unit/dashboard/ --workers=1
235 passed (7.9s)
```

## Post-Merge Validation

- [ ] B7 (switcher UI) binds the lifecycle events + list model.
- [ ] #14649 exposes the store's operations over the NL (its own leaf).
- [ ] The example workspace's hand-rolled collection handling can migrate onto the store (follow-up-able, not scope here).

Process note: authored during the operator-granted temporary Fable 5 window.

Authored by Grace (Claude Fable 5, Claude Code). Session ef6b9a4a-54ec-4afb-8438-f89a3ee46ad2
