### PR TITLE
fix(wake): disambiguate parallel Codex residents (#15054)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -38,7 +38,6 @@ import {WAKE_LANE_DIRECTIVE} from './wakeLaneDirective.mjs';
 import fs                               from 'fs-extra';
 import path                             from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { constants as fsConstants }     from 'fs';
 import { spawn, execSync }              from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -60,7 +59,7 @@ import {
 } from '../../scripts/lifecycle/harnessRouting.mjs';
 import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
 import {
-    getDefaultInstancePid,
+    getDefaultInstanceTarget,
     resolveGuiInstancePid
 } from './instanceResolver.mjs';
 import {HEARTBEAT_PULSE_ENTITY_TYPE, match} from '../../services/memory-core/heartbeatPulseEvaluator.mjs';
@@ -84,7 +83,6 @@ const LOG_RETENTION_DAYS                = 30;
 const POLL_INTERVAL_MS                  = 3000;
 const DEFAULT_COALESCE_WINDOW_MS        = 30000; // 30 seconds
 const CODEX_APP_SERVER_ADAPTER          = 'codex-app-server';
-const DEFAULT_CODEX_DESKTOP_CLI_PATH    = '/Applications/Codex.app/Contents/Resources/codex';
 const CODEX_TURN_START_PROOF_TIMEOUT_MS = Number(process.env.WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS) || 45000;
 const CODEX_TURN_START_PROOF_POLL_MS    = Number(process.env.WAKE_CODEX_TURN_START_PROOF_POLL_MS) || 1000;
 const CODEX_WAKE_SUBMIT_NONCE_PREFIX    = 'NEO_WAKE_SUBMIT_NONCE:';
@@ -780,37 +778,6 @@ function spawnAsync(command, args) {
 }
 
 /**
- * @summary Resolves the Codex CLI used by the app-server wake adapter.
- *
- * `CODEX_CLI_PATH` mirrors the resume-harness test hook and always wins. When
- * unset on macOS, the daemon probes the Codex Desktop bundled CLI path because
- * launchd / daemon environments often lack the user's interactive shell PATH.
- *
- * @returns {String}
- */
-function resolveCodexCliPath() {
-    if (process.env.CODEX_CLI_PATH) return process.env.CODEX_CLI_PATH;
-    const desktopCliPath = process.env.CODEX_DESKTOP_CLI_PATH || DEFAULT_CODEX_DESKTOP_CLI_PATH;
-    if (process.platform === 'darwin' && fileIsExecutableSync(desktopCliPath)) return desktopCliPath;
-    return 'codex';
-}
-
-/**
- * @summary Checks whether a file exists and can be executed.
- *
- * @param {String} filePath
- * @returns {Boolean}
- */
-function fileIsExecutableSync(filePath) {
-    try {
-        fs.accessSync(filePath, fsConstants.X_OK);
-        return true;
-    } catch (err) {
-        return false;
-    }
-}
-
-/**
  * @summary Dispatches a Codex wake digest through the native Codex app-server control plane.
  *
  * This is the explicit wake-daemon route for subscriptions configured as
@@ -836,7 +803,7 @@ async function deliverViaCodexAppServer(subscription, digest, evidenceLabel = ''
         throw new Error(`codex-app-server requires harnessTargetMetadata.appName='Codex' (received '${appName || ''}')`);
     }
 
-    await spawnAsync(resolveCodexCliPath(), ['debug', 'app-server', 'send-message-v2', digest]);
+    await spawnAsync(AiConfig.fleet.harnessBinaries.codex, ['debug', 'app-server', 'send-message-v2', digest]);
     writeLog('INFO', `[Wake Daemon] Dispatched ${subscription.id} via codex-app-server send-message-v2${evidenceLabel}`);
 }
 
@@ -1290,9 +1257,22 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}) {
                 // never carry --user-data-dir without breaking its system app / menu-bar integration).
                 // When a same-bundle sibling instance is running, "activate + frontmost" is ambiguous;
                 // the default is uniquely identifiable by the ABSENCE of the flag, so target its pid
-                // directly. Returns null for single-instance (or ambiguous) — the legacy activate path
-                // below is then kept unchanged, so single-instance behavior is untouched.
-                instancePid = await getDefaultInstancePid({appName});
+                // directly. A proven arg-less singleton or no matching process keeps the legacy
+                // activate path; addressed-only, ambiguous, and probe-failed states fail closed
+                // instead of guessing which window should receive destructive composer keystrokes.
+                const defaultTarget = await getDefaultInstanceTarget({appName});
+
+                if (defaultTarget.status === 'ambiguous' || defaultTarget.status === 'probe-failed') {
+                    writeLog('ERROR',
+                        `[Wake Daemon] Default-instance wake refused for ${subscription.id}: ` +
+                        `process resolution status=${defaultTarget.status}; found ${defaultTarget.instanceCount} ` +
+                        `${defaultTarget.bundleName}.app main processes without exactly one arg-less default. ` +
+                        'Failing closed to avoid wrong-resident delivery.'
+                    );
+                    return;
+                }
+
+                instancePid = defaultTarget.pid;
             }
 
             // [Anchor & Echo] The Electron-Paradox Defense:

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -68,8 +68,13 @@ import {
     isHeavyDeltaPoll,
     shouldDeferFlush
 } from './flushDeferPolicy.mjs';
-import {clampWatermark, filterEventsByWatermark, maxLogId} from './wokenWatermark.mjs';
-import {IDENTITIES}                                        from '../../graph/identityRoots.mjs';
+import {
+    claimUnwokenMessages,
+    clampWatermark,
+    filterEventsByWatermark,
+    maxLogId
+} from './wokenWatermark.mjs';
+import {IDENTITIES} from '../../graph/identityRoots.mjs';
 
 // Config-derived paths + PID_FILE (below) are declared here but ASSIGNED in initConfigDerivedState()
 // (called from the guarded main(), never at module-load): a stale memory-core overlay would otherwise
@@ -86,6 +91,7 @@ const CODEX_APP_SERVER_ADAPTER          = 'codex-app-server';
 const CODEX_TURN_START_PROOF_TIMEOUT_MS = Number(process.env.WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS) || 45000;
 const CODEX_TURN_START_PROOF_POLL_MS    = Number(process.env.WAKE_CODEX_TURN_START_PROOF_POLL_MS) || 1000;
 const CODEX_WAKE_SUBMIT_NONCE_PREFIX    = 'NEO_WAKE_SUBMIT_NONCE:';
+const WOKEN_MESSAGE_IDS_STATE_KEY       = '__messageIdsByIdentity';
 const WAKE_PRIORITY_RANKS               = {
     low   : 0,
     normal: 1,
@@ -102,32 +108,84 @@ const identityParticipationById = new Map(
 );
 
 /**
- * @summary Loads the persisted per-subscription woken-watermark map, tolerant of a missing or
- * corrupt file (a fresh daemon starts with an empty map → first wakes fire normally).
- * @returns {Object<String, Number>}
+ * @summary Loads durable GraphLog watermarks plus stable per-identity message wake claims.
+ *
+ * Legacy files contain only top-level `subscriptionId: logId` pairs. The reserved
+ * `__messageIdsByIdentity` key extends that shape without invalidating older daemon readers: they
+ * preserve the unknown object while continuing to consume the numeric subscription keys.
+ *
+ * @returns {{watermarks: Object<String, Number>, messageIdsByIdentity: Map<String, Set<String>>}}
  */
-function loadWokenWatermark() {
+function loadWokenState() {
     try {
         if (fs.existsSync(WOKEN_WATERMARK_FILE)) {
             const parsed = JSON.parse(fs.readFileSync(WOKEN_WATERMARK_FILE, 'utf8'));
-            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+            if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                const rawHistory = parsed[WOKEN_MESSAGE_IDS_STATE_KEY];
+                delete parsed[WOKEN_MESSAGE_IDS_STATE_KEY];
+
+                const messageIdsByIdentity = new Map();
+                if (rawHistory && typeof rawHistory === 'object' && !Array.isArray(rawHistory)) {
+                    for (const [identity, messageIds] of Object.entries(rawHistory)) {
+                        if (Array.isArray(messageIds)) {
+                            messageIdsByIdentity.set(identity, new Set(messageIds.filter(Boolean)));
+                        }
+                    }
+                }
+
+                return {watermarks: parsed, messageIdsByIdentity};
+            }
         }
     } catch (e) {
-        // Corrupt watermark is non-fatal: worst case is one cycle of already-woken backlog being
-        // re-counted, self-healing as the map re-persists. Daemon liveness never gates on it.
+        // Corrupt state is non-fatal: worst case is one cycle of already-woken backlog being
+        // re-counted, self-healing as the state re-persists. Daemon liveness never gates on it.
     }
-    return {};
+    return {watermarks: {}, messageIdsByIdentity: new Map()};
 }
 
 /**
- * @summary Best-effort persist of the woken-watermark map (mirrors the daemon's other internal
- * state writes); a write failure never gates daemon liveness.
+ * @summary Drops message wake claims whose mailbox record is now read.
+ *
+ * Message claims need to survive only while the stable message remains unread. Pruning on every
+ * state write keeps the durable file proportional to the unread already-woken set while preserving
+ * replay protection across daemon restarts.
+ *
+ * @returns {void}
  */
-function persistWokenWatermark() {
+function pruneReadWokenMessageIds() {
+    if (!db) return;
+
+    for (const [identity, messageIds] of wokenMessageIdsByIdentity) {
+        for (const messageId of messageIds) {
+            if (isMessageReadFor(db, messageId, identity)) messageIds.delete(messageId);
+        }
+        if (messageIds.size === 0) wokenMessageIdsByIdentity.delete(identity);
+    }
+}
+
+/**
+ * @summary Best-effort persist of GraphLog watermarks plus per-identity message wake claims.
+ * @returns {void}
+ */
+function persistWokenState() {
     try {
-        fs.writeFileSync(WOKEN_WATERMARK_FILE, JSON.stringify(wokenWatermark), 'utf8');
+        pruneReadWokenMessageIds();
+
+        const messageIdsByIdentity = Object.fromEntries(
+            [...wokenMessageIdsByIdentity]
+                .filter(([, messageIds]) => messageIds.size > 0)
+                .map(([identity, messageIds]) => [identity, [...messageIds].sort()])
+        );
+        const state = {
+            ...wokenWatermark,
+            ...(Object.keys(messageIdsByIdentity).length > 0
+                ? {[WOKEN_MESSAGE_IDS_STATE_KEY]: messageIdsByIdentity}
+                : {})
+        };
+
+        fs.writeFileSync(WOKEN_WATERMARK_FILE, JSON.stringify(state), 'utf8');
     } catch (e) {
-        // best-effort; the in-memory map still dedups for the running process
+        // best-effort; the in-memory watermark + stable-id history still dedup this process
     }
 }
 
@@ -140,6 +198,16 @@ function persistWokenWatermark() {
  * @type {Object<String, Number>}
  */
 let wokenWatermark = {};  // loaded from disk in initConfigDerivedState() (after WOKEN_WATERMARK_FILE is assigned)
+
+/**
+ * Stable per-identity application-level dedup: `agentIdentity → Set<MESSAGE id>`.
+ *
+ * Unlike GraphLog `logId`, a MESSAGE id survives projection replay. Claims are recorded before the
+ * first adapter await so overlapping subscription routes cannot race into two physical prompts.
+ * Read messages are pruned when state persists; unread claims remain durable across daemon restart.
+ * @type {Map<String, Set<String>>}
+ */
+let wokenMessageIdsByIdentity = new Map();
 
 /**
  * Rotates `wake-daemon.log` if its mtime falls on a calendar day different from today's.
@@ -706,7 +774,7 @@ async function flushSubscription(subId) {
     // dropping real wakes (unread messages, tasks, permissions, and heartbeats all still fire).
     messages = messages.filter(ev => !isMessageReadFor(db, ev.messageId, identity));
 
-    // Already-woken dedup: drop events the recipient was already woken for
+    // Already-woken GraphLog dedup: drop events the recipient was already woken for
     // (logId <= the per-subscription watermark) so a re-queued backlog can't inflate the "N new" count
     // or spoof a HIGH digest from a stale message. Composes with the readAt reconcile above + the
     // heavy-delta defer at the top — reconciling on the right axis (already-woken, not merely unread).
@@ -715,6 +783,21 @@ async function flushSubscription(subId) {
     tasks       = filterEventsByWatermark(tasks,       watermark);
     permissions = filterEventsByWatermark(permissions, watermark);
     heartbeats  = filterEventsByWatermark(heartbeats,  watermark);
+
+    // Stable application-level dedup: GraphLog can re-emit the same immutable MESSAGE under a later
+    // logId, so a numeric watermark alone cannot guarantee one physical wake per message/identity.
+    // Claim synchronously before awaiting the adapter: another active route for this same identity
+    // then sees the claim and cannot race a second prompt. The duplicate events remain "consumed"
+    // below so their newer logIds still advance that route's numeric watermark.
+    const messageHistory = identity
+        ? (wokenMessageIdsByIdentity.get(identity) || new Set())
+        : new Set();
+    if (identity && !wokenMessageIdsByIdentity.has(identity)) {
+        wokenMessageIdsByIdentity.set(identity, messageHistory);
+    }
+    const messageClaims     = claimUnwokenMessages(messages, messageHistory),
+          duplicateMessages = messageClaims.duplicates;
+    messages = messageClaims.claimed;
 
     // Mixed-wake heartbeat suppression (digest content only): a heartbeat is the idle-watchdog nudge,
     // but when it coalesces with an actionable wake (message / task / permission) the agent is already
@@ -728,8 +811,16 @@ async function flushSubscription(subId) {
         heartbeats = [];
     }
 
+    const consumedMessages = [...messages, ...duplicateMessages];
+
     // Nothing genuinely-new survived (the delta was entirely already-read or already-woken) → suppress.
+    // A stable-id duplicate may carry a newer GraphLog row, so consume that position before returning.
     if (messages.length === 0 && tasks.length === 0 && permissions.length === 0 && heartbeats.length === 0) {
+        const consumedMax = maxLogId(consumedMessages);
+        if (consumedMax !== null && consumedMax > (wokenWatermark[subId] ?? 0)) {
+            wokenWatermark[subId] = consumedMax;
+            persistWokenState();
+        }
         return;
     }
 
@@ -749,11 +840,13 @@ async function flushSubscription(subId) {
     // Advance the per-subscription watermark to the highest delivered logId so these events are not
     // re-counted if the backlog is re-queued; persist for restart durability. logId is monotonic
     // (append-only GraphLog), so genuinely-new events always land strictly above this mark.
-    const deliveredMax = maxLogId([...messages, ...tasks, ...permissions, ...consumedHeartbeats]);
+    const deliveredMax = maxLogId([...consumedMessages, ...tasks, ...permissions, ...consumedHeartbeats]);
+    let   stateChanged = messages.some(message => Boolean(message.messageId));
     if (deliveredMax !== null && deliveredMax > (wokenWatermark[subId] ?? 0)) {
         wokenWatermark[subId] = deliveredMax;
-        persistWokenWatermark();
+        stateChanged = true;
     }
+    if (stateChanged) persistWokenState();
 }
 
 /**
@@ -1727,7 +1820,9 @@ function initConfigDerivedState() {
 
     fs.ensureDirSync(DAEMON_DATA_DIR);     // data dir must exist before any state-file write
     pruneOldLogs();                        // one-shot reaper for archived logs older than retention
-    wokenWatermark = loadWokenWatermark(); // restore the durable per-subscription woken high-water marks
+    const wokenState = loadWokenState();
+    wokenWatermark            = wokenState.watermarks;
+    wokenMessageIdsByIdentity = wokenState.messageIdsByIdentity;
 }
 
 // Start loop

--- a/ai/daemons/wake/instanceResolver.mjs
+++ b/ai/daemons/wake/instanceResolver.mjs
@@ -1,8 +1,14 @@
-import {execFile} from 'child_process';
+import {execFile}  from 'child_process';
 import {promisify} from 'util';
 
-const execFileAsync = promisify(execFile);
+const execFileAsync              = promisify(execFile);
 const GUI_INSTANCE_ADDRESS_TYPES = Object.freeze(['userDataDir', 'pid']);
+const GUI_APP_PROCESS_IDENTITIES = Object.freeze({
+    // Codex is the automation/product identity, while the installed Electron bundle and main
+    // executable are both named ChatGPT. Keeping this alias here prevents app-level routing
+    // vocabulary from leaking into process matching at the same-bundle delivery boundary.
+    Codex: Object.freeze({bundleName: 'ChatGPT', executableName: 'ChatGPT'})
+});
 
 /**
  * @summary Resolves the OS process id of a specific GUI harness *instance* from its
@@ -74,7 +80,7 @@ export function resolveInstancePid({userDataDir, psOutput, appExecutableMarker =
     }
 
     // 2) Only helper subprocesses carry the dir: walk parent-pid up to the main app executable.
-    const byPid = new Map(rows.map(row => [row.pid, row]));
+    const byPid  = new Map(rows.map(row => [row.pid, row]));
     let   cursor = matches[0];
     const seen   = new Set();
 
@@ -110,6 +116,28 @@ export async function getInstancePid({userDataDir, exec = execFileAsync} = {}) {
     }
 
     return resolveInstancePid({userDataDir, psOutput});
+}
+
+/**
+ * @summary Resolves the physical macOS process identity for a GUI harness activation name.
+ *
+ * Most harnesses use the same name at both layers (`Claude` -> `Claude.app/Claude`). Codex is the
+ * known exception: AppleScript/subscription routing uses `Codex`, while the installed bundle and
+ * executable are `ChatGPT.app/ChatGPT`. The explicit tuple keeps those contracts separate without
+ * changing the externally validated activation name.
+ *
+ * @param {String} appName Harness activation/product name.
+ * @returns {{bundleName:String, executableName:String}|null} Physical process identity.
+ */
+export function resolveGuiAppProcessIdentity(appName) {
+    const normalized = String(appName ?? '').trim();
+
+    if (!normalized) return null;
+
+    return GUI_APP_PROCESS_IDENTITIES[normalized] || {
+        bundleName    : normalized,
+        executableName: normalized
+    }
 }
 
 /**
@@ -261,33 +289,38 @@ export async function resolveGuiInstancePid({
 }
 
 /**
- * @summary Pure resolver: given a `ps` snapshot, find the pid of the DEFAULT app instance — the one
- * started as the normal macOS app, carrying NO `--user-data-dir`.
+ * @summary Resolves the DEFAULT GUI-app instance and preserves ambiguity evidence.
  *
  * Complement of {@link resolveInstancePid}. The default instance can never carry a `--user-data-dir`
  * (launching the primary macOS app with that flag breaks its system app / menu-bar integration), so
  * it is identified by the *absence* of the flag among the app's main processes.
  *
- * Disambiguates only when it is actually needed: returns the default pid solely when two or more main
- * instances of the app are running and exactly one of them is arg-less. With a single instance, or
- * when the default cannot be uniquely picked (zero or multiple arg-less mains), returns `null` so the
- * caller keeps the unchanged legacy app-activate path.
+ * The structured status keeps the delivery boundary from conflating safe legacy activation with an
+ * ambiguous multi-resident state: `not-found` and `single-instance` retain legacy activation,
+ * `resolved` carries the unique arg-less pid, while `ambiguous` and `probe-failed` must fail closed.
  *
  * @param {Object} options
  * @param {String} options.appName                            The app / bundle name (e.g. `Claude`).
  * @param {String} options.psOutput                           `ps axww -o pid=,ppid=,command=` output.
  * @param {String} [options.appExecutableMarker='Contents/MacOS/'] Marker identifying the main app executable.
- * @returns {Number|null} The default instance's main-process pid, or null (caller keeps legacy activate).
+ * @returns {{bundleName: String|null, executableName: String|null, instanceCount: Number, pid: Number|null, status: String}}
+ * Physical process identity plus default-instance resolution evidence.
  */
-export function resolveDefaultInstancePid({appName, psOutput, appExecutableMarker = 'Contents/MacOS/'} = {}) {
-    if (!appName || !psOutput) {
-        return null;
-    }
+export function resolveDefaultInstanceTarget({appName, psOutput, appExecutableMarker = 'Contents/MacOS/'} = {}) {
+    const processIdentity = resolveGuiAppProcessIdentity(appName),
+          baseResult      = {
+              bundleName    : processIdentity?.bundleName || null,
+              executableName: processIdentity?.executableName || null,
+              instanceCount : 0,
+              pid           : null,
+              status        : 'not-found'
+          };
 
-    const bundleMarker     = `/${appName}.app/${appExecutableMarker}`,
-          isMainExecutable = command =>
-              command.includes(appExecutableMarker) && !/Helper|Framework|crashpad/i.test(command),
-          appMains = psOutput.split('\n')
+    if (!processIdentity || !psOutput) return baseResult;
+
+    const bundleMarker     = `/${processIdentity.bundleName}.app/${appExecutableMarker}${processIdentity.executableName}`,
+          isMainExecutable = command => command.includes(bundleMarker) && !/Helper|Framework|crashpad/i.test(command),
+          appMains         = psOutput.split('\n')
               .map(line => line.trim())
               .filter(Boolean)
               .map(line => {
@@ -295,35 +328,71 @@ export function resolveDefaultInstancePid({appName, psOutput, appExecutableMarke
                   return match ? {pid: Number(match[1]), command: match[3]} : null;
               })
               .filter(Boolean)
-              .filter(row => row.command.includes(bundleMarker) && isMainExecutable(row.command));
+              .filter(row => isMainExecutable(row.command));
 
-    const argless = appMains.filter(row => !row.command.includes('--user-data-dir'));
+    const instanceCount = appMains.length,
+          argless       = appMains.filter(row => !row.command.includes('--user-data-dir'));
 
-    // Disambiguate only when a sibling instance actually exists (>= 2 mains) and exactly one is
-    // arg-less (the default). Otherwise null -> caller keeps the legacy activate path unchanged, so
-    // single-instance behavior is untouched.
-    return appMains.length >= 2 && argless.length === 1 ? argless[0].pid : null;
+    if (instanceCount === 0) return baseResult;
+    if (instanceCount === 1) {
+        return {
+            ...baseResult,
+            instanceCount,
+            status: argless.length === 1 ? 'single-instance' : 'ambiguous'
+        };
+    }
+
+    return {
+        ...baseResult,
+        instanceCount,
+        pid   : argless.length === 1 ? argless[0].pid : null,
+        status: argless.length === 1 ? 'resolved' : 'ambiguous'
+    }
 }
 
 /**
- * @summary Runs `ps` and resolves the DEFAULT (arg-less) app-instance pid. Side-effect wrapper
- * around {@link resolveDefaultInstancePid}.
+ * @summary Compatibility projection returning only the resolved default-instance pid.
+ * Delivery boundaries that must distinguish ambiguous multi-instance state should consume
+ * {@link resolveDefaultInstanceTarget} instead.
+ * @param {Object} options See {@link resolveDefaultInstanceTarget}.
+ * @returns {Number|null}
+ */
+export function resolveDefaultInstancePid(options = {}) {
+    return resolveDefaultInstanceTarget(options).pid;
+}
+
+/**
+ * @summary Runs `ps` and returns structured DEFAULT-instance resolution evidence.
+ * Side-effect wrapper around {@link resolveDefaultInstanceTarget}.
  * @param {Object} options
  * @param {String} options.appName
  * @param {Function} [options.exec=execFileAsync] Injectable `(cmd, args) => Promise<{stdout}>` for tests.
- * @returns {Promise<Number|null>} The default instance pid, or null (caller keeps legacy activate).
+ * @returns {Promise<{bundleName: String|null, executableName: String|null, instanceCount: Number, pid: Number|null, status: String}>}
  */
-export async function getDefaultInstancePid({appName, exec = execFileAsync} = {}) {
-    if (!appName) {
-        return null;
+export async function getDefaultInstanceTarget({appName, exec = execFileAsync} = {}) {
+    let psOutput    = '';
+    let probeFailed = false;
+
+    if (appName) {
+        try {
+            ({stdout: psOutput} = await exec('ps', ['axww', '-o', 'pid=,ppid=,command=']));
+        } catch {
+            probeFailed = true;
+        }
     }
 
-    let psOutput;
-    try {
-        ({stdout: psOutput} = await exec('ps', ['axww', '-o', 'pid=,ppid=,command=']));
-    } catch {
-        return null;
-    }
+    const result = resolveDefaultInstanceTarget({appName, psOutput});
 
-    return resolveDefaultInstancePid({appName, psOutput});
+    return probeFailed ? {...result, status: 'probe-failed'} : result;
+}
+
+/**
+ * @summary Compatibility side-effect wrapper returning only the default-instance pid.
+ * Delivery boundaries that must distinguish ambiguous multi-instance state should consume
+ * {@link getDefaultInstanceTarget} instead.
+ * @param {Object} options See {@link getDefaultInstanceTarget}.
+ * @returns {Promise<Number|null>}
+ */
+export async function getDefaultInstancePid(options = {}) {
+    return (await getDefaultInstanceTarget(options)).pid;
 }

--- a/ai/daemons/wake/wokenWatermark.mjs
+++ b/ai/daemons/wake/wokenWatermark.mjs
@@ -5,15 +5,17 @@
  * The wake daemon's digest historically reconciled only on `readAt`, so a genuinely-unread
  * message the recipient had already been *woken for* (re-queued by a heavy-delta GraphLog
  * re-include or a cursor reset) survived into the "N new" count and could spoof a HIGH digest
- * from a stale backlog message. These pure helpers reconcile on the
- * right axis — the GraphLog `logId` high-water-mark of what the recipient has already been woken
- * for — and compose with (do NOT replace) the `readAt` reconcile + `flushDeferPolicy` defer.
+ * from a stale backlog message. These pure helpers reconcile on two already-woken axes: the
+ * GraphLog `logId` high-water-mark for positional replay, plus the stable application `messageId`
+ * for one logical MESSAGE re-emitted at a later position. Both compose with (do NOT replace) the
+ * `readAt` reconcile + `flushDeferPolicy` defer.
  *
  * `logId` is the append-only GraphLog position inside one graph epoch, so it is monotonic while
  * that epoch survives. Graph restore/rebuild can reset the log while wake-daemon state survives;
  * callers must detect a stale-high watermark against graph-tip evidence, then clamp it to a
- * trusted pre-batch cursor before filtering. The daemon owns the durable, per-subscription
- * watermark map + its persistence; this module is the pure, unit-testable decision core.
+ * trusted pre-batch cursor before filtering. The daemon owns the durable per-subscription watermark
+ * map, per-identity message claims, and their persistence; this module is the pure, unit-testable
+ * decision core.
  */
 
 /**
@@ -67,6 +69,39 @@ export function filterEventsByWatermark(events, watermark) {
         const logId = Number(raw);
         return !Number.isFinite(logId) || logId > mark;
     });
+}
+
+/**
+ * @summary Atomically claims message events that have not already produced a wake for an identity.
+ *
+ * GraphLog may legitimately re-emit one immutable MESSAGE under a later `logId` (for example after
+ * a projection replay). The numeric watermark therefore cannot establish message-level exactly-once
+ * semantics by itself. This helper filters on the stable application `messageId` and adds every
+ * survivor to the shared identity history before the caller awaits adapter delivery. A second route
+ * or flush in the same process then observes the claim immediately and cannot submit a duplicate.
+ *
+ * Events without a `messageId` are conservatively claimed on every pass: malformed identity data
+ * must not suppress a genuine wake.
+ *
+ * @param {Object[]} messages Candidate message wake events; `messageId` may be absent.
+ * @param {Set<String>} wokenMessageIds Mutable per-identity wake history.
+ * @returns {{claimed: Array, duplicates: Array}} Newly claimed events and already-woken events.
+ */
+export function claimUnwokenMessages(messages, wokenMessageIds) {
+    const claimed = [], duplicates = [];
+
+    for (const message of messages) {
+        const messageId = message?.messageId;
+
+        if (messageId && wokenMessageIds.has(messageId)) {
+            duplicates.push(message);
+        } else {
+            claimed.push(message);
+            if (messageId) wokenMessageIds.add(messageId);
+        }
+    }
+
+    return {claimed, duplicates};
 }
 
 /**

--- a/ai/scripts/lifecycle/resumeHarness.mjs
+++ b/ai/scripts/lifecycle/resumeHarness.mjs
@@ -11,6 +11,9 @@
  * @see ai/daemons/SwarmHeartbeatService.mjs
  * @see .agents/skills/session-sunset/references/session-sunset-workflow.md §1
  */
+import Neo                                                from '../../../src/Neo.mjs';
+import * as core                                          from '../../../src/core/_export.mjs';
+import AiConfig                                           from '../../config.mjs';
 import { spawn }                                          from 'child_process';
 import { constants as fsConstants }                       from 'fs';
 import fs                                                 from 'fs/promises';
@@ -117,22 +120,6 @@ async function resolveClaudeCliPath() {
 }
 
 /**
- * @summary Resolve the Codex CLI binary used by the Codex Desktop app-server adapter.
- *
- * `CODEX_CLI_PATH` always wins. When unset on macOS, the resolver probes the
- * Codex Desktop bundled CLI path because daemon / app-spawned environments often
- * lack the user's interactive shell PATH.
- *
- * @returns {Promise<string>} The Codex CLI command or resolved Desktop path.
- */
-async function resolveCodexCliPath() {
-    if (process.env.CODEX_CLI_PATH) return process.env.CODEX_CLI_PATH;
-    const desktopCliPath = process.env.CODEX_DESKTOP_CLI_PATH || '/Applications/Codex.app/Contents/Resources/codex';
-    if (process.platform === 'darwin' && await fileIsExecutable(desktopCliPath)) return desktopCliPath;
-    return 'codex';
-}
-
-/**
  * @summary Check whether a candidate CLI path exists and is executable.
  *
  * @param {string} filePath
@@ -232,19 +219,20 @@ export function selectHarnessAdapter(harnessTarget, hostPlatform = process.platf
  *
  * `codex debug app-server send-message-v2` creates/injects into a real Codex
  * Desktop thread. Live-host probes must require an explicit operator opt-in.
- * Unit tests satisfy this guard with
- * `CODEX_APP_SERVER_MOCK=1` plus `CODEX_CLI_PATH` or `CODEX_DESKTOP_CLI_PATH` pointing at a mock
- * executable, preserving always-on coverage without host side effects.
+ * Unit tests satisfy this guard with `CODEX_APP_SERVER_MOCK=1` plus the canonical
+ * `NEO_FLEET_CODEX_BIN` config-leaf override pointing at a mock executable, preserving always-on
+ * coverage without host side effects.
  */
 function assertCodexAppServerAllowed() {
     const hasLiveOptIn = process.env.RUN_LIVE_CODEX_APP_SERVER === '1';
     const hasMockOptIn = process.env.CODEX_APP_SERVER_MOCK === '1' &&
-        (Boolean(process.env.CODEX_CLI_PATH) || Boolean(process.env.CODEX_DESKTOP_CLI_PATH));
+        Boolean(process.env.NEO_FLEET_CODEX_BIN);
 
     if (!hasLiveOptIn && !hasMockOptIn) {
         throw new Error(
             'Codex app-server adapter is a live-host action. Set RUN_LIVE_CODEX_APP_SERVER=1 ' +
-            'for an operator-controlled probe, or set CODEX_APP_SERVER_MOCK=1 with CODEX_CLI_PATH in tests.'
+            'for an operator-controlled probe, or set CODEX_APP_SERVER_MOCK=1 with ' +
+            'NEO_FLEET_CODEX_BIN in tests.'
         );
     }
 }
@@ -378,7 +366,7 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
     //   same osascript Cmd+3 path is empirically proven by live bridge-daemon wake delivery.
     // - codex-desktop: Codex Desktop app-server debug surface through
     //   `codex debug app-server send-message-v2`; live dispatch remains explicitly
-    //   gated, while tests use CODEX_APP_SERVER_MOCK=1 + CODEX_CLI_PATH.
+    //   gated, while tests use CODEX_APP_SERVER_MOCK=1 + NEO_FLEET_CODEX_BIN.
     // The `claude-cli` adapter (embedded `claude <prompt>` CLI) is retained as a
     // non-routed fallback; no production identity routes there after the Tab-3 remap.
     const harnessTarget = resolveHarnessTargetForIdentity(identity);
@@ -462,11 +450,11 @@ export async function resumeHarness(identity, reason, originSessionId, abandoned
              * thread proves healthy Memory Core startup plus a first `add_memory`
              * sessionId change.
              *
-             * Tests use `CODEX_APP_SERVER_MOCK=1` plus a mock CLI path, verifying the
-             * command shape without creating real Codex threads.
+             * Tests use `CODEX_APP_SERVER_MOCK=1` plus a mock `NEO_FLEET_CODEX_BIN`,
+             * verifying the command shape without creating real Codex threads.
              */
             assertCodexAppServerAllowed();
-            const cliPath = await resolveCodexCliPath();
+            const cliPath = AiConfig.fleet.harnessBinaries.codex;
             const args    = ['debug', 'app-server', 'send-message-v2', payload];
             await spawnAsync(cliPath, args);
             console.log(`Successfully resumed ${identity} via codex-app-server`);

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -208,7 +208,7 @@ test.describe('Wake Daemon', () => {
     });
 
     test('detects and delivers wake events via test adapter', async () => {
-        const subId = 'sub_' + crypto.randomUUID();
+        const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
@@ -391,13 +391,13 @@ test.describe('Wake Daemon', () => {
             }
         });
 
-        let output = '';
+        let output           = '';
         let insertedPresence = false;
         let msgId;
 
         const proofPromise = new Promise((resolve, reject) => {
             const timeout = setTimeout(() => reject(new Error('Daemon did not log Codex turn-start proof')), 10000);
-            const onData = data => {
+            const onData  = data => {
                 output += data.toString();
 
                 const wakeSubmitNonce = extractWakeSubmitNonce(output);
@@ -461,12 +461,12 @@ test.describe('Wake Daemon', () => {
             }
         });
 
-        let output = '';
+        let output           = '';
         let insertedPresence = false;
 
         const proofPromise = new Promise((resolve, reject) => {
             const timeout = setTimeout(() => reject(new Error('Daemon did not log Codex ambiguous turn-start proof')), 10000);
-            const onData = data => {
+            const onData  = data => {
                 output += data.toString();
 
                 if (!insertedPresence && output.includes(`Submit attempted ${subId}`)) {
@@ -531,7 +531,7 @@ test.describe('Wake Daemon', () => {
 
         const proofPromise = new Promise((resolve, reject) => {
             const timeout = setTimeout(() => reject(new Error('Daemon did not log Codex not-started proof')), 10000);
-            const onData = data => {
+            const onData  = data => {
                 output += data.toString();
                 if (output.includes('wake-submit-not-started')) {
                     clearTimeout(timeout);
@@ -655,7 +655,7 @@ test.describe('Wake Daemon', () => {
         // rebuilds a digest over BOTH → "2 new messages". That string proves neither wake was lost.
         const coalescedPromise = new Promise((resolve, reject) => {
             const timeout = setTimeout(() => reject(new Error('Coalesced 2-message retry digest not observed within timeout')), 25000);
-            const onData = (data) => {
+            const onData  = (data) => {
                 if (data.toString().includes('2 new messages')) {
                     clearTimeout(timeout);
                     resolve();
@@ -735,10 +735,10 @@ test.describe('Wake Daemon', () => {
             }), delId);
         };
 
-        let markedRead = false;
+        let   markedRead  = false;
         const dropPromise = new Promise((resolve, reject) => {
             const timeout = setTimeout(() => reject(new Error('Retry was not dropped after the message was read within timeout')), 25000);
-            const onData = (data) => {
+            const onData  = (data) => {
                 const out = data.toString();
                 // First delivery failure → the wake is now queued for retry. Mark the message read so the
                 // retry's read-reconcile must drop it rather than re-deliver the stale digest.
@@ -975,7 +975,7 @@ test.describe('Wake Daemon', () => {
     });
 
     test('delivers GraphLog-only heartbeat pulses via test adapter', async () => {
-        const subId = 'sub_' + crypto.randomUUID();
+        const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-heartbeat';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
@@ -1110,7 +1110,7 @@ test.describe('Wake Daemon', () => {
     });
 
     test('delivers heartbeat pulses through the existing SENT_TO_ME bridge-daemon route', async () => {
-        const subId = 'sub_' + crypto.randomUUID();
+        const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-heartbeat-sent-to-me';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
@@ -1167,7 +1167,7 @@ test.describe('Wake Daemon', () => {
     });
 
     test('does not deliver wake events for wakeSuppressed mailbox-only messages', async () => {
-        const subId = 'sub_' + crypto.randomUUID();
+        const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-suppressed';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
@@ -1236,7 +1236,7 @@ test.describe('Wake Daemon', () => {
 
         expect(deliveryCount).toBe(0);
 
-        const stored = db.prepare('SELECT data FROM Nodes WHERE id = ?').get(msgId);
+        const stored        = db.prepare('SELECT data FROM Nodes WHERE id = ?').get(msgId);
         const storedMessage = JSON.parse(stored.data);
         expect(storedMessage.properties.readAt).toBeNull();
         expect(storedMessage.properties.wakeSuppressed).toBe(true);
@@ -1244,7 +1244,7 @@ test.describe('Wake Daemon', () => {
 
     test('does not queue wake delivery for known non-active identities (#13456)', async () => {
         const agentId = '@neo-gemini-pro';
-        const subId = insertWakeSubscription(db, {
+        const subId   = insertWakeSubscription(db, {
             agentId,
             harnessTargetMetadata: {
                 adapter       : 'test',
@@ -1273,7 +1273,7 @@ test.describe('Wake Daemon', () => {
     });
 
     test('deduplicates multiple triggers for the same message in the coalescing window', async () => {
-        const subId = 'sub_' + crypto.randomUUID();
+        const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-dedup';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
@@ -1304,8 +1304,8 @@ test.describe('Wake Daemon', () => {
             env  : { ...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR }
         });
 
-        let deliveryCount = 0;
-        let finalDigest = '';
+        let   deliveryCount   = 0;
+        let   finalDigest     = '';
         const deliveryPromise = new Promise((resolve, reject) => {
             const timeout = setTimeout(() => {
                 resolve(); // Resolve instead of reject because we expect exactly one delivery. We'll wait a bit.
@@ -1405,10 +1405,10 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                CODEX_CLI_PATH    : mockCodexPath,
-                NEO_MEMORY_DB_PATH: DB_PATH,
-                NEO_AI_DAEMON_DIR : DAEMON_DIR,
-                PATH              : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                NEO_FLEET_CODEX_BIN: mockCodexPath,
+                NEO_MEMORY_DB_PATH : DB_PATH,
+                NEO_AI_DAEMON_DIR  : DAEMON_DIR,
+                PATH               : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
             }
         });
 
@@ -1453,7 +1453,7 @@ test.describe('Wake Daemon', () => {
         );
     });
 
-    test('resolves bundled Codex Desktop CLI when daemon PATH lacks bare codex (#13287)', async () => {
+    test('uses the AiConfig Fleet Codex binary when daemon PATH lacks bare codex (#15054)', async () => {
         test.skip(process.platform !== 'darwin', 'Codex Desktop bundled CLI path is currently mac-specific');
 
         const subId   = 'sub_' + crypto.randomUUID();
@@ -1470,7 +1470,7 @@ test.describe('Wake Daemon', () => {
         });
 
         const binDir           = path.join(DAEMON_DIR, 'bin');
-        const mockCodexPath    = path.join(DAEMON_DIR, 'Codex.app', 'Contents', 'Resources', 'codex');
+        const mockCodexPath    = path.join(DAEMON_DIR, 'ChatGPT.app', 'Contents', 'Resources', 'codex');
         const mockCodexOutPath = path.join(DAEMON_DIR, 'mock_codex_desktop_cli_out.json');
 
         fs.ensureDirSync(binDir);
@@ -1487,11 +1487,10 @@ test.describe('Wake Daemon', () => {
             stdio: 'pipe',
             env  : {
                 ...process.env,
-                CODEX_CLI_PATH        : '',
-                CODEX_DESKTOP_CLI_PATH: mockCodexPath,
-                NEO_MEMORY_DB_PATH    : DB_PATH,
-                NEO_AI_DAEMON_DIR     : DAEMON_DIR,
-                PATH                  : `${path.dirname(process.execPath)}${path.delimiter}${path.resolve(binDir)}`
+                NEO_FLEET_CODEX_BIN: mockCodexPath,
+                NEO_MEMORY_DB_PATH : DB_PATH,
+                NEO_AI_DAEMON_DIR  : DAEMON_DIR,
+                PATH               : `${path.dirname(process.execPath)}${path.delimiter}${path.resolve(binDir)}`
             }
         });
 
@@ -1530,7 +1529,7 @@ test.describe('Wake Daemon', () => {
     });
 
     test('uses the highest coalesced message priority in the wake digest header and preserves divergent latest priority', async () => {
-        const subId = 'sub_' + crypto.randomUUID();
+        const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-priority';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
@@ -1627,7 +1626,7 @@ test.describe('Wake Daemon', () => {
     });
 
     test('skips osascript delivery and logs error when appName is missing', async () => {
-        const subId = 'sub_' + crypto.randomUUID();
+        const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-empty';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
@@ -1697,7 +1696,7 @@ test.describe('Wake Daemon', () => {
     });
 
     test('Antigravity chorded shortcut generates correct osascript using command and shift down', async () => {
-        const subId = 'sub_' + crypto.randomUUID();
+        const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-antigravity';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
@@ -1729,7 +1728,7 @@ test.describe('Wake Daemon', () => {
         fs.ensureDirSync(binDir);
         writeMockPs(binDir);
         const mockOsascriptPath = path.join(binDir, 'osascript');
-        const mockOutPath = path.join(DAEMON_DIR, 'mock_out.json');
+        const mockOutPath       = path.join(DAEMON_DIR, 'mock_out.json');
         fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
         fs.chmodSync(mockOsascriptPath, 0o755);
 
@@ -1782,7 +1781,7 @@ test.describe('Wake Daemon', () => {
         await deliveryPromise;
 
         const mockOutput = fs.readFileSync(mockOutPath, 'utf8');
-        const args = JSON.parse(mockOutput);
+        const args       = JSON.parse(mockOutput);
 
         expect(args.join(' ')).toContain('keystroke "i" using {command down, shift down}');
         expect(args.join(' ')).toContain('tell application "Antigravity" to activate');
@@ -1794,7 +1793,7 @@ test.describe('Wake Daemon', () => {
     });
 
     test('Claude default focus seed emits r -> Cmd+Z before prompt clear and guards frontmost (#10987, #10422)', async () => {
-        const subId = 'sub_' + crypto.randomUUID();
+        const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-claude';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
@@ -1825,7 +1824,7 @@ test.describe('Wake Daemon', () => {
         fs.ensureDirSync(binDir);
         writeMockPs(binDir);
         const mockOsascriptPath = path.join(binDir, 'osascript');
-        const mockOutPath = path.join(DAEMON_DIR, 'mock_claude_out.json');
+        const mockOutPath       = path.join(DAEMON_DIR, 'mock_claude_out.json');
         fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
         fs.chmodSync(mockOsascriptPath, 0o755);
 
@@ -1873,13 +1872,13 @@ test.describe('Wake Daemon', () => {
 
         await deliveryPromise;
 
-        const args          = JSON.parse(fs.readFileSync(mockOutPath, 'utf8'));
-        const scriptContent = args.filter((_, i) => args[i - 1] === '-e').join('\n');
-        const activateIndex = scriptContent.indexOf('tell application "Claude" to activate');
-        const tabIndex      = scriptContent.indexOf('keystroke "3" using command down');
-        const rIndex        = scriptContent.indexOf('keystroke "r"');
-        const zIndex        = scriptContent.indexOf('keystroke "z" using command down');
-        const clearIndex    = scriptContent.indexOf('keystroke "a" using command down');
+        const args                      = JSON.parse(fs.readFileSync(mockOutPath, 'utf8'));
+        const scriptContent             = args.filter((_, i) => args[i - 1] === '-e').join('\n');
+        const activateIndex             = scriptContent.indexOf('tell application "Claude" to activate');
+        const tabIndex                  = scriptContent.indexOf('keystroke "3" using command down');
+        const rIndex                    = scriptContent.indexOf('keystroke "r"');
+        const zIndex                    = scriptContent.indexOf('keystroke "z" using command down');
+        const clearIndex                = scriptContent.indexOf('keystroke "a" using command down');
         const guardAfterActivationIndex = scriptContent.indexOf('my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "after activation")');
         const guardBeforeClearIndex     = scriptContent.indexOf('my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "before prompt clear")');
         const guardBeforeWakeSetIndex   = scriptContent.indexOf('my assertTargetFrontmost(targetAppName, targetBundleId, targetProcessId, "before wake clipboard set")');
@@ -1907,9 +1906,159 @@ test.describe('Wake Daemon', () => {
         expect(scriptContent).not.toContain('key code 49');
     });
 
+    test('default Codex route targets the arg-less ChatGPT.app resident by pid (#15054)', async () => {
+        const agentId = '@test-codex-default-resident';
+        const subId   = insertWakeSubscription(db, {
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'osascript',
+                appName       : 'Codex',
+                coalesceWindow: 1,
+                focusSeedKey  : 'r'
+            }
+        });
+
+        const binDir = path.join(DAEMON_DIR, 'bin');
+        fs.ensureDirSync(binDir);
+        writeMockPs(binDir, [
+            '3778 1 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT',
+            '37111 1 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT --user-data-dir=/Users/example/.codex-app-instances/emmy'
+        ].join('\n'));
+        const mockOsascriptPath = path.join(binDir, 'osascript');
+        const mockOutPath       = path.join(DAEMON_DIR, 'mock_codex_default_out.json');
+        fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
+        fs.chmodSync(mockOsascriptPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
+        });
+
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver the default Codex wake within timeout')), 10000);
+
+            daemonProcess.stdout.on('data', data => {
+                if (data.toString().includes(`[Wake Daemon] Submit attempted ${subId}`)) {
+                    clearTimeout(timeout);
+                    resolve()
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject)
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {agentId, subject: 'Default Codex Resident Wake'});
+        await deliveryPromise;
+
+        const args          = JSON.parse(fs.readFileSync(mockOutPath, 'utf8'));
+        const scriptContent = args.filter((_, i) => args[i - 1] === '-e').join('\n');
+
+        expect(scriptContent).toContain('set targetProcessId to "3778"');
+        expect(scriptContent).toContain('first process whose unix id is 3778')
+    });
+
+    test('ambiguous Codex default route fails closed before osascript (#15054)', async () => {
+        const agentId = '@test-codex-ambiguous-default';
+        const subId   = insertWakeSubscription(db, {
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'osascript',
+                appName       : 'Codex',
+                coalesceWindow: 1,
+                focusSeedKey  : 'r'
+            }
+        });
+
+        const binDir = path.join(DAEMON_DIR, 'bin');
+        fs.ensureDirSync(binDir);
+        writeMockPs(binDir, [
+            '3778 1 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT',
+            '37111 1 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT'
+        ].join('\n'));
+        const mockOsascriptPath = path.join(binDir, 'osascript');
+        const mockOutPath       = path.join(DAEMON_DIR, 'mock_codex_ambiguous_out.json');
+        fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', 'unexpected delivery');\n`);
+        fs.chmodSync(mockOsascriptPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
+        });
+
+        const refusalPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon did not refuse the ambiguous Codex wake within timeout')), 10000);
+            const inspect = data => {
+                if (data.toString().includes(`Default-instance wake refused for ${subId}`)) {
+                    clearTimeout(timeout);
+                    resolve()
+                }
+            };
+
+            daemonProcess.stdout.on('data', inspect);
+            daemonProcess.stderr.on('data', inspect);
+            daemonProcess.on('error', reject)
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {agentId, subject: 'Ambiguous Codex Resident Wake'});
+        await refusalPromise;
+
+        expect(fs.existsSync(mockOutPath)).toBe(false)
+    });
+
+    test('default Codex route fails closed when only an addressed sibling resident is running (#15054)', async () => {
+        const agentId = '@test-codex-addressed-only';
+        const subId   = insertWakeSubscription(db, {
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'osascript',
+                appName       : 'Codex',
+                coalesceWindow: 1,
+                focusSeedKey  : 'r'
+            }
+        });
+
+        const binDir = path.join(DAEMON_DIR, 'bin');
+        fs.ensureDirSync(binDir);
+        writeMockPs(binDir, [
+            '37111 1 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT --user-data-dir=/Users/example/.codex-app-instances/emmy',
+            '37122 37111 /Applications/ChatGPT.app/Contents/Frameworks/ChatGPT Helper.app/Contents/MacOS/ChatGPT Helper --type=renderer --user-data-dir=/Users/example/.codex-app-instances/emmy'
+        ].join('\n'));
+        const mockOsascriptPath = path.join(binDir, 'osascript');
+        const mockOutPath       = path.join(DAEMON_DIR, 'mock_codex_addressed_only_out.json');
+        fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', 'unexpected delivery');\n`);
+        fs.chmodSync(mockOsascriptPath, 0o755);
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {...process.env, PATH: `${path.resolve(binDir)}:${process.env.PATH}`, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
+        });
+
+        const refusalPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Daemon did not refuse the addressed-only Codex wake within timeout')), 10000);
+            const inspect = data => {
+                if (data.toString().includes(`Default-instance wake refused for ${subId}`)) {
+                    clearTimeout(timeout);
+                    resolve()
+                }
+            };
+
+            daemonProcess.stdout.on('data', inspect);
+            daemonProcess.stderr.on('data', inspect);
+            daemonProcess.on('error', reject)
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {agentId, subject: 'Addressed-only Codex Resident Wake'});
+        await refusalPromise;
+
+        expect(fs.existsSync(mockOutPath)).toBe(false)
+    });
+
     test('addressType pid dispatch targets the resolved process id when HarnessPresence is fresh (#12422)', async () => {
         const agentId = '@test-agent-pid-address';
-        const subId = insertWakeSubscription(db, {
+        const subId   = insertWakeSubscription(db, {
             agentId,
             harnessTargetMetadata: {
                 adapter        : 'osascript',
@@ -1925,7 +2074,7 @@ test.describe('Wake Daemon', () => {
         fs.ensureDirSync(binDir);
         writeMockPs(binDir);
         const mockOsascriptPath = path.join(binDir, 'osascript');
-        const mockOutPath = path.join(DAEMON_DIR, 'mock_pid_out.json');
+        const mockOutPath       = path.join(DAEMON_DIR, 'mock_pid_out.json');
         fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
         fs.chmodSync(mockOsascriptPath, 0o755);
 
@@ -1952,7 +2101,7 @@ test.describe('Wake Daemon', () => {
         insertMessageWake(db, {agentId, subject: 'PID Address Wake'});
         await deliveryPromise;
 
-        const args = JSON.parse(fs.readFileSync(mockOutPath, 'utf8'));
+        const args          = JSON.parse(fs.readFileSync(mockOutPath, 'utf8'));
         const scriptContent = args.filter((_, i) => args[i - 1] === '-e').join('\n');
 
         expect(scriptContent).toContain('set targetProcessId to "4242"');
@@ -1961,7 +2110,7 @@ test.describe('Wake Daemon', () => {
 
     test('stale HarnessPresence refuses targeted GUI delivery instead of falling through to app activate (#12422)', async () => {
         const agentId = '@test-agent-stale-presence';
-        const subId = insertWakeSubscription(db, {
+        const subId   = insertWakeSubscription(db, {
             agentId,
             harnessTargetMetadata: {
                 adapter        : 'osascript',
@@ -1980,7 +2129,7 @@ test.describe('Wake Daemon', () => {
         const binDir = path.join(DAEMON_DIR, 'bin');
         fs.ensureDirSync(binDir);
         const mockOsascriptPath = path.join(binDir, 'osascript');
-        const mockOutPath = path.join(DAEMON_DIR, 'mock_stale_presence_out.json');
+        const mockOutPath       = path.join(DAEMON_DIR, 'mock_stale_presence_out.json');
         fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
         fs.chmodSync(mockOsascriptPath, 0o755);
 
@@ -2018,7 +2167,7 @@ test.describe('Wake Daemon', () => {
         const agentId     = '@test-agent-userdatadir-live';
         const userDataDir = '/Users/example/.claude-instances/test-live';
         const mainPid     = 47474;
-        const subId = insertWakeSubscription(db, {
+        const subId       = insertWakeSubscription(db, {
             agentId,
             harnessTargetMetadata: {
                 adapter        : 'osascript',
@@ -2073,7 +2222,7 @@ test.describe('Wake Daemon', () => {
     test('userDataDir still fails closed when no live process maps to the address (#12571)', async () => {
         const agentId     = '@test-agent-userdatadir-dead';
         const userDataDir = '/Users/example/.claude-instances/test-dead';
-        const subId = insertWakeSubscription(db, {
+        const subId       = insertWakeSubscription(db, {
             agentId,
             harnessTargetMetadata: {
                 adapter        : 'osascript',
@@ -2128,7 +2277,7 @@ test.describe('Wake Daemon', () => {
         // is a live oracle). `pid` has no equivalent live-target proof, so a stale-presence pid wake
         // must still fail closed — proving the relaxation did not generalize beyond userDataDir.
         const agentId = '@test-agent-pid-boundary-stale';
-        const subId = insertWakeSubscription(db, {
+        const subId   = insertWakeSubscription(db, {
             agentId,
             harnessTargetMetadata: {
                 adapter        : 'osascript',
@@ -2177,7 +2326,7 @@ test.describe('Wake Daemon', () => {
 
     test('addressType tmuxSession dispatch sends the digest to the instanceAddress session (#12422)', async () => {
         const agentId = '@test-agent-tmux-address';
-        const subId = insertWakeSubscription(db, {
+        const subId   = insertWakeSubscription(db, {
             agentId,
             harnessTargetMetadata: {
                 adapter        : 'tmux',
@@ -2192,7 +2341,7 @@ test.describe('Wake Daemon', () => {
         const binDir = path.join(DAEMON_DIR, 'bin');
         fs.ensureDirSync(binDir);
         const mockTmuxPath = path.join(binDir, 'tmux');
-        const mockOutPath = path.join(DAEMON_DIR, 'mock_tmux_out.json');
+        const mockOutPath  = path.join(DAEMON_DIR, 'mock_tmux_out.json');
         fs.writeFileSync(mockTmuxPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
         fs.chmodSync(mockTmuxPath, 0o755);
 
@@ -2228,7 +2377,7 @@ test.describe('Wake Daemon', () => {
 
     test('tmux wake delivers pure-heartbeat interactive submit (idle-gated at emit, not delivery)', async () => {
         const agentId = '@test-agent-tmux-pure-heartbeat';
-        const subId = insertWakeSubscription(db, {
+        const subId   = insertWakeSubscription(db, {
             agentId,
             harnessTargetMetadata: {
                 adapter       : 'tmux',
@@ -2240,7 +2389,7 @@ test.describe('Wake Daemon', () => {
         const binDir = path.join(DAEMON_DIR, 'bin');
         fs.ensureDirSync(binDir);
         const mockTmuxPath = path.join(binDir, 'tmux');
-        const mockOutPath = path.join(DAEMON_DIR, 'mock_tmux_pure_heartbeat_out.json');
+        const mockOutPath  = path.join(DAEMON_DIR, 'mock_tmux_pure_heartbeat_out.json');
         fs.writeFileSync(mockTmuxPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
         fs.chmodSync(mockTmuxPath, 0o755);
 
@@ -2279,9 +2428,9 @@ test.describe('Wake Daemon', () => {
             });
             server.on('error', reject);
             server.listen(0, '127.0.0.1', () => {
-                const {port} = server.address();
+                const {port}  = server.address();
                 const agentId = '@test-agent-webhook-address';
-                const subId = insertWakeSubscription(db, {
+                const subId   = insertWakeSubscription(db, {
                     agentId,
                     harnessTargetMetadata: {
                         adapter        : 'tmux',
@@ -2336,7 +2485,7 @@ test.describe('Wake Daemon', () => {
         // This test is a defense-in-depth check: the bridge refuses to send any
         // osascript keystroke for a Codex subscription that lacks an explicit
         // composer-focus primitive.
-        const subId = 'sub_' + crypto.randomUUID();
+        const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-codex-fail-closed';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
@@ -2368,7 +2517,7 @@ test.describe('Wake Daemon', () => {
         fs.ensureDirSync(binDir);
         writeMockPs(binDir);
         const mockOsascriptPath = path.join(binDir, 'osascript');
-        const mockOutPath = path.join(DAEMON_DIR, 'mock_codex_failclosed_out.json');
+        const mockOutPath       = path.join(DAEMON_DIR, 'mock_codex_failclosed_out.json');
         fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
         fs.chmodSync(mockOsascriptPath, 0o755);
 
@@ -2432,7 +2581,7 @@ test.describe('Wake Daemon', () => {
     });
 
     test('Codex wake submit attempt emits specific sequence r -> Cmd+Z -> Cmd+A/X -> paste -> Esc -> Enter (#10667, #13287, #13480)', async () => {
-        const subId = 'sub_' + crypto.randomUUID();
+        const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-codex-cleanup';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
@@ -2464,7 +2613,7 @@ test.describe('Wake Daemon', () => {
         fs.ensureDirSync(binDir);
         writeMockPs(binDir);
         const mockOsascriptPath = path.join(binDir, 'osascript');
-        const mockOutPath = path.join(DAEMON_DIR, 'mock_codex_cleanup_out.json');
+        const mockOutPath       = path.join(DAEMON_DIR, 'mock_codex_cleanup_out.json');
         fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
         fs.chmodSync(mockOsascriptPath, 0o755);
 
@@ -2515,16 +2664,16 @@ test.describe('Wake Daemon', () => {
 
         await deliveryPromise;
 
-        const rawArgs = JSON.parse(fs.readFileSync(mockOutPath, 'utf-8'));
+        const rawArgs       = JSON.parse(fs.readFileSync(mockOutPath, 'utf-8'));
         const scriptContent = rawArgs.filter((_, i) => rawArgs[i - 1] === '-e').join('\n');
 
-        const rIndex = scriptContent.indexOf('keystroke "r"');
-        const zIndex = scriptContent.indexOf('keystroke "z" using command down');
-        const aIndex = scriptContent.indexOf('keystroke "a" using command down');
-        const xIndex = scriptContent.indexOf('keystroke "x" using command down');
-        const pasteIndex = scriptContent.indexOf('keystroke "v" using command down');
+        const rIndex      = scriptContent.indexOf('keystroke "r"');
+        const zIndex      = scriptContent.indexOf('keystroke "z" using command down');
+        const aIndex      = scriptContent.indexOf('keystroke "a" using command down');
+        const xIndex      = scriptContent.indexOf('keystroke "x" using command down');
+        const pasteIndex  = scriptContent.indexOf('keystroke "v" using command down');
         const escapeIndex = scriptContent.indexOf('key code 53');
-        const enterIndex = scriptContent.indexOf('key code 36');
+        const enterIndex  = scriptContent.indexOf('key code 36');
 
         expect(rIndex).toBeGreaterThan(-1);
         expect(zIndex).toBeGreaterThan(rIndex);
@@ -2546,7 +2695,7 @@ test.describe('Wake Daemon', () => {
     });
 
     test('Codex UI wake submits pure-heartbeat interactively (idle-gated at emit, not delivery)', async () => {
-        const subId = 'sub_' + crypto.randomUUID();
+        const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-codex-pure-heartbeat';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
@@ -2578,7 +2727,7 @@ test.describe('Wake Daemon', () => {
         fs.ensureDirSync(binDir);
         writeMockPs(binDir);
         const mockOsascriptPath = path.join(binDir, 'osascript');
-        const mockOutPath = path.join(DAEMON_DIR, 'mock_codex_pure_heartbeat_out.json');
+        const mockOutPath       = path.join(DAEMON_DIR, 'mock_codex_pure_heartbeat_out.json');
         fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
         fs.chmodSync(mockOsascriptPath, 0o755);
 
@@ -2605,7 +2754,7 @@ test.describe('Wake Daemon', () => {
     });
 
     test('Codex UI wake attempts actionable message submit and drops coalesced heartbeat event (#13456, #13480)', async () => {
-        const subId = 'sub_' + crypto.randomUUID();
+        const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-codex-mixed-submit';
 
         db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
@@ -2637,7 +2786,7 @@ test.describe('Wake Daemon', () => {
         fs.ensureDirSync(binDir);
         writeMockPs(binDir);
         const mockOsascriptPath = path.join(binDir, 'osascript');
-        const mockOutPath = path.join(DAEMON_DIR, 'mock_codex_mixed_submit_out.json');
+        const mockOutPath       = path.join(DAEMON_DIR, 'mock_codex_mixed_submit_out.json');
         fs.writeFileSync(mockOsascriptPath, `#!/usr/bin/env node\nimport fs from 'fs';\nfs.writeFileSync('${mockOutPath}', JSON.stringify(process.argv.slice(2)));\n`);
         fs.chmodSync(mockOsascriptPath, 0o755);
 
@@ -2711,8 +2860,8 @@ test.describe('Wake Daemon', () => {
         };
 
         const overflowAmount = 50;
-        const totalItems = SQLITE_IN_CLAUSE_BATCH_SIZE + overflowAmount;
-        const ids = new Set(Array.from({ length: totalItems }, (_, i) => `id_${i}`));
+        const totalItems     = SQLITE_IN_CLAUSE_BATCH_SIZE + overflowAmount;
+        const ids            = new Set(Array.from({ length: totalItems }, (_, i) => `id_${i}`));
 
         const nodeResults = getNodesData(mockDb, ids);
         expect(prepareCount).toBe(2);

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -1366,6 +1366,85 @@ test.describe('Wake Daemon', () => {
         expect(finalDigest).not.toContain('priority: normal');
     });
 
+    test('#15054: one message wakes an identity once across overlapping routes and later GraphLog replay', async () => {
+        const agentId = '@test-agent-stable-message-dedup';
+
+        insertWakeSubscription(db, {
+            agentId,
+            filters              : {},
+            harnessTargetMetadata: {adapter: 'test', coalesceWindow: 0}
+        });
+        insertWakeSubscription(db, {
+            agentId,
+            filters              : {priority: 'high'},
+            harnessTargetMetadata: {adapter: 'test', coalesceWindow: 0}
+        });
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
+        });
+
+        let   deliveryCount = 0;
+        const firstDelivery = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('First stable-message wake did not arrive')), 12000);
+
+            daemonProcess.stdout.on('data', data => {
+                const output = data.toString();
+                deliveryCount += (output.match(/\[Wake Daemon Test Adapter\] Delivered/g) || []).length;
+                if (deliveryCount > 0) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        const {msgId} = insertMessageWake(db, {
+            agentId,
+            priority: 'high',
+            subject : 'Stable message identity'
+        });
+
+        await firstDelivery;
+
+        // Projection replay: the application MESSAGE id is unchanged, but GraphLog appends a new
+        // position above both per-subscription numeric watermarks. It must not create another prompt.
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
+        await new Promise(resolve => setTimeout(resolve, 4500));
+
+        expect(deliveryCount).toBe(1);
+
+        const durableState = JSON.parse(
+            fs.readFileSync(path.join(DAEMON_DIR, 'woken-watermark.json'), 'utf8')
+        );
+        expect(durableState.__messageIdsByIdentity[agentId]).toContain(msgId);
+
+        // Restart durability: the stable-id claim survives the daemon process. A third GraphLog
+        // emission after restart is still the same logical message and must remain prompt-silent.
+        const firstExit = new Promise(resolve => daemonProcess.once('exit', resolve));
+        daemonProcess.kill('SIGKILL');
+        await firstExit;
+        daemonProcess = null;
+
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
+
+        let restartDeliveryCount = 0;
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
+        });
+        daemonProcess.stdout.on('data', data => {
+            restartDeliveryCount += (data.toString().match(/\[Wake Daemon Test Adapter\] Delivered/g) || []).length;
+        });
+        daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+
+        await new Promise(resolve => setTimeout(resolve, 4000));
+        expect(restartDeliveryCount).toBe(0);
+    });
+
     test('delivers Codex wake events via app-server adapter without osascript fallback (#13067)', async () => {
         const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-codex-app-server';

--- a/test/playwright/unit/ai/daemons/wake/instanceResolver.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/instanceResolver.spec.mjs
@@ -1,8 +1,11 @@
 import {test, expect} from '@playwright/test';
 import {
+    getDefaultInstanceTarget,
     getDefaultInstancePid,
     getInstancePid,
+    resolveDefaultInstanceTarget,
     resolveDefaultInstancePid,
+    resolveGuiAppProcessIdentity,
     resolveInstancePid
 } from '../../../../../../ai/daemons/wake/instanceResolver.mjs';
 
@@ -16,8 +19,10 @@ import {
  * null (caller fails closed) when no instance matches.
  */
 
-const DEFAULT_DIR = '/Users/tobiasuhlig/Library/Application Support/Claude';
-const NEO_DIR      = '/Users/tobiasuhlig/.claude-instances/Neo';
+const DEFAULT_DIR       = '/Users/tobiasuhlig/Library/Application Support/Claude';
+const NEO_DIR           = '/Users/tobiasuhlig/.claude-instances/Neo';
+const CODEX_DEFAULT_DIR = '/Users/tobiasuhlig/Library/Application Support/Codex';
+const EMMY_DIR          = '/Users/tobiasuhlig/.codex-app-instances/neo-gpt-emmy';
 
 // Default instance: main executable has NO --user-data-dir (launched via Finder/dock); only the
 // Electron helper subprocesses carry it. Second (Neo) instance: main executable carries it (--args).
@@ -35,6 +40,15 @@ const PS_SINGLE_DEFAULT = [
     `13119 13106 /Applications/Claude.app/Contents/Frameworks/Claude Helper.app/Contents/MacOS/Claude Helper --type=gpu-process --user-data-dir=${DEFAULT_DIR} --gpu-preferences=xyz`
 ].join('\n');
 
+// Codex's automation/product name does not match its installed physical app identity: AppleScript
+// routes through `Codex`, while the two resident processes live under ChatGPT.app/ChatGPT.
+const PS_TWO_CODEX_RESIDENTS = [
+    `3778 1 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT`,
+    `3788 3778 /Applications/ChatGPT.app/Contents/Frameworks/ChatGPT Helper.app/Contents/MacOS/ChatGPT Helper --type=gpu-process --user-data-dir=${CODEX_DEFAULT_DIR}`,
+    `37111 1 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT --user-data-dir=${EMMY_DIR}`,
+    `37122 37111 /Applications/ChatGPT.app/Contents/Frameworks/ChatGPT Helper.app/Contents/MacOS/ChatGPT Helper --type=renderer --user-data-dir=${EMMY_DIR}`
+].join('\n');
+
 test.describe('wake-daemon instanceResolver', () => {
     test('resolves the second instance main pid directly when the main executable carries --user-data-dir', () => {
         // The Neo instance's main process carries the dir (open --args), and is preferred over its helper.
@@ -47,8 +61,8 @@ test.describe('wake-daemon instanceResolver', () => {
     });
 
     test('distinguishes the two same-bundle instances (never cross-targets)', () => {
-        const neo     = resolveInstancePid({userDataDir: NEO_DIR, psOutput: PS_BOTH_INSTANCES});
-        const dflt    = resolveInstancePid({userDataDir: DEFAULT_DIR, psOutput: PS_BOTH_INSTANCES});
+        const neo  = resolveInstancePid({userDataDir: NEO_DIR, psOutput: PS_BOTH_INSTANCES});
+        const dflt = resolveInstancePid({userDataDir: DEFAULT_DIR, psOutput: PS_BOTH_INSTANCES});
         expect(neo).toBe(20001);
         expect(dflt).toBe(13106);
         expect(neo).not.toBe(dflt);
@@ -99,7 +113,8 @@ test.describe('wake-daemon instanceResolver', () => {
     });
 
     test('resolveDefaultInstancePid returns null when the default cannot be uniquely picked', () => {
-        // Two arg-less mains -> ambiguous -> null (caller keeps legacy activate; never a wrong target).
+        // The pid-only compatibility projection is null; structured delivery callers inspect
+        // `status: ambiguous` and fail closed instead of treating null as legacy activation.
         const twoArgless = [
             `13106 1 /Applications/Claude.app/Contents/MacOS/Claude`,
             `40001 1 /Applications/Claude.app/Contents/MacOS/Claude`
@@ -126,5 +141,78 @@ test.describe('wake-daemon instanceResolver', () => {
         const throwingExec = async () => { throw new Error('ps failed') };
         expect(await getDefaultInstancePid({appName: 'Claude', exec: throwingExec})).toBeNull();
         expect(await getDefaultInstancePid({exec: async () => ({stdout: PS_BOTH_INSTANCES})})).toBeNull();
+    });
+
+    test('separates the Codex activation name from the ChatGPT process identity (#15054)', () => {
+        expect(resolveGuiAppProcessIdentity('Codex')).toEqual({
+            bundleName    : 'ChatGPT',
+            executableName: 'ChatGPT'
+        });
+        expect(resolveGuiAppProcessIdentity('Claude')).toEqual({
+            bundleName    : 'Claude',
+            executableName: 'Claude'
+        });
+    });
+
+    test('resolves the arg-less ChatGPT.app resident as the default Codex target (#15054)', () => {
+        expect(resolveDefaultInstancePid({appName: 'Codex', psOutput: PS_TWO_CODEX_RESIDENTS})).toBe(3778);
+        expect(resolveDefaultInstanceTarget({appName: 'Codex', psOutput: PS_TWO_CODEX_RESIDENTS})).toMatchObject({
+            bundleName    : 'ChatGPT',
+            executableName: 'ChatGPT',
+            instanceCount : 2,
+            pid           : 3778,
+            status        : 'resolved'
+        });
+        expect(resolveInstancePid({userDataDir: EMMY_DIR, psOutput: PS_TWO_CODEX_RESIDENTS})).toBe(37111);
+    });
+
+    test('reports ambiguous instead of authorizing generic activation for two arg-less Codex residents (#15054)', () => {
+        const psOutput = [
+            `3778 1 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT`,
+            `37111 1 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT`
+        ].join('\n');
+
+        expect(resolveDefaultInstanceTarget({appName: 'Codex', psOutput})).toMatchObject({
+            instanceCount: 2,
+            pid          : null,
+            status       : 'ambiguous'
+        });
+    });
+
+    test('does not authorize generic activation when only the addressed Codex resident is running (#15054)', () => {
+        const psOutput = [
+            `37111 1 /Applications/ChatGPT.app/Contents/MacOS/ChatGPT --user-data-dir=${EMMY_DIR}`,
+            `37122 37111 /Applications/ChatGPT.app/Contents/Frameworks/ChatGPT Helper.app/Contents/MacOS/ChatGPT Helper --type=renderer --user-data-dir=${EMMY_DIR}`
+        ].join('\n');
+
+        expect(resolveDefaultInstanceTarget({appName: 'Codex', psOutput})).toMatchObject({
+            instanceCount: 1,
+            pid          : null,
+            status       : 'ambiguous'
+        });
+    });
+
+    test('getDefaultInstanceTarget preserves Codex process-identity evidence from the ps probe (#15054)', async () => {
+        const exec = async () => ({stdout: PS_TWO_CODEX_RESIDENTS});
+
+        await expect(getDefaultInstanceTarget({appName: 'Codex', exec})).resolves.toMatchObject({
+            bundleName   : 'ChatGPT',
+            instanceCount: 2,
+            pid          : 3778,
+            status       : 'resolved'
+        });
+    });
+
+    test('getDefaultInstanceTarget preserves process-probe failure as fail-closed evidence (#15054)', async () => {
+        const exec = async () => {
+            throw new Error('ps unavailable');
+        };
+
+        await expect(getDefaultInstanceTarget({appName: 'Codex', exec})).resolves.toMatchObject({
+            bundleName   : 'ChatGPT',
+            instanceCount: 0,
+            pid          : null,
+            status       : 'probe-failed'
+        });
     });
 });

--- a/test/playwright/unit/ai/daemons/wake/wokenWatermark.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/wokenWatermark.spec.mjs
@@ -1,5 +1,10 @@
 import {test, expect}                      from '@playwright/test';
-import {clampWatermark, filterEventsByWatermark, maxLogId} from '../../../../../../ai/daemons/wake/wokenWatermark.mjs';
+import {
+    claimUnwokenMessages,
+    clampWatermark,
+    filterEventsByWatermark,
+    maxLogId
+} from '../../../../../../ai/daemons/wake/wokenWatermark.mjs';
 
 test.describe('wake wokenWatermark (#12850)', () => {
     test('filterEventsByWatermark keeps only events strictly above the watermark', () => {
@@ -66,7 +71,7 @@ test.describe('wake wokenWatermark (#12850)', () => {
         // Recipient has already been woken through logId 100. A heavy-delta re-include re-queues an
         // OLD high-priority message (logId 42, still readAt=null so the readAt filter alone misses it)
         // alongside one genuinely-new normal message.
-        const watermark = 100;
+        const watermark         = 100;
         const reincludedBacklog = [
             {type: 'message', messageId: 'm-stale-high', priority: 'high',   logId: 42},
             {type: 'message', messageId: 'm-new',        priority: 'normal', logId: 150}
@@ -83,7 +88,7 @@ test.describe('wake wokenWatermark (#12850)', () => {
 
     test('AC4 regression — genuinely-new events (all types) above the watermark are never dropped', () => {
         const watermark = 200;
-        const fresh = [
+        const fresh     = [
             {type: 'message',    messageId: 'm', logId: 201},
             {type: 'task',       taskId: 't',    logId: 202},
             {type: 'permission', scope: 'p',     logId: 203},
@@ -92,5 +97,32 @@ test.describe('wake wokenWatermark (#12850)', () => {
 
         expect(filterEventsByWatermark(fresh, watermark)).toHaveLength(4);
         expect(maxLogId(fresh)).toBe(204);
+    });
+
+    test('#15054: stable message IDs are claimed once across routes and later GraphLog emissions', () => {
+        const history = new Set();
+        const first   = claimUnwokenMessages([
+            {messageId: 'MESSAGE:a', logId: 10},
+            {messageId: 'MESSAGE:b', logId: 11}
+        ], history);
+        const replay = claimUnwokenMessages([
+            {messageId: 'MESSAGE:a', logId: 500},
+            {messageId: 'MESSAGE:c', logId: 501}
+        ], history);
+
+        expect(first.claimed.map(event => event.messageId)).toEqual(['MESSAGE:a', 'MESSAGE:b']);
+        expect(first.duplicates).toEqual([]);
+        expect(replay.claimed.map(event => event.messageId)).toEqual(['MESSAGE:c']);
+        expect(replay.duplicates.map(event => event.messageId)).toEqual(['MESSAGE:a']);
+        expect([...history]).toEqual(['MESSAGE:a', 'MESSAGE:b', 'MESSAGE:c']);
+    });
+
+    test('claimUnwokenMessages conservatively reclaims events without a stable message ID', () => {
+        const history = new Set();
+        const event   = {subject: 'malformed but potentially real'};
+
+        expect(claimUnwokenMessages([event], history).claimed).toEqual([event]);
+        expect(claimUnwokenMessages([event], history).claimed).toEqual([event]);
+        expect(history.size).toBe(0);
     });
 });

--- a/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lifecycle/resumeHarness.spec.mjs
@@ -1,6 +1,6 @@
 import {setup} from '../../../../setup.mjs';
 
-const appName = 'ResumeHarnessTest';
+const appName             = 'ResumeHarnessTest';
 const skipCiSubstrateData = !!process.env.NEO_TEST_SKIP_CI;
 
 setup({
@@ -34,7 +34,7 @@ import {
 test.describe('ai/scripts/resumeHarness', () => {
     test.describe.configure({mode: 'serial'});
 
-    const scriptPath = path.resolve(process.cwd(), 'ai/scripts/lifecycle/resumeHarness.mjs');
+    const scriptPath  = path.resolve(process.cwd(), 'ai/scripts/lifecycle/resumeHarness.mjs');
     const cooldownDir = path.resolve(process.cwd(), '.neo-ai-data/wake-daemon');
 
     /**
@@ -65,8 +65,8 @@ test.describe('ai/scripts/resumeHarness', () => {
      *
      * Codex live-host opt-in: `codex debug app-server send-message-v2`
      * creates/injects into a real Codex Desktop thread. Default tests MUST use
-     * `CODEX_APP_SERVER_MOCK=1` plus a mock CLI path (`CODEX_CLI_PATH` or
-     * `CODEX_DESKTOP_CLI_PATH`). Real probes require `RUN_LIVE_CODEX_APP_SERVER=1`.
+     * `CODEX_APP_SERVER_MOCK=1` plus a mock `NEO_FLEET_CODEX_BIN` config-leaf override.
+     * Real probes require `RUN_LIVE_CODEX_APP_SERVER=1`.
      */
     let gatePath, overrideEnv;
     const gateOnlyEnv = () => ({...process.env, WAKE_GATE_FILE_PATH: gatePath});
@@ -157,7 +157,7 @@ test.describe('ai/scripts/resumeHarness', () => {
 
         expect(resolveResumeHarnessInstanceAddress({
             metadata: {},
-            env: {
+            env     : {
                 NEO_HARNESS_INSTANCE_ADDRESS     : '  4242  ',
                 NEO_HARNESS_INSTANCE_ADDRESS_TYPE: '  pid  '
             }
@@ -179,7 +179,7 @@ test.describe('ai/scripts/resumeHarness', () => {
 
         expect(() => resolveResumeHarnessInstanceAddress({
             metadata: {},
-            env: {
+            env     : {
                 NEO_HARNESS_INSTANCE_ADDRESS     : '/tmp/vega',
                 NEO_HARNESS_INSTANCE_ADDRESS_TYPE: 'tmuxSession'
             }
@@ -194,18 +194,18 @@ test.describe('ai/scripts/resumeHarness', () => {
         })).toBe(12345);
 
         expect(await resolveResumeHarnessInstancePid({
-            addressType      : 'userDataDir',
-            instanceAddress  : '/Users/example/.claude-instances/neo-opus-vega',
-            deploymentMode   : 'local',
-            getInstancePidFn : async ({userDataDir}) =>
+            addressType     : 'userDataDir',
+            instanceAddress : '/Users/example/.claude-instances/neo-opus-vega',
+            deploymentMode  : 'local',
+            getInstancePidFn: async ({userDataDir}) =>
                 userDataDir === '/Users/example/.claude-instances/neo-opus-vega' ? 24680 : null
         })).toBe(24680);
 
         await expect(resolveResumeHarnessInstancePid({
-            addressType      : 'userDataDir',
-            instanceAddress  : '/Users/example/.claude-instances/missing',
-            deploymentMode   : 'local',
-            getInstancePidFn : async () => null
+            addressType     : 'userDataDir',
+            instanceAddress : '/Users/example/.claude-instances/missing',
+            deploymentMode  : 'local',
+            getInstancePidFn: async () => null
         })).rejects.toThrow(/No running Claude instance found/);
 
         await expect(resolveResumeHarnessInstancePid({
@@ -269,12 +269,12 @@ test.describe('ai/scripts/resumeHarness', () => {
             focusSeedSequence: 'r-undo'
         });
         expect(applyHarnessMetadataDefaults({appName: 'Antigravity'})).toMatchObject({
-            appName     : 'Antigravity',
-            tabShortcut : 'shift+i'
+            appName    : 'Antigravity',
+            tabShortcut: 'shift+i'
         });
         expect(applyHarnessMetadataDefaults({appName: 'Antigravity', tabShortcut: null})).toMatchObject({
-            appName     : 'Antigravity',
-            tabShortcut : null
+            appName    : 'Antigravity',
+            tabShortcut: null
         });
         expect(applyHarnessMetadataDefaults({appName: 'Claude', focusSeedKey: 'space'})).not.toHaveProperty('focusSeedSequence');
     });
@@ -419,7 +419,7 @@ test.describe('ai/scripts/resumeHarness', () => {
     });
 
     test('wake daemon consumes shared host app defaults instead of duplicating shortcut literals (#12434)', async () => {
-        const bridgePath = path.resolve(process.cwd(), 'ai/daemons/wake/daemon.mjs');
+        const bridgePath    = path.resolve(process.cwd(), 'ai/daemons/wake/daemon.mjs');
         const bridgeContent = fs.readFileSync(bridgePath, 'utf-8');
 
         expect(bridgeContent).toContain('applyHarnessMetadataDefaults(meta)');
@@ -435,7 +435,7 @@ test.describe('ai/scripts/resumeHarness', () => {
         // successful CLI dispatch, resumeHarness records the spawned process's PID via
         // harnessLifecycle.recordHarnessProcess — the PID the NEXT invocation SIGTERMs during cleanup.
         const harnessLifecycle = await import('../../../../../../ai/scripts/lifecycle/harnessLifecycle.mjs');
-        const stateFile = harnessLifecycle.getStateFilePath('@neo-gemini-pro');
+        const stateFile        = harnessLifecycle.getStateFilePath('@neo-gemini-pro');
         if (fs.existsSync(stateFile)) fs.unlinkSync(stateFile);
 
         const mockPath = path.join(os.tmpdir(), `mock-ag-record-${randomUUID()}`);
@@ -464,13 +464,13 @@ test.describe('ai/scripts/resumeHarness', () => {
         // should detect ESRCH and proceed with a fresh spawn — cleanup never blocks fresh-spawn on
         // missing/dead PIDs.
         const harnessLifecycle = await import('../../../../../../ai/scripts/lifecycle/harnessLifecycle.mjs');
-        const stateFile = harnessLifecycle.getStateFilePath('@neo-gemini-pro');
-        const stalePid = 999999; // way above typical pid_max
+        const stateFile        = harnessLifecycle.getStateFilePath('@neo-gemini-pro');
+        const stalePid         = 999999; // way above typical pid_max
         await import('fs/promises').then(({writeFile, mkdir}) => mkdir(path.dirname(stateFile), {recursive: true})
             .then(() => writeFile(stateFile, JSON.stringify({pid: stalePid, spawnedAt: Date.now() - 60000}))));
 
         const mockPath = path.join(os.tmpdir(), `mock-ag-stale-${randomUUID()}`);
-        const outPath = path.join(os.tmpdir(), `out-ag-stale-${randomUUID()}`);
+        const outPath  = path.join(os.tmpdir(), `out-ag-stale-${randomUUID()}`);
         fs.writeFileSync(mockPath, `#!/usr/bin/env node\nconst fs = require('fs');\nfs.writeFileSync('${outPath}', JSON.stringify(process.argv.slice(2)));\n`, { mode: 0o755 });
 
         try {
@@ -498,7 +498,7 @@ test.describe('ai/scripts/resumeHarness', () => {
         // The env override exercises the cross-platform adapter path without depending on
         // host-specific Antigravity installs.
         const mockPath = path.join(os.tmpdir(), `mock-ag-${randomUUID()}`);
-        const outPath = path.join(os.tmpdir(), `out-ag-${randomUUID()}`);
+        const outPath  = path.join(os.tmpdir(), `out-ag-${randomUUID()}`);
         fs.writeFileSync(mockPath, `#!/usr/bin/env node\nconst fs = require('fs');\nfs.writeFileSync('${outPath}', JSON.stringify(process.argv.slice(2)));\n`, { mode: 0o755 });
 
         try {
@@ -595,7 +595,7 @@ test.describe('ai/scripts/resumeHarness', () => {
         test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
         const { getLockPath } = await import('../../../../../../ai/scripts/lifecycle/inflightLock.mjs');
-        const lockPath = getLockPath('sunset_restart', '@neo-gpt');
+        const lockPath        = getLockPath('sunset_restart', '@neo-gpt');
         if (fs.existsSync(lockPath)) fs.unlinkSync(lockPath);
 
         try {
@@ -613,16 +613,16 @@ test.describe('ai/scripts/resumeHarness', () => {
         }
     });
 
-    test('Codex app-server: adapter executes send-message-v2 <payload> via CODEX_CLI_PATH mock (#10679)', async () => {
+    test('Codex app-server: adapter executes send-message-v2 via AiConfig Fleet binary (#15054)', async () => {
         test.skip(process.platform !== 'darwin', 'Codex Desktop app-server adapter is currently mac-specific');
         test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
         const mockPath = path.join(os.tmpdir(), `mock-codex-${randomUUID()}`);
-        const outPath = path.join(os.tmpdir(), `out-codex-${randomUUID()}`);
+        const outPath  = path.join(os.tmpdir(), `out-codex-${randomUUID()}`);
         fs.writeFileSync(mockPath, `#!/usr/bin/env node\nconst fs = require('fs');\nfs.writeFileSync('${outPath}', JSON.stringify(process.argv.slice(2)));\n`, { mode: 0o755 });
 
         try {
-            const env = { ...overrideEnv, CODEX_APP_SERVER_MOCK: '1', CODEX_CLI_PATH: mockPath };
+            const env = {...overrideEnv, CODEX_APP_SERVER_MOCK: '1', NEO_FLEET_CODEX_BIN: mockPath};
             execFileSync('node', [scriptPath, '@neo-gpt', 'testReason'], { encoding: 'utf-8', stdio: 'pipe', env });
 
             expect(fs.existsSync(outPath)).toBe(true);
@@ -638,7 +638,7 @@ test.describe('ai/scripts/resumeHarness', () => {
         }
     });
 
-    test('Codex app-server: adapter resolves bundled Desktop CLI when PATH lacks bare codex (#13287)', async () => {
+    test('Codex app-server: adapter uses AiConfig Fleet binary when PATH lacks bare codex (#15054)', async () => {
         test.skip(process.platform !== 'darwin', 'Codex Desktop app-server adapter is currently mac-specific');
         test.skip(skipCiSubstrateData, 'CI-skip: substrate data not seeded - bucket C (#10903)');
 
@@ -655,10 +655,9 @@ test.describe('ai/scripts/resumeHarness', () => {
         try {
             const env = {
                 ...overrideEnv,
-                CODEX_APP_SERVER_MOCK : '1',
-                CODEX_CLI_PATH        : '',
-                CODEX_DESKTOP_CLI_PATH: mockPath,
-                PATH                  : path.dirname(process.execPath)
+                CODEX_APP_SERVER_MOCK: '1',
+                NEO_FLEET_CODEX_BIN  : mockPath,
+                PATH                 : path.dirname(process.execPath)
             };
 
             execFileSync('node', [scriptPath, '@neo-gpt', 'testReason'], { encoding: 'utf-8', stdio: 'pipe', env });
@@ -690,7 +689,7 @@ test.describe('ai/scripts/resumeHarness', () => {
         const missingAgCli = path.join(os.tmpdir(), `missing-ag-fail-${randomUUID()}`);
 
         const { getLockPath } = await import('../../../../../../ai/scripts/lifecycle/inflightLock.mjs');
-        const lockPath = getLockPath('sunset_restart', '@neo-gemini-pro');
+        const lockPath        = getLockPath('sunset_restart', '@neo-gemini-pro');
         if (fs.existsSync(lockPath)) fs.unlinkSync(lockPath);
 
         const env = { ...overrideEnv, ANTIGRAVITY_CLI_PATH: missingAgCli };


### PR DESCRIPTION
Resolves #15054

Related: #13012
Related: #15047
Related: #13480

Parallel Codex Desktop residents now keep logical product identity separate from physical process identity. The wake daemon resolves logical `Codex` against `ChatGPT.app` / `ChatGPT`, targets the exact addressed resident PID, and refuses absent, ambiguous, or process-probe-failed states before activation or keystrokes. Wake and resume consumers also hard-cut the stale Codex CLI env/path shadows and read `AiConfig.fleet.harnessBinaries.codex` at the use site.

The final replay fence closes a second delivery boundary exposed by the live matrix: GraphLog can re-emit one stable Memory Core message through later edge/node rows, so a numeric log watermark alone is not an exactly-once prompt contract. The daemon now atomically claims stable message ids per identity before adapter dispatch, persists those claims across restart, prunes read claims, and still advances the numeric watermark when a later row repeats an already-claimed unread message.

Evidence: L3 (operator-enabled live two-resident delivery, sibling-negative transcript searches, unavailable-resident refusal, and restart-persistent exact-once replay probe) → L3 required (AC3–AC5 two-resident matrix). Residual: delayed turn-start proof latency remains tracked by #13480.

## Deltas from ticket

- The initial product/process alias fix exposed a deeper unsafe edge: one running main process is not a safe legacy singleton when it carries `--user-data-dir`. That state now classifies as ambiguous and fails closed.
- A failed host `ps` probe remains `probe-failed` evidence instead of collapsing to `not-found` and silently authorizing generic activation.
- The live matrix exposed replay after later GraphLog node/edge emissions of the same stable message ids. The final commit adds a backward-compatible `__messageIdsByIdentity` claim ledger to the existing watermark file; no second state authority or schema migration is introduced.
- Claims happen synchronously before the adapter await, so overlapping routes cannot race one message into two prompts. Restart preserves the claim, while read-state pruning bounds the ledger.
- The old `CODEX_CLI_PATH` / `CODEX_DESKTOP_CLI_PATH` chain was removed in one hard cut; tests override the canonical `NEO_FLEET_CODEX_BIN` leaf instead.
- Machine-local boot envelopes and live subscription repair remain ignored operator state; no resident profile path or static Emmy wake template enters committed identity roots.

## Test Evidence

- Focused resolver/replay regression slice — 54 passed, 0 failed.
- Wider exact wake/resume neighborhood — 231 passed, 10 skipped, 0 failed.
- Rebased-head run of all four changed specs — 94 passed, 10 skipped, 0 failed.
- Agent preflight plus both commit hooks — passed.
- Live resolver probe — logical `Codex` mapped to physical `ChatGPT.app` / `ChatGPT`; the unique arg-less default resident and Emmy's explicit profile resolved to distinct live PIDs.
- Live matrix — Euclid and Emmy each received only their addressed nonces; a nonexistent addressed profile failed before AppleScript; reciprocal Euclid delivery coalesced two source messages into one digest.
- Replay falsifier — three Emmy source messages re-emitted at later GraphLog rows and reproduced a duplicate aggregate before the fence.
- Live replay proof — source `MESSAGE:70b26d4c-4ca0-40cf-8d51-74e2081db44a` produced one Emmy user prompt with nonce `28791408-8373-411a-9a61-723dc9666472`, zero Euclid prompts, one reciprocal receipt, and no later replay under the restarted daemon. An exact diff over all eight touched files proved the rebased head byte-identical to that live-validated tree.
- Repository-wide unit baseline — 6,664 passed, 30 failed, 5 skipped, 21 did not run. This is not claimed as a green gate: all reported failures were outside the changed wake/resume specs.

## Post-Merge Validation

- [ ] Move the supervised checkout from the detached validation head back onto merged `dev`, preserving its existing operator data, then restart the wake child.
- [ ] Repeat one high-priority probe in each direction and verify one explicit `userDataDir` route per identity after Memory Core restart.
- [ ] Recheck delayed turn-start proof telemetry under an already-active Codex turn; delivery is now exactly-once, but the 45-second proof window can still expire before the Desktop prompt surfaces.

## Commits

- `5d6ede460b` — `fix(wake): disambiguate parallel Codex residents (#15054)`
- `4888282a87` — `fix(wake): fence replayed message prompts (#15054)`

## Evolution

The implementation started as a product-name/process-name alias. Live delivery testing exposed two stronger contracts: nullable PID compatibility could not distinguish a safe singleton from an addressed sibling, and monotonically increasing GraphLog rows were not equivalent to unique messages. The final shape preserves both kinds of evidence explicitly—structured resident resolution for activation safety and stable message identity for prompt exactly-once semantics—without creating a parallel source of truth.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session 837ad74b-c2d2-413d-9aab-b7165a93a82a.
