### PR TITLE
fix(agent-os): centralize AgentIdentity node-id canonicalization (#15027)

### DIFF
--- a/ai/daemons/kb-alerting/KbAlertingService.mjs
+++ b/ai/daemons/kb-alerting/KbAlertingService.mjs
@@ -8,7 +8,7 @@ import KBRecorderService              from '../../services/knowledge-base/KBReco
 import MailboxService                 from '../../services/memory-core/MailboxService.mjs';
 import RequestContextService          from '../../mcp/server/shared/services/RequestContextService.mjs';
 import logger                         from '../../mcp/server/knowledge-base/logger.mjs';
-import {normalizeAgentIdentityNodeId} from '../../scripts/lifecycle/resumeHarness.mjs';
+import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
 import {
     evaluateAlertRules,
     formatAlertMessage

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -26,7 +26,7 @@ import memoryCoreConfig                                                         
 import MailboxService                                                                               from '../../services/memory-core/MailboxService.mjs';
 import WakeSubscriptionService                                                                      from '../../services/memory-core/WakeSubscriptionService.mjs';
 import RequestContextService                                                                        from '../../mcp/server/shared/services/RequestContextService.mjs';
-import {normalizeAgentIdentityNodeId}                                                               from '../../scripts/lifecycle/resumeHarness.mjs';
+import {normalizeAgentIdentityNodeId}                                                               from '../../graph/normalizeAgentIdentityNodeId.mjs';
 import TaskStateService                                                                             from './services/TaskStateService.mjs';
 import ProcessSupervisorService                                                                     from './services/ProcessSupervisorService.mjs';
 import DeploymentRuntimeAccessService                                                               from './services/DeploymentRuntimeAccessService.mjs';
@@ -199,12 +199,12 @@ export class Orchestrator extends Base {
         dataDir_                        : null,
         // Same contract as dataDir_: the singleton is constructed during module import, so a
         // class-field leaf read would still be a module-load capture.
-        dbPath_                         : null,
-        taskDefinitions_                : null,
-        taskStateService_               : TaskStateService,
-        healthService_                  : HealthService,
-        spawnFn_                        : spawn,
-        heavyMaintenanceLeasePath_      : null
+        dbPath_                   : null,
+        taskDefinitions_          : null,
+        taskStateService_         : TaskStateService,
+        healthService_            : HealthService,
+        spawnFn_                  : spawn,
+        heavyMaintenanceLeasePath_: null
     }
 
     primaryRepoSyncService   = PrimaryRepoSyncService

--- a/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
+++ b/ai/daemons/orchestrator/scheduling/swarmHeartbeat.mjs
@@ -1,5 +1,5 @@
 import {IDENTITIES}                   from '../../../graph/identityRoots.mjs';
-import {normalizeAgentIdentityNodeId} from '../../../scripts/lifecycle/resumeHarness.mjs';
+import {normalizeAgentIdentityNodeId} from '../../../graph/normalizeAgentIdentityNodeId.mjs';
 
 /**
  * Valid `targetSource` enum values for `resolveTargets`. Exported so
@@ -191,8 +191,8 @@ export async function resolveTargets({
                 return selfFallback('active-subscribers-missing-provider');
             }
             const subscribers = (await activeSubscribersProvider()) || [];
-            const seen = new Set();
-            const out  = [];
+            const seen        = new Set();
+            const out         = [];
             if (normalizedSelf) {
                 seen.add(normalizedSelf);
                 out.push(normalizedSelf);
@@ -219,8 +219,8 @@ export async function resolveTargets({
                 return selfFallback('active-a2a-participants-missing-provider');
             }
             const participants = (await activeA2aParticipantsProvider()) || [];
-            const seen = new Set();
-            const out  = [];
+            const seen         = new Set();
+            const out          = [];
             if (normalizedSelf) {
                 seen.add(normalizedSelf);
                 out.push(normalizedSelf);

--- a/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
+++ b/ai/daemons/orchestrator/services/SwarmHeartbeatService.mjs
@@ -13,9 +13,9 @@ import {
     Memory_LifecycleService as LifecycleService
 }                    from '../../../services.mjs';
 import {getWakeRelevantNotifications} from '../../../services/github-workflow/HealthService.mjs';
-import MailboxService from '../../../services/memory-core/MailboxService.mjs';
-import RequestContextService from '../../../mcp/server/shared/services/RequestContextService.mjs';
-import logger        from '../../../mcp/server/memory-core/logger.mjs';
+import MailboxService                 from '../../../services/memory-core/MailboxService.mjs';
+import RequestContextService          from '../../../mcp/server/shared/services/RequestContextService.mjs';
+import logger                         from '../../../mcp/server/memory-core/logger.mjs';
 import {
     isGateOpen,
     readGateState
@@ -25,16 +25,16 @@ import {
     releaseHeartbeatLock,
     HEARTBEAT_LOCK_PATH
 } from '../../../scripts/lifecycle/heartbeatLock.mjs';
-import {checkSunsetted as checkSunsettedScript}     from '../../../scripts/lifecycle/checkSunsetted.mjs';
+import {checkSunsetted as checkSunsettedScript} from '../../../scripts/lifecycle/checkSunsetted.mjs';
+import {normalizeAgentIdentityNodeId}           from '../../../graph/normalizeAgentIdentityNodeId.mjs';
 import {
-    normalizeAgentIdentityNodeId,
     resumeHarness as resumeHarnessScript
 } from '../../../scripts/lifecycle/resumeHarness.mjs';
-import {checkAllAgentIdle as checkAllAgentIdleScript} from '../../../scripts/lifecycle/checkAllAgentIdle.mjs';
-import {idleOutNudge as idleOutNudgeScript}         from '../../../scripts/lifecycle/idleOutNudge.mjs';
-import WakeSubscriptionService                       from '../../../services/memory-core/WakeSubscriptionService.mjs';
+import {checkAllAgentIdle as checkAllAgentIdleScript}     from '../../../scripts/lifecycle/checkAllAgentIdle.mjs';
+import {idleOutNudge as idleOutNudgeScript}               from '../../../scripts/lifecycle/idleOutNudge.mjs';
+import WakeSubscriptionService                            from '../../../services/memory-core/WakeSubscriptionService.mjs';
 import wakeDecisionServiceInstance, {WakeDecisionService} from './WakeDecisionService.mjs';
-import {swarmWakeCooldown as swarmWakeCooldownScript} from '../../../scripts/lifecycle/swarmWakeCooldown.mjs';
+import {swarmWakeCooldown as swarmWakeCooldownScript}     from '../../../scripts/lifecycle/swarmWakeCooldown.mjs';
 import {
     resolveTargets        as resolveHeartbeatTargets,
     VALID_TARGET_SOURCES
@@ -453,7 +453,7 @@ class SwarmHeartbeatService extends Base {
      */
     async touchLivenessFile() {
         const alivePath = heartbeatAlivePath();
-        const now = new Date();
+        const now       = new Date();
         try {
             await fs.utimes(alivePath, now, now)
         } catch (err) {
@@ -578,7 +578,7 @@ class SwarmHeartbeatService extends Base {
      */
     async getResumeHarnessTargetMetadata(identity) {
         return RequestContextService.run({agentIdentityNodeId: identity}, async () => {
-            const result = await WakeSubscriptionService.list({});
+            const result     = await WakeSubscriptionService.list({});
             const candidates = (result?.subscriptions || [])
                 .filter(subscription =>
                     subscription.trigger === 'SENT_TO_ME' &&
@@ -691,10 +691,10 @@ class SwarmHeartbeatService extends Base {
      */
     async getActiveA2aParticipants() {
         try {
-            const cutoffMs   = Date.now() - 3 * 60 * 60 * 1000;
-            const cutoffIso  = new Date(cutoffMs).toISOString();
-            const db         = this.getGraphDb();
-            const stmt = db.prepare(`
+            const cutoffMs  = Date.now() - 3 * 60 * 60 * 1000;
+            const cutoffIso = new Date(cutoffMs).toISOString();
+            const db        = this.getGraphDb();
+            const stmt      = db.prepare(`
                 SELECT DISTINCT identity FROM (
                     SELECT e.target AS identity
                     FROM Edges e
@@ -741,7 +741,7 @@ class SwarmHeartbeatService extends Base {
      */
     async getWakeSubscriptionIdentities() {
         try {
-            const db = this.getGraphDb();
+            const db   = this.getGraphDb();
             const stmt = db.prepare(`
                 SELECT DISTINCT json_extract(data, '$.properties.agentIdentity') as identity
                 FROM Nodes
@@ -790,10 +790,10 @@ class SwarmHeartbeatService extends Base {
         const notifications = await this.getGitHubNotifications();
         if (notifications.length === 0) return;
 
-        const durableSeenIds = Array.isArray(state[targetIdentity]) ? state[targetIdentity] : [],
+        const durableSeenIds  = Array.isArray(state[targetIdentity]) ? state[targetIdentity] : [],
               volatileSeenIds = this.getVolatileGitHubNotificationSeenIds(targetIdentity),
-              seenIds = new Set([...durableSeenIds, ...volatileSeenIds]);
-        const unseen  = notifications.filter(notification => !seenIds.has(notification.id));
+              seenIds         = new Set([...durableSeenIds, ...volatileSeenIds]);
+        const unseen = notifications.filter(notification => !seenIds.has(notification.id));
         if (unseen.length === 0) return;
 
         const result = await WakeSubscriptionService.emitHeartbeatPulse({
@@ -903,7 +903,7 @@ class SwarmHeartbeatService extends Base {
      */
     async getGitHubNotifications() {
         try {
-            const output = await this.runCmd('gh', ['api', 'notifications?participating=true']);
+            const output        = await this.runCmd('gh', ['api', 'notifications?participating=true']);
             const notifications = getWakeRelevantNotifications(JSON.parse(output || '[]'));
             return await this.enrichGitHubNotificationsWithPullRequestState(notifications)
         } catch (err) {
@@ -1013,7 +1013,7 @@ class SwarmHeartbeatService extends Base {
      */
     async getUnreadCount() {
         try {
-            const db = this.getGraphDb();
+            const db   = this.getGraphDb();
             const stmt = db.prepare(`
                 WITH unread_messages AS (
                     SELECT n.id AS messageId
@@ -1084,7 +1084,7 @@ class SwarmHeartbeatService extends Base {
      */
     async isPushCapable(identity) {
         try {
-            const db = this.getGraphDb();
+            const db   = this.getGraphDb();
             const stmt = db.prepare(`
                 SELECT count(*) as count
                 FROM Nodes
@@ -1161,9 +1161,9 @@ class SwarmHeartbeatService extends Base {
         try {
             return await RequestContextService.run({agentIdentityNodeId: identity}, async () => {
                 const result = await MailboxService.listMessages({
-                    to            : identity,
-                    taggedConcepts: ['wake-readiness'],
-                    limit         : 20,
+                    to             : identity,
+                    taggedConcepts : ['wake-readiness'],
+                    limit          : 20,
                     includeArchived: false
                 });
                 return result?.messages || [];
@@ -1235,9 +1235,9 @@ class SwarmHeartbeatService extends Base {
      */
     runCmd(command, args = []) {
         return new Promise((resolve, reject) => {
-            const child = spawn(command, args, {stdio: ['ignore', 'pipe', 'pipe']});
-            let stdout = '';
-            let stderr = '';
+            const child  = spawn(command, args, {stdio: ['ignore', 'pipe', 'pipe']});
+            let   stdout = '';
+            let   stderr = '';
             child.stdout.on('data', chunk => { stdout += chunk.toString() });
             child.stderr.on('data', chunk => { stderr += chunk.toString() });
             child.on('error', reject);

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -56,9 +56,9 @@ import {
     isHarnessPresenceFresh
 } from './queries.mjs';
 import {
-    applyHarnessMetadataDefaults,
-    normalizeAgentIdentityNodeId
+    applyHarnessMetadataDefaults
 } from '../../scripts/lifecycle/harnessRouting.mjs';
+import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
 import {
     getDefaultInstancePid,
     resolveGuiInstancePid

--- a/ai/graph/normalizeAgentIdentityNodeId.mjs
+++ b/ai/graph/normalizeAgentIdentityNodeId.mjs
@@ -1,0 +1,27 @@
+/**
+ * @module Neo.ai.graph.normalizeAgentIdentityNodeId
+ * @summary Canonicalizes direct AgentIdentity graph-node identifiers without absorbing
+ * mailbox-specific addressing grammar.
+ */
+
+/**
+ * @summary Normalizes a direct AgentIdentity identifier to the canonical `@<identity>` graph-node form.
+ *
+ * String inputs are trimmed, a missing `@` is added, and redundant leading `@` characters collapse
+ * to one. Namespace-bearing values such as `AGENT:*`, `role:*`, and `human:*` are returned unchanged:
+ * those are addressing schemes, not direct AgentIdentity node ids, and remain owned by their service
+ * layer. Non-string inputs pass through unchanged so this primitive never invents an identity by
+ * stringifying an unrelated value.
+ *
+ * @param {*} identity Candidate direct AgentIdentity id or bare identity handle.
+ * @returns {*} Canonical direct AgentIdentity id, unchanged addressing scheme, or unchanged non-string.
+ */
+export function normalizeAgentIdentityNodeId(identity) {
+    if (typeof identity !== 'string') return identity;
+
+    const value = identity.trim();
+    if (!value || value.includes(':')) return value;
+
+    const bareIdentity = value.replace(/^@+/, '');
+    return bareIdentity ? `@${bareIdentity}` : '@';
+}

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -28,9 +28,10 @@ import {
     createMessageGraphProjectionProcessor,
     startMessageDrainLoop
 } from '../../../daemons/message/drainCycle.mjs';
-import {acquireMessageDrainLock}    from '../../../daemons/message/drainLock.mjs';
-import {getMissingMessageWalLeaves} from '../../../services/memory-core/helpers/messageWalStore.mjs';
-import {TRUST_TIERS}                from '../../../graph/identityRoots.mjs';
+import {acquireMessageDrainLock}      from '../../../daemons/message/drainLock.mjs';
+import {getMissingMessageWalLeaves}   from '../../../services/memory-core/helpers/messageWalStore.mjs';
+import {TRUST_TIERS}                  from '../../../graph/identityRoots.mjs';
+import {normalizeAgentIdentityNodeId} from '../../../graph/normalizeAgentIdentityNodeId.mjs';
 
 // Security invariant, not deployment policy: graph ids must remain namespace/path/control safe.
 const AUTH_IDENTITY_USER_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,254}$/;
@@ -531,7 +532,7 @@ class Server extends BaseServer {
      */
     async ensureAgentIdentityForAuthContext(reqAuth) {
         const userId      = this.validateAuthProvisionUserId(reqAuth?.userId),
-              graphNodeId = `@${userId}`;
+              graphNodeId = normalizeAgentIdentityNodeId(userId);
 
         try {
             await GraphService.ready();
@@ -616,8 +617,8 @@ class Server extends BaseServer {
     /**
      * @summary Resolves the active stdio agent identity and binds it to its AgentIdentity
      * graph node. Composes three steps: (1) `StdioIdentityResolver.resolve()` returns the
-     * GitHub identity via the env-var → gh-CLI chain; (2) `GraphService.getNode({id: '@' +
-     * githubLogin})` looks up the matching seeded AgentIdentity node; (3)
+     * GitHub identity via the env-var → gh-CLI chain; (2) the shared AgentIdentity node-id
+     * canonicalizer resolves the matching seeded graph node; (3)
      * the composite is shaped for `RequestContextService.run()` consumption.
      *
      * Missing graph node is non-fatal: the identity still flows as `userId` tag, but
@@ -663,7 +664,14 @@ class Server extends BaseServer {
     async bindAgentIdentity(userId) {
         if (!userId) return null;
 
-        const graphNodeId = '@' + userId;
+        const graphNodeId = normalizeAgentIdentityNodeId(userId);
+        if (
+            typeof graphNodeId !== 'string' ||
+            !graphNodeId.startsWith('@') ||
+            !AUTH_IDENTITY_USER_ID_RE.test(graphNodeId.slice(1))
+        ) {
+            return null;
+        }
 
         try {
             await GraphService.ready();
@@ -673,8 +681,12 @@ class Server extends BaseServer {
 
             while (retries > 0) {
                 node = await GraphService.getNode({id: graphNodeId});
-                if (node) {
+                if (node?.type === 'AgentIdentity') {
                     return node.id;
+                }
+                if (node) {
+                    logger.warn(`[neo-memory-core MCP] AgentIdentity graph lookup refused ${graphNodeId}: found ${node.type || 'unknown'} node`);
+                    return null;
                 }
 
                 if (GraphService.db && GraphService.db.vicinityLoadedNodes) {

--- a/ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs
+++ b/ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs
@@ -4,6 +4,7 @@ import {
     resolveMemoryCoreGraphPath,
     resolveTurnPresenceRuntimeConfig
 } from './TurnPresenceConfig.mjs';
+import {normalizeAgentIdentityNodeId} from '../../../../graph/normalizeAgentIdentityNodeId.mjs';
 
 const WAKE_SUBMIT_NONCE_PATTERN = /NEO_WAKE_SUBMIT_NONCE:([0-9a-fA-F-]{36})/;
 
@@ -158,13 +159,6 @@ async function writeTurnPresenceEvent({
     }
 }
 
-export function normalizeAgentIdentity(value) {
-    if (!value || typeof value !== 'string') return null;
-    const trimmed = value.trim();
-    if (!trimmed) return null;
-    return trimmed.startsWith('@') ? trimmed : `@${trimmed}`;
-}
-
 /**
  * @summary Extracts a wake-submit nonce from hook payload text.
  * @param {*} value Hook payload value.
@@ -243,7 +237,7 @@ export async function recordTurnPresenceFromHook({
     turnId,
     wakeSubmitNonce = extractWakeSubmitNonce(hookPayload)
 } = {}) {
-    const agentIdentity = normalizeAgentIdentity(env.NEO_AGENT_IDENTITY);
+    const agentIdentity = normalizeAgentIdentityNodeId(env.NEO_AGENT_IDENTITY);
     if (!agentIdentity) return;
 
     const validActions = ['start', 'progress', 'terminal'];

--- a/ai/mcp/server/shared/services/RequestContextService.mjs
+++ b/ai/mcp/server/shared/services/RequestContextService.mjs
@@ -1,5 +1,6 @@
-import { AsyncLocalStorage } from 'async_hooks';
-import Base from '../../../../../src/core/Base.mjs';
+import { AsyncLocalStorage }          from 'async_hooks';
+import Base                           from '../../../../../src/core/Base.mjs';
+import {normalizeAgentIdentityNodeId} from '../../../../graph/normalizeAgentIdentityNodeId.mjs';
 
 /**
  * @summary Sentinel `userId` value tagging records that belong to the shared baseline —
@@ -41,7 +42,7 @@ export const CORE_SWARM_USER_IDS = Object.freeze([
  * @member {String[]}
  */
 export const CORE_SWARM_AGENT_IDS = Object.freeze(
-    CORE_SWARM_USER_IDS.map(userId => `@${userId}`)
+    CORE_SWARM_USER_IDS.map(normalizeAgentIdentityNodeId)
 );
 
 /**

--- a/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
+++ b/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
@@ -25,9 +25,9 @@ import Base       from '../../../../../src/core/Base.mjs';
  * **Intentionally NOT in scope:**
  * - OAuth2/OIDC token validation — that's `AuthService` (SSE transport only)
  * - AgentIdentity graph-node binding — the consumer (`memory-core/Server.mjs`) calls
- *   `Memory_GraphService.getNode({id: '@' + githubLogin})` after resolution, then composes
- *   the full RequestContext. Keeping the graph lookup out of this service preserves the
- *   `shared/` ↔ `memory-core/` layering boundary.
+ *   the shared `normalizeAgentIdentityNodeId()` boundary before the graph lookup, then
+ *   composes the full RequestContext. Keeping the graph lookup out of this service preserves
+ *   the `shared/` ↔ `memory-core/` layering boundary.
  *
  * This class is a key example of the framework's **multi-tenant identity resolution** model
  * and demonstrates concepts like **agent identity**, **OAuth fallback patterns**, **zero-friction
@@ -59,8 +59,8 @@ class StdioIdentityResolver extends Base {
      *
      * **Normalization:** GitHub login strings are stored WITHOUT the leading `@` to match
      * GitHub API conventions (`gh api user .login` returns `neo-opus-ada`, not `@neo-opus-ada`).
-     * Callers that need the `@`-prefixed graph-node-id form prepend
-     * the `@` at lookup time.
+     * Callers that need the `@`-prefixed graph-node-id form use the shared
+     * `normalizeAgentIdentityNodeId()` boundary at lookup time.
      *
      * @returns {Promise<{githubLogin: String|null, username: String|null, source: String}>}
      *     An identity descriptor. `source` is one of `'env-var'`, `'gh-cli'`, or `'unresolved'`.

--- a/ai/scripts/fleet/onboardPeer.mjs
+++ b/ai/scripts/fleet/onboardPeer.mjs
@@ -6,6 +6,7 @@ import {fileURLToPath}             from 'node:url';
 import {createFleetRegistryBridge} from '../../../src/ai/fleet/createFleetRegistryBridge.mjs';
 
 import {LAUNCHABLE_HARNESS_TYPES, getHarnessAuthMode} from '../../services/fleet/deriveHarnessLaunchSpec.mjs';
+import {normalizeAgentIdentityNodeId}                 from '../../graph/normalizeAgentIdentityNodeId.mjs';
 
 /**
  * @module ai/scripts/fleet/onboardPeer
@@ -153,7 +154,7 @@ export function originDevRosterHasResident({residentId, repoRoot = REPO_ROOT, ex
         throw new Error('onboardPeer: cannot parse the merged identity roster at origin/dev; refresh the ref and re-run', {cause: error});
     }
 
-    return ids.has(`@${normalized.token}`)
+    return ids.has(normalizeAgentIdentityNodeId(normalized.token))
 }
 
 /**
@@ -606,7 +607,7 @@ async function main() {
         const sqlite              = new Database(graphPath, {readonly: true});
 
         try {
-            graphNodeSeeded = Boolean(sqlite.prepare('SELECT id FROM Nodes WHERE id = ? LIMIT 1').get(`@${intent.residentId}`));
+            graphNodeSeeded = Boolean(sqlite.prepare('SELECT id FROM Nodes WHERE id = ? LIMIT 1').get(normalizeAgentIdentityNodeId(intent.residentId)));
         } finally {
             sqlite.close();
         }

--- a/ai/scripts/lifecycle/harnessRouting.mjs
+++ b/ai/scripts/lifecycle/harnessRouting.mjs
@@ -10,7 +10,10 @@
  * @see ai/scripts/lifecycle/resumeHarness.mjs
  * @see ai/daemons/wake/daemon.mjs
  */
-import {IDENTITIES} from '../../graph/identityRoots.mjs';
+import {IDENTITIES}                   from '../../graph/identityRoots.mjs';
+import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
+
+export {normalizeAgentIdentityNodeId};
 
 const FAMILY_HARNESS_TARGETS = Object.freeze({
     claude: Object.freeze({
@@ -36,15 +39,6 @@ const APP_HARNESS_DEFAULTS = Object.freeze({
     })
 });
 
-/**
- * @summary Normalize a GitHub-login-style identity into AgentIdentity node-id form.
- * @param {String} identity Raw identity from env/config/CLI.
- * @returns {String} Canonical AgentIdentity node id, or an empty string for empty input.
- */
-export function normalizeAgentIdentityNodeId(identity) {
-    const value = String(identity ?? '').trim();
-    return value && !value.startsWith('@') ? `@${value}` : value;
-}
 /**
  * @summary Apply host-app default shortcuts while preserving explicit metadata.
  *

--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -11,24 +11,24 @@
  * @see ai/daemons/SwarmHeartbeatService.mjs
  * @see .agents/skills/session-sunset/references/session-sunset-workflow.md §1
  */
-import { spawn } from 'child_process';
-import { constants as fsConstants } from 'fs';
-import fs from 'fs/promises';
-import os from 'os';
-import path from 'path';
-import { fileURLToPath } from 'url';
-import { readGateState, hasOverride } from './wakeSafetyGate.mjs';
-import { writeInflightLock, clearInflightLock } from './inflightLock.mjs';
+import { spawn }                                          from 'child_process';
+import { constants as fsConstants }                       from 'fs';
+import fs                                                 from 'fs/promises';
+import os                                                 from 'os';
+import path                                               from 'path';
+import { fileURLToPath }                                  from 'url';
+import { readGateState, hasOverride }                     from './wakeSafetyGate.mjs';
+import { writeInflightLock, clearInflightLock }           from './inflightLock.mjs';
 import { recordHarnessProcess, terminatePreviousHarness } from './harnessLifecycle.mjs';
-import { createSpawnRequest } from './windowsBatchSpawn.mjs';
+import { createSpawnRequest }                             from './windowsBatchSpawn.mjs';
 import {
     resolveGuiInstanceAddress,
     resolveGuiInstancePid
 } from '../../daemons/wake/instanceResolver.mjs';
 import {
-    normalizeAgentIdentityNodeId,
     resolveHarnessTargetForIdentity
 } from './harnessRouting.mjs';
+import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
 
 export {normalizeAgentIdentityNodeId};
 
@@ -55,9 +55,9 @@ const __dirname  = path.dirname(__filename);
  */
 function spawnAsync(cmd, args, identity = null, hostPlatform = process.platform) {
     return new Promise((resolve, reject) => {
-        const spawnRequest = createSpawnRequest(cmd, args, hostPlatform);
-        const proc     = spawn(spawnRequest.cmd, spawnRequest.args, spawnRequest.options);
-        let recordPromise = Promise.resolve();
+        const spawnRequest  = createSpawnRequest(cmd, args, hostPlatform);
+        const proc          = spawn(spawnRequest.cmd, spawnRequest.args, spawnRequest.options);
+        let   recordPromise = Promise.resolve();
 
         if (identity && proc.pid) {
             recordPromise = recordHarnessProcess(identity, proc.pid).catch(err => {
@@ -155,7 +155,7 @@ async function fileIsExecutable(filePath) {
  */
 async function findExecutableOnPath(command) {
     const pathEntries = (process.env.PATH || '').split(path.delimiter).filter(Boolean);
-    const extensions = process.platform === 'win32' && !path.extname(command)
+    const extensions  = process.platform === 'win32' && !path.extname(command)
         ? ['.cmd', '.exe', '.bat', '']
         : [''];
 
@@ -346,7 +346,7 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
 
     // Idempotency: resolve the cooldown beside this script so cron/launchd callers
     // share the same 600s re-fire window regardless of their current working directory.
-    const cooldownDir = path.resolve(__dirname, '../../../.neo-ai-data/wake-daemon');
+    const cooldownDir  = path.resolve(__dirname, '../../../.neo-ai-data/wake-daemon');
     const cooldownFile = path.resolve(cooldownDir, `cooldown-${identity.replace(/[^a-zA-Z0-9_-]/g, '')}.txt`);
 
     try {
@@ -414,7 +414,7 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
              * @summary Cross-platform Antigravity CLI resolution for fresh-session spawn.
              */
             const cliPath = await resolveAntigravityCliPath();
-            const args = ['chat', '-n', payload];
+            const args    = ['chat', '-n', payload];
             await spawnAsync(cliPath, args, identity);
             console.log(`Successfully resumed ${identity} via antigravity-cli`);
         } else if (adapter === 'claude-cli') {
@@ -467,13 +467,13 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
              */
             assertCodexAppServerAllowed();
             const cliPath = await resolveCodexCliPath();
-            const args = ['debug', 'app-server', 'send-message-v2', payload];
+            const args    = ['debug', 'app-server', 'send-message-v2', payload];
             await spawnAsync(cliPath, args);
             console.log(`Successfully resumed ${identity} via codex-app-server`);
         } else if (adapter === 'osascript') {
             const { appName, tabShortcut, freshSessionShortcut } = harnessTarget;
-            const instanceAddress = resolveResumeHarnessInstanceAddress({metadata: harnessTargetMetadata, env});
-            const instancePid     = instanceAddress
+            const instanceAddress                                = resolveResumeHarnessInstanceAddress({metadata: harnessTargetMetadata, env});
+            const instancePid                                    = instanceAddress
                 ? await resolveResumeHarnessInstancePid({
                     ...instanceAddress,
                     deploymentMode

--- a/ai/scripts/setup/generateRosterOnboarding.mjs
+++ b/ai/scripts/setup/generateRosterOnboarding.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
-import fs              from 'node:fs';
-import path            from 'node:path';
-import {execFileSync}  from 'node:child_process';
-import {fileURLToPath} from 'node:url';
+import fs                             from 'node:fs';
+import path                           from 'node:path';
+import {execFileSync}                 from 'node:child_process';
+import {fileURLToPath}                from 'node:url';
+import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
 
 /**
  * @module ai/scripts/setup/generateRosterOnboarding
@@ -146,7 +147,7 @@ export function normalizeHandle(value, label) {
         return {valid: false, reason: `${label} must be a lowercase handle ([a-z0-9-], e.g. '@neo-fable-clio') — received '${value}'`, handle: null};
     }
 
-    return {valid: true, reason: null, handle: `@${body}`}
+    return {valid: true, reason: null, handle: normalizeAgentIdentityNodeId(body)}
 }
 
 /**

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -16,11 +16,12 @@ import {
     readWalMessagesByIds,
     readPendingMessageWalRecords
 } from './helpers/messageWalStore.mjs';
-import {IDENTITIES}                from '../../graph/identityRoots.mjs';
-import {getMissingMemoryWalLeaves} from './helpers/memoryWalStore.mjs';
-import {execFile}                  from 'child_process';
-import {promisify}                 from 'util';
-import crypto                      from 'crypto';
+import {IDENTITIES}                   from '../../graph/identityRoots.mjs';
+import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
+import {getMissingMemoryWalLeaves}    from './helpers/memoryWalStore.mjs';
+import {execFile}                     from 'child_process';
+import {promisify}                    from 'util';
+import crypto                         from 'crypto';
 
 const
     execFileAsync                        = promisify(execFile),
@@ -97,16 +98,62 @@ function getRelatedTicketsForMessage(db, messageId, messageNode) {
  */
 function normalizeMailboxTarget(to, sentBy) {
     if (!to) return to;
+    if (typeof to !== 'string') return to;
     if (to === '@me' && sentBy) return sentBy;
     if (to === 'AGENT:*') return to;                                    // sentinel preserved
     if (to.startsWith('AGENT:')) {
         to = to.slice('AGENT:'.length);
-        if (!to.startsWith('@')) return '@' + to;
-        return to;
+        return normalizeAgentIdentityNodeId(to);
     }
-    if (to.startsWith('@@')) return to.slice(1);                        // strip accidental double-@
-    if (!to.startsWith('@') && !to.includes(':')) return '@' + to;      // prepend missing @ on bare names
+    if (!to.includes(':')) return normalizeAgentIdentityNodeId(to);
     return to;
+}
+
+/**
+ * @summary Canonicalizes direct mailbox identities for authorization comparisons.
+ *
+ * Direct legacy `AGENT:<identity>` wrappers remain comparison-compatible, but graph-backed
+ * `AGENT:<family>/<model>` aliases are intentionally not re-resolved after persistence: send-time
+ * validation owns alias resolution and stores the canonical recipient id. Re-resolving a persisted
+ * family alias could change authorization when the roster changes.
+ *
+ * @param {*} identity Stored edge target or request-bound identity.
+ * @returns {*} Canonical direct identity or unchanged non-direct mailbox address.
+ * @private
+ */
+function normalizeMailboxIdentityForComparison(identity) {
+    if (typeof identity === 'string' && identity.startsWith('AGENT:') && identity.includes('/')) {
+        return identity;
+    }
+
+    return normalizeMailboxTarget(identity);
+}
+
+/**
+ * @summary Compares mailbox identity operands after canonicalizing both direct-id forms.
+ * @param {*} left First identity-shaped value.
+ * @param {*} right Second identity-shaped value.
+ * @returns {Boolean}
+ * @private
+ */
+function sameMailboxIdentity(left, right) {
+    return normalizeMailboxIdentityForComparison(left) === normalizeMailboxIdentityForComparison(right);
+}
+
+/**
+ * @summary Enumerates bounded legacy storage spellings equivalent to one direct identity.
+ * @param {*} identity Direct identity or mailbox sentinel.
+ * @returns {Array<*>} De-duplicated values suitable for SQLite `IN (...)` predicates.
+ * @private
+ */
+function getMailboxIdentityStorageVariants(identity) {
+    const canonical = normalizeMailboxIdentityForComparison(identity);
+    if (typeof canonical !== 'string' || !canonical.startsWith('@') || canonical.includes(':')) {
+        return [canonical];
+    }
+
+    const bare = canonical.slice(1);
+    return [...new Set([canonical, bare, `@${canonical}`, `AGENT:${canonical}`, `AGENT:${bare}`])];
 }
 
 /**
@@ -673,12 +720,13 @@ function messageWalRecordMatchesMailboxView(record, {box = 'all', target} = {}) 
         to           = routing.to || properties.to,
         recipients   = getMessageWalArray(routing.broadcastRecipients);
 
-    if (box === 'outbox') return sentBy === target;
+    if (box === 'outbox') return sameMailboxIdentity(sentBy, target);
 
-    const inboxMatch = to === target || to === 'AGENT:*' || recipients.includes(target);
+    const inboxMatch = sameMailboxIdentity(to, target) || to === 'AGENT:*' ||
+        recipients.some(recipient => sameMailboxIdentity(recipient, target));
     if (box === 'inbox') return inboxMatch;
 
-    return sentBy === target || inboxMatch;
+    return sameMailboxIdentity(sentBy, target) || inboxMatch;
 }
 
 /**
@@ -702,7 +750,7 @@ function getBroadcastAudience(sentBy) {
                 properties  = getRecordProperties(node),
                 accountType = properties.accountType;
 
-            if (!id || id === sentBy || id === 'AGENT:*' || !id.startsWith('@')) {
+            if (!id || sameMailboxIdentity(id, sentBy) || id === 'AGENT:*' || !id.startsWith('@')) {
                 return null;
             }
 
@@ -728,7 +776,8 @@ function getBroadcastDeliveryEdges(messageId) {
 }
 
 function getBroadcastDeliveryEdge(messageId, target) {
-    return getBroadcastDeliveryEdges(messageId).find(edge => getRecordField(edge, 'target') === target) || null;
+    return getBroadcastDeliveryEdges(messageId)
+        .find(edge => sameMailboxIdentity(getRecordField(edge, 'target'), target)) || null;
 }
 
 /**
@@ -950,10 +999,11 @@ class MailboxService extends Base {
     async addMessage({ to, subject, body, originSessionId, relatedSessions = [], relatedTickets = [], inReplyTo, priority = 'normal', partOfThread, taggedConcepts = [], wakeSuppressed = false, task }) {
         const db             = GraphService.requireDb('MailboxService.addMessage');
         const preNormalizeTo = to; // diagnostic payload captures caller-supplied target
-        const sentBy         = RequestContextService.getAgentIdentityNodeId();
-        if (!sentBy) {
+        const boundSender    = RequestContextService.getAgentIdentityNodeId();
+        if (!boundSender) {
             throw RequestContextService.unboundIdentityError('send message');
         }
+        const sentBy = normalizeMailboxIdentityForComparison(boundSender);
         // Canonical normalized isolation key for the user_id column. These message nodes/edges are
         // sharedEntity (RLS-moot), but keep the column single-form; `from: sentBy` stays the @-form label.
         const senderUserId = normalizeUserId(sentBy);
@@ -998,13 +1048,13 @@ class MailboxService extends Base {
         // Explicit blocks override both the 'open' default-allow AND the 'blocked'-mode
         // reachable-counterparty trust-lift. Re-granting CAN_REPLY_TO does not silently
         // re-enable reach. To restore reach, the recipient must revoke the BLOCKED_BY edge.
-        if (!isRoleOrHuman && to !== 'AGENT:*' && to !== sentBy) {
+        if (!isRoleOrHuman && to !== 'AGENT:*' && !sameMailboxIdentity(to, sentBy)) {
             if (PermissionService.hasPermission(sentBy, to, 'BLOCKED_BY')) {
                 throw new Error(`Unauthorized: ${to} has blocked messages from ${sentBy}.`);
             }
         }
 
-        if (strictReplyPolicy && !isRoleOrHuman && to !== 'AGENT:*' && to !== sentBy) {
+        if (strictReplyPolicy && !isRoleOrHuman && to !== 'AGENT:*' && !sameMailboxIdentity(to, sentBy)) {
             let canReply = PermissionService.hasPermission(sentBy, to, 'CAN_REPLY_TO');
 
             // Reachable Counterparty trust lift: if `to` ever sent a message that reached the
@@ -1025,7 +1075,7 @@ class MailboxService extends Base {
                 db.getAdjacentNodes('AGENT:*', 'inbound');
 
                 for (const edge of db.edges.items) {
-                    if (edge.type === 'SENT_TO' && (edge.target === sentBy || edge.target === 'AGENT:*')) {
+                    if (edge.type === 'SENT_TO' && (sameMailboxIdentity(edge.target, sentBy) || edge.target === 'AGENT:*')) {
                         // Per-message outbound vicinity lazy-load, symmetric with listMessages'
                         // inner loop. Without this, the SENT_BY edge scan below comes up empty
                         // for peer-process messages because the SENT_BY edge targets the author
@@ -1040,7 +1090,7 @@ class MailboxService extends Base {
                                 break;
                             }
                         }
-                        if (priorSender === to) {
+                        if (sameMailboxIdentity(priorSender, to)) {
                             canReply = true;
                             break;
                         }
@@ -1409,16 +1459,19 @@ class MailboxService extends Base {
      * @returns {Promise<Object>}
      */
     async listMessages({ box = 'inbox', status = 'all', to, threadId, fromIdentity, taggedConcepts, limit = 50, offset = 0, includeArchived = false } = {}) {
-        const me = RequestContextService.getAgentIdentityNodeId();
-        if (!me) {
+        const boundIdentity = RequestContextService.getAgentIdentityNodeId();
+        if (!boundIdentity) {
             throw RequestContextService.unboundIdentityError('list messages');
         }
 
         const
-            target                       = to || me,
+            me                           = normalizeMailboxIdentityForComparison(boundIdentity),
+            target                       = normalizeMailboxIdentityForComparison(to || me),
+            normalizedFromIdentity       = normalizeMailboxIdentityForComparison(fromIdentity),
+            targetStorageVariants        = getMailboxIdentityStorageVariants(target),
             requestedTaggedConceptGroups = buildTaggedConceptFilterGroups(taggedConcepts);
 
-        if (target !== me && target !== 'AGENT:*') {
+        if (!sameMailboxIdentity(target, me) && target !== 'AGENT:*') {
             if (!PermissionService.hasPermission(me, target, 'CAN_READ_INBOX_OF')) {
                 throw new Error(`Unauthorized: no CAN_READ_INBOX_OF permission for ${target}`);
             }
@@ -1442,11 +1495,15 @@ class MailboxService extends Base {
         // writes. Mailbox inbox query maps onto "inbound edges targeting me or the
         // broadcast sentinel" — vicinity of those two nodes.
         if (box === 'inbox' || box === 'all') {
-            db.getAdjacentNodes(target, 'inbound');
+            for (const targetVariant of targetStorageVariants) {
+                db.getAdjacentNodes(targetVariant, 'inbound');
+            }
             db.getAdjacentNodes('AGENT:*', 'inbound');
         }
         if (box === 'outbox' || box === 'all') {
-            db.getAdjacentNodes(target, 'inbound');
+            for (const targetVariant of targetStorageVariants) {
+                db.getAdjacentNodes(targetVariant, 'inbound');
+            }
         }
 
         let messages = [];
@@ -1463,14 +1520,14 @@ class MailboxService extends Base {
 
             if (edgeType === 'DELIVERED_TO') {
                 targetNode = edgeTarget;
-                if ((box === 'inbox' || box === 'all') && targetNode === target) {
+                if ((box === 'inbox' || box === 'all') && sameMailboxIdentity(targetNode, target)) {
                     isMatch = true;
                     deliveryEdge = edge;
                 }
             } else if (edgeType === 'SENT_TO') {
                 targetNode = edgeTarget;
                 if (box === 'inbox' || box === 'all') {
-                    if (targetNode === target) {
+                    if (sameMailboxIdentity(targetNode, target)) {
                         isMatch = true;
                     } else if (targetNode === 'AGENT:*') {
                         // Load the full message vicinity before deciding whether this is a
@@ -1484,7 +1541,7 @@ class MailboxService extends Base {
                 }
             } else if (edgeType === 'SENT_BY') {
                 senderNode = edgeTarget;
-                if ((box === 'outbox' || box === 'all') && senderNode === target) {
+                if ((box === 'outbox' || box === 'all') && sameMailboxIdentity(senderNode, target)) {
                     isMatch = true;
                 }
             }
@@ -1535,7 +1592,7 @@ class MailboxService extends Base {
                         }
                     }
 
-                    if (fromIdentity && sentByNodeId !== fromIdentity) continue;
+                    if (normalizedFromIdentity && !sameMailboxIdentity(sentByNodeId, normalizedFromIdentity)) continue;
                     if (threadId && foundThreadId !== threadId) continue;
 
                     if (requestedTaggedConceptGroups.length > 0) {
@@ -1591,10 +1648,11 @@ class MailboxService extends Base {
      * @returns {Promise<Object>}
      */
     async getMessage({ messageId }) {
-        const me = RequestContextService.getAgentIdentityNodeId();
-        if (!me) {
+        const boundIdentity = RequestContextService.getAgentIdentityNodeId();
+        if (!boundIdentity) {
             throw RequestContextService.unboundIdentityError('get message');
         }
+        const me = normalizeMailboxIdentityForComparison(boundIdentity);
 
         const db = GraphService.requireDb('MailboxService.getMessage');
 
@@ -1625,7 +1683,7 @@ class MailboxService extends Base {
 
                 if (edgeType === 'SENT_TO') {
                     sentTo = edgeTarget;
-                    if (edgeTarget === me) {
+                    if (sameMailboxIdentity(edgeTarget, me)) {
                         isDirectRecipient = true;
                     }
                 }
@@ -1636,13 +1694,13 @@ class MailboxService extends Base {
         }
 
         const deliveryEdge = getBroadcastDeliveryEdge(messageId, me);
-        let   isAuthorized = sentBy === me || isDirectRecipient;
+        let   isAuthorized = sameMailboxIdentity(sentBy, me) || isDirectRecipient;
 
         if (!isAuthorized && sentTo === 'AGENT:*') {
             // Legacy broadcasts without per-recipient receipts retain their historical
             // read-path semantics. Receipt-backed broadcasts authorize only snapshotted recipients.
             isAuthorized = deliveryEdge || !hasBroadcastDeliveryEdges(messageId);
-        } else if (!isAuthorized && sentTo && sentTo !== me && sentTo !== 'AGENT:*') {
+        } else if (!isAuthorized && sentTo && !sameMailboxIdentity(sentTo, me) && sentTo !== 'AGENT:*') {
             // Check if me has permission to read sentTo's inbox
             if (PermissionService.hasPermission(me, sentTo, 'CAN_READ_INBOX_OF')) {
                 isAuthorized = true;
@@ -1782,10 +1840,11 @@ class MailboxService extends Base {
      * @returns {Promise<Object>}
      */
     async markRead({ messageId }) {
-        const me = RequestContextService.getAgentIdentityNodeId();
-        if (!me) {
+        const boundIdentity = RequestContextService.getAgentIdentityNodeId();
+        if (!boundIdentity) {
             throw RequestContextService.unboundIdentityError('mark message read');
         }
+        const me = normalizeMailboxIdentityForComparison(boundIdentity);
 
         const db = GraphService.requireDb('MailboxService.markRead');
 
@@ -1805,7 +1864,7 @@ class MailboxService extends Base {
             if (getRecordField(edge, 'source') === messageId && getRecordField(edge, 'type') === 'SENT_TO') {
                 const edgeTarget = getRecordField(edge, 'target');
 
-                if (edgeTarget === me) {
+                if (sameMailboxIdentity(edgeTarget, me)) {
                     isDirectRecipient = true;
                     break;
                 }
@@ -1862,10 +1921,11 @@ class MailboxService extends Base {
      * @returns {Promise<Object>} `{messageId, archivedAt, status: 'archived'}`.
      */
     async archiveMessage({ messageId }) {
-        const me = RequestContextService.getAgentIdentityNodeId();
-        if (!me) {
+        const boundIdentity = RequestContextService.getAgentIdentityNodeId();
+        if (!boundIdentity) {
             throw RequestContextService.unboundIdentityError('archive message');
         }
+        const me = normalizeMailboxIdentityForComparison(boundIdentity);
 
         const db = GraphService.requireDb('MailboxService.archiveMessage');
 
@@ -1884,7 +1944,7 @@ class MailboxService extends Base {
             if (getRecordField(edge, 'source') === messageId && getRecordField(edge, 'type') === 'SENT_TO') {
                 const edgeTarget = getRecordField(edge, 'target');
 
-                if (edgeTarget === me) {
+                if (sameMailboxIdentity(edgeTarget, me)) {
                     isDirectRecipient = true;
                     break;
                 }
@@ -1941,10 +2001,11 @@ class MailboxService extends Base {
      * @returns {Promise<Object>} `{messageId, retracted: true, status: 'retracted'}`.
      */
     async deleteMessage({ messageId }) {
-        const me = RequestContextService.getAgentIdentityNodeId();
-        if (!me) {
+        const boundIdentity = RequestContextService.getAgentIdentityNodeId();
+        if (!boundIdentity) {
             throw RequestContextService.unboundIdentityError('delete message');
         }
+        const me = normalizeMailboxIdentityForComparison(boundIdentity);
 
         const db = GraphService.requireDb('MailboxService.deleteMessage');
 
@@ -1961,7 +2022,7 @@ class MailboxService extends Base {
         for (const edge of db.edges.items) {
             if (getRecordField(edge, 'source') === messageId
                 && getRecordField(edge, 'type') === 'SENT_BY'
-                && getRecordField(edge, 'target') === me) {
+                && sameMailboxIdentity(getRecordField(edge, 'target'), me)) {
                 isSender = true;
                 break;
             }
@@ -2002,10 +2063,11 @@ class MailboxService extends Base {
             throw new Error(`Invalid new task state: ${newState}. Must be one of: ${MailboxService.VALID_TASK_STATES.join(', ')}`);
         }
 
-        const me = RequestContextService.getAgentIdentityNodeId();
-        if (!me) {
+        const boundIdentity = RequestContextService.getAgentIdentityNodeId();
+        if (!boundIdentity) {
             throw RequestContextService.unboundIdentityError('transition task');
         }
+        const me = normalizeMailboxIdentityForComparison(boundIdentity);
 
         const db = GraphService.requireDb('MailboxService.transitionTask');
 
@@ -2032,8 +2094,8 @@ class MailboxService extends Base {
 
         for (const edge of db.edges.items) {
             if (edge.source === taskId) {
-                if (edge.type === 'SENT_BY' && edge.target === me) isOriginator = true;
-                if (edge.type === 'SENT_TO' && (edge.target === me || edge.target === 'AGENT:*')) isAssignee = true;
+                if (edge.type === 'SENT_BY' && sameMailboxIdentity(edge.target, me)) isOriginator = true;
+                if (edge.type === 'SENT_TO' && (sameMailboxIdentity(edge.target, me) || edge.target === 'AGENT:*')) isAssignee = true;
             }
         }
 
@@ -2230,10 +2292,11 @@ class MailboxService extends Base {
      * @returns {Promise<{count: Number}>}
      */
     async countMessages({ box = 'inbox', status = 'all', to, fromIdentity, includeArchived = false } = {}) {
-        const me = RequestContextService.getAgentIdentityNodeId();
-        if (!me) {
+        const boundIdentity = RequestContextService.getAgentIdentityNodeId();
+        if (!boundIdentity) {
             throw RequestContextService.unboundIdentityError('count messages');
         }
+        const me = normalizeMailboxIdentityForComparison(boundIdentity);
 
         // Reject unsupported `box` values explicitly rather than silently aliasing to the inbox
         // path. The branch-on-outbox shape would otherwise return partial results for `box='all'`
@@ -2242,9 +2305,16 @@ class MailboxService extends Base {
             throw new Error(`Cannot count messages: unsupported box value '${box}'. Supported values: 'inbox', 'outbox' ('all' is deferred to a follow-up).`);
         }
 
-        const target = to || me;
+        const target               = normalizeMailboxIdentityForComparison(to || me),
+            normalizedFromIdentity = normalizeMailboxIdentityForComparison(fromIdentity),
+            targetStorageVariants  = getMailboxIdentityStorageVariants(target),
+            senderStorageVariants  = normalizedFromIdentity
+                ? getMailboxIdentityStorageVariants(normalizedFromIdentity)
+                : [],
+            targetStoragePlaceholders = targetStorageVariants.map(() => '?').join(', '),
+            senderStoragePlaceholders = senderStorageVariants.map(() => '?').join(', ');
 
-        if (target !== me && target !== 'AGENT:*') {
+        if (!sameMailboxIdentity(target, me) && target !== 'AGENT:*') {
             if (!PermissionService.hasPermission(me, target, 'CAN_READ_INBOX_OF')) {
                 throw new Error(`Unauthorized: no CAN_READ_INBOX_OF permission for ${target}`);
             }
@@ -2279,8 +2349,8 @@ class MailboxService extends Base {
             : `AND json_extract(e.data, '$.properties.archivedAt') IS NULL`;
 
         // Optional sender filter — applies to inbox only.
-        const senderFilterSql = fromIdentity
-            ? `AND EXISTS (SELECT 1 FROM Edges sb WHERE sb.source = n.id AND sb.type = 'SENT_BY' AND sb.target = ?)`
+        const senderFilterSql = normalizedFromIdentity
+            ? `AND EXISTS (SELECT 1 FROM Edges sb WHERE sb.source = n.id AND sb.type = 'SENT_BY' AND sb.target IN (${senderStoragePlaceholders}))`
             : '';
 
         try {
@@ -2290,9 +2360,9 @@ class MailboxService extends Base {
                     FROM Edges e
                     JOIN Nodes n ON n.id = e.source
                     WHERE e.type = 'SENT_BY'
-                      AND e.target = ?
+                      AND e.target IN (${targetStoragePlaceholders})
                       AND json_extract(n.data, '$.label') = 'MESSAGE'
-                `).get(target);
+                `).get(...targetStorageVariants);
                 return { count: row?.count ?? 0 };
             }
 
@@ -2304,7 +2374,7 @@ class MailboxService extends Base {
                     FROM Edges e
                     JOIN Nodes n ON n.id = e.source
                     WHERE e.type = 'SENT_TO'
-                      AND e.target = ?
+                      AND e.target IN (${targetStoragePlaceholders})
                       AND json_extract(n.data, '$.label') = 'MESSAGE'
                       ${messageReadAtClause}
                       ${messageArchivedAtClause}
@@ -2316,7 +2386,7 @@ class MailboxService extends Base {
                     FROM Edges e
                     JOIN Nodes n ON n.id = e.source
                     WHERE e.type = 'DELIVERED_TO'
-                      AND e.target = ?
+                      AND e.target IN (${targetStoragePlaceholders})
                       AND json_extract(n.data, '$.label') = 'MESSAGE'
                       ${edgeReadAtClause}
                       ${edgeArchivedAtClause}
@@ -2342,11 +2412,11 @@ class MailboxService extends Base {
                 FROM inbox_messages
             `;
 
-            params.push(target);
-            if (fromIdentity) params.push(fromIdentity);
-            params.push(target);
-            if (fromIdentity) params.push(fromIdentity);
-            if (fromIdentity) params.push(fromIdentity);
+            params.push(...targetStorageVariants);
+            if (normalizedFromIdentity) params.push(...senderStorageVariants);
+            params.push(...targetStorageVariants);
+            if (normalizedFromIdentity) params.push(...senderStorageVariants);
+            if (normalizedFromIdentity) params.push(...senderStorageVariants);
 
             const row = sqlite.prepare(inboxSql).get(...params);
             return { count: row?.count ?? 0 };

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -13,6 +13,7 @@ import {buildChatModel}                                                         
 import aiConfig                                                                                                                        from '../../mcp/server/memory-core/config.mjs';
 import RequestContextService, {SHARED_USER_ID, normalizeUserId}                                                                        from '../../mcp/server/shared/services/RequestContextService.mjs';
 import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER}                                                                                     from '../../graph/identityRoots.mjs';
+import {normalizeAgentIdentityNodeId}                                                                                                  from '../../graph/normalizeAgentIdentityNodeId.mjs';
 
 /**
  * Re-exported from `./helpers/withTimeout.mjs` (moved there so `SessionService` can share it without
@@ -398,8 +399,7 @@ class MemoryService extends Base {
             // by the SSE transport layer. In stdio mode it is absent — single-tenant fallthrough.
             const requestIdentity   = RequestContextService.getAgentIdentityNodeId();
             const userId            = normalizeUserId(RequestContextService.getUserId());
-            const canonicalIdentity = requestIdentity
-                || (userId ? `@${userId}` : (agent?.startsWith('@') ? agent : (agent ? `@${agent}` : undefined)));
+            const canonicalIdentity = normalizeAgentIdentityNodeId(requestIdentity || userId || agent);
 
             if (userId) metadata.userId = userId;
             if (canonicalIdentity) metadata.agentIdentity = canonicalIdentity;
@@ -1185,13 +1185,15 @@ class MemoryService extends Base {
             }
 
             // AC1 — resolve the agent filter; capture the caller's bound identity for the privacy gate.
-            const callerIdentity = RequestContextService.getAgentIdentityNodeId();
+            const callerIdentity = normalizeAgentIdentityNodeId(RequestContextService.getAgentIdentityNodeId());
             let   identity       = agentIdentity;
             if (!identity || identity === '@me') {
                 identity = callerIdentity;
                 if (!identity) {
                     return {_channelSeparation: channelSeparation, count: 0, turns: [], nextCursor: null, scope: 'fail-closed: no resolvable agent identity'};
                 }
+            } else {
+                identity = normalizeAgentIdentityNodeId(identity);
             }
 
             // Privacy authorization (not a formatting flag): the 'private' projection exposes the

--- a/ai/services/memory-core/PermissionService.mjs
+++ b/ai/services/memory-core/PermissionService.mjs
@@ -1,8 +1,9 @@
-import Base from '../../../src/core/Base.mjs';
-import GraphService from './GraphService.mjs';
-import RequestContextService from '../../mcp/server/shared/services/RequestContextService.mjs';
-import WakeSubscriptionService from './WakeSubscriptionService.mjs';
-import logger from '../../mcp/server/memory-core/logger.mjs';
+import Base                           from '../../../src/core/Base.mjs';
+import GraphService                   from './GraphService.mjs';
+import RequestContextService          from '../../mcp/server/shared/services/RequestContextService.mjs';
+import WakeSubscriptionService        from './WakeSubscriptionService.mjs';
+import logger                         from '../../mcp/server/memory-core/logger.mjs';
+import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
 
 /**
  * @summary Service for managing cross-tenant permission edges in the Native Graph.
@@ -54,10 +55,13 @@ class PermissionService extends Base {
      * @returns {Promise<Object>}
      */
     async grantPermission({ to, scope }) {
-        const owner = RequestContextService.getAgentIdentityNodeId();
-        if (!owner) throw RequestContextService.unboundIdentityError('grant permission');
+        const boundOwner = RequestContextService.getAgentIdentityNodeId();
+        if (!boundOwner) throw RequestContextService.unboundIdentityError('grant permission');
         if (!to) throw new Error("Missing 'to' parameter.");
         if (!scope) throw new Error("Missing 'scope' parameter.");
+
+        const owner = normalizeAgentIdentityNodeId(boundOwner),
+            grantee = normalizeAgentIdentityNodeId(to);
 
         if (!this.validScopes.includes(scope)) {
             throw new Error(`Invalid scope. Must be one of: ${this.validScopes.join(', ')}`);
@@ -70,15 +74,15 @@ class PermissionService extends Base {
         // foreign-key style existence guard as graph-link writes.
         const db         = GraphService.requireDb('PermissionService.grantPermission');
         const verifyStmt = db.storage.db.prepare('SELECT count(*) as count FROM Nodes WHERE id = ?');
-        if (verifyStmt.get(to).count === 0) {
-            throw new Error(`Cannot grant ${scope} to ${to}: target does not exist. Identity nodes must be pre-seeded via ai/scripts/setup/seedAgentIdentities.mjs.`);
+        if (verifyStmt.get(grantee).count === 0) {
+            throw new Error(`Cannot grant ${scope} to ${grantee}: target does not exist. Identity nodes must be pre-seeded via ai/scripts/setup/seedAgentIdentities.mjs.`);
         }
 
         // The capability belongs to 'to', pointing at 'owner'
         // e.g. "Alice CAN_READ_INBOX_OF Bob" (source: Alice, target: Bob)
-        GraphService.linkNodes(to, owner, scope, 1.0);
+        GraphService.linkNodes(grantee, owner, scope, 1.0);
         WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
-        return { success: true, message: `Granted ${scope} to ${to}` };
+        return { success: true, message: `Granted ${scope} to ${grantee}` };
     }
 
     /**
@@ -89,13 +93,20 @@ class PermissionService extends Base {
      * @returns {Promise<Object>}
      */
     async revokePermission({ to, scope }) {
-        const owner = RequestContextService.getAgentIdentityNodeId();
-        if (!owner) throw RequestContextService.unboundIdentityError('revoke permission');
+        const boundOwner = RequestContextService.getAgentIdentityNodeId();
+        if (!boundOwner) throw RequestContextService.unboundIdentityError('revoke permission');
 
-        const db = GraphService.requireDb('PermissionService.revokePermission');
+        const owner = normalizeAgentIdentityNodeId(boundOwner),
+            grantee = normalizeAgentIdentityNodeId(to);
+
+        const db            = GraphService.requireDb('PermissionService.revokePermission');
         const edgesToRemove = [];
         for (const edge of db.edges.items) {
-            if (edge.source === to && edge.target === owner && edge.type === scope) {
+            if (
+                normalizeAgentIdentityNodeId(edge.source) === grantee &&
+                normalizeAgentIdentityNodeId(edge.target) === owner &&
+                edge.type === scope
+            ) {
                 edgesToRemove.push(edge);
             }
         }
@@ -105,7 +116,7 @@ class PermissionService extends Base {
             WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
         }
 
-        return { success: true, message: `Revoked ${scope} from ${to}` };
+        return { success: true, message: `Revoked ${scope} from ${grantee}` };
     }
 
     /**
@@ -115,33 +126,34 @@ class PermissionService extends Base {
      * @returns {Promise<Object>}
      */
     async listPermissions({ forIdentity } = {}) {
-        const caller = RequestContextService.getAgentIdentityNodeId();
-        if (!caller) throw RequestContextService.unboundIdentityError('list permissions');
+        const boundCaller = RequestContextService.getAgentIdentityNodeId();
+        if (!boundCaller) throw RequestContextService.unboundIdentityError('list permissions');
 
-        const targetId = forIdentity || caller;
+        const caller = normalizeAgentIdentityNodeId(boundCaller),
+            targetId = normalizeAgentIdentityNodeId(forIdentity || caller);
 
         // Prevent arbitrary enumeration of other agents' permissions unless the caller is the target
         if (targetId !== caller) {
             throw new Error(`Unauthorized: Cannot enumerate permissions for ${targetId}`);
         }
 
-        const db = GraphService.requireDb('PermissionService.listPermissions');
-        const capabilities = [];     // Things targetId can do to others
+        const db              = GraphService.requireDb('PermissionService.listPermissions');
+        const capabilities    = [];     // Things targetId can do to others
         const grantedToOthers = [];  // Things others can do to targetId
 
         for (const edge of db.edges.items) {
             if (this.validScopes.includes(edge.type)) {
-                if (edge.source === targetId) {
+                if (normalizeAgentIdentityNodeId(edge.source) === targetId) {
                     capabilities.push({
-                        target: edge.target,
-                        scope: edge.type,
+                        target   : normalizeAgentIdentityNodeId(edge.target),
+                        scope    : edge.type,
                         timestamp: edge.properties?.timestamp
                     });
                 }
-                if (edge.target === targetId) {
+                if (normalizeAgentIdentityNodeId(edge.target) === targetId) {
                     grantedToOthers.push({
-                        grantedTo: edge.source,
-                        scope: edge.type,
+                        grantedTo: normalizeAgentIdentityNodeId(edge.source),
+                        scope    : edge.type,
                         timestamp: edge.properties?.timestamp
                     });
                 }
@@ -159,6 +171,9 @@ class PermissionService extends Base {
      * @returns {Boolean}
      */
     hasPermission(caller, target, scope) {
+        caller = normalizeAgentIdentityNodeId(caller);
+        target = normalizeAgentIdentityNodeId(target);
+
         // Broadcasts are pseudo-targets; checking permission against broadcast logic
         // is typically handled at the service layer, but structurally always allowed.
         if (target === 'AGENT:*') return true;
@@ -168,7 +183,11 @@ class PermissionService extends Base {
 
         const db = GraphService.requireDb('PermissionService.hasPermission');
         for (const edge of db.edges.items) {
-            if (edge.source === caller && edge.target === target && edge.type === scope) {
+            if (
+                normalizeAgentIdentityNodeId(edge.source) === caller &&
+                normalizeAgentIdentityNodeId(edge.target) === target &&
+                edge.type === scope
+            ) {
                 return true;
             }
         }

--- a/test/playwright/unit/ai/graph/normalizeAgentIdentityNodeId.spec.mjs
+++ b/test/playwright/unit/ai/graph/normalizeAgentIdentityNodeId.spec.mjs
@@ -1,0 +1,37 @@
+import {test, expect}                 from '@playwright/test';
+import {normalizeAgentIdentityNodeId} from '../../../../../ai/graph/normalizeAgentIdentityNodeId.mjs';
+
+test.describe('normalizeAgentIdentityNodeId', () => {
+    test('canonicalizes direct bare, canonical, and redundant-prefix identities', () => {
+        const cases = [
+            ['neo-gpt',             '@neo-gpt'],
+            ['  neo-opus-ada  ',    '@neo-opus-ada'],
+            ['@neo-gemini-pro',     '@neo-gemini-pro'],
+            ['@@neo-gpt',           '@neo-gpt'],
+            ['@@@@neo-opus-grace',  '@neo-opus-grace'],
+            ['',                    '']
+        ];
+
+        for (const [input, expected] of cases) {
+            const normalized = normalizeAgentIdentityNodeId(input);
+            expect(normalized).toBe(expected);
+            expect(normalizeAgentIdentityNodeId(normalized)).toBe(expected);
+        }
+    });
+
+    test('leaves mailbox addressing grammar outside the graph primitive', () => {
+        expect(normalizeAgentIdentityNodeId('AGENT:*')).toBe('AGENT:*');
+        expect(normalizeAgentIdentityNodeId('AGENT:neo-gpt')).toBe('AGENT:neo-gpt');
+        expect(normalizeAgentIdentityNodeId('role:librarian')).toBe('role:librarian');
+        expect(normalizeAgentIdentityNodeId('human:tobiu')).toBe('human:tobiu');
+    });
+
+    test('passes non-string values through without inventing identities', () => {
+        const objectIdentity = {id: 'neo-gpt'};
+
+        expect(normalizeAgentIdentityNodeId(null)).toBeNull();
+        expect(normalizeAgentIdentityNodeId(undefined)).toBeUndefined();
+        expect(normalizeAgentIdentityNodeId(42)).toBe(42);
+        expect(normalizeAgentIdentityNodeId(objectIdentity)).toBe(objectIdentity);
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -121,10 +121,86 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         // Let the identity node stay in the natural cache (which is the case right after init/upsert)
         const serverInstance = await createServerWithoutBoot();
 
-        const boundId = await serverInstance.bindAgentIdentity('neo-opus-4-7');
-        expect(boundId).toBe('@neo-opus-4-7');
+        for (const input of ['neo-opus-4-7', '@neo-opus-4-7', '@@neo-opus-4-7']) {
+            const boundId = await serverInstance.bindAgentIdentity(input);
+            expect(boundId).toBe('@neo-opus-4-7');
+        }
 
         serverInstance.destroy();
+    });
+
+    test('#15027: bindAgentIdentity refuses mailbox namespaces and non-AgentIdentity collisions', async () => {
+        await GraphService.initAsync();
+
+        GraphService.upsertNode({id: 'AGENT:*', type: 'BroadcastSentinel', name: 'Broadcast'});
+        GraphService.upsertNode({id: '@identity-collision-15027', type: 'Concept', name: 'Not an identity'});
+
+        const serverInstance = await createServerWithoutBoot();
+
+        try {
+            await expect(serverInstance.bindAgentIdentity('AGENT:*')).resolves.toBeNull();
+            await expect(serverInstance.bindAgentIdentity('identity-collision-15027')).resolves.toBeNull();
+        } finally {
+            serverInstance.destroy();
+        }
+    });
+
+    test('#15027: stdio and SSE identity paths bind through the same provider-agnostic canonicalizer', async () => {
+        await GraphService.initAsync();
+
+        GraphService.upsertNode({id: '@identity-topology-15027', type: 'AgentIdentity', name: 'Identity Topology'});
+
+        const serverInstance        = await createServerWithoutBoot();
+        const StdioIdentityResolver = (await import('../../../../../../../ai/mcp/server/shared/services/StdioIdentityResolver.mjs')).default;
+        const originalResolve       = StdioIdentityResolver.resolve;
+
+        try {
+            const sseContext = await serverInstance.buildRequestContext({
+                userId  : 'identity-topology-15027',
+                username: 'Identity Topology',
+                source  : 'oidc'
+            });
+
+            expect(sseContext).toMatchObject({
+                userId             : 'identity-topology-15027',
+                agentIdentityNodeId: '@identity-topology-15027',
+                source             : 'oidc'
+            });
+
+            StdioIdentityResolver.resolve = async () => ({
+                githubLogin: 'identity-topology-15027',
+                username   : 'Identity Topology',
+                source     : 'gh-cli'
+            });
+
+            const stdioContext = await serverInstance.resolveStdioIdentity();
+            expect(stdioContext).toMatchObject({
+                userId             : 'identity-topology-15027',
+                agentIdentityNodeId: '@identity-topology-15027',
+                source             : 'gh-cli'
+            });
+
+            const [{default: RequestContextService}, {default: MailboxService}] = await Promise.all([
+                import('../../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs'),
+                import('../../../../../../../ai/services/memory-core/MailboxService.mjs')
+            ]);
+
+            for (const context of [sseContext, stdioContext]) {
+                const sent = await RequestContextService.run(context, () => MailboxService.addMessage({
+                    to     : '@me',
+                    subject: `topology round-trip ${context.source}`,
+                    body   : 'Both transports must reach the same canonical recipient.'
+                }));
+                const read = await RequestContextService.run(context, () =>
+                    MailboxService.markRead({messageId: sent.messageId})
+                );
+
+                expect(read).toMatchObject({messageId: sent.messageId, status: 'read'});
+            }
+        } finally {
+            StdioIdentityResolver.resolve = originalResolve;
+            serverInstance.destroy();
+        }
     });
 
     test('bindAgentIdentity must await the Promise-returning getNode (regression pin for #10249)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -119,6 +119,18 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         `).run(JSON.stringify(GraphService.db.nodes.get(messageId)), messageId);
     }
 
+    function retargetMessageEdge(messageId, type, target) {
+        const edge = GraphService.db.edges.items.find(candidate =>
+            candidate.source === messageId && candidate.type === type
+        );
+
+        expect(edge).toBeDefined();
+
+        GraphService.upsertNode({id: target, type: 'AGENT', name: `Legacy ${target}`, properties: {}});
+        GraphService.db.edges.remove([edge]);
+        GraphService.linkNodes(messageId, target, type, edge.weight ?? 1, edge.properties || {});
+    }
+
     function clearGraphCacheWithoutStorageMutation() {
         // Suspend autoSave around the store clears or they are NOT storage-neutral: store
         // remove-mutations echo through onNodesMutate/onEdgesMutate into storage.removeNodes/
@@ -634,6 +646,103 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         const node = GraphService.db.nodes.get(msgId);
         expect(node.properties.readAt).toBeTruthy();
+    });
+
+    test('#15027 markRead canonicalizes both bound identity and drifted direct SENT_TO targets', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        for (const target of ['bob', '@@bob', 'AGENT:@bob']) {
+            const {messageId} = await RequestContextService.run({agentIdentityNodeId: '@alice'}, () =>
+                MailboxService.addMessage({to: '@bob', subject: `legacy ${target}`, body: 'canonicalize both sides'})
+            );
+
+            retargetMessageEdge(messageId, 'SENT_TO', target);
+
+            const result = await RequestContextService.run({agentIdentityNodeId: '@@bob'}, () =>
+                MailboxService.markRead({messageId})
+            );
+
+            expect(result).toMatchObject({messageId, status: 'read'});
+            expect(result.readAt).toBeTruthy();
+        }
+    });
+
+    test('#15027 persisted family aliases stay fail-closed instead of changing meaning with the roster', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const {messageId} = await RequestContextService.run({agentIdentityNodeId: '@alice'}, () =>
+            MailboxService.addMessage({to: '@bob', subject: 'corrupt family alias', body: 'must not authorize'})
+        );
+
+        retargetMessageEdge(messageId, 'SENT_TO', 'AGENT:claude/opus');
+
+        await expect(RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.markRead({messageId})
+        )).rejects.toThrow(/Unauthorized: you are not the recipient/);
+    });
+
+    test('#15027 list/count canonicalize direct request and sender-filter identities', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const {messageId} = await RequestContextService.run({agentIdentityNodeId: '@alice'}, () =>
+            MailboxService.addMessage({to: '@bob', subject: 'normalized filters', body: 'one message'})
+        );
+
+        retargetMessageEdge(messageId, 'SENT_TO', 'bob');
+        retargetMessageEdge(messageId, 'SENT_BY', '@@alice');
+        fs.removeSync(messageWalDir);
+
+        await RequestContextService.run({agentIdentityNodeId: '@@bob'}, async () => {
+            const listed  = await MailboxService.listMessages({to: 'bob', fromIdentity: '@@alice'});
+            const counted = await MailboxService.countMessages({to: 'bob', fromIdentity: '@@alice'});
+
+            expect(listed.messages.map(message => message.messageId)).toEqual([messageId]);
+            expect(counted.count).toBe(1);
+        });
+    });
+
+    test('#15027 sibling authorization paths canonicalize stored direct identity spellings', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const archived = await RequestContextService.run({agentIdentityNodeId: '@alice'}, () =>
+            MailboxService.addMessage({to: '@bob', subject: 'archive alias', body: 'archive me'})
+        );
+        retargetMessageEdge(archived.messageId, 'SENT_TO', '@@bob');
+        await expect(RequestContextService.run({agentIdentityNodeId: 'bob'}, () =>
+            MailboxService.getMessage({messageId: archived.messageId})
+        )).resolves.toMatchObject({messageId: archived.messageId});
+        await expect(RequestContextService.run({agentIdentityNodeId: 'bob'}, () =>
+            MailboxService.archiveMessage({messageId: archived.messageId})
+        )).resolves.toMatchObject({status: 'archived'});
+
+        const retracted = await RequestContextService.run({agentIdentityNodeId: '@alice'}, () =>
+            MailboxService.addMessage({to: '@bob', subject: 'sender alias', body: 'retract me'})
+        );
+        retargetMessageEdge(retracted.messageId, 'SENT_BY', 'alice');
+        await expect(RequestContextService.run({agentIdentityNodeId: '@@alice'}, () =>
+            MailboxService.deleteMessage({messageId: retracted.messageId})
+        )).resolves.toMatchObject({status: 'retracted'});
+
+        const task = await RequestContextService.run({agentIdentityNodeId: '@alice'}, () =>
+            MailboxService.addMessage({
+                to     : '@bob',
+                subject: 'task alias',
+                body   : 'transition me',
+                task   : {state: 'Submitted'}
+            })
+        );
+        retargetMessageEdge(task.messageId, 'SENT_TO', 'AGENT:@bob');
+        await expect(RequestContextService.run({agentIdentityNodeId: 'bob'}, () =>
+            MailboxService.transitionTask({taskId: task.messageId, newState: 'Working'})
+        )).resolves.toMatchObject({success: true, task: {state: 'Working'}});
     });
 
     test('surgical repair preserves a DM readAt while restoring a lost routing edge (#14426)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs
@@ -171,6 +171,37 @@ test.describe('Neo.ai.services.memory-core.PermissionService', () => {
         expect(PermissionService.hasPermission('@alice', 'AGENT:*', 'CAN_READ_INBOX_OF')).toBe(true);
     });
 
+    test('#15027 canonicalizes permission operands at every public boundary', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@@bob'}, async () => {
+            await PermissionService.grantPermission({to: 'alice', scope: 'CAN_READ_INBOX_OF'});
+        });
+
+        const [edge] = GraphService.db.edges.items;
+        expect(edge.source).toBe('@alice');
+        expect(edge.target).toBe('@bob');
+
+        GraphService.upsertNode({id: 'alice', type: 'AGENT', name: 'Legacy Alice', properties: {}});
+        GraphService.upsertNode({id: '@@bob', type: 'AGENT', name: 'Legacy Bob', properties: {}});
+        GraphService.db.edges.remove([edge]);
+        GraphService.linkNodes('alice', '@@bob', 'CAN_READ_INBOX_OF', 1.0);
+
+        expect(PermissionService.hasPermission('@@alice', 'bob', 'CAN_READ_INBOX_OF')).toBe(true);
+
+        await RequestContextService.run({agentIdentityNodeId: '@@alice'}, async () => {
+            const permissions = await PermissionService.listPermissions({forIdentity: 'alice'});
+            expect(permissions.identity).toBe('@alice');
+            expect(permissions.capabilities).toEqual([
+                expect.objectContaining({target: '@bob', scope: 'CAN_READ_INBOX_OF'})
+            ]);
+        });
+
+        await RequestContextService.run({agentIdentityNodeId: 'bob'}, async () => {
+            await PermissionService.revokePermission({to: '@@alice', scope: 'CAN_READ_INBOX_OF'});
+        });
+
+        expect(GraphService.db.edges.getCount()).toBe(0);
+    });
+
     test('listPermissions denies access when requesting for another identity', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
             await expect(PermissionService.listPermissions({ forIdentity: '@bob' }))


### PR DESCRIPTION
Resolves #15027

Related: #10144
Related: #10259
Related: #11504

Moves the direct AgentIdentity `@<identity>` convention into one graph-owned canonicalizer and routes the lifecycle, Memory Core, permission, onboarding, and transport binding surfaces through it. Mailbox reads now canonicalize both operands across direct legacy spellings, while namespace-bearing addressing remains mailbox-owned and persisted family aliases stay fail-closed.

Evidence: L2 (provider-composition specs plus isolated SQLite service-runtime send → markRead witnesses) → L2 required (local stdio and SSE/OIDC-PAT identity binding, mailbox authorization, and permission-edge compatibility). No residuals.

## Deltas from ticket

- The producer sweep found additional true AgentIdentity constructors in turn presence, MemoryService, RequestContextService constants, and Fleet onboarding/roster probes; these now consume the shared graph primitive too.
- The generic primitive deliberately does not absorb `AGENT:*`, `AGENT:<family>/<model>`, `role:`, or `human:` grammar. Mailbox send-time resolution remains the owner; direct legacy `AGENT:@identity` comparison compatibility is local to MailboxService, and persisted family aliases fail closed so roster changes cannot alter authorization.
- `bindAgentIdentity()` now rejects namespace-shaped inputs and graph nodes whose type is not `AgentIdentity`, closing the sentinel-binding regression exposed by the independent pre-commit audit.
- `harnessRouting.mjs` and `resumeHarness.mjs` retain compatibility re-exports only; all in-repo runtime consumers import the graph SSOT directly.

## Test Evidence

- `NEO_TEST_SKIP_CI=true NEO_CHROMA_PORT_TEST=19231 npm run test-unit -- test/playwright/unit/ai/graph/normalizeAgentIdentityNodeId.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs test/playwright/unit/ai/services/memory-core/PermissionService.spec.mjs --workers=1 --grep '#15027|normalizeAgentIdentityNodeId'` — 10 passed.
- Focused five-spec compatibility slice, including `resumeHarness.spec.mjs`, completed across 152 cases after rerunning outside the log-symlink sandbox restriction.
- `node --check` passed for the changed runtime and spec modules; `git diff --check` passed.
- Direct import smoke passed for the graph helper, lifecycle compatibility surfaces, Fleet onboarding, roster generation, and turn-presence hook writer.
- `npm run agent-preflight -- <21 changed files>` passed ticket archaeology and repair-capable block alignment.

## Post-Merge Validation

- [ ] Hosted CI confirms the repo-wide import migration and full lint/test matrix.
- [ ] Observe one live stdio boot and one deployed SSE request reporting the same canonical AgentIdentity node id.

## Evolution

Prior art from sessions `29f490c0-41ed-4846-a767-287552d5c3c4` and `56d01d8b-ce3f-4194-9441-e4941ae07be8` showed both the successful canonical-mailbox migration and the strict-read alias trap. During implementation, the ticket's `AGENT:` wording was narrowed against the shipped `#10259` / `#11504` boundary: graph identity canonicalization and mailbox address resolution remain separate authorities.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session de713f27-0e82-4960-b4c6-f281e0c36449.
