### PR TITLE
feat(fleet): projection launchability — assembler-stamped launchable + authMode on cockpit roster rows (#14987)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -2,6 +2,9 @@ import Base                     from '../../../src/core/Base.mjs';
 import FleetManager             from './FleetManager.mjs';
 import FleetRegistryService     from './FleetRegistryService.mjs';
 import {resolveIdentityDisplay} from './resolveIdentityDisplay.mjs';
+
+import {LAUNCHABLE_HARNESS_TYPES, getHarnessAuthMode} from './deriveHarnessLaunchSpec.mjs';
+
 import {
     createFleetCockpitStatus,
     createNotWiredCapability,
@@ -298,8 +301,12 @@ class FleetControlBridge extends Base {
      * `fleetRuntimeStatus` live process truth), joins each agent onto its identity-root display
      * facts through the ONE {@link #getIdentityResolver} seam (`family` as era/display attribute,
      * `engineTag` as current-model metadata — read-only, era-swap re-points the resolver, zero Body
-     * diff), and hands the identity-enriched agents to the Body-side pure map
-     * (`createFleetCockpitStatus` — which never imports `ai/graph`; the hemisphere boundary holds).
+     * diff), stamps the launch-derived truth per agent (`launchable` = the family is in the
+     * launch-templated subset; `authMode` = `'marker' | 'in-app' | null` — both DERIVED at read
+     * time from the launch seam, never a second hand-maintained list, so a family becomes
+     * cockpit-launchable exactly when its template lands), and hands the enriched agents to the
+     * Body-side pure map (`createFleetCockpitStatus` — which never imports `ai/graph` or the Brain
+     * launch seam; the hemisphere boundary holds, the Body only hoists what arrives stamped).
      *
      * Rides the authenticated `registryBridge` as a **read** verb; it carries NO lifecycle-write /
      * restart authority (the R3 read-observe ÷ lifecycle-write seam). An agent without an identity
@@ -317,7 +324,9 @@ class FleetControlBridge extends Base {
 
         const agents = (registry.listAgents() ?? []).map(agent => ({
             ...agent,
-            ...resolve(agent.githubUsername ?? agent.id)
+            ...resolve(agent.githubUsername ?? agent.id),
+            launchable: LAUNCHABLE_HARNESS_TYPES.includes(agent.harnessType),
+            authMode  : getHarnessAuthMode(agent.harnessType)
         }));
 
         return createFleetCockpitStatus({

--- a/src/ai/fleet/fleetCockpitStatus.mjs
+++ b/src/ai/fleet/fleetCockpitStatus.mjs
@@ -97,13 +97,18 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                 id            : agentId,
                 githubUsername: publicAgent.githubUsername ?? null,
                 harnessType   : publicAgent.harnessType ?? null,
-                displayName   : publicAgent.displayName ?? publicAgent.name ?? publicAgent.githubUsername ?? agentId ?? null,
-                avatarUrl     : publicAgent.metadata?.avatarUrl ?? githubAvatarUrl(publicAgent.githubUsername),
-                family        : publicAgent.family ?? null,
-                engineTag     : publicAgent.engineTag ?? null,
-                agent         : publicAgent,
+                // Launch-derived truth stamped by the Brain-side assembler (fleetRoster) — hoisted
+                // like the identity facts below, tri-state honest: null = not stamped/unknown
+                // ("not read back yet"), never a guessed boolean. This pure map derives nothing.
+                launchable : publicAgent.launchable ?? null,
+                authMode   : publicAgent.authMode ?? null,
+                displayName: publicAgent.displayName ?? publicAgent.name ?? publicAgent.githubUsername ?? agentId ?? null,
+                avatarUrl  : publicAgent.metadata?.avatarUrl ?? githubAvatarUrl(publicAgent.githubUsername),
+                family     : publicAgent.family ?? null,
+                engineTag  : publicAgent.engineTag ?? null,
+                agent      : publicAgent,
                 repoStatus,
-                lifecycle     : runtime
+                lifecycle  : runtime
                     ? {
                         source    : FLEET_COCKPIT_SOURCES.runtime,
                         state     : runtime.state ?? 'unknown',

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -229,6 +229,27 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         expect(row.engineTag).toBeNull();
     });
 
+    test('fleetRoster stamps launch-derived truth per row — templated families carry their auth mode, native-neo stays honestly unlaunchable', () => {
+        registryStub.listAgents = () => [
+            {id: 'desk',   githubUsername: 'desk-gh',   harnessType: 'claude-desktop'},
+            {id: 'cli',    githubUsername: 'cli-gh',    harnessType: 'codex'},
+            {id: 'native', githubUsername: 'native-gh', harnessType: 'native-neo'}
+        ];
+        managerStub.fleetRepoStatus    = () => [];
+        managerStub.fleetRuntimeStatus = () => [];
+        FleetControlBridge.identityResolver = () => ({family: null, engineTag: null});
+
+        const rows = FleetControlBridge.fleetRoster().rows;
+
+        // DERIVED at read time from the launch seam (LAUNCHABLE_HARNESS_TYPES / getHarnessAuthMode)
+        // — a family flips cockpit-launchable exactly when its launch template lands; there is no
+        // second hand-maintained list to drift. The start control renders these honestly BEFORE
+        // any wire call: native-neo disables with truth, in-app families announce their sign-in.
+        expect(rows[0]).toMatchObject({id: 'desk',   launchable: true,  authMode: 'in-app'});
+        expect(rows[1]).toMatchObject({id: 'cli',    launchable: true,  authMode: 'marker'});
+        expect(rows[2]).toMatchObject({id: 'native', launchable: false, authMode: null});
+    });
+
     // ---- the security boundary: the allowlist OMITS the Brain-internal secret paths ----
 
     test('the surface exposes NO Brain-internal secret accessor (the capability allowlist)', () => {

--- a/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
@@ -38,6 +38,21 @@ test.describe('fleetCockpitStatus - Body-side cockpit DTO contract', () => {
         expect(snapshot.rows[1]).toMatchObject({id: 'guest', family: null, engineTag: null})
     })
 
+    test('hoists assembler-stamped launch truth — tri-state null when un-stamped, never derived in this pure map', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents: [
+                {id: 'desk', launchable: true, authMode: 'in-app'},
+                {id: 'bare'}
+            ]
+        })
+
+        // the Brain-side assembler (fleetRoster) is the ONLY deriver; this Body-pure map hoists
+        // the stamped facts like the identity facts above — absent stays an honest null
+        // ("not read back yet"), never a guessed boolean
+        expect(snapshot.rows[0]).toMatchObject({id: 'desk', launchable: true, authMode: 'in-app'})
+        expect(snapshot.rows[1]).toMatchObject({id: 'bare', launchable: null, authMode: null})
+    })
+
     test('composes runtimeStatus onto row lifecycle — observed process truth when present, honest not-wired when absent', () => {
         const snapshot = createFleetCockpitStatus({
             agents       : [{id: 'alice'}, {id: 'bob'}],


### PR DESCRIPTION
Resolves #14987

The Body-side remainder of the #14972 launch-coverage split, shaped by the ratified seam ruling (launchability = Brain-side RUNTIME truth riding the projection, never a flag in the shared display seam): the fleet-roster assembler now stamps **`launchable`** + **`authMode`** per agent, derived at read time from the launch seam — so the cockpit can render honest launchability BEFORE any wire call, and a family flips cockpit-launchable exactly when its launch template lands, with no second hand-maintained list anywhere.

- **`FleetControlBridge.fleetRoster()` (the Brain-side assembler)** stamps each roster agent with `launchable: LAUNCHABLE_HARNESS_TYPES.includes(harnessType)` and `authMode: getHarnessAuthMode(harnessType)` — the identical join pattern the identity resolver already uses (enrich Brain-side, hand to the Body-pure map). Today's truth: codex / claude-code (`'marker'`) and claude-desktop / antigravity (`'in-app'`) stamp `launchable: true`; `native-neo` stamps `false` + `null`.
- **`src/ai/fleet/fleetCockpitStatus.mjs` (the Body-pure map)** hoists the two stamped facts to row top-level exactly like `family`/`engineTag` — tri-state honest: absent stamps hoist as `null` ("not read back yet"), never a guessed boolean. The hemisphere boundary holds: this pure map derives nothing and imports no Brain module; it only hoists what arrives stamped. Rows stay additive — every existing field untouched.
- **Consumer path**: the #13015 start-from-UI control (@neo-opus-ada) reads `row.launchable` to disable/annotate honestly (`native-neo` → "not launchable — no harness template") and `row.authMode` to announce the in-window sign-in for GUI families. DTO field names flagged to her on the wire before this hardens.

Evidence: L1 (pure assembler join + pure map tests fully cover the close-target ACs — the derivation inputs are themselves the probe-verified #14977 exports; no higher runtime tier required for a read-time stamp).

## Deltas from ticket

- The ticket offered two projection surfaces (registry `getAgent`/`listAgents` OR the roster assembler); shipped is the **roster assembler only** — the seam ruling named it as built for exactly this enrichment class, and it is the DTO the cockpit grid actually renders from. The raw registry projections stay untouched (narrower than the ticket's either/or; widening them remains a trivial follow-on if a non-cockpit consumer ever needs the stamp).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs --workers=1` → **29 passed** at the pushed head (new: the 3-family stamp matrix incl. `native-neo` honest-unlaunchable; the hoist + tri-state-null test).
- `npm run test-unit -- test/playwright/unit/ai/services/fleet/ --workers=1` → **111 passed** (fleet services blast radius).
- `npm run test-unit -- test/playwright/unit/apps/agentos/ --workers=1` → **187 passed** (cockpit consumers green against the additive row shape).
- Pre-commit gates green (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation

- [ ] The #13015 start control consumes `row.launchable` / `row.authMode` — `native-neo` renders honest-unlaunchable in the cockpit (Ada's leaf; field names offered on the wire)
- [ ] The FleetAgent record/grid surfaces the two fields when the start control lands (Body-side, rides the consumer leaf)

## Commits

- 0a2da3bb1 — assembler stamps + Body-map hoisting + the 2-test delta (stamp matrix + tri-state hoist).

Related: predecessor #14972 (PR #14977, merged — exports the derivation source) · parent #13015 · seam ruling: launchability rides the projection (@neo-opus-vega) · consumer: the start-from-UI control (@neo-opus-ada) · adjacent: #14988 (@neo-gpt, conductor GUI-handoff strings — disjoint surface) · v13.2 cornerstone-1 (#14560 / #13448).

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 9cf9cce9-23bf-4211-ab0d-bab51d5e1d14.
