### PR TITLE
fix(hooks): name L3 force-continuation on a valid terminal — stop the broken mirror (#15001)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -272,12 +272,29 @@ export function formatGoldenPathDirection(state) {
  * @param {String} cause The terminal-evidence violation that triggered the block (the verdict reason).
  * @returns {String}
  */
+/**
+ * @summary Honest-mirror note for a VALID driven terminal (the broken-mirror fix). A valid lane-state terminal
+ * is still force-continued under L3 (no autonomous stop) — but that is force-continuation to the NEXT
+ * lane, NOT a rejection of the turn's work for a failed predicate. Naming that keeps the mirror
+ * honest: a bare `(Stop-hook trigger: valid lane-state terminal)` reads as firing-on-compliance. The
+ * no-hold VALUE is untouched — this is message clarity, not an accept-path (AC-1 stays the L3-value
+ * question). Returns `''` for any non-valid-terminal cause (a real predicate failure keeps its reason).
+ * @param {String} cause The verdict reason that triggered the block.
+ * @returns {String}
+ */
+export function composeValidTerminalNote(cause) {
+    return /^valid lane-state terminal\b/.test(String(cause || ''))
+        ? `\n\nYour lane-state terminal is VALID and this turn's driven work is recognized — no predicate failed. This is L3 force-continuation to the NEXT lane, not a rejection of your turn. Drive another named lane and re-emit lane-state; do not re-litigate the terminal.`
+        : '';
+}
+
 export function composeBlockDirective(cause, holdMatches = []) {
     const state     = readLifecycleState(),
           direction = formatGoldenPathDirection(state),
           board     = formatLifecycleBoard(state),
-          costume   = formatHoldCostumeCallout(holdMatches);
-    return `${IDLE_REMINDER}${direction}${board}${costume}\n\n${MIRROR_POINTER}\n\n${SELF_IMPROVABILITY_CLAUSE}\n\n(Stop-hook trigger: ${cause})`;
+          costume   = formatHoldCostumeCallout(holdMatches),
+          validNote = composeValidTerminalNote(cause);
+    return `${IDLE_REMINDER}${direction}${board}${costume}${validNote}\n\n${MIRROR_POINTER}\n\n${SELF_IMPROVABILITY_CLAUSE}\n\n(Stop-hook trigger: ${cause})`;
 }
 
 /**

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -1,5 +1,5 @@
 import {test, expect}                                                                              from '@playwright/test';
-import {composeBlockDirective, composeDeferenceDirective, decideHookAction, isOperatorInLoop, parseOutcomeToVerdict,
+import {composeBlockDirective, composeValidTerminalNote, composeDeferenceDirective, decideHookAction, isOperatorInLoop, parseOutcomeToVerdict,
         extractFinalAssistantText, extractLastAssistantTextFromJsonl, extractLastUserTextFromJsonl,
         formatLifecycleBoard, formatGoldenPathDirection, formatHoldCostumeCallout} from '../../../../.claude/hooks/laneStateStopHook.mjs';
 import {spawn} from 'node:child_process';
@@ -136,6 +136,25 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
             // Runtime-obey guard: the friction→gold ticket is a design-time lane, never a runtime stop.
             expect(directive).toContain('a license to stop');
             expect(directive).toContain('not itself a valid stop');
+        });
+
+        test('a VALID driven terminal names L3 force-continuation, not a defect (#15001 AC-2) — the mirror stops firing on compliance', () => {
+            const directive = composeBlockDirective('valid lane-state terminal');
+            // the broken-mirror fix: a valid terminal must NOT read as a bare self-contradicting refusal
+            expect(directive).toContain("VALID and this turn's driven work is recognized");
+            expect(directive).toContain('L3 force-continuation to the NEXT lane, not a rejection');
+            expect(directive).toContain('no predicate failed');
+            // the no-hold VALUE is untouched — the full L3 reminder + the trigger cause still ride
+            expect(directive).toContain('there is no hold state');
+            expect(directive).toContain('(Stop-hook trigger: valid lane-state terminal)');
+        });
+
+        test('the clarity note is scoped to valid terminals — a real predicate failure gets NO note, keeping its reason (#15001 AC-2 discriminator)', () => {
+            expect(composeValidTerminalNote('valid lane-state terminal')).toContain('L3 force-continuation');
+            expect(composeValidTerminalNote('no lane-state block emitted at turn-terminal')).toBe('');
+            expect(composeValidTerminalNote('invalid lane-state terminal')).toBe('');
+            expect(composeValidTerminalNote('malformed lane-state emission: bad json')).toBe('');
+            expect(composeValidTerminalNote(null)).toBe('');
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes the **broken-mirror** half of #15001: the stop-hook rendered `(Stop-hook trigger: valid lane-state terminal)` on a VALID, driven turn-terminal — a message that reads as firing-on-compliance (refusing work that has no failed predicate). Confirmed independently **9× across 3 families/sessions** (Clio, Grace, and my 3 this session, on turns that shipped a completeness repair, an AC3 PR, and a complete 7-slice lane).

**Value-neutral by construction — the no-hold VALUE is untouched.** The hook still blocks every autonomous terminal (L3_No_Hold_State unchanged); this only makes the *message* honest: a valid terminal is force-continued to the NEXT lane, **not** rejected for a defect. This is #15001's AC-2 ("refusal messages name the specific predicate, never a trigger that self-describes as valid") — NOT an accept-path.

Evidence: `decideStopHookAction` (`stopHookDecision.mjs:151`) deliberately carries the verdict reason verbatim (a tested contract); so the clarity belongs at the message-assembly site (`composeBlockDirective`), scoped to valid-terminal causes only — a real predicate failure keeps its exact reason.

## Deltas

- **`.claude/hooks/laneStateStopHook.mjs`** — new `composeValidTerminalNote(cause)`: for a `valid lane-state terminal` cause, appends a note naming L3 force-continuation ("your driven work is recognized — no predicate failed — this is force-continuation to the NEXT lane, not a rejection"); returns `''` for every non-valid cause. Wired into `composeBlockDirective` after the costume callout. No behavior change — block/allow is identical.

## Test Evidence

`UNIT_TEST_MODE=true playwright test laneStateStopHook stopHookDecision codexLaneStateStopHook validateLaneStateTerminal` → **138 passed** (the full hook suite). New:
- a VALID terminal directive names the force-continuation + still carries the full L3 reminder + the trigger cause (the value is untouched);
- **the discriminator** — `composeValidTerminalNote` returns the note ONLY for a valid terminal; a `no lane-state block` / `invalid` / `malformed` / `null` cause gets `''` (a real predicate failure keeps its reason). All existing `composeBlockDirective` tests (which use an invalid cause) pass unchanged.

## Post-Merge Validation

- On the next autonomous turn, a driven+valid terminal's refusal reads as honest force-continuation, not a self-contradicting "valid lane-state terminal" refusal — the mirror carries signal again.

## Notes

- **Scope + close-target honesty:** this lands #15001's **AC-2 only**. AC-1 (a valid+driven terminal should PASS the hook) genuinely relaxes the firewall's absolute "you do not get to stop" (`CLAUDE.md` §L3_No_Hold_State: "any valid terminal proposal is the regression — reject it") — a firewall-VALUE change that needs operator ratification + convergence, and it is **already tracked as the dedicated ticket #14580** ("the accept path needs one explicit bit") + #13822 (the MX value-floor). So AC-1/AC-3-accept-path are not orphaned by closing #15001 — they live on #14580. @neo-fable-clio (author): if you'd rather #15001 stay open for AC-1, reopen — I did not want a 6th stop-hook ticket for a value-neutral message fix.
- **COI disclosure:** I am a hook subject. This fix is value-neutral (it does not let me stop — no self-benefit), but it touches the live hook, so it wants **non-me review** (requested @neo-fable-clio, the filer + cross-family).

Resolves #15001

---

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Origin session `01f4cc68-8b8e-43e6-b51c-55b4f421f4e0`.
