### PR TITLE
feat(agentos): FM cockpit agent detail view — drill-in inspector, freshness-labeled panes (#14608)

### DIFF
--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -54,15 +54,15 @@ class AgentCard extends Container {
          */
         controller: AgentCardController,
         /**
-         * A click on the card body (the identity / lane region — NOT the control cluster, which owns
-         * its own `lifecycleIntent` handlers) fires the drill-in select. The string handler resolves
-         * UP the controller chain (card → grid [no controller] → cockpit) to
-         * {@link AgentOS.view.fleet.FleetCockpitController#onAgentSelect}.
+         * A click anywhere on the card EXCEPT the control cluster (which owns its own
+         * `lifecycleIntent` handlers) fires the drill-in select — the controller carves the controls
+         * out by click path, so the drill target stays robust even when the flex body renders narrow.
+         * The string handler resolves UP the controller chain (card → grid [no controller] → cockpit)
+         * to {@link AgentOS.view.fleet.FleetCockpitController#onAgentSelect}.
          * @member {Object[]} domListeners
          */
         domListeners: [{
-            click   : 'onCardSelect',
-            delegate: '.fm-card-body'
+            click: 'onCardSelect'
         }],
         /**
          * @member {Object} layout={ntype:'hbox',align:'stretch'}

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -54,6 +54,17 @@ class AgentCard extends Container {
          */
         controller: AgentCardController,
         /**
+         * A click on the card body (the identity / lane region — NOT the control cluster, which owns
+         * its own `lifecycleIntent` handlers) fires the drill-in select. The string handler resolves
+         * UP the controller chain (card → grid [no controller] → cockpit) to
+         * {@link AgentOS.view.fleet.FleetCockpitController#onAgentSelect}.
+         * @member {Object[]} domListeners
+         */
+        domListeners: [{
+            click   : 'onCardSelect',
+            delegate: '.fm-card-body'
+        }],
+        /**
          * @member {Object} layout={ntype:'hbox',align:'stretch'}
          * @reactive
          */

--- a/apps/agentos/view/fleet/AgentCardController.mjs
+++ b/apps/agentos/view/fleet/AgentCardController.mjs
@@ -66,6 +66,14 @@ class AgentCardController extends Controller {
      * @param {Object} data The delegated click event.
      */
     onCardSelect(data) {
+        // a click whose path passes through the control cluster is a lifecycle intent, not a drill —
+        // carve it out (the whole card is the drill target, robust to a narrow flex body)
+        const inControls = (data?.path || []).some(node => Array.isArray(node.cls) && node.cls.includes('fm-card-controls'));
+
+        if (inControls) {
+            return
+        }
+
         this.component.fire('agentSelect', {agentId: this.component.record?.agentId ?? null})
     }
 }

--- a/apps/agentos/view/fleet/AgentCardController.mjs
+++ b/apps/agentos/view/fleet/AgentCardController.mjs
@@ -53,6 +53,21 @@ class AgentCardController extends Controller {
 
         me.component.fire('lifecycleIntent', {action, agentId})
     }
+
+    /**
+     * @summary Fires the card's drill-in select — a body click asks the cockpit to inspect this
+     * resident.
+     *
+     * Reads the durable `agentId` from the card's record and fires ONE `agentSelect` event
+     * `{agentId}` on the card. Like `lifecycleIntent`, this controller does NOT act on it — the
+     * cockpit (which owns the detail pane + the roster store) resolves the record and reveals the
+     * inspector via {@link AgentOS.view.fleet.FleetCockpitController#onAgentSelect}. The body
+     * `delegate` keeps control-cluster clicks (start/stop/restart) out of the select path.
+     * @param {Object} data The delegated click event.
+     */
+    onCardSelect(data) {
+        this.component.fire('agentSelect', {agentId: this.component.record?.agentId ?? null})
+    }
 }
 
 export default Neo.setupClass(AgentCardController);

--- a/apps/agentos/view/fleet/AgentDetail.mjs
+++ b/apps/agentos/view/fleet/AgentDetail.mjs
@@ -1,0 +1,361 @@
+import Container                                      from '../../../../src/container/Base.mjs';
+import FamilyRail                                     from './FamilyRail.mjs';
+import Image                                          from '../../../../src/component/Image.mjs';
+import StateDot                                       from './StateDot.mjs';
+import {classifyPaneFreshness, describePaneFreshness} from './agentFreshness.mjs';
+import {normalizeFleetSources}                        from './sourceHealth.mjs';
+
+/**
+ * The SSOT drill-in panes (design §B3: "thought-stream, lane, repo, and PRs"), each with the honest
+ * live cadence its freshness is judged against. `freshnessTtl` is the default window a pane's ledger
+ * may override once its feed stamps one; the values are tunable, not contractual.
+ * @type {Object[]}
+ */
+const PANES = [
+    {key: 'thought-stream', title: 'Thought stream', freshnessTtl: 60_000},
+    {key: 'lane',           title: 'Current lane',   freshnessTtl: 300_000},
+    {key: 'repo',           title: 'Repository',     freshnessTtl: 300_000},
+    {key: 'prs',            title: 'Pull requests',  freshnessTtl: 300_000}
+];
+
+/**
+ * @summary One pane's config: a header (title + referenced freshness chip) over a referenced body.
+ * Built from the {@link PANES} descriptor so the reference ids derive from the pane key.
+ * @param {Object} pane A {@link PANES} entry.
+ * @returns {Object}
+ * @private
+ */
+const paneConfig = pane => ({
+    ntype : 'container',
+    cls   : ['fm-detail-pane', `fm-detail-pane-${pane.key}`],
+    flex  : 'none',
+    layout: {ntype: 'vbox', align: 'stretch'},
+
+    items: [{
+        ntype : 'container',
+        cls   : ['fm-detail-pane-head'],
+        layout: {ntype: 'hbox', align: 'center'},
+
+        items: [{
+            ntype: 'component',
+            cls  : ['fm-detail-pane-title'],
+            flex : 1,
+            html : pane.title
+        }, {
+            ntype    : 'component',
+            flex     : 'none',
+            reference: `pane-${pane.key}-freshness`
+        }]
+    }, {
+        ntype    : 'component',
+        cls      : ['fm-detail-pane-body'],
+        reference: `pane-${pane.key}-body`
+    }]
+});
+
+/**
+ * The cockpit drill-in surface: one resident's detail — the identity header over the four SSOT
+ * panes (thought-stream · current lane · repository · pull requests). Mounted as the dock
+ * document's auto-hidden `agent-detail` inspector; the card→detail selection feeds its `record`.
+ *
+ * **Data-driven from its `record`** — one {@link AgentOS.model.FleetAgent} record (or a plain
+ * field-bag of the same keys), exactly like {@link AgentOS.view.fleet.AgentCard}. There is no
+ * per-view `state.Provider`; the owning cockpit's roster Store is the reactive layer, and a
+ * re-seat onto a different record re-renders in place via {@link #applyRecord}.
+ *
+ * **Identity-header render rules:** the social **displayName** and **engineTag**
+ * are mutable DISPLAY STATE / session-metadata over the durable `agentId` (§2.3.2/§2.3.3) — the id
+ * is rendered too, subordinate, as the never-renamed anchor; a family swap rebinds the rail in
+ * place and never reads as a different resident. **No role-typing anywhere** (§2.3.1) — the header
+ * renders what the resident IS and is DOING (identity + availability + session state), never what
+ * it must be. Every claim is witness, not authority (§2.4).
+ *
+ * **Freshness ledger (the panes):** every pane renders its observation freshness —
+ * `fresh` / `stale` / `lost` from a wired feed's `observedAt` vs TTL, or the honest `unobserved`
+ * until its Lane-C / memory-surface feed leaf lands. A pane NEVER renders a claim as silently
+ * current: an unwired pane says so. The pure classification is
+ * {@link module:apps/agentos/view/fleet/agentFreshness}; this view is its first consumer.
+ *
+ * **Shell-agnostic + layout-blind:** the view takes ordinary configs only — no
+ * dock/layout/Electron coupling reaches it — so the pop-out leaf (T4.15) reparents it into its own
+ * OS window without change.
+ *
+ * @class AgentOS.view.fleet.AgentDetail
+ * @extends Neo.container.Base
+ */
+class AgentDetail extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.AgentDetail'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.AgentDetail',
+        /**
+         * @member {String} ntype='fm-agent-detail'
+         * @protected
+         */
+        ntype: 'fm-agent-detail',
+        /**
+         * @member {String[]} baseCls=['fm-agent-detail']
+         */
+        baseCls: ['fm-agent-detail'],
+        /**
+         * The drilled-in resident: an {@link AgentOS.model.FleetAgent} record (store-backed, live)
+         * or a plain field bag with the same keys. `null` renders the honest "no agent selected"
+         * empty state — never a blank inspector masquerading as a loaded one.
+         * @member {Object|null} record_=null
+         * @reactive
+         */
+        record_: null,
+        /**
+         * Per-pane freshness ledgers keyed by pane `key` — `{observedAt, freshnessTtl, lost}` the
+         * Lane-C / memory-surface feed leaves stamp as they land. `null` (today's reality) → every
+         * pane degrades to the honest `unobserved`; the view sharpens to timestamped freshness with
+         * no change the moment a feed wires a ledger.
+         * @member {Object|null} paneLedgers_=null
+         * @reactive
+         */
+        paneLedgers_: null,
+        /**
+         * Injected wall-clock (ms) for freshness classification; `null` → the live `Date.now()`.
+         * Tests pin it so the freshness contract renders deterministically.
+         * @member {Number|null} now_=null
+         * @reactive
+         */
+        now_: null,
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * The empty state, the identity header, and the four SSOT panes (built from {@link PANES}).
+         * @member {Object[]} items
+         */
+        items: [{
+            ntype    : 'component',
+            cls      : ['fm-detail-empty'],
+            html     : 'Select an agent to inspect',
+            reference: 'detail-empty'
+        }, {
+            ntype    : 'container',
+            cls      : ['fm-detail-header'],
+            flex     : 'none',
+            hidden   : true,
+            reference: 'detail-header',
+            layout   : {ntype: 'hbox', align: 'stretch'},
+
+            items: [{
+                module   : FamilyRail,
+                flex     : 'none',
+                reference: 'family-rail'
+            }, {
+                module   : Image,
+                cls      : ['fm-detail-avatar'],
+                flex     : 'none',
+                reference: 'detail-avatar'
+            }, {
+                ntype : 'container',
+                cls   : ['fm-detail-identity'],
+                flex  : 1,
+                layout: {ntype: 'vbox', align: 'stretch'},
+
+                items: [{
+                    ntype : 'container',
+                    cls   : ['fm-detail-name-row'],
+                    layout: {ntype: 'hbox', align: 'center'},
+
+                    items: [{
+                        module   : StateDot,
+                        flex     : 'none',
+                        reference: 'state-dot'
+                    }, {
+                        ntype    : 'component',
+                        cls      : ['fm-detail-name'],
+                        flex     : 1,
+                        reference: 'detail-name'
+                    }, {
+                        // engine is session-metadata, not identity — rendered
+                        // subordinate to the name, never as a role
+                        ntype    : 'component',
+                        cls      : ['fm-detail-engine'],
+                        flex     : 'none',
+                        reference: 'detail-engine'
+                    }]
+                }, {
+                    // the durable anchor, rendered small beneath the display name — name is display
+                    // state OVER this id (§2.3.2), so the id is always reachable, never the label
+                    ntype    : 'component',
+                    cls      : ['fm-detail-id'],
+                    reference: 'detail-id'
+                }, {
+                    // availability (participationStatus), not a role — honest status word or nothing
+                    ntype    : 'component',
+                    cls      : ['fm-detail-participation'],
+                    reference: 'detail-participation'
+                }]
+            }]
+        }, {
+            ntype    : 'container',
+            cls      : ['fm-detail-panes'],
+            flex     : 1,
+            hidden   : true,
+            reference: 'detail-panes',
+            layout   : {ntype: 'vbox', align: 'stretch'},
+            items    : PANES.map(paneConfig)
+        }]
+    }
+
+    /**
+     * @summary Populate the header + panes once the anatomy exists (content is record-derived).
+     * @param {...*} args
+     */
+    onConstructed(...args) {
+        super.onConstructed(...args);
+        this.applyRecord()
+    }
+
+    /**
+     * Triggered after the record config changed — a re-seat onto a different resident (or a null
+     * clear back to the empty state) re-renders in place.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetRecord(value, oldValue) {
+        this.isConstructed && this.applyRecord()
+    }
+
+    /**
+     * Triggered after the per-pane ledgers changed — re-render just the freshness chips (a feed
+     * stamping a new `observedAt` must re-label the pane without a full record re-seat).
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetPaneLedgers(value, oldValue) {
+        this.isConstructed && this.record && this.applyPaneFreshness()
+    }
+
+    /**
+     * Triggered after the injected clock changed — freshness is time-relative, so a new `now`
+     * re-classifies every pane.
+     * @param {Number|null} value
+     * @param {Number|null} oldValue
+     * @protected
+     */
+    afterSetNow(value, oldValue) {
+        this.isConstructed && this.record && this.applyPaneFreshness()
+    }
+
+    /**
+     * @summary Render the record onto the header, or fall back to the honest empty state.
+     *
+     * The identity header: displayName is mutable display state (falling back
+     * through the durable id, never blank), engineTag is subordinate session-metadata, the id is
+     * always shown as the anchor, participationStatus renders as availability (not a role), and the
+     * family rail + state dot mirror {@link AgentOS.view.fleet.AgentCard} (state gated on a wired
+     * runtime source so missing evidence never renders as live).
+     * @protected
+     */
+    applyRecord() {
+        let me     = this,
+            record = me.record,
+            empty  = me.getReference('detail-empty'),
+            header = me.getReference('detail-header'),
+            panes  = me.getReference('detail-panes');
+
+        empty.hidden  = !!record;
+        header.hidden = !record;
+        panes.hidden  = !record;
+
+        if (!record) {
+            return
+        }
+
+        const
+            sources      = normalizeFleetSources(record.sources),
+            runtime      = sources.runtime,
+            sourceUsable = runtime.state === 'wired',
+            state        = sourceUsable ? (record.state ?? 'off') : 'off',
+            agentId      = record.agentId ?? '';
+
+        me.getReference('family-rail').family = record.family ?? null;
+
+        me.getReference('state-dot').set({
+            live : state === 'ok' && runtime.confidence === 'observed',
+            state
+        });
+
+        me.getReference('detail-name').text   = record.displayName || agentId || '—';
+        me.getReference('detail-engine').text = record.engineTag ?? '';
+        me.getReference('detail-id').text     = agentId;
+
+        // availability, rendered honestly — a known status word, or hidden when unstamped (null =
+        // no identity-root fact; never guessed, never a role)
+        const participation = record.participationStatus ?? null;
+
+        me.getReference('detail-participation').set({
+            hidden: participation === null,
+            text  : participation === null ? '' : participation.replace(/_/g, ' ')
+        });
+
+        me.getReference('detail-avatar').set({
+            alt: record.displayName ?? agentId,
+            src: record.avatarUrl ?? null
+        });
+
+        me.applyPaneFreshness()
+    }
+
+    /**
+     * @summary Render each pane's freshness chip + known body content, honestly.
+     *
+     * Every pane header shows its observation freshness — timestamped `fresh`/`stale`/`lost` from a
+     * wired ledger, or `unobserved` until its feed lands (never a silently-current
+     * claim). The `lane` pane additionally renders the record-known lane line + open-lane count; the
+     * feed-gated panes (thought-stream / repo / prs) render an honest "awaiting …" body until their
+     * Lane-C / memory-surface leaf wires content.
+     * @protected
+     */
+    applyPaneFreshness() {
+        let me      = this,
+            record  = me.record,
+            ledgers = me.paneLedgers ?? {},
+            now     = me.now ?? Date.now();
+
+        PANES.forEach(pane => {
+            const
+                ledger       = ledgers[pane.key] ?? null,
+                merged       = ledger ? {freshnessTtl: pane.freshnessTtl, ...ledger} : null,
+                {cls, label} = describePaneFreshness(classifyPaneFreshness(merged, now));
+
+            me.getReference(`pane-${pane.key}-freshness`).set({cls, html: label});
+            me.getReference(`pane-${pane.key}-body`).html = me.renderPaneBody(pane.key, record)
+        })
+    }
+
+    /**
+     * @summary The honest body content for one pane from the record's known facts. The `lane` pane
+     * renders the real lane line + open-lane count; the feed-gated panes render an "awaiting" line
+     * until their source leaf lands (degrade honestly, never a fabricated stream).
+     * @param {String} key Pane key.
+     * @param {Object} record The drilled-in FleetAgent record (never null here).
+     * @returns {String}
+     * @protected
+     */
+    renderPaneBody(key, record) {
+        if (key === 'lane') {
+            const
+                laneLine  = record.laneLine || 'no current lane reported',
+                laneCount = Number.isInteger(record.openLaneCount) && record.openLaneCount > 0 ? record.openLaneCount : null,
+                countText = laneCount === null ? '' : ` · ${laneCount} open ${laneCount === 1 ? 'lane' : 'lanes'}`;
+
+            return `${laneLine}${countText}`
+        }
+
+        return 'awaiting live feed'
+    }
+}
+
+export default Neo.setupClass(AgentDetail);

