### PR TITLE
docs(agentos): separate agent and external PR bodies (#15141)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -268,7 +268,7 @@ until shape is correct.
 
 ## 9. PR Body Hygiene
 
-Do not blindly copy the entire ticket body into the PR description. The ticket holds the original context; the PR body summarizes the implementation delta.
+Do not copy ticket bodies or the optional external-contributor `.github/PULL_REQUEST_TEMPLATE.md` into agent PRs; summarize the implementation delta below.
 
 ### 9.1 Reference Hygiene
 


### PR DESCRIPTION
Resolves #15141

The pull-request workflow now states the audience boundary that my #15133/#15140 authoring violated: agent-authored PR bodies use the agent contract and do not copy the optional external-contributor checklist. The external template remains available and unchanged.

Evidence: L1 (exact source diff, byte comparison, and skill-manifest lint) → L1 achieved for this documentation-only close target. Residual: None.

## Deltas from ticket

None substantive. The fix is the prescribed one-sentence rewrite; open PR #15140 was independently truth-synced before this PR opened.

## Load-Effect Audit

- Always-loaded Map: `.agents/skills/pull-request/SKILL.md` — unchanged; zero router-byte delta.
- Conditional workflow payload: `.agents/skills/pull-request/references/pull-request-workflow.md` — one sentence replaced in §9; 21,985 bytes before and after.
- External contributor surface: `.github/PULL_REQUEST_TEMPLATE.md` — unchanged.
- Decay posture: no new section, file, rule block, or duplicated template; the clarification replaces an existing hygiene sentence.

## Test Evidence

- `node ai/scripts/lint/lint-skill-manifest.mjs --base origin/dev` — passed.
- `npm run agent-preflight -- --no-fix .agents/skills/pull-request/references/pull-request-workflow.md` — passed; no `.mjs` source gates in scope.
- `git diff --check` and staged diff inspection — passed; exactly one insertion and one deletion.
- `wc -c` against `origin/dev` — 21,985 bytes before and after.
- PR #15140 body update — copied external checklist removed; agent PR-body lint reran green.

## Post-Merge Validation

- [x] None. The source split, byte budget, active-PR correction, and lint gates are verified pre-merge.

Authored by Emmy (GPT-5.6 Sol, Codex). Session f95e01ff-ba36-409a-98af-573263fab247.
