### PR TITLE
refactor(dashboard): reconcile remaining dock projections (#15171)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoAWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoAWorkspace.mjs
@@ -1,10 +1,12 @@
 import ClockPane                          from './ClockPane.mjs';
+import Component                          from '../../../../../src/component/Base.mjs';
 import Container                          from '../../../../../src/container/Base.mjs';
 import DockDropIndicators                 from '../../../../../src/dashboard/DockDropIndicators.mjs';
 import DockLayoutAdapter                  from '../../../../../src/dashboard/DockLayoutAdapter.mjs';
 import DockMotionSignal                   from '../../../../../src/dashboard/DockMotionSignal.mjs';
 import DockPreview                        from '../../../view/DockPreview.mjs';
 import DockPreviewProducer                from '../../../../../src/dashboard/DockPreviewProducer.mjs';
+import DockProjectionReconciler           from '../../../../../src/dashboard/DockProjectionReconciler.mjs';
 import DockService                        from '../../../../../src/ai/client/DockService.mjs';
 import DockZoneModel                      from '../../../../../src/dashboard/DockZoneModel.mjs';
 import TourRunner                         from '../../../../../src/ai/client/TourRunner.mjs';
@@ -36,11 +38,10 @@ import '../../../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype 
  * feed binds the runner's `beat` / `scene` / `complete` / `error` events; captions narrate
  * the operations in vocabulary terms, so the tour teaches the API by describing itself.
  *
- * Refresh note: `refreshDockWorkspace()` follows the current normative coarse pattern
- * (wholesale re-projection). A known stale-DOM defect on retired components under this
- * pattern is tracked on the dashboard lane; recording takes are sequenced behind that fix.
- * The `workspace` advisory block of the screenplay (hover-reveal opt-in) is threaded into
- * the projection options — inert until the rail interaction layer lands, correct afterwards.
+ * Re-projection follows the shared staged ownership transaction: surviving panes and tab chrome
+ * move into the next projected shell while the preview and indicator overlays remain persistent
+ * siblings. The `workspace` advisory block of the screenplay (hover-reveal opt-in) is threaded
+ * into the projection options — inert until the rail interaction layer lands, correct afterwards.
  * @class AgentOS.childapps.dockdemo.view.DemoAWorkspace
  * @extends Neo.container.Base
  */
@@ -124,8 +125,8 @@ class DemoAWorkspace extends Container {
      * operation defers its view-sync one tick ({@link #onDockZoneDocumentChange}); any
      * consumer that must resolve PROJECTED components — the reveal cue path — awaits this
      * promise instead of racing that deferral (an unawaited lookup runs within ~0ms of
-     * the commit, resolves `null`, and no-ops silently). Stale-safe: each commit
-     * overwrites it, so awaiting always settles on the LATEST projection.
+     * the commit, resolves `null`, and no-ops silently). Commits chain onto this promise
+     * with their document snapshot, so staged shell transactions never overlap.
      * @member {Promise|null} refreshPromise=null
      * @protected
      */
@@ -172,7 +173,7 @@ class DemoAWorkspace extends Container {
             flex     : 1,
             layout   : {ntype: 'fit'},
             reference: 'dock-host',
-            // The projection child is index 0 and the ONLY child the coarse refresh replaces;
+            // The projection child is index 0 and the ONLY child the shared reconciler stages;
             // the preview renderer + indicator menu are PERSISTENT siblings (absolute overlays
             // via the skin) — object permanence across every re-projection.
             items: [me.projectDockModel(), {
@@ -220,8 +221,8 @@ class DemoAWorkspace extends Container {
                 reference: 'tour-play',
                 text     : 'Tour'
             }, {
-                cls      : ['agentos-dockdemo-tour-caption'],
-                flex     : 1,
+                cls : ['agentos-dockdemo-tour-caption'],
+                flex: 1,
                 // the cold-open invite: the human drag comes FIRST, the agent tour second —
                 // the §06 camera beat opens on a hand on the layout, then "watch an agent do it"
                 html     : `${demoATourScript.title} — drag any tab: every drop option lights up. Then press Tour to watch an agent drive the same operations.`,
@@ -268,11 +269,13 @@ class DemoAWorkspace extends Container {
 
         me.dockModel = document;
 
-        me.refreshPromise = me.timeout(0).then(() => {
-            if (!me.isDestroyed) {
-                return me.refreshDockWorkspace()
-            }
-        })
+        me.refreshPromise = (me.refreshPromise || Promise.resolve())
+            .then(() => me.timeout(0))
+            .then(() => {
+                if (!me.isDestroyed) {
+                    return me.refreshDockWorkspace(document)
+                }
+            })
     }
 
     /**
@@ -539,33 +542,38 @@ class DemoAWorkspace extends Container {
      * Projects the committed document into the live container config, carrying the
      * instance-bound reducer + view-sync callbacks and the screenplay's workspace advisory
      * (the hover-reveal opt-in) as projection options.
+     * @param {Function|null} [resolveComponentRef=null] Optional item resolver for staged projections.
+     * @param {Object} [document=this.dockModel] Committed document snapshot to project.
      * @returns {Object}
      */
-    projectDockModel() {
+    projectDockModel(resolveComponentRef=null, document=this.dockModel) {
         let me = this;
 
-        return DockLayoutAdapter.project(me.dockModel, {
+        return DockLayoutAdapter.project(document, {
             ...demoATourScript.workspace,
             applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
             onDockCrossZoneDragMove : me.onDockCrossZoneDragMove.bind(me),
             onDockCrossZoneDrop     : me.onDockCrossZoneDrop.bind(me),
             onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
-            resolveComponentRef     : componentRef => me.resolvePane(componentRef)
+            resolveComponentRef     : resolveComponentRef
+                || (componentRef => me.resolvePane(componentRef)),
+            resolveRevealComponentRef    : componentRef => me.resolvePane(componentRef)
         })
     }
 
     /**
-     * Re-projection from the committed document, scoped to the dock-host subtree — the tour
-     * bar lives OUTSIDE the refreshed container, so the caption feed's rapid per-beat
-     * updates never race a teardown of their own component (in-flight vdom replies to a
-     * destroyed component wedge, and ancestor updates then yield to the wedge forever).
-     * The dock subtree itself still rebuilds coarsely per the current normative pattern.
+     * Re-projection from the committed document, scoped to the dock-host subtree. The shared
+     * reconciler stages shell index 0 and transfers surviving tab chrome/panes before cleanup;
+     * the tour bar stays outside the host while preview/indicator overlays remain its persistent
+     * siblings. Drag-affordance geometry is still invalidated before structural ownership moves.
+     * @param {Object} [document=this.dockModel] Committed document snapshot owned by this refresh.
      * @protected
      */
-    async refreshDockWorkspace() {
+    async refreshDockWorkspace(document=this.dockModel) {
         const
-            me   = this,
-            host = me.getReference('dock-host');
+            me           = this,
+            host         = me.getReference('dock-host'),
+            placeholders = new Map();
 
         if (host) {
             const flip = Neo.main?.addon?.DockFlip;
@@ -580,10 +588,32 @@ class DemoAWorkspace extends Container {
                 await flip?.captureFirst({hostId: host.id, markerPrefix: 'agentos-dockdemo-pane-'})
             } catch (e) {/* instant landing */}
 
-            // Surgical: only the projection child (index 0) rebuilds — the preview renderer
-            // and the indicator menu are persistent overlay siblings and must survive.
-            host.removeAt(0);
-            host.insert(0, this.projectDockModel());
+            const nextConfig = me.projectDockModel((componentRef, item, itemId) => {
+                const placeholder = Neo.create({
+                    module: Component,
+                    header: {text: item?.title ?? componentRef ?? itemId},
+                    hidden: true
+                });
+
+                placeholders.set(itemId, placeholder);
+
+                return placeholder
+            }, document);
+
+            await DockProjectionReconciler.reconcileProjection({
+                host,
+                nextConfig,
+                placeholders,
+                resolveItem: itemId => {
+                    const item = document.items[itemId];
+
+                    return DockLayoutAdapter.decorateProjectedItem(
+                        me.resolvePane(item?.componentRef ?? itemId),
+                        itemId,
+                        item
+                    )
+                }
+            });
 
             // FLIP phase 2: fire-and-forget — the addon self-waits for the new tree to paint,
             // inverts the survivors onto their old geometry and releases the transition
@@ -607,7 +637,7 @@ class DemoAWorkspace extends Container {
      */
     resolvePane(componentRef) {
         if (componentRef === 'Editor') {
-            // the flip marker rides the cls config so FLIP correlation survives instance recreation
+            // the flip marker rides the cls config so newly materialized panes join FLIP correlation
             return {cls: ['agentos-dockdemo-clock-pane', 'agentos-dockdemo-pane-editor'], module: ClockPane}
         }
 
@@ -666,8 +696,8 @@ class DemoAWorkspace extends Container {
 
         if (me.tourRunner.log.length) {
             // restart semantics: reset the stage to the opening document before replaying
-            me.dockModel = DockZoneModel.clone(initialDocument);
-            me.refreshDockWorkspace()
+            me.onDockZoneDocumentChange(DockZoneModel.clone(initialDocument));
+            await me.refreshPromise
         }
 
         me.beatCount = 0;

--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -592,7 +592,8 @@ class DemoBWorkspace extends Container {
             applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
             onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
             resolveComponentRef     : resolveComponentRef
-                || ((componentRef, item, itemId) => me.resolvePane(itemId, item))
+                || ((componentRef, item, itemId) => me.resolvePane(itemId, item)),
+            resolveRevealComponentRef  : (componentRef, item, itemId) => me.resolvePane(itemId, item)
         })
     }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1,20 +1,22 @@
-import ActivityStream          from './ActivityStream.mjs';
-import AgentDetail             from './AgentDetail.mjs';
-import Button                  from '../../../../src/button/Base.mjs';
-import Container               from '../../../../src/container/Base.mjs';
-import DockLayoutAdapter       from '../../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockMotionSignal        from '../../../../src/dashboard/DockMotionSignal.mjs';
-import DockPerspectiveStore    from '../../../../src/dashboard/DockPerspectiveStore.mjs';
-import DockPreviewProducer     from '../../../../src/dashboard/DockPreviewProducer.mjs';
-import DockZoneModel           from '../../../../src/dashboard/DockZoneModel.mjs';
-import FleetCockpitController  from './FleetCockpitController.mjs';
-import FleetGrid               from './FleetGrid.mjs';
-import FleetRoster             from '../../store/FleetRoster.mjs';
-import StateProvider           from '../../../../src/state/Provider.mjs';
-import cockpitDockDocument     from './cockpitDockDocument.mjs';
-import cockpitPresetCollection from './cockpitPresets.mjs';
-import {mapFleetSessionHealth} from './sourceHealth.mjs';
-import {previewToOperation}    from '../../../../src/dashboard/dockPreviewContract.mjs';
+import ActivityStream           from './ActivityStream.mjs';
+import AgentDetail              from './AgentDetail.mjs';
+import Button                   from '../../../../src/button/Base.mjs';
+import Component                from '../../../../src/component/Base.mjs';
+import Container                from '../../../../src/container/Base.mjs';
+import DockLayoutAdapter        from '../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockMotionSignal         from '../../../../src/dashboard/DockMotionSignal.mjs';
+import DockPerspectiveStore     from '../../../../src/dashboard/DockPerspectiveStore.mjs';
+import DockPreviewProducer      from '../../../../src/dashboard/DockPreviewProducer.mjs';
+import DockProjectionReconciler from '../../../../src/dashboard/DockProjectionReconciler.mjs';
+import DockZoneModel            from '../../../../src/dashboard/DockZoneModel.mjs';
+import FleetCockpitController   from './FleetCockpitController.mjs';
+import FleetGrid                from './FleetGrid.mjs';
+import FleetRoster              from '../../store/FleetRoster.mjs';
+import StateProvider            from '../../../../src/state/Provider.mjs';
+import cockpitDockDocument      from './cockpitDockDocument.mjs';
+import cockpitPresetCollection  from './cockpitPresets.mjs';
+import {mapFleetSessionHealth}  from './sourceHealth.mjs';
+import {previewToOperation}     from '../../../../src/dashboard/dockPreviewContract.mjs';
 import '../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the dock projection emits for tab zones
 
 /**
@@ -46,14 +48,14 @@ const FIXTURE_ACTIVITY = [
  *   the current document — splitter drags, cross-zone tab drops and NL-driven operations all
  *   funnel through it;
  * - {@link #onDockZoneDocumentChange} is the **view-sync**: it stores the committed document and
- *   re-projects one tick deferred (the committing splitter must finish its own `onDragEnd` before
- *   `removeAll()` destroys it — use-after-destroy otherwise; `isDestroyed` guards teardown).
+ *   reconciles one tick deferred (the committing splitter must finish its own `onDragEnd` before
+ *   its retired shell destroys it — use-after-destroy otherwise; `isDestroyed` guards teardown).
  *
- * Projections REBUILD pane instances (`removeAll` + add), so runtime pane state lives on THIS
- * owner, never on the instances: {@link #resolveDockComponentRef} re-materializes each pane from
- * the held state ({@link #gridAdapterState} / {@link #streamAdapterState} / {@link #streamEvents}),
- * and the panes themselves stay layout-blind per the docking design's pane contract — ordinary
- * configs only, no dock wiring reaches them.
+ * Reconciliation retains existing pane and tab-chrome identities. Runtime pane state still lives
+ * on THIS owner, never only on instances: {@link #resolveDockComponentRef} materializes genuinely
+ * absent panes from held state ({@link #gridAdapterState} / {@link #streamAdapterState} /
+ * {@link #streamEvents}), and the panes stay layout-blind per the docking design's pane contract —
+ * ordinary configs only, no dock wiring reaches them.
  *
  * The roster data layer is ONE {@link AgentOS.store.FleetRoster} Store of
  * {@link AgentOS.model.FleetAgent} records, hosted by THIS view's `state.Provider` (`stores`
@@ -133,6 +135,14 @@ class FleetCockpit extends Container {
      */
     dockModel = null
     /**
+     * The serialized deferred projection queue. Each commit captures its document snapshot and
+     * chains behind the prior staged transaction, so rapid splitter/preset changes cannot overlap
+     * shells or resolve absent panes from a newer document.
+     * @member {Promise|null} refreshPromise=null
+     * @protected
+     */
+    refreshPromise = null
+    /**
      * The named preset library — a {@link Neo.dashboard.DockPerspectiveStore} over the seeded
      * workspace-scope collection ({@link module:cockpitPresets}). The store is the preset SSOT;
      * {@link #dockModel} stays the LIVE layout SSOT — presets are snapshots the switch restores
@@ -155,8 +165,8 @@ class FleetCockpit extends Container {
      */
     dockPreviewProducer = null
     /**
-     * The grid's held `adapterState` — re-projections re-materialize the pane from HERE, so a
-     * committed layout change can never reset a live grid back to its sample badge.
+     * The grid's held `adapterState` — absent-item materialization reads from HERE, so a committed
+     * layout change can never reset a live grid back to its sample badge.
      * @member {String} gridAdapterState='sample'
      * @protected
      */
@@ -187,7 +197,7 @@ class FleetCockpit extends Container {
      */
     rosterWired = false
     /**
-     * The stream's held `adapterState` — the re-projection source of truth, like
+     * The stream's held `adapterState` — the absent-item source of truth, like
      * {@link #gridAdapterState}.
      * @member {String} streamAdapterState='sample'
      * @protected
@@ -195,15 +205,15 @@ class FleetCockpit extends Container {
     streamAdapterState = 'sample'
     /**
      * The stream's held event list (chronological). Starts as the honestly-labelled fixture;
-     * {@link #loadActivity} replaces it with the live feed — re-projections read it back.
+     * {@link #loadActivity} replaces it with the live feed — absent-item materialization reads it back.
      * @member {Object[]} streamEvents=FIXTURE_ACTIVITY
      * @protected
      */
     streamEvents = FIXTURE_ACTIVITY
     /**
-     * The drill-in inspector's selected resident — OWNER-held so a re-projection re-materializes
-     * the {@link AgentOS.view.fleet.AgentDetail} pane at the current selection (`null` = the honest
-     * "select an agent" empty state). The card→detail selection wiring writes it.
+     * The drill-in inspector's selected resident — OWNER-held so a genuinely absent
+     * {@link AgentOS.view.fleet.AgentDetail} pane materializes at the current selection (`null` =
+     * the honest "select an agent" empty state). The card→detail selection wiring writes it.
      * @member {Object|null} detailRecord=null
      * @protected
      */
@@ -234,9 +244,9 @@ class FleetCockpit extends Container {
      * loop — the switch re-projects FLIP-animated exactly like any committed operation, with
      * reduced-motion collapsing through the token layer by construction.
      *
-     * Pane continuity across a switch is state-continuity, not instance identity: projections
-     * rebuild instances by design; the live surfaces re-materialize from the OWNER-held state
-     * ({@link #resolveDockComponentRef}) and the provider-owned roster store never restarts.
+     * Pane continuity across a switch preserves component identity when the item already exists;
+     * genuinely absent surfaces materialize from OWNER-held state ({@link #resolveDockComponentRef}),
+     * while the provider-owned roster store never restarts.
      * @param {String} name The preset's `perspectiveName` (or technical `layoutId`).
      * @returns {{switched: Boolean, errors: String[]}}
      */
@@ -246,7 +256,7 @@ class FleetCockpit extends Container {
 
         if (errors.length) {
             me.presetError = `${name}: ${errors[0]}`;
-            me.refreshDockWorkspace();
+            me.syncControlBar();
             return {errors, switched: false}
         }
 
@@ -300,9 +310,9 @@ class FleetCockpit extends Container {
      * from it.
      *
      * Deferred one tick: this fires synchronously from inside the committing splitter's
-     * `onDragEnd` (via `commitResizeSplit`). Re-projecting immediately would `removeAll()` —
-     * destroying that splitter mid-handler, a use-after-destroy on the rest of `onDragEnd`. The
-     * `isDestroyed` guard covers teardown before the tick fires.
+     * `onDragEnd` (via `commitResizeSplit`). Reconciliation still retires the old shell and its
+     * splitter; doing that mid-handler would create a use-after-destroy on the rest of `onDragEnd`.
+     * The `isDestroyed` guard covers teardown before the tick fires.
      * @param {Object} document The committed dock-zone document.
      */
     onDockZoneDocumentChange(document) {
@@ -310,41 +320,101 @@ class FleetCockpit extends Container {
 
         me.dockModel = document;
 
-        me.timeout(0).then(() => {
-            if (!me.isDestroyed) {
-                me.refreshDockWorkspace()
-            }
-        })
+        me.refreshPromise = (me.refreshPromise || Promise.resolve())
+            .then(() => me.timeout(0))
+            .then(() => {
+                if (!me.isDestroyed) {
+                    return me.refreshDockWorkspace(document)
+                }
+            })
     }
 
     /**
-     * @summary Rebuilds the toolbar + dock projection from current state, FLIP-bracketed: the
-     * outgoing pane geometry is snapshotted so the committed re-layout GLIDES, and the counted
-     * motion signal brackets the animation window (ownership lives in `DockMotionSignal`,
-     * fail-safe backstopped — never in the addon).
+     * @summary Reconciles the dock projection while synchronizing persistent control-bar state.
+     *
+     * The outgoing geometry is FLIP-snapshotted, then the shared reconciler transfers surviving
+     * panes and tab chrome into shell index 1. The toolbar at index 0 remains the same component;
+     * only its pressed/error state changes.
+     * @param {Object} [document=this.dockModel] Committed document snapshot owned by this refresh.
      */
-    async refreshDockWorkspace() {
-        const flip = Neo.main?.addon?.DockFlip;
+    async refreshDockWorkspace(document=this.dockModel) {
+        const
+            me           = this,
+            flip         = Neo.main?.addon?.DockFlip,
+            placeholders = new Map();
 
         try {
-            await flip?.captureFirst({hostId: this.id, markerPrefix: 'dock-flip-item-'})
+            await flip?.captureFirst({hostId: me.id, markerPrefix: 'dock-flip-item-'})
         } catch (e) {/* instant landing */}
 
-        this.removeAll();
-        this.add(this.buildWorkspaceItems());
+        me.syncControlBar();
+
+        const nextConfig = me.projectDockModel((componentRef, item, itemId) => {
+            const placeholder = Neo.create({
+                module: Component,
+                header: {text: item?.title ?? componentRef ?? itemId},
+                hidden: true
+            });
+
+            placeholders.set(itemId, placeholder);
+
+            return placeholder
+        }, document);
+
+        nextConfig.flex = 1;
+
+        await DockProjectionReconciler.reconcileProjection({
+            host       : me,
+            nextConfig,
+            placeholders,
+            resolveItem: itemId => {
+                const item = document.items[itemId];
+
+                return DockLayoutAdapter.decorateProjectedItem(
+                    me.resolveDockComponentRef(item?.componentRef, item, itemId),
+                    itemId,
+                    item
+                )
+            },
+            shellIndex: 1
+        });
 
         if (flip) {
-            DockMotionSignal.enter(this);
-            flip.play({hostId: this.id, markerPrefix: 'dock-flip-item-'})
+            DockMotionSignal.enter(me);
+            flip.play({hostId: me.id, markerPrefix: 'dock-flip-item-'})
                 .catch(() => {})
-                .finally(() => DockMotionSignal.leave(this))
+                .finally(() => DockMotionSignal.leave(me))
         }
     }
 
     /**
-     * Creates the top-level control bar + dock projection items from current state: the preset
-     * switcher on the left (one button per stored perspective, the active one pressed — plus
-     * the fail-closed error chip when a switch was refused), the fleet controls on the right.
+     * @summary Synchronizes the persistent control bar from the perspective store and refusal state.
+     */
+    syncControlBar() {
+        let me             = this,
+            activeLayoutId = me.perspectiveStore?.collection?.activeLayoutId,
+            error          = me.getReference('fleet-preset-error');
+
+        me.items[0]?.items.forEach(item => {
+            const layoutId = item.reference?.startsWith('fleet-preset-')
+                ? item.reference.slice('fleet-preset-'.length)
+                : null;
+
+            layoutId && item.set({pressed: layoutId === activeLayoutId})
+        });
+
+        if (error) {
+            error.set({
+                hidden: !me.presetError,
+                html  : me.presetError || ''
+            })
+        }
+    }
+
+    /**
+     * Creates the persistent top-level control bar plus the initial dock projection. The preset
+     * switcher derives from the stored collection; subsequent refreshes update it in place while
+     * the shared reconciler owns only the projection shell at index 1.
      * @returns {Object[]}
      */
     buildWorkspaceItems() {
@@ -352,11 +422,12 @@ class FleetCockpit extends Container {
             dockConfig     = me.projectDockModel(),
             activeLayoutId = me.perspectiveStore?.collection?.activeLayoutId,
             presetButtons  = (me.perspectiveStore?.list() || []).map(preset => ({
-                module : Button,
-                cls    : ['fm-preset-button'],
-                handler: () => me.activatePerspective(preset.perspectiveName ?? preset.layoutId),
-                pressed: preset.layoutId === activeLayoutId,
-                text   : preset.perspectiveName ?? preset.layoutId
+                module   : Button,
+                cls      : ['fm-preset-button'],
+                handler  : () => me.activatePerspective(preset.perspectiveName ?? preset.layoutId),
+                pressed  : preset.layoutId === activeLayoutId,
+                reference: `fleet-preset-${preset.layoutId}`,
+                text     : preset.perspectiveName ?? preset.layoutId
             }));
 
         dockConfig.flex = 1;
@@ -367,11 +438,13 @@ class FleetCockpit extends Container {
             flex : 'none',
             items: [
                 ...presetButtons,
-                ...(me.presetError ? [{
-                    ntype: 'component',
-                    cls  : ['fm-preset-error'],
-                    html : me.presetError
-                }] : []),
+                {
+                    ntype    : 'component',
+                    cls      : ['fm-preset-error'],
+                    hidden   : !me.presetError,
+                    html     : me.presetError || '',
+                    reference: 'fleet-preset-error'
+                },
                 '->', {
                     // The morning-start outcome summary — written by the controller after the
                     // staged bring-up settles ("N started · M rejected · K excluded"; per-member
@@ -396,16 +469,20 @@ class FleetCockpit extends Container {
     /**
      * Projects the live committed {@link #dockModel} into a dock-zone container config, threading
      * the instance-bound commit-loop callbacks onto every projected affordance.
+     * @param {Function|null} [resolveComponentRef=null] Optional item resolver for staged projections.
+     * @param {Object} [document=this.dockModel] Committed document snapshot to project.
      * @returns {Object}
      */
-    projectDockModel() {
+    projectDockModel(resolveComponentRef=null, document=this.dockModel) {
         let me = this;
 
-        return DockLayoutAdapter.project(me.dockModel, {
+        return DockLayoutAdapter.project(document, {
             applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
             onDockCrossZoneDrop     : me.onDockCrossZoneDrop.bind(me),
             onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
-            resolveComponentRef     : me.resolveDockComponentRef.bind(me)
+            resolveComponentRef     : resolveComponentRef
+                || me.resolveDockComponentRef.bind(me),
+            resolveRevealComponentRef   : me.resolveDockComponentRef.bind(me)
         })
     }
 
@@ -413,11 +490,11 @@ class FleetCockpit extends Container {
      * @summary Resolves a dock item's `componentRef` to its pane config — the cockpit's keeper
      * surfaces for the live refs, honest placeholders for panes whose views are sibling leaves.
      *
-     * Every pane re-materializes from the OWNER's held runtime state (`adapterState`, events):
-     * re-projections rebuild instances, so anything set only on an instance would silently reset.
-     * The flip marker class carries the stable item identity across those rebuilds (the DockFlip
-     * correlation key). Panes stay layout-blind per the docking design's pane contract: nothing
-     * dock-specific is threaded here beyond the marker class.
+     * A genuinely absent pane materializes from the OWNER's held runtime state (`adapterState`,
+     * events); ordinary reconciliations discover the existing pane before consulting this resolver.
+     * The flip marker class carries the stable item identity across both retained and new panes.
+     * Panes stay layout-blind per the docking design's pane contract: nothing dock-specific is
+     * threaded here beyond the marker class.
      * @param {String} componentRef
      * @param {Object} item The persisted item record.
      * @param {String} itemId The stable workspace identity from the item catalog.
@@ -445,9 +522,9 @@ class FleetCockpit extends Container {
                     reference   : 'activity-stream'
                 };
             case 'agent-detail':
-                // the drill-in inspector; its selected resident is OWNER-held (re-projections
-                // rebuild instances) so a committed layout change never drops the selection — null
-                // renders the view's honest "select an agent" empty state
+                // the drill-in inspector; its selected resident is OWNER-held so a pane returning
+                // from true absence never drops the selection — null renders the view's honest
+                // "select an agent" empty state
                 return {
                     module   : AgentDetail,
                     cls      : [marker],
@@ -609,7 +686,7 @@ class FleetCockpit extends Container {
      * - not-wired / absent bridge / a thrown source → leave the representative **sample** in place
      *   (honestly labelled by the stream header); fail closed rather than blanking the surface.
      * The routed state also lands on the OWNER ({@link #streamAdapterState} / {@link #streamEvents})
-     * so re-projections re-materialize the pane at current truth.
+     * so a pane returning from true absence materializes at current truth.
      * @protected
      */
     async loadActivity() {
@@ -648,7 +725,7 @@ class FleetCockpit extends Container {
      *   state, never seven sample maintainers masquerading as live); every later one **reconciles**
      *   the Store — `record.set(row)` per known `agentId`, `store.add` for a joiner, `store.remove`
      *   for a resident absent from the snapshot (a `removeAgent` must never leave a ghost card).
-     *   Grid goes `live` (instance + the owner-held state re-projections read).
+     *   Grid goes `live` (instance + the owner-held fallback state).
      * - absent bridge / no verb / a MALFORMED answer (`rows` not an Array) / a thrown source →
      *   keep the last-known roster; fail closed rather than blanking the fleet. A resolved call is
      *   mechanically distinguishable from a failed one — only failures preserve last-known state.

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -525,7 +525,8 @@ class Workspace extends Container {
             applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
             onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
             resolveComponentRef     : resolveComponentRef
-                || ((componentRef, item, itemId) => me.resolvePane(itemId, item))
+                || ((componentRef, item, itemId) => me.resolvePane(itemId, item)),
+            resolveRevealComponentRef  : (componentRef, item, itemId) => me.resolvePane(itemId, item)
         })
     }
 

--- a/examples/dashboard/dock/MainContainer.mjs
+++ b/examples/dashboard/dock/MainContainer.mjs
@@ -1,11 +1,13 @@
-import DockLayoutAdapter    from '../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockMotionSignal     from '../../../src/dashboard/DockMotionSignal.mjs';
-import DockPreviewProducer  from '../../../src/dashboard/DockPreviewProducer.mjs';
-import DockService          from '../../../src/ai/client/DockService.mjs';
-import DockZoneModel        from '../../../src/dashboard/DockZoneModel.mjs';
-import TourRunner           from '../../../src/ai/client/TourRunner.mjs';
-import Viewport             from '../../../src/container/Viewport.mjs';
-import {previewToOperation} from '../../../src/dashboard/dockPreviewContract.mjs';
+import Component                from '../../../src/component/Base.mjs';
+import DockLayoutAdapter        from '../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockMotionSignal         from '../../../src/dashboard/DockMotionSignal.mjs';
+import DockPreviewProducer      from '../../../src/dashboard/DockPreviewProducer.mjs';
+import DockProjectionReconciler from '../../../src/dashboard/DockProjectionReconciler.mjs';
+import DockService              from '../../../src/ai/client/DockService.mjs';
+import DockZoneModel            from '../../../src/dashboard/DockZoneModel.mjs';
+import TourRunner               from '../../../src/ai/client/TourRunner.mjs';
+import Viewport                 from '../../../src/container/Viewport.mjs';
+import {previewToOperation}     from '../../../src/dashboard/dockPreviewContract.mjs';
 import '../../../src/button/Base.mjs';    // registers the `button` ntype used by the perspective toolbar
 import '../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits for tab zones
 import '../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype used by the perspective toolbar
@@ -76,8 +78,7 @@ const seededPerspectives = [{
  * @returns {Object}
  */
 const resolveComponentRef = (componentRef, _item, itemId) => ({
-    // the flip marker class carries the stable item identity across coarse re-projections,
-    // so the DockFlip addon can correlate pre/post-commit geometry even when instances recreate
+    // the flip marker class carries stable item identity across reconciled geometry changes
     cls  : [`dock-flip-item-${encodeURIComponent(itemId)}`],
     ntype: 'component',
     style: {alignItems: 'center', color: '#888', display: 'flex', fontSize: '20px', justifyContent: 'center'},
@@ -160,8 +161,8 @@ class MainContainer extends Viewport {
      * The in-flight deferred re-projection, tracked as an awaitable: every committed operation
      * defers its view-sync one tick ({@link #onDockZoneDocumentChange}), so any consumer that
      * must observe a SETTLED surface — the tour-replay adapter, teardown-sensitive probes —
-     * awaits this promise instead of racing that deferral. Stale-safe: each commit overwrites
-     * it, so awaiting always settles on the LATEST projection.
+     * awaits this promise instead of racing that deferral. Commits chain with their document and
+     * one-use descriptor snapshots, so staged transactions cannot overlap or cross-correlate.
      * @member {Promise|null} refreshPromise=null
      * @protected
      */
@@ -289,7 +290,7 @@ class MainContainer extends Viewport {
     }
 
     /**
-     * Creates the top-level toolbar + dock projection items from current state.
+     * Creates the persistent top-level toolbar plus the initial dock projection.
      * @param {Object|null} [tabInsertDescriptor=null] One-use normalized `addTab` correlation
      * captured by the committing refresh; omitted for boot, restore, and unrelated projections.
      * @returns {Object[]}
@@ -310,16 +311,9 @@ class MainContainer extends Viewport {
      * @returns {Object}
      */
     createPerspectiveToolbar() {
-        let me             = this,
-            collection     = me.layoutCollection,
-            activeLayoutId = collection?.activeLayoutId,
-            layoutButtons  = Object.values(collection?.layouts || {}).map(layout => ({
-                cls    : layout.layoutId === activeLayoutId ? ['neo-dashboard-dock-perspective-active'] : [],
-                data   : {layoutId: layout.layoutId},
-                handler: () => me.restorePerspective(layout.layoutId),
-                pressed: layout.layoutId === activeLayoutId,
-                text   : layout.title
-            }));
+        let me            = this,
+            collection    = me.layoutCollection,
+            layoutButtons = Object.values(collection?.layouts || {}).map(layout => me.createPerspectiveButton(layout));
 
         return {
             cls         : ['neo-dashboard-dock-perspective-toolbar'],
@@ -361,10 +355,83 @@ class MainContainer extends Viewport {
     }
 
     /**
-     * Returns the one-use projection correlation only when the committed descriptor actually
-     * inserts a header into its target tabs node. A same-node `addTab` reorder already had that
-     * header and therefore returns `null`; malformed, unrelated, restore, and initial paths fail
-     * closed to an instant projection.
+     * Creates one identity-keyed perspective button from the current saved-layout collection.
+     * @param {Object} layout Saved layout record.
+     * @returns {Object}
+     */
+    createPerspectiveButton(layout) {
+        let me       = this,
+            isActive = layout.layoutId === me.layoutCollection?.activeLayoutId;
+
+        return {
+            cls      : isActive ? ['neo-dashboard-dock-perspective-active'] : [],
+            handler  : () => me.restorePerspective(layout.layoutId),
+            pressed  : isActive,
+            reference: `dock-perspective-${layout.layoutId}`,
+            text     : layout.title
+        }
+    }
+
+    /**
+     * @summary Reconciles dynamic perspective buttons inside the persistent toolbar.
+     *
+     * The label and Save/Delete controls retain identity. Layout buttons key by `layoutId`, move
+     * silently into collection order, update active/title state in place, and are created or
+     * destroyed only when the saved-layout membership itself changes.
+     */
+    syncPerspectiveToolbar() {
+        let me        = this,
+            toolbar   = me.items[0],
+            layouts   = Object.values(me.layoutCollection?.layouts || {}),
+            layoutIds = new Set(layouts.map(layout => layout.layoutId)),
+            buttons;
+
+        if (toolbar?.dockNodeType !== 'perspective-toolbar') return;
+
+        buttons = new Map(toolbar.items
+            .filter(item => item.reference?.startsWith('dock-perspective-'))
+            .map(item => [item.reference.slice('dock-perspective-'.length), item]));
+
+        buttons.forEach((button, layoutId) => {
+            if (!layoutIds.has(layoutId)) {
+                toolbar.remove(button, true, true)
+            }
+        });
+
+        layouts.forEach((layout, index) => {
+            let targetIndex = index + 1,
+                button      = buttons.get(layout.layoutId),
+                currentIndex,
+                isActive;
+
+            if (!button || button.isDestroyed) {
+                button = toolbar.insert(targetIndex, me.createPerspectiveButton(layout), true)
+            } else {
+                currentIndex = toolbar.indexOf(button);
+
+                if (currentIndex !== targetIndex) {
+                    toolbar.remove(button, false, true, true);
+                    toolbar.insert(targetIndex, button, true, false)
+                }
+            }
+
+            isActive = layout.layoutId === me.layoutCollection.activeLayoutId;
+            button.set({
+                cls: isActive
+                    ? [...new Set([...button.cls, 'neo-dashboard-dock-perspective-active'])]
+                    : button.cls.filter(cls => cls !== 'neo-dashboard-dock-perspective-active'),
+                pressed: isActive,
+                text   : layout.title
+            })
+        })
+    }
+
+    /**
+     * Returns the one-use projection correlation only when the committed descriptor creates a
+     * globally absent header. `DockZoneModel` downgrades `addTab` to `moveItem` whenever the item
+     * already lives in any tabs node; those identity-preserving relocations use FLIP alone. A
+     * same-node reorder, malformed descriptor, restore, and initial path fail closed to an instant
+     * projection.
      *
      * The returned object is deliberately normalized instead of retaining caller/runtime fields,
      * and is carried only by the scheduled projection closure — it never enters `dockModel`, a
@@ -384,6 +451,7 @@ class MainContainer extends Viewport {
             && typeof tabsNodeId === 'string'
             && Array.isArray(oldItems)
             && Array.isArray(newItems)
+            && !DockZoneModel.findContainingTabsId(this.dockModel, itemId)
             && !oldItems.includes(itemId)
             && newItems.includes(itemId)
                 ? {itemId, operation: 'addTab', tabsNodeId}
@@ -394,9 +462,10 @@ class MainContainer extends Viewport {
      * The view-sync `DockSplitter` / DockService calls after a successful commit: stores the new
      * committed document and re-projects the layout from it.
      *
-     * Deferred one tick: this fires synchronously from inside the committing splitter's `onDragEnd` (via
-     * `commitResizeSplit`). Re-projecting immediately would `removeAll()` — destroying that splitter mid-handler, a
-     * use-after-destroy on the rest of `onDragEnd`. The `isDestroyed` guard covers teardown before the tick fires.
+     * Deferred one tick: this fires synchronously from inside the committing splitter's `onDragEnd`
+     * (via `commitResizeSplit`). Reconciliation still retires that splitter with its old shell, so
+     * doing it mid-handler would create a use-after-destroy on the rest of `onDragEnd`. The
+     * `isDestroyed` guard covers teardown before the tick fires.
      * A real `addTab` captures its exact normalized correlation in THIS scheduled closure; every
      * other call carries `null`, so the descriptor is consumed by one projection only.
      * @param {Object} document The committed dock-zone document.
@@ -410,12 +479,14 @@ class MainContainer extends Viewport {
 
         // Retained as an awaitable (NOT fire-and-forget): a consumer asserting page survival or
         // settled geometry must be able to await the projection this commit just scheduled —
-        // otherwise its verdict window closes before the remove/add projection has executed.
-        me.refreshPromise = me.timeout(0).then(() => {
-            if (!me.isDestroyed) {
-                return me.refreshDockWorkspace(tabInsertDescriptor)
-            }
-        })
+        // otherwise its verdict window closes before the staged transaction has executed.
+        me.refreshPromise = (me.refreshPromise || Promise.resolve())
+            .then(() => me.timeout(0))
+            .then(() => {
+                if (!me.isDestroyed) {
+                    return me.refreshDockWorkspace(tabInsertDescriptor, document)
+                }
+            })
     }
 
     /**
@@ -456,8 +527,8 @@ class MainContainer extends Viewport {
             }
 
             me.layoutCollection = DockZoneModel.clone(parsed);
-            me.dockModel        = restored.document;
-            me.refreshDockWorkspace();
+            me.onDockZoneDocumentChange(restored.document);
+            await me.refreshPromise;
 
             return {collection: me.layoutCollection, document: me.dockModel, errors: [], loaded: true}
         } catch (error) {
@@ -491,30 +562,67 @@ class MainContainer extends Viewport {
     }
 
     /**
-     * Rebuilds the toolbar and dock projection from current state.
+     * Reconciles the dock projection while synchronizing the persistent perspective toolbar.
      * @param {Object|null} [tabInsertDescriptor=null] One-use normalized `addTab` correlation
      * captured by the commit that scheduled this refresh.
+     * @param {Object} [document=this.dockModel] Committed document snapshot owned by this refresh.
      */
-    async refreshDockWorkspace(tabInsertDescriptor=null) {
-        const flip = Neo.main?.addon?.DockFlip;
+    async refreshDockWorkspace(tabInsertDescriptor=null, document=this.dockModel) {
+        const
+            me           = this,
+            flip         = Neo.main?.addon?.DockFlip,
+            placeholders = new Map();
 
         // FLIP phase 1 (presentation-only, fail-safe): snapshot outgoing pane geometry so the
         // committed re-layout GLIDES — a human drop and an NL operation animate identically
         try {
-            await flip?.captureFirst({hostId: this.id, markerPrefix: 'dock-flip-item-'})
+            await flip?.captureFirst({hostId: me.id, markerPrefix: 'dock-flip-item-'})
         } catch (e) {/* instant landing */}
 
-        this.removeAll();
-        this.add(this.buildWorkspaceItems(tabInsertDescriptor));
+        me.syncPerspectiveToolbar();
+
+        const nextConfig = me.projectDockModel(tabInsertDescriptor, (componentRef, item, itemId) => {
+            const placeholder = Neo.create({
+                module: Component,
+                header: {text: item?.title ?? componentRef ?? itemId},
+                hidden: true
+            });
+
+            placeholders.set(itemId, placeholder);
+
+            return placeholder
+        }, document);
+
+        nextConfig.flex = 1;
+
+        await DockProjectionReconciler.reconcileProjection({
+            host       : me,
+            nextConfig,
+            placeholders,
+            resolveItem: itemId => {
+                const item = document.items[itemId];
+
+                return DockLayoutAdapter.decorateProjectedItem(
+                    resolveComponentRef(item?.componentRef, item, itemId),
+                    itemId,
+                    item,
+                    {
+                        nodeId: tabInsertDescriptor?.tabsNodeId,
+                        tabInsertDescriptor
+                    }
+                )
+            },
+            shellIndex: 1
+        });
 
         // FLIP phase 2: fire-and-forget — the addon self-waits for the swap, inverts, plays
         // the counted motion signal brackets the awaited animation window — ownership
         // lives in DockMotionSignal (fail-safe backstopped), never in the addon
         if (flip) {
-            DockMotionSignal.enter(this);
-            flip.play({hostId: this.id, markerPrefix: 'dock-flip-item-'})
+            DockMotionSignal.enter(me);
+            flip.play({hostId: me.id, markerPrefix: 'dock-flip-item-'})
                 .catch(() => {})
-                .finally(() => DockMotionSignal.leave(this))
+                .finally(() => DockMotionSignal.leave(me))
         }
     }
 
@@ -539,9 +647,8 @@ class MainContainer extends Viewport {
         }
 
         me.layoutCollection = selected.collection;
-        me.dockModel        = restored.document;
         me.persistLayoutCollection();
-        me.refreshDockWorkspace();
+        me.onDockZoneDocumentChange(restored.document);
 
         return {collection: me.layoutCollection, document: me.dockModel, errors: []}
     }
@@ -576,7 +683,7 @@ class MainContainer extends Viewport {
 
         me.layoutCollection = upserted.collection;
         me.persistLayoutCollection();
-        me.refreshDockWorkspace();
+        me.onDockZoneDocumentChange(me.dockModel);
 
         return {collection: me.layoutCollection, layout: saved.layout, errors: []}
     }
@@ -613,9 +720,8 @@ class MainContainer extends Viewport {
         }
 
         me.layoutCollection = removed.collection;
-        me.dockModel        = restored.document;
         me.persistLayoutCollection();
-        me.refreshDockWorkspace();
+        me.onDockZoneDocumentChange(restored.document);
 
         return {collection: me.layoutCollection, document: me.dockModel, errors: []}
     }
@@ -640,16 +746,19 @@ class MainContainer extends Viewport {
      * Projects the live committed {@link #dockModel} into a dock-zone container config, threading
      * the instance-bound commit-loop callbacks onto every projected affordance.
      * @param {Object|null} [tabInsertDescriptor=null] One-use normalized `addTab` correlation.
+     * @param {Function} [itemResolver=resolveComponentRef] Pane resolver used by this projection.
+     * @param {Object} [document=this.dockModel] Committed document snapshot to project.
      * @returns {Object}
      */
-    projectDockModel(tabInsertDescriptor=null) {
+    projectDockModel(tabInsertDescriptor=null, itemResolver=resolveComponentRef, document=this.dockModel) {
         let me = this;
 
-        return DockLayoutAdapter.project(me.dockModel, {
-            applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
-            onDockCrossZoneDrop     : me.onDockCrossZoneDrop.bind(me),
-            onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
-            resolveComponentRef,
+        return DockLayoutAdapter.project(document, {
+            applyDockZoneOperation   : me.applyDockZoneOperation.bind(me),
+            onDockCrossZoneDrop      : me.onDockCrossZoneDrop.bind(me),
+            onDockZoneDocumentChange : me.onDockZoneDocumentChange.bind(me),
+            resolveComponentRef      : itemResolver,
+            resolveRevealComponentRef: resolveComponentRef,
             tabInsertDescriptor
         })
     }

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -99,12 +99,52 @@ class DockLayoutAdapter extends Base {
         let config = {...component},
             data   = {...(config.data || {})};
 
-        data.componentRef = item.componentRef || null;
+        data.componentRef = item?.componentRef || null;
         data.dockItemId   = itemId;
 
         config.data       = data;
         config.dockItemId = itemId;
-        config.header     = config.header || {text: item.title || itemId};
+        config.header     = config.header || {text: item?.title || itemId};
+
+        return config
+    }
+
+    /**
+     * @summary Applies adapter-owned item metadata and one-use add-tab decoration to a pane config.
+     *
+     * Reconciliation discovers live panes before consulting its app resolver. When a pane is genuinely
+     * absent, this pure helper lets that resolver prepare the same config the normal projection path
+     * would have emitted without copying dashboard-owned header policy into the consuming workspace.
+     * Neo instances intentionally pass through unchanged; transient header decoration remains a
+     * plain-config capability and therefore fails closed to an instant landing for custom instances.
+     * @param {*} component Resolved pane config or live component instance.
+     * @param {String} itemId Stable item identity.
+     * @param {Object} item Persisted item record.
+     * @param {Object} [options={}]
+     * @param {String|null} [options.nodeId=null] Owning projected tabs-node id.
+     * @param {Object|null} [options.tabInsertDescriptor=null] One-use normalized `addTab` correlation.
+     * @returns {*}
+     * @static
+     */
+    static decorateProjectedItem(component, itemId, item, {nodeId=null, tabInsertDescriptor=null}={}) {
+        let config = this.decorateItemConfig(component, itemId, item),
+            header;
+
+        if (config?.constructor === Object
+            && tabInsertDescriptor?.operation === 'addTab'
+            && tabInsertDescriptor.itemId === itemId
+            && tabInsertDescriptor.tabsNodeId === nodeId) {
+            header = config.header || {text: item?.title || itemId};
+            config.header = {
+                ...header,
+                cls: [...new Set([
+                    ...(Array.isArray(header.cls) ? header.cls : header.cls ? [header.cls] : []),
+                    'neo-dashboard-dock-tab-enter',
+                    `dock-tab-enter-item-${encodeURIComponent(itemId)}`
+                ])],
+                module: DockTabEnterButton
+            }
+        }
 
         return config
     }
@@ -210,6 +250,7 @@ class DockLayoutAdapter extends Base {
      * @param {Object} model
      * @param {Object} [options={}]
      * @param {Function} [options.resolveComponentRef]
+     * @param {Function} [options.resolveRevealComponentRef] Durable resolver retained by edge rails.
      * @param {Object|null} [options.tabInsertDescriptor] Runtime-only normalized `addTab`
      * correlation consumed by this projection; never part of `model`.
      * @returns {Object}
@@ -233,17 +274,20 @@ class DockLayoutAdapter extends Base {
             // supplies a sortGroup makes every projected tab sort zone a coordinator-registered
             // drag SOURCE (the workspace id rides the drag payload for the receiving window's
             // `transferItem` resolution). Absent = fully in-window, the unchanged default.
-            crossWindowSortGroup    : options.crossWindowSortGroup ?? null,
-            defaultRevealFraction   : Number.isFinite(options.defaultRevealFraction) ? options.defaultRevealFraction : null,
-            dockZoneDocument        : options.dockZoneDocument || model,
-            items                   : model.items || {},
-            nodes                   : model.nodes,
-            onDockCrossZoneDragMove : options.onDockCrossZoneDragMove,
-            onDockCrossZoneDrop     : options.onDockCrossZoneDrop,
-            onDockZoneDocumentChange: options.onDockZoneDocumentChange,
-            resolveComponentRef     : options.resolveComponentRef || (() => null),
-            tabInsertDescriptor     : options.tabInsertDescriptor ?? null,
-            workspaceId             : options.workspaceId ?? null
+            crossWindowSortGroup     : options.crossWindowSortGroup ?? null,
+            defaultRevealFraction    : Number.isFinite(options.defaultRevealFraction) ? options.defaultRevealFraction : null,
+            dockZoneDocument         : options.dockZoneDocument || model,
+            items                    : model.items || {},
+            nodes                    : model.nodes,
+            onDockCrossZoneDragMove  : options.onDockCrossZoneDragMove,
+            onDockCrossZoneDrop      : options.onDockCrossZoneDrop,
+            onDockZoneDocumentChange : options.onDockZoneDocumentChange,
+            resolveComponentRef      : options.resolveComponentRef || (() => null),
+            resolveRevealComponentRef: options.resolveRevealComponentRef
+                || options.resolveComponentRef
+                || (() => null),
+            tabInsertDescriptor: options.tabInsertDescriptor ?? null,
+            workspaceId        : options.workspaceId ?? null
         });
 
         config.cls = [...new Set([...(config.cls || []), 'neo-dashboard'])];
@@ -346,7 +390,7 @@ class DockLayoutAdapter extends Base {
             ntype                   : 'dashboard-dock-rail',
             onDockZoneDocumentChange: context.onDockZoneDocumentChange,
             railItems               : itemIds.map(itemId => this.createRailTab(itemId, edge, context)),
-            resolveComponentRef     : context.resolveComponentRef
+            resolveComponentRef     : context.resolveRevealComponentRef
         }
     }
 
@@ -633,32 +677,15 @@ class DockLayoutAdapter extends Base {
             activeIndex = items.length ? 0 : null
         }
 
-        projectedItems = items.map(itemId => {
-            let config     = this.projectItem(itemId, context),
-                descriptor = context.tabInsertDescriptor,
-                header;
-
-            // One-use operation correlation: only a real addTab's exact target header receives
-            // the dashboard-owned producer. Non-object component results fail safe to an instant
-            // landing; no broad selector or document mutation is used as a fallback.
-            if (config?.constructor === Object
-                && descriptor?.operation === 'addTab'
-                && descriptor.itemId === itemId
-                && descriptor.tabsNodeId === nodeId) {
-                header = config.header || {text: context.items[itemId]?.title || itemId};
-                config.header = {
-                    ...header,
-                    cls: [...new Set([
-                        ...(Array.isArray(header.cls) ? header.cls : header.cls ? [header.cls] : []),
-                        'neo-dashboard-dock-tab-enter',
-                        `dock-tab-enter-item-${encodeURIComponent(itemId)}`
-                    ])],
-                    module: DockTabEnterButton
-                }
-            }
-
-            return config
-        });
+        // One-use operation correlation: only a real addTab's exact target header receives
+        // the dashboard-owned producer. Non-object component results fail safe to an instant
+        // landing; no broad selector or document mutation is used as a fallback.
+        projectedItems = items.map(itemId => this.decorateProjectedItem(
+            this.projectItem(itemId, context),
+            itemId,
+            context.items[itemId],
+            {nodeId, tabInsertDescriptor: context.tabInsertDescriptor}
+        ));
 
         return {
             activeIndex,

--- a/src/dashboard/DockProjectionReconciler.mjs
+++ b/src/dashboard/DockProjectionReconciler.mjs
@@ -122,7 +122,7 @@ class DockProjectionReconciler extends Base {
      * @param {Neo.container.Base} options.host Dock host containing the current shell.
      * @param {*} options.nextConfig Fresh {@link Neo.dashboard.DockLayoutAdapter} projection.
      * @param {Map<String,Neo.component.Base>} options.placeholders Item placeholders created by the caller.
-     * @param {Function} options.resolveItem Resolves one live pane by dock item id.
+     * @param {Function} options.resolveItem Resolves one live pane or materializable config by dock item id.
      * @param {Function|null} [options.onProjectionStaged=null]
      * @param {Number} [options.shellIndex=0]
      * @param {Function|null} [options.waitForOverflowProjection=null]
@@ -292,16 +292,17 @@ class DockProjectionReconciler extends Base {
      * @param {Map<String,Neo.component.Base>} placeholders
      * @param {Map<String,Neo.tab.Container>} currentTabs
      * @param {Neo.container.Base} nextShell
-     * @param {Function} resolveItem Resolves one live pane by dock item id.
+     * @param {Function} resolveItem Resolves one live pane or materializable config by dock item id.
      * @returns {Map<String,Object>}
      * @static
      */
     static reconcileTabChrome(plans, placeholders, currentTabs, nextShell, resolveItem) {
         const
-            nextTabs      = this.collectProjectedTabs(nextShell),
-            allTabs       = new Set([...currentTabs.values(), ...nextTabs.values()]),
-            liveItems     = new Map(),
-            resolvedItems = new Map();
+            nextTabs       = this.collectProjectedTabs(nextShell),
+            allTabs        = new Set([...currentTabs.values(), ...nextTabs.values()]),
+            desiredItemIds = new Set([...plans.values()].flatMap(plan => plan.desiredItems)),
+            liveItems      = new Map(),
+            resolvedItems  = new Map();
 
         if (typeof resolveItem !== 'function') {
             throw new Error('Dock projection reconciliation requires a live item resolver')
@@ -386,7 +387,7 @@ class DockProjectionReconciler extends Base {
                 const state = findItemState(pane);
 
                 if (!state) {
-                    targetTab.insert(targetIndex, pane, true);
+                    resolvedItems.set(itemId, targetTab.insert(targetIndex, pane, true));
                     return
                 }
 
@@ -396,6 +397,35 @@ class DockProjectionReconciler extends Base {
                 state.bar.removeAt(state.index, false, true, true);
                 targetBody.insert(targetIndex, pane, true, false);
                 targetBar.insert(targetIndex, state.button, true, false)
+            })
+        });
+
+        // Items absent from every projected tabs node are true retirements, not moves. Resolve
+        // their post-transfer positions from pane identity (the source sort arrays are intentionally
+        // not rewritten until the final exact-state pass), then remove each body/button pair in
+        // descending index order so sibling positions stay valid. Items desired anywhere in the
+        // next projection are excluded: their existing pane/button pair already moved above.
+        const retirementsByBody = new Map();
+
+        [...liveItems]
+            .filter(([itemId]) => !desiredItemIds.has(itemId))
+            .map(([itemId, pane]) => ({itemId, pane, state: findItemState(pane)}))
+            .filter(retirement => retirement.state)
+            .forEach(retirement => {
+                const bodyRetirements = retirementsByBody.get(retirement.state.body) || [];
+
+                bodyRetirements.push(retirement);
+                retirementsByBody.set(retirement.state.body, bodyRetirements)
+            });
+
+        retirementsByBody.forEach(retirements => {
+            retirements.sort((a, b) => b.state.index - a.state.index).forEach(({itemId, state}) => {
+                if (!state.button) {
+                    throw new Error(`Dock projection could not retire item "${itemId}" without its tab button`)
+                }
+
+                state.body.removeAt(state.index, true, true);
+                state.bar.removeAt(state.index, true, true)
             })
         });
 

--- a/src/dashboard/DockRail.mjs
+++ b/src/dashboard/DockRail.mjs
@@ -634,9 +634,10 @@ class DockRail extends Container {
     }
 
     /**
-     * Materializes the revealed item's pane into the overlay's slot — resolved through the SAME
-     * `resolveComponentRef` seam the adapter uses for in-flow panes, with the `componentRef` read
-     * from the committed document (the rail's copy re-projects on every change).
+     * Materializes the revealed item's pane into the overlay's slot through the adapter's durable
+     * reveal resolver, with the `componentRef` read from the committed document (the rail's copy
+     * re-projects on every change). This resolver must outlive any transaction-only in-flow staging
+     * resolver because the user can reveal the rail long after projection reconciliation settles.
      *
      * Live-instance contract: a resolver-returned Neo INSTANCE is added as-is and PARKED on
      * dismissal (removed without destroy — moved/re-parented, never destroyed), so its identity

--- a/src/dashboard/DockTabEnterButton.mjs
+++ b/src/dashboard/DockTabEnterButton.mjs
@@ -9,15 +9,15 @@ import TabHeaderButton  from '../tab/header/Button.mjs';
  * This component is intentionally dashboard-owned: the generic {@link Neo.tab.header.Button}
  * stays unaware of dock documents and operations. {@link Neo.dashboard.DockLayoutAdapter} selects
  * this subclass only for the header whose `itemId` + `tabsNodeId` match the transient descriptor
- * carried by the consuming projection. The correlation never enters the dock document and the
- * class does not survive a later coarse projection.
+ * carried by the consuming projection. The correlation never enters the dock document; this
+ * permanent header consumes its one-use classes when the rendered animation settles or collapses.
  *
  * The CSS duration/easing remain token-owned. Once mounted, the App Worker asks the main-thread DOM
  * authority for this header's rendered animation name + duration and opens the signal only for the
- * exact non-zero tab-entry animation. This avoids racing the framework's delayed local-listener
- * mount against `animationstart`, while a token-collapsed 0ms animation creates no false signal.
- * End, cancellation, replacement, and destroy settle idempotently, with `DockMotionSignal`'s
- * fail-safe remaining the final lost-event backstop.
+ * exact non-zero tab-entry animation. The same authority awaits the physical `CSSAnimation` so a
+ * newly born header cannot finish before its local `animationend` listener mounts. A token-collapsed
+ * 0ms animation creates no false signal. End, cancellation, replacement, and destroy settle
+ * idempotently, with `DockMotionSignal`'s fail-safe remaining the final lost-event backstop.
  *
  * @class Neo.dashboard.DockTabEnterButton
  * @extends Neo.tab.header.Button
@@ -95,7 +95,37 @@ class DockTabEnterButton extends TabHeaderButton {
         super.afterSetMounted(value, oldValue);
 
         if (oldValue !== undefined) {
-            value ? this.syncRenderedTabEnterMotion() : this.finishTabEnterMotion()
+            if (value) {
+                this.syncRenderedTabEnterMotion()
+            } else {
+                this.finishTabEnterMotion();
+                this.consumeTabEnterDecoration()
+            }
+        }
+    }
+
+    /**
+     * Whether this permanent header still carries the transient add-tab correlation.
+     * @returns {Boolean}
+     * @protected
+     */
+    hasTabEnterDecoration() {
+        return this.cls?.includes('neo-dashboard-dock-tab-enter') === true
+    }
+
+    /**
+     * Removes the one-use animation class and its item-correlation marker without disturbing
+     * stable header classes. Identity reconciliation keeps this instance alive across later
+     * projections, so the producer itself owns consumption instead of relying on teardown.
+     * @protected
+     */
+    consumeTabEnterDecoration() {
+        let cls     = Array.isArray(this.cls) ? this.cls : this.cls ? [this.cls] : [],
+            nextCls = cls.filter(value => value !== 'neo-dashboard-dock-tab-enter'
+                && !value.startsWith('dock-tab-enter-item-'));
+
+        if (nextCls.length !== cls.length) {
+            this.cls = nextCls
         }
     }
 
@@ -138,12 +168,31 @@ class DockTabEnterButton extends TabHeaderButton {
                 style: ['animation-name', 'animation-duration']
             })
         } catch {
+            if (me.mounted && !me.isDestroyed && !me.isDestroying) {
+                me.consumeTabEnterDecoration()
+            }
+
             return
         }
 
-        if (me.mounted && !me.isDestroyed && !me.isDestroying
-            && DockTabEnterButton.hasRenderedTabEnterMotion(styles)) {
-            me.beginTabEnterMotion()
+        if (me.mounted && !me.isDestroyed && !me.isDestroying && me.hasTabEnterDecoration()) {
+            if (DockTabEnterButton.hasRenderedTabEnterMotion(styles)) {
+                me.beginTabEnterMotion();
+
+                try {
+                    await Neo.main.DomAccess.waitForAnimation({
+                        animationName: 'neo-dock-tab-enter',
+                        id           : me.id
+                    })
+                } catch (error) {/* instant settlement */}
+
+                if (me.mounted && !me.isDestroyed && !me.isDestroying && me.hasTabEnterDecoration()) {
+                    me.finishTabEnterMotion();
+                    me.consumeTabEnterDecoration()
+                }
+            } else {
+                me.consumeTabEnterDecoration()
+            }
         }
     }
 
@@ -165,7 +214,8 @@ class DockTabEnterButton extends TabHeaderButton {
      */
     onTabEnterAnimationSettle(data) {
         if (data?.target?.id === (this.vdom?.id || this.id)) {
-            this.finishTabEnterMotion()
+            this.finishTabEnterMotion();
+            this.consumeTabEnterDecoration()
         }
     }
 }

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -87,6 +87,7 @@ class DomAccess extends Base {
                 'syncModalMask',
                 'transferCanvasToWorker',
                 'trapFocus',
+                'waitForAnimation',
                 'windowScrollTo'
             ]
         },
@@ -462,6 +463,33 @@ class DomAccess extends Base {
         }
 
         return styles
+    }
+
+    /**
+     * @summary Awaits one named CSS animation on a physical node through the browser's Animation API.
+     *
+     * App-worker components can be born with an animation class before their local DOM listeners
+     * finish mounting. The main thread already owns the physical animation, so `Animation.finished`
+     * is the race-free settlement authority. A missing, already-finished, or cancelled animation
+     * resolves safely; presentation must never wedge projection truth.
+     * @param {Object} data
+     * @param {String} data.animationName CSS animation name to match on the node itself.
+     * @param {String} data.id Physical DOM node id.
+     * @returns {Promise<Boolean>} Whether a live named animation was observed.
+     */
+    async waitForAnimation({animationName, id}) {
+        let animation = this.getElement(id)?.getAnimations?.()
+            .find(candidate => candidate.animationName === animationName);
+
+        if (!animation) {
+            return false
+        }
+
+        try {
+            await animation.finished
+        } catch (error) {/* cancellation is settlement */}
+
+        return true
     }
 
     /**

--- a/test/playwright/e2e/agentos/FleetCockpitDockNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitDockNL.spec.mjs
@@ -7,16 +7,14 @@ import {test, expect} from '../../fixtures.mjs';
  * 1. the initial projection RENDERS (both live panes + the primary splitter in the DOM);
  * 2. the READ half (`getDockZoneDocument`) serves Neural Link topology before any operation;
  * 3. a REAL pointer drag on the projected splitter commits `resizeSplit` through the reducer /
- *    view-sync split — the document advances AND the worker re-projects (a NEW splitter
- *    instance replaces the committed-away one);
+ *    view-sync split — the document advances, a NEW splitter replaces the committed-away one,
+ *    and the toolbar plus keeper panes preserve component and DOM identity;
  * 4. the WRITE half (`executeDockOperation`) round-trips the same loop programmatically — a
  *    human drag and an NL operation are the same commit path.
  *
- * Post-commit witnesses are WORKER-SIDE on purpose (instance identity via the Neural Link, not
- * DOM geometry): the App Worker's rebuilt component tree is the truth layer for "the loop
- * re-projected". The DOM-flush layer currently rides an open wholesale-refresh reconciliation
- * defect (stale child DOM surviving a removeAll+rebuild commit), owned by its own ticket with
- * this surface listed as a casualty — its regression witness belongs to that fix, not here.
+ * Post-commit witnesses deliberately pair App Worker identity through the Neural Link with exact
+ * DOM-node identity. Structural splitters are replaced only after their gesture ends; persistent
+ * toolbar and pane nodes transfer into the reconciled shell.
  *
  * State-relative throughout (the SharedWorker heap is shared across a sweep): every target
  * derives from the CURRENT committed sizes, never from assumed seeds.
@@ -27,8 +25,33 @@ test.describe('AgentOS Fleet cockpit — dock projection commit loop (Neural Lin
     test.setTimeout(90000);
 
     test('the mounted cockpit projects the committed document; splitter drag + NL operation both commit through the reducer', async ({page, neuralLink}) => {
+        const pageErrors    = [],
+              runtimeErrors = [];
+
+        await page.context().exposeFunction('__recordFleetProjectionRuntimeError', payload => runtimeErrors.push(payload));
+        await page.context().addInitScript(() => {
+            globalThis.addEventListener('error', event => {
+                globalThis.__recordFleetProjectionRuntimeError({
+                    column : event.colno,
+                    line   : event.lineno,
+                    message: event.message,
+                    source : event.filename,
+                    type   : 'error'
+                })
+            });
+            globalThis.addEventListener('unhandledrejection', event => {
+                globalThis.__recordFleetProjectionRuntimeError({
+                    reason: String(event.reason?.stack || event.reason?.message || event.reason),
+                    type  : 'unhandledrejection'
+                })
+            })
+        });
+        page.on('pageerror', error => {
+            const value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
         await page.goto('/apps/agentos/index.html');
-        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
         await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
 
         // 1) the initial projection renders: Fleet is the default keeper-view (mission control
@@ -52,13 +75,35 @@ test.describe('AgentOS Fleet cockpit — dock projection commit loop (Neural Lin
         expect(doc0.nodes['primary-split'].children).toEqual(['fleet-tabs', 'stream-tabs']);
         expect(doc0.nodes['cockpit-root'].zones.center).toBe('primary-split');
 
-        // the worker-side splitter instance identity — the re-projection witness baseline
-        const splitterIds = async () => {
-            const found = await app.findInstances({ntype: 'dashboard-dock-splitter'}, ['id']);
-            return (Array.isArray(found) ? found : [found]).map(instance => instance?.id).filter(Boolean)
+        const fleetGrids = await app.findInstances({className: 'AgentOS.view.fleet.FleetGrid'}, ['id']),
+              streams    = await app.findInstances({className: 'AgentOS.view.fleet.ActivityStream'}, ['id']),
+              identity   = {
+                  fleetGrid: (Array.isArray(fleetGrids) ? fleetGrids[0] : fleetGrids)?.id,
+                  stream   : (Array.isArray(streams) ? streams[0] : streams)?.id,
+                  toolbar  : await page.locator('.fm-cockpit-bar').getAttribute('id')
+              },
+              splitterId0 = await splitter.getAttribute('id');
+
+        expect(Object.values(identity).every(Boolean), 'toolbar and keeper pane component ids are mounted').toBe(true);
+        expect(splitterId0, 'the projection holds one live splitter instance').toBeTruthy();
+        expect(await page.evaluate(({identity, splitterId}) => {
+            globalThis.__fleetProjectionIdentity = {
+                ...Object.fromEntries(Object.entries(identity).map(([key, id]) => [key, document.getElementById(id)])),
+                splitter: document.getElementById(splitterId)
+            };
+
+            return Object.values(globalThis.__fleetProjectionIdentity).every(Boolean)
+        }, {identity, splitterId: splitterId0}), 'all permanence targets start as exact mounted DOM nodes').toBe(true);
+
+        const assertPersistentIdentity = async message => {
+            expect(await page.evaluate(ids => Object.fromEntries(Object.entries(ids).map(([key, id]) => [
+                key,
+                globalThis.__fleetProjectionIdentity?.[key] === document.getElementById(id)
+            ])), identity), message).toEqual({fleetGrid: true, stream: true, toolbar: true});
+
+            const live = await Promise.all(Object.values(identity).map(id => app.getComponent(id, ['id'])));
+            expect(live.map(component => component.id), `${message} in the App Worker`).toEqual(Object.values(identity))
         };
-        const ids0 = await splitterIds();
-        expect(ids0.length, 'the projection must hold one live splitter instance').toBeGreaterThan(0);
 
         // 3) the REAL gesture: drag the primary splitter downward (vertical split → ns-resize),
         // at real pointer cadence — clear the drag threshold first, then travel, then let the
@@ -69,6 +114,16 @@ test.describe('AgentOS Fleet cockpit — dock projection commit loop (Neural Lin
         await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 12, {steps: 4});
         await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 120, {steps: 15});
         await page.waitForTimeout(400);
+
+        expect(await page.evaluate(id => globalThis.__fleetProjectionIdentity?.splitter === document.getElementById(id), splitterId0),
+            'the committing splitter remains the exact live DOM node until pointer release').toBe(true);
+        expect((await app.getComponent(splitterId0, ['id'])).id,
+            'the committing splitter remains live in the App Worker until pointer release').toBe(splitterId0);
+        const topoDuringDrag = await app.getDockTopology(holderId),
+              docDuringDrag  = topoDuringDrag?.document ?? topoDuringDrag;
+        expect(docDuringDrag.nodes['primary-split'].sizes,
+            'the reducer document stays unchanged before pointer release').toEqual(sizes0);
+
         await page.mouse.up();
 
         // the commit loop advanced the DOCUMENT (state-relative: any change from the captured
@@ -79,19 +134,24 @@ test.describe('AgentOS Fleet cockpit — dock projection commit loop (Neural Lin
             return doc.nodes['primary-split'].sizes[0]
         }, {message: 'the splitter drag must COMMIT resizeSplit through the reducer', timeout: 10000, intervals: [100]}).not.toBe(sizes0[0]);
 
-        // ...and the worker RE-PROJECTED from the committed document: the splitter is a NEW
-        // instance (removeAll + rebuild — instances do not survive commits, by design)
         await expect.poll(async () => {
-            const ids = await splitterIds();
-            return ids.length > 0 && ids.every(id => !ids0.includes(id))
-        }, {message: 'the deferred re-projection must rebuild the splitter instance', timeout: 10000, intervals: [100]}).toBe(true);
+            const ids = await page.locator('.fm-fleet-cockpit .neo-dashboard-dock-splitter').evaluateAll(elements =>
+                elements.map(element => element.id)
+            );
+            return ids.length === 1 && ids[0] !== splitterId0
+        }, {message: 'the deferred projection must replace the committed splitter instance', timeout: 10000, intervals: [100]}).toBe(true);
+
+        const splitterId1 = await page.locator('.fm-fleet-cockpit .neo-dashboard-dock-splitter').first().getAttribute('id');
+
+        expect(await page.evaluate(id => document.getElementById(id) === null, splitterId0),
+            'the committed-away splitter DOM node is retired').toBe(true);
+        await assertPersistentIdentity('the toolbar and keeper panes survive the real splitter commit');
 
         // 4) the WRITE half: an NL-driven operation commits through the SAME loop
         const topo1  = await app.getDockTopology(holderId),
               doc1   = topo1?.document ?? topo1,
               cur    = doc1.nodes['primary-split'].sizes,
-              target = cur[0] < 0.5 ? [0.65, 0.35] : [0.3, 0.7],
-              ids1   = await splitterIds();
+              target = cur[0] < 0.5 ? [0.65, 0.35] : [0.3, 0.7];
 
         const result = await app.executeDockOperation(holderId, {
             operation: 'resizeSplit', splitNodeId: 'primary-split', sizes: target
@@ -107,14 +167,45 @@ test.describe('AgentOS Fleet cockpit — dock projection commit loop (Neural Lin
         }, {message: 'the NL operation must land in the committed document', timeout: 10000, intervals: [100]}).toEqual(target);
 
         await expect.poll(async () => {
-            const ids = await splitterIds();
-            return ids.length > 0 && ids.every(id => !ids1.includes(id))
-        }, {message: 'the NL operation must re-project like the human gesture', timeout: 10000, intervals: [100]}).toBe(true)
+            const ids = await page.locator('.fm-fleet-cockpit .neo-dashboard-dock-splitter').evaluateAll(elements =>
+                elements.map(element => element.id)
+            );
+            return ids.length === 1 && ids[0] !== splitterId1
+        }, {message: 'the NL operation must reconcile like the human gesture', timeout: 10000, intervals: [100]}).toBe(true);
+
+        await assertPersistentIdentity('the toolbar and keeper panes survive the NL splitter commit');
+        expect(runtimeErrors, 'no global error or unhandled rejection across both projection paths').toEqual([]);
+        expect(pageErrors, 'no Playwright pageerror across both projection paths').toEqual([])
     });
 
     test('perspective presets switch the committed document — one real click, then NL-verifiable switching through the same loop', async ({page, neuralLink}) => {
+        const pageErrors    = [],
+              runtimeErrors = [];
+
+        await page.context().exposeFunction('__recordFleetPerspectiveRuntimeError', payload => runtimeErrors.push(payload));
+        await page.context().addInitScript(() => {
+            globalThis.addEventListener('error', event => {
+                globalThis.__recordFleetPerspectiveRuntimeError({
+                    column : event.colno,
+                    line   : event.lineno,
+                    message: event.message,
+                    source : event.filename,
+                    type   : 'error'
+                })
+            });
+            globalThis.addEventListener('unhandledrejection', event => {
+                globalThis.__recordFleetPerspectiveRuntimeError({
+                    reason: String(event.reason?.stack || event.reason?.message || event.reason),
+                    type  : 'unhandledrejection'
+                })
+            })
+        });
+        page.on('pageerror', error => {
+            const value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
         await page.goto('/apps/agentos/index.html');
-        page.on('pageerror', err => console.error('BROWSER JS ERROR:', err));
         await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
 
         // the boot bar renders the three seeded presets, Fleet pressed
@@ -127,15 +218,28 @@ test.describe('AgentOS Fleet cockpit — dock projection commit loop (Neural Lin
 
         expect(holderId, 'the FleetCockpit must exist in the App Worker').toBeTruthy();
 
+        const fleetGrids = await app.findInstances({className: 'AgentOS.view.fleet.FleetGrid'}, ['id']),
+              streams    = await app.findInstances({className: 'AgentOS.view.fleet.ActivityStream'}, ['id']),
+              keepers    = {
+                  fleetGrid: (Array.isArray(fleetGrids) ? fleetGrids[0] : fleetGrids)?.id,
+                  stream   : (Array.isArray(streams) ? streams[0] : streams)?.id,
+                  toolbar  : await page.locator('.fm-cockpit-bar').getAttribute('id')
+              };
+
+        expect(Object.values(keepers).every(Boolean), 'perspective permanence targets start mounted').toBe(true);
+        await page.evaluate(ids => {
+            globalThis.__fleetPerspectiveIdentity = Object.fromEntries(
+                Object.entries(ids).map(([key, id]) => [key, document.getElementById(id)])
+            )
+        }, keepers);
+
         const primarySizes = async () => {
             const topo = await app.getDockTopology(holderId),
                   doc  = topo?.document ?? topo;
             return doc.nodes['primary-split'].sizes
         };
 
-        // 1) the REAL gesture on the live boot bar: one click switches to Focus — worker truth
-        // (post-switch bar re-renders ride the open wholesale-refresh flush defect, so the
-        // remaining switches drive the NL path — which the AC names verbatim)
+        // 1) the REAL gesture on the live persistent bar: one click switches to Focus
         await focusButton.click();
 
         await expect.poll(primarySizes, {message: 'the Focus click must commit the preset document', timeout: 10000, intervals: [100]})
@@ -156,6 +260,12 @@ test.describe('AgentOS Fleet cockpit — dock projection commit loop (Neural Lin
               docReview  = topoReview?.document ?? topoReview;
         expect(docReview.items.detail.autoHidden, 'Review must open the detail band').toBe(false);
 
+        await expect(page.locator('.fm-agent-detail'), 'Review materializes the genuinely absent detail pane')
+            .toBeVisible({timeout: 10000});
+        const details = await app.findInstances({className: 'AgentOS.view.fleet.AgentDetail'}, ['id']),
+              detail  = Array.isArray(details) ? details[0] : details;
+        expect(detail?.id, 'the absent-item resolver returns one live AgentDetail component').toBeTruthy();
+
         // ...and back to the default duty
         await NeuralLink_InstanceService.callMethod({
             sessionId: app.sessionId, id: holderId, method: 'activatePerspective', args: ['Fleet']
@@ -164,11 +274,30 @@ test.describe('AgentOS Fleet cockpit — dock projection commit loop (Neural Lin
         await expect.poll(primarySizes, {message: 'the Fleet switch must restore the default split', timeout: 10000, intervals: [100]})
             .toEqual([0.6078, 0.3922]);
 
+        await expect(page.locator('.fm-agent-detail'), 'returning to Fleet retires the no-longer-projected detail pane')
+            .toHaveCount(0);
+        const detailsAfter = await app.findInstances({className: 'AgentOS.view.fleet.AgentDetail'}, ['id']);
+        expect((Array.isArray(detailsAfter) ? detailsAfter : [detailsAfter]).filter(entry => entry?.id),
+            'the retired detail component leaves no worker-side corpse').toEqual([]);
+
+        expect(await page.evaluate(ids => Object.fromEntries(Object.entries(ids).map(([key, id]) => [
+            key,
+            globalThis.__fleetPerspectiveIdentity?.[key] === document.getElementById(id)
+        ])), keepers), 'Fleet and Activity plus the toolbar survive Focus → Review → Fleet')
+            .toEqual({fleetGrid: true, stream: true, toolbar: true});
+        const keeperComponents = await Promise.all(Object.values(keepers).map(id => app.getComponent(id, ['id'])));
+        expect(keeperComponents.map(component => component.id), 'keeper component identities survive every preset')
+            .toEqual(Object.values(keepers));
+
         // a refused switch fails closed: worker truth unchanged, the refusal recorded
         const ghost = await NeuralLink_InstanceService.callMethod({
             sessionId: app.sessionId, id: holderId, method: 'activatePerspective', args: ['Ghost']
         });
         expect((ghost?.result ?? ghost)?.switched).toBe(false);
-        expect(await primarySizes()).toEqual([0.6078, 0.3922])
+        expect(await primarySizes()).toEqual([0.6078, 0.3922]);
+        await expect(page.locator('.fm-preset-error'), 'a refused switch records its error in the same persistent toolbar')
+            .toContainText('Ghost');
+        expect(runtimeErrors, 'no global error or unhandled rejection across perspective reconciliation').toEqual([]);
+        expect(pageErrors, 'no Playwright pageerror across perspective reconciliation').toEqual([])
     });
 });

--- a/test/playwright/e2e/dashboard/DemoADragMenuNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DemoADragMenuNL.spec.mjs
@@ -11,7 +11,8 @@ import {test, expect} from '../../fixtures.mjs';
  * 2. hovering a different indicator re-targets the exact post-drop region preview;
  * 3. releasing ON an indicator commits exactly that candidate's semantic operation through
  *    the reducer (App Worker document truth), and the committed re-layout animates
- *    (FLIP transforms observable on marker panes);
+ *    (FLIP transforms observable on marker panes) without replacing surviving panes or the
+ *    persistent preview / indicator overlays;
  * 4. Escape mid-drag cancels: the menu clears and the release commits NOTHING;
  * 5. under `prefers-reduced-motion: reduce`, the indicator layer's motion collapses to 0s
  *    THROUGH THE TOKEN on the shared overlay ancestor — the sibling-scope defect class
@@ -87,9 +88,57 @@ test.describe('Demo-A drop-indicator menu: the real-pointer §06 journey (Neural
     test.setTimeout(120000);
 
     test('drag lights the menu, indicators re-target the preview, the release commits + animates', async ({page, neuralLink}) => {
+        const pageErrors    = [],
+              runtimeErrors = [];
+
+        await page.context().exposeFunction('__recordDemoAProjectionRuntimeError', payload => runtimeErrors.push(payload));
+        await page.context().addInitScript(() => {
+            globalThis.addEventListener('error', event => {
+                globalThis.__recordDemoAProjectionRuntimeError({
+                    column : event.colno,
+                    line   : event.lineno,
+                    message: event.message,
+                    source : event.filename,
+                    type   : 'error'
+                })
+            });
+            globalThis.addEventListener('unhandledrejection', event => {
+                globalThis.__recordDemoAProjectionRuntimeError({
+                    reason: String(event.reason?.stack || event.reason?.message || event.reason),
+                    type  : 'unhandledrejection'
+                })
+            })
+        });
+        page.on('pageerror', error => {
+            const value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
         const {app, editorZone, previewZone, wsId} = await bootDemo(page, neuralLink);
 
         const editorCenter = {x: editorZone.x + editorZone.width / 2, y: editorZone.y + editorZone.height / 2};
+
+        const identity = await page.evaluate(() => {
+            const elements = {
+                editorPane    : document.querySelector('.agentos-dockdemo-pane-editor'),
+                indicators    : document.querySelector('.neo-dashboard-dock-drop-indicators'),
+                previewOverlay: document.querySelector('.neo-dock-preview'),
+                previewPane   : document.querySelector('.agentos-dockdemo-pane-preview')
+            };
+
+            globalThis.__demoAProjectionIdentity = elements;
+
+            return {
+                ids         : Object.fromEntries(Object.entries(elements).map(([key, element]) => [key, element?.id])),
+                overlayOrder: [elements.previewOverlay, elements.indicators]
+                    .map(element => [...element.parentElement.children].indexOf(element)),
+                overlaysShareHost: elements.previewOverlay?.parentElement === elements.indicators?.parentElement
+            }
+        });
+
+        expect(Object.values(identity.ids).every(Boolean), 'all pane and overlay permanence targets are mounted').toBe(true);
+        expect(identity.overlaysShareHost, 'preview and indicator overlays share the persistent dock host').toBe(true);
+        expect(identity.overlayOrder[0], 'preview overlay precedes the indicator overlay').toBeLessThan(identity.overlayOrder[1]);
 
         // FLIP observation armed before the drop lands
         await page.evaluate(() => {
@@ -179,7 +228,38 @@ test.describe('Demo-A drop-indicator menu: the real-pointer §06 journey (Neural
 
         const {flipSamples} = await page.evaluate(() => { window.__e2e.done = true; return window.__e2e });
 
-        expect(flipSamples, 'FLIP transforms were observable on marker panes during the committed re-layout').toBeGreaterThan(0)
+        expect(flipSamples, 'FLIP transforms were observable on marker panes during the committed re-layout').toBeGreaterThan(0);
+
+        const identityAfter = await page.evaluate(ids => {
+            const before = globalThis.__demoAProjectionIdentity,
+                  same   = Object.fromEntries(Object.entries(ids).map(([key, id]) => [
+                      key,
+                      before?.[key] === document.getElementById(id)
+                  ])),
+                  previewOverlay = before?.previewOverlay,
+                  indicators     = before?.indicators;
+
+            return {
+                same,
+                overlayOrder: [previewOverlay, indicators]
+                    .map(element => [...element.parentElement.children].indexOf(element)),
+                overlaysShareHost: previewOverlay?.parentElement === indicators?.parentElement
+            }
+        }, identity.ids);
+
+        expect(identityAfter.same, 'the exact pane and overlay DOM nodes survive the dissolving-source projection')
+            .toEqual({editorPane: true, indicators: true, previewOverlay: true, previewPane: true});
+        expect(identityAfter.overlaysShareHost, 'persistent overlays remain siblings after projection').toBe(true);
+        expect(identityAfter.overlayOrder, 'persistent overlay ordering remains preview then indicators')
+            .toEqual(identity.overlayOrder);
+
+        const liveComponents = await Promise.all(Object.values(identity.ids)
+            .map(id => app.getComponent(id, ['id'])));
+
+        expect(liveComponents.map(component => component.id), 'every permanence target keeps its App Worker component identity')
+            .toEqual(Object.values(identity.ids));
+        expect(runtimeErrors, 'no global error or unhandled rejection across the projection').toEqual([]);
+        expect(pageErrors, 'no Playwright pageerror across the projection').toEqual([])
     });
 
     test('Escape mid-drag cancels: the menu clears and the release commits nothing', async ({page, neuralLink}) => {

--- a/test/playwright/e2e/dashboard/DockMotionNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockMotionNL.spec.mjs
@@ -81,9 +81,9 @@ const expectSignalBracket = async (page, {appearMs = 1500, clearMs = 3500} = {})
 };
 
 // The stable-marker motion witness: rAF-records {x, y, w, o} tuples for the first element
-// matching the selector. Sampling by MARKER CLASS, never by instance, is what lets observation
-// live THROUGH a removeAll+rebuild re-projection — the marker is exactly the
-// survives-recreation correlation key the FLIP addon itself uses. Fail-closed semantics:
+// matching the selector. Sampling by MARKER CLASS, never by instance, keeps observation
+// item-specific through native reparenting or a genuinely absent pane's later recreation — the
+// marker is the same stable correlation key the FLIP addon uses. Fail-closed semantics:
 // frames without a match count as gaps (no fabricated zeros), zero-size reads ARE recorded so
 // a consumer can convict them, and every consumer asserts a minimum sample floor before
 // reading shape — an oracle that observed nothing must fail, never default-pass.
@@ -159,7 +159,7 @@ test.describe('Dock motion pipeline (Neural Link) — the signal brackets real m
                 generic: identify(genericSelector)
             };
 
-            // Model removeAll()+rebuild reprojection with fresh nodes and the opposite DOM order.
+            // Model a fresh projection sample with new nodes and the opposite DOM order.
             root.replaceChildren(createMarker('beta'), createMarker(pinnedItemId));
 
             const afterReprojection = {
@@ -285,7 +285,7 @@ test.describe('Dock motion pipeline (Neural Link) — the signal brackets real m
         const { app, holderId } = await connect(page, neuralLink);
 
         // Deterministic state: restore the seeded Operator perspective through the visible product
-        // control. Restore is an unrelated coarse projection and MUST carry no tab-enter class.
+        // control. Restore is an unrelated reconciled projection and MUST carry no tab-enter class.
         await page.getByRole('button', {name: 'Operator', exact: true}).click();
         await expect.poll(async () => {
             const topo = await app.getDockTopology(holderId);
@@ -340,15 +340,15 @@ test.describe('Dock motion pipeline (Neural Link) — the signal brackets real m
         expect(result.document.nodes['main-tabs'].items.indexOf('swarm')).toBe(1);
         expect(result.document.nodes['main-tabs'].items.filter(itemId => itemId !== 'swarm'))
             .toEqual(unrelatedItems);
-        await expect(page.locator('.neo-dashboard-dock-tab-enter')).toHaveCount(1);
+        await expect(page.locator('.neo-dashboard-dock-tab-enter')).toHaveCount(0);
         await expect(page.locator(`${ENTER}${SIGNAL}`)).toHaveCount(0);
 
-        // A later restore is another full removeAll/rebuild but has no addTab descriptor. The
-        // recreated headers must be inert — the one-use correlation cannot leak across projections.
+        // A later identity-reconciled restore has no addTab descriptor. Retained or newly
+        // materialized headers must be inert — the one-use correlation cannot leak across projections.
         await page.getByRole('button', {name: 'Operator', exact: true}).click();
         await expect.poll(
             () => page.locator('.neo-dashboard-dock-tab-enter').count(),
-            {message: 'later coarse projections must not replay tab insertion', timeout: 5000, intervals: [50]}
+            {message: 'later reconciled projections must not replay tab insertion', timeout: 5000, intervals: [50]}
         ).toBe(0)
     });
 
@@ -393,6 +393,8 @@ test.describe('Dock motion pipeline (Neural Link) — the signal brackets real m
 
         // the reveal actually opened (the signal wasn't a stray)
         await expect(page.locator(OVERLAY)).toHaveCount(1);
+        await expect(page.locator(`${OVERLAY} .dock-flip-item-inspector`),
+            'the post-reconcile rail must resolve the real Inspector pane, not a staged placeholder').toBeVisible();
     });
 });
 
@@ -526,7 +528,7 @@ test.describe('Dock motion pipeline — reduced-motion collapses through the tok
         expect(result.document.nodes['main-tabs'].items.indexOf('swarm')).toBe(1);
         expect(result.document.nodes['main-tabs'].items.filter(itemId => itemId !== 'swarm'))
             .toEqual(unrelatedItems);
-        await expect(page.locator('.neo-dashboard-dock-tab-enter.dock-tab-enter-item-swarm')).toHaveCount(1);
+        await expect(page.locator('.neo-dashboard-dock-tab-enter.dock-tab-enter-item-swarm')).toHaveCount(0);
         await expect.poll(
             () => page.locator(SIGNAL).count(),
             {message: '0ms tab insertion must settle without sustained motion', timeout: 1500, intervals: [25]}

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoAWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoAWorkspace.spec.mjs
@@ -10,8 +10,9 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import '../../../../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
-import Button         from '../../../../../../../src/button/Base.mjs';
-import DemoAWorkspace from '../../../../../../../apps/agentos/childapps/dockdemo/view/DemoAWorkspace.mjs';
+import Button                   from '../../../../../../../src/button/Base.mjs';
+import DemoAWorkspace           from '../../../../../../../apps/agentos/childapps/dockdemo/view/DemoAWorkspace.mjs';
+import DockProjectionReconciler from '../../../../../../../src/dashboard/DockProjectionReconciler.mjs';
 
 import {initialDocument} from '../../../../../../../apps/agentos/tour/demoADockChoreography.mjs';
 
@@ -57,6 +58,74 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoAWorkspace', () => {
 
         expect(result.applied).toBe(true);
         expect(workspace.getDockZoneDocument().items.preview.autoHidden).toBe(true)
+    });
+
+    test('reconciliation preserves overlays and surviving chrome while a dissolved tabs node retires once', async () => {
+        const
+            host                = workspace.getReference('dock-host'),
+            previewOverlay      = host.items[1],
+            indicators          = host.items[2],
+            tabsBefore          = DockProjectionReconciler.collectProjectedTabs(host.items[0]),
+            editorTab           = tabsBefore.get('editor-tabs'),
+            sideTab             = tabsBefore.get('side-tabs'),
+            editorBody          = editorTab.getCardContainer(),
+            editorBar           = editorTab.getTabBar(),
+            sideBody            = sideTab.getCardContainer(),
+            sideBar             = sideTab.getTabBar(),
+            editorPane          = editorBody.items[0],
+            previewPane         = sideBody.items[0],
+            editorButton        = editorBar.items[0],
+            previewButton       = sideBar.items[0],
+            destroyCounts       = new Map(),
+            originalResolvePane = workspace.resolvePane.bind(workspace);
+
+        [
+            sideTab,
+            sideBar,
+            sideBody,
+            sideTab.getTabStrip(),
+            sideBar.getPlugin('tab-overflow')
+        ].filter(Boolean).forEach(component => {
+            const destroy = component.destroy.bind(component);
+
+            destroyCounts.set(component, 0);
+            component.destroy = (...args) => {
+                destroyCounts.set(component, destroyCounts.get(component) + 1);
+                return destroy(...args)
+            }
+        });
+
+        let resolverCalls = 0;
+
+        workspace.resolvePane = (...args) => {
+            resolverCalls++;
+            return originalResolvePane(...args)
+        };
+
+        const result = workspace.applyDockZoneOperation({
+            operation : 'addTab',
+            itemId    : 'preview',
+            tabsNodeId: 'editor-tabs'
+        });
+
+        expect(result.errors).toEqual([]);
+        workspace.onDockZoneDocumentChange(result.document);
+        await workspace.refreshPromise;
+
+        const
+            tabsAfter = DockProjectionReconciler.collectProjectedTabs(host.items[0]),
+            itemIds   = editorBar.sortZoneConfig.dockItemIds;
+
+        expect(host.items[1]).toBe(previewOverlay);
+        expect(host.items[2]).toBe(indicators);
+        expect(tabsAfter.get('editor-tabs')).toBe(editorTab);
+        expect(tabsAfter.has('side-tabs')).toBe(false);
+        expect(editorBody.items[itemIds.indexOf('editor')]).toBe(editorPane);
+        expect(editorBody.items[itemIds.indexOf('preview')]).toBe(previewPane);
+        expect(editorBar.items[itemIds.indexOf('editor')]).toBe(editorButton);
+        expect(editorBar.items[itemIds.indexOf('preview')]).toBe(previewButton);
+        expect(resolverCalls).toBe(0);
+        destroyCounts.forEach(count => expect(count).toBe(1))
     });
 
     test('drop truth is the RELEASE point: a stale hover selection never commits', async () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
@@ -27,18 +27,32 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
  * docking design's pane contract, and owner-held pane state surviving re-projection.
  */
 test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)', () => {
-    let ActivityStream, AgentDetail, DockZoneModel, FleetCockpit, FleetGrid, cockpitDockDocument;
+    let ActivityStream, AgentDetail, DockProjectionReconciler, DockZoneModel, FleetCockpit, FleetGrid, cockpitDockDocument;
 
     // a projection-capable spy owner: the REAL prototype methods over controlled state, without
     // provider/store/bridge wiring (their routing has its own suite in fleetCockpit.spec.mjs)
-    const makeHost = (overrides = {}) => Object.assign(Object.create(FleetCockpit.prototype), {
-        dockModel         : cockpitDockDocument(),
-        gridAdapterState  : 'sample',
-        isDestroyed       : false,
-        streamAdapterState: 'sample',
-        streamEvents      : [],
-        timeout           : ms => new Promise(resolve => setTimeout(resolve, ms))
-    }, overrides);
+    const makeHost = (overrides = {}) => {
+        const
+            host   = Object.create(FleetCockpit.prototype),
+            values = {
+                dockModel         : cockpitDockDocument(),
+                gridAdapterState  : 'sample',
+                isDestroyed       : false,
+                refreshPromise    : null,
+                streamAdapterState: 'sample',
+                streamEvents      : [],
+                timeout           : ms => new Promise(resolve => setTimeout(resolve, ms)),
+                ...overrides
+            };
+
+        Object.defineProperties(host, Object.fromEntries(Object.entries(values).map(([key, value]) => [key, {
+            configurable: true,
+            value,
+            writable    : true
+        }])));
+
+        return host
+    };
 
     // flatten a projected config tree (items recursion) for structural assertions
     const collect = (config, out = []) => {
@@ -50,6 +64,7 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
     test.beforeAll(async () => {
         ActivityStream      = (await import('../../../../../../../apps/agentos/view/fleet/ActivityStream.mjs')).default;
         AgentDetail         = (await import('../../../../../../../apps/agentos/view/fleet/AgentDetail.mjs')).default;
+        DockProjectionReconciler = (await import('../../../../../../../src/dashboard/DockProjectionReconciler.mjs')).default;
         DockZoneModel       = (await import('../../../../../../../src/dashboard/DockZoneModel.mjs')).default;
         FleetCockpit        = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default;
         FleetGrid           = (await import('../../../../../../../apps/agentos/view/fleet/FleetGrid.mjs')).default;
@@ -95,7 +110,7 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
         // ...but the re-projection has NOT run inside the committing call stack
         expect(refreshed).toBe(0);
 
-        await new Promise(resolve => setTimeout(resolve, 5));
+        await host.refreshPromise;
         expect(refreshed).toBe(1)
     });
 
@@ -107,8 +122,80 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
         FleetCockpit.prototype.onDockZoneDocumentChange.call(host, cockpitDockDocument());
         host.isDestroyed = true;
 
-        await new Promise(resolve => setTimeout(resolve, 5));
+        await host.refreshPromise;
         expect(refreshed).toBe(0)
+    });
+
+    test('two rapid commits serialize their captured document snapshots instead of overlapping shells', async () => {
+        const
+            first = DockZoneModel.applyOperation(cockpitDockDocument(), {
+                operation: 'resizeSplit', splitNodeId: 'primary-split', sizes: [0.3, 0.7]
+            }).document,
+            second = DockZoneModel.applyOperation(first, {
+                operation: 'resizeSplit', splitNodeId: 'primary-split', sizes: [0.4, 0.6]
+            }).document,
+            starts   = [],
+            releases = [],
+            host     = makeHost({
+                refreshDockWorkspace(document) {
+                    starts.push(document);
+                    return new Promise(resolve => releases.push(resolve))
+                }
+            });
+
+        FleetCockpit.prototype.onDockZoneDocumentChange.call(host, first);
+        FleetCockpit.prototype.onDockZoneDocumentChange.call(host, second);
+
+        await new Promise(resolve => setTimeout(resolve, 5));
+        expect(starts).toEqual([first]);
+
+        releases.shift()();
+        await new Promise(resolve => setTimeout(resolve, 5));
+        expect(starts).toEqual([first, second]);
+
+        releases.shift()();
+        await host.refreshPromise
+    });
+
+    test('refresh reconciles shell index 1, preserves flex, and decorates a genuinely absent pane', async () => {
+        const
+            document = cockpitDockDocument(),
+            original = DockProjectionReconciler.reconcileProjection,
+            preset   = {reference: 'fleet-preset-fleet', set(values) { Object.assign(this, values) }},
+            error    = {set(values) { Object.assign(this, values) }},
+            host     = makeHost({
+                id              : 'fleet-test-host',
+                items           : [{items: [preset]}],
+                perspectiveStore: {collection: {activeLayoutId: 'fleet'}},
+                presetError     : null,
+                getReference(reference) {
+                    return reference === 'fleet-preset-error' ? error : null
+                }
+            });
+
+        let options;
+
+        DockProjectionReconciler.reconcileProjection = async value => {
+            options = value
+        };
+
+        try {
+            await FleetCockpit.prototype.refreshDockWorkspace.call(host, document);
+
+            expect(options.host).toBe(host);
+            expect(options.shellIndex).toBe(1);
+            expect(options.nextConfig.flex).toBe(1);
+
+            const absent = options.resolveItem('fleet');
+
+            expect(absent.module).toBe(FleetGrid);
+            expect(absent.header).toEqual({text: 'Fleet'});
+            expect(absent.dockItemId).toBe('fleet');
+            expect(absent.data).toMatchObject({componentRef: 'fleet-grid', dockItemId: 'fleet'})
+        } finally {
+            options?.placeholders?.forEach(placeholder => !placeholder.isDestroyed && placeholder.destroy());
+            DockProjectionReconciler.reconcileProjection = original
+        }
     });
 
     test('the projection threads INSTANCE-BOUND callbacks: a projected affordance routes its commit into this host\'s document', () => {
@@ -132,7 +219,7 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
         expect(result.document.nodes['primary-split'].sizes).toEqual([0.25, 0.75])
     });
 
-    test('panes are layout-blind (§2.6) and re-materialize from OWNER-held state — a re-projection can never reset a live surface', () => {
+    test('panes are layout-blind (§2.6) and absent-item fallback reads OWNER-held state', () => {
         const host = makeHost({gridAdapterState: 'live', streamAdapterState: 'stale', streamEvents: [{type: 'pr-activity', payload: {text: 'held'}}], detailRecord: {agentId: 'vega', displayName: 'Vega'}});
 
         const grid = FleetCockpit.prototype.resolveDockComponentRef.call(host, 'fleet-grid', {title: 'Fleet'}, 'fleet');
@@ -149,8 +236,8 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
         expect(stream.events).toEqual(host.streamEvents);
         expect(stream.cls).toContain('dock-flip-item-stream');
 
-        // agent-detail now renders the real drill-in view, re-materialized from OWNER-held state
-        // (the selected record) so a committed re-projection never drops the selection
+        // agent-detail now renders the real drill-in view from OWNER-held fallback state
+        // (the selected record), so returning from true absence never drops the selection
         const detail = FleetCockpit.prototype.resolveDockComponentRef.call(host, 'agent-detail', {title: 'Agent detail'}, 'detail');
 
         expect(detail.module).toBe(AgentDetail);
@@ -197,18 +284,29 @@ test.describe('Fleet cockpit — perspective presets (the switch through the com
     let DockPerspectiveStore, DockZoneModel, FleetCockpit, cockpitPresetCollection, Neo;
 
     const makePresetHost = async (overrides = {}) => {
-        const store = Neo.create(DockPerspectiveStore, {collection: cockpitPresetCollection()});
+        const
+            store  = Neo.create(DockPerspectiveStore, {collection: cockpitPresetCollection()}),
+            host   = Object.create(FleetCockpit.prototype),
+            values = {
+                dockModel         : (await import('../../../../../../../apps/agentos/view/fleet/cockpitDockDocument.mjs')).default(),
+                gridAdapterState  : 'sample',
+                isDestroyed       : false,
+                perspectiveStore  : store,
+                presetError       : null,
+                refreshPromise    : null,
+                streamAdapterState: 'sample',
+                streamEvents      : [],
+                timeout           : ms => new Promise(resolve => setTimeout(resolve, ms)),
+                ...overrides
+            };
 
-        return Object.assign(Object.create(FleetCockpit.prototype), {
-            dockModel         : (await import('../../../../../../../apps/agentos/view/fleet/cockpitDockDocument.mjs')).default(),
-            gridAdapterState  : 'sample',
-            isDestroyed       : false,
-            perspectiveStore  : store,
-            presetError       : null,
-            streamAdapterState: 'sample',
-            streamEvents      : [],
-            timeout           : ms => new Promise(resolve => setTimeout(resolve, ms))
-        }, overrides)
+        Object.defineProperties(host, Object.fromEntries(Object.entries(values).map(([key, value]) => [key, {
+            configurable: true,
+            value,
+            writable    : true
+        }])));
+
+        return host
     };
 
     test.beforeAll(async () => {
@@ -246,7 +344,7 @@ test.describe('Fleet cockpit — perspective presets (the switch through the com
         expect(host.perspectiveStore.collection.activeLayoutId).toBe('focus');
         // deferred view-sync, same as every commit
         expect(refreshed).toBe(0);
-        await new Promise(resolve => setTimeout(resolve, 5));
+        await host.refreshPromise;
         expect(refreshed).toBe(1);
 
         // Review opens the detail band and leans the split toward the trail
@@ -273,17 +371,51 @@ test.describe('Fleet cockpit — perspective presets (the switch through the com
         expect(host.streamAdapterState).toBe('live');
         expect(host.streamEvents).toBe(events);
 
-        // and the next re-materialization carries that state into the rebuilt panes
+        // and a genuinely absent pane's next materialization carries that state
         const grid = FleetCockpit.prototype.resolveDockComponentRef.call(host, 'fleet-grid', {title: 'Fleet'}, 'fleet');
         expect(grid.adapterState).toBe('live');
 
         host.perspectiveStore.destroy()
     });
 
-    test('a refused switch fails closed VISIBLY: the live layout stays byte-identical and the error renders in the bar', async () => {
-        let refreshed = 0;
+    test('the persistent control bar keeps identities while preset and refusal state change', async () => {
+        const
+            buttons = ['fleet', 'focus', 'review'].map(layoutId => ({
+                pressed  : false,
+                reference: `fleet-preset-${layoutId}`,
+                set(values) { Object.assign(this, values) }
+            })),
+            error = {
+                hidden: true,
+                html  : '',
+                set(values) { Object.assign(this, values) }
+            },
+            host = await makePresetHost({
+                items: [{items: buttons}],
+                getReference(reference) {
+                    return reference === 'fleet-preset-error' ? error : null
+                }
+            }),
+            identities = [...buttons];
 
-        const host   = await makePresetHost({refreshDockWorkspace() { refreshed++ }}),
+        FleetCockpit.prototype.syncControlBar.call(host);
+        expect(buttons.map(button => button.pressed)).toEqual([true, false, false]);
+
+        host.perspectiveStore.loadPerspective('Focus');
+        host.presetError = 'refused visibly';
+        FleetCockpit.prototype.syncControlBar.call(host);
+
+        expect(buttons).toEqual(identities);
+        expect(buttons.map(button => button.pressed)).toEqual([false, true, false]);
+        expect(error).toMatchObject({hidden: false, html: 'refused visibly'});
+
+        host.perspectiveStore.destroy()
+    });
+
+    test('a refused switch fails closed VISIBLY: the live layout stays byte-identical and the error syncs in place', async () => {
+        let synced = 0;
+
+        const host   = await makePresetHost({syncControlBar() { synced++ }}),
               before = JSON.stringify(host.dockModel);
 
         const verdict = FleetCockpit.prototype.activatePerspective.call(host, 'ghost');
@@ -292,8 +424,8 @@ test.describe('Fleet cockpit — perspective presets (the switch through the com
         expect(verdict.errors.join(' ')).toContain('no perspective named');
         expect(JSON.stringify(host.dockModel)).toBe(before);
         expect(host.presetError).toContain('ghost');
-        // the error path re-renders the bar (visible refusal), without a document commit
-        expect(refreshed).toBe(1);
+        // the error path updates the persistent bar, without a document commit or shell refresh
+        expect(synced).toBe(1);
 
         // the bar derives from state: pressed follows the active record, the error chip renders
         const bar = FleetCockpit.prototype.buildWorkspaceItems.call(host)[0];

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -295,6 +295,29 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         expect(unrelated.items[0].items.every(item => item.header.module === undefined)).toBe(true)
     });
 
+    test('an absent-item resolver can reuse the adapter-owned metadata and addTab decoration', () => {
+        const
+            item   = {componentRef: 'Swarm', kind: 'panel', title: 'Swarm'},
+            config = DockLayoutAdapter.decorateProjectedItem(
+                {ntype: 'component'},
+                'swarm',
+                item,
+                {
+                    nodeId             : 'main-tabs',
+                    tabInsertDescriptor: {operation: 'addTab', itemId: 'swarm', tabsNodeId: 'main-tabs'}
+                }
+            );
+
+        expect(config.dockItemId).toBe('swarm');
+        expect(config.data).toEqual({componentRef: 'Swarm', dockItemId: 'swarm'});
+        expect(config.header.text).toBe('Swarm');
+        expect(config.header.module).toBe(DockTabEnterButton);
+        expect(config.header.cls).toEqual([
+            'neo-dashboard-dock-tab-enter',
+            'dock-tab-enter-item-swarm'
+        ])
+    });
+
     test('projects the documented edge-zone root model through the dashboard adapter', () => {
         let result = DockLayoutAdapter.project(createEdgeZoneModel(), {
                 resolveComponentRef: componentRef => ({
@@ -340,6 +363,27 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         });
         expect(placeholder.header.text).toBe('Missing');
         expect(model).toEqual(snapshot);
+    });
+
+    test('keeps a tabs-node item absent from the catalog recoverable', () => {
+        let model = createModel();
+
+        model.nodes['missing-tabs'] = {
+            type        : 'tabs',
+            items       : ['unknown'],
+            activeItemId: 'unknown'
+        };
+
+        let result      = DockLayoutAdapter.project(model, {resolveComponentRef: () => null}),
+            placeholder = getProjectedChildren(getProjectedChildren(result)[1])[1].items[0];
+
+        expect(placeholder.ntype).toBe('dashboard-panel');
+        expect(placeholder.data).toEqual({
+            componentRef       : null,
+            dockItemId         : 'unknown',
+            missingComponentRef: true
+        });
+        expect(placeholder.header.text).toBe('unknown')
     });
 
     test('normalizes invalid split sizes without rewriting the model', () => {
@@ -454,9 +498,11 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
     });
 
     test('threads reducer callbacks from projection context into the rail affordance', () => {
-        let applyDockZoneOperation   = () => null,
-            model                    = createEdgeZoneModel(),
-            onDockZoneDocumentChange = () => null;
+        let applyDockZoneOperation    = () => null,
+            model                     = createEdgeZoneModel(),
+            onDockZoneDocumentChange  = () => null,
+            resolveComponentRef       = componentRef => ({hidden: true, ntype: 'component', reference: componentRef}),
+            resolveRevealComponentRef = componentRef => ({html: componentRef, ntype: 'component'});
 
         model.items.terminal.autoHidden = true;
 
@@ -465,7 +511,8 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
                 autoHideRevealOnHover: true,
                 defaultRevealFraction: 0.4,
                 onDockZoneDocumentChange,
-                resolveComponentRef  : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+                resolveComponentRef,
+                resolveRevealComponentRef
             }),
             rail = result.items[0].items.find(item => item.dockNodeType === 'edge-rail');
 
@@ -473,12 +520,15 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         expect(rail.applyDockZoneOperation).toBe(applyDockZoneOperation);
         expect(rail.onDockZoneDocumentChange).toBe(onDockZoneDocumentChange);
         expect(rail.dockZoneDocument).toBe(model);
+        expect(rail.resolveComponentRef).toBe(resolveRevealComponentRef);
+        expect(rail.resolveComponentRef('terminal')).toEqual({html: 'terminal', ntype: 'component'});
         // Workspace-level interaction options thread through; they default when absent.
         expect(rail.autoHideRevealOnHover).toBe(true);
         expect(rail.defaultRevealFraction).toBe(0.4);
-        expect(DockLayoutAdapter.project(model, {
-            resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
-        }).items[0].items.find(item => item.dockNodeType === 'edge-rail').autoHideRevealOnHover).toBe(false);
+        rail = DockLayoutAdapter.project(model, {resolveComponentRef})
+            .items[0].items.find(item => item.dockNodeType === 'edge-rail');
+        expect(rail.autoHideRevealOnHover).toBe(false);
+        expect(rail.resolveComponentRef).toBe(resolveComponentRef)
     });
 
     test('resolveRevealExtent returns the committed split share, else null', () => {

--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -144,4 +144,137 @@ test.describe('Neo.dashboard.DockProjectionReconciler', () => {
             host.destroy()
         }
     })
+
+    test('normalizes an absent-item config to the inserted live component exactly once', async () => {
+        const
+            model = createRootTabsModel(),
+            pane  = Neo.create(Component, {header: {text: 'Alpha'}}),
+            host  = Neo.create(Container, {
+                items: [DockLayoutAdapter.project(model, {
+                    resolveComponentRef: () => pane
+                })]
+            }),
+            originalTab  = host.items[0],
+            nextModel    = structuredClone(model),
+            placeholders = new Map();
+
+        nextModel.items.beta = {componentRef: 'beta', kind: 'panel', title: 'Beta'};
+        nextModel.nodes['root-tabs'].items.push('beta');
+
+        const resolverCalls = [];
+
+        try {
+            const nextConfig = DockLayoutAdapter.project(nextModel, {
+                resolveComponentRef(_componentRef, item, itemId) {
+                    const placeholder = Neo.create(Component, {
+                        header: {text: item.title},
+                        hidden: true
+                    });
+
+                    placeholders.set(itemId, placeholder);
+
+                    return placeholder
+                }
+            });
+
+            await DockProjectionReconciler.reconcileProjection({
+                host,
+                nextConfig,
+                placeholders,
+                resolveItem(itemId) {
+                    resolverCalls.push(itemId);
+
+                    const item = nextModel.items[itemId];
+
+                    return DockLayoutAdapter.decorateProjectedItem(
+                        {ntype: 'component', html: item.title},
+                        itemId,
+                        item
+                    )
+                }
+            });
+
+            const body = originalTab.getCardContainer();
+
+            expect(host.items[0]).toBe(originalTab);
+            expect(body.items[0]).toBe(pane);
+            expect(body.items[1]).toBeInstanceOf(Component);
+            expect(body.items[1].html).toBe('Beta');
+            expect(originalTab.getTabBar().items[1].text).toBe('Beta');
+            expect(resolverCalls).toEqual(['beta'])
+        } finally {
+            host.destroy()
+        }
+    });
+
+    test('retires a pane and button that are absent from every projected tab exactly once', async () => {
+        const
+            model = createRootTabsModel(),
+            beta  = {componentRef: 'beta', kind: 'panel', title: 'Beta'};
+
+        model.items.beta = beta;
+        model.nodes['root-tabs'].items.push('beta');
+
+        const
+            panes = {
+                alpha: Neo.create(Component, {header: {text: 'Alpha'}}),
+                beta : Neo.create(Component, {header: {text: 'Beta'}})
+            },
+            host = Neo.create(Container, {
+                items: [DockLayoutAdapter.project(model, {
+                    resolveComponentRef: (_componentRef, _item, itemId) => panes[itemId]
+                })]
+            }),
+            tab             = host.items[0],
+            bar             = tab.getTabBar(),
+            betaButton      = bar.items[1],
+            betaPaneDestroy = panes.beta.destroy.bind(panes.beta),
+            betaButtonDestroy = betaButton.destroy.bind(betaButton),
+            nextModel       = structuredClone(model),
+            placeholders    = new Map();
+
+        let betaPaneDestroyCount   = 0,
+            betaButtonDestroyCount = 0;
+
+        panes.beta.destroy = (...args) => {
+            betaPaneDestroyCount++;
+            return betaPaneDestroy(...args)
+        };
+        betaButton.destroy = (...args) => {
+            betaButtonDestroyCount++;
+            return betaButtonDestroy(...args)
+        };
+
+        nextModel.nodes['root-tabs'].items = ['alpha'];
+
+        try {
+            const nextConfig = DockLayoutAdapter.project(nextModel, {
+                resolveComponentRef(_componentRef, item, itemId) {
+                    const placeholder = Neo.create(Component, {
+                        header: {text: item.title},
+                        hidden: true
+                    });
+
+                    placeholders.set(itemId, placeholder);
+
+                    return placeholder
+                }
+            });
+
+            await DockProjectionReconciler.reconcileProjection({
+                host,
+                nextConfig,
+                placeholders,
+                resolveItem: () => null
+            });
+
+            expect(host.items[0]).toBe(tab);
+            expect(tab.getCardContainer().items).toEqual([panes.alpha]);
+            expect(bar.items).toHaveLength(1);
+            expect(betaPaneDestroyCount).toBe(1);
+            expect(betaButtonDestroyCount).toBe(1)
+        } finally {
+            host.destroy()
+        }
+    })
 });

--- a/test/playwright/unit/dashboard/DockTabEnterButton.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabEnterButton.spec.mjs
@@ -78,8 +78,8 @@ test.describe('Neo.dashboard.DockTabEnterButton', () => {
         DockMotionSignal.activeMotions.clear()
     });
 
-    const createButton = id => {
-        let button = Neo.create(DockTabEnterButton, {id, text: id});
+    const createButton = (id, config={}) => {
+        let button = Neo.create(DockTabEnterButton, {...config, id, text: id});
 
         buttons.push(button);
         return button
@@ -106,7 +106,9 @@ test.describe('Neo.dashboard.DockTabEnterButton', () => {
     });
 
     test('brackets a real root settle, stays idempotent, and filters bubbled child animations', () => {
-        let button = createButton('dock-tab-enter-normal'),
+        let button = createButton('dock-tab-enter-normal', {
+                cls: ['stable-header', 'neo-dashboard-dock-tab-enter', 'dock-tab-enter-item-swarm']
+            }),
             rootId = button.vdom?.id || button.id;
 
         // Construction/class correlation alone is not motion. Rendered-style discovery owns entry;
@@ -118,16 +120,24 @@ test.describe('Neo.dashboard.DockTabEnterButton', () => {
         expect(button.cls).toContain(DockMotionSignal.SIGNAL_CLS);
         button.onTabEnterAnimationSettle(createAnimationEvent('animationend', 'tab-enter-child'));
         expect(DockMotionSignal.isAnimating(button.id)).toBe(true);
+        expect(button.hasTabEnterDecoration()).toBe(true);
 
         button.onTabEnterAnimationSettle(createAnimationEvent('animationend', rootId));
         expect(DockMotionSignal.isAnimating(button.id)).toBe(false);
+        expect(button.hasTabEnterDecoration()).toBe(false);
+        expect(button.cls).toContain('stable-header');
+        expect(button.cls.some(cls => cls.startsWith('dock-tab-enter-item-'))).toBe(false);
 
         // A duplicate end is idempotent. Cancellation balances a second real start.
         button.onTabEnterAnimationSettle(createAnimationEvent('animationend', rootId));
-        button = createButton('dock-tab-enter-cancel');
+        button = createButton('dock-tab-enter-cancel', {
+            cls: ['neo-dashboard-dock-tab-enter', 'dock-tab-enter-item-terminal']
+        });
         button.beginTabEnterMotion();
         button.onTabEnterAnimationSettle(createAnimationEvent('animationcancel', button.vdom?.id || button.id));
-        expect(DockMotionSignal.isAnimating(button.id)).toBe(false)
+        expect(DockMotionSignal.isAnimating(button.id)).toBe(false);
+        expect(button.hasTabEnterDecoration()).toBe(false);
+        expect(button.cls.some(cls => cls.startsWith('dock-tab-enter-item-'))).toBe(false)
     });
 
     test('rapid replacement and destroy settle only each instance-owned entry', () => {
@@ -149,14 +159,16 @@ test.describe('Neo.dashboard.DockTabEnterButton', () => {
         expect(DockMotionSignal.activeMotions.size).toBe(0)
     });
 
-    test('the refresh owner captures a real addTab for one projection only; reorder and later refreshes stay inert', async () => {
+    test('the refresh owner captures a globally absent addTab once; moves, reorders and later refreshes stay inert', async () => {
         let initial    = createModel(),
             descriptor = {operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs', index: 2},
-            inserted   = DockZoneModel.applyOperation(initial, descriptor),
+            moved      = DockZoneModel.applyOperation(initial, descriptor),
+            detached   = DockZoneModel.applyOperation(initial, {operation: 'detachItem', itemId: 'terminal'}),
+            inserted   = DockZoneModel.applyOperation(detached.document, descriptor),
             refreshes  = [],
             context    = {
                 applyDockZoneOperation() {},
-                dockModel                       : initial,
+                dockModel                       : detached.document,
                 getTabInsertProjectionDescriptor: MainContainer.prototype.getTabInsertProjectionDescriptor,
                 isDestroyed                     : false,
                 onDockCrossZoneDrop() {},
@@ -165,10 +177,15 @@ test.describe('Neo.dashboard.DockTabEnterButton', () => {
                 timeout                 : () => Promise.resolve()
             };
 
+        expect(moved.errors).toEqual([]);
+        expect(MainContainer.prototype.getTabInsertProjectionDescriptor.call(
+            {dockModel: initial}, moved.document, descriptor
+        )).toBeNull();
+        expect(detached.errors).toEqual([]);
         expect(inserted.errors).toEqual([]);
 
         MainContainer.prototype.onDockZoneDocumentChange.call(context, inserted.document, descriptor);
-        await Promise.resolve();
+        await context.refreshPromise;
 
         expect(refreshes).toEqual([{operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs'}]);
         expect(JSON.stringify(context.dockModel)).not.toContain('tabInsert');
@@ -182,14 +199,14 @@ test.describe('Neo.dashboard.DockTabEnterButton', () => {
         expect(entered[0].header.module).toBe(DockTabEnterButton);
 
         // Same-target addTab is a reorder: the header existed before the commit, so no insertion.
-        let reorder = {operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs', index: 0},
-            moved   = DockZoneModel.applyOperation(context.dockModel, reorder);
+        let reorder   = {operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs', index: 0},
+            reordered = DockZoneModel.applyOperation(context.dockModel, reorder);
 
-        MainContainer.prototype.onDockZoneDocumentChange.call(context, moved.document, reorder);
-        await Promise.resolve();
+        MainContainer.prototype.onDockZoneDocumentChange.call(context, reordered.document, reorder);
+        await context.refreshPromise;
         expect(refreshes[1]).toBeNull();
 
-        // A later coarse projection receives no captured descriptor and recreates every header inert.
+        // A later projection receives no captured descriptor and keeps or creates every header inert.
         const later     = MainContainer.prototype.projectDockModel.call(context),
               laterTabs = findProjectedNode(later, 'main-tabs');
 

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -11,11 +11,14 @@ import Neo            from '../../../../src/Neo.mjs';
 import * as core      from '../../../../src/core/_export.mjs';
 import DockZoneModel  from '../../../../src/dashboard/DockZoneModel.mjs';
 import MainContainer  from '../../../../examples/dashboard/dock/MainContainer.mjs';
+import Toolbar        from '../../../../src/toolbar/Base.mjs';
+import '../../../../src/manager/Instance.mjs';
 
 /**
  * @summary Tests for Neo.dashboard.DockZoneModel — the dock-zone semantic operations executor.
- * Pure-JSON: validity invariants, each operation, fail-closed behavior, normalizeTree collapse,
- * and the previewToOperation descriptor seam. No component construction needed.
+ * Primarily pure JSON: validity invariants, each operation, fail-closed behavior, normalizeTree
+ * collapse, and the previewToOperation descriptor seam. The standalone-example block additionally
+ * mounts its persistent toolbar to pin identity reconciliation over collection mutations.
  */
 
 /**
@@ -891,6 +894,7 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
         function createExampleHarness() {
             const example = {
                 createDefaultLayoutCollection  : MainContainer.prototype.createDefaultLayoutCollection,
+                createPerspectiveButton        : MainContainer.prototype.createPerspectiveButton,
                 createPerspectiveToolbar       : MainContainer.prototype.createPerspectiveToolbar,
                 loadLayoutCollectionFromStorage: MainContainer.prototype.loadLayoutCollectionFromStorage,
                 nextSavedPerspectiveId         : MainContainer.prototype.nextSavedPerspectiveId,
@@ -898,11 +902,17 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
                 removeActivePerspective        : MainContainer.prototype.removeActivePerspective,
                 restorePerspective             : MainContainer.prototype.restorePerspective,
                 saveCurrentPerspective         : MainContainer.prototype.saveCurrentPerspective,
+                syncPerspectiveToolbar         : MainContainer.prototype.syncPerspectiveToolbar,
 
                 layoutCollectionStorageKey: 'test.dashboard.dock.layoutCollection',
                 refreshCount              : 0,
                 savedPerspectiveCount     : 0,
                 windowId                  : 1,
+
+                onDockZoneDocumentChange(document) {
+                    this.dockModel     = document;
+                    this.refreshPromise = Promise.resolve(this.refreshDockWorkspace())
+                },
 
                 refreshDockWorkspace() {
                     this.refreshCount++
@@ -978,6 +988,52 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
             expect(example.refreshCount).toBe(3);
             expect(writes.length).toBeGreaterThanOrEqual(3);
             expect(JSON.parse(writes.at(-1).value).activeLayoutId).toBe('operator-default')
+        });
+
+        test('the perspective toolbar keeps stable controls and buttons across save and delete', () => {
+            Neo.main.addon.LocalStorage.updateLocalStorageItem = async () => {};
+
+            const
+                example        = createExampleHarness(),
+                toolbar        = Neo.create(Toolbar, example.createPerspectiveToolbar()),
+                label          = toolbar.items[0],
+                operatorButton = toolbar.items[1],
+                reviewButton   = toolbar.items[2],
+                saveButton     = toolbar.items[3],
+                deleteButton   = toolbar.items[4];
+
+            example.items = [toolbar];
+
+            try {
+                const saved = example.saveCurrentPerspective();
+
+                expect(saved.errors).toEqual([]);
+                example.syncPerspectiveToolbar();
+
+                const savedButton = toolbar.items.find(item => item.reference === `dock-perspective-${saved.layout.layoutId}`);
+
+                expect(toolbar.items[0]).toBe(label);
+                expect(toolbar.items.find(item => item.reference === 'dock-perspective-operator-default')).toBe(operatorButton);
+                expect(toolbar.items.find(item => item.reference === 'dock-perspective-review-focus')).toBe(reviewButton);
+                expect(toolbar.items.at(-2)).toBe(saveButton);
+                expect(toolbar.items.at(-1)).toBe(deleteButton);
+                expect(savedButton?.pressed).toBe(true);
+
+                const removed = example.removeActivePerspective();
+
+                expect(removed.errors).toEqual([]);
+                example.syncPerspectiveToolbar();
+
+                expect(toolbar.items[0]).toBe(label);
+                expect(toolbar.items.find(item => item.reference === 'dock-perspective-operator-default')).toBe(operatorButton);
+                expect(toolbar.items.find(item => item.reference === 'dock-perspective-review-focus')).toBe(reviewButton);
+                expect(toolbar.items.includes(savedButton)).toBe(false);
+                expect(savedButton.isDestroyed).toBe(true);
+                expect(toolbar.items.at(-2)).toBe(saveButton);
+                expect(toolbar.items.at(-1)).toBe(deleteButton)
+            } finally {
+                toolbar.destroy()
+            }
         });
 
         test('rehydrates a valid persisted collection and fails closed for invalid storage payloads', async () => {


### PR DESCRIPTION
Resolves #15171

Demo A, Fleet Cockpit, and the standalone dashboard example now use `DockProjectionReconciler` for committed dock-document projection. Surviving tab chrome, panes, and app controls retain identity; true removals retire once; Demo A overlays and Fleet's deferred interaction boundary remain app-owned.

Evidence: L3 (identity-focused unit coverage plus live Neural Link browser journeys) → L3 required (runtime identity, physical animation settlement, and interaction continuity ACs). No residuals.

## Deltas from ticket

- The shared reconciler now accepts an app resolver result that can materialize a genuinely absent pane, and retires pane/button pairs absent from every projected tab exactly once.
- `DockLayoutAdapter` exposes pure absent-item decoration plus a separate durable rail-reveal resolver, so transaction-only staging placeholders cannot leak into a later rail interaction.
- One-use tab-entry decoration is consumed when the physical CSS animation settles. Cross-tab `addTab` requests that the model downgrades to moves stay identity-preserving and use FLIP alone.
- Demo B and Workstation receive only the durable rail-resolver wiring: the reusable contract correction discovered while migrating the three remaining coarse consumers.
- Persistent Fleet and example toolbars update their controls in place while reconciliation owns only the projection shell.

## Test Evidence

- Affected unit surface: 8 focused specs covering Demo A, Demo B, Fleet, Workstation, `DockLayoutAdapter`, `DockProjectionReconciler`, `DockTabEnterButton`, and `DockZoneModel` — 183 passed in 1.9s on the rebased head. The local runner imported Neo's unit config and disabled only its unavailable Chroma web server.
- Neural Link whitebox matrix: `NEO_E2E_PORT=8130 ./node_modules/.bin/playwright test --config test/playwright/playwright.config.e2e.mjs test/playwright/e2e/agentos/FleetCockpitDockNL.spec.mjs test/playwright/e2e/dashboard/DemoADragMenuNL.spec.mjs test/playwright/e2e/dashboard/DockMotionNL.spec.mjs` — 12 passed in 50.9s. It proves Fleet splitter/preset continuity, Demo A overlay/drag continuity, surviving identity, exact one-use tab entry, a real post-reconcile rail pane, and reduced-motion settlement.
- Theme surfaces: `npm run build-themes -- -n -e dev -t all` — passed for all development themes after rebasing over #15175.
- Source gates: `npm run agent-preflight -- --no-fix <19 changed files>` — passed; commit-time staged hooks, 19 syntax checks, block alignment, and `git diff --check` also passed.

## Post-Merge Validation

- [ ] Re-run the focused unit and Neural Link matrices against the merged `dev` build.

Related: #15170 · #15175

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session adddb25d-fc36-4b08-b9a3-3a62a108cda1.
