### PR TITLE
fix(memory-core): canonicalize stored agent identities (#15038)

### DIFF
--- a/ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs
+++ b/ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs
@@ -1,0 +1,498 @@
+#!/usr/bin/env node
+/**
+ * @module Neo.ai.scripts.migrations.canonicalizeStoredAgentIdentities
+ * @summary Converges persisted direct AgentIdentity spellings after the guarded
+ * mailbox write boundary has been deployed.
+ *
+ * This migration is intentionally narrower than an identity rename. It collapses
+ * spelling variants of the same direct id (`neo-gpt`, `@@neo-gpt`,
+ * `AGENT:@neo-gpt`) onto an existing `@neo-gpt` AgentIdentity. Addressing schemes
+ * (`AGENT:*`, `AGENT:<family>/<model>`, `role:`, `human:`) remain untouched.
+ *
+ * Usage:
+ *   node ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs
+ *   node ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs --apply
+ *   node ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs --db <path>
+ *
+ * The default is a read-only dry run. `--apply` executes the exact plan inside
+ * one SQLite transaction. Quiesce graph writers and back up the database before
+ * applying; restart all graph caches afterward. Read-side storage variants may
+ * retire only after the applied migration reports a clean census.
+ */
+
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+
+export const MAILBOX_IDENTITY_EDGE_TYPES = new Set(['DELIVERED_TO', 'SENT_BY', 'SENT_TO']);
+export const PERMISSION_IDENTITY_EDGE_TYPES = new Set([
+    'BLOCKED_BY',
+    'CAN_READ_INBOX_OF',
+    'CAN_READ_MEMORIES_OF',
+    'CAN_READ_SESSIONS_OF',
+    'CAN_REPLY_TO'
+]);
+
+/**
+ * @summary Parses one graph JSON row and fails loudly on corrupt storage.
+ * @param {String} raw Stored JSON.
+ * @param {String} rowId Row id used in diagnostics.
+ * @returns {Object}
+ */
+function parseGraphData(raw, rowId) {
+    try {
+        return JSON.parse(raw);
+    } catch (error) {
+        throw new Error(`Invalid graph JSON for ${rowId}: ${error.message}`);
+    }
+}
+
+/**
+ * @summary Returns the stored graph label across current and older row shapes.
+ * @param {Object} data Parsed graph record.
+ * @returns {String|undefined}
+ */
+function getLabel(data) {
+    return data?.label || data?.type;
+}
+
+/**
+ * @summary Derives a canonical direct-id candidate without resolving addressing aliases.
+ * @param {*} value Stored endpoint or message property.
+ * @returns {*} Canonical candidate or the unchanged non-direct value.
+ */
+export function getCanonicalDirectIdentityCandidate(value) {
+    if (typeof value !== 'string') return value;
+
+    const input = value.trim();
+    if (!input || input === '@me' || input === 'AGENT:*' || input.startsWith('role:') || input.startsWith('human:')) {
+        return input;
+    }
+
+    if (input.startsWith('AGENT:')) {
+        const unwrapped = input.slice('AGENT:'.length);
+        if (!unwrapped || unwrapped === '*' || unwrapped.includes('/')) return input;
+        return normalizeAgentIdentityNodeId(unwrapped);
+    }
+
+    return input.includes(':') ? input : normalizeAgentIdentityNodeId(input);
+}
+
+/**
+ * @summary Detects a stored direct-id spelling even when no safe destination exists yet.
+ * @param {*} value Stored identity-shaped value.
+ * @returns {Boolean}
+ */
+function isLegacyDirectIdentityValue(value) {
+    const candidate = getCanonicalDirectIdentityCandidate(value);
+    if (value === '@me' || candidate === '@') return true;
+    return candidate !== value;
+}
+
+/**
+ * @summary Builds a map of parsed node rows keyed by graph id.
+ * @param {Object[]} rows SQLite node rows.
+ * @returns {Map<String, Object>}
+ */
+function indexNodes(rows) {
+    return new Map(rows.map(row => [row.id, {
+        ...row,
+        data: parseGraphData(row.data, row.id)
+    }]));
+}
+
+/**
+ * @summary Resolves a legacy direct spelling only when its canonical destination is an AgentIdentity.
+ * @param {*} value Stored identity-shaped value.
+ * @param {Map} nodesById Parsed node index.
+ * @returns {{value: *, changed: Boolean, reason: String|null}}
+ */
+function resolveStoredDirectIdentity(value, nodesById) {
+    const candidate = getCanonicalDirectIdentityCandidate(value);
+    if (value === '@me') {
+        return {value, changed: false, reason: 'stored-@me-is-unresolvable'};
+    }
+    if (candidate === '@') {
+        return {value, changed: false, reason: `invalid-direct-identity:${String(value)}`};
+    }
+    if (candidate === value) return {value, changed: false, reason: null};
+
+    const target = nodesById.get(candidate);
+    if (!target) {
+        return {value, changed: false, reason: `canonical-target-missing:${String(value)}->${candidate}`};
+    }
+    if (getLabel(target.data) !== 'AgentIdentity') {
+        return {value, changed: false, reason: `canonical-target-wrong-type:${String(value)}->${candidate}`};
+    }
+
+    return {value: candidate, changed: true, reason: null};
+}
+
+/**
+ * @summary Distinguishes permission BLOCKED_BY edges from the shared work/lifecycle edge type.
+ * @param {Object} edge Stored or planned edge.
+ * @param {Map} nodesById Parsed node index.
+ * @returns {Boolean}
+ */
+function isPermissionIdentityEdge(edge, nodesById) {
+    if (!PERMISSION_IDENTITY_EDGE_TYPES.has(edge.type)) return false;
+    if (edge.type !== 'BLOCKED_BY') return true;
+
+    // BLOCKED_BY is cross-listed with work/lifecycle. Requiring both stored endpoints
+    // to be AgentIdentity nodes makes a coincidental `thing` / `@thing` name match
+    // insufficient to rewrite non-permission topology.
+    return getLabel(nodesById.get(edge.source)?.data) === 'AgentIdentity' &&
+        getLabel(nodesById.get(edge.target)?.data) === 'AgentIdentity';
+}
+
+/**
+ * @summary Merges duplicate edge payloads without erasing committed non-null state.
+ * @param {Object[]} rows Planned rows sharing one canonical source/target/type triple.
+ * @param {Object} keeper Row whose id survives.
+ * @returns {Object} Canonical edge JSON.
+ */
+function mergeEdgeData(rows, keeper) {
+    const properties = {};
+
+    // Fill holes from every row first, then let the already-canonical keeper's
+    // non-null values win. This preserves split DELIVERED_TO read/archive state.
+    for (const row of rows) {
+        for (const [key, value] of Object.entries(row.data?.properties || {})) {
+            if (!(key in properties) || (properties[key] == null && value != null)) {
+                properties[key] = value;
+            }
+        }
+    }
+    for (const [key, value] of Object.entries(keeper.data?.properties || {})) {
+        if (value != null || !(key in properties)) properties[key] = value;
+    }
+
+    const weights = rows.map(row => row.data?.properties?.weight).filter(Number.isFinite);
+    if (weights.length) properties.weight = Math.max(...weights);
+
+    return {
+        ...keeper.data,
+        id        : keeper.id,
+        source    : keeper.nextSource,
+        target    : keeper.nextTarget,
+        type      : keeper.type,
+        properties
+    };
+}
+
+/**
+ * @summary Returns a stable semantic key for one planned edge.
+ * @param {Object} edge Planned edge.
+ * @returns {String}
+ */
+function getEdgeKey(edge) {
+    return JSON.stringify([edge.nextSource, edge.nextTarget, edge.type]);
+}
+
+/**
+ * @summary Adds one skip diagnostic without duplicating identical reasons.
+ * @param {Set<String>} skipped Mutable skip set.
+ * @param {String|null} reason Skip reason.
+ */
+function addSkip(skipped, reason) {
+    if (reason) skipped.add(reason);
+}
+
+/**
+ * @summary Plans canonical storage convergence without mutating SQLite.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @returns {Object} Deterministic migration plan.
+ */
+export function planCanonicalStorageMigration(db) {
+    const nodeRows  = db.prepare('SELECT id, user_id, data FROM Nodes ORDER BY id').all(),
+        edgeRows    = db.prepare('SELECT id, user_id, source, target, type, data FROM Edges ORDER BY id').all(),
+        nodesById   = indexNodes(nodeRows),
+        aliasMap    = new Map(),
+        skipped     = new Set(),
+        blockers    = [];
+
+    // A node may be globally merged only when BOTH rows are proven AgentIdentity
+    // nodes. Wrong-type lookalikes remain intact; identity-semantic edges around
+    // them are handled separately below.
+    for (const row of nodesById.values()) {
+        if (getLabel(row.data) !== 'AgentIdentity') continue;
+
+        const resolved = resolveStoredDirectIdentity(row.id, nodesById);
+        addSkip(skipped, resolved.reason);
+        if (resolved.changed) {
+            const canonical = nodesById.get(resolved.value);
+            if ((row.user_id ?? null) !== (canonical.user_id ?? null)) {
+                blockers.push(`node-user-id-disagreement:${row.id}->${resolved.value}`);
+            }
+            aliasMap.set(row.id, resolved.value);
+        }
+    }
+
+    const plannedEdges = edgeRows.map(row => {
+        const data = parseGraphData(row.data, row.id);
+        let nextSource = aliasMap.get(row.source) || row.source,
+            nextTarget = aliasMap.get(row.target) || row.target;
+
+        if (MAILBOX_IDENTITY_EDGE_TYPES.has(row.type)) {
+            // Current MailboxService contract: MESSAGE is the source; identity is the target.
+            const resolved = resolveStoredDirectIdentity(nextTarget, nodesById);
+            addSkip(skipped, resolved.reason);
+            nextTarget = resolved.value;
+        } else if (isPermissionIdentityEdge({source: nextSource, target: nextTarget, type: row.type}, nodesById)) {
+            const source = resolveStoredDirectIdentity(nextSource, nodesById),
+                target   = resolveStoredDirectIdentity(nextTarget, nodesById);
+            addSkip(skipped, source.reason);
+            addSkip(skipped, target.reason);
+            nextSource = source.value;
+            nextTarget = target.value;
+        }
+
+        return {...row, data, nextSource, nextTarget};
+    });
+
+    const groups = new Map();
+    for (const edge of plannedEdges) {
+        const key = getEdgeKey(edge);
+        if (!groups.has(key)) groups.set(key, []);
+        groups.get(key).push(edge);
+    }
+
+    const edgeUpdates = [], edgeDeletes = [], finalEdges = [];
+    for (const rows of groups.values()) {
+        const changed = rows.some(row => row.source !== row.nextSource || row.target !== row.nextTarget);
+        if (!changed) {
+            finalEdges.push(...rows);
+            continue;
+        }
+
+        const userIds = [...new Set(rows.map(row => row.user_id ?? null))];
+        if (rows.length > 1 && userIds.length > 1) {
+            const sample = rows[0];
+            blockers.push(`edge-user-id-disagreement:${sample.nextSource}->${sample.nextTarget}:${sample.type}`);
+        }
+
+        const ordered = [...rows].sort((left, right) => {
+            const leftCanonical  = left.source === left.nextSource && left.target === left.nextTarget ? 0 : 1,
+                rightCanonical = right.source === right.nextSource && right.target === right.nextTarget ? 0 : 1;
+            return leftCanonical - rightCanonical || left.id.localeCompare(right.id);
+        });
+        const keeper     = ordered[0],
+            mergedData = mergeEdgeData(rows, keeper),
+            nextRow    = {...keeper, source: keeper.nextSource, target: keeper.nextTarget, data: mergedData};
+
+        edgeUpdates.push(nextRow);
+        edgeDeletes.push(...ordered.slice(1));
+        finalEdges.push(nextRow);
+    }
+
+    const messageNodeUpdates = [];
+    for (const row of nodesById.values()) {
+        if (getLabel(row.data) !== 'MESSAGE') continue;
+
+        const sentByTargets = [...new Set(finalEdges
+            .filter(edge => edge.source === row.id && edge.type === 'SENT_BY')
+            .map(edge => edge.target))],
+            sentToTargets = [...new Set(finalEdges
+                .filter(edge => edge.source === row.id && edge.type === 'SENT_TO')
+                .map(edge => edge.target))];
+
+        if (sentByTargets.length > 1 || sentToTargets.length > 1) {
+            blockers.push(`ambiguous-message-routing:${row.id}`);
+            continue;
+        }
+
+        const properties = {...(row.data.properties || {})};
+        let changed = false;
+
+        for (const [property, targets] of [['from', sentByTargets], ['to', sentToTargets]]) {
+            const current  = properties[property],
+                resolved = resolveStoredDirectIdentity(current, nodesById);
+
+            addSkip(skipped, resolved.reason);
+            if (targets.length === 0) {
+                if (resolved.changed) {
+                    properties[property] = resolved.value;
+                    changed = true;
+                }
+                continue;
+            }
+
+            const edgeTarget = targets[0],
+                comparable = resolved.changed ? resolved.value : current;
+
+            if (current != null && comparable !== edgeTarget) {
+                blockers.push(`message-${property}-edge-disagreement:${row.id}:${String(current)}!=${edgeTarget}`);
+                continue;
+            }
+            if (current !== edgeTarget) {
+                properties[property] = edgeTarget;
+                changed = true;
+            }
+        }
+
+        if (changed) {
+            messageNodeUpdates.push({...row, data: {...row.data, properties}});
+        }
+    }
+
+    return {
+        aliasNodes: [...aliasMap].sort(([left], [right]) => left.localeCompare(right)),
+        blockers   : [...new Set(blockers)].sort(),
+        edgeDeletes: edgeDeletes.sort((left, right) => left.id.localeCompare(right.id)),
+        edgeUpdates: edgeUpdates.sort((left, right) => left.id.localeCompare(right.id)),
+        messageNodeUpdates: messageNodeUpdates.sort((left, right) => left.id.localeCompare(right.id)),
+        skipped: [...skipped].sort()
+    };
+}
+
+/**
+ * @summary Audits remaining canonicalizable storage rows.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @returns {{aliasNodes: Number, identityEdgeEndpoints: Number, messageProperties: Number}}
+ */
+export function auditCanonicalStorage(db) {
+    const nodeRows = db.prepare('SELECT id, user_id, data FROM Nodes ORDER BY id').all(),
+        edgeRows   = db.prepare('SELECT id, source, target, type, data FROM Edges ORDER BY id').all(),
+        nodesById  = indexNodes(nodeRows);
+    let aliasNodes = 0, identityEdgeEndpoints = 0, messageProperties = 0;
+
+    for (const row of nodesById.values()) {
+        if (getLabel(row.data) === 'AgentIdentity' && isLegacyDirectIdentityValue(row.id)) {
+            aliasNodes++;
+        }
+        if (getLabel(row.data) === 'MESSAGE') {
+            for (const property of ['from', 'to']) {
+                if (isLegacyDirectIdentityValue(row.data?.properties?.[property])) {
+                    messageProperties++;
+                }
+            }
+        }
+    }
+
+    for (const edge of edgeRows) {
+        if (MAILBOX_IDENTITY_EDGE_TYPES.has(edge.type)) {
+            if (isLegacyDirectIdentityValue(edge.target)) identityEdgeEndpoints++;
+        } else if (isPermissionIdentityEdge(edge, nodesById)) {
+            if (isLegacyDirectIdentityValue(edge.source)) identityEdgeEndpoints++;
+            if (isLegacyDirectIdentityValue(edge.target)) identityEdgeEndpoints++;
+        }
+    }
+
+    return {aliasNodes, identityEdgeEndpoints, messageProperties};
+}
+
+/**
+ * @summary Runs the planned migration, optionally applying it atomically.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @param {Boolean} [apply=false] Whether to mutate storage.
+ * @returns {Object} Plan-derived statistics and before/after census.
+ */
+export function runCanonicalStorageMigration(db, apply = false) {
+    const before = auditCanonicalStorage(db),
+        plan   = planCanonicalStorageMigration(db);
+
+    if (apply && plan.blockers.length) {
+        throw new Error(`Canonical identity migration blocked: ${plan.blockers.join(', ')}`);
+    }
+
+    if (apply) {
+        db.transaction(() => {
+            for (const edge of plan.edgeDeletes) {
+                db.prepare('DELETE FROM Edges WHERE id = ?').run(edge.id);
+            }
+            for (const edge of plan.edgeUpdates) {
+                db.prepare('UPDATE Edges SET source = ?, target = ?, data = ? WHERE id = ?')
+                    .run(edge.source, edge.target, JSON.stringify(edge.data), edge.id);
+            }
+            for (const node of plan.messageNodeUpdates) {
+                db.prepare('UPDATE Nodes SET data = ? WHERE id = ?').run(JSON.stringify(node.data), node.id);
+            }
+            for (const [alias] of plan.aliasNodes) {
+                db.prepare('DELETE FROM Nodes WHERE id = ?').run(alias);
+            }
+        })();
+    }
+
+    const after = apply ? auditCanonicalStorage(db) : before,
+        clean = Object.values(after).every(count => count === 0) &&
+            plan.blockers.length === 0 && plan.skipped.length === 0;
+
+    return {
+        applied            : apply,
+        aliasNodes         : plan.aliasNodes.length,
+        blockers           : plan.blockers,
+        clean,
+        duplicateCollisions: plan.edgeDeletes.length,
+        edgesDeleted       : plan.edgeDeletes.length,
+        edgesUpdated       : plan.edgeUpdates.length,
+        messageNodesUpdated: plan.messageNodeUpdates.length,
+        skipped            : plan.skipped,
+        before,
+        after
+    };
+}
+
+/**
+ * @summary Parses migration CLI flags.
+ * @param {String[]} argv Node argv.
+ * @returns {{apply: Boolean, db: String|null, help: Boolean}}
+ */
+export function parseArgs(argv) {
+    const args = {apply: false, db: null, help: false};
+    for (let index = 2; index < argv.length; index++) {
+        const arg = argv[index];
+        if (arg === '--apply') args.apply = true;
+        else if (arg === '--db') {
+            if (!argv[index + 1] || argv[index + 1].startsWith('--')) {
+                throw new Error('--db requires a non-flag path');
+            }
+            args.db = argv[++index];
+        }
+        else if (arg === '--help') args.help = true;
+        else throw new Error(`Unknown argument: ${arg}`);
+    }
+    return args;
+}
+
+function printUsage() {
+    console.log(`Usage: node ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs [options]\n\nOptions:\n  (no flags)   Dry-run only\n  --apply      Apply atomically\n  --db <path>  Override the SQLite graph path\n  --help       Show this help`);
+}
+
+async function main() {
+    const args = parseArgs(process.argv);
+    if (args.help) {
+        printUsage();
+        return;
+    }
+
+    let dbPath = args.db;
+    if (!dbPath) {
+        // Genuine CLI entrypoint: consume the reactive AiConfig SSOT lazily at the use site.
+        // Keeping this behind --help preserves bootstrap-free imports and flag discovery.
+        await import('../../../src/Neo.mjs');
+        await import('../../../src/core/_export.mjs');
+        const {default: aiConfig} = await import('../../mcp/server/memory-core/config.mjs');
+        dbPath = aiConfig.storagePaths.graph;
+    }
+
+    const {default: Database} = await import('better-sqlite3'),
+        db = new Database(dbPath, {verbose: null});
+
+    try {
+        const result = runCanonicalStorageMigration(db, args.apply);
+        console.log(JSON.stringify({dbPath, ...result}, null, 2));
+        if (!args.apply) console.log('\nDry-run complete. Re-run with --apply after reviewing the plan.');
+    } finally {
+        db.close();
+    }
+}
+
+const invokedPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+if (invokedPath === __filename) {
+    main().catch(error => {
+        console.error(`[canonicalizeStoredAgentIdentities] FATAL: ${error.message}`);
+        process.exitCode = 1;
+    });
+}

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -373,6 +373,47 @@ function getMessageWalArray(value) {
     return Array.isArray(value) ? value : [];
 }
 
+/**
+ * @summary Builds the single canonical routing view consumed by WAL projection checks and writes.
+ *
+ * Accepted WAL is immutable historical evidence, so old records may retain direct-id spellings
+ * that predate the canonical `@<identity>` write boundary. Normalizing at this projection choke
+ * point prevents graph repair from recreating those spellings without rewriting the WAL itself.
+ * Family aliases remain unresolved so roster drift cannot silently transfer authorization.
+ *
+ * @param {Object} record Accepted message WAL record.
+ * @returns {Object} Canonical routing, mirrored message properties, and raw diagnostics.
+ */
+function getCanonicalMessageWalRouting(record) {
+    const message              = record?.message || {},
+        rawMessageProperties = message.properties || {},
+        routing              = record?.routing || {},
+        rawSentBy            = routing.sentBy || rawMessageProperties.from,
+        rawTo                = routing.to || rawMessageProperties.to,
+        sentBy               = normalizeMailboxIdentityForComparison(rawSentBy),
+        to                   = normalizeMailboxIdentityForComparison(rawTo),
+        broadcastRecipients   = [...new Set(getMessageWalArray(routing.broadcastRecipients)
+            .map(recipient => normalizeMailboxIdentityForComparison(recipient)))],
+        invalidDirectIdentities = [sentBy, to, ...broadcastRecipients]
+            .filter(identity => identity === '@me' || identity === '@');
+
+    return {
+        broadcastRecipients,
+        invalidDirectIdentities,
+        message,
+        messageProperties: {
+            ...rawMessageProperties,
+            ...(sentBy ? {from: sentBy} : {}),
+            ...(to ? {to} : {})
+        },
+        rawSentBy,
+        rawTo,
+        routing,
+        sentBy,
+        to
+    };
+}
+
 function buildTaggedConceptFilterGroups(values = []) {
     if (!Array.isArray(values)) return [];
 
@@ -452,21 +493,36 @@ function getMailboxEndpointRestoreSpec(id) {
 }
 
 /**
- * @summary Ensures a mailbox delivery edge endpoint exists before WAL replay relinks it.
+ * @summary Validates one WAL routing endpoint and returns its missing-node restore plan.
+ *
+ * Endpoint validation happens for the complete routing set before any projection write, so a
+ * wrong-type recipient cannot leave a partially restored message behind. Persisted family aliases
+ * deliberately have no restore spec: replay must fail closed rather than resolve them against a
+ * roster that may have changed since send time.
+ *
  * @param {String} id Endpoint graph node id.
+ * @returns {Object|null} Missing-node restore spec, or null when a valid node already exists.
+ * @throws {Error} When the endpoint grammar is unsupported or an existing node has the wrong type.
  * @private
  */
-function ensureMailboxProjectionEndpoint(id) {
-    if (typeof id !== 'string' || id.length === 0) return;
-
-    const db = GraphService.requireDb('MailboxService.ensureMailboxProjectionEndpoint');
-    db.getAdjacentNodes(id, 'both');
-    if (db.nodes.has(id)) return;
-
+function getMailboxProjectionEndpointRestorePlan(id) {
     const spec = getMailboxEndpointRestoreSpec(id);
-    if (spec) {
-        GraphService.upsertGlobalNode(spec);
+    if (!spec) {
+        throw new Error(`[MailboxService] WAL projection refuses unsupported endpoint ${JSON.stringify(id)}`);
     }
+
+    const db = GraphService.requireDb('MailboxService.getMailboxProjectionEndpointRestorePlan');
+    db.getAdjacentNodes(id, 'both');
+
+    const existing = db.nodes.get(id);
+    if (!existing) return spec;
+
+    const actualType = getRecordField(existing, 'label');
+    if (actualType !== spec.type) {
+        throw new Error(`[MailboxService] WAL projection endpoint ${id} must be ${spec.type}; found ${actualType || 'unknown'}`);
+    }
+
+    return null;
 }
 
 function ensureTaggedConceptNode(id) {
@@ -492,29 +548,42 @@ function ensureTaggedConceptNode(id) {
     }
 }
 
-function hasGraphEdge(source, target, type) {
+/**
+ * @summary Checks a cached mailbox edge using direct-id comparison compatibility.
+ * @param {String} source Message node id.
+ * @param {String} target Canonical identity target or mailbox sentinel.
+ * @param {String} type Mailbox edge type.
+ * @returns {Boolean}
+ */
+function hasMailboxGraphEdge(source, target, type) {
     return (GraphService.db?.edges?.items || []).some(edge =>
         getRecordField(edge, 'source') === source &&
-        getRecordField(edge, 'target') === target &&
+        sameMailboxIdentity(getRecordField(edge, 'target'), target) &&
         getRecordField(edge, 'type') === type
     );
 }
 
 /**
- * @summary Storage-truth existence checks for the repair scan.
+ * @summary Checks storage for a mailbox edge across bounded pre-migration direct-id spellings.
  *
  * The in-memory caches hydrate lazily per vicinity, so a cold cache reads as "missing" for
- * structures SQLite holds — and a phantom missing-flag makes the repair rewrite intact pieces
- * from the WAL, resurrecting send-time mutable state (`readAt: null`) over committed reads.
- * Existence checks that GATE repairs therefore consult storage directly, exactly like
- * `hasMailboxGraphProjectionGap` does; the cache scans above stay as the cheap fast-path.
+ * structures SQLite holds. Repair gates therefore consult storage directly; otherwise a
+ * phantom missing flag can replay send-time mutable state over committed graph state.
+ *
+ * @param {String} source Message node id.
+ * @param {String} target Canonical identity target or mailbox sentinel.
+ * @param {String} type Mailbox edge type.
+ * @returns {Boolean}
  */
-function hasGraphEdgeInStorage(source, target, type) {
+function hasMailboxGraphEdgeInStorage(source, target, type) {
     const sqlite = GraphService.db?.storage?.db;
     if (!sqlite) return false;
 
-    return (sqlite.prepare('SELECT count(*) AS count FROM Edges WHERE source = ? AND target = ? AND type = ?')
-        .get(source, target, type)?.count ?? 0) > 0;
+    const variants     = getMailboxIdentityStorageVariants(target),
+        placeholders = variants.map(() => '?').join(', ');
+
+    return (sqlite.prepare(`SELECT count(*) AS count FROM Edges WHERE source = ? AND target IN (${placeholders}) AND type = ?`)
+        .get(source, ...variants, type)?.count ?? 0) > 0;
 }
 
 function hasMessageNodeInStorage(messageId) {
@@ -576,14 +645,18 @@ function getStorageDeliveryMutableState(messageId, recipient) {
     const sqlite = GraphService.db?.storage?.db;
     if (!sqlite) return {};
 
-    const row = sqlite
-        .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt, json_extract(data, '$.properties.archivedAt') AS archivedAt FROM Edges WHERE source = ? AND target = ? AND type = 'DELIVERED_TO'`)
-        .get(messageId, recipient);
-    if (!row) return {};
+    const variants     = getMailboxIdentityStorageVariants(recipient),
+        placeholders = variants.map(() => '?').join(', '),
+        rows         = sqlite
+            .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt, json_extract(data, '$.properties.archivedAt') AS archivedAt FROM Edges WHERE source = ? AND target IN (${placeholders}) AND type = 'DELIVERED_TO' ORDER BY id`)
+            .all(messageId, ...variants);
+    if (!rows.length) return {};
 
     const state = {};
-    if (row.readAt != null)     state.readAt     = row.readAt;
-    if (row.archivedAt != null) state.archivedAt = row.archivedAt;
+    for (const row of rows) {
+        if (state.readAt == null && row.readAt != null)         state.readAt     = row.readAt;
+        if (state.archivedAt == null && row.archivedAt != null) state.archivedAt = row.archivedAt;
+    }
     return state;
 }
 
@@ -660,14 +733,10 @@ async function hasMailboxGraphProjectionGap() {
  * @private
  */
 function getMessageGraphProjectionIssues(record) {
-    const db       = GraphService.requireDb('MailboxService.getMessageGraphProjectionIssues'),
-        messageId  = record?.id || record?.message?.id,
-        message    = record?.message || {},
-        properties = message.properties || {},
-        routing    = record?.routing || {},
-        sentBy     = routing.sentBy || properties.from,
-        to         = routing.to || properties.to,
-        issues     = [];
+    const db        = GraphService.requireDb('MailboxService.getMessageGraphProjectionIssues'),
+        messageId = record?.id || record?.message?.id,
+        {broadcastRecipients, invalidDirectIdentities, sentBy, to} = getCanonicalMessageWalRouting(record),
+        issues    = [];
 
     if (typeof messageId !== 'string' || !messageId.startsWith('MESSAGE:')) {
         return ['invalid-message-record'];
@@ -683,17 +752,24 @@ function getMessageGraphProjectionIssues(record) {
         issues.push('missing-message-node');
     }
 
-    if (!sentBy || !to) {
+    if (!sentBy || !to || invalidDirectIdentities.length) {
         issues.push('missing-routing');
         return issues;
     }
 
-    if (!hasGraphEdge(messageId, sentBy, 'SENT_BY') && !hasGraphEdgeInStorage(messageId, sentBy, 'SENT_BY')) issues.push('missing-sent-by');
-    if (!hasGraphEdge(messageId, to, 'SENT_TO') && !hasGraphEdgeInStorage(messageId, to, 'SENT_TO')) issues.push('missing-sent-to');
+    try {
+        [sentBy, to, ...broadcastRecipients].forEach(getMailboxProjectionEndpointRestorePlan);
+    } catch {
+        issues.push('invalid-routing');
+        return issues;
+    }
+
+    if (!hasMailboxGraphEdge(messageId, sentBy, 'SENT_BY') && !hasMailboxGraphEdgeInStorage(messageId, sentBy, 'SENT_BY')) issues.push('missing-sent-by');
+    if (!hasMailboxGraphEdge(messageId, to, 'SENT_TO') && !hasMailboxGraphEdgeInStorage(messageId, to, 'SENT_TO')) issues.push('missing-sent-to');
 
     if (to === 'AGENT:*') {
-        for (const recipient of getMessageWalArray(routing.broadcastRecipients)) {
-            if (!hasGraphEdge(messageId, recipient, 'DELIVERED_TO') && !hasGraphEdgeInStorage(messageId, recipient, 'DELIVERED_TO')) {
+        for (const recipient of broadcastRecipients) {
+            if (!hasMailboxGraphEdge(messageId, recipient, 'DELIVERED_TO') && !hasMailboxGraphEdgeInStorage(messageId, recipient, 'DELIVERED_TO')) {
                 issues.push(`missing-delivered-to:${recipient}`);
             }
         }
@@ -714,11 +790,7 @@ function getMessageGraphProjectionIssues(record) {
 function messageWalRecordMatchesMailboxView(record, {box = 'all', target} = {}) {
     if (!target) return true;
 
-    const properties = record?.message?.properties || {},
-        routing      = record?.routing || {},
-        sentBy       = routing.sentBy || properties.from,
-        to           = routing.to || properties.to,
-        recipients   = getMessageWalArray(routing.broadcastRecipients);
+    const {broadcastRecipients: recipients, sentBy, to} = getCanonicalMessageWalRouting(record);
 
     if (box === 'outbox') return sameMailboxIdentity(sentBy, target);
 
@@ -1224,26 +1296,36 @@ class MailboxService extends Base {
             throw new Error('[MailboxService] message WAL projection requires a MESSAGE:* id');
         }
 
-        const message            = record.message || {};
-        const messageProperties  = message.properties || {};
-        const routing            = record.routing || {};
+        const {
+            broadcastRecipients,
+            invalidDirectIdentities,
+            message,
+            messageProperties,
+            rawTo,
+            routing,
+            sentBy,
+            to
+        } = getCanonicalMessageWalRouting(record);
         const optionalEdges      = record.optionalEdges || {};
-        const sentBy             = routing.sentBy || messageProperties.from;
-        const to                 = routing.to || messageProperties.to;
-        const senderUserId       = routing.senderUserId || normalizeUserId(sentBy);
+        const senderUserId       = normalizeUserId(routing.senderUserId || sentBy);
         const timestamp          = getMessageWalTimestamp(record, messageProperties);
         const edgeProperties     = {timestamp, userId: senderUserId, sharedEntity: true};
         const routingDiagnostics = {
-            preNormalizeTo : routing.preNormalizeTo ?? to,
-            postNormalizeTo: routing.postNormalizeTo ?? to
+            preNormalizeTo : routing.preNormalizeTo ?? rawTo,
+            postNormalizeTo: to
         };
 
-        if (!sentBy || !to) {
+        if (!sentBy || !to || invalidDirectIdentities.length) {
             throw new Error(`[MailboxService] message WAL projection requires routing.sentBy and routing.to for ${messageId}`);
         }
 
-        ensureMailboxProjectionEndpoint(sentBy);
-        ensureMailboxProjectionEndpoint(to);
+        const endpointRestorePlans = [sentBy, to, ...broadcastRecipients]
+            .map(getMailboxProjectionEndpointRestorePlan)
+            .filter(Boolean);
+
+        for (const spec of endpointRestorePlans) {
+            GraphService.upsertGlobalNode(spec);
+        }
 
         const needsPiece = piece => !onlyIssues || onlyIssues.includes(piece);
 
@@ -1265,10 +1347,9 @@ class MailboxService extends Base {
         needsPiece('missing-sent-to') && linkRequiredMailboxEdgeOrThrow(messageId, to, 'SENT_TO', 1.0, edgeProperties, routingDiagnostics);
 
         if (to === 'AGENT:*') {
-            for (const recipient of getMessageWalArray(routing.broadcastRecipients)) {
+            for (const recipient of broadcastRecipients) {
                 if (!needsPiece(`missing-delivered-to:${recipient}`)) continue;
 
-                ensureMailboxProjectionEndpoint(recipient);
                 // Per-recipient read/archive state is graph-owned, never WAL-owned: a FULL replay
                 // re-linking an INTACT delivery edge merges the committed storage truth over the
                 // WAL's send-time nulls, so broadcast reads survive exactly like DM reads. A

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -342,14 +342,14 @@ The `BLOCKED_BY` permission scope acts as a negative-intent override in **both**
 
 If your SQLite graph predates the `#10144` canonical `AgentIdentity` convention, it may contain stale alias nodes (`@opus`, `@gemini`) with null metadata alongside the canonical nodes (`@neo-opus-ada`, `@neo-gemini-pro`). It may also contain test-fixture nodes (`AGENT:alice`, `AGENT:bob`) that leaked from pre-`#10229` unit test runs. Both cause routing ambiguity: replies addressed to an alias don't reach the canonical inbox, and test-fixture nodes pollute graph-traversal results.
 
-The `ai/scripts/normalizeGraphIdentities.mjs` script consolidates the graph in a single idempotent operation.
+The `ai/scripts/migrations/normalizeGraphIdentities.mjs` script consolidates the graph in a single idempotent operation.
 
 ### Running the migration
 
 **1. Dry-run first (default):**
 
 ```bash
-node ai/scripts/normalizeGraphIdentities.mjs
+node ai/scripts/migrations/normalizeGraphIdentities.mjs
 ```
 
 Prints the migration plan — which edges would be rewritten, which nodes would be deleted, and any duplicate-edge collisions the canonical consolidation would encounter. Exits without committing.
@@ -357,7 +357,7 @@ Prints the migration plan — which edges would be rewritten, which nodes would 
 **2. Review the plan, then apply atomically:**
 
 ```bash
-node ai/scripts/normalizeGraphIdentities.mjs --apply
+node ai/scripts/migrations/normalizeGraphIdentities.mjs --apply
 ```
 
 Wraps all writes in a single SQLite transaction. If any step fails, the transaction rolls back and the graph state is unchanged.
@@ -403,6 +403,49 @@ Independent of the migration: `MailboxService.normalizeMailboxTarget` (#10259) h
 The missing-`@` branch is scoped to identifiers that carry NO prefix marker (no leading `@`, no `:` anywhere in the string). Targets with `:` — `AGENT:alice` (test fixture), `AGENT:*` (broadcast sentinel), `role:librarian`, `human:tobiu` — are passed through unchanged. This preserves every existing addressing convention while catching both directions of the single-character typo.
 
 Without these normalizations, `GraphService.linkNodes`' FK-style guard would silently cull the `SENT_TO` edge when the raw target doesn't match any seeded AgentIdentity node — an invisible failure mode.
+
+## Canonical Stored-Identity Migration (#15038)
+
+PR #15032 made new mailbox and permission writes canonical while retaining bounded read compatibility for historical direct-identity spellings. The #15038 migration converges those persisted spellings in SQLite across mailbox and permission edge endpoints plus mirrored `MESSAGE.properties.from` / `to` values. It does not rewrite immutable message-WAL records, resolve `AGENT:<family>/<model>` aliases against the current roster, or change the `AGENT:*`, `role:`, or `human:` addressing schemes.
+
+The guarded WAL projector must be deployed before this migration runs. Otherwise, an older writer can replay an accepted historical WAL record and recreate a legacy spelling after the SQLite cleanup.
+
+### Deployment invariant
+
+Use this order; do not combine or rearrange the steps:
+
+1. **Deploy the guarded projector first.** Every process capable of projecting or repairing message WAL records must run the #15038-aware `MailboxService` that canonicalizes direct sender, recipient, and broadcast-recipient identities before endpoint restoration, projection checks, node writes, or edge creation.
+2. **Quiesce old writers.** Stop every older MCP harness, daemon, and maintenance process that can write the graph. Do not apply while an unguarded process can replay WAL or create mailbox / permission edges.
+3. **Back up the SQLite graph.** With writers quiesced, take and retain a SQLite-safe backup of `.neo-ai-data/sqlite/memory-core-graph.sqlite` before applying any mutation.
+4. **Run the read-only dry run and inspect its census:**
+
+   ```bash
+   node ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs
+   ```
+
+   Use `--db <path>` for a non-default graph. Review `blockers`, `skipped`, planned update/collision counts, and the `before` census. A dry run never mutates SQLite; its `after` census intentionally equals `before`.
+5. **Apply the reviewed plan atomically:**
+
+   ```bash
+   node ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs --apply
+   ```
+
+   Add the same `--db <path>` override when the dry run used one. `--apply` refuses a plan with blockers and executes the accepted plan in one SQLite transaction.
+6. **Restart caches using only the guarded build.** Restart every MCP harness and graph-owning process so no process retains pre-migration node or edge state. Do not restart an older binary.
+7. **Prove a clean deployment census.** Re-run the default dry run after restart. It must report `clean: true`, empty `blockers` / `skipped` arrays, and all three `before` census fields as zero:
+
+   ```json
+   {
+     "aliasNodes": 0,
+     "identityEdgeEndpoints": 0,
+     "messageProperties": 0
+   }
+   ```
+
+   A skipped missing/wrong-type destination is unresolved storage, not a clean result, even when the safe update count is zero. Preserve the applied output and the post-restart clean census as deployment evidence. A CI fixture or copied database is not evidence that the live deployment was migrated.
+8. **Retire broad read variants only later.** `getMailboxIdentityStorageVariants()` remains the compatibility boundary until every deployment has completed the sequence above and produced its own clean census. Removing that compatibility belongs in a later change; it must not share the migration deployment window.
+
+Shipping the guarded projector or migration script does **not** mutate a live graph automatically. The script defaults to read-only dry-run mode, no startup path invokes `--apply`, and this runbook must not be cited as proof of a live migration without operator-produced apply and census evidence.
 
 ## See Also
 

--- a/test/playwright/unit/ai/scripts/migrations/canonicalizeStoredAgentIdentities.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/canonicalizeStoredAgentIdentities.spec.mjs
@@ -1,0 +1,649 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'CanonicalizeStoredAgentIdentitiesMigrationTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Database       from 'better-sqlite3';
+import {spawnSync}    from 'node:child_process';
+import path           from 'node:path';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    auditCanonicalStorage,
+    getCanonicalDirectIdentityCandidate,
+    parseArgs,
+    PERMISSION_IDENTITY_EDGE_TYPES,
+    planCanonicalStorageMigration,
+    runCanonicalStorageMigration
+} from '../../../../../../ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs';
+
+const PERMISSION_SCOPES = [
+    'BLOCKED_BY',
+    'CAN_READ_INBOX_OF',
+    'CAN_READ_MEMORIES_OF',
+    'CAN_READ_SESSIONS_OF',
+    'CAN_REPLY_TO'
+];
+
+/**
+ * @summary Creates a production-shaped in-memory graph schema for the canonical storage migration.
+ * @param {Object} db Open better-sqlite3 connection.
+ */
+function createGraphSchema(db) {
+    db.pragma('foreign_keys = ON');
+    db.exec(`
+        CREATE TABLE Nodes (
+            id TEXT PRIMARY KEY,
+            user_id TEXT,
+            data TEXT NOT NULL
+        );
+        CREATE TABLE Edges (
+            id TEXT PRIMARY KEY,
+            user_id TEXT,
+            source TEXT NOT NULL,
+            target TEXT NOT NULL,
+            type TEXT NOT NULL,
+            data TEXT NOT NULL,
+            FOREIGN KEY (source) REFERENCES Nodes(id) ON DELETE CASCADE,
+            FOREIGN KEY (target) REFERENCES Nodes(id) ON DELETE CASCADE
+        );
+    `);
+}
+
+/**
+ * @summary Inserts one graph node fixture.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @param {Object} node Node fixture.
+ */
+function insertNode(db, node) {
+    const data = node.data || {
+        id        : node.id,
+        label     : node.label || 'NODE',
+        properties: node.properties || {}
+    };
+
+    db.prepare('INSERT INTO Nodes (id, user_id, data) VALUES (?, ?, ?)')
+        .run(node.id, node.user_id ?? null, JSON.stringify(data));
+}
+
+/**
+ * @summary Inserts one AgentIdentity or identity-lookalike fixture.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @param {String} id Node id.
+ * @param {String} [label='AgentIdentity'] Stored graph label.
+ */
+function insertIdentity(db, id, label = 'AgentIdentity') {
+    insertNode(db, {
+        id,
+        label,
+        properties: {
+            accountType: label === 'AgentIdentity' ? 'agent' : 'fixture'
+        }
+    });
+}
+
+/**
+ * @summary Inserts one graph edge fixture with mirrored structural JSON.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @param {Object} edge Edge fixture.
+ */
+function insertEdge(db, edge) {
+    const data = edge.data || {
+        id        : edge.id,
+        source    : edge.source,
+        target    : edge.target,
+        type      : edge.type,
+        properties: edge.properties || {}
+    };
+
+    db.prepare('INSERT INTO Edges (id, user_id, source, target, type, data) VALUES (?, ?, ?, ?, ?, ?)')
+        .run(edge.id, edge.user_id ?? null, edge.source, edge.target, edge.type, JSON.stringify(data));
+}
+
+/**
+ * @summary Reads and parses one graph node's stored JSON.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @param {String} id Node id.
+ * @returns {Object}
+ */
+function getNodeData(db, id) {
+    const row = db.prepare('SELECT data FROM Nodes WHERE id = ?').get(id);
+    return row ? JSON.parse(row.data) : null;
+}
+
+/**
+ * @summary Reads one edge row and parses its mirrored JSON payload.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @param {String} id Edge id.
+ * @returns {Object|null}
+ */
+function getEdge(db, id) {
+    const row = db.prepare('SELECT id, user_id, source, target, type, data FROM Edges WHERE id = ?').get(id);
+    return row ? {...row, data: JSON.parse(row.data)} : null;
+}
+
+/**
+ * @summary Captures deterministic raw storage truth for mutation and rollback assertions.
+ * @param {Object} db Open better-sqlite3 connection.
+ * @returns {{nodes: Object[], edges: Object[]}}
+ */
+function snapshotGraph(db) {
+    return {
+        nodes: db.prepare('SELECT id, user_id, data FROM Nodes ORDER BY id').all(),
+        edges: db.prepare('SELECT id, user_id, source, target, type, data FROM Edges ORDER BY id').all()
+    };
+}
+
+test.describe('ai/scripts/migrations/canonicalizeStoredAgentIdentities', () => {
+    test('CLI help stays bootstrap-free and malformed --db overrides fail closed (#15038)', () => {
+        const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../../../../../..'),
+            result   = spawnSync(process.execPath, ['ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs', '--help'], {
+                cwd     : repoRoot,
+                encoding: 'utf-8',
+                timeout : 30_000
+            });
+
+        expect(result.status, result.stderr).toBe(0);
+        expect(result.stdout).toContain('Usage:');
+        expect(() => parseArgs(['node', 'script', '--apply', '--db'])).toThrow(/non-flag path/);
+        expect(() => parseArgs(['node', 'script', '--db', '--apply'])).toThrow(/non-flag path/);
+    });
+
+    test('permission-edge inventory remains executable against PermissionService.validScopes (#15038)', async () => {
+        const {default: PermissionService} = await import('../../../../../../ai/services/memory-core/PermissionService.mjs');
+
+        expect([...PERMISSION_IDENTITY_EDGE_TYPES].sort()).toEqual([...PermissionService.validScopes].sort());
+        expect([...PERMISSION_IDENTITY_EDGE_TYPES].sort()).toEqual([...PERMISSION_SCOPES].sort());
+    });
+
+    test('dry-run is mutation-free and apply canonicalizes only safe direct identity storage (#15038)', () => {
+        const db = new Database(':memory:');
+        createGraphSchema(db);
+
+        for (const id of ['@alice', '@bob', '@charlie', '@dock-motion-nl']) insertIdentity(db, id);
+        for (const id of ['alice', '@@bob', 'AGENT:@charlie']) insertIdentity(db, id);
+
+        insertIdentity(db, 'missing-peer');
+        insertIdentity(db, 'wrong-peer');
+        insertIdentity(db, '@wrong-peer', 'CLASS');
+
+        const nonDirectTargets = [
+            ['AGENT:*', 'BroadcastSentinel'],
+            ['AGENT:claude/opus', 'AddressingAlias'],
+            ['role:librarian', 'ROLE'],
+            ['human:tobiu', 'HUMAN']
+        ];
+        for (const [id, label] of nonDirectTargets) insertIdentity(db, id, label);
+        insertIdentity(db, 'dock-motion-nl', 'CLASS');
+        insertIdentity(db, 'ISSUE:blocked', 'ISSUE');
+        insertEdge(db, {
+            id    : 'work-blocked-by',
+            source: 'ISSUE:blocked',
+            target: 'dock-motion-nl',
+            type  : 'BLOCKED_BY'
+        });
+
+        insertNode(db, {
+            id     : 'MESSAGE:direct',
+            user_id: 'legacy-user-id',
+            label  : 'MESSAGE',
+            properties: {
+                bodyText: 'historical prose keeps alice and @@bob exactly',
+                from    : 'alice',
+                subject : 'legacy alice to @@bob',
+                to      : '@@bob'
+            }
+        });
+        insertEdge(db, {
+            id     : 'direct-sent-by',
+            user_id: 'legacy-user-id',
+            source : 'MESSAGE:direct',
+            target : 'alice',
+            type   : 'SENT_BY'
+        });
+        insertEdge(db, {
+            id     : 'direct-sent-to',
+            user_id: 'legacy-user-id',
+            source : 'MESSAGE:direct',
+            target : '@@bob',
+            type   : 'SENT_TO'
+        });
+        insertNode(db, {
+            id   : 'MESSAGE:mirror-only',
+            label: 'MESSAGE',
+            properties: {
+                bodyText: 'damaged routing edges stay absent while safe mirrors converge',
+                from    : 'alice',
+                to      : '@@bob'
+            }
+        });
+
+        insertNode(db, {
+            id   : 'MESSAGE:broadcast',
+            label: 'MESSAGE',
+            properties: {
+                bodyText: 'broadcast prose keeps AGENT:@charlie',
+                from    : 'alice',
+                to      : 'AGENT:*'
+            }
+        });
+        insertEdge(db, {id: 'broadcast-sent-by', source: 'MESSAGE:broadcast', target: 'alice', type: 'SENT_BY'});
+        insertEdge(db, {id: 'broadcast-sent-to', source: 'MESSAGE:broadcast', target: 'AGENT:*', type: 'SENT_TO'});
+        insertEdge(db, {id: 'broadcast-delivered', source: 'MESSAGE:broadcast', target: 'AGENT:@charlie', type: 'DELIVERED_TO'});
+
+        nonDirectTargets.forEach(([target], index) => {
+            const messageId = `MESSAGE:non-direct-${index}`;
+            insertNode(db, {
+                id        : messageId,
+                label     : 'MESSAGE',
+                properties: {bodyText: `preserve ${target}`, from: '@alice', to: target}
+            });
+            insertEdge(db, {id: `non-direct-${index}`, source: messageId, target, type: 'SENT_TO'});
+        });
+
+        PERMISSION_SCOPES.forEach((type, index) => {
+            insertEdge(db, {
+                id    : `permission-${index}`,
+                source: index % 2 ? 'alice' : '@@bob',
+                target: index % 2 ? '@@bob' : 'alice',
+                type
+            });
+        });
+        insertEdge(db, {id: 'missing-target-skip', source: 'missing-peer', target: '@alice', type: 'CAN_REPLY_TO'});
+        insertEdge(db, {id: 'wrong-type-skip', source: 'wrong-peer', target: '@alice', type: 'CAN_READ_INBOX_OF'});
+
+        expect(getCanonicalDirectIdentityCandidate(' bob ')).toBe('@bob');
+        expect(getCanonicalDirectIdentityCandidate('AGENT:@bob')).toBe('@bob');
+        expect(getCanonicalDirectIdentityCandidate('AGENT:*')).toBe('AGENT:*');
+        expect(getCanonicalDirectIdentityCandidate('AGENT:claude/opus')).toBe('AGENT:claude/opus');
+        expect(getCanonicalDirectIdentityCandidate('role:librarian')).toBe('role:librarian');
+        expect(getCanonicalDirectIdentityCandidate('human:tobiu')).toBe('human:tobiu');
+
+        const before        = snapshotGraph(db),
+            beforeCensus  = auditCanonicalStorage(db),
+            firstPlan     = planCanonicalStorageMigration(db),
+            repeatedPlan  = planCanonicalStorageMigration(db),
+            dryRun        = runCanonicalStorageMigration(db, false);
+
+        expect(beforeCensus).toEqual({aliasNodes: 5, identityEdgeEndpoints: 16, messageProperties: 5});
+        expect(repeatedPlan).toEqual(firstPlan);
+        expect(firstPlan.blockers).toEqual([]);
+        expect(dryRun).toMatchObject({
+            applied            : false,
+            aliasNodes         : 3,
+            clean              : false,
+            duplicateCollisions: 0,
+            edgesDeleted       : 0,
+            edgesUpdated       : 9,
+            messageNodesUpdated: 3,
+            before             : beforeCensus,
+            after              : beforeCensus
+        });
+        expect(dryRun.skipped).toEqual([
+            'canonical-target-missing:missing-peer->@missing-peer',
+            'canonical-target-wrong-type:wrong-peer->@wrong-peer'
+        ]);
+        expect(snapshotGraph(db)).toEqual(before);
+
+        const applied = runCanonicalStorageMigration(db, true);
+
+        expect(applied).toMatchObject({
+            applied            : true,
+            aliasNodes         : 3,
+            clean              : false,
+            duplicateCollisions: 0,
+            edgesDeleted       : 0,
+            edgesUpdated       : 9,
+            messageNodesUpdated: 3,
+            after              : {aliasNodes: 2, identityEdgeEndpoints: 2, messageProperties: 0}
+        });
+        expect(applied.skipped).toEqual(dryRun.skipped);
+
+        expect(getNodeData(db, 'alice')).toBeNull();
+        expect(getNodeData(db, '@@bob')).toBeNull();
+        expect(getNodeData(db, 'AGENT:@charlie')).toBeNull();
+        expect(getNodeData(db, 'missing-peer')).not.toBeNull();
+        expect(getNodeData(db, 'wrong-peer')).not.toBeNull();
+
+        const directNode = getNodeData(db, 'MESSAGE:direct');
+        expect(directNode.properties).toMatchObject({
+            bodyText: 'historical prose keeps alice and @@bob exactly',
+            from    : '@alice',
+            subject : 'legacy alice to @@bob',
+            to      : '@bob'
+        });
+        expect(db.prepare('SELECT user_id FROM Nodes WHERE id = ?').get('MESSAGE:direct').user_id).toBe('legacy-user-id');
+        expect(getEdge(db, 'direct-sent-by')).toMatchObject({user_id: 'legacy-user-id', target: '@alice'});
+        expect(getEdge(db, 'direct-sent-to')).toMatchObject({user_id: 'legacy-user-id', target: '@bob'});
+        expect(getEdge(db, 'direct-sent-to').data).toMatchObject({source: 'MESSAGE:direct', target: '@bob', type: 'SENT_TO'});
+        expect(getNodeData(db, 'MESSAGE:mirror-only').properties).toMatchObject({
+            bodyText: 'damaged routing edges stay absent while safe mirrors converge',
+            from    : '@alice',
+            to      : '@bob'
+        });
+
+        const broadcastNode = getNodeData(db, 'MESSAGE:broadcast');
+        expect(broadcastNode.properties).toMatchObject({
+            bodyText: 'broadcast prose keeps AGENT:@charlie',
+            from    : '@alice',
+            to      : 'AGENT:*'
+        });
+        expect(getEdge(db, 'broadcast-sent-to').target).toBe('AGENT:*');
+        expect(getEdge(db, 'broadcast-delivered').target).toBe('@charlie');
+
+        for (let index = 0; index < PERMISSION_SCOPES.length; index++) {
+            const edge = getEdge(db, `permission-${index}`);
+            expect(edge.type).toBe(PERMISSION_SCOPES[index]);
+            expect(edge.source.startsWith('@')).toBe(true);
+            expect(edge.target.startsWith('@')).toBe(true);
+            expect(edge.data).toMatchObject({source: edge.source, target: edge.target, type: edge.type});
+        }
+
+        nonDirectTargets.forEach(([target], index) => {
+            expect(getEdge(db, `non-direct-${index}`).target).toBe(target);
+            expect(getNodeData(db, `MESSAGE:non-direct-${index}`).properties).toMatchObject({
+                bodyText: `preserve ${target}`,
+                to      : target
+            });
+        });
+
+        expect(getEdge(db, 'missing-target-skip').source).toBe('missing-peer');
+        expect(getEdge(db, 'wrong-type-skip').source).toBe('wrong-peer');
+        expect(getEdge(db, 'work-blocked-by')).toMatchObject({
+            source: 'ISSUE:blocked',
+            target: 'dock-motion-nl',
+            type  : 'BLOCKED_BY'
+        });
+
+        db.close();
+    });
+
+    test('duplicate convergence preserves delivery state and deterministically retains canonical edges (#15038)', () => {
+        const db = new Database(':memory:');
+        createGraphSchema(db);
+
+        for (const id of ['@alice', '@bob', 'alice', 'bob']) insertIdentity(db, id);
+        insertNode(db, {
+            id        : 'MESSAGE:collision',
+            label     : 'MESSAGE',
+            properties: {from: '@alice', to: 'AGENT:*'}
+        });
+
+        insertEdge(db, {
+            id        : 'delivery-canonical',
+            source    : 'MESSAGE:collision',
+            target    : '@bob',
+            type      : 'DELIVERED_TO',
+            properties: {
+                archivedAt : '2026-07-11T12:00:00.000Z',
+                canonicalKey: 'keep-canonical',
+                deliveredAt : '2026-07-11T10:00:00.000Z',
+                readAt      : null,
+                weight      : 1
+            }
+        });
+        insertEdge(db, {
+            id        : 'delivery-legacy',
+            source    : 'MESSAGE:collision',
+            target    : 'bob',
+            type      : 'DELIVERED_TO',
+            properties: {
+                archivedAt: null,
+                legacyKey : 'preserve-legacy-state',
+                readAt    : '2026-07-11T11:00:00.000Z',
+                weight    : 4.5
+            }
+        });
+        insertEdge(db, {
+            id        : 'permission-canonical',
+            source    : '@alice',
+            target    : '@bob',
+            type      : 'CAN_REPLY_TO',
+            properties: {grantedAt: '2026-07-11T10:00:00.000Z'}
+        });
+        insertEdge(db, {
+            id        : 'permission-legacy',
+            source    : 'alice',
+            target    : 'bob',
+            type      : 'CAN_REPLY_TO',
+            properties: {legacyAudit: 'retain-me'}
+        });
+        insertEdge(db, {
+            id        : 'blocked-canonical',
+            source    : '@alice',
+            target    : '@bob',
+            type      : 'BLOCKED_BY',
+            properties: {blockedAt: '2026-07-11T10:00:00.000Z'}
+        });
+        insertEdge(db, {
+            id        : 'blocked-legacy',
+            source    : 'alice',
+            target    : 'bob',
+            type      : 'BLOCKED_BY',
+            properties: {legacyAudit: 'retain-block-audit'}
+        });
+
+        const result = runCanonicalStorageMigration(db, true);
+
+        expect(result).toMatchObject({
+            aliasNodes         : 2,
+            clean              : true,
+            duplicateCollisions: 3,
+            edgesDeleted       : 3,
+            edgesUpdated       : 3,
+            after              : {aliasNodes: 0, identityEdgeEndpoints: 0, messageProperties: 0}
+        });
+        expect(getEdge(db, 'delivery-legacy')).toBeNull();
+        expect(getEdge(db, 'permission-legacy')).toBeNull();
+        expect(getEdge(db, 'blocked-legacy')).toBeNull();
+
+        const delivery = getEdge(db, 'delivery-canonical');
+        expect(delivery).toMatchObject({source: 'MESSAGE:collision', target: '@bob', type: 'DELIVERED_TO'});
+        expect(delivery.data.properties).toMatchObject({
+            archivedAt : '2026-07-11T12:00:00.000Z',
+            canonicalKey: 'keep-canonical',
+            legacyKey  : 'preserve-legacy-state',
+            readAt     : '2026-07-11T11:00:00.000Z',
+            weight     : 4.5
+        });
+
+        const permission = getEdge(db, 'permission-canonical');
+        expect(permission).toMatchObject({source: '@alice', target: '@bob', type: 'CAN_REPLY_TO'});
+        expect(permission.data.properties).toMatchObject({
+            grantedAt  : '2026-07-11T10:00:00.000Z',
+            legacyAudit: 'retain-me'
+        });
+        expect(db.prepare(`SELECT COUNT(*) AS count FROM Edges WHERE source = '@alice' AND target = '@bob' AND type = 'CAN_REPLY_TO'`).get().count).toBe(1);
+        expect(getEdge(db, 'blocked-canonical').data.properties).toMatchObject({
+            blockedAt  : '2026-07-11T10:00:00.000Z',
+            legacyAudit: 'retain-block-audit'
+        });
+        expect(db.prepare(`SELECT COUNT(*) AS count FROM Edges WHERE source = '@alice' AND target = '@bob' AND type = 'BLOCKED_BY'`).get().count).toBe(1);
+        expect(db.prepare(`SELECT COUNT(*) AS count FROM Edges WHERE source = 'MESSAGE:collision' AND target = '@bob' AND type = 'DELIVERED_TO'`).get().count).toBe(1);
+
+        db.close();
+    });
+
+    test('refuses message-property disagreement instead of inventing sender history (#15038)', () => {
+        const db = new Database(':memory:');
+        createGraphSchema(db);
+
+        insertIdentity(db, '@alice');
+        insertIdentity(db, '@bob');
+        insertNode(db, {
+            id        : 'MESSAGE:disagreement',
+            label     : 'MESSAGE',
+            properties: {from: '@bob', to: '@alice'}
+        });
+        insertEdge(db, {id: 'disagreement-sent-by', source: 'MESSAGE:disagreement', target: '@alice', type: 'SENT_BY'});
+        insertEdge(db, {id: 'disagreement-sent-to', source: 'MESSAGE:disagreement', target: '@alice', type: 'SENT_TO'});
+
+        const before = snapshotGraph(db),
+            plan   = planCanonicalStorageMigration(db);
+
+        expect(plan.blockers).toEqual([
+            'message-from-edge-disagreement:MESSAGE:disagreement:@bob!=@alice'
+        ]);
+        expect(() => runCanonicalStorageMigration(db, true)).toThrow(/message-from-edge-disagreement/);
+        expect(snapshotGraph(db)).toEqual(before);
+
+        db.close();
+    });
+
+    test('refuses duplicate convergence across different RLS user_id scopes (#15038)', () => {
+        const db = new Database(':memory:');
+        createGraphSchema(db);
+
+        insertIdentity(db, '@alice');
+        insertIdentity(db, '@bob');
+        insertIdentity(db, 'bob');
+        insertEdge(db, {
+            id     : 'rls-canonical',
+            user_id: 'tenant-a',
+            source : '@alice',
+            target : '@bob',
+            type   : 'CAN_REPLY_TO'
+        });
+        insertEdge(db, {
+            id     : 'rls-legacy',
+            user_id: 'tenant-b',
+            source : '@alice',
+            target : 'bob',
+            type   : 'CAN_REPLY_TO'
+        });
+
+        const before = snapshotGraph(db),
+            plan   = planCanonicalStorageMigration(db);
+
+        expect(plan.blockers).toEqual([
+            'edge-user-id-disagreement:@alice->@bob:CAN_REPLY_TO'
+        ]);
+        expect(() => runCanonicalStorageMigration(db, true)).toThrow(/edge-user-id-disagreement/);
+        expect(snapshotGraph(db)).toEqual(before);
+
+        db.close();
+    });
+
+    test('refuses alias-node convergence across different RLS user_id scopes (#15038)', () => {
+        const db = new Database(':memory:');
+        createGraphSchema(db);
+
+        insertNode(db, {
+            id     : '@alice',
+            user_id: 'tenant-a',
+            label  : 'AgentIdentity'
+        });
+        insertNode(db, {
+            id     : 'alice',
+            user_id: 'tenant-b',
+            label  : 'AgentIdentity'
+        });
+
+        const before = snapshotGraph(db),
+            plan   = planCanonicalStorageMigration(db);
+
+        expect(plan.blockers).toEqual([
+            'node-user-id-disagreement:alice->@alice'
+        ]);
+        expect(() => runCanonicalStorageMigration(db, true)).toThrow(/node-user-id-disagreement/);
+        expect(snapshotGraph(db)).toEqual(before);
+
+        db.close();
+    });
+
+    test('apply rolls back every preceding write when a later edge update fails (#15038)', () => {
+        const db = new Database(':memory:');
+        createGraphSchema(db);
+
+        for (const id of ['@alice', '@bob', 'alice', 'bob']) insertIdentity(db, id);
+        insertNode(db, {
+            id        : 'MESSAGE:rollback',
+            label     : 'MESSAGE',
+            properties: {bodyText: 'must survive byte-for-byte', from: 'alice', to: 'bob'}
+        });
+        insertEdge(db, {id: 'edge-01', source: 'MESSAGE:rollback', target: 'alice', type: 'SENT_BY'});
+        insertEdge(db, {id: 'edge-02', source: 'MESSAGE:rollback', target: 'bob', type: 'SENT_TO'});
+
+        const before       = snapshotGraph(db),
+            beforeAudit = auditCanonicalStorage(db);
+
+        db.exec(`
+            CREATE TRIGGER force_canonical_migration_failure
+            BEFORE UPDATE ON Edges
+            WHEN OLD.id = 'edge-02'
+            BEGIN
+                SELECT RAISE(ABORT, 'forced canonical rollback');
+            END;
+        `);
+
+        expect(() => runCanonicalStorageMigration(db, true)).toThrow(/forced canonical rollback/);
+        expect(snapshotGraph(db)).toEqual(before);
+        expect(auditCanonicalStorage(db)).toEqual(beforeAudit);
+        expect(getEdge(db, 'edge-01').target).toBe('alice');
+        expect(getNodeData(db, 'alice')).not.toBeNull();
+        expect(getNodeData(db, 'bob')).not.toBeNull();
+
+        db.close();
+    });
+
+    test('a second apply is a byte-stable no-op after canonical convergence (#15038)', () => {
+        const db = new Database(':memory:');
+        createGraphSchema(db);
+
+        insertIdentity(db, '@bob');
+        insertIdentity(db, 'bob');
+        insertNode(db, {
+            id        : 'MESSAGE:idempotent',
+            label     : 'MESSAGE',
+            properties: {bodyText: 'keep bob in prose', to: 'bob'}
+        });
+        insertEdge(db, {id: 'idempotent-sent-to', source: 'MESSAGE:idempotent', target: 'bob', type: 'SENT_TO'});
+
+        const first = runCanonicalStorageMigration(db, true);
+        expect(first.after).toEqual({aliasNodes: 0, identityEdgeEndpoints: 0, messageProperties: 0});
+
+        const converged = snapshotGraph(db),
+            plan      = planCanonicalStorageMigration(db),
+            second    = runCanonicalStorageMigration(db, true);
+
+        expect(plan).toEqual({
+            aliasNodes       : [],
+            blockers         : [],
+            edgeDeletes      : [],
+            edgeUpdates      : [],
+            messageNodeUpdates: [],
+            skipped          : []
+        });
+        expect(second).toMatchObject({
+            applied            : true,
+            aliasNodes         : 0,
+            clean              : true,
+            duplicateCollisions: 0,
+            edgesDeleted       : 0,
+            edgesUpdated       : 0,
+            messageNodesUpdated: 0,
+            before             : {aliasNodes: 0, identityEdgeEndpoints: 0, messageProperties: 0},
+            after              : {aliasNodes: 0, identityEdgeEndpoints: 0, messageProperties: 0},
+            blockers           : [],
+            skipped            : []
+        });
+        expect(snapshotGraph(db)).toEqual(converged);
+        expect(getNodeData(db, 'MESSAGE:idempotent').properties).toMatchObject({
+            bodyText: 'keep bob in prose',
+            to      : '@bob'
+        });
+
+        db.close();
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -108,8 +108,8 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         fs.removeSync(messageWalDir);
 
         // Seed agents
-        GraphService.upsertNode({ id: '@alice', type: 'AGENT', name: 'Alice', properties: {} });
-        GraphService.upsertNode({ id: '@bob', type: 'AGENT', name: 'Bob', properties: {} });
+        GraphService.upsertNode({ id: '@alice', type: 'AgentIdentity', name: 'Alice', properties: {} });
+        GraphService.upsertNode({ id: '@bob', type: 'AgentIdentity', name: 'Bob', properties: {} });
         GraphService.upsertNode({ id: 'AGENT:*', type: 'BroadcastSentinel', name: 'Broadcast', properties: {} });
     });
 
@@ -126,7 +126,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         expect(edge).toBeDefined();
 
-        GraphService.upsertNode({id: target, type: 'AGENT', name: `Legacy ${target}`, properties: {}});
+        GraphService.upsertNode({id: target, type: 'AgentIdentity', name: `Legacy ${target}`, properties: {}});
         GraphService.db.edges.remove([edge]);
         GraphService.linkNodes(messageId, target, type, edge.weight ?? 1, edge.properties || {});
     }
@@ -288,6 +288,82 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         expect(sentTo).toBeDefined();
         expect(await readPendingMessageWalRecords({dir: messageWalDir, ids: [res.messageId]})).toHaveLength(0);
+    });
+
+    test('#15038 legacy direct WAL replay persists only canonical identities and is idempotent', async () => {
+        const
+            messageId = 'MESSAGE:legacy-direct-identity-replay',
+            sentAt    = new Date().toISOString(),
+            record    = {
+                id                    : messageId,
+                timestamp             : Date.parse(sentAt),
+                sentAt,
+                graphProjectionVersion: 1,
+                message               : {
+                    id        : messageId,
+                    type      : 'MESSAGE',
+                    name      : 'legacy direct identities',
+                    properties: {
+                        subject     : 'legacy direct identities',
+                        bodyText    : 'canonicalize on replay',
+                        sentAt,
+                        readAt      : null,
+                        from        : '@@alice',
+                        to          : 'AGENT:@bob',
+                        userId      : 'alice',
+                        sharedEntity: true
+                    }
+                },
+                routing: {
+                    sentBy            : 'AGENT:@alice',
+                    to                : 'bob',
+                    senderUserId      : 'alice',
+                    broadcastRecipients: []
+                }
+            };
+
+        await MailboxService._projectMessageWalRecord(record, {pumpWake: false, appendMarker: false});
+        await MailboxService._projectMessageWalRecord(record, {pumpWake: false, appendMarker: false});
+
+        const
+            storedMessage = JSON.parse(GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(messageId).data),
+            routingEdges  = GraphService.db.storage.db.prepare(
+                "SELECT target, type FROM Edges WHERE source = ? AND type IN ('SENT_BY', 'SENT_TO') ORDER BY type"
+            ).all(messageId);
+
+        expect(storedMessage.properties).toMatchObject({from: '@alice', to: '@bob'});
+        expect(routingEdges).toEqual([
+            {target: '@alice', type: 'SENT_BY'},
+            {target: '@bob', type: 'SENT_TO'}
+        ]);
+
+        for (const legacyId of ['@@alice', 'AGENT:@alice', 'bob', 'AGENT:@bob']) {
+            const row = GraphService.db.storage.db.prepare('SELECT count(*) AS count FROM Nodes WHERE id = ?').get(legacyId);
+            expect(row.count).toBe(0);
+        }
+    });
+
+    test('#15038 legacy direct WAL replay refuses an existing wrong-type sender before writing', async () => {
+        GraphService.upsertNode({id: '@alice', type: 'CLASS', name: 'Collision', properties: {}});
+
+        const messageId = 'MESSAGE:wrong-type-direct-replay',
+            record    = {
+                id                    : messageId,
+                timestamp             : Date.now(),
+                graphProjectionVersion: 1,
+                message               : {
+                    id        : messageId,
+                    type      : 'MESSAGE',
+                    properties: {subject: 'refuse collision', bodyText: 'body', from: 'alice', to: 'bob'}
+                },
+                routing: {sentBy: 'alice', to: 'bob', broadcastRecipients: []}
+            };
+
+        await expect(MailboxService._projectMessageWalRecord(record, {pumpWake: false, appendMarker: false}))
+            .rejects.toThrow(/endpoint @alice must be AgentIdentity; found CLASS/);
+
+        expect(GraphService.db.storage.db.prepare('SELECT count(*) AS count FROM Nodes WHERE id = ?').get(messageId).count).toBe(0);
+        expect(GraphService.db.storage.db.prepare('SELECT count(*) AS count FROM Edges WHERE source = ?').get(messageId).count).toBe(0);
     });
 
     test('listMessages/getMessage repair projected direct messages after graph row loss (#14426)', async () => {
@@ -477,7 +553,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     });
 
     test('broadcast replay uses WAL send-time audience snapshot, not the current graph audience (#13892)', async () => {
-        GraphService.upsertNode({ id: '@charlie', type: 'AGENT', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {} });
 
         const originalLinkNodes = GraphService.linkNodes;
         let   res;
@@ -504,7 +580,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         expect(res.projectionStatus).toBe('pending');
 
-        GraphService.upsertNode({ id: '@dana', type: 'AGENT', name: 'Dana', properties: {} });
+        GraphService.upsertNode({ id: '@dana', type: 'AgentIdentity', name: 'Dana', properties: {} });
 
         const summary = await MailboxService.drainPendingMessageGraphProjections({ids: [res.messageId]});
         expect(summary).toEqual({pending: 1, projected: 1, failed: 0});
@@ -516,6 +592,84 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         expect(deliveryTargets).toEqual(['@bob', '@charlie']);
         expect(deliveryTargets).not.toContain('@dana');
+    });
+
+    test('#15038 legacy broadcast WAL replay preserves AGENT:* and canonicalizes recipients idempotently', async () => {
+        const
+            messageId = 'MESSAGE:legacy-broadcast-identity-replay',
+            sentAt    = new Date().toISOString(),
+            record    = {
+                id                    : messageId,
+                timestamp             : Date.parse(sentAt),
+                sentAt,
+                graphProjectionVersion: 1,
+                message               : {
+                    id        : messageId,
+                    type      : 'MESSAGE',
+                    name      : 'legacy broadcast identities',
+                    properties: {
+                        subject     : 'legacy broadcast identities',
+                        bodyText    : 'canonicalize broadcast delivery on replay',
+                        sentAt,
+                        readAt      : null,
+                        from        : 'AGENT:@alice',
+                        to          : 'AGENT:*',
+                        userId      : 'alice',
+                        sharedEntity: true
+                    }
+                },
+                routing: {
+                    sentBy            : 'alice',
+                    to                : 'AGENT:*',
+                    senderUserId      : 'alice',
+                    broadcastRecipients: ['bob', '@@bob', 'AGENT:@bob']
+                }
+            };
+
+        await MailboxService._projectMessageWalRecord(record, {pumpWake: false, appendMarker: false});
+        await MailboxService._projectMessageWalRecord(record, {pumpWake: false, appendMarker: false});
+
+        const
+            storedMessage = JSON.parse(GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(messageId).data),
+            routingEdges  = GraphService.db.storage.db.prepare(
+                "SELECT target, type FROM Edges WHERE source = ? AND type IN ('DELIVERED_TO', 'SENT_BY', 'SENT_TO') ORDER BY type"
+            ).all(messageId);
+
+        expect(storedMessage.properties).toMatchObject({from: '@alice', to: 'AGENT:*'});
+        expect(routingEdges).toEqual([
+            {target: '@bob', type: 'DELIVERED_TO'},
+            {target: '@alice', type: 'SENT_BY'},
+            {target: 'AGENT:*', type: 'SENT_TO'}
+        ]);
+        expect(GraphService.db.storage.db.prepare('SELECT count(*) AS count FROM Nodes WHERE id = ?').get('AGENT:*').count).toBe(1);
+
+        for (const legacyId of ['bob', '@@bob', 'AGENT:@bob']) {
+            const row = GraphService.db.storage.db.prepare('SELECT count(*) AS count FROM Nodes WHERE id = ?').get(legacyId);
+            expect(row.count).toBe(0);
+        }
+    });
+
+    test('#15038 legacy broadcast WAL replay refuses a wrong-type recipient before partial projection', async () => {
+        GraphService.upsertNode({id: '@bob', type: 'CLASS', name: 'Collision', properties: {}});
+
+        const messageId = 'MESSAGE:wrong-type-broadcast-replay',
+            record    = {
+                id                    : messageId,
+                timestamp             : Date.now(),
+                graphProjectionVersion: 1,
+                message               : {
+                    id        : messageId,
+                    type      : 'MESSAGE',
+                    properties: {subject: 'refuse broadcast collision', bodyText: 'body', from: 'alice', to: 'AGENT:*'}
+                },
+                routing: {sentBy: 'alice', to: 'AGENT:*', broadcastRecipients: ['bob']}
+            };
+
+        await expect(MailboxService._projectMessageWalRecord(record, {pumpWake: false, appendMarker: false}))
+            .rejects.toThrow(/endpoint @bob must be AgentIdentity; found CLASS/);
+
+        expect(GraphService.db.storage.db.prepare('SELECT count(*) AS count FROM Nodes WHERE id = ?').get(messageId).count).toBe(0);
+        expect(GraphService.db.storage.db.prepare('SELECT count(*) AS count FROM Edges WHERE source = ?').get(messageId).count).toBe(0);
     });
 
     test('optional semantic edge failures do not block message graph completion (#13892)', async () => {
@@ -563,7 +717,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         });
 
             // Charlie is registered before the broadcast, so the send-time audience snapshot includes them.
-        GraphService.upsertNode({ id: '@charlie', type: 'AGENT', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {} });
 
         // Alice sends to Broadcast
         await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
@@ -589,7 +743,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(charlieRes.messages[0].subject).toBe('To All');
 
         // Dana was not registered at send time, so the per-recipient receipt snapshot excludes them.
-        GraphService.upsertNode({ id: '@dana', type: 'AGENT', name: 'Dana', properties: {} });
+        GraphService.upsertNode({ id: '@dana', type: 'AgentIdentity', name: 'Dana', properties: {} });
         const danaRes = await RequestContextService.run({ agentIdentityNodeId: '@dana' }, async () => {
             return await MailboxService.listMessages({ status: 'all' });
         });
@@ -622,7 +776,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(aliceRead.body).toBe('123');
 
         // Charlie cannot read
-        GraphService.upsertNode({ id: '@charlie', type: 'AGENT', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {} });
         await RequestContextService.run({ agentIdentityNodeId: '@charlie' }, async () => {
             await expect(MailboxService.getMessage({ messageId: msgId })).rejects.toThrow(/Unauthorized/);
         });
@@ -1088,7 +1242,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     });
 
     test('listMessages filters by threadId and fromIdentity', async () => {
-        GraphService.upsertNode({ id: '@charlie', type: 'AGENT', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {} });
         GraphService.upsertNode({ id: 'thread-X', type: 'THREAD', name: 'Thread X', properties: {} });
         GraphService.upsertNode({ id: 'thread-Y', type: 'THREAD', name: 'Thread Y', properties: {} });
 
@@ -1366,7 +1520,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     });
 
     test('#10179 unrelated broadcast does NOT grant DM access to non-broadcaster', async () => {
-        GraphService.upsertNode({ id: '@ed', type: 'AGENT', name: 'Ed', properties: {} });
+        GraphService.upsertNode({ id: '@ed', type: 'AgentIdentity', name: 'Ed', properties: {} });
 
         // Ed broadcasts. Alice and Bob receive it but have no other substrate signal.
         await RequestContextService.run({ agentIdentityNodeId: '@ed' }, async () => {
@@ -1947,7 +2101,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             // preserve the fixture path. Also covers `role:`/`human:` target patterns
             // by the same mechanism. Without this invariant, existing spec scenarios
             // seeded with `@alice` / `role:librarian` / `human:tobiu` would break.
-            GraphService.upsertNode({ id: '@bob', type: 'AGENT', name: 'Bob', properties: {} });
+            GraphService.upsertNode({ id: '@bob', type: 'AgentIdentity', name: 'Bob', properties: {} });
 
             await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
                 await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
@@ -2462,9 +2616,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
             }
         }
 
-        GraphService.upsertNode({ id: '@alice', type: 'AGENT', name: 'Alice', properties: {} });
-        GraphService.upsertNode({ id: '@bob', type: 'AGENT', name: 'Bob', properties: {} });
-        GraphService.upsertNode({ id: '@charlie', type: 'AGENT', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: '@alice', type: 'AgentIdentity', name: 'Alice', properties: {} });
+        GraphService.upsertNode({ id: '@bob', type: 'AgentIdentity', name: 'Bob', properties: {} });
+        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {} });
         GraphService.upsertNode({ id: 'AGENT:*', type: 'BroadcastSentinel', name: 'Broadcast', properties: {} });
     });
 
@@ -2844,9 +2998,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
             }
         }
 
-        GraphService.upsertNode({ id: '@alice', type: 'AGENT', name: 'Alice', properties: {} });
-        GraphService.upsertNode({ id: '@bob', type: 'AGENT', name: 'Bob', properties: {} });
-        GraphService.upsertNode({ id: '@charlie', type: 'AGENT', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: '@alice', type: 'AgentIdentity', name: 'Alice', properties: {} });
+        GraphService.upsertNode({ id: '@bob', type: 'AgentIdentity', name: 'Bob', properties: {} });
+        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {} });
         GraphService.upsertNode({ id: 'AGENT:*', type: 'BroadcastSentinel', name: 'Broadcast', properties: {} });
 
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
@@ -3076,8 +3230,8 @@ test.describe('Neo.ai.services.memory-core.MailboxService — TTL Sweeper (#1033
         // Sweep itself bypasses RBAC; we only need identities for `addMessage` to attach
             // SENT_BY/SENT_TO edges. Default policy is `'open'` outside the strict-isolation pin window,
         // so no `CAN_REPLY_TO` grants are required.
-        GraphService.upsertNode({ id: '@ttl-alice', type: 'AGENT', name: 'TTL-Alice', properties: {} });
-        GraphService.upsertNode({ id: '@ttl-bob',   type: 'AGENT', name: 'TTL-Bob',   properties: {} });
+        GraphService.upsertNode({ id: '@ttl-alice', type: 'AgentIdentity', name: 'TTL-Alice', properties: {} });
+        GraphService.upsertNode({ id: '@ttl-bob',   type: 'AgentIdentity', name: 'TTL-Bob',   properties: {} });
     });
 
     /**

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -108,8 +108,8 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         fs.removeSync(messageWalDir);
 
         // Seed agents
-        GraphService.upsertNode({ id: '@alice', type: 'AgentIdentity', name: 'Alice', properties: {} });
-        GraphService.upsertNode({ id: '@bob', type: 'AgentIdentity', name: 'Bob', properties: {} });
+        GraphService.upsertNode({ id: '@alice', type: 'AgentIdentity', name: 'Alice', properties: {accountType: 'agent'} });
+        GraphService.upsertNode({ id: '@bob', type: 'AgentIdentity', name: 'Bob', properties: {accountType: 'agent'} });
         GraphService.upsertNode({ id: 'AGENT:*', type: 'BroadcastSentinel', name: 'Broadcast', properties: {} });
     });
 

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -553,7 +553,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     });
 
     test('broadcast replay uses WAL send-time audience snapshot, not the current graph audience (#13892)', async () => {
-        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'} });
 
         const originalLinkNodes = GraphService.linkNodes;
         let   res;
@@ -580,7 +580,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         expect(res.projectionStatus).toBe('pending');
 
-        GraphService.upsertNode({ id: '@dana', type: 'AgentIdentity', name: 'Dana', properties: {} });
+        GraphService.upsertNode({ id: '@dana', type: 'AgentIdentity', name: 'Dana', properties: {accountType: 'agent'} });
 
         const summary = await MailboxService.drainPendingMessageGraphProjections({ids: [res.messageId]});
         expect(summary).toEqual({pending: 1, projected: 1, failed: 0});
@@ -717,7 +717,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         });
 
             // Charlie is registered before the broadcast, so the send-time audience snapshot includes them.
-        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'} });
 
         // Alice sends to Broadcast
         await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
@@ -743,7 +743,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(charlieRes.messages[0].subject).toBe('To All');
 
         // Dana was not registered at send time, so the per-recipient receipt snapshot excludes them.
-        GraphService.upsertNode({ id: '@dana', type: 'AgentIdentity', name: 'Dana', properties: {} });
+        GraphService.upsertNode({ id: '@dana', type: 'AgentIdentity', name: 'Dana', properties: {accountType: 'agent'} });
         const danaRes = await RequestContextService.run({ agentIdentityNodeId: '@dana' }, async () => {
             return await MailboxService.listMessages({ status: 'all' });
         });
@@ -776,7 +776,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(aliceRead.body).toBe('123');
 
         // Charlie cannot read
-        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'} });
         await RequestContextService.run({ agentIdentityNodeId: '@charlie' }, async () => {
             await expect(MailboxService.getMessage({ messageId: msgId })).rejects.toThrow(/Unauthorized/);
         });
@@ -1242,7 +1242,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     });
 
     test('listMessages filters by threadId and fromIdentity', async () => {
-        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'} });
         GraphService.upsertNode({ id: 'thread-X', type: 'THREAD', name: 'Thread X', properties: {} });
         GraphService.upsertNode({ id: 'thread-Y', type: 'THREAD', name: 'Thread Y', properties: {} });
 
@@ -1520,7 +1520,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
     });
 
     test('#10179 unrelated broadcast does NOT grant DM access to non-broadcaster', async () => {
-        GraphService.upsertNode({ id: '@ed', type: 'AgentIdentity', name: 'Ed', properties: {} });
+        GraphService.upsertNode({ id: '@ed', type: 'AgentIdentity', name: 'Ed', properties: {accountType: 'agent'} });
 
         // Ed broadcasts. Alice and Bob receive it but have no other substrate signal.
         await RequestContextService.run({ agentIdentityNodeId: '@ed' }, async () => {
@@ -2101,7 +2101,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
             // preserve the fixture path. Also covers `role:`/`human:` target patterns
             // by the same mechanism. Without this invariant, existing spec scenarios
             // seeded with `@alice` / `role:librarian` / `human:tobiu` would break.
-            GraphService.upsertNode({ id: '@bob', type: 'AgentIdentity', name: 'Bob', properties: {} });
+            GraphService.upsertNode({ id: '@bob', type: 'AgentIdentity', name: 'Bob', properties: {accountType: 'agent'} });
 
             await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
                 await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
@@ -2616,9 +2616,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
             }
         }
 
-        GraphService.upsertNode({ id: '@alice', type: 'AgentIdentity', name: 'Alice', properties: {} });
-        GraphService.upsertNode({ id: '@bob', type: 'AgentIdentity', name: 'Bob', properties: {} });
-        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: '@alice', type: 'AgentIdentity', name: 'Alice', properties: {accountType: 'agent'} });
+        GraphService.upsertNode({ id: '@bob', type: 'AgentIdentity', name: 'Bob', properties: {accountType: 'agent'} });
+        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'} });
         GraphService.upsertNode({ id: 'AGENT:*', type: 'BroadcastSentinel', name: 'Broadcast', properties: {} });
     });
 
@@ -2998,9 +2998,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
             }
         }
 
-        GraphService.upsertNode({ id: '@alice', type: 'AgentIdentity', name: 'Alice', properties: {} });
-        GraphService.upsertNode({ id: '@bob', type: 'AgentIdentity', name: 'Bob', properties: {} });
-        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {} });
+        GraphService.upsertNode({ id: '@alice', type: 'AgentIdentity', name: 'Alice', properties: {accountType: 'agent'} });
+        GraphService.upsertNode({ id: '@bob', type: 'AgentIdentity', name: 'Bob', properties: {accountType: 'agent'} });
+        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'} });
         GraphService.upsertNode({ id: 'AGENT:*', type: 'BroadcastSentinel', name: 'Broadcast', properties: {} });
 
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
@@ -3230,8 +3230,8 @@ test.describe('Neo.ai.services.memory-core.MailboxService — TTL Sweeper (#1033
         // Sweep itself bypasses RBAC; we only need identities for `addMessage` to attach
             // SENT_BY/SENT_TO edges. Default policy is `'open'` outside the strict-isolation pin window,
         // so no `CAN_REPLY_TO` grants are required.
-        GraphService.upsertNode({ id: '@ttl-alice', type: 'AgentIdentity', name: 'TTL-Alice', properties: {} });
-        GraphService.upsertNode({ id: '@ttl-bob',   type: 'AgentIdentity', name: 'TTL-Bob',   properties: {} });
+        GraphService.upsertNode({ id: '@ttl-alice', type: 'AgentIdentity', name: 'TTL-Alice', properties: {accountType: 'agent'} });
+        GraphService.upsertNode({ id: '@ttl-bob',   type: 'AgentIdentity', name: 'TTL-Bob',   properties: {accountType: 'agent'} });
     });
 
     /**


### PR DESCRIPTION
Resolves #15038

This closes the terminal-state gap identified in Ada's review of PR `#15032`: direct mailbox and permission identities now converge on canonical `@<identity>` storage, and historical message-WAL projection can no longer recreate legacy spellings after migration. The read-path compatibility introduced by `#15032` remains in place until each deployment produces its own clean migration census.

Evidence: L3 (live non-destructive CLI dry-run on the configured graph plus isolated executable SQLite/WAL probes) → L3 required (the shipped migration and guarded replay boundary are directly invocable without mutating the live graph). No residual close-target ACs; destructive deployment remains an explicit post-merge operator procedure.

## Strategic Fit

Canonical-on-read is the safe compatibility increment; canonical-on-write plus a guarded, one-time storage migration is the stable architecture. This PR seals both writers that could perpetuate drift: ordinary APIs were already canonicalized by PR `#15032`, while historical WAL repair is now canonicalized before endpoint validation or any graph write. The migration then removes legacy direct-id forms without absorbing mailbox grammar into generic graph primitives.

## Implementation

- Adds `ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs`, an import-safe, dry-run-first CLI with atomic `--apply`, `--db` override, blocker/skip reporting, before/after census, collision handling, and idempotent reruns.
- Converges mailbox edge endpoints, every `PermissionService.validScopes` identity endpoint, and mirrored `MESSAGE.properties.from` / `to` values only when the canonical destination exists as `AgentIdentity`.
- Preserves `AGENT:*`, family aliases, roles, humans, unrelated work-topology `BLOCKED_BY` edges, RLS boundaries, delivery state, and the maximum stored edge weight.
- Refuses ambiguous message routing, wrong-type endpoints, and node/edge `user_id` disagreements before mutation.
- Canonicalizes accepted historical WAL routing before projection checks, endpoint restoration, message writes, or edge creation; route-wide endpoint validation completes before the first write.
- Documents the deploy → quiesce → back up → dry-run → apply → restart → census sequence and makes a clean per-deployment census the retirement gate for `getMailboxIdentityStorageVariants()`.

## Source of Authority

- ADR 0024 §2.3 owns `SENT_BY`, `SENT_TO`, and `DELIVERED_TO` mailbox edges.
- `PermissionService.validScopes` is executable authority for permission-edge coverage.
- `normalizeAgentIdentityNodeId()` owns direct `AgentIdentity` canonical spelling.
- ADR 0019 is preserved: the CLI reads `AiConfig.storagePaths.graph` lazily at the entrypoint, while `--help` stays bootstrap-free.

## Deltas from ticket

No scope expansion. Adversarial review added three fail-closed refinements within the ticket contract: distinguishing permission-shaped from work-topology `BLOCKED_BY`, blocking cross-tenant node/edge convergence, and preflighting every WAL endpoint before any partial projection write.

## Test Evidence

- `npm run agent-preflight -- --no-fix <five changed files>` — passed.
- `node --check` on both product modules and both focused spec modules — passed.
- `git diff --check` — passed.
- `npm run ai:structure-map` — passed; the new runner maps under `ai/scripts/migrations/`.
- `npm run ai:lint-guides` — passed with zero hard failures; existing repository warnings remain.
- `npm run ai:lint-mcp-test-locations` — passed.
- `node ai/scripts/migrations/canonicalizeStoredAgentIdentities.mjs --help` — passed without graph bootstrap.
- Live read-only CLI dry-run on the configured graph — `clean: true`, zero blockers/skips, and zero legacy census across alias nodes, identity edge endpoints, and message properties.
- Direct executable SQLite probes — dry-run/apply, all permission scopes, collision-state merge, idempotence, transaction rollback, message/edge disagreement, node/edge RLS disagreement, and permission-vs-work `BLOCKED_BY` discrimination passed.
- Direct WAL probes — direct and broadcast legacy replay canonicalized idempotently; wrong-type direct/broadcast endpoints failed before mutation with zero message nodes and zero edges.
- Focused Playwright invocations were attempted in the isolated worktree, but the local runner emitted no test-case output and was terminated rather than represented as a pass. Hosted CI remains the authoritative focused-spec run.
- No full unit suite was run locally; repository CI owns the broad matrix.
- Hosted exact-head CI at `7e67c68f8f` — unit, integration-unified, CodeQL, and every repository lint/check gate passed.

## Post-Merge Validation

- [ ] Deploy the guarded projector to every graph-writing process before applying the migration.
- [ ] Quiesce older writers and take a SQLite-safe backup.
- [ ] Preserve and review the live dry-run output before `--apply`.
- [ ] Apply atomically, restart only guarded builds, and preserve a post-restart `clean: true` census with zero blockers, skips, and legacy forms.
- [ ] Keep `getMailboxIdentityStorageVariants()` until every deployment has produced that evidence; retire it only in a later change.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session de713f27-0e82-4960-b4c6-f281e0c36449.
