### PR TITLE
fix(drag): add gesture readiness and cancellation (#14980)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoAWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoAWorkspace.mjs
@@ -106,20 +106,12 @@ class DemoAWorkspace extends Container {
     beatCount = 0
     /**
      * Measured drag-session geometry (host rect + tabs-zone rects + the chips' root target),
-     * built lazily on the first drag-move of a gesture and invalidated on drop, Escape, and
-     * every re-projection. Doubles as the drag-active flag for the Escape guard. Runtime-only.
+     * built lazily on the first drag-move of a gesture and invalidated on drop, cancel, and
+     * every re-projection. Runtime-only.
      * @member {Object|null} dragGeometry=null
      * @protected
      */
     dragGeometry = null
-    /**
-     * Set by mid-drag Escape: the §06 cancel — indicator menu and preview clear immediately,
-     * and the release commits NOTHING. The proxy visual stays with the base drag until
-     * release (no drag-layer abort API exists; documented residual on the ticket).
-     * @member {Boolean} dragSuppressed=false
-     * @protected
-     */
-    dragSuppressed = false
     /**
      * The in-flight deferred re-projection, tracked as an awaitable. Every committed
      * operation defers its view-sync one tick ({@link #onDockZoneDocumentChange}); any
@@ -158,10 +150,6 @@ class DemoAWorkspace extends Container {
             scene   : me.onTourScene,
             scope   : me
         });
-
-        // Escape = the §06 mid-drag cancel; the keydown bubbles up from the dragged tab
-        // button (focus lives inside the projection during a header drag).
-        me.addDomListeners([{keydown: me.onWorkspaceKeyDown, scope: me}]);
 
         me.add([me.createTourBar(), {
             module   : Container,
@@ -280,15 +268,14 @@ class DemoAWorkspace extends Container {
 
     /**
      * Ends a drag affordance session: geometry cache dropped (it doubles as the drag-active
-     * flag), Escape suppression reset, indicator menu and preview cleared. Called on drop,
-     * on Escape, and by every re-projection.
+     * flag), indicator menu and preview cleared. Called on drop, cancel, and by every
+     * re-projection.
      * @protected
      */
     clearDragAffordances() {
         let me = this;
 
-        me.dragGeometry   = null;
-        me.dragSuppressed = false;
+        me.dragGeometry = null;
 
         me.getReference('drop-indicators')?.clear();
 
@@ -377,14 +364,13 @@ class DemoAWorkspace extends Container {
      * @param {Object} data {clientX, clientY, itemId, sourceNodeId}
      */
     async onDockCrossZoneDragMove({clientX, clientY, itemId, sourceNodeId}) {
-        let me = this;
+        let me              = this,
+            geometryPromise = me.ensureDragGeometry(),
+            geometry        = await geometryPromise;
 
-        if (me.dragSuppressed) return;
-
-        let geometry = await me.ensureDragGeometry();
-
-        // re-check after the await: Escape or a re-projection may have ended the session
-        if (!geometry || me.dragSuppressed || me.isDestroyed) return;
+        // Re-check the promise identity after the await: cancel or re-projection invalidates
+        // this gesture's geometry, so a late measurement can never resurrect its overlays.
+        if (!geometry || me.dragGeometry !== geometryPromise || me.isDestroyed) return;
 
         let pointer    = {x: clientX, y: clientY},
             indicators = me.getReference('drop-indicators'),
@@ -424,32 +410,29 @@ class DemoAWorkspace extends Container {
      * left the menu after hovering an indicator must not commit the stale selection), and a
      * candidate only counts when it was built for the item THIS gesture drags. A release-point
      * indicator wins over pointer inference — the §06 tier order — and both commit through
-     * `previewToOperation` unchanged. An Escape-suppressed gesture commits nothing. Same-zone
+     * `previewToOperation` unchanged. A cancelled gesture never reaches this drop seam. Same-zone
      * pointer drops stay excluded from the fallback (the within-toolbar reorder already
      * handled them); indicator drops keep self-targets deliberately (splitting your own zone
      * is a real operation).
      * @param {Object} data {clientX, clientY, itemId, sourceNodeId}
      */
     async onDockCrossZoneDrop({clientX, clientY, itemId, sourceNodeId}) {
-        let me         = this,
-            suppressed = me.dragSuppressed,
-            geometry   = me.dragGeometry ? await me.dragGeometry : null,
-            pointer    = {x: clientX, y: clientY},
-            preview    = null;
+        let me       = this,
+            geometry = me.dragGeometry ? await me.dragGeometry : null,
+            pointer  = {x: clientX, y: clientY},
+            preview  = null;
 
-        if (!suppressed) {
-            let candidate = me.getReference('drop-indicators')?.hitTest(pointer);
+        let candidate = me.getReference('drop-indicators')?.hitTest(pointer);
 
-            if (candidate?.preview?.itemId === itemId) {
-                preview = candidate.preview
-            } else if (geometry) {
-                preview = me.dockPreviewProducer.produce({
-                    pointer,
-                    zones: geometry.zones.filter(zone => zone.nodeId !== sourceNodeId),
-                    itemId,
-                    sourceNodeId
-                })
-            }
+        if (candidate?.preview?.itemId === itemId) {
+            preview = candidate.preview
+        } else if (geometry) {
+            preview = me.dockPreviewProducer.produce({
+                pointer,
+                zones: geometry.zones.filter(zone => zone.nodeId !== sourceNodeId),
+                itemId,
+                sourceNodeId
+            })
         }
 
         me.clearDragAffordances();
@@ -466,23 +449,13 @@ class DemoAWorkspace extends Container {
     }
 
     /**
-     * Escape during a live drag cancels the affordance session (§06, absorbs tree line C5):
-     * menu and preview clear instantly, the release commits nothing. Outside a drag the key
-     * passes through untouched.
-     * @param {Object} data The keydown event data.
+     * Consumes the dock-aware projection's generic `drag:cancel` seam: the main-thread drag
+     * owner already suppresses the native release, so this workspace only retires transient
+     * geometry, menu, and preview state.
+     * @param {Object} data The dock drag identity payload.
      */
-    onWorkspaceKeyDown(data) {
-        let me = this;
-
-        if (data.key === 'Escape' && me.dragGeometry) {
-            me.dragSuppressed = true;
-
-            me.getReference('drop-indicators')?.clear();
-
-            let preview = me.getReference('dock-preview');
-
-            preview && (preview.dockPreview = null)
-        }
+    onDockCrossZoneDragCancel(data) {
+        this.clearDragAffordances()
     }
 
     /**
@@ -552,6 +525,7 @@ class DemoAWorkspace extends Container {
         return DockLayoutAdapter.project(document, {
             ...demoATourScript.workspace,
             applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
+            onDockCrossZoneDragCancel: me.onDockCrossZoneDragCancel.bind(me),
             onDockCrossZoneDragMove : me.onDockCrossZoneDragMove.bind(me),
             onDockCrossZoneDrop     : me.onDockCrossZoneDrop.bind(me),
             onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -279,6 +279,7 @@ class DockLayoutAdapter extends Base {
             dockZoneDocument         : options.dockZoneDocument || model,
             items                    : model.items || {},
             nodes                    : model.nodes,
+            onDockCrossZoneDragCancel: options.onDockCrossZoneDragCancel,
             onDockCrossZoneDragMove  : options.onDockCrossZoneDragMove,
             onDockCrossZoneDrop      : options.onDockCrossZoneDrop,
             onDockZoneDocumentChange : options.onDockZoneDocumentChange,
@@ -719,6 +720,9 @@ class DockLayoutAdapter extends Base {
             },
             items    : projectedItems,
             listeners: {
+                // Cancel is a gesture lifecycle signal, not a synthetic drop: the workspace clears
+                // transient affordances while the sort zone restores its captured layout.
+                dockCrossZoneDragCancel: data => context.onDockCrossZoneDragCancel?.(data),
                 // Live-drag hover: the dock-aware SortZone streams `dockCrossZoneDragMove` per frame; the
                 // owner renders the transient affordance tier (indicator menu / preview) from it. Same
                 // closure-captured context seam as the drop below.

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -192,13 +192,16 @@ class DockTabSortZone extends TabHeaderSortZone {
             {clientX, clientY} = data || {};
 
         if (me.sortGroup && me.dragComponent) {
-            me.dragCoordinator?.onDragEnd({
+            me.dragCoordinator?.[data.cancelled ? 'onDragCancel' : 'onDragEnd']({
                 draggedItem   : me.dragComponent,
                 sourceSortZone: me
             })
         }
 
-        if (me.remoteDropCommitted) {
+        if (data.cancelled) {
+            me.remoteDropCommitted = false;
+            itemId && tabContainer?.fire('dockCrossZoneDragCancel', {itemId, sourceNodeId: me.dockSourceNodeId})
+        } else if (me.remoteDropCommitted) {
             me.remoteDropCommitted = false
         } else if (itemId && tabContainer && Neo.isNumber(clientX) && Neo.isNumber(clientY)) {
             tabContainer.fire('dockCrossZoneDrop', {clientX, clientY, itemId, sourceNodeId: me.dockSourceNodeId})

--- a/src/draggable/DragZone.mjs
+++ b/src/draggable/DragZone.mjs
@@ -495,6 +495,17 @@ class DragZone extends Base {
     }
 
     /**
+     * Handles the first-class gesture-cancel signal. Base drag zones have no semantic drop
+     * work to undo, so cancellation fires its own observable event and tears down the proxy
+     * immediately. Sort zones override this entry to restore their captured layout first.
+     * @param {Object} data
+     */
+    onDragCancel(data) {
+        this.fire('dragCancel', data);
+        this.dragEnd({...data, cancelled: true})
+    }
+
+    /**
      * You can either extend this class and override the handler or listen to the event from the outside
      * @param {Object} data
      */

--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -353,6 +353,27 @@ class SortZone extends DragZone {
     }
 
     /**
+     * Cancels an active sort without applying its transient index. The normal end pipeline still
+     * owns placeholder/proxy/layout cleanup, while `cancelled` makes every commit branch fail shut.
+     * @param {Object} data The `drag:cancel` event data.
+     */
+    async onDragCancel(data={}) {
+        let me = this;
+
+        if (!me.dragComponent || me.dragEndActive) {
+            return
+        }
+
+        me.currentIndex     = me.startIndex;
+        me.isOverDragging   = false;
+        me.isWindowDragging = false;
+
+        me.fire('dragCancel', data);
+
+        await me.onDragEnd({...data, cancelled: true})
+    }
+
+    /**
      * Drag:end entry point. The drag listeners fan out across the owner and its child items, so one
      * native release can deliver multiple drag:end events. This entry latches synchronously and routes
      * exactly one delivery into {@link #processDragEnd} — without it, the async drop pipeline runs
@@ -467,7 +488,7 @@ class SortZone extends DragZone {
                 me.dragComponent.wrapperStyle = style;
             }
 
-            if (!me.isWindowDragging && !me.isRemoteDragging && me.startIndex !== me.currentIndex) {
+            if (!data.cancelled && !me.isWindowDragging && !me.isRemoteDragging && me.startIndex !== me.currentIndex) {
                 let fromIndex, toIndex;
 
                 if (me.dragPlaceholder) {
@@ -486,7 +507,7 @@ class SortZone extends DragZone {
                 // calling into a destroyed owner chain throws.
                 me.owner?.isDestroyed || me.moveTo(fromIndex, toIndex);
             } else {
-                me.traceEvent({t: 'end', from: me.startIndex, to: me.currentIndex, noop: true});
+                me.traceEvent({t: data.cancelled ? 'cancel' : 'end', from: me.startIndex, to: me.currentIndex, noop: true});
             }
 
             // activeTrace stays set until the next onDragStart replaces it: subclasses record

--- a/src/draggable/dashboard/SortZone.mjs
+++ b/src/draggable/dashboard/SortZone.mjs
@@ -291,7 +291,7 @@ class DashboardSortZone extends SortZone {
         let me = this;
 
         if (!me.isRemoteDragging) {
-            DragCoordinator.onDragEnd({
+            DragCoordinator[data.cancelled ? 'onDragCancel' : 'onDragEnd']({
                 draggedItem   : me.dragComponent,
                 sourceSortZone: me
             })

--- a/src/draggable/grid/header/toolbar/SortZone.mjs
+++ b/src/draggable/grid/header/toolbar/SortZone.mjs
@@ -324,6 +324,13 @@ class SortZone extends BaseSortZone {
 
         await super.processDragEnd(data);
 
+        // Cancellation restores the captured index in the base pipeline and must not let the
+        // grid-specific post-end region inference mutate a column's locked state.
+        if (data.cancelled) {
+            me.dragColumnField = null;
+            return
+        }
+
         if (!me.dragElement) {
             return
         }

--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -45,6 +45,14 @@ class DragDrop extends Base {
          */
         dragElementRootId: null,
         /**
+         * True after Escape cancelled the active gesture and until the native sensor ends it.
+         * While set, move/end/drop traffic is suppressed because `drag:cancel` already closed
+         * the worker-side session.
+         * @member {Boolean} dragCancelled=false
+         * @protected
+         */
+        dragCancelled: false,
+        /**
          * @member {String} dragProxyCls='neo-dragproxy'
          */
         dragProxyCls: 'neo-dragproxy',
@@ -183,6 +191,7 @@ class DragDrop extends Base {
     addGlobalEventListeners() {
         let me = this;
 
+        document.addEventListener('keydown',    me.onKeyDown  .bind(me), true);
         document.addEventListener('drag:end',   me.onDragEnd  .bind(me), true);
         document.addEventListener('drag:move',  me.onDragMove .bind(me), true);
         document.addEventListener('drag:start', me.onDragStart.bind(me), true)
@@ -217,9 +226,7 @@ class DragDrop extends Base {
      * @param {Event} event
      */
     onDragEnd(event) {
-        let me          = this,
-            parsedEvent = me.getEventData(event),
-            isDrop      = me.pathIncludesDropZone(parsedEvent.targetPath);
+        let me = this;
 
         if (me.bodyCursorStyle) {
             DomAccess.setStyle({
@@ -230,27 +237,64 @@ class DragDrop extends Base {
             });
         }
 
-        DomEvents.sendMessageToApp({
-            ...parsedEvent,
-            dragZoneId: me.dragZoneId,
-            isDrop,
-            offsetX   : me.offsetX,
-            offsetY   : me.offsetY,
-            type      : 'drag:end'
-        });
+        if (!me.dragCancelled) {
+            let parsedEvent = me.getEventData(event),
+                isDrop      = me.pathIncludesDropZone(parsedEvent.targetPath);
 
-        if (isDrop) {
             DomEvents.sendMessageToApp({
-                ...DomEvents.getMouseEventData(event.detail.originalEvent),
+                ...parsedEvent,
                 dragZoneId: me.dragZoneId,
-                type      : 'drop'
+                isDrop,
+                offsetX   : me.offsetX,
+                offsetY   : me.offsetY,
+                type      : 'drag:end'
+            });
+
+            if (isDrop) {
+                DomEvents.sendMessageToApp({
+                    ...DomEvents.getMouseEventData(event.detail.originalEvent),
+                    dragZoneId: me.dragZoneId,
+                    type      : 'drop'
+                })
+            }
+        }
+
+        me.resetDragState()
+    }
+
+    /**
+     * Captures Escape at the gesture owner, independent of which dragged node still owns focus.
+     * A single `drag:cancel` is routed directly to the active worker drag zone; subsequent native
+     * move/end events are ignored until the sensor releases and resets the main-thread session.
+     * @param {KeyboardEvent} event
+     */
+    onKeyDown(event) {
+        let me = this;
+
+        if (event.key === 'Escape' && me.dragZoneId && !me.dragCancelled) {
+            me.dragCancelled = true;
+            event.preventDefault();
+
+            DomEvents.sendMessageToApp({
+                ...DomEvents.getKeyboardEventData(event),
+                dragZoneId: me.dragZoneId,
+                type      : 'drag:cancel'
             })
         }
+    }
+
+    /**
+     * Restores the main-thread drag owner to its between-gestures baseline.
+     * @protected
+     */
+    resetDragState() {
+        let me = this;
 
         Object.assign(me, {
             alwaysFireDragMove    : false,
             bodyCursorStyle       : null,
             boundaryContainerRect : null,
+            dragCancelled         : false,
             dragElementRootId     : null,
             dragElementRootRect   : null,
             dragProxyCls          : 'neo-dragproxy',
@@ -267,7 +311,7 @@ class DragDrop extends Base {
             popupWidth            : null,
             scrollContainerElement: null,
             scrollContainerRect   : null,
-            setScrollFactorLeft   : 1,
+            scrollFactorLeft      : 1,
             scrollFactorTop       : 1,
             windowName            : null
         })
@@ -282,6 +326,10 @@ class DragDrop extends Base {
             proxyRect       = me.dragProxyRect,
             rect            = me.boundaryContainerRect,
             data, left, top;
+
+        if (me.dragCancelled) {
+            return
+        }
 
         if (me.isWindowDragging) {
             const
@@ -372,6 +420,7 @@ class DragDrop extends Base {
             rect = event.target.getBoundingClientRect();
 
         Object.assign(me, {
+            dragCancelled: false,
             dragProxyRect: rect,
             offsetX      : event.detail.clientX - rect.left,
             offsetY      : event.detail.clientY - rect.top

--- a/src/manager/DomEvent.mjs
+++ b/src/manager/DomEvent.mjs
@@ -38,6 +38,7 @@ const globalDomEvents = [
     'click',
     'contextmenu',
     'dblclick',
+    'drag:cancel',
     'drag:end',
     'drag:move',
     'drag:start',
@@ -256,9 +257,12 @@ class DomEvent extends Base {
             let dragZone = data.dragZoneId && Neo.get(data.dragZoneId);
 
             if (dragZone) {
-                // drag:move & drag:end
                 if (eventName.startsWith('drag:')) {
-                    dragZone[eventName === 'drag:move' ? 'onDragMove' : 'onDragEnd']?.(data)
+                    dragZone[{
+                        'drag:cancel': 'onDragCancel',
+                        'drag:end'   : 'onDragEnd',
+                        'drag:move'  : 'onDragMove'
+                    }[eventName]]?.(data)
                 } else {
                     dragZone.fire(eventName, data);
                     dragZone[{

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -308,6 +308,30 @@ class DragCoordinator extends Manager {
     }
 
     /**
+     * Cancels cross-window arbitration without committing either the active remote target or
+     * the source's terminal-drop path. Target hover state is released before the source sort
+     * zone restores its captured layout.
+     * @param {Object} data
+     * @param {Neo.component.Base} data.draggedItem
+     * @param {Neo.draggable.container.SortZone} data.sourceSortZone
+     */
+    onDragCancel(data) {
+        let me               = this,
+            {sourceSortZone} = data;
+
+        if (me.activeTargetZone) {
+            me.activeTargetZone.onRemoteDragLeave();
+            me.activeTargetZone = null
+        }
+
+        for (const [windowId, candidate] of me.nativeWindowDropCandidates.entries()) {
+            if (candidate.sourceSortZone === sourceSortZone || candidate.targetSortZone === sourceSortZone) {
+                me.clearNativeWindowDropCandidate(windowId)
+            }
+        }
+    }
+
+    /**
      * @summary Handles geometry updates for native OS-titlebar popup reintegration.
      *
      * Consumes high-frequency window geometry updates for native OS-titlebar popup drags,

--- a/test/playwright/e2e/dashboard/DemoADragMenuNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DemoADragMenuNL.spec.mjs
@@ -37,14 +37,6 @@ async function bootDemo(page, neuralLink) {
     await page.waitForSelector('.agentos-dockdemo-tour-play',          {timeout: 20000});
     await page.waitForSelector('.neo-tab-header-button.neo-draggable', {timeout: 20000});
 
-    // Early-gesture drag-listener race (engine tier, pre-existing): a pointer drag started
-    // within ~1s of mount renders a proxy (main-thread addon) but is DEAF to every worker-side
-    // sort zone — their delegated drag:start/move DOM-listener registration round-trip has not
-    // landed yet, so no dock seam fires. The `.neo-draggable` cls is NOT a sufficient readiness
-    // witness (it lands before the listener registration). Bisected: probe at +0ms fails, at
-    // +1000ms lights the menu — settle until the engine exposes a registration-complete signal.
-    await page.waitForTimeout(1200);
-
     const app        = await neuralLink.connectToApp('AgentOSDockDemo');
     const workspaces = await app.findInstances({className: 'AgentOS.childapps.dockdemo.view.DemoAWorkspace'}, ['id']);
     const wsId       = Array.isArray(workspaces) ? workspaces[0]?.id : workspaces?.id;
@@ -77,8 +69,12 @@ async function dragPreviewHeaderTo(page, target) {
 
     await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
     await page.mouse.down();
-    // clear the drag threshold first, then travel — real pointer cadence
+    // Clear the distance threshold, then wait for the App Worker to finish the drag-start
+    // handshake. This starts at first paint without a boot settle while respecting the Mouse
+    // sensor's intentional 100ms click-vs-drag delay. `neo-is-dragging` is worker-stamped after
+    // main-thread configs land, so the target leg cannot outrun drag readiness.
     await page.mouse.move(box.x + box.width / 2 + 12, box.y + box.height / 2 + 12, {steps: 4});
+    await expect(page.locator('.neo-tab-header-toolbar.neo-is-dragging')).toBeVisible();
     await page.mouse.move(target.x, target.y, {steps: 15});
     // let the move stream round-trip (main thread → worker → vdom → DOM)
     await page.waitForTimeout(400)
@@ -271,17 +267,15 @@ test.describe('Demo-A drop-indicator menu: the real-pointer §06 journey (Neural
 
         await expect(page.locator('.neo-dashboard-dock-drop-indicators:not(.neo-dashboard-dock-drop-indicators-hidden)')).toBeVisible();
 
-        // Keystroke delivery note: the base sort zone placeholder-swaps the dragged button out
-        // of the DOM, so browser focus falls to <body> and an element-scoped keydown listener
-        // cannot receive a real Escape mid-drag — gesture-time key capture is an engine-tier
-        // primitive gap (ticketed with the drag-listener race). The CANCEL SEAM itself is
-        // exercised end-to-end here: the workspace's Escape handler fires mid-REAL-drag, and
-        // the REAL pointer release proves the commit suppression.
-        await app.callMethod(wsId, 'onWorkspaceKeyDown', [{key: 'Escape'}]);
-        await page.waitForTimeout(300);
+        // Focus has fallen to <body> after the placeholder swap. The main-thread drag owner
+        // captures the REAL key and routes `drag:cancel` directly to the active worker zone.
+        await page.keyboard.press('Escape');
 
-        // the §06 cancel: menu + preview clear while the pointer is still down
+        // The §06 cancel is complete while the pointer is still down: affordances clear,
+        // worker drag state retires, and the proxy is destroyed rather than riding to release.
         await expect(page.locator('.neo-dashboard-dock-drop-indicators')).toHaveClass(/neo-dashboard-dock-drop-indicators-hidden/);
+        await expect(page.locator('.neo-tab-header-toolbar.neo-is-dragging')).toHaveCount(0);
+        await expect(page.locator('.neo-dragproxy')).toHaveCount(0);
 
         await page.mouse.up();
         await page.waitForTimeout(500);

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoAWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoAWorkspace.spec.mjs
@@ -172,6 +172,22 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoAWorkspace', () => {
         expect(JSON.stringify(workspace.getDockZoneDocument())).toBe(before)
     });
 
+    test('the drag-cancel seam invalidates geometry and clears both affordance layers', () => {
+        const
+            indicators = workspace.getReference('drop-indicators'),
+            preview    = workspace.getReference('dock-preview');
+
+        workspace.dragGeometry = Promise.resolve({hostRect: {}, zones: []});
+        indicators.candidateSet = {candidates: []};
+        preview.dockPreview     = {itemId: 'editor'};
+
+        workspace.onDockCrossZoneDragCancel({itemId: 'editor', sourceNodeId: 'editor-tabs'});
+
+        expect(workspace.dragGeometry).toBeNull();
+        expect(indicators.candidateSet).toBeNull();
+        expect(preview.dockPreview).toBeNull()
+    });
+
     test('a release ON an indicator commits exactly that candidate (positive control)', async () => {
         const indicators = workspace.getReference('drop-indicators');
         const zones      = [{nodeId: 'side-tabs', rect: {x: 400, y: 0, width: 400, height: 600}, orientation: null}];

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -435,6 +435,48 @@ test.describe('Neo.dashboard.DockCrossWindowParticipation (ADR 0029 §2.3 — wo
         zone.destroy()
     });
 
+    test('drag:cancel releases remote hover and emits only the dock cancel seam', async () => {
+        const
+            fires  = [],
+            leaves = [];
+
+        const zone = Neo.create(DockTabSortZone, {
+            dockItemIds     : ['terminal'],
+            dockSourceNodeId: 'side-tabs',
+            dockWorkspaceId : 'A',
+            owner           : {
+                addDomListeners: () => {},
+                cls            : [],
+                dragResortable : false,
+                items          : [],
+                on             : () => {},
+                style          : {},
+                up             : () => ({fire: (name, data) => fires.push([name, data])})
+            },
+            sortGroup: 'dock-crosswindow-cancel-test',
+            windowId : 'cwd-cancel-a'
+        });
+
+        await zone.resolveDragCoordinator();
+        zone.dragCoordinator = DragCoordinator;
+        zone.dragComponent   = {id: 'tab-proxy', dockItemId: 'terminal', dockSourceWorkspaceId: 'A'};
+        zone.startIndex      = 0;
+
+        DragCoordinator.activeTargetZone = {
+            onRemoteDragLeave: () => leaves.push('leave'),
+            onRemoteDrop     : () => { throw new Error('cancel must never commit the remote target') }
+        };
+
+        await zone.processDragEnd({cancelled: true});
+
+        expect(leaves).toEqual(['leave']);
+        expect(DragCoordinator.activeTargetZone).toBeNull();
+        expect(fires.filter(([name]) => name === 'dockCrossZoneDragCancel')).toHaveLength(1);
+        expect(fires.filter(([name]) => name === 'dockCrossZoneDrop')).toHaveLength(0);
+
+        zone.destroy()
+    });
+
     test('a source zone without a sortGroup is coordinator-inert: no remote engagement, no suspension — the dock stays fully in-window', async () => {
         const previews = [];
 

--- a/test/playwright/unit/draggable/container/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/container/SortZone.spec.mjs
@@ -155,6 +155,23 @@ test.describe.serial('Neo.draggable.container.SortZone', () => {
         expect(container.items[4].id).toBe('btnA');
     });
 
+    test('drag:cancel restores the captured index and commits no reorder', async () => {
+        await new Promise(resolve => setTimeout(resolve, 10));
+        sortZone = container.sortZone;
+
+        await sortZone.onDragStart({
+            path: [{id: 'btnA', cls: ['neo-draggable'], rect: {left: 0, top: 0, width: 100, height: 100}}]
+        });
+
+        sortZone.currentIndex = 2;
+
+        await sortZone.onDragCancel({key: 'Escape'});
+
+        expect(container.items.map(item => item.id)).toEqual(['btnA', 'btnB', 'sep1', 'btnC', 'btnD']);
+        expect(sortZone.currentIndex).toBe(-1);
+        expect(sortZone.dragProxy).toBeNull()
+    });
+
      test('Correctly handles placeholder in index calculation', async () => {
         await new Promise(resolve => setTimeout(resolve, 10));
         sortZone = container.sortZone;

--- a/test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs
@@ -64,4 +64,38 @@ test.describe('Neo.draggable.grid.header.toolbar.SortZone', () => {
         const noLocked = {lockedStartColumns: {length: 0}, centerColumns: {length: 4}, lockedEndColumns: {length: 0}};
         expect(columnIndexOffset.call({owner: {gridContainer: noLocked, layoutLock: null}})).toBe(0)
     })
+
+    test('a cancelled end skips grid lock-region inference after base cleanup', async () => {
+        const
+            dragComponent = {wrapperStyle: {}},
+            owner         = {
+                addDomListeners: () => {},
+                cls            : [],
+                dragResortable : true,
+                items          : [dragComponent],
+                on             : () => {},
+                style          : {},
+                vdom           : {cn: []}
+                // Deliberately no gridContainer: reaching lock inference would throw.
+            },
+            zone = Neo.create(SortZone, {owner});
+
+        Object.assign(zone, {
+            currentIndex   : 0,
+            dragColumnField: 'alpha',
+            dragComponent,
+            itemStyles     : [{}],
+            ownerStyle     : {},
+            sortableItems  : [dragComponent],
+            startIndex     : 0,
+            timeout        : () => Promise.resolve()
+        });
+
+        await zone.processDragEnd({cancelled: true});
+
+        expect(zone.dragColumnField).toBeNull();
+        expect(zone.currentIndex).toBe(-1);
+
+        zone.destroy()
+    })
 });


### PR DESCRIPTION
Resolves #14980

Drag gestures now expose two honest lifecycle contracts. Cold Demo-A drags begin without a boot delay and hold their target leg until the App Worker stamps `.neo-is-dragging`. During an active gesture, the main-thread `DragDrop` owner captures a real Escape independently of DOM focus, emits one `drag:cancel` to the active worker zone, and suppresses every later move/end/drop from that native gesture. Worker sort zones restore captured layout without committing; cross-window hover and grid-specific semantic tails also fail shut. Demo A consumes only the projected cancel seam to retire its transient overlays.

Evidence: L3 (real cold-start pointer + real Escape in local Chromium through Neural Link) → L3 required (AC1–AC4 observable gesture lifecycle). No residuals.

## Deltas from ticket

- The falsifier rejected the ticket's listener-registration premise. The worker completed `drag:start`; the scripted pointer exhausted its travel before the Mouse sensor's intentional 100 ms delay, leaving no post-arm `drag:move`. The fix therefore reuses the existing worker-stamped readiness witness instead of inventing a listener handshake.
- A first-class cancel event necessarily crosses the shared drag stack. The implementation covers base drag zones, container sorts, cross-window arbitration, dashboard sorts, dock projection, and the grid header's post-end lock inference so “cancel” cannot become a dock-only alias for “drop later.”

## Test Evidence

- `npx playwright test test/playwright/unit/draggable/container/SortZone.spec.mjs test/playwright/unit/apps/agentos/childapps/dockdemo/DemoAWorkspace.spec.mjs -c test/playwright/playwright.config.unit.mjs --workers=1` — 21 passed.
- `npx playwright test test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs -c test/playwright/playwright.config.unit.mjs --workers=1` — 13 passed; includes cancel-without-remote-drop.
- `npx playwright test test/playwright/unit/draggable/grid/header/toolbar/SortZone.spec.mjs -c test/playwright/playwright.config.unit.mjs --workers=1` — 4 passed on final test head; the cancel fixture deliberately omits `gridContainer`, so lock-inference fall-through fails loudly.
- `env NEO_E2E_PORT=8091 NEO_TEST_SKIP_CI=true npx playwright test test/playwright/e2e/dashboard/DemoADragMenuNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` — 3 passed at head `66869f082`: cold first drag, real Escape with proxy/worker cleanup before mouseup and no model commit, plus reduced motion.
- `npm run agent-preflight -- --no-fix` — staged ticket archaeology, block alignment, parsing, shorthand, whitespace, JSDoc type, and test-mutation gates passed.

Directly touched surfaces:

- Main/App Worker drag lifecycle: real Chromium + Neural Link journey; worker cancel and no-reorder unit coverage.
- Dock projection and Demo-A overlays: unit seam coverage plus the real pointer/key journey.
- Cross-window coordinator and dashboard sort: unit coverage proving remote hover leaves without local or remote drop.
- Grid header sort: direct cancel-safe post-processing unit coverage.

## Post-Merge Validation

- [ ] Re-run the cold-start Demo-A drag/Escape journey from merged `dev`.
- [ ] Remove #14980 as the blocker for #14772 and reuse the readiness witness in its cross-window showcase.

## Commits

- `e42c09434` — add worker-stamped drag readiness and the first-class cancel lifecycle.
- `66869f082` — prove grid cancellation cannot fall through into lock-region inference.

## Evolution

The implementation pivoted after the +0 ms trace showed a fully initialized worker sort zone with zero move events. The causal gap was test cadence across the sensor delay, not delegated-listener registration. That correction eliminated a proposed new handshake and let the second half land at the actual gesture owner as a reusable engine primitive.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session adddb25d-fc36-4b08-b9a3-3a62a108cda1.
