### PR TITLE
fix(ai): recency-relevance scoring for the Golden Path candidate pool (#13844)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -49,6 +49,14 @@ class Config extends ConfigProvider {
              */
             currentReleaseVersion: leaf('v13.2', 'NEO_CURRENT_RELEASE', 'string'),
             /**
+             * Golden Path candidate recency half-life (ms). A candidate's computed priority is scaled by
+             * `2^(-ageMs / halfLife)` from its `createdAt`, so a stale open issue/discussion decays out of
+             * the route while fresh release-relevant work surfaces; a candidate with no parseable
+             * `createdAt` is left unscaled. Consumers read it at the use site; never a hardcoded literal.
+             * @type {number}
+             */
+            goldenPathRecencyHalfLifeMs: leaf(90 * 24 * 60 * 60 * 1000, 'NEO_GOLDEN_PATH_RECENCY_HALF_LIFE_MS', 'number'),
+            /**
              * Universal JSONL backup/export directory for Agent OS databases.
              * @type {string}
              */

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -994,7 +994,13 @@ class GoldenPathSynthesizer extends Base {
                     // Lower distance = Higher significance. (Add 0.1 to avoid div by 0 and curb massive asymptotes)
                     const semanticScore = 1.0 / (semantic_distance + 0.1);
 
-                    const priority = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
+                    // Recency relevance: scale the priority by 2^(-age / half-life) from the node's createdAt,
+                    // so a stale open issue/discussion decays out of the route while fresh release-relevant work
+                    // surfaces. A node with no parseable createdAt is left unscaled (hermetic-fixture safe).
+                    const createdAtMs   = Date.parse(nodeData?.properties?.createdAt ?? nodeData?.properties?.filedAt ?? ''),
+                          recencyFactor = Number.isNaN(createdAtMs) ? 1 : 2 ** (-Math.max(0, now.getTime() - createdAtMs) / aiConfig.goldenPathRecencyHalfLifeMs);
+
+                    const priority = ((semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT)) * recencyFactor;
 
                     if (!this.constructor.isActionableComputedRecommendation(nodeData || {id: issueId})) {
                         scoringStats.nonActionableCandidates++;

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -657,6 +657,21 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Recency-relevance multiplier for a computed-route candidate: `2^(-age / halfLife)` from its
+     * createdAt, so a stale node decays out of the route while fresh work stays ~unscaled. A node with no
+     * parseable createdAt returns 1 (unscaled) so hermetic fixtures and un-timestamped nodes are unaffected.
+     * @param {Object} options
+     * @param {String} [options.createdAt] ISO createdAt string, or undefined
+     * @param {Number} options.nowMs current clock in ms
+     * @param {Number} options.halfLifeMs decay half-life in ms
+     * @returns {Number} factor in (0, 1]
+     */
+    static recencyPriorityFactor({createdAt, nowMs, halfLifeMs}) {
+        const createdAtMs = Date.parse(createdAt ?? '');
+        return Number.isNaN(createdAtMs) ? 1 : 2 ** (-Math.max(0, nowMs - createdAtMs) / halfLifeMs);
+    }
+
+    /**
      * @summary Delegates current release / incident focus rendering to the helper module.
      * @param {Array<Object>} candidates Current focus candidates.
      * @param {Object} options
@@ -994,11 +1009,13 @@ class GoldenPathSynthesizer extends Base {
                     // Lower distance = Higher significance. (Add 0.1 to avoid div by 0 and curb massive asymptotes)
                     const semanticScore = 1.0 / (semantic_distance + 0.1);
 
-                    // Recency relevance: scale the priority by 2^(-age / half-life) from the node's createdAt,
-                    // so a stale open issue/discussion decays out of the route while fresh release-relevant work
-                    // surfaces. A node with no parseable createdAt is left unscaled (hermetic-fixture safe).
-                    const createdAtMs   = Date.parse(nodeData?.properties?.createdAt ?? nodeData?.properties?.filedAt ?? ''),
-                          recencyFactor = Number.isNaN(createdAtMs) ? 1 : 2 ** (-Math.max(0, now.getTime() - createdAtMs) / aiConfig.goldenPathRecencyHalfLifeMs);
+                    // Recency relevance: decay a stale open issue/discussion out of the route while fresh
+                    // release-relevant work surfaces; a node with no parseable createdAt is left unscaled.
+                    const recencyFactor = this.constructor.recencyPriorityFactor({
+                        createdAt : nodeData?.properties?.createdAt ?? nodeData?.properties?.filedAt,
+                        nowMs     : now.getTime(),
+                        halfLifeMs: aiConfig.goldenPathRecencyHalfLifeMs
+                    });
 
                     const priority = ((semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT)) * recencyFactor;
 

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -2469,3 +2469,34 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
         }
     });
 });
+
+test.describe('GoldenPathSynthesizer.recencyPriorityFactor — stale candidates decay out of the route', () => {
+    let Synthesizer;
+
+    const HALF_LIFE_MS = 90 * 24 * 60 * 60 * 1000,
+          NOW_MS       = Date.parse('2026-07-12T00:00:00Z');
+
+    test.beforeAll(async () => {
+        Synthesizer = (await import('../../../../../../ai/services/graph/GoldenPathSynthesizer.mjs')).default.constructor;
+    });
+
+    test('a fresh node stays ~unscaled, a stale node is crushed, and the fresh node decisively outranks it', () => {
+        const fresh = Synthesizer.recencyPriorityFactor({createdAt: '2026-07-01T00:00:00Z', nowMs: NOW_MS, halfLifeMs: HALF_LIFE_MS}),
+              stale = Synthesizer.recencyPriorityFactor({createdAt: '2024-03-01T00:00:00Z', nowMs: NOW_MS, halfLifeMs: HALF_LIFE_MS});
+
+        expect(fresh).toBeGreaterThan(0.9);
+        expect(stale).toBeLessThan(0.01);
+        // equal semantic+structural score → the fresh candidate wins by >100x (the regression the fix kills)
+        expect(fresh).toBeGreaterThan(stale * 100);
+    });
+
+    test('a node with no parseable createdAt is left unscaled (hermetic-fixture / un-timestamped safe)', () => {
+        for (const createdAt of [undefined, null, '', 'not-a-date']) {
+            expect(Synthesizer.recencyPriorityFactor({createdAt, nowMs: NOW_MS, halfLifeMs: HALF_LIFE_MS})).toBe(1);
+        }
+    });
+
+    test('a future createdAt is clamped to unscaled (never a >1 boost)', () => {
+        expect(Synthesizer.recencyPriorityFactor({createdAt: '2027-01-01T00:00:00Z', nowMs: NOW_MS, halfLifeMs: HALF_LIFE_MS})).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes the operator's #1 Golden Path regression: the computed route recommended **stale old** open issues/discussions (issue-9864, discussion-10309/14224/…) over fresh v13.2 work. This is #13844's failed post-merge validation (per @neo-gpt's authority-chain flag) — PR #13837 type-scoped the candidate pool to ISSUE+DISCUSSION (fixing *empty*-GP), but the survivors were still ranked by pure semantic-distance × structural-weight, with **no recency/relevance term**, so an old node semantically near the frontier outranked recent release work.

## Deltas

| File | Change |
|---|---|
| `ai/services/graph/GoldenPathSynthesizer.mjs` | recency factor at the candidate-scoring site (`:997`): `priority *= 2^(-age / halfLife)` from the node's `properties.createdAt`; neutral (`1`) when `createdAt` is absent/unparseable |
| `ai/config.template.mjs` | `goldenPathRecencyHalfLifeMs` ADR-0019 leaf (90-day default), read at the use site |

The recency term is the complementary **successor** to #13837's type-scope on the same query, not a revert — @neo-opus-grace's empty-GP fix holds. Structural weight still boosts genuinely-central older nodes.

## Test Evidence

Evidence: the recency formula was computed directly — a ~28-month-old node (issue-9864 vintage) decays to **0.0013×** while a ~2-week v13.2-era node stays **0.9188×** (a **708× relative** deprioritization). The existing **57 `GoldenPathSynthesizer` specs pass** unchanged, because the factor is neutral on the hermetic fixtures that set no `createdAt`.

**Pending next commit (honest):** a dedicated integration test asserting two equal-score OPEN nodes reorder by `createdAt` (recent above old) — the truth-path proof of the reordering, beyond the formula + no-regression evidence above.

## Post-Merge Validation

- Confirm a live computed Golden Path surfaces v13.2-milestone / recent work above 2024-era nodes (the regression's observable signature).
- `provenance.algorithmVersion` bump rides the ADR-0035 `ComputedRouteResult` typing leaf when it lands (this changes the ranking algorithm).

Resolves #13844

---
Authored by Ada (@neo-opus-ada, Claude Opus 4.8) · origin session `01f4cc68-8b8e-43e6-b51c-55b4f421f4e0`
