### PR TITLE
feat(fleet): add isolated Codex Desktop lifecycle (#15047)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -90,7 +90,15 @@ class Config extends ConfigProvider {
                      * leaf, and the lifecycle status's `binaryVersion` surfaces what actually ran.
                      * @type {string}
                      */
-                    codex: leaf('/Applications/ChatGPT.app/Contents/Resources/codex', 'NEO_FLEET_CODEX_BIN', 'string')
+                    codex: leaf('/Applications/ChatGPT.app/Contents/Resources/codex', 'NEO_FLEET_CODEX_BIN', 'string'),
+                    /**
+                     * The Codex Desktop packaged MAIN binary — directly spawnable and supervised.
+                     * Its private app-profile/project/updater capabilities are probed from the
+                     * installed bundle before every first spawn; this leaf only owns executable
+                     * location, never compatibility policy.
+                     * @type {string}
+                     */
+                    codexDesktop: leaf('/Applications/ChatGPT.app/Contents/MacOS/ChatGPT', 'NEO_FLEET_CODEX_DESKTOP_BIN', 'string')
                 }
             },
             /**

--- a/ai/scripts/fleet/onboardPeer.mjs
+++ b/ai/scripts/fleet/onboardPeer.mjs
@@ -46,7 +46,7 @@ import {normalizeAgentIdentityNodeId}                 from '../../graph/normaliz
  *
  * **Usage**:
  *   node ai/scripts/fleet/onboardPeer.mjs --resident-id <s> --github-username <s>
- *       --harness-type <antigravity|claude-code|claude-desktop|codex>          # dry-run;
+ *       --harness-type <antigravity|claude-code|claude-desktop|codex|codex-desktop> # dry-run;
  *           [--clone-url <s> --repo-slug <s>]          # pair required unless repo already exists
  *   node ai/scripts/fleet/onboardPeer.mjs ... --commit                          # execute phase delta
  *   node ai/scripts/fleet/onboardPeer.mjs --help
@@ -59,7 +59,8 @@ const
         'antigravity'   : 'gemini',
         'claude-code'   : 'claude',
         'claude-desktop': 'claude',
-        codex           : 'gpt'
+        codex           : 'gpt',
+        'codex-desktop' : 'gpt'
     });
 
 /**
@@ -411,36 +412,45 @@ export function renderPlan(intent, plan) {
 }
 
 /**
- * @summary Build the exact operator-owned login command from the instance home resolved by the
- * lifecycle service. The home and executable are owned launch-contract outputs — never guessed
- * from the resident id or PATH — and are single-quoted so shell metacharacters remain data.
+ * @summary Build the exact operator-owned auth command from typed lifecycle-owned paths. Marker
+ * families consume `authHome` + `authCommand`; in-app families consume `instanceHome` +
+ * `launchCommand`. The split is load-bearing for Codex Desktop: its GUI main is never invoked as a
+ * CLI login command. Paths are never guessed from resident id/PATH and are shell-quoted as data.
  * @param {Object} options
  * @param {String} options.harnessType Curated harness family.
- * @param {String} options.instanceHome Absolute instance home from lifecycle status.
- * @param {String} options.launchCommand Absolute executable path from lifecycle status.
+ * @param {String} [options.instanceHome] GUI profile home for in-app families.
+ * @param {String} [options.launchCommand] GUI executable for in-app families.
+ * @param {String} [options.authHome] Marker/auth home for marker families.
+ * @param {String} [options.authCommand] Auth executable for marker families.
  * @returns {String}
  */
