### PR TITLE
feat(agentos): FM cockpit agent-detail pop-out — own OS window on the shared heap (#14610)

### DIFF
--- a/apps/agentos/view/fleet/AgentDetail.mjs
+++ b/apps/agentos/view/fleet/AgentDetail.mjs
@@ -1,3 +1,4 @@
+import Button                                         from '../../../../src/button/Base.mjs';
 import Container                                      from '../../../../src/container/Base.mjs';
 import FamilyRail                                     from './FamilyRail.mjs';
 import Image                                          from '../../../../src/component/Image.mjs';
@@ -77,8 +78,12 @@ const paneConfig = pane => ({
  * {@link module:apps/agentos/view/fleet/agentFreshness}; this view is its first consumer.
  *
  * **Shell-agnostic + layout-blind:** the view takes ordinary configs only — no
- * dock/layout/Electron coupling reaches it — so the pop-out leaf (T4.15) reparents it into its own
- * OS window without change.
+ * dock/layout/Electron coupling reaches it — so the pop-out (T4.15) reparents it into its own
+ * OS window without change. The header's pop-out affordance keeps that contract: it only FIRES
+ * `popOutIntent` with the current {@link #popOutMode}; the owning cockpit routes the intent
+ * through the dock layer and writes the mode back. The affordance is record-gated (it rides the
+ * identity header) — a popped-out inspector whose resident leaves the roster falls back to the
+ * empty state, and closing its window manually is the documented reattach path.
  *
  * @class AgentOS.view.fleet.AgentDetail
  * @extends Neo.container.Base
@@ -129,6 +134,15 @@ class AgentDetail extends Container {
          * @member {Number} freshnessRefreshMs=30000
          */
         freshnessRefreshMs: 30000,
+        /**
+         * Where this inspector currently renders — `'docked'` (inside the cockpit's dock
+         * projection) or `'windowed'` (its own OS window on the shared heap). DISPLAY state the
+         * owning cockpit writes after routing a `popOutIntent`; the view only flips its affordance
+         * (icon + accessible label) — it never executes dock or window operations itself.
+         * @member {String} popOutMode_='docked'
+         * @reactive
+         */
+        popOutMode_: 'docked',
         /**
          * @member {Object} layout={ntype:'vbox',align:'stretch'}
          * @reactive
@@ -187,6 +201,16 @@ class AgentDetail extends Container {
                         cls      : ['fm-detail-engine'],
                         flex     : 'none',
                         reference: 'detail-engine'
+                    }, {
+                        // the layout-blind pop-out affordance: fires intent, executes nothing —
+                        // the owning cockpit routes it through the dock layer (T4.15); icon +
+                        // accessible label sync from popOutMode via syncPopOutAffordance
+                        module   : Button,
+                        cls      : ['fm-detail-popout'],
+                        flex     : 'none',
+                        handler  : 'up.onPopOutButtonClick',
+                        iconCls  : 'fa-solid fa-arrow-up-right-from-square',
+                        reference: 'detail-popout-button'
                     }]
                 }, {
                     // the durable anchor, rendered small beneath the display name — name is display
@@ -223,7 +247,49 @@ class AgentDetail extends Container {
         // render flush; a later re-seat (applyRecord) keeps the root, so the region survives.
         Object.assign(this.vdom, {role: 'region', 'aria-label': 'Agent detail'});
         this.applyRecord();
+        this.syncPopOutAffordance();
         this.startFreshnessAging()
+    }
+
+    /**
+     * Triggered after the popOutMode config changed — the owning cockpit writes the mode after
+     * routing an intent; the view flips only its affordance rendering.
+     * @param {String} value
+     * @param {String} oldValue
+     * @protected
+     */
+    afterSetPopOutMode(value, oldValue) {
+        this.isConstructed && this.syncPopOutAffordance()
+    }
+
+    /**
+     * @summary Render the pop-out affordance for the current {@link #popOutMode}: the detach icon +
+     * label while docked, the reattach icon + label while windowed. Vdom-level `aria-label` (the
+     * house idiom) keeps the icon-only button accessible in both states.
+     * @protected
+     */
+    syncPopOutAffordance() {
+        let me       = this,
+            windowed = me.popOutMode === 'windowed',
+            button   = me.getReference('detail-popout-button'),
+            label    = windowed ? 'Reattach to the cockpit' : 'Pop out to its own window';
+
+        if (button) {
+            button.iconCls = windowed
+                ? 'fa-solid fa-down-left-and-up-right-to-center'
+                : 'fa-solid fa-arrow-up-right-from-square';
+
+            button.changeVdomRootKey('aria-label', label);
+            button.changeVdomRootKey('title', label)
+        }
+    }
+
+    /**
+     * @summary The affordance click: report intent only — the owning cockpit decides what a click
+     * means for the current mode and executes the dock/window operations.
+     */
+    onPopOutButtonClick() {
+        this.fire('popOutIntent', {mode: this.popOutMode})
     }
 
     /**

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -65,6 +65,17 @@ const FIXTURE_ACTIVITY = [
  * {@link #loadRoster} re-points it at the running fleet when the registry bridge wires up. The
  * activity zone composes {@link ActivityStream} → EventChip the same way ({@link #loadActivity}).
  *
+ * **Pop-out (T4.15):** the agent-detail inspector detaches to its own OS window while staying on
+ * the ONE shared App-Worker heap — windows are render targets, so the live instance moves and
+ * nothing re-instantiates. {@link #popOutAgentDetail} prunes the `detail` item from the committed
+ * document (`detachItem` keeps its catalog record), parks the LIVE pane, and opens the
+ * widget-childapp vessel (the app's established bare popup host); {@link #onWindowConnect} adds
+ * the parked instance to the popup's viewport, and {@link #reattachAgentDetail} brings it home
+ * (`addTab` into the remembered tabs node, first-tabs fallback). While detached, every detail
+ * consumer routes through {@link #getAgentDetailPane} — a popup-mounted pane lives in the
+ * vessel's view tree, out of this cockpit's `getReference` reach — so record mutation, selection
+ * reconciliation and the card→detail drill keep feeding the popped-out inspector live.
+ *
  * @class AgentOS.view.fleet.FleetCockpit
  * @extends Neo.container.Base
  */
@@ -218,6 +229,28 @@ class FleetCockpit extends Container {
      * @protected
      */
     detailRecord = null
+    /**
+     * Detached-detail bookkeeping — `null` while the inspector is docked. While popped out it
+     * holds `{homeTabsNodeId, windowId, windowName}`: the tabs node the reattach targets (with
+     * first-tabs fallback), the popup's `windowId` once it connects (`null` until then), and the
+     * vessel's window name for the close call. Cleared BEFORE the reattach's async vessel close —
+     * the cleared entry is the {@link #onWindowDisconnect} re-entrancy guard.
+     * @member {Object|null} detachedDetail=null
+     * @protected
+     */
+    detachedDetail = null
+    /**
+     * The live {@link AgentOS.view.fleet.AgentDetail} instance handle while it is OUT of this
+     * cockpit's projected tree (parked mid-flight or mounted in its popup window). A
+     * popup-mounted pane lives in the vessel's view tree — out of this cockpit's `down()` /
+     * `getReference` reach — so every detail consumer routes through {@link #getAgentDetailPane},
+     * the deterministic route across every phase. `null` while docked (the projection owns the
+     * pane); survives one projection cycle past reattach so {@link #resolveDockComponentRef}
+     * re-adopts the SAME instance, never a recreation.
+     * @member {Neo.container.Base|null} detachedDetailPane=null
+     * @protected
+     */
+    detachedDetailPane = null
 
     /**
      * @summary Seed the layout SSOT and build the toolbar + dock projection as instance items —
@@ -233,6 +266,13 @@ class FleetCockpit extends Container {
         me.dockPreviewProducer = Neo.create(DockPreviewProducer);
         me.perspectiveStore    = Neo.create(DockPerspectiveStore, {collection: cockpitPresetCollection()});
         me.dockModel           = me.dockModel || cockpitDockDocument();
+
+        // popup lifecycle: the popped-out inspector reparents on connect, comes home on disconnect
+        Neo.currentWorker.on({
+            connect   : me.onWindowConnect,
+            disconnect: me.onWindowDisconnect,
+            scope     : me
+        });
 
         me.add(me.buildWorkspaceItems())
     }
@@ -367,6 +407,9 @@ class FleetCockpit extends Container {
             host       : me,
             nextConfig,
             placeholders,
+            // a detached inspector is owner-preserved: the reconciler parks the pane (never
+            // destroys it) and retires only its obsolete tab button
+            preserveItemIds: me.detachedDetailPane ? ['detail'] : [],
             resolveItem: itemId => {
                 const item = document.items[itemId];
 
@@ -522,12 +565,33 @@ class FleetCockpit extends Container {
                     reference   : 'activity-stream'
                 };
             case 'agent-detail':
+                // the pane lives in its popup window — a preset restore (or an NL-driven addTab)
+                // can re-tree the `detail` item while detached, and materializing here would STEAL
+                // the live instance out of its window: an honest stand-in instead. The reattach
+                // swaps it for the live pane post-projection (the reconciler prefers tree-live
+                // occupants over this resolver, so the swap cannot ride the normal adoption).
+                if (me.detachedDetail) {
+                    return {
+                        ntype    : 'component',
+                        cls      : [marker, 'fm-pane-placeholder'],
+                        html     : 'Agent detail is open in its own window',
+                        reference: 'agent-detail-standin'
+                    }
+                }
+
+                // reattach re-adoption: the parked LIVE instance returns to the projection —
+                // same instance id, same runtime state, never a recreation
+                if (me.detachedDetailPane) {
+                    return me.detachedDetailPane
+                }
+
                 // the drill-in inspector; its selected resident is OWNER-held so a pane returning
                 // from true absence never drops the selection — null renders the view's honest
                 // "select an agent" empty state
                 return {
                     module   : AgentDetail,
                     cls      : [marker],
+                    listeners: {popOutIntent: me.onDetailPopOutIntent.bind(me)},
                     record   : me.detailRecord,
                     reference: 'agent-detail'
                 };
@@ -612,17 +676,215 @@ class FleetCockpit extends Container {
     }
 
     /**
+     * @summary Resolve the live {@link AgentOS.view.fleet.AgentDetail} instance wherever it
+     * currently renders — the projected tree while docked, the owner-held handle while detached.
+     * A popup-mounted pane lives in the vessel's view tree, out of this cockpit's `down()` /
+     * `getReference` reach, so every detail consumer (record mutation, selection reconciliation,
+     * the card→detail drill) routes through this accessor — the popped-out inspector stays as
+     * live as the docked one.
+     * @returns {Neo.container.Base|null} The detail pane, or `null` before its first materialization.
+     */
+    getAgentDetailPane() {
+        return this.detachedDetailPane || this.getReference('agent-detail')
+    }
+
+    /**
+     * @summary Detach the agent-detail inspector into its own OS window on the shared heap.
+     *
+     * The dock document stays the layout SSOT: `detachItem` prunes the `detail` item from the tree
+     * while preserving its catalog record (window ownership, per the dockZone.v1 contract), so
+     * Neural Link topology reads stay truthful about the detached state. The LIVE pane instance is
+     * parked (`remove(pane, false)`) BEFORE the re-projection retires the old shell, then the
+     * widget-childapp vessel opens and {@link #onWindowConnect} moves the instance in — a
+     * render-target change; the freshness-aging loop, the record and every pane keep running
+     * un-remounted. A vessel failure restores the docked state commit-or-neither via
+     * {@link #reattachAgentDetail}.
+     * @returns {Promise<{detached: Boolean, errors: String[]}>}
+     */
+    async popOutAgentDetail() {
+        let me   = this,
+            pane = me.getReference('agent-detail'),
+            home = DockZoneModel.findContainingTabsId(me.dockModel, 'detail');
+
+        if (me.detachedDetail || !pane || !home) {
+            return {detached: false, errors: ['agent-detail is not a docked, projected pane']}
+        }
+
+        let result = me.applyDockZoneOperation({operation: 'detachItem', itemId: 'detail'});
+
+        if (result.errors.length) {
+            return {detached: false, errors: result.errors}
+        }
+
+        me.detachedDetail     = {homeTabsNodeId: home, windowId: null, windowName: `fm-agent-detail-${me.id}`};
+        me.detachedDetailPane = pane;
+        pane.popOutMode       = 'windowed';
+
+        // the re-projection parks the preserved pane (alive on the shared heap, out of every
+        // parent) and retires its tab button — awaited, so the vessel's connect can never race
+        // a pane the old shell still holds
+        me.onDockZoneDocumentChange(result.document);
+        await me.refreshPromise;
+
+        try {
+            let {windowConfigs} = Neo,
+                firstWindowId   = Object.keys(windowConfigs)[0],
+                {basePath}      = windowConfigs[firstWindowId],
+                winData         = await Neo.Main.getWindowData({windowId: me.windowId});
+
+            await Neo.Main.windowOpen({
+                url           : `${basePath}apps/agentos/childapps/widget/index.html?detail=agent-detail&cockpitId=${me.id}`,
+                windowFeatures: `height=640,width=480,left=${winData.screenLeft + 160},top=${winData.screenTop + 120}`,
+                windowId      : me.windowId,
+                windowName    : me.detachedDetail.windowName
+            })
+        } catch (error) {
+            // the vessel failed after the document committed: restore the docked state
+            // commit-or-neither (the reattach re-adopts the parked instance)
+            await me.reattachAgentDetail({windowAlreadyClosed: true});
+
+            return {detached: false, errors: [`popup open failed: ${error?.message || error}`]}
+        }
+
+        return {detached: true, errors: []}
+    }
+
+    /**
+     * @summary Bring the detached inspector home: `addTab` returns the `detail` item into its
+     * remembered tabs node (or the first tabs node when a preset switch retired it — never a
+     * dangling reattach; an item a preset already resurrected relocates via the same operation),
+     * the parked instance is re-adopted by the projection ({@link #resolveDockComponentRef} hands
+     * back the SAME instance), and the popup vessel closes unless it already closed itself.
+     * Bookkeeping clears BEFORE the async close — the cleared entry is the
+     * {@link #onWindowDisconnect} re-entrancy guard.
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.windowAlreadyClosed=false] `true` when the disconnect path runs
+     *     the reattach (the vessel is already gone — do not close it again).
+     * @returns {Promise<{reattached: Boolean, errors: String[]}>}
+     */
+    async reattachAgentDetail({windowAlreadyClosed=false}={}) {
+        let me    = this,
+            entry = me.detachedDetail,
+            pane  = me.detachedDetailPane;
+
+        if (!entry || !pane) {
+            return {errors: ['agent-detail is not detached'], reattached: false}
+        }
+
+        let home = me.dockModel.nodes[entry.homeTabsNodeId]?.type === 'tabs'
+                ? entry.homeTabsNodeId
+                : Object.keys(me.dockModel.nodes).find(id => me.dockModel.nodes[id].type === 'tabs'),
+            result = me.applyDockZoneOperation({operation: 'addTab', itemId: 'detail', tabsNodeId: home});
+
+        if (result.errors.length) {
+            return {errors: result.errors, reattached: false}
+        }
+
+        me.detachedDetail = null;
+        pane.popOutMode   = 'docked';
+
+        // the re-projection re-adopts the instance: the resolver hands it back and the
+        // container insert performs the atomic move out of the popup viewport (core contract)
+        me.onDockZoneDocumentChange(result.document);
+
+        await me.refreshPromise;
+
+        // an external re-tree while detached left a stand-in occupying the slot, and the
+        // reconciler keeps tree-live occupants — swap it for the live instance, same position
+        let standin = me.getReference('agent-detail-standin');
+
+        if (standin) {
+            let parent = standin.parent,
+                index  = parent.items.indexOf(standin);
+
+            parent.remove(standin, true);
+            parent.insert(index, pane)
+        }
+
+        me.detachedDetailPane = null;
+
+        if (!windowAlreadyClosed) {
+            try {
+                await Neo.Main.windowClose({names: [entry.windowName], windowId: me.windowId})
+            } catch (error) {
+                return {errors: [`popup close failed: ${error?.message || error}`], reattached: true}
+            }
+        }
+
+        return {errors: [], reattached: true}
+    }
+
+    /**
+     * @summary The inspector's layout-blind pop-out affordance reports intent only — the OWNER
+     * routes it by current state: docked → {@link #popOutAgentDetail}, detached →
+     * {@link #reattachAgentDetail}. The pane itself never learns dock semantics.
+     * @param {Object} data The `popOutIntent` event payload.
+     * @returns {Promise<Object>} The routed operation's result.
+     */
+    onDetailPopOutIntent(data) {
+        let me = this;
+
+        return me.detachedDetail ? me.reattachAgentDetail() : me.popOutAgentDetail()
+    }
+
+    /**
+     * @summary A window joined the shared heap: if it is OUR detail vessel (the pop-out URL
+     * carries `detail=agent-detail&cockpitId=<this.id>`), move the parked LIVE pane into its main
+     * view. The instance moves trees on the one App-Worker heap — nothing is recreated; the
+     * freshness-aging loop keeps ticking through the transition.
+     * @param {Object} data `{appName, windowId}`
+     * @protected
+     */
+    async onWindowConnect(data) {
+        let me         = this,
+            {windowId} = data,
+            app        = Neo.apps[windowId];
+
+        if (!app || me.isDestroyed || !me.detachedDetail || !me.detachedDetailPane) {
+            return
+        }
+
+        let url    = await Neo.Main.getByPath({path: 'document.URL', windowId}),
+            params = new URL(url).searchParams;
+
+        if (params.get('cockpitId') !== me.id || params.get('detail') !== 'agent-detail') {
+            return
+        }
+
+        me.detachedDetail.windowId = windowId;
+        app.mainView.add(me.detachedDetailPane)
+    }
+
+    /**
+     * @summary The detail vessel closed (user-closed or crashed): the inspector comes HOME through
+     * the standard reattach — the document records the return and the projection re-adopts the
+     * parked instance. A reattach-initiated close never re-enters: {@link #reattachAgentDetail}
+     * clears the bookkeeping before closing the vessel.
+     * @param {Object} data `{appName, windowId}`
+     * @protected
+     */
+    onWindowDisconnect(data) {
+        let me = this;
+
+        if (!me.isDestroyed && me.detachedDetail?.windowId === data.windowId) {
+            me.reattachAgentDetail({windowAlreadyClosed: true})
+        }
+    }
+
+    /**
      * @summary Keep the open detail inspector truthful over time — route the roster store's
-     * `recordChange` to the mounted {@link AgentOS.view.fleet.AgentDetail} when the changed record
+     * `recordChange` to the live {@link AgentOS.view.fleet.AgentDetail} when the changed record
      * is the one being inspected (mirrors how the grid routes `recordChange` to its cards). A roster
      * re-poll mutating the selected resident (state, lane, sources) thus re-renders the detail in
      * place — the view is reactive to record MUTATION, not only to a re-seat onto a new record.
+     * Routed through {@link #getAgentDetailPane} so a popped-out inspector updates exactly like a
+     * docked one.
      * @param {Object} data The store `recordChange` event `{record, ...}`.
      * @protected
      */
     onDetailRecordChange({record}) {
         if (record === this.detailRecord) {
-            this.getReference('agent-detail')?.applyRecord()
+            this.getAgentDetailPane()?.applyRecord()
         }
     }
 
@@ -655,19 +917,36 @@ class FleetCockpit extends Container {
 
         if (current !== me.detailRecord) {
             me.detailRecord = current;
-            me.getReference('agent-detail')?.set({record: current})
+            me.getAgentDetailPane()?.set({record: current})
         }
     }
 
     /**
-     * @summary Detach the roster-store load guard and release the drop producer; the provider
-     * tears the owned store itself down.
+     * @summary Detach the roster-store load guard, the popup lifecycle listeners and the drop
+     * producer; the provider tears the owned store itself down. A still-detached inspector is
+     * OWNED state outside any projection: close its vessel (fire-and-forget — the guard in
+     * {@link #onWindowDisconnect} keeps a late event inert) and destroy the instance.
      * @param {...*} args
      */
     destroy(...args) {
         let me = this;
 
         me.getReference('fleet-grid')?.store?.un({load: me.onRosterStoreLoad, recordChange: me.onDetailRecordChange, scope: me});
+
+        Neo.currentWorker.un({
+            connect   : me.onWindowConnect,
+            disconnect: me.onWindowDisconnect,
+            scope     : me
+        });
+
+        if (me.detachedDetail) {
+            Neo.Main.windowClose({names: [me.detachedDetail.windowName], windowId: me.windowId}).catch(() => {});
+            me.detachedDetail = null
+        }
+
+        me.detachedDetailPane?.destroy();
+        me.detachedDetailPane = null;
+
         me.dockPreviewProducer?.destroy();
         me.dockPreviewProducer = null;
         me.perspectiveStore?.destroy();

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -158,7 +158,10 @@ class FleetCockpitController extends Controller {
         }
 
         cockpit.detailRecord = record;
-        me.getReference('agent-detail')?.set({record});
+        // routed through the owner accessor: a popped-out inspector lives in the vessel's view
+        // tree (outside this controller's getReference reach) and must drill exactly like a
+        // docked one
+        cockpit.getAgentDetailPane()?.set({record});
 
         if (cockpit.dockModel?.items?.detail?.autoHidden) {
             const result = cockpit.applyDockZoneOperation({operation: 'setItemAutoHidden', itemId: 'detail', autoHidden: false});

--- a/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
@@ -58,6 +58,24 @@
         color      : var(--fm-ink-dim);
     }
 
+    /* the pop-out affordance — icon-only ghost beside the engine tag; its label rides
+       aria-label/title (mode-synced: detach while docked, reattach while windowed) */
+    .fm-detail-popout {
+        flex      : none;
+        padding   : 2px 6px;
+        min-height: 0;
+        background: transparent;
+        border    : none;
+        font-size : 11px;
+        color     : var(--fm-ink-dim);
+        cursor    : pointer;
+
+        &:hover,
+        &:focus-visible {
+            color: var(--fm-ink);
+        }
+    }
+
     /* the durable anchor — always shown, smallest + faintest: the name is display state OVER it */
     .fm-detail-id {
         font-family: var(--fm-font-mono);

--- a/test/playwright/e2e/agentos/FleetCockpitPopOutNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitPopOutNL.spec.mjs
@@ -1,0 +1,167 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e for the cockpit pop-out: the agent-detail inspector detaches to a
+ * REAL second browser window while staying on the ONE SharedWorker App-Worker heap, and comes
+ * home — reparent-never-recreate, live through every phase:
+ *
+ * 1. drill: a card click reveals the detail inspector with its resident (the standard commit loop);
+ * 2. detach: the header affordance opens the widget-childapp vessel — the dock document prunes the
+ *    `detail` item but keeps its catalog record (Neural Link topology stays truthful), and the SAME
+ *    AgentDetail instance (App-Worker id) renders in the popup;
+ * 3. live continuity: selecting a DIFFERENT card in the MAIN window re-renders the popped-out
+ *    inspector — main-window intent → App Worker → popup render target, no remount anywhere;
+ * 4. reattach: the popup's affordance brings the item home (document re-trees it), closes the
+ *    vessel, and the SAME instance renders docked again with the state it gathered while windowed.
+ *
+ * The full gesture-driven drill tour (card → detail → pop-out → reattach as a narrated journey)
+ * is the drill-e2e sibling leaf's scope; this witness proves the capability spine it builds on.
+ *
+ * Run: NEO_E2E_PORT=8119 npx playwright test agentos/FleetCockpitPopOutNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('AgentOS Fleet cockpit — agent-detail pop-out round-trip (Neural Link)', () => {
+    test.setTimeout(120000);
+
+    test('detach → own OS window on the shared heap → live update while windowed → reattach home', async ({page, neuralLink}) => {
+        const pageErrors = [];
+
+        page.on('pageerror', error => {
+            const value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/agentos/index.html');
+        await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
+
+        // 1) drill through the REAL controller seam (onAgentSelect: owner-held record + the
+        // setItemAutoHidden reveal through the commit loop). Driven via callMethod because the
+        // card-click → agentSelect DOM chain is regressed on dev (own bug ticket; the full
+        // gesture journey belongs to the drill-e2e sibling leaf) — the seam below the gesture is
+        // the production path.
+        await expect(page.locator('.fm-agent-card').first()).toBeVisible({timeout: 30000});
+
+        const app   = await neuralLink.connectToApp('AgentOS'),
+              cards = await app.queryComponent({className: 'AgentOS.view.fleet.AgentCard'}, ['record', 'id']);
+
+        expect(cards.length, 'the fleet renders cards with records').toBeGreaterThan(1);
+
+        const controllers  = await app.findInstances({className: 'AgentOS.view.fleet.FleetCockpitController'}, ['id']),
+              controllerId = (Array.isArray(controllers) ? controllers[0] : controllers)?.id,
+              firstAgentId = cards[0]?.properties?.record?.agentId;
+
+        expect(controllerId, 'the cockpit controller must exist in the App Worker').toBeTruthy();
+        expect(firstAgentId, 'the first card carries a resident record').toBeTruthy();
+
+        await app.callMethod(controllerId, 'onAgentSelect', [{agentId: firstAgentId}]);
+
+        const detailRoot = page.locator('.fm-agent-detail');
+
+        await expect(detailRoot).toBeVisible({timeout: 30000});
+        await expect(page.locator('.fm-detail-popout')).toBeVisible();
+
+        const cockpits = await app.findInstances({className: 'AgentOS.view.fleet.FleetCockpit'}, ['id']),
+              holderId = (Array.isArray(cockpits) ? cockpits[0] : cockpits)?.id,
+              details  = await app.findInstances({className: 'AgentOS.view.fleet.AgentDetail'}, ['id']),
+              detail0  = Array.isArray(details) ? details[0] : details,
+              detailId = detail0?.id;
+
+        expect(holderId, 'the FleetCockpit must exist in the App Worker').toBeTruthy();
+        expect(detailId, 'the AgentDetail must exist in the App Worker').toBeTruthy();
+
+        const queryDetail = async () => {
+            const matches = await app.queryComponent({className: 'AgentOS.view.fleet.AgentDetail'}, ['record', 'popOutMode', 'id']);
+            return (Array.isArray(matches) ? matches : [matches]).find(candidate => candidate?.id === detailId)
+        };
+
+        const drilledAgentId = (await queryDetail())?.properties?.record?.agentId;
+
+        expect(drilledAgentId, 'the drill seated a resident record').toBeTruthy();
+
+        const topoDocked = await app.getDockTopology(holderId),
+              docDocked  = topoDocked?.document ?? topoDocked;
+
+        expect(docDocked.nodes['secondary-rail'].items).toContain('detail');
+
+        // 2) detach: one affordance click opens the REAL vessel window
+        const popupPromise = page.waitForEvent('popup', {timeout: 30000});
+
+        await page.locator('.fm-detail-popout').click();
+
+        const popup = await popupPromise;
+
+        await popup.waitForLoadState('domcontentloaded');
+        expect(popup.url()).toContain('childapps/widget/index.html');
+        expect(popup.url()).toContain('cockpitId=');
+
+        const popupErrors = [];
+
+        popup.on('pageerror', error => {
+            const value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && popupErrors.push(value)
+        });
+
+        // the SAME live instance renders in the popup; the main window no longer shows it
+        await expect(popup.locator('.fm-agent-detail')).toBeVisible({timeout: 30000});
+        await expect(page.locator('.fm-agent-detail')).toHaveCount(0);
+
+        // document truth while detached: out of the tree, still in the catalog
+        const topoDetached = await app.getDockTopology(holderId),
+              docDetached  = topoDetached?.document ?? topoDetached;
+
+        expect(docDetached.nodes['secondary-rail'].items).not.toContain('detail');
+        expect(docDetached.items.detail, 'detachItem keeps the catalog record').toBeTruthy();
+
+        const detached = await queryDetail();
+
+        expect(detached?.properties?.popOutMode).toBe('windowed');
+        expect(detached?.properties?.record?.agentId).toBe(drilledAgentId);
+
+        // 3) live continuity: a MAIN-window drill re-renders the WINDOWED inspector —
+        // one heap, two render targets, zero remounts
+        const secondAgentId = cards
+            .map(candidate => candidate?.properties?.record?.agentId)
+            .find(agentId => agentId && agentId !== drilledAgentId);
+
+        expect(secondAgentId, 'a second resident exists to drill into').toBeTruthy();
+        await app.callMethod(controllerId, 'onAgentSelect', [{agentId: secondAgentId}]);
+
+        await expect
+            .poll(async () => (await queryDetail())?.properties?.record?.agentId, {
+                message: 'the detached inspector must re-seat onto the newly selected resident',
+                timeout: 15000
+            })
+            .not.toBe(drilledAgentId);
+
+        const reseatedAgentId = (await queryDetail())?.properties?.record?.agentId;
+
+        // the POPUP's DOM renders the re-seated resident — worker truth reached the second window
+        await expect
+            .poll(async () => (await popup.locator('.fm-detail-id').textContent())?.trim(), {timeout: 15000})
+            .toBe(reseatedAgentId);
+
+        // 4) reattach from the popup's own affordance: the vessel closes, the item re-trees, the
+        // SAME instance renders docked with the state it gathered while windowed
+        const popupClosed = popup.waitForEvent('close', {timeout: 30000});
+
+        await popup.locator('.fm-detail-popout').click();
+        await popupClosed;
+
+        await expect(page.locator('.fm-agent-detail')).toBeVisible({timeout: 30000});
+
+        const topoHome = await app.getDockTopology(holderId),
+              docHome  = topoHome?.document ?? topoHome;
+
+        expect(docHome.nodes['secondary-rail'].items).toContain('detail');
+
+        const home      = await app.findInstances({className: 'AgentOS.view.fleet.AgentDetail'}, ['id']),
+              homeIds   = (Array.isArray(home) ? home : [home]).map(entry => entry?.id),
+              homeState = await queryDetail();
+
+        expect(homeIds, 'exactly one AgentDetail instance exists — never a recreation').toEqual([detailId]);
+        expect(homeState?.properties?.popOutMode).toBe('docked');
+        expect(homeState?.properties?.record?.agentId, 'the windowed-phase selection came home with the instance').toBe(reseatedAgentId);
+
+        expect(pageErrors, 'zero main-window page errors').toEqual([]);
+        expect(popupErrors, 'zero popup page errors').toEqual([])
+    })
+});

--- a/test/playwright/setup.mjs
+++ b/test/playwright/setup.mjs
@@ -148,6 +148,7 @@ export function setup(options = {}) {
         insertThemeFiles: () => {},
         isSharedWorker  : false,
         on              : () => {},
+        un              : () => {},
         promiseMessage  : async (dest, msg) => {
             if (msg?.action === 'readDom') {
                 if (msg.attributes?.includes('offsetHeight')) {

--- a/test/playwright/unit/apps/agentos/view/fleet/agentDetail.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentDetail.spec.mjs
@@ -254,4 +254,33 @@ test.describe('Fleet cockpit AgentDetail — drill-in inspector (#14608)', () =>
 
         detail.destroy()
     });
+
+    test('the pop-out affordance is layout-blind: it fires popOutIntent only, and its mode flips icon + accessible label (#14610)', () => {
+        const
+            detail  = createDetail({agentId: 'vega', state: 'ok'}),
+            button  = detail.getReference('detail-popout-button'),
+            intents = [];
+
+        detail.on('popOutIntent', data => intents.push(data));
+
+        // docked defaults: the detach affordance, labeled for icon-only accessibility
+        expect(button).toBeTruthy();
+        expect(button.iconCls).toContain('fa-arrow-up-right-from-square');
+        expect(button.vdom['aria-label']).toBe('Pop out to its own window');
+
+        // a click reports INTENT — the view executes no dock/window operation itself
+        detail.onPopOutButtonClick();
+        expect(intents).toHaveLength(1);
+        expect(intents[0].mode).toBe('docked');
+
+        // the owner writes the mode back — the affordance flips to the reattach rendering
+        detail.popOutMode = 'windowed';
+        expect(button.iconCls).toContain('fa-down-left-and-up-right-to-center');
+        expect(button.vdom['aria-label']).toBe('Reattach to the cockpit');
+
+        detail.onPopOutButtonClick();
+        expect(intents[1].mode).toBe('windowed');
+
+        detail.destroy()
+    });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -389,6 +389,7 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         const grid = {adapterState: 'sample', store};
 
         const cockpit = {
+            getAgentDetailPane: FleetCockpit.prototype.getAgentDetailPane,
             getReference      : reference => reference === 'fleet-grid' ? grid : reference === 'agent-detail' ? detail : null,
             grid,
             id                : `fake-fleet-cockpit-${index}`,
@@ -855,8 +856,9 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
             detail  = {record: null, set(cfg) { Object.assign(this, cfg) }},
             applied = [],
             cockpit = {
-                detailRecord: null,
-                dockModel   : {items: {detail: {autoHidden: true}}},
+                detailRecord      : null,
+                dockModel         : {items: {detail: {autoHidden: true}}},
+                getAgentDetailPane: () => detail,
                 applyDockZoneOperation(op) { applied.push(op); return {document: {revealed: true}, errors: []} },
                 onDockZoneDocumentChange(doc) { this.committed = doc }
             },
@@ -882,8 +884,9 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
             detail  = {record: null, set(cfg) { Object.assign(this, cfg) }},
             applied = [],
             cockpit = {
-                detailRecord: null,
-                dockModel   : {items: {detail: {autoHidden: false}}},   // already revealed
+                detailRecord      : null,
+                dockModel         : {items: {detail: {autoHidden: false}}},   // already revealed
+                getAgentDetailPane: () => detail,
                 applyDockZoneOperation(op) { applied.push(op); return {document: {}, errors: []} },
                 onDockZoneDocumentChange() { this.reprojected = true }
             },

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
@@ -1,0 +1,357 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'FleetCockpitPopOutTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import '../../../../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
+import Container     from '../../../../../../../src/container/Base.mjs';
+import DockZoneModel from '../../../../../../../src/dashboard/DockZoneModel.mjs';
+import FleetCockpit  from '../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs';
+import FleetRoster   from '../../../../../../../apps/agentos/store/FleetRoster.mjs';
+import StateProvider from '../../../../../../../src/state/Provider.mjs';
+
+/**
+ * @summary Installs deterministic popup-vessel seams for the cockpit pop-out specs — the
+ * Demo-B-proven pattern (`DemoBWorkspace.spec.mjs`). The real OS-window round-trip is owned by
+ * the E2E witness; these seams isolate document ownership, park/re-adopt identity, rollback and
+ * close bookkeeping without weakening the call contract.
+ * @param {Object} [options={}]
+ * @param {Error|null} [options.openError=null]
+ * @param {String|null} [options.popupUrl=null] The URL `getByPath` reports for the popup window.
+ * @returns {Object} spy state + `restore()`.
+ */
+function installWindowVessel({openError = null, popupUrl = null} = {}) {
+    let previous = {
+            getByPath    : Neo.Main.getByPath,
+            getWindowData: Neo.Main.getWindowData,
+            windowClose  : Neo.Main.windowClose,
+            windowOpen   : Neo.Main.windowOpen
+        },
+        previousWindowConfigs = Neo.windowConfigs,
+        state = {closeCalls: [], openCalls: []};
+
+    Neo.windowConfigs = {'unit-window': {basePath: './'}};
+
+    Neo.Main.getByPath     = async () => popupUrl;
+    Neo.Main.getWindowData = async () => ({screenLeft: 10, screenTop: 20});
+    Neo.Main.windowOpen    = async data => {
+        state.openCalls.push(data);
+        if (openError) throw openError
+    };
+    Neo.Main.windowClose   = async data => {
+        state.closeCalls.push(data)
+    };
+
+    return {
+        get closeCalls() { return state.closeCalls },
+        get openCalls()  { return state.openCalls },
+        restore() {
+            Object.assign(Neo.Main, previous);
+            Neo.windowConfigs = previousWindowConfigs
+        }
+    }
+}
+
+/**
+ * Contract specs for the cockpit pop-out: the agent-detail inspector detaches to
+ * its own window on the shared heap and comes home — reparent-never-recreate. The pins:
+ * document truth (`detachItem` prunes the tree, keeps the catalog record), park-then-vessel
+ * ordering, connect-time reparent of the SAME instance, accessor routing while detached,
+ * commit-or-neither vessel rollback, disconnect-comes-home, remembered-home fallback, the
+ * stand-in swap after an external re-tree, and destroy hygiene. The real two-window journey is
+ * the E2E witness's (`FleetCockpitPopOutNL.spec.mjs`).
+ */
+test.describe.serial('AgentOS.view.fleet.FleetCockpit — agent-detail pop-out (#14610)', () => {
+    let cockpit, vessel;
+
+    /** @returns {Object} a FleetAgent-shaped field bag (plain records are a documented AgentDetail input) */
+    const makeRecord = () => ({
+        agentId    : 'neo-fable',
+        displayName: 'Mnemosyne',
+        engineTag  : null,
+        family     : null,
+        state      : 'ok'
+    });
+
+    /**
+     * Reveals the auto-hidden detail inspector (the drill's standard commit loop), then resolves
+     * the live pane — the pre-state every pop-out flow starts from.
+     * @returns {Promise<Neo.container.Base>} the projected AgentDetail instance
+     */
+    async function revealDetail() {
+        const result = cockpit.applyDockZoneOperation({operation: 'setItemAutoHidden', itemId: 'detail', autoHidden: false});
+
+        expect(result.errors).toEqual([]);
+        cockpit.onDockZoneDocumentChange(result.document);
+        await cockpit.refreshPromise;
+
+        const pane = cockpit.getReference('agent-detail');
+
+        expect(pane).toBeTruthy();
+        return pane
+    }
+
+    test.beforeEach(() => {
+        cockpit = Neo.create(FleetCockpit, {
+            // hermetic: no sample-seed fetch in the unit env; the roster data path has its own suite
+            stateProvider: {
+                module: StateProvider,
+                stores: {fleetRoster: {module: FleetRoster, autoLoad: false}}
+            }
+        })
+    });
+
+    test.afterEach(() => {
+        // destroy BEFORE restoring the vessel seams: a detached-state destroy closes its popup
+        // through them (the bare unit env never defines Neo.Main.windowClose)
+        cockpit?.destroy?.();
+        cockpit = null;
+        vessel?.restore();
+        vessel = null
+    });
+
+    test('pop-out prunes the tree, keeps the catalog record, parks the live pane and opens the vessel', async () => {
+        vessel = installWindowVessel();
+
+        const pane   = await revealDetail();
+        const result = await cockpit.popOutAgentDetail();
+
+        expect(result).toEqual({detached: true, errors: []});
+
+        // document truth: out of the tree, still in the catalog (window ownership)
+        expect(DockZoneModel.findContainingTabsId(cockpit.dockModel, 'detail')).toBe(null);
+        expect(cockpit.dockModel.items.detail).toBeTruthy();
+
+        // parked, not destroyed — out of every parent's items (the reconciler's preserved-park
+        // leaves the stale parentId pointer; membership is the honest contract)
+        expect(pane.isDestroyed).toBeFalsy();
+        expect(pane.parent?.items ?? []).not.toContain(pane);
+        expect(pane.popOutMode).toBe('windowed');
+        expect(vessel.openCalls).toHaveLength(1);
+        expect(vessel.openCalls[0].windowName).toBe(cockpit.detachedDetail.windowName);
+        expect(vessel.openCalls[0].url).toContain('childapps/widget/index.html');
+        expect(vessel.openCalls[0].url).toContain(`cockpitId=${cockpit.id}`);
+
+        await cockpit.refreshPromise;
+
+        // the owner accessor resolves the parked instance — same reference, every phase
+        expect(cockpit.getAgentDetailPane()).toBe(pane)
+    });
+
+    test('connect reparents the SAME instance into the vessel viewport; a foreign window is ignored', async () => {
+        const pane = await revealDetail();
+
+        vessel = installWindowVessel();
+        await cockpit.popOutAgentDetail();
+
+        const popupHost = Neo.create(Container, {});
+
+        // a foreign connect (wrong params) must not claim the pane
+        Neo.Main.getByPath = async () => 'http://localhost/index.html?unrelated=1';
+        Neo.apps ??= {};
+        Neo.apps['unit-popup-window'] = {mainView: popupHost};
+        await cockpit.onWindowConnect({windowId: 'unit-popup-window'});
+        expect(popupHost.items).toHaveLength(0);
+
+        // ours: the parked instance mounts — same reference, nothing recreated
+        Neo.Main.getByPath = async () => `http://localhost/apps/agentos/childapps/widget/index.html?detail=agent-detail&cockpitId=${cockpit.id}`;
+        await cockpit.onWindowConnect({windowId: 'unit-popup-window'});
+
+        expect(popupHost.items).toHaveLength(1);
+        expect(popupHost.items[0]).toBe(pane);
+        expect(cockpit.detachedDetail.windowId).toBe('unit-popup-window');
+
+        // mounted in the vessel's tree, the pane is out of the cockpit's down() reach —
+        // the owner accessor is now the only cockpit-side route to it
+        expect(cockpit.getReference('agent-detail') ?? null).toBe(null);
+        expect(cockpit.getAgentDetailPane()).toBe(pane);
+
+        delete Neo.apps['unit-popup-window'];
+        popupHost.remove(pane, false);
+        popupHost.destroy()
+    });
+
+    test('reattach re-adopts the SAME instance, restores the document and closes the vessel', async () => {
+        const pane = await revealDetail();
+
+        pane.record = makeRecord();
+
+        vessel = installWindowVessel();
+        await cockpit.popOutAgentDetail();
+        await cockpit.refreshPromise;
+
+        const windowName = cockpit.detachedDetail.windowName;
+        const result     = await cockpit.reattachAgentDetail();
+
+        expect(result).toEqual({errors: [], reattached: true});
+
+        // document truth restored into the remembered home
+        expect(DockZoneModel.findContainingTabsId(cockpit.dockModel, 'detail')).toBe('secondary-rail');
+
+        // the projection re-adopted the very same instance — reparent, never recreate —
+        // with its runtime state (the record) intact
+        expect(cockpit.getReference('agent-detail')).toBe(pane);
+        expect(pane.record.agentId).toBe('neo-fable');
+        expect(pane.popOutMode).toBe('docked');
+        expect(cockpit.detachedDetail ?? null).toBe(null);
+        expect(cockpit.detachedDetailPane ?? null).toBe(null);
+
+        expect(vessel.closeCalls).toHaveLength(1);
+        expect(vessel.closeCalls[0].names).toEqual([windowName])
+    });
+
+    test('guards: pop-out is rejected while detached or unrevealed; reattach is rejected while docked', async () => {
+        vessel = installWindowVessel();
+
+        // never revealed: no projected pane to detach
+        const unrevealed = await cockpit.popOutAgentDetail();
+        expect(unrevealed.detached).toBe(false);
+
+        await revealDetail();
+        expect((await cockpit.reattachAgentDetail()).reattached).toBe(false);
+
+        await cockpit.popOutAgentDetail();
+        const second = await cockpit.popOutAgentDetail();
+
+        expect(second.detached).toBe(false);
+        expect(vessel.openCalls).toHaveLength(1)
+    });
+
+    test('a vessel failure rolls back commit-or-neither: docked state restored, same instance', async () => {
+        const pane = await revealDetail();
+
+        vessel = installWindowVessel({openError: new Error('popup blocked')});
+
+        const result = await cockpit.popOutAgentDetail();
+
+        expect(result.detached).toBe(false);
+        expect(result.errors[0]).toContain('popup blocked');
+
+        // the document re-trees the item and the projection re-adopted the parked instance
+        expect(DockZoneModel.findContainingTabsId(cockpit.dockModel, 'detail')).toBe('secondary-rail');
+        expect(cockpit.detachedDetail ?? null).toBe(null);
+        expect(cockpit.detachedDetailPane ?? null).toBe(null);
+
+        await cockpit.refreshPromise;
+        expect(cockpit.getReference('agent-detail')).toBe(pane);
+        expect(pane.popOutMode).toBe('docked')
+    });
+
+    test('vessel disconnect brings the inspector home without a second close call', async () => {
+        const pane = await revealDetail();
+
+        vessel = installWindowVessel();
+        await cockpit.popOutAgentDetail();
+
+        cockpit.detachedDetail.windowId = 'unit-popup-window';
+        cockpit.onWindowDisconnect({windowId: 'unit-popup-window'});
+
+        // the disconnect-triggered reattach is async; settle it
+        await new Promise(resolve => setTimeout(resolve, 50));
+        await cockpit.refreshPromise;
+
+        expect(DockZoneModel.findContainingTabsId(cockpit.dockModel, 'detail')).toBe('secondary-rail');
+        expect(cockpit.getReference('agent-detail')).toBe(pane);
+        expect(cockpit.detachedDetail ?? null).toBe(null);
+        expect(vessel.closeCalls).toHaveLength(0)
+    });
+
+    test('reattach falls back to the first tabs node when the remembered home left the tree', async () => {
+        const pane = await revealDetail();
+
+        vessel = installWindowVessel();
+        await cockpit.popOutAgentDetail();
+
+        cockpit.detachedDetail.homeTabsNodeId = 'a-node-a-preset-retired';
+
+        const result = await cockpit.reattachAgentDetail();
+
+        expect(result.reattached).toBe(true);
+
+        const landed = DockZoneModel.findContainingTabsId(cockpit.dockModel, 'detail');
+
+        expect(landed).toBeTruthy();
+        expect(cockpit.dockModel.nodes[landed].type).toBe('tabs');
+        expect(cockpit.getReference('agent-detail')).toBe(pane)
+    });
+
+    test('an external re-tree while detached renders the stand-in; reattach swaps it for the live pane', async () => {
+        const pane = await revealDetail();
+
+        vessel = installWindowVessel();
+        await cockpit.popOutAgentDetail();
+        await cockpit.refreshPromise;
+
+        // a preset restore / NL-driven addTab resurrects the item while the pane is windowed
+        const resurrect = cockpit.applyDockZoneOperation({operation: 'addTab', itemId: 'detail', tabsNodeId: 'secondary-rail'});
+
+        expect(resurrect.errors).toEqual([]);
+        cockpit.onDockZoneDocumentChange(resurrect.document);
+        await cockpit.refreshPromise;
+
+        // the slot renders an honest stand-in — never a steal of the windowed instance
+        const standin = cockpit.getReference('agent-detail-standin');
+
+        expect(standin).toBeTruthy();
+        expect(standin).not.toBe(pane);
+        expect(standin.parent.items).not.toContain(pane);
+        expect(cockpit.getAgentDetailPane()).toBe(pane);
+
+        const result = await cockpit.reattachAgentDetail();
+
+        expect(result.reattached).toBe(true);
+        expect(cockpit.getReference('agent-detail-standin') ?? null).toBe(null);
+        expect(cockpit.getReference('agent-detail')).toBe(pane);
+        expect(standin.isDestroyed).toBe(true)
+    });
+
+    test('record mutation and the drill accessor keep feeding the detached inspector', async () => {
+        const pane   = await revealDetail();
+        const record = makeRecord();
+
+        vessel = installWindowVessel();
+
+        cockpit.detailRecord = record;
+        pane.record          = record;
+
+        await cockpit.popOutAgentDetail();
+
+        let   applied             = 0;
+        const originalApplyRecord = pane.applyRecord;
+
+        pane.applyRecord = function(...args) { applied++; return originalApplyRecord.apply(this, args) };
+
+        // the roster's recordChange routing reaches the windowed pane through the accessor
+        cockpit.onDetailRecordChange({record});
+        expect(applied).toBe(1);
+
+        // a different record's mutation stays ignored (unchanged contract)
+        cockpit.onDetailRecordChange({record: {agentId: 'someone-else'}});
+        expect(applied).toBe(1);
+
+        pane.applyRecord = originalApplyRecord
+    });
+
+    test('destroying the cockpit while detached closes the vessel and destroys the owned pane', async () => {
+        const pane = await revealDetail();
+
+        vessel = installWindowVessel();
+        await cockpit.popOutAgentDetail();
+
+        const windowName = cockpit.detachedDetail.windowName;
+
+        cockpit.destroy();
+
+        expect(vessel.closeCalls).toHaveLength(1);
+        expect(vessel.closeCalls[0].names).toEqual([windowName]);
+        expect(pane.isDestroyed).toBe(true);
+
+        cockpit = null
+    })
+});


### PR DESCRIPTION
Resolves #14610

The agent-detail inspector now detaches to its own OS window on the ONE shared App-Worker heap and comes home — reparent-never-recreate, live through every phase. The dock document stays the layout SSOT (`detachItem` prunes the tree, keeps the catalog record, so Neural Link topology reads stay truthful about the detached state); the reconciler's preserved-park retires the pane's tab button while keeping the instance alive; the widget-childapp vessel (the app's established bare popup host) renders it; and every detail consumer (record mutation, selection reconciliation, the card→detail drill) routes through one owner accessor so the popped-out inspector stays exactly as live as a docked one. The view keeps its layout-blind pane contract: its header affordance only FIRES `popOutIntent` — the owning cockpit routes intent through the dock layer and writes the mode back.

Evidence: L3 (real Chromium two-window round-trip over the production `windowOpen`/connect wire, isolated per-run dev server, Neural Link instance/topology inspection) → L3 required (all close-target runtime ACs). No residuals.

## Deltas from ticket

- **The "built once, consumed by both" premise resolved:** the public demo twin shipped its pop-out first; the built-once layer is the primitive set (`DockZoneModel.detachItem`/`addTab`, park/adopt via container atomic move, `windowOpen` vessel, worker connect/disconnect). This leaf consumes the same grammar cockpit-side — no forked state-continuity guarantees.
- **Preserved-park instead of manual parking:** the reconciler's `preserveItemIds` retires pane + tab button atomically (manual parking orphans the button — the projection fails loud on the chrome mismatch). The pop-out awaits the projection before opening the vessel, so a fast connect can never race a pane the old shell still holds.
- **External re-tree while detached renders an honest stand-in, never a steal:** a preset restore (or an NL-driven `addTab`) can resurrect the `detail` item while the pane is windowed; the resolver renders a labeled stand-in, and the reattach swaps it for the live instance post-projection (the reconciler prefers tree-live occupants, so the swap cannot ride normal adoption).
- **The unit setup's `Neo.currentWorker` mock gained `un`** — destroy-path listener hygiene is now testable headlessly.
- **The e2e drives the controller seam (`onAgentSelect` via Neural Link `callMethod`) instead of the card DOM click:** the card-click → `agentSelect` dispatch chain is regressed on current `dev` (discriminated + filed as #15212 during this work — the reveal machinery itself is proven healthy). The gesture-driven drill journey remains the sibling drill-e2e leaf's scope; the affordance clicks in this witness (pop-out + reattach buttons) are real DOM interactions.

## Test Evidence

- Pop-out contract units (document truth, park/adopt identity, guards, commit-or-neither rollback, disconnect-comes-home, home fallback, stand-in swap, accessor routing, destroy hygiene): `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs` — 10 passed.
- Affordance + full fleet view suite: `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/` — 165 passed (includes the four pre-existing cockpit fixtures extended with the new accessor surface).
- Broader regression: `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/apps/agentos/ test/playwright/unit/dashboard/` — 571 passed.
- Real two-window round-trip: `NEO_E2E_PORT=8119 NEO_TEST_SKIP_CI=true npm run test-e2e -- test/playwright/e2e/agentos/FleetCockpitPopOutNL.spec.mjs --workers=1` — 1 passed (drill → detach to a real popup, same App-Worker instance id, dock document truthful both phases → main-window drill re-renders the windowed inspector → reattach home with the windowed-phase selection; zero page errors both windows).
- Cockpit e2e siblings: `Cockpit`, `FleetCockpitDockNL`, `FleetCockpitLifecycleNL` + the pop-out witness — 6 passed. Two dev-pre-existing reds verified UNRELATED via stash-isolated clean-`dev` runs: `AccountsConfigSurface` (stale harness-count literal, fixed by the since-merged canonical-readback PR) and `FleetCockpitDrillNL` (#15212, filed with the discriminated repro).
- Source + body gates: `npm run agent-preflight -- --no-fix <touched files>` — all gates passed.

## Post-Merge Validation

- [ ] On merged `dev` (with the canonical add-agent readback in the tree), a fresh AgentOS load still drills, pops out, and reattaches with the same instance.
- [ ] The drill-journey e2e leaf can now build on this seam once the #15212 card-click fix lands.

## Evolution

Live falsification reshaped the parking mechanics mid-implementation: the Demo-B-style manual park (`remove(pane, false)` before reprojection) orphans the pane's TAB BUTTON in this cockpit's reconciler-managed projection — the chrome check fails loud ("inexact item set"). The reconciler's own `preserveItemIds` contract is the designed path: pane parked, button retired, one atomic pass. The second pivot: `getReference` (a `down()` walk) still resolves a PARKED pane through its stale parent chain but loses it once the vessel mounts it — so the owner accessor is phase-deterministic by holding the instance handle, and the JSDoc states the reach semantics precisely rather than the folk claim.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 2c0a23e9-f468-4de6-9e29-ddec96103fb4