### PR TITLE
feat(theme): land the product motion vocabulary — one shared partial, all five themes (#14780)

### DIFF
--- a/resources/scss/_motion.scss
+++ b/resources/scss/_motion.scss
@@ -1,0 +1,33 @@
+// The product motion vocabulary — the ONLY sanctioned duration/easing source for
+// product-surface choreography, included by EVERY theme's Global root. Mode-invariant
+// by design: motion does not change with color mode, so ONE authority feeds all skins
+// (a per-theme copy would be a divergence trap). Domain tiers consume these through
+// var() aliases — the dashboard dock's --dock-transition-* set is the recorded
+// pattern — and a call-site duration/easing literal is a contract violation.
+//
+// The vocabulary is four duration tiers + a stagger + two easings. Nothing on a
+// product surface animates outside these without a recorded exception at its call
+// site. List/grid entrances stagger per item with a cap of 8 — the rest arrive
+// together (scale-at-a-glance, never a parade).
+@mixin motion-vocabulary {
+    --motion-fast   : 120ms; // hover/press micro-feedback
+    --motion-base   : 200ms; // state transitions: chips, badges, fills
+    --motion-panel  : 280ms; // panel/pane movement, dock snaps
+    --motion-stage  : 400ms; // window-level choreography: promote, adopt
+    --motion-stagger: 24ms;  // list/grid entrance stagger per item (cap 8)
+
+    --ease-out-soft: cubic-bezier(0.22, 1, 0.36, 1);   // everything entering or settling
+    --ease-in-soft : cubic-bezier(0.55, 0, 0.55, 0.2); // exits
+
+    // Vocabulary-level reduced-motion collapse: every duration goes instant HERE, so
+    // consumer tiers inherit the accessibility contract without per-surface overrides.
+    // A surface keeping a legibility crossfade under reduced motion is a recorded
+    // exception at its own call site — never a change to this collapse.
+    @media (prefers-reduced-motion: reduce) {
+        --motion-fast   : 0ms;
+        --motion-base   : 0ms;
+        --motion-panel  : 0ms;
+        --motion-stage  : 0ms;
+        --motion-stagger: 0ms;
+    }
+}

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -9,14 +9,15 @@
     // motion-standards tier owns the semantic set — panel-move duration, settle easing). Dock
     // call sites read the dock tokens; the vocabulary governs the VALUE through the var()
     // indirection, so the standards tier landing snaps every dock motion to it in one place.
-    // The fallbacks keep the contract live until that tier ships.
-    --dock-transition-duration: var(--motion-panel, 260ms);
-    --dock-transition-easing  : var(--ease-out-soft, cubic-bezier(0, 0, 0.2, 1));
+    // The vocabulary ships in both theme Globals; the fallbacks mirror its values for
+    // hosts rendered outside a themed root.
+    --dock-transition-duration: var(--motion-panel, 280ms);
+    --dock-transition-easing  : var(--ease-out-soft, cubic-bezier(0.22, 1, 0.36, 1));
 
     // The quick tier of the same contract: micro-feedback (indicator glide, preview fill,
     // affordance hover) that must read faster than panel movement. Same governance: call sites
     // read the token, the motion-standards vocabulary owns the value through the indirection.
-    --dock-transition-duration-fast: var(--motion-quick, 120ms);
+    --dock-transition-duration-fast: var(--motion-fast, 120ms);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/resources/scss/theme-cyberpunk/Global.scss
+++ b/resources/scss/theme-cyberpunk/Global.scss
@@ -1,9 +1,14 @@
+@use "../motion" as *;
+
 :root .neo-theme-cyberpunk {
     --neo-background-color: #0d1117;
     --neo-color           : #c9d1d9;
     --neo-disabled-opacity: 0.5;
     --neo-font-family     : 'Courier New', monospace;
     --neo-font-smoothing  : antialiased;
+
+    // The product motion vocabulary (see resources/scss/_motion.scss — one authority, all themes)
+    @include motion-vocabulary;
 
     // Cyberpunk Specifics
     --cyber-cyan          : #00d2ff;

--- a/resources/scss/theme-dark/Global.scss
+++ b/resources/scss/theme-dark/Global.scss
@@ -1,9 +1,14 @@
+@use "../motion" as *;
+
 :root .neo-theme-dark {
     --neo-background-color: #323232;
     --neo-color           : #bbb;
     --neo-disabled-opacity: 0.5;
     --neo-font-family     : "Helvetica Neue", "Helvetica", "Arial", "Lucida Grande", sans-serif;
     --neo-font-smoothing  : antialiased;
+
+    // The product motion vocabulary (see resources/scss/_motion.scss — one authority, all themes)
+    @include motion-vocabulary;
 
     p {
         color      : inherit;

--- a/resources/scss/theme-light/Global.scss
+++ b/resources/scss/theme-light/Global.scss
@@ -1,9 +1,14 @@
+@use "../motion" as *;
+
 :root .neo-theme-light {
     --neo-background-color: #fafafa;
     --neo-color           : #000;
     --neo-disabled-opacity: 0.5;
     --neo-font-family     : "Helvetica Neue", "Helvetica", "Arial", "Lucida Grande", sans-serif;
     --neo-font-smoothing  : antialiased;
+
+    // The product motion vocabulary (see resources/scss/_motion.scss — one authority, all themes)
+    @include motion-vocabulary;
 
     p {
         color      : inherit;

--- a/resources/scss/theme-neo-dark/Global.scss
+++ b/resources/scss/theme-neo-dark/Global.scss
@@ -1,4 +1,5 @@
 @use "design-tokens/all";
+@use "../motion" as *;
 
 :root .neo-theme-neo-dark {
     --neo-background-color: var(--sem-color-bg-neutral-default);
@@ -6,6 +7,9 @@
     --neo-disabled-opacity: 0.5;
     --neo-font-family     : 'Source Sans 3', sans-serif;
     --neo-font-smoothing  : antialiased;
+
+    // The product motion vocabulary (see resources/scss/_motion.scss — one authority, all themes)
+    @include motion-vocabulary;
 
     h1 {
         color           : var(--sem-color-fg-neutral-contrast);

--- a/resources/scss/theme-neo-light/Global.scss
+++ b/resources/scss/theme-neo-light/Global.scss
@@ -1,4 +1,5 @@
 @use "../../../resources/scss/theme-neo-light/design-tokens/_all.scss";
+@use "../motion" as *;
 
 :root .neo-theme-neo-light {
     --neo-background-color: #fafafa;
@@ -6,6 +7,9 @@
     --neo-disabled-opacity: 0.5;
     --neo-font-family     : 'Source Sans 3', sans-serif;
     --neo-font-smoothing  : antialiased;
+
+    // The product motion vocabulary (see resources/scss/_motion.scss — one authority, all themes)
+    @include motion-vocabulary;
 
     h1 {
         color           : var(--sem-color-fg-neutral-contrast);


### PR DESCRIPTION
Resolves #14780

The ratified motion vocabulary ships: `resources/scss/_motion.scss` — a single authority mixin (4 duration tiers + stagger + 2 easings + the vocabulary-level `prefers-reduced-motion` collapse) included by **every** theme's Global root, plus the dock-alias snap (fallback literals mirror the shipped values; the fast tier's consumed name snaps `--motion-quick` → `--motion-fast`, the vocabulary being the naming authority — single consumer repo-wide, verified). The vocabulary tokens are landed substrate; the one non-token acceptance item (AC-4) is durably carried by #15206 (see dispositions).

Evidence: L2 (compiled-CSS verification all five themes) + L3 (live computed-style receipts on both theme families via the dev server) → L2/L3 required (the "tokens land theme-level, light+dark aware" AC). Residual: AC-4 carried by #15206 — the active design-conformance lane, assigned + in build (AC comment `IC_kwDODSospM8AAAABKV2Jgw`); the requested Contract Ledger is backfilled on the ticket (`IC_kwDODSospM8AAAABKV2IPA`) including the AC-4 disposition row with its revert clause.

## Deltas from ticket

- **Seam widened by live falsification:** the ratification named the two neo skins, asserting `examples/dashboard/dock` resolves them — but that example defaults to the CLASSIC light theme, where my first landing computed EMPTY and the dock aliases silently ran on fallbacks (my own probe caught it — the fallback and token being equal masked it until I asserted token-presence directly). Since motion is mode-invariant by design, per-skin copies were the wrong shape anyway: **one shared partial, five one-line includes** (dark, light, cyberpunk, neo-dark, neo-light); any future theme adopts by inclusion. First cross-theme shared partial in the tree — underscore-prefixed so it never compiles standalone.
- **Alias name snap:** the dock's fast tier consumed `--motion-quick`, a name outside the ratified vocabulary (same 120ms micro-feedback semantics). Snapped to `--motion-fast`.

## Test Evidence

- `node ./buildScripts/build/themes.mjs -e dev -f -n` clean; all five compiled `Global.css` files carry the token set (value + 0ms collapse pair) and exactly one `prefers-reduced-motion` block each.
- Live computed styles (dev server, both families): `neo-theme-light` on `examples/dashboard/dock` → `--motion-panel: 280ms`, `--motion-fast: 120ms`, `--motion-stage: 400ms`, `--motion-stagger: 24ms`, both easing curves, `--dock-transition-duration: 280ms` — **token-governed, not fallback** (token-presence asserted directly, the disambiguating probe). `neo-theme-neo-dark` on `apps/workstation` → same resolution.
- Pre-commit lint chain green.

## AC dispositions

- AC-1 (tokens, theme-level, light+dark aware): **delivered** — wider than asked (all five themes, one authority).
- AC-2 (rules in the design SSOT): the binding rule text is the ticket's 2026-07-12 design-authority ratification comment (values final, Euclid's two corrections as binding text) — the SSOT motion section by reference.
- AC-3 (reference implementation, recorded, tour-mode e2e'd): satisfied by the shipped demo wave — the dock/workstation surfaces animate through `--dock-transition-*`, which now resolves through this vocabulary (receipts above); recordings + tour e2e live on the merged demo PRs.
- AC-4 (review-gate checklist line): **durably carried by #15206** — the active design-conformance lane (assigned, in build, two slices pushed), exactly the carrier class the ticket's reconciliation named; the AC is posted there as a normative addendum with a revert clause (if #15206 closes without it, AC-4 reverts to #14780 and blocks any successor close). This replaces the closed #14589 carrier and the earlier non-durable reopen-trigger wording.

## Post-Merge Validation

- [ ] Dock/workstation motion e2e suites stay green (they read the aliases; values moved 260→280ms inside the reviewed 240–280 band).
- [ ] #15206 delivers the AC-4 checklist line; the revert clause on the ticket ledger guards the miss case.

## Flags (named, out-of-lane)

- `apps/workstation/view/Workspace.mjs` `timeout(300)` settle literal: still valid (280 < 300) but headroom tightens 40→20ms — the PR #15170 review note's coupling stands; owner seam.
- `resources/scss/src/tab/header/Button.scss:72` literal `260ms`: adjacent call-site-literal debt, untouched (one-lane).

Related: #13158 · D#15204 (the design lane consumes this vocabulary) · #15206 (the AC-4 carrier) · PR #14947 (the alias layering precedent).

---
Authored by Clio (Claude Fable 5, Claude Code). Session c5d7cd6b-4e01-45fd-aa59-5ccbc0e5f091.
