### PR TITLE
feat(dockdemo): Demo-B — named perspectives that morph + the shared-heap OS-window pop-out (#14590)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/CounterPane.mjs
+++ b/apps/agentos/childapps/dockdemo/view/CounterPane.mjs
@@ -1,0 +1,87 @@
+import Component from '../../../../../src/component/Base.mjs';
+
+/**
+ * @summary The Demo-B state-continuity witness: a frame counter that lives on the INSTANCE.
+ *
+ * The pane increments once per second from construction and renders its count. Unlike a
+ * wall-clock (which survives remounts invisibly — it re-reads world state), this counter
+ * resets to zero if the component is ever destroyed and recreated: an unbroken count across
+ * a perspective morph, a pop-out to an OS window, and a reattach is PROOF the instance was
+ * reparented, never remade — the object-permanence story the demo exists to show.
+ * @class AgentOS.childapps.dockdemo.view.CounterPane
+ * @extends Neo.component.Base
+ */
+class CounterPane extends Component {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.childapps.dockdemo.view.CounterPane'
+         * @protected
+         */
+        className: 'AgentOS.childapps.dockdemo.view.CounterPane',
+        /**
+         * @member {String[]} cls=['agentos-dockdemo-counter-pane']
+         */
+        cls: ['agentos-dockdemo-counter-pane']
+    }
+
+    /**
+     * Seconds since THIS instance constructed — the continuity value. Instance field on
+     * purpose: no config reactivity, no persistence; only an unbroken lifecycle keeps it.
+     * @member {Number} frames=0
+     */
+    frames = 0
+    /**
+     * @member {Number|null} intervalId=null
+     * @protected
+     */
+    intervalId = null
+
+    /**
+     * Starts the once-per-second heartbeat.
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        let me = this;
+
+        me.intervalId = setInterval(() => {
+            me.frames++;
+            me.renderCount()
+        }, 1000);
+
+        me.renderCount()
+    }
+
+    /**
+     * Clears the heartbeat with the instance — a destroyed witness never ticks again,
+     * which is exactly what makes a surviving count meaningful.
+     * @param {...*} args
+     */
+    destroy(...args) {
+        this.intervalId && clearInterval(this.intervalId);
+        this.intervalId = null;
+
+        super.destroy(...args)
+    }
+
+    /**
+     * Projects the current count into the pane body.
+     * @protected
+     */
+    renderCount() {
+        let me = this;
+
+        if (me.isDestroyed) return;
+
+        me.vdom.cn = [
+            {cls: ['agentos-dockdemo-counter-label'], text: 'WORKBENCH'},
+            {cls: ['agentos-dockdemo-counter-value'], text: `${me.frames}s unbroken`},
+            {cls: ['agentos-dockdemo-counter-note'],  text: 'this counter dies on remount — it has never remounted'}
+        ];
+
+        me.update()
+    }
+}
+
+export default Neo.setupClass(CounterPane);

