### PR TITLE
fix(ai): rename server transport to streamable-http (#15188)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -116,7 +116,7 @@ class Config extends ConfigProvider {
              */
             debug: leaf(false, 'NEO_DEBUG', 'boolean'),
             /**
-             * Transport protocol ('stdio' or 'sse').
+             * Server transport protocol. Supported values are exactly `stdio` and `streamable-http`.
              * @type {string}
              */
             transport: leaf('stdio', 'NEO_TRANSPORT', 'string'),
@@ -135,7 +135,7 @@ class Config extends ConfigProvider {
              */
             allowedHosts: leaf(null, 'NEO_MCP_ALLOWED_HOSTS', 'string'),
             /**
-             * Hostname (or full `protocol://host` URL) the SSE / HTTP transport advertises when
+             * Hostname (or full `protocol://host` URL) the Streamable HTTP transport advertises when
              * `publicUrl` is unset. Bare hostnames infer their protocol by convention (http for
              * localhost/127.0.0.1, https otherwise); values containing '://' are parsed verbatim.
              * Bound to the platform-standard `HOST` env var. Consumed by TransportService.setup.
@@ -143,7 +143,7 @@ class Config extends ConfigProvider {
              */
             mcpHttpHost: leaf('localhost', 'HOST', 'string'),
             /**
-             * Port the MCP server's HTTP/SSE transport listens on.
+             * Port the MCP server's Streamable HTTP transport listens on.
              * Sub-servers will typically override this with their own defaultPort.
              * @type {number}
              */
@@ -154,7 +154,7 @@ class Config extends ConfigProvider {
              */
             authMiddleware: leaf(null),
             /**
-             * Base authentication configuration for the SSE / HTTP transport.
+             * Base authentication configuration for the Streamable HTTP transport.
              *
              * `mode` selects the authorization strategy:
              * - `'oidc'` (default, production): OAuth 2.1 / OIDC bearer tokens validated via

--- a/ai/deploy/Dockerfile
+++ b/ai/deploy/Dockerfile
@@ -61,7 +61,7 @@ RUN apk add --no-cache libstdc++ git
 COPY --from=builder /app ./
 
 ENV NODE_ENV=production
-ENV NEO_TRANSPORT=sse
+ENV NEO_TRANSPORT=streamable-http
 
 # Accept the target service as build arguments.
 # `TARGET_SERVER` selects an MCP server image ('knowledge-base' or 'memory-core').

--- a/ai/deploy/docker-compose.dev.yml
+++ b/ai/deploy/docker-compose.dev.yml
@@ -29,7 +29,7 @@ services:
         NEO_SOURCE: local  # build the local checkout for dev iteration, not a remote clone
         TARGET_SERVER: knowledge-base
     environment:
-      - NEO_TRANSPORT=sse
+      - NEO_TRANSPORT=streamable-http
       - NEO_AUTO_SYNC=false
       - NEO_KB_AUTO_START_DATABASE=false
       - NEO_CHROMA_HOST=chroma
@@ -66,7 +66,7 @@ services:
         NEO_SOURCE: local  # build the local checkout for dev iteration, not a remote clone
         TARGET_SERVER: memory-core
     environment:
-      - NEO_TRANSPORT=sse
+      - NEO_TRANSPORT=streamable-http
       - NEO_MC_PRIMARY=false
       - NEO_AUTO_SUMMARIZE=false
       - NEO_MEM_AUTO_START_DATABASE=false

--- a/ai/deploy/docker-compose.test.yml
+++ b/ai/deploy/docker-compose.test.yml
@@ -56,7 +56,7 @@ services:
         NEO_SOURCE: local  # build the local checkout under test, not a remote clone
         TARGET_SERVER: knowledge-base
     environment:
-      - NEO_TRANSPORT=sse
+      - NEO_TRANSPORT=streamable-http
       - NEO_AUTO_SYNC=false
       - NEO_KB_AUTO_START_DATABASE=false
       - NEO_CHROMA_HOST=chroma
@@ -94,7 +94,7 @@ services:
         NEO_SOURCE: local  # build the local checkout under test, not a remote clone
         TARGET_SERVER: knowledge-base
     environment:
-      - NEO_TRANSPORT=sse
+      - NEO_TRANSPORT=streamable-http
       - NEO_AUTO_SYNC=false
       - NEO_KB_AUTO_START_DATABASE=false
       - NEO_CHROMA_HOST=chroma
@@ -132,7 +132,7 @@ services:
         NEO_SOURCE: local  # build the local checkout under test, not a remote clone
         TARGET_SERVER: memory-core
     environment:
-      - NEO_TRANSPORT=sse
+      - NEO_TRANSPORT=streamable-http
       - NEO_MC_PRIMARY=false
       - NEO_AUTO_SUMMARIZE=false
       - NEO_MEM_AUTO_START_DATABASE=false
@@ -195,7 +195,7 @@ services:
         NEO_SOURCE: local  # build the local checkout under test, not a remote clone
         TARGET_SERVER: memory-core
     environment:
-      - NEO_TRANSPORT=sse
+      - NEO_TRANSPORT=streamable-http
       - NEO_MC_PRIMARY=false
       - NEO_AUTO_SUMMARIZE=false
       - NEO_MEM_AUTO_START_DATABASE=false

--- a/ai/deploy/docker-compose.yml
+++ b/ai/deploy/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       args:
         TARGET_SERVER: knowledge-base
     environment:
-      - NEO_TRANSPORT=sse
+      - NEO_TRANSPORT=streamable-http
       - NEO_AUTO_SYNC=false
       - NEO_KB_AUTO_START_DATABASE=false
       - NEO_CHROMA_HOST=chroma
@@ -105,7 +105,7 @@ services:
       args:
         TARGET_SERVER: memory-core
     environment:
-      - NEO_TRANSPORT=sse
+      - NEO_TRANSPORT=streamable-http
       - NEO_MC_PRIMARY=false
       - NEO_MAILBOX_DEFAULT_REPLY_POLICY=blocked
       - NEO_AUTO_SUMMARIZE=false

--- a/ai/examples/cloud-deployment/pre-push-hook.sh
+++ b/ai/examples/cloud-deployment/pre-push-hook.sh
@@ -48,7 +48,7 @@ while read -r local_ref local_sha remote_ref remote_sha; do
         fi
 
         # Remote tenant mode (#11743): build one content-bearing ingest_source_files
-        # envelope and submit it through the tenant-side StreamableHTTP/SSE MCP client.
+        # envelope and submit it through the tenant-side remote MCP client.
         # Auth comes from NEO_KB_INGEST_TOKEN (or NEO_KB_TOKEN_ENV).
         envelope="$(build_remote_envelope)"
         printf '%s\n' "$envelope" | \

--- a/ai/mcp/server/BaseServer.mjs
+++ b/ai/mcp/server/BaseServer.mjs
@@ -28,9 +28,9 @@ import Base                                            from '../../../src/core/B
  *   projection context for embedded harness agents. Default `null` preserves the full
  *   developer/operator surface.
  * - `logStartupStatus(health)` — per-server startup log formatting.
- * - `buildRequestContext(reqAuth)` — SSE-only hook called by `TransportService.setup()` for per-request
+ * - `buildRequestContext(reqAuth)` — Streamable-HTTP-only hook called by `TransportService.setup()` for per-request
  *   context construction. Default returns `{}`.
- * - `onSessionClosed(sessionId, mcpServerInstance)` — SSE-only hook called by `TransportService` when
+ * - `onSessionClosed(sessionId, mcpServerInstance)` — Streamable-HTTP-only hook called by `TransportService` when
  *   a session disconnects. Default no-op.
  *
  * ## Lifecycle hooks (composable)
@@ -101,7 +101,7 @@ class BaseServer extends Base {
      */
     mcpServer = null
     /**
-     * The transport instance (StdioServerTransport for stdio mode; null for SSE mode
+     * The transport instance (StdioServerTransport for stdio mode; null for Streamable HTTP mode
      * because TransportService manages per-request transports).
      * @member {Object|null} transport=null
      * @protected
@@ -202,7 +202,7 @@ class BaseServer extends Base {
     }
 
     /**
-     * @summary Override (SSE-only): build per-request RequestContext shape from `req.auth`.
+     * @summary Override (Streamable-HTTP-only): build per-request RequestContext shape from `req.auth`.
      * Invoked by `TransportService.setup()` via duck-typed hook. Default returns `{}` for
      * single-tenant fallthrough.
      * @param {Object|undefined} reqAuth The auth context populated by `AuthService`.
@@ -213,7 +213,7 @@ class BaseServer extends Base {
     }
 
     /**
-     * @summary Override (SSE-only): hook called by `TransportService` on session disconnect.
+     * @summary Override (Streamable-HTTP-only): hook called by `TransportService` on session disconnect.
      * Default no-op.
      * @param {String} sessionId
      * @param {Object} mcpServerInstance
@@ -289,7 +289,7 @@ class BaseServer extends Base {
     /**
      * @summary Constructs an `McpServer` instance from `getServerMetadata()` and wires up
      * the standard ListTools / CallTool request handlers via `setupRequestHandlers()`.
-     * Used both at boot and per-request (SSE mode) to provision dedicated server objects
+     * Used both at boot and per-request (Streamable HTTP mode) to provision dedicated server objects
      * and avoid SDK lifecycle collisions.
      * @returns {McpServer}
      * @protected
@@ -525,16 +525,32 @@ class BaseServer extends Base {
     }
 
     /**
-     * @summary Connects the transport (stdio by default; SSE if `aiConfig.transport === 'sse'`).
-     * SSE mode delegates to the shared `TransportService` for Express + per-request session
-     * lifecycle.
+     * @summary Connects the configured server transport through an exhaustive, fail-closed selector.
+     * Configured servers accept exactly `stdio` and `streamable-http`; config-less local-only
+     * servers retain the BaseServer stdio topology. Streamable HTTP delegates to the shared
+     * `TransportService` for Express + per-request session lifecycle.
      * @returns {Promise<void>}
      * @protected
      */
     async connectTransport() {
-        const metadata = this.getServerMetadata();
+        const metadata  = this.getServerMetadata();
+        const transport = this.aiConfig === null ? 'stdio' : this.aiConfig.transport;
 
-        if (this.aiConfig?.transport === 'sse') {
+        if (transport === 'sse') {
+            throw new Error(
+                `[${metadata.name}] Server transport "sse" was renamed to "streamable-http". ` +
+                'Update the configured transport value before restarting the MCP server.'
+            );
+        }
+
+        if (transport !== 'stdio' && transport !== 'streamable-http') {
+            throw new Error(
+                `[${metadata.name}] Unsupported server transport "${transport}". ` +
+                'Expected "stdio" or "streamable-http".'
+            );
+        }
+
+        if (transport === 'streamable-http') {
             const {default: TransportService} = await import('./shared/services/TransportService.mjs');
 
             await TransportService.setup({

--- a/ai/mcp/server/gitlab-workflow/config.template.mjs
+++ b/ai/mcp/server/gitlab-workflow/config.template.mjs
@@ -83,6 +83,7 @@ class Config extends ConfigProvider {
                 stderrMode  : 'threshold'
             }),
             /**
+             * Server transport protocol. Supported values are exactly `stdio` and `streamable-http`.
              * @member {String} transport='stdio'
              */
             transport: leaf('stdio', 'NEO_GITLAB_WORKFLOW_TRANSPORT', 'string'),

--- a/ai/mcp/server/knowledge-base/Server.mjs
+++ b/ai/mcp/server/knowledge-base/Server.mjs
@@ -11,7 +11,7 @@ import {listTools, callTool} from './toolService.mjs';
  *
  * Handles initialization, configuration, and lifecycle management for the Knowledge Base MCP server.
  * This server uses a dual-transport architecture, allowing it to communicate with local CLI clients
- * via `stdio` (the default) or with cloud-native/remote clients via `sse` (StreamableHTTPServerTransport).
+ * via `stdio` (the default) or with cloud-native/remote clients via `streamable-http`.
  *
  * The transport mode and HTTP port can be configured using `aiConfig.transport` and `aiConfig.mcpHttpPort`.
  *
@@ -77,10 +77,10 @@ class Server extends BaseServer {
     }
 
     /**
-     * @summary SSE-only hook: builds the KB RequestContext from authenticated transport identity.
+     * @summary Streamable-HTTP-only hook: builds the KB RequestContext from authenticated transport identity.
      *
      * Knowledge Base read and ingest services enforce tenant isolation from
-     * `RequestContextService.getUserId()`. Propagating the SSE auth context here keeps
+     * `RequestContextService.getUserId()`. Propagating the Streamable HTTP auth context here keeps
      * proxy/OIDC deployments tenant-aware while preserving single-tenant fallthrough when
      * no identity is present.
      * @param {Object|undefined} reqAuth

--- a/ai/mcp/server/knowledge-base/config.template.mjs
+++ b/ai/mcp/server/knowledge-base/config.template.mjs
@@ -43,7 +43,7 @@ class Config extends ConfigProvider {
              */
             debug: leaf(false, 'NEO_DEBUG', 'boolean'),
             /**
-             * Transport protocol for the MCP server ('stdio' or 'sse').
+             * Server transport protocol. Supported values are exactly `stdio` and `streamable-http`.
              * @type {string}
              */
             transport: leaf('stdio', 'NEO_TRANSPORT', 'string'),
@@ -59,7 +59,8 @@ class Config extends ConfigProvider {
              */
             openApiPath: leaf(path.join(__dirname, 'openapi.yaml'), 'NEO_AI_MCP_KB_OPENAPI_PATH', 'string'),
             /**
-             * Port the MCP server's HTTP/SSE transport listens on (only used when `transport === 'sse'`).
+             * Port the MCP server's Streamable HTTP transport listens on (only used when
+             * `transport === 'streamable-http'`).
              *
              * Operator env var: `MCP_HTTP_PORT`.
              * @type {number}
@@ -68,7 +69,7 @@ class Config extends ConfigProvider {
             /**
              * Optional public canonical URL for this MCP server.
              * When configured, this URL is explicitly used as the resource indicator
-             * for OAuth 2.1 / OIDC audience claims and SSE callback advertising.
+             * for OAuth 2.1 / OIDC audience claims and protected-resource advertising.
              * Required when deploying behind reverse proxies (Nginx/Caddy) where
              * the internal host:port bindings do not match the public-facing URL.
              * Example: 'https://mcp.neo.mjs.com/knowledge-base'
@@ -85,7 +86,8 @@ class Config extends ConfigProvider {
              */
             allowedHosts: leaf(null, 'NEO_MCP_ALLOWED_HOSTS', 'string'),
             /**
-             * Optional Express middleware function for authentication (only used if transport is 'sse').
+             * Optional Express middleware function for authentication (only used when
+             * `transport === 'streamable-http'`).
              * @type {Function|null}
              */
             authMiddleware: leaf(null),

--- a/ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs
+++ b/ai/mcp/server/knowledge-base/ingestSourceFilesTool.mjs
@@ -1,5 +1,5 @@
-import aiConfig         from './config.mjs';
-import IngestionService from '../../../services/knowledge-base/IngestionService.mjs';
+import aiConfig                          from './config.mjs';
+import IngestionService                  from '../../../services/knowledge-base/IngestionService.mjs';
 import {isRemoteKnowledgeBaseDeployment} from '../../../services/knowledge-base/helpers/deploymentMode.mjs';
 
 const ingestToolName = 'ingest_source_files';
@@ -37,7 +37,7 @@ const assertToolTransportAllowed = toolName => {
     if (getEffectiveToolName(toolName) === ingestToolName && !isRemoteIngestDeployment()) {
         throw new Error(
             '`ingest_source_files` is only exposed when the Knowledge Base MCP server runs ' +
-            'with `transport: "sse"` (StreamableHTTP). Use `npm run ai:ingest-tenant` or ' +
+            'with `transport: "streamable-http"`. Use `npm run ai:ingest-tenant` or ' +
             'direct service ingestion for local stdio workflows.'
         );
     }
@@ -77,12 +77,12 @@ const ingestSourceFilesViaMcp = async args => {
 
     if (batchSize > threshold) {
         return {
-            error    : 'KB ingest work volume exceeds MCP-callable threshold',
-            message  : `Batch volume ${batchSize} exceeds the MCP-synchronous threshold ${threshold}. ` +
+            error  : 'KB ingest work volume exceeds MCP-callable threshold',
+            message: `Batch volume ${batchSize} exceeds the MCP-synchronous threshold ${threshold}. ` +
                        `Re-invoke ingest_source_files with at most ${threshold} files/chunks per call; ` +
                        `a tenant-scoped bulk ingestion facade is planned (Phase 2C).`,
-            code     : 'KB_INGEST_VOLUME_EXCEEDED',
-            bulkPath : null,
+            code    : 'KB_INGEST_VOLUME_EXCEEDED',
+            bulkPath: null,
             batchSize,
             threshold
         };

--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -45,7 +45,7 @@ function compactDefinedProperties(properties) {
  *
  * Handles initialization, configuration, and lifecycle management for the Memory Core MCP server.
  * This server uses a dual-transport architecture, allowing it to communicate with local CLI clients
- * via `stdio` (the default) or with cloud-native/remote clients via `sse` (StreamableHTTPServerTransport).
+ * via `stdio` (the default) or with cloud-native/remote clients via `streamable-http`.
  *
  * The transport mode and HTTP port can be configured using `aiConfig.transport` and `aiConfig.mcpHttpPort`.
  *
@@ -67,7 +67,7 @@ class Server extends BaseServer {
     /**
      * Resolved agent identity for stdio transport sessions. Populated by `boot()` via
      * `StdioIdentityResolver` + AgentIdentity graph-node binding. Null when
-     * running under SSE transport (identity flows per-request via `AuthService` /
+     * running under Streamable HTTP transport (identity flows per-request via `AuthService` /
      * `RequestContextService` instead) or when stdio resolution yielded no identity.
      * @member {Object|null} stdioIdentity=null
      * @protected
@@ -201,7 +201,7 @@ class Server extends BaseServer {
      * @summary Wraps tool dispatch in `RequestContextService.run()` when stdio identity is
      * resolved. Establishes the AsyncLocalStorage-scoped context that
      * `MemoryService.addMemory`, etc. read via `getUserId()` to tag ChromaDB writes per
-     * tenant. SSE mode leaves `stdioIdentity` null because `TransportService` already wraps
+     * tenant. Streamable HTTP mode leaves `stdioIdentity` null because `TransportService` already wraps
      * the `/mcp` request with per-request OIDC identity — re-wrapping here would clobber
      * that context.
      * @param {Function} dispatch
@@ -216,7 +216,7 @@ class Server extends BaseServer {
      * @summary Override of `BaseServer.createMcpServer` — chains super then registers the
      * mcpServer instance with `CoalescingEngineService` so it can broadcast wake events to
      * the SDK's `experimental.neo-wake-substrate` capability subscribers. Used both at boot
-     * and per-request (SSE mode) to provision dedicated server objects per connection.
+     * and per-request (Streamable HTTP mode) to provision dedicated server objects per connection.
      * @returns {McpServer}
      */
     createMcpServer() {
@@ -337,7 +337,7 @@ class Server extends BaseServer {
         }
 
         // Stdio identity resolution BEFORE healthcheck snapshot.
-        if (aiConfig.transport !== 'sse') {
+        if (this.aiConfig.transport === 'stdio') {
             this.stdioIdentity = await this.resolveStdioIdentity();
             HealthService.setStdioIdentityState(this.stdioIdentity);
 
@@ -374,7 +374,7 @@ class Server extends BaseServer {
 
         await this.connectTransport();
 
-        if (aiConfig.transport !== 'sse') {
+        if (this.aiConfig.transport === 'stdio') {
             this.logIdentityStatus();
         }
     }
@@ -411,7 +411,7 @@ class Server extends BaseServer {
     }
 
     /**
-     * @summary SSE-only hook: builds RequestContext for a `/mcp` request from `req.auth`.
+     * @summary Streamable-HTTP-only hook: builds RequestContext for a `/mcp` request from `req.auth`.
      * Invoked by `TransportService.setup` via duck-typed hook. Returns `{}` when no identity
      * is present to preserve single-tenant fallthrough.
      * @param {Object|undefined} reqAuth
@@ -598,7 +598,7 @@ class Server extends BaseServer {
     }
 
     /**
-     * @summary SSE-only hook fired by `TransportService` on session disconnect. Removes the
+     * @summary Streamable-HTTP-only hook fired by `TransportService` on session disconnect. Removes the
      * per-session McpServer from `CoalescingEngineService`'s broadcast set (counterpart to
      * `createMcpServer`'s `addMcpServer` registration) and writes a cheap idempotent
      * `SummarizationJobs.pending` marker. The orchestrator `summary` task drains that marker;
@@ -647,7 +647,7 @@ class Server extends BaseServer {
     /**
      * @summary Resolves a bare GitHub login to its seeded AgentIdentity graph node ID
      * using the `@`-prefixed AgentIdentity convention. Shared between `resolveStdioIdentity`
-     * (stdio boot) and `buildRequestContext` (per-SSE-request) so both transports reach the
+     * (stdio boot) and `buildRequestContext` (per-Streamable-HTTP request) so both transports reach the
      * same node lookup behavior.
      *
      * Missing node is non-fatal: returns `null`. Downstream services that build `AUTHORED_BY`

--- a/ai/mcp/server/memory-core/config.template.mjs
+++ b/ai/mcp/server/memory-core/config.template.mjs
@@ -88,12 +88,13 @@ class Config extends ConfigProvider {
              */
             debug: leaf(false, 'NEO_DEBUG', 'boolean'),
             /**
-             * Transport protocol for the MCP server ('stdio' or 'sse').
+             * Server transport protocol. Supported values are exactly `stdio` and `streamable-http`.
              * @type {string}
              */
             transport: leaf('stdio', 'NEO_TRANSPORT', 'string'),
             /**
-             * Port the MCP server's HTTP/SSE transport listens on (only used when `transport === 'sse'`).
+             * Port the MCP server's Streamable HTTP transport listens on (only used when
+             * `transport === 'streamable-http'`).
              *
              * Operator env var: `MCP_HTTP_PORT`.
              * @type {number}
@@ -102,7 +103,7 @@ class Config extends ConfigProvider {
             /**
              * Optional public canonical URL for this MCP server.
              * When configured, this URL is explicitly used as the resource indicator
-             * for OAuth 2.1 / OIDC audience claims and SSE callback advertising.
+             * for OAuth 2.1 / OIDC audience claims and protected-resource advertising.
              * Required when deploying behind reverse proxies (Nginx/Caddy) where
              * the internal host:port bindings do not match the public-facing URL.
              * Example: 'https://mcp.neo.mjs.com/memory-core'
@@ -119,7 +120,8 @@ class Config extends ConfigProvider {
              */
             allowedHosts: leaf(null, 'NEO_MCP_ALLOWED_HOSTS', 'string'),
             /**
-             * Optional Express middleware function for authentication (only used if transport is 'sse').
+             * Optional Express middleware function for authentication (only used when
+             * `transport === 'streamable-http'`).
              * @type {Function|null}
              */
             authMiddleware: leaf(null),

--- a/ai/mcp/server/shared/services/AuthMiddleware.mjs
+++ b/ai/mcp/server/shared/services/AuthMiddleware.mjs
@@ -2,7 +2,7 @@ import Base from '../../../../../src/core/Base.mjs';
 
 /**
  * Set of argument keys that an MCP tool caller MUST NOT supply — the server always derives
- * these from the active `RequestContextService` (OIDC Bearer token for SSE, stdio env-var /
+ * these from the active `RequestContextService` (OIDC Bearer token for Streamable HTTP, stdio env-var /
  * gh-CLI resolution). Client-supplied values would let a Gemini-harness
  * session forge a write attributed to `@neo-opus-ada`, etc.
  *
@@ -91,7 +91,7 @@ class AuthMiddleware extends Base {
                 throw new Error(
                     `Identity-override spoof rejected: '${key}' is a server-stamped field. ` +
                     `Remove it from tool arguments; the caller identity is derived from the ` +
-                    `active RequestContext (OIDC Bearer token for SSE, NEO_AGENT_IDENTITY or ` +
+                    `active RequestContext (OIDC Bearer token for Streamable HTTP, NEO_AGENT_IDENTITY or ` +
                     `gh-CLI resolution for stdio). See learn/agentos/tooling/MemoryCoreMcpAuth.md.`
                 );
             }

--- a/ai/mcp/server/shared/services/RequestContextService.mjs
+++ b/ai/mcp/server/shared/services/RequestContextService.mjs
@@ -143,7 +143,7 @@ export function resolveSummaryVisibilityUserId({userId, participatingAgents} = {
  *
  * **Identity flow:**
  *
- * 1. **SSE transport:** `AuthService.verifyAccessToken` validates the incoming Bearer
+ * 1. **Streamable HTTP transport:** `AuthService.verifyAccessToken` validates the incoming Bearer
  *    token via OIDC introspection and returns `{userId, username, ...}` on the auth context,
  *    extracted from the introspection response's `preferred_username` / `sub` / `name` /
  *    `email` claims. `TransportService` wraps each `/mcp` request with
@@ -153,7 +153,7 @@ export function resolveSummaryVisibilityUserId({userId, participatingAgents} = {
  *    looks up the matching AgentIdentity graph node, then wraps every
  *    `CallToolRequestSchema` dispatch with `RequestContextService.run({userId, username,
  *    agentIdentityNodeId, source: 'env-var' | 'gh-cli'}, ...)`. Stdio now reaches parity with
- *    SSE — per-agent GitHub account pinning tags writes with the correct tenant regardless of
+ *    Streamable HTTP — per-agent GitHub account pinning tags writes with the correct tenant regardless of
  *    transport.
  * 3. **Service-layer consumption:** `MemoryService.addMemory`, `SummaryService.querySummaries`,
  *    etc. call `RequestContextService.getUserId()` and either tag ChromaDB writes with
@@ -226,7 +226,7 @@ class RequestContextService extends Base {
      *                                                the identity is unbound (e.g. unseeded
      *                                                agent or stdio `unresolved` source).
      * @param {String}   [context.source]             Provenance tag indicating where this
-     *                                                identity originated: `'oidc'` (SSE bearer
+     *                                                identity originated: `'oidc'` (Streamable HTTP bearer
      *                                                token), `'env-var'` (stdio
      *                                                `NEO_AGENT_IDENTITY`), `'gh-cli'` (stdio
      *                                                `gh api user` fallback), or `'unresolved'`.
@@ -323,7 +323,7 @@ class RequestContextService extends Base {
 
         return new Error(
             `Cannot ${operation}: no agent identity context bound. No identity resolved — set ` +
-            `NEO_AGENT_IDENTITY (stdio) or provide a valid Bearer token (SSE multi-user mode).`
+            `NEO_AGENT_IDENTITY (stdio) or provide a valid Bearer token (Streamable HTTP multi-user mode).`
         );
     }
 

--- a/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
+++ b/ai/mcp/server/shared/services/StdioIdentityResolver.mjs
@@ -4,10 +4,10 @@ import Base       from '../../../../../src/core/Base.mjs';
 /**
  * @summary Resolves the active agent identity for stdio MCP transport sessions.
  *
- * The stdio transport has no request-level authentication primitive (unlike the SSE transport's
+ * The stdio transport has no request-level authentication primitive (unlike the Streamable HTTP transport's
  * OIDC Bearer token flow handled by `AuthService`). Identity must be pinned at process-boot time
  * so that every subsequent `callTool` dispatch inherits a consistent tenant tag via
- * `RequestContextService`, bringing stdio to **parity with the SSE identity propagation**.
+ * `RequestContextService`, bringing stdio to **parity with Streamable HTTP identity propagation**.
  *
  * **Resolution chain** (first match wins):
  *
@@ -24,7 +24,7 @@ import Base       from '../../../../../src/core/Base.mjs';
  *    failure — preserves the existing local-agent developer experience.
  *
  * **Intentionally NOT in scope:**
- * - OAuth2/OIDC token validation — that's `AuthService` (SSE transport only)
+ * - OAuth2/OIDC token validation — that's `AuthService` (Streamable HTTP transport only)
  * - AgentIdentity graph-node binding — the consumer (`memory-core/Server.mjs`) calls
  *   the shared `normalizeAgentIdentityNodeId()` boundary before the graph lookup, then
  *   composes the full RequestContext. Keeping the graph lookup out of this service preserves
@@ -32,7 +32,7 @@ import Base       from '../../../../../src/core/Base.mjs';
  *
  * This class is a key example of the framework's **multi-tenant identity resolution** model
  * and demonstrates concepts like **agent identity**, **OAuth fallback patterns**, **zero-friction
- * developer experience**, and **stdio-SSE transport parity**.
+ * developer experience**, and **stdio/Streamable-HTTP transport parity**.
  *
  * @class Neo.ai.mcp.server.shared.services.StdioIdentityResolver
  * @extends Neo.core.Base

--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -2,7 +2,7 @@ import Base                  from '../../../../../src/core/Base.mjs';
 import RequestContextService from './RequestContextService.mjs';
 
 /**
- * @summary Orchestrates the SSE transport layer and session lifecycle for MCP servers.
+ * @summary Orchestrates the Streamable HTTP transport layer and session lifecycle for MCP servers.
  *
  * This service manages the **Logical Transport Layer** using Express and the Streamable HTTP
  * transport. It provides a standardized environment for secure agent communication by
@@ -121,7 +121,7 @@ class TransportService extends Base {
     }
 
     /**
-     * Setups the SSE transport for an MCP server.
+     * @summary Sets up the Streamable HTTP transport for an MCP server.
      * @param {Object} options
      * @param {Object} options.server The Neo MCP Server instance
      * @param {Object} options.aiConfig The server configuration object
@@ -265,7 +265,7 @@ class TransportService extends Base {
         const port = aiConfig.mcpHttpPort;
         await new Promise((resolve, reject) => {
             this.httpServer = app.listen(port, () => {
-                logger.info(`[${resourceName}] Server started on SSE transport (Port: ${port})`);
+                logger.info(`[${resourceName}] Server started on Streamable HTTP transport (Port: ${port})`);
                 logger.info(`[${resourceName}] Available tools loaded from OpenAPI spec`);
                 resolve();
             });

--- a/ai/services/knowledge-base/SearchService.mjs
+++ b/ai/services/knowledge-base/SearchService.mjs
@@ -1,18 +1,18 @@
-import aiConfig                          from '../../mcp/server/knowledge-base/config.mjs';
-import Base                              from '../../../src/core/Base.mjs';
-import {buildChatModel}                  from '../../provider/buildChatModel.mjs';
-import {PROVIDER_TIMEOUT_CODE}           from '../../provider/createTimeoutError.mjs';
-import ChromaManager                     from './ChromaManager.mjs';
-import fs                                from 'fs-extra';
-import logger                            from '../../mcp/server/knowledge-base/logger.mjs';
-import path                              from 'path';
-import QueryService                      from './QueryService.mjs';
-import {checkAskRateLimit}               from './helpers/askRateLimit.mjs';
-import {isRemoteKnowledgeBaseDeployment} from './helpers/deploymentMode.mjs';
-import {getMissingAskSynthesisLeaves}    from './helpers/askSynthesisGuard.mjs';
-import GraphService                      from '../memory-core/GraphService.mjs';
+import aiConfig                                                                      from '../../mcp/server/knowledge-base/config.mjs';
+import Base                                                                          from '../../../src/core/Base.mjs';
+import {buildChatModel}                                                              from '../../provider/buildChatModel.mjs';
+import {PROVIDER_TIMEOUT_CODE}                                                       from '../../provider/createTimeoutError.mjs';
+import ChromaManager                                                                 from './ChromaManager.mjs';
+import fs                                                                            from 'fs-extra';
+import logger                                                                        from '../../mcp/server/knowledge-base/logger.mjs';
+import path                                                                          from 'path';
+import QueryService                                                                  from './QueryService.mjs';
+import {checkAskRateLimit}                                                           from './helpers/askRateLimit.mjs';
+import {isRemoteKnowledgeBaseDeployment}                                             from './helpers/deploymentMode.mjs';
+import {getMissingAskSynthesisLeaves}                                                from './helpers/askSynthesisGuard.mjs';
+import GraphService                                                                  from '../memory-core/GraphService.mjs';
 import {CONCEPT_EXPANSION_EDGE_TYPES, KB_TERMINAL_EDGE_TYPES, enrichWithConceptWalk} from '../graph/conceptAnchoredRetrieval.mjs';
-import {buildKbFileResolveCandidate}     from './conceptWalkKbFileGate.mjs';
+import {buildKbFileResolveCandidate}                                                 from './conceptWalkKbFileGate.mjs';
 
 const LOCAL_EMPTY_COLLECTION_ANSWER  = "The knowledge base collection is empty. Populate it with the release artifact via 'npm run ai:download-kb' (or build locally with 'npm run ai:sync-kb').";
 const REMOTE_EMPTY_COLLECTION_ANSWER = "The knowledge base collection is empty. In a cloud or remote tenant-ingestion deployment, inspect ingestion state first: call get_ingestion_progress(), then inspect_deployment or get_deployment_state_snapshot for tenantRepoSync / deployment-state details. For push-mode tenants, run the configured ingest_source_files or bulk tenant-ingest path before retrying the query.";
@@ -160,7 +160,7 @@ class SearchService extends Base {
     /**
      * Returns the operator-facing answer for a healthy but empty KB collection.
      *
-     * Local stdio deployments need the curated Neo corpus download/sync hint. Remote SSE deployments
+     * Local stdio deployments need the curated Neo corpus download/sync hint. Remote Streamable HTTP deployments
      * expose tenant-ingestion tools, so an empty collection is first an ingestion-state diagnostic.
      *
      * @returns {String} The empty-collection remediation message.

--- a/ai/services/knowledge-base/helpers/deploymentMode.mjs
+++ b/ai/services/knowledge-base/helpers/deploymentMode.mjs
@@ -9,5 +9,5 @@
  * @returns {Boolean} True when remote tenant-ingestion behavior should be enabled.
  */
 export function isRemoteKnowledgeBaseDeployment(aiConfig) {
-    return aiConfig.transport === 'sse'
+    return aiConfig.transport === 'streamable-http'
 }

--- a/ai/services/memory-core/CoalescingEngineService.mjs
+++ b/ai/services/memory-core/CoalescingEngineService.mjs
@@ -1,7 +1,7 @@
-import crypto                  from 'crypto';
-import Base                    from '../../../src/core/Base.mjs';
-import WebhookDeliveryService  from './WebhookDeliveryService.mjs';
-import logger                  from '../../mcp/server/memory-core/logger.mjs';
+import crypto                 from 'crypto';
+import Base                   from '../../../src/core/Base.mjs';
+import WebhookDeliveryService from './WebhookDeliveryService.mjs';
+import logger                 from '../../mcp/server/memory-core/logger.mjs';
 
 /**
  * @summary Token-economy throttle / coalescing engine for the cross-harness
@@ -81,7 +81,7 @@ class CoalescingEngineService extends Base {
      * @summary Registers an MCP server instance for push notifications.
      * @description Provides the engine with the handle needed to dispatch
      * notifications (Shape A) back to the client. Should be populated at boot
-     * or per-SSE session.
+     * or per-Streamable-HTTP session.
      * @param {McpServer} mcpServer
      */
     addMcpServer(mcpServer) {
@@ -192,7 +192,7 @@ class CoalescingEngineService extends Base {
     _resolveWindowMs(subscription) {
         const meta     = subscription.harnessTargetMetadata || {};
         const override = meta.coalesceWindow;
-        let seconds    = (override === undefined || override === null) ? this.defaultWindowSeconds : override;
+        let   seconds  = (override === undefined || override === null) ? this.defaultWindowSeconds : override;
         seconds        = Math.max(0, Math.min(this.maxWindowSeconds, Number(seconds) || 0));
         return seconds * 1000;
     }

--- a/ai/services/memory-core/HealthService.mjs
+++ b/ai/services/memory-core/HealthService.mjs
@@ -87,7 +87,7 @@ function heartbeatLivenessStaleMs() {
  * logic without bootstrapping the full Memory Core runtime.
  *
  * Three input shapes matter:
- * 1. `null` — stdioIdentity never populated (SSE transport, or resolver ran before the
+ * 1. `null` — stdioIdentity never populated (Streamable HTTP transport, or resolver ran before the
  *    setter was invoked). Projects to `{source: 'unresolved', bound: false, nodeId: null, warning: null}`.
  * 2. Resolved without graph node — a resolver yielded a userId but no seeded
  *    AgentIdentity graph node matched. Projects to `{source: <resolved>, bound: false, nodeId: null, warning}`.
@@ -98,7 +98,7 @@ function heartbeatLivenessStaleMs() {
  *    The success shape that A2A operation requires.
  *
  * Cloud / multi-tenant request identities (`proxy-header`, `oidc`) intentionally do not warn:
- * tenant users are not expected to have AgentIdentity graph nodes, and SSE healthcheck boot state
+ * tenant users are not expected to have AgentIdentity graph nodes, and Streamable HTTP healthcheck boot state
  * normally remains unresolved because request identity flows through `RequestContextService`.
  *
  * The projection itself stays pure and does not assign top-level health. The healthcheck
@@ -868,7 +868,7 @@ class HealthService extends Base {
     /**
      * Cached stdio identity state for the healthcheck `identity` observability block.
      * Populated by `Server.mjs` post-`resolveStdioIdentity()` via {@link HealthService#setStdioIdentityState}.
-     * Null when the setter hasn't fired yet (SSE transport, pre-boot, or timing races — all of
+     * Null when the setter hasn't fired yet (Streamable HTTP transport, pre-boot, or timing races — all of
      * which project to `source: 'unresolved'` via {@link buildIdentityBlock}).
      * @member {Object|null} #stdioIdentityState
      * @private
@@ -1802,8 +1802,8 @@ class HealthService extends Base {
     /**
      * Caches the resolved stdio identity so the healthcheck `identity` block can surface
      * it. Called by `Server.mjs` after `resolveStdioIdentity()` completes in the
-     * stdio boot path. SSE transport does not call this — per-request OIDC identity is
-     * orthogonal to process-level stdio identity; observability for SSE per-request state
+     * stdio boot path. Streamable HTTP transport does not call this — per-request OIDC identity is
+     * orthogonal to process-level stdio identity; observability for Streamable HTTP per-request state
      * is a separate concern.
      *
      * Clears the healthcheck cache so the next call returns a fresh payload including

--- a/ai/services/memory-core/MemoryService.mjs
+++ b/ai/services/memory-core/MemoryService.mjs
@@ -16,7 +16,7 @@ import {IDENTITIES, TRUST_TIERS, TRUST_TIER_ORDER}                              
 import {normalizeAgentIdentityNodeId}                                                                                                  from '../../graph/normalizeAgentIdentityNodeId.mjs';
 
 import {CONCEPT_EXPANSION_EDGE_TYPES, MEMORY_TERMINAL_EDGE_TYPES, enrichWithConceptWalk} from '../graph/conceptAnchoredRetrieval.mjs';
-import {buildMemoryResolveCandidate} from './conceptWalkMemoryGate.mjs';
+import {buildMemoryResolveCandidate}                                                     from './conceptWalkMemoryGate.mjs';
 
 /**
  * Re-exported from `./helpers/withTimeout.mjs` (moved there so `SessionService` can share it without
@@ -175,7 +175,7 @@ function buildMailboxDelta() {
  * It handles the creation of new memory entries (including embedding generation), retrieving memories by session,
  * and performing semantic searches to find relevant past interactions.
  *
- * **Multi-tenant isolation:** When a request arrives via SSE transport with a valid OIDC Bearer
+ * **Multi-tenant isolation:** When a request arrives via Streamable HTTP with a valid OIDC Bearer
  * token, `RequestContextService.getUserId()` returns the authenticated user's identifier
  * (derived from the token's `preferred_username` / `sub` claim). Writes (`addMemory`) tag
  * ChromaDB metadata with that `userId`; reads (`listMemories`, `queryMemories`, and the
@@ -399,7 +399,7 @@ class MemoryService extends Base {
             };
 
             // Tenant-isolation tag: present only when a request context was established
-            // by the SSE transport layer. In stdio mode it is absent — single-tenant fallthrough.
+            // by the Streamable HTTP transport layer. In stdio mode it is absent — single-tenant fallthrough.
             const requestIdentity   = RequestContextService.getAgentIdentityNodeId();
             const userId            = normalizeUserId(RequestContextService.getUserId());
             const canonicalIdentity = normalizeAgentIdentityNodeId(requestIdentity || userId || agent);

--- a/learn/agentos/DeploymentCookbook.md
+++ b/learn/agentos/DeploymentCookbook.md
@@ -207,7 +207,7 @@ Supply these values per service/profile as needed:
 
 | Variable | Target | Purpose |
 |---|---|---|
-| `NEO_TRANSPORT=sse` | KB, MC | HTTP/SSE transport for deployed MCP servers. |
+| `NEO_TRANSPORT=streamable-http` | KB, MC | Streamable HTTP transport for deployed MCP servers. |
 | `MCP_HTTP_PORT` | KB, MC | Internal listener port. Current baseline: KB `3000`, MC `3001`. |
 | `NEO_PUBLIC_URL` | KB, MC | Canonical public MCP URL used for advertised endpoints and auth callbacks. |
 | `NEO_CHROMA_HOST` | KB, MC, Orchestrator | Internal Chroma host, for example `chroma`. |

--- a/learn/agentos/SharedDeployment.md
+++ b/learn/agentos/SharedDeployment.md
@@ -122,7 +122,7 @@ cap or pre-load setting so the chat and embedding model stay resident together.
 
 Shared deployments need to know **which agent originated each request** so memories, summaries, and graph edges are attributed correctly. The Memory Core supports two authentication paths:
 
-1. **OIDC (default for production deployments)** — the operator deploys an OIDC identity provider (e.g. Keycloak, GitLab) and the MC server validates each SSE request's `Authorization: Bearer <token>` against it via `AuthService.verifyAccessToken`. The verified `userId` becomes the `req.auth` block consumed by `Server.mjs#buildRequestContext`. Source provenance: `source: 'oidc'`.
+1. **OIDC (default for production deployments)** — the operator deploys an OIDC identity provider (e.g. Keycloak, GitLab) and the MC server validates each Streamable HTTP request's `Authorization: Bearer <token>` against it via `AuthService.verifyAccessToken`. The verified `userId` becomes the `req.auth` block consumed by `Server.mjs#buildRequestContext`. Source provenance: `source: 'oidc'`.
 
 2. **Proxy identity injection (for deployments fronted by an identity-aware proxy)** — when an `oauth2-proxy`-style reverse proxy already terminates OIDC and injects `X-PREFERRED-USERNAME` (or the oauth2-proxy-specific `X-Auth-Request-Preferred-Username`) into the upstream request, the MC server can read that header instead of running its own OIDC verification. Gated by `auth.trustProxyIdentity`. Source provenance: `source: 'proxy-header'`.
 
@@ -130,14 +130,14 @@ The two paths are NOT mutually exclusive — `req.auth` (OIDC) takes precedence 
 
 ### Configuration: Canonical `publicUrl` (PR #10802)
 
-When deploying behind a reverse proxy that uses a public domain (e.g., `https://mcp.neo.mjs.com`), the MCP server MUST know its public canonical URL to advertise correct Server-Sent Events (SSE) endpoints and validate OAuth audience claims.
+When deploying behind a reverse proxy that uses a public domain (e.g., `https://mcp.neo.mjs.com`), the MCP server MUST know its public canonical URL to advertise the correct protected resource and validate OAuth audience claims.
 
 ```bash
 # Set the canonical public URL for the server
 export NEO_PUBLIC_URL=https://mcp.neo.mjs.com/mc
 ```
 
-The `publicUrl` property decouples the public-facing URL from the internal `HOST` and `PORT` bindings, fixing SSE callback and OIDC redirect mismatches behind proxies.
+The `publicUrl` property decouples the public-facing URL from the internal `HOST` and `PORT` bindings, fixing advertised-resource and OIDC audience mismatches behind proxies.
 
 ### Configuration: `trustProxyIdentity` (PR #10768 / #10727)
 
@@ -252,7 +252,7 @@ The active auth path is asserted at runtime and surfaced per-request via the mem
 
 In a shared deployment, multiple agents connect and disconnect dynamically. To ensure session summaries are automatically available to the team without requiring manual API calls or external cron jobs, the Memory Core leverages a **disconnect-triggered summarization** primitive.
 
-When an MCP client (agent) disconnects from the Server-Sent Events (SSE) transport, the `TransportService` intercepts the termination and signals the Memory Core. The server immediately queues a `pending` summarization marker in its `SummarizationJobs` SQLite coordinator table. This behavior is gated by the `autoSummarize` feature flag. For local multi-harness duplication, single-writer enforcement is guaranteed by the `wake-daemon`. The daemon acts as a host-level singleton via a `PID_FILE` lock, and uses an in-process mutex to prevent summarization races across instances sharing the same Chroma collection. For remote multi-user Memory Core deployments, write visibility and isolation are maintained through request-scoped identity context.
+When an MCP client (agent) disconnects from a Streamable HTTP session, the `TransportService` intercepts the termination and signals the Memory Core. The server immediately queues a `pending` summarization marker in its `SummarizationJobs` SQLite coordinator table. This behavior is gated by the `autoSummarize` feature flag. For local multi-harness duplication, single-writer enforcement is guaranteed by the `wake-daemon`. The daemon acts as a host-level singleton via a `PID_FILE` lock, and uses an in-process mutex to prevent summarization races across instances sharing the same Chroma collection. For remote multi-user Memory Core deployments, write visibility and isolation are maintained through request-scoped identity context.
 
 This allows the heavy LLM summarization process to run asynchronously in the background. Because it relies on the unified `SummarizationJobs` table and the daemon's singleton lease, it naturally handles concurrent agent disconnects and server clustering without duplicating summaries. Team members can query the Memory Core and instantly access the completed session context once the background job finishes.
 

--- a/learn/agentos/cloud-deployment/ClientAuthentication.md
+++ b/learn/agentos/cloud-deployment/ClientAuthentication.md
@@ -1,6 +1,6 @@
 # Authenticating to a Deployed MCP Server
 
-A deployed Neo.mjs MCP server (Knowledge Base or Memory Core) supports two server-side authorization modes for its SSE / HTTP transport. This guide covers the **GitLab bearer** mode (`NEO_AUTH_MODE=gitlab-pat`): the server validates any GitLab bearer token against the GitLab API, with no cookie. **The client chooses how to obtain that bearer — an OAuth browser login (preferred) or a long-lived Personal Access Token (fallback) — and the server accepts both.**
+A deployed Neo.mjs MCP server (Knowledge Base or Memory Core) supports two server-side authorization modes for its Streamable HTTP transport. This guide covers the **GitLab bearer** mode (`NEO_AUTH_MODE=gitlab-pat`): the server validates any GitLab bearer token against the GitLab API, with no cookie. **The client chooses how to obtain that bearer — an OAuth browser login (preferred) or a long-lived Personal Access Token (fallback) — and the server accepts both.**
 
 > For the OIDC / OAuth 2.1 **server** mode (Keycloak, Google — where the server itself advertises Protected-Resource-Metadata and introspects tokens), see [MCP Server Authorization](../tooling/Authorization.md). That is a *different server mode* from this one: in `gitlab-pat` mode the server stays a bare-`401` resource that validates via `/api/v4/user`, and all the OAuth work happens on the **client** side (Path A below). OIDC remains the production default; `gitlab-pat` is opt-in via `NEO_AUTH_MODE`.
 

--- a/learn/agentos/cloud-deployment/Configuration.md
+++ b/learn/agentos/cloud-deployment/Configuration.md
@@ -38,14 +38,14 @@ A deployment's `config.mjs` is gitignored and copied from `config.template.mjs`.
 | `spoofRejectionMode` | `'overwrite'` | Policy for conflicting client-supplied tenant metadata. `'overwrite'` logs + replaces with server-derived values; `'reject'` fails the call with `KB_TENANT_SPOOF_REJECTED`. A multi-tenant cloud deployment should consider `'reject'` (fail-closed) — see [Security](./Security.md). |
 | `mcpSyncMaxChunks` | `50` | The [#10572](https://github.com/neomjs/neo/issues/10572) work-volume gate threshold — an MCP-callable sync/ingest batch over this count is refused (the bulk CLI bypasses it). See [Hook Wiring](./HookWiring.md). |
 
-### Transport + auth (cloud / SSE)
+### Transport + auth (cloud / Streamable HTTP)
 
 | Key | Default | Meaning |
 |---|---|---|
-| `transport` | `'stdio'` | `'stdio'` (local single-repo) or `'sse'` (StreamableHTTP — a cloud deployment serving remote tenants). |
-| `mcpHttpPort` | `3000` | The port the SSE transport listens on (only when `transport === 'sse'`). |
-| `publicUrl` | `null` | Canonical public URL — required behind a reverse proxy for OAuth 2.1 / OIDC audience claims + SSE callback advertising. |
-| `auth.mode` | `'oidc'` | Server-side bearer strategy for HTTP/SSE: `'oidc'` uses OIDC introspection + audience enforcement; `'gitlab-pat'` validates a GitLab OAuth token or PAT against `/api/v4/user` and returns a bare bearer challenge on failure. |
+| `transport` | `'stdio'` | `'stdio'` (local single-repo) or `'streamable-http'` (a cloud deployment serving remote tenants). These are the only supported server values. |
+| `mcpHttpPort` | `3000` | The port the Streamable HTTP transport listens on (only when `transport === 'streamable-http'`). |
+| `publicUrl` | `null` | Canonical public URL — required behind a reverse proxy for OAuth 2.1 / OIDC audience claims and protected-resource advertising. |
+| `auth.mode` | `'oidc'` | Server-side bearer strategy for Streamable HTTP: `'oidc'` uses OIDC introspection + audience enforcement; `'gitlab-pat'` validates a GitLab OAuth token or PAT against `/api/v4/user` and returns a bare bearer challenge on failure. |
 | `auth.issuerUrl` / `auth.host` / `auth.realm` | `null` / `null` / `'master'` | OIDC authority inputs for the default server mode. `issuerUrl` is preferred when the provider publishes discovery metadata directly. |
 | `auth.clientId` / `auth.clientSecret` | `null` / `''` | OIDC introspection client credentials for deployments that require them. |
 | `auth.trustProxyIdentity` | `false` | Accept identity from a trusted reverse-proxy header after the ingress strips spoofable client-supplied headers. |
@@ -59,6 +59,14 @@ same `/mcp` route as external callers. When a deployment sets
 the server can answer correctly while Compose keeps it unhealthy.
 
 Each key is also bindable via an environment variable (`NEO_KB_DEFAULT_TENANT_ID`, `NEO_TRANSPORT`, `MCP_HTTP_PORT`, …) — see `config.template.mjs`'s `envBindings` map for the full set.
+
+> [!IMPORTANT]
+> **v13.2 server-value migration:** replace `NEO_TRANSPORT=sse` with
+> `NEO_TRANSPORT=streamable-http` (or make the equivalent `aiConfig.transport`
+> edit) before upgrading. The old server value now fails startup with a migration
+> error; it no longer falls through to stdio. Update configuration and rebuild or
+> recreate the affected MCP servers together with the Neo upgrade. This does not
+> change the MCP client's separate `transportType: 'sse'` legacy capability.
 
 ## Tenant push-client environment
 

--- a/learn/agentos/cloud-deployment/HookWiring.md
+++ b/learn/agentos/cloud-deployment/HookWiring.md
@@ -10,15 +10,15 @@ For the operator-facing decision model — how to choose repo slugs, treat crede
 
 | Surface | Caller | Volume policy | Built for |
 |---|---|---|---|
-| `ingest_source_files` | A remote MCP client of the `sse` / StreamableHTTP deployment — an agent in the tenant workspace, or a tenant push client | Gated — refuses a batch over `mcpSyncMaxChunks` (default 50); listed/callable only when the KB server runs with `transport === 'sse'` | Incremental pushes: a commit's worth of changed files |
-| `npm run ai:kb-push-client` | A tenant git hook or CI job; wraps the remote MCP call | Same MCP gate as `ingest_source_files` | Operator-facing repo-push invocation over StreamableHTTP/SSE |
+| `ingest_source_files` | A remote MCP client of the Streamable HTTP deployment — an agent in the tenant workspace, or a tenant push client | Gated — refuses a batch over `mcpSyncMaxChunks` (default 50); listed/callable only when the KB server runs with `transport === 'streamable-http'` | Incremental pushes: a commit's worth of changed files |
+| `npm run ai:kb-push-client` | A tenant git hook or CI job; wraps the remote MCP call | Same MCP gate as `ingest_source_files` | Operator-facing repo-push invocation over the configured remote MCP client transport |
 | `npm run ai:ingest-tenant` | A shell process co-located with the KB server — the cloud operator, a CI job | Ungated (`viaMcp: false`) | Initial tenant onboarding (5k–50k chunks), large back-fills |
 
 The fork between them is the [#10572](https://github.com/neomjs/neo/issues/10572) **MCP work-volume gate**. An MCP tool call holds the calling agent's turn open; embedding tens of thousands of chunks synchronously inside one call is the wrong shape. The gate makes that structural — `ingest_source_files` *refuses* an over-volume batch (it returns a refusal payload, it does not block), and the bulk CLI is the sanctioned path for the volume the gate rejects. `viaMcp: false` — passed only by the CLI — is the single sanctioned gate bypass.
 
 ## Transport and auth model
 
-The KB MCP server runs dual-transport (`ai/mcp/server/knowledge-base/Server.mjs`): `stdio` for a local single-repo deployment, or `sse` (StreamableHTTP) for a cloud deployment serving remote tenants — selected by `aiConfig.transport` with `aiConfig.mcpHttpPort`. `ingest_source_files` is transport-gated: it is listed and callable only when the KB server runs with `transport === 'sse'`. Local `stdio` clients do not see it and direct calls fail closed with guidance to use the local CLI/service path instead. The `ai:ingest-tenant` CLI is **not** a remote facade — it imports the KB services directly and runs on the deployment host.
+The KB MCP server runs dual-transport (`ai/mcp/server/knowledge-base/Server.mjs`): `stdio` for a local single-repo deployment, or `streamable-http` for a cloud deployment serving remote tenants — selected by `aiConfig.transport` with `aiConfig.mcpHttpPort`. `ingest_source_files` is transport-gated: it is listed and callable only when the KB server runs with `transport === 'streamable-http'`. Local `stdio` clients do not see it and direct calls fail closed with guidance to use the local CLI/service path instead. The `ai:ingest-tenant` CLI is **not** a remote facade — it imports the KB services directly and runs on the deployment host.
 
 The deployable repo-push path is `npm run ai:kb-push-client`. It is a tenant-side MCP client wrapper around `ingest_source_files`:
 
@@ -145,7 +145,7 @@ A `pre-push` hook is the recommended trigger: it fires once per `git push`, rece
 1. Read the pushed ref range (`<local-ref> <local-sha> <remote-ref> <remote-sha>`) from the hook's stdin.
 2. Enumerate changed files — `git diff --name-only --diff-filter=ACMR <remote-sha> <local-sha>` for adds/modifies, `--diff-filter=D` for deletes.
 3. Assemble the envelope — changed files into `files`, deleted paths into `deleted`, the SHA pair into `baseRevision` / `headRevision`.
-4. Submit it — when `NEO_KB_MCP_URL` is configured, pipe the envelope to `ai:kb-push-client`, which calls the `sse` / StreamableHTTP `ingest_source_files` endpoint; an initial import of an existing repo still goes to the deployment-host bulk CLI. In local `stdio` mode, use the CLI/service path instead; the MCP tool is intentionally hidden.
+4. Submit it — when `NEO_KB_MCP_URL` is configured, pipe the envelope to `ai:kb-push-client`, which calls the remote `ingest_source_files` endpoint; an initial import of an existing repo still goes to the deployment-host bulk CLI. In local `stdio` mode, use the CLI/service path instead; the MCP tool is intentionally hidden.
 5. Inspect the returned summary — a non-empty `errors` array fails the hook so the developer sees it.
 
 The example combines **tombstones + revision-boundary** — the precise-but-cheap pair for a hook that already runs `git diff`.

--- a/learn/agentos/cloud-deployment/Security.md
+++ b/learn/agentos/cloud-deployment/Security.md
@@ -58,7 +58,7 @@ The invariant that holds regardless of the transport: **the tenant tuple is
 server-derived from the authenticated identity, never trusted from the
 payload.**
 
-The shipped HTTP/SSE deployment has three identity shapes:
+The shipped Streamable HTTP deployment has three identity shapes:
 
 - **OIDC server mode** (`NEO_AUTH_MODE=oidc`, the default) validates
   `Authorization: Bearer <token>` through the configured issuer, enforces the

--- a/learn/agentos/cloud-deployment/TenantIngestionModel.md
+++ b/learn/agentos/cloud-deployment/TenantIngestionModel.md
@@ -20,8 +20,8 @@ Use the same underlying ingestion service through three operational surfaces:
 
 | Surface | Use when | Volume / lifecycle |
 |---|---|---|
-| `ingest_source_files` | A tenant agent or push client sends a bounded incremental change set to the cloud MCP endpoint running with `transport === 'sse'`. | MCP-callable only in the remote StreamableHTTP profile and volume-gated by `mcpSyncMaxChunks`; split or use the CLI when the gate refuses. |
-| `npm run ai:kb-push-client` | A tenant git hook or CI job needs an operator-facing invocation wrapper for the remote MCP call. | Runs in the tenant workspace, uses StreamableHTTP/SSE, carries an automation identity bearer token, and preserves the MCP gate. |
+| `ingest_source_files` | A tenant agent or push client sends a bounded incremental change set to the cloud MCP endpoint running with `transport === 'streamable-http'`. | MCP-callable only in the remote Streamable HTTP profile and volume-gated by `mcpSyncMaxChunks`; split or use the CLI when the gate refuses. |
+| `npm run ai:kb-push-client` | A tenant git hook or CI job needs an operator-facing invocation wrapper for the remote MCP call. | Runs in the tenant workspace, uses the configured remote MCP client transport, carries an automation identity bearer token, and preserves the MCP gate. |
 | `npm run ai:ingest-tenant -- <tenantId> ...` | A deployment operator, CI job, or onboarding script performs an initial import, full backfill, or large re-push. | Runs on the deployment host, bypasses the MCP turn-volume gate via `viaMcp: false`, and holds the heavy-maintenance lease. |
 
 All three surfaces call `KnowledgeBaseIngestionService.ingestSourceFiles()`. The MCP facade is hidden and fail-closed for local `stdio` server sessions because repo-push ingestion is an operator-facing remote deployment path, not an interactive local agent tool. A future non-MCP HTTP/queue receiver may share the same service, but it is not the shipped #11743 path.

--- a/learn/agentos/cloud-deployment/Troubleshooting.md
+++ b/learn/agentos/cloud-deployment/Troubleshooting.md
@@ -18,7 +18,7 @@ Work top-to-bottom — each error means you cleared the layer above it.
 
 ### `Not Acceptable: Client must accept text/event-stream`
 
-**Layer:** you reached the MCP endpoint — it is a Streamable-HTTP / SSE endpoint, not a web page; the client omitted the required `Accept` header.
+**Layer:** you reached the Streamable HTTP MCP endpoint, not a web page; the client omitted the required `Accept` header.
 
 **Fix:** send `Accept: application/json, text/event-stream` on every request.
 
@@ -42,7 +42,7 @@ Work top-to-bottom — each error means you cleared the layer above it.
 
 ### A body of `event: message` / `data: {…}`
 
-**Not an error.** That is the normal Streamable-HTTP / SSE framing — a successful `initialize` returns `event: message` plus a `data:` line carrying the JSON-RPC result (including `serverInfo`).
+**Not an error.** That is normal SSE response framing within Streamable HTTP — a successful `initialize` returns `event: message` plus a `data:` line carrying the JSON-RPC result (including `serverInfo`).
 
 ## Deployment gotchas
 
@@ -178,7 +178,7 @@ curl -sS -X POST "$URL" "${AUTH[@]}" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
 ```
 
-A healthy server returns `event: message` SSE framing carrying the JSON-RPC results. A `Server not initialized` error means step 1's handshake was skipped.
+A healthy Streamable HTTP server can return `event: message` SSE framing carrying the JSON-RPC results. A `Server not initialized` error means step 1's handshake was skipped.
 
 > There is no auth-free `GET /health` liveness endpoint today — the server exposes only the authenticated `/mcp` route — so external liveness checks run the `initialize` handshake above (or rely on the container's internal healthcheck).
 

--- a/learn/agentos/measurements/ConfigSubstrateEnvVarAudit.md
+++ b/learn/agentos/measurements/ConfigSubstrateEnvVarAudit.md
@@ -30,7 +30,7 @@ Target-tier shorthand:
 
 | env var | current readers | target tier | deletion/keep rationale |
 |---|---|---|---|
-| `NEO_AUTH_HOST` | `memory-core/config.template.mjs:125`; `knowledge-base/config.template.mjs:70` | Tier 3 | Runtime binding for OAuth/OIDC authority host in deployed SSE mode. |
+| `NEO_AUTH_HOST` | `memory-core/config.template.mjs:125`; `knowledge-base/config.template.mjs:70` | Tier 3 | Runtime binding for OAuth/OIDC authority host in deployed Streamable HTTP mode. |
 | `NEO_AUTH_ISSUER_URL` | `memory-core/config.template.mjs:128`; `knowledge-base/config.template.mjs:73` | Tier 3 | Runtime binding for external issuer URL behind reverse proxies. |
 | `NEO_AUTH_PORT` | `memory-core/config.template.mjs:126`; `knowledge-base/config.template.mjs:71` | Tier 3 | Runtime binding for local auth server port; keep env-overridable for deployment. |
 | `NEO_AUTH_REALM` | `memory-core/config.template.mjs:127`; `knowledge-base/config.template.mjs:72` | Tier 3 | Runtime binding for auth realm; deployment/operator concern. |
@@ -47,7 +47,7 @@ Target-tier shorthand:
 | `NEO_GRAPH_DECAY_FACTOR` | `memory-core/config.template.mjs:281` | Tier 2 | Memory Core graph tuning. Prefer per-server config default over env keep-list. |
 | `HOST` | `shared/services/TransportService.mjs:112` | Defer | Bare generic env fallback for advertised URL construction. `NEO_PUBLIC_URL` is the canonical deployment surface; #10825/Phase 1.5 should decide whether `HOST` remains. |
 | `LOCALAPPDATA` | `memory-core/services/lifecycle/InferenceLifecycleService.mjs:120` | Tier 3 | Host OS discovery for Windows local inference integration; not a Neo operator var but legitimate process environment input. |
-| `MCP_HTTP_PORT` | `shared/helpers/DeploymentConfig.mjs:36`; `memory-core/config.template.mjs:103`; `knowledge-base/config.template.mjs:48` | Tier 3 | Runtime binding for SSE/HTTP server port. Keep one canonical name per concept. |
+| `MCP_HTTP_PORT` | `shared/helpers/DeploymentConfig.mjs:36`; `memory-core/config.template.mjs:103`; `knowledge-base/config.template.mjs:48` | Tier 3 | Runtime binding for the Streamable HTTP server port. Keep one canonical name per concept. |
 | `NEO_MEMORY_COLLECTION_NAME` | `memory-core/config.template.mjs:259` | Tier 2 | Collection name default; move to per-server config unless container override remains a proven need. |
 | `NEO_AGENT_ID` | `knowledge-base/Server.mjs:189,191`; `knowledge-base/services/KBRecorderService.mjs:202`; `knowledge-base/services/toolService.mjs:42` | Tier 3 | Identity binding for KB telemetry and request attribution. Keep until request-context identity fully replaces it. |
 | `NEO_AGENT_IDENTITY` | `shared/services/StdioIdentityResolver.mjs:70` | Tier 3 | Canonical local agent identity binding for stdio MCP sessions. |
@@ -92,7 +92,7 @@ Target-tier shorthand:
 | `NEO_REAL_TIME_MEMORY_PARSING` | `memory-core/config.template.mjs:80` | Tier 3 | Operator one-shot/daemon toggle; keep opt-in env to prevent accidental graph writes. |
 | `NEO_SESSION_COLLECTION_NAME` | `memory-core/config.template.mjs:260` | Tier 2 | Collection name default; move to per-server config unless deployment override remains necessary. |
 | `SSE_PORT` | `shared/helpers/DeploymentConfig.mjs:37` | Delete | Legacy dev-branch-only alias targeted by #10823. |
-| `NEO_TRANSPORT` | `memory-core/config.template.mjs:95`; `knowledge-base/config.template.mjs:40` | Tier 3 | Runtime binding for stdio vs SSE server mode. |
+| `NEO_TRANSPORT` | `memory-core/config.template.mjs:95`; `knowledge-base/config.template.mjs:40` | Tier 3 | Runtime binding for `stdio` vs `streamable-http` server mode. |
 | `USER` | `knowledge-base/Server.mjs:189,191`; `knowledge-base/services/KBRecorderService.mjs:202`; `knowledge-base/services/toolService.mjs:42` | Tier 3 | Host identity fallback. Keep as fallback only while request-bound identity migration remains incomplete. |
 
 ## Count Summary

--- a/learn/agentos/tooling/AgentAgnosticMcpConfig.md
+++ b/learn/agentos/tooling/AgentAgnosticMcpConfig.md
@@ -89,7 +89,7 @@ Key components of a server include:
 
 1.  **Dual Transport Architecture**: The servers are built to support multiple transport layers depending on the environment:
     *   **`StdioServerTransport`**: The default behavior. Servers communicate over the standard input/output of their process. This eliminates the need for port management and network configuration, making it perfect for local CLI agents.
-    *   **`StreamableHTTPServerTransport` (SSE)**: Configurable via the `transport: 'sse'` setting. The servers will dynamically load an Express app and expose a unified `/mcp` endpoint. This is essential for deploying the servers as containerized microservices (e.g., Docker) where `stdio` is not accessible to remote agents.
+    *   **`StreamableHTTPServerTransport`**: Configurable via the server-side `transport: 'streamable-http'` setting. The servers dynamically load an Express app and expose a unified `/mcp` endpoint. This is essential for deploying the servers as containerized microservices (e.g., Docker) where `stdio` is not accessible to remote agents. Client-side `type: 'sse'` remains a distinct legacy transport for endpoints that actually implement it.
 
 2.  **`openapi.yaml`**: Each server has an OpenAPI 3 specification that defines the tools it provides. The `operationId` of each path becomes the tool's name, and the schema and description are used to generate the tool manifest for the agent. This provides a structured, language-agnostic way to define capabilities.
 

--- a/learn/agentos/tooling/Authorization.md
+++ b/learn/agentos/tooling/Authorization.md
@@ -16,7 +16,7 @@ Neo.mjs MCP servers (Knowledge Base and Memory Core) include built-in support fo
 
 ## Configuration
 
-To enable authorization on your MCP server, you must use the **SSE transport** and provide the following environment variables.
+To enable authorization on your MCP server, you must use the **Streamable HTTP transport** and provide the following environment variables.
 
 ### Environment Variables
 
@@ -56,7 +56,7 @@ The server intelligently resolves URLs:
 4. **Configure .env:**
    ```bash
    # MCP Server Config
-   NEO_TRANSPORT=sse
+   NEO_TRANSPORT=streamable-http
    MCP_HTTP_PORT=3000   # legacy alias `SSE_PORT` still works during the #10808 deprecation window
 
    # Auth Config
@@ -79,7 +79,7 @@ The server validates incoming `Authorization: Bearer <token>` headers by calling
 To prevent token passthrough attacks, the server verifies that the token's audience matches its own public URL (`HOST` + `MCP_HTTP_PORT`).
 
 ### CORS Support
-The SSE transport includes CORS middleware by default:
+The Streamable HTTP transport includes CORS middleware by default:
 - **Origin:** `*`
 - **Exposed Headers:** `Mcp-Session-Id` (required for session tracking in browser clients).
 
@@ -115,7 +115,7 @@ export default {
     // Custom Express middleware
     authMiddleware: (req, res, next) => {
         const apiKey = req.headers['x-api-key'];
-        
+
         // ALWAYS use environment variables for secrets
         if (apiKey && apiKey === process.env.MY_CUSTOM_API_KEY) {
             next();

--- a/learn/agentos/tooling/GoogleAuthDemo.md
+++ b/learn/agentos/tooling/GoogleAuthDemo.md
@@ -29,7 +29,7 @@ Update your `.env` file or IaC environment variables.
 Google provides a standard OIDC discovery endpoint. This is the easiest way to configure the server.
 
 ```bash
-NEO_TRANSPORT=sse
+NEO_TRANSPORT=streamable-http
 MCP_HTTP_PORT=3000   # legacy alias `SSE_PORT` still works during the #10808 deprecation window
 HOST=mcp.yourdomain.com
 
@@ -47,7 +47,7 @@ Ensure `HOST` is set correctly. If your server is behind a load balancer with SS
 ## Step 3: Technical Nuances
 
 ### Token Introspection
-Unlike Keycloak, Google does not strictly adhere to the RFC 7662 introspection spec for all token types in the same way. However, for **OpenID Connect**, the MCP SDK handles the validation of the Bearer token. 
+Unlike Keycloak, Google does not strictly adhere to the RFC 7662 introspection spec for all token types in the same way. However, for **OpenID Connect**, the MCP SDK handles the validation of the Bearer token.
 
 ### Audience (aud) Validation
 Google ID Tokens include the `aud` field, which matches your `NEO_OAUTH_CLIENT_ID`. The Neo.mjs MCP server will validate that the incoming token's audience is authorized to access the resource.

--- a/learn/agentos/tooling/Introduction.md
+++ b/learn/agentos/tooling/Introduction.md
@@ -90,7 +90,7 @@ The servers are built using the **Neo.mjs Class System**. Every service (e.g., `
 
 ### 3. Transport Agnosticism
 
-While our default configuration uses `stdio` (standard input/output) for maximum security (local subprocesses only), the architecture is transport-agnostic. The servers can be easily exposed via HTTP/SSE for remote usage if needed, as the business logic is fully decoupled from the transport layer.
+While our default configuration uses `stdio` (standard input/output) for maximum security (local subprocesses only), the architecture is transport-agnostic. The servers can be exposed via Streamable HTTP for remote usage when needed, as the business logic is fully decoupled from the transport layer.
 
 ## Getting Started
 

--- a/learn/agentos/tooling/MCPServerBaseClass.md
+++ b/learn/agentos/tooling/MCPServerBaseClass.md
@@ -2,7 +2,7 @@
 
 The `BaseServer` class (`Neo.ai.mcp.server.BaseServer`) provides a standardized template-method scaffold for all Neo.mjs MCP servers (Memory Core, Knowledge Base, GitHub Workflow, Neural Link, File System).
 
-It was introduced during the **M2 Migration Series** (Ticket #10965) to eliminate boilerplate duplication, standardize the boot lifecycle, and unify transport logic (stdio and SSE) across the entire suite.
+It was introduced during the **M2 Migration Series** (Ticket #10965) to eliminate boilerplate duplication, standardize the boot lifecycle, and unify transport logic (stdio and Streamable HTTP) across the entire suite.
 
 ## Core Responsibilities
 
@@ -11,7 +11,7 @@ The base class lifts the following common boilerplate out of individual servers:
 - **Request Handlers:** Wiring up the default `ListToolsRequestSchema` and `CallToolRequestSchema` handlers.
 - **Result Formatting:** Wrapping tool results or exceptions in the standard MCP envelope (`{content, isError, structuredContent?}`).
 - **Health Gating:** Intercepting tool calls to execute pre-dispatch health checks, gracefully degrading unready servers instead of crashing.
-- **Transport Connection:** Selecting and connecting the correct transport (stdio vs SSE) based on runtime configuration.
+- **Transport Connection:** Selecting and connecting the correct transport (`stdio` or `streamable-http`) based on runtime configuration, while rejecting every unknown server value.
 
 ## Extension Model
 
@@ -33,8 +33,8 @@ Subclasses MAY override these to augment behavior:
 - `beforeToolDispatch(context)`: Fires **before** the health check in `CallTool`. Throwing here aborts the call as a tool error (e.g., identity spoof validation).
 - `onHealthGateFailure(context)`: Fires when the health check rejects a call. Useful for telemetry (e.g., knowledge-base logging blocked dispatches).
 - `logStartupStatus(health)`: Formats the post-healthcheck startup log line.
-- `buildRequestContext(reqAuth)`: *(SSE-only)* Builds per-request context structures.
-- `onSessionClosed(sessionId, mcpServerInstance)`: *(SSE-only)* Fired when an SSE session disconnects.
+- `buildRequestContext(reqAuth)`: *(Streamable-HTTP-only)* Builds per-request context structures.
+- `onSessionClosed(sessionId, mcpServerInstance)`: *(Streamable-HTTP-only)* Fired when a Streamable HTTP session disconnects.
 
 ## The Canonical Boot Sequence
 

--- a/learn/agentos/tooling/MemoryCoreMcpAuth.md
+++ b/learn/agentos/tooling/MemoryCoreMcpAuth.md
@@ -1,6 +1,6 @@
 # Memory Core MCP Authentication
 
-The Memory Core MCP server enforces **tenant-scoped identity** on every tool invocation — regardless of whether the caller connects over **stdio** (local agents, CI runners) or **SSE** (cloud-native, multi-tenant deployments). This guide describes the dual-path identity resolution, the `AgentIdentity` graph-node binding, and the anti-spoof invariant that together close the multi-tenant isolation contract shipped across tickets #10000, #10144, and #10145.
+The Memory Core MCP server enforces **tenant-scoped identity** on every tool invocation — regardless of whether the caller connects over **stdio** (local agents, CI runners) or **Streamable HTTP** (cloud-native, multi-tenant deployments). This guide describes the dual-path identity resolution, the `AgentIdentity` graph-node binding, and the anti-spoof invariant that together close the multi-tenant isolation contract shipped across tickets #10000, #10144, and #10145.
 
 ## Why Identity Matters Here
 
@@ -16,19 +16,19 @@ Three invariants together close the contract:
 
 | Transport | Identity Source | Implementation |
 |---|---|---|
-| **SSE** | OIDC Bearer-token introspection, or GitLab bearer validation in `gitlab-pat` mode | `AuthService.verifyAccessToken` (shipped in #10000) and `AuthService.createGitlabPatVerifier()` |
+| **Streamable HTTP** | OIDC Bearer-token introspection, or GitLab bearer validation in `gitlab-pat` mode | `AuthService.verifyAccessToken` (shipped in #10000) and `AuthService.createGitlabPatVerifier()` |
 | **stdio** | `NEO_AGENT_IDENTITY` env-var, then `gh api user` fallback | `StdioIdentityResolver` (ticket #10145) |
 
 Both paths end at the same destination: a `RequestContextService.run(context, ...)` wrap around tool dispatch, where the `context` shape is identical. Service-layer code reading `RequestContextService.getUserId()` is transport-agnostic.
 
-### SSE Path — OIDC via `AuthService`
+### Streamable HTTP Path — OIDC via `AuthService`
 
 Operators configure the Memory Core with either an OIDC discovery URL or a Keycloak-style issuer/realm pair. The `AuthService` handles discovery, token introspection, audience enforcement, and extracts `preferred_username` / `sub` as the authoritative `userId`. `TransportService` wraps each `/mcp` HTTP request in `RequestContextService.run()` using the auth context.
 
 Deployment example — Memory Core running behind Keycloak in a multi-tenant cloud environment (env vars consumed by `ai/mcp/server/memory-core/config.template.mjs` directly, no per-server prefix translation):
 
 ```
-NEO_TRANSPORT=sse
+NEO_TRANSPORT=streamable-http
 MCP_HTTP_PORT=3001       # legacy alias `SSE_PORT` still works during the #10808 deprecation window
 NEO_PUBLIC_URL=https://mcp.example.com/mc
 NEO_AUTH_ISSUER_URL=https://auth.example.com/realms/neo/
@@ -40,7 +40,7 @@ NEO_OAUTH_CLIENT_SECRET=<secret>
 
 Once the server starts, every tool call from a client MUST arrive with `Authorization: Bearer <token>` where the token was issued by the configured issuer AND audience-matches the Memory Core's canonical public URL (configured via `NEO_PUBLIC_URL`). Tokens with `aud` claims targeting a different resource are rejected per RFC 9068.
 
-### SSE Path — GitLab Bearer via `gitlab-pat`
+### Streamable HTTP Path — GitLab Bearer via `gitlab-pat`
 
 Cloud deployments can opt into `NEO_AUTH_MODE=gitlab-pat`. In that mode the server validates the incoming bearer against the configured GitLab instance's `/api/v4/user` endpoint and stamps the request with the GitLab username plus provider-neutral metadata (`authProvider`, `authSource`, `providerBaseUrl`, `providerUserId`, `providerUsername`, `providerDisplayName`). User and client allowlists, when configured, are checked before request context is built.
 
@@ -163,7 +163,7 @@ All fields are populated on a best-effort basis. `userId` is `undefined` only wh
 
 ## OAuth 2.1 Spec Version
 
-The SSE path validates Bearer tokens per OAuth 2.1 draft conventions (audience enforcement, introspection-based validation, resource indicator checks per RFC 9068). Implementations targeting this Memory Core MUST:
+The Streamable HTTP path validates Bearer tokens per OAuth 2.1 draft conventions (audience enforcement, introspection-based validation, resource indicator checks per RFC 9068). Implementations targeting this Memory Core MUST:
 
 - Issue tokens with a specific `aud` (audience) claim matching the Memory Core's public URL
 - Support RFC 7662 introspection (or expose introspection metadata in the OIDC discovery document)
@@ -232,7 +232,7 @@ The `[neo-memory-core MCP] Identity: <userId> via <source> — bound to <nodeId>
 
 The `AuthMiddleware` refused a tool-call argument. Check that the client is not attempting to supply `userId`, `agent.authorLogin`, `from`, or any other field listed above. If the tool legitimately needs to pass an identity-adjacent value, rename the field at the schema layer.
 
-### SSE transport returns 401 despite a valid-looking Bearer token
+### Streamable HTTP transport returns 401 despite a valid-looking Bearer token
 
 - Check the `aud` (audience) claim of the token — must match the Memory Core's public URL.
 - Check that the OIDC introspection endpoint is reachable from the Memory Core process.
@@ -245,13 +245,13 @@ flowchart TD
     subgraph MCP ["MCP Tool Call Dispatch"]
         direction TD
 
-        SSE["SSE Transport\nTransportService"]
+        HTTP["Streamable HTTP Transport\nTransportService"]
         STDIO["Stdio Transport\nServer.mjs"]
 
         AuthSvc["AuthService\n(OIDC introspect)"]
         StdioRes["StdioIdentityResolver\n(env-var + gh-CLI)"]
 
-        SSE --> AuthSvc
+        HTTP --> AuthSvc
         STDIO --> StdioRes
 
         Bind["bindAgentIdent\n(graph lookup)"]
@@ -461,7 +461,7 @@ Shipping the guarded projector or migration script does **not** mutate a live gr
 
 ## Related Tickets
 
-- #10000 — Hardened Identity Ingestion (SSE OIDC path + RequestContextService)
+- #10000 — Hardened Identity Ingestion (Streamable HTTP OIDC path + RequestContextService)
 - #10144 — AgentIdentity node type + seed script
 - #10145 — OAuth2 authentication layer for Memory Core MCP connections (this doc)
 - #10016 — Multi-Tenant Identity & Data Privacy (parent sub-epic)

--- a/learn/agentos/v13-path.md
+++ b/learn/agentos/v13-path.md
@@ -43,13 +43,13 @@ Verified by grep + file inspection of `ai/mcp/server/*/Server.mjs`, `ai/daemons/
 
 ### D1: Factory Pattern Evaluation (challenge)
 
-The Factory pattern landed 2026-05-07 in `ai/mcp/server/shared/services/RequestContextService.mjs` — a Neo singleton wrapping `AsyncLocalStorage` to propagate per-request identity (`userId`, `username`, `agentIdentityNodeId`) into service-layer calls. SSE transport and stdio transport both wrap dispatch in `RequestContextService.run({...}, async () => { ... })`.
+The Factory pattern landed 2026-05-07 in `ai/mcp/server/shared/services/RequestContextService.mjs` — a Neo singleton wrapping `AsyncLocalStorage` to propagate per-request identity (`userId`, `username`, `agentIdentityNodeId`) into service-layer calls. Streamable HTTP and stdio transports both wrap dispatch in `RequestContextService.run({...}, async () => { ... })`.
 
-**Pros:** clean separation of concerns; services don't need auth-claim parameters; works uniformly across SSE (per-request) and stdio (per-server-boot identity).
+**Pros:** clean separation of concerns; services don't need auth-claim parameters; works uniformly across Streamable HTTP (per-request) and stdio (per-server-boot identity).
 
 **Cons / challenges to address before v13:**
 - **Adoption gap**: only 2/5 servers wrap dispatch with `RequestContextService.run`. The 3 unwrapped servers (file-system, github-workflow, neural-link) silently fall back to "no identity context" → tenant-aware code paths in their service layers behave as if single-tenant. **Resolution**: common base server class (D2) wraps dispatch uniformly.
-- **AsyncLocalStorage edge cases**: long-running async chains (e.g., `setTimeout` callbacks, daemon-spawned work) may lose context. Specific surfaces to audit: **`EventEmitter` boundaries** (handlers fire in the emitter's own context, not the caller's) and **SSE streaming async generators** (iterators that yield asynchronously to the event loop can lose context across yield points). **Open question**: does any current service spawn out-of-context async work via these patterns? Audit needed in M2.
+- **AsyncLocalStorage edge cases**: long-running async chains (e.g., `setTimeout` callbacks, daemon-spawned work) may lose context. Specific surfaces to audit: **`EventEmitter` boundaries** (handlers fire in the emitter's own context, not the caller's) and **SSE-framed Streamable HTTP async generators** (iterators that yield asynchronously to the event loop can lose context across yield points). **Open question**: does any current service spawn out-of-context async work via these patterns? Audit needed in M2.
 - **Daemon context**: the Orchestrator daemon (D3) runs scheduled work without a request-context. Services it calls need to handle `getUserId() === undefined` gracefully (as `SHARED_USER_ID` per #10556) — already designed for, but verify on each call site.
 
 **Recommendation:** keep Factory pattern; surface it in the common base class (D2); audit AsyncLocalStorage edge cases as a single-PR sweep.
@@ -59,7 +59,7 @@ The Factory pattern landed 2026-05-07 in `ai/mcp/server/shared/services/RequestC
 Eliminates the per-server `Server.mjs` boilerplate duplication. Provides:
 - MCP server initialization (capabilities, tool registration via openapi.yaml schemas)
 - Auth integration (`AuthService`, `AuthMiddleware`)
-- Transport setup (`TransportService` for SSE, stdio handler)
+- Transport setup (`TransportService` for Streamable HTTP, stdio handler)
 - Request-context wrapping (Factory pattern uniform application)
 - Healthcheck registration
 - Graceful shutdown

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
@@ -1,5 +1,5 @@
-import {test, expect}                                           from '@playwright/test';
-import {findDbPathMutations, ALLOWLIST, ESCAPE_MARKER}          from '../../../../../../buildScripts/util/check-aiconfig-test-mutation.mjs';
+import {test, expect}                                  from '@playwright/test';
+import {findDbPathMutations, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-test-mutation.mjs';
 
 /**
  * Self-test for the Class-A DB-path AiConfig test-mutation guard: the mechanical enforcement of the
@@ -36,7 +36,7 @@ test.describe('check-aiconfig-test-mutation guard', () => {
         expect(findDbPathMutations('aiConfig[dbKey] = fakeDb;')).toEqual([]);
         expect(findDbPathMutations('aiConfig[leafName].graph = p;')).toEqual([]);
         // a Class-B leaf via bracket stays out of scope too (transport is not a DB-path leaf)
-        expect(findDbPathMutations('aiConfig["transport"] = "sse";')).toEqual([])
+        expect(findDbPathMutations('aiConfig["transport"] = "streamable-http";')).toEqual([])
     });
 
     test('does NOT flag a comparison (=== / ==)', () => {
@@ -51,7 +51,7 @@ test.describe('check-aiconfig-test-mutation guard', () => {
 
     test('does NOT flag a config-VARYING (Class B) leaf — out of scope', () => {
         expect(findDbPathMutations('aiConfig.openAiCompatible.unloadRetryCount = 3;')).toEqual([]);
-        expect(findDbPathMutations('aiConfig.transport = "sse";')).toEqual([]);
+        expect(findDbPathMutations('aiConfig.transport = "streamable-http";')).toEqual([]);
         expect(findDbPathMutations('SDK.Memory_Config.data.embeddingProvider = "openAiCompatible";')).toEqual([])
     });
 

--- a/test/playwright/unit/ai/mcp/Authorization.spec.mjs
+++ b/test/playwright/unit/ai/mcp/Authorization.spec.mjs
@@ -9,7 +9,7 @@
  * 1. **Identity Simulation:** Mocks OIDC discovery and introspection endpoints.
  * 2. **Process Orchestration:** Spawns the MCP server in a separate Node.js process with
  *    custom environment variables to simulate a real IaC deployment.
- * 3. **Handshake Verification:** Validates 401 (Unauthorized), 200 (Authorized with SSE),
+ * 3. **Handshake Verification:** Validates 401 (Unauthorized), 200 (authorized with SSE response framing),
  *    CORS headers, and Protected Resource Metadata (PRM) discovery.
  */
 import {test, expect}  from '@playwright/test';
@@ -73,19 +73,19 @@ test.describe('MCP Server OIDC/OAuth 2.1 Authorization (Functional)', () => {
         mockOidcServer = app.listen(MOCK_OIDC_PORT);
         console.log(`[Test] Mock OIDC Server listening on port ${MOCK_OIDC_PORT}`);
 
-        // 2. Start MCP Server in SSE mode with Auth enabled
+        // 2. Start MCP Server in Streamable HTTP mode with Auth enabled
         mcpServerProcess = spawn('node', [SERVER_PATH, '--debug'], {
             env: {
                 ...process.env,
-                NEO_TRANSPORT     : 'sse',
-                MCP_HTTP_PORT     : MCP_HTTP_PORT.toString(),
-                NEO_AUTO_SYNC     : 'false',
-                NEO_AUTO_SUMMARIZE: 'false',
-                NEO_AUTH_HOST     : 'localhost',
-                NEO_AUTH_PORT     : MOCK_OIDC_PORT.toString(),
-                NEO_AUTH_REALM    : 'test',
+                NEO_TRANSPORT      : 'streamable-http',
+                MCP_HTTP_PORT      : MCP_HTTP_PORT.toString(),
+                NEO_AUTO_SYNC      : 'false',
+                NEO_AUTO_SUMMARIZE : 'false',
+                NEO_AUTH_HOST      : 'localhost',
+                NEO_AUTH_PORT      : MOCK_OIDC_PORT.toString(),
+                NEO_AUTH_REALM     : 'test',
                 NEO_OAUTH_CLIENT_ID: TEST_CLIENT_ID,
-                HOST              : 'localhost'
+                HOST               : 'localhost'
             }
         });
 
@@ -93,15 +93,15 @@ test.describe('MCP Server OIDC/OAuth 2.1 Authorization (Functional)', () => {
         await new Promise((resolve, reject) => {
             mcpServerProcess.stdout.on('data', (data) => {
                 const msg = data.toString();
-                if (msg.includes('Server started on SSE transport')) {
+                if (msg.includes('Server started on Streamable HTTP transport')) {
                     resolve();
                 }
             });
             mcpServerProcess.stderr.on('data', (data) => {
                 const msg = data.toString();
                 console.error(`[MCP Server Error] ${msg}`);
-                // Often SSE server logs to stderr
-                if (msg.includes('Server started on SSE transport')) {
+                // The MCP server can log transport startup to stderr.
+                if (msg.includes('Server started on Streamable HTTP transport')) {
                     resolve();
                 }
             });
@@ -133,10 +133,10 @@ test.describe('MCP Server OIDC/OAuth 2.1 Authorization (Functional)', () => {
     });
 
     test('should allow access with a valid token', async ({request}) => {
-        // Bucket E (#10903) PoC-skip: in CI, the token-issuing substrate (OIDC discovery + JWKS)
+        // Bucket E PoC-skip: in CI, the token-issuing substrate (OIDC discovery + JWKS)
         // is not provisioned, so the bearer token validation path can't complete. TODO: investigate
         // whether this needs a mock issuer fixture or a fully-skipped substrate-data bucket — for
-        // now, skip with rationale to unblock Lane C (#10897) `unit` matrix re-add.
+        // now, skip with rationale to unblock the `unit` matrix re-add.
         test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: token-issuing substrate not provisioned — bucket E (#10903)');
 
         const response = await request.post(`http://localhost:${MCP_HTTP_PORT}/mcp`, {
@@ -193,13 +193,13 @@ test.describe('MCP Server OIDC/OAuth 2.1 Authorization (Functional)', () => {
         const discoveryProcess = spawn('node', [SERVER_PATH, '--debug'], {
             env: {
                 ...process.env,
-                NEO_TRANSPORT     : 'sse',
-                MCP_HTTP_PORT     : DISCOVERY_MCP_PORT.toString(),
-                NEO_AUTO_SYNC     : 'false',
-                NEO_AUTO_SUMMARIZE: 'false',
+                NEO_TRANSPORT      : 'streamable-http',
+                MCP_HTTP_PORT      : DISCOVERY_MCP_PORT.toString(),
+                NEO_AUTO_SYNC      : 'false',
+                NEO_AUTO_SUMMARIZE : 'false',
                 NEO_AUTH_ISSUER_URL: `http://localhost:${MOCK_OIDC_PORT}/realms/test`,
                 NEO_OAUTH_CLIENT_ID: TEST_CLIENT_ID,
-                HOST              : 'localhost'
+                HOST               : 'localhost'
             }
         });
 
@@ -207,12 +207,12 @@ test.describe('MCP Server OIDC/OAuth 2.1 Authorization (Functional)', () => {
             // Wait for server to start
             await new Promise((resolve, reject) => {
                 discoveryProcess.stdout.on('data', (data) => {
-                    if (data.toString().includes('Server started on SSE transport')) {
+                    if (data.toString().includes('Server started on Streamable HTTP transport')) {
                         resolve();
                     }
                 });
                 discoveryProcess.stderr.on('data', (data) => {
-                    if (data.toString().includes('Server started on SSE transport')) {
+                    if (data.toString().includes('Server started on Streamable HTTP transport')) {
                         resolve();
                     }
                 });

--- a/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs
@@ -162,6 +162,101 @@ test.describe('Neo.ai.mcp.server.BaseServer — optional hook defaults', () => {
     });
 });
 
+test.describe('Neo.ai.mcp.server.BaseServer — exhaustive server transport selection (#15188)', () => {
+    function createTransportServer(transport) {
+        const id = ++_testClassCounter;
+
+        class TransportServer extends BaseServer {
+            static config = {className: `Neo.test.mcp.server.TransportServer${id}`}
+
+            aiConfig = {transport}
+            logger   = {info() {}}
+
+            async initAsync() {}
+            getServerMetadata() { return {name: 'neo-transport-test'}; }
+            getToolService()    { return {listTools: () => ({tools: []}), callTool: async () => null}; }
+        }
+
+        return Neo.create(Neo.setupClass(TransportServer));
+    }
+
+    test('stdio starts StdioServerTransport', async () => {
+        const server = createTransportServer('stdio');
+        let connectedTransport;
+
+        server.mcpServer = {
+            connect: async transport => connectedTransport = transport
+        };
+
+        try {
+            await server.connectTransport();
+
+            expect(connectedTransport?.constructor?.name).toBe('StdioServerTransport');
+            expect(server.transport).toBe(connectedTransport);
+        } finally {
+            server.destroy();
+        }
+    });
+
+    test('streamable-http delegates to the shared Streamable HTTP service', async () => {
+        const server           = createTransportServer('streamable-http');
+        const TransportService = (await import('../../../../../../ai/mcp/server/shared/services/TransportService.mjs')).default;
+        const originalSetup    = TransportService.setup;
+        let setupOptions;
+
+        TransportService.setup = async options => setupOptions = options;
+
+        try {
+            await server.connectTransport();
+
+            expect(setupOptions).toMatchObject({
+                server,
+                aiConfig    : server.aiConfig,
+                logger      : server.logger,
+                resourceName: 'neo-transport-test MCP'
+            });
+            expect(server.transport).toBeNull();
+        } finally {
+            TransportService.setup = originalSetup;
+            server.destroy();
+        }
+    });
+
+    test('old sse server value fails with the canonical migration', async () => {
+        const server    = createTransportServer('sse');
+        let   connected = false;
+
+        server.mcpServer = {connect: async () => connected = true};
+
+        try {
+            await expect(server.connectTransport()).rejects.toThrow(
+                /Server transport "sse" was renamed to "streamable-http"/
+            );
+            expect(connected).toBe(false);
+            expect(server.transport).toBeNull();
+        } finally {
+            server.destroy();
+        }
+    });
+
+    test('arbitrary unknown server value fails before transport startup', async () => {
+        const server    = createTransportServer('websocket');
+        let   connected = false;
+
+        server.mcpServer = {connect: async () => connected = true};
+
+        try {
+            await expect(server.connectTransport()).rejects.toThrow(
+                /Unsupported server transport "websocket".*Expected "stdio" or "streamable-http"/
+            );
+            expect(connected).toBe(false);
+            expect(server.transport).toBeNull();
+        } finally {
+            server.destroy();
+        }
+    });
+});
+
 test.describe('Neo.ai.mcp.server.BaseServer — formatToolResult shapes', () => {
     test('object result without error → text + structuredContent', () => {
         const Cls    = makeTestServerClass();
@@ -240,22 +335,22 @@ test.describe('Neo.ai.mcp.server.BaseServer — formatToolResult shapes', () => 
         expect(result.isError).toBe(true);
         expect(result.content[0].text).toBe('Policy Refused executing write_file: blocked by policy');
         expect(result.structuredContent).toEqual({
-            error    : 'Policy Refused',
-            code     : 'POLICY_REFUSED',
-            reason   : 'blocked by policy',
-            policyId : 'test.policy',
-            action   : 'write_file',
-            tenet    : '#10293',
-            details  : {targetPath: '/repo/AGENTS_TENETS.md'}
+            error   : 'Policy Refused',
+            code    : 'POLICY_REFUSED',
+            reason  : 'blocked by policy',
+            policyId: 'test.policy',
+            action  : 'write_file',
+            tenet   : '#10293',
+            details : {targetPath: '/repo/AGENTS_TENETS.md'}
         });
     });
 });
 
 test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', () => {
     test('registers both ListTools and CallTool handlers', () => {
-        const Cls       = makeTestServerClass();
-        const server    = Neo.create(Cls);
-        const mockMcp   = makeMockMcpServer();
+        const Cls     = makeTestServerClass();
+        const server  = Neo.create(Cls);
+        const mockMcp = makeMockMcpServer();
 
         server.setupRequestHandlers(mockMcp);
 
@@ -273,9 +368,9 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
     });
 
     test('ListTools handler returns mcpTools mapping from per-server toolService', async () => {
-        const Cls       = makeTestServerClass();
-        const server    = Neo.create(Cls);
-        const mockMcp   = makeMockMcpServer();
+        const Cls     = makeTestServerClass();
+        const server  = Neo.create(Cls);
+        const mockMcp = makeMockMcpServer();
         server.setupRequestHandlers(mockMcp);
 
         const result = await mockMcp.getListToolsHandler()({params: {}});
@@ -292,7 +387,7 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
 
     test('ListTools handler passes projection context into per-server toolService', async () => {
         const seen = [];
-        const Cls = makeTestServerClass({
+        const Cls  = makeTestServerClass({
             buildToolProjectionContext: ({request, phase}) => {
                 expect(phase).toBe('listTools');
                 expect(request.params._meta.neoToolProjection).toBe('harness-embedded');
@@ -325,9 +420,9 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
     });
 
     test('CallTool handler dispatches via wrapDispatch + formatToolResult', async () => {
-        const Cls       = makeTestServerClass();
-        const server    = Neo.create(Cls);
-        const mockMcp   = makeMockMcpServer();
+        const Cls     = makeTestServerClass();
+        const server  = Neo.create(Cls);
+        const mockMcp = makeMockMcpServer();
         server.setupRequestHandlers(mockMcp);
 
         const result = await mockMcp.getCallToolHandler()({
@@ -376,8 +471,8 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
     });
 
     test('CallTool handler applies health-gate when healthService present and tool not exempt', async () => {
-        let healthCheckCalls = 0;
-        const Cls = makeTestServerClass({
+        let   healthCheckCalls = 0;
+        const Cls              = makeTestServerClass({
             getHealthService: () => ({
                 ensureHealthy: async () => { healthCheckCalls++; }
             })
@@ -394,8 +489,8 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
     });
 
     test('CallTool handler skips health-gate for exempt tools', async () => {
-        let healthCheckCalls = 0;
-        const Cls = makeTestServerClass({
+        let   healthCheckCalls = 0;
+        const Cls              = makeTestServerClass({
             getHealthService    : () => ({ensureHealthy: async () => { healthCheckCalls++; }}),
             getHealthExemptTools: () => ['healthcheck', 'sample']
         });
@@ -430,9 +525,9 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
 
     test('beforeToolDispatch hook fires BEFORE health gate with toolName + args', async () => {
         const order = [];
-        const Cls = makeTestServerClass({
-            getHealthService    : () => ({ensureHealthy: async () => { order.push('healthGate'); }}),
-            beforeToolDispatch  : async ({toolName, args}) => { order.push(`beforeToolDispatch:${toolName}:${args.x}`); }
+        const Cls   = makeTestServerClass({
+            getHealthService  : () => ({ensureHealthy: async () => { order.push('healthGate'); }}),
+            beforeToolDispatch: async ({toolName, args}) => { order.push(`beforeToolDispatch:${toolName}:${args.x}`); }
         });
         const server  = Neo.create(Cls);
         const mockMcp = makeMockMcpServer();
@@ -448,8 +543,8 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
 
     test('beforeToolDispatch throw routes to formatToolError envelope (not formatHealthError)', async () => {
         const Cls = makeTestServerClass({
-            getHealthService    : () => ({ensureHealthy: async () => {}}),
-            beforeToolDispatch  : async () => { throw new Error('Identity spoof rejected'); }
+            getHealthService  : () => ({ensureHealthy: async () => {}}),
+            beforeToolDispatch: async () => { throw new Error('Identity spoof rejected'); }
         });
         const server  = Neo.create(Cls);
         const mockMcp = makeMockMcpServer();
@@ -466,9 +561,9 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
 
     test('onHealthGateFailure hook fires with context (toolName/args/error/t0) before formatHealthError', async () => {
         const captured = [];
-        const Cls = makeTestServerClass({
-            getHealthService    : () => ({ensureHealthy: async () => { throw new Error('Service down'); }}),
-            onHealthGateFailure : async (ctx) => { captured.push(ctx); }
+        const Cls      = makeTestServerClass({
+            getHealthService   : () => ({ensureHealthy: async () => { throw new Error('Service down'); }}),
+            onHealthGateFailure: async (ctx) => { captured.push(ctx); }
         });
         const server  = Neo.create(Cls);
         const mockMcp = makeMockMcpServer();
@@ -511,7 +606,7 @@ test.describe('Neo.ai.mcp.server.BaseServer — setupRequestHandlers wiring', ()
 
     test('wrapDispatch override threads context around toolService.callTool', async () => {
         const wrapCalls = [];
-        const Cls = makeTestServerClass({
+        const Cls       = makeTestServerClass({
             wrapDispatch: async (dispatch) => {
                 wrapCalls.push('before');
                 const result = await dispatch();
@@ -596,7 +691,7 @@ test.describe('Neo.ai.mcp.server.BaseServer — initAsync canonical sequence', (
             async afterTransportConnected() { calls.push('afterTransportConnected'); }
         }
 
-        const Cls    = Neo.setupClass(SequenceServer);
+        const Cls = Neo.setupClass(SequenceServer);
         // Neo.create() auto-runs initAsync via its construction lifecycle. ready() awaits the
         // chain — calling initAsync manually would re-run the sequence and double the call list.
         const server = Neo.create(Cls);
@@ -616,7 +711,7 @@ test.describe('Neo.ai.mcp.server.BaseServer — initAsync canonical sequence', (
     });
 
     test('waitForDependentServices awaits ready() on each service in declaration order', async () => {
-        const order = [];
+        const order       = [];
         const makeService = (name) => {
             let called = false;
             return {
@@ -648,10 +743,10 @@ test.describe('Neo.ai.mcp.server.BaseServer — initAsync canonical sequence', (
     });
 
     test('loadCustomConfig is no-op when configFile unset', async () => {
-        let loadCalls = 0;
-        const Cls = makeTestServerClass();
-        const server  = Neo.create(Cls);
-        server.aiConfig = {load: async () => { loadCalls++; }};
+        let   loadCalls = 0;
+        const Cls       = makeTestServerClass();
+        const server    = Neo.create(Cls);
+        server.aiConfig = {transport: 'stdio', load: async () => { loadCalls++; }};
         // configFile remains null
 
         await server.loadCustomConfig();
@@ -659,10 +754,10 @@ test.describe('Neo.ai.mcp.server.BaseServer — initAsync canonical sequence', (
     });
 
     test('loadCustomConfig invokes aiConfig.load when configFile set', async () => {
-        let loadedFrom = null;
-        const Cls = makeTestServerClass();
-        const server = Neo.create(Cls);
-        server.aiConfig = {load: async (path) => { loadedFrom = path; }};
+        let   loadedFrom = null;
+        const Cls        = makeTestServerClass();
+        const server     = Neo.create(Cls);
+        server.aiConfig = {transport: 'stdio', load: async (path) => { loadedFrom = path; }};
         server.configFile = '/tmp/custom-config.mjs';
 
         await server.loadCustomConfig();

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs
@@ -68,7 +68,7 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
     test.beforeEach(() => {
         // Tight, predictable threshold; restore the real service method before each spec.
         aiConfig.mcpSyncMaxChunks                       = 5;
-        aiConfig.transport                              = 'sse';
+        aiConfig.transport                              = 'streamable-http';
         IngestionService.ingestSourceFiles = originalIngest;
     });
 
@@ -142,8 +142,8 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
         expect('error' in result).toBe(false);
     });
 
-    test('ingest_source_files is listed for the remote SSE transport profile', () => {
-        aiConfig.transport = 'sse';
+    test('ingest_source_files is listed for the remote Streamable HTTP transport profile', () => {
+        aiConfig.transport = 'streamable-http';
 
         const {tools} = listTools();
         const tool    = tools.find(item => item.name === 'ingest_source_files');
@@ -162,6 +162,6 @@ test.describe('ingest_source_files MCP facade — work-volume gate (#11634)', ()
         const {tools} = listTools();
 
         expect(tools.find(item => item.name === 'ingest_source_files')).toBeUndefined();
-        await expect(callTool('ingest_source_files', {files: []})).rejects.toThrow(/transport: "sse"/);
+        await expect(callTool('ingest_source_files', {files: []})).rejects.toThrow(/transport: "streamable-http"/);
     });
 });

--- a/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs
@@ -181,6 +181,26 @@ test.describe('Knowledge Base Config Tier-1 defaults (#11963)', () => {
         }
     });
 
+    test('constructs the canonical server transport values from default and env input', () => {
+        const defaultKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            expect(defaultKB.transport).toBe('stdio');
+        } finally {
+            defaultKB.destroy();
+        }
+
+        process.env.NEO_TRANSPORT = 'streamable-http';
+
+        const remoteKB = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            expect(remoteKB.transport).toBe('streamable-http');
+        } finally {
+            remoteKB.destroy();
+        }
+    });
+
     test('invalid NEO_DEBUG values fall back to the debug-off default', () => {
         process.env.NEO_DEBUG = 'maybe';
 

--- a/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs
@@ -105,7 +105,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         }
     });
 
-    test('#15027: stdio and SSE identity paths bind through the same provider-agnostic canonicalizer', async () => {
+    test('#15027: stdio and Streamable HTTP identity paths bind through the same provider-agnostic canonicalizer', async () => {
         await GraphService.initAsync();
 
         GraphService.upsertNode({id: '@identity-topology-15027', type: 'AgentIdentity', name: 'Identity Topology'});
@@ -115,13 +115,13 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
         const originalResolve       = StdioIdentityResolver.resolve;
 
         try {
-            const sseContext = await serverInstance.buildRequestContext({
+            const streamableHttpContext = await serverInstance.buildRequestContext({
                 userId  : 'identity-topology-15027',
                 username: 'Identity Topology',
                 source  : 'oidc'
             });
 
-            expect(sseContext).toMatchObject({
+            expect(streamableHttpContext).toMatchObject({
                 userId             : 'identity-topology-15027',
                 agentIdentityNodeId: '@identity-topology-15027',
                 source             : 'oidc'
@@ -145,7 +145,7 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
                 import('../../../../../../../ai/services/memory-core/MailboxService.mjs')
             ]);
 
-            for (const context of [sseContext, stdioContext]) {
+            for (const context of [streamableHttpContext, stdioContext]) {
                 const sent = await RequestContextService.run(context, () => MailboxService.addMessage({
                     to     : '@me',
                     subject: `topology round-trip ${context.source}`,
@@ -930,6 +930,38 @@ test.describe('Neo.ai.mcp.server.memory-core.Server', () => {
             for (const [name, method] of originalServerMethods) {
                 serverInstance[name] = method;
             }
+            serverInstance.destroy();
+        }
+    });
+
+    test('#15188: Streamable HTTP boot skips process-level stdio identity work', async () => {
+        const serverInstance = await createServerWithoutBoot();
+        const calls          = [];
+
+        serverInstance.aiConfig = {transport: 'streamable-http'};
+        serverInstance.loadCustomConfig = async () => calls.push('loadCustomConfig');
+        serverInstance.createMcpServer = () => {
+            calls.push('createMcpServer');
+            return {server: {setRequestHandler() {}}};
+        };
+        serverInstance.prepareStartupDependency = async () => {};
+        serverInstance.resolveStdioIdentity = async () => calls.push('resolveStdioIdentity');
+        serverInstance.runHealthcheckAndLogStatus = async () => calls.push('runHealthcheckAndLogStatus');
+        serverInstance.logSiblingConcurrency = () => calls.push('logSiblingConcurrency');
+        serverInstance.connectTransport = async () => calls.push('connectTransport');
+        serverInstance.logIdentityStatus = () => calls.push('logIdentityStatus');
+
+        try {
+            await serverInstance.boot();
+
+            expect(calls).toEqual([
+                'loadCustomConfig',
+                'createMcpServer',
+                'runHealthcheckAndLogStatus',
+                'logSiblingConcurrency',
+                'connectTransport'
+            ]);
+        } finally {
             serverInstance.destroy();
         }
     });

--- a/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs
@@ -103,6 +103,26 @@ test.describe('Memory Core Config (#10010)', () => {
         expect(config.memorySharing.defaultPolicy).toBe('team');
     });
 
+    test('constructs the canonical server transport values from default and env input', () => {
+        const defaultMC = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            expect(defaultMC.transport).toBe('stdio');
+        } finally {
+            defaultMC.destroy();
+        }
+
+        process.env.NEO_TRANSPORT = 'streamable-http';
+
+        const remoteMC = createConfigProxy(Neo.create(ConfigProvider, {data: config._data}));
+
+        try {
+            expect(remoteMC.transport).toBe('streamable-http');
+        } finally {
+            remoteMC.destroy();
+        }
+    });
+
     test('inherits deployment-wide Tier-1 defaults (provider, auth, ollama, openAiCompatible, storage) via the realm chain', () => {
         // MC declares none of these locally — they resolve UP the getParent() chain to the
         // Tier-1 realm root. Read KEYED, never whole-namespace: `toEqual(config.ollama)` would

--- a/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
+++ b/test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs
@@ -172,7 +172,7 @@ test.describe('ai/scripts/lint-config-template-ssot (#12451 — declarative conf
 
     test('ignores invocation-time and function-local AiConfig reads', () => {
         const hits = detectModuleScopeAiConfigCaptures([
-            `const isRemoteIngestTransport = () => aiConfig.transport === 'sse';`,
+            `const isRemoteIngestTransport = () => aiConfig.transport === 'streamable-http';`,
             `function getSnapshotPath() {`,
             `    const snapshotPath = AiConfig.orchestrator.deploymentStateBridge.snapshotPath;`,
             `    return snapshotPath;`,

--- a/test/playwright/unit/ai/scripts/maintenance/kbPushClient.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/kbPushClient.spec.mjs
@@ -19,7 +19,7 @@ import {Readable}     from 'stream';
 /**
  * Unit coverage for the tenant-side KB push client.
  *
- * The script is the operator-facing StreamableHTTP/SSE invocation primitive for repo-push
+ * The script is the operator-facing remote MCP invocation primitive for repo-push
  * ingestion envelopes. Tests keep network/client work injected so parsing, auth headers,
  * envelope defaults, and MCP result failure semantics are verified without a live KB server.
  */
@@ -144,12 +144,12 @@ test.describe('ai/scripts/maintenance/kbPushClient — repo-push MCP client (#11
             manifestSnapshot: {pathsAfterPush: ['src/a.mjs']}
         }, {
             tenantId: 'cli-tenant',
-            repoSlug : 'neomjs/create-app'
+            repoSlug: 'neomjs/create-app'
         });
 
         expect(normalized).toEqual({
             tenantId        : 'payload-tenant',
-            repoSlug         : 'neomjs/create-app',
+            repoSlug        : 'neomjs/create-app',
             manifestSnapshot: {
                 repoSlug      : 'neomjs/create-app',
                 pathsAfterPush: ['src/a.mjs']
@@ -190,9 +190,9 @@ test.describe('ai/scripts/maintenance/kbPushClient — repo-push MCP client (#11
     });
 
     test('runPush calls ingest_source_files with envelope defaults and cleans transient client config', async () => {
-        const calls = [];
+        const calls        = [];
         const clientConfig = {data: {mcpServers: {}}};
-        const args = parseArgs([
+        const args         = parseArgs([
             '--url', 'https://kb.example.com/mcp',
             '--from-stdin',
             '--tenant-id', 'tenant-a',
@@ -225,8 +225,8 @@ test.describe('ai/scripts/maintenance/kbPushClient — repo-push MCP client (#11
             name    : 'ingest_source_files',
             envelope: {
                 tenantId: 'tenant-a',
-                repoSlug : 'neomjs/create-app',
-                files    : [{sourcePath: 'src/a.mjs', content: 'x'}]
+                repoSlug: 'neomjs/create-app',
+                files   : [{sourcePath: 'src/a.mjs', content: 'x'}]
             }
         });
         expect(calls[2].type).toBe('close');

--- a/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs
@@ -359,7 +359,7 @@ test.describe('Neo.ai.services.knowledge-base.SearchService', () => {
 
         QueryService.queryDocuments = async () => ({results: []});
         ChromaManager.getKnowledgeBaseCollection = async () => ({count: async () => 0});
-        aiConfig.transport = 'sse';
+        aiConfig.transport = 'streamable-http';
 
         try {
             const result = await SearchService.ask({query: 'anything'});


### PR DESCRIPTION
Resolves #15188

Refs #15184

Renames Neo's server-side HTTP transport value from `sse` to `streamable-http` across the shared startup selector, declarative configuration, Knowledge Base and Memory Core consumers, Docker/Compose profiles, operator documentation, and focused tests. `BaseServer#connectTransport()` now accepts exactly `stdio` or `streamable-http`; the old value emits a targeted migration error, arbitrary values fail closed, and genuine client-side `SSEClientTransport` support remains unchanged.

Evidence: L3 (real Dockerized KB/MC Streamable HTTP endpoints, stdio non-regression, OIDC, proxy identity, and tenant isolation) → L3 required (all close-target runtime and deployment ACs). No residuals.

## Deltas from ticket

None substantive. The repair-capable preflight also removed two stale tracking tokens from explanatory comments in the already-touched authorization spec; no test behavior changed.

## Config-template synchronization

- Changed config keys: no key or environment-variable names changed. The `transport` leaves in the root, Knowledge Base, Memory Core, and GitLab Workflow templates now document the only supported server values as `stdio` and `streamable-http`.
- Local follow-up: any gitignored `config.mjs` that currently sets `transport: 'sse'` must be changed manually to `transport: 'streamable-http'` after merge. Existing `stdio` configs require no edit.
- Restart boundary: remote HTTP MCP servers must be rebuilt/recreated or restarted after applying the value change. Local stdio harnesses do not need a transport-driven restart.

## Test Evidence

- `npm run agent-preflight -- <all 48 changed files>` — passed, including block alignment and ticket-archaeology checks.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/BaseServer.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/IngestSourceFilesTool.spec.mjs test/playwright/unit/ai/mcp/server/knowledge-base/config.template.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/config.template.spec.mjs test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs test/playwright/unit/ai/services/knowledge-base/SearchService.spec.mjs` — 90 passed.
- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/Server.spec.mjs` — 20 passed.
- `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs test/playwright/unit/ai/scripts/maintenance/kbPushClient.spec.mjs test/playwright/unit/ai/mcp/Authorization.spec.mjs test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs` — 85 passed.
- `npm run test-integration-unified -- test/playwright/integration/KBRemoteMcpTransport.integration.spec.mjs test/playwright/integration/KBOidcAuth.integration.spec.mjs test/playwright/integration/KBAuthRejection.integration.spec.mjs test/playwright/integration/AuthRejection.integration.spec.mjs test/playwright/integration/OidcAuth.integration.spec.mjs test/playwright/integration/RemoteMcpTransport.integration.spec.mjs` — 20 passed against real Dockerized services on the rebased head.
- Broader integration disposition: the full 50-case run passed 46 and skipped 2; only the two sustained-liveness p95 checks missed the 500 ms host threshold at 504/506 ms. A focused retry produced 515/505 ms. The same two tests on untouched `origin/dev@310026f76f` produced 508/508 ms on the same Colima host, establishing baseline host variance rather than a transport-rename regression. The threshold was not weakened.
- Repository-wide negative sweep found only the intentional old-value migration guard/documentation plus genuine client-side SSE and SSE-framing references; no server-side `NEO_TRANSPORT=sse` or `transport === 'sse'` consumer remains outside the migration rejection.
- `git diff --check` — passed.

## Release-note handoff

This is a small breaking server-configuration change. The first release notes containing it must state:

- exact migration: `NEO_TRANSPORT=sse` → `NEO_TRANSPORT=streamable-http` (and the equivalent `aiConfig.transport` edit);
- old server configurations now fail startup with a migration error;
- operators must update configuration before or together with the Neo upgrade, then rebuild/recreate affected MCP servers;
- client-side `transportType: 'sse'` and `SSEClientTransport` remain supported.

## Signal Ledger

- `gpt`: source-author signal by `@neo-gpt` at the D#15173 body anchor `2026-07-14T21:44:26Z`.
- `claude`: non-author graduation approval by `@neo-opus-vega` at the same body anchor in [GRADUATION_APPROVED](https://github.com/neomjs/neo/discussions/15173#discussioncomment-17641110).
- Scope precision: that approval governs the graduated local-PoC architecture. This rename leaf was added afterward under the Epic and is not represented as a separate Vega review.

## Unresolved Dissent

None recorded at the approved source-body anchor.

## Unresolved Liveness

- The external `GENESIS_PROBE_READY` receipt remains outstanding for the later end-to-end PoC journey; it does not gate this server-value migration.
- `revalidationTrigger`: a substantive change to the approved D#15173 body after `2026-07-14T21:44:26Z`, or evidence reversing the one-canonical-name / standard-Streamable-HTTP contract.

## Post-Merge Validation

- [ ] Build the KB/MC deployment images from merged `dev` and repeat the remote transport smoke.
- [ ] Update each affected gitignored remote `config.mjs` before restarting that server.
- [ ] Confirm the first release notes containing this change carry the exact migration and client-side non-impact above.

Authored by Euclid (OpenAI GPT-5.6 Sol Ultra, Codex Desktop). Session 5b19219a-d8ad-4505-864f-19b5eab44a45.
