### PR TITLE
fix(build): block-alignment --fix corrupts destructuring-with-defaults (#15072)

### DIFF
--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -201,9 +201,15 @@ function evaluateColonAlignment(lines, maskedLines = []) {
 
 // ─────────────────────────── `=` declaration blocks (v1b) ───────────────────────────
 
+// The DECL_BINDING pattern-class deliberately EXCLUDES `=` from its `{…}`/`[…]` branches: a destructuring
+// binding that carries a DEFAULT (`{a = []}`, `[x = 0]`) holds an `=` that is NOT the assignment operator.
+// Excluding it makes such a line fail to match as a declaration, so it breaks the alignment run (stays
+// untouched) instead of being mis-split at its first `=` by splitAssignment — which erased a valid
+// `{blockedNodes = [], …} = focusContradiction` into a SyntaxError. Default-FREE patterns (`{record}`) carry
+// no `=`, so they still match and align exactly as before — only defaulted patterns are excluded.
 const
     LONE_KEYWORD = /^\s*(?:const|let|var)\s*$/,        // a lone `const`/`let`/`var` line (opens a comma-block)
-    DECL_BINDING = String.raw`(?:[A-Za-z_$][\w$]*|\{[^}]+\}|\[[^\]]+\])`,
+    DECL_BINDING = String.raw`(?:[A-Za-z_$][\w$]*|\{[^}=]+\}|\[[^\]=]+\])`,
     BARE_DECL    = new RegExp(`^(\\s+)${DECL_BINDING}\\s*=\\s*.+$`); // its indented `binding = value` comma-block continuation
 
 const

--- a/buildScripts/util/check-parse.mjs
+++ b/buildScripts/util/check-parse.mjs
@@ -1,0 +1,45 @@
+import {execFileSync} from 'node:child_process';
+
+/**
+ * @module buildScripts/util/check-parse
+ * @summary Commit-time syntax gate: `node --check` every staged `.mjs`, failing the commit if any no
+ * longer parses. It is the durable backstop for mechanical rewrites whose output ships un-run — most
+ * notably `check-block-alignment.mjs --fix`, which an author invokes AFTER the local test pass, so an
+ * aligner edge case that turns valid source into a `SyntaxError` would otherwise commit green locally and
+ * only blow up in CI when a spec imports the file (every importing spec throws — a full wasted CI cycle).
+ * A mechanical fixer will always have edge cases; a parse gate catches all of them, present and future,
+ * regardless of which fixer (or hand-edit) produced the break.
+ *
+ * A syntax error is never a legitimate commit, so this scopes to the WHOLE staged file (not the
+ * author's added lines — unlike the diff-scoped alignment check) and needs no git-diff context.
+ * `node --check` parses module syntax WITHOUT executing, so no imports are resolved and no module side
+ * effects run. Wired last in the `*.mjs` lint-staged chain, after the mechanical fixers it backstops.
+ *
+ * Usage:
+ *   node buildScripts/util/check-parse.mjs <file.mjs> [...]   # exit 1 if any file fails to parse
+ */
+
+const files = process.argv.slice(2).filter(arg => arg.endsWith('.mjs'));
+
+const unparseable = [];
+
+for (const file of files) {
+    // `node --check` on the current interpreter: syntax-only, no execution. A non-zero exit throws, and
+    // the SyntaxError (with its file:line:col caret) is on stderr — surfaced verbatim so the author can
+    // locate the break without re-running anything.
+    try {
+        execFileSync(process.execPath, ['--check', file], {encoding: 'utf8', stdio: 'pipe'});
+    } catch (err) {
+        unparseable.push({file, detail: (err.stderr || err.message || '').trim()});
+    }
+}
+
+if (unparseable.length > 0) {
+    console.error(`check-parse: ${unparseable.length} staged .mjs file(s) no longer parse:`);
+    for (const {file, detail} of unparseable) {
+        console.error(`  ${file}`);
+        if (detail) console.error(detail.split('\n').map(line => `    ${line}`).join('\n'));
+    }
+    console.error('\nA syntax error must never be committed. If a mechanical fixer (e.g. check-block-alignment --fix) produced it, revert that rewrite and align the block by hand, then report the input as a fixer bug (see #15057).');
+    process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -240,7 +240,8 @@
             "node ./buildScripts/util/check-shorthand.mjs",
             "node ./buildScripts/util/check-jsdoc-types.mjs",
             "node ./buildScripts/util/check-ticket-archaeology.mjs",
-            "node ./buildScripts/util/check-block-alignment.mjs --staged"
+            "node ./buildScripts/util/check-block-alignment.mjs --staged",
+            "node ./buildScripts/util/check-parse.mjs"
         ],
         "test/**/*.mjs": [
             "node ./buildScripts/util/check-aiconfig-test-mutation.mjs"

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -304,6 +304,27 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
             expect(run(file).status).toBe(0);
         });
 
+        test('#15057: a destructuring-with-defaults declarator is left untouched, never mis-split into invalid JS', () => {
+            // The default `=` inside `{blockedNodes = []}` is NOT the assignment operator. Before the guard,
+            // --fix sliced the line at that first `=` and erased `[], ...} = focusContradiction` into a
+            // SyntaxError. Such a line now fails to match as a declaration, breaks the run, and is preserved
+            // byte-for-byte. Default-FREE destructuring (`{record}`, above) still aligns — this is the only
+            // shape excluded. Pins the exact multi-declarator input the aligner corrupted.
+            const original = [
+                'function buildRouteAttributionRecords(focusContradiction) {',
+                '    const {blockedNodes = [], focusCandidates = []} = focusContradiction,',
+                '          focusReasons = [...new Set(focusCandidates.flatMap(c => Array.isArray(c.reasons) ? c.reasons : []))];',
+                '    return {blockedNodes, focusReasons};',
+                '}'
+            ].join('\n');
+            const file = write('d.mjs', original);
+
+            expect(run('--fix', file).status).toBe(0);
+            expect(fs.readFileSync(file, 'utf8')).toBe(original);    // byte-identical: the default `=` is never an alignment column
+            expect(run(file).status).toBe(0);                        // check mode: no drift, so the author is never told to --fix
+            execFileSync('node', ['--check', file], {stdio: 'pipe'}); // throws if --fix left the file un-parseable
+        });
+
         test('#13896: --fix aligns repeated-keyword declaration blocks', () => {
             const file = write('d.mjs', [
                 "const extra     = extraModels.length ? extraModels.join(', ') : 'none';",
@@ -385,7 +406,7 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
         });
 
         test('a block-opening `=` value participates in lone-keyword block alignment', () => {
-            // Regression guard: #13908 changed `me    = this` to `me = this` before a block-opening
+            // Regression guard: an earlier fix collapsed `me    = this` to `me = this` before a block-opening
             // sibling. That is still one declaration block and must align as a whole.
             const file = write('d.mjs', [
                 'const',

--- a/test/playwright/unit/ai/buildScripts/util/check-parse.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-parse.spec.mjs
@@ -1,0 +1,84 @@
+import {test, expect}  from '@playwright/test';
+import {execFileSync}  from 'node:child_process';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const
+    __filename = fileURLToPath(import.meta.url),
+    __dirname  = path.dirname(__filename),
+    scriptPath = path.resolve(__dirname, '../../../../../../buildScripts/util/check-parse.mjs');
+
+/**
+ * check-parse.mjs — the commit-time syntax gate (`node --check` each staged `.mjs`). It is the durable
+ * backstop for mechanical rewrites whose output ships un-run: `check-block-alignment --fix` runs after the
+ * author's local test pass, so a destructuring-with-defaults edge case erased valid JS into a
+ * SyntaxError that was green locally and only red in CI (every importing spec threw). A parse gate catches
+ * every such break regardless of the source that produced it.
+ */
+test.describe('check-parse.mjs (#15057)', () => {
+    let tempDir;
+
+    test.beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-check-parse-'));
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(tempDir, {recursive: true, force: true});
+    });
+
+    const write = (name, content) => {
+        const filePath = path.join(tempDir, name);
+        fs.writeFileSync(filePath, content, 'utf8');
+        return filePath;
+    };
+
+    // execFileSync (not execSync): node is spawned directly with an argv array — no shell, so the absolute
+    // scriptPath + file args can never be interpolated into a shell command (CodeQL-clean).
+    const run = (...args) => {
+        try {
+            return {status: 0, output: execFileSync('node', [scriptPath, ...args], {encoding: 'utf8', stdio: 'pipe'})};
+        } catch (error) {
+            return {status: error.status, output: (error.stderr || '') + (error.stdout || '')};
+        }
+    };
+
+    test('passes (exit 0) when every staged .mjs parses', () => {
+        const file = write('ok.mjs', 'export const answer = 42;\n');
+        expect(run(file).status).toBe(0);
+    });
+
+    test('fails (exit 1) and names the file + SyntaxError when a staged .mjs no longer parses', () => {
+        // The exact aligner-corruption shape: a multi-declarator const mis-split at the default `=` inside
+        // the destructuring pattern, leaving an unterminated `{` — a plain SyntaxError.
+        const file             = write('broken.mjs', 'const {blockedNodes = focusContradiction,\n      focusReasons  = [1];\n');
+        const {status, output} = run(file);
+
+        expect(status).toBe(1);
+        expect(output).toContain('no longer parse');
+        expect(output).toContain('broken.mjs');
+        expect(output).toContain('SyntaxError');
+    });
+
+    test('a mixed batch fails on the one broken file and reports only it', () => {
+        const
+            good             = write('good.mjs', 'const a = 1, bb = 2;\n'),
+            broken           = write('broken.mjs', 'const {x = ;\n'),
+            {status, output} = run(good, broken);
+
+        expect(status).toBe(1);
+        expect(output).toContain('broken.mjs');
+        expect(output).not.toContain('good.mjs');   // clean files are never listed
+    });
+
+    test('non-.mjs paths are ignored — a broken .js never fails the gate', () => {
+        // lint-staged globs this gate to *.mjs; a stray non-.mjs arg must be a no-op, never a false block.
+        const file = write('broken.js', 'const {x = ;\n');
+        expect(run(file).status).toBe(0);
+    });
+
+    test('no .mjs files in scope is a clean no-op (exit 0)', () => {
+        expect(run().status).toBe(0);
+    });
+});


### PR DESCRIPTION
Resolves #15072

`check-block-alignment.mjs --fix` silently rewrote a valid multi-declarator `const` into a `SyntaxError` whenever a declarator was a destructuring pattern carrying a **default** (`{blockedNodes = []}`): it located the assignment `=` with `line.indexOf('=')`, which lands on the default *inside* the pattern, so the fixer sliced mid-pattern and ate tokens. Because lint-staged runs the check-only `--staged` mode (an author runs `--fix` manually, after local tests), the corruption shipped green locally and only threw in CI when a spec imported the file.

Two changes: the aligner's `DECL_BINDING` now excludes `=` from its `{…}`/`[…]` branches, so a defaulted destructuring LHS no longer matches as a declaration — it breaks the run and is left byte-for-byte untouched (default-free `{record}` carries no `=` and still aligns — `#13908` preserved). And a new commit-time gate, `buildScripts/util/check-parse.mjs` (wired last in the `*.mjs` lint-staged chain), `node --check`s every staged `.mjs` so no mechanical fixer's future edge case can commit unparseable output.

Evidence: L1 (static + Playwright unit + a real lint-staged dry-run — the change is entirely build tooling, fully sandbox-reachable) → L1 required (every close-target AC is unit/static/lint-verifiable). Residual: none.

## Deltas from ticket
None substantive. The brief framed fix #2 as a "post-fix parse-check in the block-align step," but `git log -S` confirmed lint-staged has only ever run `check-block-alignment --staged` (check-only) — there is no `--fix` step to attach to. The durable guard is therefore a standalone commit-time gate (`check-parse.mjs`), which is strictly more general (backstops every mechanical fixer and hand-edit, not just this aligner) and directly implements "fail the commit if any no longer parses." Also cleaned one pre-existing ticket-archaeology violation the clean-as-you-touch scan surfaced in the touched spec.

## Test Evidence
- **Exact PR #15060 repro** under `--fix`: byte-identical to input, `node --check`-clean (baseline: `Aligned 2 line(s)` → `SyntaxError: Unexpected token ';'`). Check mode reports **no drift** → the author is never told to `--fix` it (chain broken at the root).
- **`#13908` preserved**: default-free `{record}`/`{value}` destructuring still aligns to its pinned output.
- **Fuzz**: `{a=1}` head, `{b=[]}` tail, `[x=0]` array-default, lone-keyword `{a=1}`, nested `{a:{b=1}}` — zero residual corruption.
- **Unit**: `UNIT_TEST_MODE=true playwright test -c test/playwright/playwright.config.unit.mjs <both specs>` → **30 passed** (23 existing, no regressions + the `#15057` regression + 5 new `check-parse` tests).
- **lint-staged dry-run**: full `*.mjs` chain green on this diff including `check-parse`; and with a corrupted `.mjs` staged, the commit is **blocked at check-parse** (`SyntaxError`, names the file) while `check-block-alignment --staged` passes it — proving the gate closes the green-locally/red-in-CI gap.
- **Fleet-wide V-B-A**: all 2587 tracked `.mjs` pass `node --check` (zero false-positive risk for the gate).

## Post-Merge Validation
- [ ] A real pre-commit `--fix` on a defaulted-destructuring `const` leaves it intact (no corruption in the live hook path).
- [ ] `check-parse` blocks a genuinely unparseable staged `.mjs` in a live commit before CI.

## Commits
- f93a6d4d3f — fix(build): aligner `=`-exclusion guard (`DECL_BINDING`) + `check-parse.mjs` commit-time gate + `#15057`/`check-parse` unit coverage.

Related: #15057, PR #15060 (origin seam). Sibling `--fix`-corruption bugs: `#13670`, `#14212`; diff-scope precedent `#13720`.

Authored by Ada (Opus 4.8, Claude Code). Session 1ce7602e-71b7-472a-9d8d-b2cf27a13cde.
