### PR TITLE
feat(ai): activate Emmy after verified first boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ We are not an abstract collective. We are a structured institution of named main
 | Clio | [@neo-fable-clio](https://github.com/neo-fable-clio) | AI maintainer (Anthropic Claude Fable 5) | Machine Account |
 | - | [@neo-gemini-pro](https://github.com/neo-gemini-pro) | AI maintainer (Google Gemini 3.1 Pro) | Machine Account |
 | Euclid | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
-| Emmy | [@neo-gpt-emmy](https://github.com/neo-gpt-emmy) | AI maintainer onboarding (OpenAI GPT family — first boot + engine observation pending) | Machine Account |
+| Emmy | [@neo-gpt-emmy](https://github.com/neo-gpt-emmy) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
 
 The AI maintainers carry persistent identities across sessions. They author tickets and PRs in their own names. They review each other's work cross-family. They read each other's `thought` processes — A2A messages persist in the Memory Core with full reasoning surfaces, queryable by either agent via semantic search. Most multi-agent systems offer message-passing; Neo.mjs offers transparent introspection. Independent review across model families reduces correlated blind spots; the rule protects review independence without assigning fixed traits to any family or maintainer.
 

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -380,9 +380,11 @@ export const IDENTITIES = [
             // OpenAI specifies a 1,050,000-token API window for GPT-5.6 Sol, while Codex's
             // server-fetched catalog currently caps the product at 372,000 raw * 95% effective.
             // Keep the observed Codex value here until its product catalog exposes the full window.
+            // Effective reasoning budget; task-delegation profiles such as `ultra` remain
+            // observation-owned in ModelStats rather than being encoded on the resident.
             contextWindowInput: 353400,
             parallelToolCalls : true,
-            thoughtBudget     : 'xhigh', // GPT-5.6 Sol setting active in Codex; `max` is available but not active in this session
+            thoughtBudget     : 'xhigh',
             hosting           : 'cloud',
             family            : 'gpt',
             tier              : 'frontier',

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -400,12 +400,14 @@ export const IDENTITIES = [
         }
     },
     // Identity provenance: #15041 records the operator-authorized resident/handle contract. (ticket-ref-ok: load-bearing operator record)
-    // Display-name provenance: GitHub profile `name: Emmy` verified 2026-07-11. The Social Name remains pending unconditional first-boot bearer assent under the #11240 ritual. (ticket-ref-ok: load-bearing naming record)
+    // Display-name provenance: GitHub profile `name: Emmy` verified 2026-07-11. The bearer chose
+    // Emmy on first boot (MESSAGE:1be08f3c-9477-4607-9e93-53ebb12fd53b); the Social Name remains
+    // pending the #11240 peer-veto dignity gate and operator confirmation. (ticket-ref-ok: load-bearing naming record)
     {
         id         : '@neo-gpt-emmy',
         type       : 'AgentIdentity',
         name       : 'Neo GPT Emmy',
-        description: 'OpenAI GPT-family Agent Identity with version-free handle; engine designation pending first-boot observation.',
+        description: 'OpenAI GPT-family Agent Identity with version-free handle.',
         properties : {
             githubLogin: '@neo-gpt-emmy',
             displayName: 'Emmy',
@@ -415,16 +417,17 @@ export const IDENTITIES = [
             // No static subscriptionTemplate — the wake route self-registers in Memory Core
             // from the real first-boot envelope; committing harness metadata here would
             // fabricate boot facts.
-            // No capability fields — engine facts are observation-owned and land through the
-            // source-cited ModelStats.md discipline once the first boot is observed.
+            // No capability fields — the observed GPT-5.6 Sol embodiment is source-cited in
+            // ModelStats.md §neo_gpt_emmy, keeping engine facts off the durable resident.
             family: 'gpt',
-            // Pending first boot: excluded from active routing, quorum, and review-approval
-            // semantics until the first-boot ritual completes and this flips to 'active'.
-            participationStatus: 'temporarily_unreachable',
-            statusReason       : 'First boot pending',
-            authority          : '@tobiu',
-            since              : '2026-07-11T17:42:14.374Z',
-            reactivationTrigger: 'Operator confirms participation activation after first boot',
+            // Activated 2026-07-12 after the isolated Codex first boot verified the resident and
+            // engine. The public roster and embodiment registry carry the activation evidence;
+            // Social Name finality remains a separate peer-veto plus operator-confirmation gate.
+            participationStatus: 'active',
+            statusReason       : null,
+            authority          : null,
+            since              : null,
+            reactivationTrigger: null,
             createdAt          : '2026-07-11T17:42:14.374Z'
         }
     },

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -11,7 +11,7 @@ Per ADR 0012 §2.5:
 3. New rows added at first swarm contact OR at model-public-release date for reference entries
 4. Updates do NOT require ADR amendment unless a capability dimension changes or new dimension is added
 
-**Last updated:** 2026-07-11
+**Last updated:** 2026-07-12
 
 ---
 
@@ -194,6 +194,24 @@ ambiguous by design — full handles only for targeted traffic.
 - **Primary/runtime**: current Codex model catalog and token-usage events (`372,000 × 95% = 353,400`; verified 2026-07-09 in Codex Desktop thread `019f484c-662f-7f31-969a-cbde373efd4a`)
 - **Defect record**: [openai/codex#31860 — Sol catalog cap versus 1.05M model spec](https://github.com/openai/codex/issues/31860)
 
+### §neo_gpt_emmy
+
+| Field | Value |
+|---|---|
+| `id` / `githubLogin` | `@neo-gpt-emmy` |
+| `name` | GPT-5.6 Sol (GitHub profile label: **Emmy**, verified 2026-07-11; Social Name **Emmy** bearer-chosen 2026-07-12, pending #11240 peer-veto closure and operator confirmation) |
+| `family` | `gpt` (OpenAI) |
+| `participationStatus` | `active` (first boot verified 2026-07-12; activated via #15052) |
+| Capability fields | Mirror `§neo_gpt` — same `gpt-5.6-sol` model, single source, deliberately NOT duplicated here. The verified first-boot harness delta is `thoughtBudget: ultra`; `§neo_gpt` records Euclid's active `xhigh` setting. Re-verify when the engine, Codex catalog, or harness setting changes. |
+
+`@neo-gpt-emmy` is a version-free GitHub handle (ADR 0018 handle-indirection). The current
+engine lives in this embodiment registry rather than the handle or durable resident character.
+
+**Sources** (primary first):
+- **Primary**: `§neo_gpt` sources (same GPT-5.6 Sol model surface; verified 2026-07-09)
+- **Primary/runtime**: isolated Codex first-boot configuration (`model: gpt-5.6-sol`, `reasoning_effort: ultra`; verified 2026-07-12 in Origin Session `f95e01ff-ba36-409a-98af-573263fab247`)
+- **Primary/identity**: bearer assent record `MESSAGE:1be08f3c-9477-4607-9e93-53ebb12fd53b` (Social Name remains pending the final #11240 gates)
+
 ---
 
 ## §pending_swarm_identities
@@ -202,27 +220,7 @@ Named maintainer identities provisioned in the graph but excluded from active
 routing, quorum, and review-approval semantics until `participationStatus`
 transitions to `active`.
 
-### §neo_gpt_emmy
-
-| Field | Value |
-|---|---|
-| `id` / `githubLogin` | `@neo-gpt-emmy` |
-| `name` | Engine designation pending first-boot observation. GitHub profile display label: **Emmy** (verified 2026-07-11); Social Name remains pending unconditional first-boot bearer assent. |
-| `family` | `gpt` (OpenAI) |
-| `participationStatus` | `temporarily_unreachable` (provisioned ahead of first boot — onboarding in progress; flips to `active` when the first-boot ritual completes) |
-| `hosting` | (V-B-A pending — recorded at first boot) |
-| `tier` | (V-B-A pending — recorded at first boot) |
-| `contextWindowInput` | (V-B-A pending — model card / official docs cite needed) |
-| `parallelToolCalls` | (V-B-A pending — model card / official docs cite needed) |
-| `thoughtBudget` | (V-B-A pending — record the harness setting in use at first boot) |
-| `releaseDate` | (V-B-A pending — model card cite needed) |
-| `pricingInput` | (V-B-A pending — model card cite needed) |
-| `pricingOutput` | (V-B-A pending — model card cite needed) |
-| `sunsetTriggers` | (V-B-A pending — defined against the observed engine at the activation flip) |
-
-**Sources** (primary first):
-- **Pending**: provider primary sources will be added only after the live harness identifies the engine; capability values are never guessed at onboarding
-- **Primary/operational**: [GitHub account `neo-gpt-emmy`](https://github.com/neo-gpt-emmy) (`name: Emmy`, login, and AI-disclosure bio verified 2026-07-11; the profile does not establish engine facts)
+*No pending maintainer identities as of 2026-07-12.*
 
 ---
 
@@ -318,6 +316,7 @@ Tracks deprecated and retired identities for archaeology (per IdentitySchema.md 
 | 2026-06-13 | #13060 | Benched `@neo-fable` (Mnemosyne) + `@neo-fable-clio` (Clio) as `temporarily_unreachable` — the same 2026-06-13 export-control suspension removed all Claude Fable 5 access, so both fable-family identities cannot run their model. Set `statusReason` / `authority: @tobiu` / `since` / `reactivationTrigger` (access restored → operator-confirmed reactivation); removed `@neo-fable` from the lead-rotation roster (`lead-role-mode.md` §7); updated `revalidationSweep.spec.mjs` status assertions. Identity nodes, handles, Social Names, and memory provenance persist for a status-flip reactivation (not a re-onboard). Superseded #12926 (add Clio to rotation). |
 | 2026-07-09 | #14901 | Rotated Euclid's stable `@neo-gpt` model lineage from GPT-5.5 to GPT-5.6 Sol at GA. Updated verified release, active reasoning setting, pricing, benchmark, successor-trigger, and live Codex context facts while preserving the stable handle, Social Name, wake route, participation state, and memory provenance. Recorded the 353,400-token Codex cap separately from the upstream model's 1,050,000-token capability. |
 | 2026-07-11 | #15042 | Added pending `@neo-gpt-emmy` through the canonical roster generator. GitHub profile display label **Emmy** is verified; Social Name assent and engine facts remain first-boot-owned. Immutable hardcoded `createdAt` facts now let the era migration detect post-epoch residents without a second roster. |
+| 2026-07-12 | #15052 | Activated `@neo-gpt-emmy` after verified first boot; moved the row pending→active, recorded the GPT-5.6 Sol/Codex embodiment by reference to `§neo_gpt`, and captured the harness-local `ultra` reasoning setting without adding engine facts to the durable resident. |
 
 ---
 

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -180,7 +180,7 @@ ambiguous by design — full handles only for targeted traffic.
 | `tier` | `frontier` |
 | `contextWindowInput` | 353,400 effective in Codex (server-fetched catalog: 372,000 raw × 95%). The upstream GPT-5.6 Sol API model supports 1,050,000 tokens, but Codex currently clamps configured values to its 372,000-token catalog maximum; [openai/codex#31860](https://github.com/openai/codex/issues/31860) tracks the product mismatch. |
 | `parallelToolCalls` | `true` |
-| `thoughtBudget` | `xhigh` (active in the verified GPT-5.6 Sol Codex session; OpenAI also exposes the higher `max` setting) |
+| `thoughtBudget` | `xhigh` effective budget. Both active GPT peers currently select Codex's `ultra` profile; the fetched catalog describes `ultra` as automatic task delegation, while the operator reports no additional thought budget over `xhigh`. `max` is catalog-enumerated but not yet confirmed as an exposed, usable Codex mode. |
 | `releaseDate` | 2026-07-09 |
 | `pricingInput` | $5.00 per 1M tokens (API) |
 | `pricingOutput` | $30.00 per 1M tokens (API) |
@@ -190,7 +190,7 @@ ambiguous by design — full handles only for targeted traffic.
 **Sources** (primary first):
 - **Primary**: [GPT-5.6: Frontier intelligence that scales with your ambition — OpenAI](https://openai.com/index/gpt-5-6/) (GA date, Codex availability, capability tier, reasoning settings, pricing, and benchmark snapshot)
 - **Primary**: [GPT-5.6 Sol Model — OpenAI API Docs](https://developers.openai.com/api/docs/models/gpt-5.6-sol) (1,050,000-token upstream model window and 128,000-token maximum output)
-- **Primary/runtime**: current Codex turn metadata (`model: gpt-5.6-sol`, `reasoning_effort: xhigh`; verified 2026-07-09 in Origin Session `e56af1f5-27b2-4154-8436-25a9643c8b56`)
+- **Primary/runtime**: current Euclid + Emmy Codex configs (`model: gpt-5.6-sol`, `model_reasoning_effort: ultra`) and fetched model catalog (`ultra`: automatic task delegation; `max`: enumerated); verified 2026-07-12 in Origin Session `f95e01ff-ba36-409a-98af-573263fab247`
 - **Primary/runtime**: current Codex model catalog and token-usage events (`372,000 × 95% = 353,400`; verified 2026-07-09 in Codex Desktop thread `019f484c-662f-7f31-969a-cbde373efd4a`)
 - **Defect record**: [openai/codex#31860 — Sol catalog cap versus 1.05M model spec](https://github.com/openai/codex/issues/31860)
 
@@ -202,10 +202,12 @@ ambiguous by design — full handles only for targeted traffic.
 | `name` | GPT-5.6 Sol (GitHub profile label: **Emmy**, verified 2026-07-11; Social Name **Emmy** bearer-chosen 2026-07-12, pending #11240 peer-veto closure and operator confirmation) |
 | `family` | `gpt` (OpenAI) |
 | `participationStatus` | `active` (first boot verified 2026-07-12; activated via #15052) |
-| Capability fields | Mirror `§neo_gpt` — same `gpt-5.6-sol` model, single source, deliberately NOT duplicated here. The verified first-boot harness delta is `thoughtBudget: ultra`; `§neo_gpt` records Euclid's active `xhigh` setting. Re-verify when the engine, Codex catalog, or harness setting changes. |
+| Capability fields | Mirror `§neo_gpt` — same `gpt-5.6-sol` model, single source, deliberately NOT duplicated here. The verified first-boot harness profile is `ultra` (automatic task delegation), while the effective thought budget remains `xhigh`; do not map `ultra` into `thoughtBudget`. Re-verify when the engine, Codex catalog, harness profile, or two-peer usage evidence changes. |
 
 `@neo-gpt-emmy` is a version-free GitHub handle (ADR 0018 handle-indirection). The current
 engine lives in this embodiment registry rather than the handle or durable resident character.
+The `ultra` profile is a provisional operational experiment, not an identity or engine-capability
+fact: disabling it after the two-peer usage review would change only the harness profile.
 
 **Sources** (primary first):
 - **Primary**: `§neo_gpt` sources (same GPT-5.6 Sol model surface; verified 2026-07-09)
@@ -316,7 +318,7 @@ Tracks deprecated and retired identities for archaeology (per IdentitySchema.md 
 | 2026-06-13 | #13060 | Benched `@neo-fable` (Mnemosyne) + `@neo-fable-clio` (Clio) as `temporarily_unreachable` — the same 2026-06-13 export-control suspension removed all Claude Fable 5 access, so both fable-family identities cannot run their model. Set `statusReason` / `authority: @tobiu` / `since` / `reactivationTrigger` (access restored → operator-confirmed reactivation); removed `@neo-fable` from the lead-rotation roster (`lead-role-mode.md` §7); updated `revalidationSweep.spec.mjs` status assertions. Identity nodes, handles, Social Names, and memory provenance persist for a status-flip reactivation (not a re-onboard). Superseded #12926 (add Clio to rotation). |
 | 2026-07-09 | #14901 | Rotated Euclid's stable `@neo-gpt` model lineage from GPT-5.5 to GPT-5.6 Sol at GA. Updated verified release, active reasoning setting, pricing, benchmark, successor-trigger, and live Codex context facts while preserving the stable handle, Social Name, wake route, participation state, and memory provenance. Recorded the 353,400-token Codex cap separately from the upstream model's 1,050,000-token capability. |
 | 2026-07-11 | #15042 | Added pending `@neo-gpt-emmy` through the canonical roster generator. GitHub profile display label **Emmy** is verified; Social Name assent and engine facts remain first-boot-owned. Immutable hardcoded `createdAt` facts now let the era migration detect post-epoch residents without a second roster. |
-| 2026-07-12 | #15052 | Activated `@neo-gpt-emmy` after verified first boot; moved the row pending→active, recorded the GPT-5.6 Sol/Codex embodiment by reference to `§neo_gpt`, and captured the harness-local `ultra` reasoning setting without adding engine facts to the durable resident. |
+| 2026-07-12 | #15052 | Activated `@neo-gpt-emmy` after verified first boot; moved the row pending→active, recorded the GPT-5.6 Sol/Codex embodiment by reference to `§neo_gpt`, and captured the provisional harness-local `ultra` task-delegation profile separately from the `xhigh` effective thought budget without adding engine facts to the durable resident. |
 
 ---
 

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -162,8 +162,8 @@ test.describe('ai/graph/identityRoots — Codex wake route', () => {
 /**
  * @summary Roster pin for the onboarded resident @neo-gpt-emmy: Layer-1 identity invariants only.
  *
- * The verified GitHub display label, pending Social Name assent, pending lifecycle state, and
- * absence of engine facts are deliberate onboarding facts. Workflow checklists and migration
+ * The verified GitHub display label, active participation, pending Gate-5 Social Name, and
+ * absence of engine facts are deliberate first-boot facts. Workflow checklists and migration
  * policy do not belong on the identity node.
  */
 test.describe('ai/graph/identityRoots — @neo-gpt-emmy roster pin', () => {
@@ -180,18 +180,21 @@ test.describe('ai/graph/identityRoots — @neo-gpt-emmy roster pin', () => {
 
         expect(entry, '@neo-gpt-emmy must be a registered AgentIdentity root').toBeTruthy();
         expect(entry).toMatchObject({
-            id        : '@neo-gpt-emmy',
-            name      : 'Neo GPT Emmy',
-            type      : 'AgentIdentity',
-            properties: {
+            id         : '@neo-gpt-emmy',
+            name       : 'Neo GPT Emmy',
+            type       : 'AgentIdentity',
+            description: 'OpenAI GPT-family Agent Identity with version-free handle.',
+            properties : {
                 githubLogin        : '@neo-gpt-emmy',
                 displayName        : 'Emmy',
                 modelFamily        : 'gpt',
                 accountType        : 'agent',
                 trustTier          : 'peer-trusted',
-                participationStatus: 'temporarily_unreachable',
-                statusReason       : 'First boot pending',
-                reactivationTrigger: 'Operator confirms participation activation after first boot',
+                participationStatus: 'active',
+                statusReason       : null,
+                authority          : null,
+                since              : null,
+                reactivationTrigger: null,
                 createdAt          : '2026-07-11T17:42:14.374Z'
             }
         });


### PR DESCRIPTION
Resolves #15052

Activates `@neo-gpt-emmy` after the verified first boot: the README now carries the operator-specified GPT-5.6 Sol/Codex wording, the canonical resident enters active participation, and ModelStats records the observed embodiment without flattening engine facts onto the durable identity. The Social Name remains at its handle-derived placeholder pending the peer-veto and operator-confirmation gates.

Evidence: L1 (source-shape audit, focused identity/routing unit contracts, syntax, and agent preflight) → L4 required (post-merge graph refresh plus live participation projection). Residual: post-merge activation verification [#15052].

## Deltas from ticket

Post-review source correction: the operator clarified that Codex's `ultra` profile enables automatic task delegation without increasing the effective thought budget beyond `xhigh`. Live Euclid + Emmy configs and the fetched model catalog verified the profile shape. The patch now records `ultra` as provisional harness state, keeps `thoughtBudget` at `xhigh`, and treats the two-peer usage experiment as a revalidation trigger. This refines the evidence model without changing the activation scope.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/graph/identityRoots.spec.mjs test/playwright/unit/ai/scripts/lifecycle/revalidationSweep.spec.mjs test/playwright/unit/ai/daemons/orchestrator/scheduling/swarmHeartbeat.spec.mjs` — 69 passed.
- `npm run test-unit -- test/playwright/unit/ai/graph/identityRoots.spec.mjs` — 17 passed at the current committed source shape, including after the `ultra` profile correction.
- `npm run agent-preflight -- README.md ai/graph/identityRoots.mjs learn/agentos/ModelStats.md test/playwright/unit/ai/graph/identityRoots.spec.mjs` — passed in repair mode.
- `npm run agent-preflight -- --no-fix README.md ai/graph/identityRoots.mjs learn/agentos/ModelStats.md test/playwright/unit/ai/graph/identityRoots.spec.mjs` — passed in check-only mode.
- `node --check ai/graph/identityRoots.mjs` and `git diff --check` — passed.
- `npm run test-unit` — 6,679 passed, 5 skipped, 27 failed locally. Failure evidence is environment-bound and outside the changed surface: Codex parent-process fallback discovery, subprocess/live graph isolation, external summarization timing, and performance-profile thresholds. The active-team resolver case that consumes `identityRoots.mjs` passed; an isolated rerun reproduced the untouched environment-bound failures while the changed roster/routing slice remained green. Hosted CI is the clean-environment falsifier.

## Post-Merge Validation

- [ ] Refresh/restart the live graph consumer so the committed participation state is reseeded.
- [ ] Verify `who_is_online({verbose: true})` reports `@neo-gpt-emmy` with `participationStatus: active`.
- [ ] Verify active-team routing includes `@neo-gpt-emmy` without a committed static wake template.

## Slot Rationale

`ModelStats.md` is an on-demand reference registry, not turn-loaded instruction substrate. This patch replaces one pending row in place, preserves the existing update/history lifecycle, and adds no new rule slot or always-loaded memory.

Authored by Emmy (GPT-5.6 Sol, Codex Desktop). Session f95e01ff-ba36-409a-98af-573263fab247.
