### PR TITLE
feat(dashboard): make dock geometry host-relative (#15172)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -209,7 +209,7 @@ class Workspace extends Container {
 
         me.add([me.createTourBar(), me.createStatusBar(), {
             module   : Container,
-            cls      : ['workstation-dock-host', 'neo-dashboard'],
+            cls      : ['workstation-dock-host', 'neo-dashboard', 'neo-dashboard-dock-query-host'],
             flex     : 1,
             items    : [me.projectDockModel()],
             layout   : {ntype: 'fit'},

--- a/resources/scss/src/apps/workstation/Workspace.scss
+++ b/resources/scss/src/apps/workstation/Workspace.scss
@@ -3,12 +3,6 @@
 // reduced-motion collapse owned by Neo.dashboard.Container.
 
 .workstation-workspace {
-    // Workstation owns its edge-band projection policy. Inline container units let the
-    // secondary bands yield to the primary work surface without teaching dockZone.v1 about
-    // viewport pixels; the block-axis band follows the standalone viewport within the same
-    // bounded desktop contract.
-    container-type: inline-size;
-
     // Workstation is a standalone instrument, so generic grid/tab primitives inherit its own
     // palette in both skins instead of leaking their default blue/purple values.
     --grid-container-border-color              : var(--workstation-line);
@@ -122,21 +116,6 @@
     .neo-tab-container > .neo-tab-body-container {
         background: transparent;
         border    : 0;
-    }
-
-    // The generic edge-zone defaults are symmetrical. Workstation's evidence column carries two
-    // vertically stacked instruments, while the left queue card is intentionally simpler.
-    // Preserve those desktop maxima while yielding enough inline space for the primary grid.
-    .neo-dashboard-dock-edge-band-left {
-        width: clamp(180px, 20.3125cqi, 260px);
-    }
-
-    .neo-dashboard-dock-edge-band-right {
-        width: clamp(220px, 25cqi, 320px);
-    }
-
-    .neo-dashboard-dock-edge-band-bottom {
-        height: clamp(140px, 28vh, 200px);
     }
 
     .neo-dashboard-dock-edge-rail {
@@ -308,6 +287,13 @@
 }
 
 .workstation-dock-host {
+    // Workstation owns density policy; the shared dashboard owns projection hooks and defaults.
+    // Root-font-relative bounds remain readable while both fluid terms follow this definite-size
+    // host, including when the standalone app becomes a child workspace.
+    --dock-edge-band-left-inline-size : clamp(11.25rem, 20.3125cqi, 16.25rem);
+    --dock-edge-band-right-inline-size: clamp(13.75rem, 25cqi, 20rem);
+    --dock-edge-band-bottom-block-size: clamp(8.75rem, 28cqb, 12.5rem);
+
     padding: 12px;
 }
 

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -93,6 +93,14 @@
     touch-action: none;
 }
 
+// Opt-in only: `size` containment requires a host with definite inline and block extents.
+// Nearest eligible containment establishes the cqi/cqb boundary; the name exposes that selected
+// host for inspection and future named @container rules without affecting unit resolution.
+.neo-dashboard-dock-query-host {
+    container-name: neo-dashboard-dock;
+    container-type: size;
+}
+
 // Scoped to 0,3,0 on purpose: the generic sort affordance (`.neo-container .neo-draggable`,
 // 0,2,0 in SortZone.css) otherwise wins the cascade and paints the resize handles with a
 // `pointer` cursor — load-order ties are not a contract.
@@ -134,14 +142,23 @@
 }
 
 .neo-dashboard-dock-edge-band {
-    &-left,
-    &-right {
-        width: 280px;
+    // Defaults stay at the consumption boundary: DockLayoutAdapter projects nested
+    // `.neo-dashboard` zones, so declaring these tokens on every dashboard would shadow
+    // application values inherited from the actual query host.
+    &-left {
+        inline-size: var(--dock-edge-band-left-inline-size, var(--dock-edge-band-inline-size, 17.5rem));
     }
 
-    &-top,
+    &-right {
+        inline-size: var(--dock-edge-band-right-inline-size, var(--dock-edge-band-inline-size, 17.5rem));
+    }
+
+    &-top {
+        block-size: var(--dock-edge-band-top-block-size, var(--dock-edge-band-block-size, 12.5rem));
+    }
+
     &-bottom {
-        height: 200px;
+        block-size: var(--dock-edge-band-bottom-block-size, var(--dock-edge-band-block-size, 12.5rem));
     }
 }
 

--- a/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
+++ b/test/playwright/e2e/workstation/WorkstationNL.spec.mjs
@@ -9,7 +9,7 @@ import {workstationTourScript} from '../../../../apps/workstation/tour/denseWork
  * two stable Store<Model> identities, an exact 100k renderer-rich grid, a sustained capped
  * feed, one owner-exact overflow surface, two real rails, frame-sampled midpoint continuity,
  * Canvas-worker pixel change, DevIndex-sized chart geometry, honest progress paints, both
- * themes, viewport-adaptive edge bands, visible real splitters, user-driven semantic resize,
+ * themes, host-relative edge bands, visible real splitters, user-driven semantic resize,
  * pane-owned chrome, replacement-chrome motion containment, sequential clip-safe fixed staging,
  * and identity preservation.
  *
@@ -249,7 +249,7 @@ const readHorizontalSplitGeometry = page => page.evaluate(() => {
 
 /**
  * Reads Workstation's app-owned responsive dock projection from the browser CSSOM.
- * @summary Pins viewport-driven edge-band geometry without treating the persisted dock document as layout state.
+ * @summary Pins host-relative edge-band geometry without treating the persisted dock document as layout state.
  * @param {import('@playwright/test').Page} page
  * @returns {Promise<Object>}
  */
@@ -282,28 +282,106 @@ const readResponsiveDockGeometry = page => page.evaluate(() => {
                 width : value.width
             }
         },
-        readBand = (element, property) => ({
-            ...readRect(element),
-            computedExtent: Number.parseFloat(getComputedStyle(element)[property])
-        });
+        nearestQueryContainerId = (element, axis) => {
+            for (let candidate = element?.parentElement; candidate; candidate = candidate.parentElement) {
+                const containerType = getComputedStyle(candidate).containerType;
+
+                if (containerType === 'size' || (axis === 'inline' && containerType === 'inline-size')) {
+                    return candidate.id
+                }
+            }
+
+            return null
+        },
+        readBand = (element, property, axis) => {
+            const style = getComputedStyle(element);
+
+            return {
+                ...readRect(element),
+                computedExtent         : Number.parseFloat(style[property]),
+                logicalProperty        : property,
+                nearestQueryContainerId: nearestQueryContainerId(element, axis)
+            }
+        },
+        readHost = element => {
+            const
+                rect   = readRect(element),
+                style  = getComputedStyle(element),
+                number = property => Number.parseFloat(style[property]) || 0;
+
+            return {
+                ...rect,
+                boxSizing       : style.boxSizing,
+                containerName   : style.containerName,
+                containerType   : style.containerType,
+                contentBlockSize: rect.height
+                    - number('borderTopWidth') - number('borderBottomWidth')
+                    - number('paddingTop') - number('paddingBottom'),
+                contentInlineSize: rect.width
+                    - number('borderLeftWidth') - number('borderRightWidth')
+                    - number('paddingLeft') - number('paddingRight'),
+                id: element.id
+            }
+        };
 
     return {
-        bottomBand      : readBand(bottom, 'height'),
+        bottomBand      : readBand(bottom, 'blockSize', 'block'),
         center          : readRect(center),
-        dockHost        : readRect(dockHost),
-        leftBand        : readBand(left, 'width'),
+        dockHost        : readHost(dockHost),
+        leftBand        : readBand(left, 'inlineSize', 'inline'),
         overflowControls: [...document.querySelectorAll('.neo-tab-overflow-control')]
             .filter(isVisible).length,
         railTabs: [...document.querySelectorAll('.neo-dashboard-dock-rail-tab')]
             .filter(isVisible).length,
-        rightBand: readBand(right, 'width'),
-        root     : readRect(root),
-        row      : readRect(row),
-        scale    : readRect(scale),
-        splitters: document.querySelectorAll('.neo-dashboard-dock-splitter').length,
-        viewport : {height: innerHeight, width: innerWidth}
+        rightBand   : readBand(right, 'inlineSize', 'inline'),
+        root        : readRect(root),
+        rootFontSize: Number.parseFloat(getComputedStyle(document.documentElement).fontSize),
+        row         : readRect(row),
+        scale       : readRect(scale),
+        splitters   : document.querySelectorAll('.neo-dashboard-dock-splitter').length,
+        viewport    : {height: innerHeight, width: innerWidth}
     }
 });
+
+/**
+ * Applies an exact content-box extent through the mounted dock host's production border-box model.
+ * @summary Separates child-workspace responsiveness from outer viewport responsiveness without reloading Neo.
+ * @param {import('@playwright/test').Page} page
+ * @param {{height:Number,width:Number}} size
+ * @returns {Promise<void>}
+ */
+const setDockHostContentSize = (page, size) => page.evaluate(({height, width}) => {
+    const
+        host        = document.querySelector('.workstation-dock-host'),
+        style       = getComputedStyle(host),
+        number      = property => Number.parseFloat(style[property]) || 0,
+        blockExtras = number('borderTopWidth') + number('borderBottomWidth')
+            + number('paddingTop') + number('paddingBottom'),
+        inlineExtras = number('borderLeftWidth') + number('borderRightWidth')
+            + number('paddingLeft') + number('paddingRight');
+
+    host.style.setProperty('block-size', `${height + blockExtras}px`, 'important');
+    host.style.setProperty('box-sizing', 'border-box', 'important');
+    host.style.setProperty('flex', 'none', 'important');
+    host.style.setProperty('inline-size', `${width + inlineExtras}px`, 'important')
+}, size);
+
+/**
+ * Restores the host's engine-projected inline style after the nested-host probe.
+ * @summary Keeps the remainder of the whitebox journey aligned with the component VDOM.
+ * @param {import('@playwright/test').Page} page
+ * @param {String|null} value
+ * @returns {Promise<void>}
+ */
+const restoreDockHostStyle = (page, value) => page.evaluate(style => {
+    const host = document.querySelector('.workstation-dock-host');
+
+    if (style === null) {
+        host.removeAttribute('style')
+    } else {
+        host.setAttribute('style', style)
+    }
+}, value);
 
 test.describe('Workstation — dense living-data composition', () => {
     test.setTimeout(150000);
@@ -426,17 +504,83 @@ test.describe('Workstation — dense living-data composition', () => {
             return readResponsiveDockGeometry(page)
         };
 
+        /**
+         * @summary Resizes only the mounted dock host and waits for its two-axis query projection.
+         * @param {{height:Number,width:Number}} size
+         * @returns {Promise<Object>}
+         */
+        const readAtHost = async size => {
+            await setDockHostContentSize(page, size);
+            await expect.poll(async () => {
+                const {dockHost} = await readResponsiveDockGeometry(page);
+
+                return {
+                    blockSize    : Math.round(dockHost.contentBlockSize),
+                    boxSizing    : dockHost.boxSizing,
+                    containerName: dockHost.containerName,
+                    containerType: dockHost.containerType,
+                    inlineSize   : Math.round(dockHost.contentInlineSize)
+                }
+            }, {
+                message  : `Dock host settles at ${size.width}x${size.height}`,
+                timeout  : 10000,
+                intervals: [25, 50, 100]
+            }).toEqual({
+                blockSize    : size.height,
+                boxSizing    : 'border-box',
+                containerName: 'neo-dashboard-dock',
+                containerType: 'size',
+                inlineSize   : size.width
+            });
+
+            return readResponsiveDockGeometry(page)
+        };
+
         const
             wideGeometry   = await readAtViewport({height: 900, width: 1280}),
             narrowGeometry = await readAtViewport({height: 900, width: 900}),
             shortGeometry  = await readAtViewport({height: 600, width: 900});
 
-        expect(wideGeometry.leftBand.computedExtent).toBeCloseTo(260, 1);
-        expect(wideGeometry.rightBand.computedExtent).toBeCloseTo(320, 1);
-        expect(wideGeometry.bottomBand.computedExtent).toBeCloseTo(200, 1);
-        expect(narrowGeometry.leftBand.computedExtent).toBeCloseTo(182.8125, 1);
-        expect(narrowGeometry.rightBand.computedExtent).toBeCloseTo(225, 1);
-        expect(narrowGeometry.bottomBand.computedExtent).toBeCloseTo(200, 1);
+        /**
+         * @summary Asserts each band resolves its cq unit and rem clamp against the measured dock host.
+         * @param {Object} geometry
+         * @returns {void}
+         */
+        const assertHostRelativeBandGeometry = geometry => {
+            const
+                clamp                    = (floor, value, cap) => Math.min(cap, Math.max(floor, value)),
+                {dockHost, rootFontSize} = geometry;
+
+            expect(rootFontSize).toBeGreaterThan(0);
+            expect(dockHost.id).toBeTruthy();
+            expect(dockHost.boxSizing).toBe('border-box');
+            expect(dockHost.containerType).toBe('size');
+            expect(dockHost.containerName).toBe('neo-dashboard-dock');
+            expect(geometry.leftBand.nearestQueryContainerId).toBe(dockHost.id);
+            expect(geometry.rightBand.nearestQueryContainerId).toBe(dockHost.id);
+            expect(geometry.bottomBand.nearestQueryContainerId).toBe(dockHost.id);
+            expect(geometry.leftBand.computedExtent).toBeCloseTo(clamp(
+                rootFontSize * 11.25,
+                dockHost.contentInlineSize * 0.203125,
+                rootFontSize * 16.25
+            ), 1);
+            expect(geometry.rightBand.computedExtent).toBeCloseTo(clamp(
+                rootFontSize * 13.75,
+                dockHost.contentInlineSize * 0.25,
+                rootFontSize * 20
+            ), 1);
+            expect(geometry.bottomBand.computedExtent).toBeCloseTo(clamp(
+                rootFontSize * 8.75,
+                dockHost.contentBlockSize * 0.28,
+                rootFontSize * 12.5
+            ), 1)
+        };
+
+        expect(wideGeometry.leftBand.logicalProperty).toBe('inlineSize');
+        expect(wideGeometry.bottomBand.logicalProperty).toBe('blockSize');
+        assertHostRelativeBandGeometry(wideGeometry);
+        assertHostRelativeBandGeometry(narrowGeometry);
+        assertHostRelativeBandGeometry(shortGeometry);
         expect(narrowGeometry.leftBand.width).toBeLessThan(wideGeometry.leftBand.width);
         expect(narrowGeometry.rightBand.width).toBeLessThan(wideGeometry.rightBand.width);
         expect(narrowGeometry.center.width, 'the primary center keeps its desktop working floor')
@@ -451,7 +595,6 @@ test.describe('Workstation — dense living-data composition', () => {
         expect(narrowGeometry.scale.right).toBeLessThanOrEqual(narrowGeometry.center.right + 1);
         expect(narrowGeometry.overflowControls, 'tab overflow remains owner-exact at the narrow desktop floor')
             .toBe(1);
-        expect(shortGeometry.bottomBand.computedExtent).toBeCloseTo(168, 1);
         expect(shortGeometry.bottomBand.height).toBeLessThan(wideGeometry.bottomBand.height);
         expect(shortGeometry.center.width).toBeCloseTo(narrowGeometry.center.width, 1);
         expect(shortGeometry.scale.width).toBeCloseTo(narrowGeometry.scale.width, 1);
@@ -459,6 +602,49 @@ test.describe('Workstation — dense living-data composition', () => {
             .toBeGreaterThanOrEqual(230);
         expect(shortGeometry.bottomBand.bottom).toBeLessThanOrEqual(shortGeometry.dockHost.bottom + 1);
         expect(shortGeometry.overflowControls).toBe(1);
+
+        const dockHostStyleBefore = await page.locator('.workstation-dock-host').getAttribute('style');
+
+        await readAtViewport({height: 900, width: 1400});
+
+        const largeHostGeometry = await readAtHost({height: 600, width: 1100});
+
+        assertHostRelativeBandGeometry(largeHostGeometry);
+        expect(largeHostGeometry.rightBand.computedExtent)
+            .toBeCloseTo(largeHostGeometry.dockHost.contentInlineSize * 0.25, 1);
+        expect(largeHostGeometry.bottomBand.computedExtent)
+            .toBeCloseTo(largeHostGeometry.dockHost.contentBlockSize * 0.28, 1);
+
+        await page.setViewportSize({height: 850, width: 1300});
+
+        const fixedHostGeometry = await readResponsiveDockGeometry(page);
+
+        expect(fixedHostGeometry.viewport).toEqual({height: 850, width: 1300});
+        expect(fixedHostGeometry.dockHost.contentInlineSize).toBeCloseTo(1100, 1);
+        expect(fixedHostGeometry.dockHost.contentBlockSize).toBeCloseTo(600, 1);
+        assertHostRelativeBandGeometry(fixedHostGeometry);
+        expect(fixedHostGeometry.leftBand.computedExtent)
+            .toBeCloseTo(largeHostGeometry.leftBand.computedExtent, 2);
+        expect(fixedHostGeometry.rightBand.computedExtent)
+            .toBeCloseTo(largeHostGeometry.rightBand.computedExtent, 2);
+        expect(fixedHostGeometry.bottomBand.computedExtent)
+            .toBeCloseTo(largeHostGeometry.bottomBand.computedExtent, 2);
+
+        await page.setViewportSize({height: 900, width: 1400});
+
+        const smallHostGeometry = await readAtHost({height: 450, width: 700});
+
+        assertHostRelativeBandGeometry(smallHostGeometry);
+        expect(smallHostGeometry.rightBand.computedExtent)
+            .toBeCloseTo(smallHostGeometry.rootFontSize * 13.75, 1);
+        expect(smallHostGeometry.bottomBand.computedExtent)
+            .toBeCloseTo(smallHostGeometry.rootFontSize * 8.75, 1);
+        expect(smallHostGeometry.rightBand.computedExtent)
+            .toBeLessThan(largeHostGeometry.rightBand.computedExtent);
+        expect(smallHostGeometry.bottomBand.computedExtent)
+            .toBeLessThan(largeHostGeometry.bottomBand.computedExtent);
+
+        await restoreDockHostStyle(page, dockHostStyleBefore);
 
         const
             responsiveIdentityAfter               = await readIdentity(app, workspaceId),


### PR DESCRIPTION
Resolves #15172

Dock edge-band geometry now follows the definite-size dock host instead of assuming the workspace is the browser viewport. The shared dashboard layer exposes an opt-in two-axis query-host contract and logical, token-backed band extents; Workstation opts its fit-sized host into that contract and keeps its own readable `rem` bounds plus `cqi` / `cqb` density policy.

Evidence: L3 (live Chromium CSSOM/DOMRect probe plus Neural Link whitebox journey) → L3 required (host-relative geometry, viewport independence, and runtime identity ACs). No residuals.

## Deltas from ticket

- Shared defaults preserve the former 280px / 200px geometry at the default 16px root size while making those bounds root-font-relative.
- The CSSOM oracle additionally proves the dock host is the nearest eligible query container per axis; `container-name` remains an inspection and future named-query hook, not a unit-binding mechanism.

## Test Evidence

- Workstation + shared dashboard projection: `NEO_E2E_PORT=8124 npx playwright test test/playwright/e2e/workstation/WorkstationNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` — 1 passed in 47.9s. The journey independently resizes the host and viewport, reads `getComputedStyle()` / DOMRects, verifies `cqi` / `cqb` formulas against the host content box and live root font size, and preserves dock data plus component / Store<Model> identities.
- Theme surfaces: `npm run build-themes -- -n -e dev -t all` — passed for all development themes.
- Source gates: `npm run agent-preflight -- --no-fix apps/workstation/view/Workspace.mjs resources/scss/src/apps/workstation/Workspace.scss resources/scss/src/dashboard/Container.scss test/playwright/e2e/workstation/WorkstationNL.spec.mjs` — passed; commit-time staged hooks and `git diff --check` also passed.

## Post-Merge Validation

- [ ] Re-run the focused Workstation Neural Link journey against the merged `dev` build.

Related: #13158

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session adddb25d-fc36-4b08-b9a3-3a62a108cda1.
