### PR TITLE
fix(ai): preserve requested serving-cost window on interrupt (#15020)

### DIFF
--- a/ai/scripts/benchmark/serving-cost-meter.mjs
+++ b/ai/scripts/benchmark/serving-cost-meter.mjs
@@ -71,6 +71,30 @@ export function parseWindow(value) {
 }
 
 /**
+ * @summary Separates the requested measurement window from the observed process lifecycle.
+ * An early stop is missing coverage inside the original window, never a shorter requested
+ * window: aggregation keeps the requested bounds while the report records the actual stop.
+ * Pure and clock-free so both early-stop and natural-completion semantics stay unit-pinned.
+ * @param {Number} startedAt Epoch-ms sampling start.
+ * @param {Number} windowMs Requested window duration in ms.
+ * @param {Number} observedEndMs Epoch-ms at which the sampling loop actually stopped.
+ * @returns {{interrupted: Boolean, observedEndMs: Number, windowBounds: {endMs: Number, startMs: Number}}}
+ */
+export function resolveWindowLifecycle(startedAt, windowMs, observedEndMs) {
+    const requestedEndMs = startedAt + windowMs;
+
+    if (![startedAt, windowMs, observedEndMs, requestedEndMs].every(Number.isFinite) || windowMs <= 0 || observedEndMs < startedAt) {
+        throw new Error('resolveWindowLifecycle: finite start/end values and a positive window are required')
+    }
+
+    return {
+        interrupted: observedEndMs < requestedEndMs,
+        observedEndMs,
+        windowBounds: {endMs: requestedEndMs, startMs: startedAt}
+    }
+}
+
+/**
  * Extracts the port from a configured endpoint URL leaf.
  * @param {String} hostUrl e.g. 'http://127.0.0.1:11434'
  * @returns {Number|null}
@@ -232,15 +256,17 @@ async function main() {
         elapsed < intervalMs && await new Promise(resolve => setTimeout(resolve, intervalMs - elapsed))
     }
 
-    // the REQUESTED bounds travel into every aggregate: a role whose endpoint appeared for
-    // only the tail of the window must read as mostly-unavailable, never as a clean short run
-    const windowBounds = {endMs: Date.now(), startMs: startedAt};
+    // REQUESTED and OBSERVED time stay distinct: Ctrl-C creates trailing unavailability inside
+    // the named window, never a shorter nominal window carrying the original rolling identity
+    const {interrupted, observedEndMs, windowBounds} = resolveWindowLifecycle(startedAt, windowMs, Date.now());
 
     const report = {
         hardware  : options.hardware,
         host      : {arch: os.arch(), cpuModel: os.cpus()[0]?.model ?? 'unknown', platform: os.platform(), totalMemBytes: os.totalmem()},
+        interrupted,
         intervalMs,
         metricBags: [],
+        observedEndMs,
         periodStart,
         roles     : {},
         skipped, // declared measurement holes (remote endpoints) live in the artifact, not just stdout

--- a/test/playwright/unit/ai/scripts/servingCostCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/servingCostCore.spec.mjs
@@ -2,7 +2,7 @@ import {test, expect} from '@playwright/test';
 
 import {aggregateWindow, buildMetricBags, classifySample}                from '../../../../../ai/scripts/benchmark/helpers/servingCostCore.mjs';
 import {createMetricId, validateBusinessProperties}                      from '../../../../../ai/graph/businessSchema.mjs';
-import {isLocalEndpoint, parseWindow, portFromHostUrl, resolveRolePorts} from '../../../../../ai/scripts/benchmark/serving-cost-meter.mjs';
+import {isLocalEndpoint, parseWindow, portFromHostUrl, resolveRolePorts, resolveWindowLifecycle} from '../../../../../ai/scripts/benchmark/serving-cost-meter.mjs';
 
 /**
  * Pins the serving-cost meter's pure core — the deterministic heart of the measurement
@@ -175,6 +175,42 @@ test.describe('serving-cost meter CLI helpers (resolution honesty)', () => {
         // a zero window would exit 0 with an empty "measurement" — refused at parse time
         expect(() => parseWindow('0s')).toThrow('positive duration');
         expect(() => parseWindow('0h')).toThrow('positive duration')
+    });
+
+    test('requested and observed windows stay distinct across early stop and natural completion', () => {
+        const interrupted = resolveWindowLifecycle(1000, 3600000, 23500);
+
+        expect(interrupted).toEqual({
+            interrupted : true,
+            observedEndMs: 23500,
+            windowBounds : {endMs: 3601000, startMs: 1000}
+        });
+
+        const aggregate = aggregateWindow([
+            {atMs: 1000,  cpuPercent: 10, role: 'chat-model', rssBytes: 1000},
+            {atMs: 23500, cpuPercent: 10, role: 'chat-model', rssBytes: 1000}
+        ], {activeCpuThreshold: 5, expectedIntervalMs: 22500, windowBounds: interrupted.windowBounds});
+
+        expect(aggregate.nominalWindowMs).toBe(3600000);
+        expect(aggregate.trailingUnavailableMs).toBe(3577500);
+        expect(aggregate.coverageRatio).toBeCloseTo(22500 / 3600000, 10);
+
+        expect(resolveWindowLifecycle(1000, 3600000, 3601000)).toEqual({
+            interrupted : false,
+            observedEndMs: 3601000,
+            windowBounds : {endMs: 3601000, startMs: 1000}
+        });
+
+        // a final sample may complete after the nominal deadline; this is still a fulfilled
+        // requested window, with the actual stop retained separately for provenance
+        expect(resolveWindowLifecycle(1000, 3600000, 3601250)).toEqual({
+            interrupted : false,
+            observedEndMs: 3601250,
+            windowBounds : {endMs: 3601000, startMs: 1000}
+        });
+
+        expect(() => resolveWindowLifecycle(1000, 0, 1000)).toThrow('positive window');
+        expect(() => resolveWindowLifecycle(1000, 1000, 999)).toThrow('finite start/end')
     });
 
     test('port extraction handles explicit ports, protocol defaults, and garbage', () => {


### PR DESCRIPTION
Resolves #15020

Interrupted serving-cost measurements now preserve the window the operator actually requested. A pure `resolveWindowLifecycle()` helper keeps nominal bounds fixed at `startedAt + windowMs`, records the real stop separately as `observedEndMs`, and marks early termination with `interrupted: true`. Aggregation therefore treats the unobserved tail as unavailable coverage instead of emitting a deceptively complete short interval under a `rolling-window-1h` identity. Naturally completed and slightly over-deadline runs retain the requested bounds and report `interrupted: false`.

Evidence: L2 (focused deterministic unit execution of early-stop, exact-completion, over-deadline, validation, and requested-window aggregation semantics) → L2 required (boundary behavior without a wall-clock-duration test). Residual: none.

## Deltas from ticket

None substantive. The implementation makes the requested-versus-observed distinction an exported clock-free helper so both CLI metadata and downstream coverage semantics share one unit-pinned boundary.

## Architectural Shape

- The CLI entrypoint remains the wall-clock owner and samples `Date.now()` only when the loop ends.
- `resolveWindowLifecycle()` derives requested bounds and additive lifecycle metadata without reading a clock.
- `aggregateWindow()` remains unchanged and receives the original requested bounds, preserving its pure ownership boundary.
- Report compatibility is additive: `interrupted` and `observedEndMs` join the existing `windowMs` and `windowBounds` fields.
- No automatic metric ingestion, pricing claim, or long-running hardware measurement enters this correction.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/servingCostCore.spec.mjs` — 10/10 passed on exact head.
- Coverage pins an interrupted one-hour request at a 22.5-second observed stop, verifies 3,577,500ms trailing unavailability and the corresponding coverage ratio, and separately pins exact and slightly-late natural completion.
- `npm run agent-preflight -- --no-fix ai/scripts/benchmark/serving-cost-meter.mjs test/playwright/unit/ai/scripts/servingCostCore.spec.mjs` — all requested gates passed.
- `git diff --check origin/dev...HEAD` — passed.
- Publication freshness: one ticketed commit, direct parent current `origin/dev`, no unrelated branch history.

## Post-Merge Validation

- [ ] Optional merged-`dev` smoke: interrupt a short throwaway meter run and confirm the report keeps its requested nominal bounds while recording the earlier observed stop. No acceptance residual is deferred.

Related: #15014
Related: #15013
Related: #14687

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session 019f484c-662f-7f31-969a-cbde373efd4a.
