### PR TITLE
fix(dashboard): release the flexbox min-content floor on projected split zones (#14985)

### DIFF
--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -569,9 +569,17 @@ class DockLayoutAdapter extends Base {
             layoutNtype = orientation === 'vertical' ? 'vbox' : 'hbox';
 
         children.forEach((childId, index) => {
+            const projected = this.projectNode(childId, context);
+
             items.push({
-                ...this.projectNode(childId, context),
-                flex: flexValues[index]
+                ...projected,
+                flex : flexValues[index],
+                // The committed sizes are the SOLE geometry authority. Flexbox's default
+                // `min-height/min-width: auto` lets a zone's min-content floor cap the
+                // distribution — the rendered split then silently deviates from the
+                // document (rects freeze while the flex values are correct). Zone content
+                // clips or scrolls internally instead of overruling the document.
+                style: {...projected.style, minHeight: 0, minWidth: 0}
             });
 
             if (index < children.length - 1) {

--- a/test/playwright/e2e/agentos/FleetCockpitDockGeometryNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitDockGeometryNL.spec.mjs
@@ -1,0 +1,87 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e: the dock GEOMETRY convergence witness for the cockpit — the reserved
+ * acceptance shape from the split-brain investigation: after every committed operation, the
+ * RENDERED tree must converge to the worker-committed document within a bounded window.
+ * Semantic-vs-physical agreement, same discipline as the tour reveal detector.
+ *
+ * The defect class this pins (empirically convicted on this surface): flexbox's default
+ * `min-height: auto` let a zone's min-content floor cap the split distribution — the
+ * committed document said one ratio, the paint held another, FOREVER, with a fully healthy
+ * vdom pipeline (correct elements, correct inline flex, no in-flight residue). The adapter
+ * now releases the floor on every projected split child; this witness fails loudly should
+ * any surface reintroduce a hidden geometry authority beside the document.
+ *
+ * Deterministic by design: commits ride the NL write-half (`executeDockOperation`) — the
+ * geometry contract is commit-path-independent; pointer-gesture coverage is the drag lane's
+ * concern, not this witness's.
+ *
+ * Run: NEO_E2E_PORT=8117 npx playwright test FleetCockpitDockGeometryNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('AgentOS Fleet cockpit — dock geometry convergence (Neural Link)', () => {
+    test.setTimeout(90000);
+
+    test('the rendered split converges to every committed ratio within a bounded window', async ({page, neuralLink}) => {
+        await page.goto('/apps/agentos/index.html');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+        await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
+
+        const splitter = page.locator('.fm-fleet-cockpit .neo-dashboard-dock-splitter').first();
+        await expect(splitter).toBeVisible({timeout: 30000});
+
+        const app      = await neuralLink.connectToApp('AgentOS'),
+              cockpits = await app.findInstances({className: 'AgentOS.view.fleet.FleetCockpit'}, ['id']),
+              holderId = Array.isArray(cockpits) ? cockpits[0]?.id : cockpits?.id;
+
+        expect(holderId, 'the FleetCockpit must exist in the App Worker').toBeTruthy();
+
+        // the physical truth: the splitter's position within ITS split container — the
+        // number the committed sizes[0] must converge to (transform-inclusive on purpose:
+        // a stuck motion layer must fail this witness too)
+        const renderedRatio = () => page.evaluate(() => {
+            const splitterEl = document.querySelector('.fm-fleet-cockpit .neo-dashboard-dock-splitter'),
+                  parent     = splitterEl?.parentElement,
+                  sr         = splitterEl?.getBoundingClientRect(),
+                  pr         = parent?.getBoundingClientRect();
+
+            return sr && pr ? (sr.top - pr.top) / pr.height : null
+        });
+
+        const committedSizes = async () => {
+            const topo = await app.getDockTopology(holderId),
+                  doc  = topo?.document ?? topo;
+            return doc.nodes['primary-split'].sizes
+        };
+
+        // state-relative targets (the SharedWorker heap is shared across a sweep): two
+        // commits in opposite directions, each PAST the ~0.42 min-content floor the
+        // convicted defect froze at — a floor regression cannot pass both
+        const sizes0  = await committedSizes(),
+              targets = sizes0[0] < 0.5 ? [[0.7, 0.3], [0.35, 0.65]] : [[0.3, 0.7], [0.75, 0.25]];
+
+        for (const target of targets) {
+            const result = await app.executeDockOperation(holderId, {
+                operation: 'resizeSplit', splitNodeId: 'primary-split', sizes: target
+            });
+
+            expect(result.applied, `resizeSplit ${JSON.stringify(target)} must commit`).toBe(true);
+
+            // worker truth first (the merged journey's own discipline)...
+            await expect.poll(committedSizes, {timeout: 10000, intervals: [100]}).toEqual(target);
+
+            // ...then the BOUNDED-CONVERGENCE witness: paint follows the document. The
+            // splitter's own extent makes the rendered ratio sit within ~1.5% of the
+            // committed share; 0.03 absorbs that plus sub-pixel rounding, while any
+            // min-content floor deviation is an order of magnitude larger.
+            await expect.poll(renderedRatio, {
+                message  : `the RENDERED split must converge to committed ${target[0]} (no hidden geometry authority)`,
+                timeout  : 4000,
+                intervals: [100]
+            }).toBeCloseTo(target[0], 1.5);
+
+            const rendered = await renderedRatio();
+            expect(Math.abs(rendered - target[0]), `rendered ${rendered} vs committed ${target[0]}`).toBeLessThan(0.03)
+        }
+    });
+});

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -152,6 +152,25 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         expect(sideChildren.map(item => item.flex)).toEqual([0.55, 0.45]);
     });
 
+    test('split children release the flexbox min-content floor: committed sizes stay the sole geometry authority', () => {
+        let result = DockLayoutAdapter.project(createModel(), {
+                resolveComponentRef: componentRef => ({
+                    ntype    : 'dashboard-panel',
+                    reference: componentRef
+                })
+            }),
+            rootChildren = getProjectedChildren(result),
+            sideChildren = getProjectedChildren(rootChildren[1]);
+
+        // without the release, a zone's min-content height/width caps the flex
+        // distribution and the rendered split silently deviates from the document —
+        // every DIRECT split child (tabs zones AND nested splits) carries the release
+        [...rootChildren, ...sideChildren].forEach(child => {
+            expect(child.style.minHeight).toBe(0);
+            expect(child.style.minWidth).toBe(0)
+        })
+    });
+
     test('projects resize splitter affordances between adjacent split children', () => {
         let result = DockLayoutAdapter.project(createModel(), {
                 resolveComponentRef: componentRef => ({


### PR DESCRIPTION
Resolves #14985

## Summary

The last standing `#14985` witness — the FM cockpit's "DOM keeps the stale tree" after a drag commit — is **not a vdom defect**. The complete falsification chain (all on dev `58653d78f`, full trail on the ticket):

1. NL-op commits: element AND geometry converge <800ms — clean.
2. Drag commits, 3/3: the "stale element" phase lasts exactly one in-flight window (`holder.isVdomUpdating: true` at t=0, new element in DOM by t≈760ms) — healthy async, not permanence.
3. The genuine permanence is GEOMETRY: document commits `0.6078 → 0.751`, the rebuilt children carry the **correct inline flex** (`0.751471/0.248529`), zero transforms (FLIP exonerated), no watchdog, empty error console — rendered ratio frozen at 0.57 forever.
4. Floor probe: `min-height: auto` (flexbox default) lets the stream pane's min-content height (289px of 686px ≈ 0.42) cap the distribution. Zeroing it snaps the layout to **511/169px = 0.751/0.249 — exactly the committed sizes**. The floor also explains the boot-state gap (0.6078 committed, 0.57 rendered from first paint) and the original observation's "new instances at partially stale geometry".

The dock contract says the committed document is the SOLE geometry authority ("JSON-first: no pixel geometry in the projection") — a min-content floor is a hidden pixel authority silently overriding it. The dockdemo surfaces never hit it (tiny pane content); any surface with real content does.

## Deltas

- `src/dashboard/DockLayoutAdapter.mjs` — `projectSplitNode` stamps `style: {minHeight: 0, minWidth: 0}` on every projected split child, beside the flex values it already stamps (the release is part of the same geometry contract and rides the same inline channel; no theme-loading dependency).
- `test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs` — pin: every direct split child (tabs zones and nested splits) carries the release.
- `test/playwright/e2e/agentos/FleetCockpitDockGeometryNL.spec.mjs` — **the reserved acceptance witness** (the bounded-convergence shape agreed on the ticket): after two NL commits in opposite directions past the old floor, the RENDERED ratio must converge to the committed sizes within a bounded window. Deterministic (write-half only), state-relative, transform-inclusive (a stuck motion layer would fail it too).

## Test Evidence

- Evidence: falsifier pair — the geometry witness is **RED without the one-line release** (`the RENDERED split must converge to committed 0.3`) and **GREEN with it** (stash/run/pop receipts in session).
- Evidence: 270 dashboard + dockdemo unit tests green (including the new pin).
- Evidence: cockpit e2e 3/3 (both merged FleetCockpitDockNL journeys + the new witness in one run).
- Evidence: dockdemo e2e 4/4 (DemoATourNL incl. the executing reveal + DemoADragMenuNL) — the shared-adapter change holds on every dock surface.

## Post-Merge Validation

- The ticket is retitled to the convicted mechanism; the `#12946` wedge class has **no standing reproducer** after this merge (tour half = `#15009`, fixed; cockpit half = this floor).
- Full dashboard e2e sweep on dev tip.

Authored by @neo-fable-clio

🤖 Generated with [Claude Code](https://claude.com/claude-code)