### PR TITLE
fix(ai): replenish Golden Path candidates after liveness filters

### DIFF
--- a/ai/graph/Database.mjs
+++ b/ai/graph/Database.mjs
@@ -1,77 +1,10 @@
-import Base            from '../../src/core/Base.mjs';
-import ClassSystemUtil from '../../src/util/ClassSystem.mjs';
-import Store           from './Store.mjs';
-import EdgeModel       from './EdgeModel.mjs';
-import NodeModel       from './NodeModel.mjs';
-import StorageBase     from './storage/Base.mjs';
-
-/**
- * @summary Set-compatible lazy-vicinity marker keyed by both node id and the active
- * requester scope. SQLite vicinity reads are RLS-filtered, so a node loaded for tenant A
- * cannot satisfy tenant B's cache lookup. Node-wide `delete()` preserves the existing
- * cross-worker invalidation contract, while `clear()` remains the test/reset boundary.
- */
-class RequestScopedVicinitySet {
-    scopesByNode = new Map();
-
-    /**
-     * @param {Function} scopeResolver Returns the current requester-scoped RLS cache key.
-     */
-    constructor(scopeResolver) {
-        this.scopeResolver = scopeResolver
-    }
-
-    /**
-     * Marks a node vicinity loaded for the active requester scope.
-     * @param {String} nodeId
-     * @returns {RequestScopedVicinitySet}
-     */
-    add(nodeId) {
-        let scopes = this.scopesByNode.get(nodeId);
-
-        if (!scopes) {
-            scopes = new Set();
-            this.scopesByNode.set(nodeId, scopes)
-        }
-
-        scopes.add(this.scopeResolver());
-
-        return this
-    }
-
-    /**
-     * Clears all requester-scoped vicinity markers.
-     */
-    clear() {
-        this.scopesByNode.clear()
-    }
-
-    /**
-     * Invalidates every requester scope for one node.
-     * @param {String} nodeId
-     * @returns {Boolean}
-     */
-    delete(nodeId) {
-        return this.scopesByNode.delete(nodeId)
-    }
-
-    /**
-     * Tests whether the active requester has loaded this node's RLS-filtered vicinity.
-     * @param {String} nodeId
-     * @returns {Boolean}
-     */
-    has(nodeId) {
-        return this.scopesByNode.get(nodeId)?.has(this.scopeResolver()) ?? false
-    }
-
-    /**
-     * Number of node ids with at least one requester-scoped marker.
-     * @returns {Number}
-     */
-    get size() {
-        return this.scopesByNode.size
-    }
-}
+import Base                     from '../../src/core/Base.mjs';
+import ClassSystemUtil          from '../../src/util/ClassSystem.mjs';
+import Store                    from './Store.mjs';
+import EdgeModel                from './EdgeModel.mjs';
+import NodeModel                from './NodeModel.mjs';
+import RequestScopedVicinitySet from './RequestScopedVicinitySet.mjs';
+import StorageBase              from './storage/Base.mjs';
 
 /**
  * The Database class serves as the core coordinator for the Native Edge Graph Database engine.
@@ -132,11 +65,16 @@ class Database extends Base {
          * @member {Object|Neo.ai.graph.storage.Base|null} storage_=null
          * @reactive
          */
-        storage_: null
+        storage_: null,
+        /**
+         * Requester-scoped lazy-vicinity marker set.
+         * @member {Neo.ai.graph.RequestScopedVicinitySet|null} vicinityLoadedNodes_=null
+         * @reactive
+         */
+        vicinityLoadedNodes_: null
     }
 
-    vicinityLoadedNodes = new RequestScopedVicinitySet(() => this.getVicinityCacheScope());
-    lastAccessMap       = new Map();
+    lastAccessMap = new Map();
 
     /**
      * @summary Resolves the same canonical requester key used by SQLite's RLS-filtered
@@ -154,6 +92,15 @@ class Database extends Base {
         return rawUserId == null
             ? null
             : (storage.normalizeUserId ? storage.normalizeUserId(rawUserId) : rawUserId)
+    }
+
+    /**
+     * Destroys the requester-scoped marker before the Database releases its own state.
+     */
+    destroy() {
+        this.vicinityLoadedNodes?.destroy();
+
+        super.destroy()
     }
 
     /**
@@ -350,6 +297,21 @@ class Database extends Base {
         store?.on('mutate', this.onNodesMutate, this);
 
         return store;
+    }
+
+    /**
+     * Creates the requester-scoped vicinity marker through the Neo class lifecycle.
+     * @param {Object|Neo.ai.graph.RequestScopedVicinitySet|null} value
+     * @param {Neo.ai.graph.RequestScopedVicinitySet|null} oldValue
+     * @returns {Neo.ai.graph.RequestScopedVicinitySet}
+     * @protected
+     */
+    beforeSetVicinityLoadedNodes(value, oldValue) {
+        oldValue?.destroy();
+
+        return ClassSystemUtil.beforeSetInstance(value, RequestScopedVicinitySet, {
+            scopeResolver: () => this.getVicinityCacheScope()
+        })
     }
 
     /**

--- a/ai/graph/Database.mjs
+++ b/ai/graph/Database.mjs
@@ -6,6 +6,74 @@ import NodeModel       from './NodeModel.mjs';
 import StorageBase     from './storage/Base.mjs';
 
 /**
+ * @summary Set-compatible lazy-vicinity marker keyed by both node id and the active
+ * requester scope. SQLite vicinity reads are RLS-filtered, so a node loaded for tenant A
+ * cannot satisfy tenant B's cache lookup. Node-wide `delete()` preserves the existing
+ * cross-worker invalidation contract, while `clear()` remains the test/reset boundary.
+ */
+class RequestScopedVicinitySet {
+    scopesByNode = new Map();
+
+    /**
+     * @param {Function} scopeResolver Returns the current requester-scoped RLS cache key.
+     */
+    constructor(scopeResolver) {
+        this.scopeResolver = scopeResolver
+    }
+
+    /**
+     * Marks a node vicinity loaded for the active requester scope.
+     * @param {String} nodeId
+     * @returns {RequestScopedVicinitySet}
+     */
+    add(nodeId) {
+        let scopes = this.scopesByNode.get(nodeId);
+
+        if (!scopes) {
+            scopes = new Set();
+            this.scopesByNode.set(nodeId, scopes)
+        }
+
+        scopes.add(this.scopeResolver());
+
+        return this
+    }
+
+    /**
+     * Clears all requester-scoped vicinity markers.
+     */
+    clear() {
+        this.scopesByNode.clear()
+    }
+
+    /**
+     * Invalidates every requester scope for one node.
+     * @param {String} nodeId
+     * @returns {Boolean}
+     */
+    delete(nodeId) {
+        return this.scopesByNode.delete(nodeId)
+    }
+
+    /**
+     * Tests whether the active requester has loaded this node's RLS-filtered vicinity.
+     * @param {String} nodeId
+     * @returns {Boolean}
+     */
+    has(nodeId) {
+        return this.scopesByNode.get(nodeId)?.has(this.scopeResolver()) ?? false
+    }
+
+    /**
+     * Number of node ids with at least one requester-scoped marker.
+     * @returns {Number}
+     */
+    get size() {
+        return this.scopesByNode.size
+    }
+}
+
+/**
  * The Database class serves as the core coordinator for the Native Edge Graph Database engine.
  * Operating in headless MCP server environments (Sandman, memory-core), it orchestrates local
  * Native Node embeddings tracking alongside Semantic vectors natively inside ChromaDB (GraphRAG).
@@ -67,8 +135,26 @@ class Database extends Base {
         storage_: null
     }
 
-    vicinityLoadedNodes = new Set();
+    vicinityLoadedNodes = new RequestScopedVicinitySet(() => this.getVicinityCacheScope());
     lastAccessMap       = new Map();
+
+    /**
+     * @summary Resolves the same canonical requester key used by SQLite's RLS-filtered
+     * `loadNodeVicinitySync()` query. Null is a real scope: unbound/system callers share the
+     * same public/team/shared projection, while each authenticated tenant gets its own marker.
+     * @returns {String|null} Canonical requester scope for lazy-vicinity caching.
+     * @protected
+     */
+    getVicinityCacheScope() {
+        const
+            storage   = this.storage,
+            rcs       = storage?.RequestContextService,
+            rawUserId = rcs ? (rcs.getUserId?.() ?? rcs.getAgentIdentityNodeId?.()) : null;
+
+        return rawUserId == null
+            ? null
+            : (storage.normalizeUserId ? storage.normalizeUserId(rawUserId) : rawUserId)
+    }
 
     /**
      * Executes strict cache synchronization polling Native SQLite triggers for identical cross-worker coherence cleanly natively.
@@ -113,7 +199,8 @@ class Database extends Base {
             this.isExecutingTransaction = false;
             this.autoSave               = false;
 
-            let edgeIdsToRemove = [];
+            let edgeIdsToRemove = [],
+                indexedEdgeRefs = new Set();
             delta.invalidEdges.forEach(edgeRef => {
                 let edgeId = typeof edgeRef === 'string' ? edgeRef : edgeRef.id;
                 let edge   = this.edges.get(edgeId);
@@ -125,9 +212,24 @@ class Database extends Base {
                 if (target) this.vicinityLoadedNodes.delete(target);
 
                 edgeIdsToRemove.push(edgeId);
+                if (edge) indexedEdgeRefs.add(edge);
+
+                // The Store map owns only one object per id, but a prior refresh can leave an older
+                // same-id object reachable exclusively from an index Set. Collect every indexed copy.
+                for (const [property, value] of [['source', source], ['target', target]]) {
+                    if (!value) continue;
+
+                    this.edges.getByIndex(property, value)
+                        .filter(indexedEdge => indexedEdge.id === edgeId)
+                        .forEach(indexedEdge => indexedEdgeRefs.add(indexedEdge))
+                }
             });
 
             this.edges.remove(edgeIdsToRemove);
+            // Drop the exact references observed before removal as well. A refreshed Store map can
+            // point at a newer object while a secondary index still retains the prior object; without
+            // this cleanup the subsequent lazy reload double-counts the same persisted edge.
+            this.edges.updateIndexMaps?.(null, [...indexedEdgeRefs]);
 
             this.autoSave               = wasAutoSave;
             this.isExecutingTransaction = wasTransacting;

--- a/ai/graph/RequestScopedVicinitySet.mjs
+++ b/ai/graph/RequestScopedVicinitySet.mjs
@@ -1,0 +1,80 @@
+import Base from '../../src/core/Base.mjs';
+
+/**
+ * Set-compatible lazy-vicinity marker keyed by both node id and the active requester
+ * scope. SQLite vicinity reads are RLS-filtered, so a node loaded for tenant A cannot
+ * satisfy tenant B's cache lookup. Node-wide `delete()` preserves the existing
+ * cross-worker invalidation contract, while `clear()` remains the test/reset boundary.
+ *
+ * @class Neo.ai.graph.RequestScopedVicinitySet
+ * @extends Neo.core.Base
+ */
+class RequestScopedVicinitySet extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.graph.RequestScopedVicinitySet'
+         * @protected
+         */
+        className: 'Neo.ai.graph.RequestScopedVicinitySet',
+        /**
+         * Returns the current requester-scoped RLS cache key.
+         * @member {Function|null} scopeResolver=null
+         */
+        scopeResolver: null
+    }
+
+    scopesByNode = new Map();
+
+    /**
+     * Marks a node vicinity loaded for the active requester scope.
+     * @param {String} nodeId
+     * @returns {Neo.ai.graph.RequestScopedVicinitySet}
+     */
+    add(nodeId) {
+        let scopes = this.scopesByNode.get(nodeId);
+
+        if (!scopes) {
+            scopes = new Set();
+            this.scopesByNode.set(nodeId, scopes)
+        }
+
+        scopes.add(this.scopeResolver());
+
+        return this
+    }
+
+    /**
+     * Clears all requester-scoped vicinity markers.
+     */
+    clear() {
+        this.scopesByNode.clear()
+    }
+
+    /**
+     * Invalidates every requester scope for one node.
+     * @param {String} nodeId
+     * @returns {Boolean}
+     */
+    delete(nodeId) {
+        return this.scopesByNode.delete(nodeId)
+    }
+
+    /**
+     * Tests whether the active requester has loaded this node's RLS-filtered vicinity.
+     * @param {String} nodeId
+     * @returns {Boolean}
+     */
+    has(nodeId) {
+        return this.scopesByNode.get(nodeId)?.has(this.scopeResolver()) ?? false
+    }
+
+    /**
+     * Number of node ids with at least one requester-scoped marker.
+     * @returns {Number}
+     */
+    get size() {
+        return this.scopesByNode.size
+    }
+}
+
+export default Neo.setupClass(RequestScopedVicinitySet);

