### PR TITLE
feat(agentos): add dense workstation showcase (#15099)

### DIFF
--- a/apps/agentos/childapps/dockdemo/model/DemoCRecord.mjs
+++ b/apps/agentos/childapps/dockdemo/model/DemoCRecord.mjs
@@ -1,0 +1,56 @@
+import Model from '../../../../../src/data/Model.mjs';
+
+/**
+ * @summary The compact record contract shared by Demo C's scale and live-feed stores.
+ *
+ * One target-owned model keeps the two panes honest without importing either precedent's
+ * product schema. The 100k store carries raw objects until the grid hydrates its viewport;
+ * the feed store carries ordinary records so each batched insert updates visible component
+ * and Sparkline cells through the normal Store<Model> path.
+ *
+ * @class AgentOS.childapps.dockdemo.model.DemoCRecord
+ * @extends Neo.data.Model
+ */
+class DemoCRecord extends Model {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.childapps.dockdemo.model.DemoCRecord'
+         * @protected
+         */
+        className: 'AgentOS.childapps.dockdemo.model.DemoCRecord',
+        /**
+         * @member {Object[]} fields
+         */
+        fields: [{
+            name: 'id'
+        }, {
+            name: 'name',
+            type: 'String'
+        }, {
+            name: 'status',
+            type: 'String'
+        }, {
+            name: 'timestamp',
+            type: 'String'
+        }, {
+            name: 'value',
+            type: 'Int'
+        }, {
+            name: 'counter',
+            type: 'Int'
+        }, {
+            name: 'progress',
+            type: 'Int'
+        }, {
+            // New arrays are assigned on each pulse so pooled Sparkline components observe
+            // a new record version instead of an in-place mutation that can short-circuit.
+            name: 'trend'
+        }],
+        /**
+         * @member {String} keyProperty='id'
+         */
+        keyProperty: 'id'
+    }
+}
+
+export default Neo.setupClass(DemoCRecord);

--- a/apps/agentos/childapps/dockdemo/store/DemoCFeed.mjs
+++ b/apps/agentos/childapps/dockdemo/store/DemoCFeed.mjs
@@ -1,0 +1,39 @@
+import DemoCRecord from '../model/DemoCRecord.mjs';
+import Store       from '../../../../../src/data/Store.mjs';
+
+/**
+ * @summary The provider-owned Store<Model> receiving Demo C's batched live feed.
+ *
+ * Production cadence belongs to the workspace, whose lifetime survives pane parking. This
+ * store owns only collection policy: newest rows first and an explicit 500-record cap.
+ *
+ * @class AgentOS.childapps.dockdemo.store.DemoCFeed
+ * @extends Neo.data.Store
+ */
+class DemoCFeed extends Store {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.childapps.dockdemo.store.DemoCFeed'
+         * @protected
+         */
+        className: 'AgentOS.childapps.dockdemo.store.DemoCFeed',
+        /**
+         * @member {String} keyProperty='id'
+         */
+        keyProperty: 'id',
+        /**
+         * @member {Number} maxRecords=500
+         */
+        maxRecords: 500,
+        /**
+         * @member {Neo.data.Model} model=DemoCRecord
+         */
+        model: DemoCRecord,
+        /**
+         * @member {Object[]} sorters
+         */
+        sorters: [{property: 'id', direction: 'DESC'}]
+    }
+}
+
+export default Neo.setupClass(DemoCFeed);

--- a/apps/agentos/childapps/dockdemo/store/DemoCScale.mjs
+++ b/apps/agentos/childapps/dockdemo/store/DemoCScale.mjs
@@ -61,7 +61,8 @@ class DemoCScale extends Store {
             records  = new Array(amountRows);
 
         for (let index = 0; index < amountRows; index++) {
-            const base = Math.round(Math.random() * 100);
+            const base   = Math.round(Math.random() * 100);
+            let   signal = 24 + index % 48;
 
             records[index] = {
                 id      : index + 1,
@@ -70,7 +71,10 @@ class DemoCScale extends Store {
                 value   : Math.round(Math.random() * 10000),
                 counter : base,
                 progress: Math.round(Math.random() * 100),
-                trend   : Array.from({length: 12}, (_, point) => (base + point * 7 + index) % 101)
+                trend   : Array.from({length: 12}, (_, point) => {
+                    signal = Math.max(8, Math.min(92, signal + ((index * 3 + point * 5) % 9) - 4));
+                    return signal
+                })
             }
         }
 

--- a/apps/agentos/childapps/dockdemo/store/DemoCScale.mjs
+++ b/apps/agentos/childapps/dockdemo/store/DemoCScale.mjs
@@ -1,0 +1,81 @@
+import DemoCRecord from '../model/DemoCRecord.mjs';
+import Store       from '../../../../../src/data/Store.mjs';
+
+/**
+ * @summary Demo C's target-owned 100,000-row scale store.
+ *
+ * This is the shipped BigData mechanism, localized rather than wrapped as another UI:
+ * build plain objects, keep `autoInitRecords:false`, and add the complete set once in
+ * Turbo Mode. Grid buffering and record hydration remain framework-owned.
+ *
+ * @class AgentOS.childapps.dockdemo.store.DemoCScale
+ * @extends Neo.data.Store
+ */
+class DemoCScale extends Store {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.childapps.dockdemo.store.DemoCScale'
+         * @protected
+         */
+        className: 'AgentOS.childapps.dockdemo.store.DemoCScale',
+        /**
+         * @member {Number} amountRows=100000
+         */
+        amountRows: 100000,
+        /**
+         * @member {Boolean} autoInitRecords=false
+         */
+        autoInitRecords: false,
+        /**
+         * @member {String} keyProperty='id'
+         */
+        keyProperty: 'id',
+        /**
+         * @member {Neo.data.Model} model=DemoCRecord
+         */
+        model: DemoCRecord
+    }
+
+    /**
+     * Generates the exact scale set once. Random values deliberately match the existing
+     * BigData precedent; this demo invents no seeded-data contract.
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        if (!this.items?.length) {
+            this.add(this.generateData(this.amountRows), false)
+        }
+    }
+
+    /**
+     * @summary Creates compact renderer-rich rows for the scale pane.
+     * @param {Number} amountRows
+     * @returns {Object[]}
+     */
+    generateData(amountRows) {
+        const
+            names    = ['Atlas', 'Beacon', 'Cipher', 'Delta', 'Echo', 'Flux', 'Graph', 'Helix'],
+            statuses = ['healthy', 'streaming', 'observed', 'queued'],
+            records  = new Array(amountRows);
+
+        for (let index = 0; index < amountRows; index++) {
+            const base = Math.round(Math.random() * 100);
+
+            records[index] = {
+                id      : index + 1,
+                name    : `${names[index % names.length]} ${String(index + 1).padStart(6, '0')}`,
+                status  : statuses[index % statuses.length],
+                value   : Math.round(Math.random() * 10000),
+                counter : base,
+                progress: Math.round(Math.random() * 100),
+                trend   : Array.from({length: 12}, (_, point) => (base + point * 7 + index) % 101)
+            }
+        }
+
+        return records
+    }
+}
+
+export default Neo.setupClass(DemoCScale);

--- a/apps/agentos/childapps/dockdemo/view/DemoCFeedPane.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoCFeedPane.mjs
@@ -22,6 +22,10 @@ class DemoCFeedPane extends GridContainer {
          */
         cls: ['agentos-dockdemo-data-pane', 'agentos-dockdemo-feed-pane'],
         /**
+         * @member {Object} columnDefaults
+         */
+        columnDefaults: {cellAlign: 'left'},
+        /**
          * @member {Object[]} columns
          */
         columns: [{
@@ -30,18 +34,20 @@ class DemoCFeedPane extends GridContainer {
             width    : 105
         }, {
             dataField: 'name',
-            flex     : 1,
+            flex     : 2,
             text     : 'Event',
-            minWidth : 180
+            minWidth : 280
         }, {
             dataField: 'status',
+            flex     : 1,
             text     : 'State',
-            width    : 105
+            minWidth : 140
         }, {
             type     : 'animatedChange',
             dataField: 'value',
+            flex     : 1,
             text     : 'Value',
-            width    : 95
+            minWidth : 120
         }, {
             type     : 'sparkline',
             dataField: 'trend',

--- a/apps/agentos/childapps/dockdemo/view/DemoCFeedPane.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoCFeedPane.mjs
@@ -1,0 +1,58 @@
+import GridContainer from '../../../../../src/grid/Container.mjs';
+
+/**
+ * @summary The second live Store<Model> pane: a capped, visibly growing event stream.
+ *
+ * @class AgentOS.childapps.dockdemo.view.DemoCFeedPane
+ * @extends Neo.grid.Container
+ */
+class DemoCFeedPane extends GridContainer {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.childapps.dockdemo.view.DemoCFeedPane'
+         * @protected
+         */
+        className: 'AgentOS.childapps.dockdemo.view.DemoCFeedPane',
+        /**
+         * @member {Object} body
+         */
+        body: {bufferColumnRange: 1, bufferRowRange: 2},
+        /**
+         * @member {String[]} cls
+         */
+        cls: ['agentos-dockdemo-data-pane', 'agentos-dockdemo-feed-pane'],
+        /**
+         * @member {Object[]} columns
+         */
+        columns: [{
+            dataField: 'timestamp',
+            text     : 'Time',
+            width    : 105
+        }, {
+            dataField: 'name',
+            text     : 'Event',
+            width    : 180
+        }, {
+            dataField: 'status',
+            text     : 'State',
+            width    : 105
+        }, {
+            type     : 'animatedChange',
+            dataField: 'value',
+            text     : 'Value',
+            width    : 95
+        }, {
+            type     : 'sparkline',
+            dataField: 'trend',
+            flex     : 1,
+            minWidth : 150,
+            text     : 'Live'
+        }],
+        /**
+         * @member {Number} rowHeight=42
+         */
+        rowHeight: 42
+    }
+}
+
+export default Neo.setupClass(DemoCFeedPane);

--- a/apps/agentos/childapps/dockdemo/view/DemoCFeedPane.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoCFeedPane.mjs
@@ -30,8 +30,9 @@ class DemoCFeedPane extends GridContainer {
             width    : 105
         }, {
             dataField: 'name',
+            flex     : 1,
             text     : 'Event',
-            width    : 180
+            minWidth : 180
         }, {
             dataField: 'status',
             text     : 'State',
@@ -44,14 +45,13 @@ class DemoCFeedPane extends GridContainer {
         }, {
             type     : 'sparkline',
             dataField: 'trend',
-            flex     : 1,
-            minWidth : 150,
-            text     : 'Live'
+            text     : 'Live',
+            width    : 160
         }],
         /**
-         * @member {Number} rowHeight=42
+         * @member {Number} rowHeight=50
          */
-        rowHeight: 42
+        rowHeight: 50
     }
 }
 

--- a/apps/agentos/childapps/dockdemo/view/DemoCScalePane.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoCScalePane.mjs
@@ -1,0 +1,92 @@
+import Button        from '../../../../../src/button/Base.mjs';
+import GridContainer from '../../../../../src/grid/Container.mjs';
+
+/**
+ * @summary Renderer-rich virtual grid for Demo C's exact 100,000-row scale store.
+ *
+ * The pane composes the generic column families proven by BigData and DevIndex: viewport-
+ * bounded row/column pools, ordinary renderers, component cells, animated values, progress,
+ * heatmap classes, and `type:'sparkline'` (the framework-owned OffscreenCanvas path).
+ *
+ * @class AgentOS.childapps.dockdemo.view.DemoCScalePane
+ * @extends Neo.grid.Container
+ */
+class DemoCScalePane extends GridContainer {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.childapps.dockdemo.view.DemoCScalePane'
+         * @protected
+         */
+        className: 'AgentOS.childapps.dockdemo.view.DemoCScalePane',
+        /**
+         * @member {Object} body
+         */
+        // The choreography can grow this pane by 28% of the 1440px reference scene in
+        // one structural update. Ten 46px rows keep that bounded expansion covered while
+        // Grid's resize buffer catches up, without rendering beyond the viewport pool.
+        body: {bufferColumnRange: 2, bufferRowRange: 10},
+        /**
+         * @member {String[]} cls
+         */
+        cls: ['agentos-dockdemo-data-pane', 'agentos-dockdemo-scale-pane'],
+        /**
+         * @member {Object} columnDefaults
+         */
+        columnDefaults: {width: 130},
+        /**
+         * @member {Object[]} columns
+         */
+        columns: [{
+            type     : 'index',
+            dataField: 'id',
+            text     : '#',
+            width    : 70
+        }, {
+            dataField: 'name',
+            text     : 'Work item',
+            width    : 190
+        }, {
+            dataField: 'status',
+            text     : 'State',
+            width    : 120
+        }, {
+            dataField: 'value',
+            text     : 'Throughput',
+            renderer : ({value}) => new Intl.NumberFormat().format(value),
+            cellCls  : ({value}) => ['agentos-dockdemo-heat', `agentos-dockdemo-heat-${Math.min(3, Math.floor((value || 0) / 2500))}`]
+        }, {
+            type     : 'animatedChange',
+            dataField: 'counter',
+            text     : 'Pulse'
+        }, {
+            type     : 'progress',
+            dataField: 'progress',
+            text     : 'Load',
+            width    : 150
+        }, {
+            type     : 'sparkline',
+            dataField: 'trend',
+            flex     : 1,
+            minWidth : 180,
+            text     : 'Living signal'
+        }, {
+            type     : 'component',
+            // A unique column data key is required even though the component acts on the full
+            // record. Reusing `counter` would alias the AnimatedChange column's pooled cells.
+            dataField: 'timestamp',
+            text     : 'Action',
+            width    : 130,
+            component: ({record}) => ({
+                module : Button,
+                handler: () => record.counter++,
+                text   : 'Pulse +1'
+            })
+        }],
+        /**
+         * @member {Number} rowHeight=46
+         */
+        rowHeight: 46
+    }
+}
+
+export default Neo.setupClass(DemoCScalePane);

--- a/apps/agentos/childapps/dockdemo/view/DemoCScalePane.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoCScalePane.mjs
@@ -32,7 +32,7 @@ class DemoCScalePane extends GridContainer {
         /**
          * @member {Object} columnDefaults
          */
-        columnDefaults: {width: 130},
+        columnDefaults: {cellAlign: 'left', width: 130},
         /**
          * @member {Object[]} columns
          */

--- a/apps/agentos/childapps/dockdemo/view/DemoCScalePane.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoCScalePane.mjs
@@ -22,7 +22,7 @@ class DemoCScalePane extends GridContainer {
          * @member {Object} body
          */
         // The choreography can grow this pane by 28% of the 1440px reference scene in
-        // one structural update. Ten 46px rows keep that bounded expansion covered while
+        // one structural update. Ten 50px rows keep that bounded expansion covered while
         // Grid's resize buffer catches up, without rendering beyond the viewport pool.
         body: {bufferColumnRange: 2, bufferRowRange: 10},
         /**
@@ -66,9 +66,8 @@ class DemoCScalePane extends GridContainer {
         }, {
             type     : 'sparkline',
             dataField: 'trend',
-            flex     : 1,
-            minWidth : 180,
-            text     : 'Living signal'
+            text     : 'Living signal',
+            width    : 160
         }, {
             type     : 'component',
             // A unique column data key is required even though the component acts on the full
@@ -78,14 +77,16 @@ class DemoCScalePane extends GridContainer {
             width    : 130,
             component: ({record}) => ({
                 module : Button,
+                cls    : ['agentos-dockdemo-row-action'],
                 handler: () => record.counter++,
-                text   : 'Pulse +1'
+                iconCls: 'fa fa-wave-square',
+                text   : '+1 pulse'
             })
         }],
         /**
-         * @member {Number} rowHeight=46
+         * @member {Number} rowHeight=50
          */
-        rowHeight: 46
+        rowHeight: 50
     }
 }
 

--- a/apps/agentos/childapps/dockdemo/view/DemoCWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoCWorkspace.mjs
@@ -145,6 +145,14 @@ class DemoCWorkspace extends Container {
      */
     cuePromise = Promise.resolve()
     /**
+     * Serialized, paint-confirmed tour progress. The runner emits `beat` before executing a
+     * step, so this local projection waits for that step's log/cue/refresh settlement before
+     * exposing progress to the viewer.
+     * @member {Promise} progressPromise
+     * @protected
+     */
+    progressPromise = Promise.resolve()
+    /**
      * Fail-closed surface-cue errors for the current visible tour.
      * @member {String[]} cueErrors
      * @protected
@@ -275,7 +283,8 @@ class DemoCWorkspace extends Container {
      * @returns {Object} Tour toolbar config.
      */
     createTourBar() {
-        let me = this;
+        let me      = this,
+            isLight = me.theme === 'neo-theme-neo-light';
 
         return {
             cls   : ['agentos-dockdemo-tourbar', 'agentos-dockdemo-tourbar-c'],
@@ -288,31 +297,32 @@ class DemoCWorkspace extends Container {
                 iconCls  : 'fa fa-play',
                 ntype    : 'button',
                 reference: 'tour-play-c',
-                text     : 'Run dense tour'
+                text     : 'Start dense tour'
             }, {
-                cls      : ['agentos-dockdemo-tour-caption'],
-                flex     : 1,
-                html     : `${demoCTourScript.title} — twenty panes, 100k rows, a 10/sec feed, real overflow, and two themes.`,
-                ntype    : 'component',
-                reference: 'tour-caption-c'
+                module: Container,
+                cls   : ['agentos-dockdemo-tour-story'],
+                flex  : 1,
+                items : [{
+                    cls      : ['agentos-dockdemo-tour-caption'],
+                    flex     : 'none',
+                    html     : `${demoCTourScript.title} — twenty panes, 100k rows, a 10/sec feed, real overflow, and two themes.`,
+                    ntype    : 'component',
+                    reference: 'tour-caption-c'
+                }, {
+                    cls      : ['agentos-dockdemo-tour-pips'],
+                    flex     : 'none',
+                    ntype    : 'component',
+                    reference: 'tour-pips-c',
+                    vdom     : {cn: DemoCWorkspace.totalBeats().map(() => ({cls: ['agentos-dockdemo-pip']}))}
+                }],
+                layout: {ntype: 'vbox', align: 'stretch', pack: 'center'}
             }, {
-                cls    : ['agentos-dockdemo-theme-button'],
-                handler: () => me.setWorkspaceTheme('neo-theme-neo-light'),
-                iconCls: 'fa fa-sun',
-                ntype  : 'button',
-                text   : 'Light'
-            }, {
-                cls    : ['agentos-dockdemo-theme-button'],
-                handler: () => me.setWorkspaceTheme('neo-theme-neo-dark'),
-                iconCls: 'fa fa-moon',
-                ntype  : 'button',
-                text   : 'Dark'
-            }, {
-                cls      : ['agentos-dockdemo-tour-pips'],
-                flex     : 'none',
-                ntype    : 'component',
-                reference: 'tour-pips-c',
-                vdom     : {cn: DemoCWorkspace.totalBeats().map(() => ({cls: ['agentos-dockdemo-pip']}))}
+                cls      : ['agentos-dockdemo-theme-button'],
+                handler  : () => me.toggleWorkspaceTheme(),
+                iconCls  : isLight ? 'fa fa-moon' : 'fa fa-sun',
+                ntype    : 'button',
+                reference: 'theme-toggle-c',
+                text     : isLight ? 'Dark mode' : 'Light mode'
             }]
         }
     }
@@ -423,10 +433,11 @@ class DemoCWorkspace extends Container {
      * @param {Object} data
      */
     onTourBeat(data) {
-        let me = this;
+        let me            = this,
+            progress      = ++me.beatCount,
+            cueSettlement = Promise.resolve();
 
         data.caption && me.setTourCaption(data.caption);
-        me.setPipProgress(++me.beatCount);
 
         if (data.cue) {
             const cue = data.cue;
@@ -448,16 +459,24 @@ class DemoCWorkspace extends Container {
                 me.setTourCaption(`Surface cue failed: ${message}`);
 
                 return false
-            })
+            });
+            cueSettlement = me.cuePromise
         }
+
+        me.progressPromise = me.progressPromise.then(async () => {
+            await me.waitForTourBeatSettlement(progress, cueSettlement);
+            await me.setPipProgress(progress);
+            // Adjacent document operations can settle within one browser frame. Keep each
+            // evidenced state visible long enough to read instead of letting VDOM paints coalesce.
+            await me.timeout(90)
+        })
     }
 
     /**
      * @param {Object} data
      */
     onTourComplete(data) {
-        this.setTourCaption(`Document playback complete — settling ${data.log.length} deterministic beats and surface cues.`);
-        this.setPipProgress(DemoCWorkspace.totalBeats().length)
+        this.setTourCaption(`Document playback complete — settling ${data.log.length} deterministic beats and surface cues.`)
     }
 
     /**
@@ -492,7 +511,7 @@ class DemoCWorkspace extends Container {
 
     /**
      * Assigns a new trend array to a registered visible scale record and refreshes the
-     * viewport pool. Coarse dock projection preserves component identities, while a resized
+     * viewport pool. Coarse dock projection preserves cached pane identities, while a resized
      * viewport pool can allocate new Canvas cells whose registration settles asynchronously;
      * the bounded wait observes that lifecycle fact instead of guessing with a screenplay delay.
      * @param {String|null} [componentId=null] Optional exact visible Sparkline identity.
@@ -520,7 +539,12 @@ class DemoCWorkspace extends Container {
 
         if (!record || !sparkline?.offscreenRegistered) return false;
 
-        record.trend = Array.from({length: 12}, (_, point) => (point * 17 + this.feedSequence) % 101);
+        let signal = record.trend.at(-1) ?? 50;
+
+        record.trend = Array.from({length: 12}, (_, point) => {
+            signal = Math.max(8, Math.min(92, signal + ((this.feedSequence + point * 5) % 9) - 4));
+            return signal
+        });
         pane?.body?.createViewData(false, true);
 
         return {componentId: sparkline.id, recordId: record.id, values: [...record.trend]}
@@ -589,6 +613,8 @@ class DemoCWorkspace extends Container {
         nextConfig.hideMode = 'visibility';
 
         const nextShell = host.insert(host.items.length, nextConfig, true);
+
+        nextShell.addCls('agentos-dockdemo-chrome-settling');
 
         // Atomic moves require both ownership paths to exist in the rendered tree. This update
         // mounts only the visibility-hidden target shell; the live panes remain in the visible
@@ -849,7 +875,7 @@ class DemoCWorkspace extends Container {
     /**
      * @param {Number} count
      */
