### PR TITLE
fix(dashboard): validate dock candidate split axes (#14983)

### DIFF
--- a/src/dashboard/dockPreviewContract.mjs
+++ b/src/dashboard/dockPreviewContract.mjs
@@ -95,22 +95,31 @@ function isValidRect(rect) {
 }
 
 /**
- * @summary One cross direction's legal placement kinds — the §06 grammar as a checkable rule.
+ * @summary One cross direction's legal placement tuple — the §06 grammar as a checkable rule.
  *
  * `center` is exactly the tab-merge. A directional indicator is either the node split for its
  * own side (`edge-<direction>`) or the along-axis sibling insert the producer's orientation
  * grammar resolves — `split-before` only from a LEADING direction (top/left), `split-after`
- * only from a TRAILING one (bottom/right). Anything else is a menu lying about its operation.
+ * only from a TRAILING one (bottom/right), with `vertical` for top/bottom and `horizontal` for
+ * left/right. Anything else is a menu lying about its operation.
  * @param {String} position a `CROSS_POSITIONS` entry
- * @param {String} kind the candidate preview's `placement.kind`
+ * @param {Object} placement the candidate preview's placement descriptor
  * @returns {Boolean}
  */
-function crossKindMatchesPosition(position, kind) {
+function crossPlacementMatchesPosition(position, placement) {
+    let {kind, orientation} = placement;
+
     if (position === 'center') return kind === 'tab-into';
 
     return kind === `edge-${position}` ||
-        (kind === 'split-before' && (position === 'top'    || position === 'left')) ||
-        (kind === 'split-after'  && (position === 'bottom' || position === 'right'))
+        (kind === 'split-before' && (
+            (position === 'top'  && orientation === 'vertical') ||
+            (position === 'left' && orientation === 'horizontal')
+        )) ||
+        (kind === 'split-after' && (
+            (position === 'bottom' && orientation === 'vertical') ||
+            (position === 'right'  && orientation === 'horizontal')
+        ))
 }
 
 /**
@@ -122,7 +131,7 @@ function crossKindMatchesPosition(position, kind) {
  * - a `cross` of EXACTLY the five unique positions (`CROSS_POSITIONS`), every candidate wrapping
  *   an individually valid preview that carries the SET's `itemId`, targets the hovered zone's
  *   node, and whose placement kind matches its position per the §06 grammar
- *   ({@link crossKindMatchesPosition});
+ *   ({@link crossPlacementMatchesPosition});
  * - a `root` that is either null (no distinct container target) or a node id + rect + EXACTLY
  *   the four unique edges (`CHIP_EDGES`), each chip's preview carrying the set's `itemId`,
  *   targeting the root node, with kind `edge-<edge>` exactly.
@@ -156,7 +165,7 @@ export function isValidCandidateSet(set) {
         isValidPreview(candidate.preview) &&
         candidate.preview.itemId === set.itemId &&
         candidate.preview.target.nodeId === zone.nodeId &&
-        crossKindMatchesPosition(candidate.position, candidate.preview.placement.kind)
+        crossPlacementMatchesPosition(candidate.position, candidate.preview.placement)
     )) {
         return false
     }

--- a/test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs
@@ -283,13 +283,15 @@ test.describe('Neo.dashboard.DockPreviewProducer (ADR 0029 §2.3 — the dock pr
         const {isValidCandidateSet} = await import('../../../../src/dashboard/dockPreviewContract.mjs');
 
         const TALL  = {x: 0, y: 0, width: 400, height: 300};
-        const zones = [{nodeId: 'main-tabs', rect: TALL}];
-        const valid = () => producer.produceCandidates({
-            pointer: {x: 200, y: 150}, zones, itemId: 'terminal',
+        const valid = (orientation='vertical') => producer.produceCandidates({
+            pointer: {x: 200, y: 150}, zones: [{nodeId: 'main-tabs', orientation, rect: TALL}], itemId: 'terminal',
             root   : {nodeId: 'root', rect: {x: 0, y: 0, width: 800, height: 600}}
         });
 
-        expect(isValidCandidateSet(valid())).toBe(true); // the producer's own emission is the positive control
+        // Both producer grammar axes are positive controls: the stricter tuple gate must preserve
+        // every real emission while rejecting only contradictory direction/orientation payloads.
+        expect(isValidCandidateSet(valid('vertical'))).toBe(true);
+        expect(isValidCandidateSet(valid('horizontal'))).toBe(true);
 
         // a one-entry "menu" is a partial menu — rejected (completeness, not just per-entry validity)
         let set = valid();
@@ -330,6 +332,19 @@ test.describe('Neo.dashboard.DockPreviewProducer (ADR 0029 §2.3 — the dock pr
         // a split-kind on a TRAILING direction claiming `split-before` is rejected
         set = valid();
         set.cross.find(c => c.position === 'bottom').preview.placement = {kind: 'split-before', orientation: 'vertical'};
-        expect(isValidCandidateSet(set)).toBe(false)
+        expect(isValidCandidateSet(set)).toBe(false);
+
+        // Split direction + kind + axis form one semantic tuple. Each otherwise-valid split kind
+        // is rejected when it advertises the perpendicular axis.
+        for (const [position, kind, orientation] of [
+            ['top',    'split-before', 'horizontal'],
+            ['bottom', 'split-after',  'horizontal'],
+            ['left',   'split-before', 'vertical'],
+            ['right',  'split-after',  'vertical']
+        ]) {
+            set = valid(position === 'left' || position === 'right' ? 'horizontal' : 'vertical');
+            set.cross.find(candidate => candidate.position === position).preview.placement = {kind, orientation};
+            expect(isValidCandidateSet(set), `${position} ${kind} must reject ${orientation}`).toBe(false)
+        }
     })
 });


### PR DESCRIPTION
Resolves #14983

Related: #13158 · #14959 · PR #14974

`isValidCandidateSet()` now treats a cross candidate's position, split kind, and orientation as one semantic tuple. Top/bottom sibling inserts accept only the vertical axis; left/right accept only horizontal. The producer, renderer, reducer, schema version, and persisted model are unchanged.

Evidence: L1 (pure contract validation + focused unit controls) satisfies every close-target AC; no higher runtime tier is required because the changed function is layer-neutral and the tests exercise both real producer axes plus every contradictory-axis class.

## Deltas from ticket

None substantive. The implementation follows the ticket's existing ownership boundary and renames the helper from kind-only language to placement-tuple language so its JSDoc matches the enforced contract.

## Test Evidence

- `env NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs` — 16 passed.
- `npm run agent-preflight -- --no-fix src/dashboard/dockPreviewContract.mjs test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs` — all requested gates passed.
- `node --check` on both changed files — passed.
- `git diff --check` — passed.
- Pre-push freshness: branch was exactly one commit ahead of current `origin/dev`; remote head verified as `0363e9c8d4147c0f811ed40700e603d70b150741`.

## Post-Merge Validation

- [ ] Hosted CI confirms the focused contract change against the merged `dev` graph.
- [ ] A malformed consumed candidate with top/bottom + horizontal or left/right + vertical continues to clear rather than render/commit.

## Commit

- `0363e9c8d4` — validate dock candidate direction/kind/orientation tuples.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session 019f484c-662f-7f31-969a-cbde373efd4a.