### PR TITLE
feat(dashboard): tab-overflow affordance — hidden-tab projection for heavy tabs nodes (#14771)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -24,6 +24,11 @@ const initialDockModel = {
     items : {
         strategy : {componentRef: 'Strategy',  title: 'Strategy',  kind: 'panel'},
         swarm    : {componentRef: 'Swarm',     title: 'Swarm',     kind: 'panel'},
+        metrics  : {componentRef: 'Metrics',   title: 'Metrics',   kind: 'panel'},
+        timeline : {componentRef: 'Timeline',  title: 'Timeline',  kind: 'panel'},
+        agents   : {componentRef: 'Agents',    title: 'Agents',    kind: 'panel'},
+        alerts   : {componentRef: 'Alerts',    title: 'Alerts',    kind: 'panel'},
+        history  : {componentRef: 'History',   title: 'History',   kind: 'panel'},
         terminal : {componentRef: 'Terminal',  title: 'Terminal',  kind: 'terminal'},
         logs     : {componentRef: 'Logs',      title: 'Logs',      kind: 'panel'},
         inspector: {componentRef: 'Inspector', title: 'Inspector', kind: 'panel'}
@@ -31,7 +36,7 @@ const initialDockModel = {
     nodes: {
         root            : {type: 'edge-zone', zones: {center: 'root-split', right: 'inspector-tabs'}},
         'root-split'    : {type: 'split', orientation: 'horizontal', children: ['main-tabs', 'side-split'], sizes: [0.65, 0.35]},
-        'main-tabs'     : {type: 'tabs',  items: ['strategy', 'swarm'], activeItemId: 'strategy'},
+        'main-tabs'     : {type: 'tabs',  items: ['strategy', 'swarm', 'metrics', 'timeline', 'agents', 'alerts', 'history'], activeItemId: 'strategy'},
         'side-split'    : {type: 'split', orientation: 'vertical', children: ['terminal-tabs', 'logs-tabs'], sizes: [0.6, 0.4]},
         'terminal-tabs' : {type: 'tabs',  items: ['terminal'],  activeItemId: 'terminal'},
         'logs-tabs'     : {type: 'tabs',  items: ['logs'],      activeItemId: 'logs'},

--- a/resources/scss/src/button/Base.scss
+++ b/resources/scss/src/button/Base.scss
@@ -30,6 +30,14 @@
     white-space       : nowrap;
     -webkit-appearance: button;
 
+    // A floating button must keep the `.neo-floating` fixed positioning. The `.neo-button` `position:
+    // relative` above otherwise wins the cascade (equal single-class specificity, later source order) and
+    // pins the button to its offsetParent instead of the viewport — so `alignTo`'s computed left/top land
+    // it at the wrong coordinates. This higher-specificity compound selector restores `position: fixed`.
+    &.neo-floating {
+        position: fixed;
+    }
+
     .neo-button-badge {
         background-color: var(--button-badge-background-color);
         border-radius   : 5px;

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -161,17 +161,28 @@ class DockLayoutAdapter extends Base {
         if (activeIndex !== -1) {
             hidden.splice(activeIndex, 1);
 
-            if (visible.length > 0) {
-                const displaced = visible.pop(),
-                      // re-insert both in items order so the menu stays predictable
-                      order     = list.map(entry => entry.id);
+            const activeWidth = width(list.find(entry => entry.id === activeItemId)),
+                  order       = list.map(entry => entry.id),
+                  displaced   = [];
 
-                visible.push(activeItemId);
-                hidden.push(displaced);
+            // Displace as many TRAILING visible items as it takes to fit the (possibly wider) active item.
+            // Popping exactly one under-displaces when the active tab is wider than that single displaced tab
+            // — the visible strip would then still exceed `usable` and the active spills. Loop until it fits,
+            // or until nothing is left (the degenerate "active alone is wider than the strip" case, where it
+            // stays visible regardless). Popping none is also correct when the active already fits (it was
+            // hidden only because an earlier item overflowed the `hidden.length === 0` gate above).
+            while (visible.length > 0 && used + activeWidth > usable) {
+                const displacedId = visible.pop();
+                used -= width(list.find(entry => entry.id === displacedId));
+                displaced.push(displacedId)
+            }
+
+            visible.push(activeItemId);
+
+            if (displaced.length > 0) {
+                // re-insert the displaced items in list order so the overflow menu stays predictable
+                hidden.push(...displaced);
                 hidden.sort((a, b) => order.indexOf(a) - order.indexOf(b))
-            } else {
-                // degenerate: nothing fits — the active tab stays visible regardless
-                visible.push(activeItemId)
             }
         }
 

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -109,6 +109,75 @@ class DockLayoutAdapter extends Base {
     }
 
     /**
+     * @summary Computes the visible/hidden tab split for a heavy tabs node — the pure core of
+     * the overflow affordance (a projection concern; nothing here persists or mutates the model).
+     *
+     * Contract (the design record's tab-overflow projection half):
+     * - The ACTIVE item is NEVER hidden — you cannot overflow the tab you are looking at. When
+     *   packing would drop it, it swaps in and the last-fitting non-active item overflows instead.
+     * - `controlWidth` (the overflow control's own extent) is reserved ONLY when overflow occurs:
+     *   a control that exists only when needed must not consume width while everything fits.
+     * - `hidden` preserves `items` order, so an overflow menu lists predictably.
+     * - Fail-soft on malformed measurements: a non-finite/negative width packs as 0 (an
+     *   unmeasured header must never crash a projection pass).
+     * @param {Object} config
+     * @param {Object[]} config.items         Ordered `[{id, headerWidth}]` in projection order
+     * @param {Number}   config.extent        Available header-strip width
+     * @param {String}  [config.activeItemId] The tabs node's active item id
+     * @param {Number}  [config.controlWidth] The overflow control's width (reserved on overflow only)
+     * @returns {{visible: String[], hidden: String[]}}
+     * @static
+     */
+    static computeTabOverflow({items, extent, activeItemId, controlWidth = 0}) {
+        const list  = Array.isArray(items) ? items : [],
+              width = entry => {
+                  const value = Number(entry?.headerWidth);
+                  return Number.isFinite(value) && value > 0 ? value : 0
+              },
+              total = list.reduce((sum, entry) => sum + width(entry), 0);
+
+        if (!(total > extent)) {
+            return {hidden: [], visible: list.map(entry => entry.id)}
+        }
+
+        const usable  = Math.max(0, extent - Math.max(0, Number(controlWidth) || 0)),
+              visible = [],
+              hidden  = [];
+        let used = 0;
+
+        for (const entry of list) {
+            if (used + width(entry) <= usable && hidden.length === 0) {
+                visible.push(entry.id);
+                used += width(entry)
+            } else {
+                hidden.push(entry.id)
+            }
+        }
+
+        // the active item never hides: swap it in, overflow the last-fitting non-active item
+        const activeIndex = hidden.indexOf(activeItemId);
+
+        if (activeIndex !== -1) {
+            hidden.splice(activeIndex, 1);
+
+            if (visible.length > 0) {
+                const displaced = visible.pop(),
+                      // re-insert both in items order so the menu stays predictable
+                      order     = list.map(entry => entry.id);
+
+                visible.push(activeItemId);
+                hidden.push(displaced);
+                hidden.sort((a, b) => order.indexOf(a) - order.indexOf(b))
+            } else {
+                // degenerate: nothing fits — the active tab stays visible regardless
+                visible.push(activeItemId)
+            }
+        }
+
+        return {hidden, visible}
+    }
+
+    /**
      * Returns normalized flex values for split children.
      * @param {Number[]} sizes
      * @param {Number} count

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -4,6 +4,7 @@ import DockSplitter       from './DockSplitter.mjs';
 import DockTabEnterButton from './DockTabEnterButton.mjs';
 import DockTabSortZone    from './DockTabSortZone.mjs';
 import DockZoneModel      from './DockZoneModel.mjs';
+import TabOverflow        from './plugin/TabOverflow.mjs';
 
 /**
  * @summary Projects Agent Harness dock-zone model nodes into existing Neo layout and tab configs.
@@ -742,6 +743,10 @@ class DockLayoutAdapter extends Base {
             // (below), cross-zone drops report their release point to `onDockCrossZoneDrop` so the owner can
             // hit-test the target zone and commit a `moveItem`. Still one drag system — no parallel pipeline.
             headerToolbar : {
+                // Tab-overflow projection half: the runtime plugin measures header extents, feeds the pure
+                // `computeTabOverflow` decider, and surfaces the hidden remainder through one overflow control
+                // whose selection rides the existing `activeIndex` path (no new persisted state).
+                plugins       : [{module: TabOverflow}],
                 sortZoneConfig: {
                     module          : DockTabSortZone,
                     dockItemIds     : items,

--- a/src/dashboard/plugin/TabOverflow.mjs
+++ b/src/dashboard/plugin/TabOverflow.mjs
@@ -61,6 +61,18 @@ class TabOverflow extends Plugin {
      * @member {Object|null} naturalWidths=null
      */
     naturalWidths = null
+    /**
+     * A project() call arrived while a measure pass was in flight; drained once the pass releases the
+     * latch, so a coalesced resize / activation / tab-set change still applies against current extents.
+     * @member {Boolean} projectQueued=false
+     */
+    projectQueued = false
+    /**
+     * Whether the coalesced re-run must re-read natural widths — sticky-true so a queued `project(true)`
+     * (a tab-set change) is never downgraded to an extent-only pass by a later queued `project(false)`.
+     * @member {Boolean} queuedRecapture=false
+     */
+    queuedRecapture = false
 
     /**
      * @param {Object} config
@@ -128,42 +140,71 @@ class TabOverflow extends Plugin {
             {owner} = me,
             buttons = me.getTabButtons();
 
-        if (me.measuring || !owner.mounted || buttons.length < 1) {
+        if (!owner.mounted || buttons.length < 1) {
+            return
+        }
+
+        // Re-entrancy: getDomRect is an async main-thread round-trip, so a resize / activation / tab-set
+        // storm can overlap passes. Coalesce instead of dropping — remember a re-run is owed (recapture is
+        // sticky) and apply it ONCE after the in-flight pass, so the last state wins over a stale split.
+        if (me.measuring) {
+            me.projectQueued   = true;
+            me.queuedRecapture = me.queuedRecapture || recapture;
             return
         }
 
         me.measuring = true;
 
-        // 1. Natural widths — measured once while every button is visible, then cached.
-        if (recapture || !me.naturalWidths) {
-            let rects = await owner.getDomRect(buttons.map(button => button.id));
+        try {
+            // 1. Natural widths — measured once while every button is visible, then cached.
+            if (recapture || !me.naturalWidths) {
+                let rects = await owner.getDomRect(buttons.map(button => button.id));
 
-            me.naturalWidths = {};
-            buttons.forEach((button, index) => {
-                me.naturalWidths[button.id] = Math.ceil(rects[index]?.width || 0)
-            })
+                me.naturalWidths = {};
+                buttons.forEach((button, index) => {
+                    me.naturalWidths[button.id] = Math.ceil(rects[index]?.width || 0)
+                })
+            }
+
+            // 2. The strip extent — the toolbar itself never hides, so it is always measurable.
+            let extentRect   = await owner.getDomRect(),
+                extent       = Math.floor(extentRect?.width || 0),
+                tabContainer = me.getTabContainer(),
+                activeButton = buttons[tabContainer?.activeIndex] || null,
+                items        = buttons.map(button => ({id: button.id, headerWidth: me.naturalWidths[button.id]})),
+
+                // 3. The pure decision: active-never-hidden packing, overflow-only control reservation.
+                //    Referenced via the Neo namespace (not imported) to keep the adapter→plugin dependency
+                //    one-directional — the adapter imports this plugin for the projection, so importing the
+                //    adapter back would be a cycle.
+                {hidden} = Neo.dashboard.DockLayoutAdapter.computeTabOverflow({
+                    activeItemId: activeButton?.id,
+                    controlWidth: me.controlWidth,
+                    extent,
+                    items
+                });
+
+            me.applySplit(hidden, buttons, tabContainer)
+        } catch {
+            // A measure is best-effort: getDomRect can lose a race with teardown, and a failed pass must
+            // neither reject a fire-and-forget resize/activation handler nor skip the queued-re-run drain
+            // below (re-throwing would strand `projectQueued`). The next event re-projects against a live
+            // owner; a genuine defect surfaces as a missing split in the example / e2e, not a frozen header.
+        } finally {
+            // ALWAYS release the latch: a thrown getDomRect / applySplit must not strand `measuring` at
+            // true, which would silently freeze every future projection (the header stops responding).
+            me.measuring = false
         }
 
-        // 2. The strip extent — the toolbar itself never hides, so it is always measurable.
-        let extentRect   = await owner.getDomRect(),
-            extent       = Math.floor(extentRect?.width || 0),
-            tabContainer = me.getTabContainer(),
-            activeButton = buttons[tabContainer?.activeIndex] || null,
-            items        = buttons.map(button => ({id: button.id, headerWidth: me.naturalWidths[button.id]})),
+        // Drain a coalesced re-run: an event that arrived mid-pass is applied once here, against the
+        // now-current extents, so the split never lags the last resize / activation / tab-set change.
+        if (me.projectQueued) {
+            let queuedRecapture = me.queuedRecapture;
 
-            // 3. The pure decision: active-never-hidden packing, overflow-only control reservation.
-            //    Referenced via the Neo namespace (not imported) to keep the adapter→plugin dependency
-            //    one-directional — the adapter imports this plugin for the projection, so importing the
-            //    adapter back would be a cycle.
-            {hidden} = Neo.dashboard.DockLayoutAdapter.computeTabOverflow({
-                activeItemId: activeButton?.id,
-                controlWidth: me.controlWidth,
-                extent,
-                items
-            });
-
-        me.applySplit(hidden, buttons, tabContainer);
-        me.measuring = false
+            me.projectQueued   = false;
+            me.queuedRecapture = false;
+            me.project(queuedRecapture)
+        }
     }
 
     /**

--- a/src/dashboard/plugin/TabOverflow.mjs
+++ b/src/dashboard/plugin/TabOverflow.mjs
@@ -1,4 +1,3 @@
-import Button from '../../button/Base.mjs';
 import Plugin from '../../plugin/Base.mjs';
 
 /**
@@ -86,7 +85,7 @@ class TabOverflow extends Plugin {
      * @returns {Neo.tab.header.Button[]}
      */
     getTabButtons() {
-        return this.owner.items || []
+        return (this.owner.items || []).filter(item => item !== this.control)
     }
 
     /**
@@ -98,6 +97,9 @@ class TabOverflow extends Plugin {
             {owner} = me;
 
         owner.addDomListeners([{resize: me.onResize, scope: me}]);
+        // Re-run on activation too: selecting a hidden tab flips activeIndex, and active-never-hidden must
+        // then surface the newly-active tab into the header (swapping a fitting one into the overflow menu).
+        me.getTabContainer()?.on('activeIndexChange', me.onActiveIndexChange, me);
         me.project(true)
     }
 
@@ -106,6 +108,14 @@ class TabOverflow extends Plugin {
      * @param {Object} data
      */
     onResize(data) {
+        this.project(false)
+    }
+
+    /**
+     * Activation handler — a selection (including from the overflow menu) flipped `activeIndex`; recompute
+     * so active-never-hidden surfaces the newly-active tab.
+     */
+    onActiveIndexChange() {
         this.project(false)
     }
 
@@ -201,8 +211,10 @@ class TabOverflow extends Plugin {
         let me = this;
 
         if (hiddenMeta.length < 1) {
-            me.control?.destroy(true);
-            me.control = null;
+            if (me.control) {
+                me.owner.remove(me.control, true);
+                me.control = null
+            }
             return
         }
 
@@ -215,26 +227,19 @@ class TabOverflow extends Plugin {
         if (me.control) {
             me.control.menu = menuItems
         } else {
-            me.control = Neo.create({
-                // Floating component (per button.Base#afterSetMenu): mounts and self-positions via `align`
-                // against a target — a plain `parentId` never renders. Anchored to the header toolbar's
-                // trailing top-right, in the `controlWidth` gap the pure core reserves; stays out of the
-                // toolbar's item collection (tab-insertion safe). Created `hidden`, then revealed below —
-                // Neo mounts a floating component on the hidden→false transition (the menu's show path,
-                // button.Base#toggleMenu), so one created already-visible never triggers the mount.
-                module         : Button,
-                align          : {edgeAlign: 'tr-tr', target: me.owner.id},
-                appName        : me.owner.appName,
-                cls            : ['neo-dock-tab-overflow-control'],
-                floating       : true,
-                hidden         : true,
-                iconCls        : 'fa fa-ellipsis',
-                menu           : menuItems,
-                parentComponent: me.owner,
-                windowId       : me.owner.windowId
+            // Added as a trailing toolbar item so it actually renders — the header toolbar renders its own
+            // items, whereas a standalone floating instance never mounted (two prior attempts). Excluded
+            // from getTabButtons() by identity, so it is never measured or hidden as a tab. Safe in the dock
+            // projection: tabs come from the projected config (not `tab.Container.add`), and `activeIndex`
+            // only ranges over the real tabs, so a trailing non-tab item never perturbs the index mapping.
+            let added = me.owner.add({
+                cls    : ['neo-dock-tab-overflow-control'],
+                iconCls: 'fa fa-ellipsis',
+                menu   : menuItems,
+                ntype  : 'button'
             });
 
-            me.control.hidden = false
+            me.control = Array.isArray(added) ? added[added.length - 1] : added
         }
     }
 

--- a/src/dashboard/plugin/TabOverflow.mjs
+++ b/src/dashboard/plugin/TabOverflow.mjs
@@ -11,14 +11,20 @@ import Plugin from '../../plugin/Base.mjs';
  * constraint). `items` order and `activeItemId` already capture the state; overflow is projection only.
  *
  * It attaches to the projected tab header toolbar (`Neo.tab.header.Toolbar`) — it is NOT a dock-specific
- * `tab.Container` fork (the model contract's Split/Tab Adapter Boundary). The overflow control is kept
- * OUT of the toolbar's item collection on purpose: `tab.Container` uses `getTabBar().items.length` as its
- * tab-insertion index (Container.mjs), so a control living among the tab buttons would corrupt insertion.
+ * `tab.Container` fork (the model contract's Split/Tab Adapter Boundary). The overflow control lives as a
+ * trailing item of that header toolbar, excluded from `getTabButtons()` by identity so it is never
+ * measured, hidden, or counted as a tab. A trailing non-tab item would corrupt `tab.Container`'s
+ * interactive insertion index (`getTabBar().items.length`) in the general case — but the dock projects its
+ * tabs declaratively (`DockLayoutAdapter` hands a full `items` config and rebuilds on every tab-set change)
+ * and never calls `tab.Container.add()`, so that path is never taken. The control also carries none of a
+ * tab button's `activeIndex` click wiring (that lives in `getTabButtonConfig`, which the plugin bypasses),
+ * so selecting it opens its menu rather than activating a phantom card.
  *
- * Natural-width discipline: overflowing buttons hide via a `display:none` cls, so re-measuring them would
- * collapse their width to 0 and corrupt the next split. The plugin therefore measures NATURAL widths once
- * while every button is visible (on mount, and whenever the tab set changes) and caches them; a plain
- * resize only re-reads the always-visible strip extent and recomputes against that cache.
+ * Natural-width discipline: overflowing buttons are removed from the DOM (Neo's built-in `hidden` /
+ * removeDom), so re-measuring them would collapse their width to 0 and corrupt the next split. The plugin
+ * therefore measures NATURAL widths once while every button is visible (on mount, and whenever the tab set
+ * changes) and caches them; a plain resize only re-reads the always-visible strip extent and recomputes
+ * against that cache.
  *
  * @class Neo.dashboard.plugin.TabOverflow
  * @extends Neo.plugin.Base
@@ -242,9 +248,10 @@ class TabOverflow extends Plugin {
      * left in the menu.
      *
      * The control is a `button.Base` with a `menu` config — button.Base builds the dropdown `menu.List`
-     * itself, so no menu is hand-assembled here. It mounts as a `floating` component self-positioned via
-     * `align` against the header toolbar (the same mechanism `button.Base#afterSetMenu` uses for its own
-     * menu), which keeps it out of the toolbar's item collection so tab insertion stays correct.
+     * itself, so no menu is hand-assembled here. It is added as a trailing item of the header toolbar
+     * (which renders its own items), and excluded from `getTabButtons()` by identity so it is never
+     * measured or hidden as a tab — see the class note on why a trailing non-tab item is safe in the dock
+     * projection.
      * @param {Object[]} hiddenMeta  `{text, iconCls, index}` per hidden tab, in header order.
      * @param {Neo.tab.Container} tabContainer
      */

--- a/src/dashboard/plugin/TabOverflow.mjs
+++ b/src/dashboard/plugin/TabOverflow.mjs
@@ -171,7 +171,10 @@ class TabOverflow extends Plugin {
         buttons.forEach((button, index) => {
             let isHidden = hiddenSet.has(button.id);
 
-            button[isHidden ? 'addCls' : 'removeCls']('neo-dock-tab-hidden');
+            // Neo's built-in `hidden` (removeDom) rather than a cls needing an external stylesheet rule —
+            // the natural-width cache (captured while every button was visible) survives the DOM removal,
+            // so a later widen re-measures nothing and simply flips `hidden` back.
+            button.hidden = isHidden;
 
             if (isHidden) {
                 hiddenMeta.push({iconCls: button.iconCls, index, text: button.text})

--- a/src/dashboard/plugin/TabOverflow.mjs
+++ b/src/dashboard/plugin/TabOverflow.mjs
@@ -76,8 +76,9 @@ class TabOverflow extends Plugin {
      */
     projectQueued = false
     /**
-     * Whether the coalesced re-run must re-read natural widths — sticky-true so a queued `project(true)`
-     * (a tab-set change) is never downgraded to an extent-only pass by a later queued `project(false)`.
+     * Whether the coalesced re-run must re-read natural widths — sticky-true so a queued width-capturing
+     * `project(true)` (the mount pass) is never downgraded to an extent-only pass by a later queued
+     * `project(false)` (resize / activation) that overlapped it.
      * @member {Boolean} queuedRecapture=false
      */
     queuedRecapture = false
@@ -109,7 +110,15 @@ class TabOverflow extends Plugin {
     }
 
     /**
-     * Owner-mounted lifecycle hook: wire the resize listener and run the first (width-capturing) pass.
+     * Owner-mounted lifecycle hook: wire the resize + activation listeners and run the first
+     * (width-capturing) pass.
+     *
+     * Tab-set-change recapture is intentionally NOT an in-instance listener here: the dock rebuilds its tab
+     * header declaratively — `DockLayoutAdapter.projectTabsNode` hands a fresh `headerToolbar` config carrying
+     * this plugin on every tab-set change — so a NEW plugin instance re-measures via this same `project(true)`
+     * on its own mount. (There is no clean tab-add/remove event to listen to: `tab.Container.insert/removeAt`
+     * fire none.) The sticky `queuedRecapture` then only has to coalesce a mount-time `project(true)` that
+     * overlaps an in-flight resize/activation pass.
      * @override
      */
     onOwnerMounted() {
@@ -193,11 +202,15 @@ class TabOverflow extends Plugin {
                 });
 
             me.applySplit(hidden, buttons, tabContainer)
-        } catch {
-            // A measure is best-effort: getDomRect can lose a race with teardown, and a failed pass must
-            // neither reject a fire-and-forget resize/activation handler nor skip the queued-re-run drain
-            // below (re-throwing would strand `projectQueued`). The next event re-projects against a live
-            // owner; a genuine defect surfaces as a missing split in the example / e2e, not a frozen header.
+        } catch (error) {
+            // getDomRect losing a race with teardown (owner unmounting mid-measure) is the ONE expected
+            // failure: it must neither reject a fire-and-forget handler nor skip the drain below, and the
+            // finally-released latch lets the NEXT event re-project (rejected→success self-heal). But a throw
+            // against a LIVE owner is a programming defect — surface it rather than swallow it silently (a
+            // blanket catch would hide real bugs behind a "just a teardown race" assumption).
+            if (owner.mounted) {
+                console.error('Neo.dashboard.plugin.TabOverflow: project() threw against a live owner', error)
+            }
         } finally {
             // ALWAYS release the latch: a thrown getDomRect / applySplit must not strand `measuring` at
             // true, which would silently freeze every future projection (the header stops responding).
@@ -290,6 +303,11 @@ class TabOverflow extends Plugin {
             // suspended requestAnimationFrame in an offscreen / hidden document.
             me.control = Neo.create({
                 module       : Button,
+                // Align to the owner toolbar's right edge — the reserved overflow slot (the pure core keeps
+                // `controlWidth` free there when anything overflows). Without an `align.target` a floating
+                // component stays at its off-screen default (`left/top: -10000px`): it renders but is not
+                // visible/clickable. `r0-r0` puts the control's right edge at the toolbar's right edge.
+                align        : {edgeAlign: 'r0-r0', target: me.owner.id},
                 appName      : me.owner.appName,
                 autoInitVnode: true,
                 autoMount    : true,

--- a/src/dashboard/plugin/TabOverflow.mjs
+++ b/src/dashboard/plugin/TabOverflow.mjs
@@ -1,3 +1,4 @@
+import Button from '../../button/Base.mjs';
 import Plugin from '../../plugin/Base.mjs';
 
 /**
@@ -11,13 +12,14 @@ import Plugin from '../../plugin/Base.mjs';
  * constraint). `items` order and `activeItemId` already capture the state; overflow is projection only.
  *
  * It attaches to the projected tab header toolbar (`Neo.tab.header.Toolbar`) — it is NOT a dock-specific
- * `tab.Container` fork (the model contract's Split/Tab Adapter Boundary). The overflow control lives as a
- * trailing item of that header toolbar, excluded from `getTabButtons()` by identity so it is never
- * measured, hidden, or counted as a tab. A trailing non-tab item would corrupt `tab.Container`'s
- * interactive insertion index (`getTabBar().items.length`) in the general case — but the dock projects its
- * tabs declaratively (`DockLayoutAdapter` hands a full `items` config and rebuilds on every tab-set change)
- * and never calls `tab.Container.add()`, so that path is never taken. The control also carries none of a
- * tab button's `activeIndex` click wiring (that lives in `getTabButtonConfig`, which the plugin bypasses),
+ * `tab.Container` fork (the model contract's Split/Tab Adapter Boundary). The overflow control is an
+ * OUT-OF-COLLECTION floating button rooted at `document.body`, deliberately NOT a member of `owner.items`:
+ * the dock enables `dragResortable` (`DockLayoutAdapter`), so the header toolbar wires a SortZone that marks
+ * every `owner.items` entry draggable and commits reorders via the `moveTo` the container fires on drop. A
+ * trailing control inside `owner.items` would therefore be drag-reorderable and would corrupt the committed
+ * dock tab order. Keeping the control floating (out of the collection) preserves the collection invariant —
+ * `owner.items` stays exactly the real tabs, so the SortZone never sees it. The control also carries none of
+ * a tab button's `activeIndex` click wiring (that lives in `getTabButtonConfig`, which the plugin bypasses),
  * so selecting it opens its menu rather than activating a phantom card.
  *
  * Natural-width discipline: overflowing buttons are removed from the DOM (Neo's built-in `hidden` /
@@ -248,10 +250,9 @@ class TabOverflow extends Plugin {
      * left in the menu.
      *
      * The control is a `button.Base` with a `menu` config — button.Base builds the dropdown `menu.List`
-     * itself, so no menu is hand-assembled here. It is added as a trailing item of the header toolbar
-     * (which renders its own items), and excluded from `getTabButtons()` by identity so it is never
-     * measured or hidden as a tab — see the class note on why a trailing non-tab item is safe in the dock
-     * projection.
+     * itself, so no menu is hand-assembled here. It is a floating instance rooted at `document.body` (out
+     * of `owner.items`), and excluded from `getTabButtons()` by identity so it is never measured or hidden
+     * as a tab — see the class note on why the control must stay out of the SortZone-draggable collection.
      * @param {Object[]} hiddenMeta  `{text, iconCls, index}` per hidden tab, in header order.
      * @param {Neo.tab.Container} tabContainer
      */
@@ -260,7 +261,7 @@ class TabOverflow extends Plugin {
 
         if (hiddenMeta.length < 1) {
             if (me.control) {
-                me.owner.remove(me.control, true);
+                me.control.destroy(true);
                 me.control = null
             }
             return
@@ -275,19 +276,30 @@ class TabOverflow extends Plugin {
         if (me.control) {
             me.control.menu = menuItems
         } else {
-            // Added as a trailing toolbar item so it actually renders — the header toolbar renders its own
-            // items, whereas a standalone floating instance never mounted (two prior attempts). Excluded
-            // from getTabButtons() by identity, so it is never measured or hidden as a tab. Safe in the dock
-            // projection: tabs come from the projected config (not `tab.Container.add`), and `activeIndex`
-            // only ranges over the real tabs, so a trailing non-tab item never perturbs the index mapping.
-            let added = me.owner.add({
-                cls    : ['neo-dock-tab-overflow-control'],
-                iconCls: 'fa fa-ellipsis',
-                menu   : menuItems,
-                ntype  : 'button'
-            });
-
-            me.control = Array.isArray(added) ? added[added.length - 1] : added
+            // OUT-OF-COLLECTION mount: a floating button rooted directly at document.body, NOT a trailing
+            // toolbar item. The dock sets `dragResortable: true` (DockLayoutAdapter), so the header toolbar
+            // wires a SortZone that marks EVERY `owner.items` entry draggable — a trailing control there
+            // would be drag-reorderable and would corrupt the committed dock tab order via the `moveTo` the
+            // container fires on drop. Keeping the control OUT of `owner.items` preserves the collection
+            // invariant (`owner.items` === exactly the real tabs) so the SortZone never sees it.
+            //
+            // `Neo.create` with `floating:true` + `parentId:'document.body'` roots at document.body directly
+            // (verified: `Container.createItem` is the only path that injects `parentId=owner.id`, and we
+            // bypass it). The parentless `initVnode(true)` autoMount reaches the DOM via the merged
+            // hidden-document render-queue drain — before it, the insertNode reply parked behind a
+            // suspended requestAnimationFrame in an offscreen / hidden document.
+            me.control = Neo.create({
+                module       : Button,
+                appName      : me.owner.appName,
+                autoInitVnode: true,
+                autoMount    : true,
+                cls          : ['neo-dock-tab-overflow-control'],
+                floating     : true,
+                iconCls      : 'fa fa-ellipsis',
+                menu         : menuItems,
+                parentId     : 'document.body',
+                windowId     : me.owner.windowId
+            })
         }
     }
 

--- a/src/dashboard/plugin/TabOverflow.mjs
+++ b/src/dashboard/plugin/TabOverflow.mjs
@@ -319,14 +319,6 @@ class TabOverflow extends Plugin {
                 windowId     : me.owner.windowId
             })
         }
-
-        // Re-align against the CURRENT owner rect: a floating component aligns once at mount and does not
-        // re-align when its target moves, so if the control mounts before the dock translates the toolbar
-        // into its settled slot it stays pinned to a stale rect. Re-aligning on each sync — once the control
-        // is mounted — repositions it on the resize/activation/tab-set passes that follow. Cheap and
-        // idempotent. (The purely-static initial case, where NO follow-up pass fires, may still need a
-        // settle-trigger; tracked with the reviewer's fresh-port geometry evidence.)
-        me.control?.mounted && me.control.alignTo()
     }
 
     /**

--- a/src/dashboard/plugin/TabOverflow.mjs
+++ b/src/dashboard/plugin/TabOverflow.mjs
@@ -187,10 +187,10 @@ class TabOverflow extends Plugin {
      * surfaces the now-active tab by construction (active-never-hidden), so the selected tab is never
      * left in the menu.
      *
-     * NOTE (live-verification point): the control is a `button.Base` with a `menu` config — button.Base
-     * builds the dropdown `menu.List` itself, so no menu is hand-assembled here. How the control mounts
-     * into the header DOM without joining the toolbar's item collection is finalized against the running
-     * `examples/dashboard/dock` surface (Neo overlay-mount pattern), not guessed.
+     * The control is a `button.Base` with a `menu` config — button.Base builds the dropdown `menu.List`
+     * itself, so no menu is hand-assembled here. It mounts as a `floating` component self-positioned via
+     * `align` against the header toolbar (the same mechanism `button.Base#afterSetMenu` uses for its own
+     * menu), which keeps it out of the toolbar's item collection so tab insertion stays correct.
      * @param {Object[]} hiddenMeta  `{text, iconCls, index}` per hidden tab, in header order.
      * @param {Neo.tab.Container} tabContainer
      */
@@ -213,11 +213,19 @@ class TabOverflow extends Plugin {
             me.control.menu = menuItems
         } else {
             me.control = Neo.create({
-                module  : Button,
-                cls     : ['neo-dock-tab-overflow-control'],
-                iconCls : 'fa fa-ellipsis',
-                menu    : menuItems,
-                parentId: me.owner.id
+                // Floating-component mount, per button.Base#afterSetMenu: a plain `parentId` never
+                // renders — a floating component mounts and self-positions via `align` against a target.
+                // Anchored to the header toolbar's trailing top-right, sitting in the `controlWidth` gap
+                // the pure core reserves; stays out of the toolbar's item collection (tab-insertion safe).
+                module         : Button,
+                align          : {edgeAlign: 'tr-tr', target: me.owner.id},
+                appName        : me.owner.appName,
+                cls            : ['neo-dock-tab-overflow-control'],
+                floating       : true,
+                iconCls        : 'fa fa-ellipsis',
+                menu           : menuItems,
+                parentComponent: me.owner,
+                windowId       : me.owner.windowId
             })
         }
     }

--- a/src/dashboard/plugin/TabOverflow.mjs
+++ b/src/dashboard/plugin/TabOverflow.mjs
@@ -216,20 +216,25 @@ class TabOverflow extends Plugin {
             me.control.menu = menuItems
         } else {
             me.control = Neo.create({
-                // Floating-component mount, per button.Base#afterSetMenu: a plain `parentId` never
-                // renders — a floating component mounts and self-positions via `align` against a target.
-                // Anchored to the header toolbar's trailing top-right, sitting in the `controlWidth` gap
-                // the pure core reserves; stays out of the toolbar's item collection (tab-insertion safe).
+                // Floating component (per button.Base#afterSetMenu): mounts and self-positions via `align`
+                // against a target — a plain `parentId` never renders. Anchored to the header toolbar's
+                // trailing top-right, in the `controlWidth` gap the pure core reserves; stays out of the
+                // toolbar's item collection (tab-insertion safe). Created `hidden`, then revealed below —
+                // Neo mounts a floating component on the hidden→false transition (the menu's show path,
+                // button.Base#toggleMenu), so one created already-visible never triggers the mount.
                 module         : Button,
                 align          : {edgeAlign: 'tr-tr', target: me.owner.id},
                 appName        : me.owner.appName,
                 cls            : ['neo-dock-tab-overflow-control'],
                 floating       : true,
+                hidden         : true,
                 iconCls        : 'fa fa-ellipsis',
                 menu           : menuItems,
                 parentComponent: me.owner,
                 windowId       : me.owner.windowId
-            })
+            });
+
+            me.control.hidden = false
         }
     }
 

--- a/src/dashboard/plugin/TabOverflow.mjs
+++ b/src/dashboard/plugin/TabOverflow.mjs
@@ -319,6 +319,14 @@ class TabOverflow extends Plugin {
                 windowId     : me.owner.windowId
             })
         }
+
+        // Re-align against the CURRENT owner rect: a floating component aligns once at mount and does not
+        // re-align when its target moves, so if the control mounts before the dock translates the toolbar
+        // into its settled slot it stays pinned to a stale rect. Re-aligning on each sync — once the control
+        // is mounted — repositions it on the resize/activation/tab-set passes that follow. Cheap and
+        // idempotent. (The purely-static initial case, where NO follow-up pass fires, may still need a
+        // settle-trigger; tracked with the reviewer's fresh-port geometry evidence.)
+        me.control?.mounted && me.control.alignTo()
     }
 
     /**

--- a/src/dashboard/plugin/TabOverflow.mjs
+++ b/src/dashboard/plugin/TabOverflow.mjs
@@ -1,0 +1,236 @@
+import Button from '../../button/Base.mjs';
+import Plugin from '../../plugin/Base.mjs';
+
+/**
+ * @summary The runtime half of the dock tab-overflow affordance for projected dock tab headers.
+ *
+ * The pure decision lives in {@link Neo.dashboard.DockLayoutAdapter.computeTabOverflow} — a projection
+ * concern, nothing persists. This plugin is the RUNTIME complement: it measures the live header extents
+ * the pure core can only be handed, applies its verdict to the header buttons, and surfaces the hidden
+ * remainder through a single overflow control whose selection routes back through the tab.Container's
+ * EXISTING `activeIndex` path — zero new operations, zero new persisted state (the binding projection
+ * constraint). `items` order and `activeItemId` already capture the state; overflow is projection only.
+ *
+ * It attaches to the projected tab header toolbar (`Neo.tab.header.Toolbar`) — it is NOT a dock-specific
+ * `tab.Container` fork (the model contract's Split/Tab Adapter Boundary). The overflow control is kept
+ * OUT of the toolbar's item collection on purpose: `tab.Container` uses `getTabBar().items.length` as its
+ * tab-insertion index (Container.mjs), so a control living among the tab buttons would corrupt insertion.
+ *
+ * Natural-width discipline: overflowing buttons hide via a `display:none` cls, so re-measuring them would
+ * collapse their width to 0 and corrupt the next split. The plugin therefore measures NATURAL widths once
+ * while every button is visible (on mount, and whenever the tab set changes) and caches them; a plain
+ * resize only re-reads the always-visible strip extent and recomputes against that cache.
+ *
+ * @class Neo.dashboard.plugin.TabOverflow
+ * @extends Neo.plugin.Base
+ */
+class TabOverflow extends Plugin {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.plugin.TabOverflow'
+         * @protected
+         */
+        className: 'Neo.dashboard.plugin.TabOverflow',
+        /**
+         * @member {String} ntype='plugin-dock-tab-overflow'
+         * @protected
+         */
+        ntype: 'plugin-dock-tab-overflow',
+        /**
+         * Width (px) the overflow control reserves from the header extent — handed to the pure core as
+         * `controlWidth`, which reserves it ONLY when something overflows (a control that exists only when
+         * needed must not consume width while everything fits).
+         * @member {Number} controlWidth=40
+         */
+        controlWidth: 40
+    }
+
+    /**
+     * The overflow control (a menu button), created on first overflow and torn down when everything fits.
+     * @member {Neo.button.Base|null} control=null
+     */
+    control = null
+    /**
+     * Re-entrancy guard: `getDomRect` is an async main-thread round-trip, so a resize storm could overlap
+     * measure passes and apply a stale split last.
+     * @member {Boolean} measuring=false
+     */
+    measuring = false
+    /**
+     * Natural (un-hidden) header widths keyed by tab-button id — see the class note on natural-width
+     * discipline. `null` until the first capture.
+     * @member {Object|null} naturalWidths=null
+     */
+    naturalWidths = null
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+        this.onResize = this.onResize.bind(this)
+    }
+
+    /**
+     * The tab.Container whose `activeIndex` an overflow-menu selection drives (the ordinary activation
+     * path — no new operation). The header toolbar (`owner`) is its primary child.
+     * @returns {Neo.tab.Container}
+     */
+    getTabContainer() {
+        return this.owner.parent
+    }
+
+    /**
+     * The header buttons that participate in overflow: the toolbar's items (the control is never among
+     * them — see the class note).
+     * @returns {Neo.tab.header.Button[]}
+     */
+    getTabButtons() {
+        return this.owner.items || []
+    }
+
+    /**
+     * Owner-mounted lifecycle hook: wire the resize listener and run the first (width-capturing) pass.
+     * @override
+     */
+    onOwnerMounted() {
+        let me      = this,
+            {owner} = me;
+
+        owner.addDomListeners([{resize: me.onResize, scope: me}]);
+        me.project(true)
+    }
+
+    /**
+     * Resize handler — an extent-only change, so recompute against the cached natural widths.
+     * @param {Object} data
+     */
+    onResize(data) {
+        this.project(false)
+    }
+
+    /**
+     * Measures (natural widths as needed, strip extent always) and applies the visible/hidden split.
+     * @param {Boolean} recapture  Re-read natural widths (mount, or the tab set changed).
+     */
+    async project(recapture) {
+        let me      = this,
+            {owner} = me,
+            buttons = me.getTabButtons();
+
+        if (me.measuring || !owner.mounted || buttons.length < 1) {
+            return
+        }
+
+        me.measuring = true;
+
+        // 1. Natural widths — measured once while every button is visible, then cached.
+        if (recapture || !me.naturalWidths) {
+            let rects = await owner.getDomRect(buttons.map(button => button.id));
+
+            me.naturalWidths = {};
+            buttons.forEach((button, index) => {
+                me.naturalWidths[button.id] = Math.ceil(rects[index]?.width || 0)
+            })
+        }
+
+        // 2. The strip extent — the toolbar itself never hides, so it is always measurable.
+        let extentRect   = await owner.getDomRect(),
+            extent       = Math.floor(extentRect?.width || 0),
+            tabContainer = me.getTabContainer(),
+            activeButton = buttons[tabContainer?.activeIndex] || null,
+            items        = buttons.map(button => ({id: button.id, headerWidth: me.naturalWidths[button.id]})),
+
+            // 3. The pure decision: active-never-hidden packing, overflow-only control reservation.
+            //    Referenced via the Neo namespace (not imported) to keep the adapter→plugin dependency
+            //    one-directional — the adapter imports this plugin for the projection, so importing the
+            //    adapter back would be a cycle.
+            {hidden} = Neo.dashboard.DockLayoutAdapter.computeTabOverflow({
+                activeItemId: activeButton?.id,
+                controlWidth: me.controlWidth,
+                extent,
+                items
+            });
+
+        me.applySplit(hidden, buttons, tabContainer);
+        me.measuring = false
+    }
+
+    /**
+     * Applies the computed hidden set: hides the overflowing header buttons and reflects the remainder
+     * through the overflow control.
+     * @param {String[]} hidden  Overflowing button ids, in header order.
+     * @param {Neo.tab.header.Button[]} buttons
+     * @param {Neo.tab.Container} tabContainer
+     */
+    applySplit(hidden, buttons, tabContainer) {
+        let me         = this,
+            hiddenSet  = new Set(hidden),
+            hiddenMeta = [];
+
+        buttons.forEach((button, index) => {
+            let isHidden = hiddenSet.has(button.id);
+
+            button[isHidden ? 'addCls' : 'removeCls']('neo-dock-tab-hidden');
+
+            if (isHidden) {
+                hiddenMeta.push({iconCls: button.iconCls, index, text: button.text})
+            }
+        });
+
+        me.syncControl(hiddenMeta, tabContainer)
+    }
+
+    /**
+     * Creates / updates / tears down the single overflow control. A menu selection sets the
+     * tab.Container's `activeIndex` (the ordinary activation path); the follow-up measure pass then
+     * surfaces the now-active tab by construction (active-never-hidden), so the selected tab is never
+     * left in the menu.
+     *
+     * NOTE (live-verification point): the control is a `button.Base` with a `menu` config — button.Base
+     * builds the dropdown `menu.List` itself, so no menu is hand-assembled here. How the control mounts
+     * into the header DOM without joining the toolbar's item collection is finalized against the running
+     * `examples/dashboard/dock` surface (Neo overlay-mount pattern), not guessed.
+     * @param {Object[]} hiddenMeta  `{text, iconCls, index}` per hidden tab, in header order.
+     * @param {Neo.tab.Container} tabContainer
+     */
+    syncControl(hiddenMeta, tabContainer) {
+        let me = this;
+
+        if (hiddenMeta.length < 1) {
+            me.control?.destroy(true);
+            me.control = null;
+            return
+        }
+
+        let menuItems = hiddenMeta.map(meta => ({
+            handler: () => {tabContainer.activeIndex = meta.index},
+            iconCls: meta.iconCls,
+            text   : meta.text
+        }));
+
+        if (me.control) {
+            me.control.menu = menuItems
+        } else {
+            me.control = Neo.create({
+                module  : Button,
+                cls     : ['neo-dock-tab-overflow-control'],
+                iconCls : 'fa fa-ellipsis',
+                menu    : menuItems,
+                parentId: me.owner.id
+            })
+        }
+    }
+
+    /**
+     * @param {...*} args
+     * @override
+     */
+    destroy(...args) {
+        this.control?.destroy(true);
+        this.control = null;
+        super.destroy(...args)
+    }
+}
+
+export default Neo.setupClass(TabOverflow);

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -140,8 +140,10 @@ class DomAccess extends Base {
 
         // Set up listeners which monitor for changes
         if (!aligns.has(id)) {
-            // Realign when target's layout-controlling element changes size
-            resizeObserver.observe(alignSpec.offsetParent);
+            // Realign when target's layout-controlling element changes size. A fixed-positioned aligned
+            // element has NO offsetParent (it is positioned against the viewport), so guard against observing
+            // null — `ResizeObserver.observe(null)` throws "parameter 1 is not of type 'Element'".
+            alignSpec.offsetParent && resizeObserver.observe(alignSpec.offsetParent);
 
             // Realign when align to target changes size
             resizeObserver.observe(alignSpec.targetElement);
@@ -246,9 +248,9 @@ class DomAccess extends Base {
             result = data.result = myRect.alignTo(align);
 
         Object.assign(style, {
-            top : 0,
-            left: 0,
-            transform : `translate(${result.x}px,${result.y}px)`
+            top      : 0,
+            left     : 0,
+            transform: `translate(${result.x}px,${result.y}px)`
         });
 
         if (result.width !== myRect.width) {
@@ -752,8 +754,8 @@ class DomAccess extends Base {
      * @param {String} data.nodeId
      */
     getOffscreenCanvas(data) {
-        let me        = this,
-            node      = me.getElement(data.nodeId),
+        let me   = this,
+            node = me.getElement(data.nodeId),
             offscreen;
 
         if (!node) {
@@ -1064,10 +1066,10 @@ class DomAccess extends Base {
      */
     syncAligns(arg1) {
         const
-            me          = this,
-            {_aligns}   = me,
-            isScroll    = arg1?.type === 'scroll',
-            evtTarget   = isScroll ? arg1.target : null,
+            me        = this,
+            {_aligns} = me,
+            isScroll  = arg1?.type === 'scroll',
+            evtTarget = isScroll ? arg1.target : null,
             // Document scroll (window) target is document.
             isDocScroll = isScroll && (evtTarget === document || evtTarget === document.documentElement);
 
@@ -1101,9 +1103,10 @@ class DomAccess extends Base {
                     {_alignResizeObserver} = me,
                     {constrainToElement}   = align;
 
-                // Stop observing the align elements
+                // Stop observing the align elements (offsetParent is null for a fixed-positioned subject —
+                // it was never observed, and unobserve(null) throws just like observe(null)).
                 _alignResizeObserver.unobserve(align.subject);
-                _alignResizeObserver.unobserve(align.offsetParent);
+                align.offsetParent && _alignResizeObserver.unobserve(align.offsetParent);
                 _alignResizeObserver.unobserve(align.targetElement);
                 if (constrainToElement) {
                     _alignResizeObserver.unobserve(constrainToElement)

--- a/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
@@ -1,16 +1,18 @@
 import { test, expect } from '../../fixtures.mjs';
 
 /**
- * Out-of-collection floating dock tab-overflow control (Neural Link).
+ * Out-of-collection floating dock tab-overflow control.
  *
  * At a narrow viewport the heavy `main-tabs` node overflows; the runtime {@link Neo.dashboard.plugin.TabOverflow}
  * plugin creates a single overflow control (a `button.Base` with a `menu`) and mounts it as a `floating`
  * component to `document.body` — OUT of the header toolbar's item collection, so `owner.items` stays exactly
- * the real tabs (the model contract's collection invariant).
+ * the real tabs (the collection invariant; a trailing toolbar item would be SortZone-draggable and corrupt
+ * the committed dock tab order). The parentless `initVnode(true)` autoMount reaches the DOM via the merged
+ * hidden-document render-queue drain.
  *
- * This witness asserts the parentless `initVnode(true)` autoMount actually reaches the DOM — it relies on the
- * merged hidden-document render-queue drain (a parentless auto-mount no longer parks behind a suspended
- * `requestAnimationFrame` in a hidden / offscreen document).
+ * Asserted against the page's OWN DOM — deliberately NOT via the neuralLink bridge, whose `connectToApp`
+ * appName-fallback can latch a long-lived stale resident and read the wrong app. The page DOM is the ground
+ * truth for "did it render".
  *
  * Run: NEO_E2E_PORT=8094 npx playwright test dashboard/DockTabOverflowNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
@@ -18,50 +20,28 @@ test.describe('#14771 dock tab-overflow floating control', () => {
     test.setTimeout(120000);
     test.use({ viewport: { width: 600, height: 800 } });
 
-    test('the out-of-collection floating overflow control mounts on main-tabs overflow', async ({ page, neuralLink }) => {
-        await page.goto('/examples/dashboard/dock/');
+    test('the floating overflow control renders at document.body and its menu surfaces the hidden tabs', async ({ page }) => {
         page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+        await page.goto('/examples/dashboard/dock/');
 
-        const app = await neuralLink.connectToApp('Neo.examples.dashboard.dock');
+        // At 600px the 7 main-tabs overflow → the plugin mounts the floating overflow control at
+        // document.body. Poll (the mount settles a beat after the app boots + measures the header extents).
+        const control = page.locator('.neo-dock-tab-overflow-control');
+        await expect(control).toHaveCount(1, { timeout: 45000 });
 
-        // The 7 main-tabs overflow at 600px → the plugin eagerly mounts the floating overflow control to
-        // document.body. The parentless autoMount only settles because the hidden-document render queue drains.
-        let control = null;
+        // Out-of-collection invariant: a FLOATING direct child of document.body, NOT a nested item of the
+        // header toolbar — so `owner.items` stays exactly the real tabs.
+        const parentIsBody = await page.evaluate(() =>
+            document.querySelector('.neo-dock-tab-overflow-control')?.parentElement === document.body);
+        expect(parentIsBody, 'the overflow control must be a direct floating child of document.body').toBe(true);
 
-        await expect.poll(async () => {
-            const found = await app.findInstances(
-                    { className: 'Neo.dashboard.plugin.TabOverflow' },
-                    ['control.mounted', 'control.id', 'control.parentId', 'control.floating', 'control.autoMount']
-                ),
-                  inst = Array.isArray(found) ? found[0] : found;
+        // It carries the ellipsis affordance.
+        await expect(control.locator('.fa-ellipsis')).toHaveCount(1);
 
-            control = inst?.properties ?? null;
-
-            return control?.['control.mounted'] === true ? 'mounted' : 'pending';
-        }, { message: 'the parentless floating overflow control must mount', timeout: 30000, intervals: [500] }).toBe('mounted');
-
-        console.log('CTRL_DEBUG ' + JSON.stringify(control));
-        const domDebug = await page.evaluate((id) => ({
-            hidden      : document.hidden,
-            byId        : id ? (document.getElementById(id) ? 1 : 0) : 'no-id',
-            overflowCls : document.querySelectorAll('.neo-dock-tab-overflow-control').length,
-            ellipsis    : document.querySelectorAll('.fa-ellipsis').length,
-            bodyChildren: document.body.children.length
-        }), control?.['control.id']);
-        console.log('DOM_DEBUG ' + JSON.stringify(domDebug));
-
-        // Stale-bundle guard (per Euclid's runtime trace): a reused webpack dev-server can serve the
-        // committed toolbar-item HEAD (owner.add → floating=false) instead of this floating syncControl,
-        // which then reads as a false "runtime re-parent" (parentId=owner.id). Assert the floating module
-        // actually loaded BEFORE the DOM checks, so a stale bundle fails LOUDLY here rather than masquerading.
-        expect(control['control.floating'], 'stale bundle: loaded the toolbar-item HEAD (floating=false), not the floating syncControl — kill the reused :8094 webpack server and re-run').toBe(true);
-
-        // Out-of-collection invariant: it is mounted DIRECTLY to document.body (a floating child), NOT as a
-        // trailing header-toolbar item — so owner.items stays exactly the real tabs (a toolbar item would
-        // corrupt tab.Container's items.length insertion index and be SortZone-draggable).
-        expect(control['control.parentId']).toBe('document.body');
-
-        // And the control instance reached the real DOM (query by its own id — robust vs class transforms).
-        await expect(page.locator(`#${control['control.id']}`)).toHaveCount(1)
+        // Interaction journey: clicking the control opens its dropdown menu, which lists the hidden tabs
+        // (button.Base builds the menu.List itself). At least one hidden-tab entry must be selectable.
+        await control.click();
+        const menuItem = page.locator('.neo-list-item, .neo-menu-item').filter({ hasText: /\S/ });
+        await expect(menuItem.first()).toBeVisible({ timeout: 10000 });
     })
 });

--- a/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
@@ -12,7 +12,7 @@ import { test, expect } from '../../fixtures.mjs';
  *
  * Asserted against the page's OWN DOM — deliberately NOT via the neuralLink bridge, whose `connectToApp`
  * appName-fallback can latch a long-lived stale resident and read the wrong app. The page DOM is the ground
- * truth for "did it render".
+ * truth for "did it render". Journey core contributed by @neo-gpt's fresh-port review probe.
  *
  * Run: NEO_E2E_PORT=8094 npx playwright test dashboard/DockTabOverflowNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
@@ -20,17 +20,16 @@ test.describe('#14771 dock tab-overflow floating control', () => {
     test.setTimeout(120000);
     test.use({ viewport: { width: 600, height: 800 } });
 
-    test('the floating overflow control renders at document.body and its menu surfaces the hidden tabs', async ({ page }) => {
-        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+    test('the floating overflow control renders at document.body, aligns to its owner toolbar, and its menu surfaces + activates the hidden tabs', async ({ page }) => {
+        const pageErrors = [];
+        page.on('pageerror', err => { pageErrors.push(err.message); console.error('BROWSER JS ERROR:', err) });
         await page.goto('/examples/dashboard/dock/');
 
-        // At 600px the 7 main-tabs overflow → the plugin mounts the floating overflow control at
-        // document.body. Poll (the mount settles a beat after the app boots + measures the header extents).
         const control = page.locator('.neo-dock-tab-overflow-control');
         await expect(control).toHaveCount(1, { timeout: 45000 });
 
-        // Out-of-collection invariant: a FLOATING direct child of document.body, NOT a nested item of the
-        // header toolbar — so `owner.items` stays exactly the real tabs.
+        // Out-of-collection invariant: a FLOATING direct child of document.body, NOT a nested header-toolbar
+        // item — so `owner.items` stays exactly the real tabs (a toolbar item would be SortZone-draggable).
         const parentIsBody = await page.evaluate(() =>
             document.querySelector('.neo-dock-tab-overflow-control')?.parentElement === document.body);
         expect(parentIsBody, 'the overflow control must be a direct floating child of document.body').toBe(true);
@@ -38,29 +37,39 @@ test.describe('#14771 dock tab-overflow floating control', () => {
         // It carries the ellipsis affordance.
         await expect(control.locator('.fa-ellipsis')).toHaveCount(1);
 
-        // Owner-relative geometry: the control must sit within a tab-header toolbar's vertical band (aligned
-        // to its owner's right-edge slot), NOT off at a stale pre-settle position. (A prior cycle mounted it
-        // clickable but at y≈310 while the toolbars sit at y≈64..202 — rendered but wrong-owner geometry.)
-        const geom = await page.evaluate(() => {
-            const ctrl     = document.querySelector('.neo-dock-tab-overflow-control'),
-                  toolbars = [...document.querySelectorAll('.neo-tab-header-toolbar')];
-            if (!ctrl || !toolbars.length) return null;
-            const c = ctrl.getBoundingClientRect();
-            return {
-                top    : c.top,
-                bandTop: Math.min(...toolbars.map(t => t.getBoundingClientRect().top)),
-                bandBot: Math.max(...toolbars.map(t => t.getBoundingClientRect().bottom))
-            }
-        });
-        expect(geom, 'control + at least one tab-header toolbar must be in the DOM').not.toBeNull();
-        expect(geom.top, `control top ${geom?.top} must sit inside the toolbar band [${geom?.bandTop}, ${geom?.bandBot}]`)
-            .toBeGreaterThanOrEqual(geom.bandTop - 4);
-        expect(geom.top).toBeLessThanOrEqual(geom.bandBot + 4);
+        // Owner-EXACT geometry: the control's right edge + top align (within 2px) to its owner toolbar — the
+        // one carrying 'Strategy' — NOT a stale pre-settle position. This requires the
+        // `.neo-button.neo-floating { position: fixed }` cascade fix; without it the control is pinned to its
+        // offsetParent instead of the viewport and lands at the wrong coordinates.
+        const mainToolbar = page.locator('.neo-tab-header-toolbar').filter({ hasText: 'Strategy' }).first(),
+              controlBox  = await control.boundingBox(),
+              toolbarBox  = await mainToolbar.boundingBox();
+        expect(Math.abs((controlBox.x + controlBox.width) - (toolbarBox.x + toolbarBox.width)),
+            'control right edge aligns to the toolbar right edge').toBeLessThanOrEqual(2);
+        expect(Math.abs(controlBox.y - toolbarBox.y), 'control top aligns to the toolbar top').toBeLessThanOrEqual(2);
 
-        // Interaction journey: clicking the control opens its dropdown menu, which lists the hidden tabs
-        // (button.Base builds the menu.List itself). At least one hidden-tab entry must be selectable.
+        // Clicking the control opens its dropdown menu of hidden tabs.
         await control.click();
-        const menuItem = page.locator('.neo-list-item, .neo-menu-item').filter({ hasText: /\S/ });
-        await expect(menuItem.first()).toBeVisible({ timeout: 10000 });
+        const menuItems = page.locator('.neo-menu-list:visible .neo-list-item').filter({ hasText: /\S/ });
+        await expect(menuItems.first()).toBeVisible({ timeout: 10000 });
+
+        // Partition: the visible headers + the hidden (menu) headers together are the full tab set — nothing
+        // is lost or duplicated across the visible/hidden split.
+        const normalize      = values => values.map(value => value.trim()).filter(Boolean),
+              visibleHeaders = normalize(await page.locator('.neo-tab-header-button:visible').allTextContents()),
+              hiddenHeaders  = normalize(await menuItems.allTextContents());
+        expect([...visibleHeaders, ...hiddenHeaders].sort()).toEqual(
+            ['Agents', 'Alerts', 'History', 'Inspector', 'Logs', 'Metrics', 'Strategy', 'Swarm', 'Terminal', 'Timeline'].sort());
+
+        // Selection: picking a hidden tab activates it and surfaces it into the header (pressed + visible),
+        // via the ordinary activeIndex path (active-never-hidden), so the picked tab is never left in the menu.
+        const selectedText = (await menuItems.first().innerText()).trim();
+        await menuItems.first().click();
+        await expect(page.locator('.neo-tab-header-button.pressed:visible').filter({ hasText: selectedText })).toHaveCount(1);
+
+        // No unexpected browser errors across the journey — notably, a fixed-positioned align must NOT trip
+        // `ResizeObserver.observe(null)` (offsetParent is null for `position: fixed`), which the DomAccess
+        // null-guard prevents.
+        expect(pageErrors, 'no unexpected page errors during the overflow journey').toEqual([])
     })
 });

--- a/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
@@ -1,0 +1,67 @@
+import { test, expect } from '../../fixtures.mjs';
+
+/**
+ * Out-of-collection floating dock tab-overflow control (Neural Link).
+ *
+ * At a narrow viewport the heavy `main-tabs` node overflows; the runtime {@link Neo.dashboard.plugin.TabOverflow}
+ * plugin creates a single overflow control (a `button.Base` with a `menu`) and mounts it as a `floating`
+ * component to `document.body` — OUT of the header toolbar's item collection, so `owner.items` stays exactly
+ * the real tabs (the model contract's collection invariant).
+ *
+ * This witness asserts the parentless `initVnode(true)` autoMount actually reaches the DOM — it relies on the
+ * merged hidden-document render-queue drain (a parentless auto-mount no longer parks behind a suspended
+ * `requestAnimationFrame` in a hidden / offscreen document).
+ *
+ * Run: NEO_E2E_PORT=8094 npx playwright test dashboard/DockTabOverflowNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('#14771 dock tab-overflow floating control', () => {
+    test.setTimeout(120000);
+    test.use({ viewport: { width: 600, height: 800 } });
+
+    test('the out-of-collection floating overflow control mounts on main-tabs overflow', async ({ page, neuralLink }) => {
+        await page.goto('/examples/dashboard/dock/');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        const app = await neuralLink.connectToApp('Neo.examples.dashboard.dock');
+
+        // The 7 main-tabs overflow at 600px → the plugin eagerly mounts the floating overflow control to
+        // document.body. The parentless autoMount only settles because the hidden-document render queue drains.
+        let control = null;
+
+        await expect.poll(async () => {
+            const found = await app.findInstances(
+                    { className: 'Neo.dashboard.plugin.TabOverflow' },
+                    ['control.mounted', 'control.id', 'control.parentId', 'control.floating', 'control.autoMount']
+                ),
+                  inst = Array.isArray(found) ? found[0] : found;
+
+            control = inst?.properties ?? null;
+
+            return control?.['control.mounted'] === true ? 'mounted' : 'pending';
+        }, { message: 'the parentless floating overflow control must mount', timeout: 30000, intervals: [500] }).toBe('mounted');
+
+        console.log('CTRL_DEBUG ' + JSON.stringify(control));
+        const domDebug = await page.evaluate((id) => ({
+            hidden      : document.hidden,
+            byId        : id ? (document.getElementById(id) ? 1 : 0) : 'no-id',
+            overflowCls : document.querySelectorAll('.neo-dock-tab-overflow-control').length,
+            ellipsis    : document.querySelectorAll('.fa-ellipsis').length,
+            bodyChildren: document.body.children.length
+        }), control?.['control.id']);
+        console.log('DOM_DEBUG ' + JSON.stringify(domDebug));
+
+        // Stale-bundle guard (per Euclid's runtime trace): a reused webpack dev-server can serve the
+        // committed toolbar-item HEAD (owner.add → floating=false) instead of this floating syncControl,
+        // which then reads as a false "runtime re-parent" (parentId=owner.id). Assert the floating module
+        // actually loaded BEFORE the DOM checks, so a stale bundle fails LOUDLY here rather than masquerading.
+        expect(control['control.floating'], 'stale bundle: loaded the toolbar-item HEAD (floating=false), not the floating syncControl — kill the reused :8094 webpack server and re-run').toBe(true);
+
+        // Out-of-collection invariant: it is mounted DIRECTLY to document.body (a floating child), NOT as a
+        // trailing header-toolbar item — so owner.items stays exactly the real tabs (a toolbar item would
+        // corrupt tab.Container's items.length insertion index and be SortZone-draggable).
+        expect(control['control.parentId']).toBe('document.body');
+
+        // And the control instance reached the real DOM (query by its own id — robust vs class transforms).
+        await expect(page.locator(`#${control['control.id']}`)).toHaveCount(1)
+    })
+});

--- a/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockTabOverflowNL.spec.mjs
@@ -38,6 +38,25 @@ test.describe('#14771 dock tab-overflow floating control', () => {
         // It carries the ellipsis affordance.
         await expect(control.locator('.fa-ellipsis')).toHaveCount(1);
 
+        // Owner-relative geometry: the control must sit within a tab-header toolbar's vertical band (aligned
+        // to its owner's right-edge slot), NOT off at a stale pre-settle position. (A prior cycle mounted it
+        // clickable but at y≈310 while the toolbars sit at y≈64..202 — rendered but wrong-owner geometry.)
+        const geom = await page.evaluate(() => {
+            const ctrl     = document.querySelector('.neo-dock-tab-overflow-control'),
+                  toolbars = [...document.querySelectorAll('.neo-tab-header-toolbar')];
+            if (!ctrl || !toolbars.length) return null;
+            const c = ctrl.getBoundingClientRect();
+            return {
+                top    : c.top,
+                bandTop: Math.min(...toolbars.map(t => t.getBoundingClientRect().top)),
+                bandBot: Math.max(...toolbars.map(t => t.getBoundingClientRect().bottom))
+            }
+        });
+        expect(geom, 'control + at least one tab-header toolbar must be in the DOM').not.toBeNull();
+        expect(geom.top, `control top ${geom?.top} must sit inside the toolbar band [${geom?.bandTop}, ${geom?.bandBot}]`)
+            .toBeGreaterThanOrEqual(geom.bandTop - 4);
+        expect(geom.top).toBeLessThanOrEqual(geom.bandBot + 4);
+
         // Interaction journey: clicking the control opens its dropdown menu, which lists the hidden tabs
         // (button.Base builds the menu.List itself). At least one hidden-tab entry must be selectable.
         await control.click();

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -549,4 +549,83 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
             {dockEdge: 'right', dockItemId: 'terminal', restorable: false, title: 'Terminal'}
         ]);
     });
+
+    test.describe('computeTabOverflow — the pure overflow core (projection concern, zero model state)', () => {
+        const items = widths => Object.entries(widths).map(([id, headerWidth]) => ({id, headerWidth}));
+
+        test('everything fits: empty hidden set, control width NOT reserved', () => {
+            const result = DockLayoutAdapter.computeTabOverflow({
+                activeItemId: 'a',
+                controlWidth: 40,
+                extent      : 300,
+                items       : items({a: 100, b: 100, c: 100})
+            });
+
+            // Σwidths === extent exactly — the control must not push anything out
+            expect(result).toEqual({hidden: [], visible: ['a', 'b', 'c']})
+        });
+
+        test('overflow: control width reserved, in-order packing, remainder hidden in items order', () => {
+            const result = DockLayoutAdapter.computeTabOverflow({
+                activeItemId: 'a',
+                controlWidth: 40,
+                extent      : 300,
+                items       : items({a: 100, b: 100, c: 100, d: 100})
+            });
+
+            // usable = 260 → a + b fit, c and d overflow in order
+            expect(result).toEqual({hidden: ['c', 'd'], visible: ['a', 'b']})
+        });
+
+        test('the ACTIVE item is never hidden: it swaps in, the last-fitting non-active item overflows', () => {
+            const result = DockLayoutAdapter.computeTabOverflow({
+                activeItemId: 'd',
+                controlWidth: 40,
+                extent      : 300,
+                items       : items({a: 100, b: 100, c: 100, d: 100})
+            });
+
+            expect(result.visible).toEqual(['a', 'd']);
+            // hidden preserves items order (b before c) — menus list predictably
+            expect(result.hidden).toEqual(['b', 'c'])
+        });
+
+        test('degenerate: a single item wider than the extent stays visible — you cannot hide the only tab', () => {
+            const result = DockLayoutAdapter.computeTabOverflow({
+                activeItemId: 'a',
+                controlWidth: 40,
+                extent      : 80,
+                items       : items({a: 500})
+            });
+
+            expect(result).toEqual({hidden: [], visible: ['a']})
+        });
+
+        test('active-only survivor: nothing fits, the active tab is force-kept and everything else overflows in order', () => {
+            const result = DockLayoutAdapter.computeTabOverflow({
+                activeItemId: 'c',
+                controlWidth: 60,
+                extent      : 50,
+                items       : items({a: 100, b: 100, c: 100})
+            });
+
+            expect(result.visible).toEqual(['c']);
+            expect(result.hidden).toEqual(['a', 'b'])
+        });
+
+        test('fail-soft measurements: non-finite/negative widths pack as zero, never crash a projection pass', () => {
+            const result = DockLayoutAdapter.computeTabOverflow({
+                activeItemId: 'a',
+                controlWidth: 40,
+                extent      : 100,
+                items       : [{id: 'a', headerWidth: 60}, {id: 'b', headerWidth: NaN}, {id: 'c', headerWidth: -5}, {id: 'd', headerWidth: 80}]
+            });
+
+            // total = 140 > 100 → overflow path; usable = 60 → a fits; b and c pack as zero-width
+            // (fail-SOFT is fail-VISIBLE — an unmeasured tab stays reachable and the next
+            // measurement pass corrects); d (80) is the first real non-fit and overflows
+            expect(result.visible).toEqual(['a', 'b', 'c']);
+            expect(result.hidden).toEqual(['d'])
+        });
+    });
 });

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -590,6 +590,21 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
             expect(result.hidden).toEqual(['b', 'c'])
         });
 
+        test('active WIDER than the displaced tab: displace as many trailing tabs as it takes — the active never spills', () => {
+            const result = DockLayoutAdapter.computeTabOverflow({
+                activeItemId: 'd',
+                controlWidth: 0,
+                extent      : 100,
+                items       : items({a: 30, b: 30, c: 30, d: 50})
+            });
+
+            // a+b+c (90) fit; d (active, 50) overflows. Surfacing d needs 50px: displacing only c (30) leaves
+            // a+b+d = 110 > 100 — the under-displacement bug. BOTH b and c must overflow so a+d = 80 fits
+            // within the 100 extent.
+            expect(result.visible).toEqual(['a', 'd']);
+            expect(result.hidden).toEqual(['b', 'c'])
+        });
+
         test('degenerate: a single item wider than the extent stays visible — you cannot hide the only tab', () => {
             const result = DockLayoutAdapter.computeTabOverflow({
                 activeItemId: 'a',

--- a/test/playwright/unit/dashboard/plugin/TabOverflow.spec.mjs
+++ b/test/playwright/unit/dashboard/plugin/TabOverflow.spec.mjs
@@ -49,12 +49,44 @@ test.describe('Neo.dashboard.plugin.TabOverflow (re-entrancy contract)', () => {
         return plugin
     };
 
-    test('project() releases the measuring latch even when getDomRect throws — a measure race with teardown never freezes future passes', async () => {
-        const plugin = createPlugin(async () => { throw new Error('getDomRect teardown race') });
+    test('a getDomRect throw against a LIVE owner surfaces the defect (console.error) and still releases the latch', async () => {
+        const plugin = createPlugin(async () => { throw new Error('live-owner programming defect') }),
+              errors = [],
+              orig   = console.error;
 
-        await plugin.project(true).catch(() => {});
+        console.error = (...args) => { errors.push(args) };
 
+        try {
+            await plugin.project(true).catch(() => {})
+        } finally {
+            console.error = orig
+        }
+
+        // owner.mounted stays true → the throw is a real defect: surfaced, not hidden behind a teardown-race assumption
+        expect(errors.length, 'a throw against a mounted owner is surfaced via console.error').toBeGreaterThan(0);
         expect(plugin.measuring, 'the latch must reset in finally so the header keeps responding').toBe(false)
+    });
+
+    test('a getDomRect throw during a mid-measure TEARDOWN (owner unmounts) is swallowed — the expected race, no defect noise', async () => {
+        // getDomRect is invoked as `owner.getDomRect(...)`, so `this` is the exact owner object project()
+        // holds — flip its `mounted` there (a regular function, not an arrow) to simulate an unmount landing
+        // mid-measure, just before the throw.
+        const plugin = createPlugin(async function () { this.mounted = false; throw new Error('teardown race') });
+
+        const errors = [],
+              orig   = console.error;
+
+        console.error = (...args) => { errors.push(args) };
+
+        try {
+            await plugin.project(true).catch(() => {})
+        } finally {
+            console.error = orig
+        }
+
+        // owner unmounted mid-measure → the throw is the ONE expected race: swallowed, and the latch still resets
+        expect(errors.length, 'a teardown race is swallowed, not logged as a defect').toBe(0);
+        expect(plugin.measuring, 'the latch still resets so future passes are not frozen').toBe(false)
     });
 
     test('a project() arriving during an in-flight pass is coalesced, then drained once — never dropped, so the last state wins', async () => {

--- a/test/playwright/unit/dashboard/plugin/TabOverflow.spec.mjs
+++ b/test/playwright/unit/dashboard/plugin/TabOverflow.spec.mjs
@@ -1,0 +1,93 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'NeoDashboardTabOverflowPluginTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Focused tests for the Neo.dashboard.plugin.TabOverflow re-entrancy contract — the part of
+ * the runtime overflow plugin that must survive a resize / activation storm without stranding state.
+ *
+ * These pin the two failure modes a naked latch produced: a thrown measure freezing every future pass,
+ * and a concurrent pass being silently dropped (leaving a stale split). The full measure/apply path is
+ * exercised by the example + e2e; here the owner is a lean stub so the guard logic is isolated.
+ */
+test.describe('Neo.dashboard.plugin.TabOverflow (re-entrancy contract)', () => {
+    let TabOverflow;
+
+    test.beforeAll(async () => {
+        // DockLayoutAdapter provides computeTabOverflow via the Neo namespace (the plugin does not import it)
+        await import('../../../../../src/dashboard/DockLayoutAdapter.mjs');
+        TabOverflow = (await import('../../../../../src/dashboard/plugin/TabOverflow.mjs')).default
+    });
+
+    /** A lean toolbar-owner stub: two header buttons, a controllable getDomRect. */
+    const createPlugin = getDomRect => {
+        const plugin = Neo.create(TabOverflow, {
+            owner: {
+                id             : 'tab-overflow-test-owner',
+                mounted        : true,
+                items          : [{id: 'b1'}, {id: 'b2'}],
+                getDomRect,
+                add            : () => ({}),
+                addDomListeners: () => {},
+                on             : () => {},
+                un             : () => {},
+                remove         : () => {},
+                up             : () => ({activeIndex: 0})
+            }
+        });
+
+        plugin.control = null;
+
+        return plugin
+    };
+
+    test('project() releases the measuring latch even when getDomRect throws — a measure race with teardown never freezes future passes', async () => {
+        const plugin = createPlugin(async () => { throw new Error('getDomRect teardown race') });
+
+        await plugin.project(true).catch(() => {});
+
+        expect(plugin.measuring, 'the latch must reset in finally so the header keeps responding').toBe(false)
+    });
+
+    test('a project() arriving during an in-flight pass is coalesced, then drained once — never dropped, so the last state wins', async () => {
+        let release,
+            gate       = new Promise(resolve => { release = resolve }),
+            callCount  = 0;
+
+        // first pass gates on getDomRect; the second project() call must queue rather than drop.
+        // A wide extent (button-id calls → per-button rects; the no-arg extent call → one wide rect)
+        // keeps nothing overflowing, so the pass completes cleanly through applySplit.
+        const plugin = createPlugin(async ids => {
+            callCount++;
+            if (callCount === 1) { await gate }
+            return ids ? [{width: 10}, {width: 10}] : {width: 1000}
+        });
+
+        const first = plugin.project(false); // enters, latches, awaits the gate
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(plugin.measuring, 'the first pass holds the latch while measuring').toBe(true);
+
+        plugin.project(true); // arrives mid-pass → must be remembered, not dropped
+
+        expect(plugin.projectQueued, 'a concurrent pass is queued, not discarded').toBe(true);
+        expect(plugin.queuedRecapture, 'the queued recapture is sticky-true').toBe(true);
+
+        release();
+        await first;
+
+        // the drain re-ran; give the async re-run a tick to settle its own pass
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        expect(plugin.projectQueued, 'the queued flag is consumed by the drain').toBe(false);
+        expect(plugin.measuring, 'no pass is left latched').toBe(false)
+    })
+});

--- a/test/playwright/unit/dashboard/plugin/TabOverflow.spec.mjs
+++ b/test/playwright/unit/dashboard/plugin/TabOverflow.spec.mjs
@@ -32,7 +32,9 @@ test.describe('Neo.dashboard.plugin.TabOverflow (re-entrancy contract)', () => {
         const plugin = Neo.create(TabOverflow, {
             owner: {
                 id             : 'tab-overflow-test-owner',
+                appName        : 'test-app',
                 mounted        : true,
+                windowId       : 1,
                 items          : [{id: 'b1'}, {id: 'b2'}],
                 getDomRect,
                 add            : () => ({}),
@@ -121,5 +123,20 @@ test.describe('Neo.dashboard.plugin.TabOverflow (re-entrancy contract)', () => {
 
         expect(plugin.projectQueued, 'the queued flag is consumed by the drain').toBe(false);
         expect(plugin.measuring, 'no pass is left latched').toBe(false)
+    });
+
+    test('all-fit teardown: syncControl destroys and nulls the control when the overflow set empties (so a later overflow recreates a fresh one, not a dead instance)', async () => {
+        // A wide extent keeps nothing overflowing, so the create-time auto-project (onOwnerMounted) settles
+        // cleanly with no control; await a tick so it does not race the direct syncControl call below.
+        const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        let destroyed = false;
+        plugin.control = {destroy: () => { destroyed = true }};
+
+        plugin.syncControl([], {activeIndex: 0}); // empty hiddenMeta → nothing overflows → teardown
+
+        expect(destroyed, 'the control is destroyed when the overflow set empties').toBe(true);
+        expect(plugin.control, 'the reference is cleared, so the next overflow builds a fresh control').toBe(null)
     })
 });

--- a/test/playwright/unit/dashboard/plugin/TabOverflow.spec.mjs
+++ b/test/playwright/unit/dashboard/plugin/TabOverflow.spec.mjs
@@ -138,5 +138,56 @@ test.describe('Neo.dashboard.plugin.TabOverflow (re-entrancy contract)', () => {
 
         expect(destroyed, 'the control is destroyed when the overflow set empties').toBe(true);
         expect(plugin.control, 'the reference is cleared, so the next overflow builds a fresh control').toBe(null)
+    });
+
+    test('error → success: a failed measure pass releases the latch so the very next pass measures cleanly (no freeze)', async () => {
+        // A `shouldThrow` latch controls WHICH pass fails, so the create-time auto-project (onOwnerMounted)
+        // settles cleanly first and only the pass we choose throws.
+        let   shouldThrow = false;
+        const plugin      = createPlugin(async ids => {
+            if (shouldThrow) { shouldThrow = false; throw new Error('transient measure failure') }
+            return ids ? [{width: 10}, {width: 10}] : {width: 1000}
+        });
+        await new Promise(resolve => setTimeout(resolve, 0)); // auto-project settles (no throw)
+
+        // Pass 1 surfaces the defect via console.error (RA-8) against the live owner — silence it; the point
+        // of THIS test is that the failure does not freeze future passes.
+        const orig = console.error;
+        console.error = () => {};
+
+        try {
+            shouldThrow = true;
+            await plugin.project(true).catch(() => {}); // pass 1: getDomRect throws → caught, latch released
+            expect(plugin.measuring, 'the latch is released after the failed pass').toBe(false);
+            await plugin.project(true);                 // pass 2: measures + applies cleanly
+        } finally {
+            console.error = orig
+        }
+
+        expect(plugin.measuring, 'the recovered pass also releases the latch — nothing is frozen').toBe(false)
+    });
+
+    test('recreation: after an all-fit teardown, a subsequent overflow enters the CREATE branch (fresh instance, not a reused reference)', async () => {
+        const plugin = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+        await new Promise(resolve => setTimeout(resolve, 0)); // settle the create-time auto-project
+
+        plugin.control = {destroy: () => {}};
+        plugin.syncControl([], {activeIndex: 0}); // all-fit → teardown
+        expect(plugin.control, 'torn down on all-fit').toBe(null);
+
+        // A subsequent overflow must BUILD a fresh instance (the create branch), not reuse a reference. In
+        // unit mode the real button.Base + menu.List construction needs `Neo.get` (unavailable here), so spy
+        // `Neo.create` to assert the create is invoked + assigned rather than exercise full construction.
+        const origCreate = Neo.create;
+        let   created    = false;
+        Neo.create = () => { created = true; return {ntype: 'button', destroy: () => {}} };
+        try {
+            plugin.syncControl([{text: 'Agents', iconCls: 'fa fa-users', index: 0}], {activeIndex: 0})
+        } finally {
+            Neo.create = origCreate
+        }
+
+        expect(created, 'a subsequent overflow builds a fresh control via Neo.create').toBe(true);
+        expect(plugin.control, 'and assigns the fresh instance as the new control').not.toBeNull()
     })
 });


### PR DESCRIPTION
Resolves #14771

The tab-overflow affordance: when a dock `tabs` node's headers exceed the available width, the overflowing tabs collapse behind an overflow control (`⋯`) whose menu reaches them — the projection half of the docking design record §2.4.

Evidence: L3 (confound-free page-DOM e2e journey, passing) → L3 required (the mount + overflow-interaction ACs are runtime/DOM effects). The `DockTabOverflowNL` e2e drives the real gesture and passes locally; residual is only the per-PR CI gap below.

## Architecture

- **Pure core** — `DockLayoutAdapter.computeTabOverflow({items, extent, activeItemId, controlWidth}) → {visible, hidden}`: active-never-hidden packing, overflow-only control-width reservation, order-preserving hidden set, fail-soft on malformed widths. Headless, unit-covered.
- **Runtime plugin** — `Neo.dashboard.plugin.TabOverflow` on the projected tab header toolbar: measures natural header widths (cached — hidden buttons `removeDom`, so a widen re-measures nothing), feeds the pure core, hides the overflow set via Neo's `button.hidden`, and surfaces the remainder through a single overflow control. The control is an **out-of-collection floating `button.Base`** rooted at `document.body`, deliberately **not** a member of `owner.items`: the dock enables `dragResortable`, so the header toolbar wires a SortZone that marks every `owner.items` entry draggable and reorders via `moveTo` — a trailing control inside the collection would be drag-reorderable and would corrupt the committed dock tab order. Keeping it floating preserves the collection invariant (`owner.items` === exactly the real tabs). It aligns to the toolbar's right-edge overflow slot (`align: {edgeAlign: 'r0-r0', target: owner.id}`). Selection sets `tabContainer.activeIndex` — the ordinary path, zero new persisted state.
- **Projection wiring** — `projectTabsNode` injects the plugin into the projected `headerToolbar.plugins`; **no** dock-specific `tab.Container` fork.

## Review-action resolution

- **RA-1 [out-of-collection mount] — resolved.** Floating instance at `document.body`, out of `owner.items` (SortZone-safe): real tab count stays N, `add()` inserts at N, the control can't be dragged, reorder is uncorrupted.
- **RA-2 [lifecycle] — resolved.** `project()` wraps the `measuring` latch in `try/finally`; a coalesced sticky queued-rerun re-applies a mount-time recapture that overlaps an in-flight resize/activation pass.
- **RA-3 [alignment / off-screen] — resolved.** The control had no `align.target`, so Component Base never aligned it and `.neo-floating` stayed at `-10000px` (rendered but not clickable). `align: {edgeAlign: 'r0-r0', target: owner.id}` places it on-screen at the toolbar's overflow slot.
- **RA-4 [e2e visibility/menu] — resolved.** `DockTabOverflowNL` drives the real gesture against the page's own DOM: render → floating child of `document.body` → ellipsis → click → menu surfaces the hidden tabs. (Deliberately page-DOM, not the neuralLink bridge, whose `connectToApp` appName-fallback latches a stale resident.)
- **RA-5 [catch + recapture] — resolved.** Narrowed the blanket `catch`: a throw against a live owner is surfaced (programming defect), only the teardown race is swallowed. Documented that tab-set-change recapture is via the adapter's declarative rebuild (a fresh plugin re-measures via `project(true)` on mount; `tab.Container.insert/removeAt` fire no listenable event).

## Deltas from ticket

- Mount pivoted floating → toolbar-item → floating; the out-of-collection floating mount is correct (SortZone) and works on the merged hidden-document render-queue drain. See Evolution.
- Added a page-DOM e2e (`DockTabOverflowNL.spec.mjs`) driving the render + interaction journey.

## Test Evidence

- Pure core: unit-covered.
- `DockTabOverflowNL` e2e: **passes locally, confound-free** (`1 passed`, ~1.7s) — asserts the floating control renders at `document.body` (`parentElement === document.body`), carries the ellipsis, is clickable (the `align.target` fix), and opens its menu of hidden tabs. It reads the page's own DOM, so it is immune to the neuralLink stale-resident confound.
- **Per-PR CI (accurate):** the per-PR suite runs `playwright.config.unit.mjs` + `playwright.config.integration.mjs` + lint. The dashboard e2e (`playwright.config.e2e.mjs`) runs via the `ai/scripts/lifecycle/nightlyE2eRunner.mjs` lifecycle daemon (nightly, RED-digest to `AGENT:*`), by design — not per-PR. So the confound-free LOCAL e2e pass is the render evidence for this PR; the nightly daemon covers it on the standing cadence. (An earlier revision of this section mis-stated a "nightly boot failure" — that `boot failed` string was a `fakeSpawn` fixture in `nightlyE2eRunner.spec.mjs`, surfacing in the unit job log, not a real run.)

## Post-Merge Validation

- [ ] Peer re-runs `examples/dashboard/dock`, narrows the main zone, confirms the `⋯` → menu → activate → surface flow, then widens to confirm the floating control disappears when all tabs fit.

## Commits

- `700d50d38` — RA-2: `project()` try/finally latch + coalesced queued rerun.
- `4cc1af500` — RA-1: out-of-collection floating mount + JSDoc.
- `c2d1d4afc` — RA-3/4/5: `align.target` (on-screen), page-DOM journey e2e, narrowed catch + recapture docs.

## Evolution

The mount went floating → toolbar-item → floating. Early floating attempts appeared not to render, so I fell back to a toolbar item ("it renders") — but RA-1 showed a control in `owner.items` is SortZone-draggable and corrupts the dock tab order; "it renders" is not "it's correct." The floating non-render was three separate confounds, not a runtime re-parent: (1) a hidden-document `requestAnimationFrame` starvation (framework blocker, fixed + merged), (2) a stale-resident test-harness read (the neuralLink bridge), and (3) a missing `align.target` leaving the mounted control off-screen. Bypassing the bridge with a page-DOM journey surfaced all three; the out-of-collection floating mount with right-edge alignment is the correct, SortZone-safe, verified shape.

Authored by Grace (Claude Opus 4.8, Claude Code).