-    setPipProgress(count) {
+    async setPipProgress(count) {
         const pips = this.getReference('tour-pips-c');
 
         if (!pips) return;
@@ -861,7 +887,8 @@ class DemoCWorkspace extends Container {
                 ? ['agentos-dockdemo-pip', 'agentos-dockdemo-pip-done']
                 : ['agentos-dockdemo-pip']
         });
-        pips.update()
+        pips.update();
+        await pips.promiseUpdate()
     }
 
     /**
@@ -879,7 +906,54 @@ class DemoCWorkspace extends Container {
      */
     setWorkspaceTheme(theme) {
         this.theme = theme;
+        this.syncThemeToggle(theme);
         return theme
+    }
+
+    /**
+     * Keeps the one theme control phrased as the available action.
+     * @param {String} theme
+     */
+    syncThemeToggle(theme) {
+        const
+            button  = this.getReference('theme-toggle-c'),
+            isLight = theme === 'neo-theme-neo-light';
+
+        if (button) {
+            button.iconCls = isLight ? 'fa fa-moon' : 'fa fa-sun';
+            button.text    = isLight ? 'Dark mode' : 'Light mode'
+        }
+    }
+
+    /**
+     * @returns {String} The newly applied theme.
+     */
+    toggleWorkspaceTheme() {
+        return this.setWorkspaceTheme(this.theme === 'neo-theme-neo-light'
+            ? 'neo-theme-neo-dark'
+            : 'neo-theme-neo-light')
+    }
+
+    /**
+     * Waits for one runner log entry, its optional surface cue, and any resulting dock
+     * projection. This is a Demo-C adapter until TourRunner exposes a reusable settled-step
+     * event; it prevents the progress surface from claiming work that is still in flight.
+     * @param {Number} count One-based flattened beat count.
+     * @param {Promise} cueSettlement
+     * @returns {Promise<Boolean>}
+     */
+    async waitForTourBeatSettlement(count, cueSettlement) {
+        for (let attempt = 0; attempt < 400; attempt++) {
+            if (this.tourRunner.log.length >= count) break;
+            await this.timeout(5)
+        }
+
+        if (this.tourRunner.log.length < count) return false;
+
+        await cueSettlement;
+        await this.refreshPromise;
+
+        return true
     }
 
     /**
@@ -899,8 +973,9 @@ class DemoCWorkspace extends Container {
         me.cuePromise      = Promise.resolve();
         me.cueReceipts     = [];
         me.lastTourReceipt = null;
+        me.progressPromise = Promise.resolve();
         me.dockModel       = DockZoneModel.clone(initialDocument);
-        me.setPipProgress(0);
+        await me.setPipProgress(0);
 
         await me.refreshDockWorkspace();
 
@@ -913,6 +988,8 @@ class DemoCWorkspace extends Container {
 
         await me.cuePromise;
         await me.refreshPromise;
+        await me.progressPromise;
+        await me.setPipProgress(DemoCWorkspace.totalBeats().length);
 
         const
             elapsedMs    = Date.now() - startedAt,
@@ -937,7 +1014,6 @@ class DemoCWorkspace extends Container {
             };
 
         me.lastTourReceipt = receipt;
-        me.setPipProgress(DemoCWorkspace.totalBeats().length);
         me.setTourCaption(receipt.completed
             ? `Tour complete — ${receipt.log.length} deterministic beats and ${receipt.cueReceipts.length} surface cues settled.`
             : `Tour stopped — ${errors[0]}`);

--- a/apps/agentos/childapps/dockdemo/view/DemoCWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoCWorkspace.mjs
@@ -1,0 +1,994 @@
+import Component                          from '../../../../../src/component/Base.mjs';
+import Container                          from '../../../../../src/container/Base.mjs';
+import DemoCFeed                          from '../store/DemoCFeed.mjs';
+import DemoCFeedPane                      from './DemoCFeedPane.mjs';
+import DemoCScale                         from '../store/DemoCScale.mjs';
+import DemoCScalePane                     from './DemoCScalePane.mjs';
+import DockLayoutAdapter                  from '../../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockMotionSignal                   from '../../../../../src/dashboard/DockMotionSignal.mjs';
+import DockService                        from '../../../../../src/ai/client/DockService.mjs';
+import DockZoneModel                      from '../../../../../src/dashboard/DockZoneModel.mjs';
+import StateProvider                      from '../../../../../src/state/Provider.mjs';
+import TourRunner                         from '../../../../../src/ai/client/TourRunner.mjs';
+import {demoCTourScript, initialDocument} from '../../../tour/demoCDenseWorkstation.mjs';
+import '../../../../../src/button/Base.mjs';
+import '../../../../../src/tab/Container.mjs';
+import '../../../../../src/toolbar/Base.mjs';
+
+/**
+ * Target-owned narrative data for Demo C's lightweight resident panes. These are presentation
+ * facts only: stores and dock state remain owned by their existing authorities.
+ * @type {Object}
+ */
+const paneStories = Object.freeze({
+    activity : {detail: '12 residents reporting', icon: 'fa-wave-square', kicker: 'SWARM PULSE',      metric: 'LIVE'},
+    alerts   : {detail: '2 require attention',    icon: 'fa-bell',        kicker: 'PRIORITY SIGNALS', metric: '07'},
+    audit    : {detail: 'all gates evidenced',    icon: 'fa-shield-alt',  kicker: 'EVIDENCE CHAIN',   metric: '100%'},
+    builds   : {detail: '8 parallel checks',      icon: 'fa-cubes',       kicker: 'BUILD FABRIC',     metric: '8/8'},
+    commits  : {detail: '5 branches converging',  icon: 'fa-code-branch', kicker: 'CHANGE STREAM',    metric: '+42'},
+    console  : {detail: 'semantic ops ready',     icon: 'fa-terminal',    kicker: 'COMMAND PLANE',    metric: 'ARMED'},
+    deploys  : {detail: '3 regions synchronized', icon: 'fa-rocket',      kicker: 'FLIGHT DECK',      metric: '03'},
+    files    : {detail: 'workspace graph indexed',icon: 'fa-folder-tree', kicker: 'SOURCE SURFACE',   metric: '25K'},
+    graph    : {detail: 'concept edges awake',    icon: 'fa-project-diagram', kicker: 'NATIVE GRAPH',  metric: '20K+'},
+    inspector: {detail: 'selection follows focus',icon: 'fa-crosshairs',  kicker: 'CONTEXT LENS',     metric: 'LOCK'},
+    logs     : {detail: 'zero fatal events',      icon: 'fa-align-left',  kicker: 'STRUCTURED LOGS',  metric: '0 ERR'},
+    memory   : {detail: 'provenance retained',    icon: 'fa-brain',       kicker: 'MEMORY CORE',      metric: 'SYNC'},
+    metrics  : {detail: 'fleet envelope stable',  icon: 'fa-chart-line',  kicker: 'LIVE METRICS',     metric: '99.9'},
+    queues   : {detail: '18 lanes in motion',     icon: 'fa-stream',      kicker: 'TASK PRESSURE',    metric: '18'},
+    runtime  : {detail: 'all residents responsive', icon: 'fa-heartbeat', kicker: 'RUNTIME HEALTH',  metric: 'GREEN'},
+    security : {detail: 'continuous policy scan', icon: 'fa-lock',        kicker: 'TRUST ENVELOPE',  metric: 'CLEAR'},
+    topology : {detail: '20 panes · one identity',icon: 'fa-sitemap',     kicker: 'WORKSPACE SHAPE',  metric: '20'},
+    traces   : {detail: '4 active continuations', icon: 'fa-route',       kicker: 'TRACE FABRIC',     metric: '04'}
+});
+
+/**
+ * @summary Demo C: the dense, themed, living-data workstation showcase.
+ *
+ * The workspace owns one committed `dockZone.v1` document, one root StateProvider, two
+ * provider-created Store<Model> instances, and one feed timer. Pane instances are cached
+ * and parked across coarse dock projections, so split/return/overflow operations preserve
+ * the owning grid and store identities. Built-in grid and Sparkline families own pooling,
+ * hydration, and OffscreenCanvas registration; this class owns only composition and story.
+ *
+ * @class AgentOS.childapps.dockdemo.view.DemoCWorkspace
+ * @extends Neo.container.Base
+ */
+class DemoCWorkspace extends Container {
+    /**
+     * Five records every 500ms: the declared 10-records/sec producer contract.
+     * @member {Number} FEED_BATCH_SIZE=5
+     * @static
+     */
+    static FEED_BATCH_SIZE = 5
+    /**
+     * @member {Number} FEED_INTERVAL_MS=500
+     * @static
+     */
+    static FEED_INTERVAL_MS = 500
+
+    static config = {
+        /**
+         * @member {String} className='AgentOS.childapps.dockdemo.view.DemoCWorkspace'
+         * @protected
+         */
+        className: 'AgentOS.childapps.dockdemo.view.DemoCWorkspace',
+        /**
+         * @member {String[]} additionalThemeFiles
+         */
+        additionalThemeFiles: [
+            'AgentOS.view.Viewport',
+            'Neo.dashboard.Container',
+            'AgentOS.childapps.dockdemo.view.DemoAWorkspace',
+            'AgentOS.childapps.dockdemo.view.DemoCWorkspace'
+        ],
+        /**
+         * @member {String[]} cls
+         */
+        cls: ['agentos-dockdemo-workspace', 'agentos-dockdemo-workspace-c'],
+        /**
+         * @member {Object} layout
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * The one root provider owns both stores; cached panes receive these exact instances.
+         * @member {Object} stateProvider
+         */
+        stateProvider: {
+            module: StateProvider,
+            stores: {
+                feed : {module: DemoCFeed},
+                scale: {module: DemoCScale}
+            }
+        }
+    }
+
+    /**
+     * @member {Object|null} dockModel=null
+     */
+    dockModel = null
+    /**
+     * @member {Neo.ai.client.DockService|null} dockService=null
+     */
+    dockService = null
+    /**
+     * @member {Neo.ai.client.TourRunner|null} tourRunner=null
+     */
+    tourRunner = null
+    /**
+     * @member {Object} paneCache={}
+     * @protected
+     */
+    paneCache = {}
+    /**
+     * @member {Promise|null} refreshPromise=null
+     * @protected
+     */
+    refreshPromise = null
+    /**
+     * @member {Number} beatCount=0
+     */
+    beatCount = 0
+    /**
+     * Number of coalesced producer batches appended over this workspace lifetime.
+     * @member {Number} feedBatchCount=0
+     */
+    feedBatchCount = 0
+    /**
+     * Monotonic feed key; padded string ordering keeps newest-first stable.
+     * @member {Number} feedSequence=0
+     */
+    feedSequence = 0
+    /**
+     * Serialized surface-cue chain for the current visible tour.
+     * @member {Promise} cuePromise
+     * @protected
+     */
+    cuePromise = Promise.resolve()
+    /**
+     * Fail-closed surface-cue errors for the current visible tour.
+     * @member {String[]} cueErrors
+     * @protected
+     */
+    cueErrors = []
+    /**
+     * Ordered observable receipts returned by the screenplay's surface cues.
+     * @member {Object[]} cueReceipts
+     * @protected
+     */
+    cueReceipts = []
+    /**
+     * The most recent fully settled visible-tour result.
+     * @member {Object|null} lastTourReceipt=null
+     */
+    lastTourReceipt = null
+    /**
+     * Five records every 500ms = an honest 10 records/sec.
+     * @member {Number|null} #feedIntervalId=null
+     * @private
+     */
+    #feedIntervalId = null
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        let me = this;
+
+        me.dockModel   = DockZoneModel.clone(initialDocument);
+        me.dockService = Neo.create(DockService, {});
+        me.tourRunner  = Neo.create(TourRunner, {
+            componentId: me.id,
+            dockService: me.dockService,
+            mode       : 'demo',
+            script     : demoCTourScript
+        });
+
+        me.tourRunner.on({
+            beat    : me.onTourBeat,
+            complete: me.onTourComplete,
+            error   : me.onTourError,
+            scene   : me.onTourScene,
+            scope   : me
+        });
+
+        me.appendFeedBatch(25);
+
+        me.add([me.createTourBar(), me.createStatusBar(), {
+            module   : Container,
+            cls      : ['agentos-dockdemo-dock-host', 'agentos-dockdemo-dock-host-c', 'neo-dashboard'],
+            flex     : 1,
+            items    : [me.projectDockModel()],
+            layout   : {ntype: 'fit'},
+            reference: 'dock-host-c'
+        }]);
+
+        me.updateStatusBar();
+        me.#feedIntervalId = setInterval(
+            () => me.appendFeedBatch(DemoCWorkspace.FEED_BATCH_SIZE),
+            DemoCWorkspace.FEED_INTERVAL_MS
+        )
+    }
+
+    /**
+     * @param {Object} descriptor
+     * @returns {{document:Object, errors:String[]}}
+     */
+    applyDockZoneOperation(descriptor) {
+        return DockZoneModel.applyOperation(this.dockModel, descriptor)
+    }
+
+    /**
+     * Adds one coalesced feed batch, then trims the capped tail in one splice.
+     * @param {Number} amount
+     * @returns {Number} Current feed count.
+     */
+    appendFeedBatch(amount=DemoCWorkspace.FEED_BATCH_SIZE) {
+        let me      = this,
+            store   = me.getStateProvider().getStore('feed'),
+            records = [],
+            now     = new Date();
+
+        for (let index = 0; index < amount; index++) {
+            const sequence = ++me.feedSequence,
+                  base     = (sequence * 13) % 101;
+
+            records.push({
+                id       : `feed-${String(sequence).padStart(8, '0')}`,
+                name     : `runtime.event.${sequence % 17}`,
+                status   : sequence % 5 ? 'accepted' : 'observed',
+                timestamp: now.toLocaleTimeString('en-GB'),
+                value    : base,
+                counter  : sequence,
+                progress : base,
+                trend    : Array.from({length: 10}, (_, point) => (base + point * 9) % 101)
+            })
+        }
+
+        store.add(records);
+        me.feedBatchCount++;
+
+        if (store.count > store.maxRecords) {
+            store.splice(store.maxRecords, store.count - store.maxRecords)
+        }
+
+        me.updateStatusBar();
+
+        return store.count
+    }
+
+    /**
+     * @returns {Object} Tour/status toolbar config.
+     */
+    createStatusBar() {
+        return {
+            cls      : ['agentos-dockdemo-statusbar'],
+            flex     : 'none',
+            html     : '',
+            ntype    : 'component',
+            reference: 'status-bar-c'
+        }
+    }
+
+    /**
+     * @returns {Object} Tour toolbar config.
+     */
+    createTourBar() {
+        let me = this;
+
+        return {
+            cls   : ['agentos-dockdemo-tourbar', 'agentos-dockdemo-tourbar-c'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+            ntype : 'toolbar',
+            items : [{
+                cls      : ['agentos-dockdemo-tour-play'],
+                handler  : () => me.startTour(),
+                iconCls  : 'fa fa-play',
+                ntype    : 'button',
+                reference: 'tour-play-c',
+                text     : 'Run dense tour'
+            }, {
+                cls      : ['agentos-dockdemo-tour-caption'],
+                flex     : 1,
+                html     : `${demoCTourScript.title} — twenty panes, 100k rows, a 10/sec feed, real overflow, and two themes.`,
+                ntype    : 'component',
+                reference: 'tour-caption-c'
+            }, {
+                cls    : ['agentos-dockdemo-theme-button'],
+                handler: () => me.setWorkspaceTheme('neo-theme-neo-light'),
+                iconCls: 'fa fa-sun',
+                ntype  : 'button',
+                text   : 'Light'
+            }, {
+                cls    : ['agentos-dockdemo-theme-button'],
+                handler: () => me.setWorkspaceTheme('neo-theme-neo-dark'),
+                iconCls: 'fa fa-moon',
+                ntype  : 'button',
+                text   : 'Dark'
+            }, {
+                cls      : ['agentos-dockdemo-tour-pips'],
+                flex     : 'none',
+                ntype    : 'component',
+                reference: 'tour-pips-c',
+                vdom     : {cn: DemoCWorkspace.totalBeats().map(() => ({cls: ['agentos-dockdemo-pip']}))}
+            }]
+        }
+    }
+
+    /**
+     * Executes a surface cue for the visual take. Spec-mode correctness waits on explicit
+     * E2E oracles because TourRunner intentionally does not await event listeners.
+     * @param {Object} cue
+     * @returns {Promise<*>}
+     */
+    async executeCue(cue) {
+        switch (cue.type) {
+            case 'overflow':
+                return this.navigateOverflowMenu(cue.itemId)
+            case 'scroll':
+                return this.scrollScaleGrid(cue.index)
+            case 'canvas-update':
+                await this.refreshPromise;
+                return this.pulseScaleSparkline()
+            case 'theme':
+                return this.setWorkspaceTheme(cue.theme)
+            default:
+                return false
+        }
+    }
+
+    /**
+     * @returns {Object} Live committed dock document.
+     */
+    getDockZoneDocument() {
+        return this.dockModel
+    }
+
+    /**
+     * Returns one cached pane identity for Neural Link continuity receipts.
+     * @param {String} itemId
+     * @returns {String|null}
+     */
+    getPaneIdentity(itemId) {
+        const item = this.dockModel.items[itemId];
+
+        return item ? this.resolvePane(itemId, item).id : null
+    }
+
+    /**
+     * Returns the last fully settled visible-tour receipt.
+     * @returns {Object|null}
+     */
+    getTourReceipt() {
+        return this.lastTourReceipt
+    }
+
+    /**
+     * Opens the real overflow control, briefly shows its menu, then invokes the first menu
+     * item's ordinary activeIndex handler. The E2E clicks this same surface as a human.
+     * @param {String} itemId Narrated target id (used for the caption/evidence contract).
+     * @returns {Promise<Boolean>}
+     */
+    async navigateOverflowMenu(itemId) {
+        // The reducer schedules projection asynchronously. Resolve the consumer only after that transaction,
+        // otherwise `down()` can capture the retiring source toolbar and wait on its deliberately hidden control.
+        await this.refreshPromise;
+
+        let tabs   = this.down({dockNodeId: 'heavy-tabs'}),
+            plugin = tabs?.getTabBar()?.getPlugin('tab-overflow'),
+            control;
+
+        // The hidden staging transaction already captured natural widths. This consumer boundary only
+        // refreshes the visible extent so the cue never turns a stable cache into a second measurement pass.
+        await plugin?.project(false);
+        control = await this.waitForOverflowMenu(plugin);
+
+        if (!control) return false;
+
+        await control.toggleMenu();
+        await this.timeout(700);
+
+        const
+            menuItems = control.menuList?.items || [],
+            item      = menuItems.find(entry => entry.text === this.dockModel.items[itemId]?.title);
+
+        item?.handler?.();
+        control.menuList && (control.menuList.hidden = true);
+
+        return item ? {activatedItemId: itemId, menuItemCount: menuItems.length} : false
+    }
+
+    /**
+     * Defers the instance-preserving re-projection after a successful reducer commit.
+     * @param {Object} document
+     */
+    onDockZoneDocumentChange(document) {
+        let me = this;
+
+        me.dockModel = document;
+        // Every projection is an atomic ownership transaction across the old shell, the staged shell,
+        // and their closest common parent. Preserve that atomicity across rapid reducer commits too:
+        // replacing this promise would allow a later commit to start a second transaction before the
+        // first removed its source shell, exposing duplicate projections and racing Canvas registration.
+        me.refreshPromise = (me.refreshPromise || Promise.resolve())
+            .then(() => me.timeout(0))
+            .then(() => {
+                if (!me.isDestroyed) return me.refreshDockWorkspace()
+            })
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onTourBeat(data) {
+        let me = this;
+
+        data.caption && me.setTourCaption(data.caption);
+        me.setPipProgress(++me.beatCount);
+
+        if (data.cue) {
+            const cue = data.cue;
+
+            me.cuePromise = me.cuePromise.then(async () => {
+                const receipt = await me.executeCue(cue);
+
+                if (!receipt) {
+                    throw new Error(`${cue.type} returned no observable receipt`)
+                }
+
+                me.cueReceipts.push({cue: {...cue}, receipt});
+
+                return receipt
+            }).catch(error => {
+                const message = `${cue.type}: ${error.message}`;
+
+                me.cueErrors.push(message);
+                me.setTourCaption(`Surface cue failed: ${message}`);
+
+                return false
+            })
+        }
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onTourComplete(data) {
+        this.setTourCaption(`Document playback complete — settling ${data.log.length} deterministic beats and surface cues.`);
+        this.setPipProgress(DemoCWorkspace.totalBeats().length)
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onTourError(data) {
+        this.setTourCaption(`Tour stopped: ${data.errors[0] || 'unknown reason'}`)
+    }
+
+    /**
+     * @param {Object} data
+     */
+    onTourScene(data) {
+        this.setTourCaption(`${data.title}${data.caption ? ' — ' + data.caption : ''}`)
+    }
+
+    /**
+     * Projects the committed document with instance-bound reducer/view callbacks.
+     * @param {Function|null} [resolveComponentRef=null] Optional staging resolver.
+     * @returns {Object}
+     */
+    projectDockModel(resolveComponentRef=null) {
+        let me = this;
+
+        return DockLayoutAdapter.project(me.dockModel, {
+            applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
+            onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
+            resolveComponentRef     : resolveComponentRef
+                || ((componentRef, item, itemId) => me.resolvePane(itemId, item))
+        })
+    }
+
+    /**
+     * Assigns a new trend array to a registered visible scale record and refreshes the
+     * viewport pool. Coarse dock projection preserves component identities, while a resized
+     * viewport pool can allocate new Canvas cells whose registration settles asynchronously;
+     * the bounded wait observes that lifecycle fact instead of guessing with a screenplay delay.
+     * @param {String|null} [componentId=null] Optional exact visible Sparkline identity.
+     * @returns {Promise<Object|Boolean>}
+     */
+    async pulseScaleSparkline(componentId=null) {
+        let pane = this.paneCache.scale,
+            sparkline,
+            record;
+
+        for (let attempt = 0; attempt < 40; attempt++) {
+            if (componentId) {
+                sparkline = Neo.getComponent(componentId)
+            } else {
+                sparkline = pane?.body?.items.flatMap(row => Object.values(row.components || {}))
+                    .find(candidate => candidate.offscreenRegistered && candidate.record)
+            }
+
+            record = sparkline?.record;
+
+            if (record && sparkline.offscreenRegistered) break;
+
+            await this.timeout(50)
+        }
+
+        if (!record || !sparkline?.offscreenRegistered) return false;
+
+        record.trend = Array.from({length: 12}, (_, point) => (point * 17 + this.feedSequence) % 101);
+        pane?.body?.createViewData(false, true);
+
+        return {componentId: sparkline.id, recordId: record.id, values: [...record.trend]}
+    }
+
+    /**
+     * Returns every tab-overflow projection owned by one dock shell.
+     * @param {Neo.container.Base} shell
+     * @returns {Neo.tab.plugin.Overflow[]}
+     */
+    getOverflowPlugins(shell) {
+        return Object.entries(this.dockModel.nodes)
+            .filter(([, node]) => node.type === 'tabs')
+            .map(([nodeId]) => shell.down({dockNodeId: nodeId})?.getTabBar()?.getPlugin('tab-overflow'))
+            .filter(Boolean)
+    }
+
+    /**
+     * Atomically hands cached panes from the current projection to a staged next projection.
+     *
+     * The next shell is first mounted with `hideMode: 'visibility'` and non-rendered placeholders,
+     * so every old and new pane parent exists in the rendered tree and has this host as its real
+     * lowest common ancestor. Replacing each placeholder through `Container.insert()` then uses
+     * Neo's native cross-parent atomic-move path: the live pane is detached silently with
+     * `keepMounted`, inserted at the model-owned target index, and remains the same DOM node. The
+     * old shell is retained but hidden for the one full host update that reconciles the ownership
+     * transaction. Only after every live DOM node has moved is that now-empty shell removed in a
+     * cleanup update. The newly visible toolbar then recaptures its natural widths; a zero-control
+     * interval is valid when the reduced tab set fits.
+     * @returns {Promise<void>}
+     */
+    async refreshDockWorkspace() {
+        const
+            me           = this,
+            host         = me.getReference('dock-host-c'),
+            flip         = Neo.main?.addon?.DockFlip,
+            placeholders = new Map();
+
+        if (!host) return;
+
+        try {
+            await flip?.captureFirst({hostId: host.id, markerPrefix: 'agentos-dockdemo-pane-'})
+        } catch (error) {/* instant landing */}
+
+        const
+            oldShell           = host.items[0],
+            oldOverflowPlugins = me.getOverflowPlugins(oldShell),
+            nextConfig         = me.projectDockModel((componentRef, item, itemId) => {
+                const placeholder = Neo.create({
+                    module: Component,
+                    header: {text: me.getPaneHeaderText(itemId, item)},
+                    hidden: true
+                });
+
+                placeholders.set(itemId, placeholder);
+
+                return placeholder
+            });
+
+        // Overflow controls are intentionally floating direct-body children, so the dock host is not their
+        // common parent and cannot hide them as part of the shell transaction. Retire the source projection
+        // first; the destination plugin independently recreates its truthful affordance from the new header.
+        oldOverflowPlugins.forEach(plugin => plugin.control && (plugin.control.hidden = true));
+
+        nextConfig.hidden   = true;
+        nextConfig.hideMode = 'visibility';
+
+        const nextShell = host.insert(host.items.length, nextConfig, true);
+
+        // Atomic moves require both ownership paths to exist in the rendered tree. This update
+        // mounts only the visibility-hidden target shell; the live panes remain in the visible
+        // old shell until the single ownership reconciliation below.
+        host.updateDepth = -1;
+        host.update();
+        await host.promiseUpdate();
+
+        const
+            transfers = [...placeholders].map(([itemId, placeholder]) => {
+                const targetParent = placeholder.parent,
+                      targetIndex  = targetParent?.indexOf(placeholder) ?? -1;
+
+                if (!targetParent || targetIndex < 0) {
+                    throw new Error(`Demo C projection did not parent placeholder "${itemId}"`)
+                }
+
+                return {
+                    itemId,
+                    pane: me.resolvePane(itemId, me.dockModel.items[itemId]),
+                    placeholder,
+                    targetIndex,
+                    targetParent
+                }
+            });
+
+        transfers.forEach(({pane, placeholder, targetIndex, targetParent}) => {
+            const sourceParent = pane.parent;
+
+            targetParent.remove(placeholder, true, true);
+            sourceParent && sourceParent !== targetParent
+                && sourceParent.remove(pane, false, true, true);
+            targetParent.insert(targetIndex, pane, true, false)
+        });
+
+        const overflowPlugins = me.getOverflowPlugins(nextShell);
+
+        // Capture natural header widths while the destination shell is still visibility-hidden. Overflow's
+        // measuring latch restores any removeDom headers and coalesces mutation/resize races internally.
+        await Promise.all(overflowPlugins.map(plugin => plugin.project(true)));
+        await Promise.all(overflowPlugins.map(plugin => me.waitForOverflowProjection(plugin)));
+
+        oldShell.setSilent({hideMode: 'visibility'});
+        oldShell.setSilent({hidden: true});
+        nextShell.setSilent({hidden: false});
+        host.updateDepth = -1;
+        host.update();
+        await host.promiseUpdate();
+
+        // The first update above is the ownership transaction: both parent trees exist, so Neo
+        // emits DOM moves for the live pane ids. This second update removes only an empty shell.
+        oldShell !== nextShell && host.remove(oldShell, true, true);
+        host.updateDepth = -1;
+        host.update();
+        await host.promiseUpdate();
+
+        await Promise.all(overflowPlugins.map(plugin => plugin.project(false)));
+        await Promise.all(overflowPlugins.map(plugin => me.waitForOverflowProjection(plugin)));
+
+        // Floating controls sit under document.body rather than below the dock host, so they cannot
+        // participate in the common-parent ownership update above. Activate only the destination
+        // projection after the source shell (and its control) has been destroyed: this preserves the
+        // exact-one-control invariant without exposing a transient duplicate or leaving the new button
+        // in the hidden/unmounted state used while its owner shell was staged.
+        overflowPlugins.forEach(plugin => {
+            plugin.control?.hidden && (plugin.control.hidden = false)
+        });
+
+        const heavyOverflow = nextShell.down({dockNodeId: 'heavy-tabs'})
+            ?.getTabBar()?.getPlugin('tab-overflow');
+
+        await me.waitForOverflowMenu(heavyOverflow);
+
+        if (flip) {
+            DockMotionSignal.enter(me);
+
+            try {
+                await flip.play({hostId: host.id, markerPrefix: 'agentos-dockdemo-pane-'})
+            } catch (error) {/* instant landing */}
+            finally {
+                DockMotionSignal.leave(me)
+            }
+        }
+    }
+
+    /**
+     * Waits for the tab-overflow projection and its asynchronously imported menu surface.
+     * `project()` intentionally coalesces while a measurement is in flight, and button menus
+     * load after control construction, so readiness requires all four lifecycle facts rather
+     * than a screenplay delay.
+     * @param {Neo.tab.plugin.Overflow|null} plugin
+     * @returns {Promise<Neo.button.Base|null>}
+     */
+    async waitForOverflowMenu(plugin) {
+        if (!plugin) return null;
+
+        for (let attempt = 0; attempt < 100; attempt++) {
+            const control = plugin.control;
+
+            if (!plugin.measuring && !plugin.projectQueued
+                && control?.mounted && control.menuList) {
+                return control
+            }
+
+            await this.timeout(0)
+        }
+
+        return null
+    }
+
+    /**
+     * Waits until one coalescing overflow projection has drained its current and queued passes.
+     * @param {Neo.tab.plugin.Overflow|null} plugin
+     * @returns {Promise<Boolean>}
+     */
+    async waitForOverflowProjection(plugin) {
+        if (!plugin) return false;
+
+        for (let attempt = 0; attempt < 100; attempt++) {
+            if (!plugin.measuring && !plugin.projectQueued) return true;
+
+            await this.timeout(0)
+        }
+
+        return false
+    }
+
+    /**
+     * Returns the model-owned tab label used by both staged projection shells and live panes.
+     * The shared resolver keeps a placeholder-built tab bar structurally identical to the one
+     * a live pane would have produced, including natural widths for the overflow plugin.
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {String}
+     */
+    getPaneHeaderText(itemId, item) {
+        return {
+            audit    : 'Audit',
+            commits  : 'Commits',
+            graph    : 'Graph',
+            inspector: 'Inspector',
+            metrics  : 'Metrics',
+            queues   : 'Queues',
+            scale    : '100k Matrix'
+        }[itemId] ?? item?.title ?? itemId
+    }
+
+    /**
+     * Returns the one live pane instance for an item id.
+     * @param {String} itemId
+     * @param {Object} item
+     * @returns {Neo.component.Base}
+     */
+    resolvePane(itemId, item) {
+        let me    = this,
+            cache = me.paneCache,
+            pane  = cache[itemId],
+            store;
+
+        if (!pane || pane.isDestroyed) {
+            if (itemId === 'scale') {
+                store = me.getStateProvider().getStore('scale');
+                pane  = cache[itemId] = Neo.create({module: DemoCScalePane, store})
+            } else if (itemId === 'feed') {
+                store = me.getStateProvider().getStore('feed');
+                pane  = cache[itemId] = Neo.create({module: DemoCFeedPane, store})
+            } else {
+                const story = paneStories[itemId] || {
+                    detail: 'resident operational',
+                    icon  : 'fa-circle-nodes',
+                    kicker: 'LIVE MODULE',
+                    metric: 'READY'
+                };
+
+                pane = cache[itemId] = Neo.create({
+                    module: Component,
+                    cls   : ['agentos-dockdemo-pane', 'agentos-dockdemo-placeholder', `agentos-dockdemo-pane-${itemId}`],
+                    html  : `<div class="agentos-dockdemo-resident-card">
+                        <div class="agentos-dockdemo-resident-kicker"><span></span>${story.kicker}</div>
+                        <i class="fa ${story.icon} agentos-dockdemo-resident-icon"></i>
+                        <div class="agentos-dockdemo-resident-metric">${story.metric}</div>
+                        <div class="agentos-dockdemo-resident-title">${item?.title ?? itemId}</div>
+                        <div class="agentos-dockdemo-resident-footer">
+                            <span>${story.detail}</span><strong>LIVE</strong>
+                        </div>
+                        <div class="agentos-dockdemo-resident-wave"><i></i><i></i><i></i><i></i><i></i><i></i></div>
+                    </div>`
+                })
+            }
+        }
+
+        // The adapter can decorate plain configs, but this showcase deliberately returns cached LIVE
+        // instances to preserve identity across re-projection. Carry the canonical tab header on the
+        // instance itself so tab.Container and Neo.tab.plugin.Overflow receive a meaningful title. The
+        // surrounding navigation groups use compact labels; the twelve-item heavy group keeps the full
+        // canonical titles and therefore owns the showcase's one intentional overflow affordance.
+        pane.header = {text: me.getPaneHeaderText(itemId, item)};
+        pane.addCls(`agentos-dockdemo-pane-${itemId}`);
+
+        return pane
+    }
+
+    /**
+     * Replays one script's document tier from a fresh document in spec mode. Runtime-only
+     * cues remain the visible tour's responsibility and are verified through its receipt.
+     * @param {Object} [script=demoCTourScript]
+     * @returns {Promise<Object>}
+     */
+    async runTourSpec(script=demoCTourScript) {
+        let me          = this,
+            dockService = Neo.create(DockService, {}),
+            runner      = Neo.create(TourRunner, {
+                componentId: me.id,
+                dockService,
+                mode       : 'spec',
+                script
+            });
+
+        me.dockModel = DockZoneModel.clone(initialDocument);
+        await me.refreshDockWorkspace();
+
+        try {
+            const result = await runner.start();
+
+            await me.refreshPromise;
+
+            return {...result, document: DockZoneModel.clone(me.dockModel)}
+        } finally {
+            runner.destroy();
+            dockService.destroy()
+        }
+    }
+
+    /**
+     * Scrolls the scale grid through one View-owned VDOM update.
+     *
+     * The View is the closest common parent of the native scrollport and every pooled body.
+     * Retargeting its VNode `scrollTop` together with `syncBodies()` therefore lets one delta
+     * move the viewport and recycle the fixed rows atomically, without a transient blank frame.
+     *
+     * @param {Number} index
+     * @returns {Promise<Boolean>}
+     */
+    async scrollScaleGrid(index=50000) {
+        let pane = this.paneCache.scale,
+            target;
+
+        if (!pane?.view?.id) return false;
+
+        target = Math.max(0, Math.min(index, pane.store.count - 1)) * pane.rowHeight;
+        pane.view.vdom.scrollTop = target;
+        pane.view.syncBodies(target);
+        await pane.view.promiseUpdate();
+
+        return Math.abs(pane.view.scrollTop - target) <= pane.rowHeight
+    }
+
+    /**
+     * @param {Number} count
+     */
+    setPipProgress(count) {
+        const pips = this.getReference('tour-pips-c');
+
+        if (!pips) return;
+
+        let {vdom} = pips;
+
+        vdom.cn.forEach((pip, index) => {
+            pip.cls = index < count
+                ? ['agentos-dockdemo-pip', 'agentos-dockdemo-pip-done']
+                : ['agentos-dockdemo-pip']
+        });
+        pips.update()
+    }
+
+    /**
+     * @param {String} text
+     */
+    setTourCaption(text) {
+        const caption = this.getReference('tour-caption-c');
+
+        caption && (caption.html = text)
+    }
+
+    /**
+     * @param {String} theme
+     * @returns {String}
+     */
+    setWorkspaceTheme(theme) {
+        this.theme = theme;
+        return theme
+    }
+
+    /**
+     * Runs the screenplay from a fresh document on every replay.
+     * @returns {Promise<Object>|undefined}
+     */
+    async startTour() {
+        let me = this;
+
+        if (me.tourRunner.running) {
+            me.setTourCaption('Tour already running — the live stores continue underneath it.');
+            return
+        }
+
+        me.beatCount       = 0;
+        me.cueErrors       = [];
+        me.cuePromise      = Promise.resolve();
+        me.cueReceipts     = [];
+        me.lastTourReceipt = null;
+        me.dockModel       = DockZoneModel.clone(initialDocument);
+        me.setPipProgress(0);
+
+        await me.refreshDockWorkspace();
+
+        const
+            feedStore      = me.getStateProvider().getStore('feed'),
+            feedStartCount = feedStore.count,
+            feedStartBatch = me.feedBatchCount,
+            startedAt      = Date.now(),
+            runnerResult   = await me.tourRunner.start();
+
+        await me.cuePromise;
+        await me.refreshPromise;
+
+        const
+            elapsedMs    = Date.now() - startedAt,
+            errors       = [...runnerResult.errors, ...me.cueErrors],
+            feedEndCount = feedStore.count,
+            receipt      = {
+                completed  : runnerResult.completed && errors.length === 0,
+                cueReceipts: me.cueReceipts.map(entry => ({cue: {...entry.cue}, receipt: entry.receipt})),
+                document   : DockZoneModel.clone(me.dockModel),
+                elapsedMs,
+                errors,
+                feed       : {
+                    batches       : me.feedBatchCount - feedStartBatch,
+                    configuredRate: DemoCWorkspace.FEED_BATCH_SIZE * 1000 / DemoCWorkspace.FEED_INTERVAL_MS,
+                    endCount      : feedEndCount,
+                    growth        : feedEndCount - feedStartCount,
+                    maxRecords    : feedStore.maxRecords,
+                    produced      : (me.feedBatchCount - feedStartBatch) * DemoCWorkspace.FEED_BATCH_SIZE,
+                    startCount    : feedStartCount
+                },
+                log       : runnerResult.log
+            };
+
+        me.lastTourReceipt = receipt;
+        me.setPipProgress(DemoCWorkspace.totalBeats().length);
+        me.setTourCaption(receipt.completed
+            ? `Tour complete — ${receipt.log.length} deterministic beats and ${receipt.cueReceipts.length} surface cues settled.`
+            : `Tour stopped — ${errors[0]}`);
+
+        return receipt
+    }
+
+    /**
+     * @returns {Object[]} Flattened screenplay steps.
+     * @static
+     */
+    static totalBeats() {
+        return demoCTourScript.scenes.flatMap(scene => scene.steps)
+    }
+
+    /**
+     * Updates the visible runtime receipt without creating another state authority.
+     */
+    updateStatusBar() {
+        let target = this.getReference('status-bar-c');
+
+        if (target) {
+            let scale = this.getStateProvider().getStore('scale'),
+                feed  = this.getStateProvider().getStore('feed');
+
+            target.html = `<span>20 dock items</span><span>${new Intl.NumberFormat().format(scale.count)} scale rows</span><span>${feed.count}/${feed.maxRecords} feed rows</span><span>${DemoCWorkspace.FEED_BATCH_SIZE * 1000 / DemoCWorkspace.FEED_INTERVAL_MS} events/sec</span>`
+        }
+    }
+
+    /**
+     * Tears down the workspace-owned producer, tour seams, and cached pane instances.
+     * @param {...*} args
+     */
+    destroy(...args) {
+        let me = this;
+
+        if (me.#feedIntervalId !== null) {
+            clearInterval(me.#feedIntervalId);
+            me.#feedIntervalId = null
+        }
+
+        me.tourRunner?.destroy();
+        me.dockService?.destroy();
+
+        Object.values(me.paneCache).forEach(pane => {
+            pane?.isDestroyed || pane?.destroy?.()
+        });
+        me.paneCache = {};
+
+        super.destroy(...args)
+    }
+}
+
+export default Neo.setupClass(DemoCWorkspace);

--- a/apps/agentos/childapps/dockdemo/view/Viewport.mjs
+++ b/apps/agentos/childapps/dockdemo/view/Viewport.mjs
@@ -1,15 +1,17 @@
 import BaseViewport   from '../../../../../src/container/Viewport.mjs';
 import DemoAWorkspace from './DemoAWorkspace.mjs';
 import DemoBWorkspace from './DemoBWorkspace.mjs';
+import DemoCWorkspace from './DemoCWorkspace.mjs';
 
 /**
  * @summary Viewport of the dock-demo childapp: mounts one of the showcase workspaces by URL.
  *
- * Three boot modes, resolved from the window's own search params (async — the worker reads
+ * Four boot modes, resolved from the window's own search params (async — the worker reads
  * the URL through the main-thread seam, so the workspace mounts in `onConstructed`):
  *
  * - default        → Demo A (dock choreography — `DemoAWorkspace`)
  * - `?demo=b`      → Demo B (perspectives + pop-out — `DemoBWorkspace`)
+ * - `?demo=c`      → Demo C (dense workstation + living data — `DemoCWorkspace`)
  * - `?popout=<id>` → an EMPTY pop-out host: this window carries no workspace of its own;
  *   the opener's workspace reparents the live pane into this viewport on connect (the
  *   shared-heap contract — one App Worker, two render targets).
@@ -52,8 +54,14 @@ class Viewport extends BaseViewport {
             return
         }
 
+        const workspaceByMode = {
+            a: DemoAWorkspace,
+            b: DemoBWorkspace,
+            c: DemoCWorkspace
+        };
+
         me.add({
-            module: params.get('demo') === 'b' ? DemoBWorkspace : DemoAWorkspace,
+            module: workspaceByMode[params.get('demo')] || DemoAWorkspace,
             flex  : 1
         })
     }

--- a/apps/agentos/tour/demoCDenseWorkstation.mjs
+++ b/apps/agentos/tour/demoCDenseWorkstation.mjs
@@ -39,7 +39,7 @@ export const initialDocument = Object.freeze({
     },
     nodes: {
         root               : {type: 'edge-zone', zones: {center: 'split-main', left: 'left-tabs', right: 'split-right', bottom: 'bottom-tabs'}},
-        'split-main'       : {type: 'split', orientation: 'horizontal', children: ['scale-tabs', 'heavy-tabs'], sizes: [0.76, 0.24]},
+        'split-main'       : {type: 'split', orientation: 'horizontal', children: ['scale-tabs', 'heavy-tabs'], sizes: [0.6, 0.4]},
         'scale-tabs'       : {type: 'tabs', items: ['scale'], activeItemId: 'scale'},
         'heavy-tabs'       : {type: 'tabs', items: ['alerts', 'activity', 'topology', 'runtime', 'traces', 'logs', 'console', 'builds', 'deploys', 'security', 'memory', 'files'], activeItemId: 'alerts'},
         'left-tabs'        : {type: 'tabs', items: ['queues', 'graph'], activeItemId: 'queues'},

--- a/apps/agentos/tour/demoCDenseWorkstation.mjs
+++ b/apps/agentos/tour/demoCDenseWorkstation.mjs
@@ -1,0 +1,134 @@
+/**
+ * @summary Demo C's data-only `neo.tour.script.v1` screenplay and opening dock document.
+ *
+ * Twenty live items prove workstation density rather than catalog density. The dominant
+ * scale grid and the live feed remain mounted as the screenplay opens the real overflow
+ * menu, scrolls the 100k grid, promotes a heavy tab through the shipped `splitNode`
+ * descriptor, returns it through `addTab`, and flips both themes. Surface cues are visual
+ * actions; the two document operations remain the deterministic runner log.
+ */
+
+/**
+ * The dense opening stage. Every catalog item is placed in the tree.
+ * @type {Object}
+ */
+export const initialDocument = Object.freeze({
+    schema: 'neo.harness.dockZone.v1',
+    root  : 'root',
+    items : {
+        scale    : {componentRef: 'Scale',     title: '100k Operations Matrix',       kind: 'grid'},
+        feed     : {componentRef: 'Feed',      title: 'Live Event Stream',            kind: 'grid'},
+        alerts   : {componentRef: 'Alerts',    title: 'Priority Alert Observatory',   kind: 'panel'},
+        activity : {componentRef: 'Activity',  title: 'Resident Activity Timeline',   kind: 'panel'},
+        topology : {componentRef: 'Topology',  title: 'Workspace Topology Inspector', kind: 'panel'},
+        runtime  : {componentRef: 'Runtime',   title: 'Runtime Health Envelope',      kind: 'panel'},
+        traces   : {componentRef: 'Traces',    title: 'Distributed Trace Explorer',   kind: 'panel'},
+        logs     : {componentRef: 'Logs',      title: 'Structured Log Console',       kind: 'terminal'},
+        console  : {componentRef: 'Console',   title: 'Command and Control Console',  kind: 'terminal'},
+        builds   : {componentRef: 'Builds',    title: 'Build Pipeline Monitor',       kind: 'panel'},
+        deploys  : {componentRef: 'Deploys',   title: 'Deployment Flight Deck',       kind: 'panel'},
+        security : {componentRef: 'Security',  title: 'Security Signal Center',       kind: 'panel'},
+        memory   : {componentRef: 'Memory',    title: 'Memory Core Telemetry',        kind: 'panel'},
+        graph    : {componentRef: 'Graph',     title: 'Native Edge Graph',            kind: 'panel', autoHidden: true},
+        queues   : {componentRef: 'Queues',    title: 'Task Queue Pressure',          kind: 'panel'},
+        metrics  : {componentRef: 'Metrics',   title: 'Fleet Metrics',                kind: 'panel'},
+        audit    : {componentRef: 'Audit',     title: 'Evidence Audit',               kind: 'panel'},
+        commits  : {componentRef: 'Commits',   title: 'Commit Stream',                kind: 'panel'},
+        files    : {componentRef: 'Files',     title: 'Workspace Files',              kind: 'panel'},
+        inspector: {componentRef: 'Inspector', title: 'Selection Inspector',          kind: 'panel', autoHidden: true}
+    },
+    nodes: {
+        root               : {type: 'edge-zone', zones: {center: 'split-main', left: 'left-tabs', right: 'split-right', bottom: 'bottom-tabs'}},
+        'split-main'       : {type: 'split', orientation: 'horizontal', children: ['scale-tabs', 'heavy-tabs'], sizes: [0.76, 0.24]},
+        'scale-tabs'       : {type: 'tabs', items: ['scale'], activeItemId: 'scale'},
+        'heavy-tabs'       : {type: 'tabs', items: ['alerts', 'activity', 'topology', 'runtime', 'traces', 'logs', 'console', 'builds', 'deploys', 'security', 'memory', 'files'], activeItemId: 'alerts'},
+        'left-tabs'        : {type: 'tabs', items: ['queues', 'graph'], activeItemId: 'queues'},
+        'split-right'      : {type: 'split', orientation: 'vertical', children: ['right-top-tabs', 'right-bottom-tabs'], sizes: [0.5, 0.5]},
+        'right-top-tabs'   : {type: 'tabs', items: ['metrics', 'audit'], activeItemId: 'metrics'},
+        'right-bottom-tabs': {type: 'tabs', items: ['commits'], activeItemId: 'commits'},
+        'bottom-tabs'      : {type: 'tabs', items: ['feed', 'inspector'], activeItemId: 'feed'}
+    }
+});
+
+/**
+ * The three-beat dense-workstation story. `promote` is prose only: the executable
+ * vocabulary is the shipped `splitNode` + `addTab` pair.
+ * @type {Object}
+ */
+export const demoCTourScript = Object.freeze({
+    schema: 'neo.tour.script.v1',
+    id    : 'demo-c-dense-workstation',
+    title : 'The content never stops living',
+
+    workspace: {height: 1440, width: 2560},
+
+    scenes: [{
+        id     : 's1',
+        title  : 'Dense overview — twenty panes, one living workspace',
+        caption: 'A 100,000-row operations matrix keeps scrolling while a second store ingests ten events per second.',
+        steps  : [{
+            type   : 'topology-assert',
+            caption: 'all twenty panes are live; the heavy group deliberately overflows',
+            expect : [
+                {path: 'nodes.scale-tabs.items', equals: ['scale']},
+                {path: 'nodes.heavy-tabs.items.0', equals: 'alerts'},
+                {path: 'nodes.heavy-tabs.items.11', equals: 'files'},
+                {path: 'items.graph.autoHidden', equals: true},
+                {path: 'items.inspector.autoHidden', equals: true}
+            ]
+        }, {
+            type   : 'pause',
+            ms     : 1400,
+            cue    : {type: 'overflow', itemId: 'security'},
+            caption: 'the real overflow menu opens and activates a hidden resident through ordinary activeIndex'
+        }, {
+            type   : 'pause',
+            ms     : 1400,
+            cue    : {type: 'scroll', index: 50000},
+            caption: 'the 100k grid crosses its midpoint without a blank frame'
+        }]
+    }, {
+        id     : 's2',
+        title  : 'Promote — the workspace transforms around living content',
+        caption: 'A heavy resident becomes its own split and returns; pane, grid, store, and component ownership remain stable.',
+        steps  : [{
+            type      : 'op',
+            caption   : 'splitNode(security → below scale): promote through the shipped semantic operation',
+            descriptor: {operation: 'splitNode', itemId: 'security', targetNodeId: 'scale-tabs', orientation: 'vertical', edge: 'bottom', sizes: [0.72, 0.28]},
+            expect    : [{path: 'nodes.split-scale-tabs-0.children', equals: ['scale-tabs', 'tabs-security-0']}]
+        }, {
+            type   : 'pause',
+            ms     : 1200,
+            cue    : {type: 'canvas-update'},
+            caption: 'a preserved visible Sparkline receives a new values array after the split and stays registered in the Canvas Worker'
+        }, {
+            type      : 'op',
+            caption   : 'addTab(security → heavy): the promoted pane rejoins the dense group',
+            descriptor: {operation: 'addTab', itemId: 'security', tabsNodeId: 'heavy-tabs'},
+            expect    : [{path: 'nodes.heavy-tabs.activeItemId', equals: 'security'}]
+        }]
+    }, {
+        id     : 's3',
+        title  : 'Theme handoff — cold light, deep dark, same live state',
+        caption: 'The skin changes; the two Store<Model> identities and their moving content do not.',
+        steps  : [{
+            type   : 'pause',
+            ms     : 1600,
+            cue    : {type: 'theme', theme: 'neo-theme-neo-light'},
+            caption: 'light mode: workstation density stays legible'
+        }, {
+            type   : 'pause',
+            ms     : 1600,
+            cue    : {type: 'theme', theme: 'neo-theme-neo-dark'},
+            caption: 'dark mode: the signature signal layer returns'
+        }, {
+            type   : 'topology-assert',
+            caption: 'finale: every data surface remains live and security returns through the ordinary tab path',
+            expect : [
+                {path: 'nodes.split-main.children.0', equals: 'scale-tabs'},
+                {path: 'nodes.heavy-tabs.activeItemId', equals: 'security'},
+                {path: 'nodes.heavy-tabs.items.11', equals: 'security'}
+            ]
+        }]
+    }]
+});

--- a/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoCWorkspace.scss
+++ b/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoCWorkspace.scss
@@ -19,7 +19,9 @@
     --grid-header-button-color-hover            : var(--fm-ink);
     --grid-header-button-glyph-color            : var(--fm-ink-dim);
     --grid-header-button-glyph-color-hover      : var(--fm-signal);
-    --grid-header-button-justify-content        : flex-start;
+    // Header buttons use row-reverse to keep their sort glyph after the label. `flex-end`
+    // therefore means physical left/start alignment for the complete label + glyph group.
+    --grid-header-button-justify-content        : flex-end;
     --grid-header-button-padding                : 0 10px;
     --tab-button-background-color               : transparent;
     --tab-button-background-color-active        : color-mix(in srgb, var(--fm-signal) 12%, transparent);
@@ -52,6 +54,17 @@
     .neo-tab-container {
         min-height: 0;
         min-width : 0;
+    }
+
+    // The generic edge-zone defaults are symmetrical. Demo C's evidence column carries two
+    // vertically stacked instruments, while the left queue card is intentionally simpler.
+    // Shift those forty pixels to the evidence side instead of starving both right-hand zones.
+    .neo-dashboard-dock-edge-band-left {
+        width: 260px;
+    }
+
+    .neo-dashboard-dock-edge-band-right {
+        width: 320px;
     }
 
     .neo-dashboard-dock-edge-rail {
@@ -91,8 +104,15 @@
         --grid-header-button-color-hover           : var(--fm-ink);
         --grid-header-button-glyph-color           : var(--fm-ink-dim);
         --grid-header-button-glyph-color-hover     : var(--fm-signal);
-        --grid-header-button-justify-content       : flex-start;
+        --grid-header-button-justify-content       : flex-end;
         --grid-header-button-padding               : 0 10px;
+
+        // Hidden sort glyphs must not indent unsorted labels (most visibly the narrow `#`
+        // column). Keep the glyph on the physical right edge without participating in flex.
+        .neo-button-glyph {
+            position: absolute;
+            right   : 10px;
+        }
     }
 }
 

--- a/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoCWorkspace.scss
+++ b/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoCWorkspace.scss
@@ -3,6 +3,32 @@
 // reduced-motion collapse owned by Neo.dashboard.Container.
 
 .agentos-dockdemo-workspace-c {
+    // Demo C is an AgentOS instrument, so generic grid/tab primitives inherit the cockpit
+    // palette in both skins instead of leaking their standalone blue/purple defaults.
+    --grid-container-border-color              : var(--fm-line);
+    --grid-container-cell-background-color     : var(--fm-panel);
+    --grid-container-cell-background-color-even: var(--fm-panel-2);
+    --grid-container-color                     : var(--fm-ink-dim);
+    --grid-container-header-cell-border-bottom : 1px solid var(--fm-line);
+    --grid-cell-background-color-hover          : color-mix(in srgb, var(--fm-signal) 10%, var(--fm-panel));
+    --grid-cell-progress-active-color           : var(--fm-signal);
+    --grid-cell-progress-track-color            : var(--fm-line);
+    --grid-header-button-background-color       : var(--fm-panel-2);
+    --grid-header-button-background-color-hover : color-mix(in srgb, var(--fm-signal) 12%, var(--fm-panel-2));
+    --grid-header-button-color                  : var(--fm-ink);
+    --grid-header-button-color-hover            : var(--fm-ink);
+    --grid-header-button-glyph-color            : var(--fm-ink-dim);
+    --grid-header-button-glyph-color-hover      : var(--fm-signal);
+    --grid-header-button-justify-content        : flex-start;
+    --grid-header-button-padding                : 0 10px;
+    --tab-button-background-color               : transparent;
+    --tab-button-background-color-active        : color-mix(in srgb, var(--fm-signal) 12%, transparent);
+    --tab-button-background-color-hover         : color-mix(in srgb, var(--fm-signal) 8%, transparent);
+    --tab-button-glyph-color                    : var(--fm-ink-dim);
+    --tab-button-text-color                     : var(--fm-ink-dim);
+    --tab-indicator-background-color-active     : var(--fm-signal);
+    --tab-strip-background-color                : var(--fm-panel-2);
+
     background:
         radial-gradient(circle at 22% 8%, color-mix(in srgb, var(--fm-signal) 8%, transparent), transparent 32%),
         var(--fm-ground);
@@ -42,6 +68,32 @@
             font-family: var(--fm-font-mono);
         }
     }
+
+    .neo-tab-header-toolbar {
+        background   : var(--fm-panel-2);
+        border-bottom: 1px solid var(--fm-line);
+    }
+
+    .neo-tab-header-button.pressed {
+        .neo-button-glyph,
+        .neo-button-text {
+            color: var(--fm-ink);
+        }
+    }
+
+    // Theme classes live on the grid primitives themselves, so inherited workspace
+    // variables alone cannot out-rank their light-skin defaults.
+    .neo-grid-header-button {
+        --grid-header-button-background-color      : var(--fm-panel-2);
+        --grid-header-button-background-color-hover: color-mix(in srgb, var(--fm-signal) 12%, var(--fm-panel-2));
+        --grid-header-button-background-image      : none;
+        --grid-header-button-color                 : var(--fm-ink);
+        --grid-header-button-color-hover           : var(--fm-ink);
+        --grid-header-button-glyph-color           : var(--fm-ink-dim);
+        --grid-header-button-glyph-color-hover     : var(--fm-signal);
+        --grid-header-button-justify-content       : flex-start;
+        --grid-header-button-padding               : 0 10px;
+    }
 }
 
 .agentos-dockdemo-tourbar-c {
@@ -50,15 +102,79 @@
         var(--fm-panel) 55%);
     border-bottom: 1px solid color-mix(in srgb, var(--fm-signal) 30%, var(--fm-line));
     box-shadow   : 0 8px 28px color-mix(in srgb, var(--fm-ground) 66%, transparent);
+    gap          : 12px;
+    height       : 64px;
+    padding      : 8px 14px;
+
+    .agentos-dockdemo-tour-story {
+        gap      : 8px;
+        min-width: 0;
+    }
+
+    .agentos-dockdemo-tour-caption {
+        color        : var(--fm-ink-dim);
+        font-family  : var(--fm-font-mono);
+        font-size    : 12px;
+        overflow     : hidden;
+        padding-left : 12px;
+        text-overflow: ellipsis;
+        white-space  : nowrap;
+    }
+
+    .agentos-dockdemo-tour-pips {
+        display: flex;
+        gap    : 5px;
+        padding: 0 12px;
+
+        .agentos-dockdemo-pip {
+            background   : var(--fm-line);
+            border-radius: 999px;
+            flex         : 1;
+            height       : 4px;
+            max-width    : 48px;
+            transition   : background .2s ease, box-shadow .2s ease;
+        }
+
+        .agentos-dockdemo-pip-done {
+            background: var(--fm-signal);
+            box-shadow: 0 0 8px color-mix(in srgb, var(--fm-signal) 45%, transparent);
+        }
+    }
 
     .agentos-dockdemo-theme-button {
-        background   : var(--fm-panel-2);
-        border       : 1px solid var(--fm-line);
+        --button-background-color       : var(--fm-panel-2);
+        --button-background-color-active: color-mix(in srgb, var(--fm-signal) 18%, var(--fm-panel-2));
+        --button-background-color-hover : color-mix(in srgb, var(--fm-signal) 12%, var(--fm-panel-2));
+        --button-border                 : 1px solid var(--fm-line);
+        --button-border-active          : 1px solid var(--fm-signal);
+        --button-border-hover           : 1px solid color-mix(in srgb, var(--fm-signal) 55%, var(--fm-line));
+        --button-glyph-color            : var(--fm-ink-dim);
+        --button-glyph-color-active     : var(--fm-signal);
+        --button-glyph-color-hover      : var(--fm-signal);
+        --button-ripple-background-color: color-mix(in srgb, var(--fm-signal) 32%, transparent);
+        --button-text-color             : var(--fm-ink);
+        --button-text-color-active      : var(--fm-ink);
+        --button-text-color-hover       : var(--fm-ink);
         border-radius: 7px;
-        color        : var(--fm-ink);
         font-family  : var(--fm-font-mono);
-        margin-left  : 6px;
+        margin       : 0;
     }
+}
+
+.agentos-dockdemo-workspace-c .neo-button.agentos-dockdemo-tour-play {
+    --button-background-color       : var(--fm-signal);
+    --button-background-color-active: color-mix(in srgb, var(--fm-signal) 78%, var(--fm-ink));
+    --button-background-color-hover : color-mix(in srgb, var(--fm-signal) 88%, var(--fm-panel));
+    --button-border                 : 1px solid var(--fm-signal);
+    --button-border-active          : 1px solid var(--fm-signal);
+    --button-border-hover           : 1px solid var(--fm-signal);
+    --button-glyph-color            : var(--fm-ground);
+    --button-glyph-color-active     : var(--fm-ground);
+    --button-glyph-color-hover      : var(--fm-ground);
+    --button-ripple-background-color: color-mix(in srgb, var(--fm-ground) 24%, transparent);
+    --button-text-color             : var(--fm-ground);
+    --button-text-color-active      : var(--fm-ground);
+    --button-text-color-hover       : var(--fm-ground);
 }
 
 // Beat generic button focus/pressed descendant colors without relying on theme load order.
