### PR TITLE
feat(agentos): cross-process boot-identity health surface — Fleet control-plane wiring (#15079)

### DIFF
--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -33,6 +33,8 @@ import DeploymentRuntimeAccessService                                           
 import DeploymentStateBridgeService                                                                 from './services/DeploymentStateBridgeService.mjs';
 import RecoveryActuatorService                                                                      from './services/RecoveryActuatorService.mjs';
 import ContainerHealthDiagnosisService                                                              from './services/ContainerHealthDiagnosisService.mjs';
+import {buildBootIdentitySource}                                                                    from './services/buildBootIdentitySource.mjs';
+import {recordBootIdentityFact}                                                                     from './services/recordBootIdentityFact.mjs';
 import DataIntegrityDiagnosisService                                                                from './services/DataIntegrityDiagnosisService.mjs';
 import DataRecoveryActuatorService                                                                  from './services/DataRecoveryActuatorService.mjs';
 import {auditChromaVectorCoverage}                                                                  from '../../scripts/maintenance/checkChromaIntegrity.mjs';
@@ -865,6 +867,11 @@ export class Orchestrator extends Base {
             writeLogFn     : this.writeLog.bind(this)
         });
 
+        // Boot-identity source: constructed ONCE (so bootAt is the process boot time), read-only advisory.
+        // Each poll persists its fact to the shared runtime-state dir so the separate fleet-bridge-server
+        // process can serve it via getBootIdentity(). Fail-soft — a null source simply writes nothing.
+        this.bootIdentitySource = buildBootIdentitySource({remRunStateDir: this.remConsolidationWatchdogRunStateDir});
+
         this.processSupervisorService = {};
         this.deploymentRuntimeAccessService = {};
         this.containerHealthDiagnosisService = {};
@@ -1024,6 +1031,12 @@ export class Orchestrator extends Base {
         runSchedulingPipeline({
             ...buildOrchestratorSchedulingOptions({orchestrator: this, config: AiConfig, now, registry: TASK_REGISTRY})
         });
+
+        // Persist this process's advisory boot-identity fact to the shared runtime-state dir for the
+        // fleet control-plane's cross-process getBootIdentity() read. Fail-soft inside recordBootIdentityFact
+        // (never gates a cycle); the .catch is belt-and-suspenders matching the sibling writes below.
+        recordBootIdentityFact({source: this.bootIdentitySource, dir: this.dataDir})
+            .catch(error => this.writeLog('ERROR', `[Orchestrator] Boot-identity fact write failed: ${error.message}`));
 
         this.deploymentStateBridgeService?.writeSnapshotIfDue()
             .catch(error => this.writeLog('ERROR', `[Orchestrator] Deployment state bridge failed: ${error.message}`));

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -867,10 +867,17 @@ export class Orchestrator extends Base {
             writeLogFn     : this.writeLog.bind(this)
         });
 
-        // Boot-identity source: constructed ONCE (so bootAt is the process boot time), read-only advisory.
-        // Each poll persists its fact to the shared runtime-state dir so the separate fleet-bridge-server
-        // process can serve it via getBootIdentity(). Fail-soft — a null source simply writes nothing.
-        this.bootIdentitySource = buildBootIdentitySource({remRunStateDir: this.remConsolidationWatchdogRunStateDir});
+        // Boot-identity source: constructed ONCE at start with the genuine process-boot time, read-only
+        // advisory. Each poll persists its fact to the shared runtime-state dir so the separate
+        // fleet-bridge-server process can serve it via getBootIdentity(). Fail-soft — a null source simply
+        // writes nothing. The freshness cadence is the REM-consolidation stall threshold (the same one the
+        // consolidation-liveness watchdog uses), so the classifier yields a real designed-deferral /
+        // restart-explains verdict instead of a perpetual `unknown`.
+        this.bootIdentitySource = buildBootIdentitySource({
+            remRunStateDir : this.remConsolidationWatchdogRunStateDir,
+            freshnessConfig: {designedCadenceMs: this.remConsolidationWatchdogThresholdMs, marginMs: 0},
+            bootAt         : Date.now() - Math.round(process.uptime() * 1000)
+        });
 
         this.processSupervisorService = {};
         this.deploymentRuntimeAccessService = {};
@@ -1033,10 +1040,15 @@ export class Orchestrator extends Base {
         });
 
         // Persist this process's advisory boot-identity fact to the shared runtime-state dir for the
-        // fleet control-plane's cross-process getBootIdentity() read. Fail-soft inside recordBootIdentityFact
-        // (never gates a cycle); the .catch is belt-and-suspenders matching the sibling writes below.
-        recordBootIdentityFact({source: this.bootIdentitySource, dir: this.dataDir})
-            .catch(error => this.writeLog('ERROR', `[Orchestrator] Boot-identity fact write failed: ${error.message}`));
+        // fleet control-plane's cross-process getBootIdentity() read. recordBootIdentityFact is fail-soft
+        // (never gates a cycle) and self-observing: a genuine produce/write failure is surfaced through
+        // onError (the LIVE log path); the trailing .catch is only a belt-and-suspenders guard for an
+        // unexpected rejection, matching the sibling writes below.
+        recordBootIdentityFact({
+            source : this.bootIdentitySource,
+            dir    : this.dataDir,
+            onError: error => this.writeLog('ERROR', `[Orchestrator] Boot-identity fact write failed: ${error.message}`)
+        }).catch(error => this.writeLog('ERROR', `[Orchestrator] Boot-identity fact write rejected: ${error.message}`));
 
         this.deploymentStateBridgeService?.writeSnapshotIfDue()
             .catch(error => this.writeLog('ERROR', `[Orchestrator] Deployment state bridge failed: ${error.message}`));

--- a/ai/daemons/orchestrator/Orchestrator.mjs
+++ b/ai/daemons/orchestrator/Orchestrator.mjs
@@ -867,17 +867,7 @@ export class Orchestrator extends Base {
             writeLogFn     : this.writeLog.bind(this)
         });
 
-        // Boot-identity source: constructed ONCE at start with the genuine process-boot time, read-only
-        // advisory. Each poll persists its fact to the shared runtime-state dir so the separate
-        // fleet-bridge-server process can serve it via getBootIdentity(). Fail-soft — a null source simply
-        // writes nothing. The freshness cadence is the REM-consolidation stall threshold (the same one the
-        // consolidation-liveness watchdog uses), so the classifier yields a real designed-deferral /
-        // restart-explains verdict instead of a perpetual `unknown`.
-        this.bootIdentitySource = buildBootIdentitySource({
-            remRunStateDir : this.remConsolidationWatchdogRunStateDir,
-            freshnessConfig: {designedCadenceMs: this.remConsolidationWatchdogThresholdMs, marginMs: 0},
-            bootAt         : Date.now() - Math.round(process.uptime() * 1000)
-        });
+        this.initBootIdentitySource();
 
         this.processSupervisorService = {};
         this.deploymentRuntimeAccessService = {};
@@ -905,6 +895,24 @@ export class Orchestrator extends Base {
         this.isPolling = true;
         this.writeLog('INFO', `[Orchestrator] Started. summaryInterval=${AiConfig.orchestrator.intervals.summarySweepMs}ms kbSyncInterval=${AiConfig.orchestrator.intervals.kbSyncMs}ms poll=${AiConfig.orchestrator.intervals.pollMs}ms.`);
         this.poll();
+    }
+
+    /**
+     * @summary Composes this process's boot-identity source (once, at start): a `BootIdentityHealthService`
+     * over the live REM-run-state fact-gatherer, with the genuine process-boot time and the REM-consolidation
+     * stall threshold as the freshness cadence (the same threshold the consolidation-liveness watchdog uses,
+     * so the classifier yields a real designed-deferral / restart-explains verdict rather than a perpetual
+     * `unknown`). Extracted from `start()` so the caller composition is exercisable through a real Orchestrator
+     * method — `start()` itself is a side-effecting daemon boot the unit suite does not run. Fail-soft: a null
+     * source simply makes each poll write nothing (the fleet reader keeps its honest advisory-`unknown`).
+     * @returns {void}
+     */
+    initBootIdentitySource() {
+        this.bootIdentitySource = buildBootIdentitySource({
+            remRunStateDir : this.remConsolidationWatchdogRunStateDir,
+            freshnessConfig: {designedCadenceMs: this.remConsolidationWatchdogThresholdMs, marginMs: 0},
+            bootAt         : Date.now() - Math.round(process.uptime() * 1000)
+        });
     }
 
     /**

--- a/ai/daemons/orchestrator/services/bootIdentityFactStore.mjs
+++ b/ai/daemons/orchestrator/services/bootIdentityFactStore.mjs
@@ -1,0 +1,89 @@
+import {mkdir, readFile, writeFile} from 'fs/promises';
+import path                         from 'path';
+
+/**
+ * @module ai/daemons/orchestrator/services/bootIdentityFactStore
+ * @summary Durable single-fact store that carries the advisory boot-identity fact ACROSS the
+ * orchestrator↔fleet-server process boundary. The producer (`BootIdentityHealthService`) + its
+ * REM-run-state fact-gatherer live in the orchestrator process; the control-plane consumer seam
+ * (`FleetControlBridge.getBootIdentity`) lives in the separate fleet-bridge-server process (Option-B
+ * dev path). So the fact cannot be injected in-process there — instead the orchestrator WRITES its
+ * latest advisory fact to this shared runtime-state file (the same shared-dir pattern the REM
+ * run-state + heal-event stores use), and the fleet-server READS it. Mode-agnostic: the in-process
+ * Electron path (Option A) reads the same file, so nothing forks on deployment mode.
+ *
+ * **Latest-wins, not a ledger:** the boot-identity fact is a single CURRENT snapshot (which source is
+ * this process running, plus the latest scheduler cycle), so the write overwrites rather than appends
+ * — there is no history to retain and thus no prune machinery.
+ *
+ * **Advisory-fail-soft read (the control-plane contract):** the read is on the control-plane path,
+ * which must NEVER be gated by this store — so a missing OR unreadable OR corrupt file resolves to
+ * `null` (the consumer renders the honest advisory-`unknown`, never a fabricated fact and never a
+ * thrown control-plane read). The write, by contrast, surfaces its own I/O error to the orchestrator
+ * caller (which swallows it fail-soft at its cycle boundary) so a persistent write failure is at least
+ * loggable rather than silent.
+ */
+
+const BOOT_IDENTITY_FACT_FILENAME = 'boot-identity-fact.json';
+
+/**
+ * @summary The boot-identity fact file path within a runtime state directory.
+ * @param {String} dir
+ * @returns {String}
+ * @throws {TypeError} when `dir` is missing/empty.
+ */
+export function getBootIdentityFactFilePath(dir) {
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('getBootIdentityFactFilePath: dir is required');
+    }
+    return path.join(dir, BOOT_IDENTITY_FACT_FILENAME);
+}
+
+/**
+ * @summary Persists the latest advisory boot-identity fact (overwrite-latest), creating the dir if
+ * needed. The orchestrator calls this at its cycle boundary; the fact is the full
+ * `produceBootIdentityFact()` shape `{fact, classification, advisory, reason}`.
+ * @param {Object} fact The advisory boot-identity fact to persist.
+ * @param {Object} options
+ * @param {String} options.dir The shared runtime state directory.
+ * @returns {Promise<String>} The file path written to.
+ * @throws {TypeError} when `fact` is not an object or `dir` is missing/empty.
+ */
+export async function writeBootIdentityFact(fact, {dir} = {}) {
+    if (!fact || typeof fact !== 'object') {
+        throw new TypeError('writeBootIdentityFact: fact object is required');
+    }
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('writeBootIdentityFact: dir is required');
+    }
+
+    await mkdir(dir, {recursive: true});
+    const filePath = getBootIdentityFactFilePath(dir);
+    await writeFile(filePath, JSON.stringify(fact), 'utf8');
+
+    return filePath;
+}
+
+/**
+ * @summary Reads the latest advisory boot-identity fact from the shared file. ADVISORY-FAIL-SOFT: a
+ * missing / unreadable / corrupt file resolves to `null` so the control-plane read is never gated and
+ * never throws — the consumer degrades to the honest advisory-`unknown`.
+ * @param {Object} options
+ * @param {String} options.dir The shared runtime state directory.
+ * @returns {Promise<Object|null>} The persisted fact, or `null` when none is readable.
+ */
+export async function readBootIdentityFact({dir} = {}) {
+    if (typeof dir !== 'string' || dir.length === 0) {
+        return null; // no dir → nothing to read (advisory: unknown, never a throw on the control-plane path)
+    }
+
+    try {
+        const text = await readFile(getBootIdentityFactFilePath(dir), 'utf8');
+        const fact = JSON.parse(text);
+
+        return fact && typeof fact === 'object' ? fact : null;
+    } catch (error) {
+        // missing (ENOENT) / unreadable / corrupt → advisory-unknown, never a definitive verdict or a throw
+        return null;
+    }
+}