--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -1,0 +1,672 @@
+import Component                          from '../../../../../src/component/Base.mjs';
+import Container                          from '../../../../../src/container/Base.mjs';
+import CounterPane                        from './CounterPane.mjs';
+import DockLayoutAdapter                  from '../../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockMotionSignal                   from '../../../../../src/dashboard/DockMotionSignal.mjs';
+import DockPerspectiveStore               from '../../../../../src/dashboard/DockPerspectiveStore.mjs';
+import DockService                        from '../../../../../src/ai/client/DockService.mjs';
+import DockZoneModel                      from '../../../../../src/dashboard/DockZoneModel.mjs';
+import TourRunner                         from '../../../../../src/ai/client/TourRunner.mjs';
+import {demoBTourScript, initialDocument} from '../../../tour/demoBPerspectives.mjs';
+import '../../../../../src/button/Base.mjs';   // registers the `button` ntype the bars compose
+import '../../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits
+import '../../../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype the bars use
+
+/**
+ * @summary The Demo-B showcase workspace: named perspectives that MORPH, and a pane that
+ * leaves for its own OS window and returns with its state unbroken — the only-Neo story.
+ *
+ * Same reducer-container ownership pattern as Demo A (committed `dockZone.v1` document as
+ * the single source of truth; the pure reducer + view-sync halves of the dock-holder
+ * contract), plus the two capabilities this demo exists to show:
+ *
+ * - **Perspectives** ride a {@link Neo.dashboard.DockPerspectiveStore}: the tour CAPTURES
+ *   three named layouts live through `createSavedLayout` → `savePerspective` (the ADR's
+ *   §2.2 capture path — no pre-baked records), and loading one back is a single committed
+ *   document swap the FLIP layer animates. The switcher bar rebuilds from the store's
+ *   lifecycle events — buttons are born from `perspectiveSaved`, never hardcoded.
+ * - **Pop-out** rides the shared-heap vessel: panes are INSTANCE-CACHED (created once,
+ *   parked across every re-projection — the reveal-pane-cache precedent), so detaching the
+ *   workbench moves the LIVE component into the popup window's view tree
+ *   (`mainView.add(instance)` — both windows share one App Worker) and reattaching moves it
+ *   home. The {@link AgentOS.childapps.dockdemo.view.CounterPane} witness makes the
+ *   reparent-never-recreate contract visible: its count survives because its instance does.
+ *   Document honesty: pop-out commits `detachItem` (the item leaves the tree, keeps its
+ *   record), reattach commits `addTab` — the document never lies about what is docked.
+ *
+ * @class AgentOS.childapps.dockdemo.view.DemoBWorkspace
+ * @extends Neo.container.Base
+ */
+class DemoBWorkspace extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.childapps.dockdemo.view.DemoBWorkspace'
+         * @protected
+         */
+        className: 'AgentOS.childapps.dockdemo.view.DemoBWorkspace',
+        /**
+         * Theme dependencies: the FM token bridge, the dock motion/token contract file (the
+         * projected tree is plain containers; nothing loads it per-class), and Demo A's skin
+         * (this workspace reuses its tourbar/pip/pane visual family — in `?demo=b` mode
+         * Demo A never instantiates, so its sheet must be declared, not assumed).
+         * @member {String[]} additionalThemeFiles
+         */
+        additionalThemeFiles: [
+            'AgentOS.view.Viewport',
+            'Neo.dashboard.Container',
+            'AgentOS.childapps.dockdemo.view.DemoAWorkspace'
+        ],
+        /**
+         * @member {String[]} cls=['agentos-dockdemo-workspace','agentos-dockdemo-workspace-b']
+         */
+        cls: ['agentos-dockdemo-workspace', 'agentos-dockdemo-workspace-b'],
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         */
+        layout: {ntype: 'vbox', align: 'stretch'}
+        // `items` is built in construct() — each projection carries the instance-bound
+        // reducer + view-sync callbacks, so it cannot live in static config.
+    }
+
+    /**
+     * The live committed dock-zone document — the single source of truth.
+     * @member {Object|null} dockModel=null
+     */
+    dockModel = null
+    /**
+     * The app-side Neural Link dock seam (tour + agent drivability).
+     * @member {Neo.ai.client.DockService|null} dockService=null
+     */
+    dockService = null
+    /**
+     * The named-perspective home. Lifecycle events feed the switcher bar.
+     * @member {Neo.dashboard.DockPerspectiveStore|null} perspectiveStore=null
+     */
+    perspectiveStore = null
+    /**
+     * The tour runner playing the Demo-B screenplay.
+     * @member {Neo.ai.client.TourRunner|null} tourRunner=null
+     */
+    tourRunner = null
+    /**
+     * Pane instances by item id — created ONCE, parked (removed without destroy) across
+     * every re-projection and window move, torn down only with the workspace. THE
+     * object-permanence substrate: `resolvePane` hands the adapter these live instances,
+     * so no morph, pop-out, or reattach ever remounts a pane.
+     * @member {Object} paneCache={}
+     * @protected
+     */
+    paneCache = {}
+    /**
+     * Detached-pane bookkeeping: itemId → {tabsNodeId, windowId|null}. `tabsNodeId` is the
+     * home the reattach commit targets; `windowId` fills in when the popup connects.
+     * @member {Object} detachedPanes={}
+     * @protected
+     */
+    detachedPanes = {}
+    /**
+     * Beats executed in the current run — the pip strip's progress counter.
+     * @member {Number} beatCount=0
+     */
+    beatCount = 0
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        let me = this;
+
+        me.dockModel        = DockZoneModel.clone(initialDocument);
+        me.dockService      = Neo.create(DockService, {});
+        me.perspectiveStore = Neo.create(DockPerspectiveStore, {});
+
+        me.tourRunner = Neo.create(TourRunner, {
+            componentId: me.id,
+            dockService: me.dockService,
+            mode       : 'demo',
+            script     : demoBTourScript
+        });
+
+        me.tourRunner.on({
+            beat    : me.onTourBeat,
+            complete: me.onTourComplete,
+            error   : me.onTourError,
+            scene   : me.onTourScene,
+            scope   : me
+        });
+
+        // switcher buttons are BORN from store lifecycle — never hardcoded
+        me.perspectiveStore.on({
+            collectionChange: me.syncSwitcher,
+            scope           : me
+        });
+
+        // popup lifecycle: the pop-out pane reparents on connect, comes home on disconnect
+        Neo.currentWorker.on({
+            connect   : me.onWindowConnect,
+            disconnect: me.onWindowDisconnect,
+            scope     : me
+        });
+
+        me.add([me.createTourBar(), me.createSwitcherBar(), {
+            module   : Container,
+            cls      : ['agentos-dockdemo-dock-host', 'neo-dashboard'],
+            flex     : 1,
+            items    : [me.projectDockModel()],
+            layout   : {ntype: 'fit'},
+            reference: 'dock-host-b'
+        }])
+    }
+
+    /**
+     * The pure reducer half of the holder contract.
+     * @param {Object} descriptor
+     * @returns {{document: Object, errors: String[]}}
+     */
+    applyDockZoneOperation(descriptor) {
+        return DockZoneModel.applyOperation(this.dockModel, descriptor)
+    }
+
+    /**
+     * Captures the CURRENT committed document as a named perspective through the real
+     * §2.2 path: `createSavedLayout` (validation + normalization) → `savePerspective`.
+     * `replace: true` keeps tour reruns idempotent — re-capturing your own name is the
+     * demo's update flow, not a collision dispute.
+     * @param {String} name
+     * @returns {{saved: Boolean, errors: String[]}}
+     */
+    capturePerspective(name) {
+        let me      = this,
+            created = DockZoneModel.createSavedLayout(me.dockModel, {
+                layoutId       : `demo-b-${name.toLowerCase()}`,
+                perspectiveName: name,
+                title          : name
+            });
+
+        if (created.errors.length) {
+            return {errors: created.errors, saved: false}
+        }
+
+        let result = me.perspectiveStore.savePerspective(created.layout, {replace: true});
+
+        return {errors: result.errors, saved: result.saved}
+    }
+
+    /**
+     * The switcher bar: one button per stored perspective (rebuilt from store lifecycle
+     * events) + the capture button. Real `button.Base` children riding the handler contract.
+     * @returns {Object}
+     */
+    createSwitcherBar() {
+        let me = this;
+
+        return {
+            cls      : ['agentos-dockdemo-switcher'],
+            flex     : 'none',
+            layout   : {ntype: 'hbox', align: 'center'},
+            ntype    : 'toolbar',
+            reference: 'switcher-bar',
+            items    : [{
+                cls  : ['agentos-dockdemo-switcher-label'],
+                html : 'Perspectives',
+                ntype: 'component',
+                style: {marginRight: '8px', opacity: 0.7, whiteSpace: 'nowrap'}
+            }]
+        }
+    }
+
+    /**
+     * The tour bar — play button, caption feed, pip strip (the Demo-A pattern).
+     * @returns {Object}
+     */
+    createTourBar() {
+        let me = this;
+
+        return {
+            cls   : ['agentos-dockdemo-tourbar'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+            ntype : 'toolbar',
+            items : [{
+                cls      : ['agentos-dockdemo-tour-play'],
+                handler  : () => me.startTour(),
+                iconCls  : 'fa fa-play',
+                ntype    : 'button',
+                reference: 'tour-play-b',
+                text     : 'Tour'
+            }, {
+                cls      : ['agentos-dockdemo-tour-caption'],
+                flex     : 1,
+                html     : `${demoBTourScript.title} — press Tour: three perspectives get captured live, morph into each other, and a pane leaves for its own OS window without dropping a beat.`,
+                ntype    : 'component',
+                reference: 'tour-caption-b',
+                style    : {padding: '0 12px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis'}
+            }, {
+                cls      : ['agentos-dockdemo-tour-pips'],
+                flex     : 'none',
+                ntype    : 'component',
+                reference: 'tour-pips-b',
+                vdom     : {cn: DemoBWorkspace.totalBeats().map(() => ({cls: ['agentos-dockdemo-pip']}))}
+            }]
+        }
+    }
+
+    /**
+     * The read half of the dock-holder contract.
+     * @returns {Object}
+     */
+    getDockZoneDocument() {
+        return this.dockModel
+    }
+
+    /**
+     * Loads a stored perspective and re-projects from its restored document — one committed
+     * swap, animated by the FLIP layer like every other re-projection.
+     * @param {String} name
+     * @returns {{loaded: Boolean, errors: String[]}}
+     */
+    loadPerspectiveByName(name) {
+        let me     = this,
+            result = me.perspectiveStore.loadPerspective(name);
+
+        if (result.errors.length || !result.document) {
+            return {errors: result.errors, loaded: false}
+        }
+
+        me.onDockZoneDocumentChange(result.document);
+
+        return {errors: [], loaded: true}
+    }
+
+    /**
+     * The view-sync half: stores the committed document and re-projects, deferred one tick
+     * (the normative guard — a committing interaction surface is never destroyed mid-handler).
+     * @param {Object} document
+     */
+    onDockZoneDocumentChange(document) {
+        let me = this;
+
+        me.dockModel = document;
+
+        me.timeout(0).then(() => {
+            if (!me.isDestroyed) {
+                me.refreshDockWorkspace()
+            }
+        })
+    }
+
+    /**
+     * Caption feed + pip progress + the surface cues that make narrated beats EXECUTABLE:
+     * perspective saves/loads ride the store, pop-out/reattach ride the vessel — none of
+     * them are dock-document ops, so none of them masquerade as descriptors.
+     * @param {Object} data The runner's beat payload.
+     */
+    onTourBeat(data) {
+        let me    = this,
+            {cue} = data;
+
+        data.caption && me.setTourCaption(data.caption);
+        me.setPipProgress(++me.beatCount);
+
+        if (!cue) return;
+
+        cue.type === 'perspective-save' && me.capturePerspective(cue.name);
+        cue.type === 'perspective-load' && me.loadPerspectiveByName(cue.name);
+        cue.type === 'popout'           && me.popOutPane(cue.itemId);
+        cue.type === 'reattach'         && me.reattachPane(cue.itemId)
+    }
+
+    /**
+     * @param {Object} data `{completed, errors, log}`
+     */
+    onTourComplete(data) {
+        let me = this;
+
+        me.setTourCaption(`Tour complete — ${data.log.length} beats; the workbench counter never reset.`);
+        me.setPipProgress(DemoBWorkspace.totalBeats().length)
+    }
+
+    /**
+     * Honest failure surface: an aborted tour names its reason.
+     * @param {Object} data `{errors, log}`
+     */
+    onTourError(data) {
+        this.setTourCaption(`Tour stopped: ${data.errors[0] || 'unknown reason'}`)
+    }
+
+    /**
+     * @param {Object} data The runner's scene payload.
+     */
+    onTourScene(data) {
+        this.setTourCaption(`${data.title}${data.caption ? ' — ' + data.caption : ''}`)
+    }
+
+    /**
+     * A popup window joined the shared heap: if it is one of OURS (the pop-out URL carries
+     * `popout=<itemId>&hostId=<this.id>`), reparent the LIVE cached pane into its main view.
+     * The instance moves trees; nothing is recreated — the counter proves it.
+     * @param {Object} data `{appName, windowId}`
+     */
+    async onWindowConnect(data) {
+        let me         = this,
+            {windowId} = data,
+            app        = Neo.apps[windowId];
+
+        if (!app || me.isDestroyed) return;
+
+        let url    = await Neo.Main.getByPath({path: 'document.URL', windowId}),
+            params = new URL(url).searchParams,
+            itemId = params.get('popout');
+
+        if (params.get('hostId') !== me.id || !itemId) return;
+
+        let entry = me.detachedPanes[itemId],
+            pane  = me.paneCache[itemId];
+
+        if (entry && pane) {
+            entry.windowId = windowId;
+            app.mainView.add(pane)
+        }
+    }
+
+    /**
+     * A popup closed: whatever pane it hosted comes HOME — the reattach commit brings the
+     * item back into the document; the re-projection re-adopts the parked instance.
+     * @param {Object} data `{appName, windowId}`
+     */
+    onWindowDisconnect(data) {
+        let me = this;
+
+        if (me.isDestroyed) return;
+
+        for (const [itemId, entry] of Object.entries(me.detachedPanes)) {
+            if (entry.windowId === data.windowId) {
+                me.reattachPane(itemId, {windowAlreadyClosed: true});
+                break
+            }
+        }
+    }
+
+    /**
+     * The pop-out moment: parks the live pane out of the projection, commits `detachItem`
+     * (document honesty — the item leaves the tree, keeps its record), and opens the popup
+     * on the SAME app: the SharedWorker heap makes the new window a second render target
+     * for the one worker, and `onWindowConnect` moves the instance in.
+     * @param {String} itemId
+     * @returns {Promise<{detached: Boolean, errors: String[]}>}
+     */
+    async popOutPane(itemId) {
+        let me   = this,
+            pane = me.paneCache[itemId],
+            home = DockZoneModel.findContainingTabsId(me.dockModel, itemId);
+
+        if (!pane || !home || me.detachedPanes[itemId]) {
+            return {detached: false, errors: [`"${itemId}" is not a docked, cached, attached pane`]}
+        }
+
+        me.detachedPanes[itemId] = {tabsNodeId: home, windowId: null};
+
+        // park BEFORE the re-projection tears the old tree down
+        pane.parent?.remove(pane, false);
+
+        let result = me.applyDockZoneOperation({operation: 'detachItem', itemId});
+
+        if (result.errors?.length) {
+            delete me.detachedPanes[itemId];
+            return {detached: false, errors: result.errors}
+        }
+
+        me.onDockZoneDocumentChange(result.document);
+
+        let winData = await Neo.Main.getWindowData({windowId: me.windowId});
+
+        await Neo.Main.windowOpen({
+            url           : `./index.html?popout=${itemId}&hostId=${me.id}`,
+            windowFeatures: `height=420,width=560,left=${winData.screenLeft + 120},top=${winData.screenTop + 120}`,
+            windowId      : me.windowId,
+            windowName    : `demo-b-${itemId}`
+        });
+
+        return {detached: true, errors: []}
+    }
+
+    /**
+     * Projects the committed document, threading the instance-bound holder callbacks.
+     * @returns {Object}
+     */
+    projectDockModel() {
+        let me = this;
+
+        return DockLayoutAdapter.project(me.dockModel, {
+            applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
+            onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
+            resolveComponentRef     : (componentRef, item, itemId) => me.resolvePane(itemId, item)
+        })
+    }
+
+    /**
+     * The reattach: closes the popup (unless it already closed itself), commits `addTab`
+     * back to the pane's home tabs node, and lets the re-projection re-adopt the parked
+     * instance — same count, same instance, home again.
+     * @param {String} itemId
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.windowAlreadyClosed=false]
+     * @returns {Promise<{reattached: Boolean, errors: String[]}>}
+     */
+    async reattachPane(itemId, {windowAlreadyClosed = false} = {}) {
+        let me    = this,
+            entry = me.detachedPanes[itemId],
+            pane  = me.paneCache[itemId];
+
+        if (!entry || !pane) {
+            return {errors: [`"${itemId}" is not detached`], reattached: false}
+        }
+
+        delete me.detachedPanes[itemId];
+
+        // pull the instance out of the popup's tree first — parked, never destroyed
+        pane.parent?.remove(pane, false);
+
+        if (!windowAlreadyClosed) {
+            await Neo.Main.windowClose({names: [`demo-b-${itemId}`], windowId: me.windowId})
+        }
+
+        // home fallback: if the remembered tabs node left the tree (a perspective moved on),
+        // the first tabs node adopts the returning pane — never a dangling reattach
+        let home = me.dockModel.nodes[entry.tabsNodeId]?.type === 'tabs'
+            ? entry.tabsNodeId
+            : Object.keys(me.dockModel.nodes).find(id => me.dockModel.nodes[id].type === 'tabs');
+
+        let result = me.applyDockZoneOperation({operation: 'addTab', itemId, tabsNodeId: home});
+
+        if (result.errors?.length) {
+            return {errors: result.errors, reattached: false}
+        }
+
+        me.onDockZoneDocumentChange(result.document);
+
+        return {errors: [], reattached: true}
+    }
+
+    /**
+     * Rebuilds the toolbar-adjacent projection from the committed document, FLIP-bracketed.
+     * Cached pane instances are PARKED first (removed without destroy) so the coarse
+     * teardown of the old projection shell can never reap them — the object-permanence
+     * mechanic every capability in this demo leans on.
+     * @protected
+     */
+    async refreshDockWorkspace() {
+        const
+            me   = this,
+            host = me.getReference('dock-host-b');
+
+        if (host) {
+            const flip = Neo.main?.addon?.DockFlip;
+
+            try {
+                await flip?.captureFirst({hostId: host.id, markerPrefix: 'agentos-dockdemo-pane-'})
+            } catch (e) {/* instant landing */}
+
+            // park every cached live pane before the old projection tree is destroyed
+            Object.values(me.paneCache).forEach(pane => {
+                pane?.parent && !pane.isDestroyed && pane.parent.remove(pane, false)
+            });
+
+            host.removeAt(0);
+            host.insert(0, me.projectDockModel());
+
+            if (flip) {
+                DockMotionSignal.enter(me);
+                flip.play({hostId: host.id, markerPrefix: 'agentos-dockdemo-pane-'})
+                    .catch(() => {})
+                    .finally(() => DockMotionSignal.leave(me))
+            }
+        }
+    }
+
+    /**
+     * Resolves a pane to its CACHED live instance, creating it on first request — the
+     * workbench is the counter witness; the rest are labeled placeholder components with
+     * stable skin hooks. The FLIP marker cls rides every instance.
+     * @param {String} itemId
+     * @param {Object} item The model item record.
+     * @returns {Neo.component.Base}
+     */
+    resolvePane(itemId, item) {
+        let me    = this,
+            cache = me.paneCache;
+
+        if (cache[itemId] && !cache[itemId].isDestroyed) {
+            return cache[itemId]
+        }
+
+        cache[itemId] = Neo.create(itemId === 'workbench' ? {
+            module: CounterPane,
+            cls   : ['agentos-dockdemo-counter-pane', 'agentos-dockdemo-pane-workbench']
+        } : {
+            module: Component,
+            cls   : ['agentos-dockdemo-pane', `agentos-dockdemo-pane-${itemId}`],
+            html  : item?.title ?? itemId,
+            style : {alignItems: 'center', display: 'flex', fontSize: '18px', justifyContent: 'center'}
+        });
+
+        return cache[itemId]
+    }
+
+    /**
+     * Lights the first `count` pips.
+     * @param {Number} count
+     */
+    setPipProgress(count) {
+        const pips = this.getReference('tour-pips-b');
+
+        if (pips) {
+            let {vdom} = pips;
+
+            vdom.cn.forEach((pip, index) => {
+                pip.cls = index < count
+                    ? ['agentos-dockdemo-pip', 'agentos-dockdemo-pip-done']
+                    : ['agentos-dockdemo-pip']
+            });
+
+            pips.update()
+        }
+    }
+
+    /**
+     * Updates the caption feed.
+     * @param {String} text
+     */
+    setTourCaption(text) {
+        const caption = this.getReference('tour-caption-b');
+
+        caption && (caption.html = text)
+    }
+
+    /**
+     * Plays the screenplay from the top; reruns reset the stage and re-capture cleanly
+     * (perspective saves use `replace: true`).
+     */
+    async startTour() {
+        let me = this;
+
+        if (me.tourRunner.running) {
+            me.setTourCaption('Tour already running — let it finish its story.');
+            return
+        }
+
+        if (me.tourRunner.log.length) {
+            me.dockModel = DockZoneModel.clone(initialDocument);
+            me.refreshDockWorkspace()
+        }
+
+        me.beatCount = 0;
+        me.setPipProgress(0);
+
+        await me.tourRunner.start()
+    }
+
+    /**
+     * Rebuilds the switcher buttons from the store's current collection — fired by every
+     * store lifecycle event; buttons load their perspective through the same path the tour
+     * cues use (one code path, human- and agent-driven alike).
+     * @protected
+     */
+    syncSwitcher() {
+        let me  = this,
+            bar = me.getReference('switcher-bar');
+
+        if (!bar) return;
+
+        let collection = me.perspectiveStore.collection,
+            layouts    = collection?.layouts ?? {},
+            names      = Object.values(layouts).map(record => record.perspectiveName ?? record.layoutId);
+
+        // children after the label are the perspective buttons — rebuild in place
+        while (bar.items.length > 1) {
+            bar.removeAt(bar.items.length - 1)
+        }
+
+        names.forEach(name => {
+            bar.add({
+                cls            : ['agentos-dockdemo-switcher-btn'],
+                handler        : () => me.loadPerspectiveByName(name),
+                ntype          : 'button',
+                text           : name,
+                useRippleEffect: false
+            })
+        })
+    }
+
+    /**
+     * One entry per script step — the pip strip's build source.
+     * @returns {Object[]}
+     * @static
+     */
+    static totalBeats() {
+        return demoBTourScript.scenes.flatMap(scene => scene.steps)
+    }
+
+    /**
+     * Tears down the runner, seam, store, and every cached pane with the workspace.
+     * @param {...*} args
+     */
+    destroy(...args) {
+        let me = this;
+
+        me.tourRunner?.destroy();
+        me.dockService?.destroy();
+        me.perspectiveStore?.destroy();
+
+        Object.values(me.paneCache).forEach(pane => {
+            pane?.isDestroyed || pane?.destroy?.()
+        });
+        me.paneCache = {};
+
+        super.destroy(...args)
+    }
+}
+
+export default Neo.setupClass(DemoBWorkspace);

