### PR TITLE
fix(ai): persist authoritative A2A Task ownership

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -483,7 +483,9 @@ async function pollLoop() {
  * delta data source (the `entityData` accessor bag) and its flat coalescing payload shape; all
  * trigger semantics live in `match()`: unread-gating + `DELIVERED_TO` receipt-dedup for
  * `SENT_TO_ME`, the `CAN_*` permission edges (the former `HAS_PERMISSION` branch was dead — those
- * edges are created nowhere), and task `from`-OR-`assignee` targeting (formerly assignee-only).
+ * edges are created nowhere), and task `from`-OR-authoritative-`assignee` targeting. Task matches
+ * retain their source-owned transition clock so coalescing can distinguish same-state transitions
+ * that happened at different times; the clock does not by itself classify every node rewrite.
  */
 function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
     if (!isWakeTargetEligible(sub.properties?.agentIdentity)) return null;
@@ -507,7 +509,15 @@ function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
         case 'sent_to_me':
             return {type: 'message', messageId: payload.messageId, from: payload.from, subject: payload.subject, priority: payload.priority, logId};
         case 'task_state_changed':
-            return {type: 'task', taskId: payload.taskId, newState: payload.newState, logId};
+            return {
+                type          : 'task',
+                taskId        : payload.taskId,
+                newState      : payload.newState,
+                originator    : payload.originator,
+                assignee      : payload.assignee,
+                lastModifiedAt: payload.lastModifiedAt,
+                logId
+            };
         case 'permission_granted':
             return {type: 'permission', scope: payload.scope, grantedBy: payload.grantedBy, logId};
         case 'heartbeat_pulse':
@@ -623,14 +633,18 @@ function queueEvent(subscription, eventPayload, watermarkResetCeiling = 0, water
         );
     }
 
