### PR TITLE
feat(dashboard): dock workspace cross-window participation — owner seams + source hooks + transferItem wiring (#14769)

### DIFF
--- a/src/dashboard/DockCrossWindowParticipation.mjs
+++ b/src/dashboard/DockCrossWindowParticipation.mjs
@@ -1,0 +1,242 @@
+import Base                  from '../core/Base.mjs';
+import CrossWindowDragTarget from './CrossWindowDragTarget.mjs';
+import DockZoneModel         from './DockZoneModel.mjs';
+
+/**
+ * @class Neo.dashboard.DockCrossWindowParticipation
+ * @extends Neo.core.Base
+ *
+ * @summary The adapter-tier composition that makes ONE dock workspace a cross-window drag
+ * participant — the integration half of the harness docking design record's §2.3 (see
+ * `learn/agentos/decisions/0029-harness-docking-design.md`) over exclusively LANDED machinery.
+ *
+ * It owns the target registration lifecycle (create on workspace mount, destroy on unmount) and
+ * binds the five owner seams of {@link Neo.dashboard.CrossWindowDragTarget} to the workspace's
+ * landed pipeline, adding exactly ONE new decision: foreign-vs-local drop discrimination at
+ * commit time.
+ *
+ * - **Local drop** (the dragged item already lives in THIS workspace's committed document): the
+ *   converted operation rides the owner's landed single-document commit seam — the identical
+ *   pipeline in-window drags use. No parallel drag system (§2.3 inherited guardrail).
+ * - **Foreign drop** (the item belongs to a sibling window's workspace on the same App-Worker
+ *   heap): the converted `addTab`/`splitNode` descriptor becomes the nested `target` of ONE
+ *   semantic `transferItem` operation, executed through the landed atomic two-document executor
+ *   ({@link Neo.dashboard.DockZoneModel#transferItem}) — commit-or-neither, item record verbatim,
+ *   live component instances move and are never re-instantiated (§2.6). The durable placement
+ *   hints (`owningWorkspaceId`, `fallbackTarget`) update on the transferred record **in the same
+ *   commit**, per the §2.1 durable-tier table — semantic node references, never geometry.
+ *
+ * Layer discipline (the target's established layer note, unchanged): `src/dashboard/` imports no app module —
+ * every seam below arrives from the app-side workspace composition, which keeps authoring the
+ * preview visuals. The {@link Neo.manager.DragCoordinator} stays dock-blind: all dock semantics
+ * live here and in the seams, never in the coordinator (§2.3 binding invariant).
+ *
+ * The cross-window drag payload contract (stamped by {@link Neo.dashboard.DockTabSortZone} at
+ * drag start): `draggedItem.dockItemId` names the dock catalog item, and
+ * `draggedItem.dockSourceWorkspaceId` names the workspace document it departs — both required
+ * for a foreign commit; a payload without them fails closed (no signal-free guessing).
+ */
+class DockCrossWindowParticipation extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockCrossWindowParticipation'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockCrossWindowParticipation',
+        /**
+         * @member {String} ntype='dock-crosswindow-participation'
+         * @protected
+         */
+        ntype: 'dock-crosswindow-participation',
+        /**
+         * Owner seam, forwarded to the target: clears the workspace's preview overlay when a
+         * remote drag leaves. Optional.
+         * @member {Function|null} clearPreview=null
+         */
+        clearPreview: null,
+        /**
+         * Owner seam: the workspace's landed single-document commit path — receives the converted
+         * operation descriptor for a LOCAL drop and returns the executor result
+         * (`{document, errors}`-shaped) or a falsy value. The same seam in-window drops ride.
+         * @member {Function|null} commitLocal=null
+         */
+        commitLocal: null,
+        /**
+         * Owner seam: publishes an atomically-transferred document PAIR through the workspace
+         * set's change-notification path. Receives
+         * `{sourceWorkspaceId, sourceDocument, targetWorkspaceId, targetDocument, descriptor}`
+         * where both documents are the executor's committed results (hints already updated).
+         * @member {Function|null} commitTransfer=null
+         */
+        commitTransfer: null,
+        /**
+         * Forwarded to the target: the arbitration registry. Defaults to the
+         * `Neo.manager.DragCoordinator` singleton inside the target; unit tests inject a stand-in.
+         * @member {Neo.manager.DragCoordinator|null} dragCoordinator=null
+         * @protected
+         */
+        dragCoordinator: null,
+        /**
+         * Owner seam: `(sourceWorkspaceId) => document` — resolves a sibling workspace's committed
+         * document from the worker-owned workspace set. Foreign drops fail closed without it.
+         * @member {Function|null} getForeignDocument=null
+         */
+        getForeignDocument: null,
+        /**
+         * Owner seam: `() => document` — this workspace's committed document (the discrimination
+         * + transfer-target input). Required.
+         * @member {Function|null} getDocument=null
+         */
+        getDocument: null,
+        /**
+         * Owner seam, forwarded to the target: cheap window-local hit-test (§2.3, side-effect
+         * free). Without it the workspace never claims a remote drag (fail-closed).
+         * @member {Function|null} hitTest=null
+         */
+        hitTest: null,
+        /**
+         * Owner seam, forwarded to the target: maps a remote hover payload onto the workspace's
+         * landed `dockPreview` compute+render path.
+         * @member {Function|null} previewFor=null
+         */
+        previewFor: null,
+        /**
+         * Owner seam, forwarded to the target: the workspace's landed `previewToOperation`
+         * converter — the single preview→operation pipeline.
+         * @member {Function|null} previewToOperation=null
+         */
+        previewToOperation: null,
+        /**
+         * §2.3 registry identity, forwarded to the target: only targets sharing the drag source's
+         * `sortGroup` are arbitration candidates.
+         * @member {String|null} sortGroup=null
+         */
+        sortGroup: null,
+        /**
+         * §2.3 registry identity, forwarded to the target: the window this workspace renders in.
+         * @member {String|Number|null} windowId=null
+         */
+        windowId: null,
+        /**
+         * This workspace's id in the worker-owned workspace set — the `targetWorkspaceId` of every
+         * foreign transfer committed here.
+         * @member {String|null} workspaceId=null
+         */
+        workspaceId: null
+    }
+
+    /**
+     * The registered {@link Neo.dashboard.CrossWindowDragTarget} this participation owns.
+     * Created in {@link #construct}, destroyed with this instance.
+     * @member {Neo.dashboard.CrossWindowDragTarget|null} target=null
+     */
+    target = null
+
+    /**
+     * Creates + registers the workspace's cross-window target with the five owner seams bound.
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        let me = this;
+
+        me.target = Neo.create(CrossWindowDragTarget, {
+            clearPreview      : me.clearPreview,
+            commitOperation   : me.commitDrop.bind(me),
+            dragCoordinator   : me.dragCoordinator,
+            hitTest           : me.hitTest,
+            previewFor        : me.previewFor,
+            previewToOperation: me.previewToOperation,
+            sortGroup         : me.sortGroup,
+            windowId          : me.windowId
+        })
+    }
+
+    /**
+     * @summary The discriminated commit — the one decision this class adds. A dragged item found
+     * in THIS workspace's committed catalog commits through the landed single-document seam; a
+     * foreign item composes ONE `transferItem` descriptor (the converted operation nested as its
+     * `target`) and executes the landed atomic two-document transfer, updating the durable
+     * placement hints on the transferred record in the same commit. Every unprovable input —
+     * missing payload identity, unresolvable source document, executor errors — fails closed:
+     * nothing commits, `null` returns, both documents stay untouched (the executor's
+     * commit-or-neither contract).
+     * @param {Object} operation The converted `addTab`/`splitNode` descriptor from the target's
+     *     preview→operation pipeline.
+     * @param {Object} draggedItem The coordinator's drag payload — carries `dockItemId` +
+     *     `dockSourceWorkspaceId` per the class-summary payload contract.
+     * @returns {Object|null} the owner commit result, or null when nothing committed.
+     */
+    commitDrop(operation, draggedItem) {
+        let me       = this,
+            itemId   = draggedItem?.dockItemId,
+            document = me.getDocument?.();
+
+        if (!operation || !itemId || !document) {
+            return null
+        }
+
+        // LOCAL: the item already lives in this workspace's committed catalog — the in-window
+        // pipeline commits it (same document, same seam, no transfer semantics).
+        if (Object.hasOwn(document.items ?? {}, itemId)) {
+            return me.commitLocal?.(operation, draggedItem) ?? null
+        }
+
+        const sourceWorkspaceId = draggedItem?.dockSourceWorkspaceId;
+        const sourceDocument    = sourceWorkspaceId != null ? me.getForeignDocument?.(sourceWorkspaceId) : null;
+
+        if (!sourceDocument || !me.commitTransfer) {
+            return null
+        }
+
+        const descriptor = {
+            operation        : 'transferItem',
+            itemId,
+            sourceWorkspaceId,
+            targetWorkspaceId: me.workspaceId,
+            target           : operation
+        };
+
+        const result = DockZoneModel.transferItem(sourceDocument, document, descriptor);
+
+        if (result.errors.length) {
+            return null
+        }
+
+        // Durable placement hints ride the SAME commit (§2.1 / §2.3 mandatory): ownership moves
+        // to this workspace, and the fallback is the semantic node the item just entered — the
+        // tabs node of an `addTab`, the split target of a `splitNode`. Never geometry. The
+        // executor returned fresh committed clones, so stamping here mutates no caller state.
+        const record = result.targetDocument.items[itemId];
+
+        record.owningWorkspaceId = me.workspaceId;
+        record.fallbackTarget    = {
+            nodeId     : operation.operation === 'addTab' ? operation.tabsNodeId : operation.targetNodeId,
+            workspaceId: me.workspaceId
+        };
+
+        me.commitTransfer({
+            descriptor,
+            sourceDocument   : result.sourceDocument,
+            sourceWorkspaceId,
+            targetDocument   : result.targetDocument,
+            targetWorkspaceId: me.workspaceId
+        });
+
+        return result
+    }
+
+    /**
+     * Unregisters + destroys the owned target before instance teardown — the unmount half of the
+     * registration lifecycle.
+     */
+    destroy() {
+        this.target?.destroy();
+        this.target = null;
+
+        super.destroy()
+    }
+}
+
+export default Neo.setupClass(DockCrossWindowParticipation);

