### PR TITLE
fix(agentos): honor canonical add-agent readback (#14614)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -141,10 +141,21 @@ class FleetControlBridge extends Base {
      * @param {Object} [definition.metadata]         Free-form non-secret metadata.
      * @param {String} [definition.modelProvider]    The agent's model-provider login; resolves via the AiConfig SSOT leaf when omitted.
      * @param {Object|null} [definition.mcpServers]   Complete sparse MCP overrides; omitted/null follows live defaults, exactly like configureAgent.
-     * @returns {Object} the public agent definition (no credential).
+     * @returns {Object} The public agent definition (no credential), or a controlled
+     *     `{status:'rejected', reason}` outcome for FleetRegistryService validation failures.
      */
     defineAgent(definition) {
-        return this.getRegistry().defineAgent(definition);
+        try {
+            return this.getRegistry().defineAgent(definition)
+        } catch (error) {
+            const prefix = 'FleetRegistryService.defineAgent:';
+
+            if (error?.message?.startsWith(prefix)) {
+                return {status: 'rejected', reason: error.message.slice(prefix.length).trim()}
+            }
+
+            throw error
+        }
     }
 
     /**

--- a/apps/agentos/view/Accounts.mjs
+++ b/apps/agentos/view/Accounts.mjs
@@ -21,8 +21,11 @@ import Toolbar            from '../../../src/toolbar/Base.mjs';
  * Capability-security boundary (the load-bearing reason this is its own surface): a credential is
  * collected only long enough to submit it to the Brain-side Fleet Registry bridge. If that bridge is
  * absent, submission fails closed, the PAT field is cleared, and **nothing is stored in the browser /
- * App Worker** — only a redacted projection reaches the shared `AgentDefinitions` roster, never a
- * credential byte (mirrors `AgentOS.model.AgentDefinition`'s deliberately credential-free shape).
+ * App Worker** — only the Brain's canonical redacted response reaches the shared
+ * `AgentDefinitions` roster, never a credential byte (mirrors
+ * `AgentOS.model.AgentDefinition`'s deliberately credential-free shape). An accepted definition
+ * emits `agentDefinitionAccepted`; the Viewport composition root owns the separate Fleet-cockpit
+ * refresh, so Accounts never maps or reaches into a sibling `FleetAgent` surface.
  */
 class Accounts extends DashboardPanel {
     static config = {
@@ -270,9 +273,9 @@ class Accounts extends DashboardPanel {
      */
     async onAgentConfigIntent(intent={}) {
         const
-            me        = this,
-            agentId   = intent.id,
-            bridge    = globalThis.AgentOS?.fleet?.registryBridge,
+            me      = this,
+            agentId = intent.id,
+            bridge  = globalThis.AgentOS?.fleet?.registryBridge,
             // Neo events add transport-irrelevant envelope fields such as `source`. Reconstruct the
             // curated wire intent explicitly so no event metadata can cross the Brain allowlist.
             wireIntent = {id: agentId};
@@ -445,23 +448,6 @@ class Accounts extends DashboardPanel {
     }
 
     /**
-     * @summary Create the redacted projection that can safely render in the Body-side roster.
-     * @param {Object} values
-     * @returns {Object} Public agent definition suitable for the shared store; never includes a credential.
-     */
-    createPublicAgentDefinition(values) {
-        return {
-            id             : values.githubUsername,
-            githubUsername : values.githubUsername,
-            harnessType    : values.harnessType,
-            credentialState: 'stored-node-side',
-            lifecycleState : 'gated',
-            statusText     : 'Agent added; lifecycle controls remain gated.',
-            updatedAt      : new Date().toISOString()
-        }
-    }
-
-    /**
      * @summary Load a sample public identity without inserting credential bytes.
      * @returns {Promise<void>}
      */
@@ -481,7 +467,12 @@ class Accounts extends DashboardPanel {
     }
 
     /**
-     * @summary Validate the form, attempt the Brain-side bridge submit, then clear the PAT field.
+     * @summary Validate the form, attempt the Brain-side bridge submit, and apply only the canonical
+     * redacted response to the provider-owned AgentDefinitions store. A controlled registry-domain
+     * rejection renders its reason without mutating Body state; an unexpected or malformed response
+     * stays sanitized. After an accepted readback, `agentDefinitionAccepted` tells the Viewport
+     * composition root to refresh the separately-owned Fleet roster from its Brain assembler.
+     * The PAT field clears after every attempted bridge submit.
      * @returns {Promise<void>}
      */
     async onSubmitAgentClick() {
@@ -504,8 +495,15 @@ class Accounts extends DashboardPanel {
         };
 
         try {
-            await this.submitToFleetRegistryBridge(payload);
-            this.upsertPublicAgentDefinition(this.createPublicAgentDefinition(payload));
+            const outcome = await this.submitToFleetRegistryBridge(payload);
+
+            if (outcome?.status === 'rejected') {
+                this.updateBridgeStatus('is-error', outcome.reason || 'Agent definition was rejected. Nothing was changed.');
+                return
+            }
+
+            this.upsertPublicAgentDefinition(outcome, payload.credential);
+            this.fire('agentDefinitionAccepted', {agent: outcome});
             this.updateBridgeStatus('is-live', 'Agent added. PAT was not retained in the app worker.')
         } catch (error) {
             this.updateBridgeStatus('is-error', 'Could not add agent. Nothing was stored in browser state; PAT field was cleared.')
@@ -545,7 +543,8 @@ class Accounts extends DashboardPanel {
      * app has no Brain-side bridge object, so the view fails closed instead of inventing browser
      * persistence.
      * @param {Object} payload
-     * @returns {Promise<*>}
+     * @returns {Promise<Object>} Canonical public agent definition on acceptance, or a controlled
+     *     `{status:'rejected', reason}` domain outcome.
      */
     async submitToFleetRegistryBridge(payload) {
         const bridge = globalThis.AgentOS?.fleet?.registryBridge;
@@ -577,17 +576,36 @@ class Accounts extends DashboardPanel {
     }
 
     /**
-     * @summary Write the redacted projection into the shared roster store (the Viewport-provider-
-     * hosted `AgentDefinitions` instance this view binds), replacing any prior row for the same
-     * agent. The Fleet view's grid (bound to the same provider store) re-renders reactively — no
-     * cross-view reference is needed.
-     * @param {Object} definition
+     * @summary Validate and write the Brain's canonical redacted response into the Viewport-owned
+     * `AgentDefinitions` store. Required public identity fields and the exact submitted credential
+     * are checked before mutation; a malformed or echoing response fails closed. Existing records
+     * update in place, while a new definition becomes the selected Accounts resident. This is the
+     * configuration projection only — the separate FleetAgent roster refreshes through the
+     * Viewport-owned `agentDefinitionAccepted` composition seam.
+     * @param {Object} definition Canonical public definition returned by the Brain bridge.
+     * @param {String} submittedCredential Ephemeral PAT used only to reject an accidental echo.
      */
-    upsertPublicAgentDefinition(definition) {
-        const store = this.agentDefinitionsStore;
+    upsertPublicAgentDefinition(definition, submittedCredential) {
+        const
+            store             = this.agentDefinitionsStore,
+            hasTopLevelSecret = definition && ['authorization', 'credential', 'password', 'pat', 'token']
+                .some(key => Object.hasOwn(definition, key));
 
-        store.remove(definition.id);
-        store.add(definition);
+        let serializedDefinition;
+
+        try {
+            serializedDefinition = JSON.stringify(definition)
+        } catch (error) {/* invalid response */}
+
+        if (!store || !definition?.id || !definition.githubUsername || !definition.harnessType ||
+            !serializedDefinition || hasTopLevelSecret ||
+            (submittedCredential && serializedDefinition.includes(submittedCredential))) {
+            throw new Error('Fleet Registry returned an invalid public agent definition')
+        }
+
+        const record = store.get(definition.id);
+
+        record ? record.set(definition) : store.add(definition);
 
         // a just-added agent becomes the scoped one — the operator configures it next
         this.selectedAgentId = definition.id

--- a/apps/agentos/view/Viewport.mjs
+++ b/apps/agentos/view/Viewport.mjs
@@ -18,6 +18,11 @@ import ViewportController from './ViewportController.mjs';
  * cockpit, the default), **Accounts** (identity setup), **Chat** (prompt → live pane, the dockable
  * work-area seam). The Fleet keeper-view renders the roster as CARDS (the design SSOT), not a
  * data-grid table. Renders through `neo-theme-neo-dark` / `neo-theme-neo-light`.
+ *
+ * The Viewport is also the composition authority between two deliberately separate projections:
+ * Accounts owns `AgentDefinitions`, while FleetCockpit owns `FleetRoster`. An accepted definition
+ * event is routed here so the cockpit can re-poll its Brain-side `fleetRoster()` assembler; neither
+ * sibling reaches into or locally maps the other's store.
  */
 class Viewport extends BaseViewport {
     static config = {
@@ -101,8 +106,9 @@ class Viewport extends BaseViewport {
                             '<p class="agent-welcome-lede">Your fleet\'s state at a glance, its work streaming in real time, commanded from the cockpit — not a terminal. Select <b>Fleet</b> in the rail to enter mission control.</p>' +
                         '</div>'
             }, {
-                module: FleetCockpit,
-                header: {iconCls: 'fa-solid fa-satellite-dish', route: '/fleet', text: 'Fleet'}
+                module   : FleetCockpit,
+                header   : {iconCls: 'fa-solid fa-satellite-dish', route: '/fleet', text: 'Fleet'},
+                reference: 'fleet-cockpit'
             }, {
                 // FleetSettingsPanel is a dashboard.Panel, so its keeper-view rides a dashboard.Container
                 // to keep the detach-to-window (pop-out) host — the WindowOps E2E contract + the working
@@ -130,6 +136,7 @@ class Viewport extends BaseViewport {
                 items: [{
                     module   : Accounts,
                     flex     : 1,
+                    listeners: {agentDefinitionAccepted: 'up.onAgentDefinitionAccepted'},
                     reference: 'accounts'
                 }]
             }, {
@@ -139,6 +146,26 @@ class Viewport extends BaseViewport {
                 html  : '<div class="agent-placeholder-inner">Chat — prompt an agent → a live widget pane you can dock and pop out. The dockable QT work-area lands here next.</div>'
             }]
         }]
+    }
+
+    /**
+     * @summary Route an accepted Accounts definition across the keeper-view composition boundary:
+     * FleetCockpit re-polls the Brain's authoritative roster assembler into its own FleetRoster
+     * store. Invalid events or an absent cockpit fail closed without a sibling-store mutation.
+     * @param {Object} data
+     * @param {Object} data.agent Canonical public agent definition accepted by Accounts.
+     * @returns {Promise<Boolean>} True after the cockpit refresh settles; false when no valid route exists.
+     */
+    async onAgentDefinitionAccepted({agent}={}) {
+        const cockpit = this.getReference('fleet-cockpit');
+
+        if (!agent?.id || typeof cockpit?.loadRoster !== 'function') {
+            return false
+        }
+
+        await cockpit.loadRoster();
+
+        return true
     }
 }
 

--- a/test/playwright/e2e/agentos/AccountsConfigSurface.spec.mjs
+++ b/test/playwright/e2e/agentos/AccountsConfigSurface.spec.mjs
@@ -1,18 +1,20 @@
-import {test, expect} from '../../fixtures.mjs';
+import {test, expect}           from '../../fixtures.mjs';
 import {NeuralLink_DataService} from '../../../../ai/services.mjs';
-import FleetRegistryService from '../../../../ai/services/fleet/FleetRegistryService.mjs';
+import FleetRegistryService     from '../../../../ai/services/fleet/FleetRegistryService.mjs';
 import {startFleetBridgeServer} from '../../../../ai/services/fleet/fleetBridgeServer.mjs';
-import fs   from 'fs';
-import os   from 'os';
-import path from 'path';
+import {listHarnessTypes}       from '../../../../apps/agentos/config/harnessTypes.mjs';
+import fs                       from 'fs';
+import os                       from 'os';
+import path                     from 'path';
 
 /**
  * @summary Verifies the agent-scoped Accounts configuration surface mounts end-to-end: the
  * selector strip derives from the roster store, the configuration card renders the scoped agent's
  * registry-derived configuration (harness chips, MCP-server rows, tri-state operational rows),
- * and the add-form's harness radios carry the shared registry's entries. The save journey uses the
- * production App-Worker bridge, a real Brain registry/server, and Neural Link store inspection;
- * it is behavioral evidence rather than a screenshot generator.
+ * and the add-form's harness radios carry the shared registry's entries. The save + operable-cold
+ * add journeys use the production App-Worker bridge, a real Brain registry/server, the Viewport's
+ * accepted-definition composition handoff, and Neural Link inspection of the deliberately separate
+ * AgentDefinitions + FleetRoster stores; this is behavioral evidence rather than a screenshot generator.
  *
  * @see apps/agentos/view/Accounts.mjs
  * @see apps/agentos/view/AgentConfigCard.mjs
@@ -20,11 +22,14 @@ import path from 'path';
 test.describe('AgentOS Accounts — agent-scoped configuration surface', () => {
     test.setTimeout(120000);
 
-    test('cold-loads, saves, and freshly rehydrates sparse config over the real Fleet wire + NL store', async ({page, neuralLink}) => {
+    test('cold-loads, saves config, adds an emergent resident, and freshly rehydrates over the real Fleet wire', async ({page, neuralLink}) => {
         const
-            priorDataDir = FleetRegistryService.dataDir,
-            tmpDir       = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-config-e2e-')),
-            agentId      = 'config-proof-agent';
+            priorDataDir    = FleetRegistryService.dataDir,
+            tmpDir          = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-config-e2e-')),
+            agentId         = 'config-proof-agent',
+            createdAgentId  = 'cold-proof-agent',
+            createdSecret   = 'ghp_e2e_add_must_stay_brain_side',
+            duplicateSecret = 'ghp_e2e_duplicate_must_stay_brain_side';
 
         FleetRegistryService.dataDir = tmpDir;
         FleetRegistryService.defineAgent({
@@ -52,7 +57,7 @@ test.describe('AgentOS Accounts — agent-scoped configuration surface', () => {
             await expect(page.locator('.agent-selector-button').filter({hasText: agentId})).toHaveCount(1);
 
             await expect(page.locator('.agent-config-card')).toBeVisible();
-            expect(await page.locator('.agent-config-chip').count()).toBe(5);
+            expect(await page.locator('.agent-config-chip').count()).toBe(listHarnessTypes().length);
             await expect(page.locator('.agent-config-chip.is-selected')).toHaveCount(1);
 
             const memoryCore = page.locator('.agent-config-toggle').filter({hasText: 'Memory Core'});
@@ -66,27 +71,93 @@ test.describe('AgentOS Accounts — agent-scoped configuration surface', () => {
 
             expect(FleetRegistryService.getDefinition(agentId).mcpServers).toEqual({'memory-core': false});
 
-            const app       = await neuralLink.connectToApp('AgentOS'),
-                  stores    = await NeuralLink_DataService.listStores({sessionId: app.sessionId}),
-                  storeMeta = stores.stores.find(candidate => candidate.model === 'AgentOS.model.AgentDefinition'),
-                  snapshot  = await NeuralLink_DataService.inspectStore({
-                      sessionId: app.sessionId,
-                      storeId  : storeMeta.id,
-                      limit    : 10
-                  }),
-                  row       = snapshot.items.find(item => item.id === agentId);
+            // Operable-cold journey: the UI request crosses the production wire once, while the
+            // Body applies only the canonical redacted response. The accepted-definition owner
+            // intent then makes FleetCockpit re-poll its separate Brain assembler.
+            const
+                usernameField   = page.getByRole('textbox', {name: 'GitHub username', exact: true}),
+                credentialField = page.getByRole('textbox', {name: 'GitHub PAT', exact: true}),
+                harnessField    = page.locator('.agent-harness-picker .neo-radiofield').filter({hasText: 'Antigravity'});
 
-            expect(row.mcpServers).toEqual({'memory-core': false});
-            expect(JSON.stringify(row)).not.toMatch(/credential|pat|token|ghp_e2e_must_stay_brain_side/i);
+            await usernameField.fill(createdAgentId);
+            await credentialField.fill(createdSecret);
+            await harnessField.locator('label').click();
+            await expect(harnessField.locator('input[type="radio"]')).toBeChecked();
+            await page.getByRole('button', {name: 'Add agent', exact: true}).click();
+
+            await expect(page.locator('.agent-bridge-status.is-live')).toContainText('Agent added');
+            await expect(credentialField).toHaveValue('');
+            await expect(page.locator('.agent-selector-button').filter({hasText: createdAgentId})).toHaveCount(1);
+
+            const createdDefinition = FleetRegistryService.getDefinition(createdAgentId);
+
+            expect(createdDefinition).toMatchObject({
+                id            : createdAgentId,
+                githubUsername: createdAgentId,
+                harnessType   : 'antigravity'
+            });
+            expect(JSON.stringify(createdDefinition)).not.toContain(createdSecret);
+
+            await page.getByRole('tab', {name: 'Fleet', exact: true}).click();
+
+            const createdCard = page.locator('.fm-agent-card').filter({hasText: createdAgentId});
+
+            await expect(createdCard).toHaveCount(1);
+            await expect(createdCard).toBeVisible();
+
+            // A registry-domain rejection travels as a controlled outcome: reason visible, no
+            // second Body mutation/owner refresh, and the retry PAT is still cleared.
+            await page.getByRole('tab', {name: 'Accounts', exact: true}).click();
+            await credentialField.fill(duplicateSecret);
+            await page.getByRole('button', {name: 'Add agent', exact: true}).click();
+            await expect(page.locator('.agent-bridge-status.is-error')).toContainText('already exists');
+            await expect(credentialField).toHaveValue('');
+            expect(FleetRegistryService.listAgents().filter(agent => agent.id === createdAgentId)).toHaveLength(1);
+
+            const
+                app             = await neuralLink.connectToApp('AgentOS'),
+                stores          = await NeuralLink_DataService.listStores({sessionId: app.sessionId}),
+                definitionsMeta = stores.stores.find(candidate => candidate.model === 'AgentOS.model.AgentDefinition'),
+                rosterMeta      = stores.stores.find(candidate => candidate.model === 'AgentOS.model.FleetAgent'),
+                definitions     = await NeuralLink_DataService.inspectStore({
+                    sessionId: app.sessionId,
+                    storeId  : definitionsMeta.id,
+                    limit    : 10
+                }),
+                roster          = await NeuralLink_DataService.inspectStore({
+                    sessionId: app.sessionId,
+                    storeId  : rosterMeta.id,
+                    limit    : 10
+                }),
+                configRow       = definitions.items.find(item => item.id === agentId),
+                definitionRow   = definitions.items.find(item => item.id === createdAgentId),
+                rosterRow       = roster.items.find(item => item.agentId === createdAgentId),
+                cards           = await app.queryComponent({className: 'AgentOS.view.fleet.AgentCard'}, ['record', 'id']),
+                card            = cards.find(candidate => candidate.properties?.record?.agentId === createdAgentId);
+
+            expect(configRow.mcpServers).toEqual({'memory-core': false});
+            expect(definitionRow).toMatchObject({
+                id            : createdAgentId,
+                githubUsername: createdAgentId,
+                harnessType   : 'antigravity'
+            });
+            expect(JSON.stringify(definitionRow)).not.toMatch(/credential|pat|ghp_e2e_add_must_stay_brain_side/i);
+            expect(rosterRow.agentId).toBe(createdAgentId);
+            expect(card.properties.record).toMatchObject({
+                agentId  : createdAgentId,
+                engineTag: null,
+                family   : null
+            });
 
             // A fresh page/store hydration must re-read the canonical sparse result, not the
             // request or the seed. This also proves persisted state survived the first app session.
             await page.reload();
             await page.locator('.agent-shell').getByText('Accounts', {exact: true}).click();
             await expect(page.locator('.agent-selector-button').filter({hasText: agentId})).toHaveCount(1);
+            await expect(page.locator('.agent-selector-button').filter({hasText: createdAgentId})).toHaveCount(1);
             await expect(page.locator('.agent-config-toggle').filter({hasText: 'Memory Core'})).toHaveClass(/is-disabled/);
 
-            expect(await page.locator('.agent-harness-picker .neo-radiofield').count()).toBe(5)
+            expect(await page.locator('.agent-harness-picker .neo-radiofield').count()).toBe(listHarnessTypes().length)
         } finally {
             server && await new Promise(resolve => server.close(resolve));
             FleetRegistryService.dataDir = priorDataDir;

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -72,6 +72,20 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         expect(result.credential).toBeUndefined();
     });
 
+    test('defineAgent exposes only controlled registry-domain reasons; unexpected failures still throw', () => {
+        registryStub.defineAgent = () => {
+            throw new TypeError("FleetRegistryService.defineAgent: id 'alice' already exists; use a scoped update operation.")
+        };
+        expect(FleetControlBridge.defineAgent({githubUsername: 'alice', harnessType: 'codex'})).toEqual({
+            status: 'rejected',
+            reason: "id 'alice' already exists; use a scoped update operation."
+        });
+
+        registryStub.defineAgent = () => { throw new Error('/secret/storage/path failed') };
+        expect(() => FleetControlBridge.defineAgent({githubUsername: 'alice', harnessType: 'codex'}))
+            .toThrow('/secret/storage/path failed')
+    });
+
     test('configureAgent forwards one curated payload and returns accepted/rejected domain outcomes', () => {
         const intent = {id: 'alice', harnessType: 'claude-code', mcpServers: {'memory-core': false}};
 

--- a/test/playwright/unit/apps/agentos/Accounts.spec.mjs
+++ b/test/playwright/unit/apps/agentos/Accounts.spec.mjs
@@ -22,21 +22,77 @@ const
     viewPath   = path.join(repoRoot, 'apps/agentos/view/Accounts.mjs');
 
 test.describe('AgentOS.view.Accounts credential boundary', () => {
-    test('public definition projection strips submitted credential material', () => {
-        const values = {
+    test('accepted creation applies the canonical Brain response, emits the owner intent, and clears the PAT', async () => {
+        const
+            canonical = {
+                id            : 'resident-42',
+                githubUsername: 'canonical-login',
+                harnessType   : 'antigravity',
+                updatedAt     : '2026-07-14T00:00:00.000Z'
+            },
+            calls     = [],
+            form      = {
+                getSubmitValues: async () => ({
+                    credential    : 'ghp_should_not_escape',
+                    githubUsername: '  submitted-login  ',
+                    harnessType   : 'codex'
+                }),
+                validate: async () => true
+            },
+            stub      = {
+                clearCredentialField       : async () => calls.push(['clear']),
+                fire                       : (name, data) => calls.push(['fire', name, data]),
+                getReference               : reference => reference === 'agent-form' ? form : null,
+                submitToFleetRegistryBridge: async payload => {
+                    calls.push(['submit', payload]);
+                    return canonical
+                },
+                updateBridgeStatus         : (state, message) => calls.push(['status', state, message]),
+                upsertPublicAgentDefinition: (definition, credential) => calls.push(['upsert', definition, credential])
+            };
+
+        await Accounts.prototype.onSubmitAgentClick.call(stub);
+
+        expect(calls[0]).toEqual(['submit', {
             credential    : 'ghp_should_not_escape',
-            githubUsername: 'neo-gpt',
-            harnessType   : 'codex',
-            pat           : 'also-secret'
-        };
+            githubUsername: 'submitted-login',
+            harnessType   : 'codex'
+        }]);
+        expect(calls[1]).toEqual(['upsert', canonical, 'ghp_should_not_escape']);
+        expect(calls[2]).toEqual(['fire', 'agentDefinitionAccepted', {agent: canonical}]);
+        expect(calls[3]).toEqual(['status', 'is-live', 'Agent added. PAT was not retained in the app worker.']);
+        expect(calls[4]).toEqual(['clear'])
+    });
 
-        const publicDefinition = Accounts.prototype.createPublicAgentDefinition(values);
+    test('controlled registry rejection renders its reason without a Body mutation and still clears the PAT', async () => {
+        const
+            calls = [],
+            form  = {
+                getSubmitValues: async () => ({
+                    credential    : 'ghp_retry',
+                    githubUsername: 'duplicate',
+                    harnessType   : 'codex'
+                }),
+                validate: async () => true
+            },
+            stub  = {
+                clearCredentialField       : async () => calls.push(['clear']),
+                fire                       : () => calls.push(['unexpected-fire']),
+                getReference               : reference => reference === 'agent-form' ? form : null,
+                submitToFleetRegistryBridge: async () => ({
+                    status: 'rejected',
+                    reason: "id 'duplicate' already exists; use a scoped update operation."
+                }),
+                updateBridgeStatus         : (state, message) => calls.push(['status', state, message]),
+                upsertPublicAgentDefinition: () => calls.push(['unexpected-upsert'])
+            };
 
-        expect(publicDefinition.githubUsername).toBe('neo-gpt');
-        expect(publicDefinition.harnessType).toBe('codex');
-        expect(JSON.stringify(publicDefinition)).not.toContain('ghp_should_not_escape');
-        expect(publicDefinition.credential).toBeUndefined();
-        expect(publicDefinition.pat).toBeUndefined()
+        await Accounts.prototype.onSubmitAgentClick.call(stub);
+
+        expect(calls).toEqual([
+            ['status', 'is-error', "id 'duplicate' already exists; use a scoped update operation."],
+            ['clear']
+        ])
     });
 
     test('view source fails closed without browser persistence or credential logging', () => {
@@ -51,11 +107,12 @@ test.describe('AgentOS.view.Accounts credential boundary', () => {
     test('identity setup writes only the redacted projection to the shared roster', () => {
         const source = fs.readFileSync(viewPath, 'utf8');
 
-        // upsert goes through the provider-bound roster store with the redacted projection,
-        // never the raw form values / credential — and never a module-global singleton import.
+        // upsert goes through the provider-bound roster store with the canonical Brain response,
+        // never a request-derived projection or a module-global singleton import.
         expect(source).toContain("bind: {agentDefinitionsStore: 'stores.agentDefinitions'}");
         expect(source).toContain('store.add(definition)');
-        expect(source).toContain('createPublicAgentDefinition');
+        expect(source).toContain('this.upsertPublicAgentDefinition(outcome, payload.credential)');
+        expect(source).not.toContain('createPublicAgentDefinition');
         expect(source).not.toContain("from '../store/AgentDefinitions.mjs'");
         expect(source).not.toMatch(/store\.add\(\s*values/)
     });
@@ -164,7 +221,7 @@ test.describe('AgentOS.view.Accounts — agent-scoped configuration (multiple ag
                 removeAll() { this.items = [] }
             },
             card     = {
-                record: undefined,
+                record      : undefined,
                 refreshCount: 0,
                 refresh() { this.refreshCount++ },
                 setSaveStatus(agentId, state, reason) {
@@ -270,18 +327,40 @@ test.describe('AgentOS.view.Accounts — agent-scoped configuration (multiple ag
         store.destroy()
     });
 
-    test('adding an agent scopes the view to it (configure-next flow)', () => {
+    test('canonical add readback becomes a real model record; malformed or echoing responses fail before mutation', () => {
         const store = makeAgentStore([{id: 'a', githubUsername: 'a', harnessType: 'codex'}]);
         const stub  = makeScopedAccounts(store);
 
         stub.upsertPublicAgentDefinition = Accounts.prototype.upsertPublicAgentDefinition;
-        stub.upsertPublicAgentDefinition(Accounts.prototype.createPublicAgentDefinition({
-            githubUsername: 'neo-new',
-            harnessType   : 'antigravity'
-        }));
+        stub.upsertPublicAgentDefinition({
+            id            : 'canonical-id',
+            githubUsername: 'canonical-login',
+            harnessType   : 'antigravity',
+            updatedAt     : '2026-07-14T00:00:00.000Z'
+        }, 'ghp_must_not_escape');
 
-        expect(stub.selectedAgentId).toBe('neo-new');
+        expect(stub.selectedAgentId).toBe('canonical-id');
+        expect(stub.card.record?.githubUsername).toBe('canonical-login');
         expect(stub.card.record?.harnessType).toBe('antigravity');
+        expect(stub.card.record?.updatedAt).toBe('2026-07-14T00:00:00.000Z');
+        expect(stub.card.record?.credential).toBeUndefined();
+        expect(stub.card.record?.pat).toBeUndefined();
+
+        const count = store.count;
+
+        expect(() => stub.upsertPublicAgentDefinition({
+            id            : 'echoing-id',
+            githubUsername: 'echoing-login',
+            harnessType   : 'codex',
+            credential    : 'ghp_must_not_escape'
+        }, 'ghp_must_not_escape')).toThrow('invalid public agent definition');
+        expect(() => stub.upsertPublicAgentDefinition({
+            id            : 'missing-harness',
+            githubUsername: 'missing-harness'
+        }, 'ghp_other')).toThrow('invalid public agent definition');
+        expect(store.count).toBe(count);
+        expect(store.get('echoing-id')).toBeNull();
+        expect(store.get('missing-harness')).toBeNull();
 
         store.destroy()
     });
@@ -388,12 +467,12 @@ test.describe('AgentOS.view.AgentConfigCard — live same-record propagation + c
         const saveStatuses = [],
               card         = {setSaveStatus: (...args) => saveStatuses.push(args)},
               stub         = {
-            agentDefinitionsStore         : store,
-            agentConfigRequestGenerations : new Map(),
-            agentConfigSaveStatuses       : new Map(),
-            onAgentConfigIntent           : Accounts.prototype.onAgentConfigIntent,
-            setAgentConfigSaveStatus      : Accounts.prototype.setAgentConfigSaveStatus,
-            getReference                  : ref => ref === 'agent-config-card' ? card : null
+            agentDefinitionsStore        : store,
+            agentConfigRequestGenerations: new Map(),
+            agentConfigSaveStatuses      : new Map(),
+            onAgentConfigIntent          : Accounts.prototype.onAgentConfigIntent,
+            setAgentConfigSaveStatus     : Accounts.prototype.setAgentConfigSaveStatus,
+            getReference                 : ref => ref === 'agent-config-card' ? card : null
         };
 
         // no bridge → fail closed, nothing mutates
@@ -467,7 +546,7 @@ test.describe('AgentOS.view.AgentConfigCard — live same-record propagation + c
             {id: 'ada', githubUsername: 'ada', harnessType: 'codex'}
         ]});
         const saveStatuses = [];
-        const stub = {
+        const stub         = {
             agentDefinitionsStore         : store,
             agentDefinitionsLoadGeneration: 0,
             agentConfigRequestGenerations : new Map(),
@@ -494,10 +573,10 @@ test.describe('AgentOS.view.AgentConfigCard — live same-record propagation + c
             {id: 'bridge-pending', githubUsername: 'bridge-pending', harnessType: 'codex'}
         ]});
         const stub = {
-            agentDefinitionsStore      : store,
+            agentDefinitionsStore         : store,
             agentDefinitionsLoadGeneration: 0,
-            syncAgentSelector          : () => {},
-            loadAgentDefinitions       : Accounts.prototype.loadAgentDefinitions
+            syncAgentSelector             : () => {},
+            loadAgentDefinitions          : Accounts.prototype.loadAgentDefinitions
         };
 
         globalThis.AgentOS = {fleet: {registryBridge: {listAgents: async () => [{

--- a/test/playwright/unit/apps/agentos/ViewportController.spec.mjs
+++ b/test/playwright/unit/apps/agentos/ViewportController.spec.mjs
@@ -86,3 +86,38 @@ test.describe('AgentOS.view.ViewportController — route → keeper-view tab', (
         expect(routes.sort()).toEqual(Object.keys(ViewportController.config.routes).sort())
     })
 });
+
+test.describe('AgentOS.view.Viewport — accepted-definition composition boundary', () => {
+    test('authors the Accounts intent listener and FleetCockpit reference at the shared owner', () => {
+        const
+            shellConfig  = Viewport.config.items.find(item => item.reference === 'shell'),
+            fleetConfig  = shellConfig.items.find(item => item.header.route === '/fleet'),
+            accountsHost = shellConfig.items.find(item => item.header.route === '/accounts'),
+            accounts     = accountsHost.items.find(item => item.reference === 'accounts');
+
+        expect(fleetConfig.reference).toBe('fleet-cockpit');
+        expect(accounts.listeners).toEqual({agentDefinitionAccepted: 'up.onAgentDefinitionAccepted'})
+    });
+
+    test('refreshes the separate Fleet roster only for a valid accepted definition', async () => {
+        const
+            calls   = [],
+            cockpit = {loadRoster: async () => calls.push('loadRoster')},
+            stub    = {getReference: reference => reference === 'fleet-cockpit' ? cockpit : null};
+
+        await expect(Viewport.prototype.onAgentDefinitionAccepted.call(stub, {agent: {id: 'resident-42'}}))
+            .resolves.toBe(true);
+        expect(calls).toEqual(['loadRoster']);
+
+        await expect(Viewport.prototype.onAgentDefinitionAccepted.call(stub, {agent: {}}))
+            .resolves.toBe(false);
+        expect(calls).toEqual(['loadRoster'])
+    });
+
+    test('fails closed when the Fleet cockpit is absent', async () => {
+        const stub = {getReference: () => null};
+
+        await expect(Viewport.prototype.onAgentDefinitionAccepted.call(stub, {agent: {id: 'resident-42'}}))
+            .resolves.toBe(false)
+    })
+});


### PR DESCRIPTION
Resolves #14614

The AgentOS add-agent journey now treats the Brain response as the only creation truth. Accounts validates and applies the canonical redacted definition, reports controlled registry-domain rejections without mutating Body state, clears the PAT after every attempted submit, and emits an owner-routed acceptance intent. The Viewport composition root then refreshes FleetCockpit from its authoritative Brain assembler, so the resident appears immediately through the separate `AgentDefinitions` and `FleetRoster` stores and one emergent AgentCard.

Evidence: L3 (real Chromium journey over the production App-Worker wire, isolated Brain registry, and Neural Link store/component inspection) → L3 required (all close-target runtime ACs). No residuals.

## Deltas from ticket

None substantive after the intake correction. The E2E fixture also derives its harness-radio count from the shared harness registry instead of retaining a stale literal.

## Test Evidence

- Fleet bridge + Accounts + Viewport composition: `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/apps/agentos/Accounts.spec.mjs test/playwright/unit/apps/agentos/ViewportController.spec.mjs test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs` — 53 passed.
- AgentOS real add/reject/reload journey: `NEO_E2E_PORT=8097 NEO_TEST_SKIP_CI=true npm run test-e2e -- test/playwright/e2e/agentos/AccountsConfigSurface.spec.mjs --workers=1` — 1 passed.
- Source and PR-body gates: `npm run agent-preflight -- --no-fix <touched files> --pr-body /tmp/neo-pr-14614.md` — passed before commit.
- Directly touched app surfaces: Accounts canonical readback, PAT clearing, rejection rendering, Viewport owner routing, Fleet emergent first render, separate-store Neural Link inspection, and fresh reload are covered by the focused specs above.

## Post-Merge Validation

- [ ] Confirm the merged `dev` AgentOS build still shows a newly registered resident in both Accounts and Fleet after a fresh load.

## Evolution

Live Neural Link exploration falsified the initial shared-store premise: Accounts is backed by `AgentDefinition`, while FleetCockpit owns a separate `FleetAgent` roster. The implementation therefore routes accepted intent through the Viewport owner and re-polls the Brain assembler instead of coupling siblings or fabricating a cross-model projection.

Authored by Euclid (GPT-5, Codex Desktop). Session a1db82b6-8a52-483c-ad7e-59ea7554f256.
