### PR TITLE
fix(fleet): reuse resolved executable identity (#14951)

### DIFF
--- a/ai/services/fleet/FleetLifecycleService.mjs
+++ b/ai/services/fleet/FleetLifecycleService.mjs
@@ -311,7 +311,6 @@ class FleetLifecycleService extends Base {
         // to failed on the child's asynchronous permission error — a transient false-running state
         // no supervisor may emit).
         const resolvedCommand = this.resolveExecutable(command, env.PATH, opts.cwd);
-
         if (!resolvedCommand) {
             throw new Error(`FleetLifecycleService.start: harness binary '${command}' not found or not executable for agent '${id}' (path-shaped commands resolve against the child cwd; bare commands against the child's PATH; executable permission required). Pin the AiConfig fleet.harnessBinaries leaf or the harnessBinaryPaths field to a real executable.`);
         }
@@ -380,7 +379,7 @@ class FleetLifecycleService extends Base {
 
         let child;
         try {
-            child = this.getSpawnFn()(command, args, spawnOptions);
+            child = this.getSpawnFn()(resolvedCommand, args, spawnOptions);
         } catch (error) {
             this.processes.set(id, {id, cwd: opts.cwd ?? null, state: 'failed', pid: null, startedAt: null, exitCode: null, exitedAt: new Date().toISOString(), error: error.message});
             throw error;
@@ -428,7 +427,7 @@ class FleetLifecycleService extends Base {
 
         if (versionProbeArgs) {
             try {
-                this.getExecFileFn()(command, versionProbeArgs, {timeout: 3000, env}, (error, stdout) => {
+                this.getExecFileFn()(resolvedCommand, versionProbeArgs, {timeout: 3000, env}, (error, stdout) => {
                     if (!error && stdout) record.binaryVersion = String(stdout).trim().split('\n')[0].slice(0, 80);
                 });
             } catch (ignored) {}

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -11,11 +11,12 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import {EventEmitter} from 'events';
-import fs             from 'fs';
-import os             from 'os';
-import path           from 'path';
+import {test, expect}    from '@playwright/test';
+import {execFile, spawn} from 'child_process';
+import {EventEmitter}    from 'events';
+import fs                from 'fs';
+import os                from 'os';
+import path              from 'path';
 
 import Neo                   from '../../../../src/Neo.mjs';
 import * as core             from '../../../../src/core/_export.mjs';
@@ -749,6 +750,43 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService — curated launch + 
         expect(stopped.success).toBe(true);
 
         fs.rmSync(childCwd, {recursive: true, force: true});
+    });
+
+    test('REAL-PROCESS relative child PATH: spawn and version probe reuse the same resolved executable', async () => {
+        const childCwd       = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-relpath-')),
+              executablePath = path.join(childCwd, 'bin', 'h'),
+              processCalls   = {spawn: [], execFile: []};
+
+        fs.mkdirSync(path.dirname(executablePath));
+        fs.writeFileSync(executablePath, '#!/bin/sh\nif [ "$1" = "--version" ]; then\n    echo relpath-v1\n    exit 0\nfi\nIFS= read -r line\n', {mode: 0o755});
+
+        install({agents: {relpath: {id: 'relpath', githubUsername: 'relpath', harnessType: 'codex', metadata: {launch: {
+            command: 'h',
+            args   : [],
+            env    : {PATH: 'bin'}
+        }}}}, creds: {}});
+        FleetLifecycleService.spawnFn = (command, args, opts) => {
+            processCalls.spawn.push({command, args, opts});
+            return spawn(command, args, opts);
+        };
+        FleetLifecycleService.execFileFn = (command, args, opts, callback) => {
+            processCalls.execFile.push({command, args, opts});
+            return execFile(command, args, opts, callback);
+        };
+
+        try {
+            FleetLifecycleService.start('relpath', {cwd: childCwd});
+
+            await expect.poll(() => FleetLifecycleService.status('relpath').binaryVersion).toBe('relpath-v1');
+            expect(FleetLifecycleService.isRunning('relpath')).toBe(true);
+            expect(processCalls.spawn).toHaveLength(1);
+            expect(processCalls.execFile).toHaveLength(1);
+            expect(processCalls.spawn[0].command).toBe(executablePath);
+            expect(processCalls.execFile[0].command).toBe(executablePath);
+        } finally {
+            if (FleetLifecycleService.isRunning('relpath')) await FleetLifecycleService.stop('relpath');
+            fs.rmSync(childCwd, {recursive: true, force: true});
+        }
     });
 
     test('REAL-PROCESS liveness falsifier: the service topology keeps an actual child alive; SIGTERM stops it', async () => {


### PR DESCRIPTION
Resolves #14951

`FleetLifecycleService.start()` now keeps the absolute executable returned by its existing preflight resolver as the canonical process identity. Both the supervised spawn and any enabled best-effort version probe use that exact path, so a command discovered through a child-relative `PATH` cannot launch one executable while observability re-resolves another token.

Evidence: L3 (real executable resolved from a child-relative `PATH`; actual spawn and version-probe calls share its absolute identity) → L3 required (all close-target runtime ACs). No residuals.

## Deltas from ticket

None substantive. The implementation preserves the newer family-specific `versionProbeArgs` policy, including an honest `null` skip, while applying canonical executable identity to every enabled child-process call.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/FleetLifecycleService.spec.mjs --workers=1` — 49 passed.
- `node --check ai/services/fleet/FleetLifecycleService.mjs` — passed.
- `node --check test/playwright/unit/ai/FleetLifecycleService.spec.mjs` — passed.
- `git diff --check origin/dev...HEAD` — passed.
- `npm run agent-preflight -- --no-fix ai/services/fleet/FleetLifecycleService.mjs test/playwright/unit/ai/FleetLifecycleService.spec.mjs` — passed.

## Post-Merge Validation

- [ ] Observe the merged-`dev` Fleet lifecycle workflow for any platform-specific executable-resolution regression; no operator-gated acceptance criterion remains.

## Commits

- `9051656097` — reuse the preflight-resolved executable for spawn and version probing.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session 837ad74b-c2d2-413d-9aab-b7165a93a82a.