--- a/apps/agentos/childapps/dockdemo/view/Viewport.mjs
+++ b/apps/agentos/childapps/dockdemo/view/Viewport.mjs
@@ -1,10 +1,19 @@
 import BaseViewport   from '../../../../../src/container/Viewport.mjs';
 import DemoAWorkspace from './DemoAWorkspace.mjs';
+import DemoBWorkspace from './DemoBWorkspace.mjs';
 
 /**
- * @summary Viewport of the Demo-A dock-choreography childapp: hosts the showcase workspace
- * full-bleed. All behavior lives in {@link AgentOS.childapps.dockdemo.view.DemoAWorkspace};
- * this class only mounts it into the window.
+ * @summary Viewport of the dock-demo childapp: mounts one of the showcase workspaces by URL.
+ *
+ * Three boot modes, resolved from the window's own search params (async — the worker reads
+ * the URL through the main-thread seam, so the workspace mounts in `onConstructed`):
+ *
+ * - default        → Demo A (dock choreography — `DemoAWorkspace`)
+ * - `?demo=b`      → Demo B (perspectives + pop-out — `DemoBWorkspace`)
+ * - `?popout=<id>` → an EMPTY pop-out host: this window carries no workspace of its own;
+ *   the opener's workspace reparents the live pane into this viewport on connect (the
+ *   shared-heap contract — one App Worker, two render targets).
+ *
  * @class AgentOS.childapps.dockdemo.view.Viewport
  * @extends Neo.container.Viewport
  */
