### PR TITLE
fix(golden-path): current-focus fallback rows round-trip through parseGoldenPath (#15092)

### DIFF
--- a/ai/services/graph/computedGoldenPathRouting.mjs
+++ b/ai/services/graph/computedGoldenPathRouting.mjs
@@ -240,7 +240,13 @@ export function renderComputedGoldenPathContradictionSection({
             const label = candidate.title || candidate.name ||
                 (Array.isArray(candidate.reasons) ? candidate.reasons.join(', ') : 'Current Release / Incident Focus');
 
-            lines.push(`${index + 1}. **issue-${candidate.number}**: Current Release / Incident Focus (${label})`)
+            // Emit the indented `- *…*` continuation line the AgentOrchestrator route parser requires:
+            // a bare `N. **issue-N**:` row without it renders for humans but extracts ZERO directives,
+            // leaving the never-empty floor silently unroutable. Mirrors the canonical route row shape.
+            lines.push(
+                `${index + 1}. **issue-${candidate.number}**: Current Release / Incident Focus`,
+                `   - *${label}*`
+            )
         });
     } else {
         // Epic-only / no-actionable-focus: the honest state is NO immediate route — an epic umbrella or

--- a/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
+++ b/test/playwright/unit/ai/AgentOrchestrator.spec.mjs
@@ -5,6 +5,9 @@ import Neo               from '../../../../src/Neo.mjs';
 import * as core         from '../../../../src/core/_export.mjs';
 import AgentOrchestrator from '../../../../ai/agent/AgentOrchestrator.mjs';
 
+import {findComputedFocusContradiction, renderComputedGoldenPathContradictionSection} from '../../../../ai/services/graph/computedGoldenPathRouting.mjs';
+import {rankByDeclaredIntent, renderDeclaredIntentFallback}                           from '../../../../ai/services/graph/goldenPathPickupBridge.mjs';
+
 const createTestHandoff = (filename, content) => {
           const filePath = path.resolve(process.cwd(), filename);
           fs.writeFileSync(filePath, content, 'utf-8');
@@ -123,6 +126,67 @@ Based on priorities, the following tasks are mathematically recommended:
         } finally {
             if (fs.existsSync(testHandoffPath)) {
                 fs.unlinkSync(testHandoffPath);
+            }
+        }
+    });
+
+    test('the current-focus contradiction fallback render round-trips through parseGoldenPath (the never-empty floor actually routes)', async () => {
+        // The producer render (routing module) and the consumer parser (this class) form a byte-format
+        // contract. A render-substring assertion is NOT proof of routability — only feeding the real
+        // render through the real parser is. This guards the regression where the focus-as-route rows
+        // lacked the `- *…*` continuation line and silently extracted ZERO directives.
+        const contradiction = findComputedFocusContradiction({
+            currentFocusCandidates: [{number: 14988, reasons: ['incident'], labels: ['bug'], title: 'Fleet auth restart supervised'}],
+            topNodes              : [{
+                node : {id: 'issue-200', type: 'ISSUE', properties: {labels: ['documentation'], title: 'docs: release notes'}},
+                score: 1, semantic: 1, structural: 0
+            }]
+        });
+
+        test.expect(contradiction).not.toBeNull();
+
+        const section = renderComputedGoldenPathContradictionSection({contradiction, stats: {}, renderLimit: 5}),
+              content = `# Autonomous Handoff\n${section}`,
+              handoff = createTestHandoff('.neo-test-handoff-contradiction.md', content);
+
+        try {
+            const orchestrator = Neo.create(AgentOrchestrator, {handoffPath: handoff}),
+                  directives   = orchestrator.parseGoldenPath();
+
+            test.expect(directives).not.toBeNull();
+            test.expect(directives.length).toBe(1);
+            test.expect(directives[0].issueId).toBe('14988');
+            // the blocked content candidate is diagnostic-only, never a routed directive
+            test.expect(directives.map(directive => directive.issueId)).not.toContain('200');
+        } finally {
+            if (fs.existsSync(handoff)) {
+                fs.unlinkSync(handoff);
+            }
+        }
+    });
+
+    test('the declared-intent frontier-empty fallback render yields ZERO parseGoldenPath directives (advisory, not executed route — by design)', async () => {
+        // The declared-intent fallback is a provisional cold-cache rescue, explicitly "not the semantic
+        // ranking" and additive-never-gating per the direction contract. It renders as a separate `### …`
+        // section with `#N` rows so the executed-route parser deliberately does NOT consume it. Elevating
+        // it into the executed route would make declared intent gate execution — this locks the boundary.
+        const section = renderDeclaredIntentFallback(
+                  rankByDeclaredIntent([{id: '14620', inOpenEpic: true, epicActivity: 3, blocked: false, filedAt: '2026-07-10'}]),
+                  5,
+                  {code: 'COLD_START', phrase: 'cold cache'}
+              ),
+              content = `# Autonomous Handoff\n${section}`,
+              handoff = createTestHandoff('.neo-test-handoff-declared-intent.md', content);
+
+        try {
+            const orchestrator = Neo.create(AgentOrchestrator, {handoffPath: handoff}),
+                  directives   = orchestrator.parseGoldenPath();
+
+            // section-shaped but non-executable: no `**issue-N**:` rows → an empty directive list, never a route
+            test.expect(directives).toEqual([]);
+        } finally {
+            if (fs.existsSync(handoff)) {
+                fs.unlinkSync(handoff);
             }
         }
     });