-export function buildLoginCommand({harnessType, instanceHome, launchCommand} = {}) {
+export function buildLoginCommand({harnessType, instanceHome, launchCommand, authHome, authCommand} = {}) {
     if (!CURATED_HARNESS_TYPES.includes(harnessType)) {
         throw new Error(`buildLoginCommand: unsupported harnessType '${String(harnessType)}'.`);
     }
-    if (typeof instanceHome !== 'string' || !path.isAbsolute(instanceHome) || CONTROL_CHARACTERS.test(instanceHome)) {
-        throw new Error('buildLoginCommand: lifecycle status must provide a control-character-free absolute instanceHome.');
+    const
+        markerMode = getHarnessAuthMode(harnessType) === 'marker',
+        home       = markerMode ? authHome : instanceHome,
+        command    = markerMode ? authCommand : launchCommand;
+
+    if (typeof home !== 'string' || !path.isAbsolute(home) || CONTROL_CHARACTERS.test(home)) {
+        throw new Error(`buildLoginCommand: lifecycle status must provide a control-character-free absolute ${markerMode ? 'authHome' : 'instanceHome'}.`);
     }
-    if (typeof launchCommand !== 'string' || !path.isAbsolute(launchCommand) || CONTROL_CHARACTERS.test(launchCommand)) {
-        throw new Error('buildLoginCommand: lifecycle status must provide a control-character-free absolute launchCommand.');
+    if (typeof command !== 'string' || !path.isAbsolute(command) || CONTROL_CHARACTERS.test(command)) {
+        throw new Error(`buildLoginCommand: lifecycle status must provide a control-character-free absolute ${markerMode ? 'authCommand' : 'launchCommand'}.`);
     }
 
     const
         quote         = value => `'${value.replaceAll("'", "'\\''")}'`,
-        quotedHome    = quote(instanceHome),
-        quotedCommand = quote(launchCommand);
+        quotedHome    = quote(home),
+        quotedCommand = quote(command);
 
     // Per-family operator-owned auth step: CLI families have a login command / in-session login;
     // the app-bundle GUI families sign in INSIDE the launched window (no CLI login exists) — the
     // printed line relaunches the same isolated instance if the operator closed it.
     switch (harnessType) {
         case 'codex':
+        case 'codex-desktop':
             return `CODEX_HOME=${quotedHome} ${quotedCommand} login`;
         case 'claude-code':
             return `CLAUDE_CONFIG_DIR=${quotedHome} ${quotedCommand}  # then /login inside the session`;
@@ -458,7 +468,8 @@ export function buildLoginCommand({harnessType, instanceHome, launchCommand} = {
  * @param {Object} options
  * @param {String} options.harnessType Curated harness family.
  * @param {Object} options.status The long-lived owner's `startAgent`/`status` projection —
- *                                `{authRequired, instanceHome, launchCommand}` consumed here.
+ *                                `{authRequired, instanceHome, launchCommand, authHome,
+ *                                  authCommand}` consumed here.
  * @returns {{kind: 'sign-in-app'|'login-required'|'done'|'unknown', lines: String[]}} printable
  * lines in conductor voice; `kind` is the decision itself, assertable without string-matching.
  */
@@ -469,7 +480,7 @@ export function deriveAuthHandoff({harnessType, status} = {}) {
             lines: [
                 '',
                 '  SIGN-IN REQUIRED (operator-owned, inside the launched app window):',
-                `    ${buildLoginCommand({harnessType, instanceHome: status.instanceHome, launchCommand: status.launchCommand})}`
+                `    ${buildLoginCommand({harnessType, instanceHome: status.instanceHome, launchCommand: status.launchCommand, authHome: status.authHome, authCommand: status.authCommand})}`
             ]
         };
     }
@@ -480,7 +491,7 @@ export function deriveAuthHandoff({harnessType, status} = {}) {
             lines: [
                 '',
                 '  LOGIN REQUIRED (operator-owned, exactly once for this home):',
-                `    ${buildLoginCommand({harnessType, instanceHome: status.instanceHome, launchCommand: status.launchCommand})}`
+                `    ${buildLoginCommand({harnessType, instanceHome: status.instanceHome, launchCommand: status.launchCommand, authHome: status.authHome, authCommand: status.authCommand})}`
             ]
         };
     }

--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -1,11 +1,12 @@
-import {execFile, spawn}         from 'child_process';
-import fs                        from 'fs';
-import path                      from 'path';
-import AiConfig                  from '../../config.mjs';
-import Base                      from '../../../src/core/Base.mjs';
-import {deriveAgentInstanceHome} from './deriveAgentInstanceHome.mjs';
-import {deriveHarnessLaunchSpec} from './deriveHarnessLaunchSpec.mjs';
-import FleetRegistryService      from './FleetRegistryService.mjs';
+import {execFile, spawn}                                            from 'child_process';
+import fs                                                           from 'fs';
+import path                                                         from 'path';
+import AiConfig                                                     from '../../config.mjs';
+import Base                                                         from '../../../src/core/Base.mjs';
+import {deriveAgentInstanceHome}                                    from './deriveAgentInstanceHome.mjs';
+import {deriveHarnessLaunchSpec}                                    from './deriveHarnessLaunchSpec.mjs';
+import FleetRegistryService                                         from './FleetRegistryService.mjs';
+import {cleanupCodexDesktopCrashpad, probeCodexDesktopCapabilities} from './manageCodexDesktopRuntime.mjs';
 
 // The forced-projection env var is a CROSS-PROCESS CONTRACT: the FM sets it on the spawned child env,
 // and the Neural Link server's `resolveToolProjectionMode` reads this exact name as the fallback to
@@ -26,7 +27,8 @@ const HARNESS_BINARY_LEAF_KEYS = {
     'antigravity'   : 'antigravity',
     'claude-code'   : 'claudeCode',
     'claude-desktop': 'claudeDesktop',
-    'codex'         : 'codex'
+    'codex'         : 'codex',
+    'codex-desktop' : 'codexDesktop'
 };
 
 // The ONLY ambient parent-env vars that cross into a spawned harness. The FM's own environment
@@ -52,7 +54,9 @@ const PROTO_ENV_KEYS = Object.freeze(['__proto__', 'constructor', 'prototype']);
 // unknown), never a guessed boolean.
 const HARNESS_AUTH_MARKERS = {
     'claude-code': '.credentials.json',
-    'codex'      : 'auth.json'
+    'codex'      : 'auth.json',
+    // Codex Desktop authenticates through the bundled CLI against its typed nested authHome.
+    'codex-desktop': 'auth.json'
 };
 
 /**
@@ -213,6 +217,20 @@ class FleetLifecycleService extends Base {
     execFileFn = null
 
     /**
+     * Installed-bundle capability probe for `codex-desktop`. Defaults to the read-only static
+     * bundle inspector; injectable so lifecycle specs never depend on an installed GUI app.
+     * @member {Function|null} codexDesktopCapabilityProbeFn=null
+     */
+    codexDesktopCapabilityProbeFn = null
+
+    /**
+     * Exact-profile Crashpad cleanup after a Codex Desktop main exit. Defaults to the bounded
+     * process-ownership helper; injectable so unit specs never inspect or signal host processes.
+     * @member {Function|null} codexDesktopCleanupFn=null
+     */
+    codexDesktopCleanupFn = null
+
+    /**
      * Supervised processes keyed by agent id. Records carry NO secret.
      * @member {Map<String,Object>} processes
      * @private
@@ -236,13 +254,19 @@ class FleetLifecycleService extends Base {
     start(id, opts = {}) {
         if (this.isRunning(id)) return this.status(id);
 
+        const priorRecord = this.processes.get(id);
+
+        if (priorRecord?.state === 'stopping' || priorRecord?.cleanupUnresolved) {
+            throw new Error(`FleetLifecycleService.start: refusing to spawn agent '${id}' while Codex Desktop helper ownership is ${priorRecord.state === 'stopping' ? 'still being finalized' : 'unresolved after a lifecycle failure'}.`);
+        }
+
         // The RAW definition read (Brain-internal): the public getAgent projection deliberately
         // redacts metadata.launch, so the spawn path — the one consumer entitled to the launch
         // override — reads through the registry's definition surface instead.
         const agent = this.getRegistry().getDefinition(id);
         if (!agent) throw new Error(`FleetLifecycleService.start: unknown agent '${id}'.`);
 
-        const launch                          = this.resolveLaunch(agent),
+        const launch                          = this.resolveLaunch(agent, opts),
               {command, args, env: launchEnv} = launch;
 
         // Env-key contract guard (fail-fast): each reserved class occupies a DISTINCT child-env slot.
@@ -290,6 +314,34 @@ class FleetLifecycleService extends Base {
 
         if (!resolvedCommand) {
             throw new Error(`FleetLifecycleService.start: harness binary '${command}' not found or not executable for agent '${id}' (path-shaped commands resolve against the child cwd; bare commands against the child's PATH; executable permission required). Pin the AiConfig fleet.harnessBinaries leaf or the harnessBinaryPaths field to a real executable.`);
+        }
+
+        let
+            authCommand            = launch.instanceHome && HARNESS_AUTH_MARKERS[agent.harnessType] ? resolvedCommand : null,
+            codexDesktopCapability = null;
+
+        if (agent.harnessType === 'codex-desktop' && launch.instanceHome) {
+            const configuredAuthCommand = this.getHarnessBinaryPath('codex');
+
+            authCommand = configuredAuthCommand && this.resolveExecutable(configuredAuthCommand, env.PATH, opts.cwd);
+
+            if (!authCommand) {
+                const reason = 'bundled Codex CLI auth command is unavailable';
+                this.publishUnavailable({id, launch, resolvedCommand, cwd: opts.cwd, reason});
+                throw new Error(`FleetLifecycleService.start: codex-desktop is unavailable for agent '${id}' — ${reason}.`);
+            }
+
+            try {
+                codexDesktopCapability = this.getCodexDesktopCapabilityProbe()({binaryPath: resolvedCommand});
+            } catch {
+                codexDesktopCapability = {available: false, reason: 'installed-bundle capability probe failed'};
+            }
+
+            if (!codexDesktopCapability?.available || !path.isAbsolute(codexDesktopCapability.crashpadExecutable || '')) {
+                const reason = codexDesktopCapability?.reason || 'exact packaged Crashpad helper proof is missing';
+                this.publishUnavailable({id, launch, resolvedCommand, authCommand, cwd: opts.cwd, reason});
+                throw new Error(`FleetLifecycleService.start: codex-desktop is unavailable for agent '${id}' — ${reason}.`);
+            }
         }
 
         const pat = this.getRegistry().resolveCredential(id);
@@ -346,10 +398,17 @@ class FleetLifecycleService extends Base {
             stderrBytes: 0,
             // Curated-launch observability: the family + isolated home let `status` compute the live
             // per-home `authRequired` heuristic; null for raw-launch agents (unknown layout).
-            harnessType  : launch.instanceHome ? agent.harnessType : null,
-            instanceHome : launch.instanceHome ?? null,
-            launchCommand: launch.instanceHome ? resolvedCommand : null,
-            binaryVersion: null
+            harnessType       : launch.instanceHome ? agent.harnessType : null,
+            instanceHome      : launch.instanceHome ?? null,
+            authHome          : launch.authHome ?? (HARNESS_AUTH_MARKERS[agent.harnessType] ? launch.instanceHome : null),
+            authCommand,
+            electronProfile   : launch.electronProfile ?? null,
+            crashpadExecutable: codexDesktopCapability?.crashpadExecutable ?? null,
+            launchCommand     : launch.instanceHome ? resolvedCommand : null,
+            binaryVersion     : null,
+            failureReason     : null,
+            cleanupUnresolved : false,
+            finalizePromise   : null
         };
         this.processes.set(id, record);
 
@@ -382,18 +441,22 @@ class FleetLifecycleService extends Base {
             record.stderrBytes += chunk.length;
         });
 
-        child.on?.('exit', (code, signal) => {
-            record.state    = 'stopped';
-            record.exitCode = code;
-            record.signal   = signal;
-            record.exitedAt = new Date().toISOString();
-            record.child    = null;
-        });
+        child.on?.('exit', (code, signal) => this.finalizeExitedProcess(record, {code, signal}));
         child.on?.('error', error => {
-            record.state    = 'failed';
-            record.error    = error.message;
-            record.exitedAt = new Date().toISOString();
-            record.child    = null;
+            record.state         = 'failed';
+            record.error         = error.message;
+            record.failureReason = 'tracked harness process emitted an error';
+            record.exitedAt      = new Date().toISOString();
+
+            if (record.electronProfile && record.pid != null) {
+                // A successfully spawned Desktop main can emit `error` without proving process exit.
+                // Keep the child handle + block replacement until stop drives the main to `exit` and
+                // the profile finalizer proves zero helpers. Pre-spawn errors have no pid/profile
+                // ownership and retain the legacy retryable failure path below.
+                record.cleanupUnresolved = true;
+            } else {
+                record.child = null;
+            }
         });
 
         return this.status(id);
@@ -402,12 +465,34 @@ class FleetLifecycleService extends Base {
     /**
      * Gracefully stop an agent's process: `SIGTERM`, then `SIGKILL` after `sigkillTimeoutMs`.
      * @param {String} id
-     * @returns {Promise<Object>} `{success, id, state}`
+     * @returns {Promise<Object>} `{success, id, state, cleanupUnresolved}`; the final field is true
+     * only when exact-profile Codex Desktop helper ownership remains unresolved.
      */
     stop(id) {
         const record = this.processes.get(id);
-        if (!record || !record.child || record.state !== 'running') {
-            return Promise.resolve({success: false, id, state: record?.state ?? 'stopped'});
+
+        if (record?.state === 'stopping' && record.finalizePromise) {
+            return record.finalizePromise.then(() => ({
+                success          : record.state === 'stopped',
+                id,
+                state            : record.state,
+                cleanupUnresolved: Boolean(record.cleanupUnresolved)
+            }));
+        }
+
+        if (record?.cleanupUnresolved && !record.child && record.electronProfile && record.crashpadExecutable) {
+            record.finalizePromise = null;
+
+            return this.finalizeCodexDesktopHelpers(record).then(() => ({
+                success          : record.state === 'stopped',
+                id,
+                state            : record.state,
+                cleanupUnresolved: Boolean(record.cleanupUnresolved)
+            }));
+        }
+
+        if (!record || !record.child || (record.state !== 'running' && !record.cleanupUnresolved)) {
+            return Promise.resolve({success: false, id, state: record?.state ?? 'stopped', cleanupUnresolved: Boolean(record?.cleanupUnresolved)});
         }
 
         const child = record.child;
@@ -415,11 +500,17 @@ class FleetLifecycleService extends Base {
         return new Promise(resolve => {
             let settled = false;
 
-            const finish = () => {
+            const finish = async () => {
                 if (settled) return;
                 settled = true;
                 clearTimeout(timer);
-                resolve({success: true, id, state: 'stopped'});
+
+                // The tracked main's exit is only phase 1 for Codex Desktop. Its profile-owned
+                // Crashpad helpers re-parent to PID 1 on current builds, so stop does not resolve
+                // until the exact-profile finalizer proves zero residuals (or fails closed).
+                await record.finalizePromise;
+
+                resolve({success: record.state === 'stopped', id, state: record.state, cleanupUnresolved: Boolean(record.cleanupUnresolved)});
             };
 
             const timer = setTimeout(() => {
@@ -427,13 +518,13 @@ class FleetLifecycleService extends Base {
             }, this.sigkillTimeoutMs);
             timer.unref?.();
 
-            child.once?.('exit', finish);
-            child.once?.('error', finish);
+            child.once?.('exit', () => { void finish() });
+            child.once?.('error', () => { void finish() });
 
             try {
                 child.kill?.('SIGTERM');
             } catch (e) {
-                finish();
+                void finish();
             }
         });
     }
@@ -448,7 +539,12 @@ class FleetLifecycleService extends Base {
      */
     async restart(id) {
         const priorCwd = this.processes.get(id)?.cwd ?? null;
-        await this.stop(id);
+        const stopped  = await this.stop(id);
+
+        if (stopped.cleanupUnresolved) {
+            throw new Error(`FleetLifecycleService.restart: cleanup failed for agent '${id}'; refusing to spawn a replacement over ambiguous residual processes.`);
+        }
+
         return this.start(id, priorCwd != null ? {cwd: priorCwd} : {});
     }
 
@@ -457,52 +553,58 @@ class FleetLifecycleService extends Base {
      * `authRequired` checks a marker file's PRESENCE, never its content).
      * @param {String} id
      * @returns {Object} `{id, state, running, pid, startedAt, uptimeMs, exitCode, exitedAt,
-     *     stderrBytes, authRequired, instanceHome, launchCommand, binaryVersion}` — `authRequired`
+     *     stderrBytes, authRequired, instanceHome, authHome, launchCommand, authCommand,
+     *     binaryVersion, failureReason, cleanupUnresolved}` — `authRequired`
      *     is the LIVE per-home
      *     auth-marker heuristic for curated launches (`true` = the operator-owned per-home login has
      *     not happened yet; recomputed each read so a completed login flips it without a restart);
-     *     `null` for raw-launch / untracked agents. `instanceHome` is the non-secret, absolute
-     *     lifecycle-owned home needed for the operator login handoff; `launchCommand` is the
-     *     non-secret executable path resolved from AiConfig/the lifecycle owner (`null` for
-     *     raw/untracked agents). Both are intentionally safe for the dev-only unauthenticated
-     *     loopback Fleet bridge: they expose no auth contents. `binaryVersion` is the best-effort
-     *     `--version` capture of what actually ran (`null` until/unless the probe answered).
+     *     `null` for raw-launch / untracked agents. `instanceHome` + `launchCommand` name the GUI or
+     *     CLI launch vessel; marker families also expose the distinct `authHome` + `authCommand`
+     *     pair consumed by the operator-owned login handoff. These absolute paths are intentionally
+     *     safe for the dev-only unauthenticated loopback Fleet bridge: they expose no auth contents.
+     *     `binaryVersion` is the best-effort `--version` capture of what actually ran (`null`
+     *     until/unless the probe answered); `failureReason` is a bounded lifecycle-owned reason,
+     *     never raw child output.
      */
     status(id) {
         const record = this.processes.get(id);
-        if (!record) return {id, state: 'stopped', running: false, pid: null, startedAt: null, uptimeMs: null, exitCode: null, exitedAt: null, stderrBytes: 0, authRequired: null, instanceHome: null, launchCommand: null, binaryVersion: null};
+        if (!record) return {id, state: 'stopped', running: false, pid: null, startedAt: null, uptimeMs: null, exitCode: null, exitedAt: null, stderrBytes: 0, authRequired: null, instanceHome: null, authHome: null, launchCommand: null, authCommand: null, binaryVersion: null, failureReason: null, cleanupUnresolved: false};
 
         return {
             id,
-            state        : record.state,
-            running      : record.state === 'running',
-            pid          : record.pid,
-            startedAt    : record.startedAt,
-            uptimeMs     : record.state === 'running' && record.startedAt ? Date.now() - Date.parse(record.startedAt) : null,
-            exitCode     : record.exitCode,
-            exitedAt     : record.exitedAt,
-            stderrBytes  : record.stderrBytes ?? 0,
-            authRequired : this.authRequiredForHome(record.harnessType, record.instanceHome),
-            instanceHome : record.instanceHome ?? null,
-            launchCommand: record.launchCommand ?? null,
-            binaryVersion: record.binaryVersion ?? null
+            state            : record.state,
+            running          : record.state === 'running',
+            pid              : record.pid,
+            startedAt        : record.startedAt,
+            uptimeMs         : record.state === 'running' && record.startedAt ? Date.now() - Date.parse(record.startedAt) : null,
+            exitCode         : record.exitCode,
+            exitedAt         : record.exitedAt,
+            stderrBytes      : record.stderrBytes ?? 0,
+            authRequired     : this.authRequiredForHome(record.harnessType, record.authHome),
+            instanceHome     : record.instanceHome ?? null,
+            authHome         : record.authHome ?? null,
+            launchCommand    : record.launchCommand ?? null,
+            authCommand      : record.authCommand ?? null,
+            binaryVersion    : record.binaryVersion ?? null,
+            failureReason    : record.failureReason ?? null,
+            cleanupUnresolved: Boolean(record.cleanupUnresolved)
         };
     }
 
     /**
      * @summary The live per-home auth heuristic: `false` when the family's auth-marker file exists
-     * inside the instance home (the operator-owned per-home login completed), `true` when the home
+     * inside the auth home (the operator-owned per-home login completed), `true` when the home
      * exists without it, `null` when the family/home is unknown (raw launches). Presence-only —
      * the marker's content is never read.
      * @param {String|null} harnessType
-     * @param {String|null} instanceHome
+     * @param {String|null} authHome
      * @returns {Boolean|null}
      */
-    authRequiredForHome(harnessType, instanceHome) {
+    authRequiredForHome(harnessType, authHome) {
         const marker = harnessType && HARNESS_AUTH_MARKERS[harnessType];
-        if (!marker || !instanceHome) return null;
+        if (!marker || !authHome) return null;
 
-        return !fs.existsSync(path.join(instanceHome, marker));
+        return !fs.existsSync(path.join(authHome, marker));
     }
 
     /**
@@ -521,6 +623,106 @@ class FleetLifecycleService extends Base {
     }
 
     // ---- internals ----------------------------------------------------------
+
+    /**
+     * @summary Publish a safe, non-running `unavailable` record when Codex Desktop's installed
+     * bundle cannot prove its private profile/project/updater contract. This happens before PAT
+     * resolution, Bridge-token minting, or spawn; status can therefore distinguish unavailable
+     * capability from an ordinary stopped agent without carrying a secret or raw environment.
+     * @param {Object} options
+     * @private
+     */
+    publishUnavailable({id, launch, resolvedCommand, authCommand = null, cwd = null, reason}) {
+        this.processes.set(id, {
+            id,
+            child             : null,
+            cwd               : cwd ?? null,
+            pid               : null,
+            state             : 'unavailable',
+            startedAt         : null,
+            exitCode          : null,
+            signal            : null,
+            exitedAt          : new Date().toISOString(),
+            stderrBytes       : 0,
+            harnessType       : null,
+            instanceHome      : launch.instanceHome ?? null,
+            authHome          : launch.authHome ?? null,
+            authCommand,
+            electronProfile   : launch.electronProfile ?? null,
+            crashpadExecutable: null,
+            launchCommand     : resolvedCommand ?? null,
+            binaryVersion     : null,
+            failureReason     : String(reason),
+            cleanupUnresolved : false,
+            finalizePromise   : null
+        });
+    }
+
+    /**
+     * @summary Finalize one tracked main-process exit. Ordinary harnesses stop immediately; Codex
+     * Desktop enters `stopping` until its exact-profile packaged Crashpad helpers are terminated and
+     * a re-scan proves zero. Ambiguous ownership becomes a durable `failed` status rather than a
+     * broader kill or a false stopped claim.
+     * @param {Object} record Tracked lifecycle record.
+     * @param {Object} exit `{code, signal}` from the child.
+     * @returns {Promise<void>}
+     * @private
+     */
+    finalizeExitedProcess(record, {code, signal}) {
+        if (record.finalizePromise) return record.finalizePromise;
+
+        record.exitCode = code;
+        record.signal   = signal;
+        record.exitedAt = new Date().toISOString();
+        record.child    = null;
+
+        if (!record.electronProfile || !record.crashpadExecutable) {
+            record.state           = 'stopped';
+            record.finalizePromise = Promise.resolve();
+            return record.finalizePromise;
+        }
+
+        return this.finalizeCodexDesktopHelpers(record);
+    }
+
+    /**
+     * @summary Run or retry the helper-only finalization for a Desktop record whose main has exited.
+     * A transient ambiguous scan remains a durable failed state, but a later `stop()` can re-run the
+     * exact same profile/executable proof and clear `cleanupUnresolved` only after zero residuals.
+     * @param {Object} record Tracked Codex Desktop lifecycle record.
+     * @returns {Promise<void>}
+     * @private
+     */
+    finalizeCodexDesktopHelpers(record) {
+        record.state           = 'stopping';
+        record.finalizePromise = Promise.resolve()
+            .then(() => this.getCodexDesktopCleanup()({
+                electronProfile   : record.electronProfile,
+                crashpadExecutable: record.crashpadExecutable
+            }))
+            .then(() => {
+                record.state             = 'stopped';
+                record.failureReason     = null;
+                record.cleanupUnresolved = false;
+            })
+            .catch(error => {
+                record.state             = 'failed';
+                record.failureReason     = `Codex Desktop helper cleanup failed: ${error?.message || 'unknown failure'}`;
+                record.cleanupUnresolved = true;
+            });
+
+        return record.finalizePromise;
+    }
+
+    /** @returns {Function} installed-bundle capability probe. @private */
+    getCodexDesktopCapabilityProbe() {
+        return this.codexDesktopCapabilityProbeFn || probeCodexDesktopCapabilities;
+    }
+
+    /** @returns {Function} exact-profile post-exit cleanup. @private */
+    getCodexDesktopCleanup() {
+        return this.codexDesktopCleanupFn || cleanupCodexDesktopCrashpad;
+    }
 
     /**
      * Resolve the launch spec for an agent — command + args + per-agent launch env.
@@ -543,10 +745,12 @@ class FleetLifecycleService extends Base {
      * start} merges it onto the child env BEFORE the reserved injections (reserved keys always win)
      * and rejects any reserved-key collision fail-fast.
      * @param {Object} agent
+     * @param {Object} [opts] Start options; the final provisioned `cwd` is launch input for
+     *                        `codex-desktop` and ignored by other curated families.
      * @returns {{command: String, args: String[], env: Object}}
      * @private
      */
-    resolveLaunch(agent) {
+    resolveLaunch(agent, opts = {}) {
         const launch = agent.metadata?.launch;
 
         if (!launch) {
@@ -558,7 +762,7 @@ class FleetLifecycleService extends Base {
             }
             const instanceHome = deriveAgentInstanceHome({instanceRoot: this.getInstanceRoot(), agentId: agent.id, harnessType: agent.harnessType});
             return {
-                ...deriveHarnessLaunchSpec({harnessType: agent.harnessType, instanceHome, binaryPath}),
+                ...deriveHarnessLaunchSpec({harnessType: agent.harnessType, instanceHome, binaryPath, cwd: opts.cwd}),
                 // carried for observability: `status` computes the live per-home authRequired from it
                 instanceHome
             };
@@ -600,8 +804,9 @@ class FleetLifecycleService extends Base {
      * @summary Resolve the harness binary path for one harness family: the `harnessBinaryPaths`
      * field entry when explicitly injected (the test/tenant override seam), else the family's
      * AiConfig `fleet.harnessBinaries.*` leaf — the SSOT owning the default and its env binding
-     * (`NEO_FLEET_CODEX_BIN` / `NEO_FLEET_CLAUDE_CODE_BIN` / `NEO_FLEET_CLAUDE_DESKTOP_BIN` /
-     * `NEO_FLEET_ANTIGRAVITY_BIN`). The codex leaf default is the ChatGPT-app-bundled CLI — an
+     * (`NEO_FLEET_CODEX_BIN` / `NEO_FLEET_CODEX_DESKTOP_BIN` / `NEO_FLEET_CLAUDE_CODE_BIN` /
+     * `NEO_FLEET_CLAUDE_DESKTOP_BIN` / `NEO_FLEET_ANTIGRAVITY_BIN`). The codex leaf default is the
+     * ChatGPT-app-bundled CLI — an
      * alpha channel that self-updates with its app, so production fleets pin the leaf;
      * `status().binaryVersion` surfaces what actually ran. The app-bundle families default to
      * their macOS bundle MAIN binaries (directly spawnable — never an `open -n` launcher). An

--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -159,15 +159,19 @@ class FleetManager extends Base {
 
         return lifecycle.getRegistry().listAgents().map(agent => {
             const status   = lifecycle.status(agent.id),
-                  observed = status.pid != null || status.startedAt != null || status.exitCode != null;
+                  observed = status.state !== 'stopped' || status.pid != null || status.startedAt != null || status.exitCode != null;
 
-            return {
+            const row = {
                 agentId   : agent.id,
                 state     : status.state,
                 running   : status.running,
                 confidence: observed ? 'observed' : 'inferred',
                 source    : 'fleet:runtimeStatus'
             };
+
+            if (status.failureReason != null) row.failureReason = status.failureReason;
+
+            return row;
         });
     }
 
@@ -177,7 +181,8 @@ class FleetManager extends Base {
      * `managedRoot` / provisioning, so it forwards straight to `FleetLifecycleService.stop`, mirroring how
      * `fleetRepoStatus` forwards to its aggregator.
      * @param {String} agentId Registry agent id.
-     * @returns {Promise<Object>} `{success, id, state}` from the lifecycle service's `stop`.
+     * @returns {Promise<Object>} `{success, id, state, cleanupUnresolved}` from the lifecycle
+     * service's `stop`.
      */
     stopAgent(agentId) {
         return this.getLifecycleService().stop(agentId);
@@ -194,7 +199,12 @@ class FleetManager extends Base {
      * @returns {Promise<Object>} the agent's lifecycle status (see {@link startAgent}).
      */
     async restartAgent(agentId) {
-        await this.stopAgent(agentId);
+        const stopped = await this.stopAgent(agentId);
+
+        if (stopped.cleanupUnresolved) {
+            throw new Error(`FleetManager.restartAgent: cleanup failed for agent '${agentId}'; refusing to spawn a replacement over ambiguous residual processes.`);
+        }
+
         return this.startAgent(agentId);
     }
 
@@ -211,7 +221,12 @@ class FleetManager extends Base {
      * existed and was deregistered).
      */
     async removeAgent(agentId) {
-        await this.stopAgent(agentId);
+        const stopped = await this.stopAgent(agentId);
+
+        if (stopped.cleanupUnresolved) {
+            throw new Error(`FleetManager.removeAgent: cleanup failed for agent '${agentId}'; refusing to deregister an agent with ambiguous residual processes.`);
+        }
+
         return this.getLifecycleService().getRegistry().removeAgent(agentId);
     }
 

--- a/ai/services/fleet/deriveHarnessLaunchSpec.mjs
+++ b/ai/services/fleet/deriveHarnessLaunchSpec.mjs
@@ -1,4 +1,5 @@
 import {HARNESS_TYPES} from '../../../src/ai/fleet/harnessTypes.mjs';
+import path            from 'node:path';
 
 // Per-family launch contracts — ONE entry per LAUNCHABLE family, keyed by the durable harness-type
 // from the shared registry authority (src/ai/fleet/harnessTypes.mjs). Every entry carries the three
@@ -6,7 +7,7 @@ import {HARNESS_TYPES} from '../../../src/ai/fleet/harnessTypes.mjs';
 // command-line switch), so fixed module data, not configurable fields — an override would set a
 // name the harness never reads, silently collapsing the isolation (fail-OPEN):
 //
-// - isolation — exactly ONE of:
+// - isolation — one OR BOTH of:
 //   `homeEnvVar`  (CLI families): the env var the harness honors as its config/state home.
 //   `homeArgFlag` (Electron/Chromium app-bundle families): the switch that relocates the profile
 //   AND the per-profile single-instance lock — which is precisely what lets many supervised
@@ -28,8 +29,9 @@ import {HARNESS_TYPES} from '../../../src/ai/fleet/harnessTypes.mjs';
 //   prepends the isolation flag, so even the probe subprocess can never cross into another
 //   instance's (or the operator's own) single-instance scope.
 // - `authMode` — how the operator-owned per-home auth step happens for the family:
-//   `'marker'` = a documented marker file inside the home flips the lifecycle `authRequired`
-//   heuristic (CLI families; the login is a command). `'in-app'` = auth is the sign-in INSIDE the
+//   `'marker'` = a documented marker file inside the AUTH home flips the lifecycle `authRequired`
+//   heuristic (the login is a command; Codex Desktop deliberately uses the sibling bundled CLI
+//   against its nested `codex-home`). `'in-app'` = auth is the sign-in INSIDE the
 //   launched window — no marker exists, `authRequired` stays honestly `null`, and the handoff
 //   instruction must render from THIS mode, never from the (permanently null) heuristic.
 const HARNESS_LAUNCH_CONTRACTS = {
@@ -56,6 +58,10 @@ const HARNESS_LAUNCH_CONTRACTS = {
         homeEnvVar      : 'CODEX_HOME',
         modeArgs        : ['app-server'],
         versionProbeArgs: ['--version']
+    },
+    'codex-desktop': {
+        authMode        : 'marker',
+        versionProbeArgs: null
     }
 };
 
@@ -124,6 +130,18 @@ export function getHarnessAuthMode(harnessType) {
  *   freshly-derived home starts unauthenticated by design — the lifecycle status's `authRequired`
  *   surfaces it).
  *
+ * - **`'codex-desktop'`** → the packaged app MAIN binary with two fixed child homes beneath the
+ *   contained Fleet instance home: `codex-home` (auth/state) + `electron-profile` (native Chromium
+ *   profile + single-instance lock). Its launch tuple is
+ *   `--user-data-dir=<electronProfile> --open-project=<absolute provisioned cwd>` plus child-only
+ *   `CODEX_HOME`, `CODEX_ELECTRON_USER_DATA_PATH` (the app-side mirror of the same profile), and
+ *   `CODEX_SPARKLE_ENABLED=false` (secondary residents never own updates). Unlike the other GUI
+ *   families, OAuth remains marker-driven through the bundled CLI, so the result carries typed
+ *   `authHome` and `electronProfile` metadata for the lifecycle owner. A missing or relative cwd
+ *   throws before spawn: silently opening the Fleet server's cwd would fork project-keyed memory.
+ *   The app binary is never executed as a version probe — that would boot another GUI/helper set;
+ *   installed-bundle capability proof is owned by `manageCodexDesktopRuntime` instead.
+ *
  * - **`'claude-code'`** → `{command: binaryPath, args: [<stream-json print mode>], env:
  *   {CLAUDE_CONFIG_DIR: instanceHome}}`. Isolation empirically verified (claude CLI 2.1.156,
  *   macOS): pointing `CLAUDE_CONFIG_DIR` at a fresh dir yields a logged-out instance materializing
@@ -167,6 +185,8 @@ export function getHarnessAuthMode(harnessType) {
  *                                      {@link Neo.ai.services.fleet.deriveAgentInstanceHome}).
  * @param {String} options.binaryPath   The harness binary to spawn (config-resolved by the caller;
  *                                      never guessed here).
+ * @param {String} [options.cwd]        Final provisioned checkout; required + absolute for
+ *                                      `codex-desktop`, ignored by other families.
  * @returns {{command: String, args: String[], env: Object, versionProbeArgs: String[]|null}} a
  * fresh spec per call — `args` / `env` / `versionProbeArgs` are caller-mutable without cross-call
  * bleed. `versionProbeArgs` is the argv for the supervisor's best-effort version capture
@@ -175,7 +195,7 @@ export function getHarnessAuthMode(harnessType) {
  * @throws {Error} If any argument is not a non-empty string, or `harnessType` is not a launchable
  * family.
  */
-export function deriveHarnessLaunchSpec({harnessType, instanceHome, binaryPath} = {}) {
+export function deriveHarnessLaunchSpec({harnessType, instanceHome, binaryPath, cwd} = {}) {
     assertNonEmptyString(harnessType,  'harnessType');
     assertNonEmptyString(instanceHome, 'instanceHome');
     assertNonEmptyString(binaryPath,   'binaryPath');
@@ -185,6 +205,32 @@ export function deriveHarnessLaunchSpec({harnessType, instanceHome, binaryPath} 
     if (!contract) {
         const supported = LAUNCHABLE_HARNESS_TYPES.map(type => `'${type}'`).join(', ');
         throw new Error(`deriveHarnessLaunchSpec: unsupported harnessType '${harnessType}'. Supported: ${supported}.`);
+    }
+
+    if (harnessType === 'codex-desktop') {
+        if (!path.isAbsolute(instanceHome)) {
+            throw new Error(`deriveHarnessLaunchSpec: 'instanceHome' must be absolute for codex-desktop, received '${instanceHome}'.`);
+        }
+        if (typeof cwd !== 'string' || !path.isAbsolute(cwd)) {
+            throw new Error("deriveHarnessLaunchSpec: 'cwd' must be an absolute provisioned checkout for codex-desktop.");
+        }
+
+        const
+            authHome        = path.join(instanceHome, 'codex-home'),
+            electronProfile = path.join(instanceHome, 'electron-profile');
+
+        return {
+            command: binaryPath,
+            args   : [`--user-data-dir=${electronProfile}`, `--open-project=${cwd}`],
+            env    : {
+                CODEX_HOME                   : authHome,
+                CODEX_ELECTRON_USER_DATA_PATH: electronProfile,
+                CODEX_SPARKLE_ENABLED        : 'false'
+            },
+            versionProbeArgs: null,
+            authHome,
+            electronProfile
+        };
     }
 
     if (contract.homeEnvVar) {

--- a/ai/services/fleet/manageCodexDesktopRuntime.mjs
+++ b/ai/services/fleet/manageCodexDesktopRuntime.mjs
@@ -1,0 +1,441 @@
+import {execFileSync} from 'node:child_process';
+import fs             from 'node:fs';
+import path           from 'node:path';
+
+const
+    ASAR_MARKERS = Object.freeze([
+        'CODEX_ELECTRON_USER_DATA_PATH',
+        '--open-project',
+        'CODEX_SPARKLE_ENABLED',
+        'shouldIncludeSparkle',
+        'enableUpdater'
+    ]),
+    FRAMEWORK_MARKERS = Object.freeze(['user-data-dir']),
+    UPDATER_DISABLE_PREDICATES = Object.freeze([
+        'CODEX_SPARKLE_ENABLED===`false`',
+        'CODEX_SPARKLE_ENABLED==="false"',
+        "CODEX_SPARKLE_ENABLED==='false'"
+    ]),
+    CRASHPAD_BASENAME = 'browser_crashpad_handler';
+
+/**
+ * @summary Probe the INSTALLED Codex Desktop app bundle for the exact launch capabilities Fleet
+ * relies on, without launching the app and without an exact-version allowlist.
+ *
+ * The app's profile mirror, project-open route, and updater-disable predicate are private packaged
+ * contracts rather than public CLI guarantees. Presence of an env-var string alone is therefore
+ * insufficient: the probe requires the app-side profile/open-project markers AND the explicit
+ * `CODEX_SPARKLE_ENABLED === 'false'` predicate feeding the packaged updater path. Native profile
+ * isolation is independently pinned by the embedded Chromium framework's `user-data-dir` marker.
+ * Any bundle reshuffle or minifier change fails CLOSED with a named missing capability; that is the
+ * revalidation trigger after an app update, never a reason to guess from the version number.
+ *
+ * The packaged Crashpad helper is derived through the framework's stable `Helpers` symlink and
+ * resolved to its exact executable identity. The observed Chromium-version directory is never
+ * hardcoded.
+ *
+ * @param {Object} options
+ * @param {String} options.binaryPath Config-resolved packaged main binary.
+ * @param {Object} [options.fsImpl] Injectable fs seam; defaults to `node:fs`.
+ * @returns {{available: Boolean, reason: String|null, binaryPath: String|null,
+ *            crashpadExecutable: String|null, appBundle: String|null}}
+ */
+export function probeCodexDesktopCapabilities({binaryPath, fsImpl = fs} = {}) {
+    if (typeof binaryPath !== 'string' || !path.isAbsolute(binaryPath)) {
+        return unavailable('binary-path-must-be-absolute');
+    }
+
+    let mainBinary;
+
+    try {
+        mainBinary = realpath(fsImpl, binaryPath);
+        assertExecutableFile(fsImpl, mainBinary);
+    } catch {
+        return unavailable('packaged-main-unavailable');
+    }
+
+    const
+        macosDir = path.dirname(mainBinary),
+        contents = path.dirname(macosDir);
+
+    if (path.basename(macosDir) !== 'MacOS' || path.basename(contents) !== 'Contents') {
+        return unavailable('binary-is-not-an-app-bundle-main');
+    }
+
+    const
+        appBundle       = path.dirname(contents),
+        appAsar         = path.join(contents, 'Resources', 'app.asar'),
+        framework       = path.join(contents, 'Frameworks', 'Codex Framework.framework', 'Codex Framework'),
+        crashpadSymlink = path.join(contents, 'Frameworks', 'Codex Framework.framework', 'Helpers', CRASHPAD_BASENAME);
+
+    let crashpadExecutable;
+
+    try {
+        assertReadableFile(fsImpl, appAsar);
+        assertReadableFile(fsImpl, framework);
+        crashpadExecutable = realpath(fsImpl, crashpadSymlink);
+        assertExecutableFile(fsImpl, crashpadExecutable);
+    } catch {
+        return unavailable('required-app-bundle-resource-unavailable', {binaryPath: mainBinary, appBundle});
+    }
+
+    const asarMissing = missingMarkers(appAsar, ASAR_MARKERS, fsImpl);
+
+    if (asarMissing.length) {
+        return unavailable(`app-contract-marker-missing:${asarMissing.join(',')}`, {binaryPath: mainBinary, appBundle});
+    }
+
+    if (!containsAnyMarker(appAsar, UPDATER_DISABLE_PREDICATES, fsImpl)) {
+        return unavailable('updater-disable-predicate-missing', {binaryPath: mainBinary, appBundle});
+    }
+
+    const frameworkMissing = missingMarkers(framework, FRAMEWORK_MARKERS, fsImpl);
+
+    if (frameworkMissing.length) {
+        return unavailable(`chromium-contract-marker-missing:${frameworkMissing.join(',')}`, {binaryPath: mainBinary, appBundle});
+    }
+
+    return {
+        available : true,
+        reason    : null,
+        binaryPath: mainBinary,
+        crashpadExecutable,
+        appBundle
+    };
+}
+
+/**
+ * @summary Classify Crashpad process observations against one exact Codex Desktop profile.
+ * A process is Fleet-owned only when ALL proofs match: its loaded executable is the exact packaged
+ * helper resolved by the capability probe, its single `--database` argument is strictly below this
+ * instance's Electron profile, and a process-birth token is available for pre-signal revalidation.
+ * A profile-matching row with missing/mismatched executable or birth proof is ambiguous — it is
+ * never killed, and the lifecycle must fail rather than broaden ownership.
+ * Rows outside the profile are foreign and remain untouched even when they use the same helper.
+ * @param {Object} options
+ * @param {Object[]} options.processes `{pid, command, executable, processToken}` observations.
+ * @param {String} options.electronProfile Exact instance Electron profile.
+ * @param {String} options.crashpadExecutable Exact packaged helper executable.
+ * @returns {{owned: Object[], foreign: Object[], ambiguous: Object[]}}
+ */
+export function classifyCodexDesktopCrashpadProcesses({processes = [], electronProfile, crashpadExecutable} = {}) {
+    assertAbsolutePath(electronProfile, 'electronProfile');
+    assertAbsolutePath(crashpadExecutable, 'crashpadExecutable');
+
+    const
+        profileRoot = path.resolve(electronProfile),
+        expectedExe = path.resolve(crashpadExecutable),
+        result      = {owned: [], foreign: [], ambiguous: []};
+
+    for (const process of processes) {
+        const
+            databases       = extractDatabaseArguments(process.command),
+            matching        = databases.filter(database => isStrictlyContained(profileRoot, path.resolve(database))),
+            exactExecutable = typeof process.executable === 'string' && path.resolve(process.executable) === expectedExe;
+
+        if (databases.length === 0 && (exactExecutable || String(process.command).includes(profileRoot))) {
+            result.ambiguous.push({...process, reason: 'database-identity-unavailable'});
+            continue;
+        }
+
+        if (matching.length === 0) {
+            result.foreign.push(process);
+            continue;
+        }
+
+        if (databases.length !== 1) {
+            result.ambiguous.push({...process, reason: 'multiple-profile-database-arguments'});
+            continue;
+        }
+
+        if (typeof process.executable !== 'string') {
+            result.ambiguous.push({...process, reason: 'executable-identity-unavailable'});
+            continue;
+        }
+
+        if (!exactExecutable) {
+            result.ambiguous.push({...process, reason: 'profile-match-with-foreign-executable'});
+            continue;
+        }
+
+        if (typeof process.processToken !== 'string' || !process.processToken) {
+            result.ambiguous.push({...process, reason: 'process-birth-token-unavailable'});
+            continue;
+        }
+
+        result.owned.push({...process, database: matching[0]});
+    }
+
+    return result;
+}
+
+/**
+ * @summary Read the host process table and return the exact-profile Crashpad ownership snapshot.
+ * `pgrep -fl` supplies candidate pid+argv rows; `lsof -d txt` supplies the loaded executable rather
+ * than trusting spoofable argv[0], and `ps lstart` supplies a stable birth token. Process-list,
+ * executable-inspection, or birth-token failure becomes ambiguity for a profile-matching row,
+ * never kill authority.
+ * @param {Object} options
+ * @param {String} options.electronProfile Exact instance Electron profile.
+ * @param {String} options.crashpadExecutable Exact packaged helper executable.
+ * @param {Function} [options.execFileImpl] Injectable shell-free `execFileSync` seam.
+ * @returns {{owned: Object[], foreign: Object[], ambiguous: Object[]}}
+ */
+export function inspectCodexDesktopCrashpadProcesses({electronProfile, crashpadExecutable, execFileImpl = execFileSync} = {}) {
+    let output;
+
+    try {
+        output = execFileImpl('pgrep', ['-fl', CRASHPAD_BASENAME], {encoding: 'utf8'});
+    } catch (error) {
+        if (error?.status === 1) {
+            return {owned: [], foreign: [], ambiguous: []};
+        }
+
+        throw new Error('inspectCodexDesktopCrashpadProcesses: process-table inspection unavailable; ownership is ambiguous.', {cause: error});
+    }
+
+    const processes = String(output)
+        .split('\n')
+        .map(line => line.match(/^\s*(\d+)\s+(.+)$/))
+        .filter(Boolean)
+        .map(match => {
+            const
+                pid     = Number(match[1]),
+                command = match[2];
+
+            let executable = null, processToken = null;
+
+            try {
+                const lsof = String(execFileImpl('lsof', ['-a', '-p', String(pid), '-d', 'txt', '-Fn'], {encoding: 'utf8'}));
+
+                executable = lsof
+                    .split('\n')
+                    .filter(line => line.startsWith('n'))
+                    .map(line => line.slice(1))
+                    .find(file => path.basename(file) === CRASHPAD_BASENAME) ?? null;
+            } catch {
+                // Classification below turns a profile-matching row into ambiguity. A foreign
+                // profile row remains foreign and is never granted kill authority.
+            }
+
+            try {
+                processToken = String(execFileImpl('ps', ['-p', String(pid), '-o', 'lstart='], {encoding: 'utf8'})).trim() || null;
+            } catch {
+                // Same fail-closed classification as executable inspection: a profile match without
+                // a stable birth token is ambiguous and never signal authority.
+            }
+
+            return {pid, command, executable, processToken}
+        });
+
+    return classifyCodexDesktopCrashpadProcesses({processes, electronProfile, crashpadExecutable});
+}
+
+/**
+ * @summary Terminate only the exact-profile Crashpad helpers after the tracked main exits.
+ * Ownership is re-proven immediately before each signal using pid + process-birth token + argv +
+ * loaded executable, materially narrowing PID-reuse races. macOS exposes only a PID-based signal,
+ * so identity-check and signal cannot be one atomic kernel operation; that final micro-window is an
+ * explicit platform bound, never claimed closed. SIGTERM gets a bounded grace window; surviving
+ * still-owned helpers receive SIGKILL; a final re-scan must prove zero. Ambiguity at any phase fails
+ * closed and sends no broader signal.
+ * @param {Object} options
+ * @param {String} options.electronProfile Exact instance Electron profile.
+ * @param {String} options.crashpadExecutable Exact packaged helper executable.
+ * @param {Function} [options.inspect] Injectable ownership inspector.
+ * @param {Function} [options.killProcess] Injectable `(pid, signal)` seam.
+ * @param {Function} [options.wait] Injectable async wait seam.
+ * @param {Number} [options.graceMs=250] Delay after each signal phase.
+ * @returns {Promise<{terminated: Number[], escalated: Number[]}>}
+ */
+export async function cleanupCodexDesktopCrashpad({
+    electronProfile,
+    crashpadExecutable,
+    inspect = inspectCodexDesktopCrashpadProcesses,
+    killProcess = process.kill,
+    wait = ms => new Promise(resolve => setTimeout(resolve, ms)),
+    graceMs = 250
+} = {}) {
+    const inspectOwned = () => {
+        const snapshot = inspect({electronProfile, crashpadExecutable});
+
+        if (snapshot.ambiguous.length) {
+            const ids = snapshot.ambiguous.map(item => item.pid).filter(Number.isInteger).join(',') || 'unknown';
+            throw new Error(`cleanupCodexDesktopCrashpad: ambiguous profile-owned process identity (pid ${ids}); refusing cleanup.`);
+        }
+
+        return snapshot.owned;
+    };
+
+    const signal = (rows, name) => {
+        const signaled = [];
+
+        for (const row of rows) {
+            const current = inspectOwned().find(item => item.pid === row.pid);
+
+            if (!current) continue;
+            if (current.processToken !== row.processToken) {
+                throw new Error(`cleanupCodexDesktopCrashpad: pid ${row.pid} birth token changed before ${name}; refusing signal.`);
+            }
+
+            try {
+                killProcess(row.pid, name);
+                signaled.push(row.pid);
+            } catch (error) {
+                if (error?.code !== 'ESRCH') throw error;
+            }
+        }
+
+        return signaled;
+    };
+
+    const first = inspectOwned();
+    if (!first.length) return {terminated: [], escalated: []};
+
+    const terminated = signal(first, 'SIGTERM');
+    await wait(graceMs);
+
+    const survivors = inspectOwned();
+    let   escalated = [];
+    if (survivors.length) {
+        escalated = signal(survivors, 'SIGKILL');
+        await wait(graceMs);
+    }
+
+    const residual = inspectOwned();
+
+    if (residual.length) {
+        throw new Error(`cleanupCodexDesktopCrashpad: ${residual.length} exact-profile helper process(es) survived SIGKILL.`);
+    }
+
+    return {
+        terminated,
+        escalated
+    };
+}
+
+/**
+ * Extract every `--database=<path>` or `--database <path>` value. `ps`/`pgrep` render argv without
+ * preserving quotes on macOS, so the value ends at the next option token (` space + --`), not at
+ * the next whitespace; this preserves profile paths containing spaces.
+ * @param {String} command
+ * @returns {String[]}
+ * @private
+ */
+function extractDatabaseArguments(command) {
+    if (typeof command !== 'string') return [];
+
+    const
+        values  = [],
+        pattern = /(?:^|\s)--database(?:=|\s+)/g;
+
+    let match;
+
+    while ((match = pattern.exec(command))) {
+        const valueStart = match.index + match[0].length;
+
+        const
+            remainder  = command.slice(valueStart),
+            nextOption = remainder.search(/\s--[a-zA-Z0-9_-]+(?:=|\s|$)/),
+            raw        = (nextOption === -1 ? remainder : remainder.slice(0, nextOption)).trim(),
+            value      = stripMatchingQuotes(raw);
+
+        if (value) values.push(value);
+        pattern.lastIndex = valueStart + Math.max(raw.length, 1);
+    }
+
+    return values;
+}
+
+/** @returns {String} @private */
+function stripMatchingQuotes(value) {
+    return value.length >= 2 && value[0] === value.at(-1) && ['"', "'"].includes(value[0])
+        ? value.slice(1, -1)
+        : value;
+}
+
+/** @returns {Boolean} @private */
+function isStrictlyContained(root, target) {
+    const relative = path.relative(root, target);
+    return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+/** @returns {String[]} @private */
+function missingMarkers(file, markers, fsImpl) {
+    const found = scanMarkers(file, markers, fsImpl);
+    return markers.filter(marker => !found.has(marker));
+}
+
+/** @returns {Boolean} @private */
+function containsAnyMarker(file, markers, fsImpl) {
+    return scanMarkers(file, markers, fsImpl).size > 0;
+}
+
+/**
+ * Memory-bounded binary marker scan. A tail preserves matches split across 1 MiB chunk boundaries.
+ * @returns {Set<String>}
+ * @private
+ */
+function scanMarkers(file, markers, fsImpl) {
+    const
+        pending    = new Map(markers.map(marker => [marker, Buffer.from(marker)])),
+        found      = new Set(),
+        chunk      = Buffer.allocUnsafe(1024 * 1024),
+        tailSize   = Math.max(...[...pending.values()].map(marker => marker.length), 1) - 1,
+        descriptor = fsImpl.openSync(file, 'r');
+
+    let tail = Buffer.alloc(0), position = 0;
+
+    try {
+        while (pending.size) {
+            const bytesRead = fsImpl.readSync(descriptor, chunk, 0, chunk.length, position);
+            if (!bytesRead) break;
+
+            position += bytesRead;
+
+            const haystack = Buffer.concat([tail, chunk.subarray(0, bytesRead)]);
+
+            for (const [text, marker] of pending) {
+                if (haystack.indexOf(marker) !== -1) {
+                    found.add(text);
+                    pending.delete(text);
+                }
+            }
+
+            tail = tailSize ? haystack.subarray(Math.max(0, haystack.length - tailSize)) : Buffer.alloc(0);
+        }
+    } finally {
+        fsImpl.closeSync(descriptor);
+    }
+
+    return found;
+}
+
+/** @private */
+function assertReadableFile(fsImpl, file) {
+    if (!fsImpl.statSync(file).isFile()) throw new Error('not a file');
+    fsImpl.accessSync(file, fs.constants.R_OK);
+}
+
+/** @private */
+function assertExecutableFile(fsImpl, file) {
+    if (!fsImpl.statSync(file).isFile()) throw new Error('not a file');
+    fsImpl.accessSync(file, fs.constants.X_OK);
+}
+
+/** @returns {String} @private */
+function realpath(fsImpl, file) {
+    return (fsImpl.realpathSync.native ?? fsImpl.realpathSync)(file);
+}
+
+/** @private */
+function assertAbsolutePath(value, name) {
+    if (typeof value !== 'string' || !path.isAbsolute(value)) {
+        throw new Error(`manageCodexDesktopRuntime: '${name}' must be an absolute path.`);
+    }
+}
+
+/** @returns {Object} @private */
+function unavailable(reason, extra = {}) {
+    return {available: false, reason, binaryPath: extra.binaryPath ?? null, crashpadExecutable: null, appBundle: extra.appBundle ?? null};
+}

--- a/src/ai/fleet/harnessTypes.mjs
+++ b/src/ai/fleet/harnessTypes.mjs
@@ -19,6 +19,7 @@
  */
 export const HARNESS_TYPES = Object.freeze([
     Object.freeze({type: 'codex',          label: 'Codex'}),
+    Object.freeze({type: 'codex-desktop',  label: 'Codex Desktop'}),
     Object.freeze({type: 'claude-code',    label: 'Claude Code'}),
     Object.freeze({type: 'claude-desktop', label: 'Claude'}),
     Object.freeze({type: 'antigravity',    label: 'Antigravity'}),

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -93,6 +93,8 @@ function install({agents = {}, creds = {}} = {}) {
     // Reset the curated-launch resolution fields too — fallback tests set them explicitly.
     FleetLifecycleService.instanceRoot       = null;
     FleetLifecycleService.harnessBinaryPaths = null;
+    FleetLifecycleService.codexDesktopCapabilityProbeFn = null;
+    FleetLifecycleService.codexDesktopCleanupFn         = null;
     return spawnStub;
 }
 
@@ -232,6 +234,16 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService', () => {
         expect(spawn.calls).toHaveLength(1);
     });
 
+    test('raw compatibility launches expose neither launchCommand nor authCommand through status', () => {
+        install({agents: {a: agentDef('a')}, creds: {}});
+
+        const status = FleetLifecycleService.start('a');
+
+        expect(status.launchCommand).toBeNull();
+        expect(status.authCommand).toBeNull();
+        expect(status.authHome).toBeNull();
+    });
+
     test('stop sends SIGTERM and transitions to stopped', async () => {
         const spawn = install({agents: {a: agentDef('a')}, creds: {a: 'ghp_x'}});
         FleetLifecycleService.start('a');
@@ -328,6 +340,246 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService — curated launch + 
         expect(args).toEqual(['app-server']);                                   // the long-lived mode is template-owned
         expect(opts.env.CODEX_HOME.startsWith('/srv/fleet/instances/')).toBe(true);
         expect(opts.env.CODEX_HOME).toContain('peer2');                         // agent.id keys the home, never githubUsername-only grain
+    });
+
+    test('curated codex-desktop derivation composes exact cwd, dual homes, typed auth, and direct packaged-main supervision', () => {
+        const
+            cwd   = '/srv/checkouts/peer-desktop/neomjs/neo',
+            spawn = install({agents: {desktop: curatedAgent('desktop', 'codex-desktop')}, creds: {}});
+
+        FleetLifecycleService.instanceRoot       = '/srv/fleet/instances';
+        FleetLifecycleService.harnessBinaryPaths = {'codex-desktop': process.execPath, codex: '/bin/sh'};
+        FleetLifecycleService.codexDesktopCapabilityProbeFn = () => ({
+            available         : true,
+            reason            : null,
+            crashpadExecutable: '/Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Helpers/browser_crashpad_handler'
+        });
+        FleetLifecycleService.codexDesktopCleanupFn = async () => ({terminated: [], escalated: []});
+
+        const status       = FleetLifecycleService.start('desktop', {cwd});
+        const {args, opts} = spawn.calls[0];
+
+        expect(args).toEqual([
+            `--user-data-dir=${opts.env.CODEX_ELECTRON_USER_DATA_PATH}`,
+            `--open-project=${cwd}`
+        ]);
+        expect(opts.cwd).toBe(cwd);
+        expect(opts.env.CODEX_HOME).toBe(status.authHome);
+        expect(opts.env.CODEX_ELECTRON_USER_DATA_PATH).toContain('electron-profile');
+        expect(opts.env.CODEX_SPARKLE_ENABLED).toBe('false');
+        expect(opts.env.CODEX_THREAD_ID).toBeUndefined();
+        expect(status.instanceHome).not.toBe(status.authHome);
+        expect(status.launchCommand).toBe(process.execPath);
+        expect(status.authCommand).toBe('/bin/sh');
+        expect(status.authCommand).not.toBe(status.launchCommand);
+        expect(status.authRequired).toBe(true);
+    });
+
+    test('codex-desktop refuses before capability probe/spawn when the final provisioned cwd is absent', () => {
+        const spawn = install({agents: {desktop: curatedAgent('desktop', 'codex-desktop')}, creds: {}});
+
+        FleetLifecycleService.instanceRoot       = '/srv/fleet/instances';
+        FleetLifecycleService.harnessBinaryPaths = {'codex-desktop': process.execPath, codex: process.execPath};
+        FleetLifecycleService.codexDesktopCapabilityProbeFn = () => {
+            throw new Error('must not run');
+        };
+
+        expect(() => FleetLifecycleService.start('desktop')).toThrow(/cwd.*absolute provisioned checkout/);
+        expect(spawn.calls).toHaveLength(0);
+    });
+
+    test('codex-desktop capability failure publishes unavailable and never spawns', () => {
+        const spawn = install({agents: {desktop: curatedAgent('desktop', 'codex-desktop')}, creds: {}});
+
+        FleetLifecycleService.instanceRoot       = '/srv/fleet/instances';
+        FleetLifecycleService.harnessBinaryPaths = {'codex-desktop': process.execPath, codex: process.execPath};
+        FleetLifecycleService.codexDesktopCapabilityProbeFn = () => ({available: false, reason: 'updater-disable-predicate-missing'});
+
+        expect(() => FleetLifecycleService.start('desktop', {cwd: '/srv/checkouts/desktop'})).toThrow(/codex-desktop is unavailable.*updater-disable-predicate-missing/);
+        expect(spawn.calls).toHaveLength(0);
+        expect(FleetLifecycleService.status('desktop')).toMatchObject({
+            state        : 'unavailable',
+            running      : false,
+            failureReason: 'updater-disable-predicate-missing'
+        });
+    });
+
+    test('codex-desktop missing bundled CLI publishes unavailable before capability probing or spawn', () => {
+        const spawn  = install({agents: {desktop: curatedAgent('desktop', 'codex-desktop')}, creds: {}});
+        let   probed = false;
+
+        FleetLifecycleService.instanceRoot       = '/srv/fleet/instances';
+        FleetLifecycleService.harnessBinaryPaths = {'codex-desktop': process.execPath, codex: '/definitely/missing/codex'};
+        FleetLifecycleService.codexDesktopCapabilityProbeFn = () => {
+            probed = true;
+            return {available: true, crashpadExecutable: '/app/browser_crashpad_handler'};
+        };
+
+        expect(() => FleetLifecycleService.start('desktop', {cwd: '/srv/checkouts/desktop'})).toThrow(/bundled Codex CLI auth command is unavailable/);
+        expect(probed).toBe(false);
+        expect(spawn.calls).toHaveLength(0);
+        expect(FleetLifecycleService.status('desktop')).toMatchObject({
+            state        : 'unavailable',
+            failureReason: 'bundled Codex CLI auth command is unavailable'
+        });
+    });
+
+    test('codex-desktop child never inherits an ambient CODEX_THREAD_ID', () => {
+        const
+            previous = process.env.CODEX_THREAD_ID,
+            spawn    = install({agents: {desktop: curatedAgent('desktop', 'codex-desktop')}, creds: {}});
+
+        FleetLifecycleService.instanceRoot       = '/srv/fleet/instances';
+        FleetLifecycleService.harnessBinaryPaths = {'codex-desktop': process.execPath, codex: process.execPath};
+        FleetLifecycleService.codexDesktopCapabilityProbeFn = () => ({
+            available         : true,
+            crashpadExecutable: '/app/browser_crashpad_handler'
+        });
+        process.env.CODEX_THREAD_ID = 'ambient-thread-must-not-cross';
+
+        try {
+            FleetLifecycleService.start('desktop', {cwd: '/srv/checkouts/desktop'});
+            expect(spawn.calls[0].opts.env.CODEX_THREAD_ID).toBeUndefined();
+        } finally {
+            if (previous === undefined) delete process.env.CODEX_THREAD_ID;
+            else process.env.CODEX_THREAD_ID = previous;
+        }
+    });
+
+    test('codex-desktop auth marker is scoped to the nested authHome, never the parent instanceHome', () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-codex-desktop-auth-'));
+
+        try {
+            install({agents: {desktop: curatedAgent('desktop', 'codex-desktop')}, creds: {}});
+            FleetLifecycleService.instanceRoot       = root;
+            FleetLifecycleService.harnessBinaryPaths = {'codex-desktop': process.execPath, codex: process.execPath};
+            FleetLifecycleService.codexDesktopCapabilityProbeFn = () => ({
+                available         : true,
+                crashpadExecutable: '/app/browser_crashpad_handler'
+            });
+
+            const started = FleetLifecycleService.start('desktop', {cwd: '/srv/checkouts/desktop'});
+
+            fs.mkdirSync(started.instanceHome, {recursive: true});
+            fs.writeFileSync(path.join(started.instanceHome, 'auth.json'), '{}');
+            expect(FleetLifecycleService.status('desktop').authRequired).toBe(true);
+
+            fs.mkdirSync(started.authHome, {recursive: true});
+            fs.writeFileSync(path.join(started.authHome, 'auth.json'), '{}');
+            expect(FleetLifecycleService.status('desktop').authRequired).toBe(false);
+        } finally {
+            fs.rmSync(root, {recursive: true, force: true});
+        }
+    });
+
+    test('codex-desktop stop waits for exact-profile helper cleanup before reporting stopped', async () => {
+        const spawn = install({agents: {desktop: curatedAgent('desktop', 'codex-desktop')}, creds: {}}),
+              calls = [];
+
+        FleetLifecycleService.instanceRoot       = '/srv/fleet/instances';
+        FleetLifecycleService.harnessBinaryPaths = {'codex-desktop': process.execPath, codex: process.execPath};
+        FleetLifecycleService.codexDesktopCapabilityProbeFn = () => ({
+            available         : true,
+            crashpadExecutable: '/app/browser_crashpad_handler'
+        });
+        FleetLifecycleService.codexDesktopCleanupFn = async options => {
+            calls.push(options);
+            await Promise.resolve();
+            return {terminated: [1, 2], escalated: []};
+        };
+
+        FleetLifecycleService.start('desktop', {cwd: '/srv/checkouts/desktop'});
+        const stopped = await FleetLifecycleService.stop('desktop');
+
+        expect(spawn.calls[0].child.signals).toContain('SIGTERM');
+        expect(calls).toHaveLength(1);
+        expect(calls[0].electronProfile).toContain('electron-profile');
+        expect(stopped).toMatchObject({success: true, state: 'stopped'});
+        expect(FleetLifecycleService.status('desktop').state).toBe('stopped');
+    });
+
+    test('codex-desktop stop joins helper finalization already started by a natural main exit', async () => {
+        const spawn = install({agents: {desktop: curatedAgent('desktop', 'codex-desktop')}, creds: {}});
+        let releaseCleanup;
+
+        FleetLifecycleService.instanceRoot       = '/srv/fleet/instances';
+        FleetLifecycleService.harnessBinaryPaths = {'codex-desktop': process.execPath, codex: process.execPath};
+        FleetLifecycleService.codexDesktopCapabilityProbeFn = () => ({
+            available         : true,
+            crashpadExecutable: '/app/browser_crashpad_handler'
+        });
+        FleetLifecycleService.codexDesktopCleanupFn = () => new Promise(resolve => { releaseCleanup = resolve });
+
+        FleetLifecycleService.start('desktop', {cwd: '/srv/checkouts/desktop'});
+        spawn.calls[0].child.emit('exit', 0, null);
+        await Promise.resolve();
+
+        expect(FleetLifecycleService.status('desktop').state).toBe('stopping');
+        expect(() => FleetLifecycleService.start('desktop', {cwd: '/srv/checkouts/desktop'})).toThrow(/still being finalized/);
+        expect(spawn.calls).toHaveLength(1);
+
+        let   settled = false;
+        const stop    = FleetLifecycleService.stop('desktop').then(result => {
+            settled = true;
+            return result;
+        });
+
+        await Promise.resolve();
+        expect(settled).toBe(false);
+
+        releaseCleanup({terminated: [], escalated: []});
+
+        await expect(stop).resolves.toMatchObject({success: true, state: 'stopped'});
+    });
+
+    test('codex-desktop ambiguous helper ownership fails stop status instead of broadening cleanup', async () => {
+        const spawn           = install({agents: {desktop: curatedAgent('desktop', 'codex-desktop')}, creds: {}});
+        let   cleanupAttempts = 0;
+
+        FleetLifecycleService.instanceRoot       = '/srv/fleet/instances';
+        FleetLifecycleService.harnessBinaryPaths = {'codex-desktop': process.execPath, codex: process.execPath};
+        FleetLifecycleService.codexDesktopCapabilityProbeFn = () => ({
+            available         : true,
+            crashpadExecutable: '/app/browser_crashpad_handler'
+        });
+        FleetLifecycleService.codexDesktopCleanupFn = async () => {
+            if (++cleanupAttempts === 1) throw new Error('ambiguous profile-owned process identity');
+            return {terminated: [], escalated: []};
+        };
+
+        FleetLifecycleService.start('desktop', {cwd: '/srv/checkouts/desktop'});
+        const stopped = await FleetLifecycleService.stop('desktop');
+
+        expect(stopped).toMatchObject({success: false, state: 'failed'});
+        expect(stopped.cleanupUnresolved).toBe(true);
+        expect(FleetLifecycleService.status('desktop').failureReason).toContain('ambiguous profile-owned process identity');
+        expect(() => FleetLifecycleService.start('desktop', {cwd: '/srv/checkouts/desktop'})).toThrow(/refusing to spawn.*lifecycle failure/);
+
+        await expect(FleetLifecycleService.stop('desktop')).resolves.toMatchObject({success: true, state: 'stopped', cleanupUnresolved: false});
+        expect(cleanupAttempts).toBe(2);
+
+        expect(FleetLifecycleService.start('desktop', {cwd: '/srv/checkouts/desktop'})).toMatchObject({state: 'running'});
+        expect(spawn.calls).toHaveLength(2);
+    });
+
+    test('codex-desktop child error after spawn preserves stop authority until helper cleanup succeeds', async () => {
+        const spawn = install({agents: {desktop: curatedAgent('desktop', 'codex-desktop')}, creds: {}});
+
+        FleetLifecycleService.instanceRoot       = '/srv/fleet/instances';
+        FleetLifecycleService.harnessBinaryPaths = {'codex-desktop': process.execPath, codex: process.execPath};
+        FleetLifecycleService.codexDesktopCapabilityProbeFn = () => ({
+            available         : true,
+            crashpadExecutable: '/app/browser_crashpad_handler'
+        });
+        FleetLifecycleService.codexDesktopCleanupFn = async () => ({terminated: [], escalated: []});
+
+        FleetLifecycleService.start('desktop', {cwd: '/srv/checkouts/desktop'});
+        spawn.calls[0].child.emit('error', new Error('synthetic child error'));
+
+        expect(FleetLifecycleService.status('desktop')).toMatchObject({state: 'failed', cleanupUnresolved: true});
+        expect(() => FleetLifecycleService.start('desktop', {cwd: '/srv/checkouts/desktop'})).toThrow(/unresolved after a lifecycle failure/);
+
+        await expect(FleetLifecycleService.stop('desktop')).resolves.toMatchObject({state: 'stopped', cleanupUnresolved: false});
     });
 
     test('curated claude-code derivation is reachable (registry vocabulary aligned) and pins the stream-json mode', () => {

--- a/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
@@ -127,7 +127,7 @@ test.describe('onboardPeer — intent construction (pure half)', () => {
     test('only curated harness families are accepted, with a named refusal', () => {
         // The curated set IS the launch-templated subset — one derived truth, widened in lockstep
         // with deriveHarnessLaunchSpec. `native-neo` stays registered-but-unlaunchable.
-        expect(CURATED_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex']);
+        expect(CURATED_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex', 'codex-desktop']);
         expect(CURATED_HARNESS_TYPES).not.toContain('native-neo');
 
         const built = buildOnboardingIntent({...BASE_OPTIONS, harnessType: 'gemini-cli'});
@@ -267,12 +267,12 @@ test.describe('onboardPeer — the two-phase planner', () => {
 
 test.describe('onboardPeer — auth handoff', () => {
     test('the lifecycle-resolved absolute home is shell-quoted; placeholders and relative homes refuse', () => {
-        expect(buildLoginCommand({harnessType: 'codex', instanceHome: "/tmp/neo homes/o'neil", launchCommand: '/Applications/ChatGPT.app/Contents/Resources/codex'}))
+        expect(buildLoginCommand({harnessType: 'codex', authHome: "/tmp/neo homes/o'neil", authCommand: '/Applications/ChatGPT.app/Contents/Resources/codex'}))
             .toBe("CODEX_HOME='/tmp/neo homes/o'\\''neil' '/Applications/ChatGPT.app/Contents/Resources/codex' login");
-        expect(buildLoginCommand({harnessType: 'claude-code', instanceHome: '/tmp/claude-home', launchCommand: '/opt/claude'}))
+        expect(buildLoginCommand({harnessType: 'claude-code', authHome: '/tmp/claude-home', authCommand: '/opt/claude'}))
             .toContain("CLAUDE_CONFIG_DIR='/tmp/claude-home'");
-        expect(() => buildLoginCommand({harnessType: 'codex', instanceHome: '<instance home>', launchCommand: '/opt/codex'})).toThrow(/absolute instanceHome/);
-        expect(() => buildLoginCommand({harnessType: 'codex', instanceHome: '/tmp/x\nFAKE', launchCommand: '/opt/codex'})).toThrow(/control-character-free/);
+        expect(() => buildLoginCommand({harnessType: 'codex', authHome: '<instance home>', authCommand: '/opt/codex'})).toThrow(/absolute authHome/);
+        expect(() => buildLoginCommand({harnessType: 'codex', authHome: '/tmp/x\nFAKE', authCommand: '/opt/codex'})).toThrow(/control-character-free/);
     });
 
     test('GUI app-bundle families print the isolated relaunch line — auth is the in-app sign-in, no CLI login exists', () => {
@@ -303,17 +303,34 @@ test.describe('onboardPeer — auth handoff', () => {
     });
 
     test('marker families keep the heuristic-driven branches unchanged: true → login command, false → done, null → honest WARN with no guessed command', () => {
-        const required = deriveAuthHandoff({harnessType: 'codex', status: {authRequired: true, instanceHome: '/srv/homes/c', launchCommand: '/opt/codex'}});
+        const required = deriveAuthHandoff({harnessType: 'codex', status: {authRequired: true, authHome: '/srv/homes/c', authCommand: '/opt/codex'}});
 
         expect(required.kind).toBe('login-required');
         expect(required.lines.join('\n')).toContain("CODEX_HOME='/srv/homes/c' '/opt/codex' login");
 
-        expect(deriveAuthHandoff({harnessType: 'codex', status: {authRequired: false, instanceHome: '/srv/homes/c', launchCommand: '/opt/codex'}}).kind).toBe('done');
+        expect(deriveAuthHandoff({harnessType: 'codex', status: {authRequired: false, authHome: '/srv/homes/c', authCommand: '/opt/codex'}}).kind).toBe('done');
 
-        const unknown = deriveAuthHandoff({harnessType: 'codex', status: {authRequired: null, instanceHome: '/srv/homes/c', launchCommand: '/opt/codex'}});
+        const unknown = deriveAuthHandoff({harnessType: 'codex', status: {authRequired: null, authHome: '/srv/homes/c', authCommand: '/opt/codex'}});
 
         expect(unknown.kind).toBe('unknown');
         expect(unknown.lines.join('\n')).not.toContain('codex login');
+    });
+
+    test('Codex Desktop marker auth uses the bundled CLI + nested auth home, never the GUI main', () => {
+        const handoff = deriveAuthHandoff({
+            harnessType: 'codex-desktop',
+            status     : {
+                authRequired : true,
+                instanceHome : '/srv/homes/desktop',
+                launchCommand: '/Applications/ChatGPT.app/Contents/MacOS/ChatGPT',
+                authHome     : '/srv/homes/desktop/codex-home',
+                authCommand  : '/Applications/ChatGPT.app/Contents/Resources/codex'
+            }
+        });
+
+        expect(handoff.kind).toBe('login-required');
+        expect(handoff.lines.join('\n')).toContain("CODEX_HOME='/srv/homes/desktop/codex-home' '/Applications/ChatGPT.app/Contents/Resources/codex' login");
+        expect(handoff.lines.join('\n')).not.toContain('Contents/MacOS/ChatGPT');
     });
 
     test('the dry-run planner names the in-app mode for GUI families — plan and post-launch decision cannot drift', () => {
@@ -336,7 +353,7 @@ test.describe('onboardPeer — auth handoff', () => {
               sentinelPath  = path.join(root, 'PWNED'),
               launchCommand = path.join(root, 'fake;touch PWNED'),
               instanceHome  = path.join(root, "home with ' quote"),
-              command       = buildLoginCommand({harnessType: 'codex', instanceHome, launchCommand});
+              command       = buildLoginCommand({harnessType: 'codex', authHome: instanceHome, authCommand: launchCommand});
 
         try {
             fs.writeFileSync(launchCommand, `#!/usr/bin/env node\nimport fs from 'node:fs';\nfs.writeFileSync(process.env.CAPTURE, JSON.stringify({home: process.env.CODEX_HOME, argv: process.argv.slice(2)}));\n`);

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -260,6 +260,7 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         registryStub.listAgents = () => [
             {id: 'desk',   githubUsername: 'desk-gh',   harnessType: 'claude-desktop'},
             {id: 'cli',    githubUsername: 'cli-gh',    harnessType: 'codex'},
+            {id: 'codexd', githubUsername: 'codexd-gh', harnessType: 'codex-desktop'},
             {id: 'native', githubUsername: 'native-gh', harnessType: 'native-neo'}
         ];
         managerStub.fleetRepoStatus    = () => [];
@@ -274,7 +275,8 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         // any wire call: native-neo disables with truth, in-app families announce their sign-in.
         expect(rows[0]).toMatchObject({id: 'desk',   launchable: true,  authMode: 'in-app'});
         expect(rows[1]).toMatchObject({id: 'cli',    launchable: true,  authMode: 'marker'});
-        expect(rows[2]).toMatchObject({id: 'native', launchable: false, authMode: null});
+        expect(rows[2]).toMatchObject({id: 'codexd', launchable: true,  authMode: 'marker'});
+        expect(rows[3]).toMatchObject({id: 'native', launchable: false, authMode: null});
     });
 
     // ---- the security boundary: the allowlist OMITS the Brain-internal secret paths ----

--- a/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
@@ -112,4 +112,76 @@ test.describe('Neo.ai.services.fleet.FleetManager — fleetRuntimeStatus (roster
             {agentId: 'alice', state: 'stopped', running: false, confidence: 'observed', source: 'fleet:runtimeStatus'}
         ]);
     });
+
+    test('an installed-capability refusal surfaces as observed unavailable with a safe reason', () => {
+        const registryStub = {listAgents: () => [{id: 'desktop'}]};
+
+        FleetManager.lifecycleService = {
+            getRegistry: () => registryStub,
+            status     : id => ({
+                id,
+                state        : 'unavailable',
+                running      : false,
+                pid          : null,
+                startedAt    : null,
+                exitCode     : null,
+                failureReason: 'updater-disable-predicate-missing'
+            })
+        };
+
+        expect(FleetManager.fleetRuntimeStatus()).toEqual([{
+            agentId      : 'desktop',
+            state        : 'unavailable',
+            running      : false,
+            confidence   : 'observed',
+            source       : 'fleet:runtimeStatus',
+            failureReason: 'updater-disable-predicate-missing'
+        }]);
+    });
+});
+
+test.describe('Neo.ai.services.fleet.FleetManager — Codex Desktop cleanup failure gates', () => {
+    let calls, registryStub;
+
+    test.beforeEach(() => {
+        calls = [];
+        registryStub = {
+            removeAgent: id => { calls.push(['removeAgent', id]); return {success: true, id}; }
+        };
+
+        FleetManager.lifecycleService = {
+            getRegistry: () => registryStub,
+            stop       : async id => ({success: false, id, state: 'failed', cleanupUnresolved: true})
+        };
+        FleetManager.provisionAndStartFn = async options => {
+            calls.push(['start', options.agentId]);
+            return {id: options.agentId, state: 'running'};
+        };
+    });
+
+    test.afterEach(() => {
+        FleetManager.lifecycleService   = null;
+        FleetManager.provisionAndStartFn = null;
+    });
+
+    test('restart refuses to spawn over ambiguous residual helpers', async () => {
+        await expect(FleetManager.restartAgent('desktop')).rejects.toThrow(/cleanup failed.*refusing to spawn/);
+
+        expect(calls).toEqual([]);
+    });
+
+    test('remove refuses to deregister the owner of ambiguous residual helpers', async () => {
+        await expect(FleetManager.removeAgent('desktop')).rejects.toThrow(/cleanup failed.*refusing to deregister/);
+
+        expect(calls).toEqual([]);
+    });
+
+    test('ordinary failed harnesses retain the legacy restart and removal recovery paths', async () => {
+        FleetManager.lifecycleService.stop = async id => ({success: false, id, state: 'failed', cleanupUnresolved: false});
+
+        await expect(FleetManager.restartAgent('cli')).resolves.toMatchObject({id: 'cli', state: 'running'});
+        await expect(FleetManager.removeAgent('cli')).resolves.toEqual({success: true, id: 'cli'});
+
+        expect(calls).toEqual([['start', 'cli'], ['removeAgent', 'cli']]);
+    });
 });

--- a/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
@@ -1,5 +1,5 @@
-import {test, expect}                                      from '@playwright/test';
-import {HARNESS_TYPES}                                     from '../../../../../../src/ai/fleet/harnessTypes.mjs';
+import {test, expect}                                                          from '@playwright/test';
+import {HARNESS_TYPES}                                                         from '../../../../../../src/ai/fleet/harnessTypes.mjs';
 import {LAUNCHABLE_HARNESS_TYPES, deriveHarnessLaunchSpec, getHarnessAuthMode} from '../../../../../../ai/services/fleet/deriveHarnessLaunchSpec.mjs';
 
 // Pure function — imported directly (no fs / spawn / env / Neo runtime), so the suite has no
@@ -17,6 +17,31 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
             args            : ['app-server'],
             env             : {CODEX_HOME: '/srv/instances/a/codex'},
             versionProbeArgs: ['--version']
+        });
+    });
+
+    test('codex-desktop: direct packaged main + dual homes + exact provisioned project + updater disabled', () => {
+        const spec = deriveHarnessLaunchSpec({
+            harnessType : 'codex-desktop',
+            instanceHome: '/srv/instances/a/codex-desktop',
+            binaryPath  : '/Applications/ChatGPT.app/Contents/MacOS/ChatGPT',
+            cwd         : '/srv/checkouts/a/neomjs/neo'
+        });
+
+        expect(spec).toEqual({
+            command: '/Applications/ChatGPT.app/Contents/MacOS/ChatGPT',
+            args   : [
+                '--user-data-dir=/srv/instances/a/codex-desktop/electron-profile',
+                '--open-project=/srv/checkouts/a/neomjs/neo'
+            ],
+            env: {
+                CODEX_HOME                   : '/srv/instances/a/codex-desktop/codex-home',
+                CODEX_ELECTRON_USER_DATA_PATH: '/srv/instances/a/codex-desktop/electron-profile',
+                CODEX_SPARKLE_ENABLED        : 'false'
+            },
+            versionProbeArgs: null,
+            authHome        : '/srv/instances/a/codex-desktop/codex-home',
+            electronProfile : '/srv/instances/a/codex-desktop/electron-profile'
         });
     });
 
