### PR TITLE
feat(ai): expose TourRunner step settlement (#15135)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoCWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoCWorkspace.mjs
@@ -125,10 +125,6 @@ class DemoCWorkspace extends Container {
      */
     refreshPromise = null
     /**
-     * @member {Number} beatCount=0
-     */
-    beatCount = 0
-    /**
      * Number of coalesced producer batches appended over this workspace lifetime.
      * @member {Number} feedBatchCount=0
      */
@@ -145,8 +141,15 @@ class DemoCWorkspace extends Container {
      */
     cuePromise = Promise.resolve()
     /**
-     * Serialized, paint-confirmed tour progress. The runner emits `beat` before executing a
-     * step, so this local projection waits for that step's log/cue/refresh settlement before
+     * Hosting-surface cue promises indexed by the runner's scene/step identity. `stepSettled`
+     * consumes each entry after runner-owned work succeeds; the map never becomes runner state.
+     * @member {Map<String,Promise>} cueSettlements
+     * @protected
+     */
+    cueSettlements = new Map()
+    /**
+     * Serialized, paint-confirmed tour progress. `TourRunner.stepSettled` proves runner-owned
+     * work only, so this local projection additionally waits for its cue and dock refresh before
      * exposing progress to the viewer.
      * @member {Promise} progressPromise
      * @protected
@@ -194,11 +197,12 @@ class DemoCWorkspace extends Container {
         });
 
         me.tourRunner.on({
-            beat    : me.onTourBeat,
-            complete: me.onTourComplete,
-            error   : me.onTourError,
-            scene   : me.onTourScene,
-            scope   : me
+            beat       : me.onTourBeat,
+            complete   : me.onTourComplete,
+            error      : me.onTourError,
+            scene      : me.onTourScene,
+            stepSettled: me.onTourStepSettled,
+            scope      : me
         });
 
         me.appendFeedBatch(25);
@@ -434,7 +438,6 @@ class DemoCWorkspace extends Container {
      */
     onTourBeat(data) {
         let me            = this,
-            progress      = ++me.beatCount,
             cueSettlement = Promise.resolve();
 
         data.caption && me.setTourCaption(data.caption);
@@ -463,9 +466,25 @@ class DemoCWorkspace extends Container {
             cueSettlement = me.cuePromise
         }
 
+        me.cueSettlements.set(`${data.sceneIndex}:${data.stepIndex}`, cueSettlement)
+    }
+
+    /**
+     * Projects one successful runner step only after the hosting surface's corresponding cue
+     * and dock refresh have also settled. The runner event deliberately does not claim either
+     * hosting-surface boundary.
+     * @param {Object} data `TourRunner.stepSettled` payload.
+     */
+    onTourStepSettled(data) {
+        let me            = this,
+            key           = `${data.sceneIndex}:${data.stepIndex}`,
+            cueSettlement = me.cueSettlements.get(key) || Promise.resolve();
+
+        me.cueSettlements.delete(key);
         me.progressPromise = me.progressPromise.then(async () => {
-            await me.waitForTourBeatSettlement(progress, cueSettlement);
-            await me.setPipProgress(progress);
+            await cueSettlement;
+            await me.refreshPromise;
+            await me.setPipProgress(data.completedCount);
             // Adjacent document operations can settle within one browser frame. Keep each
             // evidenced state visible long enough to read instead of letting VDOM paints coalesce.
             await me.timeout(90)
@@ -483,6 +502,7 @@ class DemoCWorkspace extends Container {
      * @param {Object} data
      */
     onTourError(data) {
+        this.cueSettlements.clear();
         this.setTourCaption(`Tour stopped: ${data.errors[0] || 'unknown reason'}`)
     }
 
@@ -935,28 +955,6 @@ class DemoCWorkspace extends Container {
     }
 
     /**
-     * Waits for one runner log entry, its optional surface cue, and any resulting dock
-     * projection. This is a Demo-C adapter until TourRunner exposes a reusable settled-step
-     * event; it prevents the progress surface from claiming work that is still in flight.
-     * @param {Number} count One-based flattened beat count.
-     * @param {Promise} cueSettlement
-     * @returns {Promise<Boolean>}
-     */
-    async waitForTourBeatSettlement(count, cueSettlement) {
-        for (let attempt = 0; attempt < 400; attempt++) {
-            if (this.tourRunner.log.length >= count) break;
-            await this.timeout(5)
-        }
-
-        if (this.tourRunner.log.length < count) return false;
-
-        await cueSettlement;
-        await this.refreshPromise;
-
-        return true
-    }
-
-    /**
      * Runs the screenplay from a fresh document on every replay.
      * @returns {Promise<Object>|undefined}
      */
@@ -968,10 +966,10 @@ class DemoCWorkspace extends Container {
             return
         }
 
-        me.beatCount       = 0;
         me.cueErrors       = [];
         me.cuePromise      = Promise.resolve();
         me.cueReceipts     = [];
+        me.cueSettlements.clear();
         me.lastTourReceipt = null;
         me.progressPromise = Promise.resolve();
         me.dockModel       = DockZoneModel.clone(initialDocument);
@@ -1057,6 +1055,7 @@ class DemoCWorkspace extends Container {
 
         me.tourRunner?.destroy();
         me.dockService?.destroy();
+        me.cueSettlements.clear();
 
         Object.values(me.paneCache).forEach(pane => {
             pane?.isDestroyed || pane?.destroy?.()

--- a/src/ai/client/TourRunner.mjs
+++ b/src/ai/client/TourRunner.mjs
@@ -26,8 +26,10 @@ import {evaluateExpectations, validateTourScript} from './tourScript.mjs';
  *              with motion disabled would record a lie about the product).
  * - `spec`   — pause waits skipped entirely; assertions identical. The whitebox-e2e replay mode.
  *
- * Events (observable): `beat` (before each step — the tour bar's caption feed), `scene`
+ * Events (observable): `beat` (before each step — the tour bar's caption feed), `stepSettled`
+ * (after one runner-owned step succeeds; hosting-surface cues/projection remain external), `scene`
  * (scene boundary), `error` (abort with structured failures), `complete` (full log).
+ * As with every object event, `Neo.core.Observable` adds the runner id as `source`.
  *
  * Script schema + fail-closed validator: `tourScript.mjs` (same directory) · dock documents:
  * `learn/agentos/HarnessDockZoneModel.md` (the JSON-first workspace contract).
@@ -37,7 +39,7 @@ import {evaluateExpectations, validateTourScript} from './tourScript.mjs';
 class TourRunner extends Base {
     /**
      * True automatically applies the core.Observable mixin — the tour bar and specs
-     * subscribe to `beat` / `scene` / `error` / `complete`.
+     * subscribe to `beat` / `stepSettled` / `scene` / `error` / `complete`.
      * @member {Boolean} observable=true
      * @static
      */
@@ -366,6 +368,20 @@ class TourRunner extends Base {
                         ms > 0 && await me.timeout(ms)
                     }
                 }
+
+                // This event owns ONLY runner settlement: the operation/assertion/pause succeeded
+                // and its deterministic log entry exists. Hosting surfaces combine it with their
+                // own cue and projection promises instead of making the runner await listeners.
+                const logLength = me.log.length;
+
+                me.fire('stepSettled', {
+                    completedCount: logLength,
+                    logLength,
+                    sceneId,
+                    sceneIndex,
+                    stepIndex,
+                    stepType      : step.type
+                });
 
                 stepIndex++
             }

--- a/test/playwright/unit/ai/client/TourRunner.spec.mjs
+++ b/test/playwright/unit/ai/client/TourRunner.spec.mjs
@@ -352,16 +352,20 @@ test.describe.serial('Neo.ai.client.TourRunner', () => {
 
     test.describe('execution against the real reducers', () => {
         test('the smoke tour completes: documents advance, events fire in order', async () => {
-            const events = [];
+            const events = [], settledEvents = [];
 
             createRunner();
 
             const holder = Neo.getComponent('tour-zone-1');
 
             runner.on({
-                beat    : data => events.push(`beat:${data.stepIndex}:${data.stepType}`),
-                complete: () => events.push('complete'),
-                scene   : data => events.push(`scene:${data.sceneId}`)
+                beat       : data => events.push(`beat:${data.stepIndex}:${data.stepType}`),
+                complete   : () => events.push('complete'),
+                scene      : data => events.push(`scene:${data.sceneId}`),
+                stepSettled: data => {
+                    settledEvents.push(data);
+                    events.push(`settled:${data.stepIndex}:${data.stepType}:log-${runner.log.length}`)
+                }
             });
 
             const result = await runner.start();
@@ -379,9 +383,43 @@ test.describe.serial('Neo.ai.client.TourRunner', () => {
 
             expect(events).toEqual([
                 'scene:s1',
-                'beat:0:op', 'beat:1:pause', 'beat:2:op', 'beat:3:topology-assert', 'beat:4:op',
+                'beat:0:op',              'settled:0:op:log-1',
+                'beat:1:pause',           'settled:1:pause:log-2',
+                'beat:2:op',              'settled:2:op:log-3',
+                'beat:3:topology-assert', 'settled:3:topology-assert:log-4',
+                'beat:4:op',              'settled:4:op:log-5',
                 'complete'
-            ])
+            ]);
+            expect(settledEvents).toEqual([
+                {completedCount: 1, logLength: 1, sceneId: 's1', sceneIndex: 0, source: runner.id, stepIndex: 0, stepType: 'op'},
+                {completedCount: 2, logLength: 2, sceneId: 's1', sceneIndex: 0, source: runner.id, stepIndex: 1, stepType: 'pause'},
+                {completedCount: 3, logLength: 3, sceneId: 's1', sceneIndex: 0, source: runner.id, stepIndex: 2, stepType: 'op'},
+                {completedCount: 4, logLength: 4, sceneId: 's1', sceneIndex: 0, source: runner.id, stepIndex: 3, stepType: 'topology-assert'},
+                {completedCount: 5, logLength: 5, sceneId: 's1', sceneIndex: 0, source: runner.id, stepIndex: 4, stepType: 'op'}
+            ]);
+            expect(JSON.parse(JSON.stringify(settledEvents)), 'the payload is JSON-safe and timestamp-free')
+                .toEqual(settledEvents)
+        });
+
+        test('a paced pause settles only after its runner-owned wait', async () => {
+            const script = {
+                schema: TOUR_SCRIPT_SCHEMA,
+                id    : 'paced-pause',
+                title : 'Paced pause',
+                scenes: [{id: 'paced', title: 'Paced', steps: [{type: 'pause', ms: 7}]}]
+            };
+
+            createRunner({mode: 'demo', paceMultiplier: 2, script});
+
+            const events = [];
+
+            runner.timeout = async ms => events.push(`wait:${ms}`);
+            runner.on('stepSettled', data => events.push(`settled:${data.stepType}:${data.completedCount}`));
+
+            const result = await runner.start();
+
+            expect(result.completed).toBe(true);
+            expect(events).toEqual(['wait:14', 'settled:pause:1'])
         });
 
         test('log entries carry the complete cloned descriptor — the log IS the replay wire format', async () => {
@@ -449,15 +487,17 @@ test.describe.serial('Neo.ai.client.TourRunner', () => {
             script.scenes[0].steps[0].expect = [{path: 'items.terminal.autoHidden', equals: false}];
             createRunner({script});
 
-            const errorEvents = [];
+            const errorEvents = [], settledEvents = [];
 
             runner.on('error', data => errorEvents.push(data));
+            runner.on('stepSettled', data => settledEvents.push(data));
 
             const result = await runner.start();
 
             expect(result.completed).toBe(false);
             expect(result.errors.join('\n')).toContain("expectation failed at 'items.terminal.autoHidden': expected false, got true");
             expect(errorEvents).toHaveLength(1);
+            expect(settledEvents, 'failed expectations never emit a successful settlement').toEqual([]);
 
             // the log keeps the entries up to and including the failed step — an honest partial record
             expect(result.log).toHaveLength(1);
@@ -470,11 +510,16 @@ test.describe.serial('Neo.ai.client.TourRunner', () => {
             script.scenes[0].steps[0].descriptor.itemId = 'ghost';
             createRunner({script});
 
+            const settledEvents = [];
+
+            runner.on('stepSettled', data => settledEvents.push(data));
+
             const result = await runner.start();
 
             expect(result.completed).toBe(false);
             expect(result.errors.join('\n')).toContain('rejected by the executor');
-            expect(result.errors.join('\n')).toContain('unknown item "ghost"')
+            expect(result.errors.join('\n')).toContain('unknown item "ghost"');
+            expect(settledEvents, 'rejected operations never emit a successful settlement').toEqual([])
         });
 
         test('start() while running throws — a programming error, not a tour failure', async () => {


### PR DESCRIPTION
Resolves #15135

`TourRunner` now exposes the successful boundary its progress consumers were missing: one additive `stepSettled` event after every completed runner-owned step and before the next pre-step `beat`. Demo C consumes that event, combines it with its own cue and projection settlement, and removes the mutable-log polling adapter without moving UI authority into the runner.

Evidence: L3 (mounted Chromium exact `0…N` progress sequence with zero regression frames) → L3 achieved for the runtime-visible close-target ACs. Residual: None.

## Deltas from ticket

The implementation follows the ticket's authority split exactly. `beat` remains pre-step narration/cue data. `stepSettled` fires only after the executor/assertion/pause succeeds, post-step expectations pass, and the deterministic log entry exists. Its timestamp-free JSON-safe payload carries scene/step identity, type, one-based completion count, and matching log length; the standard Observable `source` field remains additive framework provenance.

Demo C indexes each hosting-surface cue promise by scene/step identity, consumes it from `stepSettled`, then awaits its own refresh before painting progress. Failed runner steps emit no false settlement, and the workspace clears the unmatched local cue entry on error. No listener promise, DOM state, or projection ownership crosses into `TourRunner`.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/client/TourRunner.spec.mjs test/playwright/unit/apps/agentos/childapps/dockdemo/DemoCWorkspace.spec.mjs --workers=1` — 26/26 passed. Pins `beat → work → stepSettled → next beat`, op/assert/pause payloads, paced-pause ordering, JSON safety, and both rejected-operation and failed-expectation negative controls.
- `NEO_E2E_PORT=8124 npx playwright test agentos/DemoCDenseWorkstationNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — 1/1 passed. The mounted rAF oracle observed exact monotonic progress with no fill-then-reset frame and no page error.
- `npm run test-unit` — 7,146 passed in the broad local sweep before 11 unrelated environment/time-budget residuals stopped the run. The seven filesystem-denied cases passed outside the sandbox; the remaining selected residual matrix reached 115 passes, and the real-tree lint passed 21/21 with its normal 90-second allowance.
- `npm run agent-preflight -- src/ai/client/TourRunner.mjs apps/agentos/childapps/dockdemo/view/DemoCWorkspace.mjs test/playwright/unit/ai/client/TourRunner.spec.mjs` — all repair-capable gates passed.

## Post-Merge Validation

- [ ] Confirm the full CI unit matrix is green on its single-worker runner.
- [ ] Replay the mounted Demo C journey from merged `dev` and retain exact `0…N` progress with zero regression frames.

Authored by Emmy (GPT-5.6 Sol, Codex). Session f95e01ff-ba36-409a-98af-573263fab247.
