### PR TITLE
feat(agentos): FM cockpit state-backed perspective switching — named duty layouts over the landed store (#15008)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -3,6 +3,7 @@ import Button                  from '../../../../src/button/Base.mjs';
 import Container               from '../../../../src/container/Base.mjs';
 import DockLayoutAdapter       from '../../../../src/dashboard/DockLayoutAdapter.mjs';
 import DockMotionSignal        from '../../../../src/dashboard/DockMotionSignal.mjs';
+import DockPerspectiveStore    from '../../../../src/dashboard/DockPerspectiveStore.mjs';
 import DockPreviewProducer     from '../../../../src/dashboard/DockPreviewProducer.mjs';
 import DockZoneModel           from '../../../../src/dashboard/DockZoneModel.mjs';
 import FleetCockpitController  from './FleetCockpitController.mjs';
@@ -10,6 +11,7 @@ import FleetGrid               from './FleetGrid.mjs';
 import FleetRoster             from '../../store/FleetRoster.mjs';
 import StateProvider           from '../../../../src/state/Provider.mjs';
 import cockpitDockDocument     from './cockpitDockDocument.mjs';
+import cockpitPresetCollection from './cockpitPresets.mjs';
 import {mapFleetSessionHealth} from './sourceHealth.mjs';
 import {previewToOperation}    from '../../../../src/dashboard/dockPreviewContract.mjs';
 import '../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the dock projection emits for tab zones
@@ -130,6 +132,22 @@ class FleetCockpit extends Container {
      */
     dockModel = null
     /**
+     * The named preset library — a {@link Neo.dashboard.DockPerspectiveStore} over the seeded
+     * workspace-scope collection ({@link module:cockpitPresets}). The store is the preset SSOT;
+     * {@link #dockModel} stays the LIVE layout SSOT — presets are snapshots the switch restores
+     * from, never live-bound mirrors.
+     * @member {Neo.dashboard.DockPerspectiveStore|null} perspectiveStore=null
+     * @protected
+     */
+    perspectiveStore = null
+    /**
+     * The last refused preset switch, rendered in the control bar (fail-closed VISIBLY: a
+     * refused restore must never look like a no-op). Cleared by the next successful switch.
+     * @member {String|null} presetError=null
+     * @protected
+     */
+    presetError = null
+    /**
      * The cross-zone drop producer instance (pointer → placement grammar), owned per cockpit.
      * @member {Neo.dashboard.DockPreviewProducer|null} dockPreviewProducer=null
      * @protected
@@ -194,9 +212,38 @@ class FleetCockpit extends Container {
         let me = this;
 
         me.dockPreviewProducer = Neo.create(DockPreviewProducer);
+        me.perspectiveStore    = Neo.create(DockPerspectiveStore, {collection: cockpitPresetCollection()});
         me.dockModel           = me.dockModel || cockpitDockDocument();
 
         me.add(me.buildWorkspaceItems())
+    }
+
+    /**
+     * @summary Switches the cockpit to a named preset: the stored record restores through the
+     * landed fail-closed path (validate everything before mutating anything — a refused restore
+     * leaves the live layout byte-untouched), and a valid document enters the standard commit
+     * loop — the switch re-projects FLIP-animated exactly like any committed operation, with
+     * reduced-motion collapsing through the token layer by construction.
+     *
+     * Pane continuity across a switch is state-continuity, not instance identity: projections
+     * rebuild instances by design; the live surfaces re-materialize from the OWNER-held state
+     * ({@link #resolveDockComponentRef}) and the provider-owned roster store never restarts.
+     * @param {String} name The preset's `perspectiveName` (or technical `layoutId`).
+     * @returns {{switched: Boolean, errors: String[]}}
+     */
+    activatePerspective(name) {
+        let me                 = this,
+            {document, errors} = me.perspectiveStore.loadPerspective(name);
+
+        if (errors.length) {
+            me.presetError = `${name}: ${errors[0]}`;
+            me.refreshDockWorkspace();
+            return {errors, switched: false}
+        }
+
+        me.presetError = null;
+        me.onDockZoneDocumentChange(document);
+        return {errors: [], switched: true}
     }
 
     /**
@@ -286,11 +333,22 @@ class FleetCockpit extends Container {
     }
 
     /**
-     * Creates the top-level control bar + dock projection items from current state.
+     * Creates the top-level control bar + dock projection items from current state: the preset
+     * switcher on the left (one button per stored perspective, the active one pressed — plus
+     * the fail-closed error chip when a switch was refused), the fleet controls on the right.
      * @returns {Object[]}
      */
     buildWorkspaceItems() {
-        let dockConfig = this.projectDockModel();
+        let me             = this,
+            dockConfig     = me.projectDockModel(),
+            activeLayoutId = me.perspectiveStore?.collection?.activeLayoutId,
+            presetButtons  = (me.perspectiveStore?.list() || []).map(preset => ({
+                module : Button,
+                cls    : ['fm-preset-button'],
+                handler: () => me.activatePerspective(preset.perspectiveName ?? preset.layoutId),
+                pressed: preset.layoutId === activeLayoutId,
+                text   : preset.perspectiveName ?? preset.layoutId
+            }));
 
         dockConfig.flex = 1;
 
@@ -298,13 +356,21 @@ class FleetCockpit extends Container {
             ntype: 'toolbar',
             cls  : ['fm-cockpit-bar'],
             flex : 'none',
-            items: ['->', {
-                module : Button,
-                cls    : ['fm-fleet-start'],
-                iconCls: 'fa-solid fa-play',
-                text   : 'Start morning fleet',
-                handler: 'onStartFleet'
-            }]
+            items: [
+                ...presetButtons,
+                ...(me.presetError ? [{
+                    ntype: 'component',
+                    cls  : ['fm-preset-error'],
+                    html : me.presetError
+                }] : []),
+                '->', {
+                    module : Button,
+                    cls    : ['fm-fleet-start'],
+                    iconCls: 'fa-solid fa-play',
+                    text   : 'Start morning fleet',
+                    handler: 'onStartFleet'
+                }
+            ]
         }, dockConfig]
     }
 
@@ -450,6 +516,8 @@ class FleetCockpit extends Container {
         me.getReference('fleet-grid')?.store?.un({load: me.onRosterStoreLoad, scope: me});
         me.dockPreviewProducer?.destroy();
         me.dockPreviewProducer = null;
+        me.perspectiveStore?.destroy();
+        me.perspectiveStore = null;
         super.destroy(...args)
     }
 

--- a/apps/agentos/view/fleet/cockpitPresets.mjs
+++ b/apps/agentos/view/fleet/cockpitPresets.mjs
@@ -1,0 +1,65 @@
+import DockZoneModel       from '../../../../src/dashboard/DockZoneModel.mjs';
+import cockpitDockDocument from './cockpitDockDocument.mjs';
+
+/**
+ * The Fleet Cockpit's seeded perspective presets — the §01 duty variants as pure
+ * `dockLayoutCollection.v1` data over the landed saved-layout wrappers:
+ *
+ * - **Fleet** — the default mission-control split (the authored dock document, unchanged).
+ * - **Focus** — the fleet zone dominant: the ranked roster takes nearly the full column, the
+ *   activity stream stays a thin live strip (watching the fleet, not the feed).
+ * - **Review** — one agent under review: the right chrome band opens on the agent-detail pane
+ *   and the primary split leans toward the activity stream (the review evidence trail).
+ *
+ * Presets are **workspace-scope** captures (one cockpit document per record — the landed
+ * wrapper; the multi-window topology tier is its own schema and out of scope here). This is a
+ * data leaf only: a factory returning a FRESH validated collection per call — never a shared
+ * mutable singleton — so the consuming store's clone discipline never aliases an authored
+ * default. Every document round-trips the model validator by construction; a factory error is
+ * thrown loudly (an authored preset that fails validation is a build-time defect, not a
+ * runtime condition).
+ *
+ * @returns {Object} a fresh `neo.harness.dockLayoutCollection.v1` collection, `fleet` active
+ */
+export function cockpitPresetCollection() {
+    const fleetDoc = cockpitDockDocument();
+
+    const focusDoc = cockpitDockDocument();
+    focusDoc.nodes['primary-split'].sizes = [0.85, 0.15];
+
+    const reviewDoc = cockpitDockDocument();
+    reviewDoc.nodes['primary-split'].sizes = [0.45, 0.55];
+    reviewDoc.items.detail.autoHidden      = false;
+
+    const layouts = [
+        {document: fleetDoc,  layoutId: 'fleet',  perspectiveName: 'Fleet',  title: 'Fleet — mission control'},
+        {document: focusDoc,  layoutId: 'focus',  perspectiveName: 'Focus',  title: 'Focus — roster dominant'},
+        {document: reviewDoc, layoutId: 'review', perspectiveName: 'Review', title: 'Review — one agent + the trail'}
+    ].map(({document, layoutId, perspectiveName, title}) => {
+        const {layout, errors} = DockZoneModel.createSavedLayout(document, {
+            layoutId,
+            perspectiveName,
+            title,
+            metadata: {source: 'fm-cockpit-presets'}
+        });
+
+        if (errors.length) {
+            throw new Error(`cockpitPresetCollection: preset "${layoutId}" failed validation: ${errors.join('; ')}`)
+        }
+
+        return layout
+    });
+
+    const {collection, errors} = DockZoneModel.createSavedLayoutCollection(layouts, {
+        activeLayoutId: 'fleet',
+        metadata      : {owner: 'fm-cockpit'}
+    });
+
+    if (errors.length) {
+        throw new Error(`cockpitPresetCollection: collection failed validation: ${errors.join('; ')}`)
+    }
+
+    return collection
+}
+
+export default cockpitPresetCollection;

--- a/test/playwright/e2e/agentos/FleetCockpitDockNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitDockNL.spec.mjs
@@ -111,4 +111,64 @@ test.describe('AgentOS Fleet cockpit — dock projection commit loop (Neural Lin
             return ids.length > 0 && ids.every(id => !ids1.includes(id))
         }, {message: 'the NL operation must re-project like the human gesture', timeout: 10000, intervals: [100]}).toBe(true)
     });
