### PR TITLE
fix(hooks): honor mid-chain operator messages in stop-hook classification (#14440)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -12,8 +12,12 @@
  *
  * Mechanism:
  *  - `operatorInLoop` (the one allow) is determined EXTERNALLY by `isOperatorInLoop`, never
- *    self-declared, so it cannot be gamed: the prompting message must NOT be a `stop_hook_active`
- *    forced continuation, NOT a `[WAKE]` autonomous injection, and must be confirmable (fail-closed).
+ *    self-declared, so it cannot be gamed: the prompting candidate comes from the human-filtered
+ *    transcript walk ({@link extractLatestHumanUserTextFromJsonl} — harness-injected `isMeta` records
+ *    can never masquerade as dialogue), must NOT be a `[WAKE]` autonomous injection, and must be
+ *    confirmable (fail-closed). Inside a forced continuation chain (`stop_hook_active`), a genuine
+ *    operator message that arrived MID-CHAIN counts as dialogue evidence — the hook's contract could
+ *    previously never confirm it and refused live-dialogue terminals as autonomous.
  *  - Otherwise: ENFORCE → block; DRY-RUN → would-block (log only — the audit path). The lane-state
  *    `verdict` (`parseLaneState` → `validateLaneStateTerminal`) no longer gates the action — it only
  *    supplies the `reason` for the injected directive.
@@ -383,6 +387,62 @@ export function extractLastUserTextFromJsonl(jsonl = '') {
 }
 
 /**
+ * @summary Harness-marker user records — prose the harness authors ABOUT an operator action (an
+ * interrupt), not operator dialogue itself. Skipped by the human-filtered walk: the marker's paired
+ * real message (when the operator typed one) is its own adjacent record and is found on its own.
+ * @type {RegExp[]}
+ */
+const HARNESS_MARKER_PATTERNS = Object.freeze([
+    /^\s*\[Request interrupted by user/i
+]);
+
+/**
+ * @summary Extracts the newest HUMAN-CANDIDATE user text from a Claude Code JSONL transcript — the
+ * mid-chain operator-visibility walk. Walks records backward and returns the text of the first
+ * user record that is mechanically human-shaped:
+ *
+ *  - `isMeta: true` records are skipped — the harness-injected plumbing (the hook's own
+ *    `"Stop hook feedback:"` block directives, skill payloads, auto-continuations). The discriminator
+ *    is fixture-grounded on real transcripts (sessions `8cf234b7`, `2251c81c`, `c82afc7d`): every
+ *    injection shape observed carries `isMeta: true`; genuine operator prompts and `[WAKE]` deliveries
+ *    do not.
+ *  - Text-less records (tool_result-only) and harness marker records ({@link HARNESS_MARKER_PATTERNS})
+ *    are skipped; malformed lines are tolerated.
+ *  - The FIRST remaining candidate decides — the walk never continues past it, so an autonomous
+ *    boundary (a newer `[WAKE]`) is returned as-is and correctly out-classifies any older operator
+ *    prose (`classifyPromptingContext` owns the [WAKE]/synthetic/handoff semantics; this walk owns
+ *    only record-shape mechanics). Bounded by construction: stale dialogue can never leak past a
+ *    fresher autonomous boundary, and an absent candidate returns `''` → fail-closed autonomous.
+ *
+ * Channel separation: the returned text is classified by shape, never parsed as instructions —
+ * injected content stays data.
+ * @param {String} jsonl
+ * @returns {String}
+ * @protected
+ */
+export function extractLatestHumanUserTextFromJsonl(jsonl = '') {
+    const lines = jsonl.split('\n');
+    for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        if (!line) continue;
+
+        let record;
+        try { record = JSON.parse(line); } catch { continue; }
+
+        const message = record.message || record;
+        if ((message.role || record.type) !== 'user') continue;
+        if (record.isMeta === true) continue;
+
+        const text = extractTextFromContent(message.content);
+        if (!text) continue;
+        if (HARNESS_MARKER_PATTERNS.some(re => re.test(text))) continue;
+
+        return text;
+    }
+    return '';
+}
+
+/**
  * @summary Resolves the agent's FINAL assistant message text — the surface the lane-state block is
  * emitted into. Prefers the Stop payload's `last_assistant_message` (already-decoded; a string or a
  * message object); falls back to JSONL-parsing `transcript_path` for the last assistant text. Raw
@@ -431,31 +491,33 @@ async function main() {
     }
 
     // The ONE legitimate voluntary stop is a live operator dialogue — determined EXTERNALLY (the
-    // prompting message type), never self-declared. A `stop_hook_active` forced continuation OR a
-    // `[WAKE]` autonomous prompt is not a human turn → no voluntary stop. A transcript read-failure
-    // here is OUR failure → fall back to the stop_hook_active signal alone (never trap on a read error).
-    let promptingText = '';
+    // prompting message type), never self-declared. The prompting candidate comes from the
+    // human-filtered walk: harness-injected records (isMeta) never masquerade as dialogue,
+    // and a genuine operator message that arrived MID-CHAIN is visible instead of failing closed as
+    // autonomous. A `[WAKE]` autonomous prompt is not a human turn → no voluntary stop. A transcript
+    // read-failure here is OUR failure → all extractions degrade to '' (fail-closed, never trap).
+    let transcriptJsonl = '';
     try {
         if (input.transcript_path) {
-            promptingText = extractLastUserTextFromJsonl(fs.readFileSync(input.transcript_path, 'utf8'));
+            transcriptJsonl = fs.readFileSync(input.transcript_path, 'utf8');
         }
     } catch (e) {
-        // best-effort; isOperatorInLoop falls back to stop_hook_active when promptingText is empty
+        // best-effort; classification falls back to stop_hook_active when promptingText is empty
     }
+    const promptingText = extractLatestHumanUserTextFromJsonl(transcriptJsonl);
     let evidenceText = '';
     try {
-        if (input.transcript_path) {
-            evidenceText = collectLaneStateToolEvidenceFromJsonl(fs.readFileSync(input.transcript_path, 'utf8'));
-        }
+        evidenceText = collectLaneStateToolEvidenceFromJsonl(transcriptJsonl);
     } catch {
         // Missing transcript evidence is an agent-proof failure, not a hook failure.
         evidenceText = '';
     }
     const promptContext = classifyPromptingContext({
-        stopHookActive: !!input.stop_hook_active,
-        promptingText
+        stopHookActive            : !!input.stop_hook_active,
+        promptingText,
+        promptingTextHumanFiltered: true
     });
-    const {autonomousHandoff, handoffReason, handoffWindowMs, operatorInLoop} = promptContext;
+    const {autonomousHandoff, handoffReason, handoffWindowMs, midChainOperator, operatorInLoop} = promptContext;
 
     const deferenceDecision = decideDeferenceStopHookAction(finalText, {operatorInLoop, enforcing: ENFORCING});
     if (deferenceDecision) {
@@ -463,7 +525,7 @@ async function main() {
               session = input.session_id || '?';
 
         if (deferenceDecision.action === 'block') {
-            auditLog(`BLOCK (session=${session}, operatorInLoop=${operatorInLoop}, autonomousHandoff=${autonomousHandoff}, handoffReason=${handoffReason || 'none'}, handoffWindowMs=${handoffWindowMs ?? 'none'}): ${reason}`);
+            auditLog(`BLOCK (session=${session}, operatorInLoop=${operatorInLoop}, midChainOperator=${midChainOperator}, autonomousHandoff=${autonomousHandoff}, handoffReason=${handoffReason || 'none'}, handoffWindowMs=${handoffWindowMs ?? 'none'}): ${reason}`);
             process.stdout.write(JSON.stringify({
                 decision: 'block',
                 reason  : deferenceDecision.reason
@@ -471,7 +533,7 @@ async function main() {
             return;
         }
 
-        auditLog(`WOULD-BLOCK (session=${session}, operatorInLoop=${operatorInLoop}, autonomousHandoff=${autonomousHandoff}, handoffReason=${handoffReason || 'none'}, handoffWindowMs=${handoffWindowMs ?? 'none'}): ${reason}`);
+        auditLog(`WOULD-BLOCK (session=${session}, operatorInLoop=${operatorInLoop}, midChainOperator=${midChainOperator}, autonomousHandoff=${autonomousHandoff}, handoffReason=${handoffReason || 'none'}, handoffWindowMs=${handoffWindowMs ?? 'none'}): ${reason}`);
         process.exit(0);
     }
 
@@ -504,7 +566,7 @@ async function main() {
         // the injected directive names the SPECIFIC relapse-phrase back (a sharper mirror). Never gates
         // the block (the decision is unchanged) — only enriches the reason.
         const holdMatches = scanHoldLexicon(finalText);
-        auditLog(`BLOCK (session=${session}, operatorInLoop=${operatorInLoop}, autonomousHandoff=${autonomousHandoff}, handoffReason=${handoffReason || 'none'}, handoffWindowMs=${handoffWindowMs ?? 'none'}): ${reason}${holdMatches.length ? ` [hold-costume: ${holdMatches.join(', ')}]` : ''}`);
+        auditLog(`BLOCK (session=${session}, operatorInLoop=${operatorInLoop}, midChainOperator=${midChainOperator}, autonomousHandoff=${autonomousHandoff}, handoffReason=${handoffReason || 'none'}, handoffWindowMs=${handoffWindowMs ?? 'none'}): ${reason}${holdMatches.length ? ` [hold-costume: ${holdMatches.join(', ')}]` : ''}`);
         // Block the stop + inject the curated no-hold-state directive — Claude uses the injected
         // `reason` as its next instruction; the audit log keeps the terse trigger cause.
         // Exit only AFTER stdout drains so the decision JSON is never truncated on a pipe.
@@ -513,7 +575,7 @@ async function main() {
         return;
     }
 
-    auditLog(`${action === 'would-block' ? 'WOULD-BLOCK' : 'ALLOW'} (session=${session}, operatorInLoop=${operatorInLoop}, autonomousHandoff=${autonomousHandoff}, handoffReason=${handoffReason || 'none'}, handoffWindowMs=${handoffWindowMs ?? 'none'}): ${reason}`);
+    auditLog(`${action === 'would-block' ? 'WOULD-BLOCK' : 'ALLOW'} (session=${session}, operatorInLoop=${operatorInLoop}, midChainOperator=${midChainOperator}, autonomousHandoff=${autonomousHandoff}, handoffReason=${handoffReason || 'none'}, handoffWindowMs=${handoffWindowMs ?? 'none'}): ${reason}`);
     process.exit(0);
 }
 

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -89,16 +89,46 @@ export function isSyntheticPromptingText(text = '') {
 }
 
 /**
- * @summary Classifies the prompting text into operator-dialogue vs autonomous handoff.
- * @param {{stopHookActive: Boolean, promptingText: String}} signals
- * @returns {{operatorInLoop: Boolean, autonomousHandoff: Boolean, handoffReason: String|null, handoffWindowMs: Number|null}}
+ * @summary The shared operator-dialogue text gates — non-empty, not a `[WAKE]` autonomous injection,
+ * not synthetic lifecycle noise, and not an autonomous-handoff delegation. This is the single
+ * authority both the turn-prompt path and the mid-chain path classify against, so the two
+ * paths cannot drift on what counts as dialogue. Pure + total; a non-string fails closed.
+ * @param {String} text Prompting-text candidate.
+ * @returns {Boolean}
  */
-export function classifyPromptingContext({stopHookActive, promptingText = ''}) {
-    const handoff   = detectAutonomousHandoffPrompt(promptingText),
-          synthetic = isSyntheticPromptingText(promptingText);
+export function isOperatorDialogueText(text = '') {
+    return typeof text === 'string' && !!text.trim() &&
+        !/^\s*\[WAKE\]/.test(text) &&
+        !isSyntheticPromptingText(text) &&
+        !detectAutonomousHandoffPrompt(text).active;
+}
+
+/**
+ * @summary Classifies the prompting text into operator-dialogue vs autonomous handoff.
+ *
+ * Mid-chain operator visibility: inside a forced continuation chain
+ * (`stopHookActive`), a genuine operator message that arrived mid-chain is dialogue evidence per the
+ * hook's own contract — but ONLY when the adapter attests via `promptingTextHumanFiltered` that its
+ * extraction mechanically excluded harness-injected records (hook feedback, skill payloads,
+ * auto-continuations; the Claude adapter's `isMeta` discriminator). Without the attestation a chained
+ * turn fails closed as autonomous exactly as before, so adapters with cruder extraction (Codex) keep
+ * today's semantics untouched. The candidate text is classified by SHAPE only ({@link isOperatorDialogueText});
+ * its content is never parsed as instructions (L2 channel separation — injected prose stays data).
+ * @param {Object} signals
+ * @param {Boolean} signals.stopHookActive True on a forced-continuation (chained) stop event.
+ * @param {String} [signals.promptingText=''] Newest prompting-boundary candidate text.
+ * @param {Boolean} [signals.promptingTextHumanFiltered=false] Adapter attestation that `promptingText`
+ * came from a mechanically human-filtered walk (non-meta, non-marker records only). Fail-closed default.
+ * @returns {{operatorInLoop: Boolean, midChainOperator: Boolean, autonomousHandoff: Boolean, handoffReason: String|null, handoffWindowMs: Number|null}}
+ */
+export function classifyPromptingContext({stopHookActive, promptingText = '', promptingTextHumanFiltered = false}) {
+    const handoff          = detectAutonomousHandoffPrompt(promptingText),
+          dialogueText     = isOperatorDialogueText(promptingText),
+          midChainOperator = !!stopHookActive && promptingTextHumanFiltered && dialogueText;
 
     return {
-        operatorInLoop   : !stopHookActive && !!promptingText.trim() && !/^\s*\[WAKE\]/.test(promptingText) && !synthetic && !handoff.active,
+        operatorInLoop   : (!stopHookActive && dialogueText) || midChainOperator,
+        midChainOperator,
         autonomousHandoff: handoff.active,
         handoffReason    : handoff.reason,
         handoffWindowMs  : handoff.windowMs
@@ -127,13 +157,14 @@ export function parseOutcomeToVerdict({descriptor, parseError}, validate) {
 /**
  * @summary Detects whether a genuine human OPERATOR prompted this turn — the one signal that makes a
  * voluntary stop legitimate. Determined externally so it cannot be self-declared: a turn is operator
- * driven iff it is not a forced continuation, its prompting message is not an autonomous `[WAKE]`
- * injection, and a prompt is actually confirmable.
- * @param {{stopHookActive: Boolean, promptingText: String}} signals
+ * driven iff its prompting message is not an autonomous `[WAKE]` injection, a prompt is actually
+ * confirmable, and — on a forced continuation — the adapter attests the candidate came from a
+ * human-filtered walk ({@link classifyPromptingContext} mid-chain visibility).
+ * @param {{stopHookActive: Boolean, promptingText: String, promptingTextHumanFiltered: Boolean}} signals
  * @returns {Boolean}
  */
-export function isOperatorInLoop({stopHookActive, promptingText = ''}) {
-    return classifyPromptingContext({stopHookActive, promptingText}).operatorInLoop;
+export function isOperatorInLoop({stopHookActive, promptingText = '', promptingTextHumanFiltered = false}) {
+    return classifyPromptingContext({stopHookActive, promptingText, promptingTextHumanFiltered}).operatorInLoop;
 }
 
 /**

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -1,6 +1,7 @@
 import {test, expect}                                                                              from '@playwright/test';
 import {composeBlockDirective, composeDeferenceDirective, decideHookAction, isOperatorInLoop, parseOutcomeToVerdict,
         extractFinalAssistantText, extractLastAssistantTextFromJsonl, extractLastUserTextFromJsonl,
+        extractLatestHumanUserTextFromJsonl,
         formatLifecycleBoard, formatGoldenPathDirection, formatHoldCostumeCallout} from '../../../../.claude/hooks/laneStateStopHook.mjs';
 import {spawn} from 'node:child_process';
 import fs      from 'node:fs';
@@ -297,6 +298,71 @@ test.describe('laneStateStopHook — input resolution (assistant final text + pr
     });
 });
 
+/**
+ * Coverage for the human-filtered walk — the mid-chain operator-visibility extractor. Fixture
+ * shapes mirror REAL transcript records (sessions `8cf234b7` / `2251c81c` / `c82afc7d`): the hook's own
+ * block directives and skill payloads are `isMeta: true` user records; genuine operator prompts and
+ * `[WAKE]` deliveries are non-meta. The walk owns record-shape mechanics ONLY — [WAKE]/synthetic/handoff
+ * semantics stay in `classifyPromptingContext` (single authority, exercised via the integration pair).
+ */
+test.describe('laneStateStopHook — extractLatestHumanUserTextFromJsonl (#14440 human-filtered walk)', () => {
+    const metaFeedback = JSON.stringify({type: 'user', isMeta: true, message: {role: 'user',
+              content: 'Stop hook feedback:\nTurn-end refused — L3_No_Hold_State: there is no hold state, and you do not get to stop.'}}),
+          metaSkill     = JSON.stringify({type: 'user', isMeta: true, message: {role: 'user',
+              content: 'Base directory for this skill: /repo/.claude/skills/pull-request\n\n# Pull Request Skill'}}),
+          operatorMsg   = JSON.stringify({type: 'user', message: {role: 'user',
+              content: 'full stop. we need to talk about the release notes.'}}),
+          wakeMsg       = JSON.stringify({type: 'user', message: {role: 'user',
+              content: '[WAKE][priority:normal] 1 events for @neo-opus-vega'}}),
+          interruptMark = JSON.stringify({type: 'user', message: {role: 'user',
+              content: '[Request interrupted by user]'}}),
+          toolResult    = JSON.stringify({type: 'user', message: {role: 'user',
+              content: [{type: 'tool_result', tool_use_id: 'x', content: 'r'}]}}),
+          assistant     = JSON.stringify({type: 'assistant', message: {role: 'assistant',
+              content: [{type: 'text', text: 'working…'}]}});
+
+    test('mid-chain operator message beneath hook-feedback records is found (the 2251c81c shape)', () => {
+        const jsonl = [wakeMsg, assistant, metaFeedback, operatorMsg, metaFeedback, assistant].join('\n');
+        expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('full stop. we need to talk about the release notes.');
+    });
+
+    test('isMeta records (hook feedback + skill payloads) can never masquerade as the prompting boundary', () => {
+        const jsonl = [operatorMsg, assistant, metaSkill, metaFeedback].join('\n');
+        expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('full stop. we need to talk about the release notes.');
+    });
+
+    test('a NEWER [WAKE] is the decisive candidate — stale operator prose never leaks past it', () => {
+        const jsonl = [operatorMsg, assistant, metaFeedback, wakeMsg, assistant].join('\n');
+        expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('[WAKE][priority:normal] 1 events for @neo-opus-vega');
+        // integration pair: the classifier rejects the wake candidate → chained turn stays autonomous
+        expect(isOperatorInLoop({
+            stopHookActive            : true,
+            promptingText             : extractLatestHumanUserTextFromJsonl(jsonl),
+            promptingTextHumanFiltered: true
+        })).toBe(false);
+    });
+
+    test('interrupt markers are harness prose — skipped; the adjacent real message is found', () => {
+        const jsonl = [operatorMsg, assistant, interruptMark].join('\n');
+        expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('full stop. we need to talk about the release notes.');
+    });
+
+    test('tool_result-only + malformed lines are tolerated; no candidate → empty string (fail-closed)', () => {
+        expect(extractLatestHumanUserTextFromJsonl([toolResult, '{ not json }', assistant].join('\n'))).toBe('');
+        expect(extractLatestHumanUserTextFromJsonl('')).toBe('');
+        expect(extractLatestHumanUserTextFromJsonl([metaFeedback, metaSkill].join('\n'))).toBe('');
+    });
+
+    test('integration pair: mid-chain operator rescue end-to-end through the pure classifier', () => {
+        const jsonl = [wakeMsg, assistant, metaFeedback, operatorMsg, assistant].join('\n');
+        expect(isOperatorInLoop({
+            stopHookActive            : true,
+            promptingText             : extractLatestHumanUserTextFromJsonl(jsonl),
+            promptingTextHumanFiltered: true
+        })).toBe(true);
+    });
+});
+
 test.describe('laneStateStopHook — end-to-end (spawned hook against the real Stop payload)', () => {
     /**
      * @summary Spawns the real hook with a Stop payload + a temp audit-log dir; returns `{stdout, log}`.
@@ -307,7 +373,7 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
      * @param {{enforce: Boolean, promptingText: (String|null), stopHookActive: Boolean, toolCommand: String|null}} [opts]
      * @returns {Promise<{stdout: String, log: String}>}
      */
-    function runHook(finalText, {enforce = false, promptingText = null, stopHookActive = false, lifecycleState = null, toolCommand = null} = {}) {
+    function runHook(finalText, {enforce = false, promptingText = null, stopHookActive = false, lifecycleState = null, toolCommand = null, transcriptRecords = null} = {}) {
         return new Promise((resolve, reject) => {
             const dir            = fs.mkdtempSync(path.join(os.tmpdir(), 'lane-hook-e2e-')),
                   transcriptPath = path.join(dir, 'transcript.jsonl'),
@@ -318,7 +384,13 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
                 fs.writeFileSync(path.join(dir, 'lifecycle-state.json'), JSON.stringify(lifecycleState), 'utf8');
             }
 
-            if (promptingText !== null) {
+            if (transcriptRecords !== null) {
+                // Chain-shape fixtures: write the given records verbatim + the final assistant text.
+                const records = transcriptRecords.map(record => JSON.stringify(record));
+                records.push(JSON.stringify({type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: finalText}]}}));
+                fs.writeFileSync(transcriptPath, records.join('\n') + '\n');
+                payload.transcript_path = transcriptPath;
+            } else if (promptingText !== null) {
                 const records = [
                     JSON.stringify({type: 'user', message: {role: 'user', content: promptingText}})
                 ];
@@ -455,10 +527,46 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
         expect(decision.reason).toContain('Unknown laneContinuation');
     });
 
-    test('stop_hook_active (forced continuation) + enforce → BLOCK (keeps refusing, no auto-allow)', async () => {
+    // BEHAVIORAL FLIP (mid-chain operator visibility): the previous expectation here was BLOCK — the
+    // literal defect (a genuine operator record inside a forced chain refused as autonomous). Under
+    // mid-chain operator visibility, a mechanically human-shaped operator record IS live dialogue.
+    test('stop_hook_active + genuine mid-chain operator record → ALLOW (#14440 Defect-B AC)', async () => {
         const {stdout, log} = await runHook(validTerminal, {enforce: true, promptingText: 'please do X', stopHookActive: true});
+        expect(log).toContain('ALLOW');
+        expect(log).toContain('midChainOperator=true');
+        expect(stdout).toBe('');
+    });
+
+    test('stop_hook_active chain WITHOUT an operator record (wake + hook-feedback plumbing) → still BLOCK', async () => {
+        const {stdout, log} = await runHook(validTerminal, {
+            enforce          : true,
+            stopHookActive   : true,
+            transcriptRecords: [
+                {type: 'user', message: {role: 'user', content: '[WAKE][priority:normal] 1 events for @neo-opus-vega'}},
+                {type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'driving the lane…'}]}},
+                {type: 'user', isMeta: true, message: {role: 'user', content: 'Stop hook feedback:\nTurn-end refused — L3_No_Hold_State: there is no hold state, and you do not get to stop.'}}
+            ]
+        });
         expect(log).toContain('BLOCK');
+        expect(log).toContain('midChainOperator=false');
         expect(JSON.parse(stdout).decision).toBe('block');
+    });
+
+    test('mid-chain injected operator message beneath hook feedback → ALLOW (the 2251c81c shape)', async () => {
+        const {stdout, log} = await runHook('Understood — standing by for your direction.', {
+            enforce          : true,
+            stopHookActive   : true,
+            transcriptRecords: [
+                {type: 'user', message: {role: 'user', content: '[WAKE][priority:normal] 1 events for @neo-opus-vega'}},
+                {type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'driving the lane…'}]}},
+                {type: 'user', isMeta: true, message: {role: 'user', content: 'Stop hook feedback:\nTurn-end refused — L3_No_Hold_State: there is no hold state, and you do not get to stop.'}},
+                {type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'continuing…'}]}},
+                {type: 'user', message: {role: 'user', content: 'full stop. we need to talk about the release notes.'}}
+            ]
+        });
+        expect(log).toContain('ALLOW');
+        expect(log).toContain('midChainOperator=true');
+        expect(stdout).toBe('');
     });
 
     test('ENFORCE block injects the Golden Path release-goal direction from lifecycle-state (#13751)', async () => {

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -6,6 +6,7 @@ import {
     decideStopHookAction,
     detectAutonomousHandoffPrompt,
     extractAutonomousHandoffWindowMs,
+    isOperatorDialogueText,
     isOperatorInLoop,
     isSyntheticPromptingText,
     LANE_STATE_SCHEMA_HINT,
@@ -202,6 +203,85 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision
         expect(decision.action).toBe('block');
         expect(decision.phrase).toBe('your move');
         expect(decision.reason).toContain('deference phrase "your move"');
+    });
+});
+
+/**
+ * Coverage for mid-chain operator visibility (the operator-prompt-blindness defect): inside a forced
+ * continuation chain, a genuine operator message that arrived mid-chain classifies as live dialogue —
+ * but ONLY under the adapter's `promptingTextHumanFiltered` attestation that harness-injected records
+ * were mechanically excluded. Without the attestation (the Codex adapter's current shape) chained turns
+ * keep the fail-closed autonomous semantics byte-for-byte. Fixture corpus: sessions `2251c81c`,
+ * `c82afc7d`, `8cf234b7` (operator messages injected mid-chain, invisible to the previous classifier).
+ */
+test.describe('ai/scripts/lifecycle/stopHookDecision — #14440 mid-chain operator visibility', () => {
+    test('isOperatorDialogueText: the shared dialogue gates (single authority for both paths)', () => {
+        expect(isOperatorDialogueText('please stop and report')).toBe(true);
+        expect(isOperatorDialogueText('')).toBe(false);
+        expect(isOperatorDialogueText('   ')).toBe(false);
+        expect(isOperatorDialogueText('[WAKE][priority:high] 2 events')).toBe(false);
+        expect(isOperatorDialogueText('  [WAKE] leading whitespace')).toBe(false);
+        expect(isOperatorDialogueText('<hook_prompt hook_run_id="stop:1">noise</hook_prompt>')).toBe(false);
+        expect(isOperatorDialogueText('<turn_aborted>interrupted</turn_aborted>')).toBe(false);
+        expect(isOperatorDialogueText('nightshift mode for the next 5h, freely choose')).toBe(false);
+        expect(isOperatorDialogueText(null)).toBe(false);
+        expect(isOperatorDialogueText(undefined)).toBe(false);
+    });
+
+    test('chained + attested + genuine operator text → live dialogue (the Defect-B AC)', () => {
+        const context = classifyPromptingContext({
+            stopHookActive            : true,
+            promptingText             : 'full stop. we need to talk about the release notes.',
+            promptingTextHumanFiltered: true
+        });
+        expect(context.operatorInLoop).toBe(true);
+        expect(context.midChainOperator).toBe(true);
+    });
+
+    test('chained + attested + [WAKE] candidate → autonomous (a newer wake out-classifies older dialogue)', () => {
+        const context = classifyPromptingContext({
+            stopHookActive            : true,
+            promptingText             : '[WAKE][priority:normal] 1 events for @neo-opus-vega',
+            promptingTextHumanFiltered: true
+        });
+        expect(context.operatorInLoop).toBe(false);
+        expect(context.midChainOperator).toBe(false);
+    });
+
+    test('chained + attested + synthetic / handoff / empty candidates all fail closed', () => {
+        for (const promptingText of [
+            '<hook_prompt hook_run_id="stop:2">reminder</hook_prompt>',
+            "nightshift mode from here on for the next 5h, you can freely choose. I merge when I get back.",
+            ''
+        ]) {
+            const context = classifyPromptingContext({stopHookActive: true, promptingText, promptingTextHumanFiltered: true});
+            expect(context.operatorInLoop).toBe(false);
+            expect(context.midChainOperator).toBe(false);
+        }
+    });
+
+    test('chained + NOT attested + genuine text → unchanged fail-closed autonomous (Codex-shape guard)', () => {
+        const context = classifyPromptingContext({
+            stopHookActive: true,
+            promptingText : 'a real human question'
+        });
+        expect(context.operatorInLoop).toBe(false);
+        expect(context.midChainOperator).toBe(false);
+        expect(isOperatorInLoop({stopHookActive: true, promptingText: 'a real human question'})).toBe(false);
+    });
+
+    test('NON-chained turn: attestation adds nothing — midChainOperator stays false on the plain dialogue path', () => {
+        const context = classifyPromptingContext({
+            stopHookActive            : false,
+            promptingText             : 'please review the PR',
+            promptingTextHumanFiltered: true
+        });
+        expect(context.operatorInLoop).toBe(true);
+        expect(context.midChainOperator).toBe(false);
+    });
+
+    test('isOperatorInLoop passes the attestation through (chained operator rescue end-to-end)', () => {
+        expect(isOperatorInLoop({stopHookActive: true, promptingText: 'please stop', promptingTextHumanFiltered: true})).toBe(true);
     });
 });
 