--- a/test/playwright/unit/ai/services/graph/computedGoldenPathRouting.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/computedGoldenPathRouting.spec.mjs
@@ -103,9 +103,10 @@ test.describe('computedGoldenPathRouting — the contradiction guard (routing-de
 
         const section = renderComputedGoldenPathContradictionSection({contradiction, stats: {selectedTopNodes: 0}});
 
-        // never empty: the live Current Focus item IS the numbered route (parseGoldenPath-compatible)
-        expect(section).toContain('1. **issue-100**');
-        expect(section).toContain('incident: cockpit auth relaunch');
+        // never empty: the live Current Focus item IS the numbered route. Parser-SHAPED at the render
+        // level — the `**issue-N**:` row is followed by the `- *…*` continuation line the route parser
+        // requires (the full render→parseGoldenPath round-trip is asserted in AgentOrchestrator.spec).
+        expect(section).toMatch(/1\. \*\*issue-100\*\*:[^\n]*\n\s+-\s\*incident: cockpit auth relaunch\*/);
         // the blocked content is filtered-only — it appears in the diagnostic, never as a numbered route
         expect(section).toMatch(/Contradictory computed candidates filtered:.*issue-200/);
         expect(section).not.toMatch(/^\d+\.\s+\*\*issue-20[01]\*\*/m);


### PR DESCRIPTION
## Summary

The Computed Golden Path **current-focus fallback** (the "never-empty focus-as-route floor") rendered numbered `**issue-N**:` rows that `AgentOrchestrator.parseGoldenPath()` **could not parse**. In the no-survivor-contradiction state (every computed candidate contradicts live `incident`/`prio-zero` focus), the autonomous orchestrator extracted **zero directives** — the floor was silently unroutable, the exact opposite of its purpose. A **false-green test** masked it: it asserted the render *contains* `1. **issue-100**` and commented *"parseGoldenPath-compatible"*, but never ran the parser.

Surfaced during a V-B-A on D#15090 OQ2 (the typed-`ComputedRouteResult` design), where I ran both fallback renders through the exact parser regexes and found both yielding zero directives.

### Root cause

`parseGoldenPath()` (`ai/agent/AgentOrchestrator.mjs:102`) row regex requires an indented `- *description*` continuation line after each `N. **issue-N**:` row:

```js
/\d+\.\s\*\*issue-(\d+)\*\*:[^\n]*\n\s+-\s\*(.*?)\*/g
```

The canonical route render emits it; `renderComputedGoldenPathContradictionSection` did **not** — its rows were bare `N. **issue-N**: Current Release / Incident Focus (label)`, so the regex never matched.

## Deltas

- **`ai/services/graph/computedGoldenPathRouting.mjs`** — the current-focus fallback now emits the `   - *label*` continuation line per routed focus row, mirroring the canonical route row shape, so the existing parser matches. (Fixed the render, not the parser — lower blast radius.)
- **`test/playwright/unit/ai/AgentOrchestrator.spec.mjs`** — added the authoritative **cross-module round-trip** test: render the contradiction section → write as a handoff → real `parseGoldenPath()` → assert the incident directive is extracted (`red-before-green` verified: `Expected: 1, Received: 0` without the render fix). Plus a regression guard locking the **declared-intent fallback** as advisory/non-executed (zero directives, by design — see below).
- **`test/playwright/unit/ai/services/graph/computedGoldenPathRouting.spec.mjs`** — replaced the false-green substring assertion with an honest render-shape check (the `**issue-N**:` row is followed by the parser-required `- *…*` continuation) and pointed the full round-trip to `AgentOrchestrator.spec`.

## Deliberately NOT changed

The **declared-intent frontier-empty fallback** renders as a separate `### Computed Golden Path — fallback: declared-intent` (H3) with `#N` rows, explicitly *"provisional, not the semantic ranking"* and additive-never-gating per the direction contract. It is **advisory, not executed route authority** — its non-parsing is correct-by-design. Making it parse would elevate a direction-proxy surface into executed route (crossing the additive-never-gating line). A test now locks that boundary.

## Test Evidence

- `AgentOrchestrator.spec` → **11 passed** (incl. the 2 new round-trip tests).
- `computedGoldenPathRouting.spec` → **12 passed** (incl. the de-false-greened assertion).
- Red-before-green confirmed: with the render fix stashed, the round-trip test fails `Expected: 1, Received: 0`.
- `node --check` clean on all three; ticket-archaeology + block-alignment + check-parse pre-commit gates green.

## Relationship to OQ2 (D#15090)

D#15090's typed-`ComputedRouteResult` migration deletes the regex parser and makes the route a typed field read, subsuming the **render** half of this fix. But OQ2 is `[GRADUATION_DEFERRED]` (5 open OQs, not imminent), the defect is **live now**, and the **round-trip test is permanent** — it is exactly the per-mode consumer round-trip assertion OQ2's acceptance requires. This is the bridging fix; the test carries forward.

Resolves #15092. Refs D#15090 (OQ2), #15058, #14609, #15087.

---

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Origin session `01f4cc68-8b8e-43e6-b51c-55b4f421f4e0`. Cross-family reviewer welcome — Euclid (@neo-gpt) / Emmy (@neo-gpt-emmy) hold live OQ2 context.


Evidence: L2 — exact producer→consumer behavior, proven by the real render→`AgentOrchestrator.parseGoldenPath()` round trip plus the advisory-fallback negative control. Exact-head reviewer rerun also passed both new consumer tests.

## Post-Merge Validation

- [ ] On the first production no-survivor contradiction pass, verify the current-focus issue is emitted as an AgentOrchestrator directive while the declared-intent fallback remains advisory-only.