@@ -110,6 +226,73 @@
 
     .neo-grid-header-toolbar {
         background: var(--fm-panel-2);
+    }
+
+    // The Sparkline component's intrinsic canvas is 300x150. Demo C must load the
+    // same cell-fit contract proven by DevIndex instead of letting that size escape.
+    .neo-sparkline-wrapper {
+        contain  : strict;
+        height   : 100%;
+        min-width: 0;
+        position: relative;
+        width    : 100%;
+
+        .neo-sparkline-canvas {
+            height  : 100%;
+            left    : 0;
+            position: absolute;
+            top     : 0;
+            width   : 100%;
+        }
+    }
+}
+
+.agentos-dockdemo-workspace-c .neo-button.agentos-dockdemo-row-action {
+    --button-background-color       : color-mix(in srgb, var(--fm-signal) 8%, var(--fm-panel-2));
+    --button-background-color-active: color-mix(in srgb, var(--fm-signal) 20%, var(--fm-panel-2));
+    --button-background-color-hover : color-mix(in srgb, var(--fm-signal) 14%, var(--fm-panel-2));
+    --button-border                 : 1px solid color-mix(in srgb, var(--fm-signal) 34%, var(--fm-line));
+    --button-border-active          : 1px solid var(--fm-signal);
+    --button-border-hover           : 1px solid color-mix(in srgb, var(--fm-signal) 62%, var(--fm-line));
+    --button-glyph-color            : var(--fm-signal);
+    --button-glyph-color-active     : var(--fm-signal);
+    --button-glyph-color-hover      : var(--fm-signal);
+    --button-ripple-background-color: color-mix(in srgb, var(--fm-signal) 28%, transparent);
+    --button-text-color             : var(--fm-ink-dim);
+    --button-text-color-active      : var(--fm-ink);
+    --button-text-color-hover       : var(--fm-ink);
+    border-radius: 6px;
+    font-family  : var(--fm-font-mono);
+    height       : 30px;
+}
+
+// The generic overflow button is a floating direct-body child. Scope its cockpit skin to
+// documents that actually contain Demo C rather than coupling the shared plugin to this app.
+body:has(.agentos-dockdemo-workspace-c) .neo-button.neo-tab-overflow-control {
+    --button-background-color       : color-mix(in srgb, var(--fm-signal) 12%, var(--fm-panel-2));
+    --button-background-color-active: color-mix(in srgb, var(--fm-signal) 24%, var(--fm-panel-2));
+    --button-background-color-hover : color-mix(in srgb, var(--fm-signal) 18%, var(--fm-panel-2));
+    --button-border                 : 1px solid color-mix(in srgb, var(--fm-signal) 42%, var(--fm-line));
+    --button-border-active          : 1px solid var(--fm-signal);
+    --button-border-hover           : 1px solid color-mix(in srgb, var(--fm-signal) 70%, var(--fm-line));
+    --button-glyph-color            : var(--fm-signal);
+    --button-glyph-color-active     : var(--fm-signal);
+    --button-glyph-color-hover      : var(--fm-signal);
+    --button-ripple-background-color: color-mix(in srgb, var(--fm-signal) 32%, transparent);
+    border-radius: 6px;
+}
+
+// Coarse document projection deliberately replaces tab chrome while moving live pane nodes.
+// Keep that replacement chrome motionless: re-enabling the generic pressed-tab animation on
+// an already-pressed fresh node restarts it. Identity-preserving reconciliation is the shared
+// follow-up that can restore ordinary indicator motion without replaying bootstrap effects.
+.agentos-dockdemo-chrome-settling {
+    .neo-tab-button-indicator {
+        animation-duration: 0ms !important;
+    }
+
+    .neo-active-tab-indicator {
+        transition-duration: 0ms !important;
     }
 }
 

