### PR TITLE
fix(fleet): close credential recovery boundaries (#15005)

### DIFF
--- a/ai/services/fleet/FleetRegistryService.mjs
+++ b/ai/services/fleet/FleetRegistryService.mjs
@@ -8,13 +8,22 @@ import {HARNESS_TYPES}             from '../../../src/ai/fleet/harnessTypes.mjs'
 import {normalizeMcpOverrides}     from '../../../src/ai/fleet/mcpServers.mjs';
 
 const
-    __filename           = fileURLToPath(import.meta.url),
-    __dirname            = path.dirname(__filename),
-    PUBLIC_REDACTED_KEYS = new Set([
-        'credential', 'credentials', 'pat', 'githubpat', 'token', 'tokens', 'accesstoken',
-        'githubtoken', 'apitoken', 'secret', 'secrets', 'password', 'apikey', 'command', 'args',
-        'env', 'launch'
-    ]);
+    __filename              = fileURLToPath(import.meta.url),
+    __dirname               = path.dirname(__filename),
+    PUBLIC_SENSITIVE_KEY_RE = /^(?:credentials?|secrets?|tokens?|(?:github)?pats?|passwords?|authorization|(?:api|client|private)(?:key|token|secret|credential|password)s?|personalaccess(?:key|token|secret|credential|password)s?|(?:access|auth|bearer|github|id|oauth|refresh|session)(?:key|token|secret|credential|password)s?|launch|command|args|argv|env|environment)$/;
+
+/**
+ * @summary Returns whether a normalized public-definition key carries credential or launch
+ * authority. Anchoring is deliberate: `refreshToken` and `client_secret` are denied, while benign
+ * descriptive fields such as `credentialState`, `tokenBudget`, and `commandLabel` survive.
+ * @param {String} key
+ * @returns {Boolean}
+ */
+function isPublicSensitiveKey(key) {
+    const normalized = key.replaceAll('-', '').replaceAll('_', '').toLowerCase();
+
+    return PUBLIC_SENSITIVE_KEY_RE.test(normalized)
+}
 
 /**
  * @summary Recursively remove credential/launch vocabulary from a caller-owned public projection.
@@ -32,9 +41,7 @@ function redactPublicFields(value, seen=new WeakSet()) {
     seen.add(value);
 
     Object.keys(value).forEach(key => {
-        const normalized = key.replaceAll('-', '').replaceAll('_', '').toLowerCase();
-
-        if (PUBLIC_REDACTED_KEYS.has(normalized)) {
+        if (isPublicSensitiveKey(key)) {
             delete value[key]
         } else {
             redactPublicFields(value[key], seen)
@@ -184,6 +191,16 @@ class FleetRegistryService extends Base {
             throw new Error(`FleetRegistryService.defineAgent: id '${agentId}' already exists; use a scoped update operation.`)
         }
 
+        const previousCredentials = this.readCredentials();
+
+        // A process crash or failed rollback can leave a credential without its registry row.
+        // Credentialless creation MUST NOT silently adopt that orphan for a later caller. An
+        // explicit credential-bearing retry is the recovery authority: it overwrites the orphan
+        // before the public row publishes.
+        if (credential == null && Object.hasOwn(previousCredentials, agentId)) {
+            throw new Error(`FleetRegistryService.defineAgent: orphan credential exists for id '${agentId}'; credentialless creation refused. Retry with an explicit credential.`)
+        }
+
         const
             def        = {
                 id            : agentId,
@@ -202,14 +219,13 @@ class FleetRegistryService extends Base {
         nextAgents.set(agentId, def);
 
         if (credential != null) {
-            const
-                previousCredentials = this.readCredentials(),
-                nextCredentials     = Object.assign(Object.create(null), previousCredentials, {[agentId]: credential});
+            const nextCredentials = Object.assign(Object.create(null), previousCredentials, {[agentId]: credential});
 
             // Two-store create transaction: credential first, registry row last. A credential
             // failure cannot strand an unrecoverable create-only resident. If registry publish
-            // fails, restore the prior credential snapshot; the absent row remains retryable even
-            // if the best-effort rollback itself encounters a second storage failure.
+            // fails, restore the prior credential snapshot. If rollback itself fails or the
+            // process dies between files, the orphan guard above refuses credentialless adoption;
+            // an explicit credential-bearing retry remains recoverable.
             this.writeCredentials(nextCredentials);
 
             try {

--- a/test/playwright/unit/ai/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/FleetRegistryService.spec.mjs
@@ -142,6 +142,52 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService', () => {
         expect(FleetRegistryService.resolveCredential('rollback-agent')).toBe('ghp_recovered')
     });
 
+    test('a failed rollback leaves an orphan that credentialless creation cannot inherit', () => {
+        const
+            writeCredentials = FleetRegistryService.writeCredentials,
+            writeRegistry    = FleetRegistryService.writeRegistry;
+
+        let credentialWrites = 0;
+
+        FleetRegistryService.writeCredentials = credentials => {
+            credentialWrites++;
+
+            if (credentialWrites === 2) {
+                throw new Error('rollback disk full')
+            }
+
+            return writeCredentials.call(FleetRegistryService, credentials)
+        };
+        FleetRegistryService.writeRegistry = () => { throw new Error('registry disk full') };
+
+        try {
+            expect(() => FleetRegistryService.defineAgent({
+                githubUsername: 'orphan-agent',
+                harnessType   : 'codex',
+                credential    : 'ORPHAN_SECRET'
+            })).toThrow(/registry disk full/)
+        } finally {
+            FleetRegistryService.writeCredentials = writeCredentials;
+            FleetRegistryService.writeRegistry    = writeRegistry
+        }
+
+        expect(FleetRegistryService.getAgent('orphan-agent')).toBeNull();
+        expect(FleetRegistryService.resolveCredential('orphan-agent')).toBe('ORPHAN_SECRET');
+
+        expect(() => FleetRegistryService.defineAgent({
+            githubUsername: 'orphan-agent',
+            harnessType   : 'codex'
+        })).toThrow(/orphan credential.*credentialless creation refused/);
+        expect(FleetRegistryService.getAgent('orphan-agent')).toBeNull();
+
+        expect(FleetRegistryService.defineAgent({
+            githubUsername: 'orphan-agent',
+            harnessType   : 'codex',
+            credential    : 'RECOVERED_SECRET'
+        }).id).toBe('orphan-agent');
+        expect(FleetRegistryService.resolveCredential('orphan-agent')).toBe('RECOVERED_SECRET')
+    });
+
     test('CRUD round-trip: define -> list -> get -> remove', () => {
         FleetRegistryService.defineAgent({githubUsername: 'agent-a', harnessType: 'codex',       credential: 'ghp_a'});
         FleetRegistryService.defineAgent({githubUsername: 'agent-b', harnessType: 'antigravity', credential: 'ghp_b'});

--- a/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs
@@ -132,14 +132,25 @@ test.describe('Neo.ai.services.fleet.FleetRegistryService — the raw-launch sec
             githubUsername: 'nested-sec',
             harnessType   : 'codex',
             metadata      : {
-                credential: 'caller-secret',
-                nested    : {secret: 'x', command: '/bin/sh', args: ['-c'], env: {TOKEN: 'x'}},
-                repo      : {managedPath: '/safe/path', repoSlug: 'x/y'}
+                credential   : 'caller-secret',
+                refreshToken : 'refresh-secret',
+                session_token: 'session-secret',
+                client_secret: 'client-secret',
+                authorization: 'Bearer secret',
+                nested       : {secret: 'x', privateKey: 'key-secret', command: '/bin/sh', argv: ['-c'], env: {TOKEN: 'x'}},
+                benign       : {credentialState: 'stored', tokenBudget: 64, commandLabel: 'Codex', environmentName: 'local'},
+                repo         : {managedPath: '/safe/path', repoSlug: 'x/y'}
             }
         });
 
         for (const projection of [created, FleetRegistryService.getAgent('nested-sec'), FleetRegistryService.listAgents()[0]]) {
-            expect(JSON.stringify(projection)).not.toMatch(/caller-secret|"credential"|"secret"|"command"|"args"|"env"/);
+            expect(JSON.stringify(projection)).not.toMatch(/caller-secret|refresh-secret|session-secret|client-secret|Bearer secret|key-secret|"credential"|"secret"|"command"|"argv"|"env"/);
+            expect(projection.metadata.benign).toEqual({
+                credentialState: 'stored',
+                tokenBudget    : 64,
+                commandLabel   : 'Codex',
+                environmentName: 'local'
+            });
             expect(projection.metadata.repo).toEqual({managedPath: '/safe/path', repoSlug: 'x/y'})
         }
 


### PR DESCRIPTION
Resolves #15005

Closes two Fleet registry security boundaries discovered by the post-merge author-defense audit of PR #14998: credentialless creation can no longer inherit an orphaned secret left by a failed cross-file rollback, and public projections now redact anchored credential-key families without hiding benign metadata.

Evidence: L2 (failure-injection plus exact-head focused contract tests) → L2 required (local registry recovery and public projection boundaries). Residual: none.

## Contract Ledger

| Surface | Source of authority | Accepted behavior | Fail-closed behavior | Evidence |
| --- | --- | --- | --- | --- |
| `FleetRegistryService.defineAgent()` | registry row plus encrypted credential snapshot | an explicit credential-bearing retry may replace an orphan and publish the row | a credentialless create refuses a credential entry that has no registry owner | rollback-failure regression in the canonical registry spec |
| public Fleet projections | anchored sensitive-key classifier | benign names such as `credentialState`, `tokenBudget`, `commandLabel`, and `environmentName` remain visible | credential, token, secret, authorization, private-key, argv, env, and launch key families are removed recursively | positive and negative projection matrix |

## Deltas from ticket

None substantive. The implementation follows the ticketed recovery invariant and anchored classifier shape.

## Test Evidence

- `node --check ai/services/fleet/FleetRegistryService.mjs` — passed.
- `git diff --check origin/dev...HEAD` — passed.
- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/FleetRegistryService.spec.mjs test/playwright/unit/ai/services/fleet/FleetRegistryService.spec.mjs` — 38/38 passed after rebasing onto the merged PR #14998 head.
- Broader Fleet registry, bridge, transport, Accounts, and configuration focused set — 108/108 passed before the clean rebase; the rebased delta is the same single security commit.

## Post-Merge Validation

- [ ] Confirm the merged-head focused Fleet registry suites remain green on `dev`.
- [ ] Confirm no public Fleet response exposes the covered credential-key variants in the packaged harness path.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session 019f484c-662f-7f31-969a-cbde373efd4a.