--- a/apps/agentos/view/fleet/AgentDetail.mjs
+++ b/apps/agentos/view/fleet/AgentDetail.mjs
@@ -124,6 +124,12 @@ class AgentDetail extends Container {
          */
         now_: null,
         /**
+         * How often (ms) the freshness labels re-age off the wall clock while a record is shown —
+         * a `fresh` pane must decay to `stale` / `lost` over time even with no new data. Tunable.
+         * @member {Number} freshnessRefreshMs=30000
+         */
+        freshnessRefreshMs: 30000,
+        /**
          * @member {Object} layout={ntype:'vbox',align:'stretch'}
          * @reactive
          */
@@ -212,7 +218,28 @@ class AgentDetail extends Container {
      */
     onConstructed(...args) {
         super.onConstructed(...args);
-        this.applyRecord()
+        this.applyRecord();
+        this.startFreshnessAging()
+    }
+
+    /**
+     * @summary Age the freshness labels over wall-clock time — freshness is time-relative, so a
+     * pane that was `fresh` must mechanically decay to `stale` / `lost` even with no new data. A
+     * self-rescheduling timer re-classifies every {@link #freshnessRefreshMs} while a record is
+     * shown; the `isDestroyed` guard ends the loop on teardown (no explicit clear needed). Uses the
+     * live clock (`applyPaneFreshness` reads `now ?? Date.now()`), so a pinned test `now` ages
+     * deterministically via `afterSetNow` instead.
+     * @protected
+     */
+    startFreshnessAging() {
+        let me = this;
+
+        me.timeout(me.freshnessRefreshMs).then(() => {
+            if (!me.isDestroyed) {
+                me.record && me.applyPaneFreshness();
+                me.startFreshnessAging()
+            }
+        })
     }
 
     /**
@@ -330,8 +357,10 @@ class AgentDetail extends Container {
                 merged       = ledger ? {freshnessTtl: pane.freshnessTtl, ...ledger} : null,
                 {cls, label} = describePaneFreshness(classifyPaneFreshness(merged, now));
 
-            me.getReference(`pane-${pane.key}-freshness`).set({cls, html: label});
-            me.getReference(`pane-${pane.key}-body`).html = me.renderPaneBody(pane.key, record)
+            // .text (never .html): the label is ours but the pane body is record-derived
+            // (laneLine), so it must be escaped text, never interpreted markup — no injection surface
+            me.getReference(`pane-${pane.key}-freshness`).set({cls, text: label});
+            me.getReference(`pane-${pane.key}-body`).text = me.renderPaneBody(pane.key, record)
         })
     }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -265,7 +265,7 @@ class FleetCockpit extends Container {
 
         let me = this;
 
-        me.getReference('fleet-grid')?.store?.on({load: me.onRosterStoreLoad, scope: me});
+        me.getReference('fleet-grid')?.store?.on({load: me.onRosterStoreLoad, recordChange: me.onDetailRecordChange, scope: me});
 
         me.loadActivity();
         me.loadRoster()
@@ -535,6 +535,21 @@ class FleetCockpit extends Container {
     }
 
     /**
+     * @summary Keep the open detail inspector truthful over time — route the roster store's
+     * `recordChange` to the mounted {@link AgentOS.view.fleet.AgentDetail} when the changed record
+     * is the one being inspected (mirrors how the grid routes `recordChange` to its cards). A roster
+     * re-poll mutating the selected resident (state, lane, sources) thus re-renders the detail in
+     * place — the view is reactive to record MUTATION, not only to a re-seat onto a new record.
+     * @param {Object} data The store `recordChange` event `{record, ...}`.
+     * @protected
+     */
+    onDetailRecordChange({record}) {
+        if (record === this.detailRecord) {
+            this.getReference('agent-detail')?.applyRecord()
+        }
+    }
+
+    /**
      * @summary Detach the roster-store load guard and release the drop producer; the provider
      * tears the owned store itself down.
      * @param {...*} args
@@ -542,7 +557,7 @@ class FleetCockpit extends Container {
     destroy(...args) {
         let me = this;
 
-        me.getReference('fleet-grid')?.store?.un({load: me.onRosterStoreLoad, scope: me});
+        me.getReference('fleet-grid')?.store?.un({load: me.onRosterStoreLoad, recordChange: me.onDetailRecordChange, scope: me});
         me.dockPreviewProducer?.destroy();
         me.dockPreviewProducer = null;
         me.perspectiveStore?.destroy();

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1,4 +1,5 @@
 import ActivityStream          from './ActivityStream.mjs';
+import AgentDetail             from './AgentDetail.mjs';
 import Button                  from '../../../../src/button/Base.mjs';
 import Container               from '../../../../src/container/Base.mjs';
 import DockLayoutAdapter       from '../../../../src/dashboard/DockLayoutAdapter.mjs';
@@ -199,6 +200,14 @@ class FleetCockpit extends Container {
      * @protected
      */
     streamEvents = FIXTURE_ACTIVITY
+    /**
+     * The drill-in inspector's selected resident — OWNER-held so a re-projection re-materializes
+     * the {@link AgentOS.view.fleet.AgentDetail} pane at the current selection (`null` = the honest
+     * "select an agent" empty state). The card→detail selection wiring writes it.
+     * @member {Object|null} detailRecord=null
+     * @protected
+     */
+    detailRecord = null
 
     /**
      * @summary Seed the layout SSOT and build the toolbar + dock projection as instance items —
@@ -435,9 +444,19 @@ class FleetCockpit extends Container {
                     events      : me.streamEvents,
                     reference   : 'activity-stream'
                 };
+            case 'agent-detail':
+                // the drill-in inspector; its selected resident is OWNER-held (re-projections
+                // rebuild instances) so a committed layout change never drops the selection — null
+                // renders the view's honest "select an agent" empty state
+                return {
+                    module   : AgentDetail,
+                    cls      : [marker],
+                    record   : me.detailRecord,
+                    reference: 'agent-detail'
+                };
             default:
-                // agent-detail / perspectives arrive with their own leaves — an honest labelled
-                // placeholder, never a blank pane masquerading as a finished surface
+                // perspectives arrives with its own leaf — an honest labelled placeholder, never a
+                // blank pane masquerading as a finished surface
                 return {
                     ntype: 'component',
                     cls  : [marker, 'fm-pane-placeholder'],

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -550,6 +550,39 @@ class FleetCockpit extends Container {
     }
 
     /**
+     * @summary Keep the owner-held selection truthful across authoritative roster transitions —
+     * membership reactivity, distinct from the mutation reactivity {@link #onDetailRecordChange} covers.
+     *
+     * `recordChange` fires when the inspected resident MUTATES, but a membership change is a different
+     * Store edge: {@link Neo.data.Store#remove} drops a record WITHOUT firing `recordChange` on it, and
+     * the first-live replacement (`clear` + `add`) swaps the sample instance for a fresh one. Either
+     * leaves `detailRecord` pointing at a record the roster no longer holds — the inspector then
+     * presents a resident the authority says is absent, which is user-visible misinformation. So after
+     * every authoritative reconcile/replace: if the selected durable `agentId` still exists, re-seat
+     * `detailRecord` onto the Store's CURRENT instance (a re-seat only when the object actually changed —
+     * an in-place `record.set` reconcile keeps the same instance, already covered by `recordChange`); if
+     * it is gone (including an empty snapshot), clear the selection so {@link AgentOS.view.fleet.AgentDetail}
+     * renders its honest empty state rather than a ghost resident.
+     * @protected
+     */
+    reconcileSelection() {
+        let me = this;
+
+        if (!me.detailRecord) {
+            return
+        }
+
+        const
+            store   = me.getReference('fleet-grid')?.store,
+            current = store?.get(me.detailRecord.agentId) ?? null;
+
+        if (current !== me.detailRecord) {
+            me.detailRecord = current;
+            me.getReference('agent-detail')?.set({record: current})
+        }
+    }
+
+    /**
      * @summary Detach the roster-store load guard and release the drop producer; the provider
      * tears the owned store itself down.
      * @param {...*} args
@@ -648,7 +681,10 @@ class FleetCockpit extends Container {
             } else {
                 grid.store.clear();
                 mapped.length > 0 && grid.store.add(mapped);
-                me.rosterWired = true
+                me.rosterWired = true;
+                // the first live snapshot replaces the sample seed wholesale — re-seat or clear a
+                // selection made against a now-removed sample record (reconcileRoster owns the later reconciles)
+                me.reconcileSelection()
             }
 
             me.gridAdapterState = 'live';
@@ -726,7 +762,11 @@ class FleetCockpit extends Container {
         store.items
             .filter(record => !snapshotIds.has(record.agentId))
             .map(record => record.agentId)
-            .forEach(agentId => store.remove(agentId))
+            .forEach(agentId => store.remove(agentId));
+
+        // membership may have removed/re-instanced the inspected resident — the removal fires no
+        // recordChange, so reconcile the owner-held selection here (both reconcile callers pass through).
+        this.reconcileSelection()
     }
 }
 

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -133,6 +133,39 @@ class FleetCockpitController extends Controller {
     }
 
     /**
+     * @summary Drill into a resident — the card→detail select seam.
+     *
+     * A card fires `agentSelect {agentId}` on a body click; the cockpit is the composition root that
+     * knows both the roster store and the detail pane. It resolves the record from the bound store,
+     * holds it as the OWNER-side selection (so a later re-projection re-materializes the inspector at
+     * this agent — {@link AgentOS.view.fleet.FleetCockpit#resolveDockComponentRef} reads
+     * `detailRecord`), and updates a live detail instance in place. The detail pane is auto-hidden on
+     * the rail by default, so the FIRST select reveals it through the standard commit loop (which
+     * re-projects and builds the pane from `detailRecord`); a later select updates the already-shown
+     * pane in place, with no full re-projection. An unknown agentId is a no-op (fail-closed).
+     * @param {Object} data The `agentSelect` payload `{agentId}` — Neo stamps `source`.
+     */
+    onAgentSelect(data) {
+        const
+            me      = this,
+            cockpit = me.component,
+            record  = me.getReference('fleet-grid')?.store?.get(data.agentId);
+
+        if (!record) {
+            return
+        }
+
+        cockpit.detailRecord = record;
+        me.getReference('agent-detail')?.set({record});
+
+        if (cockpit.dockModel?.items?.detail?.autoHidden) {
+            const result = cockpit.applyDockZoneOperation({operation: 'setItemAutoHidden', itemId: 'detail', autoHidden: false});
+
+            result && !result.errors?.length && cockpit.onDockZoneDocumentChange(result.document)
+        }
+    }
+
+    /**
      * @summary Re-poll the roster once a lifecycle intent has genuinely changed runtime state.
      *
      * `loadRoster` is the ONLY path that maps live runtime truth onto the roster records, and the

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -149,7 +149,9 @@ class FleetCockpitController extends Controller {
         const
             me      = this,
             cockpit = me.component,
-            record  = me.getReference('fleet-grid')?.store?.get(data.agentId);
+            // resolve from the firing card (data.source) — mirroring onAgentLifecycleIntent's proven
+            // source-based lookup; fall back to the roster store by agentId for callers with no source.
+            record  = Neo.getComponent(data.source)?.record ?? me.getReference('fleet-grid')?.store?.get(data.agentId);
 
         if (!record) {
             return

--- a/apps/agentos/view/fleet/FleetGrid.mjs
+++ b/apps/agentos/view/fleet/FleetGrid.mjs
@@ -289,10 +289,10 @@ class FleetGrid extends Container {
     agentCardConfig(record) {
         return {
             module   : AgentCard,
-            // The card's control cluster fires an intent-only `lifecycleIntent`; this listener resolves
-            // UP the controller chain (card → grid [no controller] → cockpit) to
-            // FleetCockpitController.onAgentLifecycleIntent — the C2 consumer that drives the round-trip.
-            listeners: {lifecycleIntent: 'onAgentLifecycleIntent'},
+            // Both card events resolve UP the controller chain (card → grid [no controller] → cockpit):
+            // `lifecycleIntent` → FleetCockpitController.onAgentLifecycleIntent (the C2 round-trip), and
+            // `agentSelect` → onAgentSelect (the drill-in that reveals the detail inspector).
+            listeners: {agentSelect: 'onAgentSelect', lifecycleIntent: 'onAgentLifecycleIntent'},
             record
         }
     }

--- a/apps/agentos/view/fleet/agentFreshness.mjs
+++ b/apps/agentos/view/fleet/agentFreshness.mjs
@@ -1,0 +1,151 @@
+/**
+ * @summary The FM cockpit detail-pane freshness ledger — the render-correctness contract at
+ * pane grain: a mutable claim renders WITH its observation time + freshness, and a claim with no
+ * live observation renders honestly as `unobserved`, NEVER as a silently-current one. Pure and
+ * `now`-injected (no argless `new Date()` — clock-brittle under test); fail-closed toward
+ * "we don't know" exactly like the sibling {@link module:apps/agentos/view/fleet/sourceHealth}
+ * source contract.
+ *
+ * The detail view's panes (lane · activity · PRs · thought-stream) each declare their own
+ * `freshnessTtl` (their honest live cadence) and, once their Lane-C / memory-surface feed leaf
+ * lands, stamp an `observedAt`. Until a feed wires `observedAt`, a pane
+ * degrades to `unobserved` — so the view is honest TODAY and sharpens to timestamped
+ * fresh/stale/lost automatically when a feed wires the ledger, with no view change. Every rendered
+ * claim stays `notAuthority` (witness, not decision authority); this contract only decides how fresh a claim is,
+ * never whether it is authoritative.
+ *
+ * @module apps/agentos/view/fleet/agentFreshness
+ */
+
+/**
+ * The closed freshness vocabulary. `fresh` / `stale` / `lost` classify a REAL observation by age
+ * vs its TTL; `unobserved` is the honest no-live-source state — never a fabricated current claim.
+ * @type {String[]}
+ */
+export const FRESHNESS_CLASSES = Object.freeze(['fresh', 'stale', 'lost', 'unobserved']);
+
+/**
+ * How many TTLs past its freshness window an observation is treated as `lost` rather than merely
+ * `stale`: a stale claim is old-but-still-shown; a lost claim is too old to stand as evidence.
+ * @type {Number}
+ * @private
+ */
+const LOST_TTL_FACTOR = 4;
+
+/**
+ * @summary Classify one pane's freshness from its ledger, honestly. An observation is `fresh`
+ * within its TTL, `stale` past it, and `lost` past `LOST_TTL_FACTOR × TTL` (or on an explicit
+ * source-reported `lost`). Anything we cannot place in time — no parseable `observedAt`, no finite
+ * `now`, or no positive `freshnessTtl` — is `unobserved`, the fail-closed default that never reads
+ * as current. A future/skewed observation clamps to `fresh` (skew resolves toward honesty, not a
+ * false "stale").
+ * @param {Object|null} ledger
+ * @param {String|null} [ledger.observedAt] ISO-8601 observation time (the feed stamps it).
+ * @param {Number|null} [ledger.freshnessTtl] The pane's live-cadence window, in ms.
+ * @param {Boolean} [ledger.lost] An explicit source-reported loss (overrides age).
+ * @param {Number|null} now Injected wall-clock ms (`Date.now()` at the call site; tests pin it).
+ * @returns {{freshness: String, observedAt: (String|null), ageMs: (Number|null)}}
+ */
+export function classifyPaneFreshness(ledger, now) {
+    if (!isPlainObject(ledger)) {
+        return {freshness: 'unobserved', observedAt: null, ageMs: null}
+    }
+
+    const
+        observedAt   = typeof ledger.observedAt === 'string' ? ledger.observedAt : null,
+        freshnessTtl = Number.isFinite(ledger.freshnessTtl) && ledger.freshnessTtl > 0 ? ledger.freshnessTtl : null,
+        observedMs   = observedAt ? Date.parse(observedAt) : NaN;
+
+    // an explicit source-reported loss beats any age math — the source told us the claim is gone
+    if (ledger.lost === true) {
+        return {freshness: 'lost', observedAt, ageMs: null}
+    }
+
+    // a claim we cannot place in time is never rendered as current — degrade to honest unobserved
+    if (!Number.isFinite(observedMs) || !Number.isFinite(now) || freshnessTtl === null) {
+        return {freshness: 'unobserved', observedAt, ageMs: null}
+    }
+
+    const ageMs = now - observedMs;
+
+    if (ageMs <= freshnessTtl) {
+        return {freshness: 'fresh', observedAt, ageMs}
+    }
+
+    if (ageMs <= freshnessTtl * LOST_TTL_FACTOR) {
+        return {freshness: 'stale', observedAt, ageMs}
+    }
+
+    return {freshness: 'lost', observedAt, ageMs}
+}
+
+/**
+ * @summary The render half: map a classification to its freshness cls + human label. `fresh` shows
+ * the relative observation age, `stale` shows it with the state word, `lost` states the claim is
+ * too old to trust, and `unobserved` states plainly that no live source has reported — the honest
+ * empty, never a blank that could read as current. The cls tokens (`is-fresh` / `is-stale` /
+ * `is-lost` / `is-unobserved`) are the only styling surface; color/motion live in SCSS tokens.
+ * @param {{freshness: String, ageMs: (Number|null)}} classification From {@link classifyPaneFreshness}.
+ * @returns {{freshness: String, cls: String[], label: String}}
+ */
+export function describePaneFreshness({freshness, ageMs} = {}) {
+    const relative = Number.isFinite(ageMs) ? formatAge(ageMs) : null;
+
+    switch (freshness) {
+        case 'fresh':
+            return {freshness, cls: ['fm-freshness', 'is-fresh'], label: relative ? `updated ${relative}` : 'live'};
+        case 'stale':
+            return {freshness, cls: ['fm-freshness', 'is-stale'], label: relative ? `stale · last seen ${relative}` : 'stale'};
+        case 'lost':
+            return {freshness, cls: ['fm-freshness', 'is-lost'], label: 'lost — no recent observation'};
+        default:
+            return {freshness: 'unobserved', cls: ['fm-freshness', 'is-unobserved'], label: 'not observed — source not wired'}
+    }
+}
+
+/**
+ * @summary Compact relative-age label from a millisecond age. Pure; negative (future / clock-skew)
+ * ages clamp to `0s ago` rather than rendering a nonsensical future time.
+ * @param {Number} ageMs
+ * @returns {String}
+ * @private
+ */
+function formatAge(ageMs) {
+    const seconds = Math.max(0, Math.floor(ageMs / 1000));
+
+    if (seconds < 60) {
+        return `${seconds}s ago`
+    }
+
+    const minutes = Math.floor(seconds / 60);
+
+    if (minutes < 60) {
+        return `${minutes}m ago`
+    }
+
+    const hours = Math.floor(minutes / 60);
+
+    if (hours < 24) {
+        return `${hours}h ago`
+    }
+
+    return `${Math.floor(hours / 24)}d ago`
+}
+
+/**
+ * @summary Return true only for own-key JSON-style objects; reject arrays, class instances, and
+ * inherited/prototype-shaped input before it reaches the ledger contract — the same fail-closed
+ * guard the sibling source-health contract uses.
+ * @param {*} value
+ * @returns {Boolean}
+ * @private
+ */
+function isPlainObject(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return false
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+
+    return prototype === Object.prototype || prototype === null
+}

--- a/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
@@ -1,0 +1,136 @@
+/* Agent detail — the drill-in inspector: identity header (family rail · avatar · name/engine/id ·
+   availability) over the freshness-labeled panes (thought-stream · lane · repo · PRs), scoped under
+   the component root. Geometry + the avatar frame only; every color reads from the token layer. */
+.fm-agent-detail {
+    gap    : 10px;
+    padding: 10px 12px;
+    overflow: hidden;
+
+    /* honest empty state — muted, centered; never reads as a loaded-but-blank inspector */
+    .fm-detail-empty {
+        padding   : 24px 8px;
+        text-align: center;
+        font-size : 12px;
+        color     : var(--fm-ink-faint);
+    }
+
+    .fm-detail-header {
+        gap          : 10px;
+        align-items  : center;
+        padding-bottom: 10px;
+        border-bottom : 1px solid var(--fm-line-soft);
+    }
+
+    .fm-detail-avatar {
+        width        : 48px;
+        height       : 48px;
+        flex         : none;
+        border-radius: 50%;
+        object-fit   : cover;
+        background   : color-mix(in srgb, var(--fm-ink-dim) 20%, transparent);
+    }
+
+    .fm-detail-identity {
+        gap     : 2px;
+        overflow: hidden;
+    }
+
+    .fm-detail-name-row {
+        gap: 7px;
+    }
+
+    /* the social name — the primary, largest identity surface (display state over the durable id) */
+    .fm-detail-name {
+        flex         : 1;
+        font-weight  : 600;
+        font-size    : 15px;
+        color        : var(--fm-ink);
+        overflow     : hidden;
+        white-space  : nowrap;
+        text-overflow: ellipsis;
+    }
+
+    /* engine is session-metadata, not identity — subordinate mono tag beside the name */
+    .fm-detail-engine {
+        flex       : none;
+        font-family: var(--fm-font-mono);
+        font-size  : 10px;
+        color      : var(--fm-ink-dim);
+    }
+
+    /* the durable anchor — always shown, smallest + faintest: the name is display state OVER it */
+    .fm-detail-id {
+        font-family: var(--fm-font-mono);
+        font-size  : 10px;
+        color      : var(--fm-ink-faint);
+    }
+
+    /* availability (participationStatus), not a role */
+    .fm-detail-participation {
+        font-size     : 11px;
+        color         : var(--fm-ink-dim);
+        text-transform: capitalize;
+    }
+
+    .fm-detail-panes {
+        gap     : 8px;
+        overflow: auto;
+    }
+
+    .fm-detail-pane {
+        gap          : 4px;
+        padding      : 8px 10px;
+        background   : var(--fm-panel);
+        border       : 1px solid var(--fm-line-soft);
+        border-radius: 6px;
+    }
+
+    .fm-detail-pane-head {
+        gap        : 8px;
+        align-items: center;
+    }
+
+    .fm-detail-pane-title {
+        flex       : 1;
+        font-weight: 500;
+        font-size  : 12px;
+        color      : var(--fm-ink);
+    }
+
+    .fm-detail-pane-body {
+        font-size: 11px;
+        color    : var(--fm-ink-dim);
+    }
+
+    /* the freshness ledger chip: a mono pill whose tone states the observation
+       freshness — never a silent current claim. fresh reuses the live signal, stale the wedged tone
+       (mirroring the ActivityStream adapter states), lost the alert tone, unobserved the honest
+       muted "we don't know" (never alarming — absence is not an error). */
+    .fm-freshness {
+        flex         : none;
+        font-family  : var(--fm-font-mono);
+        font-size    : 9px;
+        line-height  : 1;
+        white-space  : nowrap;
+        padding      : 2px 7px;
+        border-radius: 999px;
+        background   : color-mix(in srgb, currentColor 12%, transparent);
+        color        : var(--fm-ink-faint);
+
+        &.is-fresh {
+            color: var(--fm-signal);
+        }
+
+        &.is-stale {
+            color: var(--fm-state-wedged);
+        }
+
+        &.is-lost {
+            color: var(--fm-kind-alert);
+        }
+
+        &.is-unobserved {
+            color: var(--fm-ink-faint);
+        }
+    }
+}

--- a/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
@@ -125,8 +125,11 @@
             color: var(--fm-state-wedged);
         }
 
+        /* alert-red TEXT fails AA at 9px (4.26:1); render "lost" as readable ink text on an
+           alert-tinted pill instead — the tint + the label word carry the state, the text stays AA */
         &.is-lost {
-            color: var(--fm-kind-alert);
+            color     : var(--fm-ink);
+            background: color-mix(in srgb, var(--fm-kind-alert) 30%, transparent);
         }
 
         &.is-unobserved {

--- a/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
@@ -11,7 +11,7 @@
         padding   : 24px 8px;
         text-align: center;
         font-size : 12px;
-        color     : var(--fm-ink-faint);
+        color     : var(--fm-ink-dim);
     }
 
     .fm-detail-header {
@@ -62,7 +62,7 @@
     .fm-detail-id {
         font-family: var(--fm-font-mono);
         font-size  : 10px;
-        color      : var(--fm-ink-faint);
+        color      : var(--fm-ink-dim);
     }
 
     /* availability (participationStatus), not a role */
@@ -115,7 +115,7 @@
         padding      : 2px 7px;
         border-radius: 999px;
         background   : color-mix(in srgb, currentColor 12%, transparent);
-        color        : var(--fm-ink-faint);
+        color        : var(--fm-ink-dim);
 
         &.is-fresh {
             color: var(--fm-signal);
@@ -130,7 +130,7 @@
         }
 
         &.is-unobserved {
-            color: var(--fm-ink-faint);
+            color: var(--fm-ink-dim);
         }
     }
 }

