### PR TITLE
docs(dockdemo): document fresh-checkout theme build (#14589)

### DIFF
--- a/apps/agentos/childapps/dockdemo/README.md
+++ b/apps/agentos/childapps/dockdemo/README.md
@@ -13,9 +13,13 @@ and shared-heap pop-out journey. The dense living-data Workstation is a standalo
 
 ```bash
 npm install
+npm run build-themes -- -n -e dev -t all
 npm run server-start
 # → http://localhost:8080/apps/agentos/childapps/dockdemo/index.html
 ```
+
+The non-interactive theme build creates the ignored development CSS and `theme-map.json`
+artifacts a fresh checkout does not contain.
 
 ## The tour
 


### PR DESCRIPTION
Resolves #14589

The Demo-A dock choreography showcase was already delivered across its reviewed design, runner, screenplay, motion, and live-evidence PRs. This closes the stale parent leaf by fixing its one remaining honest residual: a fresh checkout now documents the non-interactive theme build required before starting the development server.

Evidence: L3 (exact-head Neural Link browser journey plus deterministic replay evidence from the shipped leaves) → L3 required (the public route, real dock motion, and committed App-Worker truth are acceptance criteria). No residuals.

## Deltas from ticket

- The literal "every shipped v1 op" wording is superseded. Demo A intentionally choreographs its story-scoped split, resize, re-tab, and auto-hide/reveal classes; the dock vocabulary has since expanded with operations outside this showcase.
- The literal `observe_motion` wording is superseded by the stronger rendered-DOM `requestAnimationFrame` geometry oracle plus the counted `DockMotionSignal` start/settle contract.
- "Exclusively through NL tool calls" is corrected at the architecture boundary: every tour beat uses the app-side `DockService` contract that backs the Neural Link tools. Requiring an MCP self-hop inside the app would add a second transport dependency without improving drivability.
- This PR changes no runtime behavior. It documents the ignored theme artifacts that a clean tree lacks and the exact non-interactive command that creates them.

## Test Evidence

- Design-first ordering: PR #14690 merged the reviewed three-scene artifact before the showcase implementation.
- Canonical operation path and public demo: PRs #14625 and #14912 shipped the Neural Link dock tools, `TourRunner`, screenplay, childapp, and cross-family-reviewed live journey.
- Motion: PR #14944 shipped the shared FLIP layer; `DockMotionNL.spec.mjs` covers real intermediate geometry and signal settlement across the live motion classes.
- Determinism: the Demo-A screenplay unit runs twice with identical logs; PR #15107 adds two consecutive live NL-triggered spec replays with complete-document restoration.
- Fresh-checkout correction: `npm run build-themes -- -n -e dev -t all` passed on this head, generating 635 development theme files and registering Demo A, Demo B, the AgentOS viewport, and the dashboard container in `resources/theme-map.json`.
- Exact-head public route: `WATCHPACK_POLLING=true NEO_E2E_PORT=8135 npx playwright test test/playwright/e2e/dashboard/DemoATourNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` → 1 passed in 9.7s; observed 3 rail tabs, an executable reveal, 5 FLIP samples, clean rollback, and final App-Worker truth.
- Hygiene: commit-time whitespace hook and `git diff --check` passed; the docs-only agent preflight had no source gates to run.

## Post-Merge Validation

- [ ] Run the documented three-command sequence in a new clone and open the published Demo-A URL.

Related: #13158 · #14690 · #14625 · #14912 · #14944 · #15107

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session adddb25d-fc36-4b08-b9a3-3a62a108cda1.
