### PR TITLE
fix(test): route six NL fixture wrappers to their owning services (#15011)

### DIFF
--- a/test/playwright/fixtures.mjs
+++ b/test/playwright/fixtures.mjs
@@ -159,7 +159,8 @@ export const test = base.extend({
                      * @returns {Promise<Object>}
                      */
                     async inspectClass(className, detail = 'standard') {
-                        return NeuralLink_InstanceService.inspectClass({ sessionId, className, detail });
+                        // RuntimeService owns inspect_class (authority: the MCP toolService routing table)
+                        return NeuralLink_RuntimeService.inspectClass({ sessionId, className, detail });
                     },
 
                     /**
@@ -169,7 +170,8 @@ export const test = base.extend({
                      * @returns {Promise<Object>}
                      */
                     async getMethodSource(className, methodName) {
-                        return NeuralLink_InstanceService.getMethodSource({ sessionId, className, methodName });
+                        // RuntimeService owns get_method_source (authority: the MCP toolService routing table)
+                        return NeuralLink_RuntimeService.getMethodSource({ sessionId, className, methodName });
                     },
 
                     /**
@@ -181,7 +183,8 @@ export const test = base.extend({
                      * @returns {Promise<Object>}
                      */
                     async patchCode(className, methodName, source) {
-                        return NeuralLink_InstanceService.patchCode({ sessionId, className, methodName, source });
+                        // RuntimeService owns patch_code (authority: the MCP toolService routing table)
+                        return NeuralLink_RuntimeService.patchCode({ sessionId, className, methodName, source });
                     },
 
                     // --- Instance Methods ---
@@ -324,7 +327,8 @@ export const test = base.extend({
                      * @returns {Promise<Object>}
                      */
                     async highlightComponent(componentId, options) {
-                        return NeuralLink_ComponentService.highlightComponent({ sessionId, componentId, options });
+                        // InteractionService owns highlight_component (authority: the MCP toolService routing table)
+                        return NeuralLink_InteractionService.highlightComponent({ sessionId, componentId, options });
                     },
 
                     /**
@@ -533,7 +537,8 @@ export const test = base.extend({
                      * @returns {Promise<Object>}
                      */
                     async getConsoleLogs(type, filter) {
-                        return NeuralLink_RuntimeService.getConsoleLogs({ sessionId, type, filter });
+                        // ConnectionService owns get_console_logs (authority: the MCP toolService routing table)
+                        return NeuralLink_ConnectionService.getConsoleLogs({ sessionId, type, filter });
                     },
 
                     /**
@@ -567,7 +572,8 @@ export const test = base.extend({
                      * @returns {Promise<Object>}
                      */
                     async getDragState() {
-                        return NeuralLink_RuntimeService.getDragState({ sessionId });
+                        // InteractionService owns get_drag_state (authority: the MCP toolService routing table)
+                        return NeuralLink_InteractionService.getDragState({ sessionId });
                     },
 
                     /**


### PR DESCRIPTION
Resolves #15011

## Summary

Six `test/playwright/fixtures.mjs` wrappers called NL services that never owned the method — each died with `TypeError: ... is not a function` at exactly the moment the instrument was needed. Two were found by use during the `#14985` forensics (worker-console reads are the ONLY truthful console surface for SharedWorker apps; `patchCode` is the hot-instrumentation lever); the ticket's audit AC then found four more by mechanically diffing every fixture wrapper against the MCP toolService routing table (`ai/mcp/server/neural-link/toolService.mjs`), which is the authority map.

| Wrapper | Fixture called | Owner (routing table) |
|---|---|---|
| `getConsoleLogs` | RuntimeService | **ConnectionService** |
| `patchCode` | InstanceService | **RuntimeService** |
| `inspectClass` | InstanceService | **RuntimeService** |
| `getMethodSource` | InstanceService | **RuntimeService** |
| `highlightComponent` | ComponentService | **InteractionService** |
| `getDragState` | RuntimeService | **InteractionService** |

V-B-A per row: each method exists ONLY on the routing-table service (grepped every `ai/services/neural-link/*.mjs`); none is a duplicated implementation. `waitForSession` (fixture-internal, not an MCP tool) was checked and is correctly on ConnectionService.

## Deltas

- `test/playwright/fixtures.mjs` — six one-line service-object corrections, each with a one-line ownership comment citing the routing-table authority. No signatures, payloads, or behavior changed; wiring only.

## Test Evidence

- Evidence: live probe spec against the running dockdemo app (scratch, deleted before commit) exercised all six repaired wrappers — every one now reaches its seam: `getConsoleLogs` returned actual app-worker entries, `inspectClass` the full class shape (`className/ntype/ntypeChain/superClass/mixins`), `getMethodSource` `{success, source}`, `getDragState` a structured state, `highlightComponent` `{success}`, `patchCode` a structured `{success, error}` (the hot-patching config gates the actual patch — routing proven, refusal structured). Zero `is not a function` remained; probe assertion green.
- Evidence: `DemoADragMenuNL.spec.mjs` 3/3 green (the heaviest live fixture consumer on this surface).

## Post-Merge Validation

- The `#14985` cockpit-seam investigation consumes `getConsoleLogs` as its first instrument (the `#12956` wedge watchdog reports there); its output on the FM cockpit surface is the next probe.

Authored by @neo-fable-clio

🤖 Generated with [Claude Code](https://claude.com/claude-code)