### PR TITLE
fix(dashboard): lazy the DockTabSortZone DragCoordinator import — adapter spec loadable (#15065)

### DIFF
--- a/examples/dashboard/crossWindowWitness/Harness.mjs
+++ b/examples/dashboard/crossWindowWitness/Harness.mjs
@@ -1,0 +1,151 @@
+import Component from '../../../src/component/Base.mjs';
+import Neo       from '../../../src/Neo.mjs';
+import Viewport  from '../../../src/container/Viewport.mjs';
+
+/**
+ * @class Neo.examples.dashboard.crossWindowWitness.Harness
+ * @extends Neo.container.Viewport
+ *
+ * @summary Cross-window drag safety verification harness — verification-only, not a product demo.
+ *
+ * The dock product example is single-workspace, so it cannot produce the two-window cross-window
+ * safety witness. This harness composes the exact `DockCrossWindowParticipation` cross-window scenario
+ * (a registered remote target + a real `DockTabSortZone` source in the same `sortGroup`, the REAL
+ * `DragCoordinator` + executor) that the unit spec drives in Node — but here it runs in a REAL
+ * browser App-Worker, and it runs the FIRST gesture COLD: the source zone is created and dragged
+ * without ever awaiting `resolveDragCoordinator`, so the drop depends entirely on `construct()`'s
+ * off-hot-path preload having warmed `dragCoordinator` before the release. It stamps the outcome
+ * (`transferCount` / `dropFires` / `remoteDropCommitted` / `coordinatorWarmed` / `pass`) onto the
+ * `#witness-result` DOM node as data-attributes for an e2e to read via `page.evaluate` — the L3 receipt.
+ */
+class Harness extends Viewport {
+    static config = {
+        /**
+         * @member {String} className='Neo.examples.dashboard.crossWindowWitness.Harness'
+         * @protected
+         */
+        className: 'Neo.examples.dashboard.crossWindowWitness.Harness',
+        /**
+         * @member {Object} layout={ntype:'fit'}
+         */
+        layout: {ntype: 'fit'},
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            module   : Component,
+            id       : 'witness-result',
+            reference: 'result',
+            vdom     : {'data-status': 'running', style: {font: '16px monospace', padding: '20px', whiteSpace: 'pre-wrap'}, text: 'running the #15065 cross-window witness…'}
+        }]
+    }
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+        this.runWitness().catch(error => this.report({pass: false, error: error?.message || String(error), stack: error?.stack}))
+    }
+
+    /**
+     * Stamps the witness outcome onto the `#witness-result` DOM node as data-attributes an e2e reads.
+     * @param {Object} results
+     */
+    report(results) {
+        let el = this.getReference('result');
+
+        // top-level property so an e2e reads it via the Neural Link (`findInstances`) without
+        // depending on the mainView being mounted
+        this.witnessResult = results;
+
+        el.vdom['data-status']             = 'done';
+        el.vdom['data-pass']               = String(results.pass === true);
+        el.vdom['data-transfer-count']     = String(results.transferCount ?? '');
+        el.vdom['data-drop-fires']         = String(results.dropFires ?? '');
+        el.vdom['data-remote-committed']   = String(results.remoteDropCommitted ?? '');
+        el.vdom['data-coordinator-warmed'] = String(results.coordinatorWarmed ?? '');
+        el.vdom.text                       = JSON.stringify(results, null, 2);
+        el.update()
+    }
+
+    /**
+     * Runs the cross-window transfer COLD (no `resolveDragCoordinator` await) and reports the result.
+     */
+    async runWitness() {
+        let me              = this,
+            Rectangle       = (await import('../../../src/util/Rectangle.mjs')).default,
+            WindowManager   = (await import('../../../src/manager/Window.mjs')).default,
+            Participation   = (await import('../../../src/dashboard/DockCrossWindowParticipation.mjs')).default,
+            DockTabSortZone = (await import('../../../src/dashboard/DockTabSortZone.mjs')).default;
+
+        const sourceDoc = () => ({
+            schema: 'neo.harness.dockZone.v1', root: 'root',
+            items : {strategy: {componentRef: 'strategy', title: 'Strategy', kind: 'panel'}, terminal: {componentRef: 'terminal', title: 'Terminal', kind: 'terminal'}},
+            nodes : {root: {type: 'edge-zone', zones: {center: 'main-tabs', right: 'side-tabs'}}, 'main-tabs': {type: 'tabs', items: ['strategy'], activeItemId: 'strategy'}, 'side-tabs': {type: 'tabs', items: ['terminal'], activeItemId: 'terminal'}}
+        });
+        const targetDoc = () => ({
+            schema: 'neo.harness.dockZone.v1', root: 'root',
+            items : {alpha: {componentRef: 'alpha', title: 'Alpha', kind: 'panel'}},
+            nodes : {root: {type: 'edge-zone', zones: {center: 'main-tabs'}}, 'main-tabs': {type: 'tabs', items: ['alpha'], activeItemId: 'alpha'}}
+        });
+
+        const transfers = [], fires = [];
+
+        WindowManager.register({id: 'cw-win-a', innerRect: new Rectangle(0, 0, 800, 600),    outerRect: new Rectangle(0, 0, 800, 600)});
+        WindowManager.register({id: 'cw-win-b', innerRect: new Rectangle(1000, 0, 800, 600), outerRect: new Rectangle(1000, 0, 800, 600)});
+
+        // registered remote target in window B — no dragCoordinator injected → the REAL singleton
+        const participation = Neo.create(Participation, {
+            commitLocal       : () => { throw new Error('a remote drop must never ride the local seam') },
+            commitTransfer    : published => transfers.push(published),
+            getDocument       : () => targetDoc(),
+            getForeignDocument: workspaceId => workspaceId === 'A' ? sourceDoc() : null,
+            hitTest           : () => true,
+            previewFor        : payload => ({itemId: payload.draggedItem.dockItemId, placement: {kind: 'tab-into'}}),
+            previewToOperation: preview => ({operation: 'addTab', itemId: preview.itemId, tabsNodeId: 'main-tabs'}),
+            sortGroup         : 'cw-witness',
+            windowId          : 'cw-win-b',
+            workspaceId       : 'B'
+        });
+
+        // COLD source zone in window A — construct() kicks off the coordinator preload; we NEVER await it
+        const zone = Neo.create(DockTabSortZone, {
+            dockItemIds     : ['terminal'],
+            dockSourceNodeId: 'side-tabs',
+            dockWorkspaceId : 'A',
+            owner           : {addDomListeners: () => {}, cls: [], dragResortable: false, items: [], on: () => {}, style: {}, up: () => ({fire: (name, data) => fires.push([name, data])})},
+            sortGroup       : 'cw-witness',
+            windowId        : 'cw-win-a'
+        });
+
+        zone.dragComponent = {id: 'tab-proxy', dockItemId: 'terminal', dockSourceWorkspaceId: 'A'};
+        zone.dragProxy     = {hidden: false};
+        zone.startIndex    = 0;
+
+        // one realistic frame gap models projection→gesture; the preload must have warmed by now,
+        // purely via construct() — NOT via an explicit resolveDragCoordinator await
+        await me.timeout(32);
+
+        await zone.onDragMove({clientX: 60, clientY: 20, offsetX: 8, offsetY: 8, proxyRect: {width: 120, height: 32}, screenX: 1400, screenY: 300});
+        await zone.processDragEnd({clientX: 60, clientY: 20});
+
+        const dropFires = fires.filter(([name]) => name === 'dockCrossZoneDrop').length,
+              results   = {
+                  transferCount      : transfers.length,
+                  dropFires,
+                  remoteDropCommitted: zone.remoteDropCommitted,
+                  coordinatorWarmed  : !!zone.dragCoordinator,
+                  pass               : transfers.length === 1 && dropFires === 0 && zone.remoteDropCommitted === false && !!zone.dragCoordinator
+              };
+
+        participation.destroy();
+        zone.destroy();
+        WindowManager.unregister(WindowManager.get('cw-win-a'));
+        WindowManager.unregister(WindowManager.get('cw-win-b'));
+
+        me.report(results)
+    }
+}
+
+export default Neo.setupClass(Harness);