-    // Deduplicate within the coalescing window
+    // Deduplicate within the coalescing window. A Task transition's identity includes its
+    // source-owned clock: Working -> InputRequired -> Working is three transitions even though
+    // the first and last share taskId + newState.
     const isDuplicate = coalesceState[subId].queue.some(existing => {
         if (existing.type !== eventPayload.type) return false;
 
         if (eventPayload.type === 'message') {
             return existing.messageId === eventPayload.messageId;
         } else if (eventPayload.type === 'task') {
-            return existing.taskId === eventPayload.taskId && existing.newState === eventPayload.newState;
+            return existing.taskId === eventPayload.taskId
+                && existing.newState === eventPayload.newState
+                && existing.lastModifiedAt === eventPayload.lastModifiedAt;
         } else if (eventPayload.type === 'permission') {
             return existing.scope === eventPayload.scope && existing.grantedBy === eventPayload.grantedBy;
         } else if (eventPayload.type === 'heartbeat') {

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1331,8 +1331,7 @@ paths:
       x-neo-tool-tier: write
       x-pass-as-object: true
       x-neo-tool-summary: Send an A2A message to one peer or an agent broadcast.
-      description: |
-        Sends an A2A message to a specific agent identity or broadcast (*).
+      description: Sends a message or optional Task; Task assignment is server-owned, and broadcasts remain unassigned until an eligible send-time recipient claims them.
       tags: [Mailbox]
       requestBody:
         required: true
@@ -1380,7 +1379,25 @@ paths:
                   description: "Persist + deliver the message but emit NO wake event — the recipient sees it on their next list_messages rather than via an interrupt. Use for awareness/FYI (e.g. PR-opened-you're-not-the-reviewer, lane-progress, acks) or session-sunset self-DM handovers. Do NOT suppress actionable messages (you're the reviewer, a lane was claimed on you, REQUEST_CHANGES) — those must wake. Known-actionable direct lifecycle messages are rejected when wakeSuppressed is true. In autonomous mode a suppressed message stays unseen until the recipient next lists/boots. Default: omit (= false)."
                 task:
                   type: object
-                  description: "Optional A2A Task envelope (https://a2a-protocol.org/latest/specification/) for structured agent coordination. Omit for free-form markdown messages."
+                  additionalProperties: true
+                  description: "Optional A2A Task envelope (https://a2a-protocol.org/latest/specification/) for structured agent coordination. Omit for free-form markdown messages. The server clones the envelope and overwrites `assignee`; callers cannot select or mutate the owner."
+                  properties:
+                    id:
+                      type: string
+                      description: Optional Task-level identifier carried inside the MESSAGE envelope.
+                    state:
+                      type: string
+                      enum: [Submitted, Working, InputRequired, Completed, Canceled, Failed, Rejected, AuthRequired, Unknown, Expired, Blocked]
+                      description: Initial A2A Task state per the A2A Protocol plus Neo's Blocked extension.
+                    assignee:
+                      type: string
+                      nullable: true
+                      readOnly: true
+                      description: "Server-owned canonical AgentIdentity owner. Direct Tasks bind immediately; broadcasts begin null and bind atomically to the first eligible DELIVERED_TO claimant. Caller input is overwritten."
+                    expiresAt:
+                      type: string
+                      format: date-time
+                      description: Optional expiry time consumed by the Task TTL sweeper.
       responses:
         '200':
           description: OK
@@ -1640,9 +1657,7 @@ paths:
       operationId: transition_task
       x-neo-tool-tier: extended
       x-pass-as-object: true
-      description: |
-        Transitions the state of an A2A Task using optimistic concurrency control.
-        Validates roles (Originator vs Assignee) against the new state.
+      description: Transitions a Task with optimistic state locking; broadcast claims are send-time-recipient-only, and later transitions require the persisted server-owned assignee.
       tags: [Mailbox]
       requestBody:
         required: true
@@ -1662,7 +1677,8 @@ paths:
                   description: "Target A2A Task state per A2A Protocol spec (PascalCase). See https://a2a-protocol.org/latest/specification/."
                 expectedCurrentState:
                   type: string
-                  description: The expected current state for optimistic locking.
+                  enum: [Submitted, Working, InputRequired, Completed, Canceled, Failed, Rejected, AuthRequired, Unknown, Expired, Blocked]
+                  description: The expected current state for optimistic locking. A mismatch returns a non-mutating race result.
       responses:
         '200':
           description: OK

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -6,6 +6,7 @@ import {canonicalizeTaggedConceptIds}           from '../graph/conceptSpineCanon
 import GraphService                             from './GraphService.mjs';
 import PermissionService                        from './PermissionService.mjs';
 import WakeSubscriptionService                  from './WakeSubscriptionService.mjs';
+import {TASK_ASSIGNMENT_AUTHORITY}              from './taskAssignmentContract.mjs';
 import {
     appendMessageWalGraphProjectionMarker,
     appendWalMessage,
@@ -138,6 +139,41 @@ function normalizeMailboxIdentityForComparison(identity) {
  */
 function sameMailboxIdentity(left, right) {
     return normalizeMailboxIdentityForComparison(left) === normalizeMailboxIdentityForComparison(right);
+}
+
+/**
+ * @summary Resolves one validated direct mailbox target into a canonical Task assignee.
+ *
+ * Task assignment is server-owned: a caller-supplied `task.assignee` cannot grant transition
+ * authority. Broadcasts deliberately return `null` until `Submitted → Working` atomically records
+ * the winning claimant. Human, role, sentinel, and otherwise non-agent targets remain unassigned.
+ *
+ * @param {*} target Validated mailbox target.
+ * @param {Object} [db] Graph database facade.
+ * @returns {String|null} Canonical AgentIdentity id, or `null` when the target is not assignable.
+ * @private
+ */
+function getCanonicalTaskAssigneeForTarget(target, db = GraphService.requireDb('MailboxService.getCanonicalTaskAssigneeForTarget')) {
+    const canonical = normalizeMailboxIdentityForComparison(target);
+
+    if (typeof canonical !== 'string' || canonical === 'AGENT:*' || !canonical.startsWith('@')) {
+        return null;
+    }
+
+    let node = db?.nodes?.get(canonical);
+
+    if (!node && db?.getAdjacentNodes) {
+        db.getAdjacentNodes(canonical, 'both');
+        node = db.nodes.get(canonical);
+    }
+
+    const
+        label       = getRecordField(node, 'label'),
+        accountType = getRecordProperties(node).accountType;
+
+    return label === 'AgentIdentity' && accountType === 'agent'
+        ? canonical
+        : null;
 }
 
 /**
@@ -385,14 +421,14 @@ function getMessageWalArray(value) {
  * @returns {Object} Canonical routing, mirrored message properties, and raw diagnostics.
  */
 function getCanonicalMessageWalRouting(record) {
-    const message              = record?.message || {},
+    const message            = record?.message || {},
         rawMessageProperties = message.properties || {},
         routing              = record?.routing || {},
         rawSentBy            = routing.sentBy || rawMessageProperties.from,
         rawTo                = routing.to || rawMessageProperties.to,
         sentBy               = normalizeMailboxIdentityForComparison(rawSentBy),
         to                   = normalizeMailboxIdentityForComparison(rawTo),
-        broadcastRecipients   = [...new Set(getMessageWalArray(routing.broadcastRecipients)
+        broadcastRecipients  = [...new Set(getMessageWalArray(routing.broadcastRecipients)
             .map(recipient => normalizeMailboxIdentityForComparison(recipient)))],
         invalidDirectIdentities = [sentBy, to, ...broadcastRecipients]
             .filter(identity => identity === '@me' || identity === '@');
@@ -579,11 +615,37 @@ function hasMailboxGraphEdgeInStorage(source, target, type) {
     const sqlite = GraphService.db?.storage?.db;
     if (!sqlite) return false;
 
-    const variants     = getMailboxIdentityStorageVariants(target),
+    const variants   = getMailboxIdentityStorageVariants(target),
         placeholders = variants.map(() => '?').join(', ');
 
     return (sqlite.prepare(`SELECT count(*) AS count FROM Edges WHERE source = ? AND target IN (${placeholders}) AND type = ?`)
         .get(source, ...variants, type)?.count ?? 0) > 0;
+}
+
+/**
+ * @summary Reads all targets for one mailbox edge type from cache plus SQLite storage.
+ * @param {String} source Message node id.
+ * @param {String} type Mailbox edge type.
+ * @returns {String[]} De-duplicated stored targets.
+ * @private
+ */
+function getMailboxGraphEdgeTargets(source, type) {
+    const targets = new Set();
+
+    for (const edge of GraphService.db?.edges?.items || []) {
+        if (getRecordField(edge, 'source') === source && getRecordField(edge, 'type') === type) {
+            targets.add(getRecordField(edge, 'target'));
+        }
+    }
+
+    const sqlite = GraphService.db?.storage?.db;
+    if (sqlite) {
+        for (const row of sqlite.prepare('SELECT target FROM Edges WHERE source = ? AND type = ? ORDER BY id').all(source, type)) {
+            targets.add(row.target);
+        }
+    }
+
+    return [...targets];
 }
 
 function hasMessageNodeInStorage(messageId) {
@@ -595,39 +657,84 @@ function hasMessageNodeInStorage(messageId) {
 }
 
 /**
- * @summary Storage-truth read of the graph-owned mutable MESSAGE-node state: the recipient's
- * `readAt`/`archivedAt` (written by `markRead` / archive) AND the sender's irreversible retraction
- * tombstone (`retracted` + the placeholder `subject`/`bodyText` written by `deleteMessage` — a
- * permanent decision with no undo path). The WAL is pure intake — its records carry send-time
- * state (`readAt: null`, the original content) forever — so ANY projection landing on an EXISTING
- * node must let the committed graph values win for exactly this surface. Returns `{}` for a
- * missing node, so a true first projection keeps the WAL values.
- * @param {String} messageId Message graph node id.
- * @returns {Object} Only the committed fields: `{readAt?, archivedAt?, retracted?, subject?,
- * bodyText?}` — the tombstone trio rides together, never partially.
+ * @summary Parses one JSON-object field read through SQLite `json_extract`.
+ * @param {*} value SQLite value.
+ * @param {String} field Property name used in diagnostics.
+ * @param {String} messageId MESSAGE node id used in diagnostics.
+ * @returns {Object|undefined}
+ * @throws {Error} When a present value is not valid object-shaped JSON.
  * @private
  */
-function getStorageMessageMutableState(messageId) {
+function parseStorageJsonObject(value, field, messageId) {
+    if (value == null) return undefined;
+
+    let parsed = value;
+    if (typeof value === 'string') {
+        try {
+            parsed = JSON.parse(value);
+        } catch (e) {
+            throw new Error(`Stored ${field} for ${messageId} is malformed JSON: ${e.message}`);
+        }
+    }
+
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        throw new Error(`Stored ${field} for ${messageId} must be a JSON object`);
+    }
+
+    return parsed;
+}
+
+/**
+ * @summary Reads graph-owned Task state that must win over immutable send-time WAL payloads.
+ * @param {String} messageId MESSAGE node id.
+ * @returns {Object} Stored Task, assignment provenance, and transition-clock fields when present.
+ * @private
+ */
+function getStorageTaskMutableState(messageId) {
     const sqlite = GraphService.db?.storage?.db;
     if (!sqlite) return {};
 
-    const row = sqlite
-        .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt, json_extract(data, '$.properties.archivedAt') AS archivedAt, json_extract(data, '$.properties.retracted') AS retracted, json_extract(data, '$.properties.subject') AS subject, json_extract(data, '$.properties.bodyText') AS bodyText FROM Nodes WHERE id = ?`)
-        .get(messageId);
+    const row = sqlite.prepare(`
+        SELECT
+            json_extract(data, '$.properties.task') AS task,
+            json_extract(data, '$.properties.taskAssignmentAuthority') AS taskAssignmentAuthority,
+            json_extract(data, '$.properties.lastModifiedAt') AS lastModifiedAt
+        FROM Nodes
+        WHERE id = ?
+    `).get(messageId);
     if (!row) return {};
 
     const state = {};
-    if (row.readAt != null)     state.readAt     = row.readAt;
-    if (row.archivedAt != null) state.archivedAt = row.archivedAt;
+    if (row.task != null)                    state.task                    = parseStorageJsonObject(row.task, 'task', messageId);
+    if (row.taskAssignmentAuthority != null) state.taskAssignmentAuthority = row.taskAssignmentAuthority;
+    if (row.lastModifiedAt != null)          state.lastModifiedAt          = row.lastModifiedAt;
 
-    // A retraction permanently overwrote the content at write time; a replay resurrecting the
-    // WAL's original subject/body would undo an irreversible sender decision.
-    if (row.retracted) {
-        state.retracted = true;
-        state.subject   = row.subject;
-        state.bodyText  = row.bodyText;
-    }
     return state;
+}
+
+/**
+ * @summary Refreshes cached Task-owned fields from one SQLite truth snapshot without writing.
+ * @param {Object} messageNode Cached MESSAGE node.
+ * @param {Object} state Result from `getStorageTaskMutableState()`.
+ * @returns {void}
+ * @private
+ */
+function applyStorageTaskMutableState(messageNode, state) {
+    if (!messageNode) return;
+
+    // Mutate the cached properties object in place. Some Graph records expose that same object
+    // through both `record.get('properties')` and the compatibility `.properties` field; replacing
+    // it would leave existing consumer references pinned to stale Task authority.
+    const properties = getRecordProperties(messageNode);
+
+    if (Object.hasOwn(state, 'task'))                    properties.task                    = {...state.task};
+    else                                                delete properties.task;
+    if (Object.hasOwn(state, 'taskAssignmentAuthority')) properties.taskAssignmentAuthority = state.taskAssignmentAuthority;
+    else                                                delete properties.taskAssignmentAuthority;
+    if (Object.hasOwn(state, 'lastModifiedAt'))          properties.lastModifiedAt          = state.lastModifiedAt;
+    else                                                delete properties.lastModifiedAt;
+
+    setRecordProperties(messageNode, properties);
 }
 
 /**
@@ -645,7 +752,7 @@ function getStorageDeliveryMutableState(messageId, recipient) {
     const sqlite = GraphService.db?.storage?.db;
     if (!sqlite) return {};
 
-    const variants     = getMailboxIdentityStorageVariants(recipient),
+    const variants   = getMailboxIdentityStorageVariants(recipient),
         placeholders = variants.map(() => '?').join(', '),
         rows         = sqlite
             .prepare(`SELECT json_extract(data, '$.properties.readAt') AS readAt, json_extract(data, '$.properties.archivedAt') AS archivedAt FROM Edges WHERE source = ? AND target IN (${placeholders}) AND type = 'DELIVERED_TO' ORDER BY id`)
@@ -733,10 +840,10 @@ async function hasMailboxGraphProjectionGap() {
  * @private
  */
 function getMessageGraphProjectionIssues(record) {
-    const db        = GraphService.requireDb('MailboxService.getMessageGraphProjectionIssues'),
-        messageId = record?.id || record?.message?.id,
+    const db                                                       = GraphService.requireDb('MailboxService.getMessageGraphProjectionIssues'),
+        messageId                                                  = record?.id || record?.message?.id,
         {broadcastRecipients, invalidDirectIdentities, sentBy, to} = getCanonicalMessageWalRouting(record),
-        issues    = [];
+        issues                                                     = [];
 
     if (typeof messageId !== 'string' || !messageId.startsWith('MESSAGE:')) {
         return ['invalid-message-record'];
@@ -1059,12 +1166,12 @@ class MailboxService extends Base {
      *   wake events. Intended for mailbox-only handovers such as session-sunset self-DMs that must be
      *   consumed by the next boot, not injected back into the active sender harness. Known-actionable
      *   direct lifecycle messages reject wake suppression before persistence.
-     * @param {Object} [args.task] Optional A2A Task envelope payload. When present,
-     *   stored verbatim as a property on the MESSAGE node and surfaced by get_message + list_messages
-     *   for programmatic agent coordination. This write primitive treats `task` as opaque JSON;
-     *   the transition API owns state-machine transitions, RBAC enforcement, and idempotency
-     *   claim-and-lock semantics. Schema follows Neo's A2A hybrid contract: an A2A spec subset plus
-     *   Neo extensions such as `expiresAt` and `Blocked`. See
+     * @param {Object} [args.task] Optional A2A Task envelope payload. Caller fields are cloned, then
+     *   the server overwrites `task.assignee`: a direct AgentIdentity recipient is bound immediately;
+     *   a broadcast remains `null` until an eligible recipient wins the atomic claim. The top-level
+     *   `taskAssignmentAuthority` provenance marker is also server-owned. The transition API owns
+     *   state-machine transitions, RBAC, and idempotent claim-and-lock semantics. Schema follows
+     *   Neo's A2A hybrid contract: an A2A subset plus `expiresAt` / `Blocked`. See
      *   {@link https://a2a-protocol.org/latest/specification/} for the canonical Task envelope.
      * @returns {Promise<Object>}
      */
@@ -1191,7 +1298,9 @@ class MailboxService extends Base {
         // The optional `task` property carries an A2A-Task-object-shaped JSON payload. When
         // present, downstream consumers surface it for programmatic agent coordination. The
         // payload follows Neo's hybrid contract: A2A spec subset + Neo extensions like
-        // `expiresAt` / `Blocked`; state transitions and RBAC are owned by transitionTask.
+        // `expiresAt` / `Blocked`. `assignee` is a server-owned extension: direct tasks bind to
+        // their validated AgentIdentity recipient, broadcasts stay null until the atomic claim.
+        // State transitions and RBAC are owned by transitionTask.
         // See https://a2a-protocol.org/latest/specification/ for the canonical envelope shape.
         const messageProperties = {
             subject,
@@ -1210,7 +1319,16 @@ class MailboxService extends Base {
         };
 
         if (task !== undefined) {
-            messageProperties.task = task;
+            messageProperties.task = task && typeof task === 'object' && !Array.isArray(task)
+                ? {
+                    ...task,
+                    assignee: getCanonicalTaskAssigneeForTarget(to, db)
+                }
+                : task;
+
+            if (messageProperties.task && typeof messageProperties.task === 'object' && !Array.isArray(messageProperties.task)) {
+                messageProperties.taskAssignmentAuthority = TASK_ASSIGNMENT_AUTHORITY;
+            }
         }
         if (relatedTickets.length > 0) {
             messageProperties.relatedTickets = [...new Set(relatedTickets)].sort();
@@ -1279,8 +1397,9 @@ class MailboxService extends Base {
      *   pure intake — its records carry send-time mutable state (`readAt: null`) forever — so a
      *   FULL re-projection over existing structures resurrects unread state on top of committed
      *   reads (the read-state-rollback defect: partial damage must never trigger a total rewrite).
-     *   `null` (accept/drain paths) keeps the full projection for never-projected records — made
-     *   idempotent-safe by the node piece's mutable-state merge below.
+     *   `null` (accept/drain paths) keeps the full projection for never-projected records. When the
+     *   MESSAGE already exists, the node write is skipped entirely: immutable intake WAL must never
+     *   race and rewind graph-owned read, retraction, Task-owner, state, or transition-clock facts.
      * @param {Boolean} [options.appendMarker=!onlyIssues] Whether to append the graph-projection
      *   success marker. Full projections (accept / drain) append — the marker is what retires the
      *   record from the pending index. Surgical repairs default OFF: they exist for the
@@ -1295,6 +1414,8 @@ class MailboxService extends Base {
         if (typeof messageId !== 'string' || !messageId.startsWith('MESSAGE:')) {
             throw new Error('[MailboxService] message WAL projection requires a MESSAGE:* id');
         }
+
+        const db = GraphService.requireDb('MailboxService._projectMessageWalRecord');
 
         const {
             broadcastRecipients,
@@ -1330,17 +1451,38 @@ class MailboxService extends Base {
         const needsPiece = piece => !onlyIssues || onlyIssues.includes(piece);
 
         if (needsPiece('missing-message-node')) {
-            // Recipient-mutable state is graph-owned, never WAL-owned: when this projection lands
-            // on an EXISTING node (a marker-lost-but-projected record replayed by the drain, or
-            // any future full-path caller), the committed `readAt`/`archivedAt` win over the WAL's
-            // eternal send-time nulls. This makes the write choke-point structurally unable to
-            // resurrect unread state, whichever caller reaches it.
-            GraphService.upsertNode({
-                id        : messageId,
-                type      : message.type || 'MESSAGE',
-                name      : message.name || messageProperties.subject || messageId,
-                properties: {...messageProperties, ...getStorageMessageMutableState(messageId)}
-            });
+            if (hasMessageNodeInStorage(messageId)) {
+                // Existing-node replay is storage-neutral. Reading mutable state and then writing
+                // a merged whole-node snapshot still leaves a stale-writer window: a peer can
+                // transition the Task after our read and before our upsert. The only safe replay
+                // write for an existing node is no node write at all.
+                db.getAdjacentNodes(messageId, 'both');
+            } else {
+                const
+                    isPostMarkerRepair = Array.isArray(onlyIssues) && onlyIssues.includes('missing-message-node'),
+                    properties         = {...messageProperties};
+
+                if (isPostMarkerRepair && properties.task && typeof properties.task === 'object' && !Array.isArray(properties.task)) {
+                    // The node existed after acceptance but was later lost. Intake WAL cannot tell
+                    // whether the Task had already been claimed or completed, so restoring its
+                    // send-time Submitted state would reopen executed work. Preserve the envelope
+                    // as observable evidence, but make it explicitly non-claimable and ownerless.
+                    properties.task = {
+                        ...properties.task,
+                        state   : 'Unknown',
+                        assignee: null
+                    };
+                    properties.taskAssignmentAuthority = TASK_ASSIGNMENT_AUTHORITY;
+                    delete properties.lastModifiedAt;
+                }
+
+                GraphService.upsertNode({
+                    id  : messageId,
+                    type: message.type || 'MESSAGE',
+                    name: message.name || messageProperties.subject || messageId,
+                    properties
+                });
+            }
         }
 
         needsPiece('missing-sent-by') && linkRequiredMailboxEdgeOrThrow(messageId, sentBy, 'SENT_BY', 1.0, edgeProperties, routingDiagnostics);
@@ -2131,7 +2273,9 @@ class MailboxService extends Base {
      * - Throws an Error for unauthorized access or invalid input parameters.
      * - Returns { success: false, reason: ... } for expected state-race failures (e.g., expectedCurrentState mismatch, or optimistic-concurrency race lost).
      * Note on Broadcast Assignees:
-     * - Tasks sent to `AGENT:*` are broadcast and can be claimed by ANY authenticated agent. The UPDATE-WHERE-state optimistic concurrency guard serializes the race to claim it.
+     * - Tasks sent to `AGENT:*` can be claimed only by a member of the immutable send-time
+     *   `DELIVERED_TO` cohort. The guarded SQLite write serializes the first-claim race and records
+     *   both owner plus server provenance atomically.
      *
      * @param {Object} args
      * @param {String} args.taskId The ID of the MESSAGE node containing the task
@@ -2156,32 +2300,79 @@ class MailboxService extends Base {
         db.getAdjacentNodes(taskId, 'both');
 
         const messageNode = db.nodes.get(taskId);
-        if (!messageNode || messageNode.label !== 'MESSAGE') {
+        if (!messageNode || getRecordField(messageNode, 'label') !== 'MESSAGE') {
             throw new Error(`Task not found: ${taskId}`);
         }
 
-        if (!messageNode.properties.task || !messageNode.properties.task.state) {
+        const storedState = getStorageTaskMutableState(taskId);
+        if (!storedState.task?.state) {
             throw new Error(`Message ${taskId} is not an A2A Task (missing task.state)`);
         }
 
-        const currentState = messageNode.properties.task.state;
+        const
+            currentState    = storedState.task.state,
+            sentByTargets   = [...new Set(getMailboxGraphEdgeTargets(taskId, 'SENT_BY'))],
+            sentToTargets   = [...new Set(getMailboxGraphEdgeTargets(taskId, 'SENT_TO'))],
+            isOriginator    = sentByTargets.some(target => sameMailboxIdentity(target, me)),
+            isBroadcast     = sentToTargets.includes('AGENT:*'),
+            directAssignees = [...new Set(sentToTargets
+                .filter(target => target !== 'AGENT:*')
+                .map(target => getCanonicalTaskAssigneeForTarget(target, db))
+                .filter(Boolean))],
+            directAssignee           = directAssignees[0] || null,
+            isBroadcastCohortMember = isBroadcast && (
+                hasMailboxGraphEdge(taskId, me, 'DELIVERED_TO') ||
+                hasMailboxGraphEdgeInStorage(taskId, me, 'DELIVERED_TO')
+            ),
+            hasTrustedAssignment     = storedState.taskAssignmentAuthority === TASK_ASSIGNMENT_AUTHORITY,
+            rawStoredAssignee        = storedState.task.assignee,
+            trustedBroadcastAssignee = hasTrustedAssignment
+                ? getCanonicalTaskAssigneeForTarget(rawStoredAssignee, db)
+                : null;
 
-        if (expectedCurrentState && currentState !== expectedCurrentState) {
-            return { success: false, rowsAffected: 0, reason: `State mismatch: expected ${expectedCurrentState}, got ${currentState}` };
+        if (sentByTargets.length !== 1) {
+            throw new Error(`Task ${taskId} has ambiguous originators: expected 1 SENT_BY edge, got ${sentByTargets.length}`);
         }
 
-        let isOriginator = false;
-        let isAssignee   = false;
-
-        for (const edge of db.edges.items) {
-            if (edge.source === taskId) {
-                if (edge.type === 'SENT_BY' && sameMailboxIdentity(edge.target, me)) isOriginator = true;
-                if (edge.type === 'SENT_TO' && (sameMailboxIdentity(edge.target, me) || edge.target === 'AGENT:*')) isAssignee = true;
-            }
+        if (sentToTargets.length !== 1) {
+            throw new Error(`Task ${taskId} has ambiguous recipients: expected 1 SENT_TO edge, got ${sentToTargets.length}`);
         }
+
+        if (directAssignees.length > 1) {
+            throw new Error(`Task ${taskId} has ambiguous direct assignees: ${directAssignees.join(', ')}`);
+        }
+
+        if (isBroadcast && hasTrustedAssignment && rawStoredAssignee != null && !trustedBroadcastAssignee) {
+            throw new Error(`Task ${taskId} has an invalid authoritative broadcast assignee`);
+        }
+
+        if (isBroadcast && currentState !== 'Submitted' && !trustedBroadcastAssignee) {
+            throw new Error(`Task ${taskId} has unknown broadcast owner: missing authoritative assignee`);
+        }
+
+        if (isBroadcast && currentState === 'Submitted' && trustedBroadcastAssignee) {
+            throw new Error(`Task ${taskId} has inconsistent Submitted state with an authoritative assignee`);
+        }
+
+        const isAssignee = isBroadcast
+            ? (currentState === 'Submitted' ? isBroadcastCohortMember : sameMailboxIdentity(trustedBroadcastAssignee, me))
+            : sameMailboxIdentity(directAssignee, me);
 
         if (!isOriginator && !isAssignee) {
             throw new Error(`Unauthorized: ${me} is neither originator nor assignee for task ${taskId}`);
+        }
+
+        // State mismatches are an expected optimistic-concurrency outcome, but the stored Task is
+        // caller-visible data. Return it only after routing and participant authorization succeed.
+        if (expectedCurrentState && currentState !== expectedCurrentState) {
+            applyStorageTaskMutableState(messageNode, storedState);
+
+            return {
+                success     : false,
+                rowsAffected: 0,
+                reason      : `State mismatch: expected ${expectedCurrentState}, got ${currentState}`,
+                task        : storedState.task
+            };
         }
 
         let authorized = false;
@@ -2201,40 +2392,58 @@ class MailboxService extends Base {
             throw new Error(`Unauthorized: ${me} as ${role} cannot transition \`${currentState} → ${newState}\``);
         }
 
-        const timestamp = new Date().toISOString();
+        const
+            timestamp    = new Date().toISOString(),
+            nextAssignee = isBroadcast
+                ? (currentState === 'Submitted' && newState === 'Working' ? me : trustedBroadcastAssignee)
+                : directAssignee;
 
-        // Optimistic concurrency claim-and-lock: Update SQLite with WHERE-state guard
+        // Optimistic concurrency claim-and-lock: state, owner, provenance, and transition clock
+        // land in one SQLite write. No later whole-node upsert may rewind a concurrent winner.
         const stmt = db.storage.db.prepare(`
             UPDATE Nodes
-            SET data = json_set(data, '$.properties.task.state', ?, '$.properties.lastModifiedAt', ?)
+            SET data = json_set(
+                data,
+                '$.properties.task.state', ?,
+                '$.properties.task.assignee', ?,
+                '$.properties.taskAssignmentAuthority', ?,
+                '$.properties.lastModifiedAt', ?
+            )
             WHERE id = ? AND json_extract(data, '$.properties.task.state') = ?
         `);
-        const info = stmt.run(newState, timestamp, taskId, currentState);
+        const info = stmt.run(
+            newState,
+            nextAssignee,
+            TASK_ASSIGNMENT_AUTHORITY,
+            timestamp,
+            taskId,
+            currentState
+        );
 
         if (info.changes === 0) {
-            // Lost the race or state changed asynchronously. Fetch fresh state directly from DB.
-            const row        = db.storage.db.prepare(`SELECT json_extract(data, '$.properties.task.state') as state FROM Nodes WHERE id = ?`).get(taskId);
-            const freshState = row && row.state ? row.state : currentState;
-            // Sync memory node to reality and trigger cache events
-            if (messageNode && messageNode.properties && messageNode.properties.task) {
-                messageNode.properties.task.state = freshState;
-                GraphService.upsertNode(messageNode);
-            }
-            return { success: false, rowsAffected: 0, reason: `Race lost: state changed to ${freshState}` };
+            const fresh = getStorageTaskMutableState(taskId);
+
+            applyStorageTaskMutableState(messageNode, fresh);
+
+            return {
+                success     : false,
+                rowsAffected: 0,
+                reason      : `Race lost: state changed to ${fresh.task?.state || currentState}`,
+                task        : fresh.task || storedState.task
+            };
         }
 
-        messageNode.properties.task.state = newState;
-        messageNode.properties.lastModifiedAt = timestamp;
+        db.acknowledgeLocalMutations?.();
 
-        // Push the merged object back to GraphService cache to trigger events
-        GraphService.upsertNode(messageNode);
+        const fresh = getStorageTaskMutableState(taskId);
+        applyStorageTaskMutableState(messageNode, fresh);
 
         WakeSubscriptionService.pump().catch(e => logger.error('[wake-pump]', e));
 
         return {
             success     : true,
             rowsAffected: info.changes,
-            task        : messageNode.properties.task
+            task        : fresh.task
         };
     }
 

--- a/ai/services/memory-core/heartbeatPulseEvaluator.mjs
+++ b/ai/services/memory-core/heartbeatPulseEvaluator.mjs
@@ -20,6 +20,8 @@
  * consolidated here, not the data-fetch or the output format.
  */
 
+import {TASK_ASSIGNMENT_AUTHORITY} from './taskAssignmentContract.mjs';
+
 /**
  * Canonical GraphLog `entity_type` for a heartbeat pulse.
  * @type {String}
@@ -239,13 +241,21 @@ export function match(subscription, entityData, trace) {
         return {type: 'permission_granted', payload: {scope: entity.type, grantedBy: entity.source}, logId: trace.log_id};
     }
 
-    // TASK_STATE_CHANGED — a MESSAGE node carrying a Task envelope, targeted at the owner
-    // (originator OR assignee — the daemon formerly matched assignee only).
+    // TASK_STATE_CHANGED — a MESSAGE node carrying a transitioned Task envelope, targeted at the
+    // originator or a Memory-Core-authoritative assignee. `lastModifiedAt` is mandatory so initial
+    // MESSAGE creation cannot masquerade as a transition and downstream coalescing can distinguish
+    // real same-state transitions. A later unrelated MESSAGE rewrite still re-exposes the last
+    // transition clock; durable cross-window transition-event identity is a separate follow-up.
     if (trigger === 'TASK_STATE_CHANGED' && trace?.entity_type === 'nodes' && entity.label === 'MESSAGE') {
-        const props = entity.properties || {};
-        const task  = props.task;
-        if (!task?.state) return null;
-        if (props.from !== agentIdentity && task.assignee !== agentIdentity) return null;
+        const
+            props              = entity.properties || {},
+            task               = props.task,
+            hasTrustedAssignee = props.taskAssignmentAuthority === TASK_ASSIGNMENT_AUTHORITY,
+            isOriginator       = props.from === agentIdentity,
+            isAssignee         = hasTrustedAssignee && task?.assignee === agentIdentity;
+
+        if (!task?.state || !props.lastModifiedAt) return null;
+        if (!isOriginator && !isAssignee) return null;
 
         return {
             type   : 'task_state_changed',
@@ -254,8 +264,8 @@ export function match(subscription, entityData, trace) {
                 previousState : null,                          // GraphLog carries only the new state at resync time
                 newState      : task.state,
                 originator    : props.from,
-                assignee      : task.assignee,
-                lastModifiedAt: props.updatedAt || props.sentAt
+                assignee      : hasTrustedAssignee ? task.assignee : null,
+                lastModifiedAt: props.lastModifiedAt
             },
             logId: trace.log_id
         };

--- a/ai/services/memory-core/taskAssignmentContract.mjs
+++ b/ai/services/memory-core/taskAssignmentContract.mjs
@@ -1,0 +1,15 @@
+/**
+ * @module ai/services/memory-core/taskAssignmentContract
+ * @summary Shared Memory Core contract for server-owned A2A Task assignment provenance.
+ */
+
+/**
+ * Provenance value proving that Memory Core, rather than caller-authored Task JSON,
+ * assigned `task.assignee`.
+ *
+ * Writers persist this marker with the assignment; wake consumers require the same marker before
+ * treating the nested assignee as authoritative.
+ *
+ * @type {String}
+ */
+export const TASK_ASSIGNMENT_AUTHORITY = 'memory-core.v1';

--- a/learn/agentos/A2A.md
+++ b/learn/agentos/A2A.md
@@ -184,6 +184,25 @@ optional task envelope for structured coordination. The write path stores that
 task payload as part of the `MESSAGE` node, while task-state transition rules
 remain owned by the transition APIs.
 
+Delivery and ownership are deliberately separate facts. `SENT_TO` answers who
+may receive the message; it does not let every member of that audience become
+the task owner. A task sent directly to a registered agent binds to that
+canonical `AgentIdentity`. A broadcast task starts unassigned. Its first
+eligible member of the send-time `DELIVERED_TO` cohort to perform the atomic
+`Submitted → Working` transition becomes the one durable assignee; later
+assignee-owned transitions remain restricted to that winner. The originator's
+existing `InputRequired → Working` response remains valid only while that
+canonical ownership fact is intact.
+
+Memory Core owns that assignment truth. Callers may describe the work, but they
+cannot grant themselves authority by supplying `task.assignee`: the server
+overwrites it and marks the stored message with the read-only
+`taskAssignmentAuthority` provenance property. Older broadcast tasks that have
+already moved beyond `Submitted` without this trusted ownership record fail
+closed instead of guessing a winner. Every successful transition also advances
+the message's `lastModifiedAt`, the canonical clock used by task-change
+consumers.
+
 That split keeps the conceptual model clean. A message can simply be a note. It
 can also be the visible surface for an agent task that moves through states such
 as submitted, working, input-required, completed, failed, or blocked. The point

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -32,7 +32,8 @@ function insertWakeSubscription(db, {
     subId = 'sub_' + crypto.randomUUID(),
     agentId,
     filters = {},
-    harnessTargetMetadata
+    harnessTargetMetadata,
+    trigger = 'SENT_TO_ME'
 }) {
     db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(agentId, JSON.stringify({
         id        : agentId,
@@ -48,7 +49,7 @@ function insertWakeSubscription(db, {
             filters,
             harnessTarget: 'bridge-daemon',
             status       : 'active',
-            trigger      : 'SENT_TO_ME',
+            trigger,
             harnessTargetMetadata
         }
     }));
@@ -1364,6 +1365,67 @@ test.describe('Wake Daemon', () => {
         expect(finalDigest).toContain('Test Dedup Event');
         expect(finalDigest).toContain('[WAKE][priority:normal]');
         expect(finalDigest).not.toContain('priority: normal');
+    });
+
+    test('keeps same-state Task transitions at distinct authoritative clocks in one coalescing window', async () => {
+        const agentId = '@test-agent-task-clock';
+        const taskId  = 'MSG:TASK-CLOCK-COALESCE';
+        const subId   = insertWakeSubscription(db, {
+            agentId,
+            trigger              : 'TASK_STATE_CHANGED',
+            harnessTargetMetadata: {
+                adapter       : 'test',
+                coalesceWindow: 10
+            }
+        });
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
+        });
+
+        let   stdoutLog       = '';
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Task transition digest did not arrive')), 20000);
+
+            daemonProcess.stdout.on('data', data => {
+                stdoutLog += data.toString();
+                if (stdoutLog.includes(`[Wake Daemon Test Adapter] Delivered ${subId}`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            });
+            daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+            daemonProcess.on('error', reject);
+        });
+
+        const writeTaskTransition = (state, lastModifiedAt) => {
+            db.prepare('INSERT OR REPLACE INTO Nodes (id, data) VALUES (?, ?)').run(taskId, JSON.stringify({
+                id        : taskId,
+                label     : 'MESSAGE',
+                properties: {
+                    from                   : '@task-originator',
+                    lastModifiedAt,
+                    taskAssignmentAuthority: 'memory-core.v1',
+                    task                   : {state, assignee: agentId}
+                }
+            }));
+            db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(taskId, 'nodes');
+        };
+
+        // Keep each mutation in a distinct daemon poll. The final state repeats the first state,
+        // but its later source clock makes it a distinct transition rather than a duplicate.
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        writeTaskTransition('Working',       '2026-07-12T20:01:02.003Z');
+        await new Promise(resolve => setTimeout(resolve, 3500));
+        writeTaskTransition('InputRequired', '2026-07-12T20:01:05.006Z');
+        await new Promise(resolve => setTimeout(resolve, 3500));
+        writeTaskTransition('Working',       '2026-07-12T20:01:08.009Z');
+
+        await deliveryPromise;
+
+        expect(stdoutLog).toContain('3 task transitions');
+        expect(stdoutLog).toContain(`latest: Working on task ${taskId}`);
     });
 
     test('#15054: one message wakes an identity once across overlapping routes and later GraphLog replay', async () => {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -315,9 +315,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                     }
                 },
                 routing: {
-                    sentBy            : 'AGENT:@alice',
-                    to                : 'bob',
-                    senderUserId      : 'alice',
+                    sentBy             : 'AGENT:@alice',
+                    to                 : 'bob',
+                    senderUserId       : 'alice',
                     broadcastRecipients: []
                 }
             };
@@ -347,7 +347,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         GraphService.upsertNode({id: '@alice', type: 'CLASS', name: 'Collision', properties: {}});
 
         const messageId = 'MESSAGE:wrong-type-direct-replay',
-            record    = {
+            record      = {
                 id                    : messageId,
                 timestamp             : Date.now(),
                 graphProjectionVersion: 1,
@@ -619,9 +619,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                     }
                 },
                 routing: {
-                    sentBy            : 'alice',
-                    to                : 'AGENT:*',
-                    senderUserId      : 'alice',
+                    sentBy             : 'alice',
+                    to                 : 'AGENT:*',
+                    senderUserId       : 'alice',
                     broadcastRecipients: ['bob', '@@bob', 'AGENT:@bob']
                 }
             };
@@ -653,7 +653,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         GraphService.upsertNode({id: '@bob', type: 'CLASS', name: 'Collision', properties: {}});
 
         const messageId = 'MESSAGE:wrong-type-broadcast-replay',
-            record    = {
+            record      = {
                 id                    : messageId,
                 timestamp             : Date.now(),
                 graphProjectionVersion: 1,
@@ -2730,9 +2730,9 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
     });
 
     // A2A Task envelope primitive.
-    // Phase 1 stores the optional `task` field as opaque JSON and roundtrips it through
-    // get_message + list_messages. State-machine semantics + RBAC enforcement layer on
-    // top in the task state-machine layer. Schema follows Option C hybrid: A2A spec subset + Neo
+    // The write path clones caller-authored Task JSON, overwrites the server-owned assignee, and
+    // roundtrips the resulting envelope through get_message + list_messages. State-machine
+    // semantics + RBAC enforcement layer on top. Schema follows Option C hybrid: A2A spec subset + Neo
     // extensions (`expiresAt`, `Blocked`) per the originating Discussion graduation. See
     // https://a2a-protocol.org/latest/specification/.
     test('#10334 task envelope: roundtrips through addMessage/getMessage/listMessages', async () => {
@@ -2769,15 +2769,19 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
             msgId = res.messageId;
         });
 
-        // Verify task stored on the MESSAGE node verbatim
-        const node = GraphService.db.nodes.get(msgId);
-        expect(node.properties.task).toEqual(taskPayload);
+        // Verify caller fields survive while assignment authority stays server-owned.
+        const
+            node       = GraphService.db.nodes.get(msgId),
+            storedTask = {...taskPayload, assignee: '@bob'};
+
+        expect(node.properties.task).toEqual(storedTask);
+        expect(node.properties.taskAssignmentAuthority).toBe('memory-core.v1');
 
         // Verify getMessage returns task field
         const bobRead = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             return await MailboxService.getMessage({ messageId: msgId });
         });
-        expect(bobRead.task).toEqual(taskPayload);
+        expect(bobRead.task).toEqual(storedTask);
         expect(bobRead.body).toBe('See task envelope');
 
         // Verify listMessages includes task field in summary
@@ -2786,7 +2790,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — open policy mode (
         });
         const found = bobList.messages.find(m => m.messageId === msgId);
         expect(found).toBeDefined();
-        expect(found.task).toEqual(taskPayload);
+        expect(found.task).toEqual(storedTask);
     });
 
     test('#13411 related PR state echo: getMessage/listMessages surface live state', async () => {
@@ -3013,6 +3017,33 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
         });
     });
 
