### PR TITLE
feat(agentos): fleet morning start — wire-derived eligibility partition + per-card cascade + honest outcome summary (#14612)

### DIFF
--- a/ai/services/fleet/resolveIdentityDisplay.mjs
+++ b/ai/services/fleet/resolveIdentityDisplay.mjs
@@ -2,8 +2,8 @@ import {IDENTITIES} from '../../graph/identityRoots.mjs';
 
 /**
  * @summary The ONE fleet↔identity join seam (the single ratified resolver site): maps a
- * fleet-registry agent (by GitHub username or registry id) onto its identity-root display facts —
- * `{family, engineTag}` — for the cockpit DTO.
+ * fleet-registry agent (by GitHub username or registry id) onto its identity-root facts —
+ * `{family, engineTag, participationStatus}` — for the cockpit DTO.
  *
  * **Source discipline:** reads the flat `ai/graph/identityRoots.mjs` registry — the ratified
  * migration-safe bridge source (usable-now-must-not-ossify) — READ-ONLY: this seam never writes
@@ -19,10 +19,16 @@ import {IDENTITIES} from '../../graph/identityRoots.mjs';
  * session facts) — the era swap re-points exactly this resolver, zero change for the assembler or
  * any Body-side consumer. Until then, null renders as a hidden tag: honest, never guessed.
  *
+ * **`participationStatus` is the AUTHORITATIVE swarm-participation fact** (the identity roots
+ * document it as such): `active` by default, `operator_benched` / `temporarily_unreachable` when
+ * a transition was recorded. It rides this seam so fleet-level control surfaces (the cockpit's
+ * morning-start eligibility partition) can exclude an operator-benched identity BEFORE any
+ * lifecycle write — heartbeat/recency signals are explicitly not valid substitutes for it.
+ *
  * **Closed-set honesty:** an agent with no identity root (a guest / freshly-defined fleet agent
- * that is not a named maintainer) resolves to `{family: null, engineTag: null}` — the cockpit's
- * FamilyRail renders unknown families as `unclassified`, so an unresolved identity degrades
- * honestly instead of guessing.
+ * that is not a named maintainer) resolves to `{family: null, engineTag: null,
+ * participationStatus: null}` — the cockpit's FamilyRail renders unknown families as
+ * `unclassified`, so an unresolved identity degrades honestly instead of guessing.
  * @module ai/services/fleet/resolveIdentityDisplay
  */
 
@@ -39,13 +45,15 @@ const identityByLogin = new Map(
 );
 
 /**
- * @summary Resolve a fleet agent's identity display facts from the identity roots.
+ * @summary Resolve a fleet agent's identity facts from the identity roots.
  * @param {String|null} agentIdOrLogin The agent's GitHub username or registry id, with or without
  *     a leading `@` (e.g. `neo-gpt`, `@neo-gpt`).
- * @returns {{family: String|null, engineTag: String|null}} the display facts; `family` is `null`
- *     when the agent has no identity root (rendered as unclassified, never guessed); `engineTag`
- *     is currently ALWAYS `null` (see the module summary — no truthful flat source exists), kept
- *     in the contract shape so the era-layer re-point changes no consumer.
+ * @returns {{family: String|null, engineTag: String|null, participationStatus: String|null}} the
+ *     identity facts; `family` is `null` when the agent has no identity root (rendered as
+ *     unclassified, never guessed); `engineTag` is currently ALWAYS `null` (see the module
+ *     summary — no truthful flat source exists), kept in the contract shape so the era-layer
+ *     re-point changes no consumer; `participationStatus` is the root's authoritative
+ *     participation fact (`null` when no root exists — unknown, never assumed active).
  */
 export function resolveIdentityDisplay(agentIdOrLogin) {
     const node = typeof agentIdOrLogin === 'string'
@@ -53,7 +61,8 @@ export function resolveIdentityDisplay(agentIdOrLogin) {
         : null;
 
     return {
-        family   : node?.properties?.family ?? null,
-        engineTag: null
+        family             : node?.properties?.family ?? null,
+        engineTag          : null,
+        participationStatus: node?.properties?.participationStatus ?? null
     }
 }

--- a/ai/services/fleet/resolveIdentityDisplay.mjs
+++ b/ai/services/fleet/resolveIdentityDisplay.mjs
@@ -22,8 +22,9 @@ import {IDENTITIES} from '../../graph/identityRoots.mjs';
  * **`participationStatus` is the AUTHORITATIVE swarm-participation fact** (the identity roots
  * document it as such): `active` by default, `operator_benched` / `temporarily_unreachable` when
  * a transition was recorded. It rides this seam so fleet-level control surfaces (the cockpit's
- * morning-start eligibility partition) can exclude an operator-benched identity BEFORE any
- * lifecycle write — heartbeat/recency signals are explicitly not valid substitutes for it.
+ * morning-start eligibility partition) can exclude any KNOWN non-active identity BEFORE a
+ * lifecycle write — the same hard-gate reading the wake-subscription liveness and heartbeat
+ * target-discovery layers apply; heartbeat/recency signals are explicitly not valid substitutes.
  *
  * **Closed-set honesty:** an agent with no identity root (a guest / freshly-defined fleet agent
  * that is not a named maintainer) resolves to `{family: null, engineTag: null,

--- a/apps/agentos/model/FleetAgent.mjs
+++ b/apps/agentos/model/FleetAgent.mjs
@@ -67,7 +67,8 @@ class FleetAgent extends Model {
             // the AUTHORITATIVE swarm-participation fact from the identity roots ('active' |
             // 'operator_benched' | 'temporarily_unreachable'), resolved Brain-side through the
             // identity join seam; typeless so null (no identity root / not stamped) survives —
-            // fleet-level eligibility excludes 'operator_benched' before any lifecycle write
+            // fleet-level eligibility excludes any KNOWN non-active status before a lifecycle
+            // write (null stays eligible: the open-set case for forks/custom residents)
             name        : 'participationStatus',
             defaultValue: null
         }, {

--- a/apps/agentos/model/FleetAgent.mjs
+++ b/apps/agentos/model/FleetAgent.mjs
@@ -64,6 +64,13 @@ class FleetAgent extends Model {
             name        : 'launchable',
             defaultValue: null
         }, {
+            // the AUTHORITATIVE swarm-participation fact from the identity roots ('active' |
+            // 'operator_benched' | 'temporarily_unreachable'), resolved Brain-side through the
+            // identity join seam; typeless so null (no identity root / not stamped) survives —
+            // fleet-level eligibility excludes 'operator_benched' before any lifecycle write
+            name        : 'participationStatus',
+            defaultValue: null
+        }, {
             // the verb whose lifecycle round-trip is in flight, written by the C2 adapter;
             // null when settled
             name        : 'pendingAction',

--- a/apps/agentos/model/FleetAgent.mjs
+++ b/apps/agentos/model/FleetAgent.mjs
@@ -41,6 +41,11 @@ class FleetAgent extends Model {
             type        : 'Object',
             defaultValue: null
         }, {
+            // the launch seam's per-family auth mode ('marker' | 'in-app'), stamped Brain-side on
+            // the roster row; null = not read back / unlaunchable — tri-state, never guessed
+            name        : 'authMode',
+            defaultValue: null
+        }, {
             name: 'displayName',
             type: 'String'
         }, {
@@ -52,6 +57,12 @@ class FleetAgent extends Model {
         }, {
             name: 'laneLine',
             type: 'String'
+        }, {
+            // the launch seam's derived launchability truth (a launch template exists for the
+            // family), stamped Brain-side on the roster row; tri-state — true / false / null
+            // (not read back yet) — so the field carries no type coercion
+            name        : 'launchable',
+            defaultValue: null
         }, {
             // the verb whose lifecycle round-trip is in flight, written by the C2 adapter;
             // null when settled

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -652,7 +652,8 @@ class FleetCockpit extends Container {
             family     : row.family ?? null,
             launchable : row.launchable ?? null,
             // the authoritative identity-root participation fact (tri-state null = no root) —
-            // the eligibility partition excludes 'operator_benched' before any lifecycle write
+            // the eligibility partition excludes any KNOWN non-active status before a lifecycle
+            // write; null stays eligible (open-set honesty for forks/custom residents)
             participationStatus: row.participationStatus ?? null,
             sources            : sessionHealth.sources,
             state              : sessionHealth.state

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -364,6 +364,16 @@ class FleetCockpit extends Container {
                     html : me.presetError
                 }] : []),
                 '->', {
+                    // The morning-start outcome summary — written by the controller after the
+                    // staged bring-up settles ("N started · M rejected · K excluded"; per-member
+                    // reasons ride the title). Empty + hidden until a start ran; hover reaches the
+                    // reasons — the honest summary state, no separate progress modal (the health
+                    // bar stays the live progression surface).
+                    ntype    : 'component',
+                    cls      : ['fm-fleet-start-summary'],
+                    hidden   : true,
+                    reference: 'fleet-start-summary'
+                }, {
                     module : Button,
                     cls    : ['fm-fleet-start'],
                     iconCls: 'fa-solid fa-play',
@@ -617,12 +627,14 @@ class FleetCockpit extends Container {
     /**
      * @summary Map one assembler DTO row onto the FleetAgent record contract. The durable `id`
      * becomes `agentId`; identity display facts (`family` / `engineTag`) flow through (null =
-     * unclassified / tagless, never guessed); the runtime `lifecycle.state` maps onto the cockpit's
-     * session-state vocabulary only when `sources.runtime` is usable; missing / not-wired /
-     * malformed source truth forces `off`, so placeholder can never render as fact. The normalized
-     * three-source object remains on the record for the card markers. `laneLine` is deliberately
-     * OMITTED (not nulled): the activity capability owns it, and a merge must never wipe what another
-     * producer wrote.
+     * unclassified / tagless, never guessed); the launch-derived truths (`launchable` /
+     * `authMode`, stamped Brain-side by the roster assembler) flow through tri-state so the
+     * morning-start eligibility partition reads the wire, never a cockpit guess; the runtime
+     * `lifecycle.state` maps onto the cockpit's session-state vocabulary only when
+     * `sources.runtime` is usable; missing / not-wired / malformed source truth forces `off`, so
+     * placeholder can never render as fact. The normalized three-source object remains on the
+     * record for the card markers. `laneLine` is deliberately OMITTED (not nulled): the activity
+     * capability owns it, and a merge must never wipe what another producer wrote.
      * @param {Object} row One cockpit DTO row (`fleetCockpitStatus` shape).
      * @returns {Object} FleetAgent record field values.
      */
@@ -631,10 +643,12 @@ class FleetCockpit extends Container {
 
         return {
             agentId    : row.id,
+            authMode   : row.authMode ?? null,
             avatarUrl  : row.avatarUrl ?? null,
             displayName: row.displayName ?? null,
             engineTag  : row.engineTag ?? null,
             family     : row.family ?? null,
+            launchable : row.launchable ?? null,
             sources    : sessionHealth.sources,
             state      : sessionHealth.state
         }

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -626,15 +626,17 @@ class FleetCockpit extends Container {
 
     /**
      * @summary Map one assembler DTO row onto the FleetAgent record contract. The durable `id`
-     * becomes `agentId`; identity display facts (`family` / `engineTag`) flow through (null =
-     * unclassified / tagless, never guessed); the launch-derived truths (`launchable` /
-     * `authMode`, stamped Brain-side by the roster assembler) flow through tri-state so the
-     * morning-start eligibility partition reads the wire, never a cockpit guess; the runtime
-     * `lifecycle.state` maps onto the cockpit's session-state vocabulary only when
-     * `sources.runtime` is usable; missing / not-wired / malformed source truth forces `off`, so
-     * placeholder can never render as fact. The normalized three-source object remains on the
-     * record for the card markers. `laneLine` is deliberately OMITTED (not nulled): the activity
-     * capability owns it, and a merge must never wipe what another producer wrote.
+     * becomes `agentId`; identity facts (`family` / `engineTag` / the authoritative
+     * `participationStatus`) flow through (null = unclassified / tagless / no identity root,
+     * never guessed); the launch-derived truths (`launchable` / `authMode`, stamped Brain-side by
+     * the roster assembler) flow through tri-state so the morning-start eligibility partition
+     * reads the wire, never a cockpit guess; the runtime `lifecycle.state` maps onto the
+     * cockpit's session-state vocabulary only when `sources.runtime` is usable; missing /
+     * not-wired / malformed source truth forces `off`, so placeholder can never render as fact.
+     * The normalized three-source object remains on the record for the card markers AND the
+     * eligibility partition (an unusable runtime source must fail a fleet start closed). `laneLine`
+     * is deliberately OMITTED (not nulled): the activity capability owns it, and a merge must
+     * never wipe what another producer wrote.
      * @param {Object} row One cockpit DTO row (`fleetCockpitStatus` shape).
      * @returns {Object} FleetAgent record field values.
      */
@@ -649,8 +651,11 @@ class FleetCockpit extends Container {
             engineTag  : row.engineTag ?? null,
             family     : row.family ?? null,
             launchable : row.launchable ?? null,
-            sources    : sessionHealth.sources,
-            state      : sessionHealth.state
+            // the authoritative identity-root participation fact (tri-state null = no root) —
+            // the eligibility partition excludes 'operator_benched' before any lifecycle write
+            participationStatus: row.participationStatus ?? null,
+            sources            : sessionHealth.sources,
+            state              : sessionHealth.state
         }
     }
 

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -1,6 +1,8 @@
 import Controller                   from '../../../../src/controller/Component.mjs';
 import {handleFleetLifecycleIntent} from './fleetLifecycleIntentAdapter.mjs';
 
+import {partitionFleetStart, renderFleetStartSummary, summarizeFleetStart} from './fleetStartPlan.mjs';
+
 /**
  * Controller for {@link AgentOS.view.fleet.FleetCockpit} — the cockpit is the **composition root** of
  * the B4÷C2 seam: the one place that knows both the resident cards and the fleet bridge, so the wire
@@ -26,26 +28,79 @@ class FleetCockpitController extends Controller {
     }
 
     /**
-     * @summary The one-click morning start — fan `start` out to every resident card via the C2 adapter.
+     * @summary The one-click morning start — the STAGED fleet bring-up: partition, cascade,
+     * honest summary.
      *
-     * The cockpit owns the wire (the cards stay intent-only): it enumerates the rendered cards and hands
-     * each a `start` intent + that card's roster record to `handleFleetLifecycleIntent`, so every
-     * resident drives its own honest round-trip (pending → settled / rejected), never an optimistic
-     * fleet-wide success. Starting an already-running resident is the bridge's concern; the per-record
-     * honest state reflects whatever actually happens.
+     * The cockpit owns the wire (the cards stay intent-only). The action reads the roster STORE
+     * (the full fleet truth — a folded idle card is still a member) and partitions it through the
+     * pure {@link module:apps/agentos/view/fleet/fleetStartPlan} rules — every eligibility fact
+     * comes from the wire (guest without a definition, launch-seam `launchable`, an in-flight
+     * verb, a live session state), and every excluded member carries its reason: never silently
+     * skipped, never a hardcoded roster. Each ELIGIBLE record then drives its own honest
+     * round-trip through the C2 adapter — the per-card pending CASCADE (excluded cards never flip
+     * pending; there is no fleet-wide spinner to lie N ways at once).
      *
-     * After the fan-out settles, the roster is re-polled ONCE (not per card) so every resident that
-     * actually started advances from its stale pre-start state to live runtime truth — see
-     * {@link #refreshRosterOnSettle}.
+     * After the cascade settles, the outcome summary renders into the chrome
+     * (`fleet-start-summary`): started / rejected / excluded counts with per-member reasons
+     * reachable from it — and the roster is re-polled ONCE so every resident that actually
+     * started advances to live runtime truth ({@link #refreshRosterOnSettle}).
+     * @returns {Promise<Object>} The outcome summary (see `summarizeFleetStart`) — for tests and
+     *     callers; the chrome render is the operator-facing half.
      */
-    onStartFleet() {
-        const results = this.getAgentCards().map(card => {
-            const {record} = card;
+    async onStartFleet() {
+        const
+            me      = this,
+            records = me.getRosterRecords(),
+            plan    = partitionFleetStart(records);
 
-            return handleFleetLifecycleIntent({action: 'start', agentId: record?.agentId ?? null}, record)
-        });
+        me.renderStartSummary(null);
 
-        return this.refreshRosterOnSettle(Promise.all(results).then(settled => settled.some(result => result?.ok)))
+        const results = await Promise.all(plan.eligible.map(record =>
+            handleFleetLifecycleIntent({action: 'start', agentId: record.agentId}, record)
+        ));
+
+        const summary = summarizeFleetStart(plan, results);
+
+        me.renderStartSummary(summary);
+
+        await me.refreshRosterOnSettle(Promise.resolve(results.some(result => result?.ok)));
+
+        return summary
+    }
+
+    /**
+     * @summary The full roster truth for fleet-level actions: the grid store's records — a folded
+     * idle card is still a fleet member — with the rendered-cards fallback for compositions that
+     * mount the controller without the grid reference.
+     * @returns {Object[]}
+     */
+    getRosterRecords() {
+        const storeItems = this.getReference('fleet-grid')?.store?.items;
+
+        return storeItems?.length ? [...storeItems] : this.getAgentCards().map(card => card.record).filter(Boolean)
+    }
+
+    /**
+     * @summary Write the morning-start outcome into the chrome summary slot: the compact counts
+     * line as the element text, the per-member reasons as its title (hover-reachable), hidden
+     * again when cleared (`null` — a new run starts with no stale outcome showing).
+     * @param {Object|null} summary From `summarizeFleetStart`, or null to clear.
+     */
+    renderStartSummary(summary) {
+        const slot = this.getReference('fleet-start-summary');
+
+        if (!slot) return;
+
+        if (!summary) {
+            slot.set({hidden: true, html: ''});
+            return
+        }
+
+        const {detail, text} = renderFleetStartSummary(summary);
+
+        slot.set({hidden: false, html: text});
+        slot.vdom.title = detail;
+        slot.update()
     }
 
     /**

--- a/apps/agentos/view/fleet/fleetStartPlan.mjs
+++ b/apps/agentos/view/fleet/fleetStartPlan.mjs
@@ -1,0 +1,121 @@
+/**
+ * @summary Pure planning + summary helpers for the fleet-level morning start — the SSOT chrome's
+ * one-click bring-up: partition the roster records into START-eligible members vs
+ * excluded-with-reason, and fold the per-record round-trip results into the honest outcome
+ * summary the operator can trust at a glance.
+ *
+ * Rendering-free and transport-free: the cockpit controller composes these around the landed
+ * per-verb C2 adapter (`fleetLifecycleIntentAdapter`), so a fleet start stays N per-record honest
+ * round-trips — the per-card pending CASCADE — never one optimistic fleet-wide spinner. Every
+ * eligibility rule below reads WIRE truth already on the record (`agentId` presence, the
+ * launch-seam `launchable` stamp, the C2 `pendingAction` seam, the runtime-derived session
+ * `state`) — nothing is hardcoded per agent, and an excluded member always carries its reason:
+ * excluded-with-reason, never silently skipped.
+ * @module apps/agentos/view/fleet/fleetStartPlan
+ */
+
+/**
+ * @summary Partition roster records into start-eligible members and excluded-with-reason entries.
+ *
+ * Rules, first match wins, each derived from a wire fact on the record:
+ * 1. no `agentId` → a guest/identity-only row with no fleet definition — nothing to start;
+ * 2. `launchable === false` → the launch seam says this family has no harness template
+ *    (tri-state honesty: `null` = not read back yet stays ELIGIBLE — the bridge's own refusal is
+ *    the truthful outcome, never a cockpit guess);
+ * 3. a `pendingAction` in flight → the C2 round-trip seam owns the card until it settles;
+ * 4. session `state` other than `off` → the resident is already up (ok / idle / wedged / limited
+ *    are all live states) — a morning start targets the DOWN fleet.
+ * @param {Object[]} records FleetAgent records (or plain field bags in tests).
+ * @returns {{eligible: Object[], excluded: Object[]}} `excluded` entries are
+ * `{record, agentId, reason}` — the reason is always present and wire-derived.
+ */
+export function partitionFleetStart(records) {
+    const
+        eligible = [],
+        excluded = [];
+
+    (records ?? []).forEach(record => {
+        if (!record) return;
+
+        const
+            agentId = record.agentId ?? null,
+            exclude = reason => excluded.push({agentId, reason, record});
+
+        if (!agentId) {
+            exclude('guest — no fleet definition to start')
+        } else if (record.launchable === false) {
+            exclude(`not launchable — no harness template for the '${record.family ?? 'unknown'}' family`)
+        } else if (record.pendingAction) {
+            exclude(`'${record.pendingAction}' round-trip already in flight`)
+        } else if ((record.state ?? 'off') !== 'off') {
+            exclude(`already up — session state '${record.state}'`)
+        } else {
+            eligible.push(record)
+        }
+    });
+
+    return {eligible, excluded}
+}
+
+/**
+ * @summary Fold the partition + the per-record C2 adapter results into the honest outcome
+ * summary: started / rejected-with-reasons / excluded-with-reasons, in the roster's own order.
+ * A non-`ok` result keeps its terminal kind visible (`rejected` / `timeout` / `unauthorized` —
+ * the adapter's settle-or-reject vocabulary), because a timeout is an UNKNOWN outcome, not a
+ * failure the operator may silently retry.
+ * @param {{eligible: Object[], excluded: Object[]}} partition From {@link partitionFleetStart}.
+ * @param {Object[]} results Per-eligible-record results from `handleFleetLifecycleIntent`, index-aligned.
+ * @returns {{started: Number, rejected: Object[], excluded: Object[], attempted: Number, total: Number}}
+ * `rejected` / `excluded` entries are `{agentId, reason}` pairs in roster order.
+ */
+export function summarizeFleetStart(partition, results) {
+    const
+        {eligible, excluded} = partition,
+        rejected             = [];
+
+    let started = 0;
+
+    eligible.forEach((record, index) => {
+        const result = results?.[index];
+
+        if (result?.ok) {
+            started++
+        } else {
+            const
+                kind   = result?.status ?? 'rejected',
+                reason = result?.controlReason?.reason ?? `start ${kind}`;
+
+            rejected.push({agentId: record.agentId, reason: kind === 'rejected' ? reason : `${kind}: ${reason}`})
+        }
+    });
+
+    return {
+        attempted: eligible.length,
+        excluded : excluded.map(({agentId, reason}) => ({agentId, reason})),
+        rejected,
+        started,
+        total    : eligible.length + excluded.length
+    }
+}
+
+/**
+ * @summary Render the summary as the compact chrome line + the reachable per-member reasons.
+ * Pure string building: `text` is the at-a-glance state ("3 started · 1 rejected · 2 excluded");
+ * `detail` lists every rejected/excluded member with its reason, one per line — the "reasons
+ * reachable from the summary" contract, carried as the summary element's title.
+ * @param {Object} summary From {@link summarizeFleetStart}.
+ * @returns {{text: String, detail: String}}
+ */
+export function renderFleetStartSummary(summary) {
+    const
+        parts  = [`${summary.started} started`],
+        detail = [];
+
+    summary.rejected.length && parts.push(`${summary.rejected.length} rejected`);
+    summary.excluded.length && parts.push(`${summary.excluded.length} excluded`);
+
+    summary.rejected.forEach(({agentId, reason}) => detail.push(`${agentId}: ${reason}`));
+    summary.excluded.forEach(({agentId, reason}) => detail.push(`${agentId ?? '(guest)'}: ${reason}`));
+
+    return {detail: detail.join('\n'), text: parts.join(' · ')}
+}

--- a/apps/agentos/view/fleet/fleetStartPlan.mjs
+++ b/apps/agentos/view/fleet/fleetStartPlan.mjs
@@ -13,11 +13,13 @@
  * `state`) — nothing is hardcoded per agent, and an excluded member always carries its reason:
  * excluded-with-reason, never silently skipped.
  *
- * The two AUTHORITY rules gate before any state read: an `operator_benched` identity is a
- * recorded operator decision no lifecycle fan-out may override, and a projected `state: 'off'`
- * over an unusable runtime source is a degraded DISPLAY fallback, not control-plane proof of a
- * stopped runtime — the same fail-closed contract the per-card controls enforce via
- * {@link module:apps/agentos/view/fleet/sourceHealth}.
+ * The two AUTHORITY rules gate before any state read: a KNOWN non-active `participationStatus`
+ * is a recorded participation fact no lifecycle fan-out may override — the same hard-gate
+ * reading the wake-subscription liveness and heartbeat target-discovery layers apply (known
+ * non-active excluded; `null`/unknown identities pass: open-set honesty for forks and custom
+ * residents) — and a projected `state: 'off'` over an unusable runtime source is a degraded
+ * DISPLAY fallback, not control-plane proof of a stopped runtime — the same fail-closed
+ * contract the per-card controls enforce via {@link module:apps/agentos/view/fleet/sourceHealth}.
  * @module apps/agentos/view/fleet/fleetStartPlan
  */
 import {normalizeFleetSources} from './sourceHealth.mjs';
@@ -27,10 +29,12 @@ import {normalizeFleetSources} from './sourceHealth.mjs';
  *
  * Rules, first match wins, each derived from a wire fact on the record:
  * 1. no `agentId` → a guest/identity-only row with no fleet definition — nothing to start;
- * 2. `participationStatus === 'operator_benched'` → the identity roots' AUTHORITATIVE
- *    participation fact records an operator bench decision — no lifecycle write may override it
- *    (`active` / `temporarily_unreachable` / `null` = no root all pass through: unreachable is an
- *    A2A-liveness fact, not a start prohibition);
+ * 2. any KNOWN non-active `participationStatus` (non-null and not `'active'`, including
+ *    `operator_benched` and `temporarily_unreachable`) → the identity roots' AUTHORITATIVE
+ *    participation fact — the wake-subscription liveness gate and the heartbeat target
+ *    discovery both read every known non-active status as a hard exclusion, and lifecycle
+ *    fan-out follows the same authority; `null` (no identity root) stays ELIGIBLE — the
+ *    open-set case for forks/custom residents, unknown is not a recorded prohibition;
  * 3. `launchable === false` → the launch seam says this family has no harness template
  *    (tri-state honesty: `null` = not read back yet stays ELIGIBLE — the bridge's own refusal is
  *    the truthful outcome, never a cockpit guess);
@@ -61,8 +65,8 @@ export function partitionFleetStart(records) {
 
         if (!agentId) {
             exclude('guest — no fleet definition to start')
-        } else if (record.participationStatus === 'operator_benched') {
-            exclude("benched — authoritative participation status 'operator_benched'")
+        } else if (record.participationStatus != null && record.participationStatus !== 'active') {
+            exclude(`not active — authoritative participation status '${record.participationStatus}'`)
         } else if (record.launchable === false) {
             exclude(`not launchable — no harness template for the '${record.family ?? 'unknown'}' family`)
         } else if (record.pendingAction) {

--- a/apps/agentos/view/fleet/fleetStartPlan.mjs
+++ b/apps/agentos/view/fleet/fleetStartPlan.mjs
@@ -8,23 +8,40 @@
  * per-verb C2 adapter (`fleetLifecycleIntentAdapter`), so a fleet start stays N per-record honest
  * round-trips — the per-card pending CASCADE — never one optimistic fleet-wide spinner. Every
  * eligibility rule below reads WIRE truth already on the record (`agentId` presence, the
- * launch-seam `launchable` stamp, the C2 `pendingAction` seam, the runtime-derived session
+ * authoritative identity-root `participationStatus`, the launch-seam `launchable` stamp, the C2
+ * `pendingAction` seam, the normalized `sources.runtime` provenance, the runtime-derived session
  * `state`) — nothing is hardcoded per agent, and an excluded member always carries its reason:
  * excluded-with-reason, never silently skipped.
+ *
+ * The two AUTHORITY rules gate before any state read: an `operator_benched` identity is a
+ * recorded operator decision no lifecycle fan-out may override, and a projected `state: 'off'`
+ * over an unusable runtime source is a degraded DISPLAY fallback, not control-plane proof of a
+ * stopped runtime — the same fail-closed contract the per-card controls enforce via
+ * {@link module:apps/agentos/view/fleet/sourceHealth}.
  * @module apps/agentos/view/fleet/fleetStartPlan
  */
+import {normalizeFleetSources} from './sourceHealth.mjs';
 
 /**
  * @summary Partition roster records into start-eligible members and excluded-with-reason entries.
  *
  * Rules, first match wins, each derived from a wire fact on the record:
  * 1. no `agentId` → a guest/identity-only row with no fleet definition — nothing to start;
- * 2. `launchable === false` → the launch seam says this family has no harness template
+ * 2. `participationStatus === 'operator_benched'` → the identity roots' AUTHORITATIVE
+ *    participation fact records an operator bench decision — no lifecycle write may override it
+ *    (`active` / `temporarily_unreachable` / `null` = no root all pass through: unreachable is an
+ *    A2A-liveness fact, not a start prohibition);
+ * 3. `launchable === false` → the launch seam says this family has no harness template
  *    (tri-state honesty: `null` = not read back yet stays ELIGIBLE — the bridge's own refusal is
  *    the truthful outcome, never a cockpit guess);
- * 3. a `pendingAction` in flight → the C2 round-trip seam owns the card until it settles;
- * 4. session `state` other than `off` → the resident is already up (ok / idle / wedged / limited
- *    are all live states) — a morning start targets the DOWN fleet.
+ * 4. a `pendingAction` in flight → the C2 round-trip seam owns the card until it settles;
+ * 5. `sources.runtime` unusable after normalization (`not-wired` / `missing` — the normalizer
+ *    guarantees a `wired` fact carries `observed`/`inferred` confidence, never `none`) → fail
+ *    closed: the projected `state: 'off'` below is a degraded DISPLAY fallback in this case, not
+ *    evidence of a stopped runtime — the same gate that disables the per-card controls;
+ * 6. session `state` other than `off` → the resident is already up (ok / idle / wedged / limited
+ *    are all live states) — a morning start targets the DOWN fleet (a WIRED stopped record —
+ *    `observed` or `inferred` — is exactly that fleet).
  * @param {Object[]} records FleetAgent records (or plain field bags in tests).
  * @returns {{eligible: Object[], excluded: Object[]}} `excluded` entries are
  * `{record, agentId, reason}` — the reason is always present and wire-derived.
@@ -39,14 +56,19 @@ export function partitionFleetStart(records) {
 
         const
             agentId = record.agentId ?? null,
+            runtime = normalizeFleetSources(record.sources).runtime,
             exclude = reason => excluded.push({agentId, reason, record});
 
         if (!agentId) {
             exclude('guest — no fleet definition to start')
+        } else if (record.participationStatus === 'operator_benched') {
+            exclude("benched — authoritative participation status 'operator_benched'")
         } else if (record.launchable === false) {
             exclude(`not launchable — no harness template for the '${record.family ?? 'unknown'}' family`)
         } else if (record.pendingAction) {
             exclude(`'${record.pendingAction}' round-trip already in flight`)
+        } else if (runtime.state !== 'wired') {
+            exclude(`runtime source '${runtime.state}' — no usable lifecycle evidence to start against`)
         } else if ((record.state ?? 'off') !== 'off') {
             exclude(`already up — session state '${record.state}'`)
         } else {

--- a/src/ai/fleet/fleetCockpitStatus.mjs
+++ b/src/ai/fleet/fleetCockpitStatus.mjs
@@ -106,9 +106,13 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                 avatarUrl  : publicAgent.metadata?.avatarUrl ?? githubAvatarUrl(publicAgent.githubUsername),
                 family     : publicAgent.family ?? null,
                 engineTag  : publicAgent.engineTag ?? null,
-                agent      : publicAgent,
+                // The AUTHORITATIVE swarm-participation fact, resolved Brain-side through the ONE
+                // identity join seam — hoisted so fleet-level control eligibility can exclude an
+                // operator-benched identity. Tri-state: null = no identity root / not stamped.
+                participationStatus: publicAgent.participationStatus ?? null,
+                agent              : publicAgent,
                 repoStatus,
-                lifecycle  : runtime
+                lifecycle          : runtime
                     ? {
                         source    : FLEET_COCKPIT_SOURCES.runtime,
                         state     : runtime.state ?? 'unknown',

--- a/test/playwright/unit/ai/services/fleet/resolveIdentityDisplay.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/resolveIdentityDisplay.spec.mjs
@@ -28,12 +28,16 @@ import {resolveIdentityDisplay} from '../../../../../../ai/services/fleet/resolv
 test.describe('ai/services/fleet/resolveIdentityDisplay — the fleet↔identity display join', () => {
     const agentNodes = IDENTITIES.filter(node => node.type === 'AgentIdentity' && node.properties?.accountType === 'agent');
 
-    test('resolves every named maintainer to its root family — unprefixed and @-prefixed inputs alike', () => {
+    test('resolves every named maintainer to its root family + authoritative participation fact — unprefixed and @-prefixed inputs alike', () => {
         agentNodes.forEach(node => {
             const login    = node.id.replace(/^@/, ''),
                   expected = {
                       family   : node.properties.family ?? null,
-                      engineTag: null
+                      engineTag: null,
+                      // flows VERBATIM from the root — the identity registry documents this field
+                      // as the authoritative participation fact (benched roots resolve benched),
+                      // so no value is pinned here: a bench/unbench PR must not break the seam
+                      participationStatus: node.properties.participationStatus ?? null
                   };
 
             expect(resolveIdentityDisplay(login)).toEqual(expected);
@@ -55,12 +59,12 @@ test.describe('ai/services/fleet/resolveIdentityDisplay — the fleet↔identity
     });
 
     test('an agent without an identity root resolves to null facts — unclassified/tagless, never guessed', () => {
-        expect(resolveIdentityDisplay('freshly-defined-fleet-agent')).toEqual({family: null, engineTag: null})
+        expect(resolveIdentityDisplay('freshly-defined-fleet-agent')).toEqual({family: null, engineTag: null, participationStatus: null})
     });
 
     test('non-string / absent input degrades to null facts, never throws', () => {
-        expect(resolveIdentityDisplay(null)).toEqual({family: null, engineTag: null});
-        expect(resolveIdentityDisplay(undefined)).toEqual({family: null, engineTag: null});
-        expect(resolveIdentityDisplay(42)).toEqual({family: null, engineTag: null})
+        expect(resolveIdentityDisplay(null)).toEqual({family: null, engineTag: null, participationStatus: null});
+        expect(resolveIdentityDisplay(undefined)).toEqual({family: null, engineTag: null, participationStatus: null});
+        expect(resolveIdentityDisplay(42)).toEqual({family: null, engineTag: null, participationStatus: null})
     });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -495,8 +495,9 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
 
     test('onStartFleet partitions from the wire: excluded members never flip pending, and the summary renders their reasons (#14612)', async () => {
         // The staged bring-up targets the WIRED DOWN fleet: an already-up member, an unlaunchable
-        // family, a guest row, an operator-BENCHED identity (the authoritative participation
-        // fact), and a runtime-unwired row are EXCLUDED-with-reason — no intent fires at them
+        // family, a guest row, KNOWN non-active participation statuses (benched AND temporarily
+        // unreachable — the authoritative fact), and a runtime-unwired row are EXCLUDED-with-reason
+        // — no intent fires at them
         // (their records take zero writes; excluded cards never join the pending cascade) — while
         // the eligible member drives its round-trip (no bridge → honest unauthorized). The chrome
         // summary slot receives the counts line + hover-reachable reasons.
@@ -508,13 +509,14 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
         };
 
         const
-            down     = mkRecord({agentId: 'vega',   state: 'off', sources: wiredSources()}),
-            up       = mkRecord({agentId: 'ada',    state: 'ok',  sources: wiredSources()}),
-            noLaunch = mkRecord({agentId: 'native', state: 'off', launchable: false, family: 'native-neo'}),
-            guest    = mkRecord({state: 'off'}),
-            benched  = mkRecord({agentId: 'gemini', state: 'off', sources: wiredSources(), participationStatus: 'operator_benched'}),
-            unwired  = mkRecord({agentId: 'silent', state: 'off'}),   // no sources → runtime normalizes not-wired
-            slot     = {
+            down        = mkRecord({agentId: 'vega',   state: 'off', sources: wiredSources()}),
+            up          = mkRecord({agentId: 'ada',    state: 'ok',  sources: wiredSources()}),
+            noLaunch    = mkRecord({agentId: 'native', state: 'off', launchable: false, family: 'native-neo'}),
+            guest       = mkRecord({state: 'off'}),
+            benched     = mkRecord({agentId: 'gemini', state: 'off', sources: wiredSources(), participationStatus: 'operator_benched'}),
+            unreachable = mkRecord({agentId: 'flaky',  state: 'off', sources: wiredSources(), participationStatus: 'temporarily_unreachable'}),
+            unwired     = mkRecord({agentId: 'silent', state: 'off'}),   // no sources → runtime normalizes not-wired
+            slot        = {
                 sets: [],
                 vdom: {},
                 set(values) { this.sets.push(values) },
@@ -524,7 +526,7 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
         const controller = Object.create(FleetCockpitController.prototype);
 
         controller.getReference = name => ({
-            'fleet-grid'         : {store: {items: [down, up, noLaunch, guest, benched, unwired]}},
+            'fleet-grid'         : {store: {items: [down, up, noLaunch, guest, benched, unreachable, unwired]}},
             'fleet-start-summary': slot
         })[name] ?? null;
         controller.refreshRosterOnSettle = async () => {};
@@ -534,25 +536,28 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
         // eligible: only the wired down member — it took the honest unauthorized round-trip
         expect(down.writes.some(write => write.controlReason?.kind === 'unauthorized')).toBe(true);
         // excluded members took ZERO writes — never silently skipped, never falsely pending;
-        // the benched + unwired rows are the authority witnesses: zero bridge writes
+        // the benched + unreachable + unwired rows are the authority witnesses: zero bridge
+        // writes for EVERY known non-active participation status and unusable runtime source
         expect(up.writes).toHaveLength(0);
         expect(noLaunch.writes).toHaveLength(0);
         expect(guest.writes).toHaveLength(0);
         expect(benched.writes).toHaveLength(0);
+        expect(unreachable.writes).toHaveLength(0);
         expect(unwired.writes).toHaveLength(0);
 
         expect(summary.started).toBe(0);
         expect(summary.rejected).toHaveLength(1);
-        expect(summary.excluded.map(entry => entry.agentId)).toEqual(['ada', 'native', null, 'gemini', 'silent']);
+        expect(summary.excluded.map(entry => entry.agentId)).toEqual(['ada', 'native', null, 'gemini', 'flaky', 'silent']);
 
         // the chrome slot rendered: cleared at action start, then the outcome line + reasons title
         expect(slot.sets[0]).toEqual({hidden: true, html: ''});
         expect(slot.sets[1].hidden).toBe(false);
         expect(slot.sets[1].html).toContain('rejected');
-        expect(slot.sets[1].html).toContain('5 excluded');
+        expect(slot.sets[1].html).toContain('6 excluded');
         expect(slot.vdom.title).toContain('native: not launchable');
         expect(slot.vdom.title).toContain("ada: already up — session state 'ok'");
-        expect(slot.vdom.title).toContain("gemini: benched — authoritative participation status 'operator_benched'");
+        expect(slot.vdom.title).toContain("gemini: not active — authoritative participation status 'operator_benched'");
+        expect(slot.vdom.title).toContain("flaky: not active — authoritative participation status 'temporarily_unreachable'");
         expect(slot.vdom.title).toContain("silent: runtime source 'not-wired'")
     });
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -247,10 +247,12 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
 
         expect(mapped).toEqual({
             agentId    : 'neo-gpt',
+            authMode   : null,   // tri-state launch facts: absent on the row → honest null, never guessed
             avatarUrl  : 'https://github.com/neo-gpt.png?size=80',
             displayName: 'Neo GPT',
             engineTag  : 'GPT-5.6 Sol',
             family     : 'gpt',
+            launchable : null,
             sources    : liveSources(),
             state      : 'ok'
         });
@@ -329,10 +331,12 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         // known resident → runtime status reconciled onto ITS record (the store re-renders just that card)
         expect(writes).toEqual([{
             agentId    : 'vega',
+            authMode   : null,
             avatarUrl  : null,
             displayName: null,
             engineTag  : null,
             family     : 'claude',
+            launchable : null,
             sources    : liveSources(),
             state      : 'ok'
         }]);
@@ -475,6 +479,61 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
 
         expect(vega.writes.some(write => write.controlReason?.kind === 'unauthorized')).toBe(true);
         expect(ada.writes.some(write => write.controlReason?.kind === 'unauthorized')).toBe(true)
+    });
+
+    test('onStartFleet partitions from the wire: excluded members never flip pending, and the summary renders their reasons (#14612)', async () => {
+        // The staged bring-up targets the DOWN fleet: an already-up member, an unlaunchable
+        // family, and a guest row are EXCLUDED-with-reason — no intent fires at them (their
+        // records take zero writes; excluded cards never join the pending cascade) — while the
+        // eligible member drives its round-trip (no bridge → honest unauthorized). The chrome
+        // summary slot receives the counts line + hover-reachable reasons.
+        delete globalThis.AgentOS?.fleet;
+
+        const mkRecord = fields => {
+            const writes = [];
+            return {...fields, writes, set(values) { writes.push(values) }}
+        };
+
+        const
+            down     = mkRecord({agentId: 'vega',   state: 'off'}),
+            up       = mkRecord({agentId: 'ada',    state: 'ok'}),
+            noLaunch = mkRecord({agentId: 'native', state: 'off', launchable: false, family: 'native-neo'}),
+            guest    = mkRecord({state: 'off'}),
+            slot     = {
+                sets: [],
+                vdom: {},
+                set(values) { this.sets.push(values) },
+                update() {}
+            };
+
+        const controller = Object.create(FleetCockpitController.prototype);
+
+        controller.getReference = name => ({
+            'fleet-grid'         : {store: {items: [down, up, noLaunch, guest]}},
+            'fleet-start-summary': slot
+        })[name] ?? null;
+        controller.refreshRosterOnSettle = async () => {};
+
+        const summary = await controller.onStartFleet();
+
+        // eligible: only the down member — it took the honest unauthorized round-trip
+        expect(down.writes.some(write => write.controlReason?.kind === 'unauthorized')).toBe(true);
+        // excluded members took ZERO writes — never silently skipped, never falsely pending
+        expect(up.writes).toHaveLength(0);
+        expect(noLaunch.writes).toHaveLength(0);
+        expect(guest.writes).toHaveLength(0);
+
+        expect(summary.started).toBe(0);
+        expect(summary.rejected).toHaveLength(1);
+        expect(summary.excluded.map(entry => entry.agentId)).toEqual(['ada', 'native', null]);
+
+        // the chrome slot rendered: cleared at action start, then the outcome line + reasons title
+        expect(slot.sets[0]).toEqual({hidden: true, html: ''});
+        expect(slot.sets[1].hidden).toBe(false);
+        expect(slot.sets[1].html).toContain('rejected');
+        expect(slot.sets[1].html).toContain('3 excluded');
+        expect(slot.vdom.title).toContain('native: not launchable');
+        expect(slot.vdom.title).toContain("ada: already up — session state 'ok'")
     });
 
     test('onAgentLifecycleIntent resolves the firing card + drives the C2 adapter — no bridge → fail-closed onto the card record, never optimistic', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -22,6 +22,15 @@ import Instance        from '../../../../../../../src/manager/Instance.mjs';
 
 const seedPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../../../apps/agentos/resources/data/fleetRoster.json');
 
+// A usable three-source collection: the runtime axis is WIRED. The eligibility partition fails a
+// fleet start closed without it (projected 'off' over unusable provenance is display fallback,
+// never a stopped runtime), so every fixture that models a startable member carries this shape.
+const wiredSources = () => ({
+    roster    : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
+    repoStatus: {source: 'fleet:fleetStatus',   state: 'wired', confidence: 'observed'},
+    runtime   : {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}
+});
+
 /**
  * Covers the fail-closed matrix for `FleetCockpit.loadActivity()` — the app-side consumption of the
  * read-observe `fleetActivity` bridge verb.
@@ -253,8 +262,10 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             engineTag  : 'GPT-5.6 Sol',
             family     : 'gpt',
             launchable : null,
-            sources    : liveSources(),
-            state      : 'ok'
+            // the authoritative participation fact: absent on the row → honest null, never guessed
+            participationStatus: null,
+            sources            : liveSources(),
+            state              : 'ok'
         });
 
         // laneLine is OMITTED, never nulled — a roster merge must not wipe what the activity producer writes
@@ -330,15 +341,16 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
 
         // known resident → runtime status reconciled onto ITS record (the store re-renders just that card)
         expect(writes).toEqual([{
-            agentId    : 'vega',
-            authMode   : null,
-            avatarUrl  : null,
-            displayName: null,
-            engineTag  : null,
-            family     : 'claude',
-            launchable : null,
-            sources    : liveSources(),
-            state      : 'ok'
+            agentId            : 'vega',
+            authMode           : null,
+            avatarUrl          : null,
+            displayName        : null,
+            engineTag          : null,
+            family             : 'claude',
+            launchable         : null,
+            participationStatus: null,
+            sources            : liveSources(),
+            state              : 'ok'
         }]);
 
         // a resident ABSENT from the authoritative snapshot is removed — define → remove → no ghost card
@@ -463,7 +475,7 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
 
         const mkCard = agentId => {
             const writes = [],
-                  record = {agentId, writes, set(values) { writes.push(values) }};
+                  record = {agentId, sources: wiredSources(), state: 'off', writes, set(values) { writes.push(values) }};
             return {ntype: 'fm-agent-card', record, writes}
         };
 
@@ -482,10 +494,11 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
     });
 
     test('onStartFleet partitions from the wire: excluded members never flip pending, and the summary renders their reasons (#14612)', async () => {
-        // The staged bring-up targets the DOWN fleet: an already-up member, an unlaunchable
-        // family, and a guest row are EXCLUDED-with-reason — no intent fires at them (their
-        // records take zero writes; excluded cards never join the pending cascade) — while the
-        // eligible member drives its round-trip (no bridge → honest unauthorized). The chrome
+        // The staged bring-up targets the WIRED DOWN fleet: an already-up member, an unlaunchable
+        // family, a guest row, an operator-BENCHED identity (the authoritative participation
+        // fact), and a runtime-unwired row are EXCLUDED-with-reason — no intent fires at them
+        // (their records take zero writes; excluded cards never join the pending cascade) — while
+        // the eligible member drives its round-trip (no bridge → honest unauthorized). The chrome
         // summary slot receives the counts line + hover-reachable reasons.
         delete globalThis.AgentOS?.fleet;
 
@@ -495,10 +508,12 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
         };
 
         const
-            down     = mkRecord({agentId: 'vega',   state: 'off'}),
-            up       = mkRecord({agentId: 'ada',    state: 'ok'}),
+            down     = mkRecord({agentId: 'vega',   state: 'off', sources: wiredSources()}),
+            up       = mkRecord({agentId: 'ada',    state: 'ok',  sources: wiredSources()}),
             noLaunch = mkRecord({agentId: 'native', state: 'off', launchable: false, family: 'native-neo'}),
             guest    = mkRecord({state: 'off'}),
+            benched  = mkRecord({agentId: 'gemini', state: 'off', sources: wiredSources(), participationStatus: 'operator_benched'}),
+            unwired  = mkRecord({agentId: 'silent', state: 'off'}),   // no sources → runtime normalizes not-wired
             slot     = {
                 sets: [],
                 vdom: {},
@@ -509,31 +524,36 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
         const controller = Object.create(FleetCockpitController.prototype);
 
         controller.getReference = name => ({
-            'fleet-grid'         : {store: {items: [down, up, noLaunch, guest]}},
+            'fleet-grid'         : {store: {items: [down, up, noLaunch, guest, benched, unwired]}},
             'fleet-start-summary': slot
         })[name] ?? null;
         controller.refreshRosterOnSettle = async () => {};
 
         const summary = await controller.onStartFleet();
 
-        // eligible: only the down member — it took the honest unauthorized round-trip
+        // eligible: only the wired down member — it took the honest unauthorized round-trip
         expect(down.writes.some(write => write.controlReason?.kind === 'unauthorized')).toBe(true);
-        // excluded members took ZERO writes — never silently skipped, never falsely pending
+        // excluded members took ZERO writes — never silently skipped, never falsely pending;
+        // the benched + unwired rows are the authority witnesses: zero bridge writes
         expect(up.writes).toHaveLength(0);
         expect(noLaunch.writes).toHaveLength(0);
         expect(guest.writes).toHaveLength(0);
+        expect(benched.writes).toHaveLength(0);
+        expect(unwired.writes).toHaveLength(0);
 
         expect(summary.started).toBe(0);
         expect(summary.rejected).toHaveLength(1);
-        expect(summary.excluded.map(entry => entry.agentId)).toEqual(['ada', 'native', null]);
+        expect(summary.excluded.map(entry => entry.agentId)).toEqual(['ada', 'native', null, 'gemini', 'silent']);
 
         // the chrome slot rendered: cleared at action start, then the outcome line + reasons title
         expect(slot.sets[0]).toEqual({hidden: true, html: ''});
         expect(slot.sets[1].hidden).toBe(false);
         expect(slot.sets[1].html).toContain('rejected');
-        expect(slot.sets[1].html).toContain('3 excluded');
+        expect(slot.sets[1].html).toContain('5 excluded');
         expect(slot.vdom.title).toContain('native: not launchable');
-        expect(slot.vdom.title).toContain("ada: already up — session state 'ok'")
+        expect(slot.vdom.title).toContain("ada: already up — session state 'ok'");
+        expect(slot.vdom.title).toContain("gemini: benched — authoritative participation status 'operator_benched'");
+        expect(slot.vdom.title).toContain("silent: runtime source 'not-wired'")
     });
 
     test('onAgentLifecycleIntent resolves the firing card + drives the C2 adapter — no bridge → fail-closed onto the card record, never optimistic', () => {
@@ -646,9 +666,9 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
         const calls      = [],
               controller = makeController(calls),
               cards      = [
-                  {ntype: 'fm-agent-card', record: {agentId: 'vega'}},
-                  {ntype: 'fm-agent-card', record: {agentId: 'ada'}},
-                  {ntype: 'fm-agent-card', record: {agentId: 'grace'}}
+                  {ntype: 'fm-agent-card', record: {agentId: 'vega',  sources: wiredSources(), state: 'off'}},
+                  {ntype: 'fm-agent-card', record: {agentId: 'ada',   sources: wiredSources(), state: 'off'}},
+                  {ntype: 'fm-agent-card', record: {agentId: 'grace', sources: wiredSources(), state: 'off'}}
               ];
 
         controller.getReference = name => name === 'fleet-cards' ? {items: cards} : null;

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetStartPlan.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetStartPlan.spec.mjs
@@ -22,13 +22,21 @@ import {partitionFleetStart, renderFleetStartSummary, summarizeFleetStart} from 
  * bring-up: wire-derived eligibility partition (excluded-with-reason, never silently
  * skipped) and the honest outcome summary (started / rejected-with-reasons / excluded).
  */
+
+/** A usable three-source collection: the runtime axis is WIRED with real confidence. */
+const wiredRuntime = (confidence = 'observed') => ({
+    roster    : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
+    repoStatus: {source: 'fleet:fleetStatus',   state: 'wired', confidence: 'observed'},
+    runtime   : {source: 'fleet:runtimeStatus', state: 'wired', confidence}
+});
+
 test.describe('fleetStartPlan — the staged morning bring-up (pure half)', () => {
 
     test('partition: every exclusion is wire-derived and carries its reason; the down fleet is what starts', () => {
         const records = [
-            {agentId: 'vega',   state: 'off'},                                          // eligible — down
-            {agentId: 'ada',    state: 'ok'},                                           // up
-            {agentId: 'grace',  state: 'idle'},                                         // up (idle is alive)
+            {agentId: 'vega',   state: 'off',  sources: wiredRuntime()},                // eligible — wired down
+            {agentId: 'ada',    state: 'ok',   sources: wiredRuntime()},                // up
+            {agentId: 'grace',  state: 'idle', sources: wiredRuntime()},                // up (idle is alive)
             {agentId: 'native', state: 'off', launchable: false, family: 'native-neo'}, // no template
             {agentId: 'euclid', state: 'off', pendingAction: 'restart'},                // verb in flight
             {state: 'off'}                                                              // guest — no definition
@@ -51,20 +59,73 @@ test.describe('fleetStartPlan — the staged morning bring-up (pure half)', () =
 
     test('tri-state honesty: launchable null (not read back) stays ELIGIBLE — the bridge owns the real refusal', () => {
         const {eligible, excluded} = partitionFleetStart([
-            {agentId: 'vega', state: 'off', launchable: null},
-            {agentId: 'ada',  state: 'off'}   // field absent entirely
+            {agentId: 'vega', state: 'off', launchable: null, sources: wiredRuntime()},
+            {agentId: 'ada',  state: 'off', sources: wiredRuntime()}   // launchable absent entirely
         ]);
 
         expect(eligible).toHaveLength(2);
         expect(excluded).toHaveLength(0)
     });
 
+    test("authority rule: an 'operator_benched' identity NEVER starts — the recorded operator decision beats every runtime fact", () => {
+        const {eligible, excluded} = partitionFleetStart([
+            // the live-registry shape: defined, launchable, wired, down — and benched
+            {agentId: 'gemini', state: 'off', launchable: true, sources: wiredRuntime(), participationStatus: 'operator_benched'},
+            // active + null (no identity root) + temporarily_unreachable all pass this rule:
+            // unreachable is an A2A-liveness fact, not a start prohibition
+            {agentId: 'vega',  state: 'off', sources: wiredRuntime(), participationStatus: 'active'},
+            {agentId: 'guest-def', state: 'off', sources: wiredRuntime(), participationStatus: null},
+            {agentId: 'ada',   state: 'off', sources: wiredRuntime(), participationStatus: 'temporarily_unreachable'}
+        ]);
+
+        expect(eligible.map(record => record.agentId)).toEqual(['vega', 'guest-def', 'ada']);
+        expect(excluded).toHaveLength(1);
+        expect(excluded[0].agentId).toBe('gemini');
+        expect(excluded[0].reason).toContain('operator_benched')
+    });
+
+    test("authority rule: unusable runtime provenance fails a start closed — projected 'off' is display fallback, not a stopped runtime", () => {
+        const partitionOne = record => partitionFleetStart([record]);
+
+        // the direct probe shape: not-wired/none must never be eligible
+        let {eligible, excluded} = partitionOne({
+            agentId: 'ghost', state: 'off',
+            sources: {...wiredRuntime(), runtime: {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}}
+        });
+        expect(eligible).toHaveLength(0);
+        expect(excluded[0].reason).toContain("runtime source 'not-wired'");
+
+        // missing runtime axis → fail closed with the missing state visible
+        ({eligible, excluded} = partitionOne({
+            agentId: 'gone', state: 'off',
+            sources: {...wiredRuntime(), runtime: {source: 'fleet:runtimeStatus', state: 'missing'}}
+        }));
+        expect(eligible).toHaveLength(0);
+        expect(excluded[0].reason).toContain("runtime source 'missing'");
+
+        // no sources at all → the normalizer fails the whole collection closed
+        ({eligible, excluded} = partitionOne({agentId: 'bare', state: 'off'}));
+        expect(eligible).toHaveLength(0);
+        expect(excluded[0].reason).toContain('no usable lifecycle evidence');
+
+        // a malformed fact (wrong producer literal) normalizes closed — cross-axis facts are not evidence
+        ({eligible, excluded} = partitionOne({
+            agentId: 'crossed', state: 'off',
+            sources: {...wiredRuntime(), runtime: {source: 'fleet:fleetStatus', state: 'wired', confidence: 'observed'}}
+        }));
+        expect(eligible).toHaveLength(0);
+
+        // the preserve side: genuinely WIRED stopped records are the morning start's exact target
+        expect(partitionOne({agentId: 'observed-down', state: 'off', sources: wiredRuntime('observed')}).eligible).toHaveLength(1);
+        expect(partitionOne({agentId: 'inferred-down', state: 'off', sources: wiredRuntime('inferred')}).eligible).toHaveLength(1)
+    });
+
     test('mixed settle/reject: the summary counts honestly and keeps every terminal kind visible', () => {
         const partition = partitionFleetStart([
-            {agentId: 'vega',   state: 'off'},
-            {agentId: 'ada',    state: 'off'},
-            {agentId: 'euclid', state: 'off'},
-            {agentId: 'up',     state: 'ok'}
+            {agentId: 'vega',   state: 'off', sources: wiredRuntime()},
+            {agentId: 'ada',    state: 'off', sources: wiredRuntime()},
+            {agentId: 'euclid', state: 'off', sources: wiredRuntime()},
+            {agentId: 'up',     state: 'ok',  sources: wiredRuntime()}
         ]);
 
         // index-aligned per-eligible results in the C2 adapter's vocabulary
@@ -87,8 +148,8 @@ test.describe('fleetStartPlan — the staged morning bring-up (pure half)', () =
 
     test('all-reject: zero started renders honestly — partial success is the normal case, total failure is too', () => {
         const partition = partitionFleetStart([
-            {agentId: 'vega', state: 'off'},
-            {agentId: 'ada',  state: 'off'}
+            {agentId: 'vega', state: 'off', sources: wiredRuntime()},
+            {agentId: 'ada',  state: 'off', sources: wiredRuntime()}
         ]);
 
         const summary = summarizeFleetStart(partition, [

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetStartPlan.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetStartPlan.spec.mjs
@@ -67,21 +67,28 @@ test.describe('fleetStartPlan — the staged morning bring-up (pure half)', () =
         expect(excluded).toHaveLength(0)
     });
 
-    test("authority rule: an 'operator_benched' identity NEVER starts — the recorded operator decision beats every runtime fact", () => {
+    test('authority rule: every KNOWN non-active participationStatus is excluded — the wake/heartbeat hard-gate reading; null stays eligible (open set)', () => {
         const {eligible, excluded} = partitionFleetStart([
             // the live-registry shape: defined, launchable, wired, down — and benched
             {agentId: 'gemini', state: 'off', launchable: true, sources: wiredRuntime(), participationStatus: 'operator_benched'},
-            // active + null (no identity root) + temporarily_unreachable all pass this rule:
-            // unreachable is an A2A-liveness fact, not a start prohibition
-            {agentId: 'vega',  state: 'off', sources: wiredRuntime(), participationStatus: 'active'},
+            // active passes; null (no identity root) passes — unknown/custom residents are the
+            // open-set case, an absent root is not a recorded prohibition
+            {agentId: 'vega',      state: 'off', sources: wiredRuntime(), participationStatus: 'active'},
             {agentId: 'guest-def', state: 'off', sources: wiredRuntime(), participationStatus: null},
-            {agentId: 'ada',   state: 'off', sources: wiredRuntime(), participationStatus: 'temporarily_unreachable'}
+            // temporarily_unreachable is a KNOWN non-active status — the wake-subscription
+            // liveness gate and heartbeat target discovery both exclude it, and lifecycle
+            // fan-out follows the same authority
+            {agentId: 'ada', state: 'off', sources: wiredRuntime(), participationStatus: 'temporarily_unreachable'},
+            // a NOVEL non-null status fails closed too: any recorded non-active value is an
+            // exclusion until eligibility is deliberately widened
+            {agentId: 'future', state: 'off', sources: wiredRuntime(), participationStatus: 'hibernating'}
         ]);
 
-        expect(eligible.map(record => record.agentId)).toEqual(['vega', 'guest-def', 'ada']);
-        expect(excluded).toHaveLength(1);
-        expect(excluded[0].agentId).toBe('gemini');
-        expect(excluded[0].reason).toContain('operator_benched')
+        expect(eligible.map(record => record.agentId)).toEqual(['vega', 'guest-def']);
+        expect(excluded.map(entry => entry.agentId)).toEqual(['gemini', 'ada', 'future']);
+        expect(excluded[0].reason).toContain('operator_benched');
+        expect(excluded[1].reason).toContain('temporarily_unreachable');
+        expect(excluded[2].reason).toContain('hibernating')
     });
 
     test("authority rule: unusable runtime provenance fails a start closed — projected 'off' is display fallback, not a stopped runtime", () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetStartPlan.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetStartPlan.spec.mjs
@@ -1,0 +1,123 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'FleetStartPlanTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+
+import {partitionFleetStart, renderFleetStartSummary, summarizeFleetStart} from '../../../../../../../apps/agentos/view/fleet/fleetStartPlan.mjs';
+
+/**
+ * @summary Tests for the morning-start plan helpers — the pure half of the fleet-level
+ * bring-up: wire-derived eligibility partition (excluded-with-reason, never silently
+ * skipped) and the honest outcome summary (started / rejected-with-reasons / excluded).
+ */
+test.describe('fleetStartPlan — the staged morning bring-up (pure half)', () => {
+
+    test('partition: every exclusion is wire-derived and carries its reason; the down fleet is what starts', () => {
+        const records = [
+            {agentId: 'vega',   state: 'off'},                                          // eligible — down
+            {agentId: 'ada',    state: 'ok'},                                           // up
+            {agentId: 'grace',  state: 'idle'},                                         // up (idle is alive)
+            {agentId: 'native', state: 'off', launchable: false, family: 'native-neo'}, // no template
+            {agentId: 'euclid', state: 'off', pendingAction: 'restart'},                // verb in flight
+            {state: 'off'}                                                              // guest — no definition
+        ];
+
+        const {eligible, excluded} = partitionFleetStart(records);
+
+        expect(eligible.map(record => record.agentId)).toEqual(['vega']);
+        expect(excluded.map(({agentId, reason}) => ({agentId, hasReason: reason.length > 0}))).toEqual([
+            {agentId: 'ada',    hasReason: true},
+            {agentId: 'grace',  hasReason: true},
+            {agentId: 'native', hasReason: true},
+            {agentId: 'euclid', hasReason: true},
+            {agentId: null,     hasReason: true}
+        ]);
+        expect(excluded.find(entry => entry.agentId === 'native').reason).toContain('native-neo');
+        expect(excluded.find(entry => entry.agentId === 'euclid').reason).toContain('restart');
+        expect(excluded.find(entry => entry.agentId === null).reason).toContain('guest')
+    });
+
+    test('tri-state honesty: launchable null (not read back) stays ELIGIBLE — the bridge owns the real refusal', () => {
+        const {eligible, excluded} = partitionFleetStart([
+            {agentId: 'vega', state: 'off', launchable: null},
+            {agentId: 'ada',  state: 'off'}   // field absent entirely
+        ]);
+
+        expect(eligible).toHaveLength(2);
+        expect(excluded).toHaveLength(0)
+    });
+
+    test('mixed settle/reject: the summary counts honestly and keeps every terminal kind visible', () => {
+        const partition = partitionFleetStart([
+            {agentId: 'vega',   state: 'off'},
+            {agentId: 'ada',    state: 'off'},
+            {agentId: 'euclid', state: 'off'},
+            {agentId: 'up',     state: 'ok'}
+        ]);
+
+        // index-aligned per-eligible results in the C2 adapter's vocabulary
+        const summary = summarizeFleetStart(partition, [
+            {ok: true,  status: 'settled'},
+            {ok: false, status: 'rejected', controlReason: {reason: 'missing credential'}},
+            {ok: false, status: 'timeout',  controlReason: {reason: 'start timed out after 30000ms'}}
+        ]);
+
+        expect(summary.started).toBe(1);
+        expect(summary.attempted).toBe(3);
+        expect(summary.total).toBe(4);
+        expect(summary.rejected).toEqual([
+            {agentId: 'ada',    reason: 'missing credential'},
+            // a timeout is an UNKNOWN outcome — the kind stays visible, never folded into a plain reject
+            {agentId: 'euclid', reason: 'timeout: start timed out after 30000ms'}
+        ]);
+        expect(summary.excluded).toEqual([{agentId: 'up', reason: "already up — session state 'ok'"}])
+    });
+
+    test('all-reject: zero started renders honestly — partial success is the normal case, total failure is too', () => {
+        const partition = partitionFleetStart([
+            {agentId: 'vega', state: 'off'},
+            {agentId: 'ada',  state: 'off'}
+        ]);
+
+        const summary = summarizeFleetStart(partition, [
+            {ok: false, status: 'unauthorized', controlReason: {reason: 'Fleet Registry bridge unavailable'}},
+            {ok: false, status: 'unauthorized', controlReason: {reason: 'Fleet Registry bridge unavailable'}}
+        ]);
+
+        expect(summary.started).toBe(0);
+        expect(summary.rejected).toHaveLength(2);
+        expect(summary.rejected[0].reason).toContain('unauthorized:')
+    });
+
+    test('renderFleetStartSummary: the at-a-glance counts line + every reason reachable in the detail', () => {
+        const {text, detail} = renderFleetStartSummary({
+            attempted: 3,
+            excluded : [{agentId: null, reason: 'guest — no fleet definition to start'}],
+            rejected : [{agentId: 'ada', reason: 'missing credential'}],
+            started  : 2,
+            total    : 4
+        });
+
+        expect(text).toBe('2 started · 1 rejected · 1 excluded');
+        expect(detail).toContain('ada: missing credential');
+        expect(detail).toContain('(guest): guest — no fleet definition to start');
+
+        // the quiet morning: everything started, nothing to explain
+        const clean = renderFleetStartSummary({attempted: 2, excluded: [], rejected: [], started: 2, total: 2});
+
+        expect(clean.text).toBe('2 started');
+        expect(clean.detail).toBe('')
+    });
+});


### PR DESCRIPTION
Resolves #14612

The SSOT chrome's "▶ Start morning fleet" becomes the STAGED bring-up the ticket demands: a wire-derived eligibility partition (excluded-with-reason, never silently skipped), the per-card pending cascade over exactly the eligible members (excluded cards never flip pending — no fleet-wide spinner to lie N ways at once), and an honest outcome summary the operator can trust at a glance. First leaf of the #14560 OPERATE spine (the operator-directed render/operate split with @neo-opus-vega).

- **`fleetStartPlan.mjs` (new, pure)** — `partitionFleetStart(records)`: SIX rules, each reading a WIRE fact already on the record, first match wins — no `agentId` (guest, nothing to start) · **any KNOWN non-active `participationStatus` (review cycles 1+2: the identity roots' AUTHORITATIVE participation fact — the wake-subscription liveness gate and heartbeat target discovery both read every known non-active status as a hard exclusion, and lifecycle fan-out follows the same authority; non-null ≠ `'active'` excludes, including `operator_benched` AND `temporarily_unreachable` AND any novel recorded status; `null` = no identity root stays ELIGIBLE — open-set honesty for forks/custom residents)** · `launchable === false` (the launch seam says no harness template; tri-state honesty: `null` = not-read-back stays ELIGIBLE, the bridge's own refusal is the truthful outcome) · a `pendingAction` in flight (the C2 seam owns the card until settle) · **`sources.runtime` unusable after `normalizeFleetSources` (review cycle 1, RA2: `not-wired`/`missing` fail closed — the SAME authority helper the per-card controls disable on; the normalizer guarantees a `wired` fact carries `observed`/`inferred` confidence, never `none`, so projected `state: 'off'` over unusable provenance is display fallback, not a stopped runtime)** · session `state !== 'off'` (ok/idle/wedged/limited are all live — a morning start targets the WIRED DOWN fleet). `summarizeFleetStart` folds the per-record C2 results into started / rejected-with-reasons / excluded-with-reasons, keeping every terminal kind visible (a `timeout` is an UNKNOWN outcome, never folded into a plain reject). `renderFleetStartSummary` builds the counts line + the per-member reason detail.
- **`participationStatus` threading (review cycle 1, RA1)** — the authority fact now rides the full chain: `resolveIdentityDisplay` returns it verbatim from the identity root (null when no root — unknown, never assumed active) → the `fleetRoster` assembler's resolver spread → the `fleetCockpitStatus` Body-pure row hoist (tri-state, derives nothing) → `mapRosterRow` → a typeless `FleetAgent` field. The Body/Brain seam holds: the pure map hoists what the Brain-side resolver stamped, exactly like `family`/`launchable`.
- **`FleetCockpitController.onStartFleet` (recomposed)** — reads the roster STORE (the full fleet truth: a folded idle card is still a member; rendered-cards fallback preserved), partitions, cascades `start` over the eligible through the landed per-verb C2 adapter (each record drives its own honest round-trip — the landed #14611 machine at roster scale), renders the summary into the chrome, and keeps the settle semantics: roster re-polled ONCE when anything really started, never on all-reject (the honest reasons must stand). Ordering/backoff stays SERVICE-side per the seam discipline — the cockpit renders progression and outcome only.
- **`FleetAgent` + `mapRosterRow`** — the launch-seam truths (`launchable`, `authMode`) now ride the record tri-state (the named #14991 consumer moment: eligibility reads the wire, never a cockpit guess). Both fields typeless by design so `null` (not read back) survives without coercion.
- **Chrome** — a `fleet-start-summary` slot beside the button: the counts line as text, per-member reasons as the hover title; hidden until a start ran, cleared at each new action. The health bar remains the live progression surface — no separate progress modal.

Evidence: L1 (pure partition/summary fixtures + the controller composition against the real C2 adapter's fail-closed vocabulary) → the NL-verifiable staged bring-up against the real seam rides the walkthrough leaf (#14646, mine, sequenced last) where the tour records the finished surfaces. Residual: none on this leaf's unit ACs; the NL live receipt is named in Post-Merge Validation.

## Deltas from ticket

- ~~"benched-as-a-distinct-wire-flag does not exist yet"~~ — **this cycle-0 delta claim was WRONG and is retracted** (review cycle 1 caught it): `ai/graph/identityRoots.mjs` documents `participationStatus` as the authoritative participation fact and encodes a live `operator_benched` identity. The fact was being dropped at the resolver boundary, not absent from the substrate. Cycle 1 threads it end-to-end and the partition now excludes benched members with their reason — the ticket's benched AC is met against the REAL authority, no future flag needed.
- The summary renders in the chrome slot (text + hover-reachable reasons) rather than a dedicated panel — the ticket's "reachable from the summary" contract with the smallest honest surface; the health bar (#14599) stays the live progress renderer as specified.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/fleetStartPlan.spec.mjs test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs --workers=1` at the cycle-1 head → **32 passed** — the original matrix (tri-state null-launchable eligibility · mixed settle/reject with kind-visible timeouts · all-reject · summary rendering · the controller exclusion witness) **plus the review-cycle authority witnesses**: the participation rule (a defined/launchable/wired/off record with ANY known non-active `participationStatus` — `operator_benched`, `temporarily_unreachable`, and a novel `hibernating` — is EXCLUDED with the status visible in its reason, while `active` and `null` pass; the controller witness proves benched AND unreachable records take ZERO bridge writes with reasons in the chrome) and the runtime-usability matrix (`not-wired`+`none` — the probe shape — excluded · `missing` excluded · absent sources excluded · cross-axis producer literal excluded · wired `stopped/observed` AND `stopped/inferred` remain ELIGIBLE). The controller witness now proves an operator-benched record and a runtime-unwired record take ZERO writes with reasons rendered in the chrome.
- Focused batch across every touched surface (the two above + `resolveIdentityDisplay.spec` + `fleetCockpitStatus.spec` + `FleetControlBridge.spec`) → **67 passed** (the resolver spec asserts `participationStatus` flows VERBATIM from each root — no value pinned, so a bench/unbench PR never breaks the seam).
- `npm run test-unit -- test/playwright/unit/apps/ --workers=1` → **247 passed, 1 failed** — the KNOWN pre-existing `fleetGrid.spec` full-dir ordering flake (reproduced at base with the cycle-0 diff stashed; standalone 10/10 at this head).
- `npm run test-unit -- test/playwright/unit/ai/services/ test/playwright/unit/ai/scripts/ test/playwright/unit/ai/graph/ --workers=1` → **3236 passed, 19 failed** — all 19 in memory-core/lifecycle/lint specs DISJOINT from this diff (zero file overlap; every fleet spec green). The class is local-environment: the same specs fail identically on a clean dev checkout at `aa6b9cf02` (specimen: `QueryReRanker.spec` + `checkSunsetted.spec` → 11 failed on clean dev, matching counts). `unit/ai/daemons/` additionally dies at COLLECTION on both this branch and clean dev (`Orchestrator.mjs` singleton constructs at import and `AiConfig.orchestrator.dataDir` is absent from local config overlays) — hosted CI generates its own config and is the canonical gate; CI green at this head.
- Existing `onStartFleet` contracts hold unchanged (fan-out fail-closed per card, EXACTLY-ONCE re-poll, the #14978 composition-root witness).
- Pre-commit gates green (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment).

## Post-Merge Validation

- [ ] NL-verifiable staged bring-up against the real seam with a mixed-outcome fleet (rides #14646, the walkthrough leaf)
- [ ] `fm-fleet-start-summary` styling lands with the cockpit theme pass (cls-only today, zero CSS-in-JS)

## Commits

- 8903c7196 — the pure plan module + controller recomposition + record fields + chrome slot + the fixture matrix.
- 67bab63a1 — review cycle 1: `participationStatus` threaded resolver → DTO → record (RA1) + runtime-usability eligibility gate via the shared `normalizeFleetSources` authority (RA2) + the benched/runtime witnesses; the cycle-0 "benched flag does not exist" delta claim retracted in this body.
- 9d7723a34 — review cycle 2: the participation predicate generalized to EVERY known non-active status (non-null ≠ `'active'`), matching the wake-subscription hard gate and heartbeat target-discovery authority — `temporarily_unreachable` flipped from eligible to excluded (my cycle-1 "A2A-liveness only" reading had no authority behind it), novel statuses fail closed, `null` stays open-set eligible; plan + controller witnesses updated (unreachable record: zero writes, visible reason).

Related: parent #14560 (OPERATE spine, operator-directed split) · composes #14611 (per-verb machine, closed) · consumes #14991 (`launchable`/`authMode` roster stamps — the named consumer moment) · seam authority: Lane C bring-up semantics stay service-side · next spine leaves: #14641 → #14620 → #14646.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 9cf9cce9-23bf-4211-ab0d-bab51d5e1d14.