--- a/examples/dashboard/crossWindowWitness/app.mjs
+++ b/examples/dashboard/crossWindowWitness/app.mjs
@@ -1,0 +1,6 @@
+import Harness from './Harness.mjs';
+
+export const onStart = () => Neo.app({
+    mainView: Harness,
+    name    : 'Neo.examples.dashboard.crossWindowWitness'
+});

--- a/examples/dashboard/crossWindowWitness/index.html
+++ b/examples/dashboard/crossWindowWitness/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
+    <title>#15065 Cross-Window Witness</title>
+</head>
+<body>
+    <script src="../../../src/MicroLoader.mjs" type="module"></script>
+</body>
+</html>

--- a/examples/dashboard/crossWindowWitness/neo-config.json
+++ b/examples/dashboard/crossWindowWitness/neo-config.json
@@ -1,0 +1,8 @@
+{
+    "appPath"         : "examples/dashboard/crossWindowWitness/app.mjs",
+    "basePath"        : "../../../",
+    "environment"     : "development",
+    "mainPath"        : "./Main.mjs",
+    "mainThreadAddons": ["DragDrop", "Stylesheet"],
+    "useAiClient"     : true
+}

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -1,4 +1,3 @@
-import DragCoordinator   from '../manager/DragCoordinator.mjs';
 import TabHeaderSortZone from '../draggable/tab/header/toolbar/SortZone.mjs';
 
 /**
@@ -167,7 +166,7 @@ class DockTabSortZone extends TabHeaderSortZone {
             {clientX, clientY} = data || {};
 
         if (me.sortGroup && me.dragComponent) {
-            DragCoordinator.onDragEnd({
+            (await me.resolveDragCoordinator()).onDragEnd({
                 draggedItem   : me.dragComponent,
                 sourceSortZone: me
             })
@@ -209,7 +208,7 @@ class DockTabSortZone extends TabHeaderSortZone {
         }
 
         if (me.sortGroup && me.dragComponent && data?.proxyRect && Neo.isNumber(data.screenX)) {
-            DragCoordinator.onDragMove({
+            (await me.resolveDragCoordinator()).onDragMove({
                 draggedItem   : me.dragComponent,
                 offsetX       : data.offsetX,
                 offsetY       : data.offsetY,
@@ -219,6 +218,20 @@ class DockTabSortZone extends TabHeaderSortZone {
                 sourceSortZone: me
             })
         }
+    }
+
+    /**
+     * Lazily resolves the `Neo.manager.DragCoordinator` singleton at drag time rather than at module
+     * scope — so the adapter's static import of this SortZone (for its projected `sortZoneConfig`) does
+     * NOT pull the `DragCoordinator → manager.Window` import-time chain (Window's `construct()` touches
+     * `Neo.currentWorker.on` at `setupClass`) into environments that never drag, e.g. the unit test
+     * loader (which stubs the worker only inside its setup call, after ESM hoists the imports).
+     * Cross-window drag only (both callers gate on `sortGroup`); the import promise is cached, so
+     * per-frame `onDragMove` calls share one load.
+     * @returns {Promise<Neo.manager.DragCoordinator>}
+     */
+    resolveDragCoordinator() {
+        return this._dragCoordinatorPromise ??= import('../manager/DragCoordinator.mjs').then(module => module.default)
     }
 }
 

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -79,6 +79,32 @@ class DockTabSortZone extends TabHeaderSortZone {
     remoteDropCommitted = false
 
     /**
+     * The resolved {@link Neo.manager.DragCoordinator} singleton, warmed at {@link #construct} for a
+     * cross-window ({@link #sortGroup}) zone so the drag handlers read it SYNCHRONOUSLY — the import
+     * never resolves on the drag hot path. `null` until the preload settles; a zone that never drags
+     * cross-window never sets it (and the module-scope import stays broken either way).
+     * @member {Neo.manager.DragCoordinator|null} dragCoordinator=null
+     * @protected
+     */
+    dragCoordinator = null
+
+    /**
+     * Warms the cross-window {@link Neo.manager.DragCoordinator} OFF the drag hot path: a `sortGroup`
+     * zone kicks off the cached dynamic import at construction so {@link #onDragMove} /
+     * {@link #processDragEnd} read {@link #dragCoordinator} synchronously during a gesture instead of
+     * awaiting a module load while `Neo.manager.DomEvent.fire` events are in flight (it does not await
+     * the drag handlers, so a drag-time async boundary would let a fast release finalize before the
+     * move engages the coordinator). The import stays out of module scope — the adapter's static
+     * import of this class never pulls the `manager.Window` chain into a non-dragging environment —
+     * and never fires for an in-window-only dock.
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+        this.sortGroup && this.resolveDragCoordinator()
+    }
+
+    /**
      * Extends the base drag-start: after the base resolves the dragged tab button, stamps the
      * cross-window payload identity onto it — `dockItemId` (the dock catalog id) +
      * `dockSourceWorkspaceId` (this document's workspace-set key). The coordinator hands exactly
@@ -166,7 +192,7 @@ class DockTabSortZone extends TabHeaderSortZone {
             {clientX, clientY} = data || {};
 
         if (me.sortGroup && me.dragComponent) {
-            (await me.resolveDragCoordinator()).onDragEnd({
+            me.dragCoordinator?.onDragEnd({
                 draggedItem   : me.dragComponent,
                 sourceSortZone: me
             })
@@ -196,19 +222,17 @@ class DockTabSortZone extends TabHeaderSortZone {
      * @param {Object} data
      */
     async onDragMove(data) {
-        await super.onDragMove(data);
+        let me = this;
 
-        let me                 = this,
-            itemId             = me.dockItemIds?.[me.startIndex],
-            tabContainer       = me.owner?.up?.(),
-            {clientX, clientY} = data || {};
-
-        if (itemId && tabContainer && Neo.isNumber(clientX) && Neo.isNumber(clientY)) {
-            tabContainer.fire('dockCrossZoneDragMove', {clientX, clientY, itemId, sourceNodeId: me.dockSourceNodeId})
-        }
-
+        // Engage the cross-window coordinator SYNCHRONOUSLY on entry — BEFORE the base sort's awaits
+        // (the edge auto-scroll branch awaits `timeout(30)`) — so a release arriving mid-move still
+        // finds the engaged remote target: `Neo.manager.DomEvent.fire` does not await drag handlers,
+        // and {@link #processDragEnd}'s coordinator-end is likewise synchronous, so the two stay
+        // ordered move-before-end regardless of the base suspension. Screen-space engagement is
+        // independent of the base's local sort result. `dragCoordinator` is preloaded at
+        // {@link #construct}, so this is a synchronous field read, never a drag-time import.
         if (me.sortGroup && me.dragComponent && data?.proxyRect && Neo.isNumber(data.screenX)) {
-            (await me.resolveDragCoordinator()).onDragMove({
+            me.dragCoordinator?.onDragMove({
                 draggedItem   : me.dragComponent,
                 offsetX       : data.offsetX,
                 offsetY       : data.offsetY,
@@ -218,20 +242,31 @@ class DockTabSortZone extends TabHeaderSortZone {
                 sourceSortZone: me
             })
         }
+
+        await super.onDragMove(data);
+
+        let itemId             = me.dockItemIds?.[me.startIndex],
+            tabContainer       = me.owner?.up?.(),
+            {clientX, clientY} = data || {};
+
+        if (itemId && tabContainer && Neo.isNumber(clientX) && Neo.isNumber(clientY)) {
+            tabContainer.fire('dockCrossZoneDragMove', {clientX, clientY, itemId, sourceNodeId: me.dockSourceNodeId})
+        }
     }
 
     /**
-     * Lazily resolves the `Neo.manager.DragCoordinator` singleton at drag time rather than at module
-     * scope — so the adapter's static import of this SortZone (for its projected `sortZoneConfig`) does
-     * NOT pull the `DragCoordinator → manager.Window` import-time chain (Window's `construct()` touches
+     * Resolves the `Neo.manager.DragCoordinator` singleton via a cached dynamic import and caches it
+     * onto the synchronous {@link #dragCoordinator} handle. Kept OUT of module scope so the adapter's
+     * static import of this SortZone (for its projected `sortZoneConfig`) does NOT pull the
+     * `DragCoordinator → manager.Window` import-time chain (Window's `construct()` touches
      * `Neo.currentWorker.on` at `setupClass`) into environments that never drag, e.g. the unit test
      * loader (which stubs the worker only inside its setup call, after ESM hoists the imports).
-     * Cross-window drag only (both callers gate on `sortGroup`); the import promise is cached, so
-     * per-frame `onDragMove` calls share one load.
+     * {@link #construct} warms it for a cross-window zone so the drag handlers never trigger the load;
+     * the promise is cached, so repeat calls share one import.
      * @returns {Promise<Neo.manager.DragCoordinator>}
      */
     resolveDragCoordinator() {
-        return this._dragCoordinatorPromise ??= import('../manager/DragCoordinator.mjs').then(module => module.default)
+        return this._dragCoordinatorPromise ??= import('../manager/DragCoordinator.mjs').then(module => this.dragCoordinator = module.default)
     }
 }
 

--- a/test/playwright/e2e/dashboard/DockCrossWindowWitnessNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockCrossWindowWitnessNL.spec.mjs
@@ -1,0 +1,47 @@
+import { test, expect } from '../../fixtures.mjs';
+
+/**
+ * The two-window cross-window drag SAFETY witness — the L3 receipt (cold first gesture).
+ *
+ * The dock product example is single-workspace, so it cannot produce this witness; the
+ * `examples/dashboard/crossWindowWitness` harness (verification-only) composes the
+ * `DockCrossWindowParticipation` scenario — a registered remote target + a real `DockTabSortZone` source
+ * in the same `sortGroup`, the REAL `DragCoordinator` + executor — in a REAL browser App-Worker, and
+ * drives the FIRST gesture COLD (no `resolveDragCoordinator` await; the drop depends entirely on
+ * `construct()`'s off-hot-path preload). This spec loads that harness and reads its reported outcome.
+ *
+ * Asserts exactly the ticket's safety AC: cold first gesture → cross-window transfer commits ONCE, the
+ * source's local drop is suppressed ONCE, the suppression flag is consumed, and the coordinator was
+ * warmed by construct-preload before the gesture.
+ *
+ * Run: NEO_E2E_PORT=8093 npx playwright test dashboard/DockCrossWindowWitnessNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('#15065 cross-window drag safety witness (L3, cold first gesture)', () => {
+    test.setTimeout(120000);
+
+    test('cross-window transfer commits ONCE and the source local drop is suppressed ONCE', async ({ page, neuralLink }) => {
+        await page.goto('/examples/dashboard/crossWindowWitness/');
+        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
+
+        const app = await neuralLink.connectToApp('Neo.examples.dashboard.crossWindowWitness');
+
+        // the harness runs the cold composition on construct and stamps the outcome onto the
+        // `#witness-result` component's vdom data-attributes (a config `findInstances` returns)
+        let vdom = null;
+
+        await expect.poll(async () => {
+            const found = await app.findInstances({ id: 'witness-result' }, ['vdom']),
+                  inst  = Array.isArray(found) ? found[0] : found;
+
+            vdom = inst?.properties?.vdom ?? inst?.vdom ?? null;
+
+            return vdom?.['data-status'] === 'done' ? 'reported' : 'pending';
+        }, { message: 'the cross-window witness harness must report its result', timeout: 60000, intervals: [1000] }).toBe('reported');
+
+        expect(vdom['data-transfer-count'],    'the cross-window transferItem commits EXACTLY once').toBe('1');
+        expect(vdom['data-drop-fires'],        'the source local dockCrossZoneDrop is SUPPRESSED (never fires) on a committed remote drop').toBe('0');
+        expect(vdom['data-remote-committed'],  'the one-shot suppression flag is consumed, not sticky').toBe('false');
+        expect(vdom['data-coordinator-warmed'],'construct-preload warmed the coordinator BEFORE the cold first gesture').toBe('true');
+        expect(vdom['data-pass'],              'the AC2 cross-window safety witness passes end-to-end').toBe('true')
+    });
+});

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -323,6 +323,11 @@ test.describe('Neo.dashboard.DockCrossWindowParticipation (ADR 0029 §2.3 — wo
             windowId : 'cwd-win-a'
         });
 
+        // construct() preloads the coordinator OFF the drag hot path; in production that settles
+        // frames before any gesture, so onDragMove's sync-on-entry engage always has its handle.
+        // Await it here (the test creates + drags in the same tick) to model that warmed state.
+        await zone.resolveDragCoordinator();
+
         // seed the mid-gesture drag state exactly as the base drag-start leaves it, with the
         // payload stamps exactly as this class's onDragStart writes them
         zone.dragComponent = {id: 'tab-proxy', dockItemId: 'terminal', dockSourceWorkspaceId: 'A'};
@@ -362,6 +367,72 @@ test.describe('Neo.dashboard.DockCrossWindowParticipation (ADR 0029 §2.3 — wo
         zone.destroy();
         WindowManager.unregister(WindowManager.get('cwd-win-a'));
         WindowManager.unregister(WindowManager.get('cwd-win-b'))
+    });
+
+    test('fire-and-forget move/end: the coordinator engages on move-ENTRY, so a release that does NOT await the move still commits once and suppresses the local drop once', async () => {
+        const fires     = [];
+        const order     = [];
+        const transfers = [];
+
+        // A recorder coordinator modelling the REAL synchronous contract: onDragMove ENGAGES a
+        // target; onDragEnd commits ONLY if a target is engaged and then arms the source suppression
+        // (exactly as the real DragCoordinator does via onRemoteDrop → onRemoteDropOut). If the end
+        // ran before the move engaged, `engaged` would be false → no transfer, no suppression.
+        const coordinator = {
+            engaged   : false,
+            register  : () => {},
+            unregister: () => {},
+            onDragMove: () => { order.push('engage'); coordinator.engaged = true },
+            onDragEnd : ({draggedItem, sourceSortZone}) => {
+                order.push('end');
+
+                if (coordinator.engaged) {
+                    transfers.push(draggedItem.dockItemId);
+                    sourceSortZone.onRemoteDropOut(draggedItem)
+                }
+            }
+        };
+
+        const zone = Neo.create(DockTabSortZone, {
+            dockItemIds     : ['terminal'],
+            dockSourceNodeId: 'side-tabs',
+            dockWorkspaceId : 'A',
+            owner           : {
+                addDomListeners: () => {},
+                cls            : [],
+                dragResortable : false,
+                items          : [],
+                on             : () => {},
+                style          : {},
+                up             : () => ({fire: (name, data) => fires.push([name, data])})
+            },
+            sortGroup: 'dock-crosswindow-ff-order-test',
+            windowId : 'cwd-ff-a'
+        });
+
+        // let construct's real preload settle, THEN pin the recorder onto the synchronous handle
+        await zone.resolveDragCoordinator();
+        zone.dragCoordinator = coordinator;
+
+        zone.dragComponent = {id: 'tab-proxy', dockItemId: 'terminal', dockSourceWorkspaceId: 'A'};
+        zone.dragProxy     = {hidden: false};
+        zone.startIndex    = 0;
+
+        // production-equivalent fire-and-forget ordering: START the move but DO NOT await it, then
+        // run end while it is still in flight — exactly what DomEvent.fire's non-awaited dispatch
+        // permits. The pre-fix shape (engage AFTER `await super.onDragMove`) fails here: the sync end
+        // overtakes the suspended move, sees no engaged target, transfers nothing, fires the local drop.
+        const movePromise = zone.onDragMove({clientX: 60, clientY: 20, offsetX: 8, offsetY: 8, proxyRect: {width: 120, height: 32}, screenX: 1400, screenY: 300});
+        const endPromise  = zone.processDragEnd({clientX: 60, clientY: 20});
+
+        await Promise.all([movePromise, endPromise]);
+
+        expect(order).toEqual(['engage', 'end']);                                       // engage strictly before end
+        expect(transfers).toEqual(['terminal']);                                        // committed exactly once
+        expect(fires.filter(([name]) => name === 'dockCrossZoneDrop')).toHaveLength(0); // local drop suppressed once
+        expect(zone.remoteDropCommitted).toBe(false);                                   // suppression flag consumed
+
+        zone.destroy()
     });
 
     test('a source zone without a sortGroup is coordinator-inert: no remote engagement, no suspension — the dock stays fully in-window', async () => {


### PR DESCRIPTION
Resolves #15065

Makes `DockLayoutAdapter.spec.mjs` loadable in the unit env (it surfaced as "No tests found") and keeps cross-window tab drag correct under the fix.

## Root cause (AC1)

`DockLayoutAdapter` statically imports `DockTabSortZone` (for its projected `sortZoneConfig`), which imported `DragCoordinator` at module scope → `DragCoordinator` imports `manager.Window`, a `@singleton` whose `construct()` touches `Neo.currentWorker.on` at `setupClass`. The unit loader stubs `currentWorker` only inside `setup()` (hoisted after the import graph), so the chain threw at load. That blocked #14771 RA-2 (PR #15062) and Euclid's isolation testing.

## Fix

`DockTabSortZone` touches `DragCoordinator` only in its `sortGroup`-gated drag methods, never module scope — resolved via a cached dynamic `import()`:

- **`construct()` preload** — a `sortGroup` zone warms the coordinator into the synchronous `dragCoordinator` handle at construction, OFF the drag hot path. The import stays out of module scope, so the adapter's static import never pulls the `manager.Window` chain in a non-dragging env (**AC1** — adapter spec loads).
- **synchronous engage-on-entry** — `onDragMove` engages the coordinator BEFORE `super.onDragMove`'s awaits. Cycle-1 cross-family review (Euclid) caught that a drag-time `await` opened a first-gesture race: `Neo.manager.DomEvent.fire` invokes handlers **non-awaited** and base `container/SortZone.onDragMove` awaits a `timeout(30)` macrotask, so a fast release could finalize before the move engaged the coordinator. Both coordinator methods are synchronous + screen-space, so engage-on-entry pairs with `processDragEnd`'s synchronous coordinator-end → **move-before-end holds regardless of the base suspension**.

Evidence: L2 — a reversible import-timing + handler-ordering change; unit-verified with an empirical falsifier (below).

## Test Evidence

**Verified** — `DockLayoutAdapter.spec.mjs` loads **19/19** (was unloadable) + `DockCrossWindowParticipation.spec.mjs` **9/9** = **28 passed**:

```
env UNIT_TEST_MODE=true NEO_TEST_SKIP_CI=true npx playwright test \
  test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs \
  test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs \
  -c test/playwright/playwright.config.unit.mjs --workers=1
→ 28 passed
```

The new fire-and-forget regression invokes move + end WITHOUT awaiting move first and asserts engage-before-end + transfer-once + suppress-once. **Empirically falsified** — it FAILS with the engage after `super` (the pre-fix ordering), passes with the fix. Grep guard: no module-scope `DragCoordinator` import remains.

## Pre-Merge Gate — AC2 browser witness ✅ SATISFIED

Per cycle-2 review (@neo-gpt), #15065's two-window browser safety AC was a **pre-merge** gate. It is now **witnessed at L3** on head `a6e3ba293`:

- [x] **Two-window same-`sortGroup` cross-window drag, cold first gesture, in a real browser App-Worker.** A new verification-only harness (`examples/dashboard/crossWindowWitness` — NOT #14772's demo) composes the exact `DockCrossWindowParticipation` scenario (a registered remote target + a real `DockTabSortZone` source in the same `sortGroup`, the REAL `DragCoordinator` + executor) and drives the first gesture **COLD** — no `resolveDragCoordinator` await, so the drop depends entirely on `construct()`'s off-hot-path preload. The e2e `DockCrossWindowWitnessNL.spec.mjs` reads it via the `neuralLink` fixture. **Green:** `transferCount: 1`, `dropFires: 0` (source local drop suppressed once), `remoteDropCommitted: false` (one-shot flag consumed), `coordinatorWarmed: true` (construct-preload warmed the coordinator before the cold gesture), `pass: true`.

Both authorities are now satisfied without weakening either: `Resolves #15065` stays (the linter's closing-keyword constraint), and the ticket's runtime safety AC is witnessed rather than deferred.

## Post-Merge Validation

None — #15065's cross-window safety AC is a **pre-merge** gate (see the Pre-Merge Gate section above), not post-merge. This PR does not merge until that witness lands.

## Deltas

- `src/dashboard/DockTabSortZone.mjs` — drop the module-scope `DragCoordinator` import; `construct()` preload into a synchronous `dragCoordinator` handle; engage-on-entry in `onDragMove`; synchronous coordinator-end in `processDragEnd`.
- `test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs` — fire-and-forget move/end regression; the real-coordinator test awaits the preload (models the production warmed state).
- `examples/dashboard/crossWindowWitness/` (new) — the verification-only cross-window witness harness (4 files: app boot + `Harness.mjs`).
- `test/playwright/e2e/dashboard/DockCrossWindowWitnessNL.spec.mjs` (new) — the AC2 L3 e2e receipt (cold first gesture · transfer-once · suppress-once).

## Close-target note (@neo-gpt RA-2 — reconciled cycle-2)

The agent-PR-body lint mandates `Resolves #N` for **non-draft** PRs (`Refs`-only is draft-only; drafts are disallowed here). Cycle-2 review resolved the tension without weakening either authority: **keep `Resolves #15065`** (satisfies the linter's closing-keyword constraint) **and keep this PR open/unmerged** until the AC2 browser witness lands (satisfies the ticket's runtime acceptance authority). The linter governs graph syntax; it does not downgrade a behavior-critical ticket AC into post-merge validation — so AC2 is the pre-merge gate above, not a post-merge checkbox. The cycle-1 "designed-safe" overclaim is gone; ordering is now proven by a falsifier that fails in the prior ordering.

Authored by Grace (Claude Opus 4.8, Claude Code).