@@ -20,16 +29,33 @@ class Viewport extends BaseViewport {
          */
         cls: ['agentos-dockdemo-viewport'],
         /**
-         * @member {Object[]} items
-         */
-        items: [{
-            module: DemoAWorkspace,
-            flex  : 1
-        }],
-        /**
          * @member {Object} layout={ntype:'vbox',align:'stretch'}
          */
         layout: {ntype: 'vbox', align: 'stretch'}
+    }
+
+    /**
+     * Resolves the boot mode from the window URL and mounts the matching workspace.
+     * A pop-out window mounts NOTHING — it is a render target waiting for its pane.
+     */
+    async onConstructed() {
+        super.onConstructed();
+
+        let me     = this,
+            url    = await Neo.Main.getByPath({path: 'document.URL', windowId: me.windowId}),
+            params = new URL(url).searchParams;
+
+        if (me.isDestroyed) return;
+
+        if (params.get('popout')) {
+            me.addCls('agentos-dockdemo-popout-host');
+            return
+        }
+
+        me.add({
+            module: params.get('demo') === 'b' ? DemoBWorkspace : DemoAWorkspace,
+            flex  : 1
+        })
     }
 }
 

--- a/apps/agentos/tour/demoBPerspectives.mjs
+++ b/apps/agentos/tour/demoBPerspectives.mjs
@@ -1,0 +1,134 @@
+/**
+ * @summary Demo-B screenplay: named perspectives morphing + the shared-heap pop-out — the
+ * only-Neo showcase (`neo.tour.script.v1` data, consumed by the Demo-B workspace's runner).
+ *
+ * Dramatic arc (the differentiator story single-process docking libraries cannot tell):
+ *
+ * 1. **Capture** — the agent BUILDS three named perspectives live, saving each through the
+ *    real perspective store (no pre-baked records: S1's saves are the §2.2 capture path).
+ * 2. **Morph** — loading the perspectives back re-projects the committed document and the
+ *    FLIP layer glides every surviving pane to its new geometry; the counter keeps counting.
+ * 3. **Pop-out** — the workbench pane detaches to a real OS window on the SAME SharedWorker
+ *    heap and reattaches, its instance-bound counter unbroken: reparent, never recreate.
+ * 4. **Honest limits** — a perspective captured while the pane was detached restores into a
+ *    one-window world through the §2.2 fail-closed path, shown, not hidden.
+ *
+ * Store/pop-out beats ride surface CUES (the Demo-A reveal-cue pattern): perspectives are
+ * store operations and window moves are vessel operations — neither is a dock-zone document
+ * op, so they must not masquerade as descriptors. Document-shaped beats stay `op` steps with
+ * expects; the runner's replay determinism covers both alike.
+ */
+
+/**
+ * The opening stage — also captured live as the "Focus" perspective in scene 1.
+ * @type {Object}
+ */
+export const initialDocument = Object.freeze({
+    schema: 'neo.harness.dockZone.v1',
+    root  : 'root',
+    items : {
+        workbench: {componentRef: 'Workbench', title: 'Workbench', kind: 'panel'},
+        inspector: {componentRef: 'Inspector', title: 'Inspector', kind: 'panel'},
+        timeline : {componentRef: 'Timeline',  title: 'Timeline',  kind: 'panel'},
+        console  : {componentRef: 'Console',   title: 'Console',   kind: 'terminal'}
+    },
+    nodes: {
+        root            : {type: 'edge-zone', zones: {center: 'workbench-tabs', right: 'side-tabs'}},
+        'workbench-tabs': {type: 'tabs', items: ['workbench'], activeItemId: 'workbench'},
+        'side-tabs'     : {type: 'tabs', items: ['inspector', 'timeline', 'console'], activeItemId: 'inspector'}
+    }
+});
+
+/**
+ * The Demo-B tour script. Perspective and window beats are cues; document mutations are op
+ * steps with expects. Pauses are viewer pacing only.
+ * @type {Object}
+ */
+export const demoBTourScript = Object.freeze({
+    schema: 'neo.tour.script.v1',
+    id    : 'demo-b-perspectives-popout',
+    title : 'Perspectives that morph, panes that leave the window',
+
+    workspace: {},
+
+    scenes: [{
+        id     : 's1',
+        title  : 'Capture — three perspectives, saved live',
+        caption: 'The agent shapes the workspace and NAMES each shape. Every save goes through the perspective store — captured state, not screenshots.',
+        steps  : [
+            {type: 'pause', ms: 600, cue: {type: 'perspective-save', name: 'Focus'}, caption: 'save("Focus"): the opening stage becomes a named perspective'},
+            {type: 'pause', ms: 700},
+            {
+                type      : 'op',
+                caption   : 'split(timeline → below workbench): the review shape begins',
+                descriptor: {operation: 'splitNode', itemId: 'timeline', targetNodeId: 'workbench-tabs', orientation: 'vertical', edge: 'bottom', sizes: [0.65, 0.35]},
+                expect    : [{path: 'nodes.split-workbench-tabs-0.orientation', equals: 'vertical'}]
+            },
+            {
+                type      : 'op',
+                caption   : 'split(console → below inspector): logs live right-low',
+                descriptor: {operation: 'splitNode', itemId: 'console', targetNodeId: 'side-tabs', orientation: 'vertical', edge: 'bottom', sizes: [0.6, 0.4]},
+                expect    : [{path: 'nodes.split-side-tabs-0.orientation', equals: 'vertical'}]
+            },
+            {type: 'pause', ms: 600, cue: {type: 'perspective-save', name: 'Review'}, caption: 'save("Review"): the four-quadrant working shape, named'},
+            {type: 'pause', ms: 700},
+            {
+                type      : 'op',
+                caption   : 'merge(everything → workbench): one stage for the audience',
+                descriptor: {operation: 'moveItem', itemId: 'inspector', targetNodeId: 'workbench-tabs'},
+                expect    : [{path: 'nodes.workbench-tabs.items', equals: ['workbench', 'inspector']}]
+            },
+            {
+                type      : 'op',
+                caption   : 'merge(timeline → workbench)',
+                descriptor: {operation: 'moveItem', itemId: 'timeline', targetNodeId: 'workbench-tabs'},
+                expect    : [{path: 'nodes.workbench-tabs.items', equals: ['workbench', 'inspector', 'timeline']}]
+            },
+            {
+                type      : 'op',
+                caption   : 'merge(console → workbench): tabs behind the star',
+                descriptor: {operation: 'moveItem', itemId: 'console', targetNodeId: 'workbench-tabs'},
+                expect    : [{path: 'nodes.workbench-tabs.items', equals: ['workbench', 'inspector', 'timeline', 'console']}]
+            },
+            {
+                type      : 'op',
+                caption   : 'the workbench takes the stage',
+                descriptor: {operation: 'addTab', itemId: 'workbench', tabsNodeId: 'workbench-tabs'},
+                expect    : [{path: 'nodes.workbench-tabs.activeItemId', equals: 'workbench'}]
+            },
+            {type: 'pause', ms: 600, cue: {type: 'perspective-save', name: 'Presentation'}, caption: 'save("Presentation"): full-bleed, one pane, all attention'}
+        ]
+    }, {
+        id     : 's2',
+        title  : 'Morph — load a name, watch the layout glide',
+        caption: 'Loading a perspective is one committed document swap; the FLIP layer glides every surviving pane into its new geometry. The counter never blinks.',
+        steps  : [
+            {type: 'pause', ms: 900, cue: {type: 'perspective-load', name: 'Focus'}, caption: 'load("Focus"): back to the opening shape — animated, not repainted'},
+            {type: 'pause', ms: 1200},
+            {type: 'pause', ms: 900, cue: {type: 'perspective-load', name: 'Review'}, caption: 'load("Review"): the quadrants return'},
+            {type: 'pause', ms: 1200},
+            {type: 'pause', ms: 900, cue: {type: 'perspective-load', name: 'Presentation'}, caption: 'load("Presentation"): and collapse to the stage'},
+            {type: 'pause', ms: 1200}
+        ]
+    }, {
+        id     : 's3',
+        title  : 'Pop-out — the pane leaves the window, the state does not blink',
+        caption: 'The workbench detaches to its OWN OS window. Both windows share ONE app-worker heap: the component instance reparents — it is never recreated.',
+        steps  : [
+            {type: 'pause', ms: 900, cue: {type: 'perspective-load', name: 'Review'}, caption: 'back to "Review" — room to leave from'},
+            {type: 'pause', ms: 900},
+            {type: 'pause', ms: 900, cue: {type: 'popout', itemId: 'workbench'}, caption: 'pop-out(workbench): a real OS window opens on the shared heap. Watch the counter — it does not reset.'},
+            {type: 'pause', ms: 2500},
+            {type: 'pause', ms: 900, cue: {type: 'reattach', itemId: 'workbench'}, caption: 'reattach(workbench): home again. Same instance, same count — reparent, never recreate.'},
+            {type: 'pause', ms: 1200}
+        ]
+    }, {
+        id     : 's4',
+        title  : 'Finale — home',
+        caption: 'Back to "Focus": three named shapes, one OS-window round-trip, one unbroken counter — and every transition was a committed document.',
+        steps  : [
+            {type: 'pause', ms: 900, cue: {type: 'perspective-load', name: 'Focus'}, caption: 'load("Focus"): the finale returns to where we started'},
+            {type: 'pause', ms: 900}
+        ]
+    }]
+});

