### PR TITLE
fix(hooks): surface attachment-delivered mid-turn operator messages to the stop-hook walk (#15216)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -408,6 +408,9 @@ const HARNESS_MARKER_PATTERNS = Object.freeze([
  *    do not.
  *  - Text-less records (tool_result-only) and harness marker records ({@link HARNESS_MARKER_PATTERNS})
  *    are skipped; malformed lines are tolerated.
+ *  - `attachment` records carrying a non-empty string `attachment.prompt` (the queued mid-TURN
+ *    operator-message field — "sent while you were working" deliveries never materialize as
+ *    user-role records) are candidates in the same pass; other attachment kinds never are.
  *  - The FIRST remaining candidate decides — the walk never continues past it, so an autonomous
  *    boundary (a newer `[WAKE]`) is returned as-is and correctly out-classifies any older operator
  *    prose (`classifyPromptingContext` owns the [WAKE]/synthetic/handoff semantics; this walk owns
@@ -429,9 +432,25 @@ export function extractLatestHumanUserTextFromJsonl(jsonl = '') {
         let record;
         try { record = JSON.parse(line); } catch { continue; }
 
+        if (record.isMeta === true) continue;
+
+        // Mid-TURN operator messages ("sent while you were working") are delivered as
+        // attachment records carrying the queued text at `attachment.prompt` — never as
+        // user-role records — so the walk considers them in the SAME backward pass (the
+        // newest-candidate rule must hold across record kinds). Corpus-verified shapes on
+        // this field: [WAKE] digests and task-notification payloads (both rejected by the
+        // classifier's dialogue gates) and genuine operator prose. Attachment records
+        // without a non-empty string `attachment.prompt` (other attachment kinds) are
+        // never candidates.
+        if (record.type === 'attachment') {
+            const prompt = record.attachment?.prompt;
+            if (typeof prompt !== 'string' || !prompt.trim()) continue;
+            if (HARNESS_MARKER_PATTERNS.some(re => re.test(prompt))) continue;
+            return prompt;
+        }
+
         const message = record.message || record;
         if ((message.role || record.type) !== 'user') continue;
-        if (record.isMeta === true) continue;
 
         const text = extractTextFromContent(message.content);
         if (!text) continue;

--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -409,11 +409,12 @@ const HARNESS_MARKER_PATTERNS = Object.freeze([
  *  - Text-less records (tool_result-only) and harness marker records ({@link HARNESS_MARKER_PATTERNS})
  *    are skipped; malformed lines are tolerated.
  *  - `attachment` records are classified by ENVELOPE PROVENANCE before any payload text is read:
- *    only the corpus-verified operator/wake delivery shape (`attachment.type: 'queued_command'`,
- *    `commandMode: 'prompt'`, `source_uuid` present — the queued mid-TURN operator messages that
- *    never materialize as user-role records) yields a candidate. Prompt-bearing records of any
- *    OTHER envelope shape (task notifications, unknown modes) are walk-stopping autonomous
- *    boundaries; prompt-less attachment kinds are skipped.
+ *    only the corpus-VALIDATED operator/wake delivery shape (`attachment.type: 'queued_command'`,
+ *    `commandMode: 'prompt'`, a non-empty STRING `source_uuid`, `origin.kind === 'human'` — the
+ *    queued mid-TURN operator messages that never materialize as user-role records; 47/47 in the
+ *    live two-session census) yields a candidate. Prompt-bearing records missing ANY predicate leg
+ *    (task notifications, unknown modes, object/whitespace `source_uuid`, missing or non-`'human'`
+ *    `origin.kind`) are walk-stopping autonomous boundaries; prompt-less attachment kinds are skipped.
  *  - The FIRST remaining candidate decides — the walk never continues past it, so an autonomous
  *    boundary (a newer `[WAKE]`) is returned as-is and correctly out-classifies any older operator
  *    prose (`classifyPromptingContext` owns the [WAKE]/synthetic/handoff semantics; this walk owns
@@ -441,15 +442,17 @@ export function extractLatestHumanUserTextFromJsonl(jsonl = '') {
         // attachment records carrying the queued text at `attachment.prompt` — never as
         // user-role records — so the walk considers them in the SAME backward pass (the
         // newest-candidate rule holds across record kinds). ENVELOPE PROVENANCE decides the
-        // record KIND before any payload text is read: the corpus-total structural split is
-        // `attachment.type: 'queued_command'` + `commandMode: 'prompt'` + a `source_uuid`
-        // (operator/wake deliveries) vs `commandMode: 'task-notification'` with neither
-        // (background-task events). Payload markers stay defense-in-depth in the shared
-        // classifier — never the sender/kind identity. Prompt-less attachment kinds are not
-        // prompting records at all (skip); a prompt-bearing record whose envelope is NOT the
-        // verified operator/wake shape — task notifications and every unknown mode — is a
-        // structurally synthetic/unknown authority and STOPS the walk as an autonomous
-        // boundary, so it can never leak past to older operator prose.
+        // record KIND before any payload text is read, and the human predicate VALIDATES the
+        // observed delivery shape rather than testing field truthiness: the live corpus census
+        // (47/47 genuine prompt deliveries across two sessions) is `attachment.type:
+        // 'queued_command'` + `commandMode: 'prompt'` + a non-empty STRING `source_uuid` + `origin.
+        // kind === 'human'`; background-task events are `commandMode: 'task-notification'` with
+        // neither. Payload markers stay defense-in-depth in the shared classifier — never the
+        // sender/kind identity. Prompt-less attachment kinds are not prompting records at all
+        // (skip); a prompt-bearing record whose envelope misses ANY predicate leg — task
+        // notifications, unknown modes, object/whitespace `source_uuid`, missing or non-`'human'`
+        // `origin.kind` — is a structurally synthetic/unknown/spoofable authority and STOPS the
+        // walk as an autonomous boundary, so it can never leak past to older operator prose.
         if (record.type === 'attachment') {
             const attachment = record.attachment,
                   prompt     = attachment?.prompt;
@@ -458,7 +461,8 @@ export function extractLatestHumanUserTextFromJsonl(jsonl = '') {
 
             const isOperatorDelivery = attachment.type === 'queued_command' &&
                 attachment.commandMode === 'prompt' &&
-                !!attachment.source_uuid;
+                typeof attachment.source_uuid === 'string' && attachment.source_uuid.trim() !== '' &&
+                attachment.origin?.kind === 'human';
 
             if (!isOperatorDelivery) return '';
 

--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -408,9 +408,12 @@ const HARNESS_MARKER_PATTERNS = Object.freeze([
  *    do not.
  *  - Text-less records (tool_result-only) and harness marker records ({@link HARNESS_MARKER_PATTERNS})
  *    are skipped; malformed lines are tolerated.
- *  - `attachment` records carrying a non-empty string `attachment.prompt` (the queued mid-TURN
- *    operator-message field — "sent while you were working" deliveries never materialize as
- *    user-role records) are candidates in the same pass; other attachment kinds never are.
+ *  - `attachment` records are classified by ENVELOPE PROVENANCE before any payload text is read:
+ *    only the corpus-verified operator/wake delivery shape (`attachment.type: 'queued_command'`,
+ *    `commandMode: 'prompt'`, `source_uuid` present — the queued mid-TURN operator messages that
+ *    never materialize as user-role records) yields a candidate. Prompt-bearing records of any
+ *    OTHER envelope shape (task notifications, unknown modes) are walk-stopping autonomous
+ *    boundaries; prompt-less attachment kinds are skipped.
  *  - The FIRST remaining candidate decides — the walk never continues past it, so an autonomous
  *    boundary (a newer `[WAKE]`) is returned as-is and correctly out-classifies any older operator
  *    prose (`classifyPromptingContext` owns the [WAKE]/synthetic/handoff semantics; this walk owns
@@ -437,14 +440,28 @@ export function extractLatestHumanUserTextFromJsonl(jsonl = '') {
         // Mid-TURN operator messages ("sent while you were working") are delivered as
         // attachment records carrying the queued text at `attachment.prompt` — never as
         // user-role records — so the walk considers them in the SAME backward pass (the
-        // newest-candidate rule must hold across record kinds). Corpus-verified shapes on
-        // this field: [WAKE] digests and task-notification payloads (both rejected by the
-        // classifier's dialogue gates) and genuine operator prose. Attachment records
-        // without a non-empty string `attachment.prompt` (other attachment kinds) are
-        // never candidates.
+        // newest-candidate rule holds across record kinds). ENVELOPE PROVENANCE decides the
+        // record KIND before any payload text is read: the corpus-total structural split is
+        // `attachment.type: 'queued_command'` + `commandMode: 'prompt'` + a `source_uuid`
+        // (operator/wake deliveries) vs `commandMode: 'task-notification'` with neither
+        // (background-task events). Payload markers stay defense-in-depth in the shared
+        // classifier — never the sender/kind identity. Prompt-less attachment kinds are not
+        // prompting records at all (skip); a prompt-bearing record whose envelope is NOT the
+        // verified operator/wake shape — task notifications and every unknown mode — is a
+        // structurally synthetic/unknown authority and STOPS the walk as an autonomous
+        // boundary, so it can never leak past to older operator prose.
         if (record.type === 'attachment') {
-            const prompt = record.attachment?.prompt;
+            const attachment = record.attachment,
+                  prompt     = attachment?.prompt;
+
             if (typeof prompt !== 'string' || !prompt.trim()) continue;
+
+            const isOperatorDelivery = attachment.type === 'queued_command' &&
+                attachment.commandMode === 'prompt' &&
+                !!attachment.source_uuid;
+
+            if (!isOperatorDelivery) return '';
+
             if (HARNESS_MARKER_PATTERNS.some(re => re.test(prompt))) continue;
             return prompt;
         }
@@ -524,7 +541,7 @@ async function main() {
         // best-effort; classification falls back to stop_hook_active when promptingText is empty
     }
     const promptingText = extractLatestHumanUserTextFromJsonl(transcriptJsonl);
-    let evidenceText = '';
+    let   evidenceText  = '';
     try {
         evidenceText = collectLaneStateToolEvidenceFromJsonl(transcriptJsonl);
     } catch {

--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -411,10 +411,13 @@ const HARNESS_MARKER_PATTERNS = Object.freeze([
  *  - `attachment` records are classified by ENVELOPE PROVENANCE before any payload text is read:
  *    only the corpus-VALIDATED operator/wake delivery shape (`attachment.type: 'queued_command'`,
  *    `commandMode: 'prompt'`, a non-empty STRING `source_uuid`, `origin.kind === 'human'` — the
- *    queued mid-TURN operator messages that never materialize as user-role records; 47/47 in the
- *    live two-session census) yields a candidate. Prompt-bearing records missing ANY predicate leg
- *    (task notifications, unknown modes, object/whitespace `source_uuid`, missing or non-`'human'`
- *    `origin.kind`) are walk-stopping autonomous boundaries; prompt-less attachment kinds are skipped.
+ *    queued mid-TURN operator messages that never materialize as user-role records; 360/360
+ *    current-format deliveries in the full local corpus census satisfy every leg, while pre-July
+ *    envelopes lacking `origin`/`timestamp` are format history outside the live contract) yields a
+ *    candidate. Prompt-bearing records missing ANY predicate leg (task notifications, unknown
+ *    modes, object/whitespace `source_uuid`, missing or non-`'human'` `origin.kind`) and records
+ *    whose PRESENT `prompt` is non-string (malformed envelope) are walk-stopping autonomous
+ *    boundaries; prompt-less attachment kinds (absent/blank prompt) are skipped.
  *  - The FIRST remaining candidate decides — the walk never continues past it, so an autonomous
  *    boundary (a newer `[WAKE]`) is returned as-is and correctly out-classifies any older operator
  *    prose (`classifyPromptingContext` owns the [WAKE]/synthetic/handoff semantics; this walk owns
@@ -443,11 +446,13 @@ export function extractLatestHumanUserTextFromJsonl(jsonl = '') {
         // user-role records — so the walk considers them in the SAME backward pass (the
         // newest-candidate rule holds across record kinds). ENVELOPE PROVENANCE decides the
         // record KIND before any payload text is read, and the human predicate VALIDATES the
-        // observed delivery shape rather than testing field truthiness: the live corpus census
-        // (47/47 genuine prompt deliveries across two sessions) is `attachment.type:
-        // 'queued_command'` + `commandMode: 'prompt'` + a non-empty STRING `source_uuid` + `origin.
-        // kind === 'human'`; background-task events are `commandMode: 'task-notification'` with
-        // neither. Payload markers stay defense-in-depth in the shared classifier — never the
+        // observed delivery shape rather than testing field truthiness: the full local corpus
+        // census puts every current-format delivery (360/360; pre-July envelopes lack
+        // `origin`/`timestamp` and are format history outside the live contract) at
+        // `attachment.type: 'queued_command'` + `commandMode: 'prompt'` + a non-empty STRING
+        // `source_uuid` + `origin.kind === 'human'`; background-task events (118/118) are
+        // `commandMode: 'task-notification'` with neither field. Payload markers stay
+        // defense-in-depth in the shared classifier — never the
         // sender/kind identity. Prompt-less attachment kinds are not prompting records at all
         // (skip); a prompt-bearing record whose envelope misses ANY predicate leg — task
         // notifications, unknown modes, object/whitespace `source_uuid`, missing or non-`'human'`
@@ -457,7 +462,13 @@ export function extractLatestHumanUserTextFromJsonl(jsonl = '') {
             const attachment = record.attachment,
                   prompt     = attachment?.prompt;
 
-            if (typeof prompt !== 'string' || !prompt.trim()) continue;
+            // Genuinely prompt-LESS attachment kinds — no prompt field, or a blank string — are
+            // not prompting records at all: skip. A PRESENT non-string prompt (object/array/
+            // number) is a MALFORMED prompt-bearing envelope: walk-stopping autonomous boundary,
+            // never a skip (a skip would leak past it to older operator prose).
+            if (prompt == null) continue;
+            if (typeof prompt !== 'string') return '';
+            if (!prompt.trim()) continue;
 
             const isOperatorDelivery = attachment.type === 'queued_command' &&
                 attachment.commandMode === 'prompt' &&

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -35,7 +35,11 @@ const AUTONOMOUS_HANDOFF_PATTERNS = Object.freeze([
 
 const SYNTHETIC_PROMPT_PATTERNS = Object.freeze([
     /^\s*<hook_prompt\b/i,
-    /^\s*<turn_aborted\b/i
+    /^\s*<turn_aborted\b/i,
+    // Background-task event payloads: harness-generated lifecycle noise that rides the same
+    // delivery channels as queued operator messages (corpus-verified as the one injected shape
+    // in attachment-delivered prompts) — never operator dialogue.
+    /^\s*<task-notification\b/i
 ]);
 
 /**

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -363,12 +363,25 @@ test.describe('laneStateStopHook — extractLatestHumanUserTextFromJsonl (#14440
     });
 
     // ── Mid-TURN operator messages: attachment-delivered prompts (never user-role records) ──────
-    const attachmentOperator = JSON.stringify({type: 'attachment',
-              attachment: {prompt: 'why is the walk still blind here? scope-ruling attached.'}}),
-          attachmentWake     = JSON.stringify({type: 'attachment',
-              attachment: {prompt: '[WAKE][priority:normal] 1 events for @neo-opus-vega'}}),
-          attachmentTaskNote = JSON.stringify({type: 'attachment',
-              attachment: {prompt: '<task-notification>\n<task-id>b123</task-id>\n</task-notification>'}}),
+    // Fixtures mirror the REAL `queued_command` envelopes (corpus-total split): operator/wake
+    // deliveries carry `commandMode: 'prompt'` + `source_uuid` + `origin`; task notifications
+    // carry `commandMode: 'task-notification'` and neither. Envelope provenance — not payload
+    // prose — is the sender/kind identity.
+    const attachmentOperator = JSON.stringify({type: 'attachment', attachment: {
+              type  : 'queued_command', commandMode: 'prompt', source_uuid: 'u-op-1', origin: {kind: 'human'},
+              prompt: 'why is the walk still blind here? scope-ruling attached.'}}),
+          attachmentWake     = JSON.stringify({type: 'attachment', attachment: {
+              type  : 'queued_command', commandMode: 'prompt', source_uuid: 'u-wake-1', origin: {kind: 'human'},
+              prompt: '[WAKE][priority:normal] 1 events for @neo-opus-vega'}}),
+          attachmentTaskNote = JSON.stringify({type: 'attachment', attachment: {
+              type  : 'queued_command', commandMode: 'task-notification',
+              prompt: '<task-notification>\n<task-id>b123</task-id>\n</task-notification>'}}),
+          attachmentTaskNoteUntagged = JSON.stringify({type: 'attachment', attachment: {
+              type  : 'queued_command', commandMode: 'task-notification',
+              prompt: 'background task complete'}}),
+          attachmentUnknownMode = JSON.stringify({type: 'attachment', attachment: {
+              type  : 'queued_command', commandMode: 'mystery-mode', source_uuid: 'u-x-1',
+              prompt: 'genuine-looking prose from an unknown delivery mode'}}),
           attachmentOther    = JSON.stringify({type: 'attachment',
               attachment: {kind: 'file', path: '/tmp/x.png'}});
 
@@ -392,9 +405,23 @@ test.describe('laneStateStopHook — extractLatestHumanUserTextFromJsonl (#14440
         })).toBe(false);
     });
 
-    test('injected attachment shapes never rescue a chain: [WAKE] digests and task-notification payloads fail the dialogue gates', () => {
-        for (const injected of [attachmentWake, attachmentTaskNote]) {
+    test('a [WAKE]-prose operator-envelope attachment is a candidate the dialogue gates then reject', () => {
+        const jsonl = [operatorMsg, assistant, metaFeedback, attachmentWake].join('\n');
+        expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('[WAKE][priority:normal] 1 events for @neo-opus-vega');
+        expect(isOperatorInLoop({
+            stopHookActive            : true,
+            promptingText             : extractLatestHumanUserTextFromJsonl(jsonl),
+            promptingTextHumanFiltered: true
+        })).toBe(false);
+    });
+
+    test('structurally synthetic attachments are walk-stopping boundaries — envelope decides, prose is irrelevant', () => {
+        // The tagged AND the untagged task-notification (the falsifier that killed the
+        // text-prefix design) plus an unknown prompt-bearing mode: each STOPS the walk —
+        // older operator prose can never leak past a newer synthetic/unknown boundary.
+        for (const injected of [attachmentTaskNote, attachmentTaskNoteUntagged, attachmentUnknownMode]) {
             const jsonl = [operatorMsg, assistant, metaFeedback, injected].join('\n');
+            expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('');
             expect(isOperatorInLoop({
                 stopHookActive            : true,
                 promptingText             : extractLatestHumanUserTextFromJsonl(jsonl),
@@ -403,7 +430,7 @@ test.describe('laneStateStopHook — extractLatestHumanUserTextFromJsonl (#14440
         }
     });
 
-    test('attachment records without attachment.prompt (other kinds) are never candidates', () => {
+    test('attachment records without attachment.prompt (other kinds) are skipped, not boundaries', () => {
         const jsonl = [operatorMsg, assistant, attachmentOther].join('\n');
         expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('full stop. we need to talk about the release notes.');
     });
@@ -607,7 +634,7 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
                 {type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'driving the lane…'}]}},
                 {type: 'user', isMeta: true, message: {role: 'user', content: 'Stop hook feedback:\nTurn-end refused — L3_No_Hold_State: there is no hold state, and you do not get to stop.'}},
                 {type: 'queue-operation', operation: 'enqueue', timestamp: '2026-07-16T07:00:00Z'},
-                {type: 'attachment', attachment: {prompt: 'full stop — answering your fork question now, hold the lane.'}}
+                {type: 'attachment', attachment: {type: 'queued_command', commandMode: 'prompt', source_uuid: 'u-e2e-1', origin: {kind: 'human'}, prompt: 'full stop — answering your fork question now, hold the lane.'}}
             ]
         });
         expect(log).toContain('ALLOW');
@@ -622,7 +649,7 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
             transcriptRecords: [
                 {type: 'user', message: {role: 'user', content: '[WAKE][priority:normal] 1 events for @neo-opus-vega'}},
                 {type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'driving the lane…'}]}},
-                {type: 'attachment', attachment: {prompt: '<task-notification>\n<task-id>b9</task-id>\n<status>completed</status>\n</task-notification>'}}
+                {type: 'attachment', attachment: {type: 'queued_command', commandMode: 'task-notification', prompt: 'background task b9 completed without a tag prefix'}}
             ]
         });
         expect(log).toContain('BLOCK');

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -363,11 +363,13 @@ test.describe('laneStateStopHook — extractLatestHumanUserTextFromJsonl (#14440
     });
 
     // ── Mid-TURN operator messages: attachment-delivered prompts (never user-role records) ──────
-    // Fixtures mirror the REAL `queued_command` envelopes (corpus census: 47/47 genuine prompt
-    // deliveries across two sessions carry `commandMode: 'prompt'` + a 36-char STRING `source_uuid`
-    // + `origin.kind: 'human'`; task notifications carry `commandMode: 'task-notification'` and
-    // neither). Envelope provenance — VALIDATED shape, not field truthiness — is the sender/kind
-    // identity; payload prose is never it.
+    // Fixtures mirror the REAL `queued_command` envelopes (full local corpus census: 360/360
+    // current-format prompt deliveries carry `commandMode: 'prompt'` + a 36-char STRING
+    // `source_uuid` + `origin.kind: 'human'`; 118/118 task notifications carry
+    // `commandMode: 'task-notification'` and neither field; pre-July envelopes lack
+    // `origin`/`timestamp` and are format history outside the live contract). Envelope
+    // provenance — VALIDATED shape, not field truthiness — is the sender/kind identity;
+    // payload prose is never it.
     const attachmentOperator = JSON.stringify({type: 'attachment', attachment: {
               type  : 'queued_command', commandMode: 'prompt', source_uuid: 'u-op-1', origin: {kind: 'human'},
               prompt: 'why is the walk still blind here? scope-ruling attached.'}}),
@@ -380,9 +382,17 @@ test.describe('laneStateStopHook — extractLatestHumanUserTextFromJsonl (#14440
           attachmentTaskNoteUntagged = JSON.stringify({type: 'attachment', attachment: {
               type  : 'queued_command', commandMode: 'task-notification',
               prompt: 'background task complete'}}),
+          // Isolates commandMode as the ONLY invalid leg: every other human-envelope leg is
+          // valid (string source_uuid + origin.kind 'human'), so a pass here would prove the
+          // mode check specifically, not a confounded second leg.
           attachmentUnknownMode = JSON.stringify({type: 'attachment', attachment: {
-              type  : 'queued_command', commandMode: 'mystery-mode', source_uuid: 'u-x-1',
+              type  : 'queued_command', commandMode: 'mystery-mode', source_uuid: 'u-x-1', origin: {kind: 'human'},
               prompt: 'genuine-looking prose from an unknown delivery mode'}}),
+          // Malformed prompt-bearing envelope: PRESENT non-string prompt with every provenance
+          // leg valid — must stop the walk (a skip would leak past to older operator prose).
+          attachmentObjectPrompt = JSON.stringify({type: 'attachment', attachment: {
+              type  : 'queued_command', commandMode: 'prompt', source_uuid: 'u-op-9', origin: {kind: 'human'},
+              prompt: {nested: 'object payload'}}}),
           attachmentOther    = JSON.stringify({type: 'attachment',
               attachment: {kind: 'file', path: '/tmp/x.png'}});
 
@@ -434,6 +444,23 @@ test.describe('laneStateStopHook — extractLatestHumanUserTextFromJsonl (#14440
     test('attachment records without attachment.prompt (other kinds) are skipped, not boundaries', () => {
         const jsonl = [operatorMsg, assistant, attachmentOther].join('\n');
         expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('full stop. we need to talk about the release notes.');
+    });
+
+    test('a PRESENT non-string prompt is a MALFORMED envelope — walk-stopping, never a skip (cycle-3 boundary)', () => {
+        // All provenance legs valid; only the prompt VALUE is malformed. The prompt-less rule
+        // (absent/blank → skip) must not swallow it: skipping would leak past to older prose.
+        const jsonl = [operatorMsg, assistant, metaFeedback, attachmentObjectPrompt].join('\n');
+        expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('');
+        expect(isOperatorInLoop({
+            stopHookActive            : true,
+            promptingText             : extractLatestHumanUserTextFromJsonl(jsonl),
+            promptingTextHumanFiltered: true
+        })).toBe(false);
+        // The prompt-less boundary stays a skip: absent prompt and blank-string prompt.
+        const blankPrompt = JSON.stringify({type: 'attachment', attachment: {
+            type: 'queued_command', commandMode: 'prompt', source_uuid: 'u-op-10', origin: {kind: 'human'}, prompt: '   '}});
+        expect(extractLatestHumanUserTextFromJsonl([operatorMsg, assistant, blankPrompt].join('\n')))
+            .toBe('full stop. we need to talk about the release notes.');
     });
 
     test('the human predicate VALIDATES envelope shape — spoofable variants are walk-stopping, never candidates (cycle-2 reviewer falsifiers)', () => {
@@ -688,14 +715,31 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
 
     test('an UNKNOWN prompt-bearing mode ABOVE older operator prose keeps the chain BLOCKED (walk-stop at the spawned seam)', async () => {
         // The unknown-mode record is NEWER than a genuine operator user record; the walk must stop
-        // at the unknown boundary rather than leak past it to the older dialogue evidence.
+        // at the unknown boundary rather than leak past it to the older dialogue evidence. Every
+        // OTHER human-envelope leg is valid (string source_uuid + origin.kind 'human') so the mode
+        // check is isolated — not confounded by a second invalid leg.
         const {stdout, log} = await runHook(validTerminal, {
             enforce          : true,
             stopHookActive   : true,
             transcriptRecords: [
                 {type: 'user', message: {role: 'user', content: 'full stop. we need to talk about the release notes.'}},
                 {type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'driving the lane…'}]}},
-                {type: 'attachment', attachment: {type: 'queued_command', commandMode: 'mystery-mode', source_uuid: 'u-x-e2e', prompt: 'genuine-looking prose from an unknown delivery mode'}}
+                {type: 'attachment', attachment: {type: 'queued_command', commandMode: 'mystery-mode', source_uuid: 'u-x-e2e', origin: {kind: 'human'}, prompt: 'genuine-looking prose from an unknown delivery mode'}}
+            ]
+        });
+        expect(log).toContain('BLOCK');
+        expect(log).toContain('midChainOperator=false');
+        expect(JSON.parse(stdout).decision).toBe('block');
+    });
+
+    test('a MALFORMED present prompt (object value) ABOVE older operator prose keeps the chain BLOCKED (spawned seam)', async () => {
+        const {stdout, log} = await runHook(validTerminal, {
+            enforce          : true,
+            stopHookActive   : true,
+            transcriptRecords: [
+                {type: 'user', message: {role: 'user', content: 'full stop. we need to talk about the release notes.'}},
+                {type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'driving the lane…'}]}},
+                {type: 'attachment', attachment: {type: 'queued_command', commandMode: 'prompt', source_uuid: 'u-op-e2e', origin: {kind: 'human'}, prompt: {nested: 'object payload'}}}
             ]
         });
         expect(log).toContain('BLOCK');

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -363,10 +363,11 @@ test.describe('laneStateStopHook — extractLatestHumanUserTextFromJsonl (#14440
     });
 
     // ── Mid-TURN operator messages: attachment-delivered prompts (never user-role records) ──────
-    // Fixtures mirror the REAL `queued_command` envelopes (corpus-total split): operator/wake
-    // deliveries carry `commandMode: 'prompt'` + `source_uuid` + `origin`; task notifications
-    // carry `commandMode: 'task-notification'` and neither. Envelope provenance — not payload
-    // prose — is the sender/kind identity.
+    // Fixtures mirror the REAL `queued_command` envelopes (corpus census: 47/47 genuine prompt
+    // deliveries across two sessions carry `commandMode: 'prompt'` + a 36-char STRING `source_uuid`
+    // + `origin.kind: 'human'`; task notifications carry `commandMode: 'task-notification'` and
+    // neither). Envelope provenance — VALIDATED shape, not field truthiness — is the sender/kind
+    // identity; payload prose is never it.
     const attachmentOperator = JSON.stringify({type: 'attachment', attachment: {
               type  : 'queued_command', commandMode: 'prompt', source_uuid: 'u-op-1', origin: {kind: 'human'},
               prompt: 'why is the walk still blind here? scope-ruling attached.'}}),
@@ -433,6 +434,34 @@ test.describe('laneStateStopHook — extractLatestHumanUserTextFromJsonl (#14440
     test('attachment records without attachment.prompt (other kinds) are skipped, not boundaries', () => {
         const jsonl = [operatorMsg, assistant, attachmentOther].join('\n');
         expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('full stop. we need to talk about the release notes.');
+    });
+
+    test('the human predicate VALIDATES envelope shape — spoofable variants are walk-stopping, never candidates (cycle-2 reviewer falsifiers)', () => {
+        // Each variant passed the previous truthiness check and classified midChainOperator:true
+        // at the prior head; all four must stop the walk: an object source_uuid, a whitespace
+        // source_uuid, a valid-string source_uuid with a non-human origin, and a missing origin.
+        const spoofObjectUuid = JSON.stringify({type: 'attachment', attachment: {
+                  type  : 'queued_command', commandMode: 'prompt', source_uuid: {spoof: true}, origin: {kind: 'human'},
+                  prompt: 'prose behind an object-valued source uuid'}}),
+              spoofBlankUuid  = JSON.stringify({type: 'attachment', attachment: {
+                  type  : 'queued_command', commandMode: 'prompt', source_uuid: '   ', origin: {kind: 'human'},
+                  prompt: 'prose behind a whitespace source uuid'}}),
+              spoofTaskOrigin = JSON.stringify({type: 'attachment', attachment: {
+                  type  : 'queued_command', commandMode: 'prompt', source_uuid: 'u-real-string', origin: {kind: 'task'},
+                  prompt: 'prose behind a non-human origin kind'}}),
+              spoofNoOrigin   = JSON.stringify({type: 'attachment', attachment: {
+                  type  : 'queued_command', commandMode: 'prompt', source_uuid: 'u-real-string',
+                  prompt: 'prose behind a missing origin'}});
+
+        for (const injected of [spoofObjectUuid, spoofBlankUuid, spoofTaskOrigin, spoofNoOrigin]) {
+            const jsonl = [operatorMsg, assistant, metaFeedback, injected].join('\n');
+            expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('');
+            expect(isOperatorInLoop({
+                stopHookActive            : true,
+                promptingText             : extractLatestHumanUserTextFromJsonl(jsonl),
+                promptingTextHumanFiltered: true
+            })).toBe(false);
+        }
     });
 });
 
@@ -650,6 +679,38 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
                 {type: 'user', message: {role: 'user', content: '[WAKE][priority:normal] 1 events for @neo-opus-vega'}},
                 {type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'driving the lane…'}]}},
                 {type: 'attachment', attachment: {type: 'queued_command', commandMode: 'task-notification', prompt: 'background task b9 completed without a tag prefix'}}
+            ]
+        });
+        expect(log).toContain('BLOCK');
+        expect(log).toContain('midChainOperator=false');
+        expect(JSON.parse(stdout).decision).toBe('block');
+    });
+
+    test('an UNKNOWN prompt-bearing mode ABOVE older operator prose keeps the chain BLOCKED (walk-stop at the spawned seam)', async () => {
+        // The unknown-mode record is NEWER than a genuine operator user record; the walk must stop
+        // at the unknown boundary rather than leak past it to the older dialogue evidence.
+        const {stdout, log} = await runHook(validTerminal, {
+            enforce          : true,
+            stopHookActive   : true,
+            transcriptRecords: [
+                {type: 'user', message: {role: 'user', content: 'full stop. we need to talk about the release notes.'}},
+                {type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'driving the lane…'}]}},
+                {type: 'attachment', attachment: {type: 'queued_command', commandMode: 'mystery-mode', source_uuid: 'u-x-e2e', prompt: 'genuine-looking prose from an unknown delivery mode'}}
+            ]
+        });
+        expect(log).toContain('BLOCK');
+        expect(log).toContain('midChainOperator=false');
+        expect(JSON.parse(stdout).decision).toBe('block');
+    });
+
+    test('a malformed prompt-mode envelope (object source_uuid) is walk-stopping at the spawned seam — BLOCKED', async () => {
+        const {stdout, log} = await runHook(validTerminal, {
+            enforce          : true,
+            stopHookActive   : true,
+            transcriptRecords: [
+                {type: 'user', message: {role: 'user', content: 'full stop. we need to talk about the release notes.'}},
+                {type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'driving the lane…'}]}},
+                {type: 'attachment', attachment: {type: 'queued_command', commandMode: 'prompt', source_uuid: {spoof: true}, origin: {kind: 'human'}, prompt: 'prose behind an object-valued source uuid'}}
             ]
         });
         expect(log).toContain('BLOCK');

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -361,6 +361,52 @@ test.describe('laneStateStopHook — extractLatestHumanUserTextFromJsonl (#14440
             promptingTextHumanFiltered: true
         })).toBe(true);
     });
+
+    // ── Mid-TURN operator messages: attachment-delivered prompts (never user-role records) ──────
+    const attachmentOperator = JSON.stringify({type: 'attachment',
+              attachment: {prompt: 'why is the walk still blind here? scope-ruling attached.'}}),
+          attachmentWake     = JSON.stringify({type: 'attachment',
+              attachment: {prompt: '[WAKE][priority:normal] 1 events for @neo-opus-vega'}}),
+          attachmentTaskNote = JSON.stringify({type: 'attachment',
+              attachment: {prompt: '<task-notification>\n<task-id>b123</task-id>\n</task-notification>'}}),
+          attachmentOther    = JSON.stringify({type: 'attachment',
+              attachment: {kind: 'file', path: '/tmp/x.png'}});
+
+    test('an attachment-delivered mid-turn operator message is the decisive candidate', () => {
+        const jsonl = [wakeMsg, assistant, metaFeedback, attachmentOperator, assistant].join('\n');
+        expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('why is the walk still blind here? scope-ruling attached.');
+        expect(isOperatorInLoop({
+            stopHookActive            : true,
+            promptingText             : extractLatestHumanUserTextFromJsonl(jsonl),
+            promptingTextHumanFiltered: true
+        })).toBe(true);
+    });
+
+    test('newest-candidate ordering holds across record kinds: a NEWER [WAKE] user record wins over an older operator attachment', () => {
+        const jsonl = [attachmentOperator, assistant, metaFeedback, wakeMsg, assistant].join('\n');
+        expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('[WAKE][priority:normal] 1 events for @neo-opus-vega');
+        expect(isOperatorInLoop({
+            stopHookActive            : true,
+            promptingText             : extractLatestHumanUserTextFromJsonl(jsonl),
+            promptingTextHumanFiltered: true
+        })).toBe(false);
+    });
+
+    test('injected attachment shapes never rescue a chain: [WAKE] digests and task-notification payloads fail the dialogue gates', () => {
+        for (const injected of [attachmentWake, attachmentTaskNote]) {
+            const jsonl = [operatorMsg, assistant, metaFeedback, injected].join('\n');
+            expect(isOperatorInLoop({
+                stopHookActive            : true,
+                promptingText             : extractLatestHumanUserTextFromJsonl(jsonl),
+                promptingTextHumanFiltered: true
+            })).toBe(false);
+        }
+    });
+
+    test('attachment records without attachment.prompt (other kinds) are never candidates', () => {
+        const jsonl = [operatorMsg, assistant, attachmentOther].join('\n');
+        expect(extractLatestHumanUserTextFromJsonl(jsonl)).toBe('full stop. we need to talk about the release notes.');
+    });
 });
 
 test.describe('laneStateStopHook — end-to-end (spawned hook against the real Stop payload)', () => {
@@ -545,6 +591,38 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
                 {type: 'user', message: {role: 'user', content: '[WAKE][priority:normal] 1 events for @neo-opus-vega'}},
                 {type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'driving the lane…'}]}},
                 {type: 'user', isMeta: true, message: {role: 'user', content: 'Stop hook feedback:\nTurn-end refused — L3_No_Hold_State: there is no hold state, and you do not get to stop.'}}
+            ]
+        });
+        expect(log).toContain('BLOCK');
+        expect(log).toContain('midChainOperator=false');
+        expect(JSON.parse(stdout).decision).toBe('block');
+    });
+
+    test('mid-TURN attachment-delivered operator message → ALLOW (the queued-delivery chain shape)', async () => {
+        const {stdout, log} = await runHook('Understood — over to you.', {
+            enforce          : true,
+            stopHookActive   : true,
+            transcriptRecords: [
+                {type: 'user', message: {role: 'user', content: '[WAKE][priority:normal] 1 events for @neo-opus-vega'}},
+                {type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'driving the lane…'}]}},
+                {type: 'user', isMeta: true, message: {role: 'user', content: 'Stop hook feedback:\nTurn-end refused — L3_No_Hold_State: there is no hold state, and you do not get to stop.'}},
+                {type: 'queue-operation', operation: 'enqueue', timestamp: '2026-07-16T07:00:00Z'},
+                {type: 'attachment', attachment: {prompt: 'full stop — answering your fork question now, hold the lane.'}}
+            ]
+        });
+        expect(log).toContain('ALLOW');
+        expect(log).toContain('midChainOperator=true');
+        expect(stdout).toBe('');
+    });
+
+    test('injected attachment payloads (task-notification) keep a chain BLOCKED — no false-ALLOW channel', async () => {
+        const {stdout, log} = await runHook(validTerminal, {
+            enforce          : true,
+            stopHookActive   : true,
+            transcriptRecords: [
+                {type: 'user', message: {role: 'user', content: '[WAKE][priority:normal] 1 events for @neo-opus-vega'}},
+                {type: 'assistant', message: {role: 'assistant', content: [{type: 'text', text: 'driving the lane…'}]}},
+                {type: 'attachment', attachment: {prompt: '<task-notification>\n<task-id>b9</task-id>\n<status>completed</status>\n</task-notification>'}}
             ]
         });
         expect(log).toContain('BLOCK');

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -94,6 +94,8 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision
     test('isOperatorInLoop: synthetic hook prompts are lifecycle noise, not operator turns', () => {
         expect(isSyntheticPromptingText('<hook_prompt hook_run_id="stop:1">No-hold reminder</hook_prompt>')).toBe(true);
         expect(isSyntheticPromptingText('<turn_aborted>interrupted by new prompt</turn_aborted>')).toBe(true);
+        expect(isSyntheticPromptingText('<task-notification>\n<task-id>b123</task-id>\n</task-notification>')).toBe(true);
+        expect(isOperatorInLoop({stopHookActive: false, promptingText: '<task-notification>done</task-notification>'})).toBe(false);
         expect(isOperatorInLoop({stopHookActive: false, promptingText: '<hook_prompt hook_run_id="stop:1">No-hold reminder</hook_prompt>'})).toBe(false);
         expect(isOperatorInLoop({stopHookActive: false, promptingText: '<turn_aborted>interrupted by new prompt</turn_aborted>'})).toBe(false);
     });


### PR DESCRIPTION
Resolves #15216

Mid-TURN operator messages become visible to the stop-hook's human-filtered walk — with **envelope provenance, not payload text, as the sender/kind identity** (hardened per Emmy's review falsifier). Claude Code delivers "sent while you were working" messages as `type: 'attachment'` records; the corpus-validated human predicate is `attachment.type: 'queued_command'` + `commandMode: 'prompt'` + a non-empty STRING `source_uuid` + `origin.kind === 'human'` (operator/wake deliveries) versus `commandMode: 'task-notification'` with neither field (background-task events). The walk classifies that envelope BEFORE reading any prose, validating SHAPE rather than field truthiness (hardened per Emmy's cycle-2 falsifiers: an object-valued or whitespace `source_uuid`, a non-`'human'` `origin.kind`, or a missing `origin` all fail the predicate): only the validated operator/wake shape yields a candidate (which then flows through the unchanged single classification authority, `isOperatorDialogueText`); a prompt-bearing record missing ANY predicate leg — task notifications, unknown modes, malformed/spoof-shaped envelopes — is a **walk-stopping autonomous boundary** that can never leak past to older operator prose; prompt-less attachment kinds are skipped. Newest-candidate ordering holds across record kinds (spec-pinned), `isMeta` is honored for every record kind, and the `<task-notification` synthetic pattern remains in the shared decision module strictly as defense-in-depth for the user-record path — documented as such, never the discriminator.

Evidence: L2 (spawned real hook over fixtures mirroring the real `queued_command` envelopes; **145 specs green across the three hook suites at the current head** — laneStateStopHook + stopHookDecision + the untouched Codex sibling — incl. the untagged-prose falsifier chain, the four spoof-shape predicate falsifiers, the malformed-present-prompt falsifier, and the three spawned walk-stop BLOCK chains) → L3 (live-session classification post harness-restart). Residual: post-merge live audit observation [#15216].

## Corpus note (AC-5, envelope-grounded)

Census across ALL local transcripts (both project dirs, every session — reviewer-reproduced independently at cycle-4; the JSDoc/walk-comment/fixture-comment surfaces share the verified 360/360 current-delivery and 118/118 task-notification split while identifying pre-July envelopes as format history; the #15216 Contract Ledger records the measured 188 historical records plus the three-way prompt-value boundary): **360/360 current-format prompt deliveries** carry `commandMode: 'prompt'` + a non-empty STRING `source_uuid` + `origin.kind: 'human'`; **118/118 task notifications** carry `commandMode: 'task-notification'` and neither field; **188 pre-July prompt records lack `origin`/`timestamp` entirely** — the envelope gained those fields in a late-June harness update, so they are format history outside the live contract (the earlier 41/41 and the reviewer's 47/47 were both narrower in-window samples of the same split). No skill payloads, hook feedback, or system reminders ride `attachment.prompt`. The consumed-format Contract Ledger (five record-shape rows → candidate/boundary/skip) is backfilled on #15216.

## Deltas from ticket

- **Reviewer-hardened discriminator (Emmy's catch, the review bar working):** my first head recognized task-notifications by the `<task-notification` prose prefix while attesting the result as mechanically human-filtered — a structurally synthetic record with untagged prose ("background task complete") would have false-ALLOWed. The envelope fields the ticket's corpus-check arm anticipated are the real identity; the fix classifies them first, and the untagged falsifier is now a spawned-hook e2e case.
- **Boundary semantics for synthetic/unknown prompt-bearing records** (stricter than skip): a newer task-notification or unknown-mode record stops the walk entirely, so older operator prose cannot be rescued past it — fail-closed at the authority boundary.
- The ticket's "gate should be presence of `attachment.prompt`" arm resolved to presence + envelope shape; presence alone was proven insufficient twice (first by my census's tagged payloads, then by Emmy's untagged falsifier).

## Test Evidence

- Hook suites (current head): laneStateStopHook + stopHookDecision + codexLaneStateStopHook — **145 passed** (envelope-real fixtures; the untagged task-notification + unknown-mode falsifiers as walk-boundary specs AND spawned e2e BLOCK chains — the unknown mode ABOVE older operator prose with every other envelope leg valid, isolating the mode check; four spoof-shape predicate falsifiers (object/whitespace `source_uuid`, `origin.kind:'task'`, missing `origin`) as pure walk-stops; the malformed PRESENT non-string prompt as a pure walk-stop AND a spawned BLOCK above older operator prose, with absent/blank prompt pinned as the skip boundary; the operator-envelope [WAKE]-prose case pinned as candidate-then-rejected; cross-kind newest-candidate ordering pinned).
- Codex sibling: green unchanged (no attestation → fail-closed semantics untouched).
- Directly touched surfaces: `ai/scripts/lifecycle/stopHookDecision.mjs`: stopHookDecision.spec.mjs | `.claude/hooks/laneStateStopHook.mjs`: laneStateStopHook.spec.mjs.

## Post-Merge Validation

- [ ] After harness restarts pick up the merged hook: observe a live mid-turn operator message classifying `midChainOperator=true` → ALLOW in `lane-state-stop-hook.log`.
- [ ] Confirm background-task notification deliveries never produce an ALLOW (boundary semantics: the chain stays autonomous).

## Commits

- 444a1716b3 — walk extension + synthetic-pattern addition + 8 specs (superseded discriminator design).
- ff6b3bfdeb — envelope-provenance-first classification + boundary semantics + real-envelope fixtures + the untagged/unknown-mode falsifiers (per review).
- ca7434b849 — shape-validated human predicate (string source_uuid + origin.kind human) + four spoof falsifiers + spawned walk-stop chains (per cycle-2 review).
- 4e35fd8690 — malformed-present-prompt walk-stop, mode-isolated falsifiers, corpus-wide census sync (per cycle-3 review).

Authored by Vega (Claude Fable 5, Claude Code). Session c4f8e75b-bf73-448b-bee3-6a17e3b1cb45.



