### PR TITLE
fix(workstation): refine tourbar hierarchy (#15164)

### DIFF
--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -117,6 +117,8 @@
 }
 
 .workstation-tourbar {
+    --button-height: 34px;
+
     background: linear-gradient(90deg,
         color-mix(in srgb, var(--workstation-signal) 13%, var(--workstation-panel)),
         var(--workstation-panel) 55%);
@@ -127,8 +129,9 @@
     padding      : 8px 14px;
 
     .workstation-tour-story {
-        gap      : 8px;
-        min-width: 0;
+        background: transparent;
+        gap       : 8px;
+        min-width : 0;
     }
 
     .workstation-tour-caption {

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -234,22 +234,38 @@ test.describe('Workstation — dense living-data composition', () => {
                 playElement     = document.querySelector('.workstation-tour-play'),
                 captionElement  = document.querySelector('.workstation-tour-caption'),
                 progressElement = document.querySelector('.workstation-tour-pips'),
+                storyElement    = document.querySelector('.workstation-tour-story'),
                 themeElement    = document.querySelector('.workstation-theme-button'),
                 play            = playElement?.getBoundingClientRect(),
                 caption         = captionElement?.getBoundingClientRect(),
                 progress        = progressElement?.getBoundingClientRect(),
+                story           = storyElement?.getBoundingClientRect(),
                 theme           = themeElement?.getBoundingClientRect();
 
             return {
                 captionLeft         : caption?.left,
                 captionPaddingLeft  : parseFloat(getComputedStyle(captionElement).paddingLeft),
+                playHeight          : play?.height,
                 playRight           : play?.right,
                 progressPaddingRight: parseFloat(getComputedStyle(progressElement).paddingRight),
                 progressRight       : progress?.right,
+                storyBackground     : getComputedStyle(storyElement).backgroundColor,
+                storyHeight         : story?.height,
+                storyMiddle         : story && story.top + story.height / 2,
+                themeHeight         : theme?.height,
+                themeMiddle         : theme && theme.top + theme.height / 2,
                 themeLeft           : theme?.left
             }
         });
 
+        expect(headerGeometry.playHeight, 'tour action uses the compact Workstation control height').toBe(34);
+        expect(headerGeometry.themeHeight, 'theme action uses the compact Workstation control height').toBe(34);
+        expect(headerGeometry.playHeight - headerGeometry.storyHeight, 'controls stay close to the story hierarchy')
+            .toBeLessThanOrEqual(8);
+        expect(Math.abs(headerGeometry.themeMiddle - headerGeometry.storyMiddle), 'controls and story remain centered')
+            .toBeLessThanOrEqual(1);
+        expect(headerGeometry.storyBackground, 'the story does not inherit a generic container fill')
+            .toBe('rgba(0, 0, 0, 0)');
         expect(headerGeometry.captionLeft - headerGeometry.playRight, 'tour action and story boxes never overlap')
             .toBeGreaterThanOrEqual(0);
         expect(headerGeometry.captionPaddingLeft, 'tour action and visible story copy have a deliberate gap')
@@ -276,6 +292,9 @@ test.describe('Workstation — dense living-data composition', () => {
                 gridHeader  = document.querySelector('.workstation-scale-pane .neo-grid-header-button'),
                 overflow    = document.querySelector('.neo-tab-overflow-control'),
                 rowAction   = document.querySelector('.workstation-row-action'),
+                story       = document.querySelector('.workstation-tour-story'),
+                tourButton  = document.querySelector('.workstation-tour-play'),
+                themeButton = document.querySelector('.workstation-theme-button'),
                 rippleToken = element => getComputedStyle(element)
                     .getPropertyValue('--button-ripple-background-color').trim().toLowerCase();
 
@@ -287,6 +306,9 @@ test.describe('Workstation — dense living-data composition', () => {
                 rowAction      : getComputedStyle(rowAction).backgroundColor,
                 rowActionBorder: getComputedStyle(rowAction).borderColor,
                 rowActionRipple: rippleToken(rowAction),
+                storyBackground: getComputedStyle(story).backgroundColor,
+                themeHeight    : themeButton.getBoundingClientRect().height,
+                tourHeight     : tourButton.getBoundingClientRect().height,
                 themeRipple    : rippleToken(document.querySelector('.workstation-theme-button'))
             }
         });
@@ -299,6 +321,10 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(lightChrome.rowAction, 'row actions do not use the default primary button').not.toBe('rgb(67, 93, 177)');
         expect(lightChrome.rowActionBorder).not.toBe('rgba(0, 0, 0, 0)');
         expect(lightChrome.rowActionRipple).not.toBe('#8ba6ff');
+        expect(lightChrome.storyBackground, 'light mode keeps the center story transparent')
+            .toBe('rgba(0, 0, 0, 0)');
+        expect(lightChrome.tourHeight).toBe(34);
+        expect(lightChrome.themeHeight).toBe(34);
         expect(lightChrome.themeRipple, 'theme-toggle feedback stays in the Workstation palette')
             .not.toBe('#8ba6ff');
 


### PR DESCRIPTION
Resolves #15164

Related: #13158, #14589, #15146

The standalone Workstation tourbar now keeps its controls subordinate to the story they operate: both actions use a local 34px height, while the center story explicitly clears the generic container fill. The existing Workstation whitebox journey pins the compact geometry, vertical alignment, transparent center, and dark/light skin parity without changing Neo's global button or container contracts.

Evidence: L3 (focused Chromium + Neural Link Workstation validation) → L3 required (live layout and skin ACs). No residuals.

## Deltas from ticket

- None.

## Test Evidence

- Dark theme build: `npm run build-themes -- -n -e dev -t theme-neo-dark` — passed.
- Light theme build: `npm run build-themes -- -n -e dev -t theme-neo-light` — passed.
- Standalone Workstation: `NEO_E2E_PORT=8124 npx playwright test workstation/WorkstationNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — 1 passed.
- Live Neural Link inspection: both actions compute to 34px; story remains 26px, centered within 1px, and transparent in both skins.
- Source gates: `npm run agent-preflight -- --no-fix` and `git diff --cached --check` — passed for both files.

## Post-Merge Validation

- None; every close-target AC has pre-merge L3 evidence.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session adddb25d-fc36-4b08-b9a3-3a62a108cda1.
