### PR TITLE
docs(workstation): document fresh-checkout theme build (#15179)

### DIFF
--- a/apps/workstation/README.md
+++ b/apps/workstation/README.md
@@ -10,9 +10,13 @@ It is an independent application under `apps/workstation/` with its own boot sur
 
 ```bash
 npm install
+npm run build-themes -- -n -e dev -t all
 npm run server-start
 # → http://localhost:8080/apps/workstation/index.html
 ```
+
+The non-interactive theme build creates the ignored development CSS and `theme-map.json`
+artifacts a fresh checkout does not contain.
 
 Press **Start dense tour**. The screenplay opens the real overflow menu, scrolls the 100k grid,
 promotes a live pane through `splitNode`, returns it through `addTab`, and flips both themes.


### PR DESCRIPTION
Resolves #15179

Workstation's standalone README now carries the same verified fresh-checkout sequence as Dock Demo: install, non-interactive development theme build, then server start. The complete `apps/**/README.md` census found no other runnable sequence requiring a change.

Evidence: L1 (the exact documented command built 635 development theme files and registered Workstation in `resources/theme-map.json`) -> L1 required (documentation-only setup correction). No residuals.

Related: #15146
Related: #14589
Related: #13158

## Deltas from ticket

- Corrected the explanatory location: application theme CSS is generated under `dist/development/css/**`; `resources/theme-map.json` is generated separately. Both are ignored. The README keeps the accurate user-facing "ignored development CSS and `theme-map.json`" wording.
- Audited all four `apps/**/README.md` files. Dock Demo already has the three-command sequence from merged PR #15177; Colors and RealWorld2 contain no local run instructions and are N/A. Only Workstation required a change.
- Did not create a shared run guide or change install hooks; the two showcase READMEs remain self-contained.

## Test Evidence

- Workstation setup: `npm run build-themes -- -n -e dev -t all` - 635 files, exit 0; generated Workstation source/dark/light CSS and `theme-map.json` entries for `apps.workstation.Viewport` plus a source entry for `Workspace`.
- README census: `rg --files apps -g 'README.md'` - four files; only Workstation and Dock Demo contain local run sequences.
- Hygiene: `npm run agent-preflight -- --no-fix apps/workstation/README.md` and `git diff --check` passed.

## Post-Merge Validation

- [ ] Follow the three-command sequence from a clean checkout and open `http://localhost:8080/apps/workstation/index.html`.

## Evolution

The ticket described "`apps/**` development CSS"; live `themes.mjs` behavior and generated output place those files under `dist/development/css/**`. The implementation preserves the correct user-facing instruction while keeping filesystem claims exact.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex), consuming Vega's A+FU handoff - session A `a8b22c4c-dc82-440e-a8fb-95570036aa4e`, session B `adddb25d-fc36-4b08-b9a3-3a62a108cda1`.
