### PR TITLE
feat(dashboard): showcase real cross-window dock transfer (#14772)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/CounterPane.mjs
+++ b/apps/agentos/childapps/dockdemo/view/CounterPane.mjs
@@ -4,10 +4,10 @@ import Component from '../../../../../src/component/Base.mjs';
  * @summary The Demo-B state-continuity witness: a frame counter that lives on the INSTANCE.
  *
  * The pane increments once per second from construction and renders its count. Unlike a
- * wall-clock (which survives remounts invisibly — it re-reads world state), this counter
- * resets to zero if the component is ever destroyed and recreated: an unbroken count across
- * a perspective morph, a pop-out to an OS window, and a reattach is PROOF the instance was
- * reparented, never remade — the object-permanence story the demo exists to show.
+ * wall-clock (which re-reads world state), this instance-local value resets only if the
+ * component is destroyed and recreated. Cross-window movement does run the target document's
+ * normal mount lifecycle; the separate mount count makes that truth visible while the unbroken
+ * seconds value proves the worker-owned instance and state were never remade.
  * @class AgentOS.childapps.dockdemo.view.CounterPane
  * @extends Neo.component.Base
  */
@@ -31,6 +31,13 @@ class CounterPane extends Component {
      */
     frames = 0
     /**
+     * Number of browser-document mount events this live instance has completed. Moving into a
+     * second OS window increments this count by design; preserving the JS instance does not mean
+     * one DOM mount spans two documents.
+     * @member {Number} mountCount=0
+     */
+    mountCount = 0
+    /**
      * @member {Number|null} intervalId=null
      * @protected
      */
@@ -51,6 +58,21 @@ class CounterPane extends Component {
         }, 1000);
 
         me.renderCount()
+    }
+
+    /**
+     * Counts truthful render-target embodiments while preserving the instance-local heartbeat.
+     * @param {Boolean} value
+     * @param {Boolean} oldValue
+     * @protected
+     */
+    afterSetMounted(value, oldValue) {
+        super.afterSetMounted(value, oldValue);
+
+        if (value && oldValue !== undefined) {
+            this.mountCount++;
+            this.renderCount()
+        }
     }
 
     /**
@@ -77,7 +99,7 @@ class CounterPane extends Component {
         me.vdom.cn = [
             {cls: ['agentos-dockdemo-counter-label'], text: 'WORKBENCH'},
             {cls: ['agentos-dockdemo-counter-value'], text: `${me.frames}s unbroken`},
-            {cls: ['agentos-dockdemo-counter-note'],  text: 'this counter dies on remount — it has never remounted'}
+            {cls: ['agentos-dockdemo-counter-note'],  text: `${me.mountCount} render-target mount${me.mountCount === 1 ? '' : 's'} · same worker instance`}
         ];
 
         me.update()

--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -1,14 +1,19 @@
 import Component                          from '../../../../../src/component/Base.mjs';
 import Container                          from '../../../../../src/container/Base.mjs';
 import CounterPane                        from './CounterPane.mjs';
+import DockDropIndicators                 from '../../../../../src/dashboard/DockDropIndicators.mjs';
 import DockLayoutAdapter                  from '../../../../../src/dashboard/DockLayoutAdapter.mjs';
 import DockMotionSignal                   from '../../../../../src/dashboard/DockMotionSignal.mjs';
 import DockPerspectiveStore               from '../../../../../src/dashboard/DockPerspectiveStore.mjs';
+import DockPreview                        from '../../../view/DockPreview.mjs';
+import DockPreviewProducer                from '../../../../../src/dashboard/DockPreviewProducer.mjs';
 import DockProjectionReconciler           from '../../../../../src/dashboard/DockProjectionReconciler.mjs';
 import DockService                        from '../../../../../src/ai/client/DockService.mjs';
 import DockTopologyReconciler             from '../../../../../src/dashboard/DockTopologyReconciler.mjs';
 import DockZoneModel                      from '../../../../../src/dashboard/DockZoneModel.mjs';
+import InteractionService                 from '../../../../../src/ai/client/InteractionService.mjs';
 import TourRunner                         from '../../../../../src/ai/client/TourRunner.mjs';
+import {previewToOperation}               from '../../../../../src/dashboard/dockPreviewContract.mjs';
 import {demoBTourScript, initialDocument} from '../../../tour/demoBPerspectives.mjs';
 import '../../../../../src/button/Base.mjs';   // registers the `button` ntype the bars compose
 import '../../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits
@@ -41,6 +46,25 @@ import '../../../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype 
  * @extends Neo.container.Base
  */
 class DemoBWorkspace extends Container {
+    /**
+     * Shared coordinator registry key for the two active Demo-B workspaces.
+     * @member {String} CROSS_WINDOW_SORT_GROUP='demo-b-cross-window'
+     * @static
+     */
+    static CROSS_WINDOW_SORT_GROUP = 'demo-b-cross-window'
+    /**
+     * Stable worker-owned workspace id for the primary document.
+     * @member {String} MAIN_WORKSPACE_ID='demo-b-main'
+     * @static
+     */
+    static MAIN_WORKSPACE_ID = 'demo-b-main'
+    /**
+     * Stable worker-owned workspace id for the popup document.
+     * @member {String} POPUP_WORKSPACE_ID='demo-b-popup'
+     * @static
+     */
+    static POPUP_WORKSPACE_ID = 'demo-b-popup'
+
     static config = {
         /**
          * @member {String} className='AgentOS.childapps.dockdemo.view.DemoBWorkspace'
@@ -88,6 +112,16 @@ class DemoBWorkspace extends Container {
      */
     dockService = null
     /**
+     * Existing ordered DOM-event driver used by the real two-window falsifier.
+     * @member {Neo.ai.client.InteractionService|null} interactionService=null
+     */
+    interactionService = null
+    /**
+     * Runtime-only dock-preview producer shared by the two window surfaces.
+     * @member {Neo.dashboard.DockPreviewProducer|null} dockPreviewProducer=null
+     */
+    dockPreviewProducer = null
+    /**
      * The named-perspective home. Lifecycle events feed the switcher bar.
      * @member {Neo.dashboard.DockPerspectiveStore|null} perspectiveStore=null
      */
@@ -101,11 +135,91 @@ class DemoBWorkspace extends Container {
      * Pane instances by item id — created ONCE, handed across every re-projection and
      * parked for explicit window moves or an unrestored topology remainder, torn down only
      * with the workspace. THE object-permanence substrate: `resolvePane` hands the adapter
-     * these live instances, so no morph, pop-out, or reattach ever remounts a pane.
+     * these live instances, so no morph or reattach recreates a pane. Moving an existing pane
+     * into a different browser document still runs that render target's required mount lifecycle.
      * @member {Object} paneCache={}
      * @protected
      */
     paneCache = {}
+    /**
+     * Live render hosts keyed by worker-owned workspace id. The main host is a descendant of
+     * this component; the popup host is a sibling render target beneath the second window's
+     * viewport, so neither component-tree ancestry nor a window id owns document truth.
+     * @member {Map<String,Neo.container.Base>} crossWindowHosts
+     * @protected
+     */
+    crossWindowHosts = new Map()
+    /**
+     * Registered target-side participation adapters keyed by workspace id.
+     * @member {Map<String,Neo.dashboard.DockCrossWindowParticipation>} crossWindowParticipations
+     * @protected
+     */
+    crossWindowParticipations = new Map()
+    /**
+     * Paint-confirmed, window-local drag geometry keyed by workspace id.
+     * @member {Map<String,Object>} crossWindowGeometry
+     * @protected
+     */
+    crossWindowGeometry = new Map()
+    /**
+     * Runtime proof counters for the current gesture. A remote commit must produce one transfer,
+     * one source-side remote-drop-out notification, and zero source-local drop callbacks.
+     * @member {Object} crossWindowStats
+     * @protected
+     */
+    crossWindowStats = {localDropFires: 0, remoteDropOutFires: 0, transferCommits: 0}
+    /**
+     * The popup render target currently bound to {@link #POPUP_WORKSPACE_ID}.
+     * @member {String|null} crossWindowTargetWindowId=null
+     * @protected
+     */
+    crossWindowTargetWindowId = null
+    /**
+     * Connect-settled promise for the deterministic two-window stage.
+     * @member {Promise|null} crossWindowStagePromise=null
+     * @protected
+     */
+    crossWindowStagePromise = null
+    /**
+     * Resolver for {@link #crossWindowStagePromise}; set before windowOpen so a cold, fast
+     * connection cannot outrun the owner.
+     * @member {Function|null} crossWindowStageResolve=null
+     * @protected
+     */
+    crossWindowStageResolve = null
+    /**
+     * Rejecter for {@link #crossWindowStagePromise}.
+     * @member {Function|null} crossWindowStageReject=null
+     * @protected
+     */
+    crossWindowStageReject = null
+    /**
+     * Monotonic target-ownership generation. Every open attempt captures the current value;
+     * disconnect and destroy advance it so an awaited popup mount cannot resurrect stale state.
+     * @member {Number} crossWindowStageGeneration=0
+     * @protected
+     */
+    crossWindowStageGeneration = 0
+    /**
+     * Whether projections opt into coordinator participation. Demo B starts enabled so every
+     * source SortZone warms the coordinator off the gesture hot path; without a registered
+     * remote target, ordinary in-window and legacy pop-out behavior remains unchanged.
+     * @member {Boolean} crossWindowEnabled=true
+     * @protected
+     */
+    crossWindowEnabled = true
+    /**
+     * Gesture settlement resolver installed before InteractionService dispatch.
+     * @member {Function|null} crossWindowGestureResolve=null
+     * @protected
+     */
+    crossWindowGestureResolve = null
+    /**
+     * Runtime-only source-zone and continuity snapshot for the gesture being driven.
+     * @member {Object|null} crossWindowGestureContext=null
+     * @protected
+     */
+    crossWindowGestureContext = null
     /**
      * Detached-pane bookkeeping: itemId → {tabsNodeId, windowId|null}. `tabsNodeId` is the
      * home the reattach commit targets; `windowId` fills in when the popup connects.
@@ -127,6 +241,14 @@ class DemoBWorkspace extends Container {
      */
     refreshPromise = Promise.resolve()
     /**
+     * Latest atomic projection request per worker-owned workspace. Document truth and
+     * owner-preservation policy coalesce together; transaction metadata can never trail behind
+     * and mutate a newer document.
+     * @member {Map<String,Object>} workspaceProjectionRequests
+     * @protected
+     */
+    workspaceProjectionRequests = new Map()
+    /**
      * Beats executed in the current run — the pip strip's progress counter.
      * @member {Number} beatCount=0
      */
@@ -142,14 +264,17 @@ class DemoBWorkspace extends Container {
 
         me.dockModel        = DockZoneModel.clone(initialDocument);
         me.popupDocument    = DemoBWorkspace.createPopupDocument();
+        me.dockPreviewProducer = Neo.create(DockPreviewProducer);
         me.dockService      = Neo.create(DockService, {});
+        me.interactionService = Neo.create(InteractionService, {});
         me.perspectiveStore = Neo.create(DockPerspectiveStore, {});
 
         me.tourRunner = Neo.create(TourRunner, {
-            componentId: me.id,
-            dockService: me.dockService,
-            mode       : 'demo',
-            script     : demoBTourScript
+            componentId        : me.id,
+            crossWindowExecutor: me,
+            dockService        : me.dockService,
+            mode               : 'demo',
+            script             : demoBTourScript
         });
 
         me.tourRunner.on({
@@ -180,13 +305,19 @@ class DemoBWorkspace extends Container {
             ntype    : 'component',
             reference: 'restore-report-b'
         }, {
-            module   : Container,
-            cls      : ['agentos-dockdemo-dock-host', 'neo-dashboard'],
-            flex     : 1,
-            items    : [me.projectDockModel()],
+            module: Container,
+            cls   : ['agentos-dockdemo-dock-host', 'neo-dashboard'],
+            flex  : 1,
+            items : [me.projectDockModel(), {
+                module: DockPreview
+            }, {
+                module: DockDropIndicators
+            }],
             layout   : {ntype: 'fit'},
             reference: 'dock-host-b'
-        }])
+        }]);
+
+        me.crossWindowHosts.set(DemoBWorkspace.MAIN_WORKSPACE_ID, me.getReference('dock-host-b'))
     }
 
     /**
@@ -196,6 +327,36 @@ class DemoBWorkspace extends Container {
      */
     applyDockZoneOperation(descriptor) {
         return DockZoneModel.applyOperation(this.dockModel, descriptor)
+    }
+
+    /**
+     * Resolves worker-owned document truth by semantic workspace id.
+     * @param {String} workspaceId
+     * @returns {Object|null}
+     */
+    getWorkspaceDocument(workspaceId) {
+        if (workspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID) {
+            return this.dockModel
+        }
+
+        if (workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID) {
+            return this.popupDocument
+        }
+
+        return null
+    }
+
+    /**
+     * Applies one ordinary single-document operation against a named live workspace.
+     * @param {String} workspaceId
+     * @param {Object} descriptor
+     * @returns {{document:Object,errors:String[]}|null}
+     * @protected
+     */
+    applyWorkspaceOperation(workspaceId, descriptor) {
+        let document = this.getWorkspaceDocument(workspaceId);
+
+        return document ? DockZoneModel.applyOperation(document, descriptor) : null
     }
 
     /**
@@ -355,13 +516,18 @@ class DemoBWorkspace extends Container {
      * @protected
      */
     commitTopologyRestore({documents, hasLivePopup, report}) {
-        let me            = this,
-            liveDocuments = hasLivePopup ? documents.slice(0, 2) : documents.slice(0, 1);
+        let me              = this,
+            liveDocuments   = hasLivePopup ? documents.slice(0, 2) : documents.slice(0, 1),
+            liveItemIds     = new Set(liveDocuments.flatMap(document => Object.keys(document?.items || {}))),
+            preserveItemIds = (report?.unrestored || [])
+                .map(entry => entry.itemId)
+                .filter(itemId => !liveItemIds.has(itemId));
 
-        me.parkUnrestoredPanes(liveDocuments, report);
         hasLivePopup && (me.popupDocument = documents[1]);
 
-        return me.onDockZoneDocumentChange(documents[0])
+        return me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, documents[0], {
+            preserveItemIds
+        })
     }
 
     /**
@@ -401,29 +567,6 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * @summary Parks cached panes represented by an unrestored topology remainder before the
-     * shared reconciler can classify their temporary projection absence as a true removal.
-     * @param {Object[]} liveDocuments Documents that have an actual render target.
-     * @param {Object} report Structured topology reconciliation remainder.
-     * @protected
-     */
-    parkUnrestoredPanes(liveDocuments, report) {
-        let me              = this,
-            liveItemIds     = new Set(liveDocuments.flatMap(document => Object.keys(document?.items || {}))),
-            unrestoredItems = new Set((report?.unrestored || []).map(entry => entry.itemId));
-
-        unrestoredItems.forEach(itemId => {
-            let pane = me.paneCache[itemId];
-
-            if (!liveItemIds.has(itemId) && pane && !pane.isDestroyed) {
-                // The pane is still owned by Demo B, just not by a currently renderable document.
-                // Remove without destroy BEFORE projection so true-removal retirement never sees it.
-                pane.parent?.remove(pane, false)
-            }
-        })
-    }
-
-    /**
      * @summary Renders the structured topology remainder into a dedicated visible strip.
      * Item ids are escaped because saved layouts are data, not trusted markup.
      * @protected
@@ -455,14 +598,45 @@ class DemoBWorkspace extends Container {
      * @returns {Promise}
      */
     onDockZoneDocumentChange(document) {
-        let me = this;
+        return this.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, document)
+    }
 
