### PR TITLE
feat(workstation): preserve dock tab chrome identity (#15136)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -4,6 +4,7 @@ import CounterPane                        from './CounterPane.mjs';
 import DockLayoutAdapter                  from '../../../../../src/dashboard/DockLayoutAdapter.mjs';
 import DockMotionSignal                   from '../../../../../src/dashboard/DockMotionSignal.mjs';
 import DockPerspectiveStore               from '../../../../../src/dashboard/DockPerspectiveStore.mjs';
+import DockProjectionReconciler           from '../../../../../src/dashboard/DockProjectionReconciler.mjs';
 import DockService                        from '../../../../../src/ai/client/DockService.mjs';
 import DockTopologyReconciler             from '../../../../../src/dashboard/DockTopologyReconciler.mjs';
 import DockZoneModel                      from '../../../../../src/dashboard/DockZoneModel.mjs';
@@ -28,7 +29,7 @@ import '../../../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype 
  *   The switcher bar rebuilds from store lifecycle events — buttons are born from
  *   `perspectiveSaved`, never hardcoded.
  * - **Pop-out** rides the shared-heap vessel: panes are INSTANCE-CACHED (created once,
- *   parked across every re-projection — the reveal-pane-cache precedent), so detaching the
+ *   handed across every re-projection by `DockProjectionReconciler`), so detaching the
  *   workbench moves the LIVE component into the popup window's view tree
  *   (`mainView.add(instance)` — both windows share one App Worker) and reattaching moves it
  *   home. The {@link AgentOS.childapps.dockdemo.view.CounterPane} witness makes the
