### PR TITLE
fix(memory-core): mailbox read-state survives WAL re-projection — issues-first drain + choke-point merge (#14992)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -479,13 +479,16 @@ function hasMessageNodeInStorage(messageId) {
 }
 
 /**
- * @summary Storage-truth read of the recipient-mutable MESSAGE-node fields (`readAt`,
- * `archivedAt`). The WAL is pure intake — its records carry send-time state (`readAt: null`)
- * forever — so ANY projection landing on an EXISTING node must let the committed graph values win
- * for exactly these two fields: they are graph-owned (written by `markRead` / archive), never
- * WAL-owned. Returns `{}` for a missing node, so a true first projection keeps the WAL values.
+ * @summary Storage-truth read of the graph-owned mutable MESSAGE-node state: the recipient's
+ * `readAt`/`archivedAt` (written by `markRead` / archive) AND the sender's irreversible retraction
+ * tombstone (`retracted` + the placeholder `subject`/`bodyText` written by `deleteMessage` — a
+ * permanent decision with no undo path). The WAL is pure intake — its records carry send-time
+ * state (`readAt: null`, the original content) forever — so ANY projection landing on an EXISTING
+ * node must let the committed graph values win for exactly this surface. Returns `{}` for a
+ * missing node, so a true first projection keeps the WAL values.
  * @param {String} messageId Message graph node id.
- * @returns {Object} `{readAt?, archivedAt?}` — only the fields with committed non-null values.
+ * @returns {Object} Only the committed fields: `{readAt?, archivedAt?, retracted?, subject?,
+ * bodyText?}` — the tombstone trio rides together, never partially.
  * @private
  */
 function getStorageMessageMutableState(messageId) {
@@ -493,8 +496,42 @@ function getStorageMessageMutableState(messageId) {
     if (!sqlite) return {};
 
     const row = sqlite
-        .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt, json_extract(data, '$.properties.archivedAt') AS archivedAt FROM Nodes WHERE id = ?`)
+        .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt, json_extract(data, '$.properties.archivedAt') AS archivedAt, json_extract(data, '$.properties.retracted') AS retracted, json_extract(data, '$.properties.subject') AS subject, json_extract(data, '$.properties.bodyText') AS bodyText FROM Nodes WHERE id = ?`)
         .get(messageId);
+    if (!row) return {};
+
+    const state = {};
+    if (row.readAt != null)     state.readAt     = row.readAt;
+    if (row.archivedAt != null) state.archivedAt = row.archivedAt;
+
+    // A retraction permanently overwrote the content at write time; a replay resurrecting the
+    // WAL's original subject/body would undo an irreversible sender decision.
+    if (row.retracted) {
+        state.retracted = true;
+        state.subject   = row.subject;
+        state.bodyText  = row.bodyText;
+    }
+    return state;
+}
+
+/**
+ * @summary Storage-truth read of the graph-owned mutable state on one per-recipient broadcast
+ * `DELIVERED_TO` edge: `readAt` (written by `markRead`) and `archivedAt` (receiver-side archive).
+ * The WAL replay's edge payload carries `readAt: null` forever — send-time truth — so a FULL
+ * projection re-linking an EXISTING delivery edge must let the committed per-recipient state win.
+ * Returns `{}` for a missing edge, so a genuinely-recreated delivery honestly starts unread.
+ * @param {String} messageId Message graph node id.
+ * @param {String} recipient Recipient identity node id.
+ * @returns {Object} `{readAt?, archivedAt?}` — only the fields with committed non-null values.
+ * @private
+ */
+function getStorageDeliveryMutableState(messageId, recipient) {
+    const sqlite = GraphService.db?.storage?.db;
+    if (!sqlite) return {};
+
+    const row = sqlite
+        .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt, json_extract(data, '$.properties.archivedAt') AS archivedAt FROM Edges WHERE source = ? AND target = ? AND type = 'DELIVERED_TO'`)
+        .get(messageId, recipient);
     if (!row) return {};
 
     const state = {};
@@ -1182,15 +1219,18 @@ class MailboxService extends Base {
                 if (!needsPiece(`missing-delivered-to:${recipient}`)) continue;
 
                 ensureMailboxProjectionEndpoint(recipient);
-                // A RECREATED delivery edge honestly starts unread — its prior read-state is the
-                // damage being repaired; intact sibling edges above are never rewritten, which is
-                // what keeps their committed readAt alive.
+                // Per-recipient read/archive state is graph-owned, never WAL-owned: a FULL replay
+                // re-linking an INTACT delivery edge merges the committed storage truth over the
+                // WAL's send-time nulls, so broadcast reads survive exactly like DM reads. A
+                // genuinely missing edge has no storage row — the merge is empty and the recreated
+                // delivery honestly starts unread (its prior read-state IS the damage).
                 linkRequiredMailboxEdgeOrThrow(messageId, recipient, 'DELIVERED_TO', 1.0, {
                     deliveredAt : timestamp,
                     readAt      : null,
                     deliveryKind: 'broadcast',
                     userId      : senderUserId,
-                    sharedEntity: true
+                    sharedEntity: true,
+                    ...getStorageDeliveryMutableState(messageId, recipient)
                 }, routingDiagnostics);
             }
         }

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -478,6 +478,31 @@ function hasMessageNodeInStorage(messageId) {
         .get(messageId)?.count ?? 0) > 0;
 }
 
+/**
+ * @summary Storage-truth read of the recipient-mutable MESSAGE-node fields (`readAt`,
+ * `archivedAt`). The WAL is pure intake — its records carry send-time state (`readAt: null`)
+ * forever — so ANY projection landing on an EXISTING node must let the committed graph values win
+ * for exactly these two fields: they are graph-owned (written by `markRead` / archive), never
+ * WAL-owned. Returns `{}` for a missing node, so a true first projection keeps the WAL values.
+ * @param {String} messageId Message graph node id.
+ * @returns {Object} `{readAt?, archivedAt?}` — only the fields with committed non-null values.
+ * @private
+ */
+function getStorageMessageMutableState(messageId) {
+    const sqlite = GraphService.db?.storage?.db;
+    if (!sqlite) return {};
+
+    const row = sqlite
+        .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt, json_extract(data, '$.properties.archivedAt') AS archivedAt FROM Nodes WHERE id = ?`)
+        .get(messageId);
+    if (!row) return {};
+
+    const state = {};
+    if (row.readAt != null)     state.readAt     = row.readAt;
+    if (row.archivedAt != null) state.archivedAt = row.archivedAt;
+    return state;
+}
+
 function hasGraphEdgeOfType(source, type) {
     return (GraphService.db?.edges?.items || []).some(edge =>
         getRecordField(edge, 'source') === source &&
@@ -1095,11 +1120,18 @@ class MailboxService extends Base {
      *   pure intake — its records carry send-time mutable state (`readAt: null`) forever — so a
      *   FULL re-projection over existing structures resurrects unread state on top of committed
      *   reads (the read-state-rollback defect: partial damage must never trigger a total rewrite).
-     *   `null` (accept/drain paths) keeps the full projection for never-projected records.
+     *   `null` (accept/drain paths) keeps the full projection for never-projected records — made
+     *   idempotent-safe by the node piece's mutable-state merge below.
+     * @param {Boolean} [options.appendMarker=!onlyIssues] Whether to append the graph-projection
+     *   success marker. Full projections (accept / drain) append — the marker is what retires the
+     *   record from the pending index. Surgical repairs default OFF: they exist for the
+     *   POST-marker damage class, so the marker is already present by definition — re-appending
+     *   inflated the marker index multiples past the accepted-record count (observed 7×/3× on
+     *   2026-07-09/10) and masks projection-count diagnostics.
      * @returns {Promise<void>}
      * @private
      */
-    async _projectMessageWalRecord(record, {pumpWake = true, onlyIssues = null} = {}) {
+    async _projectMessageWalRecord(record, {pumpWake = true, onlyIssues = null, appendMarker = !onlyIssues} = {}) {
         const messageId = record?.id || record?.message?.id;
         if (typeof messageId !== 'string' || !messageId.startsWith('MESSAGE:')) {
             throw new Error('[MailboxService] message WAL projection requires a MESSAGE:* id');
@@ -1129,11 +1161,16 @@ class MailboxService extends Base {
         const needsPiece = piece => !onlyIssues || onlyIssues.includes(piece);
 
         if (needsPiece('missing-message-node')) {
+            // Recipient-mutable state is graph-owned, never WAL-owned: when this projection lands
+            // on an EXISTING node (a marker-lost-but-projected record replayed by the drain, or
+            // any future full-path caller), the committed `readAt`/`archivedAt` win over the WAL's
+            // eternal send-time nulls. This makes the write choke-point structurally unable to
+            // resurrect unread state, whichever caller reaches it.
             GraphService.upsertNode({
                 id        : messageId,
                 type      : message.type || 'MESSAGE',
                 name      : message.name || messageProperties.subject || messageId,
-                properties: messageProperties
+                properties: {...messageProperties, ...getStorageMessageMutableState(messageId)}
             });
         }
 
@@ -1187,10 +1224,12 @@ class MailboxService extends Base {
         // taggedConcepts are replayed above, while low-confidence model-derived concepts stay out
         // of the message hot path.
 
-        await appendMessageWalGraphProjectionMarker({
-            id        : messageId,
-            segmentKey: record.segmentKey || getMessageWalSegmentKey(record.timestamp ?? Date.now())
-        }, {dir: aiConfig.messageWal.dir});
+        if (appendMarker) {
+            await appendMessageWalGraphProjectionMarker({
+                id        : messageId,
+                segmentKey: record.segmentKey || getMessageWalSegmentKey(record.timestamp ?? Date.now())
+            }, {dir: aiConfig.messageWal.dir});
+        }
 
         if (pumpWake) {
             WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
@@ -1214,7 +1253,25 @@ class MailboxService extends Base {
 
         for (const record of records) {
             try {
-                await this._projectMessageWalRecord(record);
+                // Issues-first: a marker-less record is NOT necessarily unprojected — a crash
+                // between projection commit and marker append (or a diverged marker index) leaves
+                // fully-intact graph state behind, and blindly re-projecting it was the
+                // read-state-rollback amplifier. Graph already intact ⇒ heal the marker only;
+                // partial damage ⇒ surgical projection of the named pieces; a genuinely absent
+                // MESSAGE node ⇒ the full projection (the one path that also links the optional
+                // semantic edges — the established first-projection contract).
+                const issues = getMessageGraphProjectionIssues(record);
+
+                if (issues.length === 0) {
+                    await appendMessageWalGraphProjectionMarker({
+                        id        : record.id,
+                        segmentKey: record.segmentKey || getMessageWalSegmentKey(record.timestamp ?? Date.now())
+                    }, {dir: aiConfig.messageWal.dir});
+                } else if (issues.includes('missing-message-node')) {
+                    await this._projectMessageWalRecord(record);
+                } else {
+                    await this._projectMessageWalRecord(record, {onlyIssues: issues, appendMarker: true});
+                }
                 summary.projected++;
             } catch (error) {
                 summary.failed++;

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -721,6 +721,52 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(readBack.readAt).toBeTruthy();
     });
 
+    test('full replay preserves the COMPLETE graph-owned surface: broadcast delivery readAt AND the retraction tombstone (#14992)', async () => {
+        let msgId;
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: 'AGENT:*', subject: 'replay me broadly', body: 'original content' });
+            msgId = res.messageId;
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await MailboxService.markRead({ messageId: msgId });
+        });
+
+        const {readWalMessagesByIds} = await import('../../../../../../ai/services/memory-core/helpers/messageWalStore.mjs');
+        const [record]               = await readWalMessagesByIds({dir: messageWalDir, ids: [msgId]});
+        expect(record?.id).toBe(msgId);
+
+        const edgeReadAt = () => GraphService.db.storage.db
+            .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt FROM Edges WHERE source = ? AND target = ? AND type = 'DELIVERED_TO'`)
+            .get(msgId, '@bob');
+
+        expect(edgeReadAt().readAt).toBeTruthy();
+
+        // Full replay #1: per-recipient read-state lives on the DELIVERED_TO edge, not the node —
+        // the reviewer falsifier: pre-fix, this re-link stamped the WAL's readAt: null over it.
+        await MailboxService._projectMessageWalRecord(record, {pumpWake: false});
+        expect(edgeReadAt().readAt).toBeTruthy();
+
+        // The sender's retraction is an IRREVERSIBLE decision: replay must never resurrect the
+        // WAL's original subject/body over the tombstone.
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            await MailboxService.deleteMessage({ messageId: msgId });
+        });
+
+        // Full replay #2 over the tombstone + the read edge together.
+        await MailboxService._projectMessageWalRecord(record, {pumpWake: false});
+
+        const node = GraphService.db.storage.db
+            .prepare(`SELECT json_extract(data, '$.properties.retracted') AS retracted, json_extract(data, '$.properties.subject') AS subject, json_extract(data, '$.properties.bodyText') AS bodyText FROM Nodes WHERE id = ?`)
+            .get(msgId);
+
+        expect(node.retracted).toBeTruthy();
+        expect(node.subject).toBe('[retracted by sender]');
+        expect(node.bodyText).toBe('[retracted by sender]');
+        expect(node.subject).not.toBe('replay me broadly');
+        expect(edgeReadAt().readAt).toBeTruthy()
+    });
+
     test('the drain heals a lost marker on an intact projection WITHOUT rewriting graph state (#14992)', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -686,6 +686,110 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(readBack.readAt).toBeTruthy();
     });
 
+    test('a FULL re-projection over an existing read DM preserves the committed readAt — the write choke-point is caller-proof (#14992)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        let msgId;
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: '@bob', subject: 'full replay must not unread me', body: 'committed' });
+            msgId = res.messageId;
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await MailboxService.markRead({ messageId: msgId });
+        });
+
+        const {readWalMessagesByIds} = await import('../../../../../../ai/services/memory-core/helpers/messageWalStore.mjs');
+        const [record]               = await readWalMessagesByIds({dir: messageWalDir, ids: [msgId]});
+        expect(record?.id).toBe(msgId);
+
+        // The empirical 2026-07-10 incident path: a projected record replayed through the FULL
+        // path (marker loss, index divergence — whichever caller). The WAL properties carry the
+        // send-time readAt: null forever; the node piece's storage-truth merge must win.
+        await MailboxService._projectMessageWalRecord(record, {pumpWake: false});
+
+        const postReplay = GraphService.db.storage.db
+            .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt FROM Nodes WHERE id = ?`)
+            .get(msgId);
+        expect(postReplay.readAt).toBeTruthy();
+
+        const readBack = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.getMessage({messageId: msgId});
+        });
+        expect(readBack.readAt).toBeTruthy();
+    });
+
+    test('the drain heals a lost marker on an intact projection WITHOUT rewriting graph state (#14992)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        let msgId;
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: '@bob', subject: 'marker-lost but projected', body: 'intact' });
+            msgId = res.messageId;
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await MailboxService.markRead({ messageId: msgId });
+        });
+
+        // Simulate the crash window between projection commit and marker append: the graph is
+        // fully intact (node + edges + committed readAt), only the marker line vanishes.
+        const markerFiles = fs.readdirSync(messageWalDir).filter(name => name.endsWith('.graph.jsonl'));
+        for (const name of markerFiles) {
+            const filePath = path.join(messageWalDir, name);
+            const kept     = fs.readFileSync(filePath, 'utf8').split('\n').filter(line => line.trim() && !line.includes(msgId));
+            fs.writeFileSync(filePath, kept.length ? kept.join('\n') + '\n' : '');
+        }
+        expect((await readPendingMessageWalRecords({dir: messageWalDir, ids: [msgId]})).map(record => record.id)).toEqual([msgId]);
+
+        // Pre-fix, this drain FULL-re-projected the intact record — resurrecting readAt: null
+        // (the rollback amplifier). Issues-first, it only heals the marker.
+        const summary = await MailboxService.drainPendingMessageGraphProjections({ids: [msgId]});
+        expect(summary).toEqual({pending: 1, projected: 1, failed: 0});
+
+        const postDrain = GraphService.db.storage.db
+            .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt FROM Nodes WHERE id = ?`)
+            .get(msgId);
+        expect(postDrain.readAt).toBeTruthy();
+
+        // marker healed: the record retired from the pending index
+        expect(await readPendingMessageWalRecords({dir: messageWalDir, ids: [msgId]})).toHaveLength(0);
+    });
+
+    test('surgical repair does not duplicate the projection marker — the marker index stays 1:1 with accepted records (#14992)', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        let msgId;
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: '@bob', subject: 'one marker only', body: 'no inflation' });
+            msgId = res.messageId;
+        });
+
+        const countMarkerLines = () => fs.readdirSync(messageWalDir)
+            .filter(name => name.endsWith('.graph.jsonl'))
+            .reduce((count, name) => count + fs.readFileSync(path.join(messageWalDir, name), 'utf8')
+                .split('\n').filter(line => line.includes(msgId)).length, 0);
+
+        expect(countMarkerLines()).toBe(1);
+
+        // post-marker damage: repair restores the edge; the pre-existing marker must NOT be
+        // re-appended (observed inflation: 499 markers over 70 accepted records on 2026-07-09)
+        GraphService.db.storage.db.prepare('DELETE FROM Edges WHERE source = ? AND target = ? AND type = ?')
+            .run(msgId, '@bob', 'SENT_TO');
+        clearGraphCacheWithoutStorageMutation();
+
+        const summary = await MailboxService.repairMessageGraphIntegrity({ids: [msgId]});
+        expect(summary).toMatchObject({scanned: 1, repaired: 1, failed: 0});
+
+        expect(countMarkerLines()).toBe(1);
+    });
+
     test('unread counts are stable across consecutive cold-cache listMessages calls — reads never revert reads (#14797)', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });


### PR DESCRIPTION
Resolves #14992

Mailbox read-status was durably reverting: `readAt` values committed by `mark_read` (acknowledged receipts) rolled back to `null` hours later, swarm-wide. The forensic trail (full receipts on the ticket) pinned the mechanism, and this PR closes it at three layers so the class cannot recur, whichever caller fires.

**The proven mechanism** (read-only DB + WAL forensics, 2026-07-10): message WAL records carry send-time state (`readAt: null`) forever, and already-projected records were being **fully re-projected** — the specimen `MESSAGE:b67207fb…` has ONE accepted WAL record and THREE projection markers (13:01 accept, 17:20 and 20:50 rogue re-projections; GraphLog shows the node rewritten at those instants, erasing the 18:00 committed `readAt`). Marker-index inflation corroborates scale: 70 accepted / 499 markers (07-09), 436 / 1232 (07-10). The pending-drain's premise — "marker absent ⇒ never projected ⇒ full projection is safe" — is false across crash windows (projection commits to sqlite; the marker append is a separate JSONL write) and marker-index divergence; the #14806 surgical-repair fix covered the *repair* path but the drain kept the blind full projection, and surgical repairs re-appended markers on every pass (masking the signal).

**The fix (defense-in-depth, one choke-point + two callers):**

1. **Choke-point (caller-proof across the COMPLETE graph-owned surface — cycle-1 P1):** full projection now merges storage truth over the WAL payload on every mutation-bearing surface: the MESSAGE node's `readAt`/`archivedAt` AND the sender's irreversible retraction tombstone (`retracted` + placeholder `subject`/`bodyText` — replay never resurrects retracted content), plus each per-recipient broadcast `DELIVERED_TO` edge's `readAt`/`archivedAt` (`getStorageDeliveryMutableState` merges committed edge state over the WAL's send-time nulls at the ONE link site serving both surgical and full paths — a genuinely missing edge merges `{}` and honestly starts unread). Graph-owned mutations win over eternal send-time WAL state, whichever caller fires.
2. **Drain goes issues-first:** `drainPendingMessageGraphProjections` runs the storage-truth `getMessageGraphProjectionIssues` scan per record — graph intact ⇒ heal the marker only (zero graph writes); partial damage ⇒ surgical projection of the named pieces; `missing-message-node` ⇒ the full projection (the one path that links optional semantic edges — the established first-projection contract, now safe via layer 1).
3. **Marker append is projection-scoped:** `_projectMessageWalRecord` gains `appendMarker` (default `!onlyIssues`) — full projections and drain-surgical calls append (the marker retires the record from the pending index); post-marker-damage surgical repairs no longer re-append, ending the 3-7× marker inflation.

Evidence: L2 — the incident is reproduced as regression: the exact specimen path (projected → marked read → full re-projection replay) now preserves `readAt` at the storage row every process re-hydrates from; the lost-marker drain heal and the marker-1:1 invariant are asserted against the real WAL files. Root-cause receipts (GraphLog sequence forensics, marker counts, holder topology) live on #14992.

## Deltas from ticket

- The ticket's H1–H3 hypothesis ranking resolved differently than ranked: not snapshot staleness, not restart rollback of sqlite, not dual-root divergence (the two checkout roots share ONE physical DB — same inode; the diagnostics' config-derived `sqliteFile` self-report is cosmetic) — but **overwrite-after-mark via full WAL re-projection**, proven by marker multiplicity + GraphLog write sequencing. The ticket's AC-2 (diagnostics reports the actual open handle) is descoped to a follow-up note on the ticket: with the root defect fixed and the path being cosmetic-only, it does not block this leaf.
- The exact trigger-caller question (which process ran the rogue drains — tool-log correlates `list_messages` timestamps, but the daemon/in-process host isn't tool-logged) is left OPEN on the ticket as an observability note; the fix makes the answer moot for correctness (every caller is now safe by construction).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs --workers=1` → **88 passed** (84 existing contracts — drain idempotency, #14426 surgical repair, #14797 cold-cache stability — all green unchanged, + 4 new: full-re-projection DM readAt survival · the cycle-1 reviewer falsifier as permanent regression (broadcast `DELIVERED_TO` readAt survives full replay + the retraction tombstone survives replay over the read edge) · lost-marker drain heal without graph writes · surgical-repair marker 1:1).
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/ --workers=1` → **868 passed, 0 failed** (21 "did not run" = pre-existing cross-file serial-ordering skips; the mailbox-adjacent one, `WriteSideInvariant.spec.mjs`, passes 3/3 in isolation).
- Observed-unrelated: `test/playwright/unit/ai/daemons/` fails identically on clean `dev` in this environment (`Orchestrator.mjs:424` singleton-time `dataDir` undefined — stale local config overlay predating the `orchestrator.dataDir` leaf; CI runs the template).
- Pre-commit gates green (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation

- [ ] Restart the Memory Core servers on the merged head, re-mark a batch of resurrected 2026-07-10 messages, and verify no revert across the next drain cycles (the live falsifier of the incident)
- [ ] Marker files stop growing faster than accepted records (spot-check `wc -l` on `message-wal-<day>.jsonl` vs `.graph.jsonl` after a day)

## Commits

- 24519f4cb — the three-layer fix + 3 regression tests.
- dc5cebc28 — cycle-1 discharge: the preservation surface widened to delivery-edge read/archive state + the retraction tombstone, with the reviewer falsifier as the bundled ownership regression.

Related: #14806 (the surgical-repair predecessor this completes) · #14426 (WAL repair lineage) · #13892/#13890 (drain topology) · session with the full forensic trail: 9cf9cce9-23bf-4211-ab0d-bab51d5e1d14.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 9cf9cce9-23bf-4211-ab0d-bab51d5e1d14.
