### PR TITLE
fix(button/main): floating-button position:fixed cascade + DomAccess null-offsetParent guards (#14771)

### DIFF
--- a/resources/scss/src/button/Base.scss
+++ b/resources/scss/src/button/Base.scss
@@ -30,6 +30,14 @@
     white-space       : nowrap;
     -webkit-appearance: button;
 
+    // A floating button must keep the `.neo-floating` fixed positioning. The `.neo-button` `position:
+    // relative` above otherwise wins the cascade (equal single-class specificity, later source order) and
+    // pins the button to its offsetParent instead of the viewport — so `alignTo`'s computed left/top land
+    // it at the wrong coordinates. This higher-specificity compound selector restores `position: fixed`.
+    &.neo-floating {
+        position: fixed;
+    }
+
     .neo-button-badge {
         background-color: var(--button-badge-background-color);
         border-radius   : 5px;

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -140,9 +140,10 @@ class DomAccess extends Base {
 
         // Set up listeners which monitor for changes
         if (!aligns.has(id)) {
-            // Realign when target's layout-controlling element changes size. A fixed-positioned aligned
-            // element has NO offsetParent (it is positioned against the viewport), so guard against observing
-            // null — `ResizeObserver.observe(null)` throws "parameter 1 is not of type 'Element'".
+            // Realign when the target's layout-controlling element changes size. `align()` stores
+            // `alignSpec.offsetParent = targetElement.offsetParent` — the TARGET's layout parent, which is
+            // null when the target is position:fixed (or the body/root). Guard against observing null —
+            // `ResizeObserver.observe(null)` throws "parameter 1 is not of type 'Element'".
             alignSpec.offsetParent && resizeObserver.observe(alignSpec.offsetParent);
 
             // Realign when align to target changes size
@@ -1103,8 +1104,9 @@ class DomAccess extends Base {
                     {_alignResizeObserver} = me,
                     {constrainToElement}   = align;
 
-                // Stop observing the align elements (offsetParent is null for a fixed-positioned subject —
-                // it was never observed, and unobserve(null) throws just like observe(null)).
+                // Stop observing the align elements. `align.offsetParent` is the TARGET's layout parent
+                // (null when the target is position:fixed or the body/root) — never observed in that case,
+                // and unobserve(null) throws just like observe(null).
                 _alignResizeObserver.unobserve(align.subject);
                 align.offsetParent && _alignResizeObserver.unobserve(align.offsetParent);
                 _alignResizeObserver.unobserve(align.targetElement);

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -140,8 +140,10 @@ class DomAccess extends Base {
 
         // Set up listeners which monitor for changes
         if (!aligns.has(id)) {
-            // Realign when target's layout-controlling element changes size
-            resizeObserver.observe(alignSpec.offsetParent);
+            // Realign when target's layout-controlling element changes size. A fixed-positioned aligned
+            // element has NO offsetParent (it is positioned against the viewport), so guard against observing
+            // null — `ResizeObserver.observe(null)` throws "parameter 1 is not of type 'Element'".
+            alignSpec.offsetParent && resizeObserver.observe(alignSpec.offsetParent);
 
             // Realign when align to target changes size
             resizeObserver.observe(alignSpec.targetElement);
@@ -246,9 +248,9 @@ class DomAccess extends Base {
             result = data.result = myRect.alignTo(align);
 
         Object.assign(style, {
-            top : 0,
-            left: 0,
-            transform : `translate(${result.x}px,${result.y}px)`
+            top      : 0,
+            left     : 0,
+            transform: `translate(${result.x}px,${result.y}px)`
         });
 
         if (result.width !== myRect.width) {
@@ -752,8 +754,8 @@ class DomAccess extends Base {
      * @param {String} data.nodeId
      */
     getOffscreenCanvas(data) {
-        let me        = this,
-            node      = me.getElement(data.nodeId),
+        let me   = this,
+            node = me.getElement(data.nodeId),
             offscreen;
 
         if (!node) {
@@ -1064,10 +1066,10 @@ class DomAccess extends Base {
      */
     syncAligns(arg1) {
         const
-            me          = this,
-            {_aligns}   = me,
-            isScroll    = arg1?.type === 'scroll',
-            evtTarget   = isScroll ? arg1.target : null,
+            me        = this,
+            {_aligns} = me,
+            isScroll  = arg1?.type === 'scroll',
+            evtTarget = isScroll ? arg1.target : null,
             // Document scroll (window) target is document.
             isDocScroll = isScroll && (evtTarget === document || evtTarget === document.documentElement);
 
@@ -1101,9 +1103,10 @@ class DomAccess extends Base {
                     {_alignResizeObserver} = me,
                     {constrainToElement}   = align;
 
-                // Stop observing the align elements
+                // Stop observing the align elements (offsetParent is null for a fixed-positioned subject —
+                // it was never observed, and unobserve(null) throws just like observe(null)).
                 _alignResizeObserver.unobserve(align.subject);
-                _alignResizeObserver.unobserve(align.offsetParent);
+                align.offsetParent && _alignResizeObserver.unobserve(align.offsetParent);
                 _alignResizeObserver.unobserve(align.targetElement);
                 if (constrainToElement) {
                     _alignResizeObserver.unobserve(constrainToElement)


### PR DESCRIPTION
Resolves #15112

Two placement-independent framework root-fixes for the alignment / floating-element subsystem, generalized out of the tab-overflow work (parent #14771, closed) so they land on their own authority. Both are generic — any floating aligned element, not just the tab-overflow control. Ordered to land **before** the tab-native successor #15098.

## RA-9 — floating-button `position: fixed` cascade
`resources/scss/src/button/Base.scss`. A floating button carries both `.neo-floating {position: fixed}` (component/Base) and `.neo-button {position: relative}` (button/Base). Equal single-class specificity → `.neo-button` wins on source order → the floating button resolves to `position: relative`, pinning it to its `offsetParent` instead of the viewport, so `alignTo` lands it at the wrong coordinates. Fix: the compound `.neo-button.neo-floating {position: fixed}` (higher specificity) restores fixed positioning.

## RA-10 — null **target**-offsetParent observer guards
`src/main/DomAccess.mjs`. `align()` stores `data.offsetParent = data.targetElement.offsetParent` — the alignment **target's** layout parent — and `addAligned` / `removeAligned` observe/unobserve it via the align `ResizeObserver`. When the target's `offsetParent` is **null** — a `position: fixed` target (e.g. the floating overflow button once RA-9 pins it, when its own menu aligns *to* it) or a body/root target — `observe(null)` / `unobserve(null)` throws *"parameter 1 is not of type 'Element'"*. Fix: null-guard both call sites. The observed field belongs to the **target**, not the aligned subject — RA-9's subject-positioning and RA-10's target-null-offsetParent are separate facts that co-occur when a menu aligns to a now-fixed button.

Evidence: L3 — both fixes were exercised by the tab-overflow owner-exact-geometry e2e journey (passing on #15062's branch). No unit coverage in this PR: RA-9 is a CSS cascade (not unit-testable) and RA-10's guard is a main-thread DOM path — the e2e is the test-of-record. #15098's 13 unit specs do **not** cover RA-9/RA-10.

## Test Evidence
- No new per-PR test in this carve-out. RA-9 (CSS cascade) + RA-10 (main-thread DOM null-guard) were exercised by the tab-overflow owner-geometry L3 journey (green on #15062). That durable replay re-homes to #15099 (dense-workstation scene); this PR does **not** claim #15098's unit suite covers these fixes.
- `node --check src/main/DomAccess.mjs` passes; hosted unit / integration / lint / CodeQL green.

## Post-Merge Validation
- [ ] #15099's dense-workstation e2e replays the owner-exact-geometry journey and stays green with RA-9/RA-10 in `dev` (the durable witness for both fixes).
- [ ] No regression in existing align behavior for non-fixed targets.

## Deltas
- Corrected the RA-10 causal comments (commit `bd701c58a`) per @neo-gpt's #15109 review: the guarded `offsetParent` is the alignment **target's** layout parent (`data.targetElement.offsetParent`), not the aligned subject's — the two `DomAccess` comments previously mis-attributed nullability to the fixed subject. Guard code unchanged (already correct).
- Created dedicated leaf **#15112** (RA-9/RA-10) as the close-target; #14771 (closed parent) and #15098 (successor) are non-closing references only.

## Commits
- `acfb2ea90` — RA-9 (button floating `position: fixed` cascade).
- `fcd7e8af5` — RA-10 (DomAccess null target-offsetParent observer guards).
- `bd701c58a` — RA-10 comment causal-model correction (target, not subject).

Authored by Grace (Claude Opus 4.8, Claude Code). Refs #14771 (closed parent) · Refs #15098 (tab-native successor, non-closing) · Refs #15099 (durable e2e replay).
