### PR TITLE
fix(dashboard): perspective toolbar sizes to content, not ~51% viewport (#15056)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -261,6 +261,9 @@ class MainContainer extends Viewport {
         return {
             cls         : ['neo-dashboard-dock-perspective-toolbar'],
             dockNodeType: 'perspective-toolbar',
+            // Size to content: without this the toolbar inherits the root vbox's growing default and
+            // splits the viewport ~50/50 with the flex:1 dock. `flex:'none'` keeps it a compact strip.
+            flex        : 'none',
             itemDefaults: {
                 ntype: 'button',
                 style: {margin: '0 8px 0 0'}


### PR DESCRIPTION
Resolves #15056

The dock example's **Perspectives** toolbar rendered at **368.5px on a 720px viewport (~51%)** with a large empty band above and below its buttons, pushing the dock zones into the bottom half of the screen. Surfaced by the operator during a live review of the #14771 tab-overflow verification.

**Root cause:** `createPerspectiveToolbar()` returned the toolbar config with no `flex`. In the root `vbox`, the unset toolbar inherited a growing default and split the height ~50/50 with the `flex: 1` dock; the toolbar's own `hbox align:'center'` then vertically centered the buttons inside that over-tall element — the empty band above and below.

**Fix:** `flex: 'none'` on the perspective toolbar → it sizes to content and the dock takes the remaining viewport.

## AC map

- **Toolbar renders at content height, not a viewport fraction** → `flex: 'none'`; verified live 368.5px → 42px.
- **Dock fills the remaining viewport** → the `flex: 1` dock now owns the freed space.
- **No control/handler regression** → config-only change; the toolbar's items, `itemDefaults`, `layout`, and handlers are untouched.

## Deltas

- `examples/dashboard/dock/MainContainer.mjs` — `flex: 'none'` on the perspective toolbar config (one line + a rationale comment).

## Test Evidence

Verified via a live runtime probe on the running example: injecting the identical flex reset (`.neo-dashboard-dock-perspective-toolbar { flex: 0 0 auto !important }`) dropped the toolbar `368.5px → 42px` and the dock filled the remainder (before/after screenshots captured). Neo's `flex: 'none'` config emits the same `flex: none` on that element.

**Checkout note (honest bound):** the local dev server on `:8080` runs from a *different* checkout (`/Users/Shared/github/neomjs/neo`), so a soft reload of the running app does not pick up this branch's source — which is why the source render couldn't be observed locally. The runtime probe is client-side (checkout-independent), so it proves the behavior regardless. A reviewer can confirm the source render by serving this branch (or rebuilding in the serving checkout).

Evidence: L2 (live runtime behavioral probe of the exact fix effect on the real example) — a config-only presentation fix; the measured `368.5px → 42px` + corrected layout is the behavior. Residual: source re-render on a checkout that serves this branch (checkout mismatch documented above).

## Post-Merge Validation

- [ ] On a checkout that serves this branch, load `examples/dashboard/dock` and confirm the perspective toolbar is a compact strip with the dock filling the viewport.

Authored by Grace (Claude Opus 4.8, Claude Code).
