### PR TITLE
feat(agentos): ActivityStream density re-freeze — 12-row window, 200-event ring, same-actor coalescing (#14606)

### DIFF
--- a/apps/agentos/view/fleet/ActivityStream.mjs
+++ b/apps/agentos/view/fleet/ActivityStream.mjs
@@ -111,8 +111,11 @@ class ActivityStream extends Container {
         /**
          * The held-event ring bound: a payload longer than this keeps its NEWEST `bufferSize`
          * events (drop-oldest), and the drop is counted into the fold — the feed's memory can
-         * never grow unbounded, and a drop is never silent. 200 holds ~55 minutes of the worst
-         * measured burst (~3.6 events/min p95).
+         * never grow unbounded, and a drop is never silent. Reactive INCLUDING the held payload:
+         * a runtime shrink re-bounds the events already held (their drop joins the fold count); a
+         * grow widens the bound for the next payload only. Positive integers only — an invalid
+         * bound is refused, never a disabled ring. 200 holds ~55 minutes of the worst measured
+         * burst (~3.6 events/min p95).
          * @member {Number} bufferSize_=200
          * @reactive
          */
@@ -150,9 +153,10 @@ class ActivityStream extends Container {
     }
 
     /**
-     * Events the ring dropped from the LAST accepted payload (payload length minus `bufferSize`).
-     * Folded into the "N earlier events" count so a ring drop is never silent. Replace semantics:
-     * each payload replaces the feed, so the count describes the current payload, not a lifetime.
+     * Events the ring dropped from the CURRENT payload: the intake drop (payload length minus
+     * `bufferSize`) plus any later runtime-shrink drops on the same payload — cumulative within
+     * the payload, RESET by the next `events` assignment. Folded into the "N earlier events"
+     * count so no drop is ever silent.
      * @member {Number} droppedCount=0
      * @protected
      */
@@ -178,12 +182,31 @@ class ActivityStream extends Container {
     }
 
     /**
+     * @summary The reactive half of the ring contract: a runtime SHRINK re-bounds the already-held
+     * events (drop-oldest, silently via the raw backing store — no beforeSet re-entry, which would
+     * reset the payload's drop accounting) and ADDS the shrink's drop to {@link #droppedCount}, so
+     * the fold stays honest about everything gone from the current payload. A grow only widens the
+     * bound for the NEXT payload — dropped events are gone, never resurrected.
      * @param {Number} value
      * @param {Number} oldValue
      * @protected
      */
     afterSetBufferSize(value, oldValue) {
-        this.isConstructed && this.refreshFeed()
+        let me = this;
+
+        if (!me.isConstructed) {
+            return
+        }
+
+        const held   = me._events || [],
+              excess = Math.max(0, held.length - value);
+
+        if (excess > 0) {
+            me.droppedCount += excess;
+            me._events = held.slice(-value)   // silent raw update: re-bound without re-entering beforeSetEvents
+        }
+
+        me.refreshFeed()
     }
 
     /**
@@ -211,6 +234,20 @@ class ActivityStream extends Container {
      */
     afterSetMaxVisible(value, oldValue) {
         this.isConstructed && this.refreshFeed()
+    }
+
+    /**
+     * @summary Guard the ring bound itself: only a positive integer can BE a buffer bound — zero,
+     * negatives, and non-finite values would silently disable the ring (`slice(-0)` retains
+     * everything), so an invalid value is refused and the previous bound (or the density default)
+     * stays in force.
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @returns {Number}
+     * @protected
+     */
+    beforeSetBufferSize(value, oldValue) {
+        return Number.isInteger(value) && value > 0 ? value : (oldValue ?? 200)
     }
 
     /**

--- a/apps/agentos/view/fleet/ActivityStream.mjs
+++ b/apps/agentos/view/fleet/ActivityStream.mjs
@@ -23,16 +23,66 @@ export function boundActivity(events, maxVisible) {
 }
 
 /**
+ * @summary Coalesce same-actor event RUNS into grouped rows — the measured-density consequence:
+ * a sustained burst (above ~2 events/min from one actor) rendered one-row-per-event floods the
+ * window with repetition and pushes every OTHER actor out of view. Consecutive events from the
+ * SAME `agentId` whose timestamps sit closer than `gapMs` join one row carrying the run's count
+ * and its newest event. Honesty bounds the grouping: an event with no/invalid timestamp, an
+ * anonymous event (no `agentId`), or an out-of-order timestamp can never PROVE run membership,
+ * so each renders as its own row and breaks the run — grouping only what is evidenced. Pure +
+ * serializable, so the rule is unit-provable in isolation.
+ * @param {Object[]} events Chronological (oldest→newest) activity events.
+ * @param {Number} gapMs Max gap between consecutive same-actor events to count as one run.
+ * @returns {Object[]} Chronological rows: `{agentId, count, events: Object[], newest: Object}`.
+ */
+export function coalesceActivity(events, gapMs) {
+    const list = Array.isArray(events) ? events : [],
+          gap  = Number.isFinite(gapMs) && gapMs > 0 ? gapMs : 0,
+          rows = [];
+
+    let lastRow  = null,
+        lastTime = NaN;
+
+    list.forEach(event => {
+        const agentId = event?.agentId ?? null,
+              time    = Date.parse(event?.occurredAt);
+
+        const joinsRun = lastRow !== null && agentId !== null && lastRow.agentId === agentId
+            && Number.isFinite(time) && Number.isFinite(lastTime)
+            && time - lastTime >= 0 && time - lastTime < gap;
+
+        if (joinsRun) {
+            lastRow.count++;
+            lastRow.events.push(event);
+            lastRow.newest = event
+        } else {
+            lastRow = {agentId, count: 1, events: [event], newest: event};
+            rows.push(lastRow)
+        }
+
+        // an unprovable timestamp breaks the run for the NEXT event too — a follower cannot
+        // evidence its gap against a row whose newest time is unknown
+        lastTime = time
+    });
+
+    return rows
+}
+
+/**
  * @summary The fleet cockpit's live activity feed — a bounded, backpressure-aware stream of A2A / PR /
  * lane events. Composes {@link EventChip} for the kind chip (kind rendering delegates ENTIRELY to it —
  * this view passes the event's type straight through and holds zero local kind logic; unknown types
- * degrade to EventChip's neutral chip), timestamps each row, and caps the rendered window at
- * `maxVisible` with an honest "N more" fold so a burst can never grow the DOM unbounded or silently
- * drop. On adapter loss it degrades honestly — a stale banner, never a frozen feed. Event application
- * rides the normal data->VDom flow; no manual DOM.
+ * degrade to EventChip's neutral chip) and timestamps each row. On adapter loss it degrades honestly —
+ * a stale banner, never a frozen feed. Event application rides the normal data->VDom flow; no manual DOM.
  *
- * The live-adapter binding and the NL-verified live mount are sibling leaves; this leaf is the component
- * + its bounded-buffer contract, unit-provable against a burst fixture.
+ * Three bounds hold the feed honest under measured burst pressure, each frozen from live density
+ * evidence (sustained 0.5–1 events/min on a sprint day, ~3.6/min p95 burst):
+ * 1. **The ring** — `bufferSize` (200 ≈ 55min of the worst recorded burst) caps the HELD events;
+ *    an overlong payload drops oldest-first and the drop is COUNTED, never silent.
+ * 2. **Coalescing** — same-actor runs above ~2/min ({@link module:apps/agentos/view/fleet/ActivityStream~coalesceActivity})
+ *    group into one row carrying the run count, so one busy actor cannot flood every other off the glass.
+ * 3. **The window** — the newest `maxVisible` rows render; everything older folds into the honest
+ *    "N earlier events" line (N counts EVENTS — folded rows' runs plus ring drops — never rows).
  *
  * @class AgentOS.view.fleet.ActivityStream
  * @extends Neo.container.Base
@@ -59,17 +109,36 @@ class ActivityStream extends Container {
          */
         layout: {ntype: 'vbox', align: 'stretch'},
         /**
-         * Chronological (oldest->newest) activity events; the feed renders the newest `maxVisible`.
+         * The held-event ring bound: a payload longer than this keeps its NEWEST `bufferSize`
+         * events (drop-oldest), and the drop is counted into the fold — the feed's memory can
+         * never grow unbounded, and a drop is never silent. 200 holds ~55 minutes of the worst
+         * measured burst (~3.6 events/min p95).
+         * @member {Number} bufferSize_=200
+         * @reactive
+         */
+        bufferSize_: 200,
+        /**
+         * The same-actor coalescing threshold: consecutive events from one `agentId` closer than
+         * this join one grouped row (~2/min — the measured rate above which one actor's run
+         * floods the window). See {@link module:apps/agentos/view/fleet/ActivityStream~coalesceActivity}.
+         * @member {Number} coalesceGapMs_=30000
+         * @reactive
+         */
+        coalesceGapMs_: 30000,
+        /**
+         * Chronological (oldest->newest) activity events; capped to the newest `bufferSize` on
+         * the way in, then coalesced + windowed for render.
          * @member {Object[]} events_=[]
          * @reactive
          */
         events_: [],
         /**
-         * The render-window bound — the density-derived cap (default 15) beyond which events fold.
-         * @member {Number} maxVisible_=15
+         * The render-window bound — the density-frozen visible ROW cap (10–12 measured; 12)
+         * beyond which rows fold.
+         * @member {Number} maxVisible_=12
          * @reactive
          */
-        maxVisible_: 15,
+        maxVisible_: 12,
         /**
          * Feed liveness — `live` streams; `sample` labels a representative (source-not-wired) feed so it
          * is never mistaken for live; `stale` renders the degrade banner (adapter loss). None of the
@@ -81,6 +150,15 @@ class ActivityStream extends Container {
     }
 
     /**
+     * Events the ring dropped from the LAST accepted payload (payload length minus `bufferSize`).
+     * Folded into the "N earlier events" count so a ring drop is never silent. Replace semantics:
+     * each payload replaces the feed, so the count describes the current payload, not a lifetime.
+     * @member {Number} droppedCount=0
+     * @protected
+     */
+    droppedCount = 0
+
+    /**
      * @summary Build the feed once constructed — the items are data-derived, so the initial render
      * happens here rather than through static config.
      * @param {...*} args
@@ -88,6 +166,33 @@ class ActivityStream extends Container {
     onConstructed(...args) {
         super.onConstructed(...args);
         this.refreshFeed()
+    }
+
+    /**
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetAdapterState(value, oldValue) {
+        this.isConstructed && this.refreshFeed()
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetBufferSize(value, oldValue) {
+        this.isConstructed && this.refreshFeed()
+    }
+
+    /**
+     * @param {Number} value
+     * @param {Number} oldValue
+     * @protected
+     */
+    afterSetCoalesceGapMs(value, oldValue) {
+        this.isConstructed && this.refreshFeed()
     }
 
     /**
@@ -109,29 +214,44 @@ class ActivityStream extends Container {
     }
 
     /**
-     * @param {String} value
-     * @param {String} oldValue
+     * @summary The ring: an incoming payload keeps only its NEWEST `bufferSize` events
+     * (drop-oldest), and the drop count lands in {@link #droppedCount} for the fold — the feed's
+     * held memory is bounded by construction, and a drop is surfaced, never silent.
+     * @param {Object[]} value
+     * @param {Object[]} oldValue
+     * @returns {Object[]}
      * @protected
      */
-    afterSetAdapterState(value, oldValue) {
-        this.isConstructed && this.refreshFeed()
+    beforeSetEvents(value, oldValue) {
+        const list  = Array.isArray(value) ? value : [],
+              bound = this.bufferSize;
+
+        this.droppedCount = Math.max(0, list.length - bound);
+
+        return this.droppedCount > 0 ? list.slice(-bound) : list
     }
 
     /**
-     * @summary Rebuild the bounded feed: the liveness header, the newest `maxVisible` event rows, and
-     * the "N more" fold when the burst exceeds the window. Bounded by construction — the rendered child
-     * count never exceeds the window + header + fold, regardless of event volume.
+     * @summary Rebuild the bounded feed: the liveness header, the newest `maxVisible` rows (each a
+     * single event or a coalesced same-actor run), and the "N earlier events" fold whenever events
+     * sit beyond the glass — folded rows' runs plus anything the ring dropped. Bounded by
+     * construction — the rendered child count never exceeds the window + header + fold, regardless
+     * of event volume, and the fold counts EVENTS (the honest unit), never rows.
      */
     refreshFeed() {
-        const {visible, overflowCount} = boundActivity(this.events, this.maxVisible),
-              items                    = [this.headerConfig(), ...visible.map(event => this.rowConfig(event))];
+        const me                       = this,
+              rows                     = coalesceActivity(me.events, me.coalesceGapMs),
+              {visible, overflowCount} = boundActivity(rows, me.maxVisible),
+              foldedEventCount         = rows.slice(0, overflowCount).reduce((count, row) => count + row.count, 0),
+              earlierCount             = foldedEventCount + me.droppedCount,
+              items                    = [me.headerConfig(), ...visible.map(row => me.rowConfig(row))];
 
-        if (overflowCount > 0) {
-            items.push(this.foldConfig(overflowCount))
+        if (earlierCount > 0) {
+            items.push(me.foldConfig(earlierCount))
         }
 
-        this.removeAll(true);
-        this.add(items)
+        me.removeAll(true);
+        me.add(items)
     }
 
     /**
@@ -158,37 +278,43 @@ class ActivityStream extends Container {
     }
 
     /**
-     * @summary One event row: timestamp, the kind chip (EventChip), and the text. The chip's kind is the
-     * event's type passed straight through — EventChip + the kind registry own the kind->visual mapping,
-     * so this row holds no kind logic and an unknown type degrades to the neutral chip.
-     * @param {Object} event
+     * @summary One feed row from a coalesced row descriptor: timestamp, the kind chip (EventChip),
+     * and the text — the row's NEWEST event carries all three. The chip's kind is that event's type
+     * passed straight through — EventChip + the kind registry own the kind->visual mapping, so this
+     * row holds no kind logic and an unknown type degrades to the neutral chip. A run (count > 1)
+     * renders as ONE grouped row: the `×N` prefix carries the run count, the newest event the text.
+     * @param {Object} row A `coalesceActivity` row: `{agentId, count, events, newest}`.
      * @returns {Object}
      */
-    rowConfig(event) {
+    rowConfig(row) {
+        const event     = row.newest,
+              coalesced = row.count > 1;
+
         return {
             module: Container,
-            cls   : ['fm-ev-row'],
+            cls   : coalesced ? ['fm-ev-row', 'fm-ev-coalesced'] : ['fm-ev-row'],
             flex  : 'none',
             layout: {ntype: 'hbox', align: 'start'},
             items : [
                 {module: Component, cls: ['fm-ev-time'], flex: 'none', text: this.formatTime(event?.occurredAt)},
                 {module: EventChip, flex: 'none', kind: event?.type},
-                {module: Component, cls: ['fm-ev-text'], flex: 1, text: this.eventText(event)}
+                {module: Component, cls: ['fm-ev-text'], flex: 1, text: coalesced ? `×${row.count} · ${this.eventText(event)}` : this.eventText(event)}
             ]
         }
     }
 
     /**
-     * @summary The overflow fold — the honest count of events beyond the window (never a silent drop).
-     * @param {Number} overflowCount
+     * @summary The overflow fold — the honest count of EVENTS beyond the glass: the folded rows'
+     * runs plus anything the ring dropped (never a silent drop, never a row count posing as one).
+     * @param {Number} earlierCount
      * @returns {Object}
      */
-    foldConfig(overflowCount) {
+    foldConfig(earlierCount) {
         return {
             module: Component,
             cls   : ['fm-stream-fold'],
             flex  : 'none',
-            text  : `${overflowCount} more`
+            text  : `${earlierCount} earlier events`
         }
     }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -23,12 +23,12 @@ import '../../../../src/tab/Container.mjs'; // registers the `tab-container` nty
  * @type {Object[]}
  */
 const FIXTURE_ACTIVITY = [
-    {type: 'a2a-activity',    agentId: 'neo-opus-vega', occurredAt: '2026-07-05T10:52:00.000Z', payload: {text: 'Vega → AGENT:* [lane-claim] harness-UI shell + nav'}},
-    {type: 'review-activity', agentId: 'neo-opus-vega', occurredAt: '2026-07-05T10:26:00.000Z', payload: {text: 'Vega → APPROVED — transaction archive Architectural Pillar'}},
-    {type: 'pr-activity',     agentId: 'neo-gpt',       occurredAt: '2026-07-05T10:11:00.000Z', payload: {text: 'Euclid opened a PR — roadmap cornerstone-4 hygiene'}},
-    {type: 'pr-activity',     agentId: 'neo-opus-vega', occurredAt: '2026-07-05T09:40:00.000Z', payload: {text: 'Vega merged — FM fleet grid + health bar'}},
+    {type: 'lane-activity',   agentId: 'neo-fable-clio',occurredAt: '2026-07-05T07:15:00.000Z', payload: {text: 'Clio → CrossWindowDragTarget docking, awaiting cross-family'}},
     {type: 'a2a-activity',    agentId: 'neo-opus-ada',  occurredAt: '2026-07-05T08:30:00.000Z', payload: {text: 'Ada → control-plane restart actuator merged'}},
-    {type: 'lane-activity',   agentId: 'neo-fable-clio',occurredAt: '2026-07-05T07:15:00.000Z', payload: {text: 'Clio → CrossWindowDragTarget docking, awaiting cross-family'}}
+    {type: 'pr-activity',     agentId: 'neo-opus-vega', occurredAt: '2026-07-05T09:40:00.000Z', payload: {text: 'Vega merged — FM fleet grid + health bar'}},
+    {type: 'pr-activity',     agentId: 'neo-gpt',       occurredAt: '2026-07-05T10:11:00.000Z', payload: {text: 'Euclid opened a PR — roadmap cornerstone-4 hygiene'}},
+    {type: 'review-activity', agentId: 'neo-opus-vega', occurredAt: '2026-07-05T10:26:00.000Z', payload: {text: 'Vega → APPROVED — transaction archive Architectural Pillar'}},
+    {type: 'a2a-activity',    agentId: 'neo-opus-vega', occurredAt: '2026-07-05T10:52:00.000Z', payload: {text: 'Vega → AGENT:* [lane-claim] harness-UI shell + nav'}}
 ];
 
 /**

--- a/resources/scss/src/apps/agentos/fleet/ActivityStream.scss
+++ b/resources/scss/src/apps/agentos/fleet/ActivityStream.scss
@@ -1,5 +1,6 @@
-/* Activity stream — a liveness header over bounded event rows (time · kind chip · text) plus the
-   "N more" fold, all scoped under the component root. Rail-toned; every color from the token layer. */
+/* Activity stream — a liveness header over bounded event rows (time · kind chip · text; a coalesced
+   same-actor run reads slightly stronger) plus the "N earlier events" fold, all scoped under the
+   component root. Rail-toned; every color from the token layer. */
 .fm-activity-stream {
     padding   : 12px 14px;
     background: var(--fm-rail);
@@ -49,6 +50,12 @@
         overflow     : hidden;
         white-space  : nowrap;
         text-overflow: ellipsis;
+    }
+
+    /* a coalesced same-actor run — the ×N text carries the count; the row reads slightly
+       stronger so a burst is glanceable without flooding the window */
+    .fm-ev-coalesced .fm-ev-text {
+        font-weight: 600;
     }
 
     .fm-stream-fold {

--- a/test/playwright/unit/apps/agentos/view/fleet/activityStream.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/activityStream.spec.mjs
@@ -151,6 +151,41 @@ test.describe('Fleet cockpit ActivityStream — bounded, backpressure-aware feed
         stream.destroy()
     });
 
+    test('reactive ring: a runtime SHRINK re-bounds the HELD events with cumulative honest drop accounting; an invalid bound is refused', () => {
+        const stream = Neo.create(ActivityStream, {appName, events: makeEvents(250)});
+
+        // intake: 250 → 200 held / 50 dropped / 12 rows / 238 folded+dropped events
+        expect(stream.events.length).toBe(200);
+        expect(stream.droppedCount).toBe(50);
+        expect(rows(stream).length).toBe(12);
+        expect(fold(stream).text).toBe('238 earlier events');
+
+        // the falsifier: shrinking the bound must re-bound the ALREADY-HELD payload — the ring is
+        // reactive for real, not a render-only claim
+        stream.bufferSize = 10;
+        expect(stream.events.length).toBe(10);
+        // drop accounting is cumulative within the payload: 50 intake + 190 shrink = 240 of the
+        // original 250 are gone, and the fold says so (10 held ≤ 12-row window → nothing folded)
+        expect(stream.droppedCount).toBe(240);
+        expect(rows(stream).length).toBe(10);
+        expect(fold(stream).text).toBe('240 earlier events');
+
+        // zero/negative/non-finite bounds would DISABLE the ring (slice(-0) keeps everything) —
+        // refused: the previous bound and the held events stay exactly as they were
+        for (const bad of [0, -5, NaN, Infinity, 2.5]) {
+            stream.bufferSize = bad;
+            expect(stream.bufferSize).toBe(10);
+            expect(stream.events.length).toBe(10)
+        }
+
+        // a fresh payload RESETS the accounting (replace semantics) against the shrunk bound
+        stream.events = makeEvents(25);
+        expect(stream.events.length).toBe(10);
+        expect(stream.droppedCount).toBe(15);
+
+        stream.destroy()
+    });
+
     test('kind rendering delegates entirely to EventChip — unknown types still render a chip (neutral path)', () => {
         const stream = Neo.create(ActivityStream, {
             appName,

--- a/test/playwright/unit/apps/agentos/view/fleet/activityStream.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/activityStream.spec.mjs
@@ -18,7 +18,7 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
 import Instance       from '../../../../../../../src/manager/Instance.mjs';
 
 test.describe('Fleet cockpit ActivityStream — bounded, backpressure-aware feed (#14606)', () => {
-    let ActivityStream, boundActivity;
+    let ActivityStream, boundActivity, coalesceActivity;
 
     const makeEvents = n => Array.from({length: n}, (_, i) => ({
         type      : 'a2a-activity',
@@ -34,8 +34,9 @@ test.describe('Fleet cockpit ActivityStream — bounded, backpressure-aware feed
 
     test.beforeAll(async () => {
         const mod = await import('../../../../../../../apps/agentos/view/fleet/ActivityStream.mjs');
-        ActivityStream = mod.default;
-        boundActivity  = mod.boundActivity
+        ActivityStream   = mod.default;
+        boundActivity    = mod.boundActivity;
+        coalesceActivity = mod.coalesceActivity
     });
 
     test('boundActivity is the pure backpressure core — bound holds, overflow counted, newest-first', () => {
@@ -56,14 +57,96 @@ test.describe('Fleet cockpit ActivityStream — bounded, backpressure-aware feed
         expect(boundActivity(makeEvents(5), 0)).toEqual({visible: [], overflowCount: 5})
     });
 
-    test('the component bounds the rendered DOM under a 100-event burst + renders the "N more" fold', () => {
+    test('the component bounds the rendered DOM under a 100-event burst + renders the "N earlier events" fold', () => {
         const stream = Neo.create(ActivityStream, {appName, maxVisible: 15, events: makeEvents(100)});
 
         // bounded: the rendered event rows never exceed the window regardless of event volume
         expect(rows(stream).length).toBe(15);
-        // honest overflow: the fold surfaces the folded count — never a silent drop
+        // honest overflow: the fold surfaces the folded EVENT count — never a silent drop
         expect(fold(stream)).toBeTruthy();
-        expect(fold(stream).text).toBe('85 more');
+        expect(fold(stream).text).toBe('85 earlier events');
+
+        stream.destroy()
+    });
+
+    test('density re-freeze: coalesceActivity groups only PROVEN same-actor runs — the pure rule', () => {
+        const at = seconds => `2026-07-04T10:00:${String(seconds).padStart(2, '0')}.000Z`;
+
+        // a >2/min same-actor run (10s gaps) groups into ONE row carrying the count + newest event
+        const run = coalesceActivity([
+            {type: 'a2a-activity', agentId: 'vega', occurredAt: at(0),  payload: {text: 'one'}},
+            {type: 'a2a-activity', agentId: 'vega', occurredAt: at(10), payload: {text: 'two'}},
+            {type: 'pr-activity',  agentId: 'vega', occurredAt: at(20), payload: {text: 'three'}}
+        ], 30000);
+        expect(run.length).toBe(1);
+        expect(run[0]).toMatchObject({agentId: 'vega', count: 3});
+        expect(run[0].newest.payload.text).toBe('three');
+
+        // a gap AT the threshold (30s = exactly 2/min) splits — coalescing is strictly-above-rate
+        expect(coalesceActivity([
+            {agentId: 'vega', occurredAt: at(0)},
+            {agentId: 'vega', occurredAt: at(30)}
+        ], 30000).length).toBe(2);
+
+        // distinct actors never group, however tight the timestamps
+        expect(coalesceActivity([
+            {agentId: 'vega', occurredAt: at(0)},
+            {agentId: 'ada',  occurredAt: at(1)}
+        ], 30000).length).toBe(2);
+
+        // unprovable membership never groups: a missing timestamp breaks the run on BOTH sides,
+        // and anonymous events (no agentId) each stand alone
+        expect(coalesceActivity([
+            {agentId: 'vega', occurredAt: at(0)},
+            {agentId: 'vega'},
+            {agentId: 'vega', occurredAt: at(2)}
+        ], 30000).length).toBe(3);
+        expect(coalesceActivity([
+            {occurredAt: at(0)},
+            {occurredAt: at(1)}
+        ], 30000).length).toBe(2);
+
+        // non-array input degrades to an empty row set
+        expect(coalesceActivity(null, 30000)).toEqual([])
+    });
+
+    test('density re-freeze: a same-actor burst renders as ONE grouped ×N row — one busy actor cannot flood the window', () => {
+        const burst = Array.from({length: 5}, (_, i) => ({
+            type      : 'a2a-activity',
+            agentId   : 'neo-opus-vega',
+            occurredAt: `2026-07-04T10:00:${String(i * 10).padStart(2, '0')}.000Z`,
+            payload   : {text: `vega burst ${i}`}
+        }));
+
+        const stream = Neo.create(ActivityStream, {appName, events: [
+            ...burst,
+            {type: 'review-activity', agentId: 'neo-gpt', occurredAt: '2026-07-04T10:05:00.000Z', payload: {text: 'euclid single'}}
+        ]});
+
+        // 6 events → 2 rows: the run coalesced + the single (newest-first: the single leads)
+        expect(rows(stream).length).toBe(2);
+
+        const [single, grouped] = rows(stream);
+        expect(single.cls).not.toContain('fm-ev-coalesced');
+        expect(single.items.find(item => item.cls.includes('fm-ev-text')).text).toBe('euclid single');
+
+        // the grouped row: ×N carries the run count, the NEWEST event carries text + chip kind
+        expect(grouped.cls).toContain('fm-ev-coalesced');
+        expect(grouped.items.find(item => item.cls.includes('fm-ev-text')).text).toBe('×5 · vega burst 4');
+
+        stream.destroy()
+    });
+
+    test('density re-freeze: the 200-event ring drops oldest COUNTED, and the default window is 12 rows', () => {
+        const stream = Neo.create(ActivityStream, {appName, events: makeEvents(500)});
+
+        // the ring: the held events are capped at bufferSize (200) — memory bounded by construction
+        expect(stream.events.length).toBe(200);
+        // the window: density-frozen 12 rows by default
+        expect(rows(stream).length).toBe(12);
+        // the fold counts EVENTS beyond the glass: 188 folded rows (distinct actors → 1 event each)
+        // + 300 ring-dropped = 488 — a drop is surfaced, never silent
+        expect(fold(stream).text).toBe('488 earlier events');
 
         stream.destroy()
     });


### PR DESCRIPTION
Resolves #15037

Related: #14606 (the origin ticket — **stays OPEN**, re-scoped to the liveness contract per the cycle-1 review: production activity-source composition, recurring refresh ownership, and a behavior-witnessing live-mount proof) · epic #14560 (parent of both) · #14592 (the density evidence — every bound cites a measured figure) · #14831/PR #14827 (the merged component slice this re-freezes) · #14607 (the burst e2e sibling that will drive these bounds)

**The density contract, split honest (review-corrected close target).** Cycle 1 established that density and liveness are separate contracts: this PR is the density leaf (#15037, split from #14606), and the liveness ACs stay open on #14606 — `FleetControlBridge.activitySource` is production-`null`, `loadActivity()` runs once at construction, and the mounted e2e witnesses presence only, so no close claim can ride those seams yet.

The three measured bounds (sustained 0.5–1 events/min on a sprint day; ~3.6/min p95 burst):
1. **The ring** — `bufferSize` (200 ≈ 55min of the worst recorded burst) caps the HELD events in `beforeSetEvents`, drop-oldest with the drop COUNTED into the fold. **Reactive including the held payload**: a runtime shrink re-bounds the already-held events through the raw backing store and ADDS the excess to the payload's drop accounting (cumulative within the payload, reset by the next assignment); non-positive/non-integer bounds are refused — `slice(-0)` must never silently disable the ring.
2. **Coalescing** — pure `coalesceActivity(events, gapMs)` groups only PROVEN same-actor >2/min runs (gap < 30s) into ONE `×N` grouped row carrying the run's newest event. Honesty bounds the grouping: missing/out-of-order timestamps and anonymous events can't prove run membership, so each stands alone.
3. **The window** — `maxVisible` 15 → 12 rows (the evidence froze 10–12), and the fold becomes the honest **"N earlier events"** line — counting EVENTS (folded rows' runs + ring drops), never rows.

Plus the sample-order fix the visual pass surfaced: `FIXTURE_ACTIVITY` was ordered against its own oldest→newest contract, rendering the sample feed upside-down.

Evidence: L2 (unit construct-probes) — `npx playwright test --config=<canonical unit config minus webServer> unit/apps/agentos/view/fleet/activityStream.spec.mjs unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs --workers=1` → the authored stream suite **10/10 passed** (cycle 1 counted 10 where the suite held 9 — corrected; it holds 10 now with the ring falsifier) and both cockpit consumer suites regression-clean, at head `09d2247d7`.

## Deltas from ticket

- #15037 IS this PR's contract (authored from it); the deltas live against origin #14606: its density numbers (visible ≈ 15, "virtualization + fold") predate the #14592 evidence — superseded by the 12-row/200-ring/coalescing freeze. No virtualization below measured scale: ring + window keep the DOM ≤ header + 12 rows + fold at ANY event volume.
- `coalesceGapMs` and `bufferSize` are reactive configs so #14607's burst e2e can drive the bounds without touching the component — and the ring's reactivity is now falsifier-proven, not claimed.

## Test Evidence

- `activityStream.spec.mjs` 10/10 green — the coalescing rule matrix (run groups with count+newest; threshold-exact splits; distinct actors never group; unprovable membership stands alone; non-array degrades), the grouped `×5` render beside an un-grouped single, the 500-event ring test (200 held / 12 default rows / fold `488 earlier events`), and the reviewer's exact falsifiers: 250 → 200/50/`238 earlier events`; `bufferSize = 10` → **10 held / 240 dropped / `240 earlier events`**; five invalid bounds refused with held events untouched; fresh-payload accounting reset.
- `fleetCockpit.spec.mjs` + `fleetCockpitProjection.spec.mjs` regression-clean (owner-held `streamEvents` re-materialization unchanged).
- Pre-commit gates green (whitespace, shorthand, jsdoc-types, archaeology, block-alignment, aiconfig-test-mutation).

## Post-Merge Validation

- [ ] #15037 closes on merge; #14606 remains open, scoped to the liveness contract (its 2026-07-05 scope-correction comment + the cycle-1 review findings are the AC authority).
- [ ] #14607 (burst e2e) drives ≥3.6/min against THESE bounds — my assigned next leaf.

## Commits

- 09d2247d7 — the reactive-ring correction: bound guard (`beforeSetBufferSize`), shrink re-bounds held events with cumulative drop accounting, the reviewer's exact falsifiers as a spec (2 files, +78/−6).
- fc411505a — the sample-fixture order fix (oldest→newest, as its own comment promises).
- f0f12ba4c — the density re-freeze: `coalesceActivity` + ring + window + fold wording + token-layer coalesced style + specs (3 files, +258/−42).

Authored by Vega (Claude Fable 5, Claude Code). Session d2fbbdb4-404b-47e1-bbb3-1b9e0330894b.
