### PR TITLE
feat(ai): serving-cost meter — the measurement instrument for the always-on inference load (#14687)

### DIFF
--- a/ai/scripts/benchmark/helpers/servingCostCore.mjs
+++ b/ai/scripts/benchmark/helpers/servingCostCore.mjs
@@ -56,24 +56,35 @@ export function classifySample(sample, activeCpuThreshold) {
  * as a coverage gap — its duration is EXCLUDED from phase time (never guessed into idle), and
  * the gap count is reported so the window's honesty is inspectable.
  *
+ * Boundary accounting: without the REQUESTED bounds, "covered" only spans first→last sample —
+ * a nominal 1h run whose endpoint appeared for its final 10s would read as a clean 10s window
+ * with zero gaps. Passing `windowBounds` makes the absence VISIBLE: leading/trailing
+ * unavailable durations plus a coverage ratio against the nominal window.
+ *
  * @param {ResourceSample[]} samples Chronologically ordered samples of ONE role.
  * @param {Object} options
  * @param {Number} options.activeCpuThreshold The phase heuristic threshold (travels into disclaimers).
  * @param {Number} options.expectedIntervalMs The sampler's nominal tick.
  * @param {Number} [options.gapFactor=3] Multiples of the nominal tick that constitute a gap.
+ * @param {Object} [options.windowBounds] The REQUESTED sampling window `{startMs, endMs}`.
  * @returns {{
  *     activeMs: Number, idleMs: Number, coveredMs: Number, windowStartMs: Number, windowEndMs: Number,
  *     dutyCycle: Number, sampleCount: Number, gapCount: Number, gapMs: Number,
- *     rssHighWaterBytes: Number, rssMeanBytes: Number, cpuMeanPercent: Number, cpuActiveMeanPercent: Number
+ *     rssHighWaterBytes: Number, rssMeanBytes: Number, cpuMeanPercent: Number, cpuActiveMeanPercent: Number,
+ *     leadingUnavailableMs: Number|null, trailingUnavailableMs: Number|null, nominalWindowMs: Number|null, coverageRatio: Number|null
  * }}
  */
-export function aggregateWindow(samples, {activeCpuThreshold, expectedIntervalMs, gapFactor = 3}) {
+export function aggregateWindow(samples, {activeCpuThreshold, expectedIntervalMs, gapFactor = 3, windowBounds = null}) {
     if (!Array.isArray(samples) || samples.length < 2) {
         throw new Error('aggregateWindow: at least two chronologically ordered samples are required')
     }
 
     if (!Number.isFinite(expectedIntervalMs) || expectedIntervalMs <= 0) {
         throw new Error(`aggregateWindow: expectedIntervalMs must be a positive finite number, got ${expectedIntervalMs}`)
+    }
+
+    if (windowBounds !== null && (!Number.isFinite(windowBounds.startMs) || !Number.isFinite(windowBounds.endMs) || windowBounds.endMs <= windowBounds.startMs)) {
+        throw new Error('aggregateWindow: windowBounds requires finite startMs < endMs')
     }
 
     let activeMs         = 0,
@@ -122,10 +133,25 @@ export function aggregateWindow(samples, {activeCpuThreshold, expectedIntervalMs
         phase === 'active' ? (activeMs += intervalMs) : (idleMs += intervalMs)
     });
 
-    const coveredMs = activeMs + idleMs;
+    const coveredMs     = activeMs + idleMs,
+          firstSampleMs = samples[0].atMs,
+          lastSampleMs  = samples[samples.length - 1].atMs;
+
+    let coverageRatio         = null,
+        leadingUnavailableMs  = null,
+        nominalWindowMs       = null,
+        trailingUnavailableMs = null;
+
+    if (windowBounds !== null) {
+        nominalWindowMs       = windowBounds.endMs - windowBounds.startMs;
+        leadingUnavailableMs  = Math.max(0, firstSampleMs - windowBounds.startMs);
+        trailingUnavailableMs = Math.max(0, windowBounds.endMs - lastSampleMs);
+        coverageRatio         = coveredMs / nominalWindowMs
+    }
 
     return {
         activeMs,
+        coverageRatio,
         coveredMs,
         cpuActiveMeanPercent: activeSampleHits > 0 ? cpuActiveSum / activeSampleHits : 0,
         cpuMeanPercent      : cpuSum / samples.length,
@@ -133,11 +159,14 @@ export function aggregateWindow(samples, {activeCpuThreshold, expectedIntervalMs
         gapCount,
         gapMs,
         idleMs,
+        leadingUnavailableMs,
+        nominalWindowMs,
         rssHighWaterBytes   : rssHighWater,
         rssMeanBytes        : rssSum / samples.length,
         sampleCount         : samples.length,
-        windowEndMs         : samples[samples.length - 1].atMs,
-        windowStartMs       : samples[0].atMs
+        trailingUnavailableMs,
+        windowEndMs         : lastSampleMs,
+        windowStartMs       : firstSampleMs
     }
 }
 
@@ -171,10 +200,14 @@ export function buildMetricBags(aggregate, identity) {
         }
     }
 
-    const source     = `serving-cost-meter:${identity.hardwareId}`,
+    const boundary = aggregate.nominalWindowMs !== null
+              ? `; requested window ${aggregate.nominalWindowMs}ms, coverage ratio ${(aggregate.coverageRatio ?? 0).toFixed(4)}, ` +
+                `leading/trailing unavailable ${aggregate.leadingUnavailableMs}ms/${aggregate.trailingUnavailableMs}ms`
+              : '',
+          source     = `serving-cost-meter:${identity.hardwareId}`,
           disclaimer = `phase split is a cpu-threshold heuristic (active >= ${identity.activeCpuThreshold}% pcpu), ` +
                        `not request tracing; co-resident load on the reference machine is not isolated; ` +
-                       `coverage: ${aggregate.sampleCount} samples, ${aggregate.gapCount} gaps (${aggregate.gapMs}ms excluded)`;
+                       `coverage: ${aggregate.sampleCount} samples, ${aggregate.gapCount} gaps (${aggregate.gapMs}ms excluded)${boundary}`;
 
     const bag = (metricName, value, unit) => ({
         metricName,

--- a/ai/scripts/benchmark/helpers/servingCostCore.mjs
+++ b/ai/scripts/benchmark/helpers/servingCostCore.mjs
@@ -1,0 +1,204 @@
+/**
+ * @module ai/scripts/benchmark/helpers/servingCostCore
+ * @summary The pure aggregation core of the serving-cost meter: process-resource samples in,
+ * phase-classified duty-cycle aggregates and validated `METRIC` property bags out.
+ *
+ * **Why a pure module**: the meter's CLI is a thread-entrypoint (it may import `AiConfig` to
+ * resolve the resident-model endpoints); THIS module is not — it holds every function whose
+ * correctness a unit spec must pin (phase classification, window aggregation, metric-bag
+ * shaping) as pure data transforms over injected samples. No Neo import, no config read, no
+ * clock read — callers inject timestamps, so identical inputs are identical outputs forever.
+ *
+ * **Honesty contract** (the `[UNMEASURED]` discipline this leaf exists to serve):
+ * - phases are classified by a CPU-activity THRESHOLD heuristic; the threshold travels into
+ *   every produced metric's `confoundDisclaimer` — a consumer can never mistake the split for
+ *   ground-truth request tracing;
+ * - every metric bag carries `claimClass: 'measured'` plus the `falsifyingQuery` that re-runs
+ *   the measurement — a figure without its falsifier is refused upstream by the business
+ *   schema's own validation, and this module never fabricates one;
+ * - aggregation reports COVERAGE (`sampleCount`, `gapCount`, window bounds) so a sparse or
+ *   interrupted run reads as exactly that, never as a clean day.
+ */
+
+/**
+ * One resource sample of one process at one instant. `cpuPercent` is the scheduler-reported
+ * utilization since the previous observation (the `ps pcpu` semantic); `rssBytes` is resident
+ * set size.
+ * @typedef {Object} ResourceSample
+ * @property {Number} atMs        Injected epoch timestamp (the caller owns the clock).
+ * @property {Number} cpuPercent  0..(100 * cores)
+ * @property {Number} rssBytes    Resident set size in bytes.
+ * @property {String} role        The sampled process role (e.g. 'chat-model', 'embedding-model').
+ */
+
+/**
+ * Classifies one sample against the activity threshold — the meter's honest phase heuristic.
+ * @param {ResourceSample} sample
+ * @param {Number} activeCpuThreshold CPU percent at/above which the instant counts as active.
+ * @returns {'active'|'idle'}
+ */
+export function classifySample(sample, activeCpuThreshold) {
+    if (!Number.isFinite(sample?.cpuPercent) || sample.cpuPercent < 0) {
+        throw new Error(`classifySample: cpuPercent must be a finite non-negative number, got ${sample?.cpuPercent}`)
+    }
+
+    if (!Number.isFinite(activeCpuThreshold) || activeCpuThreshold <= 0) {
+        throw new Error(`classifySample: activeCpuThreshold must be a positive finite number, got ${activeCpuThreshold}`)
+    }
+
+    return sample.cpuPercent >= activeCpuThreshold ? 'active' : 'idle'
+}
+
+/**
+ * Aggregates one role's sample stream into the duty-cycle figures the results doc publishes.
+ *
+ * Gap accounting: any inter-sample interval exceeding `expectedIntervalMs * gapFactor` counts
+ * as a coverage gap — its duration is EXCLUDED from phase time (never guessed into idle), and
+ * the gap count is reported so the window's honesty is inspectable.
+ *
+ * @param {ResourceSample[]} samples Chronologically ordered samples of ONE role.
+ * @param {Object} options
+ * @param {Number} options.activeCpuThreshold The phase heuristic threshold (travels into disclaimers).
+ * @param {Number} options.expectedIntervalMs The sampler's nominal tick.
+ * @param {Number} [options.gapFactor=3] Multiples of the nominal tick that constitute a gap.
+ * @returns {{
+ *     activeMs: Number, idleMs: Number, coveredMs: Number, windowStartMs: Number, windowEndMs: Number,
+ *     dutyCycle: Number, sampleCount: Number, gapCount: Number, gapMs: Number,
+ *     rssHighWaterBytes: Number, rssMeanBytes: Number, cpuMeanPercent: Number, cpuActiveMeanPercent: Number
+ * }}
+ */
+export function aggregateWindow(samples, {activeCpuThreshold, expectedIntervalMs, gapFactor = 3}) {
+    if (!Array.isArray(samples) || samples.length < 2) {
+        throw new Error('aggregateWindow: at least two chronologically ordered samples are required')
+    }
+
+    if (!Number.isFinite(expectedIntervalMs) || expectedIntervalMs <= 0) {
+        throw new Error(`aggregateWindow: expectedIntervalMs must be a positive finite number, got ${expectedIntervalMs}`)
+    }
+
+    let activeMs         = 0,
+        idleMs           = 0,
+        gapCount         = 0,
+        gapMs            = 0,
+        rssHighWater     = 0,
+        rssSum           = 0,
+        cpuSum           = 0,
+        cpuActiveSum     = 0,
+        activeSampleHits = 0;
+
+    const gapLimitMs = expectedIntervalMs * gapFactor;
+
+    samples.forEach((sample, index) => {
+        if (index > 0 && sample.atMs <= samples[index - 1].atMs) {
+            throw new Error('aggregateWindow: samples must be strictly chronological')
+        }
+
+        rssHighWater = Math.max(rssHighWater, sample.rssBytes);
+        rssSum      += sample.rssBytes;
+        cpuSum      += sample.cpuPercent;
+
+        const phase = classifySample(sample, activeCpuThreshold);
+
+        if (phase === 'active') {
+            activeSampleHits++;
+            cpuActiveSum += sample.cpuPercent
+        }
+
+        if (index === 0) {
+            return
+        }
+
+        const intervalMs = sample.atMs - samples[index - 1].atMs;
+
+        if (intervalMs > gapLimitMs) {
+            // a coverage hole is REPORTED, never guessed into a phase
+            gapCount++;
+            gapMs += intervalMs;
+            return
+        }
+
+        // the interval is attributed to the phase of its CLOSING sample — a fixed, documented
+        // convention (the alternative attributions differ by at most one tick per transition)
+        phase === 'active' ? (activeMs += intervalMs) : (idleMs += intervalMs)
+    });
+
+    const coveredMs = activeMs + idleMs;
+
+    return {
+        activeMs,
+        coveredMs,
+        cpuActiveMeanPercent: activeSampleHits > 0 ? cpuActiveSum / activeSampleHits : 0,
+        cpuMeanPercent      : cpuSum / samples.length,
+        dutyCycle           : coveredMs > 0 ? activeMs / coveredMs : 0,
+        gapCount,
+        gapMs,
+        idleMs,
+        rssHighWaterBytes   : rssHighWater,
+        rssMeanBytes        : rssSum / samples.length,
+        sampleCount         : samples.length,
+        windowEndMs         : samples[samples.length - 1].atMs,
+        windowStartMs       : samples[0].atMs
+    }
+}
+
+/**
+ * Shapes one role's aggregate into the `METRIC` property bags the business schema accepts —
+ * identity fields for `createMetricId`, plus the full required-property set with the
+ * falsifying re-run command and the heuristic disclaimer. Emits one bag per published figure
+ * (duty cycle, rss high-water, active-phase cpu mean) so each number is independently
+ * falsifiable and independently ingestible.
+ *
+ * This module does NOT write the graph: the bags flow to the tenant-ingestion path, and the
+ * schema's own `validateBusinessProperties` remains the gate — a bag this function produces
+ * with a missing falsifier is a bug the unit spec pins, not a runtime possibility.
+ *
+ * @param {Object} aggregate One `aggregateWindow` result.
+ * @param {Object} identity
+ * @param {String} identity.role             The sampled process role.
+ * @param {String} identity.hardwareId       The named reference hardware slug (provenance, not marketing).
+ * @param {String} identity.periodStart      ISO date of the window start (identity field).
+ * @param {String} identity.windowSemantics  e.g. 'institution-day-rolling'.
+ * @param {String} identity.rerunCommand     The exact CLI invocation that reproduces the figures.
+ * @param {Number} identity.activeCpuThreshold The heuristic threshold (for the disclaimer).
+ * @returns {Object[]} property bags, each `{metricName, source, windowSemantics, periodStart, properties}`
+ */
+export function buildMetricBags(aggregate, identity) {
+    const required = ['role', 'hardwareId', 'periodStart', 'windowSemantics', 'rerunCommand', 'activeCpuThreshold'];
+
+    for (const key of required) {
+        if (identity?.[key] === undefined || identity[key] === null || identity[key] === '') {
+            throw new Error(`buildMetricBags: identity field "${key}" is required — provenance is not optional`)
+        }
+    }
+
+    const source     = `serving-cost-meter:${identity.hardwareId}`,
+          disclaimer = `phase split is a cpu-threshold heuristic (active >= ${identity.activeCpuThreshold}% pcpu), ` +
+                       `not request tracing; co-resident load on the reference machine is not isolated; ` +
+                       `coverage: ${aggregate.sampleCount} samples, ${aggregate.gapCount} gaps (${aggregate.gapMs}ms excluded)`;
+
+    const bag = (metricName, value, unit) => ({
+        metricName,
+        periodStart: identity.periodStart,
+        properties : {
+            claimClass        : 'measured',
+            confoundDisclaimer: disclaimer,
+            falsifyingQuery   : identity.rerunCommand,
+            publicFlag        : true,
+            role              : identity.role,
+            unit,
+            value,
+            windowEndMs       : aggregate.windowEndMs,
+            windowSemantics   : identity.windowSemantics,
+            windowStartMs     : aggregate.windowStartMs
+        },
+        source,
+        windowSemantics: identity.windowSemantics
+    });
+
+    return [
+        bag(`${identity.role}.dutyCycle`,            aggregate.dutyCycle,            'fraction'),
+        bag(`${identity.role}.rssHighWater`,         aggregate.rssHighWaterBytes,    'bytes'),
+        bag(`${identity.role}.cpuActiveMean`,        aggregate.cpuActiveMeanPercent, 'pcpu-percent'),
+        bag(`${identity.role}.coveredWindow`,        aggregate.coveredMs,            'ms')
+    ]
+}

--- a/ai/scripts/benchmark/serving-cost-meter.mjs
+++ b/ai/scripts/benchmark/serving-cost-meter.mjs
@@ -1,0 +1,230 @@
+import {Command}          from 'commander';
+import {execFile}         from 'node:child_process';
+import {mkdir, writeFile} from 'node:fs/promises';
+import os                 from 'node:os';
+import path               from 'node:path';
+import {promisify}        from 'node:util';
+import Neo                from '../../../src/Neo.mjs';
+import '../../../src/core/_export.mjs';
+import aiConfig                           from '../../mcp/server/memory-core/config.mjs';
+import {aggregateWindow, buildMetricBags} from './helpers/servingCostCore.mjs';
+
+const run = promisify(execFile);
+
+/**
+ * @module ai/scripts/benchmark/serving-cost-meter
+ * @summary The steady-state serving-cost meter: samples the RESIDENT model-serving processes
+ * (the always-on inference load) over a configurable window and emits duty-cycle / memory /
+ * cpu figures as business-schema-valid `METRIC` bags plus a provenance-stamped JSON report.
+ *
+ * **Why this exists**: every serving-cost conversation ran on gut-feel figures until the
+ * `[UNMEASURED]` rule landed — a cost claim is invalid until a NAMED measurement exists. This
+ * meter is that measurement's instrument: what does one institution-day actually consume on
+ * named reference hardware, split honestly into idle vs active phases?
+ *
+ * **What this meter actually measures**:
+ * - the processes OWNING the configured endpoint ports (the model server via the
+ *   `openAiCompatible`/`ollama` host leaves, the vector store via the chroma port leaf),
+ *   re-resolved every tick (a mid-window server restart is sampled, not lost);
+ * - scheduler-reported cpu (`ps pcpu`) + resident memory (`ps rss`) per tick;
+ * - phase split via the documented cpu-threshold heuristic — the threshold travels into every
+ *   figure's `confoundDisclaimer` (see the pure core's honesty contract).
+ *
+ * **What this meter does NOT measure** (declared, not hidden):
+ * - request-level token throughput (no provider `/metrics` dependency in v1 — a server that
+ *   exposes one can feed a later leaf);
+ * - per-model attribution when chat + embedding share one server process (the default
+ *   deployment points both at ONE endpoint — the meter then reports ONE honest role for that
+ *   port rather than fabricating a per-model split);
+ * - anything about pricing — figures are public-safe method + raw measurements; derivations
+ *   live in the private substrate only.
+ *
+ * The N-hour institution-day runs on named reference hardware and the hosting-bill console
+ * read are OPERATOR-executed (this CLI is their instrument, not their substitute).
+ *
+ * Run: node ai/scripts/benchmark/serving-cost-meter.mjs --hardware <slug> --window 8h
+ * @see ai/scripts/benchmark/helpers/servingCostCore.mjs — the pure, unit-pinned transforms
+ * @see ai/scripts/benchmark/keep-alive-probe.mjs — the sibling probe pattern
+ * @see learn/agentos/measurements/serving-cost.md — the results doc (numbers only with provenance)
+ */
+
+/**
+ * Parses a `--window` duration ('45m', '8h', '90s') into ms — fail-closed on anything else.
+ * @param {String} value
+ * @returns {Number}
+ */
+export function parseWindow(value) {
+    const match = /^(\d+)([smh])$/.exec(String(value).trim());
+
+    if (!match) {
+        throw new Error(`--window must look like 90s / 45m / 8h, got "${value}"`)
+    }
+
+    return Number(match[1]) * {s: 1000, m: 60000, h: 3600000}[match[2]]
+}
+
+/**
+ * Extracts the port from a configured endpoint URL leaf.
+ * @param {String} hostUrl e.g. 'http://127.0.0.1:11434'
+ * @returns {Number|null}
+ */
+export function portFromHostUrl(hostUrl) {
+    try {
+        const url = new URL(hostUrl);
+        return url.port ? Number(url.port) : (url.protocol === 'https:' ? 443 : 80)
+    } catch (e) {
+        return null
+    }
+}
+
+/**
+ * Resolves the role→port map from the config SSOT — merged honestly when roles share a port.
+ * @param {Object} config The AiConfig data proxy.
+ * @returns {Object[]} `[{role, port}]` with unique ports.
+ */
+export function resolveRolePorts(config) {
+    const candidates = [
+        {port: portFromHostUrl(config.openAiCompatible.host), role: 'model-server-openai-compatible'},
+        {port: portFromHostUrl(config.ollama.host),           role: 'model-server-ollama'},
+        {port: Number(config.engines.chroma.portProd),        role: 'vector-store'}
+    ];
+
+    // one entry per PORT and one ROLE per entry — two configured endpoints on one port
+    // collapse to the first role (same process, one honest stream), while distinct ports
+    // keep distinct roles so their sample streams never interleave
+    const byPort = new Map();
+
+    for (const {port, role} of candidates) {
+        Number.isFinite(port) && port > 0 && !byPort.has(port) && byPort.set(port, {port, role})
+    }
+
+    return [...byPort.values()]
+}
+
+/**
+ * Samples the processes currently owning one port: summed rss bytes + summed pcpu.
+ * Missing owner (server down / restarting) returns null — recorded as a coverage gap by
+ * omission, never as a fabricated zero-load sample.
+ * @param {Number} port
+ * @returns {Promise<{cpuPercent: Number, rssBytes: Number}|null>}
+ */
+export async function samplePort(port) {
+    let pids;
+
+    try {
+        const {stdout} = await run('lsof', ['-ti', `:${port}`]);
+        pids = stdout.trim().split('\n').filter(Boolean)
+    } catch (e) {
+        return null // no owner right now
+    }
+
+    if (!pids.length) {
+        return null
+    }
+
+    try {
+        const {stdout} = await run('ps', ['-o', 'rss=,pcpu=', '-p', pids.join(',')]);
+        let   rssKb    = 0, cpu = 0;
+
+        for (const line of stdout.trim().split('\n')) {
+            const [rss, pcpu] = line.trim().split(/\s+/).map(Number);
+            Number.isFinite(rss)  && (rssKb += rss);
+            Number.isFinite(pcpu) && (cpu   += pcpu)
+        }
+
+        return {cpuPercent: cpu, rssBytes: rssKb * 1024}
+    } catch (e) {
+        return null // pids raced away between lsof and ps — a gap, not a zero
+    }
+}
+
+async function main() {
+    const program = new Command()
+        .requiredOption('--hardware <slug>', 'named reference hardware slug (provenance, e.g. mac-studio-m2ultra-192gb)')
+        .option('--window <duration>',   'sampling window (90s / 45m / 8h)', '8h')
+        .option('--interval <seconds>',  'sampling tick in seconds', '5')
+        .option('--threshold <pcpu>',    'active-phase cpu threshold (percent)', '5')
+        .option('--out <file>',          'report path (default: ~/.neo-ai-data/serving-cost/report-<start>.json)')
+        .parse(process.argv);
+
+    const options    = program.opts(),
+          windowMs   = parseWindow(options.window),
+          intervalMs = Number(options.interval) * 1000,
+          threshold  = Number(options.threshold),
+          config     = aiConfig.data,
+          rolePorts  = resolveRolePorts(config);
+
+    if (!rolePorts.length) {
+        throw new Error('serving-cost-meter: no endpoint ports resolvable from the config SSOT — nothing to measure')
+    }
+
+    const startedAt   = Date.now(),
+          periodStart = new Date(startedAt).toISOString().slice(0, 10),
+          samples     = new Map(rolePorts.map(({role}) => [role, []])),
+          rerun       = `node ai/scripts/benchmark/serving-cost-meter.mjs --hardware ${options.hardware} ` +
+                        `--window ${options.window} --interval ${options.interval} --threshold ${options.threshold}`;
+
+    console.log(`[serving-cost-meter] window=${options.window} interval=${options.interval}s threshold=${threshold}% roles=${rolePorts.map(r => `${r.role}:${r.port}`).join(' ')}`);
+    console.log('[serving-cost-meter] Ctrl-C ends the window early — the report is written either way.');
+
+    let stopped = false;
+    process.on('SIGINT', () => { stopped = true });
+
+    while (!stopped && Date.now() - startedAt < windowMs) {
+        const tickAt = Date.now();
+
+        for (const {port, role} of rolePorts) {
+            const sample = await samplePort(port);
+            sample && samples.get(role).push({atMs: tickAt, cpuPercent: sample.cpuPercent, role, rssBytes: sample.rssBytes})
+        }
+
+        const elapsed = Date.now() - tickAt;
+        elapsed < intervalMs && await new Promise(resolve => setTimeout(resolve, intervalMs - elapsed))
+    }
+
+    const report = {
+        hardware  : options.hardware,
+        host      : {arch: os.arch(), cpuModel: os.cpus()[0]?.model ?? 'unknown', platform: os.platform(), totalMemBytes: os.totalmem()},
+        intervalMs,
+        metricBags: [],
+        periodStart,
+        roles     : {},
+        threshold,
+        windowMs
+    };
+
+    for (const role of samples.keys()) {
+        const roleSamples = samples.get(role);
+
+        if (roleSamples.length < 2) {
+            report.roles[role] = {error: `insufficient samples (${roleSamples.length}) — the endpoint owner was absent for (nearly) the whole window`};
+            continue
+        }
+
+        const aggregate = aggregateWindow(roleSamples, {activeCpuThreshold: threshold, expectedIntervalMs: intervalMs});
+
+        report.roles[role] = aggregate;
+        report.metricBags.push(...buildMetricBags(aggregate, {
+            activeCpuThreshold: threshold,
+            hardwareId        : options.hardware,
+            periodStart,
+            rerunCommand      : rerun,
+            role,
+            windowSemantics   : `rolling-window-${options.window}`
+        }))
+    }
+
+    const outFile = options.out ?? path.join(os.homedir(), '.neo-ai-data', 'serving-cost', `report-${periodStart}-${startedAt}.json`);
+
+    await mkdir(path.dirname(outFile), {recursive: true});
+    await writeFile(outFile, JSON.stringify(report, null, 2));
+
+    console.log(`[serving-cost-meter] report written: ${outFile}`);
+    console.log(`[serving-cost-meter] ${report.metricBags.length} schema-valid metric bags emitted (ingestion is the tenant path's job).`)
+}
+
+// commander parses only when executed directly — importing the pure helpers above never runs a sample
+import.meta.url === `file://${process.argv[1]}` && main().catch(error => {
+    console.error(`[serving-cost-meter] ${error.message}`);
+    process.exit(1)
+});

--- a/ai/scripts/benchmark/serving-cost-meter.mjs
+++ b/ai/scripts/benchmark/serving-cost-meter.mjs
@@ -60,7 +60,14 @@ export function parseWindow(value) {
         throw new Error(`--window must look like 90s / 45m / 8h, got "${value}"`)
     }
 
-    return Number(match[1]) * {s: 1000, m: 60000, h: 3600000}[match[2]]
+    const ms = Number(match[1]) * {s: 1000, m: 60000, h: 3600000}[match[2]];
+
+    if (ms <= 0) {
+        // a zero window would exit 0 with an empty "measurement" — success theater, refused
+        throw new Error(`--window must be a positive duration, got "${value}"`)
+    }
+
+    return ms
 }
 
 /**
@@ -225,6 +232,10 @@ async function main() {
         elapsed < intervalMs && await new Promise(resolve => setTimeout(resolve, intervalMs - elapsed))
     }
 
+    // the REQUESTED bounds travel into every aggregate: a role whose endpoint appeared for
+    // only the tail of the window must read as mostly-unavailable, never as a clean short run
+    const windowBounds = {endMs: Date.now(), startMs: startedAt};
+
     const report = {
         hardware  : options.hardware,
         host      : {arch: os.arch(), cpuModel: os.cpus()[0]?.model ?? 'unknown', platform: os.platform(), totalMemBytes: os.totalmem()},
@@ -234,6 +245,7 @@ async function main() {
         roles     : {},
         skipped, // declared measurement holes (remote endpoints) live in the artifact, not just stdout
         threshold,
+        windowBounds,
         windowMs
     };
 
@@ -245,7 +257,7 @@ async function main() {
             continue
         }
 
-        const aggregate = aggregateWindow(roleSamples, {activeCpuThreshold: threshold, expectedIntervalMs: intervalMs});
+        const aggregate = aggregateWindow(roleSamples, {activeCpuThreshold: threshold, expectedIntervalMs: intervalMs, windowBounds});
 
         report.roles[role] = aggregate;
         report.metricBags.push(...buildMetricBags(aggregate, {

--- a/ai/scripts/benchmark/serving-cost-meter.mjs
+++ b/ai/scripts/benchmark/serving-cost-meter.mjs
@@ -78,32 +78,62 @@ export function portFromHostUrl(hostUrl) {
 }
 
 /**
- * Resolves the role→port map from the config SSOT — merged honestly when roles share a port.
+ * Whether a configured endpoint URL points at THIS machine — the only case where sampling
+ * local PIDs measures the endpoint's true owner. A remote endpoint is skipped WITH a declared
+ * reason at startup, never silently sampled into nonsense.
+ * @param {String} hostUrl
+ * @returns {Boolean}
+ */
+export function isLocalEndpoint(hostUrl) {
+    try {
+        return ['127.0.0.1', 'localhost', '::1', '0.0.0.0'].includes(new URL(hostUrl).hostname)
+    } catch (e) {
+        return false
+    }
+}
+
+/**
+ * Resolves the role→port map from the config SSOT — merged honestly when roles share a port,
+ * and LOCAL endpoints only (a remote host's load cannot be measured from this machine's
+ * process table; such endpoints surface in `skipped` with the reason, never as silent holes).
  * @param {Object} config The AiConfig data proxy.
- * @returns {Object[]} `[{role, port}]` with unique ports.
+ * @returns {{rolePorts: Object[], skipped: Object[]}} unique-port `{role, port}` entries + declared skips.
  */
 export function resolveRolePorts(config) {
     const candidates = [
-        {port: portFromHostUrl(config.openAiCompatible.host), role: 'model-server-openai-compatible'},
-        {port: portFromHostUrl(config.ollama.host),           role: 'model-server-ollama'},
-        {port: Number(config.engines.chroma.portProd),        role: 'vector-store'}
+        {hostUrl: config.openAiCompatible.host,                          role: 'model-server-openai-compatible'},
+        {hostUrl: config.ollama.host,                                    role: 'model-server-ollama'},
+        {hostUrl: `http://127.0.0.1:${config.engines.chroma.portProd}`,  role: 'vector-store'}
     ];
 
     // one entry per PORT and one ROLE per entry — two configured endpoints on one port
     // collapse to the first role (same process, one honest stream), while distinct ports
     // keep distinct roles so their sample streams never interleave
-    const byPort = new Map();
+    const byPort  = new Map(),
+          skipped = [];
 
-    for (const {port, role} of candidates) {
+    for (const {hostUrl, role} of candidates) {
+        if (!isLocalEndpoint(hostUrl)) {
+            skipped.push({reason: `endpoint is not local (${hostUrl}) — its process table is not ours to sample`, role});
+            continue
+        }
+
+        const port = portFromHostUrl(hostUrl);
+
         Number.isFinite(port) && port > 0 && !byPort.has(port) && byPort.set(port, {port, role})
     }
 
-    return [...byPort.values()]
+    return {rolePorts: [...byPort.values()], skipped}
 }
 
 /**
- * Samples the processes currently owning one port: summed rss bytes + summed pcpu.
- * Missing owner (server down / restarting) returns null — recorded as a coverage gap by
+ * Samples the processes LISTENING on one port: summed rss bytes + summed pcpu.
+ *
+ * Listener-only on purpose: a bare port query matches every process with a socket on the
+ * port — INCLUDING connected clients — so a busy client (a summarizer mid-batch) would be
+ * misattributed as server load. `-sTCP:LISTEN` scopes ownership to the actual server.
+ *
+ * Missing listener (server down / restarting) returns null — recorded as a coverage gap by
  * omission, never as a fabricated zero-load sample.
  * @param {Number} port
  * @returns {Promise<{cpuPercent: Number, rssBytes: Number}|null>}
@@ -112,10 +142,10 @@ export async function samplePort(port) {
     let pids;
 
     try {
-        const {stdout} = await run('lsof', ['-ti', `:${port}`]);
+        const {stdout} = await run('lsof', ['-ti', `:${port}`, '-sTCP:LISTEN']);
         pids = stdout.trim().split('\n').filter(Boolean)
     } catch (e) {
-        return null // no owner right now
+        return null // no listener right now
     }
 
     if (!pids.length) {
@@ -151,11 +181,24 @@ async function main() {
           windowMs   = parseWindow(options.window),
           intervalMs = Number(options.interval) * 1000,
           threshold  = Number(options.threshold),
-          config     = aiConfig.data,
-          rolePorts  = resolveRolePorts(config);
+          config     = aiConfig.data;
+
+    // startup validation fails loud BEFORE the first sample — a NaN tick or threshold would
+    // otherwise surface hours later as an empty or garbage window
+    if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+        throw new Error(`serving-cost-meter: --interval must be a positive number of seconds, got "${options.interval}"`)
+    }
+
+    if (!Number.isFinite(threshold) || threshold <= 0) {
+        throw new Error(`serving-cost-meter: --threshold must be a positive pcpu percentage, got "${options.threshold}"`)
+    }
+
+    const {rolePorts, skipped} = resolveRolePorts(config);
+
+    skipped.forEach(({reason, role}) => console.log(`[serving-cost-meter] skipping ${role}: ${reason}`));
 
     if (!rolePorts.length) {
-        throw new Error('serving-cost-meter: no endpoint ports resolvable from the config SSOT — nothing to measure')
+        throw new Error('serving-cost-meter: no LOCAL endpoint ports resolvable from the config SSOT — nothing to measure on this machine')
     }
 
     const startedAt   = Date.now(),
@@ -189,6 +232,7 @@ async function main() {
         metricBags: [],
         periodStart,
         roles     : {},
+        skipped, // declared measurement holes (remote endpoints) live in the artifact, not just stdout
         threshold,
         windowMs
     };

--- a/learn/agentos/measurements/serving-cost.md
+++ b/learn/agentos/measurements/serving-cost.md
@@ -1,0 +1,47 @@
+# Serving-cost measurement — the always-on inference load, measured not vibed
+
+> **Status: INSTRUMENT LANDED · RUNS PENDING.** Every figure slot below is `[UNMEASURED]`
+> until a named run fills it with provenance. Per the standing rule, a cost claim without a
+> named measurement is invalid — this document refuses placeholder numbers by construction.
+
+## Why
+
+Every serving-cost conversation prior to this program ran on gut-feel figures (the correction
+that mandated it is on record). Three economic unknowns block honest architecture choices:
+the always-on inference duty cycle, hardware-option economics under identical workload, and
+the actual current hosting bill. This document publishes the **method and the raw measured
+figures only** — pricing derivations live in the private substrate, never here.
+
+## Method
+
+- **Instrument**: `ai/scripts/benchmark/serving-cost-meter.mjs` — samples the processes
+  owning the configured endpoint ports (model server, vector store) every N seconds over a
+  named window; phases split by a cpu-threshold heuristic; coverage gaps reported, never
+  guessed into idle. The transforms are unit-pinned (`servingCostCore`), and every published
+  figure is born as a business-schema-valid `METRIC` bag carrying its `falsifyingQuery`
+  (the exact re-run command) and its `confoundDisclaimer` (the heuristic + coverage).
+- **What it does not measure** (declared): request-level token throughput (v1 has no provider
+  `/metrics` dependency); per-model attribution when chat + embedding share one server
+  (reported as the merged `model-server` role); anything about pricing.
+- **Run protocol**: one institution-day window (`--window 24h`, default tick 5s) on named
+  reference hardware, executed while the institution operates normally — the measurement IS
+  the normal day, not a synthetic load.
+
+## Run ledger
+
+| Run | Hardware (named) | Window | Report artifact | Status |
+|---|---|---|---|---|
+| Duty-cycle, reference machine | `[UNMEASURED — operator run pending]` | 24h | — | pending |
+| Same workload, hardware option 2 | `[UNMEASURED — availability to be documented]` | 24h | — | pending |
+| Hosting bill, deployed front-door | `[UNMEASURED — operator console read]` | current period | — | pending |
+
+## Results
+
+`[UNMEASURED]` — this section fills ONLY from run-ledger artifacts, each figure with its
+falsifying re-run command. Zero extrapolation; a gap in coverage is published as a gap.
+
+## Provenance discipline
+
+Every number that ever lands here carries: the hardware slug, the window semantics, the
+sample/gap coverage counts, the threshold heuristic used, and the exact reproducing command.
+A figure missing any of these is refused at review.

--- a/test/playwright/unit/ai/scripts/servingCostCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/servingCostCore.spec.mjs
@@ -1,7 +1,8 @@
 import {test, expect} from '@playwright/test';
 
-import {aggregateWindow, buildMetricBags, classifySample} from '../../../../../ai/scripts/benchmark/helpers/servingCostCore.mjs';
-import {createMetricId, validateBusinessProperties}       from '../../../../../ai/graph/businessSchema.mjs';
+import {aggregateWindow, buildMetricBags, classifySample}                from '../../../../../ai/scripts/benchmark/helpers/servingCostCore.mjs';
+import {createMetricId, validateBusinessProperties}                      from '../../../../../ai/graph/businessSchema.mjs';
+import {isLocalEndpoint, parseWindow, portFromHostUrl, resolveRolePorts} from '../../../../../ai/scripts/benchmark/serving-cost-meter.mjs';
 
 /**
  * Pins the serving-cost meter's pure core — the deterministic heart of the measurement
@@ -114,5 +115,66 @@ test.describe('serving-cost meter core (the pure measurement transforms)', () =>
         // provenance is not optional — a missing identity field throws, never defaults
         expect(() => buildMetricBags(aggregate, {...identity, hardwareId: ''}))
             .toThrow('provenance is not optional')
+    });
+});
+
+/**
+ * Pins the CLI's pure resolution helpers (import-safe — the entrypoint only parses argv when
+ * executed directly): window parsing fails closed, endpoint locality gates what this
+ * machine's process table may honestly claim to measure, and role/port resolution dedupes by
+ * port while DECLARING remote skips instead of silently dropping them.
+ */
+test.describe('serving-cost meter CLI helpers (resolution honesty)', () => {
+    test('window parsing accepts s/m/h and fails closed on anything else', () => {
+        expect(parseWindow('90s')).toBe(90000);
+        expect(parseWindow('45m')).toBe(2700000);
+        expect(parseWindow('8h')).toBe(28800000);
+        expect(() => parseWindow('8')).toThrow('--window');
+        expect(() => parseWindow('8d')).toThrow('--window');
+        expect(() => parseWindow('')).toThrow('--window')
+    });
+
+    test('port extraction handles explicit ports, protocol defaults, and garbage', () => {
+        expect(portFromHostUrl('http://127.0.0.1:11434')).toBe(11434);
+        expect(portFromHostUrl('http://localhost')).toBe(80);
+        expect(portFromHostUrl('https://example.com')).toBe(443);
+        expect(portFromHostUrl('not a url')).toBeNull()
+    });
+
+    test('endpoint locality is the sampling gate: only THIS machine\'s listeners are ours to measure', () => {
+        expect(isLocalEndpoint('http://127.0.0.1:1234')).toBe(true);
+        expect(isLocalEndpoint('http://localhost:11434')).toBe(true);
+        expect(isLocalEndpoint('http://0.0.0.0:8000')).toBe(true);
+        expect(isLocalEndpoint('http://192.168.1.50:11434')).toBe(false);
+        expect(isLocalEndpoint('https://api.example.com')).toBe(false);
+        expect(isLocalEndpoint('garbage')).toBe(false)
+    });
+
+    test('role/port resolution dedupes shared ports to one honest stream and DECLARES remote skips', () => {
+        const config = {
+            engines         : {chroma: {portProd: 8000}},
+            ollama          : {host: 'http://remote-box:11434'},
+            openAiCompatible: {host: 'http://127.0.0.1:1234'}
+        };
+
+        const {rolePorts, skipped} = resolveRolePorts(config);
+
+        expect(rolePorts).toEqual([
+            {port: 1234, role: 'model-server-openai-compatible'},
+            {port: 8000, role: 'vector-store'}
+        ]);
+        expect(skipped).toHaveLength(1);
+        expect(skipped[0].role).toBe('model-server-ollama');
+        expect(skipped[0].reason).toContain('not local');
+
+        // shared port → first role wins, one stream (same process, never interleaved samples)
+        const shared = resolveRolePorts({
+            engines         : {chroma: {portProd: 11434}},
+            ollama          : {host: 'http://127.0.0.1:11434'},
+            openAiCompatible: {host: 'http://127.0.0.1:11434'}
+        });
+
+        expect(shared.rolePorts).toEqual([{port: 11434, role: 'model-server-openai-compatible'}]);
+        expect(shared.skipped).toEqual([])
     });
 });

--- a/test/playwright/unit/ai/scripts/servingCostCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/servingCostCore.spec.mjs
@@ -1,0 +1,118 @@
+import {test, expect} from '@playwright/test';
+
+import {aggregateWindow, buildMetricBags, classifySample} from '../../../../../ai/scripts/benchmark/helpers/servingCostCore.mjs';
+import {createMetricId, validateBusinessProperties}       from '../../../../../ai/graph/businessSchema.mjs';
+
+/**
+ * Pins the serving-cost meter's pure core — the deterministic heart of the measurement
+ * program: phase classification is threshold-honest, window aggregation reports coverage
+ * instead of guessing through gaps, and every produced figure is born as a business-schema
+ * VALID metric bag (falsifier + disclaimer mandatory) whose identity is deterministic.
+ */
+test.describe('serving-cost meter core (the pure measurement transforms)', () => {
+    const sample = (atMs, cpuPercent, rssBytes = 1000, role = 'chat-model') => ({atMs, cpuPercent, role, rssBytes});
+
+    test('phase classification is the documented threshold heuristic — inclusive at the boundary, fail-closed on garbage', () => {
+        expect(classifySample(sample(0, 4.9), 5)).toBe('idle');
+        expect(classifySample(sample(0, 5),   5)).toBe('active');   // inclusive: >= threshold
+        expect(classifySample(sample(0, 380), 5)).toBe('active');   // multi-core percents are legal
+
+        expect(() => classifySample(sample(0, NaN), 5)).toThrow('finite non-negative');
+        expect(() => classifySample(sample(0, -1),  5)).toThrow('finite non-negative');
+        expect(() => classifySample(sample(0, 10),  0)).toThrow('positive finite')
+    });
+
+    test('window aggregation: phase time attributes to the closing sample, gaps are EXCLUDED and reported, never guessed into idle', () => {
+        const tick = 1000;
+        // 0s idle → 1s idle → 2s active → 3s active → [10s gap] → 13s idle
+        const aggregate = aggregateWindow([
+            sample(0,     1),
+            sample(1000,  1),
+            sample(2000, 50),
+            sample(3000, 60),
+            sample(13000, 1)
+        ], {activeCpuThreshold: 5, expectedIntervalMs: tick});
+
+        expect(aggregate.idleMs).toBe(1000);          // interval closed by the 1s idle sample
+        expect(aggregate.activeMs).toBe(2000);        // intervals closed by the 2s + 3s active samples
+        expect(aggregate.gapCount).toBe(1);
+        expect(aggregate.gapMs).toBe(10000);          // the hole is reported...
+        expect(aggregate.coveredMs).toBe(3000);       // ...and excluded from coverage
+        expect(aggregate.dutyCycle).toBeCloseTo(2000 / 3000, 10);
+        expect(aggregate.sampleCount).toBe(5);
+        expect(aggregate.windowStartMs).toBe(0);
+        expect(aggregate.windowEndMs).toBe(13000);
+        expect(aggregate.rssHighWaterBytes).toBe(1000);
+        expect(aggregate.cpuActiveMeanPercent).toBeCloseTo(55, 10);
+
+        // determinism: identical input, identical output — the module reads no clock
+        expect(aggregateWindow([
+            sample(0,     1),
+            sample(1000,  1),
+            sample(2000, 50),
+            sample(3000, 60),
+            sample(13000, 1)
+        ], {activeCpuThreshold: 5, expectedIntervalMs: tick})).toEqual(aggregate)
+    });
+
+    test('aggregation fails closed on unusable streams', () => {
+        expect(() => aggregateWindow([sample(0, 1)], {activeCpuThreshold: 5, expectedIntervalMs: 1000}))
+            .toThrow('at least two');
+        expect(() => aggregateWindow([sample(1000, 1), sample(1000, 2)], {activeCpuThreshold: 5, expectedIntervalMs: 1000}))
+            .toThrow('strictly chronological');
+        expect(() => aggregateWindow([sample(0, 1), sample(1000, 1)], {activeCpuThreshold: 5, expectedIntervalMs: 0}))
+            .toThrow('expectedIntervalMs')
+    });
+
+    test('every published figure is born schema-valid: falsifier + disclaimer mandatory, identity deterministic, provenance non-optional', () => {
+        const aggregate = aggregateWindow([
+            sample(0, 1), sample(1000, 50), sample(2000, 1)
+        ], {activeCpuThreshold: 5, expectedIntervalMs: 1000});
+
+        const identity = {
+            activeCpuThreshold: 5,
+            hardwareId        : 'ref-mac-m2ultra',
+            periodStart       : '2026-07-10',
+            rerunCommand      : 'node ai/scripts/benchmark/serving-cost-meter.mjs --window 24h --hardware ref-mac-m2ultra',
+            role              : 'chat-model',
+            windowSemantics   : 'institution-day-rolling'
+        };
+
+        const bags = buildMetricBags(aggregate, identity);
+
+        expect(bags.map(b => b.metricName)).toEqual([
+            'chat-model.dutyCycle',
+            'chat-model.rssHighWater',
+            'chat-model.cpuActiveMean',
+            'chat-model.coveredWindow'
+        ]);
+
+        for (const b of bags) {
+            // the business schema itself is the gate this core must always satisfy
+            expect(validateBusinessProperties(b.properties)).toEqual({errors: [], valid: true});
+            expect(b.properties.claimClass).toBe('measured');
+            expect(b.properties.falsifyingQuery).toBe(identity.rerunCommand);
+            expect(b.properties.confoundDisclaimer).toContain('cpu-threshold heuristic');
+            expect(b.properties.confoundDisclaimer).toContain('0 gaps');
+
+            // deterministic idempotent identity: recomputation lands on the SAME node
+            const id = createMetricId({
+                metricName     : b.metricName,
+                periodStart    : b.periodStart,
+                source         : b.source,
+                windowSemantics: b.windowSemantics
+            });
+            expect(id).toBe(createMetricId({
+                metricName     : b.metricName,
+                periodStart    : b.periodStart,
+                source         : b.source,
+                windowSemantics: b.windowSemantics
+            }));
+            expect(id.startsWith('metric-')).toBe(true)
+        }
+
+        // provenance is not optional — a missing identity field throws, never defaults
+        expect(() => buildMetricBags(aggregate, {...identity, hardwareId: ''}))
+            .toThrow('provenance is not optional')
+    });
+});

--- a/test/playwright/unit/ai/scripts/servingCostCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/servingCostCore.spec.mjs
@@ -56,6 +56,46 @@ test.describe('serving-cost meter core (the pure measurement transforms)', () =>
         ], {activeCpuThreshold: 5, expectedIntervalMs: tick})).toEqual(aggregate)
     });
 
+    test('boundary honesty: a tail-only sample stream against the REQUESTED window reads as mostly-unavailable, never as a clean short run', () => {
+        // the reviewer's exact falsifier: a nominal 1h window whose endpoint appeared only for
+        // its final 10s — without bounds this read "10s covered, 0 gaps"; with bounds the
+        // 59m50s leading absence is VISIBLE
+        const aggregate = aggregateWindow([
+            sample(3590000, 50),
+            sample(3600000, 60)
+        ], {activeCpuThreshold: 5, expectedIntervalMs: 5000, windowBounds: {endMs: 3600000, startMs: 0}});
+
+        expect(aggregate.coveredMs).toBe(10000);
+        expect(aggregate.gapCount).toBe(0);
+        expect(aggregate.nominalWindowMs).toBe(3600000);
+        expect(aggregate.leadingUnavailableMs).toBe(3590000);
+        expect(aggregate.trailingUnavailableMs).toBe(0);
+        expect(aggregate.coverageRatio).toBeCloseTo(10000 / 3600000, 10);
+
+        // the disclaimer carries the boundary truth into every published figure
+        const bags = buildMetricBags(aggregate, {
+            activeCpuThreshold: 5,
+            hardwareId        : 'ref',
+            periodStart       : '2026-07-11',
+            rerunCommand      : 'rerun',
+            role              : 'chat-model',
+            windowSemantics   : 'rolling-window-1h'
+        });
+
+        expect(bags[0].properties.confoundDisclaimer).toContain('leading/trailing unavailable 3590000ms/0ms');
+        expect(bags[0].properties.confoundDisclaimer).toContain('coverage ratio 0.0028');
+
+        // bounds sanity fails closed
+        expect(() => aggregateWindow([sample(0, 1), sample(1000, 1)], {activeCpuThreshold: 5, expectedIntervalMs: 1000, windowBounds: {endMs: 0, startMs: 0}}))
+            .toThrow('windowBounds');
+
+        // and WITHOUT bounds the boundary fields are explicitly null — absence of the claim,
+        // never a fabricated zero
+        const unbounded = aggregateWindow([sample(0, 1), sample(1000, 1)], {activeCpuThreshold: 5, expectedIntervalMs: 1000});
+        expect(unbounded.leadingUnavailableMs).toBeNull();
+        expect(unbounded.coverageRatio).toBeNull()
+    });
+
     test('aggregation fails closed on unusable streams', () => {
         expect(() => aggregateWindow([sample(0, 1)], {activeCpuThreshold: 5, expectedIntervalMs: 1000}))
             .toThrow('at least two');
@@ -125,13 +165,16 @@ test.describe('serving-cost meter core (the pure measurement transforms)', () =>
  * port while DECLARING remote skips instead of silently dropping them.
  */
 test.describe('serving-cost meter CLI helpers (resolution honesty)', () => {
-    test('window parsing accepts s/m/h and fails closed on anything else', () => {
+    test('window parsing accepts s/m/h and fails closed on anything else — including the zero-duration success-theater case', () => {
         expect(parseWindow('90s')).toBe(90000);
         expect(parseWindow('45m')).toBe(2700000);
         expect(parseWindow('8h')).toBe(28800000);
         expect(() => parseWindow('8')).toThrow('--window');
         expect(() => parseWindow('8d')).toThrow('--window');
-        expect(() => parseWindow('')).toThrow('--window')
+        expect(() => parseWindow('')).toThrow('--window');
+        // a zero window would exit 0 with an empty "measurement" — refused at parse time
+        expect(() => parseWindow('0s')).toThrow('positive duration');
+        expect(() => parseWindow('0h')).toThrow('positive duration')
     });
 
     test('port extraction handles explicit ports, protocol defaults, and garbage', () => {


### PR DESCRIPTION
Resolves #15014

Related: #14687 — the measurement PROGRAM stays open for the operator evidence (the institution-day runs on named hardware + the hosting-bill read); this PR delivers its INSTRUMENT leaf, converged in review as the honest close-target split.

The `[UNMEASURED]` discipline gets its instrument: a steady-state serving-cost meter for the always-on inference load — the measurement half of "cost claims are invalid until a named measurement exists." What one institution-day actually consumes, split honestly into idle vs active phases, on named reference hardware.

**The shape (entrypoint CLI + pure core, per the C1 discipline):**
- `ai/scripts/benchmark/helpers/servingCostCore.mjs` — the PURE transforms (no Neo/AiConfig import, no clock reads — callers inject timestamps, so identical inputs are identical outputs forever): threshold-heuristic phase classification (inclusive boundary, fail-closed on garbage), window aggregation where **coverage gaps are excluded and reported, never guessed into idle**, and metric-bag shaping where every figure is BORN business-schema-valid — `claimClass: 'measured'`, the exact re-run command as its `falsifyingQuery`, the heuristic + coverage counts as its `confoundDisclaimer`, deterministic idempotent `METRIC` identity (recomputation lands on the same node).
- `ai/scripts/benchmark/serving-cost-meter.mjs` — the entrypoint CLI (the sanctioned home for the `AiConfig` read, beside its sibling probes): resolves the sampled ports from the config SSOT's own endpoint leaves (`openAiCompatible.host` / `ollama.host` / the chroma port), re-resolves owning PIDs every tick (a mid-window server restart is sampled, not lost), `ps`-samples rss + pcpu, and writes a provenance-stamped JSON report (host descriptor, threshold, interval, per-role aggregates, the schema-valid bags). A vanished endpoint owner is a gap by omission — never a fabricated zero-load sample. Bags flow to the existing tenant-ingestion path; this instrument never writes the graph.
- `learn/agentos/measurements/serving-cost.md` — the results doc SKELETON: method + run ledger + provenance discipline, with every figure slot `[UNMEASURED]` by construction (zero placeholder numbers; the doc refuses them the way the schema refuses an unanchored metric). Follows the sibling measurement-doc precedent in the same directory.

**What the meter deliberately does NOT do** (declared in its own JSDoc): request-level token throughput (no provider-metrics dependency in v1), per-model attribution when chat + embedding share one server process (one honest role per port, never a fabricated split), anything about pricing (public substrate carries method + raw measurements only — derivations are private-side, the standing rule).

**Live-proven, and two real bugs died before the formal review:** (1) my own smoke caught a double-count — two endpoint entries sharing one role name made the aggregation loop emit duplicate bags, with a latent same-timestamp chronology trap had both servers been live; fixed (unique per-endpoint roles; aggregation iterates the sample streams). (2) The reviewer's pre-review live falsifier caught a **client-misattribution** in the sampler: a bare `lsof -ti :port` matches every process with a socket on the port — INCLUDING connected clients — so a 100%-CPU summarizer client was counted as ~98.7% "vector-store" load. Fixed at the root: `-sTCP:LISTEN` scopes ownership to the actual server (documented in the sampler's JSDoc), plus two adjacent hardenings from the same cycle — **remote endpoints are skipped with a DECLARED reason** (in stdout and in the report artifact — a host that isn't local isn't ours to sample, never a silent hole) and **startup validation** fails loud on a NaN interval/threshold before the first sample rather than hours later as a garbage window.

Evidence: L2 (the pure core 4/4 spec-pinned against the REAL `businessSchema` gate — verdict-object validation, determinism proof, provenance-throws) + L3 (two live smoke runs on this machine's actual resident processes; the second at the fixed shape: 2 roles, 8 schema-valid bags, report artifact written) → L3 achieved for the INSTRUMENT. Residual (L4, operator-executed by nature — declared at claim time, the evidence-ladder handoff pattern): the N-hour institution-day runs on named reference hardware (AC 1–2) and the hosting-bill console read (AC 3) — the CLI is their instrument, not their substitute.

## Deltas from ticket

- The ticket's cited instrumentation pattern (the fresh-install phase-log vocabulary) did not survive into the shipped tree (its measurement anchor was retired since) — the meter follows the LIVE sibling precedent in `ai/scripts/benchmark/` instead (the probe-CLI shape with the what-this-does-NOT-prove honesty sections). Recorded at intake.
- Token-throughput sampling is explicitly v1-out (no provider `/metrics` dependency) — a server that exposes one feeds a later leaf; the ticket's duty-cycle/memory/cpu core is fully served.
- METRIC emission ships as validated bags consumed by the existing tenant-ingestion path (the epic's own named-reuse AC), not as direct graph writes from the meter.

## Test Evidence

At head `9069e7784` (post-convergence: listener-only sampling + declared skips + startup validation):

```
npm run test-unit -- test/playwright/unit/ai/scripts/servingCostCore.spec.mjs --workers=1
8 passed — the pure core (phase heuristic incl. boundary + fail-closed; gap-excluding aggregation with the determinism proof; schema-valid bags against businessSchema's own gate; deterministic idempotent identity; provenance-throws) + the CLI resolution helpers (window parsing fail-closed; port extraction; the endpoint-LOCALITY sampling gate; role/port dedupe with DECLARED remote skips)

node --check ai/scripts/benchmark/serving-cost-meter.mjs — passed
node ai/scripts/benchmark/serving-cost-meter.mjs --hardware dev-smoke-<host> --window 12s --interval 3
→ listener-only sampling: 2 live roles, 8 schema-valid metric bags, report artifact (with the skipped[] declarations) written under ~/.neo-ai-data/serving-cost/
```

## Post-Merge Validation

- [ ] Operator run 1 (AC 1): one institution-day window (`--window 24h --hardware <named-slug>`) on the reference machine during normal operation — the report artifact fills the results doc's first ledger row.
- [ ] Operator run 2 (AC 2): the same window on a second available hardware option (availability documented; no modeled third options).
- [ ] Operator read (AC 3): the live hosting bill from the console, recorded in the ledger with its date.
- [ ] The emitted bags ride the tenant-ingestion path into the graph once the first real run exists (no smoke-run figures ingest — dev-smoke reports are instrument evidence, not measurements).

Process note: authored during the operator-granted temporary Fable 5 window.

Authored by Grace (Claude Fable 5, Claude Code). Session ef6b9a4a-54ec-4afb-8438-f89a3ee46ad2
