### PR TITLE
fix(dockdemo): preserve panes across topology gaps (#15178)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -99,9 +99,9 @@ class DemoBWorkspace extends Container {
     tourRunner = null
     /**
      * Pane instances by item id — created ONCE, handed across every re-projection and
-     * parked only for explicit window moves, torn down only with the workspace. THE
-     * object-permanence substrate: `resolvePane` hands the adapter these live instances,
-     * so no morph, pop-out, or reattach ever remounts a pane.
+     * parked for explicit window moves or an unrestored topology remainder, torn down only
+     * with the workspace. THE object-permanence substrate: `resolvePane` hands the adapter
+     * these live instances, so no morph, pop-out, or reattach ever remounts a pane.
      * @member {Object} paneCache={}
      * @protected
      */
@@ -119,6 +119,13 @@ class DemoBWorkspace extends Container {
      * @member {Object|null} restoreReport=null
      */
     restoreReport = null
+    /**
+     * The serialized projection queue. Exposing its settled promise keeps topology specs on
+     * the same deferred view-sync boundary as the live tour instead of racing the next commit.
+     * @member {Promise} refreshPromise=Promise.resolve()
+     * @protected
+     */
+    refreshPromise = Promise.resolve()
     /**
      * Beats executed in the current run — the pip strip's progress counter.
      * @member {Number} beatCount=0
@@ -321,8 +328,7 @@ class DemoBWorkspace extends Container {
                 return {errors: activated.errors, loaded: false, report: preview.report}
             }
 
-            preview.hasLivePopup && (me.popupDocument = preview.documents[1]);
-            me.onDockZoneDocumentChange(preview.documents[0]);
+            me.commitTopologyRestore(preview);
 
             return {errors: [], loaded: true, report: preview.report}
         }
@@ -336,6 +342,26 @@ class DemoBWorkspace extends Container {
         me.onDockZoneDocumentChange(result.document);
 
         return {errors: [], loaded: true}
+    }
+
+    /**
+     * @summary Commits a validated topology result while preserving panes that remain owner-held
+     * but cannot be projected because their captured window is not live.
+     * @param {Object} result
+     * @param {Object[]} result.documents Reconciled documents for the currently live topology.
+     * @param {Boolean} result.hasLivePopup Whether a second render target currently exists.
+     * @param {Object} result.report Structured reconciliation remainder.
+     * @returns {Promise}
+     * @protected
+     */
+    commitTopologyRestore({documents, hasLivePopup, report}) {
+        let me            = this,
+            liveDocuments = hasLivePopup ? documents.slice(0, 2) : documents.slice(0, 1);
+
+        me.parkUnrestoredPanes(liveDocuments, report);
+        hasLivePopup && (me.popupDocument = documents[1]);
+
+        return me.onDockZoneDocumentChange(documents[0])
     }
 
     /**
@@ -369,12 +395,32 @@ class DemoBWorkspace extends Container {
             return {documents: result.documents, errors: result.errors, hasLivePopup, loaded: false, report}
         }
 
-        if (commit) {
-            hasLivePopup && (me.popupDocument = result.documents[1]);
-            me.onDockZoneDocumentChange(result.documents[0])
-        }
+        commit && me.commitTopologyRestore({documents: result.documents, hasLivePopup, report});
 
         return {documents: result.documents, errors: [], hasLivePopup, loaded: true, report}
+    }
+
+    /**
+     * @summary Parks cached panes represented by an unrestored topology remainder before the
+     * shared reconciler can classify their temporary projection absence as a true removal.
+     * @param {Object[]} liveDocuments Documents that have an actual render target.
+     * @param {Object} report Structured topology reconciliation remainder.
+     * @protected
+     */
+    parkUnrestoredPanes(liveDocuments, report) {
+        let me              = this,
+            liveItemIds     = new Set(liveDocuments.flatMap(document => Object.keys(document?.items || {}))),
+            unrestoredItems = new Set((report?.unrestored || []).map(entry => entry.itemId));
+
+        unrestoredItems.forEach(itemId => {
+            let pane = me.paneCache[itemId];
+
+            if (!liveItemIds.has(itemId) && pane && !pane.isDestroyed) {
+                // The pane is still owned by Demo B, just not by a currently renderable document.
+                // Remove without destroy BEFORE projection so true-removal retirement never sees it.
+                pane.parent?.remove(pane, false)
+            }
+        })
     }
 
     /**
@@ -406,17 +452,20 @@ class DemoBWorkspace extends Container {
      * The view-sync half: stores the committed document and re-projects, deferred one tick
      * (the normative guard — a committing interaction surface is never destroyed mid-handler).
      * @param {Object} document
+     * @returns {Promise}
      */
     onDockZoneDocumentChange(document) {
         let me = this;
 
         me.dockModel = document;
 
-        me.timeout(0).then(() => {
-            if (!me.isDestroyed) {
-                me.refreshDockWorkspace()
-            }
-        })
+        me.refreshPromise = me.refreshPromise
+            .then(() => me.timeout(0))
+            .then(() => {
+                if (!me.isDestroyed) return me.refreshDockWorkspace()
+            });
+
+        return me.refreshPromise
     }
 
     /**

--- a/learn/agentos/HarnessDockZoneModel.md
+++ b/learn/agentos/HarnessDockZoneModel.md
@@ -456,6 +456,8 @@ This aligns the adapter with stale `componentRef` restore behavior: runtime comp
 
 Repeated projections add one ownership rule: the adapter remains pure and stateless, while `DockProjectionReconciler` keys surviving tab containers by `dockNodeId` and moves each pane/header-button pair before moving its retained tab-container ancestor. The reconciler commits those descendant and ancestor handoffs separately; app-local code owns only its pane resolver, animation, and app-specific menu readiness. Workstation and Dock Demo B exercise the same transaction with different pane policies, keeping the projection contract reusable without making `DockLayoutAdapter` stateful.
 
+The resolver may return either an existing live component or a materializable component config; the reconciler normalizes an inserted config to its one live instance. Once every projected tabs destination is known, a live pane/header-button pair absent from all of them is a **true projection retirement** and is destroyed exactly once. This cleanup cannot infer broader app ownership from a single committed document. A consumer that intentionally retains a pane outside the currently renderable projection — for example, during a popup handoff or as an unrestored `no-live-window` topology remainder — must park that live instance with a non-destroying removal before reconciliation. A cache guard that recreates an `isDestroyed` entry is recovery safety, not identity preservation.
+
 ## Demand Validation
 
 The contract is justified by two independent shapes:

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
@@ -227,6 +227,15 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
             expect(loaded.report.displaced).toEqual([{itemId: 'workbench', liveIndex: 0}]);
             expect(workspace.dockModel.items.workbench).toBeUndefined();
 
+            // Let the changed-topology projection fully settle while Workbench has no live
+            // render target. This is the exact interval where true-removal retirement used
+            // to destroy the instance and the synchronous test immediately restored Focus.
+            await workspace.refreshPromise;
+
+            expect(pane.isDestroyed, 'the topology remainder keeps Workbench live').toBeFalsy();
+            expect(Boolean(pane.parent?.items?.includes(pane)), 'the live pane is parked outside the old projection')
+                .toBe(false);
+
             const report = workspace.getReference('restore-report-b');
 
             expect(report.hidden).toBe(false);
@@ -234,8 +243,9 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
             expect(report.html).toContain('workbench (no-live-window)');
 
             expect(workspace.loadPerspectiveByName('Focus').loaded).toBe(true);
+            await workspace.refreshPromise;
             expect(workspace.resolvePane('workbench', initialDocument.items.workbench)).toBe(pane);
-            expect(pane.frames).toBe(41)
+            expect(pane.frames).toBeGreaterThanOrEqual(41)
         } finally {
             vessel.restore()
         }


### PR DESCRIPTION
Resolves #15178

Demo B now parks owner-retained panes before committing a changed-topology result whose captured window is not live, so the shared projection reconciler never mistakes temporary unrenderability for a true removal. The deferred projection path is serialized and awaitable, the existing topology unit now settles the exact absence window, and the durable dock-zone contract distinguishes config materialization, true retirement, and app-owner parking.

Evidence: L3 (unchanged mounted Neural Link journey with a real popup, shared App Worker, settled changed-topology gap, and exact CounterPane identity) → L3 required (runtime object permanence plus the popup/topology round trip). No residuals.

Related: #15171

Related: #13158

## Deltas from ticket

- Kept `DockProjectionReconciler`'s true-removal behavior unchanged; the app owner has the missing topology-remainder information and parks only `unrestored` cached panes absent from every live target document.
- Serialized Demo B's deferred refreshes through `refreshPromise`, letting unit coverage await the same settled boundary exercised by the live tour instead of restoring Focus before retirement could run.
- Added no synthetic Workstation rail-collapse journey: current Workstation source exposes two initially railed items but no retire-then-return operation. Its hypothetical cache-recreation path is not this regression.
- Updated `HarnessDockZoneModel.md` so a destroyed-cache guard is documented as recovery safety, not identity preservation.

## Test Evidence

- Regression falsifier on merged `origin/dev` (`bdd741ff1`): `NEO_E2E_PORT=8117 npx playwright test agentos/DemoBPerspectivesNL -c test/playwright/playwright.config.e2e.mjs --workers=1` failed because Focus restored `neo-component-86` instead of original `neo-component-1`.
- Demo B owner policy: `npm run test-unit -- apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs --workers=1` — 12 passed.
- Shared reconciler contract: `npm run test-unit -- dashboard/DockProjectionReconciler.spec.mjs --workers=1` — 5 passed, including config materialization once and true pane/button retirement once.
- Mounted Neural Link regression journey at `da727b2c7`: same E2E command — 1 passed in 46.0s; two deterministic popup/topology runs preserved the original CounterPane and monotonic instance-local frames.
- Theme prerequisite: `npm run build-themes -- -n -e dev -t all` — 635 files built, exit 0.
- Source gates: scoped repair + check-only `npm run agent-preflight`, full `check-jsdoc-types` (1,767 files), commit hooks, and `git diff --check` all passed.

## Post-Merge Validation

- [ ] Re-run `DemoBPerspectivesNL` once on merged `dev` to guard integration drift at the merge commit.

## Substrate Slot Rationale

`learn/agentos/HarnessDockZoneModel.md` is opt-in architectural authority rather than per-turn loaded substrate. Disposition: **keep** the added paragraph beside Component Identity Handoff because projection-lifetime mistakes cause silent state loss and the shared reconciler now has multiple consumers. Enforcement is split between the reconciler unit (materialize/retire) and Demo B's unit + L3 journey (owner-park). Retirement trigger: update or remove the paragraph if the reconciler gains a different explicit lifetime-policy API that supersedes owner-side parking.

## Evolution

Vega's non-blocking review challenge correctly identified the prior instance-cache consumers but generalized Workstation's provider-owned stores to Demo B. The unchanged L3 falsifier showed that `CounterPane.frames` is deliberately instance-local and resets after the `!isDestroyed` guard recreates the pane. The implementation therefore corrects the ownership boundary instead of merely adding coverage or persisting the witness state.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session adddb25d-fc36-4b08-b9a3-3a62a108cda1.