--- a/src/dashboard/DockCrossWindowParticipation.mjs
+++ b/src/dashboard/DockCrossWindowParticipation.mjs
@@ -15,9 +15,10 @@ import DockZoneModel         from './DockZoneModel.mjs';
  * landed pipeline, adding exactly ONE new decision: foreign-vs-local drop discrimination at
  * commit time.
  *
- * - **Local drop** (the dragged item already lives in THIS workspace's committed document): the
- *   converted operation rides the owner's landed single-document commit seam — the identical
- *   pipeline in-window drags use. No parallel drag system (§2.3 inherited guardrail).
+ * - **Local drop** (the payload's source workspace IS this one — two windows may project the
+ *   same document): the converted operation rides the owner's landed single-document commit
+ *   seam — the identical pipeline in-window drags use. No parallel drag system (§2.3 inherited
+ *   guardrail).
  * - **Foreign drop** (the item belongs to a sibling window's workspace on the same App-Worker
  *   heap): the converted `addTab`/`splitNode` descriptor becomes the nested `target` of ONE
  *   semantic `transferItem` operation, executed through the landed atomic two-document executor
@@ -33,8 +34,11 @@ import DockZoneModel         from './DockZoneModel.mjs';
  *
  * The cross-window drag payload contract (stamped by {@link Neo.dashboard.DockTabSortZone} at
  * drag start): `draggedItem.dockItemId` names the dock catalog item, and
- * `draggedItem.dockSourceWorkspaceId` names the workspace document it departs — both required
- * for a foreign commit; a payload without them fails closed (no signal-free guessing).
+ * `draggedItem.dockSourceWorkspaceId` names the workspace document it departs. The local/foreign
+ * discriminator keys on the LATTER's identity with this workspace — item-id presence in the
+ * target catalog is never ownership evidence (a foreign item with a colliding id must reach the
+ * executor's fail-closed collision rejection, not commit the local record) — and a payload
+ * missing either stamp fails closed (no signal-free guessing).
  */
 class DockCrossWindowParticipation extends Base {
     static config = {
@@ -154,14 +158,16 @@ class DockCrossWindowParticipation extends Base {
     }
 
     /**
-     * @summary The discriminated commit — the one decision this class adds. A dragged item found
-     * in THIS workspace's committed catalog commits through the landed single-document seam; a
-     * foreign item composes ONE `transferItem` descriptor (the converted operation nested as its
-     * `target`) and executes the landed atomic two-document transfer, updating the durable
-     * placement hints on the transferred record in the same commit. Every unprovable input —
-     * missing payload identity, unresolvable source document, executor errors — fails closed:
-     * nothing commits, `null` returns, both documents stay untouched (the executor's
-     * commit-or-neither contract).
+     * @summary The discriminated commit — the one decision this class adds. A payload whose
+     * `dockSourceWorkspaceId` IS this workspace commits through the landed single-document seam;
+     * any other source workspace composes ONE `transferItem` descriptor (the converted operation
+     * nested as its `target`) and executes the landed atomic two-document transfer, updating the
+     * durable placement hints on the transferred record in the same commit. Discrimination is
+     * workspace IDENTITY, never item-id presence in the target catalog — an id collision across
+     * workspaces rides the executor's fail-closed rejection. Every unprovable input — missing
+     * payload identity, unresolvable source document, executor errors — fails closed: nothing
+     * commits, `null` returns, both documents stay untouched (the executor's commit-or-neither
+     * contract).
      * @param {Object} operation The converted `addTab`/`splitNode` descriptor from the target's
      *     preview→operation pipeline.
      * @param {Object} draggedItem The coordinator's drag payload — carries `dockItemId` +
@@ -169,22 +175,25 @@ class DockCrossWindowParticipation extends Base {
      * @returns {Object|null} the owner commit result, or null when nothing committed.
      */
     commitDrop(operation, draggedItem) {
-        let me       = this,
-            itemId   = draggedItem?.dockItemId,
-            document = me.getDocument?.();
+        let me                = this,
+            itemId            = draggedItem?.dockItemId,
+            sourceWorkspaceId = draggedItem?.dockSourceWorkspaceId,
+            document          = me.getDocument?.();
 
         if (!operation || !itemId || !document) {
             return null
         }
 
-        // LOCAL: the item already lives in this workspace's committed catalog — the in-window
-        // pipeline commits it (same document, same seam, no transfer semantics).
-        if (Object.hasOwn(document.items ?? {}, itemId)) {
+        // LOCAL means the payload NAMES this workspace as its source (two windows may project the
+        // same document) — workspace IDENTITY, never item-id presence in the target catalog: a
+        // foreign item whose id collides with a local one must reach the executor's fail-closed
+        // collision rejection below, not silently commit the local record. An unstamped payload
+        // proves neither side, so it falls through to the foreign guard and fails closed.
+        if (sourceWorkspaceId != null && sourceWorkspaceId === me.workspaceId) {
             return me.commitLocal?.(operation, draggedItem) ?? null
         }
 
-        const sourceWorkspaceId = draggedItem?.dockSourceWorkspaceId;
-        const sourceDocument    = sourceWorkspaceId != null ? me.getForeignDocument?.(sourceWorkspaceId) : null;
+        const sourceDocument = sourceWorkspaceId != null ? me.getForeignDocument?.(sourceWorkspaceId) : null;
 
         if (!sourceDocument || !me.commitTransfer) {
             return null

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -223,8 +223,13 @@ class DockLayoutAdapter extends Base {
         }
 
         let config = this.projectNode(model.root, {
-            applyDockZoneOperation  : options.applyDockZoneOperation,
-            autoHideRevealOnHover   : options.autoHideRevealOnHover === true,
+            applyDockZoneOperation: options.applyDockZoneOperation,
+            autoHideRevealOnHover : options.autoHideRevealOnHover === true,
+            // Cross-WINDOW participation (docking design record §2.3, additive + opt-in): a composition that
+            // supplies a sortGroup makes every projected tab sort zone a coordinator-registered
+            // drag SOURCE (the workspace id rides the drag payload for the receiving window's
+            // `transferItem` resolution). Absent = fully in-window, the unchanged default.
+            crossWindowSortGroup    : options.crossWindowSortGroup ?? null,
             defaultRevealFraction   : Number.isFinite(options.defaultRevealFraction) ? options.defaultRevealFraction : null,
             dockZoneDocument        : options.dockZoneDocument || model,
             items                   : model.items || {},
@@ -232,7 +237,8 @@ class DockLayoutAdapter extends Base {
             onDockCrossZoneDragMove : options.onDockCrossZoneDragMove,
             onDockCrossZoneDrop     : options.onDockCrossZoneDrop,
             onDockZoneDocumentChange: options.onDockZoneDocumentChange,
-            resolveComponentRef     : options.resolveComponentRef || (() => null)
+            resolveComponentRef     : options.resolveComponentRef || (() => null),
+            workspaceId             : options.workspaceId ?? null
         });
 
         config.cls = [...new Set([...(config.cls || []), 'neo-dashboard'])];
@@ -630,7 +636,11 @@ class DockLayoutAdapter extends Base {
                 sortZoneConfig: {
                     module          : DockTabSortZone,
                     dockItemIds     : items,
-                    dockSourceNodeId: nodeId
+                    dockSourceNodeId: nodeId,
+                    // §2.3 source identity (opt-in): the coordinator gates registration on
+                    // sortGroup, so a null group keeps this zone in-window exactly as before.
+                    dockWorkspaceId: context.workspaceId,
+                    sortGroup      : context.crossWindowSortGroup
                 }
             },
             items    : items.map(itemId => this.projectItem(itemId, context)),

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -16,6 +16,17 @@ import TabHeaderSortZone from '../draggable/tab/header/toolbar/SortZone.mjs';
  * the drag data ({@link Neo.draggable.container.SortZone#onDragMove} threads `clientX`/`clientY`); this
  * class only reads the outcome and forwards it. No popup / window-detach path is involved
  * (`enableProxyToPopup` stays at its `false` default).
+ *
+ * **Cross-WINDOW participation (the harness docking design record, §2.3 source side).** The base chain already registers with
+ * `Neo.manager.DragCoordinator` and routes drags through it (registration is coordinator-gated on
+ * `sortGroup` — a dock composition that never sets one stays fully in-window). This class implements
+ * the contract's three mandatory source hooks per the §2.3 OQ2 constraint (dock surfaces implement
+ * the CONTRACT; they do not inherit the dashboard sort zone) and stamps the cross-window payload
+ * identity at drag start: `dragComponent.dockItemId` + `dragComponent.dockSourceWorkspaceId` — what a
+ * receiving {@link Neo.dashboard.DockCrossWindowParticipation} needs to discriminate foreign drops
+ * and compose `transferItem`. The source NEVER mutates documents on a remote drop: the target side
+ * owns the atomic two-document commit (both workspace documents live on the one App-Worker heap);
+ * this side only suppresses its own in-window drop event so the transfer cannot double-commit.
  */
 class DockTabSortZone extends TabHeaderSortZone {
     static config = {
@@ -38,7 +49,79 @@ class DockTabSortZone extends TabHeaderSortZone {
          * The dock-zone (tabs node) id this toolbar renders — the source of a cross-zone move.
          * @member {String|null} dockSourceNodeId=null
          */
-        dockSourceNodeId: null
+        dockSourceNodeId: null,
+        /**
+         * The workspace document id this toolbar's items belong to — stamped onto the drag payload
+         * as `dockSourceWorkspaceId`, the receiving window's `transferItem` source-resolution key.
+         * @member {String|null} dockWorkspaceId=null
+         */
+        dockWorkspaceId: null
+    }
+
+    /**
+     * Set by {@link #onRemoteDropOut} when a remote target committed this drag's item transfer;
+     * consumed exactly once by {@link #processDragEnd} to suppress the in-window cross-zone drop
+     * event (the item already left this document — firing it would double-commit).
+     * @member {Boolean} remoteDropCommitted=false
+     */
+    remoteDropCommitted = false
+
+    /**
+     * Extends the base drag-start: after the base resolves the dragged tab button, stamps the
+     * cross-window payload identity onto it — `dockItemId` (the dock catalog id) +
+     * `dockSourceWorkspaceId` (this document's workspace-set key). The coordinator hands exactly
+     * this component to a remote target's hooks, so the stamp is what lets the receiving
+     * workspace discriminate a foreign drop and compose `transferItem` without any dock knowledge
+     * entering the coordinator (§2.3 dock-blind invariant).
+     * @param {Object} data
+     */
+    async onDragStart(data) {
+        await super.onDragStart(data);
+
+        let me   = this,
+            item = me.dragComponent;
+
+        if (item) {
+            item.dockItemId              = me.dockItemIds?.[me.startIndex] ?? null;
+            item.dockSourceWorkspaceId   = me.dockWorkspaceId
+        }
+    }
+
+    /**
+     * §2.3 mandatory source hook: a remote target committed the drop — release the item on the
+     * source side. For a dock source that means embodiment cleanup ONLY: the atomic two-document
+     * `transferItem` already removed the item from this document (target-side commit), so this
+     * hook just arms the one-shot suppression flag {@link #processDragEnd} consumes. No document
+     * writes here — the source must never race the executor's commit-or-neither contract.
+     * @param {Neo.component.Base} draggedItem
+     */
+    onRemoteDropOut(draggedItem) {
+        this.remoteDropCommitted = true
+    }
+
+    /**
+     * §2.3 mandatory source hook: a remote target engaged — the source's drag embodiment yields
+     * while the target window hosts the hover. The dock's embodiment is the in-window drag proxy
+     * (no popup path, `enableProxyToPopup` false), so suspension is hiding it.
+     * @param {String} widgetName
+     */
+    suspendWindowDrag(widgetName) {
+        let proxy = this.dragProxy;
+
+        proxy && (proxy.hidden = true)
+    }
+
+    /**
+     * §2.3 mandatory source hook: the drag left every remote target back into the void — the
+     * source embodiment resumes. The in-window proxy un-hides; its position keeps riding the base
+     * drag-move stream (the supplied rect matters only for the popup embodiment class).
+     * @param {String} widgetName
+     * @param {Object} proxyRect
+     */
+    resumeWindowDrag(widgetName, proxyRect) {
+        let proxy = this.dragProxy;
+
+        proxy && (proxy.hidden = false)
     }
 
     /**
@@ -49,6 +132,10 @@ class DockTabSortZone extends TabHeaderSortZone {
      * component-tree walk). Fires BEFORE `super`: the base drag-end resets `startIndex` and its within-reorder
      * commit can trigger a deferred re-projection that destroys this tab container, so firing after would
      * land on a dead component.
+     *
+     * A drag a remote window committed ({@link #remoteDropCommitted}) suppresses the event for
+     * exactly one drag-end: the item already transferred out of this document, so the in-window
+     * cross-zone commit path must not fire a second, now-invalid operation. Base cleanup still runs.
      * @param {Object} data
      */
     async processDragEnd(data) {
@@ -61,7 +148,9 @@ class DockTabSortZone extends TabHeaderSortZone {
             tabContainer = me.owner?.up?.(),
             {clientX, clientY} = data || {};
 
-        if (itemId && tabContainer && Neo.isNumber(clientX) && Neo.isNumber(clientY)) {
+        if (me.remoteDropCommitted) {
+            me.remoteDropCommitted = false
+        } else if (itemId && tabContainer && Neo.isNumber(clientX) && Neo.isNumber(clientY)) {
             tabContainer.fire('dockCrossZoneDrop', {clientX, clientY, itemId, sourceNodeId: me.dockSourceNodeId})
         }
 

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -1,3 +1,4 @@
+import DragCoordinator   from '../manager/DragCoordinator.mjs';
 import TabHeaderSortZone from '../draggable/tab/header/toolbar/SortZone.mjs';
 
 /**
@@ -17,11 +18,15 @@ import TabHeaderSortZone from '../draggable/tab/header/toolbar/SortZone.mjs';
  * class only reads the outcome and forwards it. No popup / window-detach path is involved
  * (`enableProxyToPopup` stays at its `false` default).
  *
- * **Cross-WINDOW participation (the harness docking design record, §2.3 source side).** The base chain already registers with
- * `Neo.manager.DragCoordinator` and routes drags through it (registration is coordinator-gated on
- * `sortGroup` — a dock composition that never sets one stays fully in-window). This class implements
- * the contract's three mandatory source hooks per the §2.3 OQ2 constraint (dock surfaces implement
- * the CONTRACT; they do not inherit the dashboard sort zone) and stamps the cross-window payload
+ * **Cross-WINDOW participation (the harness docking design record, §2.3 source side).** The base tab-header
+ * chain carries NO `Neo.manager.DragCoordinator` delegation (that lives only in the dashboard sort
+ * zone, which dock surfaces must not inherit per the §2.3 OQ2 constraint: implement the CONTRACT,
+ * not the class) — so THIS class feeds the coordinator explicitly from its own lifecycle:
+ * {@link #onDragMove} reports every move in screen space and {@link #processDragEnd} closes the
+ * gesture through the coordinator BEFORE deciding the local drop. Both feeds are gated on
+ * {@link #sortGroup} (the §2.3 registry identity) — a dock composition that never sets one stays
+ * fully in-window with zero coordinator traffic. This class also implements the contract's three
+ * mandatory source hooks per that same constraint and stamps the cross-window payload
  * identity at drag start: `dragComponent.dockItemId` + `dragComponent.dockSourceWorkspaceId` — what a
  * receiving {@link Neo.dashboard.DockCrossWindowParticipation} needs to discriminate foreign drops
  * and compose `transferItem`. The source NEVER mutates documents on a remote drop: the target side
@@ -55,7 +60,15 @@ class DockTabSortZone extends TabHeaderSortZone {
          * as `dockSourceWorkspaceId`, the receiving window's `transferItem` source-resolution key.
          * @member {String|null} dockWorkspaceId=null
          */
-        dockWorkspaceId: null
+        dockWorkspaceId: null,
+        /**
+         * §2.3 registry identity for the SOURCE side: {@link Neo.manager.DragCoordinator} resolves
+         * remote-target candidates from the source zone's `sortGroup` + the pointer's screen-space
+         * window, so a `null` group short-circuits both coordinator feeds — the dock stays fully
+         * in-window. Threaded by {@link Neo.dashboard.DockLayoutAdapter} (`crossWindowSortGroup`).
+         * @member {String|null} sortGroup=null
+         */
+        sortGroup: null
     }
 
     /**
@@ -136,6 +149,11 @@ class DockTabSortZone extends TabHeaderSortZone {
      * A drag a remote window committed ({@link #remoteDropCommitted}) suppresses the event for
      * exactly one drag-end: the item already transferred out of this document, so the in-window
      * cross-zone commit path must not fire a second, now-invalid operation. Base cleanup still runs.
+     *
+     * Cross-window gestures close through {@link Neo.manager.DragCoordinator#onDragEnd} FIRST: a
+     * release over an engaged remote target commits there, and the coordinator arms
+     * {@link #remoteDropCommitted} via {@link #onRemoteDropOut} on this same call stack — so the
+     * local decision below always sees the truth.
      * @param {Object} data
      */
     async processDragEnd(data) {
@@ -147,6 +165,13 @@ class DockTabSortZone extends TabHeaderSortZone {
             // listener the adapter wires.
             tabContainer = me.owner?.up?.(),
             {clientX, clientY} = data || {};
+
+        if (me.sortGroup && me.dragComponent) {
+            DragCoordinator.onDragEnd({
+                draggedItem   : me.dragComponent,
+                sourceSortZone: me
+            })
+        }
 
         if (me.remoteDropCommitted) {
             me.remoteDropCommitted = false
@@ -163,6 +188,12 @@ class DockTabSortZone extends TabHeaderSortZone {
      * id, so the owner can compute + render the transient dock-preview affordance under the pointer each
      * frame. Purely additive + reactive — the base owns the proxy and the sort math; the affordance is a
      * consumer of this hover signal, never a parallel drag system. Mirrors the {@link #processDragEnd} drop seam.
+     *
+     * Cross-window gestures additionally feed {@link Neo.manager.DragCoordinator#onDragMove} in
+     * screen space (the base chain has no coordinator delegation of its own): the coordinator
+     * arbitrates registered remote targets from this signal and drives the suspend / resume /
+     * remote-hover hooks back into this zone. Gated on {@link #sortGroup}; the `proxyRect` gate
+     * matters too — the move payload carries one exactly while a live drag proxy exists.
      * @param {Object} data
      */
     async onDragMove(data) {
@@ -175,6 +206,18 @@ class DockTabSortZone extends TabHeaderSortZone {
 
         if (itemId && tabContainer && Neo.isNumber(clientX) && Neo.isNumber(clientY)) {
             tabContainer.fire('dockCrossZoneDragMove', {clientX, clientY, itemId, sourceNodeId: me.dockSourceNodeId})
+        }
+
+        if (me.sortGroup && me.dragComponent && data?.proxyRect && Neo.isNumber(data.screenX)) {
+            DragCoordinator.onDragMove({
+                draggedItem   : me.dragComponent,
+                offsetX       : data.offsetX,
+                offsetY       : data.offsetY,
+                proxyRect     : data.proxyRect,
+                screenX       : data.screenX,
+                screenY       : data.screenY,
+                sourceSortZone: me
+            })
         }
     }
 }

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -1,0 +1,226 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'NeoDashboardDockCrossWindowParticipationTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+/**
+ * @summary Tests for Neo.dashboard.DockCrossWindowParticipation — the adapter-tier composition
+ * that wires ONE dock workspace into the §2.3 cross-window contract over landed machinery only:
+ * target registration lifecycle, the owner seams, foreign-vs-local drop discrimination, the
+ * atomic `transferItem` composition, and the durable placement-hint updates riding the same
+ * commit. The executor itself is the REAL DockZoneModel — no transfer semantics are mocked.
+ */
+
+/** A fresh source-workspace document ('A') — `terminal` is the item every transfer moves. */
+function sourceDoc() {
+    return {
+        schema: 'neo.harness.dockZone.v1',
+        root  : 'root',
+        items : {
+            strategy: {componentRef: 'strategy', title: 'Strategy', kind: 'panel'},
+            terminal: {componentRef: 'terminal', title: 'Terminal', kind: 'terminal'}
+        },
+        nodes: {
+            root       : {type: 'edge-zone', zones: {center: 'main-tabs', right: 'side-tabs'}},
+            'main-tabs': {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'},
+            'side-tabs': {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}
+        }
+    }
+}
+
+/** A fresh target-workspace document ('B') with a disjoint catalog. */
+function targetDoc() {
+    return {
+        schema: 'neo.harness.dockZone.v1',
+        root  : 'root',
+        items : {alpha: {componentRef: 'alpha', title: 'Alpha', kind: 'panel'}},
+        nodes : {
+            root       : {type: 'edge-zone', zones: {center: 'main-tabs'}},
+            'main-tabs': {type: 'tabs', items: ['alpha'], activeItemId: 'alpha'}
+        }
+    }
+}
+
+test.describe('Neo.dashboard.DockCrossWindowParticipation (ADR 0029 §2.3 — workspace wiring)', () => {
+    let DockCrossWindowParticipation;
+
+    const createCoordinatorStub = calls => ({
+        register  : zone => calls.push(['register', zone]),
+        unregister: zone => calls.push(['unregister', zone])
+    });
+
+    test.beforeAll(async () => {
+        DockCrossWindowParticipation = (await import('../../../../src/dashboard/DockCrossWindowParticipation.mjs')).default
+    });
+
+    test('registration lifecycle: mount registers ONE identity-complete target, unmount unregisters the same instance', () => {
+        const calls = [];
+
+        const participation = Neo.create(DockCrossWindowParticipation, {
+            dragCoordinator: createCoordinatorStub(calls),
+            getDocument    : () => targetDoc(),
+            hitTest        : () => true,
+            sortGroup      : 'dock-demo',
+            windowId       : 'window-b',
+            workspaceId    : 'B'
+        });
+
+        expect(calls).toHaveLength(1);
+
+        const [action, zone] = calls[0];
+
+        expect(action).toBe('register');
+        expect(zone).toBe(participation.target);
+        expect(zone.sortGroup).toBe('dock-demo');
+        expect(zone.windowId).toBe('window-b');
+        // the §2.3 mandatory target hooks all exist on the registered instance
+        for (const hook of ['acceptsRemoteDrag', 'onRemoteDragMove', 'onRemoteDragLeave', 'onRemoteDrop']) {
+            expect(typeof zone[hook]).toBe('function')
+        }
+
+        participation.destroy();
+
+        expect(calls).toHaveLength(2);
+        expect(calls[1]).toEqual(['unregister', zone]);
+        // Base.destroy() deletes own members — the owned target reference is gone either way
+        expect(participation.target ?? null).toBeNull()
+    });
+
+    test('seam binding: the registered target rides the owner preview pipeline — previewFor on hover, previewToOperation + commit on drop', () => {
+        const seen  = {previews: [], conversions: [], commits: []};
+        const calls = [];
+
+        const participation = Neo.create(DockCrossWindowParticipation, {
+            commitLocal       : operation => { seen.commits.push(operation); return {document: targetDoc(), errors: []} },
+            dragCoordinator   : createCoordinatorStub(calls),
+            getDocument       : () => targetDoc(),
+            hitTest           : () => true,
+            previewFor        : payload => { seen.previews.push(payload); return {itemId: payload.draggedItem.dockItemId, placement: {kind: 'tab-into'}} },
+            previewToOperation: preview => { seen.conversions.push(preview); return {operation: 'addTab', itemId: preview.itemId, tabsNodeId: 'main-tabs'} },
+            sortGroup         : 'dock-demo',
+            windowId          : 'window-b',
+            workspaceId       : 'B'
+        });
+
+        const draggedItem = {dockItemId: 'alpha', dockSourceWorkspaceId: 'B'};
+        const payload     = {draggedItem, localX: 10, localY: 10, offsetX: 0, offsetY: 0, proxyRect: null};
+
+        // hover computes through the owner's landed path and the drop converts THAT preview
+        const preview = participation.target.onRemoteDragMove(payload);
+
+        expect(seen.previews).toEqual([payload]);
+        expect(preview.itemId).toBe('alpha');
+
+        participation.target.onRemoteDrop(draggedItem);
+
+        expect(seen.conversions).toEqual([preview]);
+        // `alpha` lives in THIS workspace's committed catalog → the LOCAL seam committed it
+        expect(seen.commits).toEqual([{operation: 'addTab', itemId: 'alpha', tabsNodeId: 'main-tabs'}]);
+
+        participation.destroy()
+    });
+
+    test('foreign drop: composes ONE transferItem through the real executor — source loses the item, target gains it, commitTransfer publishes the pair', () => {
+        const transfers = [];
+        const source    = sourceDoc();
+
+        const participation = Neo.create(DockCrossWindowParticipation, {
+            commitLocal       : () => { throw new Error('a foreign drop must never ride the local seam') },
+            commitTransfer    : published => transfers.push(published),
+            dragCoordinator   : createCoordinatorStub([]),
+            getDocument       : () => targetDoc(),
+            getForeignDocument: workspaceId => workspaceId === 'A' ? source : null,
+            sortGroup         : 'dock-demo',
+            windowId          : 'window-b',
+            workspaceId       : 'B'
+        });
+
+        const result = participation.commitDrop(
+            {operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs'},
+            {dockItemId: 'terminal', dockSourceWorkspaceId: 'A'}
+        );
+
+        expect(result).not.toBeNull();
+        expect(transfers).toHaveLength(1);
+
+        const {descriptor, sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId} = transfers[0];
+
+        expect(sourceWorkspaceId).toBe('A');
+        expect(targetWorkspaceId).toBe('B');
+        expect(descriptor).toMatchObject({operation: 'transferItem', itemId: 'terminal', sourceWorkspaceId: 'A', targetWorkspaceId: 'B'});
+        expect(descriptor.target).toEqual({operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs'});
+
+        // atomic two-document truth from the REAL executor: the source lost tree + catalog
+        // entry — and `normalizeTree` collapsed the emptied `side-tabs` slot entirely (the §2.3
+        // invariant-restoring commit) — while the target gained the verbatim record in place
+        expect(sourceDocument.items.terminal).toBeUndefined();
+        expect(sourceDocument.nodes['side-tabs']).toBeUndefined();
+        expect(targetDocument.nodes['main-tabs'].items).toContain('terminal');
+        expect(targetDocument.items.terminal).toMatchObject({componentRef: 'terminal', title: 'Terminal', kind: 'terminal'});
+
+        participation.destroy()
+    });
+
+    test('durable placement hints ride the SAME commit: owningWorkspaceId + semantic fallbackTarget, for addTab AND splitNode shapes', () => {
+        for (const [operation, expectedNodeId] of [
+            [{operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs'}, 'main-tabs'],
+            [{operation: 'splitNode', itemId: 'terminal', targetNodeId: 'main-tabs', orientation: 'horizontal', position: 'after', sizes: [0.5, 0.5]}, 'main-tabs']
+        ]) {
+            const transfers     = [];
+            const participation = Neo.create(DockCrossWindowParticipation, {
+                commitTransfer    : published => transfers.push(published),
+                dragCoordinator   : createCoordinatorStub([]),
+                getDocument       : () => targetDoc(),
+                getForeignDocument: () => sourceDoc(),
+                sortGroup         : 'dock-demo',
+                windowId          : 'window-b',
+                workspaceId       : 'B'
+            });
+
+            participation.commitDrop(operation, {dockItemId: 'terminal', dockSourceWorkspaceId: 'A'});
+
+            const record = transfers[0].targetDocument.items.terminal;
+
+            // the hints are in the PUBLISHED document — same commit, never a follow-up write;
+            // the fallback is a semantic node reference, never geometry (§2.1 durable tier)
+            expect(record.owningWorkspaceId).toBe('B');
+            expect(record.fallbackTarget).toEqual({nodeId: expectedNodeId, workspaceId: 'B'});
+
+            participation.destroy()
+        }
+    });
+
+    test('fails closed: missing payload identity, unresolvable source workspace, and executor rejections all commit NOTHING', () => {
+        const transfers     = [];
+        const participation = Neo.create(DockCrossWindowParticipation, {
+            commitLocal       : () => { throw new Error('must not commit locally') },
+            commitTransfer    : published => transfers.push(published),
+            dragCoordinator   : createCoordinatorStub([]),
+            getDocument       : () => targetDoc(),
+            getForeignDocument: workspaceId => workspaceId === 'A' ? sourceDoc() : null,
+            sortGroup         : 'dock-demo',
+            windowId          : 'window-b',
+            workspaceId       : 'B'
+        });
+
+        const operation = {operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs'};
+
+        // no dockItemId stamped on the payload → no guessing, no commit
+        expect(participation.commitDrop(operation, {id: 'anonymous'})).toBeNull();
+        // an unknown source workspace resolves no document → no commit
+        expect(participation.commitDrop(operation, {dockItemId: 'terminal', dockSourceWorkspaceId: 'ghost'})).toBeNull();
+        // the executor rejects an invalid nested target → commit-or-neither holds, nothing publishes
+        expect(participation.commitDrop({operation: 'moveItem', itemId: 'terminal'}, {dockItemId: 'terminal', dockSourceWorkspaceId: 'A'})).toBeNull();
+
+        expect(transfers).toHaveLength(0);
+
+        participation.destroy()
+    });
+});

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -49,7 +49,7 @@ function targetDoc() {
 }
 
 test.describe('Neo.dashboard.DockCrossWindowParticipation (ADR 0029 §2.3 — workspace wiring)', () => {
-    let DockCrossWindowParticipation;
+    let DockCrossWindowParticipation, DockTabSortZone, DragCoordinator, Rectangle, WindowManager;
 
     const createCoordinatorStub = calls => ({
         register  : zone => calls.push(['register', zone]),
@@ -57,7 +57,11 @@ test.describe('Neo.dashboard.DockCrossWindowParticipation (ADR 0029 §2.3 — wo
     });
 
     test.beforeAll(async () => {
-        DockCrossWindowParticipation = (await import('../../../../src/dashboard/DockCrossWindowParticipation.mjs')).default
+        DockCrossWindowParticipation = (await import('../../../../src/dashboard/DockCrossWindowParticipation.mjs')).default;
+        DockTabSortZone              = (await import('../../../../src/dashboard/DockTabSortZone.mjs')).default;
+        DragCoordinator              = (await import('../../../../src/manager/DragCoordinator.mjs')).default;
+        Rectangle                    = (await import('../../../../src/util/Rectangle.mjs')).default;
+        WindowManager                = (await import('../../../../src/manager/Window.mjs')).default
     });
 
     test('registration lifecycle: mount registers ONE identity-complete target, unmount unregisters the same instance', () => {
@@ -121,7 +125,7 @@ test.describe('Neo.dashboard.DockCrossWindowParticipation (ADR 0029 §2.3 — wo
         participation.target.onRemoteDrop(draggedItem);
 
         expect(seen.conversions).toEqual([preview]);
-        // `alpha` lives in THIS workspace's committed catalog → the LOCAL seam committed it
+        // the payload NAMES this workspace ('B') as its source → the LOCAL seam committed it
         expect(seen.commits).toEqual([{operation: 'addTab', itemId: 'alpha', tabsNodeId: 'main-tabs'}]);
 
         participation.destroy()
@@ -222,5 +226,180 @@ test.describe('Neo.dashboard.DockCrossWindowParticipation (ADR 0029 §2.3 — wo
         expect(transfers).toHaveLength(0);
 
         participation.destroy()
+    });
+
+    test('id collision across workspaces: a foreign payload whose id exists in the target NEVER rides the local seam — the executor rejects, nothing commits', () => {
+        const locals    = [];
+        const transfers = [];
+
+        // the collision trap: the TARGET document also catalogs an item named `terminal`, so
+        // item-id presence must not read as ownership — only workspace identity may
+        const collisionTarget = () => {
+            const doc = targetDoc();
+
+            doc.items.terminal = {componentRef: 'terminal-b', title: 'Terminal B', kind: 'terminal'};
+            doc.nodes['main-tabs'].items.push('terminal');
+
+            return doc
+        };
+
+        const create = getDocument => Neo.create(DockCrossWindowParticipation, {
+            commitLocal       : operation => { locals.push(operation); return {document: getDocument(), errors: []} },
+            commitTransfer    : published => transfers.push(published),
+            dragCoordinator   : createCoordinatorStub([]),
+            getDocument,
+            getForeignDocument: workspaceId => workspaceId === 'A' ? sourceDoc() : null,
+            sortGroup         : 'dock-demo',
+            windowId          : 'window-b',
+            workspaceId       : 'B'
+        });
+
+        const operation   = {operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs'};
+        const foreignDrag = {dockItemId: 'terminal', dockSourceWorkspaceId: 'A'};
+
+        // source workspace A → target workspace B, both cataloging `terminal`: the discriminator
+        // sends it FOREIGN, the executor's collision precondition rejects, commit-or-neither holds
+        const collided = create(collisionTarget);
+
+        expect(collided.commitDrop(operation, foreignDrag)).toBeNull();
+        expect(locals).toHaveLength(0);
+        expect(transfers).toHaveLength(0);
+
+        // control: the identical gesture with the collision removed transfers cleanly — only the
+        // collision blocked the commit, never the discrimination
+        const clean = create(targetDoc);
+
+        expect(clean.commitDrop(operation, foreignDrag)).not.toBeNull();
+        expect(locals).toHaveLength(0);
+        expect(transfers).toHaveLength(1);
+
+        // an UNSTAMPED payload whose id happens to exist locally proves nothing → fails closed,
+        // and in particular never rides the local seam on id-presence alone
+        expect(clean.commitDrop({operation: 'addTab', itemId: 'alpha', tabsNodeId: 'main-tabs'}, {dockItemId: 'alpha'})).toBeNull();
+        expect(locals).toHaveLength(0);
+
+        collided.destroy();
+        clean.destroy()
+    });
+
+    test('source→target through the REAL coordinator: a real DockTabSortZone engages a registered remote target, the drop transfers, exactly ONE local commit is suppressed', async () => {
+        const fires     = [];
+        const previews  = [];
+        const transfers = [];
+
+        // two windows on the coordinator's screen-space map: the source zone drags in win-a, the
+        // registered target lives in win-b
+        WindowManager.register({id: 'cwd-win-a', innerRect: new Rectangle(0, 0, 800, 600),    outerRect: new Rectangle(0, 0, 800, 600)});
+        WindowManager.register({id: 'cwd-win-b', innerRect: new Rectangle(1000, 0, 800, 600), outerRect: new Rectangle(1000, 0, 800, 600)});
+
+        // no dragCoordinator injected → the target registers with the REAL singleton
+        const participation = Neo.create(DockCrossWindowParticipation, {
+            commitLocal       : () => { throw new Error('a remote drop must never ride the local seam') },
+            commitTransfer    : published => transfers.push(published),
+            getDocument       : () => targetDoc(),
+            getForeignDocument: workspaceId => workspaceId === 'A' ? sourceDoc() : null,
+            hitTest           : () => true,
+            previewFor        : payload => { previews.push(payload); return {itemId: payload.draggedItem.dockItemId, placement: {kind: 'tab-into'}} },
+            previewToOperation: preview => ({operation: 'addTab', itemId: preview.itemId, tabsNodeId: 'main-tabs'}),
+            sortGroup         : 'dock-crosswindow-source-test',
+            windowId          : 'cwd-win-b',
+            workspaceId       : 'B'
+        });
+
+        const zone = Neo.create(DockTabSortZone, {
+            dockItemIds     : ['terminal'],
+            dockSourceNodeId: 'side-tabs',
+            dockWorkspaceId : 'A',
+            owner           : {
+                addDomListeners: () => {},
+                cls            : [],
+                dragResortable : false,
+                items          : [],
+                on             : () => {},
+                style          : {},
+                up             : () => ({fire: (name, data) => fires.push([name, data])})
+            },
+            sortGroup: 'dock-crosswindow-source-test',
+            windowId : 'cwd-win-a'
+        });
+
+        // seed the mid-gesture drag state exactly as the base drag-start leaves it, with the
+        // payload stamps exactly as this class's onDragStart writes them
+        zone.dragComponent = {id: 'tab-proxy', dockItemId: 'terminal', dockSourceWorkspaceId: 'A'};
+        zone.dragProxy     = {hidden: false};
+        zone.startIndex    = 0;
+
+        // the REAL move lifecycle with the pointer in win-b's screen space: the coordinator
+        // engages the registered remote target and suspends the source embodiment
+        await zone.onDragMove({clientX: 60, clientY: 20, offsetX: 8, offsetY: 8, proxyRect: {width: 120, height: 32}, screenX: 1400, screenY: 300});
+
+        expect(previews).toHaveLength(1);
+        expect(previews[0].draggedItem).toBe(zone.dragComponent);
+        expect(previews[0].localX).toBe(400); // screen 1400 − win-b origin 1000
+        expect(zone.dragProxy.hidden).toBe(true);
+
+        // the REAL end lifecycle: the drop commits through the coordinator → the real executor
+        // transfers A→B, and the source suppresses its local cross-zone drop event
+        await zone.processDragEnd({clientX: 60, clientY: 20});
+
+        expect(transfers).toHaveLength(1);
+        expect(transfers[0].targetDocument.items.terminal).toBeDefined();
+        expect(zone.remoteDropCommitted).toBe(false); // consumed, never sticky
+        expect(fires.filter(([name]) => name === 'dockCrossZoneDrop')).toHaveLength(0);
+
+        // …suppressed exactly ONCE: the next gesture (no remote target engaged) fires the local
+        // cross-zone drop again, and no second transfer occurs
+        zone.dockItemIds   = ['strategy'];
+        zone.dragComponent = {id: 'tab-proxy-2', dockItemId: 'strategy', dockSourceWorkspaceId: 'A'};
+        zone.startIndex    = 0;
+
+        await zone.processDragEnd({clientX: 40, clientY: 10});
+
+        expect(fires.filter(([name]) => name === 'dockCrossZoneDrop')).toHaveLength(1);
+        expect(transfers).toHaveLength(1);
+
+        participation.destroy();
+        zone.destroy();
+        WindowManager.unregister(WindowManager.get('cwd-win-a'));
+        WindowManager.unregister(WindowManager.get('cwd-win-b'))
+    });
+
+    test('a source zone without a sortGroup is coordinator-inert: no remote engagement, no suspension — the dock stays fully in-window', async () => {
+        const previews = [];
+
+        WindowManager.register({id: 'cwd-inert-a', innerRect: new Rectangle(0, 0, 800, 600),    outerRect: new Rectangle(0, 0, 800, 600)});
+        WindowManager.register({id: 'cwd-inert-b', innerRect: new Rectangle(1000, 0, 800, 600), outerRect: new Rectangle(1000, 0, 800, 600)});
+
+        const participation = Neo.create(DockCrossWindowParticipation, {
+            getDocument: () => targetDoc(),
+            hitTest    : () => true,
+            previewFor : payload => { previews.push(payload); return {itemId: payload.draggedItem.dockItemId} },
+            sortGroup  : 'dock-crosswindow-inert-test',
+            windowId   : 'cwd-inert-b',
+            workspaceId: 'B'
+        });
+
+        const zone = Neo.create(DockTabSortZone, {
+            dockItemIds    : ['terminal'],
+            dockWorkspaceId: 'A',
+            owner          : {addDomListeners: () => {}, cls: [], dragResortable: false, items: [], on: () => {}, style: {}, up: () => null},
+            windowId       : 'cwd-inert-a'
+            // no sortGroup — the §2.3 opt-in axis stays unset
+        });
+
+        zone.dragComponent = {id: 'tab-proxy', dockItemId: 'terminal', dockSourceWorkspaceId: 'A'};
+        zone.dragProxy     = {hidden: false};
+        zone.startIndex    = 0;
+
+        await zone.onDragMove({clientX: 60, clientY: 20, offsetX: 8, offsetY: 8, proxyRect: {width: 120, height: 32}, screenX: 1400, screenY: 300});
+        await zone.processDragEnd({clientX: 60, clientY: 20});
+
+        expect(previews).toHaveLength(0);
+        expect(zone.dragProxy.hidden).toBe(false);
+
+        participation.destroy();
+        zone.destroy();
+        WindowManager.unregister(WindowManager.get('cwd-inert-a'));
+        WindowManager.unregister(WindowManager.get('cwd-inert-b'))
     });
 });


### PR DESCRIPTION
Resolves #14769

The integration half of ADR 0029 §2.3 over exclusively landed machinery: a dock workspace can now participate in cross-window drags — as target AND as source — with foreign drops committing through the atomic `transferItem` executor. Three surfaces, no new pipeline, the coordinator stays dock-blind.

- **`DockCrossWindowParticipation` (new, adapter tier)** — owns the target registration lifecycle (create on workspace mount, destroy on unmount) and binds the five owner seams of the landed `CrossWindowDragTarget` (#14757) to the workspace's landed pipeline (`hitTest` / `previewFor` / `clearPreview` / `previewToOperation` / commit). It adds exactly ONE new decision: **foreign-vs-local drop discrimination at commit, keyed on workspace IDENTITY** — a payload whose `dockSourceWorkspaceId` IS this workspace rides the owner's landed single-document commit seam (the identical in-window pipeline; two windows may project the same document); any other source workspace composes ONE `transferItem` descriptor (the converted `addTab`/`splitNode` nested as its `target`) and executes the landed atomic two-document executor (#14768): commit-or-neither, record verbatim, live instances move and never re-instantiate (§2.6). Item-id presence in the target catalog is never ownership evidence — an id collision across workspaces reaches the executor's fail-closed collision rejection instead of silently committing the local record (review cycle 1, RA2). The **durable placement hints update in the same commit** (§2.1/§2.3 mandatory): `owningWorkspaceId` flips to the receiving workspace and `fallbackTarget` becomes the semantic node the item entered (`{workspaceId, nodeId}` — never geometry). Every unprovable input — unstamped payload, unresolvable source workspace, executor rejection — fails closed: nothing commits, both documents stay untouched.
- **`DockTabSortZone` (source side)** — implements the §2.3 mandatory source hooks per the OQ2 constraint (dock surfaces implement the CONTRACT; they do not inherit the dashboard sort zone): `suspendWindowDrag`/`resumeWindowDrag` hide/unhide the in-window drag proxy (the dock's embodiment — no popup path, `enableProxyToPopup` stays false; OS-window spawning remains the #13028 boundary), and `onRemoteDropOut` arms a one-shot suppression consumed by `processDragEnd` so a remotely-committed transfer can never double-commit through the in-window cross-zone event. Drag-start now stamps the cross-window payload identity onto the dragged tab button (`dockItemId` + `dockSourceWorkspaceId`) — what the receiving window needs to discriminate and compose `transferItem`, with zero dock knowledge entering the coordinator. **The source feeds the coordinator EXPLICITLY** (review cycle 1, RA1 — the base tab-header chain carries no `DragCoordinator` delegation; that lives only in the dashboard sort zone, which the dock must not inherit per OQ2): `onDragMove` reports every move in screen space (`screenX`/`screenY`/`offsetX`/`offsetY`/`proxyRect` all ride the wire payload since the base chain sets `alwaysFireDragMove`) and `processDragEnd` closes the gesture through `DragCoordinator.onDragEnd()` BEFORE deciding the local drop — the coordinator arms the one-shot suppression via `onRemoteDropOut` on that same call stack. Both feeds are gated on the new `sortGroup` config (the §2.3 registry identity, threaded by the adapter): a dock without one produces zero coordinator traffic.
- **`DockLayoutAdapter` (additive, opt-in)** — threads two new projection options (`crossWindowSortGroup`, `workspaceId`) into every projected tab sort zone's config. Absent = fully in-window, byte-identical behavior (the coordinator no-ops on a null `sortGroup`).

Evidence: L1 (the executor is REAL in every foreign-drop spec — no transfer semantics mocked; the target/coordinator seams are injected exactly as the landed #14757 spec idiom established) → L2 for the live two-window gesture rides the G3 demo leaf per the ticket's own Out-of-Scope. Residual: none on this leaf's ACs.

## Deltas from ticket

- AC-4 (source hooks + coordinator dock-blindness) is delivered review-checkable as the ticket itself specifies — the hooks are implemented and documented against the §2.3 mandatory table; the coordinator diff is zero lines (grep-provable).
- The ticket's five-seam list maps onto the landed target's four seams + `clearPreview` (the target's own optional fifth) — no seam was invented beyond #14757's shipped contract.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs --workers=1` → **8 passed**: the original five (registration lifecycle · seam binding · foreign drop through the REAL executor with `normalizeTree` slot collapse · durable hints ride the same commit for `addTab` AND `splitNode` · fail-closed matrix) **plus the two review-cycle-1 falsifiers and an inertness guard**:
  - **id collision across workspaces** (RA2's probe shape): source A and target B both catalog `terminal` → the foreign payload NEVER rides the local seam, the executor's collision precondition rejects, nothing commits; the identical gesture with the collision removed transfers cleanly (proving discrimination never blocked it); an UNSTAMPED payload whose id exists locally also fails closed.
  - **source→target through the REAL coordinator** (RA1): a real `DockTabSortZone` (real move/end lifecycle, seeded mid-gesture drag state, two windows registered on the real `Neo.manager.Window` map) engages the registered remote target — `previewFor` receives the hover at the correct window-local coordinates (screen 1400 → local 400), the source proxy suspends via the coordinator round-trip, the drop commits the REAL A→B transfer, the local `dockCrossZoneDrop` is suppressed — and the NEXT gesture with no remote target fires the local drop again: suppression is exactly-once.
  - **no `sortGroup` = coordinator-inert**: the same real source lifecycle without the opt-in produces zero remote engagement and no suspension.
- `npm run test-unit -- test/playwright/unit/dashboard/ --workers=1` → **257 passed** (full dashboard blast radius).
- `npm run test-unit -- test/playwright/unit/apps/ --workers=1` at the cycle-1 head → **235 passed, 1 failed** — the failure is the KNOWN pre-existing dev flake (`fleetGrid.spec` full-directory ordering race: `AgentOS.view.fleet.HealthBar does not exist`; the file passes 10/10 standalone at this head, receipt below; the same flake is documented as reproducing at base with the diff stashed in the fleet morning-start PR). Zero `apps/` files in this diff.
- `node --check` clean; pre-commit gates green (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation

- [ ] The G3 demo leaf wires a two-window composition (workspace set + `getForeignDocument`/`commitTransfer` seams) and proves the live cockpit→dock→OS-window continuity gesture (#14772 path)
- [ ] `native` drag QA: suspend/resume proxy behavior under a real remote hover (the popup-embodiment class stays #13028's boundary)

## Commits

- 800dc0bd6 — the participation class + source hooks + adapter threading + 5-test spec.
- b328f4550 — review cycle 1: explicit `DragCoordinator` move/end feeds from the dock source (gated on the new `sortGroup` config) + workspace-identity drop discrimination + the three falsifiers; the source class summary now states the true wiring (the base chain carries no coordinator delegation).

Related: parent #13158 · authority: ADR 0029 §2.1/§2.3/§2.6 · consumed: #14757 (`CrossWindowDragTarget`), #14768 (`transferItem`), the #13025/#13028 coordinator lineage · unlocks: #14772 (fusion continuity) + the G3 demo leaf · v13.2 cornerstone-2.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 9cf9cce9-23bf-4211-ab0d-bab51d5e1d14.

