### PR TITLE
fix(fleet): keep GUI auth restart supervised (#14988)

### DIFF
--- a/ai/scripts/fleet/onboardPeer.mjs
+++ b/ai/scripts/fleet/onboardPeer.mjs
@@ -34,9 +34,10 @@ import {normalizeAgentIdentityNodeId}                 from '../../graph/normaliz
  *      seeded (read-only probe). Refuse with the exact missing operator step named.
  *   5. `launch`    — `FleetManager.startAgent(id)` (provision-then-start, supervised child in
  *      its isolated instance home via the curated per-family template).
- *   6. `auth`      — take `instanceHome` + `authRequired` from the long-lived lifecycle owner's
- *      `startAgent` status and print the exact per-home login line. Secrets never touch this script:
- *      authentication is the operator-owned step by design.
+ *   6. `auth`      — use the long-lived lifecycle owner's auth-mode/status projection to hand off
+ *      the operator step: marker families receive the exact per-home login line; GUI families sign
+ *      in inside the Fleet-launched window and return to Fleet for any restart. Secrets never touch
+ *      this script.
  *
  * Idempotent per segment because every underlying contract already is (definition conflicts refuse,
  * repo drift reconciles through `setRepo`, repo ensure-or-reuse, start short-circuits when running,
@@ -379,7 +380,7 @@ export function planOnboarding({intent, facts = {}} = {}) {
     // decision `deriveAuthHandoff` makes post-launch (dry-run and --commit cannot drift).
     push('auth', 'PRINT',
         getHarnessAuthMode(intent.harnessType) === 'in-app'
-            ? 'in-app sign-in inside the launched window (operator-owned; the isolated relaunch line prints after launch)'
+            ? 'in-app sign-in inside the Fleet-launched window (operator-owned; if closed, restart through this command --commit or Fleet cockpit Start)'
             : facts.authRequired === false
                 ? 'per-home credentials already present — no login step required'
                 : facts.authRequired === true
@@ -412,42 +413,37 @@ export function renderPlan(intent, plan) {
 }
 
 /**
- * @summary Build the exact operator-owned auth command from typed lifecycle-owned paths. Marker
- * families consume `authHome` + `authCommand`; in-app families consume `instanceHome` +
- * `launchCommand`. The split is load-bearing for Codex Desktop: its GUI main is never invoked as a
- * CLI login command. Paths are never guessed from resident id/PATH and are shell-quoted as data.
+ * @summary Build the exact operator-owned login command for marker-auth families from the typed
+ * auth home + executable resolved by the lifecycle service. In-app GUI families never enter this
+ * helper: authentication happens inside the already Fleet-launched window, and any restart stays
+ * owned by Fleet. The split is load-bearing for Codex Desktop: its bundled CLI authenticates the
+ * nested Codex home, while its GUI main is never invoked as a login command. Paths are never
+ * guessed from resident id/PATH and are shell-quoted as data.
  * @param {Object} options
- * @param {String} options.harnessType Curated harness family.
- * @param {String} [options.instanceHome] GUI profile home for in-app families.
- * @param {String} [options.launchCommand] GUI executable for in-app families.
- * @param {String} [options.authHome] Marker/auth home for marker families.
- * @param {String} [options.authCommand] Auth executable for marker families.
+ * @param {String} options.harnessType Curated marker-auth family.
+ * @param {String} options.authHome Absolute marker/auth home from lifecycle status.
+ * @param {String} options.authCommand Absolute auth executable from lifecycle status.
  * @returns {String}
  */
-export function buildLoginCommand({harnessType, instanceHome, launchCommand, authHome, authCommand} = {}) {
+export function buildLoginCommand({harnessType, authHome, authCommand} = {}) {
     if (!CURATED_HARNESS_TYPES.includes(harnessType)) {
         throw new Error(`buildLoginCommand: unsupported harnessType '${String(harnessType)}'.`);
     }
-    const
-        markerMode = getHarnessAuthMode(harnessType) === 'marker',
-        home       = markerMode ? authHome : instanceHome,
-        command    = markerMode ? authCommand : launchCommand;
-
-    if (typeof home !== 'string' || !path.isAbsolute(home) || CONTROL_CHARACTERS.test(home)) {
-        throw new Error(`buildLoginCommand: lifecycle status must provide a control-character-free absolute ${markerMode ? 'authHome' : 'instanceHome'}.`);
+    if (getHarnessAuthMode(harnessType) !== 'marker') {
+        throw new Error(`buildLoginCommand: harnessType '${harnessType}' authenticates in-app; login commands are marker-family only.`);
     }
-    if (typeof command !== 'string' || !path.isAbsolute(command) || CONTROL_CHARACTERS.test(command)) {
-        throw new Error(`buildLoginCommand: lifecycle status must provide a control-character-free absolute ${markerMode ? 'authCommand' : 'launchCommand'}.`);
+    if (typeof authHome !== 'string' || !path.isAbsolute(authHome) || CONTROL_CHARACTERS.test(authHome)) {
+        throw new Error('buildLoginCommand: lifecycle status must provide a control-character-free absolute authHome.');
+    }
+    if (typeof authCommand !== 'string' || !path.isAbsolute(authCommand) || CONTROL_CHARACTERS.test(authCommand)) {
+        throw new Error('buildLoginCommand: lifecycle status must provide a control-character-free absolute authCommand.');
     }
 
     const
         quote         = value => `'${value.replaceAll("'", "'\\''")}'`,
-        quotedHome    = quote(home),
-        quotedCommand = quote(command);
+        quotedHome    = quote(authHome),
+        quotedCommand = quote(authCommand);
 
-    // Per-family operator-owned auth step: CLI families have a login command / in-session login;
-    // the app-bundle GUI families sign in INSIDE the launched window (no CLI login exists) — the
-    // printed line relaunches the same isolated instance if the operator closed it.
     switch (harnessType) {
         case 'codex':
         case 'codex-desktop':
@@ -455,7 +451,7 @@ export function buildLoginCommand({harnessType, instanceHome, launchCommand, aut
         case 'claude-code':
             return `CLAUDE_CONFIG_DIR=${quotedHome} ${quotedCommand}  # then /login inside the session`;
         default:
-            return `${quotedCommand} --user-data-dir=${quotedHome}  # sign in inside the app window (relaunch if closed)`;
+            throw new Error(`buildLoginCommand: marker-family '${harnessType}' has no login renderer.`);
     }
 }
 
@@ -463,13 +459,14 @@ export function buildLoginCommand({harnessType, instanceHome, launchCommand, aut
  * @summary The post-launch auth handoff DECISION — the one branch `--commit` executes after
  * `startAgent` returns, extracted pure so tests enter where the real conductor does. Mode-first:
  * an `'in-app'` family (permanently-null `authRequired` — no marker exists) ALWAYS hands off the
- * in-window sign-in instruction; a `'marker'` family branches on the live heuristic (`true` →
- * the login command, `false` → done, `null` → an honest WARN, never a guessed command).
+ * in-window sign-in instruction and routes a closed-window recovery back through Fleet; a
+ * `'marker'` family branches on the live heuristic (`true` → the login command, `false` → done,
+ * `null` → an honest WARN, never a guessed command).
  * @param {Object} options
  * @param {String} options.harnessType Curated harness family.
  * @param {Object} options.status The long-lived owner's `startAgent`/`status` projection —
- *                                `{authRequired, instanceHome, launchCommand, authHome,
- *                                  authCommand}` consumed here.
+ *                                marker branches consume `{authRequired, authHome, authCommand}`;
+ *                                in-app branches deliberately emit none of the launch details.
  * @returns {{kind: 'sign-in-app'|'login-required'|'done'|'unknown', lines: String[]}} printable
  * lines in conductor voice; `kind` is the decision itself, assertable without string-matching.
  */
@@ -479,8 +476,9 @@ export function deriveAuthHandoff({harnessType, status} = {}) {
             kind : 'sign-in-app',
             lines: [
                 '',
-                '  SIGN-IN REQUIRED (operator-owned, inside the launched app window):',
-                `    ${buildLoginCommand({harnessType, instanceHome: status.instanceHome, launchCommand: status.launchCommand, authHome: status.authHome, authCommand: status.authCommand})}`
+                '  SIGN-IN REQUIRED (operator-owned, inside the already Fleet-launched app window):',
+                '    Sign in inside that window.',
+                '    If it was closed, restart through Fleet: re-run this onboardPeer command with --commit, or use Start in the Fleet cockpit.'
             ]
         };
     }
@@ -491,7 +489,7 @@ export function deriveAuthHandoff({harnessType, status} = {}) {
             lines: [
                 '',
                 '  LOGIN REQUIRED (operator-owned, exactly once for this home):',
-                `    ${buildLoginCommand({harnessType, instanceHome: status.instanceHome, launchCommand: status.launchCommand, authHome: status.authHome, authCommand: status.authCommand})}`
+                `    ${buildLoginCommand({harnessType, authHome: status.authHome, authCommand: status.authCommand})}`
             ]
         };
     }

--- a/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
@@ -270,36 +270,57 @@ test.describe('onboardPeer — auth handoff', () => {
         expect(buildLoginCommand({harnessType: 'codex', authHome: "/tmp/neo homes/o'neil", authCommand: '/Applications/ChatGPT.app/Contents/Resources/codex'}))
             .toBe("CODEX_HOME='/tmp/neo homes/o'\\''neil' '/Applications/ChatGPT.app/Contents/Resources/codex' login");
         expect(buildLoginCommand({harnessType: 'claude-code', authHome: '/tmp/claude-home', authCommand: '/opt/claude'}))
-            .toContain("CLAUDE_CONFIG_DIR='/tmp/claude-home'");
+            .toBe("CLAUDE_CONFIG_DIR='/tmp/claude-home' '/opt/claude'  # then /login inside the session");
         expect(() => buildLoginCommand({harnessType: 'codex', authHome: '<instance home>', authCommand: '/opt/codex'})).toThrow(/absolute authHome/);
         expect(() => buildLoginCommand({harnessType: 'codex', authHome: '/tmp/x\nFAKE', authCommand: '/opt/codex'})).toThrow(/control-character-free/);
     });
 
-    test('GUI app-bundle families print the isolated relaunch line — auth is the in-app sign-in, no CLI login exists', () => {
-        expect(buildLoginCommand({harnessType: 'claude-desktop', instanceHome: '/srv/homes/a', launchCommand: '/Applications/Claude.app/Contents/MacOS/Claude'}))
-            .toBe("'/Applications/Claude.app/Contents/MacOS/Claude' --user-data-dir='/srv/homes/a'  # sign in inside the app window (relaunch if closed)");
-        expect(buildLoginCommand({harnessType: 'antigravity', instanceHome: '/srv/homes/b', launchCommand: '/Applications/Antigravity.app/Contents/MacOS/Antigravity'}))
-            .toContain("--user-data-dir='/srv/homes/b'");
-        // The curated guard still fronts the family switch — an unlaunchable family never renders a line.
+    test('the executable login helper is marker-only — GUI families cannot manufacture a raw relaunch', () => {
+        expect(() => buildLoginCommand({harnessType: 'claude-desktop', instanceHome: '/srv/homes/a', launchCommand: '/Applications/Claude.app/Contents/MacOS/Claude'}))
+            .toThrow(/marker-family only/);
+        expect(() => buildLoginCommand({harnessType: 'antigravity', instanceHome: '/srv/homes/b', launchCommand: '/Applications/Antigravity.app/Contents/MacOS/Antigravity'}))
+            .toThrow(/marker-family only/);
         expect(() => buildLoginCommand({harnessType: 'native-neo', instanceHome: '/srv/homes/c', launchCommand: '/bin/x'})).toThrow(/unsupported harnessType/);
     });
 
-    test('the REAL post-launch decision: an in-app family reaches its sign-in handoff despite authRequired null — the exact branch --commit executes', () => {
-        // This enters where main() enters: null previously fell through to the generic WARN, so the
-        // GUI instruction was unreachable in a real run. Mode-first fixes the decision itself.
-        const desktop = deriveAuthHandoff({
+    test('claude-desktop authenticates in the Fleet-launched window and routes closed-window recovery back through Fleet', () => {
+        const status = {
+            authRequired : null,
+            instanceHome : '/srv/homes/a',
+            launchCommand: '/Applications/Claude.app/Contents/MacOS/Claude'
+        };
+        const handoff = deriveAuthHandoff({
             harnessType: 'claude-desktop',
-            status     : {authRequired: null, instanceHome: '/srv/homes/a', launchCommand: '/Applications/Claude.app/Contents/MacOS/Claude'}
+            status
         });
+        const output = handoff.lines.join('\n');
 
-        expect(desktop.kind).toBe('sign-in-app');
-        expect(desktop.lines.join('\n')).toContain('SIGN-IN REQUIRED');
-        expect(desktop.lines.join('\n')).toContain("--user-data-dir='/srv/homes/a'");
+        expect(handoff.kind).toBe('sign-in-app');
+        expect(output).toContain('already Fleet-launched app window');
+        expect(output).toContain('re-run this onboardPeer command with --commit');
+        expect(output).toContain('Start in the Fleet cockpit');
+        expect(output).not.toContain(status.instanceHome);
+        expect(output).not.toContain(status.launchCommand);
+        expect(output).not.toContain('--user-data-dir');
+        expect(output).not.toContain('launchCommand');
+    });
 
-        expect(deriveAuthHandoff({
-            harnessType: 'antigravity',
-            status     : {authRequired: null, instanceHome: '/srv/homes/b', launchCommand: '/Applications/Antigravity.app/Contents/MacOS/Antigravity'}
-        }).kind).toBe('sign-in-app');
+    test('antigravity authenticates in the Fleet-launched window without leaking an unmanaged relaunch', () => {
+        const status = {
+            authRequired : null,
+            instanceHome : '/srv/homes/b',
+            launchCommand: '/Applications/Antigravity.app/Contents/MacOS/Antigravity'
+        };
+        const handoff = deriveAuthHandoff({harnessType: 'antigravity', status});
+        const output  = handoff.lines.join('\n');
+
+        expect(handoff.kind).toBe('sign-in-app');
+        expect(output).toContain('already Fleet-launched app window');
+        expect(output).toContain('restart through Fleet');
+        expect(output).not.toContain(status.instanceHome);
+        expect(output).not.toContain(status.launchCommand);
+        expect(output).not.toContain('--user-data-dir');
+        expect(output).not.toContain('launchCommand');
     });
 
     test('marker families keep the heuristic-driven branches unchanged: true → login command, false → done, null → honest WARN with no guessed command', () => {
@@ -307,6 +328,11 @@ test.describe('onboardPeer — auth handoff', () => {
 
         expect(required.kind).toBe('login-required');
         expect(required.lines.join('\n')).toContain("CODEX_HOME='/srv/homes/c' '/opt/codex' login");
+
+        const claudeRequired = deriveAuthHandoff({harnessType: 'claude-code', status: {authRequired: true, authHome: '/srv/homes/d', authCommand: '/opt/claude'}});
+
+        expect(claudeRequired.kind).toBe('login-required');
+        expect(claudeRequired.lines.at(-1)).toBe("    CLAUDE_CONFIG_DIR='/srv/homes/d' '/opt/claude'  # then /login inside the session");
 
         expect(deriveAuthHandoff({harnessType: 'codex', status: {authRequired: false, authHome: '/srv/homes/c', authCommand: '/opt/codex'}}).kind).toBe('done');
 


### PR DESCRIPTION
Resolves #14988

GUI in-app authentication now stays inside Fleet lifecycle ownership end to end. Claude Desktop and Antigravity tell the operator to sign in inside the already supervised window; if it was closed, recovery routes through the same `onboardPeer --commit` path or the Fleet cockpit Start action. The executable login helper is marker-family-only, so no in-app path can print a raw app binary, `--user-data-dir`, profile home, or launch command. Codex, Codex Desktop, and Claude Code keep their current marker-auth commands.

Evidence: L2 (focused unit execution + negative output assertions + exact diff/mechanical gates; fully sandbox-reachable) → L2 required (auth-mode routing, raw-relaunch prohibition, and marker-family regression coverage). Residual: none.

## Deltas from ticket

The recovered implementation was rebased onto the newer typed auth projection: marker families now consume `authHome` + `authCommand`, including Codex Desktop's bundled CLI/nested home contract. This strengthens the ticket's mode-first sketch without changing scope; GUI families still consume no executable auth path.

## Test Evidence

- `NEO_CHROMA_PORT_TEST=18196 npx playwright test --config=test/playwright/playwright.config.unit.mjs --workers=1 test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs` → **26 passed (31.6s)**.
- Direct negative coverage for both in-app families proves the rendered handoff contains neither `instanceHome`, `launchCommand`, nor `--user-data-dir`, and `buildLoginCommand()` rejects both families as marker-only.
- Marker regressions cover Codex, Codex Desktop, and Claude Code against the current `authHome` / `authCommand` projection.
- `check-whitespace`, `check-shorthand`, `check-jsdoc-types`, `check-ticket-archaeology`, `check-block-alignment`, `check-parse`, and `check-aiconfig-test-mutation` all pass on the two changed files.
- `git diff --check origin/dev...HEAD` passes; outgoing history is exactly one ticketed commit.

## Post-Merge Validation

- [ ] On the next real Claude Desktop or Antigravity onboarding, close the launched window once and confirm the operator recovery path returns through Fleet ownership; this is a field receipt, not a merge blocker.

Related: #13015
Related: #14972

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session 837ad74b-c2d2-413d-9aab-b7165a93a82a.
