### PR TITLE
feat(memory-core): register explore_memory_history — the Memory/session temporal Bird View runtime tool (#14435)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -668,13 +668,13 @@ paths:
         - name: windowStart
           in: query
           required: false
-          description: "Explicit inclusive window start (ISO 8601 / epoch ms). Provide together with windowEnd instead of a preset."
+          description: "Explicit inclusive window start as an ISO 8601 string. Provide together with windowEnd instead of a preset."
           schema:
             type: string
         - name: windowEnd
           in: query
           required: false
-          description: "Explicit exclusive window end (ISO 8601 / epoch ms). Provide together with windowStart instead of a preset."
+          description: "Explicit exclusive window end as an ISO 8601 string. Provide together with windowStart instead of a preset."
           schema:
             type: string
       responses:

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -684,6 +684,72 @@ paths:
             application/json:
               schema:
                 type: object
+                description: The non-authoritative Bird View envelope. Nothing here is durable — it is a query-time view.
+                properties:
+                  window:
+                    type: object
+                    description: The resolved half-open window (partition, windowStart, windowEnd, and their ISO forms).
+                  coverage:
+                    type: object
+                    description: Retrieval completeness — the narrative is withheld unless coverage is provably complete.
+                    properties:
+                      totalResolved:
+                        type: integer
+                        description: The chronological census — every source resolved in the window.
+                      included:
+                        type: integer
+                      excluded:
+                        type: integer
+                      truncated:
+                        type: boolean
+                      sourceTypeCounts:
+                        type: object
+                        description: Per-source-type counts (e.g. session vs memory), so a caller sees the split, not just a total.
+                      synthesisInputCount:
+                        type: integer
+                        description: How many sources the narrative was actually built from; on a window larger than the prompt bounds this is below totalResolved. Present only when the synthesis reported its inference inputs.
+                      degraded:
+                        type: boolean
+                      degradedReason:
+                        type: string
+                        nullable: true
+                  sourceManifestHash:
+                    type: string
+                    description: Order-independent FNV-1a fingerprint of the exact source manifest (provenance / cache comparison).
+                  citations:
+                    type: array
+                    description: Per-source drill-down. inSynthesis (when present) separates inference inputs from census-only sources.
+                    items:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                        id:
+                          type: string
+                        sessionId:
+                          type: string
+                          description: Present when the source carries one — pivot into get_session_memories.
+                        ref:
+                          type: string
+                        inSynthesis:
+                          type: boolean
+                          description: True when this citation was among the sources the narrative was built from.
+                  synthesis:
+                    type: string
+                    nullable: true
+                    description: The "what happened" narrative — non-null ONLY when coverage is provably complete.
+                  synthesisAvailable:
+                    type: boolean
+                  synthesisUnavailableReason:
+                    type: string
+                    nullable: true
+                    description: coverage-incomplete, no-narrative, or null when a narrative is present.
+                  generatedAt:
+                    type: string
+                    description: ISO-8601 generation stamp (injected, never read from a clock internally).
+                  notAuthority:
+                    type: boolean
+                    description: Always true — this envelope is a query-time view, never an authority.
         '503':
           description: Cannot connect to database
           content:

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -627,6 +627,70 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
 
+  /memories/history:
+    get:
+      summary: Explore Memory History
+      operationId: explore_memory_history
+      x-neo-tool-tier: read
+      x-pass-as-object: true
+      x-neo-tool-summary: Synthesize a non-authoritative "what happened" Bird View over a Memory/session time window.
+      x-annotations:
+        readOnlyHint: true
+      description: |
+        The Memory/session temporal Bird View — a computed-on-demand "what happened this week/month/quarter"
+        synthesis over a time window, never a stored digest. Walks the chronological recency spine
+        (query_recent_turns) to completeness, foregrounds recurring themes via semantic enrichment
+        (query_raw_memories), and returns ONE non-authoritative envelope with cited sources. The narrative is
+        WITHHELD on any coverage gap — honest absence over a plausible-but-partial story. Zero durable output
+        above L2: nothing is written.
+
+        **When to Use:**
+        To orient on a stretch of work ("what happened this week") rather than a point recall. Pass a `preset`
+        grain (weekly/monthly/quarterly, or the finer daily/3-day) OR an explicit windowStart/windowEnd, not
+        both. `partition` is 'unified' (the full maintainer roster, cross-agent de-duplicated) or a single
+        '@<identity>'.
+      tags: [Memories]
+      parameters:
+        - name: partition
+          in: query
+          required: false
+          description: "'unified' (default) walks the full AgentIdentity roster + cross-agent de-duplicates; '@<identity>' walks exactly that identity."
+          schema:
+            type: string
+            default: unified
+        - name: preset
+          in: query
+          required: false
+          description: "Window grain (mutually exclusive with windowStart/windowEnd). weekly=L3, monthly=L4, quarterly=L5; daily / 3-day are finer arbitrary grains."
+          schema:
+            type: string
+            enum: [daily, 3-day, weekly, monthly, quarterly]
+        - name: windowStart
+          in: query
+          required: false
+          description: "Explicit inclusive window start (ISO 8601 / epoch ms). Provide together with windowEnd instead of a preset."
+          schema:
+            type: string
+        - name: windowEnd
+          in: query
+          required: false
+          description: "Explicit exclusive window end (ISO 8601 / epoch ms). Provide together with windowStart instead of a preset."
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Bird View envelope synthesized (non-authoritative; narrative withheld on any coverage gap)
+          content:
+            application/json:
+              schema:
+                type: object
+        '503':
+          description: Cannot connect to database
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
   /context/frontier:
     get:
       summary: Get Context Frontier

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -13,6 +13,9 @@ import WakeSubscriptionService       from '../../../services/memory-core/WakeSub
 import TurnPresenceService           from '../../../services/memory-core/TurnPresenceService.mjs';
 import MemoryCoreRecorderService     from '../../../services/memory-core/MemoryCoreRecorderService.mjs';
 import {readDeploymentStateSnapshot} from '../../../services/memory-core/helpers/deploymentStateBridgeStore.mjs';
+import {buildChatModel}              from '../../../provider/buildChatModel.mjs';
+import {exploreMemoryHistory}        from '../../../services/memory-core/helpers/exploreMemoryHistory.mjs';
+import {makeChatModelGenerate}       from '../../../services/memory-core/helpers/chatModelGenerate.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
@@ -24,6 +27,37 @@ const readDeploymentInspection = args => readDeploymentStateSnapshot({
     maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
 });
 
+// `explore_memory_history` — the Memory/session temporal Bird View runtime op. The pure composition
+// (`exploreMemoryHistory`) is dependency-injected; this handler binds the impure edges at the MC server:
+// the recency spine + semantic enrichment ride `MemoryService`, synthesis rides the `modelProvider`
+// reactive-Provider SSOT through `buildChatModel` (read at use-site, never captured at module load), and
+// the `unified` roster is the union of the who-is-online buckets (every AgentIdentity sits in exactly one).
+// The real clock is injected here; the composition stays deterministic on the value it receives.
+const exploreMemoryHistoryOp = args => exploreMemoryHistory({
+    partition  : args?.partition,
+    preset     : args?.preset,
+    windowStart: args?.windowStart,
+    windowEnd  : args?.windowEnd,
+    now        : new Date(),
+    deps       : {
+        queryRecentTurns: MemoryService.queryRecentTurns.bind(MemoryService),
+        queryMemories   : MemoryService.queryMemories.bind(MemoryService),
+        generate        : makeChatModelGenerate({
+            buildModel: () => buildChatModel({
+                modelProvider         : AiConfig.modelProvider,
+                openAiCompatibleConfig: AiConfig.openAiCompatible,
+                ollamaConfig          : AiConfig.ollama,
+                geminiApiKey          : AiConfig.geminiApiKey,
+                geminiModelName       : AiConfig.modelName
+            })
+        }),
+        listIdentities: async () => {
+            const {online, idle, benched} = await WakeSubscriptionService.whoIsOnline();
+            return [...(online || []), ...(idle || []), ...(benched || [])]
+        }
+    }
+});
+
 const serviceMapping = {
     add_memory           : MemoryService          .addMemory               .bind(MemoryService),
     get_mcp_tool_handbook: toolId => toolService.getToolHandbook(toolId),
@@ -32,19 +66,20 @@ const serviceMapping = {
     // NOT agent-callable: a mass-destructive op does not belong on the MCP surface, and any
     // confirmation an agent can supply is not a guard. An operator path, if ever needed,
     // routes through DestructiveOperationGuard — never through tool re-exposure.
-    get_all_summaries   : SummaryService         .listSummaries           .bind(SummaryService),
-    get_context_frontier: MemoryService          .getContextFrontier      .bind(MemoryService),
-    get_neighbors       : GraphService           .getNeighbors            .bind(GraphService),
-    get_node            : GraphService           .getNode                 .bind(GraphService),
-    get_session_memories: MemoryService          .listMemories            .bind(MemoryService),
-    healthcheck         : HealthService          .healthcheck             .bind(HealthService),
-    mutate_frontier     : MemoryService          .mutateFrontier          .bind(MemoryService),
-    pre_brief_session   : MemoryService          .preBriefSession         .bind(MemoryService),
-    query_hybrid_graph  : GraphService           .queryNodeTopology       .bind(GraphService),
-    query_raw_memories  : MemoryService          .queryMemories           .bind(MemoryService),
-    query_recent_turns  : MemoryService          .queryRecentTurns        .bind(MemoryService),
-    query_summaries     : SummaryService         .querySummaries          .bind(SummaryService),
-    search_nodes        : GraphService           .searchNodes             .bind(GraphService),
+    get_all_summaries     : SummaryService         .listSummaries           .bind(SummaryService),
+    get_context_frontier  : MemoryService          .getContextFrontier      .bind(MemoryService),
+    get_neighbors         : GraphService           .getNeighbors            .bind(GraphService),
+    get_node              : GraphService           .getNode                 .bind(GraphService),
+    get_session_memories  : MemoryService          .listMemories            .bind(MemoryService),
+    healthcheck           : HealthService          .healthcheck             .bind(HealthService),
+    mutate_frontier       : MemoryService          .mutateFrontier          .bind(MemoryService),
+    pre_brief_session     : MemoryService          .preBriefSession         .bind(MemoryService),
+    query_hybrid_graph    : GraphService           .queryNodeTopology       .bind(GraphService),
+    query_raw_memories    : MemoryService          .queryMemories           .bind(MemoryService),
+    query_recent_turns    : MemoryService          .queryRecentTurns        .bind(MemoryService),
+    query_summaries       : SummaryService         .querySummaries          .bind(SummaryService),
+    explore_memory_history: exploreMemoryHistoryOp,
+    search_nodes          : GraphService           .searchNodes             .bind(GraphService),
     get_memory_core_tool_metrics:
                               MemoryCoreRecorderService.getMemoryCoreToolMetrics.bind(MemoryCoreRecorderService),
     add_message           : MailboxService         .addMessage              .bind(MailboxService),

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -43,13 +43,19 @@ const exploreMemoryHistoryOp = args => exploreMemoryHistory({
         queryRecentTurns: MemoryService.queryRecentTurns.bind(MemoryService),
         queryMemories   : MemoryService.queryMemories.bind(MemoryService),
         generate        : makeChatModelGenerate({
-            buildModel: () => buildChatModel({
-                modelProvider         : AiConfig.modelProvider,
-                openAiCompatibleConfig: AiConfig.openAiCompatible,
-                ollamaConfig          : AiConfig.ollama,
-                geminiApiKey          : AiConfig.geminiApiKey,
-                geminiModelName       : AiConfig.modelName
-            })
+            // read the resolved provider leaves at the use site, then hand them to the buildChatModel
+            // seam — never thread the config SSOT's provider sub-objects into another consumer's config.
+            buildModel: () => {
+                const {modelProvider, openAiCompatible, ollama, geminiApiKey, modelName} = AiConfig;
+
+                return buildChatModel({
+                    modelProvider,
+                    openAiCompatibleConfig: openAiCompatible,
+                    ollamaConfig          : ollama,
+                    geminiApiKey,
+                    geminiModelName       : modelName
+                })
+            }
         }),
         listIdentities: async () => {
             const {online, idle, benched} = await WakeSubscriptionService.whoIsOnline();

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -54,7 +54,10 @@ const exploreMemoryHistoryOp = args => exploreMemoryHistory({
         listIdentities: async () => {
             const {online, idle, benched} = await WakeSubscriptionService.whoIsOnline();
             return [...(online || []), ...(idle || []), ...(benched || [])]
-        }
+        },
+        // the team-visible session-summary coverage leg — recovers the peer sessions the tenant-bound
+        // recency walk structurally cannot see (query_recent_turns is caller-userId-bound)
+        listSummaries: SummaryService.listSummaries.bind(SummaryService)
     }
 });
 

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -13,7 +13,6 @@ import WakeSubscriptionService       from '../../../services/memory-core/WakeSub
 import TurnPresenceService           from '../../../services/memory-core/TurnPresenceService.mjs';
 import MemoryCoreRecorderService     from '../../../services/memory-core/MemoryCoreRecorderService.mjs';
 import {readDeploymentStateSnapshot} from '../../../services/memory-core/helpers/deploymentStateBridgeStore.mjs';
-import {buildChatModel}              from '../../../provider/buildChatModel.mjs';
 import {exploreMemoryHistory}        from '../../../services/memory-core/helpers/exploreMemoryHistory.mjs';
 import {makeChatModelGenerate}       from '../../../services/memory-core/helpers/chatModelGenerate.mjs';
 
@@ -29,8 +28,8 @@ const readDeploymentInspection = args => readDeploymentStateSnapshot({
 
 // `explore_memory_history` — the Memory/session temporal Bird View runtime op. The pure composition
 // (`exploreMemoryHistory`) is dependency-injected; this handler binds the impure edges at the MC server:
-// the recency spine + semantic enrichment ride `MemoryService`, synthesis rides the `modelProvider`
-// reactive-Provider SSOT through `buildChatModel` (read at use-site, never captured at module load), and
+// the recency spine + semantic enrichment ride `MemoryService`; synthesis reuses the generation model
+// already owned by `SessionService` instead of rebuilding provider config at the tool boundary; and
 // the `unified` roster is the union of the who-is-online buckets (every AgentIdentity sits in exactly one).
 // The real clock is injected here; the composition stays deterministic on the value it receives.
 const exploreMemoryHistoryOp = args => exploreMemoryHistory({
@@ -43,19 +42,9 @@ const exploreMemoryHistoryOp = args => exploreMemoryHistory({
         queryRecentTurns: MemoryService.queryRecentTurns.bind(MemoryService),
         queryMemories   : MemoryService.queryMemories.bind(MemoryService),
         generate        : makeChatModelGenerate({
-            // read the resolved provider leaves at the use site, then hand them to the buildChatModel
-            // seam — never thread the config SSOT's provider sub-objects into another consumer's config.
-            buildModel: () => {
-                const {modelProvider, openAiCompatible, ollama, geminiApiKey, modelName} = AiConfig;
-
-                return buildChatModel({
-                    modelProvider,
-                    openAiCompatibleConfig: openAiCompatible,
-                    ollamaConfig          : ollama,
-                    geminiApiKey,
-                    geminiModelName       : modelName
-                })
-            }
+            // SessionService is the Memory Core server's model owner and completes startup before tools
+            // dispatch. Read the live model at call time; do not thread AiConfig leaves into a second builder.
+            buildModel: () => SessionService.model
         }),
         listIdentities: async () => {
             const {online, idle, benched} = await WakeSubscriptionService.whoIsOnline();

--- a/ai/services/memory-core/helpers/chatModelGenerate.mjs
+++ b/ai/services/memory-core/helpers/chatModelGenerate.mjs
@@ -1,0 +1,46 @@
+/**
+ * @module ai/services/memory-core/helpers/chatModelGenerate
+ * @summary Adapts the Memory Core chat-model builder into the `generate({prompt}) => string` seam the
+ * temporal synthesis adapter calls — the one edge that turns the deployment-agnostic `modelProvider` SSOT
+ * into a narrative for a Bird View.
+ *
+ * The model BUILDER is injected (`buildModel`), so the provider selection (local gemma via
+ * openAiCompatible/ollama, or remote gemini) stays the reactive-Provider SSOT's job and this adapter stays
+ * hermetically testable. A missing provider (e.g. gemini with no API key) or an empty completion THROWS,
+ * so the Bird View orchestrator degrades the envelope rather than emitting an empty "what happened" — the
+ * synthesis path fails loud where `buildMiniSummary` (a fire-and-forget write-path summary) fails soft.
+ */
+
+const DEFAULT_OPERATION_LABEL = 'temporal bird view synthesis';
+
+/**
+ * @summary Builds a `generate({prompt}) => Promise<String>` closure over an injected chat-model builder.
+ * @param {Object} options
+ * @param {Function} options.buildModel `() => model | null` — the injected model builder (real caller wraps `buildChatModel`).
+ * @param {Number} [options.timeoutMs] Generation timeout passed to `model.generateContent`.
+ * @param {String} [options.operationLabel='temporal bird view synthesis'] Label for the model call telemetry.
+ * @returns {Function} `async ({prompt}) => string` (the narrative text).
+ */
+export function makeChatModelGenerate({buildModel, timeoutMs, operationLabel = DEFAULT_OPERATION_LABEL} = {}) {
+    if (typeof buildModel !== 'function') {
+        throw new Error('makeChatModelGenerate: an injected `buildModel` function is required')
+    }
+
+    return async function generate({prompt}) {
+        const model = buildModel();
+
+        if (!model) {
+            // no configured provider (e.g. gemini without an API key) — fail loud so synthesis degrades
+            throw new Error('makeChatModelGenerate: no chat model provider is configured')
+        }
+
+        const result = await model.generateContent(prompt, {timeoutMs, operationLabel, priority: 'interactive'}),
+              text   = result?.response?.text?.() ?? null;
+
+        if (typeof text !== 'string' || text.length === 0) {
+            throw new Error('makeChatModelGenerate: the chat model returned no text')
+        }
+
+        return text
+    }
+}

--- a/ai/services/memory-core/helpers/chronologicalWindowSources.mjs
+++ b/ai/services/memory-core/helpers/chronologicalWindowSources.mjs
@@ -1,0 +1,156 @@
+/**
+ * @module ai/services/memory-core/helpers/chronologicalWindowSources
+ * @summary The chronological completeness **spine** of the temporal Bird View retrieve leg: walks the
+ * recency cursor to exhaustion across the requested partition, keeps only the items inside the half-open
+ * window, cross-agent de-duplicates, and reports an honest coverage manifest.
+ *
+ * This is the backbone that PROVES which sources exist in a window — not a relevance-ranked semantic sample.
+ * Completeness is earned by exhaustion: a partition is complete only when every walked identity's cursor
+ * reached its end (or paged strictly past the window's start) within the runaway cap and no page fetch
+ * failed. A cap hit or a fetch error yields `coverage.degraded` with a reason, so the envelope withholds any
+ * narrative — a partial recency walk must never masquerade as "everything that happened."
+ *
+ * The page fetch is **injected** (`fetchPage`), so the pagination / window-filter / de-dup logic is pure and
+ * hermetically testable while the real `query_recent_turns` adapter plugs into the same seam. Pages are
+ * assumed newest-first (recency order), matching the recency cursor contract.
+ */
+
+/**
+ * @summary Coerces a `Date` / ISO-8601 string / epoch-ms number to finite epoch milliseconds, or `null`.
+ * (Duplicated across the temporal helpers — extract to a shared helper if a further consumer appears.)
+ * @param {Date|String|Number} value
+ * @returns {Number|null}
+ */
+function toEpochMs(value) {
+    if (value instanceof Date)     return Number.isFinite(value.getTime()) ? value.getTime() : null;
+    if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+    if (typeof value === 'string') return Number.isFinite(Date.parse(value)) ? Date.parse(value) : null;
+
+    return null
+}
+
+/**
+ * @summary Walks the recency cursor to exhaustion for one identity, collecting the items inside the window.
+ *
+ * Stops when the cursor is exhausted (`nextCursor` falsy), when a page's OLDEST item is already older than
+ * the window start (chronological order guarantees no older page can re-enter the window), or when the
+ * runaway page cap is hit (reported as an un-exhausted walk). A thrown page fetch ends the walk un-exhausted.
+ *
+ * @param {Object} options
+ * @param {String} options.identity          The agent identity whose recency stream is walked.
+ * @param {Number} options.windowStart       Inclusive window start (epoch ms).
+ * @param {Number} options.windowEnd         Exclusive window end (epoch ms).
+ * @param {Function} options.fetchPage        `async ({identity, cursor}) => {items: [{id, timestamp, ...}], nextCursor}`.
+ * @param {Number} options.maxPages          Runaway page cap.
+ * @returns {Promise<{items: Object[], exhausted: Boolean, pages: Number, error: (String|null)}>}
+ */
+async function walkIdentity({identity, windowStart, windowEnd, fetchPage, maxPages}) {
+    const collected = [];
+    let   cursor    = undefined,
+        pages     = 0,
+        exhausted = false,
+        error     = null;
+
+    while (true) {
+        if (pages >= maxPages) break;   // runaway guard → left un-exhausted (degraded upstream)
+
+        pages++;
+
+        let page;
+
+        try {
+            page = await fetchPage({identity, cursor})
+        } catch (fetchError) {
+            error = fetchError instanceof Error ? fetchError.message : String(fetchError);
+            break
+        }
+
+        const items = Array.isArray(page?.items) ? page.items : [];
+
+        for (const item of items) {
+            const ts = toEpochMs(item?.timestamp);
+
+            if (ts !== null && ts >= windowStart && ts < windowEnd) {
+                collected.push({...item, identity})
+            }
+        }
+
+        // recency order (newest-first): once the OLDEST item on the page predates the window start, every
+        // older page is out of the window too — stop, and the walk is exhausted WITHIN the window.
+        const oldestTs = items.length ? toEpochMs(items[items.length - 1]?.timestamp) : null;
+
+        if (oldestTs !== null && oldestTs < windowStart) {
+            exhausted = true;
+            break
+        }
+
+        if (!page?.nextCursor) {
+            exhausted = true;
+            break
+        }
+
+        cursor = page.nextCursor
+    }
+
+    return {items: collected, exhausted, pages, error}
+}
+
+/**
+ * @summary Enumerates every Memory/session source inside a resolved window by exhausting the recency cursor.
+ *
+ * @param {Object} options
+ * @param {Object} options.window The resolved half-open window (from `resolveTemporalWindow`).
+ * @param {String[]} options.identities The agent identities to walk — one for `@<identity>`, the full roster for `unified`.
+ * @param {Function} options.fetchPage `async ({identity, cursor}) => {items: [{id, timestamp, ...}], nextCursor}`.
+ * @param {Number} [options.maxPagesPerIdentity=1000] Runaway page cap per identity.
+ * @returns {Promise<{sources: Object[], coverage: {totalResolved: Number, identitiesWalked: Number, exhausted: Boolean, degraded: Boolean, degradedReason: (String|null)}}>}
+ */
+export async function enumerateChronologicalWindowSources({window, identities, fetchPage, maxPagesPerIdentity = 1000} = {}) {
+    if (!window || typeof window !== 'object') {
+        throw new Error('enumerateChronologicalWindowSources: a resolved `window` is required')
+    }
+
+    if (typeof fetchPage !== 'function') {
+        throw new Error('enumerateChronologicalWindowSources: an injected `fetchPage` function is required')
+    }
+
+    const identityList = Array.isArray(identities) ? identities.filter(Boolean) : [];
+
+    if (identityList.length === 0) {
+        throw new Error('enumerateChronologicalWindowSources: at least one identity is required to walk')
+    }
+
+    const {windowStart, windowEnd} = window,
+          byId                     = new Map(),   // cross-agent de-dup by source id (first walk wins)
+          failed                   = [];
+    let   allExhausted = true;
+
+    for (const identity of identityList) {
+        const walk = await walkIdentity({identity, windowStart, windowEnd, fetchPage, maxPages: maxPagesPerIdentity});
+
+        if (!walk.exhausted) {
+            allExhausted = false;
+            failed.push(walk.error ? `${identity}: ${walk.error}` : `${identity}: page-cap`)
+        }
+
+        for (const item of walk.items) {
+            if (!byId.has(item.id)) {
+                byId.set(item.id, item)
+            }
+        }
+    }
+
+    const sources  = [...byId.values()],
+          degraded = !allExhausted;
+
+    return {
+        sources,
+        coverage: {
+            totalResolved   : sources.length,
+            identitiesWalked: identityList.length,
+            exhausted       : allExhausted,
+            degraded,
+            degradedReason  : degraded ? `chronological-walk-incomplete: ${failed.join('; ')}` : null
+        }
+    }
+}

--- a/ai/services/memory-core/helpers/citationProminence.mjs
+++ b/ai/services/memory-core/helpers/citationProminence.mjs
@@ -1,0 +1,64 @@
+/**
+ * @module ai/services/memory-core/helpers/citationProminence
+ * @summary Annotates enumerated sources with citation **prominence** — which of them the concise narrative
+ * foregrounds and direct-cites — WITHOUT ever changing which sources are admitted.
+ *
+ * This is the fidelity discipline of the temporal Bird View: high-impact sessions and accepted ADRs earn a
+ * direct citation, and a resolved pull request earns prominence only through a NAMED fidelity marker
+ * (an accepted-ADR link, an epic label, or high-impact review metadata) — never an invented universal PR
+ * impact score. The load-bearing separation: prominence is NOT admission. Every enumerated source stays in
+ * the coverage manifest and remains drill-down-citable; prominence only decides emphasis, so a low-impact
+ * session is never silently dropped from the window it belongs to.
+ */
+
+const PROMINENT_SESSION_IMPACT = 90;
+
+/**
+ * @summary Decides whether one source earns direct-citation prominence in the narrative.
+ * @param {Object} source A source record `{id, type, impact?, accepted?, acceptedAdrLink?, epicLabel?, highImpactReview?}`.
+ * @returns {Boolean}
+ */
+function isProminentSource(source) {
+    switch (source?.type) {
+        case 'session':
+        case 'memory':
+            // high-impact sessions (>= the direct-cite threshold) cite directly
+            return Number(source.impact) >= PROMINENT_SESSION_IMPACT;
+        case 'adr':
+            // accepted ADRs cite directly
+            return source.accepted === true;
+        case 'pull-request':
+            // PR fidelity flows through a NAMED source only — accepted-ADR link, epic label, or high-impact
+            // review metadata. NO invented universal PR impact score.
+            return Boolean(source.acceptedAdrLink || source.epicLabel || source.highImpactReview);
+        default:
+            return false
+    }
+}
+
+/**
+ * @summary Annotates each source with `prominent` (direct-citation emphasis) — admission is untouched.
+ * @param {Object[]} sources Enumerated window sources (the complete, admitted manifest).
+ * @returns {Object[]} The same sources, order preserved, each with a `prominent` boolean.
+ */
+export function annotateCitationProminence(sources) {
+    return (Array.isArray(sources) ? sources : []).map(source => ({...source, prominent: isProminentSource(source)}))
+}
+
+/**
+ * @summary Partitions the annotated sources into `{prominent, context}` for prompt construction.
+ *
+ * The narrative foregrounds `prominent` and direct-cites it; `context` remains available for coverage and
+ * drill-down but is not foregrounded. Both halves together are exactly the admitted manifest — nothing is
+ * dropped, so `prominent.length + context.length === sources.length`.
+ * @param {Object[]} sources Enumerated window sources.
+ * @returns {{prominent: Object[], context: Object[]}}
+ */
+export function partitionByProminence(sources) {
+    const annotated = annotateCitationProminence(sources);
+
+    return {
+        prominent: annotated.filter(source => source.prominent),
+        context  : annotated.filter(source => !source.prominent)
+    }
+}

--- a/ai/services/memory-core/helpers/exploreMemoryHistory.mjs
+++ b/ai/services/memory-core/helpers/exploreMemoryHistory.mjs
@@ -64,7 +64,9 @@ export async function exploreMemoryHistory({
 
     // synthesis foregrounds themes (best-effort, never coverage) then runs the fidelity-bound generation
     const synthesize = async ({window, sources}) => {
-        const {themes} = await enrich({query: enrichmentQuery});
+        // enrichment is window-bound to the resolved window so a relevance-ranked theme cannot leak in
+        // from outside [windowStart, windowEnd) and fabricate a narrative this window was never about.
+        const {themes} = await enrich({query: enrichmentQuery, windowStart: window.windowStart, windowEnd: window.windowEnd});
 
         return generateNarrative({window, sources, themes})
     };

--- a/ai/services/memory-core/helpers/exploreMemoryHistory.mjs
+++ b/ai/services/memory-core/helpers/exploreMemoryHistory.mjs
@@ -1,0 +1,73 @@
+import {enumerateChronologicalWindowSources} from './chronologicalWindowSources.mjs';
+import {makeRecentTurnsFetchPage}            from './recentTurnsFetchPage.mjs';
+import {makeSemanticEnrichment}              from './semanticEnrichment.mjs';
+import {makeTemporalSynthesize}              from './temporalSynthesis.mjs';
+import {synthesizeTemporalBirdView}          from './temporalBirdViewSynthesizer.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/exploreMemoryHistory
+ * @summary The Memory/session temporal Bird View composition — wires the resolved window through the
+ * chronological completeness spine, best-effort semantic enrichment, and cited synthesis into one honest
+ * `notAuthority` envelope. This is the logic behind the `explore_memory_history` runtime operation, kept
+ * separate from its MCP-server registration so the whole path is dependency-injected and hermetically
+ * testable.
+ *
+ * All Memory Core / inference touchpoints are injected via `deps` (`queryRecentTurns`, `queryMemories`,
+ * `generate`, `listIdentities`), so this composes the eight tested primitives without reaching for a global.
+ * Coverage is the recency spine's alone; enrichment only foregrounds themes; the envelope withholds the
+ * narrative on any coverage gap. The `unified` partition walks the full identity roster and cross-agent
+ * de-duplicates; an `@<identity>` partition walks exactly that identity.
+ */
+
+const DEFAULT_ENRICHMENT_QUERY = 'notable engineering decisions, friction, and outcomes';
+
+/**
+ * @summary Runs one `explore_memory_history` synthesis and returns the non-authoritative Bird View envelope.
+ *
+ * @param {Object} options
+ * @param {String} [options.partition='unified'] `'unified'` or a canonical `'@<identity>'`.
+ * @param {String} [options.preset] A grain preset (mutually exclusive with an explicit window).
+ * @param {Date|String|Number} [options.windowStart] Explicit inclusive start.
+ * @param {Date|String|Number} [options.windowEnd]   Explicit exclusive end.
+ * @param {Date|String|Number} [options.now] Injected reference clock (required for a preset).
+ * @param {Date|String|Number} [options.generatedAt] Injected generation stamp; defaults to `now`.
+ * @param {String} [options.enrichmentQuery] Semantic theme query (best-effort).
+ * @param {Object} options.deps Injected Memory Core / inference touchpoints.
+ * @param {Function} options.deps.queryRecentTurns Bound `queryRecentTurns` (the recency spine source).
+ * @param {Function} options.deps.queryMemories   Bound `queryMemories` (semantic enrichment).
+ * @param {Function} options.deps.generate         The LLM `generate` call.
+ * @param {Function} options.deps.listIdentities   `async () => string[]` — the roster walked for `unified`.
+ * @returns {Promise<Object>} The `notAuthority` Bird View envelope.
+ */
+export async function exploreMemoryHistory({
+    partition = 'unified', preset, windowStart, windowEnd, now, generatedAt,
+    enrichmentQuery = DEFAULT_ENRICHMENT_QUERY, deps
+} = {}) {
+    const {queryRecentTurns, queryMemories, generate, listIdentities} = deps || {};
+
+    if (typeof queryRecentTurns !== 'function' || typeof queryMemories !== 'function' ||
+        typeof generate !== 'function' || typeof listIdentities !== 'function') {
+        throw new Error('exploreMemoryHistory: deps must supply queryRecentTurns, queryMemories, generate, and listIdentities')
+    }
+
+    const fetchPage         = makeRecentTurnsFetchPage({queryRecentTurns}),
+          enrich            = makeSemanticEnrichment({queryMemories}),
+          generateNarrative = makeTemporalSynthesize({generate});
+
+    // the recency spine is the coverage backbone; identities resolve at retrieve time so `unified` walks
+    // the live roster while `@<identity>` walks exactly one.
+    const retrieve = async ({window}) => {
+        const identities = window.partition === 'unified' ? await listIdentities() : [window.partition];
+
+        return enumerateChronologicalWindowSources({window, identities, fetchPage})
+    };
+
+    // synthesis foregrounds themes (best-effort, never coverage) then runs the fidelity-bound generation
+    const synthesize = async ({window, sources}) => {
+        const {themes} = await enrich({query: enrichmentQuery});
+
+        return generateNarrative({window, sources, themes})
+    };
+
+    return synthesizeTemporalBirdView({partition, preset, windowStart, windowEnd, now, generatedAt, retrieve, synthesize})
+}

--- a/ai/services/memory-core/helpers/exploreMemoryHistory.mjs
+++ b/ai/services/memory-core/helpers/exploreMemoryHistory.mjs
@@ -1,6 +1,7 @@
 import {enumerateChronologicalWindowSources} from './chronologicalWindowSources.mjs';
 import {makeRecentTurnsFetchPage}            from './recentTurnsFetchPage.mjs';
 import {makeSemanticEnrichment}              from './semanticEnrichment.mjs';
+import {makeSessionSummaryReader}            from './sessionSummaryReader.mjs';
 import {makeTemporalSynthesize}              from './temporalSynthesis.mjs';
 import {synthesizeTemporalBirdView}          from './temporalBirdViewSynthesizer.mjs';
 
@@ -37,29 +38,48 @@ const DEFAULT_ENRICHMENT_QUERY = 'notable engineering decisions, friction, and o
  * @param {Function} options.deps.queryMemories   Bound `queryMemories` (semantic enrichment).
  * @param {Function} options.deps.generate         The LLM `generate` call.
  * @param {Function} options.deps.listIdentities   `async () => string[]` — the roster walked for `unified`.
+ * @param {Function} options.deps.listSummaries    Bound `listSummaries` — the team-visible session-summary coverage leg.
  * @returns {Promise<Object>} The `notAuthority` Bird View envelope.
  */
 export async function exploreMemoryHistory({
     partition = 'unified', preset, windowStart, windowEnd, now, generatedAt,
     enrichmentQuery = DEFAULT_ENRICHMENT_QUERY, deps
 } = {}) {
-    const {queryRecentTurns, queryMemories, generate, listIdentities} = deps || {};
+    const {queryRecentTurns, queryMemories, generate, listIdentities, listSummaries} = deps || {};
 
     if (typeof queryRecentTurns !== 'function' || typeof queryMemories !== 'function' ||
-        typeof generate !== 'function' || typeof listIdentities !== 'function') {
-        throw new Error('exploreMemoryHistory: deps must supply queryRecentTurns, queryMemories, generate, and listIdentities')
+        typeof generate !== 'function' || typeof listIdentities !== 'function' ||
+        typeof listSummaries !== 'function') {
+        throw new Error('exploreMemoryHistory: deps must supply queryRecentTurns, queryMemories, generate, listIdentities, and listSummaries')
     }
 
-    const fetchPage         = makeRecentTurnsFetchPage({queryRecentTurns}),
-          enrich            = makeSemanticEnrichment({queryMemories}),
-          generateNarrative = makeTemporalSynthesize({generate});
+    const fetchPage           = makeRecentTurnsFetchPage({queryRecentTurns}),
+          fetchWindowSessions = makeSessionSummaryReader({listSummaries}),
+          enrich              = makeSemanticEnrichment({queryMemories}),
+          generateNarrative   = makeTemporalSynthesize({generate});
 
-    // the recency spine is the coverage backbone; identities resolve at retrieve time so `unified` walks
-    // the live roster while `@<identity>` walks exactly one.
+    // Coverage has TWO legs: the tenant-scoped recency walk (the caller's own turns) AND the team-visible
+    // session-summary leg (the peer sessions the recency walk structurally cannot see — query_recent_turns
+    // is userId-bound). Merged + deduped by id; a failure in EITHER leg degrades coverage honestly, so the
+    // narrative is withheld rather than served partial.
     const retrieve = async ({window}) => {
-        const identities = window.partition === 'unified' ? await listIdentities() : [window.partition];
+        const identities = window.partition === 'unified' ? await listIdentities() : [window.partition],
+              turnResult = await enumerateChronologicalWindowSources({window, identities, fetchPage}),
+              summaries  = await fetchWindowSessions({windowStart: window.windowStart, windowEnd: window.windowEnd, partition: window.partition});
 
-        return enumerateChronologicalWindowSources({window, identities, fetchPage})
+        const byId = new Map(turnResult.sources.map(source => [source.id, source]));
+        for (const source of summaries.sources) if (!byId.has(source.id)) byId.set(source.id, source);
+        const sources = [...byId.values()];
+
+        return {
+            sources,
+            coverage: {
+                ...turnResult.coverage,
+                totalResolved : sources.length,
+                degraded      : turnResult.coverage.degraded || summaries.degraded,
+                degradedReason: turnResult.coverage.degradedReason || (summaries.degraded ? summaries.reason : null)
+            }
+        }
     };
 
     // synthesis foregrounds themes (best-effort, never coverage) then runs the fidelity-bound generation

--- a/ai/services/memory-core/helpers/recentTurnsFetchPage.mjs
+++ b/ai/services/memory-core/helpers/recentTurnsFetchPage.mjs
@@ -1,0 +1,43 @@
+/**
+ * @module ai/services/memory-core/helpers/recentTurnsFetchPage
+ * @summary Adapts Memory Core's `queryRecentTurns` into the `fetchPage` seam the chronological window-source
+ * spine walks — the one impure edge that turns the recency-cursor contract into paginable window sources.
+ *
+ * `queryRecentTurns({agentIdentity, before, limit}) => {turns:[{id, timestamp, …}], nextCursor:{timestamp,id}|null}`
+ * returns reverse-chronological turns and a compound `{timestamp, id}` cursor to pass back as `before`. This
+ * factory binds that method behind a `fetchPage({identity, cursor})` closure so the pure spine
+ * ({@link enumerateChronologicalWindowSources}) can exhaust it identity-by-identity. `queryRecentTurns`
+ * signals failure by RETURNING `{error, message}` (it never vetoes a turn save by throwing); this adapter
+ * converts that into a thrown error so the spine's per-identity walk degrades the coverage manifest rather
+ * than silently treating an errored page as an exhausted one.
+ */
+
+/**
+ * @summary Builds a `fetchPage({identity, cursor})` closure over an injected `queryRecentTurns`.
+ * @param {Object} options
+ * @param {Function} options.queryRecentTurns The bound Memory Core method (injected — keeps this testable).
+ * @param {Number} [options.limit=100] Page size (the method caps at its own bound; 100 matches the tool cap).
+ * @returns {Function} `async ({identity, cursor}) => {items: [{id, timestamp, type}], nextCursor}`.
+ */
+export function makeRecentTurnsFetchPage({queryRecentTurns, limit = 100} = {}) {
+    if (typeof queryRecentTurns !== 'function') {
+        throw new Error('makeRecentTurnsFetchPage: an injected `queryRecentTurns` function is required')
+    }
+
+    return async function fetchPage({identity, cursor}) {
+        const result = await queryRecentTurns({agentIdentity: identity, before: cursor, limit});
+
+        // queryRecentTurns returns an error envelope instead of throwing — surface it as a throw so the
+        // spine's per-identity catch degrades coverage (an errored page must never look exhausted).
+        if (result?.error) {
+            throw new Error(`query_recent_turns failed for ${identity}: ${result.message || result.error}`)
+        }
+
+        const turns = Array.isArray(result?.turns) ? result.turns : [];
+
+        return {
+            items     : turns.map(turn => ({id: turn.id, timestamp: turn.timestamp, type: 'turn'})),
+            nextCursor: result?.nextCursor ?? null
+        }
+    }
+}

--- a/ai/services/memory-core/helpers/recentTurnsFetchPage.mjs
+++ b/ai/services/memory-core/helpers/recentTurnsFetchPage.mjs
@@ -35,8 +35,17 @@ export function makeRecentTurnsFetchPage({queryRecentTurns, limit = 100} = {}) {
 
         const turns = Array.isArray(result?.turns) ? result.turns : [];
 
+        // Preserve the fidelity fields the downstream synthesis + citation-prominence read — dropping
+        // `impact`/`summary` here forced the narrative to reconstruct from ids alone (a false-narrative
+        // vector). Kept explicit (not a spread) so the window-source item stays a known shape.
         return {
-            items     : turns.map(turn => ({id: turn.id, timestamp: turn.timestamp, type: 'turn'})),
+            items: turns.map(turn => ({
+                id       : turn.id,
+                timestamp: turn.timestamp,
+                type     : 'turn',
+                impact   : turn.impact,
+                summary  : turn.summary
+            })),
             nextCursor: result?.nextCursor ?? null
         }
     }

--- a/ai/services/memory-core/helpers/recentTurnsFetchPage.mjs
+++ b/ai/services/memory-core/helpers/recentTurnsFetchPage.mjs
@@ -35,14 +35,17 @@ export function makeRecentTurnsFetchPage({queryRecentTurns, limit = 100} = {}) {
 
         const turns = Array.isArray(result?.turns) ? result.turns : [];
 
-        // Preserve the fidelity fields the downstream synthesis + citation-prominence read — dropping
-        // `impact`/`summary` here forced the narrative to reconstruct from ids alone (a false-narrative
-        // vector). Kept explicit (not a spread) so the window-source item stays a known shape.
+        // Preserve the fidelity fields the downstream synthesis + citation-prominence read: a turn IS a
+        // `memory` record, so it is typed as such — citationProminence classifies memory/session/adr/pr,
+        // and the previous `'turn'` literal fell to its default and could NEVER earn direct citation.
+        // sessionId, impact, and summary carry through for prominence + session drill-down. Explicit
+        // (not a spread) so the window-source item stays a known shape.
         return {
             items: turns.map(turn => ({
                 id       : turn.id,
                 timestamp: turn.timestamp,
-                type     : 'turn',
+                type     : 'memory',
+                sessionId: turn.sessionId,
                 impact   : turn.impact,
                 summary  : turn.summary
             })),

--- a/ai/services/memory-core/helpers/semanticEnrichment.mjs
+++ b/ai/services/memory-core/helpers/semanticEnrichment.mjs
@@ -24,14 +24,15 @@ function errMsg(error) {
  * @param {Object} options
  * @param {Function} options.queryMemories The bound Memory Core method (injected — keeps this testable).
  * @param {Number} [options.nResults=100] Result cap (the tool caps at 100; enrichment is a sample, never a census).
- * @returns {Function} `async ({query}) => {themes: Object[], degraded: Boolean, reason: (String|null)}`.
+ * @returns {Function} `async ({query, windowStart, windowEnd}) => {themes, degraded, reason}` — themes are
+ * window-bound to [windowStart, windowEnd) so enrichment never imports a theme from outside the window.
  */
 export function makeSemanticEnrichment({queryMemories, nResults = 100} = {}) {
     if (typeof queryMemories !== 'function') {
         throw new Error('makeSemanticEnrichment: an injected `queryMemories` function is required')
     }
 
-    return async function enrich({query} = {}) {
+    return async function enrich({query, windowStart, windowEnd} = {}) {
         if (typeof query !== 'string' || query.length === 0) {
             return {themes: [], degraded: true, reason: 'no-query'}
         }
@@ -51,8 +52,20 @@ export function makeSemanticEnrichment({queryMemories, nResults = 100} = {}) {
 
         const results = Array.isArray(result?.results) ? result.results : [];
 
-        // pass the raw relevance-ranked records through, tagged as theme evidence — the synthesis prompt
-        // decides which fields to foreground; this adapter makes no assumption about the record shape.
-        return {themes: results.map(record => ({...record, type: 'memory'})), degraded: false, reason: null}
+        // Window-bind the enrichment: a relevance-ranked semantic search returns matches from ANY time, so
+        // an out-of-window record would import a theme this window was never about (a false-narrative
+        // vector). Keep only records whose ISO `timestamp` is inside [windowStart, windowEnd); a record
+        // with no verifiable timestamp is dropped — it cannot be proven in-window.
+        // No window passed → pass-through (a direct best-effort call); a resolved window → strictly bind.
+        const startMs  = windowStart == null ? -Infinity : new Date(windowStart).getTime(),
+              endMs    = windowEnd   == null ?  Infinity : new Date(windowEnd).getTime(),
+              inWindow = windowStart == null && windowEnd == null ? results : results.filter(record => {
+                  const ts = new Date(record?.timestamp).getTime();
+                  return !Number.isNaN(ts) && ts >= startMs && ts < endMs
+              });
+
+        // pass the in-window relevance-ranked records through, tagged as theme evidence — the synthesis
+        // prompt decides which fields to foreground; this adapter makes no assumption about record shape.
+        return {themes: inWindow.map(record => ({...record, type: 'memory'})), degraded: false, reason: null}
     }
 }

--- a/ai/services/memory-core/helpers/semanticEnrichment.mjs
+++ b/ai/services/memory-core/helpers/semanticEnrichment.mjs
@@ -1,0 +1,58 @@
+/**
+ * @module ai/services/memory-core/helpers/semanticEnrichment
+ * @summary Adapts Memory Core's `queryMemories` (relevance-ranked semantic search) into a BEST-EFFORT theme
+ * enrichment for the temporal Bird View — recovers what a window was *about*, never what it *contained*.
+ *
+ * Enrichment is strictly additive: it surfaces semantic/theme evidence the concise narrative can foreground,
+ * and it is capped and relevance-ranked, so it can NEVER prove window completeness. The load-bearing
+ * consequence: this adapter's `degraded` flag is entirely SEPARATE from the chronological coverage spine.
+ * An enrichment failure means fewer themes to foreground — it must never withhold the narrative, degrade
+ * `coverage`, or make a complete window look incomplete. Completeness is the recency spine's job alone.
+ */
+
+/**
+ * @summary Extracts a safe message string from a thrown value.
+ * @param {*} error
+ * @returns {String}
+ */
+function errMsg(error) {
+    return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * @summary Builds a best-effort `enrich({query})` closure over an injected `queryMemories`.
+ * @param {Object} options
+ * @param {Function} options.queryMemories The bound Memory Core method (injected — keeps this testable).
+ * @param {Number} [options.nResults=100] Result cap (the tool caps at 100; enrichment is a sample, never a census).
+ * @returns {Function} `async ({query}) => {themes: Object[], degraded: Boolean, reason: (String|null)}`.
+ */
+export function makeSemanticEnrichment({queryMemories, nResults = 100} = {}) {
+    if (typeof queryMemories !== 'function') {
+        throw new Error('makeSemanticEnrichment: an injected `queryMemories` function is required')
+    }
+
+    return async function enrich({query} = {}) {
+        if (typeof query !== 'string' || query.length === 0) {
+            return {themes: [], degraded: true, reason: 'no-query'}
+        }
+
+        let result;
+
+        try {
+            result = await queryMemories({query, nResults})
+        } catch (error) {
+            // best-effort: a semantic-search failure yields no themes but NEVER touches coverage
+            return {themes: [], degraded: true, reason: `enrichment-failed: ${errMsg(error)}`}
+        }
+
+        if (result?.error) {
+            return {themes: [], degraded: true, reason: `enrichment-error: ${result.error}`}
+        }
+
+        const results = Array.isArray(result?.results) ? result.results : [];
+
+        // pass the raw relevance-ranked records through, tagged as theme evidence — the synthesis prompt
+        // decides which fields to foreground; this adapter makes no assumption about the record shape.
+        return {themes: results.map(record => ({...record, type: 'memory'})), degraded: false, reason: null}
+    }
+}

--- a/ai/services/memory-core/helpers/sessionSummaryReader.mjs
+++ b/ai/services/memory-core/helpers/sessionSummaryReader.mjs
@@ -1,0 +1,91 @@
+/**
+ * @module ai/services/memory-core/helpers/sessionSummaryReader
+ * @summary Adapts Memory Core's `listSummaries` into the team-visible session-summary leg of the temporal
+ * Bird View's coverage — the second source the chronological spine consumes alongside `query_recent_turns`.
+ *
+ * `query_recent_turns` is tenant-bound by deliberate multi-tenant design (it AND-filters the requested
+ * identity with the CALLER's userId), so a `unified` walk cannot see a PEER's turns — their turns live under
+ * the peer's userId. `listSummaries` reads the team-visible summary index (deployment-wide under the additive
+ * team policy), so session summaries recover the peer sessions the recency walk structurally cannot, and the
+ * `unified` window stops silently declaring peers exhausted. Summaries are session-grain (`type:'session'`),
+ * carry `impact` (so citationProminence can direct-cite the high-impact ones) and `sessionId` (drill-down).
+ *
+ * This is a COVERAGE source, not enrichment: a read failure degrades coverage honestly rather than being
+ * treated as an empty window.
+ */
+
+/**
+ * @summary Coerces a Date / ISO-8601 string / epoch-ms number to finite epoch milliseconds, or `null`.
+ * @param {(Date|String|Number)} value
+ * @returns {(Number|null)}
+ */
+function toEpochMs(value) {
+    if (value == null) return null;
+    const ms = value instanceof Date ? value.getTime() : new Date(value).getTime();
+    return Number.isNaN(ms) ? null : ms
+}
+
+/**
+ * @summary Builds a `fetchWindowSessions({windowStart, windowEnd, partition})` closure over an injected
+ * `listSummaries`. Walks the timestamp-DESC summary index page-by-page, collecting the summaries inside the
+ * half-open window and stopping once a page runs older than `windowStart` (the index is sorted, so nothing
+ * older can follow).
+ * @param {Object} options
+ * @param {Function} options.listSummaries The bound Memory Core method (injected — keeps this testable).
+ * @param {Number} [options.pageSize=50] Page size for the offset walk.
+ * @returns {Function} `async ({windowStart, windowEnd, partition}) => {sources: Object[], degraded, reason}`.
+ */
+export function makeSessionSummaryReader({listSummaries, pageSize = 50} = {}) {
+    if (typeof listSummaries !== 'function') {
+        throw new Error('makeSessionSummaryReader: an injected `listSummaries` function is required')
+    }
+
+    return async function fetchWindowSessions({windowStart, windowEnd, partition = 'unified'} = {}) {
+        const startMs = toEpochMs(windowStart) ?? -Infinity,
+              endMs   = toEpochMs(windowEnd)   ??  Infinity,
+              // `unified` reads team-wide (no author scope); a `@identity` partition scopes to that author.
+              listArgs = partition && partition !== 'unified' ? {agentIdentity: partition} : {},
+              sources  = [];
+
+        let offset = 0;
+
+        while (true) {
+            let page;
+
+            try {
+                page = await listSummaries({...listArgs, limit: pageSize, offset})
+            } catch (error) {
+                return {sources, degraded: true, reason: `session-summary-read-failed: ${error instanceof Error ? error.message : String(error)}`}
+            }
+
+            if (page?.error) {
+                return {sources, degraded: true, reason: `session-summary-read-error: ${page.error}`}
+            }
+
+            const summaries = Array.isArray(page?.summaries) ? page.summaries : [];
+            if (summaries.length === 0) break;
+
+            let ranOlderThanWindow = false;
+            for (const summary of summaries) {
+                const ts = toEpochMs(summary?.timestamp);
+                if (ts == null) continue;                       // no verifiable timestamp — cannot place in-window
+                if (ts < startMs) { ranOlderThanWindow = true; break } // sorted DESC → nothing newer follows
+                if (ts < endMs) {
+                    sources.push({
+                        id       : summary.id,
+                        timestamp: summary.timestamp,
+                        type     : 'session',
+                        sessionId: summary.sessionId,
+                        impact   : summary.impact,
+                        summary  : summary.summary || summary.title
+                    })
+                }
+            }
+
+            if (ranOlderThanWindow || summaries.length < pageSize) break;
+            offset += summaries.length
+        }
+
+        return {sources, degraded: false, reason: null}
+    }
+}

--- a/ai/services/memory-core/helpers/temporalBirdViewEnvelope.mjs
+++ b/ai/services/memory-core/helpers/temporalBirdViewEnvelope.mjs
@@ -1,0 +1,122 @@
+/**
+ * @module ai/services/memory-core/helpers/temporalBirdViewEnvelope
+ * @summary Assembles the structured, cite-backed, **non-authoritative** Bird View result for the
+ * temporal-pyramid dynamic-synthesis path — the discipline layer that guarantees coverage never
+ * masquerades as complete and a narrative is never claimed over incomplete or degraded retrieval.
+ *
+ * The synthesis path resolves a window, retrieves its source records, and (when coverage is complete)
+ * synthesizes a narrative. This helper wraps that into one honest envelope: it stamps `notAuthority: true`,
+ * hashes the exact source manifest for provenance, carries per-source citations for drill-down, and — the
+ * load-bearing rule — **withholds the narrative whenever coverage is not provably complete**. A caller that
+ * cannot prove it retrieved every resolved source (unknown total, truncation, or an excluded remainder) gets
+ * a deterministic coverage report with `synthesisAvailable: false`, never a confident "what happened" over
+ * a partial read. Nothing here is durable: the envelope is a query-time result, written nowhere.
+ */
+
+/**
+ * @summary Deterministic FNV-1a manifest hash over the sorted source ids.
+ *
+ * This is a change-detection fingerprint of exactly which sources fed a synthesis (provenance / cache
+ * comparison), not a cryptographic digest — order-independent (ids are sorted first) so the same source set
+ * always hashes identically regardless of retrieval order.
+ * @param {String[]} sourceIds
+ * @returns {String} 8-hex-char manifest hash.
+ */
+function hashSourceManifest(sourceIds) {
+    const joined = [...sourceIds].sort().join('\n');
+    let   hash   = 0x811c9dc5;
+
+    for (let i = 0; i < joined.length; i++) {
+        hash ^= joined.charCodeAt(i);
+        hash  = Math.imul(hash, 0x01000193) >>> 0
+    }
+
+    return hash.toString(16).padStart(8, '0')
+}
+
+/**
+ * @summary Coerces a `Date` / ISO-8601 string / epoch-ms number to finite epoch milliseconds, or `null`.
+ * @param {Date|String|Number} value
+ * @returns {Number|null}
+ */
+function toMs(value) {
+    if (value instanceof Date)    return Number.isFinite(value.getTime()) ? value.getTime() : null;
+    if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+    if (typeof value === 'string') return Number.isFinite(Date.parse(value)) ? Date.parse(value) : null;
+
+    return null
+}
+
+/**
+ * @summary Builds the non-authoritative temporal Bird View envelope from a resolved window + retrieved sources.
+ *
+ * Completeness is proven, never assumed: an envelope is `synthesisAvailable: true` only when the caller
+ * supplies a finite `coverage.totalResolved`, every resolved source was included (`excluded === 0`), nothing
+ * was truncated, the caller did not flag `degraded`, AND a `narrative` exists. Any gap withholds the narrative
+ * and records the exact `degradedReason` — the "no confident narrative without complete coverage" contract.
+ *
+ * @param {Object} options
+ * @param {Object} options.window The resolved half-open window (from `resolveTemporalWindow`).
+ * @param {Object[]} [options.sources=[]] Retrieved source records `[{id, type?, ref?}]`; `id` is required per source.
+ * @param {String} [options.narrative=null] The synthesized "what happened" text — used ONLY when coverage is complete.
+ * @param {Object} [options.coverage={}] `{totalResolved?, truncated?, degraded?, degradedReason?}` from retrieval.
+ * @param {Date|String|Number} options.generatedAt Injected generation stamp (never read from a clock internally).
+ * @returns {Object} The `notAuthority` Bird View envelope.
+ */
+export function buildTemporalBirdViewEnvelope({window, sources = [], narrative = null, coverage = {}, generatedAt} = {}) {
+    const generatedMs = toMs(generatedAt);
+
+    if (generatedMs === null) {
+        throw new Error('buildTemporalBirdViewEnvelope: an injected `generatedAt` (Date / ISO-8601 / epoch-ms) is required')
+    }
+
+    if (!window || typeof window !== 'object') {
+        throw new Error('buildTemporalBirdViewEnvelope: a resolved `window` is required')
+    }
+
+    const sourceIds  = (Array.isArray(sources) ? sources : []).map(source => source?.id).filter(Boolean),
+          included   = sourceIds.length,
+          totalKnown = Number.isFinite(coverage.totalResolved),
+          total      = totalKnown ? coverage.totalResolved : included,
+          excluded   = totalKnown ? Math.max(0, total - included) : 0,
+          truncated  = coverage.truncated === true,
+          // completeness must be PROVEN: unknown total, truncation, an excluded remainder, or an explicit
+          // degraded flag each block the narrative — coverage never masquerades as complete.
+          incomplete = !totalKnown || truncated || excluded > 0 || coverage.degraded === true,
+          hasNarrative      = typeof narrative === 'string' && narrative.length > 0,
+          synthesisAvailable = hasNarrative && !incomplete;
+
+    let degradedReason = null;
+
+    if (incomplete) {
+        degradedReason = coverage.degradedReason ||
+            (!totalKnown ? 'coverage-unknown'   :
+             truncated   ? 'source-truncated'   :
+             excluded > 0 ? 'incomplete-inclusion' : 'flagged-degraded')
+    }
+
+    return {
+        window,
+        coverage: {
+            totalResolved: total,
+            included,
+            excluded,
+            truncated,
+            degraded     : incomplete,
+            degradedReason
+        },
+        sourceManifestHash: hashSourceManifest(sourceIds),
+        citations         : (Array.isArray(sources) ? sources : [])
+            .filter(source => source?.id)
+            .map(source => ({
+                type: source.type || 'unknown',
+                id  : source.id,
+                ...(source.ref ? {ref: source.ref} : {})
+            })),
+        synthesis                 : synthesisAvailable ? narrative : null,
+        synthesisAvailable,
+        synthesisUnavailableReason: synthesisAvailable ? null : (incomplete ? 'coverage-incomplete' : 'no-narrative'),
+        generatedAt               : new Date(generatedMs).toISOString(),
+        notAuthority              : true
+    }
+}

--- a/ai/services/memory-core/helpers/temporalBirdViewEnvelope.mjs
+++ b/ai/services/memory-core/helpers/temporalBirdViewEnvelope.mjs
@@ -86,6 +86,12 @@ export function buildTemporalBirdViewEnvelope({window, sources = [], narrative =
           hasNarrative      = typeof narrative === 'string' && narrative.length > 0,
           synthesisAvailable = hasNarrative && !incomplete;
 
+    // per-type counts (e.g. {session, memory}) so a caller sees the session/turn split, not just a total
+    const sourceTypeCounts = {};
+    for (const source of (Array.isArray(sources) ? sources : [])) {
+        if (source?.id) sourceTypeCounts[source.type || 'unknown'] = (sourceTypeCounts[source.type || 'unknown'] || 0) + 1
+    }
+
     let degradedReason = null;
 
     if (incomplete) {
@@ -102,6 +108,7 @@ export function buildTemporalBirdViewEnvelope({window, sources = [], narrative =
             included,
             excluded,
             truncated,
+            sourceTypeCounts,
             degraded     : incomplete,
             degradedReason
         },
@@ -111,6 +118,7 @@ export function buildTemporalBirdViewEnvelope({window, sources = [], narrative =
             .map(source => ({
                 type: source.type || 'unknown',
                 id  : source.id,
+                ...(source.sessionId ? {sessionId: source.sessionId} : {}),
                 ...(source.ref ? {ref: source.ref} : {})
             })),
         synthesis                 : synthesisAvailable ? narrative : null,

--- a/ai/services/memory-core/helpers/temporalBirdViewEnvelope.mjs
+++ b/ai/services/memory-core/helpers/temporalBirdViewEnvelope.mjs
@@ -60,10 +60,14 @@ function toMs(value) {
  * @param {Object[]} [options.sources=[]] Retrieved source records `[{id, type?, ref?}]`; `id` is required per source.
  * @param {String} [options.narrative=null] The synthesized "what happened" text — used ONLY when coverage is complete.
  * @param {Object} [options.coverage={}] `{totalResolved?, truncated?, degraded?, degradedReason?}` from retrieval.
+ * @param {String[]} [options.inferenceInputIds] The ids the synthesis actually enumerated. When supplied, the
+ *   envelope marks each citation `inSynthesis` and reports `coverage.synthesisInputCount` — so a caller on a
+ *   window larger than the prompt bounds sees which citations the narrative could actually have used, distinct
+ *   from the chronological census. Omitted (degraded path / narrative-only synthesize) → citations are unmarked.
  * @param {Date|String|Number} options.generatedAt Injected generation stamp (never read from a clock internally).
  * @returns {Object} The `notAuthority` Bird View envelope.
  */
-export function buildTemporalBirdViewEnvelope({window, sources = [], narrative = null, coverage = {}, generatedAt} = {}) {
+export function buildTemporalBirdViewEnvelope({window, sources = [], narrative = null, coverage = {}, inferenceInputIds, generatedAt} = {}) {
     const generatedMs = toMs(generatedAt);
 
     if (generatedMs === null) {
@@ -92,6 +96,11 @@ export function buildTemporalBirdViewEnvelope({window, sources = [], narrative =
         if (source?.id) sourceTypeCounts[source.type || 'unknown'] = (sourceTypeCounts[source.type || 'unknown'] || 0) + 1
     }
 
+    // census-vs-inference: when the synthesis reports which sources it actually enumerated, the citations
+    // carry `inSynthesis` and coverage exposes `synthesisInputCount` — so a caller on an over-bound window
+    // never reads a citation the narrative could not have used. Absent the manifest, citations stay unmarked.
+    const inferenceSet = Array.isArray(inferenceInputIds) ? new Set(inferenceInputIds) : null;
+
     let degradedReason = null;
 
     if (incomplete) {
@@ -109,6 +118,7 @@ export function buildTemporalBirdViewEnvelope({window, sources = [], narrative =
             excluded,
             truncated,
             sourceTypeCounts,
+            ...(inferenceSet ? {synthesisInputCount: inferenceSet.size} : {}),
             degraded     : incomplete,
             degradedReason
         },
@@ -119,7 +129,8 @@ export function buildTemporalBirdViewEnvelope({window, sources = [], narrative =
                 type: source.type || 'unknown',
                 id  : source.id,
                 ...(source.sessionId ? {sessionId: source.sessionId} : {}),
-                ...(source.ref ? {ref: source.ref} : {})
+                ...(source.ref ? {ref: source.ref} : {}),
+                ...(inferenceSet ? {inSynthesis: inferenceSet.has(source.id)} : {})
             })),
         synthesis                 : synthesisAvailable ? narrative : null,
         synthesisAvailable,

--- a/ai/services/memory-core/helpers/temporalBirdViewSynthesizer.mjs
+++ b/ai/services/memory-core/helpers/temporalBirdViewSynthesizer.mjs
@@ -91,10 +91,15 @@ export async function synthesizeTemporalBirdView({
         return provisional
     }
 
-    let narrative;
+    let narrative, inferenceInputIds;
 
     try {
-        narrative = await synthesize({window, sources})
+        // synthesize may return the bare narrative (legacy / test seam) OR {narrative, inferenceInputIds};
+        // the manifest lets the envelope separate inference inputs from the census on an over-bound window.
+        const synthResult = await synthesize({window, sources});
+
+        narrative         = typeof synthResult === 'string' ? synthResult : synthResult?.narrative;
+        inferenceInputIds = typeof synthResult === 'string' ? undefined   : synthResult?.inferenceInputIds
     } catch (error) {
         return buildTemporalBirdViewEnvelope({
             window,
@@ -104,5 +109,5 @@ export async function synthesizeTemporalBirdView({
         })
     }
 
-    return buildTemporalBirdViewEnvelope({window, sources, coverage, narrative, generatedAt: stamp})
+    return buildTemporalBirdViewEnvelope({window, sources, coverage, narrative, inferenceInputIds, generatedAt: stamp})
 }

--- a/ai/services/memory-core/helpers/temporalBirdViewSynthesizer.mjs
+++ b/ai/services/memory-core/helpers/temporalBirdViewSynthesizer.mjs
@@ -1,0 +1,108 @@
+import {buildTemporalBirdViewEnvelope} from './temporalBirdViewEnvelope.mjs';
+import {resolveTemporalWindow}         from './temporalWindowResolver.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/temporalBirdViewSynthesizer
+ * @summary The composition core of the temporal-pyramid dynamic-synthesis path: resolve a window → retrieve
+ * its sources → (only when coverage is provably complete) synthesize a narrative → wrap in the honest
+ * `notAuthority` envelope.
+ *
+ * The two impure legs — source retrieval and narrative synthesis — are **injected** (`retrieve`, `synthesize`),
+ * so this orchestrator is deterministic and hermetically testable while the real Memory Core / inference
+ * adapters plug into the same seam. Two disciplines are enforced here rather than trusted to the callers:
+ *
+ * 1. **Fail-open synthesis.** A retrieval or synthesis error degrades *this one* Bird View (returns a
+ *    coverage-bearing degraded envelope with the failure reason) — it never throws out of the synthesis. An
+ *    invalid *window request* is the one exception: that is a caller error and propagates, because there is
+ *    no honest window to report against.
+ * 2. **No inference over incomplete coverage.** The LLM synthesis leg is skipped entirely when retrieval
+ *    reports degraded/incomplete coverage — the envelope would withhold the narrative anyway, so a partial
+ *    read must not incur (or pay for) a synthesis call.
+ *
+ * Nothing is written: the whole path is a query-time composition, per the no-durable-above-L2 contract.
+ */
+
+/**
+ * @summary Extracts a safe message string from a thrown value.
+ * @param {*} error
+ * @returns {String}
+ */
+function errMsg(error) {
+    return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * @summary Runs one temporal Bird View synthesis over a resolved window using injected retrieval + synthesis.
+ *
+ * @param {Object} options
+ * @param {String} [options.partition='unified'] Per-agent partition key, or `'unified'`.
+ * @param {String} [options.preset]      A grain preset (mutually exclusive with an explicit window).
+ * @param {Date|String|Number} [options.windowStart] Explicit inclusive start.
+ * @param {Date|String|Number} [options.windowEnd]   Explicit exclusive end.
+ * @param {Date|String|Number} [options.now] Injected reference clock (required for a preset window; also the
+ *   default generation stamp).
+ * @param {Date|String|Number} [options.generatedAt] Injected generation stamp; defaults to `now`.
+ * @param {Function} options.retrieve `async ({window}) => {sources: [{id, type?, ref?}], coverage: {...}}`.
+ * @param {Function} options.synthesize `async ({window, sources}) => string` (called ONLY on complete coverage).
+ * @returns {Promise<Object>} The `notAuthority` Bird View envelope.
+ */
+export async function synthesizeTemporalBirdView({
+    partition, preset, windowStart, windowEnd, now, generatedAt, retrieve, synthesize
+} = {}) {
+    if (typeof retrieve !== 'function') {
+        throw new Error('synthesizeTemporalBirdView: an injected `retrieve` function is required')
+    }
+
+    if (typeof synthesize !== 'function') {
+        throw new Error('synthesizeTemporalBirdView: an injected `synthesize` function is required')
+    }
+
+    // an invalid window request is a CALLER error (no honest window to report against) — it propagates
+    const window = resolveTemporalWindow({partition, preset, windowStart, windowEnd, now}),
+          stamp  = generatedAt !== undefined ? generatedAt : now;
+
+    if (stamp === undefined) {
+        throw new Error('synthesizeTemporalBirdView: a `generatedAt` or `now` stamp is required for the envelope')
+    }
+
+    // retrieval is fail-OPEN: a source-read failure degrades this synthesis, never throws out of it
+    let sources, coverage;
+
+    try {
+        const retrieved = await retrieve({window});
+
+        sources  = Array.isArray(retrieved?.sources) ? retrieved.sources : [];
+        coverage = retrieved?.coverage && typeof retrieved.coverage === 'object' ? retrieved.coverage : {}
+    } catch (error) {
+        return buildTemporalBirdViewEnvelope({
+            window,
+            sources    : [],
+            coverage   : {degraded: true, degradedReason: `retrieval-failed: ${errMsg(error)}`},
+            generatedAt: stamp
+        })
+    }
+
+    // only pay for LLM synthesis when coverage is provably complete — the envelope withholds the narrative
+    // on any gap, so a degraded read must not incur a synthesis call. The provisional envelope is the single
+    // authority for "is this coverage complete?".
+    const provisional = buildTemporalBirdViewEnvelope({window, sources, coverage, generatedAt: stamp});
+
+    if (provisional.coverage.degraded) {
+        return provisional
+    }
+
+    let narrative;
+
+    try {
+        narrative = await synthesize({window, sources})
+    } catch (error) {
+        return buildTemporalBirdViewEnvelope({
+            window,
+            sources,
+            coverage   : {...coverage, degraded: true, degradedReason: `synthesis-failed: ${errMsg(error)}`},
+            generatedAt: stamp
+        })
+    }
+
+    return buildTemporalBirdViewEnvelope({window, sources, coverage, narrative, generatedAt: stamp})
+}

--- a/ai/services/memory-core/helpers/temporalSynthesis.mjs
+++ b/ai/services/memory-core/helpers/temporalSynthesis.mjs
@@ -29,6 +29,42 @@ function sourceLine(source) {
 }
 
 /**
+ * @summary The bounded prominent + context slices that actually enter the synthesis prompt.
+ *
+ * The prompt cites prominent sources directly and enumerates context sources up to a bound; sources past the
+ * bound are noted only as an overflow count — their facts never reach the model. This is the single place that
+ * decides *what the synthesis actually saw*, so both the prompt renderer and the inference-input manifest
+ * derive from it and can never drift apart.
+ * @param {Object[]} [sources=[]]
+ * @returns {{prominent: Object[], context: Object[], contextOverflow: Number}}
+ */
+function selectSynthesisSources(sources = []) {
+    const {prominent, context} = partitionByProminence(sources);
+
+    return {
+        prominent      : prominent.slice(0, MAX_PROMINENT_CITED),
+        context        : context.slice(0, MAX_CONTEXT_ENUMERATED),
+        contextOverflow: Math.max(0, context.length - MAX_CONTEXT_ENUMERATED)
+    }
+}
+
+/**
+ * @summary The ids of the sources the synthesis actually enumerated in its prompt — its inference inputs.
+ *
+ * For a window whose source count fits the prompt bounds this equals the full chronological census; for a
+ * larger window it is the bounded subset the narrative was built from. Exposing it lets the envelope
+ * distinguish *inference inputs* from the census it also carries, so a caller never reads a citation the
+ * narrative could not have used.
+ * @param {Object[]} [sources=[]]
+ * @returns {String[]}
+ */
+export function selectSynthesisInputIds(sources = []) {
+    const {prominent, context} = selectSynthesisSources(sources);
+
+    return [...prominent, ...context].map(source => source?.id).filter(Boolean)
+}
+
+/**
  * @summary Builds the temporal synthesis prompt from a resolved window, admitted sources, and theme evidence.
  *
  * The concise-narrative instruction foregrounds `prominent` sources (direct citation) and enumerates the
@@ -43,20 +79,19 @@ function sourceLine(source) {
  * @returns {String} The synthesis prompt.
  */
 export function buildTemporalSynthesisPrompt({window, sources = [], themes = []} = {}) {
-    const {prominent, context} = partitionByProminence(sources),
-          citedProminent       = prominent.slice(0, MAX_PROMINENT_CITED),
-          citedThemes          = (Array.isArray(themes) ? themes : []).slice(0, MAX_THEMES);
+    const {prominent, context, contextOverflow} = selectSynthesisSources(sources),
+          citedThemes                           = (Array.isArray(themes) ? themes : []).slice(0, MAX_THEMES);
 
     const lines = [
         `You are summarizing what happened in one time window of an engineering team's activity.`,
         `Window: [${window?.windowStartIso ?? window?.windowStart}, ${window?.windowEndIso ?? window?.windowEnd}) — half-open, partition "${window?.partition ?? 'unified'}".`,
         ``,
         `PROMINENT sources — cite each you use directly by its id:`,
-        ...(citedProminent.length ? citedProminent.map(sourceLine) : ['- (none)']),
+        ...(prominent.length ? prominent.map(sourceLine) : ['- (none)']),
         ``,
         `CONTEXT — further in-window sources; this is what those turns were about, so cite them by id where relevant:`,
-        ...(context.length ? context.slice(0, MAX_CONTEXT_ENUMERATED).map(sourceLine) : ['- (none)']),
-        ...(context.length > MAX_CONTEXT_ENUMERATED ? [`- …and ${context.length - MAX_CONTEXT_ENUMERATED} more in-window source(s), bounded for prompt size`] : []),
+        ...(context.length ? context.map(sourceLine) : ['- (none)']),
+        ...(contextOverflow > 0 ? [`- …and ${contextOverflow} more in-window source(s), bounded for prompt size`] : []),
         ``,
         `THEME EVIDENCE (semantic, best-effort — may be incomplete):`,
         ...(citedThemes.length ? citedThemes.map(theme => `- ${theme.document || theme.text || theme.summary || theme.id}`) : ['- (none surfaced)']),
@@ -72,9 +107,13 @@ export function buildTemporalSynthesisPrompt({window, sources = [], themes = []}
 
 /**
  * @summary Builds a `synthesize({window, sources, themes})` closure over an injected LLM `generate`.
+ *
+ * The closure returns the narrative AND `inferenceInputIds` — the ids the prompt actually enumerated — so the
+ * envelope can distinguish inference inputs from the chronological census on a window larger than the prompt
+ * bounds. The narrative-only `string` shape stays valid for callers/tests that inject a bare `generate`.
  * @param {Object} options
  * @param {Function} options.generate The injected model call — `async ({prompt}) => string | {content: string}`.
- * @returns {Function} `async ({window, sources, themes}) => string` (the narrative).
+ * @returns {Function} `async ({window, sources, themes}) => {narrative: String, inferenceInputIds: String[]}`.
  */
 export function makeTemporalSynthesize({generate} = {}) {
     if (typeof generate !== 'function') {
@@ -90,6 +129,6 @@ export function makeTemporalSynthesize({generate} = {}) {
             throw new Error('temporal synthesis produced no narrative')
         }
 
-        return narrative
+        return {narrative, inferenceInputIds: selectSynthesisInputIds(sources)}
     }
 }

--- a/ai/services/memory-core/helpers/temporalSynthesis.mjs
+++ b/ai/services/memory-core/helpers/temporalSynthesis.mjs
@@ -13,8 +13,9 @@ import {partitionByProminence} from './citationProminence.mjs';
  * rather than returning an empty "what happened".
  */
 
-const MAX_PROMINENT_CITED = 40,
-      MAX_THEMES          = 20;
+const MAX_PROMINENT_CITED    = 40,
+      MAX_CONTEXT_ENUMERATED = 60,
+      MAX_THEMES             = 20;
 
 /**
  * @summary Renders one source as a compact prompt line `- <type> <id>[: <title>]`.
@@ -30,10 +31,10 @@ function sourceLine(source) {
 /**
  * @summary Builds the temporal synthesis prompt from a resolved window, admitted sources, and theme evidence.
  *
- * The concise-narrative instruction foregrounds `prominent` sources (direct citation) and gives the `context`
- * only as a bounded count — every source stays in the coverage manifest elsewhere, so the prompt bounds
- * density without dropping admission. `themes` (best-effort semantic evidence) inform emphasis, never
- * coverage.
+ * The concise-narrative instruction foregrounds `prominent` sources (direct citation) and enumerates the
+ * `context` sources' facts up to a bound — so the model sees what those turns were about rather than a bare
+ * count it could cite past — noting any overflow. `themes` (best-effort semantic evidence) inform emphasis,
+ * never coverage.
  *
  * @param {Object} options
  * @param {Object} options.window The resolved half-open window.
@@ -53,7 +54,9 @@ export function buildTemporalSynthesisPrompt({window, sources = [], themes = []}
         `PROMINENT sources — cite each you use directly by its id:`,
         ...(citedProminent.length ? citedProminent.map(sourceLine) : ['- (none)']),
         ``,
-        `CONTEXT: ${context.length} further admitted source(s) inform the window but need not be enumerated.`,
+        `CONTEXT — further in-window sources; this is what those turns were about, so cite them by id where relevant:`,
+        ...(context.length ? context.slice(0, MAX_CONTEXT_ENUMERATED).map(sourceLine) : ['- (none)']),
+        ...(context.length > MAX_CONTEXT_ENUMERATED ? [`- …and ${context.length - MAX_CONTEXT_ENUMERATED} more in-window source(s), bounded for prompt size`] : []),
         ``,
         `THEME EVIDENCE (semantic, best-effort — may be incomplete):`,
         ...(citedThemes.length ? citedThemes.map(theme => `- ${theme.document || theme.text || theme.summary || theme.id}`) : ['- (none surfaced)']),

--- a/ai/services/memory-core/helpers/temporalSynthesis.mjs
+++ b/ai/services/memory-core/helpers/temporalSynthesis.mjs
@@ -1,0 +1,92 @@
+import {partitionByProminence} from './citationProminence.mjs';
+
+/**
+ * @module ai/services/memory-core/helpers/temporalSynthesis
+ * @summary Builds the "what happened in this window" synthesis prompt and adapts an injected LLM `generate`
+ * into the `synthesize({window, sources, themes})` seam the Bird View orchestrator calls.
+ *
+ * Two fidelity rules are baked into the prompt, not left to the model's discretion: prominent sources
+ * (high-impact sessions, accepted ADRs, named-marker PRs) are the ones the narrative must cite directly, and
+ * the model may use ONLY the provided sources/themes — no invented events, no outside knowledge. The prompt
+ * builder is pure (hermetically testable); the adapter wraps it with the injected `generate` so the model
+ * call stays a seam. A generation that yields no narrative throws, so the orchestrator degrades the envelope
+ * rather than returning an empty "what happened".
+ */
+
+const MAX_PROMINENT_CITED = 40,
+      MAX_THEMES          = 20;
+
+/**
+ * @summary Renders one source as a compact prompt line `- <type> <id>[: <title>]`.
+ * @param {Object} source
+ * @returns {String}
+ */
+function sourceLine(source) {
+    const title = source.title || source.name || source.summary || '';
+
+    return `- ${source.type || 'source'} ${source.id}${title ? `: ${title}` : ''}`
+}
+
+/**
+ * @summary Builds the temporal synthesis prompt from a resolved window, admitted sources, and theme evidence.
+ *
+ * The concise-narrative instruction foregrounds `prominent` sources (direct citation) and gives the `context`
+ * only as a bounded count — every source stays in the coverage manifest elsewhere, so the prompt bounds
+ * density without dropping admission. `themes` (best-effort semantic evidence) inform emphasis, never
+ * coverage.
+ *
+ * @param {Object} options
+ * @param {Object} options.window The resolved half-open window.
+ * @param {Object[]} [options.sources=[]] The admitted window sources.
+ * @param {Object[]} [options.themes=[]] Best-effort theme evidence (may be empty).
+ * @returns {String} The synthesis prompt.
+ */
+export function buildTemporalSynthesisPrompt({window, sources = [], themes = []} = {}) {
+    const {prominent, context} = partitionByProminence(sources),
+          citedProminent       = prominent.slice(0, MAX_PROMINENT_CITED),
+          citedThemes          = (Array.isArray(themes) ? themes : []).slice(0, MAX_THEMES);
+
+    const lines = [
+        `You are summarizing what happened in one time window of an engineering team's activity.`,
+        `Window: [${window?.windowStartIso ?? window?.windowStart}, ${window?.windowEndIso ?? window?.windowEnd}) — half-open, partition "${window?.partition ?? 'unified'}".`,
+        ``,
+        `PROMINENT sources — cite each you use directly by its id:`,
+        ...(citedProminent.length ? citedProminent.map(sourceLine) : ['- (none)']),
+        ``,
+        `CONTEXT: ${context.length} further admitted source(s) inform the window but need not be enumerated.`,
+        ``,
+        `THEME EVIDENCE (semantic, best-effort — may be incomplete):`,
+        ...(citedThemes.length ? citedThemes.map(theme => `- ${theme.document || theme.text || theme.summary || theme.id}`) : ['- (none surfaced)']),
+        ``,
+        `Write a concise narrative of what happened in this window: the notable decisions, friction, and`,
+        `outcomes. Cite prominent sources by id inline. Use ONLY the sources and themes above — do not invent`,
+        `events and do not draw on outside knowledge. If the provided evidence is thin, say so plainly rather`,
+        `than embellishing.`
+    ];
+
+    return lines.join('\n')
+}
+
+/**
+ * @summary Builds a `synthesize({window, sources, themes})` closure over an injected LLM `generate`.
+ * @param {Object} options
+ * @param {Function} options.generate The injected model call — `async ({prompt}) => string | {content: string}`.
+ * @returns {Function} `async ({window, sources, themes}) => string` (the narrative).
+ */
+export function makeTemporalSynthesize({generate} = {}) {
+    if (typeof generate !== 'function') {
+        throw new Error('makeTemporalSynthesize: an injected `generate` function is required')
+    }
+
+    return async function synthesize({window, sources = [], themes = []} = {}) {
+        const prompt    = buildTemporalSynthesisPrompt({window, sources, themes}),
+              result    = await generate({prompt}),
+              narrative = typeof result === 'string' ? result : result?.content;
+
+        if (typeof narrative !== 'string' || narrative.length === 0) {
+            throw new Error('temporal synthesis produced no narrative')
+        }
+
+        return narrative
+    }
+}

--- a/ai/services/memory-core/helpers/temporalWindowResolver.mjs
+++ b/ai/services/memory-core/helpers/temporalWindowResolver.mjs
@@ -1,0 +1,161 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * @module ai/services/memory-core/helpers/temporalWindowResolver
+ * @summary Pure window resolution for the temporal-pyramid dynamic-synthesis path — turns a caller's
+ * `(partition, preset | explicit windowStart/windowEnd)` request into a validated **half-open**
+ * `[windowStart, windowEnd)` interval with a declared filter-set.
+ *
+ * This is the deterministic front of the on-demand weekly / monthly / quarterly synthesis path: it decides
+ * WHICH window to synthesize and nothing else — it never touches storage or inference and writes no durable
+ * output. The named grains (weekly / monthly / quarterly) and the finer arbitrary grains (daily / 3-day)
+ * resolve through the SAME path, and an arbitrary `(windowStart, windowEnd)` is a first-class call, not a
+ * retrofit. Half-open boundaries keep adjacent windows non-overlapping: an event at exactly `windowEnd`
+ * belongs to the next window, never to both.
+ *
+ * The reference clock is **injected** (`now`), never read internally — a synthesis run is deterministic and
+ * replayable from its resolved window, so the same request against the same clock always resolves the same
+ * interval. `filterSet` is carried on every result because cross-window comparisons are only defined within
+ * an identical filter set (partition + grain); a comparison across differing filter sets is undefined, not
+ * merely noisy.
+ */
+
+/**
+ * The duration-based grain presets. Each names its pyramid tier where one exists — weekly/monthly/quarterly
+ * are the L3/L4/L5 dynamic tiers; the finer daily/3-day grains are first-class arbitrary windows below the
+ * pyramid and carry `tier: null`. Release (cut-to-cut) windows are NOT duration-based and resolve through a
+ * separate release-boundary lookup, so they are deliberately absent from this pure duration map.
+ * @type {Object<String, {durationMs: Number, tier: (String|null)}>}
+ */
+const TEMPORAL_WINDOW_PRESETS = Object.freeze({
+    'daily'    : {durationMs:  1 * DAY_MS, tier: null},
+    '3-day'    : {durationMs:  3 * DAY_MS, tier: null},
+    'weekly'   : {durationMs:  7 * DAY_MS, tier: 'L3'},
+    'monthly'  : {durationMs: 30 * DAY_MS, tier: 'L4'},
+    'quarterly': {durationMs: 90 * DAY_MS, tier: 'L5'}
+});
+
+/**
+ * @summary Returns the sorted list of supported grain presets (for callers / OpenAPI enums / diagnostics).
+ * @returns {String[]}
+ */
+export function getTemporalWindowPresets() {
+    return Object.keys(TEMPORAL_WINDOW_PRESETS)
+}
+
+/**
+ * @summary Coerces a `Date` / ISO-8601 string / epoch-ms number to finite epoch milliseconds, or `null`.
+ *
+ * A pure boundary parser: it never invents a value. `null`/`undefined`/unparseable inputs return `null` so
+ * the caller fails loud with a precise message rather than silently synthesizing a wrong window.
+ * @param {Date|String|Number} value
+ * @returns {Number|null}
+ */
+function toEpochMs(value) {
+    if (value === undefined || value === null) return null;
+
+    if (value instanceof Date) {
+        const time = value.getTime();
+        return Number.isFinite(time) ? time : null
+    }
+
+    if (typeof value === 'number') {
+        return Number.isFinite(value) ? value : null
+    }
+
+    if (typeof value === 'string') {
+        const time = Date.parse(value);
+        return Number.isFinite(time) ? time : null
+    }
+
+    return null
+}
+
+/**
+ * @summary Assembles the resolved-window descriptor shared by both the explicit and preset paths.
+ * @param {Object} options
+ * @param {String} options.partition Per-agent partition key, or `'unified'`.
+ * @param {Number} options.start     Inclusive window start (epoch ms).
+ * @param {Number} options.end       Exclusive window end (epoch ms).
+ * @param {String|null} options.preset The named grain preset, or `null` for an explicit window.
+ * @param {String|null} options.tier   The pyramid tier (`'L3'|'L4'|'L5'`), or `null` for finer/explicit windows.
+ * @returns {Object} The resolved half-open window with declared filter-set semantics.
+ */
+function buildResolvedWindow({partition, start, end, preset, tier}) {
+    return {
+        partition,
+        preset,
+        tier,
+        windowStart    : start,
+        windowEnd      : end,
+        windowStartIso : new Date(start).toISOString(),
+        windowEndIso   : new Date(end).toISOString(),
+        windowSemantics: {
+            interval  : 'half-open',
+            durationMs: end - start,
+            filterSet : {grain: preset || 'explicit', partition}
+        }
+    }
+}
+
+/**
+ * @summary Resolves a temporal synthesis request into a validated half-open `[windowStart, windowEnd)` window.
+ *
+ * Two mutually-exclusive request shapes, one path:
+ * - **explicit** — supply `windowStart` and `windowEnd` (Date / ISO / epoch-ms); the window is used verbatim
+ *   after validation. No `now` is needed.
+ * - **preset** — supply a grain `preset` (see {@link getTemporalWindowPresets}); the window is `[now - grain,
+ *   now)` and an injected `now` reference is REQUIRED (never read internally, so the run stays deterministic).
+ *
+ * Fails loud on every ambiguous or invalid request — an unparseable bound, a non-`start < end` interval, an
+ * unknown preset, a preset without `now`, or a request that supplies neither shape — rather than synthesizing
+ * a silently-wrong window.
+ *
+ * @param {Object} options
+ * @param {String} [options.partition='unified'] Per-agent partition key, or `'unified'` for the cross-agent view.
+ * @param {String} [options.preset]      A grain preset (`'daily'|'3-day'|'weekly'|'monthly'|'quarterly'`).
+ * @param {Date|String|Number} [options.windowStart] Explicit inclusive start (mutually exclusive with `preset`).
+ * @param {Date|String|Number} [options.windowEnd]   Explicit exclusive end.
+ * @param {Date|String|Number} [options.now] Injected reference clock — REQUIRED for a preset window.
+ * @returns {{partition: String, preset: (String|null), tier: (String|null), windowStart: Number, windowEnd: Number, windowStartIso: String, windowEndIso: String, windowSemantics: Object}}
+ */
+export function resolveTemporalWindow({partition = 'unified', preset, windowStart, windowEnd, now} = {}) {
+    const hasExplicit = windowStart !== undefined || windowEnd !== undefined;
+
+    if (hasExplicit) {
+        if (preset !== undefined) {
+            throw new Error('resolveTemporalWindow: pass EITHER a preset OR an explicit windowStart/windowEnd, not both')
+        }
+
+        const start = toEpochMs(windowStart),
+              end   = toEpochMs(windowEnd);
+
+        if (start === null || end === null) {
+            throw new Error('resolveTemporalWindow: an explicit window needs a parseable windowStart AND windowEnd (Date / ISO-8601 / epoch-ms)')
+        }
+
+        if (!(start < end)) {
+            throw new Error('resolveTemporalWindow: a half-open window requires windowStart < windowEnd')
+        }
+
+        return buildResolvedWindow({partition, start, end, preset: null, tier: null})
+    }
+
+    if (preset === undefined) {
+        throw new Error('resolveTemporalWindow: supply either a preset or an explicit windowStart/windowEnd')
+    }
+
+    const presetDef = TEMPORAL_WINDOW_PRESETS[preset];
+
+    if (!presetDef) {
+        throw new Error(`resolveTemporalWindow: unknown grain preset "${preset}" (supported: ${getTemporalWindowPresets().join(', ')})`)
+    }
+
+    const nowMs = toEpochMs(now);
+
+    if (nowMs === null) {
+        throw new Error('resolveTemporalWindow: a preset window requires an injected `now` reference (Date / ISO-8601 / epoch-ms)')
+    }
+
+    return buildResolvedWindow({partition, start: nowMs - presetDef.durationMs, end: nowMs, preset, tier: presetDef.tier})
+}

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -267,6 +267,7 @@ const expectedMemoryCoreToolTiers = {
     pre_brief_session            : 'extended',
     get_all_summaries            : 'read',
     query_summaries              : 'read',
+    explore_memory_history       : 'read',
     purge_session                : 'admin',
     resume_session               : 'extended',
     set_session_id               : 'extended',

--- a/test/playwright/unit/ai/services/memory-core/chatModelGenerate.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/chatModelGenerate.spec.mjs
@@ -1,0 +1,47 @@
+import {test, expect}          from '@playwright/test';
+import {makeChatModelGenerate} from '../../../../../../ai/services/memory-core/helpers/chatModelGenerate.mjs';
+
+// a stub chat model mirroring the buildChatModel contract: generateContent(prompt, opts) -> {response:{text()}}
+const stubModel = (text, capture) => ({
+    generateContent: async (prompt, opts) => {
+        capture?.({prompt, opts});
+        return {response: {text: () => text}}
+    }
+});
+
+test.describe('chatModelGenerate — the buildChatModel -> generate seam (fails loud for synthesis)', () => {
+    test('builds the model, passes the prompt + opts to generateContent, returns the extracted text', async () => {
+        let seen = null;
+
+        const generate = makeChatModelGenerate({buildModel: () => stubModel('a bird view narrative', c => { seen = c }), timeoutMs: 5000}),
+              text     = await generate({prompt: 'summarize the window'});
+
+        expect(text).toBe('a bird view narrative');
+        expect(seen.prompt).toBe('summarize the window');
+        expect(seen.opts).toMatchObject({timeoutMs: 5000, operationLabel: 'temporal bird view synthesis', priority: 'interactive'})
+    });
+
+    test('a null model (no configured provider) throws — synthesis degrades rather than emitting empty prose', async () => {
+        const generate = makeChatModelGenerate({buildModel: () => null});
+
+        await expect(generate({prompt: 'x'})).rejects.toThrow(/no chat model provider is configured/)
+    });
+
+    test('an empty/whitespace-less completion throws (no text extracted)', async () => {
+        const emptyString = makeChatModelGenerate({buildModel: () => stubModel('')}),
+              nullText    = makeChatModelGenerate({buildModel: () => ({generateContent: async () => ({response: {text: () => null}})})});
+
+        await expect(emptyString({prompt: 'x'})).rejects.toThrow(/returned no text/);
+        await expect(nullText({prompt: 'x'})).rejects.toThrow(/returned no text/)
+    });
+
+    test('a response missing the text() accessor throws rather than returning undefined', async () => {
+        const generate = makeChatModelGenerate({buildModel: () => ({generateContent: async () => ({response: {}})})});
+
+        await expect(generate({prompt: 'x'})).rejects.toThrow(/returned no text/)
+    });
+
+    test('the injected buildModel is required', () => {
+        expect(() => makeChatModelGenerate({})).toThrow(/buildModel/)
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/chronologicalWindowSources.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/chronologicalWindowSources.spec.mjs
@@ -1,0 +1,124 @@
+import {test, expect}                        from '@playwright/test';
+import {enumerateChronologicalWindowSources} from '../../../../../../ai/services/memory-core/helpers/chronologicalWindowSources.mjs';
+
+// simple half-open window [1000, 2000) in epoch-ms; item timestamps are plain ms for clarity
+const WINDOW = {windowStart: 1000, windowEnd: 2000};
+
+// a per-identity paginator: pagesByIdentity[identity] is an ordered [{items, nextCursor}] list.
+// cursor is the page index; undefined → page 0, each page names its own nextCursor (next index or null).
+const pager = (pagesByIdentity, onFetch) => async ({identity, cursor}) => {
+    onFetch?.({identity, cursor});
+    const pages = pagesByIdentity[identity] || [];
+    return pages[cursor === undefined ? 0 : cursor] || {items: [], nextCursor: null}
+};
+
+test.describe('chronologicalWindowSources — the recency-exhaustion completeness spine', () => {
+    test('single identity, one exhausted page, all in-window → complete coverage', async () => {
+        const {sources, coverage} = await enumerateChronologicalWindowSources({
+            window    : WINDOW,
+            identities: ['@a'],
+            fetchPage : pager({'@a': [{items: [{id: 's1', timestamp: 1500}], nextCursor: null}]})
+        });
+
+        expect(sources.map(s => s.id)).toEqual(['s1']);
+        expect(coverage).toMatchObject({totalResolved: 1, identitiesWalked: 1, exhausted: true, degraded: false, degradedReason: null})
+    });
+
+    test('walks nextCursor to exhaustion across multiple pages', async () => {
+        const {sources, coverage} = await enumerateChronologicalWindowSources({
+            window    : WINDOW,
+            identities: ['@a'],
+            fetchPage : pager({'@a': [
+                {items: [{id: 's1', timestamp: 1800}], nextCursor: 1},
+                {items: [{id: 's2', timestamp: 1200}], nextCursor: null}
+            ]})
+        });
+
+        expect(sources.map(s => s.id).sort()).toEqual(['s1', 's2']);
+        expect(coverage.exhausted).toBe(true)
+    });
+
+    test('early-stops once a page predates the window start — no over-paging', async () => {
+        let fetches = 0;
+
+        const {sources, coverage} = await enumerateChronologicalWindowSources({
+            window    : WINDOW,
+            identities: ['@a'],
+            fetchPage : pager({'@a': [
+                // this page already contains an item older than windowStart(1000) → the walk must STOP here
+                {items: [{id: 's1', timestamp: 1500}, {id: 'old', timestamp: 500}], nextCursor: 1},
+                {items: [{id: 'should-not-be-fetched', timestamp: 1400}], nextCursor: null}
+            ]}, () => { fetches++ })
+        });
+
+        expect(sources.map(s => s.id)).toEqual(['s1']);   // 500 is out of window; the second page is never walked
+        expect(fetches).toBe(1);
+        expect(coverage.exhausted).toBe(true)
+    });
+
+    test('filters half-open: an item at exactly windowEnd is excluded (too new), one at windowStart is included', async () => {
+        const {sources} = await enumerateChronologicalWindowSources({
+            window    : WINDOW,
+            identities: ['@a'],
+            fetchPage : pager({'@a': [{items: [
+                {id: 'too-new', timestamp: 2000},   // == windowEnd → excluded (half-open)
+                {id: 'edge',    timestamp: 1000},   // == windowStart → included
+                {id: 'mid',     timestamp: 1500}
+            ], nextCursor: null}]})
+        });
+
+        expect(sources.map(s => s.id).sort()).toEqual(['edge', 'mid'])
+    });
+
+    test('unified: walks every identity and cross-agent de-duplicates by id', async () => {
+        const {sources, coverage} = await enumerateChronologicalWindowSources({
+            window    : WINDOW,
+            identities: ['@a', '@b'],
+            fetchPage : pager({
+                '@a': [{items: [{id: 'shared', timestamp: 1500}],                              nextCursor: null}],
+                '@b': [{items: [{id: 'shared', timestamp: 1500}, {id: 'b1', timestamp: 1600}], nextCursor: null}]
+            })
+        });
+
+        expect(sources.map(s => s.id).sort()).toEqual(['b1', 'shared']);   // 'shared' counted once
+        expect(coverage).toMatchObject({totalResolved: 2, identitiesWalked: 2, exhausted: true, degraded: false})
+    });
+
+    test('a page-fetch failure degrades (never throws) and preserves the sources it did enumerate', async () => {
+        const {sources, coverage} = await enumerateChronologicalWindowSources({
+            window    : WINDOW,
+            identities: ['@a', '@b'],
+            fetchPage : async ({identity}) => {
+                if (identity === '@b') throw new Error('cursor lost');
+                return {items: [{id: 'a1', timestamp: 1500}], nextCursor: null}
+            }
+        });
+
+        expect(sources.map(s => s.id)).toEqual(['a1']);       // @a's sources survive
+        expect(coverage.exhausted).toBe(false);
+        expect(coverage.degraded).toBe(true);
+        expect(coverage.degradedReason).toMatch(/chronological-walk-incomplete: @b: cursor lost/)
+    });
+
+    test('a runaway page cap degrades with a page-cap reason (never spins forever)', async () => {
+        const {coverage} = await enumerateChronologicalWindowSources({
+            window             : WINDOW,
+            identities         : ['@a'],
+            maxPagesPerIdentity: 2,
+            // every page stays in-window and always has a nextCursor → only the cap ends it
+            fetchPage          : async () => ({items: [{id: `s-${Math.random()}`, timestamp: 1500}], nextCursor: 'more'})
+        });
+
+        expect(coverage.exhausted).toBe(false);
+        expect(coverage.degraded).toBe(true);
+        expect(coverage.degradedReason).toMatch(/page-cap/)
+    });
+
+    test('fails loud on a missing window, fetchPage, or identities', async () => {
+        const ok = pager({'@a': []});
+
+        await expect(enumerateChronologicalWindowSources({identities: ['@a'], fetchPage: ok})).rejects.toThrow(/window/);
+        await expect(enumerateChronologicalWindowSources({window: WINDOW, identities: ['@a']})).rejects.toThrow(/fetchPage/);
+        await expect(enumerateChronologicalWindowSources({window: WINDOW, identities: [], fetchPage: ok})).rejects.toThrow(/identity/)
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/citationProminence.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/citationProminence.spec.mjs
@@ -1,0 +1,69 @@
+import {test, expect}                                      from '@playwright/test';
+import {annotateCitationProminence, partitionByProminence} from '../../../../../../ai/services/memory-core/helpers/citationProminence.mjs';
+
+test.describe('citationProminence — prominence is emphasis, never admission', () => {
+    test('impact >= 90 sessions are prominent; lower-impact sessions are admitted but not foregrounded', () => {
+        const annotated = annotateCitationProminence([
+            {id: 'hi',  type: 'session', impact: 90},
+            {id: 'higher', type: 'session', impact: 97},
+            {id: 'lo',  type: 'session', impact: 42}
+        ]);
+
+        expect(annotated.find(s => s.id === 'hi').prominent).toBe(true);
+        expect(annotated.find(s => s.id === 'higher').prominent).toBe(true);
+        expect(annotated.find(s => s.id === 'lo').prominent).toBe(false)
+    });
+
+    test('accepted ADRs are prominent; non-accepted ADRs are not', () => {
+        const annotated = annotateCitationProminence([
+            {id: 'adr-28', type: 'adr', accepted: true},
+            {id: 'adr-99', type: 'adr', accepted: false}
+        ]);
+
+        expect(annotated.find(s => s.id === 'adr-28').prominent).toBe(true);
+        expect(annotated.find(s => s.id === 'adr-99').prominent).toBe(false)
+    });
+
+    test('a PR is prominent only through a NAMED fidelity marker — never an invented impact score', () => {
+        const annotated = annotateCitationProminence([
+            {id: 'pr-adr',   type: 'pull-request', acceptedAdrLink: 'ADR-0028'},
+            {id: 'pr-epic',  type: 'pull-request', epicLabel: 'epic:temporal-pyramid'},
+            {id: 'pr-review', type: 'pull-request', highImpactReview: true},
+            {id: 'pr-bare',  type: 'pull-request'},
+            // a raw numeric "impact" on a PR must NOT confer prominence (no universal PR impact score)
+            {id: 'pr-score', type: 'pull-request', impact: 100}
+        ]);
+
+        expect(annotated.find(s => s.id === 'pr-adr').prominent).toBe(true);
+        expect(annotated.find(s => s.id === 'pr-epic').prominent).toBe(true);
+        expect(annotated.find(s => s.id === 'pr-review').prominent).toBe(true);
+        expect(annotated.find(s => s.id === 'pr-bare').prominent).toBe(false);
+        expect(annotated.find(s => s.id === 'pr-score').prominent).toBe(false)
+    });
+
+    test('partitionByProminence drops NOTHING — prominent + context === the full admitted manifest', () => {
+        const sources = [
+            {id: 'a', type: 'session', impact: 95},
+            {id: 'b', type: 'session', impact: 10},
+            {id: 'c', type: 'adr', accepted: true},
+            {id: 'd', type: 'pull-request'}
+        ];
+
+        const {prominent, context} = partitionByProminence(sources);
+
+        expect(prominent.map(s => s.id).sort()).toEqual(['a', 'c']);
+        expect(context.map(s => s.id).sort()).toEqual(['b', 'd']);
+        // admission invariant: nothing is dropped
+        expect(prominent.length + context.length).toBe(sources.length)
+    });
+
+    test('order is preserved and an unknown source type is never prominent', () => {
+        const annotated = annotateCitationProminence([
+            {id: 'x', type: 'mystery'},
+            {id: 'y', type: 'session', impact: 91}
+        ]);
+
+        expect(annotated.map(s => s.id)).toEqual(['x', 'y']);   // order preserved
+        expect(annotated[0].prominent).toBe(false)
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/exploreMemoryHistory.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/exploreMemoryHistory.spec.mjs
@@ -1,0 +1,82 @@
+import {test, expect}         from '@playwright/test';
+import {exploreMemoryHistory} from '../../../../../../ai/services/memory-core/helpers/exploreMemoryHistory.mjs';
+
+const NOW = '2026-07-12T12:00:00.000Z';   // preset 'weekly' → window [2026-07-05T12:00Z, 2026-07-12T12:00Z)
+
+// a deps builder with sensible in-window defaults; override any leg per test
+const makeDeps = (over = {}) => ({
+    listIdentities  : async () => ['@a', '@b'],
+    queryRecentTurns: async ({agentIdentity}) => ({
+        turns     : [{id: `turn-${agentIdentity}`, timestamp: '2026-07-08T00:00:00.000Z'}],
+        nextCursor: null   // one exhausted page → complete coverage
+    }),
+    queryMemories: async () => ({results: [{id: 'm1', document: 'a recurring theme'}]}),
+    generate     : async () => 'Two sessions of work happened this week.',
+    ...over
+});
+
+test.describe('exploreMemoryHistory — the full Memory/session Bird View composition (8 primitives end-to-end)', () => {
+    test('unified happy path: walks the roster, complete coverage, enriched + synthesized envelope', async () => {
+        const envelope = await exploreMemoryHistory({partition: 'unified', preset: 'weekly', now: NOW, deps: makeDeps()});
+
+        expect(envelope.notAuthority).toBe(true);
+        expect(envelope.synthesisAvailable).toBe(true);
+        expect(envelope.synthesis).toBe('Two sessions of work happened this week.');
+        expect(envelope.coverage).toMatchObject({totalResolved: 2, degraded: false});
+        expect(envelope.citations.map(c => c.id).sort()).toEqual(['turn-@a', 'turn-@b']);
+        expect(envelope.window.preset).toBe('weekly')
+    });
+
+    test('an @identity partition walks exactly that identity — the roster is never consulted', async () => {
+        let rosterCalls = 0;
+
+        const envelope = await exploreMemoryHistory({
+            partition: '@a',
+            preset   : 'weekly',
+            now      : NOW,
+            deps     : makeDeps({listIdentities: async () => { rosterCalls++; return ['@a', '@b'] }})
+        });
+
+        expect(rosterCalls).toBe(0);
+        expect(envelope.citations.map(c => c.id)).toEqual(['turn-@a'])
+    });
+
+    test('a recency-spine failure degrades the envelope and the LLM is never called', async () => {
+        let generateCalls = 0;
+
+        const envelope = await exploreMemoryHistory({
+            partition: '@a',
+            preset   : 'weekly',
+            now      : NOW,
+            deps     : makeDeps({
+                // queryRecentTurns signals failure by RETURNING an error envelope
+                queryRecentTurns: async () => ({error: 'graph unavailable', message: 'chroma down'}),
+                generate        : async () => { generateCalls++; return 'x' }
+            })
+        });
+
+        expect(envelope.synthesisAvailable).toBe(false);
+        expect(envelope.coverage.degraded).toBe(true);
+        expect(envelope.coverage.degradedReason).toMatch(/chronological-walk-incomplete/);
+        expect(generateCalls, 'no synthesis over incomplete coverage').toBe(0)
+    });
+
+    test('an enrichment failure does NOT block synthesis — themes are best-effort, coverage is intact', async () => {
+        const envelope = await exploreMemoryHistory({
+            partition: '@a',
+            preset   : 'weekly',
+            now      : NOW,
+            deps     : makeDeps({queryMemories: async () => { throw new Error('chroma semantic down') }})
+        });
+
+        // coverage came from the recency spine (intact); enrichment failure only means fewer themes
+        expect(envelope.synthesisAvailable).toBe(true);
+        expect(envelope.synthesis).toBe('Two sessions of work happened this week.');
+        expect(envelope.coverage.degraded).toBe(false)
+    });
+
+    test('fails loud when a dep is missing', async () => {
+        await expect(exploreMemoryHistory({preset: 'weekly', now: NOW, deps: {queryRecentTurns: async () => ({})}}))
+            .rejects.toThrow(/deps must supply/)
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/exploreMemoryHistory.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/exploreMemoryHistory.spec.mjs
@@ -28,6 +28,16 @@ test.describe('exploreMemoryHistory — the full Memory/session Bird View compos
         expect(envelope.window.preset).toBe('weekly')
     });
 
+    test('census-vs-inference flows end-to-end: a within-bounds window marks every citation inSynthesis + reports the input count', async () => {
+        const envelope = await exploreMemoryHistory({partition: 'unified', preset: 'weekly', now: NOW, deps: makeDeps()});
+
+        // the 2 recency turns fit the prompt bound → the manifest reaches the envelope through the full
+        // composition: every citation is an inference input, and the count is exposed beside the census total.
+        expect(envelope.coverage.synthesisInputCount).toBe(2);
+        expect(envelope.coverage.totalResolved).toBe(2);
+        expect(envelope.citations.every(c => c.inSynthesis === true)).toBe(true)
+    });
+
     test('unified surfaces PEER sessions from the team-visible summary leg the tenant-bound recency walk cannot see', async () => {
         // query_recent_turns is caller-userId-bound → a peer's turns come back empty; listSummaries is team-visible.
         const envelope = await exploreMemoryHistory({partition: 'unified', preset: 'weekly', now: NOW, deps: makeDeps({

--- a/test/playwright/unit/ai/services/memory-core/exploreMemoryHistory.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/exploreMemoryHistory.spec.mjs
@@ -12,6 +12,7 @@ const makeDeps = (over = {}) => ({
     }),
     queryMemories: async () => ({results: [{id: 'm1', document: 'a recurring theme'}]}),
     generate     : async () => 'Two sessions of work happened this week.',
+    listSummaries: async () => ({summaries: []}),   // team-visible session leg; empty unless a test overrides
     ...over
 });
 
@@ -25,6 +26,18 @@ test.describe('exploreMemoryHistory — the full Memory/session Bird View compos
         expect(envelope.coverage).toMatchObject({totalResolved: 2, degraded: false});
         expect(envelope.citations.map(c => c.id).sort()).toEqual(['turn-@a', 'turn-@b']);
         expect(envelope.window.preset).toBe('weekly')
+    });
+
+    test('unified surfaces PEER sessions from the team-visible summary leg the tenant-bound recency walk cannot see', async () => {
+        // query_recent_turns is caller-userId-bound → a peer's turns come back empty; listSummaries is team-visible.
+        const envelope = await exploreMemoryHistory({partition: 'unified', preset: 'weekly', now: NOW, deps: makeDeps({
+            queryRecentTurns: async () => ({turns: [], nextCursor: null}),
+            listSummaries   : async () => ({summaries: [{id: 'sess-peer', sessionId: 's-peer', timestamp: '2026-07-08T00:00:00.000Z', impact: 95, summary: 'a peer shipped the thing'}]})
+        })});
+
+        // the peer session is admitted into coverage + prominence even though the recency walk saw zero turns
+        expect(envelope.coverage.totalResolved).toBe(1);
+        expect(envelope.citations.map(c => c.id)).toContain('sess-peer')
     });
 
     test('an @identity partition walks exactly that identity — the roster is never consulted', async () => {

--- a/test/playwright/unit/ai/services/memory-core/recentTurnsFetchPage.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/recentTurnsFetchPage.spec.mjs
@@ -1,0 +1,59 @@
+import {test, expect}                        from '@playwright/test';
+import {makeRecentTurnsFetchPage}            from '../../../../../../ai/services/memory-core/helpers/recentTurnsFetchPage.mjs';
+import {enumerateChronologicalWindowSources} from '../../../../../../ai/services/memory-core/helpers/chronologicalWindowSources.mjs';
+
+test.describe('recentTurnsFetchPage — the query_recent_turns → fetchPage seam adapter', () => {
+    test('maps turns to {id, timestamp, type:"turn"} and passes agentIdentity/before/limit through', async () => {
+        const calls     = [],
+              fetchPage = makeRecentTurnsFetchPage({
+                  limit           : 50,
+                  queryRecentTurns: async args => {
+                      calls.push(args);
+                      return {turns: [{id: 't1', timestamp: '2026-07-10T00:00:00Z', extra: 'ignored'}], nextCursor: {timestamp: 'x', id: 'y'}}
+                  }
+              });
+
+        const page = await fetchPage({identity: '@ada', cursor: {timestamp: 'c', id: 'z'}});
+
+        expect(page.items).toEqual([{id: 't1', timestamp: '2026-07-10T00:00:00Z', type: 'turn'}]);
+        expect(page.nextCursor).toEqual({timestamp: 'x', id: 'y'});
+        expect(calls[0]).toEqual({agentIdentity: '@ada', before: {timestamp: 'c', id: 'z'}, limit: 50})
+    });
+
+    test('an error-envelope return (queryRecentTurns does not throw) is surfaced as a throw so coverage degrades', async () => {
+        const fetchPage = makeRecentTurnsFetchPage({
+            queryRecentTurns: async () => ({error: 'Failed to query recent turns', message: 'graph unavailable', code: 'RECENT_TURNS_ERROR'})
+        });
+
+        await expect(fetchPage({identity: '@ada'})).rejects.toThrow(/query_recent_turns failed for @ada: graph unavailable/)
+    });
+
+    test('an empty page maps to empty items + null nextCursor', async () => {
+        const fetchPage = makeRecentTurnsFetchPage({queryRecentTurns: async () => ({turns: [], nextCursor: null})});
+
+        expect(await fetchPage({identity: '@ada'})).toEqual({items: [], nextCursor: null})
+    });
+
+    test('the injected queryRecentTurns is required', () => {
+        expect(() => makeRecentTurnsFetchPage({})).toThrow(/queryRecentTurns/)
+    });
+
+    test('integration: the adapter drives the chronological spine to exhaustion over paged turns', async () => {
+        // a two-page reverse-chronological stream for @ada; page 2 ends the cursor (nextCursor null)
+        const pages = [
+            {turns: [{id: 't-newer', timestamp: '2026-07-11T00:00:00Z'}], nextCursor: {timestamp: '2026-07-11T00:00:00Z', id: 't-newer'}},
+            {turns: [{id: 't-older', timestamp: '2026-07-10T00:00:00Z'}], nextCursor: null}
+        ];
+        let call = 0;
+
+        const fetchPage           = makeRecentTurnsFetchPage({queryRecentTurns: async () => pages[call++] || {turns: [], nextCursor: null}}),
+              {sources, coverage} = await enumerateChronologicalWindowSources({
+                  window    : {windowStart: Date.parse('2026-07-01T00:00:00Z'), windowEnd: Date.parse('2026-07-12T00:00:00Z')},
+                  identities: ['@ada'],
+                  fetchPage
+              });
+
+        expect(sources.map(s => s.id).sort()).toEqual(['t-older', 't-newer'].sort());
+        expect(coverage).toMatchObject({totalResolved: 2, exhausted: true, degraded: false})
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/recentTurnsFetchPage.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/recentTurnsFetchPage.spec.mjs
@@ -3,20 +3,21 @@ import {makeRecentTurnsFetchPage}            from '../../../../../../ai/services
 import {enumerateChronologicalWindowSources} from '../../../../../../ai/services/memory-core/helpers/chronologicalWindowSources.mjs';
 
 test.describe('recentTurnsFetchPage — the query_recent_turns → fetchPage seam adapter', () => {
-    test('preserves the fidelity fields (impact, summary), drops arbitrary ones, and passes agentIdentity/before/limit through', async () => {
+    test('types turns as memory + preserves fidelity fields (sessionId, impact, summary), drops arbitrary ones, passes args through', async () => {
         const calls     = [],
               fetchPage = makeRecentTurnsFetchPage({
                   limit           : 50,
                   queryRecentTurns: async args => {
                       calls.push(args);
-                      return {turns: [{id: 't1', timestamp: '2026-07-10T00:00:00Z', impact: 87, summary: 'shipped the thing', extra: 'ignored'}], nextCursor: {timestamp: 'x', id: 'y'}}
+                      return {turns: [{id: 't1', timestamp: '2026-07-10T00:00:00Z', sessionId: 's1', impact: 87, summary: 'shipped the thing', extra: 'ignored'}], nextCursor: {timestamp: 'x', id: 'y'}}
                   }
               });
 
         const page = await fetchPage({identity: '@ada', cursor: {timestamp: 'c', id: 'z'}});
 
-        // impact + summary survive (the synthesis reads them); `extra` is dropped (the item stays a known shape).
-        expect(page.items).toEqual([{id: 't1', timestamp: '2026-07-10T00:00:00Z', type: 'turn', impact: 87, summary: 'shipped the thing'}]);
+        // type is `memory` (so citationProminence can classify it); sessionId + impact + summary survive for
+        // prominence + drill-down; `extra` is dropped (the item stays a known shape).
+        expect(page.items).toEqual([{id: 't1', timestamp: '2026-07-10T00:00:00Z', type: 'memory', sessionId: 's1', impact: 87, summary: 'shipped the thing'}]);
         expect(page.nextCursor).toEqual({timestamp: 'x', id: 'y'});
         expect(calls[0]).toEqual({agentIdentity: '@ada', before: {timestamp: 'c', id: 'z'}, limit: 50})
     });

--- a/test/playwright/unit/ai/services/memory-core/recentTurnsFetchPage.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/recentTurnsFetchPage.spec.mjs
@@ -3,19 +3,20 @@ import {makeRecentTurnsFetchPage}            from '../../../../../../ai/services
 import {enumerateChronologicalWindowSources} from '../../../../../../ai/services/memory-core/helpers/chronologicalWindowSources.mjs';
 
 test.describe('recentTurnsFetchPage — the query_recent_turns → fetchPage seam adapter', () => {
-    test('maps turns to {id, timestamp, type:"turn"} and passes agentIdentity/before/limit through', async () => {
+    test('preserves the fidelity fields (impact, summary), drops arbitrary ones, and passes agentIdentity/before/limit through', async () => {
         const calls     = [],
               fetchPage = makeRecentTurnsFetchPage({
                   limit           : 50,
                   queryRecentTurns: async args => {
                       calls.push(args);
-                      return {turns: [{id: 't1', timestamp: '2026-07-10T00:00:00Z', extra: 'ignored'}], nextCursor: {timestamp: 'x', id: 'y'}}
+                      return {turns: [{id: 't1', timestamp: '2026-07-10T00:00:00Z', impact: 87, summary: 'shipped the thing', extra: 'ignored'}], nextCursor: {timestamp: 'x', id: 'y'}}
                   }
               });
 
         const page = await fetchPage({identity: '@ada', cursor: {timestamp: 'c', id: 'z'}});
 
-        expect(page.items).toEqual([{id: 't1', timestamp: '2026-07-10T00:00:00Z', type: 'turn'}]);
+        // impact + summary survive (the synthesis reads them); `extra` is dropped (the item stays a known shape).
+        expect(page.items).toEqual([{id: 't1', timestamp: '2026-07-10T00:00:00Z', type: 'turn', impact: 87, summary: 'shipped the thing'}]);
         expect(page.nextCursor).toEqual({timestamp: 'x', id: 'y'});
         expect(calls[0]).toEqual({agentIdentity: '@ada', before: {timestamp: 'c', id: 'z'}, limit: 50})
     });

--- a/test/playwright/unit/ai/services/memory-core/semanticEnrichment.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/semanticEnrichment.spec.mjs
@@ -1,0 +1,61 @@
+import {test, expect}           from '@playwright/test';
+import {makeSemanticEnrichment} from '../../../../../../ai/services/memory-core/helpers/semanticEnrichment.mjs';
+
+test.describe('semanticEnrichment — best-effort theme evidence, never the coverage backbone', () => {
+    test('maps queryMemories results to themes tagged type:"memory" and passes query + nResults', async () => {
+        const calls  = [],
+              enrich = makeSemanticEnrichment({
+                  nResults     : 25,
+                  queryMemories: async args => {
+                      calls.push(args);
+                      return {query: args.query, count: 1, results: [{id: 'm1', document: 'a decision', distance: 0.1}]}
+                  }
+              });
+
+        const result = await enrich({query: 'notable decisions and friction'});
+
+        expect(result).toEqual({
+            themes  : [{id: 'm1', document: 'a decision', distance: 0.1, type: 'memory'}],
+            degraded: false,
+            reason  : null
+        });
+        expect(calls[0]).toEqual({query: 'notable decisions and friction', nResults: 25})
+    });
+
+    test('a thrown queryMemories degrades ENRICHMENT ONLY — empty themes, its own reason, never a throw', async () => {
+        const enrich = makeSemanticEnrichment({queryMemories: async () => { throw new Error('chroma down') }}),
+              result = await enrich({query: 'themes'});
+
+        expect(result.themes).toEqual([]);
+        expect(result.degraded).toBe(true);
+        expect(result.reason).toMatch(/^enrichment-failed: chroma down/)
+    });
+
+    test('an error-envelope return degrades enrichment only', async () => {
+        const enrich = makeSemanticEnrichment({queryMemories: async () => ({error: 'Invalid minTrustTier'})}),
+              result = await enrich({query: 'themes'});
+
+        expect(result.themes).toEqual([]);
+        expect(result.degraded).toBe(true);
+        expect(result.reason).toMatch(/^enrichment-error: Invalid minTrustTier/)
+    });
+
+    test('a missing/empty query returns no themes with a no-query reason (never calls the search)', async () => {
+        let   called = 0;
+        const enrich = makeSemanticEnrichment({queryMemories: async () => { called++; return {results: []} }});
+
+        expect(await enrich({})).toEqual({themes: [], degraded: true, reason: 'no-query'});
+        expect(await enrich({query: ''})).toEqual({themes: [], degraded: true, reason: 'no-query'});
+        expect(called).toBe(0)
+    });
+
+    test('an empty result set is a clean (non-degraded) enrichment — the search ran, found nothing', async () => {
+        const enrich = makeSemanticEnrichment({queryMemories: async () => ({results: []})});
+
+        expect(await enrich({query: 'themes'})).toEqual({themes: [], degraded: false, reason: null})
+    });
+
+    test('the injected queryMemories is required', () => {
+        expect(() => makeSemanticEnrichment({})).toThrow(/queryMemories/)
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/semanticEnrichment.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/semanticEnrichment.spec.mjs
@@ -57,5 +57,23 @@ test.describe('semanticEnrichment — best-effort theme evidence, never the cove
 
     test('the injected queryMemories is required', () => {
         expect(() => makeSemanticEnrichment({})).toThrow(/queryMemories/)
+    });
+
+    test('window-binds themes: out-of-window and unverifiable-timestamp records are dropped', async () => {
+        const enrich = makeSemanticEnrichment({
+            queryMemories: async () => ({results: [
+                {id: 'in',   timestamp: '2026-07-10T12:00:00Z', document: 'in-window theme'},
+                {id: 'out',  timestamp: '2026-01-01T00:00:00Z', document: 'out-of-window theme'},
+                {id: 'none', document: 'no timestamp — cannot be proven in-window'}
+            ]})
+        });
+
+        const {themes} = await enrich({
+            query      : 'themes',
+            windowStart: Date.parse('2026-07-08T00:00:00Z'),
+            windowEnd  : Date.parse('2026-07-12T00:00:00Z')
+        });
+
+        expect(themes.map(t => t.id)).toEqual(['in'])
     })
 });

--- a/test/playwright/unit/ai/services/memory-core/sessionSummaryReader.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/sessionSummaryReader.spec.mjs
@@ -1,0 +1,68 @@
+import {test, expect}             from '@playwright/test';
+import {makeSessionSummaryReader} from '../../../../../../ai/services/memory-core/helpers/sessionSummaryReader.mjs';
+
+/**
+ * sessionSummaryReader — the team-visible session-summary coverage leg. It recovers the peer sessions the
+ * tenant-bound recency walk structurally cannot see, so a `unified` window stops silently declaring peers
+ * exhausted. These hermetic fixtures pin the half-open window filter, the team-vs-author scope, the
+ * DESC-sorted early stop, and honest degradation on a read failure.
+ */
+test.describe('sessionSummaryReader — the team-visible session-summary coverage leg', () => {
+    const S = (id, ts, extra = {}) => ({id, timestamp: ts, sessionId: `sess-${id}`, impact: 50, summary: `${id} summary`, ...extra});
+
+    test('collects in-window summaries as type:session sources, drops out-of-window, preserves impact/sessionId', async () => {
+        const reader = makeSessionSummaryReader({
+            pageSize     : 10,
+            // DESC-sorted (newest first), as the summary index returns
+            listSummaries: async () => ({summaries: [
+                S('new', '2026-07-20T00:00:00Z'),            // newer than windowEnd → skipped
+                S('in',  '2026-07-10T00:00:00Z', {impact: 92}),
+                S('old', '2026-01-01T00:00:00Z')             // older than windowStart → skipped (+ stops walk)
+            ]})
+        });
+
+        const {sources, degraded} = await reader({
+            windowStart: Date.parse('2026-07-08T00:00:00Z'),
+            windowEnd  : Date.parse('2026-07-12T00:00:00Z'),
+            partition  : 'unified'
+        });
+
+        expect(degraded).toBe(false);
+        expect(sources.map(s => s.id)).toEqual(['in']);
+        expect(sources[0]).toMatchObject({type: 'session', sessionId: 'sess-in', impact: 92, summary: 'in summary'})
+    });
+
+    test('unified reads team-wide (no agentIdentity); a @identity partition scopes the author', async () => {
+        const seen   = [],
+              reader = makeSessionSummaryReader({listSummaries: async args => { seen.push(args); return {summaries: []} }});
+
+        await reader({windowStart: 0, windowEnd: 1, partition: 'unified'});
+        await reader({windowStart: 0, windowEnd: 1, partition: '@neo-opus-ada'});
+
+        expect(seen[0].agentIdentity).toBeUndefined();       // unified → team-visible, sees peer sessions
+        expect(seen[1].agentIdentity).toBe('@neo-opus-ada')  // partition → author-scoped
+    });
+
+    test('stops the walk once a page runs older than the window (DESC-sorted index)', async () => {
+        let   calls  = 0;
+        const reader = makeSessionSummaryReader({
+            pageSize     : 2,
+            listSummaries: async () => { calls++; return {summaries: [S('a', '2026-07-10T00:00:00Z'), S('b', '2020-01-01T00:00:00Z')]} }
+        });
+
+        await reader({windowStart: Date.parse('2026-07-08T00:00:00Z'), windowEnd: Date.parse('2026-07-12T00:00:00Z')});
+        expect(calls).toBe(1) // 'b' is older than windowStart → stop, no second page fetched
+    });
+
+    test('a read error degrades coverage honestly (never an empty-window false pass)', async () => {
+        const thrown    = makeSessionSummaryReader({listSummaries: async () => { throw new Error('chroma down') }}),
+              enveloped = makeSessionSummaryReader({listSummaries: async () => ({error: 'quarantined'})});
+
+        expect((await thrown({windowStart: 0, windowEnd: 1})).degraded).toBe(true);
+        expect((await enveloped({windowStart: 0, windowEnd: 1})).degraded).toBe(true)
+    });
+
+    test('the injected listSummaries is required', () => {
+        expect(() => makeSessionSummaryReader({})).toThrow(/listSummaries/)
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/temporalBirdViewEnvelope.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/temporalBirdViewEnvelope.spec.mjs
@@ -44,6 +44,34 @@ test.describe('temporalBirdViewEnvelope — the non-authoritative coverage/citat
         expect(envelope.citations.find(c => c.id === 'mem-1')).toMatchObject({type: 'memory', sessionId: 'sess-1'})
     });
 
+    test('census-vs-inference: an inferenceInputIds manifest marks each citation inSynthesis + reports the input count', () => {
+        const envelope = buildTemporalBirdViewEnvelope({
+            window : WINDOW,
+            sources: [
+                {id: 'in-1',  type: 'memory'},
+                {id: 'in-2',  type: 'memory'},
+                {id: 'census-only', type: 'memory'}   // resolved into coverage but NOT enumerated in the synthesis
+            ],
+            narrative        : 'built from the two inference inputs',
+            coverage         : {totalResolved: 3},
+            inferenceInputIds: ['in-1', 'in-2'],
+            generatedAt      : GEN_ISO
+        });
+
+        // census stays 3; the narrative was built from 2 — a caller can tell inference inputs from the census
+        expect(envelope.coverage.totalResolved).toBe(3);
+        expect(envelope.coverage.synthesisInputCount).toBe(2);
+        expect(envelope.citations.find(c => c.id === 'in-1').inSynthesis).toBe(true);
+        expect(envelope.citations.find(c => c.id === 'census-only').inSynthesis).toBe(false)
+    });
+
+    test('no inferenceInputIds manifest → citations stay unmarked (no false inSynthesis claim)', () => {
+        const envelope = buildTemporalBirdViewEnvelope({window: WINDOW, sources: SOURCES, coverage: {totalResolved: 2}, generatedAt: GEN_ISO});
+
+        expect(envelope.coverage.synthesisInputCount).toBeUndefined();
+        expect(envelope.citations.every(c => !('inSynthesis' in c))).toBe(true)
+    });
+
     test('citations carry per-source type/id/ref for drill-down', () => {
         const envelope = buildTemporalBirdViewEnvelope({window: WINDOW, sources: SOURCES, coverage: {totalResolved: 2}, generatedAt: GEN_ISO});
 

--- a/test/playwright/unit/ai/services/memory-core/temporalBirdViewEnvelope.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/temporalBirdViewEnvelope.spec.mjs
@@ -27,6 +27,23 @@ test.describe('temporalBirdViewEnvelope — the non-authoritative coverage/citat
         expect(envelope.generatedAt).toBe(GEN_ISO)
     });
 
+    test('exposes per-type counts + sessionId drill-down so a caller can pivot from the census into the source', () => {
+        const envelope = buildTemporalBirdViewEnvelope({
+            window : WINDOW,
+            sources: [
+                {id: 'mem-1',       type: 'memory',  sessionId: 'sess-1'},
+                {id: 'mem-2',       type: 'memory',  sessionId: 'sess-2'},
+                {id: 'session-abc', type: 'session', sessionId: 'sess-abc'}
+            ],
+            narrative  : 'stuff happened',
+            coverage   : {totalResolved: 3},
+            generatedAt: GEN_ISO
+        });
+
+        expect(envelope.coverage.sourceTypeCounts).toEqual({memory: 2, session: 1});
+        expect(envelope.citations.find(c => c.id === 'mem-1')).toMatchObject({type: 'memory', sessionId: 'sess-1'})
+    });
+
     test('citations carry per-source type/id/ref for drill-down', () => {
         const envelope = buildTemporalBirdViewEnvelope({window: WINDOW, sources: SOURCES, coverage: {totalResolved: 2}, generatedAt: GEN_ISO});
 

--- a/test/playwright/unit/ai/services/memory-core/temporalBirdViewEnvelope.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/temporalBirdViewEnvelope.spec.mjs
@@ -1,0 +1,108 @@
+import {test, expect}                  from '@playwright/test';
+import {buildTemporalBirdViewEnvelope} from '../../../../../../ai/services/memory-core/helpers/temporalBirdViewEnvelope.mjs';
+
+const GEN_ISO = '2026-07-12T12:00:00.000Z',
+      // a minimal resolved-window stand-in (the resolver's shape is covered by its own spec)
+      WINDOW  = {preset: 'weekly', tier: 'L3', windowStart: 1, windowEnd: 2, windowSemantics: {interval: 'half-open'}},
+      SOURCES = [
+          {id: 'pr-100',      type: 'pull-request', ref: 'merged'},
+          {id: 'session-abc', type: 'session'}
+      ];
+
+test.describe('temporalBirdViewEnvelope — the non-authoritative coverage/citation discipline layer', () => {
+    test('complete coverage + a narrative → synthesisAvailable, narrative present, notAuthority stamped', () => {
+        const envelope = buildTemporalBirdViewEnvelope({
+            window     : WINDOW,
+            sources    : SOURCES,
+            narrative  : 'Two items resolved: a merged PR and a session.',
+            coverage   : {totalResolved: 2},
+            generatedAt: GEN_ISO
+        });
+
+        expect(envelope.synthesisAvailable).toBe(true);
+        expect(envelope.synthesis).toBe('Two items resolved: a merged PR and a session.');
+        expect(envelope.synthesisUnavailableReason).toBeNull();
+        expect(envelope.coverage).toMatchObject({totalResolved: 2, included: 2, excluded: 0, truncated: false, degraded: false});
+        expect(envelope.notAuthority).toBe(true);
+        expect(envelope.generatedAt).toBe(GEN_ISO)
+    });
+
+    test('citations carry per-source type/id/ref for drill-down', () => {
+        const envelope = buildTemporalBirdViewEnvelope({window: WINDOW, sources: SOURCES, coverage: {totalResolved: 2}, generatedAt: GEN_ISO});
+
+        expect(envelope.citations).toEqual([
+            {type: 'pull-request', id: 'pr-100', ref: 'merged'},
+            {type: 'session',      id: 'session-abc'}
+        ])
+    });
+
+    test('sourceManifestHash is deterministic AND order-independent (same set → same hash)', () => {
+        const a = buildTemporalBirdViewEnvelope({window: WINDOW, sources: [{id: 'x'}, {id: 'y'}], coverage: {totalResolved: 2}, generatedAt: GEN_ISO}),
+              b = buildTemporalBirdViewEnvelope({window: WINDOW, sources: [{id: 'y'}, {id: 'x'}], coverage: {totalResolved: 2}, generatedAt: GEN_ISO}),
+              c = buildTemporalBirdViewEnvelope({window: WINDOW, sources: [{id: 'x'}, {id: 'z'}], coverage: {totalResolved: 2}, generatedAt: GEN_ISO});
+
+        expect(a.sourceManifestHash).toBe(b.sourceManifestHash);
+        expect(a.sourceManifestHash).not.toBe(c.sourceManifestHash);
+        expect(a.sourceManifestHash).toMatch(/^[0-9a-f]{8}$/)
+    });
+
+    test.describe('completeness is proven, never assumed — the narrative is withheld on every gap', () => {
+        const withGap = coverage => buildTemporalBirdViewEnvelope({
+            window     : WINDOW,
+            sources    : [{id: 'pr-100'}],
+            narrative  : 'a confident story the caller should NOT get over a partial read',
+            coverage,
+            generatedAt: GEN_ISO
+        });
+
+        test('unknown totalResolved → coverage-unknown, no narrative (completeness unprovable)', () => {
+            const envelope = withGap({});   // no totalResolved
+
+            expect(envelope.synthesisAvailable).toBe(false);
+            expect(envelope.synthesis).toBeNull();
+            expect(envelope.coverage.degraded).toBe(true);
+            expect(envelope.coverage.degradedReason).toBe('coverage-unknown')
+        });
+
+        test('truncated retrieval → source-truncated, no narrative', () => {
+            const envelope = withGap({totalResolved: 1, truncated: true});
+
+            expect(envelope.synthesisAvailable).toBe(false);
+            expect(envelope.coverage.degradedReason).toBe('source-truncated')
+        });
+
+        test('an excluded remainder (included < totalResolved) → incomplete-inclusion, no narrative', () => {
+            const envelope = withGap({totalResolved: 5});   // included 1 < 5
+
+            expect(envelope.synthesisAvailable).toBe(false);
+            expect(envelope.coverage.excluded).toBe(4);
+            expect(envelope.coverage.degradedReason).toBe('incomplete-inclusion')
+        });
+
+        test('an explicit degraded flag → flagged-degraded, no narrative even when counts line up', () => {
+            const envelope = withGap({totalResolved: 1, degraded: true});
+
+            expect(envelope.synthesisAvailable).toBe(false);
+            expect(envelope.coverage.degradedReason).toBe('flagged-degraded')
+        });
+
+        test('a caller-supplied degradedReason is preserved verbatim', () => {
+            const envelope = withGap({totalResolved: 1, degraded: true, degradedReason: 'lm-studio-unreachable'});
+
+            expect(envelope.coverage.degradedReason).toBe('lm-studio-unreachable')
+        })
+    });
+
+    test('complete coverage but NO narrative → synthesisAvailable false with the no-narrative reason (not a coverage gap)', () => {
+        const envelope = buildTemporalBirdViewEnvelope({window: WINDOW, sources: SOURCES, coverage: {totalResolved: 2}, generatedAt: GEN_ISO});
+
+        expect(envelope.synthesisAvailable).toBe(false);
+        expect(envelope.synthesisUnavailableReason).toBe('no-narrative');
+        expect(envelope.coverage.degraded).toBe(false)
+    });
+
+    test('fails loud: a missing generatedAt and a missing window each throw', () => {
+        expect(() => buildTemporalBirdViewEnvelope({window: WINDOW, sources: SOURCES})).toThrow(/generatedAt/);
+        expect(() => buildTemporalBirdViewEnvelope({sources: SOURCES, generatedAt: GEN_ISO})).toThrow(/window/)
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/temporalBirdViewSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/temporalBirdViewSynthesizer.spec.mjs
@@ -1,0 +1,99 @@
+import {test, expect}               from '@playwright/test';
+import {synthesizeTemporalBirdView} from '../../../../../../ai/services/memory-core/helpers/temporalBirdViewSynthesizer.mjs';
+
+const GEN_ISO = '2026-07-12T12:00:00.000Z',
+      NOW_ISO = '2026-07-12T12:00:00.000Z',
+      SOURCES = [{id: 'session-a', type: 'session'}, {id: 'session-b', type: 'session'}],
+      // a retrieval that reports COMPLETE coverage (chronological spine exhausted) over 2 sources
+      complete = () => ({sources: SOURCES, coverage: {totalResolved: 2}});
+
+test.describe('temporalBirdViewSynthesizer — the fail-open, no-inference-over-incomplete-coverage orchestrator', () => {
+    test('happy path: complete coverage + a narrative → full envelope, narrative present', async () => {
+        const envelope = await synthesizeTemporalBirdView({
+            preset     : 'weekly',
+            now        : NOW_ISO,
+            generatedAt: GEN_ISO,
+            retrieve   : async () => complete(),
+            synthesize : async () => 'Two sessions this week: a and b.'
+        });
+
+        expect(envelope.synthesisAvailable).toBe(true);
+        expect(envelope.synthesis).toBe('Two sessions this week: a and b.');
+        expect(envelope.coverage.totalResolved).toBe(2);
+        expect(envelope.window.preset).toBe('weekly');
+        expect(envelope.notAuthority).toBe(true)
+    });
+
+    test('retrieval failure is fail-open → degraded envelope, and synthesize is NEVER called', async () => {
+        let synthesizeCalls = 0;
+
+        const envelope = await synthesizeTemporalBirdView({
+            preset    : 'weekly',
+            now       : NOW_ISO,
+            retrieve  : async () => { throw new Error('memory core unreachable') },
+            synthesize: async () => { synthesizeCalls++; return 'x' }
+        });
+
+        expect(envelope.synthesisAvailable).toBe(false);
+        expect(envelope.coverage.degraded).toBe(true);
+        expect(envelope.coverage.degradedReason).toMatch(/^retrieval-failed: memory core unreachable/);
+        expect(synthesizeCalls).toBe(0)
+    });
+
+    test('incomplete coverage skips the LLM entirely — synthesize is not called, the narrative is withheld', async () => {
+        let synthesizeCalls = 0;
+
+        const envelope = await synthesizeTemporalBirdView({
+            preset: 'weekly',
+            now   : NOW_ISO,
+            // retrieval proved 5 exist but only returned 2 (an unexhausted recency page) → incomplete
+            retrieve  : async () => ({sources: SOURCES, coverage: {totalResolved: 5}}),
+            synthesize: async () => { synthesizeCalls++; return 'a story over a partial read' }
+        });
+
+        expect(envelope.synthesisAvailable).toBe(false);
+        expect(envelope.coverage.excluded).toBe(3);
+        expect(envelope.coverage.degradedReason).toBe('incomplete-inclusion');
+        expect(synthesizeCalls, 'no LLM call is paid for over incomplete coverage').toBe(0)
+    });
+
+    test('synthesis failure is fail-open → degraded with the failure reason, coverage evidence preserved', async () => {
+        const envelope = await synthesizeTemporalBirdView({
+            preset    : 'weekly',
+            now       : NOW_ISO,
+            retrieve  : async () => complete(),
+            synthesize: async () => { throw new Error('provider timeout') }
+        });
+
+        expect(envelope.synthesisAvailable).toBe(false);
+        expect(envelope.coverage.degradedReason).toMatch(/^synthesis-failed: provider timeout/);
+        // the coverage manifest survives the synthesis failure — a Bird View still reports WHAT was found
+        expect(envelope.coverage.totalResolved).toBe(2);
+        expect(envelope.citations).toHaveLength(2)
+    });
+
+    test('an invalid window request PROPAGATES (a caller error, not a degraded synthesis)', async () => {
+        await expect(synthesizeTemporalBirdView({
+            preset    : 'fortnightly',   // unknown preset
+            now       : NOW_ISO,
+            retrieve  : async () => complete(),
+            synthesize: async () => 'x'
+        })).rejects.toThrow(/unknown grain preset/)
+    });
+
+    test('generatedAt defaults to the run clock (now) when omitted', async () => {
+        const envelope = await synthesizeTemporalBirdView({
+            preset    : 'weekly',
+            now       : NOW_ISO,
+            retrieve  : async () => complete(),
+            synthesize: async () => 'story'
+        });
+
+        expect(envelope.generatedAt).toBe(NOW_ISO)
+    });
+
+    test('the injected retrieve + synthesize seams are required', async () => {
+        await expect(synthesizeTemporalBirdView({preset: 'weekly', now: NOW_ISO, synthesize: async () => 'x'})).rejects.toThrow(/`retrieve`/);
+        await expect(synthesizeTemporalBirdView({preset: 'weekly', now: NOW_ISO, retrieve: async () => complete()})).rejects.toThrow(/`synthesize`/)
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/temporalSynthesis.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/temporalSynthesis.spec.mjs
@@ -4,12 +4,12 @@ import {buildTemporalSynthesisPrompt, makeTemporalSynthesize} from '../../../../
 const WINDOW = {partition: '@ada', windowStartIso: '2026-07-05T00:00:00.000Z', windowEndIso: '2026-07-12T00:00:00.000Z'};
 
 test.describe('temporalSynthesis — the §-fidelity prompt + injected-generate seam', () => {
-    test('the prompt states the half-open window + partition, foregrounds prominent ids, and bounds context to a count', () => {
+    test('the prompt states the half-open window + partition, foregrounds prominent ids, and enumerates context facts', () => {
         const prompt = buildTemporalSynthesisPrompt({
             window : WINDOW,
             sources: [
                 {id: 'session-hi', type: 'session', impact: 95, title: 'the big call'},
-                {id: 'session-lo', type: 'session', impact: 10},
+                {id: 'session-lo', type: 'session', impact: 10, summary: 'a routine dependency bump'},
                 {id: 'adr-28',     type: 'adr', accepted: true}
             ],
             themes: [{id: 'm1', document: 'a recurring friction theme'}]
@@ -20,9 +20,10 @@ test.describe('temporalSynthesis — the §-fidelity prompt + injected-generate 
         // prominent (impact>=90 session + accepted ADR) are foregrounded by id
         expect(prompt).toContain('session-hi: the big call');
         expect(prompt).toContain('adr-28');
-        // the low-impact session is CONTEXT (a count), not foregrounded by id
-        expect(prompt).not.toContain('session-lo');
-        expect(prompt).toContain('CONTEXT: 1 further admitted source');
+        // the low-impact session is CONTEXT — now ENUMERATED with its fact (the model sees what it was
+        // about, so it cannot cite past a bare count), while still not being in the PROMINENT block.
+        expect(prompt).toContain('session-lo: a routine dependency bump');
+        expect(prompt).toMatch(/CONTEXT — further in-window sources/);
         expect(prompt).toContain('a recurring friction theme');
         // fidelity: cite prominent + no invention
         expect(prompt).toMatch(/Cite prominent sources by id/);
@@ -34,7 +35,7 @@ test.describe('temporalSynthesis — the §-fidelity prompt + injected-generate 
 
         expect(prompt).toContain('- (none)');
         expect(prompt).toContain('- (none surfaced)');
-        expect(prompt).toContain('CONTEXT: 0 further admitted source')
+        expect(prompt).toMatch(/CONTEXT — further in-window sources/)
     });
 
     test('makeTemporalSynthesize passes the prompt to generate and returns the narrative (string or {content})', async () => {

--- a/test/playwright/unit/ai/services/memory-core/temporalSynthesis.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/temporalSynthesis.spec.mjs
@@ -1,5 +1,5 @@
-import {test, expect}                                         from '@playwright/test';
-import {buildTemporalSynthesisPrompt, makeTemporalSynthesize} from '../../../../../../ai/services/memory-core/helpers/temporalSynthesis.mjs';
+import {test, expect}                                                                  from '@playwright/test';
+import {buildTemporalSynthesisPrompt, makeTemporalSynthesize, selectSynthesisInputIds} from '../../../../../../ai/services/memory-core/helpers/temporalSynthesis.mjs';
 
 const WINDOW = {partition: '@ada', windowStartIso: '2026-07-05T00:00:00.000Z', windowEndIso: '2026-07-12T00:00:00.000Z'};
 
@@ -38,15 +38,29 @@ test.describe('temporalSynthesis — the §-fidelity prompt + injected-generate 
         expect(prompt).toMatch(/CONTEXT — further in-window sources/)
     });
 
-    test('makeTemporalSynthesize passes the prompt to generate and returns the narrative (string or {content})', async () => {
+    test('makeTemporalSynthesize passes the prompt to generate and returns {narrative, inferenceInputIds}', async () => {
         let seenPrompt = null;
 
         const fromString  = makeTemporalSynthesize({generate: async ({prompt}) => { seenPrompt = prompt; return 'a narrative' }}),
               fromContent = makeTemporalSynthesize({generate: async () => ({content: 'wrapped narrative'})});
 
-        expect(await fromString({window: WINDOW, sources: [{id: 'x', type: 'session', impact: 99}]})).toBe('a narrative');
+        // the manifest reports the ids the prompt actually enumerated — its inference inputs
+        expect(await fromString({window: WINDOW, sources: [{id: 'x', type: 'session', impact: 99}]}))
+            .toEqual({narrative: 'a narrative', inferenceInputIds: ['x']});
         expect(seenPrompt).toContain('partition "@ada"');
-        expect(await fromContent({window: WINDOW})).toBe('wrapped narrative')
+        expect(await fromContent({window: WINDOW})).toEqual({narrative: 'wrapped narrative', inferenceInputIds: []})
+    });
+
+    test('selectSynthesisInputIds is the bounded prompt subset — the census-vs-inference boundary on a large window', () => {
+        // 70 context (non-prominent) sources exceed the 60-enumeration bound; 2 prominent are always cited.
+        const context   = Array.from({length: 70}, (_, i) => ({id: `ctx-${i}`, type: 'memory', impact: 10})),
+              prominent = [{id: 'hot-a', type: 'session', impact: 99}, {id: 'hot-b', type: 'session', impact: 95}],
+              inputIds  = selectSynthesisInputIds([...prominent, ...context]);
+
+        // prominent (2, both cited) + the first 60 context = 62 inference inputs, NOT the full 72-source census
+        expect(inputIds).toHaveLength(62);
+        expect(inputIds).toEqual(expect.arrayContaining(['hot-a', 'hot-b', 'ctx-0', 'ctx-59']));
+        expect(inputIds).not.toContain('ctx-60')
     });
 
     test('a generation that yields no narrative throws — the orchestrator will degrade the envelope', async () => {

--- a/test/playwright/unit/ai/services/memory-core/temporalSynthesis.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/temporalSynthesis.spec.mjs
@@ -1,0 +1,62 @@
+import {test, expect}                                         from '@playwright/test';
+import {buildTemporalSynthesisPrompt, makeTemporalSynthesize} from '../../../../../../ai/services/memory-core/helpers/temporalSynthesis.mjs';
+
+const WINDOW = {partition: '@ada', windowStartIso: '2026-07-05T00:00:00.000Z', windowEndIso: '2026-07-12T00:00:00.000Z'};
+
+test.describe('temporalSynthesis — the §-fidelity prompt + injected-generate seam', () => {
+    test('the prompt states the half-open window + partition, foregrounds prominent ids, and bounds context to a count', () => {
+        const prompt = buildTemporalSynthesisPrompt({
+            window : WINDOW,
+            sources: [
+                {id: 'session-hi', type: 'session', impact: 95, title: 'the big call'},
+                {id: 'session-lo', type: 'session', impact: 10},
+                {id: 'adr-28',     type: 'adr', accepted: true}
+            ],
+            themes: [{id: 'm1', document: 'a recurring friction theme'}]
+        });
+
+        expect(prompt).toContain('[2026-07-05T00:00:00.000Z, 2026-07-12T00:00:00.000Z)');
+        expect(prompt).toContain('partition "@ada"');
+        // prominent (impact>=90 session + accepted ADR) are foregrounded by id
+        expect(prompt).toContain('session-hi: the big call');
+        expect(prompt).toContain('adr-28');
+        // the low-impact session is CONTEXT (a count), not foregrounded by id
+        expect(prompt).not.toContain('session-lo');
+        expect(prompt).toContain('CONTEXT: 1 further admitted source');
+        expect(prompt).toContain('a recurring friction theme');
+        // fidelity: cite prominent + no invention
+        expect(prompt).toMatch(/Cite prominent sources by id/);
+        expect(prompt).toMatch(/do not invent/)
+    });
+
+    test('an empty window renders honestly (no prominent, no themes) without crashing', () => {
+        const prompt = buildTemporalSynthesisPrompt({window: WINDOW, sources: [], themes: []});
+
+        expect(prompt).toContain('- (none)');
+        expect(prompt).toContain('- (none surfaced)');
+        expect(prompt).toContain('CONTEXT: 0 further admitted source')
+    });
+
+    test('makeTemporalSynthesize passes the prompt to generate and returns the narrative (string or {content})', async () => {
+        let seenPrompt = null;
+
+        const fromString  = makeTemporalSynthesize({generate: async ({prompt}) => { seenPrompt = prompt; return 'a narrative' }}),
+              fromContent = makeTemporalSynthesize({generate: async () => ({content: 'wrapped narrative'})});
+
+        expect(await fromString({window: WINDOW, sources: [{id: 'x', type: 'session', impact: 99}]})).toBe('a narrative');
+        expect(seenPrompt).toContain('partition "@ada"');
+        expect(await fromContent({window: WINDOW})).toBe('wrapped narrative')
+    });
+
+    test('a generation that yields no narrative throws — the orchestrator will degrade the envelope', async () => {
+        const empty   = makeTemporalSynthesize({generate: async () => ''}),
+              nullish = makeTemporalSynthesize({generate: async () => ({content: null})});
+
+        await expect(empty({window: WINDOW})).rejects.toThrow(/no narrative/);
+        await expect(nullish({window: WINDOW})).rejects.toThrow(/no narrative/)
+    });
+
+    test('the injected generate is required', () => {
+        expect(() => makeTemporalSynthesize({})).toThrow(/generate/)
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/temporalWindowResolver.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/temporalWindowResolver.spec.mjs
@@ -1,0 +1,108 @@
+import {test, expect}                                    from '@playwright/test';
+import {getTemporalWindowPresets, resolveTemporalWindow} from '../../../../../../ai/services/memory-core/helpers/temporalWindowResolver.mjs';
+
+const DAY_MS = 24 * 60 * 60 * 1000,
+      // fixed injected reference clock — the resolver never reads a clock internally, so every case is deterministic
+      NOW_ISO = '2026-07-12T12:00:00.000Z',
+      NOW_MS  = Date.parse(NOW_ISO);
+
+test.describe('temporalWindowResolver — pure half-open window resolution (temporal-pyramid dynamic-synthesis front)', () => {
+    test('preset weekly resolves to [now - 7d, now), tier L3, half-open', () => {
+        const window = resolveTemporalWindow({preset: 'weekly', now: NOW_ISO});
+
+        expect(window.windowStart).toBe(NOW_MS - 7 * DAY_MS);
+        expect(window.windowEnd).toBe(NOW_MS);
+        expect(window.tier).toBe('L3');
+        expect(window.preset).toBe('weekly');
+        expect(window.windowSemantics.interval).toBe('half-open');
+        expect(window.windowSemantics.durationMs).toBe(7 * DAY_MS)
+    });
+
+    test('the named grains map to their pyramid tiers; the finer grains carry no tier', () => {
+        expect(resolveTemporalWindow({preset: 'weekly',    now: NOW_MS}).tier).toBe('L3');
+        expect(resolveTemporalWindow({preset: 'monthly',   now: NOW_MS}).tier).toBe('L4');
+        expect(resolveTemporalWindow({preset: 'quarterly', now: NOW_MS}).tier).toBe('L5');
+        // daily / 3-day are first-class arbitrary grains BELOW the pyramid — no L-tier
+        expect(resolveTemporalWindow({preset: 'daily', now: NOW_MS}).tier).toBeNull();
+        expect(resolveTemporalWindow({preset: '3-day', now: NOW_MS}).tier).toBeNull();
+        // and their durations are the raw grain, not rounded to a tier
+        expect(resolveTemporalWindow({preset: '3-day', now: NOW_MS}).windowSemantics.durationMs).toBe(3 * DAY_MS)
+    });
+
+    test('an explicit (windowStart, windowEnd) window is first-class — used verbatim, no preset/tier, no `now` needed', () => {
+        const window = resolveTemporalWindow({
+            windowStart: '2026-07-01T00:00:00.000Z',
+            windowEnd  : '2026-07-08T00:00:00.000Z'
+        });
+
+        expect(window.windowStart).toBe(Date.parse('2026-07-01T00:00:00.000Z'));
+        expect(window.windowEnd).toBe(Date.parse('2026-07-08T00:00:00.000Z'));
+        expect(window.preset).toBeNull();
+        expect(window.tier).toBeNull();
+        expect(window.windowStartIso).toBe('2026-07-01T00:00:00.000Z');
+        expect(window.windowSemantics.filterSet.grain).toBe('explicit')
+    });
+
+    test('explicit bounds accept Date objects and epoch-ms numbers, not just ISO strings', () => {
+        const fromDates   = resolveTemporalWindow({windowStart: new Date(NOW_MS - DAY_MS), windowEnd: new Date(NOW_MS)}),
+              fromNumbers = resolveTemporalWindow({windowStart: NOW_MS - DAY_MS,           windowEnd: NOW_MS});
+
+        expect(fromDates.windowStart).toBe(NOW_MS - DAY_MS);
+        expect(fromDates.windowEnd).toBe(NOW_MS);
+        expect(fromNumbers.windowStart).toBe(NOW_MS - DAY_MS);
+        expect(fromNumbers.windowEnd).toBe(NOW_MS)
+    });
+
+    test('boundaries are half-open — durationMs === end - start, so adjacent windows never double-count an edge event', () => {
+        const window = resolveTemporalWindow({
+            windowStart: NOW_MS - 3 * DAY_MS,
+            windowEnd  : NOW_MS
+        });
+
+        // an event stamped exactly at windowEnd is NOT in this window (it opens the next one) — proven by the
+        // exclusive-end contract: [start, end) has duration end-start with the end instant excluded
+        expect(window.windowSemantics.durationMs).toBe(3 * DAY_MS);
+        expect(window.windowSemantics.interval).toBe('half-open')
+    });
+
+    test('every result declares its filter-set (grain + partition) — cross-window comparison is defined only within an identical set', () => {
+        const unified  = resolveTemporalWindow({preset: 'weekly', now: NOW_MS}),
+              perAgent = resolveTemporalWindow({preset: 'weekly', now: NOW_MS, partition: 'neo-opus-ada'});
+
+        expect(unified.partition).toBe('unified');
+        expect(unified.windowSemantics.filterSet).toEqual({grain: 'weekly', partition: 'unified'});
+        expect(perAgent.partition).toBe('neo-opus-ada');
+        expect(perAgent.windowSemantics.filterSet).toEqual({grain: 'weekly', partition: 'neo-opus-ada'})
+    });
+
+    test('getTemporalWindowPresets exposes exactly the supported grains', () => {
+        expect(getTemporalWindowPresets().sort()).toEqual(['3-day', 'daily', 'monthly', 'quarterly', 'weekly'])
+    });
+
+    test.describe('fails loud — never synthesizes a silently-wrong window', () => {
+        test('a non-(start < end) explicit window throws (zero-width and inverted both rejected)', () => {
+            expect(() => resolveTemporalWindow({windowStart: NOW_MS, windowEnd: NOW_MS})).toThrow(/windowStart < windowEnd/);
+            expect(() => resolveTemporalWindow({windowStart: NOW_MS, windowEnd: NOW_MS - DAY_MS})).toThrow(/windowStart < windowEnd/)
+        });
+
+        test('an unparseable explicit bound throws (never coerced to a wrong instant)', () => {
+            expect(() => resolveTemporalWindow({windowStart: 'not-a-date', windowEnd: NOW_MS})).toThrow(/parseable/)
+        });
+
+        test('an unknown preset throws and names the supported set', () => {
+            expect(() => resolveTemporalWindow({preset: 'fortnightly', now: NOW_MS})).toThrow(/unknown grain preset/)
+        });
+
+        test('a preset without an injected `now` throws (the resolver never reads a clock itself)', () => {
+            expect(() => resolveTemporalWindow({preset: 'weekly'})).toThrow(/injected `now`/)
+        });
+
+        test('supplying neither a preset nor an explicit window throws', () => {
+            expect(() => resolveTemporalWindow({})).toThrow(/either a preset or an explicit/)
+        });
+
+        test('supplying BOTH a preset and an explicit window throws (ambiguous request)', () => {
+            expect(() => resolveTemporalWindow({preset: 'weekly', windowStart: NOW_MS - DAY_MS, windowEnd: NOW_MS})).toThrow(/not both/)
+        })
+    })
+});


### PR DESCRIPTION
## Summary

Registers the `explore_memory_history` MCP tool and completes the **truth-path repair** @neo-gpt (Euclid) required, completing #14435 (Leaf C of #12679 — temporal-pyramid L3–L5 dynamic synthesis). The Memory/session temporal **Bird View** computes "what happened this week / month / quarter" ON DEMAND over a time window — never a stored digest — from the chronological recency spine + best-effort semantic enrichment + cited synthesis, returning ONE non-authoritative envelope whose narrative is WITHHELD on any coverage gap (honest absence over a plausible-but-partial story).

The pure composition + its primitives shipped across the earlier increments; this revision binds the impure edges at the MC server AND closes every code item of Euclid's CHANGES_REQUESTED review — the envelope no longer merely registers, it now tells the truth about what it saw.

## RC closure — every code item of @neo-gpt's review addressed

- **Falsifier 1 — the synthesis saw only a count.** The prompt now ENUMERATES the in-window context sources' facts (id + summary), bounded, with an overflow note, so the narrative is grounded in evidence actually in the prompt (`03be17580d`). The recency fetch-page preserves `impact`/`summary` and types turns as `memory` + carries `sessionId` (`dbf6a895d5`, `bbd27ea5f3`) — a hardcoded `type:'turn'` could never be prominent under `citationProminence`'s classifier.
- **Falsifier 2 — enrichment was unbounded.** `semanticEnrichment` is now window-bound; an out-of-window or unverifiable-timestamp theme is dropped (`72e0d7df72`).
- **Falsifier 3 — `unified` silently omitted peers.** Root-caused to `query_recent_turns`' deliberate caller-userId tenant filter; `unified` now ALSO walks the **team-visible session-summary leg** (`listSummaries`), merged + deduped into coverage, so a peer session surfaces even when the recency walk returns zero peer turns (`e3a4433db3`, `de9c469ad6`). This is also the ADR 0028 §2.2 L2 coverage source.
- **Envelope drill-down.** `coverage.sourceTypeCounts` (session/turn split) + `sessionId` on each citation for `get_session_memories` pivots (`959816ae86`).
- **Census-vs-inference provenance.** On a window larger than the prompt bounds the synthesis enumerates only the top slice; `makeTemporalSynthesize` now reports `inferenceInputIds` (derived from the same `selectSynthesisSources` the prompt renders from, so prompt + manifest can't drift), the orchestrator forwards them dual-shape (a bare-string synthesize stays valid), and the envelope marks each citation `inSynthesis` + reports `coverage.synthesisInputCount` beside `totalResolved` (`331c0fd8a5`, integration-asserted `26d6f8d05e`). A caller can no longer read a citation the narrative never saw.

## Deltas

- **`ai/services/memory-core/helpers/`** — `recentTurnsFetchPage` (impact/summary + memory-type + sessionId), `semanticEnrichment` (window-bound), **`sessionSummaryReader` (new)** — the team-visible L2 coverage leg, `temporalSynthesis` (context enumeration + `selectSynthesisInputIds` manifest), `temporalBirdViewEnvelope` (sourceTypeCounts, sessionId, inSynthesis, synthesisInputCount), `temporalBirdViewSynthesizer` (dual-shape inference-input forwarding), `exploreMemoryHistory` (two-leg merged coverage).
- **`ai/mcp/server/memory-core/toolService.mjs`** — `exploreMemoryHistoryOp` binds the deps: `queryRecentTurns` + `queryMemories` via `MemoryService`; `generate` via the generation model already owned by `SessionService` (read at call time; no AiConfig pass-through or duplicate builder); `listIdentities` = the who-is-online union; **`listSummaries`** = the team-visible session leg. Injected real clock.
- **`ai/mcp/server/memory-core/openapi.yaml`** — the `/memories/history` GET operation, plus a documented response envelope schema (coverage incl. `synthesisInputCount`, citations incl. `sessionId` + `inSynthesis`, synthesis nullability, `notAuthority`) — bringing an under-documented tool up to the codebase's detailed-response-schema norm.

## Test Evidence

Evidence: L2 hermetic + the truth-path is now ASSERTED, not pending — the specs make the exact assertions Euclid's review required.

- Current-team corrective review closure at `014b1b89da`: **147/147** focused tests passed, including the complete Bird View matrix, OpenAPI validator compliance, and the ADR-0019 config SSOT lint suite. `SessionService.model` is now the single Memory Core generation-model owner; the public explicit-window contract is ISO-8601 string only.

- The recency fetch-page preserves `impact`/`summary`; enrichment drops out-of-window themes; `unified` surfaces a peer session the tenant-bound recency walk returns empty for (`exploreMemoryHistory.spec` — the team-visible summary leg); the census-vs-inference boundary bounds `selectSynthesisInputIds` to the prompt subset AND flows `inSynthesis` end-to-end through the full composition. Each affected spec file is green (temporalSynthesis, temporalBirdViewEnvelope, temporalBirdViewSynthesizer, exploreMemoryHistory, sessionSummaryReader).
- **Zero durable output — by construction:** the composition's only deps are reads (`queryRecentTurns`, `queryMemories`, `listSummaries`), inference (`generate`), and a roster read (`listIdentities`); no write dep is injectable, so nothing above L2 can be written.

## Cost

Per invocation (no scheduled calls, no durable cache): ≤ roster-size recency-page walks + one team-visible summary-index walk (both early-stop past the window) + 1 semantic enrichment + exactly 1 synthesis call; synthesis is skipped entirely on incomplete coverage. Live measurements on the configured `openAiCompatible` model: weekly unified window — 437 sources (284 memory / 153 session), 75 inference inputs, 41.20s wall time; explicit 2026-07-10 → 2026-07-13 unified window — 400 sources (254 memory / 146 session), 75 inference inputs, 40.44s wall time. Both were complete, non-degraded, synthesis-available, and `notAuthority:true`. The streaming provider adapter does not expose usage-token counts, so token usage is recorded as unavailable rather than estimated; the observable prompt/chunking ceiling is the 75-source inference manifest.

## Notes

- **New consumed surface, no consumer migration:** the openapi `/memories/history` operation IS the contract; there are no existing consumers to reconcile.
- **ADR 0028 is Accepted** (merged 2026-07-02) — no un-merge-ready hold.
- Separate from #15088's PR-conversation Bird View, which injects its PR-source retrieve into the SAME `synthesizeTemporalBirdView` primitive — #15088 depends on this merging (shared dynamic-synthesis engine).
- Cross-family review requested — the contract converged with Euclid; re-review is scoped to the truth-path closure above.

## Post-Merge Validation

- Inspect the first post-merge operator call for the same complete/non-degraded envelope and keep provider token-usage telemetry as an observability follow-up if the streaming adapter begins exposing it.

Resolves #14435

---

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Origin session `01f4cc68-8b8e-43e6-b51c-55b4f421f4e0`.
