### PR TITLE
fix(dashboard): keep preserved dock motion clip-safe (#15137)

### DIFF
--- a/src/main/addon/DockFlip.mjs
+++ b/src/main/addon/DockFlip.mjs
@@ -16,6 +16,11 @@ import Base from './Base.mjs';
  * the DOM nodes are new. Entering elements (no First rect) fade/scale in from their landing
  * spot; exiting elements are the outgoing tree's problem and need no animation.
  *
+ * Native atomic cross-parent moves preserve the exact marker nodes. That branch skips the
+ * replacement-tree detach poll and, when the First rect would be clipped by the destination,
+ * temporarily fixes the same node to its Last viewport rect before applying the inverse. The
+ * real parent and clipping contract remain untouched; unsafe containing blocks land instantly.
+ *
  * Presentation-only by contract: the committed document never waits on motion — a failed or
  * skipped animation lands the final layout instantly (every path here is fail-safe), and
  * `prefers-reduced-motion: reduce` renders the instant path by construction.
@@ -44,11 +49,19 @@ class DockFlip extends Base {
     }
 
     /**
-     * First-phase rect snapshots, keyed by hostId → Map<markerClass, DOMRect>.
-     * @member {Object} #firstRects={}
+     * First-phase marker, parent, and rect snapshots keyed by host id.
+     * @member {Object} #firstSnapshots={}
      * @private
      */
-    #firstRects = {}
+    #firstSnapshots = {}
+
+    /**
+     * Active presentation cleanups. Destroy interrupts them before the base lifecycle tears
+     * down the addon, so no fixed stage, inverse transform, class, or timer can outlive it.
+     * @member {Set<Function>} #activeCleanups
+     * @private
+     */
+    #activeCleanups = new Set()
 
     /**
      * Collects the marker elements inside a host: every element whose class list contains a
@@ -72,6 +85,147 @@ class DockFlip extends Base {
     }
 
     /**
+     * @summary Returns whether the captured connected marker set has landed across a parent boundary.
+     * @param {Map<String, HTMLElement>} firstMarkers
+     * @param {Map<String, HTMLElement>} markers
+     * @param {Map<String, HTMLElement>} firstParents
+     * @returns {Boolean}
+     * @protected
+     */
+    hasPreservedMarkerSet(firstMarkers, markers, firstParents) {
+        const exactSet = firstMarkers?.size === markers.size
+            && [...markers].every(([key, el]) => el.isConnected && firstMarkers.get(key) === el);
+
+        // An exact same-parent set can still be the outgoing tree while an async delta is
+        // pending. A parent change is the falsifier that Neo's atomic cross-parent move landed.
+        return exactSet && [...markers].some(([key, el]) => firstParents.get(key) !== el.parentElement)
+    }
+
+    /**
+     * @summary Finds the nearest ancestor that clips either axis between a marker and its dock host.
+     * @param {HTMLElement} el
+     * @param {HTMLElement} hostEl
+     * @returns {Object|null}
+     * @protected
+     */
+    getClippingContext(el, hostEl) {
+        const readStyle = globalThis.getComputedStyle;
+
+        if (!readStyle) return null;
+
+        let current = el.parentElement;
+
+        while (current) {
+            const
+                style     = readStyle(current),
+                overflow  = style.overflow || 'visible',
+                overflowX = style.overflowX || overflow,
+                overflowY = style.overflowY || overflow,
+                clips     = value => !['visible', 'initial', 'unset'].includes(value),
+                clipsX    = clips(overflowX),
+                clipsY    = clips(overflowY);
+
+            if (clipsX || clipsY) {
+                return {
+                    clipsX,
+                    clipsY,
+                    el  : current,
+                    rect: current.getBoundingClientRect()
+                }
+            }
+
+            if (current === hostEl) break;
+
+            current = current.parentElement
+        }
+
+        return null
+    }
+
+    /**
+     * @summary Reports whether a First rect would extend beyond the destination clipping context.
+     * @param {DOMRect} rect
+     * @param {Object} clippingContext
+     * @returns {Boolean}
+     * @protected
+     */
+    isRectClipped(rect, clippingContext) {
+        const
+            clip       = clippingContext.rect,
+            rectRight  = rect.right  ?? rect.left + rect.width,
+            rectBottom = rect.bottom ?? rect.top  + rect.height,
+            clipRight  = clip.right  ?? clip.left + clip.width,
+            clipBottom = clip.bottom ?? clip.top  + clip.height,
+            tolerance  = 0.5;
+
+        return clippingContext.clipsX && (rect.left < clip.left - tolerance || rectRight > clipRight + tolerance)
+            || clippingContext.clipsY && (rect.top < clip.top - tolerance || rectBottom > clipBottom + tolerance)
+    }
+
+    /**
+     * @summary Verifies that fixed-position staging will remain viewport-relative instead of being trapped by a containing-block ancestor.
+     * @param {HTMLElement} el
+     * @returns {Boolean}
+     * @protected
+     */
+    canUseFixedStage(el) {
+        const readStyle = globalThis.getComputedStyle;
+
+        if (!readStyle) return false;
+
+        let current = el.parentElement;
+
+        while (current) {
+            const
+                style      = readStyle(current),
+                contain    = style.contain || '',
+                willChange = (style.willChange || '').split(',').map(value => value.trim()),
+                trapped    = style.transform && style.transform !== 'none'
+                    || style.perspective && style.perspective !== 'none'
+                    || style.filter && style.filter !== 'none'
+                    || style.backdropFilter && style.backdropFilter !== 'none'
+                    || /(?:^|\s)(?:layout|paint|strict|content)(?:\s|$)/.test(contain)
+                    || style.contentVisibility && style.contentVisibility !== 'visible'
+                    || willChange.some(value => ['transform', 'perspective', 'filter'].includes(value));
+
+            if (trapped) return false;
+
+            current = current.parentElement
+        }
+
+        return true
+    }
+
+    /**
+     * @summary Captures every inline style DockFlip may mutate so cleanup restores the exact prior presentation.
+     * @param {HTMLElement} el
+     * @returns {Object}
+     * @protected
+     */
+    captureInlineStyles(el) {
+        return Object.fromEntries([
+            'bottom',
+            'boxSizing',
+            'height',
+            'left',
+            'margin',
+            'maxHeight',
+            'maxWidth',
+            'minHeight',
+            'minWidth',
+            'opacity',
+            'position',
+            'right',
+            'top',
+            'transform',
+            'transformOrigin',
+            'transition',
+            'width',
+            'zIndex'
+        ].map(property => [property, el.style[property] ?? '']))
+    }
+
+    /**
      * Phase 1: snapshot the current geometry of every marker element inside the host.
      * Call immediately BEFORE swapping the projected tree.
      * @param {Object} opts
@@ -80,15 +234,28 @@ class DockFlip extends Base {
      */
     captureFirst({hostId, markerPrefix}) {
         const
-            els   = [],
-            rects = new Map();
+            markers = this.collectMarkers(hostId, markerPrefix),
+            parents = new Map(),
+            rects   = new Map();
 
-        this.collectMarkers(hostId, markerPrefix).forEach((el, key) => {
+        markers.forEach((el, key) => {
+            parents.set(key, el.parentElement);
             rects.set(key, el.getBoundingClientRect());
-            els.push(el)
         });
 
-        this.#firstRects[hostId] = {els, rects}
+        this.#firstSnapshots[hostId] = {els: [...markers.values()], markers, parents, rects}
+    }
+
+    /**
+     * @summary Interrupts every active presentation stage before the addon lifecycle is destroyed.
+     * @returns {void}
+     */
+    destroy() {
+        this.#activeCleanups.forEach(cancel => cancel());
+        this.#activeCleanups.clear();
+        this.#firstSnapshots = {};
+
+        super.destroy()
     }
 
     /**
@@ -123,35 +290,62 @@ class DockFlip extends Base {
      * @returns {Promise<Boolean>} true if an animation played (resolves AFTER the motion completes), false on any instant-landing path
      */
     async play({hostId, markerPrefix, maxFrames = 15}) {
-        const first = this.#firstRects[hostId];
+        const first = this.#firstSnapshots[hostId];
 
-        let hostEl,
-            moves = [];
+        let cancel,
+            durationResolve = null,
+            durationTimer   = null,
+            hostEl,
+            interrupted     = false,
+            moves           = [],
+            settled         = false;
 
         // One idempotent settlement path owns every temporary visual mutation. In particular,
         // a rejected post-invert frame must restore the final layout instead of preserving the
         // inverse transform or observability class indefinitely.
-        const cleanup = () => {
-            moves.forEach(({el}) => {
-                el.style.opacity         = '';
-                el.style.transform       = '';
-                el.style.transformOrigin = '';
-                el.style.transition      = ''
+        const cleanup = (wasInterrupted = false) => {
+            if (settled) return;
+
+            interrupted ||= wasInterrupted;
+
+            const resolveDuration = durationResolve;
+
+            if (durationTimer !== null) {
+                clearTimeout(durationTimer);
+                durationTimer   = null;
+                durationResolve = null
+            }
+
+            moves.forEach(({el, fixedStage, hadStageClass, styleSnapshot}) => {
+                styleSnapshot && Object.entries(styleSnapshot).forEach(([property, value]) => {
+                    el.style[property] = value
+                });
+
+                fixedStage && !hadStageClass && el.classList.remove('neo-dock-flip-fixed-stage')
             });
 
             hostEl?.classList.remove('dock-animating');
 
             hostEl = null;
-            moves  = []
+            moves  = [];
+            settled = true;
+
+            this.#activeCleanups.delete(cancel);
+            resolveDuration?.()
         };
 
-        delete this.#firstRects[hostId];
+        cancel = () => cleanup(true);
 
-        if (!first?.rects.size) {
+        delete this.#firstSnapshots[hostId];
+
+        if (!first?.rects.size || this.isDestroyed) {
             return false
         }
 
-        const firstRects = first.rects;
+        const
+            firstMarkers = first.markers,
+            firstParents = first.parents,
+            firstRects   = first.rects;
 
         try {
             // Both consumers pass a workspace host ABOVE the projected `.neo-dashboard`.
@@ -171,18 +365,24 @@ class DockFlip extends Base {
                 return false // token-layer reduced-motion collapse or missing contract: land instantly
             }
 
-            let frame = 0;
+            let
+                frame              = 0,
+                markers            = this.collectMarkers(hostId, markerPrefix),
+                preservedMarkerSet = this.hasPreservedMarkerSet(firstMarkers, markers, firstParents);
 
             // stage A: the swap lands asynchronously through the delta pipeline — the OLD
             // tree's markers would satisfy a naive presence-poll instantly and measure
-            // identical geometry, so first wait (bounded) for an outgoing element to detach
-            while (frame < maxFrames && first.els.length > 0 && first.els.every(el => el.isConnected)) {
-                await new Promise(resolve => requestAnimationFrame(resolve));
-                frame++
+            // identical geometry. An exact preserved marker set is the native atomic-move path:
+            // those nodes MUST remain connected, so it bypasses the outgoing-detach poll.
+            if (!preservedMarkerSet) {
+                while (frame < maxFrames && first.els.length > 0 && first.els.every(el => el.isConnected)) {
+                    await new Promise(resolve => requestAnimationFrame(resolve));
+                    frame++
+                }
             }
 
             // stage B: now wait (bounded) for the NEW tree's markers to exist
-            let markers = this.collectMarkers(hostId, markerPrefix);
+            markers = this.collectMarkers(hostId, markerPrefix);
 
             while (markers.size < 1 && frame < maxFrames * 2) {
                 await new Promise(resolve => requestAnimationFrame(resolve));
@@ -194,27 +394,49 @@ class DockFlip extends Base {
                 return false
             }
 
-            await new Promise(resolve => requestAnimationFrame(resolve));
+            if (this.isDestroyed) return false;
+
+            // Replacement trees retain their settle frame. Preserved identities are already in
+            // their committed Last geometry, so delaying here would expose the clipped final tree
+            // for one paint before the inverse transform is installed.
+            if (!preservedMarkerSet) {
+                await new Promise(resolve => requestAnimationFrame(resolve))
+            }
 
             markers.forEach((el, key) => {
                 const
-                    first = firstRects.get(key),
-                    last  = el.getBoundingClientRect();
+                    firstRect = firstRects.get(key),
+                    last      = el.getBoundingClientRect();
 
-                if (!first) {
+                if (!firstRect) {
                     // entering element: grow into place from its landing spot
-                    moves.push({el, transform: 'scale(0.92)', fade: true});
+                    moves.push({el, fixedStage: false, transform: 'scale(0.92)', fade: true, last});
                     return
                 }
 
                 const
-                    dx = first.left - last.left,
-                    dy = first.top  - last.top,
-                    sx = last.width  > 0 ? first.width  / last.width  : 1,
-                    sy = last.height > 0 ? first.height / last.height : 1;
+                    dx                = firstRect.left - last.left,
+                    dy                = firstRect.top  - last.top,
+                    sx                = last.width  > 0 ? firstRect.width  / last.width  : 1,
+                    sy                = last.height > 0 ? firstRect.height / last.height : 1,
+                    preservedIdentity = firstMarkers.get(key) === el && el.isConnected,
+                    movedAcrossParent = preservedIdentity && firstParents.get(key) !== el.parentElement,
+                    clippingContext   = movedAcrossParent && this.getClippingContext(el, hostEl),
+                    needsFixedStage   = clippingContext && this.isRectClipped(firstRect, clippingContext),
+                    fixedStage        = needsFixedStage && this.canUseFixedStage(el);
+
+                // A containing-block ancestor can trap a fixed descendant inside the same bad
+                // clip. In that unsafe case, snap this pane to Last instead of animating a false
+                // blank frame; unrelated safe moves may still play.
+                if (needsFixedStage && !fixedStage) return;
 
                 if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5 || Math.abs(sx - 1) > 0.005 || Math.abs(sy - 1) > 0.005) {
-                    moves.push({el, transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`})
+                    moves.push({
+                        el,
+                        fixedStage,
+                        last,
+                        transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`
+                    })
                 }
             });
 
@@ -228,7 +450,35 @@ class DockFlip extends Base {
             // (cleanup still strips the legacy `dock-animating` class defensively)
 
             // Invert: place every survivor on its old geometry, entering panes at their birth state
-            moves.forEach(({el, transform, fade}) => {
+            this.#activeCleanups.add(cancel);
+
+            moves.forEach(move => {
+                const {el, fixedStage, last, transform, fade} = move;
+
+                move.hadStageClass = el.classList.contains('neo-dock-flip-fixed-stage');
+                move.styleSnapshot = this.captureInlineStyles(el);
+
+                if (fixedStage) {
+                    el.classList.add('neo-dock-flip-fixed-stage');
+
+                    Object.assign(el.style, {
+                        bottom   : 'auto',
+                        boxSizing: 'border-box',
+                        height   : `${last.height}px`,
+                        left     : `${last.left}px`,
+                        margin   : '0',
+                        maxHeight: 'none',
+                        maxWidth : 'none',
+                        minHeight: '0',
+                        minWidth : '0',
+                        position : 'fixed',
+                        right    : 'auto',
+                        top      : `${last.top}px`,
+                        width    : `${last.width}px`,
+                        zIndex   : '2'
+                    })
+                }
+
                 el.style.transformOrigin = 'top left';
                 el.style.transition      = 'none';
                 el.style.transform       = transform;
@@ -237,17 +487,32 @@ class DockFlip extends Base {
 
             await new Promise(resolve => requestAnimationFrame(resolve));
 
+            if (interrupted || this.isDestroyed) {
+                cleanup(true);
+
+                return false
+            }
+
             // Play: release to the new geometry in one composited transition
-            moves.forEach(({el}) => {
+            moves.forEach(({el, styleSnapshot}) => {
                 el.style.transition = `transform ${duration}ms ${easing}, opacity ${duration}ms ${easing}`;
-                el.style.transform  = '';
-                el.style.opacity    = ''
+                el.style.transform  = styleSnapshot.transform;
+                el.style.opacity    = styleSnapshot.opacity
             });
 
             // resolve AFTER the motion completes, so an awaiting consumer's signal bracket
             // (DockMotionSignal enter/leave) covers the true animation window; the idempotent
             // cleanup owns every temporary visual mutation (the hardening contract)
-            await new Promise(resolve => setTimeout(resolve, duration + 50));
+            await new Promise(resolve => {
+                durationResolve = resolve;
+                durationTimer   = setTimeout(() => {
+                    durationResolve = null;
+                    durationTimer   = null;
+                    resolve()
+                }, duration + 50)
+            });
+
+            if (interrupted || this.isDestroyed) return false;
 
             cleanup();
 

--- a/test/playwright/e2e/agentos/DemoCDenseWorkstationNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoCDenseWorkstationNL.spec.mjs
@@ -9,7 +9,8 @@ import {demoCTourScript} from '../../../../apps/agentos/tour/demoCDenseWorkstati
  * two stable Store<Model> identities, an exact 100k renderer-rich grid, a sustained capped
  * feed, one owner-exact overflow surface, two real rails, frame-sampled midpoint continuity,
  * Canvas-worker pixel change, DevIndex-sized chart geometry, honest progress paints, both
- * themes, replacement-chrome motion containment, and identity preservation.
+ * themes, replacement-chrome motion containment, sequential clip-safe fixed staging, and
+ * identity preservation.
  *
  * Run: NEO_E2E_PORT=8124 npx playwright test agentos/DemoCDenseWorkstationNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
@@ -520,11 +521,20 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
                 replacementHeaderSamples      : 0,
                 sampledFrames                 : 0,
                 securityCaptured              : false,
+                securityActiveHeaderMissFrames: 0,
+                securityBodyMissingFrames     : 0,
+                securityFullyClippedFrames    : 0,
+                securityFullyClippedSamples   : [],
                 securityMissingFrames         : 0,
+                securityOverflowMutationFrames: 0,
                 securityReplacementFrames     : 0
             };
             const activeTabEmptySpans = {};
-            let   securityNode        = null;
+            let   securityNode        = null,
+                  securityWasStaged   = false;
+
+            state.securityStageBursts = 0;
+            state.securityStageFrames = 0;
 
             const tick = () => {
                 const isVisible = node => {
@@ -619,6 +629,61 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
                     }
                 } else if (state.securityCaptured) {
                     state.securityMissingFrames++
+                }
+
+                if (currentSecurityNode) {
+                    const
+                        securityBody = currentSecurityNode.closest('.neo-tab-body-container'),
+                        staged       = currentSecurityNode.classList.contains('neo-dock-flip-fixed-stage'),
+                        activeHeader = securityBody?.closest('.neo-tab-container')
+                            ?.querySelector('.neo-tab-header-button.pressed');
+
+                    if (staged) {
+                        const
+                            bodyStyle = securityBody && getComputedStyle(securityBody),
+                            rect      = currentSecurityNode.getBoundingClientRect(),
+                            insetX    = Math.min(8, rect.width / 4),
+                            insetY    = Math.min(8, rect.height / 4),
+                            points    = [
+                                [rect.left + rect.width / 2, rect.top + rect.height / 2],
+                                [rect.left + insetX, rect.top + insetY],
+                                [rect.right - insetX, rect.top + insetY],
+                                [rect.left + insetX, rect.bottom - insetY],
+                                [rect.right - insetX, rect.bottom - insetY]
+                            ].filter(([x, y]) => x >= 0 && y >= 0 && x < innerWidth && y < innerHeight),
+                            painted = points.some(([x, y]) => {
+                                const hit = document.elementFromPoint(x, y);
+
+                                return hit === currentSecurityNode || currentSecurityNode.contains(hit)
+                            });
+
+                        if (!securityWasStaged) state.securityStageBursts++;
+
+                        state.securityStageFrames++;
+
+                        if (!securityBody) state.securityBodyMissingFrames++;
+                        if (!activeHeader || !isVisible(activeHeader)) state.securityActiveHeaderMissFrames++;
+                        if (bodyStyle?.overflowX !== 'hidden' || bodyStyle?.overflowY !== 'hidden') {
+                            state.securityOverflowMutationFrames++
+                        }
+
+                        if (!painted) {
+                            state.securityFullyClippedFrames++;
+                            state.securityFullyClippedSamples.length < 20
+                                && state.securityFullyClippedSamples.push({
+                                    bottom: Math.round(rect.bottom),
+                                    height: Math.round(rect.height),
+                                    left  : Math.round(rect.left),
+                                    right : Math.round(rect.right),
+                                    top   : Math.round(rect.top),
+                                    width : Math.round(rect.width)
+                                })
+                        }
+                    }
+
+                    securityWasStaged = staged
+                } else {
+                    securityWasStaged = false
                 }
 
                 if (root) {
@@ -757,10 +822,22 @@ test.describe('AgentOS Demo C — dense workstation composition', () => {
         expect(monitor.securityCaptured, 'the overflow cue mounts Security before its structural move').toBe(true);
         expect(monitor.securityMissingFrames, 'the active Security pane never leaves the DOM after capture').toBe(0);
         expect(monitor.securityReplacementFrames, 'Security keeps the same DOM node across split and return').toBe(0);
+        expect(monitor.securityStageBursts, 'split and return each expose one preserved-identity fixed stage').toBe(2);
+        expect(monitor.securityStageFrames, 'the sequential sampler observes the real fixed-stage motion').toBeGreaterThan(2);
+        expect(monitor.securityBodyMissingFrames,
+            'fixed staging keeps the exact pane inside its real destination body').toBe(0);
+        expect(monitor.securityActiveHeaderMissFrames,
+            'every staged frame retains a visible active tab header').toBe(0);
+        expect(monitor.securityOverflowMutationFrames,
+            'the real tab-body overflow contract stays hidden throughout both moves').toBe(0);
+        expect(monitor.securityFullyClippedFrames,
+            `every staged frame paints pane content: ${JSON.stringify(monitor.securityFullyClippedSamples)}`).toBe(0);
         expect(monitor.palettes.length, 'the actual tour materially renders both theme palettes').toBeGreaterThanOrEqual(2);
         expect(monitor.flipSamples, 'committed transformations emit visible FLIP motion').toBeGreaterThan(0);
         await expect(page.locator('.agentos-dockdemo-workspace-c'))
             .not.toHaveClass(/neo-dashboard-dock-animating/);
+        await expect(page.locator('.neo-dock-flip-fixed-stage'),
+            'fixed staging leaves no class or active presentation residue').toHaveCount(0);
         await expect(page.locator('.neo-tab-overflow-control:visible'),
             'the returned twelve-tab group restores its one real overflow control').toHaveCount(1);
 

--- a/test/playwright/unit/dashboard/DockFlip.spec.mjs
+++ b/test/playwright/unit/dashboard/DockFlip.spec.mjs
@@ -39,13 +39,19 @@ function createClassList(...values) {
  * @returns {Object}
  */
 function createMarker(markerClass, rect) {
+    let currentRect = rect;
+
     return {
         classList: createClassList(markerClass),
         getBoundingClientRect() {
-            return rect
+            return currentRect
         },
-        isConnected: true,
-        style      : {}
+        isConnected  : true,
+        parentElement: null,
+        setRect(value) {
+            currentRect = value
+        },
+        style: {}
     }
 }
 
@@ -152,7 +158,314 @@ test.describe('Neo.main.addon.DockFlip', () => {
         expect(dockFlip.parseDurationToken('0ms')).toBe(0);
         expect(dockFlip.parseDurationToken('260ms')).toBe(260);
         expect(dockFlip.parseDurationToken('0.26s')).toBe(260);
-        expect(dockFlip.parseDurationToken('bogus')).toBe(0)
+        expect(dockFlip.parseDurationToken('bogus')).toBe(0);
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false);
+        expect(marker.style).toEqual({})
+    });
+
+    test('skips the detach poll when the complete marker set keeps the same connected identities', async () => {
+        const
+            markerClass = 'dock-flip-item-alpha',
+            marker      = createMarker(markerClass, {height: 100, left: 0, top: 0, width: 100}),
+            sourceBody  = {parentElement: null},
+            targetBody  = {parentElement: null},
+            host        = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            };
+
+        sourceBody.parentElement = host;
+        targetBody.parentElement = host;
+        marker.parentElement     = sourceBody;
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = () => ({
+            getPropertyValue(name) {
+                return name === '--dock-transition-duration' ? '1ms' : 'linear'
+            }
+        });
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+        marker.parentElement = targetBody;
+        marker.setRect({height: 100, left: 80, top: 40, width: 100});
+
+        let frame = 0;
+
+        globalThis.requestAnimationFrame = callback => {
+            frame++;
+            callback()
+        };
+
+        await expect(dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-'
+        })).resolves.toBe(true);
+
+        expect(frame, 'only the post-invert frame remains on the preserved-identity path').toBe(1)
+    });
+
+    test('retains the bounded wait for an exact same-parent set whose projection is still ambiguous', async () => {
+        const
+            markerClass = 'dock-flip-item-alpha',
+            marker      = createMarker(markerClass, {height: 100, left: 0, top: 0, width: 100}),
+            host        = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            };
+
+        marker.parentElement = host;
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = () => ({
+            getPropertyValue(name) {
+                return name === '--dock-transition-duration' ? '1ms' : 'linear'
+            }
+        });
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+        marker.setRect({height: 100, left: 80, top: 40, width: 100});
+
+        let frame = 0;
+
+        globalThis.requestAnimationFrame = callback => {
+            frame++;
+            callback()
+        };
+
+        await expect(dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-',
+            maxFrames   : 2
+        })).resolves.toBe(true);
+
+        expect(frame, 'two detach polls, one replacement settle, and one post-invert frame').toBe(4)
+    });
+
+    test('retains the bounded detach wait when replacement markers take over', async () => {
+        const
+            markerClass = 'dock-flip-item-alpha',
+            outgoing    = createMarker(markerClass, {height: 100, left: 0, top: 0, width: 100}),
+            incoming    = createMarker(markerClass, {height: 100, left: 80, top: 40, width: 100}),
+            host        = {
+                classList: createClassList(),
+                markers  : [outgoing],
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return this.markers
+                }
+            };
+
+        outgoing.parentElement = host;
+        incoming.parentElement = host;
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = () => ({
+            getPropertyValue(name) {
+                return name === '--dock-transition-duration' ? '1ms' : 'linear'
+            }
+        });
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+
+        let frame = 0;
+
+        globalThis.requestAnimationFrame = callback => {
+            frame++;
+
+            if (frame === 3) {
+                outgoing.isConnected = false;
+                host.markers          = [incoming]
+            }
+
+            callback()
+        };
+
+        await expect(dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-'
+        })).resolves.toBe(true);
+
+        expect(frame, 'three detach polls, one replacement settle, and one post-invert frame').toBe(5)
+    });
+
+    test('fixed-stages a preserved cross-parent move without changing the destination clip', async () => {
+        const
+            markerClass     = 'dock-flip-item-alpha',
+            marker          = createMarker(markerClass, {bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100}),
+            sourceBody      = {parentElement: null},
+            destinationBody = {
+                parentElement: null,
+                style        : {},
+                getBoundingClientRect() {
+                    return {bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100}
+                }
+            },
+            host            = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            },
+            visibleStyle = {
+                contain    : 'none',
+                filter     : 'none',
+                overflowX  : 'visible',
+                overflowY  : 'visible',
+                perspective: 'none',
+                transform  : 'none',
+                willChange : 'auto',
+                getPropertyValue(name) {
+                    return name === '--dock-transition-duration' ? '1ms' : 'linear'
+                }
+            };
+
+        sourceBody.parentElement      = host;
+        destinationBody.parentElement = host;
+        marker.parentElement          = sourceBody;
+        marker.style.position         = 'relative';
+        marker.style.zIndex           = '7';
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = element => element === destinationBody
+            ? {...visibleStyle, overflowX: 'hidden', overflowY: 'hidden'}
+            : visibleStyle;
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+        marker.parentElement = destinationBody;
+        marker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
+
+        const stageSamples = [];
+
+        globalThis.requestAnimationFrame = callback => {
+            stageSamples.push({
+                position: marker.style.position,
+                staged  : marker.classList.contains('neo-dock-flip-fixed-stage')
+            });
+            callback()
+        };
+
+        await expect(dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-'
+        })).resolves.toBe(true);
+
+        expect(stageSamples).toEqual([{position: 'fixed', staged: true}]);
+        expect(marker.parentElement, 'the live pane remains the destination body child').toBe(destinationBody);
+        expect(destinationBody.style.overflow, 'the real tab-body clip is never mutated').toBeUndefined();
+        expect(marker.style.position).toBe('relative');
+        expect(marker.style.zIndex).toBe('7');
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false)
+    });
+
+    test('destroy interrupts an active fixed stage and restores its presentation state', async () => {
+        const
+            markerClass     = 'dock-flip-item-alpha',
+            marker          = createMarker(markerClass, {bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100}),
+            sourceBody      = {parentElement: null},
+            destinationBody = {
+                parentElement: null,
+                getBoundingClientRect() {
+                    return {bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100}
+                }
+            },
+            host            = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            },
+            visibleStyle = {
+                contain    : 'none',
+                filter     : 'none',
+                overflowX  : 'visible',
+                overflowY  : 'visible',
+                perspective: 'none',
+                transform  : 'none',
+                willChange : 'auto',
+                getPropertyValue(name) {
+                    return name === '--dock-transition-duration' ? '1ms' : 'linear'
+                }
+            };
+
+        sourceBody.parentElement      = host;
+        destinationBody.parentElement = host;
+        marker.parentElement          = sourceBody;
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = element => element === destinationBody
+            ? {...visibleStyle, overflowX: 'hidden', overflowY: 'hidden'}
+            : visibleStyle;
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+        marker.parentElement = destinationBody;
+        marker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
+
+        let releaseFrame;
+
+        globalThis.requestAnimationFrame = callback => {
+            releaseFrame = callback
+        };
+
+        const playPromise = dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-'
+        });
+
+        expect(marker.style.position).toBe('fixed');
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(true);
+
+        dockFlip.destroy();
+        dockFlip = null;
+
+        expect(marker.style.position).toBe('');
+        expect(marker.style.transform).toBe('');
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false);
+
+        releaseFrame();
+
+        await expect(playPromise).resolves.toBe(false)
     });
 
     test('restores the host class and every temporary style when a post-invert frame fails', async () => {


### PR DESCRIPTION
Resolves #15137

Preserved-identity dock moves now bypass the replacement-tree detach poll once an atomic cross-parent reparent is observable. When the pane's First geometry would be clipped by its destination tab body, `DockFlip` temporarily fixes that same live node to its Last viewport rect, animates the inverse transform without changing its real parent or the body's `overflow: hidden` contract, and restores every touched style and class on all settlement paths.

Evidence: L3 (mounted Chromium plus Neural Link sequential-frame sampling of both Demo C cross-parent beats, including DOM identity, visible header/pane paint, hidden overflow, and cleanup) → L3 required (all close-target runtime ACs are browser-reachable). No residuals.

## Deltas from ticket

- The bounded clip-safe mechanism uses `position: fixed` on the same destination-owned pane rather than an overlay clone or temporary reparent, preserving the component and DOM identities by construction.
- Immediate identity playback requires an observed parent change as well as the exact connected marker set. An exact same-parent set remains ambiguous with an outgoing async tree and therefore retains the bounded wait.
- A transform/filter/contain-based fixed containing block fails closed to an instant Last landing instead of presenting a geometrically false animation.

## Test Evidence

- DockFlip core: `npx playwright test dashboard/DockFlip -c test/playwright/playwright.config.unit.mjs --workers=1` — 8 passed, covering preserved/replacement/ambiguous branches, fixed staging, reduced motion, destroy, and post-invert cleanup.
- AgentOS Demo C: `NEO_E2E_PORT=8124 npx playwright test agentos/DemoCDenseWorkstationNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — 1 passed in mounted Chromium; both split/return stages remained painted with the same pane node, visible active header, hidden destination overflow, and zero residue.
- Full unit gate: `npm run test-unit -- --workers=4` — 7,144 passed in the initial run. Serial and unsandboxed reruns cleared 14 unrelated failures; the remaining real-tree lint oracle passed 21/21 with a 60s diagnostic bound and reported 216 valid nodes, exposing a default 30s performance-bound mismatch rather than a functional failure.
- Existing dashboard motion journey: `NEO_E2E_PORT=8126 npx playwright test dashboard/DockMotionNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — 5 passed; 2 pre-operation seed assertions still expect the former two-tab Operator layout while current `dev` seeds seven tabs. No DockFlip assertion failed.
- Repository gates: repair-capable and check-only `npm run agent-preflight` passes; commit hooks passed whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, parsing, and test-mutation checks.

## Post-Merge Validation

- [ ] Re-run the mounted Demo C journey on the merged `dev` head and confirm both fixed-stage bursts remain residue-free.

Related: #13158
Related: #14929
Related: #15099
Related: #15136

Authored by Emmy (GPT-5, Codex). Session f95e01ff-ba36-409a-98af-573263fab247.
