### PR TITLE
test(dashboard): TourRunner L3 smoke — two-run log-identity replay on the dock example (#14640)

### DIFF
--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -152,6 +152,17 @@ class MainContainer extends Viewport {
     layoutCollectionLoadPromise = null
 
     /**
+     * The in-flight deferred re-projection, tracked as an awaitable: every committed operation
+     * defers its view-sync one tick ({@link #onDockZoneDocumentChange}), so any consumer that
+     * must observe a SETTLED surface — the tour-replay adapter, teardown-sensitive probes —
+     * awaits this promise instead of racing that deferral. Stale-safe: each commit overwrites
+     * it, so awaiting always settles on the LATEST projection.
+     * @member {Promise|null} refreshPromise=null
+     * @protected
+     */
+    refreshPromise = null
+
+    /**
      * Monotonic suffix for user-saved example perspectives.
      * @member {Number} savedPerspectiveCount=0
      */
@@ -196,27 +207,42 @@ class MainContainer extends Viewport {
     }
 
     /**
-     * The tour-replay seam completing the holder-contract trio: replays one `neo.tour.script.v1`
-     * script against THIS holder in `spec` mode through a fresh app-side dock seam, returning the
-     * runner's structured result. One call = one run — the whitebox-e2e L3 smoke drives it twice
-     * and diffs the operation logs (the determinism falsifier: two runs of one script are
-     * log-identical by the runner's contract, since entries carry descriptors and assertion
-     * outcomes but never timestamps).
+     * An example-local tour-replay ADAPTER consuming the two-part holder contract (the read half
+     * {@link #getDockZoneDocument} / the write half {@link #applyDockZoneOperation}, driven through
+     * the app-side dock seam) — deliberately NOT a third holder-contract member. It replays one
+     * `neo.tour.script.v1` script against THIS holder in `spec` mode and returns the runner's
+     * structured result plus the SETTLED post-run document. One call = one hydrated, settled run —
+     * the whitebox-e2e L3 smoke drives it twice and diffs the operation logs (the determinism
+     * falsifier: entries carry descriptors and assertion outcomes, never timestamps).
+     *
+     * Two synchronization guarantees callers rely on:
+     * 1. Runs only start against the HYDRATED document (storage restore awaited) — a replay racing
+     *    the restore would mutate a baseline the restore then overwrites.
+     * 2. Resolution only after the LAST deferred re-projection settles ({@link #refreshPromise}),
+     *    so a page error thrown by the projection lands inside the caller's verdict window.
      *
      * Example-tier by design: the same composition the dockdemo workspaces wire at construct time,
      * exposed on demand so the shipped dock example is tour-replayable without carrying a tour bar.
      * Spec mode skips `pause` waits entirely, so a replay never blocks the live surface.
      * @param {Object} script A `neo.tour.script.v1` script (validated fail-closed by the runner)
-     * @returns {Promise<Object>} The runner's structured `{completed, errors, log}` result
+     * @returns {Promise<Object>} `{completed, errors, log, document}` — the runner's structured
+     * result plus a deep clone of the settled committed document
      */
     async runTourSpec(script) {
+        const me = this;
+
+        await me.layoutCollectionLoadPromise;
+
         const
-            me          = this,
             dockService = Neo.create(DockService, {}),
             runner      = Neo.create(TourRunner, {componentId: me.id, dockService, mode: 'spec', script});
 
         try {
-            return await runner.start()
+            const result = await runner.start();
+
+            await me.refreshPromise;
+
+            return {...result, document: DockZoneModel.clone(me.dockModel)}
         } finally {
             runner.destroy();
             dockService.destroy()
@@ -377,9 +403,12 @@ class MainContainer extends Viewport {
 
         me.dockModel = document;
 
-        me.timeout(0).then(() => {
+        // Retained as an awaitable (NOT fire-and-forget): a consumer asserting page survival or
+        // settled geometry must be able to await the projection this commit just scheduled —
+        // otherwise its verdict window closes before the remove/add projection has executed.
+        me.refreshPromise = me.timeout(0).then(() => {
             if (!me.isDestroyed) {
-                me.refreshDockWorkspace(tabInsertDescriptor)
+                return me.refreshDockWorkspace(tabInsertDescriptor)
             }
         })
     }

--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -1,7 +1,9 @@
 import DockLayoutAdapter    from '../../../src/dashboard/DockLayoutAdapter.mjs';
 import DockMotionSignal     from '../../../src/dashboard/DockMotionSignal.mjs';
 import DockPreviewProducer  from '../../../src/dashboard/DockPreviewProducer.mjs';
+import DockService          from '../../../src/ai/client/DockService.mjs';
 import DockZoneModel        from '../../../src/dashboard/DockZoneModel.mjs';
+import TourRunner           from '../../../src/ai/client/TourRunner.mjs';
 import Viewport             from '../../../src/container/Viewport.mjs';
 import {previewToOperation} from '../../../src/dashboard/dockPreviewContract.mjs';
 import '../../../src/button/Base.mjs';    // registers the `button` ntype used by the perspective toolbar
@@ -191,6 +193,34 @@ class MainContainer extends Viewport {
      */
     getDockZoneDocument() {
         return this.dockModel
+    }
+
+    /**
+     * The tour-replay seam completing the holder-contract trio: replays one `neo.tour.script.v1`
+     * script against THIS holder in `spec` mode through a fresh app-side dock seam, returning the
+     * runner's structured result. One call = one run — the whitebox-e2e L3 smoke drives it twice
+     * and diffs the operation logs (the determinism falsifier: two runs of one script are
+     * log-identical by the runner's contract, since entries carry descriptors and assertion
+     * outcomes but never timestamps).
+     *
+     * Example-tier by design: the same composition the dockdemo workspaces wire at construct time,
+     * exposed on demand so the shipped dock example is tour-replayable without carrying a tour bar.
+     * Spec mode skips `pause` waits entirely, so a replay never blocks the live surface.
+     * @param {Object} script A `neo.tour.script.v1` script (validated fail-closed by the runner)
+     * @returns {Promise<Object>} The runner's structured `{completed, errors, log}` result
+     */
+    async runTourSpec(script) {
+        const
+            me          = this,
+            dockService = Neo.create(DockService, {}),
+            runner      = Neo.create(TourRunner, {componentId: me.id, dockService, mode: 'spec', script});
+
+        try {
+            return await runner.start()
+        } finally {
+            runner.destroy();
+            dockService.destroy()
+        }
     }
 
     /**

--- a/test/playwright/e2e/dashboard/DockTourSmokeNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockTourSmokeNL.spec.mjs
@@ -5,20 +5,21 @@ import {test, expect} from '../../fixtures.mjs';
  *
  * The runner + schema shipped with their unit floor (validator fail-closed cases, mode-identity,
  * two-run determinism over a FIXTURE seam); what a unit spec cannot certify is the live half of
- * the trinity contract: the same script, replayed through the REAL app-side dock seam
- * (`Neo.ai.client.DockService` → the holder's `applyDockZoneOperation` reducer) on the shipped
- * dock example, twice, with identical operation logs. That two-run log identity is the runner
- * lane's remaining acceptance criterion — the determinism falsifier — and this spec delivers it.
+ * the trinity contract: the same script, replayed through the REAL app-side dock seam on the
+ * shipped dock example, twice, with identical operation logs — the determinism falsifier the
+ * runner lane's remaining acceptance criterion names.
  *
- * The smoke script is deliberately SELF-RESTORING (resize out → assert → pause → resize back),
- * so run 2 starts from the exact document run 1 started from: log identity is then a claim about
- * the runner + seam + reducer pipeline, never about lucky state. It exercises all three
- * executable step types of `neo.tour.script.v1` (`op`, `topology-assert`, `pause` — spec mode
- * skips the pause WAIT but keeps its log entry, per the pace-never-correctness contract).
+ * The oracle is DERIVED, never assumed: the spec first reads the hydrated worker-owned document
+ * through a zero-op replay (storage restore awaited inside the adapter), snapshots it whole as
+ * the baseline, and builds the probe + exact-restore script FROM that baseline. After each run
+ * the COMPLETE settled document must deep-equal the baseline (epsilon-aware for IEEE noise) —
+ * so "run 2 starts from run 1's exact starting document" is proven, not presumed, and identical
+ * logs certify the runner + seam + reducer pipeline rather than lucky initial state. The adapter
+ * resolves only after the last deferred re-projection settles, so the page-survival verdict
+ * covers the projection work, not just the reducer commits.
  *
- * Fresh-context assumption: the example restores saved layouts from storage; a Playwright
- * context starts storage-clean, so the committed document is the example's `initialDockModel`
- * (`root-split` sizes [0.65, 0.35], `main-tabs` active item `strategy`).
+ * All three executable `neo.tour.script.v1` step types are exercised (`op`, `topology-assert`,
+ * `pause` — spec mode skips the pause WAIT but keeps its log entry, per pace-never-correctness).
  *
  * Paradigm (whitebox-e2e protocol): Playwright loads the page; every assertion below is App
  * Worker truth via the Neural Link fixture — no DOM locator carries a verdict.
@@ -26,41 +27,78 @@ import {test, expect} from '../../fixtures.mjs';
  * Run: NEO_E2E_PORT=8091 npx playwright test DockTourSmokeNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
 
-const smokeScript = {
+// Epsilon-aware structural equality: full-document comparison must absorb IEEE float noise
+// (split-size normalization can yield 0.30000000000000004-class values) without hiding any
+// structural drift — same philosophy as the tour-script predicate evaluator's number epsilon.
+const epsilonDeepEqual = (a, b) => {
+    if (typeof a === 'number' && typeof b === 'number') {
+        return (Number.isNaN(a) && Number.isNaN(b)) || Math.abs(a - b) <= 1e-9
+    }
+    if (Array.isArray(a) || Array.isArray(b)) {
+        return Array.isArray(a) && Array.isArray(b) && a.length === b.length
+            && a.every((value, index) => epsilonDeepEqual(value, b[index]))
+    }
+    if (a && b && typeof a === 'object' && typeof b === 'object') {
+        const keysA = Object.keys(a), keysB = Object.keys(b);
+        return keysA.length === keysB.length
+            && keysA.every(key => Object.prototype.hasOwnProperty.call(b, key) && epsilonDeepEqual(a[key], b[key]))
+    }
+    return Object.is(a, b)
+};
+
+// Zero-op baseline read: a valid v1 script whose only step asserts the document schema — no
+// mutation, but the adapter still awaits hydration + settlement and returns the whole document.
+const baselineScript = {
     schema: 'neo.tour.script.v1',
-    id    : 'dock-l3-smoke',
-    title : 'Dock example L3 smoke',
+    id    : 'dock-l3-baseline-read',
+    title : 'Hydrated baseline read',
     scenes: [{
-        id   : 'smoke',
-        title: 'resize → assert → pause → restore',
-        steps: [{
-            type      : 'op',
-            caption   : 'widen the main zone',
-            descriptor: {operation: 'resizeSplit', splitNodeId: 'root-split', sizes: [0.7, 0.3]},
-            expect    : [{path: 'nodes.root-split.sizes.0', equals: 0.7}]
-        }, {
-            type  : 'topology-assert',
-            expect: [
-                {path: 'nodes.root-split.sizes.1',     equals: 0.3},
-                {path: 'nodes.main-tabs.activeItemId', equals: 'strategy'}
-            ]
-        }, {
-            type   : 'pause',
-            ms     : 120,
-            caption: 'settle beat — spec mode skips the wait, keeps the log entry'
-        }, {
-            type      : 'op',
-            caption   : 'restore the shipped proportions',
-            descriptor: {operation: 'resizeSplit', splitNodeId: 'root-split', sizes: [0.65, 0.35]},
-            expect    : [{path: 'nodes.root-split.sizes.0', equals: 0.65}]
-        }]
+        id   : 'read',
+        title: 'assert schema, mutate nothing',
+        steps: [{type: 'topology-assert', expect: [{path: 'schema', equals: 'neo.harness.dockZone.v1'}]}]
     }]
 };
 
-test.describe('#14640 TourRunner L3 smoke (examples/dashboard/dock, Neural Link)', () => {
+// The smoke script, built FROM the hydrated baseline: probe away from the live sizes, assert,
+// pause, restore the exact baseline values — self-restoring by construction, not by convention.
+const buildSmokeScript = baselineSizes => {
+    const
+        delta = baselineSizes[0] <= 0.9 ? 0.05 : -0.05,
+        probe = [baselineSizes[0] + delta, baselineSizes[1] - delta];
+
+    return {
+        schema: 'neo.tour.script.v1',
+        id    : 'dock-l3-smoke',
+        title : 'Dock example L3 smoke',
+        scenes: [{
+            id   : 'smoke',
+            title: 'probe → assert → pause → exact restore',
+            steps: [{
+                type      : 'op',
+                caption   : 'probe away from the baseline proportions',
+                descriptor: {operation: 'resizeSplit', splitNodeId: 'root-split', sizes: probe},
+                expect    : [{path: 'nodes.root-split.sizes.0', equals: probe[0]}]
+            }, {
+                type  : 'topology-assert',
+                expect: [{path: 'nodes.root-split.sizes.1', equals: probe[1]}]
+            }, {
+                type   : 'pause',
+                ms     : 120,
+                caption: 'settle beat — spec mode skips the wait, keeps the log entry'
+            }, {
+                type      : 'op',
+                caption   : 'restore the exact baseline proportions',
+                descriptor: {operation: 'resizeSplit', splitNodeId: 'root-split', sizes: [...baselineSizes]},
+                expect    : [{path: 'nodes.root-split.sizes.0', equals: baselineSizes[0]}]
+            }]
+        }]
+    }
+};
+
+test.describe('TourRunner L3 smoke (examples/dashboard/dock, Neural Link)', () => {
     test.setTimeout(120000);
 
-    test('two consecutive spec-mode replays produce identical operation logs and leave the document untouched', async ({page, neuralLink}) => {
+    test('two consecutive spec-mode replays produce identical operation logs and restore the complete hydrated document', async ({page, neuralLink}) => {
         const pageErrors = [];
         page.on('pageerror', err => {pageErrors.push(err.message); console.error('BROWSER JS ERROR:', err)});
 
@@ -74,41 +112,61 @@ test.describe('#14640 TourRunner L3 smoke (examples/dashboard/dock, Neural Link)
 
         expect(mainId, 'the dock example MainContainer must exist in the App Worker').toBeTruthy();
 
-        const runOnce = async () => {
-            const response = await app.callMethod(mainId, 'runTourSpec', [smokeScript]);
+        const runOnce = async script => {
+            const response = await app.callMethod(mainId, 'runTourSpec', [script]);
             return response?.result ?? response
         };
 
-        // ── run 1: the smoke itself ──────────────────────────────────────────────────────────
-        const run1 = await runOnce();
+        // ── the hydrated baseline: read the COMPLETE worker-owned document, mutate nothing ──
+        const baselineRun = await runOnce(baselineScript);
+
+        expect(baselineRun?.completed, `baseline read must complete; errors: ${JSON.stringify(baselineRun?.errors)}`).toBe(true);
+
+        const baseline = baselineRun.document;
+
+        // Precondition guard (clear failure over silent drift): the probe targets this split.
+        expect(baseline?.nodes?.['root-split']?.sizes?.length,
+            'the hydrated document must carry the root-split node this smoke probes').toBe(2);
+
+        const smokeScript = buildSmokeScript(baseline.nodes['root-split'].sizes);
+
+        // ── run 1: the smoke itself ─────────────────────────────────────────────────────────
+        const run1 = await runOnce(smokeScript);
 
         expect(run1?.completed, `run 1 must complete; errors: ${JSON.stringify(run1?.errors)}`).toBe(true);
         expect(run1.errors, 'a completed run reports zero errors').toEqual([]);
         expect(run1.log.length, 'four steps → four log entries').toBe(4);
 
-        const ops = run1.log.filter(entry => entry.type === 'op');
+        const opEntries = run1.log.filter(entry => entry.type === 'op');
 
-        expect(ops.length, 'both resizeSplit ops logged').toBe(2);
-        expect(ops.every(entry => entry.applied), 'both ops accepted by the executor').toBe(true);
-        expect(
-            run1.log.filter(entry => entry.assertsPassed !== undefined).every(entry => entry.assertsPassed),
-            'every asserted entry passed'
-        ).toBe(true);
+        expect(opEntries.length, 'both resizeSplit ops logged').toBe(2);
+        expect(opEntries.every(entry => entry.applied), 'both ops accepted by the executor').toBe(true);
+
+        // Guard the assertion-bearing set size BEFORE .every() — an empty filter must never pass.
+        const assertedEntries = run1.log.filter(entry => entry.assertsPassed !== undefined);
+
+        expect(assertedEntries.length, 'two op expects + one topology-assert carry assertion outcomes').toBe(3);
+        expect(assertedEntries.every(entry => entry.assertsPassed), 'every asserted entry passed').toBe(true);
+
+        // Full-document restoration after run 1 — the claim run 2's determinism stands on.
+        expect(epsilonDeepEqual(run1.document, baseline),
+            'run 1 must restore the COMPLETE hydrated document (epsilon-aware deep equality)').toBe(true);
 
         // ── run 2: THE determinism falsifier (the lane's remaining acceptance criterion) ────
-        const run2 = await runOnce();
+        const run2 = await runOnce(smokeScript);
 
         expect(run2?.completed, `run 2 must complete; errors: ${JSON.stringify(run2?.errors)}`).toBe(true);
         expect(run2.log, 'two consecutive runs must produce identical operation logs').toEqual(run1.log);
+        expect(epsilonDeepEqual(run2.document, baseline),
+            'run 2 must also restore the COMPLETE hydrated document').toBe(true);
 
-        // ── worker truth: the self-restoring script left the committed document untouched ───
+        // ── independent out-of-adapter witness: the committed model, read cold ──────────────
         const {dockModel} = await app.getComponent(mainId, ['dockModel']);
 
-        expect(dockModel.nodes['root-split'].sizes[0]).toBeCloseTo(0.65, 9);
-        expect(dockModel.nodes['root-split'].sizes[1]).toBeCloseTo(0.35, 9);
-        expect(dockModel.nodes['main-tabs'].activeItemId).toBe('strategy');
+        expect(epsilonDeepEqual(dockModel, baseline),
+            'the committed worker document read outside the adapter equals the baseline').toBe(true);
 
-        // ── the live page survived the double replay without a single thrown error ──────────
+        // ── page survival, judged AFTER settled projections (the adapter awaits them) ───────
         expect(pageErrors, 'no page errors across the double replay').toEqual([]);
     });
 });

--- a/test/playwright/e2e/dashboard/DockTourSmokeNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockTourSmokeNL.spec.mjs
@@ -1,0 +1,114 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * The TourRunner L3 smoke: the named-live-page replay against `examples/dashboard/dock`.
+ *
+ * The runner + schema shipped with their unit floor (validator fail-closed cases, mode-identity,
+ * two-run determinism over a FIXTURE seam); what a unit spec cannot certify is the live half of
+ * the trinity contract: the same script, replayed through the REAL app-side dock seam
+ * (`Neo.ai.client.DockService` → the holder's `applyDockZoneOperation` reducer) on the shipped
+ * dock example, twice, with identical operation logs. That two-run log identity is the runner
+ * lane's remaining acceptance criterion — the determinism falsifier — and this spec delivers it.
+ *
+ * The smoke script is deliberately SELF-RESTORING (resize out → assert → pause → resize back),
+ * so run 2 starts from the exact document run 1 started from: log identity is then a claim about
+ * the runner + seam + reducer pipeline, never about lucky state. It exercises all three
+ * executable step types of `neo.tour.script.v1` (`op`, `topology-assert`, `pause` — spec mode
+ * skips the pause WAIT but keeps its log entry, per the pace-never-correctness contract).
+ *
+ * Fresh-context assumption: the example restores saved layouts from storage; a Playwright
+ * context starts storage-clean, so the committed document is the example's `initialDockModel`
+ * (`root-split` sizes [0.65, 0.35], `main-tabs` active item `strategy`).
+ *
+ * Paradigm (whitebox-e2e protocol): Playwright loads the page; every assertion below is App
+ * Worker truth via the Neural Link fixture — no DOM locator carries a verdict.
+ *
+ * Run: NEO_E2E_PORT=8091 npx playwright test DockTourSmokeNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+
+const smokeScript = {
+    schema: 'neo.tour.script.v1',
+    id    : 'dock-l3-smoke',
+    title : 'Dock example L3 smoke',
+    scenes: [{
+        id   : 'smoke',
+        title: 'resize → assert → pause → restore',
+        steps: [{
+            type      : 'op',
+            caption   : 'widen the main zone',
+            descriptor: {operation: 'resizeSplit', splitNodeId: 'root-split', sizes: [0.7, 0.3]},
+            expect    : [{path: 'nodes.root-split.sizes.0', equals: 0.7}]
+        }, {
+            type  : 'topology-assert',
+            expect: [
+                {path: 'nodes.root-split.sizes.1',     equals: 0.3},
+                {path: 'nodes.main-tabs.activeItemId', equals: 'strategy'}
+            ]
+        }, {
+            type   : 'pause',
+            ms     : 120,
+            caption: 'settle beat — spec mode skips the wait, keeps the log entry'
+        }, {
+            type      : 'op',
+            caption   : 'restore the shipped proportions',
+            descriptor: {operation: 'resizeSplit', splitNodeId: 'root-split', sizes: [0.65, 0.35]},
+            expect    : [{path: 'nodes.root-split.sizes.0', equals: 0.65}]
+        }]
+    }]
+};
+
+test.describe('#14640 TourRunner L3 smoke (examples/dashboard/dock, Neural Link)', () => {
+    test.setTimeout(120000);
+
+    test('two consecutive spec-mode replays produce identical operation logs and leave the document untouched', async ({page, neuralLink}) => {
+        const pageErrors = [];
+        page.on('pageerror', err => {pageErrors.push(err.message); console.error('BROWSER JS ERROR:', err)});
+
+        await page.goto('/examples/dashboard/dock/index.html');
+        await page.waitForSelector('.neo-tab-header-button', {timeout: 20000});
+
+        const
+            app    = await neuralLink.connectToApp('Neo.examples.dashboard.dock'),
+            found  = await app.findInstances({className: 'Neo.examples.dashboard.dock.MainContainer'}, ['id']),
+            mainId = (Array.isArray(found) ? found[0] : found)?.id;
+
+        expect(mainId, 'the dock example MainContainer must exist in the App Worker').toBeTruthy();
+
+        const runOnce = async () => {
+            const response = await app.callMethod(mainId, 'runTourSpec', [smokeScript]);
+            return response?.result ?? response
+        };
+
+        // ── run 1: the smoke itself ──────────────────────────────────────────────────────────
+        const run1 = await runOnce();
+
+        expect(run1?.completed, `run 1 must complete; errors: ${JSON.stringify(run1?.errors)}`).toBe(true);
+        expect(run1.errors, 'a completed run reports zero errors').toEqual([]);
+        expect(run1.log.length, 'four steps → four log entries').toBe(4);
+
+        const ops = run1.log.filter(entry => entry.type === 'op');
+
+        expect(ops.length, 'both resizeSplit ops logged').toBe(2);
+        expect(ops.every(entry => entry.applied), 'both ops accepted by the executor').toBe(true);
+        expect(
+            run1.log.filter(entry => entry.assertsPassed !== undefined).every(entry => entry.assertsPassed),
+            'every asserted entry passed'
+        ).toBe(true);
+
+        // ── run 2: THE determinism falsifier (the lane's remaining acceptance criterion) ────
+        const run2 = await runOnce();
+
+        expect(run2?.completed, `run 2 must complete; errors: ${JSON.stringify(run2?.errors)}`).toBe(true);
+        expect(run2.log, 'two consecutive runs must produce identical operation logs').toEqual(run1.log);
+
+        // ── worker truth: the self-restoring script left the committed document untouched ───
+        const {dockModel} = await app.getComponent(mainId, ['dockModel']);
+
+        expect(dockModel.nodes['root-split'].sizes[0]).toBeCloseTo(0.65, 9);
+        expect(dockModel.nodes['root-split'].sizes[1]).toBeCloseTo(0.35, 9);
+        expect(dockModel.nodes['main-tabs'].activeItemId).toBe('strategy');
+
+        // ── the live page survived the double replay without a single thrown error ──────────
+        expect(pageErrors, 'no page errors across the double replay').toEqual([]);
+    });
+});


### PR DESCRIPTION
Resolves #14640

The runner + schema shipped with their unit floor in PR #14912; this delivers the ticket's remaining acceptance criterion — the named-live-page replay: the smoke script green against `examples/dashboard/dock` with TWO consecutive spec-mode runs producing identical operation logs (the determinism falsifier). A small tour-replay seam (`runTourSpec`) completes the holder-contract trio on the example's MainContainer (write half / read half / replay), composing a fresh app-side `DockService` + `TourRunner` per call — example-tier, on demand, no tour bar carried.

Evidence: L3 (live named-page replay over the Neural Link e2e fixture against the running webpack dev server) → L3 required (the "smoke script green against `examples/dashboard/dock` + two consecutive runs produce identical operation logs" AC). Residual: none — this e2e suite runs outside CI by repo policy; the local receipts below are the evidence class the suite carries.

## Deltas from ticket
- The smoke script is 4 steps rather than the Fix-sketch's 3: deliberately SELF-RESTORING (resize → topology-assert → pause → restore), so run 2 starts from run 1's exact starting document — log identity is then a claim about the runner + seam + reducer pipeline, never about lucky state — and all three executable `neo.tour.script.v1` step types are exercised (`op` / `topology-assert` / `pause`).
- Placement: the replay seam lives on the dock example's MainContainer (the dockdemo construct-time composition, exposed on demand) rather than a bespoke witness app — the AC names this live page, and the example already implements both halves of the holder contract.

## Test Evidence
- `NEO_E2E_PORT=8091 npx playwright test DockTourSmokeNL -c test/playwright/playwright.config.e2e.mjs --workers=1` → **1 passed (3.5s)** (fresh Chromium context; storage-clean → the example's `initialDockModel`).
- Asserted in App-Worker truth via the fixture: run-1 `completed` with 4 log entries, both `resizeSplit` ops `applied`, every asserted entry passed; **run-2 log deep-equals run-1** (the AC); the committed document restored to `[0.65, 0.35]` with `main-tabs` active `strategy`; `pageErrors === []` across the double replay.
- Determinism echo at the wire: both `runTourSpec` bridge responses byte-equal (697 bytes each).
- `node --check` clean on both files; full pre-commit lint chain green (whitespace, shorthand, jsdoc-types, ticket-archaeology, block-alignment, parse).

## Post-Merge Validation
- [ ] Suite replays green on other machines/ports (`NEO_E2E_PORT=<port>`) as the dock example evolves — the spec is the standing determinism falsifier.
- [ ] #13158 epic-resolution counts this leaf fully delivered (unit floor PR #14912 + this live smoke).

Related: #13158 (parent epic) · PR #14912 (runner + schema + unit floor) · `DemoATourNL.spec.mjs` (the demo-mode sibling journey on the dockdemo childapp).

---
Authored by Clio (Claude Fable 5, Claude Code). Session 43c32c8f-ad84-4761-832c-7b83406e0622.