--- a/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoCWorkspace.scss
+++ b/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoCWorkspace.scss
@@ -1,0 +1,236 @@
+// Demo C — dense-workstation composition. Theme values come exclusively from the
+// AgentOS/Fleet token layer; all motion rides the dashboard aliases, including the
+// reduced-motion collapse owned by Neo.dashboard.Container.
+
+.agentos-dockdemo-workspace-c {
+    background:
+        radial-gradient(circle at 22% 8%, color-mix(in srgb, var(--fm-signal) 8%, transparent), transparent 32%),
+        var(--fm-ground);
+    color: var(--fm-ink);
+
+    .agentos-dockdemo-tourbar-c,
+    .agentos-dockdemo-statusbar {
+        transition: background var(--dock-transition-duration-fast) var(--dock-transition-easing),
+                    color var(--dock-transition-duration-fast) var(--dock-transition-easing);
+    }
+
+    .neo-dashboard-dock-edge-zone {
+        gap: 7px;
+    }
+
+    .neo-dashboard-dock-edge-row {
+        gap: 7px;
+    }
+
+    .neo-dashboard-dock-edge-band,
+    .neo-tab-container {
+        min-height: 0;
+        min-width : 0;
+    }
+
+    .neo-dashboard-dock-edge-rail {
+        background   : color-mix(in srgb, var(--fm-signal) 18%, var(--fm-rail));
+        border        : 1px solid color-mix(in srgb, var(--fm-signal) 52%, var(--fm-line));
+        border-radius : 7px;
+        box-shadow    : 0 0 22px color-mix(in srgb, var(--fm-signal) 12%, transparent);
+        overflow      : hidden;
+
+        .neo-dashboard-dock-rail-tab {
+            background: transparent;
+            border    : 0;
+            color     : var(--fm-ink);
+            font-family: var(--fm-font-mono);
+        }
+    }
+}
+
+.agentos-dockdemo-tourbar-c {
+    background: linear-gradient(90deg,
+        color-mix(in srgb, var(--fm-signal) 13%, var(--fm-panel)),
+        var(--fm-panel) 55%);
+    border-bottom: 1px solid color-mix(in srgb, var(--fm-signal) 30%, var(--fm-line));
+    box-shadow   : 0 8px 28px color-mix(in srgb, var(--fm-ground) 66%, transparent);
+
+    .agentos-dockdemo-theme-button {
+        background   : var(--fm-panel-2);
+        border       : 1px solid var(--fm-line);
+        border-radius: 7px;
+        color        : var(--fm-ink);
+        font-family  : var(--fm-font-mono);
+        margin-left  : 6px;
+    }
+}
+
+// Beat generic button focus/pressed descendant colors without relying on theme load order.
+.agentos-dockdemo-workspace-c .agentos-dockdemo-tourbar-c {
+    .agentos-dockdemo-theme-button {
+        .neo-button-glyph,
+        .neo-button-text {
+            color: var(--fm-ink);
+        }
+    }
+}
+
+.agentos-dockdemo-statusbar {
+    align-items  : center;
+    background   : var(--fm-panel-2);
+    border-bottom: 1px solid var(--fm-line);
+    display      : flex;
+    flex         : 0 0 34px;
+    gap          : 8px;
+    min-height   : 34px;
+    padding      : 5px 12px;
+    position     : relative;
+    z-index      : 2;
+
+    span {
+        background    : color-mix(in srgb, var(--fm-signal) 9%, var(--fm-panel));
+        border        : 1px solid color-mix(in srgb, var(--fm-signal) 32%, var(--fm-line));
+        border-radius : 999px;
+        color         : var(--fm-ink-dim);
+        font-family   : var(--fm-font-mono);
+        font-size     : 10px;
+        letter-spacing: .04em;
+        padding       : 3px 9px;
+        text-transform: uppercase;
+    }
+}
+
+.agentos-dockdemo-dock-host-c {
+    padding: 12px;
+}
+
+.agentos-dockdemo-data-pane {
+    background   : var(--fm-panel);
+    border       : 1px solid var(--fm-line-soft);
+    border-radius: 8px;
+    min-height   : 0;
+    min-width    : 0;
+    overflow     : hidden;
+
+    .neo-grid-header-toolbar {
+        background: var(--fm-panel-2);
+    }
+}
+
+.agentos-dockdemo-placeholder {
+    background:
+        radial-gradient(circle at 82% 16%, color-mix(in srgb, var(--fm-signal) 16%, transparent), transparent 38%),
+        linear-gradient(145deg, var(--fm-panel), color-mix(in srgb, var(--fm-signal) 5%, var(--fm-panel-2)));
+    border        : 1px solid var(--fm-line-soft);
+    border-radius : 8px;
+    overflow      : hidden;
+    padding       : 0;
+    position      : relative;
+
+    &::after {
+        background: linear-gradient(90deg, transparent, color-mix(in srgb, var(--fm-signal) 55%, transparent), transparent);
+        content   : '';
+        height    : 1px;
+        left      : 8%;
+        position  : absolute;
+        right     : 8%;
+        top       : 0;
+    }
+}
+
+.agentos-dockdemo-resident-card {
+    box-sizing    : border-box;
+    display       : flex;
+    flex-direction: column;
+    height        : 100%;
+    min-height    : 0;
+    padding       : clamp(12px, 2vw, 24px);
+    position      : relative;
+}
+
+.agentos-dockdemo-resident-kicker {
+    align-items   : center;
+    color         : var(--fm-ink-dim);
+    display       : flex;
+    font-family   : var(--fm-font-mono);
+    font-size     : 10px;
+    font-weight   : 700;
+    gap           : 7px;
+    letter-spacing: .13em;
+
+    span {
+        background   : var(--fm-state-ok);
+        border-radius: 50%;
+        box-shadow   : 0 0 12px color-mix(in srgb, var(--fm-state-ok) 72%, transparent);
+        height       : 6px;
+        width        : 6px;
+    }
+}
+
+.agentos-dockdemo-resident-icon {
+    color    : color-mix(in srgb, var(--fm-signal) 72%, var(--fm-ink));
+    font-size: clamp(18px, 2vw, 30px);
+    margin   : auto 0 8px;
+    opacity  : .82;
+}
+
+.agentos-dockdemo-resident-metric {
+    color         : var(--fm-ink);
+    font-family   : var(--fm-font-mono);
+    font-size     : clamp(24px, 4vw, 58px);
+    font-weight   : 800;
+    letter-spacing: -.06em;
+    line-height   : .95;
+    text-shadow   : 0 0 28px color-mix(in srgb, var(--fm-signal) 18%, transparent);
+}
+
+.agentos-dockdemo-resident-title {
+    color         : var(--fm-ink);
+    font-family   : var(--fm-font-sans);
+    font-size     : clamp(11px, 1.2vw, 16px);
+    font-weight   : 650;
+    letter-spacing: .02em;
+    margin-top    : 8px;
+}
+
+.agentos-dockdemo-resident-footer {
+    align-items   : center;
+    border-top    : 1px solid var(--fm-line-soft);
+    color         : var(--fm-ink-faint);
+    display       : flex;
+    font-family   : var(--fm-font-mono);
+    font-size     : 9px;
+    gap           : 8px;
+    justify-content: space-between;
+    margin-top    : 14px;
+    padding-top   : 9px;
+    text-transform: uppercase;
+
+    strong {
+        color         : var(--fm-state-ok);
+        font-size     : 9px;
+        letter-spacing: .12em;
+    }
+}
+
+.agentos-dockdemo-resident-wave {
+    align-items: end;
+    display    : flex;
+    gap        : 3px;
+    height     : 15px;
+    margin-top : 9px;
+
+    i {
+        background   : color-mix(in srgb, var(--fm-signal) 68%, var(--fm-line));
+        border-radius: 2px;
+        display      : block;
+        height       : 40%;
+        width        : 8px;
+
+        &:nth-child(2), &:nth-child(5) {height: 78%}
+        &:nth-child(3) {height: 100%}
+        &:nth-child(4) {height: 62%}
+        &:nth-child(6) {height: 28%}
+    }
+}
+
+.agentos-dockdemo-heat-0 {background: color-mix(in srgb, var(--fm-panel-2) 92%, var(--fm-signal))}
+.agentos-dockdemo-heat-1 {background: color-mix(in srgb, var(--fm-panel-2) 84%, var(--fm-signal))}
+.agentos-dockdemo-heat-2 {background: color-mix(in srgb, var(--fm-panel-2) 76%, var(--fm-signal))}
+.agentos-dockdemo-heat-3 {background: color-mix(in srgb, var(--fm-panel-2) 66%, var(--fm-signal))}

