### PR TITLE
fix(main): drain hidden document queues (#15083)

### DIFF
--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -185,7 +185,7 @@ class Main extends core.Base {
             mozInnerScreenY: win.mozInnerScreenY, // Firefox specific
             outerHeight    : win.outerHeight,
             outerWidth     : win.outerWidth,
-            screen: {
+            screen         : {
                 availHeight: screen.availHeight,
                 availLeft  : screen.availLeft,
                 availTop   : screen.availTop,
@@ -242,9 +242,9 @@ class Main extends core.Base {
      *
      */
     async onDomContentLoaded() {
-        let me       = this,
-            {config} = Neo,
-            imports  = [],
+        let me                                                = this,
+            {config}                                          = Neo,
+            imports                                           = [],
             {environment, mainThreadAddons, useServiceWorker} = config,
             modules;
 
@@ -325,7 +325,7 @@ class Main extends core.Base {
         while (operation = queue.shift()) {
             if (new Date() - start > limit) {
                 queue.unshift(operation);
-                return requestAnimationFrame(me.renderFrame.bind(me))
+                return me.scheduleRenderQueueDrain()
             } else {
                 // Per-operation containment: a throwing delta must neither swallow this operation's
                 // reply nor escape the loop and drop the replies of everything still queued behind it.
@@ -358,7 +358,7 @@ class Main extends core.Base {
 
         if (!me.running) {
             me.running = true;
-            requestAnimationFrame(me.renderFrame.bind(me))
+            me.scheduleRenderQueueDrain()
         }
     }
 
@@ -372,8 +372,30 @@ class Main extends core.Base {
 
         if (!me.running) {
             me.running = true;
-            requestAnimationFrame(me.renderFrame.bind(me))
+            me.scheduleRenderQueueDrain()
         }
+    }
+
+    /**
+     * @summary Schedules the next Main-thread DOM queue drain without stranding hidden documents.
+     *
+     * Visible documents stay aligned to the browser's paint cycle. Hidden documents can suspend
+     * animation frames indefinitely, so their queued operations use a task instead. This preserves
+     * the invariant that delayed worker replies settle only after their DOM operations are applied.
+     *
+     * @returns {Boolean} True once the queue drain has been scheduled
+     * @protected
+     */
+    scheduleRenderQueueDrain() {
+        const callback = this.renderFrame.bind(this);
+
+        if (document.hidden) {
+            setTimeout(callback, 0)
+        } else {
+            requestAnimationFrame(callback)
+        }
+
+        return true
     }
 
     /**
@@ -520,7 +542,7 @@ class Main extends core.Base {
      * @return {Boolean}
      */
     windowOpen({url, useTotalHeight=true, windowFeatures, windowName}) {
-        let existingWin  = this.openWindows[windowName],
+        let existingWin = this.openWindows[windowName],
             targetName;
 
         if (existingWin && !existingWin.win.closed) {

--- a/test/playwright/unit/vdom/MainRenderQueue.spec.mjs
+++ b/test/playwright/unit/vdom/MainRenderQueue.spec.mjs
@@ -1,0 +1,137 @@
+import {test, expect}  from '@playwright/test';
+import {execFile}      from 'child_process';
+import path            from 'path';
+import {promisify}     from 'util';
+import {fileURLToPath} from 'url';
+
+const __dirname     = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT     = path.resolve(__dirname, '../../../..');
+const execFileAsync = promisify(execFile);
+
+async function runRenderQueueProbe(hidden) {
+    const script = `
+        import Neo from './src/Neo.mjs';
+        import * as core from './src/core/_export.mjs';
+        import {setup} from './test/playwright/setup.mjs';
+
+        setup({mockMain: false, neoConfig: {unitTestMode: true}});
+
+        globalThis.document = {
+            readyState         : 'loading',
+            hidden             : ${hidden},
+            visibilityState    : '${hidden ? 'hidden' : 'visible'}',
+            addEventListener   : () => {},
+            removeEventListener: () => {},
+            getElementById     : () => null,
+            querySelector      : () => null,
+            createElement      : () => ({
+                addEventListener: () => {},
+                classList       : {add: () => {}, remove: () => {}}
+            }),
+            body: {
+                addEventListener: () => {},
+                classList       : {add: () => {}, remove: () => {}}
+            },
+            documentElement: {classList: {add: () => {}, remove: () => {}}}
+        };
+        globalThis.window                  = globalThis;
+        globalThis.addEventListener        = () => {};
+        globalThis.removeEventListener     = () => {};
+        globalThis.location                = {};
+        globalThis.screen                  = {orientation: {}};
+        globalThis.matchMedia              = () => ({
+            matches            : false,
+            addEventListener   : () => {},
+            removeEventListener: () => {}
+        });
+        globalThis.Worker                  = class {};
+        globalThis.SharedWorker            = class {};
+
+        const scheduled       = [];
+        const originalTimeout = globalThis.setTimeout;
+
+        globalThis.requestAnimationFrame = callback => {
+            scheduled.push({callback, kind: 'animation-frame'});
+            return 1
+        };
+        globalThis.cancelAnimationFrame = () => {};
+        globalThis.setTimeout = (callback, delay) => {
+            scheduled.push({callback, delay, kind: 'task'});
+            return 2
+        };
+
+        Neo.insideWorker = true;
+        delete Neo.main.DomAccess;
+        delete Neo.worker.Manager;
+
+        const {default: Main}          = await import('./src/Main.mjs');
+        const {default: DeltaUpdates}  = await import('./src/main/DeltaUpdates.mjs');
+        const {default: WorkerManager} = await import('./src/worker/Manager.mjs');
+        const applied                  = [];
+        let resolved                   = null;
+
+        DeltaUpdates.update = operation => applied.push(operation);
+        WorkerManager.promises['reply-1'] = {
+            data   : {settled: true},
+            reject : error => { throw error },
+            resolve: value => { resolved = value }
+        };
+
+        scheduled.length = 0;
+        Main.queueWrite({deltas: [], replyId: 'reply-1'});
+
+        const next = scheduled.shift();
+        next?.callback();
+        globalThis.setTimeout = originalTimeout;
+
+        console.log(JSON.stringify({
+            applied       : applied.length,
+            delay         : next?.delay,
+            kind          : next?.kind,
+            queueRemaining: Main.writeQueue.length,
+            resolved,
+            running       : Main.running
+        }))
+    `;
+    const {stdout} = await execFileAsync(process.execPath, ['--input-type=module', '-e', script], {
+        cwd     : REPO_ROOT,
+        encoding: 'utf8',
+        timeout : 15_000
+    });
+
+    return JSON.parse(stdout.trim().split('\n').at(-1))
+}
+
+/**
+ * @summary Pins Main-thread queue progress across visible and hidden documents.
+ *
+ * Main keeps DOM writes frame-batched while visible. Hidden documents may suspend
+ * animation frames indefinitely, so their queue drain must use a task and still settle
+ * the delayed worker reply after the DOM operation has applied.
+ */
+test.describe('Neo.Main render queue scheduling', () => {
+    test('keeps visible writes aligned to the animation frame', async () => {
+        const result = await runRenderQueueProbe(false);
+
+        expect(result).toEqual({
+            applied       : 1,
+            kind          : 'animation-frame',
+            queueRemaining: 0,
+            resolved      : {settled: true},
+            running       : false
+        })
+    });
+
+    test('drains hidden writes through a task and settles their reply', async () => {
+        const result = await runRenderQueueProbe(true);
+
+        expect(result).toEqual({
+            applied       : 1,
+            delay         : 0,
+            kind          : 'task',
+            queueRemaining: 0,
+            resolved      : {settled: true},
+            running       : false
+        })
+    })
+});


### PR DESCRIPTION
Resolves #15083

Related: #15062

Hidden documents no longer strand Main-thread DOM queues and their delayed worker replies. `Neo.Main` now keeps animation-frame batching while visible and uses a task-backed queue drain while hidden, covering reads, writes, and time-slice continuation through one scheduling choke point.

Evidence: L3 (live hidden Electron controls plus exact-head `#15062` stacked runtime at 560 px) → L3 required (post-app-mount parentless and Qt overflow round-trips). No residuals.

## Deltas from ticket

The evidence-first trace corrected the ticket's provisional "lost reply" framing: the reply stays parked behind `Neo.Main.writeQueue` because hidden Electron documents suspend `requestAnimationFrame()`. The fix therefore belongs in Main queue scheduling, below the parentless auto-mount triangle; no VDom routing or plugin timing workaround is needed.

The repair-capable preflight also aligned five pre-existing declaration blocks in `src/Main.mjs`; those edits are mechanical only.

## Test Evidence

- Red baseline: the new isolated production-module probe passed the visible branch and failed the hidden branch because production selected `requestAnimationFrame()`.
- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/vdom/MainRenderQueue.spec.mjs` — 2/2 passed after the fix.
- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/vdom/MainRenderQueue.spec.mjs test/playwright/unit/vdom/UpdateWedge.spec.mjs test/playwright/unit/vdom/VdomLifecycle.spec.mjs` — 8/8 passed.
- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/vdom` — 156/156 passed.
- Live hidden Electron 148 branch probe at 560 px: `document.hidden === true`; both `initVnode(false)` and parentless floating `initVnode(true)` resolved; the auto-mounted control ended `mounted:true`, `vnodeInitialized:true`, `isVdomUpdating:false`; `Neo.Main.writeQueue.length === 0`.
- Exact-head `#15062` stacked runtime (`2e82008012a429dbb8af1f4b9ba5c015275ce8eb`) in the same hidden 560 px Electron window: `TabOverflow` created its floating control; it ended mounted and settled; Main write queue was empty; no wedge error was logged.
- `npm run agent-preflight -- src/Main.mjs test/playwright/unit/vdom/MainRenderQueue.spec.mjs` — passed.
- `node --check` for both changed modules and `git diff --check` — passed.

## Post-Merge Validation

- [ ] Rebase PR #15062 onto the merged `dev` head and repeat its ordinary CI/live handoff without the temporary stacked composition.

## Evolution

The live trace moved the diagnosis from an auto-mount-specific transport loss to hidden-page render starvation: direct `applyDeltas()` parked too, while Main reported `running:true`, `mode:'write'`, and eleven queued writes. That narrower lower-layer cause produced the smaller framework fix.

Authored by Euclid (GPT-5, Codex Desktop). Session 837ad74b-c2d2-413d-9aab-b7165a93a82a.