+    function clearTaskCacheWithoutStorageMutation() {
+        const wasAutoSave = GraphService.db.autoSave;
+
+        GraphService.db.autoSave = false;
+        GraphService.db.nodes.clear();
+        GraphService.db.edges.clear();
+        GraphService.db.autoSave = wasAutoSave;
+        GraphService.db.vicinityLoadedNodes.clear();
+        GraphService.db.lastAccessMap.clear();
+    }
+
+    function readStoredTask(taskId) {
+        const row = GraphService.db.storage.db.prepare(`
+            SELECT
+                json_extract(data, '$.properties.task')                    AS task,
+                json_extract(data, '$.properties.taskAssignmentAuthority') AS taskAssignmentAuthority,
+                json_extract(data, '$.properties.lastModifiedAt')          AS lastModifiedAt
+            FROM Nodes
+            WHERE id = ?
+        `).get(taskId);
+
+        return {
+            ...row,
+            task: row?.task ? JSON.parse(row.task) : row?.task
+        };
+    }
+
     test('addMessage and transitionTask enforce state enum validation', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
             await expect(MailboxService.addMessage({
@@ -3028,6 +3059,384 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
             await expect(MailboxService.transitionTask({
                 taskId: res.messageId, newState: 'AlsoInvalid'
             })).rejects.toThrow(/Invalid new task state: AlsoInvalid/);
+        });
+    });
+
+    test('Task assignment is server-owned for direct and broadcast messages without mutating caller input', async () => {
+        const
+            directInput    = {state: 'Submitted', assignee: '@charlie', metadata: {keep: true}},
+            broadcastInput = {state: 'Submitted', assignee: '@charlie', metadata: {keep: true}};
+        let directId, broadcastId, roleId;
+
+        GraphService.upsertNode({id: 'role:task-triage', type: 'ROLE', name: 'Task triage', properties: {}});
+
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            directId = (await MailboxService.addMessage({
+                to: '@bob', subject: 'direct server-owned assignee', body: 'body', task: directInput
+            })).messageId;
+            broadcastId = (await MailboxService.addMessage({
+                to: 'AGENT:*', subject: 'broadcast unclaimed', body: 'body', task: broadcastInput
+            })).messageId;
+            roleId = (await MailboxService.addMessage({
+                to  : 'role:task-triage', subject: 'non-agent target', body: 'body',
+                task: {state: 'Submitted', assignee: '@bob'}
+            })).messageId;
+        });
+
+        expect(directInput).toEqual({state: 'Submitted', assignee: '@charlie', metadata: {keep: true}});
+        expect(broadcastInput).toEqual({state: 'Submitted', assignee: '@charlie', metadata: {keep: true}});
+
+        const
+            directNode    = GraphService.db.nodes.get(directId),
+            broadcastNode = GraphService.db.nodes.get(broadcastId);
+
+        expect(directNode.properties.task).toEqual({
+            state: 'Submitted', assignee: '@bob', metadata: {keep: true}
+        });
+        expect(directNode.properties.taskAssignmentAuthority).toBe('memory-core.v1');
+        expect(broadcastNode.properties.task).toEqual({
+            state: 'Submitted', assignee: null, metadata: {keep: true}
+        });
+        expect(broadcastNode.properties.taskAssignmentAuthority).toBe('memory-core.v1');
+        expect(GraphService.db.nodes.get(roleId).properties.task.assignee).toBeNull();
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await expect(MailboxService.transitionTask({taskId: roleId, newState: 'Working'}))
+                .rejects.toThrow(/Unauthorized|assignee/i);
+        });
+
+        const {readWalMessagesByIds} = await import('../../../../../../ai/services/memory-core/helpers/messageWalStore.mjs');
+        const records                = await readWalMessagesByIds({
+            dir: mailboxAiConfig.messageWal.dir,
+            ids: [directId, broadcastId]
+        });
+        const recordsById = new Map(records.map(record => [record.id, record]));
+
+        expect(recordsById.get(directId).message.properties.task.assignee).toBe('@bob');
+        expect(recordsById.get(directId).message.properties.taskAssignmentAuthority).toBe('memory-core.v1');
+        expect(recordsById.get(broadcastId).message.properties.task.assignee).toBeNull();
+        expect(recordsById.get(broadcastId).message.properties.taskAssignmentAuthority).toBe('memory-core.v1');
+
+        const directRead = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.getMessage({messageId: directId})
+        );
+        const broadcastList = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.listMessages({status: 'all'})
+        );
+
+        expect(directRead.task.assignee).toBe('@bob');
+        expect(broadcastList.messages.find(message => message.messageId === broadcastId).task.assignee).toBeNull();
+    });
+
+    test('broadcast claim is receipt-cohort-bound and persists one canonical winner', async () => {
+        let msgId;
+
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            msgId = (await MailboxService.addMessage({
+                to: 'AGENT:*', subject: 'cohort claim', body: 'body', task: {state: 'Submitted'}
+            })).messageId;
+        });
+
+        // Created after send: authenticated, but absent from the immutable delivery cohort.
+        GraphService.upsertNode({
+            id: '@late', type: 'AgentIdentity', name: 'Late', properties: {accountType: 'agent'}
+        });
+
+        await RequestContextService.run({agentIdentityNodeId: '@late'}, async () => {
+            await expect(MailboxService.transitionTask({taskId: msgId, newState: 'Working'}))
+                .rejects.toThrow(/Unauthorized|delivery cohort|assignee/i);
+        });
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            await expect(MailboxService.transitionTask({taskId: msgId, newState: 'Working'}))
+                .rejects.toThrow(/Unauthorized|delivery cohort|assignee/i);
+        });
+
+        const claim = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.transitionTask({taskId: msgId, newState: 'Working'})
+        );
+        const stored = readStoredTask(msgId);
+        const cached = GraphService.db.nodes.get(msgId);
+
+        expect(claim).toMatchObject({success: true, rowsAffected: 1, task: {state: 'Working', assignee: '@bob'}});
+        expect(stored.task).toMatchObject({state: 'Working', assignee: '@bob'});
+        expect(stored.taskAssignmentAuthority).toBe('memory-core.v1');
+        expect(stored.lastModifiedAt).toBeTruthy();
+        expect(cached.properties.task).toEqual(stored.task);
+        expect(cached.properties.taskAssignmentAuthority).toBe('memory-core.v1');
+        expect(cached.properties.lastModifiedAt).toBe(stored.lastModifiedAt);
+
+        clearTaskCacheWithoutStorageMutation();
+
+        const claimedRead = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.getMessage({messageId: msgId})
+        );
+        const claimedList = await RequestContextService.run({agentIdentityNodeId: '@charlie'}, () =>
+            MailboxService.listMessages({status: 'all'})
+        );
+
+        expect(claimedRead.task).toMatchObject({state: 'Working', assignee: '@bob'});
+        expect(claimedList.messages.find(message => message.messageId === msgId).task)
+            .toMatchObject({state: 'Working', assignee: '@bob'});
+
+        await RequestContextService.run({agentIdentityNodeId: '@charlie'}, async () => {
+            await expect(MailboxService.transitionTask({taskId: msgId, newState: 'Completed'}))
+                .rejects.toThrow(/Unauthorized|assignee/i);
+        });
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await expect(MailboxService.transitionTask({taskId: msgId, newState: 'Completed'}))
+                .resolves.toMatchObject({success: true, task: {state: 'Completed', assignee: '@bob'}});
+        });
+    });
+
+    test('race loser refreshes winner state, assignee, authority, and clock without a second write', async () => {
+        let msgId;
+
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            msgId = (await MailboxService.addMessage({
+                to: 'AGENT:*', subject: 'two claimant race', body: 'body', task: {state: 'Submitted'}
+            })).messageId;
+        });
+        const sqlite         = GraphService.db.storage.db;
+        const nodeWriteCount = () => sqlite.prepare(`
+            SELECT COUNT(*) AS count FROM GraphLog WHERE entity_id = ? AND entity_type = 'nodes'
+        `).get(msgId).count;
+        const writesBefore    = nodeWriteCount();
+        const originalPrepare = sqlite.prepare;
+        const winnerClock     = '2026-07-12T20:30:00.000Z';
+        let   injected        = false, loser;
+
+        // Interpose the peer winner after Charlie's authoritative read/RBAC pass but immediately
+        // before Charlie prepares the guarded UPDATE. This is the actual cross-process race window;
+        // mutating only the local cache cannot model it now that transitionTask reads SQLite first.
+        sqlite.prepare = function(sql) {
+            if (!injected && sql.includes("'$.properties.task.assignee'") && sql.includes('UPDATE Nodes')) {
+                injected = true;
+                originalPrepare.call(sqlite, `
+                    UPDATE Nodes
+                    SET data = json_set(
+                        data,
+                        '$.properties.task.state', 'Working',
+                        '$.properties.task.assignee', '@bob',
+                        '$.properties.taskAssignmentAuthority', 'memory-core.v1',
+                        '$.properties.lastModifiedAt', ?
+                    )
+                    WHERE id = ? AND json_extract(data, '$.properties.task.state') = 'Submitted'
+                `).run(winnerClock, msgId);
+            }
+
+            return originalPrepare.call(sqlite, sql);
+        };
+
+        try {
+            loser = await RequestContextService.run({agentIdentityNodeId: '@charlie'}, () =>
+                MailboxService.transitionTask({taskId: msgId, newState: 'Working'})
+            );
+        } finally {
+            sqlite.prepare = originalPrepare;
+        }
+
+        const winner = readStoredTask(msgId);
+
+        expect(loser).toMatchObject({
+            success     : false,
+            rowsAffected: 0,
+            task        : {state: 'Working', assignee: '@bob'}
+        });
+        expect(loser.reason).toMatch(/Race lost: state changed to Working/);
+        expect(readStoredTask(msgId)).toEqual(winner);
+        expect(GraphService.db.nodes.get(msgId).properties.task).toEqual(winner.task);
+        expect(GraphService.db.nodes.get(msgId).properties.taskAssignmentAuthority).toBe(winner.taskAssignmentAuthority);
+        expect(GraphService.db.nodes.get(msgId).properties.lastModifiedAt).toBe(winner.lastModifiedAt);
+        expect(winner.lastModifiedAt).toBe(winnerClock);
+        expect(nodeWriteCount()).toBe(writesBefore + 1);
+    });
+
+    test('legacy direct Task backfills its one canonical recipient before a later transition', async () => {
+        let msgId;
+
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            msgId = (await MailboxService.addMessage({
+                to: '@bob', subject: 'legacy direct', body: 'body', task: {state: 'Working'}
+            })).messageId;
+        });
+
+        GraphService.db.storage.db.prepare(`
+            UPDATE Nodes
+            SET data = json_remove(
+                json_remove(data, '$.properties.task.assignee'),
+                '$.properties.taskAssignmentAuthority'
+            )
+            WHERE id = ?
+        `).run(msgId);
+        clearTaskCacheWithoutStorageMutation();
+
+        const result = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.transitionTask({taskId: msgId, newState: 'Completed'})
+        );
+
+        expect(result).toMatchObject({success: true, task: {state: 'Completed', assignee: '@bob'}});
+        expect(readStoredTask(msgId)).toMatchObject({
+            task                   : {state: 'Completed', assignee: '@bob'},
+            taskAssignmentAuthority: 'memory-core.v1'
+        });
+    });
+
+    test('untrusted legacy broadcast post-claim states fail closed even with a spoofed assignee', async () => {
+        for (const state of ['Working', 'InputRequired']) {
+            let msgId;
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                msgId = (await MailboxService.addMessage({
+                    to: 'AGENT:*', subject: `legacy ${state}`, body: 'body', task: {state}
+                })).messageId;
+            });
+
+            GraphService.db.storage.db.prepare(`
+                UPDATE Nodes
+                SET data = json_set(
+                    json_remove(data, '$.properties.taskAssignmentAuthority'),
+                    '$.properties.task.assignee',
+                    '@charlie'
+                )
+                WHERE id = ?
+            `).run(msgId);
+            clearTaskCacheWithoutStorageMutation();
+
+            const actor = state === 'InputRequired' ? '@alice' : '@charlie';
+
+            await RequestContextService.run({agentIdentityNodeId: actor}, async () => {
+                await expect(MailboxService.transitionTask({
+                    taskId  : msgId,
+                    newState: state === 'InputRequired' ? 'Working' : 'Completed'
+                })).rejects.toThrow(/owner.*unknown|unknown.*owner/i);
+            });
+        }
+    });
+
+    test('full WAL replay preserves committed Task state, winner, authority, and transition clock', async () => {
+        let msgId;
+
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            msgId = (await MailboxService.addMessage({
+                to: 'AGENT:*', subject: 'replay claimed task', body: 'body', task: {state: 'Submitted'}
+            })).messageId;
+        });
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.transitionTask({taskId: msgId, newState: 'Working'})
+        );
+
+        const committed              = readStoredTask(msgId);
+        const {readWalMessagesByIds} = await import('../../../../../../ai/services/memory-core/helpers/messageWalStore.mjs');
+        const [record]               = await readWalMessagesByIds({
+            dir: mailboxAiConfig.messageWal.dir,
+            ids: [msgId]
+        });
+
+        expect(record.message.properties.task).toMatchObject({state: 'Submitted', assignee: null});
+        await MailboxService._projectMessageWalRecord(record, {pumpWake: false});
+
+        expect(readStoredTask(msgId)).toEqual(committed);
+    });
+
+    test('existing-node full replay is storage-neutral across an interposed peer transition', async () => {
+        let msgId;
+
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            msgId = (await MailboxService.addMessage({
+                to: 'AGENT:*', subject: 'replay race', body: 'body', task: {state: 'Submitted'}
+            })).messageId;
+        });
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.transitionTask({taskId: msgId, newState: 'Working'})
+        );
+
+        const {readWalMessagesByIds} = await import('../../../../../../ai/services/memory-core/helpers/messageWalStore.mjs');
+        const [record]               = await readWalMessagesByIds({
+            dir: mailboxAiConfig.messageWal.dir,
+            ids: [msgId]
+        });
+        const
+            sqlite          = GraphService.db.storage.db,
+            originalPrepare = sqlite.prepare,
+            peerClock       = '2026-07-12T21:15:00.000Z';
+        let injected = false;
+
+        sqlite.prepare = function(sql) {
+            const statement = originalPrepare.call(sqlite, sql);
+
+            if (sql.includes('SELECT count(*) AS count FROM Nodes WHERE id = ?')) {
+                return {
+                    get(...args) {
+                        const result = statement.get(...args);
+
+                        if (!injected && args[0] === msgId) {
+                            injected = true;
+                            originalPrepare.call(sqlite, `
+                                UPDATE Nodes
+                                SET data = json_set(
+                                    data,
+                                    '$.properties.task.state', 'Completed',
+                                    '$.properties.lastModifiedAt', ?
+                                )
+                                WHERE id = ?
+                            `).run(peerClock, msgId);
+                        }
+
+                        return result;
+                    }
+                };
+            }
+
+            return statement;
+        };
+
+        try {
+            await MailboxService._projectMessageWalRecord(record, {pumpWake: false});
+        } finally {
+            sqlite.prepare = originalPrepare;
+        }
+
+        expect(injected).toBe(true);
+        expect(readStoredTask(msgId)).toMatchObject({
+            task                   : {state: 'Completed', assignee: '@bob'},
+            taskAssignmentAuthority: 'memory-core.v1',
+            lastModifiedAt         : peerClock
+        });
+    });
+
+    test('post-marker Task node-loss repair restores non-claimable Unknown, never WAL Submitted', async () => {
+        let msgId;
+
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            msgId = (await MailboxService.addMessage({
+                to: 'AGENT:*', subject: 'lost claimed task', body: 'body', task: {state: 'Submitted'}
+            })).messageId;
+        });
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.transitionTask({taskId: msgId, newState: 'Working'})
+        );
+
+        GraphService.db.storage.db.prepare('DELETE FROM Nodes WHERE id = ?').run(msgId);
+        clearTaskCacheWithoutStorageMutation();
+
+        const repair = await MailboxService.repairMessageGraphIntegrity({ids: [msgId]});
+        const stored = readStoredTask(msgId);
+
+        expect(repair).toMatchObject({scanned: 1, repaired: 1, failed: 0});
+        expect(stored).toMatchObject({
+            task                   : {state: 'Unknown', assignee: null},
+            taskAssignmentAuthority: 'memory-core.v1'
+        });
+        expect(stored.lastModifiedAt).toBeNull();
+
+        const readBack = await RequestContextService.run({agentIdentityNodeId: '@bob'}, () =>
+            MailboxService.getMessage({messageId: msgId})
+        );
+        expect(readBack.task).toMatchObject({state: 'Unknown', assignee: null});
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await expect(MailboxService.transitionTask({taskId: msgId, newState: 'Working'}))
+                .rejects.toThrow(/owner.*unknown|unknown.*owner/i);
         });
     });
 