+
+    test('perspective presets switch the committed document — one real click, then NL-verifiable switching through the same loop', async ({page, neuralLink}) => {
+        await page.goto('/apps/agentos/index.html');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+        await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
+
+        // the boot bar renders the three seeded presets, Fleet pressed
+        const focusButton = page.locator('.fm-preset-button', {hasText: 'Focus'}).first();
+        await expect(focusButton, 'the preset bar must render on the boot surface').toBeVisible({timeout: 30000});
+
+        const app      = await neuralLink.connectToApp('AgentOS'),
+              cockpits = await app.findInstances({className: 'AgentOS.view.fleet.FleetCockpit'}, ['id']),
+              holderId = Array.isArray(cockpits) ? cockpits[0]?.id : cockpits?.id;
+
+        expect(holderId, 'the FleetCockpit must exist in the App Worker').toBeTruthy();
+
+        const primarySizes = async () => {
+            const topo = await app.getDockTopology(holderId),
+                  doc  = topo?.document ?? topo;
+            return doc.nodes['primary-split'].sizes
+        };
+
+        // 1) the REAL gesture on the live boot bar: one click switches to Focus — worker truth
+        // (post-switch bar re-renders ride the open wholesale-refresh flush defect, so the
+        // remaining switches drive the NL path — which the AC names verbatim)
+        await focusButton.click();
+
+        await expect.poll(primarySizes, {message: 'the Focus click must commit the preset document', timeout: 10000, intervals: [100]})
+            .toEqual([0.85, 0.15]);
+
+        // 2) NL-verifiable switching: the same public seam a switcher UI calls
+        const {NeuralLink_InstanceService} = await import('../../../../ai/services.mjs');
+
+        const review = await NeuralLink_InstanceService.callMethod({
+            sessionId: app.sessionId, id: holderId, method: 'activatePerspective', args: ['Review']
+        });
+        expect(review?.result ?? review).toMatchObject({switched: true});
+
+        await expect.poll(primarySizes, {message: 'the Review switch must commit', timeout: 10000, intervals: [100]})
+            .toEqual([0.45, 0.55]);
+
+        const topoReview = await app.getDockTopology(holderId),
+              docReview  = topoReview?.document ?? topoReview;
+        expect(docReview.items.detail.autoHidden, 'Review must open the detail band').toBe(false);
+
+        // ...and back to the default duty
+        await NeuralLink_InstanceService.callMethod({
+            sessionId: app.sessionId, id: holderId, method: 'activatePerspective', args: ['Fleet']
+        });
+
+        await expect.poll(primarySizes, {message: 'the Fleet switch must restore the default split', timeout: 10000, intervals: [100]})
+            .toEqual([0.6078, 0.3922]);
+
+        // a refused switch fails closed: worker truth unchanged, the refusal recorded
+        const ghost = await NeuralLink_InstanceService.callMethod({
+            sessionId: app.sessionId, id: holderId, method: 'activatePerspective', args: ['Ghost']
+        });
+        expect((ghost?.result ?? ghost)?.switched).toBe(false);
+        expect(await primarySizes()).toEqual([0.6078, 0.3922])
+    });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
@@ -175,3 +175,122 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
         expect(nodes.filter(node => node.cls?.includes('fm-pane-placeholder')).length).toBe(0)
     });
 });
