### PR TITLE
feat(mcp): add loopback local bearer ingress (#15185)

### DIFF
--- a/ai/config.template.mjs
+++ b/ai/config.template.mjs
@@ -143,6 +143,16 @@ class Config extends ConfigProvider {
              */
             mcpHttpHost: leaf('localhost', 'HOST', 'string'),
             /**
+             * @summary Optional actual listener bind for the Streamable HTTP transport.
+             *
+             * When absent, the
+             * existing `app.listen(port)` behavior is preserved. Local-bearer mode requires the
+             * literal IPv4 loopback address `127.0.0.1`; advertised-host behavior remains owned by
+             * `mcpHttpHost` / `publicUrl`.
+             * @type {string|null}
+             */
+            mcpListenHost: leaf(null, 'NEO_MCP_LISTEN_HOST', 'string'),
+            /**
              * Port the MCP server's Streamable HTTP transport listens on.
              * Sub-servers will typically override this with their own defaultPort.
              * @type {number}
@@ -164,6 +174,8 @@ class Config extends ConfigProvider {
              *   bearer token, validated against `{gitlabApiBaseUrl}/api/v4/user`. No `aud` claim and
              *   no PRM advertisement (a naked `401` on failure) — the lighter path for clients that
              *   authenticate with a long-lived PAT from an env var instead of an OAuth dance.
+             * - `'local-bearer'`: a generated process-lifetime possession credential for an
+             *   explicitly loopback-bound listener. It performs no identity lookup or provisioning.
              * @type {Object}
              */
             auth: {
@@ -174,8 +186,23 @@ class Config extends ConfigProvider {
                 clientId          : leaf(null, 'NEO_OAUTH_CLIENT_ID', 'string'),
                 clientSecret      : leaf('', 'NEO_OAUTH_CLIENT_SECRET', 'string'),
                 trustProxyIdentity: leaf(false, 'NEO_AUTH_TRUST_PROXY_IDENTITY', 'boolean'),
-                // Authorization strategy selector: 'oidc' (default) | 'gitlab-pat'. See block doc above.
+                // Authorization strategy selector: 'oidc' (default) | 'gitlab-pat' | 'local-bearer'.
                 mode              : leaf('oidc', 'NEO_AUTH_MODE', 'string'),
+                /**
+                 * @summary Disposable process-lifetime possession credential for local-bearer mode.
+                 *
+                 * Generate exactly 32 random bytes as canonical unpadded base64url. Never persist
+                 * or log this value; process exit is the revocation boundary.
+                 * @type {String}
+                 */
+                localBearerToken  : leaf('', 'NEO_AUTH_LOCAL_BEARER_TOKEN', 'string', {
+                    requiredFor: [{
+                        entrypoints   : '*',
+                        modes         : ['local-bearer'],
+                        consumerClaims: ['readiness'],
+                        reason        : 'Local-bearer readiness requires a process-lifetime possession credential.'
+                    }]
+                }),
                 // GitLab API base URL used by 'gitlab-pat' mode for token validation (self-managed configurable).
                 gitlabApiBaseUrl  : leaf('https://gitlab.com', 'NEO_AUTH_GITLAB_API_BASE_URL', 'string', {
                     requiredFor: [{

--- a/ai/mcp/server/shared/helpers/localBearer.mjs
+++ b/ai/mcp/server/shared/helpers/localBearer.mjs
@@ -1,0 +1,95 @@
+import {randomBytes, timingSafeEqual} from 'crypto';
+
+/**
+ * Number of random bytes in a disposable local bearer credential.
+ * @type {Number}
+ */
+export const LOCAL_BEARER_BYTE_LENGTH = 32;
+
+/**
+ * Canonical unpadded-base64url length for a 32-byte value.
+ * @type {Number}
+ */
+export const LOCAL_BEARER_ENCODED_LENGTH = 43;
+
+const localBearerPattern = new RegExp(`^[A-Za-z0-9_-]{${LOCAL_BEARER_ENCODED_LENGTH}}$`);
+
+/**
+ * @summary Decodes a canonical disposable local bearer token.
+ *
+ * Rejects non-strings, padding, non-base64url characters, non-canonical encodings, and values
+ * that do not decode to exactly 32 bytes. Returning `null` keeps validation side-effect-free and
+ * lets the auth seam choose the caller-facing error type without exposing bearer material.
+ * @param {*} token Candidate token
+ * @returns {Buffer|null}
+ */
+export function decodeLocalBearerToken(token) {
+    if (typeof token !== 'string' || !localBearerPattern.test(token)) {
+        return null
+    }
+
+    const bytes = Buffer.from(token, 'base64url');
+
+    if (bytes.length !== LOCAL_BEARER_BYTE_LENGTH || bytes.toString('base64url') !== token) {
+        return null
+    }
+
+    return bytes
+}
+
+/**
+ * @summary Reports whether a value is a canonical 32-byte local bearer token.
+ * @param {*} token Candidate token
+ * @returns {Boolean}
+ */
+export function isLocalBearerToken(token) {
+    return decodeLocalBearerToken(token) !== null
+}
+
+/**
+ * @summary Compares two canonical local bearer tokens in constant time.
+ *
+ * Both values are decoded and length-checked before `timingSafeEqual` is invoked. Malformed or
+ * length-mismatched values therefore fail closed without calling the equal-length primitive.
+ * @param {*} presentedToken Request bearer token
+ * @param {*} configuredToken Process-lifetime server token
+ * @returns {Boolean}
+ */
+export function matchesLocalBearerToken(presentedToken, configuredToken) {
+    const
+        presentedBytes  = decodeLocalBearerToken(presentedToken),
+        configuredBytes = decodeLocalBearerToken(configuredToken);
+
+    return Boolean(presentedBytes && configuredBytes && timingSafeEqual(presentedBytes, configuredBytes))
+}
+
+/**
+ * @summary Generates one disposable 32-byte bearer token as canonical unpadded base64url.
+ * @returns {String}
+ */
+export function generateLocalBearerToken() {
+    return randomBytes(LOCAL_BEARER_BYTE_LENGTH).toString('base64url')
+}
+
+/**
+ * @summary Creates the in-memory server/client launch contract for local-bearer mode.
+ *
+ * The returned surfaces can be passed directly to a child server process and an MCP client. The
+ * helper performs no logging, file/database writes, environment mutation, or durable config
+ * update; process exit remains the credential-revocation boundary.
+ * @returns {{serverEnv: Object, clientHeaders: Object}}
+ */
+export function createLocalBearerLaunchContract() {
+    const token = generateLocalBearerToken();
+
+    return Object.freeze({
+        serverEnv: Object.freeze({
+            NEO_AUTH_MODE              : 'local-bearer',
+            NEO_AUTH_LOCAL_BEARER_TOKEN: token,
+            NEO_MCP_LISTEN_HOST        : '127.0.0.1'
+        }),
+        clientHeaders: Object.freeze({
+            Authorization: `Bearer ${token}`
+        })
+    })
+}

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -1,8 +1,9 @@
-import Base         from '../../../../../src/core/Base.mjs';
-import {createHash} from 'crypto';
+import Base                                          from '../../../../../src/core/Base.mjs';
+import {createHash}                                  from 'crypto';
+import {isLocalBearerToken, matchesLocalBearerToken} from '../helpers/localBearer.mjs';
 
 /**
- * @summary Orchestrates OIDC and OAuth 2.1 authorization for Neo.mjs MCP servers.
+ * @summary Orchestrates OIDC, GitLab-PAT, and disposable local-bearer authorization.
  *
  * This service acts as the **Authorization Anchor** for the MCP ecosystem. It implements
  * the **Discovery-First Pattern**, where it dynamically resolves security endpoints from the
@@ -47,7 +48,7 @@ class AuthService extends Base {
     }
 
     /**
-     * Setups OIDC/OAuth authorization for an Express application.
+     * @summary Sets up the configured authorization strategy for an Express application.
      * @param {Object} options
      * @param {Object} options.app The Express application instance
      * @param {Object} options.aiConfig The server configuration object
@@ -61,6 +62,12 @@ class AuthService extends Base {
 
         const {requireBearerAuth} = await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js');
         const {InvalidTokenError} = await import('@modelcontextprotocol/sdk/server/auth/errors.js');
+
+        // Local-bearer mode is possession-only: no PRM, discovery, identity lookup, or provisioning.
+        if (aiConfig.auth.mode === 'local-bearer') {
+            this.setupLocalBearer({app, aiConfig, logger}, {requireBearerAuth, InvalidTokenError});
+            return
+        }
 
         // GitLab-PAT mode installs a naked-401 bearer path (no `aud`, no PRM advertisement) and
         // returns early — the OIDC discovery + introspection flow below does not apply.
@@ -206,6 +213,66 @@ class AuthService extends Base {
         app.use(authMiddleware);
 
         logger.info(`[AuthService] Authorization enabled (Issuer: ${oauthUrls.issuer})`);
+    }
+
+    /**
+     * @summary Installs the process-lifetime local-bearer middleware.
+     *
+     * The SDK middleware owns Authorization-header parsing and request `AuthInfo` propagation.
+     * This strategy adds only strict canonical-token validation and possession comparison; it
+     * deliberately installs no metadata router and never logs the configured credential.
+     * @param {Object}   options
+     * @param {Object}   options.app Express application instance
+     * @param {Object}   options.aiConfig Server configuration object
+     * @param {Object}   options.logger Logger instance
+     * @param {Object}   deps
+     * @param {Function} deps.requireBearerAuth SDK bearer-auth middleware factory
+     * @param {Function} deps.InvalidTokenError SDK error class for rejected tokens
+     * @returns {void}
+     */
+    setupLocalBearer({app, aiConfig, logger}, {requireBearerAuth, InvalidTokenError}) {
+        const verifier = this.createLocalBearerVerifier({aiConfig, InvalidTokenError});
+
+        app.use(requireBearerAuth({verifier, requiredScopes: []}));
+
+        logger.info('[AuthService] Authorization enabled (mode: local-bearer, possession-only)')
+    }
+
+    /**
+     * @summary Builds the strict verifier for one disposable local bearer credential.
+     *
+     * The configured token must be canonical unpadded base64url for exactly 32 bytes. Successful
+     * verification returns the minimum SDK `AuthInfo` shape with no `userId` or `username`: the
+     * credential proves possession, not identity. `Number.MAX_SAFE_INTEGER` is the SDK-required
+     * numeric expiry sentinel; process exit is the actual revocation boundary, so no arbitrary
+     * wall-clock TTL is invented.
+     * @param {Object}   options
+     * @param {Object}   options.aiConfig Server configuration object
+     * @param {Function} options.InvalidTokenError SDK error class for rejected tokens
+     * @returns {{verifyAccessToken: Function}}
+     */
+    createLocalBearerVerifier({aiConfig, InvalidTokenError}) {
+        const configuredToken = aiConfig.auth.localBearerToken;
+
+        if (!isLocalBearerToken(configuredToken)) {
+            throw new Error('Local-bearer mode requires a canonical 32-byte unpadded-base64url token')
+        }
+
+        return {
+            verifyAccessToken: async token => {
+                if (!matchesLocalBearerToken(token, configuredToken)) {
+                    throw new InvalidTokenError('Invalid local bearer token')
+                }
+
+                return {
+                    token,
+                    clientId : 'neo-local-bearer',
+                    scopes   : [],
+                    expiresAt: Number.MAX_SAFE_INTEGER,
+                    source   : 'local-bearer'
+                }
+            }
+        }
     }
 
     /**

--- a/ai/mcp/server/shared/services/TransportService.mjs
+++ b/ai/mcp/server/shared/services/TransportService.mjs
@@ -12,8 +12,8 @@ import RequestContextService from './RequestContextService.mjs';
  * - **Session Management:** Handles the lifecycle of stateful MCP sessions via `Mcp-Session-Id`.
  * - **Transport Abstraction:** Decouples the Express app and CORS configuration from the
  *   individual server logic (e.g. Knowledge Base, Memory Core).
- * - **Auth Integration:** Automatically wires up the **Authorization Anchor** when OIDC
- *   configuration is detected in the environment.
+ * - **Auth Integration:** Automatically wires up the configured OIDC, GitLab-PAT, or
+ *   possession-only local-bearer strategy.
  * - **CORS Enforcement:** Ensures cross-origin compatibility for modern browser-based AI agents.
  * - **Request-Context Propagation:** Each `/mcp` request is wrapped in
  *   `RequestContextService.run({userId, username, sessionId}, ...)` before dispatching to the MCP
@@ -131,6 +131,11 @@ class TransportService extends Base {
      */
     async setup(options) {
         const { server, aiConfig, logger, resourceName } = options;
+        const isLocalBearer                              = aiConfig.auth.mode === 'local-bearer';
+
+        if (isLocalBearer && aiConfig.mcpListenHost !== '127.0.0.1') {
+            throw new Error("Local-bearer mode requires mcpListenHost to be the literal IPv4 loopback address '127.0.0.1'")
+        }
 
         const { createMcpExpressApp }           = await import('@modelcontextprotocol/sdk/server/express.js');
         const { StreamableHTTPServerTransport } = await import('@modelcontextprotocol/sdk/server/streamableHttp.js');
@@ -143,6 +148,24 @@ class TransportService extends Base {
         const app = createMcpExpressApp({allowedHosts: this.computeAllowedHosts(aiConfig)});
 
         this.app = app;
+
+        // Browser-originated requests are outside the trusted-loopback contract. Presence is the
+        // discriminator: even an empty Origin header is rejected before wildcard CORS, auth, or
+        // MCP dispatch; non-browser clients legitimately omit Origin.
+        if (isLocalBearer) {
+            app.use((req, res, next) => {
+                if (Object.hasOwn(req.headers, 'origin')) {
+                    res.status(403).json({
+                        jsonrpc: '2.0',
+                        error  : {code: -32000, message: 'Origin header is not allowed in local-bearer mode'},
+                        id     : null
+                    });
+                    return
+                }
+
+                next()
+            })
+        }
 
         app.use(cors.default({
             origin        : '*',
@@ -163,8 +186,8 @@ class TransportService extends Base {
         const mcpServerUrl = aiConfig.publicUrl ? new URL(aiConfig.publicUrl) : getFullUrl(aiConfig.mcpHttpHost, aiConfig.mcpHttpPort);
         this.mcpServerUrl = mcpServerUrl;
 
-        // Optional Authorization: OIDC/OAuth (host / issuerUrl) OR the GitLab-PAT bearer mode.
-        if (aiConfig.auth.host || aiConfig.auth.issuerUrl || aiConfig.auth.mode === 'gitlab-pat') {
+        // Optional Authorization: OIDC/OAuth (host / issuerUrl), GitLab-PAT, or local-bearer.
+        if (aiConfig.auth.host || aiConfig.auth.issuerUrl || aiConfig.auth.mode === 'gitlab-pat' || isLocalBearer) {
             const { default: AuthService } = await import('./AuthService.mjs');
             await AuthService.setup({
                 app,
@@ -264,11 +287,17 @@ class TransportService extends Base {
 
         const port = aiConfig.mcpHttpPort;
         await new Promise((resolve, reject) => {
-            this.httpServer = app.listen(port, () => {
-                logger.info(`[${resourceName}] Server started on Streamable HTTP transport (Port: ${port})`);
+            const onListening = () => {
+                const hostSuffix = aiConfig.mcpListenHost ? `, Host: ${aiConfig.mcpListenHost}` : '';
+
+                logger.info(`[${resourceName}] Server started on Streamable HTTP transport (Port: ${port}${hostSuffix})`);
                 logger.info(`[${resourceName}] Available tools loaded from OpenAPI spec`);
                 resolve();
-            });
+            };
+
+            this.httpServer = aiConfig.mcpListenHost
+                ? app.listen(port, aiConfig.mcpListenHost, onListening)
+                : app.listen(port, onListening);
             this.httpServer.on('error', reject);
         });
     }

--- a/test/playwright/unit/ai/config.template.spec.mjs
+++ b/test/playwright/unit/ai/config.template.spec.mjs
@@ -80,6 +80,54 @@ test.describe('Tier 1 Config Immutability', () => {
         }
     });
 
+    test('mcpListenHost is opt-in and owns the listener-bind env contract', () => {
+        expect(Config.mcpListenHost).toBe(process.env.NEO_MCP_LISTEN_HOST || null);
+
+        const fresh = createIsolatedConfig();
+
+        try {
+            fresh.setEnvOverride('NEO_MCP_LISTEN_HOST', '127.0.0.1');
+            expect(fresh.mcpListenHost).toBe('127.0.0.1');
+        } finally {
+            fresh.destroy();
+        }
+    });
+
+    test('local-bearer readiness requires the declarative process-lifetime token leaf', () => {
+        const fresh = createIsolatedConfig();
+
+        try {
+            fresh.setEnvOverride('NEO_AUTH_LOCAL_BEARER_TOKEN', '');
+
+            const missing = fresh.validateRequiredEnv({
+                consumerClaim: 'readiness',
+                entrypoint   : 'neural-link-mcp',
+                mode         : 'local-bearer'
+            });
+
+            expect(missing.ok).toBe(false);
+            expect(missing.findings).toEqual([{
+                consumerClaim: 'readiness',
+                entrypoint   : 'neural-link-mcp',
+                env          : 'NEO_AUTH_LOCAL_BEARER_TOKEN',
+                leafPath     : 'auth.localBearerToken',
+                mode         : 'local-bearer',
+                reason       : 'Local-bearer readiness requires a process-lifetime possession credential.',
+                valueState   : 'absent',
+                disposition  : 'fail-closed'
+            }]);
+
+            fresh.setEnvOverride('NEO_AUTH_LOCAL_BEARER_TOKEN', 'configured-for-use-site-validation');
+            expect(fresh.validateRequiredEnv({
+                consumerClaim: 'readiness',
+                entrypoint   : 'neural-link-mcp',
+                mode         : 'local-bearer'
+            })).toEqual({findings: [], ok: true});
+        } finally {
+            fresh.destroy();
+        }
+    });
+
     test('ships a machine-neutral orchestrator dev-sync root default', async () => {
         expect(Config.orchestrator.devSyncRoots).toEqual([]);
     });

--- a/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
@@ -454,3 +454,129 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT midd
         expect(res.statusCode).toBe(401);
     });
 });
+
+/**
+ * @summary Consumed-boundary coverage for the possession-only local-bearer strategy.
+ *
+ * Drives the verifier through the real SDK middleware so header parsing, AuthInfo expiry, strict
+ * token shape, identity absence, and token non-observability are proven at the consumed seam.
+ */
+test.describe('Neo.ai.mcp.server.shared.services.AuthService — local-bearer middleware boundary', () => {
+    let AuthService, generateLocalBearerToken, requireBearerAuth, InvalidTokenError;
+
+    function mockReq(authHeader) {
+        const headers = authHeader === undefined ? {} : {authorization: authHeader};
+
+        return {headers, get(name) { return headers[String(name).toLowerCase()]; }}
+    }
+
+    function mockRes() {
+        return {
+            statusCode: 200,
+            headers   : {},
+            body      : undefined,
+            ended     : false,
+            status(code) { this.statusCode = code; return this; },
+            set(field, value) {
+                if (field && typeof field === 'object') {
+                    Object.entries(field).forEach(([key, item]) => {
+                        this.headers[String(key).toLowerCase()] = item
+                    })
+                } else {
+                    this.headers[String(field).toLowerCase()] = value
+                }
+                return this
+            },
+            json(payload) { this.body = payload; this.ended = true; return this; }
+        }
+    }
+
+    function installLocalMiddleware(token, logEntries = []) {
+        const
+            middlewares = [],
+            app         = {use: middleware => middlewares.push(middleware)},
+            aiConfig    = {auth: {mode: 'local-bearer', localBearerToken: token}},
+            logger      = {info: message => logEntries.push(String(message))};
+
+        AuthService.setupLocalBearer({app, aiConfig, logger}, {requireBearerAuth, InvalidTokenError});
+
+        expect(middlewares).toHaveLength(1);
+        return middlewares[0]
+    }
+
+    test.beforeAll(async () => {
+        AuthService             = (await import('../../../../../../../ai/mcp/server/shared/services/AuthService.mjs')).default;
+        generateLocalBearerToken = (await import('../../../../../../../ai/mcp/server/shared/helpers/localBearer.mjs')).generateLocalBearerToken;
+        requireBearerAuth       = (await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js')).requireBearerAuth;
+        InvalidTokenError       = (await import('@modelcontextprotocol/sdk/server/auth/errors.js')).InvalidTokenError;
+    });
+
+    test('a valid token passes with possession metadata and no resolved identity', async () => {
+        const
+            token      = generateLocalBearerToken(),
+            logEntries = [],
+            middleware = installLocalMiddleware(token, logEntries),
+            req        = mockReq(`Bearer ${token}`),
+            res        = mockRes();
+
+        let nextError = 'unset';
+        await middleware(req, res, error => { nextError = error; });
+
+        expect(nextError).toBeUndefined();
+        expect(res.ended).toBe(false);
+        expect(req.auth).toMatchObject({
+            clientId : 'neo-local-bearer',
+            scopes   : [],
+            expiresAt: Number.MAX_SAFE_INTEGER,
+            source   : 'local-bearer'
+        });
+        expect(req.auth).not.toHaveProperty('userId');
+        expect(req.auth).not.toHaveProperty('username');
+        expect(logEntries.join('\n')).not.toContain(token);
+    });
+
+    test('missing headers, malformed schemes, and length mismatches fail through the SDK boundary', async () => {
+        const
+            token      = generateLocalBearerToken(),
+            middleware = installLocalMiddleware(token);
+
+        for (const authHeader of [undefined, `Basic ${token}`, 'Bearer short']) {
+            const req = mockReq(authHeader),
+                  res = mockRes();
+            let nextCalled = false;
+
+            await middleware(req, res, () => { nextCalled = true; });
+
+            expect(nextCalled).toBe(false);
+            expect(res.statusCode).toBe(401);
+        }
+    });
+
+    test('a different canonical token fails without exposing either credential', async () => {
+        const
+            configuredToken = generateLocalBearerToken(),
+            presentedToken  = generateLocalBearerToken(),
+            logEntries      = [],
+            middleware      = installLocalMiddleware(configuredToken, logEntries),
+            req             = mockReq(`Bearer ${presentedToken}`),
+            res             = mockRes();
+
+        let nextCalled = false;
+        await middleware(req, res, () => { nextCalled = true; });
+
+        expect(nextCalled).toBe(false);
+        expect(res.statusCode).toBe(401);
+        expect(String(res.body?.error_description || res.body?.error || '')).not.toContain(configuredToken);
+        expect(String(res.body?.error_description || res.body?.error || '')).not.toContain(presentedToken);
+        expect(logEntries.join('\n')).not.toContain(configuredToken);
+        expect(logEntries.join('\n')).not.toContain(presentedToken);
+    });
+
+    test('startup rejects missing, padded, and non-32-byte configured credentials', () => {
+        const token = generateLocalBearerToken();
+
+        for (const invalidToken of ['', `${token}=`, 'short']) {
+            expect(() => installLocalMiddleware(invalidToken)).toThrow(/canonical 32-byte unpadded-base64url token/)
+        }
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/shared/helpers/localBearer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/helpers/localBearer.spec.mjs
@@ -1,0 +1,84 @@
+import {setup} from '../../../../../../setup.mjs';
+
+const appName = 'LocalBearerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary Coverage for the disposable local-bearer generation and comparison contract.
+ */
+test.describe('LocalBearer helper', () => {
+    let createLocalBearerLaunchContract,
+        generateLocalBearerToken,
+        isLocalBearerToken,
+        matchesLocalBearerToken;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../../ai/mcp/server/shared/helpers/localBearer.mjs');
+
+        createLocalBearerLaunchContract = mod.createLocalBearerLaunchContract;
+        generateLocalBearerToken        = mod.generateLocalBearerToken;
+        isLocalBearerToken              = mod.isLocalBearerToken;
+        matchesLocalBearerToken         = mod.matchesLocalBearerToken;
+    });
+
+    test('generates exactly 32 random bytes as canonical unpadded base64url', () => {
+        const first  = generateLocalBearerToken(),
+              second = generateLocalBearerToken();
+
+        expect(first).toHaveLength(43);
+        expect(first).toMatch(/^[A-Za-z0-9_-]+$/);
+        expect(first).not.toContain('=');
+        expect(Buffer.from(first, 'base64url')).toHaveLength(32);
+        expect(Buffer.from(first, 'base64url').toString('base64url')).toBe(first);
+        expect(second).not.toBe(first);
+    });
+
+    test('rejects padding, invalid characters, non-canonical lengths, and non-strings', () => {
+        const token = generateLocalBearerToken();
+
+        expect(isLocalBearerToken(token)).toBe(true);
+        expect(isLocalBearerToken(`${token}=`)).toBe(false);
+        expect(isLocalBearerToken(`${token.slice(0, -1)}+`)).toBe(false);
+        expect(isLocalBearerToken(token.slice(0, -1))).toBe(false);
+        expect(isLocalBearerToken(`${token}A`)).toBe(false);
+        expect(isLocalBearerToken(null)).toBe(false);
+    });
+
+    test('uses the strict equal-length comparison boundary', () => {
+        const token = generateLocalBearerToken();
+
+        expect(matchesLocalBearerToken(token, token)).toBe(true);
+        expect(matchesLocalBearerToken(generateLocalBearerToken(), token)).toBe(false);
+        expect(matchesLocalBearerToken('short', token)).toBe(false);
+        expect(matchesLocalBearerToken(token, 'short')).toBe(false);
+    });
+
+    test('creates one frozen in-memory value shared by server and client surfaces only', () => {
+        const contract = createLocalBearerLaunchContract(),
+              token    = contract.serverEnv.NEO_AUTH_LOCAL_BEARER_TOKEN;
+
+        expect(Object.keys(contract).sort()).toEqual(['clientHeaders', 'serverEnv']);
+        expect(Object.isFrozen(contract)).toBe(true);
+        expect(Object.isFrozen(contract.serverEnv)).toBe(true);
+        expect(Object.isFrozen(contract.clientHeaders)).toBe(true);
+        expect(contract).not.toHaveProperty('token');
+        expect(contract.serverEnv.NEO_AUTH_MODE).toBe('local-bearer');
+        expect(contract.serverEnv.NEO_MCP_LISTEN_HOST).toBe('127.0.0.1');
+        expect(contract.clientHeaders.Authorization).toBe(`Bearer ${token}`);
+        expect(isLocalBearerToken(token)).toBe(true);
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs
@@ -15,6 +15,8 @@ setup({
 
 import { test, expect } from '@playwright/test';
 import http             from 'http';
+import net              from 'net';
+import os               from 'os';
 import Neo              from '../../../../../../../../src/Neo.mjs';
 import * as core        from '../../../../../../../../src/core/_export.mjs';
 
@@ -329,6 +331,233 @@ test.describe('Neo.ai.mcp.server.shared.services.TransportService', () => {
 
         test('ignores an unparseable publicUrl without throwing', () => {
             expect(TransportService.computeAllowedHosts({publicUrl: 'not a url'})).toEqual(['localhost', '127.0.0.1', '[::1]']);
+        });
+    });
+
+    /**
+     * @summary Real-socket coverage for the loopback/origin/Host/bearer ingress contract.
+     */
+    test.describe('local-bearer ingress', () => {
+        let TransportService, McpServer, generateLocalBearerToken;
+
+        const externalIpv4 = Object.values(os.networkInterfaces())
+            .flat()
+            .find(address => address && !address.internal && (address.family === 'IPv4' || address.family === 4))
+            ?.address;
+
+        function localConfig(token, overrides = {}) {
+            return {
+                mcpHttpHost  : '127.0.0.1',
+                mcpListenHost: '127.0.0.1',
+                mcpHttpPort  : 0,
+                auth         : {
+                    mode              : 'local-bearer',
+                    localBearerToken  : token,
+                    trustProxyIdentity: false
+                },
+                ...overrides
+            }
+        }
+
+        function httpRequest({port, method='POST', headers={}, body}) {
+            return new Promise((resolve, reject) => {
+                const request = http.request({
+                    host: '127.0.0.1',
+                    port,
+                    path: '/mcp',
+                    method,
+                    headers
+                }, response => {
+                    const chunks = [];
+
+                    response.on('data', chunk => chunks.push(chunk));
+                    response.on('end', () => resolve({
+                        body   : Buffer.concat(chunks).toString('utf8'),
+                        headers: response.headers,
+                        status : response.statusCode
+                    }));
+                });
+
+                request.on('error', reject);
+                if (body !== undefined) {
+                    request.write(body)
+                }
+                request.end()
+            })
+        }
+
+        function initializeBody() {
+            return JSON.stringify({
+                jsonrpc: '2.0',
+                id     : 1,
+                method : 'initialize',
+                params : {
+                    protocolVersion: '2024-11-05',
+                    capabilities   : {},
+                    clientInfo     : {name: 'local-bearer-test', version: '1.0.0'}
+                }
+            })
+        }
+
+        async function setupLocal({token=generateLocalBearerToken(), aiConfig={}, server} = {}) {
+            const mcpServer = new McpServer({name: 'local-bearer-test', version: '1.0.0'});
+
+            await TransportService.setup({
+                server: server || {
+                    mcpServer,
+                    onSessionClosed: () => {}
+                },
+                aiConfig    : localConfig(token, aiConfig),
+                logger      : {info: () => {}, warn: () => {}, error: () => {}},
+                resourceName: 'LocalBearerTest'
+            });
+
+            return {
+                port: TransportService.httpServer.address().port,
+                token
+            }
+        }
+
+        function canConnect(host, port) {
+            return new Promise(resolve => {
+                const socket  = net.createConnection({host, port});
+                let   settled = false;
+
+                const finish = connected => {
+                    if (settled) {
+                        return
+                    }
+                    settled = true;
+                    socket.destroy();
+                    resolve(connected)
+                };
+
+                socket.setTimeout(1000);
+                socket.once('connect', () => finish(true));
+                socket.once('error',   () => finish(false));
+                socket.once('timeout', () => finish(false));
+            })
+        }
+
+        test.beforeAll(async () => {
+            TransportService        = (await import('../../../../../../../../ai/mcp/server/shared/services/TransportService.mjs')).default;
+            McpServer               = (await import('@modelcontextprotocol/sdk/server/mcp.js')).McpServer;
+            generateLocalBearerToken = (await import('../../../../../../../../ai/mcp/server/shared/helpers/localBearer.mjs')).generateLocalBearerToken;
+        });
+
+        test.beforeEach(() => {
+            // Legacy cases above call Base.destroy(), which clears instance-owned maps. Recreate
+            // this describe's isolated session state so CI's single worker does not inherit it.
+            TransportService.app        = null;
+            TransportService.httpServer = null;
+            TransportService.transports = new Map();
+            TransportService.mcpServers = new Map()
+        });
+
+        test.afterEach(async () => {
+            if (TransportService.httpServer?.listening) {
+                await new Promise((resolve, reject) => {
+                    TransportService.httpServer.close(error => error ? reject(error) : resolve())
+                })
+            }
+
+            TransportService.app        = null;
+            TransportService.httpServer = null;
+            TransportService.transports.clear();
+            TransportService.mcpServers.clear()
+        });
+
+        test('fails startup unless the actual listener bind is literal 127.0.0.1', async () => {
+            const token = generateLocalBearerToken();
+
+            await expect(TransportService.setup({
+                server      : {mcpServer: {connect: async () => {}}},
+                aiConfig    : localConfig(token, {mcpListenHost: 'localhost'}),
+                logger      : {info: () => {}},
+                resourceName: 'InvalidLocalBind'
+            })).rejects.toThrow(/literal IPv4 loopback address '127\.0\.0\.1'/);
+
+            expect(TransportService.httpServer?.listening).not.toBe(true);
+        });
+
+        test('binds the real socket to IPv4 loopback and accepts an absent-Origin valid request', async () => {
+            const {port, token} = await setupLocal();
+            const address       = TransportService.httpServer.address();
+
+            expect(address.address).toBe('127.0.0.1');
+
+            const response = await httpRequest({
+                port,
+                headers: {
+                    Accept        : 'application/json, text/event-stream',
+                    Authorization : `Bearer ${token}`,
+                    'Content-Type': 'application/json'
+                },
+                body: initializeBody()
+            });
+
+            expect(response.status).toBe(200);
+            expect(response.headers['mcp-session-id']).toBeTruthy();
+        });
+
+        test('rejects every present Origin before auth or MCP dispatch, including an empty value', async () => {
+            let   connectCalls = 0;
+            const token        = generateLocalBearerToken();
+            const {port}       = await setupLocal({
+                token,
+                server: {mcpServer: {connect: async () => { connectCalls++ }}}
+            });
+
+            for (const origin of ['https://browser.example', '']) {
+                const response = await httpRequest({
+                    port,
+                    method : 'GET',
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        Origin       : origin
+                    }
+                });
+
+                expect(response.status).toBe(403);
+                expect(response.body).toContain('Origin header is not allowed');
+            }
+
+            expect(connectCalls).toBe(0);
+        });
+
+        test('keeps bearer and Host validation as independent guards', async () => {
+            const {port, token} = await setupLocal({
+                server: {mcpServer: {connect: async () => {}}}
+            });
+
+            const missing = await httpRequest({port, method: 'GET'});
+            expect(missing.status).toBe(401);
+
+            const invalidBearer = await httpRequest({
+                port,
+                method : 'GET',
+                headers: {Authorization: `Bearer ${generateLocalBearerToken()}`}
+            });
+            expect(invalidBearer.status).toBe(401);
+
+            const invalidHost = await httpRequest({
+                port,
+                method : 'GET',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    Host         : 'attacker.example'
+                }
+            });
+            expect(invalidHost.status).toBe(403);
+            expect(invalidHost.body).toContain('Invalid Host');
+        });
+
+        test('is unreachable through a discovered non-loopback IPv4 interface', async () => {
+            test.skip(!externalIpv4, 'No non-loopback IPv4 interface is available in this test environment');
+
+            const {port} = await setupLocal();
+
+            expect(await canConnect(externalIpv4, port)).toBe(false);
         });
     });
 


### PR DESCRIPTION
Resolves #15185

Related: #15184

Related: #15187

Adds an opt-in local Streamable HTTP ingress that is pinned to IPv4 loopback, rejects browser-originated requests, preserves the SDK Host allowlist, and authenticates one disposable possession credential without resolving or provisioning an identity. Existing OIDC, GitLab-PAT, proxy-identity, and unauthenticated profiles retain their prior listener and middleware paths.

Evidence: L3 (real Express/MCP socket bound to `127.0.0.1`, authenticated SDK initialize request, present-Origin/invalid-Host/invalid-bearer rejection, and non-loopback reachability probe) → L3 required (the close target's observable local-ingress ACs). No residuals.

## Deltas from ticket

- The ticket refers to both canonical config/template surfaces. Repository reality has one tracked canonical SSOT, `ai/config.template.mjs`, plus the gitignored operator overlay `ai/config.mjs`; this PR changes the tracked template and relies on the existing `--migrate-config` path to materialize the new leaves without committing operator state.
- The generic generator and server/client launch contract live in `shared/helpers/localBearer.mjs`. The executable BigData reference journey remains owned by `#15187`, avoiding duplicate journey acceptance surfaces.
- The configured credential is validated as canonical unpadded base64url for exactly 32 bytes at startup, which is stricter than the ticket's non-empty minimum. The SDK-required numeric expiry uses `Number.MAX_SAFE_INTEGER`; process exit remains the actual revocation boundary, so no arbitrary wall-clock TTL is introduced.

## Test Evidence

- `CI=1 NEO_CHROMA_PORT_TEST=18185 npm run test-unit -- test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/mcp/server/shared/helpers/localBearer.spec.mjs test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs test/playwright/unit/ai/mcp/server/shared/services/TransportService.spec.mjs --retries=0` — **60 passed**.
- `CI=1 NEO_CHROMA_PORT_TEST=18185 npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs --retries=0` — **31 passed** after the broad parallel run exposed a cross-file boot race.
- `npx lint-staged` / commit hook — whitespace, shorthand, JSDoc types, ticket archaeology, block alignment, AiConfig test mutation, and parse gates all passed.
- `npm run --silent ai:structure-map -- --files --loc` — passed for the new shared helper placement.
- Broad `NEO_CHROMA_PORT_TEST=18185 npm run test-unit` attempt — **7,200 passed, 5 skipped**; the run was not green in this sandbox: 11 failures consisted of protected `.neo-ai-data` `EPERM` writes plus parallel shared-state/30-second timeout cases. The only MCP list-tools failure from that run passed 31/31 in the isolated CI-shape rerun above.
- Config authority: `config.template.spec.mjs` covers optional bind defaults, env resolution, and local-bearer readiness.
- Credential helper: `localBearer.spec.mjs` covers random-byte shape, canonical encoding, strict validation, equal-length comparison, and the frozen in-memory launch contract.
- Auth boundary: `AuthService.spec.mjs` drives the real MCP SDK bearer middleware across valid, missing, malformed, length-mismatched, and wrong-token cases, asserting no identity fields and no token logging.
- Transport boundary: `TransportService.spec.mjs` uses a real socket and MCP initialize request to prove loopback binding, absent/present Origin behavior, independent Host/auth guards, and non-loopback unreachability.

## Post-Merge Validation

- [ ] In a fresh checkout, run `npm run prepare -- --migrate-config` and confirm the two new Tier-1 leaves materialize into the local operator overlay without overwriting operator deltas.
- [ ] Confirm `#15187` consumes the generic launch contract in the executable BigData journey after `#15186` lands; this is downstream scope, not a residual `#15185` AC.

## Evolution

The implementation originally considered a short synthetic bearer TTL. Exercising the real SDK boundary showed that `AuthInfo.expiresAt` must remain a numeric future timestamp, while the accepted security contract defines process exit as revocation. A maximum numeric sentinel preserves SDK compatibility without inventing a second lifetime policy.

Authored by Euclid (OpenAI GPT-5.6 Sol Ultra, Codex Desktop). Session 7efa8a03-b5cb-46c6-b1e9-bda072fead25.