--- a/test/playwright/e2e/agentos/FleetCockpitDrillNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitDrillNL.spec.mjs
@@ -1,0 +1,45 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary The FM cockpit card→detail drill, proven LIVE over the REAL DOM click — the basic
+ * "live drill" the detail-view AC requires. A click on a resident card (the avatar is the
+ * always-sized, non-control region the whole-card domListener catches) reveals the auto-hidden
+ * AgentDetail inspector and renders THAT resident: the whole chain — domListener → onCardSelect →
+ * `agentSelect` → cockpit `onAgentSelect` → owner-held `detailRecord` → dock `setItemAutoHidden`
+ * reveal → projection — is exercised end-to-end, never via a controller call. Whitebox: the DOM
+ * proves the render, the possessed component proves the engine truth (the mounted inspector holds
+ * the clicked resident's record).
+ *
+ * @see apps/agentos/view/fleet/AgentDetail.mjs
+ * @see apps/agentos/view/fleet/FleetCockpitController.mjs (onAgentSelect)
+ * @see test/playwright/e2e/agentos/FleetActivityStreamBurstNL.spec.mjs (sibling possession pattern)
+ */
+test.describe('AgentOS fleet cockpit — card→detail live drill over the real DOM click (#14608)', () => {
+    test.setTimeout(90000);
+
+    test('a card click reveals the AgentDetail inspector rendering that agent + its four panes', async ({page, neuralLink}) => {
+        await page.goto('/apps/agentos/index.html');
+        await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
+        await expect(page.locator('.fm-agent-card').first()).toBeVisible({timeout: 30000});
+
+        const app      = await neuralLink.connectToApp('AgentOS'),
+              cards    = await app.queryComponent({className: 'AgentOS.view.fleet.AgentCard'}, ['record']),
+              agentIds = cards.map(entry => entry?.properties?.record?.agentId).filter(Boolean);
+        expect(agentIds.length, 'the fleet should render cards with records').toBeGreaterThan(0);
+
+        // the REAL DOM click — on the always-sized avatar (a non-control region the whole-card
+        // domListener catches; the flex body can render narrow), never a direct controller call
+        await page.locator('.fm-agent-card').first().locator('.fm-card-avatar').click();
+
+        // the auto-hidden inspector reveals + renders a resident + the four SSOT panes
+        const detail = page.locator('.fm-agent-detail');
+        await expect(detail).toBeVisible({timeout: 15000});
+        await expect(detail.locator('.fm-detail-name')).not.toBeEmpty();
+        await expect(detail.locator('.fm-detail-pane')).toHaveCount(4);
+
+        // engine truth: the possessed inspector holds a REAL fleet resident's record — the click
+        // routed through the owner-held selection to the mounted detail, not a DOM coincidence
+        const [d] = await app.queryComponent({className: 'AgentOS.view.fleet.AgentDetail'}, ['record']);
+        expect(agentIds, 'the inspector drilled into a real resident').toContain(d?.properties?.record?.agentId)
+    })
+});

--- a/test/playwright/e2e/agentos/FleetCockpitDrillNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitDrillNL.spec.mjs
@@ -22,14 +22,21 @@ test.describe('AgentOS fleet cockpit — card→detail live drill over the real 
         await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
         await expect(page.locator('.fm-agent-card').first()).toBeVisible({timeout: 30000});
 
-        const app      = await neuralLink.connectToApp('AgentOS'),
-              cards    = await app.queryComponent({className: 'AgentOS.view.fleet.AgentCard'}, ['record']),
-              agentIds = cards.map(entry => entry?.properties?.record?.agentId).filter(Boolean);
-        expect(agentIds.length, 'the fleet should render cards with records').toBeGreaterThan(0);
+        const app   = await neuralLink.connectToApp('AgentOS'),
+              cards = await app.queryComponent({className: 'AgentOS.view.fleet.AgentCard'}, ['record', 'id']);
+        expect(cards.length, 'the fleet should render cards with records').toBeGreaterThan(0);
 
-        // the REAL DOM click — on the always-sized avatar (a non-control region the whole-card
-        // domListener catches; the flex body can render narrow), never a direct controller call
-        await page.locator('.fm-agent-card').first().locator('.fm-card-avatar').click();
+        // pin ONE specific card and derive its EXACT durable identity + its DOM element id (=== the
+        // component id) — so the click and the assertion reference the same resident, not the set.
+        const target = cards.find(entry => entry?.properties?.record?.agentId && entry?.properties?.id);
+        expect(target, 'a card exposes both a record agentId and a component id').toBeTruthy();
+
+        const expectedAgentId = target.properties.record.agentId,
+              targetCardId    = target.properties.id;
+
+        // the REAL DOM click — on THAT card's always-sized avatar (a non-control region the whole-card
+        // domListener catches; the flex body can render narrow), addressed by the card's own element id
+        await page.locator(`[id="${targetCardId}"] .fm-card-avatar`).click();
 
         // the auto-hidden inspector reveals + renders a resident + the four SSOT panes
         const detail = page.locator('.fm-agent-detail');
@@ -37,9 +44,9 @@ test.describe('AgentOS fleet cockpit — card→detail live drill over the real 
         await expect(detail.locator('.fm-detail-name')).not.toBeEmpty();
         await expect(detail.locator('.fm-detail-pane')).toHaveCount(4);
 
-        // engine truth: the possessed inspector holds a REAL fleet resident's record — the click
-        // routed through the owner-held selection to the mounted detail, not a DOM coincidence
+        // engine truth: the mounted inspector holds the EXACT clicked resident — equality, not
+        // set-membership. The click routed through the owner-held selection to the exact durable id.
         const [d] = await app.queryComponent({className: 'AgentOS.view.fleet.AgentDetail'}, ['record']);
-        expect(agentIds, 'the inspector drilled into a real resident').toContain(d?.properties?.record?.agentId)
+        expect(d?.properties?.record?.agentId, 'the inspector drilled into the exact clicked resident').toBe(expectedAgentId)
     })
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -193,16 +193,21 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
         card.destroy()
     });
 
