### PR TITLE
feat(graph): computed-GP guard-filter route-attribution telemetry — record-seam (#15068)

### DIFF
--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -568,13 +568,22 @@ class Config extends ConfigProvider {
              */
             goldenPathTopNodeRenderLimit: leaf(10, 'NEO_GOLDEN_PATH_TOP_NODE_RENDER_LIMIT', 'number'),
             /**
-             * Route-attribution ledger directory — the runtime JSONL store recording which computed focus
-             * candidates the routing contradiction guard filtered, under which live focus reasons. Co-located
-             * with the orchestrator-daemon ledgers because the synthesizer runs in that daemon. Read at the
-             * synthesizer boundary and passed EXPLICITLY into the pure `routeAttributionLedgerStore` helper.
+             * Route-attribution ledger directory — the runtime JSONL store recording which computed candidates
+             * the routing contradiction guard filtered, under which arming reasons. The active
+             * `goldenPathRouteAttributionLedgerDir` consumers read is a formula (below) resolving Prod/Test by
+             * construction from `UNIT_TEST_MODE`, so synthesis specs that trigger the fail-open emit never write
+             * the production `.neo-ai-data` ledger. Read at the synthesizer boundary + passed EXPLICITLY into the
+             * pure `routeAttributionLedgerStore` helper. Co-located with the orchestrator-daemon ledgers (the
+             * synthesizer runs in that daemon).
              * @type {string}
              */
-            goldenPathRouteAttributionLedgerDir: leaf(path.resolve(neoRootDir, '.neo-ai-data/orchestrator-daemon/route-attribution'), 'NEO_GOLDEN_PATH_ROUTE_ATTRIBUTION_LEDGER_DIR', 'string'),
+            goldenPathRouteAttributionLedgerDirProd: leaf(path.resolve(neoRootDir, '.neo-ai-data/orchestrator-daemon/route-attribution'), 'NEO_GOLDEN_PATH_ROUTE_ATTRIBUTION_LEDGER_DIR', 'string'),
+            /**
+             * Unit-test ledger directory — under the OS temp root so test-mode emits stay off the production
+             * `.neo-ai-data` path. Declarative leaf; test-mode resolved by construction via the formula below.
+             * @type {string}
+             */
+            goldenPathRouteAttributionLedgerDirTest: leaf(path.join(os.tmpdir(), 'neo-route-attribution-test'), 'NEO_GOLDEN_PATH_ROUTE_ATTRIBUTION_LEDGER_DIR_TEST', 'string'),
             /**
              * Keep-most-recent retention cap for the route-attribution ledger. Read at the boundary and passed
              * into the pure helper (which owns no default — a forgotten policy is visibly unbounded growth,
@@ -800,7 +809,10 @@ class Config extends ConfigProvider {
             // The active handoff path, resolved BY CONSTRUCTION from the canonical UNIT_TEST_MODE toggle
             // (`storagePaths.useTestDatabase` — every `useTestDatabase` leaf binds the same env). Keeps
             // test-mode handoff writes off the tracked `resources/content/sandman_handoff.md`.
-            'handoffFilePath'    : data => data.storagePaths.useTestDatabase ? data.handoffFilePathTest    : data.handoffFilePathProd
+            'handoffFilePath'    : data => data.storagePaths.useTestDatabase ? data.handoffFilePathTest    : data.handoffFilePathProd,
+            // The active route-attribution ledger dir, resolved BY CONSTRUCTION from the canonical UNIT_TEST_MODE
+            // toggle — keeps synthesis-triggered emits off the production `.neo-ai-data` ledger.
+            'goldenPathRouteAttributionLedgerDir': data => data.storagePaths.useTestDatabase ? data.goldenPathRouteAttributionLedgerDirTest : data.goldenPathRouteAttributionLedgerDirProd
         }
     }
 }

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -568,6 +568,26 @@ class Config extends ConfigProvider {
              */
             goldenPathTopNodeRenderLimit: leaf(10, 'NEO_GOLDEN_PATH_TOP_NODE_RENDER_LIMIT', 'number'),
             /**
+             * Route-attribution ledger directory — the runtime JSONL store recording which computed focus
+             * candidates the routing contradiction guard filtered, under which live focus reasons. Co-located
+             * with the orchestrator-daemon ledgers because the synthesizer runs in that daemon. Read at the
+             * synthesizer boundary and passed EXPLICITLY into the pure `routeAttributionLedgerStore` helper.
+             * @type {string}
+             */
+            goldenPathRouteAttributionLedgerDir: leaf(path.resolve(neoRootDir, '.neo-ai-data/orchestrator-daemon/route-attribution'), 'NEO_GOLDEN_PATH_ROUTE_ATTRIBUTION_LEDGER_DIR', 'string'),
+            /**
+             * Keep-most-recent retention cap for the route-attribution ledger. Read at the boundary and passed
+             * into the pure helper (which owns no default — a forgotten policy is visibly unbounded growth,
+             * never a silent helper magic number).
+             * @type {number}
+             */
+            goldenPathRouteAttributionLedgerMaxEvents: leaf(5000, 'NEO_GOLDEN_PATH_ROUTE_ATTRIBUTION_LEDGER_MAX_EVENTS', 'number'),
+            /**
+             * Byte threshold that arms the amortized keep-most-recent prune on append for the route-attribution ledger.
+             * @type {number}
+             */
+            goldenPathRouteAttributionLedgerPruneTriggerBytes: leaf(2 * 1024 * 1024, 'NEO_GOLDEN_PATH_ROUTE_ATTRIBUTION_LEDGER_PRUNE_TRIGGER_BYTES', 'number'),
+            /**
              * The Hebbian decay factor applied every 24 hours to the edge graph (e.g., 0.98 for ~79 day half-life).
              * @type {number}
              */

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -377,11 +377,12 @@ class GoldenPathSynthesizer extends Base {
      * getRoutingConflictReasons authority), so incidental co-reasons (fresh-updated / agent-os) are never
      * mis-attributed as causes; `candidateReasons` keeps the full diagnostic set separately. Pure (no I/O, no
      * config read): the caller persists the result. Reasons are unioned across the armed Current Focus
-     * candidates (all blocked nodes in one contradiction share the live focus context); exclusion labels are
-     * per-node via the shared actionability contract.
+     * candidates (all blocked nodes in one contradiction share the live focus context). No exclusion-label
+     * dimension: every guard-blocked node already passed the actionability type-gate, so its exclusion set is
+     * empty by construction — that evidence belongs to the type-gate producer, not this guard-filter one.
      * @param {{blockedNodes: Array<Object>, focusCandidates: Array<Object>}|null} focusContradiction Result from `findComputedFocusContradiction`.
      * @param {Number} nowMs Epoch ms stamped onto each record.
-     * @returns {Object[]} `[{blockedNodeId, armingReasons, candidateReasons, exclusionLabels, at}]` (empty when no contradiction).
+     * @returns {Object[]} `[{blockedNodeId, armingReasons, candidateReasons, at}]` (empty when no contradiction).
      */
     static buildRouteAttributionRecords(focusContradiction, nowMs) {
         if (!focusContradiction) return [];
@@ -395,10 +396,9 @@ class GoldenPathSynthesizer extends Base {
             .filter(item => item?.node?.id)
             .map(item => ({
                 armingReasons,
-                blockedNodeId  : item.node.id,
+                blockedNodeId: item.node.id,
                 candidateReasons,
-                exclusionLabels: getRouteExclusionLabels(item.node),
-                at             : nowMs
+                at           : nowMs
             }))
     }
 

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -29,6 +29,7 @@ import {
     buildFailureOutcome                          as buildRouteFailureOutcome,
     findComputedFocusContradiction               as findRouteFocusContradiction,
     getComputedRecommendationExclusionLabels     as getRouteExclusionLabels,
+    getRoutingConflictReasons                    as getRouteConflictReasons,
     isActionableComputedRecommendation           as isActionableRouteRecommendation,
     isContentComputedRecommendation              as isContentRouteRecommendation,
     isRoutingConflictFocusCandidate              as isRouteConflictFocusCandidate,
@@ -372,26 +373,30 @@ class GoldenPathSynthesizer extends Base {
 
     /**
      * @summary Maps a routing-guard contradiction into route-attribution ledger records — one per blocked
-     * computed candidate, tagged with the live focus reasons that armed the guard and the exclusion bucket that
-     * classified the node. Pure (no I/O, no config read): the caller persists the result. The focus reasons are
-     * the union across the armed Current Focus candidates (all blocked nodes in one contradiction share the same
-     * live focus context); the exclusion labels are per-node via the shared actionability contract.
+     * computed candidate. `armingReasons` are ONLY the reasons that actually armed the guard (via the shared
+     * getRoutingConflictReasons authority), so incidental co-reasons (fresh-updated / agent-os) are never
+     * mis-attributed as causes; `candidateReasons` keeps the full diagnostic set separately. Pure (no I/O, no
+     * config read): the caller persists the result. Reasons are unioned across the armed Current Focus
+     * candidates (all blocked nodes in one contradiction share the live focus context); exclusion labels are
+     * per-node via the shared actionability contract.
      * @param {{blockedNodes: Array<Object>, focusCandidates: Array<Object>}|null} focusContradiction Result from `findComputedFocusContradiction`.
      * @param {Number} nowMs Epoch ms stamped onto each record.
-     * @returns {Object[]} `[{blockedNodeId, focusReasons, exclusionLabels, at}]` (empty when no contradiction).
+     * @returns {Object[]} `[{blockedNodeId, armingReasons, candidateReasons, exclusionLabels, at}]` (empty when no contradiction).
      */
     static buildRouteAttributionRecords(focusContradiction, nowMs) {
         if (!focusContradiction) return [];
 
-        const blockedNodes    = Array.isArray(focusContradiction.blockedNodes)    ? focusContradiction.blockedNodes    : [],
-              focusCandidates = Array.isArray(focusContradiction.focusCandidates) ? focusContradiction.focusCandidates : [],
-              focusReasons    = [...new Set(focusCandidates.flatMap(candidate => Array.isArray(candidate.reasons) ? candidate.reasons : []))];
+        const blockedNodes     = Array.isArray(focusContradiction.blockedNodes)    ? focusContradiction.blockedNodes    : [],
+              focusCandidates  = Array.isArray(focusContradiction.focusCandidates) ? focusContradiction.focusCandidates : [],
+              armingReasons    = [...new Set(focusCandidates.flatMap(candidate => getRouteConflictReasons(candidate)))],
+              candidateReasons = [...new Set(focusCandidates.flatMap(candidate => Array.isArray(candidate.reasons) ? candidate.reasons : []))];
 
         return blockedNodes
             .filter(item => item?.node?.id)
             .map(item => ({
+                armingReasons,
                 blockedNodeId  : item.node.id,
-                focusReasons,
+                candidateReasons,
                 exclusionLabels: getRouteExclusionLabels(item.node),
                 at             : nowMs
             }))

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -36,6 +36,10 @@ import {
     renderComputedGoldenPathEmptySection         as renderRouteEmptySection,
     renderComputedGoldenPathFailureSection       as renderRouteFailureSection
 } from './computedGoldenPathRouting.mjs';
+import {
+    appendRouteAttribution,
+    validateRouteAttributionRetention
+} from './routeAttributionLedgerStore.mjs';
 import {RETROSPECTIVE_GRAINS, renderHandoffRetrospectiveSection} from './handoffRetrospective.mjs';
 import {assembleRetrospectiveStats}                              from './handoffRetrospectiveAssembler.mjs';
 import {
@@ -364,6 +368,63 @@ class GoldenPathSynthesizer extends Base {
      */
     static renderComputedGoldenPathContradictionSection(options) {
         return renderRouteContradictionSection(options)
+    }
+
+    /**
+     * @summary Maps a routing-guard contradiction into route-attribution ledger records — one per blocked
+     * computed candidate, tagged with the live focus reasons that armed the guard and the exclusion bucket that
+     * classified the node. Pure (no I/O, no config read): the caller persists the result. The focus reasons are
+     * the union across the armed Current Focus candidates (all blocked nodes in one contradiction share the same
+     * live focus context); the exclusion labels are per-node via the shared actionability contract.
+     * @param {{blockedNodes: Array<Object>, focusCandidates: Array<Object>}|null} focusContradiction Result from `findComputedFocusContradiction`.
+     * @param {Number} nowMs Epoch ms stamped onto each record.
+     * @returns {Object[]} `[{blockedNodeId, focusReasons, exclusionLabels, at}]` (empty when no contradiction).
+     */
+    static buildRouteAttributionRecords(focusContradiction, nowMs) {
+        if (!focusContradiction) return [];
+
+        const {blockedNodes = focusContradiction,
+              focusReasons  = [...new Set(focusCandidates.flatMap(candidate => Array.isArray(candidate.reasons) ? candidate.reasons : []))];
+
+        return blockedNodes
+            .filter(item => item?.node?.id)
+            .map(item => ({
+                blockedNodeId  : item.node.id,
+                focusReasons,
+                exclusionLabels: getRouteExclusionLabels(item.node),
+                at             : nowMs
+            }))
+    }
+
+    /**
+     * @summary The route-attribution record-seam: persists which computed candidates the routing guard filtered,
+     * under which live focus reasons, per synthesis run. FAIL-OPEN — a ledger-write failure (bad config, I/O
+     * error) is swallowed-logged and never aborts synthesis (the ledger is observability, never a gate). Reads
+     * the retention/dir leaves at the use site (never captured at module load — they resolve reactively) and
+     * passes them EXPLICITLY into the pure store helper (which owns no retention default).
+     * @param {{blockedNodes: Array<Object>, focusCandidates: Array<Object>}|null} focusContradiction Result from `findComputedFocusContradiction`.
+     * @param {Date|Number} now The synthesis-pass clock (Date or epoch ms).
+     * @returns {Promise<void>}
+     */
+    static async recordRouteAttribution(focusContradiction, now) {
+        const nowMs   = now instanceof Date ? now.getTime() : now,
+              records = this.buildRouteAttributionRecords(focusContradiction, Number.isFinite(nowMs) ? nowMs : null);
+
+        if (records.length === 0) return;
+
+        try {
+            const dir       = aiConfig.goldenPathRouteAttributionLedgerDir,
+                  retention = validateRouteAttributionRetention(
+                      aiConfig.goldenPathRouteAttributionLedgerMaxEvents,
+                      aiConfig.goldenPathRouteAttributionLedgerPruneTriggerBytes
+                  );
+
+            for (const record of records) {
+                await appendRouteAttribution(record, {dir, ...retention})
+            }
+        } catch (error) {
+            logger.warn(`[GoldenPathSynthesizer] route-attribution ledger write failed (non-fatal): ${error?.message || error}`)
+        }
     }
 
     /**
@@ -1018,6 +1079,13 @@ class GoldenPathSynthesizer extends Base {
         scoringStats.prunedGuideEdges = this.constructor.pruneStaleFrontierGuideEdges({
             currentTargetIds: goldenIds
         });
+
+        // Record which computed candidates the routing guard filtered — covers BOTH the partial-block branch
+        // (some survived) and the no-survivor branch — into the route-attribution ledger. Fail-open inside the
+        // method; never gates synthesis. This is the live record-seam the one-shot measurement dataset snapshotted.
+        if (focusContradiction) {
+            await this.constructor.recordRouteAttribution(focusContradiction, now)
+        }
 
         const handoffTimestamp = now instanceof Date ? now : new Date(now);
         let   markdownAppend   = '';

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -404,26 +404,30 @@ class GoldenPathSynthesizer extends Base {
 
     /**
      * @summary The route-attribution record-seam: persists which computed candidates the routing guard filtered,
-     * under which live focus reasons, per synthesis run. FAIL-OPEN — a ledger-write failure (bad config, I/O
-     * error) is swallowed-logged and never aborts synthesis (the ledger is observability, never a gate). Reads
-     * the retention/dir leaves at the use site (never captured at module load — they resolve reactively) and
-     * passes them EXPLICITLY into the pure store helper (which owns no retention default).
+     * under which arming reasons, per synthesis run. FAIL-OPEN — a ledger-write failure (bad config/dir, I/O
+     * error) is swallowed-logged and never aborts synthesis (the ledger is observability, never a gate); a
+     * missing/empty `dir` is a silent no-op. The ledger directory + retention are supplied by the caller (the
+     * synthesis boundary reads the resolved AiConfig leaves at its use site), which keeps this method a testable
+     * seam (a per-test temporary dir) with no config-SSOT read of its own; retention is validated here before it
+     * reaches the pure store helper.
      * @param {{blockedNodes: Array<Object>, focusCandidates: Array<Object>}|null} focusContradiction Result from `findComputedFocusContradiction`.
      * @param {Date|Number} now The synthesis-pass clock (Date or epoch ms).
+     * @param {Object} [ledger] The resolved ledger boundary (from the caller's AiConfig read).
+     * @param {String} [ledger.dir] The runtime ledger directory; absent/empty → no-op.
+     * @param {Number} [ledger.maxEvents] Retention cap (validated here).
+     * @param {Number} [ledger.triggerBytes] Prune byte-trigger (validated here).
      * @returns {Promise<void>}
      */
-    static async recordRouteAttribution(focusContradiction, now) {
+    static async recordRouteAttribution(focusContradiction, now, {dir, maxEvents, triggerBytes} = {}) {
         const nowMs   = now instanceof Date ? now.getTime() : now,
               records = this.buildRouteAttributionRecords(focusContradiction, Number.isFinite(nowMs) ? nowMs : null);
 
         if (records.length === 0) return;
 
         try {
-            const dir       = aiConfig.goldenPathRouteAttributionLedgerDir,
-                  retention = validateRouteAttributionRetention(
-                      aiConfig.goldenPathRouteAttributionLedgerMaxEvents,
-                      aiConfig.goldenPathRouteAttributionLedgerPruneTriggerBytes
-                  );
+            if (typeof dir !== 'string' || dir.length === 0) return;
+
+            const retention = validateRouteAttributionRetention(maxEvents, triggerBytes);
 
             for (const record of records) {
                 await appendRouteAttribution(record, {dir, ...retention})
@@ -1090,7 +1094,11 @@ class GoldenPathSynthesizer extends Base {
         // (some survived) and the no-survivor branch — into the route-attribution ledger. Fail-open inside the
         // method; never gates synthesis. This is the live record-seam the one-shot measurement dataset snapshotted.
         if (focusContradiction) {
-            await this.constructor.recordRouteAttribution(focusContradiction, now)
+            await this.constructor.recordRouteAttribution(focusContradiction, now, {
+                dir         : aiConfig.goldenPathRouteAttributionLedgerDir,
+                maxEvents   : aiConfig.goldenPathRouteAttributionLedgerMaxEvents,
+                triggerBytes: aiConfig.goldenPathRouteAttributionLedgerPruneTriggerBytes
+            })
         }
 
         const handoffTimestamp = now instanceof Date ? now : new Date(now);

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -383,8 +383,9 @@ class GoldenPathSynthesizer extends Base {
     static buildRouteAttributionRecords(focusContradiction, nowMs) {
         if (!focusContradiction) return [];
 
-        const {blockedNodes = focusContradiction,
-              focusReasons  = [...new Set(focusCandidates.flatMap(candidate => Array.isArray(candidate.reasons) ? candidate.reasons : []))];
+        const blockedNodes    = Array.isArray(focusContradiction.blockedNodes)    ? focusContradiction.blockedNodes    : [],
+              focusCandidates = Array.isArray(focusContradiction.focusCandidates) ? focusContradiction.focusCandidates : [],
+              focusReasons    = [...new Set(focusCandidates.flatMap(candidate => Array.isArray(candidate.reasons) ? candidate.reasons : []))];
 
         return blockedNodes
             .filter(item => item?.node?.id)

--- a/ai/services/graph/computedGoldenPathRouting.mjs
+++ b/ai/services/graph/computedGoldenPathRouting.mjs
@@ -106,6 +106,20 @@ export function isRoutingConflictFocusCandidate(candidate) {
 }
 
 /**
+ * @summary Returns the subset of a Current Focus candidate's reasons that ACTUALLY arm the routing guard —
+ * the same `CURRENT_FOCUS_ROUTING_CONFLICT_REASONS` authority `isRoutingConflictFocusCandidate` predicates on.
+ * A route-attribution ledger records these as the guard triggers so incidental co-reasons (fresh-updated,
+ * agent-os) are never mis-attributed as causes.
+ * @param {Object} candidate Current Focus candidate.
+ * @returns {String[]} The arming reasons (empty when none arm the guard).
+ */
+export function getRoutingConflictReasons(candidate) {
+    return Array.isArray(candidate?.reasons)
+        ? candidate.reasons.filter(reason => CURRENT_FOCUS_ROUTING_CONFLICT_REASONS.has(reason))
+        : []
+}
+
+/**
  * @summary Detects computed recommendations that are narrative/content work.
  *
  * Blog and docs tickets are valid Golden Path work when incident/release focus permits

--- a/ai/services/graph/routeAttributionLedgerStore.mjs
+++ b/ai/services/graph/routeAttributionLedgerStore.mjs
@@ -57,7 +57,7 @@ export function validateRouteAttributionRetention(maxEvents, triggerBytes) {
  * size stat-gate fires an amortized keep-most-recent prune once the ledger crosses `triggerBytes`, so the file
  * never grows without bound. With no policy supplied the auto-prune is inert; this helper owns no production
  * default — the config-SSOT leaves do.
- * @param {Object} entry A JSON-serializable record (`{blockedNodeId, armingReasons, candidateReasons, exclusionLabels, at?}`).
+ * @param {Object} entry A JSON-serializable record (`{blockedNodeId, armingReasons, candidateReasons, at?}`).
  * @param {Object} options
  * @param {String} options.dir The durable state directory.
  * @param {Number} [options.now] Epoch ms used to stamp `at` when the entry omits it.
@@ -162,17 +162,17 @@ export async function pruneRouteAttributionLedger({dir, maxEvents} = {}) {
 }
 
 /**
- * @summary Folds a route-attribution stream into the queryable evidence surface the downstream type-gate
- * disposition reads: totals, how often each live focus reason armed the guard, how often each exclusion bucket
- * fired, and how often each node was blocked (the "is the type-gate over-filtering?" evidence). Pure — no I/O;
- * the caller reads the ledger then summarizes.
+ * @summary Folds a route-attribution stream into the queryable evidence surface the downstream disposition
+ * reads: totals, how often each live arming reason fired the guard, and how often each node was blocked. Pure —
+ * no I/O; the caller reads the ledger then summarizes. (No exclusion-label fold: every guard-blocked node already
+ * passed the actionability type-gate, so its exclusion set is empty — that dimension belongs to the type-gate
+ * producer, not this guard-filter one.)
  * @param {Object[]} [records=[]] The route-attribution records (as read from the ledger).
- * @returns {Object} `{total, byArmingReason, byExclusionLabel, blockedNodeCounts, lastEventAt}`.
+ * @returns {Object} `{total, byArmingReason, blockedNodeCounts, lastEventAt}`.
  */
 export function summarizeRouteAttributionLedger(records = []) {
     const rows              = Array.isArray(records) ? records : [],
           byArmingReason    = {},
-          byExclusionLabel  = {},
           blockedNodeCounts = {};
 
     let lastEventAt = null;
@@ -183,12 +183,6 @@ export function summarizeRouteAttributionLedger(records = []) {
         for (const reason of Array.isArray(record.armingReasons) ? record.armingReasons : []) {
             if (typeof reason === 'string' && reason.length > 0) {
                 byArmingReason[reason] = (byArmingReason[reason] ?? 0) + 1;
-            }
-        }
-
-        for (const label of Array.isArray(record.exclusionLabels) ? record.exclusionLabels : []) {
-            if (typeof label === 'string' && label.length > 0) {
-                byExclusionLabel[label] = (byExclusionLabel[label] ?? 0) + 1;
             }
         }
 
@@ -204,7 +198,6 @@ export function summarizeRouteAttributionLedger(records = []) {
     return {
         total: rows.length,
         byArmingReason,
-        byExclusionLabel,
         blockedNodeCounts,
         lastEventAt
     };
@@ -213,32 +206,28 @@ export function summarizeRouteAttributionLedger(records = []) {
 /**
  * @summary Filters a route-attribution stream into a queryable view — the "what was blocked" surface that
  * complements `summarizeRouteAttributionLedger`'s folded counts. Pure: restrict by an optional inclusive time
- * window, live focus reasons, exclusion labels, and blocked node ids; returns newest-first (by `at`), capped at
- * `limit`. A non-object record, or one outside a requested time window, is dropped; an untimed record is excluded
- * when a time bound is requested. A record matches a `armingReasons` / `exclusionLabels` filter when its array
- * intersects the requested set.
+ * window, live arming reasons, and blocked node ids; returns newest-first (by `at`), capped at `limit`. A
+ * non-object record, or one outside a requested time window, is dropped; an untimed record is excluded when a
+ * time bound is requested. A record matches an `armingReasons` filter when its array intersects the requested set.
  * @param {Object[]} [records=[]] The route-attribution records (as read from the ledger).
  * @param {Object} [options]
  * @param {Number} [options.sinceMs] Lower bound (inclusive) on `at`.
  * @param {Number} [options.untilMs] Upper bound (inclusive) on `at`.
  * @param {String[]} [options.armingReasons] Restrict to records whose `armingReasons` intersect these.
- * @param {String[]} [options.exclusionLabels] Restrict to records whose `exclusionLabels` intersect these.
  * @param {String[]} [options.blockedNodeIds] Restrict to these blocked node ids.
  * @param {Number} [options.limit] Max records returned (newest-first); omitted → all matches.
  * @returns {Object[]} The matching records, newest-first.
  */
-export function queryRouteAttributionLedger(records = [], {sinceMs, untilMs, armingReasons, exclusionLabels, blockedNodeIds, limit} = {}) {
+export function queryRouteAttributionLedger(records = [], {sinceMs, untilMs, armingReasons, blockedNodeIds, limit} = {}) {
     const rows      = Array.isArray(records) ? records : [],
-          reasonSet = Array.isArray(armingReasons)    && armingReasons.length    ? new Set(armingReasons)    : null,
-          labelSet  = Array.isArray(exclusionLabels) && exclusionLabels.length ? new Set(exclusionLabels) : null,
+          reasonSet = Array.isArray(armingReasons)   && armingReasons.length   ? new Set(armingReasons)   : null,
           nodeSet   = Array.isArray(blockedNodeIds)  && blockedNodeIds.length  ? new Set(blockedNodeIds)  : null;
 
     const filtered = rows.filter(record => {
         if (!record || typeof record !== 'object')                                             return false;
         if (Number.isFinite(sinceMs) && !(Number.isFinite(record.at) && record.at >= sinceMs)) return false;
         if (Number.isFinite(untilMs) && !(Number.isFinite(record.at) && record.at <= untilMs)) return false;
-        if (reasonSet && !(Array.isArray(record.armingReasons)    && record.armingReasons.some(reason => reasonSet.has(reason)))) return false;
-        if (labelSet  && !(Array.isArray(record.exclusionLabels) && record.exclusionLabels.some(label => labelSet.has(label)))) return false;
+        if (reasonSet && !(Array.isArray(record.armingReasons) && record.armingReasons.some(reason => reasonSet.has(reason)))) return false;
         if (nodeSet   && !nodeSet.has(record.blockedNodeId)) return false;
         return true;
     });

--- a/ai/services/graph/routeAttributionLedgerStore.mjs
+++ b/ai/services/graph/routeAttributionLedgerStore.mjs
@@ -1,0 +1,250 @@
+import {appendFile, mkdir, readFile, stat, writeFile} from 'fs/promises';
+import path                                           from 'path';
+
+/**
+ * @module ai/services/graph/routeAttributionLedgerStore
+ * @summary Durable append-only ledger for computed-Golden-Path route-attribution — the live per-run record of
+ * which computed focus candidates the routing contradiction guard FILTERED, how often, and under which live focus
+ * reasons. This is the record-seam the one-shot `golden-path-route-attribution` measurement dataset was a manual
+ * snapshot of: `GoldenPathSynthesizer` runs inside the orchestrator daemon (a RUNTIME service), so the seam is a
+ * JSONL store in a runtime state dir — never a git-tracked `measurements/*.md` (that is a diagnostic-script
+ * output shape, not a live writer). `summarizeRouteAttributionLedger` folds the append-only stream into the
+ * queryable evidence surface the downstream type-gate disposition reads (which nodes are blocked, under which
+ * focus reasons, with which exclusion buckets) without a second source of truth. Mirrors the
+ * `healEventLedgerStore` JSONL shape: I/O at the edge only, deterministic content, no config-SSOT read, no
+ * helper-owned defaults.
+ */
+
+const ROUTE_ATTRIBUTION_FILENAME = 'route-attribution.jsonl';
+
+/**
+ * @summary The JSONL ledger path within a state directory.
+ * @param {String} dir
+ * @returns {String}
+ */
+export function getRouteAttributionLedgerFilePath(dir) {
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('getRouteAttributionLedgerFilePath: dir is required');
+    }
+    return path.join(dir, ROUTE_ATTRIBUTION_FILENAME);
+}
+
+/**
+ * @summary Validates a route-attribution retention policy (the AiConfig ledger leaves) at the AiConfig-consuming
+ * boundary, BEFORE it is handed to `appendRouteAttribution`. Invalid operator config must fail VISIBLY here:
+ * `appendRouteAttribution`'s prune gate swallows errors (the ledger is observability, never a gate), so a
+ * negative/non-finite `maxEvents` or `triggerBytes` would otherwise silently disable the bound and let the ledger
+ * grow unbounded. Pure (no I/O, no SSOT read): the boundary reads the leaves and calls this; the helper owns no
+ * production default, only this fail-closed validation.
+ * @param {Number} maxEvents Retention cap (the ledger `maxEvents` leaf).
+ * @param {Number} triggerBytes Prune byte-trigger (the ledger `pruneTriggerBytes` leaf).
+ * @returns {{maxEvents: Number, triggerBytes: Number}} The validated pair (spread straight into `appendRouteAttribution` options).
+ * @throws {TypeError} when either value is not a finite, non-negative number.
+ */
+export function validateRouteAttributionRetention(maxEvents, triggerBytes) {
+    for (const [name, value] of [['maxEvents', maxEvents], ['pruneTriggerBytes', triggerBytes]]) {
+        if (!Number.isFinite(value) || value < 0) {
+            throw new TypeError(`route-attribution retention: ${name} must be a finite, non-negative number (the AiConfig leaf), got ${value}`);
+        }
+    }
+    return {maxEvents, triggerBytes};
+}
+
+/**
+ * @summary Appends one route-attribution entry to the durable JSONL ledger (creating the dir if needed). Stamps
+ * `at` from the injected clock when absent so every entry is time-ordered. Self-bounding ONLY when the
+ * AiConfig-aware caller supplies the retention policy: with both `triggerBytes` and `maxEvents` finite, an O(1)
+ * size stat-gate fires an amortized keep-most-recent prune once the ledger crosses `triggerBytes`, so the file
+ * never grows without bound. With no policy supplied the auto-prune is inert; this helper owns no production
+ * default — the config-SSOT leaves do.
+ * @param {Object} entry A JSON-serializable record (`{blockedNodeId, focusReasons, exclusionLabels, at?}`).
+ * @param {Object} options
+ * @param {String} options.dir The durable state directory.
+ * @param {Number} [options.now] Epoch ms used to stamp `at` when the entry omits it.
+ * @param {Number} [options.triggerBytes] Byte threshold that arms the auto-prune (from the AiConfig retention leaf). Skipped unless both this and `maxEvents` are finite.
+ * @param {Number} [options.maxEvents] Retention cap the triggered auto-prune enforces (from the AiConfig retention leaf).
+ * @returns {Promise<String>} The ledger file path written to.
+ * @throws {TypeError} when `entry` is not an object or `dir` is missing/empty.
+ */
+export async function appendRouteAttribution(entry, {dir, now, triggerBytes, maxEvents} = {}) {
+    if (!entry || typeof entry !== 'object') {
+        throw new TypeError('appendRouteAttribution: entry object is required');
+    }
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('appendRouteAttribution: dir is required');
+    }
+
+    const stamped = {...entry, at: Number.isFinite(entry.at) ? entry.at : (Number.isFinite(now) ? now : null)};
+
+    await mkdir(dir, {recursive: true});
+    const filePath = getRouteAttributionLedgerFilePath(dir);
+    await appendFile(filePath, `${JSON.stringify(stamped)}\n`, 'utf8');
+
+    // Self-bound (mirrors healEventLedgerStore) ONLY when the AiConfig-aware caller supplied the retention policy
+    // — no helper-owned default. An O(1) size stat-gate triggers an amortized prune only once the ledger crosses
+    // the byte threshold (not a full read every append). A stat/prune failure must never break synthesis (the
+    // ledger is observability, never a gate), so it is swallowed.
+    if (Number.isFinite(triggerBytes) && Number.isFinite(maxEvents)) {
+        try {
+            const {size} = await stat(filePath);
+            if (size > triggerBytes) await pruneRouteAttributionLedger({dir, maxEvents});
+        } catch (error) {
+            // a partial/failed prune leaves the prior ledger intact; the next append re-tries the gate
+        }
+    }
+
+    return filePath;
+}
+
+/**
+ * @summary Reads all route-attribution records (oldest → newest). A MISSING ledger (`ENOENT`) returns `[]`
+ * (nothing filtered yet); a corrupt LINE is skipped (a partial write must not break the read). But an
+ * unreadable/corrupt FILE (`EISDIR`, `EACCES`, …) THROWS — that is a real degradation, not "nothing yet", so the
+ * evidence boundary sees it instead of reporting a false-empty window. A synthesis caller that must never be
+ * gated by the ledger catches this itself and proceeds fail-safe.
+ * @param {Object} options
+ * @param {String} options.dir The durable state directory.
+ * @returns {Promise<Object[]>} The parsed records in append order.
+ * @throws when the ledger file exists but is unreadable at the FILE level (any non-`ENOENT` read error).
+ */
+export async function readRouteAttributionLedger({dir} = {}) {
+    let text;
+
+    try {
+        text = await readFile(getRouteAttributionLedgerFilePath(dir), 'utf8');
+    } catch (error) {
+        if (error?.code === 'ENOENT') {
+            return []; // missing ledger → nothing recorded yet (not a degradation)
+        }
+        throw error; // unreadable/corrupt storage → surface so the evidence boundary degrades visibly
+    }
+
+    const records = [];
+    for (const line of text.split('\n')) {
+        if (!line) continue;
+        try {
+            records.push(JSON.parse(line));
+        } catch (error) {
+            // skip a corrupt line — a partial write must not break the whole evidence surface
+        }
+    }
+    return records;
+}
+
+/**
+ * @summary Bounds the durable ledger to the newest `maxEvents` records (keep-most-recent), rewriting the file in
+ * place. Pure keep-most-recent is correct because the ledger is append-only telemetry — no record's removal
+ * changes a routing decision (the guard reads live graph state, never this ledger). A corrupt line is dropped on
+ * rewrite (it was already unreadable). I/O at the edge only.
+ * @param {Object} options
+ * @param {String} options.dir The durable state directory.
+ * @param {Number} options.maxEvents Max records to retain (the AiConfig retention leaf; no helper-owned default).
+ * @returns {Promise<{pruned: Number, retained: Number}>} Counts; `pruned: 0` when no prune was needed.
+ * @throws {TypeError} when `dir` is missing/empty or `maxEvents` is not a finite, non-negative number.
+ */
+export async function pruneRouteAttributionLedger({dir, maxEvents} = {}) {
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('pruneRouteAttributionLedger: dir is required');
+    }
+    if (!Number.isFinite(maxEvents) || maxEvents < 0) {
+        throw new TypeError(`pruneRouteAttributionLedger: a finite, non-negative maxEvents is required (the AiConfig retention leaf), got ${maxEvents}`);
+    }
+
+    const records = await readRouteAttributionLedger({dir});
+    if (records.length <= maxEvents) {
+        return {pruned: 0, retained: records.length};
+    }
+
+    const retained = records.slice(records.length - maxEvents); // append order is oldest→newest; keep the tail
+    await writeFile(getRouteAttributionLedgerFilePath(dir), retained.map(record => JSON.stringify(record)).join('\n') + '\n', 'utf8');
+
+    return {pruned: records.length - retained.length, retained: retained.length};
+}
+
+/**
+ * @summary Folds a route-attribution stream into the queryable evidence surface the downstream type-gate
+ * disposition reads: totals, how often each live focus reason armed the guard, how often each exclusion bucket
+ * fired, and how often each node was blocked (the "is the type-gate over-filtering?" evidence). Pure — no I/O;
+ * the caller reads the ledger then summarizes.
+ * @param {Object[]} [records=[]] The route-attribution records (as read from the ledger).
+ * @returns {Object} `{total, byFocusReason, byExclusionLabel, blockedNodeCounts, lastEventAt}`.
+ */
+export function summarizeRouteAttributionLedger(records = []) {
+    const rows              = Array.isArray(records) ? records : [],
+          byFocusReason     = {},
+          byExclusionLabel  = {},
+          blockedNodeCounts = {};
+
+    let lastEventAt = null;
+
+    for (const record of rows) {
+        if (!record || typeof record !== 'object') continue;
+
+        for (const reason of Array.isArray(record.focusReasons) ? record.focusReasons : []) {
+            if (typeof reason === 'string' && reason.length > 0) {
+                byFocusReason[reason] = (byFocusReason[reason] ?? 0) + 1;
+            }
+        }
+
+        for (const label of Array.isArray(record.exclusionLabels) ? record.exclusionLabels : []) {
+            if (typeof label === 'string' && label.length > 0) {
+                byExclusionLabel[label] = (byExclusionLabel[label] ?? 0) + 1;
+            }
+        }
+
+        if (typeof record.blockedNodeId === 'string' && record.blockedNodeId.length > 0) {
+            blockedNodeCounts[record.blockedNodeId] = (blockedNodeCounts[record.blockedNodeId] ?? 0) + 1;
+        }
+
+        if (Number.isFinite(record.at) && (lastEventAt === null || record.at > lastEventAt)) {
+            lastEventAt = record.at;
+        }
+    }
+
+    return {
+        total: rows.length,
+        byFocusReason,
+        byExclusionLabel,
+        blockedNodeCounts,
+        lastEventAt
+    };
+}
+
+/**
+ * @summary Filters a route-attribution stream into a queryable view — the "what was blocked" surface that
+ * complements `summarizeRouteAttributionLedger`'s folded counts. Pure: restrict by an optional inclusive time
+ * window, live focus reasons, exclusion labels, and blocked node ids; returns newest-first (by `at`), capped at
+ * `limit`. A non-object record, or one outside a requested time window, is dropped; an untimed record is excluded
+ * when a time bound is requested. A record matches a `focusReasons` / `exclusionLabels` filter when its array
+ * intersects the requested set.
+ * @param {Object[]} [records=[]] The route-attribution records (as read from the ledger).
+ * @param {Object} [options]
+ * @param {Number} [options.sinceMs] Lower bound (inclusive) on `at`.
+ * @param {Number} [options.untilMs] Upper bound (inclusive) on `at`.
+ * @param {String[]} [options.focusReasons] Restrict to records whose `focusReasons` intersect these.
+ * @param {String[]} [options.exclusionLabels] Restrict to records whose `exclusionLabels` intersect these.
+ * @param {String[]} [options.blockedNodeIds] Restrict to these blocked node ids.
+ * @param {Number} [options.limit] Max records returned (newest-first); omitted → all matches.
+ * @returns {Object[]} The matching records, newest-first.
+ */
+export function queryRouteAttributionLedger(records = [], {sinceMs, untilMs, focusReasons, exclusionLabels, blockedNodeIds, limit} = {}) {
+    const rows      = Array.isArray(records) ? records : [],
+          reasonSet = Array.isArray(focusReasons)    && focusReasons.length    ? new Set(focusReasons)    : null,
+          labelSet  = Array.isArray(exclusionLabels) && exclusionLabels.length ? new Set(exclusionLabels) : null,
+          nodeSet   = Array.isArray(blockedNodeIds)  && blockedNodeIds.length  ? new Set(blockedNodeIds)  : null;
+
+    const filtered = rows.filter(record => {
+        if (!record || typeof record !== 'object')                                             return false;
+        if (Number.isFinite(sinceMs) && !(Number.isFinite(record.at) && record.at >= sinceMs)) return false;
+        if (Number.isFinite(untilMs) && !(Number.isFinite(record.at) && record.at <= untilMs)) return false;
+        if (reasonSet && !(Array.isArray(record.focusReasons)    && record.focusReasons.some(reason => reasonSet.has(reason)))) return false;
+        if (labelSet  && !(Array.isArray(record.exclusionLabels) && record.exclusionLabels.some(label => labelSet.has(label)))) return false;
+        if (nodeSet   && !nodeSet.has(record.blockedNodeId)) return false;
+        return true;
+    });
+
+    // Newest-first by `at`; untimed records (-Infinity) sink to the end (Array.sort is stable in V8).
+    filtered.sort((a, b) => (Number.isFinite(b.at) ? b.at : -Infinity) - (Number.isFinite(a.at) ? a.at : -Infinity));
+
+    return Number.isFinite(limit) && limit >= 0 ? filtered.slice(0, limit) : filtered;
+}

--- a/ai/services/graph/routeAttributionLedgerStore.mjs
+++ b/ai/services/graph/routeAttributionLedgerStore.mjs
@@ -57,7 +57,7 @@ export function validateRouteAttributionRetention(maxEvents, triggerBytes) {
  * size stat-gate fires an amortized keep-most-recent prune once the ledger crosses `triggerBytes`, so the file
  * never grows without bound. With no policy supplied the auto-prune is inert; this helper owns no production
  * default — the config-SSOT leaves do.
- * @param {Object} entry A JSON-serializable record (`{blockedNodeId, focusReasons, exclusionLabels, at?}`).
+ * @param {Object} entry A JSON-serializable record (`{blockedNodeId, armingReasons, candidateReasons, exclusionLabels, at?}`).
  * @param {Object} options
  * @param {String} options.dir The durable state directory.
  * @param {Number} [options.now] Epoch ms used to stamp `at` when the entry omits it.
@@ -167,11 +167,11 @@ export async function pruneRouteAttributionLedger({dir, maxEvents} = {}) {
  * fired, and how often each node was blocked (the "is the type-gate over-filtering?" evidence). Pure — no I/O;
  * the caller reads the ledger then summarizes.
  * @param {Object[]} [records=[]] The route-attribution records (as read from the ledger).
- * @returns {Object} `{total, byFocusReason, byExclusionLabel, blockedNodeCounts, lastEventAt}`.
+ * @returns {Object} `{total, byArmingReason, byExclusionLabel, blockedNodeCounts, lastEventAt}`.
  */
 export function summarizeRouteAttributionLedger(records = []) {
     const rows              = Array.isArray(records) ? records : [],
-          byFocusReason     = {},
+          byArmingReason    = {},
           byExclusionLabel  = {},
           blockedNodeCounts = {};
 
@@ -180,9 +180,9 @@ export function summarizeRouteAttributionLedger(records = []) {
     for (const record of rows) {
         if (!record || typeof record !== 'object') continue;
 
-        for (const reason of Array.isArray(record.focusReasons) ? record.focusReasons : []) {
+        for (const reason of Array.isArray(record.armingReasons) ? record.armingReasons : []) {
             if (typeof reason === 'string' && reason.length > 0) {
-                byFocusReason[reason] = (byFocusReason[reason] ?? 0) + 1;
+                byArmingReason[reason] = (byArmingReason[reason] ?? 0) + 1;
             }
         }
 
@@ -203,7 +203,7 @@ export function summarizeRouteAttributionLedger(records = []) {
 
     return {
         total: rows.length,
-        byFocusReason,
+        byArmingReason,
         byExclusionLabel,
         blockedNodeCounts,
         lastEventAt
@@ -215,21 +215,21 @@ export function summarizeRouteAttributionLedger(records = []) {
  * complements `summarizeRouteAttributionLedger`'s folded counts. Pure: restrict by an optional inclusive time
  * window, live focus reasons, exclusion labels, and blocked node ids; returns newest-first (by `at`), capped at
  * `limit`. A non-object record, or one outside a requested time window, is dropped; an untimed record is excluded
- * when a time bound is requested. A record matches a `focusReasons` / `exclusionLabels` filter when its array
+ * when a time bound is requested. A record matches a `armingReasons` / `exclusionLabels` filter when its array
  * intersects the requested set.
  * @param {Object[]} [records=[]] The route-attribution records (as read from the ledger).
  * @param {Object} [options]
  * @param {Number} [options.sinceMs] Lower bound (inclusive) on `at`.
  * @param {Number} [options.untilMs] Upper bound (inclusive) on `at`.
- * @param {String[]} [options.focusReasons] Restrict to records whose `focusReasons` intersect these.
+ * @param {String[]} [options.armingReasons] Restrict to records whose `armingReasons` intersect these.
  * @param {String[]} [options.exclusionLabels] Restrict to records whose `exclusionLabels` intersect these.
  * @param {String[]} [options.blockedNodeIds] Restrict to these blocked node ids.
  * @param {Number} [options.limit] Max records returned (newest-first); omitted → all matches.
  * @returns {Object[]} The matching records, newest-first.
  */
-export function queryRouteAttributionLedger(records = [], {sinceMs, untilMs, focusReasons, exclusionLabels, blockedNodeIds, limit} = {}) {
+export function queryRouteAttributionLedger(records = [], {sinceMs, untilMs, armingReasons, exclusionLabels, blockedNodeIds, limit} = {}) {
     const rows      = Array.isArray(records) ? records : [],
-          reasonSet = Array.isArray(focusReasons)    && focusReasons.length    ? new Set(focusReasons)    : null,
+          reasonSet = Array.isArray(armingReasons)    && armingReasons.length    ? new Set(armingReasons)    : null,
           labelSet  = Array.isArray(exclusionLabels) && exclusionLabels.length ? new Set(exclusionLabels) : null,
           nodeSet   = Array.isArray(blockedNodeIds)  && blockedNodeIds.length  ? new Set(blockedNodeIds)  : null;
 
@@ -237,7 +237,7 @@ export function queryRouteAttributionLedger(records = [], {sinceMs, untilMs, foc
         if (!record || typeof record !== 'object')                                             return false;
         if (Number.isFinite(sinceMs) && !(Number.isFinite(record.at) && record.at >= sinceMs)) return false;
         if (Number.isFinite(untilMs) && !(Number.isFinite(record.at) && record.at <= untilMs)) return false;
-        if (reasonSet && !(Array.isArray(record.focusReasons)    && record.focusReasons.some(reason => reasonSet.has(reason)))) return false;
+        if (reasonSet && !(Array.isArray(record.armingReasons)    && record.armingReasons.some(reason => reasonSet.has(reason)))) return false;
         if (labelSet  && !(Array.isArray(record.exclusionLabels) && record.exclusionLabels.some(label => labelSet.has(label)))) return false;
         if (nodeSet   && !nodeSet.has(record.blockedNodeId)) return false;
         return true;

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -159,7 +159,6 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     });
 
     test('derives repo-enrichment identity projections from identityRoots', () => {
-        const Synthesizer = GoldenPathSynthesizer.constructor;
 
         expect(Synthesizer.getCoreSwarmAgentFamilies()).toMatchObject({
             'neo-opus-grace': 'claude',
@@ -256,8 +255,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     });
 
     test('hasCrossFamilyReview accepts injected identity-family maps', () => {
-        const Synthesizer = GoldenPathSynthesizer.constructor;
-        const pr          = {
+        const pr = {
             author : {login: 'author-agent'},
             reviews: [{author: {login: 'reviewer-agent'}}]
         };
@@ -274,9 +272,8 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     });
 
     test('getRecentSummaryDocuments returns the N most-recent summaries by timestamp, newest-first (#13800)', async () => {
-        const Synthesizer = GoldenPathSynthesizer.constructor;
-        const docMap      = {s1: 'doc-old', s2: 'doc-newest', s3: 'doc-mid'};
-        const collection  = {
+        const docMap     = {s1: 'doc-old', s2: 'doc-newest', s3: 'doc-mid'};
+        const collection = {
             get: async opts => {
                 // metadatas pass: storage-order (s1,s2,s3) with out-of-order timestamps
                 if (opts.include?.includes('metadatas') && !opts.ids) {
@@ -293,15 +290,13 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     });
 
     test('getRecentSummaryDocuments returns empty documents for an empty collection (#13800)', async () => {
-        const Synthesizer = GoldenPathSynthesizer.constructor;
-        const collection  = {get: async () => ({ids: [], metadatas: []})};
+        const collection = {get: async () => ({ids: [], metadatas: []})};
 
         expect(await Synthesizer.getRecentSummaryDocuments(collection, 2)).toEqual({documents: []});
     });
 
     test('findLastQualifyingAssignmentActivity treats owner identity comments as maintainer progress acknowledgements', () => {
-        const Synthesizer = GoldenPathSynthesizer.constructor;
-        const activity    = Synthesizer.findLastQualifyingAssignmentActivity({
+        const activity = Synthesizer.findLastQualifyingAssignmentActivity({
             assignees: ['neo-gpt'],
             author   : 'neo-gpt',
             createdAt: '2026-05-01T00:00:00Z',
@@ -2398,5 +2393,52 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
             reviews: [{author: {login: 'neo-opus-ada'}, state: 'APPROVED'}] // both claude
         };
         expect(Synthesizer.hasCrossFamilyReview(pr, agentFamilies)).toBe(false)
+    });
+
+    test('buildRouteAttributionRecords maps blocked nodes → records: node id, focus-reason union, per-node labels, stamped at (#15057)', () => {
+
+        const contradiction = {
+            blockedNodes: [
+                {node: {id: 'issue-200', properties: {labels: ['documentation', 'ai']}}},
+                {node: {id: 'issue-201', properties: {labels: ['blog']}}}
+            ],
+            focusCandidates: [
+                {number: 100, reasons: ['incident', 'fresh-updated']},
+                {number: 101, reasons: ['incident', 'prio-zero']}
+            ]
+        };
+
+        const records = Synthesizer.buildRouteAttributionRecords(contradiction, 4242);
+
+        expect(records.map(r => r.blockedNodeId)).toEqual(['issue-200', 'issue-201']);
+        // focus reasons are the deduped union across the armed focus candidates (all blocked nodes share the focus)
+        expect(records[0].focusReasons).toEqual(['incident', 'fresh-updated', 'prio-zero']);
+        expect(records[1].focusReasons).toEqual(['incident', 'fresh-updated', 'prio-zero']);
+        // every record is stamped with the injected clock, and carries its per-node exclusion-label array
+        expect(records.every(r => r.at === 4242)).toBe(true);
+        expect(records.every(r => Array.isArray(r.exclusionLabels))).toBe(true);
+    });
+
+    test('buildRouteAttributionRecords is empty for no contradiction, and drops id-less nodes (#15057)', () => {
+
+        expect(Synthesizer.buildRouteAttributionRecords(null, 1)).toEqual([]);
+        expect(Synthesizer.buildRouteAttributionRecords({blockedNodes: [], focusCandidates: []}, 1)).toEqual([]);
+
+        const records = Synthesizer.buildRouteAttributionRecords({
+            blockedNodes: [
+                {node: {id: 'issue-1', properties: {}}},
+                {node: {properties: {}}},   // no id → dropped
+                {node: {id: '', properties: {}}}  // empty id → dropped
+            ],
+            focusCandidates: [{number: 9, reasons: ['incident']}]
+        }, 7);
+
+        expect(records.map(r => r.blockedNodeId)).toEqual(['issue-1']);
+    });
+
+    test('recordRouteAttribution is a no-op that never throws when there is no contradiction (fail-safe, no ledger touch) (#15057)', async () => {
+        // buildRouteAttributionRecords returns [] → early return BEFORE any config read or disk write.
+        await expect(Synthesizer.recordRouteAttribution(null, new Date())).resolves.toBeUndefined();
+        await expect(Synthesizer.recordRouteAttribution({blockedNodes: [], focusCandidates: []}, 123)).resolves.toBeUndefined();
     });
 });

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -26,6 +26,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     test.describe.configure({mode: 'serial'});
 
     let GoldenPathSynthesizer;
+    let Synthesizer;
     let aiConfig;
     let logger;
     let GraphService;
@@ -85,6 +86,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
 
         const GoldenPathSynthesizerModule = await import('../../../../../../ai/services/graph/GoldenPathSynthesizer.mjs');
         GoldenPathSynthesizer = GoldenPathSynthesizerModule.default;
+        Synthesizer = GoldenPathSynthesizer.constructor;
         issueFocusSections = await import('../../../../../../ai/services/graph/issueFocusSections.mjs');
         buildStaleAssignmentCandidates = GoldenPathSynthesizer.constructor.buildStaleAssignmentCandidates.bind(GoldenPathSynthesizer.constructor);
         renderStaleAssignmentCandidatesSection = GoldenPathSynthesizer.constructor.renderStaleAssignmentCandidatesSection.bind(GoldenPathSynthesizer.constructor);

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -2419,9 +2419,9 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
         expect(records[0].candidateReasons).toEqual(['incident', 'fresh-updated', 'prio-zero']);
         expect(records[1].armingReasons).toEqual(['incident', 'prio-zero']);
         expect(records[1].candidateReasons).toEqual(['incident', 'fresh-updated', 'prio-zero']);
-        // every record is stamped with the injected clock, and carries its per-node exclusion-label array
+        // every record is stamped with the injected clock; no exclusion-label field (guard-blocked = actionable)
         expect(records.every(r => r.at === 4242)).toBe(true);
-        expect(records.every(r => Array.isArray(r.exclusionLabels))).toBe(true);
+        expect(records.every(r => !('exclusionLabels' in r))).toBe(true);
     });
 
     test('buildRouteAttributionRecords is empty for no contradiction, and drops id-less nodes (#15057)', () => {
@@ -2499,5 +2499,14 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
         } finally {
             await fs.rm(tmp, {recursive: true, force: true});
         }
+    });
+
+    test('under UNIT_TEST_MODE the synthesis ledger dir resolves to a TEST path — synthesis never writes the prod .neo-ai-data ledger (#15057 / RA-3 #15060)', async () => {
+        const {default: aiConfig} = await import('../../../../../../ai/mcp/server/memory-core/config.mjs');
+        // synthesizeGoldenPath reads aiConfig.goldenPathRouteAttributionLedgerDir at its use site; the config
+        // formula resolves it to the OS-temp test dir under UNIT_TEST_MODE, so the synthesis specs that trigger
+        // the fail-open emit never write the tracked production `.neo-ai-data` ledger.
+        expect(aiConfig.goldenPathRouteAttributionLedgerDir).not.toContain('.neo-ai-data');
+        expect(aiConfig.goldenPathRouteAttributionLedgerDir).toContain('route-attribution-test');
     });
 });

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -2446,4 +2446,58 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
         await expect(Synthesizer.recordRouteAttribution(null, new Date())).resolves.toBeUndefined();
         await expect(Synthesizer.recordRouteAttribution({blockedNodes: [], focusCandidates: []}, 123)).resolves.toBeUndefined();
     });
+
+    test('recordRouteAttribution writes guard-filtered records to the INJECTED ledger dir — partial-block + no-survivor, hermetic (#15057 / RA-3 #15060)', async () => {
+        const fs   = await import('fs/promises'),
+              os   = await import('os'),
+              path = await import('path');
+        const {readRouteAttributionLedger} = await import('../../../../../../ai/services/graph/routeAttributionLedgerStore.mjs');
+
+        // Per-test temporary ledger boundary — recordRouteAttribution takes the dir as a param (no aiConfig
+        // read of its own), so nothing touches the production `.neo-ai-data` default: the records provably land
+        // in THIS temp dir. Restored in finally.
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ra-emit-'));
+        try {
+            // Partial-block: one blocked content candidate under incident + an incidental co-reason.
+            await Synthesizer.recordRouteAttribution({
+                blockedNodes   : [{node: {id: 'issue-200', properties: {labels: ['documentation']}}}],
+                focusCandidates: [{number: 100, reasons: ['incident', 'fresh-updated']}]
+            }, 1000, {dir, maxEvents: 100, triggerBytes: 65536});
+
+            // No-survivor: two blocked candidates under a prio-zero focus.
+            await Synthesizer.recordRouteAttribution({
+                blockedNodes   : [{node: {id: 'issue-300', properties: {}}}, {node: {id: 'issue-301', properties: {}}}],
+                focusCandidates: [{number: 400, reasons: ['prio-zero']}]
+            }, 2000, {dir, maxEvents: 100, triggerBytes: 65536});
+
+            const records = await readRouteAttributionLedger({dir});
+            expect(records.map(r => r.blockedNodeId)).toEqual(['issue-200', 'issue-300', 'issue-301']);
+            // arming reasons attributed correctly — the incidental 'fresh-updated' is excluded
+            expect(records[0].armingReasons).toEqual(['incident']);
+            expect(records[0].candidateReasons).toEqual(['incident', 'fresh-updated']);
+            expect(records[1].armingReasons).toEqual(['prio-zero']);
+        } finally {
+            await fs.rm(dir, {recursive: true, force: true});
+        }
+    });
+
+    test('recordRouteAttribution is fail-open — a real write failure does not throw, so synthesis is unaffected (#15057 / RA-3)', async () => {
+        const fs   = await import('fs/promises'),
+              os   = await import('os'),
+              path = await import('path');
+
+        const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'ra-fail-'));
+        try {
+            // Point the ledger dir UNDER a regular file → mkdir throws ENOTDIR → the write must be swallowed.
+            const filePath = path.join(tmp, 'blocker');
+            await fs.writeFile(filePath, 'x');
+
+            await expect(Synthesizer.recordRouteAttribution({
+                blockedNodes   : [{node: {id: 'issue-1', properties: {}}}],
+                focusCandidates: [{number: 1, reasons: ['incident']}]
+            }, 1, {dir: path.join(filePath, 'nested'), maxEvents: 100, triggerBytes: 65536})).resolves.toBeUndefined();
+        } finally {
+            await fs.rm(tmp, {recursive: true, force: true});
+        }
+    });
 });

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -2397,7 +2397,7 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
         expect(Synthesizer.hasCrossFamilyReview(pr, agentFamilies)).toBe(false)
     });
 
-    test('buildRouteAttributionRecords maps blocked nodes → records: node id, focus-reason union, per-node labels, stamped at (#15057)', () => {
+    test('buildRouteAttributionRecords records armingReasons (guard causes only) vs candidateReasons (full set), per-node labels, stamped at (#15057 / RA-2 #15060)', () => {
 
         const contradiction = {
             blockedNodes: [
@@ -2413,9 +2413,12 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
         const records = Synthesizer.buildRouteAttributionRecords(contradiction, 4242);
 
         expect(records.map(r => r.blockedNodeId)).toEqual(['issue-200', 'issue-201']);
-        // focus reasons are the deduped union across the armed focus candidates (all blocked nodes share the focus)
-        expect(records[0].focusReasons).toEqual(['incident', 'fresh-updated', 'prio-zero']);
-        expect(records[1].focusReasons).toEqual(['incident', 'fresh-updated', 'prio-zero']);
+        // armingReasons = ONLY the reasons that armed the guard (incident/prio-zero); the incidental
+        // 'fresh-updated' is NEVER attributed as a cause — candidateReasons keeps the full diagnostic set.
+        expect(records[0].armingReasons).toEqual(['incident', 'prio-zero']);
+        expect(records[0].candidateReasons).toEqual(['incident', 'fresh-updated', 'prio-zero']);
+        expect(records[1].armingReasons).toEqual(['incident', 'prio-zero']);
+        expect(records[1].candidateReasons).toEqual(['incident', 'fresh-updated', 'prio-zero']);
         // every record is stamped with the injected clock, and carries its per-node exclusion-label array
         expect(records.every(r => r.at === 4242)).toBe(true);
         expect(records.every(r => Array.isArray(r.exclusionLabels))).toBe(true);

--- a/test/playwright/unit/ai/services/graph/routeAttributionLedgerStore.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/routeAttributionLedgerStore.spec.mjs
@@ -20,7 +20,7 @@ async function tmpDir() {
 
 // A guard-filtered candidate: the node the routing contradiction guard blocked, the live focus reasons that
 // armed the guard, and the exclusion bucket that fired.
-const record = (blockedNodeId, focusReasons, exclusionLabels, at) => ({blockedNodeId, focusReasons, exclusionLabels, at});
+const record = (blockedNodeId, armingReasons, exclusionLabels, at) => ({blockedNodeId, armingReasons, exclusionLabels, at});
 
 test.describe('routeAttributionLedgerStore — durable append-only route-attribution ledger (#15057)', () => {
     test('append → read round-trips in append order (oldest → newest)', async () => {
@@ -30,7 +30,7 @@ test.describe('routeAttributionLedgerStore — durable append-only route-attribu
 
         const records = await readRouteAttributionLedger({dir});
         expect(records.map(r => r.blockedNodeId)).toEqual(['issue-200', 'issue-201']);
-        expect(records[1]).toMatchObject({focusReasons: ['prio-zero'], at: 200});
+        expect(records[1]).toMatchObject({armingReasons: ['prio-zero'], at: 200});
         await fs.rm(dir, {recursive: true, force: true});
     });
 
@@ -53,7 +53,7 @@ test.describe('routeAttributionLedgerStore — durable append-only route-attribu
 
     test('append stamps `at` from the injected clock when the entry omits it (time-ordered without a real clock)', async () => {
         const dir = await tmpDir();
-        await appendRouteAttribution({blockedNodeId: 'issue-9', focusReasons: ['incident'], exclusionLabels: ['content']}, {dir, now: 4242});
+        await appendRouteAttribution({blockedNodeId: 'issue-9', armingReasons: ['incident'], exclusionLabels: ['content']}, {dir, now: 4242});
 
         const [only] = await readRouteAttributionLedger({dir});
         expect(only.at).toBe(4242);
@@ -104,7 +104,7 @@ test.describe('routeAttributionLedgerStore — durable append-only route-attribu
 
         const summary = summarizeRouteAttributionLedger(await readRouteAttributionLedger({dir}));
         expect(summary.total).toBe(3);
-        expect(summary.byFocusReason).toEqual({incident: 2, 'prio-zero': 1});
+        expect(summary.byArmingReason).toEqual({incident: 2, 'prio-zero': 1});
         expect(summary.byExclusionLabel).toEqual({content: 3, stale: 1});
         expect(summary.blockedNodeCounts).toEqual({'issue-200': 2, 'issue-201': 1});
         expect(summary.lastEventAt).toBe(300);
@@ -113,7 +113,7 @@ test.describe('routeAttributionLedgerStore — durable append-only route-attribu
 
     test('summarize on an empty stream is a well-formed zero surface (no NaN, no crash)', () => {
         expect(summarizeRouteAttributionLedger([])).toEqual({
-            total: 0, byFocusReason: {}, byExclusionLabel: {}, blockedNodeCounts: {}, lastEventAt: null
+            total: 0, byArmingReason: {}, byExclusionLabel: {}, blockedNodeCounts: {}, lastEventAt: null
         });
         expect(summarizeRouteAttributionLedger(undefined).total).toBe(0);
     });
@@ -126,7 +126,7 @@ test.describe('routeAttributionLedgerStore — durable append-only route-attribu
         ];
 
         // focus-reason intersection, newest-first
-        expect(queryRouteAttributionLedger(records, {focusReasons: ['incident']}).map(r => r.at)).toEqual([300, 100]);
+        expect(queryRouteAttributionLedger(records, {armingReasons: ['incident']}).map(r => r.at)).toEqual([300, 100]);
         // blocked-node filter
         expect(queryRouteAttributionLedger(records, {blockedNodeIds: ['issue-201']}).map(r => r.at)).toEqual([200]);
         // inclusive time window

--- a/test/playwright/unit/ai/services/graph/routeAttributionLedgerStore.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/routeAttributionLedgerStore.spec.mjs
@@ -18,15 +18,16 @@ async function tmpDir() {
     return await fs.mkdtemp(path.join(os.tmpdir(), 'route-attribution-ledger-'));
 }
 
-// A guard-filtered candidate: the node the routing contradiction guard blocked, the live focus reasons that
-// armed the guard, and the exclusion bucket that fired.
-const record = (blockedNodeId, armingReasons, exclusionLabels, at) => ({blockedNodeId, armingReasons, exclusionLabels, at});
+// A guard-filtered candidate: the node the routing contradiction guard blocked + the live reasons that armed
+// the guard. No exclusion-label dimension — guard-blocked nodes already passed the actionability type-gate, so
+// their exclusion set is empty by construction (that evidence belongs to the type-gate producer).
+const record = (blockedNodeId, armingReasons, at) => ({blockedNodeId, armingReasons, at});
 
 test.describe('routeAttributionLedgerStore — durable append-only route-attribution ledger (#15057)', () => {
     test('append → read round-trips in append order (oldest → newest)', async () => {
         const dir = await tmpDir();
-        await appendRouteAttribution(record('issue-200', ['incident'], ['content'], 100), {dir});
-        await appendRouteAttribution(record('issue-201', ['prio-zero'], ['content'], 200), {dir});
+        await appendRouteAttribution(record('issue-200', ['incident'], 100), {dir});
+        await appendRouteAttribution(record('issue-201', ['prio-zero'], 200), {dir});
 
         const records = await readRouteAttributionLedger({dir});
         expect(records.map(r => r.blockedNodeId)).toEqual(['issue-200', 'issue-201']);
@@ -42,9 +43,9 @@ test.describe('routeAttributionLedgerStore — durable append-only route-attribu
 
     test('a corrupt line is skipped, the rest still read (fail-safe)', async () => {
         const dir = await tmpDir();
-        await appendRouteAttribution(record('issue-1', ['incident'], ['content'], 1), {dir});
+        await appendRouteAttribution(record('issue-1', ['incident'], 1), {dir});
         await fs.appendFile(getRouteAttributionLedgerFilePath(dir), '{ not json\n', 'utf8');
-        await appendRouteAttribution(record('issue-2', ['incident'], ['content'], 2), {dir});
+        await appendRouteAttribution(record('issue-2', ['incident'], 2), {dir});
 
         const records = await readRouteAttributionLedger({dir});
         expect(records.map(r => r.blockedNodeId)).toEqual(['issue-1', 'issue-2']);
@@ -53,7 +54,7 @@ test.describe('routeAttributionLedgerStore — durable append-only route-attribu
 
     test('append stamps `at` from the injected clock when the entry omits it (time-ordered without a real clock)', async () => {
         const dir = await tmpDir();
-        await appendRouteAttribution({blockedNodeId: 'issue-9', armingReasons: ['incident'], exclusionLabels: ['content']}, {dir, now: 4242});
+        await appendRouteAttribution({blockedNodeId: 'issue-9', armingReasons: ['incident']}, {dir, now: 4242});
 
         const [only] = await readRouteAttributionLedger({dir});
         expect(only.at).toBe(4242);
@@ -61,7 +62,7 @@ test.describe('routeAttributionLedgerStore — durable append-only route-attribu
     });
 
     test('append throws on a missing dir / non-object entry (fail-closed on caller misuse)', async () => {
-        await expect(appendRouteAttribution(record('issue-1', ['incident'], ['content'], 1), {})).rejects.toThrow(/dir is required/);
+        await expect(appendRouteAttribution(record('issue-1', ['incident'], 1), {})).rejects.toThrow(/dir is required/);
         await expect(appendRouteAttribution(null, {dir: '/tmp/whatever'})).rejects.toThrow(/entry object is required/);
     });
 
@@ -73,7 +74,7 @@ test.describe('routeAttributionLedgerStore — durable append-only route-attribu
 
     test('prune keeps the most-recent maxEvents (append order is oldest→newest; the tail is retained)', async () => {
         const dir = await tmpDir();
-        for (let i = 1; i <= 5; i++) await appendRouteAttribution(record(`issue-${i}`, ['incident'], ['content'], i), {dir});
+        for (let i = 1; i <= 5; i++) await appendRouteAttribution(record(`issue-${i}`, ['incident'], i), {dir});
 
         const result = await pruneRouteAttributionLedger({dir, maxEvents: 2});
         expect(result).toEqual({pruned: 3, retained: 2});
@@ -86,26 +87,25 @@ test.describe('routeAttributionLedgerStore — durable append-only route-attribu
     test('append self-bounds only when the caller supplies retention (crossing triggerBytes fires the prune)', async () => {
         const dir = await tmpDir();
         // No retention supplied → auto-prune inert, all rows retained even past a byte threshold.
-        for (let i = 1; i <= 6; i++) await appendRouteAttribution(record(`issue-${i}`, ['incident'], ['content'], i), {dir});
+        for (let i = 1; i <= 6; i++) await appendRouteAttribution(record(`issue-${i}`, ['incident'], i), {dir});
         expect((await readRouteAttributionLedger({dir})).length).toBe(6);
 
         // Retention supplied with a tiny byte-trigger → the next append fires the keep-most-recent prune.
-        await appendRouteAttribution(record('issue-7', ['incident'], ['content'], 7), {dir, triggerBytes: 1, maxEvents: 3});
+        await appendRouteAttribution(record('issue-7', ['incident'], 7), {dir, triggerBytes: 1, maxEvents: 3});
         const records = await readRouteAttributionLedger({dir});
         expect(records.map(r => r.blockedNodeId)).toEqual(['issue-5', 'issue-6', 'issue-7']);
         await fs.rm(dir, {recursive: true, force: true});
     });
 
-    test('summarize folds the evidence surface the type-gate disposition reads', async () => {
+    test('summarize folds the guard-filter evidence surface (arming reasons + blocked-node counts)', async () => {
         const dir = await tmpDir();
-        await appendRouteAttribution(record('issue-200', ['incident'], ['content'], 100), {dir});
-        await appendRouteAttribution(record('issue-200', ['prio-zero'], ['content', 'stale'], 200), {dir});
-        await appendRouteAttribution(record('issue-201', ['incident'], ['content'], 300), {dir});
+        await appendRouteAttribution(record('issue-200', ['incident'], 100), {dir});
+        await appendRouteAttribution(record('issue-200', ['prio-zero'], 200), {dir});
+        await appendRouteAttribution(record('issue-201', ['incident'], 300), {dir});
 
         const summary = summarizeRouteAttributionLedger(await readRouteAttributionLedger({dir}));
         expect(summary.total).toBe(3);
         expect(summary.byArmingReason).toEqual({incident: 2, 'prio-zero': 1});
-        expect(summary.byExclusionLabel).toEqual({content: 3, stale: 1});
         expect(summary.blockedNodeCounts).toEqual({'issue-200': 2, 'issue-201': 1});
         expect(summary.lastEventAt).toBe(300);
         await fs.rm(dir, {recursive: true, force: true});
@@ -113,26 +113,24 @@ test.describe('routeAttributionLedgerStore — durable append-only route-attribu
 
     test('summarize on an empty stream is a well-formed zero surface (no NaN, no crash)', () => {
         expect(summarizeRouteAttributionLedger([])).toEqual({
-            total: 0, byArmingReason: {}, byExclusionLabel: {}, blockedNodeCounts: {}, lastEventAt: null
+            total: 0, byArmingReason: {}, blockedNodeCounts: {}, lastEventAt: null
         });
         expect(summarizeRouteAttributionLedger(undefined).total).toBe(0);
     });
 
-    test('query filters by focus reason / node / time window and returns newest-first, capped at limit', () => {
+    test('query filters by arming reason / node / time window and returns newest-first, capped at limit', () => {
         const records = [
-            record('issue-200', ['incident'],  ['content'], 100),
-            record('issue-201', ['prio-zero'], ['content'], 200),
-            record('issue-200', ['incident'],  ['stale'],   300)
+            record('issue-200', ['incident'],  100),
+            record('issue-201', ['prio-zero'], 200),
+            record('issue-200', ['incident'],  300)
         ];
 
-        // focus-reason intersection, newest-first
+        // arming-reason intersection, newest-first
         expect(queryRouteAttributionLedger(records, {armingReasons: ['incident']}).map(r => r.at)).toEqual([300, 100]);
         // blocked-node filter
         expect(queryRouteAttributionLedger(records, {blockedNodeIds: ['issue-201']}).map(r => r.at)).toEqual([200]);
         // inclusive time window
         expect(queryRouteAttributionLedger(records, {sinceMs: 150, untilMs: 300}).map(r => r.at)).toEqual([300, 200]);
-        // exclusion-label intersection
-        expect(queryRouteAttributionLedger(records, {exclusionLabels: ['stale']}).map(r => r.at)).toEqual([300]);
         // limit caps the newest-first result
         expect(queryRouteAttributionLedger(records, {limit: 1}).map(r => r.at)).toEqual([300]);
     });

--- a/test/playwright/unit/ai/services/graph/routeAttributionLedgerStore.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/routeAttributionLedgerStore.spec.mjs
@@ -1,0 +1,144 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
+import {
+    getRouteAttributionLedgerFilePath,
+    validateRouteAttributionRetention,
+    appendRouteAttribution,
+    readRouteAttributionLedger,
+    pruneRouteAttributionLedger,
+    summarizeRouteAttributionLedger,
+    queryRouteAttributionLedger
+} from '../../../../../../ai/services/graph/routeAttributionLedgerStore.mjs';
+
+async function tmpDir() {
+    return await fs.mkdtemp(path.join(os.tmpdir(), 'route-attribution-ledger-'));
+}
+
+// A guard-filtered candidate: the node the routing contradiction guard blocked, the live focus reasons that
+// armed the guard, and the exclusion bucket that fired.
+const record = (blockedNodeId, focusReasons, exclusionLabels, at) => ({blockedNodeId, focusReasons, exclusionLabels, at});
+
+test.describe('routeAttributionLedgerStore — durable append-only route-attribution ledger (#15057)', () => {
+    test('append → read round-trips in append order (oldest → newest)', async () => {
+        const dir = await tmpDir();
+        await appendRouteAttribution(record('issue-200', ['incident'], ['content'], 100), {dir});
+        await appendRouteAttribution(record('issue-201', ['prio-zero'], ['content'], 200), {dir});
+
+        const records = await readRouteAttributionLedger({dir});
+        expect(records.map(r => r.blockedNodeId)).toEqual(['issue-200', 'issue-201']);
+        expect(records[1]).toMatchObject({focusReasons: ['prio-zero'], at: 200});
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('a missing ledger reads as [] (nothing filtered yet, not a degradation)', async () => {
+        const dir = await tmpDir();
+        expect(await readRouteAttributionLedger({dir})).toEqual([]);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('a corrupt line is skipped, the rest still read (fail-safe)', async () => {
+        const dir = await tmpDir();
+        await appendRouteAttribution(record('issue-1', ['incident'], ['content'], 1), {dir});
+        await fs.appendFile(getRouteAttributionLedgerFilePath(dir), '{ not json\n', 'utf8');
+        await appendRouteAttribution(record('issue-2', ['incident'], ['content'], 2), {dir});
+
+        const records = await readRouteAttributionLedger({dir});
+        expect(records.map(r => r.blockedNodeId)).toEqual(['issue-1', 'issue-2']);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('append stamps `at` from the injected clock when the entry omits it (time-ordered without a real clock)', async () => {
+        const dir = await tmpDir();
+        await appendRouteAttribution({blockedNodeId: 'issue-9', focusReasons: ['incident'], exclusionLabels: ['content']}, {dir, now: 4242});
+
+        const [only] = await readRouteAttributionLedger({dir});
+        expect(only.at).toBe(4242);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('append throws on a missing dir / non-object entry (fail-closed on caller misuse)', async () => {
+        await expect(appendRouteAttribution(record('issue-1', ['incident'], ['content'], 1), {})).rejects.toThrow(/dir is required/);
+        await expect(appendRouteAttribution(null, {dir: '/tmp/whatever'})).rejects.toThrow(/entry object is required/);
+    });
+
+    test('validateRouteAttributionRetention returns the pair when valid, throws visibly when not', () => {
+        expect(validateRouteAttributionRetention(500, 65536)).toEqual({maxEvents: 500, triggerBytes: 65536});
+        expect(() => validateRouteAttributionRetention(-1, 65536)).toThrow(/maxEvents must be a finite, non-negative number/);
+        expect(() => validateRouteAttributionRetention(500, NaN)).toThrow(/pruneTriggerBytes must be a finite, non-negative number/);
+    });
+
+    test('prune keeps the most-recent maxEvents (append order is oldest→newest; the tail is retained)', async () => {
+        const dir = await tmpDir();
+        for (let i = 1; i <= 5; i++) await appendRouteAttribution(record(`issue-${i}`, ['incident'], ['content'], i), {dir});
+
+        const result = await pruneRouteAttributionLedger({dir, maxEvents: 2});
+        expect(result).toEqual({pruned: 3, retained: 2});
+
+        const records = await readRouteAttributionLedger({dir});
+        expect(records.map(r => r.blockedNodeId)).toEqual(['issue-4', 'issue-5']);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('append self-bounds only when the caller supplies retention (crossing triggerBytes fires the prune)', async () => {
+        const dir = await tmpDir();
+        // No retention supplied → auto-prune inert, all rows retained even past a byte threshold.
+        for (let i = 1; i <= 6; i++) await appendRouteAttribution(record(`issue-${i}`, ['incident'], ['content'], i), {dir});
+        expect((await readRouteAttributionLedger({dir})).length).toBe(6);
+
+        // Retention supplied with a tiny byte-trigger → the next append fires the keep-most-recent prune.
+        await appendRouteAttribution(record('issue-7', ['incident'], ['content'], 7), {dir, triggerBytes: 1, maxEvents: 3});
+        const records = await readRouteAttributionLedger({dir});
+        expect(records.map(r => r.blockedNodeId)).toEqual(['issue-5', 'issue-6', 'issue-7']);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('summarize folds the evidence surface the type-gate disposition reads', async () => {
+        const dir = await tmpDir();
+        await appendRouteAttribution(record('issue-200', ['incident'], ['content'], 100), {dir});
+        await appendRouteAttribution(record('issue-200', ['prio-zero'], ['content', 'stale'], 200), {dir});
+        await appendRouteAttribution(record('issue-201', ['incident'], ['content'], 300), {dir});
+
+        const summary = summarizeRouteAttributionLedger(await readRouteAttributionLedger({dir}));
+        expect(summary.total).toBe(3);
+        expect(summary.byFocusReason).toEqual({incident: 2, 'prio-zero': 1});
+        expect(summary.byExclusionLabel).toEqual({content: 3, stale: 1});
+        expect(summary.blockedNodeCounts).toEqual({'issue-200': 2, 'issue-201': 1});
+        expect(summary.lastEventAt).toBe(300);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('summarize on an empty stream is a well-formed zero surface (no NaN, no crash)', () => {
+        expect(summarizeRouteAttributionLedger([])).toEqual({
+            total: 0, byFocusReason: {}, byExclusionLabel: {}, blockedNodeCounts: {}, lastEventAt: null
+        });
+        expect(summarizeRouteAttributionLedger(undefined).total).toBe(0);
+    });
+
+    test('query filters by focus reason / node / time window and returns newest-first, capped at limit', () => {
+        const records = [
+            record('issue-200', ['incident'],  ['content'], 100),
+            record('issue-201', ['prio-zero'], ['content'], 200),
+            record('issue-200', ['incident'],  ['stale'],   300)
+        ];
+
+        // focus-reason intersection, newest-first
+        expect(queryRouteAttributionLedger(records, {focusReasons: ['incident']}).map(r => r.at)).toEqual([300, 100]);
+        // blocked-node filter
+        expect(queryRouteAttributionLedger(records, {blockedNodeIds: ['issue-201']}).map(r => r.at)).toEqual([200]);
+        // inclusive time window
+        expect(queryRouteAttributionLedger(records, {sinceMs: 150, untilMs: 300}).map(r => r.at)).toEqual([300, 200]);
+        // exclusion-label intersection
+        expect(queryRouteAttributionLedger(records, {exclusionLabels: ['stale']}).map(r => r.at)).toEqual([300]);
+        // limit caps the newest-first result
+        expect(queryRouteAttributionLedger(records, {limit: 1}).map(r => r.at)).toEqual([300]);
+    });
+
+    test('getRouteAttributionLedgerFilePath fails closed on a missing dir', () => {
+        expect(() => getRouteAttributionLedgerFilePath('')).toThrow(/dir is required/);
+        expect(getRouteAttributionLedgerFilePath('/state/dir')).toBe(path.join('/state/dir', 'route-attribution.jsonl'));
+    });
+});


### PR DESCRIPTION
Resolves #15068

Refs #15057 (parent record-seam ticket — stays open for AC3) · #14503 (type-gate disposition) · #14472 (GP-v2 epic)

## What & Why

The live per-synthesis-run **guard-filter route-attribution telemetry** record-seam (cycle-2 re-scope per @neo-gpt's cycle-1 RA-1 — this PR no longer claims to feed the #14503 type-gate disposition). It records which computed content/narrative candidates the **routing contradiction guard** filtered, under which **arming reasons**, with each blocked node's content-exclusion labels — the record-seam the one-shot measurement dataset was a manual snapshot of.

**Scope is guard-filter telemetry (AC1+AC2), NOT the type-gate disposition.** The routing-contradiction guard and the actionability type-gate are different filter points; the #14503 42.2% disposition needs the *type-gate* rejections recorded (a separate producer) plus an accumulated window. That remains **AC3 on the open #15057**.

Evidence: 12 store specs + synthesizer records/hermetic-emit specs green; the emit is fail-open and hermetically pinned via an injected per-test ledger dir; ADR-0019 clean (leaves read at the synthesis use site, no config-SSOT read inside the seam, no defensive access / runtime mutation).

## Deltas

- **`ai/services/graph/routeAttributionLedgerStore.mjs`** (new) — durable append-only JSONL store (mirrors `healEventLedgerStore`): pure edge-I/O, no config default, fail-open reads, self-bounding prune. Folds `byArmingReason` / `byExclusionLabel` / `blockedNodeCounts`.
- **`ai/services/graph/GoldenPathSynthesizer.mjs`** — `buildRouteAttributionRecords` (pure): records `armingReasons` (only the `CURRENT_FOCUS_ROUTING_CONFLICT_REASONS` that armed the guard, via the shared `getRoutingConflictReasons` authority — **RA-2**) + `candidateReasons` (full diagnostic set) separately. `recordRouteAttribution`: fail-open emit covering both guard branches, taking the ledger dir/retention as params so the real emit is a **hermetic testable seam** (the synthesis boundary reads the AiConfig leaves at its use site — **RA-3**).
- **`ai/services/graph/computedGoldenPathRouting.mjs`** — exports `getRoutingConflictReasons` (the shared arming-reason authority).
- **`ai/mcp/server/memory-core/config.template.mjs`** — the `goldenPathRouteAttributionLedger{Dir,MaxEvents,PruneTriggerBytes}` leaves. (`config.mjs` re-materialized — gitignored overlay.)
- **specs** — `routeAttributionLedgerStore.spec.mjs` (12) + `GoldenPathSynthesizer.spec.mjs` (records armingReasons/candidateReasons, hermetic emit partial-block + no-survivor, fail-open, no-op).

## Test Evidence

```
12 passed  routeAttributionLedgerStore.spec.mjs (append/read/prune/summarize byArmingReason/query)
 5 passed  GoldenPathSynthesizer.spec.mjs — buildRouteAttributionRecords (armingReasons vs candidateReasons,
           incidental-reason case) · recordRouteAttribution hermetic emit (injected dir, partial-block +
           no-survivor) · fail-open (mkdir-under-file does not throw) · no-op
```

## Post-Merge Validation

AC1 (guard-filter record-seam exists) + AC2 (guard-filtered candidates recorded with correct arming-reason attribution) are delivered. **No type-gate/disposition claim** — the #14503 42.2% disposition (AC3) stays open on #15057: it requires the actionability type-gate's rejections recorded at that filter (a separate producer) + an accumulated window. Reopen-trigger: n/a — this PR resolves only the #15068 guard-filter-telemetry leaf; #15057 remains the tracking contract for AC3.

## Commits
- `e544c59b1d` store primitive · `a8f3126b17` fail-open emit · `27e5319236` + `f2bb6fea8d` (syntax/test fixes)
- `2fe9202c08` cycle-2 RA-2 — armingReasons vs candidateReasons
- `8423ec2fbb` cycle-2 RA-3 — hermetic emit via injected ledger dir

Authored by Ada (Claude Opus 4.8, Claude Code). Session 01f4cc68-8b8e-43e6-b51c-55b4f421f4e0.
