### PR TITLE
feat(graph): type-gate rejection producer — the AC3 record-seam (#15076)

### DIFF
--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -41,6 +41,10 @@ import {
     appendRouteAttribution,
     validateRouteAttributionRetention
 } from './routeAttributionLedgerStore.mjs';
+import {
+    TYPE_GATE_REJECTION_FILENAME,
+    TYPE_GATE_REJECTION_STAGE
+} from './typeGateRejectionLedgerStore.mjs';
 import {RETROSPECTIVE_GRAINS, renderHandoffRetrospectiveSection} from './handoffRetrospective.mjs';
 import {assembleRetrospectiveStats}                              from './handoffRetrospectiveAssembler.mjs';
 import {
@@ -434,6 +438,62 @@ class GoldenPathSynthesizer extends Base {
             }
         } catch (error) {
             logger.warn(`[GoldenPathSynthesizer] route-attribution ledger write failed (non-fatal): ${error?.message || error}`)
+        }
+    }
+
+    /**
+     * @summary Pure builder for the type-gate rejection records — the SECOND GP filter point's evidence. Where
+     * `buildRouteAttributionRecords` captures the routing-contradiction GUARD's filtering, this captures the
+     * actionability TYPE-GATE's rejections (`isActionableComputedRecommendation` === false): the visibility-only
+     * candidates (`epic` / `not-code-ready` / …) that never reach scoring. Each record carries the node id, its
+     * exclusion-label bucket (the exact labels that made it non-actionable, from the shared authority), and the
+     * `stage` discriminator so a merged read stays self-describing.
+     * @param {Array<{nodeId: String, rejectionBucket: String[]}>} rejections Collected at the type-gate filter point.
+     * @param {Number} nowMs Epoch ms stamped onto each record.
+     * @returns {Object[]} `[{nodeId, rejectionBucket, stage, at}]` (empty when nothing was rejected).
+     */
+    static buildTypeGateRejectionRecords(rejections, nowMs) {
+        return (Array.isArray(rejections) ? rejections : [])
+            .filter(item => typeof item?.nodeId === 'string' && item.nodeId.length > 0)
+            .map(item => ({
+                nodeId         : item.nodeId,
+                rejectionBucket: Array.isArray(item.rejectionBucket) ? item.rejectionBucket : [],
+                stage          : TYPE_GATE_REJECTION_STAGE,
+                at             : nowMs
+            }))
+    }
+
+    /**
+     * @summary The type-gate rejection record-seam: persists which computed candidates the actionability gate
+     * rejected, under which exclusion labels, per synthesis run — the evidence window the 42.2%-type-gate
+     * disposition decides against. FAIL-OPEN, exactly like `recordRouteAttribution` — a ledger-write failure is
+     * swallowed-logged and never aborts synthesis (the ledger is observability, never a gate); a missing/empty
+     * `dir` is a silent no-op. Reuses the route-attribution ledger's runtime dir + retention leaves + shape-agnostic
+     * append via the `filename` seam, writing a SIBLING file so the two filter points stay queryable-apart.
+     * @param {Array<{nodeId: String, rejectionBucket: String[]}>} rejections The type-gate rejections for this pass.
+     * @param {Date|Number} now The synthesis-pass clock (Date or epoch ms).
+     * @param {Object} [ledger] The resolved ledger boundary (from the caller's AiConfig read).
+     * @param {String} [ledger.dir] The runtime ledger directory; absent/empty → no-op.
+     * @param {Number} [ledger.maxEvents] Retention cap (validated before the store write).
+     * @param {Number} [ledger.triggerBytes] Prune byte-trigger (validated before the store write).
+     * @returns {Promise<void>}
+     */
+    static async recordTypeGateRejections(rejections, now, {dir, maxEvents, triggerBytes} = {}) {
+        const nowMs   = now instanceof Date ? now.getTime() : now,
+              records = this.buildTypeGateRejectionRecords(rejections, Number.isFinite(nowMs) ? nowMs : null);
+
+        if (records.length === 0) return;
+
+        try {
+            if (typeof dir !== 'string' || dir.length === 0) return;
+
+            const retention = validateRouteAttributionRetention(maxEvents, triggerBytes);
+
+            for (const record of records) {
+                await appendRouteAttribution(record, {dir, filename: TYPE_GATE_REJECTION_FILENAME, ...retention})
+            }
+        } catch (error) {
+            logger.warn(`[GoldenPathSynthesizer] type-gate rejection ledger write failed (non-fatal): ${error?.message || error}`)
         }
     }
 