@@ -3047,6 +3456,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
             const res = await MailboxService.transitionTask({ taskId: msgId, newState: 'Working' });
             expect(res.success).toBe(true);
             expect(res.task.state).toBe('Working');
+            expect(res.task.assignee).toBe('@bob');
         });
 
         // Bob (Assignee) can transition Working -> InputRequired
@@ -3054,6 +3464,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
             const res = await MailboxService.transitionTask({ taskId: msgId, newState: 'InputRequired' });
             expect(res.success).toBe(true);
             expect(res.task.state).toBe('InputRequired');
+            expect(res.task.assignee).toBe('@bob');
         });
 
         // Alice (Originator) can transition InputRequired -> Working
@@ -3061,6 +3472,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
             const res = await MailboxService.transitionTask({ taskId: msgId, newState: 'Working' });
             expect(res.success).toBe(true);
             expect(res.task.state).toBe('Working');
+            expect(res.task.assignee).toBe('@bob');
         });
 
         // Bob (Assignee) can transition Working -> Completed
@@ -3068,6 +3480,7 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
             const res = await MailboxService.transitionTask({ taskId: msgId, newState: 'Completed' });
             expect(res.success).toBe(true);
             expect(res.task.state).toBe('Completed');
+            expect(res.task.assignee).toBe('@bob');
         });
 
         // Test Canceled by Originator