--- a/ai/daemons/orchestrator/services/bootIdentityFactStore.mjs
+++ b/ai/daemons/orchestrator/services/bootIdentityFactStore.mjs
@@ -1,5 +1,6 @@
-import {mkdir, readFile, rename, stat, writeFile} from 'fs/promises';
-import path                                       from 'path';
+import {mkdir, readFile, rename, stat, unlink, writeFile} from 'fs/promises';
+import path                                               from 'path';
+import {BOOT_FRESHNESS_CLASS}                             from './bootIdentityFreshness.mjs';
 
 /**
  * @module ai/daemons/orchestrator/services/bootIdentityFactStore
@@ -14,14 +15,20 @@ import path                                       from 'path';
  *
  * **Explicit cross-process snapshot contract (not a raw blob).** Because a writer and a reader in two
  * OS processes share this file, the on-disk form is a versioned, self-describing envelope
- * `{v, generatedAt, bootId, fact}`:
- *  - **Atomic replace** (write-temp → `rename`) so a concurrent reader never observes a torn,
- *    half-written JSON (which would read as corrupt → a spurious `unknown`).
- *  - **Generation metadata** (`generatedAt`, `bootId`) so the reader can tell a fresh snapshot from a
- *    stale prior-process one, and a future format change from the current version.
+ * `{v, generatedAt, fact}`:
+ *  - **Concurrency-safe atomic replace.** Each write goes to a UNIQUE per-write sibling temp
+ *    (`…json.<pid>.<ts>.<seq>.tmp`) then `rename`s over the target — so overlapping writers (a poll
+ *    racing a restart) never share a temp path and a reader never observes a torn, half-written JSON.
+ *    A fixed temp name would collide under concurrency (one writer's `rename` unlinks the temp another
+ *    is still writing → `ENOENT` / an unreadable final snapshot); the per-write name is the same shape
+ *    `deploymentStateBridgeStore` uses.
+ *  - **Generation metadata** (`generatedAt`) so the reader can tell a fresh snapshot from a stale
+ *    prior-process one, and a future format change from the current version.
  *  - **Byte bound** (`MAX_FACT_BYTES`) so a pathological oversized field can never be written or parsed.
- *  - **Schema validation** on read (version + required-key shape) so a wrong-version / wrong-shape file
- *    degrades to `unknown` rather than serving garbage.
+ *  - **Canonical-codebook validation** on read — the envelope version, plus the fact's `classification`
+ *    against the producer's `BOOT_FRESHNESS_CLASS` codebook, `advisory === true`, and a non-empty
+ *    `reason` — so a wrong-version / wrong-shape / non-codebook file degrades to `unknown`, never a
+ *    fabricated classification served as a real one.
  *
  * **Latest-wins, not a ledger:** the boot-identity fact is a single CURRENT snapshot (which source is
  * this process running, plus the latest scheduler cycle), so the write overwrites rather than appends
@@ -29,11 +36,11 @@ import path                                       from 'path';
  *
  * **Advisory-fail-soft read (the control-plane contract):** the read is on the control-plane path,
  * which must NEVER be gated by this store — so a missing / unreadable / corrupt / wrong-version /
- * **stale-prior-process** file resolves to an honest `unknown` (a `null` for the absent/unreadable
- * classes, or an explicit stale advisory), never a fabricated fact and never a thrown control-plane
- * read. The write, by contrast, fails LOUD (a bad fact / oversized envelope / I/O fault throws) so the
- * orchestrator's per-cycle writer (`recordBootIdentityFact`) can route it to observability instead of
- * swallowing it blind.
+ * non-codebook / **stale-prior-process** file resolves to an honest `unknown` (a `null` for the
+ * absent/unreadable/invalid classes, or an explicit stale advisory), never a fabricated fact and never
+ * a thrown control-plane read. The write, by contrast, fails LOUD (a bad fact / oversized envelope /
+ * I/O fault throws) so the orchestrator's per-cycle writer (`recordBootIdentityFact`) can route it to
+ * observability instead of swallowing it blind.
  */
 
 const
@@ -48,9 +55,13 @@ const
     /**
      * Default staleness horizon. A live orchestrator rewrites the fact every scheduler cycle, so a fact
      * older than this means the producing process is gone → the advisory degrades to `unknown` rather
-     * than serving a dead process's snapshot as if live. The reader wiring overrides it from config.
+     * than serving a dead process's snapshot as if live. The reader wiring overrides it via `maxAgeMs`.
      */
     DEFAULT_MAX_FACT_AGE_MS     = 6 * 60 * 60 * 1000;
+
+// Per-process monotonic write counter — disambiguates two writes within the same millisecond so the
+// unique-temp name never collides even under a tight write loop in one process.
+let writeSeq = 0;
 
 export {BOOT_IDENTITY_FACT_VERSION, DEFAULT_MAX_FACT_AGE_MS, MAX_FACT_BYTES};
 