-        me.dockModel = document;
+    /**
+     * @summary Publishes one named workspace document, then serializes a deferred projection refresh.
+     *
+     * Ordinary queued refreshes coalesce onto the latest worker-owned document for that
+     * workspace; the atomic cross-window commit owns its explicit target-first pair separately.
+     * @param {String} workspaceId
+     * @param {Object} document
+     * @param {Object} [options={}] Projection-lifecycle options
+     * @param {Iterable<String>} [options.preserveItemIds=[]] Owner-held panes absent from this
+     * document which the shared reconciler must park instead of destroy.
+     * @returns {Promise}
+     * @protected
+     */
+    onWorkspaceDocumentChange(workspaceId, document, {preserveItemIds = []} = {}) {
+        let me      = this,
+            request = {document, preserveItemIds: [...preserveItemIds]};
 
+        if (workspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID) {
+            me.dockModel = document
+        } else if (workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID) {
+            me.popupDocument = document
+        } else {
+            return Promise.reject(new Error(`unknown Demo-B workspace "${workspaceId}"`))
+        }
+
+        me.workspaceProjectionRequests.set(workspaceId, request);
         me.refreshPromise = me.refreshPromise
             .then(() => me.timeout(0))
             .then(() => {
-                if (!me.isDestroyed) return me.refreshDockWorkspace()
+                if (!me.isDestroyed) {
+                    const latest = me.workspaceProjectionRequests.get(workspaceId);
+
+                    return me.refreshWorkspace(workspaceId, latest.document, {
+                        preserveItemIds: latest.preserveItemIds
+                    })
+                }
             });
 
         return me.refreshPromise
@@ -515,6 +689,998 @@ class DemoBWorkspace extends Container {
     }
 
     /**
+     * Creates the target-side participation adapter lazily after the popup window has joined.
+     * The dynamic import keeps the DragCoordinator/Window chain out of headless holder tests
+     * until a real cross-window stage exists.
+     * @param {String} workspaceId
+     * @param {String} windowId
+     * @returns {Promise<Neo.dashboard.DockCrossWindowParticipation>}
+     * @protected
+     */
+    async createCrossWindowParticipation(workspaceId, windowId, host, generation) {
+        let me            = this,
+            Participation = (await import('../../../../../src/dashboard/DockCrossWindowParticipation.mjs')).default;
+
+        if (!me.isCrossWindowTargetCurrent(workspaceId, windowId, host, generation)) {
+            return null
+        }
+
+        me.crossWindowParticipations.get(workspaceId)?.destroy();
+
+        let participation = Neo.create(Participation, {
+            clearPreview: () => me.clearWorkspaceAffordances(workspaceId),
+            commitLocal : operation => {
+                let result = me.applyWorkspaceOperation(workspaceId, operation);
+
+                if (result && !result.errors?.length && result.document) {
+                    me.onWorkspaceDocumentChange(workspaceId, result.document)
+                }
+
+                return result
+            },
+            commitTransfer    : data => me.commitCrossWindowTransfer(data),
+            getDocument       : () => me.getWorkspaceDocument(workspaceId),
+            getForeignDocument: sourceWorkspaceId => me.getWorkspaceDocument(sourceWorkspaceId),
+            hitTest           : (localX, localY) => me.hitTestWorkspace(workspaceId, localX, localY),
+            previewFor        : data => me.renderWorkspacePreview(workspaceId, data),
+            previewToOperation,
+            sortGroup         : DemoBWorkspace.CROSS_WINDOW_SORT_GROUP,
+            windowId,
+            workspaceId
+        });
+
+        me.crossWindowParticipations.set(workspaceId, participation);
+
+        return participation
+    }
+
+    /**
+     * Checks that an async popup continuation still belongs to the live target generation.
+     * @param {String} workspaceId
+     * @param {String} windowId
+     * @param {Neo.container.Base} host
+     * @param {Number} generation
+     * @returns {Boolean}
+     * @protected
+     */
+    isCrossWindowTargetCurrent(workspaceId, windowId, host, generation) {
+        let me = this;
+
+        return !me.isDestroyed
+            && me.crossWindowStageGeneration === generation
+            && me.crossWindowTargetWindowId === windowId
+            && me.crossWindowHosts.get(workspaceId) === host
+            && !host.isDestroyed
+    }
+
+    /**
+     * Mounts the popup workspace projection into a newly connected render target, registers its
+     * target participation, and resolves only after real DOM geometry is measurable.
+     * @param {Neo.app.Base} app
+     * @param {String} windowId
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async mountCrossWindowTarget(app, windowId) {
+        let me          = this,
+            workspaceId = DemoBWorkspace.POPUP_WORKSPACE_ID,
+            generation  = me.crossWindowStageGeneration,
+            host        = app.mainView.add({
+                module: Container,
+                cls   : ['agentos-dockdemo-dock-host', 'neo-dashboard'],
+                flex  : 1,
+                items : [me.projectDockModel(null, workspaceId), {
+                    module: DockPreview
+                }, {
+                    module: DockDropIndicators
+                }],
+                layout: {ntype: 'fit'}
+            });
+
+        me.crossWindowTargetWindowId = windowId;
+        me.crossWindowHosts.set(workspaceId, host);
+
+        try {
+            await app.mainView.promiseUpdate();
+
+            if (!me.isCrossWindowTargetCurrent(workspaceId, windowId, host, generation)) {
+                return null
+            }
+
+            let participation = await me.createCrossWindowParticipation(workspaceId, windowId, host, generation);
+
+            if (!participation || !me.isCrossWindowTargetCurrent(workspaceId, windowId, host, generation)) {
+                participation?.destroy();
+                return null
+            }
+
+            let geometry = await me.waitForWorkspaceGeometry(workspaceId);
+
+            if (!geometry || !me.isCrossWindowTargetCurrent(workspaceId, windowId, host, generation)) {
+                throw new Error('popup workspace geometry is not measurable')
+            }
+
+            let receipt = {windowId, workspaceId, hostId: host.id};
+
+            me.crossWindowStageResolve?.(receipt);
+            me.crossWindowStageResolve = null;
+            me.crossWindowStageReject  = null;
+
+            return receipt
+        } catch (error) {
+            if (me.crossWindowStageGeneration === generation) {
+                me.crossWindowStageReject?.(error);
+                me.crossWindowStageResolve = null;
+                me.crossWindowStageReject  = null
+            }
+
+            if (me.isCrossWindowTargetCurrent(workspaceId, windowId, host, generation)) {
+                throw error
+            }
+
+            return null
+        }
+    }
+
+    /**
+     * Opens two non-overlapping active workspaces and resolves from the worker connect + measured
+     * geometry contract, never from a blind sleep.
+     * @returns {Promise<Object>}
+     */
+    async openCrossWindowStage() {
+        let me          = this,
+            workspaceId = DemoBWorkspace.POPUP_WORKSPACE_ID,
+            host        = me.crossWindowHosts.get(workspaceId),
+            windowId    = me.crossWindowTargetWindowId;
+
+        // A physical popup close can precede the worker disconnect callback. Reuse only a
+        // complete, live owner bundle; a partial/destroyed cache must enter the ordinary cold
+        // open path instead of handing the gesture a stale target id.
+        if (windowId && host && !host.isDestroyed
+            && me.crossWindowParticipations.has(workspaceId)
+            && me.crossWindowGeometry.has(workspaceId)) {
+            return {
+                hostId: host.id,
+                windowId,
+                workspaceId
+            }
+        }
+
+        if (me.crossWindowStagePromise) return me.crossWindowStagePromise;
+
+        if (Object.keys(me.popupDocument?.items || {}).length) {
+            return Promise.reject(new Error('popup workspace is not empty; cross-window stage refuses split ownership'))
+        }
+
+        me.crossWindowStageGeneration++;
+        me.popupDocument = DemoBWorkspace.createPopupDocument();
+
+        me.crossWindowStagePromise = new Promise((resolve, reject) => {
+            me.crossWindowStageResolve = resolve;
+            me.crossWindowStageReject  = reject
+        });
+
+        let winData = await Neo.Main.getWindowData({windowId: me.windowId}),
+            left    = winData.screenLeft > 660
+                ? winData.screenLeft - 640
+                : winData.screenLeft + (winData.innerWidth || 1280) + 40,
+            top     = winData.screenTop;
+
+        try {
+            await Neo.Main.windowOpen({
+                url           : `./index.html?workspaceId=${workspaceId}&hostId=${me.id}`,
+                windowFeatures: `height=520,width=600,left=${left},top=${top}`,
+                windowId      : me.windowId,
+                windowName    : 'demo-b-cross-window'
+            })
+        } catch (error) {
+            me.crossWindowStageReject?.(error);
+            me.crossWindowStagePromise = null;
+            me.crossWindowStageResolve = null;
+            me.crossWindowStageReject  = null;
+            throw error
+        }
+
+        let timeout = me.timeout(10000).then(() => {
+            throw new Error('cross-window target did not connect and become measurable within 10s')
+        });
+
+        try {
+            return await Promise.race([me.crossWindowStagePromise, timeout])
+        } catch (error) {
+            me.crossWindowStagePromise = null;
+            throw error
+        }
+    }
+
+    /**
+     * Publishes the atomic transfer pair, then reconciles target before source. Target-first is
+     * load-bearing: it adopts the cached pane across the window boundary before the source shell
+     * can classify the now-absent item as a retirement.
+     * @param {Object} data
+     * @returns {Promise}
+     * @protected
+     */
+    commitCrossWindowTransfer(data) {
+        let me = this,
+            {
+                descriptor,
+                sourceDocument,
+                sourceWorkspaceId,
+                targetDocument,
+                targetWorkspaceId
+            } = data;
+
+        const
+            context       = me.crossWindowGestureContext,
+            generation    = me.crossWindowStageGeneration,
+            itemId        = descriptor.itemId,
+            isPopupDetach = sourceWorkspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID
+                && targetWorkspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID,
+            targetWindowId   = me.crossWindowTargetWindowId,
+            ownsTransfer     = () => !me.isDestroyed
+                && me.crossWindowStageGeneration === generation
+                && me.crossWindowTargetWindowId === targetWindowId
+                && (!isPopupDetach || me.detachedPanes[itemId]?.windowId === targetWindowId);
+
+        me.crossWindowStats.transferCommits++;
+
+        sourceWorkspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID
+            ? (me.dockModel = sourceDocument)
+            : (me.popupDocument = sourceDocument);
+        targetWorkspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID
+            ? (me.dockModel = targetDocument)
+            : (me.popupDocument = targetDocument);
+
+        // The document pair and vessel ownership are one worker-side commit. A physical close can
+        // arrive before either projection settles; publishing this entry synchronously lets the
+        // disconnect path reattach the item instead of misclassifying committed truth as a cold
+        // cancellation. The generation predicate below prevents that superseded projection from
+        // writing stale source/target chrome after the recovery transaction has taken ownership.
+        if (isPopupDetach) {
+            me.detachedPanes[itemId] = {
+                tabsNodeId: context?.sourceNodeId,
+                windowId  : targetWindowId,
+                windowName: 'demo-b-cross-window'
+            }
+        }
+
+        me.refreshPromise = me.refreshPromise
+            .then(() => me.timeout(0))
+            .then(async () => {
+                if (!ownsTransfer()) return;
+
+                // `onRemoteDropOut()` and the source-local suppression decision both finish on
+                // the coordinator's synchronous mouseup stack, before this deferred projection.
+                // Snapshot their counters now: the source projection intentionally destroys its
+                // empty tabs zone, so reading a field from that zone after reconciliation would
+                // manufacture false evidence from a torn-down object.
+                let sourceDecision = {
+                    localDropFires    : me.crossWindowStats.localDropFires,
+                    remoteDropOutFires: me.crossWindowStats.remoteDropOutFires
+                };
+
+                try {
+                    await me.refreshWorkspace(targetWorkspaceId, targetDocument)
+                } catch (error) {
+                    if (!ownsTransfer()) return;
+                    throw error
+                }
+
+                if (!ownsTransfer()) return;
+
+                await me.refreshWorkspace(sourceWorkspaceId, sourceDocument);
+
+                if (!ownsTransfer()) return;
+
+                let pane         = me.paneCache[itemId],
+                    framesAfter  = pane?.frames ?? -1,
+                    targetTabsId = DockZoneModel.findContainingTabsId(targetDocument, itemId),
+                    proof        = {
+                        framesAfter,
+                        framesBefore      : context?.frames ?? null,
+                        framesNotReset    : framesAfter >= (context?.frames ?? Infinity),
+                        localDropFires    : sourceDecision.localDropFires,
+                        mountDelta        : (pane?.mountCount ?? 0) - (context?.mountCount ?? 0),
+                        remoteDropOutFires: sourceDecision.remoteDropOutFires,
+                        remoteSnapshot    : context?.remoteSnapshot ?? null,
+                        sameInstance      : pane === context?.pane,
+                        sourceItemRemoved : !sourceDocument.items?.[itemId]
+                            && DockZoneModel.findContainingTabsId(sourceDocument, itemId) === null,
+                        sourceSuppressionConsumed: sourceDecision.remoteDropOutFires === 1
+                            && sourceDecision.localDropFires === 0,
+                        targetItemPlaced        : !!targetDocument.items?.[itemId]
+                            && targetTabsId === descriptor.target?.tabsNodeId,
+                        targetTabsId,
+                        transferCommits         : me.crossWindowStats.transferCommits
+                    },
+                    checks         = [
+                        ['transfer committed exactly once', proof.transferCommits === 1],
+                        ['source remote-drop-out fired exactly once', proof.remoteDropOutFires === 1],
+                        ['source local drop stayed suppressed', proof.localDropFires === 0],
+                        ['remote semantic and rendered preview settled', proof.remoteSnapshot?.ready === true],
+                        ['source document relinquished the item', proof.sourceItemRemoved],
+                        ['target document placed the item', proof.targetItemPlaced],
+                        ['worker component instance stayed identical', proof.sameInstance],
+                        ['instance heartbeat did not reset', proof.framesNotReset],
+                        ['target document added exactly one mount', proof.mountDelta === 1],
+                        ['continuity witness is complete', typeof pane?.id === 'string'
+                            && Number.isInteger(pane?.mountCount)]
+                    ],
+                    errors         = checks.filter(([, passed]) => !passed).map(([message]) => message),
+                    receipt        = {
+                        applied       : errors.length === 0,
+                        errors,
+                        sourceDocument: DockZoneModel.clone(sourceDocument),
+                        targetDocument: DockZoneModel.clone(targetDocument),
+                        witness       : {
+                            instanceId: pane?.id ?? null,
+                            mountCount: pane?.mountCount ?? null
+                        },
+                        proof
+                    };
+
+                me.crossWindowGestureResolve?.(receipt);
+                me.crossWindowGestureResolve = null
+            });
+
+        return me.refreshPromise
+    }
+
+    /**
+     * @summary Installs a gesture-local witness around the source's remote-drop-out hook.
+     * The hook itself stays authoritative and runs unchanged; this wrapper only counts how
+     * often the coordinator selected that exact completion path before projection teardown.
+     * @param {Neo.dashboard.DockTabSortZone} sourceZone
+     * @returns {Object}
+     * @protected
+     */
+    installCrossWindowSourceProbe(sourceZone) {
+        let me       = this,
+            stats    = me.crossWindowStats,
+            hadOwn   = Object.hasOwn(sourceZone, 'onRemoteDropOut'),
+            original = sourceZone.onRemoteDropOut,
+            probe    = function(draggedItem) {
+                stats.remoteDropOutFires++;
+                return original.call(sourceZone, draggedItem)
+            };
+
+        sourceZone.onRemoteDropOut = probe;
+
+        return {hadOwn, original, probe, sourceZone}
+    }
+
+    /**
+     * @summary Removes a gesture-local source witness when the source zone survived the probe.
+     * A successful singleton transfer destroys that empty source zone, in which case teardown
+     * has already removed the own wrapper and there is nothing to restore.
+     * @param {Object|null} sourceProbe
+     * @protected
+     */
+    restoreCrossWindowSourceProbe(sourceProbe) {
+        let {hadOwn, original, probe, sourceZone} = sourceProbe || {};
+
+        if (!sourceZone || sourceZone.onRemoteDropOut !== probe) return;
+
+        if (hadOwn) {
+            sourceZone.onRemoteDropOut = original
+        } else {
+            delete sourceZone.onRemoteDropOut
+        }
+    }
+
+    /**
+     * @summary Reads the live source SortZone's drag-session readiness contract.
+     * @param {Object} context
+     * @returns {Object}
+     * @protected
+     */
+    readCrossWindowDragReadiness(context) {
+        let {itemId, sourceWorkspaceId, sourceZone} = context || {},
+            draggedItem                             = sourceZone?.dragComponent,
+            snapshot                                = {
+                coordinatorReady: !!sourceZone?.dragCoordinator,
+                dragProxyReady  : !!sourceZone?.dragProxy,
+                dragging        : sourceZone?.owner?.cls?.includes?.('neo-is-dragging') === true,
+                itemId          : draggedItem?.dockItemId ?? null,
+                workspaceId     : draggedItem?.dockSourceWorkspaceId ?? null
+            };
+
+        snapshot.ready = snapshot.coordinatorReady
+            && snapshot.dragProxyReady
+            && snapshot.dragging
+            && snapshot.itemId === itemId
+            && snapshot.workspaceId === sourceWorkspaceId;
+
+        return snapshot
+    }
+
+    /**
+     * @summary Polls source gesture state, never elapsed time, before any remote screen move.
+     * @param {Object} context
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=120]
+     * @param {Number} [options.delay=16]
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async waitForCrossWindowDragReadiness(context, {attempts=120, delay=16}={}) {
+        let me = this,
+            snapshot;
+
+        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+            snapshot = me.readCrossWindowDragReadiness(context);
+
+            if (snapshot.ready || attempt === attempts) break;
+
+            await me.timeout(delay)
+        }
+
+        return snapshot || {ready: false}
+    }
+
+    /**
+     * @summary Captures the remote target while the pointer is still down. This JSON-safe
+     * snapshot is the Whitebox/NL observation seam: coordinator engagement, semantic preview,
+     * rendered preview, and menu selection all become inspectable before mouseup commits.
+     * @param {Object} context
+     * @returns {Object}
+     * @protected
+     */
+    readCrossWindowRemoteSnapshot(context) {
+        let me                                            = this,
+            {sourceZone, targetNodeId, targetWorkspaceId} = context || {},
+            coordinator                                   = sourceZone?.dragCoordinator,
+            participation                                 = me.crossWindowParticipations.get(targetWorkspaceId),
+            target                                        = participation?.target,
+            host                                          = me.crossWindowHosts.get(targetWorkspaceId),
+            renderer                                      = host?.down({ntype: 'dock-preview'}),
+            indicators                                    = host?.down({ntype: 'dashboard-dock-drop-indicators'}),
+            preview                                       = target?.currentPreview ?? null,
+            rendered                                      = renderer?.dockPreview ?? null,
+            candidateSet                                  = indicators?.candidateSet ?? null,
+            snapshot                                      = {
+                coordinator: coordinator?.toJSON?.() ?? null,
+                engaged    : coordinator?.activeTargetZone === target,
+                indicators : {
+                    activePreviewId: indicators?.activeCandidate?.preview?.previewId ?? null,
+                    candidateCount : (candidateSet?.cross?.length ?? 0)
+                        + (candidateSet?.root?.chips?.length ?? 0),
+                    schema         : candidateSet?.schema ?? null
+                },
+                preview : preview ? DockZoneModel.clone(preview) : null,
+                rendered: rendered ? DockZoneModel.clone(rendered) : null,
+                targetNodeId
+            };
+
+        snapshot.ready = snapshot.engaged
+            && snapshot.preview?.target?.nodeId === targetNodeId
+            && snapshot.rendered?.previewId === snapshot.preview?.previewId;
+
+        return snapshot
+    }
+
+    /**
+     * @summary Polls the target's semantic + rendered hover state before allowing mouseup.
+     * @param {Object} context
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=120]
+     * @param {Number} [options.delay=16]
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async waitForCrossWindowRemotePreview(context, {attempts=120, delay=16}={}) {
+        let me = this,
+            snapshot;
+
+        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+            snapshot = me.readCrossWindowRemoteSnapshot(context);
+
+            if (snapshot.ready || attempt === attempts) break;
+
+            await me.timeout(delay)
+        }
+
+        return snapshot || {ready: false}
+    }
+
+    /**
+     * @summary Reads every terminal state the Escape journey must clear after remote hover.
+     * @param {Object} context
+     * @returns {Object}
+     * @protected
+     */
+    readCrossWindowCancellationSnapshot(context) {
+        let me                              = this,
+            {sourceZone, targetWorkspaceId} = context || {},
+            coordinator                     = sourceZone?.dragCoordinator,
+            participation                   = me.crossWindowParticipations.get(targetWorkspaceId),
+            host                            = me.crossWindowHosts.get(targetWorkspaceId),
+            renderer                        = host?.down({ntype: 'dock-preview'}),
+            indicators                      = host?.down({ntype: 'dashboard-dock-drop-indicators'}),
+            snapshot                        = {
+                activeTargetZone      : coordinator?.toJSON?.().activeTargetZone ?? null,
+                activeCandidateId     : indicators?.activeCandidate?.preview?.previewId ?? null,
+                candidateSetSchema    : indicators?.candidateSet?.schema ?? null,
+                dragDataPresent       : sourceZone?.data != null,
+                dragEndActive         : sourceZone?.dragEndActive === true,
+                dragPlaceholderPresent: !!sourceZone?.dragPlaceholder,
+                dragProxyPresent      : !!sourceZone?.dragProxy,
+                draggingClass         : sourceZone?.owner?.cls?.includes?.('neo-is-dragging') === true,
+                nativeCandidateCount  : coordinator?.nativeWindowDropCandidates?.size ?? 0,
+                semanticPreviewId     : participation?.target?.currentPreview?.previewId ?? null,
+                renderedPreviewId     : renderer?.dockPreview?.previewId ?? null
+            };
+
+        snapshot.ready = snapshot.activeTargetZone === null
+            && snapshot.activeCandidateId === null
+            && snapshot.candidateSetSchema === null
+            && snapshot.dragDataPresent === false
+            && snapshot.dragEndActive === false
+            && snapshot.dragPlaceholderPresent === false
+            && snapshot.dragProxyPresent === false
+            && snapshot.draggingClass === false
+            && snapshot.nativeCandidateCount === 0
+            && snapshot.semanticPreviewId === null
+            && snapshot.renderedPreviewId === null;
+
+        return snapshot
+    }
+
+    /**
+     * @summary Polls the full cancellation contract rather than treating one cleared CSS class
+     * as proof that coordinator, target, proxy and render affordances all settled.
+     * @param {Object} context
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=120]
+     * @param {Number} [options.delay=16]
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async waitForCrossWindowCancellation(context, {attempts=120, delay=16}={}) {
+        let me = this,
+            snapshot;
+
+        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+            snapshot = me.readCrossWindowCancellationSnapshot(context);
+
+            if (snapshot.ready || attempt === attempts) break;
+
+            await me.timeout(delay)
+        }
+
+        return snapshot || {ready: false}
+    }
+
+    /**
+     * @summary Cancels a failed probe through the real main-thread Escape route, then releases
+     * the native mouse sensor so the next cold gesture starts from a clean owner state.
+     * @param {Object|null} context
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async cancelCrossWindowGesture(context) {
+        let me = this,
+            {
+                sourceButtonId,
+                sourceWindowId,
+                sourceX,
+                sourceY,
+                sourceScreenX,
+                sourceScreenY,
+                sourceZone
+            } = context || {};
+
+        if (!sourceButtonId || sourceWindowId == null || !sourceZone) {
+            sourceZone?.dragCoordinator?.onDragCancel({sourceSortZone: sourceZone});
+            return {escapeDispatched: false, releaseDispatched: false, settled: false}
+        }
+
+        let escapeDispatched = await me.interactionService.dispatch({
+                id      : sourceButtonId,
+                type    : 'keydown',
+                windowId: sourceWindowId,
+                options : {bubbles: true, cancelable: true, code: 'Escape', key: 'Escape'}
+            }),
+            releaseDispatched = await me.interactionService.dispatch({
+                id      : sourceButtonId,
+                type    : 'mouseup',
+                windowId: sourceWindowId,
+                options : {
+                    bubbles: true, button: 0, buttons: 0, cancelable: true,
+                    clientX: sourceX, clientY: sourceY, screenX: sourceScreenX, screenY: sourceScreenY
+                }
+            });
+
+        for (let attempt = 0; attempt <= 60 && !me.isDestroyed; attempt++) {
+            let settled = sourceZone.owner?.cls?.includes?.('neo-is-dragging') !== true
+                && sourceZone.dragEndActive !== true
+                && sourceZone.data == null
+                && !sourceZone.dragPlaceholder
+                && !sourceZone.dragProxy;
+
+            if (settled) return {escapeDispatched, releaseDispatched, settled: true};
+
+            attempt < 60 && await me.timeout(16)
+        }
+
+        return {escapeDispatched, releaseDispatched, settled: false}
+    }
+
+    /**
+     * @summary Places the popup outside the source viewport and proves the Window manager sees
+     * two non-overlapping rectangles. Browsers may ignore `window.open(left=...)`; therefore the
+     * requested feature is only an intent, while the live Window manager projection is the
+     * readiness authority used by global drag hit-testing.
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=120]
+     * @param {Number} [options.delay=16]
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async positionCrossWindowStage({attempts=120, delay=16}={}) {
+        let me            = this,
+            WindowManager = (await import('../../../../../src/manager/Window.mjs')).default,
+            sourceWindow  = WindowManager.get(me.windowId),
+            targetWindow  = WindowManager.get(me.crossWindowTargetWindowId),
+            sourceData    = await Neo.Main.getWindowData({windowId: me.windowId}),
+            screen        = sourceData?.screen,
+            sourceRect    = sourceWindow?.innerRect,
+            targetRect    = targetWindow?.innerRect,
+            gap           = 40,
+            candidates, desired, snapshot;
+
+        if (!sourceRect || !targetRect || !screen) {
+            return {ready: false, reason: 'window geometry or screen bounds are unavailable'}
+        }
+
+        candidates = [{x: sourceRect.right + gap, y: sourceRect.y}, {
+            x: sourceRect.x - targetRect.width - gap,
+            y: sourceRect.y
+        }, {
+            x: sourceRect.x,
+            y: sourceRect.bottom + gap
+        }, {
+            x: sourceRect.x,
+            y: sourceRect.y - targetRect.height - gap
+        }];
+
+        desired = candidates.find(point => point.x >= screen.availLeft
+            && point.y >= screen.availTop
+            && point.x + targetRect.width <= screen.availLeft + screen.availWidth
+            && point.y + targetRect.height <= screen.availTop + screen.availHeight);
+
+        if (!desired) {
+            return {
+                ready : false,
+                reason: 'the available screen cannot hold both configured viewports without overlap',
+                screen,
+                source: sourceRect,
+                target: targetRect
+            }
+        }
+
+        await Neo.Main.windowMoveTo({
+            windowId  : me.windowId,
+            windowName: 'demo-b-cross-window',
+            x         : desired.x,
+            y         : desired.y
+        });
+
+        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+            sourceWindow = WindowManager.get(me.windowId);
+            targetWindow = WindowManager.get(me.crossWindowTargetWindowId);
+            sourceRect   = sourceWindow?.innerRect;
+            targetRect   = targetWindow?.innerRect;
+
+            let overlaps = sourceRect && targetRect
+                && sourceRect.x < targetRect.right
+                && sourceRect.right > targetRect.x
+                && sourceRect.y < targetRect.bottom
+                && sourceRect.bottom > targetRect.y;
+
+            snapshot = {
+                desired,
+                ready : !!sourceRect && !!targetRect && !overlaps,
+                source: sourceRect,
+                target: targetRect
+            };
+
+            if (snapshot.ready || attempt === attempts) break;
+
+            await me.timeout(delay)
+        }
+
+        return snapshot || {desired, ready: false}
+    }
+
+    /**
+     * @summary Phase-0 falsifier: drives the real first pointer gesture through InteractionService.
+     * The step carries semantic ids only; this host resolves live windows, component ids, and
+     * coordinates immediately before dispatch.
+     * @param {Object} step
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.cancelAtTarget=false] Whitebox-only branch: Escape after
+     * remote preview settles, before mouseup. This option never enters tour-script data.
+     * @returns {Promise<Object>}
+     */
+    async executeCrossWindowStep(step, {cancelAtTarget = false} = {}) {
+        let me          = this,
+            sourceProbe = null,
+            {
+                itemId,
+                sourceWorkspaceId,
+                targetWorkspaceId,
+                targetNodeId
+            } = step || {};
+
+        if (itemId !== 'workbench'
+            || sourceWorkspaceId !== DemoBWorkspace.MAIN_WORKSPACE_ID
+            || targetWorkspaceId !== DemoBWorkspace.POPUP_WORKSPACE_ID
+            || targetNodeId !== 'popup-tabs') {
+            return {applied: false, errors: ['unsupported Demo-B cross-window step']}
+        }
+
+        let pane = me.paneCache[itemId];
+
+        if (!me.getWorkspaceDocument(sourceWorkspaceId)?.items?.[itemId]
+            || !pane
+            || pane.isDestroyed) {
+            return {applied: false, errors: ['source Workbench pane is not live and owned by the source workspace']}
+        }
+
+        try {
+            // Surface cues are deliberately data-only and fire synchronously from TourRunner. A
+            // perspective load can therefore enqueue a projection immediately before this step,
+            // especially in spec mode where viewer pauses are skipped. Drain the host-owned queue
+            // before opening the second vessel so gesture geometry never reads stale tab chrome.
+            await me.awaitProjectionIdle();
+            await me.openCrossWindowStage();
+            await me.waitForWorkspaceGeometry(sourceWorkspaceId);
+            await me.waitForWorkspaceGeometry(targetWorkspaceId);
+
+            let stagePlacement = await me.positionCrossWindowStage();
+
+            if (!stagePlacement.ready) {
+                return {
+                    applied: false,
+                    errors : ['cross-window stage could not establish two non-overlapping active windows'],
+                    debug  : {stagePlacement}
+                }
+            }
+
+            let sourceDocument = me.getWorkspaceDocument(sourceWorkspaceId),
+                sourceNodeId   = DockZoneModel.findContainingTabsId(sourceDocument, itemId),
+                sourceItems    = sourceDocument.nodes[sourceNodeId]?.items || [],
+                sourceHost     = me.crossWindowHosts.get(sourceWorkspaceId),
+                sourceTabs     = sourceHost?.down({dockNodeId: sourceNodeId}),
+                itemIndex      = sourceDocument.nodes[sourceNodeId]?.items.indexOf(itemId) ?? -1,
+                sourceButton   = sourceTabs?.getTabAtIndex(itemIndex),
+                sourceBar      = sourceTabs?.getTabBar(),
+                sourceZone     = sourceBar?.sortZone,
+                projectedItems = sourceZone?.dockItemIds || [],
+                [buttonRect]   = sourceButton
+                    ? await sourceButton.getDomRect([sourceButton.id], sourceButton.windowId)
+                    : [],
+                targetGeometry = me.crossWindowGeometry.get(targetWorkspaceId),
+                targetRect     = targetGeometry?.zones.find(zone => zone.nodeId === targetNodeId)?.rect,
+                WindowManager  = (await import('../../../../../src/manager/Window.mjs')).default,
+                sourceWindow   = WindowManager.get(sourceButton?.windowId),
+                targetWindow   = WindowManager.get(me.crossWindowTargetWindowId);
+
+            if (sourceItems.length !== 1 || sourceItems[0] !== itemId) {
+                return {
+                    applied: false,
+                    errors : ['Demo-B cross-window projection currently supports only its singleton Workbench source tab']
+                }
+            }
+
+            if (sourceTabs?.dockNodeId !== sourceNodeId
+                || sourceZone?.dockWorkspaceId !== sourceWorkspaceId
+                || sourceBar?.items?.length !== sourceItems.length
+                || projectedItems.length !== sourceItems.length
+                || projectedItems.some((projectedItemId, index) => projectedItemId !== sourceItems[index])) {
+                return {
+                    applied: false,
+                    errors : ['source drag chrome does not match the current workspace document']
+                }
+            }
+
+            if (!sourceButton || !sourceZone || !buttonRect || !targetRect
+                || !sourceWindow?.innerRect || !targetWindow?.innerRect) {
+                return {applied: false, errors: ['cross-window gesture surfaces are not ready']}
+            }
+
+            if (!sourceZone.dragCoordinator) {
+                return {applied: false, errors: ['source cross-window coordinator is not ready']}
+            }
+
+            let sourceX       = buttonRect.x + buttonRect.width / 2,
+                sourceY       = buttonRect.y + buttonRect.height / 2,
+                sourceScreenX = sourceWindow.innerRect.x + sourceX,
+                sourceScreenY = sourceWindow.innerRect.y + sourceY,
+                targetX       = targetRect.x + targetRect.width / 2,
+                targetY       = targetRect.y + targetRect.height / 2,
+                targetScreenX = targetWindow.innerRect.x + targetX,
+                targetScreenY = targetWindow.innerRect.y + targetY;
+
+            me.crossWindowStats          = {localDropFires: 0, remoteDropOutFires: 0, transferCommits: 0};
+            sourceProbe                  = me.installCrossWindowSourceProbe(sourceZone);
+            me.crossWindowGestureContext = {
+                frames        : pane?.frames ?? 0,
+                itemId,
+                mountCount    : pane?.mountCount ?? 0,
+                pane,
+                sourceButtonId: sourceButton.id,
+                sourceNodeId,
+                sourceScreenX,
+                sourceScreenY,
+                sourceWorkspaceId,
+                sourceWindowId: sourceButton.windowId,
+                sourceX,
+                sourceY,
+                sourceZone,
+                targetNodeId,
+                targetWorkspaceId
+            };
+
+            let settled = new Promise(resolve => me.crossWindowGestureResolve = resolve),
+                options = (clientX, clientY, screenX, screenY, buttons) => ({
+                    bubbles: true, button: 0, buttons, cancelable: true,
+                    clientX, clientY, screenX, screenY
+                });
+
+            // Phase 1: own the native sensor and cross the local drag threshold. The next phase
+            // cannot begin until the worker-side SortZone exposes its readiness state.
+            await me.interactionService.simulateEvent({events: [{
+                targetId: sourceButton.id,
+                type    : 'mousedown',
+                windowId: sourceButton.windowId,
+                options : options(sourceX, sourceY, sourceScreenX, sourceScreenY, 1)
+            }, {
+                delay   : 120,
+                targetId: sourceButton.id,
+                type    : 'mousemove',
+                windowId: sourceButton.windowId,
+                options : options(sourceX + 8, sourceY, sourceScreenX + 8, sourceScreenY, 1)
+            }, {
+                delay   : 16,
+                targetId: sourceButton.id,
+                type    : 'mousemove',
+                windowId: sourceButton.windowId,
+                options : options(sourceX + 24, sourceY, sourceScreenX + 24, sourceScreenY, 1)
+            }]});
+
+            let readiness = await me.waitForCrossWindowDragReadiness(me.crossWindowGestureContext);
+
+            if (!readiness.ready) {
+                let cancellation = await me.cancelCrossWindowGesture(me.crossWindowGestureContext);
+
+                me.restoreCrossWindowSourceProbe(sourceProbe);
+                me.crossWindowGestureResolve = null;
+                me.crossWindowGestureContext = null;
+
+                return {
+                    applied: false,
+                    errors : ['source drag did not reach the landed readiness contract'],
+                    debug  : {cancellation, readiness}
+                }
+            }
+
+            // Phase 2: move in screen space while the source document still owns the pointer.
+            // Mouseup remains withheld until the target's semantic AND rendered preview agree.
+            await me.interactionService.simulateEvent({events: [{
+                delay   : 16,
+                targetId: sourceButton.id,
+                type    : 'mousemove',
+                windowId: sourceButton.windowId,
+                options : options(sourceX + 32, sourceY, targetScreenX, targetScreenY, 1)
+            }, {
+                delay   : 16,
+                targetId: sourceButton.id,
+                type    : 'mousemove',
+                windowId: sourceButton.windowId,
+                options : options(sourceX + 34, sourceY, targetScreenX + 2, targetScreenY, 1)
+            }]});
+
+            let remoteSnapshot = await me.waitForCrossWindowRemotePreview(me.crossWindowGestureContext);
+
+            if (!remoteSnapshot.ready) {
+                let cancellation = await me.cancelCrossWindowGesture(me.crossWindowGestureContext);
+
+                me.restoreCrossWindowSourceProbe(sourceProbe);
+                me.crossWindowGestureResolve = null;
+                me.crossWindowGestureContext = null;
+
+                return {
+                    applied: false,
+                    errors : ['remote target did not expose a settled semantic preview'],
+                    debug  : {cancellation, readiness, remoteSnapshot}
+                }
+            }
+
+            me.crossWindowGestureContext.remoteSnapshot = remoteSnapshot;
+
+            if (cancelAtTarget) {
+                let sourceBefore = DockZoneModel.clone(me.getWorkspaceDocument(sourceWorkspaceId)),
+                    targetBefore = DockZoneModel.clone(me.getWorkspaceDocument(targetWorkspaceId)),
+                    cancellation = await me.cancelCrossWindowGesture(me.crossWindowGestureContext),
+                    cleanup      = await me.waitForCrossWindowCancellation(me.crossWindowGestureContext),
+                    sourceAfter  = DockZoneModel.clone(me.getWorkspaceDocument(sourceWorkspaceId)),
+                    targetAfter  = DockZoneModel.clone(me.getWorkspaceDocument(targetWorkspaceId)),
+                    result       = {
+                        applied       : false,
+                        cancelled     : true,
+                        errors        : ['cross-window gesture cancelled before commit'],
+                        sourceDocument: sourceAfter,
+                        targetDocument: targetAfter,
+                        proof         : {
+                            cancellation,
+                            cleanup,
+                            documentsUnchanged: JSON.stringify(sourceBefore) === JSON.stringify(sourceAfter)
+                                && JSON.stringify(targetBefore) === JSON.stringify(targetAfter),
+                            remoteSnapshot,
+                            stats: {...me.crossWindowStats}
+                        }
+                    };
+
+                me.restoreCrossWindowSourceProbe(sourceProbe);
+                me.crossWindowGestureResolve = null;
+                me.crossWindowGestureContext = null;
+
+                return result
+            }
+
+            // Phase 3: release only after the mid-gesture receipt is captured. The coordinator
+            // now has one unambiguous target and can commit through its ordinary onDragEnd path.
+            await me.interactionService.simulateEvent({events: [{
+                targetId: sourceButton.id,
+                type    : 'mouseup',
+                windowId: sourceButton.windowId,
+                options : options(sourceX + 34, sourceY, targetScreenX + 2, targetScreenY, 0)
+            }]});
+
+            let timeout = me.timeout(5000).then(() => ({
+                applied: false,
+                errors : ['real cross-window gesture did not settle through the target commit path'],
+                debug  : {
+                    coordinator: sourceZone.dragCoordinator?.toJSON?.() ?? null,
+                    source     : {
+                        buttonRect,
+                        sortGroup          : sourceZone.sortGroup,
+                        windowId           : sourceZone.windowId,
+                        remoteDropCommitted: sourceZone.remoteDropCommitted
+                    },
+                    sourceWindow: sourceWindow.innerRect,
+                    stagePlacement,
+                    stats       : {...me.crossWindowStats},
+                    target      : {nodeId: targetNodeId, rect: targetRect},
+                    targetWindow: targetWindow.innerRect
+                }
+            }));
+
+            let result = await Promise.race([settled, timeout]);
+
+            if (!result.applied) {
+                await me.cancelCrossWindowGesture(me.crossWindowGestureContext)
+            }
+
+            me.restoreCrossWindowSourceProbe(sourceProbe);
+            me.crossWindowGestureResolve = null;
+            me.crossWindowGestureContext = null;
+
+            return result
+        } catch (error) {
+            await me.cancelCrossWindowGesture(me.crossWindowGestureContext).catch(() => {});
+            me.restoreCrossWindowSourceProbe(sourceProbe);
+            me.crossWindowGestureResolve = null;
+            me.crossWindowGestureContext = null;
+
+            return {applied: false, errors: [error?.message || String(error)]}
+        }
+    }
+
+    /**
      * A popup window joined the shared heap: if it is one of OURS (the pop-out URL carries
      * `popout=<itemId>&hostId=<this.id>`), reparent the LIVE cached pane into its main view.
      * The instance moves trees; nothing is recreated — the counter proves it.
@@ -527,11 +1693,19 @@ class DemoBWorkspace extends Container {
 
         if (!app || me.isDestroyed) return;
 
-        let url    = await Neo.Main.getByPath({path: 'document.URL', windowId}),
-            params = new URL(url).searchParams,
-            itemId = params.get('popout');
+        let url         = await Neo.Main.getByPath({path: 'document.URL', windowId}),
+            params      = new URL(url).searchParams,
+            workspaceId = params.get('workspaceId'),
+            itemId      = params.get('popout');
 
-        if (params.get('hostId') !== me.id || !itemId) return;
+        if (params.get('hostId') !== me.id) return;
+
+        if (workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID) {
+            await me.mountCrossWindowTarget(app, windowId);
+            return
+        }
+
+        if (!itemId) return;
 
         let entry = me.detachedPanes[itemId],
             pane  = me.paneCache[itemId];
@@ -551,6 +1725,38 @@ class DemoBWorkspace extends Container {
         let me = this;
 
         if (me.isDestroyed) return;
+
+        if (data.windowId === me.crossWindowTargetWindowId) {
+            let workspaceId    = DemoBWorkspace.POPUP_WORKSPACE_ID,
+                detachedItemId = Object.entries(me.detachedPanes)
+                    .find(([, entry]) => entry.windowId === data.windowId)?.[0];
+
+            me.crossWindowStageGeneration++;
+            me.crossWindowGestureContext?.sourceZone?.dragCoordinator?.onDragCancel({
+                sourceSortZone: me.crossWindowGestureContext.sourceZone
+            });
+            me.crossWindowGestureResolve?.({
+                applied: false,
+                errors : ['cross-window target disconnected before the gesture settled']
+            });
+            me.crossWindowStageReject?.(new Error('cross-window target disconnected before readiness settled'));
+
+            me.crossWindowParticipations.get(workspaceId)?.destroy();
+            me.crossWindowParticipations.delete(workspaceId);
+            me.crossWindowHosts.delete(workspaceId);
+            me.crossWindowGeometry.delete(workspaceId);
+            me.crossWindowTargetWindowId = null;
+            me.crossWindowStagePromise   = null;
+            me.crossWindowStageResolve   = null;
+            me.crossWindowStageReject    = null;
+            me.crossWindowGestureResolve = null;
+            me.crossWindowGestureContext = null;
+
+            // A post-commit manual close is a terminal vessel event, not ownership loss.
+            // A pre-commit close has no detached entry and remains a cancelled gesture.
+            detachedItemId && me.reattachPane(detachedItemId, {windowAlreadyClosed: true});
+            return
+        }
 
         for (const [itemId, entry] of Object.entries(me.detachedPanes)) {
             if (entry.windowId === data.windowId) {
@@ -630,19 +1836,268 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * Projects the committed document, threading the instance-bound holder callbacks.
+     * Measures one active workspace's host and tabs geometry. The result is window-local and
+     * runtime-only; it is invalidated by every projection refresh and never enters a document.
+     * @param {String} workspaceId
+     * @returns {Promise<Object|null>}
+     * @protected
+     */
+    async measureWorkspaceGeometry(workspaceId) {
+        let me       = this,
+            host     = me.crossWindowHosts.get(workspaceId),
+            document = me.getWorkspaceDocument(workspaceId),
+            nodes    = document?.nodes || {};
+
+        if (!host || host.isDestroyed) return null;
+
+        let zoneEntries = Object.keys(nodes)
+                .filter(nodeId => nodes[nodeId].type === 'tabs')
+                .map(nodeId => ({nodeId, container: host.down({dockNodeId: nodeId})}))
+                .filter(zone => zone.container),
+            rootId      = nodes[document.root]?.type === 'edge-zone'
+                ? (nodes[document.root].zones?.center ?? document.root)
+                : document.root,
+            [hostRect, ...zoneRects] = await host.getDomRect(
+                [host.id, ...zoneEntries.map(zone => zone.container.id)],
+                host.windowId
+            ),
+            geometry;
+
+        geometry = hostRect && {
+            hostRect,
+            root : {nodeId: rootId, rect: hostRect},
+            zones: zoneEntries
+                .map((zone, index) => ({
+                    nodeId: zone.nodeId,
+                    rect  : zone.nodeId === rootId
+                        && nodes[zone.nodeId].items?.length === 0
+                        && (!zoneRects[index]?.width || !zoneRects[index]?.height)
+                            ? hostRect
+                            : zoneRects[index],
+                    orientation: Object.values(nodes).find(node =>
+                        node.type === 'split' && node.children?.includes(zone.nodeId)
+                    )?.orientation ?? null
+                }))
+                .filter(zone => zone.rect)
+        };
+
+        if (!geometry
+            || geometry.hostRect.width < 1
+            || geometry.hostRect.height < 1
+            || geometry.zones.length < 1
+            || geometry.zones.some(zone => zone.rect.width < 1 || zone.rect.height < 1)) {
+            me.crossWindowGeometry.delete(workspaceId);
+            return null
+        }
+
+        me.crossWindowGeometry.set(workspaceId, geometry);
+
+        let indicators = host.down({ntype: 'dashboard-dock-drop-indicators'});
+
+        indicators && (indicators.hostRect = geometry.hostRect);
+
+        return geometry
+    }
+
+    /**
+     * Waits for main-thread paint evidence instead of assuming a worker update acknowledgement
+     * implies measurable geometry. Every retry is routed through the host's own render target;
+     * the bounded delay is cadence only, while non-zero host + zone rects are the readiness fact.
+     * @param {String} workspaceId
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=120]
+     * @param {Number} [options.delay=16]
+     * @returns {Promise<Object|null>}
+     * @protected
+     */
+    async waitForWorkspaceGeometry(workspaceId, {attempts=120, delay=16}={}) {
+        let me       = this,
+            geometry = await me.measureWorkspaceGeometry(workspaceId);
+
+        if (!geometry && attempts > 0 && !me.isDestroyed) {
+            await me.timeout(delay);
+            return me.waitForWorkspaceGeometry(workspaceId, {attempts: attempts - 1, delay})
+        }
+
+        return geometry
+    }
+
+    /**
+     * Converts a viewport-space rect into a dock host's local overlay coordinates.
+     * @param {Object} rect
+     * @param {Object} hostRect
+     * @returns {Object}
+     * @protected
+     */
+    localDockRect(rect, hostRect) {
+        return {x: rect.x - hostRect.x, y: rect.y - hostRect.y, width: rect.width, height: rect.height}
+    }
+
+    /**
+     * Clears transient preview state for one workspace.
+     * @param {String} workspaceId
+     * @protected
+     */
+    clearWorkspaceAffordances(workspaceId) {
+        let host = this.crossWindowHosts.get(workspaceId);
+
+        host?.down({ntype: 'dashboard-dock-drop-indicators'})?.clear();
+
+        let preview = host?.down({ntype: 'dock-preview'});
+
+        preview && (preview.dockPreview = null)
+    }
+
+    /**
+     * Synchronous remote-target hit test over pre-measured window-local tabs geometry.
+     * @param {String} workspaceId
+     * @param {Number} localX
+     * @param {Number} localY
+     * @returns {Boolean}
+     * @protected
+     */
+    hitTestWorkspace(workspaceId, localX, localY) {
+        return !!this.dockPreviewProducer.hitTestZone(
+            this.crossWindowGeometry.get(workspaceId)?.zones,
+            {x: localX, y: localY}
+        )
+    }
+
+    /**
+     * Computes and renders one preview through the same producer/indicator/converter pipeline
+     * used by an in-window drag. This method stays synchronous for coordinator callbacks.
+     * @param {String} workspaceId
+     * @param {Object} data
+     * @returns {Object|null}
+     * @protected
+     */
+    renderWorkspacePreview(workspaceId, data) {
+        let me                = this,
+            host              = me.crossWindowHosts.get(workspaceId),
+            geometry          = me.crossWindowGeometry.get(workspaceId),
+            draggedItem       = data.draggedItem,
+            itemId            = data.itemId ?? draggedItem?.dockItemId,
+            sourceWorkspaceId = draggedItem?.dockSourceWorkspaceId ?? workspaceId,
+            sourceNodeId      = data.sourceNodeId
+                ?? DockZoneModel.findContainingTabsId(me.getWorkspaceDocument(sourceWorkspaceId), itemId),
+            pointer    = {x: data.localX ?? data.clientX, y: data.localY ?? data.clientY};
+
+        if (!host || !geometry || !itemId || !Neo.isNumber(pointer.x) || !Neo.isNumber(pointer.y)) {
+            return null
+        }
+
+        let producer   = me.dockPreviewProducer,
+            indicators = host.down({ntype: 'dashboard-dock-drop-indicators'}),
+            renderer   = host.down({ntype: 'dock-preview'}),
+            zone       = producer.hitTestZone(geometry.zones, pointer);
+
+        if (indicators && (zone?.nodeId ?? null) !== (indicators.candidateSet?.zone?.nodeId ?? null)) {
+            indicators.candidateSet = zone
+                ? producer.produceCandidates({pointer, zones: geometry.zones, itemId, sourceNodeId, root: geometry.root})
+                : null
+        }
+
+        let candidate = indicators?.updatePointer(pointer) ?? null,
+            preview   = candidate?.preview
+                ?? producer.produce({pointer, zones: geometry.zones, itemId, sourceNodeId});
+
+        if (renderer) {
+            renderer.dockPreview = preview;
+
+            if (preview) {
+                let targetRect = preview.target.nodeId === geometry.root.nodeId
+                    ? geometry.root.rect
+                    : geometry.zones.find(entry => entry.nodeId === preview.target.nodeId)?.rect;
+
+                targetRect && renderer.applyTargetGeometry(me.localDockRect(targetRect, geometry.hostRect))
+            }
+        }
+
+        return preview
+    }
+
+    /**
+     * Local drag-move adapter for either active workspace.
+     * @param {String} workspaceId
+     * @param {Object} data
+     * @protected
+     */
+    async onDockCrossZoneDragMove(workspaceId, data) {
+        this.crossWindowGeometry.has(workspaceId) || await this.measureWorkspaceGeometry(workspaceId);
+        this.renderWorkspacePreview(workspaceId, data)
+    }
+
+    /**
+     * Local release path. A committed remote drop must suppress this callback entirely; the
+     * counter is the product witness for that one-shot source decision.
+     * @param {String} workspaceId
+     * @param {Object} data
+     * @returns {Object|null}
+     * @protected
+     */
+    onDockCrossZoneDrop(workspaceId, data) {
+        let me         = this,
+            preview    = me.renderWorkspacePreview(workspaceId, data),
+            descriptor = previewToOperation(preview),
+            result     = null;
+
+        me.crossWindowStats.localDropFires++;
+        me.clearWorkspaceAffordances(workspaceId);
+
+        if (descriptor) {
+            result = me.applyWorkspaceOperation(workspaceId, descriptor);
+
+            if (result && !result.errors?.length && result.document) {
+                me.onWorkspaceDocumentChange(workspaceId, result.document)
+            }
+        }
+
+        return result
+    }
+
+    /**
+     * Cancels every window-local affordance and resolves the cancellation readiness signal.
+     * @param {String} workspaceId
+     * @param {Object} data
+     * @protected
+     */
+    onDockCrossZoneDragCancel(workspaceId, data) {
+        this.crossWindowHosts.forEach((host, id) => this.clearWorkspaceAffordances(id));
+        this.crossWindowGestureResolve?.({
+            applied: false,
+            errors : ['cross-window gesture cancelled before commit'],
+            itemId : data?.itemId,
+            workspaceId
+        });
+        this.crossWindowGestureResolve = null
+    }
+
+    /**
+     * Projects one named committed document, threading the same holder and drag callbacks into
+     * both render targets. Cross-window participation is opt-in for the dedicated scene only.
      * @param {Function|null} [resolveComponentRef=null]
+     * @param {String} [workspaceId=DemoBWorkspace.MAIN_WORKSPACE_ID]
+     * @param {Object} [document]
      * @returns {Object}
      */
-    projectDockModel(resolveComponentRef=null) {
+    projectDockModel(
+        resolveComponentRef=null,
+        workspaceId=DemoBWorkspace.MAIN_WORKSPACE_ID,
+        document=this.getWorkspaceDocument(workspaceId)
+    ) {
         let me = this;
 
-        return DockLayoutAdapter.project(me.dockModel, {
-            applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
-            onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
-            resolveComponentRef     : resolveComponentRef
+        return DockLayoutAdapter.project(document, {
+            applyDockZoneOperation   : descriptor => me.applyWorkspaceOperation(workspaceId, descriptor),
+            crossWindowSortGroup     : me.crossWindowEnabled ? DemoBWorkspace.CROSS_WINDOW_SORT_GROUP : null,
+            onDockCrossZoneDragCancel: data => me.onDockCrossZoneDragCancel(workspaceId, data),
+            onDockCrossZoneDragMove  : data => me.onDockCrossZoneDragMove(workspaceId, data),
+            onDockCrossZoneDrop      : data => me.onDockCrossZoneDrop(workspaceId, data),
+            onDockZoneDocumentChange : nextDocument => me.onWorkspaceDocumentChange(workspaceId, nextDocument),
+            resolveComponentRef      : resolveComponentRef
                 || ((componentRef, item, itemId) => me.resolvePane(itemId, item)),
-            resolveRevealComponentRef  : (componentRef, item, itemId) => me.resolvePane(itemId, item)
+            resolveRevealComponentRef: (componentRef, item, itemId) => me.resolvePane(itemId, item),
+            workspaceId
         })
     }
 
@@ -690,7 +2145,10 @@ class DemoBWorkspace extends Container {
 
         if (!windowAlreadyClosed) {
             try {
-                await Neo.Main.windowClose({names: [`demo-b-${itemId}`], windowId: me.windowId})
+                await Neo.Main.windowClose({
+                    names   : [entry.windowName || `demo-b-${itemId}`],
+                    windowId: me.windowId
+                })
             } catch (error) {
                 return {errors: [`popup close failed: ${error?.message || error}`], reattached: true}
             }
@@ -700,19 +2158,34 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * Reconciles the toolbar-adjacent projection from the committed document, FLIP-bracketed.
+     * @summary Reconciles one workspace projection from its atomic document/preservation request.
+     *
      * The shared projection reconciler moves cached panes and tab chrome into the staged tree
      * before retiring the empty shell, so object permanence no longer depends on coarse parking.
+     * @param {String} workspaceId Worker-owned workspace id.
+     * @param {Object} [document=this.getWorkspaceDocument(workspaceId)] Document to project.
+     * @param {Object} [options={}] Projection policy.
+     * @param {Iterable<String>} [options.preserveItemIds=[]] Owner-held panes to park.
+     * @returns {Promise}
      * @protected
      */
-    async refreshDockWorkspace() {
+    async refreshWorkspace(
+        workspaceId,
+        document=this.getWorkspaceDocument(workspaceId),
+        {preserveItemIds=[]}={}
+    ) {
         const
             me           = this,
-            host         = me.getReference('dock-host-b'),
+            host         = me.crossWindowHosts.get(workspaceId),
             placeholders = new Map();
 
         if (host) {
-            const flip = Neo.main?.addon?.DockFlip;
+            const flip = workspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID
+                ? Neo.main?.addon?.DockFlip
+                : null;
+
+            me.crossWindowGeometry.delete(workspaceId);
+            me.clearWorkspaceAffordances(workspaceId);
 
             try {
                 await flip?.captureFirst({hostId: host.id, markerPrefix: 'agentos-dockdemo-pane-'})
@@ -728,14 +2201,17 @@ class DemoBWorkspace extends Container {
                 placeholders.set(itemId, placeholder);
 
                 return placeholder
-            });
+            }, workspaceId, document);
 
             await DockProjectionReconciler.reconcileProjection({
                 host,
                 nextConfig,
                 placeholders,
-                resolveItem: itemId => me.resolvePane(itemId, me.dockModel.items[itemId])
+                preserveItemIds,
+                resolveItem: itemId => me.resolvePane(itemId, document.items[itemId])
             });
+
+            me.crossWindowEnabled && await me.measureWorkspaceGeometry(workspaceId);
 
             if (flip) {
                 DockMotionSignal.enter(me);
@@ -744,6 +2220,24 @@ class DemoBWorkspace extends Container {
                     .finally(() => DockMotionSignal.leave(me))
             }
         }
+    }
+
+    /**
+     * Backward-compatible primary-workspace refresh seam used by the perspective tests and tour.
+     * @returns {Promise}
+     * @protected
+     */
+    refreshDockWorkspace() {
+        return this.refreshWorkspace(DemoBWorkspace.MAIN_WORKSPACE_ID, this.dockModel)
+    }
+
+    /**
+     * @summary Resolves only after every currently queued projection has committed or failed.
+     * Whitebox journeys use this worker-owned boundary instead of guessing from runner timing.
+     * @returns {Promise}
+     */
+    awaitProjectionIdle() {
+        return this.refreshPromise
     }
 
     /**
@@ -806,8 +2300,10 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * Plays the screenplay from the top; reruns reset the stage and re-capture cleanly
-     * (perspective saves use `replace: true`).
+     * @summary Plays the screenplay from the top. A rerun first drains the prior projection
+     * transaction, then serializes the opening-stage reset through the same refresh queue as
+     * every tour mutation; reset and replay can therefore never reconcile the tab chrome at
+     * the same time. Perspective saves remain idempotent through `replace: true`.
      */
     async startTour() {
         let me = this;
@@ -818,9 +2314,13 @@ class DemoBWorkspace extends Container {
         }
 
         if (me.tourRunner.log.length) {
-            me.dockModel     = DockZoneModel.clone(initialDocument);
+            await me.refreshPromise;
+
             me.popupDocument = DemoBWorkspace.createPopupDocument();
-            me.refreshDockWorkspace()
+            await me.onWorkspaceDocumentChange(
+                DemoBWorkspace.MAIN_WORKSPACE_ID,
+                DockZoneModel.clone(initialDocument)
+            )
         }
 
         me.beatCount = 0;
@@ -896,8 +2396,27 @@ class DemoBWorkspace extends Container {
     destroy(...args) {
         let me = this;
 
+        me.crossWindowStageGeneration++;
+        me.crossWindowGestureContext?.sourceZone?.dragCoordinator?.onDragCancel({
+            sourceSortZone: me.crossWindowGestureContext.sourceZone
+        });
+        me.crossWindowGestureResolve?.({applied: false, errors: ['Demo-B workspace destroyed']});
+        me.crossWindowStageReject?.(new Error('Demo-B workspace destroyed'));
+        me.crossWindowParticipations.forEach(participation => participation.destroy());
+        me.crossWindowParticipations.clear();
+        me.crossWindowHosts.clear();
+        me.crossWindowGeometry.clear();
+        me.workspaceProjectionRequests.clear();
+        me.crossWindowStagePromise   = null;
+        me.crossWindowStageResolve   = null;
+        me.crossWindowStageReject    = null;
+        me.crossWindowGestureResolve = null;
+        me.crossWindowGestureContext = null;
+
         me.tourRunner?.destroy();
         me.dockService?.destroy();
+        me.dockPreviewProducer?.destroy();
+        me.interactionService?.destroy();
         me.perspectiveStore?.destroy();
 
         Object.values(me.paneCache).forEach(pane => {

--- a/apps/agentos/childapps/dockdemo/view/Viewport.mjs
+++ b/apps/agentos/childapps/dockdemo/view/Viewport.mjs
@@ -13,6 +13,8 @@ import DemoBWorkspace from './DemoBWorkspace.mjs';
  * - `?popout=<id>` → an EMPTY pop-out host: this window carries no workspace of its own;
  *   the opener's workspace reparents the live pane into this viewport on connect (the
  *   shared-heap contract — one App Worker, two render targets).
+ * - `?workspaceId=demo-b-popup` → an EMPTY second render target which the opener fills with
+ *   an active popup workspace projection for the cross-window drag scene.
  *
  * @class AgentOS.childapps.dockdemo.view.Viewport
  * @extends Neo.container.Viewport
@@ -47,7 +49,7 @@ class Viewport extends BaseViewport {
 
         if (me.isDestroyed) return;
 
-        if (params.get('popout')) {
+        if (params.get('popout') || params.get('workspaceId')) {
             me.addCls('agentos-dockdemo-popout-host');
             return
         }

--- a/apps/agentos/tour/demoBPerspectives.mjs
+++ b/apps/agentos/tour/demoBPerspectives.mjs
@@ -14,10 +14,10 @@
  *    world through the real reconciler. Its no-live-window remainder is rendered, and no
  *    popup is auto-spawned.
  *
- * Store/pop-out beats ride surface CUES (the Demo-A reveal-cue pattern): perspectives are
- * store operations and window moves are vessel operations — neither is a dock-zone document
- * op, so they must not masquerade as descriptors. Document-shaped beats stay `op` steps with
- * expects; the runner's replay determinism covers both alike.
+ * Perspective saves/loads and reattach ride surface CUES (the Demo-A reveal-cue pattern).
+ * The actual two-window move is different: one semantic `cross-window` runner step awaits the
+ * host-owned real pointer gesture and its structured continuity receipt. Document mutations
+ * stay `op` steps with expects; every executable step remains deterministic in the replay log.
  */
 
 /**
@@ -41,8 +41,8 @@ export const initialDocument = Object.freeze({
 });
 
 /**
- * The Demo-B tour script. Perspective and window beats are cues; document mutations are op
- * steps with expects. Pauses are viewer pacing only.
+ * The Demo-B tour script. Perspective/reattach beats are cues; the cross-window move and
+ * document mutations are executable steps. Pauses are viewer pacing only.
  * @type {Object}
  */
 export const demoBTourScript = Object.freeze({
@@ -118,7 +118,14 @@ export const demoBTourScript = Object.freeze({
         steps  : [
             {type: 'pause', ms: 900, cue: {type: 'perspective-load', name: 'Review'}, caption: 'back to "Review" — room to leave from'},
             {type: 'pause', ms: 900},
-            {type: 'pause', ms: 900, cue: {type: 'popout', itemId: 'workbench'}, caption: 'pop-out(workbench): a real OS window opens on the shared heap. Watch the counter — it does not reset.'},
+            {
+                type             : 'cross-window',
+                itemId           : 'workbench',
+                sourceWorkspaceId: 'demo-b-main',
+                targetWorkspaceId: 'demo-b-popup',
+                targetNodeId     : 'popup-tabs',
+                caption          : 'drag(workbench → popup): one real pointer gesture crosses two active OS windows. The worker instance and counter never reset.'
+            },
             {type: 'pause', ms: 2000},
             {type: 'pause', ms: 600, cue: {type: 'perspective-save', name: 'Detached', scope: 'topology'}, caption: 'save("Detached"): topology capture records BOTH worker-owned workspace documents — main plus popup'},
             {type: 'pause', ms: 900, cue: {type: 'reattach', itemId: 'workbench'}, caption: 'reattach(workbench): home again. Same instance, same count — reparent, never recreate.'},

--- a/src/ai/client/TourRunner.mjs
+++ b/src/ai/client/TourRunner.mjs
@@ -2,20 +2,86 @@ import Base                                       from '../../core/Base.mjs';
 import {evaluateExpectations, validateTourScript} from './tourScript.mjs';
 
 /**
+ * @summary True only for plain JSON-object-shaped values.
+ * @param {*} value
+ * @returns {Boolean}
+ */
+function isPlainObject(value) {
+    if (value === null || typeof value !== 'object') return false;
+
+    const proto = Object.getPrototypeOf(value);
+
+    return proto === Object.prototype || proto === null
+}
+
+/**
+ * @summary Validates the settlement receipt returned by an injected cross-window host.
+ * Rejected steps may omit document/witness data; successful steps must prove both document
+ * outcomes plus the surviving component identity and target-document mount lifecycle.
+ * @param {*} result
+ * @returns {String[]} validation errors
+ */
+function validateCrossWindowResult(result) {
+    const errors = [];
+
+    if (!isPlainObject(result)) {
+        return ['cross-window executor returned a non-object receipt']
+    }
+
+    if (typeof result.applied !== 'boolean') {
+        errors.push('cross-window receipt.applied must be a Boolean')
+    }
+
+    if (!Array.isArray(result.errors) || result.errors.some(error => typeof error !== 'string')) {
+        errors.push('cross-window receipt.errors must be an array of strings')
+    }
+
+    if (result.applied === true) {
+        if (result.errors?.length) {
+            errors.push('cross-window receipt cannot be applied with non-empty errors')
+        }
+
+        if (!isPlainObject(result.sourceDocument)) {
+            errors.push('cross-window applied receipt requires a plain sourceDocument')
+        }
+
+        if (!isPlainObject(result.targetDocument)) {
+            errors.push('cross-window applied receipt requires a plain targetDocument')
+        }
+
+        if (!isPlainObject(result.witness)) {
+            errors.push('cross-window applied receipt requires witness {instanceId, mountCount}')
+        } else {
+            if (typeof result.witness.instanceId !== 'string' || result.witness.instanceId.length < 1) {
+                errors.push('cross-window witness.instanceId must be a non-empty string')
+            }
+
+            if (!Number.isInteger(result.witness.mountCount) || result.witness.mountCount < 0) {
+                errors.push('cross-window witness.mountCount must be a non-negative integer')
+            }
+        }
+    } else if (result.applied === false && result.errors?.length < 1) {
+        errors.push('cross-window rejected receipt requires at least one error')
+    }
+
+    return errors
+}
+
+/**
  * @summary Executes `neo.tour.script.v1` scripts against a live dock workspace with
  * deterministic operation ordering — the player behind demo tours, e2e replays and video takes.
  *
  * The runner is the "trinity enabler": ONE reviewed script is the demo a viewer watches, the
  * e2e scenario the replay specs execute, and the video take a recording captures.
- * It composes the app-side Neural Link dock seam ({@link Neo.ai.client.DockService}) and
- * NEVER touches the dock model directly — the same commit path an agent drives through
- * `execute_dock_operation` is the only mutation path, so a tour and a live agent are
- * indistinguishable at the document layer.
+ * It composes the app-side Neural Link dock seam ({@link Neo.ai.client.DockService}) plus an
+ * optional host-owned cross-window executor and NEVER mutates dock truth directly. Ordinary
+ * operations ride the same `execute_dock_operation` path as a live agent; cross-window steps
+ * await one real gesture and accept only its structured document + continuity receipt.
  *
- * **Determinism contract:** steps settle on the executor's returned post-operation document
- * (or explicit `topology-assert` reads) — never on wall-clock time. `pause` steps are viewer
- * PACING only: modes may scale or skip the waiting, but every step always appends the same
- * log entry, so two runs of one script — in any mode — produce identical operation logs.
+ * **Determinism contract:** steps settle on an executor-owned result (post-operation document,
+ * structured cross-window receipt, or explicit `topology-assert` read) — never on wall-clock
+ * time. `pause` steps are viewer PACING only: modes may scale or skip the waiting, but every
+ * step always appends the same log entry, so two runs in any mode produce identical logs.
  * The log records order, descriptors and assertion outcomes; deliberately no timestamps.
  *
  * **Modes** (pace differs, correctness never):
@@ -66,6 +132,13 @@ class TourRunner extends Base {
          * @member {String|null} componentId=null
          */
         componentId: null,
+        /**
+         * Optional app-side executor for semantic `cross-window` steps. The runner never
+         * resolves window ids, DOM ids or coordinates; a compatible host exposes exactly
+         * `executeCrossWindowStep(step)` and returns the structured settlement receipt.
+         * @member {Object|null} crossWindowExecutor=null
+         */
+        crossWindowExecutor: null,
         /**
          * The app-side dock seam instance ({@link Neo.ai.client.DockService} or a
          * spec fixture exposing the same `executeDockOperation` / `getDockTopology`
@@ -171,9 +244,10 @@ class TourRunner extends Base {
      */
     #preflight() {
         const
-            me            = this,
-            {dockService} = me,
-            errors        = [];
+            me                                 = this,
+            {crossWindowExecutor, dockService} = me,
+            crossWindowAvailable               = typeof crossWindowExecutor?.executeCrossWindowStep === 'function',
+            errors                             = [];
 
         if (typeof dockService?.executeDockOperation !== 'function' || typeof dockService?.getDockTopology !== 'function') {
             errors.push('dockService: required — inject Neo.ai.client.DockService (or a fixture exposing executeDockOperation + getDockTopology)')
@@ -193,7 +267,10 @@ class TourRunner extends Base {
         const operations = me.operations || dockService?.constructor?.operations || [];
 
         if (errors.length === 0) {
-            const {valid, errors: scriptErrors} = validateTourScript(me.script, {operations});
+            const {valid, errors: scriptErrors} = validateTourScript(me.script, {
+                crossWindowAvailable,
+                operations
+            });
 
             if (!valid) {
                 errors.push(...scriptErrors)
@@ -238,13 +315,15 @@ class TourRunner extends Base {
         me.#running = true;
         me.log      = [];
 
+        const log = me.log;
+
         try {
             return await me.#run()
         } catch (e) {
             if (e === Neo.isDestroyed) {
                 // destroy() rejected a pending pause via the registered-async contract —
                 // the tour ends quietly with an honest partial log
-                return {completed: false, errors: ['TourRunner destroyed mid-tour'], log: me.log}
+                return {completed: false, errors: ['TourRunner destroyed mid-tour'], log}
             }
 
             throw e
@@ -261,9 +340,9 @@ class TourRunner extends Base {
      */
     async #run() {
         const
-            me                         = this,
-            {componentId, dockService} = me,
-            {scenes}                   = me.script;
+            me                                              = this,
+            {componentId, crossWindowExecutor, dockService} = me,
+            {scenes}                                        = me.script;
 
         let sceneIndex = 0;
 
@@ -332,6 +411,49 @@ class TourRunner extends Base {
                                 `expected ${JSON.stringify(failure.expected)}, got ${JSON.stringify(failure.actual)}`
                             ))
                         }
+                    }
+                }
+
+                else if (step.type === 'cross-window') {
+                    const
+                        executorStep = JSON.parse(JSON.stringify(step)),
+                        semanticStep = {
+                            itemId           : step.itemId,
+                            sourceWorkspaceId: step.sourceWorkspaceId,
+                            targetWorkspaceId: step.targetWorkspaceId,
+                            targetNodeId     : step.targetNodeId
+                        };
+                    let result;
+
+                    try {
+                        result = await me.trap(crossWindowExecutor.executeCrossWindowStep(executorStep))
+                    } catch (e) {
+                        if (e === Neo.isDestroyed) throw e;
+
+                        return me.#abort([
+                            `${sceneId}[${stepIndex}] cross-window executor failure: ${e?.message || String(e)}`
+                        ])
+                    }
+
+                    const receiptErrors = validateCrossWindowResult(result);
+
+                    if (receiptErrors.length > 0) {
+                        return me.#abort(receiptErrors.map(error => `${sceneId}[${stepIndex}] ${error}`))
+                    }
+
+                    me.log.push({
+                        applied: result.applied,
+                        errors : [...result.errors],
+                        sceneId,
+                        step   : semanticStep,
+                        stepIndex,
+                        type   : 'cross-window'
+                    });
+
+                    if (!result.applied) {
+                        return me.#abort([
+                            `${sceneId}[${stepIndex}] cross-window step rejected by the executor: ${result.errors.join('; ')}`
+                        ])
                     }
                 }
 

--- a/src/ai/client/tourScript.mjs
+++ b/src/ai/client/tourScript.mjs
@@ -63,16 +63,26 @@ export const TOUR_SCRIPT_SCHEMA = 'neo.tour.script.v1';
  * vocabulary enumerated (fail-closed contract, mirroring the dock-operation executor).
  * @type {ReadonlyArray<String>}
  */
-export const STEP_TYPES = Object.freeze(['op', 'pause', 'topology-assert']);
+export const STEP_TYPES = Object.freeze(['op', 'pause', 'topology-assert', 'cross-window']);
 
 /**
- * Step types the schema RESERVES for the perspective / cross-window tool tiers that have not
- * shipped as runner-executable steps yet. Reserved types validate as known —
+ * Step types the schema RESERVES for future tool tiers that have not shipped as
+ * runner-executable steps yet. Reserved types validate as known —
  * the error message says "reserved, not yet available" instead of "unknown" — but still
  * fail closed: a v1 runner must never silently skip a step it cannot execute.
  * @type {ReadonlyArray<String>}
  */
-export const RESERVED_STEP_TYPES = Object.freeze(['cross-window', 'perspective']);
+export const RESERVED_STEP_TYPES = Object.freeze(['perspective']);
+
+/**
+ * The exact data vocabulary of a cross-window step. Keeping this allowlist beside the
+ * schema validator mechanically prevents runtime window / DOM ids, coordinates, geometry,
+ * functions or live references from leaking into the reviewed screenplay.
+ * @type {ReadonlyArray<String>}
+ */
+export const CROSS_WINDOW_STEP_KEYS = Object.freeze([
+    'type', 'caption', 'itemId', 'sourceWorkspaceId', 'targetWorkspaceId', 'targetNodeId'
+]);
 
 /**
  * Default tolerance for number-to-number comparisons: IEEE floating-point noise scale, not a
@@ -330,6 +340,36 @@ function validateExpect(expect, path, errors, required = false) {
 }
 
 /**
+ * Validates one host-executed cross-window step. The script owns semantic identities only;
+ * the injected host resolves current windows, components, coordinates and geometry at run time.
+ * @param {Object}   step
+ * @param {String}   path
+ * @param {String[]} errors
+ */
+function validateCrossWindowStep(step, path, errors) {
+    const allowedKeys = new Set(CROSS_WINDOW_STEP_KEYS);
+
+    Object.keys(step).forEach(key => {
+        if (!allowedKeys.has(key)) {
+            errors.push(
+                `${path}.${key}: cross-window steps accept semantic ids only; ` +
+                `the allowed keys are: ${CROSS_WINDOW_STEP_KEYS.join(', ')}`
+            )
+        }
+    });
+
+    ['itemId', 'sourceWorkspaceId', 'targetWorkspaceId', 'targetNodeId'].forEach(key => {
+        if (typeof step[key] !== 'string' || step[key].length < 1) {
+            errors.push(`${path}.${key}: required non-empty semantic id string`)
+        }
+    });
+
+    if (step.sourceWorkspaceId === step.targetWorkspaceId) {
+        errors.push(`${path}: sourceWorkspaceId and targetWorkspaceId must identify different workspaces`)
+    }
+}
+
+/**
  * Fail-closed structural validation of a tour script against the v1 schema and a concrete
  * operation vocabulary (pass `DockService.operations` — the executor's exported SSOT — or a
  * fixture vocabulary in unit specs). A `{valid: true}` script is guaranteed: JSON-pure,
@@ -338,9 +378,10 @@ function validateExpect(expect, path, errors, required = false) {
  * @param {Object} script
  * @param {Object} options
  * @param {String[]} options.operations The executable dock-operation vocabulary (required for op steps)
+ * @param {Boolean}  options.crossWindowAvailable True only when a compatible host executor is injected
  * @returns {Object} `{valid, errors}` — errors are human-readable strings with script paths
  */
-export function validateTourScript(script, {operations = []} = {}) {
+export function validateTourScript(script, {crossWindowAvailable = false, operations = []} = {}) {
     const errors = [];
 
     if (!isPlainObject(script)) {
@@ -394,14 +435,22 @@ export function validateTourScript(script, {operations = []} = {}) {
 
             if (RESERVED_STEP_TYPES.includes(step.type)) {
                 errors.push(
-                    `${stepPath}.type: '${step.type}' is reserved for the perspective / cross-window ` +
-                    'tool tier and not yet available — v1 fails closed instead of skipping it'
+                    `${stepPath}.type: '${step.type}' is reserved for a future tool tier and not yet available — ` +
+                    'v1 fails closed instead of skipping it'
                 );
                 return
             }
 
             if (!STEP_TYPES.includes(step.type)) {
                 errors.push(`${stepPath}.type: unknown '${step.type}'. The v1 vocabulary is: ${STEP_TYPES.join(', ')}`);
+                return
+            }
+
+            if (step.type === 'cross-window' && !crossWindowAvailable) {
+                errors.push(
+                    `${stepPath}.type: 'cross-window' remains reserved unless a compatible ` +
+                    'crossWindowExecutor is injected — v1 fails closed instead of skipping it'
+                );
                 return
             }
 
@@ -428,6 +477,10 @@ export function validateTourScript(script, {operations = []} = {}) {
                 if (typeof step.ms !== 'number' || !Number.isFinite(step.ms) || step.ms < 0) {
                     errors.push(`${stepPath}.ms: required finite number >= 0 (viewer pacing in milliseconds)`)
                 }
+            }
+
+            if (step.type === 'cross-window') {
+                validateCrossWindowStep(step, stepPath, errors)
             }
 
             if (step.type === 'topology-assert') {

--- a/src/dashboard/DockProjectionReconciler.mjs
+++ b/src/dashboard/DockProjectionReconciler.mjs
@@ -1,5 +1,6 @@
 import Component from '../component/Base.mjs';
 import Base      from '../core/Base.mjs';
+import NeoArray  from '../util/Array.mjs';
 
 /**
  * @summary Preserves live tab-chrome identity across dock-layout projections.
@@ -122,6 +123,8 @@ class DockProjectionReconciler extends Base {
      * @param {Neo.container.Base} options.host Dock host containing the current shell.
      * @param {*} options.nextConfig Fresh {@link Neo.dashboard.DockLayoutAdapter} projection.
      * @param {Map<String,Neo.component.Base>} options.placeholders Item placeholders created by the caller.
+     * @param {Iterable<String>} [options.preserveItemIds=[]] Owner-held panes which are absent
+     * from this projection but must survive without their obsolete tab buttons.
      * @param {Function} options.resolveItem Resolves one live pane or materializable config by dock item id.
      * @param {Function|null} [options.onProjectionStaged=null]
      * @param {Number} [options.shellIndex=0]
@@ -133,6 +136,7 @@ class DockProjectionReconciler extends Base {
         host,
         nextConfig,
         placeholders,
+        preserveItemIds=[],
         resolveItem,
         onProjectionStaged=null,
         shellIndex=0,
@@ -176,7 +180,30 @@ class DockProjectionReconciler extends Base {
         host.update();
         await host.promiseUpdate();
 
-        this.reconcileTabChrome(plans, placeholders, currentTabs, nextShell, resolveItem);
+        const materializedBars = new Set();
+
+        this.reconcileTabChrome(
+            plans,
+            placeholders,
+            currentTabs,
+            nextShell,
+            resolveItem,
+            preserveItemIds,
+            materializedBars
+        );
+
+        // Existing pane/button pairs move through the host's common-ancestor transaction below.
+        // A parked pane has no surviving button DOM to move, so its newly materialized pair needs
+        // one explicit toolbar commit while the destination shell is still staged/hidden. This is
+        // the same owner a normal non-silent toolbar insert updates; committing its parent tab can
+        // leave the toolbar's VDOM change invisible to the main-thread delta boundary. Silent
+        // insertion also bypasses the SortZone's insert listener, so restore its delegated marker
+        // before that one owner commit.
+        await Promise.all([...materializedBars].map(bar => {
+            bar.sortZone?.adjustItemCls(true);
+            bar.updateDepth = -1;
+            return bar.promiseUpdate()
+        }));
 
         // A removed logical tab can be the source of a returning pane. Hide that now-empty source in
         // the descendant commit; the ancestor/cleanup phases destroy it with its retiring shell once.
@@ -293,15 +320,27 @@ class DockProjectionReconciler extends Base {
      * @param {Map<String,Neo.tab.Container>} currentTabs
      * @param {Neo.container.Base} nextShell
      * @param {Function} resolveItem Resolves one live pane or materializable config by dock item id.
+     * @param {Iterable<String>} [preserveItemIds=[]] Owner-held panes to park instead of destroy.
+     * @param {Set<Neo.tab.header.Toolbar>} [materializedBars=new Set()] Output set for toolbars which
+     * created a fresh pane/button pair and therefore require one awaited direct-owner commit.
      * @returns {Map<String,Object>}
      * @static
      */
-    static reconcileTabChrome(plans, placeholders, currentTabs, nextShell, resolveItem) {
+    static reconcileTabChrome(
+        plans,
+        placeholders,
+        currentTabs,
+        nextShell,
+        resolveItem,
+        preserveItemIds=[],
+        materializedBars=new Set()
+    ) {
         const
             nextTabs       = this.collectProjectedTabs(nextShell),
             allTabs        = new Set([...currentTabs.values(), ...nextTabs.values()]),
             desiredItemIds = new Set([...plans.values()].flatMap(plan => plan.desiredItems)),
             liveItems      = new Map(),
+            preservedItems = new Set(preserveItemIds),
             resolvedItems  = new Map();
 
         if (typeof resolveItem !== 'function') {
@@ -367,6 +406,7 @@ class DockProjectionReconciler extends Base {
                 const
                     pane        = resolve(itemId),
                     placeholder = placeholders.get(itemId);
+                let stagedButton = null;
 
                 if (!pane) {
                     throw new Error(`Dock projection could not resolve live item "${itemId}"`)
@@ -379,16 +419,46 @@ class DockProjectionReconciler extends Base {
                         throw new Error(`Dock projection placed item "${itemId}" into the wrong tab body`)
                     }
 
+                    stagedButton = targetBar.items[placeholderIndex];
+
+                    if (!stagedButton) {
+                        throw new Error(`Dock projection could not stage tab chrome for item "${itemId}"`)
+                    }
+
                     targetBody.removeAt(placeholderIndex, true, true);
-                    targetBar.removeAt(placeholderIndex, true, true);
                     placeholders.delete(itemId)
                 }
 
                 const state = findItemState(pane);
 
                 if (!state) {
-                    resolvedItems.set(itemId, targetTab.insert(targetIndex, pane, true));
+                    const
+                        inserted     = targetBody.insert(targetIndex, pane, true),
+                        buttonConfig = targetTab.getTabButtonConfig(inserted.header, targetIndex);
+
+                    // The projected placeholder body/button are one disposable pair. Reusing only
+                    // its already-mounted button leaves that DOM lifecycle coupled to the destroyed
+                    // placeholder pane. Materialize the live pair together, then commit its toolbar
+                    // explicitly through the direct-owner transaction above. Silent insertion skips
+                    // SortZone#onItemInsert and the configured SortZone can still be awaiting its
+                    // construction microtask, so stamp the delegated drag marker into the button's
+                    // creation transaction instead of depending on a later timing-sensitive repair.
+                    if (stagedButton) {
+                        targetBar.remove(stagedButton, true, true)
+                    }
+
+                    NeoArray.add(buttonConfig.wrapperCls ||= [], 'neo-draggable');
+                    targetBar.insert(targetIndex, buttonConfig, true);
+                    materializedBars.add(targetBar);
+
+                    resolvedItems.set(itemId, inserted);
                     return
+                }
+
+                // A live source pair will move into this slot. Retire only the staged target
+                // button; its body placeholder was already removed above.
+                if (stagedButton) {
+                    targetBar.remove(stagedButton, true, true)
                 }
 
                 if (state.tab === targetTab && state.index === targetIndex) return;
@@ -400,11 +470,12 @@ class DockProjectionReconciler extends Base {
             })
         });
 
-        // Items absent from every projected tabs node are true retirements, not moves. Resolve
-        // their post-transfer positions from pane identity (the source sort arrays are intentionally
-        // not rewritten until the final exact-state pass), then remove each body/button pair in
-        // descending index order so sibling positions stay valid. Items desired anywhere in the
-        // next projection are excluded: their existing pane/button pair already moved above.
+        // Items absent from every projected tabs node are either true retirements or panes whose
+        // owner explicitly preserves them outside the current render topology. Resolve their
+        // post-transfer positions from pane identity while the body/button/item-id triple is still
+        // exact, then remove each pair in descending index order so sibling positions stay valid.
+        // Preserved panes lose only their obsolete button; ordinary retirements destroy both.
+        // Items desired anywhere in the next projection are excluded because their pair moved above.
         const retirementsByBody = new Map();
 
         [...liveItems]
@@ -424,7 +495,7 @@ class DockProjectionReconciler extends Base {
                     throw new Error(`Dock projection could not retire item "${itemId}" without its tab button`)
                 }
 
-                state.body.removeAt(state.index, true, true);
+                state.body.removeAt(state.index, !preservedItems.has(itemId), true);
                 state.bar.removeAt(state.index, true, true)
             })
         });
@@ -450,7 +521,7 @@ class DockProjectionReconciler extends Base {
             tab._activeIndex         = activeIndex;
             body.layout._activeIndex = activeIndex;
             bar.setSilent({sortZoneConfig: sortConfig});
-            bar.sortZone?.setSilent?.({
+            bar.sortZone?.set({
                 dockItemIds     : [...plan.desiredItems],
                 dockSourceNodeId: sortConfig.dockSourceNodeId,
                 dockWorkspaceId : sortConfig.dockWorkspaceId,

--- a/src/tab/plugin/Overflow.mjs
+++ b/src/tab/plugin/Overflow.mjs
@@ -273,9 +273,14 @@ class Overflow extends Plugin {
                 // natural geometry. Any resize raised by that update queues behind the latch and drains as
                 // an extent-only pass after this authoritative capture.
                 if (removedButtons.length > 0) {
-                    removedButtons.forEach(button => button.setSilent({hidden: false}));
+                    removedButtons.forEach(button => {
+                        button.setSilent({hidden: false});
+                        // setSilent intentionally bypasses Component#show(). Keep the config and VDOM
+                        // surfaces atomic or a later `button.hidden = false` becomes a no-op while the
+                        // stale removeDom marker keeps the supposedly visible header physically absent.
+                        delete button.vdom.removeDom
+                    });
                     owner.updateDepth = -1;
-                    owner.update();
                     await owner.promiseUpdate()
                 }
 
@@ -355,7 +360,14 @@ class Overflow extends Plugin {
             // Neo's built-in `hidden` (removeDom) rather than a cls needing an external stylesheet rule —
             // the natural-width cache (captured while every button was visible) survives the DOM removal,
             // so a later widen re-measures nothing and simply flips `hidden` back.
-            button.hidden = isHidden;
+            if (isHidden) {
+                button.hidden = true
+            } else if (button.hidden || button.vdom?.removeDom) {
+                // Repair both surfaces. A prior silent batch can already report hidden=false while
+                // removeDom still exists; assigning false again is then a reactive no-op, whereas
+                // show() clears the marker and schedules the toolbar update which remounts the header.
+                button.show()
+            }
 
             if (isHidden) {
                 hiddenMeta.push({iconCls: button.iconCls, index, text: button.text})

--- a/test/playwright/e2e/agentos/DemoBCrossWindowDragNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBCrossWindowDragNL.spec.mjs
@@ -1,0 +1,371 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Headless-Chrome physical-window adapter. Product browsers honor the app-owned
+ * placement request; headless Chrome ignores it, so CDP moves only the real top-level vessel.
+ * Dock semantics, pointer events, previews and commits remain entirely Neo-owned.
+ * @param {import('@playwright/test').Page} page
+ * @param {import('@playwright/test').Page} popup
+ */
+async function placePopupOutsideSource(page, popup) {
+    const popupCdp    = await page.context().newCDPSession(popup),
+          popupWindow = await popupCdp.send('Browser.getWindowForTarget'),
+          sourceStage = await page.evaluate(() => ({
+              left : globalThis.screenX,
+              top  : globalThis.screenY,
+              width: globalThis.innerWidth
+          }));
+
+    await popupCdp.send('Browser.setWindowBounds', {
+        bounds: {
+            height     : popupWindow.bounds.height,
+            left       : sourceStage.left + sourceStage.width + 40,
+            top        : sourceStage.top,
+            width      : popupWindow.bounds.width,
+            windowState: 'normal'
+        },
+        windowId: popupWindow.windowId
+    })
+}
+
+/**
+ * @summary Whitebox Phase-0 gate for Demo B's real two-window dock gesture.
+ *
+ * Neural Link invokes the app's semantic executor, but the executor itself resolves the live tab
+ * header and both render-target geometries immediately before dispatching a readiness-gated
+ * mousedown -> threshold moves -> remote screen moves -> mouseup sequence through the existing
+ * InteractionService. Before release, the receipt captures the live coordinator, semantic
+ * preview, rendered preview, and indicator selection. The post-state then proves the real path,
+ * not an equivalent reducer call: target transfer once, source remote-drop-out once, source local
+ * drop zero times, both worker-owned documents changed, and the same CounterPane instance mounted
+ * into the second browser document without resetting its heartbeat.
+ *
+ * Run: NEO_E2E_PORT=8120 npx playwright test agentos/DemoBCrossWindowDragNL \
+ *   -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('AgentOS Demo B — real cross-window dock drag', () => {
+    test.setTimeout(120000);
+    // Both physical viewports must fit side-by-side on the CI screen because global screen-space
+    // hit-testing deliberately resolves the first intersecting window. The app itself remains
+    // container-responsive; this is stage geometry, not a fixed product layout assumption.
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 720, width: 760}
+    });
+
+    test('the cold gesture transfers Workbench once and preserves its live worker instance', async ({page, neuralLink}) => {
+        const pageErrors    = [],
+              popupErrors   = [],
+              runtimeErrors = [];
+
+        await page.context().exposeFunction('__recordDemoBCrossWindowError', payload => runtimeErrors.push(payload));
+        await page.context().addInitScript(() => {
+            globalThis.addEventListener('error', event => {
+                globalThis.__recordDemoBCrossWindowError({
+                    column : event.colno,
+                    line   : event.lineno,
+                    message: event.message,
+                    source : event.filename,
+                    type   : 'error'
+                })
+            });
+            globalThis.addEventListener('unhandledrejection', event => {
+                globalThis.__recordDemoBCrossWindowError({
+                    reason: String(event.reason?.stack || event.reason?.message || event.reason),
+                    type  : 'unhandledrejection'
+                })
+            })
+        });
+
+        page.on('pageerror', error => {
+            let value = String(error?.stack || error?.message || error || '');
+
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
+        await page.waitForSelector('.agentos-dockdemo-counter-pane', {timeout: 30000});
+
+        const app        = await neuralLink.connectToApp('AgentOSDockDemo'),
+              workspaces = await app.findInstances(
+                  {className: 'AgentOS.childapps.dockdemo.view.DemoBWorkspace'},
+                  ['id']
+              ),
+              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+
+        expect(wsId, 'the App Worker must own one DemoBWorkspace').toBeTruthy();
+
+        const readCounter = async () => {
+            const counters = await app.findInstances(
+                {className: 'AgentOS.childapps.dockdemo.view.CounterPane'},
+                ['frames', 'id', 'mounted', 'mountCount', 'windowId']
+            );
+
+            return Array.isArray(counters) ? counters[0] : counters
+        };
+
+        await expect.poll(async () => (await readCounter())?.properties?.mountCount, {
+            message  : 'the real source-document mount must be observable before the gesture',
+            timeout  : 10000,
+            intervals: [100]
+        }).toBe(1);
+
+        const baseline = await readCounter(),
+              before   = await app.getComponent(wsId, ['dockModel', 'popupDocument']);
+
+        expect(before.dockModel.nodes['workbench-tabs'].items).toEqual(['workbench']);
+        expect(before.popupDocument.nodes['popup-tabs'].items).toEqual([]);
+
+        await app.getDragTrace(true);
+
+        const popupPromise  = page.waitForEvent('popup', {timeout: 30000}),
+              resultPromise = app.callMethod(wsId, 'executeCrossWindowStep', [{
+                  itemId           : 'workbench',
+                  sourceWorkspaceId: 'demo-b-main',
+                  targetNodeId     : 'popup-tabs',
+                  targetWorkspaceId: 'demo-b-popup'
+              }]),
+              popup = await popupPromise;
+
+        // Chrome's headless window manager ignores `window.open(left=...)` and `window.moveTo`,
+        // even though headed/product browsers honor the app-owned placement path. Move the REAL
+        // popup target through CDP so Neo's screen-space Window manager observes two physical,
+        // non-overlapping rectangles; no dock semantics or gesture events ride this adapter.
+        await placePopupOutsideSource(page, popup);
+
+        popup.on('pageerror', error => {
+            let value = String(error?.stack || error?.message || error || '');
+
+            value && value !== 'undefined' && popupErrors.push(value)
+        });
+
+        const result         = await resultPromise,
+              phaseZeroTrace = await app.getDragTrace();
+
+        expect(result.errors, 'the real gesture must settle through the remote target').toEqual([]);
+        expect(result.applied).toBe(true);
+        expect(result.witness.instanceId, 'the transferred pane is the original live instance').toBe(baseline.id);
+        expect(result.proof).toMatchObject({
+            framesNotReset           : true,
+            localDropFires           : 0,
+            mountDelta               : 1,
+            remoteDropOutFires       : 1,
+            sameInstance             : true,
+            sourceSuppressionConsumed: true,
+            transferCommits          : 1
+        });
+        expect(result.proof.remoteSnapshot).toMatchObject({
+            engaged     : true,
+            ready       : true,
+            targetNodeId: 'popup-tabs',
+            preview     : {itemId: 'workbench', target: {nodeId: 'popup-tabs'}},
+            rendered    : {itemId: 'workbench', target: {nodeId: 'popup-tabs'}}
+        });
+        expect(result.proof.remoteSnapshot.indicators.candidateCount,
+            'the empty root tabs target must expose its five distinct cross candidates before release').toBe(5);
+        expect(result.proof.remoteSnapshot.indicators.activePreviewId,
+            'the lit indicator and committed semantic preview must be the same candidate')
+            .toBe(result.proof.remoteSnapshot.preview.previewId);
+
+        await expect(popup.locator('.agentos-dockdemo-counter-pane'),
+            'the target window must render the transferred live pane').toBeVisible({timeout: 10000});
+
+        const after                = await app.getComponent(wsId, ['crossWindowStats', 'dockModel', 'popupDocument']),
+              counter              = await readCounter(),
+              topologyCaptureProbe = await app.callMethod(wsId, 'capturePerspective', [
+                  'CrossWindowProbe', {scope: 'topology'}
+              ]);
+
+        expect(topologyCaptureProbe, 'the real transferred documents must remain topology-capturable')
+            .toEqual({errors: [], saved: true});
+
+        const expectedSource = {
+                  schema: 'neo.harness.dockZone.v1',
+                  root  : 'root',
+                  items : {
+                      inspector: {componentRef: 'Inspector', title: 'Inspector', kind: 'panel'},
+                      timeline : {componentRef: 'Timeline',  title: 'Timeline',  kind: 'panel'},
+                      console  : {componentRef: 'Console',   title: 'Console',   kind: 'terminal'}
+                  },
+                  nodes: {
+                      root       : {type: 'edge-zone', zones: {right: 'side-tabs'}},
+                      'side-tabs': {
+                          type: 'tabs', items: ['inspector', 'timeline', 'console'], activeItemId: 'inspector'
+                      }
+                  }
+              },
+              expectedTarget = {
+                  schema: 'neo.harness.dockZone.v1',
+                  root  : 'popup-root',
+                  items : {
+                      workbench: {componentRef: 'Workbench', title: 'Workbench', kind: 'panel'}
+                  },
+                  nodes: {
+                      'popup-root': {type: 'edge-zone', zones: {center: 'popup-tabs'}},
+                      'popup-tabs': {type: 'tabs', items: ['workbench'], activeItemId: 'workbench'}
+                  }
+              };
+
+        expect(result.sourceDocument).toEqual(expectedSource);
+        expect(result.targetDocument).toEqual(expectedTarget);
+        expect(after.dockModel).toEqual(result.sourceDocument);
+        expect(after.popupDocument).toEqual(result.targetDocument);
+        expect(after.crossWindowStats).toEqual({
+            localDropFires    : 0,
+            remoteDropOutFires: 1,
+            transferCommits   : 1
+        });
+        expect(counter.id).toBe(baseline.id);
+        expect(counter.properties.mountCount).toBe(baseline.properties.mountCount + 1);
+        expect(counter.properties.mounted).toBe(true);
+        expect(counter.properties.windowId).not.toBe(baseline.properties.windowId);
+
+        await expect.poll(async () => (await readCounter())?.properties?.frames, {
+            message  : 'the instance-local heartbeat must continue after the target-document mount',
+            timeout  : 5000,
+            intervals: [100, 250]
+        }).toBeGreaterThan(counter.properties.frames);
+
+        const traceData = phaseZeroTrace,
+              traces    = traceData?.traces || traceData?.result?.traces || [],
+              trace     = traces[traces.length - 1];
+
+        expect(trace, 'the real tab SortZone must record the gesture').toBeTruthy();
+        expect(trace.events.some(event => event.t === 'move'), 'the sensor must produce a real move leg').toBe(true);
+        expect(trace.events.at(-1)?.t, 'the source SortZone must complete its terminal cleanup').toBe('end');
+
+        const targets = await app.findInstances({dockNodeId: 'popup-tabs'}, ['id', 'windowId']),
+              target  = Array.isArray(targets) ? targets[0] : targets;
+
+        expect(target?.id, 'the target tabs projection must exist in worker truth').toBeTruthy();
+
+        const consistency = await app.verifyComponentConsistency(target.id),
+              mismatches  = consistency?.mismatches || consistency?.result?.mismatches || [];
+
+        expect(mismatches, 'target items / VDOM / DOM must agree after adoption').toEqual([]);
+        expect(runtimeErrors).toEqual([]);
+        expect(popupErrors).toEqual([]);
+        expect(pageErrors).toEqual([])
+    });
+
+    test('Escape after remote preview clears every gesture surface and mutates neither document', async ({page, neuralLink}) => {
+        const pageErrors    = [],
+              popupErrors   = [],
+              runtimeErrors = [];
+
+        await page.context().exposeFunction('__recordDemoBCrossWindowCancelError', payload => runtimeErrors.push(payload));
+        await page.context().addInitScript(() => {
+            globalThis.addEventListener('error', event => {
+                globalThis.__recordDemoBCrossWindowCancelError({
+                    column : event.colno,
+                    line   : event.lineno,
+                    message: event.message,
+                    source : event.filename,
+                    type   : 'error'
+                })
+            });
+            globalThis.addEventListener('unhandledrejection', event => {
+                globalThis.__recordDemoBCrossWindowCancelError({
+                    reason: String(event.reason?.stack || event.reason?.message || event.reason),
+                    type  : 'unhandledrejection'
+                })
+            })
+        });
+
+        page.on('pageerror', error => {
+            let value = String(error?.stack || error?.message || error || '');
+
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
+        await page.waitForSelector('.agentos-dockdemo-counter-pane', {timeout: 30000});
+
+        const app        = await neuralLink.connectToApp('AgentOSDockDemo'),
+              workspaces = await app.findInstances(
+                  {className: 'AgentOS.childapps.dockdemo.view.DemoBWorkspace'},
+                  ['id']
+              ),
+              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id,
+              counters   = await app.findInstances(
+                  {className: 'AgentOS.childapps.dockdemo.view.CounterPane'},
+                  ['frames', 'id', 'mountCount', 'windowId']
+              ),
+              baseline   = Array.isArray(counters) ? counters[0] : counters,
+              before     = await app.getComponent(wsId, ['dockModel', 'popupDocument']);
+
+        expect(wsId).toBeTruthy();
+        await app.getDragTrace(true);
+
+        const popupPromise  = page.waitForEvent('popup', {timeout: 30000}),
+              resultPromise = app.callMethod(wsId, 'executeCrossWindowStep', [{
+                  itemId           : 'workbench',
+                  sourceWorkspaceId: 'demo-b-main',
+                  targetNodeId     : 'popup-tabs',
+                  targetWorkspaceId: 'demo-b-popup'
+              }, {cancelAtTarget: true}]),
+              popup = await popupPromise;
+
+        popup.on('pageerror', error => {
+            let value = String(error?.stack || error?.message || error || '');
+
+            value && value !== 'undefined' && popupErrors.push(value)
+        });
+
+        await placePopupOutsideSource(page, popup);
+
+        const result        = await resultPromise,
+              after         = await app.getComponent(wsId, ['crossWindowStats', 'dockModel', 'popupDocument']),
+              finalCounters = await app.findInstances(
+                  {className: 'AgentOS.childapps.dockdemo.view.CounterPane'},
+                  ['frames', 'id', 'mountCount', 'windowId']
+              ),
+              finalCounter = Array.isArray(finalCounters) ? finalCounters[0] : finalCounters,
+              traceData    = await app.getDragTrace(),
+              traces       = traceData?.traces || traceData?.result?.traces || [],
+              trace        = traces[traces.length - 1];
+
+        expect(result.applied).toBe(false);
+        expect(result.cancelled).toBe(true);
+        expect(result.errors).toEqual(['cross-window gesture cancelled before commit']);
+        expect(result.proof.documentsUnchanged).toBe(true);
+        expect(result.proof.remoteSnapshot).toMatchObject({engaged: true, ready: true});
+        expect(result.proof.cancellation).toEqual({
+            escapeDispatched : true,
+            releaseDispatched: true,
+            settled          : true
+        });
+        expect(result.proof.cleanup).toEqual({
+            activeTargetZone      : null,
+            activeCandidateId     : null,
+            candidateSetSchema    : null,
+            dragDataPresent       : false,
+            dragEndActive         : false,
+            dragPlaceholderPresent: false,
+            dragProxyPresent      : false,
+            draggingClass         : false,
+            nativeCandidateCount  : 0,
+            semanticPreviewId     : null,
+            renderedPreviewId     : null,
+            ready                 : true
+        });
+        expect(result.proof.stats).toEqual({
+            localDropFires    : 0,
+            remoteDropOutFires: 0,
+            transferCommits   : 0
+        });
+
+        expect(after.dockModel).toEqual(before.dockModel);
+        expect(after.popupDocument).toEqual(before.popupDocument);
+        expect(after.crossWindowStats).toEqual(result.proof.stats);
+        expect(finalCounter.id).toBe(baseline.id);
+        expect(finalCounter.properties.mountCount).toBe(baseline.properties.mountCount);
+        expect(finalCounter.properties.windowId).toBe(baseline.properties.windowId);
+        expect(trace?.events.at(-1)?.t).toBe('cancel');
+        expect(runtimeErrors).toEqual([]);
+        expect(popupErrors).toEqual([]);
+        expect(pageErrors).toEqual([]);
+
+        await popup.close()
+    })
+});

--- a/test/playwright/e2e/agentos/DemoBPerspectivesNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBPerspectivesNL.spec.mjs
@@ -2,23 +2,56 @@ import {test, expect}    from '../../fixtures.mjs';
 import {demoBTourScript} from '../../../../apps/agentos/tour/demoBPerspectives.mjs';
 
 /**
+ * @summary Moves only the real headless-Chrome popup vessel outside the source viewport.
+ * Product browsers honor the app-owned placement request; CDP supplies the missing window-manager
+ * behavior in headless Chrome without bypassing Neo's pointer, preview, or commit path.
+ * @param {import('@playwright/test').Page} page
+ * @param {import('@playwright/test').Page} popup
+ */
+async function placePopupOutsideSource(page, popup) {
+    const popupCdp    = await page.context().newCDPSession(popup),
+          popupWindow = await popupCdp.send('Browser.getWindowForTarget'),
+          sourceStage = await page.evaluate(() => ({
+              left : globalThis.screenX,
+              top  : globalThis.screenY,
+              width: globalThis.innerWidth
+          }));
+
+    await popupCdp.send('Browser.setWindowBounds', {
+        bounds: {
+            height     : popupWindow.bounds.height,
+            left       : sourceStage.left + sourceStage.width + 40,
+            top        : sourceStage.top,
+            width      : popupWindow.bounds.width,
+            windowState: 'normal'
+        },
+        windowId: popupWindow.windowId
+    })
+}
+
+/**
  * @summary Whitebox E2E for Demo B's full two-window perspective story.
  *
  * One native Tour click must open exactly one real popup, move the same live CounterPane
  * instance into it, capture the two worker-owned workspace documents, reattach, reconcile
  * that saved topology into one live window without opening another popup, render the exact
  * no-live-window remainder, and finish on Focus with the original counter still advancing.
- * The same page repeats the run so the executable screenplay proves deterministic replay.
+ * The same page repeats the run without viewer pauses so the executable screenplay proves
+ * deterministic replay and host-owned projection settledness independently of demo pacing.
  *
  * Run: NEO_E2E_PORT=8117 npx playwright test agentos/DemoBPerspectivesNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  */
 test.describe('AgentOS Demo B — topology perspective + shared-heap popup journey', () => {
     test.setTimeout(150000);
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 720, width: 760}
+    });
 
-    test('two deterministic runs each open one popup; topology restore opens none and preserves the CounterPane instance', async ({page, neuralLink}) => {
+    test('paced demo + no-pause spec each open one popup; replay stays deterministic and preserves the CounterPane instance', async ({page, neuralLink}) => {
         const pageErrors    = [],
               runtimeErrors = [];
-        let popupCount      = 0;
+        let popupCount = 0;
 
         await page.context().exposeFunction('__recordDemoBRuntimeError', payload => runtimeErrors.push(payload));
         await page.context().addInitScript(() => {
@@ -54,18 +87,22 @@ test.describe('AgentOS Demo B — topology perspective + shared-heap popup journ
 
         expect(wsId, 'the DemoBWorkspace must exist in the App Worker').toBeTruthy();
 
+        const runnerId = (await app.getComponent(wsId, ['tourRunner.id']))['tourRunner.id'];
+
+        expect(runnerId, 'the workspace must expose its TourRunner through worker truth').toBeTruthy();
+
         const readCounter = async () => {
             const counters = await app.findInstances(
                 {className: 'AgentOS.childapps.dockdemo.view.CounterPane'},
-                ['id', 'frames']
+                ['frames', 'id', 'mountCount', 'windowId']
             );
 
             return (Array.isArray(counters) ? counters[0] : counters)
         };
 
         await expect.poll(async () => !!(await readCounter())?.id, {
-            message: 'the worker must own one CounterPane before the tour',
-            timeout: 10000,
+            message  : 'the worker must own one CounterPane before the tour',
+            timeout  : 10000,
             intervals: [100]
         }).toBe(true);
 
@@ -76,24 +113,50 @@ test.describe('AgentOS Demo B — topology perspective + shared-heap popup journ
         const logs = [];
 
         for (let run = 0; run < 2; run++) {
-            const popupsBefore = popupCount,
+            const runBaseline  = await readCounter(),
+                  popupsBefore = popupCount,
                   popupPromise = page.waitForEvent('popup', {timeout: 30000});
 
+            await app.setProperties(runnerId, {mode: run === 0 ? 'demo' : 'spec'});
             await page.locator('.agentos-dockdemo-tour-play').click();
 
-            const popup      = await popupPromise,
+            const popup       = await popupPromise,
                   popupErrors = [];
+
+            await placePopupOutsideSource(page, popup);
 
             popup.on('pageerror', error => {
                 let value = error == null ? '' : String(error.stack || error.message || error);
                 value && value !== 'undefined' && popupErrors.push(value)
             });
-            await expect(popup.locator('.agentos-dockdemo-counter-pane'), 'the real popup hosts the live workbench pane')
-                .toBeVisible({timeout: 10000});
 
-            const inPopup = await readCounter();
+            let inPopup = runBaseline;
 
-            expect(inPopup.id, 'the popup must hold the original CounterPane instance').toBe(baseline.id);
+            // Demo pacing leaves the transferred pane onscreen long enough for a human-facing
+            // visual witness. Spec mode deliberately skips every pause, so transfer + reattach can
+            // finish before Playwright samples the transient vessel; its structured receipt and
+            // final document/log assertions below are the zero-pause correctness witness.
+            if (run === 0) {
+                await expect(popup.locator('.agentos-dockdemo-counter-pane'), 'the real popup hosts the live workbench pane')
+                    .toBeVisible({timeout: 10000});
+
+                await expect.poll(readCounter, {
+                    message  : 'worker truth must show the original instance mounted once into the popup',
+                    timeout  : 10000,
+                    intervals: [100]
+                }).toMatchObject({
+                    id        : baseline.id,
+                    properties: {
+                        frames    : expect.any(Number),
+                        mountCount: runBaseline.properties.mountCount + 1
+                    }
+                });
+
+                inPopup = await readCounter();
+
+                expect(inPopup.properties.frames).toBeGreaterThanOrEqual(runBaseline.properties.frames);
+                expect(inPopup.properties.windowId).not.toBe(runBaseline.properties.windowId)
+            }
 
             await expect.poll(async () => {
                 const state = await app.getComponent(wsId, ['tourRunner.running', 'tourRunner.log']);
@@ -102,38 +165,108 @@ test.describe('AgentOS Demo B — topology perspective + shared-heap popup journ
                     running: state['tourRunner.running']
                 }
             }, {
-                message: `Demo B run ${run + 1} must complete every executable beat`,
-                timeout: 60000,
+                message  : `Demo B run ${run + 1} must complete every executable beat`,
+                timeout  : 60000,
                 intervals: [100, 250]
             }).toEqual({length: totalBeats, running: false});
 
+            // Runner settlement does not claim hosting-surface projection settlement. Await the
+            // worker-owned queue explicitly so a first-run projection defect cannot masquerade as
+            // a second-run popup timeout.
+            await app.callMethod(wsId, 'awaitProjectionIdle');
+            await expect(page.locator('.agentos-dockdemo-counter-pane'), 'Focus is visibly projected before replay')
+                .toBeVisible();
+
+            const sourceTabs = await app.findInstances(
+                    {dockNodeId: 'workbench-tabs'},
+                    ['id', 'tabBarId']
+                ),
+                sourceTab = Array.isArray(sourceTabs) ? sourceTabs[0] : sourceTabs,
+                sourceButtons = await app.findInstances(
+                    {parentId: sourceTab.properties.tabBarId},
+                    ['hidden', 'hideMode', 'id', 'mounted', 'pressed', 'text', 'vdom.removeDom', 'windowId']
+                ),
+                sourceButton = Array.isArray(sourceButtons) ? sourceButtons[0] : sourceButtons,
+                sourceBarConsistency = await app.verifyComponentConsistency(sourceTab.properties.tabBarId),
+                sourceBarMismatches = sourceBarConsistency?.mismatches
+                    || sourceBarConsistency?.result?.mismatches
+                    || [];
+
+            expect(sourceButton?.properties,
+                `Focus header state before replay: ${JSON.stringify(sourceButton)}`).toMatchObject({
+                hidden : false,
+                mounted: true,
+                pressed: true
+            });
+            expect(sourceBarMismatches,
+                'Focus restore must commit the re-created tab header into worker, VDOM, and DOM truth')
+                .toEqual([]);
+
             await expect.poll(() => popup.isClosed(), {
-                message: 'the scripted reattach closes the popup before topology restore',
-                timeout: 10000,
+                message  : 'the scripted reattach closes the popup before topology restore',
+                timeout  : 10000,
                 intervals: [100]
             }).toBe(true);
 
-            const state = await app.getComponent(wsId, ['dockModel', 'restoreReport', 'tourRunner.log']),
+            await expect.poll(async () => (await app.getComponent(wsId, ['crossWindowTargetWindowId']))
+                .crossWindowTargetWindowId, {
+                message  : 'worker disconnect cleanup must retire the closed target before replay',
+                timeout  : 10000,
+                intervals: [100]
+            }).toBeNull();
+
+            const state = await app.getComponent(wsId, [
+                      'detachedPanes',
+                      'dockModel',
+                      'perspectiveStore.collection',
+                      'restoreReport',
+                      'tourRunner.log'
+                  ]),
                   final = await readCounter();
 
+            const detached = state['perspectiveStore.collection']?.layouts?.['demo-b-detached'];
+
+            expect(state.restoreReport).not.toBeNull();
+            expect(detached?.captureScope).toBe('topology');
+            expect(detached?.windowDocuments).toHaveLength(1);
+            expect(detached.windowDocuments[0].items.workbench).toEqual({
+                componentRef: 'Workbench',
+                kind        : 'panel',
+                title       : 'Workbench'
+            });
+            expect(detached.windowDocuments[0].nodes['popup-tabs'].items).toEqual(['workbench']);
             expect(state.restoreReport.noWindowSpawned).toBe(true);
             expect(state.restoreReport.unrestored).toEqual([
                 {capturedIndex: 1, itemId: 'workbench', reason: 'no-live-window'}
             ]);
             expect(state.restoreReport.displaced).toEqual([{itemId: 'workbench', liveIndex: 0}]);
             expect(state.dockModel.items.workbench.title).toBe('Workbench');
+            expect(state['tourRunner.log'].filter(entry => entry.type === 'cross-window')).toEqual([{
+                applied: true,
+                errors : [],
+                sceneId: 's3',
+                step   : {
+                    itemId           : 'workbench',
+                    sourceWorkspaceId: 'demo-b-main',
+                    targetWorkspaceId: 'demo-b-popup',
+                    targetNodeId     : 'popup-tabs'
+                },
+                stepIndex: 2,
+                type     : 'cross-window'
+            }]);
             expect(final.id, 'Focus restore must re-adopt the same live CounterPane').toBe(baseline.id);
-            expect(final.properties.frames).toBeGreaterThan(baseline.properties.frames);
+            expect(final.properties.frames).toBeGreaterThanOrEqual(inPopup.properties.frames);
+            expect(final.properties.windowId).toBe(runBaseline.properties.windowId);
             expect(popupCount - popupsBefore, 'S3 opens one popup; S4 topology restore opens none').toBe(1);
             expect(popupErrors).toEqual([]);
 
             await expect(page.locator('.agentos-dockdemo-restore-report'))
                 .toContainText('no window spawned');
 
-            logs.push(state['tourRunner.log'])
+            logs.push(JSON.stringify(state['tourRunner.log']))
         }
 
-        expect(logs[1], 'the second run must produce the same timestamp-free operation log').toEqual(logs[0]);
+        expect(logs[1], 'the no-pause spec run must produce the same byte-identical operation log').toBe(logs[0]);
         expect(runtimeErrors).toEqual([]);
         expect(pageErrors).toEqual([])
     })

--- a/test/playwright/e2e/dashboard/DockTourSmokeNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockTourSmokeNL.spec.mjs
@@ -18,8 +18,9 @@ import {test, expect} from '../../fixtures.mjs';
  * resolves only after the last deferred re-projection settles, so the page-survival verdict
  * covers the projection work, not just the reducer commits.
  *
- * All three executable `neo.tour.script.v1` step types are exercised (`op`, `topology-assert`,
- * `pause` — spec mode skips the pause WAIT but keeps its log entry, per pace-never-correctness).
+ * All three reducer-owned `neo.tour.script.v1` step types are exercised (`op`,
+ * `topology-assert`, `pause`). The conditionally executable `cross-window` type belongs to the
+ * two-window Demo-B journey; spec mode skips pause waits but keeps their log entries.
  *
  * Paradigm (whitebox-e2e protocol): Playwright loads the page; every assertion below is App
  * Worker truth via the Neural Link fixture — no DOM locator carries a verdict.

--- a/test/playwright/unit/ai/client/TourRunner.spec.mjs
+++ b/test/playwright/unit/ai/client/TourRunner.spec.mjs
@@ -37,9 +37,9 @@ function doc() {
 }
 
 /**
- * @summary The canonical three-step smoke script: two real semantic operations plus a
- * topology assert and a (tiny) pause — every step type of the v1 vocabulary except the
- * reserved ones, executable against the real reducers with predictable post-state.
+ * @summary The canonical reducer smoke script: two real semantic operations plus a topology
+ * assert and a (tiny) pause. The conditionally executable cross-window type has its own host
+ * suite below; every reducer-owned type remains predictable against one document.
  * @returns {Object}
  */
 function smokeScript() {
@@ -80,6 +80,46 @@ function smokeScript() {
                 }
             ]
         }]
+    }
+}
+
+/**
+ * @summary One semantic cross-window step with no runtime window, DOM or geometry data.
+ * @returns {Object}
+ */
+function crossWindowScript() {
+    return {
+        schema: TOUR_SCRIPT_SCHEMA,
+        id    : 'unit-cross-window',
+        title : 'Unit cross-window tour',
+        scenes: [{
+            id   : 'cross',
+            title: 'Cross-window',
+            steps: [{
+                type             : 'cross-window',
+                caption          : 'move the live workbench',
+                itemId           : 'workbench',
+                sourceWorkspaceId: 'demo-b-main',
+                targetWorkspaceId: 'demo-b-popup',
+                targetNodeId     : 'popup-tabs'
+            }]
+        }]
+    }
+}
+
+/**
+ * @summary A successful host receipt. Runtime witness values are deliberately configurable
+ * so determinism tests can prove they never leak into TourRunner.log.
+ * @param {Object} options
+ * @returns {Object}
+ */
+function crossWindowReceipt({instanceId = 'neo-component-runtime-1', mountCount = 1} = {}) {
+    return {
+        applied       : true,
+        errors        : [],
+        sourceDocument: {schema: 'source.v1'},
+        targetDocument: {schema: 'target.v1'},
+        witness       : {instanceId, mountCount}
     }
 }
 
@@ -152,7 +192,7 @@ test.describe.serial('Neo.ai.client.TourRunner', () => {
             expect(errors.join('\n')).toContain(`unknown 'teleport'. The v1 vocabulary is: ${STEP_TYPES.join(', ')}`)
         });
 
-        test('reserved step types are rejected as reserved, not unknown', () => {
+        test('future reserved step types are rejected as reserved, not unknown', () => {
             RESERVED_STEP_TYPES.forEach(type => {
                 const script = smokeScript();
 
@@ -163,6 +203,41 @@ test.describe.serial('Neo.ai.client.TourRunner', () => {
                 expect(valid).toBe(false);
                 expect(errors.join('\n')).toContain(`'${type}' is reserved`)
             })
+        });
+
+        test('cross-window remains reserved without a compatible host executor', () => {
+            const {valid, errors} = validateTourScript(crossWindowScript(), {operations});
+
+            expect(valid).toBe(false);
+            expect(errors.join('\n')).toContain("'cross-window' remains reserved")
+        });
+
+        test('cross-window validates only its four semantic ids when a host is available', () => {
+            const valid = validateTourScript(crossWindowScript(), {
+                crossWindowAvailable: true,
+                operations
+            });
+
+            expect(valid).toEqual({errors: [], valid: true});
+
+            const missing = crossWindowScript();
+
+            missing.scenes[0].steps[0].itemId = '';
+
+            const sameWorkspace = crossWindowScript();
+
+            sameWorkspace.scenes[0].steps[0].targetWorkspaceId = 'demo-b-main';
+
+            const runtimeLeak = crossWindowScript();
+
+            runtimeLeak.scenes[0].steps[0].screenX = 720;
+
+            expect(validateTourScript(missing, {crossWindowAvailable: true, operations}).errors.join('\n'))
+                .toContain('itemId: required non-empty semantic id string');
+            expect(validateTourScript(sameWorkspace, {crossWindowAvailable: true, operations}).errors.join('\n'))
+                .toContain('must identify different workspaces');
+            expect(validateTourScript(runtimeLeak, {crossWindowAvailable: true, operations}).errors.join('\n'))
+                .toContain('screenX: cross-window steps accept semantic ids only')
         });
 
         test('unknown operations are rejected with the executable vocabulary enumerated', () => {
@@ -348,6 +423,23 @@ test.describe.serial('Neo.ai.client.TourRunner', () => {
             expect(result.completed).toBe(false);
             expect(result.errors.join('\n')).toContain("unknown 'teleportItem'")
         });
+
+        test('cross-window refuses an absent or incompatible executor before dispatch', async () => {
+            createRunner({script: crossWindowScript()});
+
+            let result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain("'cross-window' remains reserved");
+
+            runner.destroy();
+            createRunner({crossWindowExecutor: {}, script: crossWindowScript()});
+
+            result = await runner.start();
+
+            expect(result.completed).toBe(false);
+            expect(result.errors.join('\n')).toContain("'cross-window' remains reserved")
+        });
     });
 
     test.describe('execution against the real reducers', () => {
@@ -420,6 +512,163 @@ test.describe.serial('Neo.ai.client.TourRunner', () => {
 
             expect(result.completed).toBe(true);
             expect(events).toEqual(['wait:14', 'settled:pause:1'])
+        });
+
+        test('cross-window awaits one host dispatch before settlement and logs semantics only', async () => {
+            let release;
+            const
+                calls    = [],
+                executor = {
+                    executeCrossWindowStep(step) {
+                        calls.push(step);
+                        return new Promise(resolve => release = resolve)
+                    }
+                },
+                settled = [];
+
+            createRunner({crossWindowExecutor: executor, script: crossWindowScript()});
+            runner.on('stepSettled', data => settled.push(data));
+
+            const running = runner.start();
+
+            await Promise.resolve();
+
+            expect(calls).toHaveLength(1);
+            expect(calls[0]).toEqual(crossWindowScript().scenes[0].steps[0]);
+            expect(calls[0]).not.toBe(runner.script.scenes[0].steps[0]);
+            expect(settled).toEqual([]);
+
+            release(crossWindowReceipt());
+
+            const result = await running;
+
+            expect(result.completed).toBe(true);
+            expect(settled).toHaveLength(1);
+            expect(result.log).toEqual([{
+                applied: true,
+                errors : [],
+                sceneId: 'cross',
+                step   : {
+                    itemId           : 'workbench',
+                    sourceWorkspaceId: 'demo-b-main',
+                    targetWorkspaceId: 'demo-b-popup',
+                    targetNodeId     : 'popup-tabs'
+                },
+                stepIndex: 0,
+                type     : 'cross-window'
+            }]);
+            expect(JSON.stringify(result.log)).not.toContain('neo-component-runtime-1');
+            expect(JSON.stringify(result.log)).not.toContain('mountCount')
+        });
+
+        test('destroying the runner settles a pending cross-window host without a late step event', async () => {
+            let release;
+            const settled = [];
+
+            createRunner({
+                crossWindowExecutor: {
+                    executeCrossWindowStep: () => new Promise(resolve => release = resolve)
+                },
+                script: crossWindowScript()
+            });
+            runner.on('stepSettled', data => settled.push(data));
+
+            const running = runner.start();
+
+            await Promise.resolve();
+            runner.destroy();
+
+            expect(await running).toEqual({
+                completed: false,
+                errors   : ['TourRunner destroyed mid-tour'],
+                log      : []
+            });
+            expect(settled).toEqual([]);
+
+            release(crossWindowReceipt());
+            await Promise.resolve();
+
+            expect(settled).toEqual([])
+        });
+
+        test('cross-window rejection, throw and malformed success abort structurally without settlement', async () => {
+            const run = async executeCrossWindowStep => {
+                const settled = [];
+
+                runner?.destroy?.();
+                createRunner({crossWindowExecutor: {executeCrossWindowStep}, script: crossWindowScript()});
+                runner.on('stepSettled', data => settled.push(data));
+
+                const result = await runner.start();
+
+                expect(result.completed).toBe(false);
+                expect(settled).toEqual([]);
+
+                return result
+            };
+
+            let result = await run(async () => ({applied: false, errors: ['target refused']}));
+
+            expect(result.errors.join('\n')).toContain('target refused');
+            expect(result.log).toHaveLength(1);
+
+            result = await run(async () => { throw new Error('host vanished') });
+
+            expect(result.errors.join('\n')).toContain('cross-window executor failure: host vanished');
+            expect(result.log).toEqual([]);
+
+            result = await run(async () => ({applied: true, errors: []}));
+
+            expect(result.errors.join('\n')).toContain('requires a plain sourceDocument');
+            expect(result.errors.join('\n')).toContain('requires witness');
+            expect(result.log).toEqual([])
+        });
+
+        test('changing runtime witnesses across runs cannot change the cross-window replay log', async () => {
+            let   run      = 0;
+            const executor = {
+                executeCrossWindowStep: async () => crossWindowReceipt({
+                    instanceId: `runtime-${++run}`,
+                    mountCount: run
+                })
+            };
+
+            createRunner({crossWindowExecutor: executor, script: crossWindowScript()});
+
+            const first  = await runner.start(),
+                  second = await runner.start();
+
+            expect(first.completed && second.completed).toBe(true);
+            expect(second.log).toEqual(first.log)
+        });
+
+        test('cross-window logs are mode-identical while the host receipt settles correctness', async () => {
+            const executor = {executeCrossWindowStep: async () => crossWindowReceipt()};
+            let   results  = [];
+
+            for (const mode of ['spec', 'demo', 'record']) {
+                runner?.destroy?.();
+                createRunner({
+                    crossWindowExecutor: executor,
+                    mode,
+                    reducedMotion      : mode === 'record' ? false : null,
+                    script             : crossWindowScript()
+                });
+
+                results.push(await runner.start())
+            }
+
+            results.forEach(result => {
+                expect(result.completed).toBe(true);
+                expect(result.errors).toEqual([]);
+                expect(result.log).toHaveLength(1);
+                expect(result.log[0].type).toBe('cross-window')
+            });
+
+            const logs = results.map(result => JSON.stringify(result.log));
+
+            expect(logs[1]).toBe(logs[0]);
+            expect(logs[2]).toBe(logs[0])
         });
 
         test('log entries carry the complete cloned descriptor — the log IS the replay wire format', async () => {

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
@@ -14,7 +14,7 @@ import DemoBWorkspace           from '../../../../../../../apps/agentos/childapp
 import DockProjectionReconciler from '../../../../../../../src/dashboard/DockProjectionReconciler.mjs';
 import DockZoneModel            from '../../../../../../../src/dashboard/DockZoneModel.mjs';
 
-import {initialDocument} from '../../../../../../../apps/agentos/tour/demoBPerspectives.mjs';
+import {demoBTourScript, initialDocument} from '../../../../../../../apps/agentos/tour/demoBPerspectives.mjs';
 
 /**
  * @summary Installs deterministic popup-vessel seams for the worker-side workspace specs.
@@ -23,7 +23,7 @@ import {initialDocument} from '../../../../../../../apps/agentos/tour/demoBPersp
  * @param {Object} [options={}]
  * @param {Error|null} [options.openError=null]
  * @param {Error|null} [options.closeError=null]
- * @returns {{openCount: Number, closeCount: Number, restore: Function}}
+ * @returns {{openCount: Number, closeCount: Number, closeCalls: Object[], restore: Function}}
  */
 function installWindowVessel({openError = null, closeError = null} = {}) {
     let previous = {
@@ -31,20 +31,22 @@ function installWindowVessel({openError = null, closeError = null} = {}) {
             windowClose  : Neo.Main.windowClose,
             windowOpen   : Neo.Main.windowOpen
         },
-        state = {closeCount: 0, openCount: 0};
+        state = {closeCalls: [], closeCount: 0, openCount: 0};
 
     Neo.Main.getWindowData = async () => ({screenLeft: 10, screenTop: 20});
     Neo.Main.windowOpen    = async () => {
         state.openCount++;
         if (openError) throw openError
     };
-    Neo.Main.windowClose   = async () => {
+    Neo.Main.windowClose   = async data => {
+        state.closeCalls.push(data);
         state.closeCount++;
         if (closeError) throw closeError
     };
 
     return {
         get closeCount() { return state.closeCount },
+        get closeCalls() { return state.closeCalls },
         get openCount()  { return state.openCount },
         restore() {
             Object.assign(Neo.Main, previous)
@@ -77,6 +79,21 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
         expect(doc).not.toBe(initialDocument);
         expect(doc.nodes.root.zones.center).toBe('workbench-tabs');
         expect(doc.nodes['side-tabs'].items).toEqual(['inspector', 'timeline', 'console'])
+    });
+
+    test('this host conditionally activates one semantic cross-window step', () => {
+        const steps = demoBTourScript.scenes.flatMap(scene => scene.steps)
+            .filter(step => step.type === 'cross-window');
+
+        expect(workspace.tourRunner.crossWindowExecutor).toBe(workspace);
+        expect(steps).toEqual([{
+            type             : 'cross-window',
+            itemId           : 'workbench',
+            sourceWorkspaceId: 'demo-b-main',
+            targetWorkspaceId: 'demo-b-popup',
+            targetNodeId     : 'popup-tabs',
+            caption          : 'drag(workbench → popup): one real pointer gesture crosses two active OS windows. The worker instance and counter never reset.'
+        }])
     });
 
     test('capture → load round-trip through the REAL store: one committed swap, honest names', () => {
@@ -177,6 +194,165 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
         const home = Object.keys(doc.nodes).find(id => doc.nodes[id].type === 'tabs' && doc.nodes[id].items.includes('workbench'));
 
         expect(home, 'the returning pane found a real tabs home').toBeTruthy()
+    });
+
+    test('reattachPane closes the stored cross-window vessel name', async () => {
+        const vessel = installWindowVessel();
+
+        try {
+            workspace.resolvePane('workbench', initialDocument.items.workbench);
+
+            const detached = DockZoneModel.transferItem(
+                workspace.dockModel,
+                DemoBWorkspace.createPopupDocument(),
+                {
+                    itemId: 'workbench', sourceWorkspaceId: 'main', targetWorkspaceId: 'popup',
+                    target: {operation: 'addTab', tabsNodeId: 'popup-tabs'}
+                }
+            );
+
+            workspace.dockModel     = detached.sourceDocument;
+            workspace.popupDocument = detached.targetDocument;
+            workspace.detachedPanes.workbench = {
+                tabsNodeId: 'workbench-tabs',
+                windowId  : 'window-popup',
+                windowName: 'demo-b-cross-window'
+            };
+
+            expect(await workspace.reattachPane('workbench')).toEqual({errors: [], reattached: true});
+            expect(vessel.closeCalls).toEqual([{
+                names   : ['demo-b-cross-window'],
+                windowId: workspace.windowId
+            }])
+        } finally {
+            vessel.restore()
+        }
+    });
+
+    test('a manual cross-window close after transfer returns the live item to main ownership', () => {
+        const pane     = workspace.resolvePane('workbench', initialDocument.items.workbench),
+              detached = DockZoneModel.transferItem(
+                  workspace.dockModel,
+                  DemoBWorkspace.createPopupDocument(),
+                  {
+                      itemId: 'workbench', sourceWorkspaceId: 'main', targetWorkspaceId: 'popup',
+                      target: {operation: 'addTab', tabsNodeId: 'popup-tabs'}
+                  }
+              );
+
+        workspace.dockModel               = detached.sourceDocument;
+        workspace.popupDocument           = detached.targetDocument;
+        workspace.crossWindowTargetWindowId = 'window-popup';
+        workspace.detachedPanes.workbench = {
+            tabsNodeId: 'workbench-tabs',
+            windowId  : 'window-popup',
+            windowName: 'demo-b-cross-window'
+        };
+
+        workspace.onWindowDisconnect({windowId: 'window-popup'});
+
+        expect(workspace.dockModel.items.workbench).toEqual(initialDocument.items.workbench);
+        expect(workspace.popupDocument.items.workbench).toBeUndefined();
+        expect(workspace.paneCache.workbench).toBe(pane);
+        expect(workspace.detachedPanes.workbench).toBeUndefined()
+    });
+
+    test('a popup close during projection settlement cannot strand committed popup ownership', async () => {
+        const
+            pane     = workspace.resolvePane('workbench', initialDocument.items.workbench),
+            detached = DockZoneModel.transferItem(
+                workspace.dockModel,
+                DemoBWorkspace.createPopupDocument(),
+                {
+                    itemId: 'workbench', sourceWorkspaceId: 'demo-b-main', targetWorkspaceId: 'demo-b-popup',
+                    target: {operation: 'addTab', tabsNodeId: 'popup-tabs'}
+                }
+            );
+
+        let releaseTargetRefresh,
+            targetRefreshEntered;
+
+        const
+            targetRefreshStarted = new Promise(resolve => targetRefreshEntered = resolve),
+            refreshCalls         = [];
+
+        workspace.crossWindowTargetWindowId = 'window-popup';
+        workspace.crossWindowGestureContext = {
+            frames      : pane.frames,
+            mountCount  : pane.mountCount,
+            pane,
+            sourceNodeId: 'workbench-tabs'
+        };
+        workspace.crossWindowStats = {localDropFires: 0, remoteDropOutFires: 1, transferCommits: 0};
+        workspace.timeout          = async () => {};
+        workspace.refreshWorkspace = async (workspaceId, document) => {
+            refreshCalls.push({document, workspaceId});
+
+            if (refreshCalls.length === 1) {
+                targetRefreshEntered();
+                await new Promise(resolve => releaseTargetRefresh = resolve)
+            }
+        };
+
+        const commit = workspace.commitCrossWindowTransfer({
+            descriptor: {
+                itemId: 'workbench',
+                target: {operation: 'addTab', tabsNodeId: 'popup-tabs'}
+            },
+            sourceDocument   : detached.sourceDocument,
+            sourceWorkspaceId: 'demo-b-main',
+            targetDocument   : detached.targetDocument,
+            targetWorkspaceId: 'demo-b-popup'
+        });
+
+        await targetRefreshStarted;
+
+        expect(workspace.detachedPanes.workbench.windowId).toBe('window-popup');
+
+        workspace.onWindowDisconnect({windowId: 'window-popup'});
+
+        expect(workspace.dockModel.items.workbench).toEqual(initialDocument.items.workbench);
+        expect(workspace.popupDocument.items.workbench).toBeUndefined();
+        expect(workspace.detachedPanes.workbench).toBeUndefined();
+
+        releaseTargetRefresh();
+        await commit;
+        await workspace.awaitProjectionIdle();
+
+        expect(refreshCalls.map(call => call.workspaceId)).toEqual(['demo-b-popup', 'demo-b-main']);
+        expect(workspace.dockModel.items.workbench).toEqual(initialDocument.items.workbench);
+        expect(workspace.popupDocument.items.workbench).toBeUndefined()
+    });
+
+    test('cross-window execution drains a cue projection before it opens the popup stage', async () => {
+        workspace.resolvePane('workbench', initialDocument.items.workbench);
+
+        let openCount = 0,
+            releaseProjection;
+
+        workspace.refreshPromise = new Promise(resolve => releaseProjection = resolve);
+        workspace.openCrossWindowStage = async () => {
+            openCount++;
+            throw new Error('stop after projection readiness gate')
+        };
+
+        const running = workspace.executeCrossWindowStep({
+            itemId           : 'workbench',
+            sourceWorkspaceId: 'demo-b-main',
+            targetWorkspaceId: 'demo-b-popup',
+            targetNodeId     : 'popup-tabs'
+        });
+
+        await Promise.resolve();
+        expect(openCount).toBe(0);
+
+        releaseProjection();
+
+        const result = await running;
+
+        expect(openCount).toBe(1);
+        expect(result.applied).toBe(false);
+        expect(result.errors).toEqual(['stop after projection readiness gate'])
     });
 
     test('topology round-trip transfers ownership, reports the missing popup slot, never spawns on restore, and preserves the pane instance', async () => {
@@ -334,6 +510,80 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
         // one button, not two — the store replaced, the switcher rebuilt
         const bar = workspace.getReference('switcher-bar');
         expect(bar.items.slice(1).map(item => item.text)).toEqual(['Focus'])
+    });
+
+    test('projection coalescing keeps the latest document and preservation policy atomic', async () => {
+        const
+            topologyDocument = DockZoneModel.clone(initialDocument),
+            focusDocument    = DockZoneModel.clone(initialDocument),
+            calls            = [];
+
+        delete topologyDocument.items.workbench;
+        topologyDocument.nodes['workbench-tabs'].items = [];
+        topologyDocument.nodes['workbench-tabs'].activeItemId = null;
+
+        workspace.refreshWorkspace = async (workspaceId, document, options) => {
+            calls.push({document, options, workspaceId})
+        };
+
+        workspace.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, topologyDocument, {
+            preserveItemIds: ['workbench']
+        });
+        workspace.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, focusDocument);
+
+        await workspace.awaitProjectionIdle();
+
+        expect(calls).toHaveLength(2);
+        calls.forEach(call => {
+            expect(call.workspaceId).toBe(DemoBWorkspace.MAIN_WORKSPACE_ID);
+            expect(call.document).toBe(focusDocument);
+            expect(call.options.preserveItemIds).toEqual([])
+        })
+    });
+
+    test('a rerun drains the prior projection before resetting and starting replay', async () => {
+        let releasePrior,
+            order = [];
+
+        const mutated = workspace.applyDockZoneOperation({
+            operation  : 'splitNode', itemId: 'timeline', targetNodeId: 'workbench-tabs',
+            orientation: 'vertical', edge: 'bottom'
+        }).document;
+
+        workspace.dockModel = mutated;
+        workspace.tourRunner.log.push({type: 'prior-run'});
+        workspace.refreshPromise = new Promise(resolve => {
+            releasePrior = () => {
+                order.push('prior-settled');
+                resolve()
+            }
+        });
+        workspace.refreshWorkspace = async (workspaceId, document) => {
+            order.push(`refresh:${workspaceId}`);
+            expect(document).toBe(workspace.dockModel)
+        };
+        workspace.tourRunner.start = async () => {
+            order.push('runner-started');
+            return {completed: true, errors: [], log: []}
+        };
+
+        const rerun = workspace.startTour();
+
+        await Promise.resolve();
+
+        expect(order).toEqual([]);
+        expect(workspace.dockModel).toBe(mutated);
+
+        releasePrior();
+        await rerun;
+
+        expect(order).toEqual([
+            'prior-settled',
+            `refresh:${DemoBWorkspace.MAIN_WORKSPACE_ID}`,
+            'runner-started'
+        ]);
+        expect(workspace.dockModel).not.toBe(initialDocument);
+        expect(workspace.dockModel).toEqual(initialDocument)
     });
 
     test('destroy tears down the runner, seam, store, and every cached pane', () => {

--- a/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
+++ b/test/playwright/unit/dashboard/DockProjectionReconciler.spec.mjs
@@ -162,6 +162,7 @@ test.describe('Neo.dashboard.DockProjectionReconciler', () => {
         nextModel.nodes['root-tabs'].items.push('beta');
 
         const resolverCalls = [];
+        let   headerCommits = 0;
 
         try {
             const nextConfig = DockLayoutAdapter.project(nextModel, {
@@ -176,6 +177,15 @@ test.describe('Neo.dashboard.DockProjectionReconciler', () => {
                     return placeholder
                 }
             });
+
+            const
+                bar                   = originalTab.getTabBar(),
+                originalPromiseUpdate = bar.promiseUpdate.bind(bar);
+
+            bar.promiseUpdate = (...args) => {
+                headerCommits++;
+                return originalPromiseUpdate(...args)
+            };
 
             await DockProjectionReconciler.reconcileProjection({
                 host,
@@ -201,6 +211,8 @@ test.describe('Neo.dashboard.DockProjectionReconciler', () => {
             expect(body.items[1]).toBeInstanceOf(Component);
             expect(body.items[1].html).toBe('Beta');
             expect(originalTab.getTabBar().items[1].text).toBe('Beta');
+            expect(originalTab.getTabBar().items[1].wrapperCls).toContain('neo-draggable');
+            expect(headerCommits, 'new chrome commits once through its direct toolbar owner').toBe(1);
             expect(resolverCalls).toEqual(['beta'])
         } finally {
             host.destroy()
@@ -273,6 +285,97 @@ test.describe('Neo.dashboard.DockProjectionReconciler', () => {
             expect(bar.items).toHaveLength(1);
             expect(betaPaneDestroyCount).toBe(1);
             expect(betaButtonDestroyCount).toBe(1)
+        } finally {
+            host.destroy()
+        }
+    })
+
+    test('parks an absent middle pane without shifting sibling chrome and re-adopts the same instance', async () => {
+        const model = createRootTabsModel();
+
+        model.items.beta  = {componentRef: 'beta',  kind: 'panel', title: 'Beta'};
+        model.items.gamma = {componentRef: 'gamma', kind: 'panel', title: 'Gamma'};
+        model.nodes['root-tabs'].items = ['alpha', 'beta', 'gamma'];
+
+        const
+            panes = {
+                alpha: Neo.create(Component, {header: {text: 'Alpha'}}),
+                beta : Neo.create(Component, {header: {text: 'Beta'}}),
+                gamma: Neo.create(Component, {header: {text: 'Gamma'}})
+            },
+            host = Neo.create(Container, {
+                items: [DockLayoutAdapter.project(model, {
+                    resolveComponentRef: (_componentRef, _item, itemId) => panes[itemId]
+                })]
+            }),
+            tab               = host.items[0],
+            originalButton    = tab.getTabBar().items[1],
+            originalDestroy   = panes.beta.destroy.bind(panes.beta),
+            nextModel         = structuredClone(model),
+            firstPlaceholders = new Map();
+
+        let paneDestroyCount = 0;
+
+        panes.beta.destroy = (...args) => {
+            paneDestroyCount++;
+            return originalDestroy(...args)
+        };
+        nextModel.nodes['root-tabs'].items = ['alpha', 'gamma'];
+
+        const project = (document, placeholders) => DockLayoutAdapter.project(document, {
+            resolveComponentRef(_componentRef, item, itemId) {
+                const placeholder = Neo.create(Component, {
+                    header: {text: item.title},
+                    hidden: true
+                });
+
+                placeholders.set(itemId, placeholder);
+
+                return placeholder
+            }
+        });
+
+        try {
+            await DockProjectionReconciler.reconcileProjection({
+                host,
+                nextConfig     : project(nextModel, firstPlaceholders),
+                placeholders   : firstPlaceholders,
+                preserveItemIds: ['beta'],
+                resolveItem    : itemId => panes[itemId]
+            });
+
+            let body = tab.getCardContainer(),
+                bar  = tab.getTabBar();
+
+            expect(body.items).toEqual([panes.alpha, panes.gamma]);
+            expect(bar.items.map(button => button.text)).toEqual(['Alpha', 'Gamma']);
+            expect(bar.sortZoneConfig.dockItemIds).toEqual(['alpha', 'gamma']);
+            expect(bar.sortZone.dockItemIds).toEqual(['alpha', 'gamma']);
+            expect(Boolean(panes.beta.parent?.items?.includes(panes.beta))).toBe(false);
+            expect(panes.beta.isDestroyed).toBeFalsy();
+            expect(originalButton.isDestroyed).toBeTruthy();
+            expect(paneDestroyCount).toBe(0);
+
+            const returnPlaceholders = new Map();
+
+            await DockProjectionReconciler.reconcileProjection({
+                host,
+                nextConfig  : project(model, returnPlaceholders),
+                placeholders: returnPlaceholders,
+                resolveItem : itemId => panes[itemId]
+            });
+
+            body = tab.getCardContainer();
+            bar  = tab.getTabBar();
+
+            expect(body.items).toEqual([panes.alpha, panes.beta, panes.gamma]);
+            expect(body.items[1]).toBe(panes.beta);
+            expect(bar.items.map(button => button.text)).toEqual(['Alpha', 'Beta', 'Gamma']);
+            expect(bar.items[1]).not.toBe(originalButton);
+            expect(bar.items[1].wrapperCls).toContain('neo-draggable');
+            expect(bar.sortZoneConfig.dockItemIds).toEqual(['alpha', 'beta', 'gamma']);
+            expect(bar.sortZone.dockItemIds).toEqual(['alpha', 'beta', 'gamma']);
+            expect(paneDestroyCount).toBe(0)
         } finally {
             host.destroy()
         }

--- a/test/playwright/unit/tab/plugin/Overflow.spec.mjs
+++ b/test/playwright/unit/tab/plugin/Overflow.spec.mjs
@@ -125,6 +125,36 @@ test.describe('Neo.tab.plugin.Overflow (re-entrancy contract)', () => {
         expect(plugin.measuring, 'no pass is left latched').toBe(false)
     });
 
+    test('a recapture restores hidden-button config and VDOM removal state atomically', async () => {
+        const
+            makeButton = id => ({
+                hidden: id === 'b2',
+                id,
+                setSilent(values) { Object.assign(this, values) },
+                show() {
+                    this.hidden = false;
+                    delete this.vdom.removeDom
+                },
+                vdom: {removeDom: true}
+            }),
+            buttons = [makeButton('b1'), makeButton('b2')],
+            plugin  = createPlugin(async ids => ids ? [{width: 10}, {width: 10}] : {width: 1000});
+
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        plugin.owner.items         = buttons;
+        plugin.owner.promiseUpdate = async () => {};
+        plugin.owner.update        = () => {};
+
+        await plugin.project(true);
+
+        buttons.forEach(button => {
+            expect(button.hidden).toBe(false);
+            expect(button.vdom.removeDom,
+                'silent visibility restoration must not strand a removeDom marker').toBeUndefined()
+        })
+    });
+
     test('all-fit teardown: syncControl destroys and nulls the control when the overflow set empties (so a later overflow recreates a fresh one, not a dead instance)', async () => {
         // A wide extent keeps nothing overflowing, so the create-time auto-project (onOwnerMounted) settles
         // cleanly with no control; await a tick so it does not race the direct syncControl call below.


### PR DESCRIPTION
Resolves #14772

Demo B now turns Neo's cross-window docking contracts into one public product journey: a real pointer drag moves the live Workbench component between two active OS-window workspaces, commits the target transfer once, suppresses the source-local drop once, and keeps both worker-owned documents truthful. The same reviewed screenplay drives the paced demo and a zero-pause spec replay; the live instance, heartbeat, and required target-document mount lifecycle remain observable throughout.

Evidence: L3 (real Chromium two-window gesture, remote-preview Escape, and paced-demo plus zero-pause-spec replay through Neural Link) → L3 required (all runtime transfer and continuity ACs). No runtime residuals; qualitative operator eyes-on remains queued below.

## Architecture

- Activates the reserved `cross-window` screenplay step only when a compatible host executor is injected. Script data stays JSON-first and semantic; the host alone resolves live windows, DOM surfaces, and screen geometry.
- Reuses `InteractionService`, `DockCrossWindowParticipation`, `DragCoordinator`, and `DockZoneModel.transferItem()` rather than creating a parallel drag path. The target publishes the atomic document pair; the source consumes one remote-drop suppression.
- Preserves worker instance identity while honoring the required browser-document mount lifecycle. `CounterPane` exposes stable instance, mount, window, and heartbeat witnesses without serializing state.
- Makes popup ownership synchronous with document publication and generation-guards projection continuation, so a close during settlement reattaches instead of stranding windowless truth.
- Extends the generic projection reconciler and tab-overflow repair only where the product journey falsified reusable tab-chrome lifecycle gaps.

## Contract Ledger

| Surface | Authority | Contract | Failure posture |
|---|---|---|---|
| `cross-window` tour step | `neo.tour.script.v1` + injected host seam | four semantic ids; structured settlement receipt; mode-stable log | absent/incompatible executor and malformed receipts fail closed |
| real gesture | existing `InteractionService` + dock participation | cold source readiness, remote preview, one target commit, one source suppression | readiness/geometry/preview mismatch cancels through the real Escape route |
| continuity witness | Demo B Workbench / `CounterPane` | same instance; heartbeat never resets; exactly one target-document mount | incomplete identity or lifecycle proof rejects the step |
| vessel ownership | worker-owned main/popup documents | ownership record publishes atomically and stale continuations are generation-invalidated | disconnect during settlement reattaches to main truth |
| replay settledness | host projection queue + live source chrome | paced demo and skipped-pause spec resolve the same document/chrome state | mismatched workspace, node, item order, or toolbar count fails closed before dispatch |

## Deltas

- Corrected the original “no remount” wording: crossing browser documents preserves the JavaScript instance and state, while the target document necessarily adds one mount lifecycle.
- Folded the remote-preview Escape challenge into this leaf and proves all gesture surfaces clear with neither document mutated.
- Added replay-hardening discovered by the second real run: parked-pane re-adoption creates draggable tab chrome atomically, hidden overflow headers repair VDOM removal markers, and TourRunner traps a pending host promise on destruction.
- Replaced timing-based replay confidence with a real zero-pause `spec` run and explicit source-document-to-tab-chrome validation.

## Test Evidence

- TourRunner + Demo B worker contracts: `npm run test-unit -- TourRunner DemoBWorkspace --workers=1` — 51 passed.
- Generic projection reconciliation: `npm run test-unit -- DockProjectionReconciler --workers=1` — 6 passed.
- Focused feature units including tab overflow: `npm run test-unit -- TourRunner Overflow DockProjectionReconciler DemoBWorkspace --workers=1` — 71 passed before the final lifecycle additions; the two changed suites were then refreshed by the 51-test run above.
- Real transfer + cancellation: `NEO_E2E_PORT=8130 npx playwright test agentos/DemoBCrossWindowDragNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — 2 passed.
- Full product replay: `NEO_E2E_PORT=8129 npx playwright test agentos/DemoBPerspectivesNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — 1 passed; first run paced `demo`, second run zero-pause `spec`, byte-identical logs.
- Existing tour smoke: `NEO_E2E_PORT=8125 npx playwright test dashboard/DockTourSmokeNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — 1 passed.
- Theme build: `npm run build-themes -- -n -e dev` — 635 development CSS outputs built non-interactively.
- Repository gates: `npm run agent-preflight -- --no-fix` — 15 files scanned, 0 ticket-archaeology violations, all requested gates passed.

## Post-Merge Validation

- [ ] Open Demo B from the merged `dev` build and perform one operator eyes-on pass for popup placement, captions, and transition legibility at release scale.
- [ ] Confirm the generated production theme bundle renders the Demo B chrome consistently with the validated development theme.

## Commit

- `ef258e09c` — real cross-window showcase, semantic runner activation, lifecycle hardening, and whitebox proof.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session adddb25d-fc36-4b08-b9a3-3a62a108cda1.