--- a/resources/scss/src/tab/header/Toolbar.scss
+++ b/resources/scss/src/tab/header/Toolbar.scss
@@ -86,3 +86,9 @@
         }
     }
 }
+
+// The out-of-collection overflow button aligns its border box to this toolbar. Theme-level
+// button margins must not shift that floating geometry away from the source-owner edge.
+.neo-button.neo-tab-overflow-control {
+    margin: 0;
+}

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -341,6 +341,7 @@ class DockLayoutAdapter extends Base {
             dockNodeType            : 'edge-rail',
             dockZoneDocument        : context.dockZoneDocument,
             edge,
+            flex                    : 'none',
             module                  : DockRail,
             ntype                   : 'dashboard-dock-rail',
             onDockZoneDocumentChange: context.onDockZoneDocumentChange,

--- a/src/layout/Card.mjs
+++ b/src/layout/Card.mjs
@@ -153,15 +153,27 @@ class Card extends Base {
             childCls      = item.wrapperCls || [],
             {vdom}        = item;
 
-        NeoArray.add(childCls, sCfg.itemCls);
-        NeoArray.add(childCls, isActiveIndex ? sCfg.activeItemCls : sCfg.inactiveItemCls);
+        NeoArray.add(   childCls, sCfg.itemCls);
+        NeoArray.remove(childCls, isActiveIndex ? sCfg.inactiveItemCls : sCfg.activeItemCls);
+        NeoArray.add(   childCls, isActiveIndex ? sCfg.activeItemCls   : sCfg.inactiveItemCls);
 
-        if (!keepInDom && me.removeInactiveCards) {
-            vdom.removeDom  = !isActiveIndex;
-            item.wrapperCls = childCls;
-            item.update?.() // can get called for an item config
+        if (me.removeInactiveCards) {
+            if (isActiveIndex) {
+                // An atomic cross-parent move can make a previously inactive card active. `keepInDom`
+                // preserves its mounted identity, but must not preserve the source layout's remove marker.
+                delete vdom.removeDom
+            } else if (!keepInDom) {
+                vdom.removeDom = true
+            }
+        }
+
+        if (keepInDom && item.setSilent) {
+            // Container.insert() uses keepInDom for atomic moves. Keep the item-level class mutation
+            // inside that silent transaction; the caller's common-parent update owns the one DOM commit.
+            item.setSilent({wrapperCls: childCls})
         } else {
-            item.wrapperCls = childCls
+            item.wrapperCls = childCls;
+            me.removeInactiveCards && item.update?.() // can get called for an item config
         }
     }
 

--- a/src/tab/BodyContainer.mjs
+++ b/src/tab/BodyContainer.mjs
@@ -25,13 +25,14 @@ class BodyContainer extends Container {
      * @param {Neo.component.Base} component
      * @param {Boolean} [destroyItem=true]
      * @param {Boolean} [silent=false]
+     * @param {Boolean} [keepMounted=false]
      * @returns {Neo.component.Base|null}
      */
-    remove(component, destroyItem, silent) {
+    remove(component, destroyItem, silent, keepMounted) {
         if (component?.isTab) {
-            this.parent.remove(component, destroyItem, silent)
+            return this.parent.remove(component, destroyItem, silent, keepMounted)
         } else {
-            super.remove(component, destroyItem, silent)
+            return super.remove(component, destroyItem, silent, keepMounted)
         }
     }
 }

--- a/src/tab/Container.mjs
+++ b/src/tab/Container.mjs
@@ -262,11 +262,11 @@ class Container extends BaseContainer {
      * @protected
      */
     createItems() {
-        let me            = this,
+        let me                                                        = this,
             {activeIndex, removeInactiveCards, useActiveTabIndicator} = me,
-            items         = me.items || [],
-            tabButtons    = [],
-            tabComponents = [];
+            items                                                     = me.items || [],
+            tabButtons                                                = [],
+            tabComponents                                             = [];
 
         Object.assign(me, {
             bodyContainerId: me.bodyContainerId || Neo.getId('container'),
@@ -593,15 +593,16 @@ class Container extends BaseContainer {
      * @param {Neo.component.Base} component The card component instance to remove.
      * @param {Boolean} [destroyItem=true] Set to false to keep the component instance in memory.
      * @param {Boolean} [silent=false] Set to true to prevent `updateTabButtons` from being called.
+     * @param {Boolean} [keepMounted=false] Preserve the card's mounted state for an atomic cross-parent move.
      */
-    remove(component, destroyItem=true, silent=false) {
+    remove(component, destroyItem=true, silent=false, keepMounted=false) {
         let items = [...this.getCardContainer().items],
             i     = 0,
             len   = items.length;
 
         for (; i < len; i++) {
             if (items[i].id === component.id) {
-                this.removeAt(i, destroyItem, silent)
+                return this.removeAt(i, destroyItem, silent, keepMounted)
             }
         }
     }
@@ -611,15 +612,16 @@ class Container extends BaseContainer {
      * @param {Number} index The index of the tab to remove.
      * @param {Boolean} [destroyItem=true] Set to false to keep the component instance in memory.
      * @param {Boolean} [silent=false] Set to true to prevent `updateTabButtons` from being called.
+     * @param {Boolean} [keepMounted=false] Preserve the card's mounted state for an atomic cross-parent move.
      */
-    removeAt(index, destroyItem=true, silent=false) {
+    removeAt(index, destroyItem=true, silent=false, keepMounted=false) {
         let me            = this,
             {activeIndex} = me,
             cardContainer = me.getCardContainer(),
             tabBar        = me.getTabBar(),
-            i, len;
+            card, i, len;
 
-        cardContainer.removeAt(index, destroyItem, silent);
+        card = cardContainer.removeAt(index, destroyItem, silent, keepMounted);
         tabBar       .removeAt(index, true,        false);
 
         if (index < activeIndex) {
@@ -637,6 +639,8 @@ class Container extends BaseContainer {
         for (; i < len; i++) {
             tabBar.items[i].index = i
         }
+
+        return card
     }
 
     /**

--- a/src/tab/Container.mjs
+++ b/src/tab/Container.mjs
@@ -611,7 +611,7 @@ class Container extends BaseContainer {
      * Removes a tab from the container at a specific index.
      * @param {Number} index The index of the tab to remove.
      * @param {Boolean} [destroyItem=true] Set to false to keep the component instance in memory.
-     * @param {Boolean} [silent=false] Set to true to prevent `updateTabButtons` from being called.
+     * @param {Boolean} [silent=false] Defer child DOM updates to the caller's common-parent transaction.
      * @param {Boolean} [keepMounted=false] Preserve the card's mounted state for an atomic cross-parent move.
      */
     removeAt(index, destroyItem=true, silent=false, keepMounted=false) {
@@ -622,14 +622,26 @@ class Container extends BaseContainer {
             card, i, len;
 
         card = cardContainer.removeAt(index, destroyItem, silent, keepMounted);
-        tabBar       .removeAt(index, true,        false);
+        tabBar       .removeAt(index, true,        silent);
 
         if (index < activeIndex) {
             // silent updates
             me._activeIndex = activeIndex - 1;
             cardContainer.layout._activeIndex = activeIndex - 1
         } else if (index === activeIndex) {
-            me.activeIndex = activeIndex - 1
+            if (silent) {
+                me._activeIndex = activeIndex - 1;
+                cardContainer.layout._activeIndex = activeIndex - 1;
+
+                // Atomic cross-parent moves defer their one DOM commit to the closest common parent.
+                // Keep both card visibility and tab pressed-state inside that same silent transaction.
+                cardContainer.items.forEach((item, itemIndex) => {
+                    cardContainer.layout.applyChildAttributes(item, itemIndex, true)
+                });
+                me.updateTabButtons(true)
+            } else {
+                me.activeIndex = activeIndex - 1
+            }
         }
 
         // todo: non index based matching of tab buttons and cards
@@ -646,15 +658,20 @@ class Container extends BaseContainer {
     /**
      * Synchronizes the `pressed` state of all tab buttons with the container's `activeIndex`.
      * This ensures that only the button corresponding to the active tab appears pressed.
+     * @param {Boolean} [silent=false] Mutate VDOM state without committing a child-level update.
      * @protected
      */
-    updateTabButtons() {
+    updateTabButtons(silent=false) {
         let me            = this,
             {activeIndex} = me,
             tabButtons    = me.getTabBar()?.items || [];
 
         tabButtons.forEach((item, index) => {
-            item.pressed = index === activeIndex
+            if (silent) {
+                item.setSilent({pressed: index === activeIndex})
+            } else {
+                item.pressed = index === activeIndex
+            }
         })
     }
 }

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -266,11 +266,31 @@ class Overflow extends Plugin {
         try {
             // 1. Natural widths — measured once while every button is visible, then cached.
             if (recapture || !me.naturalWidths) {
-                let rects = await owner.getDomRect(buttons.map(button => button.id));
+                const removedButtons = buttons.filter(button => button.hidden);
+
+                // A prior split removes overflowing buttons from DOM. Restore them under this method's
+                // measuring latch, then reconcile their closest common parent once so getDomRect observes
+                // natural geometry. Any resize raised by that update queues behind the latch and drains as
+                // an extent-only pass after this authoritative capture.
+                if (removedButtons.length > 0) {
+                    removedButtons.forEach(button => button.setSilent({hidden: false}));
+                    owner.updateDepth = -1;
+                    owner.update();
+                    await owner.promiseUpdate()
+                }
+
+                let previousWidths = me.naturalWidths || {},
+                    rects          = await owner.getDomRect(buttons.map(button => button.id));
 
                 me.naturalWidths = {};
                 buttons.forEach((button, index) => {
-                    me.naturalWidths[button.id] = Math.ceil(rects[index]?.width || 0)
+                    // A recapture can run after the previous split removed overflowing headers from DOM.
+                    // Their live rect is then zero by construction, not because their natural width changed.
+                    // Keep the last positive measurement for those stable button identities; newly inserted
+                    // buttons are visible on their first mutation pass and therefore still enter the cache.
+                    me.naturalWidths[button.id] = Math.ceil(
+                        rects[index]?.width || previousWidths[button.id] || 0
+                    )
                 })
             }
 

--- a/test/playwright/e2e/agentos/DemoCDenseWorkstationNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoCDenseWorkstationNL.spec.mjs
@@ -430,6 +430,8 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
                     .map(element => element.id);
 
             const state = globalThis.__demoCMonitor = {
+                activeTabEmptyMaxMs           : 0,
+                activeTabEmptySamples         : [],
                 blankSamples                  : [],
                 blankFrames                   : 0,
                 chromeAnimationLeakFrames     : 0,
@@ -451,6 +453,7 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
                 securityMissingFrames         : 0,
                 securityReplacementFrames     : 0
             };
+            const activeTabEmptySpans = {};
             let securityNode = null;
 
             const tick = () => {
@@ -473,6 +476,7 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
 
                 if (root) {
                     const
+                        activeTabEmptyIds = new Set(),
                         pipCount = root.querySelectorAll('.agentos-dockdemo-pip-done').length,
                         previous = state.pipCounts.at(-1);
 
@@ -496,6 +500,38 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
                                 hasRunningEntryEffect && state.chromeAnimationLeakFrames++
                             }
                         }
+                    });
+
+                    [...root.querySelectorAll('.neo-tab-container')].filter(isVisible).forEach(container => {
+                        const
+                            activeHeader = [...container.querySelectorAll('.neo-tab-header-button.pressed')]
+                                .find(isVisible),
+                            body         = container.querySelector('.neo-tab-body-container'),
+                            activeCard   = body && [...body.children].find(isVisible);
+
+                        if (activeHeader && isVisible(body) && !activeCard) {
+                            let sample = activeTabEmptySpans[container.id];
+
+                            activeTabEmptyIds.add(container.id);
+
+                            if (!sample) {
+                                sample = activeTabEmptySpans[container.id] = {
+                                    bodyId     : body.id,
+                                    containerId: container.id,
+                                    duration   : 0,
+                                    start      : performance.now(),
+                                    title      : activeHeader.textContent?.trim() || ''
+                                };
+                                state.activeTabEmptySamples.length < 20 && state.activeTabEmptySamples.push(sample)
+                            }
+
+                            sample.duration = Math.round((performance.now() - sample.start) * 10) / 10;
+                            state.activeTabEmptyMaxMs = Math.max(state.activeTabEmptyMaxMs, sample.duration)
+                        }
+                    });
+
+                    Object.keys(activeTabEmptySpans).forEach(containerId => {
+                        activeTabEmptyIds.has(containerId) || delete activeTabEmptySpans[containerId]
                     })
                 }
 
@@ -636,6 +672,9 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
         expect(monitor.replacementHeaderSamples, 'the journey sampled replacement tab chrome').toBeGreaterThan(0);
         expect(monitor.chromeAnimationLeakFrames,
             'fresh replacement chrome does not replay shared entry animations').toBe(0);
+        expect(monitor.activeTabEmptyMaxMs,
+            `no visible active tab exposes a sustained empty paint: ${JSON.stringify(monitor.activeTabEmptySamples)}`)
+            .toBeLessThan(17);
         expect(monitor.missingBodyFrames, 'the preserved scale body never leaves the DOM between projections').toBe(0);
         expect(monitor.blankFrames,
             `no mounted visible scale row goes blank during choreography: ${JSON.stringify(monitor.blankSamples)}`)

--- a/test/playwright/e2e/agentos/DemoCDenseWorkstationNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoCDenseWorkstationNL.spec.mjs
@@ -1,0 +1,511 @@
+import {test, expect}    from '../../fixtures.mjs';
+import {demoCTourScript} from '../../../../apps/agentos/tour/demoCDenseWorkstation.mjs';
+
+/**
+ * @summary Mounted L3 proof for Demo C's dense, living-data workstation.
+ *
+ * The unit floor owns the document/script contract. This journey drives the REAL tour button
+ * and owns what only the App Worker + DOM + Canvas Worker composition can prove: one Provider,
+ * two stable Store<Model> identities, an exact 100k renderer-rich grid, a sustained capped
+ * feed, one owner-exact overflow surface, two real rails, frame-sampled midpoint continuity,
+ * Canvas-worker pixel change, both themes, motion settlement, and identity preservation.
+ *
+ * Run: NEO_E2E_PORT=8124 npx playwright test agentos/DemoCDenseWorkstationNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+
+const heavyTitles = [
+    'Priority Alert Observatory',
+    'Resident Activity Timeline',
+    'Workspace Topology Inspector',
+    'Runtime Health Envelope',
+    'Distributed Trace Explorer',
+    'Structured Log Console',
+    'Command and Control Console',
+    'Build Pipeline Monitor',
+    'Deployment Flight Deck',
+    'Security Signal Center',
+    'Memory Core Telemetry',
+    'Workspace Files'
+];
+
+const asArray = value => Array.isArray(value) ? value : value ? [value] : [];
+
+/**
+ * @param {Object} app Neural Link fixture app handle.
+ * @param {String} workspaceId Demo C workspace id.
+ * @returns {Promise<Object>} Identity-only snapshot (counts deliberately excluded).
+ */
+const readIdentity = async (app, workspaceId) => {
+    const [providers, scalePanes, feedPanes, listedStores, workspace, securityPaneId] = await Promise.all([
+        app.findInstances({className: 'Neo.state.Provider'}, ['id']),
+        app.findInstances({className: 'AgentOS.childapps.dockdemo.view.DemoCScalePane'}, ['id', 'store.id']),
+        app.findInstances({className: 'AgentOS.childapps.dockdemo.view.DemoCFeedPane'}, ['id', 'store.id']),
+        app.listStores(),
+        app.getComponent(workspaceId, ['stateProvider.id']),
+        app.callMethod(workspaceId, 'getPaneIdentity', ['security'])
+    ]),
+        providerList = asArray(providers),
+        scaleList    = asArray(scalePanes),
+        feedList     = asArray(feedPanes),
+        stores       = asArray(listedStores?.stores ?? listedStores),
+        scaleStore   = stores.find(store => store.id?.endsWith('__scale')),
+        feedStore    = stores.find(store => store.id?.endsWith('__feed'));
+
+    return {
+        feedPaneId         : feedList[0]?.id,
+        feedStoreId        : feedStore?.id ?? feedList[0]?.properties?.['store.id'],
+        providerCount      : providerList.length,
+        providerId         : providerList[0]?.id,
+        scalePaneId        : scaleList[0]?.id,
+        scaleStoreId       : scaleStore?.id ?? scaleList[0]?.properties?.['store.id'],
+        securityPaneId,
+        workspaceProviderId: workspace['stateProvider.id']
+    }
+};
+
+/**
+ * Returns only mounted Sparkline components owned by the scale pane.
+ * @param {Object} app Neural Link fixture app handle.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<Object[]>}
+ */
+const readScaleSparklines = async (app, page) => {
+    const instances = asArray(await app.findInstances(
+        {className: 'Neo.component.Sparkline'},
+        ['id', 'mounted', 'offscreenRegistered', 'parentId', 'record.id', 'values']
+    )),
+        scaleIds = await page.evaluate(ids => ids.filter(id => {
+            const element = document.getElementById(id),
+                  rect    = element?.getBoundingClientRect();
+
+            return Boolean(element?.closest('.agentos-dockdemo-scale-pane')
+                && rect?.width > 0
+                && rect?.height > 0)
+        }), instances.map(instance => instance.id));
+
+    return instances.filter(instance => scaleIds.includes(instance.id))
+};
+
+test.describe('AgentOS Demo C — dense workstation composition', () => {
+    test.setTimeout(150000);
+    test.use({viewport: {height: 1440, width: 2560}});
+
+    test('the real tour keeps density, data, Canvas output, themes, rails, and identities live', async ({page, neuralLink}) => {
+        const pageErrors    = [],
+              runtimeErrors = [];
+
+        await page.context().exposeFunction('__recordDemoCRuntimeError', payload => runtimeErrors.push(payload));
+        await page.context().addInitScript(() => {
+            globalThis.addEventListener('error', event => {
+                globalThis.__recordDemoCRuntimeError({
+                    column : event.colno,
+                    line   : event.lineno,
+                    message: event.message,
+                    source : event.filename,
+                    type   : 'error'
+                })
+            });
+            globalThis.addEventListener('unhandledrejection', event => {
+                globalThis.__recordDemoCRuntimeError({
+                    reason: String(event.reason?.stack || event.reason?.message || event.reason),
+                    type  : 'unhandledrejection'
+                })
+            })
+        });
+
+        page.on('pageerror', error => {
+            const value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=c');
+        await page.waitForSelector('.agentos-dockdemo-tour-play', {timeout: 30000});
+        await page.waitForSelector('.neo-tab-overflow-control', {timeout: 30000});
+
+        const app        = await neuralLink.connectToApp('AgentOSDockDemo'),
+              workspaces = asArray(await app.findInstances(
+                  {className: 'AgentOS.childapps.dockdemo.view.DemoCWorkspace'},
+                  ['id']
+              )),
+              workspaceId = workspaces[0]?.id;
+
+        expect(workspaces, 'the page owns exactly one Demo C workspace').toHaveLength(1);
+        expect(workspaceId).toBeTruthy();
+
+        const beforeIdentity = await readIdentity(app, workspaceId);
+
+        expect(beforeIdentity.providerCount, 'Demo C owns one root StateProvider').toBe(1);
+        expect(beforeIdentity.workspaceProviderId, 'the workspace references that one Provider')
+            .toBe(beforeIdentity.providerId);
+        expect(beforeIdentity.scaleStoreId).toBeTruthy();
+        expect(beforeIdentity.feedStoreId).toBeTruthy();
+        expect(beforeIdentity.securityPaneId, 'the transformed heavy resident has a stable pane identity').toBeTruthy();
+        expect(beforeIdentity.scaleStoreId, 'scale and feed are distinct Store<Model> identities')
+            .not.toBe(beforeIdentity.feedStoreId);
+
+        const scaleSnapshot = await app.inspectStore(beforeIdentity.scaleStoreId, 2, 0),
+              feedBaseline  = await app.inspectStore(beforeIdentity.feedStoreId, 2, 0);
+
+        expect(scaleSnapshot.count, 'the composed scale store is exactly 100,000 rows').toBe(100000);
+        expect(scaleSnapshot.model?.className ?? scaleSnapshot.model)
+            .toBe('AgentOS.childapps.dockdemo.model.DemoCRecord');
+        expect(feedBaseline.model?.className ?? feedBaseline.model)
+            .toBe('AgentOS.childapps.dockdemo.model.DemoCRecord');
+
+        // Two source-owned rails are visible and legible at workstation geometry.
+        const railTabs = page.locator('.neo-dashboard-dock-rail-tab');
+
+        await expect(railTabs).toHaveCount(2);
+        expect((await railTabs.allTextContents()).map(value => value.trim()).sort())
+            .toEqual(['Native Edge Graph', 'Selection Inspector'].sort());
+
+        // One REAL generic overflow control, outside the draggable header collection.
+        const control = page.locator('.neo-tab-overflow-control');
+
+        await expect(control).toHaveCount(1);
+        expect(await page.evaluate(() =>
+            document.querySelector('.neo-tab-overflow-control')?.parentElement === document.body
+        ), 'the overflow control is a floating direct body child').toBe(true);
+
+        const heavyToolbar = page.locator('.neo-tab-header-toolbar').filter({hasText: 'Priority Alert Observatory'});
+
+        await expect(heavyToolbar, 'one header owns the intentionally dense twelve-tab group').toHaveCount(1);
+
+        const controlBox = await control.boundingBox(),
+              toolbarBox = await heavyToolbar.boundingBox();
+
+        expect(Math.abs((controlBox.x + controlBox.width) - (toolbarBox.x + toolbarBox.width)),
+            'overflow control right edge tracks the exact heavy toolbar').toBeLessThanOrEqual(2);
+        expect(Math.abs(controlBox.y - toolbarBox.y),
+            'overflow control top tracks the exact heavy toolbar').toBeLessThanOrEqual(2);
+
+        await control.click();
+
+        const menuItems      = page.locator('.neo-menu-list:visible .neo-list-item').filter({hasText: /\S/}),
+              visibleHeaders = heavyToolbar.locator('.neo-tab-header-button:visible');
+
+        await expect(menuItems.first(), 'the floating overflow menu becomes visible').toBeVisible({timeout: 10000});
+
+        const hiddenCount  = await menuItems.count(),
+              visibleCount = await visibleHeaders.count();
+
+        expect(hiddenCount, 'the heavy group has a real hidden partition at 2560x1440').toBeGreaterThan(0);
+        expect(visibleCount, 'the heavy group keeps at least one direct tab').toBeGreaterThan(0);
+        expect(hiddenCount + visibleCount, 'visible + hidden counts cover the twelve-tab owner').toBe(12);
+
+        const normalize = values => values.map(value => value.trim()).filter(Boolean),
+              partition = [
+                  ...normalize(await visibleHeaders.allTextContents()),
+                  ...normalize(await menuItems.allTextContents())
+              ];
+
+        expect(partition.sort(), 'visible + hidden is the exact heavy resident set')
+            .toEqual([...heavyTitles].sort());
+
+        const memoryItem = menuItems.filter({hasText: 'Memory Core Telemetry'});
+
+        await expect(memoryItem).toHaveCount(1);
+        await memoryItem.click();
+        await expect(page.locator('.neo-tab-header-button.pressed:visible')
+            .filter({hasText: 'Memory Core Telemetry'}),
+        'ordinary activeIndex surfaces the selected hidden resident').toHaveCount(1);
+
+        // Owner-scoped Canvas proof: disable autonomous animation, then require this exact
+        // scale Sparkline's Canvas-worker pixels and values to change after a record mutation.
+        await expect.poll(async () => (await readScaleSparklines(app, page))
+            .filter(entry => entry.properties?.offscreenRegistered).length, {
+            message  : 'the visible scale pool registers into the Canvas Worker',
+            timeout  : 10000,
+            intervals: [100, 250]
+        }).toBeGreaterThan(0);
+
+        const scaleSparklinesBefore = await readScaleSparklines(app, page),
+              pulseTarget           = scaleSparklinesBefore.find(entry => entry.properties?.offscreenRegistered),
+              domIdentityIds        = {
+                  canvas   : pulseTarget.id,
+                  feedPane : beforeIdentity.feedPaneId,
+                  scalePane: beforeIdentity.scalePaneId
+              };
+
+        expect(await page.evaluate(ids => {
+            const entries = Object.entries(ids);
+
+            globalThis.__demoCDomIdentity = Object.fromEntries(
+                entries.map(([key, id]) => [key, document.getElementById(id)])
+            );
+            globalThis.__demoCDomIdentity.scaleBody = document.querySelector(
+                '.agentos-dockdemo-scale-pane .neo-grid-body'
+            );
+
+            return Object.values(globalThis.__demoCDomIdentity).every(Boolean)
+        }, domIdentityIds), 'all permanence targets start as mounted DOM nodes').toBe(true);
+
+        for (const sparkline of scaleSparklinesBefore) {
+            await app.setProperties(sparkline.id, {usePulse: false, useTransition: false})
+        }
+
+        await page.waitForTimeout(150);
+
+        const targetCanvas = page.locator(`[id="${pulseTarget.id}"]`),
+              beforePixels = (await targetCanvas.screenshot()).toString('base64'),
+              beforeValues = pulseTarget.properties.values,
+              pulseReceipt = await app.callMethod(workspaceId, 'pulseScaleSparkline', [pulseTarget.id]);
+
+        expect(pulseReceipt.componentId).toBe(pulseTarget.id);
+        expect(pulseReceipt.recordId).toBeTruthy();
+        await expect.poll(async () => (await targetCanvas.screenshot()).toString('base64'), {
+            message  : 'the exact scale canvas changes after its worker receives new data',
+            timeout  : 10000,
+            intervals: [100, 250]
+        }).not.toBe(beforePixels);
+
+        const pulseTargetAfter = (await readScaleSparklines(app, page))
+            .find(entry => entry.id === pulseTarget.id);
+
+        expect(pulseTargetAfter.properties.values).not.toEqual(beforeValues);
+
+        // Frame-sample the ACTUAL screenplay path. A missing scale body is itself a blank
+        // frame; when mounted, every visible row must stay populated.
+        await page.evaluate(identity => {
+            const state = globalThis.__demoCMonitor = {
+                blankSamples                  : [],
+                blankFrames                   : 0,
+                done                          : false,
+                flipSamples                   : 0,
+                midpointSeen                  : false,
+                missingBodyFrames             : 0,
+                overflowControlCounts         : {},
+                overflowControlDuplicateFrames: 0,
+                palettes                      : [],
+                railMismatchFrames            : 0,
+                sampledFrames                 : 0,
+                securityCaptured              : false,
+                securityMissingFrames         : 0,
+                securityReplacementFrames     : 0
+            };
+            let securityNode = null;
+
+            const tick = () => {
+                const isVisible = node => {
+                    const style = getComputedStyle(node);
+
+                    return node.getClientRects().length > 0
+                        && style.display !== 'none'
+                        && style.opacity !== '0'
+                        && style.visibility !== 'hidden'
+                };
+
+                const root         = document.querySelector('.agentos-dockdemo-workspace-c'),
+                      body         = document.querySelector('.agentos-dockdemo-scale-pane .neo-grid-body'),
+                      railTabCount = [...document.querySelectorAll('.neo-dashboard-dock-rail-tab')]
+                          .filter(isVisible).length,
+                      overflowControlCount = [...document.querySelectorAll('.neo-tab-overflow-control')]
+                          .filter(isVisible).length,
+                      currentSecurityNode = document.getElementById(identity.securityPaneId);
+
+                railTabCount === 2 || state.railMismatchFrames++;
+                state.overflowControlCounts[overflowControlCount]
+                    = (state.overflowControlCounts[overflowControlCount] || 0) + 1;
+                overflowControlCount > 1 && state.overflowControlDuplicateFrames++;
+
+                if (currentSecurityNode) {
+                    if (!securityNode) {
+                        securityNode = currentSecurityNode;
+                        state.securityCaptured = true
+                    } else if (currentSecurityNode !== securityNode) {
+                        state.securityReplacementFrames++
+                    }
+                } else if (state.securityCaptured) {
+                    state.securityMissingFrames++
+                }
+
+                if (root) {
+                    const palette = getComputedStyle(root).backgroundColor;
+
+                    state.palettes.includes(palette) || state.palettes.push(palette);
+
+                    if ([...root.querySelectorAll('[class*="agentos-dockdemo-pane-"]')]
+                        .some(element => getComputedStyle(element).transform !== 'none')) {
+                        state.flipSamples++
+                    }
+                }
+
+                if (root && !body) {
+                    state.missingBodyFrames++
+                } else if (body) {
+                    const
+                        wrapper     = body.closest('.neo-grid-view'),
+                        wrapperRect = wrapper?.getBoundingClientRect(),
+                        rows        = [...body.querySelectorAll('.neo-grid-row')].filter(element => {
+                            const rect = element.getBoundingClientRect();
+
+                            return rect.height > 0 && rect.width > 0
+                        });
+
+                    if (wrapperRect?.height > 0 && wrapperRect.width > 0) {
+                        const
+                            rowRects    = rows.map(element => element.getBoundingClientRect()),
+                            rowsTop     = rowRects.length ? Math.min(...rowRects.map(rect => rect.top)) : 0,
+                            rowsBottom  = rowRects.length ? Math.max(...rowRects.map(rect => rect.bottom)) : 0,
+                            visibleRows = rows.filter((element, index) => {
+                                const rect = rowRects[index];
+
+                                return rect.bottom > wrapperRect.top && rect.top < wrapperRect.bottom
+                            }),
+                            texts      = visibleRows.map(element => element.textContent?.trim() || ''),
+                            isBlank    = rows.length === 0
+                                || rowsBottom < wrapperRect.top
+                                || rowsTop > wrapperRect.bottom
+                                || rowsTop - wrapperRect.top > 100
+                                || wrapperRect.bottom - rowsBottom > 100
+                                || texts.some(text => !text);
+
+                        state.sampledFrames++;
+                        state.midpointSeen ||= texts.some(text => /^500\d{2}/.test(text));
+
+                        if (isBlank) {
+                            state.blankFrames++;
+                            state.blankSamples.length < 20 && state.blankSamples.push({
+                                bottomGap    : Math.round(wrapperRect.bottom - rowsBottom),
+                                rowCount     : rows.length,
+                                rowsBottom,
+                                rowsTop,
+                                time         : Math.round(performance.now()),
+                                topGap       : Math.round(rowsTop - wrapperRect.top),
+                                visibleRows  : visibleRows.length,
+                                wrapperBottom: Math.round(wrapperRect.bottom),
+                                wrapperTop   : Math.round(wrapperRect.top)
+                            })
+                        }
+                    }
+                }
+
+                state.done || requestAnimationFrame(tick)
+            };
+
+            requestAnimationFrame(tick)
+        }, beforeIdentity);
+
+        await page.click('.agentos-dockdemo-tour-play');
+        await expect.poll(async () => Boolean(await app.callMethod(workspaceId, 'getTourReceipt')), {
+            message  : 'the native tour button settles document and surface tiers',
+            timeout  : 30000,
+            intervals: [100, 250]
+        }).toBe(true);
+
+        const tourReceipt        = await app.callMethod(workspaceId, 'getTourReceipt'),
+              canvasFailureState = tourReceipt.completed ? [] : await readScaleSparklines(app, page),
+              monitor            = await page.evaluate(async () => {
+                  globalThis.__demoCMonitor.done = true;
+                  await new Promise(resolve => requestAnimationFrame(resolve));
+                  return globalThis.__demoCMonitor
+              });
+
+        expect(tourReceipt.completed,
+            `tour errors: ${JSON.stringify(tourReceipt.errors)}; visible Canvas state: ${JSON.stringify(canvasFailureState)}`)
+            .toBe(true);
+        expect(tourReceipt.errors).toEqual([]);
+        expect(tourReceipt.cueReceipts.map(entry => entry.cue.type))
+            .toEqual(['overflow', 'scroll', 'canvas-update', 'theme', 'theme']);
+        expect(tourReceipt.cueReceipts.find(entry => entry.cue.type === 'overflow').receipt)
+            .toMatchObject({activatedItemId: 'security'});
+        expect(tourReceipt.cueReceipts.find(entry => entry.cue.type === 'overflow').receipt.menuItemCount)
+            .toBeGreaterThan(0);
+        expect(tourReceipt.cueReceipts.find(entry => entry.cue.type === 'canvas-update').receipt.componentId)
+            .toBeTruthy();
+        expect(tourReceipt.cueReceipts.filter(entry => entry.cue.type === 'theme').map(entry => entry.receipt))
+            .toEqual(['neo-theme-neo-light', 'neo-theme-neo-dark']);
+        expect(tourReceipt.feed.configuredRate, 'the declared producer cadence is 10 records/sec').toBe(10);
+        expect(tourReceipt.feed.batches, 'many coalesced batches land across the real tour').toBeGreaterThanOrEqual(10);
+        expect(tourReceipt.feed.produced, 'every observed batch produces exactly five records')
+            .toBe(tourReceipt.feed.batches * 5);
+        expect(tourReceipt.feed.endCount, 'visible feed growth is exact until the declared cap')
+            .toBe(Math.min(
+                tourReceipt.feed.maxRecords,
+                tourReceipt.feed.startCount + tourReceipt.feed.produced
+            ));
+        expect(tourReceipt.feed.growth, 'the receipt reports the cap-aware visible delta')
+            .toBe(tourReceipt.feed.endCount - tourReceipt.feed.startCount);
+        expect(tourReceipt.document.nodes['heavy-tabs'].activeItemId).toBe('security');
+        expect(tourReceipt.document.nodes['heavy-tabs'].items).toEqual([
+            'alerts', 'activity', 'topology', 'runtime', 'traces', 'logs',
+            'console', 'builds', 'deploys', 'memory', 'files', 'security'
+        ]);
+
+        expect(monitor.sampledFrames).toBeGreaterThan(10);
+        expect(monitor.midpointSeen, 'rAF sampling observes the live midpoint scroll').toBe(true);
+        expect(monitor.missingBodyFrames, 'the preserved scale body never leaves the DOM between projections').toBe(0);
+        expect(monitor.blankFrames,
+            `no mounted visible scale row goes blank during choreography: ${JSON.stringify(monitor.blankSamples)}`)
+            .toBe(0);
+        expect(monitor.railMismatchFrames, 'both real rails remain present through every sampled frame').toBe(0);
+        expect(monitor.overflowControlDuplicateFrames,
+            `the projection never leaks duplicate overflow controls: ${JSON.stringify(monitor.overflowControlCounts)}`)
+            .toBe(0);
+        expect(monitor.overflowControlCounts['1'], 'the real overflow state is observed').toBeGreaterThan(0);
+        expect(monitor.securityCaptured, 'the overflow cue mounts Security before its structural move').toBe(true);
+        expect(monitor.securityMissingFrames, 'the active Security pane never leaves the DOM after capture').toBe(0);
+        expect(monitor.securityReplacementFrames, 'Security keeps the same DOM node across split and return').toBe(0);
+        expect(monitor.palettes.length, 'the actual tour materially renders both theme palettes').toBeGreaterThanOrEqual(2);
+        expect(monitor.flipSamples, 'committed transformations emit visible FLIP motion').toBeGreaterThan(0);
+        await expect(page.locator('.agentos-dockdemo-workspace-c'))
+            .not.toHaveClass(/neo-dashboard-dock-animating/);
+        await expect(page.locator('.neo-tab-overflow-control:visible'),
+            'the returned twelve-tab group restores its one real overflow control').toHaveCount(1);
+
+        // Two fresh document-tier spec runs remain byte-identical; the real-button receipt above
+        // is the separate authority for asynchronous surface cues.
+        const run1 = await app.callMethod(workspaceId, 'runTourSpec', []),
+              run2 = await app.callMethod(workspaceId, 'runTourSpec', []);
+
+        expect(run1.completed, `run 1 errors: ${JSON.stringify(run1.errors)}`).toBe(true);
+        expect(run1.errors).toEqual([]);
+        expect(run1.log).toHaveLength(demoCTourScript.scenes.flatMap(scene => scene.steps).length);
+        expect(run2.completed, `run 2 errors: ${JSON.stringify(run2.errors)}`).toBe(true);
+        expect(run2.errors).toEqual([]);
+        expect(run2.log, 'both timestamp-free document runs are deterministic').toEqual(run1.log);
+
+        const stableScaleComponentIds = [
+            pulseTarget.id,
+            tourReceipt.cueReceipts.find(entry => entry.cue.type === 'canvas-update').receipt.componentId
+        ];
+
+        await expect.poll(async () => {
+            const current    = await readScaleSparklines(app, page),
+                  currentIds = current.map(entry => entry.id);
+
+            return current.length > 0
+                && stableScaleComponentIds.every(id => currentIds.includes(id))
+                && current.every(entry => entry.properties?.offscreenRegistered)
+        }, {
+            message  : 'stable Canvas identities survive while the viewport-sized pool remains registered',
+            timeout  : 5000,
+            intervals: [50, 100]
+        }).toBe(true);
+
+        const afterIdentity        = await readIdentity(app, workspaceId),
+              scaleSparklinesAfter = await readScaleSparklines(app, page);
+
+        expect(afterIdentity, 'workspace, heavy pane, data panes, Provider, and stores survive all transformations')
+            .toEqual(beforeIdentity);
+        expect(scaleSparklinesAfter.length, 'the viewport-bounded scale component pool remains live')
+            .toBeGreaterThan(0);
+        expect(stableScaleComponentIds.every(id => scaleSparklinesAfter.some(entry => entry.id === id)),
+            'the exact components exercised before and during transformation preserve identity').toBe(true);
+        const domIdentityState = await page.evaluate(ids => ({
+            ...Object.fromEntries(Object.entries(ids).map(([key, id]) => [
+                key,
+                globalThis.__demoCDomIdentity?.[key] === document.getElementById(id)
+            ])),
+            scaleBody: globalThis.__demoCDomIdentity?.scaleBody
+                === document.querySelector('.agentos-dockdemo-scale-pane .neo-grid-body')
+        }), domIdentityIds);
+
+        expect(domIdentityState, 'the exact always-mounted pane, body, and Canvas DOM nodes survive every projection')
+            .toEqual({canvas: true, feedPane: true, scaleBody: true, scalePane: true});
+        expect(scaleSparklinesAfter.every(entry => entry.properties?.offscreenRegistered),
+            'the preserved scale Canvas pool is registered after the final projection').toBe(true);
+        expect(runtimeErrors, 'no global error or unhandled rejection across the journey').toEqual([]);
+        expect(pageErrors, 'no Playwright pageerror across the journey').toEqual([])
+    })
+});

--- a/test/playwright/e2e/agentos/DemoCDenseWorkstationNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoCDenseWorkstationNL.spec.mjs
@@ -308,6 +308,76 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
         expectDevIndexSparklineFit(await readSparklineGeometry(page, '.agentos-dockdemo-scale-pane'));
         expectDevIndexSparklineFit(await readSparklineGeometry(page, '.agentos-dockdemo-feed-pane'));
 
+        const gridLayout = await page.evaluate(() => {
+            const
+                rect = element => {
+                    const value = element?.getBoundingClientRect();
+
+                    return value && {
+                        bottom: value.bottom,
+                        left  : value.left,
+                        right : value.right,
+                        top   : value.top,
+                        width : value.width
+                    }
+                },
+                readHeaders = selector => [...document.querySelectorAll(`${selector} .neo-grid-header-button`)]
+                    .map(element => {
+                        const
+                            glyph      = element.querySelector('.neo-button-glyph'),
+                            label      = element.querySelector('.neo-button-text'),
+                            glyphStyle = getComputedStyle(glyph),
+                            style      = getComputedStyle(element);
+
+                        return {
+                            button: rect(element),
+                            glyph : rect(glyph),
+                            label : rect(label),
+                            style : {
+                                flexDirection : style.flexDirection,
+                                glyphPosition : glyphStyle.position,
+                                justifyContent: style.justifyContent,
+                                paddingLeft   : style.paddingLeft
+                            },
+                            text: label?.textContent?.trim()
+                        }
+                    }),
+                scaleHeaders = readHeaders('.agentos-dockdemo-scale-pane'),
+                feedHeaders  = readHeaders('.agentos-dockdemo-feed-pane'),
+                heavyHeader  = [...document.querySelectorAll('.neo-tab-header-toolbar')]
+                    .find(element => element.textContent?.includes('Priority Alert Observatory')),
+                scaleToolbar = document.querySelector('.agentos-dockdemo-scale-pane .neo-grid-header-toolbar');
+
+            return {
+                feedHeaders,
+                heavyWidth        : rect(heavyHeader?.closest('.neo-tab-container'))?.width,
+                leftBandWidth     : rect(document.querySelector('.neo-dashboard-dock-edge-band-left'))?.width,
+                rightBandWidth    : rect(document.querySelector('.neo-dashboard-dock-edge-band-right'))?.width,
+                scaleHeaders,
+                scaleTrailingSpace: rect(scaleToolbar)?.right - scaleHeaders.at(-1)?.button.right
+            }
+        });
+
+        for (const header of [...gridLayout.scaleHeaders, ...gridLayout.feedHeaders]) {
+            expect(header.label.left - header.button.left,
+                `${header.text} header label is physically left-aligned: ${JSON.stringify(header)}`)
+                .toBeLessThanOrEqual(16)
+        }
+
+        const feedWidths = Object.fromEntries(gridLayout.feedHeaders.map(header => [header.text, header.button.width]));
+
+        expect(gridLayout.scaleTrailingSpace,
+            'the scale grid keeps breathing room without wasting a second panel width').toBeGreaterThanOrEqual(0);
+        expect(gridLayout.scaleTrailingSpace).toBeLessThanOrEqual(140);
+        expect(gridLayout.heavyWidth, 'the dense heavy-tab panel is no longer cramped by the scale grid')
+            .toBeGreaterThanOrEqual(700);
+        expect(gridLayout.leftBandWidth).toBeCloseTo(260, 0);
+        expect(gridLayout.rightBandWidth, 'the stacked evidence cards get more room than the queue card')
+            .toBeCloseTo(320, 0);
+        expect(feedWidths.Event / feedWidths.State,
+            'Event remains the narrative column without consuming nearly the whole feed').toBeLessThanOrEqual(2.1);
+        expect(feedWidths.Event / feedWidths.Value).toBeLessThanOrEqual(2.1);
+
         // Two source-owned rails are visible and legible at workstation geometry.
         const railTabs = page.locator('.neo-dashboard-dock-rail-tab');
 
@@ -454,7 +524,7 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
                 securityReplacementFrames     : 0
             };
             const activeTabEmptySpans = {};
-            let securityNode = null;
+            let   securityNode        = null;
 
             const tick = () => {
                 const isVisible = node => {
@@ -477,8 +547,8 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
                 if (root) {
                     const
                         activeTabEmptyIds = new Set(),
-                        pipCount = root.querySelectorAll('.agentos-dockdemo-pip-done').length,
-                        previous = state.pipCounts.at(-1);
+                        pipCount          = root.querySelectorAll('.agentos-dockdemo-pip-done').length,
+                        previous          = state.pipCounts.at(-1);
 
                     if (pipCount !== previous) {
                         pipCount < previous && state.pipRegressionFrames++;

--- a/test/playwright/e2e/agentos/DemoCDenseWorkstationNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoCDenseWorkstationNL.spec.mjs
@@ -8,7 +8,8 @@ import {demoCTourScript} from '../../../../apps/agentos/tour/demoCDenseWorkstati
  * and owns what only the App Worker + DOM + Canvas Worker composition can prove: one Provider,
  * two stable Store<Model> identities, an exact 100k renderer-rich grid, a sustained capped
  * feed, one owner-exact overflow surface, two real rails, frame-sampled midpoint continuity,
- * Canvas-worker pixel change, both themes, motion settlement, and identity preservation.
+ * Canvas-worker pixel change, DevIndex-sized chart geometry, honest progress paints, both
+ * themes, replacement-chrome motion containment, and identity preservation.
  *
  * Run: NEO_E2E_PORT=8124 npx playwright test agentos/DemoCDenseWorkstationNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
@@ -86,6 +87,72 @@ const readScaleSparklines = async (app, page) => {
     return instances.filter(instance => scaleIds.includes(instance.id))
 };
 
+/**
+ * Reads the first visible Sparkline's cell/content geometry from one data pane.
+ * @param {import('@playwright/test').Page} page
+ * @param {String} paneSelector
+ * @returns {Promise<Object>}
+ */
+const readSparklineGeometry = (page, paneSelector) => page.evaluate(selector => {
+    const
+        wrapper = [...document.querySelectorAll(`${selector} .neo-sparkline-wrapper`)]
+            .find(element => element.getClientRects().length > 0),
+        canvas  = wrapper?.querySelector('.neo-sparkline-canvas'),
+        cell    = wrapper?.closest('.neo-grid-cell'),
+        row     = wrapper?.closest('.neo-grid-row');
+
+    if (!wrapper || !canvas || !cell || !row) return null;
+
+    const
+        canvasRect  = canvas.getBoundingClientRect(),
+        cellRect    = cell.getBoundingClientRect(),
+        rowRect     = row.getBoundingClientRect(),
+        style       = getComputedStyle(cell),
+        wrapperRect = wrapper.getBoundingClientRect(),
+        number      = property => Number.parseFloat(style[property]) || 0,
+        contentBox  = {
+            bottom: cellRect.bottom - number('borderBottomWidth') - number('paddingBottom'),
+            height: cellRect.height
+                - number('borderTopWidth') - number('borderBottomWidth')
+                - number('paddingTop') - number('paddingBottom'),
+            left : cellRect.left + number('borderLeftWidth') + number('paddingLeft'),
+            top  : cellRect.top + number('borderTopWidth') + number('paddingTop'),
+            width: cellRect.width
+                - number('borderLeftWidth') - number('borderRightWidth')
+                - number('paddingLeft') - number('paddingRight')
+        };
+
+    return {
+        canvas : {bottom: canvasRect.bottom, height: canvasRect.height, left: canvasRect.left, top: canvasRect.top, width: canvasRect.width},
+        cell   : {height: cellRect.height, width: cellRect.width},
+        content: contentBox,
+        row    : {height: rowRect.height},
+        wrapper: {bottom: wrapperRect.bottom, height: wrapperRect.height, left: wrapperRect.left, top: wrapperRect.top, width: wrapperRect.width}
+    }
+}, paneSelector);
+
+/**
+ * @param {Object} geometry
+ */
+const expectDevIndexSparklineFit = geometry => {
+    expect(geometry).toBeTruthy();
+    expect(Math.abs(geometry.cell.width - 160), 'Sparkline keeps the DevIndex-sized column').toBeLessThanOrEqual(1);
+    expect(Math.abs(geometry.row.height - 50), 'Sparkline keeps the DevIndex row height').toBeLessThanOrEqual(1);
+    expect(
+        Math.abs(geometry.wrapper.width - geometry.content.width),
+        `Sparkline wrapper fills the cell content box: ${JSON.stringify(geometry)}`
+    ).toBeLessThanOrEqual(1);
+    expect(
+        Math.abs(geometry.wrapper.height - geometry.content.height),
+        `Sparkline wrapper fills the row content box: ${JSON.stringify(geometry)}`
+    ).toBeLessThanOrEqual(1);
+    expect(Math.abs(geometry.canvas.width - geometry.wrapper.width)).toBeLessThanOrEqual(1);
+    expect(Math.abs(geometry.canvas.height - geometry.wrapper.height)).toBeLessThanOrEqual(1);
+    expect(geometry.canvas.left).toBeGreaterThanOrEqual(geometry.content.left - 1);
+    expect(geometry.canvas.top).toBeGreaterThanOrEqual(geometry.content.top - 1);
+    expect(geometry.canvas.bottom).toBeLessThanOrEqual(geometry.content.bottom + 1)
+};
+
 test.describe('AgentOS Demo C — dense workstation composition', () => {
     test.setTimeout(150000);
     test.use({viewport: {height: 1440, width: 2560}});
@@ -151,6 +218,95 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
             .toBe('AgentOS.childapps.dockdemo.model.DemoCRecord');
         expect(feedBaseline.model?.className ?? feedBaseline.model)
             .toBe('AgentOS.childapps.dockdemo.model.DemoCRecord');
+
+        const
+            root        = page.locator('.agentos-dockdemo-workspace-c'),
+            tourButton  = page.locator('.agentos-dockdemo-tour-play'),
+            themeToggle = page.locator('.agentos-dockdemo-theme-button');
+
+        await expect(tourButton).toHaveText('Start dense tour');
+        await expect(themeToggle, 'one action-labelled theme toggle replaces two mode buttons').toHaveCount(1);
+        await expect(themeToggle).toHaveText('Light mode');
+
+        const headerGeometry = await page.evaluate(() => {
+            const
+                playElement     = document.querySelector('.agentos-dockdemo-tour-play'),
+                captionElement  = document.querySelector('.agentos-dockdemo-tour-caption'),
+                progressElement = document.querySelector('.agentos-dockdemo-tour-pips'),
+                themeElement    = document.querySelector('.agentos-dockdemo-theme-button'),
+                play            = playElement?.getBoundingClientRect(),
+                caption         = captionElement?.getBoundingClientRect(),
+                progress        = progressElement?.getBoundingClientRect(),
+                theme           = themeElement?.getBoundingClientRect();
+
+            return {
+                captionLeft         : caption?.left,
+                captionPaddingLeft  : parseFloat(getComputedStyle(captionElement).paddingLeft),
+                playRight           : play?.right,
+                progressPaddingRight: parseFloat(getComputedStyle(progressElement).paddingRight),
+                progressRight       : progress?.right,
+                themeLeft           : theme?.left
+            }
+        });
+
+        expect(headerGeometry.captionLeft - headerGeometry.playRight, 'tour action and story boxes never overlap')
+            .toBeGreaterThanOrEqual(0);
+        expect(headerGeometry.captionPaddingLeft, 'tour action and visible story copy have a deliberate gap')
+            .toBeGreaterThanOrEqual(10);
+        expect(headerGeometry.themeLeft - headerGeometry.progressRight, 'story/progress and theme action boxes never overlap')
+            .toBeGreaterThanOrEqual(0);
+        expect(headerGeometry.progressPaddingRight, 'visible progress and theme action form separate zones')
+            .toBeGreaterThanOrEqual(10);
+
+        const initialTourBackground = await tourButton.evaluate(element => getComputedStyle(element).backgroundColor);
+
+        await tourButton.hover();
+        const hoverTourBackground = await tourButton.evaluate(element => getComputedStyle(element).backgroundColor);
+
+        expect(initialTourBackground).not.toBe('rgb(67, 93, 177)');
+        expect(hoverTourBackground, 'hover remains in the AgentOS signal palette').not.toBe('rgb(67, 93, 177)');
+
+        await themeToggle.click();
+        await expect(root).toHaveClass(/neo-theme-neo-light/);
+        await expect(themeToggle).toHaveText('Dark mode');
+
+        const lightChrome = await page.evaluate(() => {
+            const
+                gridHeader  = document.querySelector('.agentos-dockdemo-scale-pane .neo-grid-header-button'),
+                overflow    = document.querySelector('.neo-tab-overflow-control'),
+                rowAction   = document.querySelector('.agentos-dockdemo-row-action'),
+                rippleToken = element => getComputedStyle(element)
+                    .getPropertyValue('--button-ripple-background-color').trim().toLowerCase();
+
+            return {
+                gridBackground : getComputedStyle(gridHeader).backgroundColor,
+                gridColor      : getComputedStyle(gridHeader).color,
+                overflow       : getComputedStyle(overflow).backgroundColor,
+                overflowRipple : rippleToken(overflow),
+                rowAction      : getComputedStyle(rowAction).backgroundColor,
+                rowActionBorder: getComputedStyle(rowAction).borderColor,
+                rowActionRipple: rippleToken(rowAction),
+                themeRipple    : rippleToken(document.querySelector('.agentos-dockdemo-theme-button'))
+            }
+        });
+
+        expect(lightChrome.gridBackground, 'light mode does not leak the standalone grid blue')
+            .not.toBe('rgb(93, 131, 167)');
+        expect(lightChrome.gridColor, 'light header copy is not forced to generic white').not.toBe('rgb(255, 255, 255)');
+        expect(lightChrome.overflow, 'overflow control belongs to the AgentOS palette').not.toBe('rgb(67, 93, 177)');
+        expect(lightChrome.overflowRipple).not.toBe('#8ba6ff');
+        expect(lightChrome.rowAction, 'row actions do not use the default primary button').not.toBe('rgb(67, 93, 177)');
+        expect(lightChrome.rowActionBorder).not.toBe('rgba(0, 0, 0, 0)');
+        expect(lightChrome.rowActionRipple).not.toBe('#8ba6ff');
+        expect(lightChrome.themeRipple, 'theme-toggle feedback stays in the AgentOS palette')
+            .not.toBe('#8ba6ff');
+
+        await themeToggle.click();
+        await expect(root).toHaveClass(/neo-theme-neo-dark/);
+        await expect(themeToggle).toHaveText('Light mode');
+
+        expectDevIndexSparklineFit(await readSparklineGeometry(page, '.agentos-dockdemo-scale-pane'));
+        expectDevIndexSparklineFit(await readSparklineGeometry(page, '.agentos-dockdemo-feed-pane'));
 
         // Two source-owned rails are visible and legible at workstation geometry.
         const railTabs = page.locator('.neo-dashboard-dock-rail-tab');
@@ -267,17 +423,29 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
         // Frame-sample the ACTUAL screenplay path. A missing scale body is itself a blank
         // frame; when mounted, every visible row must stay populated.
         await page.evaluate(identity => {
+            const
+                root             = document.querySelector('.agentos-dockdemo-workspace-c'),
+                initialPipCount  = root?.querySelectorAll('.agentos-dockdemo-pip-done').length || 0,
+                initialHeaderIds = [...root?.querySelectorAll('.neo-tab-header-toolbar') || []]
+                    .map(element => element.id);
+
             const state = globalThis.__demoCMonitor = {
                 blankSamples                  : [],
                 blankFrames                   : 0,
+                chromeAnimationLeakFrames     : 0,
                 done                          : false,
                 flipSamples                   : 0,
+                initialHeaderIds,
                 midpointSeen                  : false,
                 missingBodyFrames             : 0,
                 overflowControlCounts         : {},
                 overflowControlDuplicateFrames: 0,
                 palettes                      : [],
+                pipCounts                     : [initialPipCount],
+                pipRegressionFrames           : 0,
                 railMismatchFrames            : 0,
+                replacementHeaderBirth        : {},
+                replacementHeaderSamples      : 0,
                 sampledFrames                 : 0,
                 securityCaptured              : false,
                 securityMissingFrames         : 0,
@@ -302,6 +470,34 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
                       overflowControlCount = [...document.querySelectorAll('.neo-tab-overflow-control')]
                           .filter(isVisible).length,
                       currentSecurityNode = document.getElementById(identity.securityPaneId);
+
+                if (root) {
+                    const
+                        pipCount = root.querySelectorAll('.agentos-dockdemo-pip-done').length,
+                        previous = state.pipCounts.at(-1);
+
+                    if (pipCount !== previous) {
+                        pipCount < previous && state.pipRegressionFrames++;
+                        state.pipCounts.push(pipCount)
+                    }
+
+                    [...root.querySelectorAll('.neo-tab-header-toolbar')].filter(isVisible).forEach(toolbar => {
+                        if (!state.initialHeaderIds.includes(toolbar.id)) {
+                            state.replacementHeaderBirth[toolbar.id] ??= performance.now();
+
+                            if (performance.now() - state.replacementHeaderBirth[toolbar.id] <= 320) {
+                                state.replacementHeaderSamples++;
+
+                                const hasRunningEntryEffect = toolbar.getAnimations({subtree: true}).some(animation =>
+                                    animation.playState === 'running'
+                                    && Number(animation.effect?.getTiming().duration) > 0
+                                );
+
+                                hasRunningEntryEffect && state.chromeAnimationLeakFrames++
+                            }
+                        }
+                    })
+                }
 
                 railTabCount === 2 || state.railMismatchFrames++;
                 state.overflowControlCounts[overflowControlCount]
@@ -434,6 +630,12 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
 
         expect(monitor.sampledFrames).toBeGreaterThan(10);
         expect(monitor.midpointSeen, 'rAF sampling observes the live midpoint scroll').toBe(true);
+        expect(monitor.pipCounts, 'every settled beat paints once, in order')
+            .toEqual(Array.from({length: demoCTourScript.scenes.flatMap(scene => scene.steps).length + 1}, (_, index) => index));
+        expect(monitor.pipRegressionFrames, 'progress never fills early and jumps backward').toBe(0);
+        expect(monitor.replacementHeaderSamples, 'the journey sampled replacement tab chrome').toBeGreaterThan(0);
+        expect(monitor.chromeAnimationLeakFrames,
+            'fresh replacement chrome does not replay shared entry animations').toBe(0);
         expect(monitor.missingBodyFrames, 'the preserved scale body never leaves the DOM between projections').toBe(0);
         expect(monitor.blankFrames,
             `no mounted visible scale row goes blank during choreography: ${JSON.stringify(monitor.blankSamples)}`)
@@ -505,6 +707,8 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
             .toEqual({canvas: true, feedPane: true, scaleBody: true, scalePane: true});
         expect(scaleSparklinesAfter.every(entry => entry.properties?.offscreenRegistered),
             'the preserved scale Canvas pool is registered after the final projection').toBe(true);
+        expectDevIndexSparklineFit(await readSparklineGeometry(page, '.agentos-dockdemo-scale-pane'));
+        expectDevIndexSparklineFit(await readSparklineGeometry(page, '.agentos-dockdemo-feed-pane'));
         expect(runtimeErrors, 'no global error or unhandled rejection across the journey').toEqual([]);
         expect(pageErrors, 'no Playwright pageerror across the journey').toEqual([])
     })

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoCWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoCWorkspace.spec.mjs
@@ -10,6 +10,7 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import '../../../../../../../src/manager/Instance.mjs';
+import DemoCFeedPane  from '../../../../../../../apps/agentos/childapps/dockdemo/view/DemoCFeedPane.mjs';
 import DemoCScalePane from '../../../../../../../apps/agentos/childapps/dockdemo/view/DemoCScalePane.mjs';
 import DemoCWorkspace from '../../../../../../../apps/agentos/childapps/dockdemo/view/DemoCWorkspace.mjs';
 
@@ -23,11 +24,22 @@ import {initialDocument} from '../../../../../../../apps/agentos/tour/demoCDense
  */
 test.describe.serial('AgentOS.childapps.dockdemo.view.DemoCWorkspace', () => {
     test('renderer-rich scale columns carry unique pooling keys', () => {
-        const dataFields = DemoCScalePane.config.columns.map(column => column.dataField);
+        const
+            dataFields     = DemoCScalePane.config.columns.map(column => column.dataField),
+            feedEvent      = DemoCFeedPane.config.columns.find(column => column.dataField === 'name'),
+            feedSparkline  = DemoCFeedPane.config.columns.find(column => column.type === 'sparkline'),
+            scaleSparkline = DemoCScalePane.config.columns.find(column => column.type === 'sparkline');
 
         expect(new Set(dataFields).size).toBe(dataFields.length);
         expect(DemoCScalePane.config.body.bufferRowRange * DemoCScalePane.config.rowHeight)
-            .toBeGreaterThanOrEqual(0.28 * 1440)
+            .toBeGreaterThanOrEqual(0.28 * 1440);
+        expect(DemoCScalePane.config.rowHeight).toBe(50);
+        expect(DemoCFeedPane.config.rowHeight).toBe(50);
+        expect(scaleSparkline).toMatchObject({width: 160});
+        expect(scaleSparkline.flex).toBeUndefined();
+        expect(feedSparkline).toMatchObject({width: 160});
+        expect(feedSparkline.flex).toBeUndefined();
+        expect(feedEvent).toMatchObject({flex: 1, minWidth: 180})
     });
 
     test('provider-owned stores and cached data panes survive split + return', async () => {
@@ -46,6 +58,9 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoCWorkspace', () => {
             expect(feedStore.className).toBe('AgentOS.childapps.dockdemo.store.DemoCFeed');
             expect(scaleStore.count).toBe(100000);
             expect(scaleStore.autoInitRecords).toBe(false);
+            expect(scaleStore.items.slice(0, 20).every(record => record.trend
+                .slice(1).every((value, index) => Math.abs(value - record.trend[index]) <= 4)),
+                'synthetic Sparkline series stay bounded instead of wrapping across the full plot').toBe(true);
             expect(feedBefore).toBeGreaterThanOrEqual(25);
 
             workspace.appendFeedBatch(5);

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoCWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoCWorkspace.spec.mjs
@@ -1,0 +1,98 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DockDemoWorkspaceCTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import '../../../../../../../src/manager/Instance.mjs';
+import DemoCScalePane from '../../../../../../../apps/agentos/childapps/dockdemo/view/DemoCScalePane.mjs';
+import DemoCWorkspace from '../../../../../../../apps/agentos/childapps/dockdemo/view/DemoCWorkspace.mjs';
+
+import {initialDocument} from '../../../../../../../apps/agentos/tour/demoCDenseWorkstation.mjs';
+
+/**
+ * @summary Pins the composition choices Demo C itself owns: one provider with two stores,
+ * an exact 100k Turbo scale set, a growing capped feed, and stable pane/store identities
+ * across a reducer-driven coarse projection. Primitive grid/Canvas stress remains in its
+ * existing suites; the browser journey owns rendered continuity.
+ */
+test.describe.serial('AgentOS.childapps.dockdemo.view.DemoCWorkspace', () => {
+    test('renderer-rich scale columns carry unique pooling keys', () => {
+        const dataFields = DemoCScalePane.config.columns.map(column => column.dataField);
+
+        expect(new Set(dataFields).size).toBe(dataFields.length);
+        expect(DemoCScalePane.config.body.bufferRowRange * DemoCScalePane.config.rowHeight)
+            .toBeGreaterThanOrEqual(0.28 * 1440)
+    });
+
+    test('provider-owned stores and cached data panes survive split + return', async () => {
+        const workspace = Neo.create(DemoCWorkspace, {});
+
+        try {
+            const
+                provider   = workspace.getStateProvider(),
+                scaleStore = provider.getStore('scale'),
+                feedStore  = provider.getStore('feed'),
+                scalePane  = workspace.resolvePane('scale', initialDocument.items.scale),
+                feedPane   = workspace.resolvePane('feed', initialDocument.items.feed),
+                feedBefore = feedStore.count;
+
+            expect(scaleStore.className).toBe('AgentOS.childapps.dockdemo.store.DemoCScale');
+            expect(feedStore.className).toBe('AgentOS.childapps.dockdemo.store.DemoCFeed');
+            expect(scaleStore.count).toBe(100000);
+            expect(scaleStore.autoInitRecords).toBe(false);
+            expect(feedBefore).toBeGreaterThanOrEqual(25);
+
+            workspace.appendFeedBatch(5);
+            expect(feedStore.count).toBeGreaterThanOrEqual(feedBefore + 5);
+            expect(feedStore.count).toBeLessThanOrEqual(feedStore.maxRecords);
+
+            workspace.appendFeedBatch(600);
+            expect(feedStore.count).toBe(feedStore.maxRecords);
+            expect(feedStore.items[0].id)
+                .toBe(`feed-${String(workspace.feedSequence).padStart(8, '0')}`);
+            expect(feedStore.items.at(-1).id)
+                .toBe(`feed-${String(workspace.feedSequence - feedStore.maxRecords + 1).padStart(8, '0')}`);
+            expect(DemoCWorkspace.FEED_BATCH_SIZE * 1000 / DemoCWorkspace.FEED_INTERVAL_MS).toBe(10);
+
+            let result = workspace.applyDockZoneOperation({
+                operation   : 'splitNode',
+                itemId      : 'security',
+                targetNodeId: 'scale-tabs',
+                orientation : 'vertical',
+                edge        : 'bottom',
+                sizes       : [0.72, 0.28]
+            });
+
+            expect(result.errors).toEqual([]);
+            workspace.onDockZoneDocumentChange(result.document);
+            await workspace.refreshPromise;
+
+            result = workspace.applyDockZoneOperation({
+                operation : 'addTab',
+                itemId    : 'security',
+                tabsNodeId: 'heavy-tabs'
+            });
+
+            expect(result.errors).toEqual([]);
+            workspace.onDockZoneDocumentChange(result.document);
+            await workspace.refreshPromise;
+
+            expect(workspace.resolvePane('scale', initialDocument.items.scale)).toBe(scalePane);
+            expect(workspace.resolvePane('feed', initialDocument.items.feed)).toBe(feedPane);
+            expect(scalePane.store).toBe(scaleStore);
+            expect(feedPane.store).toBe(feedStore);
+            expect(provider.getStore('scale')).toBe(scaleStore);
+            expect(provider.getStore('feed')).toBe(feedStore);
+            expect(scalePane.isDestroyed).toBeFalsy();
+            expect(feedPane.isDestroyed).toBeFalsy()
+        } finally {
+            workspace.destroy()
+        }
+    })
+});

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoCWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoCWorkspace.spec.mjs
@@ -27,7 +27,9 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoCWorkspace', () => {
         const
             dataFields     = DemoCScalePane.config.columns.map(column => column.dataField),
             feedEvent      = DemoCFeedPane.config.columns.find(column => column.dataField === 'name'),
+            feedState      = DemoCFeedPane.config.columns.find(column => column.dataField === 'status'),
             feedSparkline  = DemoCFeedPane.config.columns.find(column => column.type === 'sparkline'),
+            feedValue      = DemoCFeedPane.config.columns.find(column => column.dataField === 'value'),
             scaleSparkline = DemoCScalePane.config.columns.find(column => column.type === 'sparkline');
 
         expect(new Set(dataFields).size).toBe(dataFields.length);
@@ -39,7 +41,12 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoCWorkspace', () => {
         expect(scaleSparkline.flex).toBeUndefined();
         expect(feedSparkline).toMatchObject({width: 160});
         expect(feedSparkline.flex).toBeUndefined();
-        expect(feedEvent).toMatchObject({flex: 1, minWidth: 180})
+        expect(DemoCScalePane.config.columnDefaults.cellAlign).toBe('left');
+        expect(DemoCFeedPane.config.columnDefaults.cellAlign).toBe('left');
+        expect(feedEvent).toMatchObject({flex: 2, minWidth: 280});
+        expect(feedState).toMatchObject({flex: 1, minWidth: 140});
+        expect(feedValue).toMatchObject({flex: 1, minWidth: 120});
+        expect(initialDocument.nodes['split-main'].sizes).toEqual([0.6, 0.4])
     });
 
     test('provider-owned stores and cached data panes survive split + return', async () => {

--- a/test/playwright/unit/apps/agentos/tour/demoCDenseWorkstation.spec.mjs
+++ b/test/playwright/unit/apps/agentos/tour/demoCDenseWorkstation.spec.mjs
@@ -1,0 +1,107 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DemoCDenseWorkstationTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import DockService    from '../../../../../../src/ai/client/DockService.mjs';
+import DockZoneModel  from '../../../../../../src/dashboard/DockZoneModel.mjs';
+import TourRunner     from '../../../../../../src/ai/client/TourRunner.mjs';
+
+import {validateTourScript}               from '../../../../../../src/ai/client/tourScript.mjs';
+import {demoCTourScript, initialDocument} from '../../../../../../apps/agentos/tour/demoCDenseWorkstation.mjs';
+
+/**
+ * @summary Verifies Demo C as executable content: exact live-item density, only shipped
+ * operation names, fail-closed validation, green real-reducer execution, and deterministic
+ * document logs. Grid/overflow/Canvas runtime behavior remains the composed E2E's authority.
+ */
+test.describe.serial('apps/agentos/tour/demoCDenseWorkstation', () => {
+    let originalGetComponent, runner, service;
+
+    /**
+     * @returns {Neo.ai.client.TourRunner}
+     */
+    function createRunner() {
+        const holder = {dockZoneDocument: DockZoneModel.clone(initialDocument), id: 'demo-c-stage'};
+
+        Neo.getComponent = () => holder;
+        runner = Neo.create(TourRunner, {
+            componentId: holder.id,
+            dockService: service,
+            mode       : 'spec',
+            script     : demoCTourScript
+        });
+
+        return runner
+    }
+
+    test.beforeEach(() => {
+        originalGetComponent = Neo.getComponent;
+        service              = Neo.create(DockService, {})
+    });
+
+    test.afterEach(() => {
+        Neo.getComponent = originalGetComponent;
+        runner?.destroy?.();
+        runner = null;
+        service.destroy?.()
+    });
+
+    test('the body is self-contained: 20 placed items, reviewed cues, no invented operation', () => {
+        const
+            {valid, errors} = validateTourScript(demoCTourScript, {operations: DockZoneModel.operations}),
+            placed          = Object.values(initialDocument.nodes)
+                .filter(node => node.type === 'tabs')
+                .flatMap(node => node.items),
+            cues            = demoCTourScript.scenes.flatMap(scene => scene.steps)
+                .filter(step => step.cue)
+                .map(step => step.cue.type),
+            operations      = demoCTourScript.scenes.flatMap(scene => scene.steps)
+                .filter(step => step.type === 'op')
+                .map(step => step.descriptor.operation);
+
+        expect(valid).toBe(true);
+        expect(errors).toEqual([]);
+        expect(Object.keys(initialDocument.items)).toHaveLength(20);
+        expect(new Set(placed).size).toBe(20);
+        expect([...placed].sort()).toEqual(Object.keys(initialDocument.items).sort());
+        expect(Object.entries(initialDocument.items)
+            .filter(([, item]) => item.autoHidden === true)
+            .map(([itemId]) => itemId)).toEqual(['graph', 'inspector']);
+        expect(cues).toEqual(['overflow', 'scroll', 'canvas-update', 'theme', 'theme']);
+        expect(demoCTourScript.scenes[0].steps[1].cue.itemId).toBe('security');
+        expect(operations).toEqual(['splitNode', 'addTab']);
+        operations.forEach(operation => expect(DockZoneModel.operations).toContain(operation));
+        expect(operations).not.toContain('promote')
+    });
+
+    test('two real-reducer runs complete with identical logs and the promoted tab returned', async () => {
+        createRunner();
+
+        const first = await runner.start();
+
+        expect(first.completed).toBe(true);
+        expect(first.errors).toEqual([]);
+
+        const firstDocument = Neo.getComponent('demo-c-stage').dockZoneDocument;
+
+        expect(firstDocument.nodes['split-main'].children[0]).toBe('scale-tabs');
+        expect(firstDocument.nodes['heavy-tabs'].activeItemId).toBe('security');
+        expect(firstDocument.nodes['heavy-tabs'].items.at(-1)).toBe('security');
+
+        runner.destroy();
+        createRunner();
+
+        const second = await runner.start();
+
+        expect(second.completed).toBe(true);
+        expect(second.errors).toEqual([]);
+        expect(second.log).toEqual(first.log)
+    })
+});

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -406,6 +406,7 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         expect(rail).toBeTruthy();
         expect(rail.dockEdge).toBe('right');
         expect(rail.edge).toBe('right');
+        expect(rail.flex).toBe('none');
         expect(rail.module).toBe(DockRail);
         expect(rail.ntype).toBe('dashboard-dock-rail');
         expect(rail.railItems).toEqual([

--- a/test/playwright/unit/tab/BodyContainer.spec.mjs
+++ b/test/playwright/unit/tab/BodyContainer.spec.mjs
@@ -1,0 +1,73 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'TabBodyContainerAtomicMoveTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+import BodyContainer  from '../../../../src/tab/BodyContainer.mjs';
+import TabContainer   from '../../../../src/tab/Container.mjs';
+
+/**
+ * @summary Pins the tab adapters to `Neo.container.Base`'s four-argument atomic-remove contract.
+ *
+ * A silent cross-parent move must keep a live card mounted until the caller updates the common
+ * ancestor. Both BodyContainer paths matter: projected Neo instances use its direct base path,
+ * while ordinary tab configs delegate removal through their owning TabContainer.
+ */
+test.describe('Neo.tab.BodyContainer atomic moves', () => {
+    test('direct projected cards preserve mounted state when keepMounted is true', () => {
+        const body = Neo.create(BodyContainer, {
+                items: [{module: Component}]
+            }),
+            card = body.items[0];
+
+        card.mounted = true;
+
+        expect(body.remove(card, false, true, true)).toBe(card);
+        expect(body.items).toHaveLength(0);
+        expect(card.mounted).toBe(true)
+    });
+
+    test('tab-owned cards forward keepMounted through TabContainer.removeAt', () => {
+        const tabs = Neo.create(TabContainer, {
+                items: [{header: {text: 'Atomic'}, module: Component}]
+            }),
+            body = tabs.getCardContainer(),
+            card = body.items[0];
+
+        expect(card.isTab).toBe(true);
+        card.mounted = true;
+        expect(body.remove(card, false, true, true)).toBe(card);
+
+        expect(body.items).toHaveLength(0);
+        expect(tabs.getTabBar().items).toHaveLength(0);
+        expect(card.mounted).toBe(true)
+    });
+
+    test('ordinary non-destructive removals still unmount cards', () => {
+        const directBody = Neo.create(BodyContainer, {
+                items: [{module: Component}]
+            }),
+            directCard = directBody.items[0],
+            tabs = Neo.create(TabContainer, {
+                items: [{header: {text: 'Ordinary'}, module: Component}]
+            }),
+            tabBody = tabs.getCardContainer(),
+            tabCard = tabBody.items[0];
+
+        directCard.mounted = true;
+        tabCard.mounted    = true;
+
+        directBody.remove(directCard, false, true);
+        tabBody.remove(tabCard, false, true);
+
+        expect(directCard.mounted).toBe(false);
+        expect(tabCard.mounted).toBe(false)
+    })
+});

--- a/test/playwright/unit/tab/BodyContainer.spec.mjs
+++ b/test/playwright/unit/tab/BodyContainer.spec.mjs
@@ -12,6 +12,7 @@ import * as core      from '../../../../src/core/_export.mjs';
 import Component      from '../../../../src/component/Base.mjs';
 import BodyContainer  from '../../../../src/tab/BodyContainer.mjs';
 import TabContainer   from '../../../../src/tab/Container.mjs';
+import '../../../../src/manager/Instance.mjs'; // defines Neo.get for the existing-instance insert path
 
 /**
  * @summary Pins the tab adapters to `Neo.container.Base`'s four-argument atomic-remove contract.
@@ -50,6 +51,55 @@ test.describe('Neo.tab.BodyContainer atomic moves', () => {
         expect(card.mounted).toBe(true)
     });
 
+    test('tab-owned active-card moves keep header and replacement-card changes silent', () => {
+        const tabs = Neo.create(TabContainer, {
+                activeIndex: 1,
+                items      : [
+                    {header: {text: 'First'},  module: Component},
+                    {header: {text: 'Second'}, module: Component}
+                ]
+            }),
+            body          = tabs.getCardContainer(),
+            tabBar        = tabs.getTabBar(),
+            movedCard     = body.items[1],
+            remainingCard = body.items[0],
+            remainingTab  = tabBar.items[0];
+        let bodyUpdates            = 0,
+            remainingCardWasSilent = false,
+            remainingTabWasSilent  = false,
+            tabBarUpdates          = 0;
+
+        body.update   = () => bodyUpdates++;
+        tabBar.update = () => tabBarUpdates++;
+
+        const
+            afterSetPressed    = remainingTab.afterSetPressed.bind(remainingTab),
+            afterSetWrapperCls = remainingCard.afterSetWrapperCls.bind(remainingCard);
+
+        remainingCard.afterSetWrapperCls = (...args) => {
+            remainingCardWasSilent = Boolean(remainingCard.silentVdomUpdate);
+            afterSetWrapperCls(...args)
+        };
+        remainingTab.afterSetPressed = (...args) => {
+            remainingTabWasSilent = Boolean(remainingTab.silentVdomUpdate);
+            afterSetPressed(...args)
+        };
+
+        movedCard.mounted = true;
+        expect(body.remove(movedCard, false, true, true)).toBe(movedCard);
+
+        expect(bodyUpdates, 'the body waits for the closest-common-parent commit').toBe(0);
+        expect(tabBarUpdates, 'the tab header waits for the closest-common-parent commit').toBe(0);
+        expect(tabs.activeIndex).toBe(0);
+        expect(remainingCard.wrapperCls).toContain('neo-active-item');
+        expect(remainingCard.wrapperCls).not.toContain('neo-inactive-item');
+        expect(remainingCard.vdom.removeDom).toBeUndefined();
+        expect(remainingCardWasSilent).toBe(true);
+        expect(remainingTab.pressed).toBe(true);
+        expect(remainingTabWasSilent).toBe(true);
+        expect(movedCard.mounted).toBe(true)
+    });
+
     test('ordinary non-destructive removals still unmount cards', () => {
         const directBody = Neo.create(BodyContainer, {
                 items: [{module: Component}]
@@ -69,5 +119,39 @@ test.describe('Neo.tab.BodyContainer atomic moves', () => {
 
         expect(directCard.mounted).toBe(false);
         expect(tabCard.mounted).toBe(false)
+    });
+
+    test('an inactive projected card becomes renderable when atomically moved into an active slot', () => {
+        const source = Neo.create(BodyContainer, {
+                items : [{module: Component}, {module: Component}],
+                layout: {ntype: 'card', activeIndex: 1}
+            }),
+            target = Neo.create(BodyContainer, {
+                items : [{module: Component}],
+                layout: {ntype: 'card', activeIndex: 0}
+            }),
+            card        = source.items[0],
+            placeholder = target.items[0];
+        let wrapperUpdateWasSilent = false;
+
+        const afterSetWrapperCls = card.afterSetWrapperCls.bind(card);
+
+        card.afterSetWrapperCls = (...args) => {
+            wrapperUpdateWasSilent = Boolean(card.silentVdomUpdate);
+            afterSetWrapperCls(...args)
+        };
+
+        expect(card.wrapperCls).toContain('neo-inactive-item');
+        expect(card.vdom.removeDom).toBe(true);
+
+        target.remove(placeholder, true, true);
+        source.remove(card, false, true, true);
+        target.insert(0, card, true, false);
+
+        expect(target.items[0]).toBe(card);
+        expect(card.wrapperCls).toContain('neo-active-item');
+        expect(card.wrapperCls).not.toContain('neo-inactive-item');
+        expect(card.vdom.removeDom).toBeUndefined();
+        expect(wrapperUpdateWasSilent, 'the common-parent update remains the only DOM commit').toBe(true)
     })
 });


### PR DESCRIPTION
Resolves #15099

Demo C adds the v13.2 dense-workstation proof: twenty dock items at 2560x1440, a renderer-rich 100,000-row `Store<Model>` grid, a capped batched 10-records/sec feed, two source-owned rails, real tab overflow, split-and-return choreography, and both AgentOS themes. The signature holds under live transformation: the content never stops living while the workspace moves.

Evidence: L3 (local 2560x1440 Chromium + Neural Link + Canvas Worker journey) → L3 achieved for the runtime and visual close-target ACs. Residual: None. The operator accepted exact head `9d803ba37` as the first release-ready version; earlier passes found and drove both a real title/body desynchronization and the opening-layout imbalance. One distinct single-frame DockFlip clipping boundary remains explicitly tracked in #15137.

## Deltas from ticket

The ticket's cached-pane composition remains the authority, but live falsification sharpened its mechanism. Demo C stages the next dock shell under the real closest common parent, silently transfers pane ownership with `keepMounted`, and performs one `updateDepth = -1` reconciliation so Neo emits DOM moves instead of remove/reinsert cycles. The trace exposed an override-signature gap in `Neo.tab.BodyContainer` / `Neo.tab.Container`; this PR forwards the existing four-argument atomic-remove contract and adds direct, delegated, and negative-control unit coverage.

The operator visual pass produced a bounded presentation repair: both Sparkline columns now use DevIndex-sized 160×50 cell geometry with contained canvases; smooth bounded series replace wraparound spikes; the header has one action-labelled theme toggle and a coherent story/progress zone; start, row-action, overflow, grid, hover, pressed, and ripple states consume the AgentOS palette in both themes; progress paints exactly once per settled beat; and coarse replacement chrome no longer replays entry effects.

The follow-up layout pass keeps that proof dense without letting the scale grid monopolize the workstation: the center split is 60/40, the left/right edge bands are 260/320px, all grid labels are physically left-aligned with sort glyphs removed from label flow, and the feed distributes its flexible width 2:1:1 across Event/State/Value. These are Demo C composition choices, not generic dashboard or grid policy.

The same pass exposed a deeper atomic-transfer defect at head `7ecac3c83`: `Neo.tab.Container.removeAt(..., silent=true)` still performed an eager TabBar removal and a reactive active-index update. The source tab title could therefore commit before the closest-common-parent workspace transaction moved and activated its card, producing the observed multi-frame title-without-content state. Head `0127bf8a6` propagates the silent contract through TabBar and Card state, clears stale opposing wrapper/remove flags, and leaves the common-parent update as the sole DOM commit. The mounted E2E now samples every animation frame and rejects any visible active-tab header without a visible active body for one 60Hz frame or longer. It also measures the opening composition at 2560×1440: every header label stays within a 16px physical-left inset, scale-grid remainder stays at or below 140px, the heavy panel stays at or above 700px, edge bands resolve to 260/320px, and Event never exceeds 2.1× State or Value.

Three deeper contracts are deliberately not hidden inside this demo PR. #15135 owns a reusable `TourRunner.stepSettled` event that will replace Demo C's temporary log-settlement adapter. #15136 owns identity-preserving tab-container/header/strip/overflow reconciliation so the local replacement-chrome containment can be removed. #15137 owns clip-safe and immediate DockFlip presentation for preserved-identity cross-parent moves; it explicitly forbids a global overflow escape hatch. All three carry v13.2 project/milestone metadata.

## Test Evidence

- Exact current head `9d803ba37`: `npm run test-unit -- test/playwright/unit/tab/BodyContainer.spec.mjs test/playwright/unit/apps/agentos/childapps/dockdemo/DemoCWorkspace.spec.mjs` — 7/7 passed, including zero-update silent active-card removal and silent inactive→active target projection.
- Exact current head `9d803ba37`: `NEO_E2E_PORT=8124 npx playwright test agentos/DemoCDenseWorkstationNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — 1/1 passed. The requestAnimationFrame oracle observed zero active-header/empty-body intervals across 997 sampled frames and zero page errors.
- Exact current head `9d803ba37`: `npm run agent-preflight -- --no-fix` for the four repaired/test files — all requested gates passed; commit-time lint-staged passed whitespace, shorthand, AiConfig mutation, JSDoc, ticket archaeology, block alignment, and parse checks.
- Layout-polish capture: the exact-head journey recorded at 2560×1440 into 1280×720 WebM — 1/1 passed; fresh opening, light, dark, split, return, and final frames were inspected. Sequential playback confirms the repeated title-without-content state is gone. Random-access VP9 seeking can amplify black bands and is not used as the runtime oracle.
- Presentation oracles: exact 160×50 Sparkline fit with canvas content containment; true physical-left grid labels; bounded scale remainder; 60/40 primary split; 260/320px edge bands; 2:1:1 Event/State/Value distribution; one theme toggle; no generic-primary button/ripple leakage; exact progress sequence `[0…9]` with no regression; replacement chrome sampled with zero running entry-effect frames; zero page/runtime errors.
- Broader composition + consumed seams from the initial implementation: focused Demo C, TourRunner, DockLayoutAdapter, Overflow, and BodyContainer matrix — 44/44 passed; post-fast-forward critical subset — 7/7 passed.
- AgentOS theme ownership: `npm run check-agentos-theme` — parity, token-only, and completeness passed.

## Post-Merge Validation

- [x] None. Runtime and visual acceptance completed pre-merge, including operator acceptance of exact head `9d803ba37`.

## Evolution

The first implementation treated cached pane re-projection as destroy-free ownership bookkeeping. The live Canvas falsifier showed that a tab override dropped `keepMounted`, causing an otherwise invisible mounted true→false transition and invalidating transferred OffscreenCanvas ownership. Tobi's common-parent update model supplied the correct invariant: silent source/target mutation plus one closest-common-parent reconciliation.

The next visual falsifier separated two failure classes that looked similar in video. The repeated title-without-content interval was a real transaction-boundary defect and belongs in the atomic transfer contract, so this PR repairs it and adds a frame-level oracle. A remaining single FLIP inversion frame can place the transformed pane outside the destination body's clip; broad `overflow: visible` experiments disrupted the tour and were rejected. That presentation contract remains visible and bounded in #15137 rather than being hidden by demo CSS.

**Does this PR resolve an issue?**

Resolves #15099. AC6/operator visual acceptance was received for exact head `9d803ba37`.

**What kind of change does this PR introduce?**

- [x] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills this requirement:**

- [x] It's submitted to the `dev` branch, _not_ the `main` branch

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature

Authored by Emmy (GPT-5.6 Sol, Codex). Session f95e01ff-ba36-409a-98af-573263fab247.