@@ -77,13 +102,15 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
     });
 
     test('LAUNCHABLE_HARNESS_TYPES is the frozen alphabetical template subset AND every entry is a registered harness type', () => {
-        expect(LAUNCHABLE_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex']);
+        expect(LAUNCHABLE_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex', 'codex-desktop']);
         expect(Object.isFrozen(LAUNCHABLE_HARNESS_TYPES)).toBe(true);
 
         // The lockstep invariant the module also guards at import: launch vocabulary ⊆ the shared
         // registry authority. `native-neo` stays registered-but-unlaunchable by design.
         const registered = new Set(HARNESS_TYPES.map(entry => entry.type));
 
+        expect(registered.size).toBe(HARNESS_TYPES.length);
+        expect(HARNESS_TYPES.filter(entry => entry.type === 'codex-desktop')).toHaveLength(1);
         for (const type of LAUNCHABLE_HARNESS_TYPES) {
             expect(registered.has(type), `'${type}' must be registered in src/ai/fleet/harnessTypes.mjs`).toBe(true);
         }
@@ -93,6 +120,7 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
 
     test('getHarnessAuthMode: marker for the CLI families, in-app for the app bundles, null fail-closed for everything else', () => {
         expect(getHarnessAuthMode('codex')).toBe('marker');
+        expect(getHarnessAuthMode('codex-desktop')).toBe('marker');
         expect(getHarnessAuthMode('claude-code')).toBe('marker');
         expect(getHarnessAuthMode('claude-desktop')).toBe('in-app');
         expect(getHarnessAuthMode('antigravity')).toBe('in-app');
@@ -106,6 +134,7 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
         expect(call).toThrow(/unsupported harnessType 'gemini-cli'/);
         expect(call).toThrow(/'claude-code'/);
         expect(call).toThrow(/'codex'/);
+        expect(call).toThrow(/'codex-desktop'/);
         expect(call).toThrow(/'claude-desktop'/);
         expect(call).toThrow(/'antigravity'/);
     });
@@ -117,5 +146,7 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
         expect(() => deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: '/h', binaryPath: ''  })).toThrow(/binaryPath/);
         expect(() => deriveHarnessLaunchSpec({harnessType: 'codex', instanceHome: 42,   binaryPath: '/b'})).toThrow(/instanceHome/);
         expect(() => deriveHarnessLaunchSpec({})).toThrow(/harnessType/);
+        expect(() => deriveHarnessLaunchSpec({harnessType: 'codex-desktop', instanceHome: '/h', binaryPath: '/b'})).toThrow(/cwd/);
+        expect(() => deriveHarnessLaunchSpec({harnessType: 'codex-desktop', instanceHome: '/h', binaryPath: '/b', cwd: 'relative'})).toThrow(/cwd/);
     });
 });