+
+/**
+ * Covers the perspective presets — named workspace-scope layouts switching the committed
+ * document through the SAME commit loop every other dock gesture uses. The units: the seeded
+ * library validates and adopts, a switch restores fail-closed and commits deferred, pane
+ * continuity is STATE continuity (owner-held fields and the preset library untouched by a
+ * switch), a refused switch renders visibly with the live layout byte-untouched, and the
+ * control bar derives from store state.
+ */
+test.describe('Fleet cockpit — perspective presets (the switch through the commit loop)', () => {
+    let DockPerspectiveStore, DockZoneModel, FleetCockpit, cockpitPresetCollection, Neo;
+
+    const makePresetHost = async (overrides = {}) => {
+        const store = Neo.create(DockPerspectiveStore, {collection: cockpitPresetCollection()});
+
+        return Object.assign(Object.create(FleetCockpit.prototype), {
+            dockModel         : (await import('../../../../../../../apps/agentos/view/fleet/cockpitDockDocument.mjs')).default(),
+            gridAdapterState  : 'sample',
+            isDestroyed       : false,
+            perspectiveStore  : store,
+            presetError       : null,
+            streamAdapterState: 'sample',
+            streamEvents      : [],
+            timeout           : ms => new Promise(resolve => setTimeout(resolve, ms))
+        }, overrides)
+    };
+
+    test.beforeAll(async () => {
+        Neo                     = (await import('../../../../../../../src/Neo.mjs')).default;
+        DockPerspectiveStore    = (await import('../../../../../../../src/dashboard/DockPerspectiveStore.mjs')).default;
+        DockZoneModel           = (await import('../../../../../../../src/dashboard/DockZoneModel.mjs')).default;
+        FleetCockpit            = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default;
+        cockpitPresetCollection = (await import('../../../../../../../apps/agentos/view/fleet/cockpitPresets.mjs')).default
+    });
+
+    test('the seeded library validates whole and lists the three duty presets, Fleet active', () => {
+        const collection = cockpitPresetCollection();
+
+        expect(DockZoneModel.validateSavedLayoutCollection(collection)).toEqual([]);
+        expect(collection.activeLayoutId).toBe('fleet');
+
+        const store = Neo.create(DockPerspectiveStore, {collection});
+
+        expect(store.list().map(preset => preset.perspectiveName)).toEqual(['Fleet', 'Focus', 'Review']);
+        store.destroy()
+    });
+
+    test('a switch restores the preset document through the standard commit loop — stored synchronously, re-projected deferred', async () => {
+        let refreshed = 0;
+
+        const host = await makePresetHost({refreshDockWorkspace() { refreshed++ }});
+
+        const verdict = FleetCockpit.prototype.activatePerspective.call(host, 'Focus');
+
+        expect(verdict).toEqual({errors: [], switched: true});
+        expect(host.presetError).toBeNull();
+        // the restored document is the live SSOT immediately, with Focus geometry
+        expect(host.dockModel.nodes['primary-split'].sizes).toEqual([0.85, 0.15]);
+        // the preset library tracks the active record
+        expect(host.perspectiveStore.collection.activeLayoutId).toBe('focus');
+        // deferred view-sync, same as every commit
+        expect(refreshed).toBe(0);
+        await new Promise(resolve => setTimeout(resolve, 5));
+        expect(refreshed).toBe(1);
+
+        // Review opens the detail band and leans the split toward the trail
+        FleetCockpit.prototype.activatePerspective.call(host, 'Review');
+        expect(host.dockModel.nodes['primary-split'].sizes).toEqual([0.45, 0.55]);
+        expect(host.dockModel.items.detail.autoHidden).toBe(false);
+
+        host.perspectiveStore.destroy()
+    });
+
+    test('pane continuity across a switch is STATE continuity: owner-held fields and the resolver output survive untouched', async () => {
+        const events = [{type: 'pr-activity', payload: {text: 'live-held'}}],
+              host   = await makePresetHost({
+                  gridAdapterState  : 'live',
+                  refreshDockWorkspace() {},
+                  streamAdapterState: 'live',
+                  streamEvents      : events
+              });
+
+        FleetCockpit.prototype.activatePerspective.call(host, 'Focus');
+
+        // the switch touched the LAYOUT SSOT only — held pane state is not its surface
+        expect(host.gridAdapterState).toBe('live');
+        expect(host.streamAdapterState).toBe('live');
+        expect(host.streamEvents).toBe(events);
+
+        // and the next re-materialization carries that state into the rebuilt panes
+        const grid = FleetCockpit.prototype.resolveDockComponentRef.call(host, 'fleet-grid', {title: 'Fleet'}, 'fleet');
+        expect(grid.adapterState).toBe('live');
+
+        host.perspectiveStore.destroy()
+    });
+
+    test('a refused switch fails closed VISIBLY: the live layout stays byte-identical and the error renders in the bar', async () => {
+        let refreshed = 0;
+
+        const host   = await makePresetHost({refreshDockWorkspace() { refreshed++ }}),
+              before = JSON.stringify(host.dockModel);
+
+        const verdict = FleetCockpit.prototype.activatePerspective.call(host, 'ghost');
+
+        expect(verdict.switched).toBe(false);
+        expect(verdict.errors.join(' ')).toContain('no perspective named');
+        expect(JSON.stringify(host.dockModel)).toBe(before);
+        expect(host.presetError).toContain('ghost');
+        // the error path re-renders the bar (visible refusal), without a document commit
+        expect(refreshed).toBe(1);
+
+        // the bar derives from state: pressed follows the active record, the error chip renders
+        const bar = FleetCockpit.prototype.buildWorkspaceItems.call(host)[0];
+        expect(bar.items.filter(item => item.cls?.includes('fm-preset-button')).map(item => item.pressed)).toEqual([true, false, false]);
+        expect(bar.items.find(item => item.cls?.includes('fm-preset-error'))?.html).toContain('ghost');
+
+        host.perspectiveStore.destroy()
+    });
+});


