### PR TITLE
fix(dock): harden FLIP boundary oracles (#15147)

### DIFF
--- a/src/main/addon/DockFlip.mjs
+++ b/src/main/addon/DockFlip.mjs
@@ -16,7 +16,7 @@ import Base from './Base.mjs';
  * the DOM nodes are new. Entering elements (no First rect) fade/scale in from their landing
  * spot; exiting elements are the outgoing tree's problem and need no animation.
  *
- * Native atomic cross-parent moves preserve the exact marker nodes. That branch skips the
+ * Native atomic cross-boundary moves preserve the exact marker nodes. That branch skips the
  * replacement-tree detach poll and, when the First rect would be clipped by the destination,
  * temporarily fixes the same node to its Last viewport rect before applying the inverse. The
  * real parent and clipping contract remain untouched; unsafe containing blocks land instantly.
@@ -49,7 +49,7 @@ class DockFlip extends Base {
     }
 
     /**
-     * First-phase marker, parent, and rect snapshots keyed by host id.
+     * First-phase marker, ancestor-lineage, stacking, and rect snapshots keyed by host id.
      * @member {Object} #firstSnapshots={}
      * @private
      */
@@ -85,20 +85,82 @@ class DockFlip extends Base {
     }
 
     /**
-     * @summary Returns whether the captured connected marker set has landed across a parent boundary.
-     * @param {Map<String, HTMLElement>} firstMarkers
-     * @param {Map<String, HTMLElement>} markers
-     * @param {Map<String, HTMLElement>} firstParents
+     * @summary Captures one marker's ancestor identities through its owning dock host.
+     * @param {HTMLElement} el
+     * @param {HTMLElement} hostEl
+     * @returns {HTMLElement[]}
+     * @protected
+     */
+    captureAncestorLineage(el, hostEl) {
+        const lineage = [];
+
+        let current = el.parentElement;
+
+        while (current) {
+            lineage.push(current);
+
+            if (current === hostEl) break;
+
+            current = current.parentElement
+        }
+
+        return lineage
+    }
+
+    /**
+     * @summary Reports whether a marker moved across any captured ancestor boundary.
+     * @param {HTMLElement} el
+     * @param {HTMLElement[]} firstLineage
+     * @param {HTMLElement} hostEl
      * @returns {Boolean}
      * @protected
      */
-    hasPreservedMarkerSet(firstMarkers, markers, firstParents) {
+    hasAncestorLineageChanged(el, firstLineage, hostEl) {
+        const lineage = this.captureAncestorLineage(el, hostEl);
+
+        return Boolean(firstLineage)
+            && (lineage.length !== firstLineage.length
+            || lineage.some((ancestor, index) => ancestor !== firstLineage[index])
+            )
+    }
+
+    /**
+     * @summary Returns whether the captured connected marker set has landed across an ancestor boundary.
+     * @param {Map<String, HTMLElement>} firstMarkers
+     * @param {Map<String, HTMLElement>} markers
+     * @param {Map<String, HTMLElement[]>} firstLineages
+     * @param {HTMLElement} hostEl
+     * @returns {Boolean}
+     * @protected
+     */
+    hasPreservedMarkerSet(firstMarkers, markers, firstLineages, hostEl) {
         const exactSet = firstMarkers?.size === markers.size
             && [...markers].every(([key, el]) => el.isConnected && firstMarkers.get(key) === el);
 
-        // An exact same-parent set can still be the outgoing tree while an async delta is
-        // pending. A parent change is the falsifier that Neo's atomic cross-parent move landed.
-        return exactSet && [...markers].some(([key, el]) => firstParents.get(key) !== el.parentElement)
+        // An exact unchanged-lineage set can still be the outgoing tree while an async delta is
+        // pending. Any ancestor change is the falsifier that Neo's atomic boundary move landed.
+        return exactSet && [...markers].some(([key, el]) =>
+            this.hasAncestorLineageChanged(el, firstLineages.get(key), hostEl)
+        )
+    }
+
+    /**
+     * @summary Resolves the fixed-stage stacking value without lowering captured or effective numeric stacking.
+     * @param {HTMLElement} el
+     * @param {...String} capturedValues
+     * @returns {String}
+     * @protected
+     */
+    resolveFixedStageZIndex(el, ...capturedValues) {
+        const
+            computedValue = globalThis.getComputedStyle?.(el)?.zIndex,
+            values        = [...capturedValues, computedValue]
+                .map(value => String(value ?? '').trim())
+                .filter(value => /^[+-]?\d+$/.test(value))
+                .map(Number)
+                .filter(Number.isFinite);
+
+        return String(Math.max(2, ...values))
     }
 
     /**
@@ -234,16 +296,19 @@ class DockFlip extends Base {
      */
     captureFirst({hostId, markerPrefix}) {
         const
-            markers = this.collectMarkers(hostId, markerPrefix),
-            parents = new Map(),
-            rects   = new Map();
+            hostEl   = document.getElementById(hostId),
+            markers  = this.collectMarkers(hostId, markerPrefix),
+            lineages = new Map(),
+            rects    = new Map(),
+            zIndexes = new Map();
 
         markers.forEach((el, key) => {
-            parents.set(key, el.parentElement);
+            lineages.set(key, this.captureAncestorLineage(el, hostEl));
             rects.set(key, el.getBoundingClientRect());
+            zIndexes.set(key, this.resolveFixedStageZIndex(el, el.style.zIndex));
         });
 
-        this.#firstSnapshots[hostId] = {els: [...markers.values()], markers, parents, rects}
+        this.#firstSnapshots[hostId] = {els: [...markers.values()], lineages, markers, rects, zIndexes}
     }
 
     /**
@@ -343,9 +408,10 @@ class DockFlip extends Base {
         }
 
         const
-            firstMarkers = first.markers,
-            firstParents = first.parents,
-            firstRects   = first.rects;
+            firstLineages = first.lineages,
+            firstMarkers  = first.markers,
+            firstRects    = first.rects,
+            firstZIndexes = first.zIndexes;
 
         try {
             // Both consumers pass a workspace host ABOVE the projected `.neo-dashboard`.
@@ -368,7 +434,7 @@ class DockFlip extends Base {
             let
                 frame              = 0,
                 markers            = this.collectMarkers(hostId, markerPrefix),
-                preservedMarkerSet = this.hasPreservedMarkerSet(firstMarkers, markers, firstParents);
+                preservedMarkerSet = this.hasPreservedMarkerSet(firstMarkers, markers, firstLineages, hostEl);
 
             // stage A: the swap lands asynchronously through the delta pipeline — the OLD
             // tree's markers would satisfy a naive presence-poll instantly and measure
@@ -415,13 +481,14 @@ class DockFlip extends Base {
                 }
 
                 const
-                    dx                = firstRect.left - last.left,
-                    dy                = firstRect.top  - last.top,
-                    sx                = last.width  > 0 ? firstRect.width  / last.width  : 1,
-                    sy                = last.height > 0 ? firstRect.height / last.height : 1,
-                    preservedIdentity = firstMarkers.get(key) === el && el.isConnected,
-                    movedAcrossParent = preservedIdentity && firstParents.get(key) !== el.parentElement,
-                    clippingContext   = movedAcrossParent && this.getClippingContext(el, hostEl),
+                    dx                  = firstRect.left - last.left,
+                    dy                  = firstRect.top  - last.top,
+                    sx                  = last.width  > 0 ? firstRect.width  / last.width  : 1,
+                    sy                  = last.height > 0 ? firstRect.height / last.height : 1,
+                    preservedIdentity   = firstMarkers.get(key) === el && el.isConnected,
+                    movedAcrossBoundary = preservedIdentity
+                        && this.hasAncestorLineageChanged(el, firstLineages.get(key), hostEl),
+                    clippingContext    = movedAcrossBoundary && this.getClippingContext(el, hostEl),
                     needsFixedStage   = clippingContext && this.isRectClipped(firstRect, clippingContext),
                     fixedStage        = needsFixedStage && this.canUseFixedStage(el);
 
@@ -433,9 +500,10 @@ class DockFlip extends Base {
                 if (Math.abs(dx) > 0.5 || Math.abs(dy) > 0.5 || Math.abs(sx - 1) > 0.005 || Math.abs(sy - 1) > 0.005) {
                     moves.push({
                         el,
+                        firstZIndex: firstZIndexes.get(key),
                         fixedStage,
                         last,
-                        transform: `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`
+                        transform  : `translate(${dx}px, ${dy}px) scale(${sx}, ${sy})`
                     })
                 }
             });
@@ -453,13 +521,19 @@ class DockFlip extends Base {
             this.#activeCleanups.add(cancel);
 
             moves.forEach(move => {
-                const {el, fixedStage, last, transform, fade} = move;
+                const {el, firstZIndex, fixedStage, last, transform, fade} = move;
 
                 move.hadStageClass = el.classList.contains('neo-dock-flip-fixed-stage');
                 move.styleSnapshot = this.captureInlineStyles(el);
 
                 if (fixedStage) {
                     el.classList.add('neo-dock-flip-fixed-stage');
+
+                    const zIndex = this.resolveFixedStageZIndex(
+                        el,
+                        firstZIndex,
+                        move.styleSnapshot.zIndex
+                    );
 
                     Object.assign(el.style, {
                         bottom   : 'auto',
@@ -475,7 +549,7 @@ class DockFlip extends Base {
                         right    : 'auto',
                         top      : `${last.top}px`,
                         width    : `${last.width}px`,
-                        zIndex   : '2'
+                        zIndex
                     })
                 }
 

--- a/test/playwright/e2e/dashboard/DockMotionNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockMotionNL.spec.mjs
@@ -290,9 +290,21 @@ test.describe('Dock motion pipeline (Neural Link) — the signal brackets real m
         await expect.poll(async () => {
             const topo = await app.getDockTopology(holderId);
             const doc  = topo?.document ?? topo;
-            return doc.nodes['main-tabs']?.items?.join(',')
-        }, {message: 'Operator restore must re-seed the main tab pair', timeout: 10000, intervals: [100]}).toBe('strategy,swarm');
+            const node = doc.nodes['main-tabs'];
+
+            return Boolean(node?.items?.includes('swarm')
+                && node.items.some(itemId => itemId !== 'swarm')
+                && node.activeItemId !== 'swarm')
+        }, {message: 'Operator restore must expose Swarm as an inactive main tab', timeout: 10000, intervals: [100]}).toBe(true);
         await expect(page.locator('.neo-dashboard-dock-tab-enter')).toHaveCount(0);
+
+        const restoredTopology = await app.getDockTopology(holderId),
+              restoredDocument = restoredTopology?.document ?? restoredTopology,
+              restoredItems    = restoredDocument.nodes['main-tabs'].items,
+              unrelatedItems   = restoredItems.filter(itemId => itemId !== 'swarm'),
+              expectedItems    = [...unrelatedItems];
+
+        expectedItems.splice(1, 0, 'swarm');
 
         // Remove the inactive Swarm tab first. Adding it back into the SAME tab container creates a
         // new header without changing the container's footprint — the non-FLIP producer must carry
@@ -324,7 +336,10 @@ test.describe('Dock motion pipeline (Neural Link) — the signal brackets real m
 
         expect(result.errors).toEqual([]);
         expect(result.applied).toBe(true);
-        expect(result.document.nodes['main-tabs'].items).toEqual(['strategy', 'swarm']);
+        expect(result.document.nodes['main-tabs'].items).toEqual(expectedItems);
+        expect(result.document.nodes['main-tabs'].items.indexOf('swarm')).toBe(1);
+        expect(result.document.nodes['main-tabs'].items.filter(itemId => itemId !== 'swarm'))
+            .toEqual(unrelatedItems);
         await expect(page.locator('.neo-dashboard-dock-tab-enter')).toHaveCount(1);
         await expect(page.locator(`${ENTER}${SIGNAL}`)).toHaveCount(0);
 
@@ -476,8 +491,20 @@ test.describe('Dock motion pipeline — reduced-motion collapses through the tok
         await expect.poll(async () => {
             const topo = await app.getDockTopology(holderId);
             const doc  = topo?.document ?? topo;
-            return doc.nodes['main-tabs']?.items?.join(',')
-        }, {message: 'Operator restore must re-seed the reduced-motion setup', timeout: 10000, intervals: [100]}).toBe('strategy,swarm');
+            const node = doc.nodes['main-tabs'];
+
+            return Boolean(node?.items?.includes('swarm')
+                && node.items.some(itemId => itemId !== 'swarm')
+                && node.activeItemId !== 'swarm')
+        }, {message: 'Operator restore must expose Swarm as an inactive main tab', timeout: 10000, intervals: [100]}).toBe(true);
+
+        const restoredTopology = await app.getDockTopology(holderId),
+              restoredDocument = restoredTopology?.document ?? restoredTopology,
+              restoredItems    = restoredDocument.nodes['main-tabs'].items,
+              unrelatedItems   = restoredItems.filter(itemId => itemId !== 'swarm'),
+              expectedItems    = [...unrelatedItems];
+
+        expectedItems.splice(1, 0, 'swarm');
 
         const detached = await app.executeDockOperation(holderId, {operation: 'detachItem', itemId: 'swarm'});
         expect(detached.errors).toEqual([]);
@@ -494,6 +521,11 @@ test.describe('Dock motion pipeline — reduced-motion collapses through the tok
         });
 
         expect(result.errors).toEqual([]);
+        expect(result.applied).toBe(true);
+        expect(result.document.nodes['main-tabs'].items).toEqual(expectedItems);
+        expect(result.document.nodes['main-tabs'].items.indexOf('swarm')).toBe(1);
+        expect(result.document.nodes['main-tabs'].items.filter(itemId => itemId !== 'swarm'))
+            .toEqual(unrelatedItems);
         await expect(page.locator('.neo-dashboard-dock-tab-enter.dock-tab-enter-item-swarm')).toHaveCount(1);
         await expect.poll(
             () => page.locator(SIGNAL).count(),

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -527,7 +527,8 @@ test.describe('Workstation — dense living-data composition', () => {
                 securityFullyClippedSamples   : [],
                 securityMissingFrames         : 0,
                 securityOverflowMutationFrames: 0,
-                securityReplacementFrames     : 0
+                securityReplacementFrames     : 0,
+                securityStageFramesByBurst    : []
             };
             const activeTabEmptySpans = {};
             let   securityNode        = null,
@@ -657,9 +658,13 @@ test.describe('Workstation — dense living-data composition', () => {
                                 return hit === currentSecurityNode || currentSecurityNode.contains(hit)
                             });
 
-                        if (!securityWasStaged) state.securityStageBursts++;
+                        if (!securityWasStaged) {
+                            state.securityStageBursts++;
+                            state.securityStageFramesByBurst.push(0)
+                        }
 
                         state.securityStageFrames++;
+                        state.securityStageFramesByBurst[state.securityStageFramesByBurst.length - 1]++;
 
                         if (!securityBody) state.securityBodyMissingFrames++;
                         if (!activeHeader || !isVisible(activeHeader)) state.securityActiveHeaderMissFrames++;
@@ -823,7 +828,13 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(monitor.securityMissingFrames, 'the active Security pane never leaves the DOM after capture').toBe(0);
         expect(monitor.securityReplacementFrames, 'Security keeps the same DOM node across split and return').toBe(0);
         expect(monitor.securityStageBursts, 'split and return each expose one preserved-identity fixed stage').toBe(2);
-        expect(monitor.securityStageFrames, 'the sequential sampler observes the real fixed-stage motion').toBeGreaterThan(2);
+        expect(monitor.securityStageFramesByBurst, 'the sequential sampler isolates the split and return stages')
+            .toHaveLength(2);
+        expect(monitor.securityStageFramesByBurst[0], 'the split stage spans multiple sequential samples')
+            .toBeGreaterThan(1);
+        expect(monitor.securityStageFramesByBurst[1], 'the return stage spans multiple sequential samples')
+            .toBeGreaterThan(1);
+        expect(monitor.securityStageFrames).toBe(monitor.securityStageFramesByBurst.reduce((sum, count) => sum + count, 0));
         expect(monitor.securityBodyMissingFrames,
             'fixed staging keeps the exact pane inside its real destination body').toBe(0);
         expect(monitor.securityActiveHeaderMissFrames,

--- a/test/playwright/unit/dashboard/DockFlip.spec.mjs
+++ b/test/playwright/unit/dashboard/DockFlip.spec.mjs
@@ -214,6 +214,60 @@ test.describe('Neo.main.addon.DockFlip', () => {
         expect(frame, 'only the post-invert frame remains on the preserved-identity path').toBe(1)
     });
 
+    test('skips the detach poll when an exact marker keeps its direct parent but crosses an ancestor boundary', async () => {
+        const
+            markerClass         = 'dock-flip-item-alpha',
+            marker              = createMarker(markerClass, {height: 100, left: 0, top: 0, width: 100}),
+            markerParent        = {parentElement: null},
+            sourceAncestor      = {parentElement: null},
+            destinationAncestor = {parentElement: null},
+            host                = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
+                querySelectorAll() {
+                    return [marker]
+                }
+            };
+
+        sourceAncestor.parentElement      = host;
+        destinationAncestor.parentElement = host;
+        markerParent.parentElement        = sourceAncestor;
+        marker.parentElement              = markerParent;
+
+        globalThis.document = {
+            getElementById(id) {
+                return id === 'dock-host' ? host : null
+            }
+        };
+        globalThis.getComputedStyle = () => ({
+            getPropertyValue(name) {
+                return name === '--dock-transition-duration' ? '1ms' : 'linear'
+            }
+        });
+
+        dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+        markerParent.parentElement = destinationAncestor;
+        marker.setRect({height: 100, left: 80, top: 40, width: 100});
+
+        let frame = 0;
+
+        globalThis.requestAnimationFrame = callback => {
+            frame++;
+            callback()
+        };
+
+        await expect(dockFlip.play({
+            hostId      : 'dock-host',
+            markerPrefix: 'dock-flip-item-'
+        })).resolves.toBe(true);
+
+        expect(marker.parentElement, 'the marker direct parent remains identical').toBe(markerParent);
+        expect(frame, 'the changed ancestor lineage bypasses the detach poll').toBe(1)
+    });
+
     test('retains the bounded wait for an exact same-parent set whose projection is still ambiguous', async () => {
         const
             markerClass = 'dock-flip-item-alpha',
@@ -317,7 +371,11 @@ test.describe('Neo.main.addon.DockFlip', () => {
     test('fixed-stages a preserved cross-parent move without changing the destination clip', async () => {
         const
             markerClass     = 'dock-flip-item-alpha',
+            defaultClass    = 'dock-flip-item-beta',
+            effectiveClass  = 'dock-flip-item-gamma',
             marker          = createMarker(markerClass, {bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100}),
+            defaultMarker   = createMarker(defaultClass, {bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100}),
+            effectiveMarker = createMarker(effectiveClass, {bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100}),
             sourceBody      = {parentElement: null},
             destinationBody = {
                 parentElement: null,
@@ -333,7 +391,7 @@ test.describe('Neo.main.addon.DockFlip', () => {
                     return null
                 },
                 querySelectorAll() {
-                    return [marker]
+                    return [marker, defaultMarker, effectiveMarker]
                 }
             },
             visibleStyle = {
@@ -352,6 +410,8 @@ test.describe('Neo.main.addon.DockFlip', () => {
         sourceBody.parentElement      = host;
         destinationBody.parentElement = host;
         marker.parentElement          = sourceBody;
+        defaultMarker.parentElement   = sourceBody;
+        effectiveMarker.parentElement = sourceBody;
         marker.style.position         = 'relative';
         marker.style.zIndex           = '7';
 
@@ -360,20 +420,31 @@ test.describe('Neo.main.addon.DockFlip', () => {
                 return id === 'dock-host' ? host : null
             }
         };
-        globalThis.getComputedStyle = element => element === destinationBody
-            ? {...visibleStyle, overflowX: 'hidden', overflowY: 'hidden'}
-            : visibleStyle;
+        globalThis.getComputedStyle = element => {
+            if (element === destinationBody) {
+                return {...visibleStyle, overflowX: 'hidden', overflowY: 'hidden'}
+            }
+
+            return element === effectiveMarker ? {...visibleStyle, zIndex: '13'} : visibleStyle
+        };
 
         dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
         marker.parentElement = destinationBody;
+        defaultMarker.parentElement = destinationBody;
+        effectiveMarker.parentElement = destinationBody;
         marker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
+        defaultMarker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
+        effectiveMarker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
 
         const stageSamples = [];
 
         globalThis.requestAnimationFrame = callback => {
             stageSamples.push({
-                position: marker.style.position,
-                staged  : marker.classList.contains('neo-dock-flip-fixed-stage')
+                defaultZIndex  : defaultMarker.style.zIndex,
+                effectiveZIndex: effectiveMarker.style.zIndex,
+                position       : marker.style.position,
+                staged         : marker.classList.contains('neo-dock-flip-fixed-stage'),
+                zIndex         : marker.style.zIndex
             });
             callback()
         };
@@ -383,11 +454,21 @@ test.describe('Neo.main.addon.DockFlip', () => {
             markerPrefix: 'dock-flip-item-'
         })).resolves.toBe(true);
 
-        expect(stageSamples).toEqual([{position: 'fixed', staged: true}]);
+        expect(stageSamples).toEqual([{
+            defaultZIndex  : '2',
+            effectiveZIndex: '13',
+            position       : 'fixed',
+            staged         : true,
+            zIndex         : '7'
+        }]);
         expect(marker.parentElement, 'the live pane remains the destination body child').toBe(destinationBody);
+        expect(defaultMarker.parentElement).toBe(destinationBody);
+        expect(effectiveMarker.parentElement).toBe(destinationBody);
         expect(destinationBody.style.overflow, 'the real tab-body clip is never mutated').toBeUndefined();
         expect(marker.style.position).toBe('relative');
         expect(marker.style.zIndex).toBe('7');
+        expect(defaultMarker.style.zIndex, 'default stacking restores its exact empty inline value').toBe('');
+        expect(effectiveMarker.style.zIndex, 'computed stacking never leaks into the inline style').toBe('');
         expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false)
     });
 
@@ -428,6 +509,7 @@ test.describe('Neo.main.addon.DockFlip', () => {
         sourceBody.parentElement      = host;
         destinationBody.parentElement = host;
         marker.parentElement          = sourceBody;
+        marker.style.zIndex           = '9';
 
         globalThis.document = {
             getElementById(id) {
@@ -454,6 +536,7 @@ test.describe('Neo.main.addon.DockFlip', () => {
         });
 
         expect(marker.style.position).toBe('fixed');
+        expect(marker.style.zIndex).toBe('9');
         expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(true);
 
         dockFlip.destroy();
@@ -461,6 +544,7 @@ test.describe('Neo.main.addon.DockFlip', () => {
 
         expect(marker.style.position).toBe('');
         expect(marker.style.transform).toBe('');
+        expect(marker.style.zIndex).toBe('9');
         expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false);
 
         releaseFrame();
@@ -470,41 +554,59 @@ test.describe('Neo.main.addon.DockFlip', () => {
 
     test('restores the host class and every temporary style when a post-invert frame fails', async () => {
         const
-            markerClass = 'dock-flip-item-alpha',
-            outgoing    = createMarker(markerClass, {height: 100, left: 0, top: 0, width: 100}),
-            incoming    = createMarker(markerClass, {height: 100, left: 80, top: 40, width: 100}),
-            host        = {
-                classList: createClassList(),
-                markers  : [outgoing],
+            markerClass     = 'dock-flip-item-alpha',
+            marker          = createMarker(markerClass, {bottom: 100, height: 100, left: 0, right: 100, top: 0, width: 100}),
+            sourceBody      = {parentElement: null},
+            destinationBody = {
+                parentElement: null,
+                getBoundingClientRect() {
+                    return {bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100}
+                }
+            },
+            host            = {
+                classList    : createClassList(),
+                parentElement: null,
+                querySelector() {
+                    return null
+                },
                 querySelectorAll() {
-                    return this.markers
+                    return [marker]
+                }
+            },
+            visibleStyle = {
+                contain    : 'none',
+                filter     : 'none',
+                overflowX  : 'visible',
+                overflowY  : 'visible',
+                perspective: 'none',
+                transform  : 'none',
+                willChange : 'auto',
+                getPropertyValue(name) {
+                    return name === '--dock-transition-duration' ? '1ms' : 'linear'
                 }
             };
+
+        sourceBody.parentElement      = host;
+        destinationBody.parentElement = host;
+        marker.parentElement          = sourceBody;
+        marker.style.position         = 'relative';
+        marker.style.zIndex           = '11';
 
         globalThis.document = {
             getElementById(id) {
                 return id === 'dock-host' ? host : null
             }
         };
-        globalThis.getComputedStyle = () => ({
-            getPropertyValue(name) {
-                return name === '--dock-transition-duration' ? '1ms' : 'linear'
-            }
-        });
+        globalThis.getComputedStyle = element => element === destinationBody
+            ? {...visibleStyle, overflowX: 'hidden', overflowY: 'hidden'}
+            : visibleStyle;
 
         dockFlip.captureFirst({hostId: 'dock-host', markerPrefix: 'dock-flip-item-'});
+        marker.parentElement = destinationBody;
+        marker.setRect({bottom: 200, height: 100, left: 200, right: 300, top: 100, width: 100});
 
-        outgoing.isConnected = false;
-        host.markers          = [incoming];
-
-        let frame = 0;
-
-        globalThis.requestAnimationFrame = callback => {
-            if (++frame === 2) {
-                throw new Error('forced post-invert frame failure')
-            }
-
-            callback()
+        globalThis.requestAnimationFrame = () => {
+            throw new Error('forced post-invert frame failure')
         };
 
         await expect(dockFlip.play({
@@ -513,11 +615,14 @@ test.describe('Neo.main.addon.DockFlip', () => {
         })).resolves.toBe(false);
 
         expect(host.classList.contains('dock-animating')).toBe(false);
-        expect(incoming.style).toMatchObject({
+        expect(marker.style).toMatchObject({
             opacity        : '',
+            position       : 'relative',
             transform      : '',
             transformOrigin: '',
-            transition     : ''
-        })
+            transition     : '',
+            zIndex         : '11'
+        });
+        expect(marker.classList.contains('neo-dock-flip-fixed-stage')).toBe(false)
     })
 });


### PR DESCRIPTION
Resolves #15147

Related: #13158

DockFlip now treats any changed captured ancestor identity as the atomic-landing witness for an exact connected marker set, while an unchanged or unavailable lineage remains on the bounded ambiguous path. Fixed staging keeps its safety floor without lowering a higher captured inline or computed numeric z-index, and every cleanup path restores the exact inline presentation. The dashboard add-tab journeys derive their expected order from the restored Operator document, and Workstation now proves both Security stage bursts independently.

Evidence: L3 (focused Chromium + Neural Link validation across DockFlip, DockMotion, and standalone Workstation) → L3 required (all close-target runtime ACs). No residuals.

## Deltas from ticket

- None substantive. The implementation additionally fail-closes an unavailable lineage to the bounded wait and directly covers computed-only numeric stacking above the safety floor.

## Test Evidence

- DockFlip core: `npm run test-unit -- test/playwright/unit/dashboard/DockFlip.spec.mjs` — 9 passed.
- Dashboard DockMotion: `NEO_E2E_PORT=8093 npx playwright test test/playwright/e2e/dashboard/DockMotionNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` — 7 passed.
- Dashboard seed regression final rerun: the same command with `--grep addTab` — 2 passed.
- Standalone Workstation: `NEO_E2E_PORT=8124 npx playwright test test/playwright/e2e/workstation/WorkstationNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` — 1 passed.
- Source/PR gates: `npm run agent-preflight -- --no-fix` and `git diff --cached --check` — passed for all four files.

## Post-Merge Validation

- None; every close-target AC has pre-merge L3 evidence.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session adddb25d-fc36-4b08-b9a3-3a62a108cda1.
