### PR TITLE
fix(ai): production initAsync sweep — every external call rides ready(), double-init bugs fixed, contract guard frozen at zero (#15033)

### DIFF
--- a/ai/Agent.mjs
+++ b/ai/Agent.mjs
@@ -102,17 +102,33 @@ ALWAYS use your file system or knowledge base tools to read the relevant source 
     /**
      * The captured boot failure when the construct-fired `initAsync()` could not complete.
      * The framework fires `initAsync()` with no external observer to reject to, and a
-     * rejection there would leave `ready()` hanging forever — so boot failures degrade
-     * instead (the GraphService precedent): `ready()` resolves, this field carries the
-     * error, and consumers own the disposition after awaiting `ready()`.
+     * rejection there would leave the base ready promise hanging forever — so the boot
+     * captures the failure here and {@link #ready} re-throws it: a broken Agent (no loop,
+     * no clients) must never look success-shaped to ANY consumer boundary.
      * @member {Error|null} initError=null
      */
     initError = null
 
     /**
+     * Sharpens the base readiness contract: the base promise resolves when the construct-fired
+     * init COMPLETED — including a captured-failure completion — but an Agent whose boot failed
+     * holds no usable runtime. Re-throwing {@link #initError} here makes a failed boot
+     * observable at every direct consumer boundary (the orchestrator, `delegate()`'s sub-agent
+     * cache, standalone scripts) without any of them reaching for the field.
+     * @returns {Promise<void>}
+     */
+    async ready() {
+        await super.ready();
+
+        if (this.initError) {
+            throw this.initError
+        }
+    }
+
+    /**
      * Async initialization sequence.
      * Creates and connects all configured clients, then initializes the Cognitive Runtime.
-     * Failures degrade into {@link #initError} rather than rejecting (see the field JSDoc).
+     * Failures are captured into {@link #initError}, which {@link #ready} re-throws.
      * @returns {Promise<void>}
      */
     async initAsync() {

--- a/ai/Agent.mjs
+++ b/ai/Agent.mjs
@@ -100,59 +100,75 @@ ALWAYS use your file system or knowledge base tools to read the relevant source 
     subAgentTurns = {}
 
     /**
+     * The captured boot failure when the construct-fired `initAsync()` could not complete.
+     * The framework fires `initAsync()` with no external observer to reject to, and a
+     * rejection there would leave `ready()` hanging forever — so boot failures degrade
+     * instead (the GraphService precedent): `ready()` resolves, this field carries the
+     * error, and consumers own the disposition after awaiting `ready()`.
+     * @member {Error|null} initError=null
+     */
+    initError = null
+
+    /**
      * Async initialization sequence.
      * Creates and connects all configured clients, then initializes the Cognitive Runtime.
+     * Failures degrade into {@link #initError} rather than rejecting (see the field JSDoc).
      * @returns {Promise<void>}
      */
     async initAsync() {
         await super.initAsync();
 
-        // 1. Connect to MCP Servers
-        const readyPromises = [];
+        try {
+            // 1. Connect to MCP Servers
+            const readyPromises = [];
 
-        for (const serverName of this.servers) {
-            const client = Neo.create(Client, {
-                serverName,
-                env: process.env // Pass generic env for now
+            for (const serverName of this.servers) {
+                const client = Neo.create(Client, {
+                    serverName,
+                    env: process.env // Pass generic env for now
+                });
+
+                readyPromises.push(client.ready());
+
+                this.clients[Neo.camel(serverName)] = client;
+            }
+
+            await Promise.all(readyPromises);
+            console.log('[Agent] Connected to MCP servers:', Object.keys(this.clients));
+
+            // 2. Initialize Cognitive Runtime
+            console.log('[Agent] Initializing Cognitive Runtime...');
+
+            let providerClass = this.modelProvider;
+
+            if (typeof providerClass === 'string') {
+                providerClass = providerClass.toLowerCase() === 'ollama' ? OllamaProvider : GeminiProvider;
+            }
+
+            const provider = Neo.create(providerClass, this.providerConfig || {});
+
+            const assembler = Neo.create(ContextAssembler);
+            await assembler.ready(); // Connects to Memory Core via Services SDK
+
+            const scheduler = Neo.create(Scheduler);
+
+            // Create the Loop
+            this.loop = Neo.create(Loop, {
+                agent       : this,
+                allowedTools: this.allowedTools,
+                assembler,
+                clients     : this.clients,
+                provider,
+                scheduler
             });
 
-            readyPromises.push(client.ready());
+            await this.loop.ready();
 
-            this.clients[Neo.camel(serverName)] = client;
+            console.log('[Agent] Runtime Ready.');
+        } catch (error) {
+            this.initError = error;
+            console.error('[Agent] Boot failed; runtime degraded:', error.message);
         }
-
-        await Promise.all(readyPromises);
-        console.log('[Agent] Connected to MCP servers:', Object.keys(this.clients));
-
-        // 2. Initialize Cognitive Runtime
-        console.log('[Agent] Initializing Cognitive Runtime...');
-
-        let providerClass = this.modelProvider;
-
-        if (typeof providerClass === 'string') {
-            providerClass = providerClass.toLowerCase() === 'ollama' ? OllamaProvider : GeminiProvider;
-        }
-
-        const provider = Neo.create(providerClass, this.providerConfig || {});
-
-        const assembler = Neo.create(ContextAssembler);
-        await assembler.ready(); // Connects to Memory Core via Services SDK
-
-        const scheduler = Neo.create(Scheduler);
-
-        // Create the Loop
-        this.loop = Neo.create(Loop, {
-            agent       : this,
-            allowedTools: this.allowedTools,
-            assembler,
-            clients     : this.clients,
-            provider,
-            scheduler
-        });
-
-        await this.loop.ready();
-
-        console.log('[Agent] Runtime Ready.');
     }
 
     /**
@@ -239,8 +255,8 @@ ALWAYS use your file system or knowledge base tools to read the relevant source 
             this.subAgentTurns[profileName]++;
 
             const result = await subAgent.loop.processEvent({
-                type: 'delegate',
-                data: request,
+                type        : 'delegate',
+                data        : request,
                 systemPrompt: subAgent.getEnhancedSystemPrompt()
             });
 

--- a/ai/agent/AgentOrchestrator.mjs
+++ b/ai/agent/AgentOrchestrator.mjs
@@ -408,13 +408,9 @@ class AgentOrchestrator extends Base {
             const agent = this.createAgent();
 
             // construct() auto-fired the agent's initAsync; ready() awaits it without the former
-            // double-run (which created every MCP client twice). Boot failures degrade inside
-            // Agent.initAsync and surface here, keeping this catch block the error path.
+            // double-run (which created every MCP client twice) and re-throws a captured boot
+            // failure (the Agent readiness contract), keeping this catch block the error path.
             await agent.ready();
-
-            if (agent.initError) {
-                throw agent.initError;
-            }
 
             console.log('   Injecting Golden Path Directives into Scheduler...');
 

--- a/ai/agent/AgentOrchestrator.mjs
+++ b/ai/agent/AgentOrchestrator.mjs
@@ -1,11 +1,11 @@
-import Base  from '../../src/core/Base.mjs';
-import Agent from '../Agent.mjs';
+import Base   from '../../src/core/Base.mjs';
+import Agent  from '../Agent.mjs';
 import crypto from 'crypto';
-import fs    from 'fs';
-import path  from 'path';
+import fs     from 'fs';
+import path   from 'path';
 
 const OUTCOME_STATUSES = new Set(['completed', 'failed', 'blocked', 'expired', 'exhausted', 'crashed']),
-      REASON_CODES      = new Set([
+      REASON_CODES     = new Set([
           'agent-uncaught-error',
           'productive-failure-tripwire',
           'turn-limit',
@@ -89,7 +89,7 @@ class AgentOrchestrator extends Base {
             return null;
         }
 
-        const content = fs.readFileSync(this.handoffPath, 'utf-8');
+        const content         = fs.readFileSync(this.handoffPath, 'utf-8');
         const goldenPathMatch = content.match(/## Computed Golden Path[^\n]*\n([\s\S]*?)(?=\n#|$)/);
 
         if (!goldenPathMatch) {
@@ -407,7 +407,14 @@ class AgentOrchestrator extends Base {
 
             const agent = this.createAgent();
 
-            await agent.initAsync();
+            // construct() auto-fired the agent's initAsync; ready() awaits it without the former
+            // double-run (which created every MCP client twice). Boot failures degrade inside
+            // Agent.initAsync and surface here, keeping this catch block the error path.
+            await agent.ready();
+
+            if (agent.initError) {
+                throw agent.initError;
+            }
 
             console.log('   Injecting Golden Path Directives into Scheduler...');
 

--- a/ai/daemons/orchestrator/services/DreamService.mjs
+++ b/ai/daemons/orchestrator/services/DreamService.mjs
@@ -234,14 +234,11 @@ class DreamService extends Base {
         await StorageRouter.ready();
         this.sessionsCollection = await StorageRouter.getSummaryCollection();
 
-        // Inter-service dependency lock: ensure DB is ready BEFORE scheduling background work
+        // Inter-service dependency lock: ready() reflects the full lifecycle boot (GraphService.db
+        // mounted included) — the former `_initPromise` reach-in below it was dead code, since
+        // SystemLifecycleService never assigned that field.
         const LifecycleService = (await import('../../../services.mjs')).Memory_LifecycleService;
         await LifecycleService.ready();
-
-        // Wait for the full lifecycle boot to ensure GraphService.db is mounted
-        if (LifecycleService._initPromise) {
-            await LifecycleService._initPromise;
-        }
     }
 
     /**
@@ -739,9 +736,9 @@ class DreamService extends Base {
         includeDecay = true,
         dryRun       = false
     } = {}) {
-        const startedAtMs = Date.now();
-        const startedAt   = new Date(startedAtMs);
-        const runId       = `rem-${crypto.randomUUID()}`;
+        const startedAtMs      = Date.now();
+        const startedAt        = new Date(startedAtMs);
+        const runId            = `rem-${crypto.randomUUID()}`;
         const perPhaseStates   = [];
         let   perSessionStates = [];
 
@@ -888,8 +885,8 @@ class DreamService extends Base {
                     const message = toErrorMessage(e);
                     perPhaseStates.push(finishPhase('decay', decayStart, 'failed', {error: message}));
                     return await finalize('failed', {
-                        reasonCode  : 'decay-failed',
-                        failurePhase: 'decay',
+                        reasonCode       : 'decay-failed',
+                        failurePhase     : 'decay',
                         error            : {message: `decayGlobalTopology threw on zero-session path: ${message}`, stack: e?.stack},
                         sessionsProcessed: 0
                     });

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -267,7 +267,7 @@ class Server extends BaseServer {
         await this.prepareStartupDependency({
             name      : 'tool-telemetry',
             dependency: RecorderService,
-            start     : () => RecorderService.initAsync(),
+            start     : () => RecorderService.ready(),
             degraded  : 'Memory Core tool telemetry is disabled; tool dispatch remains available'
         });
 

--- a/ai/mcp/server/neural-link/test_connection_service.mjs
+++ b/ai/mcp/server/neural-link/test_connection_service.mjs
@@ -6,7 +6,8 @@ console.log('ConnectionService imported');
 console.log('Is instance?', ConnectionService instanceof Neo.core.Base);
 
 try {
-    await ConnectionService.initAsync();
+    // construct auto-fires initAsync; ready() resolves once the singleton finished initializing
+    await ConnectionService.ready();
     console.log('ConnectionService initialized');
 
     try {

--- a/ai/scripts/lifecycle/backfill-memory-summaries.mjs
+++ b/ai/scripts/lifecycle/backfill-memory-summaries.mjs
@@ -23,7 +23,7 @@ import MemoryService               from '../../services/memory-core/MemoryServic
 async function main() {
     const outcome = await withHeavyMaintenanceLease(
         async () => {
-            await LifecycleService.initAsync();
+            await LifecycleService.ready();
             return MemoryService.backfillMiniSummaries();
         },
         {

--- a/ai/scripts/lifecycle/checkAllAgentIdle.mjs
+++ b/ai/scripts/lifecycle/checkAllAgentIdle.mjs
@@ -54,8 +54,8 @@ export function deriveAllAgentIdleCycleId(identities, details) {
  * @returns {Promise<Object>} All-agent-idle detector signal.
  */
 export async function checkAllAgentIdle() {
-    await LifecycleService.initAsync();
-    await GraphService.initAsync();
+    await LifecycleService.ready();
+    await GraphService.ready();
     const db = GraphService.db.storage.db;
 
     // All-idle check set: the registered active team (deployment-portable via `identityRoots`),

--- a/ai/scripts/lifecycle/checkSunsetted.mjs
+++ b/ai/scripts/lifecycle/checkSunsetted.mjs
@@ -72,10 +72,10 @@ import { checkInflightLock } from './inflightLock.mjs';
  * @returns {Promise<Object>} Structured detector contract consumed by shell and daemon paths.
  */
 export async function checkSunsetted(identity = process.env.NEO_AGENT_IDENTITY || '@neo-gemini-pro') {
-    await LifecycleService.initAsync();
+    await LifecycleService.ready();
 
-    // Ensure GraphService is initialized
-    await GraphService.initAsync();
+    // Ensure GraphService finished initializing
+    await GraphService.ready();
     const db = GraphService.db.storage.db;
 
     // Query all subscriptions for this identity so the detector emits a structured

--- a/ai/scripts/lifecycle/idleOutNudge.mjs
+++ b/ai/scripts/lifecycle/idleOutNudge.mjs
@@ -93,9 +93,9 @@ export async function idleOutNudge(identity) {
         }
     }
 
-    // 2. Initialize Memory Core services before graph access.
-    await LifecycleService.initAsync();
-    await GraphService.initAsync();
+    // 2. Await Memory Core service readiness before graph access.
+    await LifecycleService.ready();
+    await GraphService.ready();
 
     // 3. Defensive in-flight lock check. The detector contract in checkSunsetted.mjs
     //    SHOULD have already filtered this out — it consults the lock and downgrades

--- a/ai/scripts/lifecycle/nightlyE2eRunner.mjs
+++ b/ai/scripts/lifecycle/nightlyE2eRunner.mjs
@@ -138,8 +138,8 @@ export async function runNightlyE2e() {
         }
 
         const sender = process.env.NEO_AGENT_IDENTITY || '@system';
-        await LifecycleService.initAsync();
-        await GraphService.initAsync();
+        await LifecycleService.ready();
+        await GraphService.ready();
 
         await RequestContextService.run({agentIdentityNodeId: sender}, async () => {
             await MailboxService.addMessage({

--- a/ai/scripts/lifecycle/summarize-sessions.mjs
+++ b/ai/scripts/lifecycle/summarize-sessions.mjs
@@ -27,7 +27,7 @@ const logInfo = message => console.error(`[INFO] ${message}`);
 async function summarize() {
     logInfo('[summarize-sessions] Initializing SessionService...');
     try {
-        await Memory_SessionService.initAsync();
+        await Memory_SessionService.ready();
 
         logInfo('[summarize-sessions] Draining pending session summarization markers...');
         const pendingResult = await Memory_SessionService.summarizePendingSessions();

--- a/ai/scripts/lifecycle/swarmWakeCooldown.mjs
+++ b/ai/scripts/lifecycle/swarmWakeCooldown.mjs
@@ -56,9 +56,9 @@ export async function swarmWakeCooldown(signal) {
 
         console.error(`[swarmWakeCooldown] Firing SYSTEM WAKE for cycle ${signal.cycle_id} to ${signal.coordinator_recommendation}`);
 
-        // Initialize Services to send an A2A message
-        await LifecycleService.initAsync();
-        await GraphService.initAsync();
+        // Await service readiness to send an A2A message (construct auto-fires init; never call initAsync externally)
+        await LifecycleService.ready();
+        await GraphService.ready();
 
         const coordinator = signal.coordinator_recommendation || '@neo-gemini-pro';
         const sender = process.env.NEO_AGENT_IDENTITY || '@system';

--- a/ai/scripts/lifecycle/sweepExpiredTasks.mjs
+++ b/ai/scripts/lifecycle/sweepExpiredTasks.mjs
@@ -31,7 +31,7 @@ import LifecycleService from '../../services/memory-core/lifecycle/SystemLifecyc
 import MailboxService   from '../../services/memory-core/MailboxService.mjs';
 
 async function main() {
-    await LifecycleService.initAsync();
+    await LifecycleService.ready();
     const result = await MailboxService.sweepExpiredTasks();
     console.log(JSON.stringify(result));
     process.exit(0)

--- a/ai/scripts/maintenance/auditGraphIntegrity.mjs
+++ b/ai/scripts/maintenance/auditGraphIntegrity.mjs
@@ -304,7 +304,7 @@ export async function runAudit({
     logger        = console
 } = {}) {
     await lifecycle.ready();
-    await graphService.initAsync();
+    await graphService.ready();
 
     const [memoryCollection, summaryCollection] = await Promise.all([
         storageRouter.getMemoryCollection(),

--- a/ai/scripts/maintenance/businessMetricsProbeCore.mjs
+++ b/ai/scripts/maintenance/businessMetricsProbeCore.mjs
@@ -197,7 +197,7 @@ export async function runProbe(args, {aiConfig, graphService, execGit, writeMani
 
     const id = createMetricId({source, metricName: FIRST_CATEGORY, windowSemantics: 'day:utc', periodStart: period});
 
-    await graphService.initAsync();
+    await graphService.ready();
 
     const existing = await graphService.getNodeRecord({id});
     const guard    = isClosedPeriodViolation(existing?.properties, properties);
@@ -237,7 +237,7 @@ export async function runProbe(args, {aiConfig, graphService, execGit, writeMani
  * @returns {Object} `{exitCode, survived, lost}`
  */
 export async function runVerify({manifest}, {graphService}) {
-    await graphService.initAsync();
+    await graphService.ready();
 
     const survived = [];
     const lost     = [];

--- a/ai/scripts/maintenance/graphLifecycleReport.mjs
+++ b/ai/scripts/maintenance/graphLifecycleReport.mjs
@@ -110,7 +110,7 @@ export async function runReport({
     logger               = console
 } = {}) {
     await lifecycle.ready();
-    await graphService.initAsync();
+    await graphService.ready();
 
     const census = await graphService.getLifecycleCensus({includeIncidentEdges});
 

--- a/ai/scripts/maintenance/kbPushClient.mjs
+++ b/ai/scripts/maintenance/kbPushClient.mjs
@@ -3,13 +3,13 @@
 // wrapper from a tenant checkout or CI job.
 import 'dotenv/config';
 import {Command}       from 'commander';
-import Neo            from '../../../src/Neo.mjs';
-import * as core      from '../../../src/core/_export.mjs';
+import Neo             from '../../../src/Neo.mjs';
+import * as core       from '../../../src/core/_export.mjs';
 import InstanceManager from '../../../src/manager/Instance.mjs';
-import fs             from 'fs';
+import fs              from 'fs';
 import {pathToFileURL} from 'url';
-import Client         from '../../mcp/client/Client.mjs';
-import ClientConfig   from '../../mcp/client/config.mjs';
+import Client          from '../../mcp/client/Client.mjs';
+import ClientConfig    from '../../mcp/client/config.mjs';
 
 /**
  * @module ai/scripts/maintenance/kbPushClient
@@ -72,8 +72,8 @@ function createArgParser() {
  * @returns {Object}
  */
 function parseArgs(argv, env = process.env) {
-    const program = createArgParser();
-    let parseError = null;
+    const program    = createArgParser();
+    let   parseError = null;
 
     try {
         program.parse(argv, {from: 'user'});
@@ -224,7 +224,7 @@ function hasIngestFailure(payload) {
  * @returns {Promise<*>} Decoded tool payload.
  */
 async function runPush({args, input, clientFactory, clientConfig = ClientConfig}) {
-    const envelope = applyEnvelopeDefaults(await readJsonPayload(input), args),
+    const envelope   = applyEnvelopeDefaults(await readJsonPayload(input), args),
           serverName = `knowledge-base-push-${Date.now()}`;
 
     clientConfig.data.mcpServers[serverName] = buildServerConfig(args);
@@ -234,7 +234,7 @@ async function runPush({args, input, clientFactory, clientConfig = ClientConfig}
         : Neo.create(Client, {serverName, clientName: args.clientName});
 
     try {
-        await client.initAsync?.();
+        await client.ready?.();
         return decodeToolResult(await client.callTool('ingest_source_files', envelope));
     } finally {
         await client.close?.();

--- a/ai/scripts/maintenance/migrationCensusReport.mjs
+++ b/ai/scripts/maintenance/migrationCensusReport.mjs
@@ -112,7 +112,7 @@ export async function runReport({
     logger        = console
 } = {}) {
     await lifecycle.ready();
-    await graphService.initAsync();
+    await graphService.ready();
 
     const census = await healthService.getMigrationCensus({includeChroma});
 

--- a/ai/scripts/maintenance/probeCollectionQueryHealth.mjs
+++ b/ai/scripts/maintenance/probeCollectionQueryHealth.mjs
@@ -20,9 +20,9 @@ import {
  * @module ai/scripts/maintenance/probeCollectionQueryHealth
  */
 async function main() {
-    await LifecycleService.initAsync();
-    await GraphService.initAsync();
-    await StorageRouter.initAsync();
+    await LifecycleService.ready();
+    await GraphService.ready();
+    await StorageRouter.ready();
 
     const result = await StorageRouter.probeCollectionQueryHealth();
 

--- a/ai/scripts/maintenance/purgeNoContentGraphMemories.mjs
+++ b/ai/scripts/maintenance/purgeNoContentGraphMemories.mjs
@@ -119,7 +119,7 @@ export function countIncidentEdges({db, nodeIds, chunkSize = DEFAULT_CHROMA_FETC
 
     for (const slice of chunk(nodeIds, chunkSize)) {
         const placeholders = slice.map(() => '?').join(',');
-        const row = db.prepare(`
+        const row          = db.prepare(`
             SELECT COUNT(*) AS count
             FROM Edges
             WHERE source IN (${placeholders})
@@ -199,7 +199,7 @@ export async function runNoContentGraphMemoryCleanup({
     }
 
     await lifecycle?.ready?.();
-    await graphService?.initAsync?.();
+    await graphService?.ready?.();
 
     const db = graphService?.db?.storage?.db;
 
@@ -210,7 +210,7 @@ export async function runNoContentGraphMemoryCleanup({
     collection ??= await storageRouter.getMemoryCollection();
 
     const beforePendingSessionSummaryCount = getPendingSessionSummaryCount(db);
-    const plan = await buildCleanupPlan({db, collection, chunkSize});
+    const plan                             = await buildCleanupPlan({db, collection, chunkSize});
 
     let deletedNodes = 0;
 
@@ -220,7 +220,7 @@ export async function runNoContentGraphMemoryCleanup({
     }
 
     const afterPendingSessionSummaryCount = getPendingSessionSummaryCount(db);
-    const result = {
+    const result                          = {
         apply,
         dryRun: !apply,
         beforePendingSessionSummaryCount,
@@ -290,7 +290,7 @@ export async function runCli(argv = process.argv) {
 
     command.parse(argv);
 
-    const options = command.opts();
+    const options   = command.opts();
     const chunkSize = Number(options.chunkSize);
 
     if (!Number.isInteger(chunkSize) || chunkSize <= 0) {

--- a/ai/scripts/maintenance/repairUnprojectedSessions.mjs
+++ b/ai/scripts/maintenance/repairUnprojectedSessions.mjs
@@ -285,7 +285,7 @@ export async function createDryRunRuntime() {
     const {default: ChromaManager} = await import('../../services/memory-core/managers/ChromaManager.mjs');
     const {default: Database}      = await import('better-sqlite3');
 
-    await ChromaManager.initAsync();
+    await ChromaManager.ready();
 
     const
         summaryCollection = await ChromaManager.getSummaryCollection(),
@@ -319,9 +319,9 @@ export async function createApplyRuntime() {
     } = await import('../../services.mjs');
     const {default: MemorySessionIngestor} = await import('../../services/ingestion/MemorySessionIngestor.mjs');
 
-    await LifecycleService.initAsync();
-    await GraphService.initAsync();
-    await StorageRouter.initAsync();
+    await LifecycleService.ready();
+    await GraphService.ready();
+    await StorageRouter.ready();
 
     const
         summaryCollection = await StorageRouter.getSummaryCollection(),

--- a/ai/scripts/migrations/priorityBackfill.mjs
+++ b/ai/scripts/migrations/priorityBackfill.mjs
@@ -55,8 +55,8 @@ for (let i = 0; i < args.length; i++) {
 }
 
 async function run() {
-    logger.info('[priorityBackfill] Bootstrapping Memory Graph Service...');
-    await GraphService.initAsync();
+    logger.info('[priorityBackfill] Awaiting Memory Graph Service readiness...');
+    await GraphService.ready();
 
     const summaryCollection = await StorageRouter.getSummaryCollection();
 

--- a/ai/scripts/setup/seedAgentIdentities.mjs
+++ b/ai/scripts/setup/seedAgentIdentities.mjs
@@ -37,8 +37,8 @@ import { Memory_GraphService } from '../../services.mjs';
 import { IDENTITIES }          from '../../graph/identityRoots.mjs';
 
 async function seed() {
-    console.log('Bootstrapping Memory Graph Service...');
-    await Memory_GraphService.initAsync();
+    console.log('Awaiting Memory Graph Service readiness...');
+    await Memory_GraphService.ready();
 
     console.log('Seeding Agent Identities...');
     let seededCount = 0;

--- a/ai/services/knowledge-base/IngestionService.mjs
+++ b/ai/services/knowledge-base/IngestionService.mjs
@@ -698,7 +698,7 @@ class IngestionService extends Base {
     async getTenantManifests({tenantId} = {}) {
         const {tenantId: resolvedTenant} = this.resolveTenantContext({tenantId});
 
-        await this.graphService.initAsync();
+        await this.graphService.ready();
 
         const record = this.graphService.getNodeRecord({id: `kb-manifest:${resolvedTenant}`}),
               source = record?.properties?.manifests;
@@ -765,7 +765,7 @@ class IngestionService extends Base {
                 };
             }
 
-            await this.graphService.initAsync();
+            await this.graphService.ready();
 
             const nodeId    = `kb-manifest:${tenantContext.tenantId}`,
                   existing  = this.graphService.getNodeRecord({id: nodeId}),
@@ -1232,7 +1232,7 @@ class IngestionService extends Base {
     async getTenantConfig({tenantId} = {}) {
         const resolvedTenant = normalizeUserId(tenantId) || aiConfig.defaultTenantId;
 
-        await this.graphService.initAsync();
+        await this.graphService.ready();
 
         const record = this.graphService.getNodeRecord({id: `kb-config:${resolvedTenant}`});
 
@@ -1333,7 +1333,7 @@ class IngestionService extends Base {
      * @returns {Promise<{tenantRepos: Array<Object>}>} Contract-normalized; throws on a malformed entry.
      */
     async listConfiguredTenantRepos() {
-        await this.graphService.initAsync();
+        await this.graphService.ready();
 
         const bootstrap       = this.readKbConfigBootstrap(),
               yamlTenants     = (bootstrap && bootstrap.tenants) || {},
@@ -1440,7 +1440,7 @@ class IngestionService extends Base {
             const {tenantId: resolvedTenant} = this.resolveTenantContext({tenantId}),
                   normalizedConfig           = normalizeTenantRepoConfig(config);
 
-            await this.graphService.initAsync();
+            await this.graphService.ready();
 
             const nodeId   = `kb-config:${resolvedTenant}`,
                   existing = this.graphService.getNodeRecord({id: nodeId}),

--- a/ai/services/memory-core/lifecycle/SystemLifecycleService.mjs
+++ b/ai/services/memory-core/lifecycle/SystemLifecycleService.mjs
@@ -37,19 +37,13 @@ class SystemLifecycleService extends Base {
 
         logger.info('[SystemLifecycleService] Booting internal memory-core microservices. Please stand by...');
 
-        const GraphService        = (await import('../GraphService.mjs')).default;
-        const StorageRouter       = (await import('../managers/StorageRouter.mjs')).default;
+        const GraphService  = (await import('../GraphService.mjs')).default;
+        const StorageRouter = (await import('../managers/StorageRouter.mjs')).default;
 
-        // 1. Boot External Daemons First
-        if (!ChromaLifecycleService._initPromise) await ChromaLifecycleService.initAsync();
-        if (!InferenceLifecycleService._initPromise) await InferenceLifecycleService.initAsync();
-
-        // 2. Boot Core Storage
-        if (!GraphService._initPromise) await GraphService.initAsync();
-
-        // 3. Boot Router (relies on active Daemons)
-        if (!StorageRouter._initPromise) await StorageRouter.initAsync();
-
+        // Every child is a singleton whose construct() already auto-fired its own initAsync at
+        // import time — awaiting ready() is the whole boot contract. The former external
+        // initAsync() calls here double-initialized StorageRouter on every boot (its guard flag
+        // was never set), which this collapse removes.
         await ChromaLifecycleService.ready();
         await InferenceLifecycleService.ready();
         await GraphService.ready();

--- a/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
+++ b/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
@@ -32,11 +32,11 @@ const createTestHandoff = (filename, content) => {
                   }
               },
               scheduled: [],
-              async initAsync() {
-                  if (initError) {
-                      throw initError;
-                  }
-              },
+              // the core.Base contract surface: construct auto-fires init; consumers await
+              // ready() and read the catch-and-degrade initError field afterwards — the
+              // orchestrator re-throws it, which the crashed-outcome spec below pins
+              initError,
+              async ready() {},
               schedule(event) {
                   this.scheduled.push(event);
                   onSchedule?.(event);

--- a/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
+++ b/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
@@ -1,8 +1,8 @@
-import test         from '@playwright/test';
-import fs           from 'fs';
-import path         from 'path';
+import test              from '@playwright/test';
+import fs                from 'fs';
+import path              from 'path';
 import Neo               from '../../../../src/Neo.mjs';
-import * as core       from '../../../../src/core/_export.mjs';
+import * as core         from '../../../../src/core/_export.mjs';
 import AgentOrchestrator from '../../../../ai/agent/AgentOrchestrator.mjs';
 
 const createTestHandoff = (filename, content) => {
@@ -32,11 +32,15 @@ const createTestHandoff = (filename, content) => {
                   }
               },
               scheduled: [],
-              // the core.Base contract surface: construct auto-fires init; consumers await
-              // ready() and read the catch-and-degrade initError field afterwards — the
-              // orchestrator re-throws it, which the crashed-outcome spec below pins
+              // the Agent readiness contract: construct auto-fires init; ready() resolves on a
+              // healthy boot and re-throws the captured boot failure — the crashed-outcome spec
+              // below pins that a failed boot never looks success-shaped
               initError,
-              async ready() {},
+              async ready() {
+                  if (this.initError) {
+                      throw this.initError;
+                  }
+              },
               schedule(event) {
                   this.scheduled.push(event);
                   onSchedule?.(event);
@@ -147,10 +151,10 @@ Based on priorities, the following tasks are mathematically recommended:
 
         try {
             const orchestrator = Neo.create(AgentOrchestrator, {
-                agentFactory     : () => fakeAgent,
-                exitHandler      : code => exitCodes.push(code),
-                handoffPath      : testHandoffPath,
-                healthService    : {
+                agentFactory : () => fakeAgent,
+                exitHandler  : code => exitCodes.push(code),
+                handoffPath  : testHandoffPath,
+                healthService: {
                     recordTaskOutcome: (...args) => healthCalls.push(args)
                 },
                 monitorIntervalMs: 1,
@@ -223,14 +227,14 @@ Based on priorities, the following tasks are mathematically recommended:
 
         try {
             const orchestrator = Neo.create(AgentOrchestrator, {
-                agentFactory     : () => createFakeAgent({failedEvents}),
-                exitHandler      : () => {},
-                handoffEmitter   : outcome => {
+                agentFactory  : () => createFakeAgent({failedEvents}),
+                exitHandler   : () => {},
+                handoffEmitter: outcome => {
                     handoffCalls.push(outcome);
                     return 'MESSAGE:failed';
                 },
-                handoffPath      : testHandoffPath,
-                healthService    : {
+                handoffPath  : testHandoffPath,
+                healthService: {
                     recordTaskOutcome: (...args) => healthCalls.push(args)
                 },
                 monitorIntervalMs: 1,
@@ -277,8 +281,8 @@ Based on priorities, the following tasks are mathematically recommended:
         const testHandoffPath = createTestHandoff('.neo-test-handoff-blocked.md', content),
               outcomePath     = path.resolve(process.cwd(), '.neo-test-agent-orchestrator/blocked.jsonl'),
               failedEvents    = [{
-                  error     : 'blocked-task-state: credentials required',
-                  event     : {
+                  error: 'blocked-task-state: credentials required',
+                  event: {
                       type: 'system:golden-path',
                       data: {
                           issueId: '9900'
@@ -340,8 +344,8 @@ Based on priorities, the following tasks are mathematically recommended:
                     handoffCalls.push(outcome);
                     return 'MESSAGE:expired';
                 },
-                handoffPath       : testHandoffPath,
-                monitorIntervalMs : 50,
+                handoffPath      : testHandoffPath,
+                monitorIntervalMs: 50,
                 outcomePath
             });
 
@@ -390,8 +394,8 @@ Based on priorities, the following tasks are mathematically recommended:
 
         try {
             const orchestrator = Neo.create(AgentOrchestrator, {
-                agentFactory     : () => createFakeAgent({initError}),
-                handoffEmitter   : outcome => {
+                agentFactory  : () => createFakeAgent({initError}),
+                handoffEmitter: outcome => {
                     handoffCalls.push(outcome);
                     return {messageId: 'MESSAGE:crash'};
                 },
@@ -450,10 +454,10 @@ Based on priorities, the following tasks are mathematically recommended:
 
         try {
             const orchestrator = Neo.create(AgentOrchestrator, {
-                agentFactory     : () => createFakeAgent(),
-                exitHandler      : code => exitCodes.push(code),
-                handoffPath      : testHandoffPath,
-                healthService    : {
+                agentFactory : () => createFakeAgent(),
+                exitHandler  : code => exitCodes.push(code),
+                handoffPath  : testHandoffPath,
+                healthService: {
                     recordTaskOutcome: () => {
                         throw new Error('health down');
                     }
@@ -484,8 +488,8 @@ Based on priorities, the following tasks are mathematically recommended:
         const orchestrator = Neo.create(AgentOrchestrator, {});
 
         test.expect(() => orchestrator.createOutcome({
-            runId      : 'run-invalid',
-            directive  : {
+            runId    : 'run-invalid',
+            directive: {
                 issueId    : '1',
                 description: 'invalid vocabulary'
             },

--- a/test/playwright/unit/ai/AgentReadiness.spec.mjs
+++ b/test/playwright/unit/ai/AgentReadiness.spec.mjs
@@ -1,0 +1,93 @@
+import test      from '@playwright/test';
+import Neo       from '../../../../src/Neo.mjs';
+import * as core from '../../../../src/core/_export.mjs';
+import Agent     from '../../../../ai/Agent.mjs';
+
+const {expect} = test;
+
+/**
+ * @summary Probes for the Agent readiness contract: a failed boot must be observable at every
+ * direct `ready()` boundary — never success-shaped partial state.
+ *
+ * The base ready promise resolves when the construct-fired `initAsync()` COMPLETES, including a
+ * captured-failure completion (a rejection there would hang every waiter — the framework fires
+ * init with no external observer). `Agent.ready()` therefore re-throws the captured
+ * `initError`, so consumers cannot proceed onto an instance with no loop and no clients. These
+ * probes drive the REAL class through a boot-bypassing subclass: the real `initAsync` needs
+ * live MCP servers, which a unit run must never require — the subclass simulates exactly the
+ * two completions the contract distinguishes (healthy / captured failure).
+ */
+class ProbeAgent extends Agent {
+    static config = {
+        /**
+         * @member {String} className='Probe.ai.AgentReadiness'
+         * @protected
+         */
+        className: 'Probe.ai.AgentReadiness',
+        /**
+         * Simulate the captured-failure boot completion.
+         * @member {Boolean} failBoot=false
+         */
+        failBoot: false
+    }
+
+    /**
+     * Boot bypass: completes like the real one (resolve + optionally capture), without MCP I/O.
+     * @returns {Promise<void>}
+     */
+    async initAsync() {
+        // deliberately skips Agent.initAsync (the MCP boot) — core.Base registers remotes only
+        await Neo.core.Base.prototype.initAsync.call(this);
+
+        if (this.failBoot) {
+            this.initError = new Error('boot failed: probe')
+        }
+    }
+}
+
+Neo.setupClass(ProbeAgent);
+
+test.describe('Neo.ai.Agent — readiness contract (failed boot is never success-shaped)', () => {
+    test('a healthy boot resolves ready(); a failed boot REJECTS it even though the base promise resolved', async () => {
+        const healthy = Neo.create(ProbeAgent, {servers: []});
+        await expect(healthy.ready()).resolves.toBeUndefined();
+        healthy.destroy();
+
+        const broken = Neo.create(ProbeAgent, {failBoot: true, servers: []});
+
+        await expect(broken.ready()).rejects.toThrow('boot failed: probe');
+        // the sharpened contract in one frame: init COMPLETED (isReady true — the base promise
+        // resolved, nothing hangs) yet readiness is REFUSED (the runtime is unusable)
+        expect(broken.isReady).toBe(true);
+        expect(broken.initError).not.toBeNull();
+        broken.destroy()
+    });
+
+    test('delegate() never caches a sub-agent whose boot failed', async () => {
+        const parent = Neo.create(ProbeAgent, {
+            servers  : [],
+            subAgents: {
+                broken: () => Promise.resolve(ProbeAgent)
+            }
+        });
+
+        await parent.ready();
+
+        // the profile class boots with failBoot via a scoped default: create the sub-agent
+        // through a wrapper class so the probe failure rides the REAL delegate() path
+        class BrokenProfile extends ProbeAgent {
+            static config = {
+                className: 'Probe.ai.AgentReadiness.BrokenProfile',
+                failBoot : true
+            }
+        }
+        Neo.setupClass(BrokenProfile);
+        parent.subAgents = {broken: () => Promise.resolve(BrokenProfile)};
+
+        await expect(parent.delegate('broken', 'any request')).rejects.toThrow('boot failed: probe');
+        // the cache stays clean: a broken sub-agent must never be handed to the NEXT delegate call
+        expect(parent.activeSubAgents.broken).toBeUndefined();
+
+        parent.destroy()
+    });
+});

--- a/test/playwright/unit/ai/InitAsyncContractGuard.spec.mjs
+++ b/test/playwright/unit/ai/InitAsyncContractGuard.spec.mjs
@@ -22,12 +22,38 @@ const SCAN_ROOTS = ['src', 'ai'];
 const EXEMPT_FILES = new Set(['src/core/Base.mjs']);
 
 // Call-anchored, not await-anchored: thunks and passed references (`start: () => X.initAsync()`)
-// are the same double-run bug without an `await` keyword in front.
-const EXTERNAL_INIT_CALL = /(?<!super)\.initAsync\(\)/;
+// are the same double-run bug without an `await` keyword in front. Syntax-tolerant: optional
+// chaining (`.initAsync?.()`) and whitespace variants evaded the first, exact-literal shape of
+// this pattern — the fixture self-test below pins every variant permanently.
+const EXTERNAL_INIT_CALL = /(?<!super)\.initAsync\s*(\?\.)?\s*\(/;
 
 // Any `X._initPromise` where X is not `this`: reads, writes, and null-resets are all reach-ins.
 // Owner-internal `this._initPromise` stays legal until the bespoke guards are deleted.
 const INIT_PROMISE_REACH_IN = /(?<!this)\._initPromise/;
+
+// The permanent regex falsifiers: every syntax variant that MUST flag, and every legitimate
+// form that MUST pass. A future pattern change that un-catches a variant fails here — the
+// tree can be at zero while the regex is wrong, and this is the test that knows.
+const MUST_FLAG = [
+    'await GraphService.initAsync()',
+    'await client.initAsync?.()',
+    'start: () => RecorderService.initAsync(),',
+    'await service.initAsync ()',
+    'await service.initAsync?. ()',
+    'if (LifecycleService._initPromise) {',
+    'await LifecycleService._initPromise;',
+    'GraphService._initPromise = null;',
+    'if (service?._initPromise) {'
+];
+
+const MUST_PASS = [
+    'await super.initAsync();',
+    'async initAsync() {',
+    '// await myInstance.initAsync() would double-run the boot',
+    ' * Calling it externally (e.g. `await myInstance.initAsync()`) duplicates init.',
+    'await this._initPromise;',
+    'this._initPromise = (async () => {'
+];
 
 /**
  * @summary Recursively collects .mjs files under a root, skipping build/dependency output.
@@ -66,12 +92,35 @@ function isCommentLine(line) {
 }
 
 /**
- * @summary Scans the production trees for one violation pattern.
- * @param {RegExp} pattern
+ * @summary The single line classifier BOTH the tree scan and the fixture self-test run through —
+ * one code path, so the fixtures genuinely falsify what the scan executes.
+ * @param {String} line
+ * @returns {String|null} 'external-initAsync' | 'initPromise-reach-in' | null
+ */
+function violationLabel(line) {
+    // definitions (`async initAsync()`) and `super.initAsync()` chains are the contract,
+    // not violations; comment prose is documentation
+    if (isCommentLine(line) || line.includes('async initAsync(')) {
+        return null
+    }
+
+    if (EXTERNAL_INIT_CALL.test(line)) {
+        return 'external-initAsync'
+    }
+
+    if (INIT_PROMISE_REACH_IN.test(line)) {
+        return 'initPromise-reach-in'
+    }
+
+    return null
+}
+
+/**
+ * @summary Scans the production trees for violations of one label class.
  * @param {String} label
  * @returns {String[]} `file:line: source` entries
  */
-function scanFor(pattern, label) {
+function scanFor(label) {
     const violations = [];
 
     for (const root of SCAN_ROOTS) {
@@ -83,13 +132,7 @@ function scanFor(pattern, label) {
             }
 
             fs.readFileSync(file, 'utf8').split('\n').forEach((line, index) => {
-                // definitions (`async initAsync()`) and `super.initAsync()` chains are the contract,
-                // not violations; comment prose is documentation
-                if (isCommentLine(line) || line.includes('async initAsync(')) {
-                    return
-                }
-
-                if (pattern.test(line)) {
+                if (violationLabel(line) === label) {
                     violations.push(`${relative}:${index + 1} [${label}]: ${line.trim()}`)
                 }
             })
@@ -101,7 +144,7 @@ function scanFor(pattern, label) {
 
 test.describe('core.Base init/ready contract guard (production trees)', () => {
     test('no external initAsync() call sites exist in src/ or ai/', () => {
-        const violations = scanFor(EXTERNAL_INIT_CALL, 'external-initAsync');
+        const violations = scanFor('external-initAsync');
 
         expect(violations,
             'External initAsync() calls double-execute init ("fatal duplication bugs" — src/core/Base.mjs warning). ' +
@@ -110,11 +153,23 @@ test.describe('core.Base init/ready contract guard (production trees)', () => {
     });
 
     test('no _initPromise reach-ins exist in src/ or ai/', () => {
-        const violations = scanFor(INIT_PROMISE_REACH_IN, 'initPromise-reach-in');
+        const violations = scanFor('initPromise-reach-in');
 
         expect(violations,
             '`X._initPromise` is a private lifecycle duplication — ready()/isReady are the contract surface. ' +
             'Await the instance\'s ready() instead:\n' + violations.join('\n')
         ).toEqual([])
+    });
+
+    test('the classifier itself is pinned: every syntax variant flags, every legitimate form passes', () => {
+        // a green tree scan through a too-narrow regex is a false zero — this is the test
+        // that fails when the PATTERN regresses, independent of tree state
+        for (const line of MUST_FLAG) {
+            expect(violationLabel(line), `must flag but passed: ${line}`).not.toBeNull()
+        }
+
+        for (const line of MUST_PASS) {
+            expect(violationLabel(line), `must pass but flagged: ${line}`).toBeNull()
+        }
     });
 });

--- a/test/playwright/unit/ai/InitAsyncContractGuard.spec.mjs
+++ b/test/playwright/unit/ai/InitAsyncContractGuard.spec.mjs
@@ -1,0 +1,120 @@
+import {test, expect}  from '@playwright/test';
+import fs              from 'fs';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../../..');
+
+// The core.Base lifecycle contract (src/core/Base.mjs): construct() auto-fires initAsync()
+// exactly once; external consumers await ready(). An external initAsync() call double-executes
+// the override ("fatal duplication bugs" per the Base warning), and a `_initPromise` reach-in
+// is a private duplication of the #readyPromise lifecycle that shatters when init internals
+// change. This guard freezes the production trees at zero for both patterns.
+//
+// Scope: src/ + ai/ (the production tranche). test/ joins once the singleton re-init seam
+// lands and the spec tranche migrates — extending SCAN_ROOTS is that ticket's one-line change.
+const SCAN_ROOTS = ['src', 'ai'];
+
+// The contract's home defines the lifecycle and legitimately contains the framework-internal
+// fire (`await me.initAsync()` inside construct) plus the warning-comment example.
+const EXEMPT_FILES = new Set(['src/core/Base.mjs']);
+
+// Call-anchored, not await-anchored: thunks and passed references (`start: () => X.initAsync()`)
+// are the same double-run bug without an `await` keyword in front.
+const EXTERNAL_INIT_CALL = /(?<!super)\.initAsync\(\)/;
+
+// Any `X._initPromise` where X is not `this`: reads, writes, and null-resets are all reach-ins.
+// Owner-internal `this._initPromise` stays legal until the bespoke guards are deleted.
+const INIT_PROMISE_REACH_IN = /(?<!this)\._initPromise/;
+
+/**
+ * @summary Recursively collects .mjs files under a root, skipping build/dependency output.
+ * @param {String} dir
+ * @param {String[]} bucket
+ * @returns {String[]}
+ */
+function collectMjsFiles(dir, bucket = []) {
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+        if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name.startsWith('.')) {
+            continue
+        }
+
+        const full = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            collectMjsFiles(full, bucket)
+        } else if (entry.name.endsWith('.mjs')) {
+            bucket.push(full)
+        }
+    }
+
+    return bucket
+}
+
+/**
+ * @summary Comment lines may cite the anti-pattern as prose (the Base warning does); only code
+ * lines count as violations.
+ * @param {String} line
+ * @returns {Boolean}
+ */
+function isCommentLine(line) {
+    const trimmed = line.trim();
+
+    return trimmed.startsWith('//') || trimmed.startsWith('*') || trimmed.startsWith('/*')
+}
+
+/**
+ * @summary Scans the production trees for one violation pattern.
+ * @param {RegExp} pattern
+ * @param {String} label
+ * @returns {String[]} `file:line: source` entries
+ */
+function scanFor(pattern, label) {
+    const violations = [];
+
+    for (const root of SCAN_ROOTS) {
+        for (const file of collectMjsFiles(path.join(repoRoot, root))) {
+            const relative = path.relative(repoRoot, file);
+
+            if (EXEMPT_FILES.has(relative)) {
+                continue
+            }
+
+            fs.readFileSync(file, 'utf8').split('\n').forEach((line, index) => {
+                // definitions (`async initAsync()`) and `super.initAsync()` chains are the contract,
+                // not violations; comment prose is documentation
+                if (isCommentLine(line) || line.includes('async initAsync(')) {
+                    return
+                }
+
+                if (pattern.test(line)) {
+                    violations.push(`${relative}:${index + 1} [${label}]: ${line.trim()}`)
+                }
+            })
+        }
+    }
+
+    return violations
+}
+
+test.describe('core.Base init/ready contract guard (production trees)', () => {
+    test('no external initAsync() call sites exist in src/ or ai/', () => {
+        const violations = scanFor(EXTERNAL_INIT_CALL, 'external-initAsync');
+
+        expect(violations,
+            'External initAsync() calls double-execute init ("fatal duplication bugs" — src/core/Base.mjs warning). ' +
+            'Await the instance\'s ready() instead:\n' + violations.join('\n')
+        ).toEqual([])
+    });
+
+    test('no _initPromise reach-ins exist in src/ or ai/', () => {
+        const violations = scanFor(INIT_PROMISE_REACH_IN, 'initPromise-reach-in');
+
+        expect(violations,
+            '`X._initPromise` is a private lifecycle duplication — ready()/isReady are the contract surface. ' +
+            'Await the instance\'s ready() instead:\n' + violations.join('\n')
+        ).toEqual([])
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -798,7 +798,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         const originalWakeInit                = SDK.Memory_WakeSubscriptionService.init;
         const originalInferenceReady          = SDK.Memory_InferenceLifecycleService.ready;
         const originalSessionReady            = SDK.Memory_SessionService.ready;
-        const originalRecorderInitAsync       = SDK.Memory_RecorderService.initAsync;
+        const originalRecorderReady           = SDK.Memory_RecorderService.ready;
         const originalRecordStartupDependency = HealthService.recordStartupDependency;
         const originalSetStdioIdentityState   = HealthService.setStdioIdentityState;
 
@@ -808,7 +808,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         };
         SDK.Memory_InferenceLifecycleService.ready = async () => calls.push('inferenceReady');
         SDK.Memory_SessionService.ready = async () => calls.push('sessionReady');
-        SDK.Memory_RecorderService.initAsync = async () => calls.push('toolTelemetryReady');
+        SDK.Memory_RecorderService.ready = async () => calls.push('toolTelemetryReady');
         HealthService.recordStartupDependency = (name, status, details) => {
             startupStates.push({name, status, error: details?.error});
         };
@@ -842,7 +842,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             SDK.Memory_WakeSubscriptionService.init = originalWakeInit;
             SDK.Memory_InferenceLifecycleService.ready = originalInferenceReady;
             SDK.Memory_SessionService.ready = originalSessionReady;
-            SDK.Memory_RecorderService.initAsync = originalRecorderInitAsync;
+            SDK.Memory_RecorderService.ready = originalRecorderReady;
             HealthService.recordStartupDependency = originalRecordStartupDependency;
             HealthService.setStdioIdentityState = originalSetStdioIdentityState;
             HealthService.clearStartupDependencyState();

--- a/test/playwright/unit/ai/scripts/maintenance/businessMetricsProbeCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/businessMetricsProbeCore.spec.mjs
@@ -34,7 +34,7 @@ function makeGraph({existing = null, failReadBack = false} = {}) {
     return {
         calls: {upserts: []},
         nodes,
-        async initAsync() {},
+        async ready() {},
         async getNodeRecord({id}) {
             if (failReadBack && nodes.has(id)) return null;
             if (nodes.has(id)) return nodes.get(id);

--- a/test/playwright/unit/ai/scripts/maintenance/graphLifecycleReport.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/graphLifecycleReport.spec.mjs
@@ -64,7 +64,7 @@ test.describe('graphLifecycleReport.mjs (#10158)', () => {
         const result = await mod.runReport({
             lifecycle   : {ready: async () => { calls.push('ready'); }},
             graphService: {
-                initAsync         : async () => { calls.push('init'); },
+                ready             : async () => { calls.push('graph-ready'); },
                 getLifecycleCensus: async opts => { calls.push(['census', opts.includeIncidentEdges]); return census; }
             },
             includeIncidentEdges: true,
@@ -73,8 +73,8 @@ test.describe('graphLifecycleReport.mjs (#10158)', () => {
         });
 
         expect(result).toBe(census);
-        // Readiness + init happen before the census query; the opt-in flag threads through.
-        expect(calls).toEqual(['ready', 'init', ['census', true]]);
+        // Both readiness gates precede the census query; the opt-in flag threads through.
+        expect(calls).toEqual(['ready', 'graph-ready', ['census', true]]);
         expect(lines[0]).toContain('"memoryNodes": 1');  // --json emits raw payload
     });
 });

--- a/test/playwright/unit/ai/scripts/maintenance/kbPushClient.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/kbPushClient.spec.mjs
@@ -17,7 +17,7 @@ import * as core      from '../../../../../../src/core/_export.mjs';
 import {Readable}     from 'stream';
 
 /**
- * Unit coverage for the tenant-side KB push client (#11743).
+ * Unit coverage for the tenant-side KB push client.
  *
  * The script is the operator-facing StreamableHTTP/SSE invocation primitive for repo-push
  * ingestion envelopes. Tests keep network/client work injected so parsing, auth headers,
@@ -205,7 +205,7 @@ test.describe('ai/scripts/maintenance/kbPushClient — repo-push MCP client (#11
             input        : Readable.from('{"files":[{"sourcePath":"src/a.mjs","content":"x"}]}'),
             clientConfig,
             clientFactory: ({serverName, clientName}) => ({
-                async initAsync() {
+                async ready() {
                     calls.push({type: 'init', serverName, clientName});
                 },
                 async callTool(name, envelope) {

--- a/test/playwright/unit/ai/scripts/maintenance/migrationCensusReport.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/migrationCensusReport.spec.mjs
@@ -66,7 +66,7 @@ test.describe('migrationCensusReport.mjs (#12768)', () => {
 
         const result = await mod.runReport({
             lifecycle    : {ready: async () => { calls.push('ready'); }},
-            graphService : {initAsync: async () => { calls.push('init'); }},
+            graphService : {ready: async () => { calls.push('graph-ready'); }},
             healthService: {
                 getMigrationCensus: async opts => { calls.push(['census', opts.includeChroma]); return census; }
             },
@@ -76,8 +76,8 @@ test.describe('migrationCensusReport.mjs (#12768)', () => {
         });
 
         expect(result).toBe(census);
-        // Readiness + graph init happen before the census query; the opt-in flag threads through.
-        expect(calls).toEqual(['ready', 'init', ['census', true]]);
+        // Both readiness gates precede the census query; the opt-in flag threads through.
+        expect(calls).toEqual(['ready', 'graph-ready', ['census', true]]);
         expect(lines[0]).toContain('"memory": 1');  // --json emits raw payload
     });
 });

--- a/test/playwright/unit/ai/scripts/maintenance/purgeNoContentGraphMemories.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/purgeNoContentGraphMemories.spec.mjs
@@ -138,7 +138,7 @@ test.describe('purgeNoContentGraphMemories.mjs', () => {
         const result = await runNoContentGraphMemoryCleanup({
             lifecycle   : {ready: async () => {}},
             graphService: {
-                initAsync  : async () => {},
+                ready      : async () => {},
                 db         : {storage: {db}},
                 removeNodes: ids => removed.push(...ids)
             },
@@ -177,7 +177,7 @@ test.describe('purgeNoContentGraphMemories.mjs', () => {
             confirmation: APPLY_CONFIRMATION_TOKEN,
             lifecycle   : {ready: async () => {}},
             graphService: {
-                initAsync  : async () => {},
+                ready      : async () => {},
                 db         : {storage: {db}},
                 removeNodes: ids => {
                     removed.push(...ids);

--- a/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/IngestionService.spec.mjs
@@ -80,7 +80,7 @@ function createGraphStub() {
 
     return {
         store,
-        async initAsync() {},
+        async ready() {},
         getNodeRecord({id}) {
             return store.has(id) ? {...store.get(id)} : null;
         },


### PR DESCRIPTION
Resolves #15033

Sub 1 of #15031: every external `initAsync()` call in the production trees migrates to the `core.Base` contract surface (`ready()`), per-site — with the rejection-path classification the parent's V-B-A required, and the contract frozen at zero by a call-anchored guard spec. No `core.Base` change, no bespoke-guard deletion (that is #15034, blocked on this landing), no `test/` churn.

**The sweep (24 production files after cycle 2):** 38 await-anchored sites from the intake inventory PLUS four the tightened scans caught (two thunk/daemons finds at intake, two optional-call finds from the review's syntax falsifier) that an await-anchored grep misses — a **thunk** (`start: () => RecorderService.initAsync()` in the memory-core Server's startup-dependency table; its sibling entry one line above already used `ready()`) and the `DreamService` `_initPromise` reach-in the parent ticket cited (in `ai/daemons/`, which my intake grep scoped past — the guard spec now scans the full `ai/` tree precisely so scope errors of that kind cannot recur).

**Two live production bugs fixed by the migration itself (found at source, not hypothesized):**
- `SystemLifecycleService.initAsync()` **double-initialized StorageRouter on every boot** — its `if (!StorageRouter._initPromise)` gate checked a field StorageRouter never assigns, so the external call always re-ran `initAsync()` and created a second `CollectionProxy` per boot. The whole init-vs-ready dance collapses to the four `await X.ready()` calls that were ALREADY there beneath it.
- `AgentOrchestrator` **created every MCP client twice**: `createAgent()` (`Neo.create` → construct auto-fires init) followed by `await agent.initAsync()` re-ran the full connection loop. Now `await agent.ready()`.
- (Plus dead code removed: DreamService's reach-in guarded on a field that is never set — the branch never executed.)

**Rejection-path classification (the error-visibility AC):** verified first that `ai/` has **no global `unhandledRejection` handler**, so a construct-fired init rejection crashes Node loudly at import time — visibility is process-level and survives the migration for every crash-loud service. Per target:

| Service | initAsync failure mode | Disposition |
|---|---|---|
| `GraphService` (memory-core; incl. `Memory_GraphService`, IngestionService's injected `graphService`) | internal catch → degraded, init resolves | safe as-is (the precedent) |
| `ChromaLifecycleService` / `InferenceLifecycleService` | log-only bodies — cannot reject | safe as-is |
| `SystemLifecycleService` | composes children via `ready()`; rejects if a crash-loud child rejects | crash-loud at import (unhandled rejection) — visibility preserved |
| `StorageRouter` / `ChromaManager` / `SessionService` / `ConnectionService` | can reject (proxy/connect/spawn) | crash-loud at import — identical today and after; scripts' exit-code contracts intact |
| `Agent` | MCP client boot + cognitive runtime — the ONE consumer whose try/catch did real structured handling (`AgentOrchestrator`) | **central readiness contract** (review cycle 2): failures land in `Agent#initError` and `Agent.ready()` RE-THROWS it — a failed boot is observable at every direct boundary (the orchestrator's catch, `delegate()`'s sub-agent cache, standalone scripts) with no consumer reaching for the field; `AgentReadiness.spec.mjs` probes both boundaries (ready() rejects while `isReady` stays true; a broken sub-agent is never cached) |

**The guard (`test/playwright/unit/ai/InitAsyncContractGuard.spec.mjs`):** the `GuideToolParity` repo-invariant pattern — runs in the existing unit job, zero CI wiring. Call-anchored AND syntax-tolerant (cycle 2: optional-chaining `.initAsync?.()` + whitespace variants — two real sites evaded the first exact-literal shape), `_initPromise` reach-ins (non-`this`), comment-prose skipped, `src/core/Base.mjs` exempt. The classifier is one code path shared by the tree scan and a PERMANENT fixture self-test (`MUST_FLAG`/`MUST_PASS`) — the regex can no longer false-green independently of tree state. Owner-internal `this._initPromise` (GraphService) stays legal until #15034 deletes the bespoke guards; extending `SCAN_ROOTS` to `test/` is that ticket's one-line change.

Evidence: L2 (behavior + guard):

```
# guard: green on head, red-on-seeded proven both classes
InitAsyncContractGuard.spec.mjs → 2 passed
seeded probe (external call + reach-in) → 2 failed, exact file:line reported → removed → 2 passed

# contract greps at head
external non-super initAsync() calls in src/+ai/ → 0 (Base.mjs framework fire + comments only)
._initPromise (non-this) in src/+ai/ → 0

# structural edits: node --check clean (Agent, AgentOrchestrator, SystemLifecycleService,
# DreamService, memory-core Server, IngestionService)
```

Behavior gate: the directly-affected spec set (lifecycle + maintenance scripts, orchestrator services/scheduling, memory-core services) runs locally at head — result appended to this body when it completes; the hosted full unit suite on this PR is the authoritative regression gate either way (the migrated call sites are exercised by their existing suites, unchanged).

## Deltas from ticket

- +2 sites over the intake inventory (the thunk + the daemons-tree reach-in) — both inside the ticket's scope definition; the inventory's grep shape was the gap, and the guard is call-anchored because of it.
- `Agent` gains `initError` (catch-and-degrade) — this is the ticket's own "explicit error surface" disposition for the one real structured-error consumer, not scope growth.
- The guard lands as a unit spec (repo-invariant pattern) rather than a separate CI workflow — the AC asks that CI fails on violations; the unit job IS that gate, with zero new pipeline surface.

## Test Evidence

At head `bb7025f5c`:

```
npm run test-unit -- test/playwright/unit/ai/InitAsyncContractGuard.spec.mjs \
  test/playwright/unit/ai/scripts/lifecycle/ test/playwright/unit/ai/scripts/maintenance/ \
  test/playwright/unit/ai/daemons/orchestrator/ test/playwright/unit/ai/services/memory-core/ --workers=1
(result appended on completion; hosted unit suite = the authoritative gate)
```

## Post-Merge Validation

- [ ] The nightly lifecycle scripts (`swarmWakeCooldown`, `checkAllAgentIdle`, `checkSunsetted`, `idleOutNudge`, `sweepExpiredTasks`) complete their next scheduled runs with unchanged exit-code behavior.
- [ ] #15034 (re-init seam + test tranche + bespoke-guard deletion + repo-wide lint) picks up from the frozen-at-zero production baseline.

## Deltas

See "Deltas from ticket" above.

Process note: authored during the operator-granted temporary Fable 5 window.

Authored by Grace (Claude Fable 5, Claude Code). Session ef6b9a4a-54ec-4afb-8438-f89a3ee46ad2
