### PR TITLE
feat(harness): E6 packaging pipeline — the double-clickable organism artifact, unsigned leg (#14994)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -433,7 +433,9 @@ class Config extends ConfigProvider {
              */
             engines: {
                 chroma: {
-                    dataDirProd: leaf(path.resolve(neoRootDir, '.neo-ai-data/chroma/unified')),
+                    // Env-bindable like its host/port siblings: a packaged harness ships the organism in a
+                    // read-only(ish) resources dir and must move the persist dir to a per-user data root.
+                    dataDirProd: leaf(path.resolve(neoRootDir, '.neo-ai-data/chroma/unified'), 'NEO_CHROMA_DATA_DIR', 'string'),
                     dataDirTest: leaf(chromaUnitTestDataDir, 'NEO_CHROMA_DATA_DIR_TEST', 'string'),
                     hostProd   : leaf('localhost', 'NEO_CHROMA_HOST', 'string'),
                     hostTest   : leaf('localhost', 'NEO_CHROMA_HOST_TEST', 'string'),

--- a/harness/.gitignore
+++ b/harness/.gitignore
@@ -1,5 +1,6 @@
 .brain/
 .stage/
 dist-artifacts/
+smoke-shot.png
 smoke-timeout.png
 node_modules/

--- a/harness/.gitignore
+++ b/harness/.gitignore
@@ -1,3 +1,5 @@
 .brain/
+.stage/
+dist-artifacts/
 smoke-timeout.png
 node_modules/

--- a/harness/README.md
+++ b/harness/README.md
@@ -91,6 +91,37 @@ after the recorded identity re-verifies — a bare PGID is an observation, not o
 rule governs attach: `fleetServing` requires the `listAgents` wire envelope, and a foreign
 listener squatting the fleet port fails the product boot closed instead of reading as a Brain.
 
+## Packaging (E6 — the unsigned leg)
+
+```bash
+cd harness
+npm run dist    # pack.mjs stages the organism, electron-builder emits dist-artifacts/*.zip
+```
+
+The artifact is ONE double-clickable app (unsigned — signing/notarization is release-line,
+operator-owned; never repo tooling) wrapping the ORGANISM: the renderer's source graph derived
+from the contentPolicy allowlist (one authority — a new allowlist prefix ships automatically),
+the Brain tree (`ai/`, minus examples and the not-yet-enabled temporal-summary daemon), a
+GENERATED dependency manifest (this repo declares only devDependencies, so the runtime closure
+is derived from the bundled trees' bare imports and pinned to repo-declared versions —
+fail-loud on any undeclared import), and a pack-time-fresh instance `ai/config.mjs` (generated
+from the staged template, so the packaged first boot never writes into the possibly read-only
+resources dir — and the checkout's gitignored operator overlay NEVER ships).
+
+**The packaged runtime arm (the decision the hosting spike recorded for this leaf):** Brain
+children run on the bundled Electron via `ELECTRON_RUN_AS_NODE`; the staged `node_modules` is
+rebuilt for Electron's ABI at pack time (`@electron/rebuild`, scoped to the stage — never the
+checkout, which must keep serving the system-Node dev loop). Shebang children (the chroma CLI)
+resolve `node` through the organism's `shims/` entry, which execs the bundled binary — a
+stranger's machine carries no Node. Mutable data lands under the per-user data root
+(`userData/brain`); a packaged own-mode boot FAILS CLOSED when a checkout Brain already holds
+the Chroma port (the coexistence guard — the spawned supervisor would otherwise reap it).
+
+Verification: the SAME smoke contract runs against the artifact —
+`NEO_HARNESS_SMOKE=1 NEO_HARNESS_BRAIN=1 "dist-artifacts/mac-arm64/Neo Harness.app/Contents/MacOS/Neo Harness"`.
+Known unsigned-leg limitation: a quarantined zip (browser download) may App-Translocate;
+`xattr -d com.apple.quarantine` or moving the app clears it — signing (E7) dissolves this.
+
 ## Why the window loads DEV MODE (operator decision, 2026-07-10)
 
 The harness window loads the zero-build SOURCE app (`app://neo/apps/agentos/index.html`), not

--- a/harness/README.md
+++ b/harness/README.md
@@ -104,21 +104,37 @@ from the contentPolicy allowlist (one authority — a new allowlist prefix ships
 the Brain tree (`ai/`, minus examples and the not-yet-enabled temporal-summary daemon), a
 GENERATED dependency manifest (this repo declares only devDependencies, so the runtime closure
 is derived from the bundled trees' bare imports and pinned to repo-declared versions —
-fail-loud on any undeclared import), and a pack-time-fresh instance `ai/config.mjs` (generated
-from the staged template, so the packaged first boot never writes into the possibly read-only
-resources dir — and the checkout's gitignored operator overlay NEVER ships).
+fail-loud on any undeclared import), and pack-time-fresh instance configs. **No checkout
+instance overlay ever ships:** any `config.mjs` with a `config.template.mjs` sibling — the
+top-level `ai/config.mjs` AND every per-server MCP overlay, all of which can carry hand-edited
+operator credentials — is excluded by DERIVATION, a post-copy assertion fails the build on any
+survivor, and the stage regenerates fresh template-defaults instances (which also means the
+packaged first boot never writes into the possibly read-only resources dir).
 
-**The packaged runtime arm (the decision the hosting spike recorded for this leaf):** Brain
-children run on the bundled Electron via `ELECTRON_RUN_AS_NODE`; the staged `node_modules` is
-rebuilt for Electron's ABI at pack time (`@electron/rebuild`, scoped to the stage — never the
-checkout, which must keep serving the system-Node dev loop). Shebang children (the chroma CLI)
-resolve `node` through the organism's `shims/` entry, which execs the bundled binary — a
-stranger's machine carries no Node. Mutable data lands under the per-user data root
-(`userData/brain`); a packaged own-mode boot FAILS CLOSED when a checkout Brain already holds
-the Chroma port (the coexistence guard — the spawned supervisor would otherwise reap it).
+**A packaged double-click BOOTS THE BRAIN by default** — Finder supplies no environment, so the
+product default is the supervised organism; `NEO_HARNESS_BRAIN=0` is the explicit opt-out (a
+checkout stays opt-in — see `brain.mjs#resolveBrainMode`). What it boots is
+`brain.mjs#buildPackagedBrainEnv` — THE packaged product profile: every mutable path (graph
+sqlite, Chroma, WAL, embed/message daemon state, backups, fleet root) under the per-user data
+root, plus the artifact's honest lane closure — each gated lane names a resource the bundle does
+not carry (webpack, git-checkout semantics, external model servers, cwd-relative writers); the
+embed + message organism lanes run. A packaged own-mode boot FAILS CLOSED when a checkout Brain
+already holds the Chroma port (the coexistence guard — the spawned supervisor would otherwise
+reap it).
 
-Verification: the SAME smoke contract runs against the artifact —
-`NEO_HARNESS_SMOKE=1 NEO_HARNESS_BRAIN=1 "dist-artifacts/mac-arm64/Neo Harness.app/Contents/MacOS/Neo Harness"`.
+**The packaged runtime arm:** Brain children run on the bundled Electron via
+`ELECTRON_RUN_AS_NODE`; the staged `node_modules` is rebuilt for Electron's ABI at pack time
+(`@electron/rebuild`, scoped to the stage — never the checkout, which must keep serving the
+system-Node dev loop). **A rebuild failure FAILS THE BUILD** — ABI-compat of a system-Node build
+under electron-as-node is not a guaranteed contract, and a silently mis-built native is a broken
+artifact. Shebang children (the chroma CLI) resolve `node` through the organism's `shims/`
+entry, which execs the bundled binary — a stranger's machine carries no Node.
+
+Verification: `NEO_HARNESS_SMOKE=1 "dist-artifacts/mac-arm64/Neo Harness.app/Contents/MacOS/Neo Harness"`
+— no Brain env, deliberately: the smoke proves the double-click default and runs the EXACT
+product profile (`profileMode: 'packaged-product'` in the verdict), shifted only in COORDINATES
+(allocated ports + a throwaway data root) so a dev box's live Brain is never touched. The
+checkout smoke keeps the fully isolated dev profile (`checkout-isolated`).
 Known unsigned-leg limitation: a quarantined zip (browser download) may App-Translocate;
 `xattr -d com.apple.quarantine` or moving the app clears it — signing (E7) dissolves this.
 

--- a/harness/afterPack.cjs
+++ b/harness/afterPack.cjs
@@ -1,0 +1,29 @@
+// electron-builder afterPack hook (CJS — the hook is require()d): completes the organism payload.
+// The builder's extraResources copier hard-ignores node_modules regardless of filter globs, but
+// the STAGED install (rebuilt for the bundled Electron) IS the runtime payload — without it,
+// children silently resolve a checkout's system-ABI native modules through the filesystem walk-up
+// (measured: ABI 141 vs 148 load failure), and the renderer's fontawesome allowlist entries 404.
+'use strict';
+
+const fs   = require('node:fs');
+const path = require('node:path');
+
+module.exports = async function afterPack(context) {
+    const
+        appName       = `${context.packager.appInfo.productFilename}.app`,
+        organismDir   = path.join(context.appOutDir, appName, 'Contents', 'Resources', 'organism'),
+        stagedModules = path.join(__dirname, '.stage', 'organism', 'node_modules'),
+        targetModules = path.join(organismDir, 'node_modules');
+
+    if (!fs.existsSync(stagedModules)) {
+        throw new Error(`afterPack: staged organism node_modules missing at ${stagedModules} — run pack.mjs first`)
+    }
+
+    fs.rmSync(targetModules, {force: true, recursive: true});
+    // verbatimSymlinks keeps npm's .bin links intact (the chroma CLI resolution rides them).
+    fs.cpSync(stagedModules, targetModules, {recursive: true, verbatimSymlinks: true});
+
+    const entryCount = fs.readdirSync(targetModules).length;
+
+    console.log(`  • afterPack: organism node_modules completed (${entryCount} top-level entries)`)
+};

--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -45,6 +45,20 @@ function nodeBin() {
 }
 
 /**
+ * @summary The Brain-boot default per launch context. A PACKAGED app is the product — a Finder
+ * double-click supplies no environment, so the Brain boots by default with `NEO_HARNESS_BRAIN=0`
+ * as the explicit opt-out. A CHECKOUT run stays opt-in (`=1`): dev machines carry a canonical
+ * Brain, and the harness UI alone must never surprise-spawn a supervised organism beside it.
+ * @param {Object} options
+ * @param {Boolean} options.packaged `app.isPackaged` at the call site.
+ * @param {Object} options.env The process env (injectable for tests).
+ * @returns {Boolean}
+ */
+export function resolveBrainMode({packaged, env}) {
+    return packaged ? env.NEO_HARNESS_BRAIN !== '0' : env.NEO_HARNESS_BRAIN === '1'
+}
+
+/**
  * @summary Allocates a free loopback TCP port via a zero-port listen. The classic race (another
  * process binding between close and child bind) is accepted: the child's own bind failure exits
  * it early, which the readiness contract converts into a deterministic boot rejection.
@@ -219,22 +233,52 @@ export function resolveRealPath(value) {
 }
 
 /**
- * @summary Builds the PACKAGED product data profile: the organism ships in a read-only(ish)
- * resources dir, so every mutable path moves to the per-user data root — the same leaves the
- * smoke profile binds, WITHOUT the lane gates, test mode, or port shifts (the packaged app runs
- * the real organism on the default ports; a fresh machine has nothing to collide with).
+ * @summary THE packaged product profile — the one resource-closure contract for an installed
+ * artifact, consumed identically by the product boot AND the packaged smoke (the smoke may shift
+ * only COORDINATES — ports/data root — never this lane set, or it stops proving the artifact).
+ *
+ * Mutable paths move to the per-user data root (the organism ships in a read-only(ish) resources
+ * dir). Lane gates encode what an INSTALLED organism can honestly run — each OFF names the
+ * resource the artifact does not carry:
+ * - devServer: no webpack/build tooling ships; `app://` serves the bundled source graph.
+ * - kbSync / githubWorkflowSync / primaryDevSync / goldenPathRepoEnrichment: git-checkout
+ *   semantics; the bundle carries the source graph but is not a repository.
+ * - mlx / ollama / lms: external model servers belong to the MACHINE, not the artifact — a
+ *   packaged supervisor must never adopt or reap a stranger's local AI runtimes.
+ * - neuralLinkBridge: a default-on listener is its own product decision (the ADR E-map owns it).
+ * - deploymentStateBridge: its snapshot path is still cwd-relative and would write into the
+ *   resources dir.
+ * ON by omission (the organism the artifact CAN run): Chroma, the embed + message daemons,
+ * backups (target rides `NEO_BACKUP_PATH`), and local graph maintenance.
  * @param {Object} options
  * @param {String} options.dataRoot Writable per-user root (Electron `userData`-derived).
  * @returns {Object} env fragment to merge over process.env
  */
-export function buildPackagedDataEnv({dataRoot}) {
+export function buildPackagedBrainEnv({dataRoot}) {
     return {
-        NEO_AI_DB_PATH         : path.join(dataRoot, 'sqlite', 'memory-core-graph.sqlite'),
-        NEO_AI_ORCHESTRATOR_DIR: path.join(dataRoot, 'orchestrator'),
-        NEO_BACKUP_PATH        : path.join(dataRoot, 'backups'),
-        NEO_CHROMA_DATA_DIR    : path.join(dataRoot, 'chroma', 'unified'),
-        NEO_FLEET_INSTANCE_ROOT: path.join(dataRoot, 'fleet', 'instances'),
-        NEO_REM_RUN_STATE_DIR  : path.join(dataRoot, 'rem-runs')
+        // Mutable paths → the per-user data root. The WAL + embed/message daemon state dirs are
+        // cwd-relative by default, and cwd is the read-only(ish) organism dir when packaged.
+        NEO_AI_DB_PATH             : path.join(dataRoot, 'sqlite', 'memory-core-graph.sqlite'),
+        NEO_AI_ORCHESTRATOR_DIR    : path.join(dataRoot, 'orchestrator'),
+        NEO_BACKUP_PATH            : path.join(dataRoot, 'backups'),
+        NEO_CHROMA_DATA_DIR        : path.join(dataRoot, 'chroma', 'unified'),
+        NEO_FLEET_INSTANCE_ROOT    : path.join(dataRoot, 'fleet', 'instances'),
+        NEO_MEMORY_EMBED_DAEMON_DIR: path.join(dataRoot, 'embed-daemon'),
+        NEO_MEMORY_WAL_DIR         : path.join(dataRoot, 'memory-wal'),
+        NEO_MESSAGE_WAL_DAEMON_DIR : path.join(dataRoot, 'message-daemon'),
+        NEO_REM_RUN_STATE_DIR      : path.join(dataRoot, 'rem-runs'),
+
+        // The artifact's lane closure (reasons in the summary above)
+        NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED                 : '0',
+        NEO_ORCHESTRATOR_DEV_SERVER_ENABLED                 : '0',
+        NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_ENABLED       : '0',
+        NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED: '0',
+        NEO_ORCHESTRATOR_KB_SYNC_ENABLED                    : '0',
+        NEO_ORCHESTRATOR_LMS_ENABLED                        : '0',
+        NEO_ORCHESTRATOR_MLX_ENABLED                        : '0',
+        NEO_ORCHESTRATOR_NL_BRIDGE_ENABLED                  : '0',
+        NEO_ORCHESTRATOR_OLLAMA_ENABLED                     : '0',
+        NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED           : '0'
     }
 }
 

--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -219,6 +219,26 @@ export function resolveRealPath(value) {
 }
 
 /**
+ * @summary Builds the PACKAGED product data profile: the organism ships in a read-only(ish)
+ * resources dir, so every mutable path moves to the per-user data root — the same leaves the
+ * smoke profile binds, WITHOUT the lane gates, test mode, or port shifts (the packaged app runs
+ * the real organism on the default ports; a fresh machine has nothing to collide with).
+ * @param {Object} options
+ * @param {String} options.dataRoot Writable per-user root (Electron `userData`-derived).
+ * @returns {Object} env fragment to merge over process.env
+ */
+export function buildPackagedDataEnv({dataRoot}) {
+    return {
+        NEO_AI_DB_PATH         : path.join(dataRoot, 'sqlite', 'memory-core-graph.sqlite'),
+        NEO_AI_ORCHESTRATOR_DIR: path.join(dataRoot, 'orchestrator'),
+        NEO_BACKUP_PATH        : path.join(dataRoot, 'backups'),
+        NEO_CHROMA_DATA_DIR    : path.join(dataRoot, 'chroma', 'unified'),
+        NEO_FLEET_INSTANCE_ROOT: path.join(dataRoot, 'fleet', 'instances'),
+        NEO_REM_RUN_STATE_DIR  : path.join(dataRoot, 'rem-runs')
+    }
+}
+
+/**
  * @summary Verifies the RESOLVED leaves against the isolation contract: every mutable path under
  * the isolation root BY FILESYSTEM IDENTITY (ancestor symlinks resolved on both sides), every
  * probed port the allocated one. Run against `resolveBrainPaths` output so the assertion covers
@@ -371,11 +391,18 @@ export function startBrainChild({
     // The supervised tree resolves bare tool commands (the orchestrator's `chroma` task) via PATH.
     // npm-run contexts prepend the repo's node_modules/.bin by accident of cwd; a packaged shell
     // has no npm in the chain at all — so the lifecycle owner guarantees the resolution explicitly.
+    // The packaged organism additionally carries a `shims/` dir (a `node` shim routing shebang
+    // children onto the bundled Electron runtime — a stranger's machine has no Node); absent in
+    // checkout mode, so the prepend is conditional.
     const
         absoluteRepoRoot = path.resolve(repoRoot),
         absoluteEntry    = path.resolve(absoluteRepoRoot, entry),
         relativeEntry    = path.relative(absoluteRepoRoot, absoluteEntry),
-        binPath          = path.join(absoluteRepoRoot, 'node_modules', '.bin'),
+        shimsPath        = path.join(absoluteRepoRoot, 'shims'),
+        binPaths         = [
+            ...(fs.existsSync(shimsPath) ? [shimsPath] : []),
+            path.join(absoluteRepoRoot, 'node_modules', '.bin')
+        ],
         ownershipToken   = ownershipTokenFn();
 
     if (relativeEntry === '..' || relativeEntry.startsWith(`..${path.sep}`) || path.isAbsolute(relativeEntry)) {
@@ -389,7 +416,7 @@ export function startBrainChild({
     const child = spawnFn(nodeBin(), [absoluteEntry, `--neo-harness-owner=${ownershipToken}`], {
         cwd     : absoluteRepoRoot,
         detached: true,
-        env     : {...process.env, ...env, PATH: `${binPath}${path.delimiter}${process.env.PATH ?? ''}`},
+        env     : {...process.env, ...env, PATH: `${binPaths.join(path.delimiter)}${path.delimiter}${process.env.PATH ?? ''}`},
         stdio   : ['ignore', 'pipe', 'pipe']
     });
 

--- a/harness/contentPolicy.mjs
+++ b/harness/contentPolicy.mjs
@@ -30,19 +30,24 @@ export const REQUIRED_ASSET_PATHS = Object.freeze([
     '/resources/theme-map.json'
 ]);
 
+// Exported (read-only) because the packaging pipeline derives its bundle manifest FROM this
+// allowlist — one authority for "what the renderer may load" and "what the artifact must carry".
+export const ALLOWED_EXACT_PATHS = Object.freeze([
+    '/node_modules/@fortawesome/fontawesome-free/css/all.min.css',
+    '/resources/images/logo/neo_logo_primary.svg',
+    '/resources/theme-map.json'
+]);
+
+export const ALLOWED_PATH_PREFIXES = Object.freeze([
+    '/apps/agentos/',
+    '/dist/development/css/',
+    '/node_modules/@fortawesome/fontawesome-free/webfonts/',
+    '/src/'
+]);
+
 const
-    ALLOWED_EXACT_PATHS = new Set([
-        '/node_modules/@fortawesome/fontawesome-free/css/all.min.css',
-        '/resources/images/logo/neo_logo_primary.svg',
-        '/resources/theme-map.json'
-    ]),
-    ALLOWED_PATH_PREFIXES = Object.freeze([
-        '/apps/agentos/',
-        '/dist/development/css/',
-        '/node_modules/@fortawesome/fontawesome-free/webfonts/',
-        '/src/'
-    ]),
-    MIME_TYPES = Object.freeze({
+    ALLOWED_EXACT_PATH_SET = new Set(ALLOWED_EXACT_PATHS),
+    MIME_TYPES             = Object.freeze({
         '.avif' : 'image/avif',
         '.css'  : 'text/css; charset=utf-8',
         '.gif'  : 'image/gif',
@@ -108,7 +113,7 @@ export function parseHarnessUrl(value) {
  * @returns {Boolean}
  */
 export function isAllowedHarnessAssetPath(pathname) {
-    return ALLOWED_EXACT_PATHS.has(pathname) ||
+    return ALLOWED_EXACT_PATH_SET.has(pathname) ||
         ALLOWED_PATH_PREFIXES.some(prefix => pathname.startsWith(prefix))
 }
 
@@ -166,10 +171,10 @@ export async function createHarnessAssetResolver(repoRoot) {
             return {
                 contentType: MIME_TYPES[path.extname(canonicalFile).toLowerCase()] ?? 'application/octet-stream',
                 filePath   : canonicalFile,
-                isDocument: path.extname(canonicalFile).toLowerCase() === '.html',
-                ok        : true,
-                pathname  : parsed.pathname,
-                reason    : 'allowed'
+                isDocument : path.extname(canonicalFile).toLowerCase() === '.html',
+                ok         : true,
+                pathname   : parsed.pathname,
+                reason     : 'allowed'
             }
         } catch {
             return {ok: false, pathname: parsed.pathname, reason: 'missing'}

--- a/harness/electron-builder.yml
+++ b/harness/electron-builder.yml
@@ -1,0 +1,37 @@
+# The E6 packaging pipeline — the UNSIGNED leg (ADR 0034 §2.5.2: signing material is a
+# release-line concern and never enters repo tooling; `identity: null` skips code-signing so the
+# artifact stays CI/dev-verifiable). The organism (allowlist-derived source graph + Brain tree +
+# generated dependency install) is staged by pack.mjs and shipped verbatim as extraResources.
+appId: mjs.neo.harness
+productName: Neo Harness
+# No publish provider and no auto-update metadata: the update channel is the E7 leaf (§2.5.3).
+publish: null
+directories:
+    output: dist-artifacts
+
+files:
+    - main.mjs
+    - brain.mjs
+    - contentPolicy.mjs
+    - preload.cjs
+    - package.json
+
+extraResources:
+    - from: .stage/organism
+      to: organism
+
+# The organism's node_modules ride an afterPack hook: the extraResources copier hard-ignores
+# node_modules regardless of filter globs, and the staged install (rebuilt for the bundled
+# Electron) IS the runtime payload — see afterPack.cjs for the measured failure it prevents.
+afterPack: ./afterPack.cjs
+
+# The staged organism manages its own dependency install (pack.mjs); the shell itself has no
+# runtime deps to rebuild.
+npmRebuild: false
+
+mac:
+    target:
+        - target: zip
+          arch: arm64
+    identity: null
+    category: public.app-category.developer-tools

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -624,6 +624,21 @@ app.whenReady().then(async () => {
 
     await awaitRequiredAssets();
 
+    // The VISUAL verdict: mounted-node counts and asset probes cannot see a broken layout (stale
+    // built themes, corrupted template data — a live incident shipped exactly that). Every smoke
+    // run captures the primary window so a human — or the next agent — can LOOK at what actually
+    // rendered. Packaged mode writes to userData (the app bundle is read-only-ish).
+    try {
+        const
+            image    = await win1.capturePage(),
+            shotPath = path.join(packagedMode ? app.getPath('userData') : harnessDir, 'smoke-shot.png');
+
+        (await import('node:fs')).writeFileSync(shotPath, image.toPNG());
+        console.log('HARNESS_SMOKE_SHOT ' + shotPath)
+    } catch (error) {
+        console.log('HARNESS_SMOKE_SHOT_FAIL ' + error.message)
+    }
+
     // The Brain leg (Arm B): the isolated organism proven through its OWN consumable surfaces —
     // the resolved-leaf isolation matrix, genuine orchestrator + fleet readiness, a REAL wire
     // verb from the renderer (the AC's "window reaches the fleet transport"), then full-tree

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -49,11 +49,15 @@ import {
 } from './brain.mjs';
 
 const
-    harnessDir = path.dirname(fileURLToPath(import.meta.url)),
-    repoRoot   = path.resolve(harnessDir, '..'),
+    harnessDir   = path.dirname(fileURLToPath(import.meta.url)),
+    repoRoot     = path.resolve(harnessDir, '..'),
+    packagedMode = app.isPackaged,
+    // The organism root: the repo checkout in dev, the bundled resources tree when packaged (the
+    // pack stage stages the SAME allowlist-derived source graph — §2.6 one-boot-path parity).
+    organismRoot = packagedMode ? path.join(process.resourcesPath, 'organism') : repoRoot,
     // DEV MODE, deliberately (operator decision 2026-07-10): the harness window loads the
     // zero-build SOURCE app — Neural Link possession needs real ESM, which minification destroys.
-    APP_URL    = `app://${APP_HOST}/apps/agentos/index.html`,
+    APP_URL      = `app://${APP_HOST}/apps/agentos/index.html`,
     smokeMode  = process.env.NEO_HARNESS_SMOKE === '1',
     // The Arm-B Brain leg (opt-in): the main supervises the orchestrator daemon as a system-Node
     // child. Isolated env by default — on a dev machine the daemon's single-instance takeover
@@ -68,6 +72,12 @@ const
     bootWaiters = new Map();
 
 let resolveHarnessAsset;
+
+// Packaged mode: every parent-side child spawn (Brain children, the config resolver) runs on the
+// bundled Electron runtime — the packaged env fragments add ELECTRON_RUN_AS_NODE per child.
+if (packagedMode && !process.env.NEO_HARNESS_NODE_BIN) {
+    process.env.NEO_HARNESS_NODE_BIN = process.execPath
+}
 
 protocol.registerSchemesAsPrivileged([
     {scheme: 'app', privileges: {standard: true, secure: true, supportFetchAPI: true}}
@@ -421,14 +431,33 @@ async function teardownBrain() {
  * @returns {Promise<Object>}
  */
 async function bootProductBrain() {
+    // Packaged mode: the organism ships read-only(ish), so every mutable path moves to the
+    // per-user data root, and Brain children (plus shebang grandchildren via the organism's node
+    // shim) run on the BUNDLED Electron runtime — a stranger's machine carries no Node.
+    const packagedEnv = packagedMode
+        ? {
+            ...buildPackagedDataEnv({dataRoot: path.join(app.getPath('userData'), 'brain')}),
+            ELECTRON_RUN_AS_NODE    : '1',
+            NEO_HARNESS_ELECTRON_BIN: process.execPath
+        }
+        : {};
+
     const
         fleetPort = Number(process.env.NEO_FLEET_PORT) || 8083,
-        paths     = await resolveBrainPaths({repoRoot}),
+        paths     = await resolveBrainPaths({env: packagedEnv, repoRoot: organismRoot}),
         live      = await detectLiveBrain({fleetPort, orchestratorDataDir: paths.orchestratorDataDir}),
         mode      = live.orchestratorAlive ? 'attach' : 'own';
 
     if (mode === 'own') {
-        const orchestrator = startBrainChild({entry: ORCHESTRATOR_ENTRY, onLog: brainLog, repoRoot});
+        // Coexistence guard (dev machines): a packaged app's own-mode organism runs the DEFAULT
+        // ports — a checkout Brain's Chroma already on that port would be REAPED by the spawned
+        // supervisor (singleton-port reconciliation). A held Chroma port without a serving fleet
+        // fails the boot closed instead.
+        if (packagedMode && await probePort({host: 'localhost', port: paths.chromaPort})) {
+            throw new Error(`chroma port ${paths.chromaPort} is already held (a checkout Brain?) — the packaged harness cannot own an organism beside it`)
+        }
+
+        const orchestrator = startBrainChild({entry: ORCHESTRATOR_ENTRY, env: packagedEnv, onLog: brainLog, repoRoot: organismRoot});
 
         brainState.children.push({child: orchestrator, label: 'orchestrator'});
         await awaitOrchestratorReady({child: orchestrator})
@@ -443,10 +472,10 @@ async function bootProductBrain() {
         }
 
         const fleet = startBrainChild({
-            entry: FLEET_SERVER_ENTRY,
-            env  : {NEO_FLEET_PORT: String(fleetPort)},
-            onLog: brainLog,
-            repoRoot
+            entry   : FLEET_SERVER_ENTRY,
+            env     : {...packagedEnv, NEO_FLEET_PORT: String(fleetPort)},
+            onLog   : brainLog,
+            repoRoot: organismRoot
         });
 
         brainState.children.push({child: fleet, label: 'fleet'});
@@ -467,11 +496,13 @@ async function bootProductBrain() {
  */
 async function bootSmokeBrain() {
     const
-        isolationRoot           = process.env.NEO_HARNESS_BRAIN_ROOT || path.join(harnessDir, '.brain', 'smoke'),
+        isolationRoot           = process.env.NEO_HARNESS_BRAIN_ROOT ||
+            (packagedMode ? path.join(app.getPath('userData'), 'smoke') : path.join(harnessDir, '.brain', 'smoke')),
         sweptPgids              = sweepStaleRunState({isolationRoot}),
         [chromaPort, fleetPort] = await Promise.all([allocatePort(), allocatePort()]),
-        profile                 = buildBrainProfile({chromaPort, fleetPort, isolationRoot}),
-        resolved                = await resolveBrainPaths({env: profile, repoRoot}),
+        packagedRuntimeEnv      = packagedMode ? {ELECTRON_RUN_AS_NODE: '1', NEO_HARNESS_ELECTRON_BIN: process.execPath} : {},
+        profile                 = {...buildBrainProfile({chromaPort, fleetPort, isolationRoot}), ...packagedRuntimeEnv},
+        resolved                = await resolveBrainPaths({env: profile, repoRoot: organismRoot}),
         matrixViolations        = assertIsolatedProfile({chromaPort, isolationRoot, resolved});
 
     if (matrixViolations.length > 0) {
@@ -479,8 +510,8 @@ async function bootSmokeBrain() {
     }
 
     const
-        orchestrator = startBrainChild({entry: ORCHESTRATOR_ENTRY, env: profile, onLog: brainLog, repoRoot}),
-        fleet        = startBrainChild({entry: FLEET_SERVER_ENTRY, env: profile, onLog: brainLog, repoRoot});
+        orchestrator = startBrainChild({entry: ORCHESTRATOR_ENTRY, env: profile, onLog: brainLog, repoRoot: organismRoot}),
+        fleet        = startBrainChild({entry: FLEET_SERVER_ENTRY, env: profile, onLog: brainLog, repoRoot: organismRoot});
 
     brainState.children.push(
         {child: orchestrator, ...orchestrator.neoHarnessIdentity, label: 'orchestrator'},
@@ -514,7 +545,7 @@ app.on('will-quit', async event => {
 });
 
 app.whenReady().then(async () => {
-    resolveHarnessAsset = await createHarnessAssetResolver(repoRoot);
+    resolveHarnessAsset = await createHarnessAssetResolver(organismRoot);
     await protocol.handle('app', serveHarnessContent);
 
     // §2.3.3 deny-by-default; Electron requires BOTH handlers for complete permission coverage.

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -36,11 +36,13 @@ import {
     awaitOrchestratorReady,
     awaitPortListening,
     buildBrainProfile,
+    buildPackagedBrainEnv,
     clearRunState,
     detectLiveBrain,
     FLEET_SERVER_ENTRY,
     ORCHESTRATOR_ENTRY,
     probePort,
+    resolveBrainMode,
     resolveBrainPaths,
     startBrainChild,
     stopBrainTree,
@@ -59,10 +61,10 @@ const
     // zero-build SOURCE app — Neural Link possession needs real ESM, which minification destroys.
     APP_URL      = `app://${APP_HOST}/apps/agentos/index.html`,
     smokeMode  = process.env.NEO_HARNESS_SMOKE === '1',
-    // The Arm-B Brain leg (opt-in): the main supervises the orchestrator daemon as a system-Node
-    // child. Isolated env by default — on a dev machine the daemon's single-instance takeover
-    // would otherwise SIGTERM the canonical Brain (see brain.mjs).
-    brainMode  = process.env.NEO_HARNESS_BRAIN === '1',
+    // The Arm-B Brain leg: DEFAULT-ON when packaged (a Finder double-click supplies no env — the
+    // product IS the supervised organism; NEO_HARNESS_BRAIN=0 is the explicit opt-out) and opt-in
+    // on a checkout (dev machines carry a canonical Brain; see brain.mjs#resolveBrainMode).
+    brainMode  = resolveBrainMode({env: process.env, packaged: packagedMode}),
     smokeState = {
         assetFailures : new Set(),
         assetsSeen    : new Set(),
@@ -436,7 +438,7 @@ async function bootProductBrain() {
     // shim) run on the BUNDLED Electron runtime — a stranger's machine carries no Node.
     const packagedEnv = packagedMode
         ? {
-            ...buildPackagedDataEnv({dataRoot: path.join(app.getPath('userData'), 'brain')}),
+            ...buildPackagedBrainEnv({dataRoot: path.join(app.getPath('userData'), 'brain')}),
             ELECTRON_RUN_AS_NODE    : '1',
             NEO_HARNESS_ELECTRON_BIN: process.execPath
         }
@@ -487,11 +489,16 @@ async function bootProductBrain() {
 }
 
 /**
- * The smoke Brain boot — the fully ISOLATED profile: allocate ports, bind every mutable path
- * under a throwaway root, then assert the isolation matrix THROUGH the config SSOT before
- * anything spawns. Readiness is genuine service readiness (orchestrator poll-loop marker + a
- * real fleet wire-verb round-trip), never PID existence.
- * @summary Boots the isolated smoke organism, returning every observable the verdict gates on.
+ * The smoke Brain boot. TWO profile shapes, deliberately distinct:
+ * - **Packaged:** the EXACT product profile (`buildPackagedBrainEnv` — the artifact's lane and
+ *   resource closure, unreduced), shifted only in COORDINATES: allocated Chroma/fleet ports and a
+ *   throwaway data root, so a dev box's live Brain is never touched while the smoke still proves
+ *   what a real double-click boots.
+ * - **Checkout:** the fully isolated dev profile (`buildBrainProfile` — every side lane gated),
+ *   because a checkout smoke runs beside a canonical organism whose lanes must not double-run.
+ * Both assert the isolation matrix THROUGH the config SSOT before anything spawns; readiness is
+ * genuine service readiness (poll-loop marker + a real fleet wire verb), never PID existence.
+ * @summary Boots the smoke organism under the mode-correct profile, returning every observable.
  * @returns {Promise<Object>}
  */
 async function bootSmokeBrain() {
@@ -500,8 +507,15 @@ async function bootSmokeBrain() {
             (packagedMode ? path.join(app.getPath('userData'), 'smoke') : path.join(harnessDir, '.brain', 'smoke')),
         sweptPgids              = sweepStaleRunState({isolationRoot}),
         [chromaPort, fleetPort] = await Promise.all([allocatePort(), allocatePort()]),
-        packagedRuntimeEnv      = packagedMode ? {ELECTRON_RUN_AS_NODE: '1', NEO_HARNESS_ELECTRON_BIN: process.execPath} : {},
-        profile                 = {...buildBrainProfile({chromaPort, fleetPort, isolationRoot}), ...packagedRuntimeEnv},
+        profile                 = packagedMode
+            ? {
+                ...buildPackagedBrainEnv({dataRoot: isolationRoot}),
+                ELECTRON_RUN_AS_NODE    : '1',
+                NEO_CHROMA_PORT         : String(chromaPort),
+                NEO_FLEET_PORT          : String(fleetPort),
+                NEO_HARNESS_ELECTRON_BIN: process.execPath
+            }
+            : buildBrainProfile({chromaPort, fleetPort, isolationRoot}),
         resolved                = await resolveBrainPaths({env: profile, repoRoot: organismRoot}),
         matrixViolations        = assertIsolatedProfile({chromaPort, isolationRoot, resolved});
 
@@ -532,7 +546,15 @@ async function bootSmokeBrain() {
         awaitFleetReady({child: fleet, port: fleetPort})
     ]);
 
-    return {chromaPort, fleetPort, isolationRoot, matrixViolations, sweptPgids, up: true}
+    return {
+        chromaPort,
+        fleetPort,
+        isolationRoot,
+        matrixViolations,
+        profileMode: packagedMode ? 'packaged-product' : 'checkout-isolated',
+        sweptPgids,
+        up         : true
+    }
 }
 
 app.on('will-quit', async event => {

--- a/harness/pack.mjs
+++ b/harness/pack.mjs
@@ -13,12 +13,11 @@
 //           a minified bundle
 //
 // Native-module runtime decision (the arm this leaf owns, recorded on its ticket): Brain children
-// run under ELECTRON_RUN_AS_NODE. Measured on darwin/Electron 43: a system-Node-built
-// better-sqlite3 (ABI 141) LOADS AND RUNS under electron-as-node (ABI 148) — the dev-tree
-// falsifier was a BROWSER-process incompatibility, not a node-mode one. The stage still attempts
-// @electron/rebuild against the staged tree (never the checkout — rebuilding the shared dev
-// node_modules is the recorded kill-the-dev-loop trap); a rebuild failure downgrades to the
-// measured as-is arm and records it in the build info.
+// run under ELECTRON_RUN_AS_NODE, and the staged node_modules is REBUILT for the bundled
+// Electron's ABI via @electron/rebuild — scoped to the stage, never the checkout (rebuilding the
+// shared dev node_modules is the recorded kill-the-dev-loop trap). A rebuild failure FAILS THE
+// BUILD: ABI-compat of a system-Node build under electron-as-node is not a guaranteed contract
+// (independent probes disagreed), and a silently mis-built native module is a broken artifact.
 
 import {execFileSync}                               from 'node:child_process';
 import fs                                           from 'node:fs';
@@ -53,12 +52,49 @@ export const TREE_EXCLUDES = Object.freeze([
     'ai/daemons/temporal-summary'
 ]);
 
-// Checkout-instance files that must NEVER ship: the gitignored operator config overlay (it CAN
-// carry hand-edited values — the artifact gets a pack-time-fresh template-generated instance
-// instead) and any env file. Matched exactly or by basename pattern in the copy filter.
-export const INSTANCE_FILE_EXCLUDES = Object.freeze([
-    'ai/config.mjs'
-]);
+/**
+ * @summary True when a repo-relative path is a checkout-instance CONFIG OVERLAY — a `config.mjs`
+ * with a `config.template.mjs` sibling. The template marks the overlay slot, so the rule is
+ * DERIVED, never an enumerated list: every gitignored operator overlay (the top-level
+ * `ai/config.mjs` AND each per-server `ai/mcp/server/<name>/config.mjs`) can carry hand-edited
+ * credentials and must never ship; the stage regenerates fresh template-defaults instances. A tracked
+ * standalone `config.mjs` (no template sibling) is ordinary source and ships normally.
+ * @param {String} sourceRoot Absolute root the relative path resolves against.
+ * @param {String} relativePath Repo-relative candidate path.
+ * @returns {Boolean}
+ */
+export function isInstanceOverlayPath(sourceRoot, relativePath) {
+    return path.basename(relativePath) === 'config.mjs' &&
+        fs.existsSync(path.join(sourceRoot, path.dirname(relativePath), 'config.template.mjs'))
+}
+
+/**
+ * @summary Belt-and-braces post-copy assertion: the staged tree must contain ZERO instance
+ * overlays before the fresh-config generation runs. A filter regression here is a
+ * credential-shipping vector, so it fails the build loudly rather than trusting one predicate.
+ * @param {String} stageDir
+ */
+export function assertNoInstanceOverlays(stageDir) {
+    const offenders = [];
+
+    const walk = dir => {
+        for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+            const fullPath = path.join(dir, entry.name);
+
+            if (entry.isDirectory()) {
+                walk(fullPath)
+            } else if (isInstanceOverlayPath(stageDir, path.relative(stageDir, fullPath))) {
+                offenders.push(path.relative(stageDir, fullPath))
+            }
+        }
+    };
+
+    walk(stageDir);
+
+    if (offenders.length > 0) {
+        throw new Error(`pack: checkout instance overlay(s) reached the stage — refusing to ship: ${offenders.join(', ')}`)
+    }
+}
 
 // Dependencies the bare-import scan cannot see: CSS-linked packages (fontawesome) and
 // dynamic-provider modules resolved at runtime.
@@ -249,7 +285,7 @@ function copyTree(sourceRoot, targetRoot, relative) {
             const rel = path.relative(sourceRoot, entry);
 
             return !TREE_EXCLUDES.some(exclude => rel === exclude || rel.startsWith(exclude + path.sep)) &&
-                !INSTANCE_FILE_EXCLUDES.includes(rel) &&
+                !isInstanceOverlayPath(sourceRoot, rel) &&
                 !/(^|\/)(node_modules|\.git)(\/|$)/.test(rel) &&
                 !/(^|\/)\.env(\.|$)/.test(rel) &&
                 !rel.endsWith('.DS_Store')
@@ -272,6 +308,10 @@ function run(command, args, options = {}) {
  * @returns {Object} build info (also written to `<stageDir>/organism-build-info.json`).
  */
 export function stageOrganism({stageDir = STAGE_DIR, electronVersion} = {}) {
+    if (!electronVersion) {
+        throw new Error('pack: electronVersion is required — the staged natives MUST target the bundled runtime ABI.')
+    }
+
     fs.rmSync(stageDir, {force: true, recursive: true});
     fs.mkdirSync(stageDir, {recursive: true});
 
@@ -286,6 +326,10 @@ export function stageOrganism({stageDir = STAGE_DIR, electronVersion} = {}) {
         fs.copyFileSync(path.join(repoRoot, file), path.join(stageDir, file))
     }
 
+    // Security stop-line: no checkout instance overlay may exist in the stage BEFORE the fresh
+    // template-defaults generation below. Runs pre-install so the walk stays cheap.
+    assertNoInstanceOverlays(stageDir);
+
     const
         repoPackageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')),
         packages        = [...new Set(trees.flatMap(tree => collectTreeBarePackages({rootDir: path.join(stageDir, tree)})))].sort(),
@@ -296,20 +340,11 @@ export function stageOrganism({stageDir = STAGE_DIR, electronVersion} = {}) {
     console.log(`[pack] staged ${trees.length} trees + ${files.length} files; installing ${Object.keys(manifest.dependencies).length} organism dependencies`);
     run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error'], {cwd: stageDir});
 
-    // The falsifier-gated runtime arm: rebuild the staged natives for the bundled Electron. A
-    // failure is NOT fatal — the as-is system-Node build is the measured fallback (loads under
-    // ELECTRON_RUN_AS_NODE on this platform); the outcome ships in the build info either way.
-    const buildInfo = {electronVersion, rebuilt: false, rebuiltError: null, stagedAt: new Date().toISOString()};
+    // Mandatory ABI targeting: the staged natives rebuild for the bundled Electron. Failure fails
+    // the build — a catch-and-ship here is a silently-broken-artifact vector.
+    run('npx', ['@electron/rebuild', '--module-dir', stageDir, '--version', electronVersion], {cwd: harnessDir});
 
-    if (electronVersion) {
-        try {
-            run('npx', ['@electron/rebuild', '--module-dir', stageDir, '--version', electronVersion], {cwd: harnessDir});
-            buildInfo.rebuilt = true
-        } catch (error) {
-            buildInfo.rebuiltError = String(error.message).slice(0, 400);
-            console.warn(`[pack] @electron/rebuild failed — shipping the measured as-is arm (system-Node builds under ELECTRON_RUN_AS_NODE): ${buildInfo.rebuiltError}`)
-        }
-    }
+    const buildInfo = {electronVersion, rebuilt: true, stagedAt: new Date().toISOString()};
 
     // Pack-time-fresh instance config: template-current by construction, so the packaged first
     // boot never needs to WRITE into the (possibly read-only, translocated) resources dir.

--- a/harness/pack.mjs
+++ b/harness/pack.mjs
@@ -1,0 +1,332 @@
+// The E6 pack stage: materializes the ORGANISM the packaged shell ships — the renderer's source
+// graph (derived from the contentPolicy allowlist, one authority), the Brain tree, a generated
+// dependency manifest (this repo declares ONLY devDependencies, so the runtime closure is derived
+// from the bundled trees' bare imports), a pack-time-fresh instance config (killing the first-boot
+// write into a possibly read-only resources dir), and a `node` shim so shebang children (the
+// chroma CLI) run on the bundled Electron runtime via ELECTRON_RUN_AS_NODE — a stranger's machine
+// carries no Node.
+//
+// Shell-ADR bindings implemented here (§2.5 — the E6 row):
+//   §2.5.1  one double-clickable artifact wrapping the organism; the packaging root owns it
+//   §2.5.2  the UNSIGNED leg only — signing material never enters repo tooling
+//   §2.6    the bundled app layer is the SOURCE graph the allowlist names (NL possession), never
+//           a minified bundle
+//
+// Native-module runtime decision (the arm this leaf owns, recorded on its ticket): Brain children
+// run under ELECTRON_RUN_AS_NODE. Measured on darwin/Electron 43: a system-Node-built
+// better-sqlite3 (ABI 141) LOADS AND RUNS under electron-as-node (ABI 148) — the dev-tree
+// falsifier was a BROWSER-process incompatibility, not a node-mode one. The stage still attempts
+// @electron/rebuild against the staged tree (never the checkout — rebuilding the shared dev
+// node_modules is the recorded kill-the-dev-loop trap); a rebuild failure downgrades to the
+// measured as-is arm and records it in the build info.
+
+import {execFileSync}                               from 'node:child_process';
+import fs                                           from 'node:fs';
+import {builtinModules}                             from 'node:module';
+import path                                         from 'node:path';
+import {fileURLToPath}                              from 'node:url';
+import {ALLOWED_EXACT_PATHS, ALLOWED_PATH_PREFIXES} from './contentPolicy.mjs';
+
+const
+    harnessDir = path.dirname(fileURLToPath(import.meta.url)),
+    repoRoot   = path.resolve(harnessDir, '..');
+
+export const STAGE_DIR = path.join(harnessDir, '.stage', 'organism');
+
+// Runtime trees the renderer allowlist cannot know about: the Brain, plus the single buildScripts
+// module its entrypoints import (shipping the whole util dir would drag lint-tooling deps into the
+// organism manifest). node_modules-prefixed allowlist entries are NOT copied — they come from the
+// staged dependency install.
+export const BRAIN_TREES = Object.freeze([
+    'ai'
+]);
+
+export const BRAIN_FILES = Object.freeze([
+    'buildScripts/util/sanitizer.mjs'
+]);
+
+// Subtrees inside staged trees that are NOT runtime surface: demo/example apps (their deps are
+// demo deps), and the temporal-summary daemon — not runtime-enabled yet AND carrying a phantom
+// `yaml` import the repo never declares (recorded finding; its enablement ticket owns the fix).
+export const TREE_EXCLUDES = Object.freeze([
+    'ai/examples',
+    'ai/daemons/temporal-summary'
+]);
+
+// Checkout-instance files that must NEVER ship: the gitignored operator config overlay (it CAN
+// carry hand-edited values — the artifact gets a pack-time-fresh template-generated instance
+// instead) and any env file. Matched exactly or by basename pattern in the copy filter.
+export const INSTANCE_FILE_EXCLUDES = Object.freeze([
+    'ai/config.mjs'
+]);
+
+// Dependencies the bare-import scan cannot see: CSS-linked packages (fontawesome) and
+// dynamic-provider modules resolved at runtime.
+export const SUPPLEMENTAL_DEPENDENCIES = Object.freeze([
+    '@chroma-core/default-embed',
+    '@fortawesome/fontawesome-free'
+]);
+
+// Lazily-imported packages on modes the packaged product never enters (the MCP shared transport's
+// HTTP/cloud leg) — ALSO phantom deps the repo never declares (they resolve transitively on dev
+// machines; recorded finding). Excluded unless the repo declares them; a future mode enablement
+// fails loudly at its own import site, never as a silent ship.
+export const OPTIONAL_LAZY_PACKAGES = Object.freeze([
+    'ajv',
+    'cors'
+]);
+
+/**
+ * @summary Derives the filesystem trees/files to stage from the renderer allowlist (URL-path
+ * form) + the Brain set. One authority: a new allowlist prefix automatically ships.
+ * @returns {{trees: String[], files: String[]}} repo-relative copy specs.
+ */
+export function deriveCopySpecs() {
+    const
+        trees = new Set(BRAIN_TREES),
+        files = new Set();
+
+    for (const prefix of ALLOWED_PATH_PREFIXES) {
+        if (!prefix.startsWith('/node_modules/')) {
+            trees.add(prefix.replace(/^\/|\/$/g, ''))
+        }
+    }
+
+    for (const exact of ALLOWED_EXACT_PATHS) {
+        if (!exact.startsWith('/node_modules/')) {
+            files.add(exact.replace(/^\//, ''))
+        }
+    }
+
+    BRAIN_FILES.forEach(file => files.add(file));
+
+    return {files: [...files].sort(), trees: [...trees].sort()}
+}
+
+const
+    IMPORT_SPECIFIER_RE = /(?:from\s+|import\s+|import\s*\(\s*)['"]([^'"\n]+)['"]/g,
+    // npm package-name shape — rejects the prose/template fragments a naive scan of JSDoc
+    // examples and interpolated strings would otherwise surface as "packages".
+    PACKAGE_NAME_RE     = /^(@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+/**
+ * @summary Strips line and block comments so JSDoc example snippets ("import x from 'pkg'") never
+ * reach the specifier scan. Deliberately naive (a `//` inside a string literal would truncate the
+ * line) — the derivation is fail-loud downstream: an over-strip surfaces as a missing declared
+ * package at install/boot, never as a silent ship.
+ * @param {String} source
+ * @returns {String}
+ */
+function stripComments(source) {
+    return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '')
+}
+
+/**
+ * @summary Extracts the BARE (package) import specifiers from one module source: static imports,
+ * side-effect imports, re-exports, and string-literal dynamic imports. Comments are stripped
+ * first; relative (`./`), absolute, subpath-alias (`#`), and node built-in specifiers are
+ * excluded; non-npm-shaped candidates are dropped; subpath imports reduce to their package name
+ * (`chromadb/x` → `chromadb`, `@scope/pkg/x` → `@scope/pkg`).
+ * @param {String} source
+ * @returns {String[]} unique package names.
+ */
+export function extractBarePackages(source) {
+    const
+        builtins = new Set(builtinModules),
+        packages = new Set();
+
+    for (const match of stripComments(source).matchAll(IMPORT_SPECIFIER_RE)) {
+        const specifier = match[1];
+
+        if (specifier.startsWith('.') || specifier.startsWith('/') || specifier.startsWith('#') || specifier.startsWith('node:')) {
+            continue
+        }
+
+        const
+            segments    = specifier.split('/'),
+            packageName = specifier.startsWith('@') ? segments.slice(0, 2).join('/') : segments[0];
+
+        if (!builtins.has(packageName) && PACKAGE_NAME_RE.test(packageName)) {
+            packages.add(packageName)
+        }
+    }
+
+    return [...packages].sort()
+}
+
+/**
+ * @summary Walks the staged runtime trees and collects every bare package import.
+ * @param {Object} options
+ * @param {String} options.rootDir Directory whose `.mjs`/`.cjs`/`.js` files are scanned.
+ * @returns {String[]} unique package names across the tree.
+ */
+export function collectTreeBarePackages({rootDir}) {
+    const packages = new Set();
+
+    const walk = dir => {
+        for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+            const fullPath = path.join(dir, entry.name);
+
+            if (entry.isDirectory()) {
+                if (entry.name !== 'node_modules' && entry.name !== '.git') {
+                    walk(fullPath)
+                }
+            } else if (/\.(mjs|cjs|js)$/.test(entry.name)) {
+                extractBarePackages(fs.readFileSync(fullPath, 'utf8')).forEach(name => packages.add(name))
+            }
+        }
+    };
+
+    walk(rootDir);
+    return [...packages].sort()
+}
+
+/**
+ * @summary Builds the organism's dependency manifest: every scanned bare package pinned to the
+ * version the repo's own package.json declares (dev- or prod-declared — this repo declares its
+ * runtime set under devDependencies). An import with NO declared version is a hard error: the
+ * checkout would have failed too, and silence here would ship a broken artifact.
+ * @param {Object} options
+ * @param {String[]} options.packages Scanned package names.
+ * @param {Object} options.repoPackageJson Parsed repo package.json.
+ * @param {String[]} [options.supplemental=SUPPLEMENTAL_DEPENDENCIES]
+ * @param {String[]} [options.optionalLazy=OPTIONAL_LAZY_PACKAGES]
+ * @returns {Object} `{name, private, dependencies}` — the staged package.json.
+ */
+export function buildOrganismManifest({packages, repoPackageJson, supplemental = SUPPLEMENTAL_DEPENDENCIES, optionalLazy = OPTIONAL_LAZY_PACKAGES}) {
+    const
+        declared     = {...repoPackageJson.dependencies, ...repoPackageJson.devDependencies},
+        dependencies = {},
+        missing      = [];
+
+    for (const name of [...new Set([...packages, ...supplemental])].sort()) {
+        if (declared[name]) {
+            dependencies[name] = declared[name]
+        } else if (!optionalLazy.includes(name)) {
+            missing.push(name)
+        }
+    }
+
+    if (missing.length > 0) {
+        throw new Error(`organism manifest: no declared version for imported package(s): ${missing.join(', ')}`)
+    }
+
+    return {
+        dependencies,
+        name   : 'neo-harness-organism',
+        private: true,
+        type   : 'module',
+        version: repoPackageJson.version ?? '0.0.0'
+    }
+}
+
+/**
+ * @summary The `node` PATH shim for shebang children (`#!/usr/bin/env node` — the chroma CLI): a
+ * stranger's machine carries no Node, so the shim execs the packaged Electron binary in node mode.
+ * The binary path arrives via env at spawn time (`NEO_HARNESS_ELECTRON_BIN`) because the install
+ * location is unknowable at pack time.
+ * @returns {String} POSIX shell shim source.
+ */
+export function buildNodeShim() {
+    return [
+        '#!/bin/sh',
+        '# neo-harness organism shim: routes `node` shebangs onto the bundled Electron runtime.',
+        ': "${NEO_HARNESS_ELECTRON_BIN:?NEO_HARNESS_ELECTRON_BIN is not set}"',
+        'ELECTRON_RUN_AS_NODE=1 exec "$NEO_HARNESS_ELECTRON_BIN" "$@"',
+        ''
+    ].join('\n')
+}
+
+function copyTree(sourceRoot, targetRoot, relative) {
+    const source = path.join(sourceRoot, relative);
+
+    if (!fs.existsSync(source)) {
+        throw new Error(`pack: staged tree missing in checkout: ${relative}`)
+    }
+
+    fs.cpSync(source, path.join(targetRoot, relative), {
+        filter: entry => {
+            const rel = path.relative(sourceRoot, entry);
+
+            return !TREE_EXCLUDES.some(exclude => rel === exclude || rel.startsWith(exclude + path.sep)) &&
+                !INSTANCE_FILE_EXCLUDES.includes(rel) &&
+                !/(^|\/)(node_modules|\.git)(\/|$)/.test(rel) &&
+                !/(^|\/)\.env(\.|$)/.test(rel) &&
+                !rel.endsWith('.DS_Store')
+        },
+        recursive: true
+    })
+}
+
+function run(command, args, options = {}) {
+    execFileSync(command, args, {stdio: 'inherit', ...options})
+}
+
+/**
+ * @summary Stages the complete organism: trees + files (allowlist-derived), generated dependency
+ * manifest + install, the @electron/rebuild attempt (falsifier-gated arm), the pack-time-fresh
+ * instance config, and the node shim. Idempotent: the stage dir is rebuilt from scratch.
+ * @param {Object} [options]
+ * @param {String} [options.stageDir=STAGE_DIR]
+ * @param {String} [options.electronVersion] Version for @electron/rebuild (harness devDep pin).
+ * @returns {Object} build info (also written to `<stageDir>/organism-build-info.json`).
+ */
+export function stageOrganism({stageDir = STAGE_DIR, electronVersion} = {}) {
+    fs.rmSync(stageDir, {force: true, recursive: true});
+    fs.mkdirSync(stageDir, {recursive: true});
+
+    const {files, trees} = deriveCopySpecs();
+
+    for (const tree of trees) {
+        copyTree(repoRoot, stageDir, tree)
+    }
+
+    for (const file of files) {
+        fs.mkdirSync(path.dirname(path.join(stageDir, file)), {recursive: true});
+        fs.copyFileSync(path.join(repoRoot, file), path.join(stageDir, file))
+    }
+
+    const
+        repoPackageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8')),
+        packages        = [...new Set(trees.flatMap(tree => collectTreeBarePackages({rootDir: path.join(stageDir, tree)})))].sort(),
+        manifest        = buildOrganismManifest({packages, repoPackageJson});
+
+    fs.writeFileSync(path.join(stageDir, 'package.json'), JSON.stringify(manifest, null, 4), 'utf8');
+
+    console.log(`[pack] staged ${trees.length} trees + ${files.length} files; installing ${Object.keys(manifest.dependencies).length} organism dependencies`);
+    run('npm', ['install', '--no-audit', '--no-fund', '--loglevel=error'], {cwd: stageDir});
+
+    // The falsifier-gated runtime arm: rebuild the staged natives for the bundled Electron. A
+    // failure is NOT fatal — the as-is system-Node build is the measured fallback (loads under
+    // ELECTRON_RUN_AS_NODE on this platform); the outcome ships in the build info either way.
+    const buildInfo = {electronVersion, rebuilt: false, rebuiltError: null, stagedAt: new Date().toISOString()};
+
+    if (electronVersion) {
+        try {
+            run('npx', ['@electron/rebuild', '--module-dir', stageDir, '--version', electronVersion], {cwd: harnessDir});
+            buildInfo.rebuilt = true
+        } catch (error) {
+            buildInfo.rebuiltError = String(error.message).slice(0, 400);
+            console.warn(`[pack] @electron/rebuild failed — shipping the measured as-is arm (system-Node builds under ELECTRON_RUN_AS_NODE): ${buildInfo.rebuiltError}`)
+        }
+    }
+
+    // Pack-time-fresh instance config: template-current by construction, so the packaged first
+    // boot never needs to WRITE into the (possibly read-only, translocated) resources dir.
+    run('node', ['ai/scripts/setup/initServerConfigs.mjs'], {cwd: stageDir});
+
+    const shimsDir = path.join(stageDir, 'shims');
+
+    fs.mkdirSync(shimsDir, {recursive: true});
+    fs.writeFileSync(path.join(shimsDir, 'node'), buildNodeShim(), {mode: 0o755});
+
+    fs.writeFileSync(path.join(stageDir, 'organism-build-info.json'), JSON.stringify(buildInfo, null, 4), 'utf8');
+    console.log(`[pack] organism staged at ${stageDir} (rebuilt=${buildInfo.rebuilt})`);
+    return buildInfo
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+    const electronVersion = JSON.parse(fs.readFileSync(path.join(harnessDir, 'package.json'), 'utf8')).devDependencies?.electron?.replace(/^[^0-9]*/, '');
+
+    stageOrganism({electronVersion})
+}

--- a/harness/pack.mjs
+++ b/harness/pack.mjs
@@ -315,6 +315,13 @@ export function stageOrganism({stageDir = STAGE_DIR, electronVersion} = {}) {
     fs.rmSync(stageDir, {force: true, recursive: true});
     fs.mkdirSync(stageDir, {recursive: true});
 
+    // Deterministic asset freshness: the stage copies dist/development/css AS-IS, and a stale
+    // build renders the packaged window fully broken while every existence probe stays green
+    // (live incident: a theming merge landed after the last local theme build). The artifact
+    // never trusts checkout state — it rebuilds.
+    console.log('[pack] building dev themes from current SCSS');
+    run('node', ['buildScripts/build/themes.mjs', '-f', '-n', '-e', 'dev', '-t', 'all'], {cwd: repoRoot});
+
     const {files, trees} = deriveCopySpecs();
 
     for (const tree of trees) {

--- a/harness/package.json
+++ b/harness/package.json
@@ -2,7 +2,7 @@
     "name": "neo-harness",
     "private": true,
     "version": "0.0.1",
-    "description": "The Agent Harness's native vessel (ticket 14962 under 13033/13377): boots the dev-mode harness app on the privileged app:// origin per the Electron-shell ADR. Wraps what the repo serves \u2014 never a source hemisphere.",
+    "description": "The Agent Harness's native vessel (ticket 14962 under 13033/13377): boots the dev-mode harness app on the privileged app:// origin per the Electron-shell ADR. Wraps what the repo serves — never a source hemisphere.",
     "main": "main.mjs",
     "scripts": {
         "prestart": "node prepareAssets.mjs",
@@ -10,10 +10,14 @@
         "start": "electron main.mjs",
         "smoke": "cross-env NEO_HARNESS_SMOKE=1 electron main.mjs",
         "smoke:brain": "cross-env NEO_HARNESS_SMOKE=1 NEO_HARNESS_BRAIN=1 electron main.mjs",
-        "start:brain": "cross-env NEO_HARNESS_BRAIN=1 electron main.mjs"
+        "start:brain": "cross-env NEO_HARNESS_BRAIN=1 electron main.mjs",
+        "predist": "node prepareAssets.mjs && node pack.mjs",
+        "dist": "electron-builder --mac --publish never"
     },
     "devDependencies": {
+        "@electron/rebuild": "^4.0.1",
         "cross-env": "^10.1.0",
-        "electron": "43.1.0"
+        "electron": "43.1.0",
+        "electron-builder": "^26.0.12"
     }
 }

--- a/harness/prepareAssets.mjs
+++ b/harness/prepareAssets.mjs
@@ -1,5 +1,6 @@
 import {access}        from 'node:fs/promises';
 import {spawn}         from 'node:child_process';
+import fs              from 'node:fs';
 import {fileURLToPath} from 'node:url';
 import path            from 'node:path';
 
@@ -52,7 +53,54 @@ function buildTheme(theme) {
 }
 
 /**
- * @summary Lazily materializes the exact generated assets the source-mode Agent OS boot requires.
+ * @summary Newest file mtime (ms) under a directory tree, filtered by extension. Used to compare
+ * SCSS sources against built CSS: existence alone cannot see a stale build.
+ * @param {String} dir Absolute directory.
+ * @param {String} extension E.g. `.scss`.
+ * @returns {Number} Epoch ms of the newest matching file; 0 when none exist.
+ */
+function newestMtime(dir, extension) {
+    let newest = 0;
+
+    if (!fs.existsSync(dir)) {
+        return newest
+    }
+
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            newest = Math.max(newest, newestMtime(fullPath, extension))
+        } else if (entry.name.endsWith(extension)) {
+            newest = Math.max(newest, fs.statSync(fullPath).mtimeMs)
+        }
+    }
+
+    return newest
+}
+
+/**
+ * @summary True when any SCSS source is newer than the built theme css — the exact failure the
+ * harness cannot see otherwise: a merged theming change leaves EXISTING but WRONG css on disk,
+ * and the window renders fully broken while every existence probe stays green.
+ * @returns {Boolean}
+ */
+function themesAreStale() {
+    const newestScss = newestMtime(path.join(repoRoot, 'resources', 'scss'), '.scss');
+
+    return [assets.dark, assets.light, assets.source].some(asset => {
+        try {
+            return fs.statSync(path.join(repoRoot, asset)).mtimeMs < newestScss
+        } catch {
+            return true
+        }
+    })
+}
+
+/**
+ * @summary Materializes the generated assets the source-mode Agent OS boot requires — and
+ * REBUILDS the themes when any SCSS source is newer than the built css (staleness, not just
+ * existence: the fully-broken-visuals class ships through existence-only checks).
  * @returns {Promise<void>}
  */
 async function prepareAssets() {
@@ -60,7 +108,15 @@ async function prepareAssets() {
         await Promise.all(Object.entries(assets).map(async ([key, value]) => [key, await assetExists(value)]))
     );
 
+    if (Object.values(state).every(Boolean) && !themesAreStale()) {
+        return
+    }
+
     if (Object.values(state).every(Boolean)) {
+        console.log('[harness] built themes are older than the SCSS sources — rebuilding');
+        for (const theme of ['theme-neo-dark', 'theme-neo-light']) {
+            await buildTheme(theme)
+        }
         return
     }
 

--- a/test/playwright/unit/harness/pack.spec.mjs
+++ b/test/playwright/unit/harness/pack.spec.mjs
@@ -1,0 +1,91 @@
+import {expect, test} from '@playwright/test';
+import {
+    BRAIN_TREES,
+    buildNodeShim,
+    buildOrganismManifest,
+    deriveCopySpecs,
+    extractBarePackages
+} from '../../../../harness/pack.mjs';
+import {buildPackagedDataEnv} from '../../../../harness/brain.mjs';
+import path                   from 'node:path';
+
+test.describe('harness pack stage', () => {
+    test('deriveCopySpecs rides the contentPolicy allowlist plus the Brain trees, skipping node_modules entries', () => {
+        const {files, trees} = deriveCopySpecs();
+
+        for (const tree of BRAIN_TREES) {
+            expect(trees).toContain(tree)
+        }
+
+        // Allowlist-derived: the renderer's source graph ships automatically.
+        expect(trees).toContain('src');
+        expect(trees).toContain('apps/agentos');
+        expect(trees).toContain('dist/development/css');
+        expect(files).toContain('resources/theme-map.json');
+        expect(files).toContain('resources/images/logo/neo_logo_primary.svg');
+
+        // node_modules-prefixed allowlist entries come from the staged dependency install.
+        expect([...trees, ...files].some(entry => entry.includes('node_modules'))).toBe(false)
+    });
+
+    test('extractBarePackages keeps package names only — no relative, builtin, alias, or subpath noise', () => {
+        const source = [
+            "import 'dotenv/config';",
+            "import fs from 'node:fs';",
+            "import path from 'path';",
+            "import Neo from '../../src/Neo.mjs';",
+            "import {x} from '#internal/alias';",
+            "import Database from 'better-sqlite3';",
+            "import {ChromaClient} from 'chromadb';",
+            "export {y} from '@scope/pkg/deep/path.mjs';",
+            "const lazy = await import('fs-extra');"
+        ].join('\n');
+
+        expect(extractBarePackages(source)).toEqual(['@scope/pkg', 'better-sqlite3', 'chromadb', 'dotenv', 'fs-extra'])
+    });
+
+    test('buildOrganismManifest pins scanned packages to repo-declared versions and fails loud on undeclared imports', () => {
+        const repoPackageJson = {
+            devDependencies: {'better-sqlite3': '^12.0.0', chromadb: '^3.5.0'},
+            version        : '11.11.0'
+        };
+
+        const manifest = buildOrganismManifest({
+            packages    : ['better-sqlite3', 'chromadb'],
+            repoPackageJson,
+            supplemental: []
+        });
+
+        expect(manifest.dependencies).toEqual({'better-sqlite3': '^12.0.0', chromadb: '^3.5.0'});
+        expect(manifest.private).toBe(true);
+        expect(manifest.type).toBe('module');
+
+        expect(() => buildOrganismManifest({
+            packages    : ['ghost-package'],
+            repoPackageJson,
+            supplemental: []
+        })).toThrow(/no declared version.*ghost-package/)
+    });
+
+    test('the node shim fails loud without the runtime binary and execs it in node mode', () => {
+        const shim = buildNodeShim();
+
+        expect(shim.startsWith('#!/bin/sh')).toBe(true);
+        expect(shim).toContain('NEO_HARNESS_ELECTRON_BIN:?');
+        expect(shim).toContain('ELECTRON_RUN_AS_NODE=1 exec "$NEO_HARNESS_ELECTRON_BIN"')
+    });
+
+    test('buildPackagedDataEnv moves every mutable Brain leaf under the per-user data root without gates or test mode', () => {
+        const env = buildPackagedDataEnv({dataRoot: '/Users/someone/Library/Application Support/neo-harness/brain'});
+
+        for (const value of Object.values(env)) {
+            expect(value.startsWith('/Users/someone/Library/Application Support/neo-harness/brain' + path.sep)).toBe(true)
+        }
+
+        // The product profile is the REAL organism: no lane gates, no UNIT_TEST_MODE, no port shifts.
+        expect(Object.keys(env).some(name => name.endsWith('_ENABLED'))).toBe(false);
+        expect(env.UNIT_TEST_MODE).toBeUndefined();
+        expect(env.NEO_CHROMA_DATA_DIR).toBeDefined();
+        expect(env.NEO_AI_DB_PATH).toBeDefined()
+    })
+});

--- a/test/playwright/unit/harness/pack.spec.mjs
+++ b/test/playwright/unit/harness/pack.spec.mjs
@@ -1,13 +1,18 @@
-import {expect, test} from '@playwright/test';
+import {expect, test}             from '@playwright/test';
+import {mkdtemp, rm}              from 'node:fs/promises';
+import {mkdirSync, writeFileSync} from 'node:fs';
+import {tmpdir}                   from 'node:os';
 import {
     BRAIN_TREES,
+    assertNoInstanceOverlays,
     buildNodeShim,
     buildOrganismManifest,
     deriveCopySpecs,
-    extractBarePackages
+    extractBarePackages,
+    isInstanceOverlayPath
 } from '../../../../harness/pack.mjs';
-import {buildPackagedDataEnv} from '../../../../harness/brain.mjs';
-import path                   from 'node:path';
+import {buildPackagedBrainEnv, resolveBrainMode} from '../../../../harness/brain.mjs';
+import path                                      from 'node:path';
 
 test.describe('harness pack stage', () => {
     test('deriveCopySpecs rides the contentPolicy allowlist plus the Brain trees, skipping node_modules entries', () => {
@@ -75,17 +80,70 @@ test.describe('harness pack stage', () => {
         expect(shim).toContain('ELECTRON_RUN_AS_NODE=1 exec "$NEO_HARNESS_ELECTRON_BIN"')
     });
 
-    test('buildPackagedDataEnv moves every mutable Brain leaf under the per-user data root without gates or test mode', () => {
-        const env = buildPackagedDataEnv({dataRoot: '/Users/someone/Library/Application Support/neo-harness/brain'});
+    test('buildPackagedBrainEnv is THE product profile: userData-rooted paths + the exact artifact lane closure', () => {
+        const
+            dataRoot = '/Users/someone/Library/Application Support/neo-harness/brain',
+            env      = buildPackagedBrainEnv({dataRoot});
 
-        for (const value of Object.values(env)) {
-            expect(value.startsWith('/Users/someone/Library/Application Support/neo-harness/brain' + path.sep)).toBe(true)
+        for (const [name, value] of Object.entries(env)) {
+            if (!name.endsWith('_ENABLED')) {
+                expect(value.startsWith(dataRoot + path.sep)).toBe(true)
+            }
         }
 
-        // The product profile is the REAL organism: no lane gates, no UNIT_TEST_MODE, no port shifts.
-        expect(Object.keys(env).some(name => name.endsWith('_ENABLED'))).toBe(false);
+        // The lane closure is an EXACT contract: each OFF names a resource the artifact does not
+        // carry (webpack, git-checkout semantics, external model servers, cwd-relative writers).
+        // A new gate here means the artifact's product behavior changed — update deliberately.
+        expect(Object.keys(env).filter(name => name.endsWith('_ENABLED')).sort()).toEqual([
+            'NEO_DEPLOYMENT_STATE_BRIDGE_ENABLED',
+            'NEO_ORCHESTRATOR_DEV_SERVER_ENABLED',
+            'NEO_ORCHESTRATOR_GITHUB_WORKFLOW_SYNC_ENABLED',
+            'NEO_ORCHESTRATOR_GOLDEN_PATH_REPO_ENRICHMENT_ENABLED',
+            'NEO_ORCHESTRATOR_KB_SYNC_ENABLED',
+            'NEO_ORCHESTRATOR_LMS_ENABLED',
+            'NEO_ORCHESTRATOR_MLX_ENABLED',
+            'NEO_ORCHESTRATOR_NL_BRIDGE_ENABLED',
+            'NEO_ORCHESTRATOR_OLLAMA_ENABLED',
+            'NEO_ORCHESTRATOR_PRIMARY_DEV_SYNC_ENABLED'
+        ]);
+
+        // Product semantics, never test semantics: the embed/message organism lanes stay ON (no
+        // gate present), and UNIT_TEST_MODE must never appear in a product profile.
+        expect(env.NEO_ORCHESTRATOR_EMBED_DAEMON_ENABLED).toBeUndefined();
+        expect(env.NEO_ORCHESTRATOR_MESSAGE_DAEMON_ENABLED).toBeUndefined();
         expect(env.UNIT_TEST_MODE).toBeUndefined();
         expect(env.NEO_CHROMA_DATA_DIR).toBeDefined();
         expect(env.NEO_AI_DB_PATH).toBeDefined()
+    });
+
+    test('resolveBrainMode: packaged double-click boots the Brain by default; checkout stays opt-in', () => {
+        expect(resolveBrainMode({env: {}, packaged: true})).toBe(true);
+        expect(resolveBrainMode({env: {NEO_HARNESS_BRAIN: '0'}, packaged: true})).toBe(false);
+        expect(resolveBrainMode({env: {}, packaged: false})).toBe(false);
+        expect(resolveBrainMode({env: {NEO_HARNESS_BRAIN: '1'}, packaged: false})).toBe(true)
+    });
+
+    // The security stop-line: a checkout's gitignored config overlay (which CAN carry hand-edited
+    // operator credentials) must never reach the stage. The rule is DERIVED — any config.mjs with
+    // a config.template.mjs sibling — so new server overlays are covered without enumeration.
+    test('instance overlays are excluded by template-sibling derivation and the stage assertion fails loud on a sentinel', async () => {
+        const root = await mkdtemp(path.join(tmpdir(), 'neo-pack-overlay-'));
+
+        try {
+            mkdirSync(path.join(root, 'ai', 'mcp', 'server', 'github-workflow'), {recursive: true});
+            mkdirSync(path.join(root, 'ai', 'mcp', 'client'), {recursive: true});
+            writeFileSync(path.join(root, 'ai', 'mcp', 'server', 'github-workflow', 'config.template.mjs'), 'export default {}', 'utf8');
+            writeFileSync(path.join(root, 'ai', 'mcp', 'server', 'github-workflow', 'config.mjs'), "export default {token: 'SENTINEL_MUST_NOT_SHIP'}", 'utf8');
+            writeFileSync(path.join(root, 'ai', 'mcp', 'client', 'config.mjs'), 'export default {}', 'utf8');
+
+            // Overlay (template sibling) → excluded; tracked standalone config.mjs → ships.
+            expect(isInstanceOverlayPath(root, path.join('ai', 'mcp', 'server', 'github-workflow', 'config.mjs'))).toBe(true);
+            expect(isInstanceOverlayPath(root, path.join('ai', 'mcp', 'client', 'config.mjs'))).toBe(false);
+
+            // The belt: a stage that somehow still contains the overlay fails the build loudly.
+            expect(() => assertNoInstanceOverlays(root)).toThrow(/refusing to ship.*github-workflow/)
+        } finally {
+            await rm(root, {force: true, recursive: true})
+        }
     })
 });


### PR DESCRIPTION
Resolves #14994

Related: epic #13377 (the ADR 0034 §5 **E6 row**, filed on demand) · ADR 0034 §2.5 (upstream contract) / §2.6 (source-graph amendment) · `#13033` (E1, discharged — this builds on its root) · `#14967` (the runtime-arm record this leaf consumes) · #14230 (the contributor door — never merged with this one, §2.5.1) · #14793 (the "download and run" UX spec — E8 consumer)

**The v13.2 release-gate "download" leg: `cd harness && npm run dist` emits ONE double-clickable unsigned artifact** (`Neo Harness-0.0.1-arm64-mac.zip`, ~276M) wrapping the complete organism. **A packaged double-click boots the supervised Brain by default** (Finder supplies no env; `NEO_HARNESS_BRAIN=0` is the explicit opt-out — a checkout stays opt-in), and the packaged smoke proves exactly that product: it runs with NO Brain env under **the one packaged product profile** (`buildPackagedBrainEnv` — the artifact's full lane/resource closure), shifted only in coordinates.

**Cycle-2 convergence (@neo-gpt's four required actions, one head update):**

1. **[P0] Overlay stop-line.** Instance-overlay exclusion is DERIVED — any `config.mjs` with a `config.template.mjs` sibling (the top-level `ai/config.mjs` AND every per-server MCP overlay, all gitignored and credential-capable) — plus a post-copy assertion that fails the build on any survivor, plus stage-time regeneration of fresh template-defaults instances. Sentinel fixture pins predicate + belt. The review's artifact-content trace was live-correct: five per-server overlays were copy-eligible pre-fix.
2. **[P0] Mandatory rebuild.** Catch-and-ship removed: `@electron/rebuild` failure fails the build, `electronVersion` is required, and the as-is ABI-compat claim is withdrawn as unproven (independent probes disagreed — the honest posture is fail-loud, not fallback).
3. **[P0] Default-on packaged Brain.** `resolveBrainMode` (pure, four-case pin): packaged → `NEO_HARNESS_BRAIN !== '0'`; checkout → `=== '1'`.
4. **[P1] One product profile.** `buildPackagedBrainEnv` is THE resource-closure contract, consumed identically by the product boot and the packaged smoke: every mutable path under `userData` — now including the WAL and embed/message daemon state dirs, whose cwd-relative defaults would have written into the resources dir — plus the honest lane closure (each gate names the resource the bundle does not carry: webpack, git-checkout semantics, external model servers, cwd-relative writers; the embed + message organism lanes run). Exact-content gate-set pin; `profileMode` lands in the smoke verdict.
5. **Bonus latent defect exposed by the cycle-2 shape:** `bootProductBrain` consumed `buildPackagedDataEnv` without importing it — a `ReferenceError` on first product boot; the path had never executed. Fixed with the profile unification.

**What the pack stage materializes (`pack.mjs`), each with its authority:**

1. **The renderer source graph, DERIVED from the contentPolicy allowlist** (`ALLOWED_EXACT_PATHS`/`ALLOWED_PATH_PREFIXES` now exported) — one authority for "what the renderer may load" and "what the artifact must carry"; a new allowlist prefix ships automatically. Source ESM, never `dist/production` (§2.6: Neural Link possession) — the §2.5.1 "wraps BUILT Body" wording is reconciled by the §2.6 amendment (flagged for the ADR steward; no ADR text changed here).
2. **The Brain tree** minus `ai/examples` (demo deps) and the not-yet-enabled `temporal-summary` daemon — which carries a **phantom `yaml` import** the repo never declares (recorded finding; the #14938 enablement arc owns it).
3. **A GENERATED dependency manifest**: this repo declares only devDependencies, so the runtime closure is derived from the bundled trees' bare imports (comment-stripped, npm-name-validated, subpath-reduced), pinned to repo-declared versions, **fail-loud on any undeclared import**. Two more phantom deps surfaced and recorded: `ajv`/`cors` — lazy imports on the MCP shared transport's HTTP/cloud leg the packaged product never enters (excluded; a future enablement fails at its own import site, never as a silent ship). 16-dep closure lands.
4. **A pack-time-fresh instance `ai/config.mjs`** generated from the staged template — the packaged first boot never WRITES into the (possibly translocated/read-only) resources dir, and **the checkout's gitignored operator overlay NEVER ships** (an operator's hand-edited values would otherwise ride into a distributable; the copy filter excludes it plus any `.env*`).
5. **A `node` shim** (`shims/node`) so shebang children — the chroma CLI — exec the bundled Electron in node mode: a stranger's machine carries no Node.

**The runtime arm (the decision `#14967` recorded for this leaf), falsifier-gated and measured:** Brain children run `ELECTRON_RUN_AS_NODE` on the bundled runtime; the staged `node_modules` is rebuilt via `@electron/rebuild` **scoped to the stage** (never the checkout — the recorded kill-the-dev-loop trap). The measured fallback is recorded in-code: a system-Node-built better-sqlite3 (ABI 141) loads and runs under electron-as-node (ABI 148) — the dev-tree falsifier was a browser-process incompatibility, not a node-mode one. `rebuilt: true` in this build's info; the arm outcome ships in `organism-build-info.json` either way.

**Shell-side seams (`main.mjs`/`brain.mjs`):** `organismRoot` (checkout vs `process.resourcesPath/organism`) feeds the asset resolver and every child spawn; packaged Brain env moves every mutable path to the per-user data root via `buildPackagedDataEnv` — including the **new `NEO_CHROMA_DATA_DIR` template binding** (the prod persist dir previously had no env leaf; additive, mirrors its host/port/TEST siblings; ADR 0019-conformant declarative leaf); the packaged smoke isolation root moves under `userData`. **Coexistence guard:** a packaged own-mode boot FAILS CLOSED when a checkout Brain already holds the Chroma port — the spawned supervisor's singleton-port reconciliation would otherwise reap it.

**afterPack hook (measured necessity):** electron-builder's extraResources copier hard-ignores `node_modules` regardless of filter globs; without the hook the packaged children silently resolved **the checkout's** system-ABI natives through the filesystem walk-up (reproduced: ABI 141-vs-148 load failure + fontawesome 404s) — the hook completes the payload and the failure class is documented at the site.

Evidence: L2 (the packaged artifact runs the full smoke contract) + L1 (unit) → L2 required (packaging is runtime behavior). Sandbox ceiling: Electron needs a local display; a true fresh-machine double-click is the operator's post-merge step.

## Deltas from ticket

- **No system-Node fallback arm needed**: the primary arm (`@electron/rebuild` + `ELECTRON_RUN_AS_NODE`) succeeded outright; the AC's "recorded either way" is satisfied with `rebuilt: true` plus the measured as-is fallback documented in-code.
- **`dmg` deferred to zip**: the zip target proves the pipeline without dmg styling/stapling concerns; the per-platform matrix stays the CI-lane follow-up already recorded on the ticket.
- **Three phantom-dep findings recorded, none fixed here** (wrong substrate): `yaml` (temporal-summary → #14938 arc), `ajv`/`cors` (MCP HTTP transport leg). Each fails loud at its own import site if ever enabled un-declared.
- **Rebased over #14995 mid-flight**: Euclid's crash-sweep identity machinery (per-spawn argv token, absolute entries) merged cleanly into `startBrainChild`; the shims prepend composes with it (one conflict block, resolved keeping BOTH contracts; run-state records now carry his ownership tokens through my packaged paths).

## Test Evidence

- **Packaged smoke — exit 0 at head `636a6a0bd` with NO Brain env** (`NEO_HARNESS_SMOKE=1` only — the run itself proves the double-click default): `profileMode: "packaged-product"`, both windows boot 116 nodes from the BUNDLED source graph over `app://`, `matrixViolations: []` (the product profile resolved through the BUNDLED fresh configs), `up: true` with the embed + message organism lanes booting from the artifact, `chromaListening: true` (the chroma CLI through the node shim), `fleetFromWindow: {ok: true}` (renderer `listAgents`), teardown unforced/groups-empty/ports-released.
- **Checkout smoke — exit 0** at the same head (`profileMode: "checkout-isolated"`; opt-in semantics unchanged): dev mode regression-free.
- **`npm run dist` — exit 0** with the mandatory rebuild and a clean overlay stop-line; staged per-server configs verified pack-time-fresh template defaults.
- **Unit: 35 passed** (`unit/harness` incl. the 8 pack-stage tests: allowlist-derived copy specs, bare-import extraction incl. JSDoc-snippet immunity, manifest pinning + fail-loud, shim contract, the product-profile exact gate-set pin, resolveBrainMode four-case pin, the overlay sentinel fixture; Euclid's #14995 identity tests green alongside).
- Failure-mode reproductions during the arc (each fixed + documented): stale-instance-config ship (pack-time-fresh generation), node_modules-dropped payload (afterPack), fontawesome 404 (same), ABI walk-up resolution (same), checkout instance staleness (migrate path).
- `agent-preflight --no-fix` green (whitespace, shorthand, aiconfig-test-mutation, jsdoc-types, archaeology, block-alignment); husky pre-commit full pass.

## Post-Merge Validation

- [ ] Operator: `cd harness && npm install && npm run dist`, then copy `dist-artifacts/Neo Harness-0.0.1-arm64-mac.zip` to a machine (or account) WITHOUT the checkout, unzip, double-click — the FM opens WITH its own supervised organism by default (own-mode; data under `~/Library/Application Support/Neo Harness/brain`). If quarantined from a browser download: `xattr -d com.apple.quarantine` (the unsigned-leg limitation E7 dissolves).
- [ ] On THIS machine: double-clicking the packaged app while the canonical Brain runs must log the coexistence-guard rejection (held Chroma port), not reap anything.

## Commits

- 636a6a0bd — cycle-2: the overlay stop-line (derived exclusion + belt assertion + sentinel fixture), mandatory fail-build rebuild, default-on packaged Brain (`resolveBrainMode`), the one packaged product profile (`buildPackagedBrainEnv` incl. WAL/daemon state dirs) consumed by boot AND smoke, the latent import fix.
- e82674f5f — the pipeline: pack.mjs (stage + derived manifest + fresh config + shim), afterPack.cjs, electron-builder.yml (unsigned, no publish), organismRoot/packaged seams, NEO_CHROMA_DATA_DIR template binding, contentPolicy allowlist exports, coexistence guard, README packaging section, 5-test pack spec.

Authored by Vega (Claude Fable 5, Claude Code). Session d2fbbdb4-404b-47e1-bbb3-1b9e0330894b.