@@ -923,8 +983,11 @@ class GoldenPathSynthesizer extends Base {
             return this.constructor.buildFailureOutcome('embedding-dimension-mismatch', message);
         }
 
-        const scoredNodes  = [];
-        const scoringStats = {
+        const scoredNodes = [];
+        // AC3: the type-gate rejections collected across the scoring loop (emitted once after it, like the
+        // route-attribution record-seam) — the SECOND GP filter point's evidence for the type-gate disposition.
+        const typeGateRejections = [];
+        const scoringStats       = {
             semanticCandidates     : 0,
             sqliteOpenMatches      : 0,
             blockedCandidates      : 0,
@@ -1041,6 +1104,12 @@ class GoldenPathSynthesizer extends Base {
 
                     if (!this.constructor.isActionableComputedRecommendation(nodeData || {id: issueId})) {
                         scoringStats.nonActionableCandidates++;
+                        // AC3 evidence: record which exclusion labels made this candidate non-actionable
+                        // (the shared bucket authority), for the type-gate disposition window.
+                        typeGateRejections.push({
+                            nodeId         : issueId,
+                            rejectionBucket: this.constructor.getComputedRecommendationExclusionLabels(nodeData || {id: issueId})
+                        });
                         logger.debug(`[GoldenPathSynthesizer] Skipping non-actionable computed recommendation: ${issueId}`);
                         continue;
                     }
@@ -1100,6 +1169,15 @@ class GoldenPathSynthesizer extends Base {
                 triggerBytes: aiConfig.goldenPathRouteAttributionLedgerPruneTriggerBytes
             })
         }
+
+        // AC3: record the actionability type-gate's rejections (the SECOND filter point) into a sibling ledger in
+        // the same runtime dir — the evidence window the 42.2%-type-gate disposition decides against. No-ops
+        // on an empty pass; fail-open inside the method; reuses the route-attribution dir + retention leaves.
+        await this.constructor.recordTypeGateRejections(typeGateRejections, now, {
+            dir         : aiConfig.goldenPathRouteAttributionLedgerDir,
+            maxEvents   : aiConfig.goldenPathRouteAttributionLedgerMaxEvents,
+            triggerBytes: aiConfig.goldenPathRouteAttributionLedgerPruneTriggerBytes
+        })
 
         const handoffTimestamp = now instanceof Date ? now : new Date(now);
         let   markdownAppend   = '';

--- a/ai/services/graph/routeAttributionLedgerStore.mjs
+++ b/ai/services/graph/routeAttributionLedgerStore.mjs
@@ -18,15 +18,21 @@ import path                                           from 'path';
 const ROUTE_ATTRIBUTION_FILENAME = 'route-attribution.jsonl';
 
 /**
- * @summary The JSONL ledger path within a state directory.
+ * @summary The JSONL ledger path within a state directory. The append/read/prune I/O below is
+ * record-shape-agnostic, so the optional `filename` generalizes it to a SIBLING ledger sharing the
+ * same runtime dir + retention machinery but a distinct record shape — e.g. the type-gate rejection
+ * ledger (`typeGateRejectionLedgerStore`), which passes its own filename and owns its own
+ * summarize/query fold. `filename` defaults to the route-attribution ledger, so the guard-filter
+ * callers pass nothing and are unchanged.
  * @param {String} dir
+ * @param {String} [filename=ROUTE_ATTRIBUTION_FILENAME] Ledger leaf within `dir`.
  * @returns {String}
  */
-export function getRouteAttributionLedgerFilePath(dir) {
+export function getRouteAttributionLedgerFilePath(dir, filename = ROUTE_ATTRIBUTION_FILENAME) {
     if (typeof dir !== 'string' || dir.length === 0) {
         throw new TypeError('getRouteAttributionLedgerFilePath: dir is required');
     }
-    return path.join(dir, ROUTE_ATTRIBUTION_FILENAME);
+    return path.join(dir, filename);
 }
 
 /**
@@ -60,13 +66,14 @@ export function validateRouteAttributionRetention(maxEvents, triggerBytes) {
  * @param {Object} entry A JSON-serializable record (`{blockedNodeId, armingReasons, candidateReasons, at?}`).
  * @param {Object} options
  * @param {String} options.dir The durable state directory.
+ * @param {String} [options.filename] Ledger leaf within `dir` (defaults to the route-attribution ledger); a sibling record shape passes its own.
  * @param {Number} [options.now] Epoch ms used to stamp `at` when the entry omits it.
  * @param {Number} [options.triggerBytes] Byte threshold that arms the auto-prune (from the AiConfig retention leaf). Skipped unless both this and `maxEvents` are finite.
  * @param {Number} [options.maxEvents] Retention cap the triggered auto-prune enforces (from the AiConfig retention leaf).
  * @returns {Promise<String>} The ledger file path written to.
  * @throws {TypeError} when `entry` is not an object or `dir` is missing/empty.
  */
-export async function appendRouteAttribution(entry, {dir, now, triggerBytes, maxEvents} = {}) {
+export async function appendRouteAttribution(entry, {dir, filename, now, triggerBytes, maxEvents} = {}) {
     if (!entry || typeof entry !== 'object') {
         throw new TypeError('appendRouteAttribution: entry object is required');
     }
@@ -77,7 +84,7 @@ export async function appendRouteAttribution(entry, {dir, now, triggerBytes, max
     const stamped = {...entry, at: Number.isFinite(entry.at) ? entry.at : (Number.isFinite(now) ? now : null)};
 
     await mkdir(dir, {recursive: true});
-    const filePath = getRouteAttributionLedgerFilePath(dir);
+    const filePath = getRouteAttributionLedgerFilePath(dir, filename);
     await appendFile(filePath, `${JSON.stringify(stamped)}\n`, 'utf8');
 
     // Self-bound (mirrors healEventLedgerStore) ONLY when the AiConfig-aware caller supplied the retention policy
@@ -87,7 +94,7 @@ export async function appendRouteAttribution(entry, {dir, now, triggerBytes, max
     if (Number.isFinite(triggerBytes) && Number.isFinite(maxEvents)) {
         try {
             const {size} = await stat(filePath);
-            if (size > triggerBytes) await pruneRouteAttributionLedger({dir, maxEvents});
+            if (size > triggerBytes) await pruneRouteAttributionLedger({dir, filename, maxEvents});
         } catch (error) {
             // a partial/failed prune leaves the prior ledger intact; the next append re-tries the gate
         }
@@ -104,14 +111,15 @@ export async function appendRouteAttribution(entry, {dir, now, triggerBytes, max
  * gated by the ledger catches this itself and proceeds fail-safe.
  * @param {Object} options
  * @param {String} options.dir The durable state directory.
+ * @param {String} [options.filename] Ledger leaf within `dir` (defaults to the route-attribution ledger).
  * @returns {Promise<Object[]>} The parsed records in append order.
  * @throws when the ledger file exists but is unreadable at the FILE level (any non-`ENOENT` read error).
  */
-export async function readRouteAttributionLedger({dir} = {}) {
+export async function readRouteAttributionLedger({dir, filename} = {}) {
     let text;
 
     try {
-        text = await readFile(getRouteAttributionLedgerFilePath(dir), 'utf8');
+        text = await readFile(getRouteAttributionLedgerFilePath(dir, filename), 'utf8');
     } catch (error) {
         if (error?.code === 'ENOENT') {
             return []; // missing ledger → nothing recorded yet (not a degradation)
@@ -138,11 +146,12 @@ export async function readRouteAttributionLedger({dir} = {}) {
  * rewrite (it was already unreadable). I/O at the edge only.
  * @param {Object} options
  * @param {String} options.dir The durable state directory.
+ * @param {String} [options.filename] Ledger leaf within `dir` (defaults to the route-attribution ledger).
  * @param {Number} options.maxEvents Max records to retain (the AiConfig retention leaf; no helper-owned default).
  * @returns {Promise<{pruned: Number, retained: Number}>} Counts; `pruned: 0` when no prune was needed.
  * @throws {TypeError} when `dir` is missing/empty or `maxEvents` is not a finite, non-negative number.
  */
-export async function pruneRouteAttributionLedger({dir, maxEvents} = {}) {
+export async function pruneRouteAttributionLedger({dir, filename, maxEvents} = {}) {
     if (typeof dir !== 'string' || dir.length === 0) {
         throw new TypeError('pruneRouteAttributionLedger: dir is required');
     }
@@ -150,13 +159,13 @@ export async function pruneRouteAttributionLedger({dir, maxEvents} = {}) {
         throw new TypeError(`pruneRouteAttributionLedger: a finite, non-negative maxEvents is required (the AiConfig retention leaf), got ${maxEvents}`);
     }
 
-    const records = await readRouteAttributionLedger({dir});
+    const records = await readRouteAttributionLedger({dir, filename});
     if (records.length <= maxEvents) {
         return {pruned: 0, retained: records.length};
     }
 
     const retained = records.slice(records.length - maxEvents); // append order is oldest→newest; keep the tail
-    await writeFile(getRouteAttributionLedgerFilePath(dir), retained.map(record => JSON.stringify(record)).join('\n') + '\n', 'utf8');
+    await writeFile(getRouteAttributionLedgerFilePath(dir, filename), retained.map(record => JSON.stringify(record)).join('\n') + '\n', 'utf8');
 
     return {pruned: records.length - retained.length, retained: retained.length};
 }

--- a/ai/services/graph/typeGateRejectionLedgerStore.mjs
+++ b/ai/services/graph/typeGateRejectionLedgerStore.mjs
@@ -1,0 +1,119 @@
+import {readRouteAttributionLedger} from './routeAttributionLedgerStore.mjs';
+
+/**
+ * @module ai/services/graph/typeGateRejectionLedgerStore
+ * @summary Durable append-only ledger for the computed-Golden-Path **actionability type-gate**
+ * rejections — the live per-run record of which computed candidates the `isActionableComputedRecommendation`
+ * gate rejected (visibility-only nodes: `epic` / `not-code-ready` / …) and under which exclusion labels.
+ * It is the SECOND filter point in the GP scoring pipeline, distinct from the routing-contradiction guard
+ * the `routeAttributionLedgerStore` records: the guard filters candidates that CONTRADICT the current focus,
+ * this gate rejects candidates that are structurally NON-ACTIONABLE. Keeping the two as sibling ledgers (one
+ * runtime dir + the shared append/read/prune I/O + retention machinery, distinct filenames + record shapes)
+ * lets the downstream 42.2%-type-gate disposition read exactly the type-gate window without
+ * stage-filtering a mixed stream. Records carry an explicit `stage` so a merged analysis stays self-describing.
+ *
+ * The producer (the emit at the gate's real filter point) lives in `GoldenPathSynthesizer`; this module owns
+ * the filename + record `stage` + the queryable fold (`summarize`/`query`) the disposition reads. I/O reuses
+ * the shape-agnostic `routeAttributionLedgerStore` primitives via the `filename` seam — no duplicated append.
+ */
+
+/**
+ * The JSONL leaf, a sibling of the route-attribution ledger inside the same runtime state dir.
+ * @type {String}
+ */
+export const TYPE_GATE_REJECTION_FILENAME = 'type-gate-rejection.jsonl';
+
+/**
+ * The record `stage` discriminator — self-describes a type-gate rejection if it is ever read alongside
+ * route-attribution records in a merged analysis.
+ * @type {String}
+ */
+export const TYPE_GATE_REJECTION_STAGE = 'actionability-type-gate';
+
+/**
+ * @summary Reads all type-gate rejection records (oldest → newest) from the sibling ledger file. Delegates to
+ * the shared shape-agnostic reader with the type-gate filename — same ENOENT-is-empty / corrupt-line-skipped /
+ * unreadable-file-throws contract.
+ * @param {Object} options
+ * @param {String} options.dir The durable state directory (the shared route-attribution ledger dir).
+ * @returns {Promise<Object[]>} The parsed records in append order.
+ */
+export function readTypeGateRejectionLedger({dir} = {}) {
+    return readRouteAttributionLedger({dir, filename: TYPE_GATE_REJECTION_FILENAME});
+}
+
+/**
+ * @summary Folds a type-gate rejection stream into the queryable evidence surface the type-gate disposition reads:
+ * totals, how often each exclusion label rejected a candidate, and how often each node was rejected. Pure — no
+ * I/O; the caller reads the ledger then summarizes. This is the type-gate analog of
+ * `summarizeRouteAttributionLedger` (which folds the guard-filter stream's arming reasons + blocked nodes).
+ * @param {Object[]} [records=[]] The type-gate rejection records (as read from the ledger).
+ * @returns {Object} `{total, byRejectionLabel, rejectedNodeCounts, lastEventAt}`.
+ */
+export function summarizeTypeGateRejectionLedger(records = []) {
+    const rows               = Array.isArray(records) ? records : [],
+          byRejectionLabel   = {},
+          rejectedNodeCounts = {};
+
+    let lastEventAt = null;
+
+    for (const record of rows) {
+        if (!record || typeof record !== 'object') continue;
+
+        for (const label of Array.isArray(record.rejectionBucket) ? record.rejectionBucket : []) {
+            if (typeof label === 'string' && label.length > 0) {
+                byRejectionLabel[label] = (byRejectionLabel[label] ?? 0) + 1;
+            }
+        }
+
+        if (typeof record.nodeId === 'string' && record.nodeId.length > 0) {
+            rejectedNodeCounts[record.nodeId] = (rejectedNodeCounts[record.nodeId] ?? 0) + 1;
+        }
+
+        if (Number.isFinite(record.at) && (lastEventAt === null || record.at > lastEventAt)) {
+            lastEventAt = record.at;
+        }
+    }
+
+    return {
+        total: rows.length,
+        byRejectionLabel,
+        rejectedNodeCounts,
+        lastEventAt
+    };
+}
+
+/**
+ * @summary Filters a type-gate rejection stream into a queryable view — the "what was rejected" surface that
+ * complements the summarized counts. Pure: restrict by an optional inclusive time window, exclusion labels, and
+ * node ids; returns newest-first (by `at`), capped at `limit`. A non-object record, or one outside a requested
+ * time window, is dropped; an untimed record is excluded when a time bound is requested. A record matches a
+ * `rejectionLabels` filter when its `rejectionBucket` array intersects the requested set.
+ * @param {Object[]} [records=[]] The type-gate rejection records (as read from the ledger).
+ * @param {Object} [options]
+ * @param {Number} [options.sinceMs] Lower bound (inclusive) on `at`.
+ * @param {Number} [options.untilMs] Upper bound (inclusive) on `at`.
+ * @param {String[]} [options.rejectionLabels] Restrict to records whose `rejectionBucket` intersects these.
+ * @param {String[]} [options.nodeIds] Restrict to these rejected node ids.
+ * @param {Number} [options.limit] Max records returned (newest-first); omitted → all matches.
+ * @returns {Object[]} The matching records, newest-first.
+ */
+export function queryTypeGateRejectionLedger(records = [], {sinceMs, untilMs, rejectionLabels, nodeIds, limit} = {}) {
+    const rows     = Array.isArray(records) ? records : [],
+          labelSet = Array.isArray(rejectionLabels) && rejectionLabels.length ? new Set(rejectionLabels) : null,
+          nodeSet  = Array.isArray(nodeIds)         && nodeIds.length         ? new Set(nodeIds)         : null;
+
+    const filtered = rows.filter(record => {
+        if (!record || typeof record !== 'object')                                             return false;
+        if (Number.isFinite(sinceMs) && !(Number.isFinite(record.at) && record.at >= sinceMs)) return false;
+        if (Number.isFinite(untilMs) && !(Number.isFinite(record.at) && record.at <= untilMs)) return false;
+        if (labelSet && !(Array.isArray(record.rejectionBucket) && record.rejectionBucket.some(label => labelSet.has(label)))) return false;
+        if (nodeSet  && !nodeSet.has(record.nodeId)) return false;
+        return true;
+    });
+
+    // Newest-first by `at`; untimed records (-Infinity) sink to the end (Array.sort is stable in V8).
+    filtered.sort((a, b) => (Number.isFinite(b.at) ? b.at : -Infinity) - (Number.isFinite(a.at) ? a.at : -Infinity));
+
+    return Number.isFinite(limit) && limit >= 0 ? filtered.slice(0, limit) : filtered;
+}

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -2509,4 +2509,73 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
         expect(aiConfig.goldenPathRouteAttributionLedgerDir).not.toContain('.neo-ai-data');
         expect(aiConfig.goldenPathRouteAttributionLedgerDir).toContain('route-attribution-test');
     });
+
+    test('buildTypeGateRejectionRecords stamps nodeId + exclusion bucket + stage + at, drops id-less, defaults a non-array bucket to [] (#15057 AC3)', () => {
+        const records = Synthesizer.buildTypeGateRejectionRecords([
+            {nodeId: 'issue-10', rejectionBucket: ['epic']},
+            {nodeId: 'issue-11', rejectionBucket: ['not-code-ready', 'ai-generated']},
+            {rejectionBucket: ['epic']},              // no nodeId → dropped
+            {nodeId: '', rejectionBucket: ['epic']},   // empty nodeId → dropped
+            {nodeId: 'issue-12', rejectionBucket: 'epic'} // non-array bucket → []
+        ], 4242);
+
+        expect(records.map(r => r.nodeId)).toEqual(['issue-10', 'issue-11', 'issue-12']);
+        expect(records[0]).toEqual({nodeId: 'issue-10', rejectionBucket: ['epic'], stage: 'actionability-type-gate', at: 4242});
+        expect(records[2].rejectionBucket).toEqual([]);        // non-array bucket normalized
+        expect(records.every(r => r.stage === 'actionability-type-gate' && r.at === 4242)).toBe(true);
+    });
+
+    test('buildTypeGateRejectionRecords is empty for no rejections / a non-array input (#15057 AC3)', () => {
+        expect(Synthesizer.buildTypeGateRejectionRecords([], 1)).toEqual([]);
+        expect(Synthesizer.buildTypeGateRejectionRecords(null, 1)).toEqual([]);
+        expect(Synthesizer.buildTypeGateRejectionRecords(undefined, 1)).toEqual([]);
+    });
+
+    test('recordTypeGateRejections is a no-op that never throws when nothing was rejected (fail-safe, no ledger touch) (#15057 AC3)', async () => {
+        await expect(Synthesizer.recordTypeGateRejections([], new Date())).resolves.toBeUndefined();
+        await expect(Synthesizer.recordTypeGateRejections(null, 123)).resolves.toBeUndefined();
+    });
+
+    test('recordTypeGateRejections writes rejection records to the INJECTED ledger dir as a SIBLING file, hermetic (#15057 AC3)', async () => {
+        const fs   = await import('fs/promises'),
+              os   = await import('os'),
+              path = await import('path');
+        const {readTypeGateRejectionLedger} = await import('../../../../../../ai/services/graph/typeGateRejectionLedgerStore.mjs');
+        const {readRouteAttributionLedger}  = await import('../../../../../../ai/services/graph/routeAttributionLedgerStore.mjs');
+
+        const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'tg-emit-'));
+        try {
+            await Synthesizer.recordTypeGateRejections([
+                {nodeId: 'issue-epic', rejectionBucket: ['epic']},
+                {nodeId: 'issue-draft', rejectionBucket: ['not-code-ready']}
+            ], 1000, {dir, maxEvents: 100, triggerBytes: 65536});
+
+            const records = await readTypeGateRejectionLedger({dir});
+            expect(records.map(r => r.nodeId)).toEqual(['issue-epic', 'issue-draft']);
+            expect(records[0]).toMatchObject({rejectionBucket: ['epic'], stage: 'actionability-type-gate', at: 1000});
+            // the type-gate producer writes a SIBLING file — the route-attribution ledger stays empty
+            expect(await readRouteAttributionLedger({dir})).toEqual([]);
+        } finally {
+            await fs.rm(dir, {recursive: true, force: true});
+        }
+    });
+
+    test('recordTypeGateRejections is fail-open — a real write failure does not throw, so synthesis is unaffected (#15057 AC3)', async () => {
+        const fs   = await import('fs/promises'),
+              os   = await import('os'),
+              path = await import('path');
+
+        const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'tg-fail-'));
+        try {
+            const filePath = path.join(tmp, 'blocker');
+            await fs.writeFile(filePath, 'x'); // ledger dir UNDER a regular file → mkdir ENOTDIR → swallowed
+
+            await expect(Synthesizer.recordTypeGateRejections(
+                [{nodeId: 'issue-1', rejectionBucket: ['epic']}],
+                1, {dir: path.join(filePath, 'nested'), maxEvents: 100, triggerBytes: 65536}
+            )).resolves.toBeUndefined();
+        } finally {
+            await fs.rm(tmp, {recursive: true, force: true});
+        }
+    });
 });

--- a/test/playwright/unit/ai/services/graph/typeGateRejectionLedgerStore.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/typeGateRejectionLedgerStore.spec.mjs
@@ -1,0 +1,106 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
+import {
+    appendRouteAttribution,
+    readRouteAttributionLedger,
+    getRouteAttributionLedgerFilePath
+} from '../../../../../../ai/services/graph/routeAttributionLedgerStore.mjs';
+import {
+    TYPE_GATE_REJECTION_FILENAME,
+    TYPE_GATE_REJECTION_STAGE,
+    readTypeGateRejectionLedger,
+    summarizeTypeGateRejectionLedger,
+    queryTypeGateRejectionLedger
+} from '../../../../../../ai/services/graph/typeGateRejectionLedgerStore.mjs';
+
+async function tmpDir() {
+    return await fs.mkdtemp(path.join(os.tmpdir(), 'type-gate-rejection-ledger-'));
+}
+
+// A type-gate rejection: the non-actionable node + the exclusion labels that made it visibility-only.
+const record = (nodeId, rejectionBucket, at) => ({nodeId, rejectionBucket, stage: TYPE_GATE_REJECTION_STAGE, at});
+
+test.describe('typeGateRejectionLedgerStore — the actionability type-gate rejection ledger (#15057 AC3)', () => {
+    test('append (via the shared filename seam) → read round-trips the sibling ledger in append order', async () => {
+        const dir = await tmpDir();
+        await appendRouteAttribution(record('issue-10', ['epic'], 100), {dir, filename: TYPE_GATE_REJECTION_FILENAME});
+        await appendRouteAttribution(record('issue-11', ['not-code-ready'], 200), {dir, filename: TYPE_GATE_REJECTION_FILENAME});
+
+        const records = await readTypeGateRejectionLedger({dir});
+        expect(records.map(r => r.nodeId)).toEqual(['issue-10', 'issue-11']);
+        expect(records[1]).toMatchObject({rejectionBucket: ['not-code-ready'], stage: TYPE_GATE_REJECTION_STAGE, at: 200});
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('the two filter points are queryable-APART — a route-attribution write does not leak into the type-gate read', async () => {
+        const dir = await tmpDir();
+        // route-attribution (guard) write → route-attribution.jsonl (no filename)
+        await appendRouteAttribution({blockedNodeId: 'issue-guard', armingReasons: ['incident'], at: 1}, {dir});
+        // type-gate write → the sibling type-gate-rejection.jsonl
+        await appendRouteAttribution(record('issue-typegate', ['epic'], 2), {dir, filename: TYPE_GATE_REJECTION_FILENAME});
+
+        const typeGate = await readTypeGateRejectionLedger({dir});
+        expect(typeGate.map(r => r.nodeId)).toEqual(['issue-typegate']);        // only the type-gate record
+        // and the route-attribution ledger stays clean of the type-gate record
+        const route = await readRouteAttributionLedger({dir});
+        expect(route.map(r => r.blockedNodeId)).toEqual(['issue-guard']);
+        // they are genuinely distinct files in the one dir
+        expect(getRouteAttributionLedgerFilePath(dir, TYPE_GATE_REJECTION_FILENAME))
+            .not.toBe(getRouteAttributionLedgerFilePath(dir));
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('a missing ledger reads as [] (nothing rejected yet, not a degradation)', async () => {
+        const dir = await tmpDir();
+        expect(await readTypeGateRejectionLedger({dir})).toEqual([]);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('summarize folds exclusion labels + rejected-node counts + the newest timestamp', () => {
+        const summary = summarizeTypeGateRejectionLedger([
+            record('issue-1', ['epic'], 100),
+            record('issue-1', ['epic', 'not-code-ready'], 300),
+            record('issue-2', ['not-code-ready'], 200)
+        ]);
+
+        expect(summary.total).toBe(3);
+        expect(summary.byRejectionLabel).toEqual({epic: 2, 'not-code-ready': 2});
+        expect(summary.rejectedNodeCounts).toEqual({'issue-1': 2, 'issue-2': 1});
+        expect(summary.lastEventAt).toBe(300);
+    });
+
+    test('summarize ignores malformed records + non-array buckets without throwing', () => {
+        const summary = summarizeTypeGateRejectionLedger([
+            null,
+            {nodeId: 'issue-1', rejectionBucket: 'epic', at: 1}, // bucket not an array → contributes no label
+            record('issue-2', ['epic'], 2)
+        ]);
+
+        expect(summary.total).toBe(3);                              // total is row count
+        expect(summary.byRejectionLabel).toEqual({epic: 1});       // only the well-formed bucket folds
+        expect(summary.rejectedNodeCounts).toEqual({'issue-1': 1, 'issue-2': 1});
+    });
+
+    test('query restricts by time window / exclusion labels / node ids and returns newest-first, capped', () => {
+        const records = [
+            record('issue-1', ['epic'], 100),
+            record('issue-2', ['not-code-ready'], 200),
+            record('issue-3', ['epic'], 300)
+        ];
+
+        // newest-first, no filter
+        expect(queryTypeGateRejectionLedger(records).map(r => r.nodeId)).toEqual(['issue-3', 'issue-2', 'issue-1']);
+        // by exclusion label (intersect)
+        expect(queryTypeGateRejectionLedger(records, {rejectionLabels: ['epic']}).map(r => r.nodeId)).toEqual(['issue-3', 'issue-1']);
+        // by node id
+        expect(queryTypeGateRejectionLedger(records, {nodeIds: ['issue-2']}).map(r => r.nodeId)).toEqual(['issue-2']);
+        // inclusive time window
+        expect(queryTypeGateRejectionLedger(records, {sinceMs: 200, untilMs: 300}).map(r => r.nodeId)).toEqual(['issue-3', 'issue-2']);
+        // limit (after newest-first sort)
+        expect(queryTypeGateRejectionLedger(records, {limit: 1}).map(r => r.nodeId)).toEqual(['issue-3']);
+    });
+});


### PR DESCRIPTION
## Summary

The **AC3 producer** for the computed-Golden-Path type-gate — the split-out evidence-window half of #15057 (its AC3a), the direct analog of #15068/PR #15060 (the AC1+AC2 guard-filter record-seam). The GP scoring pipeline has TWO filter points; #15060 recorded the routing-**contradiction guard**, this records the **actionability type-gate** (`isActionableComputedRecommendation` false — the visibility-only `epic`/`not-code-ready`/… candidates, a measured 42.2% residual per #14503) that previously recorded nothing. Now the 42.2%-type-gate disposition has a *live* evidence window instead of a one-shot snapshot.

Evidence: the type-gate site (`GoldenPathSynthesizer` scoring loop, the `isActionableComputedRecommendation` false `continue`) is the exact filter point; the rejection bucket is the shared authority `getComputedRecommendationExclusionLabels(nodeData)`. The producer collects per-node across the loop and emits once after it, exactly mirroring `recordRouteAttribution`'s fail-open/no-op-on-empty shape and reusing the same runtime dir + retention leaves — so no new config leaf. The added consumption site remains an ADR-0019 surface: it reads the existing resolved leaves inline at the synthesis use site, without aliasing, pass-along plumbing, hidden defaults, defensive reads, or runtime mutation.

## Deltas

- **`routeAttributionLedgerStore.mjs`** — parameterized the shape-agnostic I/O (`getRouteAttributionLedgerFilePath` / `appendRouteAttribution` / `readRouteAttributionLedger` / `pruneRouteAttributionLedger`) with an optional `filename` (default = the route-attribution ledger, so #15060's guard-filter callers are byte-for-byte unchanged). This lets a SIBLING record shape share the same dir + retention machinery + prune, without duplicating the I/O.
- **NEW `typeGateRejectionLedgerStore.mjs`** — the sibling ledger's filename (`type-gate-rejection.jsonl`) + `stage` + the queryable fold: `summarizeTypeGateRejectionLedger` (`byRejectionLabel` + `rejectedNodeCounts`) + `queryTypeGateRejectionLedger` (time-window / labels / nodeIds / limit, newest-first) + `readTypeGateRejectionLedger` (delegates to the shared reader with the sibling filename).
- **`GoldenPathSynthesizer.mjs`** — `buildTypeGateRejectionRecords` (pure → `[{nodeId, rejectionBucket, stage: 'actionability-type-gate', at}]`) + `recordTypeGateRejections` (fail-open, no-op on empty, reuses the route-attribution dir + retention leaves via the `filename` seam). The scoring loop collects `{nodeId, rejectionBucket}` at the type-gate `continue`; the after-loop emit writes the sibling ledger alongside the existing route-attribution emit.

## Test Evidence

`UNIT_TEST_MODE=true playwright test typeGateRejectionLedgerStore routeAttributionLedgerStore GoldenPathSynthesizer` → **76 passed** (then **64 passed** on the two touched suites after the block-align `--fix`, re-run per discipline).
- `typeGateRejectionLedgerStore.spec.mjs` (7): append→read round-trip via the shared filename seam; **the two filter points are queryable-APART** (a route-attribution write does not leak into the type-gate read, and vice-versa; distinct files in one dir); missing-ledger → `[]`; summarize folds labels + rejected-node counts + newest `at`; malformed/non-array-bucket handled without throwing; query by window/labels/nodeIds/limit newest-first.
- `GoldenPathSynthesizer.spec.mjs` (+5): `buildTypeGateRejectionRecords` stamps + drops id-less + normalizes a non-array bucket; empty/non-array input → `[]`; `recordTypeGateRejections` no-op-never-throws on empty; hermetic INJECTED-dir write as a SIBLING file (route-attribution ledger stays empty); fail-open on a real write failure.
- All existing route-attribution + synthesizer tests pass unchanged (the `filename` param is backward-compatible). Block-align + `node --check` parse gate + all pre-commit hooks green.

## Post-Merge Validation

- After a production synthesis run with type-gate rejections, `type-gate-rejection.jsonl` appears in the route-attribution runtime dir with `{nodeId, rejectionBucket, stage, at}` records; `route-attribution.jsonl` stays the guard-filter's own stream.
- `summarizeTypeGateRejectionLedger` over the accumulated window surfaces the real `byRejectionLabel` distribution — the evidence the #14503 42.2%-type-gate disposition (the follow-up on #15057 AC3b) decides against.

## Notes

- **Scope boundary (honest close-target):** this ships #15057's AC3a (the evidence-window producer). AC3b — the disposition-DECISION (keep / narrow / rank-with-discount) — needs an *accumulated* production window (nothing to decide against until synthesis populates it) and stays on #15057, naturally a later PR (per #15057's own note). So this Resolves the split leaf #15076, not #15057.
- No new config leaf; the added consumption site was audited against ADR 0019 and reuses the resolved route-attribution directory + retention leaves inline at the emit use site.

Resolves #15076

---

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Origin session `01f4cc68-8b8e-43e6-b51c-55b4f421f4e0`.