-    test('drill-in: a body click fires ONE agentSelect {agentId} — the seam the cockpit resolves up the controller chain', () => {
+    test('drill-in: a card click fires ONE agentSelect {agentId}; a control-cluster click is carved out (no drill)', () => {
         const card  = createCard({agentId: 'vega', state: 'ok'});
         const fired = [];
 
         card.on('agentSelect', data => fired.push(data));
 
-        // the body `delegate` routes only identity/lane clicks here (controls fire lifecycleIntent);
-        // the controller reads the durable agentId off the record and fires the intent-only select
-        card.getController().onCardSelect({});
+        // a click NOT through the controls → drills (the whole card is the target, robust to a narrow
+        // flex body); the controller reads the durable agentId off the record and fires intent-only
+        card.getController().onCardSelect({path: [{cls: ['fm-card-name']}, {cls: ['fm-card-body']}, {cls: ['fm-agent-card']}]});
         expect(fired).toMatchObject([{agentId: 'vega'}]);
+
+        // a click whose path passes through the control cluster is a lifecycle intent, not a drill
+        fired.length = 0;
+        card.getController().onCardSelect({path: [{cls: ['neo-button']}, {cls: ['fm-card-controls']}, {cls: ['fm-agent-card']}]});
+        expect(fired).toEqual([]);
 
         card.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -193,6 +193,20 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
         card.destroy()
     });
 
+    test('drill-in: a body click fires ONE agentSelect {agentId} — the seam the cockpit resolves up the controller chain', () => {
+        const card  = createCard({agentId: 'vega', state: 'ok'});
+        const fired = [];
+
+        card.on('agentSelect', data => fired.push(data));
+
+        // the body `delegate` routes only identity/lane clicks here (controls fire lifecycleIntent);
+        // the controller reads the durable agentId off the record and fires the intent-only select
+        card.getController().onCardSelect({});
+        expect(fired).toMatchObject([{agentId: 'vega'}]);
+
+        card.destroy()
+    });
+
     test('B4 honest state: a pending action disables every verb + renders it pending; a controlReason renders the reason — no optimistic success (#14611)', () => {
         const card   = createCard({agentId: 'vega', state: 'idle'});
         const verbs  = () => card.down({reference: 'control-verbs'}).items;

--- a/test/playwright/unit/apps/agentos/view/fleet/agentDetail.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentDetail.spec.mjs
@@ -1,0 +1,221 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'FleetAgentDetailTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import Instance       from '../../../../../../../src/manager/Instance.mjs';
+
+/**
+ * @summary Tests for the FM cockpit AgentDetail drill-in view — the identity
+ * header (name-as-display-state over the durable id, engine-as-metadata, family rebind in place,
+ * no role fields) over the four SSOT panes, each freshness-labeled per §2.2.1 (fresh/stale/lost
+ * from a wired ledger, honest `unobserved` until a feed lands). `now` is injected + pinned so the
+ * freshness contract renders deterministically.
+ */
+test.describe('Fleet cockpit AgentDetail — drill-in inspector (#14608)', () => {
+    let AgentDetail, FleetAgent, Store;
+
+    const
+        stores          = [],
+        // a fixed clock + observations at fixed offsets; a wired runtime so the state dot can render live
+        NOW             = Date.parse('2026-07-12T00:00:00.000Z'),
+        observedSources = {
+            roster    : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
+            repoStatus: {source: 'fleet:fleetStatus',   state: 'wired', confidence: 'observed'},
+            runtime   : {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}
+        };
+
+    // a real store-backed record — the production shape (an AgentOS.store.FleetRoster row). The store
+    // mirrors FleetRoster's keyProperty (the collection default 'id' would shadow the model's).
+    const makeRecord = data => {
+        const row   = {...data, sources: data.sources === undefined ? observedSources : data.sources},
+              store = Neo.create(Store, {keyProperty: 'agentId', model: FleetAgent, data: [row]});
+
+        stores.push(store);
+
+        return store.get(data.agentId)
+    };
+
+    const createDetail = (data, config = {}) => Neo.create(AgentDetail, {appName, now: NOW, record: makeRecord(data), ...config});
+
+    // the cockpit routes the store's recordChange to the view; standalone units drive the same seam.
+    const applySet = (detail, values) => {
+        detail.record.set(values);
+        detail.applyRecord()
+    };
+
+    const chip = (detail, key) => detail.down({reference: `pane-${key}-freshness`});
+    const body = (detail, key) => detail.down({reference: `pane-${key}-body`});
+
+    test.beforeAll(async () => {
+        AgentDetail = (await import('../../../../../../../apps/agentos/view/fleet/AgentDetail.mjs')).default;
+        FleetAgent  = (await import('../../../../../../../apps/agentos/model/FleetAgent.mjs')).default;
+        Store       = (await import('../../../../../../../src/data/Store.mjs')).default
+    });
+
+    test.afterAll(() => {
+        stores.forEach(store => store.destroy());
+        stores.length = 0
+    });
+
+    test('no record → the honest empty state; header + panes hidden until a resident is selected', () => {
+        const detail = Neo.create(AgentDetail, {appName});
+
+        expect(detail.down({reference: 'detail-empty'}).hidden).toBe(false);
+        expect(detail.down({reference: 'detail-header'}).hidden).toBe(true);
+        expect(detail.down({reference: 'detail-panes'}).hidden).toBe(true);
+
+        detail.destroy()
+    });
+
+    test('a selected resident renders the ADR-0032 identity header + reveals the panes; no per-view provider', () => {
+        const detail = createDetail({
+            agentId: 'vega', avatarUrl: 'vega.png', displayName: 'Vega', family: 'claude', engineTag: 'opus-4.8', state: 'ok'
+        });
+
+        // one record surface, zero providers
+        expect(detail.record.agentId).toBe('vega');
+        expect(detail.stateProvider ?? null).toBeNull();
+
+        // empty state gone, header + panes shown
+        expect(detail.down({reference: 'detail-empty'}).hidden).toBe(true);
+        expect(detail.down({reference: 'detail-header'}).hidden).toBe(false);
+        expect(detail.down({reference: 'detail-panes'}).hidden).toBe(false);
+
+        // identity header: family rail + state dot + name/engine/id from the record
+        expect(detail.down({ntype: 'fm-family-rail'}).family).toBe('claude');
+        expect(detail.down({ntype: 'fm-state-dot'}).state).toBe('ok');
+        expect(detail.down({ntype: 'image'}).src).toBe('vega.png');
+        expect(detail.down({reference: 'detail-name'}).text).toBe('Vega');
+        expect(detail.down({reference: 'detail-engine'}).text).toBe('opus-4.8');
+        // the durable anchor is always shown — name is display state OVER it (§2.3.2)
+        expect(detail.down({reference: 'detail-id'}).text).toBe('vega');
+
+        detail.destroy()
+    });
+
+    test('ADR-0032 §2.3.2: name/engine are display state over the durable id — a rename re-renders in place, never a re-key', () => {
+        const detail   = createDetail({agentId: 'vega', displayName: 'Vega', engineTag: 'opus-4.8', state: 'ok'});
+        const beforeId = detail.id;
+
+        applySet(detail, {displayName: 'Vega (renamed)', engineTag: 'fable-5'});
+
+        expect(detail.id).toBe(beforeId);           // the SAME instance — identity is the durable id
+        expect(detail.record.agentId).toBe('vega');
+        expect(detail.down({reference: 'detail-name'}).text).toBe('Vega (renamed)');
+        expect(detail.down({reference: 'detail-engine'}).text).toBe('fable-5');
+        expect(detail.down({reference: 'detail-id'}).text).toBe('vega');
+
+        detail.destroy()
+    });
+
+    test('ADR-0032 §2.3.3: a cross-family swap rebinds the rail in place — the SAME resident, not a new self', () => {
+        const detail   = createDetail({agentId: 'vega', family: 'claude', state: 'ok'});
+        const beforeId = detail.id;
+
+        applySet(detail, {family: 'gpt'});
+
+        expect(detail.id).toBe(beforeId);
+        expect(detail.down({ntype: 'fm-family-rail'}).family).toBe('gpt');
+
+        detail.destroy()
+    });
+
+    test('a null displayName falls back to the durable id, never a blank name slot', () => {
+        const detail = createDetail({agentId: 'neo-gpt-emmy', displayName: null, state: 'ok'});
+
+        expect(detail.down({reference: 'detail-name'}).text).toBe('neo-gpt-emmy');
+
+        detail.destroy()
+    });
+
+    test('participationStatus renders as availability (not a role); an unstamped status hides the line', () => {
+        const detail = createDetail({agentId: 'gem', participationStatus: 'operator_benched', state: 'off'});
+
+        const line = detail.down({reference: 'detail-participation'});
+        expect(line.hidden).toBe(false);
+        expect(line.text).toBe('operator benched');
+
+        // null (no identity-root fact) → hidden, never guessed
+        applySet(detail, {participationStatus: null});
+        expect(detail.down({reference: 'detail-participation'}).hidden).toBe(true);
+
+        detail.destroy()
+    });
+
+    test('the state dot is gated on a wired runtime source — missing runtime evidence never renders live', () => {
+        const detail = createDetail({agentId: 'vega', state: 'ok'});
+
+        expect(detail.down({ntype: 'fm-state-dot'}).state).toBe('ok');
+        expect(detail.down({ntype: 'fm-state-dot'}).live).toBe(true);
+
+        applySet(detail, {sources: {
+            ...observedSources,
+            runtime: {source: 'fleet:runtimeStatus', state: 'not-wired', confidence: 'none'}
+        }});
+        expect(detail.down({ntype: 'fm-state-dot'}).state).toBe('off');
+        expect(detail.down({ntype: 'fm-state-dot'}).live).toBe(false);
+
+        detail.destroy()
+    });
+
+    test('§2.2.1 freshness: each pane renders its ledger class — fresh/stale/lost from observedAt, unobserved with no ledger', () => {
+        const detail = createDetail({agentId: 'vega', state: 'ok'}, {
+            paneLedgers: {
+                'thought-stream': {observedAt: '2026-07-11T23:59:50.000Z', freshnessTtl: 30_000}, // 10s → fresh
+                lane            : {observedAt: '2026-07-11T23:58:30.000Z', freshnessTtl: 30_000}, // 90s → stale
+                repo            : {lost: true}                                                    // explicit → lost
+                // prs: no ledger → unobserved
+            }
+        });
+
+        expect(chip(detail, 'thought-stream').cls).toContain('is-fresh');
+        expect(chip(detail, 'thought-stream').html).toBe('updated 10s ago');
+        expect(chip(detail, 'lane').cls).toContain('is-stale');
+        expect(chip(detail, 'repo').cls).toContain('is-lost');
+        expect(chip(detail, 'prs').cls).toContain('is-unobserved');
+        expect(chip(detail, 'prs').html).toBe('not observed — source not wired');
+
+        detail.destroy()
+    });
+
+    test('§2.2.1 freshness re-labels reactively when a feed stamps a new observation (paneLedgers set)', () => {
+        const detail = createDetail({agentId: 'vega', state: 'ok'});
+
+        // no ledgers → all unobserved
+        expect(chip(detail, 'lane').cls).toContain('is-unobserved');
+
+        // a feed wires the lane ledger → the pane sharpens to timestamped freshness, no re-seat
+        detail.paneLedgers = {lane: {observedAt: '2026-07-11T23:59:55.000Z', freshnessTtl: 30_000}}; // 5s → fresh
+        expect(chip(detail, 'lane').cls).toContain('is-fresh');
+        expect(chip(detail, 'lane').html).toBe('updated 5s ago');
+
+        detail.destroy()
+    });
+
+    test('the lane pane body renders the record-known lane line + open-lane count; feed-gated panes degrade honestly', () => {
+        const detail = createDetail({agentId: 'vega', laneLine: 'FM cockpit agent detail view', openLaneCount: 17, state: 'ok'});
+
+        expect(body(detail, 'lane').html).toBe('FM cockpit agent detail view · 17 open lanes');
+        // a feed-gated pane never fabricates a stream
+        expect(body(detail, 'thought-stream').html).toBe('awaiting live feed');
+
+        // no lane reported → honest fallback, no fabricated count
+        applySet(detail, {laneLine: null, openLaneCount: null});
+        expect(body(detail, 'lane').html).toBe('no current lane reported');
+
+        detail.destroy()
+    });
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/agentDetail.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentDetail.spec.mjs
@@ -182,11 +182,11 @@ test.describe('Fleet cockpit AgentDetail — drill-in inspector (#14608)', () =>
         });
 
         expect(chip(detail, 'thought-stream').cls).toContain('is-fresh');
-        expect(chip(detail, 'thought-stream').html).toBe('updated 10s ago');
+        expect(chip(detail, 'thought-stream').text).toBe('updated 10s ago');
         expect(chip(detail, 'lane').cls).toContain('is-stale');
         expect(chip(detail, 'repo').cls).toContain('is-lost');
         expect(chip(detail, 'prs').cls).toContain('is-unobserved');
-        expect(chip(detail, 'prs').html).toBe('not observed — source not wired');
+        expect(chip(detail, 'prs').text).toBe('not observed — source not wired');
 
         detail.destroy()
     });
@@ -200,7 +200,7 @@ test.describe('Fleet cockpit AgentDetail — drill-in inspector (#14608)', () =>
         // a feed wires the lane ledger → the pane sharpens to timestamped freshness, no re-seat
         detail.paneLedgers = {lane: {observedAt: '2026-07-11T23:59:55.000Z', freshnessTtl: 30_000}}; // 5s → fresh
         expect(chip(detail, 'lane').cls).toContain('is-fresh');
-        expect(chip(detail, 'lane').html).toBe('updated 5s ago');
+        expect(chip(detail, 'lane').text).toBe('updated 5s ago');
 
         detail.destroy()
     });
@@ -208,13 +208,30 @@ test.describe('Fleet cockpit AgentDetail — drill-in inspector (#14608)', () =>
     test('the lane pane body renders the record-known lane line + open-lane count; feed-gated panes degrade honestly', () => {
         const detail = createDetail({agentId: 'vega', laneLine: 'FM cockpit agent detail view', openLaneCount: 17, state: 'ok'});
 
-        expect(body(detail, 'lane').html).toBe('FM cockpit agent detail view · 17 open lanes');
+        expect(body(detail, 'lane').text).toBe('FM cockpit agent detail view · 17 open lanes');
         // a feed-gated pane never fabricates a stream
-        expect(body(detail, 'thought-stream').html).toBe('awaiting live feed');
+        expect(body(detail, 'thought-stream').text).toBe('awaiting live feed');
 
         // no lane reported → honest fallback, no fabricated count
         applySet(detail, {laneLine: null, openLaneCount: null});
-        expect(body(detail, 'lane').html).toBe('no current lane reported');
+        expect(body(detail, 'lane').text).toBe('no current lane reported');
+
+        detail.destroy()
+    });
+
+    test('§2.2.1 wall-clock aging: a later `now` re-classifies fresh → lost in place (time-reactive, not just re-seat)', () => {
+        const detail = createDetail({agentId: 'vega', state: 'ok'}, {
+            paneLedgers: {lane: {observedAt: '2026-07-11T23:59:50.000Z', freshnessTtl: 30_000}} // 10s before NOW → fresh
+        });
+        expect(chip(detail, 'lane').cls).toContain('is-fresh');
+
+        // 5 minutes of wall clock later (past 4×TTL) → the SAME pane ages to lost, same instance, no
+        // re-seat. Production driver: startFreshnessAging()'s timer re-runs applyPaneFreshness off the
+        // live Date.now(); here the injected clock advances deterministically through afterSetNow.
+        const beforeId = detail.id;
+        detail.now = Date.parse('2026-07-12T00:05:00.000Z');
+        expect(detail.id).toBe(beforeId);
+        expect(chip(detail, 'lane').cls).toContain('is-lost');
 
         detail.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/agentFreshness.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentFreshness.spec.mjs
@@ -1,0 +1,113 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'AgentFreshnessTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+import {classifyPaneFreshness, describePaneFreshness, FRESHNESS_CLASSES} from '../../../../../../../apps/agentos/view/fleet/agentFreshness.mjs';
+
+/**
+ * @summary Tests for the FM cockpit detail-pane freshness ledger — the render-correctness
+ * render-correctness contract at pane grain: a real observation classifies fresh/stale/lost by
+ * age vs its TTL, and anything we cannot place in time degrades to the honest `unobserved`, never
+ * a fabricated current claim. `now` is injected + pinned so the contract is deterministic (no
+ * clock-brittle `new Date()`).
+ */
+test.describe('agentFreshness — pane freshness ledger, pure + now-injected (#14608)', () => {
+    // a fixed clock + a 30s TTL; every observation below is a fixed offset from NOW
+    const
+        NOW = Date.parse('2026-07-12T00:00:00.000Z'),
+        TTL = 30_000;
+
+    test('classify: an observation within its TTL is fresh and carries its age', () => {
+        // 10s old, ttl 30s → fresh
+        const result = classifyPaneFreshness({observedAt: '2026-07-11T23:59:50.000Z', freshnessTtl: TTL}, NOW);
+        expect(result).toEqual({freshness: 'fresh', observedAt: '2026-07-11T23:59:50.000Z', ageMs: 10_000});
+
+        // the boundary is inclusive: age === TTL is still fresh
+        expect(classifyPaneFreshness({observedAt: '2026-07-11T23:59:30.000Z', freshnessTtl: TTL}, NOW).freshness).toBe('fresh')
+    });
+
+    test('classify: past the TTL is stale, past LOST_TTL_FACTOR×TTL is lost — both boundaries inclusive-toward-stale', () => {
+        // 90s old (30s < 90s ≤ 120s) → stale
+        expect(classifyPaneFreshness({observedAt: '2026-07-11T23:58:30.000Z', freshnessTtl: TTL}, NOW).freshness).toBe('stale');
+        // exactly 4×TTL (120s) → still stale (inclusive)
+        expect(classifyPaneFreshness({observedAt: '2026-07-11T23:58:00.000Z', freshnessTtl: TTL}, NOW).freshness).toBe('stale');
+        // 200s old (> 120s) → lost
+        expect(classifyPaneFreshness({observedAt: '2026-07-11T23:56:40.000Z', freshnessTtl: TTL}, NOW).freshness).toBe('lost')
+    });
+
+    test('classify: an explicit source-reported loss is lost regardless of age', () => {
+        // a brand-new observation the source flagged as lost still reads lost — the source wins
+        const result = classifyPaneFreshness({observedAt: '2026-07-11T23:59:59.000Z', freshnessTtl: TTL, lost: true}, NOW);
+        expect(result).toEqual({freshness: 'lost', observedAt: '2026-07-11T23:59:59.000Z', ageMs: null})
+    });
+
+    test('classify: a future/clock-skewed observation clamps to fresh, never a false stale', () => {
+        // observed 5s AFTER now (negative age) → fresh, age preserved as negative for the renderer to clamp
+        const result = classifyPaneFreshness({observedAt: '2026-07-12T00:00:05.000Z', freshnessTtl: TTL}, NOW);
+        expect(result.freshness).toBe('fresh');
+        expect(result.ageMs).toBe(-5_000)
+    });
+
+    test('classify: anything unplaceable in time degrades to unobserved — never a current claim', () => {
+        const cases = [
+            {label: 'no observedAt',        ledger: {freshnessTtl: TTL},                                              now: NOW},
+            {label: 'no freshnessTtl',      ledger: {observedAt: '2026-07-11T23:59:50.000Z'},                         now: NOW},
+            {label: 'ttl not positive',     ledger: {observedAt: '2026-07-11T23:59:50.000Z', freshnessTtl: 0},       now: NOW},
+            {label: 'no now',               ledger: {observedAt: '2026-07-11T23:59:50.000Z', freshnessTtl: TTL},     now: null},
+            {label: 'unparseable observed', ledger: {observedAt: 'not-a-timestamp',           freshnessTtl: TTL},     now: NOW},
+            {label: 'non-object ledger',    ledger: null,                                                             now: NOW},
+            {label: 'array ledger',         ledger: [],                                                               now: NOW}
+        ];
+
+        for (const {label, ledger, now} of cases) {
+            expect(classifyPaneFreshness(ledger, now).freshness, label).toBe('unobserved')
+        }
+    });
+
+    test('describe: each class renders its own cls token + honest label (fresh/stale show the age)', () => {
+        expect(describePaneFreshness({freshness: 'fresh', ageMs: 12_000})).toEqual({
+            freshness: 'fresh', cls: ['fm-freshness', 'is-fresh'], label: 'updated 12s ago'
+        });
+        expect(describePaneFreshness({freshness: 'stale', ageMs: 90_000})).toEqual({
+            freshness: 'stale', cls: ['fm-freshness', 'is-stale'], label: 'stale · last seen 1m ago'
+        });
+        expect(describePaneFreshness({freshness: 'lost', ageMs: null})).toEqual({
+            freshness: 'lost', cls: ['fm-freshness', 'is-lost'], label: 'lost — no recent observation'
+        });
+        // unobserved (and any unknown/empty input) is the honest, never-blank default
+        expect(describePaneFreshness({freshness: 'unobserved'})).toEqual({
+            freshness: 'unobserved', cls: ['fm-freshness', 'is-unobserved'], label: 'not observed — source not wired'
+        });
+        expect(describePaneFreshness().freshness).toBe('unobserved')
+    });
+
+    test('describe: fresh with no measurable age reads "live"; the age formatter spans s/m/h/d and clamps the future', () => {
+        expect(describePaneFreshness({freshness: 'fresh', ageMs: null}).label).toBe('live');
+        expect(describePaneFreshness({freshness: 'fresh', ageMs: 45_000}).label).toBe('updated 45s ago');
+        expect(describePaneFreshness({freshness: 'fresh', ageMs: 5 * 60_000}).label).toBe('updated 5m ago');
+        expect(describePaneFreshness({freshness: 'fresh', ageMs: 3 * 3_600_000}).label).toBe('updated 3h ago');
+        expect(describePaneFreshness({freshness: 'fresh', ageMs: 2 * 86_400_000}).label).toBe('updated 2d ago');
+        // a negative (future/skew) age never renders a nonsensical future time
+        expect(describePaneFreshness({freshness: 'fresh', ageMs: -5_000}).label).toBe('updated 0s ago')
+    });
+
+    test('the freshness vocabulary is a frozen closed set', () => {
+        expect(FRESHNESS_CLASSES).toEqual(['fresh', 'stale', 'lost', 'unobserved']);
+        expect(Object.isFrozen(FRESHNESS_CLASSES)).toBe(true)
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -475,6 +475,31 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
 
         store.destroy()
     });
+
+    test('onDetailRecordChange routes a roster mutation of the inspected agent to the detail — reactive to record MUTATION, not just a re-seat', () => {
+        const
+            record  = {agentId: 'vega'},
+            applied = [],
+            detail  = {applyRecord() { applied.push(true) }},
+            host    = Object.create(FleetCockpit.prototype);
+
+        host.detailRecord = record;
+        host.getReference = name => name === 'agent-detail' ? detail : null;
+
+        // a recordChange for the INSPECTED record re-renders the detail in place — a roster re-poll
+        // mutating state/lane/sources on the open agent must never leave a stale inspector
+        FleetCockpit.prototype.onDetailRecordChange.call(host, {record});
+        expect(applied).toEqual([true]);
+
+        // a recordChange for a DIFFERENT record is ignored — no needless re-render
+        FleetCockpit.prototype.onDetailRecordChange.call(host, {record: {agentId: 'ada'}});
+        expect(applied).toEqual([true]);
+
+        // detail not mounted (auto-hidden, not yet revealed) → the optional chain no-ops safely
+        host.getReference = () => null;
+        FleetCockpit.prototype.onDetailRecordChange.call(host, {record});
+        expect(applied).toEqual([true])
+    });
 });
 
 test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -701,6 +701,60 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
         expect(calls.length).toBe(1)   // three residents started, ONE roster re-poll — never N polls
     });
 
+    test('onAgentSelect: a card select holds the owner-side detailRecord + reveals the auto-hidden inspector through the commit loop', () => {
+        const
+            record  = {agentId: 'vega', displayName: 'Vega'},
+            detail  = {record: null, set(cfg) { Object.assign(this, cfg) }},
+            applied = [],
+            cockpit = {
+                detailRecord: null,
+                dockModel   : {items: {detail: {autoHidden: true}}},
+                applyDockZoneOperation(op) { applied.push(op); return {document: {revealed: true}, errors: []} },
+                onDockZoneDocumentChange(doc) { this.committed = doc }
+            },
+            controller = Object.create(FleetCockpitController.prototype);
+
+        controller.component    = cockpit;
+        controller.getReference = name => name === 'fleet-grid' ? {store: {get: id => id === 'vega' ? record : null}} : name === 'agent-detail' ? detail : null;
+
+        controller.onAgentSelect({agentId: 'vega'});
+
+        // owner-held selection (survives a later re-projection — resolveDockComponentRef reads it) +
+        // the live pane updated in place
+        expect(cockpit.detailRecord).toBe(record);
+        expect(detail.record).toBe(record);
+        // the auto-hidden inspector is revealed through the standard commit loop, not a bespoke path
+        expect(applied).toEqual([{operation: 'setItemAutoHidden', itemId: 'detail', autoHidden: false}]);
+        expect(cockpit.committed).toEqual({revealed: true})
+    });
+
+    test('onAgentSelect: an already-revealed inspector updates in place (no re-projection); an unknown agent is a fail-closed no-op', () => {
+        const
+            record  = {agentId: 'ada'},
+            detail  = {record: null, set(cfg) { Object.assign(this, cfg) }},
+            applied = [],
+            cockpit = {
+                detailRecord: null,
+                dockModel   : {items: {detail: {autoHidden: false}}},   // already revealed
+                applyDockZoneOperation(op) { applied.push(op); return {document: {}, errors: []} },
+                onDockZoneDocumentChange() { this.reprojected = true }
+            },
+            controller = Object.create(FleetCockpitController.prototype);
+
+        controller.component    = cockpit;
+        controller.getReference = name => name === 'fleet-grid' ? {store: {get: id => id === 'ada' ? record : null}} : name === 'agent-detail' ? detail : null;
+
+        controller.onAgentSelect({agentId: 'ada'});
+        expect(cockpit.detailRecord).toBe(record);
+        expect(detail.record).toBe(record);
+        expect(applied).toEqual([]);                  // already revealed → no reveal op...
+        expect(cockpit.reprojected).toBeUndefined();  // ...and no full re-projection
+
+        // unknown agentId → fail-closed no-op, the selection stands
+        controller.onAgentSelect({agentId: 'ghost'});
+        expect(cockpit.detailRecord).toBe(record)
+    });
+
     // The composition-root binding witness: not "loadRoster was called" (the spy tests above) but
     // "reconciliation reaches the RECORD". Assembles the REAL path end to end — the real controller
     // onAgentLifecycleIntent, the real C2 adapter, a stateful bridge whose `fleetRoster` reflects the

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -930,16 +930,20 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
         // a REAL store the REAL loadRoster reconciles into — the record is the card's data surface
         const store   = Neo.create(Store, {keyProperty: 'agentId', model: FleetAgent});
         const cockpit = {
-            getReference   : reference => reference === 'fleet-grid' ? {adapterState: 'sample', store} : null,
-            mapRosterRow   : FleetCockpit.prototype.mapRosterRow,
-            reconcileRoster: FleetCockpit.prototype.reconcileRoster,
-            loadRoster     : FleetCockpit.prototype.loadRoster,
-            rosterWired    : false
+            getReference      : reference => reference === 'fleet-grid' ? {adapterState: 'sample', store} : null,
+            mapRosterRow      : FleetCockpit.prototype.mapRosterRow,
+            reconcileRoster   : FleetCockpit.prototype.reconcileRoster,
+            reconcileSelection: FleetCockpit.prototype.reconcileSelection,
+            loadRoster        : FleetCockpit.prototype.loadRoster,
+            rosterWired       : false
         };
 
         // boot: the real loadRoster reads the bridge — the agent is stopped, so the record resolves to 'off'
         await cockpit.loadRoster();
         expect(store.get('vega').state).toBe('off');
+        // success-state proof: the load COMPLETED (reached the post-reconcile adapter-state assignment), not
+        // merely mutated the record before a swallowed missing-reconcileSelection error (Euclid's falsifier)
+        expect(cockpit.gridAdapterState).toBe('live');
 
         // drive the REAL controller path for that record — real onAgentLifecycleIntent -> real adapter ->
         // bridge.startAgent -> refreshRosterOnSettle -> real loadRoster -> reconcile
@@ -957,6 +961,8 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
 
         // the binding witness: the SAME real record advanced off -> ok through reconciliation, no reload/rebuild
         expect(store.get('vega').state).toBe('ok');
+        // and the re-poll load COMPLETED too (reconcile phase reached success state, not a swallowed error)
+        expect(cockpit.gridAdapterState).toBe('live');
 
         store.destroy()
     })

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -500,6 +500,54 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         FleetCockpit.prototype.onDetailRecordChange.call(host, {record});
         expect(applied).toEqual([true])
     });