--- a/test/playwright/unit/ai/services/fleet/manageCodexDesktopRuntime.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/manageCodexDesktopRuntime.spec.mjs
@@ -1,0 +1,288 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+import {
+    classifyCodexDesktopCrashpadProcesses,
+    cleanupCodexDesktopCrashpad,
+    inspectCodexDesktopCrashpadProcesses,
+    probeCodexDesktopCapabilities
+} from '../../../../../../ai/services/fleet/manageCodexDesktopRuntime.mjs';
+
+const REQUIRED_ASAR_MARKERS = [
+    'CODEX_ELECTRON_USER_DATA_PATH',
+    '--open-project',
+    'CODEX_SPARKLE_ENABLED',
+    'CODEX_SPARKLE_ENABLED===`false`',
+    'shouldIncludeSparkle',
+    'enableUpdater'
+].join('\n');
+
+function makeBundle({asar = REQUIRED_ASAR_MARKERS, framework = 'user-data-dir'} = {}) {
+    const
+        appBundle     = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-desktop-probe-')),
+        contents      = path.join(appBundle, 'Contents'),
+        main          = path.join(contents, 'MacOS', 'ChatGPT'),
+        appAsar       = path.join(contents, 'Resources', 'app.asar'),
+        frameworkDir  = path.join(contents, 'Frameworks', 'Codex Framework.framework'),
+        frameworkPath = path.join(frameworkDir, 'Codex Framework'),
+        crashpad      = path.join(frameworkDir, 'Helpers', 'browser_crashpad_handler');
+
+    for (const directory of [path.dirname(main), path.dirname(appAsar), path.dirname(crashpad)]) {
+        fs.mkdirSync(directory, {recursive: true});
+    }
+
+    fs.writeFileSync(main, '#!/bin/sh\n', {mode: 0o755});
+    fs.writeFileSync(appAsar, asar);
+    fs.writeFileSync(frameworkPath, framework);
+    fs.writeFileSync(crashpad, '#!/bin/sh\n', {mode: 0o755});
+
+    return {appBundle, main, crashpad};
+}
+
+test.describe('manageCodexDesktopRuntime', () => {
+    const roots = [];
+
+    test.afterEach(() => {
+        for (const root of roots.splice(0)) fs.rmSync(root, {recursive: true, force: true});
+    });
+
+    test('capability probe proves the packaged profile/project/updater tuple without a version allowlist', () => {
+        const fixture = makeBundle();
+        roots.push(fixture.appBundle);
+
+        expect(probeCodexDesktopCapabilities({binaryPath: fixture.main})).toEqual({
+            available         : true,
+            reason            : null,
+            binaryPath        : fs.realpathSync(fixture.main),
+            crashpadExecutable: fs.realpathSync(fixture.crashpad),
+            appBundle         : fs.realpathSync(fixture.appBundle)
+        });
+    });
+
+    test('capability probe fails closed when updater env presence lacks the falsifiable false predicate', () => {
+        const fixture = makeBundle({
+            asar: REQUIRED_ASAR_MARKERS.replace('CODEX_SPARKLE_ENABLED===`false`', 'CODEX_SPARKLE_ENABLED')
+        });
+        roots.push(fixture.appBundle);
+
+        expect(probeCodexDesktopCapabilities({binaryPath: fixture.main})).toMatchObject({
+            available: false,
+            reason   : 'updater-disable-predicate-missing'
+        });
+    });
+
+    test('capability probe names every missing project/profile contract before any launch', () => {
+        const scenarios = [{
+            bundle: {asar: REQUIRED_ASAR_MARKERS.replace('--open-project', '')},
+            reason: 'app-contract-marker-missing:--open-project'
+        }, {
+            bundle: {asar: REQUIRED_ASAR_MARKERS.replace('CODEX_ELECTRON_USER_DATA_PATH', '')},
+            reason: 'app-contract-marker-missing:CODEX_ELECTRON_USER_DATA_PATH'
+        }, {
+            bundle: {framework: ''},
+            reason: 'chromium-contract-marker-missing:user-data-dir'
+        }];
+
+        for (const scenario of scenarios) {
+            const fixture = makeBundle(scenario.bundle);
+            roots.push(fixture.appBundle);
+
+            expect(probeCodexDesktopCapabilities({binaryPath: fixture.main})).toMatchObject({
+                available: false,
+                reason   : scenario.reason
+            });
+        }
+    });
+
+    test('capability probe rejects a standalone executable that is not an app-bundle main', () => {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-desktop-standalone-')),
+              bin  = path.join(root, 'ChatGPT');
+        roots.push(root);
+        fs.writeFileSync(bin, '#!/bin/sh\n', {mode: 0o755});
+
+        expect(probeCodexDesktopCapabilities({binaryPath: bin})).toMatchObject({
+            available: false,
+            reason   : 'binary-is-not-an-app-bundle-main'
+        });
+    });
+
+    test('classifier owns only exact executable + contained database and leaves foreign profiles untouched', () => {
+        const
+            profile = '/srv/fleet/peer/codex-desktop/electron-profile',
+            helper  = '/Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Versions/Current/Helpers/browser_crashpad_handler',
+            result  = classifyCodexDesktopCrashpadProcesses({
+                electronProfile   : profile,
+                crashpadExecutable: helper,
+                processes         : [{
+                    pid         : 11,
+                    executable  : helper,
+                    processToken: 'birth-11',
+                    command     : `${helper} --monitor-self --database=${profile}/Crashpad --annotation=prod=Codex`
+                }, {
+                    pid       : 12,
+                    executable: helper,
+                    command   : `${helper} --database=/Users/operator/Library/Application Support/Codex/Crashpad --annotation=prod=Codex`
+                }, {
+                    pid       : 13,
+                    executable: helper,
+                    command   : `${helper} --database=${profile}-foreign/Crashpad --annotation=prod=Codex`
+                }]
+            });
+
+        expect(result.owned.map(row => row.pid)).toEqual([11]);
+        expect(result.foreign.map(row => row.pid)).toEqual([12, 13]);
+        expect(result.ambiguous).toEqual([]);
+    });
+
+    test('classifier treats profile-matching rows with missing or foreign executable proof as ambiguous', () => {
+        const
+            profile = '/srv/fleet/peer/electron-profile',
+            helper  = '/Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Helpers/browser_crashpad_handler',
+            command = `${helper} --database=${profile}/Crashpad --annotation=prod=Codex`,
+            result  = classifyCodexDesktopCrashpadProcesses({
+                electronProfile   : profile,
+                crashpadExecutable: helper,
+                processes         : [
+                    {pid: 21, command, executable: null},
+                    {pid: 22, command, executable: '/tmp/foreign/browser_crashpad_handler'},
+                    {pid: 23, command, executable: helper, processToken: null}
+                ]
+            });
+
+        expect(result.owned).toEqual([]);
+        expect(result.ambiguous.map(row => row.reason)).toEqual([
+            'executable-identity-unavailable',
+            'profile-match-with-foreign-executable',
+            'process-birth-token-unavailable'
+        ]);
+    });
+
+    test('classifier fails closed when exact-helper database ownership is absent or unparseable', () => {
+        const
+            profile = '/srv/fleet/peer/electron-profile',
+            helper  = '/Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Helpers/browser_crashpad_handler',
+            result  = classifyCodexDesktopCrashpadProcesses({
+                electronProfile   : profile,
+                crashpadExecutable: helper,
+                processes         : [{pid: 24, command: `${helper} --monitor-self`, executable: helper}]
+            });
+
+        expect(result.owned).toEqual([]);
+        expect(result.ambiguous).toMatchObject([{pid: 24, reason: 'database-identity-unavailable'}]);
+    });
+
+    test('classifier accepts the alternate spaced database argv form without losing paths with spaces', () => {
+        const
+            profile = '/srv/fleet/Peer With Spaces/electron-profile',
+            helper  = '/Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Helpers/browser_crashpad_handler',
+            result  = classifyCodexDesktopCrashpadProcesses({
+                electronProfile   : profile,
+                crashpadExecutable: helper,
+                processes         : [{pid: 25, command: `${helper} --database ${profile}/Crashpad --annotation=prod=Codex`, executable: helper, processToken: 'birth-25'}]
+            });
+
+        expect(result.owned).toMatchObject([{pid: 25, database: `${profile}/Crashpad`}]);
+        expect(result.ambiguous).toEqual([]);
+    });
+
+    test('classifier refuses kill authority when one argv carries multiple database roots', () => {
+        const
+            profile = '/srv/fleet/peer/electron-profile',
+            helper  = '/Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Helpers/browser_crashpad_handler',
+            result  = classifyCodexDesktopCrashpadProcesses({
+                electronProfile   : profile,
+                crashpadExecutable: helper,
+                processes         : [{
+                    pid       : 23,
+                    executable: helper,
+                    command   : `${helper} --database=${profile}/Crashpad --database=/tmp/foreign --annotation=prod=Codex`
+                }]
+            });
+
+        expect(result.owned).toEqual([]);
+        expect(result.ambiguous).toMatchObject([{pid: 23, reason: 'multiple-profile-database-arguments'}]);
+    });
+
+    test('host inspector combines pgrep argv with lsof loaded-executable identity', () => {
+        const
+            profile      = '/srv/fleet/Peer With Spaces/electron-profile',
+            helper       = '/Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Helpers/browser_crashpad_handler',
+            execFileImpl = (command, args) => command === 'pgrep'
+                ? `31 ${helper} --database=${profile}/Crashpad --annotation=prod=Codex\n`
+                : command === 'ps'
+                    ? 'Sun Jul 12 04:00:00 2026\n'
+                    : `p${args[2]}\nftxt\nn${helper}\nftxt\nn/usr/lib/dyld\n`,
+            result = inspectCodexDesktopCrashpadProcesses({electronProfile: profile, crashpadExecutable: helper, execFileImpl});
+
+        expect(result.owned.map(row => row.pid)).toEqual([31]);
+        expect(result.ambiguous).toEqual([]);
+    });
+
+    test('cleanup re-proves ownership, escalates surviving owned helpers, and requires zero residuals', async () => {
+        const
+            owned   = pid => ({pid, processToken: `birth-${pid}`}),
+            alive   = new Map([[41, owned(41)], [42, owned(42)]]),
+            signals = [];
+
+        const result = await cleanupCodexDesktopCrashpad({
+            electronProfile   : '/srv/fleet/peer/electron-profile',
+            crashpadExecutable: '/app/browser_crashpad_handler',
+            inspect           : () => ({owned: [...alive.values()], foreign: [], ambiguous: []}),
+            killProcess       : (pid, signal) => {
+                signals.push([pid, signal]);
+                if (pid === 41 || signal === 'SIGKILL') alive.delete(pid);
+            },
+            wait              : async () => {}
+        });
+
+        expect(signals).toEqual([[41, 'SIGTERM'], [42, 'SIGTERM'], [42, 'SIGKILL']]);
+        expect(result).toEqual({terminated: [41, 42], escalated: [42]});
+    });
+
+    test('cleanup sends no signal when profile ownership is ambiguous', async () => {
+        const signals = [];
+
+        await expect(cleanupCodexDesktopCrashpad({
+            electronProfile   : '/srv/fleet/peer/electron-profile',
+            crashpadExecutable: '/app/browser_crashpad_handler',
+            inspect           : () => ({owned: [], foreign: [], ambiguous: [{pid: 51}]}),
+            killProcess       : (...args) => signals.push(args),
+            wait              : async () => {}
+        })).rejects.toThrow(/ambiguous profile-owned process identity/);
+
+        expect(signals).toEqual([]);
+    });
+
+    test('cleanup fails when an exact-profile helper survives SIGKILL', async () => {
+        const
+            owned = {pid: 61, processToken: 'birth-61'};
+
+        await expect(cleanupCodexDesktopCrashpad({
+            electronProfile   : '/srv/fleet/peer/electron-profile',
+            crashpadExecutable: '/app/browser_crashpad_handler',
+            inspect           : () => ({owned: [owned], foreign: [], ambiguous: []}),
+            killProcess       : () => {},
+            wait              : async () => {}
+        })).rejects.toThrow(/survived SIGKILL/);
+    });
+
+    test('cleanup refuses a reused pid whose birth token changes before signal', async () => {
+        let   inspection = 0;
+        const signals    = [];
+
+        await expect(cleanupCodexDesktopCrashpad({
+            electronProfile   : '/srv/fleet/peer/electron-profile',
+            crashpadExecutable: '/app/browser_crashpad_handler',
+            inspect           : () => ({
+                owned    : [{pid: 71, processToken: inspection++ === 0 ? 'birth-old' : 'birth-reused'}],
+                foreign  : [],
+                ambiguous: []
+            }),
+            killProcess: (...args) => signals.push(args),
+            wait       : async () => {}
+        })).rejects.toThrow(/birth token changed/);
+
+        expect(signals).toEqual([]);
+    });
+});