--- a/apps/agentos/tour/demoBPerspectives.mjs
+++ b/apps/agentos/tour/demoBPerspectives.mjs
@@ -125,10 +125,10 @@ export const demoBTourScript = Object.freeze({
         ]
     }, {
         id     : 's4',
-        title  : 'Honest limits — a capture from a two-window world, restored into one',
-        caption: '"Detached" was captured while the workbench lived in another window. Restoring it here undocks the pane — the document tells the truth instead of inventing a slot.',
+        title  : 'Detached intent — one workspace, two render targets',
+        caption: '"Detached" captured the worker-owned workspace while the workbench rendered in the popup. Restoring it preserves that detached catalog state without persisting window identity or geometry.',
         steps  : [
-            {type: 'pause', ms: 1400, cue: {type: 'perspective-load', name: 'Detached'}, caption: 'load("Detached"): the workbench leaves the layout — this capture remembers it elsewhere. Fail-closed, shown, never silent.'},
+            {type: 'pause', ms: 1400, cue: {type: 'perspective-load', name: 'Detached'}, caption: 'load("Detached"): the workbench leaves the primary tree because the saved workspace records it detached. Window-scope restore, shown, never silent.'},
             {
                 type   : 'topology-assert',
                 caption: 'the catalog still knows the workbench (nothing was deleted) — the layout simply has no slot for it, visibly',

--- a/apps/agentos/tour/demoBPerspectives.mjs
+++ b/apps/agentos/tour/demoBPerspectives.mjs
@@ -118,16 +118,23 @@ export const demoBTourScript = Object.freeze({
             {type: 'pause', ms: 900, cue: {type: 'perspective-load', name: 'Review'}, caption: 'back to "Review" — room to leave from'},
             {type: 'pause', ms: 900},
             {type: 'pause', ms: 900, cue: {type: 'popout', itemId: 'workbench'}, caption: 'pop-out(workbench): a real OS window opens on the shared heap. Watch the counter — it does not reset.'},
-            {type: 'pause', ms: 2500},
+            {type: 'pause', ms: 2000},
+            {type: 'pause', ms: 600, cue: {type: 'perspective-save', name: 'Detached'}, caption: 'save("Detached"): capturing THIS state — a perspective that remembers the workbench being elsewhere'},
             {type: 'pause', ms: 900, cue: {type: 'reattach', itemId: 'workbench'}, caption: 'reattach(workbench): home again. Same instance, same count — reparent, never recreate.'},
             {type: 'pause', ms: 1200}
         ]
     }, {
         id     : 's4',
-        title  : 'Finale — home',
-        caption: 'Back to "Focus": three named shapes, one OS-window round-trip, one unbroken counter — and every transition was a committed document.',
+        title  : 'Honest limits — a capture from a two-window world, restored into one',
+        caption: '"Detached" was captured while the workbench lived in another window. Restoring it here undocks the pane — the document tells the truth instead of inventing a slot.',
         steps  : [
-            {type: 'pause', ms: 900, cue: {type: 'perspective-load', name: 'Focus'}, caption: 'load("Focus"): the finale returns to where we started'},
+            {type: 'pause', ms: 1400, cue: {type: 'perspective-load', name: 'Detached'}, caption: 'load("Detached"): the workbench leaves the layout — this capture remembers it elsewhere. Fail-closed, shown, never silent.'},
+            {
+                type   : 'topology-assert',
+                caption: 'the catalog still knows the workbench (nothing was deleted) — the layout simply has no slot for it, visibly',
+                expect : [{path: 'items.workbench.title', equals: 'Workbench'}]
+            },
+            {type: 'pause', ms: 1400, cue: {type: 'perspective-load', name: 'Focus'}, caption: 'load("Focus"): the finale brings it home — and the counter STILL never reset, even undocked'},
             {type: 'pause', ms: 900}
         ]
     }]

--- a/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.scss
+++ b/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.scss
@@ -1,0 +1,72 @@
+// Demo-B perspectives + pop-out showcase — the hooks Demo A's skin does not carry.
+// Same discipline: fleet-manager module tokens only, theme variance rides the token layer.
+
+.agentos-dockdemo-switcher {
+    background   : var(--fm-panel);
+    border-bottom: 1px solid var(--fm-line);
+    flex   : 0 0 auto;
+    height : 44px;
+    padding: 6px 12px;
+
+    .agentos-dockdemo-switcher-label {
+        color         : var(--fm-ink-dim);
+        font-family   : var(--fm-font-mono);
+        font-size     : 11px;
+        letter-spacing: .08em;
+        text-transform: uppercase;
+    }
+
+    .agentos-dockdemo-switcher-btn {
+        background   : var(--fm-panel-2);
+        border       : 1px solid var(--fm-line);
+        border-radius: 6px;
+        color        : var(--fm-ink);
+        font-family  : var(--fm-font-mono);
+        margin-left  : 6px;
+
+        .neo-button-text {
+            color: var(--fm-ink);
+        }
+    }
+}
+
+.agentos-dockdemo-counter-pane {
+    align-items    : center;
+    background     : var(--fm-panel);
+    border         : 1px solid var(--fm-line-soft);
+    border-radius  : 8px;
+    display        : flex;
+    flex-direction : column;
+    gap            : 6px;
+    justify-content: center;
+
+    .agentos-dockdemo-counter-label {
+        color         : var(--fm-ink-dim);
+        font-family   : var(--fm-font-mono);
+        font-size     : 12px;
+        letter-spacing: .12em;
+    }
+
+    .agentos-dockdemo-counter-value {
+        color      : var(--fm-signal);
+        font-family: var(--fm-font-mono);
+        font-size  : 34px;
+        font-weight: 700;
+    }
+
+    .agentos-dockdemo-counter-note {
+        color      : var(--fm-ink-dim);
+        font-size  : 11px;
+        font-style : italic;
+    }
+}
+
+// the pop-out window: a bare stage for the reparented pane — full-bleed, token ground
+.agentos-dockdemo-popout-host {
+    background: var(--fm-ground);
+    padding   : 10px;
+
+    > * {
+        flex: 1;
+    }
+}

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
@@ -1,0 +1,172 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DockDemoWorkspaceBTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import '../../../../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
+import DemoBWorkspace from '../../../../../../../apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs';
+
+import {initialDocument} from '../../../../../../../apps/agentos/tour/demoBPerspectives.mjs';
+
+/**
+ * @summary Contract specs for the Demo-B workspace: the dock-holder contract, the live
+ * perspective capture→load round-trip over the real store, pane-instance permanence across
+ * re-projections, the pop-out bookkeeping guards, and the store-born switcher. The window
+ * side of pop-out (real popup + reparent) is live-surface behavior; the e2e sibling leaf
+ * owns it post-merge — these specs pin every seam the workspace itself decides.
+ */
+test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
+    let workspace;
+
+    test.beforeEach(() => {
+        workspace = Neo.create(DemoBWorkspace, {})
+    });
+
+    test.afterEach(() => {
+        workspace?.destroy?.();
+        workspace = null
+    });
+
+    test('the holder contract: an own cloned stage, readable before any operation', () => {
+        const doc = workspace.getDockZoneDocument();
+
+        expect(doc).not.toBe(initialDocument);
+        expect(doc.nodes.root.zones.center).toBe('workbench-tabs');
+        expect(doc.nodes['side-tabs'].items).toEqual(['inspector', 'timeline', 'console'])
+    });
+
+    test('capture → load round-trip through the REAL store: one committed swap, honest names', () => {
+        // capture the boot stage under a name
+        const captured = workspace.capturePerspective('Focus');
+
+        expect(captured.saved).toBe(true);
+        expect(captured.errors).toEqual([]);
+
+        // mutate the live document (a committed split)
+        const result = workspace.applyDockZoneOperation({
+            operation  : 'splitNode', itemId: 'timeline', targetNodeId: 'workbench-tabs',
+            orientation: 'vertical', edge: 'bottom'
+        });
+
+        expect(result.errors).toEqual([]);
+        workspace.dockModel = result.document;
+
+        expect(workspace.getDockZoneDocument().nodes['split-workbench-tabs-0']).toBeTruthy();
+
+        // loading the name restores the captured shape — the split is gone again
+        const loaded = workspace.loadPerspectiveByName('Focus');
+
+        expect(loaded.loaded).toBe(true);
+        expect(workspace.getDockZoneDocument().nodes['split-workbench-tabs-0']).toBeUndefined();
+        expect(workspace.getDockZoneDocument().nodes.root.zones.center).toBe('workbench-tabs')
+    });
+
+    test('loading an unknown perspective fails closed and mutates nothing', () => {
+        const before = JSON.stringify(workspace.getDockZoneDocument());
+        const loaded = workspace.loadPerspectiveByName('Nope');
+
+        expect(loaded.loaded).toBe(false);
+        expect(loaded.errors.join()).toContain('no perspective named');
+        expect(JSON.stringify(workspace.getDockZoneDocument())).toBe(before)
+    });
+
+    test('pane instances are PERMANENT: the same objects survive a re-projection', async () => {
+        const workbenchBefore = workspace.resolvePane('workbench', initialDocument.items.workbench);
+        const inspectorBefore = workspace.resolvePane('inspector', initialDocument.items.inspector);
+
+        await workspace.refreshDockWorkspace();
+
+        expect(workspace.resolvePane('workbench', initialDocument.items.workbench)).toBe(workbenchBefore);
+        expect(workspace.resolvePane('inspector', initialDocument.items.inspector)).toBe(inspectorBefore);
+        expect(workbenchBefore.isDestroyed).toBeFalsy()
+    });
+
+    test('popOutPane guards: unknown, uncached, and double detach all fail closed', async () => {
+        // unknown item: no cache entry, no home
+        let result = await workspace.popOutPane('ghost');
+        expect(result.detached).toBe(false);
+
+        // materialize the pane cache, then detach legitimately would need window seams —
+        // assert the DOUBLE-detach guard by staging the bookkeeping directly
+        workspace.resolvePane('workbench', initialDocument.items.workbench);
+        workspace.detachedPanes.workbench = {tabsNodeId: 'workbench-tabs', windowId: null};
+
+        result = await workspace.popOutPane('workbench');
+        expect(result.detached).toBe(false);
+        expect(result.errors.join()).toContain('workbench')
+    });
+
+    test('reattachPane falls back to the first tabs node when the remembered home left the tree', async () => {
+        // stage: pane cached, marked detached from a node that no longer exists,
+        // and the document no longer contains the item in any tabs node
+        workspace.resolvePane('workbench', initialDocument.items.workbench);
+
+        const detached = workspace.applyDockZoneOperation({operation: 'detachItem', itemId: 'workbench'});
+        expect(detached.errors).toEqual([]);
+        workspace.dockModel = detached.document;
+
+        workspace.detachedPanes.workbench = {tabsNodeId: 'vanished-tabs', windowId: null};
+
+        const result = await workspace.reattachPane('workbench', {windowAlreadyClosed: true});
+
+        expect(result.reattached).toBe(true);
+
+        const doc  = workspace.getDockZoneDocument();
+        const home = Object.keys(doc.nodes).find(id => doc.nodes[id].type === 'tabs' && doc.nodes[id].items.includes('workbench'));
+
+        expect(home, 'the returning pane found a real tabs home').toBeTruthy()
+    });
+
+    test('the switcher is BORN from store lifecycle: buttons appear per capture', () => {
+        const bar = workspace.getReference('switcher-bar');
+
+        expect(bar.items.length).toBe(1); // the label only, pre-capture
+
+        workspace.capturePerspective('Focus');
+        workspace.capturePerspective('Review');
+
+        const labels = bar.items.slice(1).map(item => item.text);
+
+        expect(labels).toEqual(['Focus', 'Review'])
+    });
+
+    test('re-capturing a name is the update flow, never a collision dispute', () => {
+        expect(workspace.capturePerspective('Focus').saved).toBe(true);
+
+        // mutate + re-capture under the same name (the tour-rerun path)
+        const result = workspace.applyDockZoneOperation({
+            operation  : 'splitNode', itemId: 'console', targetNodeId: 'side-tabs',
+            orientation: 'vertical', edge: 'bottom'
+        });
+        workspace.dockModel = result.document;
+
+        const recaptured = workspace.capturePerspective('Focus');
+
+        expect(recaptured.saved).toBe(true);
+        expect(recaptured.errors).toEqual([]);
+
+        // one button, not two — the store replaced, the switcher rebuilt
+        const bar = workspace.getReference('switcher-bar');
+        expect(bar.items.slice(1).map(item => item.text)).toEqual(['Focus'])
+    });
+
+    test('destroy tears down the runner, seam, store, and every cached pane', () => {
+        const pane                                        = workspace.resolvePane('workbench', initialDocument.items.workbench);
+        const {dockService, perspectiveStore, tourRunner} = workspace;
+
+        workspace.destroy();
+
+        expect(tourRunner.isDestroyed).toBeTruthy();
+        expect(dockService.isDestroyed).toBeTruthy();
+        expect(perspectiveStore.isDestroyed).toBeTruthy();
+        expect(pane.isDestroyed).toBeTruthy();
+
+        workspace = null
+    })
+});