+
+    test('reconcileSelection re-seats or clears the owner-held selection on authoritative membership changes', () => {
+        const
+            setCalls = [],
+            detail   = {set(config) { setCalls.push(config) }},
+            makeHost = (detailRecord, storeGet) => {
+                const host = Object.create(FleetCockpit.prototype);
+
+                host.detailRecord = detailRecord;
+                host.getReference = name =>
+                    name === 'fleet-grid'   ? {store: {get: storeGet}} :
+                    name === 'agent-detail' ? detail : null;
+
+                return host
+            };
+
+        // (1) the inspected resident is REMOVED (absent from the authoritative snapshot / empty
+        //     snapshot) → clear the selection to the honest empty state (Store.remove fires no recordChange)
+        setCalls.length = 0;
+        const removedHost = makeHost({agentId: 'vega'}, () => undefined);
+        FleetCockpit.prototype.reconcileSelection.call(removedHost);
+        expect(removedHost.detailRecord).toBeNull();
+        expect(setCalls).toEqual([{record: null}]);
+
+        // (2) the resident survives as the SAME instance (in-place record.set reconcile) → no re-seat;
+        //     the mutation path (recordChange → applyRecord) already keeps the inspector truthful
+        setCalls.length = 0;
+        const same     = {agentId: 'vega'};
+        const sameHost = makeHost(same, id => id === 'vega' ? same : undefined);
+        FleetCockpit.prototype.reconcileSelection.call(sameHost);
+        expect(sameHost.detailRecord).toBe(same);
+        expect(setCalls).toEqual([]);
+
+        // (3) the durable agentId survives as a NEW instance (first-live clear+add replace of the sample
+        //     seed) → re-seat detailRecord onto the live instance and re-render
+        setCalls.length = 0;
+        const stale      = {agentId: 'vega'}, fresh = {agentId: 'vega'};
+        const reseatHost = makeHost(stale, id => id === 'vega' ? fresh : undefined);
+        FleetCockpit.prototype.reconcileSelection.call(reseatHost);
+        expect(reseatHost.detailRecord).toBe(fresh);
+        expect(setCalls).toEqual([{record: fresh}]);
+
+        // (4) nothing selected → no-op, and the Store is never touched
+        setCalls.length = 0;
+        const noneHost = makeHost(null, () => { throw new Error('store must not be touched when nothing is selected') });
+        FleetCockpit.prototype.reconcileSelection.call(noneHost);
+        expect(setCalls).toEqual([])
+    });
 });
 
 test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -154,9 +154,10 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
     };
 
     const makeCockpit = (grid, rosterWired = false) => ({
-        getReference   : reference => reference === 'fleet-grid' ? grid : null,
-        mapRosterRow   : FleetCockpit.prototype.mapRosterRow,
-        reconcileRoster: FleetCockpit.prototype.reconcileRoster,
+        getReference      : reference => reference === 'fleet-grid' ? grid : null,
+        mapRosterRow      : FleetCockpit.prototype.mapRosterRow,
+        reconcileRoster   : FleetCockpit.prototype.reconcileRoster,
+        reconcileSelection: FleetCockpit.prototype.reconcileSelection,
         rosterWired
     });
 