@@ -3130,7 +3543,66 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
         });
     });
 
-    test('Optimistic concurrency (claim-and-lock) handles race conditions', async () => {
+    test('expected-state mismatches disclose stored Task data only to authorized participants', async () => {
+        let directId, ownerlessBroadcastId;
+
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            directId = (await MailboxService.addMessage({
+                to  : '@bob', subject: 'mismatch privacy', body: 'body',
+                task: {state: 'Submitted', metadata: {privateMarker: 'participant-only'}}
+            })).messageId;
+            ownerlessBroadcastId = (await MailboxService.addMessage({
+                to  : 'AGENT:*', subject: 'legacy ownerless mismatch', body: 'body',
+                task: {state: 'Working', metadata: {privateMarker: 'owner-unknown'}}
+            })).messageId;
+        });
+
+        await RequestContextService.run({agentIdentityNodeId: '@charlie'}, async () => {
+            await expect(MailboxService.transitionTask({
+                taskId: directId, newState: 'Working', expectedCurrentState: 'Working'
+            })).rejects.toThrow(/Unauthorized: @charlie is neither originator nor assignee/);
+        });
+
+        GraphService.db.storage.db.prepare(`
+            UPDATE Nodes
+            SET data = json_remove(data, '$.properties.taskAssignmentAuthority')
+            WHERE id = ?
+        `).run(ownerlessBroadcastId);
+        clearTaskCacheWithoutStorageMutation();
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await expect(MailboxService.transitionTask({
+                taskId              : ownerlessBroadcastId,
+                newState            : 'Completed',
+                expectedCurrentState: 'Submitted'
+            })).rejects.toThrow(/owner.*unknown|unknown.*owner/i);
+        });
+    });
+
+    test('ambiguous Task routing fails closed before participant or state evaluation', async () => {
+        let hybridId, multiOriginId;
+
+        await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            hybridId = (await MailboxService.addMessage({
+                to: 'AGENT:*', subject: 'hybrid route', body: 'body', task: {state: 'Submitted'}
+            })).messageId;
+            multiOriginId = (await MailboxService.addMessage({
+                to: '@bob', subject: 'multiple origins', body: 'body', task: {state: 'Submitted'}
+            })).messageId;
+        });
+
+        GraphService.linkNodes(hybridId, '@bob', 'SENT_TO', 1);
+        GraphService.linkNodes(multiOriginId, '@charlie', 'SENT_BY', 1);
+
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await expect(MailboxService.transitionTask({taskId: hybridId, newState: 'Working'}))
+                .rejects.toThrow(/ambiguous recipients/);
+            await expect(MailboxService.transitionTask({taskId: multiOriginId, newState: 'Working'}))
+                .rejects.toThrow(/ambiguous originators/);
+        });
+    });
+
+    test('claim-and-lock keeps later claim attempts bound to the persisted winner', async () => {
         let msgId;
         // Broadcast task -> ANY agent could potentially be assignee
         await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
@@ -3148,16 +3620,11 @@ test.describe('Neo.ai.services.memory-core.MailboxService — A2A_TASK (#10338)'
         });
 
         await RequestContextService.run({ agentIdentityNodeId: '@charlie' }, async () => {
-            // Charlie thinks it's still 'Submitted' (by mutating local in-memory representation)
-            const node = GraphService.db.nodes.get(msgId);
-            node.properties.task.state = 'Submitted';
-
-            // But DB actually has 'Working'. Charlie's UPDATE will have changes === 0
-            const resCharlie = await MailboxService.transitionTask({ taskId: msgId, newState: 'Working' });
-
-            expect(resCharlie.success).toBe(false);
-            expect(resCharlie.reason).toMatch(/Race lost: state changed to Working/);
+            await expect(MailboxService.transitionTask({ taskId: msgId, newState: 'Working' }))
+                .rejects.toThrow(/Unauthorized: @charlie is neither originator nor assignee/);
         });
+
+        expect(readStoredTask(msgId).task).toMatchObject({state: 'Working', assignee: '@bob'});
     });
 });
 