### PR DESCRIPTION
Resolves #14590

## Deltas

**Demo B — the only-Neo showcase, first mergeable slice:** named single-workspace perspectives that morph, and a pane that leaves for its own OS window and returns with its live state unbroken.

- **`DemoBWorkspace`** lives beside Demo A and composes the reducer-container holder pattern with `DockPerspectiveStore`. The tour captures four named **window-scope** perspectives through `createSavedLayout()` → `savePerspective()`; loading one performs one committed document swap that the FLIP layer animates. The switcher is generated from store lifecycle events rather than hardcoded names.
- **Instance-cached panes** are created once and parked without destruction across every reprojection. `resolvePane()` returns the same live instances, so morphs, popup reparenting, and reattachment never remount a pane.
- **The pop-out moment** follows ADR 0029's detached-item shape: `detachItem` removes the pane from the primary tree while retaining its catalog record, the cached instance reparents into a popup on the same SharedWorker heap, and `addTab` returns it home. Manually closing the popup auto-reattaches it.
- **`CounterPane`** is the continuity witness. Its instance-bound seconds counter would reset on remount; the full tour proves it remains monotonic.
- **Detached-intent beat:** the `Detached` window-scope perspective is captured while the workbench renders in the popup. Reloading it truthfully preserves the worker-owned document's detached catalog state without persisting window identity or geometry. This is deliberately no longer described as changed-topology reconciliation or validation fail-closed behavior.
- **Viewport boot modes:** default → Demo A · `?demo=b` → Demo B · `?popout=<id>` → an empty render host for the same worker.

