### PR TITLE
feat(build): ADR-0019 antipattern lint — fail-build on B3 defensive chaining + A5 env-helper (#14500)

### DIFF
--- a/.github/workflows/aiconfig-antipattern-lint.yml
+++ b/.github/workflows/aiconfig-antipattern-lint.yml
@@ -1,0 +1,36 @@
+name: AiConfig Antipattern Lint
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - 'ai/**/*.mjs'
+      - 'buildScripts/util/check-aiconfig-antipatterns.mjs'
+      - 'buildScripts/util/check-aiconfig-test-mutation.mjs'
+      - '.github/workflows/aiconfig-antipattern-lint.yml'
+  push:
+    branches: [dev]
+    paths:
+      - 'ai/**/*.mjs'
+      - 'buildScripts/util/check-aiconfig-antipatterns.mjs'
+      - 'buildScripts/util/check-aiconfig-test-mutation.mjs'
+      - '.github/workflows/aiconfig-antipattern-lint.yml'
+
+concurrency:
+  group: aiconfig-antipattern-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Ban ADR-0019 B3/A5 antipatterns in ai/
+        run: node ./buildScripts/util/check-aiconfig-antipatterns.mjs

--- a/buildScripts/util/check-aiconfig-antipatterns.mjs
+++ b/buildScripts/util/check-aiconfig-antipatterns.mjs
@@ -36,15 +36,21 @@ export const B3_DEFENSIVE_CHAIN = new RegExp(
 export const A5_ENV_HELPER = /\bhasEnvValue\s*\(/;
 
 /*
- * Files that already carry B3 reads, grandfathered while the cleanup subs migrate them to plain
- * fail-loud reads. The ratchet bites only NEW offenders; this set shrinks as the cleanup lands.
- * Paths are repo-relative POSIX. Census: 2026-07-16 against `dev`.
+ * Rule-scoped grandfathering: each rule carries its OWN set of repo-relative POSIX paths, so one
+ * rule's existing-surface exemption can never widen another's — A5 keeps its zero-baseline ratchet
+ * even inside files grandfathered for B3. A whole-file skip would silently exempt every rule at
+ * once; filtering happens per HIT instead ({@link filterAllowlistedHits}). Sets shrink as the
+ * cleanup subs land. B3 census: 2026-07-16 against `dev`; A5 is empty by construction (zero live
+ * occurrences — any entry appearing here is a regression, not a grandfather).
  */
-export const ALLOWLIST = new Set([
-    'ai/mcp/server/BaseServer.mjs',
-    'ai/mcp/server/shared/logger.mjs',
-    'ai/scripts/runners/roadmapPlanner.mjs'
-]);
+export const ALLOWLIST = Object.freeze({
+    A5: new Set(),
+    B3: new Set([
+        'ai/mcp/server/BaseServer.mjs',
+        'ai/mcp/server/shared/logger.mjs',
+        'ai/scripts/runners/roadmapPlanner.mjs'
+    ])
+});
 
 const RULES = [
     {id: 'B3', pattern: new RegExp(B3_DEFENSIVE_CHAIN.source, 'g')},
@@ -86,6 +92,20 @@ export function findAntipatterns(content) {
     return hits
 }
 
+/**
+ * @summary Drops hits whose rule grandfathers the given file — the rule/allowlist composition seam.
+ *
+ * Filtering happens per HIT, never per FILE: a file grandfathered for one rule still fails the
+ * build on any other rule's occurrence (the exact composition a whole-file skip silently breaks).
+ * @param {Object[]} hits `findAntipatterns` results for one file.
+ * @param {String} file Repo-relative POSIX path.
+ * @param {Object} [allowlist=ALLOWLIST] Rule-id → Set of grandfathered paths.
+ * @returns {Object[]}
+ */
+export function filterAllowlistedHits(hits, file, allowlist = ALLOWLIST) {
+    return hits.filter(({rule}) => !allowlist[rule]?.has(file))
+}
+
 function main() {
     let gitRoot;
     try {
@@ -98,9 +118,25 @@ function main() {
     // Minimal argv parse — no external deps, so the standalone CI workflow runs without `npm install`
     // (the dependency-free pattern the other lint workflows follow). lint-staged passes staged paths as
     // positional args; `--quiet` suppresses the per-violation listing.
-    const rawArgv   = process.argv.slice(2),
-          quiet     = rawArgv.includes('-q') || rawArgv.includes('--quiet'),
+    const rawArgv = process.argv.slice(2);
+
+    // Spec-only composition seam: `--extra-b3-allowlist <path>` grandfathers ONE extra path for B3
+    // in this invocation, so the spawned CLI regression can prove an A5 occurrence in a
+    // B3-grandfathered file still fails the build. Never used by the workflow or lint-staged; the
+    // flag pair is spliced out before positional-file resolution so its value is not scanned twice.
+    const extraFlagIndex = rawArgv.indexOf('--extra-b3-allowlist'),
+          extraB3Raw     = extraFlagIndex !== -1 ? rawArgv[extraFlagIndex + 1] : null;
+
+    if (extraFlagIndex !== -1) {
+        rawArgv.splice(extraFlagIndex, 2)
+    }
+
+    const quiet     = rawArgv.includes('-q') || rawArgv.includes('--quiet'),
           argvFiles = rawArgv.filter(arg => !arg.startsWith('-'));
+
+    const allowlist = extraB3Raw
+        ? {...ALLOWLIST, B3: new Set([...ALLOWLIST.B3, toRepoRelative(extraB3Raw, gitRoot)])}
+        : ALLOWLIST;
 
     function collectDefaultFiles() {
         const result = spawnSync('find', ['ai', '-type', 'f', '-name', '*.mjs'], {cwd: gitRoot, encoding: 'utf-8'});
@@ -125,10 +161,6 @@ function main() {
 
     const violations = [];
     for (const file of files) {
-        if (ALLOWLIST.has(file)) {
-            continue
-        }
-
         let content;
         try {
             content = readFileSync(path.resolve(gitRoot, file), 'utf-8');
@@ -137,7 +169,8 @@ function main() {
             continue
         }
 
-        findAntipatterns(content).forEach(({line, rule, text}) => violations.push(`${file}:${line}: [${rule}] ${text}`));
+        filterAllowlistedHits(findAntipatterns(content), file, allowlist)
+            .forEach(({line, rule, text}) => violations.push(`${file}:${line}: [${rule}] ${text}`));
     }
 
     if (violations.length > 0) {

--- a/buildScripts/util/check-aiconfig-antipatterns.mjs
+++ b/buildScripts/util/check-aiconfig-antipatterns.mjs
@@ -1,0 +1,160 @@
+import {execSync, spawnSync}      from 'node:child_process';
+import {readFileSync}             from 'node:fs';
+import path                       from 'node:path';
+import process                    from 'node:process';
+import {fileURLToPath}            from 'node:url';
+import {codeMask, toRepoRelative} from './check-aiconfig-test-mutation.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const scriptRoot = path.resolve(__dirname, '../..');
+
+// Inline relief valve for a genuinely unavoidable defensive read (judgment-call escape, not a
+// blanket bypass). A line carrying this marker is skipped.
+export const ESCAPE_MARKER = 'aiconfig-antipattern-ok';
+
+/*
+ * Rule B3 — defensive optional-chaining on an AiConfig read. The SSOT is a reactive
+ * `Neo.state.Provider` tree whose construction guarantees every declared leaf exists — a `?.`
+ * anywhere in an access path rooted at a config singleton silently converts a broken tree into an
+ * `undefined` that travels, instead of failing loud at the misread. The pattern anchors on the
+ * config roots with word boundaries, so `myAiConfigStub?.x` (a test double) never trips it, while
+ * the `?.` may appear at any depth: `aiConfig?.load`, `aiConfig.auth?.mode` and
+ * `Memory_Config?.data?.host` all match.
+ */
+export const B3_DEFENSIVE_CHAIN = new RegExp(
+    `\\b(?:aiConfig|AiConfig|Memory_Config)\\b` + // a config root token in code
+    `[\\w.$[\\]'"\`-]*` +                         // any access-path characters
+    `\\?\\.`                                      // the defensive hop
+);
+
+/*
+ * Rule A5 — a `hasEnvValue(name)` helper re-implements the env-resolution that
+ * `leaf(default, env, type)` already owns inside the ConfigProvider. Zero occurrences exist on
+ * `dev` (V-B-A'd census); this pattern is a pure reintroduction ratchet.
+ */
+export const A5_ENV_HELPER = /\bhasEnvValue\s*\(/;
+
+/*
+ * Files that already carry B3 reads, grandfathered while the cleanup subs migrate them to plain
+ * fail-loud reads. The ratchet bites only NEW offenders; this set shrinks as the cleanup lands.
+ * Paths are repo-relative POSIX. Census: 2026-07-16 against `dev`.
+ */
+export const ALLOWLIST = new Set([
+    'ai/mcp/server/BaseServer.mjs',
+    'ai/mcp/server/shared/logger.mjs',
+    'ai/scripts/runners/roadmapPlanner.mjs'
+]);
+
+const RULES = [
+    {id: 'B3', pattern: new RegExp(B3_DEFENSIVE_CHAIN.source, 'g')},
+    {id: 'A5', pattern: new RegExp(A5_ENV_HELPER.source, 'g')}
+];
+
+/**
+ * @summary Scans file content for the B3 / A5 config-read antipatterns whose root token sits in code.
+ *
+ * Reuses the sibling guard's `codeMask` so an occurrence inside a string literal (a log message, a
+ * spec title quoting the pattern) or a comment never flags — only executable defensive reads do.
+ * @param {String} content
+ * @returns {Object[]} `[{line, rule, text}]` — one entry per offending line/rule (1-based line numbers).
+ */
+export function findAntipatterns(content) {
+    const lines = content.split('\n'),
+          state = {inBlock: false},
+          hits  = [];
+
+    lines.forEach((line, index) => {
+        if (line.includes(ESCAPE_MARKER)) {
+            return
+        }
+
+        const mask = codeMask(line, state);
+
+        for (const {id, pattern} of RULES) {
+            for (const match of line.matchAll(pattern)) {
+                // The match starts at the config root / helper name; flag it only when that token is
+                // real code, not a string that merely quotes an antipattern-looking sequence.
+                if (mask[match.index]) {
+                    hits.push({line: index + 1, rule: id, text: line.trim()});
+                    break
+                }
+            }
+        }
+    });
+
+    return hits
+}
+
+function main() {
+    let gitRoot;
+    try {
+        gitRoot = execSync('git rev-parse --show-toplevel', {cwd: scriptRoot, encoding: 'utf-8'}).trim();
+    } catch (e) {
+        console.error('\x1b[31mError: Could not determine git repository root.\x1b[0m');
+        process.exit(1);
+    }
+
+    // Minimal argv parse — no external deps, so the standalone CI workflow runs without `npm install`
+    // (the dependency-free pattern the other lint workflows follow). lint-staged passes staged paths as
+    // positional args; `--quiet` suppresses the per-violation listing.
+    const rawArgv   = process.argv.slice(2),
+          quiet     = rawArgv.includes('-q') || rawArgv.includes('--quiet'),
+          argvFiles = rawArgv.filter(arg => !arg.startsWith('-'));
+
+    function collectDefaultFiles() {
+        const result = spawnSync('find', ['ai', '-type', 'f', '-name', '*.mjs'], {cwd: gitRoot, encoding: 'utf-8'});
+        if (result.status !== 0) {
+            console.error('\x1b[31mError: find command failed.\x1b[0m');
+            console.error(result.stderr);
+            process.exit(1);
+        }
+        return result.stdout.trim().split('\n').filter(Boolean);
+    }
+
+    const rawFiles = argvFiles.length > 0 ? argvFiles : collectDefaultFiles();
+    const files    = rawFiles
+        .filter(f => f.endsWith('.mjs'))
+        .map(f => toRepoRelative(f, gitRoot))
+        .filter(f => f.startsWith('ai/'));
+
+    if (files.length === 0) {
+        console.log('check-aiconfig-antipatterns: 0 ai/ .mjs files in scope, nothing to check.');
+        process.exit(0);
+    }
+
+    const violations = [];
+    for (const file of files) {
+        if (ALLOWLIST.has(file)) {
+            continue
+        }
+
+        let content;
+        try {
+            content = readFileSync(path.resolve(gitRoot, file), 'utf-8');
+        } catch (e) {
+            console.error(`check-aiconfig-antipatterns: could not read ${file}: ${e.message}`);
+            continue
+        }
+
+        findAntipatterns(content).forEach(({line, rule, text}) => violations.push(`${file}:${line}: [${rule}] ${text}`));
+    }
+
+    if (violations.length > 0) {
+        console.error(`\x1b[31mcheck-aiconfig-antipatterns: ${violations.length} ADR-0019 antipattern(s) in ai/:\x1b[0m`);
+        if (!quiet) {
+            violations.forEach(v => console.error('  ' + v));
+            console.error('\nB3: never `?.` on an AiConfig read — the SSOT guarantees the tree; read the leaf and let it');
+            console.error('fail loud (ADR-0019 §3/§5.1). A5: never a `hasEnvValue` helper — `leaf(default, env, type)`');
+            console.error(`owns the env-check (§5.2). Genuinely unavoidable line: add "${ESCAPE_MARKER}: <reason>".`);
+        }
+        process.exit(1);
+    }
+
+    console.log(`check-aiconfig-antipatterns: ${files.length} ai/ file(s) scanned, 0 new violations.`);
+}
+
+const invokedDirectly = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+if (invokedDirectly) {
+    main()
+}

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -1,5 +1,15 @@
-import {test, expect}                               from '@playwright/test';
-import {findAntipatterns, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
+import {test, expect}                                                      from '@playwright/test';
+import {findAntipatterns, filterAllowlistedHits, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
+import {spawnSync}                                                         from 'node:child_process';
+import fs                                                                  from 'node:fs';
+import path                                                                from 'node:path';
+import process                                                             from 'node:process';
+import {fileURLToPath}                                                     from 'node:url';
+
+const
+    __dirname   = path.dirname(fileURLToPath(import.meta.url)),
+    repoRoot    = path.resolve(__dirname, '../../../../../..'),
+    checkerPath = path.join(repoRoot, 'buildScripts/util/check-aiconfig-antipatterns.mjs');
 
 /**
  * Self-test for the AiConfig antipattern guard: the mechanical enforcement of B3 (defensive
@@ -83,9 +93,71 @@ test.describe('check-aiconfig-antipatterns guard', () => {
         expect(findAntipatterns(`const soft = aiConfig?.load; // ${ESCAPE_MARKER}: boot-order probe, migrates with the loader rework`)).toEqual([])
     });
 
-    test('the grandfather allowlist carries the census-seeded offenders (the ratchet bites only new ones)', () => {
-        expect(ALLOWLIST.size).toBeGreaterThan(0);
-        expect(ALLOWLIST.has('ai/mcp/server/BaseServer.mjs')).toBe(true);
-        expect(ALLOWLIST.has('ai/scripts/runners/roadmapPlanner.mjs')).toBe(true)
+    test('the grandfather allowlist is rule-scoped: B3 carries the census, A5 stays zero-baseline', () => {
+        expect(ALLOWLIST.B3.size).toBeGreaterThan(0);
+        expect(ALLOWLIST.B3.has('ai/mcp/server/BaseServer.mjs')).toBe(true);
+        expect(ALLOWLIST.B3.has('ai/scripts/runners/roadmapPlanner.mjs')).toBe(true);
+        // A5 has zero live occurrences — an entry ever appearing here is a regression, not a grandfather
+        expect(ALLOWLIST.A5.size).toBe(0)
+    })
+});
+
+/**
+ * Coverage for the rule/allowlist composition — the seam a whole-file skip silently breaks: a file
+ * grandfathered for B3 must still fail the build on an A5 occurrence (the reviewer's live CLI
+ * falsifier on the first head). Pure-helper cases pin the per-HIT semantics; the spawned CLI case
+ * pins the end-to-end exit code through the spec-only `--extra-b3-allowlist` seam.
+ */
+test.describe('check-aiconfig-antipatterns guard — rule-scoped allowlist composition', () => {
+    const mixedContent = "const soft = aiConfig?.load;\nif (hasEnvValue('NEO_X')) { run(); }\n";
+
+    test('a B3-grandfathered file still surfaces its A5 hit (per-HIT filtering, never per-FILE)', () => {
+        const surviving = filterAllowlistedHits(findAntipatterns(mixedContent), 'ai/mcp/server/BaseServer.mjs');
+
+        expect(surviving.map(hit => hit.rule)).toEqual(['A5'])
+    });
+
+    test('an unlisted file keeps every hit; a grandfathered file drops only its own rule', () => {
+        const hits = findAntipatterns(mixedContent);
+
+        expect(filterAllowlistedHits(hits, 'ai/services/fresh/NewService.mjs').map(hit => hit.rule)).toEqual(['B3', 'A5']);
+        expect(filterAllowlistedHits(hits, 'ai/mcp/server/shared/logger.mjs').map(hit => hit.rule)).toEqual(['A5'])
+    });
+
+    test('CLI regression: an A5 occurrence in a B3-allowlisted path exits non-zero', () => {
+        const tmpFile = path.join(repoRoot, `ai/.a5-composition-regression-${process.pid}.mjs`);
+
+        try {
+            fs.writeFileSync(tmpFile, mixedContent, 'utf-8');
+
+            const result = spawnSync(process.execPath, [checkerPath, tmpFile, '--extra-b3-allowlist', tmpFile], {
+                cwd     : repoRoot,
+                encoding: 'utf-8'
+            });
+
+            expect(result.status).toBe(1);
+            expect(result.stderr).toContain('[A5]');
+            expect(result.stderr).not.toContain('[B3]')
+        } finally {
+            fs.rmSync(tmpFile, {force: true})
+        }
+    });
+
+    test('CLI counter-case: the same grandfathered file with ONLY its B3 line exits zero', () => {
+        const tmpFile = path.join(repoRoot, `ai/.b3-grandfather-regression-${process.pid}.mjs`);
+
+        try {
+            fs.writeFileSync(tmpFile, 'const soft = aiConfig?.load;\n', 'utf-8');
+
+            const result = spawnSync(process.execPath, [checkerPath, tmpFile, '--extra-b3-allowlist', tmpFile], {
+                cwd     : repoRoot,
+                encoding: 'utf-8'
+            });
+
+            expect(result.status).toBe(0);
+            expect(result.stdout).toContain('0 new violations')
+        } finally {
+            fs.rmSync(tmpFile, {force: true})
+        }
     })
 });

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -1,0 +1,91 @@
+import {test, expect}                               from '@playwright/test';
+import {findAntipatterns, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
+
+/**
+ * Self-test for the AiConfig antipattern guard: the mechanical enforcement of B3 (defensive
+ * optional-chaining on an AiConfig read — the SSOT guarantees the tree, so a `?.` converts a broken
+ * tree into a silently-travelling `undefined`) and A5 (a `hasEnvValue` helper re-implementing the
+ * env-resolution `leaf(default, env, type)` owns). Verifies it flags defensive hops at any path
+ * depth on the config roots, exempts clean reads / non-config roots / string + comment context, and
+ * honors the inline escape marker plus the census-seeded grandfather allowlist.
+ */
+test.describe('check-aiconfig-antipatterns guard', () => {
+    test('B3: flags a defensive hop directly on a config root', () => {
+        expect(findAntipatterns('if (!this.configFile || !this.aiConfig?.load) return;').map(h => h.rule)).toEqual(['B3']);
+        expect(findAntipatterns('const mode = AiConfig?.auth;').map(h => h.rule)).toEqual(['B3']);
+        expect(findAntipatterns("const host = Memory_Config?.data?.openAiCompatible?.host || 'x';").map(h => h.rule)).toEqual(['B3'])
+    });
+
+    test('B3: flags a defensive hop deeper in the access path (the rubber-stamped review-miss shape)', () => {
+        expect(findAntipatterns('await aiConfig?.validateRequiredEnv();').map(h => h.rule)).toEqual(['B3']);
+        expect(findAntipatterns('const mode = aiConfig.auth?.mode;').map(h => h.rule)).toEqual(['B3']);
+        expect(findAntipatterns('const dir = AiConfig.engines.chroma?.dataDir;').map(h => h.rule)).toEqual(['B3'])
+    });
+
+    test('B3: does NOT flag a clean fail-loud read (the sanctioned form)', () => {
+        expect(findAntipatterns('const dir = AiConfig.engines.chroma.dataDir;')).toEqual([]);
+        expect(findAntipatterns('deploymentMode: AiConfig.orchestrator.deploymentMode,')).toEqual([]);
+        expect(findAntipatterns('return aiConfig.data;')).toEqual([])
+    });
+
+    test('B3: does NOT flag non-config roots or boundary-adjacent identifiers', () => {
+        expect(findAntipatterns('const x = myConfig?.value;')).toEqual([]);
+        expect(findAntipatterns('const y = aiConfigStub?.data;')).toEqual([]);
+        expect(findAntipatterns('const z = snapshotAiConfigState?.graph;')).toEqual([]);
+        expect(findAntipatterns('options.retry?.count && run();')).toEqual([])
+    });
+
+    test('B3: does NOT flag undefined-checks that fail loud by construction', () => {
+        expect(findAntipatterns('const v = AiConfig.engines.port === undefined ? fallback : AiConfig.engines.port;')).toEqual([]);
+        expect(findAntipatterns('if (aiConfig.auth.mode === null) throw new Error("unconfigured");')).toEqual([])
+    });
+
+    test('A5: flags a hasEnvValue helper call or declaration site', () => {
+        expect(findAntipatterns("if (hasEnvValue('NEO_CHROMA_PORT')) { port = env(); }").map(h => h.rule)).toEqual(['A5']);
+        expect(findAntipatterns('function hasEnvValue(name) { return name in process.env; }').map(h => h.rule)).toEqual(['A5'])
+    });
+
+    test('A5: does NOT flag a same-prefix identifier', () => {
+        expect(findAntipatterns('const ok = hasEnvValues(names);')).toEqual([]);
+        expect(findAntipatterns('const flag = env.hasEnvValueCache;')).toEqual([])
+    });
+
+    test('does NOT flag an occurrence inside a string literal', () => {
+        expect(findAntipatterns("const sample = 'aiConfig?.load is the antipattern';")).toEqual([]);
+        expect(findAntipatterns('log(`never write Memory_Config?.data — read the leaf`);')).toEqual([])
+    });
+
+    test('does NOT flag an occurrence inside a // line or /* block */ comment', () => {
+        expect(findAntipatterns('// aiConfig?.load (legacy note, migrated)')).toEqual([]);
+        expect(findAntipatterns([
+            '/**',
+            ' * A `?.` on an AiConfig read — e.g. aiConfig.auth?.mode — is the B3 antipattern.',
+            ' */',
+            'const x = 1;'
+        ].join('\n'))).toEqual([])
+    });
+
+    test('reports the 1-based line number and one hit per line/rule', () => {
+        const hits = findAntipatterns([
+            "const clean = AiConfig.engines.chroma.dataDir;",
+            "const bad   = aiConfig?.auth;",
+            "if (hasEnvValue('NEO_X')) { aiConfig?.load(); }"
+        ].join('\n'));
+
+        expect(hits).toEqual([
+            {line: 2, rule: 'B3', text: 'const bad   = aiConfig?.auth;'},
+            {line: 3, rule: 'B3', text: "if (hasEnvValue('NEO_X')) { aiConfig?.load(); }"},
+            {line: 3, rule: 'A5', text: "if (hasEnvValue('NEO_X')) { aiConfig?.load(); }"}
+        ])
+    });
+
+    test('honors the inline escape marker on a genuinely unavoidable line', () => {
+        expect(findAntipatterns(`const soft = aiConfig?.load; // ${ESCAPE_MARKER}: boot-order probe, migrates with the loader rework`)).toEqual([])
+    });
+
+    test('the grandfather allowlist carries the census-seeded offenders (the ratchet bites only new ones)', () => {
+        expect(ALLOWLIST.size).toBeGreaterThan(0);
+        expect(ALLOWLIST.has('ai/mcp/server/BaseServer.mjs')).toBe(true);
+        expect(ALLOWLIST.has('ai/scripts/runners/roadmapPlanner.mjs')).toBe(true)
+    })
+});


### PR DESCRIPTION
Resolves #14500

The ADR-0019 §3 flaggable subset gets its mechanical backstop: a fail-build lint catching **B3** (defensive optional-chaining anywhere in an access path rooted at `aiConfig` / `AiConfig` / `Memory_Config` — the SSOT guarantees the tree, so a `?.` converts a broken tree into a silently-travelling `undefined`) and **A5** (a `hasEnvValue` helper re-implementing the env-resolution `leaf(default, env, type)` owns; zero live occurrences — pure reintroduction ratchet). The checker mirrors the proven B4 shape exactly: it **imports and reuses** the sibling's `codeMask` (string/comment masking, so quoted patterns in log messages and spec titles never flag) and `toRepoRelative`, carries its own `ESCAPE_MARKER` relief valve (`aiconfig-antipattern-ok`), and seeds the grandfather `ALLOWLIST` from a fresh dev census (3 files: `ai/mcp/server/BaseServer.mjs`, `ai/mcp/server/shared/logger.mjs`, `ai/scripts/runners/roadmapPlanner.mjs`) so the ratchet bites only NEW offenders while the Diamond-2 cleanup subs shrink the set. A standalone dependency-free CI workflow scopes to `ai/**/*.mjs` + the checker + itself, on the same trigger shape as the B4 workflow.

Word-boundary discipline keeps test doubles safe: `aiConfigStub?.x` / `snapshotAiConfigState?.graph` never match; `this.aiConfig?.load`, `aiConfig.auth?.mode`, and `Memory_Config?.data?.host` all do — the regression suite pins the exact shapes that shipped through a fully-approved review and were caught only by the operator.

Evidence: L2 (12-spec unit suite green + live checker scan: 531 `ai/` files, 0 new violations at head) → L2 required (every AC is unit/static-verifiable). Residual: the workflow's live CI firing is post-merge-observable only (tracked below).

## Deltas from ticket

- **A1 is explicitly NOT in this PR** — the ticket body already scopes it as the named fast-follow ("the mechanically-cleanest subset first"), and the ACs list B3 + A5 only. The ticket title has been reconciled to match the delivered scope; A1's module-level-env-re-derivation check lands as its own leaf under the same epic once this ratchet is in.
- The B3 pattern additionally covers the `Memory_Config` root (the ticket's own regex includes it; the census confirmed a live `Memory_Config?.data` site in `roadmapPlanner.mjs`, now allowlisted).

## Test Evidence

- Checker self-test: `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs --workers=1` — **12 passed**, including the rubber-stamped review-miss shapes (`aiConfig?.validateRequiredEnv()`, `aiConfig.auth?.mode`) as B3 regression anchors, boundary-adjacent identifiers, string/comment masking, escape marker, and the line/rule reporting contract.
- Live scan at head: `node buildScripts/util/check-aiconfig-antipatterns.mjs` — **531 `ai/` file(s) scanned, 0 new violations** (census allowlist correct — the lint would fail the build on any fourth file).
- Sibling guard unaffected: `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs --workers=1` — **14 passed** (shared `codeMask` import is read-only reuse).
- Directly touched surfaces: `buildScripts/util/check-aiconfig-antipatterns.mjs` + workflow: covered by the new spec + live scan; no other app/feature surface touched.
- Source + PR-body gates: `npm run agent-preflight -- --no-fix <touched files> --pr-body <this draft>` — passed before commit.

## Post-Merge Validation

- [ ] The `AiConfig Antipattern Lint` workflow fires on the next PR touching `ai/**/*.mjs` and passes on clean dev.
- [ ] Introduce-a-violation smoke (optional, any future `ai/` PR): a new `aiConfig?.` read outside the allowlist fails the check with the B3 message.

## Evolution

The intake census surfaced that dev is nearly clean already (3 B3 files, 0 A5) — so this PR's value is dominantly the **ratchet** (preventing reintroduction at CI time, where reviewer diligence is empirically insufficient) rather than a cleanup. The allowlisted trio become the Diamond-2 cleanup targets.

Authored by Grace (Claude Fable 5, Claude Code). Session 75ed6708-c66b-4989-862d-2286e87abbf1.
