### PR TITLE
feat(dashboard): scale changed-topology slot assignment (#14945)

### DIFF
--- a/src/dashboard/DockTopologyReconciler.mjs
+++ b/src/dashboard/DockTopologyReconciler.mjs
@@ -3,6 +3,254 @@ import DockRestorePlanner from './DockRestorePlanner.mjs';
 import DockZoneModel      from './DockZoneModel.mjs';
 
 /**
+ * @summary Reduces an exact assignment-score fraction to its canonical form.
+ *
+ * The assignment solver keeps overlap evidence as integer ratios. This avoids scalar
+ * weights and floating-point epsilons changing the ordered objective at dense scale.
+ * @param {BigInt|Number} numerator
+ * @param {BigInt|Number} [denominator=1]
+ * @returns {{denominator: BigInt, numerator: BigInt}}
+ * @private
+ */
+function createFraction(numerator, denominator=1) {
+    numerator   = BigInt(numerator);
+    denominator = BigInt(denominator);
+
+    if (denominator === 0n) {
+        throw new Error('Dock topology assignment fraction denominator must be non-zero')
+    }
+
+    if (denominator < 0n) {
+        numerator   = -numerator;
+        denominator = -denominator
+    }
+
+    let a = numerator < 0n ? -numerator : numerator,
+        b = denominator;
+
+    while (b !== 0n) {
+        [a, b] = [b, a % b]
+    }
+
+    let divisor = a || 1n;
+
+    return {denominator: denominator / divisor, numerator: numerator / divisor}
+}
+
+/**
+ * @summary Adds two exact assignment-score fractions.
+ * @param {{denominator: BigInt, numerator: BigInt}} a
+ * @param {{denominator: BigInt, numerator: BigInt}} b
+ * @returns {{denominator: BigInt, numerator: BigInt}}
+ * @private
+ */
+function addFractions(a, b) {
+    return createFraction(
+        a.numerator * b.denominator + b.numerator * a.denominator,
+        a.denominator * b.denominator
+    )
+}
+
+/**
+ * @summary Compares two exact assignment-score fractions.
+ * @param {{denominator: BigInt, numerator: BigInt}} a
+ * @param {{denominator: BigInt, numerator: BigInt}} b
+ * @returns {Number} `-1`, `0`, or `1`
+ * @private
+ */
+function compareFractions(a, b) {
+    let delta = a.numerator * b.denominator - b.numerator * a.denominator;
+
+    return delta < 0n ? -1 : delta > 0n ? 1 : 0
+}
+
+/**
+ * @summary Creates the additive identity for one lexicographic assignment path.
+ * @param {Number} coordinateCount Captured-slot count
+ * @returns {Object}
+ * @private
+ */
+function createZeroCost(coordinateCount) {
+    return {
+        jaccard   : createFraction(0),
+        structural: createFraction(0),
+        signature : Array(coordinateCount).fill(0n),
+        sequence  : Array(coordinateCount).fill(0n)
+    }
+}
+
+/**
+ * @summary Adds two lexicographic assignment-path costs.
+ * @param {Object} a
+ * @param {Object} b
+ * @returns {Object}
+ * @private
+ */
+function addCosts(a, b) {
+    return {
+        jaccard   : addFractions(a.jaccard, b.jaccard),
+        structural: addFractions(a.structural, b.structural),
+        signature : a.signature.map((value, index) => value + b.signature[index]),
+        sequence  : a.sequence.map((value, index) => value + b.sequence[index])
+    }
+}
+
+/**
+ * @summary Negates a lexicographic path cost for a residual reverse edge.
+ * @param {Object} cost
+ * @returns {Object}
+ * @private
+ */
+function negateCost(cost) {
+    return {
+        jaccard   : {denominator: cost.jaccard.denominator, numerator: -cost.jaccard.numerator},
+        structural: {denominator: cost.structural.denominator, numerator: -cost.structural.numerator},
+        signature : cost.signature.map(value => -value),
+        sequence  : cost.sequence.map(value => -value)
+    }
+}
+
+/**
+ * @summary Compares assignment costs in the contract's exact ordered objective.
+ *
+ * Costs are minimized, so affinity fractions enter negated. Content-signature and
+ * live-index coordinates remain ascending, one coordinate per captured slot.
+ * @param {Object} a
+ * @param {Object} b
+ * @returns {Number} `-1`, `0`, or `1`
+ * @private
+ */
+function compareCosts(a, b) {
+    let result = compareFractions(a.jaccard, b.jaccard)
+              || compareFractions(a.structural, b.structural);
+
+    if (result) return result;
+
+    for (let index = 0; index < a.signature.length; index++) {
+        if (a.signature[index] !== b.signature[index]) {
+            return a.signature[index] < b.signature[index] ? -1 : 1
+        }
+    }
+
+    for (let index = 0; index < a.sequence.length; index++) {
+        if (a.sequence[index] !== b.sequence[index]) {
+            return a.sequence[index] < b.sequence[index] ? -1 : 1
+        }
+    }
+
+    return 0
+}
+
+/**
+ * @summary Adds one unit-capacity edge and its exact inverse to a residual graph.
+ * @param {Object[][]} graph
+ * @param {Number} from
+ * @param {Number} to
+ * @param {Object} cost
+ * @param {Object|null} [pair=null] Assignment metadata for captured-to-live edges
+ * @returns {Object} The forward edge
+ * @private
+ */
+function addResidualEdge(graph, from, to, cost, pair=null) {
+    let forward = {capacity: 1, cost, pair, reverseIndex: graph[to].length, to},
+        reverse = {capacity: 0, cost: negateCost(cost), pair: null, reverseIndex: graph[from].length, to: from};
+
+    graph[from].push(forward);
+    graph[to].push(reverse);
+
+    return forward
+}
+
+/**
+ * @summary Finds the cheapest residual augmenting path under the ordered objective.
+ *
+ * Bellman-Ford is intentional: reverse edges are negative and let later flow units repair
+ * earlier pairings. The residual invariant therefore yields a globally optimal matching at
+ * every attained cardinality, while avoiding any unsafe scalarization.
+ * @param {Object[][]} graph
+ * @param {Number} source
+ * @param {Number} coordinateCount
+ * @returns {Object[]} Predecessor edge per graph node
+ * @private
+ */
+function findShortestResidualPath(graph, source, coordinateCount) {
+    let distance = Array(graph.length).fill(null),
+        previous = Array(graph.length).fill(null);
+
+    distance[source] = createZeroCost(coordinateCount);
+
+    for (let pass = 0; pass < graph.length - 1; pass++) {
+        let changed = false;
+
+        graph.forEach((edges, from) => {
+            if (!distance[from]) return;
+
+            edges.forEach((edge, edgeIndex) => {
+                if (edge.capacity === 0) return;
+
+                let candidate = addCosts(distance[from], edge.cost);
+
+                if (!distance[edge.to] || compareCosts(candidate, distance[edge.to]) < 0) {
+                    distance[edge.to] = candidate;
+                    previous[edge.to] = {edgeIndex, from};
+                    changed           = true
+                }
+            })
+        });
+
+        if (!changed) break
+    }
+
+    return previous
+}
+
+/**
+ * @summary Computes numeric affinity plus exact ratios from the same integer evidence.
+ * @param {Object} captured
+ * @param {Object} live
+ * @returns {{affinity: Object, jaccardFraction: Object, structuralFraction: Object}}
+ * @private
+ */
+function createAffinityDetails(captured, live) {
+    const typeCounts = document => {
+        let counts = {};
+
+        Object.values(document?.nodes || {}).forEach(node => {
+            counts[node.type] = (counts[node.type] || 0) + 1
+        });
+
+        return counts
+    };
+
+    let capturedIds     = Object.keys(captured?.items || {}),
+        liveIds         = new Set(Object.keys(live?.items || {})),
+        overlap         = capturedIds.filter(id => liveIds.has(id)).length,
+        itemUnion       = capturedIds.length + liveIds.size - overlap,
+        capturedTypes   = typeCounts(captured),
+        liveTypes       = typeCounts(live),
+        types           = new Set([...Object.keys(capturedTypes), ...Object.keys(liveTypes)]),
+        structuralInter = 0,
+        structuralUnion = 0;
+
+    types.forEach(type => {
+        structuralInter += Math.min(capturedTypes[type] || 0, liveTypes[type] || 0);
+        structuralUnion += Math.max(capturedTypes[type] || 0, liveTypes[type] || 0)
+    });
+
+    let jaccardFraction    = createFraction(overlap, itemUnion || 1),
+        structuralFraction = createFraction(structuralInter, structuralUnion || 1);
+
+    return {
+        affinity: {
+            jaccard   : Number(jaccardFraction.numerator) / Number(jaccardFraction.denominator),
+            structural: Number(structuralFraction.numerator) / Number(structuralFraction.denominator)
+        },
+        jaccardFraction,
+        structuralFraction
+    }
+}
+
+/**
  * @summary Changed-topology perspective restore: assigns captured workspace slots onto live
  * windows by id-free shape affinity (optimal assignment, never greedy order), composes the landed
  * per-window restore, and reports everything it cannot cover — nothing silently drops, in either
@@ -120,15 +368,7 @@ class DockTopologyReconciler extends Base {
      * @static
      */
     static slotAffinity(captured, live) {
-        let capturedIds = Object.keys(captured?.items || {}),
-            liveIds     = new Set(Object.keys(live?.items || {})),
-            overlap     = capturedIds.filter(id => liveIds.has(id)).length,
-            union       = capturedIds.length + liveIds.size - overlap;
-
-        return {
-            jaccard   : union === 0 ? 0 : overlap / union,
-            structural: this.structuralAffinity(captured, live)
-        }
+        return createAffinityDetails(captured, live).affinity
     }
 
     /**
@@ -155,38 +395,24 @@ class DockTopologyReconciler extends Base {
      * @static
      */
     static structuralAffinity(captured, live) {
-        const counts = document => {
-            let map = {};
-            Object.values(document?.nodes || {}).forEach(node => {
-                map[node.type] = (map[node.type] || 0) + 1
-            });
-            return map
-        };
-
-        let a     = counts(captured),
-            b     = counts(live),
-            types = new Set([...Object.keys(a), ...Object.keys(b)]),
-            inter = 0,
-            union = 0;
-
-        types.forEach(type => {
-            inter += Math.min(a[type] || 0, b[type] || 0);
-            union += Math.max(a[type] || 0, b[type] || 0)
-        });
-
-        return union === 0 ? 0 : inter / union
+        return createAffinityDetails(captured, live).affinity.structural
     }
 
     /**
-     * Optimal deterministic slot assignment: exhaustive search over the (small — window-count-
-     * bounded) pairing space, maximizing `(cardinality, Σ jaccard, Σ structural)`, then the
-     * lexicographically smallest CONTENT signature (`capturedIndex>liveContentKey` per pair) —
-     * permutation-stable: equal-affinity candidates with different content resolve to the SAME
-     * content under any live array order. Only fully content-identical candidates fall through
-     * to the smallest live-index sequence, where the pick is content-irrelevant by construction.
-     * A pair requires Jaccard > 0. Greedy captured-order matching is explicitly NOT used — it
-     * can strand a slot whose only viable window was consumed by an earlier slot's marginally
-     * better match (the greedy trap; spec-pinned).
+     * Optimal deterministic slot assignment via exact lexicographic min-cost max-flow. Every
+     * positive-Jaccard pair becomes a unit-capacity captured→live edge. Successive shortest
+     * residual paths maximize cardinality, then minimize the additive cost vector
+     * `(-Σjaccard, -Σstructural, contentSignature, liveIndexSequence)`. Affinity components are
+     * reduced `BigInt` fractions; content and live-index tie coordinates use an explicit
+     * unassigned sentinel per captured row. This preserves content-permutation stability and
+     * makes the final content-identical tie numeric (`2 < 10`) instead of stringifying indices.
+     *
+     * With `C` captured slots, `L` live windows, `P ≤ C·L` viable pairs, `V=C+L+2`, and
+     * `F≤min(C,L)` assignments, Bellman-Ford successive-shortest-path runs in
+     * `O(F·V·(C+L+P)·C)` ordered-coordinate work (plus polynomial exact-integer arithmetic).
+     * Production never falls back to exhaustive traversal. Greedy captured-order matching is
+     * explicitly NOT used — it can strand a slot whose only viable window was consumed by an
+     * earlier slot's marginally better match (the greedy trap; spec-pinned).
      * @param {Object[]} capturedDocs
      * @param {Object[]} liveDocs
      * @returns {{mapping: Object[], unmapped: Object[], unmatchedLive: Number[]}}
@@ -195,48 +421,76 @@ class DockTopologyReconciler extends Base {
      * @static
      */
     static assignSlots(capturedDocs, liveDocs) {
-        let matrix      = capturedDocs.map(captured => liveDocs.map(live => this.slotAffinity(captured, live))),
-            contentKeys = liveDocs.map(live => this.liveContentKey(live)),
-            best        = null;
+        let matrix       = capturedDocs.map(captured => liveDocs.map(live => createAffinityDetails(captured, live))),
+            contentKeys  = liveDocs.map(live => this.liveContentKey(live)),
+            orderedKeys  = [...new Set(contentKeys)].sort(),
+            contentRanks = new Map(orderedKeys.map((key, index) => [key, index])),
+            capturedBase = 1,
+            liveBase     = capturedBase + capturedDocs.length,
+            source       = 0,
+            sink         = liveBase + liveDocs.length,
+            graph        = Array.from({length: sink + 1}, () => []),
+            pairEdges    = [];
 
-        const consider = (slotIndex, used, pairs, cardinality, jaccardSum, structuralSum) => {
-            if (slotIndex === capturedDocs.length) {
-                // Content first (permutation-stable), live-index sequence last (only reachable
-                // between fully content-identical candidates, where the pick is content-free).
-                let signature = pairs.map(pair => `${pair.capturedIndex}>${contentKeys[pair.liveIndex]}`).join('|'),
-                    sequence  = pairs.map(pair => pair.liveIndex).join(',');
+        capturedDocs.forEach((captured, capturedIndex) => {
+            addResidualEdge(graph, source, capturedBase + capturedIndex, createZeroCost(capturedDocs.length));
 
-                if (!best
-                    || cardinality > best.cardinality
-                    || (cardinality === best.cardinality && jaccardSum > best.jaccardSum)
-                    || (cardinality === best.cardinality && jaccardSum === best.jaccardSum && structuralSum > best.structuralSum)
-                    || (cardinality === best.cardinality && jaccardSum === best.jaccardSum && structuralSum === best.structuralSum && signature < best.signature)
-                    || (cardinality === best.cardinality && jaccardSum === best.jaccardSum && structuralSum === best.structuralSum && signature === best.signature && sequence < best.sequence)
-                ) {
-                    best = {cardinality, jaccardSum, pairs: [...pairs], sequence, signature, structuralSum}
-                }
-                return
-            }
+            matrix[capturedIndex].forEach((details, liveIndex) => {
+                if (details.jaccardFraction.numerator === 0n) return;
 
-            // Option A: leave this slot unassigned.
-            consider(slotIndex + 1, used, pairs, cardinality, jaccardSum, structuralSum);
+                let cost            = createZeroCost(capturedDocs.length),
+                    contentSentinel = orderedKeys.length,
+                    liveSentinel    = liveDocs.length;
 
-            // Option B: pair it with any unused positive-affinity window.
-            matrix[slotIndex].forEach((affinity, liveIndex) => {
-                if (affinity.jaccard > 0 && !used.has(liveIndex)) {
-                    used.add(liveIndex);
-                    pairs.push({affinity, capturedIndex: slotIndex, liveIndex});
-                    consider(slotIndex + 1, used, pairs, cardinality + 1, jaccardSum + affinity.jaccard, structuralSum + affinity.structural);
-                    pairs.pop();
-                    used.delete(liveIndex)
-                }
+                cost.jaccard = {
+                    denominator: details.jaccardFraction.denominator,
+                    numerator  : -details.jaccardFraction.numerator
+                };
+                cost.structural = {
+                    denominator: details.structuralFraction.denominator,
+                    numerator  : -details.structuralFraction.numerator
+                };
+                cost.signature[capturedIndex] = BigInt(contentRanks.get(contentKeys[liveIndex]) - contentSentinel);
+                cost.sequence[capturedIndex]  = BigInt(liveIndex - liveSentinel);
+
+                let pair = {affinity: details.affinity, capturedIndex, liveIndex};
+
+                pairEdges.push(addResidualEdge(
+                    graph,
+                    capturedBase + capturedIndex,
+                    liveBase + liveIndex,
+                    cost,
+                    pair
+                ))
             })
-        };
+        });
 
-        consider(0, new Set(), [], 0, 0, 0);
+        liveDocs.forEach((live, liveIndex) => {
+            addResidualEdge(graph, liveBase + liveIndex, sink, createZeroCost(capturedDocs.length))
+        });
 
-        let assigned = new Set(best.pairs.map(pair => pair.capturedIndex)),
-            usedLive = new Set(best.pairs.map(pair => pair.liveIndex)),
+        // Each successful augmentation raises cardinality by one. Reverse edges let the path
+        // re-route previous pairs, so stopping only when the sink is unreachable yields maximum
+        // cardinality and the exact minimum ordered cost at that cardinality.
+        while (true) {
+            let previous = findShortestResidualPath(graph, source, capturedDocs.length);
+
+            if (!previous[sink]) break;
+
+            for (let node = sink; node !== source;) {
+                let {edgeIndex, from} = previous[node],
+                    edge              = graph[from][edgeIndex];
+
+                edge.capacity = 0;
+                graph[node][edge.reverseIndex].capacity = 1;
+                node = from
+            }
+        }
+
+        let pairs = pairEdges.filter(edge => edge.capacity === 0).map(edge => edge.pair)
+                .sort((a, b) => a.capturedIndex - b.capturedIndex),
+            assigned = new Set(pairs.map(pair => pair.capturedIndex)),
+            usedLive = new Set(pairs.map(pair => pair.liveIndex)),
             unmapped = [];
 
         capturedDocs.forEach((doc, capturedIndex) => {
@@ -244,7 +498,7 @@ class DockTopologyReconciler extends Base {
                 // Cardinality-first optimality guarantees: a slot with positive affinity to a
                 // STILL-FREE window would have been assigned — so an unassigned slot either had
                 // zero affinity everywhere, or every viable window went to a better match.
-                let hadAffinity = matrix[capturedIndex].some(affinity => affinity.jaccard > 0);
+                let hadAffinity = matrix[capturedIndex].some(details => details.jaccardFraction.numerator > 0n);
 
                 unmapped.push({
                     capturedIndex,
@@ -254,7 +508,7 @@ class DockTopologyReconciler extends Base {
         });
 
         return {
-            mapping      : best.pairs.sort((a, b) => a.capturedIndex - b.capturedIndex),
+            mapping      : pairs,
             unmapped,
             unmatchedLive: liveDocs.map((doc, index) => index).filter(index => !usedLive.has(index))
         }

--- a/test/playwright/unit/dashboard/DockTopologyReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTopologyReconciler.spec.mjs
@@ -22,6 +22,153 @@ const tabsDoc = ids => ({
     }
 });
 
+// Pure assignment fixtures deliberately omit the persisted-layout envelope. `assignSlots()`
+// owns only item/type affinity, so these isolate the solver from restore/executor behavior.
+const assignmentDoc = (ids, types=['tabs']) => ({
+    items: Object.fromEntries(ids.map(id => [id, {}])),
+    nodes: Object.fromEntries(types.map((type, index) => [`n${index}`, {type}]))
+});
+
+/**
+ * @summary Independent test-only affinity implementation for the exhaustive oracle.
+ * @param {Object} captured
+ * @param {Object} live
+ * @returns {{jaccard: Number, structural: Number}}
+ */
+const oracleAffinity = (captured, live) => {
+    const counts = document => {
+        let result = {};
+
+        Object.values(document?.nodes || {}).forEach(node => {
+            result[node.type] = (result[node.type] || 0) + 1
+        });
+
+        return result
+    };
+
+    let capturedIds = Object.keys(captured?.items || {}),
+        liveIds     = new Set(Object.keys(live?.items || {})),
+        overlap     = capturedIds.filter(id => liveIds.has(id)).length,
+        itemUnion   = capturedIds.length + liveIds.size - overlap,
+        a           = counts(captured),
+        b           = counts(live),
+        types       = new Set([...Object.keys(a), ...Object.keys(b)]),
+        inter       = 0,
+        union       = 0;
+
+    types.forEach(type => {
+        inter += Math.min(a[type] || 0, b[type] || 0);
+        union += Math.max(a[type] || 0, b[type] || 0)
+    });
+
+    return {
+        jaccard   : itemUnion === 0 ? 0 : overlap / itemUnion,
+        structural: union === 0 ? 0 : inter / union
+    }
+};
+
+/**
+ * @summary Independent test-only content key for deterministic tie comparison.
+ * @param {Object} document
+ * @returns {String}
+ */
+const oracleContentKey = document => {
+    let items = Object.keys(document?.items || {}).sort().join(','),
+        types = Object.values(document?.nodes || {}).map(node => node.type).sort().join(',');
+
+    return `${items}#${types}`
+};
+
+/**
+ * @summary Frozen bounded exhaustive oracle for assignment-result equivalence.
+ *
+ * This is the retired production search copied into the spec, with independent affinity and
+ * content-key primitives. It is intentionally exponential and therefore used only at arity ≤ 6.
+ * @param {Object[]} capturedDocs
+ * @param {Object[]} liveDocs
+ * @returns {{mapping: Object[], unmapped: Object[], unmatchedLive: Number[]}}
+ */
+const exhaustiveAssignmentOracle = (capturedDocs, liveDocs) => {
+    let matrix      = capturedDocs.map(captured => liveDocs.map(live => oracleAffinity(captured, live))),
+        contentKeys = liveDocs.map(oracleContentKey),
+        best        = null;
+
+    const consider = (slotIndex, used, pairs, cardinality, jaccardSum, structuralSum) => {
+        if (slotIndex === capturedDocs.length) {
+            let signature = pairs.map(pair => `${pair.capturedIndex}>${contentKeys[pair.liveIndex]}`).join('|'),
+                sequence  = pairs.map(pair => pair.liveIndex).join(',');
+
+            if (!best
+                || cardinality > best.cardinality
+                || (cardinality === best.cardinality && jaccardSum > best.jaccardSum)
+                || (cardinality === best.cardinality && jaccardSum === best.jaccardSum && structuralSum > best.structuralSum)
+                || (cardinality === best.cardinality && jaccardSum === best.jaccardSum && structuralSum === best.structuralSum && signature < best.signature)
+                || (cardinality === best.cardinality && jaccardSum === best.jaccardSum && structuralSum === best.structuralSum && signature === best.signature && sequence < best.sequence)
+            ) {
+                best = {cardinality, jaccardSum, pairs: [...pairs], sequence, signature, structuralSum}
+            }
+            return
+        }
+
+        consider(slotIndex + 1, used, pairs, cardinality, jaccardSum, structuralSum);
+
+        matrix[slotIndex].forEach((affinity, liveIndex) => {
+            if (affinity.jaccard > 0 && !used.has(liveIndex)) {
+                used.add(liveIndex);
+                pairs.push({affinity, capturedIndex: slotIndex, liveIndex});
+                consider(slotIndex + 1, used, pairs, cardinality + 1,
+                    jaccardSum + affinity.jaccard, structuralSum + affinity.structural);
+                pairs.pop();
+                used.delete(liveIndex)
+            }
+        })
+    };
+
+    consider(0, new Set(), [], 0, 0, 0);
+
+    let assigned = new Set(best.pairs.map(pair => pair.capturedIndex)),
+        usedLive = new Set(best.pairs.map(pair => pair.liveIndex));
+
+    return {
+        mapping : best.pairs.sort((a, b) => a.capturedIndex - b.capturedIndex),
+        unmapped: capturedDocs.flatMap((doc, capturedIndex) => {
+            if (assigned.has(capturedIndex)) return [];
+
+            return [{
+                capturedIndex,
+                reason: matrix[capturedIndex].some(affinity => affinity.jaccard > 0)
+                    ? DockTopologyReconciler.REASON_NO_LIVE_WINDOW
+                    : DockTopologyReconciler.REASON_UNMAPPED_SLOT
+            }]
+        }),
+        unmatchedLive: liveDocs.map((doc, index) => index).filter(index => !usedLive.has(index))
+    }
+};
+
+/**
+ * @summary Creates a deterministic pseudo-random stream for reproducible property coverage.
+ * @param {Number} seed
+ * @returns {Function}
+ */
+const seededRandom = seed => () => {
+    seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+    return seed / 0x100000000
+};
+
+/**
+ * @summary Builds one bounded random assignment document.
+ * @param {Function} random
+ * @param {Number} salt
+ * @returns {Object}
+ */
+const randomAssignmentDoc = (random, salt) => {
+    let ids   = Array.from({length: 7}, (item, index) => `item-${index}`).filter(() => random() < 0.42),
+        types = Array.from({length: 1 + Math.floor(random() * 3)}, (item, index) =>
+            ['tabs', 'split-horizontal', 'split-vertical'][(index + salt + Math.floor(random() * 3)) % 3]);
+
+    return assignmentDoc(ids, types)
+};
+
 // Fixtures ride the REAL landed producer — hand-rolled envelopes only appear in the negative
 // cases that deliberately break the envelope contract.
 const capture = docs => {
@@ -45,6 +192,108 @@ const expectConservation = (saved, result) => {
 };
 
 test.describe('Neo.dashboard.DockTopologyReconciler', () => {
+    test('polynomial solver is output-equivalent to the bounded exhaustive oracle on seeded rectangular matrices', () => {
+        for (let seed = 1; seed <= 96; seed++) {
+            let random        = seededRandom(seed),
+                capturedCount = Math.floor(random() * 7),
+                liveCount     = Math.floor(random() * 7),
+                captured      = Array.from({length: capturedCount}, (item, index) =>
+                    randomAssignmentDoc(random, index)),
+                live          = Array.from({length: liveCount}, (item, index) =>
+                    randomAssignmentDoc(random, index + capturedCount));
+
+            expect(
+                DockTopologyReconciler.assignSlots(captured, live),
+                `seed=${seed}, captured=${capturedCount}, live=${liveCount}`
+            ).toEqual(exhaustiveAssignmentOracle(captured, live))
+        }
+    });
+
+    test('objective order keeps structural affinity above content and uses numeric live-index ties at 10+', () => {
+        let captured = [assignmentDoc(['shared'], ['tabs', 'split-horizontal'])],
+            live     = [
+                assignmentDoc(['shared', 'alpha'], ['tabs']),
+                assignmentDoc(['shared', 'zeta'],  ['tabs', 'split-horizontal'])
+            ],
+            result   = DockTopologyReconciler.assignSlots(captured, live);
+
+        // Jaccard ties at 1/2. The structurally exact (but lexically later) window wins.
+        expect(result.mapping).toEqual([
+            expect.objectContaining({capturedIndex: 0, liveIndex: 1})
+        ]);
+
+        live = Array.from({length: 12}, (item, index) => assignmentDoc([`other-${index}`]));
+        live[2]  = assignmentDoc(['shared']);
+        live[10] = assignmentDoc(['shared']);
+        result   = DockTopologyReconciler.assignSlots([assignmentDoc(['shared'])], live);
+
+        // Both viable documents are content-identical. The old string sequence made "10" < "2";
+        // the contract says live-index order, so the exact solver intentionally chooses numeric 2.
+        expect(result.mapping).toEqual([
+            expect.objectContaining({capturedIndex: 0, liveIndex: 2})
+        ])
+    });
+
+    test('captured/live permutations preserve the content-canonical optimum when slot identity is content-derived', () => {
+        let captured = [
+                assignmentDoc(['a', 'b'], ['tabs']),
+                assignmentDoc(['c', 'd'], ['split-horizontal']),
+                assignmentDoc(['e', 'f'], ['split-vertical'])
+            ],
+            live = [
+                assignmentDoc(['a', 'b', 'x'], ['tabs']),
+                assignmentDoc(['c', 'd', 'y'], ['split-horizontal']),
+                assignmentDoc(['e', 'f', 'z'], ['split-vertical'])
+            ];
+
+        const canonicalPairs = (capturedDocs, liveDocs) => DockTopologyReconciler
+            .assignSlots(capturedDocs, liveDocs).mapping
+            .map(({capturedIndex, liveIndex}) => [
+                oracleContentKey(capturedDocs[capturedIndex]),
+                oracleContentKey(liveDocs[liveIndex])
+            ])
+            .sort((a, b) => a[0].localeCompare(b[0]));
+
+        expect(canonicalPairs(captured, live)).toEqual(canonicalPairs([...captured].reverse(), [...live].reverse()))
+    });
+
+    test('dense 8×8 / 9×9 / 12×12 matrices complete with full unique assignment', () => {
+        [8, 9, 12].forEach(size => {
+            let shared   = Array.from({length: size}, (item, index) => `shared-${index}`),
+                captured = Array.from({length: size}, (item, index) =>
+                    assignmentDoc([...shared, `captured-${index}`], ['tabs', `shape-${index % 3}`])),
+                live     = Array.from({length: size}, (item, index) =>
+                    assignmentDoc([`shared-${index}`, `live-${index}`], ['tabs', `shape-${index % 3}`])),
+                samples  = [],
+                result;
+
+            // One unrecorded warmup, then a deterministic fixture / fixed-run-count sample.
+            // Output is evidence, never a hardware-sensitive merge gate.
+            DockTopologyReconciler.assignSlots(captured, live);
+
+            for (let run = 0; run < 5; run++) {
+                let startedAt = performance.now();
+
+                result = DockTopologyReconciler.assignSlots(captured, live);
+                samples.push(performance.now() - startedAt)
+            }
+
+            samples.sort((a, b) => a - b);
+            console.log('[dock-topology-assignment]', JSON.stringify({
+                mapped  : result.mapping.length,
+                medianMs: Math.round(samples[2] * 1000) / 1000,
+                runsMs  : samples.map(value => Math.round(value * 1000) / 1000),
+                size
+            }));
+
+            expect(result.mapping).toHaveLength(size);
+            expect(new Set(result.mapping.map(pair => pair.capturedIndex)).size).toBe(size);
+            expect(new Set(result.mapping.map(pair => pair.liveIndex)).size).toBe(size);
+            expect(result.unmapped).toEqual([]);
+            expect(result.unmatchedLive).toEqual([])
+        })
+    });
+
     test('shrunk topology: best-coverage assignment + reason-classed remainder + conservation', () => {
         let saved = capture([
                 tabsDoc(['alpha', 'beta']),


### PR DESCRIPTION
Resolves #14945

Replaces the factorial changed-topology slot search with exact lexicographic min-cost max-flow. The production solver now reaches maximum cardinality through residual augmenting paths, preserves summed Jaccard and structural affinity with reduced `BigInt` fractions, and keeps content-canonical plus numeric live-index tie ordering without changing the public reconciliation result shape. Demo B and Neural Link continue through the same `DockTopologyReconciler.assignSlots()` path; there is no exhaustive production fallback or consumer-specific bypass.

Evidence: L2 (focused executable unit contract, bounded exhaustive-oracle equivalence, residual-reroute coverage, and deterministic dense runtime probe) → L2 required (all close-target ACs are pure Body-side algorithm and consumer-path contracts). No residuals.

Decision Record impact: aligned-with ADR 0029 §2.2.

Related: #13158
Refs #14668

## Deltas from ticket

- Uses an additive lexicographic cost vector instead of unsafe scalar weights or epsilon comparisons. Worst-case ordered-coordinate work is documented as `O(F·V·(C+L+P)·C)` plus polynomial exact-integer arithmetic.
- Corrects one inherited edge-case artifact: the retired solver compared comma-joined live indices as strings, making `10 < 2`. The contract says live-index order, so content-identical ties are now numeric.
- Keeps the reproducible 8×8 / 9×9 / 12×12 benchmark inside the focused unit spec instead of adding a standalone production-adjacent benchmark module. It emits measurements but deliberately has no hardware-fragile time threshold.

## Test Evidence

- `NEO_CHROMA_PORT_TEST=19153 NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/dashboard/DockTopologyReconciler.spec.mjs --workers=1` — 17/17 passed.
- 96 deterministic rectangular matrices at arity 0–6 match an independent frozen exhaustive oracle across the complete `{mapping, unmapped, unmatchedLive}` result.
- Existing greedy-trap, permutation, conservation, fail-closed, reason-class, pass-through, uniqueness, and no-window-creation coverage remains green.
- Final dense medians on the author machine: 8×8 = 0.947 ms; 9×9 = 2.543 ms; 12×12 = 2.595 ms. The issue records the retired 9×9 baseline at approximately 5.4 s; these figures are evidence, not CI thresholds.
- `node buildScripts/util/check-block-alignment.mjs src/dashboard/DockTopologyReconciler.mjs test/playwright/unit/dashboard/DockTopologyReconciler.spec.mjs` — passed.
- `npm run agent-preflight -- --no-fix src/dashboard/DockTopologyReconciler.mjs test/playwright/unit/dashboard/DockTopologyReconciler.spec.mjs` — passed.
- `git diff --check` and both `node --check` probes passed.

## Post-Merge Validation

- [ ] Observe the next routine Demo B G4 and Neural Link topology-restore runs on `dev`; both consumers should retain their existing result vocabulary while using the scaled solver.

## Evolution

The first implementation sketch treated the old comma-joined sequence as a literal oracle. An explicit 12-window falsifier exposed that it was string ordering, not the documented numeric live-index fallback. The bounded oracle remains frozen for small-matrix regression equivalence, while the 10+ test pins the corrected authority.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex). Session de713f27-0e82-4960-b4c6-f281e0c36449.