### PR DESCRIPTION
Resolves #15008

Related: #14616 — the live-instance identity remainder stays OPEN (its ACs bind stable `componentRef` to the SAME live pane instance across projection per the docking design's pane contract; the reviewer's exact-head falsifier proved this PR's switch rebuilds instances, so that contract is deliberately NOT claimed here — its owner drives it as the adapter-tier successor).

The cockpit's named duty layouts — **Fleet / Focus / Review** — switching the committed dock document through the SAME commit loop every other dock gesture uses. The preset library is a `DockPerspectiveStore` over a seeded `dockLayoutCollection.v1` (workspace-scope captures — the landed wrapper; the multi-window `dockPerspective.v1` topology tier is explicitly NOT this scope per the settled spec's two-scope table). A switch is `loadPerspective` (the landed fail-closed restore: validate everything before mutating anything) feeding `onDockZoneDocumentChange` — so the transition re-projects FLIP-animated exactly like a splitter commit, and reduced-motion collapses through the token layer by construction, not per call site.

**Scope honesty (converged in review):** what ships here is the **state-backed** preset layer over today's rebuild-model projection — pane instances are destroyed/recreated by the switch (the reviewer's live falsifier confirmed it), with continuity delivered at the STATE tier: a switch touches only the layout SSOT, owner-held pane state (`gridAdapterState` / `streamEvents`) survives untouched, the next re-materialization carries it, and the provider-owned roster store never restarts (fixture-asserted). The **instance-identity** tier — the same live instance moved, never destroyed — is #14616's remainder, not claimed by this PR.