@@ -97,8 +98,8 @@ class DemoBWorkspace extends Container {
      */
     tourRunner = null
     /**
-     * Pane instances by item id — created ONCE, parked (removed without destroy) across
-     * every re-projection and window move, torn down only with the workspace. THE
+     * Pane instances by item id — created ONCE, handed across every re-projection and
+     * parked only for explicit window moves, torn down only with the workspace. THE
      * object-permanence substrate: `resolvePane` hands the adapter these live instances,
      * so no morph, pop-out, or reattach ever remounts a pane.
      * @member {Object} paneCache={}
@@ -352,13 +353,13 @@ class DemoBWorkspace extends Container {
             liveDocuments = hasLivePopup ? [me.dockModel, me.popupDocument] : [me.dockModel],
             result        = DockTopologyReconciler.reconcile(layout, liveDocuments),
             report        = DockZoneModel.clone({
-                applied       : result.applied,
-                displaced     : result.displaced,
-                errors        : result.errors,
-                mapping       : result.mapping,
+                applied        : result.applied,
+                displaced      : result.displaced,
+                errors         : result.errors,
+                mapping        : result.mapping,
                 noWindowSpawned: true,
-                unmatchedLive : result.unmatchedLive,
-                unrestored    : result.unrestored
+                unmatchedLive  : result.unmatchedLive,
+                unrestored     : result.unrestored
             });
 
         me.restoreReport = report;
@@ -382,10 +383,10 @@ class DemoBWorkspace extends Container {
      * @protected
      */
     renderRestoreReport() {
-        let me      = this,
-            target  = me.getReference('restore-report-b'),
-            report  = me.restoreReport,
-            escape  = value => String(value)
+        let me     = this,
+            target = me.getReference('restore-report-b'),
+            report = me.restoreReport,
+            escape = value => String(value)
                 .replaceAll('&', '&amp;')
                 .replaceAll('<', '&lt;')
                 .replaceAll('>', '&gt;'),
@@ -581,15 +582,17 @@ class DemoBWorkspace extends Container {
 
     /**
      * Projects the committed document, threading the instance-bound holder callbacks.
+     * @param {Function|null} [resolveComponentRef=null]
      * @returns {Object}
      */
-    projectDockModel() {
+    projectDockModel(resolveComponentRef=null) {
         let me = this;
 
         return DockLayoutAdapter.project(me.dockModel, {
             applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
             onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
-            resolveComponentRef     : (componentRef, item, itemId) => me.resolvePane(itemId, item)
+            resolveComponentRef     : resolveComponentRef
+                || ((componentRef, item, itemId) => me.resolvePane(itemId, item))
         })
     }
 
@@ -647,16 +650,16 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * Rebuilds the toolbar-adjacent projection from the committed document, FLIP-bracketed.
-     * Cached pane instances are PARKED first (removed without destroy) so the coarse
-     * teardown of the old projection shell can never reap them — the object-permanence
-     * mechanic every capability in this demo leans on.
+     * Reconciles the toolbar-adjacent projection from the committed document, FLIP-bracketed.
+     * The shared projection reconciler moves cached panes and tab chrome into the staged tree
+     * before retiring the empty shell, so object permanence no longer depends on coarse parking.
      * @protected
      */
     async refreshDockWorkspace() {
         const
-            me   = this,
-            host = me.getReference('dock-host-b');
+            me           = this,
+            host         = me.getReference('dock-host-b'),
+            placeholders = new Map();
 
         if (host) {
             const flip = Neo.main?.addon?.DockFlip;
@@ -665,13 +668,24 @@ class DemoBWorkspace extends Container {
                 await flip?.captureFirst({hostId: host.id, markerPrefix: 'agentos-dockdemo-pane-'})
             } catch (e) {/* instant landing */}
 
-            // park every cached live pane before the old projection tree is destroyed
-            Object.values(me.paneCache).forEach(pane => {
-                pane?.parent && !pane.isDestroyed && pane.parent.remove(pane, false)
+            const nextConfig = me.projectDockModel((componentRef, item, itemId) => {
+                const placeholder = Neo.create({
+                    module: Component,
+                    header: {text: item?.title ?? itemId},
+                    hidden: true
+                });
+
+                placeholders.set(itemId, placeholder);
+
+                return placeholder
             });
 
-            host.removeAt(0);
-            host.insert(0, me.projectDockModel());
+            await DockProjectionReconciler.reconcileProjection({
+                host,
+                nextConfig,
+                placeholders,
+                resolveItem: itemId => me.resolvePane(itemId, me.dockModel.items[itemId])
+            });
 
             if (flip) {
                 DockMotionSignal.enter(me);

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -6,6 +6,7 @@ import Scale                                    from '../store/Scale.mjs';
 import ScalePane                                from './ScalePane.mjs';
 import DockLayoutAdapter                        from '../../../src/dashboard/DockLayoutAdapter.mjs';
 import DockMotionSignal                         from '../../../src/dashboard/DockMotionSignal.mjs';
+import DockProjectionReconciler                 from '../../../src/dashboard/DockProjectionReconciler.mjs';
 import DockService                              from '../../../src/ai/client/DockService.mjs';
 import DockZoneModel                            from '../../../src/dashboard/DockZoneModel.mjs';
 import StateProvider                            from '../../../src/state/Provider.mjs';
@@ -570,281 +571,6 @@ class Workspace extends Container {
     }
 
     /**
-     * Returns every tab-overflow projection owned by one dock shell.
-     * @param {Neo.container.Base} shell
-     * @returns {Neo.tab.plugin.Overflow[]}
-     */
-    getOverflowPlugins(shell) {
-        return Object.entries(this.dockModel.nodes)
-            .filter(([, node]) => node.type === 'tabs')
-            .map(([nodeId]) => shell.down({dockNodeId: nodeId})?.getTabBar()?.getPlugin('tab-overflow'))
-            .filter(Boolean)
-    }
-
-    /**
-     * @summary Collects the keyed tab-chrome owners below one projected dock shell.
-     * @param {Neo.component.Base|null} root
-     * @returns {Map<String,Neo.tab.Container>}
-     */
-    collectProjectedTabs(root) {
-        const tabs = new Map();
-
-        const visit = component => {
-            if (!component || component.isDestroyed) return;
-
-            if (component.dockNodeType === 'tabs') {
-                tabs.set(component.dockNodeId, component);
-                return
-            }
-
-            component.items?.forEach(visit)
-        };
-
-        visit(root);
-
-        return tabs
-    }
-
-    /**
-     * @summary Replaces surviving projected tab configs with geometry-equivalent staging placeholders.
-     *
-     * The adapter remains a stateless JSON-to-config projection. Workstation alone keys the config
-     * by `dockNodeId`, records its desired item/active state, and substitutes a visibility-hidden
-     * component only when a live tab container with that logical identity already exists.
-     * @param {*} config
-     * @param {Map<String,Neo.tab.Container>} currentTabs
-     * @param {Map<String,Object>} plans
-     * @returns {*}
-     */
-    prepareTabChromeProjection(config, currentTabs, plans) {
-        if (Array.isArray(config)) {
-            return config.map(item => this.prepareTabChromeProjection(item, currentTabs, plans))
-        }
-
-        if (config?.constructor !== Object) return config;
-
-        if (config.dockNodeType === 'tabs') {
-            const
-                nodeId       = config.dockNodeId,
-                currentTab   = currentTabs.get(nodeId) || null,
-                desiredItems = [...(config.headerToolbar?.sortZoneConfig?.dockItemIds || [])],
-                plan         = {
-                    activeIndex: config.activeIndex,
-                    config,
-                    desiredItems,
-                    placeholder: null,
-                    tab        : currentTab
-                };
-
-            plans.set(nodeId, plan);
-
-            if (currentTab) {
-                plan.placeholder = Neo.create({
-                    module  : Component,
-                    cls     : ['workstation-tab-chrome-placeholder'],
-                    flex    : config.flex,
-                    hidden  : true,
-                    hideMode: 'visibility',
-                    style   : config.style
-                });
-
-                return plan.placeholder
-            }
-
-            return config
-        }
-
-        return Array.isArray(config.items)
-            ? {...config, items: this.prepareTabChromeProjection(config.items, currentTabs, plans)}
-            : config
-    }
-
-    /**
-     * @summary Moves retained tab chrome into its staged projected slot silently.
-     *
-     * Cross-tab card/button moves commit before this method runs. Keeping descendant and ancestor moves
-     * in separate host updates prevents the main-thread delta from retiring a child after its ancestor
-     * has already landed. New/removed logical tab nodes remain ordinary projected instances.
-     * @param {Map<String,Object>} plans
-     * @returns {Map<String,Object>}
-     */
-    moveRetainedTabChrome(plans) {
-        plans.forEach((plan, nodeId) => {
-            const
-                tab          = plan.tab,
-                placeholder  = plan.placeholder,
-                sourceParent = tab?.parent,
-                targetParent = placeholder?.parent,
-                targetIndex  = targetParent?.indexOf(placeholder) ?? -1;
-
-            if (!placeholder) return;
-
-            if (!sourceParent || !targetParent || targetIndex < 0) {
-                throw new Error(`Workstation could not stage surviving tab chrome "${nodeId}"`)
-            }
-
-            // A floating overflow control is aligned outside the dock host. Its target toolbar briefly
-            // leaves the main-thread DOM during native reparenting, and the align layer hides the control.
-            // Visibility mode keeps that exact DOM node mounted until the destination target is present.
-            tab.getTabBar()?.getPlugin('tab-overflow')?.control?.setSilent({hideMode: 'visibility'});
-            targetParent.remove(placeholder, true, true);
-            sourceParent.remove(tab, false, true, true);
-            tab.setSilent({
-                cls      : plan.config.cls,
-                flex     : plan.config.flex,
-                listeners: plan.config.listeners,
-                style    : plan.config.style,
-                // Flexbox stores parent-owned sizing on the child's wrapper. A retained tab
-                // otherwise carries its source split ratio into the destination projection.
-                wrapperStyle: {...tab.wrapperStyle, flex: plan.config.flex ?? null}
-            });
-            targetParent.insert(targetIndex, tab, true, false)
-        });
-
-        return plans
-    }
-
-    /**
-     * @summary Reconciles paired live cards/buttons before their retained tab ancestors move.
-     *
-     * Both shells are mounted before this method runs. Cross-tab transfers first move each cached pane
-     * and existing header button as a pair while their tab-container ancestors remain stationary. The
-     * caller commits this ownership layer before `moveRetainedTabChrome()` handles the ancestor layer.
-     * @param {Map<String,Object>} plans
-     * @param {Map<String,Neo.component.Base>} placeholders
-     * @param {Map<String,Neo.tab.Container>} currentTabs
-     * @param {Neo.container.Base} nextShell
-     * @returns {Map<String,Object>}
-     */
-    reconcileTabChrome(plans, placeholders, currentTabs, nextShell) {
-        const me = this;
-
-        const
-            nextTabs = me.collectProjectedTabs(nextShell),
-            allTabs  = new Set([...currentTabs.values(), ...nextTabs.values()]);
-
-        plans.forEach((plan, nodeId) => {
-            plan.tab = nextTabs.get(nodeId) || plan.tab;
-
-            if (!plan.tab) {
-                throw new Error(`Workstation did not project tab chrome "${nodeId}"`)
-            }
-        });
-
-        const findItemState = pane => {
-            for (const tab of allTabs) {
-                if (tab.isDestroyed) continue;
-
-                const
-                    body  = tab.getCardContainer(),
-                    index = body?.items.indexOf(pane) ?? -1;
-
-                if (index > -1) {
-                    return {
-                        bar   : tab.getTabBar(),
-                        body,
-                        button: tab.getTabBar().items[index],
-                        index,
-                        tab
-                    }
-                }
-            }
-
-            return null
-        };
-
-        plans.forEach(plan => {
-            const
-                targetTab  = plan.tab,
-                targetBar  = targetTab.getTabBar(),
-                targetBody = targetTab.getCardContainer();
-
-            plan.desiredItems.forEach((itemId, targetIndex) => {
-                const
-                    item        = me.dockModel.items[itemId],
-                    pane        = me.resolvePane(itemId, item),
-                    placeholder = placeholders.get(itemId);
-
-                if (placeholder?.parent) {
-                    const placeholderIndex = targetBody.indexOf(placeholder);
-
-                    if (placeholder.parent !== targetBody || placeholderIndex < 0) {
-                        throw new Error(`Workstation projected item "${itemId}" into the wrong tab body`)
-                    }
-
-                    targetBody.removeAt(placeholderIndex, true, true);
-                    targetBar.removeAt(placeholderIndex, true, true);
-                    placeholders.delete(itemId)
-                }
-
-                const state = findItemState(pane);
-
-                if (!state) {
-                    targetTab.insert(targetIndex, pane, true);
-                    return
-                }
-
-                if (state.tab === targetTab && state.index === targetIndex) return;
-
-                state.body.removeAt(state.index, false, true, true);
-                state.bar.removeAt(state.index, false, true, true);
-                targetBody.insert(targetIndex, pane, true, false);
-                targetBar.insert(targetIndex, state.button, true, false)
-            })
-        });
-
-        plans.forEach((plan, nodeId) => {
-            const
-                tab                 = plan.tab,
-                bar                 = tab.getTabBar(),
-                body                = tab.getCardContainer(),
-                activeIndex         = plan.activeIndex,
-                projectedSortConfig = plan.config.headerToolbar?.sortZoneConfig || {},
-                sortConfig          = {
-                    ...bar.sortZoneConfig,
-                    ...projectedSortConfig,
-                    dockItemIds: [...plan.desiredItems]
-                };
-
-            if (body.items.length !== plan.desiredItems.length
-                || bar.items.length !== plan.desiredItems.length) {
-                throw new Error(`Workstation tab chrome "${nodeId}" did not reconcile its exact item set`)
-            }
-
-            tab._activeIndex         = activeIndex;
-            body.layout._activeIndex = activeIndex;
-            bar.setSilent({sortZoneConfig: sortConfig});
-            bar.sortZone?.setSilent?.({
-                dockItemIds     : [...plan.desiredItems],
-                dockSourceNodeId: sortConfig.dockSourceNodeId,
-                dockWorkspaceId : sortConfig.dockWorkspaceId,
-                sortGroup       : sortConfig.sortGroup
-            });
-
-            plan.desiredItems.forEach((itemId, index) => {
-                const
-                    pane   = me.resolvePane(itemId, me.dockModel.items[itemId]),
-                    button = bar.items[index],
-                    header = tab.getTabButtonConfig(pane.header, index);
-
-                if (body.items[index] !== pane || !button) {
-                    throw new Error(`Workstation tab chrome "${nodeId}" lost item "${itemId}"`)
-                }
-
-                body.layout.applyChildAttributes(pane, index, true);
-                button.setSilent({
-                    domListeners: header.domListeners,
-                    index,
-                    pressed     : index === activeIndex,
-                    text        : header.text
-                })
-            })
-        });
-
-        return plans
-    }
-
-    /**
      * @summary Returns a serializable identity receipt for one live logical tab surface.
      * @param {String} nodeId
      * @returns {Object|null}
@@ -852,7 +578,7 @@ class Workspace extends Container {
     getTabChromeIdentity(nodeId) {
         const
             shell = this.getReference('dock-host')?.items[0],
-            tab   = this.collectProjectedTabs(shell).get(nodeId);
+            tab   = DockProjectionReconciler.collectProjectedTabs(shell).get(nodeId);
 
         if (!tab) return null;
 
@@ -882,15 +608,9 @@ class Workspace extends Container {
     /**
      * Atomically hands cached panes from the current projection to a staged next projection.
      *
-     * The next shell is first mounted with `hideMode: 'visibility'` and non-rendered placeholders,
-     * so every old and new pane parent exists in the rendered tree and has this host as its real
-     * lowest common ancestor. Replacing each placeholder through `Container.insert()` then uses
-     * Neo's native cross-parent atomic-move path: the live pane is detached silently with
-     * `keepMounted`, inserted at the model-owned target index, and remains the same DOM node. The
-     * old shell is retained but hidden for the one full host update that reconciles the ownership
-     * transaction. Only after every live DOM node has moved is that now-empty shell removed in a
-     * cleanup update. The newly visible toolbar then recaptures its natural widths; a zero-control
-     * interval is valid when the reduced tab set fits.
+     * {@link Neo.dashboard.DockProjectionReconciler} owns the renderer-safe staged ownership
+     * transaction shared with other docking workspaces. Workstation supplies its cached-pane resolver,
+     * header text, FLIP motion, retained-indicator suppression, and the heavy Overflow menu witness.
      * @returns {Promise<void>}
      */
     async refreshDockWorkspace() {
@@ -906,101 +626,41 @@ class Workspace extends Container {
             await flip?.captureFirst({hostId: host.id, markerPrefix: 'workstation-pane-'})
         } catch (error) {/* instant landing */}
 
-        const
-            oldShell    = host.items[0],
-            currentTabs = me.collectProjectedTabs(oldShell),
-            tabPlans    = new Map(),
-            nextConfig  = me.prepareTabChromeProjection(me.projectDockModel((componentRef, item, itemId) => {
-                const placeholder = Neo.create({
-                    module: Component,
-                    header: {text: me.getPaneHeaderText(itemId, item)},
-                    hidden: true
-                });
+        const nextConfig = me.projectDockModel((componentRef, item, itemId) => {
+            const placeholder = Neo.create({
+                module: Component,
+                header: {text: me.getPaneHeaderText(itemId, item)},
+                hidden: true
+            });
 
-                placeholders.set(itemId, placeholder);
+            placeholders.set(itemId, placeholder);
 
-                return placeholder
-            }), currentTabs, tabPlans);
-
-        // Pane placeholders inside a discarded config for a retained tab node never enter a parent.
-        // Retire them now; only genuinely new tab nodes need their projected placeholders for pairing.
-        tabPlans.forEach(plan => {
-            if (!plan.tab) return;
-
-            plan.desiredItems.forEach(itemId => {
-                const placeholder = placeholders.get(itemId);
-
-                if (placeholder && !placeholder.parent) {
-                    placeholder.destroy();
-                    placeholders.delete(itemId)
-                }
-            })
+            return placeholder
         });
 
-        nextConfig.hidden   = true;
-        nextConfig.hideMode = 'visibility';
+        let animationSuppressedBars = [];
 
-        const nextShell = host.insert(host.items.length, nextConfig, true);
+        const {nextShell} = await DockProjectionReconciler.reconcileProjection({
+            host,
+            nextConfig,
+            placeholders,
+            resolveItem: itemId => me.resolvePane(itemId, me.dockModel.items[itemId]),
+            onProjectionStaged({plans}) {
+                const retainedTabBars = [...plans.values()]
+                    .filter(plan => plan.tab)
+                    .map(plan => plan.tab.getTabBar());
 
-        const
-            retainedTabBars = [...tabPlans.values()]
-                .filter(plan => plan.tab)
-                .map(plan => plan.tab.getTabBar()),
-            animationSuppressedBars = retainedTabBars
-                .filter(bar => !bar.cls.includes('neo-no-animation'));
+                animationSuppressedBars = retainedTabBars
+                    .filter(bar => !bar.cls.includes('neo-no-animation'));
 
-        // Native reparenting keeps each toolbar DOM node, but CSS animations restart when that node
-        // re-enters the document. Reuse the tab drag contract so retained pressed indicators settle at
-        // their final color immediately; genuinely new tab chrome keeps its ordinary entry animation.
-        animationSuppressedBars.forEach(bar => {
-            bar.setSilent({cls: [...bar.cls, 'neo-no-animation']})
+                // Native reparenting keeps each toolbar DOM node, but CSS animations restart when it
+                // re-enters the document. Retained indicators settle immediately; new chrome still enters.
+                animationSuppressedBars.forEach(bar => {
+                    bar.setSilent({cls: [...bar.cls, 'neo-no-animation']})
+                })
+            },
+            waitForOverflowProjection: plugin => me.waitForOverflowProjection(plugin)
         });
-
-        // Atomic moves require both ownership paths to exist in the rendered tree. This update
-        // mounts only the visibility-hidden target shell; layered ownership commits then move
-        // retained pane/header pairs before their ancestor tab containers.
-        host.updateDepth = -1;
-        host.update();
-        await host.promiseUpdate();
-
-        me.reconcileTabChrome(tabPlans, placeholders, currentTabs, nextShell);
-
-        // A removed logical tab can be the source of a returning pane. Hide that now-empty source in
-        // the descendant commit; the next commit destroys it with the retiring shell exactly once.
-        currentTabs.forEach((tab, nodeId) => {
-            if (!tabPlans.has(nodeId)) {
-                tab.setSilent({hideMode: 'visibility', hidden: true})
-            }
-        });
-        host.updateDepth = -1;
-        host.update();
-        await host.promiseUpdate();
-
-        me.moveRetainedTabChrome(tabPlans);
-
-        oldShell.setSilent({hideMode: 'visibility'});
-        oldShell.setSilent({hidden: true});
-        nextShell.setSilent({hidden: false});
-        host.updateDepth = -1;
-        host.update();
-        await host.promiseUpdate();
-
-        // Descendants and retained tab ancestors have now landed in separate ownership commits. This
-        // cleanup update removes only the empty shell and any genuinely retired tab chrome.
-        oldShell !== nextShell && host.remove(oldShell, true, true);
-        host.updateDepth = -1;
-        host.update();
-        await host.promiseUpdate();
-
-        const overflowPlugins = me.getOverflowPlugins(nextShell);
-
-        // Retained plugins keep their exact control identity. Re-capture only after the ownership commit,
-        // when every paired button is under its final toolbar and the visible shell owns current geometry.
-        overflowPlugins.forEach(plugin => {
-            plugin.control?.hidden && (plugin.control.hidden = false)
-        });
-        await Promise.all(overflowPlugins.map(plugin => plugin.project(true)));
-        await Promise.all(overflowPlugins.map(plugin => me.waitForOverflowProjection(plugin)));
 
         const heavyOverflow = nextShell.down({dockNodeId: 'heavy-tabs'})
             ?.getTabBar()?.getPlugin('tab-overflow');

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -582,6 +582,304 @@ class Workspace extends Container {
     }
 
     /**
+     * @summary Collects the keyed tab-chrome owners below one projected dock shell.
+     * @param {Neo.component.Base|null} root
+     * @returns {Map<String,Neo.tab.Container>}
+     */
+    collectProjectedTabs(root) {
+        const tabs = new Map();
+
+        const visit = component => {
+            if (!component || component.isDestroyed) return;
+
+            if (component.dockNodeType === 'tabs') {
+                tabs.set(component.dockNodeId, component);
+                return
+            }
+
+            component.items?.forEach(visit)
+        };
+
+        visit(root);
+
+        return tabs
+    }
+
+    /**
+     * @summary Replaces surviving projected tab configs with geometry-equivalent staging placeholders.
+     *
+     * The adapter remains a stateless JSON-to-config projection. Workstation alone keys the config
+     * by `dockNodeId`, records its desired item/active state, and substitutes a visibility-hidden
+     * component only when a live tab container with that logical identity already exists.
+     * @param {*} config
+     * @param {Map<String,Neo.tab.Container>} currentTabs
+     * @param {Map<String,Object>} plans
+     * @returns {*}
+     */
+    prepareTabChromeProjection(config, currentTabs, plans) {
+        if (Array.isArray(config)) {
+            return config.map(item => this.prepareTabChromeProjection(item, currentTabs, plans))
+        }
+
+        if (config?.constructor !== Object) return config;
+
+        if (config.dockNodeType === 'tabs') {
+            const
+                nodeId       = config.dockNodeId,
+                currentTab   = currentTabs.get(nodeId) || null,
+                desiredItems = [...(config.headerToolbar?.sortZoneConfig?.dockItemIds || [])],
+                plan         = {
+                    activeIndex: config.activeIndex,
+                    config,
+                    desiredItems,
+                    placeholder: null,
+                    tab        : currentTab
+                };
+
+            plans.set(nodeId, plan);
+
+            if (currentTab) {
+                plan.placeholder = Neo.create({
+                    module  : Component,
+                    cls     : ['workstation-tab-chrome-placeholder'],
+                    flex    : config.flex,
+                    hidden  : true,
+                    hideMode: 'visibility',
+                    style   : config.style
+                });
+
+                return plan.placeholder
+            }
+
+            return config
+        }
+
+        return Array.isArray(config.items)
+            ? {...config, items: this.prepareTabChromeProjection(config.items, currentTabs, plans)}
+            : config
+    }
+
+    /**
+     * @summary Moves retained tab chrome into its staged projected slot silently.
+     *
+     * Cross-tab card/button moves commit before this method runs. Keeping descendant and ancestor moves
+     * in separate host updates prevents the main-thread delta from retiring a child after its ancestor
+     * has already landed. New/removed logical tab nodes remain ordinary projected instances.
+     * @param {Map<String,Object>} plans
+     * @returns {Map<String,Object>}
+     */
+    moveRetainedTabChrome(plans) {
+        plans.forEach((plan, nodeId) => {
+            const
+                tab          = plan.tab,
+                placeholder  = plan.placeholder,
+                sourceParent = tab?.parent,
+                targetParent = placeholder?.parent,
+                targetIndex  = targetParent?.indexOf(placeholder) ?? -1;
+
+            if (!placeholder) return;
+
+            if (!sourceParent || !targetParent || targetIndex < 0) {
+                throw new Error(`Workstation could not stage surviving tab chrome "${nodeId}"`)
+            }
+
+            // A floating overflow control is aligned outside the dock host. Its target toolbar briefly
+            // leaves the main-thread DOM during native reparenting, and the align layer hides the control.
+            // Visibility mode keeps that exact DOM node mounted until the destination target is present.
+            tab.getTabBar()?.getPlugin('tab-overflow')?.control?.setSilent({hideMode: 'visibility'});
+            targetParent.remove(placeholder, true, true);
+            sourceParent.remove(tab, false, true, true);
+            tab.setSilent({
+                cls      : plan.config.cls,
+                flex     : plan.config.flex,
+                listeners: plan.config.listeners,
+                style    : plan.config.style,
+                // Flexbox stores parent-owned sizing on the child's wrapper. A retained tab
+                // otherwise carries its source split ratio into the destination projection.
+                wrapperStyle: {...tab.wrapperStyle, flex: plan.config.flex ?? null}
+            });
+            targetParent.insert(targetIndex, tab, true, false)
+        });
+
+        return plans
+    }
+
+    /**
+     * @summary Reconciles paired live cards/buttons before their retained tab ancestors move.
+     *
+     * Both shells are mounted before this method runs. Cross-tab transfers first move each cached pane
+     * and existing header button as a pair while their tab-container ancestors remain stationary. The
+     * caller commits this ownership layer before `moveRetainedTabChrome()` handles the ancestor layer.
+     * @param {Map<String,Object>} plans
+     * @param {Map<String,Neo.component.Base>} placeholders
+     * @param {Map<String,Neo.tab.Container>} currentTabs
+     * @param {Neo.container.Base} nextShell
+     * @returns {Map<String,Object>}
+     */
+    reconcileTabChrome(plans, placeholders, currentTabs, nextShell) {
+        const me = this;
+
+        const
+            nextTabs = me.collectProjectedTabs(nextShell),
+            allTabs  = new Set([...currentTabs.values(), ...nextTabs.values()]);
+
+        plans.forEach((plan, nodeId) => {
+            plan.tab = nextTabs.get(nodeId) || plan.tab;
+
+            if (!plan.tab) {
+                throw new Error(`Workstation did not project tab chrome "${nodeId}"`)
+            }
+        });
+
+        const findItemState = pane => {
+            for (const tab of allTabs) {
+                if (tab.isDestroyed) continue;
+
+                const
+                    body  = tab.getCardContainer(),
+                    index = body?.items.indexOf(pane) ?? -1;
+
+                if (index > -1) {
+                    return {
+                        bar   : tab.getTabBar(),
+                        body,
+                        button: tab.getTabBar().items[index],
+                        index,
+                        tab
+                    }
+                }
+            }
+
+            return null
+        };
+
+        plans.forEach(plan => {
+            const
+                targetTab  = plan.tab,
+                targetBar  = targetTab.getTabBar(),
+                targetBody = targetTab.getCardContainer();
+
+            plan.desiredItems.forEach((itemId, targetIndex) => {
+                const
+                    item        = me.dockModel.items[itemId],
+                    pane        = me.resolvePane(itemId, item),
+                    placeholder = placeholders.get(itemId);
+
+                if (placeholder?.parent) {
+                    const placeholderIndex = targetBody.indexOf(placeholder);
+
+                    if (placeholder.parent !== targetBody || placeholderIndex < 0) {
+                        throw new Error(`Workstation projected item "${itemId}" into the wrong tab body`)
+                    }
+
+                    targetBody.removeAt(placeholderIndex, true, true);
+                    targetBar.removeAt(placeholderIndex, true, true);
+                    placeholders.delete(itemId)
+                }
+
+                const state = findItemState(pane);
+
+                if (!state) {
+                    targetTab.insert(targetIndex, pane, true);
+                    return
+                }
+
+                if (state.tab === targetTab && state.index === targetIndex) return;
+
+                state.body.removeAt(state.index, false, true, true);
+                state.bar.removeAt(state.index, false, true, true);
+                targetBody.insert(targetIndex, pane, true, false);
+                targetBar.insert(targetIndex, state.button, true, false)
+            })
+        });
+
+        plans.forEach((plan, nodeId) => {
+            const
+                tab                 = plan.tab,
+                bar                 = tab.getTabBar(),
+                body                = tab.getCardContainer(),
+                activeIndex         = plan.activeIndex,
+                projectedSortConfig = plan.config.headerToolbar?.sortZoneConfig || {},
+                sortConfig          = {
+                    ...bar.sortZoneConfig,
+                    ...projectedSortConfig,
+                    dockItemIds: [...plan.desiredItems]
+                };
+
+            if (body.items.length !== plan.desiredItems.length
+                || bar.items.length !== plan.desiredItems.length) {
+                throw new Error(`Workstation tab chrome "${nodeId}" did not reconcile its exact item set`)
+            }
+
+            tab._activeIndex         = activeIndex;
+            body.layout._activeIndex = activeIndex;
+            bar.setSilent({sortZoneConfig: sortConfig});
+            bar.sortZone?.setSilent?.({
+                dockItemIds     : [...plan.desiredItems],
+                dockSourceNodeId: sortConfig.dockSourceNodeId,
+                dockWorkspaceId : sortConfig.dockWorkspaceId,
+                sortGroup       : sortConfig.sortGroup
+            });
+
+            plan.desiredItems.forEach((itemId, index) => {
+                const
+                    pane   = me.resolvePane(itemId, me.dockModel.items[itemId]),
+                    button = bar.items[index],
+                    header = tab.getTabButtonConfig(pane.header, index);
+
+                if (body.items[index] !== pane || !button) {
+                    throw new Error(`Workstation tab chrome "${nodeId}" lost item "${itemId}"`)
+                }
+
+                body.layout.applyChildAttributes(pane, index, true);
+                button.setSilent({
+                    domListeners: header.domListeners,
+                    index,
+                    pressed     : index === activeIndex,
+                    text        : header.text
+                })
+            })
+        });
+
+        return plans
+    }
+
+    /**
+     * @summary Returns a serializable identity receipt for one live logical tab surface.
+     * @param {String} nodeId
+     * @returns {Object|null}
+     */
+    getTabChromeIdentity(nodeId) {
+        const
+            shell = this.getReference('dock-host')?.items[0],
+            tab   = this.collectProjectedTabs(shell).get(nodeId);
+
+        if (!tab) return null;
+
+        const
+            bar     = tab.getTabBar(),
+            body    = tab.getCardContainer(),
+            plugin  = bar.getPlugin('tab-overflow'),
+            buttons = {};
+
+        Object.entries(this.paneCache).forEach(([itemId, pane]) => {
+            const index = body.items.indexOf(pane);
+
+            index > -1 && (buttons[itemId] = bar.items[index]?.id || null)
+        });
+
+        return {
+            bodyId           : body.id,
+            buttons,
+            containerId      : tab.id,
+            headerId         : bar.id,
+            overflowControlId: plugin?.control?.id || null,
+            overflowPluginId : plugin?.id || null,
+            stripId          : tab.getTabStrip().id
+        }
+    }
+
+    /**
      * Atomically hands cached panes from the current projection to a staged next projection.
      *
      * The next shell is first mounted with `hideMode: 'visibility'` and non-rendered placeholders,
@@ -609,9 +907,10 @@ class Workspace extends Container {
         } catch (error) {/* instant landing */}
 
         const
-            oldShell           = host.items[0],
-            oldOverflowPlugins = me.getOverflowPlugins(oldShell),
-            nextConfig         = me.projectDockModel((componentRef, item, itemId) => {
+            oldShell    = host.items[0],
+            currentTabs = me.collectProjectedTabs(oldShell),
+            tabPlans    = new Map(),
+            nextConfig  = me.prepareTabChromeProjection(me.projectDockModel((componentRef, item, itemId) => {
                 const placeholder = Neo.create({
                     module: Component,
                     header: {text: me.getPaneHeaderText(itemId, item)},
@@ -621,60 +920,63 @@ class Workspace extends Container {
                 placeholders.set(itemId, placeholder);
 
                 return placeholder
-            });
+            }), currentTabs, tabPlans);
 
-        // Overflow controls are intentionally floating direct-body children, so the dock host is not their
-        // common parent and cannot hide them as part of the shell transaction. Retire the source projection
-        // first; the destination plugin independently recreates its truthful affordance from the new header.
-        oldOverflowPlugins.forEach(plugin => plugin.control && (plugin.control.hidden = true));
+        // Pane placeholders inside a discarded config for a retained tab node never enter a parent.
+        // Retire them now; only genuinely new tab nodes need their projected placeholders for pairing.
+        tabPlans.forEach(plan => {
+            if (!plan.tab) return;
+
+            plan.desiredItems.forEach(itemId => {
+                const placeholder = placeholders.get(itemId);
+
+                if (placeholder && !placeholder.parent) {
+                    placeholder.destroy();
+                    placeholders.delete(itemId)
+                }
+            })
+        });
 
         nextConfig.hidden   = true;
         nextConfig.hideMode = 'visibility';
 
         const nextShell = host.insert(host.items.length, nextConfig, true);
 
-        nextShell.addCls('workstation-chrome-settling');
+        const
+            retainedTabBars = [...tabPlans.values()]
+                .filter(plan => plan.tab)
+                .map(plan => plan.tab.getTabBar()),
+            animationSuppressedBars = retainedTabBars
+                .filter(bar => !bar.cls.includes('neo-no-animation'));
+
+        // Native reparenting keeps each toolbar DOM node, but CSS animations restart when that node
+        // re-enters the document. Reuse the tab drag contract so retained pressed indicators settle at
+        // their final color immediately; genuinely new tab chrome keeps its ordinary entry animation.
+        animationSuppressedBars.forEach(bar => {
+            bar.setSilent({cls: [...bar.cls, 'neo-no-animation']})
+        });
 
         // Atomic moves require both ownership paths to exist in the rendered tree. This update
-        // mounts only the visibility-hidden target shell; the live panes remain in the visible
-        // old shell until the single ownership reconciliation below.
+        // mounts only the visibility-hidden target shell; layered ownership commits then move
+        // retained pane/header pairs before their ancestor tab containers.
         host.updateDepth = -1;
         host.update();
         await host.promiseUpdate();
 
-        const
-            transfers = [...placeholders].map(([itemId, placeholder]) => {
-                const targetParent = placeholder.parent,
-                      targetIndex  = targetParent?.indexOf(placeholder) ?? -1;
+        me.reconcileTabChrome(tabPlans, placeholders, currentTabs, nextShell);
 
-                if (!targetParent || targetIndex < 0) {
-                    throw new Error(`Workstation projection did not parent placeholder "${itemId}"`)
-                }
-
-                return {
-                    itemId,
-                    pane: me.resolvePane(itemId, me.dockModel.items[itemId]),
-                    placeholder,
-                    targetIndex,
-                    targetParent
-                }
-            });
-
-        transfers.forEach(({pane, placeholder, targetIndex, targetParent}) => {
-            const sourceParent = pane.parent;
-
-            targetParent.remove(placeholder, true, true);
-            sourceParent && sourceParent !== targetParent
-                && sourceParent.remove(pane, false, true, true);
-            targetParent.insert(targetIndex, pane, true, false)
+        // A removed logical tab can be the source of a returning pane. Hide that now-empty source in
+        // the descendant commit; the next commit destroys it with the retiring shell exactly once.
+        currentTabs.forEach((tab, nodeId) => {
+            if (!tabPlans.has(nodeId)) {
+                tab.setSilent({hideMode: 'visibility', hidden: true})
+            }
         });
+        host.updateDepth = -1;
+        host.update();
+        await host.promiseUpdate();
 
-        const overflowPlugins = me.getOverflowPlugins(nextShell);
-
-        // Capture natural header widths while the destination shell is still visibility-hidden. Overflow's
-        // measuring latch restores any removeDom headers and coalesces mutation/resize races internally.
-        await Promise.all(overflowPlugins.map(plugin => plugin.project(true)));
-        await Promise.all(overflowPlugins.map(plugin => me.waitForOverflowProjection(plugin)));
+        me.moveRetainedTabChrome(tabPlans);
 
         oldShell.setSilent({hideMode: 'visibility'});
         oldShell.setSilent({hidden: true});
@@ -683,29 +985,31 @@ class Workspace extends Container {
         host.update();
         await host.promiseUpdate();
 
-        // The first update above is the ownership transaction: both parent trees exist, so Neo
-        // emits DOM moves for the live pane ids. This second update removes only an empty shell.
+        // Descendants and retained tab ancestors have now landed in separate ownership commits. This
+        // cleanup update removes only the empty shell and any genuinely retired tab chrome.
         oldShell !== nextShell && host.remove(oldShell, true, true);
         host.updateDepth = -1;
         host.update();
         await host.promiseUpdate();
 
-        await Promise.all(overflowPlugins.map(plugin => plugin.project(false)));
-        await Promise.all(overflowPlugins.map(plugin => me.waitForOverflowProjection(plugin)));
+        const overflowPlugins = me.getOverflowPlugins(nextShell);
 
-        // Floating controls sit under document.body rather than below the dock host, so they cannot
-        // participate in the common-parent ownership update above. Activate only the destination
-        // projection after the source shell (and its control) has been destroyed: this preserves the
-        // exact-one-control invariant without exposing a transient duplicate or leaving the new button
-        // in the hidden/unmounted state used while its owner shell was staged.
+        // Retained plugins keep their exact control identity. Re-capture only after the ownership commit,
+        // when every paired button is under its final toolbar and the visible shell owns current geometry.
         overflowPlugins.forEach(plugin => {
             plugin.control?.hidden && (plugin.control.hidden = false)
         });
+        await Promise.all(overflowPlugins.map(plugin => plugin.project(true)));
+        await Promise.all(overflowPlugins.map(plugin => me.waitForOverflowProjection(plugin)));
 
         const heavyOverflow = nextShell.down({dockNodeId: 'heavy-tabs'})
             ?.getTabBar()?.getPlugin('tab-overflow');
 
         await me.waitForOverflowMenu(heavyOverflow);
+
+        // Changing only animation-duration keeps the same CSS Animation object. Waiting out the
+        // theme's 260ms window before restoring it prevents a delayed replay on retained indicators.
+        const chromeAnimationSettle = me.timeout(300);
 
         if (flip) {
             DockMotionSignal.enter(me);
@@ -717,6 +1021,14 @@ class Workspace extends Container {
                 DockMotionSignal.leave(me)
             }
         }
+
+        await chromeAnimationSettle;
+        animationSuppressedBars.forEach(bar => {
+            bar.setSilent({cls: bar.cls.filter(cls => cls !== 'neo-no-animation')})
+        });
+        host.updateDepth = -1;
+        host.update();
+        await host.promiseUpdate()
     }
 
     /**

--- a/learn/agentos/HarnessDockZoneModel.md
+++ b/learn/agentos/HarnessDockZoneModel.md
@@ -393,14 +393,14 @@ First implementation ownership may be harness-local when the storage backend, pa
 
 ## Split/Tab Adapter Boundary
 
-The first rendering slice is an adapter, not a new layout engine. It consumes the dock-zone model and emits ordinary Neo child configs and live component moves that existing containers can own.
+The rendering boundary is an adapter/reconciler pair, not a new layout engine. `Neo.dashboard.DockLayoutAdapter` consumes the dock-zone model and emits ordinary Neo child configs; `Neo.dashboard.DockProjectionReconciler` hands surviving live components into that projection without changing their identity. Existing containers still own layout, tabs, and cards.
 
-Adapter and model both live in the dashboard layer (`src/dashboard/`) — per the operator's 2026-06-13 placement decision (see §Ownership Boundary), the dock-zone subsystem is a reusable Neo layout topic, not harness-app-private. A *further* lift into a generic core layout primitive (beyond dashboard adaptation) still requires a second independent in-repo consumer and source evidence that the logic is reusable outside dashboard adaptation.
+Adapter, projection reconciler, and model live in the dashboard layer (`src/dashboard/`) — per the operator's 2026-06-13 placement decision (see §Ownership Boundary), the dock-zone subsystem is a reusable Neo layout topic, not harness-app-private. A *further* lift into a generic core layout primitive (beyond dashboard adaptation) still requires a second independent in-repo consumer and source evidence that the logic is reusable outside dashboard adaptation.
 
 Rejected placements for the first adapter:
 
 - **Generic core layout primitive:** rejected for this slice. Core layout classes own child arrangement; they do not yet need to own dock item identity, stale component recovery, drag-drop producer handoff, or future blueprint persistence.
-- **Tab-container fork:** rejected. `Neo.tab.Container` already owns tab button order, card-backed active content, `activeIndex`, and `tabBarPosition`; the adapter should feed it compatible child/header configs rather than create a harness-only tab system.
+- **Tab-container fork:** rejected. `Neo.tab.Container` already owns tab button order, card-backed active content, `activeIndex`, and `tabBarPosition`; the adapter/reconciler pair should feed it compatible child/header configs and retained live children rather than create a harness-only tab system.
 - **Splitter-owned model:** rejected. `Neo.component.Splitter` is a resize affordance for existing siblings, not the authority for persistent split topology. The model keeps split orientation, child order, and normalized sizes; splitters may render between children later.
 - **Preview producer as adapter owner:** rejected. Drag preview state is runtime-only and converts to semantic operations on drop. The adapter receives committed model changes; it must not depend on hover rectangles or pointer lifecycle state.
 
@@ -453,6 +453,8 @@ The adapter must preserve the current `Neo.tab.Container` contract: tab headers 
 4. If neither exists, render a recoverable placeholder, validation error, or other policy-owned fail-safe state, then leave the persisted item record intact for recovery.
 
 This aligns the adapter with stale `componentRef` restore behavior: runtime component references are recoverable state, not a reason to corrupt the persisted dock tree.
+
+Repeated projections add one ownership rule: the adapter remains pure and stateless, while `DockProjectionReconciler` keys surviving tab containers by `dockNodeId` and moves each pane/header-button pair before moving its retained tab-container ancestor. The reconciler commits those descendant and ancestor handoffs separately; app-local code owns only its pane resolver, animation, and app-specific menu readiness. Workstation and Dock Demo B exercise the same transaction with different pane policies, keeping the projection contract reusable without making `DockLayoutAdapter` stateful.
 
 ## Demand Validation
 

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -377,20 +377,6 @@ body:has(.workstation-workspace) .neo-button.neo-tab-overflow-control {
     border-radius: 6px;
 }
 
-// Coarse document projection deliberately replaces tab chrome while moving live pane nodes.
-// Keep that replacement chrome motionless: re-enabling the generic pressed-tab animation on
-// an already-pressed fresh node restarts it. Identity-preserving reconciliation is the shared
-// follow-up that can restore ordinary indicator motion without replaying bootstrap effects.
-.workstation-chrome-settling {
-    .neo-tab-button-indicator {
-        animation-duration: 0ms !important;
-    }
-
-    .neo-active-tab-indicator {
-        transition-duration: 0ms !important;
-    }
-}
-
 .workstation-placeholder {
     background:
         radial-gradient(circle at 82% 16%, color-mix(in srgb, var(--workstation-signal) 16%, transparent), transparent 38%),

--- a/src/dashboard/DockProjectionReconciler.mjs
+++ b/src/dashboard/DockProjectionReconciler.mjs
@@ -1,0 +1,454 @@
+import Component from '../component/Base.mjs';
+import Base      from '../core/Base.mjs';
+
+/**
+ * @summary Preserves live tab-chrome identity across dock-layout projections.
+ *
+ * {@link Neo.dashboard.DockLayoutAdapter} deliberately remains a stateless document-to-config
+ * projector. This class owns the complementary live-component handoff: it keys projected tab
+ * containers by `dockNodeId`, stages retained ancestors behind geometry-equivalent placeholders,
+ * and moves each pane/button pair before its owning tab container moves. Callers must commit those
+ * descendant and ancestor ownership layers separately so the main-thread delta cannot retire a
+ * child after its retained ancestor has landed.
+ *
+ * The reconciler owns no workspace document or pane cache. Each docking workspace supplies its
+ * item resolver and controls its own animation and app-specific overflow/menu readiness.
+ *
+ * @class Neo.dashboard.DockProjectionReconciler
+ * @extends Neo.core.Base
+ * @see Neo.dashboard.DockLayoutAdapter
+ * @see learn/agentos/HarnessDockZoneModel.md
+ */
+class DockProjectionReconciler extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.dashboard.DockProjectionReconciler'
+         * @protected
+         */
+        className: 'Neo.dashboard.DockProjectionReconciler'
+    }
+
+    /**
+     * @summary Collects keyed tab-chrome owners below one projected dock shell.
+     * @param {Neo.component.Base|null} root
+     * @returns {Map<String,Neo.tab.Container>}
+     * @static
+     */
+    static collectProjectedTabs(root) {
+        const tabs = new Map();
+
+        const visit = component => {
+            if (!component || component.isDestroyed) return;
+
+            if (component.dockNodeType === 'tabs') {
+                tabs.set(component.dockNodeId, component);
+                return
+            }
+
+            component.items?.forEach(visit)
+        };
+
+        visit(root);
+
+        return tabs
+    }
+
+    /**
+     * @summary Replaces retained projected tab configs with geometry-equivalent staging placeholders.
+     *
+     * Each plan captures the projected active/item state while the placeholder reserves the retained
+     * tab container's destination. New and removed logical tab nodes remain ordinary projected instances.
+     * @param {*} config
+     * @param {Map<String,Neo.tab.Container>} currentTabs
+     * @param {Map<String,Object>} plans
+     * @returns {*}
+     * @static
+     */
+    static prepareTabChromeProjection(config, currentTabs, plans) {
+        if (Array.isArray(config)) {
+            return config.map(item => this.prepareTabChromeProjection(item, currentTabs, plans))
+        }
+
+        if (config?.constructor !== Object) return config;
+
+        if (config.dockNodeType === 'tabs') {
+            const
+                nodeId       = config.dockNodeId,
+                currentTab   = currentTabs.get(nodeId) || null,
+                desiredItems = [...(config.headerToolbar?.sortZoneConfig?.dockItemIds || [])],
+                plan         = {
+                    activeIndex: config.activeIndex,
+                    config,
+                    desiredItems,
+                    placeholder: null,
+                    tab        : currentTab
+                };
+
+            plans.set(nodeId, plan);
+
+            if (currentTab) {
+                plan.placeholder = Neo.create({
+                    module  : Component,
+                    cls     : ['neo-dashboard-dock-projection-placeholder'],
+                    flex    : config.flex,
+                    hidden  : true,
+                    hideMode: 'visibility',
+                    style   : config.style
+                });
+
+                return plan.placeholder
+            }
+
+            return config
+        }
+
+        return Array.isArray(config.items)
+            ? {...config, items: this.prepareTabChromeProjection(config.items, currentTabs, plans)}
+            : config
+    }
+
+    /**
+     * @summary Stages and commits one identity-preserving dock projection.
+     *
+     * The host keeps its current shell rendered while a visibility-hidden projection is inserted
+     * beside it. Four explicit ownership phases follow: mount the target tree, move pane/button
+     * descendants, move retained tab ancestors plus swap shell visibility, then destroy the empty
+     * source shell. Each phase receives its own host update so renderer cleanup cannot overtake a
+     * native reparent. Floating Overflow controls are reprojected only after final ownership settles.
+     *
+     * Workspace-specific FLIP capture/play, animation timing, pane creation, and menu readiness stay
+     * outside this method. `onProjectionStaged` can decorate retained chrome before the first commit.
+     * @param {Object} options
+     * @param {Neo.container.Base} options.host Dock host containing the current shell.
+     * @param {*} options.nextConfig Fresh {@link Neo.dashboard.DockLayoutAdapter} projection.
+     * @param {Map<String,Neo.component.Base>} options.placeholders Item placeholders created by the caller.
+     * @param {Function} options.resolveItem Resolves one live pane by dock item id.
+     * @param {Function|null} [options.onProjectionStaged=null]
+     * @param {Number} [options.shellIndex=0]
+     * @param {Function|null} [options.waitForOverflowProjection=null]
+     * @returns {Promise<{currentTabs: Map, nextShell: Neo.component.Base, overflowPlugins: Object[], plans: Map}>}
+     * @static
+     */
+    static async reconcileProjection({
+        host,
+        nextConfig,
+        placeholders,
+        resolveItem,
+        onProjectionStaged=null,
+        shellIndex=0,
+        waitForOverflowProjection=null
+    }) {
+        const oldShell = host?.items?.[shellIndex];
+
+        if (!oldShell) {
+            throw new Error(`Dock projection could not find a current shell at index ${shellIndex}`)
+        }
+
+        const
+            currentTabs    = this.collectProjectedTabs(oldShell),
+            plans          = new Map(),
+            preparedConfig = this.prepareTabChromeProjection(nextConfig, currentTabs, plans);
+
+        // Pane placeholders inside a discarded config for a retained tab node never enter a parent.
+        // Retire them now; only genuinely new tab nodes need projected placeholders for pairing.
+        plans.forEach(plan => {
+            if (!plan.tab) return;
+
+            plan.desiredItems.forEach(itemId => {
+                const placeholder = placeholders.get(itemId);
+
+                if (placeholder && !placeholder.parent) {
+                    placeholder.destroy();
+                    placeholders.delete(itemId)
+                }
+            })
+        });
+
+        preparedConfig.setSilent
+            ? preparedConfig.setSilent({hidden: true, hideMode: 'visibility'})
+            : Object.assign(preparedConfig, {hidden: true, hideMode: 'visibility'});
+
+        let nextShell = host.insert(shellIndex + 1, preparedConfig, true);
+
+        await onProjectionStaged?.({currentTabs, nextShell, oldShell, plans});
+
+        host.updateDepth = -1;
+        host.update();
+        await host.promiseUpdate();
+
+        this.reconcileTabChrome(plans, placeholders, currentTabs, nextShell, resolveItem);
+
+        // A removed logical tab can be the source of a returning pane. Hide that now-empty source in
+        // the descendant commit; the ancestor/cleanup phases destroy it with its retiring shell once.
+        currentTabs.forEach((tab, nodeId) => {
+            if (!plans.has(nodeId)) {
+                tab.setSilent({hideMode: 'visibility', hidden: true})
+            }
+        });
+        host.updateDepth = -1;
+        host.update();
+        await host.promiseUpdate();
+
+        this.moveRetainedTabChrome(plans);
+
+        // A tabs node may itself be the projected root. In that case its staging placeholder has
+        // disappeared and the retained tab is both old and new shell; never retire it as source chrome.
+        nextShell = nextShell.isDestroyed ? host.items[shellIndex] : nextShell;
+
+        const retainedRoot = oldShell === nextShell;
+
+        if (!retainedRoot) {
+            oldShell.setSilent({hideMode: 'visibility', hidden: true});
+            nextShell.setSilent({hidden: false})
+        }
+
+        host.updateDepth = -1;
+        host.update();
+        await host.promiseUpdate();
+
+        if (!retainedRoot) {
+            host.remove(oldShell, true, true);
+            host.updateDepth = -1;
+            host.update();
+            await host.promiseUpdate()
+        }
+
+        const overflowPlugins = [...new Set([...plans.values()]
+            .map(plan => plan.tab?.getTabBar()?.getPlugin('tab-overflow'))
+            .filter(Boolean))];
+
+        // Overflow controls float outside the dock host. Restore their visible state only after every
+        // retained toolbar owns final geometry, then let each plugin recapture its natural widths.
+        overflowPlugins.forEach(plugin => {
+            plugin.control?.hidden && (plugin.control.hidden = false)
+        });
+        await Promise.all(overflowPlugins.map(plugin => plugin.project(true)));
+
+        if (waitForOverflowProjection) {
+            await Promise.all(overflowPlugins.map(plugin => waitForOverflowProjection(plugin)))
+        }
+
+        return {currentTabs, nextShell, overflowPlugins, plans}
+    }
+
+    /**
+     * @summary Moves retained tab-container ancestors into their staged projected slots silently.
+     *
+     * Cross-tab card/button moves must commit before this method runs. The distinct ancestor commit
+     * prevents the main-thread delta from retiring a child after its retained ancestor has landed.
+     * @param {Map<String,Object>} plans
+     * @returns {Map<String,Object>}
+     * @static
+     */
+    static moveRetainedTabChrome(plans) {
+        plans.forEach((plan, nodeId) => {
+            const
+                tab          = plan.tab,
+                placeholder  = plan.placeholder,
+                sourceParent = tab?.parent,
+                targetParent = placeholder?.parent,
+                sourceIndex  = sourceParent?.indexOf(tab) ?? -1,
+                targetIndex  = targetParent?.indexOf(placeholder) ?? -1;
+
+            if (!placeholder) return;
+
+            if (!sourceParent || !targetParent || targetIndex < 0) {
+                throw new Error(`Dock projection could not stage surviving tab chrome "${nodeId}"`)
+            }
+
+            // A floating overflow control is aligned outside the dock host. Its target toolbar briefly
+            // leaves the main-thread DOM during native reparenting, and the align layer hides the control.
+            // Visibility mode keeps that exact DOM node mounted until the destination target is present.
+            tab.getTabBar()?.getPlugin('tab-overflow')?.control?.setSilent({hideMode: 'visibility'});
+            targetParent.remove(placeholder, true, true);
+            sourceParent.remove(tab, false, true, true);
+            tab.setSilent({
+                cls      : plan.config.cls,
+                flex     : plan.config.flex,
+                listeners: plan.config.listeners,
+                style    : plan.config.style,
+                // Flexbox stores parent-owned sizing on the child's wrapper. A retained tab
+                // otherwise carries its source split ratio into the destination projection.
+                wrapperStyle: {...tab.wrapperStyle, flex: plan.config.flex ?? null}
+            });
+            targetParent.insert(
+                sourceParent === targetParent && sourceIndex < targetIndex ? targetIndex - 1 : targetIndex,
+                tab,
+                true,
+                false
+            )
+        });
+
+        return plans
+    }
+
+    /**
+     * @summary Reconciles paired live cards/buttons before their retained tab ancestors move.
+     *
+     * Both shells must be mounted. Cross-tab transfers move each pane and its existing header button
+     * as a pair while their tab-container ancestors remain stationary. The caller commits this layer
+     * before invoking {@link Neo.dashboard.DockProjectionReconciler.moveRetainedTabChrome}.
+     * @param {Map<String,Object>} plans
+     * @param {Map<String,Neo.component.Base>} placeholders
+     * @param {Map<String,Neo.tab.Container>} currentTabs
+     * @param {Neo.container.Base} nextShell
+     * @param {Function} resolveItem Resolves one live pane by dock item id.
+     * @returns {Map<String,Object>}
+     * @static
+     */
+    static reconcileTabChrome(plans, placeholders, currentTabs, nextShell, resolveItem) {
+        const
+            nextTabs      = this.collectProjectedTabs(nextShell),
+            allTabs       = new Set([...currentTabs.values(), ...nextTabs.values()]),
+            liveItems     = new Map(),
+            resolvedItems = new Map();
+
+        if (typeof resolveItem !== 'function') {
+            throw new Error('Dock projection reconciliation requires a live item resolver')
+        }
+
+        currentTabs.forEach(tab => {
+            const
+                bar     = tab.getTabBar(),
+                body    = tab.getCardContainer(),
+                itemIds = bar.sortZoneConfig?.dockItemIds || [];
+
+            itemIds.forEach((itemId, index) => {
+                body.items[index] && liveItems.set(itemId, body.items[index])
+            })
+        });
+
+        const resolve = itemId => {
+            if (!resolvedItems.has(itemId)) {
+                resolvedItems.set(itemId, liveItems.get(itemId) || resolveItem(itemId) || null)
+            }
+
+            return resolvedItems.get(itemId)
+        };
+
+        plans.forEach((plan, nodeId) => {
+            plan.tab = nextTabs.get(nodeId) || plan.tab;
+
+            if (!plan.tab) {
+                throw new Error(`Dock projection did not create tab chrome "${nodeId}"`)
+            }
+        });
+
+        const findItemState = pane => {
+            for (const tab of allTabs) {
+                if (tab.isDestroyed) continue;
+
+                const
+                    body  = tab.getCardContainer(),
+                    index = body?.items.indexOf(pane) ?? -1;
+
+                if (index > -1) {
+                    return {
+                        bar   : tab.getTabBar(),
+                        body,
+                        button: tab.getTabBar().items[index],
+                        index,
+                        tab
+                    }
+                }
+            }
+
+            return null
+        };
+
+        plans.forEach(plan => {
+            const
+                targetTab  = plan.tab,
+                targetBar  = targetTab.getTabBar(),
+                targetBody = targetTab.getCardContainer();
+
+            plan.desiredItems.forEach((itemId, targetIndex) => {
+                const
+                    pane        = resolve(itemId),
+                    placeholder = placeholders.get(itemId);
+
+                if (!pane) {
+                    throw new Error(`Dock projection could not resolve live item "${itemId}"`)
+                }
+
+                if (placeholder?.parent) {
+                    const placeholderIndex = targetBody.indexOf(placeholder);
+
+                    if (placeholder.parent !== targetBody || placeholderIndex < 0) {
+                        throw new Error(`Dock projection placed item "${itemId}" into the wrong tab body`)
+                    }
+
+                    targetBody.removeAt(placeholderIndex, true, true);
+                    targetBar.removeAt(placeholderIndex, true, true);
+                    placeholders.delete(itemId)
+                }
+
+                const state = findItemState(pane);
+
+                if (!state) {
+                    targetTab.insert(targetIndex, pane, true);
+                    return
+                }
+
+                if (state.tab === targetTab && state.index === targetIndex) return;
+
+                state.body.removeAt(state.index, false, true, true);
+                state.bar.removeAt(state.index, false, true, true);
+                targetBody.insert(targetIndex, pane, true, false);
+                targetBar.insert(targetIndex, state.button, true, false)
+            })
+        });
+
+        plans.forEach((plan, nodeId) => {
+            const
+                tab                 = plan.tab,
+                bar                 = tab.getTabBar(),
+                body                = tab.getCardContainer(),
+                activeIndex         = plan.activeIndex,
+                projectedSortConfig = plan.config.headerToolbar?.sortZoneConfig || {},
+                sortConfig          = {
+                    ...bar.sortZoneConfig,
+                    ...projectedSortConfig,
+                    dockItemIds: [...plan.desiredItems]
+                };
+
+            if (body.items.length !== plan.desiredItems.length
+                || bar.items.length !== plan.desiredItems.length) {
+                throw new Error(`Dock projection tab chrome "${nodeId}" has an inexact item set`)
+            }
+
+            tab._activeIndex         = activeIndex;
+            body.layout._activeIndex = activeIndex;
+            bar.setSilent({sortZoneConfig: sortConfig});
+            bar.sortZone?.setSilent?.({
+                dockItemIds     : [...plan.desiredItems],
+                dockSourceNodeId: sortConfig.dockSourceNodeId,
+                dockWorkspaceId : sortConfig.dockWorkspaceId,
+                sortGroup       : sortConfig.sortGroup
+            });
+
+            plan.desiredItems.forEach((itemId, index) => {
+                const
+                    pane   = resolve(itemId),
+                    button = bar.items[index],
+                    header = tab.getTabButtonConfig(pane?.header, index);
+
+                if (body.items[index] !== pane || !button) {
+                    throw new Error(`Dock projection tab chrome "${nodeId}" lost item "${itemId}"`)
+                }
+
+                body.layout.applyChildAttributes(pane, index, true);
+                button.setSilent({
+                    domListeners: header.domListeners,
+                    index,
+                    pressed     : index === activeIndex,
+                    text        : header.text
+                })
+            })
+        });
+
+        return plans
+    }
+}
+
+export default Neo.setupClass(DockProjectionReconciler);

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -31,6 +31,11 @@ const heavyTitles = [
     'Workspace Files'
 ];
 
+const initialTabNodeIds = [
+    'scale-tabs', 'heavy-tabs', 'left-tabs',
+    'right-top-tabs', 'right-bottom-tabs', 'bottom-tabs'
+];
+
 const asArray = value => Array.isArray(value) ? value : value ? [value] : [];
 
 /**
@@ -65,6 +70,19 @@ const readIdentity = async (app, workspaceId) => {
         workspaceProviderId: workspace['stateProvider.id']
     }
 };
+
+/**
+ * @summary Reads the component identity receipt for every opening-document tab surface.
+ * @param {Object} app Neural Link fixture app handle.
+ * @param {String} workspaceId Workstation workspace id.
+ * @returns {Promise<Object>}
+ */
+const readTabChromeIdentity = async (app, workspaceId) => Object.fromEntries(await Promise.all(
+    initialTabNodeIds.map(async nodeId => [
+        nodeId,
+        await app.callMethod(workspaceId, 'getTabChromeIdentity', [nodeId])
+    ])
+));
 
 /**
  * Returns only mounted Sparkline components owned by the scale pane.
@@ -212,8 +230,12 @@ const readDockChrome = page => page.evaluate(() => {
 const readHorizontalSplitGeometry = page => page.evaluate(() => {
     const
         splitter = document.querySelector('.neo-dashboard-dock-splitter-horizontal'),
-        children = [...splitter.parentElement.children]
-            .filter(element => !element.classList.contains('neo-dashboard-dock-splitter')),
+        children = splitter && [...splitter.parentElement.children]
+            .filter(element => !element.classList.contains('neo-dashboard-dock-splitter'));
+
+    if (!splitter || children.length < 2) return null;
+
+    const
         first    = children[0].getBoundingClientRect(),
         second   = children[1].getBoundingClientRect(),
         boundary = splitter.getBoundingClientRect();
@@ -285,7 +307,10 @@ const readResponsiveDockGeometry = page => page.evaluate(() => {
 
 test.describe('Workstation — dense living-data composition', () => {
     test.setTimeout(150000);
-    test.use({viewport: {height: 1440, width: 2560}});
+    test.use({
+        reducedMotion: 'no-preference',
+        viewport     : {height: 1440, width: 2560}
+    });
 
     test('the real tour keeps density, data, Canvas output, themes, rails, and identities live', async ({page, neuralLink}) => {
         const pageErrors    = [],
@@ -329,7 +354,9 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(workspaces, 'the page owns exactly one Workstation workspace').toHaveLength(1);
         expect(workspaceId).toBeTruthy();
 
-        const beforeIdentity = await readIdentity(app, workspaceId);
+        const
+            beforeIdentity = await readIdentity(app, workspaceId),
+            beforeChrome   = await readTabChromeIdentity(app, workspaceId);
 
         expect(beforeIdentity.providerCount, 'Workstation owns one root StateProvider').toBe(1);
         expect(beforeIdentity.workspaceProviderId, 'the workspace references that one Provider')
@@ -339,6 +366,10 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(beforeIdentity.securityPaneId, 'the transformed heavy resident has a stable pane identity').toBeTruthy();
         expect(beforeIdentity.scaleStoreId, 'scale and feed are distinct Store<Model> identities')
             .not.toBe(beforeIdentity.feedStoreId);
+        expect(Object.values(beforeChrome).every(Boolean), 'all opening tab surfaces expose identity receipts')
+            .toBe(true);
+        expect(beforeChrome['heavy-tabs'].overflowPluginId, 'the heavy surface owns one Overflow plugin').toBeTruthy();
+        expect(beforeChrome['heavy-tabs'].overflowControlId, 'the heavy surface owns one floating control').toBeTruthy();
 
         const scaleSnapshot = await app.inspectStore(beforeIdentity.scaleStoreId, 2, 0),
               feedBaseline  = await app.inspectStore(beforeIdentity.feedStoreId, 2, 0);
@@ -775,7 +806,7 @@ test.describe('Workstation — dense living-data composition', () => {
         await expect.poll(async () => {
             const geometry = await readHorizontalSplitGeometry(page);
 
-            return geometry.firstWidth - dragGeometryBefore.firstWidth
+            return geometry ? geometry.firstWidth - dragGeometryBefore.firstWidth : -Infinity
         }, {
             message  : 'the deferred projection applies the committed split to live DOM extents',
             timeout  : 10000,
@@ -799,6 +830,7 @@ test.describe('Workstation — dense living-data composition', () => {
             {dockModel: dragModelAfter} = await app.getComponent(workspaceId, ['dockModel']),
             dragGeometryAfter           = await readHorizontalSplitGeometry(page),
             dragIdentityAfter           = await readIdentity(app, workspaceId),
+            dragChromeAfter             = await readTabChromeIdentity(app, workspaceId),
             scalePanePreserved          = await page.evaluate(() => globalThis.__workstationPreResizeScalePane
                 === document.querySelector('.workstation-scale-pane'));
 
@@ -808,6 +840,8 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(dragGeometryBefore.secondWidth - dragGeometryAfter.secondWidth).toBeGreaterThan(80);
         expect(dragIdentityAfter, 'the user resize preserves pane, Provider, and Store<Model> identities')
             .toEqual(dragIdentityBefore);
+        expect(dragChromeAfter, 'a resize preserves every opening tab surface and paired button identity')
+            .toEqual(beforeChrome);
         expect(scalePanePreserved, 'the exact scale pane DOM node survives splitter re-projection').toBe(true);
         expect(await page.locator('.neo-dashboard-dock-splitter').count()).toBe(boundaryCount);
         expectDevIndexSparklineFit(await readSparklineGeometry(page, '.workstation-scale-pane'));
@@ -901,6 +935,27 @@ test.describe('Workstation — dense living-data composition', () => {
             return Object.values(globalThis.__workstationDomIdentity).every(Boolean)
         }, domIdentityIds), 'all permanence targets start as mounted DOM nodes').toBe(true);
 
+        // Header buttons are deliberately excluded from this persistent DOM sample. tab.plugin.Overflow
+        // removes overflowed buttons from the DOM while retaining their components, so button DOM identity
+        // is not stable across an intentional overflow transition. The component matrix still covers them.
+        const capturedChromeDomNodes = await page.evaluate(receipts => {
+            const captured = globalThis.__workstationChromeDomIdentity = {};
+
+            Object.entries(receipts).forEach(([nodeId, receipt]) => {
+                ['containerId', 'headerId', 'bodyId', 'stripId', 'overflowControlId'].forEach(key => {
+                    const id      = receipt[key],
+                          element = id && document.getElementById(id);
+
+                    element && (captured[`${nodeId}:${key}`] = element)
+                });
+            });
+
+            return Object.keys(captured).length
+        }, beforeChrome);
+
+        expect(capturedChromeDomNodes, 'mounted tab chrome has a persistent structural DOM identity sample')
+            .toBeGreaterThanOrEqual(initialTabNodeIds.length * 4 + 1);
+
         for (const sparkline of scaleSparklinesBefore) {
             await app.setProperties(sparkline.id, {usePulse: false, useTransition: false})
         }
@@ -929,9 +984,11 @@ test.describe('Workstation — dense living-data composition', () => {
         // frame; when mounted, every visible row must stay populated.
         await page.evaluate(identity => {
             const
-                root             = document.querySelector('.workstation-workspace'),
-                initialPipCount  = root?.querySelectorAll('.workstation-pip-done').length || 0,
-                initialHeaderIds = [...root?.querySelectorAll('.neo-tab-header-toolbar') || []]
+                root                = document.querySelector('.workstation-workspace'),
+                initialPipCount     = root?.querySelectorAll('.workstation-pip-done').length || 0,
+                initialContainerIds = [...root?.querySelectorAll('.neo-tab-container') || []]
+                    .map(element => element.id),
+                initialHeaderIds    = [...root?.querySelectorAll('.neo-tab-header-toolbar') || []]
                     .map(element => element.id);
 
             const state = globalThis.__workstationMonitor = {
@@ -940,19 +997,23 @@ test.describe('Workstation — dense living-data composition', () => {
                 blankSamples                  : [],
                 blankFrames                   : 0,
                 chromeAnimationLeakFrames     : 0,
+                chromeAnimationMaxTargets     : 0,
                 done                          : false,
                 flipSamples                   : 0,
+                initialContainerIds,
+                initialContainerMissingFrames : 0,
                 initialHeaderIds,
+                initialHeaderMissingFrames    : 0,
                 midpointSeen                  : false,
                 missingBodyFrames             : 0,
+                novelContainerIds             : [],
+                novelHeaderIds                : [],
                 overflowControlCounts         : {},
                 overflowControlDuplicateFrames: 0,
                 palettes                      : [],
                 pipCounts                     : [initialPipCount],
                 pipRegressionFrames           : 0,
                 railMismatchFrames            : 0,
-                replacementHeaderBirth        : {},
-                replacementHeaderSamples      : 0,
                 sampledFrames                 : 0,
                 securityCaptured              : false,
                 securityActiveHeaderMissFrames: 0,
@@ -960,6 +1021,7 @@ test.describe('Workstation — dense living-data composition', () => {
                 securityFullyClippedFrames    : 0,
                 securityFullyClippedSamples   : [],
                 securityMissingFrames         : 0,
+                securityPresenceTransitions   : [],
                 securityOverflowMutationFrames: 0,
                 securityReplacementFrames     : 0,
                 securityStageFramesByBurst    : []
@@ -989,6 +1051,19 @@ test.describe('Workstation — dense living-data composition', () => {
                           .filter(isVisible).length,
                       currentSecurityNode = document.getElementById(identity.securityPaneId);
 
+                if (Boolean(currentSecurityNode) !== Boolean(state.securityPresent)) {
+                    state.securityPresent = Boolean(currentSecurityNode);
+                    state.securityPresenceTransitions.length < 20 && state.securityPresenceTransitions.push({
+                        activeHeaders: [...document.querySelectorAll('.neo-tab-header-button.pressed')]
+                            .filter(isVisible)
+                            .map(element => element.textContent?.trim() || ''),
+                        caption : document.querySelector('.workstation-tour-caption')?.textContent?.trim() || '',
+                        pipCount: root?.querySelectorAll('.workstation-pip-done').length || 0,
+                        present : state.securityPresent,
+                        time    : Math.round(performance.now())
+                    })
+                }
+
                 if (root) {
                     const
                         activeTabEmptyIds = new Set(),
@@ -1000,22 +1075,39 @@ test.describe('Workstation — dense living-data composition', () => {
                         state.pipCounts.push(pipCount)
                     }
 
-                    [...root.querySelectorAll('.neo-tab-header-toolbar')].filter(isVisible).forEach(toolbar => {
-                        if (!state.initialHeaderIds.includes(toolbar.id)) {
-                            state.replacementHeaderBirth[toolbar.id] ??= performance.now();
+                    state.initialContainerIds.some(id => !document.getElementById(id))
+                        && state.initialContainerMissingFrames++;
+                    state.initialHeaderIds.some(id => !document.getElementById(id))
+                        && state.initialHeaderMissingFrames++;
 
-                            if (performance.now() - state.replacementHeaderBirth[toolbar.id] <= 320) {
-                                state.replacementHeaderSamples++;
-
-                                const hasRunningEntryEffect = toolbar.getAnimations({subtree: true}).some(animation =>
-                                    animation.playState === 'running'
-                                    && Number(animation.effect?.getTiming().duration) > 0
-                                );
-
-                                hasRunningEntryEffect && state.chromeAnimationLeakFrames++
-                            }
+                    [...root.querySelectorAll('.neo-tab-container')].filter(isVisible).forEach(container => {
+                        if (!state.initialContainerIds.includes(container.id)
+                            && !state.novelContainerIds.includes(container.id)) {
+                            state.novelContainerIds.push(container.id)
                         }
                     });
+
+                    const visibleToolbars = [...root.querySelectorAll('.neo-tab-header-toolbar')].filter(isVisible);
+
+                    visibleToolbars.forEach(toolbar => {
+                        if (!state.initialHeaderIds.includes(toolbar.id)) {
+                            state.novelHeaderIds.includes(toolbar.id) || state.novelHeaderIds.push(toolbar.id);
+                        }
+                    });
+
+                    const runningChromeTargets = visibleToolbars.filter(toolbar =>
+                        toolbar.getAnimations({subtree: true}).some(animation =>
+                            ['delaybgcolor', 'neo-dock-tab-enter'].includes(animation.animationName)
+                            && animation.playState === 'running'
+                            && Number(animation.effect?.getTiming().duration) > 0
+                        )
+                    ).length;
+
+                    state.chromeAnimationMaxTargets = Math.max(
+                        state.chromeAnimationMaxTargets,
+                        runningChromeTargets
+                    );
+                    runningChromeTargets > 1 && state.chromeAnimationLeakFrames++;
 
                     [...root.querySelectorAll('.neo-tab-container')].filter(isVisible).forEach(container => {
                         const
@@ -1245,9 +1337,18 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(monitor.pipCounts, 'every settled beat paints once, in order')
             .toEqual(Array.from({length: workstationTourScript.scenes.flatMap(scene => scene.steps).length + 1}, (_, index) => index));
         expect(monitor.pipRegressionFrames, 'progress never fills early and jumps backward').toBe(0);
-        expect(monitor.replacementHeaderSamples, 'the journey sampled replacement tab chrome').toBeGreaterThan(0);
+        expect(monitor.initialContainerIds).toHaveLength(initialTabNodeIds.length);
+        expect(monitor.initialHeaderIds).toHaveLength(initialTabNodeIds.length);
+        expect(monitor.initialContainerMissingFrames,
+            'every surviving tab.Container remains in the DOM through all projections').toBe(0);
+        expect(monitor.initialHeaderMissingFrames,
+            'every surviving header toolbar remains in the DOM through all projections').toBe(0);
+        expect(monitor.novelContainerIds, 'splitNode creates exactly one genuine temporary tab surface').toHaveLength(1);
+        expect(monitor.novelHeaderIds, 'that temporary surface creates exactly one genuine new header').toHaveLength(1);
+        expect(monitor.chromeAnimationMaxTargets,
+            'operation-correlated chrome motion is scoped to at most one logical header').toBeLessThanOrEqual(1);
         expect(monitor.chromeAnimationLeakFrames,
-            'fresh replacement chrome does not replay shared entry animations').toBe(0);
+            'coarse projection never replays construction or entry motion across multiple headers').toBe(0);
         expect(monitor.activeTabEmptyMaxMs,
             `no visible active tab exposes a sustained empty paint: ${JSON.stringify(monitor.activeTabEmptySamples)}`)
             .toBeLessThan(17);
@@ -1261,7 +1362,9 @@ test.describe('Workstation — dense living-data composition', () => {
             .toBe(0);
         expect(monitor.overflowControlCounts['1'], 'the real overflow state is observed').toBeGreaterThan(0);
         expect(monitor.securityCaptured, 'the overflow cue mounts Security before its structural move').toBe(true);
-        expect(monitor.securityMissingFrames, 'the active Security pane never leaves the DOM after capture').toBe(0);
+        expect(monitor.securityMissingFrames,
+            `the active Security pane never leaves the DOM after capture: ${JSON.stringify(monitor.securityPresenceTransitions)}`)
+            .toBe(0);
         expect(monitor.securityReplacementFrames, 'Security keeps the same DOM node across split and return').toBe(0);
         expect(monitor.securityStageBursts, 'split and return each expose one preserved-identity fixed stage').toBe(2);
         expect(monitor.securityStageFramesByBurst, 'the sequential sampler isolates the split and return stages')
@@ -1320,11 +1423,74 @@ test.describe('Workstation — dense living-data composition', () => {
             intervals: [50, 100]
         }).toBe(true);
 
-        const afterIdentity        = await readIdentity(app, workspaceId),
-              scaleSparklinesAfter = await readScaleSparklines(app, page);
+        const postTourChrome = await readTabChromeIdentity(app, workspaceId);
+
+        expect(postTourChrome, 'split + return preserves the complete opening tab-chrome identity matrix')
+            .toEqual(beforeChrome);
+
+        const indicatorSetup = await page.evaluate(receipt => {
+            const
+                strip     = document.getElementById(receipt.stripId),
+                indicator = strip?.querySelector('.neo-active-tab-indicator'),
+                parseTime = value => value.endsWith('ms') ? parseFloat(value) : parseFloat(value) * 1000,
+                durations = indicator
+                    ? getComputedStyle(indicator).transitionDuration.split(',').map(value => parseTime(value.trim()))
+                    : [];
+
+            if (!indicator) return null;
+
+            const state = globalThis.__workstationIndicatorMotion = {
+                ends      : 0,
+                properties: [],
+                runs      : 0
+            };
+
+            indicator.addEventListener('transitionrun', event => {
+                if (event.target === indicator) {
+                    state.runs++;
+                    state.properties.includes(event.propertyName) || state.properties.push(event.propertyName)
+                }
+            });
+            indicator.addEventListener('transitionend', event => {
+                event.target === indicator && state.ends++
+            });
+
+            return {
+                durationMs : Math.max(0, ...durations),
+                indicatorId: indicator.id || null
+            }
+        }, postTourChrome['heavy-tabs']);
+
+        expect(indicatorSetup?.durationMs, 'the ordinary indicator keeps a non-zero theme transition')
+            .toBeGreaterThan(0);
+
+        const nextVisibleHeavyTab = page.locator(
+            `[id="${postTourChrome['heavy-tabs'].headerId}"] .neo-tab-header-button:visible:not(.pressed)`
+        ).first();
+
+        await expect(nextVisibleHeavyTab, 'the returned dense group exposes another direct tab target').toBeVisible();
+        await nextVisibleHeavyTab.click();
+        await expect.poll(() => page.evaluate(() => globalThis.__workstationIndicatorMotion?.runs || 0), {
+            message  : 'ordinary active-tab input starts the standard indicator transition',
+            timeout  : 5000,
+            intervals: [25, 50]
+        }).toBeGreaterThan(0);
+        await expect.poll(() => page.evaluate(() => globalThis.__workstationIndicatorMotion?.ends || 0), {
+            message  : 'the standard indicator transition completes on the retained strip DOM node',
+            timeout  : 5000,
+            intervals: [25, 50]
+        }).toBeGreaterThan(0);
+        await expect(root).not.toHaveClass(/neo-dashboard-dock-animating/);
+
+        const
+            afterIdentity        = await readIdentity(app, workspaceId),
+            afterChrome          = await readTabChromeIdentity(app, workspaceId),
+            scaleSparklinesAfter = await readScaleSparklines(app, page);
 
         expect(afterIdentity, 'workspace, heavy pane, data panes, Provider, and stores survive all transformations')
             .toEqual(beforeIdentity);
+        expect(afterChrome, 'ordinary active-tab input also preserves every tab-chrome component identity')
+            .toEqual(beforeChrome);
         expect(scaleSparklinesAfter.length, 'the viewport-bounded scale component pool remains live')
             .toBeGreaterThan(0);
         expect(stableScaleComponentIds.every(id => scaleSparklinesAfter.some(entry => entry.id === id)),
@@ -1337,9 +1503,22 @@ test.describe('Workstation — dense living-data composition', () => {
             scaleBody: globalThis.__workstationDomIdentity?.scaleBody
                 === document.querySelector('.workstation-scale-pane .neo-grid-body')
         }), domIdentityIds);
+        const chromeDomIdentityState = await page.evaluate(() => {
+            const entries    = Object.entries(globalThis.__workstationChromeDomIdentity || {}),
+                  mismatches = entries
+                      .filter(([, element]) => element !== document.getElementById(element.id))
+                      .map(([key, element]) => ({id: element.id, key}));
+
+            return {
+                count: entries.length,
+                mismatches
+            }
+        });
 
         expect(domIdentityState, 'the exact always-mounted pane, body, and Canvas DOM nodes survive every projection')
             .toEqual({canvas: true, feedPane: true, scaleBody: true, scalePane: true});
+        expect(chromeDomIdentityState, 'every sampled structural chrome DOM node remains the exact same object')
+            .toEqual({count: capturedChromeDomNodes, mismatches: []});
         expect(scaleSparklinesAfter.every(entry => entry.properties?.offscreenRegistered),
             'the preserved scale Canvas pool is registered after the final projection').toBe(true);
         expectDevIndexSparklineFit(await readSparklineGeometry(page, '.workstation-scale-pane'));

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
@@ -10,8 +10,9 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import '../../../../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
-import DemoBWorkspace from '../../../../../../../apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs';
-import DockZoneModel  from '../../../../../../../src/dashboard/DockZoneModel.mjs';
+import DemoBWorkspace           from '../../../../../../../apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs';
+import DockProjectionReconciler from '../../../../../../../src/dashboard/DockProjectionReconciler.mjs';
+import DockZoneModel            from '../../../../../../../src/dashboard/DockZoneModel.mjs';
 
 import {initialDocument} from '../../../../../../../apps/agentos/tour/demoBPerspectives.mjs';
 
@@ -114,14 +115,24 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
     });
 
     test('pane instances are PERMANENT: the same objects survive a re-projection', async () => {
-        const workbenchBefore = workspace.resolvePane('workbench', initialDocument.items.workbench);
-        const inspectorBefore = workspace.resolvePane('inspector', initialDocument.items.inspector);
+        const
+            workbenchBefore = workspace.resolvePane('workbench', initialDocument.items.workbench),
+            inspectorBefore = workspace.resolvePane('inspector', initialDocument.items.inspector),
+            chromeBefore    = DockProjectionReconciler.collectProjectedTabs(
+                workspace.getReference('dock-host-b').items[0]
+            );
 
         await workspace.refreshDockWorkspace();
 
+        const chromeAfter = DockProjectionReconciler.collectProjectedTabs(
+            workspace.getReference('dock-host-b').items[0]
+        );
+
         expect(workspace.resolvePane('workbench', initialDocument.items.workbench)).toBe(workbenchBefore);
         expect(workspace.resolvePane('inspector', initialDocument.items.inspector)).toBe(inspectorBefore);
-        expect(workbenchBefore.isDestroyed).toBeFalsy()
+        expect(workbenchBefore.isDestroyed).toBeFalsy();
+        expect([...chromeAfter.keys()]).toEqual([...chromeBefore.keys()]);
+        chromeBefore.forEach((tab, nodeId) => expect(chromeAfter.get(nodeId)).toBe(tab))
     });
 
     test('popOutPane guards: unknown, uncached, and double detach all fail closed', async () => {

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -6,9 +6,10 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../src/Neo.mjs';
-import * as core      from '../../../../../src/core/_export.mjs';
+import {test, expect}           from '@playwright/test';
+import Neo                      from '../../../../../src/Neo.mjs';
+import * as core                from '../../../../../src/core/_export.mjs';
+import DockProjectionReconciler from '../../../../../src/dashboard/DockProjectionReconciler.mjs';
 import '../../../../../src/manager/Instance.mjs';
 import FeedPane  from '../../../../../apps/workstation/view/FeedPane.mjs';
 import ScalePane from '../../../../../apps/workstation/view/ScalePane.mjs';
@@ -26,7 +27,7 @@ const readTabChrome = workspace => {
         shell        = workspace.getReference('dock-host').items[0],
         itemIdByPane = new Map(Object.entries(workspace.paneCache).map(([itemId, pane]) => [pane, itemId]));
 
-    return new Map([...workspace.collectProjectedTabs(shell)].map(([nodeId, tab]) => {
+    return new Map([...DockProjectionReconciler.collectProjectedTabs(shell)].map(([nodeId, tab]) => {
         const
             bar     = tab.getTabBar(),
             body    = tab.getCardContainer(),

--- a/test/playwright/unit/apps/workstation/Workspace.spec.mjs
+++ b/test/playwright/unit/apps/workstation/Workspace.spec.mjs
@@ -17,6 +17,33 @@ import Workspace from '../../../../../apps/workstation/view/Workspace.mjs';
 import {initialDocument} from '../../../../../apps/workstation/tour/denseWorkstation.mjs';
 
 /**
+ * @summary Captures object identities for every live logical tab surface in one Workstation shell.
+ * @param {Workstation.view.Workspace} workspace
+ * @returns {Map<String,Object>}
+ */
+const readTabChrome = workspace => {
+    const
+        shell        = workspace.getReference('dock-host').items[0],
+        itemIdByPane = new Map(Object.entries(workspace.paneCache).map(([itemId, pane]) => [pane, itemId]));
+
+    return new Map([...workspace.collectProjectedTabs(shell)].map(([nodeId, tab]) => {
+        const
+            bar     = tab.getTabBar(),
+            body    = tab.getCardContainer(),
+            buttons = new Map(body.items.map((pane, index) => [itemIdByPane.get(pane), bar.items[index]]));
+
+        return [nodeId, {
+            bar,
+            body,
+            buttons,
+            overflow: bar.getPlugin('tab-overflow'),
+            strip   : tab.getTabStrip(),
+            tab
+        }]
+    }))
+};
+
+/**
  * @summary Pins the composition choices Workstation itself owns: one provider with two stores,
  * an exact 100k Turbo scale set, a growing capped feed, and stable pane/store identities
  * across a reducer-driven coarse projection. Primitive grid/Canvas stress remains in its
@@ -54,12 +81,20 @@ test.describe.serial('Workstation.view.Workspace', () => {
 
         try {
             const
-                provider   = workspace.getStateProvider(),
-                scaleStore = provider.getStore('scale'),
-                feedStore  = provider.getStore('feed'),
-                scalePane  = workspace.resolvePane('scale', initialDocument.items.scale),
-                feedPane   = workspace.resolvePane('feed', initialDocument.items.feed),
-                feedBefore = feedStore.count;
+                provider       = workspace.getStateProvider(),
+                scaleStore     = provider.getStore('scale'),
+                feedStore      = provider.getStore('feed'),
+                scalePane      = workspace.resolvePane('scale', initialDocument.items.scale),
+                feedPane       = workspace.resolvePane('feed', initialDocument.items.feed),
+                feedBefore     = feedStore.count,
+                initialChrome  = readTabChrome(workspace),
+                initialNodeIds = [...initialChrome.keys()],
+                securityButton = initialChrome.get('heavy-tabs').buttons.get('security');
+
+            expect(new Set(initialNodeIds)).toEqual(new Set([
+                'scale-tabs', 'heavy-tabs', 'left-tabs',
+                'right-top-tabs', 'right-bottom-tabs', 'bottom-tabs'
+            ]));
 
             expect(scaleStore.className).toBe('Workstation.store.Scale');
             expect(feedStore.className).toBe('Workstation.store.Feed');
@@ -95,6 +130,51 @@ test.describe.serial('Workstation.view.Workspace', () => {
             workspace.onDockZoneDocumentChange(result.document);
             await workspace.refreshPromise;
 
+            const
+                splitChrome   = readTabChrome(workspace),
+                temporaryNode = splitChrome.get('tabs-security-0'),
+                destroyCounts = new Map();
+
+            expect(splitChrome.size).toBe(initialChrome.size + 1);
+            expect(temporaryNode).toBeTruthy();
+            expect(temporaryNode.buttons.get('security')).toBe(securityButton);
+            expect(temporaryNode.body.items[0]).toBe(workspace.resolvePane('security', initialDocument.items.security));
+            expect(splitChrome.get('heavy-tabs').bar.sortZoneConfig.dockItemIds)
+                .toEqual(initialDocument.nodes['heavy-tabs'].items.filter(itemId => itemId !== 'security'));
+
+            initialNodeIds.forEach(nodeId => {
+                const
+                    before = initialChrome.get(nodeId),
+                    after  = splitChrome.get(nodeId);
+
+                expect(after.tab, `${nodeId} keeps its tab.Container`).toBe(before.tab);
+                expect(after.bar, `${nodeId} keeps its header toolbar`).toBe(before.bar);
+                expect(after.body, `${nodeId} keeps its body container`).toBe(before.body);
+                expect(after.strip, `${nodeId} keeps its indicator strip`).toBe(before.strip);
+                expect(after.overflow, `${nodeId} keeps its Overflow plugin`).toBe(before.overflow);
+
+                before.buttons.forEach((button, itemId) => {
+                    itemId !== 'security'
+                        && expect(after.buttons.get(itemId), `${itemId} keeps its tab button`).toBe(button)
+                })
+            });
+
+            [
+                temporaryNode.tab,
+                temporaryNode.bar,
+                temporaryNode.body,
+                temporaryNode.strip,
+                temporaryNode.overflow
+            ].forEach(component => {
+                const destroy = component.destroy.bind(component);
+
+                destroyCounts.set(component, 0);
+                component.destroy = (...args) => {
+                    destroyCounts.set(component, destroyCounts.get(component) + 1);
+                    return destroy(...args)
+                }
+            });
+
             result = workspace.applyDockZoneOperation({
                 operation : 'addTab',
                 itemId    : 'security',
@@ -104,6 +184,33 @@ test.describe.serial('Workstation.view.Workspace', () => {
             expect(result.errors).toEqual([]);
             workspace.onDockZoneDocumentChange(result.document);
             await workspace.refreshPromise;
+
+            const returnedChrome = readTabChrome(workspace);
+
+            expect(returnedChrome.size).toBe(initialChrome.size);
+            expect(returnedChrome.has('tabs-security-0')).toBe(false);
+            expect(returnedChrome.get('heavy-tabs').buttons.get('security')).toBe(securityButton);
+            expect(returnedChrome.get('heavy-tabs').bar.sortZoneConfig.dockItemIds)
+                .toEqual(result.document.nodes['heavy-tabs'].items);
+            expect(returnedChrome.get('heavy-tabs').tab.activeIndex)
+                .toBe(result.document.nodes['heavy-tabs'].items.indexOf('security'));
+            expect(securityButton.pressed).toBe(true);
+            destroyCounts.forEach(count => expect(count).toBe(1));
+
+            initialNodeIds.forEach(nodeId => {
+                const
+                    before = initialChrome.get(nodeId),
+                    after  = returnedChrome.get(nodeId);
+
+                expect(after.tab).toBe(before.tab);
+                expect(after.bar).toBe(before.bar);
+                expect(after.body).toBe(before.body);
+                expect(after.strip).toBe(before.strip);
+                expect(after.overflow).toBe(before.overflow);
+                before.buttons.forEach((button, itemId) => {
+                    expect(after.buttons.get(itemId), `${itemId} returns with its original tab button`).toBe(button)
+                })
+            });
 
             expect(workspace.resolvePane('scale', initialDocument.items.scale)).toBe(scalePane);
             expect(workspace.resolvePane('feed', initialDocument.items.feed)).toBe(feedPane);

--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -1,0 +1,147 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockProjectionReconcilerTest'
+    }
+});
+
+import {test, expect}           from '@playwright/test';
+import Neo                      from '../../../../src/Neo.mjs';
+import * as core                from '../../../../src/core/_export.mjs';
+import Component                from '../../../../src/component/Base.mjs';
+import Container                from '../../../../src/container/Base.mjs';
+import DockLayoutAdapter        from '../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockProjectionReconciler from '../../../../src/dashboard/DockProjectionReconciler.mjs';
+import '../../../../src/manager/Instance.mjs';
+import '../../../../src/button/Base.mjs';
+import '../../../../src/tab/Container.mjs';
+import '../../../../src/toolbar/Base.mjs';
+
+const createRootTabsModel = () => ({
+    schema: 'neo.harness.dockZone.v1',
+    root  : 'root-tabs',
+    items : {
+        alpha: {componentRef: 'alpha', kind: 'panel', title: 'Alpha'}
+    },
+    nodes: {
+        'root-tabs': {activeItemId: 'alpha', items: ['alpha'], type: 'tabs'}
+    }
+});
+
+test.describe('Neo.dashboard.DockProjectionReconciler', () => {
+    test('keys retained tab chrome and reserves only its projected destination', () => {
+        const
+            retainedTab = {dockNodeId: 'primary-tabs', dockNodeType: 'tabs'},
+            retiredTab  = {dockNodeId: 'retired-tabs', dockNodeType: 'tabs'},
+            liveShell   = {
+                items: [{
+                    items: [retainedTab, retiredTab]
+                }]
+            },
+            currentTabs = DockProjectionReconciler.collectProjectedTabs(liveShell),
+            plans       = new Map(),
+            primary     = {
+                activeIndex  : 1,
+                cls          : ['primary'],
+                dockNodeId   : 'primary-tabs',
+                dockNodeType : 'tabs',
+                flex         : 0.7,
+                headerToolbar: {
+                    sortZoneConfig: {dockItemIds: ['alpha', 'beta']}
+                },
+                items: ['projected-pane-config']
+            },
+            secondary = {
+                activeIndex  : 0,
+                dockNodeId   : 'secondary-tabs',
+                dockNodeType : 'tabs',
+                headerToolbar: {
+                    sortZoneConfig: {dockItemIds: ['gamma']}
+                },
+                items: ['new-pane-config']
+            },
+            projection = DockProjectionReconciler.prepareTabChromeProjection({
+                dockNodeId  : 'root',
+                dockNodeType: 'split',
+                items       : [primary, secondary]
+            }, currentTabs, plans),
+            retainedPlan = plans.get('primary-tabs');
+
+        try {
+            expect([...currentTabs.keys()]).toEqual(['primary-tabs', 'retired-tabs']);
+            expect([...plans.keys()]).toEqual(['primary-tabs', 'secondary-tabs']);
+            expect(retainedPlan).toMatchObject({
+                activeIndex : 1,
+                config      : primary,
+                desiredItems: ['alpha', 'beta'],
+                tab         : retainedTab
+            });
+            expect(retainedPlan.placeholder.cls).toContain('neo-dashboard-dock-projection-placeholder');
+            expect(retainedPlan.placeholder.flex).toBe(0.7);
+            expect(retainedPlan.placeholder.hidden).toBe(true);
+            expect(retainedPlan.placeholder.hideMode).toBe('visibility');
+            expect(projection.items[0]).toBe(retainedPlan.placeholder);
+            expect(projection.items[1]).toBe(secondary);
+            expect(plans.get('secondary-tabs').placeholder).toBeNull();
+        } finally {
+            retainedPlan.placeholder.destroy()
+        }
+    });
+
+    test('fails closed when a live item resolver is absent', () => {
+        expect(() => DockProjectionReconciler.reconcileTabChrome(
+            new Map(),
+            new Map(),
+            new Map(),
+            {items: []}
+        )).toThrow('requires a live item resolver')
+    });
+
+    test('retains a root tab and discovers its live item before consulting the app resolver', async () => {
+        const
+            model = createRootTabsModel(),
+            pane  = Neo.create(Component, {header: {text: 'Alpha'}}),
+            host  = Neo.create(Container, {
+                items: [DockLayoutAdapter.project(model, {
+                    resolveComponentRef: () => pane
+                })]
+            }),
+            originalTab  = host.items[0],
+            placeholders = new Map();
+
+        let resolverCalls = 0;
+
+        try {
+            const nextConfig = DockLayoutAdapter.project(model, {
+                    resolveComponentRef(componentRef, item, itemId) {
+                        const placeholder = Neo.create(Component, {
+                            header: {text: item.title},
+                            hidden: true
+                        });
+
+                        placeholders.set(itemId, placeholder);
+
+                        return placeholder
+                    }
+                }),
+                result = await DockProjectionReconciler.reconcileProjection({
+                    host,
+                    nextConfig,
+                    placeholders,
+                    resolveItem() {
+                        resolverCalls++;
+                        return null
+                    }
+                });
+
+            expect(result.nextShell).toBe(originalTab);
+            expect(host.items.length).toBe(1);
+            expect(host.items[0]).toBe(originalTab);
+            expect(originalTab.getCardContainer().items[0]).toBe(pane);
+            expect(resolverCalls).toBe(0)
+        } finally {
+            host.destroy()
+        }
+    })
+});


### PR DESCRIPTION
Resolves #15136

Workstation now retains every surviving logical tab surface across dock-document projection: the `tab.Container`, header toolbar, body, strip, Overflow plugin/control, and surviving header-button components move through Neo's native ownership path instead of being reconstructed. The renderer-safe transaction now lives in `Neo.dashboard.DockProjectionReconciler`; Workstation and Dock Demo B consume the same shared path with different pane policies. Genuine logical tab nodes still enter and leave normally, `DockLayoutAdapter` stays stateless, the broad `workstation-chrome-settling` CSS suppression is gone, and ordinary active-tab indicator motion remains intact.

Evidence: L3 (live Chromium + Neural Link component/DOM identity, two-window popup/perspective continuity, overflow, staging-safety, and animation probes) -> L3 required (all browser-observable close-target ACs). No #15136 residuals; remaining coarse-consumer migration is tracked by #15171.

## Deltas from ticket

- The ticket's local-first expectation was falsified by five direct `DockLayoutAdapter` consumers. A stable contract emerged, so the transaction moved into `src/dashboard/DockProjectionReconciler.mjs` without making `DockLayoutAdapter` stateful.
- Workstation and Dock Demo B are independent live consumers. Demo B replaces pane parking/coarse shell teardown with the same staged transaction; Demo A, Fleet Cockpit, and the dashboard example are deliberately isolated in #15171 because their overlay, interaction-owner, and example-policy boundaries require focused evidence.
- Descendant pane/button transfers and retained ancestor tab-container moves use separate common-host commits. A combined commit let main-thread cleanup retire an already-moved Security pane after its ancestor landed.
- The browser DOM oracle covers persistent structural chrome. Header-button component identity is complete, while button DOM identity intentionally follows `tab.plugin.Overflow`'s existing `removeDom` contract when a button becomes overflow-hidden.

## Contract Ledger

| Surface | Signature | Authority |
|---|---|---|
| shared transaction | `reconcileProjection(options)` | stages target shell; commits descendants, ancestors, cleanup, and Overflow in order |
| keyed chrome discovery | `collectProjectedTabs(root)` | `dockNodeId` identifies surviving logical tab owners |
| item ownership | `reconcileTabChrome(plans, placeholders, currentTabs, nextShell, resolveItem)` | current live tab order wins before app resolver |
| ancestor handoff | `moveRetainedTabChrome(plans)` | native remove/insert with mounted identity retained |
| app hooks | `onProjectionStaged` / `waitForOverflowProjection` | app-specific animation/menu readiness only |

## Test Evidence

- Themes: `npm run build-themes -- -n -e dev -t all` - passed; no tracked generated drift.
- Shared + consumer units: `npm run test-unit -- test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs test/playwright/unit/apps/workstation/Workspace.spec.mjs test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs --workers=1` - 17 passed.
- Live browser journeys: `NEO_E2E_PORT=8124 npx playwright test test/playwright/e2e/workstation/WorkstationNL.spec.mjs test/playwright/e2e/agentos/DemoBPerspectivesNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` - 2 passed (Workstation dense identity/Canvas tour + Demo B two-run popup/perspective journey).
- Source gates: `npm run agent-preflight -- --no-fix` - passed; commit hooks passed whitespace, shorthand, JSDoc types, ticket archaeology, alignment, AiConfig-test mutation, and parse checks.

## Post-Merge Validation

- [ ] Confirm deployed `dev` Workstation completes its tour with exactly one Overflow control after production assets are rebuilt.
- [ ] Confirm deployed Dock Demo B completes both popup/perspective runs with one retained CounterPane and stable surviving tab chrome.

## Evolution

The first retained-chrome implementation placed shared ownership mechanics in `apps/workstation/view/Workspace.mjs`. The operator's architectural challenge forced a consumer sweep: five apps/examples use the same adapter, and Demo B immediately proved a second policy-distinct consumer. The corrected shape keeps projection pure in `DockLayoutAdapter`, centralizes live ownership in `DockProjectionReconciler`, and leaves each app responsible only for resolver and presentation hooks.

Within the transaction, the first design moved descendant cards/buttons and tab-container ancestors in one host update. Frame-level Neural Link evidence showed worker state remained correct while the Security pane disappeared from the main DOM: old-ancestor cleanup overtook its moved child. The final shape commits descendants first, ancestors second, cleanup third, then reprojects floating Overflow controls.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session adddb25d-fc36-4b08-b9a3-3a62a108cda1.
