### PR TITLE
fix(harness): bind crash sweep to exact process identity (#14993)

### DIFF
--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -27,6 +27,7 @@
 // exactly why parent-only teardown leaks: the group is the only boundary that owns the whole tree.
 
 import {execFile, execFileSync, spawn} from 'node:child_process';
+import {randomUUID}                    from 'node:crypto';
 import fs                              from 'node:fs';
 import net                             from 'node:net';
 import path                            from 'node:path';
@@ -355,21 +356,46 @@ function forwardLines(child, onLog) {
  * @param {String}   options.entry Entry script, repo-relative.
  * @param {Object}   [options.env] Env fragment merged over process.env.
  * @param {Function} [options.onLog] Receives trimmed child stdout/stderr lines.
+ * @param {Function} [options.ownershipTokenFn=randomUUID] Per-spawn identity seam for tests.
  * @param {Function} [options.spawnFn=spawn] Injection seam for tests.
- * @returns {import('node:child_process').ChildProcess}
+ * @returns {import('node:child_process').ChildProcess & {neoHarnessIdentity: Object}}
  */
-export function startBrainChild({repoRoot, entry, env = {}, onLog, spawnFn = spawn}) {
+export function startBrainChild({
+    repoRoot,
+    entry,
+    env = {},
+    onLog,
+    ownershipTokenFn = randomUUID,
+    spawnFn = spawn
+}) {
     // The supervised tree resolves bare tool commands (the orchestrator's `chroma` task) via PATH.
     // npm-run contexts prepend the repo's node_modules/.bin by accident of cwd; a packaged shell
     // has no npm in the chain at all — so the lifecycle owner guarantees the resolution explicitly.
-    const binPath = path.join(repoRoot, 'node_modules', '.bin');
+    const
+        absoluteRepoRoot = path.resolve(repoRoot),
+        absoluteEntry    = path.resolve(absoluteRepoRoot, entry),
+        relativeEntry    = path.relative(absoluteRepoRoot, absoluteEntry),
+        binPath          = path.join(absoluteRepoRoot, 'node_modules', '.bin'),
+        ownershipToken   = ownershipTokenFn();
 
-    const child = spawnFn(nodeBin(), [entry], {
-        cwd     : repoRoot,
+    if (relativeEntry === '..' || relativeEntry.startsWith(`..${path.sep}`) || path.isAbsolute(relativeEntry)) {
+        throw new TypeError('entry must resolve inside repoRoot')
+    }
+
+    if (typeof ownershipToken !== 'string' || ownershipToken.length === 0 || /\s/.test(ownershipToken)) {
+        throw new TypeError('ownershipTokenFn must return a non-empty token without whitespace')
+    }
+
+    const child = spawnFn(nodeBin(), [absoluteEntry, `--neo-harness-owner=${ownershipToken}`], {
+        cwd     : absoluteRepoRoot,
         detached: true,
         env     : {...process.env, ...env, PATH: `${binPath}${path.delimiter}${process.env.PATH ?? ''}`},
         stdio   : ['ignore', 'pipe', 'pipe']
     });
+
+    // The parent persists this pair only for smoke crash recovery. The absolute entry distinguishes
+    // checkouts; the argv token distinguishes this exact process instance from every later spawn.
+    child.neoHarnessIdentity = Object.freeze({entry: absoluteEntry, ownershipToken});
 
     forwardLines(child, onLog);
     return child
@@ -601,14 +627,14 @@ export async function stopBrainTree(children, options = {}) {
 }
 
 /**
- * @summary Persists the process groups of a SMOKE run — WITH an ownership token per group (the
- * group leader's entry script) — so a crashed harness's next run can sweep its own leftovers
- * (the crash path bypasses will-quit). A bare PGID is not ownership evidence: the OS reuses ids,
- * so the sweep re-verifies the recorded identity before signaling. Product own-mode leftovers
- * are deliberately NOT recorded: a still-live default-paths Brain is attached to next boot.
+ * @summary Persists the process groups of a SMOKE run with checkout + process-instance identity
+ * so a crashed harness's next run can sweep only its own leftovers (the crash path bypasses
+ * will-quit). A PGID or program name is not ownership evidence: the OS reuses ids and every clone
+ * runs the same scripts. Product own-mode leftovers are deliberately NOT recorded: a still-live
+ * default-paths Brain is attached to next boot.
  * @param {Object} options
  * @param {String} options.isolationRoot
- * @param {Object[]} options.children `{pgid, entry}` per supervised group leader.
+ * @param {Object[]} options.children `{pgid, entry, ownershipToken}` per supervised group leader.
  */
 export function writeRunState({isolationRoot, children}) {
     fs.mkdirSync(isolationRoot, {recursive: true});
@@ -630,10 +656,10 @@ export function clearRunState({isolationRoot}) {
 }
 
 /**
- * @summary Sweeps a prior CRASHED smoke run's process groups — but only after re-proving
- * ownership: the group leader's current command line must still carry the recorded entry script.
- * An identity mismatch (recycled pid) drops the record without signaling. The state file is
- * cleared either way. No-op when no state exists.
+ * @summary Sweeps a prior CRASHED smoke run's process groups only after re-proving both checkout
+ * and process-instance identity: the current command must carry the recorded absolute entry and
+ * per-spawn argv token. Missing/legacy identity and recycled groups fail closed without signaling.
+ * The state file is cleared either way. No-op when no state exists.
  * @param {Object} options
  * @param {String} options.isolationRoot
  * @param {Function} [options.killFn=process.kill] Injection seam for tests.
@@ -655,19 +681,40 @@ export function sweepStaleRunState({isolationRoot, killFn = process.kill, comman
     let children = [];
 
     try {
-        children = JSON.parse(fs.readFileSync(runStateFile, 'utf8')).children ?? []
+        const parsed = JSON.parse(fs.readFileSync(runStateFile, 'utf8'));
+
+        children = Array.isArray(parsed?.children) ? parsed.children : []
     } catch (error) {
+        clearRunState({isolationRoot});
         return swept
     }
 
-    for (const {pgid, entry} of children) {
-        if (!Number.isInteger(pgid) || pgid <= 1 || typeof entry !== 'string' || !groupAlive(pgid, killFn)) {
+    for (const record of children) {
+        if (!record || typeof record !== 'object') {
             continue
         }
 
-        // Ownership re-proof: the recorded leader must still run OUR entry script. Mirrors the
-        // daemon's own isOrchestratorDaemonCommand guard against recycled pids.
-        if (!readCommand(pgid).includes(entry)) {
+        const {pgid, entry, ownershipToken} = record;
+
+        if (
+            !Number.isInteger(pgid)
+            || pgid <= 1
+            || typeof entry !== 'string'
+            || !path.isAbsolute(entry)
+            || typeof ownershipToken !== 'string'
+            || ownershipToken.length === 0
+            || /\s/.test(ownershipToken)
+            || !groupAlive(pgid, killFn)
+        ) {
+            continue
+        }
+
+        const command = readCommand(pgid);
+
+        // BOTH adjacent argv observations are required. Absolute entry separates sibling
+        // checkouts; the unique token separates later spawns. Boundary matching prevents a path
+        // or token that merely contains the recorded value from authorizing destruction.
+        if (!commandCarriesHarnessIdentity({command, entry, ownershipToken})) {
             continue
         }
 
@@ -682,5 +729,14 @@ export function sweepStaleRunState({isolationRoot, killFn = process.kill, comman
 }
 
 function execFileSyncCommand(pid) {
-    return execFileSync('ps', ['-p', String(pid), '-o', 'command=']).toString().trim()
+    return execFileSync('ps', ['-ww', '-p', String(pid), '-o', 'command=']).toString().trim()
+}
+
+function commandCarriesHarnessIdentity({command, entry, ownershipToken}) {
+    const
+        escapeRegExp = value => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+        entryArg     = escapeRegExp(entry),
+        ownerArg     = escapeRegExp(`--neo-harness-owner=${ownershipToken}`);
+
+    return new RegExp(`(?:^|\\s)${entryArg}\\s+${ownerArg}(?:\\s|$)`).test(command)
 }

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -483,11 +483,18 @@ async function bootSmokeBrain() {
         fleet        = startBrainChild({entry: FLEET_SERVER_ENTRY, env: profile, onLog: brainLog, repoRoot});
 
     brainState.children.push(
-        {child: orchestrator, entry: ORCHESTRATOR_ENTRY, label: 'orchestrator'},
-        {child: fleet,        entry: FLEET_SERVER_ENTRY, label: 'fleet'}
+        {child: orchestrator, ...orchestrator.neoHarnessIdentity, label: 'orchestrator'},
+        {child: fleet,        ...fleet.neoHarnessIdentity,        label: 'fleet'}
     );
     brainState.isolationRoot = isolationRoot;
-    writeRunState({isolationRoot, children: brainState.children.map(entry => ({entry: entry.entry, pgid: entry.child.pid}))});
+    writeRunState({
+        isolationRoot,
+        children: brainState.children.map(({child, entry, ownershipToken}) => ({
+            entry,
+            ownershipToken,
+            pgid: child.pid
+        }))
+    });
 
     await Promise.all([
         awaitOrchestratorReady({child: orchestrator}),

--- a/test/playwright/unit/harness/brain.spec.mjs
+++ b/test/playwright/unit/harness/brain.spec.mjs
@@ -19,6 +19,7 @@ import {
     probeFleetServing,
     probePort,
     resolveRealPath,
+    startBrainChild,
     stopBrainChild,
     stopBrainTree,
     sweepStaleRunState,
@@ -306,25 +307,59 @@ test.describe('harness brain lifecycle', () => {
         expect(report.orchestrator.groupEmpty).toBe(true)
     });
 
-    // A bare PGID is not ownership: the OS recycles ids, so the sweep must re-prove the recorded
-    // identity (the leader still runs OUR entry script) before signaling, and a CLEAN stop must
-    // clear the record so it can never outlive the run.
-    test('run-state sweep kills only identity-verified groups, skips recycled pids, clears state', () => {
-        const group = createFakeGroup({diesOn: ['SIGKILL'], pid: 7001});
+    test('startBrainChild exposes an absolute checkout entry and per-spawn argv identity', () => {
+        let invocation;
+
+        const child = startBrainChild({
+            entry             : ORCHESTRATOR_ENTRY,
+            ownershipTokenFn  : () => 'spawn-token-a',
+            repoRoot          : workDir,
+            spawnFn           : (command, args, options) => {
+                invocation = {args, command, options};
+                return createFakeChild()
+            }
+        });
+        const absoluteEntry = path.join(workDir, ORCHESTRATOR_ENTRY);
+
+        expect(invocation.args).toEqual([absoluteEntry, '--neo-harness-owner=spawn-token-a']);
+        expect(invocation.options.cwd).toBe(workDir);
+        expect(invocation.options.detached).toBe(true);
+        expect(child.neoHarnessIdentity).toEqual({entry: absoluteEntry, ownershipToken: 'spawn-token-a'})
+    });
+
+    test('startBrainChild rejects entries outside its checkout root', () => {
+        expect(() => startBrainChild({
+            entry             : path.join('..', 'sibling', ORCHESTRATOR_ENTRY),
+            ownershipTokenFn  : () => 'spawn-token-a',
+            repoRoot          : workDir,
+            spawnFn           : () => createFakeChild()
+        })).toThrow(/entry must resolve inside repoRoot/)
+    });
+
+    // A bare PGID OR program name is not ownership: ids are recycled and every checkout runs the
+    // same scripts. Cleanup requires this checkout's absolute entry AND this spawn's argv token.
+    test('run-state sweep requires exact checkout + spawn identity, skips recycled pids, clears state', () => {
+        const
+            group        = createFakeGroup({diesOn: ['SIGKILL'], pid: 7001}),
+            ownedEntry   = path.join(workDir, ORCHESTRATOR_ENTRY),
+            siblingEntry = path.join(workDir + '-sibling', ORCHESTRATOR_ENTRY);
 
         writeRunState({
             children     : [
-                {entry: ORCHESTRATOR_ENTRY, pgid: 7001},
-                {entry: FLEET_SERVER_ENTRY, pgid: 7002},
-                {entry: ORCHESTRATOR_ENTRY, pgid: 999999}
+                {entry: ownedEntry, ownershipToken: 'owned-token', pgid: 7001},
+                {entry: ownedEntry, ownershipToken: 'owned-token', pgid: 7002},
+                {entry: ownedEntry, ownershipToken: 'owned-token', pgid: 7003},
+                {entry: ownedEntry, pgid: 7004},
+                {entry: ownedEntry, ownershipToken: 'owned-token', pgid: 7005},
+                {entry: ownedEntry, ownershipToken: 'owned-token', pgid: 999999}
             ],
             isolationRoot: workDir
         });
 
         const killFn = (target, signal) => {
-            if ([7002, 999999].includes(Math.abs(target))) {
-                if (Math.abs(target) === 7002 && signal === 0) {
-                    return true // alive — but identity will mismatch below
+            if ([7002, 7003, 7004, 7005, 999999].includes(Math.abs(target))) {
+                if (Math.abs(target) !== 999999 && signal === 0) {
+                    return true // alive — but identity will fail closed below
                 }
 
                 const error = new Error('ESRCH');
@@ -335,11 +370,17 @@ test.describe('harness brain lifecycle', () => {
             return group.killFn(target, signal)
         };
 
-        const commandFn = pgid => pgid === 7001
-            ? `node ${ORCHESTRATOR_ENTRY}`
-            : '/usr/bin/unrelated-tool-that-recycled-the-pid';
+        const commandFn = pgid => ({
+            7001: `node ${ownedEntry} --neo-harness-owner=owned-token`,
+            7002: `node ${ownedEntry} --neo-harness-owner=later-spawn`,
+            7003: `node ${siblingEntry} --neo-harness-owner=owned-token`,
+            7004: `node ${ownedEntry}`,
+            7005: `node /prefix${ownedEntry} --neo-harness-owner=owned-token`
+        })[pgid] ?? '';
 
-        // 7001: alive + identity match → killed. 7002: alive but recycled → SKIPPED. 999999: dead.
+        // 7001 matches both identities. 7002 has a later token. 7003 is a sibling checkout.
+        // 7004 is a legacy record without a token; 7005 only contains the entry as a suffix.
+        // 999999 is dead. Only 7001 is signal-authorized.
         expect(sweepStaleRunState({commandFn, isolationRoot: workDir, killFn})).toEqual([7001]);
         expect(group.signals).toEqual(['SIGKILL']);
         expect(existsSync(path.join(workDir, 'run-state.json'))).toBe(false);
@@ -348,8 +389,30 @@ test.describe('harness brain lifecycle', () => {
         expect(sweepStaleRunState({commandFn, isolationRoot: workDir, killFn})).toEqual([])
     });
 
+    test('run-state sweep clears malformed JSON without signaling', () => {
+        const runStateFile = path.join(workDir, 'run-state.json');
+
+        writeFileSync(runStateFile, '{not-json', 'utf8');
+        expect(sweepStaleRunState({
+            isolationRoot: workDir,
+            killFn       : () => { throw new Error('must not signal') }
+        })).toEqual([]);
+        expect(existsSync(runStateFile)).toBe(false);
+
+        writeFileSync(runStateFile, JSON.stringify({children: [null, 'legacy', {}]}), 'utf8');
+        expect(sweepStaleRunState({isolationRoot: workDir})).toEqual([]);
+        expect(existsSync(runStateFile)).toBe(false)
+    });
+
     test('clearRunState removes the record after a clean stop and tolerates absence', () => {
-        writeRunState({children: [{entry: ORCHESTRATOR_ENTRY, pgid: 7100}], isolationRoot: workDir});
+        writeRunState({
+            children: [{
+                entry         : path.join(workDir, ORCHESTRATOR_ENTRY),
+                ownershipToken: 'clean-token',
+                pgid          : 7100
+            }],
+            isolationRoot: workDir
+        });
         expect(existsSync(path.join(workDir, 'run-state.json'))).toBe(true);
 
         clearRunState({isolationRoot: workDir});
@@ -428,9 +491,14 @@ test.describe('harness brain lifecycle', () => {
     });
 
     test('run-state file content carries the ownership token per group', () => {
-        writeRunState({children: [{entry: ORCHESTRATOR_ENTRY, pgid: 111}], isolationRoot: workDir});
+        const entry = path.join(workDir, ORCHESTRATOR_ENTRY);
+
+        writeRunState({
+            children: [{entry, ownershipToken: 'token-111', pgid: 111}],
+            isolationRoot: workDir
+        });
 
         expect(JSON.parse(readFileSync(path.join(workDir, 'run-state.json'), 'utf8')))
-            .toEqual({children: [{entry: ORCHESTRATOR_ENTRY, pgid: 111}]})
+            .toEqual({children: [{entry, ownershipToken: 'token-111', pgid: 111}]})
     })
 });


### PR DESCRIPTION
Resolves #14993

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session 019f484c-662f-7f31-969a-cbde373efd4a.

Crash recovery for `smoke:brain` now proves the exact process instance before sending group `SIGKILL`: each supervised child launches from its absolute checkout entry with a unique, non-secret argv token; run-state persists that pair; the next smoke run requires the boundary-matched adjacent entry+token arguments. Sibling checkouts, later spawns, substring decoys, malformed/legacy records, and dead groups all fail closed without signaling.

Evidence: L2 (mock child spawn plus injected process-table and process-group signal probes) → L2 required (#14993 crash-sweep identity ACs). No residuals.

## Deltas from ticket

- Entry resolution now also rejects paths outside `repoRoot` before spawning.
- The process-table read uses wide `ps -ww` output so the ownership token is not silently truncated.
- Malformed JSON and structurally invalid/legacy child records are cleared without becoming kill-capable.
- Exact adjacent argv matching rejects a command that merely contains the expected absolute entry as a suffix.

## Contract Ledger

| Surface | Authority | Shipped contract | Fail-closed evidence |
|---|---|---|---|
| Child spawn | `startBrainChild()` | absolute in-checkout entry + random per-spawn `--neo-harness-owner` token | outside-root entry rejects before spawn |
| Crash record | `writeRunState()` | `{pgid, entry, ownershipToken}` per smoke child | legacy/malformed records never authorize a signal |
| Stale sweep | `sweepStaleRunState()` | exact adjacent entry+token pair required before group `SIGKILL` | same entry/different token, sibling entry/same token, substring decoy, and dead group all skip |
| Clean stop | `clearRunState()` | clean teardown removes the record | idempotent absence remains safe |

## Test Evidence

- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/harness/brain.spec.mjs` — **22/22 passed** at exact head `974e7cd588` after rebasing onto current `dev`.
- `node --check harness/brain.mjs` — passed.
- `node --check harness/main.mjs` — passed.
- `git diff --check origin/dev...HEAD` — passed.
- Two independent read-only adversarial audits; the terminal pass reported no actionable findings.

## Post-Merge Validation

- [ ] Run one isolated `smoke:brain` cycle from merged `dev` and verify clean teardown leaves no `run-state.json`.

## Commit

- `974e7cd588` — `fix(harness): bind crash sweep to process identity (#14993)`

Related: #14976 · #14967 · #13033
