### PR TITLE
feat(workstation): adapt dock composition to viewport (#15165)

### DIFF
--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -3,6 +3,12 @@
 // reduced-motion collapse owned by Neo.dashboard.Container.
 
 .workstation-workspace {
+    // Workstation owns its edge-band projection policy. Inline container units let the
+    // secondary bands yield to the primary work surface without teaching dockZone.v1 about
+    // viewport pixels; the block-axis band follows the standalone viewport within the same
+    // bounded desktop contract.
+    container-type: inline-size;
+
     // Workstation is a standalone instrument, so generic grid/tab primitives inherit its own
     // palette in both skins instead of leaking their default blue/purple values.
     --grid-container-border-color              : var(--workstation-line);
@@ -120,13 +126,17 @@
 
     // The generic edge-zone defaults are symmetrical. Workstation's evidence column carries two
     // vertically stacked instruments, while the left queue card is intentionally simpler.
-    // Shift those forty pixels to the evidence side instead of starving both right-hand zones.
+    // Preserve those desktop maxima while yielding enough inline space for the primary grid.
     .neo-dashboard-dock-edge-band-left {
-        width: 260px;
+        width: clamp(180px, 20.3125cqi, 260px);
     }
 
     .neo-dashboard-dock-edge-band-right {
-        width: 320px;
+        width: clamp(220px, 25cqi, 320px);
+    }
+
+    .neo-dashboard-dock-edge-band-bottom {
+        height: clamp(140px, 28vh, 200px);
     }
 
     .neo-dashboard-dock-edge-rail {

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -9,9 +9,9 @@ import {workstationTourScript} from '../../../../apps/workstation/tour/denseWork
  * two stable Store<Model> identities, an exact 100k renderer-rich grid, a sustained capped
  * feed, one owner-exact overflow surface, two real rails, frame-sampled midpoint continuity,
  * Canvas-worker pixel change, DevIndex-sized chart geometry, honest progress paints, both
- * themes, visible real splitters, user-driven semantic resize, pane-owned chrome,
- * replacement-chrome motion containment, sequential clip-safe fixed staging, and identity
- * preservation.
+ * themes, viewport-adaptive edge bands, visible real splitters, user-driven semantic resize,
+ * pane-owned chrome, replacement-chrome motion containment, sequential clip-safe fixed staging,
+ * and identity preservation.
  *
  * Run: NEO_E2E_PORT=8124 npx playwright test workstation/WorkstationNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
@@ -225,6 +225,64 @@ const readHorizontalSplitGeometry = page => page.evaluate(() => {
     }
 });
 
+/**
+ * Reads Workstation's app-owned responsive dock projection from the browser CSSOM.
+ * @summary Pins viewport-driven edge-band geometry without treating the persisted dock document as layout state.
+ * @param {import('@playwright/test').Page} page
+ * @returns {Promise<Object>}
+ */
+const readResponsiveDockGeometry = page => page.evaluate(() => {
+    const
+        root      = document.querySelector('.workstation-workspace'),
+        dockHost  = document.querySelector('.workstation-dock-host'),
+        row       = document.querySelector('.neo-dashboard-dock-edge-row'),
+        left      = document.querySelector('.neo-dashboard-dock-edge-band-left'),
+        center    = row?.querySelector(':scope > .neo-dashboard-dock-split-horizontal'),
+        right     = document.querySelector('.neo-dashboard-dock-edge-band-right'),
+        bottom    = document.querySelector('.neo-dashboard-dock-edge-band-bottom'),
+        scale     = document.querySelector('.workstation-scale-pane'),
+        isVisible = element => {
+            const style = getComputedStyle(element);
+
+            return element.getClientRects().length > 0
+                && style.display !== 'none'
+                && style.visibility !== 'hidden'
+        },
+        readRect = element => {
+            const value = element?.getBoundingClientRect();
+
+            return value && {
+                bottom: value.bottom,
+                height: value.height,
+                left  : value.left,
+                right : value.right,
+                top   : value.top,
+                width : value.width
+            }
+        },
+        readBand = (element, property) => ({
+            ...readRect(element),
+            computedExtent: Number.parseFloat(getComputedStyle(element)[property])
+        });
+
+    return {
+        bottomBand      : readBand(bottom, 'height'),
+        center          : readRect(center),
+        dockHost        : readRect(dockHost),
+        leftBand        : readBand(left, 'width'),
+        overflowControls: [...document.querySelectorAll('.neo-tab-overflow-control')]
+            .filter(isVisible).length,
+        railTabs: [...document.querySelectorAll('.neo-dashboard-dock-rail-tab')]
+            .filter(isVisible).length,
+        rightBand: readBand(right, 'width'),
+        root     : readRect(root),
+        row      : readRect(row),
+        scale    : readRect(scale),
+        splitters: document.querySelectorAll('.neo-dashboard-dock-splitter').length,
+        viewport : {height: innerHeight, width: innerWidth}
+    }
+});
+
 test.describe('Workstation — dense living-data composition', () => {
     test.setTimeout(150000);
     test.use({viewport: {height: 1440, width: 2560}});
@@ -295,6 +353,109 @@ test.describe('Workstation — dense living-data composition', () => {
             root        = page.locator('.workstation-workspace'),
             tourButton  = page.locator('.workstation-tour-play'),
             themeToggle = page.locator('.workstation-theme-button');
+
+        const
+            {dockModel: responsiveDockModelBefore} = await app.getComponent(workspaceId, ['dockModel']),
+            {feedSequence: feedSequenceBefore}     = await app.getComponent(workspaceId, ['feedSequence']);
+
+        await page.evaluate(() => {
+            globalThis.__workstationResponsiveDocument = document;
+            globalThis.__workstationResponsiveScalePane = document.querySelector('.workstation-scale-pane')
+        });
+
+        /**
+         * @summary Resizes this loaded page and waits for the responsive dock projection to settle.
+         * @param {{height:Number,width:Number}} viewport
+         * @returns {Promise<Object>}
+         */
+        const readAtViewport = async viewport => {
+            await page.setViewportSize(viewport);
+            await expect.poll(async () => {
+                const geometry = await readResponsiveDockGeometry(page);
+
+                return {
+                    height   : Math.round(geometry.root.height),
+                    railTabs : geometry.railTabs,
+                    splitters: geometry.splitters,
+                    viewport : geometry.viewport,
+                    width    : Math.round(geometry.root.width)
+                }
+            }, {
+                message  : `Workstation settles at ${viewport.width}x${viewport.height}`,
+                timeout  : 10000,
+                intervals: [25, 50, 100]
+            }).toEqual({
+                height   : viewport.height,
+                railTabs : 2,
+                splitters: 2,
+                viewport,
+                width    : viewport.width
+            });
+
+            return readResponsiveDockGeometry(page)
+        };
+
+        const
+            wideGeometry   = await readAtViewport({height: 900, width: 1280}),
+            narrowGeometry = await readAtViewport({height: 900, width: 900}),
+            shortGeometry  = await readAtViewport({height: 600, width: 900});
+
+        expect(wideGeometry.leftBand.computedExtent).toBeCloseTo(260, 1);
+        expect(wideGeometry.rightBand.computedExtent).toBeCloseTo(320, 1);
+        expect(wideGeometry.bottomBand.computedExtent).toBeCloseTo(200, 1);
+        expect(narrowGeometry.leftBand.computedExtent).toBeCloseTo(182.8125, 1);
+        expect(narrowGeometry.rightBand.computedExtent).toBeCloseTo(225, 1);
+        expect(narrowGeometry.bottomBand.computedExtent).toBeCloseTo(200, 1);
+        expect(narrowGeometry.leftBand.width).toBeLessThan(wideGeometry.leftBand.width);
+        expect(narrowGeometry.rightBand.width).toBeLessThan(wideGeometry.rightBand.width);
+        expect(narrowGeometry.center.width, 'the primary center keeps its desktop working floor')
+            .toBeGreaterThanOrEqual(400);
+        expect(narrowGeometry.scale.width, 'the 100k-row primary grid remains usable')
+            .toBeGreaterThanOrEqual(230);
+        expect(narrowGeometry.row.left).toBeGreaterThanOrEqual(narrowGeometry.dockHost.left - 1);
+        expect(narrowGeometry.row.right).toBeLessThanOrEqual(narrowGeometry.dockHost.right + 1);
+        expect(narrowGeometry.center.left).toBeGreaterThanOrEqual(narrowGeometry.row.left - 1);
+        expect(narrowGeometry.center.right).toBeLessThanOrEqual(narrowGeometry.row.right + 1);
+        expect(narrowGeometry.scale.left).toBeGreaterThanOrEqual(narrowGeometry.center.left - 1);
+        expect(narrowGeometry.scale.right).toBeLessThanOrEqual(narrowGeometry.center.right + 1);
+        expect(narrowGeometry.overflowControls, 'tab overflow remains owner-exact at the narrow desktop floor')
+            .toBe(1);
+        expect(shortGeometry.bottomBand.computedExtent).toBeCloseTo(168, 1);
+        expect(shortGeometry.bottomBand.height).toBeLessThan(wideGeometry.bottomBand.height);
+        expect(shortGeometry.center.width).toBeCloseTo(narrowGeometry.center.width, 1);
+        expect(shortGeometry.scale.width).toBeCloseTo(narrowGeometry.scale.width, 1);
+        expect(shortGeometry.scale.height, 'the short desktop keeps a usable primary grid height')
+            .toBeGreaterThanOrEqual(230);
+        expect(shortGeometry.bottomBand.bottom).toBeLessThanOrEqual(shortGeometry.dockHost.bottom + 1);
+        expect(shortGeometry.overflowControls).toBe(1);
+
+        const
+            responsiveIdentityAfter               = await readIdentity(app, workspaceId),
+            {dockModel: responsiveDockModelAfter} = await app.getComponent(workspaceId, ['dockModel']);
+
+        expect(responsiveDockModelAfter, 'viewport projection never rewrites dockZone.v1')
+            .toEqual(responsiveDockModelBefore);
+        expect(responsiveDockModelAfter.nodes['split-main'].sizes).toEqual([0.6, 0.4]);
+        expect(responsiveDockModelAfter.nodes['split-right'].sizes).toEqual([0.5, 0.5]);
+        expect(responsiveIdentityAfter, 'viewport resizing preserves panes, Provider, and Store<Model> identities')
+            .toEqual(beforeIdentity);
+        expect(
+            await page.evaluate(() => globalThis.__workstationResponsiveDocument === document
+                && globalThis.__workstationResponsiveScalePane === document.querySelector('.workstation-scale-pane')),
+            'the same document and primary pane survive every viewport'
+        ).toBe(true);
+        await expect.poll(async () => (await app.getComponent(workspaceId, ['feedSequence'])).feedSequence, {
+            message  : 'the live feed keeps advancing through viewport-only projection changes',
+            timeout  : 3000,
+            intervals: [100, 250]
+        }).toBeGreaterThan(feedSequenceBefore);
+
+        const restoredGeometry = await readAtViewport({height: 1440, width: 2560});
+
+        expect(restoredGeometry.leftBand.computedExtent).toBeCloseTo(260, 1);
+        expect(restoredGeometry.rightBand.computedExtent).toBeCloseTo(320, 1);
+        expect(restoredGeometry.bottomBand.computedExtent).toBeCloseTo(200, 1);
+        expect(restoredGeometry.overflowControls).toBe(1);
 
         await expect(tourButton).toHaveText('Start dense tour');
         await expect(themeToggle, 'one action-labelled theme toggle replaces two mode buttons').toHaveCount(1);


### PR DESCRIPTION
Resolves #15165

Workstation now keeps its 260px/320px/200px desktop edge-band maxima while app-owned bounded CSS lets the secondary side bands yield at the 900px desktop floor and the bottom band yield on a 600px-tall viewport. The persisted `dockZone.v1` document remains untouched; the same-page whitebox journey proves the center grid, rails, overflow, split ratios, Provider, live Store<Model> instances, feed producer, and pane identities survive every resize.

Evidence: L3 (same-page Chromium CSSOM geometry plus Neural Link runtime continuity) → L3 required (all live viewport-resize acceptance criteria). No residuals.

## Deltas from ticket

None substantive. The projection uses inline container units for left/right geometry and a bounded viewport-relative block extent, keeping pixel policy in Workstation SCSS rather than adding resize mutations to the dock document.

## Test Evidence

- Workstation: `NEO_E2E_PORT=8124 npx playwright test workstation/WorkstationNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — 1 passed (20.6s).
- Theme compilation: `npm run build-themes -- -n -e dev -t theme-neo-dark` and `npm run build-themes -- -n -e dev -t theme-neo-light` — passed.
- Source gates: `npm run agent-preflight -- resources/scss/src/apps/workstation/Workspace.scss test/playwright/e2e/workstation/WorkstationNL.spec.mjs` — passed.

## Post-Merge Validation

- [ ] Confirm the Workstation whitebox shard remains green on the exact merged `dev` head.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session adddb25d-fc36-4b08-b9a3-3a62a108cda1.
