### PR TITLE
docs(learn): perspective schema naming reconciled — the dockLayout.v2 envelope is the carrier (#14773)

### DIFF
--- a/learn/agentos/HarnessDockZoneModel.md
+++ b/learn/agentos/HarnessDockZoneModel.md
@@ -167,7 +167,7 @@ If a future slice needs to restore detached windows, it should persist semantic 
 
 ## Named Layout Collections / Perspectives
 
-Named perspectives collect multiple saved layouts without choosing a storage backend or rendering a switcher. The model shape is pure JSON:
+Named perspectives collect multiple saved layouts without choosing a storage backend or rendering a switcher. Current writers place the `dockLayout.v2` envelope inside the unchanged collection shape:
 
 ```json
 {
@@ -175,10 +175,13 @@ Named perspectives collect multiple saved layouts without choosing a storage bac
   "activeLayoutId": "operator-default",
   "layouts": {
     "operator-default": {
-      "schema": "neo.harness.dockLayout.v1",
+      "schema": "neo.harness.dockLayout.v2",
       "layoutId": "operator-default",
       "title": "Operator Default",
-      "dockZone": {}
+      "dockZone": {},
+      "captureScope": "window",
+      "windowFingerprint": null,
+      "perspectiveName": "Operator Default"
     }
   },
   "metadata": {},
@@ -195,6 +198,8 @@ Rules:
 - Removing the active layout requires an explicit replacement id. Do not silently pick a different active layout.
 
 Storage remains out of scope for this layer. Browser preferences, Memory Core persistence, import/export, and rendered layout switchers consume this collection contract later; they must not fork their own collection shape.
+
+Legacy `dockLayout.v1` entries remain valid on the read path only. `migrateSavedLayout()` upgrades them to v2 with the honest defaults `captureScope: 'window'` and `windowFingerprint: null`; no writer emits v1.
 
 ## Operations
 
@@ -333,11 +338,11 @@ If neither a live component nor a valid `item.blueprint` exists, the adapter mus
 
 Layout persistence owns saved workspace documents, not drag-time state or component lifetime.
 
-A persisted layout is a small versioned wrapper around the normalized dock-zone model:
+A persisted layout is a small versioned wrapper around the normalized dock-zone model. Current writers emit v2:
 
 ```json
 {
-  "schema": "neo.harness.dockLayout.v1",
+  "schema": "neo.harness.dockLayout.v2",
   "layoutId": "operator-default",
   "title": "Operator Default",
   "dockZone": {
@@ -346,6 +351,9 @@ A persisted layout is a small versioned wrapper around the normalized dock-zone 
     "items": {},
     "nodes": {}
   },
+  "captureScope": "window",
+  "windowFingerprint": null,
+  "perspectiveName": "Operator Default",
   "revision": 1,
   "metadata": {}
 }
@@ -357,11 +365,15 @@ Required wrapper fields:
 - `layoutId`: stable user/workspace layout identity, distinct from dock item ids.
 - `title`: display label for layout pickers or recovery UIs.
 - `dockZone`: a normalized `neo.harness.dockZone.v1` model after semantic operations have run.
+- `captureScope`: `window` for one document or `topology` for a multi-window capture.
+- `windowFingerprint`: JSON-only topology-shape evidence, or `null` when a legacy v1 record had no captured fingerprint.
 
 Optional wrapper fields:
 
 - `revision`: monotonic revision, content version, or adapter-owned equivalent used for conflict/recovery messaging.
 - `metadata`: JSON-only descriptive data. It must not contain DOM nodes, functions, live component instances, credentials, PATs, access tokens, or harness bridge tokens.
+- `perspectiveName`: a non-empty display name when the wrapper is used as a named perspective.
+- `windowDocuments`: additional normalized dock-zone documents, valid only for `captureScope: 'topology'`; the primary document remains in `dockZone`.
 
 Schema-name row (the canonical vocabulary both tiers share — the design record's capture-scope amendment is the prescriptive side of this row):
 

--- a/learn/agentos/HarnessDockZoneModel.md
+++ b/learn/agentos/HarnessDockZoneModel.md
@@ -363,6 +363,14 @@ Optional wrapper fields:
 - `revision`: monotonic revision, content version, or adapter-owned equivalent used for conflict/recovery messaging.
 - `metadata`: JSON-only descriptive data. It must not contain DOM nodes, functions, live component instances, credentials, PATs, access tokens, or harness bridge tokens.
 
+Schema-name row (the canonical vocabulary both tiers share — the design record's capture-scope amendment is the prescriptive side of this row):
+
+| Schema | Role | Notes |
+|---|---|---|
+| `neo.harness.dockLayout.v1` | legacy saved-layout wrapper | read-path only; migrates forward with honest defaults |
+| `neo.harness.dockLayout.v2` | THE saved-layout AND perspective wrapper | adds `captureScope` (`window` \| `topology`), `windowFingerprint`, `perspectiveName`, `windowDocuments`; there is no separate perspective schema — the envelope carries the capability |
+| `neo.harness.dockLayoutCollection.v1` | the one named-collection shape | perspective collections reuse it verbatim; no third collection shape exists |
+
 Persistence consumes only committed dock-zone state. It must not serialize `dockPreview`, hover rectangles, screen coordinates, `windowId`, `sourceSortZone`, `targetSortZone`, runtime hover/open state for auto-hidden panes, live components, event listeners, controllers, functions, or credential material. If a future detached-window slice needs restore hints, those hints must be separate semantic placement metadata; they must not turn the dock layout into an OS-window session dump.
 
 Restore must validate the wrapper schema, the inner dock-zone schema, and the normalized model invariants before replacing an active layout. Unsupported wrapper versions, unsupported dock-zone versions, invalid references, or invalid split/tab invariants fail closed: keep the last-good active layout and surface validation or recovery state to the caller.

--- a/learn/agentos/decisions/0029-harness-docking-design.md
+++ b/learn/agentos/decisions/0029-harness-docking-design.md
@@ -351,7 +351,7 @@ Per the parent epic's discipline (one Contract-Ledgered leaf per capability), im
 |---|---|---|
 | Auto-hide UI: reveal overlay + pin control + rail drag source | §2.7 | **#13280 (in flight, Grace)** — held design-first by owner decision; this record is its contract |
 | `CrossWindowDragTarget` formalization + dock workspace target + `transferItem` | §2.3 | unfiled; file at claim time citing §2.3 |
-| Topology perspectives: the hint layer on `dockLayout.v2` + switcher + restore reconciliation | §2.2 | envelope + capture/list/restore tools landed; the placement-hint layer + multi-window restore remain |
+| Topology perspectives: the hint layer on `dockLayout.v2` + switcher + restore reconciliation | §2.2 | envelope + model-level capture/collection substrate landed; NL capture/list/restore tools are in review (#15019); the placement-hint layer + atomic multi-window restore remain |
 | Grouped drag (`moveNode`/`transferNode`) + tab overflow affordance | §2.4 | unfiled |
 | Core lift to a non-dashboard namespace | §2.5 | **gated** — fires only on the named trigger |
 

--- a/learn/agentos/decisions/0029-harness-docking-design.md
+++ b/learn/agentos/decisions/0029-harness-docking-design.md
@@ -1,6 +1,6 @@
 # ADR 0029: Harness Docking Design — Multi-Window Layout Model, Perspectives, Cross-Window Drag
 
-> Architectural Decision Record for the design tier **above** the landed `dockZone.v1` model contract: the multi-window layout model and its SharedWorker seam, named perspectives across a window topology (`dockPerspective.v1`), cross-window drag as semantic operations (`transferItem`), grouped drag (`moveNode` / `transferNode`) and tab overflow, the core-lift disposition, the container contract embedded product surfaces consume, and the auto-hide UI contract. It settles the questions the remaining docking capability leaves share and cannot answer coherently one leaf at a time. Everything is **additive on the landed `dockZone.v1` model — not a redesign**: where this record names a new schema or operation, it extends the existing family; it never alters a landed shape.
+> Architectural Decision Record for the design tier **above** the landed `dockZone.v1` model contract: the multi-window layout model and its SharedWorker seam, named perspectives across a window topology (carried by the `dockLayout.v2` envelope per the §2.2 amendment), cross-window drag as semantic operations (`transferItem`), grouped drag (`moveNode` / `transferNode`) and tab overflow, the core-lift disposition, the container contract embedded product surfaces consume, and the auto-hide UI contract. It settles the questions the remaining docking capability leaves share and cannot answer coherently one leaf at a time. Everything is **additive on the landed `dockZone.v1` model — not a redesign**: where this record names a new schema or operation, it extends the existing family; it never alters a landed shape.
 
 | Attribute | Value |
 |---|---|
@@ -31,7 +31,7 @@
 
 **Design provenance:** Discussion #13370 (graduated 2026-06-15) resolved the cross-window seam contract, the placement-hint layer, and the contract-over-lift constraint absorbed here; issue #14423 carries the criteria mapping. The window-manager leaves #13025 (popup terminal drop) and #13028 (OS-window drag reintegration) are landed and consumed as boundaries — their arbitration substrate is formalized, not reopened, by §2.3.
 
-**Why this is an ADR and not a contract doc (the re-home).** This record settles seven design questions shared by multiple future leaves, defines new persisted schemas (`dockPerspective.v1`, the durable placement-hint layer) and new semantic operations (`transferItem`, `moveNode`, `transferNode`), dispositions the core-lift clause, and binds implementation leaves to amend-this-first semantics. That crosses ADR 0005's `ADR_REQUIRED` threshold on three prongs: it changes durable persisted shapes, it decomposes into multiple future tickets needing one canonical authority, and without a decision record future V-B-A would require archaeology across leaf PRs. The content initially shipped as a public learning-tree contract page citing Discussion #13370's "Decision Record: OPTIONAL" disposition — but that disposition covered only the narrow landed-seam formalization (the §2.3 duck-type table), not the seven-section settled authority this document became. Review cycle 3 on PR #14425 (operator-flagged) corrected the placement: the authority now lives here in `learn/agentos/decisions/`, and the guide-tree page is removed in the same change. `HarnessDockZoneModel.md` keeps its own tier — descriptive contract of record for landed substrate; this ADR is prescriptive authority for the leaves above it.
+**Why this is an ADR and not a contract doc (the re-home).** This record settles seven design questions shared by multiple future leaves, defines new persisted shapes (the perspective fields on the `dockLayout` envelope — see the §2.2 amendment — and the durable placement-hint layer) and new semantic operations (`transferItem`, `moveNode`, `transferNode`), dispositions the core-lift clause, and binds implementation leaves to amend-this-first semantics. That crosses ADR 0005's `ADR_REQUIRED` threshold on three prongs: it changes durable persisted shapes, it decomposes into multiple future tickets needing one canonical authority, and without a decision record future V-B-A would require archaeology across leaf PRs. The content initially shipped as a public learning-tree contract page citing Discussion #13370's "Decision Record: OPTIONAL" disposition — but that disposition covered only the narrow landed-seam formalization (the §2.3 duck-type table), not the seven-section settled authority this document became. Review cycle 3 on PR #14425 (operator-flagged) corrected the placement: the authority now lives here in `learn/agentos/decisions/`, and the guide-tree page is removed in the same change. `HarnessDockZoneModel.md` keeps its own tier — descriptive contract of record for landed substrate; this ADR is prescriptive authority for the leaves above it.
 
 **Escalation boundary, explicitly named:** if a future leaf needs to *change* `DragCoordinator`'s arbitration semantics — its target-resolution order, its registry shape, or its dock-blindness (§2.3 invariant) — that change **amends this ADR before implementation** (ADR-0005 lifecycle), never lands as a leaf-local decision.
 
@@ -75,7 +75,7 @@ Resolved by Discussion #13370 (OQ1) and bound here: window placement intent is a
 
 | State class | Examples | Owner | Persistence |
 |---|---|---|---|
-| **Worker-owned shared truth** | committed `dockZone.v1` documents; the workspace-set registry; `dockLayout.v1` wrappers; `dockLayoutCollection.v1`; `dockPerspective.v1` (§2.2); durable placement hints; item catalogs incl. `pinned` / `autoHidden` | workspace container(s) in the App Worker | Serializable per contract rules |
+| **Worker-owned shared truth** | committed `dockZone.v1` documents; the workspace-set registry; `dockLayout.v2` wrappers (perspectives incl., §2.2 amendment); `dockLayoutCollection.v1`; durable placement hints; item catalogs incl. `pinned` / `autoHidden` | workspace container(s) in the App Worker | Serializable per contract rules |
 | **Per-window render projection** | projected config trees; edge rails; splitter affordances; tab headers; placeholder panes | `DockLayoutAdapter.project()` output per window | Never persisted; derived |
 | **Per-window runtime interaction state** | `dockPreview` payloads; reveal/open state of auto-hidden panes (§2.7); hover state; splitter pixel math mid-drag | the window's drag/interaction surfaces | Never persisted; never crosses the seam except as operation descriptors |
 | **Main-thread-only state** | DOM nodes; `DOMRect`s; screen coordinates; native window geometry; `getWindowAt` lookups | main-thread addons (`Neo.manager.Window`, `WindowPosition`) | Never persisted; consumed by arbitration (§2.3), results delivered as semantic events |
@@ -92,35 +92,27 @@ Every future docking leaf classifies each new piece of state into exactly one ro
 
 Single-workspace persistence is shipped and closed (fail-closed restore and no-secret metadata enforcement — `createSavedLayout`, `restoreSavedLayout`, `validateSavedLayoutCollection`, `createSavedLayoutCollection`, `upsertSavedLayout`, `selectSavedLayout`, `removeSavedLayout`, `restoreActiveSavedLayout` in `DockZoneModel`). `dockLayoutCollection.v1` already gives one workspace named, switchable layouts. This section extends the semantics to the multi-window topology; it does not reopen the landed wrappers.
 
-#### Capture scope
+#### Capture scope (amendment, 2026-07-11 — #14773: the shipped envelope IS the perspective carrier)
+
+**Why this amendment exists.** This section originally projected a NEW persisted schema (`neo.harness.dockPerspective.v1`) for topology-scope perspectives. The perspective substrate that actually landed ships `neo.harness.dockLayout.v2` — the EXISTING envelope family extended with the perspective fields (`captureScope`, `windowFingerprint`, `perspectiveName`, `windowDocuments`) — and it covers BOTH scopes. Minting a second wrapper name for the same capability territory would itself be the shape-proliferation this record's own anti-anchor forbids; the reconciliation therefore RETIRES the `dockPerspective.v1` name entirely: **`dockLayout.v2` is v2 of the ENVELOPE carrying v1 of the perspective CAPABILITY.** Vocabulary mapping, stated once: the capability scope this section calls `workspace` is the envelope value `captureScope: 'window'`; tool-tier surfaces (the NL perspective tools) expose the capability vocabulary and map to the envelope value internally.
 
 Two scopes exist. A perspective declares which one it is; there is no implicit scope.
 
 | Scope | Captures | Wrapper |
 |---|---|---|
-| `workspace` | one workspace document | `neo.harness.dockLayout.v1` (landed, unchanged) |
-| `topology` | every workspace document in the workspace set **plus** the durable half of the placement-hint layer | `neo.harness.dockPerspective.v1` (new, below) |
+| `workspace` | one workspace document | `neo.harness.dockLayout.v2` with `captureScope: 'window'` (shipped) |
+| `topology` | every workspace document in the workspace set **plus** the durable half of the placement-hint layer | `neo.harness.dockLayout.v2` with `captureScope: 'topology'` + `windowDocuments` (multi-document half shipped; hint layer pending, below) |
 
 ```json
 {
-  "schema": "neo.harness.dockPerspective.v1",
-  "perspectiveId": "operator-default",
+  "schema": "neo.harness.dockLayout.v2",
+  "layoutId": "operator-default",
+  "perspectiveName": "Operator Default",
   "title": "Operator Default",
-  "workspaces": {
-    "main": {
-      "schema": "neo.harness.dockLayout.v1",
-      "layoutId": "main",
-      "title": "Main Workspace",
-      "dockZone": {}
-    }
-  },
-  "placementHints": {
-    "terminal": {
-      "detached": true,
-      "owningWorkspaceId": "main",
-      "fallbackTarget": {"workspaceId": "main", "nodeId": "side-tabs"}
-    }
-  },
+  "captureScope": "topology",
+  "windowFingerprint": null,
+  "dockZone": {},
+  "windowDocuments": [],
   "revision": 1,
   "metadata": {}
 }
@@ -128,23 +120,23 @@ Two scopes exist. A perspective declares which one it is; there is no implicit s
 
 Rules, inheriting every `dockLayoutCollection.v1` discipline:
 
-- `workspaces` is keyed by stable workspace ids; each value is a valid `dockLayout.v1` wrapper validated by the landed restore path.
-- `placementHints` contains **durable hint fields only** (§2.1 table). A perspective containing `windowId`, screen coordinates, monitor geometry, or rects is invalid and must be rejected at validation.
+- `dockZone` carries the PRIMARY window's document (slot 0); `windowDocuments` is an array of the ADDITIONAL windows' documents (slots 1..N), valid only on `captureScope: 'topology'` records — each tree validated by the landed path.
+- **The durable placement-hint layer is the REMAINING §2.2 obligation** (detached-item intent, `owningWorkspaceId`, semantic `fallbackTarget` — the §2.1 durable set). It lands as ADDITIVE fields on this same envelope when the multi-window restore leaf files — never as a new schema name. A perspective containing `windowId`, screen coordinates, monitor geometry, or rects remains invalid and must be rejected at validation.
 - `metadata` is JSON-only, no secrets — enforced by the same `findSecretMetadataKey` class of checks that guards saved layouts.
-- Perspective collections (named sets of perspectives) reuse the `dockLayoutCollection.v1` pattern verbatim with `dockPerspective.v1` entries; they must not fork a third collection shape.
+- Perspective collections (named sets of perspectives) reuse `dockLayoutCollection.v1` verbatim with `dockLayout.v2` entries; they must not fork a third collection shape — and after this amendment not even a second WRAPPER shape exists.
 
 #### Restore semantics into a changed window topology
 
 Windows are render targets (§2.1); restoring a perspective restores **worker-owned truth first**, then lets windows catch up:
 
 1. **Validate everything before mutating anything.** Wrapper schema, every inner `dockZone.v1` document, every hint record. Any failure → fail closed: the entire active perspective stays untouched; validation errors surface to the caller. There is no partial restore.
-2. **Restore workspace documents** through the landed `restoreSavedLayout()` path, one per workspace id.
+2. **Restore workspace documents** through the landed `restoreSavedLayout()` path, one per captured document (`dockZone` + each `windowDocuments` entry).
 3. **Reconcile windows.** A workspace whose window is already open re-projects in place. A workspace or detached item whose window does not exist does **not** auto-spawn one: browser popup creation requires user activation, and a restore MUST NOT depend on popup permission. The content is instead placed by semantic recovery — the detached item re-enters at its `fallbackTarget`; a workspace with no window renders when a window next binds to it — and the restore reports which hints were applied vs recovered, so a switcher UI can offer "open as window" affordances behind a user gesture.
 4. **Excess windows** (open windows whose workspace the perspective does not name) keep their workspace documents untouched; the perspective governs only what it captured.
 
 #### Revision migration
 
-`revision` is monotonic per perspective. An unknown *wrapper* schema version fails closed (keep last-good, surface the error) — same rule as the landed wrappers. A future `dockPerspective.v2` must ship a documented `v1 → v2` migration in the same change that introduces it; silent best-effort upgrades are forbidden.
+`revision` is monotonic per perspective. An unknown *wrapper* schema version fails closed (keep last-good, surface the error) — same rule as the landed wrappers. A future envelope revision (`dockLayout.v3`) must ship a documented migration in the same change that introduces it — the shipped `v1 → v2` migration (`migrateSavedLayout`, honest defaults) is the precedent; silent best-effort upgrades are forbidden.
 
 ### §2.3 Cross-Window Drag
 
@@ -359,7 +351,7 @@ Per the parent epic's discipline (one Contract-Ledgered leaf per capability), im
 |---|---|---|
 | Auto-hide UI: reveal overlay + pin control + rail drag source | §2.7 | **#13280 (in flight, Grace)** — held design-first by owner decision; this record is its contract |
 | `CrossWindowDragTarget` formalization + dock workspace target + `transferItem` | §2.3 | unfiled; file at claim time citing §2.3 |
-| Topology perspectives: `dockPerspective.v1` + switcher + restore reconciliation | §2.2 | unfiled; single-workspace substrate landed |
+| Topology perspectives: the hint layer on `dockLayout.v2` + switcher + restore reconciliation | §2.2 | envelope + capture/list/restore tools landed; the placement-hint layer + multi-window restore remain |
 | Grouped drag (`moveNode`/`transferNode`) + tab overflow affordance | §2.4 | unfiled |
 | Core lift to a non-dashboard namespace | §2.5 | **gated** — fires only on the named trigger |
 
@@ -367,7 +359,7 @@ Per the parent epic's discipline (one Contract-Ledgered leaf per capability), im
 
 Inherited unchanged from the model contract's §Serializable vs Runtime State and applied to every shape this record introduces:
 
-- `neo.harness.dockPerspective.v1` persists workspace documents, durable hints, titles, ids, revisions, JSON-only metadata. It MUST NOT contain `DOMRect`s, screen or monitor coordinates, `windowId`s, live components, functions, credentials, or any preview payload.
+- Perspective records (`neo.harness.dockLayout.v2`, §2.2 amendment) persist workspace documents, durable hints, titles, ids, revisions, JSON-only metadata. They MUST NOT contain `DOMRect`s, screen or monitor coordinates, `windowId`s, live components, functions, credentials, or any preview payload.
 - Durable placement hints persist intent and semantic targets only; every geometric or window-identity field is runtime-only (§2.1 hint table).
 - `dockPreview` (including the §2.4 `groupNodeId` field) remains runtime-only in its entirety.
 - Reveal/open state of auto-hidden panes is never serialized (§2.7).


### PR DESCRIPTION
Resolves #14773

Option (a) from the ticket, executed under the ADR-0005 amend-this-first lifecycle: the design record's §2.2 now names the SHIPPED `neo.harness.dockLayout.v2` envelope as the perspective carrier, and the projected-but-never-shipped `neo.harness.dockPerspective.v1` name is **retired** — it survives only inside the amendment's own why-paragraph as the historical record. One capability territory, one name: **v2 of the ENVELOPE carrying v1 of the perspective CAPABILITY.**

**Intake falsification (the ticket's own gate for option a):** verified at source that the shipped envelope covers §2.2 — `captureScope` (`window` | `topology`), `windowFingerprint`, `perspectiveName`, and `windowDocuments` (an array of the ADDITIONAL windows' trees; slot 0 stays the primary `dockZone`; validator-enforced topology-only). The envelope carries BOTH scopes, so a second wrapper name would itself be the shape-proliferation the record's anti-anchor forbids — the amendment strengthens the anti-anchor's position: after it, not even a second WRAPPER shape exists.

**What the amendment reconciles beyond the schema string** (found at intake, firsthand): the vocabulary seam is THREE-way — the ADR's capability scope `workspace`, the envelope value `captureScope: 'window'`, and the tool tier exposing the capability vocabulary. The amendment states the mapping once (`workspace` ⇔ envelope `'window'`; tools map internally), so no future leaf burns a session proving the three names are one thing.

**Honesty preserved (nothing silently dropped):** the durable placement-hint layer (`fallbackTarget` semantics, detached-item intent) did NOT ship — the amendment names it explicitly as the REMAINING §2.2 obligation, landing as additive fields on the SAME envelope when the multi-window restore leaf files; the §3 leaf-ledger row updates to the honest split (envelope + model-level capture/collection substrate landed; NL capture/list/restore tools remain in review; hint layer + atomic multi-window restore remain). The topology-sample JSON, the restore-semantics step, the revision-migration rule (now citing the shipped `migrateSavedLayout` precedent), the durable-truth table, the header, and the JSON-first guardrail all carry the reconciled name.

**Both tiers agree:** `HarnessDockZoneModel.md` (the descriptive contract of record) gains the schema-name row — v1 read-path-only, v2 as THE saved-layout and perspective wrapper, the one collection shape — mirroring the prescriptive amendment.

**Open-ticket prose sweep (the third AC surface):** the live search for the stale name across open issues returns only this ticket itself; the repo-wide grep returns only the ADR (fixed here). Nothing else to sweep — the landed store/preset consumers already cite the canonical names, while the NL tool exposure remains in review in #15019.

Evidence: L1 (docs/spec reconcile — the change class is textual authority; the source-of-truth verification was read from `DockZoneModel` at head) → L1 required (naming-only per the ticket's own Decision Record impact line: amends ADR 0029, naming only; no envelope field changes, validator untouched). Residual: none.

## Deltas from ticket

- The scope-vocabulary mapping (`workspace` ⇔ envelope `'window'`) folded into the same amendment — the identical naming-seam class one layer down, cheaper settled now than as its own future leaf.
- The §3 leaf-ledger row and the JSON-first guardrail bullet updated in the same pass (they carried the retired name; leaving them would re-create the dual vocabulary this ticket exists to end).

## Test Evidence

Docs-only change (no code, no schema, no validator touch — the lint tier is the relevant gate):

```
grep -rn "dockPerspective" learn/ src/ ai/  → the amendment's why-paragraph only (the historical record, by design)
git diff --stat: 2 files changed, 30 insertions(+), 30 deletions(-)
```

## Post-Merge Validation

- [ ] The multi-window restore leaf, when filed, lands the placement-hint fields on the v2 envelope per the amendment (never a new schema name).
- [ ] Future leaf prose cites `dockLayout.v2` for perspectives; the retired name appearing anywhere outside the amendment's why-paragraph is a regression.

Process note: authored during the operator-granted temporary Fable 5 window.

Authored by Grace (Claude Fable 5, Claude Code). Session ef6b9a4a-54ec-4afb-8438-f89a3ee46ad2