**Fail-closed is VISIBLE:** a refused switch (unknown name; any validator refusal) leaves the live document byte-identical, records `presetError` on the owner, and re-renders the control bar with an error chip — a refusal can never look like a silent no-op. The store's whole-candidate validation covers the deep corrupt-record class upstream (its own falsifier suite).

**The bar:** one button per stored perspective (pressed follows `activeLayoutId`), derived from store state on every rebuild — the post-switch re-projection updates pressed states for free. The `perspectives` rail pane keeps its honest placeholder: the fuller management surface (save-current / rename / delete UI) is the switcher leaf's scope, not this one's.

Evidence: L3 (real preset-button click committing the Focus document on the mounted cockpit + NL-driven `activatePerspective` switching Review/Fleet + the fail-closed ghost refusal with worker truth intact — plus the full agentos e2e suite) → L3 required (the AC names NL-verifiable switching verbatim). Residual: the post-switch BAR re-render's DOM flush rides the open wholesale-refresh reconciliation defect like every re-projection on this surface (worker truth + one live-bar gesture fully proven; the journey drives subsequent switches through the NL seam by design).

## Deltas from ticket

- The close-target converged in review: this PR delivers the state-backed layer under #15008 (its honest scope); #14616's instance-identity contract stays open as its owner's remainder — the review record on this PR carries the full reasoning.
- The originally-cited `blocked-by` on the source ticket predated its own blocker's closure (the perspective-semantics spec settled 2026-07-02; the store ships its §2 semantics) — recorded at intake as satisfied, not bypassed.
- The preset bar lives in the cockpit control bar (operable-cold, always visible) rather than behind the auto-hidden rail pane — a hidden switcher would defeat the "operator switches instead of hand-dragging" premise.