@@ -3357,6 +3824,47 @@ test.describe('Neo.ai.services.memory-core.MailboxService — TTL Sweeper (#1033
         // by THIS sweep cycle, not seeded from addMessage (which has no lastModifiedAt).
         expect(node.properties.lastModifiedAt >= before).toBe(true);
         expect(node.properties.lastModifiedAt <= after).toBe(true);
+    });
+
+    test('sweep preserves a claimed broadcast winner and advances its transition clock', async () => {
+        const id = await seedTask({
+            to       : 'AGENT:*',
+            state    : 'Submitted',
+            expiresAt: '2020-01-01T00:00:00Z'
+        });
+
+        await RequestContextService.run({agentIdentityNodeId: '@ttl-bob'}, () =>
+            MailboxService.transitionTask({taskId: id, newState: 'Working'})
+        );
+
+        const oldClock = '2000-01-01T00:00:00.000Z';
+        GraphService.db.storage.db.prepare(`
+            UPDATE Nodes
+            SET data = json_set(data, '$.properties.lastModifiedAt', ?)
+            WHERE id = ?
+        `).run(oldClock, id);
+
+        const result = await MailboxService.sweepExpiredTasks();
+        const row    = GraphService.db.storage.db.prepare(`
+            SELECT
+                json_extract(data, '$.properties.task.state')               AS state,
+                json_extract(data, '$.properties.task.assignee')            AS assignee,
+                json_extract(data, '$.properties.taskAssignmentAuthority')   AS taskAssignmentAuthority,
+                json_extract(data, '$.properties.lastModifiedAt')            AS lastModifiedAt
+            FROM Nodes
+            WHERE id = ?
+        `).get(id);
+
+        expect(result.sweptCount).toBe(1);
+        expect(row).toMatchObject({
+            state                  : 'Expired',
+            assignee               : '@ttl-bob',
+            taskAssignmentAuthority: 'memory-core.v1'
+        });
+        expect(row.lastModifiedAt).not.toBe(oldClock);
+        expect(GraphService.db.nodes.get(id).properties.task.assignee).toBe('@ttl-bob');
+        expect(GraphService.db.nodes.get(id).properties.taskAssignmentAuthority).toBe('memory-core.v1');
+        expect(GraphService.db.nodes.get(id).properties.lastModifiedAt).toBe(row.lastModifiedAt);
     });
 
     test('sweep does not require an identity context (maintenance role bypasses RBAC)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -115,7 +115,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         updatedAt = createdAt
     } = {}) {
         const sqlite = GraphService.db.storage.db;
-        const node = {
+        const node   = {
             id        : subscriptionId,
             label     : 'WAKE_SUBSCRIPTION',
             properties: {
@@ -132,7 +132,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             }
         };
         const edgeId = `EDGE:${crypto.randomUUID()}`;
-        const edge = {
+        const edge   = {
             id        : edgeId,
             source    : owner,
             target    : subscriptionId,
@@ -452,7 +452,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             });
 
             // Verify durable state: older retired, newer still active.
-            const sqlite = GraphService.db.storage.db;
+            const sqlite   = GraphService.db.storage.db;
             const olderRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(older.subscriptionId);
             const newerRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(newer.subscriptionId);
 
@@ -493,7 +493,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
             // The single subscription should remain ACTIVE (not erroneously retired).
             const sqlite = GraphService.db.storage.db;
-            const row = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(only.subscriptionId);
+            const row    = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(only.subscriptionId);
             expect(JSON.parse(row.data).properties.status).toBe('active');
         });
 