--- a/ai/scripts/diagnostics/audit-discussion-lifecycle.mjs
+++ b/ai/scripts/diagnostics/audit-discussion-lifecycle.mjs
@@ -1,8 +1,9 @@
-import fs                 from 'node:fs/promises';
-import path               from 'node:path';
-import process            from 'node:process';
-import {fileURLToPath}    from 'node:url';
-import {Command, InvalidArgumentError} from 'commander';
+import fs                                     from 'node:fs/promises';
+import path                                   from 'node:path';
+import process                                from 'node:process';
+import {fileURLToPath}                        from 'node:url';
+import {Command, InvalidArgumentError}        from 'commander';
+import {classifyDiscussionRoutingDisposition} from '../../services/github-workflow/shared/discussionRoutingDisposition.mjs';
 
 /**
  * Pre-Flight (structural fast-path): `ai/scripts/diagnostics/audit-discussion-lifecycle.mjs`
@@ -18,23 +19,6 @@ import {Command, InvalidArgumentError} from 'commander';
 
 const DEFAULT_DISCUSSIONS_DIR = path.resolve(process.cwd(), 'resources/content/discussions');
 const DEFAULT_STALE_DAYS      = 90;
-
-const GRADUATED_RE          = /\[GRADUATED_TO_TICKET(?::[^\]]*)?\]/i;
-const TICKETED_GRADUATED_RE = /\[GRADUATED_TO_TICKET:\s*#\d+\]/i;
-const RESOLVED_RE           = /\[RESOLVED_TO_AC\]/i;
-
-const OPEN_SCOPE_RES = [
-    /\[OQ_RESOLUTION_PENDING\]/i,
-    /\[CONVERGING\]/i,
-    /\[OPEN(?:_QUESTION)?\]/i,
-    /\bremaining\b/i,
-    /\bremains\b/i,
-    /\bstill pending\b/i,
-    /\bnot yet\b/i,
-    /\bnext cycle\b/i,
-    /\bnot proposed for graduation\b/i,
-    /\bseeding only\b/i
-];
 
 const CANDIDATE_ORDER = {
     'graduated-open'      : 0,
@@ -88,7 +72,7 @@ function parseFrontmatter(raw) {
     const lines = block.split(/\r?\n/);
 
     for (let i = 0; i < lines.length; i++) {
-        const line = lines[i];
+        const line  = lines[i];
         const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
 
         if (!match) {
@@ -160,66 +144,6 @@ function getAgeDays(updatedAt, now) {
 }
 
 /**
- * @param {String} body
- * @returns {Boolean}
- */
-function hasOpenScope(body) {
-    return OPEN_SCOPE_RES.some(re => re.test(body))
-}
-
-/**
- * @param {String} body
- * @returns {Boolean}
- */
-function hasGraduatedMarker(body) {
-    return body.split(/\r?\n/).some(line => {
-        if (!GRADUATED_RE.test(line)) {
-            return false
-        }
-
-        if (TICKETED_GRADUATED_RE.test(line)) {
-            return true
-        }
-
-        if (/(graduates when|graduation criteria|before any|candidate)/i.test(line)) {
-            return false
-        }
-
-        const normalized = line
-            .replace(/^[>\s#*-]+/, '')
-            .replace(/[*_`]/g, '')
-            .trim();
-
-        return /^(\[GRADUATED_TO_TICKET\]|Status:\s*\[GRADUATED_TO_TICKET\])/.test(normalized) ||
-            /met all graduation criteria and is now\s+\[GRADUATED_TO_TICKET\]/i.test(normalized)
-    })
-}
-
-/**
- * @param {String} body
- * @returns {Boolean}
- */
-function hasResolvedDispositionMarker(body) {
-    return body.split(/\r?\n/).some(line => {
-        if (!RESOLVED_RE.test(line)) {
-            return false
-        }
-
-        if (/(before any|graduates when|graduation criteria|candidate|ready-to-graduate)/i.test(line)) {
-            return false
-        }
-
-        const normalized = line
-            .replace(/^[>\s#*-]+/, '')
-            .replace(/[*`]/g, '')
-            .trim();
-
-        return /^\[RESOLVED_TO_AC\]/i.test(normalized) ||
-            /^(OQ\d+|Open Question\b)[^[]*\[RESOLVED_TO_AC\]/i.test(normalized)
-    })
-}
-
-/**
  * @param {Object} discussion
  * @param {Object} options
  * @param {Date} options.now
@@ -230,8 +154,15 @@ function classifyDiscussion(discussion, {now, staleDays}) {
     const
         category = normalizeCategory(discussion.category),
         closed   = isTruthyClosed(discussion.closed) || String(discussion.state || '').toLowerCase() === 'closed',
-        body     = String(discussion.body || ''),
-        ageDays  = getAgeDays(discussion.updatedAt || discussion.createdAt, now);
+        // Synced Markdown appends comments after the authoritative root body. Comments remain
+        // diagnostic evidence only and cannot mutate the source-owned lifecycle projection.
+        body     = String(discussion.body || '').split(/\n## Comments\s*\n/)[0],
+        ageDays  = getAgeDays(discussion.updatedAt || discussion.createdAt, now),
+        routing  = classifyDiscussionRoutingDisposition({
+            author: discussion.author,
+            body,
+            closed
+        });
 
     if (category !== 'Ideas' || closed) {
         return null
@@ -245,7 +176,7 @@ function classifyDiscussion(discussion, {now, staleDays}) {
         filePath : discussion.filePath || ''
     };
 
-    if (hasGraduatedMarker(body)) {
+    if (routing.disposition === 'terminal' && routing.reasonCode === 'graduated-to-ticket') {
         return {
             ...base,
             kind  : 'graduated-open',
@@ -254,12 +185,18 @@ function classifyDiscussion(discussion, {now, staleDays}) {
         }
     }
 
-    if (hasResolvedDispositionMarker(body) && !hasOpenScope(body)) {
+    if (routing.disposition === 'terminal' || routing.reasonCode === 'resolved-scope-without-terminal-signal') {
+        const hasExplicitTerminalSignal = routing.disposition === 'terminal';
+
         return {
             ...base,
             kind  : 'resolved-only-review',
-            action: 'maintainer review, then close RESOLVED if no scope remains',
-            reason: 'Discussion has resolved AC markers and no obvious unresolved-scope marker.'
+            action: hasExplicitTerminalSignal
+                ? 'maintainer review, then close RESOLVED if no scope remains'
+                : 'maintainer scope review; add an explicit terminal signal only if no scope remains',
+            reason: hasExplicitTerminalSignal
+                ? `Discussion routing disposition is terminal (${routing.reasonCode}).`
+                : 'Discussion contains resolved-scope evidence without an explicit whole-Discussion terminal signal.'
         }
     }
 
@@ -268,7 +205,9 @@ function classifyDiscussion(discussion, {now, staleDays}) {
             ...base,
             kind  : 'stale-open',
             action: 'maintainer stale-archive review',
-            reason: `No activity for ${ageDays} days (threshold: ${staleDays}).`
+            reason: routing.disposition === 'active'
+                ? `Explicit active source state has no activity for ${ageDays} days (threshold: ${staleDays}); age is diagnostic only.`
+                : `No activity for ${ageDays} days (threshold: ${staleDays}).`
         }
     }
 
@@ -284,7 +223,7 @@ function classifyDiscussion(discussion, {now, staleDays}) {
  */
 function auditDiscussions(discussions, {now, staleDays}) {
     const candidates = [];
-    let scanned = 0;
+    let   scanned    = 0;
 
     for (const discussion of discussions) {
         if (normalizeCategory(discussion.category) === 'Ideas') {
@@ -347,7 +286,7 @@ async function collectDiscussionFiles(dir) {
  * @returns {Promise<Object[]>}
  */
 async function loadDiscussionsFromDir(discussionsDir) {
-    const files = await collectDiscussionFiles(discussionsDir);
+    const files       = await collectDiscussionFiles(discussionsDir);
     const discussions = [];
 
     for (const filePath of files) {
@@ -396,7 +335,7 @@ function formatReport(result, {json = false} = {}) {
     }
 
     const grouped = groupCandidates(result.candidates);
-    const lines = [
+    const lines   = [
         `[discussion-lifecycle-audit] scanned ${result.scanned} Ideas discussions.`,
         `[discussion-lifecycle-audit] candidates: ${result.candidates.length}` +
             ` (graduated-open=${grouped['graduated-open'] || 0},` +
@@ -536,6 +475,7 @@ function runSelfTest() {
         {
             number   : 1,
             title    : 'graduated',
+            author   : 'neo-gpt',
             category : 'Ideas',
             closed   : false,
             updatedAt: '2026-06-01T00:00:00Z',
@@ -544,6 +484,7 @@ function runSelfTest() {
         {
             number   : 5,
             title    : 'future criterion',
+            author   : 'neo-gpt',
             category : 'Ideas',
             closed   : false,
             updatedAt: '2026-06-01T00:00:00Z',
@@ -552,6 +493,7 @@ function runSelfTest() {
         {
             number   : 2,
             title    : 'partial',
+            author   : 'neo-gpt',
             category : 'Ideas',
             closed   : false,
             updatedAt: '2026-06-01T00:00:00Z',
@@ -560,6 +502,7 @@ function runSelfTest() {
         {
             number   : 6,
             title    : 'instructional resolved marker',
+            author   : 'neo-gpt',
             category : 'Ideas',
             closed   : false,
             updatedAt: '2026-06-01T00:00:00Z',
@@ -568,22 +511,34 @@ function runSelfTest() {
         {
             number   : 7,
             title    : 'resolved only',
+            author   : 'neo-gpt',
             category : 'Ideas',
             closed   : false,
             updatedAt: '2026-06-01T00:00:00Z',
-            body     : '[RESOLVED_TO_AC] OQ1 resolved.\nAll scope complete.'
+            body     : 'OQ1 [RESOLVED_TO_AC] resolved.\nAll scope complete.'
         },
         {
             number   : 3,
             title    : 'stale',
+            author   : 'neo-gpt',
             category : 'Ideas',
             closed   : false,
             updatedAt: '2026-01-01T00:00:00Z',
             body     : 'No markers.'
         },
         {
+            number   : 8,
+            title    : 'stale but explicitly active',
+            author   : 'neo-gpt',
+            category : 'Ideas',
+            closed   : false,
+            updatedAt: '2026-01-01T00:00:00Z',
+            body     : 'OQ2 [OQ_RESOLUTION_PENDING] still open.'
+        },
+        {
             number   : 4,
             title    : 'closed graduated',
+            author   : 'neo-gpt',
             category : 'Ideas',
             closed   : true,
             updatedAt: '2026-01-01T00:00:00Z',
@@ -596,7 +551,7 @@ function runSelfTest() {
 
     const kinds = result.candidates.map(candidate => `${candidate.number}:${candidate.kind}`);
 
-    if (result.scanned !== 7 || kinds.join(',') !== '1:graduated-open,7:resolved-only-review,3:stale-open') {
+    if (result.scanned !== 8 || kinds.join(',') !== '1:graduated-open,7:resolved-only-review,3:stale-open,8:stale-open') {
         throw new Error(`Self-test failed: ${JSON.stringify({scanned: result.scanned, kinds})}`);
     }
 

--- a/ai/services/github-workflow/shared/discussionRoutingDisposition.mjs
+++ b/ai/services/github-workflow/shared/discussionRoutingDisposition.mjs
@@ -41,7 +41,7 @@ const TERMINAL_MARKERS = Object.freeze([
     'SUPERSEDED'
 ]);
 
-const AUTHOR_UPDATE_RE      = /^>\s*\*{0,2}Update\s+\d{4}-\d{2}-\d{2}\b/i;
+const AUTHOR_UPDATE_RE              = /^>\s*\*{0,2}Update\s+\d{4}-\d{2}-\d{2}\b/i;
 const NON_AUTHORITATIVE_SECTION_RES = Object.freeze([
     /^(?:history|historical|retrospectives?|archiv(?:e|ed|es)|examples?|instructions?|instructional|how(?:-|\s+)to|usage)\b/i,
     /\(\s*(?:historical|retrospective|archived?|examples?)\b/i
@@ -195,16 +195,28 @@ function parseFenceDelimiter(line) {
 }
 
 /**
- * @summary Parses one ATX Markdown heading for section-authority tracking.
+ * @summary Parses one ATX or Setext Markdown heading for section-authority tracking.
  * @param {String} line Markdown source line.
+ * @param {String} [nextLine] Following Markdown source line for Setext underlines.
  * @returns {{level: Number, title: String}|null}
  */
-function parseSectionHeading(line) {
-    const match = String(line || '').match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/);
+function parseSectionHeading(line, nextLine) {
+    const
+        sourceLine = String(line || ''),
+        atxMatch   = sourceLine.match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/);
 
-    return match ? {
-        level: match[1].length,
-        title: match[2].replace(/[*`_]/g, '').trim()
+    if (atxMatch) {
+        return {
+            level: atxMatch[1].length,
+            title: atxMatch[2].replace(/[*`_]/g, '').trim()
+        }
+    }
+
+    const setextMatch = String(nextLine || '').match(/^\s{0,3}(=+|-+)\s*$/);
+
+    return setextMatch && sourceLine.trim() && !/^\s*>/.test(sourceLine) ? {
+        level: setextMatch[1][0] === '=' ? 1 : 2,
+        title: sourceLine.replace(/[*`_]/g, '').trim()
     } : null
 }
 
@@ -228,7 +240,10 @@ function findLifecycleMarkers(body) {
     let   fence = null,
           nonAuthoritativeSectionLevel = null;
 
-    for (const line of String(body || '').split(/\r?\n/)) {
+    const lines = String(body || '').split(/\r?\n/);
+
+    for (let index = 0; index < lines.length; index++) {
+        const line      = lines[index];
         const delimiter = parseFenceDelimiter(line);
 
         if (fence) {
@@ -248,7 +263,7 @@ function findLifecycleMarkers(body) {
             continue
         }
 
-        const heading = parseSectionHeading(line);
+        const heading = parseSectionHeading(line, lines[index + 1]);
 
         if (heading) {
             if (

--- a/ai/services/github-workflow/shared/discussionRoutingDisposition.mjs
+++ b/ai/services/github-workflow/shared/discussionRoutingDisposition.mjs
@@ -42,6 +42,10 @@ const TERMINAL_MARKERS = Object.freeze([
 ]);
 
 const AUTHOR_UPDATE_RE      = /^>\s*\*{0,2}Update\s+\d{4}-\d{2}-\d{2}\b/i;
+const NON_AUTHORITATIVE_SECTION_RES = Object.freeze([
+    /^(?:history|historical|retrospectives?|archiv(?:e|ed|es)|examples?|instructions?|instructional|how(?:-|\s+)to|usage)\b/i,
+    /\(\s*(?:historical|retrospective|archived?|examples?)\b/i
+]);
 const GRADUATED_CALLOUT_RES = Object.freeze([
     /^>\s*\*\*GRADUATED\*\*\s*\(\d{4}-\d{2}-\d{2}\):\s*This Discussion graduated to\s+(?:Epic|Ticket)\s+#\d+\b/i,
     /^>\s*\*\*Status:\s*GRADUATED\s+\d{4}-\d{2}-\d{2}\*\*[^\n]*\b(?:epic|ticket):?\s*#\d+\b/i
@@ -191,13 +195,38 @@ function parseFenceDelimiter(line) {
 }
 
 /**
+ * @summary Parses one ATX Markdown heading for section-authority tracking.
+ * @param {String} line Markdown source line.
+ * @returns {{level: Number, title: String}|null}
+ */
+function parseSectionHeading(line) {
+    const match = String(line || '').match(/^\s{0,3}(#{1,6})\s+(.+?)\s*#*\s*$/);
+
+    return match ? {
+        level: match[1].length,
+        title: match[2].replace(/[*`_]/g, '').trim()
+    } : null
+}
+
+/**
+ * @summary Returns true for explicitly historical, retrospective, archived, example, or instructional sections.
+ * Their complete Markdown subtree is evidence, not current whole-Discussion lifecycle authority.
+ * @param {String} title Normalized heading title.
+ * @returns {Boolean}
+ */
+function isNonAuthoritativeSection(title) {
+    return NON_AUTHORITATIVE_SECTION_RES.some(pattern => pattern.test(title))
+}
+
+/**
  * @summary Finds authoritative lifecycle markers in a trusted Discussion body.
  * @param {String} body Discussion body.
  * @returns {String[]} Marker names in source order, de-duplicated.
  */
 function findLifecycleMarkers(body) {
     const found = [];
-    let   fence = null;
+    let   fence = null,
+          nonAuthoritativeSectionLevel = null;
 
     for (const line of String(body || '').split(/\r?\n/)) {
         const delimiter = parseFenceDelimiter(line);
@@ -218,6 +247,26 @@ function findLifecycleMarkers(body) {
             fence = delimiter;
             continue
         }
+
+        const heading = parseSectionHeading(line);
+
+        if (heading) {
+            if (
+                nonAuthoritativeSectionLevel !== null &&
+                heading.level <= nonAuthoritativeSectionLevel
+            ) {
+                nonAuthoritativeSectionLevel = null
+            }
+
+            if (
+                nonAuthoritativeSectionLevel === null &&
+                isNonAuthoritativeSection(heading.title)
+            ) {
+                nonAuthoritativeSectionLevel = heading.level
+            }
+        }
+
+        if (nonAuthoritativeSectionLevel !== null) continue;
 
         if (GRADUATED_CALLOUT_RES.some(pattern => pattern.test(line)) && !found.includes('GRADUATED_CALLOUT')) {
             found.push('GRADUATED_CALLOUT')

--- a/ai/services/github-workflow/shared/discussionRoutingDisposition.mjs
+++ b/ai/services/github-workflow/shared/discussionRoutingDisposition.mjs
@@ -1,0 +1,333 @@
+import {
+    classifyAuthorTrust,
+    isTrustedTier
+} from '../../shared/contentTrust/authorTrustClassifier.mjs';
+
+/**
+ * Pre-Flight (structural fast-path): `discussionRoutingDisposition.mjs` matches the pure,
+ * no-I/O sibling helpers in this directory (`conversationTrust.mjs`, `contentPath.mjs`).
+ * It is source-owned GitHub Workflow policy, not a graph scorer or diagnostic-script authority.
+ *
+ * @module ai/services/github-workflow/shared/discussionRoutingDisposition
+ * @summary Classifies source-backed Discussion routing lifecycle without using age, `updatedAt`,
+ * or comment activity as authority. The projection is intentionally small and typed so sync,
+ * ingestion, diagnostics, and Golden Path can share one marker interpretation.
+ */
+
+export const DISCUSSION_ROUTING_DISPOSITIONS = Object.freeze({
+    ACTIVE      : 'active',
+    TERMINAL    : 'terminal',
+    UNDETERMINED: 'undetermined'
+});
+
+/**
+ * @summary Schema discriminator for coherent source-owned Discussion routing projections.
+ * @type {String}
+ */
+export const DISCUSSION_ROUTING_DISPOSITION_SCHEMA_VERSION = 'discussion-routing-disposition.v1';
+
+const ACTIVE_MARKERS = Object.freeze([
+    'CONVERGING',
+    'EVERGREEN',
+    'GRADUATION_PROPOSED',
+    'OQ_RESOLUTION_PENDING',
+    'REVALIDATED',
+    'REVALIDATION_PENDING'
+]);
+
+const TERMINAL_MARKERS = Object.freeze([
+    'DECLINED',
+    'DROPPED',
+    'SUPERSEDED'
+]);
+
+const AUTHOR_UPDATE_RE      = /^>\s*\*{0,2}Update\s+\d{4}-\d{2}-\d{2}\b/i;
+const GRADUATED_CALLOUT_RES = Object.freeze([
+    /^>\s*\*\*GRADUATED\*\*\s*\(\d{4}-\d{2}-\d{2}\):\s*This Discussion graduated to\s+(?:Epic|Ticket)\s+#\d+\b/i,
+    /^>\s*\*\*Status:\s*GRADUATED\s+\d{4}-\d{2}-\d{2}\*\*[^\n]*\b(?:epic|ticket):?\s*#\d+\b/i
+]);
+
+const ACTIVE_EVIDENCE = new Set(ACTIVE_MARKERS.map(marker => `marker:${marker}`));
+
+/**
+ * @summary Compares one persisted evidence vector against the classifier's canonical ordered shape.
+ * @param {String[]} evidence Actual evidence vector.
+ * @param {String[]} expected Canonical evidence vector.
+ * @returns {Boolean}
+ */
+function isExactEvidence(evidence, expected) {
+    return evidence.length === expected.length && evidence.every((value, index) => value === expected[index])
+}
+
+/**
+ * @summary Validates and normalizes one persisted lifecycle tuple. Current-schema tuples must be
+ * semantically coherent across disposition, reason, and evidence; any missing, malformed, or
+ * contradictory tuple degrades atomically to the legacy undetermined projection.
+ * @param {Object} projection
+ * @param {String} projection.schemaVersion
+ * @param {String} projection.disposition
+ * @param {String} projection.reasonCode
+ * @param {String[]} projection.evidence
+ * @returns {{schemaVersion: String, disposition: String, reasonCode: String, evidence: String[]}}
+ */
+export function normalizeDiscussionRoutingProjection({
+    schemaVersion,
+    disposition,
+    reasonCode,
+    evidence
+} = {}) {
+    const hasValidShape = schemaVersion === DISCUSSION_ROUTING_DISPOSITION_SCHEMA_VERSION &&
+        Object.values(DISCUSSION_ROUTING_DISPOSITIONS).includes(disposition) &&
+        typeof reasonCode === 'string' && reasonCode.length > 0 &&
+        Array.isArray(evidence) && evidence.every(value => typeof value === 'string') &&
+        new Set(evidence).size === evidence.length;
+    let coherent = false;
+
+    if (hasValidShape && disposition === DISCUSSION_ROUTING_DISPOSITIONS.ACTIVE) {
+        coherent = reasonCode === 'explicit-active-marker' &&
+            evidence.length > 0 &&
+            evidence.every(value => ACTIVE_EVIDENCE.has(value))
+    } else if (hasValidShape && disposition === DISCUSSION_ROUTING_DISPOSITIONS.TERMINAL) {
+        if (reasonCode === 'github-closed') {
+            coherent = isExactEvidence(evidence, ['github:closed'])
+        } else if (reasonCode === 'graduated-to-ticket') {
+            coherent = evidence.length === 1 && [
+                'marker:GRADUATED_TO_TICKET',
+                'callout:GRADUATED'
+            ].includes(evidence[0])
+        } else {
+            const match = reasonCode.match(/^terminal-marker:(declined|dropped|superseded)$/);
+            coherent = Boolean(match) && isExactEvidence(evidence, [`marker:${match[1].toUpperCase()}`])
+        }
+    } else if (hasValidShape && disposition === DISCUSSION_ROUTING_DISPOSITIONS.UNDETERMINED) {
+        coherent = (
+            ['untrusted-or-unclassified-root-author', 'no-authoritative-lifecycle-marker'].includes(reasonCode) &&
+            evidence.length === 0
+        ) || (
+            reasonCode === 'resolved-scope-without-terminal-signal' &&
+            isExactEvidence(evidence, ['marker:RESOLVED_TO_AC'])
+        )
+    }
+
+    return coherent ? {
+        schemaVersion,
+        disposition,
+        reasonCode,
+        evidence: [...evidence]
+    } : {
+        schemaVersion: 'discussion-routing-disposition.legacy',
+        disposition  : DISCUSSION_ROUTING_DISPOSITIONS.UNDETERMINED,
+        reasonCode   : 'legacy-or-invalid-projection',
+        evidence     : []
+    }
+}
+
+/**
+ * @summary Normalizes a possible lifecycle marker line while preserving marker order.
+ * @param {String} line Source Markdown line.
+ * @returns {String} Trimmed line without presentation prefixes.
+ */
+function normalizeMarkerLine(line) {
+    return String(line || '')
+        .replace(/^\s*#{1,6}\s*/, '')
+        // Preserve `_` inside machine markers such as `GRADUATED_TO_TICKET`.
+        // Removing it before matching was the old diagnostic's silent false-negative class.
+        .replace(/[*`]/g, '')
+        .trim()
+}
+
+/**
+ * @summary Returns true only when a line uses a marker as current lifecycle data, rather than
+ * mentioning its syntax in prose or graduation criteria.
+ * @param {String} line Source Markdown line.
+ * @param {String} marker Marker name without brackets.
+ * @returns {Boolean}
+ */
+function isLifecycleMarkerLine(line, marker) {
+    const sourceLine = String(line || '');
+    const isAuthorUpdate = AUTHOR_UPDATE_RE.test(sourceLine);
+
+    const
+        normalized = normalizeMarkerLine(sourceLine.replace(AUTHOR_UPDATE_RE, 'Update ')),
+        escaped     = marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
+        markerRe    = new RegExp(`\\[${escaped}(?::[^\\]]*)?\\]`, 'i'),
+        statusRe    = new RegExp(`^(?:Status:\\s*)?\\[${escaped}(?::[^\\]]*)?\\]`, 'i'),
+        oqBound     = /(?:\bOQ\s*\d+\b|\bOpen Question\b)/i.test(normalized);
+
+    if (!markerRe.test(normalized)) return false;
+    if (/^\s*>/.test(sourceLine) && !isAuthorUpdate) return false;
+    if (isAuthorUpdate) return true;
+
+    if (marker === 'GRADUATED_TO_TICKET' || TERMINAL_MARKERS.includes(marker)) {
+        // Whole-Discussion terminal authority is deliberately stricter than per-OQ marker evidence:
+        // a current Status/bare/heading marker classifies; a bullet, criterion, or prose mention does not.
+        return statusRe.test(normalized)
+    }
+
+    if (marker === 'OQ_RESOLUTION_PENDING' || marker === 'RESOLVED_TO_AC') {
+        return statusRe.test(normalized) || oqBound
+    }
+
+    // Active whole-Discussion signals are authoritative only in a current status/bare-marker
+    // shape, or when explicitly bound to an OQ. Prose that merely names marker syntax, including
+    // negated or future instructions, is not lifecycle data.
+    return statusRe.test(normalized) || oqBound
+}
+
+/**
+ * @summary Parses a Markdown fence delimiter. A close delimiter must use the same character,
+ * contain at least the opener's run length, and carry no info string.
+ * @param {String} line Markdown source line.
+ * @returns {{character: String, length: Number, tail: String}|null}
+ */
+function parseFenceDelimiter(line) {
+    const match = String(line || '').match(/^\s*(`{3,}|~{3,})(.*)$/);
+
+    return match ? {
+        character: match[1][0],
+        length   : match[1].length,
+        tail     : match[2]
+    } : null
+}
+
+/**
+ * @summary Finds authoritative lifecycle markers in a trusted Discussion body.
+ * @param {String} body Discussion body.
+ * @returns {String[]} Marker names in source order, de-duplicated.
+ */
+function findLifecycleMarkers(body) {
+    const found = [];
+    let   fence = null;
+
+    for (const line of String(body || '').split(/\r?\n/)) {
+        const delimiter = parseFenceDelimiter(line);
+
+        if (fence) {
+            if (
+                delimiter &&
+                delimiter.character === fence.character &&
+                delimiter.length >= fence.length &&
+                delimiter.tail.trim() === ''
+            ) {
+                fence = null
+            }
+            continue
+        }
+
+        if (delimiter) {
+            fence = delimiter;
+            continue
+        }
+
+        if (GRADUATED_CALLOUT_RES.some(pattern => pattern.test(line)) && !found.includes('GRADUATED_CALLOUT')) {
+            found.push('GRADUATED_CALLOUT')
+        }
+
+        for (const marker of [
+            'GRADUATED_TO_TICKET',
+            ...TERMINAL_MARKERS,
+            ...ACTIVE_MARKERS,
+            'RESOLVED_TO_AC'
+        ]) {
+            if (isLifecycleMarkerLine(line, marker) && !found.includes(marker)) {
+                found.push(marker)
+            }
+        }
+    }
+
+    return found
+}
+
+/**
+ * @summary Classifies one GitHub Discussion into the source-owned routing disposition.
+ *
+ * Precedence is deliberate: GitHub closure and explicit terminal markers win; an explicit active
+ * marker then keeps partially-resolved Discussions live; per-OQ resolution without an explicit
+ * whole-Discussion terminal signal remains `undetermined`; all other states remain `undetermined`.
+ * Raw timestamps never participate. Marker-bearing content
+ * from an untrusted root author cannot manufacture either active or terminal routing state.
+ *
+ * @param {Object} discussion Source Discussion/frontmatter projection.
+ * @param {String} [discussion.author] GitHub login when `authorTrust` is not already projected.
+ * @param {String} [discussion.authorTrust] Precomputed content-trust tier.
+ * @param {String} [discussion.body] Root Discussion body (comments are intentionally excluded).
+ * @param {Boolean} [discussion.closed] GitHub lifecycle fact.
+ * @returns {{schemaVersion: String, disposition: String, reasonCode: String, evidence: String[]}}
+ */
+export function classifyDiscussionRoutingDisposition({
+    author,
+    authorTrust,
+    body = '',
+    closed = false
+} = {}) {
+    if (closed === true || String(closed).toLowerCase() === 'true') {
+        return {
+            schemaVersion: DISCUSSION_ROUTING_DISPOSITION_SCHEMA_VERSION,
+            disposition  : DISCUSSION_ROUTING_DISPOSITIONS.TERMINAL,
+            reasonCode   : 'github-closed',
+            evidence     : ['github:closed']
+        }
+    }
+
+    const trustTier = authorTrust || classifyAuthorTrust(author);
+
+    if (!isTrustedTier(trustTier)) {
+        return {
+            schemaVersion: DISCUSSION_ROUTING_DISPOSITION_SCHEMA_VERSION,
+            disposition  : DISCUSSION_ROUTING_DISPOSITIONS.UNDETERMINED,
+            reasonCode   : 'untrusted-or-unclassified-root-author',
+            evidence     : []
+        }
+    }
+
+    const markers = findLifecycleMarkers(body);
+
+    if (markers.includes('GRADUATED_TO_TICKET') || markers.includes('GRADUATED_CALLOUT')) {
+        return {
+            schemaVersion: DISCUSSION_ROUTING_DISPOSITION_SCHEMA_VERSION,
+            disposition  : DISCUSSION_ROUTING_DISPOSITIONS.TERMINAL,
+            reasonCode   : 'graduated-to-ticket',
+            evidence     : markers.includes('GRADUATED_TO_TICKET')
+                ? ['marker:GRADUATED_TO_TICKET']
+                : ['callout:GRADUATED']
+        }
+    }
+
+    const terminalMarker = markers.find(marker => TERMINAL_MARKERS.includes(marker));
+    if (terminalMarker) {
+        return {
+            schemaVersion: DISCUSSION_ROUTING_DISPOSITION_SCHEMA_VERSION,
+            disposition  : DISCUSSION_ROUTING_DISPOSITIONS.TERMINAL,
+            reasonCode   : `terminal-marker:${terminalMarker.toLowerCase()}`,
+            evidence     : [`marker:${terminalMarker}`]
+        }
+    }
+
+    const activeMarkers = markers.filter(marker => ACTIVE_MARKERS.includes(marker));
+    if (activeMarkers.length > 0) {
+        return {
+            schemaVersion: DISCUSSION_ROUTING_DISPOSITION_SCHEMA_VERSION,
+            disposition  : DISCUSSION_ROUTING_DISPOSITIONS.ACTIVE,
+            reasonCode   : 'explicit-active-marker',
+            evidence     : activeMarkers.map(marker => `marker:${marker}`)
+        }
+    }
+
+    if (markers.includes('RESOLVED_TO_AC')) {
+        return {
+            schemaVersion: DISCUSSION_ROUTING_DISPOSITION_SCHEMA_VERSION,
+            disposition  : DISCUSSION_ROUTING_DISPOSITIONS.UNDETERMINED,
+            reasonCode   : 'resolved-scope-without-terminal-signal',
+            evidence     : ['marker:RESOLVED_TO_AC']
+        }
+    }
+
+    return {
+        schemaVersion: DISCUSSION_ROUTING_DISPOSITION_SCHEMA_VERSION,
+        disposition  : DISCUSSION_ROUTING_DISPOSITIONS.UNDETERMINED,
+        reasonCode   : 'no-authoritative-lifecycle-marker',
+        evidence     : []
+    }
+}
+
+export {findLifecycleMarkers, isLifecycleMarkerLine};

--- a/ai/services/github-workflow/sync/CONTENT_GRAMMAR.md
+++ b/ai/services/github-workflow/sync/CONTENT_GRAMMAR.md
@@ -32,7 +32,7 @@ Verified against the emit code (`PullRequestSyncer.mjs`, `DiscussionSyncer.mjs`,
 
 ## Discussions — `DiscussionSyncer`
 
-- Frontmatter: `number, title, author, category` (`Ideas`|`General`|`Q&A`|…), `createdAt, updatedAt, closed` (boolean), `closedAt`. No `state`, no `labels`.
+- Frontmatter: `number, title, author, category` (`Ideas`|`General`|`Q&A`|…), `createdAt, updatedAt, closed` (boolean), `closedAt`, and the source-owned `routingDispositionSchemaVersion, routingDisposition, routingDispositionReason, routingDispositionEvidence`. No `state`, no `labels`; raw timestamps are observability and never routing-liveness authority.
 - Sections: `## Description`, then `## Comments`.
 - `## Comments` entries: `` ### `@user` commented on <ISO_Z> `` — the backtick form, **like PRs, not** the issue `- <ts> @user` event form.
 - Threaded replies follow their parent comment, each headed `` #### Reply depth=<N> by `@user` on <ISO_Z> `` with raw reply markdown after the header. Parent association is lexical: a reply belongs to the preceding top-level comment until the next top-level `` ### `@user` commented on <ISO_Z> `` header.

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -14,6 +14,7 @@ import {
     updateContentIndex
 } from '../shared/contentIndex.mjs';
 import {createContentTrustSummary, projectAuthoredNodeTrust} from '../shared/conversationTrust.mjs';
+import {classifyDiscussionRoutingDisposition}                from '../shared/discussionRoutingDisposition.mjs';
 import pruneEmptyDirs                                        from '../shared/pruneEmptyDirs.mjs';
 import {verifyDiscussionFrontmatter}                         from './verifyFrontmatterIntegrity.mjs';
 
@@ -120,13 +121,13 @@ class DiscussionSyncer extends Base {
             });
         }
 
-        const buckets = new Map();
+        const buckets     = new Map();
         const activeItems = [];
 
         for (const discussion of combined.values()) {
             let version = null;
             if (discussion.closedAt) {
-                const closed = new Date(discussion.closedAt);
+                const closed  = new Date(discussion.closedAt);
                 const release = (ReleaseNotesSyncer.sortedReleases || []).find(r => new Date(r.publishedAt) > closed);
                 if (release) {
                     version = release.tagName.startsWith(issueSyncConfig.versionDirectoryPrefix)
@@ -185,9 +186,9 @@ class DiscussionSyncer extends Base {
      * @private
      */
     #getDiscussionPath(discussion, planBuckets) {
-        const filename = `${issueSyncConfig.discussionFilenamePrefix}${discussion.number}.md`;
+        const filename    = `${issueSyncConfig.discussionFilenamePrefix}${discussion.number}.md`;
         const contentRoot = issueSyncConfig.contentRoot;
-        const plan = planBuckets.get(discussion.number);
+        const plan        = planBuckets.get(discussion.number);
 
         const config = {
             contentRoot,
@@ -231,18 +232,28 @@ class DiscussionSyncer extends Base {
      * @throws {Error} When the serialized content is missing required frontmatter keys (a frontmatter-contract violation — likely a stale daemon code path).
      */
     #renderDiscussionMarkdown(discussion) {
-        const contentTrust = createContentTrustSummary();
+        const contentTrust        = createContentTrustSummary();
         const projectedDiscussion = this.#projectAuthoredNode(discussion, contentTrust, 'body');
+        const routingDisposition  = classifyDiscussionRoutingDisposition({
+            author     : discussion.author?.login,
+            authorTrust: projectedDiscussion.authorTrust,
+            body       : projectedDiscussion.body,
+            closed     : discussion.closed
+        });
 
         const frontmatter = {
-            number   : discussion.number,
-            title    : discussion.title,
-            author   : discussion.author?.login || 'unknown',
-            category : discussion.category?.name || 'Uncategorized',
-            createdAt: discussion.createdAt,
-            updatedAt: discussion.updatedAt,
-            closed   : discussion.closed,
-            closedAt : discussion.closedAt,
+            number                         : discussion.number,
+            title                          : discussion.title,
+            author                         : discussion.author?.login || 'unknown',
+            category                       : discussion.category?.name || 'Uncategorized',
+            createdAt                      : discussion.createdAt,
+            updatedAt                      : discussion.updatedAt,
+            closed                         : discussion.closed,
+            closedAt                       : discussion.closedAt,
+            routingDispositionSchemaVersion: routingDisposition.schemaVersion,
+            routingDisposition             : routingDisposition.disposition,
+            routingDispositionReason       : routingDisposition.reasonCode,
+            routingDispositionEvidence     : routingDisposition.evidence,
             contentTrust
         };
 
@@ -381,20 +392,20 @@ class DiscussionSyncer extends Base {
             allDiscussions = allDiscussions.filter(discussion => !deniedFetchedNumbers.has(discussion.number));
         }
 
-        const planBuckets = this.#planBuckets(metadata, allDiscussions);
-        let shouldPruneEmptyDirs = false;
+        const planBuckets          = this.#planBuckets(metadata, allDiscussions);
+        let   shouldPruneEmptyDirs = false;
 
         for (const discussion of allDiscussions) {
             try {
-                const targetPath  = this.#getDiscussionPath(discussion, planBuckets);
+                const targetPath = this.#getDiscussionPath(discussion, planBuckets);
                 if (!targetPath) continue;
 
                 const content     = this.#renderDiscussionMarkdown(discussion);
                 const currentHash = this.#calculateContentHash(content);
 
                 const cachedDiscussion = cachedDiscussions[discussion.number];
-                const oldPathRelative = cachedDiscussion?.path;
-                const oldAbsolutePath = oldPathRelative ? this.#resolvePath(oldPathRelative) : null;
+                const oldPathRelative  = cachedDiscussion?.path;
+                const oldAbsolutePath  = oldPathRelative ? this.#resolvePath(oldPathRelative) : null;
 
                 const needsUpdate = !cachedDiscussion ||
                     oldAbsolutePath !== targetPath;

--- a/ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs
+++ b/ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs
@@ -51,7 +51,7 @@ function verifyFrontmatterIntegrity(content, requiredKeys) {
         return {ok: false, missing: requiredKeys.slice()};
     }
 
-    const data = parsed.data || {};
+    const data    = parsed.data || {};
     const missing = requiredKeys.filter(key => !Object.prototype.hasOwnProperty.call(data, key));
 
     return {
@@ -65,7 +65,7 @@ function verifyFrontmatterIntegrity(content, requiredKeys) {
  * "what counts as a complete Discussion frontmatter" contract so future migrations
  * can extend this single list instead of grepping all syncers.
  *
- * Currently mirrors `DiscussionSyncer.mjs:241-250` frontmatter object construction.
+ * Mirrors `DiscussionSyncer.#renderDiscussionMarkdown()` frontmatter construction.
  *
  * @param {string} content
  * @returns {{ok: boolean, missing: string[]}}
@@ -79,7 +79,11 @@ function verifyDiscussionFrontmatter(content) {
         'createdAt',
         'updatedAt',
         'closed',
-        'closedAt'
+        'closedAt',
+        'routingDispositionSchemaVersion',
+        'routingDisposition',
+        'routingDispositionReason',
+        'routingDispositionEvidence'
     ]);
 }
 

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -27,6 +27,7 @@ import {
 } from './agentFamilyResolution.mjs';
 import {
     buildFailureOutcome                          as buildRouteFailureOutcome,
+    evaluateDiscussionLiveness                   as evaluateRouteDiscussionLiveness,
     findComputedFocusContradiction               as findRouteFocusContradiction,
     getComputedRecommendationExclusionLabels     as getRouteExclusionLabels,
     getRoutingConflictReasons                    as getRouteConflictReasons,
@@ -42,8 +43,9 @@ import {
     validateRouteAttributionRetention
 } from './routeAttributionLedgerStore.mjs';
 import {
-    TYPE_GATE_REJECTION_FILENAME,
-    TYPE_GATE_REJECTION_STAGE
+    appendTypeGateRejection,
+    TYPE_GATE_REJECTION_STAGE,
+    DISCUSSION_LIVENESS_REJECTION_STAGE
 } from './typeGateRejectionLedgerStore.mjs';
 import {
     getActivePrCycleStatus                      as resolveActivePrCycleStatus,
@@ -91,6 +93,14 @@ import {
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
+
+// Candidate admission widens complete prefixes, but an unhealthy proxy must never drive
+// exponentially large ANN requests or SQLite placeholder lists. The collection count narrows the
+// real ceiling when available; this hard ceiling is an operational failure boundary, not a ranking
+// input. SQLite hydration is chunked independently so the ceiling stays below no variable limit.
+const SEMANTIC_QUERY_INITIAL_WIDTH = 20;
+const SEMANTIC_QUERY_MAX_WIDTH     = 4096;
+const SQLITE_ID_CHUNK_SIZE         = 500;
 
 // The embedding-dimension helpers were extracted to ./embeddingDimension.mjs (the SRP decomposition). They are
 // imported above for the internal dimension guard, and re-exported here so the public API stays stable.
@@ -333,6 +343,16 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Delegates the distinct Discussion-liveness gate to the pure routing authority.
+     * @param {Object} nodeData Parsed graph node payload.
+     * @param {Number} decayingWeight RLS-visible non-protected inbound support.
+     * @returns {{eligible: Boolean, rejectionBucket: String[]}}
+     */
+    static evaluateDiscussionLiveness(nodeData, decayingWeight) {
+        return evaluateRouteDiscussionLiveness(nodeData, decayingWeight)
+    }
+
+    /**
      * @summary Delegates routing-conflict focus detection to `computedGoldenPathRouting.mjs`.
      * @param {Object} candidate Current Focus candidate.
      * @returns {Boolean}
@@ -440,35 +460,37 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
-     * @summary Pure builder for the type-gate rejection records — the SECOND GP filter point's evidence. Where
-     * `buildRouteAttributionRecords` captures the routing-contradiction GUARD's filtering, this captures the
-     * actionability TYPE-GATE's rejections (`isActionableComputedRecommendation` === false): the visibility-only
-     * candidates (`epic` / `not-code-ready` / …) that never reach scoring. Each record carries the node id, its
-     * exclusion-label bucket (the exact labels that made it non-actionable, from the shared authority), and the
-     * `stage` discriminator so a merged read stays self-describing.
-     * @param {Array<{nodeId: String, rejectionBucket: String[]}>} rejections Collected at the type-gate filter point.
+     * @summary Pure builder for candidate-admission rejection records. Actionability remains the
+     * compatibility-default stage; Discussion liveness supplies its explicit sibling stage. Unknown
+     * stages are dropped so they cannot leak into either stage-specific evidence view.
+     * @param {Array<{nodeId: String, rejectionBucket: String[], stage: (String|undefined)}>} rejections Final-pass rejection rows.
      * @param {Number} nowMs Epoch ms stamped onto each record.
      * @returns {Object[]} `[{nodeId, rejectionBucket, stage, at}]` (empty when nothing was rejected).
      */
     static buildTypeGateRejectionRecords(rejections, nowMs) {
         return (Array.isArray(rejections) ? rejections : [])
-            .filter(item => typeof item?.nodeId === 'string' && item.nodeId.length > 0)
+            .filter(item =>
+                typeof item?.nodeId === 'string' &&
+                item.nodeId.length > 0 &&
+                (item.stage == null || [TYPE_GATE_REJECTION_STAGE, DISCUSSION_LIVENESS_REJECTION_STAGE].includes(item.stage))
+            )
             .map(item => ({
                 nodeId         : item.nodeId,
                 rejectionBucket: Array.isArray(item.rejectionBucket) ? item.rejectionBucket : [],
-                stage          : TYPE_GATE_REJECTION_STAGE,
+                stage          : item.stage || TYPE_GATE_REJECTION_STAGE,
                 at             : nowMs
             }))
     }
 
     /**
-     * @summary The type-gate rejection record-seam: persists which computed candidates the actionability gate
-     * rejected, under which exclusion labels, per synthesis run — the evidence window the 42.2%-type-gate
-     * disposition decides against. FAIL-OPEN, exactly like `recordRouteAttribution` — a ledger-write failure is
+     * @summary The candidate-admission rejection record-seam: persists final-pass actionability and
+     * Discussion-liveness rows into one stage-discriminated physical stream. FAIL-OPEN, exactly like
+     * `recordRouteAttribution` — a ledger-write failure is
      * swallowed-logged and never aborts synthesis (the ledger is observability, never a gate); a missing/empty
-     * `dir` is a silent no-op. Reuses the route-attribution ledger's runtime dir + retention leaves + shape-agnostic
-     * append via the `filename` seam, writing a SIBLING file so the two filter points stay queryable-apart.
-     * @param {Array<{nodeId: String, rejectionBucket: String[]}>} rejections The type-gate rejections for this pass.
+     * `dir` is a silent no-op. Reuses the route-attribution ledger's runtime dir + retention leaves while the
+     * rejection store applies the cap per stage inside one SIBLING file, so liveness pressure cannot evict the
+     * compatibility-default actionability view.
+     * @param {Array<{nodeId: String, rejectionBucket: String[], stage: (String|undefined)}>} rejections Final-pass rejection rows.
      * @param {Date|Number} now The synthesis-pass clock (Date or epoch ms).
      * @param {Object} [ledger] The resolved ledger boundary (from the caller's AiConfig read).
      * @param {String} [ledger.dir] The runtime ledger directory; absent/empty → no-op.
@@ -488,7 +510,7 @@ class GoldenPathSynthesizer extends Base {
             const retention = validateRouteAttributionRetention(maxEvents, triggerBytes);
 
             for (const record of records) {
-                await appendRouteAttribution(record, {dir, filename: TYPE_GATE_REJECTION_FILENAME, ...retention})
+                await appendTypeGateRejection(record, {dir, ...retention})
             }
         } catch (error) {
             logger.warn(`[GoldenPathSynthesizer] type-gate rejection ledger write failed (non-fatal): ${error?.message || error}`)
@@ -877,155 +899,258 @@ class GoldenPathSynthesizer extends Base {
             return this.constructor.buildFailureOutcome('embedding-dimension-mismatch', message);
         }
 
-        const scoredNodes = [];
-        // AC3: the type-gate rejections collected across the scoring loop (emitted once after it, like the
-        // route-attribution record-seam) — the SECOND GP filter point's evidence for the type-gate disposition.
-        const typeGateRejections = [];
-        const scoringStats       = {
-            semanticCandidates     : 0,
-            sqliteOpenMatches      : 0,
-            blockedCandidates      : 0,
-            nonActionableCandidates: 0,
-            scoredCandidates       : 0,
-            selectedTopNodes       : 0,
-            prunedGuideEdges       : 0
+        let   scoredNodes                  = [];
+        let   typeGateRejections           = [];
+        let   discussionLivenessRejections = [];
+        const scoringStats                 = {
+            semanticCandidates          : 0,
+            sqliteOpenMatches           : 0,
+            blockedCandidates           : 0,
+            nonActionableCandidates     : 0,
+            discussionLivenessRejections: 0,
+            scoredCandidates            : 0,
+            selectedTopNodes            : 0,
+            prunedGuideEdges            : 0,
+            semanticQueryPasses         : 0,
+            semanticQueryRequestedWidth : 0,
+            semanticCorpusSize          : null,
+            semanticReturnedCandidates  : 0,
+            semanticUniqueCandidates    : 0,
+            semanticCorpusExhausted     : false,
+            candidateAdmissionStopReason: null
         };
-        let routeFailure = null;
-
-        // Pillar 1: Semantic Distance from ChromaDB
-        let semanticIds       = [];
-        let semanticDistances = [];
-        try {
-            const semanticResults = await graphColl.query({
-                queryEmbeddings: [frontierEmbedding],
-                nResults       : 20,
-                // Scope the candidate pool to actionable ISSUE + DISCUSSION vectors. Without this, the
-                // top-20 is taken across ALL embedded node types (the CONCEPT + ADR/GUIDES meta dominate),
-                // so the downstream state='OPEN' intersection yields nothing and the Computed Golden Path
-                // renders empty even when fresh open issues/discussions exist. Both are execution-steerable
-                // (work-to-do / converge-to-drive) and both embed with state='OPEN' metadata (IssueIngestor).
-                where          : {type: {'$in': ['ISSUE', 'DISCUSSION']}}
-            });
-            if (semanticResults && semanticResults.ids && semanticResults.ids.length > 0) {
-                semanticIds = semanticResults.ids[0];
-                semanticDistances = semanticResults.distances ? semanticResults.distances[0] : new Array(semanticIds.length).fill(0.1);
-            }
-        } catch (e) {
-            logger.warn('[GoldenPathSynthesizer] Failed to query semantic vectors from ChromaDB.', e);
-            routeFailure = this.constructor.buildFailureOutcome('semantic-query-failed', e);
-        }
-
-        if (semanticIds.length === 0) {
-            logger.info('[GoldenPathSynthesizer] No semantic nodes found. Golden path empty.');
-        }
-        scoringStats.semanticCandidates = semanticIds.length;
-
-        // Pillar 2: Structural Weight from SQLite Graph
         const SEMANTIC_WEIGHT   = 2.0;
         const STRUCTURAL_WEIGHT = 1.0;
+        const admissionTarget   = Number.isFinite(Number(aiConfig.goldenPathTopNodeRenderLimit)) && Number(aiConfig.goldenPathTopNodeRenderLimit) > 0
+            ? Math.max(1, Math.floor(Number(aiConfig.goldenPathTopNodeRenderLimit)))
+            : 1;
+        let routeFailure       = null;
+        let semanticCorpusSize = null;
 
-        if (semanticIds.length > 0 && !routeFailure) {
+        try {
+            if (typeof graphColl.count === 'function') {
+                const count = Number(await graphColl.count());
+
+                if (!Number.isInteger(count) || count < 0) {
+                    throw new Error(`Graph collection returned invalid corpus count: ${count}`)
+                }
+
+                semanticCorpusSize = count;
+                scoringStats.semanticCorpusSize = count
+            }
+        } catch (error) {
+            logger.warn('[GoldenPathSynthesizer] Failed to count semantic graph candidates.', error);
+            routeFailure = this.constructor.buildFailureOutcome('semantic-query-failed', error);
+            scoringStats.candidateAdmissionStopReason = 'semantic-query-failed'
+        }
+
+        const admissionCeiling = Math.min(
+            semanticCorpusSize === null ? SEMANTIC_QUERY_MAX_WIDTH : Math.max(1, semanticCorpusSize + 1),
+            SEMANTIC_QUERY_MAX_WIDTH
+        );
+        let requestedWidth = Math.min(SEMANTIC_QUERY_INITIAL_WIDTH, admissionCeiling);
+        let admissionDone  = semanticCorpusSize === 0;
+
+        if (admissionDone) {
+            scoringStats.semanticCorpusExhausted      = true;
+            scoringStats.candidateAdmissionStopReason = 'semantic-corpus-exhausted'
+        }
+
+        // Candidate admission is a bounded whole-prefix loop: every widened pass rebuilds the full
+        // state/blocker/actionability/liveness chain, then commits only the final successful attempt.
+        // A returned prefix shorter than requested is the only corpus-exhaustion proof; equality widens.
+        while (!routeFailure && !admissionDone) {
+            let semanticIds       = [];
+            let semanticDistances = [];
+
+            scoringStats.semanticQueryPasses++;
+            scoringStats.semanticQueryRequestedWidth = requestedWidth;
+
             try {
-                const placeholders = semanticIds.map(() => '?').join(',');
-                const stmt         = GraphService.db.storage.db.prepare(`
-                    SELECT
-                        n.id,
-                        n.data,
-                        COALESCE((
-                            SELECT SUM(json_extract(e.data, '$.properties.weight'))
-                            FROM Edges e
-                            WHERE e.target = n.id AND e.type != 'BLOCKS'
-                        ), 0.0) as struct_score
-                    FROM Nodes n
-                    WHERE (json_extract(n.data, '$.properties.state') = 'OPEN' OR json_extract(n.data, '$.state') = 'OPEN')
-                      AND n.id IN (${placeholders})
-                `);
+                const semanticResults = await graphColl.query({
+                    queryEmbeddings: [frontierEmbedding],
+                    nResults       : requestedWidth,
+                    where          : {type: {'$in': ['ISSUE', 'DISCUSSION']}}
+                });
 
-                const results = stmt.all(...semanticIds);
-                scoringStats.sqliteOpenMatches = results.length;
+                if (semanticResults?._degraded) {
+                    throw new Error(semanticResults._degradedReason || 'Graph semantic query returned a degraded envelope')
+                }
 
-                for (const row of results) {
-                    const issueId = row.id;
+                const
+                    rawIds       = Array.isArray(semanticResults?.ids?.[0]) ? semanticResults.ids[0] : [],
+                    rawDistances = Array.isArray(semanticResults?.distances?.[0]) ? semanticResults.distances[0] : [];
 
-                    // Guarantee graph topology is completely loaded into RAM BEFORE executing cold-cache resistant queries natively!
-                    GraphService.db.getAdjacentNodes(issueId, 'both');
-                    const rawStructScore = parseFloat(row.struct_score) || 0;
+                if (rawIds.length !== rawDistances.length) {
+                    throw new Error(`Graph semantic query returned ${rawIds.length} ids but ${rawDistances.length} distances`)
+                }
+                if (rawDistances.some(distance => typeof distance !== 'number' || !Number.isFinite(distance) || distance < 0)) {
+                    throw new Error('Graph semantic query returned a non-finite, non-numeric, or negative distance')
+                }
 
-                    // #14659 fail-open parent-inheritance (ticket-ref-ok: owning-leaf anchor): a cold-start (~0)
-                    // leaf inherits alpha * its parent-epic structural weight, so tree-filed leaves are visible to
-                    // the normal formula, not just the fallback. Non-cold-start scores pass through untouched, so
-                    // the base route is preserved. Reuses the verified getIssueStructuralWeight query for the parent.
-                    let struct_score = rawStructScore;
-                    if (rawStructScore <= STRUCTURAL_COLD_START_EPSILON) {
-                        const parentEdge = GraphService.db.edges.getByIndex('target', issueId).find(e => e.type === 'PARENT_OF');
-                        if (parentEdge) {
-                            struct_score = inheritParentStructuralWeight({
-                                structuralWeight      : rawStructScore,
-                                parentStructuralWeight: getIssueFocusStructuralWeight(parentEdge.source)
+                const seenIds = new Set();
+                rawIds.forEach((id, index) => {
+                    if (typeof id === 'string' && id.length > 0 && !seenIds.has(id)) {
+                        seenIds.add(id);
+                        semanticIds.push(id);
+                        semanticDistances.push(rawDistances[index])
+                    }
+                });
+
+                scoringStats.semanticUniqueCandidates = semanticIds.length;
+                scoringStats.semanticReturnedCandidates = rawIds.length;
+            } catch (e) {
+                logger.warn('[GoldenPathSynthesizer] Failed to query semantic vectors from ChromaDB.', e);
+                routeFailure = this.constructor.buildFailureOutcome('semantic-query-failed', e);
+                scoringStats.candidateAdmissionStopReason = 'semantic-query-failed';
+                break
+            }
+
+            const attemptScoredNodes                  = [];
+            const attemptTypeGateRejections           = [];
+            const attemptDiscussionLivenessRejections = [];
+            const attemptStats                        = {
+                semanticCandidates          : semanticIds.length,
+                sqliteOpenMatches           : 0,
+                blockedCandidates           : 0,
+                nonActionableCandidates     : 0,
+                discussionLivenessRejections: 0
+            };
+
+            try {
+                if (semanticIds.length > 0) {
+                    const resultById = new Map();
+
+                    for (let offset = 0; offset < semanticIds.length; offset += SQLITE_ID_CHUNK_SIZE) {
+                        const
+                            idChunk      = semanticIds.slice(offset, offset + SQLITE_ID_CHUNK_SIZE),
+                            placeholders = idChunk.map(() => '?').join(','),
+                            stmt         = GraphService.db.storage.db.prepare(`
+                                SELECT n.id, n.data
+                                FROM Nodes n
+                                WHERE (json_extract(n.data, '$.properties.state') = 'OPEN' OR json_extract(n.data, '$.state') = 'OPEN')
+                                  AND n.id IN (${placeholders})
+                            `);
+
+                        stmt.all(...idChunk).forEach(row => resultById.set(row.id, row))
+                    }
+
+                    // Preserve semantic prefix order after chunked SQLite hydration.
+                    for (const issueId of semanticIds) {
+                        const row = resultById.get(issueId);
+                        if (!row) continue;
+                        let   nodeData = null;
+                        try { nodeData = JSON.parse(row.data); } catch (e) {}
+                        nodeData ||= {id: issueId};
+
+                        // One cache-loading, RLS-safe projection owns direct support, blockers, and parent facts.
+                        // Operational failures throw into this pass's fail-loud mapping boundary.
+                        const structuralSupport = GraphService.getInboundStructuralSupport({id: issueId});
+                        if (!structuralSupport) continue;
+                        attemptStats.sqliteOpenMatches++;
+
+                        if (structuralSupport.hasOpenBlocker) {
+                            attemptStats.blockedCandidates++;
+                            continue
+                        }
+
+                        if (!this.constructor.isActionableComputedRecommendation(nodeData)) {
+                            attemptStats.nonActionableCandidates++;
+                            attemptTypeGateRejections.push({
+                                nodeId         : issueId,
+                                rejectionBucket: this.constructor.getComputedRecommendationExclusionLabels(nodeData)
                             });
+                            continue
                         }
-                    }
 
-                    let nodeData = null;
-                    try { nodeData = JSON.parse(row.data); } catch (e) { }
-
-                    // Re-verify blocker topology natively using GraphService API
-                    const blockers       = GraphService.db.edges.getByIndex('target', issueId).filter(e => e.type === 'BLOCKS');
-                    const openBlockerIds = [];
-                    let   isBlocked      = false;
-
-                    for (const bEdge of blockers) {
-                        const blockerNode = GraphService.db.nodes.get(bEdge.source);
-                        if (blockerNode && (blockerNode.properties?.state === 'OPEN' || blockerNode.state === 'OPEN')) {
-                            isBlocked = true;
-                            openBlockerIds.push(bEdge.source);
-                            break;
+                        const liveness = this.constructor.evaluateDiscussionLiveness(nodeData, structuralSupport.decayingWeight);
+                        if (!liveness.eligible) {
+                            attemptStats.discussionLivenessRejections++;
+                            attemptDiscussionLivenessRejections.push({
+                                nodeId         : issueId,
+                                rejectionBucket: liveness.rejectionBucket,
+                                stage          : DISCUSSION_LIVENESS_REJECTION_STAGE
+                            });
+                            continue
                         }
+
+                        const rawStructScore = structuralSupport.totalWeight;
+                        let   struct_score   = rawStructScore;
+
+                        // Parent inheritance can lift an ISSUE score, but never supplies the decaying
+                        // support used by the Discussion-liveness decision above.
+                        if (
+                            issueId.startsWith('issue-') &&
+                            rawStructScore <= STRUCTURAL_COLD_START_EPSILON &&
+                            structuralSupport.parentId
+                        ) {
+                            const parentSupport = GraphService.getInboundStructuralSupport({id: structuralSupport.parentId});
+                            if (parentSupport) {
+                                struct_score = inheritParentStructuralWeight({
+                                    structuralWeight      : rawStructScore,
+                                    parentStructuralWeight: parentSupport.totalWeight
+                                })
+                            }
+                        }
+
+                        const index             = semanticIds.indexOf(issueId);
+                        const semantic_distance = semanticDistances[index];
+
+                        // Lower distance = Higher significance. (Add 0.1 to avoid div by 0 and curb massive asymptotes)
+                        const semanticScore = 1.0 / (semantic_distance + 0.1);
+                        const priority      = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
+
+                        attemptScoredNodes.push({
+                            node      : nodeData,
+                            score     : priority,
+                            semantic  : semanticScore,
+                            structural: struct_score
+                        })
                     }
-
-                    if (isBlocked) {
-                        scoringStats.blockedCandidates++;
-                        continue; // Architecturally blocked issues cannot be Golden
-                    }
-
-                    const idx               = semanticIds.indexOf(issueId);
-                    const semantic_distance = parseFloat(semanticDistances[idx]) || 0.1;
-
-                    // Lower distance = Higher significance. (Add 0.1 to avoid div by 0 and curb massive asymptotes)
-                    const semanticScore = 1.0 / (semantic_distance + 0.1);
-
-                    const priority = (semanticScore * SEMANTIC_WEIGHT) + (struct_score * STRUCTURAL_WEIGHT);
-
-                    if (!this.constructor.isActionableComputedRecommendation(nodeData || {id: issueId})) {
-                        scoringStats.nonActionableCandidates++;
-                        // AC3 evidence: record which exclusion labels made this candidate non-actionable
-                        // (the shared bucket authority), for the type-gate disposition window.
-                        typeGateRejections.push({
-                            nodeId         : issueId,
-                            rejectionBucket: this.constructor.getComputedRecommendationExclusionLabels(nodeData || {id: issueId})
-                        });
-                        logger.debug(`[GoldenPathSynthesizer] Skipping non-actionable computed recommendation: ${issueId}`);
-                        continue;
-                    }
-
-                    scoredNodes.push({
-                        node      : nodeData || { id: issueId },
-                        score     : priority,
-                        semantic  : semanticScore,
-                        structural: struct_score
-                    });
                 }
             } catch (e) {
                 logger.warn('[GoldenPathSynthesizer] Error executing hybrid mapping across local Graph Store.', e);
                 routeFailure = this.constructor.buildFailureOutcome('graph-store-mapping-failed', e);
+                scoringStats.candidateAdmissionStopReason = 'graph-store-mapping-failed';
+                break
             }
+
+            const corpusExhausted      = scoringStats.semanticReturnedCandidates < requestedWidth;
+            const renderableCount      = attemptScoredNodes.filter(node => node.score > -5000).length;
+            const renderLimitSatisfied = renderableCount >= admissionTarget;
+
+            if (renderLimitSatisfied || corpusExhausted) {
+                scoredNodes                  = attemptScoredNodes;
+                typeGateRejections           = attemptTypeGateRejections;
+                discussionLivenessRejections = attemptDiscussionLivenessRejections;
+                Object.assign(scoringStats, attemptStats, {
+                    semanticCorpusExhausted     : corpusExhausted,
+                    candidateAdmissionStopReason: renderLimitSatisfied ? 'render-limit-satisfied' : 'semantic-corpus-exhausted'
+                });
+                admissionDone = true;
+            } else if (requestedWidth >= admissionCeiling) {
+                const message = `Adaptive candidate admission reached its safe width ${admissionCeiling}` +
+                    ` without ${admissionTarget} unique admissible candidates or verified exhaustion.`;
+                scoredNodes                  = attemptScoredNodes;
+                typeGateRejections           = attemptTypeGateRejections;
+                discussionLivenessRejections = attemptDiscussionLivenessRejections;
+                Object.assign(scoringStats, attemptStats, {semanticCorpusExhausted: false});
+                routeFailure = this.constructor.buildFailureOutcome('candidate-admission-budget-exhausted', message);
+                scoringStats.candidateAdmissionStopReason = 'candidate-admission-budget-exhausted';
+            } else {
+                requestedWidth = Math.min(requestedWidth * 2, admissionCeiling)
+            }
+        }
+
+        if (!routeFailure && scoringStats.semanticCandidates === 0) {
+            logger.info('[GoldenPathSynthesizer] No semantic nodes found. Golden path empty.');
         }
 
         // Sort descending by calculated priority
         scoredNodes.sort((a, b) => b.score - a.score);
 
         // Remove mathematically rejected targets (Negative ROI), then slice
-        const topNodes = routeFailure ? [] : scoredNodes.filter(n => n.score > -5000).slice(0, aiConfig.goldenPathTopNodeRenderLimit);
+        const topNodes = routeFailure ? [] : scoredNodes.filter(n => n.score > -5000).slice(0, admissionTarget);
 
         let currentFocusCandidates = [];
         if (repoEnrichmentEnabled) {
@@ -1064,10 +1189,12 @@ class GoldenPathSynthesizer extends Base {
             })
         }
 
-        // AC3: record the actionability type-gate's rejections (the SECOND filter point) into a sibling ledger in
-        // the same runtime dir — the evidence window the 42.2%-type-gate disposition decides against. No-ops
-        // on an empty pass; fail-open inside the method; reuses the route-attribution dir + retention leaves.
-        await this.constructor.recordTypeGateRejections(typeGateRejections, now, {
+        // Record the FINAL adaptive pass's actionability + Discussion-liveness rejections once into the
+        // existing stage-discriminated sibling ledger. Provisional widening passes never write evidence.
+        await this.constructor.recordTypeGateRejections([
+            ...typeGateRejections,
+            ...discussionLivenessRejections
+        ], now, {
             dir         : aiConfig.goldenPathRouteAttributionLedgerDir,
             maxEvents   : aiConfig.goldenPathRouteAttributionLedgerMaxEvents,
             triggerBytes: aiConfig.goldenPathRouteAttributionLedgerPruneTriggerBytes
@@ -1486,12 +1613,14 @@ DO NOT output markdown, \`\`\`json blocks, or any other explanations. Provide pu
             ...routeFailure,
             wroteHandoff    : true,
             selectedTopNodes: scoringStats.selectedTopNodes,
-            prunedGuideEdges: scoringStats.prunedGuideEdges
+            prunedGuideEdges: scoringStats.prunedGuideEdges,
+            scoringStats
         } : {
             status          : 'completed',
             wroteHandoff    : true,
             selectedTopNodes: scoringStats.selectedTopNodes,
-            prunedGuideEdges: scoringStats.prunedGuideEdges
+            prunedGuideEdges: scoringStats.prunedGuideEdges,
+            scoringStats
         };
     }
 }

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -978,11 +978,25 @@ class GoldenPathSynthesizer extends Base {
                 }
 
                 const
-                    rawIds       = Array.isArray(semanticResults?.ids?.[0]) ? semanticResults.ids[0] : [],
-                    rawDistances = Array.isArray(semanticResults?.distances?.[0]) ? semanticResults.distances[0] : [];
+                    idsEnvelope       = semanticResults?.ids,
+                    distancesEnvelope = semanticResults?.distances;
+
+                if (!Array.isArray(idsEnvelope) || idsEnvelope.length !== 1 || !Array.isArray(idsEnvelope[0])) {
+                    throw new Error('Graph semantic query returned an invalid ids envelope; expected exactly one nested query-result array')
+                }
+                if (!Array.isArray(distancesEnvelope) || distancesEnvelope.length !== 1 || !Array.isArray(distancesEnvelope[0])) {
+                    throw new Error('Graph semantic query returned an invalid distances envelope; expected exactly one nested query-result array')
+                }
+
+                const
+                    rawIds       = idsEnvelope[0],
+                    rawDistances = distancesEnvelope[0];
 
                 if (rawIds.length !== rawDistances.length) {
                     throw new Error(`Graph semantic query returned ${rawIds.length} ids but ${rawDistances.length} distances`)
+                }
+                if (rawIds.some(id => typeof id !== 'string' || id.trim().length === 0)) {
+                    throw new Error('Graph semantic query returned a non-string or empty id')
                 }
                 if (rawDistances.some(distance => typeof distance !== 'number' || !Number.isFinite(distance) || distance < 0)) {
                     throw new Error('Graph semantic query returned a non-finite, non-numeric, or negative distance')
@@ -990,7 +1004,7 @@ class GoldenPathSynthesizer extends Base {
 
                 const seenIds = new Set();
                 rawIds.forEach((id, index) => {
-                    if (typeof id === 'string' && id.length > 0 && !seenIds.has(id)) {
+                    if (!seenIds.has(id)) {
                         seenIds.add(id);
                         semanticIds.push(id);
                         semanticDistances.push(rawDistances[index])
@@ -1132,8 +1146,6 @@ class GoldenPathSynthesizer extends Base {
                 const message = `Adaptive candidate admission reached its safe width ${admissionCeiling}` +
                     ` without ${admissionTarget} unique admissible candidates or verified exhaustion.`;
                 scoredNodes                  = attemptScoredNodes;
-                typeGateRejections           = attemptTypeGateRejections;
-                discussionLivenessRejections = attemptDiscussionLivenessRejections;
                 Object.assign(scoringStats, attemptStats, {semanticCorpusExhausted: false});
                 routeFailure = this.constructor.buildFailureOutcome('candidate-admission-budget-exhausted', message);
                 scoringStats.candidateAdmissionStopReason = 'candidate-admission-budget-exhausted';

--- a/ai/services/graph/GoldenPathSynthesizer.mjs
+++ b/ai/services/graph/GoldenPathSynthesizer.mjs
@@ -353,6 +353,20 @@ class GoldenPathSynthesizer extends Base {
     }
 
     /**
+     * @summary Normalizes the configured route-render limit into the positive integer required by
+     * adaptive candidate admission. Invalid and non-positive values fail safe to one candidate.
+     * @param {*} value Resolved route-render limit.
+     * @returns {Number}
+     */
+    static normalizeAdmissionTarget(value) {
+        const numericValue = Number(value);
+
+        return Number.isFinite(numericValue) && numericValue > 0
+            ? Math.max(1, Math.floor(numericValue))
+            : 1
+    }
+
+    /**
      * @summary Delegates routing-conflict focus detection to `computedGoldenPathRouting.mjs`.
      * @param {Object} candidate Current Focus candidate.
      * @returns {Boolean}
@@ -919,13 +933,11 @@ class GoldenPathSynthesizer extends Base {
             semanticCorpusExhausted     : false,
             candidateAdmissionStopReason: null
         };
-        const SEMANTIC_WEIGHT   = 2.0;
-        const STRUCTURAL_WEIGHT = 1.0;
-        const admissionTarget   = Number.isFinite(Number(aiConfig.goldenPathTopNodeRenderLimit)) && Number(aiConfig.goldenPathTopNodeRenderLimit) > 0
-            ? Math.max(1, Math.floor(Number(aiConfig.goldenPathTopNodeRenderLimit)))
-            : 1;
-        let routeFailure       = null;
-        let semanticCorpusSize = null;
+        const SEMANTIC_WEIGHT    = 2.0;
+        const STRUCTURAL_WEIGHT  = 1.0;
+        const admissionTarget    = this.constructor.normalizeAdmissionTarget(aiConfig.goldenPathTopNodeRenderLimit);
+        let   routeFailure       = null;
+        let   semanticCorpusSize = null;
 
         try {
             if (typeof graphColl.count === 'function') {

--- a/ai/services/graph/computedGoldenPathRouting.mjs
+++ b/ai/services/graph/computedGoldenPathRouting.mjs
@@ -1,3 +1,4 @@
+import {normalizeDiscussionRoutingProjection}                    from '../github-workflow/shared/discussionRoutingDisposition.mjs';
 import {normalizeLabels}                                         from './issueFocusSections.mjs';
 import {formatGoldenPathCapturedAt as formatGoldenPathTimestamp} from './goldenPathTimestamp.mjs';
 
@@ -60,6 +61,61 @@ export function getComputedRecommendationExclusionLabels(nodeData) {
 }
 
 /**
+ * @summary Returns the typed source projection for a Discussion, failing closed to `undetermined`
+ * for legacy/malformed graph rows.
+ * @param {Object} nodeData Parsed graph node payload.
+ * @returns {String} `active | terminal | undetermined`.
+ */
+export function getDiscussionRoutingDisposition(nodeData) {
+    const properties = nodeData?.properties || nodeData || {};
+    const projection = normalizeDiscussionRoutingProjection({
+        schemaVersion: properties.routingDispositionSchemaVersion,
+        disposition  : properties.routingDisposition,
+        reasonCode   : properties.routingDispositionReason,
+        evidence     : properties.routingDispositionEvidence
+    });
+
+    return projection.disposition
+}
+
+/**
+ * @summary Resolves the steerable graph node type from explicit metadata or the canonical id
+ * prefix used by legacy graph rows.
+ * @param {Object} nodeData Parsed graph node payload.
+ * @returns {String}
+ */
+function getComputedRecommendationNodeType(nodeData) {
+    const explicit = String(nodeData?.type || nodeData?.properties?.type || '').toUpperCase();
+    if (explicit) return explicit;
+
+    const nodeId = String(nodeData?.id || '');
+    if (nodeId.startsWith('discussion-')) return 'DISCUSSION';
+    if (nodeId.startsWith('issue-')) return 'ISSUE';
+    return ''
+}
+
+/**
+ * @summary Applies the Discussion-liveness gate without turning lifecycle facts into score or
+ * contaminating the preceding actionability type/label gate.
+ * @param {Object} nodeData Parsed graph node payload.
+ * @param {Number} [decayingWeight=0] Current RLS-visible, non-protected inbound support.
+ * @returns {{eligible: Boolean, rejectionBucket: String[]}}
+ */
+export function evaluateDiscussionLiveness(nodeData, decayingWeight = 0) {
+    const nodeType = getComputedRecommendationNodeType(nodeData);
+    if (nodeType !== 'DISCUSSION') return {eligible: true, rejectionBucket: []};
+
+    const disposition = getDiscussionRoutingDisposition(nodeData);
+
+    if (disposition === 'active') return {eligible: true, rejectionBucket: []};
+    if (disposition === 'terminal') return {eligible: false, rejectionBucket: ['terminal']};
+
+    return Number.isFinite(decayingWeight) && decayingWeight > 0
+        ? {eligible: true, rejectionBucket: []}
+        : {eligible: false, rejectionBucket: ['undetermined-no-decaying-support']}
+}
+
+/**
  * @summary Determines whether a graph node can be an immediate computed recommendation.
  *
  * The Computed Golden Path is an execution steering surface. ISSUE (work-to-do) and
@@ -73,7 +129,7 @@ export function getComputedRecommendationExclusionLabels(nodeData) {
  */
 export function isActionableComputedRecommendation(nodeData) {
     const nodeId   = String(nodeData?.id || '');
-    const nodeType = String(nodeData?.type || nodeData?.properties?.type || '').toUpperCase();
+    const nodeType = getComputedRecommendationNodeType(nodeData);
 
     // ISSUE = work-to-do, DISCUSSION = an open convergence-to-drive; both are execution-steerable.
     if (nodeType && nodeType !== 'ISSUE' && nodeType !== 'DISCUSSION') return false;
@@ -263,6 +319,10 @@ export function renderComputedGoldenPathContradictionSection({
         `- Active incident/release focus candidates: ${focusRefs}`,
         `- Contradictory computed candidates filtered: ${blockedRefs}`,
         `- Semantic candidates: ${count(stats.semanticCandidates)}`,
+        `- Semantic query passes: ${count(stats.semanticQueryPasses)}`,
+        `- Final requested semantic width: ${count(stats.semanticQueryRequestedWidth)}`,
+        `- Semantic corpus exhausted: ${stats.semanticCorpusExhausted === true}`,
+        `- Candidate admission stop: ${stats.candidateAdmissionStopReason || 'unknown'}`,
         `- SQLite OPEN matches: ${count(stats.sqliteOpenMatches)}`,
         `- Scored actionable candidates: ${count(stats.scoredCandidates)}`,
         `- Selected routed nodes: ${count(stats.selectedTopNodes)}`,
@@ -297,9 +357,14 @@ export function renderComputedGoldenPathEmptySection(stats = {}, capturedAt = ne
         'No actionable computed recommendations survived the current Tri-Vector filter pass.',
         '',
         `- Semantic candidates: ${count(stats.semanticCandidates)}`,
+        `- Semantic query passes: ${count(stats.semanticQueryPasses)}`,
+        `- Final requested semantic width: ${count(stats.semanticQueryRequestedWidth)}`,
+        `- Semantic corpus exhausted: ${stats.semanticCorpusExhausted === true}`,
+        `- Candidate admission stop: ${stats.candidateAdmissionStopReason || 'unknown'}`,
         `- SQLite OPEN matches: ${count(stats.sqliteOpenMatches)}`,
         `- Blocked candidates filtered: ${count(stats.blockedCandidates)}`,
         `- Non-actionable candidates filtered: ${count(stats.nonActionableCandidates)}`,
+        `- Discussion-liveness candidates filtered: ${count(stats.discussionLivenessRejections)}`,
         `- Scored actionable candidates: ${count(stats.scoredCandidates)}`,
         `- Selected top nodes: ${count(stats.selectedTopNodes)}`,
         `- Stale frontier GUIDES pruned: ${count(stats.prunedGuideEdges)}`,
@@ -361,6 +426,9 @@ export function renderComputedGoldenPathFailureSection({
         `- Reason: \`${reasonCode}\``,
         `- Error: \`${error}\``,
         `- Semantic candidates: ${count(stats.semanticCandidates)}`,
+        `- Semantic query passes: ${count(stats.semanticQueryPasses)}`,
+        `- Final requested semantic width: ${count(stats.semanticQueryRequestedWidth)}`,
+        `- Candidate admission stop: ${stats.candidateAdmissionStopReason || 'unknown'}`,
         `- SQLite OPEN matches: ${count(stats.sqliteOpenMatches)}`,
         `- Scored actionable candidates: ${count(stats.scoredCandidates)}`,
         `- Selected routed nodes: ${count(stats.selectedTopNodes)}`,

--- a/ai/services/graph/typeGateRejectionLedgerStore.mjs
+++ b/ai/services/graph/typeGateRejectionLedgerStore.mjs
@@ -1,16 +1,21 @@
-import {readRouteAttributionLedger} from './routeAttributionLedgerStore.mjs';
+import {stat, writeFile} from 'fs/promises';
+import {
+    appendRouteAttribution,
+    getRouteAttributionLedgerFilePath,
+    readRouteAttributionLedger
+} from './routeAttributionLedgerStore.mjs';
 
 /**
  * @module ai/services/graph/typeGateRejectionLedgerStore
- * @summary Durable append-only ledger for the computed-Golden-Path **actionability type-gate**
- * rejections — the live per-run record of which computed candidates the `isActionableComputedRecommendation`
- * gate rejected (visibility-only nodes: `epic` / `not-code-ready` / …) and under which exclusion labels.
- * It is the SECOND filter point in the GP scoring pipeline, distinct from the routing-contradiction guard
+ * @summary Durable append-only ledger for computed-Golden-Path candidate-admission rejections.
+ * One physical stream carries stage-discriminated actionability and Discussion-liveness rows while
+ * stage-aware read/fold/query defaults preserve the existing actionability-only view.
+ * It is distinct from the routing-contradiction guard
  * the `routeAttributionLedgerStore` records: the guard filters candidates that CONTRADICT the current focus,
- * this gate rejects candidates that are structurally NON-ACTIONABLE. Keeping the two as sibling ledgers (one
- * runtime dir + the shared append/read/prune I/O + retention machinery, distinct filenames + record shapes)
- * lets the downstream 42.2%-type-gate disposition read exactly the type-gate window without
- * stage-filtering a mixed stream. Records carry an explicit `stage` so a merged analysis stays self-describing.
+ * these admission gates reject candidates before scoring. Keeping the two as sibling ledgers (one
+ * runtime dir + shared low-level append/read I/O, distinct filenames + record shapes) lets the downstream
+ * disposition query either gate without cross-contamination. This store specializes pruning because its one
+ * physical file carries two independently retained stage views.
  *
  * The producer (the emit at the gate's real filter point) lives in `GoldenPathSynthesizer`; this module owns
  * the filename + record `stage` + the queryable fold (`summarize`/`query`) the disposition reads. I/O reuses
@@ -31,28 +36,138 @@ export const TYPE_GATE_REJECTION_FILENAME = 'type-gate-rejection.jsonl';
 export const TYPE_GATE_REJECTION_STAGE = 'actionability-type-gate';
 
 /**
- * @summary Reads all type-gate rejection records (oldest → newest) from the sibling ledger file. Delegates to
+ * @summary Exact stage discriminator for source-lifecycle/decaying-support rejections.
+ * @type {String}
+ */
+export const DISCUSSION_LIVENESS_REJECTION_STAGE = 'discussion-liveness-gate';
+
+const REJECTION_STAGES = new Set([
+    TYPE_GATE_REJECTION_STAGE,
+    DISCUSSION_LIVENESS_REJECTION_STAGE
+]);
+
+/**
+ * @summary Accepts only the two producer-owned candidate-admission stage discriminators.
+ * @param {String} stage
+ * @returns {String|null}
+ */
+function normalizeRejectionStage(stage) {
+    return REJECTION_STAGES.has(stage) ? stage : null
+}
+
+/**
+ * @summary Appends one candidate-admission rejection to the shared physical rejection stream, then applies the
+ * configured retention cap independently to each producer-owned stage. A busy Discussion-liveness producer
+ * therefore cannot evict the actionability evidence that powers the compatibility-default read. The same
+ * `maxEvents` and `triggerBytes` AiConfig leaves remain authoritative; this store owns no defaults.
+ * @param {Object} entry A rejection row with one of the two exact `stage` discriminators.
+ * @param {Object} options
+ * @param {String} options.dir The durable state directory.
+ * @param {Number} [options.now] Epoch ms used to stamp `at` when absent.
+ * @param {Number} [options.triggerBytes] Byte threshold that arms stage-aware pruning.
+ * @param {Number} [options.maxEvents] Per-stage retention cap.
+ * @returns {Promise<String>} The physical ledger file path written to.
+ * @throws {TypeError} when the row has no producer-owned stage.
+ */
+export async function appendTypeGateRejection(entry, {dir, now, triggerBytes, maxEvents} = {}) {
+    if (!entry || typeof entry !== 'object' || !normalizeRejectionStage(entry.stage)) {
+        throw new TypeError('appendTypeGateRejection: entry.stage must be a producer-owned rejection stage')
+    }
+
+    const filePath = await appendRouteAttribution(entry, {
+        dir,
+        filename: TYPE_GATE_REJECTION_FILENAME,
+        now
+    });
+
+    if (Number.isFinite(triggerBytes) && Number.isFinite(maxEvents)) {
+        try {
+            const {size} = await stat(filePath);
+            if (size > triggerBytes) await pruneTypeGateRejectionLedger({dir, maxEvents})
+        } catch (error) {
+            // Observability must not gate synthesis; the next append re-tries the bounded prune.
+        }
+    }
+
+    return filePath
+}
+
+/**
+ * @summary Bounds each producer-owned stage within the one physical rejection stream to its newest `maxEvents`
+ * rows while preserving global append order among retained rows. Invalid-stage rows are discarded during a
+ * rewrite because no reader can treat them as candidate-admission evidence.
+ * @param {Object} options
+ * @param {String} options.dir The durable state directory.
+ * @param {Number} options.maxEvents Per-stage retention cap from the existing AiConfig leaf.
+ * @returns {Promise<{pruned: Number, retained: Number}>} Physical row counts after stage-aware pruning.
+ */
+export async function pruneTypeGateRejectionLedger({dir, maxEvents} = {}) {
+    if (typeof dir !== 'string' || dir.length === 0) {
+        throw new TypeError('pruneTypeGateRejectionLedger: dir is required')
+    }
+    if (!Number.isFinite(maxEvents) || maxEvents < 0) {
+        throw new TypeError(`pruneTypeGateRejectionLedger: a finite, non-negative maxEvents is required (the AiConfig leaf), got ${maxEvents}`)
+    }
+
+    const records  = await readRouteAttributionLedger({dir, filename: TYPE_GATE_REJECTION_FILENAME}),
+          counts   = new Map([...REJECTION_STAGES].map(stage => [stage, 0])),
+          retained = [];
+
+    for (let index = records.length - 1; index >= 0; index--) {
+        const record = records[index],
+              stage  = normalizeRejectionStage(record?.stage);
+
+        if (stage && counts.get(stage) < maxEvents) {
+            counts.set(stage, counts.get(stage) + 1);
+            retained.push(record)
+        }
+    }
+
+    retained.reverse();
+
+    if (retained.length === records.length) {
+        return {pruned: 0, retained: retained.length}
+    }
+
+    const text = retained.length ? `${retained.map(record => JSON.stringify(record)).join('\n')}\n` : '';
+    await writeFile(getRouteAttributionLedgerFilePath(dir, TYPE_GATE_REJECTION_FILENAME), text, 'utf8');
+
+    return {pruned: records.length - retained.length, retained: retained.length}
+}
+
+/**
+ * @summary Reads one exact rejection stage (oldest → newest) from the sibling ledger file. Delegates to
  * the shared shape-agnostic reader with the type-gate filename — same ENOENT-is-empty / corrupt-line-skipped /
  * unreadable-file-throws contract.
  * @param {Object} options
  * @param {String} options.dir The durable state directory (the shared route-attribution ledger dir).
+ * @param {String} [options.stage=TYPE_GATE_REJECTION_STAGE] Exact stage view.
  * @returns {Promise<Object[]>} The parsed records in append order.
  */
-export function readTypeGateRejectionLedger({dir} = {}) {
-    return readRouteAttributionLedger({dir, filename: TYPE_GATE_REJECTION_FILENAME});
+export async function readTypeGateRejectionLedger({dir, stage = TYPE_GATE_REJECTION_STAGE} = {}) {
+    const normalizedStage = normalizeRejectionStage(stage);
+    if (!normalizedStage) return [];
+
+    const records = await readRouteAttributionLedger({dir, filename: TYPE_GATE_REJECTION_FILENAME});
+    return records.filter(record => record?.stage === normalizedStage)
 }
 
 /**
- * @summary Folds a type-gate rejection stream into the queryable evidence surface the type-gate disposition reads:
+ * @summary Folds one stage of a mixed candidate-admission stream into its queryable evidence surface:
  * totals, how often each exclusion label rejected a candidate, and how often each node was rejected. Pure — no
  * I/O; the caller reads the ledger then summarizes. This is the type-gate analog of
  * `summarizeRouteAttributionLedger` (which folds the guard-filter stream's arming reasons + blocked nodes).
- * @param {Object[]} [records=[]] The type-gate rejection records (as read from the ledger).
- * @returns {Object} `{total, byRejectionLabel, rejectedNodeCounts, lastEventAt}`.
+ * @param {Object[]} [records=[]] Mixed-stage rejection records.
+ * @param {Object} [options]
+ * @param {String} [options.stage=TYPE_GATE_REJECTION_STAGE] Exact stage view.
+ * @returns {Object} `{total, byRejectionBucket, byRejectionLabel, rejectedNodeCounts, lastEventAt}`.
  */
-export function summarizeTypeGateRejectionLedger(records = []) {
-    const rows               = Array.isArray(records) ? records : [],
-          byRejectionLabel   = {},
+export function summarizeTypeGateRejectionLedger(records = [], {stage = TYPE_GATE_REJECTION_STAGE} = {}) {
+    const normalizedStage = normalizeRejectionStage(stage),
+          rows            = normalizedStage && Array.isArray(records)
+              ? records.filter(record => record?.stage === normalizedStage)
+              : [],
+          byRejectionBucket  = {},
           rejectedNodeCounts = {};
 
     let lastEventAt = null;
@@ -62,7 +177,7 @@ export function summarizeTypeGateRejectionLedger(records = []) {
 
         for (const label of Array.isArray(record.rejectionBucket) ? record.rejectionBucket : []) {
             if (typeof label === 'string' && label.length > 0) {
-                byRejectionLabel[label] = (byRejectionLabel[label] ?? 0) + 1;
+                byRejectionBucket[label] = (byRejectionBucket[label] ?? 0) + 1;
             }
         }
 
@@ -76,8 +191,9 @@ export function summarizeTypeGateRejectionLedger(records = []) {
     }
 
     return {
-        total: rows.length,
-        byRejectionLabel,
+        total           : rows.length,
+        byRejectionBucket,
+        byRejectionLabel: normalizedStage === TYPE_GATE_REJECTION_STAGE ? {...byRejectionBucket} : {},
         rejectedNodeCounts,
         lastEventAt
     };
@@ -85,7 +201,7 @@ export function summarizeTypeGateRejectionLedger(records = []) {
 
 /**
  * @summary Filters a type-gate rejection stream into a queryable view — the "what was rejected" surface that
- * complements the summarized counts. Pure: restrict by an optional inclusive time window, exclusion labels, and
+ * complements the summarized counts. Pure: restrict by one exact stage plus an optional inclusive time window, rejection buckets, and
  * node ids; returns newest-first (by `at`), capped at `limit`. A non-object record, or one outside a requested
  * time window, is dropped; an untimed record is excluded when a time bound is requested. A record matches a
  * `rejectionLabels` filter when its `rejectionBucket` array intersects the requested set.
@@ -94,17 +210,32 @@ export function summarizeTypeGateRejectionLedger(records = []) {
  * @param {Number} [options.sinceMs] Lower bound (inclusive) on `at`.
  * @param {Number} [options.untilMs] Upper bound (inclusive) on `at`.
  * @param {String[]} [options.rejectionLabels] Restrict to records whose `rejectionBucket` intersects these.
+ * @param {String[]} [options.rejectionBuckets] Generic alias for liveness or actionability buckets.
  * @param {String[]} [options.nodeIds] Restrict to these rejected node ids.
+ * @param {String} [options.stage=TYPE_GATE_REJECTION_STAGE] Exact stage view.
  * @param {Number} [options.limit] Max records returned (newest-first); omitted → all matches.
  * @returns {Object[]} The matching records, newest-first.
  */
-export function queryTypeGateRejectionLedger(records = [], {sinceMs, untilMs, rejectionLabels, nodeIds, limit} = {}) {
-    const rows     = Array.isArray(records) ? records : [],
-          labelSet = Array.isArray(rejectionLabels) && rejectionLabels.length ? new Set(rejectionLabels) : null,
-          nodeSet  = Array.isArray(nodeIds)         && nodeIds.length         ? new Set(nodeIds)         : null;
+export function queryTypeGateRejectionLedger(records = [], {
+    sinceMs,
+    untilMs,
+    rejectionLabels,
+    rejectionBuckets,
+    nodeIds,
+    limit,
+    stage = TYPE_GATE_REJECTION_STAGE
+} = {}) {
+    const normalizedStage = normalizeRejectionStage(stage),
+          rows            = Array.isArray(records) ? records : [],
+          buckets         = Array.isArray(rejectionBuckets) ? rejectionBuckets : rejectionLabels,
+          labelSet        = Array.isArray(buckets) && buckets.length ? new Set(buckets) : null,
+          nodeSet         = Array.isArray(nodeIds)         && nodeIds.length         ? new Set(nodeIds)         : null;
+
+    if (!normalizedStage) return [];
 
     const filtered = rows.filter(record => {
         if (!record || typeof record !== 'object')                                             return false;
+        if (record.stage !== normalizedStage)                                                   return false;
         if (Number.isFinite(sinceMs) && !(Number.isFinite(record.at) && record.at >= sinceMs)) return false;
         if (Number.isFinite(untilMs) && !(Number.isFinite(record.at) && record.at <= untilMs)) return false;
         if (labelSet && !(Array.isArray(record.rejectionBucket) && record.rejectionBucket.some(label => labelSet.has(label)))) return false;

--- a/ai/services/ingestion/IssueIngestor.mjs
+++ b/ai/services/ingestion/IssueIngestor.mjs
@@ -1,19 +1,22 @@
-import fs from 'fs';
-import path from 'path';
+import fs                                        from 'fs';
+import path                                      from 'path';
 import * as yaml                                 from 'js-yaml';
-import {fileURLToPath} from 'url';
-import crypto from 'crypto';
-import Base from '../../../src/core/Base.mjs';
+import {fileURLToPath}                           from 'url';
+import crypto                                    from 'crypto';
+import Base                                      from '../../../src/core/Base.mjs';
 import { Memory_StorageRouter as StorageRouter } from '../../services.mjs';
-import { Memory_GraphService as GraphService } from '../../services.mjs';
-import logger from '../../mcp/server/memory-core/logger.mjs';
-import {IDENTITIES} from '../../graph/identityRoots.mjs';
+import { Memory_GraphService as GraphService }   from '../../services.mjs';
+import logger                                    from '../../mcp/server/memory-core/logger.mjs';
+import {IDENTITIES}                              from '../../graph/identityRoots.mjs';
+import {
+    normalizeDiscussionRoutingProjection as normalizeSourceDiscussionRoutingProjection
+} from '../github-workflow/shared/discussionRoutingDisposition.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
 const loadIndexMap = async (neoRootDir, type) => {
-    const map = new Map();
+    const map       = new Map();
     const typeIndex = path.resolve(neoRootDir, `resources/content/${type}/_index.json`);
     const rootIndex = path.resolve(neoRootDir, 'resources/content/_index.json');
 
@@ -66,6 +69,57 @@ class IssueIngestor extends Base {
     )
 
     /**
+     * @summary Validates the source-owned Discussion routing projection as one atomic tuple. A
+     * missing or malformed field degrades the entire tuple together, so graph/vector consumers
+     * never observe a v1 schema paired with contradictory legacy reason/evidence fields.
+     * @param {Object} meta Parsed synced-Discussion frontmatter.
+     * @returns {{schemaVersion: String, disposition: String, reason: String, evidence: String[]}}
+     */
+    static normalizeDiscussionRoutingProjection(meta = {}) {
+        const normalized = normalizeSourceDiscussionRoutingProjection({
+            schemaVersion: meta.routingDispositionSchemaVersion,
+            disposition  : meta.routingDisposition,
+            reasonCode   : meta.routingDispositionReason,
+            evidence     : meta.routingDispositionEvidence
+        });
+
+        return {
+            schemaVersion: normalized.schemaVersion,
+            disposition  : normalized.disposition,
+            reason       : normalized.reasonCode,
+            evidence     : normalized.evidence
+        }
+    }
+
+    /**
+     * @summary Chooses the canonical source when a Discussion exists in both active and archive
+     * trees during the sync writer's write-before-unlink crash window. GitHub `updatedAt` is the
+     * primary lifecycle clock; the content index and active tree provide deterministic tie-breaks.
+     * @param {Object} candidate Candidate parsed from one synced Markdown file.
+     * @param {Object|null} incumbent Current winner for the same Discussion id.
+     * @returns {Boolean} True when `candidate` must replace `incumbent`.
+     */
+    static isPreferredDiscussionSource(candidate, incumbent) {
+        if (!incumbent) {
+            return true;
+        }
+
+        if (candidate.updatedAtMs !== incumbent.updatedAtMs) {
+            return candidate.updatedAtMs > incumbent.updatedAtMs;
+        }
+
+        if (candidate.isIndexedPath !== incumbent.isIndexedPath) {
+            return candidate.isIndexedPath;
+        }
+
+        if (candidate.isArchived !== incumbent.isArchived) {
+            return !candidate.isArchived;
+        }
+
+        return candidate.filePath.localeCompare(incumbent.filePath) < 0;
+    }
+
+    /**
      * @summary Whether a ticket author qualifies for the community-multiplier boost: true when the
      * author exists, the internal-author registry is non-empty, and the author is not a registered
      * maintainer. The non-empty guard makes an unconfigured deployment degrade safely (multiplier
@@ -108,13 +162,13 @@ class IssueIngestor extends Base {
             return [];
         }
 
-        const files = filesRaw;
-        const openIssues = [];
+        const files        = filesRaw;
+        const openIssues   = [];
         const parsedIssues = [];
 
-        const neoRootDir = path.resolve(__dirname, '../../..');
+        const neoRootDir  = path.resolve(__dirname, '../../..');
         const contentRoot = path.join(neoRootDir, 'resources/content');
-        const indexMap = await loadIndexMap(neoRootDir, 'issues');
+        const indexMap    = await loadIndexMap(neoRootDir, 'issues');
 
         let nodesCollection = null;
         if (StorageRouter) {
@@ -124,25 +178,25 @@ class IssueIngestor extends Base {
         // Pass 1: Upsert all nodes
         for (const filePath of files) {
             const content = await fs.promises.readFile(filePath, 'utf8');
-            const match = content.match(/^---\n([\s\S]*?)\n---/);
+            const match   = content.match(/^---\n([\s\S]*?)\n---/);
             if (match) {
                 try {
                     const meta = yaml.load(match[1]);
                     if (meta && meta.state) {
                         const relativeToContent = path.relative(contentRoot, filePath);
-                        let id = indexMap.get(relativeToContent);
+                        let   id                = indexMap.get(relativeToContent);
                         if (id === undefined) {
                             id = meta.id || path.basename(filePath).replace(/\.md$/, '').replace(/^issue-/, '');
                         }
                         const issueId = 'issue-' + id;
 
                         GraphService.upsertNode({
-                            id: issueId,
-                            type: 'ISSUE',
-                            name: meta.title || issueId,
-                            state: meta.state,
+                            id        : issueId,
+                            type      : 'ISSUE',
+                            name      : meta.title || issueId,
+                            state     : meta.state,
                             properties: {
-                                state: meta.state,
+                                state : meta.state,
                                 labels: Array.isArray(meta.labels) ? meta.labels : []
                             },
                             updatedAt: meta.updatedAt || meta.createdAt
@@ -204,7 +258,7 @@ class IssueIngestor extends Base {
                         let isBlocked = false;
                         if (Array.isArray(meta.blockedBy)) {
                             for (const blocker of meta.blockedBy) {
-                                const blockerId = extractIssueId(blocker);
+                                const blockerId   = extractIssueId(blocker);
                                 const blockerData = parsedIssues.find(p => p.issueId === blockerId);
                                 if (blockerData && blockerData.meta.state === 'OPEN') {
                                     isBlocked = true;
@@ -238,13 +292,13 @@ class IssueIngestor extends Base {
                         }
                     }
 
-                    const body = content.replace(/^---\n[\s\S]*?\n---\n/, '').trim();
+                    const body         = content.replace(/^---\n[\s\S]*?\n---\n/, '').trim();
                     const titleAndBody = `${meta.title}\n\n${body}`;
 
                     // Markdown-Aware Vector Chunking using hash bypass
                     if (nodesCollection) {
-                        const contentHash = crypto.createHash('md5').update(titleAndBody).digest('hex');
-                        let needsEmbedding = true;
+                        const contentHash    = crypto.createHash('md5').update(titleAndBody).digest('hex');
+                        let   needsEmbedding = true;
 
                         try {
                             const existing = await nodesCollection.get({ ids: [issueId], include: ['metadatas'] });
@@ -261,7 +315,7 @@ class IssueIngestor extends Base {
                         if (needsEmbedding) {
                             logger.debug(`[IssueIngestor] Dynamically embedding OPEN issue: ${issueId}`);
                             await nodesCollection.upsert({
-                                ids: [issueId],
+                                ids      : [issueId],
                                 documents: [titleAndBody],
                                 metadatas: [{ hash: contentHash, title: meta.title, type: 'ISSUE' }]
                             });
@@ -270,9 +324,9 @@ class IssueIngestor extends Base {
 
                     openIssues.push({
                         sourceType: 'ISSUE',
-                        issueId: issueId || meta.id || path.basename(filePath).replace(/\.md$/, ''),
-                        createdAt: meta.createdAt,
-                        title: meta.title,
+                        issueId   : issueId || meta.id || path.basename(filePath).replace(/\.md$/, ''),
+                        createdAt : meta.createdAt,
+                        title     : meta.title,
                         body
                     });
                 }
@@ -307,94 +361,129 @@ class IssueIngestor extends Base {
             }
         }
 
-        const neoRootDir = path.resolve(__dirname, '../../..');
+        const neoRootDir  = path.resolve(__dirname, '../../..');
         const contentRoot = path.join(neoRootDir, 'resources/content');
-        const indexMap = await loadIndexMap(neoRootDir, 'discussions');
+        const indexMap    = await loadIndexMap(neoRootDir, 'discussions');
 
-        let nodesCollection = null;
-        try {
-            nodesCollection = await StorageRouter.getGraphCollection();
-        } catch (e) {
-            logger.warn('[IssueIngestor] Could not resolve graph collection via StorageRouter.');
-        }
+        const nodesCollection = await StorageRouter.getGraphCollection();
+        const discussions     = new Map();
 
         for (const filePath of files) {
             const content = await fs.promises.readFile(filePath, 'utf8');
-            const match = content.match(/^---\n([\s\S]*?)\n---/);
-            if (match) {
-                try {
-                    const meta = yaml.load(match[1]);
-                    if (meta) {
-                        const relativeToContent = path.relative(contentRoot, filePath);
-                        let id = indexMap.get(relativeToContent);
-                        if (id === undefined) {
-                            id = meta.number || path.basename(filePath).replace(/\.md$/, '').replace(/^discussion-/, '');
-                        }
-                        const discussionId = `discussion-${id}`;
+            const match   = content.match(/^---\n([\s\S]*?)\n---/);
+            if (!match) {
+                continue;
+            }
 
-                        // DiscussionSyncer emits lifecycle metadata; Golden Path OPEN filtering relies on graph state.
-                        const
-                            closed          = meta.closed === true,
-                            discussionState = closed ? 'CLOSED' : 'OPEN',
-                            closedAt        = closed ? (meta.closedAt || null) : null,
-                            category        = meta.category || 'Ideas';
+            let meta;
+            try {
+                meta = yaml.load(match[1]);
+            } catch (e) {
+                logger.warn(`[IssueIngestor] Failed to parse frontmatter for ${filePath}`, e);
+                continue;
+            }
 
-                        GraphService.upsertNode({
-                            id: discussionId,
-                            type: 'DISCUSSION',
-                            name: meta.title || discussionId,
-                            state: discussionState,
-                            updatedAt: meta.updatedAt || meta.createdAt,
-                            properties: {
-                                state: discussionState,
-                                closed,
-                                closedAt,
-                                category
-                            }
-                        });
+            if (!meta) {
+                continue;
+            }
 
-                        const body = content.replace(/^---\n[\s\S]*?\n---\n/, '').trim();
-                        const titleAndBody = `[DISCUSSION] ${meta.title}\n\n${body}`;
+            const relativeToContent = path.relative(contentRoot, filePath);
+            const indexedId         = indexMap.get(relativeToContent);
+            const id                = indexedId === undefined
+                ? meta.number || path.basename(filePath).replace(/\.md$/, '').replace(/^discussion-/, '')
+                : indexedId;
+            const discussionId = `discussion-${id}`;
+            const updatedAtMs  = Date.parse(meta.updatedAt || meta.createdAt || '') || Number.NEGATIVE_INFINITY;
+            const candidate    = {
+                content,
+                discussionId,
+                filePath,
+                isArchived   : relativeToContent.startsWith(`archive${path.sep}discussions${path.sep}`),
+                isIndexedPath: indexedId !== undefined,
+                meta,
+                updatedAtMs
+            };
 
-                        if (nodesCollection) {
-                            const
-                                lifecycleFingerprint = JSON.stringify({closed, closedAt, discussionState}),
-                                contentHash = crypto.createHash('md5')
-                                    .update(`${titleAndBody}\n${lifecycleFingerprint}`)
-                                    .digest('hex');
-                            let needsEmbedding = true;
+            if (this.constructor.isPreferredDiscussionSource(candidate, discussions.get(discussionId))) {
+                discussions.set(discussionId, candidate);
+            }
+        }
 
-                            try {
-                                const existing = await nodesCollection.get({ ids: [discussionId], include: ['metadatas'] });
-                                if (existing && existing.ids.length > 0) {
-                                    const exMeta = existing.metadatas[0] || {};
-                                    if (exMeta.hash === contentHash) {
-                                        needsEmbedding = false;
-                                    }
-                                }
-                            } catch (e) {}
+        for (const {content, discussionId, meta} of discussions.values()) {
+            // DiscussionSyncer emits lifecycle metadata; Golden Path OPEN filtering relies on graph state.
+            const
+                closed                          = meta.closed === true,
+                discussionState                 = closed ? 'CLOSED' : 'OPEN',
+                closedAt                        = closed ? (meta.closedAt || null) : null,
+                category                        = meta.category || 'Ideas',
+                routingProjection               = this.constructor.normalizeDiscussionRoutingProjection(meta),
+                routingDispositionSchemaVersion = routingProjection.schemaVersion,
+                routingDisposition              = routingProjection.disposition,
+                routingDispositionReason        = routingProjection.reason,
+                routingDispositionEvidence      = routingProjection.evidence;
 
-                            if (needsEmbedding) {
-                                logger.debug(`[IssueIngestor] Dynamically embedding DISCUSSION: ${discussionId}`);
-                                await nodesCollection.upsert({
-                                    ids: [discussionId],
-                                    documents: [titleAndBody],
-                                    metadatas: [{
-                                        hash: contentHash,
-                                        title: meta.title,
-                                        type: 'DISCUSSION',
-                                        state: discussionState,
-                                        closed,
-                                        closedAt,
-                                        category
-                                    }]
-                                });
-                            }
-                        }
-                    }
-                } catch (e) {
-                    logger.warn(`[IssueIngestor] Failed to parse frontmatter for ${filePath}`, e);
+            GraphService.upsertNode({
+                id        : discussionId,
+                type      : 'DISCUSSION',
+                name      : meta.title || discussionId,
+                state     : discussionState,
+                updatedAt : meta.updatedAt || meta.createdAt,
+                properties: {
+                    state: discussionState,
+                    closed,
+                    closedAt,
+                    category,
+                    routingDispositionSchemaVersion,
+                    routingDisposition,
+                    routingDispositionReason,
+                    routingDispositionEvidence
                 }
+            });
+
+            const body         = content.replace(/^---\n[\s\S]*?\n---\n/, '').trim();
+            const titleAndBody = `[DISCUSSION] ${meta.title}\n\n${body}`;
+            const
+                lifecycleFingerprint = JSON.stringify({
+                    closed,
+                    closedAt,
+                    discussionState,
+                    routingDispositionSchemaVersion,
+                    routingDisposition,
+                    routingDispositionReason,
+                    routingDispositionEvidence
+                }),
+                contentHash = crypto.createHash('md5')
+                    .update(`${titleAndBody}\n${lifecycleFingerprint}`)
+                    .digest('hex');
+            let needsEmbedding = true;
+
+            const existing = await nodesCollection.get({ ids: [discussionId], include: ['metadatas'] });
+            if (existing && existing.ids.length > 0) {
+                const exMeta = existing.metadatas[0] || {};
+                if (exMeta.hash === contentHash) {
+                    needsEmbedding = false;
+                }
+            }
+
+            if (needsEmbedding) {
+                logger.debug(`[IssueIngestor] Dynamically embedding DISCUSSION: ${discussionId}`);
+                await nodesCollection.upsert({
+                    ids      : [discussionId],
+                    documents: [titleAndBody],
+                    metadatas: [{
+                        hash                      : contentHash,
+                        title                     : meta.title,
+                        type                      : 'DISCUSSION',
+                        state                     : discussionState,
+                        closed,
+                        closedAt,
+                        category,
+                        routingDispositionSchemaVersion,
+                        routingDisposition,
+                        routingDispositionReason,
+                        routingDispositionEvidence: JSON.stringify(routingDispositionEvidence)
+                    }]
+                });
             }
         }
     }
@@ -422,19 +511,19 @@ class IssueIngestor extends Base {
             }
         }
 
-        const neoRootDir = path.resolve(__dirname, '../../..');
+        const neoRootDir  = path.resolve(__dirname, '../../..');
         const contentRoot = path.join(neoRootDir, 'resources/content');
-        const indexMap = await loadIndexMap(neoRootDir, 'pulls');
+        const indexMap    = await loadIndexMap(neoRootDir, 'pulls');
 
         for (const filePath of files) {
             const content = fs.readFileSync(filePath, 'utf8');
-            const match = content.match(/^---\n([\s\S]*?)\n---/);
+            const match   = content.match(/^---\n([\s\S]*?)\n---/);
             if (match) {
                 try {
                     const meta = yaml.load(match[1]);
                     if (meta) {
                         const relativeToContent = path.relative(contentRoot, filePath);
-                        let id = indexMap.get(relativeToContent);
+                        let   id                = indexMap.get(relativeToContent);
                         if (id === undefined) {
                             id = meta.number || path.basename(filePath).replace(/\.md$/, '').replace(/^pr-/, '');
                         }
@@ -442,10 +531,10 @@ class IssueIngestor extends Base {
 
                         // Upsert the PR node structurally
                         GraphService.upsertNode({
-                            id: prId,
-                            type: 'PULL_REQUEST',
-                            name: meta.title || prId,
-                            state: meta.state,
+                            id       : prId,
+                            type     : 'PULL_REQUEST',
+                            name     : meta.title || prId,
+                            state    : meta.state,
                             updatedAt: meta.updatedAt || meta.createdAt
                         });
 
@@ -454,7 +543,7 @@ class IssueIngestor extends Base {
                         for (const line of lines) {
                             const gapMatch = line.match(/\[(KB_GAP|TOOLING_GAP|RETROSPECTIVE)\](.*?)$/);
                             if (gapMatch) {
-                                const gapType = gapMatch[1]; // KB_GAP, TOOLING_GAP, RETROSPECTIVE
+                                const gapType    = gapMatch[1]; // KB_GAP, TOOLING_GAP, RETROSPECTIVE
                                 const gapContent = gapMatch[2].replace(/^[\`\*:\s]+/, '').trim();
 
                                 if (!gapContent) continue;

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -70,7 +70,7 @@ function isValidGraphNodeId(id) {
     return typeof id === 'string' && id.length > 0;
 }
 
-const PROTECTED_EDGE_TYPES = Object.freeze([
+export const PROTECTED_EDGE_TYPES = Object.freeze([
     'ADVANCED_BY',   // business layer: goal→work advancement is history, never scent; zombie-priority is handled by explicit retirement reweight (ai/graph/businessSchema.mjs), not decay
     'ATTRIBUTED_TO', // direction layer: motion→direction attribution is measurement substrate — a velocity number built on decaying edges rots invisibly; fact-class per the direction contract (ai/graph/directionSchema.mjs)
     'IMPLEMENTS',
@@ -78,6 +78,7 @@ const PROTECTED_EDGE_TYPES = Object.freeze([
     'SYSTEM_TENET',
     'RESOLVES'
 ]);
+const PROTECTED_EDGE_TYPE_SET = new Set(PROTECTED_EDGE_TYPES);
 
 /**
  * @summary Service that manages the SQLite Knowledge Graph (Nodes and Edges).
@@ -660,6 +661,11 @@ class GraphService extends Base {
         `);
         const info = pruneStmt.run(...PROTECTED_EDGE_TYPES, pruningThreshold);
 
+        // The bulk SQL above bypasses Database's Store mutation path. Consume its SQLite-triggered
+        // invalidation delta before the clock upsert acknowledges local mutations; otherwise the
+        // acknowledgement advances lastSyncId past the changed edges and RAM keeps pre-decay weights.
+        this.db.syncCache();
+
         // Commit global clock update
         this.upsertGlobalNode({
             id        : '_SYSTEM_STATE',
@@ -880,6 +886,79 @@ class GraphService extends Base {
             return { in_degree: inCount, out_degree: outCount };
         } catch (e) {
             return { in_degree: 0, out_degree: 0 };
+        }
+    }
+
+    /**
+     * @summary Returns one RLS-safe inbound-support projection for Golden Path scoring and
+     * Discussion liveness. Total support preserves existing structural scoring; decaying support
+     * excludes protected fact edges and Golden Path's own `frontier → GUIDES` output so archaeology
+     * or a prior route cannot masquerade as current swarm motion. The same visible inbound projection
+     * exposes open-blocker and parent facts, keeping admission and cold-start inheritance cache-safe.
+     *
+     * Root, source node, and edge must all be visible at the cache return boundary. `BLOCKS`,
+     * non-positive, and non-finite weights contribute to neither projection. A missing edge weight
+     * retains the graph's established default of 1.
+     *
+     * @param {Object} data
+     * @param {String} data.id Graph node id.
+     * @returns {{totalWeight: Number, decayingWeight: Number, totalEdgeCount: Number, decayingEdgeCount: Number, hasOpenBlocker: Boolean, parentId: String|null}|null}
+     * @throws {Error} When the graph store cannot load or project the candidate topology.
+     */
+    getInboundStructuralSupport({id} = {}) {
+        if (!isValidGraphNodeId(id) || !this.db) return null;
+
+        try {
+            this.db.getAdjacentNodes(id, 'both');
+
+            const
+                rlsUserId = resolveRlsUserId(this.db.storage?.RequestContextService),
+                rootNode  = this.db.nodes.get(id);
+
+            if (!rootNode || !isRlsVisible(rootNode, rlsUserId)) return null;
+
+            const support = {
+                totalWeight      : 0,
+                decayingWeight   : 0,
+                totalEdgeCount   : 0,
+                decayingEdgeCount: 0,
+                hasOpenBlocker   : false,
+                parentId         : null
+            };
+
+            for (const edge of this.db.edges.getByIndex('target', id)) {
+                const sourceNode = this.db.nodes.get(edge.source);
+
+                if (!isRlsVisible(sourceNode, rlsUserId) || !isRlsVisible(edge, rlsUserId)) continue;
+
+                if (edge.type === 'BLOCKS') {
+                    const sourceState = sourceNode.properties?.state ?? sourceNode.state;
+                    if (sourceState === 'OPEN') support.hasOpenBlocker = true;
+                    continue
+                }
+
+                if (edge.type === 'PARENT_OF' && support.parentId === null) {
+                    support.parentId = edge.source
+                }
+
+                const weight = Number(edge.properties?.weight ?? 1);
+                if (!Number.isFinite(weight) || weight <= 0) continue;
+
+                support.totalWeight += weight;
+                support.totalEdgeCount++;
+
+                const isGoldenPathOutput = edge.type === 'GUIDES' && edge.source === 'frontier';
+                if (!PROTECTED_EDGE_TYPE_SET.has(edge.type) && !isGoldenPathOutput) {
+                    support.decayingWeight += weight;
+                    support.decayingEdgeCount++
+                }
+
+            }
+
+            return support
+        } catch (error) {
+            logger.warn(`[GraphService] getInboundStructuralSupport failed for ${id}:`, error?.message ?? error);
+            throw error
         }
     }
 

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamServiceGoldenPath.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamServiceGoldenPath.spec.mjs
@@ -15,26 +15,27 @@ setup({
     }
 });
 
-import {test, expect}  from '@playwright/test';
-import Neo             from '../../../../../../../src/Neo.mjs';
-import * as core       from '../../../../../../../src/core/_export.mjs';
-import InstanceManager from '../../../../../../../src/manager/Instance.mjs';
-import path            from 'path';
-import {fileURLToPath} from 'url';
-import crypto          from 'crypto';
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../../src/core/_export.mjs';
+import InstanceManager       from '../../../../../../../src/manager/Instance.mjs';
+import path                  from 'path';
+import {fileURLToPath}       from 'url';
+import crypto                from 'crypto';
 import {TestLifecycleHelper} from '../../../services/memory-core/util.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
 test.describe('DreamService Golden Path', () => {
-    let TextEmbeddingService, aiConfig, DreamService, GraphService, SystemLifecycleService;
+    let TextEmbeddingService, aiConfig, DreamService, GraphService, OpenAiCompatible, StorageRouter, SystemLifecycleService;
+    let originalGenerate;
 
     test.beforeAll(async () => {
         aiConfig = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
 
-        const os         = await import('os');
-        const fs         = await import('fs');
+        const os     = await import('os');
+        const fs     = await import('fs');
         const tmpDir = path.resolve(process.cwd(), 'tmp');
         if (!fs.existsSync(tmpDir)) {
             fs.mkdirSync(tmpDir, { recursive: true });
@@ -49,6 +50,8 @@ test.describe('DreamService Golden Path', () => {
         TextEmbeddingService = (await import('../../../../../../../ai/services/memory-core/TextEmbeddingService.mjs')).default;
         DreamService         = (await import('../../../../../../../ai/daemons/orchestrator/services/DreamService.mjs')).default;
         GraphService         = (await import('../../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        OpenAiCompatible     = (await import('../../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        StorageRouter        = (await import('../../../../../../../ai/services/memory-core/managers/StorageRouter.mjs')).default;
         SystemLifecycleService = (await import('../../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
 
         if (fs.existsSync(testDbPath)) {
@@ -57,6 +60,10 @@ test.describe('DreamService Golden Path', () => {
 
         // Mock TextEmbeddingService to return an array of 4096 floats for Qwen3 compatibility
         TextEmbeddingService.embedText = async () => new Array(4096).fill(0.1);
+        originalGenerate = OpenAiCompatible.prototype.generate;
+        OpenAiCompatible.prototype.generate = async () => ({
+            content: JSON.stringify({strategic_brief: 'Bounded Dream Golden Path synthesis.'})
+        });
 
         if (!SystemLifecycleService._initPromise) { await SystemLifecycleService.initAsync(); } else { await SystemLifecycleService.ready(); }
     });
@@ -65,9 +72,10 @@ test.describe('DreamService Golden Path', () => {
         const fs         = await import('fs');
         const testDbPath = aiConfig.storagePaths.graph;
 
+        OpenAiCompatible.prototype.generate = originalGenerate;
         await TestLifecycleHelper.cleanupGraphService(GraphService, SystemLifecycleService, testDbPath, fs, 'clear');
 
-        const tmpDir     = path.resolve(process.cwd(), 'tmp');
+        const tmpDir      = path.resolve(process.cwd(), 'tmp');
         const mockHandoff = path.join(tmpDir, 'mock_sandman_handoff.md');
         if (fs.existsSync(mockHandoff)) {
             try {fs.unlinkSync(mockHandoff);} catch (e) {}
@@ -78,8 +86,41 @@ test.describe('DreamService Golden Path', () => {
         test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: synthesis-write race post-#10940 engine=hybrid fix (#10946)');
         test.setTimeout(60000);
 
-        await DreamService.ingestIssueStates();
-        await DreamService.synthesizeGoldenPath();
+        const originalGetGraphCollection = StorageRouter.getGraphCollection;
+        let   capturedWhere              = null;
+
+        // Seed one bounded real SQLite + Chroma candidate. Scanning and embedding the repository's
+        // ever-growing live issue corpus made this synthesis test scale with backlog size; dedicated
+        // IssueIngestor tests own that separate contract.
+        const issueId = 'issue-dream-golden-path-fixture';
+
+        GraphService.upsertNode({
+            id        : issueId,
+            type      : 'ISSUE',
+            name      : 'Dream Golden Path Fixture',
+            state     : 'OPEN',
+            properties: {state: 'OPEN', labels: ['enhancement']}
+        });
+
+        // Keep the vector boundary hermetic. A shared Chroma collection can contain unrelated
+        // ISSUE vectors and let this test pass even when the fixture is never selected.
+        StorageRouter.getGraphCollection = async () => ({
+            count: async () => 1,
+            query: async ({where}) => {
+                capturedWhere = where;
+
+                return {
+                    ids      : [[issueId]],
+                    distances: [[0.1]]
+                }
+            }
+        });
+
+        try {
+            await DreamService.synthesizeGoldenPath();
+        } finally {
+            StorageRouter.getGraphCollection = originalGetGraphCollection
+        }
 
         const topology = await GraphService.getContextFrontier();
         expect(topology).not.toBeNull();
@@ -87,10 +128,11 @@ test.describe('DreamService Golden Path', () => {
 
         const openIssues = GraphService.db.nodes.items.filter(n => (n.label === 'ISSUE' || n.type === 'ISSUE') && n.properties?.state === 'OPEN');
 
-        expect(openIssues.length).toBeGreaterThan(0);
+        expect(openIssues.map(issue => issue.id)).toContain(issueId);
+        expect(capturedWhere).toEqual({type: {'$in': ['ISSUE', 'DISCUSSION']}});
 
-        // There should be GUIDES edges out of frontier
+        // The exact fixture must be guided; an unrelated shared-vector candidate cannot satisfy this oracle.
         const guides = topology.strategicNeighbors.filter(n => n.relationship === 'GUIDES');
-        expect(guides.length).toBeGreaterThan(0);
+        expect(guides.map(node => node.id)).toEqual([issueId]);
     });
 });

--- a/test/playwright/unit/ai/graph/Database.spec.mjs
+++ b/test/playwright/unit/ai/graph/Database.spec.mjs
@@ -100,6 +100,19 @@ test.describe('Neo.ai.graph.Database', () => {
         }
     });
 
+    test('should own requester-scoped vicinity markers through the Neo class lifecycle', () => {
+        const markers = db.vicinityLoadedNodes;
+
+        expect(markers).toBeInstanceOf(Neo.core.Base);
+        expect(markers.className).toBe('Neo.ai.graph.RequestScopedVicinitySet');
+        expect(markers.scopeResolver).toBeInstanceOf(Function);
+
+        db.destroy();
+        db = null;
+
+        expect(markers.isDestroyed).toBe(true)
+    });
+
     test('should add and retrieve a node correctly', async () => {
         db.addNode({ id: 'node1', label: 'Person', properties: { name: 'Alice' } });
 
@@ -412,7 +425,7 @@ test.describe('Neo.ai.graph.Database', () => {
     });
 
     test('should rollback remove-by-key node removal without TypeError on string.Symbol assignment (#11595)', async () => {
-        // Regression #11595: GraphMaintenanceService apoptosis pass called
+        // Regression: GraphMaintenanceService apoptosis pass called
         // GraphService.removeNodes(['CONCEPT:foo', ...]) inside a transaction; on rollback, the
         // mutate event payload's removedItems contained STRING IDs (not actual node objects)
         // because Collection.Base.splice() emitted `toRemoveArray || removedItems` — the INPUT
@@ -451,11 +464,10 @@ test.describe('Neo.ai.graph.Database', () => {
     });
 
     test('should rollback remove-by-key edge removal without TypeError (#11595)', async () => {
-        // Sibling regression #11595: same shape-mismatch class on the edge-removal path.
+        // Sibling regression: same shape-mismatch class on the edge-removal path.
         // `Database.removeEdge(edgeId)` flows STRING IDs through the mutate event. Rollback must
-        // restore the edge as an OBJECT without TypeError on string.Symbol assignment. Per #11595
-        // AC explicit requirement (caught by @neo-gpt PR #11611 Cycle 1 review): "Edge rollback
-        // remains covered; removing edges by string ID must not regress."
+        // restore the edge as an OBJECT without TypeError on string.Symbol assignment. The paired
+        // edge rollback path must remain covered; removing edges by string ID must not regress.
         let dbEdgeRollback = Neo.create(Database, { id: 'graph-edge-rollback-test' });
 
         dbEdgeRollback.addNode({ id: 'A', label: 'src' });
@@ -489,7 +501,7 @@ test.describe('Neo.ai.graph.Database', () => {
     test('Collection.splice mutate-event removedItems is always object-shaped, regardless of remove-by-key vs remove-by-object input (#11595)', async () => {
         // Direct contract test: the mutate event payload's removedItems must be the locally-built
         // actual-removed-objects array, not the input keys. V-B-A on consumer impact across the
-        // 5 mutate-event listeners in the codebase (per @neo-gpt PR #11611 Cycle 1 review):
+        // five mutate-event listeners in the codebase:
         // 2 require object-shape (Database.onEdgesMutate + onNodesMutate); 3 are payload-neutral
         // or shape-flexible (Collection.Base.onMutate forwards via splice which handles both,
         // Data.Store.onCollectionMutate uses only addedItems, Grid.Container.onColumnsMutate
@@ -637,11 +649,11 @@ test.describe('Neo.ai.graph.Database', () => {
         // Instance A adds a new edge between the nodes
         dbA.addEdge({ id: 'edge-xy', source: 'node-x', target: 'node-y', type: 'LINKS' });
 
-        // Without the #10260 fix, dbB.syncCache() would remove the edge ID from delta,
+        // Without endpoint invalidation, dbB.syncCache() would remove the edge ID from delta,
         // but it wouldn't clear 'node-x' or 'node-y' from vicinityLoadedNodes.
         dbB.syncCache();
 
-        // With #10260, they should no longer be marked as loaded
+        // With endpoint invalidation, they should no longer be marked as loaded
         expect(dbB.vicinityLoadedNodes.has('node-x')).toBe(false);
         expect(dbB.vicinityLoadedNodes.has('node-y')).toBe(false);
 

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -86,10 +86,10 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
             }
         });
 
-        const metadata = {discussions: {}};
-        const stats = await DiscussionSyncer.syncDiscussions(metadata);
+        const metadata   = {discussions: {}};
+        const stats      = await DiscussionSyncer.syncDiscussions(metadata);
         const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-24001.md');
-        const index = await fs.readJson(path.join(tmpRoot, '_index.json'));
+        const index      = await fs.readJson(path.join(tmpRoot, '_index.json'));
 
         expect(stats.synced).toEqual([24001]);
         await expect(fs.pathExists(targetPath)).resolves.toBe(true);
@@ -105,6 +105,80 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         const content = await fs.readFile(targetPath, 'utf8');
         expect(content).toMatch(/^closed: false$/m);
         expect(content).toMatch(/^closedAt: null$/m);
+        expect(content).toMatch(/^routingDispositionSchemaVersion: discussion-routing-disposition\.v1$/m);
+        expect(content).toMatch(/^routingDisposition: undetermined$/m);
+        expect(content).toMatch(/^routingDispositionReason: untrusted-or-unclassified-root-author$/m);
+    });
+
+    test('projects trusted lifecycle markers into typed source-owned routing frontmatter', async () => {
+        const discussion = buildDiscussion(24007, {category: 'Ideas'});
+        discussion.author = {login: 'neo-gpt'};
+        discussion.body   = 'OQ1 [RESOLVED_TO_AC]\nOQ2 [OQ_RESOLUTION_PENDING]';
+
+        GraphqlService.query = async () => ({
+            repository: {
+                discussions: {
+                    nodes   : [discussion],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        await DiscussionSyncer.syncDiscussions({discussions: {}});
+
+        const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-24007.md');
+        const parsed     = matter(await fs.readFile(targetPath, 'utf8'));
+
+        expect(parsed.data).toMatchObject({
+            routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+            routingDisposition             : 'active',
+            routingDispositionReason       : 'explicit-active-marker',
+            routingDispositionEvidence     : ['marker:OQ_RESOLUTION_PENDING']
+        })
+    });
+
+    test('keeps comments and truncated comment pages outside the root-body lifecycle authority', async () => {
+        const discussion = buildDiscussion(24008, {
+            category: 'Ideas',
+            comments: {
+                nodes: [{
+                    author   : {login: 'external-commenter'},
+                    body     : '[GRADUATED_TO_TICKET: #99999]',
+                    createdAt: '2026-05-02T01:00:00Z',
+                    replies  : {nodes: []}
+                }, {
+                    author   : {login: 'neo-gpt'},
+                    body     : '[OQ_RESOLUTION_PENDING] trusted comment only',
+                    createdAt: '2026-05-02T02:00:00Z',
+                    replies  : {nodes: []}
+                }],
+                pageInfo: {hasNextPage: true, endCursor: 'truncated-after-50'}
+            }
+        });
+        discussion.author = {login: 'neo-gpt'};
+        discussion.body   = 'Marker-free authoritative root body.';
+
+        GraphqlService.query = async () => ({
+            repository: {
+                discussions: {
+                    nodes   : [discussion],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        await DiscussionSyncer.syncDiscussions({discussions: {}});
+
+        const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-24008.md');
+        const parsed     = matter(await fs.readFile(targetPath, 'utf8'));
+
+        expect(parsed.content).toContain('[GRADUATED_TO_TICKET: #99999]');
+        expect(parsed.content).toContain('[OQ_RESOLUTION_PENDING] trusted comment only');
+        expect(parsed.data).toMatchObject({
+            routingDisposition        : 'undetermined',
+            routingDispositionReason  : 'no-authoritative-lifecycle-marker',
+            routingDispositionEvidence: []
+        })
     });
 
     test('fetches accepted-answer flags for comments and replies', () => {
@@ -148,7 +222,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         await DiscussionSyncer.syncDiscussions({discussions: {}});
 
         const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-24003.md');
-        const content = await fs.readFile(targetPath, 'utf8');
+        const content    = await fs.readFile(targetPath, 'utf8');
 
         expect(content).toContain([
             '### `@neo-answer` commented on 2026-05-02T01:00:00Z',
@@ -196,7 +270,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         await DiscussionSyncer.syncDiscussions({discussions: {}});
 
         const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-24005.md');
-        const content = await fs.readFile(targetPath, 'utf8');
+        const content    = await fs.readFile(targetPath, 'utf8');
 
         expect(content).toContain([
             '### `@neo-parent` commented on 2026-05-02T01:00:00Z',
@@ -213,7 +287,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
 
     test('sync write-boundary defangs untrusted discussion bodies, comments, and replies before local markdown persistence (#13691)', async () => {
         const discussionNumber = 24006;
-        const discussion = buildDiscussion(discussionNumber, {
+        const discussion       = buildDiscussion(discussionNumber, {
             comments: {nodes: [{
                 id       : 'DC_external',
                 author   : {login: 'external-commenter'},
@@ -285,7 +359,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         await DiscussionSyncer.syncDiscussions({discussions: {}});
 
         const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-24004.md');
-        const content = await fs.readFile(targetPath, 'utf8');
+        const content    = await fs.readFile(targetPath, 'utf8');
 
         expect(content).toContain('Regular discussion comment.');
         expect(content).not.toContain('> [!ANSWER]');
@@ -306,10 +380,10 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
             }
         });
 
-        const metadata = {discussions: {}};
-        const stats = await DiscussionSyncer.syncDiscussions(metadata);
+        const metadata   = {discussions: {}};
+        const stats      = await DiscussionSyncer.syncDiscussions(metadata);
         const targetPath = path.join(aiConfig.issueSync.archiveRoot, 'discussions', 'v13.0.0', 'chunk-1', 'discussion-24002.md');
-        const index = await fs.readJson(path.join(tmpRoot, '_index.json'));
+        const index      = await fs.readJson(path.join(tmpRoot, '_index.json'));
 
         expect(stats.synced).toEqual([24002]);
         await expect(fs.pathExists(targetPath)).resolves.toBe(true);
@@ -412,7 +486,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         aiConfig.issueSync.discussionDenylist = {numbers: [25002], authors: []};
 
         const metadata = {discussions: {}};
-        const stats = await DiscussionSyncer.syncDiscussions(metadata);
+        const stats    = await DiscussionSyncer.syncDiscussions(metadata);
 
         const allowedPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-25001.md');
         const deniedPath  = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-25002.md');
@@ -441,7 +515,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
 
         aiConfig.issueSync.discussionDenylist = {numbers: [], authors: ['astroturf-account']};
 
-        const stats = await DiscussionSyncer.syncDiscussions({discussions: {}});
+        const stats      = await DiscussionSyncer.syncDiscussions({discussions: {}});
         const deniedPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-25003.md');
 
         expect(stats.synced).toEqual([]);
@@ -522,7 +596,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
 
         aiConfig.issueSync.discussionDenylist = {numbers: [], authors: []};
 
-        const stats = await DiscussionSyncer.syncDiscussions({discussions: {}});
+        const stats      = await DiscussionSyncer.syncDiscussions({discussions: {}});
         const targetPath = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-25005.md');
 
         expect(stats.synced).toEqual([25005]);
@@ -575,7 +649,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
 
     test('refetchDiscussionsByNumber skips a discussion that no longer exists on GitHub (#13794)', async () => {
         const discussionNumber = 24051;
-        const metadata = {discussions: {}};
+        const metadata         = {discussions: {}};
 
         GraphqlService.query = async () => ({repository: {discussion: null}});
 
@@ -596,7 +670,7 @@ function buildDiscussion(number, config = {}) {
 
     return {
         number,
-        title: `Discussion ${number}`,
+        title    : `Discussion ${number}`,
         body     : 'Discussion body',
         closed,
         closedAt,

--- a/test/playwright/unit/ai/services/github-workflow/discussionRoutingDisposition.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/discussionRoutingDisposition.spec.mjs
@@ -40,6 +40,78 @@ test.describe('discussionRoutingDisposition', () => {
         })
     });
 
+    test('ignores terminal markers inside non-authoritative sections while preserving current active authority', () => {
+        for (const nonAuthoritativeHeading of [
+            '## History',
+            '## Historical decisions',
+            '## Retrospective',
+            '## Archive',
+            '## Archived decisions',
+            '## Examples',
+            '## Instruction',
+            '## Instructions',
+            '## Instructional syntax',
+            '## How-to',
+            '## Usage',
+            '## Signal Ledger (archived — nothing graduated)'
+        ]) {
+            const result = classifyDiscussionRoutingDisposition({
+                author: 'neo-gpt',
+                body  : [
+                    nonAuthoritativeHeading,
+                    '[SUPERSEDED] prior direction',
+                    '### Prior-cycle detail',
+                    '[GRADUATED_TO_TICKET: #1] historical result',
+                    '## Current status',
+                    '[CONVERGING] work continues'
+                ].join('\n')
+            });
+
+            expect(result, nonAuthoritativeHeading).toEqual({
+                schemaVersion: 'discussion-routing-disposition.v1',
+                disposition  : 'active',
+                reasonCode   : 'explicit-active-marker',
+                evidence     : ['marker:CONVERGING']
+            })
+        }
+    });
+
+    test('restores lifecycle authority after leaving a historical section', () => {
+        expect(findLifecycleMarkers([
+            '## Historical decisions',
+            '[SUPERSEDED] prior direction',
+            '### Current status inside the historical subtree',
+            '[DECLINED] still historical',
+            '## Current status',
+            '[CONVERGING] current direction'
+        ].join('\n'))).toEqual(['CONVERGING']);
+
+        expect(classifyDiscussionRoutingDisposition({
+            author: 'neo-gpt',
+            body  : [
+                '### Examples',
+                '[SUPERSEDED] syntax example',
+                '## [SUPERSEDED] current whole-Discussion status'
+            ].join('\n')
+        })).toMatchObject({
+            disposition: 'terminal',
+            reasonCode : 'terminal-marker:superseded'
+        })
+    });
+
+    test('does not let fenced or quoted headings suppress current terminal authority', () => {
+        for (const body of [
+            '```md\n## Historical decisions\n```\n[SUPERSEDED] current status',
+            '> ## Historical decisions\n[SUPERSEDED] current status',
+            '## Current status\n[SUPERSEDED] current status'
+        ]) {
+            expect(classifyDiscussionRoutingDisposition({author: 'neo-gpt', body}), body).toMatchObject({
+                disposition: 'terminal',
+                reasonCode : 'terminal-marker:superseded'
+            })
+        }
+    });
+
     test('keeps partially resolved scope active and never infers whole-Discussion terminal state from one resolved OQ', () => {
         const partial = classifyDiscussionRoutingDisposition({
             author: 'neo-gpt',

--- a/test/playwright/unit/ai/services/github-workflow/discussionRoutingDisposition.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/discussionRoutingDisposition.spec.mjs
@@ -1,0 +1,194 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import {
+    classifyDiscussionRoutingDisposition,
+    findLifecycleMarkers,
+    normalizeDiscussionRoutingProjection
+} from '../../../../../../ai/services/github-workflow/shared/discussionRoutingDisposition.mjs';
+
+test.describe('discussionRoutingDisposition', () => {
+    test('classifies explicit trusted convergence and evergreen signals as active', () => {
+        for (const marker of ['CONVERGING', 'GRADUATION_PROPOSED', 'OQ_RESOLUTION_PENDING', 'EVERGREEN', 'REVALIDATED']) {
+            const result = classifyDiscussionRoutingDisposition({
+                author: 'neo-gpt',
+                body  : `[${marker}] live scope`,
+                closed: false
+            });
+
+            expect(result).toMatchObject({
+                disposition: 'active',
+                reasonCode : 'explicit-active-marker'
+            });
+            expect(result.evidence).toContain(`marker:${marker}`)
+        }
+    });
+
+    test('gives explicit terminal state precedence over older active signals', () => {
+        const result = classifyDiscussionRoutingDisposition({
+            author: 'neo-gpt',
+            body  : [
+                '[CONVERGING] prior cycle',
+                '[GRADUATED_TO_TICKET: #15100]'
+            ].join('\n')
+        });
+
+        expect(result).toEqual({
+            schemaVersion: 'discussion-routing-disposition.v1',
+            disposition  : 'terminal',
+            reasonCode   : 'graduated-to-ticket',
+            evidence     : ['marker:GRADUATED_TO_TICKET']
+        })
+    });
+
+    test('keeps partially resolved scope active and never infers whole-Discussion terminal state from one resolved OQ', () => {
+        const partial = classifyDiscussionRoutingDisposition({
+            author: 'neo-gpt',
+            body  : 'OQ1 [RESOLVED_TO_AC]\nOQ2 [OQ_RESOLUTION_PENDING]'
+        });
+        const resolved = classifyDiscussionRoutingDisposition({
+            author: 'neo-gpt',
+            body  : 'OQ1 [RESOLVED_TO_AC]'
+        });
+
+        expect(partial.disposition).toBe('active');
+        expect(resolved).toMatchObject({
+            disposition: 'undetermined',
+            reasonCode : 'resolved-scope-without-terminal-signal'
+        })
+    });
+
+    test('ignores quoted and fenced marker examples while accepting canonical author update annotations', () => {
+        expect(findLifecycleMarkers('> [GRADUATED_TO_TICKET: #1] historical quote')).toEqual([]);
+        expect(findLifecycleMarkers('```md\n[GRADUATED_TO_TICKET: #1]\n```')).toEqual([]);
+        expect(findLifecycleMarkers('Previously [GRADUATION_PROPOSED], now withdrawn.')).toEqual([]);
+        expect(findLifecycleMarkers('> **Update 2026-05-20 (Cycle-4 — `[GRADUATION_PROPOSED]`):** quorum remains open.'))
+            .toContain('GRADUATION_PROPOSED');
+        expect(classifyDiscussionRoutingDisposition({
+            author: 'neo-gpt',
+            body  : '> **Update 2026-07-12:** [GRADUATED_TO_TICKET: #15100]'
+        })).toMatchObject({
+            disposition: 'terminal',
+            reasonCode : 'graduated-to-ticket'
+        });
+        expect(classifyDiscussionRoutingDisposition({
+            author: 'neo-gpt',
+            body  : '> **Update 2026-07-12:** [DECLINED] superseded by evidence.'
+        })).toMatchObject({
+            disposition: 'terminal',
+            reasonCode : 'terminal-marker:declined'
+        });
+        expect(findLifecycleMarkers('**Status:** [GRADUATED_TO_TICKET: #15100] — shipped.'))
+            .toContain('GRADUATED_TO_TICKET')
+    });
+
+    test('preserves canonical legacy graduation callouts from the live corpus', () => {
+        for (const number of [10289, 14456]) {
+            const content = fs.readFileSync(`resources/content/discussions/chunk-1/discussion-${number}.md`, 'utf8');
+            const author  = content.match(/^author:\s*([^\n]+)$/m)?.[1]?.trim();
+            const body    = content.replace(/^---\n[\s\S]*?\n---\n/, '').split(/\n## Comments\s*\n/)[0];
+            const result  = classifyDiscussionRoutingDisposition({author, body});
+
+            expect(result, `discussion-${number}`).toMatchObject({
+                disposition: 'terminal',
+                reasonCode : 'graduated-to-ticket'
+            })
+        }
+
+        expect(findLifecycleMarkers('> **GRADUATED** is only an example without a dated destination.')).toEqual([])
+    });
+
+    test('preserves the canonical partially-open corpus shapes', () => {
+        for (const number of [13378, 11690]) {
+            const content = fs.readFileSync(`resources/content/discussions/chunk-1/discussion-${number}.md`, 'utf8');
+            const author  = content.match(/^author:\s*([^\n]+)$/m)?.[1]?.trim();
+            const body    = content.replace(/^---\n[\s\S]*?\n---\n/, '').split(/\n## Comments\s*\n/)[0];
+            const result  = classifyDiscussionRoutingDisposition({author, body});
+
+            expect(result.disposition, `discussion-${number}`).toBe('active')
+        }
+    });
+
+    test('does not promote marker syntax examples or untrusted authored markers', () => {
+        expect(findLifecycleMarkers('This Discussion graduates when it can emit `[GRADUATED_TO_TICKET]`.')).toEqual([]);
+        expect(findLifecycleMarkers([
+            '```md',
+            '~~~',
+            '[GRADUATED_TO_TICKET: #9]',
+            '```'
+        ].join('\n'))).toEqual([]);
+
+        for (const body of [
+            'Do not set [GRADUATION_PROPOSED]; quorum failed.',
+            'This is not [EVERGREEN].',
+            'Use [REVALIDATED] after rechecking.',
+            'Valid lifecycle states include [CONVERGING] and [EVERGREEN].',
+            'The marker [GRADUATION_PROPOSED] is recognized by tooling.'
+        ]) {
+            expect(classifyDiscussionRoutingDisposition({author: 'neo-gpt', body}), body).toMatchObject({
+                disposition: 'undetermined',
+                reasonCode : 'no-authoritative-lifecycle-marker'
+            })
+        }
+
+        expect(classifyDiscussionRoutingDisposition({
+            author: 'neo-gpt',
+            body  : 'Status: [OQ_RESOLUTION_PENDING].'
+        }).disposition).toBe('active');
+        expect(classifyDiscussionRoutingDisposition({
+            author: 'neo-gpt',
+            body  : '[SUPERSEDED] replaced by newer authority.'
+        })).toMatchObject({
+            disposition: 'terminal',
+            reasonCode : 'terminal-marker:superseded'
+        });
+
+        const external = classifyDiscussionRoutingDisposition({
+            author: 'external-contributor',
+            body  : '[GRADUATION_PROPOSED]\n[GRADUATED_TO_TICKET: #9]'
+        });
+
+        expect(external).toMatchObject({
+            disposition: 'undetermined',
+            reasonCode : 'untrusted-or-unclassified-root-author'
+        })
+    });
+
+    test('treats GitHub closure as terminal even when marker provenance is unavailable', () => {
+        const result = classifyDiscussionRoutingDisposition({closed: true});
+
+        expect(result).toEqual({
+            schemaVersion: 'discussion-routing-disposition.v1',
+            disposition  : 'terminal',
+            reasonCode   : 'github-closed',
+            evidence     : ['github:closed']
+        })
+    });
+
+    test('leaves comment touches and marker-free open Discussions undetermined', () => {
+        const result = classifyDiscussionRoutingDisposition({
+            author   : 'neo-gpt',
+            body     : 'Open-ended exploration without a lifecycle marker.',
+            closed   : false,
+            updatedAt: '2099-01-01T00:00:00Z'
+        });
+
+        expect(result).toMatchObject({
+            disposition: 'undetermined',
+            reasonCode : 'no-authoritative-lifecycle-marker'
+        })
+    });
+
+    test('normalizes type-valid but contradictory persisted tuples to legacy undetermined', () => {
+        expect(normalizeDiscussionRoutingProjection({
+            schemaVersion: 'discussion-routing-disposition.v1',
+            disposition  : 'active',
+            reasonCode   : 'github-closed',
+            evidence     : ['marker:GRADUATED_TO_TICKET']
+        })).toEqual({
+            schemaVersion: 'discussion-routing-disposition.legacy',
+            disposition  : 'undetermined',
+            reasonCode   : 'legacy-or-invalid-projection',
+            evidence     : []
+        })
+    })
+});

--- a/test/playwright/unit/ai/services/github-workflow/discussionRoutingDisposition.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/discussionRoutingDisposition.spec.mjs
@@ -99,6 +99,34 @@ test.describe('discussionRoutingDisposition', () => {
         })
     });
 
+    test('treats Setext historical and instructional subtrees as non-authoritative, then restores authority', () => {
+        for (const body of [
+            [
+                'History',
+                '-------',
+                '[SUPERSEDED] historical only',
+                'Current status',
+                '--------------',
+                '[CONVERGING] current direction'
+            ].join('\n'),
+            [
+                'Instructions',
+                '============',
+                '[GRADUATED_TO_TICKET: #1] example only',
+                'Current status',
+                '==============',
+                '[CONVERGING] current direction'
+            ].join('\n')
+        ]) {
+            expect(classifyDiscussionRoutingDisposition({author: 'neo-gpt', body}), body).toEqual({
+                schemaVersion: 'discussion-routing-disposition.v1',
+                disposition  : 'active',
+                reasonCode   : 'explicit-active-marker',
+                evidence     : ['marker:CONVERGING']
+            })
+        }
+    });
+
     test('does not let fenced or quoted headings suppress current terminal authority', () => {
         for (const body of [
             '```md\n## Historical decisions\n```\n[SUPERSEDED] current status',

--- a/test/playwright/unit/ai/services/github-workflow/verifyFrontmatterIntegrity.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/verifyFrontmatterIntegrity.spec.mjs
@@ -6,19 +6,19 @@ import {
 } from '../../../../../../ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs';
 
 /**
- * @summary Coverage for `ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs` —
- * the post-serialization integrity gate authored under #11573.
+ * @summary Coverage for the post-serialization integrity gate in
+ * `ai/services/github-workflow/sync/verifyFrontmatterIntegrity.mjs`.
  *
  * Test axes:
  *
  * 1. Empty / malformed input safety (null content, empty key set).
  * 2. Happy path — full key set present.
  * 3. AC3 failing fixture — synthesized markdown lacking `closed`/`closedAt` (the empirical
- *    bug captured by operator V-B-A 2026-05-18: 0/104 on-disk Discussion files lacked
- *    these keys despite #11554 having merged the frontmatter-emit fix).
+ *    bug captured by operator V-B-A 2026-05-18: 0/104 on-disk Discussion files carried
+ *    these keys despite the frontmatter emitter already claiming to provide them).
  * 4. AC2 allowed fixture — historical/archive-style discussions where `closed: true`
  *    and `closedAt: '<date>'` are both present.
- * 5. Convenience wrapper `verifyDiscussionFrontmatter` requires all 8 Discussion keys.
+ * 5. Convenience wrapper `verifyDiscussionFrontmatter` requires the lifecycle + routing tuple.
  */
 test.describe('ai/services/github-workflow/sync/verifyFrontmatterIntegrity (#11573)', () => {
     test('verifyFrontmatterIntegrity: returns ok=true when all required keys present', () => {
@@ -28,6 +28,10 @@ test.describe('ai/services/github-workflow/sync/verifyFrontmatterIntegrity (#115
             'title: Test',
             'closed: false',
             'closedAt: null',
+            'routingDispositionSchemaVersion: discussion-routing-disposition.v1',
+            'routingDisposition: undetermined',
+            'routingDispositionReason: no-authoritative-lifecycle-marker',
+            'routingDispositionEvidence: []',
             '---',
             'Body.'
         ].join('\n');
@@ -62,9 +66,9 @@ test.describe('ai/services/github-workflow/sync/verifyFrontmatterIntegrity (#115
     });
 
     test('verifyFrontmatterIntegrity: ignores body content (no false-positive on body-line `key:`)', () => {
-        // Body contains a quoted "closed:" line. The frontmatter LACKS `closed:`. Per the
-        // ticket contract + GPT cycle-1 V-B-A on PR #11574 (gray-matter parse, not regex on
-        // whole doc), this MUST report `closed` as missing.
+        // Body contains a quoted "closed:" line. The frontmatter LACKS `closed:`. The
+        // gray-matter contract parses frontmatter rather than the whole document, so this
+        // MUST report `closed` as missing.
         const content = [
             '---',
             'number: 11089',
@@ -79,7 +83,7 @@ test.describe('ai/services/github-workflow/sync/verifyFrontmatterIntegrity (#115
     });
 
     test('verifyFrontmatterIntegrity: regression — body-line literal `closed:` does NOT satisfy missing frontmatter key (GPT V-B-A #11574 cycle-1)', () => {
-        // GPT's empirical false-positive reproduction from PR #11574 cycle-1 review:
+        // Empirical false-positive reproduction from the original review cycle:
         //   content has `closed:` / `closedAt:` only AFTER the closing `---`, not inside
         //   the frontmatter block. The pre-fix regex-on-whole-doc helper falsely reported
         //   {ok:true, missing:[]}. The gray-matter parse correctly reports both keys missing.
@@ -119,6 +123,10 @@ test.describe('ai/services/github-workflow/sync/verifyFrontmatterIntegrity (#115
             'updatedAt: \'2026-05-10T22:54:27Z\'',
             'closed: false',
             'closedAt: null',
+            'routingDispositionSchemaVersion: discussion-routing-disposition.v1',
+            'routingDisposition: undetermined',
+            'routingDispositionReason: no-authoritative-lifecycle-marker',
+            'routingDispositionEvidence: []',
             '---',
             'Body.'
         ].join('\n');
@@ -139,6 +147,11 @@ test.describe('ai/services/github-workflow/sync/verifyFrontmatterIntegrity (#115
             'updatedAt: \'2025-03-04T20:25:15Z\'',
             'closed: true',
             'closedAt: \'2024-08-03T00:00:00Z\'',
+            'routingDispositionSchemaVersion: discussion-routing-disposition.v1',
+            'routingDisposition: terminal',
+            'routingDispositionReason: github-closed',
+            'routingDispositionEvidence:',
+            '  - github:closed',
             '---',
             'Body.'
         ].join('\n');
@@ -150,7 +163,7 @@ test.describe('ai/services/github-workflow/sync/verifyFrontmatterIntegrity (#115
 
     test('verifyDiscussionFrontmatter: catches the #11554 regression — missing closed + closedAt', () => {
         // Empirical anchor: this is the exact frontmatter shape that all 104 on-disk
-        // Discussion markdown files had on 2026-05-18 (operator V-B-A) — pre-#11554 shape.
+        // Discussion markdown files had on 2026-05-18 (operator V-B-A), before the emitter fix.
         const content = [
             '---',
             'number: 11089',
@@ -159,6 +172,10 @@ test.describe('ai/services/github-workflow/sync/verifyFrontmatterIntegrity (#115
             'category: Ideas',
             'createdAt: \'2026-05-10T01:33:43Z\'',
             'updatedAt: \'2026-05-10T22:54:27Z\'',
+            'routingDispositionSchemaVersion: discussion-routing-disposition.v1',
+            'routingDisposition: undetermined',
+            'routingDispositionReason: no-authoritative-lifecycle-marker',
+            'routingDispositionEvidence: []',
             '---',
             'Body.'
         ].join('\n');
@@ -179,6 +196,10 @@ test.describe('ai/services/github-workflow/sync/verifyFrontmatterIntegrity (#115
             'createdAt: \'2026-05-10T01:33:43Z\'',
             'updatedAt: \'2026-05-10T22:54:27Z\'',
             'closed: false',
+            'routingDispositionSchemaVersion: discussion-routing-disposition.v1',
+            'routingDisposition: undetermined',
+            'routingDispositionReason: no-authoritative-lifecycle-marker',
+            'routingDispositionEvidence: []',
             '---',
             'Body.'
         ].join('\n');

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -853,6 +853,609 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(capturedWhere).toEqual({type: {'$in': ['ISSUE', 'DISCUSSION']}})
     });
 
+    test('adaptive admission widens past 20 rejected neighbors and renders the legitimate rank-21 candidate', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const OpenAiCompatible             = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        const originalGenerate             = OpenAiCompatible.prototype.generate;
+        const widths                       = [];
+        const ids                          = Array.from({length: 40}, (_, index) => `issue-${92000 + index}`);
+        const rank21Id                     = ids[20];
+        aiConfig.vectorDimension                = 2;
+        aiConfig.goldenPathTopNodeRenderLimit   = 1;
+
+        ids.forEach((id, index) => GraphService.upsertNode({
+            id,
+            type      : 'ISSUE',
+            properties: {
+                state : 'OPEN',
+                title : index === 20 ? 'Legitimate rank-21 candidate' : `Rejected semantic neighbor ${index + 1}`,
+                labels: index === 20 ? ['bug', 'ai'] : ['not-code-ready', 'ai']
+            }
+        }));
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async ({nResults, where}) => {
+                widths.push(nResults);
+                expect(where).toEqual({type: {'$in': ['ISSUE', 'DISCUSSION']}});
+                return {
+                    ids      : [ids.slice(0, nResults)],
+                    distances: [ids.slice(0, nResults).map((id, index) => id === rank21Id ? 0 : 0.1 + index / 100)]
+                }
+            }
+        });
+        StorageRouter.getSummaryCollection  = async () => ({get: async () => ({documents: ['rank-21 admission proof']})});
+        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
+        OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
+
+        let outcome;
+        try {
+            outcome = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+        } finally {
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            OpenAiCompatible.prototype.generate = originalGenerate;
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+        expect(widths).toEqual([20, 40]);
+        expect(handoffContent).toContain(rank21Id);
+        expect(handoffContent).toContain('Semantic: 10.00');
+        expect(outcome).toMatchObject({
+            status          : 'completed',
+            selectedTopNodes: 1,
+            scoringStats    : {
+                semanticQueryPasses         : 2,
+                semanticQueryRequestedWidth : 40,
+                semanticCorpusExhausted     : false,
+                candidateAdmissionStopReason: 'render-limit-satisfied'
+            }
+        })
+    });
+
+    test('adaptive admission bounds exact-width duplicate prefixes at the corpus-derived ceiling', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalRecordTypeRejections = Synthesizer.recordTypeGateRejections;
+        const duplicateId                  = 'issue-92050';
+        const recorded                     = [];
+        const widths                       = [];
+        aiConfig.vectorDimension              = 2;
+        aiConfig.goldenPathTopNodeRenderLimit = 2;
+
+        GraphService.upsertNode({
+            id        : duplicateId,
+            type      : 'ISSUE',
+            properties: {
+                state : 'OPEN',
+                title : 'Duplicate semantic neighbor',
+                labels: ['not-code-ready', 'ai']
+            }
+        });
+
+        StorageRouter.getGraphCollection = async () => ({
+            count: async () => 25,
+            query: async ({nResults}) => {
+                widths.push(nResults);
+
+                return {
+                    ids      : [new Array(nResults).fill(duplicateId)],
+                    distances: [new Array(nResults).fill(0.1)]
+                }
+            }
+        });
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['duplicate-prefix proof']})});
+        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+        Synthesizer.recordTypeGateRejections = async rejections => recorded.push(rejections);
+
+        let outcome;
+        try {
+            outcome = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+        } finally {
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText;
+            Synthesizer.recordTypeGateRejections = originalRecordTypeRejections;
+        }
+
+        expect(widths).toEqual([20, 26]);
+        expect(outcome).toMatchObject({
+            status      : 'failed',
+            reasonCode  : 'candidate-admission-budget-exhausted',
+            scoringStats: {
+                semanticCorpusSize          : 25,
+                semanticReturnedCandidates  : 26,
+                semanticUniqueCandidates    : 1,
+                semanticCandidates          : 1,
+                nonActionableCandidates     : 1,
+                semanticQueryPasses         : 2,
+                semanticQueryRequestedWidth : 26,
+                candidateAdmissionStopReason: 'candidate-admission-budget-exhausted'
+            }
+        });
+        expect(recorded).toEqual([[
+            {nodeId: duplicateId, rejectionBucket: ['not-code-ready']}
+        ]])
+    });
+
+    test('a fractional positive render limit still requires and selects one candidate', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const OpenAiCompatible             = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        const originalGenerate             = OpenAiCompatible.prototype.generate;
+        const candidateId                  = 'issue-92055';
+        aiConfig.vectorDimension              = 2;
+        aiConfig.goldenPathTopNodeRenderLimit = 0.5;
+
+        GraphService.upsertNode({
+            id        : candidateId,
+            type      : 'ISSUE',
+            properties: {state: 'OPEN', title: 'One required route', labels: ['bug', 'ai']}
+        });
+        StorageRouter.getGraphCollection = async () => ({
+            count: async () => 1,
+            query: async () => ({ids: [[candidateId]], distances: [[0.1]]})
+        });
+        StorageRouter.getSummaryCollection  = async () => ({get: async () => ({documents: ['fractional-limit proof']})});
+        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
+        OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
+
+        let outcome;
+        try {
+            outcome = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+        } finally {
+            StorageRouter.getGraphCollection    = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection  = originalGetSummaryCollection;
+            TextEmbeddingService.embedText      = originalEmbedText;
+            OpenAiCompatible.prototype.generate = originalGenerate
+        }
+
+        expect(outcome).toMatchObject({
+            status          : 'completed',
+            selectedTopNodes: 1,
+            scoringStats    : {candidateAdmissionStopReason: 'render-limit-satisfied'}
+        });
+        expect(fs.readFileSync(tmpHandoffFile, 'utf-8')).toContain(`1. **${candidateId}**`)
+    });
+
+    test('equal semantic candidates reorder after Hebbian reinforcement and ambient decay', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const OpenAiCompatible             = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        const originalGenerate             = OpenAiCompatible.prototype.generate;
+        const candidateA                   = 'issue-92060';
+        const candidateB                   = 'issue-92061';
+        aiConfig.vectorDimension              = 2;
+        aiConfig.goldenPathTopNodeRenderLimit = 2;
+
+        for (const [id, title] of [[candidateA, 'Initially stronger'], [candidateB, 'Reinforced mover']]) {
+            GraphService.upsertNode({
+                id,
+                type      : 'ISSUE',
+                properties: {state: 'OPEN', title, labels: ['bug', 'ai']}
+            })
+        }
+        GraphService.upsertNode({id: 'session-92060', type: 'SESSION', properties: {state: 'CLOSED'}});
+        GraphService.upsertNode({id: 'session-92061', type: 'SESSION', properties: {state: 'CLOSED'}});
+        GraphService.linkNodes('session-92060', candidateA, 'RELATES_TO', 1);
+        GraphService.linkNodes('session-92061', candidateB, 'RELATES_TO', 0.1);
+
+        StorageRouter.getGraphCollection = async () => ({
+            count: async () => 2,
+            query: async () => ({
+                ids      : [[candidateA, candidateB]],
+                distances: [[0.1, 0.1]]
+            })
+        });
+        StorageRouter.getSummaryCollection  = async () => ({get: async () => ({documents: ['Hebbian reorder proof']})});
+        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
+        OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
+
+        try {
+            const firstOutcome   = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+            let   handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+            expect(firstOutcome).toMatchObject({status: 'completed', selectedTopNodes: 2});
+            expect(handoffContent.indexOf(`1. **${candidateA}**`)).toBeGreaterThan(-1);
+            expect(handoffContent.indexOf(`1. **${candidateA}**`)).toBeLessThan(handoffContent.indexOf(`2. **${candidateB}**`));
+
+            // Remove the route's own output before changing ambient evidence. Two reinforcements lift B
+            // from 0.1 to 1.1; the forced 0.5 decay then leaves B at 0.55 and A at 0.5.
+            Synthesizer.pruneStaleFrontierGuideEdges({graphService: GraphService, currentTargetIds: new Set()});
+            expect(GraphService.db.storage.db.prepare(`
+                SELECT count(*) AS count
+                FROM Edges
+                WHERE source = 'frontier'
+                  AND type = 'GUIDES'
+                  AND target IN (?, ?)
+            `).get(candidateA, candidateB).count).toBe(0);
+            GraphService.linkNodes('session-92061', candidateB, 'RELATES_TO', 5);
+            GraphService.linkNodes('session-92061', candidateB, 'RELATES_TO', 5);
+            GraphService.decayGlobalTopology(0.5, 0.1, true);
+            fs.unlinkSync(tmpHandoffFile);
+
+            const
+                edgeRows      = GraphService.db.storage.db.prepare(`
+                    SELECT target, type, CAST(json_extract(data, '$.properties.weight') AS REAL) AS weight
+                    FROM Edges
+                    WHERE target IN (?, ?)
+                      AND source != 'frontier'
+                    ORDER BY target, type
+                `).all(candidateA, candidateB),
+                supportA      = GraphService.getInboundStructuralSupport({id: candidateA}),
+                supportB      = GraphService.getInboundStructuralSupport({id: candidateB}),
+                secondOutcome = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+
+            expect(edgeRows).toEqual([
+                {target: candidateA, type: 'RELATES_TO', weight: 0.5},
+                {target: candidateB, type: 'RELATES_TO', weight: 0.55}
+            ]);
+            expect(supportB.totalWeight).toBeGreaterThan(supportA.totalWeight);
+            expect(secondOutcome).toMatchObject({status: 'completed', selectedTopNodes: 2});
+            handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+            expect(handoffContent.indexOf(`1. **${candidateB}**`)).toBeGreaterThan(-1);
+            expect(handoffContent.indexOf(`1. **${candidateB}**`)).toBeLessThan(handoffContent.indexOf(`2. **${candidateA}**`))
+        } finally {
+            StorageRouter.getGraphCollection    = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection  = originalGetSummaryCollection;
+            TextEmbeddingService.embedText      = originalEmbedText;
+            OpenAiCompatible.prototype.generate = originalGenerate
+        }
+    });
+
+    test('a degraded later widening pass discards the earlier partial route and provisional rejections', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalRecordTypeRejections = Synthesizer.recordTypeGateRejections;
+        const ids                          = Array.from({length: 20}, (_, index) => `issue-${92100 + index}`);
+        const validId                      = ids[0];
+        const recorded                     = [];
+        const widths                       = [];
+        aiConfig.vectorDimension              = 2;
+        aiConfig.goldenPathTopNodeRenderLimit = 2;
+
+        ids.forEach((id, index) => GraphService.upsertNode({
+            id,
+            type      : 'ISSUE',
+            properties: {
+                state : 'OPEN',
+                title : index === 0 ? 'Provisional survivor' : `Provisional rejection ${index}`,
+                labels: index === 0 ? ['bug', 'ai'] : ['epic', 'ai']
+            }
+        }));
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async ({nResults}) => {
+                widths.push(nResults);
+                return nResults === 20 ? {
+                    ids      : [ids],
+                    distances: [ids.map((id, index) => 0.1 + index / 100)]
+                } : {
+                    ids            : [[]],
+                    distances      : [[]],
+                    _degraded      : true,
+                    _degradedReason: 'second-pass graph query degraded'
+                }
+            }
+        });
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['later-pass failure proof']})});
+        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+        Synthesizer.recordTypeGateRejections = async rejections => recorded.push(rejections);
+
+        let outcome;
+        try {
+            outcome = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+        } finally {
+            StorageRouter.getGraphCollection    = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection  = originalGetSummaryCollection;
+            TextEmbeddingService.embedText      = originalEmbedText;
+            Synthesizer.recordTypeGateRejections = originalRecordTypeRejections;
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+        expect(widths).toEqual([20, 40]);
+        expect(outcome).toMatchObject({
+            status      : 'failed',
+            reasonCode  : 'semantic-query-failed',
+            scoringStats: {
+                semanticQueryPasses         : 2,
+                semanticQueryRequestedWidth : 40,
+                candidateAdmissionStopReason: 'semantic-query-failed'
+            }
+        });
+        expect(handoffContent).not.toContain(validId);
+        expect(recorded).toEqual([[]])
+    });
+
+    test('a malformed distance on a later widening pass fails loud and discards provisional output', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalRecordTypeRejections = Synthesizer.recordTypeGateRejections;
+        const ids                          = Array.from({length: 40}, (_, index) => `issue-${92140 + index}`);
+        const provisionalId                = ids[0];
+        const recorded                     = [];
+        const widths                       = [];
+        aiConfig.vectorDimension              = 2;
+        aiConfig.goldenPathTopNodeRenderLimit = 2;
+
+        ids.slice(0, 20).forEach((id, index) => GraphService.upsertNode({
+            id,
+            type      : 'ISSUE',
+            properties: {
+                state : 'OPEN',
+                title : index === 0 ? 'Provisional survivor' : `Provisional malformed-distance rejection ${index}`,
+                labels: index === 0 ? ['bug', 'ai'] : ['not-code-ready', 'ai']
+            }
+        }));
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async ({nResults}) => {
+                widths.push(nResults);
+                const resultIds = ids.slice(0, nResults);
+                const distances = resultIds.map((id, index) => 0.1 + index / 100);
+
+                if (nResults > 20) distances[25] = null;
+
+                return {ids: [resultIds], distances: [distances]}
+            }
+        });
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['malformed-distance proof']})});
+        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+        Synthesizer.recordTypeGateRejections = async rejections => recorded.push(rejections);
+
+        let outcome;
+        try {
+            outcome = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+        } finally {
+            StorageRouter.getGraphCollection    = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection  = originalGetSummaryCollection;
+            TextEmbeddingService.embedText      = originalEmbedText;
+            Synthesizer.recordTypeGateRejections = originalRecordTypeRejections
+        }
+
+        expect(widths).toEqual([20, 40]);
+        expect(outcome).toMatchObject({
+            status      : 'failed',
+            reasonCode  : 'semantic-query-failed',
+            scoringStats: {
+                semanticQueryPasses         : 2,
+                semanticQueryRequestedWidth : 40,
+                candidateAdmissionStopReason: 'semantic-query-failed'
+            }
+        });
+        expect(fs.readFileSync(tmpHandoffFile, 'utf-8')).not.toContain(provisionalId);
+        expect(recorded).toEqual([[]])
+    });
+
+    test('a later structural-projection failure discards the provisional route and fails loud', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalGetInboundSupport    = GraphService.getInboundStructuralSupport;
+        const originalRecordTypeRejections = Synthesizer.recordTypeGateRejections;
+        const ids                          = Array.from({length: 20}, (_, index) => `issue-${92150 + index}`);
+        const validId                      = ids[0];
+        const recorded                     = [];
+        let   queryPass                    = 0;
+        aiConfig.vectorDimension              = 2;
+        aiConfig.goldenPathTopNodeRenderLimit = 2;
+
+        ids.forEach((id, index) => GraphService.upsertNode({
+            id,
+            type      : 'ISSUE',
+            properties: {
+                state : 'OPEN',
+                title : index === 0 ? 'Provisional structural survivor' : `Structural rejection ${index}`,
+                labels: index === 0 ? ['bug', 'ai'] : ['epic', 'ai']
+            }
+        }));
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async () => {
+                queryPass++;
+                return {
+                    ids      : [ids],
+                    distances: [ids.map((id, index) => 0.1 + index / 100)]
+                }
+            }
+        });
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['structural failure proof']})});
+        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
+        GraphService.getInboundStructuralSupport = function(data) {
+            if (queryPass === 2) throw new Error('second-pass structural projection failed');
+            return originalGetInboundSupport.call(this, data)
+        };
+        Synthesizer.recordTypeGateRejections = async rejections => recorded.push(rejections);
+
+        let outcome;
+        try {
+            outcome = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+        } finally {
+            StorageRouter.getGraphCollection          = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection        = originalGetSummaryCollection;
+            TextEmbeddingService.embedText            = originalEmbedText;
+            GraphService.getInboundStructuralSupport  = originalGetInboundSupport;
+            Synthesizer.recordTypeGateRejections      = originalRecordTypeRejections;
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+        expect(queryPass).toBe(2);
+        expect(outcome).toMatchObject({
+            status      : 'failed',
+            reasonCode  : 'graph-store-mapping-failed',
+            scoringStats: {candidateAdmissionStopReason: 'graph-store-mapping-failed'}
+        });
+        expect(handoffContent).not.toContain(validId);
+        expect(recorded).toEqual([[]])
+    });
+
+    test('Discussion liveness uses decaying support, rejects protected-only archaeology, and proves short-corpus exhaustion', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalRecordTypeRejections = Synthesizer.recordTypeGateRejections;
+        const OpenAiCompatible             = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        const originalGenerate             = OpenAiCompatible.prototype.generate;
+        const protectedOnlyId              = 'discussion-92200';
+        const decayingId                   = 'discussion-92201';
+        const terminalId                   = 'discussion-92202';
+        const recorded                     = [];
+        aiConfig.vectorDimension = 2;
+
+        [
+            {
+                id         : protectedOnlyId,
+                disposition: 'undetermined',
+                reason     : 'no-authoritative-lifecycle-marker',
+                evidence   : []
+            },
+            {
+                id         : decayingId,
+                disposition: 'undetermined',
+                reason     : 'no-authoritative-lifecycle-marker',
+                evidence   : []
+            },
+            {
+                id         : terminalId,
+                disposition: 'terminal',
+                reason     : 'graduated-to-ticket',
+                evidence   : ['marker:GRADUATED_TO_TICKET']
+            }
+        ].forEach(({id, disposition, reason, evidence}) => GraphService.upsertNode({
+            id,
+            type      : 'DISCUSSION',
+            properties: {
+                state                          : 'OPEN',
+                title                          : id,
+                routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+                routingDisposition             : disposition,
+                routingDispositionReason       : reason,
+                routingDispositionEvidence     : evidence
+            }
+        }));
+        ['protected-source', 'decaying-source', 'terminal-source'].forEach(id => GraphService.upsertNode({id, type: 'ISSUE'}));
+        GraphService.linkNodes('protected-source', protectedOnlyId, 'RESOLVES', 2);
+        GraphService.linkNodes('decaying-source', decayingId, 'GUIDES', 1);
+        GraphService.linkNodes('terminal-source', terminalId, 'GUIDES', 1);
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async () => ({
+                ids      : [[protectedOnlyId, decayingId, terminalId]],
+                distances: [[0.1, 0.2, 0.3]]
+            })
+        });
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['Discussion liveness proof']})});
+        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+        Synthesizer.recordTypeGateRejections = async rejections => recorded.push(rejections);
+        OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
+
+        let outcome;
+        try {
+            outcome = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+        } finally {
+            StorageRouter.getGraphCollection    = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection  = originalGetSummaryCollection;
+            TextEmbeddingService.embedText      = originalEmbedText;
+            Synthesizer.recordTypeGateRejections = originalRecordTypeRejections;
+            OpenAiCompatible.prototype.generate = originalGenerate;
+        }
+
+        const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+        expect(handoffContent).toContain(decayingId);
+        expect(handoffContent).not.toContain(protectedOnlyId);
+        expect(handoffContent).not.toContain(terminalId);
+        expect(recorded).toHaveLength(1);
+        expect(recorded[0]).toEqual(expect.arrayContaining([
+            {nodeId: protectedOnlyId, rejectionBucket: ['undetermined-no-decaying-support'], stage: 'discussion-liveness-gate'},
+            {nodeId: terminalId, rejectionBucket: ['terminal'], stage: 'discussion-liveness-gate'}
+        ]));
+        expect(outcome.scoringStats).toMatchObject({
+            discussionLivenessRejections: 2,
+            semanticCorpusExhausted     : true,
+            candidateAdmissionStopReason: 'semantic-corpus-exhausted'
+        })
+    });
+
+    test('a prior Golden Path GUIDES edge cannot self-authorize an undetermined Discussion on the next run', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const originalRecordTypeRejections = Synthesizer.recordTypeGateRejections;
+        const OpenAiCompatible             = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
+        const originalGenerate             = OpenAiCompatible.prototype.generate;
+        const discussionId                 = 'discussion-92210';
+        const recorded                     = [];
+        aiConfig.vectorDimension              = 2;
+        aiConfig.goldenPathTopNodeRenderLimit = 1;
+
+        GraphService.upsertNode({
+            id        : discussionId,
+            type      : 'DISCUSSION',
+            properties: {
+                state                          : 'OPEN',
+                title                          : 'One-run convergence proof',
+                routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+                routingDisposition             : 'active',
+                routingDispositionReason       : 'explicit-active-marker',
+                routingDispositionEvidence     : ['marker:CONVERGING']
+            }
+        });
+
+        StorageRouter.getGraphCollection = async () => ({
+            query: async () => ({ids: [[discussionId]], distances: [[0.1]]})
+        });
+        StorageRouter.getSummaryCollection  = async () => ({get: async () => ({documents: ['self-guidance proof']})});
+        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
+        Synthesizer.recordTypeGateRejections = async rejections => recorded.push(rejections);
+        OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
+
+        try {
+            const first = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+            expect(first.selectedTopNodes).toBe(1);
+            const priorRouteSupport = GraphService.getInboundStructuralSupport({id: discussionId});
+            expect(priorRouteSupport.totalWeight).toBeGreaterThan(0);
+            expect(priorRouteSupport.decayingWeight).toBe(0);
+
+            GraphService.upsertNode({
+                id        : discussionId,
+                type      : 'DISCUSSION',
+                properties: {
+                    state                          : 'OPEN',
+                    title                          : 'One-run convergence proof',
+                    routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+                    routingDisposition             : 'undetermined',
+                    routingDispositionReason       : 'no-authoritative-lifecycle-marker',
+                    routingDispositionEvidence     : []
+                }
+            });
+
+            const second         = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+            const handoffContent = fs.readFileSync(tmpHandoffFile, 'utf-8');
+
+            expect(second.selectedTopNodes).toBe(0);
+            expect(handoffContent).not.toContain(discussionId);
+            expect(recorded.at(-1)).toEqual([
+                {
+                    nodeId         : discussionId,
+                    rejectionBucket: ['undetermined-no-decaying-support'],
+                    stage          : 'discussion-liveness-gate'
+                }
+            ])
+        } finally {
+            StorageRouter.getGraphCollection          = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection        = originalGetSummaryCollection;
+            TextEmbeddingService.embedText            = originalEmbedText;
+            Synthesizer.recordTypeGateRejections      = originalRecordTypeRejections;
+            OpenAiCompatible.prototype.generate       = originalGenerate;
+        }
+    });
+
     test('synthesizeGoldenPath surfaces current incidents, focus epics, and filters non-actionable computed recommendations', async () => {
         const originalGetGraphCollection   = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
@@ -930,7 +1533,14 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             id        : discussionId,
             type      : 'DISCUSSION',
             state     : 'OPEN',
-            properties: {state: 'OPEN', title: 'Governance discussion'}
+            properties: {
+                state                          : 'OPEN',
+                title                          : 'Governance discussion',
+                routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+                routingDisposition             : 'active',
+                routingDispositionReason       : 'explicit-active-marker',
+                routingDispositionEvidence     : ['marker:CONVERGING']
+            }
         });
         GraphService.upsertNode({
             id        : epicId,
@@ -2037,7 +2647,14 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             type      : 'DISCUSSION',
             name      : 'Open Discussion Fixture',
             state     : 'OPEN',
-            properties: {state: 'OPEN', title: 'Open Discussion Fixture'}
+            properties: {
+                state                          : 'OPEN',
+                title                          : 'Open Discussion Fixture',
+                routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+                routingDisposition             : 'active',
+                routingDispositionReason       : 'explicit-active-marker',
+                routingDispositionEvidence     : ['marker:CONVERGING']
+            }
         });
         GraphService.upsertNode({
             id        : closedId,
@@ -2406,13 +3023,16 @@ test.describe('GoldenPathSynthesizer.hasCrossFamilyReview — author family from
             {nodeId: 'issue-11', rejectionBucket: ['not-code-ready', 'ai-generated']},
             {rejectionBucket: ['epic']},              // no nodeId → dropped
             {nodeId: '', rejectionBucket: ['epic']},   // empty nodeId → dropped
-            {nodeId: 'issue-12', rejectionBucket: 'epic'} // non-array bucket → []
+            {nodeId: 'issue-12', rejectionBucket: 'epic'}, // non-array bucket → []
+            {nodeId: 'discussion-13', rejectionBucket: ['terminal'], stage: 'discussion-liveness-gate'},
+            {nodeId: 'issue-14', rejectionBucket: ['epic'], stage: 'unknown-stage'}
         ], 4242);
 
-        expect(records.map(r => r.nodeId)).toEqual(['issue-10', 'issue-11', 'issue-12']);
+        expect(records.map(r => r.nodeId)).toEqual(['issue-10', 'issue-11', 'issue-12', 'discussion-13']);
         expect(records[0]).toEqual({nodeId: 'issue-10', rejectionBucket: ['epic'], stage: 'actionability-type-gate', at: 4242});
         expect(records[2].rejectionBucket).toEqual([]);        // non-array bucket normalized
-        expect(records.every(r => r.stage === 'actionability-type-gate' && r.at === 4242)).toBe(true);
+        expect(records[3].stage).toBe('discussion-liveness-gate');
+        expect(records.every(r => r.at === 4242)).toBe(true);
     });
 
     test('buildTypeGateRejectionRecords is empty for no rejections / a non-array input (#15057 AC3)', () => {

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -915,6 +915,97 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         })
     });
 
+    test('malformed ANN envelopes and positional values fail loud on the first adaptive pass', async () => {
+        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
+        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
+        const originalEmbedText            = TextEmbeddingService.embedText;
+        const malformedResults             = [
+            {
+                expectedError: 'invalid ids envelope',
+                name         : 'missing ids envelope',
+                result       : {distances: [[]]}
+            },
+            {
+                expectedError: 'invalid ids envelope',
+                name         : 'flat ids envelope',
+                result       : {ids: ['issue-flat'], distances: [[0.1]]}
+            },
+            {
+                expectedError: 'invalid ids envelope',
+                name         : 'multi-query ids envelope',
+                result       : {ids: [[], []], distances: [[], []]}
+            },
+            {
+                expectedError: 'invalid distances envelope',
+                name         : 'missing distances envelope',
+                result       : {ids: [[]]}
+            },
+            {
+                expectedError: 'invalid distances envelope',
+                name         : 'flat distances envelope',
+                result       : {ids: [['issue-flat-distance']], distances: [0.1]}
+            },
+            {
+                expectedError: 'invalid distances envelope',
+                name         : 'multi-query distances envelope',
+                result       : {ids: [[]], distances: [[], []]}
+            },
+            {
+                expectedError: 'non-string or empty id',
+                name         : 'non-string id',
+                result       : {ids: [[42]], distances: [[0.1]]}
+            },
+            {
+                expectedError: 'non-string or empty id',
+                name         : 'empty id',
+                result       : {ids: [['  ']], distances: [[0.1]]}
+            },
+            {
+                expectedError: 'non-finite, non-numeric, or negative distance',
+                name         : 'numeric-string distance',
+                result       : {ids: [['issue-string-distance']], distances: [['0.1']]}
+            },
+            {
+                expectedError: 'non-finite, non-numeric, or negative distance',
+                name         : 'negative distance',
+                result       : {ids: [['issue-negative-distance']], distances: [[-0.1]]}
+            },
+            {
+                expectedError: 'non-finite, non-numeric, or negative distance',
+                name         : 'non-finite distance',
+                result       : {ids: [['issue-infinite-distance']], distances: [[Infinity]]}
+            }
+        ];
+        let semanticResult;
+        aiConfig.vectorDimension = 2;
+
+        StorageRouter.getGraphCollection   = async () => ({query: async () => semanticResult});
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['malformed-envelope proof']})});
+        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+
+        try {
+            for (const {expectedError, name, result} of malformedResults) {
+                semanticResult = result;
+                const outcome = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
+
+                expect(outcome, name).toMatchObject({
+                    status      : 'failed',
+                    reasonCode  : 'semantic-query-failed',
+                    scoringStats: {
+                        semanticQueryPasses         : 1,
+                        semanticQueryRequestedWidth : 20,
+                        candidateAdmissionStopReason: 'semantic-query-failed'
+                    }
+                });
+                expect(outcome.error, name).toContain(expectedError)
+            }
+        } finally {
+            StorageRouter.getGraphCollection   = originalGetGraphCollection;
+            StorageRouter.getSummaryCollection = originalGetSummaryCollection;
+            TextEmbeddingService.embedText     = originalEmbedText
+        }
+    });
+
     test('adaptive admission bounds exact-width duplicate prefixes at the corpus-derived ceiling', async () => {
         const originalGetGraphCollection   = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
@@ -976,9 +1067,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
                 candidateAdmissionStopReason: 'candidate-admission-budget-exhausted'
             }
         });
-        expect(recorded).toEqual([[
-            {nodeId: duplicateId, rejectionBucket: ['not-code-ready']}
-        ]])
+        expect(recorded).toEqual([[]])
     });
 
     test('a fractional positive render limit still requires and selects one candidate', async () => {
@@ -1172,7 +1261,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(recorded).toEqual([[]])
     });
 
-    test('a malformed distance on a later widening pass fails loud and discards provisional output', async () => {
+    test('a malformed ANN envelope on a later widening pass fails loud and discards provisional output', async () => {
         const originalGetGraphCollection   = StorageRouter.getGraphCollection;
         const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
         const originalEmbedText            = TextEmbeddingService.embedText;
@@ -1198,14 +1287,16 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             query: async ({nResults}) => {
                 widths.push(nResults);
                 const resultIds = ids.slice(0, nResults);
-                const distances = resultIds.map((id, index) => 0.1 + index / 100);
 
-                if (nResults > 20) distances[25] = null;
-
-                return {ids: [resultIds], distances: [distances]}
+                return nResults === 20 ? {
+                    ids      : [resultIds],
+                    distances: [resultIds.map((id, index) => 0.1 + index / 100)]
+                } : {
+                    ids: [resultIds]
+                }
             }
         });
-        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['malformed-distance proof']})});
+        StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['malformed-envelope proof']})});
         TextEmbeddingService.embedText     = async () => [0.1, 0.2];
         Synthesizer.recordTypeGateRejections = async rejections => recorded.push(rejections);
 
@@ -1223,6 +1314,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(outcome).toMatchObject({
             status      : 'failed',
             reasonCode  : 'semantic-query-failed',
+            error       : 'Graph semantic query returned an invalid distances envelope; expected exactly one nested query-result array',
             scoringStats: {
                 semanticQueryPasses         : 2,
                 semanticQueryRequestedWidth : 40,

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -57,6 +57,15 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
     let originalVectorDimension;
     let originalWarn;
 
+    /**
+     * @summary Builds a deterministic embedding with the resolved SSOT dimension, keeping tests from
+     * mutating the shared AiConfig singleton merely to fit a two-element fixture.
+     * @returns {Number[]}
+     */
+    function buildConfiguredEmbedding() {
+        return new Array(Number(aiConfig.vectorDimension)).fill(0.1)
+    }
+
     test.beforeAll(async () => {
         aiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
 
@@ -828,11 +837,9 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const originalGenerate             = OpenAiCompatible.prototype.generate;
         const issuesDir                    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-pool-scope-'));
         let   capturedWhere                = 'UNSET';
-        aiConfig.vectorDimension = 2;
-
         StorageRouter.getGraphCollection    = async () => ({query: async args => { capturedWhere = args.where; return {ids: [[]], distances: [[]]}; }});
         StorageRouter.getSummaryCollection  = async () => ({get: async () => ({documents: ['mock document']})});
-        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
+        TextEmbeddingService.embedText      = async () => buildConfiguredEmbedding();
         GoldenPathSynthesizer.fetchOpenPRs  = async () => [];
         OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
 
@@ -862,16 +869,14 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const widths                       = [];
         const ids                          = Array.from({length: 40}, (_, index) => `issue-${92000 + index}`);
         const rank21Id                     = ids[20];
-        aiConfig.vectorDimension                = 2;
-        aiConfig.goldenPathTopNodeRenderLimit   = 1;
 
         ids.forEach((id, index) => GraphService.upsertNode({
             id,
             type      : 'ISSUE',
             properties: {
                 state : 'OPEN',
-                title : index === 20 ? 'Legitimate rank-21 candidate' : `Rejected semantic neighbor ${index + 1}`,
-                labels: index === 20 ? ['bug', 'ai'] : ['not-code-ready', 'ai']
+                title : index === 20 ? 'Legitimate rank-21 candidate' : `Semantic neighbor ${index + 1}`,
+                labels: index >= 20 && index < 30 ? ['bug', 'ai'] : ['not-code-ready', 'ai']
             }
         }));
 
@@ -886,7 +891,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             }
         });
         StorageRouter.getSummaryCollection  = async () => ({get: async () => ({documents: ['rank-21 admission proof']})});
-        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
+        TextEmbeddingService.embedText      = async () => buildConfiguredEmbedding();
         OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
 
         let outcome;
@@ -905,7 +910,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(handoffContent).toContain('Semantic: 10.00');
         expect(outcome).toMatchObject({
             status          : 'completed',
-            selectedTopNodes: 1,
+            selectedTopNodes: 10,
             scoringStats    : {
                 semanticQueryPasses         : 2,
                 semanticQueryRequestedWidth : 40,
@@ -977,11 +982,10 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             }
         ];
         let semanticResult;
-        aiConfig.vectorDimension = 2;
 
         StorageRouter.getGraphCollection   = async () => ({query: async () => semanticResult});
         StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['malformed-envelope proof']})});
-        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+        TextEmbeddingService.embedText     = async () => buildConfiguredEmbedding();
 
         try {
             for (const {expectedError, name, result} of malformedResults) {
@@ -1014,8 +1018,6 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const duplicateId                  = 'issue-92050';
         const recorded                     = [];
         const widths                       = [];
-        aiConfig.vectorDimension              = 2;
-        aiConfig.goldenPathTopNodeRenderLimit = 2;
 
         GraphService.upsertNode({
             id        : duplicateId,
@@ -1039,7 +1041,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             }
         });
         StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['duplicate-prefix proof']})});
-        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+        TextEmbeddingService.embedText     = async () => buildConfiguredEmbedding();
         Synthesizer.recordTypeGateRejections = async rejections => recorded.push(rejections);
 
         let outcome;
@@ -1070,45 +1072,11 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         expect(recorded).toEqual([[]])
     });
 
-    test('a fractional positive render limit still requires and selects one candidate', async () => {
-        const originalGetGraphCollection   = StorageRouter.getGraphCollection;
-        const originalGetSummaryCollection = StorageRouter.getSummaryCollection;
-        const originalEmbedText            = TextEmbeddingService.embedText;
-        const OpenAiCompatible             = (await import('../../../../../../ai/provider/OpenAiCompatible.mjs')).default;
-        const originalGenerate             = OpenAiCompatible.prototype.generate;
-        const candidateId                  = 'issue-92055';
-        aiConfig.vectorDimension              = 2;
-        aiConfig.goldenPathTopNodeRenderLimit = 0.5;
-
-        GraphService.upsertNode({
-            id        : candidateId,
-            type      : 'ISSUE',
-            properties: {state: 'OPEN', title: 'One required route', labels: ['bug', 'ai']}
-        });
-        StorageRouter.getGraphCollection = async () => ({
-            count: async () => 1,
-            query: async () => ({ids: [[candidateId]], distances: [[0.1]]})
-        });
-        StorageRouter.getSummaryCollection  = async () => ({get: async () => ({documents: ['fractional-limit proof']})});
-        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
-        OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
-
-        let outcome;
-        try {
-            outcome = await GoldenPathSynthesizer.synthesizeGoldenPath({repoEnrichmentEnabled: false});
-        } finally {
-            StorageRouter.getGraphCollection    = originalGetGraphCollection;
-            StorageRouter.getSummaryCollection  = originalGetSummaryCollection;
-            TextEmbeddingService.embedText      = originalEmbedText;
-            OpenAiCompatible.prototype.generate = originalGenerate
-        }
-
-        expect(outcome).toMatchObject({
-            status          : 'completed',
-            selectedTopNodes: 1,
-            scoringStats    : {candidateAdmissionStopReason: 'render-limit-satisfied'}
-        });
-        expect(fs.readFileSync(tmpHandoffFile, 'utf-8')).toContain(`1. **${candidateId}**`)
+    test('normalizeAdmissionTarget clamps fractional positive limits without mutating the config SSOT', () => {
+        expect(Synthesizer.normalizeAdmissionTarget(0.5)).toBe(1);
+        expect(Synthesizer.normalizeAdmissionTarget(2.9)).toBe(2);
+        expect(Synthesizer.normalizeAdmissionTarget(0)).toBe(1);
+        expect(Synthesizer.normalizeAdmissionTarget(Number.NaN)).toBe(1)
     });
 
     test('equal semantic candidates reorder after Hebbian reinforcement and ambient decay', async () => {
@@ -1119,8 +1087,6 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const originalGenerate             = OpenAiCompatible.prototype.generate;
         const candidateA                   = 'issue-92060';
         const candidateB                   = 'issue-92061';
-        aiConfig.vectorDimension              = 2;
-        aiConfig.goldenPathTopNodeRenderLimit = 2;
 
         for (const [id, title] of [[candidateA, 'Initially stronger'], [candidateB, 'Reinforced mover']]) {
             GraphService.upsertNode({
@@ -1142,7 +1108,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             })
         });
         StorageRouter.getSummaryCollection  = async () => ({get: async () => ({documents: ['Hebbian reorder proof']})});
-        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
+        TextEmbeddingService.embedText      = async () => buildConfiguredEmbedding();
         OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
 
         try {
@@ -1205,8 +1171,6 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const validId                      = ids[0];
         const recorded                     = [];
         const widths                       = [];
-        aiConfig.vectorDimension              = 2;
-        aiConfig.goldenPathTopNodeRenderLimit = 2;
 
         ids.forEach((id, index) => GraphService.upsertNode({
             id,
@@ -1233,7 +1197,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             }
         });
         StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['later-pass failure proof']})});
-        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+        TextEmbeddingService.embedText     = async () => buildConfiguredEmbedding();
         Synthesizer.recordTypeGateRejections = async rejections => recorded.push(rejections);
 
         let outcome;
@@ -1270,8 +1234,6 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const provisionalId                = ids[0];
         const recorded                     = [];
         const widths                       = [];
-        aiConfig.vectorDimension              = 2;
-        aiConfig.goldenPathTopNodeRenderLimit = 2;
 
         ids.slice(0, 20).forEach((id, index) => GraphService.upsertNode({
             id,
@@ -1297,7 +1259,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             }
         });
         StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['malformed-envelope proof']})});
-        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+        TextEmbeddingService.embedText     = async () => buildConfiguredEmbedding();
         Synthesizer.recordTypeGateRejections = async rejections => recorded.push(rejections);
 
         let outcome;
@@ -1335,8 +1297,6 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const validId                      = ids[0];
         const recorded                     = [];
         let   queryPass                    = 0;
-        aiConfig.vectorDimension              = 2;
-        aiConfig.goldenPathTopNodeRenderLimit = 2;
 
         ids.forEach((id, index) => GraphService.upsertNode({
             id,
@@ -1358,7 +1318,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             }
         });
         StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['structural failure proof']})});
-        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
+        TextEmbeddingService.embedText      = async () => buildConfiguredEmbedding();
         GraphService.getInboundStructuralSupport = function(data) {
             if (queryPass === 2) throw new Error('second-pass structural projection failed');
             return originalGetInboundSupport.call(this, data)
@@ -1398,7 +1358,6 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const decayingId                   = 'discussion-92201';
         const terminalId                   = 'discussion-92202';
         const recorded                     = [];
-        aiConfig.vectorDimension = 2;
 
         [
             {
@@ -1443,7 +1402,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             })
         });
         StorageRouter.getSummaryCollection = async () => ({get: async () => ({documents: ['Discussion liveness proof']})});
-        TextEmbeddingService.embedText     = async () => [0.1, 0.2];
+        TextEmbeddingService.embedText     = async () => buildConfiguredEmbedding();
         Synthesizer.recordTypeGateRejections = async rejections => recorded.push(rejections);
         OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
 
@@ -1483,8 +1442,6 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         const originalGenerate             = OpenAiCompatible.prototype.generate;
         const discussionId                 = 'discussion-92210';
         const recorded                     = [];
-        aiConfig.vectorDimension              = 2;
-        aiConfig.goldenPathTopNodeRenderLimit = 1;
 
         GraphService.upsertNode({
             id        : discussionId,
@@ -1503,7 +1460,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
             query: async () => ({ids: [[discussionId]], distances: [[0.1]]})
         });
         StorageRouter.getSummaryCollection  = async () => ({get: async () => ({documents: ['self-guidance proof']})});
-        TextEmbeddingService.embedText      = async () => [0.1, 0.2];
+        TextEmbeddingService.embedText      = async () => buildConfiguredEmbedding();
         Synthesizer.recordTypeGateRejections = async rejections => recorded.push(rejections);
         OpenAiCompatible.prototype.generate = async () => ({content: '{"strategic_brief":"stub"}'});
 

--- a/test/playwright/unit/ai/services/graph/computedGoldenPathRouting.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/computedGoldenPathRouting.spec.mjs
@@ -175,10 +175,16 @@ test.describe('computedGoldenPathRouting — the contradiction guard (routing-de
 });
 
 test.describe('computedGoldenPathRouting — the fixture-provenance guard (source-set hygiene)', () => {
+    let evaluateDiscussionLiveness;
+    let getDiscussionRoutingDisposition;
     let isActionableComputedRecommendation;
 
     test.beforeAll(async () => {
-        ({isActionableComputedRecommendation} = await import('../../../../../../ai/services/graph/computedGoldenPathRouting.mjs'));
+        ({
+            evaluateDiscussionLiveness,
+            getDiscussionRoutingDisposition,
+            isActionableComputedRecommendation
+        } = await import('../../../../../../ai/services/graph/computedGoldenPathRouting.mjs'));
     });
 
     test('a stamped test fixture never enters the scored steering surface', () => {
@@ -215,5 +221,58 @@ test.describe('computedGoldenPathRouting — the fixture-provenance guard (sourc
             type      : 'DISCUSSION',
             properties: {state: 'OPEN', title: 'v13.2 planning'}
         })).toBe(true);
+    });
+
+    test('Discussion liveness is a distinct post-actionability gate with typed rejection buckets', () => {
+        const projection = disposition => {
+            if (disposition === 'active') return {
+                routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+                routingDisposition             : 'active',
+                routingDispositionReason       : 'explicit-active-marker',
+                routingDispositionEvidence     : ['marker:CONVERGING']
+            };
+            if (disposition === 'terminal') return {
+                routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+                routingDisposition             : 'terminal',
+                routingDispositionReason       : 'graduated-to-ticket',
+                routingDispositionEvidence     : ['marker:GRADUATED_TO_TICKET']
+            };
+            if (disposition === 'undetermined') return {
+                routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+                routingDisposition             : 'undetermined',
+                routingDispositionReason       : 'no-authoritative-lifecycle-marker',
+                routingDispositionEvidence     : []
+            };
+            return {}
+        };
+        const discussion = disposition => ({
+            id        : 'discussion-15090',
+            type      : 'DISCUSSION',
+            properties: {state: 'OPEN', title: 'Live lane awareness', ...projection(disposition)}
+        });
+
+        expect(isActionableComputedRecommendation(discussion('terminal'))).toBe(true);
+        expect(evaluateDiscussionLiveness(discussion('active'), 0)).toEqual({eligible: true, rejectionBucket: []});
+        expect(evaluateDiscussionLiveness(discussion('terminal'), 9)).toEqual({eligible: false, rejectionBucket: ['terminal']});
+        expect(evaluateDiscussionLiveness(discussion('undetermined'), 0)).toEqual({eligible: false, rejectionBucket: ['undetermined-no-decaying-support']});
+        expect(evaluateDiscussionLiveness(discussion('undetermined'), 0.1)).toEqual({eligible: true, rejectionBucket: []});
+        expect(evaluateDiscussionLiveness(discussion(), 0.1)).toEqual({eligible: true, rejectionBucket: []});
+
+        for (const unsupported of [-1, NaN, Infinity]) {
+            expect(evaluateDiscussionLiveness(discussion(), unsupported).eligible).toBe(false)
+        }
+
+        const partialActive = {
+            id        : 'discussion-partial-active',
+            type      : 'DISCUSSION',
+            properties: {routingDisposition: 'active'}
+        };
+        expect(getDiscussionRoutingDisposition(partialActive)).toBe('undetermined');
+        expect(evaluateDiscussionLiveness(partialActive, 0)).toEqual({
+            eligible       : false,
+            rejectionBucket: ['undetermined-no-decaying-support']
+        });
+
+        expect(evaluateDiscussionLiveness({id: 'issue-1', type: 'ISSUE'}, 0)).toEqual({eligible: true, rejectionBucket: []})
     });
 });

--- a/test/playwright/unit/ai/services/graph/typeGateRejectionLedgerStore.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/typeGateRejectionLedgerStore.spec.mjs
@@ -12,6 +12,8 @@ import {
 import {
     TYPE_GATE_REJECTION_FILENAME,
     TYPE_GATE_REJECTION_STAGE,
+    DISCUSSION_LIVENESS_REJECTION_STAGE,
+    appendTypeGateRejection,
     readTypeGateRejectionLedger,
     summarizeTypeGateRejectionLedger,
     queryTypeGateRejectionLedger
@@ -22,7 +24,13 @@ async function tmpDir() {
 }
 
 // A type-gate rejection: the non-actionable node + the exclusion labels that made it visibility-only.
-const record = (nodeId, rejectionBucket, at) => ({nodeId, rejectionBucket, stage: TYPE_GATE_REJECTION_STAGE, at});
+const record         = (nodeId, rejectionBucket, at) => ({nodeId, rejectionBucket, stage: TYPE_GATE_REJECTION_STAGE, at});
+const livenessRecord = (nodeId, rejectionBucket, at) => ({
+    nodeId,
+    rejectionBucket,
+    stage: DISCUSSION_LIVENESS_REJECTION_STAGE,
+    at
+});
 
 test.describe('typeGateRejectionLedgerStore — the actionability type-gate rejection ledger (#15057 AC3)', () => {
     test('append (via the shared filename seam) → read round-trips the sibling ledger in append order', async () => {
@@ -60,6 +68,67 @@ test.describe('typeGateRejectionLedgerStore — the actionability type-gate reje
         await fs.rm(dir, {recursive: true, force: true});
     });
 
+    test('one physical stream exposes stage-isolated defaults and explicit liveness views', async () => {
+        const dir = await tmpDir();
+        await appendRouteAttribution(record('issue-actionability', ['epic'], 100), {dir, filename: TYPE_GATE_REJECTION_FILENAME});
+        await appendRouteAttribution(livenessRecord('discussion-dormant', ['undetermined-no-decaying-support'], 200), {dir, filename: TYPE_GATE_REJECTION_FILENAME});
+
+        expect((await readTypeGateRejectionLedger({dir})).map(row => row.nodeId)).toEqual(['issue-actionability']);
+        expect((await readTypeGateRejectionLedger({dir, stage: DISCUSSION_LIVENESS_REJECTION_STAGE})).map(row => row.nodeId))
+            .toEqual(['discussion-dormant']);
+
+        const mixed = await readRouteAttributionLedger({dir, filename: TYPE_GATE_REJECTION_FILENAME});
+        expect(summarizeTypeGateRejectionLedger(mixed)).toMatchObject({
+            total             : 1,
+            byRejectionBucket : {epic: 1},
+            byRejectionLabel  : {epic: 1},
+            rejectedNodeCounts: {'issue-actionability': 1},
+            lastEventAt       : 100
+        });
+        expect(summarizeTypeGateRejectionLedger(mixed, {stage: DISCUSSION_LIVENESS_REJECTION_STAGE})).toMatchObject({
+            total             : 1,
+            byRejectionBucket : {'undetermined-no-decaying-support': 1},
+            byRejectionLabel  : {},
+            rejectedNodeCounts: {'discussion-dormant': 1},
+            lastEventAt       : 200
+        });
+        expect(queryTypeGateRejectionLedger(mixed).map(row => row.nodeId)).toEqual(['issue-actionability']);
+        expect(queryTypeGateRejectionLedger(mixed, {stage: DISCUSSION_LIVENESS_REJECTION_STAGE}).map(row => row.nodeId))
+            .toEqual(['discussion-dormant']);
+        await fs.rm(dir, {recursive: true, force: true})
+    });
+
+    test('maxEvents is retained per stage — later liveness pressure cannot evict the actionability view', async () => {
+        const dir = await tmpDir();
+
+        await appendTypeGateRejection(record('issue-actionability', ['epic'], 100), {
+            dir,
+            maxEvents   : 2,
+            triggerBytes: 0
+        });
+        await appendTypeGateRejection(livenessRecord('discussion-liveness-1', ['terminal'], 200), {
+            dir,
+            maxEvents   : 2,
+            triggerBytes: 0
+        });
+        await appendTypeGateRejection(livenessRecord('discussion-liveness-2', ['terminal'], 300), {
+            dir,
+            maxEvents   : 2,
+            triggerBytes: 0
+        });
+
+        expect((await readTypeGateRejectionLedger({dir})).map(row => row.nodeId))
+            .toEqual(['issue-actionability']);
+        expect((await readTypeGateRejectionLedger({dir, stage: DISCUSSION_LIVENESS_REJECTION_STAGE})).map(row => row.nodeId))
+            .toEqual(['discussion-liveness-1', 'discussion-liveness-2']);
+
+        const physicalRows = await readRouteAttributionLedger({dir, filename: TYPE_GATE_REJECTION_FILENAME});
+        expect(physicalRows.map(row => row.nodeId))
+            .toEqual(['issue-actionability', 'discussion-liveness-1', 'discussion-liveness-2']);
+
+        await fs.rm(dir, {recursive: true, force: true})
+    });
+
     test('summarize folds exclusion labels + rejected-node counts + the newest timestamp', () => {
         const summary = summarizeTypeGateRejectionLedger([
             record('issue-1', ['epic'], 100),
@@ -68,6 +137,7 @@ test.describe('typeGateRejectionLedgerStore — the actionability type-gate reje
         ]);
 
         expect(summary.total).toBe(3);
+        expect(summary.byRejectionBucket).toEqual({epic: 2, 'not-code-ready': 2});
         expect(summary.byRejectionLabel).toEqual({epic: 2, 'not-code-ready': 2});
         expect(summary.rejectedNodeCounts).toEqual({'issue-1': 2, 'issue-2': 1});
         expect(summary.lastEventAt).toBe(300);
@@ -80,9 +150,9 @@ test.describe('typeGateRejectionLedgerStore — the actionability type-gate reje
             record('issue-2', ['epic'], 2)
         ]);
 
-        expect(summary.total).toBe(3);                              // total is row count
+        expect(summary.total).toBe(1);                              // missing-stage rows never enter a stage view
         expect(summary.byRejectionLabel).toEqual({epic: 1});       // only the well-formed bucket folds
-        expect(summary.rejectedNodeCounts).toEqual({'issue-1': 1, 'issue-2': 1});
+        expect(summary.rejectedNodeCounts).toEqual({'issue-2': 1});
     });
 
     test('query restricts by time window / exclusion labels / node ids and returns newest-first, capped', () => {

--- a/test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/IssueIngestor.spec.mjs
@@ -70,6 +70,11 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
             "createdAt: '2026-05-20T10:00:00Z'",
             "updatedAt: '2026-05-20T11:00:00Z'",
             'closed: false',
+            'routingDispositionSchemaVersion: discussion-routing-disposition.v1',
+            'routingDisposition: active',
+            'routingDispositionReason: explicit-active-marker',
+            'routingDispositionEvidence:',
+            '  - marker:OQ_RESOLUTION_PENDING',
             '---',
             '# Open Discussion Body'
         ].join('\n'),
@@ -82,6 +87,11 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
             "updatedAt: '2026-05-20T11:00:00Z'",
             'closed: true',
             "closedAt: '2026-05-20T12:00:00Z'",
+            'routingDispositionSchemaVersion: discussion-routing-disposition.v1',
+            'routingDisposition: terminal',
+            'routingDispositionReason: github-closed',
+            'routingDispositionEvidence:',
+            '  - github:closed',
             '---',
             '# Closed Discussion Body'
         ].join('\n'),
@@ -315,26 +325,223 @@ test.describe('Neo.ai.daemons.services.IssueIngestor', () => {
         const closedNode = graphNodes.find(node => node.id === 'discussion-3002');
 
         expect(openNode.properties).toMatchObject({
-            state   : 'OPEN',
-            closed  : false,
-            closedAt: null,
-            category: 'Ideas'
+            state                          : 'OPEN',
+            closed                         : false,
+            closedAt                       : null,
+            category                       : 'Ideas',
+            routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+            routingDisposition             : 'active',
+            routingDispositionReason       : 'explicit-active-marker',
+            routingDispositionEvidence     : ['marker:OQ_RESOLUTION_PENDING']
         });
         expect(closedNode.properties).toMatchObject({
-            state   : 'CLOSED',
-            closed  : true,
-            closedAt: '2026-05-20T12:00:00Z',
-            category: 'Q&A'
+            state             : 'CLOSED',
+            closed            : true,
+            closedAt          : '2026-05-20T12:00:00Z',
+            category          : 'Q&A',
+            routingDisposition: 'terminal'
         });
 
         const closedUpsert = upserts.find(payload => payload.ids[0] === 'discussion-3002');
         expect(closedUpsert.metadatas[0]).toMatchObject({
-            type    : 'DISCUSSION',
-            state   : 'CLOSED',
-            closed  : true,
-            closedAt: '2026-05-20T12:00:00Z',
-            category: 'Q&A'
+            type                      : 'DISCUSSION',
+            state                     : 'CLOSED',
+            closed                    : true,
+            closedAt                  : '2026-05-20T12:00:00Z',
+            category                  : 'Q&A',
+            routingDisposition        : 'terminal',
+            routingDispositionReason  : 'github-closed',
+            routingDispositionEvidence: '["github:closed"]'
         });
+    });
+
+    test('ingestDiscussionStates() skips malformed frontmatter without suppressing valid siblings', async () => {
+        const priorReaddir  = fs.promises.readdir;
+        const priorReadFile = fs.promises.readFile;
+        const upserts       = [];
+
+        StorageRouter.getGraphCollection = async () => ({
+            upsert: async payload => upserts.push(payload),
+            get   : async () => ({ ids: [], metadatas: [], documents: [] })
+        });
+        fs.promises.readdir = async (dirPath, options) => {
+            if (typeof dirPath === 'string' && dirPath.includes('resources/content/archive/discussions')) {
+                return [];
+            }
+            if (typeof dirPath === 'string' && dirPath.includes('resources/content/discussions')) {
+                return ['discussion-malformed.md', 'discussion-3001.md'];
+            }
+            return priorReaddir.call(fs.promises, dirPath, options);
+        };
+        fs.promises.readFile = async (filePath, encoding) => {
+            if (typeof filePath === 'string' && filePath.endsWith('discussion-malformed.md')) {
+                return '---\ntitle: [unterminated\n---\n# malformed';
+            }
+            return priorReadFile.call(fs.promises, filePath, encoding);
+        };
+
+        try {
+            await IssueIngestor.ingestDiscussionStates();
+        } finally {
+            fs.promises.readdir = priorReaddir;
+            fs.promises.readFile = priorReadFile;
+            StorageRouter.getGraphCollection = _originalGetGraphCollection;
+        }
+
+        expect(graphNodes.map(node => node.id)).toEqual(['discussion-3001']);
+        expect(upserts).toHaveLength(1);
+        expect(upserts[0].ids).toEqual(['discussion-3001']);
+    });
+
+    test('ingestDiscussionStates() fails loud when graph persistence rejects lifecycle state', async () => {
+        const priorUpsertNode = GraphService.upsertNode;
+
+        StorageRouter.getGraphCollection = async () => ({
+            upsert: async () => {},
+            get   : async () => ({ ids: [], metadatas: [], documents: [] })
+        });
+        GraphService.upsertNode = () => {
+            throw new Error('graph persistence failed');
+        };
+
+        try {
+            await expect(IssueIngestor.ingestDiscussionStates()).rejects.toThrow('graph persistence failed');
+        } finally {
+            GraphService.upsertNode = priorUpsertNode;
+            StorageRouter.getGraphCollection = _originalGetGraphCollection;
+        }
+    });
+
+    test('ingestDiscussionStates() fails loud when vector persistence rejects lifecycle state', async () => {
+        StorageRouter.getGraphCollection = async () => ({
+            upsert: async () => {
+                throw new Error('vector persistence failed');
+            },
+            get: async () => ({ ids: [], metadatas: [], documents: [] })
+        });
+
+        try {
+            await expect(IssueIngestor.ingestDiscussionStates()).rejects.toThrow('vector persistence failed');
+        } finally {
+            StorageRouter.getGraphCollection = _originalGetGraphCollection;
+        }
+    });
+
+    test('ingestDiscussionStates() selects the newly active source over a stale archive duplicate', async () => {
+        const priorReaddir  = fs.promises.readdir;
+        const priorReadFile = fs.promises.readFile;
+        const upserts       = [];
+        const staleArchive  = [
+            '---',
+            'number: 3001',
+            'title: Stale Archived Discussion',
+            'category: Ideas',
+            "createdAt: '2026-05-20T10:00:00Z'",
+            "updatedAt: '2026-05-20T10:30:00Z'",
+            'closed: true',
+            "closedAt: '2026-05-20T10:30:00Z'",
+            'routingDispositionSchemaVersion: discussion-routing-disposition.v1',
+            'routingDisposition: terminal',
+            'routingDispositionReason: github-closed',
+            'routingDispositionEvidence:',
+            '  - github:closed',
+            '---',
+            '# Stale Archived Discussion Body'
+        ].join('\n');
+
+        StorageRouter.getGraphCollection = async () => ({
+            upsert: async payload => upserts.push(payload),
+            get   : async () => ({ ids: [], metadatas: [], documents: [] })
+        });
+        fs.promises.readdir = async (dirPath, options) => {
+            if (typeof dirPath === 'string' && dirPath.includes('resources/content/archive/discussions')) {
+                return ['v13.1.0/discussion-3001.md'];
+            }
+            if (typeof dirPath === 'string' && dirPath.includes('resources/content/discussions')) {
+                return ['discussion-3001.md'];
+            }
+            return priorReaddir.call(fs.promises, dirPath, options);
+        };
+        fs.promises.readFile = async (filePath, encoding) => {
+            const normalized = typeof filePath === 'string' ? filePath.replace(/\\/g, '/') : '';
+            if (normalized.endsWith('resources/content/archive/discussions/v13.1.0/discussion-3001.md')) {
+                return staleArchive;
+            }
+            return priorReadFile.call(fs.promises, filePath, encoding);
+        };
+
+        try {
+            await IssueIngestor.ingestDiscussionStates();
+        } finally {
+            fs.promises.readdir = priorReaddir;
+            fs.promises.readFile = priorReadFile;
+            StorageRouter.getGraphCollection = _originalGetGraphCollection;
+        }
+
+        const discussionNodes = graphNodes.filter(node => node.id === 'discussion-3001');
+        expect(discussionNodes).toHaveLength(1);
+        expect(discussionNodes[0].properties).toMatchObject({
+            state             : 'OPEN',
+            closed            : false,
+            routingDisposition: 'active'
+        });
+        expect(upserts).toHaveLength(1);
+        expect(upserts[0].metadatas[0]).toMatchObject({
+            state : 'OPEN',
+            closed: false
+        });
+    });
+
+    test('normalizes Discussion routing projection as one atomic current-or-legacy tuple', () => {
+        const normalize = IssueIngestor.constructor.normalizeDiscussionRoutingProjection;
+        const current   = normalize({
+            routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+            routingDisposition             : 'terminal',
+            routingDispositionReason       : 'graduated-to-ticket',
+            routingDispositionEvidence     : ['marker:GRADUATED_TO_TICKET']
+        });
+
+        expect(current).toEqual({
+            schemaVersion: 'discussion-routing-disposition.v1',
+            disposition  : 'terminal',
+            reason       : 'graduated-to-ticket',
+            evidence     : ['marker:GRADUATED_TO_TICKET']
+        });
+
+        for (const malformed of [
+            {},
+            {
+                routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+                routingDisposition             : 'invalid',
+                routingDispositionReason       : 'graduated-to-ticket',
+                routingDispositionEvidence     : ['marker:GRADUATED_TO_TICKET']
+            },
+            {
+                routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+                routingDisposition             : 'terminal',
+                routingDispositionReason       : 'graduated-to-ticket',
+                routingDispositionEvidence     : '["marker:GRADUATED_TO_TICKET"]'
+            },
+            {
+                routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+                routingDisposition             : 'terminal',
+                routingDispositionReason       : '',
+                routingDispositionEvidence     : []
+            },
+            {
+                routingDispositionSchemaVersion: 'discussion-routing-disposition.v1',
+                routingDisposition             : 'active',
+                routingDispositionReason       : 'github-closed',
+                routingDispositionEvidence     : ['marker:GRADUATED_TO_TICKET']
+            }
+        ]) {
+            expect(normalize(malformed)).toEqual({
+                schemaVersion: 'discussion-routing-disposition.legacy',
+                disposition  : 'undetermined',
+                reason       : 'legacy-or-invalid-projection',
+                evidence     : []
+            })
+        }
     });
 
     test('ingestPullRequestFeedback() creates PR nodes and RESOLVES edges from PR markdown (#12644)', async () => {

--- a/test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs
@@ -16,6 +16,10 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
+import Database       from '../../../../../../ai/graph/Database.mjs';
+import SQLite         from '../../../../../../ai/graph/storage/SQLite.mjs';
+import fs             from 'fs-extra';
+import path           from 'path';
 
 /**
  * Graph RLS read-side return boundary.
@@ -40,8 +44,8 @@ function node(id, properties = {}) {
     return {id, label: properties.type || 'TestNode', properties};
 }
 
-function edge(id, source, target, weight = 1.0, props = {}) {
-    return {id, source, target, type: 'REL', properties: {weight, ...props}};
+function edge(id, source, target, weight = 1.0, props = {}, type = 'REL') {
+    return {id, source, target, type, properties: {weight, ...props}};
 }
 
 /**
@@ -233,6 +237,145 @@ test.describe('GraphService — RLS read-side return boundary (#10011)', () => {
         requester.value = '@tenant-b';
 
         expect(GraphService.getNeighbors({id: 'root-b'}).neighbors).toEqual([]);
+    });
+
+    test('getInboundStructuralSupport requires visible root, inbound source node, and edge', () => {
+        const privateSourceEdge = edge('e-private-source', 'source-a', 'root-b', 2),
+              privateEdge       = edge('e-private-edge', 'source-team', 'root-b', 3, {userId: '@tenant-a'}),
+              teamEdge          = edge('e-team', 'source-team', 'root-b', 4, {visibility: 'team'});
+
+        GraphService.db = makeFakeDb([
+            node('root-b',      {userId: '@tenant-b'}),
+            node('root-a',      {userId: '@tenant-a'}),
+            node('source-a',    {userId: '@tenant-a'}),
+            node('source-team', {visibility: 'team'})
+        ], [privateSourceEdge, privateEdge, teamEdge]);
+        requester.value = '@tenant-b';
+
+        expect(GraphService.getInboundStructuralSupport({id: 'root-a'})).toBeNull();
+        expect(GraphService.getInboundStructuralSupport({id: 'root-b'})).toEqual({
+            totalWeight      : 4,
+            decayingWeight   : 4,
+            totalEdgeCount   : 1,
+            decayingEdgeCount: 1,
+            hasOpenBlocker   : false,
+            parentId         : null
+        })
+    });
+
+    test('getInboundStructuralSupport ignores private blockers and parents in a warm cross-tenant cache', () => {
+        GraphService.db = makeFakeDb([
+            node('root-b',         {userId: '@tenant-b'}),
+            node('blocker-a',      {userId: '@tenant-a', state: 'OPEN'}),
+            node('blocker-team',   {visibility: 'team', state: 'OPEN'}),
+            node('parent-a',       {userId: '@tenant-a'}),
+            node('parent-team',    {visibility: 'team'})
+        ], [
+            edge('block-private-source', 'blocker-a',    'root-b', 1, {}, 'BLOCKS'),
+            edge('block-private-edge',   'blocker-team', 'root-b', 1, {userId: '@tenant-a'}, 'BLOCKS'),
+            edge('parent-private',       'parent-a',     'root-b', 1, {}, 'PARENT_OF'),
+            edge('parent-visible',       'parent-team',  'root-b', 1, {visibility: 'team'}, 'PARENT_OF')
+        ]);
+        requester.value = '@tenant-b';
+
+        expect(GraphService.getInboundStructuralSupport({id: 'root-b'})).toEqual({
+            totalWeight      : 1,
+            decayingWeight   : 1,
+            totalEdgeCount   : 1,
+            decayingEdgeCount: 1,
+            hasOpenBlocker   : false,
+            parentId         : 'parent-team'
+        })
+    });
+
+    test('getInboundStructuralSupport lazy-loads the same SQLite vicinity once per requester scope', async () => {
+        const
+            dbPath = path.resolve(
+                process.cwd(),
+                'tmp',
+                `graph-inbound-support-tenant-cache-${globalThis.crypto.randomUUID()}.sqlite`
+            ),
+            storage = Neo.create(SQLite, {dbPath});
+
+        let database,
+            activeRequester = '@tenant-a',
+            loadedScopes    = [];
+
+        try {
+            await storage.initAsync();
+
+            storage.RequestContextService = {
+                getUserId: () => activeRequester
+            };
+
+            const loadNodeVicinitySync = storage.loadNodeVicinitySync.bind(storage);
+            storage.loadNodeVicinitySync = nodeIds => {
+                loadedScopes.push(activeRequester);
+                return loadNodeVicinitySync(nodeIds)
+            };
+
+            storage.addNodes([
+                node('shared-root'),
+                node('support-a', {userId: 'tenant-a'}),
+                node('blocker-a', {userId: 'tenant-a', state: 'OPEN'}),
+                node('parent-a',  {userId: 'tenant-a'}),
+                node('support-b', {userId: 'tenant-b'}),
+                node('blocker-b', {userId: 'tenant-b', state: 'CLOSED'}),
+                node('parent-b',  {userId: 'tenant-b'})
+            ]);
+            storage.addEdges([
+                edge('support-edge-a', 'support-a', 'shared-root', 2, {userId: 'tenant-a'}, 'ADVANCES'),
+                edge('blocker-edge-a', 'blocker-a', 'shared-root', 1, {userId: 'tenant-a'}, 'BLOCKS'),
+                edge('parent-edge-a',  'parent-a',  'shared-root', 1, {userId: 'tenant-a'}, 'PARENT_OF'),
+                edge('support-edge-b', 'support-b', 'shared-root', 5, {userId: 'tenant-b'}, 'ADVANCES'),
+                edge('blocker-edge-b', 'blocker-b', 'shared-root', 1, {userId: 'tenant-b'}, 'BLOCKS'),
+                edge('parent-edge-b',  'parent-b',  'shared-root', 1, {userId: 'tenant-b'}, 'PARENT_OF')
+            ]);
+
+            database = Neo.create(Database, {
+                id: `graph-inbound-support-tenant-cache-${globalThis.crypto.randomUUID()}`,
+                storage
+            });
+            await storage.load();
+            GraphService.db = database;
+
+            const supportA = {
+                totalWeight      : 3,
+                decayingWeight   : 3,
+                totalEdgeCount   : 2,
+                decayingEdgeCount: 2,
+                hasOpenBlocker   : true,
+                parentId         : 'parent-a'
+            };
+
+            expect(GraphService.getInboundStructuralSupport({id: 'shared-root'})).toEqual(supportA);
+            expect(GraphService.getInboundStructuralSupport({id: 'shared-root'})).toEqual(supportA);
+
+            activeRequester = '@tenant-b';
+
+            const supportB = {
+                totalWeight      : 6,
+                decayingWeight   : 6,
+                totalEdgeCount   : 2,
+                decayingEdgeCount: 2,
+                hasOpenBlocker   : false,
+                parentId         : 'parent-b'
+            };
+
+            expect(GraphService.getInboundStructuralSupport({id: 'shared-root'})).toEqual(supportB);
+            expect(GraphService.getInboundStructuralSupport({id: 'shared-root'})).toEqual(supportB);
+            expect(loadedScopes).toEqual(['@tenant-a', '@tenant-b'])
+        } finally {
+            database?.destroy();
+
+            if (storage.db?.open) {
+                storage.db.close()
+            }
+
+            for (const suffix of ['', '-wal', '-shm']) {
+                fs.removeSync(dbPath + suffix)
+            }
+        }
     });
 
     test('queryNodeTopology omits a cross-tenant private edge between visible nodes', () => {

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -24,6 +24,7 @@ import {getPaths}      from '../../../../../../ai/graph/queries/traversal.mjs';
 
 test.describe('Neo.ai.services.memory-core.GraphService', () => {
     let GraphService;
+    let protectedEdgeTypes;
     let SystemLifecycleService;
     let service;
     const testDbName = `memory-core-graph-test-${process.pid}-${Date.now()}.sqlite`;
@@ -42,7 +43,9 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         // resolve to test values BY CONSTRUCTION under UNIT_TEST_MODE (config.template's
         // `useTestDatabase` toggle). The test never mutates the shared AiConfig singleton.
 
-        GraphService = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default;
+        const graphModule = await import('../../../../../../ai/services/memory-core/GraphService.mjs');
+        GraphService       = graphModule.default;
+        protectedEdgeTypes = graphModule.PROTECTED_EDGE_TYPES;
         SystemLifecycleService = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default;
         if (fs.existsSync(testDbPath)) {
             try {
@@ -193,6 +196,52 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(JSON.parse(resolvesRow.data).properties.weight).toBe(0.05);
 
         expect(edgeRow.get('AmbientSource', 'AmbientTarget', 'RELATES_TO')).toBeUndefined();
+    });
+
+    test('getInboundStructuralSupport separates canonical protected facts from current decaying scent', async () => {
+        await GraphService.upsertNode({id: 'discussion-15105', type: 'DISCUSSION'});
+
+        for (const [index, type] of protectedEdgeTypes.entries()) {
+            const source = `protected-source-${index}`;
+            await GraphService.upsertNode({id: source, type: 'TEST_NODE'});
+            GraphService.linkNodes(source, 'discussion-15105', type, 1)
+        }
+
+        await GraphService.upsertNode({id: 'scent-source', type: 'TEST_NODE'});
+        await GraphService.upsertNode({id: 'blocker-source', type: 'TEST_NODE', properties: {state: 'OPEN'}});
+        await GraphService.upsertNode({id: 'parent-source', type: 'ISSUE'});
+        await GraphService.upsertNode({id: 'frontier', type: 'CONTEXT_FRONTIER'});
+        await GraphService.upsertNode({id: 'outbound-target', type: 'TEST_NODE'});
+        GraphService.linkNodes('scent-source', 'discussion-15105', 'GUIDES', 2);
+        GraphService.linkNodes('frontier', 'discussion-15105', 'GUIDES', 3);
+        GraphService.linkNodes('parent-source', 'discussion-15105', 'PARENT_OF', 1);
+        GraphService.linkNodes('blocker-source', 'discussion-15105', 'BLOCKS', 5);
+        GraphService.linkNodes('discussion-15105', 'outbound-target', 'RELATES_TO', 7);
+
+        expect(GraphService.getInboundStructuralSupport({id: 'discussion-15105'})).toEqual({
+            totalWeight      : protectedEdgeTypes.length + 6,
+            decayingWeight   : 3,
+            totalEdgeCount   : protectedEdgeTypes.length + 3,
+            decayingEdgeCount: 2,
+            hasOpenBlocker   : true,
+            parentId         : 'parent-source'
+        })
+    });
+
+    test('getInboundStructuralSupport propagates graph-store failures to the fail-loud caller', async () => {
+        await GraphService.upsertNode({id: 'discussion-support-failure', type: 'DISCUSSION'});
+        const originalGetAdjacentNodes = GraphService.db.getAdjacentNodes;
+
+        GraphService.db.getAdjacentNodes = () => {
+            throw new Error('simulated structural projection failure')
+        };
+
+        try {
+            expect(() => GraphService.getInboundStructuralSupport({id: 'discussion-support-failure'}))
+                .toThrow('simulated structural projection failure')
+        } finally {
+            GraphService.db.getAdjacentNodes = originalGetAdjacentNodes
+        }
     });
 
     test('decayGlobalTopology preserves business ADVANCED_BY edges — advancement is a fact, not scent (#14446)', async () => {


### PR DESCRIPTION
Resolves #15105

Related: #14472

Golden Path now replenishes the semantic candidate prefix after state, blocker, actionability, and typed Discussion-liveness filtering instead of treating the raw top 20 as the route contract. A single trusted-root Discussion classifier projects lifecycle facts through sync and ingestion; the graph exposes RLS-safe total versus decaying inbound support; canonical ranking math remains unchanged; final-pass rejection evidence stays in the existing stage-isolated ledger.

Evidence: L3 achieved on behavioral ancestor `92fdc2999348eb3d0f617b854ce6270e83b0d7a4` by isolated live source → ingest → SQLite/Chroma equality → fresh Golden Path hindcast. Run `15105-l3-attempt6-vlujdo` selected only `issue-15105`; closed `issue-15089`, terminal `discussion-10289`, and undetermined `discussion-14561` were excluded. Exact head `a80abd607c37140840d786c5b7c5e41c37492caf` additionally repairs Neo class lifecycle, Setext section authority, and ADR-0019-safe test fixtures; the exact-head focused matrix and mechanical gates below pass while hosted CI runs.

## Deltas from ticket

- The persisted lifecycle tuple is normalized atomically: any malformed or contradictory v1 field set degrades together to legacy `undetermined` rather than mixing current and legacy authority.
- Current-body classification ignores lifecycle-looking examples inside fenced/quoted content and historical, retrospective, archived, instructional, or how-to ATX/Setext heading subtrees; sibling or higher current-authority headings restore classification.
- Requester-scoped vicinity markers preserve RLS isolation across sequential tenants. The marker is a dedicated one-class module extending `Neo.core.Base`, created and destroyed through Database’s config lifecycle; SQLite invalidation removes every stale same-id secondary-index reference before lazy reload.
- Active/archive Discussion mirrors are canonicalized by current source timestamps and deterministic source precedence. Operational graph/vector failures propagate; malformed YAML remains a bounded local skip.
- The graph projection excludes canonical protected fact edges and prior `frontier → GUIDES` output from decaying support, preventing Golden Path from authorizing its own next run.
- Adaptive admission is count-bounded, ID-deduplicated, SQLite-chunked, and fail-loud at its safe ceiling. Every ANN pass requires a one-query nested ids/distances envelope with equal lengths, nonblank IDs, and nonnegative finite numeric distances.
- Adaptive admission publishes only the final whole-prefix attempt; later query, distance, or structural failures discard provisional routes and ledger rows through the existing fail-loud result. Budget exhaustion retains diagnostics without publishing rejection-ledger rows for an unsuccessful attempt.
- The one physical rejection stream now retains its actionability and Discussion-liveness stages independently, so liveness pressure cannot evict the actionability view.
- No ranking formula, Direction-GP input, Bird View, hook renderer, config leaf, or new ledger was added.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/discussionRoutingDisposition.spec.mjs test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs --reporter=dot` — **81 passed** on exact head `a80abd607c`.
- `npm run test-unit -- test/playwright/unit/ai/graph/Database.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs test/playwright/unit/ai/services/memory-core/GraphService.TenantIsolation.spec.mjs --reporter=dot` — **79 passed** on exact head `a80abd607c` in the unsandboxed test harness.
- Earlier exact affected matrix: **212 passed, 8 skipped**; non-skipped `DreamServiceGoldenPath.spec.mjs`: **1 passed** with a hermetic exact-fixture vector boundary.
- Independent final-diff matrix on alternate isolated Chroma port — **199 passed** before the final audit folds; targeted admission/Hebbian falsifiers then passed.
- `npm run ai:audit-discussion-lifecycle -- --self-test` — passed.
- `npm run --silent ai:structure-map -- --files --loc` — passed; the new pure helper remains in the existing GitHub Workflow shared-helper home.
- `npm run agent-preflight -- --no-fix <changed/new .mjs files>` — 0 ticket-archaeology violations; all requested gates passed. The staged `check-aiconfig-test-mutation` hook also passed with zero new shared-singleton writes.
- `node --check <changed/new .mjs files>` and `git diff --check` — passed.
- Hosted CI was fully green on ancestor `0e70f39a49`; exact head `a80abd607c` is pending after the authority/test-fixture repair.
- Broad-suite receipts are disclosed, not promoted: the 9-worker hermetic run was killed with exit 137 after 5,363/6,895 tests; the 4-worker hermetic run reached the full test list but ended with 6,738 passed, 116 skipped, 15 cross-suite shared-state failures, 26 non-runs, and one non-test error. The exact affected matrix above is green.

## L3 Live Receipt

- Behavioral ancestor: `92fdc2999348eb3d0f617b854ce6270e83b0d7a4`; captured `2026-07-13T00:15:30.162Z`; GitHub identity `neo-gpt`. Exact-head L3 is not claimed after the class-lifecycle-only repair.
- Fresh non-git mirror; initial source Markdown count `0`; isolated Chroma port `54831` (shared ports `8000` and `18180` excluded); isolated service stopped after the receipt and the port was verified closed.
- Configured provider `openAiCompatible`: observed vector dimension `4096`, configured dimension `4096`, all values finite.
- Live sync fetched exactly issues `15105`, `15089` and discussions `10289`, `14561`.
- SQLite cohort: all four source nodes. Active semantic cohort: `issue-15105`, `discussion-10289`, `discussion-14561`; the closed issue had no active vector.
- Discussion source/SQLite/Chroma lifecycle tuples deep-equaled. `discussion-10289` was terminal / graduated-to-ticket; `discussion-14561` was undetermined / no-authoritative-lifecycle-marker.
- Synthesis completed with 3 semantic candidates, 3 SQLite-open matches, 2 Discussion-liveness rejections, 1 selected node, corpus exhausted, and stop reason `render-limit-satisfied`.
- Parsed route and frontier `GUIDES` both equal `['issue-15105']`. Handoff SHA-256: `33f9065fec02c460fbc7622bf1f2becc7a34fcf90d3017fd1f595e324a7cc342`.

## Evidence Incident

The first L3 attempt accidentally reached a resident Chroma endpoint and refreshed 212 IDs before containment. A read-only audit found the resident collection healthy; no restore or drop was performed. A later truly isolated run stopped because the embedding provider degraded before a valid chain receipt. Subsequent harness-only failures were preserved rather than promoted: one sandbox PID permission failure, one mirror that correctly rejected a non-empty committed corpus, and one receipt-serializer label defect after every substantive assertion had passed. The final fresh isolated run above is the sole L3 PASS receipt.

## Post-Merge Validation

- [ ] Inspect the next scheduled Golden Path pass for candidate-admission stop reason, final requested width, and stage-isolated Discussion-liveness rejection counts.

## Evolution

The implementation retained the ticket's source → graph → canonical-ranking composition while tightening falsified shortcuts: lifecycle classification never reads comments or raw timestamps; historical prose cannot masquerade as current lifecycle authority; liveness never treats protected history or prior Golden Path output as motion; malformed ANN envelopes never become priority; and tenant-scoped lazy loading cannot reuse another requester's visibility marker. The live-evidence incident also exposed why ad-hoc Chroma diagnostics require resolved-coordinate guards before any collection access.

Authored by Euclid (GPT-5.6 Sol, Ultra mode, Codex Desktop). Session 837ad74b-c2d2-413d-9aab-b7165a93a82a.