The changed-topology consumer originally bundled into #14590 is explicitly extracted to assigned child #15003: real main↔popup workspace documents, `captureTopologyPerspective()`, `DockTopologyReconciler.reconcile()`, and a visible `unrestored` / `displaced` report. This PR carries `Resolves #14590` for the delivered morph/pop-out demo while the extracted successor remains an independently tracked v13.2 gate.

## Contract Ledger

| Surface | Authority | This PR | Successor |
|---|---|---|---|
| Named perspective capture/load | `DockPerspectiveStore` + `dockLayout.v2` window scope | Captures and morphs four named layouts | — |
| Detached item popup | ADR 0029 §2.1 detached-item path | Same cached pane instance reparents across two render targets | — |
| Changed-topology restore | ADR 0029 §2.2 + `DockTopologyReconciler` | Not claimed | #15003 |
| Validation fail-closed | `restoreSavedLayout()` | Existing store guard retained | #15003 adds the visible topology consumer proof |

## Test Evidence

Evidence: L2 unit contracts + L3 live-surface probe receipts.

- **Unit:** 9/9 focused Demo-B specs at exact head after reviewer polish; the surrounding author run reported 197/197 for the AgentOS directory.
- **Live full-tour:** 28/28 beats; four store-born switcher entries; one real OS popup opened and closed; workbench visibly absent while detached; counter monotonic for the full tour; zero page errors.
- **Reviewer probe:** the counter advanced in the popup and after return, proving object continuity. The same audit identified the missing topology-reconciler consumer and split it to #15003 rather than mislabeling the current window-scope path.
- Hosted CI was fully green at the author head; exact-head CI reruns after the narrative-only polish.

## Post-Merge Validation

- [ ] Open `apps/agentos/childapps/dockdemo/index.html?demo=b`, run the tour twice, and confirm four captures, animated morphs, one OS-window round-trip, and an unbroken counter.
- [ ] Verify a manually closed popup auto-reattaches the same pane instance.
- [ ] Drive #15003 to complete #14590's changed-topology restore/report beat.

## Boundaries

- This PR consumes existing single-workspace perspective and detached-item semantics; it defines neither.
- Changed-topology capture/reconciliation is not silently claimed or closed here; #15003 is the assigned v13.2 child.
- Grouped drag and overflow remain future leaves per ADR 0029.
- #14945 remains the dense slot-assignment performance complement; this demo's future topology scene is two slots.

Authored by Clio (Claude Fable 5, Claude Code).