## Test Evidence

At head `5c7fcd580`:

```
npm run test-unit -- test/playwright/unit/apps/agentos/ --workers=1
197 passed / 1 failed — the red is fleetGrid.spec.mjs:103, the PRE-EXISTING sweep-order heap-bleed (convicted on clean dev; repro triple in PR #14996's body; its owner has the flag)

NEO_E2E_PORT=8117 npx playwright test agentos -c test/playwright/playwright.config.e2e.mjs --workers=1
6 passed — the FULL agentos e2e suite, including the new perspective journey (real Focus click → worker-verified commit; NL Review/Fleet switches; ghost refusal fail-closed) and every sibling surface
```

The four new unit specs: the seeded library validates whole + lists the three duty presets; a switch restores through the standard commit loop (stored synchronously, re-projected deferred, active record tracked); state continuity across a switch (owner-held fields + resolver output + the library untouched); the refused switch fails closed visibly (byte-identical document, error chip rendered, pressed states derived from store state).

## Post-Merge Validation

- [ ] When the wholesale-refresh reconciliation defect closes, extend the journey with the bounded-frame DOM-convergence poll (the witness shape its owner confirmed) covering the post-switch bar + pane flush.
- [ ] The switcher leaf (save-current / rename / delete management UI) replaces the `perspectives` rail placeholder and consumes the same store seam.

Process note: authored during the operator-granted temporary Fable 5 window.

Authored by Grace (Claude Fable 5, Claude Code). Session ef6b9a4a-54ec-4afb-8438-f89a3ee46ad2