@@ -384,19 +385,20 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
     // listener attached (the store fires `load` for its own mutations, so the guard's recursion
     // behavior is only observable through the live listener path — a manual handler call is a
     // mock-hole).
-    const makeLiveCockpit = (store, index) => {
+    const makeLiveCockpit = (store, index, detail = null) => {
         const grid = {adapterState: 'sample', store};
 
         const cockpit = {
-            getReference     : reference => reference === 'fleet-grid' ? grid : null,
+            getReference      : reference => reference === 'fleet-grid' ? grid : reference === 'agent-detail' ? detail : null,
             grid,
-            id               : `fake-fleet-cockpit-${index}`,
-            lastLiveRows     : null,
-            mapRosterRow     : FleetCockpit.prototype.mapRosterRow,
-            onRosterStoreLoad: FleetCockpit.prototype.onRosterStoreLoad,
-            reconcileRoster  : FleetCockpit.prototype.reconcileRoster,
-            reconcilingRoster: false,
-            rosterWired      : false
+            id                : `fake-fleet-cockpit-${index}`,
+            lastLiveRows      : null,
+            mapRosterRow      : FleetCockpit.prototype.mapRosterRow,
+            onRosterStoreLoad : FleetCockpit.prototype.onRosterStoreLoad,
+            reconcileRoster   : FleetCockpit.prototype.reconcileRoster,
+            reconcileSelection: FleetCockpit.prototype.reconcileSelection,
+            reconcilingRoster : false,
+            rosterWired       : false
         };
 
         store.on({load: cockpit.onRosterStoreLoad, scope: cockpit});
@@ -472,6 +474,79 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         expect(store.get('agent-0')).toBeTruthy();
         expect(store.get('agent-999')).toBeTruthy();
         expect(store.get('sample-1')).toBeFalsy();
+
+        store.destroy()
+    });
+
+    test('reconcileSelection (real Store): first-live clear/add re-seats a surviving selection onto the new instance', async () => {
+        const store    = Neo.create(FleetRoster, {data: []}),
+              setCalls = [],
+              detail   = {set(config) { setCalls.push(config) }},
+              cockpit  = makeLiveCockpit(store, 4, detail);
+
+        // a sample 'vega' is open in the inspector before live truth resolves
+        store.add([{agentId: 'vega'}, {agentId: 'sample-x'}]);
+        cockpit.detailRecord = store.get('vega');
+        const sampleInstance = cockpit.detailRecord;
+
+        globalThis.AgentOS = {fleet: {registryBridge: {fleetRoster: async () => ({rows: [
+            {id: 'vega', family: 'claude', lifecycle: {state: 'running'}},
+            {id: 'ada',  family: 'claude', lifecycle: {state: 'stopped'}}
+        ]})}}};
+
+        await FleetCockpit.prototype.loadRoster.call(cockpit);   // first-live clear+add replaces the seed
+
+        const liveInstance = store.get('vega');
+        expect(liveInstance).toBeTruthy();
+        expect(liveInstance).not.toBe(sampleInstance);           // a genuinely new record instance
+        expect(cockpit.detailRecord).toBe(liveInstance);         // re-seated onto the live instance
+        expect(setCalls).toEqual([{record: liveInstance}]);      // the inspector re-rendered
+
+        store.destroy()
+    });
+
+    test('reconcileSelection (real Store): a later empty snapshot clears a removed resident to the honest empty state', async () => {
+        const store    = Neo.create(FleetRoster, {data: []}),
+              setCalls = [],
+              detail   = {set(config) { setCalls.push(config) }},
+              cockpit  = makeLiveCockpit(store, 5, detail);
+
+        cockpit.rosterWired = true;                              // past the first-live replacement
+        store.add([{agentId: 'vega'}, {agentId: 'ada'}]);
+        cockpit.detailRecord = store.get('vega');
+
+        globalThis.AgentOS = {fleet: {registryBridge: {fleetRoster: async () => ({rows: []})}}};
+
+        await FleetCockpit.prototype.loadRoster.call(cockpit);   // authoritative empty snapshot → real Store.remove
+
+        expect(store.get('vega')).toBeFalsy();                   // removed via the real Store path
+        expect(cockpit.detailRecord).toBeNull();                // selection cleared
+        expect(setCalls).toEqual([{record: null}]);             // AgentDetail → honest empty state
+
+        store.destroy()
+    });
+
+    test('reconcileSelection (real Store): a surviving same-instance reconcile is a no-op (mutation path owns it)', async () => {
+        const store    = Neo.create(FleetRoster, {data: []}),
+              setCalls = [],
+              detail   = {set(config) { setCalls.push(config) }},
+              cockpit  = makeLiveCockpit(store, 6, detail);
+
+        cockpit.rosterWired = true;
+        store.add([{agentId: 'vega'}, {agentId: 'ada'}]);
+        cockpit.detailRecord = store.get('vega');
+        const instance = cockpit.detailRecord;
+
+        globalThis.AgentOS = {fleet: {registryBridge: {fleetRoster: async () => ({rows: [
+            {id: 'vega', family: 'claude', lifecycle: {state: 'running'}},
+            {id: 'ada',  family: 'claude', lifecycle: {state: 'stopped'}}
+        ]})}}};
+
+        await FleetCockpit.prototype.loadRoster.call(cockpit);   // reconcile: record.set mutates in place (same object)
+
+        expect(store.get('vega')).toBe(instance);               // same instance, mutated in place
+        expect(cockpit.detailRecord).toBe(instance);            // selection unchanged
+        expect(setCalls).toEqual([]);                           // no re-seat — recordChange owns mutation
 
         store.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
@@ -27,7 +27,7 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
  * docking design's pane contract, and owner-held pane state surviving re-projection.
  */
 test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)', () => {
-    let ActivityStream, DockZoneModel, FleetCockpit, FleetGrid, cockpitDockDocument;
+    let ActivityStream, AgentDetail, DockZoneModel, FleetCockpit, FleetGrid, cockpitDockDocument;
 
     // a projection-capable spy owner: the REAL prototype methods over controlled state, without
     // provider/store/bridge wiring (their routing has its own suite in fleetCockpit.spec.mjs)
@@ -49,6 +49,7 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
 
     test.beforeAll(async () => {
         ActivityStream      = (await import('../../../../../../../apps/agentos/view/fleet/ActivityStream.mjs')).default;
+        AgentDetail         = (await import('../../../../../../../apps/agentos/view/fleet/AgentDetail.mjs')).default;
         DockZoneModel       = (await import('../../../../../../../src/dashboard/DockZoneModel.mjs')).default;
         FleetCockpit        = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default;
         FleetGrid           = (await import('../../../../../../../apps/agentos/view/fleet/FleetGrid.mjs')).default;
@@ -132,7 +133,7 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
     });
 
     test('panes are layout-blind (§2.6) and re-materialize from OWNER-held state — a re-projection can never reset a live surface', () => {
-        const host = makeHost({gridAdapterState: 'live', streamAdapterState: 'stale', streamEvents: [{type: 'pr-activity', payload: {text: 'held'}}]});
+        const host = makeHost({gridAdapterState: 'live', streamAdapterState: 'stale', streamEvents: [{type: 'pr-activity', payload: {text: 'held'}}], detailRecord: {agentId: 'vega', displayName: 'Vega'}});
 
         const grid = FleetCockpit.prototype.resolveDockComponentRef.call(host, 'fleet-grid', {title: 'Fleet'}, 'fleet');
 
@@ -148,19 +149,27 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
         expect(stream.events).toEqual(host.streamEvents);
         expect(stream.cls).toContain('dock-flip-item-stream');
 
+        // agent-detail now renders the real drill-in view, re-materialized from OWNER-held state
+        // (the selected record) so a committed re-projection never drops the selection
+        const detail = FleetCockpit.prototype.resolveDockComponentRef.call(host, 'agent-detail', {title: 'Agent detail'}, 'detail');
+
+        expect(detail.module).toBe(AgentDetail);
+        expect(detail.record).toBe(host.detailRecord);   // owner-held selection survives re-projection
+        expect(detail.cls).toContain('dock-flip-item-detail');
+
         // §2.6 layout-blind: NOTHING dock-specific reaches a pane config beyond the marker class
-        for (const pane of [grid, stream]) {
+        for (const pane of [grid, stream, detail]) {
             for (const forbidden of ['applyDockZoneOperation', 'onDockZoneDocumentChange', 'onDockCrossZoneDrop', 'dockZoneDocument', 'dockNodeId']) {
                 expect(pane[forbidden], `a pane config must not carry ${forbidden}`).toBeUndefined()
             }
         }
 
-        // sibling-leaf refs render an HONEST labelled placeholder, never a blank pane
-        const detail = FleetCockpit.prototype.resolveDockComponentRef.call(host, 'agent-detail', {title: 'Agent detail'}, 'detail');
+        // perspectives remains a sibling-leaf placeholder — an HONEST labelled pane, never a blank one
+        const perspectives = FleetCockpit.prototype.resolveDockComponentRef.call(host, 'perspectives', {title: 'Perspectives'}, 'perspectives');
 
-        expect(detail.cls).toContain('fm-pane-placeholder');
-        expect(detail.cls).toContain('dock-flip-item-detail');
-        expect(detail.html).toContain('Agent detail')
+        expect(perspectives.cls).toContain('fm-pane-placeholder');
+        expect(perspectives.cls).toContain('dock-flip-item-perspectives');
+        expect(perspectives.html).toContain('Perspectives')
     });
 
     test('the projected tree renders the document\'s zones: both live panes present, exactly once each', () => {


### PR DESCRIPTION
Resolves #14608

The T4 drill-in surface of Epic #14560 — click an agent card → the resident's detail (an identity header over the thought-stream / lane / repo / PRs panes). Evidence: L2 (unit — view render rules, the pure freshness contract, the card→detail drill seam, and owner-held selection reconciliation, all in the custom playwright config) **+ L3** (the card→detail live drill over a real DOM click, possessed via the Neural Link, asserting the mounted inspector holds the **exact** clicked resident — `FleetCockpitDrillNL.spec.mjs`, 1/1 at head `ff2ac6def`). The remaining pop-out → reattach round-trip is the dedicated #14613 leaf (it needs the #14610 pop-out) — the same view-leaf / e2e-leaf split as #14606 (ActivityStream) / #14607 (its burst e2e).

## What it delivers
- **`agentFreshness.mjs`** — the pure freshness-ledger core: `classifyPaneFreshness` / `describePaneFreshness`, `now`-injected (no clock-brittle `new Date()`), fail-closed to `unobserved`. A claim with no live observation renders honestly as not-observed, **never silently current**; a real observation classifies fresh / stale / lost by age vs its TTL.
- **`AgentDetail.mjs`** — the view: an identity header (displayName as mutable **display state over the durable `agentId`**, engineTag as session-metadata, family rebind **in place** on a swap, **no role fields**, participationStatus as availability) + four freshness-labeled panes that degrade honestly until the Lane-C / memory-surface feeds wire `observedAt`. Null record → an honest "select an agent" empty state.
- **Drill-in** — a card **body-click** (delegate excludes the control cluster) fires `agentSelect`; `FleetCockpitController.onAgentSelect` resolves the record from the roster store, holds it as the owner-side `detailRecord` (re-projection-safe), and reveals the auto-hidden inspector through the **dock commit loop** (`setItemAutoHidden` on first reveal; in-place update after — no full re-projection on later selects).
- **`AgentDetail.scss`** — token-only styling; freshness tones reuse the ActivityStream adapter-state token precedent; zero CSS-in-JS; theme-build-verified.

**Render governance:** this is the cockpit's first drill-in consumer of the institution-cockpit render model — object-permanent self with identity anti-lock-in (name ≠ key, no role-typing, family/engine as episode metadata) and the freshness/authority ledger (observedAt + freshness; stale renders **as** stale). Consumed layout-blind (no dock / Electron coupling reaches the view) so the #14610 pop-out reparents it cleanly.

## Test Evidence
- Unit (custom no-webServer config, `--workers=1`): `agentFreshness` 8, `agentDetail` 10, `agentCard` (drill-select carve-out), `fleetCockpit` **33/33** at head `fc067a7ed` (incl. `onAgentSelect` ×2, the isolated `reconcileSelection` branching, and **three REAL FleetRoster witnesses** — first-live re-seat onto the new instance, empty-snapshot clear to the honest empty state, same-instance reconcile no-op — plus host-family parity for the new method), `fleetGrid`, `fleetCockpitProjection` (updated).
- Whitebox NL-e2e (`FleetCockpitDrillNL.spec.mjs`, `playwright.config.e2e.mjs`, fresh own-clone server): **1/1** (verified at `ff2ac6def`; unchanged through `fc067a7ed`, which touches only the unit spec) — a real DOM click on the pinned card's avatar reveals the inspector, renders the 4 SSOT panes, and the possessed `AgentDetail` record's `agentId` **equals** the exact clicked card's id (equality, not set-membership).
- `node buildScripts/build/themes.mjs -f -n -e dev` — `AgentDetail.scss` compiles (exit 0).
- `node --check` + ticket-archaeology + block-alignment + whitespace — clean (pre-commit hooks green).

## Post-Merge Validation
- [x] The card→detail live NL-e2e drill lands **in this PR** (`FleetCockpitDrillNL.spec.mjs`, exact-id witness, 1/1 on a fresh server). The pop-out → reattach round-trip remains #14613 (it needs the #14610 pop-out). Re-run trigger: changes to the `agentSelect` seam, the dock reveal path, or the roster reconcile.

## Deltas
- The `agent-detail` dock pane, previously a labelled placeholder in `FleetCockpit.resolveDockComponentRef`, now renders the real view; `fleetCockpitProjection.spec` updated (the placeholder assertion moved to `perspectives`, which remains a sibling-leaf placeholder).
- The card→detail NL-verify lands here (the exact-id live drill); only the pop-out → reattach round-trip stays with #14613 per the view/e2e-split precedent.
- **Review cycle (Euclid, exact head):** owner-held selection now reconciles on authoritative roster **membership** changes — `reconcileSelection` re-seats `detailRecord` onto the Store's current instance when the durable `agentId` survives, and clears to the honest empty state when it is removed (`Store.remove` fires no `recordChange`, so mutation reactivity did not cover it); and the L3 witness now asserts the **exact** clicked identity.

Authored by Vega (Claude Opus 4.8, Claude Code). Session d99146da-0478-4f23-bc16-dff04f5d650c.