--- a/test/playwright/unit/apps/agentos/config/accountConfigModel.spec.mjs
+++ b/test/playwright/unit/apps/agentos/config/accountConfigModel.spec.mjs
@@ -51,6 +51,7 @@ test.describe('FM account configuration model', () => {
         expect(harnessTypes.resolveHarnessType('claude-desktop')?.label).toBe('Claude');
         expect(harnessTypes.resolveHarnessType('claude-code')?.label).toBe('Claude Code');
         expect(harnessTypes.resolveHarnessType('codex')?.label).toBe('Codex');
+        expect(harnessTypes.resolveHarnessType('codex-desktop')?.label).toBe('Codex Desktop');
         expect(harnessTypes.resolveHarnessType('antigravity')?.label).toBe('Antigravity');
 
         // fail-closed: never guess a launcher or a label


### PR DESCRIPTION
Resolves #15047

Fleet now treats interactive Codex Desktop as a distinct curated harness instead of overloading headless `codex app-server`. The recipe directly supervises the packaged main, binds the final provisioned checkout through `--open-project`, isolates both Codex state and Chromium profile state beneath the contained instance home, keeps OAuth on the bundled CLI, and owns profile-scoped Crashpad teardown through a fail-closed lifecycle.

Evidence: L3 (installed Codex Desktop `26.707.41301` dual-instance direct-child launch, isolated state/profile roots, exact-checkout persistence, clean-shell identity/GitHub binding, and bounded helper teardown to zero) → L3 required (all host-observable close-target ACs). No residuals.

Related: #13015

## Deltas from ticket

- The exact-helper ownership proof includes a process-birth token and revalidates pid + birth + argv + loaded executable immediately before every signal. The unavoidable final macOS PID-only identity-to-signal micro-window is documented rather than claimed closed.
- `cleanupUnresolved` is a typed lifecycle fact, not an inference from generic `state:'failed'`; existing Codex/Claude failure recovery remains unchanged.
- A failed or transiently ambiguous helper scan can be retried in-process through `stop()`. Restart/removal remain blocked until a later exact-profile scan proves zero residuals.
- Raw compatibility launches retain command redaction; the new `authHome` / `authCommand` projection exists only for curated launches.

## Test Evidence

- `npm run test-unit -- <nine focused Fleet/onboarding/registry specs> --reporter=dot` — 155/155 focused tests green.
- `npm run test-unit -- <lifecycle/runtime/manager specs>` — 74/74 focused race and teardown tests green.
- `npm run agent-preflight -- --no-fix <14 changed files>` — all requested gates passed.
- `npm run ai:lint-config-template-ssot` — ADR-0019 config ownership lint passed.
- Node syntax checks, block alignment, shorthand, JSDoc types, ticket archaeology, whitespace, AiConfig test-mutation lint, and `git diff --check` passed.
- L3 local dual-instance receipt on the installed app:
  - two packaged mains remained direct tracked children with distinct `codex-home` and `electron-profile` roots;
  - both argv sets carried the native profile selector and exact provisioned project, and both state stores persisted that checkout;
  - each isolated group produced two exact-profile helpers; no scoped process opened the operator default Codex roots;
  - a sterile `zsh -f` resolved `NEO_AGENT_IDENTITY`, `gh api user --jq .login`, and cwd to the same Fleet definition/checkout;
  - both main stops succeeded, both helper sets reached zero owned/ambiguous residuals, and the disposable roots were removed.

## Post-Merge Validation

- [ ] On the next installed Codex Desktop update, re-run the capability probe before enabling new resident starts; any missing profile/project/updater marker must surface `unavailable` before spawn.
- [ ] Confirm the first durable Fleet-managed Desktop stop reports `cleanupUnresolved:false` after the operator-owned OAuth handoff.

## Commits

- `898f3ab1c` — add the isolated Codex Desktop launch, auth, capability, and teardown lifecycle.

## Evolution

The live current-build probe falsified “main PID exit equals lifecycle completion”: two profile-scoped Crashpad helpers survived each direct main exit. The implementation therefore moved from ordinary child supervision to a bounded exact-profile finalization phase, then tightened that phase through independent review with birth-token revalidation, raw-launch redaction, retryable ambiguity, and legacy-family compatibility pins.

Authored by Emmy (OpenAI GPT-5.6 Sol, Codex). Session f95e01ff-ba36-409a-98af-573263fab247.
