### PR TITLE
feat(dashboard): add operation-correlated tab entry (#14968)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -229,10 +229,12 @@ class MainContainer extends Viewport {
 
     /**
      * Creates the top-level toolbar + dock projection items from current state.
+     * @param {Object|null} [tabInsertDescriptor=null] One-use normalized `addTab` correlation
+     * captured by the committing refresh; omitted for boot, restore, and unrelated projections.
      * @returns {Object[]}
      */
-    buildWorkspaceItems() {
-        let dockConfig = this.projectDockModel();
+    buildWorkspaceItems(tabInsertDescriptor=null) {
+        let dockConfig = this.projectDockModel(tabInsertDescriptor);
 
         dockConfig.flex = 1;
 
@@ -298,22 +300,56 @@ class MainContainer extends Viewport {
     }
 
     /**
-     * The view-sync `DockSplitter` calls after a successful commit: stores the new committed document and re-projects
-     * the layout from it.
+     * Returns the one-use projection correlation only when the committed descriptor actually
+     * inserts a header into its target tabs node. A same-node `addTab` reorder already had that
+     * header and therefore returns `null`; malformed, unrelated, restore, and initial paths fail
+     * closed to an instant projection.
+     *
+     * The returned object is deliberately normalized instead of retaining caller/runtime fields,
+     * and is carried only by the scheduled projection closure — it never enters `dockModel`, a
+     * saved perspective, or persistence.
+     * @param {Object} document The post-commit dock-zone document.
+     * @param {Object|null} descriptor The semantic operation that produced `document`.
+     * @returns {Object|null}
+     * @protected
+     */
+    getTabInsertProjectionDescriptor(document, descriptor) {
+        let {itemId, operation, tabsNodeId} = descriptor || {},
+            oldItems                        = this.dockModel?.nodes?.[tabsNodeId]?.items,
+            newItems                        = document?.nodes?.[tabsNodeId]?.items;
+
+        return operation === 'addTab'
+            && typeof itemId === 'string'
+            && typeof tabsNodeId === 'string'
+            && Array.isArray(oldItems)
+            && Array.isArray(newItems)
+            && !oldItems.includes(itemId)
+            && newItems.includes(itemId)
+                ? {itemId, operation: 'addTab', tabsNodeId}
+                : null
+    }
+
+    /**
+     * The view-sync `DockSplitter` / DockService calls after a successful commit: stores the new
+     * committed document and re-projects the layout from it.
      *
      * Deferred one tick: this fires synchronously from inside the committing splitter's `onDragEnd` (via
      * `commitResizeSplit`). Re-projecting immediately would `removeAll()` — destroying that splitter mid-handler, a
      * use-after-destroy on the rest of `onDragEnd`. The `isDestroyed` guard covers teardown before the tick fires.
+     * A real `addTab` captures its exact normalized correlation in THIS scheduled closure; every
+     * other call carries `null`, so the descriptor is consumed by one projection only.
      * @param {Object} document The committed dock-zone document.
+     * @param {Object|null} [descriptor=null] The semantic operation that produced `document`.
      */
-    onDockZoneDocumentChange(document) {
-        let me = this;
+    onDockZoneDocumentChange(document, descriptor=null) {
+        let me                  = this,
+            tabInsertDescriptor = me.getTabInsertProjectionDescriptor(document, descriptor);
 
         me.dockModel = document;
 
         me.timeout(0).then(() => {
             if (!me.isDestroyed) {
-                me.refreshDockWorkspace()
+                me.refreshDockWorkspace(tabInsertDescriptor)
             }
         })
     }
@@ -392,8 +428,10 @@ class MainContainer extends Viewport {
 
     /**
      * Rebuilds the toolbar and dock projection from current state.
+     * @param {Object|null} [tabInsertDescriptor=null] One-use normalized `addTab` correlation
+     * captured by the commit that scheduled this refresh.
      */
-    async refreshDockWorkspace() {
+    async refreshDockWorkspace(tabInsertDescriptor=null) {
         const flip = Neo.main?.addon?.DockFlip;
 
         // FLIP phase 1 (presentation-only, fail-safe): snapshot outgoing pane geometry so the
@@ -403,7 +441,7 @@ class MainContainer extends Viewport {
         } catch (e) {/* instant landing */}
 
         this.removeAll();
-        this.add(this.buildWorkspaceItems());
+        this.add(this.buildWorkspaceItems(tabInsertDescriptor));
 
         // FLIP phase 2: fire-and-forget — the addon self-waits for the swap, inverts, plays
         // the counted motion signal brackets the awaited animation window — ownership
@@ -535,18 +573,20 @@ class MainContainer extends Viewport {
     }
 
     /**
-     * Projects the live committed {@link #dockModel} into a dock-zone container config, threading the instance-bound
-     * resize-commit-loop callbacks onto every projected splitter affordance.
+     * Projects the live committed {@link #dockModel} into a dock-zone container config, threading
+     * the instance-bound commit-loop callbacks onto every projected affordance.
+     * @param {Object|null} [tabInsertDescriptor=null] One-use normalized `addTab` correlation.
      * @returns {Object}
      */
-    projectDockModel() {
+    projectDockModel(tabInsertDescriptor=null) {
         let me = this;
 
         return DockLayoutAdapter.project(me.dockModel, {
             applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
             onDockCrossZoneDrop     : me.onDockCrossZoneDrop.bind(me),
             onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
-            resolveComponentRef
+            resolveComponentRef,
+            tabInsertDescriptor
         })
     }
 

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -55,6 +55,21 @@
 @keyframes neo-dock-reveal-from-top    { from { opacity: 0.4; transform: translateY(8px) } }
 @keyframes neo-dock-reveal-from-bottom { from { opacity: 0.4; transform: translateY(-8px) } }
 
+// Operation-correlated tab insertion. The adapter stamps this class on ONE recreated header only
+// when its item + target tabs node match the committed addTab descriptor carried by that projection.
+// No broad tab selector: boot, restore, reorder and unrelated coarse refreshes remain motion-free.
+.neo-dashboard-dock-tab-enter {
+    animation       : neo-dock-tab-enter var(--dock-transition-duration) var(--dock-transition-easing);
+    transform-origin: center left;
+}
+
+@keyframes neo-dock-tab-enter {
+    from {
+        opacity  : 0.35;
+        transform: scaleX(0.82);
+    }
+}
+
 // Arrival settle: a brief outline pulse on the pane that just landed from another window
 // (§2.3 cross-window arrival) — the workspace toggles the class; the animation completes
 // itself. transform/opacity/outline only: no layout thrash.

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -1,8 +1,9 @@
-import Base            from '../core/Base.mjs';
-import DockRail        from './DockRail.mjs';
-import DockSplitter    from './DockSplitter.mjs';
-import DockTabSortZone from './DockTabSortZone.mjs';
-import DockZoneModel   from './DockZoneModel.mjs';
+import Base               from '../core/Base.mjs';
+import DockRail           from './DockRail.mjs';
+import DockSplitter       from './DockSplitter.mjs';
+import DockTabEnterButton from './DockTabEnterButton.mjs';
+import DockTabSortZone    from './DockTabSortZone.mjs';
+import DockZoneModel      from './DockZoneModel.mjs';
 
 /**
  * @summary Projects Agent Harness dock-zone model nodes into existing Neo layout and tab configs.
@@ -208,6 +209,8 @@ class DockLayoutAdapter extends Base {
      * @param {Object} model
      * @param {Object} [options={}]
      * @param {Function} [options.resolveComponentRef]
+     * @param {Object|null} [options.tabInsertDescriptor] Runtime-only normalized `addTab`
+     * correlation consumed by this projection; never part of `model`.
      * @returns {Object}
      * @static
      */
@@ -238,6 +241,7 @@ class DockLayoutAdapter extends Base {
             onDockCrossZoneDrop     : options.onDockCrossZoneDrop,
             onDockZoneDocumentChange: options.onDockZoneDocumentChange,
             resolveComponentRef     : options.resolveComponentRef || (() => null),
+            tabInsertDescriptor     : options.tabInsertDescriptor ?? null,
             workspaceId             : options.workspaceId ?? null
         });
 
@@ -620,11 +624,39 @@ class DockLayoutAdapter extends Base {
             items    = context.railedItemIds
                 ? allItems.filter(itemId => !context.railedItemIds.has(itemId))
                 : allItems,
-            activeIndex = items.length ? items.indexOf(node.activeItemId) : null;
+            activeIndex = items.length ? items.indexOf(node.activeItemId) : null,
+            projectedItems;
 
         if (activeIndex < 0) {
             activeIndex = items.length ? 0 : null
         }
+
+        projectedItems = items.map(itemId => {
+            let config     = this.projectItem(itemId, context),
+                descriptor = context.tabInsertDescriptor,
+                header;
+
+            // One-use operation correlation: only a real addTab's exact target header receives
+            // the dashboard-owned producer. Non-object component results fail safe to an instant
+            // landing; no broad selector or document mutation is used as a fallback.
+            if (config?.constructor === Object
+                && descriptor?.operation === 'addTab'
+                && descriptor.itemId === itemId
+                && descriptor.tabsNodeId === nodeId) {
+                header = config.header || {text: context.items[itemId]?.title || itemId};
+                config.header = {
+                    ...header,
+                    cls: [...new Set([
+                        ...(Array.isArray(header.cls) ? header.cls : header.cls ? [header.cls] : []),
+                        'neo-dashboard-dock-tab-enter',
+                        `dock-tab-enter-item-${encodeURIComponent(itemId)}`
+                    ])],
+                    module: DockTabEnterButton
+                }
+            }
+
+            return config
+        });
 
         return {
             activeIndex,
@@ -651,7 +683,7 @@ class DockLayoutAdapter extends Base {
                     sortGroup      : context.crossWindowSortGroup
                 }
             },
-            items    : items.map(itemId => this.projectItem(itemId, context)),
+            items    : projectedItems,
             listeners: {
                 // Live-drag hover: the dock-aware SortZone streams `dockCrossZoneDragMove` per frame; the
                 // owner renders the transient affordance tier (indicator menu / preview) from it. Same

--- a/src/dashboard/DockTabEnterButton.mjs
+++ b/src/dashboard/DockTabEnterButton.mjs
@@ -1,0 +1,119 @@
+import DockMotionSignal from './DockMotionSignal.mjs';
+import TabHeaderButton  from '../tab/header/Button.mjs';
+
+/**
+ * @summary The operation-correlated tab header used for exactly one committed dock `addTab`
+ * projection. It brackets its CSS entry animation through {@link Neo.dashboard.DockMotionSignal}
+ * and settles on the root animation end/cancel or teardown.
+ *
+ * This component is intentionally dashboard-owned: the generic {@link Neo.tab.header.Button}
+ * stays unaware of dock documents and operations. {@link Neo.dashboard.DockLayoutAdapter} selects
+ * this subclass only for the header whose `itemId` + `tabsNodeId` match the transient descriptor
+ * carried by the consuming projection. The correlation never enters the dock document and the
+ * class does not survive a later coarse projection.
+ *
+ * The CSS duration/easing remain token-owned. Motion enters only when the browser emits the root
+ * `animationstart`, so a token-collapsed 0ms animation (which emits no animation events) creates no
+ * false signal. End, cancellation, replacement, and destroy settle idempotently, with
+ * `DockMotionSignal`'s fail-safe remaining the final lost-event backstop.
+ *
+ * @class Neo.dashboard.DockTabEnterButton
+ * @extends Neo.tab.header.Button
+ * @see Neo.dashboard.DockLayoutAdapter
+ * @see Neo.dashboard.DockMotionSignal
+ */
+class DockTabEnterButton extends TabHeaderButton {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockTabEnterButton'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockTabEnterButton',
+        /**
+         * @member {String} ntype='dashboard-dock-tab-enter-button'
+         * @protected
+         */
+        ntype: 'dashboard-dock-tab-enter-button'
+    }
+
+    /**
+     * Whether this instance currently owns one counted tab-entry motion.
+     * @member {Boolean} tabEnterMotionActive=false
+     * @protected
+     */
+    tabEnterMotionActive = false
+
+    /**
+     * Wires local root animation start/settlement. The browser opens the counted window only when
+     * CSS actually starts; construction alone is not evidence of motion.
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        let me = this;
+
+        me.addDomListeners([
+            {animationcancel: me.onTabEnterAnimationSettle, scope: me},
+            {animationend   : me.onTabEnterAnimationSettle, scope: me},
+            {animationstart : me.onTabEnterAnimationStart,  scope: me}
+        ])
+    }
+
+    /**
+     * Opens this producer's one counted motion entry.
+     * @protected
+     */
+    beginTabEnterMotion() {
+        if (!this.tabEnterMotionActive) {
+            this.tabEnterMotionActive = true;
+            DockMotionSignal.enter(this)
+        }
+    }
+
+    /**
+     * Settles this producer's owned motion entry exactly once.
+     * @protected
+     */
+    finishTabEnterMotion() {
+        if (this.tabEnterMotionActive) {
+            this.tabEnterMotionActive = false;
+            DockMotionSignal.leave(this)
+        }
+    }
+
+    /**
+     * Opens the motion signal only for this button's real root CSS animation. A 0ms token emits no
+     * start, so reduced motion stays honestly signal-free instead of waiting on a timer backstop.
+     * @param {Object} data
+     */
+    onTabEnterAnimationStart(data) {
+        if (data?.target?.id === (this.vdom?.id || this.id)) {
+            this.beginTabEnterMotion()
+        }
+    }
+
+    /**
+     * Replacement or teardown may remove the animated node before the browser emits an end event.
+     * Settle while the instance is still live, then continue the ordinary component lifecycle.
+     */
+    destroy() {
+        this.finishTabEnterMotion();
+        super.destroy()
+    }
+
+    /**
+     * Settles only for this button's root event. Descendant animations bubble through the same
+     * local listener but retain their own config-aware target id and cannot close this producer.
+     * Both `animationend` and `animationcancel` route here. An end without a matching start is an
+     * intentional safe no-op (the zero-duration / missing-animation path).
+     * @param {Object} data
+     */
+    onTabEnterAnimationSettle(data) {
+        if (data?.target?.id === (this.vdom?.id || this.id)) {
+            this.finishTabEnterMotion()
+        }
+    }
+}
+
+export default Neo.setupClass(DockTabEnterButton);

--- a/src/dashboard/DockTabEnterButton.mjs
+++ b/src/dashboard/DockTabEnterButton.mjs
@@ -12,10 +12,12 @@ import TabHeaderButton  from '../tab/header/Button.mjs';
  * carried by the consuming projection. The correlation never enters the dock document and the
  * class does not survive a later coarse projection.
  *
- * The CSS duration/easing remain token-owned. Motion enters only when the browser emits the root
- * `animationstart`, so a token-collapsed 0ms animation (which emits no animation events) creates no
- * false signal. End, cancellation, replacement, and destroy settle idempotently, with
- * `DockMotionSignal`'s fail-safe remaining the final lost-event backstop.
+ * The CSS duration/easing remain token-owned. Once mounted, the App Worker asks the main-thread DOM
+ * authority for this header's rendered animation name + duration and opens the signal only for the
+ * exact non-zero tab-entry animation. This avoids racing the framework's delayed local-listener
+ * mount against `animationstart`, while a token-collapsed 0ms animation creates no false signal.
+ * End, cancellation, replacement, and destroy settle idempotently, with `DockMotionSignal`'s
+ * fail-safe remaining the final lost-event backstop.
  *
  * @class Neo.dashboard.DockTabEnterButton
  * @extends Neo.tab.header.Button
@@ -23,6 +25,29 @@ import TabHeaderButton  from '../tab/header/Button.mjs';
  * @see Neo.dashboard.DockMotionSignal
  */
 class DockTabEnterButton extends TabHeaderButton {
+    /**
+     * Whether the rendered style describes this producer's live, non-zero animation. CSS lists
+     * repeat shorter duration lists across animation names; mirror that grammar without owning any
+     * duration value here.
+     * @param {Object|null} styles Main-thread computed-style projection.
+     * @returns {Boolean}
+     * @static
+     */
+    static hasRenderedTabEnterMotion(styles) {
+        let durations = String(styles?.['animation-duration'] || '').split(',').map(value => value.trim()),
+            names     = String(styles?.['animation-name']     || '').split(',').map(value => value.trim()),
+            index     = names.indexOf('neo-dock-tab-enter'),
+            match;
+
+        if (index < 0 || durations.length === 0) {
+            return false
+        }
+
+        match = /^(-?(?:\d+(?:\.\d+)?|\.\d+))(ms|s)$/.exec(durations[index % durations.length]);
+
+        return !!match && Number(match[1]) > 0
+    }
+
     static config = {
         /**
          * @member {String} className='Neo.dashboard.DockTabEnterButton'
@@ -44,8 +69,8 @@ class DockTabEnterButton extends TabHeaderButton {
     tabEnterMotionActive = false
 
     /**
-     * Wires local root animation start/settlement. The browser opens the counted window only when
-     * CSS actually starts; construction alone is not evidence of motion.
+     * Wires local root animation settlement. The counted window opens from rendered-style truth in
+     * {@link #afterSetMounted}; construction alone is not evidence of motion.
      * @param {Object} config
      */
     construct(config) {
@@ -55,9 +80,23 @@ class DockTabEnterButton extends TabHeaderButton {
 
         me.addDomListeners([
             {animationcancel: me.onTabEnterAnimationSettle, scope: me},
-            {animationend   : me.onTabEnterAnimationSettle, scope: me},
-            {animationstart : me.onTabEnterAnimationStart,  scope: me}
+            {animationend   : me.onTabEnterAnimationSettle, scope: me}
         ])
+    }
+
+    /**
+     * Starts rendered-style discovery only after the physical header exists. Unmount is a
+     * cancellation boundary and must settle before a late style-read response can arrive.
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetMounted(value, oldValue) {
+        super.afterSetMounted(value, oldValue);
+
+        if (oldValue !== undefined) {
+            value ? this.syncRenderedTabEnterMotion() : this.finishTabEnterMotion()
+        }
     }
 
     /**
@@ -83,13 +122,28 @@ class DockTabEnterButton extends TabHeaderButton {
     }
 
     /**
-     * Opens the motion signal only for this button's real root CSS animation. A 0ms token emits no
-     * start, so reduced motion stays honestly signal-free instead of waiting on a timer backstop.
-     * @param {Object} data
+     * Reads the physical header's computed animation contract from its owning main thread. A late
+     * response after unmount/destroy is inert; an unavailable or malformed style projection fails
+     * safe to an instant landing.
+     * @returns {Promise<void>}
+     * @protected
      */
-    onTabEnterAnimationStart(data) {
-        if (data?.target?.id === (this.vdom?.id || this.id)) {
-            this.beginTabEnterMotion()
+    async syncRenderedTabEnterMotion() {
+        let me = this,
+            styles;
+
+        try {
+            styles = await Neo.main.DomAccess.getComputedStyle({
+                id   : me.id,
+                style: ['animation-name', 'animation-duration']
+            })
+        } catch {
+            return
+        }
+
+        if (me.mounted && !me.isDestroyed && !me.isDestroying
+            && DockTabEnterButton.hasRenderedTabEnterMotion(styles)) {
+            me.beginTabEnterMotion()
         }
     }
 
@@ -105,8 +159,8 @@ class DockTabEnterButton extends TabHeaderButton {
     /**
      * Settles only for this button's root event. Descendant animations bubble through the same
      * local listener but retain their own config-aware target id and cannot close this producer.
-     * Both `animationend` and `animationcancel` route here. An end without a matching start is an
-     * intentional safe no-op (the zero-duration / missing-animation path).
+     * Both `animationend` and `animationcancel` route here. An end without a matching rendered
+     * motion entry is an intentional safe no-op (the zero-duration / missing-animation path).
      * @param {Object} data
      */
     onTabEnterAnimationSettle(data) {

--- a/test/playwright/e2e/dashboard/DockMotionNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockMotionNL.spec.mjs
@@ -281,6 +281,62 @@ test.describe('Dock motion pipeline (Neural Link) — the signal brackets real m
         expect(positions.length, `the FLIP must travel THROUGH intermediate positions (saw ${positions.length})`).toBeGreaterThan(2);
     });
 
+    test('a committed addTab animates exactly the inserted header, signal-bracketed for one projection only', async ({ page, neuralLink }) => {
+        const { app, holderId } = await connect(page, neuralLink);
+
+        // Deterministic state: restore the seeded Operator perspective through the visible product
+        // control. Restore is an unrelated coarse projection and MUST carry no tab-enter class.
+        await page.getByRole('button', {name: 'Operator', exact: true}).click();
+        await expect.poll(async () => {
+            const topo = await app.getDockTopology(holderId);
+            const doc  = topo?.document ?? topo;
+            return doc.nodes['main-tabs']?.items?.join(',')
+        }, {message: 'Operator restore must re-seed the main tab pair', timeout: 10000, intervals: [100]}).toBe('strategy,swarm');
+        await expect(page.locator('.neo-dashboard-dock-tab-enter')).toHaveCount(0);
+
+        // Remove the inactive Swarm tab first. Adding it back into the SAME tab container creates a
+        // new header without changing the container's footprint — the non-FLIP producer must carry
+        // the observable motion even when structural pane geometry has no useful delta.
+        const detached = await app.executeDockOperation(holderId, {operation: 'detachItem', itemId: 'swarm'});
+        expect(detached.errors).toEqual([]);
+
+        await expect.poll(
+            () => page.locator(SIGNAL).count(),
+            {message: 'the detach setup projection must settle before the insertion witness', timeout: 3500, intervals: [50]}
+        ).toBe(0);
+        await expect(page.locator('.neo-dashboard-dock-tab-enter')).toHaveCount(0);
+
+        const ENTER = '.neo-dashboard-dock-tab-enter.dock-tab-enter-item-swarm';
+
+        // Arm both observers before dispatching the operation. The exact marker proves correlation;
+        // the shared signal bracket proves the CSS animation owns a counted lifecycle independently
+        // of whether DockFlip finds geometry to play.
+        const [, , result] = await Promise.all([
+            expectSignalBracket(page),
+            expect.poll(
+                () => page.locator(ENTER).count(),
+                {message: 'only the inserted Swarm header receives the tab-enter class', timeout: 1500, intervals: [20]}
+            ).toBe(1),
+            app.executeDockOperation(holderId, {
+                operation: 'addTab', itemId: 'swarm', tabsNodeId: 'main-tabs', index: 1
+            })
+        ]);
+
+        expect(result.errors).toEqual([]);
+        expect(result.applied).toBe(true);
+        expect(result.document.nodes['main-tabs'].items).toEqual(['strategy', 'swarm']);
+        await expect(page.locator('.neo-dashboard-dock-tab-enter')).toHaveCount(1);
+        await expect(page.locator(`${ENTER}${SIGNAL}`)).toHaveCount(0);
+
+        // A later restore is another full removeAll/rebuild but has no addTab descriptor. The
+        // recreated headers must be inert — the one-use correlation cannot leak across projections.
+        await page.getByRole('button', {name: 'Operator', exact: true}).click();
+        await expect.poll(
+            () => page.locator('.neo-dashboard-dock-tab-enter').count(),
+            {message: 'later coarse projections must not replay tab insertion', timeout: 5000, intervals: [50]}
+        ).toBe(0)
+    });
+
     test('a rail-click reveal SLIDES: the overlay travels through intermediate render states, signal-bracketed', async ({ page, neuralLink }) => {
         const { app, holderId } = await connect(page, neuralLink);
 
@@ -409,5 +465,39 @@ test.describe('Dock motion pipeline — reduced-motion collapses through the tok
             () => page.locator(SIGNAL).count(),
             { message: 'the signal must clear within the fail-safe horizon', timeout: 3500, intervals: [100] }
         ).toBe(0);
+    });
+
+    test('a committed addTab uses the 0ms token and leaves no sustained tab motion', async ({ page, neuralLink }) => {
+        await page.emulateMedia({reducedMotion: 'reduce'});
+
+        const { app, holderId } = await connect(page, neuralLink);
+
+        await page.getByRole('button', {name: 'Operator', exact: true}).click();
+        await expect.poll(async () => {
+            const topo = await app.getDockTopology(holderId);
+            const doc  = topo?.document ?? topo;
+            return doc.nodes['main-tabs']?.items?.join(',')
+        }, {message: 'Operator restore must re-seed the reduced-motion setup', timeout: 10000, intervals: [100]}).toBe('strategy,swarm');
+
+        const detached = await app.executeDockOperation(holderId, {operation: 'detachItem', itemId: 'swarm'});
+        expect(detached.errors).toEqual([]);
+        await expect.poll(() => page.locator(SIGNAL).count(), {timeout: 3500, intervals: [50]}).toBe(0);
+
+        const token = await page.evaluate(() => {
+            const scope = document.querySelector('.neo-dashboard') || document.body;
+            return getComputedStyle(scope).getPropertyValue('--dock-transition-duration').trim()
+        });
+        expect(token).toBe('0ms');
+
+        const result = await app.executeDockOperation(holderId, {
+            operation: 'addTab', itemId: 'swarm', tabsNodeId: 'main-tabs', index: 1
+        });
+
+        expect(result.errors).toEqual([]);
+        await expect(page.locator('.neo-dashboard-dock-tab-enter.dock-tab-enter-item-swarm')).toHaveCount(1);
+        await expect.poll(
+            () => page.locator(SIGNAL).count(),
+            {message: '0ms tab insertion must settle without sustained motion', timeout: 1500, intervals: [25]}
+        ).toBe(0)
     });
 });

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -6,13 +6,14 @@ setup({
     }
 });
 
-import {test, expect}    from '@playwright/test';
-import Neo               from '../../../../src/Neo.mjs';
-import * as core         from '../../../../src/core/_export.mjs';
-import DockLayoutAdapter from '../../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockRail          from '../../../../src/dashboard/DockRail.mjs';
-import DockSplitter      from '../../../../src/dashboard/DockSplitter.mjs';
-import DockZoneModel     from '../../../../src/dashboard/DockZoneModel.mjs';
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import DockLayoutAdapter  from '../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockRail           from '../../../../src/dashboard/DockRail.mjs';
+import DockSplitter       from '../../../../src/dashboard/DockSplitter.mjs';
+import DockTabEnterButton from '../../../../src/dashboard/DockTabEnterButton.mjs';
+import DockZoneModel      from '../../../../src/dashboard/DockZoneModel.mjs';
 
 const createModel = () => ({
     schema: 'neo.harness.dockZone.v1',
@@ -261,6 +262,36 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         expect(result.items[0].activeIndex).toBe(1);
         expect(result.items[0].items.map(item => item.header.text)).toEqual(['Strategy', 'Swarm']);
         expect(result.items[0].items.map(item => item.data.dockItemId)).toEqual(['strategy', 'swarm']);
+    });
+
+    test('a transient addTab correlation decorates only the exact target header without mutating the model', () => {
+        let model    = createModel(),
+            snapshot = JSON.parse(JSON.stringify(model)),
+            result   = DockLayoutAdapter.project(model, {
+                resolveComponentRef: componentRef => ({
+                    ntype    : 'dashboard-panel',
+                    reference: componentRef
+                }),
+                tabInsertDescriptor: {operation: 'addTab', itemId: 'swarm', tabsNodeId: 'main-tabs'}
+            }),
+            mainTabs = result.items[0],
+            headers  = mainTabs.items.map(item => item.header);
+
+        expect(headers[0].module).toBeUndefined();
+        expect(headers[0].cls).toBeUndefined();
+        expect(headers[1].module).toBe(DockTabEnterButton);
+        expect(headers[1].cls).toEqual([
+            'neo-dashboard-dock-tab-enter',
+            'dock-tab-enter-item-swarm'
+        ]);
+        expect(model).toEqual(snapshot);
+
+        const unrelated = DockLayoutAdapter.project(model, {
+            resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef}),
+            tabInsertDescriptor: {operation: 'addTab', itemId: 'swarm', tabsNodeId: 'terminal-tabs'}
+        });
+
+        expect(unrelated.items[0].items.every(item => item.header.module === undefined)).toBe(true)
     });
 
     test('projects the documented edge-zone root model through the dashboard adapter', () => {

--- a/test/playwright/unit/dashboard/DockTabEnterButton.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabEnterButton.spec.mjs
@@ -1,0 +1,180 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockTabEnterButtonTest'
+    }
+});
+
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../src/Neo.mjs';
+import * as core          from '../../../../src/core/_export.mjs';
+import DockMotionSignal   from '../../../../src/dashboard/DockMotionSignal.mjs';
+import DockTabEnterButton from '../../../../src/dashboard/DockTabEnterButton.mjs';
+import DockZoneModel      from '../../../../src/dashboard/DockZoneModel.mjs';
+import MainContainer      from '../../../../examples/dashboard/dock/MainContainer.mjs';
+
+const createModel = () => ({
+    schema: 'neo.harness.dockZone.v1',
+    root  : 'root',
+    items : {
+        strategy: {componentRef: 'Strategy', title: 'Strategy'},
+        swarm   : {componentRef: 'Swarm', title: 'Swarm'},
+        terminal: {componentRef: 'Terminal', title: 'Terminal'}
+    },
+    nodes: {
+        root: {
+            type       : 'split',
+            orientation: 'horizontal',
+            children   : ['main-tabs', 'terminal-tabs'],
+            sizes      : [0.7, 0.3]
+        },
+        'main-tabs': {
+            type        : 'tabs',
+            items       : ['strategy', 'swarm'],
+            activeItemId: 'strategy'
+        },
+        'terminal-tabs': {
+            type        : 'tabs',
+            items       : ['terminal'],
+            activeItemId: 'terminal'
+        }
+    }
+});
+
+const createAnimationEvent = (type, targetId) => ({
+    target: {id: targetId},
+    type
+});
+
+/**
+ * Finds one projected dock-node config across split/edge container nesting.
+ * @param {Object} config
+ * @param {String} nodeId
+ * @returns {Object|null}
+ */
+const findProjectedNode = (config, nodeId) => {
+    if (config?.dockNodeId === nodeId) {
+        return config
+    }
+
+    for (const item of config?.items || []) {
+        const match = findProjectedNode(item, nodeId);
+
+        if (match) {
+            return match
+        }
+    }
+
+    return null
+};
+
+test.describe('Neo.dashboard.DockTabEnterButton', () => {
+    let buttons = [];
+
+    test.afterEach(() => {
+        buttons.reverse().forEach(button => !button.isDestroyed && button.destroy());
+        buttons = [];
+        DockMotionSignal.activeMotions.clear()
+    });
+
+    const createButton = id => {
+        let button = Neo.create(DockTabEnterButton, {id, text: id});
+
+        buttons.push(button);
+        return button
+    };
+
+    test('brackets a real root start/end, stays inert at zero duration, and filters bubbled child animations', () => {
+        let button = createButton('dock-tab-enter-normal'),
+            rootId = button.vdom?.id || button.id;
+
+        // Construction/class correlation alone is not motion. A 0ms token emits no start/end,
+        // leaving this path honestly signal-free.
+        expect(DockMotionSignal.isAnimating(button.id)).toBe(false);
+
+        button.onTabEnterAnimationStart(createAnimationEvent('animationstart', 'tab-enter-child'));
+        expect(DockMotionSignal.isAnimating(button.id)).toBe(false);
+        button.onTabEnterAnimationStart(createAnimationEvent('animationstart', rootId));
+        expect(DockMotionSignal.isAnimating(button.id)).toBe(true);
+        expect(button.cls).toContain(DockMotionSignal.SIGNAL_CLS);
+        button.onTabEnterAnimationSettle(createAnimationEvent('animationend', 'tab-enter-child'));
+        expect(DockMotionSignal.isAnimating(button.id)).toBe(true);
+
+        button.onTabEnterAnimationSettle(createAnimationEvent('animationend', rootId));
+        expect(DockMotionSignal.isAnimating(button.id)).toBe(false);
+
+        // A duplicate end is idempotent. Cancellation balances a second real start.
+        button.onTabEnterAnimationSettle(createAnimationEvent('animationend', rootId));
+        button = createButton('dock-tab-enter-cancel');
+        button.onTabEnterAnimationStart(createAnimationEvent('animationstart', button.vdom?.id || button.id));
+        button.onTabEnterAnimationSettle(createAnimationEvent('animationcancel', button.vdom?.id || button.id));
+        expect(DockMotionSignal.isAnimating(button.id)).toBe(false)
+    });
+
+    test('rapid replacement and destroy settle only each instance-owned entry', () => {
+        let first  = createButton('dock-tab-enter-first'),
+            second = createButton('dock-tab-enter-second');
+
+        first.onTabEnterAnimationStart(createAnimationEvent('animationstart', first.vdom?.id || first.id));
+        second.onTabEnterAnimationStart(createAnimationEvent('animationstart', second.vdom?.id || second.id));
+
+        expect(DockMotionSignal.isAnimating(first.id)).toBe(true);
+        expect(DockMotionSignal.isAnimating(second.id)).toBe(true);
+
+        first.destroy();
+        expect(DockMotionSignal.isAnimating(first.id)).toBe(false);
+        expect(DockMotionSignal.isAnimating(second.id)).toBe(true);
+
+        second.destroy();
+        expect(DockMotionSignal.isAnimating(second.id)).toBe(false);
+        expect(DockMotionSignal.activeMotions.size).toBe(0)
+    });
+
+    test('the refresh owner captures a real addTab for one projection only; reorder and later refreshes stay inert', async () => {
+        let initial    = createModel(),
+            descriptor = {operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs', index: 2},
+            inserted   = DockZoneModel.applyOperation(initial, descriptor),
+            refreshes  = [],
+            context    = {
+                applyDockZoneOperation() {},
+                dockModel                       : initial,
+                getTabInsertProjectionDescriptor: MainContainer.prototype.getTabInsertProjectionDescriptor,
+                isDestroyed                     : false,
+                onDockCrossZoneDrop() {},
+                onDockZoneDocumentChange: MainContainer.prototype.onDockZoneDocumentChange,
+                refreshDockWorkspace    : transient => refreshes.push(transient),
+                timeout                 : () => Promise.resolve()
+            };
+
+        expect(inserted.errors).toEqual([]);
+
+        MainContainer.prototype.onDockZoneDocumentChange.call(context, inserted.document, descriptor);
+        await Promise.resolve();
+
+        expect(refreshes).toEqual([{operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs'}]);
+        expect(JSON.stringify(context.dockModel)).not.toContain('tabInsert');
+
+        const projected = MainContainer.prototype.projectDockModel.call(context, refreshes[0]),
+              mainTabs  = findProjectedNode(projected, 'main-tabs'),
+              entered   = mainTabs.items.filter(item => item.header?.cls?.includes('neo-dashboard-dock-tab-enter'));
+
+        expect(entered).toHaveLength(1);
+        expect(entered[0].data.dockItemId).toBe('terminal');
+        expect(entered[0].header.module).toBe(DockTabEnterButton);
+
+        // Same-target addTab is a reorder: the header existed before the commit, so no insertion.
+        let reorder = {operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs', index: 0},
+            moved   = DockZoneModel.applyOperation(context.dockModel, reorder);
+
+        MainContainer.prototype.onDockZoneDocumentChange.call(context, moved.document, reorder);
+        await Promise.resolve();
+        expect(refreshes[1]).toBeNull();
+
+        // A later coarse projection receives no captured descriptor and recreates every header inert.
+        const later     = MainContainer.prototype.projectDockModel.call(context),
+              laterTabs = findProjectedNode(later, 'main-tabs');
+
+        expect(laterTabs.items.some(item => item.header?.cls?.includes('neo-dashboard-dock-tab-enter'))).toBe(false)
+    });
+});

--- a/test/playwright/unit/dashboard/DockTabEnterButton.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabEnterButton.spec.mjs
@@ -85,17 +85,35 @@ test.describe('Neo.dashboard.DockTabEnterButton', () => {
         return button
     };
 
-    test('brackets a real root start/end, stays inert at zero duration, and filters bubbled child animations', () => {
+    test('recognizes only the exact rendered non-zero tab-entry animation', () => {
+        expect(DockTabEnterButton.hasRenderedTabEnterMotion({
+            'animation-duration': '0.26s',
+            'animation-name'    : 'neo-dock-tab-enter'
+        })).toBe(true);
+        expect(DockTabEnterButton.hasRenderedTabEnterMotion({
+            'animation-duration': '120ms, 0.26s',
+            'animation-name'    : 'other, neo-dock-tab-enter'
+        })).toBe(true);
+        expect(DockTabEnterButton.hasRenderedTabEnterMotion({
+            'animation-duration': '0s',
+            'animation-name'    : 'neo-dock-tab-enter'
+        })).toBe(false);
+        expect(DockTabEnterButton.hasRenderedTabEnterMotion({
+            'animation-duration': '0.26s',
+            'animation-name'    : 'other'
+        })).toBe(false);
+        expect(DockTabEnterButton.hasRenderedTabEnterMotion(null)).toBe(false)
+    });
+
+    test('brackets a real root settle, stays idempotent, and filters bubbled child animations', () => {
         let button = createButton('dock-tab-enter-normal'),
             rootId = button.vdom?.id || button.id;
 
-        // Construction/class correlation alone is not motion. A 0ms token emits no start/end,
-        // leaving this path honestly signal-free.
+        // Construction/class correlation alone is not motion. Rendered-style discovery owns entry;
+        // this test drives the already-validated non-zero branch directly.
         expect(DockMotionSignal.isAnimating(button.id)).toBe(false);
 
-        button.onTabEnterAnimationStart(createAnimationEvent('animationstart', 'tab-enter-child'));
-        expect(DockMotionSignal.isAnimating(button.id)).toBe(false);
-        button.onTabEnterAnimationStart(createAnimationEvent('animationstart', rootId));
+        button.beginTabEnterMotion();
         expect(DockMotionSignal.isAnimating(button.id)).toBe(true);
         expect(button.cls).toContain(DockMotionSignal.SIGNAL_CLS);
         button.onTabEnterAnimationSettle(createAnimationEvent('animationend', 'tab-enter-child'));
@@ -107,7 +125,7 @@ test.describe('Neo.dashboard.DockTabEnterButton', () => {
         // A duplicate end is idempotent. Cancellation balances a second real start.
         button.onTabEnterAnimationSettle(createAnimationEvent('animationend', rootId));
         button = createButton('dock-tab-enter-cancel');
-        button.onTabEnterAnimationStart(createAnimationEvent('animationstart', button.vdom?.id || button.id));
+        button.beginTabEnterMotion();
         button.onTabEnterAnimationSettle(createAnimationEvent('animationcancel', button.vdom?.id || button.id));
         expect(DockMotionSignal.isAnimating(button.id)).toBe(false)
     });
@@ -116,8 +134,8 @@ test.describe('Neo.dashboard.DockTabEnterButton', () => {
         let first  = createButton('dock-tab-enter-first'),
             second = createButton('dock-tab-enter-second');
 
-        first.onTabEnterAnimationStart(createAnimationEvent('animationstart', first.vdom?.id || first.id));
-        second.onTabEnterAnimationStart(createAnimationEvent('animationstart', second.vdom?.id || second.id));
+        first.beginTabEnterMotion();
+        second.beginTabEnterMotion();
 
         expect(DockMotionSignal.isAnimating(first.id)).toBe(true);
         expect(DockMotionSignal.isAnimating(second.id)).toBe(true);


### PR DESCRIPTION
Resolves #14968

Adds the operation-correlated tab-insert motion seam that the broad selector approach could not provide. The dock refresh owner now carries one successful `addTab` descriptor into exactly one projection; `DockLayoutAdapter` decorates only the matching recreated header; and `DockTabEnterButton` brackets the real CSS animation with the shared counted `DockMotionSignal`. Initial construction, restore, reorder, unrelated refreshes, later projections, and invalid correlation remain motion-free.

Evidence: L2 (23/23 exact dependency-integrated units on `af20c7cf53`; syntax and theme build green) → L3 required (exact post-rebase `DockMotionNL.spec.mjs` rerun for the real insertion/signal journey). Residual: AC6 [#14968].

Related: #13158

## Deltas

- The transient carrier lives on the workspace refresh owner and is cleared after the consuming projection; no operation, preview, dock document, saved layout, or perspective schema gains animation state.
- The adapter uses a dedicated header-button subclass only for the exact correlated `itemId`; there is no global tab-header selector and no second timing source.
- The producer settles `DockMotionSignal` on normal end, zero duration, cancellation/replacement, rapid successive inserts, and destroy. Duration/easing come only from `--dock-transition-*`.
- The branch was rebased after PR #15067 merged, so the formerly blocked adapter discovery path now executes locally.
- The draft keeps AC6 visible: the browser suite passed 7/7 on patch-identical pre-rebase head `718c7bd828`, but the post-rebase Chrome run could not be launched because the author harness's out-of-sandbox execution quota was exhausted. Patch-id is unchanged (`adee8f5ab44d69eeedc0e711d45f52441cce44e7`); this is useful evidence, not a substitute for the exact-head rerun.

## Test Evidence

- `NEO_CHROMA_PORT_TEST=18201 NEO_TEST_SKIP_CI=true npx playwright test test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs test/playwright/unit/dashboard/DockTabEnterButton.spec.mjs -c test/playwright/playwright.config.unit.mjs --workers=1` → **23/23 passed** on `af20c7cf53`.
- `DockMotionNL.spec.mjs` → **7/7 passed** on pre-rebase head `718c7bd828` after #15070; old/new commits have the same stable patch-id.
- `node --check` passed for `MainContainer.mjs`, `DockLayoutAdapter.mjs`, and `DockTabEnterButton.mjs`.
- `node buildScripts/build/themes.mjs -f -n -e dev` completed successfully; `Container.scss` compiles into the development themes.
- `git diff --check origin/dev..HEAD` → clean.

## Post-Merge Validation

- [ ] Re-run the same DockMotion browser journey after future changes to the projection carrier, header producer, or motion tokens. No acceptance evidence is intentionally deferred past merge; the exact-head AC6 run is a pre-ready gate while this PR remains draft.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session 837ad74b-c2d2-413d-9aab-b7165a93a82a.
