### PR TITLE
test(util): cover Json extraction

### DIFF
--- a/test/playwright/unit/util/Json.spec.mjs
+++ b/test/playwright/unit/util/Json.spec.mjs
@@ -1,0 +1,61 @@
+import { setup } from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'JsonTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Json           from '../../../../src/util/Json.mjs';
+
+test.describe('Neo.util.Json', () => {
+    test('parses plain JSON objects and arrays', () => {
+        expect(Json.extract('{"name":"Neo","versions":[12,13]}')).toEqual({
+            name    : 'Neo',
+            versions: [12, 13]
+        });
+        expect(Json.extract('[1, true, null, "four"]')).toEqual([1, true, null, 'four']);
+    });
+
+    test('parses every supported Markdown fence form', () => {
+        for (const language of ['json', 'javascript', 'js', '']) {
+            expect(Json.extract(`\`\`\`${language}\n{"language":"${language || 'untagged'}"}\n\`\`\``)).toEqual({
+                language: language || 'untagged'
+            });
+        }
+    });
+
+    test('finds a supported fenced block inside surrounding text', () => {
+        const input = 'Here is the requested value:\n```json\n{"ready":true}\n```\nHope that helps.';
+
+        expect(Json.extract(input)).toEqual({ready: true});
+    });
+
+    test('returns null for empty, whitespace-only, and malformed input without throwing', () => {
+        for (const input of ['', '   \n\t', '{"missing":}', '```json\nnot json\n```']) {
+            expect(() => Json.extract(input)).not.toThrow();
+            expect(Json.extract(input)).toBeNull();
+        }
+    });
+
+    test('preserves representative nested JSON values', () => {
+        const input = JSON.stringify({
+            active : true,
+            count  : 3,
+            label  : 'nested',
+            missing: null,
+            values : [false, 1.5, {items: ['a', 'b']}]
+        });
+
+        expect(Json.extract(input)).toEqual({
+            active : true,
+            count  : 3,
+            label  : 'nested',
+            missing: null,
+            values : [false, 1.5, {items: ['a', 'b']}]
+        });
+    });
+});


### PR DESCRIPTION
**Does this PR resolve an issue?** (Required)

Closes #15117

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: focused unit coverage

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

**The PR fulfills this requirement:**

- [x] It's submitted to the `dev` branch, _not_ the `main` branch

**Other information:**

Adds a focused `Neo.util.Json.extract()` spec covering:

- plain objects and arrays
- `json`, `javascript`, `js`, and untagged Markdown fences
- fenced JSON surrounded by unrelated prose
- empty, whitespace-only, and malformed fail-closed inputs
- nested objects, arrays, booleans, numbers, strings, and `null`

Verification:

- focused Playwright unit spec: 5 passed
- all staged-file lint gates passed
- `git diff --check` passed

AI disclosure: Codex assisted with implementation and verification. I reviewed the complete diff and ran the checks reported above locally.
