### PR TITLE
feat(fleet): persist sparse agent configuration (#14964)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -130,8 +130,9 @@ class FleetControlBridge extends Base {
     // ---- capability allowlist (the ONLY pane-reachable operations) ----------
 
     /**
-     * @summary Define (create or update) an agent. A supplied `credential` (PAT) is stored encrypted
-     * Node-side by the registry and is **never** echoed back — the return is the public definition.
+     * @summary Create an agent. Existing ids reject so established residents can change only through
+     * scoped update authorities. A supplied `credential` (PAT) is stored encrypted Node-side and is
+     * **never** echoed back — the return is the public definition.
      * @param {Object}  definition
      * @param {String}  definition.githubUsername    The agent's GitHub username (required).
      * @param {String}  definition.harnessType       A supported harness type (required).
@@ -139,6 +140,7 @@ class FleetControlBridge extends Base {
      * @param {String} [definition.id]               Stable id; defaults to `githubUsername`.
      * @param {Object} [definition.metadata]         Free-form non-secret metadata.
      * @param {String} [definition.modelProvider]    The agent's model-provider login; resolves via the AiConfig SSOT leaf when omitted.
+     * @param {Object|null} [definition.mcpServers]   Complete sparse MCP overrides; omitted/null follows live defaults, exactly like configureAgent.
      * @returns {Object} the public agent definition (no credential).
      */
     defineAgent(definition) {
@@ -146,16 +148,28 @@ class FleetControlBridge extends Base {
     }
 
     /**
-     * @summary Configure an existing agent — harness type + per-agent MCP matrix + operational
-     * intents (the scoped patch path; fleet authority, as with `defineAgent`). Never identity,
-     * never credential: the registry validates and persists, and the returned public definition
-     * is the Body's readback.
-     * @param {String} id
-     * @param {Object} config `{harnessType?, mcpServers?, hooksActive?, wakeSubscriptionsActive?}`
-     * @returns {Object|null} the updated public definition, or `null` for an unknown id.
+     * @summary Configure an existing agent through one serializable curated intent. Validation
+     * failures become an explicit domain outcome the Accounts card may render; unexpected service
+     * failures still throw and are sanitized by dispatchFleetRequest.
+     * @param {Object} intent `{id, harnessType?, mcpServers?}`
+     * @returns {{status: 'accepted', agent: Object}|{status: 'rejected', reason: String}}
      */
-    configureAgent(id, config) {
-        return this.getRegistry().configureAgent(id, config);
+    configureAgent(intent) {
+        try {
+            const agent = this.getRegistry().configureAgent(intent);
+
+            return agent
+                ? {status: 'accepted', agent}
+                : {status: 'rejected', reason: `Unknown agent '${intent?.id ?? ''}'.`}
+        } catch (error) {
+            const prefix = 'FleetRegistryService.configureAgent:';
+
+            if (error?.message?.startsWith(prefix)) {
+                return {status: 'rejected', reason: error.message.slice(prefix.length).trim()}
+            }
+
+            throw error
+        }
     }
 
     /**

--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -2,13 +2,47 @@ import crypto          from 'crypto';
 import fs              from 'fs';
 import path            from 'path';
 import {fileURLToPath} from 'url';
-import aiConfig        from '../../config.mjs';
-import Base            from '../../../src/core/Base.mjs';
-import {HARNESS_TYPES} from '../../../src/ai/fleet/harnessTypes.mjs';
+import aiConfig                    from '../../config.mjs';
+import Base                        from '../../../src/core/Base.mjs';
+import {HARNESS_TYPES}             from '../../../src/ai/fleet/harnessTypes.mjs';
+import {normalizeMcpOverrides}     from '../../../src/ai/fleet/mcpServers.mjs';
 
 const
-    __filename = fileURLToPath(import.meta.url),
-    __dirname  = path.dirname(__filename);
+    __filename           = fileURLToPath(import.meta.url),
+    __dirname            = path.dirname(__filename),
+    PUBLIC_REDACTED_KEYS = new Set([
+        'credential', 'credentials', 'pat', 'githubpat', 'token', 'tokens', 'accesstoken',
+        'githubtoken', 'apitoken', 'secret', 'secrets', 'password', 'apikey', 'command', 'args',
+        'env', 'launch'
+    ]);
+
+/**
+ * @summary Recursively remove credential/launch vocabulary from a caller-owned public projection.
+ * Registry metadata is intentionally extensible, so redaction must guard nested legacy entries as
+ * well as the current top-level fields. Keys normalize hyphens/underscores and case before lookup.
+ * @param {*} value Structured-cloned public value.
+ * @param {WeakSet<Object>} [seen]
+ * @returns {*} The same redacted value.
+ */
+function redactPublicFields(value, seen=new WeakSet()) {
+    if (!value || typeof value !== 'object' || seen.has(value)) {
+        return value
+    }
+
+    seen.add(value);
+
+    Object.keys(value).forEach(key => {
+        const normalized = key.replaceAll('-', '').replaceAll('_', '').toLowerCase();
+
+        if (PUBLIC_REDACTED_KEYS.has(normalized)) {
+            delete value[key]
+        } else {
+            redactPublicFields(value[key], seen)
+        }
+    });
+
+    return value
+}
 
 /**
  * @class Neo.ai.services.fleet.FleetRegistryService
@@ -20,7 +54,7 @@ const
  * This is the first leaf of the Fleet Manager MVP: the `define` surface of the operator loop
  * *define agents → start/stop → repos managed under the hood*.
  *
- * An **agent definition** is `{id, githubUsername, harnessType, modelProvider, metadata, createdAt, updatedAt}` —
+ * An **agent definition** is `{id, githubUsername, harnessType, modelProvider, mcpServers, metadata, createdAt, updatedAt}` —
  * never a secret. `modelProvider` (the agent's model-provider login) resolves via the AiConfig
  * `modelProvider` SSOT leaf when not supplied — read-only, no service-local default shadow. The associated **credential** (a GitHub PAT) is stored separately, encrypted at
  * rest, and is the load-bearing security boundary of this service:
@@ -109,7 +143,9 @@ class FleetRegistryService extends Base {
     // ---- public API ---------------------------------------------------------
 
     /**
-     * Define (create or update) an agent and, optionally, store its credential.
+     * Create an agent and, optionally, store its credential. Existing ids reject: every edit of an
+     * established resident must use a scoped authority (`configureAgent`, `setRepo`, `setAvatar`,
+     * or the Brain-only launch override), never replay this credential-bearing creation surface.
      * @param {Object}  opts
      * @param {String}  opts.githubUsername     The agent's GitHub username (required).
      * @param {String}  opts.harnessType        One of {@link harnessTypes} (required).
@@ -117,9 +153,10 @@ class FleetRegistryService extends Base {
      * @param {String} [opts.id=githubUsername] Stable id; pass an explicit id to register multiple instances per user.
      * @param {Object} [opts.metadata={}]       Free-form non-secret metadata.
      * @param {String} [opts.modelProvider]     The agent's model-provider login (e.g. `openAiCompatible`, `ollama`). Resolves via the AiConfig `modelProvider` SSOT leaf when omitted — no service-local default shadow. Non-secret; carried in the public definition.
+     * @param {Object|null} [opts.mcpServers]   Sparse MCP overrides shared with configureAgent; omitted/null follows defaults.
      * @returns {Object} The public agent definition (no credential).
      */
-    defineAgent({githubUsername, harnessType, credential, id, metadata={}, modelProvider} = {}) {
+    defineAgent({githubUsername, harnessType, credential, id, metadata={}, modelProvider, mcpServers} = {}) {
         if (!githubUsername) throw new Error("FleetRegistryService.defineAgent: 'githubUsername' is required.");
         if (!harnessType)    throw new Error("FleetRegistryService.defineAgent: 'harnessType' is required.");
 
@@ -136,42 +173,69 @@ class FleetRegistryService extends Base {
             throw new Error("FleetRegistryService.defineAgent: 'metadata.launch' is not definable through this surface — wire callers send curated harnessType intent only. Brain/operator launch overrides go through setLaunchOverride.");
         }
 
+        const
+            agentId = id || githubUsername,
+            now     = new Date().toISOString(),
+            matrix  = mcpServers === undefined ? null : normalizeMcpOverrides(mcpServers);
+
         this.ensureLoaded();
 
+        if (this.agents.has(agentId)) {
+            throw new Error(`FleetRegistryService.defineAgent: id '${agentId}' already exists; use a scoped update operation.`)
+        }
+
         const
-            agentId  = id || githubUsername,
-            now      = new Date().toISOString(),
-            existing = this.agents.get(agentId),
-            def      = {
+            def        = {
                 id            : agentId,
                 githubUsername,
                 harnessType,
                 // provider-login resolves via the AiConfig SSOT leaf when unset (no service-local
-                // default shadow); an explicit arg wins, else a prior value is preserved on update.
-                modelProvider: modelProvider || existing?.modelProvider || aiConfig.modelProvider,
+                // default shadow); an explicit arg wins on creation.
+                modelProvider: modelProvider || aiConfig.modelProvider,
                 metadata,
-                createdAt    : existing?.createdAt || now,
+                mcpServers   : matrix,
+                createdAt    : now,
                 updatedAt    : now
-            };
+            },
+            nextAgents = new Map(this.agents);
 
-        this.agents.set(agentId, def);
-        this.writeRegistry();
+        nextAgents.set(agentId, def);
 
         if (credential != null) {
-            this.storeCredential(agentId, credential);
+            const
+                previousCredentials = this.readCredentials(),
+                nextCredentials     = Object.assign(Object.create(null), previousCredentials, {[agentId]: credential});
+
+            // Two-store create transaction: credential first, registry row last. A credential
+            // failure cannot strand an unrecoverable create-only resident. If registry publish
+            // fails, restore the prior credential snapshot; the absent row remains retryable even
+            // if the best-effort rollback itself encounters a second storage failure.
+            this.writeCredentials(nextCredentials);
+
+            try {
+                this.writeRegistry(nextAgents)
+            } catch (error) {
+                try {
+                    this.writeCredentials(previousCredentials)
+                } catch (rollbackError) {}
+
+                throw error
+            }
+        } else {
+            this.writeRegistry(nextAgents)
         }
 
+        this.agents = nextAgents;
         return this.toPublic(def);
     }
 
     /**
      * Partially update an existing agent definition: merge `metadata` (does NOT replace it) and
      * override `modelProvider` if given, preserving every other field, `createdAt`, and the stored
-     * credential. The narrow patch path distinct from {@link defineAgent}'s full create-or-replace
-     * upsert — control verbs (e.g. `FleetManager.setRepo`) mutate one facet without re-supplying the
-     * whole definition (which would demand `githubUsername`/`harnessType` and wipe unspecified
-     * metadata). Non-destructive to on-disk checkout and credential. No-op-safe: an unknown id
-     * returns `null` rather than creating a partial definition.
+     * credential. This narrow patch path is distinct from {@link defineAgent}'s create-only
+     * boundary — control verbs (e.g. `FleetManager.setRepo`) mutate one facet without replaying
+     * identity or credentials. Non-destructive to on-disk checkout and credential. No-op-safe: an
+     * unknown id returns `null` rather than creating a partial definition.
      * @param {String}  id
      * @param {Object}  patch
      * @param {Object} [patch.metadata]      Metadata keys merged into the existing metadata.
@@ -198,57 +262,81 @@ class FleetRegistryService extends Base {
             updatedAt    : new Date().toISOString()
         };
 
-        this.agents.set(id, def);
-        this.writeRegistry();
+        const nextAgents = new Map(this.agents);
+        nextAgents.set(id, def);
+        this.writeRegistry(nextAgents);
+        this.agents = nextAgents;
 
         return this.toPublic(def);
     }
 
     /**
-     * Configure an existing agent's harness + per-agent runtime configuration — the scoped patch
-     * path Body configuration surfaces round-trip through (the {@link updateAgent} pattern, one
-     * facet class): validates `harnessType` against {@link harnessTypes}, boolean-coerces the MCP
-     * enable matrix, and preserves everything unspecified — identity, metadata, `createdAt`, and
-     * the stored credential are untouchable through this surface. The returned public definition
-     * IS the caller's readback: the Body renders what the registry persisted, never what it sent.
-     * No-op-safe: an unknown id returns `null` rather than creating a partial definition.
-     * @param {String}        id
-     * @param {Object}        config
-     * @param {String}       [config.harnessType]             New harness type — one of {@link harnessTypes}.
-     * @param {Object|null}  [config.mcpServers]              Per-agent MCP enable matrix (values boolean-coerced); `null` resets to catalog defaults.
-     * @param {Boolean|null} [config.hooksActive]             Configured hooks intent; `null` = not read back.
-     * @param {Boolean|null} [config.wakeSubscriptionsActive] Configured wake-subscription intent; `null` = not read back.
-     * @returns {Object|null} The updated public definition (no credential), or `null` when the agent doesn't exist.
+     * Configure an existing agent through the ONE wire-serializable curated intent. Only `id`,
+     * `harnessType`, and sparse `mcpServers` overrides are accepted; credentials, launch fields,
+     * wake, hooks, identity, and generic config bags are mechanically rejected. Unspecified fields
+     * are preserved. The returned public definition is canonical persisted readback, never request
+     * echo. Controlled validation failures use the method prefix so FleetControlBridge can expose a
+     * safe rejected-domain reason while unexpected storage failures remain transport-sanitized.
+     * @param {Object} intent
+     * @param {String} intent.id Existing registry id.
+     * @param {String} [intent.harnessType] Registered durable harness key.
+     * @param {Object|null} [intent.mcpServers] Complete sparse MCP override set; null follows defaults.
+     * @returns {Object|null} Updated public definition, or `null` when the id is not registered.
      */
-    configureAgent(id, {harnessType, mcpServers, hooksActive, wakeSubscriptionsActive} = {}) {
+    configureAgent(intent={}) {
+        const reject = reason => {
+            throw new TypeError(`FleetRegistryService.configureAgent: ${reason}`)
+        };
+
+        if (!intent || typeof intent !== 'object' || Array.isArray(intent)) {
+            reject('intent must be an object.')
+        }
+
+        const
+            allowed = new Set(['id', 'harnessType', 'mcpServers']),
+            unknown = Object.keys(intent).find(key => !allowed.has(key)),
+            {id, harnessType, mcpServers} = intent;
+
+        if (unknown) {
+            reject(`unsupported field '${unknown}'.`)
+        }
+        if (typeof id !== 'string' || !id.trim()) {
+            reject("'id' is required.")
+        }
+        if (!Object.hasOwn(intent, 'harnessType') && !Object.hasOwn(intent, 'mcpServers')) {
+            reject('at least one configuration field is required.')
+        }
+
         this.ensureLoaded();
 
         const existing = this.agents.get(id);
         if (!existing) return null;
 
-        if (harnessType != null && !this.harnessTypes.includes(harnessType)) {
-            throw new Error(`FleetRegistryService.configureAgent: invalid harnessType '${harnessType}'. Must be one of: ${this.harnessTypes.join(', ')}.`);
+        if (Object.hasOwn(intent, 'harnessType') && !this.harnessTypes.includes(harnessType)) {
+            reject(`invalid harnessType '${harnessType}'. Must be one of: ${this.harnessTypes.join(', ')}.`)
         }
 
         let matrix = existing.mcpServers ?? null;
 
-        if (mcpServers !== undefined) {
-            matrix = mcpServers === null
-                ? null
-                : Object.fromEntries(Object.entries(mcpServers).map(([key, value]) => [key, !!value]));
+        if (Object.hasOwn(intent, 'mcpServers')) {
+            try {
+                matrix = normalizeMcpOverrides(mcpServers)
+            } catch (error) {
+                reject(error.message)
+            }
         }
 
         const def = {
             ...existing,
-            harnessType            : harnessType ?? existing.harnessType,
-            mcpServers             : matrix,
-            hooksActive            : hooksActive !== undefined ? hooksActive : (existing.hooksActive ?? null),
-            wakeSubscriptionsActive: wakeSubscriptionsActive !== undefined ? wakeSubscriptionsActive : (existing.wakeSubscriptionsActive ?? null),
-            updatedAt              : new Date().toISOString()
+            harnessType: Object.hasOwn(intent, 'harnessType') ? harnessType : existing.harnessType,
+            mcpServers : matrix,
+            updatedAt  : new Date().toISOString()
         };
 
-        this.agents.set(id, def);
-        this.writeRegistry();
+        const nextAgents = new Map(this.agents);
+        nextAgents.set(id, def);
+        this.writeRegistry(nextAgents);
+        this.agents = nextAgents;
 
         return this.toPublic(def);
     }
@@ -408,14 +496,7 @@ class FleetRegistryService extends Base {
      * @private
      */
     toPublic(def) {
-        const {credential, pat, ...rest} = def;
-        const pub                        = structuredClone(rest);
-
-        if (pub.metadata && Object.hasOwn(pub.metadata, 'launch')) {
-            delete pub.metadata.launch;
-        }
-
-        return pub;
+        return redactPublicFields(structuredClone(def))
     }
 
     /**
@@ -449,10 +530,22 @@ class FleetRegistryService extends Base {
      * Persist the in-memory registry to `registry.json` (no secrets).
      * @private
      */
-    writeRegistry() {
+    writeRegistry(agents=this.agents) {
         this.ensureDataDir();
-        const payload = {agents: Object.fromEntries(this.agents)};
-        fs.writeFileSync(this.registryPath(), JSON.stringify(payload, null, 2), 'utf8');
+        const
+            file    = this.registryPath(),
+            tmpFile = `${file}.${process.pid}.${crypto.randomUUID()}.tmp`,
+            payload = {agents: Object.fromEntries(agents)};
+
+        try {
+            fs.writeFileSync(tmpFile, JSON.stringify(payload, null, 2), 'utf8');
+            fs.renameSync(tmpFile, file)
+        } catch (error) {
+            if (fs.existsSync(tmpFile)) {
+                fs.unlinkSync(tmpFile)
+            }
+            throw error
+        }
     }
 
     /**
@@ -499,13 +592,25 @@ class FleetRegistryService extends Base {
     }
 
     /**
-     * Encrypt + write the full credential map to `credentials.enc` (`0600`).
+     * Encrypt + atomically publish the full credential map to `credentials.enc` (`0600`).
      * @param {Object} map
      * @private
      */
     writeCredentials(map) {
         this.ensureDataDir();
-        fs.writeFileSync(this.credentialsPath(), this.encrypt(JSON.stringify(map)), {mode: 0o600});
+        const
+            file    = this.credentialsPath(),
+            tmpFile = `${file}.${process.pid}.${crypto.randomUUID()}.tmp`;
+
+        try {
+            fs.writeFileSync(tmpFile, this.encrypt(JSON.stringify(map)), {mode: 0o600});
+            fs.renameSync(tmpFile, file)
+        } catch (error) {
+            if (fs.existsSync(tmpFile)) {
+                fs.unlinkSync(tmpFile)
+            }
+            throw error
+        }
     }
 
     // ---- crypto (AES-256-GCM) ----------------------------------------------

--- a/apps/agentos/config/mcpServers.mjs
+++ b/apps/agentos/config/mcpServers.mjs
@@ -1,66 +1,13 @@
 /**
- * The Fleet Manager MCP-server catalog: one data-driven entry per attachable MCP server, plus the
- * per-agent matrix resolvers. Pure data, no component coupling — ADDING A SERVER IS ONE
- * REGISTRATION; the per-agent enable/disable matrix is DATA on the agent record
- * ({@link AgentOS.model.AgentDefinition} `mcpServers`), rendered as the agent's configuration card.
- *
- * The Neo core set (Memory Core · Knowledge Base · Neural Link) defaults ON — a fleet agent
- * without its memory, knowledge, and possession seams is not a fleet agent. Workflow servers
- * default OFF and opt in per agent. `label` is operator-facing product language.
+ * Fleet Manager MCP-server configuration — a thin re-export of the ONE shared Body↔Brain
+ * authority (`src/ai/fleet/mcpServers.mjs`). App views keep their conventional config import path;
+ * durable keys, labels, defaults, and sparse-override validation never fork here.
  */
-
-const MCP_SERVERS = [
-    {key: 'memory-core',     label: 'Memory Core',     core: true,  defaultEnabled: true},
-    {key: 'knowledge-base',  label: 'Knowledge Base',  core: true,  defaultEnabled: true},
-    {key: 'neural-link',     label: 'Neural Link',     core: true,  defaultEnabled: true},
-    {key: 'github-workflow', label: 'GitHub workflow', core: false, defaultEnabled: false},
-    {key: 'gitlab-workflow', label: 'GitLab workflow', core: false, defaultEnabled: false}
-];
-
-const BY_KEY = new Map(MCP_SERVERS.map(entry => [entry.key, entry]));
-
-/**
- * @summary Every registered MCP server, in display order. Frozen shape: consumers render, never mutate.
- * @returns {Object[]} `[{key, label, core, defaultEnabled}]`
- */
-export function listMcpServers() {
-    return MCP_SERVERS.map(entry => ({...entry}))
-}
-
-/**
- * @summary The default per-agent matrix — the registry's `defaultEnabled` per key. This is what a
- * record's `mcpServers: null` MEANS: defaults apply, derived from the ONE registry, never baked
- * into records (a catalog change must reach every default-following agent).
- * @returns {Object} `{serverKey: Boolean}`
- */
-export function defaultMcpMatrix() {
-    const matrix = {};
-
-    MCP_SERVERS.forEach(entry => {
-        matrix[entry.key] = entry.defaultEnabled
-    });
-
-    return matrix
-}
-
-/**
- * @summary Resolve one agent's effective matrix: the registry defaults with the record's explicit
- * per-key choices merged on top. Unknown keys inside the stored matrix are IGNORED (fail-closed:
- * a stale record never invents a server), and only registered keys come back — the result is
- * always renderable against the live catalog.
- * @param {Object|null} storedMatrix The record's `mcpServers` value (null = defaults apply).
- * @returns {Object} `{serverKey: Boolean}` for every registered server.
- */
-export function resolveMcpMatrix(storedMatrix) {
-    const matrix = defaultMcpMatrix();
-
-    Object.entries(storedMatrix || {}).forEach(([key, enabled]) => {
-        if (BY_KEY.has(key)) {
-            matrix[key] = enabled === true
-        }
-    });
-
-    return matrix
-}
-
-export default {defaultMcpMatrix, listMcpServers, resolveMcpMatrix};
+export {
+    MCP_SERVERS,
+    defaultMcpMatrix,
+    listMcpServers,
+    normalizeMcpOverrides,
+    resolveMcpMatrix
+} from '../../../src/ai/fleet/mcpServers.mjs';
+export {default} from '../../../src/ai/fleet/mcpServers.mjs';

--- a/apps/agentos/model/AgentDefinition.mjs
+++ b/apps/agentos/model/AgentDefinition.mjs
@@ -6,8 +6,9 @@ import Model from '../../../src/data/Model.mjs';
  *
  * @summary Public, Body-side shape for Fleet Manager agent definitions — the per-agent
  * configuration model every account surface binds: identity, ONE harness choice (a registered
- * `config/harnessTypes.mjs` key), the per-agent MCP-server matrix (`mcpServers` — null means the
- * catalog defaults apply; resolve via `config/mcpServers.mjs`, never bake defaults into records),
+ * `config/harnessTypes.mjs` key), the per-agent sparse MCP-server overrides (`mcpServers` — null
+ * means every current catalog default applies; resolve via `config/mcpServers.mjs`, never persist
+ * the fully resolved matrix),
  * and the operational toggles (honest readback: null = state not read back yet, never an
  * optimistic guess). This model deliberately contains no credential field: PAT bytes remain
  * Brain-side in FleetRegistryService and may only surface here as redacted state.
@@ -42,7 +43,7 @@ class AgentDefinition extends Model {
             name: 'lifecycleState',
             type: 'String'
         }, {
-            // the per-agent MCP-server matrix {serverKey: Boolean}; null = catalog defaults apply
+            // sparse per-agent MCP overrides {serverKey: Boolean}; null = all live defaults apply
             name        : 'mcpServers',
             type        : 'Object',
             defaultValue: null

--- a/apps/agentos/view/Accounts.mjs
+++ b/apps/agentos/view/Accounts.mjs
@@ -169,6 +169,30 @@ class Accounts extends DashboardPanel {
     }
 
     /**
+     * Monotonic guard for canonical roster reads. An accepted configure response increments the
+     * generation so an older listAgents response cannot overwrite newer persisted truth.
+     * @member {Number} agentDefinitionsLoadGeneration=0
+     * @private
+     */
+    agentDefinitionsLoadGeneration = 0
+
+    /**
+     * Latest save-request generation per agent. Only the newest response may update the Body
+     * projection or visible save state.
+     * @member {Map<String,Number>} agentConfigRequestGenerations
+     * @private
+     */
+    agentConfigRequestGenerations = new Map()
+
+    /**
+     * Ephemeral save status per agent. Selection changes re-project this state onto the card, so a
+     * pending/accepted/rejected result never moves to or disappears behind another agent.
+     * @member {Map<String,Object>} agentConfigSaveStatuses
+     * @private
+     */
+    agentConfigSaveStatuses = new Map()
+
+    /**
      * @summary Wire the configuration card's intent event — the card renders and fires; this view
      * owns the bridge round-trip (see {@link #onAgentConfigIntent}).
      * @param {...*} args
@@ -197,7 +221,8 @@ class Accounts extends DashboardPanel {
         value   ?.on({...listeners});
         oldValue?.un({...listeners});
 
-        me.syncAgentSelector()
+        me.syncAgentSelector();
+        value && void me.loadAgentDefinitions?.()
     }
 
     /**
@@ -215,7 +240,10 @@ class Accounts extends DashboardPanel {
             card.record = value ? (me.agentDefinitionsStore?.get(value) ?? null) : null;
             // a recordChange mutates fields WITHOUT changing record identity, and the reactive
             // config setter suppresses same-identity assignments — refresh() closes that gap
-            card.refresh()
+            card.refresh();
+
+            const status = me.agentConfigSaveStatuses.get(value) ?? {state: 'idle', reason: ''};
+            value && card.setSaveStatus(value, status.state, status.reason)
         }
 
         me.getReference('agent-selector')?.items?.forEach(item => {
@@ -237,35 +265,118 @@ class Accounts extends DashboardPanel {
      * validates + persists, and the RESPONSE (the public definition — the readback) is written
      * onto the store record, which re-renders the card. Fail-closed: without a bridge nothing
      * mutates locally — a config that did not persist must never render as if it had.
-     * @param {Object} data `{agentId, config}` from {@link AgentOS.view.AgentConfigCard}.
+     * @param {Object} intent The one wire shape: `{id, harnessType?, mcpServers?}`.
      * @returns {Promise<void>}
      */
-    async onAgentConfigIntent({agentId, config}) {
+    async onAgentConfigIntent(intent={}) {
         const
-            me     = this,
-            bridge = globalThis.AgentOS?.fleet?.registryBridge;
+            me        = this,
+            agentId   = intent.id,
+            bridge    = globalThis.AgentOS?.fleet?.registryBridge,
+            // Neo events add transport-irrelevant envelope fields such as `source`. Reconstruct the
+            // curated wire intent explicitly so no event metadata can cross the Brain allowlist.
+            wireIntent = {id: agentId};
+
+        if (me.agentConfigSaveStatuses.get(agentId)?.state === 'pending') {
+            return
+        }
+
+        if (Object.hasOwn(intent, 'harnessType')) wireIntent.harnessType = intent.harnessType;
+        if (Object.hasOwn(intent, 'mcpServers'))  wireIntent.mcpServers  = intent.mcpServers;
+
+        const requestGeneration = (me.agentConfigRequestGenerations.get(agentId) || 0) + 1;
+        me.agentConfigRequestGenerations.set(agentId, requestGeneration);
+        me.setAgentConfigSaveStatus(agentId, 'pending', 'Saving configuration…');
 
         if (typeof bridge?.configureAgent !== 'function') {
-            me.updateBridgeStatus('is-error', 'Configuration is unavailable in dev-server mode. Nothing was changed.');
+            const reason = 'Configuration is unavailable in dev-server mode. Nothing was changed.';
+            me.setAgentConfigSaveStatus(agentId, 'rejected', reason);
             return
         }
 
         try {
-            const updated = await bridge.configureAgent(agentId, config);
+            const outcome = await bridge.configureAgent(wireIntent);
 
-            if (updated) {
-                me.agentDefinitionsStore?.get(agentId)?.set({
-                    harnessType            : updated.harnessType,
-                    hooksActive            : updated.hooksActive ?? null,
-                    mcpServers             : updated.mcpServers ?? null,
-                    wakeSubscriptionsActive: updated.wakeSubscriptionsActive ?? null
-                });
-                me.updateBridgeStatus('is-live', 'Configuration saved.')
+            if (me.agentConfigRequestGenerations.get(agentId) !== requestGeneration) {
+                return
+            }
+
+            if (outcome?.status === 'accepted' && outcome.agent?.id === agentId) {
+                const record = me.agentDefinitionsStore?.get(agentId);
+
+                if (!record) {
+                    throw new Error('accepted configuration has no matching local agent')
+                }
+
+                // Invalidate any older boot-list response before applying the canonical save
+                // readback. Only the RESPONSE mutates the durable Body projection.
+                me.agentDefinitionsLoadGeneration = (me.agentDefinitionsLoadGeneration || 0) + 1;
+                record.set(outcome.agent);
+                me.setAgentConfigSaveStatus(agentId, 'accepted', 'Configuration saved.')
             } else {
-                me.updateBridgeStatus('is-error', 'Unknown agent — configuration not saved.')
+                const reason = outcome?.status === 'rejected'
+                    ? (outcome.reason || 'Configuration was rejected.')
+                    : 'Configuration response was invalid. Nothing was changed.';
+
+                me.setAgentConfigSaveStatus(agentId, 'rejected', reason)
             }
         } catch (error) {
-            me.updateBridgeStatus('is-error', 'Could not save the configuration. Nothing was changed.')
+            if (me.agentConfigRequestGenerations.get(agentId) !== requestGeneration) {
+                return
+            }
+
+            const reason = 'Could not save the configuration. Nothing was changed.';
+            me.setAgentConfigSaveStatus(agentId, 'rejected', reason)
+        }
+    }
+
+    /**
+     * @summary Store one agent's ephemeral save state and project it only when that agent is still
+     * visible. The state survives selection changes without entering the durable roster model.
+     * @param {String} agentId
+     * @param {'idle'|'pending'|'accepted'|'rejected'} state
+     * @param {String} [reason='']
+     */
+    setAgentConfigSaveStatus(agentId, state, reason='') {
+        this.agentConfigSaveStatuses.set(agentId, {state, reason});
+        this.getReference('agent-config-card')?.setSaveStatus(agentId, state, reason)
+    }
+
+    /**
+     * @summary Hydrate the provider-hosted AgentDefinitions store from the Brain's canonical public
+     * roster. A failed or stale request preserves the last rendered state. A generation guard keeps
+     * a slow boot read from overwriting a newer accepted configure response.
+     * @returns {Promise<Boolean>} True only when canonical roster data replaced the local projection.
+     */
+    async loadAgentDefinitions() {
+        const
+            me         = this,
+            store      = me.agentDefinitionsStore,
+            bridge     = globalThis.AgentOS?.fleet?.registryBridge,
+            generation = (me.agentDefinitionsLoadGeneration || 0) + 1;
+
+        me.agentDefinitionsLoadGeneration = generation;
+
+        if (!store || typeof bridge?.listAgents !== 'function') {
+            return false
+        }
+
+        try {
+            const agents = await bridge.listAgents();
+
+            if (!Array.isArray(agents)) {
+                return false
+            }
+            if (generation !== me.agentDefinitionsLoadGeneration || store !== me.agentDefinitionsStore) {
+                return false
+            }
+
+            store.data = agents;
+            me.syncAgentSelector();
+
+            return true
+        } catch (error) {
+            return false
         }
     }
 

--- a/apps/agentos/view/AgentConfigCard.mjs
+++ b/apps/agentos/view/AgentConfigCard.mjs
@@ -1,6 +1,10 @@
 import Component                              from '../../../src/component/Base.mjs';
 import {listHarnessTypes, resolveHarnessType} from '../config/harnessTypes.mjs';
-import {listMcpServers, resolveMcpMatrix}     from '../config/mcpServers.mjs';
+import {
+    listMcpServers,
+    normalizeMcpOverrides,
+    resolveMcpMatrix
+} from '../config/mcpServers.mjs';
 
 /**
  * @class AgentOS.view.AgentConfigCard
@@ -36,7 +40,15 @@ class AgentConfigCard extends Component {
          * @member {Object|null} record_=null
          * @reactive
          */
-        record_: null
+        record_: null,
+        /**
+         * Ephemeral save feedback for the currently rendered record. This is deliberately component
+         * state, never AgentDefinition data: pending/rejected are transport facts, not durable fleet
+         * configuration.
+         * @member {Object|null} saveStatus_=null
+         * @reactive
+         */
+        saveStatus_: null
     }
 
     /**
@@ -54,6 +66,7 @@ class AgentConfigCard extends Component {
      * @protected
      */
     afterSetRecord(value, oldValue) {
+        this.saveStatus = {agentId: value?.id ?? null, state: 'idle', reason: ''};
         this.refresh()
     }
 
@@ -82,7 +95,7 @@ class AgentConfigCard extends Component {
             record = me.record,
             node   = data.path?.find(item => item.id?.startsWith(`${me.id}__`));
 
-        if (!node || !record) {
+        if (!node || !record || (me.saveStatus?.agentId === record.id && me.saveStatus.state === 'pending')) {
             return
         }
 
@@ -90,17 +103,31 @@ class AgentConfigCard extends Component {
 
         if (kind === 'srv') {
             const matrix = resolveMcpMatrix(record.mcpServers);
+            matrix[key] = !matrix[key];
 
-            me.fire('configIntent', {
-                agentId: record.id,
-                config : {mcpServers: {...matrix, [key]: !matrix[key]}}
-            })
+            me.fire('configIntent', {id: record.id, mcpServers: normalizeMcpOverrides(matrix)})
         } else if (kind === 'harness' && key !== record.harnessType) {
-            me.fire('configIntent', {
-                agentId: record.id,
-                config : {harnessType: key}
-            })
+            me.fire('configIntent', {id: record.id, harnessType: key})
         }
+    }
+
+    /**
+     * @summary Render one save-state transition only when the card still shows the originating
+     * agent. A slow response after selection changed must never paint the next agent's card.
+     * @param {String} agentId
+     * @param {'idle'|'pending'|'accepted'|'rejected'} state
+     * @param {String} [reason=''] Operator-facing status or rejection reason.
+     * @returns {Boolean} True when the visible card accepted the state.
+     */
+    setSaveStatus(agentId, state, reason='') {
+        if (this.record?.id !== agentId) {
+            return false
+        }
+
+        this.saveStatus = {agentId, state, reason};
+        this.refresh();
+
+        return true
     }
 
     /**
@@ -117,9 +144,12 @@ class AgentConfigCard extends Component {
         }
 
         const
-            me      = this,
-            harness = resolveHarnessType(record.harnessType),
-            matrix  = resolveMcpMatrix(record.mcpServers);
+            me         = this,
+            harness    = resolveHarnessType(record.harnessType),
+            matrix     = resolveMcpMatrix(record.mcpServers),
+            saveStatus = me.saveStatus?.agentId === record.id
+                ? me.saveStatus
+                : {state: 'idle', reason: ''};
 
         return [{
             cls: ['agent-config-identity'],
@@ -160,6 +190,9 @@ class AgentConfigCard extends Component {
                 this.createToggleRow('Hooks',              record.hooksActive),
                 this.createToggleRow('Wake subscriptions', record.wakeSubscriptionsActive)
             ]
+        }, {
+            cls : ['agent-config-save-status', `is-${saveStatus.state}`],
+            text: saveStatus.reason
         }]
     }
 

--- a/resources/scss/src/apps/agentos/Accounts.scss
+++ b/resources/scss/src/apps/agentos/Accounts.scss
@@ -113,6 +113,28 @@
                 }
             }
         }
+
+        .agent-config-save-status {
+            font-size  : 11px;
+            min-height : 14px;
+
+            &.is-idle {
+                visibility : hidden;
+            }
+
+            &.is-pending {
+                font-style : italic;
+                opacity    : .7;
+            }
+
+            &.is-accepted {
+                font-weight : 600;
+            }
+
+            &.is-rejected {
+                color : var(--sem-color-red-500, #b42318);
+            }
+        }
     }
 
     .agent-definition-form {

--- a/src/ai/fleet/mcpServers.mjs
+++ b/src/ai/fleet/mcpServers.mjs
@@ -1,0 +1,111 @@
+/**
+ * The ONE Fleet Manager MCP-server authority, shared across the Body and Brain. Durable keys,
+ * operator labels, and defaults live here so the registry validates the same vocabulary the
+ * Accounts surface renders. The persisted value is always a SPARSE override object: `null` means
+ * every current catalog default applies.
+ *
+ * **Dependency-free by design** — this module is imported by both Node services and App-Worker
+ * modules and MUST NOT pull in either a Node-only or framework dependency chain.
+ * @summary Shared Body↔Brain MCP catalog plus sparse override projection and validation.
+ */
+
+/**
+ * @type {ReadonlyArray<{key: String, label: String, core: Boolean, defaultEnabled: Boolean}>}
+ */
+export const MCP_SERVERS = Object.freeze([
+    Object.freeze({key: 'memory-core',     label: 'Memory Core',     core: true,  defaultEnabled: true}),
+    Object.freeze({key: 'knowledge-base',  label: 'Knowledge Base',  core: true,  defaultEnabled: true}),
+    Object.freeze({key: 'neural-link',     label: 'Neural Link',     core: true,  defaultEnabled: true}),
+    Object.freeze({key: 'github-workflow', label: 'GitHub workflow', core: false, defaultEnabled: false}),
+    Object.freeze({key: 'gitlab-workflow', label: 'GitLab workflow', core: false, defaultEnabled: false})
+]);
+
+/**
+ * @summary List every registered MCP server in display order. Every result is caller-owned.
+ * @returns {Object[]} `[{key, label, core, defaultEnabled}]`
+ */
+export function listMcpServers() {
+    return MCP_SERVERS.map(entry => ({...entry}))
+}
+
+/**
+ * @summary Build the effective default matrix for the supplied catalog. The optional catalog seam
+ * makes default-evolution behavior directly falsifiable without mutating the frozen authority.
+ * @param {Object[]} [catalog=MCP_SERVERS]
+ * @returns {Object} `{serverKey: Boolean}`
+ */
+export function defaultMcpMatrix(catalog=MCP_SERVERS) {
+    return Object.fromEntries(catalog.map(entry => [entry.key, entry.defaultEnabled]))
+}
+
+/**
+ * @summary Resolve sparse stored overrides over the live catalog defaults. Unknown stored keys are
+ * ignored so retired servers cannot reappear in the projection; non-boolean legacy values fail
+ * closed to `false` rather than truthy-coercing.
+ * @param {Object|null} overrides Sparse persisted overrides; `null` follows every default.
+ * @param {Object[]} [catalog=MCP_SERVERS]
+ * @returns {Object} Effective `{serverKey: Boolean}` matrix for every registered server.
+ */
+export function resolveMcpMatrix(overrides, catalog=MCP_SERVERS) {
+    const
+        matrix = defaultMcpMatrix(catalog),
+        keys   = new Set(catalog.map(entry => entry.key));
+
+    Object.entries(overrides || {}).forEach(([key, enabled]) => {
+        if (keys.has(key)) {
+            matrix[key] = enabled === true
+        }
+    });
+
+    return matrix
+}
+
+/**
+ * @summary Validate one complete sparse-override intent and canonicalize it against the current
+ * defaults. Only registered boolean entries may cross the wire. Values equal to their catalog
+ * default disappear; an empty result becomes `null`, preserving future default evolution.
+ * @param {Object|null} overrides Sparse overrides or an effective matrix to reduce.
+ * @param {Object[]} [catalog=MCP_SERVERS]
+ * @returns {Object|null} Canonical sparse overrides, in catalog order.
+ */
+export function normalizeMcpOverrides(overrides, catalog=MCP_SERVERS) {
+    if (overrides === null) {
+        return null
+    }
+
+    if (!overrides || typeof overrides !== 'object' || Array.isArray(overrides)) {
+        throw new TypeError('MCP overrides must be an object or null.')
+    }
+
+    const
+        byKey   = new Map(catalog.map(entry => [entry.key, entry])),
+        unknown = Object.keys(overrides).find(key => !byKey.has(key));
+
+    if (unknown) {
+        throw new TypeError(`Unknown MCP server '${unknown}'.`)
+    }
+
+    const nonBoolean = Object.entries(overrides).find(([, value]) => typeof value !== 'boolean');
+
+    if (nonBoolean) {
+        throw new TypeError(`MCP override '${nonBoolean[0]}' must be boolean.`)
+    }
+
+    const sparse = {};
+
+    catalog.forEach(entry => {
+        if (Object.hasOwn(overrides, entry.key) && overrides[entry.key] !== entry.defaultEnabled) {
+            sparse[entry.key] = overrides[entry.key]
+        }
+    });
+
+    return Object.keys(sparse).length ? sparse : null
+}
+
+export default {
+    MCP_SERVERS,
+    defaultMcpMatrix,
+    listMcpServers,
+    normalizeMcpOverrides,
+    resolveMcpMatrix
+};

--- a/test/playwright/e2e/agentos/AccountsConfigSurface.spec.mjs
+++ b/test/playwright/e2e/agentos/AccountsConfigSurface.spec.mjs
@@ -1,13 +1,18 @@
 import {test, expect} from '../../fixtures.mjs';
+import {NeuralLink_DataService} from '../../../../ai/services.mjs';
+import FleetRegistryService from '../../../../ai/services/fleet/FleetRegistryService.mjs';
+import {startFleetBridgeServer} from '../../../../ai/services/fleet/fleetBridgeServer.mjs';
+import fs   from 'fs';
+import os   from 'os';
+import path from 'path';
 
 /**
  * @summary Verifies the agent-scoped Accounts configuration surface mounts end-to-end: the
  * selector strip derives from the roster store, the configuration card renders the scoped agent's
  * registry-derived configuration (harness chips, MCP-server rows, tri-state operational rows),
- * and the add-form's harness radios carry the shared registry's entries.
- *
- * The run also captures the surface screenshot the FM design gate reviews view-PRs against
- * (`screenshots/accounts-14807.png` — regenerated on every run, referenced from PR bodies).
+ * and the add-form's harness radios carry the shared registry's entries. The save journey uses the
+ * production App-Worker bridge, a real Brain registry/server, and Neural Link store inspection;
+ * it is behavioral evidence rather than a screenshot generator.
  *
  * @see apps/agentos/view/Accounts.mjs
  * @see apps/agentos/view/AgentConfigCard.mjs
@@ -15,32 +20,77 @@ import {test, expect} from '../../fixtures.mjs';
 test.describe('AgentOS Accounts — agent-scoped configuration surface', () => {
     test.setTimeout(120000);
 
-    test('mounts the selector strip + config card + registry-derived form; captures the design-gate screenshot', async ({page}) => {
-        await page.goto('/apps/agentos/index.html');
+    test('cold-loads, saves, and freshly rehydrates sparse config over the real Fleet wire + NL store', async ({page, neuralLink}) => {
+        const
+            priorDataDir = FleetRegistryService.dataDir,
+            tmpDir       = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-config-e2e-')),
+            agentId      = 'config-proof-agent';
 
-        await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
+        FleetRegistryService.dataDir = tmpDir;
+        FleetRegistryService.defineAgent({
+            id            : agentId,
+            githubUsername: agentId,
+            harnessType   : 'codex',
+            credential    : 'ghp_e2e_must_stay_brain_side'
+        });
 
-        await page.locator('.agent-shell').getByText('Accounts', {exact: true}).click();
-        await expect(page.locator('.agent-panel-accounts')).toBeVisible({timeout: 30000});
+        let server;
 
-        // the selector strip derives one button per roster agent (the seed roster has one)
-        await expect(page.locator('.agent-selector')).toBeVisible();
-        expect(await page.locator('.agent-selector-button').count()).toBeGreaterThan(0);
+        try {
+            // Fixed product port by design. EADDRINUSE is a hard red: never reuse a foreign server
+            // and accidentally test another checkout's tree.
+            server = await startFleetBridgeServer({port: 8083});
+            await page.goto('/apps/agentos/index.html');
 
-        // the config card renders the scoped agent: harness chips from the ONE shared registry
-        await expect(page.locator('.agent-config-card')).toBeVisible();
-        expect(await page.locator('.agent-config-chip').count()).toBe(5);
-        await expect(page.locator('.agent-config-chip.is-selected')).toHaveCount(1);
+            await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
 
-        // MCP-server rows in catalog order, operational rows tri-state honest
-        expect(await page.locator('.agent-config-toggle').count()).toBeGreaterThan(3);
-        await expect(page.locator('.agent-config-row.is-unknown').first()).toContainText('Not read back yet');
+            await page.locator('.agent-shell').getByText('Accounts', {exact: true}).click();
+            await expect(page.locator('.agent-panel-accounts')).toBeVisible({timeout: 30000});
 
-        // the add-form's harness radios derive from the same registry (5 registered entries)
-        expect(await page.locator('.agent-harness-picker .neo-radiofield').count()).toBe(5);
+            // The provider store cold-hydrates from the REAL Brain registry; the bridge-pending seed
+            // is gone before an existing agent can be edited.
+            await expect(page.locator('.agent-selector-button').filter({hasText: agentId})).toHaveCount(1);
 
-        await page.locator('.agent-panel-accounts').screenshot({
-            path: 'test/playwright/e2e/agentos/screenshots/accounts-14807.png'
-        })
+            await expect(page.locator('.agent-config-card')).toBeVisible();
+            expect(await page.locator('.agent-config-chip').count()).toBe(5);
+            await expect(page.locator('.agent-config-chip.is-selected')).toHaveCount(1);
+
+            const memoryCore = page.locator('.agent-config-toggle').filter({hasText: 'Memory Core'});
+            await expect(memoryCore).toHaveClass(/is-enabled/);
+            // Docked keeper views may render beyond the browser viewport while remaining the live
+            // mounted surface. Dispatch through the real DOM listener instead of weakening the
+            // component path with a direct method call.
+            await memoryCore.dispatchEvent('click');
+            await expect(page.locator('.agent-config-save-status.is-accepted')).toContainText('Configuration saved');
+            await expect(memoryCore).toHaveClass(/is-disabled/);
+
+            expect(FleetRegistryService.getDefinition(agentId).mcpServers).toEqual({'memory-core': false});
+
+            const app       = await neuralLink.connectToApp('AgentOS'),
+                  stores    = await NeuralLink_DataService.listStores({sessionId: app.sessionId}),
+                  storeMeta = stores.stores.find(candidate => candidate.model === 'AgentOS.model.AgentDefinition'),
+                  snapshot  = await NeuralLink_DataService.inspectStore({
+                      sessionId: app.sessionId,
+                      storeId  : storeMeta.id,
+                      limit    : 10
+                  }),
+                  row       = snapshot.items.find(item => item.id === agentId);
+
+            expect(row.mcpServers).toEqual({'memory-core': false});
+            expect(JSON.stringify(row)).not.toMatch(/credential|pat|token|ghp_e2e_must_stay_brain_side/i);
+
+            // A fresh page/store hydration must re-read the canonical sparse result, not the
+            // request or the seed. This also proves persisted state survived the first app session.
+            await page.reload();
+            await page.locator('.agent-shell').getByText('Accounts', {exact: true}).click();
+            await expect(page.locator('.agent-selector-button').filter({hasText: agentId})).toHaveCount(1);
+            await expect(page.locator('.agent-config-toggle').filter({hasText: 'Memory Core'})).toHaveClass(/is-disabled/);
+
+            expect(await page.locator('.agent-harness-picker .neo-radiofield').count()).toBe(5)
+        } finally {
+            server && await new Promise(resolve => server.close(resolve));
+            FleetRegistryService.dataDir = priorDataDir;
+            fs.rmSync(tmpDir, {recursive: true, force: true})
+        }
     });
 });

--- a/test/playwright/unit/ai/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/FleetRegistryService.spec.mjs
@@ -72,7 +72,7 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService', () => {
         expect(JSON.stringify(def)).not.toContain('ghp_secretTokenAAA');
     });
 
-    test('modelProvider resolves via the AiConfig SSOT leaf when unset, honors an explicit value, and is preserved on update', () => {
+    test('modelProvider resolves via the AiConfig SSOT leaf when unset and honors an explicit value on creation', () => {
         // unset -> resolves via the AiConfig modelProvider SSOT (read-only; no service-local default shadow)
         const defaulted = FleetRegistryService.defineAgent({githubUsername: 'prov-default', harnessType: 'codex'});
         expect(defaulted.modelProvider).toBe(aiConfig.modelProvider);
@@ -81,12 +81,65 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService', () => {
         const explicit = FleetRegistryService.defineAgent({githubUsername: 'prov-explicit', harnessType: 'codex', modelProvider: 'ollama'});
         expect(explicit.modelProvider).toBe('ollama');
 
-        // a prior value is preserved when the agent is re-defined without modelProvider
-        const updated = FleetRegistryService.defineAgent({githubUsername: 'prov-explicit', harnessType: 'codex'});
-        expect(updated.modelProvider).toBe('ollama');
+        // definition is create-only; existing-agent changes use the scoped update/config surfaces
+        expect(() => FleetRegistryService.defineAgent({githubUsername: 'prov-explicit', harnessType: 'codex'}))
+            .toThrow(/already exists/);
 
         // non-secret: the provider-login is carried in the public projection
         expect(FleetRegistryService.getAgent('prov-explicit').modelProvider).toBe('ollama');
+    });
+
+    test('create-only registration stays retryable when credential persistence fails', () => {
+        const writeCredentials = FleetRegistryService.writeCredentials;
+
+        FleetRegistryService.writeCredentials = () => { throw new Error('credential disk full') };
+
+        try {
+            expect(() => FleetRegistryService.defineAgent({
+                githubUsername: 'atomic-agent',
+                harnessType   : 'codex',
+                credential    : 'ghp_atomic'
+            })).toThrow(/credential disk full/);
+
+            expect(FleetRegistryService.getAgent('atomic-agent')).toBeNull();
+            expect(FleetRegistryService.listAgents()).toEqual([])
+        } finally {
+            FleetRegistryService.writeCredentials = writeCredentials
+        }
+
+        // The exact same public create succeeds after storage recovers — no credentialless row was
+        // persisted to trip the create-only guard.
+        expect(FleetRegistryService.defineAgent({
+            githubUsername: 'atomic-agent',
+            harnessType   : 'codex',
+            credential    : 'ghp_atomic'
+        }).id).toBe('atomic-agent');
+        expect(FleetRegistryService.resolveCredential('atomic-agent')).toBe('ghp_atomic')
+    });
+
+    test('registry publish failure rolls the new credential back and leaves creation retryable', () => {
+        const writeRegistry = FleetRegistryService.writeRegistry;
+
+        FleetRegistryService.writeRegistry = () => { throw new Error('registry disk full') };
+
+        try {
+            expect(() => FleetRegistryService.defineAgent({
+                githubUsername: 'rollback-agent',
+                harnessType   : 'codex',
+                credential    : 'ghp_rollback'
+            })).toThrow(/registry disk full/)
+        } finally {
+            FleetRegistryService.writeRegistry = writeRegistry
+        }
+
+        expect(FleetRegistryService.getAgent('rollback-agent')).toBeNull();
+        expect(FleetRegistryService.resolveCredential('rollback-agent')).toBeNull();
+        expect(FleetRegistryService.defineAgent({
+            githubUsername: 'rollback-agent',
+            harnessType   : 'codex',
+            credential    : 'ghp_recovered'
+        }).id).toBe('rollback-agent');
+        expect(FleetRegistryService.resolveCredential('rollback-agent')).toBe('ghp_recovered')
     });
 
     test('CRUD round-trip: define -> list -> get -> remove', () => {

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -32,9 +32,10 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         calls = [];
 
         registryStub = {
-            defineAgent: def => { calls.push(['defineAgent', def]); const {credential, ...pub} = def; return {id: def.id || def.githubUsername, ...pub}; },
-            listAgents : ()  => { calls.push(['listAgents']);       return [{id: 'alice'}, {id: 'bob'}]; },
-            getAgent   : id  => { calls.push(['getAgent', id]);     return {id}; }
+            defineAgent   : def => { calls.push(['defineAgent', def]); const {credential, ...pub} = def; return {id: def.id || def.githubUsername, ...pub}; },
+            configureAgent: intent => { calls.push(['configureAgent', intent]); return intent.id === 'alice' ? {id: 'alice', harnessType: intent.harnessType} : null; },
+            listAgents    : ()  => { calls.push(['listAgents']);       return [{id: 'alice'}, {id: 'bob'}]; },
+            getAgent      : id  => { calls.push(['getAgent', id]);     return {id}; }
         };
 
         managerStub = {
@@ -69,6 +70,32 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         expect(result.githubUsername).toBe('alice');
         // the bridge adds no credential path of its own — it returns exactly the registry's public API result
         expect(result.credential).toBeUndefined();
+    });
+
+    test('configureAgent forwards one curated payload and returns accepted/rejected domain outcomes', () => {
+        const intent = {id: 'alice', harnessType: 'claude-code', mcpServers: {'memory-core': false}};
+
+        expect(FleetControlBridge.configureAgent(intent)).toEqual({
+            status: 'accepted',
+            agent : {id: 'alice', harnessType: 'claude-code'}
+        });
+        expect(calls).toEqual([['configureAgent', intent]]);
+
+        calls.length = 0;
+        expect(FleetControlBridge.configureAgent({id: 'ghost', harnessType: 'codex'}))
+            .toEqual({status: 'rejected', reason: "Unknown agent 'ghost'."})
+    });
+
+    test('configureAgent exposes only controlled validation reasons; unexpected failures still throw', () => {
+        registryStub.configureAgent = () => {
+            throw new TypeError("FleetRegistryService.configureAgent: unsupported field 'credential'.")
+        };
+        expect(FleetControlBridge.configureAgent({id: 'alice', credential: 'secret'}))
+            .toEqual({status: 'rejected', reason: "unsupported field 'credential'."});
+
+        registryStub.configureAgent = () => { throw new Error('/secret/storage/path failed') };
+        expect(() => FleetControlBridge.configureAgent({id: 'alice', harnessType: 'codex'}))
+            .toThrow('/secret/storage/path failed')
     });
 
     test('listAgents delegates to the registry roster', () => {

--- a/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
@@ -127,6 +127,46 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService — the raw-launch sec
         expect(FleetRegistryService.getDefinition('sec').metadata.launch.env.PROBE_SECRET).toBe('x');
     });
 
+    test('public projections recursively redact reserved credential/launch vocabulary', () => {
+        const created = FleetRegistryService.defineAgent({
+            githubUsername: 'nested-sec',
+            harnessType   : 'codex',
+            metadata      : {
+                credential: 'caller-secret',
+                nested    : {secret: 'x', command: '/bin/sh', args: ['-c'], env: {TOKEN: 'x'}},
+                repo      : {managedPath: '/safe/path', repoSlug: 'x/y'}
+            }
+        });
+
+        for (const projection of [created, FleetRegistryService.getAgent('nested-sec'), FleetRegistryService.listAgents()[0]]) {
+            expect(JSON.stringify(projection)).not.toMatch(/caller-secret|"credential"|"secret"|"command"|"args"|"env"/);
+            expect(projection.metadata.repo).toEqual({managedPath: '/safe/path', repoSlug: 'x/y'})
+        }
+
+        // Redaction is projection-only: the Brain-owned raw definition retains non-launch metadata.
+        expect(FleetRegistryService.getDefinition('nested-sec').metadata.nested.command).toBe('/bin/sh')
+    });
+
+    test('defineAgent is create-only: an existing id cannot bypass scoped config or erase launch state', () => {
+        FleetRegistryService.defineAgent({githubUsername: 'resident', harnessType: 'codex', credential: 'original-pat'});
+        FleetRegistryService.setLaunchOverride('resident', {command: '/owned/launcher', args: [], env: {}});
+
+        expect(() => FleetRegistryService.defineAgent({
+            id            : 'resident',
+            githubUsername: 'attacker',
+            harnessType   : 'native-neo',
+            credential    : 'replacement-pat',
+            mcpServers    : {'memory-core': false}
+        })).toThrow(/already exists/);
+
+        expect(FleetRegistryService.getDefinition('resident')).toMatchObject({
+            githubUsername: 'resident',
+            harnessType   : 'codex',
+            metadata      : {launch: {command: '/owned/launcher'}}
+        });
+        expect(FleetRegistryService.resolveCredential('resident')).toBe('original-pat')
+    });
+
     test('projections are DEEP CLONES — mutating a returned definition never reaches the registry cache', () => {
         FleetRegistryService.defineAgent({githubUsername: 'iso', harnessType: 'codex'});
         FleetRegistryService.setLaunchOverride('iso', {command: '/opt/custom', args: [], env: {}});
@@ -167,48 +207,122 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService.configureAgent — the
         expect(FleetRegistryService.harnessTypes).toContain('claude-code');
     });
 
-    test('persists config, returns the readback projection, and preserves identity + credential state', () => {
-        FleetRegistryService.defineAgent({githubUsername: 'neo-gpt', harnessType: 'codex'});
-
-        const updated = FleetRegistryService.configureAgent('neo-gpt', {
-            harnessType: 'claude-code',
-            mcpServers : {'memory-core': true, 'knowledge-base': 0},
-            hooksActive: true
+    test('persists only sparse overrides and returns secret/launch-free canonical readback', () => {
+        FleetRegistryService.defineAgent({
+            githubUsername: 'neo-gpt',
+            harnessType   : 'codex',
+            credential    : 'ghp_config_secret'
+        });
+        FleetRegistryService.setLaunchOverride('neo-gpt', {
+            command: '/secret/bin/codex',
+            args   : ['--secret-arg'],
+            env    : {CONFIG_SECRET: 'do-not-cross'}
         });
 
-        // the RESPONSE is the readback: persisted truth, boolean-coerced matrix, no credential
+        const updated = FleetRegistryService.configureAgent({
+            id          : 'neo-gpt',
+            harnessType : 'claude-code',
+            mcpServers  : {'memory-core': true, 'knowledge-base': false, 'github-workflow': true}
+        });
+
         expect(updated.harnessType).toBe('claude-code');
-        expect(updated.mcpServers).toEqual({'memory-core': true, 'knowledge-base': false});
-        expect(updated.hooksActive).toBe(true);
-        expect(updated.wakeSubscriptionsActive).toBeNull();
-        expect(updated.credential).toBeUndefined();
+        expect(updated.mcpServers).toEqual({'knowledge-base': false, 'github-workflow': true});
         expect(updated.githubUsername).toBe('neo-gpt');
+        expect(updated.credential).toBeUndefined();
+        expect(updated.pat).toBeUndefined();
+        expect(updated.token).toBeUndefined();
+        expect(updated.metadata.launch).toBeUndefined();
+        expect(JSON.stringify(updated)).not.toMatch(/ghp_config_secret|secret-bin|secret-arg|CONFIG_SECRET|do-not-cross/);
 
-        // and it round-trips through the read API
-        expect(FleetRegistryService.getAgent('neo-gpt').mcpServers).toEqual({'memory-core': true, 'knowledge-base': false});
+        const persisted = JSON.parse(fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8'));
+        expect(persisted.agents['neo-gpt'].mcpServers)
+            .toEqual({'knowledge-base': false, 'github-workflow': true});
+        expect(FleetRegistryService.resolveCredential('neo-gpt')).toBe('ghp_config_secret')
     });
 
-    test('partial patches preserve unspecified config; null matrix resets to catalog defaults', () => {
-        FleetRegistryService.defineAgent({githubUsername: 'ada', harnessType: 'codex'});
-        FleetRegistryService.configureAgent('ada', {mcpServers: {'neural-link': true}, wakeSubscriptionsActive: false});
+    test('partial patches preserve unspecified config; all-default and null matrices persist as null', () => {
+        FleetRegistryService.defineAgent({
+            githubUsername: 'ada',
+            harnessType   : 'codex',
+            mcpServers    : {'neural-link': false}
+        });
 
-        // a later harness-only patch keeps the matrix + the wake intent
-        const second = FleetRegistryService.configureAgent('ada', {harnessType: 'native-neo'});
+        const second = FleetRegistryService.configureAgent({id: 'ada', harnessType: 'native-neo'});
 
-        expect(second.mcpServers).toEqual({'neural-link': true});
-        expect(second.wakeSubscriptionsActive).toBe(false);
+        expect(second.mcpServers).toEqual({'neural-link': false});
 
-        // explicit null resets the matrix to "catalog defaults" (the Body resolves null that way)
-        expect(FleetRegistryService.configureAgent('ada', {mcpServers: null}).mcpServers).toBeNull();
+        expect(FleetRegistryService.configureAgent({
+            id        : 'ada',
+            mcpServers: {
+                'memory-core'    : true,
+                'knowledge-base' : true,
+                'neural-link'    : true,
+                'github-workflow': false,
+                'gitlab-workflow': false
+            }
+        }).mcpServers).toBeNull();
+        expect(FleetRegistryService.configureAgent({id: 'ada', mcpServers: null}).mcpServers).toBeNull()
     });
 
-    test('fail-closed edges: unknown id returns null; an invalid harnessType throws and persists nothing', () => {
-        expect(FleetRegistryService.configureAgent('ghost', {harnessType: 'codex'})).toBeNull();
-
+    test('strict curated intent rejects unknown/non-boolean/authority-crossing fields without a write', () => {
         FleetRegistryService.defineAgent({githubUsername: 'vega', harnessType: 'codex'});
+        const before = fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8');
 
-        expect(() => FleetRegistryService.configureAgent('vega', {harnessType: 'not-a-harness'}))
-            .toThrow(/invalid harnessType/);
-        expect(FleetRegistryService.getAgent('vega').harnessType).toBe('codex');
+        const rejected = [
+            {id: 'vega', harnessType: null},
+            {id: 'vega', harnessType: 'not-a-harness'},
+            {id: 'vega', mcpServers: {'unknown-server': true}},
+            {id: 'vega', mcpServers: {'memory-core': 1}},
+            {id: 'vega', mcpServers: []},
+            {id: 'vega', hooksActive: true},
+            {id: 'vega', command: '/bin/sh'},
+            {id: 'vega', credential: 'secret'},
+            {id: 'vega'}
+        ];
+
+        rejected.forEach(intent => {
+            expect(() => FleetRegistryService.configureAgent(intent)).toThrow(/FleetRegistryService\.configureAgent/);
+            expect(fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8')).toBe(before)
+        });
+
+        expect(FleetRegistryService.configureAgent({id: 'ghost', harnessType: 'codex'})).toBeNull();
+        expect(FleetRegistryService.getAgent('vega').harnessType).toBe('codex')
+    });
+
+    test('fresh registry hydration returns the persisted sparse configuration', () => {
+        FleetRegistryService.defineAgent({githubUsername: 'fresh', harnessType: 'codex'});
+        FleetRegistryService.configureAgent({id: 'fresh', mcpServers: {'memory-core': false}});
+
+        const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-fleet-reg-other-'));
+        FleetRegistryService.dataDir = otherDir;
+        expect(FleetRegistryService.listAgents()).toEqual([]);
+
+        FleetRegistryService.dataDir = tmpDir;
+        expect(FleetRegistryService.listAgents().find(agent => agent.id === 'fresh').mcpServers)
+            .toEqual({'memory-core': false});
+
+        fs.rmSync(otherDir, {recursive: true, force: true})
+    });
+
+    test('a failed atomic publish leaves both cache and registry.json on the prior accepted state', () => {
+        FleetRegistryService.defineAgent({githubUsername: 'atomic', harnessType: 'codex'});
+
+        const
+            beforeAgent  = FleetRegistryService.getAgent('atomic'),
+            beforeDisk   = fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8'),
+            originalMove = fs.renameSync;
+
+        fs.renameSync = () => { throw Object.assign(new Error('injected rename failure'), {code: 'EIO'}) };
+
+        try {
+            expect(() => FleetRegistryService.configureAgent({id: 'atomic', harnessType: 'native-neo'}))
+                .toThrow('injected rename failure')
+        } finally {
+            fs.renameSync = originalMove
+        }
+
+        expect(FleetRegistryService.getAgent('atomic')).toEqual(beforeAgent);
+        expect(fs.readFileSync(path.join(tmpDir, 'registry.json'), 'utf8')).toBe(beforeDisk);
+        expect(fs.readdirSync(tmpDir).some(name => name.endsWith('.tmp'))).toBe(false)
     });
 });

--- a/test/playwright/unit/ai/services/fleet/createFleetRegistryBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/createFleetRegistryBridge.spec.mjs
@@ -47,6 +47,19 @@ test.describe('createFleetRegistryBridge — the browser-side pane bridge factor
         expect(sent).toEqual([{method: 'startAgent', params: 'alice'}]);
     });
 
+    test('configureAgent forwards its ONE curated intent as params', async () => {
+        const
+            sent   = [],
+            intent = {id: 'alice', harnessType: 'claude-code', mcpServers: {'memory-core': false}},
+            bridge = createFleetRegistryBridge(async req => {
+                sent.push(req);
+                return {ok: true, result: {status: 'accepted', agent: {id: 'alice'}}}
+            });
+
+        await expect(bridge.configureAgent(intent)).resolves.toEqual({status: 'accepted', agent: {id: 'alice'}});
+        expect(sent).toEqual([{method: 'configureAgent', params: intent}])
+    });
+
     test('an {ok:false} envelope rejects with the transport error (fail-closed for the pane)', async () => {
         const bridge = createFleetRegistryBridge(async () => ({ok: false, error: 'spawn failed'}));
         await expect(bridge.startAgent('alice')).rejects.toThrow('spawn failed');

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -29,9 +29,10 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
     test.beforeEach(() => {
         calls  = [];
         bridge = {
-            defineAgent : p  => { calls.push(['defineAgent', p]); return {id: p.githubUsername}; },
-            listAgents  : () => { calls.push(['listAgents']);     return [{id: 'a'}]; },
-            getAgent    : id => { calls.push(['getAgent', id]);   return {id}; },
+            defineAgent   : p  => { calls.push(['defineAgent', p]); return {id: p.githubUsername}; },
+            configureAgent: p  => { calls.push(['configureAgent', p]); return {status: 'accepted', agent: {id: p.id, harnessType: p.harnessType}}; },
+            listAgents    : () => { calls.push(['listAgents']);     return [{id: 'a'}]; },
+            getAgent      : id => { calls.push(['getAgent', id]);   return {id}; },
             startAgent  : async id => { calls.push(['startAgent', id]);   return {id, state: 'running'}; },
             stopAgent   : async id => { calls.push(['stopAgent', id]);    return {success: true, id}; },
             restartAgent: async id => { calls.push(['restartAgent', id]); return {id, state: 'running'}; },
@@ -63,6 +64,18 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
 
         expect(res).toEqual({ok: true, result: {id: 'alice', metadata: {repo: payload}}});
         expect(calls).toEqual([['setRepo', payload]]);
+    });
+
+    test('routes configureAgent as one payload and preserves the domain outcome', async () => {
+        const
+            payload = {id: 'alice', harnessType: 'claude-code', mcpServers: {'memory-core': false}},
+            res     = await dispatchFleetRequest({method: 'configureAgent', params: payload}, bridge);
+
+        expect(res).toEqual({
+            ok    : true,
+            result: {status: 'accepted', agent: {id: 'alice', harnessType: 'claude-code'}}
+        });
+        expect(calls).toEqual([['configureAgent', payload]])
     });
 
     test('routes setAvatar, forwarding the single payload to the bridge', async () => {

--- a/test/playwright/unit/ai/services/fleet/fleetTransport.integration.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetTransport.integration.spec.mjs
@@ -92,6 +92,46 @@ test.describe('fleet transport — full-chain integration (real server + real re
         expect(raw).not.toContain('ghp_SECRET_integration')
     });
 
+    test('configureAgent crosses the full one-params wire, persists sparse overrides, and reads back canonically', async () => {
+        FleetRegistryService.setLaunchOverride('integration-alice', {
+            command: '/secret/bin/codex',
+            args   : ['--secret'],
+            env    : {TRANSPORT_SECRET: 'hidden'}
+        });
+
+        const intent = {
+            id         : 'integration-alice',
+            harnessType: 'claude-code',
+            mcpServers : {'memory-core': true, 'github-workflow': true}
+        };
+        const outcome = await registryBridge.configureAgent(intent);
+
+        expect(outcome.status).toBe('accepted');
+        expect(outcome.agent).toMatchObject({
+            id         : 'integration-alice',
+            harnessType: 'claude-code',
+            mcpServers : {'github-workflow': true}
+        });
+        expect(outcome.agent.credential).toBeUndefined();
+        expect(outcome.agent.metadata.launch).toBeUndefined();
+        expect(JSON.stringify(outcome)).not.toMatch(/ghp_SECRET_integration|secret-bin|TRANSPORT_SECRET|hidden/);
+
+        const [readback] = await registryBridge.listAgents();
+        expect(readback.harnessType).toBe('claude-code');
+        expect(readback.mcpServers).toEqual({'github-workflow': true})
+    });
+
+    test('configureAgent returns a safe rejection over the real wire and preserves persisted state', async () => {
+        const before  = FleetRegistryService.getAgent('integration-alice'),
+              outcome = await registryBridge.configureAgent({
+                  id        : 'integration-alice',
+                  mcpServers: {'not-registered': true}
+              });
+
+        expect(outcome).toEqual({status: 'rejected', reason: "Unknown MCP server 'not-registered'."});
+        expect(FleetRegistryService.getAgent('integration-alice')).toEqual(before)
+    });
+
     test('an off-allowlist method is rejected by the real server, never reaching a resolver seam', async () => {
         const url = `http://127.0.0.1:${server.address().port}/fleet`;
         const res = await fetch(url, {

--- a/test/playwright/unit/apps/agentos/Accounts.spec.mjs
+++ b/test/playwright/unit/apps/agentos/Accounts.spec.mjs
@@ -163,11 +163,19 @@ test.describe('AgentOS.view.Accounts — agent-scoped configuration (multiple ag
                 add(items) { this.items.push(...[].concat(items)) },
                 removeAll() { this.items = [] }
             },
-            card     = {record: undefined, refreshCount: 0, refresh() { this.refreshCount++ }};
+            card     = {
+                record: undefined,
+                refreshCount: 0,
+                refresh() { this.refreshCount++ },
+                setSaveStatus(agentId, state, reason) {
+                    if (this.record?.id === agentId) this.saveStatus = {agentId, state, reason}
+                }
+            };
 
         const stub = {
             id                     : `accounts-scoped-stub-${Math.abs(store.id.length)}-${store.id}`,
             agentDefinitionsStore  : store,
+            agentConfigSaveStatuses: new Map(),
             card,
             selector,
             afterSetSelectedAgentId: Accounts.prototype.afterSetSelectedAgentId,
@@ -221,6 +229,24 @@ test.describe('AgentOS.view.Accounts — agent-scoped configuration (multiple ag
         expect(stub.selectedAgentId).toBe('b');
         expect(stub.card.record?.id).toBe('b');
         expect(stub.card.record?.mcpServers).toEqual({'github-workflow': true});
+
+        store.destroy()
+    });
+
+    test('save feedback stays keyed to its agent across selection changes', () => {
+        const store = makeAgentStore([
+            {id: 'a', githubUsername: 'a', harnessType: 'codex'},
+            {id: 'b', githubUsername: 'b', harnessType: 'antigravity'}
+        ]);
+        const stub = makeScopedAccounts(store);
+
+        stub.agentConfigSaveStatuses.set('a', {state: 'pending', reason: 'Saving A…'});
+        stub.onSelectAgentClick({component: {agentId: 'b'}});
+        expect(stub.card.record.id).toBe('b');
+        expect(stub.card.saveStatus?.agentId).not.toBe('a');
+
+        stub.onSelectAgentClick({component: {agentId: 'a'}});
+        expect(stub.card.saveStatus).toEqual({agentId: 'a', state: 'pending', reason: 'Saving A…'});
 
         store.destroy()
     });
@@ -313,7 +339,7 @@ test.describe('AgentOS.view.AgentConfigCard — live same-record propagation + c
         store.destroy()
     });
 
-    test('server-row and harness-chip clicks fire configIntent with the toggled config — the card never mutates', () => {
+    test('server-row and harness-chip clicks fire the flat sparse intent; pending blocks overlap', () => {
         const store = Neo.create(Store, {keyProperty: 'id', model: AgentDefinition, data: [
             {id: 'ada', githubUsername: 'ada', harnessType: 'codex', mcpServers: {'memory-core': true}}
         ]});
@@ -330,12 +356,24 @@ test.describe('AgentOS.view.AgentConfigCard — live same-record propagation + c
         card.onCardClick({path: [{id: 'unrelated-node'}]});                  // off-card → no intent
 
         expect(intents.length).toBe(2);
-        expect(intents[0].agentId).toBe('ada');
-        expect(intents[0].config.mcpServers['memory-core']).toBe(false);
-        expect(intents[1].config).toEqual({harnessType: 'claude-code'});
+        expect(intents[0]).toMatchObject({id: 'ada', mcpServers: {'memory-core': false}});
+        expect(intents[1]).toMatchObject({id: 'ada', harnessType: 'claude-code'});
+        expect(intents[0].source).toBe(card.id); // event envelope exists; Accounts strips it before wire
+
+        card.setSaveStatus('ada', 'pending', 'Saving configuration…');
+        card.onCardClick({path: [{id: `${card.id}__srv__memory-core`}]});
+        expect(intents).toHaveLength(2);
+        expect(cardText(card)).toContain('Saving configuration');
+
+        // Returning the sole override to its live default emits null, never a resolved matrix.
+        card.setSaveStatus('ada', 'idle');
+        record.set({mcpServers: {'memory-core': false}});
+        card.refresh();
+        card.onCardClick({path: [{id: `${card.id}__srv__memory-core`}]});
+        expect(intents[2]).toMatchObject({id: 'ada', mcpServers: null});
 
         // the record itself is untouched — the owning view writes only from the bridge RESPONSE
-        expect(record.mcpServers).toEqual({'memory-core': true});
+        expect(record.mcpServers).toEqual({'memory-core': false});
         expect(record.harnessType).toBe('codex');
 
         card.destroy();
@@ -347,31 +385,131 @@ test.describe('AgentOS.view.AgentConfigCard — live same-record propagation + c
             {id: 'ada', githubUsername: 'ada', harnessType: 'codex'}
         ]});
 
-        const statuses = [];
-        const stub     = {
-            agentDefinitionsStore: store,
-            onAgentConfigIntent  : Accounts.prototype.onAgentConfigIntent,
-            updateBridgeStatus   : (cls, text) => statuses.push(cls)
+        const saveStatuses = [],
+              card         = {setSaveStatus: (...args) => saveStatuses.push(args)},
+              stub         = {
+            agentDefinitionsStore         : store,
+            agentConfigRequestGenerations : new Map(),
+            agentConfigSaveStatuses       : new Map(),
+            onAgentConfigIntent           : Accounts.prototype.onAgentConfigIntent,
+            setAgentConfigSaveStatus      : Accounts.prototype.setAgentConfigSaveStatus,
+            getReference                  : ref => ref === 'agent-config-card' ? card : null
         };
 
         // no bridge → fail closed, nothing mutates
         delete globalThis.AgentOS;
-        await stub.onAgentConfigIntent({agentId: 'ada', config: {harnessType: 'claude-code'}});
-        expect(statuses).toEqual(['is-error']);
+        await stub.onAgentConfigIntent({id: 'ada', harnessType: 'claude-code'});
         expect(store.get('ada').harnessType).toBe('codex');
 
         // bridge answers → the RESPONSE (not the request) lands on the record
-        globalThis.AgentOS = {fleet: {registryBridge: {configureAgent: async () => ({
-            harnessType: 'claude-code', mcpServers: {'neural-link': true}, hooksActive: true, wakeSubscriptionsActive: null
-        })}}};
+        let received;
+        globalThis.AgentOS = {fleet: {registryBridge: {configureAgent: async intent => {
+            received = intent;
+            return {status: 'accepted', agent: {
+                id: 'ada', harnessType: 'native-neo', mcpServers: {'neural-link': false}
+            }}
+        }}}};
 
-        await stub.onAgentConfigIntent({agentId: 'ada', config: {harnessType: 'claude-code'}});
+        await stub.onAgentConfigIntent({id: 'ada', harnessType: 'claude-code'});
 
         const record = store.get('ada');
-        expect(record.harnessType).toBe('claude-code');
-        expect(record.mcpServers).toEqual({'neural-link': true});
-        expect(record.hooksActive).toBe(true);
-        expect(statuses).toEqual(['is-error', 'is-live']);
+        expect(received).toEqual({id: 'ada', harnessType: 'claude-code'});
+        expect(record.harnessType).toBe('native-neo'); // response, not request
+        expect(record.mcpServers).toEqual({'neural-link': false});
+        expect(saveStatuses.map(entry => entry[1])).toEqual(['pending', 'rejected', 'pending', 'accepted']);
+
+        delete globalThis.AgentOS;
+        store.destroy()
+    });
+
+    test('a stale out-of-order save response cannot regress the newer canonical readback', async () => {
+        const
+            store    = Neo.create(Store, {keyProperty: 'id', model: AgentDefinition, data: [
+                {id: 'ada', githubUsername: 'ada', harnessType: 'codex'}
+            ]}),
+            deferred = [],
+            card     = {setSaveStatus: () => {}},
+            stub     = {
+                agentDefinitionsStore         : store,
+                agentDefinitionsLoadGeneration: 0,
+                agentConfigRequestGenerations : new Map(),
+                agentConfigSaveStatuses       : new Map(),
+                onAgentConfigIntent           : Accounts.prototype.onAgentConfigIntent,
+                setAgentConfigSaveStatus      : Accounts.prototype.setAgentConfigSaveStatus,
+                getReference                  : () => card
+            };
+
+        globalThis.AgentOS = {fleet: {registryBridge: {configureAgent: intent => new Promise(resolve => {
+            deferred.push({intent, resolve})
+        })}}};
+
+        const older = stub.onAgentConfigIntent({id: 'ada', harnessType: 'claude-code'});
+        // Simulate a non-card caller bypassing the pending UI latch: the generation guard is the
+        // final defense when two transport responses still overlap.
+        stub.agentConfigSaveStatuses.set('ada', {state: 'idle', reason: ''});
+        const newer = stub.onAgentConfigIntent({id: 'ada', harnessType: 'native-neo'});
+
+        deferred[1].resolve({status: 'accepted', agent: {id: 'ada', harnessType: 'native-neo', mcpServers: null}});
+        await newer;
+        deferred[0].resolve({status: 'accepted', agent: {id: 'ada', harnessType: 'claude-code', mcpServers: null}});
+        await older;
+
+        expect(deferred.map(entry => entry.intent.harnessType)).toEqual(['claude-code', 'native-neo']);
+        expect(store.get('ada').harnessType).toBe('native-neo');
+        expect(stub.agentConfigSaveStatuses.get('ada').state).toBe('accepted');
+
+        delete globalThis.AgentOS;
+        store.destroy()
+    });
+
+    test('a rejected domain outcome renders its reason and leaves the real record untouched', async () => {
+        const store = Neo.create(Store, {keyProperty: 'id', model: AgentDefinition, data: [
+            {id: 'ada', githubUsername: 'ada', harnessType: 'codex'}
+        ]});
+        const saveStatuses = [];
+        const stub = {
+            agentDefinitionsStore         : store,
+            agentDefinitionsLoadGeneration: 0,
+            agentConfigRequestGenerations : new Map(),
+            agentConfigSaveStatuses       : new Map(),
+            onAgentConfigIntent           : Accounts.prototype.onAgentConfigIntent,
+            setAgentConfigSaveStatus      : Accounts.prototype.setAgentConfigSaveStatus,
+            getReference                  : () => ({setSaveStatus: (...args) => saveStatuses.push(args)})
+        };
+        globalThis.AgentOS = {fleet: {registryBridge: {configureAgent: async () => ({
+            status: 'rejected', reason: "Unknown MCP server 'bogus'."
+        })}}};
+
+        await stub.onAgentConfigIntent({id: 'ada', mcpServers: {bogus: true}});
+
+        expect(store.get('ada').harnessType).toBe('codex');
+        expect(saveStatuses.at(-1)).toEqual(['ada', 'rejected', "Unknown MCP server 'bogus'."]);
+
+        delete globalThis.AgentOS;
+        store.destroy()
+    });
+
+    test('cold hydration replaces the placeholder from canonical listAgents; failure preserves last state', async () => {
+        const store = Neo.create(Store, {keyProperty: 'id', model: AgentDefinition, data: [
+            {id: 'bridge-pending', githubUsername: 'bridge-pending', harnessType: 'codex'}
+        ]});
+        const stub = {
+            agentDefinitionsStore      : store,
+            agentDefinitionsLoadGeneration: 0,
+            syncAgentSelector          : () => {},
+            loadAgentDefinitions       : Accounts.prototype.loadAgentDefinitions
+        };
+
+        globalThis.AgentOS = {fleet: {registryBridge: {listAgents: async () => [{
+            id: 'canonical', githubUsername: 'canonical', harnessType: 'claude-code', mcpServers: {'memory-core': false}
+        }]}}};
+        await expect(stub.loadAgentDefinitions()).resolves.toBe(true);
+        expect(store.get('bridge-pending')).toBeNull();
+        expect(store.get('canonical').mcpServers).toEqual({'memory-core': false});
+
+        globalThis.AgentOS.fleet.registryBridge.listAgents = async () => { throw new Error('offline') };
+        await expect(stub.loadAgentDefinitions()).resolves.toBe(false);
+        expect(store.get('canonical').harnessType).toBe('claude-code');
 
         delete globalThis.AgentOS;
         store.destroy()

--- a/test/playwright/unit/apps/agentos/config/accountConfigModel.spec.mjs
+++ b/test/playwright/unit/apps/agentos/config/accountConfigModel.spec.mjs
@@ -99,6 +99,26 @@ test.describe('FM account configuration model', () => {
         expect(mcpServers.resolveMcpMatrix({'memory-core': 'yes'})['memory-core']).toBe(false)
     });
 
+    test('sparse normalization rejects malformed intent, removes defaults, and follows catalog evolution', () => {
+        expect(mcpServers.normalizeMcpOverrides({
+            'memory-core'    : true,
+            'github-workflow': true
+        })).toEqual({'github-workflow': true});
+        expect(mcpServers.normalizeMcpOverrides(mcpServers.defaultMcpMatrix())).toBeNull();
+
+        expect(() => mcpServers.normalizeMcpOverrides({'made-up-server': true})).toThrow(/Unknown MCP server/);
+        expect(() => mcpServers.normalizeMcpOverrides({'memory-core': 1})).toThrow(/must be boolean/);
+        expect(() => mcpServers.normalizeMcpOverrides([])).toThrow(/object or null/);
+
+        const evolvedCatalog = mcpServers.listMcpServers().map(entry => entry.key === 'github-workflow'
+            ? {...entry, defaultEnabled: true}
+            : entry);
+
+        // No override follows the NEW default; the old explicit opt-in is now redundant.
+        expect(mcpServers.resolveMcpMatrix(null, evolvedCatalog)['github-workflow']).toBe(true);
+        expect(mcpServers.normalizeMcpOverrides({'github-workflow': true}, evolvedCatalog)).toBeNull()
+    });
+
     test('the AgentDefinition record contract: matrix passthrough, tri-state toggles, credential-free', () => {
         const store = Neo.create(Store, {
             keyProperty: 'id',


### PR DESCRIPTION
Resolves #14964

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session 019f484c-662f-7f31-969a-cbde373efd4a.

Fleet Manager Accounts can now edit an existing resident’s harness and MCP choices through one Brain-owned curated intent. The registry validates and atomically persists sparse overrides, returns a deeply redacted canonical readback, and the Body updates its real shared record only from that response. A shared dependency-free MCP catalog prevents Body/Brain key drift; stale save responses, rejection states, and catalog-default evolution are all pinned.

Evidence: L3 (real browser → production App-Worker bridge → loopback Fleet server/registry → Neural Link store inspection, including reload hydration) → L3 required (#14964 save/persist/readback journey). No residuals.

## Deltas from ticket

- `defineAgent` is now create-only so existing residents cannot bypass scoped configuration or erase Brain-only launch state.
- New-agent creation is failure-atomic across credential and registry stores: credential publish happens first, registry row last, with rollback and retryability probes.
- Public registry projection recursively strips credential/token/launch/command/args/env vocabulary, including nested legacy metadata.
- Registry and credential JSON/ciphertext stores publish through temp-file rename; failed writes leave cache and prior durable state unchanged.
- Accounts uses per-agent save/list generations so late responses cannot regress newer canonical state; feedback remains keyed correctly across selection changes.

## Contract Ledger

| Surface | Authority | Shipped behavior | Fail-closed evidence |
|---|---|---|---|
| MCP vocabulary/defaults | `src/ai/fleet/mcpServers.mjs` | one dependency-free Body↔Brain catalog; persist sparse deviations only | unknown/non-boolean keys reject; retired stored keys do not render |
| Existing-agent write | `FleetRegistryService.configureAgent` | allowlist exactly `{id,harnessType,mcpServers}`; canonical readback | credential/launch/wake/hooks/generic bags reject before write |
| Durable publish | registry + credential stores | copy-on-write cache, temp rename, failure-atomic create | write failure preserves prior state and public create stays retryable |
| Wire | Fleet bridge/dispatch | one serializable curated intent, accepted/rejected domain result | unexpected errors remain transport-sanitized |
| Accounts projection | real AgentDefinitions store | pending → canonical accepted readback or rendered rejection | stale generations cannot overwrite newer state; no optimistic success |
| Security | public DTO/readback | recursive secret + launch redaction | PAT/token/command/args/env absent from service, wire, store, and NL evidence |

## Test Evidence

- Focused Brain/bridge/transport suite — **81/81 passed** at exact rebased head.
- Focused Accounts/shared-config suite — **27/27 passed**.
- `NEO_E2E_PORT=8097 NEO_TEST_SKIP_CI=true npm run test-e2e -- test/playwright/e2e/agentos/AccountsConfigSurface.spec.mjs --workers=1` — **1/1 passed** with the production App-Worker bridge, real loopback Fleet registry/server, browser reload, and Neural Link store inspection.
- `node --check` across every changed/new `.mjs` file — passed.
- `git diff --check origin/dev...HEAD` — passed.
- Two independent adversarial audits: UI/round-trip returned no blocker; Brain audit’s create-only atomicity blocker was fixed and pinned before commit.
- Environment disclosure: the first sandboxed E2E launch was denied by `uv_uptime`/Chrome process permissions and hit Watchpack `EMFILE` before application code; the identical single-spec run with host permissions passed.

## Post-Merge Validation

- [ ] From merged `dev`, save one non-default MCP choice in Accounts, reload, and confirm the canonical sparse readback remains visible with no credential fields in the NL store projection.

## Commit

- `d75bb47cf0` — `feat(fleet): persist sparse agent configuration (#14964)`

Related: #13015 · #14807 · #14614 · #14537 · PR #14960