### PR DESCRIPTION
Resolves #14440

The lane-state Stop hook can now see a genuine operator message that arrived inside a forced continuation chain, so live-dialogue terminals stop being refused as autonomous (#14420 Defect-B). The prompting candidate now comes from a human-filtered transcript walk: a new `extractLatestHumanUserTextFromJsonl` walks user records backward and mechanically skips harness-injected plumbing (`isMeta: true` — the hook's own `Stop hook feedback:` directives, skill payloads, auto-continuations) and interrupt-marker prose, returning the newest human-shaped candidate. The shared classifier gains an `isOperatorDialogueText` single-authority gate set plus an adapter attestation flag (`promptingTextHumanFiltered`): only an adapter that attests its extraction is mechanically human-filtered may classify a chained turn as dialogue — the Codex adapter passes no attestation and keeps today's fail-closed semantics byte-for-byte (its 37-spec suite passes unchanged). Fail-closed is preserved everywhere: no candidate, a `[WAKE]`, synthetic lifecycle noise, or an autonomous-handoff delegation all classify autonomous, and a newer `[WAKE]` out-classifies older operator prose by construction (the walk returns the newest candidate only, so stale dialogue can never leak past a fresher autonomous boundary). Candidate text is classified by record shape only and never parsed as instructions (L2 channel separation). The same extractor closes the inverse hole on the non-chained path: an `isMeta` skill payload can no longer masquerade as an operator prompt and false-ALLOW a wake turn. Audit lines now carry `midChainOperator=` for dry-run observability.

Evidence: L2 (spawned real hook over transcript fixtures mirroring real session records — `8cf234b7`, `2251c81c`, `c82afc7d`) → L3 (live-session chain classification observable in the dry-run audit log). Residual: post-merge live audit observation [#14440].

## Deltas from ticket

- **Fixture-shape correction:** the ticket describes operator messages "delivered as injected mid-turn messages (`The user sent a new message while you were working`)". Against the real `2251c81c` transcript, that wrapper phrase exists only in UI/assistant prose — the transcript records the queued operator message as a plain non-meta user record (queue-operation records carry the enqueue/dequeue metadata separately). The mechanical reality is simpler than the ticket's premise: `isMeta` is the injection discriminator, verified across all three corpus sessions. The spec fixtures mirror the real record shapes accordingly.
- **Stale prescription paragraph:** the ticket references "transcript-walking extractors … from #14438's PR" — PR #14439 closed unmerged (operator-directed premise rejection), so those extractors never landed; only `collectLaneStateToolEvidenceFromJsonl` exists on dev (via #14823). The chain-scan extractor here is new work, per the ticket's "claimer settles specifics" clause.
- **One expectation flip, which is the AC:** the pre-existing e2e test `stop_hook_active + genuine operator prompt → BLOCK` encoded Defect-B literally. It now expects ALLOW with `midChainOperator=true` — this is AC-1 delivered, not collateral (flagged inline in the spec).
- **Inverse-defect fix in passing:** the human-filtered walk also prevents `isMeta` skill payloads from classifying a WAKE turn as operator dialogue on the FIRST terminal (a latent false-ALLOW in the previous last-user-record extraction). Covered by the extractor specs.

## Test Evidence

- Hook suites: `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/hooks/stopHookDecision.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs --workers=1` — **96 passed** (includes 7 new classifier specs, 6 new extractor specs, 3 new/flipped spawned-hook e2e chain cases).
- Codex sibling untouched-behavior proof: `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs --workers=1` — **37 passed** (no attestation → fail-closed default → byte-identical semantics).
- Directly touched surfaces: `ai/scripts/lifecycle/stopHookDecision.mjs`: stopHookDecision.spec.mjs (classifier gates, attestation guard, backward-compat) | `.claude/hooks/laneStateStopHook.mjs`: laneStateStopHook.spec.mjs (extractor + spawned e2e chain shapes).
- Source and PR-body gates: `npm run agent-preflight -- --no-fix <touched files> --pr-body <this file>` — passed before commit.

## Post-Merge Validation

- [ ] Observe a live forced-continuation chain in the dry-run audit log (`lane-state-stop-hook.log`) after an operator message arrives mid-chain: the terminal line carries `midChainOperator=true` + ALLOW instead of a refused live-dialogue terminal.
- [ ] Confirm no false-ALLOW appears on wake-opened turns that invoke skills (the inverse-defect guard): skill-payload turns keep `operatorInLoop=false`.

## Evolution

The initial design carried a separate `midChainUserText` classifier input extracted by a second transcript walk. Reading the real corpora collapsed it: the human-filtered walk IS the correct prompting-boundary extraction for both the chained and non-chained paths (one extraction, one attestation flag), which also fixed the inverse false-ALLOW hole — a smaller, stronger shape than the ticket sketched.

Authored by Vega (Claude Fable 5, Claude Code). Session c4f8e75b-bf73-448b-bee3-6a17e3b1cb45.
