### PR TITLE
test(util): cover String helpers

### DIFF
--- a/test/playwright/unit/util/String.spec.mjs
+++ b/test/playwright/unit/util/String.spec.mjs
@@ -1,0 +1,48 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'StringUtilTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import StringUtil     from '../../../../src/util/String.mjs';
+
+test.describe('Neo.util.String', () => {
+    test('escapeHtml replaces every character selected by charPattern', () => {
+        expect(StringUtil.escapeHtml('&<>"\'$\\')).toBe('&amp;&lt;&gt;&quot;&apos;&dollar;&bsol;')
+    });
+
+    test('unescapeHtml replaces every entity selected by entityPattern', () => {
+        expect(StringUtil.unescapeHtml(
+            '&amp;&lt;&gt;&quot;&apos;&dollar;&bsol;&sol;'
+        )).toBe('&<>"\'$\\/')
+    });
+
+    test('mapping helpers preserve unknown values', () => {
+        expect(StringUtil.getEntityFromChar('&')).toBe('&amp;');
+        expect(StringUtil.getEntityFromChar('x')).toBe('x');
+        expect(StringUtil.getCharFromEntity('&amp;')).toBe('&');
+        expect(StringUtil.getCharFromEntity('&unknown;')).toBe('&unknown;')
+    });
+
+    test('escapeHtml and unescapeHtml pass non-string input through unchanged', () => {
+        const objectValue = {value: '&amp;'};
+
+        expect(StringUtil.escapeHtml(objectValue)).toBe(objectValue);
+        expect(StringUtil.unescapeHtml(objectValue)).toBe(objectValue);
+        expect(StringUtil.escapeHtml(null)).toBeNull();
+        expect(StringUtil.unescapeHtml(42)).toBe(42)
+    });
+
+    test('uncapitalize only lowercases the first character and preserves falsy input', () => {
+        expect(StringUtil.uncapitalize('HelloWorld')).toBe('helloWorld');
+        expect(StringUtil.uncapitalize('alreadyLower')).toBe('alreadyLower');
+        expect(StringUtil.uncapitalize('')).toBe('');
+        expect(StringUtil.uncapitalize(null)).toBeNull();
+        expect(StringUtil.uncapitalize(false)).toBe(false)
+    })
+});


### PR DESCRIPTION
## Summary
- add focused unit coverage for every character selected by StringUtil.charPattern
- cover every supported entity, mapping fallbacks, and non-string pass-through
- pin uncapitalize behavior for uppercase, lowercase, empty, null, and false inputs

Closes #15118.

## Verification
- focused unit spec: 5 passed
- complete unit run: 6,975 tests collected; 6,693 passed, 85 skipped, 197 unrelated environment-sensitive failures; zero failures in String.spec.mjs
- all lint-staged gates passed: whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parser, and AiConfig mutation checks
- node syntax and staged diff checks passed

## AI disclosure
OpenAI Codex assisted with implementation and test execution. I reviewed the final diff and verification output.