### PR TITLE
feat(fleet): prepare managed workspaces before launch (#15048)

### DIFF
--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -145,14 +145,15 @@ export const BOOTSTRAP_CONFIGS = [
 ];
 
 /**
- * Blocklist of `.neo-ai-data/` children that must NEVER be symlinked to canonical.
+ * Blocklist of live `.neo-ai-data/` children that must NEVER be symlinked to canonical.
  *
  * **Blocklist, not allowlist.** The retired `DATA_SUBDIRS_TO_LINK` allowlist enumerated exactly
  * which subdirs to link — and silently drifted: `memory-wal` was never added, so every
  * non-canonical clone wrote its `add_memory` WAL to its own un-drained dir, orphaning thousands
  * of records across clones for ~8 days. {@link symlinkDataDir} now links EVERY child of
- * canonical's `.neo-ai-data/` EXCEPT the entries here, so a newly-introduced substrate child is
- * unified automatically — the drift class is gone by construction.
+ * canonical's `.neo-ai-data/` EXCEPT the live entries here and the separately-owned canonical
+ * read-alias names, so a newly-introduced substrate child is unified automatically without two
+ * hydration primitives fighting over one alias path.
  *
  * Two kinds of entry:
  * 1. **`concepts/`** — the ONLY git-tracked item inside `.neo-ai-data/` (`.gitignore`:
@@ -181,6 +182,18 @@ export const DATA_SUBDIRS_BLOCKLIST = ['concepts', 'orchestrator-daemon', 'embed
 export const CANONICAL_DATA_READ_ALIASES = [
     {source: 'orchestrator-daemon', alias: 'orchestrator-daemon-canonical'}
 ];
+
+// A read alias is safe only when the live source name stays clone-local. Keep that cross-registry
+// invariant executable: adding an alias without blocklisting its source would let symlinkDataDir()
+// mount the canonical live path first, then expose the same state again under the read alias.
+for (const {source, alias} of CANONICAL_DATA_READ_ALIASES) {
+    if (!DATA_SUBDIRS_BLOCKLIST.includes(source)) {
+        throw new Error(
+            `bootstrapWorktree: canonical data read alias '${alias}' requires source '${source}' ` +
+            'to remain in DATA_SUBDIRS_BLOCKLIST.'
+        );
+    }
+}
 
 /**
  * Allowlist of gitignored single files (outside `.neo-ai-data/`) to symlink to canonical
@@ -359,14 +372,19 @@ async function exists(p) {
  * daemons spawned from different worktrees can't see each other's locks. Same logic for
  * the persistent `.neo-ai-data/wake-daemon/bridge.log` substrate.
  *
- * Idempotent per-subdir by design: an existing symlink reports `'already-linked'`; a
+ * Idempotent per-subdir by design: an existing symlink to the canonical source reports
+ * `'already-linked'`; a symlink to any other checkout refuses rather than silently adopting
+ * cross-resident state; a
  * missing canonical source reports `'skip-no-source'` (graceful for fresh repos that
  * haven't created the subdir yet); a non-symlink directory throws unless `force=true`.
  *
  * @param {object}   options
  * @param {string}   options.mainCheckout Absolute path to the primary git checkout.
  * @param {string}   options.projectRoot  Absolute path to the worktree root to link from.
- * @param {string[]} [options.blocklist]  Child names to NEVER symlink; defaults to {@link DATA_SUBDIRS_BLOCKLIST}.
+ * @param {string[]} [options.blocklist]  Live child names to NEVER symlink; defaults to {@link DATA_SUBDIRS_BLOCKLIST}.
+ *                                        Sources + names owned by {@link CANONICAL_DATA_READ_ALIASES}
+ *                                        are always excluded from this generic pass and materialized
+ *                                        separately, even when callers inject a narrower blocklist.
  * @param {boolean}  [options.force=false] If true, clobber an existing non-symlink dir/file at a non-blocklisted child (never touches blocklisted children).
  * @param {Function} [options.log=console.log] Logger fn for action diagnostics.
  * @returns {Promise<{linked: string[], alreadyLinked: string[], clobbered: string[], skippedNoSource: string[], mainCheckout: boolean}>} Per-item action map.
@@ -397,7 +415,10 @@ export async function symlinkDataDir({
     // Blocklist, not allowlist: enumerate EVERY child of canonical's .neo-ai-data and link all
     // except the blocklist. A new substrate child is unified automatically, removing the
     // allowlist-drift class that silently orphaned memory-wal across non-canonical clones.
-    const blocklistSet = new Set(blocklist);
+    const
+        blocklistSet       = new Set(blocklist),
+        readAliasSet       = new Set(CANONICAL_DATA_READ_ALIASES.map(entry => entry.alias)),
+        readAliasSourceSet = new Set(CANONICAL_DATA_READ_ALIASES.map(entry => entry.source));
     let entries;
     try {
         entries = await fs.readdir(canonicalDataDir, {withFileTypes: true});
@@ -410,7 +431,7 @@ export async function symlinkDataDir({
     for (const entry of entries) {
         const name = entry.name;
 
-        if (blocklistSet.has(name)) {
+        if (blocklistSet.has(name) || readAliasSet.has(name) || readAliasSourceSet.has(name)) {
             log(`symlink skip (blocklisted): ${name}`);
             continue;
         }
@@ -420,6 +441,18 @@ export async function symlinkDataDir({
         const lstat = await fs.lstat(dst).catch(() => null);
 
         if (lstat?.isSymbolicLink()) {
+            const
+                existingTarget = await fs.readlink(dst),
+                resolvedTarget = path.resolve(path.dirname(dst), existingTarget),
+                canonicalReal  = await fs.realpath(src),
+                existingReal   = await fs.realpath(resolvedTarget).catch(() => resolvedTarget);
+
+            if (existingReal !== canonicalReal) {
+                throw new Error(
+                    `Refusing unexpected symlink target at ${dst}: expected ${src}, found ${resolvedTarget}. ` +
+                    `Managed hydration never adopts another checkout's state implicitly.`
+                );
+            }
             log(`symlink skip (already linked): ${name}`);
             result.alreadyLinked.push(name);
             continue;
@@ -584,7 +617,9 @@ export async function symlinkCanonicalDataReadAliases({
  * canonical's overwrite). Conservative skip-with-warning is the safer default. Users
  * who want the symlink can manually `rm` the local file before re-running.
  *
- * Idempotent per-file by design: an existing symlink reports `'already-linked'`; a
+ * Idempotent per-file by design: an existing symlink to the canonical source reports
+ * `'already-linked'`; a symlink to any other checkout refuses rather than silently adopting
+ * cross-resident state; a
  * missing canonical source reports `'skipped-no-source'` (graceful for fresh repos that
  * haven't run Sandman yet); a real file at the destination reports `'skipped-real-file'`
  * with a warning pointing at the manual remediation path.
@@ -616,6 +651,18 @@ export async function symlinkGitignoredFiles({
         const lstat = await fs.lstat(dst).catch(() => null);
 
         if (lstat?.isSymbolicLink()) {
+            const
+                existingTarget = await fs.readlink(dst),
+                resolvedTarget = path.resolve(path.dirname(dst), existingTarget),
+                canonicalReal  = await fs.realpath(src),
+                existingReal   = await fs.realpath(resolvedTarget).catch(() => resolvedTarget);
+
+            if (existingReal !== canonicalReal) {
+                throw new Error(
+                    `Refusing unexpected symlink target at ${dst}: expected ${src}, found ${resolvedTarget}. ` +
+                    `Managed hydration never adopts another checkout's state implicitly.`
+                );
+            }
             log(`file-symlink skip (already linked): ${rel}`);
             result.alreadyLinked.push(rel);
             continue;

--- a/ai/services/fleet/deriveHarnessLaunchSpec.mjs
+++ b/ai/services/fleet/deriveHarnessLaunchSpec.mjs
@@ -142,15 +142,22 @@ export function getHarnessAuthMode(harnessType) {
  *   The app binary is never executed as a version probe — that would boot another GUI/helper set;
  *   installed-bundle capability proof is owned by `manageCodexDesktopRuntime` instead.
  *
- * - **`'claude-code'`** → `{command: binaryPath, args: [<stream-json print mode>], env:
- *   {CLAUDE_CONFIG_DIR: instanceHome}}`. Isolation empirically verified (claude CLI 2.1.156,
+ * - **`'claude-code'`** → `{command: binaryPath, args: ['--mcp-config',
+ *   '<instanceHome>/mcp-config.json', '--strict-mcp-config', <stream-json print mode>], env:
+ *   {CLAUDE_CONFIG_DIR: instanceHome}}`. The explicit strict path binds the secret-free, Fleet-owned
+ *   MCP projection prepared before spawn; the CLI's documented `${VAR}` expansion resolves dynamic
+ *   Fleet child env only in memory. Isolation empirically verified (claude CLI 2.1.156,
  *   macOS): pointing `CLAUDE_CONFIG_DIR` at a fresh dir yields a logged-out instance materializing
  *   its own config tree (`.claude.json`, `projects/`, `sessions/`) while the default `~/.claude`
  *   stays the untouched ambient auth home. Liveness empirically verified: the stream-JSON session
  *   on a held-open piped stdin stays resident and stops cleanly on SIGTERM. Per-home `/login` is
  *   the operator-owned auth step.
  *
- * - **`'claude-desktop'`** → `{command: binaryPath, args: ['--user-data-dir=<home>'], env: {}}`.
+ * - **`'claude-desktop'`** → `{command: binaryPath, args: ['--user-data-dir=<home>'], env:
+ *   {CLAUDE_USER_DATA_DIR: instanceHome}}`. The env binding is not redundant: installed Desktop
+ *   1.20186.1 otherwise appends its internal `-3p` suffix and reads a sibling config path. Its exact
+ *   startup code applies `CLAUDE_USER_DATA_DIR` through Electron `app.setPath('userData', ...)`, so
+ *   config, logs, and profile stay contained at the derived resident home.
  *   The app-bundle MAIN binary (`Claude.app/Contents/MacOS/Claude`, a universal Mach-O) spawned
  *   DIRECTLY — a real supervisable child, not an `open -n` launcher. Probed on the exact binary
  *   (Claude 1.20186.0, macOS): two instances with distinct `--user-data-dir` homes coexist
@@ -230,6 +237,30 @@ export function deriveHarnessLaunchSpec({harnessType, instanceHome, binaryPath, 
             versionProbeArgs: null,
             authHome,
             electronProfile
+        };
+    }
+
+    if (harnessType === 'claude-code') {
+        return {
+            command: binaryPath,
+            args   : [
+                '--mcp-config', path.join(instanceHome, 'mcp-config.json'),
+                '--strict-mcp-config',
+                ...contract.modeArgs
+            ],
+            env             : {[contract.homeEnvVar]: instanceHome},
+            versionProbeArgs: [...contract.versionProbeArgs]
+        };
+    }
+
+    if (harnessType === 'claude-desktop') {
+        const homeArg = `${contract.homeArgFlag}=${instanceHome}`;
+
+        return {
+            command         : binaryPath,
+            args            : [homeArg],
+            env             : {CLAUDE_USER_DATA_DIR: instanceHome},
+            versionProbeArgs: [homeArg, ...contract.versionProbeArgs]
         };
     }
 

--- a/ai/services/fleet/prepareManagedAgentWorkspace.mjs
+++ b/ai/services/fleet/prepareManagedAgentWorkspace.mjs
@@ -1,0 +1,688 @@
+import {constants as fsConstants}      from 'node:fs';
+import fs                              from 'node:fs/promises';
+import path                            from 'node:path';
+import {fileURLToPath}                 from 'node:url';
+import {hydrateCurrentWorktree}        from '../../scripts/migrations/bootstrapWorktree.mjs';
+import {MCP_SERVERS, resolveMcpMatrix} from '../../../src/ai/fleet/mcpServers.mjs';
+import {deriveAgentInstanceHome}       from './deriveAgentInstanceHome.mjs';
+import {LAUNCHABLE_HARNESS_TYPES}      from './deriveHarnessLaunchSpec.mjs';
+
+const
+    __filename            = fileURLToPath(import.meta.url),
+    __dirname             = path.dirname(__filename),
+    DEFAULT_MAIN_CHECKOUT = path.resolve(__dirname, '../../..'),
+    NEO_MCP_NAME_PREFIX   = 'neo-mjs-';
+
+/**
+ * @summary Convergence states for Fleet-owned workspace artifacts. `DIVERGENT` is emitted on the
+ * thrown error's `artifact` field because preparation fails closed instead of returning a launchable
+ * result alongside unresolved operator content.
+ * @type {Readonly<{CREATED: String, MATCH: String, DIVERGENT: String}>}
+ */
+export const WORKSPACE_ARTIFACT_STATES = Object.freeze({
+    CREATED  : 'CREATED',
+    MATCH    : 'MATCH',
+    DIVERGENT: 'DIVERGENT'
+});
+
+// One executable descriptor per shared catalog key. The catalog remains the durable key/default
+// authority; these Node-only leaves add the installed-checkout-relative entrypoint + environment
+// transport facts the Body-safe catalog deliberately cannot carry. Import-time lockstep below turns catalog drift into a
+// loud failure rather than silently omitting a newly registered server.
+const MCP_SERVER_DESCRIPTORS = Object.freeze({
+    'memory-core': Object.freeze({
+        entrypoint: 'ai/mcp/server/memory-core/mcp-server.mjs',
+        runtimeEnv: Object.freeze([
+            'NEO_AGENT_IDENTITY',
+            'NEO_CHROMA_EMBEDDING_PROVIDER',
+            'NEO_CHROMA_UNIFIED',
+            'NEO_EMBEDDING_PROVIDER',
+            'NEO_MEM_AUTO_START_DATABASE',
+            'NEO_MEM_AUTO_START_INFERENCE',
+            'NEO_MODEL_PROVIDER',
+            'NEO_OPENAI_COMPATIBLE_API_KEY',
+            'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
+            'NEO_OPENAI_COMPATIBLE_HOST',
+            'NEO_OPENAI_COMPATIBLE_MODEL'
+        ]),
+        requiredRuntimeEnv: Object.freeze(['NEO_AGENT_IDENTITY'])
+    }),
+    'knowledge-base': Object.freeze({
+        entrypoint: 'ai/mcp/server/knowledge-base/mcp-server.mjs',
+        runtimeEnv: Object.freeze([
+            'NEO_AGENT_IDENTITY',
+            'NEO_CHROMA_EMBEDDING_PROVIDER',
+            'NEO_CHROMA_UNIFIED',
+            'NEO_EMBEDDING_PROVIDER',
+            'NEO_KB_ASK_API_KEY',
+            'NEO_KB_AUTO_START_DATABASE',
+            'NEO_OPENAI_COMPATIBLE_API_KEY',
+            'NEO_OPENAI_COMPATIBLE_EMBEDDING_MODEL',
+            'NEO_OPENAI_COMPATIBLE_HOST',
+            'NEO_OPENAI_COMPATIBLE_MODEL'
+        ]),
+        requiredRuntimeEnv: Object.freeze(['NEO_AGENT_IDENTITY'])
+    }),
+    'neural-link': Object.freeze({
+        entrypoint: 'ai/mcp/server/neural-link/mcp-server.mjs',
+        runtimeEnv: Object.freeze([
+            'NEO_AGENT_IDENTITY',
+            'NEO_FLEET_BRIDGE_TOKEN',
+            'NEO_NL_TOOL_PROJECTION_MODE'
+        ]),
+        requiredRuntimeEnv: Object.freeze([
+            'NEO_AGENT_IDENTITY',
+            'NEO_NL_TOOL_PROJECTION_MODE'
+        ]),
+        secretEnv: Object.freeze(['NEO_FLEET_BRIDGE_TOKEN'])
+    }),
+    'github-workflow': Object.freeze({
+        entrypoint        : 'ai/mcp/server/github-workflow/mcp-server.mjs',
+        runtimeEnv        : Object.freeze(['GH_TOKEN', 'GITHUB_TOKEN', 'NEO_AGENT_IDENTITY']),
+        requiredRuntimeEnv: Object.freeze(['GH_TOKEN', 'NEO_AGENT_IDENTITY']),
+        secretEnv         : Object.freeze(['GH_TOKEN'])
+    }),
+    'gitlab-workflow': Object.freeze({
+        entrypoint        : 'ai/mcp/server/gitlab-workflow/mcp-server.mjs',
+        runtimeEnv        : Object.freeze(['NEO_AGENT_IDENTITY', 'NEO_GITLAB_HOST', 'NEO_GITLAB_PAT', 'NEO_GITLAB_PROJECT']),
+        requiredRuntimeEnv: Object.freeze(['NEO_AGENT_IDENTITY', 'NEO_GITLAB_PAT']),
+        secretEnv         : Object.freeze(['NEO_GITLAB_PAT']),
+        unsupportedReason : 'FleetLifecycleService has no GitLab credential injection contract'
+    })
+});
+
+{
+    const catalogKeys = new Set(MCP_SERVERS.map(entry => entry.key));
+
+    for (const key of catalogKeys) {
+        if (!MCP_SERVER_DESCRIPTORS[key]) {
+            throw new Error(`prepareManagedAgentWorkspace: MCP catalog key '${key}' has no executable descriptor.`);
+        }
+    }
+    for (const key of Object.keys(MCP_SERVER_DESCRIPTORS)) {
+        if (!catalogKeys.has(key)) {
+            throw new Error(`prepareManagedAgentWorkspace: executable descriptor '${key}' is absent from the shared MCP catalog.`);
+        }
+    }
+}
+
+/**
+ * @summary Error for a fail-closed workspace preparation result. `code` is stable for callers;
+ * `artifact` contains paths, owned-key names, and state only — never file contents or secret values.
+ */
+export class ManagedWorkspacePreparationError extends Error {
+    constructor(message, {code = 'FLEET_WORKSPACE_PREPARATION_FAILED', artifact} = {}) {
+        super(message);
+        this.name = 'ManagedWorkspacePreparationError';
+        this.code = code;
+        if (artifact) this.artifact = artifact;
+    }
+}
+
+/**
+ * @summary Hydrate and converge one Fleet-managed checkout plus its isolated harness home before
+ * process spawn. This is the missing lifecycle seam between `ensureAgentRepo` and
+ * `FleetLifecycleService.start`: no install/build, no operator-dotfile reads, no secret rendering.
+ *
+ * Executable MCP entrypoints deliberately resolve from the installed `mainCheckout`: fresh managed
+ * clones have no dependencies, dependency installation/build is outside this composer, and sharing
+ * another checkout's writable `node_modules` would collapse the checkout boundary. The prepared
+ * `repoPath` remains the single harness cwd/project truth (and Neural Link's explicit `--cwd`), while
+ * its ignored overlays are hydrated for resident workspace tooling. No resident dependency artifact
+ * is created or adopted.
+ *
+ * Product adapters are evidence-gated. Codex uses project TOML plus an isolated home; Claude Code
+ * uses an explicit strict MCP JSON with environment-variable references; Claude Desktop uses its
+ * exact `CLAUDE_USER_DATA_DIR` profile file but refuses any enabled server whose startup requires a
+ * dynamic secret that cannot be represented without writing the secret. Optional secrets remain
+ * child-environment capabilities, not persisted config. Antigravity refuses until a contained
+ * per-resident MCP authority is proven.
+ *
+ * @param {Object}   options
+ * @param {Object}   options.agent               Fleet registry agent definition.
+ * @param {String}   options.repoPath            Absolute provisioned checkout path.
+ * @param {String}   options.instanceRoot        Absolute Fleet harness-home root.
+ * @param {String}  [options.mainCheckout]       Installed canonical checkout; defaults to this module's repo root.
+ * @param {String}  [options.nodePath]           Node executable used for installed MCP entrypoints.
+ * @param {Function}[options.hydrateWorkspace]    Import-safe checkout hydration seam.
+ * @param {Function}[options.deriveInstanceHome]  Per-agent home derivation seam.
+ * @param {Function}[options.resolveMatrix]       Sparse-at-rest MCP resolver seam.
+ * @param {Object}  [options.fileSystem]          Promise filesystem seam.
+ * @param {Function}[options.log]                 Hydration logger.
+ * @returns {Promise<{repoPath: String, instanceHome: String, mcpMatrix: Object, hydration: Object, artifacts: Object[]}>}
+ * @throws {ManagedWorkspacePreparationError} for unsupported adapters or divergent owned content.
+ */
+export async function prepareManagedAgentWorkspace({
+    agent,
+    repoPath,
+    instanceRoot,
+    mainCheckout = DEFAULT_MAIN_CHECKOUT,
+    nodePath = process.execPath,
+    hydrateWorkspace = hydrateCurrentWorktree,
+    deriveInstanceHome = deriveAgentInstanceHome,
+    resolveMatrix = resolveMcpMatrix,
+    fileSystem = fs,
+    log = () => {}
+} = {}) {
+    if (!agent || typeof agent !== 'object') {
+        throw new ManagedWorkspacePreparationError("prepareManagedAgentWorkspace: 'agent' is required.");
+    }
+
+    assertNonEmptyString(agent.id, 'agent.id');
+    assertNonEmptyString(agent.harnessType, 'agent.harnessType');
+    assertAbsolutePath(repoPath, 'repoPath');
+    assertAbsolutePath(instanceRoot, 'instanceRoot');
+    assertAbsolutePath(mainCheckout, 'mainCheckout');
+    assertAbsolutePath(nodePath, 'nodePath');
+
+    const
+        canonicalRepoPath = path.resolve(repoPath),
+        installedRoot     = path.resolve(mainCheckout),
+        mcpMatrix         = resolveMatrix(agent.mcpServers),
+        plan              = createMcpPlan({mcpMatrix, repoPath: canonicalRepoPath, mainCheckout: installedRoot, nodePath}),
+        instanceHome      = deriveInstanceHome({instanceRoot, agentId: agent.id, harnessType: agent.harnessType});
+
+    // Hardest/unsupported adapter gate runs before hydration or artifact writes. A failed product
+    // authority proof cannot leave a checkout looking partially resident-ready.
+    assertHarnessSupported({agent, plan});
+    await assertNoSymlinkSegments({
+        rootPath  : path.resolve(instanceRoot),
+        targetPath: instanceHome,
+        fileSystem,
+        label     : 'resident home'
+    });
+
+    const hydration = await hydrateWorkspace({
+        mainCheckout: installedRoot,
+        projectRoot : canonicalRepoPath,
+        log
+    });
+
+    await assertRealDirectory(canonicalRepoPath, 'repoPath', fileSystem);
+    await assertExecutablePlan({plan, nodePath, fileSystem});
+
+    await assertNoSymlinkSegments({
+        rootPath  : path.resolve(instanceRoot),
+        targetPath: instanceHome,
+        fileSystem,
+        label     : 'resident home'
+    });
+
+    const artifacts = await prepareHarnessArtifacts({
+        agent,
+        repoPath    : canonicalRepoPath,
+        instanceHome,
+        mainCheckout: installedRoot,
+        plan,
+        fileSystem
+    });
+
+    return {repoPath: canonicalRepoPath, instanceHome, mcpMatrix, hydration, artifacts};
+}
+
+/** @private */
+function createMcpPlan({mcpMatrix, repoPath, mainCheckout, nodePath}) {
+    return MCP_SERVERS.map(entry => {
+        const descriptor = MCP_SERVER_DESCRIPTORS[entry.key];
+
+        return {
+            key    : entry.key,
+            name   : `${NEO_MCP_NAME_PREFIX}${entry.key}`,
+            enabled: mcpMatrix[entry.key] === true,
+            command: nodePath,
+            args   : [
+                path.join(mainCheckout, descriptor.entrypoint),
+                ...(entry.key === 'neural-link' ? ['--cwd', repoPath] : [])
+            ],
+            runtimeEnv        : [...descriptor.runtimeEnv],
+            requiredRuntimeEnv: [...descriptor.requiredRuntimeEnv],
+            secretEnv         : [...(descriptor.secretEnv || [])],
+            unsupportedReason : descriptor.unsupportedReason || null
+        };
+    });
+}
+
+/** @private */
+function assertHarnessSupported({agent, plan}) {
+    if (agent.metadata?.launch) {
+        throw unsupported('raw metadata.launch overrides bypass curated resident-home and MCP preparation');
+    }
+
+    if (!LAUNCHABLE_HARNESS_TYPES.includes(agent.harnessType)) {
+        throw unsupported(`harness '${agent.harnessType}' has no launch/workspace adapter`);
+    }
+
+    const catalogUnsupported = plan.find(server => server.enabled && server.unsupportedReason);
+    if (catalogUnsupported) {
+        throw unsupported(`MCP server '${catalogUnsupported.key}' is enabled but unsupported: ${catalogUnsupported.unsupportedReason}`);
+    }
+
+    if (agent.harnessType === 'antigravity') {
+        throw unsupported('Antigravity 2.x exposes no proven contained per-resident MCP configuration root');
+    }
+
+    if (agent.harnessType === 'claude-desktop') {
+        const secretServer = plan.find(server => server.enabled &&
+            server.requiredRuntimeEnv.some(name => server.secretEnv.includes(name)));
+        if (secretServer) {
+            throw unsupported(`Claude Desktop cannot represent startup-required Fleet secret env for enabled MCP server '${secretServer.key}' without persisting secret bytes`);
+        }
+    }
+}
+
+/** @private */
+async function assertRealDirectory(directoryPath, label, fileSystem) {
+    const stat = await fileSystem.lstat(directoryPath).catch(() => null);
+
+    if (!stat?.isDirectory() || stat.isSymbolicLink()) {
+        throw divergentArtifact(directoryPath, label, 'expected a real resident-owned directory');
+    }
+}
+
+/** @private */
+async function assertExecutablePlan({plan, nodePath, fileSystem}) {
+    const nodeStat = await fileSystem.stat(nodePath).catch(() => null);
+
+    if (!nodeStat?.isFile()) {
+        throw unsupported(`Node executable is absent or not a file at '${nodePath}'`);
+    }
+
+    try {
+        await fileSystem.access(nodePath, fsConstants.X_OK);
+    } catch {
+        throw unsupported(`Node executable is absent or non-executable at '${nodePath}'`);
+    }
+
+    for (const server of plan) {
+        if (!server.enabled) continue;
+
+        const
+            entrypoint = server.args[0],
+            entryStat  = await fileSystem.lstat(entrypoint).catch(() => null);
+
+        if (!entryStat?.isFile()) {
+            throw unsupported(`enabled MCP server '${server.key}' has no installed file entrypoint at '${entrypoint}'`);
+        }
+
+        try {
+            await fileSystem.access(entrypoint, fsConstants.R_OK);
+        } catch {
+            throw unsupported(`enabled MCP server '${server.key}' has no readable installed entrypoint at '${entrypoint}'`);
+        }
+    }
+}
+
+/** @private */
+async function assertNoSymlinkSegments({rootPath, targetPath, fileSystem, label}) {
+    const relative = path.relative(rootPath, targetPath);
+
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+        throw divergentArtifact(targetPath, label, 'path escapes its trusted root');
+    }
+
+    const rootStat = await fileSystem.lstat(rootPath).catch(error => {
+        if (error?.code === 'ENOENT') return null;
+        throw error;
+    });
+    if (rootStat && (!rootStat.isDirectory() || rootStat.isSymbolicLink())) {
+        throw divergentArtifact(rootPath, label, 'trusted root is not a real directory');
+    }
+
+    let current = rootPath;
+    for (const segment of relative.split(path.sep).filter(Boolean)) {
+        current = path.join(current, segment);
+        const stat = await fileSystem.lstat(current).catch(error => {
+            if (error?.code === 'ENOENT') return null;
+            throw error;
+        });
+        if (!stat) break;
+        if (stat.isSymbolicLink()) {
+            throw divergentArtifact(current, label, 'symlinked resident-owned path segment');
+        }
+    }
+}
+
+/** @private */
+async function prepareHarnessArtifacts({agent, repoPath, instanceHome, mainCheckout, plan, fileSystem}) {
+    switch (agent.harnessType) {
+        case 'codex':
+        case 'codex-desktop':
+            return prepareCodexArtifacts({agent, repoPath, instanceHome, mainCheckout, plan, fileSystem});
+        case 'claude-code':
+            return [await prepareClaudeJsonArtifact({
+                agent,
+                filePath      : path.join(instanceHome, 'mcp-config.json'),
+                trustedRoot   : instanceHome,
+                plan,
+                fileSystem,
+                interpolateEnv: true
+            })];
+        case 'claude-desktop':
+            return [await prepareClaudeJsonArtifact({
+                agent,
+                filePath      : path.join(instanceHome, 'claude_desktop_config.json'),
+                trustedRoot   : instanceHome,
+                plan,
+                fileSystem,
+                interpolateEnv: false
+            })];
+        default:
+            throw unsupported(`harness '${agent.harnessType}' has no workspace adapter`);
+    }
+}
+
+/** @private */
+async function prepareCodexArtifacts({agent, repoPath, instanceHome, mainCheckout, plan, fileSystem}) {
+    const
+        templatePath   = path.join(mainCheckout, '.codex', 'config.template.toml'),
+        projectPath    = path.join(repoPath, '.codex', 'config.toml'),
+        template       = await fileSystem.readFile(templatePath, 'utf8'),
+        projectContent = renderCodexProjectConfig(template, plan),
+        homeRoot       = agent.harnessType === 'codex-desktop' ? path.join(instanceHome, 'codex-home') : instanceHome,
+        homePath       = path.join(homeRoot, 'config.toml'),
+        memoriesPath   = path.join(homeRoot, 'memories'),
+        artifacts      = [];
+
+    artifacts.push(await convergeTextArtifact({
+        filePath       : projectPath,
+        desiredContent : projectContent,
+        ownedProjection: projectCodexOwnedProjection,
+        ownedLabel     : 'mcp_servers.\"neo-mjs-*\"',
+        trustedRoot    : repoPath,
+        fileSystem
+    }));
+    artifacts.push(await convergeTextArtifact({
+        filePath       : homePath,
+        desiredContent : renderCodexHomeConfig(),
+        ownedProjection: codexHomeOwnedProjection,
+        ownedLabel     : 'cli_auth_credentials_store,mcp_oauth_credentials_store,features.memories',
+        trustedRoot    : instanceHome,
+        fileSystem
+    }));
+    artifacts.push(await ensureDirectoryArtifact(memoriesPath, instanceHome, fileSystem));
+
+    return artifacts;
+}
+
+/** @private */
+async function prepareClaudeJsonArtifact({agent, filePath, trustedRoot, plan, fileSystem, interpolateEnv}) {
+    const servers = {};
+
+    for (const server of plan) {
+        if (!server.enabled) continue;
+
+        const
+            env      = {},
+            envNames = interpolateEnv
+                ? new Set([...server.requiredRuntimeEnv, ...server.secretEnv])
+                : server.requiredRuntimeEnv;
+
+        for (const name of envNames) {
+            if (interpolateEnv) {
+                env[name] = `\${${name}}`;
+            } else if (name === 'NEO_AGENT_IDENTITY') {
+                env[name] = agent.id;
+            } else if (name === 'NEO_NL_TOOL_PROJECTION_MODE') {
+                env[name] = 'harness-embedded';
+            } else {
+                throw unsupported(`Claude Desktop has no secret-free representation for runtime env '${name}'`);
+            }
+        }
+
+        servers[server.name] = {command: server.command, args: server.args, env};
+    }
+
+    return convergeTextArtifact({
+        filePath,
+        desiredContent : JSON.stringify({mcpServers: servers}, null, 2) + '\n',
+        ownedProjection: claudeJsonOwnedProjection,
+        ownedLabel     : 'mcpServers.neo-mjs-*',
+        trustedRoot,
+        fileSystem
+    });
+}
+
+/** @private */
+function renderCodexProjectConfig(template, plan) {
+    const
+        base     = stripManagedMcpTables(template).trimEnd(),
+        sections = plan.map(renderCodexMcpTable).join('\n\n'),
+        marker   = /^\[features\]\s*$/m,
+        header   = '# Fleet-managed Neo MCP tables: executable paths come from the installed canonical checkout; cwd/project paths stay bound to this prepared resident checkout; enabled values are the current Brain projection.';
+
+    if (!marker.test(base)) return `${base}\n\n${header}\n${sections}\n`;
+
+    return base.replace(marker, `${header}\n${sections}\n\n[features]`) + '\n';
+}
+
+/** @private */
+function renderCodexMcpTable(server) {
+    return [
+        `[mcp_servers.\"${server.name}\"]`,
+        `command = ${JSON.stringify(server.command)}`,
+        `args = ${JSON.stringify(server.args)}`,
+        `env_vars = ${JSON.stringify(server.runtimeEnv)}`,
+        'startup_timeout_sec = 30',
+        'tool_timeout_sec = 120',
+        `enabled = ${server.enabled}`
+    ].join('\n');
+}
+
+/** @private */
+function renderCodexHomeConfig() {
+    return [
+        '# Fleet-owned Codex home policy. Authentication material itself is created by Codex login, never by Fleet.',
+        'cli_auth_credentials_store = "file"',
+        'mcp_oauth_credentials_store = "file"',
+        '',
+        '[features]',
+        'memories = true',
+        ''
+    ].join('\n');
+}
+
+/** @private */
+function stripManagedMcpTables(source) {
+    const lines    = source.split(/\r?\n/), output = [];
+    let   skipping = false;
+
+    for (const line of lines) {
+        const header = line.match(/^\s*\[mcp_servers\.\"([^\"]+)\"\]\s*$/);
+        if (header) {
+            skipping = header[1].startsWith(NEO_MCP_NAME_PREFIX);
+            if (!skipping) output.push(line);
+            continue;
+        }
+        if (/^\s*\[[^\]]+\]\s*$/.test(line)) skipping = false;
+        if (!skipping) output.push(line);
+    }
+
+    return output.join('\n').replace(/\n{3,}/g, '\n\n');
+}
+
+/** @private */
+function projectCodexOwnedProjection(source) {
+    const lines   = source.split(/\r?\n/), result = {};
+    let   current = null, buffer = [];
+
+    const flush = () => {
+        if (current?.startsWith(NEO_MCP_NAME_PREFIX)) {
+            result[current] = buffer.map(line => line.trimEnd()).join('\n').trim();
+        }
+    };
+
+    for (const line of lines) {
+        const header = line.match(/^\s*\[mcp_servers\.\"([^\"]+)\"\]\s*$/);
+        if (header) {
+            flush();
+            current = header[1];
+            buffer = [line];
+            continue;
+        }
+        if (/^\s*\[[^\]]+\]\s*$/.test(line)) {
+            flush();
+            current = null;
+            buffer = [];
+            continue;
+        }
+        if (current) buffer.push(line);
+    }
+    flush();
+
+    return canonicalize(result);
+}
+
+/** @private */
+function codexHomeOwnedProjection(source) {
+    const wanted = new Set([
+        'cli_auth_credentials_store',
+        'mcp_oauth_credentials_store',
+        'features.memories'
+    ]), result = {};
+    let table = '';
+
+    for (const rawLine of source.split(/\r?\n/)) {
+        const line = rawLine.replace(/\s+#.*$/, '').trim();
+        if (!line) continue;
+        const header = line.match(/^\[([^\]]+)\]$/);
+        if (header) {
+            table = header[1];
+            continue;
+        }
+        const entry = line.match(/^([A-Za-z0-9_-]+)\s*=\s*(.+)$/);
+        if (!entry) continue;
+        const key = table ? `${table}.${entry[1]}` : entry[1];
+        if (wanted.has(key)) result[key] = entry[2].trim();
+    }
+
+    return canonicalize(result);
+}
+
+/** @private */
+function claudeJsonOwnedProjection(source) {
+    let parsed;
+    try {
+        parsed = JSON.parse(source);
+    } catch {
+        return {__invalidJson: true};
+    }
+
+    const result = {};
+    for (const [name, definition] of Object.entries(parsed?.mcpServers || {})) {
+        if (name.startsWith(NEO_MCP_NAME_PREFIX)) result[name] = definition;
+    }
+    return canonicalize(result);
+}
+
+/** @private */
+async function convergeTextArtifact({filePath, desiredContent, ownedProjection, ownedLabel, trustedRoot, fileSystem}) {
+    await assertNoSymlinkSegments({rootPath: trustedRoot, targetPath: filePath, fileSystem, label: ownedLabel});
+
+    let existing;
+    try {
+        existing = await fileSystem.readFile(filePath, 'utf8');
+    } catch (error) {
+        if (error?.code !== 'ENOENT') throw error;
+
+        await fileSystem.mkdir(path.dirname(filePath), {recursive: true});
+        await assertNoSymlinkSegments({rootPath: trustedRoot, targetPath: filePath, fileSystem, label: ownedLabel});
+        try {
+            await fileSystem.writeFile(filePath, desiredContent, {encoding: 'utf8', flag: 'wx', mode: 0o600});
+            return {path: filePath, status: WORKSPACE_ARTIFACT_STATES.CREATED, ownedKeys: ownedLabel};
+        } catch (writeError) {
+            if (writeError?.code !== 'EEXIST') throw writeError;
+            existing = await fileSystem.readFile(filePath, 'utf8');
+        }
+    }
+
+    const
+        actual  = ownedProjection(existing),
+        desired = ownedProjection(desiredContent);
+
+    if (JSON.stringify(actual) === JSON.stringify(desired)) {
+        return {path: filePath, status: WORKSPACE_ARTIFACT_STATES.MATCH, ownedKeys: ownedLabel};
+    }
+
+    const artifact = {
+        path     : filePath,
+        status   : WORKSPACE_ARTIFACT_STATES.DIVERGENT,
+        ownedKeys: ownedLabel,
+        reason   : actual.__invalidJson ? 'invalid JSON' : 'Fleet-owned keys differ or are missing'
+    };
+    throw new ManagedWorkspacePreparationError(
+        `prepareManagedAgentWorkspace: refusing to overwrite divergent Fleet-owned content at '${filePath}' (${ownedLabel}).`,
+        {code: 'FLEET_WORKSPACE_DIVERGENT', artifact}
+    );
+}
+
+/** @private */
+async function ensureDirectoryArtifact(directoryPath, trustedRoot, fileSystem) {
+    let stat;
+    try {
+        stat = await fileSystem.lstat(directoryPath);
+    } catch (error) {
+        if (error?.code !== 'ENOENT') throw error;
+    }
+
+    if (stat) {
+        if (stat.isSymbolicLink()) {
+            throw divergentArtifact(directoryPath, 'directory', 'symlinked resident-owned directory');
+        }
+        if (!stat.isDirectory()) {
+            const artifact = {path: directoryPath, status: WORKSPACE_ARTIFACT_STATES.DIVERGENT, ownedKeys: 'directory'};
+            throw new ManagedWorkspacePreparationError(
+                `prepareManagedAgentWorkspace: expected directory '${directoryPath}', found another filesystem entry.`,
+                {code: 'FLEET_WORKSPACE_DIVERGENT', artifact}
+            );
+        }
+        return {path: directoryPath, status: WORKSPACE_ARTIFACT_STATES.MATCH, ownedKeys: 'directory'};
+    }
+
+    await fileSystem.mkdir(directoryPath, {recursive: true});
+    await assertNoSymlinkSegments({rootPath: trustedRoot, targetPath: directoryPath, fileSystem, label: 'directory'});
+    return {path: directoryPath, status: WORKSPACE_ARTIFACT_STATES.CREATED, ownedKeys: 'directory'};
+}
+
+/** @private */
+function canonicalize(value) {
+    if (Array.isArray(value)) return value.map(canonicalize);
+    if (!value || typeof value !== 'object') return value;
+
+    return Object.fromEntries(Object.keys(value).sort().map(key => [key, canonicalize(value[key])]));
+}
+
+/** @private */
+function divergentArtifact(filePath, ownedKeys, reason) {
+    return new ManagedWorkspacePreparationError(
+        `prepareManagedAgentWorkspace: refusing divergent resident-owned path '${filePath}' (${reason}).`,
+        {
+            code    : 'FLEET_WORKSPACE_DIVERGENT',
+            artifact: {path: filePath, status: WORKSPACE_ARTIFACT_STATES.DIVERGENT, ownedKeys, reason}
+        }
+    );
+}
+
+/** @private */
+function unsupported(reason) {
+    return new ManagedWorkspacePreparationError(
+        `prepareManagedAgentWorkspace: unsupported adapter state — ${reason}.`,
+        {code: 'FLEET_WORKSPACE_UNSUPPORTED'}
+    );
+}
+
+/** @private */
+function assertNonEmptyString(value, name) {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new ManagedWorkspacePreparationError(`prepareManagedAgentWorkspace: '${name}' must be a non-empty string.`);
+    }
+}
+
+/** @private */
+function assertAbsolutePath(value, name) {
+    assertNonEmptyString(value, name);
+    if (!path.isAbsolute(value)) {
+        throw new ManagedWorkspacePreparationError(`prepareManagedAgentWorkspace: '${name}' must be absolute, received '${value}'.`);
+    }
+}
+
+export default prepareManagedAgentWorkspace;

--- a/ai/services/fleet/startAgentProvisioned.mjs
+++ b/ai/services/fleet/startAgentProvisioned.mjs
@@ -1,4 +1,5 @@
-import {ensureAgentRepo} from './ensureAgentRepo.mjs';
+import {ensureAgentRepo}              from './ensureAgentRepo.mjs';
+import {prepareManagedAgentWorkspace} from './prepareManagedAgentWorkspace.mjs';
 
 /**
  * @summary Start a Fleet Manager agent's harness *in its own provisioned repo* — the turnkey
@@ -8,20 +9,24 @@ import {ensureAgentRepo} from './ensureAgentRepo.mjs';
  * harness in the Fleet Manager's own working directory. This composer closes that gap. Given an agent
  * whose definition carries its working-repo coordinates (`metadata.repo = {cloneUrl, repoSlug}`), it
  * first ensures the canonical checkout exists — clone-or-reuse, never clobber, via
- * {@link Neo.ai.services.fleet.ensureAgentRepo} — then starts the harness with its `cwd` pinned to that
- * checkout, so the harness operates on ITS repo. Fleet Manager auto-memory is checkout-path-keyed, so
- * the path is load-bearing: launching in the wrong directory is a silent correctness failure.
+ * {@link Neo.ai.services.fleet.ensureAgentRepo} — then hydrates the checkout + isolated harness home
+ * through {@link Neo.ai.services.fleet.prepareManagedAgentWorkspace}, and only then starts the harness
+ * with its `cwd` pinned to the prepared checkout. Fleet Manager auto-memory is checkout-path-keyed, so
+ * the path is load-bearing: launching in the wrong or unprepared directory is a silent correctness
+ * failure.
  *
- * **Fail-closed:** a provisioning error propagates and the harness is NEVER spawned — the Fleet Manager
- * must not launch an agent into an unprovisioned or conflicting directory.
+ * **Fail-closed:** a provisioning OR preparation error propagates and the harness is NEVER spawned —
+ * the Fleet Manager must not launch an agent into an unprovisioned, divergent, unsupported, or
+ * identity-colliding directory/home.
  *
  * **Backward-compatible:** an agent without `metadata.repo` has no repo to provision, so it starts
  * exactly as before (inherited cwd). The opinionated provisioning + the `metadata.repo` convention live
  * here, NOT in the registry-owned supervisor — `start` only gained a generic optional `cwd`.
  *
- * Pure composition over injectable seams: `ensureRepo` (default {@link Neo.ai.services.fleet.ensureAgentRepo})
- * + `cloneRepo` (forwarded to it) make this unit-testable without a git binary or the filesystem,
- * mirroring the `spawnFn` / `cloneRepo` test idioms already used across the fleet services.
+ * Pure composition over injectable seams: `ensureRepo` (default {@link Neo.ai.services.fleet.ensureAgentRepo}),
+ * `prepareWorkspace` (default {@link Neo.ai.services.fleet.prepareManagedAgentWorkspace}), and
+ * `cloneRepo` (forwarded to provisioning) make the order/failure contract unit-testable without a git
+ * binary or filesystem, mirroring the `spawnFn` / `cloneRepo` idioms across the Fleet services.
  *
  * @param {Object}    options
  * @param {Object}    options.lifecycleService The `FleetLifecycleService` (or a stub) that supervises
@@ -35,11 +40,28 @@ import {ensureAgentRepo} from './ensureAgentRepo.mjs';
  * @param {Function} [options.ensureRepo]      The repo-provisioning composer; defaults to
  *                                             {@link Neo.ai.services.fleet.ensureAgentRepo}, injectable
  *                                             for tests.
+ * @param {Function} [options.prepareWorkspace] The post-provisioning workspace/home composer; defaults
+ *                                              to {@link Neo.ai.services.fleet.prepareManagedAgentWorkspace}.
+ * @param {String}   [options.instanceRoot]     Explicit harness-home root; omitted ⇒ the lifecycle
+ *                                              service's config-resolved `getInstanceRoot()` value.
+ * @param {String}   [options.mainCheckout]     Installed canonical checkout override for preparation.
+ * @param {String}   [options.nodePath]         Node executable override for generated MCP definitions.
  * @returns {Promise<Object>} the agent's lifecycle status (see `FleetLifecycleService.status`).
  * @throws {Error} when `lifecycleService` / `agentId` is missing, the agent is unknown, `managedRoot`
- *   is absent for a repo-bearing agent, or provisioning fails (re-thrown — the harness is not spawned).
+ *   is absent for a repo-bearing agent, a repo-bearing raw launch override would bypass curated
+ *   preparation, or provisioning/preparation fails (re-thrown — no spawn).
  */
-export async function startAgentProvisioned({lifecycleService, agentId, managedRoot, cloneRepo, ensureRepo = ensureAgentRepo} = {}) {
+export async function startAgentProvisioned({
+    lifecycleService,
+    agentId,
+    managedRoot,
+    cloneRepo,
+    ensureRepo = ensureAgentRepo,
+    prepareWorkspace = prepareManagedAgentWorkspace,
+    instanceRoot,
+    mainCheckout,
+    nodePath
+} = {}) {
     if (!lifecycleService) throw new Error("startAgentProvisioned: 'lifecycleService' is required.");
     if (!agentId)          throw new Error("startAgentProvisioned: 'agentId' is required.");
 
@@ -48,13 +70,21 @@ export async function startAgentProvisioned({lifecycleService, agentId, managedR
     // agent that is already up.
     if (lifecycleService.isRunning(agentId)) return lifecycleService.status(agentId);
 
-    const agent = lifecycleService.getRegistry().getAgent(agentId);
+    const registry = lifecycleService.getRegistry(),
+          agent    = registry.getDefinition?.(agentId) ?? registry.getAgent(agentId);
     if (!agent) throw new Error(`startAgentProvisioned: unknown agent '${agentId}'.`);
 
     const repo = agent.metadata?.repo;
 
     // No repo coordinates ⇒ nothing to provision; start in the inherited cwd (backward-compatible).
     if (!repo) return lifecycleService.start(agentId);
+
+    // The managed-workspace contract is coupled to Fleet's curated harness launch. A repo-bearing
+    // raw override can execute an unrelated command and consumes no derived home/MCP artifacts, so
+    // reporting it as prepared would be a false resident-ready claim. Reject before repo side effects.
+    if (agent.metadata?.launch) {
+        throw new Error(`startAgentProvisioned: repo-bearing agent '${agentId}' uses a raw metadata.launch override; curated managed-workspace preparation is required.`);
+    }
 
     if (!managedRoot) {
         throw new Error(`startAgentProvisioned: 'managedRoot' is required to provision the repo for agent '${agentId}'.`);
@@ -72,5 +102,20 @@ export async function startAgentProvisioned({lifecycleService, agentId, managedR
         cloneRepo
     });
 
-    return lifecycleService.start(agentId, {cwd: repoPath});
+    // Preparation is a mandatory gate for repo-bearing agents. The lifecycle owns the resolved
+    // instance-root SSOT; the explicit option is only a test/per-tenant seam. A preparation throw
+    // propagates, so `start` is never called over divergent or unsupported resident state.
+    const prepared = await prepareWorkspace({
+        agent,
+        repoPath,
+        instanceRoot: instanceRoot ?? lifecycleService.getInstanceRoot?.(),
+        mainCheckout,
+        nodePath
+    });
+
+    if (!prepared || prepared.repoPath !== repoPath) {
+        throw new Error(`startAgentProvisioned: preparation did not return the canonical provisioned repoPath for agent '${agentId}'.`);
+    }
+
+    return lifecycleService.start(agentId, {cwd: prepared.repoPath});
 }

--- a/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
+++ b/test/playwright/unit/ai/FleetLifecycleService.spec.mjs
@@ -583,7 +583,7 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService — curated launch + 
         await expect(FleetLifecycleService.stop('desktop')).resolves.toMatchObject({state: 'stopped', cleanupUnresolved: false});
     });
 
-    test('curated claude-code derivation is reachable (registry vocabulary aligned) and pins the stream-json mode', () => {
+    test('curated claude-code derivation pins strict per-home MCP config plus stream-json mode', () => {
         const spawn = install({agents: {c2: curatedAgent('c2', 'claude-code')}, creds: {}});
         FleetLifecycleService.instanceRoot       = '/srv/fleet/instances';
         FleetLifecycleService.harnessBinaryPaths = {'claude-code': process.execPath};
@@ -591,7 +591,14 @@ test.describe('Neo.ai.services.fleet.FleetLifecycleService — curated launch + 
         FleetLifecycleService.start('c2');
 
         const {args, opts} = spawn.calls[0];
-        expect(args).toEqual(['--input-format', 'stream-json', '--output-format', 'stream-json', '--print', '--verbose']);
+        expect(args).toEqual([
+            '--mcp-config', path.join(FleetLifecycleService.instanceRoot, 'c2-9c0abe51c6e6', 'claude-code-28e174396028', 'mcp-config.json'),
+            '--strict-mcp-config',
+            '--input-format', 'stream-json',
+            '--output-format', 'stream-json',
+            '--print',
+            '--verbose'
+        ]);
         expect(Object.keys(opts.env)).toContain('CLAUDE_CONFIG_DIR');
     });
 

--- a/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
+++ b/test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs
@@ -75,7 +75,7 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
     });
 
     test.beforeEach(async () => {
-        const tmpBase    = path.resolve(process.cwd(), 'tmp', `bootstrap-worktree-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+        const tmpBase = path.resolve(process.cwd(), 'tmp', `bootstrap-worktree-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
         fakeMainCheckout = path.join(tmpBase, 'main-checkout');
         fakeWorktree     = path.join(tmpBase, 'worktree');
 
@@ -322,12 +322,18 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             });
         }
 
-        test('exports a canonical read alias without removing the daemon-pid blocklist', () => {
+        test('every canonical read alias keeps its live source blocklisted and names stay unique', () => {
             expect(CANONICAL_DATA_READ_ALIASES).toContainEqual({
                 source: sourceSubdir,
                 alias : aliasSubdir
             });
-            expect(DATA_SUBDIRS_BLOCKLIST).toContain(sourceSubdir);
+
+            const aliases = new Set();
+            for (const {source, alias} of CANONICAL_DATA_READ_ALIASES) {
+                expect(DATA_SUBDIRS_BLOCKLIST).toContain(source);
+                expect(aliases.has(alias)).toBe(false);
+                aliases.add(alias);
+            }
         });
 
         test('links a separate canonical alias while preserving the clone-local daemon dir', async () => {
@@ -504,6 +510,28 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             expect(await fs.pathExists(path.join(fakeWorktree, dataDir, 'embed-daemon'))).toBe(false);
         });
 
+        test('leaves canonical read-alias sources + names to the dedicated primitive even with a custom blocklist', async () => {
+            const
+                source = path.join(fakeMainCheckout, dataDir, 'orchestrator-daemon'),
+                alias  = path.join(fakeMainCheckout, dataDir, 'orchestrator-daemon-canonical'),
+                target = path.join(fakeWorktree, dataDir, 'orchestrator-daemon-canonical');
+
+            await fs.ensureDir(source);
+            await fs.symlink(source, alias, 'dir');
+
+            const result = await symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                blocklist   : [],
+                log         : () => {}
+            });
+
+            expect(result.linked).not.toContain('orchestrator-daemon');
+            expect(result.linked).not.toContain('orchestrator-daemon-canonical');
+            expect(await fs.pathExists(path.join(fakeWorktree, dataDir, 'orchestrator-daemon'))).toBe(false);
+            expect(await fs.pathExists(target)).toBe(false);
+        });
+
         test('symlinks every canonical child except the blocklist when none exist in worktree', async () => {
             await seedMainSubdirs();
 
@@ -598,6 +626,25 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             expect(result.linked).toEqual(['chroma']);
             expect(result.clobbered).toHaveLength(0);
             expect(result.skippedNoSource).toHaveLength(0);
+        });
+
+        test('refuses an existing child symlink into another checkout instead of reporting alreadyLinked', async () => {
+            await seedMainSubdirs(['sqlite']);
+
+            const
+                foreign = path.join(path.dirname(fakeMainCheckout), 'foreign-checkout', dataDir, 'sqlite'),
+                dst     = path.join(fakeWorktree, dataDir, 'sqlite');
+
+            await fs.ensureDir(foreign);
+            await fs.ensureDir(path.dirname(dst));
+            await fs.symlink(foreign, dst, 'dir');
+
+            await expect(symlinkDataDir({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                log         : () => {}
+            })).rejects.toThrow(/unexpected symlink target/);
+            expect(path.resolve(path.dirname(dst), await fs.readlink(dst))).toBe(foreign);
         });
 
         test('refuses to clobber a non-symlink subdir without force', async () => {
@@ -830,6 +877,27 @@ test.describe('ai/scripts/bootstrapWorktree', () => {
             expect(result.alreadyLinked).toEqual(fixtureFiles);
             expect(result.skippedNoSource).toHaveLength(0);
             expect(result.skippedRealFile).toHaveLength(0);
+        });
+
+        test('refuses an existing file symlink into another checkout instead of reporting alreadyLinked', async () => {
+            await seedMainHandoff();
+
+            const
+                foreign = path.join(path.dirname(fakeMainCheckout), 'foreign-checkout', fixtureFile),
+                dst     = path.join(fakeWorktree, fixtureFile);
+
+            await fs.ensureDir(path.dirname(foreign));
+            await fs.writeFile(foreign, '# foreign\n', 'utf8');
+            await fs.ensureDir(path.dirname(dst));
+            await fs.symlink(foreign, dst, 'file');
+
+            await expect(symlinkGitignoredFiles({
+                mainCheckout: fakeMainCheckout,
+                projectRoot : fakeWorktree,
+                files       : fixtureFiles,
+                log         : () => {}
+            })).rejects.toThrow(/unexpected symlink target/);
+            expect(path.resolve(path.dirname(dst), await fs.readlink(dst))).toBe(foreign);
         });
 
         test('gracefully skips files missing in the main checkout (pre-Sandman state)', async () => {

--- a/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
@@ -45,18 +45,25 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
         });
     });
 
-    test('claude-code: the binary + the stream-json long-lived print mode + CLAUDE_CONFIG_DIR pinned to the instance home', () => {
+    test('claude-code: strict per-home MCP config + stream-json mode + isolated CLAUDE_CONFIG_DIR', () => {
         const spec = deriveHarnessLaunchSpec({harnessType: 'claude-code', instanceHome: '/srv/instances/a/claude', binaryPath: '/usr/local/bin/claude'});
 
         expect(spec).toEqual({
-            command         : '/usr/local/bin/claude',
-            args            : ['--input-format', 'stream-json', '--output-format', 'stream-json', '--print', '--verbose'],
+            command: '/usr/local/bin/claude',
+            args   : [
+                '--mcp-config', '/srv/instances/a/claude/mcp-config.json',
+                '--strict-mcp-config',
+                '--input-format', 'stream-json',
+                '--output-format', 'stream-json',
+                '--print',
+                '--verbose'
+            ],
             env             : {CLAUDE_CONFIG_DIR: '/srv/instances/a/claude'},
             versionProbeArgs: ['--version']
         });
     });
 
-    test('claude-desktop: the app-bundle main binary with --user-data-dir isolation riding ARGV — env stays empty', () => {
+    test('claude-desktop: argv isolation + exact contained CLAUDE_USER_DATA_DIR authority', () => {
         const spec = deriveHarnessLaunchSpec({harnessType: 'claude-desktop', instanceHome: '/srv/instances/a/claude-desktop', binaryPath: '/Applications/Claude.app/Contents/MacOS/Claude'});
 
         // The profile switch is BOTH halves at once for an Electron app: it relocates the config
@@ -66,7 +73,7 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
         expect(spec).toEqual({
             command         : '/Applications/Claude.app/Contents/MacOS/Claude',
             args            : ['--user-data-dir=/srv/instances/a/claude-desktop'],
-            env             : {},
+            env             : {CLAUDE_USER_DATA_DIR: '/srv/instances/a/claude-desktop'},
             versionProbeArgs: ['--user-data-dir=/srv/instances/a/claude-desktop', '--version']
         });
     });

--- a/test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs
@@ -1,0 +1,404 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs/promises';
+import os             from 'node:os';
+import path           from 'node:path';
+import {
+    ManagedWorkspacePreparationError,
+    WORKSPACE_ARTIFACT_STATES,
+    prepareManagedAgentWorkspace
+} from '../../../../../../ai/services/fleet/prepareManagedAgentWorkspace.mjs';
+
+// Temp-filesystem contract tests: the real artifact writer runs, while checkout hydration is an
+// injected recorder. `hydrateCurrentWorktree` has its own real temp-checkout suite; this spec proves
+// the new composer calls that existing primitive at the right boundary without invoking its CLI,
+// install, or build path.
+
+const TEMPLATE = `# local project policy
+project_doc_max_bytes = 131072
+
+[mcp_servers."neo-mjs-memory-core"]
+command = "npm"
+args = ["run", "old"]
+enabled = true
+
+[features]
+hooks = true
+`;
+
+const NODE_PATH = process.execPath;
+
+const MCP_ENTRYPOINTS = [
+    'ai/mcp/server/memory-core/mcp-server.mjs',
+    'ai/mcp/server/knowledge-base/mcp-server.mjs',
+    'ai/mcp/server/neural-link/mcp-server.mjs',
+    'ai/mcp/server/github-workflow/mcp-server.mjs',
+    'ai/mcp/server/gitlab-workflow/mcp-server.mjs'
+];
+
+let root, mainCheckout, repoRoot, instanceRoot, hydrationCalls;
+
+test.beforeEach(async () => {
+    root          = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-fleet-workspace-'));
+    mainCheckout  = path.join(root, 'installed-neo');
+    repoRoot      = path.join(root, 'managed-repos');
+    instanceRoot  = path.join(root, 'instances');
+    hydrationCalls = [];
+
+    await fs.mkdir(path.join(mainCheckout, '.codex'), {recursive: true});
+    await fs.writeFile(path.join(mainCheckout, '.codex', 'config.template.toml'), TEMPLATE, 'utf8');
+    for (const relativePath of MCP_ENTRYPOINTS) {
+        const filePath = path.join(mainCheckout, relativePath);
+        await fs.mkdir(path.dirname(filePath), {recursive: true});
+        await fs.writeFile(filePath, '// installed canonical entrypoint\n', 'utf8');
+    }
+});
+
+test.afterEach(async () => {
+    await fs.rm(root, {recursive: true, force: true});
+});
+
+function makeAgent(harnessType, {id = 'agent-a', mcpServers = null} = {}) {
+    return {id, githubUsername: 'shared-login', harnessType, mcpServers};
+}
+
+function makeHydrate() {
+    return async args => {
+        hydrationCalls.push(args);
+        await fs.mkdir(args.projectRoot, {recursive: true});
+        return {hydrated: true};
+    };
+}
+
+function options(agent, repoName = agent.id) {
+    return {
+        agent,
+        repoPath        : path.join(repoRoot, repoName),
+        instanceRoot,
+        mainCheckout,
+        nodePath        : NODE_PATH,
+        hydrateWorkspace: makeHydrate()
+    };
+}
+
+async function read(filePath) {
+    return fs.readFile(filePath, 'utf8');
+}
+
+test.describe('prepareManagedAgentWorkspace', () => {
+    test('Codex: hydrate → project MCP projection + isolated home policy, all CREATED', async () => {
+        const
+            opts              = options(makeAgent('codex')),
+            result            = await prepareManagedAgentWorkspace(opts),
+            projectConfigPath = path.join(opts.repoPath, '.codex', 'config.toml'),
+            homeConfigPath    = path.join(result.instanceHome, 'config.toml'),
+            memoriesPath      = path.join(result.instanceHome, 'memories'),
+            projectConfig     = await read(projectConfigPath),
+            homeConfig        = await read(homeConfigPath);
+
+        expect(hydrationCalls).toHaveLength(1);
+        expect(hydrationCalls[0]).toMatchObject({mainCheckout, projectRoot: opts.repoPath});
+        expect(result.repoPath).toBe(opts.repoPath);
+        expect(result.hydration).toEqual({hydrated: true});
+        expect(result.artifacts.map(item => item.status)).toEqual([
+            WORKSPACE_ARTIFACT_STATES.CREATED,
+            WORKSPACE_ARTIFACT_STATES.CREATED,
+            WORKSPACE_ARTIFACT_STATES.CREATED
+        ]);
+
+        // Fresh managed clones have no dependencies: every executable comes from the installed
+        // checkout, while Neural Link receives the managed repo as its explicit project cwd.
+        expect(projectConfig).toContain(`command = ${JSON.stringify(NODE_PATH)}`);
+        expect(projectConfig).toContain(path.join(mainCheckout, 'ai/mcp/server/memory-core/mcp-server.mjs'));
+        expect(projectConfig).toContain(JSON.stringify(['--cwd', opts.repoPath]).slice(1, -1));
+        expect(projectConfig).not.toContain('command = "npm"');
+        await expect(fs.stat(path.join(opts.repoPath, 'node_modules'))).rejects.toMatchObject({code: 'ENOENT'});
+
+        // All catalog keys are projected from current defaults; optional workflows remain disabled.
+        expect(projectConfig.match(/^\[mcp_servers\./gm)).toHaveLength(5);
+        expect(projectConfig).toMatch(/\[mcp_servers\."neo-mjs-github-workflow"\][\s\S]*?enabled = false/);
+        expect(projectConfig).toMatch(/\[mcp_servers\."neo-mjs-gitlab-workflow"\][\s\S]*?enabled = false/);
+        expect(homeConfig).toContain('cli_auth_credentials_store = "file"');
+        expect(homeConfig).toContain('mcp_oauth_credentials_store = "file"');
+        expect(homeConfig).toContain('memories = true');
+        expect((await fs.stat(memoriesPath)).isDirectory()).toBe(true);
+        expect((await fs.stat(homeConfigPath)).mode & 0o777).toBe(0o600);
+    });
+
+    test('re-entry reports MATCH and ignores unrelated operator-owned TOML tables/keys', async () => {
+        const opts        = options(makeAgent('codex'));
+        const first       = await prepareManagedAgentWorkspace(opts);
+        const projectPath = path.join(opts.repoPath, '.codex', 'config.toml');
+        const homePath    = path.join(first.instanceHome, 'config.toml');
+
+        await fs.appendFile(projectPath, '\n[mcp_servers."operator-local"]\ncommand = "custom"\n', 'utf8');
+        await fs.appendFile(homePath, '\n[operator]\nkeep = true\n', 'utf8');
+
+        const second = await prepareManagedAgentWorkspace(opts);
+
+        expect(second.artifacts.map(item => item.status)).toEqual([
+            WORKSPACE_ARTIFACT_STATES.MATCH,
+            WORKSPACE_ARTIFACT_STATES.MATCH,
+            WORKSPACE_ARTIFACT_STATES.MATCH
+        ]);
+        expect(await read(projectPath)).toContain('[mcp_servers."operator-local"]');
+        expect(await read(homePath)).toContain('[operator]');
+    });
+
+    test('divergent owned content refuses without overwrite and exposes only bounded metadata', async () => {
+        const opts      = options(makeAgent('codex'));
+        const first     = await prepareManagedAgentWorkspace(opts);
+        const homePath  = path.join(first.instanceHome, 'config.toml');
+        const divergent = (await read(homePath)).replace('memories = true', 'memories = false');
+
+        await fs.writeFile(homePath, divergent, 'utf8');
+
+        let error;
+        try {
+            await prepareManagedAgentWorkspace(opts);
+        } catch (caught) {
+            error = caught;
+        }
+
+        expect(error).toBeInstanceOf(ManagedWorkspacePreparationError);
+        expect(error.code).toBe('FLEET_WORKSPACE_DIVERGENT');
+        expect(error.artifact).toMatchObject({
+            path     : homePath,
+            status   : WORKSPACE_ARTIFACT_STATES.DIVERGENT,
+            ownedKeys: 'cli_auth_credentials_store,mcp_oauth_credentials_store,features.memories'
+        });
+        expect(error.artifact).not.toHaveProperty('actual');
+        expect(error.artifact).not.toHaveProperty('desired');
+        expect(await read(homePath)).toBe(divergent);
+    });
+
+    test('two residents sharing one GitHub identity have disjoint Codex auth/memory homes', async () => {
+        const
+            a = await prepareManagedAgentWorkspace(options(makeAgent('codex', {id: 'resident-a'}))),
+            b = await prepareManagedAgentWorkspace(options(makeAgent('codex', {id: 'resident-b'})));
+
+        expect(a.instanceHome).not.toBe(b.instanceHome);
+        expect(path.join(a.instanceHome, 'config.toml')).not.toBe(path.join(b.instanceHome, 'config.toml'));
+        expect(path.join(a.instanceHome, 'memories')).not.toBe(path.join(b.instanceHome, 'memories'));
+        expect((await fs.stat(path.join(a.instanceHome, 'memories'))).isDirectory()).toBe(true);
+        expect((await fs.stat(path.join(b.instanceHome, 'memories'))).isDirectory()).toBe(true);
+    });
+
+    test('Codex Desktop keeps its auth/memory policy inside the nested codex-home', async () => {
+        const
+            opts     = options(makeAgent('codex-desktop')),
+            result   = await prepareManagedAgentWorkspace(opts),
+            authHome = path.join(result.instanceHome, 'codex-home');
+
+        expect(await read(path.join(authHome, 'config.toml'))).toContain('features');
+        expect((await fs.stat(path.join(authHome, 'memories'))).isDirectory()).toBe(true);
+        await expect(fs.stat(path.join(result.instanceHome, 'config.toml'))).rejects.toMatchObject({code: 'ENOENT'});
+    });
+
+    test('a symlinked resident-home segment fails before hydration or artifact writes', async () => {
+        const
+            opts        = options(makeAgent('codex')),
+            foreignHome = path.join(root, 'foreign-resident-home'),
+            agentRoot   = path.join(instanceRoot, 'agent-a');
+
+        opts.deriveInstanceHome = () => path.join(agentRoot, 'codex');
+        await fs.mkdir(foreignHome, {recursive: true});
+        await fs.mkdir(instanceRoot, {recursive: true});
+        await fs.symlink(foreignHome, agentRoot, 'dir');
+
+        await expect(prepareManagedAgentWorkspace(opts)).rejects.toMatchObject({
+            code    : 'FLEET_WORKSPACE_DIVERGENT',
+            artifact: {path: agentRoot, reason: 'symlinked resident-owned path segment'}
+        });
+        expect(hydrationCalls).toHaveLength(0);
+    });
+
+    test('a symlinked instance root fails before hydration or artifact writes', async () => {
+        const
+            opts        = options(makeAgent('codex')),
+            foreignRoot = path.join(root, 'foreign-instance-root');
+
+        await fs.mkdir(foreignRoot, {recursive: true});
+        await fs.symlink(foreignRoot, instanceRoot, 'dir');
+
+        await expect(prepareManagedAgentWorkspace(opts)).rejects.toMatchObject({
+            code    : 'FLEET_WORKSPACE_DIVERGENT',
+            artifact: {path: instanceRoot, reason: 'trusted root is not a real directory'}
+        });
+        expect(hydrationCalls).toHaveLength(0);
+    });
+
+    test('resident node_modules stays outside the owned artifact set', async () => {
+        const
+            opts        = options(makeAgent('codex')),
+            foreignDeps = path.join(root, 'foreign-resident', 'node_modules');
+
+        await fs.mkdir(foreignDeps, {recursive: true});
+        await fs.mkdir(opts.repoPath, {recursive: true});
+        await fs.symlink(foreignDeps, path.join(opts.repoPath, 'node_modules'), 'dir');
+
+        const result = await prepareManagedAgentWorkspace(opts);
+
+        expect(result.artifacts.every(item => item.ownedKeys !== 'dependency-root')).toBe(true);
+        expect(path.resolve(path.dirname(path.join(opts.repoPath, 'node_modules')), await fs.readlink(path.join(opts.repoPath, 'node_modules'))))
+            .toBe(foreignDeps);
+    });
+
+    test('raw launch overrides and missing executables fail before a launchable config exists', async () => {
+        const raw = options(makeAgent('codex'));
+        raw.agent.metadata = {launch: {command: '/custom'}};
+
+        await expect(prepareManagedAgentWorkspace(raw)).rejects.toMatchObject({
+            code: 'FLEET_WORKSPACE_UNSUPPORTED'
+        });
+        expect(hydrationCalls).toHaveLength(0);
+
+        const missingNode = options(makeAgent('codex'), 'missing-node');
+        missingNode.nodePath = path.join(root, 'absent-node');
+        await expect(prepareManagedAgentWorkspace(missingNode)).rejects.toMatchObject({
+            code: 'FLEET_WORKSPACE_UNSUPPORTED'
+        });
+        await expect(fs.stat(path.join(missingNode.repoPath, '.codex', 'config.toml'))).rejects.toMatchObject({code: 'ENOENT'});
+
+        const missingEntrypoint = options(makeAgent('codex'), 'missing-entrypoint');
+        await fs.rm(path.join(mainCheckout, MCP_ENTRYPOINTS[0]));
+        await expect(prepareManagedAgentWorkspace(missingEntrypoint)).rejects.toMatchObject({
+            code: 'FLEET_WORKSPACE_UNSUPPORTED'
+        });
+        await expect(fs.stat(path.join(missingEntrypoint.repoPath, '.codex', 'config.toml'))).rejects.toMatchObject({code: 'ENOENT'});
+    });
+
+    test('directory-valued Node and MCP entrypoint paths fail executable preflight', async () => {
+        const directoryNode = options(makeAgent('codex'), 'directory-node');
+        directoryNode.nodePath = root;
+
+        await expect(prepareManagedAgentWorkspace(directoryNode)).rejects.toMatchObject({
+            code: 'FLEET_WORKSPACE_UNSUPPORTED'
+        });
+
+        const directoryEntrypoint = options(makeAgent('codex'), 'directory-entrypoint');
+        const directoryPath       = path.join(mainCheckout, MCP_ENTRYPOINTS[0]);
+        await fs.rm(directoryPath);
+        await fs.mkdir(directoryPath);
+
+        await expect(prepareManagedAgentWorkspace(directoryEntrypoint)).rejects.toMatchObject({
+            code: 'FLEET_WORKSPACE_UNSUPPORTED'
+        });
+    });
+
+    test('Claude Code: strict home JSON stores env references, never dynamic secret values', async () => {
+        const originalBridgeToken = process.env.NEO_FLEET_BRIDGE_TOKEN;
+        process.env.NEO_FLEET_BRIDGE_TOKEN = 'secret-token-value';
+
+        const opts = options(makeAgent('claude-code'));
+        let result;
+        try {
+            result = await prepareManagedAgentWorkspace(opts);
+        } finally {
+            if (originalBridgeToken === undefined) delete process.env.NEO_FLEET_BRIDGE_TOKEN;
+            else process.env.NEO_FLEET_BRIDGE_TOKEN = originalBridgeToken;
+        }
+
+        const
+            configPath = path.join(result.instanceHome, 'mcp-config.json'),
+            raw        = await read(configPath),
+            config     = JSON.parse(raw),
+            nl         = config.mcpServers['neo-mjs-neural-link'];
+
+        expect(Object.keys(config.mcpServers).sort()).toEqual([
+            'neo-mjs-knowledge-base',
+            'neo-mjs-memory-core',
+            'neo-mjs-neural-link'
+        ]);
+        expect(nl.command).toBe(NODE_PATH);
+        expect(nl.args).toEqual([
+            path.join(mainCheckout, 'ai/mcp/server/neural-link/mcp-server.mjs'),
+            '--cwd',
+            opts.repoPath
+        ]);
+        expect(nl.env).toEqual({
+            NEO_AGENT_IDENTITY         : '${NEO_AGENT_IDENTITY}',
+            NEO_FLEET_BRIDGE_TOKEN     : '${NEO_FLEET_BRIDGE_TOKEN}',
+            NEO_NL_TOOL_PROJECTION_MODE: '${NEO_NL_TOOL_PROJECTION_MODE}'
+        });
+        expect(raw).not.toContain('secret-token-value');
+        await expect(fs.stat(path.join(opts.repoPath, '.mcp.json'))).rejects.toMatchObject({code: 'ENOENT'});
+    });
+
+    test('Claude Desktop: default profile includes Neural Link without persisting its optional Bridge token', async () => {
+        const originalBridgeToken = process.env.NEO_FLEET_BRIDGE_TOKEN;
+        process.env.NEO_FLEET_BRIDGE_TOKEN = 'secret-token-value';
+
+        const opts = options(makeAgent('claude-desktop'));
+        let result;
+        try {
+            result = await prepareManagedAgentWorkspace(opts);
+        } finally {
+            if (originalBridgeToken === undefined) delete process.env.NEO_FLEET_BRIDGE_TOKEN;
+            else process.env.NEO_FLEET_BRIDGE_TOKEN = originalBridgeToken;
+        }
+
+        const
+            configPath = path.join(result.instanceHome, 'claude_desktop_config.json'),
+            raw        = await read(configPath),
+            nl         = JSON.parse(raw).mcpServers['neo-mjs-neural-link'];
+
+        expect(nl.env).toEqual({
+            NEO_AGENT_IDENTITY         : 'agent-a',
+            NEO_NL_TOOL_PROJECTION_MODE: 'harness-embedded'
+        });
+        expect(raw).not.toContain('NEO_FLEET_BRIDGE_TOKEN');
+        expect(raw).not.toContain('secret-token-value');
+    });
+
+    test('Claude Desktop: a secret-free matrix materializes the exact contained profile config', async () => {
+        const
+            opts       = options(makeAgent('claude-desktop', {mcpServers: {'neural-link': false}})),
+            result     = await prepareManagedAgentWorkspace(opts),
+            configPath = path.join(result.instanceHome, 'claude_desktop_config.json'),
+            config     = JSON.parse(await read(configPath));
+
+        expect(result.artifacts).toEqual([
+            {
+                path     : configPath,
+                status   : WORKSPACE_ARTIFACT_STATES.CREATED,
+                ownedKeys: 'mcpServers.neo-mjs-*'
+            }
+        ]);
+        expect(Object.keys(config.mcpServers).sort()).toEqual([
+            'neo-mjs-knowledge-base',
+            'neo-mjs-memory-core'
+        ]);
+        expect(config.mcpServers['neo-mjs-memory-core'].env).toEqual({NEO_AGENT_IDENTITY: 'agent-a'});
+    });
+
+    test('Claude Desktop refuses an enabled server whose startup requires secret env', async () => {
+        const opts = options(makeAgent('claude-desktop', {mcpServers: {'github-workflow': true}}));
+
+        await expect(prepareManagedAgentWorkspace(opts)).rejects.toMatchObject({
+            code: 'FLEET_WORKSPACE_UNSUPPORTED'
+        });
+        expect(hydrationCalls).toHaveLength(0);
+        await expect(fs.stat(instanceRoot)).rejects.toMatchObject({code: 'ENOENT'});
+    });
+
+    test('Antigravity and unprovisioned GitLab credential authority fail before hydration', async () => {
+        await expect(prepareManagedAgentWorkspace(options(makeAgent('antigravity')))).rejects.toMatchObject({
+            code: 'FLEET_WORKSPACE_UNSUPPORTED'
+        });
+        await expect(prepareManagedAgentWorkspace(options(makeAgent('codex', {
+            mcpServers: {'gitlab-workflow': true}
+        }), 'gitlab-agent'))).rejects.toMatchObject({code: 'FLEET_WORKSPACE_UNSUPPORTED'});
+
+        expect(hydrationCalls).toHaveLength(0);
+        await expect(fs.stat(path.join(repoRoot, 'agent-a', '.gemini', 'settings.json'))).rejects.toMatchObject({code: 'ENOENT'});
+    });
+
+    test('required arguments fail loud before any hydration', async () => {
+        await expect(prepareManagedAgentWorkspace()).rejects.toThrow(/agent/);
+        await expect(prepareManagedAgentWorkspace({
+            ...options(makeAgent('codex')),
+            repoPath: 'relative/repo'
+        })).rejects.toThrow(/repoPath.*absolute/);
+        expect(hydrationCalls).toHaveLength(0);
+    });
+});

--- a/test/playwright/unit/ai/startAgentProvisioned.spec.mjs
+++ b/test/playwright/unit/ai/startAgentProvisioned.spec.mjs
@@ -7,21 +7,33 @@ import {startAgentProvisioned} from '../../../../ai/services/fleet/startAgentPro
 // the `lifecycleService` stub records every `start` call so the cwd-threading contract is assertable.
 
 /** A recording FleetLifecycleService stub: tracks start() calls + answers isRunning/status/getRegistry. */
-function makeLifecycle({agents = {}, running = {}} = {}) {
+function makeLifecycle({agents = {}, definitions = agents, running = {}, events} = {}) {
     const calls = {start: [], status: []};
     return {
         calls,
         isRunning  : id => !!running[id],
         status     : id => { calls.status.push(id); return {id, running: !!running[id], state: running[id] ? 'running' : 'stopped'}; },
-        getRegistry: () => ({getAgent: id => agents[id] || null}),
-        start      : (id, opts) => { calls.start.push({id, opts}); return {id, running: true, state: 'running', cwd: opts?.cwd}; }
+        getRegistry: () => ({
+            getAgent     : id => agents[id] || null,
+            getDefinition: id => definitions[id] || null
+        }),
+        getInstanceRoot: () => '/instances',
+        start          : (id, opts) => { events?.push('start'); calls.start.push({id, opts}); return {id, running: true, state: 'running', cwd: opts?.cwd}; }
     };
 }
 
 /** A recording ensureAgentRepo stub: records its args, returns a fixed repoPath (no fs / git). */
-function makeEnsureRepo(repoPath = '/managed/agent/repo') {
+function makeEnsureRepo(repoPath = '/managed/agent/repo', events) {
     const calls = [];
-    const fn    = async args => { calls.push(args); return {repoPath, state: 'absent', action: 'cloned', cloned: true}; };
+    const fn    = async args => { events?.push('ensure'); calls.push(args); return {repoPath, state: 'absent', action: 'cloned', cloned: true}; };
+    fn.calls    = calls;
+    return fn;
+}
+
+/** Recording post-provisioning workspace/home preparation seam. */
+function makePrepareWorkspace(events) {
+    const calls = [];
+    const fn    = async args => { events?.push('prepare'); calls.push(args); return {repoPath: args.repoPath}; };
     fn.calls    = calls;
     return fn;
 }
@@ -29,20 +41,40 @@ function makeEnsureRepo(repoPath = '/managed/agent/repo') {
 const REPO = {cloneUrl: 'https://github.com/neomjs/neo.git', repoSlug: 'neomjs/neo'};
 
 function repoAgent(id = 'a') {
-    return {[id]: {id, githubUsername: id, harnessType: 'codex', metadata: {launch: {command: 'h'}, repo: REPO}}};
+    return {[id]: {id, githubUsername: id, harnessType: 'codex', metadata: {repo: REPO}}};
 }
 
 test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning)', () => {
-    test('provisions the repo then starts the harness with cwd pinned to the checkout', async () => {
-        const lifecycle  = makeLifecycle({agents: repoAgent('a')}),
-              ensureRepo = makeEnsureRepo('/managed/a/neomjs-neo'),
-              cloneRepo  = () => {},
-              status     = await startAgentProvisioned({lifecycleService: lifecycle, agentId: 'a', managedRoot: '/managed', cloneRepo, ensureRepo});
+    test('provisions, prepares, then starts with one canonical checkout path', async () => {
+        const events           = [],
+              lifecycle        = makeLifecycle({agents: repoAgent('a'), events}),
+              ensureRepo       = makeEnsureRepo('/managed/a/neomjs-neo', events),
+              prepareWorkspace = makePrepareWorkspace(events),
+              cloneRepo        = () => {},
+              status           = await startAgentProvisioned({
+                  lifecycleService: lifecycle,
+                  agentId         : 'a',
+                  managedRoot     : '/managed',
+                  cloneRepo,
+                  ensureRepo,
+                  prepareWorkspace,
+                  mainCheckout    : '/installed/neo',
+                  nodePath        : '/usr/bin/node'
+              });
 
         // provisioning fed the agent's metadata.repo coordinates + the managed root + the clone seam
         expect(ensureRepo.calls).toHaveLength(1);
         expect(ensureRepo.calls[0]).toMatchObject({managedRoot: '/managed', agentId: 'a', repoSlug: 'neomjs/neo', cloneUrl: REPO.cloneUrl, cloneRepo});
-        // the harness was started with cwd === the provisioned repoPath
+        expect(prepareWorkspace.calls).toHaveLength(1);
+        expect(prepareWorkspace.calls[0]).toMatchObject({
+            agent       : repoAgent('a').a,
+            repoPath    : '/managed/a/neomjs-neo',
+            instanceRoot: '/instances',
+            mainCheckout: '/installed/neo',
+            nodePath    : '/usr/bin/node'
+        });
+        expect(events).toEqual(['ensure', 'prepare', 'start']);
+        // The harness starts with cwd === provisioned repoPath === prepared repoPath.
         expect(lifecycle.calls.start).toHaveLength(1);
         expect(lifecycle.calls.start[0]).toEqual({id: 'a', opts: {cwd: '/managed/a/neomjs-neo'}});
         expect(status.state).toBe('running');
@@ -50,13 +82,15 @@ test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning
     });
 
     test('an agent with no metadata.repo starts in the inherited cwd (backward-compatible)', async () => {
-        const lifecycle  = makeLifecycle({agents: {a: {id: 'a', metadata: {launch: {command: 'h'}}}}}),
-              ensureRepo = makeEnsureRepo();
+        const lifecycle        = makeLifecycle({agents: {a: {id: 'a', metadata: {launch: {command: 'h'}}}}}),
+              ensureRepo       = makeEnsureRepo(),
+              prepareWorkspace = makePrepareWorkspace();
 
-        await startAgentProvisioned({lifecycleService: lifecycle, agentId: 'a', managedRoot: '/managed', ensureRepo});
+        await startAgentProvisioned({lifecycleService: lifecycle, agentId: 'a', managedRoot: '/managed', ensureRepo, prepareWorkspace});
 
         // nothing to provision; start called with NO opts (no cwd)
         expect(ensureRepo.calls).toHaveLength(0);
+        expect(prepareWorkspace.calls).toHaveLength(0);
         expect(lifecycle.calls.start).toHaveLength(1);
         expect(lifecycle.calls.start[0].id).toBe('a');
         expect(lifecycle.calls.start[0].opts).toBeUndefined();
@@ -72,13 +106,55 @@ test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning
         expect(lifecycle.calls.start).toHaveLength(0);
     });
 
+    test('a preparation rejection propagates and start is NEVER called (fail-closed)', async () => {
+        const lifecycle        = makeLifecycle({agents: repoAgent('a')}),
+              prepareWorkspace = async () => { throw new Error('DIVERGENT: owned MCP keys'); };
+
+        await expect(startAgentProvisioned({
+            lifecycleService: lifecycle,
+            agentId         : 'a',
+            managedRoot     : '/managed',
+            ensureRepo      : makeEnsureRepo('/managed/a/neomjs-neo'),
+            prepareWorkspace
+        })).rejects.toThrow('DIVERGENT: owned MCP keys');
+
+        expect(lifecycle.calls.start).toHaveLength(0);
+    });
+
+    test('a repo-bearing raw launch override refuses before clone, prepare, or start', async () => {
+        const
+            publicAgent = repoAgent('a'),
+            rawAgent    = structuredClone(publicAgent);
+
+        rawAgent.a.metadata.launch = {command: '/custom/harness'};
+
+        const
+            lifecycle        = makeLifecycle({agents: publicAgent, definitions: rawAgent}),
+            ensureRepo       = makeEnsureRepo(),
+            prepareWorkspace = makePrepareWorkspace();
+
+        await expect(startAgentProvisioned({
+            lifecycleService: lifecycle,
+            agentId         : 'a',
+            managedRoot     : '/managed',
+            ensureRepo,
+            prepareWorkspace
+        })).rejects.toThrow(/raw metadata\.launch override/);
+
+        expect(ensureRepo.calls).toHaveLength(0);
+        expect(prepareWorkspace.calls).toHaveLength(0);
+        expect(lifecycle.calls.start).toHaveLength(0);
+    });
+
     test('an already-running agent short-circuits to status without provisioning or re-spawning', async () => {
-        const lifecycle  = makeLifecycle({agents: repoAgent('a'), running: {a: true}}),
-              ensureRepo = makeEnsureRepo(),
-              status     = await startAgentProvisioned({lifecycleService: lifecycle, agentId: 'a', managedRoot: '/managed', ensureRepo});
+        const lifecycle        = makeLifecycle({agents: repoAgent('a'), running: {a: true}}),
+              ensureRepo       = makeEnsureRepo(),
+              prepareWorkspace = makePrepareWorkspace(),
+              status           = await startAgentProvisioned({lifecycleService: lifecycle, agentId: 'a', managedRoot: '/managed', ensureRepo, prepareWorkspace});
 
         expect(status.running).toBe(true);
         expect(ensureRepo.calls).toHaveLength(0);
+        expect(prepareWorkspace.calls).toHaveLength(0);
         expect(lifecycle.calls.start).toHaveLength(0);
     });
 
@@ -103,5 +179,19 @@ test.describe('startAgentProvisioned (Fleet Manager spawn-time repo provisioning
 
         await expect(startAgentProvisioned({lifecycleService: lifecycle, agentId: 'ghost', managedRoot: '/managed'}))
             .rejects.toThrow(/unknown agent/);
+    });
+
+    test('a preparation result cannot substitute a second checkout path', async () => {
+        const lifecycle = makeLifecycle({agents: repoAgent('a')});
+
+        await expect(startAgentProvisioned({
+            lifecycleService: lifecycle,
+            agentId         : 'a',
+            managedRoot     : '/managed',
+            ensureRepo      : makeEnsureRepo('/managed/a/neomjs-neo'),
+            prepareWorkspace: async () => ({repoPath: '/other/repo'})
+        })).rejects.toThrow(/canonical provisioned repoPath/);
+
+        expect(lifecycle.calls.start).toHaveLength(0);
     });
 });


### PR DESCRIPTION
Resolves #15048

Related: #13015

Adds the missing Fleet pre-launch stage: a repo-bearing resident now follows `ensureAgentRepo → prepareManagedAgentWorkspace → FleetLifecycleService.start`. Preparation reuses the import-safe checkout hydrator, resolves current Brain-owned MCP intent, converges only explicit Fleet-owned keys, creates isolated Codex/Claude homes, and refuses divergent or unsupported state before spawn. The provisioned `repoPath` remains the single harness cwd/project truth; executable MCP code comes from the installed canonical checkout so a cold clone needs neither dependency installation nor a shared dependency tree.

Evidence: L3 (real local clone, real checkout/home convergence, exact-cwd login-shell + live GitHub identity receipt, Claude Desktop profile materialization, and Antigravity negative probe) → L3 required (cold-bootstrap acceptance). No residuals.

## Deltas from ticket

- Folded the intake authority refinement into implementation: generated MCP definitions use readable absolute entrypoints under the installed checkout, while the resident checkout remains cwd/project truth. No resident `node_modules` is created, shared, or adopted; this preserves the merged #10352 no-symlink boundary.
- Classified `NEO_FLEET_BRIDGE_TOKEN` as optional for Neural Link stdio startup and required only for authenticated live-Bridge capability. Claude Desktop's default profile can therefore include Neural Link without persisting token names/bytes; servers with startup-required secrets still refuse.
- Added an explicit pre-clone refusal for repo-bearing raw `metadata.launch` overrides because they bypass curated home/MCP preparation.
- Tightened existing hydration primitives so canonical data/read aliases and the Sandman handoff never accept another checkout's symlink target. Canonical read-alias sources/names stay outside the generic linker even with a custom blocklist.
- Antigravity remains a named `FLEET_WORKSPACE_UNSUPPORTED` result because installed 2.x exposes no proven contained per-resident Desktop MCP authority. No `.gemini/settings.json` is created.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/FleetLifecycleService.spec.mjs test/playwright/unit/ai/scripts/migrations/bootstrapWorktree.spec.mjs test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs test/playwright/unit/ai/startAgentProvisioned.spec.mjs test/playwright/unit/ai/services/fleet/prepareManagedAgentWorkspace.spec.mjs` — 138/138 passed before the final contained-root/read-alias guard; the two directly affected specs then passed 69/69 after that guard.
- `npm run test-unit` — broader local sweep reached 7,004 passing tests; 40 unrelated baseline/infrastructure failures and one interrupted test remained after 4.7 minutes. Focused touched-surface suites above are green; CI is the clean-room full-suite authority.
- `node --check` — all four touched implementation modules passed.
- `git diff --check` — passed.
- `npm run agent-preflight -- <all touched .mjs files> --no-fix --pr-body /private/tmp/neo-15048-pr-body.md` — final result recorded after staging.
- Fleet workspace surface: focused composer, lifecycle, launch-spec, and real temp-checkout coverage passed.
- Non-CI L3 cold receipt: real local clone produced Codex Desktop `CREATED ×3 → MATCH ×3`, installed entrypoints `true`, resident cwd `true`, resident dependencies `false`; Claude Desktop profile `CREATED`; Antigravity `FLEET_WORKSPACE_UNSUPPORTED`; effective shell identity + `gh api user` both `neo-gpt-emmy`; secret leak `false`.

## Post-Merge Validation

- [x] None required for the close target; the L3 cold-bootstrap receipt is complete. Product OAuth/login remains operator-owned and out of scope.

## Evolution

An intermediate implementation pointed resident MCP source at the cold clone and linked its `node_modules` to the installed checkout. A prior-art falsifier against #10351/#10352 showed that topology had already been rejected at the harness security boundary and contradicted this ticket's own intake authority. The dependency artifact was removed completely; tests now prove installed executable authority, resident cwd truth, and absence of a resident dependency tree.

Authored by Emmy (GPT-5.6 Sol, Codex). Session f95e01ff-ba36-409a-98af-573263fab247.
