### PR TITLE
fix(dockdemo): reveal cue awaits the deferred re-projection settle (#15009)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoAWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoAWorkspace.mjs
@@ -119,6 +119,17 @@ class DemoAWorkspace extends Container {
      * @protected
      */
     dragSuppressed = false
+    /**
+     * The in-flight deferred re-projection, tracked as an awaitable. Every committed
+     * operation defers its view-sync one tick ({@link #onDockZoneDocumentChange}); any
+     * consumer that must resolve PROJECTED components — the reveal cue path — awaits this
+     * promise instead of racing that deferral (an unawaited lookup runs within ~0ms of
+     * the commit, resolves `null`, and no-ops silently). Stale-safe: each commit
+     * overwrites it, so awaiting always settles on the LATEST projection.
+     * @member {Promise|null} refreshPromise=null
+     * @protected
+     */
+    refreshPromise = null
 
     /**
      * @param {Object} config
@@ -257,9 +268,9 @@ class DemoAWorkspace extends Container {
 
         me.dockModel = document;
 
-        me.timeout(0).then(() => {
+        me.refreshPromise = me.timeout(0).then(() => {
             if (!me.isDestroyed) {
-                me.refreshDockWorkspace()
+                return me.refreshDockWorkspace()
             }
         })
     }
@@ -476,7 +487,7 @@ class DemoAWorkspace extends Container {
      * and lights its pip.
      * @param {Object} data The runner's beat payload.
      */
-    onTourBeat(data) {
+    async onTourBeat(data) {
         let me = this;
 
         data.caption && me.setTourCaption(data.caption);
@@ -486,6 +497,13 @@ class DemoAWorkspace extends Container {
         // machine through the same entry a native tab click uses (runtime-only; the next
         // committed operation's re-projection releases the overlay)
         if (data.cue?.type === 'reveal') {
+            // the preceding commit's re-projection is deferred one tick — the rail this cue
+            // targets exists only after it lands. Await the tracked settle, or the lookup
+            // below resolves null and the chain no-ops silently.
+            await me.refreshPromise;
+
+            if (me.isDestroyed) return;
+
             me.getReference('dock-host')
                 ?.down({ntype: 'dashboard-dock-rail'})
                 ?.onTabClick({component: {dockItemId: data.cue.itemId}})


### PR DESCRIPTION
Resolves #15009

## Summary

The Demo-A tour's reveal beat **never executed once** — the flagship dock-choreography demo narrated a reveal that did not happen, and the merged `DemoATourNL` spec has stood honestly red on `revealSeen` since it landed. That red was attributed to the vdom update wedge (`#14985` / the `#12946` class); tonight's three-run forensics falsified the attribution and convicted an app-level race instead.

**The mechanism (all three parties behaving by design):**
1. `onDockZoneDocumentChange` stores the committed document immediately but defers `refreshDockWorkspace()` one tick (the normative teardown guard);
2. the tour runner fires the `beat` event (carrying the cue) before executing the step, and `executeDockOperation` resolves at document-commit — the runner is document-tier and never awaits view-sync;
3. the reveal cue rides the pause beat immediately after three tuck commits: its `down({ntype: 'dashboard-dock-rail'})` runs within ~0ms of the last commit, the rail is not yet projected, and the triple-optional-chain swallows the `null` silently. The 1600ms pause then elapses uselessly.

**Conviction evidence** (instance-field trail at the live cue moment): `{hostFound: true, railFound: false, beat: 14}` — while worker/DOM agreement (`isVdomUpdating:false`, both sides `sem-hidden`, 4672 DOM frames / 0 visible) proved no update was ever sent, i.e. NOT the wedge.

## Deltas

- `apps/agentos/childapps/dockdemo/view/DemoAWorkspace.mjs`
  - new `refreshPromise` field: every commit's deferred view-sync tracked as an awaitable; each commit overwrites it, so consumers always settle on the LATEST projection (stale-safe).
  - `onDockZoneDocumentChange` assigns the tracked chain (behavior otherwise unchanged).
  - `onTourBeat` (now async) reveal path: `await me.refreshPromise` + `isDestroyed` guard before rail resolution. No wall-clock sleeps, no retry-polling, no runner changes.

## Test Evidence

- Evidence: `DemoATourNL.spec.mjs` — the standing red flips green **3/3 consecutive runs**; the overlay-state histogram inverts from `{sem-hidden: 4672, visible: 0}` to `{flex/visible/sem-visible: 3414, hidden: 0}` — the reveal overlay now genuinely opens mid-tour and is released by the following commit's re-projection.
- Evidence: `DemoADragMenuNL.spec.mjs` — 3/3 green (drag affordances unaffected by the tracked promise).
- Evidence: dockdemo unit suites (`DemoAWorkspace` + `DemoBWorkspace`) — 20/20 green.
- Evidence: the scratch forensic spec used for conviction was deleted; the EXISTING merged spec is the permanent regression witness.

## Post-Merge Validation

- `#14985` reattribution comment: the tour-red witness is withdrawn as wedge evidence; the FM-cockpit repro (from `#14658` / PR `#14996` instrumentation) remains its sole standing witness — the wedge investigation continues on that seam.
- Full dashboard e2e sweep on dev tip after merge.

Authored by @neo-fable-clio

🤖 Generated with [Claude Code](https://claude.com/claude-code)