@@ -591,8 +591,8 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
             // Both routes survive: distinct route-tuples must NOT be reconciled as duplicates.
             const sqlite = GraphService.db.storage.db;
-            const aRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(routeA.subscriptionId);
-            const bRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(routeB.subscriptionId);
+            const aRow   = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(routeA.subscriptionId);
+            const bRow   = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(routeB.subscriptionId);
 
             expect(JSON.parse(aRow.data).properties.status).toBe('active');
             expect(JSON.parse(bRow.data).properties.status).toBe('active');
@@ -635,7 +635,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             });
 
             // Already-retired stays retired; active stays active.
-            const sqlite = GraphService.db.storage.db;
+            const sqlite     = GraphService.db.storage.db;
             const retiredRow = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(retired.subscriptionId);
             const activeRow  = sqlite.prepare('SELECT data FROM Nodes WHERE id = ?').get(active.subscriptionId);
 
@@ -1175,7 +1175,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
     });
 
     test('emitHeartbeatPulse writes only a heartbeat GraphLog row and replays through resync', async () => {
-        const sqlite = GraphService.db.storage.db;
+        const sqlite           = GraphService.db.storage.db;
         const {subscriptionId} = insertDurableSubscription({
             trigger              : 'HEARTBEAT_PULSE',
             harnessTarget        : 'bridge-daemon',
@@ -1221,7 +1221,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
         const sqlite = GraphService.db.storage.db;
         const before = sqlite.prepare('SELECT MAX(log_id) as maxId FROM GraphLog').get().maxId || 0;
 
-        const emitted = await WakeSubscriptionService.emitHeartbeatPulse({targetIdentity: '@alice'});
+        const emitted   = await WakeSubscriptionService.emitHeartbeatPulse({targetIdentity: '@alice'});
         const pulseRows = sqlite.prepare(`
             SELECT COUNT(*) as count
             FROM GraphLog
@@ -1239,7 +1239,7 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
 
     test('emitHeartbeatPulse fires when only a SENT_TO_ME bridge-daemon subscription exists (Epic #11993 gate fix)', async () => {
         // Production agents establish bridge-daemon routing through SENT_TO_ME subscriptions.
-        const sqlite = GraphService.db.storage.db;
+        const sqlite           = GraphService.db.storage.db;
         const {subscriptionId} = insertDurableSubscription({
             trigger              : 'SENT_TO_ME',
             harnessTarget        : 'bridge-daemon',
@@ -1350,6 +1350,47 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(emittedEvents[0].params.payload.messageId).toBe('MSG:2');
             expect(emittedEvents[0].params.payload.from).toBe('@bob');
             expect(emittedEvents[0].params.payload.subject).toBe('hello');
+        });
+
+        test('preserves the trusted Task assignee and exact transition clock through the pump route', async () => {
+            CoalescingEngineService.addMcpServer(mockMcpServer);
+
+            await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+                await WakeSubscriptionService.subscribe({
+                    trigger      : 'TASK_STATE_CHANGED',
+                    harnessTarget: 'mcp-notifications'
+                });
+            });
+
+            GraphService.upsertNode({
+                id        : 'MSG:TASK-AUTHORITATIVE-CLOCK',
+                type      : 'MESSAGE',
+                properties: {
+                    from                   : '@bob',
+                    lastModifiedAt         : '2026-07-12T20:01:02.003Z',
+                    taskAssignmentAuthority: 'memory-core.v1',
+                    task                   : {
+                        state   : 'InputRequired',
+                        assignee: '@alice'
+                    }
+                }
+            });
+
+            await WakeSubscriptionService.pump();
+            await CoalescingEngineService.flushAll();
+
+            expect(emittedEvents).toHaveLength(1);
+            expect(emittedEvents[0].params).toMatchObject({
+                eventType    : 'wake/task_state_changed',
+                agentIdentity: '@alice',
+                payload      : {
+                    taskId        : 'MSG:TASK-AUTHORITATIVE-CLOCK',
+                    newState      : 'InputRequired',
+                    originator    : '@bob',
+                    assignee      : '@alice',
+                    lastModifiedAt: '2026-07-12T20:01:02.003Z'
+                }
+            });
         });
 
         test('does not emit SENT_TO_ME wake for wakeSuppressed mailbox-only messages', async () => {

--- a/test/playwright/unit/ai/services/memory-core/heartbeatPulseEvaluator.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/heartbeatPulseEvaluator.spec.mjs
@@ -209,7 +209,17 @@ test.describe('Neo.ai.services.memory-core.heartbeatPulseEvaluator — match() (
     });
 
     // --- TASK_STATE_CHANGED (the broadening fix: daemon matched assignee only) ---
-    const taskNode = (task, extra = {}) => ({id: 'MESSAGE:t1', label: 'MESSAGE', properties: {from: '@neo-gpt', task, ...extra}});
+    const taskNode = (task, extra = {}) => ({
+        id        : 'MESSAGE:t1',
+        label     : 'MESSAGE',
+        properties: {
+            from                   : '@neo-gpt',
+            task,
+            taskAssignmentAuthority: 'memory-core.v1',
+            lastModifiedAt         : '2026-07-12T20:00:00.000Z',
+            ...extra
+        }
+    });
 
     test('task_state_changed: fires when the owner is the assignee', () => {
         const node = taskNode({state: 'in_progress', assignee: OWNER});
@@ -225,6 +235,40 @@ test.describe('Neo.ai.services.memory-core.heartbeatPulseEvaluator — match() (
 
     test('task_state_changed: does not fire when the owner is neither originator nor assignee', () => {
         const node = taskNode({state: 'in_progress', assignee: '@neo-gpt'}, {from: '@neo-gpt'});
+        expect(match(sub({trigger: 'TASK_STATE_CHANGED'}), {entity: node}, nodeTrace)).toBe(null);
+    });
+
+    test('task_state_changed: does not trust an assignee without the server-owned authority stamp', () => {
+        const missing = taskNode(
+            {state: 'Working', assignee: OWNER},
+            {taskAssignmentAuthority: undefined}
+        );
+        const spoofed = taskNode(
+            {state: 'Working', assignee: OWNER},
+            {taskAssignmentAuthority: 'caller-spoof.v1'}
+        );
+
+        expect(match(sub({trigger: 'TASK_STATE_CHANGED'}), {entity: missing}, nodeTrace)).toBe(null);
+        expect(match(sub({trigger: 'TASK_STATE_CHANGED'}), {entity: spoofed}, nodeTrace)).toBe(null);
+    });
+
+    test('task_state_changed: reports the exact transition clock, never updatedAt or sentAt', () => {
+        const node = taskNode({state: 'Working', assignee: OWNER}, {
+            lastModifiedAt: '2026-07-12T20:01:02.003Z',
+            updatedAt     : '1999-01-01T00:00:00.000Z',
+            sentAt        : '1998-01-01T00:00:00.000Z'
+        });
+
+        expect(match(sub({trigger: 'TASK_STATE_CHANGED'}), {entity: node}, nodeTrace))
+            .toMatchObject({payload: {lastModifiedAt: '2026-07-12T20:01:02.003Z'}});
+    });
+
+    test('task_state_changed: missing transition clock is not a state-change event', () => {
+        const node = taskNode(
+            {state: 'Submitted', assignee: OWNER},
+            {lastModifiedAt: undefined, sentAt: '2026-07-12T19:00:00.000Z'}
+        );
+
         expect(match(sub({trigger: 'TASK_STATE_CHANGED'}), {entity: node}, nodeTrace)).toBe(null);
     });
 


### PR DESCRIPTION
Resolves #15106

Memory Core now owns A2A Task assignment as a durable source fact. Direct Tasks bind to their validated AgentIdentity recipient; broadcasts remain unassigned until one immutable send-time recipient atomically wins `Submitted → Working`. Later transitions and wake targeting use that persisted winner instead of treating the entire broadcast audience as an assignee.

The same guarded SQLite update now persists Task state, canonical assignee, assignment provenance, and the exact transition clock. Race losers refresh from storage, existing-node WAL replay performs no MESSAGE-node write, and post-marker recovery restores an unprovable lost Task as non-claimable `Unknown` rather than resurrecting send-time `Submitted` work.

Evidence: L3 (real wake-daemon child process plus SQLite-backed Memory Core transition, replay, cold-cache, and wake-route probes) → L3 required by #15106. Residual: generic later MESSAGE rewrites can still generate a new GraphLog row for the same Task transition outside one daemon coalescing window; durable typed transition-event identity is intentionally a follow-up, not assignment-authority scope.

## Deltas from ticket

- The accepted MESSAGE WAL is immutable intake truth, so existing-node replay is storage-neutral. A missing post-marker Task node restores as `Unknown + assignee:null` because the WAL cannot prove whether the original Task was unclaimed, active, or terminal.
- Broadcast claim eligibility is the immutable `DELIVERED_TO` send-time cohort, not every future authenticated identity.
- Independent review found that the provenance literal initially lived on the wake-consumer side. A structural fast-path added `taskAssignmentContract.mjs` as the neutral Memory Core contract seam shared by the writer and consumer; no new service or authority layer was introduced.
- Independent security review also added fail-closed routing cardinality and moved optimistic-mismatch payloads behind participant authorization, preventing a wrong-state probe from disclosing Task metadata.

## Contract outcome

- `addMessage()` clones the caller Task, overwrites `task.assignee`, and stamps top-level `taskAssignmentAuthority: 'memory-core.v1'`.
- `transitionTask()` reads storage truth, validates exactly one `SENT_BY` and one `SENT_TO`, binds the broadcast winner atomically, and exposes mismatch state only to an authorized participant.
- Ownerless legacy broadcast Tasks beyond `Submitted` fail closed; a legacy direct Task can derive only its one canonical direct recipient.
- `TASK_STATE_CHANGED` trusts only the server provenance marker and carries `lastModifiedAt` without a `sentAt` fallback.
- The real wake daemon preserves originator, assignee, and clock, and coalesces by `(taskId, state, lastModifiedAt)`.

## Test Evidence

- Canonical independent focused run: **265/265 passed** at the final diff.
- `MailboxService.spec.mjs`: **107/107 passed**, including unrelated-caller mismatch privacy, ownerless legacy, hybrid recipient, multiple-origin, interposed race, replay, recovery, cold-cache, and TTL ownership cases.
- `heartbeatPulseEvaluator.spec.mjs`: **40/40 passed**.
- New real-daemon + WakeSubscription regressions: **2/2 passed**.
- An attempted broad daemon/subscription run was intentionally stopped after 13 unrelated passes because the daemon suite is long-running; the two changed routing cases were then run directly and passed.
- `node --check` passed for all changed production modules; OpenAPI parsed and the two changed operation descriptions are 150 and 163 characters.
- `npm run agent-preflight -- --no-fix <8 changed mjs files>` passed; `git diff --check` clean.
- `npm run ai:lint-guides`: 0 hard errors; only pre-existing repository warnings.
- Agent OS structure maps confirm the shared contract stays in the existing `ai/services/memory-core` boundary and the daemon delta stays in `ai/daemons/wake`.

## Decision Record impact

Aligned with ADR 0035. This makes the Task-owner and transition-clock source facts reliable before lifecycle normalization, hook projection, Bird Views, or Fleet consumers read them. It does not add a fifth authority or move lifecycle composition into Memory Core.

## Post-Merge Validation

- [ ] Restart the deployed Memory Core/wake daemon and confirm the served OpenAPI digest includes the read-only Task assignment contract.
- [ ] Send one broadcast Task, claim it from one peer, and verify a second peer cannot transition it while originator and winner receive the correct clocked wakes.
- [ ] Track durable transition-event identity separately so unrelated later MESSAGE rewrites cannot replay an old transition outside a coalescing window.

---
Authored by Emmy (OpenAI GPT-5.6 Sol, Codex). Session f95e01ff-ba36-409a-98af-573263fab247.
