### PR TITLE
feat(agentos): restore Demo B topology perspectives (#15003)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -298,7 +298,7 @@ class DemoBWorkspace extends Container {
      * Loads a stored perspective. Window-scope records commit the restored primary document;
      * topology-scope records go through the changed-topology reconciler and expose its remainder.
      * @param {String} name
-     * @returns {{loaded: Boolean, errors: String[], report?: Object}}
+     * @returns {{loaded: Boolean, errors: String[], report: (Object|undefined)}}
      */
     loadPerspectiveByName(name) {
         let me         = this,

--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -5,6 +5,7 @@ import DockLayoutAdapter                  from '../../../../../src/dashboard/Doc
 import DockMotionSignal                   from '../../../../../src/dashboard/DockMotionSignal.mjs';
 import DockPerspectiveStore               from '../../../../../src/dashboard/DockPerspectiveStore.mjs';
 import DockService                        from '../../../../../src/ai/client/DockService.mjs';
+import DockTopologyReconciler             from '../../../../../src/dashboard/DockTopologyReconciler.mjs';
 import DockZoneModel                      from '../../../../../src/dashboard/DockZoneModel.mjs';
 import TourRunner                         from '../../../../../src/ai/client/TourRunner.mjs';
 import {demoBTourScript, initialDocument} from '../../../tour/demoBPerspectives.mjs';
@@ -20,19 +21,20 @@ import '../../../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype 
  * the single source of truth; the pure reducer + view-sync halves of the dock-holder
  * contract), plus the two capabilities this demo exists to show:
  *
- * - **Perspectives** ride a {@link Neo.dashboard.DockPerspectiveStore}: the tour CAPTURES
- *   three named layouts live through `createSavedLayout` → `savePerspective` (the ADR's
- *   §2.2 capture path — no pre-baked records), and loading one back is a single committed
- *   document swap the FLIP layer animates. The switcher bar rebuilds from the store's
- *   lifecycle events — buttons are born from `perspectiveSaved`, never hardcoded.
+ * - **Perspectives** ride a {@link Neo.dashboard.DockPerspectiveStore}: ordinary views are
+ *   window-scoped; the detached view captures BOTH worker-owned workspace documents through
+ *   `captureTopologyPerspective`. Loading that record composes the real
+ *   {@link Neo.dashboard.DockTopologyReconciler} and renders its structured remainder.
+ *   The switcher bar rebuilds from store lifecycle events — buttons are born from
+ *   `perspectiveSaved`, never hardcoded.
  * - **Pop-out** rides the shared-heap vessel: panes are INSTANCE-CACHED (created once,
  *   parked across every re-projection — the reveal-pane-cache precedent), so detaching the
  *   workbench moves the LIVE component into the popup window's view tree
  *   (`mainView.add(instance)` — both windows share one App Worker) and reattaching moves it
  *   home. The {@link AgentOS.childapps.dockdemo.view.CounterPane} witness makes the
  *   reparent-never-recreate contract visible: its count survives because its instance does.
- *   Document honesty: pop-out commits `detachItem` (the item leaves the tree, keeps its
- *   record), reattach commits `addTab` — the document never lies about what is docked.
+ *   Document honesty: pop-out and reattach use the atomic two-document `transferItem` seam,
+ *   so ownership moves commit-or-neither while component reparenting stays orthogonal.
  *
  * @class AgentOS.childapps.dockdemo.view.DemoBWorkspace
  * @extends Neo.container.Base
@@ -74,6 +76,12 @@ class DemoBWorkspace extends Container {
      */
     dockModel = null
     /**
+     * The popup render target's worker-owned dock-zone document. It participates in topology
+     * capture while the live pane instance remains owned by {@link #paneCache}.
+     * @member {Object|null} popupDocument=null
+     */
+    popupDocument = null
+    /**
      * The app-side Neural Link dock seam (tour + agent drivability).
      * @member {Neo.ai.client.DockService|null} dockService=null
      */
@@ -105,6 +113,12 @@ class DemoBWorkspace extends Container {
      */
     detachedPanes = {}
     /**
+     * Plain structured result of the most recent topology reconciliation. This is rendered
+     * into the workspace so remainder semantics are visible rather than buried in logs.
+     * @member {Object|null} restoreReport=null
+     */
+    restoreReport = null
+    /**
      * Beats executed in the current run — the pip strip's progress counter.
      * @member {Number} beatCount=0
      */
@@ -119,6 +133,7 @@ class DemoBWorkspace extends Container {
         let me = this;
 
         me.dockModel        = DockZoneModel.clone(initialDocument);
+        me.popupDocument    = DemoBWorkspace.createPopupDocument();
         me.dockService      = Neo.create(DockService, {});
         me.perspectiveStore = Neo.create(DockPerspectiveStore, {});
 
@@ -151,6 +166,12 @@ class DemoBWorkspace extends Container {
         });
 
         me.add([me.createTourBar(), me.createSwitcherBar(), {
+            cls      : ['agentos-dockdemo-restore-report'],
+            hidden   : true,
+            html     : '',
+            ntype    : 'component',
+            reference: 'restore-report-b'
+        }, {
             module   : Container,
             cls      : ['agentos-dockdemo-dock-host', 'neo-dashboard'],
             flex     : 1,
@@ -170,20 +191,32 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * Captures the CURRENT committed document as a named perspective through the real
-     * §2.2 path: `createSavedLayout` (validation + normalization) → `savePerspective`.
+     * Captures the CURRENT committed workspace state as a named perspective through the real
+     * §2.2 path. Window scope persists the primary document; topology scope persists the
+     * primary + popup documents with one composed fingerprint.
      * `replace: true` keeps tour reruns idempotent — re-capturing your own name is the
      * demo's update flow, not a collision dispute.
      * @param {String} name
+     * @param {Object} [options={}]
+     * @param {'window'|'topology'} [options.scope='window']
      * @returns {{saved: Boolean, errors: String[]}}
      */
-    capturePerspective(name) {
-        let me      = this,
-            created = DockZoneModel.createSavedLayout(me.dockModel, {
+    capturePerspective(name, {scope = 'window'} = {}) {
+        let me       = this,
+            metadata = {
                 layoutId       : `demo-b-${name.toLowerCase()}`,
                 perspectiveName: name,
                 title          : name
-            });
+            },
+            created;
+
+        if (scope !== 'window' && scope !== 'topology') {
+            return {errors: [`unknown perspective capture scope "${scope}"`], saved: false}
+        }
+
+        created = scope === 'topology'
+            ? DockZoneModel.captureTopologyPerspective([me.dockModel, me.popupDocument], metadata)
+            : DockZoneModel.createSavedLayout(me.dockModel, metadata);
 
         if (created.errors.length) {
             return {errors: created.errors, saved: false}
@@ -262,14 +295,38 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * Loads a stored perspective and re-projects from its restored document — one committed
-     * swap, animated by the FLIP layer like every other re-projection.
+     * Loads a stored perspective. Window-scope records commit the restored primary document;
+     * topology-scope records go through the changed-topology reconciler and expose its remainder.
      * @param {String} name
-     * @returns {{loaded: Boolean, errors: String[]}}
+     * @returns {{loaded: Boolean, errors: String[], report?: Object}}
      */
     loadPerspectiveByName(name) {
-        let me     = this,
-            result = me.perspectiveStore.loadPerspective(name);
+        let me         = this,
+            summary    = me.perspectiveStore.list().find(entry => entry.perspectiveName === name || entry.layoutId === name),
+            collection = me.perspectiveStore.collection,
+            layout     = summary ? collection.layouts[summary.layoutId] : null;
+
+        // Reconcile BEFORE `loadPerspective` advances the store's active id. A malformed
+        // topology record or live document must leave both layout truth and selection truth
+        // untouched — fail-closed means more than avoiding a document assignment.
+        if (layout?.captureScope === 'topology') {
+            let preview = me.restoreTopologyPerspective(layout, {commit: false});
+
+            if (!preview.loaded) return preview;
+
+            let activated = me.perspectiveStore.loadPerspective(name);
+
+            if (activated.errors.length) {
+                return {errors: activated.errors, loaded: false, report: preview.report}
+            }
+
+            preview.hasLivePopup && (me.popupDocument = preview.documents[1]);
+            me.onDockZoneDocumentChange(preview.documents[0]);
+
+            return {errors: [], loaded: true, report: preview.report}
+        }
+
+        let result = me.perspectiveStore.loadPerspective(name);
 
         if (result.errors.length || !result.document) {
             return {errors: result.errors, loaded: false}
@@ -278,6 +335,70 @@ class DemoBWorkspace extends Container {
         me.onDockZoneDocumentChange(result.document);
 
         return {errors: [], loaded: true}
+    }
+
+    /**
+     * @summary Reconciles one topology record onto the currently live workspace documents.
+     * A connected/detached popup contributes its worker-owned document; otherwise the live
+     * topology is intentionally one window. Validation errors mutate neither document.
+     * @param {Object} layout A topology-scope saved-layout record.
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.commit=true] Commit reconciled documents; false is a preflight.
+     * @returns {{loaded: Boolean, errors: String[], report: Object, documents: Object[], hasLivePopup: Boolean}}
+     */
+    restoreTopologyPerspective(layout, {commit = true} = {}) {
+        let me            = this,
+            hasLivePopup  = Object.keys(me.detachedPanes).length > 0,
+            liveDocuments = hasLivePopup ? [me.dockModel, me.popupDocument] : [me.dockModel],
+            result        = DockTopologyReconciler.reconcile(layout, liveDocuments),
+            report        = DockZoneModel.clone({
+                applied       : result.applied,
+                displaced     : result.displaced,
+                errors        : result.errors,
+                mapping       : result.mapping,
+                noWindowSpawned: true,
+                unmatchedLive : result.unmatchedLive,
+                unrestored    : result.unrestored
+            });
+
+        me.restoreReport = report;
+        me.renderRestoreReport();
+
+        if (result.errors.length) {
+            return {documents: result.documents, errors: result.errors, hasLivePopup, loaded: false, report}
+        }
+
+        if (commit) {
+            hasLivePopup && (me.popupDocument = result.documents[1]);
+            me.onDockZoneDocumentChange(result.documents[0])
+        }
+
+        return {documents: result.documents, errors: [], hasLivePopup, loaded: true, report}
+    }
+
+    /**
+     * @summary Renders the structured topology remainder into a dedicated visible strip.
+     * Item ids are escaped because saved layouts are data, not trusted markup.
+     * @protected
+     */
+    renderRestoreReport() {
+        let me      = this,
+            target  = me.getReference('restore-report-b'),
+            report  = me.restoreReport,
+            escape  = value => String(value)
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;'),
+            entries = values => values.length
+                ? values.map(entry => `${escape(entry.itemId)} (${escape(entry.reason)})`).join(', ')
+                : 'none';
+
+        if (!target || !report) return;
+
+        target.html = report.errors.length
+            ? `<strong>Topology restore rejected.</strong> Validation failed; live documents stayed untouched. ${report.errors.map(escape).join('; ')}`
+            : `<strong>Topology restore — no window spawned.</strong> Unrestored: ${entries(report.unrestored)}. Displaced: ${report.displaced.length ? report.displaced.map(entry => escape(entry.itemId)).join(', ') : 'none'}. Unmatched live slots: ${report.unmatchedLive.length ? report.unmatchedLive.join(', ') : 'none'}.`;
+        target.hidden = false
     }
 
     /**
@@ -312,7 +433,7 @@ class DemoBWorkspace extends Container {
 
         if (!cue) return;
 
-        cue.type === 'perspective-save' && me.capturePerspective(cue.name);
+        cue.type === 'perspective-save' && me.capturePerspective(cue.name, {scope: cue.scope});
         cue.type === 'perspective-load' && me.loadPerspectiveByName(cue.name);
         cue.type === 'popout'           && me.popOutPane(cue.itemId);
         cue.type === 'reattach'         && me.reattachPane(cue.itemId)
@@ -365,7 +486,7 @@ class DemoBWorkspace extends Container {
         let entry = me.detachedPanes[itemId],
             pane  = me.paneCache[itemId];
 
-        if (entry && pane) {
+        if (entry && pane && me.popupDocument?.items?.[itemId]) {
             entry.windowId = windowId;
             app.mainView.add(pane)
         }
@@ -390,10 +511,10 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * The pop-out moment: parks the live pane out of the projection, commits `detachItem`
-     * (document honesty — the item leaves the tree, keeps its record), and opens the popup
-     * on the SAME app: the SharedWorker heap makes the new window a second render target
-     * for the one worker, and `onWindowConnect` moves the instance in.
+     * The pop-out moment: atomically transfers the item record + placement from the primary
+     * workspace document into the popup document, parks the live pane out of the projection,
+     * and opens the popup on the SAME app. The SharedWorker heap makes the new window a second
+     * render target for the one worker; `onWindowConnect` moves the cached instance in.
      * @param {String} itemId
      * @returns {Promise<{detached: Boolean, errors: String[]}>}
      */
@@ -406,28 +527,54 @@ class DemoBWorkspace extends Container {
             return {detached: false, errors: [`"${itemId}" is not a docked, cached, attached pane`]}
         }
 
+        // A prior round-trip normalizes the now-empty popup tree. Re-seed its valid landing
+        // tabs before the next transfer; no item state exists there to preserve at that point.
+        let sourceBefore = me.dockModel,
+            popupBefore  = me.popupDocument,
+            popup        = Object.keys(me.popupDocument.items || {}).length
+                ? me.popupDocument
+                : DemoBWorkspace.createPopupDocument(),
+            result       = DockZoneModel.transferItem(sourceBefore, popup, {
+                itemId,
+                sourceWorkspaceId: 'main',
+                targetWorkspaceId: 'popup',
+                target           : {operation: 'addTab', tabsNodeId: 'popup-tabs'}
+            });
+
+        if (result.errors.length) {
+            return {detached: false, errors: result.errors}
+        }
+
         me.detachedPanes[itemId] = {tabsNodeId: home, windowId: null};
 
         // park BEFORE the re-projection tears the old tree down
         pane.parent?.remove(pane, false);
 
-        let result = me.applyDockZoneOperation({operation: 'detachItem', itemId});
+        me.popupDocument = result.targetDocument;
+        me.onDockZoneDocumentChange(result.sourceDocument);
 
-        if (result.errors?.length) {
+        try {
+            let winData = await Neo.Main.getWindowData({windowId: me.windowId});
+
+            await Neo.Main.windowOpen({
+                url           : `./index.html?popout=${itemId}&hostId=${me.id}`,
+                windowFeatures: `height=420,width=560,left=${winData.screenLeft + 120},top=${winData.screenTop + 120}`,
+                windowId      : me.windowId,
+                windowName    : `demo-b-${itemId}`
+            })
+        } catch (error) {
+            // The vessel failed after the pure transfer result was staged. Restore BOTH pristine
+            // inputs: the source's old home may have normalized away after losing its sole item,
+            // so replaying another placement is weaker than the transfer's commit-or-neither truth.
             delete me.detachedPanes[itemId];
-            return {detached: false, errors: result.errors}
+            me.popupDocument = popupBefore;
+            me.onDockZoneDocumentChange(sourceBefore);
+
+            return {
+                detached: false,
+                errors  : [`popup open failed: ${error?.message || error}`]
+            }
         }
-
-        me.onDockZoneDocumentChange(result.document);
-
-        let winData = await Neo.Main.getWindowData({windowId: me.windowId});
-
-        await Neo.Main.windowOpen({
-            url           : `./index.html?popout=${itemId}&hostId=${me.id}`,
-            windowFeatures: `height=420,width=560,left=${winData.screenLeft + 120},top=${winData.screenTop + 120}`,
-            windowId      : me.windowId,
-            windowName    : `demo-b-${itemId}`
-        });
 
         return {detached: true, errors: []}
     }
@@ -447,9 +594,9 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * The reattach: closes the popup (unless it already closed itself), commits `addTab`
-     * back to the pane's home tabs node, and lets the re-projection re-adopt the parked
-     * instance — same count, same instance, home again.
+     * The reattach: atomically transfers the item from the popup document into its primary
+     * tabs home, closes the popup (unless it already closed itself), and lets the projection
+     * re-adopt the parked instance — same count, same instance, home again.
      * @param {String} itemId
      * @param {Object} [options={}]
      * @param {Boolean} [options.windowAlreadyClosed=false]
@@ -464,28 +611,37 @@ class DemoBWorkspace extends Container {
             return {errors: [`"${itemId}" is not detached`], reattached: false}
         }
 
-        delete me.detachedPanes[itemId];
-
-        // pull the instance out of the popup's tree first — parked, never destroyed
-        pane.parent?.remove(pane, false);
-
-        if (!windowAlreadyClosed) {
-            await Neo.Main.windowClose({names: [`demo-b-${itemId}`], windowId: me.windowId})
-        }
-
         // home fallback: if the remembered tabs node left the tree (a perspective moved on),
         // the first tabs node adopts the returning pane — never a dangling reattach
         let home = me.dockModel.nodes[entry.tabsNodeId]?.type === 'tabs'
-            ? entry.tabsNodeId
-            : Object.keys(me.dockModel.nodes).find(id => me.dockModel.nodes[id].type === 'tabs');
+                ? entry.tabsNodeId
+                : Object.keys(me.dockModel.nodes).find(id => me.dockModel.nodes[id].type === 'tabs'),
+            result = DockZoneModel.transferItem(me.popupDocument, me.dockModel, {
+                itemId,
+                sourceWorkspaceId: 'popup',
+                targetWorkspaceId: 'main',
+                target           : {operation: 'addTab', tabsNodeId: home}
+            });
 
-        let result = me.applyDockZoneOperation({operation: 'addTab', itemId, tabsNodeId: home});
-
-        if (result.errors?.length) {
+        if (result.errors.length) {
             return {errors: result.errors, reattached: false}
         }
 
-        me.onDockZoneDocumentChange(result.document);
+        delete me.detachedPanes[itemId];
+
+        // Commit model ownership before awaiting the vessel. The deleted bookkeeping entry is
+        // the disconnect re-entrancy guard; a close failure leaves an empty popup, not split truth.
+        pane.parent?.remove(pane, false);
+        me.popupDocument = result.sourceDocument;
+        me.onDockZoneDocumentChange(result.targetDocument);
+
+        if (!windowAlreadyClosed) {
+            try {
+                await Neo.Main.windowClose({names: [`demo-b-${itemId}`], windowId: me.windowId})
+            } catch (error) {
+                return {errors: [`popup close failed: ${error?.message || error}`], reattached: true}
+            }
+        }
 
         return {errors: [], reattached: true}
     }
@@ -598,7 +754,8 @@ class DemoBWorkspace extends Container {
         }
 
         if (me.tourRunner.log.length) {
-            me.dockModel = DockZoneModel.clone(initialDocument);
+            me.dockModel     = DockZoneModel.clone(initialDocument);
+            me.popupDocument = DemoBWorkspace.createPopupDocument();
             me.refreshDockWorkspace()
         }
 
@@ -647,6 +804,25 @@ class DemoBWorkspace extends Container {
      */
     static totalBeats() {
         return demoBTourScript.scenes.flatMap(scene => scene.steps)
+    }
+
+    /**
+     * @summary Creates the valid empty popup workspace used as the target of an atomic transfer.
+     * The empty tabs node is intentional: it is the landing slot and is normalized away when
+     * the last item transfers home, after which the next pop-out creates a fresh target.
+     * @returns {Object}
+     * @static
+     */
+    static createPopupDocument() {
+        return {
+            schema: DockZoneModel.SCHEMA,
+            root  : 'popup-root',
+            items : {},
+            nodes : {
+                'popup-root': {type: 'edge-zone', zones: {center: 'popup-tabs'}},
+                'popup-tabs': {type: 'tabs', items: [], activeItemId: null}
+            }
+        }
     }
 
     /**

--- a/apps/agentos/tour/demoBPerspectives.mjs
+++ b/apps/agentos/tour/demoBPerspectives.mjs
@@ -10,8 +10,9 @@
  *    FLIP layer glides every surviving pane to its new geometry; the counter keeps counting.
  * 3. **Pop-out** — the workbench pane detaches to a real OS window on the SAME SharedWorker
  *    heap and reattaches, its instance-bound counter unbroken: reparent, never recreate.
- * 4. **Honest limits** — a perspective captured while the pane was detached restores into a
- *    one-window world through the §2.2 fail-closed path, shown, not hidden.
+ * 4. **Changed topology** — the detached two-workspace record restores into a one-window
+ *    world through the real reconciler. Its no-live-window remainder is rendered, and no
+ *    popup is auto-spawned.
  *
  * Store/pop-out beats ride surface CUES (the Demo-A reveal-cue pattern): perspectives are
  * store operations and window moves are vessel operations — neither is a dock-zone document
@@ -119,20 +120,20 @@ export const demoBTourScript = Object.freeze({
             {type: 'pause', ms: 900},
             {type: 'pause', ms: 900, cue: {type: 'popout', itemId: 'workbench'}, caption: 'pop-out(workbench): a real OS window opens on the shared heap. Watch the counter — it does not reset.'},
             {type: 'pause', ms: 2000},
-            {type: 'pause', ms: 600, cue: {type: 'perspective-save', name: 'Detached'}, caption: 'save("Detached"): capturing THIS state — a perspective that remembers the workbench being elsewhere'},
+            {type: 'pause', ms: 600, cue: {type: 'perspective-save', name: 'Detached', scope: 'topology'}, caption: 'save("Detached"): topology capture records BOTH worker-owned workspace documents — main plus popup'},
             {type: 'pause', ms: 900, cue: {type: 'reattach', itemId: 'workbench'}, caption: 'reattach(workbench): home again. Same instance, same count — reparent, never recreate.'},
             {type: 'pause', ms: 1200}
         ]
     }, {
         id     : 's4',
-        title  : 'Detached intent — one workspace, two render targets',
-        caption: '"Detached" captured the worker-owned workspace while the workbench rendered in the popup. Restoring it preserves that detached catalog state without persisting window identity or geometry.',
+        title  : 'Changed topology — restore truth, never summon a window',
+        caption: '"Detached" captured two worker-owned workspace documents. Only the main window is live now, so reconciliation applies what fits and renders the exact remainder.',
         steps  : [
-            {type: 'pause', ms: 1400, cue: {type: 'perspective-load', name: 'Detached'}, caption: 'load("Detached"): the workbench leaves the primary tree because the saved workspace records it detached. Window-scope restore, shown, never silent.'},
+            {type: 'pause', ms: 1400, cue: {type: 'perspective-load', name: 'Detached'}, caption: 'reconcile("Detached"): no popup is spawned; Workbench is reported unrestored with reason no-live-window, and displaced primary content is named'},
             {
                 type   : 'topology-assert',
-                caption: 'the catalog still knows the workbench (nothing was deleted) — the layout simply has no slot for it, visibly',
-                expect : [{path: 'items.workbench.title', equals: 'Workbench'}]
+                caption: 'the coverable primary slot committed, while the dedicated report strip keeps the missing popup slot visible',
+                expect : [{path: 'items.inspector.title', equals: 'Inspector'}]
             },
             {type: 'pause', ms: 1400, cue: {type: 'perspective-load', name: 'Focus'}, caption: 'load("Focus"): the finale brings it home — and the counter STILL never reset, even undocked'},
             {type: 'pause', ms: 900}

--- a/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.scss
+++ b/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.scss
@@ -30,6 +30,21 @@
     }
 }
 
+.agentos-dockdemo-restore-report {
+    background : color-mix(in srgb, var(--fm-signal) 10%, var(--fm-panel));
+    border-bottom: 1px solid var(--fm-line);
+    color      : var(--fm-ink);
+    flex       : 0 0 auto;
+    font-family: var(--fm-font-mono);
+    font-size  : 11px;
+    line-height: 1.45;
+    padding    : 7px 12px;
+
+    strong {
+        color: var(--fm-signal);
+    }
+}
+
 .agentos-dockdemo-counter-pane {
     align-items    : center;
     background     : var(--fm-panel);

--- a/test/playwright/e2e/agentos/DemoBPerspectivesNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBPerspectivesNL.spec.mjs
@@ -1,0 +1,140 @@
+import {test, expect}    from '../../fixtures.mjs';
+import {demoBTourScript} from '../../../../apps/agentos/tour/demoBPerspectives.mjs';
+
+/**
+ * @summary Whitebox E2E for Demo B's full two-window perspective story.
+ *
+ * One native Tour click must open exactly one real popup, move the same live CounterPane
+ * instance into it, capture the two worker-owned workspace documents, reattach, reconcile
+ * that saved topology into one live window without opening another popup, render the exact
+ * no-live-window remainder, and finish on Focus with the original counter still advancing.
+ * The same page repeats the run so the executable screenplay proves deterministic replay.
+ *
+ * Run: NEO_E2E_PORT=8117 npx playwright test agentos/DemoBPerspectivesNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('AgentOS Demo B — topology perspective + shared-heap popup journey', () => {
+    test.setTimeout(150000);
+
+    test('two deterministic runs each open one popup; topology restore opens none and preserves the CounterPane instance', async ({page, neuralLink}) => {
+        const pageErrors    = [],
+              runtimeErrors = [];
+        let popupCount      = 0;
+
+        await page.context().exposeFunction('__recordDemoBRuntimeError', payload => runtimeErrors.push(payload));
+        await page.context().addInitScript(() => {
+            globalThis.addEventListener('error', event => {
+                globalThis.__recordDemoBRuntimeError({
+                    column : event.colno,
+                    line   : event.lineno,
+                    message: event.message,
+                    source : event.filename,
+                    type   : 'error'
+                })
+            });
+            globalThis.addEventListener('unhandledrejection', event => {
+                globalThis.__recordDemoBRuntimeError({
+                    reason: String(event.reason?.stack || event.reason?.message || event.reason),
+                    type  : 'unhandledrejection'
+                })
+            })
+        });
+
+        page.on('pageerror', error => {
+            let value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+        page.on('popup', () => popupCount++);
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
+        await page.waitForSelector('.agentos-dockdemo-tour-play', {timeout: 30000});
+
+        const app        = await neuralLink.connectToApp('AgentOSDockDemo'),
+              workspaces = await app.findInstances({className: 'AgentOS.childapps.dockdemo.view.DemoBWorkspace'}, ['id']),
+              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id,
+              totalBeats = demoBTourScript.scenes.flatMap(scene => scene.steps).length;
+
+        expect(wsId, 'the DemoBWorkspace must exist in the App Worker').toBeTruthy();
+
+        const readCounter = async () => {
+            const counters = await app.findInstances(
+                {className: 'AgentOS.childapps.dockdemo.view.CounterPane'},
+                ['id', 'frames']
+            );
+
+            return (Array.isArray(counters) ? counters[0] : counters)
+        };
+
+        await expect.poll(async () => !!(await readCounter())?.id, {
+            message: 'the worker must own one CounterPane before the tour',
+            timeout: 10000,
+            intervals: [100]
+        }).toBe(true);
+
+        const baseline = await readCounter();
+
+        expect(baseline.id).toBeTruthy();
+
+        const logs = [];
+
+        for (let run = 0; run < 2; run++) {
+            const popupsBefore = popupCount,
+                  popupPromise = page.waitForEvent('popup', {timeout: 30000});
+
+            await page.locator('.agentos-dockdemo-tour-play').click();
+
+            const popup      = await popupPromise,
+                  popupErrors = [];
+
+            popup.on('pageerror', error => {
+                let value = error == null ? '' : String(error.stack || error.message || error);
+                value && value !== 'undefined' && popupErrors.push(value)
+            });
+            await expect(popup.locator('.agentos-dockdemo-counter-pane'), 'the real popup hosts the live workbench pane')
+                .toBeVisible({timeout: 10000});
+
+            const inPopup = await readCounter();
+
+            expect(inPopup.id, 'the popup must hold the original CounterPane instance').toBe(baseline.id);
+
+            await expect.poll(async () => {
+                const state = await app.getComponent(wsId, ['tourRunner.running', 'tourRunner.log']);
+                return {
+                    length : state['tourRunner.log']?.length ?? 0,
+                    running: state['tourRunner.running']
+                }
+            }, {
+                message: `Demo B run ${run + 1} must complete every executable beat`,
+                timeout: 60000,
+                intervals: [100, 250]
+            }).toEqual({length: totalBeats, running: false});
+
+            await expect.poll(() => popup.isClosed(), {
+                message: 'the scripted reattach closes the popup before topology restore',
+                timeout: 10000,
+                intervals: [100]
+            }).toBe(true);
+
+            const state = await app.getComponent(wsId, ['dockModel', 'restoreReport', 'tourRunner.log']),
+                  final = await readCounter();
+
+            expect(state.restoreReport.noWindowSpawned).toBe(true);
+            expect(state.restoreReport.unrestored).toEqual([
+                {capturedIndex: 1, itemId: 'workbench', reason: 'no-live-window'}
+            ]);
+            expect(state.restoreReport.displaced).toEqual([{itemId: 'workbench', liveIndex: 0}]);
+            expect(state.dockModel.items.workbench.title).toBe('Workbench');
+            expect(final.id, 'Focus restore must re-adopt the same live CounterPane').toBe(baseline.id);
+            expect(final.properties.frames).toBeGreaterThan(baseline.properties.frames);
+            expect(popupCount - popupsBefore, 'S3 opens one popup; S4 topology restore opens none').toBe(1);
+            expect(popupErrors).toEqual([]);
+
+            await expect(page.locator('.agentos-dockdemo-restore-report'))
+                .toContainText('no window spawned');
+
+            logs.push(state['tourRunner.log'])
+        }
+
+        expect(logs[1], 'the second run must produce the same timestamp-free operation log').toEqual(logs[0]);
+        expect(runtimeErrors).toEqual([]);
+        expect(pageErrors).toEqual([])
+    })
+});

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
@@ -11,8 +11,45 @@ import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import '../../../../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
 import DemoBWorkspace from '../../../../../../../apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs';
+import DockZoneModel  from '../../../../../../../src/dashboard/DockZoneModel.mjs';
 
 import {initialDocument} from '../../../../../../../apps/agentos/tour/demoBPerspectives.mjs';
+
+/**
+ * @summary Installs deterministic popup-vessel seams for the worker-side workspace specs.
+ * The real OS-window round-trip is owned by the E2E witness; these seams isolate document
+ * ownership, rollback, and no-spawn behavior without weakening their call contract.
+ * @param {Object} [options={}]
+ * @param {Error|null} [options.openError=null]
+ * @param {Error|null} [options.closeError=null]
+ * @returns {{openCount: Number, closeCount: Number, restore: Function}}
+ */
+function installWindowVessel({openError = null, closeError = null} = {}) {
+    let previous = {
+            getWindowData: Neo.Main.getWindowData,
+            windowClose  : Neo.Main.windowClose,
+            windowOpen   : Neo.Main.windowOpen
+        },
+        state = {closeCount: 0, openCount: 0};
+
+    Neo.Main.getWindowData = async () => ({screenLeft: 10, screenTop: 20});
+    Neo.Main.windowOpen    = async () => {
+        state.openCount++;
+        if (openError) throw openError
+    };
+    Neo.Main.windowClose   = async () => {
+        state.closeCount++;
+        if (closeError) throw closeError
+    };
+
+    return {
+        get closeCount() { return state.closeCount },
+        get openCount()  { return state.openCount },
+        restore() {
+            Object.assign(Neo.Main, previous)
+        }
+    }
+}
 
 /**
  * @summary Contract specs for the Demo-B workspace: the dock-holder contract, the live
@@ -103,13 +140,21 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
     });
 
     test('reattachPane falls back to the first tabs node when the remembered home left the tree', async () => {
-        // stage: pane cached, marked detached from a node that no longer exists,
-        // and the document no longer contains the item in any tabs node
+        // stage a REAL two-document transfer, then remember a home that no longer exists
         workspace.resolvePane('workbench', initialDocument.items.workbench);
 
-        const detached = workspace.applyDockZoneOperation({operation: 'detachItem', itemId: 'workbench'});
+        const detached = DockZoneModel.transferItem(
+            workspace.dockModel,
+            DemoBWorkspace.createPopupDocument(),
+            {
+                itemId: 'workbench', sourceWorkspaceId: 'main', targetWorkspaceId: 'popup',
+                target: {operation: 'addTab', tabsNodeId: 'popup-tabs'}
+            }
+        );
+
         expect(detached.errors).toEqual([]);
-        workspace.dockModel = detached.document;
+        workspace.dockModel     = detached.sourceDocument;
+        workspace.popupDocument = detached.targetDocument;
 
         workspace.detachedPanes.workbench = {tabsNodeId: 'vanished-tabs', windowId: null};
 
@@ -121,6 +166,120 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
         const home = Object.keys(doc.nodes).find(id => doc.nodes[id].type === 'tabs' && doc.nodes[id].items.includes('workbench'));
 
         expect(home, 'the returning pane found a real tabs home').toBeTruthy()
+    });
+
+    test('topology round-trip transfers ownership, reports the missing popup slot, never spawns on restore, and preserves the pane instance', async () => {
+        const vessel = installWindowVessel();
+
+        try {
+            const pane = workspace.resolvePane('workbench', initialDocument.items.workbench);
+
+            pane.frames = 41;
+            expect(workspace.capturePerspective('Focus').saved).toBe(true);
+
+            const popped = await workspace.popOutPane('workbench');
+
+            expect(popped).toEqual({detached: true, errors: []});
+            expect(vessel.openCount).toBe(1);
+            expect(workspace.dockModel.items.workbench).toBeUndefined();
+            expect(workspace.popupDocument.items.workbench).toEqual(initialDocument.items.workbench);
+            expect(DockZoneModel.validate(workspace.dockModel)).toEqual([]);
+            expect(DockZoneModel.validate(workspace.popupDocument)).toEqual([]);
+
+            expect(workspace.capturePerspective('Detached', {scope: 'topology'}).saved).toBe(true);
+
+            const detachedSummary = workspace.perspectiveStore.list().find(entry => entry.perspectiveName === 'Detached'),
+                  detachedLayout  = workspace.perspectiveStore.collection.layouts[detachedSummary.layoutId];
+
+            expect(detachedLayout.captureScope).toBe('topology');
+            expect(detachedLayout.windowDocuments).toHaveLength(1);
+
+            const reattached = await workspace.reattachPane('workbench', {windowAlreadyClosed: true});
+
+            expect(reattached).toEqual({errors: [], reattached: true});
+            expect(workspace.dockModel.items.workbench).toEqual(initialDocument.items.workbench);
+            expect(workspace.popupDocument.items.workbench).toBeUndefined();
+            expect(DockZoneModel.validate(workspace.dockModel)).toEqual([]);
+            expect(DockZoneModel.validate(workspace.popupDocument)).toEqual([]);
+            expect(workspace.resolvePane('workbench', initialDocument.items.workbench)).toBe(pane);
+
+            const opensBeforeRestore = vessel.openCount,
+                  loaded             = workspace.loadPerspectiveByName('Detached');
+
+            expect(loaded.loaded).toBe(true);
+            expect(loaded.errors).toEqual([]);
+            expect(vessel.openCount).toBe(opensBeforeRestore);
+            expect(loaded.report.noWindowSpawned).toBe(true);
+            expect(loaded.report.unrestored).toEqual([
+                {capturedIndex: 1, itemId: 'workbench', reason: 'no-live-window'}
+            ]);
+            expect(loaded.report.displaced).toEqual([{itemId: 'workbench', liveIndex: 0}]);
+            expect(workspace.dockModel.items.workbench).toBeUndefined();
+
+            const report = workspace.getReference('restore-report-b');
+
+            expect(report.hidden).toBe(false);
+            expect(report.html).toContain('no window spawned');
+            expect(report.html).toContain('workbench (no-live-window)');
+
+            expect(workspace.loadPerspectiveByName('Focus').loaded).toBe(true);
+            expect(workspace.resolvePane('workbench', initialDocument.items.workbench)).toBe(pane);
+            expect(pane.frames).toBe(41)
+        } finally {
+            vessel.restore()
+        }
+    });
+
+    test('invalid topology restore leaves both live documents and active selection untouched', async () => {
+        const vessel = installWindowVessel();
+
+        try {
+            workspace.resolvePane('workbench', initialDocument.items.workbench);
+            expect(await workspace.popOutPane('workbench')).toEqual({detached: true, errors: []});
+            expect(workspace.capturePerspective('Detached', {scope: 'topology'}).saved).toBe(true);
+
+            const summary      = workspace.perspectiveStore.list().find(entry => entry.perspectiveName === 'Detached'),
+                  layout       = DockZoneModel.clone(workspace.perspectiveStore.collection.layouts[summary.layoutId]),
+                  dockBefore   = workspace.dockModel,
+                  popupBefore  = workspace.popupDocument,
+                  dockSnapshot = JSON.stringify(dockBefore),
+                  popSnapshot  = JSON.stringify(popupBefore),
+                  activeBefore = workspace.perspectiveStore.collection.activeLayoutId;
+
+            layout.windowDocuments[0].root = 'ghost-root';
+
+            const restored = workspace.restoreTopologyPerspective(layout);
+
+            expect(restored.loaded).toBe(false);
+            expect(restored.errors.length).toBeGreaterThan(0);
+            expect(workspace.dockModel).toBe(dockBefore);
+            expect(workspace.popupDocument).toBe(popupBefore);
+            expect(JSON.stringify(workspace.dockModel)).toBe(dockSnapshot);
+            expect(JSON.stringify(workspace.popupDocument)).toBe(popSnapshot);
+            expect(workspace.perspectiveStore.collection.activeLayoutId).toBe(activeBefore);
+            expect(workspace.getReference('restore-report-b').html).toContain('live documents stayed untouched')
+        } finally {
+            vessel.restore()
+        }
+    });
+
+    test('popup-open failure reverses the transfer instead of orphaning worker truth', async () => {
+        const vessel = installWindowVessel({openError: new Error('popup denied')});
+
+        try {
+            workspace.resolvePane('workbench', initialDocument.items.workbench);
+
+            const before = JSON.stringify(workspace.dockModel),
+                  result = await workspace.popOutPane('workbench');
+
+            expect(result.detached).toBe(false);
+            expect(result.errors.join(' ')).toContain('popup denied');
+            expect(JSON.stringify(workspace.dockModel)).toBe(before);
+            expect(workspace.popupDocument.items.workbench).toBeUndefined();
+            expect(workspace.detachedPanes.workbench).toBeUndefined()
+        } finally {
+            vessel.restore()
+        }
     });
 
     test('the switcher is BORN from store lifecycle: buttons appear per capture', () => {


### PR DESCRIPTION
Resolves #15003

Demo B now tells the real changed-topology story: the App Worker owns valid primary and popup workspace documents, pop-out and reattach transfer the workbench atomically between them, “Detached” captures topology scope, and restore composes DockTopologyReconciler instead of swapping only the primary document. The UI renders the structured remainder — including the missing popup slot, displaced item, and explicit no-window-spawn result — while invalid topology input leaves both live documents and active perspective selection untouched. The cached CounterPane remains the same live instance throughout the real popup round-trip and final Focus restore.

Evidence: L3 (exact-head Chromium + Neural Link tour with a real popup, two deterministic runs, visible reconciliation remainder, and live component identity proof) → L3 required (runtime topology restore, no-spawn behavior, fail-closed validation, and state continuity). Residual: none.

## Deltas from ticket

None substantive. The implementation makes two ticket requirements mechanically stronger: topology restore is previewed before the store advances its active selection, and a denied popup open restores both pristine workspace documents rather than replaying a weaker compensating placement.

## Architectural Shape

- `DockZoneModel.transferItem()` is the only ownership move; component reparenting remains an orthogonal SharedWorker render operation.
- `captureTopologyPerspective()` persists the primary and popup documents as one topology record, while ordinary named views remain window-scoped.
- `DockTopologyReconciler.reconcile()` runs against the actually live document set and never spawns a missing window.
- A dedicated restore strip exposes `unrestored`, `displaced`, and `unmatchedLive` instead of hiding reconciliation semantics in logs.
- Saved-layout data is escaped before rendering; popup-open failure and invalid topology both fail closed.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs` — 12/12 passed.
- `NEO_E2E_PORT=<fresh> npx playwright test DemoBPerspectivesNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` — 1/1 passed; the witness runs the full tour twice, performs one real popup round-trip per run, proves identical timestamp-free logs, and preserves the CounterPane id.
- A later redundant browser rerun stopped before product execution because the host hit process-wide `EMFILE` / `uv_uptime EPERM`; it produced no contradictory product evidence.
- `node ./buildScripts/util/check-jsdoc-types.mjs` — 1,722 files scanned, 0 unparseable type expressions.
- `npm run agent-preflight -- --no-fix <changed files>` — all requested gates passed.
- `git diff --check` — passed.
- Publication freshness: the two ticketed commits form a fast-forward chain rooted directly at current `origin/dev`; no unrelated branch history.

## Commits

- `b3185519a` — implement the Demo B topology capture/reconciliation journey.
- `b38efbe51d` — express the optional restore report in Closure/JSDoc-compatible syntax.

## Post-Merge Validation

- [ ] Optional merged-`dev` smoke: play Demo B once in the portal and confirm host popup policy matches the already-green exact-head witness. No acceptance residual is deferred.

Related: #14590
Related: #14999
Related: #14945

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session 019f484c-662f-7f31-969a-cbde373efd4a.
