### PR TITLE
perf(memory-core): bound session-summary discovery retention

### DIFF
--- a/ai/services/memory-core/SessionService.mjs
+++ b/ai/services/memory-core/SessionService.mjs
@@ -315,7 +315,9 @@ class SessionService extends Base {
      * **Logic:**
      * 1.  **Scope:** Fetches memory and summary metadata across all sessions (all-time). The prior
      *     30-day window was an obsolete safeguard from boot-coupled summarization that stranded old sessions.
-     * 2.  **Grouping:** Aggregates actual memory counts per session from the raw memory data.
+     * 2.  **Grouping:** Folds each fetched page directly into per-session count and latest-activity
+     *     state. Peak discovery retention therefore scales with distinct sessions plus one Chroma page,
+     *     rather than retaining metadata for every memory and summary row in the all-time scan.
      * 3.  **Comparison:**
      *     -   **Missing Summary:** If a session has memories but no summary, it is flagged.
      *     -   **Count Mismatch:** If `DB_Count !== Summary_Count`, it implies the session has changed
@@ -344,10 +346,10 @@ class SessionService extends Base {
         const limit         = aiConfig.summarizationBatchLimit;
         const maxIterations = 1000; // Safety break: max 2M records (2000 * 1000)
 
-        let allMetadatas = [];
-        let offset       = 0;
-        let hasMore      = true;
-        let iterations   = 0;
+        let offset              = 0;
+        let hasMore             = true;
+        let iterations          = 0;
+        let memoryMetadataCount = 0;
 
         // Build query options dynamically to avoid passing `where: undefined`
         const baseQueryOptions = {
@@ -355,7 +357,9 @@ class SessionService extends Base {
             limit
         };
 
-        const memoryQueryOptions = { ...baseQueryOptions };
+        const
+            memoryQueryOptions = { ...baseQueryOptions },
+            sessions           = new Map(); // sessionId => {count, lastActivity}
 
         while (hasMore) {
             if (iterations++ > maxIterations) {
@@ -369,7 +373,32 @@ class SessionService extends Base {
             if (batch.ids.length === 0) {
                 hasMore = false;
             } else {
-                allMetadatas = allMetadatas.concat(batch.metadatas);
+                memoryMetadataCount += batch.metadatas.length;
+
+                batch.metadatas.forEach(metadata => {
+                    const {sessionId} = metadata;
+
+                    if (!sessionId) return;
+
+                    let sessionData = sessions.get(sessionId);
+
+                    if (!sessionData) {
+                        sessionData = {count: 0, lastActivity: 0};
+                        sessions.set(sessionId, sessionData)
+                    }
+
+                    sessionData.count++;
+
+                    // Normalize to epoch-ms (numeric, numeric-string, ISO, and the legacy
+                    // `Memory: <iso>` name formats are all in play) so lastActivity is a reliable
+                    // clock for the churn-gate below — mirrors getExternallyActiveSessionIds.
+                    const tsMs = this.resolveGraphTimestampMs(metadata.timestamp, metadata.name);
+
+                    if (tsMs !== null && tsMs > sessionData.lastActivity) {
+                        sessionData.lastActivity = tsMs
+                    }
+                });
+
                 offset += limit;
 
                 if (batch.ids.length < limit) {
@@ -378,36 +407,17 @@ class SessionService extends Base {
             }
         }
 
-        if (allMetadatas.length === 0) return [];
-
-        // 2. Group memories by session
-        const sessions = {}; // {sessionId: {count: number, lastActivity: number}}
-
-        allMetadatas.forEach(m => {
-            if (!m.sessionId) return;
-
-            if (!sessions[m.sessionId]) {
-                sessions[m.sessionId] = { count: 0, lastActivity: 0 };
-            }
-
-            sessions[m.sessionId].count++;
-            // Normalize to epoch-ms (numeric, numeric-string, ISO, and the legacy `Memory: <iso>`
-            // name formats are all in play) so lastActivity is a reliable clock for the churn-gate
-            // below — mirrors getExternallyActiveSessionIds' resolution.
-            const tsMs = this.resolveGraphTimestampMs(m.timestamp, m.name);
-            if (tsMs !== null && tsMs > sessions[m.sessionId].lastActivity) {
-                sessions[m.sessionId].lastActivity = tsMs;
-            }
-        });
+        if (memoryMetadataCount === 0) return [];
 
         // 3. Fetch existing summaries
-        // Matches the scope of the memory fetch (30 days or all).
-        let allSummaryMetadatas = [];
+        // Matches the all-time scope of the memory fetch.
         offset = 0;
         hasMore = true;
         iterations = 0;
 
-        const summaryQueryOptions = { ...baseQueryOptions };
+        const
+            summaryQueryOptions = { ...baseQueryOptions },
+            summaryMap          = new Map(); // sessionId => memoryCount
 
         while (hasMore) {
             if (iterations++ > maxIterations) {
@@ -421,7 +431,12 @@ class SessionService extends Base {
             if (batch.ids.length === 0) {
                 hasMore = false;
             } else {
-                allSummaryMetadatas = allSummaryMetadatas.concat(batch.metadatas);
+                batch.metadatas.forEach(metadata => {
+                    if (metadata.sessionId) {
+                        summaryMap.set(metadata.sessionId, metadata.memoryCount || 0)
+                    }
+                });
+
                 offset += limit;
 
                 if (batch.ids.length < limit) {
@@ -429,14 +444,6 @@ class SessionService extends Base {
                 }
             }
         }
-
-        const summaryMap = {}; // {sessionId: memoryCount}
-
-        allSummaryMetadatas.forEach(m => {
-            if (m.sessionId) {
-                summaryMap[m.sessionId] = m.memoryCount || 0;
-            }
-        });
 
         // 4. Determine candidates
         const nowMs = typeof now === 'number' ? now : new Date(now).getTime();
@@ -447,9 +454,8 @@ class SessionService extends Base {
         const externallyActiveSessionIds = this.getExternallyActiveSessionIds({now: nowMs});
         const sessionsToUpdate           = [];
 
-        Object.keys(sessions).forEach(sessionId => {
-            const sessionData  = sessions[sessionId];
-            const summaryCount = summaryMap[sessionId];
+        sessions.forEach((sessionData, sessionId) => {
+            const summaryCount = summaryMap.get(sessionId);
 
             // Skip the in-process current session (it summarizes on its own sunset).
             if (sessionId === this.currentSessionId) {

--- a/test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs
@@ -133,6 +133,113 @@ test.describe('SessionService.summarizeSession — memory-fetch pagination (clos
         }
     });
 
+    test('#15126: consumes discovery metadata page-locally while preserving candidate semantics', async () => {
+        const svc            = SDK.Memory_SessionService,
+              aiConfig       = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default,
+              batchLimit     = aiConfig.summarizationBatchLimit,
+              currentSession = svc.currentSessionId || 'fixture-current',
+              origMemGet     = svc.memoryCollection.get,
+              origSessions   = svc.sessionsCollection,
+              origActiveRead = svc.getExternallyActiveSessionIds,
+              origLegacyId   = svc._legacySessionId;
+
+        if (!svc.currentSessionId) {
+            svc.currentSessionId = currentSession
+        }
+
+        /**
+         * Returns metadata proxies that expire when the next page is requested. A consumer that
+         * retains full-scan pages and reads them after pagination completes fails deterministically;
+         * a page-local aggregator consumes every row before requesting the next page.
+         * @param {String} label
+         * @param {Object[][]} pages
+         * @returns {{get: Function, stats: Object}}
+         */
+        const createPageLocalFixture = (label, pages) => {
+            let activeRows = [], pageIndex = 0;
+
+            const stats = {
+                maxPageRows: 0,
+                pageCount  : 0,
+                totalRows  : 0
+            };
+
+            return {
+                async get({limit, offset = 0}) {
+                    expect(limit).toBe(batchLimit);
+                    expect(offset).toBe(pageIndex * batchLimit);
+
+                    activeRows.forEach(row => { row.active = false });
+
+                    const page = pages[pageIndex++] || [];
+
+                    activeRows = page.map(metadata => ({active: true, metadata}));
+                    stats.maxPageRows = Math.max(stats.maxPageRows, page.length);
+                    stats.pageCount++;
+                    stats.totalRows += page.length;
+
+                    return {
+                        ids      : page.map((_, index) => `${label}-${offset + index}`),
+                        metadatas: activeRows.map(row => new Proxy(row.metadata, {
+                            get(target, key, receiver) {
+                                if (!row.active) {
+                                    throw new Error(`${label} metadata from an expired page was retained`)
+                                }
+
+                                return Reflect.get(target, key, receiver)
+                            }
+                        }))
+                    }
+                },
+                stats
+            }
+        };
+
+        const
+            fullPage      = metadata => Array.from({length: batchLimit}, () => ({...metadata})),
+            memoryFixture = createPageLocalFixture('memory', [
+                fullPage({sessionId: 'stable',   timestamp: 100}),
+                fullPage({sessionId: 'mismatch', timestamp: 200}),
+                fullPage({sessionId: 'missing',  timestamp: 300}),
+                fullPage({timestamp: 400}),
+                [
+                    {sessionId: 'stable',   timestamp: 1001},
+                    {sessionId: 'mismatch', timestamp: 1002},
+                    {sessionId: 'missing',  timestamp: 1003},
+                    {sessionId: currentSession, timestamp: 1004},
+                    {sessionId: 'external', timestamp: 1005}
+                ]
+            ]),
+            summaryFixture = createPageLocalFixture('summary', [
+                [
+                    {sessionId: 'stable', memoryCount: batchLimit + 1},
+                    {sessionId: 'mismatch', memoryCount: 1},
+                    ...Array.from({length: batchLimit - 2}, () => ({}))
+                ],
+                [{sessionId: 'mismatch', memoryCount: batchLimit}]
+            ]);
+
+        svc.memoryCollection.get          = memoryFixture.get;
+        svc.sessionsCollection            = {get: summaryFixture.get};
+        svc.getExternallyActiveSessionIds = () => new Set(['external']);
+
+        try {
+            const candidates = await svc.findSessionsToSummarize({now: Date.now() + 60 * 60 * 1000});
+
+            // Stable is reconciled (2001 === 2001). Mismatch sees the last summary row across
+            // pages (2001 !== 2000). Missing has no summary. The current and externally-active
+            // sessions stay excluded, and candidate order remains newest-first.
+            expect(candidates).toEqual(['missing', 'mismatch']);
+            expect(memoryFixture.stats).toEqual({maxPageRows: batchLimit, pageCount: 5, totalRows: batchLimit * 4 + 5});
+            expect(summaryFixture.stats).toEqual({maxPageRows: batchLimit, pageCount: 2, totalRows: batchLimit + 1});
+        } finally {
+            svc.memoryCollection.get          = origMemGet;
+            svc.sessionsCollection            = origSessions;
+            svc.getExternallyActiveSessionIds = origActiveRead;
+            svc._legacySessionId               = origLegacyId
+        }
+    });
+
     test('reconstructs a dropped turn-document from split metadata before synthesis (#14211 de-dup read)', async () => {
         const svc        = SDK.Memory_SessionService,
               aiConfig   = (await import('../../../../../../ai/mcp/server/memory-core/config.mjs')).default,


### PR DESCRIPTION
Resolves #15126

`SessionService.findSessionsToSummarize()` now folds each Chroma page directly into bounded per-session maps instead of retaining every memory and summary metadata row until the all-time scans finish. Pagination, timestamp normalization, eligibility gates, candidate ordering, and last-summary-row semantics remain in place.

Evidence: L2 — a deterministic page-expiry fixture consumes 8,005 memory rows across 5 pages and 2,001 summary rows across 2 pages while retaining only 5 distinct session aggregates plus the active page; current-session, externally-active, reconciled, mismatch, missing-summary, newest-first, churn, future-skew, and unparseable-timestamp behavior is covered. L2 required — this is an internal service allocation-shape change with no user-facing runtime surface. No residuals.

## Deltas from ticket

None substantive. The regression fixture additionally pins the existing current-session and externally-active exclusions so parity does not depend on the older live A2A fixture.

## Test Evidence

- `npm run agent-preflight -- --no-fix ai/services/memory-core/SessionService.mjs test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs` — passed.
- `node --check` on both changed modules — passed.
- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/SessionService.SummarizePagination.spec.mjs test/playwright/unit/ai/services/memory-core/SessionService.ChurnCooldown.spec.mjs --workers=1` — 8/8 passed against an ephemeral Chroma instance.
- Full `npm run test-unit` — 7,077 passed, 5 skipped, 27 failed; all 3 tests in the touched pagination spec passed. The remaining failures span live-fixture/environment surfaces. Baseline was not established, so they are disclosed rather than labeled pre-existing.
- Isolated legacy `QueryReRanker.spec.mjs --grep findSessionsToSummarize` — 3/5 passed. One failing external-activity assertion stops before the touched method; the stale-session fixture no longer returns the caller-supplied session id from its tool write. The new hermetic fixture pins both eligibility boundaries directly.
- Surface: `SessionService.findSessionsToSummarize()` — memory and summary discovery now aggregate page-locally; returned candidate semantics stay covered by deterministic unit tests.
- Non-CI coverage: None found — this internal Memory Core service path has focused unit coverage and no whitebox E2E surface.

## Post-Merge Validation

- [ ] Confirm the focused SessionService unit cohort remains green on merged `dev`.
- [ ] Observe the next scheduled drift sweep for unchanged candidate behavior and absence of discovery errors.

Authored by Emmy (GPT-5.6 Sol, Codex Desktop). Session f95e01ff-ba36-409a-98af-573263fab247.