@@ -69,38 +80,44 @@ export function getBootIdentityFactFilePath(dir) {
 
 /**
  * @summary Validates a parsed envelope against the cross-process snapshot contract: the current
- * version, a finite generation timestamp, and a fact carrying the produce-shape's required keys.
- * A failure degrades the read to `unknown` (never a throw, never a fabricated fact).
+ * version, a finite generation timestamp, and a fact whose `classification` is a member of the
+ * producer's canonical `BOOT_FRESHNESS_CLASS` codebook, is `advisory === true`, and carries a
+ * non-empty `reason`. A failure degrades the read to `unknown` (never a throw, never a fabricated fact).
  * @param {*} envelope The parsed file contents.
  * @returns {Boolean}
  * @protected
  */
 export function isValidBootIdentityEnvelope(envelope) {
-    return !!envelope
-        && typeof envelope === 'object'
-        && envelope.v === BOOT_IDENTITY_FACT_VERSION
-        && Number.isFinite(envelope.generatedAt)
-        && !!envelope.fact
-        && typeof envelope.fact                === 'object'
-        && typeof envelope.fact.classification === 'string'
-        && typeof envelope.fact.advisory       === 'boolean';
+    if (!envelope || typeof envelope !== 'object' || envelope.v !== BOOT_IDENTITY_FACT_VERSION) {
+        return false;
+    }
+    if (!Number.isFinite(envelope.generatedAt)) {
+        return false;
+    }
+
+    const fact = envelope.fact;
+
+    return !!fact
+        && typeof fact === 'object'
+        && Object.values(BOOT_FRESHNESS_CLASS).includes(fact.classification) // the producer's codebook, not any string
+        && fact.advisory === true                                            // advisory-only invariant (never a certainty verdict)
+        && typeof fact.reason === 'string' && fact.reason.length > 0;
 }
 
 /**
- * @summary Persists the latest advisory boot-identity fact as a versioned, atomically-replaced
- * snapshot envelope, creating the dir if needed. The orchestrator calls this at its cycle boundary;
- * `fact` is the full `produceBootIdentityFact()` shape `{fact, classification, advisory, reason}`.
- * Fails LOUD (bad fact / oversized envelope / I/O fault) — the caller routes the error to observability.
+ * @summary Persists the latest advisory boot-identity fact as a versioned, concurrency-safe
+ * atomically-replaced snapshot envelope, creating the dir if needed. The orchestrator calls this at its
+ * cycle boundary; `fact` is the full `produceBootIdentityFact()` shape `{fact, classification, advisory,
+ * reason}`. Fails LOUD (bad fact / oversized envelope / I/O fault) — the caller routes it to observability.
  * @param {Object} fact The advisory boot-identity fact to persist.
  * @param {Object} options
  * @param {String} options.dir The shared runtime state directory.
- * @param {String|Number|null} [options.bootId=null] Producing-process boot generation id (metadata).
  * @param {Function} [options.nowFn=Date.now] Injected epoch-ms clock (stamps `generatedAt`).
  * @returns {Promise<String>} The file path written to.
  * @throws {TypeError} when `fact` is not an object or `dir` is missing/empty.
  * @throws {RangeError} when the serialized envelope exceeds `MAX_FACT_BYTES`.
  */
-export async function writeBootIdentityFact(fact, {dir, bootId = null, nowFn = Date.now} = {}) {
+export async function writeBootIdentityFact(fact, {dir, nowFn = Date.now} = {}) {
     if (!fact || typeof fact !== 'object') {
         throw new TypeError('writeBootIdentityFact: fact object is required');
     }
@@ -109,7 +126,7 @@ export async function writeBootIdentityFact(fact, {dir, bootId = null, nowFn = D
     }
 
     const
-        envelope   = {v: BOOT_IDENTITY_FACT_VERSION, generatedAt: nowFn(), bootId, fact},
+        envelope   = {v: BOOT_IDENTITY_FACT_VERSION, generatedAt: nowFn(), fact},
         serialized = JSON.stringify(envelope);
 
     if (Buffer.byteLength(serialized, 'utf8') > MAX_FACT_BYTES) {
@@ -120,22 +137,30 @@ export async function writeBootIdentityFact(fact, {dir, bootId = null, nowFn = D
 
     const
         filePath = getBootIdentityFactFilePath(dir),
-        tmpPath  = `${filePath}.tmp`;
+        // Unique per-write temp: pid + timestamp + monotonic seq → no two concurrent writers (overlapping
+        // polls / a restart racing a poll) ever share a temp path, so a rename never unlinks a temp another
+        // writer is mid-write to. Matches deploymentStateBridgeStore's atomic-snapshot precedent.
+        tmpPath  = `${filePath}.${process.pid}.${nowFn()}.${++writeSeq}.tmp`;
 
-    // Atomic replace: write the whole envelope to a sibling temp then rename over the target, so a
-    // concurrent cross-process reader observes either the old file or the new one — never a torn write.
-    await writeFile(tmpPath, serialized, 'utf8');
-    await rename(tmpPath, filePath);
+    try {
+        await writeFile(tmpPath, serialized, 'utf8');
+        await rename(tmpPath, filePath);
+    } catch (error) {
+        // Best-effort cleanup so a failed write never orphans its own temp; the original error still throws.
+        await unlink(tmpPath).catch(() => {});
+        throw error;
+    }
 
     return filePath;
 }
 
 /**
  * @summary Reads the latest advisory boot-identity snapshot. ADVISORY-FAIL-SOFT: a missing /
- * unreadable / oversized / corrupt / wrong-version file resolves to `null`; a valid-but-STALE snapshot
- * (older than `maxAgeMs` → the producing process is gone) resolves to an explicit `unknown` advisory
- * carrying a `stale-boot-identity-fact` reason. Either way the control-plane read is never gated and
- * never throws — the consumer degrades to an honest `unknown`, never a dead process's fact-as-live.
+ * unreadable / oversized / corrupt / wrong-version / non-codebook file resolves to `null`; a
+ * valid-but-STALE snapshot (older than `maxAgeMs` → the producing process is gone) resolves to an
+ * explicit `unknown` advisory carrying a `stale-boot-identity-fact` reason. Either way the control-plane
+ * read is never gated and never throws — the consumer degrades to an honest `unknown`, never a dead
+ * process's fact-as-live.
  * @param {Object} options
  * @param {String} options.dir The shared runtime state directory.
  * @param {Number} [options.maxAgeMs=DEFAULT_MAX_FACT_AGE_MS] Staleness horizon; `Infinity` disables it.
@@ -171,14 +196,14 @@ export async function readBootIdentityFact({dir, maxAgeMs = DEFAULT_MAX_FACT_AGE
     }
 
     if (!isValidBootIdentityEnvelope(envelope)) {
-        return null; // wrong version / wrong shape → advisory-unknown, never garbage-as-fact
+        return null; // wrong version / non-codebook shape → advisory-unknown, never garbage-as-fact
     }
 
     // Stale prior-process guard: a fact older than the horizon means the producing orchestrator is
     // gone → surface an explicit `unknown` (never a dead process's snapshot as if live). Distinct from
     // the `null` absent-class so the fleet reader can render the stale reason.
     if (Number.isFinite(maxAgeMs) && (nowFn() - envelope.generatedAt) > maxAgeMs) {
-        return {fact: null, classification: 'unknown', advisory: true, reason: 'stale-boot-identity-fact'};
+        return {fact: null, classification: BOOT_FRESHNESS_CLASS.unknown, advisory: true, reason: 'stale-boot-identity-fact'};
     }
 
     return envelope.fact;

--- a/ai/daemons/orchestrator/services/bootIdentityFactStore.mjs
+++ b/ai/daemons/orchestrator/services/bootIdentityFactStore.mjs
@@ -1,9 +1,9 @@
-import {mkdir, readFile, writeFile} from 'fs/promises';
-import path                         from 'path';
+import {mkdir, readFile, rename, stat, writeFile} from 'fs/promises';
+import path                                       from 'path';
 
 /**
  * @module ai/daemons/orchestrator/services/bootIdentityFactStore
- * @summary Durable single-fact store that carries the advisory boot-identity fact ACROSS the
+ * @summary Durable single-fact carrier that moves the advisory boot-identity fact ACROSS the
  * orchestrator↔fleet-server process boundary. The producer (`BootIdentityHealthService`) + its
  * REM-run-state fact-gatherer live in the orchestrator process; the control-plane consumer seam
  * (`FleetControlBridge.getBootIdentity`) lives in the separate fleet-bridge-server process (Option-B
@@ -12,19 +12,47 @@ import path                         from 'path';
  * run-state + heal-event stores use), and the fleet-server READS it. Mode-agnostic: the in-process
  * Electron path (Option A) reads the same file, so nothing forks on deployment mode.
  *
+ * **Explicit cross-process snapshot contract (not a raw blob).** Because a writer and a reader in two
+ * OS processes share this file, the on-disk form is a versioned, self-describing envelope
+ * `{v, generatedAt, bootId, fact}`:
+ *  - **Atomic replace** (write-temp → `rename`) so a concurrent reader never observes a torn,
+ *    half-written JSON (which would read as corrupt → a spurious `unknown`).
+ *  - **Generation metadata** (`generatedAt`, `bootId`) so the reader can tell a fresh snapshot from a
+ *    stale prior-process one, and a future format change from the current version.
+ *  - **Byte bound** (`MAX_FACT_BYTES`) so a pathological oversized field can never be written or parsed.
+ *  - **Schema validation** on read (version + required-key shape) so a wrong-version / wrong-shape file
+ *    degrades to `unknown` rather than serving garbage.
+ *
  * **Latest-wins, not a ledger:** the boot-identity fact is a single CURRENT snapshot (which source is
  * this process running, plus the latest scheduler cycle), so the write overwrites rather than appends
  * — there is no history to retain and thus no prune machinery.
  *
  * **Advisory-fail-soft read (the control-plane contract):** the read is on the control-plane path,
- * which must NEVER be gated by this store — so a missing OR unreadable OR corrupt file resolves to
- * `null` (the consumer renders the honest advisory-`unknown`, never a fabricated fact and never a
- * thrown control-plane read). The write, by contrast, surfaces its own I/O error to the orchestrator
- * caller (which swallows it fail-soft at its cycle boundary) so a persistent write failure is at least
- * loggable rather than silent.
+ * which must NEVER be gated by this store — so a missing / unreadable / corrupt / wrong-version /
+ * **stale-prior-process** file resolves to an honest `unknown` (a `null` for the absent/unreadable
+ * classes, or an explicit stale advisory), never a fabricated fact and never a thrown control-plane
+ * read. The write, by contrast, fails LOUD (a bad fact / oversized envelope / I/O fault throws) so the
+ * orchestrator's per-cycle writer (`recordBootIdentityFact`) can route it to observability instead of
+ * swallowing it blind.
  */
 
-const BOOT_IDENTITY_FACT_FILENAME = 'boot-identity-fact.json';
+const
+    BOOT_IDENTITY_FACT_FILENAME = 'boot-identity-fact.json',
+    /** Envelope schema version — bump on any breaking on-disk shape change; a mismatch reads as unknown. */
+    BOOT_IDENTITY_FACT_VERSION  = 1,
+    /**
+     * A single advisory boot-identity snapshot is a small fixed-shape record; this generous cap only
+     * guards against a pathological oversized field, never a legitimate fact.
+     */
+    MAX_FACT_BYTES              = 16 * 1024,
+    /**
+     * Default staleness horizon. A live orchestrator rewrites the fact every scheduler cycle, so a fact
+     * older than this means the producing process is gone → the advisory degrades to `unknown` rather
+     * than serving a dead process's snapshot as if live. The reader wiring overrides it from config.
+     */
+    DEFAULT_MAX_FACT_AGE_MS     = 6 * 60 * 60 * 1000;
+
+export {BOOT_IDENTITY_FACT_VERSION, DEFAULT_MAX_FACT_AGE_MS, MAX_FACT_BYTES};
 
 /**
  * @summary The boot-identity fact file path within a runtime state directory.
@@ -40,16 +68,39 @@ export function getBootIdentityFactFilePath(dir) {
 }
 
 /**
- * @summary Persists the latest advisory boot-identity fact (overwrite-latest), creating the dir if
- * needed. The orchestrator calls this at its cycle boundary; the fact is the full
- * `produceBootIdentityFact()` shape `{fact, classification, advisory, reason}`.
+ * @summary Validates a parsed envelope against the cross-process snapshot contract: the current
+ * version, a finite generation timestamp, and a fact carrying the produce-shape's required keys.
+ * A failure degrades the read to `unknown` (never a throw, never a fabricated fact).
+ * @param {*} envelope The parsed file contents.
+ * @returns {Boolean}
+ * @protected
+ */
+export function isValidBootIdentityEnvelope(envelope) {
+    return !!envelope
+        && typeof envelope === 'object'
+        && envelope.v === BOOT_IDENTITY_FACT_VERSION
+        && Number.isFinite(envelope.generatedAt)
+        && !!envelope.fact
+        && typeof envelope.fact                === 'object'
+        && typeof envelope.fact.classification === 'string'
+        && typeof envelope.fact.advisory       === 'boolean';
+}
+
+/**
+ * @summary Persists the latest advisory boot-identity fact as a versioned, atomically-replaced
+ * snapshot envelope, creating the dir if needed. The orchestrator calls this at its cycle boundary;
+ * `fact` is the full `produceBootIdentityFact()` shape `{fact, classification, advisory, reason}`.
+ * Fails LOUD (bad fact / oversized envelope / I/O fault) — the caller routes the error to observability.
  * @param {Object} fact The advisory boot-identity fact to persist.
  * @param {Object} options
  * @param {String} options.dir The shared runtime state directory.
+ * @param {String|Number|null} [options.bootId=null] Producing-process boot generation id (metadata).
+ * @param {Function} [options.nowFn=Date.now] Injected epoch-ms clock (stamps `generatedAt`).
  * @returns {Promise<String>} The file path written to.
  * @throws {TypeError} when `fact` is not an object or `dir` is missing/empty.
+ * @throws {RangeError} when the serialized envelope exceeds `MAX_FACT_BYTES`.
  */
-export async function writeBootIdentityFact(fact, {dir} = {}) {
+export async function writeBootIdentityFact(fact, {dir, bootId = null, nowFn = Date.now} = {}) {
     if (!fact || typeof fact !== 'object') {
         throw new TypeError('writeBootIdentityFact: fact object is required');
     }
@@ -57,33 +108,78 @@ export async function writeBootIdentityFact(fact, {dir} = {}) {
         throw new TypeError('writeBootIdentityFact: dir is required');
     }
 
+    const
+        envelope   = {v: BOOT_IDENTITY_FACT_VERSION, generatedAt: nowFn(), bootId, fact},
+        serialized = JSON.stringify(envelope);
+
+    if (Buffer.byteLength(serialized, 'utf8') > MAX_FACT_BYTES) {
+        throw new RangeError(`writeBootIdentityFact: envelope exceeds ${MAX_FACT_BYTES} bytes`);
+    }
+
     await mkdir(dir, {recursive: true});
-    const filePath = getBootIdentityFactFilePath(dir);
-    await writeFile(filePath, JSON.stringify(fact), 'utf8');
+
+    const
+        filePath = getBootIdentityFactFilePath(dir),
+        tmpPath  = `${filePath}.tmp`;
+
+    // Atomic replace: write the whole envelope to a sibling temp then rename over the target, so a
+    // concurrent cross-process reader observes either the old file or the new one — never a torn write.
+    await writeFile(tmpPath, serialized, 'utf8');
+    await rename(tmpPath, filePath);
 
     return filePath;
 }
 
 /**
- * @summary Reads the latest advisory boot-identity fact from the shared file. ADVISORY-FAIL-SOFT: a
- * missing / unreadable / corrupt file resolves to `null` so the control-plane read is never gated and
- * never throws — the consumer degrades to the honest advisory-`unknown`.
+ * @summary Reads the latest advisory boot-identity snapshot. ADVISORY-FAIL-SOFT: a missing /
+ * unreadable / oversized / corrupt / wrong-version file resolves to `null`; a valid-but-STALE snapshot
+ * (older than `maxAgeMs` → the producing process is gone) resolves to an explicit `unknown` advisory
+ * carrying a `stale-boot-identity-fact` reason. Either way the control-plane read is never gated and
+ * never throws — the consumer degrades to an honest `unknown`, never a dead process's fact-as-live.
  * @param {Object} options
  * @param {String} options.dir The shared runtime state directory.
- * @returns {Promise<Object|null>} The persisted fact, or `null` when none is readable.
+ * @param {Number} [options.maxAgeMs=DEFAULT_MAX_FACT_AGE_MS] Staleness horizon; `Infinity` disables it.
+ * @param {Function} [options.nowFn=Date.now] Injected epoch-ms clock (for the staleness compare).
+ * @returns {Promise<Object|null>} The persisted `{fact, classification, advisory, reason}` when fresh,
+ *     an explicit stale `unknown` advisory when too old, or `null` when absent/unreadable/invalid.
  */
-export async function readBootIdentityFact({dir} = {}) {
+export async function readBootIdentityFact({dir, maxAgeMs = DEFAULT_MAX_FACT_AGE_MS, nowFn = Date.now} = {}) {
     if (typeof dir !== 'string' || dir.length === 0) {
-        return null; // no dir → nothing to read (advisory: unknown, never a throw on the control-plane path)
+        return null; // no dir → nothing to read (advisory-unknown, never a throw on the control-plane path)
     }
+
+    let text;
 
     try {
-        const text = await readFile(getBootIdentityFactFilePath(dir), 'utf8');
-        const fact = JSON.parse(text);
+        const filePath = getBootIdentityFactFilePath(dir);
 
-        return fact && typeof fact === 'object' ? fact : null;
+        // Byte-bound the read too: never parse an oversized file (defensive against a corrupt/huge file).
+        if ((await stat(filePath)).size > MAX_FACT_BYTES) {
+            return null;
+        }
+        text = await readFile(filePath, 'utf8');
     } catch (error) {
-        // missing (ENOENT) / unreadable / corrupt → advisory-unknown, never a definitive verdict or a throw
-        return null;
+        return null; // missing (ENOENT) / unreadable → advisory-unknown, never a throw
     }
+
+    let envelope;
+
+    try {
+        envelope = JSON.parse(text);
+    } catch (error) {
+        return null; // corrupt JSON → advisory-unknown
+    }
+
+    if (!isValidBootIdentityEnvelope(envelope)) {
+        return null; // wrong version / wrong shape → advisory-unknown, never garbage-as-fact
+    }
+
+    // Stale prior-process guard: a fact older than the horizon means the producing orchestrator is
+    // gone → surface an explicit `unknown` (never a dead process's snapshot as if live). Distinct from
+    // the `null` absent-class so the fleet reader can render the stale reason.
+    if (Number.isFinite(maxAgeMs) && (nowFn() - envelope.generatedAt) > maxAgeMs) {
+        return {fact: null, classification: 'unknown', advisory: true, reason: 'stale-boot-identity-fact'};
+    }
+
+    return envelope.fact;
 }

--- a/ai/daemons/orchestrator/services/buildBootIdentitySource.mjs
+++ b/ai/daemons/orchestrator/services/buildBootIdentitySource.mjs
@@ -1,0 +1,47 @@
+import Neo                              from '../../../../src/Neo.mjs';
+import BootIdentityHealthService        from './BootIdentityHealthService.mjs';
+import {createBootIdentityFactGatherer} from './bootIdentityFactGatherer.mjs';
+import {readRecentRemRunStates}         from '../../../services/memory-core/helpers/remRunStateStore.mjs';
+
+/**
+ * @module ai/daemons/orchestrator/services/buildBootIdentitySource
+ * @summary Constructs the orchestrator-side boot-identity source (`BootIdentityHealthService` over a
+ * live REM-run-state fact-gatherer) that the orchestrator produces its advisory fact from each cycle
+ * (then persists via `recordBootIdentityFact`). Isolated from `Orchestrator.mjs` so the `Neo.create`
+ * composition is unit-testable without booting the whole daemon.
+ *
+ * **Fail-soft (bounded blast radius).** A construction error returns `null` — the orchestrator then
+ * simply never writes a boot-identity fact, and the fleet reader keeps its honest advisory-`unknown`.
+ * The boot-identity surface is read-only observability, so its wiring must NEVER be able to break the
+ * orchestrator boot.
+ */
+
+/**
+ * @summary Build the boot-identity source. Called once at orchestrator start (so `bootAt` is the
+ * process boot time).
+ * @param {Object} options
+ * @param {String} options.remRunStateDir Directory holding the REM run-state JSONL artifacts (the same
+ *     source the consolidation liveness watchdog reads); the gatherer pairs the last cycle with `bootAt`.
+ * @param {Number} [options.bootAt=Date.now()] Epoch-ms process boot time.
+ * @param {Function} [options.nowFn=Date.now] Injected clock.
+ * @param {Function} [options.createGatherer=createBootIdentityFactGatherer] Injected in specs.
+ * @param {Object} [options.ServiceClass=BootIdentityHealthService] Injected in specs.
+ * @returns {Object|null} the boot-identity source (exposing async `produceBootIdentityFact()`), or
+ *     `null` when construction failed (fail-soft).
+ */
+export function buildBootIdentitySource({
+    remRunStateDir,
+    bootAt         = Date.now(),
+    nowFn          = Date.now,
+    createGatherer = createBootIdentityFactGatherer,
+    ServiceClass   = BootIdentityHealthService
+} = {}) {
+    try {
+        return Neo.create(ServiceClass, {
+            factGatherer: createGatherer({bootAt, readRecentRemRunStates, remRunStateDir}),
+            nowFn
+        });
+    } catch (error) {
+        return null; // fail-soft: an unwired source degrades to advisory-unknown, never a broken boot
+    }
+}

--- a/ai/daemons/orchestrator/services/buildBootIdentitySource.mjs
+++ b/ai/daemons/orchestrator/services/buildBootIdentitySource.mjs
@@ -1,4 +1,3 @@
-import Neo                              from '../../../../src/Neo.mjs';
 import BootIdentityHealthService        from './BootIdentityHealthService.mjs';
 import {createBootIdentityFactGatherer} from './bootIdentityFactGatherer.mjs';
 import {readRecentRemRunStates}         from '../../../services/memory-core/helpers/remRunStateStore.mjs';
@@ -9,6 +8,23 @@ import {readRecentRemRunStates}         from '../../../services/memory-core/help
  * live REM-run-state fact-gatherer) that the orchestrator produces its advisory fact from each cycle
  * (then persists via `recordBootIdentityFact`). Isolated from `Orchestrator.mjs` so the `Neo.create`
  * composition is unit-testable without booting the whole daemon.
+ *
+ * **Global `Neo`, never a non-entrypoint import.** This is a non-entrypoint helper (imported by
+ * `Orchestrator.mjs`), so it uses the GLOBAL `Neo` the daemon entrypoint bootstrapped — the same
+ * pattern `BootIdentityHealthService` itself follows (it imports `core.Base`, not `Neo`, and calls the
+ * global `Neo.setupClass`). A non-entrypoint `import Neo` can re-trigger bootstrap side-effects, so it
+ * is the forbidden pattern here.
+ *
+ * **Real freshness composition.** `classifyBootFreshness` returns `unknown` unless it is given a finite
+ * `designedCadenceMs`, so this leaf threads the caller's resolved `freshnessConfig` into the service —
+ * the orchestrator passes its REM-consolidation cadence (the same threshold the consolidation-liveness
+ * watchdog uses), which is what lets the default path produce a real `designed-deferral` /
+ * `restart-explains-gap` result instead of a perpetual `unknown`.
+ *
+ * **Scope (Leaf 1 = wiring).** `bootAt` + `lastCycle` (via the REM store) + the cadence are wired live.
+ * `sourceRef` / `deferralReason` / `schedulerResumeState` remain the gatherer's own declared optional
+ * "refine in place" resolvers (its docstring: "conservative first cut" — null / `none` best-effort),
+ * intentionally NOT built in this wiring leaf; they refine without restructuring this composition.
  *
  * **Fail-soft (bounded blast radius).** A construction error returns `null` — the orchestrator then
  * simply never writes a boot-identity fact, and the fleet reader keeps its honest advisory-`unknown`.
@@ -22,7 +38,11 @@ import {readRecentRemRunStates}         from '../../../services/memory-core/help
  * @param {Object} options
  * @param {String} options.remRunStateDir Directory holding the REM run-state JSONL artifacts (the same
  *     source the consolidation liveness watchdog reads); the gatherer pairs the last cycle with `bootAt`.
- * @param {Number} [options.bootAt=Date.now()] Epoch-ms process boot time.
+ * @param {Object|null} [options.freshnessConfig=null] `{designedCadenceMs, marginMs}` — the resolved
+ *     scheduler cadence the caller reads from config; without a finite `designedCadenceMs` the
+ *     classifier stays `unknown`.
+ * @param {Number} [options.bootAt=Date.now()] Epoch-ms process boot time (the orchestrator passes the
+ *     value it captured at `start()`).
  * @param {Function} [options.nowFn=Date.now] Injected clock.
  * @param {Function} [options.createGatherer=createBootIdentityFactGatherer] Injected in specs.
  * @param {Object} [options.ServiceClass=BootIdentityHealthService] Injected in specs.
@@ -31,14 +51,16 @@ import {readRecentRemRunStates}         from '../../../services/memory-core/help
  */
 export function buildBootIdentitySource({
     remRunStateDir,
-    bootAt         = Date.now(),
-    nowFn          = Date.now,
-    createGatherer = createBootIdentityFactGatherer,
-    ServiceClass   = BootIdentityHealthService
+    freshnessConfig = null,
+    bootAt          = Date.now(),
+    nowFn           = Date.now,
+    createGatherer  = createBootIdentityFactGatherer,
+    ServiceClass    = BootIdentityHealthService
 } = {}) {
     try {
         return Neo.create(ServiceClass, {
             factGatherer: createGatherer({bootAt, readRecentRemRunStates, remRunStateDir}),
+            freshnessConfig,
             nowFn
         });
     } catch (error) {

--- a/ai/daemons/orchestrator/services/recordBootIdentityFact.mjs
+++ b/ai/daemons/orchestrator/services/recordBootIdentityFact.mjs
@@ -1,0 +1,46 @@
+import {writeBootIdentityFact} from './bootIdentityFactStore.mjs';
+
+/**
+ * @module ai/daemons/orchestrator/services/recordBootIdentityFact
+ * @summary The orchestrator's per-cycle WRITER half of the cross-process advisory boot-identity
+ * surface: produce the current advisory fact from the boot-identity source and persist it to the shared
+ * runtime-state file, so the separate fleet-bridge-server process can read it via `FleetControlBridge`.
+ *
+ * **Fail-soft — observability, never a gate.** A produce/write error is swallowed so it can NEVER break
+ * a scheduler cycle; an absent/null fact is not written (the reader keeps its honest advisory-`unknown`
+ * rather than serving a fabricated one). This mirrors the ledger-store discipline (a ledger write must
+ * never fail synthesis / a cycle).
+ */
+
+/**
+ * @summary Produce + persist the current advisory boot-identity fact. Called per scheduler cycle with
+ * the orchestrator-constructed source; safe to call unconditionally (it no-ops on missing inputs).
+ * @param {Object} options
+ * @param {Object} options.source A boot-identity source exposing async `produceBootIdentityFact()`
+ *     (the orchestrator's `BootIdentityHealthService`).
+ * @param {String} options.dir The shared runtime-state directory the fleet reader also reads.
+ * @param {Function} [options.writeImpl=writeBootIdentityFact] The store writer seam (injected in specs).
+ * @returns {Promise<Object|null>} the persisted fact, or `null` when nothing was written.
+ */
+export async function recordBootIdentityFact({source, dir, writeImpl = writeBootIdentityFact} = {}) {
+    try {
+        if (!source || typeof source.produceBootIdentityFact !== 'function') {
+            return null;
+        }
+        if (typeof dir !== 'string' || dir.length === 0) {
+            return null;
+        }
+
+        const fact = await source.produceBootIdentityFact();
+
+        if (!fact || typeof fact !== 'object') {
+            return null;
+        }
+
+        await writeImpl(fact, {dir});
+
+        return fact;
+    } catch (error) {
+        return null; // fail-soft: never gate a scheduler cycle on a boot-identity write
+    }
+}

--- a/ai/daemons/orchestrator/services/recordBootIdentityFact.mjs
+++ b/ai/daemons/orchestrator/services/recordBootIdentityFact.mjs
@@ -6,10 +6,13 @@ import {writeBootIdentityFact} from './bootIdentityFactStore.mjs';
  * surface: produce the current advisory fact from the boot-identity source and persist it to the shared
  * runtime-state file, so the separate fleet-bridge-server process can read it via `FleetControlBridge`.
  *
- * **Fail-soft — observability, never a gate.** A produce/write error is swallowed so it can NEVER break
- * a scheduler cycle; an absent/null fact is not written (the reader keeps its honest advisory-`unknown`
- * rather than serving a fabricated one). This mirrors the ledger-store discipline (a ledger write must
- * never fail synthesis / a cycle).
+ * **Fail-soft, but OBSERVABLE.** A produce/write error can NEVER break a scheduler cycle — but it is no
+ * longer swallowed blind: a genuine produce/write throw is routed to an injected `onError` (default
+ * no-op) before the fail-soft `null` return, so a persistent write failure is loggable rather than
+ * silent. (The prior shape caught the error internally AND returned `null`, so a caller's `.catch()`
+ * was dead code and the failure was invisible.) A NO-OP condition — a missing source / produce method /
+ * dir, or an absent fact — returns `null` quietly: it is not an error, so it does not fire `onError`
+ * (the reader simply keeps its honest advisory-`unknown`).
  */
 
 /**
@@ -20,27 +23,35 @@ import {writeBootIdentityFact} from './bootIdentityFactStore.mjs';
  *     (the orchestrator's `BootIdentityHealthService`).
  * @param {String} options.dir The shared runtime-state directory the fleet reader also reads.
  * @param {Function} [options.writeImpl=writeBootIdentityFact] The store writer seam (injected in specs).
+ * @param {Function} [options.onError] Observability sink for a genuine produce/write error; called with
+ *     the error before the fail-soft `null` return. Never fires on a no-op. An `onError` that itself
+ *     throws is swallowed (an observer must not gate the cycle either).
  * @returns {Promise<Object|null>} the persisted fact, or `null` when nothing was written.
  */
-export async function recordBootIdentityFact({source, dir, writeImpl = writeBootIdentityFact} = {}) {
-    try {
-        if (!source || typeof source.produceBootIdentityFact !== 'function') {
-            return null;
-        }
-        if (typeof dir !== 'string' || dir.length === 0) {
-            return null;
-        }
+export async function recordBootIdentityFact({source, dir, writeImpl = writeBootIdentityFact, onError} = {}) {
+    if (!source || typeof source.produceBootIdentityFact !== 'function') {
+        return null; // no-op: nothing to produce (not an error)
+    }
+    if (typeof dir !== 'string' || dir.length === 0) {
+        return null; // no-op: nowhere to write (not an error)
+    }
 
+    try {
         const fact = await source.produceBootIdentityFact();
 
         if (!fact || typeof fact !== 'object') {
-            return null;
+            return null; // no-op: an absent fact is not written (reader keeps its honest advisory-unknown)
         }
 
         await writeImpl(fact, {dir});
 
         return fact;
     } catch (error) {
-        return null; // fail-soft: never gate a scheduler cycle on a boot-identity write
+        // fail-soft: never gate a scheduler cycle on a boot-identity write — but surface the error so a
+        // persistent produce/write failure is observable rather than silent.
+        if (typeof onError === 'function') {
+            try { onError(error) } catch (observerError) { /* an observer must never gate the cycle either */ }
+        }
+        return null;
     }
 }

--- a/ai/services/fleet/createBootIdentityReadSource.mjs
+++ b/ai/services/fleet/createBootIdentityReadSource.mjs
@@ -28,13 +28,17 @@ const UNKNOWN_FACT = Object.freeze({
  * @summary Build a boot-identity read-source over the shared fact-file.
  * @param {Object} options
  * @param {String} options.dir The shared runtime-state directory the orchestrator writes the fact to.
+ * @param {Number} [options.maxAgeMs] Staleness horizon forwarded to the store read; omit to use the
+ *     store's default. This is the mechanical override point the store's contract refers to.
  * @param {Function} [options.readImpl=readBootIdentityFact] The store reader seam (injected in specs).
  * @returns {{produceBootIdentityFact: Function}} the read-source `FleetControlBridge.bootIdentitySource` expects.
  */
-export function createBootIdentityReadSource({dir, readImpl = readBootIdentityFact} = {}) {
+export function createBootIdentityReadSource({dir, maxAgeMs, readImpl = readBootIdentityFact} = {}) {
     return {
         async produceBootIdentityFact() {
-            const fact = await readImpl({dir});
+            // Pass maxAgeMs through so the wiring can tighten/relax the staleness horizon; `undefined`
+            // falls back to the store's default (readBootIdentityFact's own maxAgeMs default).
+            const fact = await readImpl({dir, maxAgeMs});
 
             // A fresh copy of the fallback so a caller can never mutate the shared frozen constant.
             return fact && typeof fact === 'object' ? fact : {...UNKNOWN_FACT};

--- a/ai/services/fleet/createBootIdentityReadSource.mjs
+++ b/ai/services/fleet/createBootIdentityReadSource.mjs
@@ -1,0 +1,43 @@
+import {readBootIdentityFact} from '../../daemons/orchestrator/services/bootIdentityFactStore.mjs';
+
+/**
+ * @module ai/services/fleet/createBootIdentityReadSource
+ * @summary The fleet-server-side READER half of the cross-process advisory boot-identity surface.
+ * `FleetControlBridge` runs in the separate fleet-bridge-server process, so
+ * the orchestrator (which owns the boot-identity fact + the REM/scheduler surfaces) cannot inject its
+ * live source there directly in the dev (Option-B) path. Instead the orchestrator WRITES its latest
+ * advisory fact to a shared runtime-state file (`bootIdentityFactStore`), and this factory builds the
+ * read-source `FleetControlBridge.bootIdentitySource` expects: an object exposing
+ * `produceBootIdentityFact()` that reads that file and returns the persisted advisory fact, or an honest
+ * advisory-`unknown` when it is absent/unreadable.
+ *
+ * **Mode-agnostic + read-only.** It mirrors the in-process `BootIdentityHealthService.produceBootIdentityFact()`
+ * contract, so the consumer seam is identical whether the source is the live service (in-process Electron,
+ * Option A) or this file reader (cross-process dev, Option B). READ-ONLY advisory: it never carries a
+ * restart command (R3), and an absent fact is `unknown`, never fabricated liveness.
+ */
+
+const UNKNOWN_FACT = Object.freeze({
+    fact          : null,
+    classification: 'unknown',
+    advisory      : true,
+    reason        : 'no-boot-identity-fact-file'
+});
+
+/**
+ * @summary Build a boot-identity read-source over the shared fact-file.
+ * @param {Object} options
+ * @param {String} options.dir The shared runtime-state directory the orchestrator writes the fact to.
+ * @param {Function} [options.readImpl=readBootIdentityFact] The store reader seam (injected in specs).
+ * @returns {{produceBootIdentityFact: Function}} the read-source `FleetControlBridge.bootIdentitySource` expects.
+ */
+export function createBootIdentityReadSource({dir, readImpl = readBootIdentityFact} = {}) {
+    return {
+        async produceBootIdentityFact() {
+            const fact = await readImpl({dir});
+
+            // A fresh copy of the fallback so a caller can never mutate the shared frozen constant.
+            return fact && typeof fact === 'object' ? fact : {...UNKNOWN_FACT};
+        }
+    };
+}

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -17,17 +17,24 @@
 
 // Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate globalThis.Neo so
 // the fleet singletons' `Neo.setupClass` succeeds at module-load; `InstanceManager` binds the aliases.
-import Neo                      from '../../../src/Neo.mjs';
-import * as core                from '../../../src/core/_export.mjs';
-import InstanceManager          from '../../../src/manager/Instance.mjs';
-import {startFleetBridgeServer} from './fleetBridgeServer.mjs';
-import {pathToFileURL}          from 'node:url';
+import Neo                          from '../../../src/Neo.mjs';
+import * as core                    from '../../../src/core/_export.mjs';
+import InstanceManager              from '../../../src/manager/Instance.mjs';
+import AiConfig                     from '../../config.mjs';
+import {startFleetBridgeServer}     from './fleetBridgeServer.mjs';
+import {wireBootIdentityReadSource} from './wireBootIdentityReadSource.mjs';
+import {pathToFileURL}              from 'node:url';
 
 const port = Number(process.env.NEO_FLEET_PORT) || 8083;
 
 // Process-entry only: start + register signal handlers ONLY when this file is the main module, never
 // on import — preserves the process-entry isolation invariant (mirrors the orchestrator/kb daemons).
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    // Wire the cross-process boot-identity reader BEFORE serving: getBootIdentity() then serves the
+    // orchestrator's advisory fact from the shared runtime-state dir (read at this use site), instead of
+    // the advisory-unknown fallback. Fail-soft — an absent dir leaves the seam honestly unwired.
+    wireBootIdentityReadSource({dir: AiConfig.orchestrator.dataDir});
+
     startFleetBridgeServer({port})
         .then(server => {
             const cleanShutdown = signal => {

--- a/ai/services/fleet/wireBootIdentityReadSource.mjs
+++ b/ai/services/fleet/wireBootIdentityReadSource.mjs
@@ -21,16 +21,18 @@ import {createBootIdentityReadSource} from './createBootIdentityReadSource.mjs';
  * @param {Object} options
  * @param {String} options.dir The shared runtime-state directory the orchestrator writes the fact to
  *     (read from `AiConfig.orchestrator.dataDir` at the caller's boot use site).
+ * @param {Number} [options.maxAgeMs] Staleness horizon forwarded to the read-source; omit for the
+ *     store default. Threaded so the fleet-server boot can tighten/relax the horizon from config.
  * @param {Object} [options.bridge=FleetControlBridge] The control bridge to wire (a stub in specs).
  * @param {Function} [options.createSource=createBootIdentityReadSource] The read-source factory (injected in specs).
  * @returns {Object|null} the wired read-source, or `null` when no dir was supplied (left unwired).
  */
-export function wireBootIdentityReadSource({dir, bridge = FleetControlBridge, createSource = createBootIdentityReadSource} = {}) {
+export function wireBootIdentityReadSource({dir, maxAgeMs, bridge = FleetControlBridge, createSource = createBootIdentityReadSource} = {}) {
     if (typeof dir !== 'string' || dir.length === 0) {
         return null; // no shared dir → leave the seam unwired (honest advisory-unknown), never fabricate a source
     }
 
-    bridge.bootIdentitySource = createSource({dir});
+    bridge.bootIdentitySource = createSource({dir, maxAgeMs});
 
     return bridge.bootIdentitySource;
 }

--- a/ai/services/fleet/wireBootIdentityReadSource.mjs
+++ b/ai/services/fleet/wireBootIdentityReadSource.mjs
@@ -1,0 +1,36 @@
+import FleetControlBridge             from './FleetControlBridge.mjs';
+import {createBootIdentityReadSource} from './createBootIdentityReadSource.mjs';
+
+/**
+ * @module ai/services/fleet/wireBootIdentityReadSource
+ * @summary Injects the cross-process boot-identity READER into `FleetControlBridge.bootIdentitySource`
+ * at the fleet-bridge-server boot, so `getBootIdentity()` serves the orchestrator's advisory fact
+ * (written to the shared runtime-state file by the orchestrator process) instead of the honest
+ * advisory-`unknown` fallback. This is the composition point the read-observe seam always assumed but
+ * nothing supplied — the fleet server and the orchestrator are separate processes in the dev (Option-B)
+ * path, so the source is wired here, from the shared dir, rather than injected in-process.
+ *
+ * **Read-at-use-site.** The caller (the fleet-server process entry) reads
+ * `AiConfig.orchestrator.dataDir` at the boot call and passes it in; this function owns no config
+ * default and captures no leaf. **Fail-soft:** an absent/empty dir leaves `bootIdentitySource` unwired
+ * (the seam keeps its honest advisory-`unknown`), never a fabricated source.
+ */
+
+/**
+ * @summary Wire the boot-identity read-source onto the fleet control bridge.
+ * @param {Object} options
+ * @param {String} options.dir The shared runtime-state directory the orchestrator writes the fact to
+ *     (read from `AiConfig.orchestrator.dataDir` at the caller's boot use site).
+ * @param {Object} [options.bridge=FleetControlBridge] The control bridge to wire (a stub in specs).
+ * @param {Function} [options.createSource=createBootIdentityReadSource] The read-source factory (injected in specs).
+ * @returns {Object|null} the wired read-source, or `null` when no dir was supplied (left unwired).
+ */
+export function wireBootIdentityReadSource({dir, bridge = FleetControlBridge, createSource = createBootIdentityReadSource} = {}) {
+    if (typeof dir !== 'string' || dir.length === 0) {
+        return null; // no shared dir → leave the seam unwired (honest advisory-unknown), never fabricate a source
+    }
+
+    bridge.bootIdentitySource = createSource({dir});
+
+    return bridge.bootIdentitySource;
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/Orchestrator.spec.mjs
@@ -14,6 +14,9 @@ import {
     buildTaskDefinitions
 } from '../../../../../../ai/daemons/orchestrator/taskDefinitions.mjs';
 import TaskStateService, { createInitialTaskState } from '../../../../../../ai/daemons/orchestrator/services/TaskStateService.mjs';
+import os                                           from 'os';
+import {createBootIdentityReadSource}               from '../../../../../../ai/services/fleet/createBootIdentityReadSource.mjs';
+import {BOOT_FRESHNESS_CLASS}                       from '../../../../../../ai/daemons/orchestrator/services/bootIdentityFreshness.mjs';
 
 let   testOrchestratorSeq            = 0;
 const TEST_DEV_SERVER_PORT           = 18080;
@@ -226,6 +229,33 @@ function restoreConfigObject(target, prior) {
 }
 
 test.describe('Neo.ai.daemons.Orchestrator (#11009)', () => {
+    test('boot-identity caller seam: initBootIdentitySource() + poll() writes a codebook-valid advisory fact the fleet reader serves', async () => {
+        const dir          = fs.mkdtempSync(path.join(os.tmpdir(), 'orch-boot-identity-')),
+              orchestrator = createTestOrchestrator();
+
+        orchestrator.dataDir = dir; // the shared runtime-state dir the fleet reader also reads
+
+        // Both are REAL Orchestrator methods (no free-helper replay): initBootIdentitySource() composes the
+        // source with the orchestrator's OWN cadence getter + process-boot time (exactly what start() calls);
+        // poll() persists it via recordBootIdentityFact(this.bootIdentitySource, this.dataDir, onError).
+        orchestrator.initBootIdentitySource();
+        expect(typeof orchestrator.bootIdentitySource.produceBootIdentityFact).toBe('function');
+
+        orchestrator.poll();
+
+        // poll() writes fire-and-forget → wait for the shared file, then read it back through the fleet seam.
+        await expect.poll(async () =>
+            (await createBootIdentityReadSource({dir}).produceBootIdentityFact()).reason
+        ).not.toBe('no-boot-identity-fact-file');
+
+        const served = await createBootIdentityReadSource({dir}).produceBootIdentityFact();
+        expect(Object.values(BOOT_FRESHNESS_CLASS)).toContain(served.classification); // a real codebook class, cross-process
+        expect(served.advisory).toBe(true);                                           // read-observe advisory, never a command
+        expect(typeof served.reason).toBe('string');
+
+        fs.rmSync(dir, {recursive: true, force: true});
+    });
+
     test('creates an isolated persisted-state envelope per task', () => {
         const state = createInitialTaskState(buildTaskDefinitions({
             scriptDir                        : '/repo/ai/scripts',

--- a/test/playwright/unit/ai/daemons/orchestrator/services/bootIdentityFactStore.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/bootIdentityFactStore.spec.mjs
@@ -1,9 +1,10 @@
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../../src/core/_export.mjs';
-import fs             from 'fs/promises';
-import os             from 'os';
-import path           from 'path';
+import {test, expect}         from '@playwright/test';
+import Neo                    from '../../../../../../../src/Neo.mjs';
+import * as core              from '../../../../../../../src/core/_export.mjs';
+import fs                     from 'fs/promises';
+import os                     from 'os';
+import path                   from 'path';
+import {BOOT_FRESHNESS_CLASS} from '../../../../../../../ai/daemons/orchestrator/services/bootIdentityFreshness.mjs';
 import {
     BOOT_IDENTITY_FACT_VERSION,
     getBootIdentityFactFilePath,
@@ -17,31 +18,32 @@ async function tmpDir() {
     return await fs.mkdtemp(path.join(os.tmpdir(), 'boot-identity-fact-'));
 }
 
-// The full produceBootIdentityFact() shape the orchestrator persists.
-const fact = (sourceRef, classification) => ({
+// The full produceBootIdentityFact() shape the orchestrator persists — classification is a member of the
+// producer's canonical BOOT_FRESHNESS_CLASS codebook (the read path validates against it).
+const fact = (sourceRef, classification = BOOT_FRESHNESS_CLASS.designedDeferral) => ({
     fact    : {bootAt: 1000, sourceRef, schedulerResumeState: 'none', lastCycleRef: 'rem-1', lastCycleAt: 2000},
     classification,
     advisory: true,
-    reason  : 'fresh'
+    reason  : 'within-cadence-margin'
 });
 
 test.describe('bootIdentityFactStore — the cross-process advisory boot-identity fact carrier (#15079)', () => {
     test('write → read round-trips the latest fact', async () => {
         const dir = await tmpDir();
-        await writeBootIdentityFact(fact('abc123', 'current'), {dir});
+        await writeBootIdentityFact(fact('abc123'), {dir});
 
         const read = await readBootIdentityFact({dir});
-        expect(read).toMatchObject({classification: 'current', advisory: true, fact: {sourceRef: 'abc123', bootAt: 1000}});
+        expect(read).toMatchObject({classification: 'designed-deferral', advisory: true, fact: {sourceRef: 'abc123', bootAt: 1000}});
         await fs.rm(dir, {recursive: true, force: true});
     });
 
     test('write is latest-wins (overwrite, not append)', async () => {
         const dir = await tmpDir();
-        await writeBootIdentityFact(fact('old', 'stale-suspected'), {dir});
-        await writeBootIdentityFact(fact('new', 'current'), {dir});
+        await writeBootIdentityFact(fact('old', BOOT_FRESHNESS_CLASS.restartExplains), {dir});
+        await writeBootIdentityFact(fact('new', BOOT_FRESHNESS_CLASS.designedDeferral), {dir});
 
         const read = await readBootIdentityFact({dir});
-        expect(read.classification).toBe('current');
+        expect(read.classification).toBe('designed-deferral');
         expect(read.fact.sourceRef).toBe('new');
         await fs.rm(dir, {recursive: true, force: true});
     });
@@ -72,12 +74,26 @@ test.describe('bootIdentityFactStore — the cross-process advisory boot-identit
         await fs.rm(dir, {recursive: true, force: true});
     });
 
-    // --- cross-process snapshot contract: versioned envelope, atomic replace, stale-aware ---
+    // --- cross-process snapshot contract: versioned envelope, atomic replace, codebook + stale-aware ---
+
+    test('CONCURRENT writers do not corrupt the snapshot — unique per-write temps, a valid final read', async () => {
+        const dir = await tmpDir();
+        // Overlapping writes (a poll racing a restart) must never share a temp path; the final read is a
+        // single valid snapshot, never a torn / ENOENT-orphaned file. A fixed .tmp name fails this.
+        await Promise.all(Array.from({length: 40}, (_, i) => writeBootIdentityFact(fact(`w${i}`), {dir})));
+
+        const read    = await readBootIdentityFact({dir});
+        const entries = await fs.readdir(dir);
+        expect(read).not.toBeNull();                                  // a readable, valid final snapshot survived the race
+        expect(read.classification).toBe('designed-deferral');
+        expect(entries.filter(f => f.endsWith('.tmp'))).toHaveLength(0); // no orphaned temps
+        await fs.rm(dir, {recursive: true, force: true});
+    });
 
     test('STALE prior-process snapshot → an explicit unknown advisory, never served as live', async () => {
         const dir = await tmpDir();
         // stamp generatedAt at t=1_000_000 (injected clock)…
-        await writeBootIdentityFact(fact('abc', 'current'), {dir, nowFn: () => 1_000_000});
+        await writeBootIdentityFact(fact('abc'), {dir, nowFn: () => 1_000_000});
         // …then read 7h later — past the default 6h staleness horizon (the producing process is gone).
         const read = await readBootIdentityFact({dir, nowFn: () => 1_000_000 + 7 * 60 * 60 * 1000});
         expect(read).toEqual({fact: null, classification: 'unknown', advisory: true, reason: 'stale-boot-identity-fact'});
@@ -86,48 +102,65 @@ test.describe('bootIdentityFactStore — the cross-process advisory boot-identit
 
     test('a FRESH snapshot within the horizon is served as-is (staleness is a boundary, not a blanket)', async () => {
         const dir = await tmpDir();
-        await writeBootIdentityFact(fact('abc', 'current'), {dir, nowFn: () => 1_000_000});
+        await writeBootIdentityFact(fact('abc'), {dir, nowFn: () => 1_000_000});
         const read = await readBootIdentityFact({dir, nowFn: () => 1_000_000 + 60_000}); // 1 min later
-        expect(read.classification).toBe('current');
+        expect(read.classification).toBe('designed-deferral');
         expect(read.fact.sourceRef).toBe('abc');
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('a NON-CODEBOOK classification → null (codebook validation, never a fabricated class served as real)', async () => {
+        const dir = await tmpDir();
+        // A structurally-fine envelope whose classification is NOT a BOOT_FRESHNESS_CLASS member must be rejected.
+        await fs.writeFile(getBootIdentityFactFilePath(dir),
+            JSON.stringify({v: BOOT_IDENTITY_FACT_VERSION, generatedAt: 1_000_000, fact: {classification: 'current', advisory: true, reason: 'x'}}), 'utf8');
+        expect(await readBootIdentityFact({dir, nowFn: () => 1_000_000})).toBeNull();
+
+        // advisory:false is likewise out of contract (the surface is advisory-only, never a certainty verdict).
+        await fs.writeFile(getBootIdentityFactFilePath(dir),
+            JSON.stringify({v: BOOT_IDENTITY_FACT_VERSION, generatedAt: 1_000_000, fact: {classification: 'unknown', advisory: false, reason: 'x'}}), 'utf8');
+        expect(await readBootIdentityFact({dir, nowFn: () => 1_000_000})).toBeNull();
         await fs.rm(dir, {recursive: true, force: true});
     });
 
     test('a WRONG-VERSION / raw pre-envelope file → null (schema validation, never garbage-as-fact)', async () => {
         const dir = await tmpDir();
         // a raw pre-envelope fact (no {v, generatedAt}) must not be mis-served as a live fact
-        await fs.writeFile(getBootIdentityFactFilePath(dir), JSON.stringify(fact('x', 'current')), 'utf8');
+        await fs.writeFile(getBootIdentityFactFilePath(dir), JSON.stringify(fact('x')), 'utf8');
         expect(await readBootIdentityFact({dir})).toBeNull();
         // an explicitly wrong version
         await fs.writeFile(getBootIdentityFactFilePath(dir),
-            JSON.stringify({v: 999, generatedAt: 1_000_000, fact: {classification: 'current', advisory: true}}), 'utf8');
+            JSON.stringify({v: 999, generatedAt: 1_000_000, fact: {classification: 'unknown', advisory: true, reason: 'x'}}), 'utf8');
         expect(await readBootIdentityFact({dir, nowFn: () => 1_000_000})).toBeNull();
         await fs.rm(dir, {recursive: true, force: true});
     });
 
     test('write fails LOUD (RangeError) on an oversized envelope — the byte bound', async () => {
         const dir  = await tmpDir();
-        const huge = {fact: {bootAt: 1, sourceRef: 'x'.repeat(MAX_FACT_BYTES + 100)}, classification: 'current', advisory: true, reason: 'r'};
+        const huge = {fact: {bootAt: 1, sourceRef: 'x'.repeat(MAX_FACT_BYTES + 100)}, classification: 'designed-deferral', advisory: true, reason: 'r'};
         await expect(writeBootIdentityFact(huge, {dir})).rejects.toThrow(/exceeds \d+ bytes/);
         await fs.rm(dir, {recursive: true, force: true});
     });
 
     test('write is ATOMIC — a successful write leaves the target and no .tmp residue', async () => {
         const dir = await tmpDir();
-        await writeBootIdentityFact(fact('abc', 'current'), {dir});
+        await writeBootIdentityFact(fact('abc'), {dir});
         const entries = await fs.readdir(dir);
         expect(entries).toContain('boot-identity-fact.json');
         expect(entries.filter(f => f.endsWith('.tmp'))).toHaveLength(0);
         await fs.rm(dir, {recursive: true, force: true});
     });
 
-    test('isValidBootIdentityEnvelope discriminates the on-disk contract', () => {
-        const good = {v: BOOT_IDENTITY_FACT_VERSION, generatedAt: 1, fact: {classification: 'current', advisory: true}};
+    test('isValidBootIdentityEnvelope discriminates the on-disk contract (version + codebook + advisory + reason)', () => {
+        const good = {v: BOOT_IDENTITY_FACT_VERSION, generatedAt: 1, fact: {classification: BOOT_FRESHNESS_CLASS.designedDeferral, advisory: true, reason: 'r'}};
         expect(isValidBootIdentityEnvelope(good)).toBe(true);
         expect(isValidBootIdentityEnvelope(null)).toBe(false);
-        expect(isValidBootIdentityEnvelope({...good, v: BOOT_IDENTITY_FACT_VERSION + 1})).toBe(false); // wrong version
-        expect(isValidBootIdentityEnvelope({...good, generatedAt: NaN})).toBe(false);                  // no finite generation ts
-        expect(isValidBootIdentityEnvelope({...good, fact: null})).toBe(false);                        // no fact
-        expect(isValidBootIdentityEnvelope({...good, fact: {advisory: true}})).toBe(false);            // fact missing classification
+        expect(isValidBootIdentityEnvelope({...good, v: BOOT_IDENTITY_FACT_VERSION + 1})).toBe(false);                     // wrong version
+        expect(isValidBootIdentityEnvelope({...good, generatedAt: NaN})).toBe(false);                                     // no finite generation ts
+        expect(isValidBootIdentityEnvelope({...good, fact: null})).toBe(false);                                           // no fact
+        expect(isValidBootIdentityEnvelope({...good, fact: {advisory: true, reason: 'r'}})).toBe(false);                  // missing classification
+        expect(isValidBootIdentityEnvelope({...good, fact: {classification: 'current', advisory: true, reason: 'r'}})).toBe(false); // non-codebook class
+        expect(isValidBootIdentityEnvelope({...good, fact: {classification: BOOT_FRESHNESS_CLASS.unknown, advisory: false, reason: 'r'}})).toBe(false); // advisory:false
+        expect(isValidBootIdentityEnvelope({...good, fact: {classification: BOOT_FRESHNESS_CLASS.unknown, advisory: true, reason: ''}})).toBe(false);   // empty reason
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/bootIdentityFactStore.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/bootIdentityFactStore.spec.mjs
@@ -5,9 +5,12 @@ import fs             from 'fs/promises';
 import os             from 'os';
 import path           from 'path';
 import {
+    BOOT_IDENTITY_FACT_VERSION,
     getBootIdentityFactFilePath,
-    writeBootIdentityFact,
-    readBootIdentityFact
+    isValidBootIdentityEnvelope,
+    MAX_FACT_BYTES,
+    readBootIdentityFact,
+    writeBootIdentityFact
 } from '../../../../../../../ai/daemons/orchestrator/services/bootIdentityFactStore.mjs';
 
 async function tmpDir() {
@@ -67,5 +70,64 @@ test.describe('bootIdentityFactStore — the cross-process advisory boot-identit
         await expect(writeBootIdentityFact(null, {dir})).rejects.toThrow('fact object is required');
         await expect(writeBootIdentityFact({fact: null}, {})).rejects.toThrow('dir is required');
         await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    // --- cross-process snapshot contract: versioned envelope, atomic replace, stale-aware ---
+
+    test('STALE prior-process snapshot → an explicit unknown advisory, never served as live', async () => {
+        const dir = await tmpDir();
+        // stamp generatedAt at t=1_000_000 (injected clock)…
+        await writeBootIdentityFact(fact('abc', 'current'), {dir, nowFn: () => 1_000_000});
+        // …then read 7h later — past the default 6h staleness horizon (the producing process is gone).
+        const read = await readBootIdentityFact({dir, nowFn: () => 1_000_000 + 7 * 60 * 60 * 1000});
+        expect(read).toEqual({fact: null, classification: 'unknown', advisory: true, reason: 'stale-boot-identity-fact'});
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('a FRESH snapshot within the horizon is served as-is (staleness is a boundary, not a blanket)', async () => {
+        const dir = await tmpDir();
+        await writeBootIdentityFact(fact('abc', 'current'), {dir, nowFn: () => 1_000_000});
+        const read = await readBootIdentityFact({dir, nowFn: () => 1_000_000 + 60_000}); // 1 min later
+        expect(read.classification).toBe('current');
+        expect(read.fact.sourceRef).toBe('abc');
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('a WRONG-VERSION / raw pre-envelope file → null (schema validation, never garbage-as-fact)', async () => {
+        const dir = await tmpDir();
+        // a raw pre-envelope fact (no {v, generatedAt}) must not be mis-served as a live fact
+        await fs.writeFile(getBootIdentityFactFilePath(dir), JSON.stringify(fact('x', 'current')), 'utf8');
+        expect(await readBootIdentityFact({dir})).toBeNull();
+        // an explicitly wrong version
+        await fs.writeFile(getBootIdentityFactFilePath(dir),
+            JSON.stringify({v: 999, generatedAt: 1_000_000, fact: {classification: 'current', advisory: true}}), 'utf8');
+        expect(await readBootIdentityFact({dir, nowFn: () => 1_000_000})).toBeNull();
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('write fails LOUD (RangeError) on an oversized envelope — the byte bound', async () => {
+        const dir  = await tmpDir();
+        const huge = {fact: {bootAt: 1, sourceRef: 'x'.repeat(MAX_FACT_BYTES + 100)}, classification: 'current', advisory: true, reason: 'r'};
+        await expect(writeBootIdentityFact(huge, {dir})).rejects.toThrow(/exceeds \d+ bytes/);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('write is ATOMIC — a successful write leaves the target and no .tmp residue', async () => {
+        const dir = await tmpDir();
+        await writeBootIdentityFact(fact('abc', 'current'), {dir});
+        const entries = await fs.readdir(dir);
+        expect(entries).toContain('boot-identity-fact.json');
+        expect(entries.filter(f => f.endsWith('.tmp'))).toHaveLength(0);
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('isValidBootIdentityEnvelope discriminates the on-disk contract', () => {
+        const good = {v: BOOT_IDENTITY_FACT_VERSION, generatedAt: 1, fact: {classification: 'current', advisory: true}};
+        expect(isValidBootIdentityEnvelope(good)).toBe(true);
+        expect(isValidBootIdentityEnvelope(null)).toBe(false);
+        expect(isValidBootIdentityEnvelope({...good, v: BOOT_IDENTITY_FACT_VERSION + 1})).toBe(false); // wrong version
+        expect(isValidBootIdentityEnvelope({...good, generatedAt: NaN})).toBe(false);                  // no finite generation ts
+        expect(isValidBootIdentityEnvelope({...good, fact: null})).toBe(false);                        // no fact
+        expect(isValidBootIdentityEnvelope({...good, fact: {advisory: true}})).toBe(false);            // fact missing classification
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/bootIdentityFactStore.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/bootIdentityFactStore.spec.mjs
@@ -1,0 +1,71 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import fs             from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
+import {
+    getBootIdentityFactFilePath,
+    writeBootIdentityFact,
+    readBootIdentityFact
+} from '../../../../../../../ai/daemons/orchestrator/services/bootIdentityFactStore.mjs';
+
+async function tmpDir() {
+    return await fs.mkdtemp(path.join(os.tmpdir(), 'boot-identity-fact-'));
+}
+
+// The full produceBootIdentityFact() shape the orchestrator persists.
+const fact = (sourceRef, classification) => ({
+    fact    : {bootAt: 1000, sourceRef, schedulerResumeState: 'none', lastCycleRef: 'rem-1', lastCycleAt: 2000},
+    classification,
+    advisory: true,
+    reason  : 'fresh'
+});
+
+test.describe('bootIdentityFactStore — the cross-process advisory boot-identity fact carrier (#15079)', () => {
+    test('write → read round-trips the latest fact', async () => {
+        const dir = await tmpDir();
+        await writeBootIdentityFact(fact('abc123', 'current'), {dir});
+
+        const read = await readBootIdentityFact({dir});
+        expect(read).toMatchObject({classification: 'current', advisory: true, fact: {sourceRef: 'abc123', bootAt: 1000}});
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('write is latest-wins (overwrite, not append)', async () => {
+        const dir = await tmpDir();
+        await writeBootIdentityFact(fact('old', 'stale-suspected'), {dir});
+        await writeBootIdentityFact(fact('new', 'current'), {dir});
+
+        const read = await readBootIdentityFact({dir});
+        expect(read.classification).toBe('current');
+        expect(read.fact.sourceRef).toBe('new');
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('read of a MISSING file resolves to null — advisory-unknown, never a throw (control-plane never gated)', async () => {
+        const dir = await tmpDir();
+        expect(await readBootIdentityFact({dir})).toBeNull();
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('read of a CORRUPT file resolves to null — advisory-unknown, never a throw', async () => {
+        const dir = await tmpDir();
+        await fs.writeFile(getBootIdentityFactFilePath(dir), '{ not valid json', 'utf8');
+
+        expect(await readBootIdentityFact({dir})).toBeNull();
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('read with no dir resolves to null without throwing (defensive control-plane read)', async () => {
+        expect(await readBootIdentityFact({})).toBeNull();
+        expect(await readBootIdentityFact()).toBeNull();
+    });
+
+    test('write fails LOUD on a bad fact / missing dir (the orchestrator caller swallows it fail-soft, but a bug surfaces)', async () => {
+        const dir = await tmpDir();
+        await expect(writeBootIdentityFact(null, {dir})).rejects.toThrow('fact object is required');
+        await expect(writeBootIdentityFact({fact: null}, {})).rejects.toThrow('dir is required');
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/bootIdentityWiring.integration.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/bootIdentityWiring.integration.spec.mjs
@@ -1,0 +1,79 @@
+import {test, expect}                 from '@playwright/test';
+import Neo                            from '../../../../../../../src/Neo.mjs';
+import * as core                      from '../../../../../../../src/core/_export.mjs';
+import fs                             from 'fs/promises';
+import os                             from 'os';
+import path                           from 'path';
+import {buildBootIdentitySource}      from '../../../../../../../ai/daemons/orchestrator/services/buildBootIdentitySource.mjs';
+import {recordBootIdentityFact}       from '../../../../../../../ai/daemons/orchestrator/services/recordBootIdentityFact.mjs';
+import {createBootIdentityReadSource} from '../../../../../../../ai/services/fleet/createBootIdentityReadSource.mjs';
+
+/**
+ * Caller-level integration for the boot-identity wiring. Exercises the EXACT chain
+ * `Orchestrator.start()` composes + `poll()` persists + the separate fleet-bridge-server process reads:
+ *
+ *   buildBootIdentitySource(...)  →  recordBootIdentityFact(...)  →  shared file  →  createBootIdentityReadSource(...)
+ *
+ * over a shared tmp dir, proving the DEFAULT path (a real REM cadence threaded as `freshnessConfig`)
+ * produces a NON-`unknown` fact for both worked cases Euclid named — restart-explains-gap and
+ * designed-deferral — and that the fact survives the cross-process round-trip to the reader. This is the
+ * caller seam without a heavy, flaky full-daemon boot: the composition + carrier + reader are the entire
+ * live surface `start()`/`poll()` touch; the daemon around them adds only unrelated services.
+ */
+test.describe('boot-identity wiring — the Orchestrator.start/poll → shared-file → fleet-read chain (#15079)', () => {
+    async function tmpDir() {
+        return await fs.mkdtemp(path.join(os.tmpdir(), 'boot-identity-wiring-'));
+    }
+
+    // The composition Orchestrator.start() performs (real freshnessConfig + bootAt), with an injected
+    // gatherer standing in for the REM-run-state read so a single cycle is deterministic.
+    function buildSource({dir, now, cadence, lastCycleAt, bootAt, schedulerResumeState = 'none'}) {
+        return buildBootIdentitySource({
+            remRunStateDir : dir,
+            freshnessConfig: {designedCadenceMs: cadence, marginMs: 0},
+            bootAt,
+            nowFn          : () => now,
+            createGatherer : ({bootAt: b}) => async () => ({bootAt: b, lastCycleAt, schedulerResumeState})
+        });
+    }
+
+    test('restart-explains-gap: boot AFTER a long-ago last cycle → non-unknown, round-trips to the fleet reader', async () => {
+        const dir = await tmpDir();
+
+        // A 9h gap (10h now − 1h last cycle) far exceeds the 6h cadence, and the process booted (2h) AFTER
+        // the last cycle with an un-re-armed scheduler → a restart explains it.
+        const source  = buildSource({dir, now: 10 * 3600_000, cadence: 6 * 3600_000, lastCycleAt: 1 * 3600_000, bootAt: 2 * 3600_000});
+        const written = await recordBootIdentityFact({source, dir}); // poll() writes to the shared dir
+        expect(written.classification).toBe('restart-explains-gap'); // non-unknown at the producer
+
+        const served = await createBootIdentityReadSource({dir}).produceBootIdentityFact(); // the fleet server reads back
+        expect(served.classification).toBe('restart-explains-gap'); // survives the cross-process round-trip
+        expect(served.advisory).toBe(true);                         // read-observe advisory, never a restart command
+
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('designed-deferral: a last cycle within cadence → non-unknown designed-deferral across the boundary', async () => {
+        const dir = await tmpDir();
+
+        const source = buildSource({dir, now: 6000, cadence: 60_000, lastCycleAt: 5000, bootAt: 100});
+        await recordBootIdentityFact({source, dir});
+
+        const served = await createBootIdentityReadSource({dir}).produceBootIdentityFact();
+        expect(served.classification).toBe('designed-deferral');
+
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+
+    test('the unwired seam (no source) writes nothing → the reader keeps its honest advisory-unknown', async () => {
+        const dir = await tmpDir();
+
+        await recordBootIdentityFact({source: null, dir}); // no-op — nothing is written
+
+        const served = await createBootIdentityReadSource({dir}).produceBootIdentityFact();
+        expect(served.classification).toBe('unknown');
+        expect(served.reason).toBe('no-boot-identity-fact-file');
+
+        await fs.rm(dir, {recursive: true, force: true});
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/buildBootIdentitySource.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/buildBootIdentitySource.spec.mjs
@@ -1,7 +1,10 @@
 import {test, expect}            from '@playwright/test';
 import Neo                       from '../../../../../../../src/Neo.mjs';
 import * as core                 from '../../../../../../../src/core/_export.mjs';
+import fs                        from 'fs/promises';
 import {buildBootIdentitySource} from '../../../../../../../ai/daemons/orchestrator/services/buildBootIdentitySource.mjs';
+
+const MODULE_URL = new URL('../../../../../../../ai/daemons/orchestrator/services/buildBootIdentitySource.mjs', import.meta.url);
 
 test.describe('buildBootIdentitySource — the orchestrator-side boot-identity source composition (#15079)', () => {
     test('constructs a source that produces an advisory fact, building the gatherer with bootAt + the REM dir', async () => {
@@ -31,5 +34,36 @@ test.describe('buildBootIdentitySource — the orchestrator-side boot-identity s
     test('FAIL-SOFT: a failed service construction returns null', () => {
         // Neo.create(null, ...) throws → caught → null (the orchestrator then simply never writes a fact)
         expect(buildBootIdentitySource({remRunStateDir: '/rem', createGatherer: () => async () => ({}), ServiceClass: null})).toBeNull();
+    });
+
+    // --- global-Neo (no non-entrypoint import) + the real freshness composition ---
+
+    test('ADR-0019 C1: the module has NO non-entrypoint `import Neo` (it uses the global Neo)', async () => {
+        const src = await fs.readFile(MODULE_URL, 'utf8');
+        expect(src).not.toMatch(/^\s*import\s+Neo\b/m); // a non-entrypoint `import Neo` is the C1 forbidden pattern
+    });
+
+    test('threads freshnessConfig so the classifier yields a real (non-unknown) verdict on a live cadence', async () => {
+        // A last cycle 1s ago against a 60s cadence → designed-deferral (NOT the perpetual `unknown` of cfg={}).
+        const createGatherer = () => async () => ({bootAt: 1000, lastCycleAt: 5000, schedulerResumeState: 'none'});
+
+        const source = buildBootIdentitySource({
+            remRunStateDir : '/rem',
+            freshnessConfig: {designedCadenceMs: 60_000, marginMs: 0},
+            nowFn          : () => 6000,
+            createGatherer
+        });
+
+        const result = await source.produceBootIdentityFact();
+        expect(result.classification).toBe('designed-deferral'); // the cadence is threaded → non-unknown
+        expect(result.advisory).toBe(true);
+    });
+
+    test('WITHOUT a freshnessConfig the classifier stays `unknown` (the gap the wiring closes)', async () => {
+        const createGatherer = () => async () => ({bootAt: 1000, lastCycleAt: 5000, schedulerResumeState: 'none'});
+
+        const source = buildBootIdentitySource({remRunStateDir: '/rem', nowFn: () => 6000, createGatherer});
+        const result = await source.produceBootIdentityFact();
+        expect(result.classification).toBe('unknown'); // no designedCadenceMs → insufficient-facts
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/buildBootIdentitySource.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/buildBootIdentitySource.spec.mjs
@@ -1,0 +1,35 @@
+import {test, expect}            from '@playwright/test';
+import Neo                       from '../../../../../../../src/Neo.mjs';
+import * as core                 from '../../../../../../../src/core/_export.mjs';
+import {buildBootIdentitySource} from '../../../../../../../ai/daemons/orchestrator/services/buildBootIdentitySource.mjs';
+
+test.describe('buildBootIdentitySource — the orchestrator-side boot-identity source composition (#15079)', () => {
+    test('constructs a source that produces an advisory fact, building the gatherer with bootAt + the REM dir', async () => {
+        const seen           = [];
+        const createGatherer = ({bootAt, remRunStateDir}) => {
+            seen.push({bootAt, remRunStateDir});
+            return async () => ({bootAt, sourceRef: 'abc', lastCycleAt: null});
+        };
+
+        const source = buildBootIdentitySource({remRunStateDir: '/rem', bootAt: 1000, createGatherer});
+
+        expect(seen).toEqual([{bootAt: 1000, remRunStateDir: '/rem'}]); // the gatherer is built with bootAt + the shared REM dir
+        expect(typeof source.produceBootIdentityFact).toBe('function');
+
+        const result = await source.produceBootIdentityFact();
+        expect(result.advisory).toBe(true);       // read-observe advisory, never a restart command
+        expect(result.fact.bootAt).toBe(1000);
+        expect(result.fact.sourceRef).toBe('abc');
+    });
+
+    test('FAIL-SOFT: a throwing gatherer factory returns null — never a broken orchestrator boot', () => {
+        const createGatherer = () => { throw new Error('gatherer construction exploded') };
+
+        expect(buildBootIdentitySource({remRunStateDir: '/rem', createGatherer})).toBeNull();
+    });
+
+    test('FAIL-SOFT: a failed service construction returns null', () => {
+        // Neo.create(null, ...) throws → caught → null (the orchestrator then simply never writes a fact)
+        expect(buildBootIdentitySource({remRunStateDir: '/rem', createGatherer: () => async () => ({}), ServiceClass: null})).toBeNull();
+    });
+});

--- a/test/playwright/unit/ai/daemons/orchestrator/services/recordBootIdentityFact.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/recordBootIdentityFact.spec.mjs
@@ -3,7 +3,7 @@ import Neo                      from '../../../../../../../src/Neo.mjs';
 import * as core                from '../../../../../../../src/core/_export.mjs';
 import {recordBootIdentityFact} from '../../../../../../../ai/daemons/orchestrator/services/recordBootIdentityFact.mjs';
 
-const advisoryFact = () => ({fact: {bootAt: 1000, sourceRef: 'abc'}, classification: 'current', advisory: true, reason: 'fresh'});
+const advisoryFact = () => ({fact: {bootAt: 1000, sourceRef: 'abc'}, classification: 'designed-deferral', advisory: true, reason: 'within-cadence-margin'});
 
 test.describe('recordBootIdentityFact — the orchestrator per-cycle boot-identity writer (#15079)', () => {
     test('produces the fact and persists it to the shared dir', async () => {
@@ -12,10 +12,10 @@ test.describe('recordBootIdentityFact — the orchestrator per-cycle boot-identi
 
         const result = await recordBootIdentityFact({source, dir: '/shared/runtime', writeImpl: async (fact, {dir}) => { written.push({fact, dir}) }});
 
-        expect(result).toMatchObject({classification: 'current'});
+        expect(result).toMatchObject({classification: 'designed-deferral'});
         expect(written).toHaveLength(1);
         expect(written[0].dir).toBe('/shared/runtime');
-        expect(written[0].fact).toMatchObject({classification: 'current'});
+        expect(written[0].fact).toMatchObject({classification: 'designed-deferral'});
     });
 
     test('no-ops (no write) on a missing source / missing produce method / missing dir', async () => {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/recordBootIdentityFact.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/recordBootIdentityFact.spec.mjs
@@ -48,4 +48,39 @@ test.describe('recordBootIdentityFact — the orchestrator per-cycle boot-identi
         await expect(recordBootIdentityFact({source, dir: '/shared', writeImpl: async () => { throw new Error('disk full') }}))
             .resolves.toBeNull();
     });
+
+    // --- observability: the fail-soft null is no longer a blind swallow ---
+
+    test('OBSERVABLE: a genuine write failure fires onError with the error (fail-soft null preserved)', async () => {
+        const seen   = [];
+        const source = {produceBootIdentityFact: async () => advisoryFact()};
+
+        const result = await recordBootIdentityFact({
+            source, dir: '/shared',
+            writeImpl: async () => { throw new Error('disk full') },
+            onError  : error => seen.push(error.message)
+        });
+
+        expect(result).toBeNull();           // fail-soft: never gates the cycle
+        expect(seen).toEqual(['disk full']); // …but the failure is surfaced, not swallowed blind (the dead-.catch fix)
+    });
+
+    test('a NO-OP (missing source / absent fact) does NOT fire onError — a no-op is not an error', async () => {
+        const seen    = [];
+        const onError = error => seen.push(error);
+
+        expect(await recordBootIdentityFact({dir: '/x', onError})).toBeNull();                                    // missing source
+        expect(await recordBootIdentityFact({source: {produceBootIdentityFact: async () => null}, dir: '/x', onError})).toBeNull(); // absent fact
+        expect(seen).toHaveLength(0);
+    });
+
+    test('an onError that itself throws never gates the cycle (still resolves null)', async () => {
+        const source = {produceBootIdentityFact: async () => advisoryFact()};
+
+        await expect(recordBootIdentityFact({
+            source, dir: '/shared',
+            writeImpl: async () => { throw new Error('disk full') },
+            onError  : () => { throw new Error('observer boom') }
+        })).resolves.toBeNull();
+    });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/services/recordBootIdentityFact.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/recordBootIdentityFact.spec.mjs
@@ -1,0 +1,51 @@
+import {test, expect}           from '@playwright/test';
+import Neo                      from '../../../../../../../src/Neo.mjs';
+import * as core                from '../../../../../../../src/core/_export.mjs';
+import {recordBootIdentityFact} from '../../../../../../../ai/daemons/orchestrator/services/recordBootIdentityFact.mjs';
+
+const advisoryFact = () => ({fact: {bootAt: 1000, sourceRef: 'abc'}, classification: 'current', advisory: true, reason: 'fresh'});
+
+test.describe('recordBootIdentityFact — the orchestrator per-cycle boot-identity writer (#15079)', () => {
+    test('produces the fact and persists it to the shared dir', async () => {
+        const written = [];
+        const source  = {produceBootIdentityFact: async () => advisoryFact()};
+
+        const result = await recordBootIdentityFact({source, dir: '/shared/runtime', writeImpl: async (fact, {dir}) => { written.push({fact, dir}) }});
+
+        expect(result).toMatchObject({classification: 'current'});
+        expect(written).toHaveLength(1);
+        expect(written[0].dir).toBe('/shared/runtime');
+        expect(written[0].fact).toMatchObject({classification: 'current'});
+    });
+
+    test('no-ops (no write) on a missing source / missing produce method / missing dir', async () => {
+        const written   = [];
+        const writeImpl = async (fact, opts) => { written.push([fact, opts]) };
+
+        expect(await recordBootIdentityFact({dir: '/x', writeImpl})).toBeNull();
+        expect(await recordBootIdentityFact({source: {}, dir: '/x', writeImpl})).toBeNull();
+        expect(await recordBootIdentityFact({source: {produceBootIdentityFact: async () => advisoryFact()}, dir: '', writeImpl})).toBeNull();
+        expect(written).toHaveLength(0);
+    });
+
+    test('a null/absent fact from the source is NOT written (the reader keeps its honest advisory-unknown)', async () => {
+        const written = [];
+        const source  = {produceBootIdentityFact: async () => null};
+
+        expect(await recordBootIdentityFact({source, dir: '/shared', writeImpl: async (...a) => { written.push(a) }})).toBeNull();
+        expect(written).toHaveLength(0);
+    });
+
+    test('FAIL-SOFT: a throwing source never throws the cycle (returns null)', async () => {
+        const source = {produceBootIdentityFact: async () => { throw new Error('gather exploded') }};
+
+        await expect(recordBootIdentityFact({source, dir: '/shared'})).resolves.toBeNull();
+    });
+
+    test('FAIL-SOFT: a throwing writer never throws the cycle (returns null)', async () => {
+        const source = {produceBootIdentityFact: async () => advisoryFact()};
+
+        await expect(recordBootIdentityFact({source, dir: '/shared', writeImpl: async () => { throw new Error('disk full') }}))
+            .resolves.toBeNull();
+    });
+});

--- a/test/playwright/unit/ai/services/fleet/createBootIdentityReadSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/createBootIdentityReadSource.spec.mjs
@@ -1,0 +1,46 @@
+import {test, expect}                 from '@playwright/test';
+import Neo                            from '../../../../../../src/Neo.mjs';
+import * as core                      from '../../../../../../src/core/_export.mjs';
+import {createBootIdentityReadSource} from '../../../../../../ai/services/fleet/createBootIdentityReadSource.mjs';
+
+test.describe('createBootIdentityReadSource — the fleet-server reader over the shared boot-identity fact-file (#15079)', () => {
+    test('produceBootIdentityFact returns the persisted advisory fact when the store has one, reading the given dir', async () => {
+        const persisted = {fact: {bootAt: 1000, sourceRef: 'abc123'}, classification: 'current', advisory: true, reason: 'fresh'};
+        const seen      = [];
+        const source    = createBootIdentityReadSource({dir: '/shared/runtime', readImpl: async ({dir}) => { seen.push(dir); return persisted; }});
+
+        expect(await source.produceBootIdentityFact()).toEqual(persisted);
+        expect(seen).toEqual(['/shared/runtime']); // the reader is pointed at the shared dir
+    });
+
+    test('produceBootIdentityFact yields an advisory-unknown fact when the file is absent — never fabricated liveness', async () => {
+        const source = createBootIdentityReadSource({dir: '/shared/runtime', readImpl: async () => null});
+
+        expect(await source.produceBootIdentityFact()).toEqual({
+            fact          : null,
+            classification: 'unknown',
+            advisory      : true,
+            reason        : 'no-boot-identity-fact-file'
+        });
+    });
+
+    test('the unknown fallback is a FRESH object each call — a caller can never mutate the shared constant', async () => {
+        const source = createBootIdentityReadSource({dir: '/shared/runtime', readImpl: async () => null});
+
+        const a = await source.produceBootIdentityFact();
+        a.reason = 'mutated';
+        const b = await source.produceBootIdentityFact();
+
+        expect(b.reason).toBe('no-boot-identity-fact-file'); // b is unaffected by mutating a
+    });
+
+    test('the shape matches the in-process BootIdentityHealthService contract (advisory, never a restart command)', async () => {
+        const source = createBootIdentityReadSource({dir: '/shared/runtime', readImpl: async () => null});
+        const result = await source.produceBootIdentityFact();
+
+        // read-observe: advisory + no restart/lifecycle command surface — the R3 read ÷ write seam
+        expect(result.advisory).toBe(true);
+        expect(result).not.toHaveProperty('restart');
+        expect(typeof source.produceBootIdentityFact).toBe('function');
+    });
+});

--- a/test/playwright/unit/ai/services/fleet/wireBootIdentityReadSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/wireBootIdentityReadSource.spec.mjs
@@ -1,0 +1,27 @@
+import {test, expect}               from '@playwright/test';
+import Neo                          from '../../../../../../src/Neo.mjs';
+import * as core                    from '../../../../../../src/core/_export.mjs';
+import {wireBootIdentityReadSource} from '../../../../../../ai/services/fleet/wireBootIdentityReadSource.mjs';
+
+test.describe('wireBootIdentityReadSource — the fleet-server boot injection of the boot-identity reader', () => {
+    test('wires bootIdentitySource with a read-source built from the shared dir', () => {
+        const bridge       = {bootIdentitySource: null},
+              seen         = [],
+              stubSource   = {produceBootIdentityFact: async () => ({fact: null, classification: 'unknown', advisory: true})},
+              createSource = ({dir}) => { seen.push(dir); return stubSource };
+
+        const wired = wireBootIdentityReadSource({dir: '/shared/runtime', bridge, createSource});
+
+        expect(seen).toEqual(['/shared/runtime']);          // the reader was pointed at the shared dir
+        expect(bridge.bootIdentitySource).toBe(stubSource); // the bridge seam is now wired
+        expect(wired).toBe(stubSource);
+    });
+
+    test('an absent / empty dir leaves bootIdentitySource UNWIRED — the honest advisory-unknown, never a fabricated source', () => {
+        const bridge = {bootIdentitySource: null};
+
+        expect(wireBootIdentityReadSource({dir: '', bridge})).toBeNull();
+        expect(wireBootIdentityReadSource({bridge})).toBeNull();
+        expect(bridge.bootIdentitySource).toBeNull(); // untouched — the seam degrades to advisory-unknown
+    });
+});


### PR DESCRIPTION
## Summary

Wires the advisory boot-identity health surface into the Fleet control-plane, end-to-end (#14477 Leaf 1). The producer (`BootIdentityHealthService` + its REM-run-state fact-gatherer) was built + spec-covered but instantiated/injected **nowhere live**, so `FleetControlBridge.getBootIdentity()` always returned the advisory-`unknown` fallback. This makes it live — and, per the cycle-2 review, makes the cross-process carrier an explicit snapshot contract and the producer composition a real (non-`unknown`) one.

**Verify-before-assert corrected the premise:** the ticket first assumed the orchestrator injects `FleetControlBridge.bootIdentitySource` in-process. A grep of who imports `FleetControlBridge` proved it lives in the **separate fleet-bridge-server process** (`devFleetServer` → `dispatchFleetRequest`), so it can't be injected there directly in the dev (Option-B) path. The corrected, mode-agnostic design: the orchestrator WRITES its advisory fact to a shared runtime-state file each cycle; the fleet server READS it. In-process (Electron, Option A) and cross-process (dev, Option B) read the same file — no fork on deployment mode.

Evidence: `FleetControlBridge` is imported only by `dispatchFleetRequest.mjs` (fleet-server process) — not the orchestrator; both `activitySource` + `bootIdentitySource` were assigned nowhere live. `remConsolidationStallThresholdMs` = `leaf(6h)` (memory-core config) is finite, so the threaded cadence yields a real classification.

## Deltas

**The shared carrier — an explicit cross-process snapshot contract (`bootIdentityFactStore.mjs`):**
- **Versioned envelope** `{v, generatedAt, fact}` — self-describing, so the reader can tell a fresh snapshot from a stale prior-process one, and a future format change from the current version.
- **Concurrency-safe atomic replace.** Each write goes to a UNIQUE per-write sibling temp (`…json.<pid>.<ts>.<seq>.tmp`) then `rename`s over the target — so overlapping writers (a poll racing a restart) never share a temp path, with cleanup-on-error. A fixed temp name collides under concurrency (one writer's `rename` unlinks the temp another is mid-write to → `ENOENT` / an unreadable snapshot — Euclid's cycle-2 32-writer probe produced 372 rejects); this is the `deploymentStateBridgeStore` precedent. A 40-concurrent-writer test proves a valid final snapshot + no orphaned temps.
- **Byte bound** (`MAX_FACT_BYTES` = 16 KiB) — a pathological oversized field can never be written (loud `RangeError`) or parsed.
- **Canonical-codebook validation on read** (`isValidBootIdentityEnvelope`): the envelope version, plus the fact's `classification` against the producer's `BOOT_FRESHNESS_CLASS` codebook, `advisory === true`, and a non-empty `reason` → a wrong-version / non-codebook file (e.g. `classification:'current'` or `advisory:false`) degrades to `unknown`, never a fabricated class served as real.
- **Stale prior-process → advisory-`unknown`.** A snapshot older than the horizon (`DEFAULT_MAX_FACT_AGE_MS`, 6 h) means the producing orchestrator is gone → an explicit `unknown` advisory (`reason: stale-boot-identity-fact`), never a dead process's fact served as if live. The horizon is mechanically overridable via `maxAgeMs` threaded `wireBootIdentityReadSource` → `createBootIdentityReadSource` → the store read. This is the correctness core of the repair.

**The per-cycle writer — fail-soft AND observable (`recordBootIdentityFact.mjs`):**
- A genuine produce/write failure now routes through an injected `onError` (the orchestrator logs it) before the fail-soft `null`. The prior shape caught the error internally **and** returned `null`, so the orchestrator's outer `.catch` (the log path) was dead code and the failure was silent. A no-op (missing source/dir, absent fact) stays quiet — it is not an error.

**The composition — a real (non-`unknown`) producer (`buildBootIdentitySource.mjs`):**
- Threads the caller's resolved **`freshnessConfig`** (`designedCadenceMs` = the REM-consolidation stall threshold the liveness watchdog already uses) + a **genuine process-boot `bootAt`** (`Date.now() − process.uptime()·1000`). `classifyBootFreshness` returns `unknown` without a finite cadence, so without this thread the wired surface would classify as a perpetual `unknown`; with it, the default path yields real `designed-deferral` / `restart-explains-gap` verdicts.
- Uses the **global `Neo`** (bootstrapped by the daemon entrypoint) — dropped the non-entrypoint `import Neo` (the forbidden bootstrap-side-effect import; matches `BootIdentityHealthService`, which imports `core.Base` and calls global `Neo.setupClass`).
- **Scope (wiring leaf):** `sourceRef` / `deferralReason` / `schedulerResumeState` remain the gatherer's own declared optional "refine in place" resolvers (its docstring: "conservative first cut" — null / `none` best-effort). They are intentionally NOT built here; wiring them is a follow-up refinement, not this leaf's contract. `bootAt` + `lastCycle` (REM store) + the cadence are the live inputs a classification actually needs.

**The reader (fleet-server side):**
- **`createBootIdentityReadSource.mjs`** — the reader adapter over the store (`produceBootIdentityFact()`, same contract as the in-process service); a `null` from the store → the frozen advisory-`unknown` fallback; a stale advisory rides through as-is.
- **`wireBootIdentityReadSource.mjs`** + the `devFleetServer.mjs` boot call — injects the reader as `FleetControlBridge.bootIdentitySource`, reading `AiConfig.orchestrator.dataDir` at the use site (fail-soft: no dir → left honestly unwired).

**`Orchestrator.mjs`** — `start()` calls the extracted `initBootIdentitySource()` instance method (composes the source with the real cadence + genuine boot time); `poll()` calls `recordBootIdentityFact({…, onError})` after `runSchedulingPipeline` (the `onError` is the live log path; the trailing `.catch` is only an unexpected-rejection guard). The composition was extracted to a real method so the caller seam is exercisable in a unit test (`start()` itself is a side-effecting daemon boot the unit suite does not run).

## Contract Ledger

| Surface | Producer | On-disk / carrier | Reader | Fallback |
|---|---|---|---|---|
| `writeBootIdentityFact(fact,{dir,nowFn})` | orchestrator per `poll()` | versioned envelope `{v:1, generatedAt, fact}`, unique-per-write temp → atomic `rename`, ≤ 16 KiB | — | throws (loud) on bad fact / missing dir / oversized → routed to `onError` |
| `readBootIdentityFact({dir,maxAgeMs,nowFn})` | — | validates version + `BOOT_FRESHNESS_CLASS` codebook + advisory + reason + staleness | fleet server per `getBootIdentity()` | `null` for absent/unreadable/corrupt/wrong-version/non-codebook; explicit `unknown{reason:stale-boot-identity-fact}` when > `maxAgeMs` |
| `recordBootIdentityFact({source,dir,onError})` | orchestrator | writes via the store | — | fail-soft `null`; a genuine error fires `onError` (never a no-op); never throws the cycle |
| `createBootIdentityReadSource({dir,maxAgeMs})` | — | reads via the store (forwards `maxAgeMs`) | `FleetControlBridge.bootIdentitySource` | frozen advisory-`unknown{reason:no-boot-identity-fact-file}` on `null` |

Invariant across all rows: **R3 read-only advisory** — no restart command ever crosses the surface; the wiring can never break the orchestrator boot or gate a scheduler cycle (worst case: `getBootIdentity()` stays advisory-`unknown`).

## Test Evidence

`UNIT_TEST_MODE=true playwright test bootIdentity bootIdentityWiring` → **50 passed**; `Orchestrator.spec` → **81 passed** (incl. the new real-caller test). Highlights across cycle-1 → 3:
- **Carrier:** a **40-concurrent-writer** race → a valid final snapshot + no orphaned temps (the fixed-`.tmp` collision Euclid's 32-writer probe proved); stale-prior-process → explicit `unknown`; fresh-within-horizon served; **non-codebook** (`classification:'current'` / `advisory:false`) → `null`; wrong-version / raw-pre-envelope → `null`; oversized → loud `RangeError`; `isValidBootIdentityEnvelope` version+codebook+advisory+reason discrimination.
- **Writer:** a genuine write failure fires `onError` (fail-soft `null` preserved); a no-op does NOT fire `onError`; a throwing `onError` never gates the cycle.
- **Composition:** NO non-entrypoint `import Neo`; `freshnessConfig` threaded → a real `designed-deferral`; without it → `unknown`.
- **Real caller seam (NEW):** `Orchestrator.spec` drives the REAL `orchestrator.initBootIdentitySource()` + `orchestrator.poll()` methods over a tmp `dataDir` → a codebook-valid advisory fact is written + served back through `createBootIdentityReadSource` — the actual caller seam, not a free-helper replay.
- **Cross-process chain:** `buildBootIdentitySource → recordBootIdentityFact → shared file → createBootIdentityReadSource` proves both worked cases (**restart-explains-gap** + **designed-deferral**) are non-`unknown` across the round-trip.

**Orchestrator regression:** the full `Orchestrator.spec` → 81 passed with the `start()`-extraction (`initBootIdentitySource()`). The unrelated `DreamServiceGoldenPath` synthesis failure in the wider daemon suite is a `ChromaConnectionError` (no live Chroma in the unit env → 60 s hang) — it does not import `Orchestrator`, my diff never touches that path, and it reproduces identically on `dev`. Environmental, not a regression. All pre-commit gates (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-align, parse, aiconfig-test-mutation) green.

## Post-Merge Validation

- NL-verify: on a running orchestrator + fleet server, a control-plane `getBootIdentity()` returns the **live** advisory fact (`bootAt` / freshness classification) rather than advisory-`unknown`, and correctly distinguishes a false-positive stale-wake (`designed-deferral`) from real staleness (`restart-explains-gap`) without a false restart.
- Reopen-trigger: `getBootIdentity()` on a running fleet returns advisory-`unknown` while the orchestrator is healthy and has completed ≥ 1 cycle, OR serves a snapshot whose `generatedAt` is not advancing across polls (stale carrier).
- **L3 residual (unrun in this env):** the live *two-process* control-plane probe (a real orchestrator writing + a real fleet-bridge-server reading across the OS boundary) is **not** exercised by the unit suite — the caller-level chain test runs both halves in one process over a shared tmp dir. The cross-process seam (atomic `rename` visibility, real `dataDir`) is covered by construction (same file API) but its live two-process form is a post-merge NL-verify residual, annotated here and on #15079.

## Notes

- No new config leaf — the shared dir + cadence are read at the use site (`AiConfig.orchestrator.dataDir` / `this.remConsolidationWatchdogThresholdMs`), ADR-clean (A1 entrypoint reads, no non-entrypoint capture).
- Scope stays boot-identity only; the sibling `activitySource` (also uncomposed) is a separate seam, not bundled. Restart authority / R2 drain / R3 trigger are Leaf 2/3 of #14477.

Resolves #15079

---

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Origin session `01f4cc68-8b8e-43e6-b51c-55b4f421f4e0`.
