### PR TITLE
feat(agentos): FM card name slot — display state over the durable id, provenance-honest (#14641)

### DIFF
--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -7,6 +7,8 @@ import SourceHealthMarker      from './SourceHealthMarker.mjs';
 import StateDot                from './StateDot.mjs';
 import {normalizeFleetSources} from './sourceHealth.mjs';
 
+import {describeNameProvenance, resolveNameSlot} from './nameSlot.mjs';
+
 /**
  * The resident card: the cockpit's atom. Composes the class-based fleet primitives (FamilyRail +
  * StateDot + SourceHealthMarker) with a profile avatar, name, engine tag, and the lane row —
@@ -125,6 +127,15 @@ class AgentCard extends Container {
                     flex     : 1,
                     handler  : 'onCardSelect',
                     reference: 'card-name'
+                }, {
+                    // the name-slot provenance chip (mono pill, freshness-chip register): `named`
+                    // when a naming-layer trail is wired on the record, `declared` while the name
+                    // is registry display state without a trail, `id` when the durable anchor
+                    // itself renders. The long copy (and the trail, once wired) rides title +
+                    // aria-label — reachable, never a silent claim (applyRecord writes it).
+                    ntype    : 'component',
+                    flex     : 'none',
+                    reference: 'name-provenance'
                 }, {
                     ntype    : 'component',
                     cls      : ['fm-card-engine'],
@@ -294,7 +305,22 @@ class AgentCard extends Container {
         // stamped count — rendering "0 lanes" there would fabricate a fact no producer stated
         const laneCount = Number.isInteger(record.openLaneCount) && record.openLaneCount > 0 ? record.openLaneCount : null;
 
-        me.getReference('card-name').text          = record.displayName ?? '';
+        // the name slot: the folded display name as MUTABLE DISPLAY STATE over the durable id —
+        // a record with no folded name renders the id itself in the mono register (never a blank
+        // drill target), and the provenance chip states how the rendered name is grounded
+        const
+            nameSlot   = resolveNameSlot(record),
+            nameButton = me.getReference('card-name'),
+            provenance = me.getReference('name-provenance'),
+            chip       = describeNameProvenance(nameSlot.provenance.state);
+
+        nameButton.text = nameSlot.text;
+        nameButton[nameSlot.isFallback ? 'addCls' : 'removeCls']('fm-card-name-id');
+
+        provenance.set({cls: chip.cls, text: chip.text});
+        provenance.changeVdomRootKey('title', nameSlot.provenance.label);
+        provenance.changeVdomRootKey('aria-label', nameSlot.provenance.label);
+
         me.getReference('card-engine').text        = record.engineTag ?? '';
         me.getReference('card-lane').text          = record.laneLine ?? '';
 

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -128,11 +128,11 @@ class AgentCard extends Container {
                     handler  : 'onCardSelect',
                     reference: 'card-name'
                 }, {
-                    // the name-slot provenance chip (mono pill, freshness-chip register): `named`
-                    // when a naming-layer trail is wired on the record, `declared` while the name
-                    // is registry display state without a trail, `id` when the durable anchor
-                    // itself renders. The long copy (and the trail, once wired) rides title +
-                    // aria-label — reachable, never a silent claim (applyRecord writes it).
+                    // the name-slot provenance chip, density-calibrated: the `named` word only for
+                    // a wired naming-layer trail (the divergent state), a quiet outline glyph for
+                    // declared-proxy (today's uniform reality — long copy on title/aria), and NO
+                    // chip for the durable-id case (the name slot's mono register IS that signal).
+                    // applyRecord writes it.
                     ntype    : 'component',
                     flex     : 'none',
                     reference: 'name-provenance'
@@ -317,9 +317,12 @@ class AgentCard extends Container {
         nameButton.text = nameSlot.text;
         nameButton[nameSlot.isFallback ? 'addCls' : 'removeCls']('fm-card-name-id');
 
-        provenance.set({cls: chip.cls, text: chip.text});
-        provenance.changeVdomRootKey('title', nameSlot.provenance.label);
-        provenance.changeVdomRootKey('aria-label', nameSlot.provenance.label);
+        provenance.set({cls: chip.cls, hidden: chip.hidden, text: chip.text});
+
+        if (!chip.hidden) {
+            provenance.changeVdomRootKey('title', nameSlot.provenance.label);
+            provenance.changeVdomRootKey('aria-label', nameSlot.provenance.label)
+        }
 
         me.getReference('card-engine').text        = record.engineTag ?? '';
         me.getReference('card-lane').text          = record.laneLine ?? '';

--- a/apps/agentos/view/fleet/nameSlot.mjs
+++ b/apps/agentos/view/fleet/nameSlot.mjs
@@ -1,10 +1,12 @@
 /**
  * @summary The FM cockpit name-slot contract — the render-correctness rule at name grain: the
  * social display name renders as MUTABLE DISPLAY STATE over the durable id (never as a key), and
- * its provenance is stated honestly — a wired naming-layer trail when the record carries one, the
- * explicit `declared-proxy` state until that layer lands. Pure and record-shaped (no clock, no
- * instance coupling); fail-closed toward the durable id exactly like the sibling
- * {@link module:apps/agentos/view/fleet/agentFreshness} contract fails toward `unobserved`.
+ * its provenance is stated honestly. Today's live vocabulary is TWO states: `declared-proxy`
+ * (a name exists as registry/identity display state; no assent trail is wired anywhere yet) and
+ * `durable-id` (no display name — the never-renamed anchor itself renders). Pure and
+ * record-shaped (no clock, no instance coupling); fails closed toward the durable id exactly like
+ * the sibling {@link module:apps/agentos/view/fleet/agentFreshness} contract fails toward
+ * `unobserved`.
  *
  * **The fallback chain is folded Brain-side** (`src/ai/fleet/fleetCockpitStatus.mjs` — the
  * cockpit DTO assembler resolves `displayName → name → githubUsername → id` into ONE
@@ -13,19 +15,24 @@
  * and owns only the view-grain safety net — a record with no folded display name (a non-DTO row,
  * a sparse fixture) renders its durable id in the mono register, never a blank name slot.
  *
- * **Provenance sharpens with no view change:** today no naming-layer feed stamps a trail, so
- * every named record classifies `declared-proxy` — the name is declared registry/identity display
- * state, its sketch/assent trail not yet wired. The moment a feed stamps `nameProvenance` on the
- * record, the same call classifies `naming-layer` and surfaces the trail. Every rendered claim
- * stays witness, not authority.
+ * **`naming-layer` is a RESERVED state, not a live one.** The naming-layer plumbing (the
+ * sketch/assent trail of the peer-naming ritual) is explicitly outside this leaf: the live
+ * `FleetAgent` record contract carries no `nameProvenance` field, so no store-backed record can
+ * reach the state today — and this classifier honestly refuses to emit it. The state stays in the
+ * closed vocabulary and in {@link describeNameProvenance}'s presentation map so the activation
+ * leaf (the record-contract + feed + trail-render work, tracked in the naming-layer orbit) flips
+ * ONE classifier branch when the field is real — that leaf must also render the trail FACTS into
+ * the reachable title/aria surface, and should guard its input with the sibling
+ * `agentFreshness.mjs` prototype-checked plain-object discipline.
  *
  * @module apps/agentos/view/fleet/nameSlot
  */
 
 /**
- * The closed provenance vocabulary. `naming-layer` = the record carries a wired sketch/assent
- * trail; `declared-proxy` = the name is declared display state with no trail wired yet;
- * `durable-id` = no display name at all — the slot renders the never-renamed anchor itself.
+ * The closed provenance vocabulary. `declared-proxy` and `durable-id` are the live states;
+ * `naming-layer` is RESERVED for the activation leaf (see the module summary) — present here so
+ * the presentation map and the eventual classifier branch share one vocabulary, but never emitted
+ * by {@link resolveNameSlot} today.
  * @type {String[]}
  */
 export const NAME_PROVENANCE_STATES = Object.freeze(['naming-layer', 'declared-proxy', 'durable-id']);
@@ -33,19 +40,17 @@ export const NAME_PROVENANCE_STATES = Object.freeze(['naming-layer', 'declared-p
 /**
  * @summary Resolve one record's name slot, honestly. The folded display name renders when
  * present; otherwise the durable `agentId` renders in its place (flagged, so consumers switch to
- * the mono id register); a record with neither renders the explicit `—` empty marker. The
- * provenance classifies from the record's `nameProvenance` trail: present → `naming-layer` (trail
- * passed through verbatim), absent with a name → `declared-proxy`, absent without a name →
- * `durable-id`.
- * @param {Object|null} record A FleetAgent record or same-keyed field bag (`displayName`,
- *     `agentId`, optional `nameProvenance`).
- * @returns {{text: String, isFallback: Boolean, provenance: {state: String, label: String, trail: (Object|null)}}}
+ * the mono id register); a record with neither renders the explicit `—` empty marker. Provenance
+ * classifies from what is mechanically true today: a name is `declared-proxy` (display state,
+ * trail not wired — any trail-shaped field on the input is IGNORED, since the live record
+ * contract cannot carry one), no name is `durable-id`.
+ * @param {Object|null} record A FleetAgent record or same-keyed field bag (`displayName`, `agentId`).
+ * @returns {{text: String, isFallback: Boolean, provenance: {state: String, label: String}}}
  */
 export function resolveNameSlot(record) {
     const
         displayName = typeof record?.displayName === 'string' && record.displayName.trim() !== '' ? record.displayName : null,
-        agentId     = typeof record?.agentId === 'string' && record.agentId.trim() !== '' ? record.agentId : null,
-        trail       = isPlainObject(record?.nameProvenance) ? record.nameProvenance : null;
+        agentId     = typeof record?.agentId === 'string' && record.agentId.trim() !== '' ? record.agentId : null;
 
     if (!displayName) {
         return {
@@ -55,20 +60,7 @@ export function resolveNameSlot(record) {
                 state: 'durable-id',
                 label: agentId
                     ? 'Durable id — no display name declared; the id is the never-renamed anchor'
-                    : 'No identity facts on this record',
-                trail: null
-            }
-        }
-    }
-
-    if (trail) {
-        return {
-            text      : displayName,
-            isFallback: false,
-            provenance: {
-                state: 'naming-layer',
-                label: `Named "${displayName}" — naming-layer trail wired (display state over the durable id${agentId ? ` ${agentId}` : ''})`,
-                trail
+                    : 'No identity facts on this record'
             }
         }
     }
@@ -78,8 +70,7 @@ export function resolveNameSlot(record) {
         isFallback: false,
         provenance: {
             state: 'declared-proxy',
-            label: `"${displayName}" is declared display state over the durable id${agentId ? ` ${agentId}` : ''} — the naming-layer assent trail is not wired yet`,
-            trail: null
+            label: `"${displayName}" is declared display state over the durable id${agentId ? ` ${agentId}` : ''} — the naming-layer assent trail is not wired yet`
         }
     }
 }
@@ -87,10 +78,11 @@ export function resolveNameSlot(record) {
 /**
  * @summary The compact chip rendering for one provenance state — calibrated to the density
  * surface: a uniform signal carries no per-card information, so each state renders only what
- * differentiates it. `naming-layer` (trail wired — the future divergent state) earns the word
- * `named`; `declared-proxy` (today's uniform reality) renders a quiet outline glyph with the long
- * copy on title/aria; `durable-id` renders NO chip at all — the name slot's mono-id register IS
- * that signal, and a chip beside it would state the same fact twice.
+ * differentiates it. `declared-proxy` (today's uniform reality) renders a quiet outline glyph
+ * with the long copy on title/aria; `durable-id` renders NO chip at all — the name slot's mono-id
+ * register IS that signal, and a chip beside it would state the same fact twice; `naming-layer`
+ * (the RESERVED future divergent state) already maps to the word `named`, so the activation leaf
+ * changes no presentation code.
  * @param {String} state One of {@link NAME_PROVENANCE_STATES}.
  * @returns {{cls: String[], hidden: Boolean, text: String}}
  */
@@ -100,14 +92,4 @@ export function describeNameProvenance(state) {
         hidden: state === 'durable-id',
         text  : state === 'naming-layer' ? 'named' : state === 'declared-proxy' ? '◇' : ''
     }
-}
-
-/**
- * @summary Plain-object check (arrays and class instances are not trails).
- * @param {*} value
- * @returns {Boolean}
- * @private
- */
-function isPlainObject(value) {
-    return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }

--- a/apps/agentos/view/fleet/nameSlot.mjs
+++ b/apps/agentos/view/fleet/nameSlot.mjs
@@ -85,18 +85,20 @@ export function resolveNameSlot(record) {
 }
 
 /**
- * @summary The compact chip word for one provenance state — the glanceable register the cockpit
- * chips share (mono pill, long copy on the title/aria): `named` (trail wired) / `declared`
- * (proxy) / `id` (durable-id fallback).
+ * @summary The compact chip rendering for one provenance state — calibrated to the density
+ * surface: a uniform signal carries no per-card information, so each state renders only what
+ * differentiates it. `naming-layer` (trail wired — the future divergent state) earns the word
+ * `named`; `declared-proxy` (today's uniform reality) renders a quiet outline glyph with the long
+ * copy on title/aria; `durable-id` renders NO chip at all — the name slot's mono-id register IS
+ * that signal, and a chip beside it would state the same fact twice.
  * @param {String} state One of {@link NAME_PROVENANCE_STATES}.
- * @returns {{cls: String[], text: String}}
+ * @returns {{cls: String[], hidden: Boolean, text: String}}
  */
 export function describeNameProvenance(state) {
-    const text = state === 'naming-layer' ? 'named' : state === 'declared-proxy' ? 'declared' : 'id';
-
     return {
-        cls : ['fm-name-provenance', `is-${state}`],
-        text
+        cls   : ['fm-name-provenance', `is-${state}`],
+        hidden: state === 'durable-id',
+        text  : state === 'naming-layer' ? 'named' : state === 'declared-proxy' ? '◇' : ''
     }
 }
 

--- a/apps/agentos/view/fleet/nameSlot.mjs
+++ b/apps/agentos/view/fleet/nameSlot.mjs
@@ -1,0 +1,111 @@
+/**
+ * @summary The FM cockpit name-slot contract — the render-correctness rule at name grain: the
+ * social display name renders as MUTABLE DISPLAY STATE over the durable id (never as a key), and
+ * its provenance is stated honestly — a wired naming-layer trail when the record carries one, the
+ * explicit `declared-proxy` state until that layer lands. Pure and record-shaped (no clock, no
+ * instance coupling); fail-closed toward the durable id exactly like the sibling
+ * {@link module:apps/agentos/view/fleet/agentFreshness} contract fails toward `unobserved`.
+ *
+ * **The fallback chain is folded Brain-side** (`src/ai/fleet/fleetCockpitStatus.mjs` — the
+ * cockpit DTO assembler resolves `displayName → name → githubUsername → id` into ONE
+ * `displayName` field, the CARD-CONTRACT row). This module deliberately does NOT re-implement
+ * that chain: a Body-side copy would be a second truth that drifts. It consumes the folded field
+ * and owns only the view-grain safety net — a record with no folded display name (a non-DTO row,
+ * a sparse fixture) renders its durable id in the mono register, never a blank name slot.
+ *
+ * **Provenance sharpens with no view change:** today no naming-layer feed stamps a trail, so
+ * every named record classifies `declared-proxy` — the name is declared registry/identity display
+ * state, its sketch/assent trail not yet wired. The moment a feed stamps `nameProvenance` on the
+ * record, the same call classifies `naming-layer` and surfaces the trail. Every rendered claim
+ * stays witness, not authority.
+ *
+ * @module apps/agentos/view/fleet/nameSlot
+ */
+
+/**
+ * The closed provenance vocabulary. `naming-layer` = the record carries a wired sketch/assent
+ * trail; `declared-proxy` = the name is declared display state with no trail wired yet;
+ * `durable-id` = no display name at all — the slot renders the never-renamed anchor itself.
+ * @type {String[]}
+ */
+export const NAME_PROVENANCE_STATES = Object.freeze(['naming-layer', 'declared-proxy', 'durable-id']);
+
+/**
+ * @summary Resolve one record's name slot, honestly. The folded display name renders when
+ * present; otherwise the durable `agentId` renders in its place (flagged, so consumers switch to
+ * the mono id register); a record with neither renders the explicit `—` empty marker. The
+ * provenance classifies from the record's `nameProvenance` trail: present → `naming-layer` (trail
+ * passed through verbatim), absent with a name → `declared-proxy`, absent without a name →
+ * `durable-id`.
+ * @param {Object|null} record A FleetAgent record or same-keyed field bag (`displayName`,
+ *     `agentId`, optional `nameProvenance`).
+ * @returns {{text: String, isFallback: Boolean, provenance: {state: String, label: String, trail: (Object|null)}}}
+ */
+export function resolveNameSlot(record) {
+    const
+        displayName = typeof record?.displayName === 'string' && record.displayName.trim() !== '' ? record.displayName : null,
+        agentId     = typeof record?.agentId === 'string' && record.agentId.trim() !== '' ? record.agentId : null,
+        trail       = isPlainObject(record?.nameProvenance) ? record.nameProvenance : null;
+
+    if (!displayName) {
+        return {
+            text      : agentId ?? '—',
+            isFallback: true,
+            provenance: {
+                state: 'durable-id',
+                label: agentId
+                    ? 'Durable id — no display name declared; the id is the never-renamed anchor'
+                    : 'No identity facts on this record',
+                trail: null
+            }
+        }
+    }
+
+    if (trail) {
+        return {
+            text      : displayName,
+            isFallback: false,
+            provenance: {
+                state: 'naming-layer',
+                label: `Named "${displayName}" — naming-layer trail wired (display state over the durable id${agentId ? ` ${agentId}` : ''})`,
+                trail
+            }
+        }
+    }
+
+    return {
+        text      : displayName,
+        isFallback: false,
+        provenance: {
+            state: 'declared-proxy',
+            label: `"${displayName}" is declared display state over the durable id${agentId ? ` ${agentId}` : ''} — the naming-layer assent trail is not wired yet`,
+            trail: null
+        }
+    }
+}
+
+/**
+ * @summary The compact chip word for one provenance state — the glanceable register the cockpit
+ * chips share (mono pill, long copy on the title/aria): `named` (trail wired) / `declared`
+ * (proxy) / `id` (durable-id fallback).
+ * @param {String} state One of {@link NAME_PROVENANCE_STATES}.
+ * @returns {{cls: String[], text: String}}
+ */
+export function describeNameProvenance(state) {
+    const text = state === 'naming-layer' ? 'named' : state === 'declared-proxy' ? 'declared' : 'id';
+
+    return {
+        cls : ['fm-name-provenance', `is-${state}`],
+        text
+    }
+}
+
+/**
+ * @summary Plain-object check (arrays and class instances are not trails).
+ * @param {*} value
+ * @returns {Boolean}
+ * @private
+ */
+function isPlainObject(value) {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}

--- a/resources/scss/src/apps/agentos/fleet/AgentCard.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentCard.scss
@@ -64,6 +64,34 @@
         }
     }
 
+    /* the durable-id fallback register: when no display name is folded, the id renders as the
+       drill target in mono — display state OVER the anchor, and honestly the anchor itself here */
+    .fm-card-name-id .neo-button-text {
+        font-family: var(--fm-font-mono);
+        font-weight: 500;
+        font-size  : 12px;
+        color      : var(--fm-ink-dim);
+    }
+
+    /* the name-provenance chip — the freshness-pill register: a compact mono word stating how
+       the rendered name is grounded (named = trail wired · declared = registry display state ·
+       id = the durable anchor itself); the long copy rides title/aria-label */
+    .fm-name-provenance {
+        flex         : none;
+        font-family  : var(--fm-font-mono);
+        font-size    : 9px;
+        line-height  : 1;
+        white-space  : nowrap;
+        padding      : 2px 6px;
+        border-radius: 999px;
+        background   : color-mix(in srgb, currentColor 12%, transparent);
+        color        : var(--fm-ink-dim);
+
+        &.is-naming-layer {
+            color: var(--fm-ink);
+        }
+    }
+
     .fm-card-engine {
         flex       : none;
         font-family: var(--fm-font-mono);

--- a/test/playwright/e2e/agentos/FleetCardNameSlotNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCardNameSlotNL.spec.mjs
@@ -43,7 +43,7 @@ test.describe('AgentOS Fleet card — name slot on live roster data (Neural Link
             // DOM truth: the Brain-folded name (displayName -> name -> githubUsername -> id, folded
             // Brain-side) is the drill target; the chip states the honest provenance register
             await expect(card.locator('.fm-card-name .neo-button-text')).toHaveText(agentId);
-            await expect(card.locator('.fm-name-provenance')).toHaveText('declared');
+            await expect(card.locator('.fm-name-provenance')).toHaveText('◇');
             await expect(card.locator('.fm-name-provenance')).toHaveAttribute('title', /declared display state/);
             await expect(card.locator('.fm-name-provenance')).toHaveAttribute('aria-label', /declared display state/);
 

--- a/test/playwright/e2e/agentos/FleetCardNameSlotNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCardNameSlotNL.spec.mjs
@@ -1,0 +1,65 @@
+import {test, expect}           from '../../fixtures.mjs';
+import FleetRegistryService     from '../../../../ai/services/fleet/FleetRegistryService.mjs';
+import {startFleetBridgeServer} from '../../../../ai/services/fleet/fleetBridgeServer.mjs';
+import fs                       from 'fs';
+import os                       from 'os';
+import path                     from 'path';
+
+/**
+ * Whitebox-e2e for the card name slot on LIVE roster data: a real Brain registry seeds one
+ * resident over the production App-Worker wire, the cockpit's authoritative roster replaces the
+ * sample seed, and the rendered card proves the name-slot contract end to end — the Brain-folded
+ * display name renders as the drill target, and the provenance chip states honestly how that name
+ * is grounded (`declared` — registry display state, naming-layer trail not yet wired), with the
+ * long copy reachable on title/aria. Engine truth (record fields) and DOM truth are asserted
+ * together, Neural-Link-verified.
+ */
+test.describe('AgentOS Fleet card — name slot on live roster data (Neural Link)', () => {
+    test.setTimeout(120000);
+
+    test('a live-registry resident renders the folded name + an honest provenance chip', async ({page, neuralLink}) => {
+        const
+            priorDataDir = FleetRegistryService.dataDir,
+            tmpDir       = fs.mkdtempSync(path.join(os.tmpdir(), 'fleet-name-slot-e2e-')),
+            agentId      = 'name-slot-proof-agent';
+
+        FleetRegistryService.dataDir = tmpDir;
+        FleetRegistryService.defineAgent({
+            githubUsername: agentId,
+            harnessType   : 'codex'
+        });
+
+        const server = await startFleetBridgeServer();
+
+        try {
+            await page.goto('/apps/agentos/index.html');
+            await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
+
+            // the authoritative roster replaces the sample seed: exactly the seeded resident renders
+            const card = page.locator('.fm-agent-card');
+
+            await expect(card).toHaveCount(1, {timeout: 30000});
+
+            // DOM truth: the Brain-folded name (displayName -> name -> githubUsername -> id, folded
+            // Brain-side) is the drill target; the chip states the honest provenance register
+            await expect(card.locator('.fm-card-name .neo-button-text')).toHaveText(agentId);
+            await expect(card.locator('.fm-name-provenance')).toHaveText('declared');
+            await expect(card.locator('.fm-name-provenance')).toHaveAttribute('title', /declared display state/);
+            await expect(card.locator('.fm-name-provenance')).toHaveAttribute('aria-label', /declared display state/);
+
+            // engine truth through the Neural Link: the record carries the durable id and the
+            // folded display name — the same durable resident the DOM renders
+            const
+                app   = await neuralLink.connectToApp('AgentOS'),
+                cards = await app.queryComponent({className: 'AgentOS.view.fleet.AgentCard'}, ['record']),
+                row   = (Array.isArray(cards) ? cards : [cards]).find(candidate => candidate?.properties?.record?.agentId === agentId);
+
+            expect(row, 'the seeded resident reached the rendered card through the live wire').toBeTruthy();
+            expect(row.properties.record.displayName).toBe(agentId)
+        } finally {
+            server && await new Promise(resolve => server.close(resolve));
+            FleetRegistryService.dataDir = priorDataDir;
+            fs.rmSync(tmpDir, {force: true, recursive: true})
+        }
+    })
+});

--- a/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
@@ -38,6 +38,21 @@ test.describe('fleetCockpitStatus - Body-side cockpit DTO contract', () => {
         expect(snapshot.rows[1]).toMatchObject({id: 'guest', family: null, engineTag: null})
     })
 
+    test('folds the display-name chain in the CARD-CONTRACT order: displayName -> name -> githubUsername -> id', () => {
+        const snapshot = createFleetCockpitStatus({
+            agents: [
+                {id: 'full',  githubUsername: 'full-gh',  name: 'Full Name',  displayName: 'Chosen'},
+                {id: 'named', githubUsername: 'named-gh', name: 'Named'},
+                {id: 'login', githubUsername: 'login-gh'},
+                {id: 'bare'}
+            ]
+        })
+
+        // one folded field, resolved Brain-side ONCE — the Body name slot consumes it and never
+        // re-implements the chain (a view-side copy would be a second truth that drifts)
+        expect(snapshot.rows.map(row => row.displayName)).toEqual(['Chosen', 'Named', 'login-gh', 'bare'])
+    })
+
     test('hoists assembler-stamped launch truth — tri-state null when un-stamped, never derived in this pure map', () => {
         const snapshot = createFleetCockpitStatus({
             agents: [

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -375,4 +375,54 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
 
         card.destroy()
     });
+
+    test('name slot: the display name renders with its provenance chip; a rename re-renders IN PLACE — same instance, never a re-key (§2.3.2, #14641)', () => {
+        const
+            card       = createCard({agentId: 'vega', displayName: 'Vega', state: 'ok'}),
+            beforeId   = card.id,
+            name       = () => card.down({reference: 'card-name'}),
+            provenance = () => card.down({reference: 'name-provenance'});
+
+        expect(name().text).toBe('Vega');
+        expect(name().cls).not.toContain('fm-card-name-id');
+
+        // provenance is stated, reachable, and honest: declared display state, trail not yet wired
+        expect(provenance().text).toBe('declared');
+        expect(provenance().cls).toContain('is-declared-proxy');
+        expect(provenance().vdom.title).toContain('declared display state');
+        expect(provenance().vdom.title).toContain('vega');
+        expect(provenance().vdom['aria-label']).toBe(provenance().vdom.title);
+
+        // the §2.3.2 fixture: a rename mutates DISPLAY STATE on the SAME card instance
+        applySet(card, {displayName: 'Vega Prime'});
+        expect(card.id).toBe(beforeId);
+        expect(name().text).toBe('Vega Prime');
+        expect(provenance().vdom.title).toContain('Vega Prime');
+
+        card.destroy()
+    });
+
+    test('name slot: no display name → the durable id renders as the drill target in the mono register, chip says so (#14641)', () => {
+        const
+            card       = createCard({agentId: 'guest-agent-7', displayName: null, state: 'ok'}),
+            name       = () => card.down({reference: 'card-name'}),
+            provenance = () => card.down({reference: 'name-provenance'});
+
+        // never a blank drill target: the never-renamed anchor itself renders, register-flagged
+        expect(name().text).toBe('guest-agent-7');
+        expect(name().cls).toContain('fm-card-name-id');
+        expect(provenance().text).toBe('id');
+        expect(provenance().cls).toContain('is-durable-id');
+
+        // a later rename flips the register back — in place, same instance
+        const beforeId = card.id;
+
+        applySet(card, {displayName: 'Guest Seven'});
+        expect(card.id).toBe(beforeId);
+        expect(name().text).toBe('Guest Seven');
+        expect(name().cls).not.toContain('fm-card-name-id');
+        expect(provenance().text).toBe('declared');
+
+        card.destroy()
+    })
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -386,8 +386,10 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
         expect(name().text).toBe('Vega');
         expect(name().cls).not.toContain('fm-card-name-id');
 
-        // provenance is stated, reachable, and honest: declared display state, trail not yet wired
-        expect(provenance().text).toBe('declared');
+        // provenance is stated, reachable, and honest: declared display state, trail not yet
+        // wired — the quiet glyph on the density surface, the words on title/aria
+        expect(provenance().hidden).toBe(false);
+        expect(provenance().text).toBe('◇');
         expect(provenance().cls).toContain('is-declared-proxy');
         expect(provenance().vdom.title).toContain('declared display state');
         expect(provenance().vdom.title).toContain('vega');
@@ -408,10 +410,11 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
             name       = () => card.down({reference: 'card-name'}),
             provenance = () => card.down({reference: 'name-provenance'});
 
-        // never a blank drill target: the never-renamed anchor itself renders, register-flagged
+        // never a blank drill target: the never-renamed anchor itself renders, register-flagged —
+        // and NO chip beside it (the mono register IS the signal; a chip would state it twice)
         expect(name().text).toBe('guest-agent-7');
         expect(name().cls).toContain('fm-card-name-id');
-        expect(provenance().text).toBe('id');
+        expect(provenance().hidden).toBe(true);
         expect(provenance().cls).toContain('is-durable-id');
 
         // a later rename flips the register back — in place, same instance
@@ -421,7 +424,8 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
         expect(card.id).toBe(beforeId);
         expect(name().text).toBe('Guest Seven');
         expect(name().cls).not.toContain('fm-card-name-id');
-        expect(provenance().text).toBe('declared');
+        expect(provenance().hidden).toBe(false);
+        expect(provenance().text).toBe('◇');
 
         card.destroy()
     })

--- a/test/playwright/unit/apps/agentos/view/fleet/nameSlot.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/nameSlot.spec.mjs
@@ -60,12 +60,15 @@ test.describe('nameSlot — display state over the durable id, provenance-honest
         expect(resolveNameSlot({agentId: 'x', displayName: 'X', nameProvenance: []}).provenance.state).toBe('declared-proxy')
     });
 
-    test('the chip vocabulary is closed and maps one word per state', () => {
+    test('the chip rendering is density-calibrated: word only for the divergent state, glyph for the uniform one, nothing beside the mono id', () => {
         expect(NAME_PROVENANCE_STATES).toEqual(['naming-layer', 'declared-proxy', 'durable-id']);
 
-        expect(describeNameProvenance('naming-layer').text).toBe('named');
-        expect(describeNameProvenance('declared-proxy').text).toBe('declared');
-        expect(describeNameProvenance('durable-id').text).toBe('id');
+        // naming-layer (future, divergent across cards) earns the word
+        expect(describeNameProvenance('naming-layer')).toMatchObject({hidden: false, text: 'named'});
+        // declared-proxy (today's uniform reality) renders the quiet outline glyph
+        expect(describeNameProvenance('declared-proxy')).toMatchObject({hidden: false, text: '◇'});
+        // durable-id renders NO chip — the name slot's mono register already states it
+        expect(describeNameProvenance('durable-id').hidden).toBe(true);
 
         // every chip carries the base class + its state class (the SCSS register contract)
         NAME_PROVENANCE_STATES.forEach(state => {

--- a/test/playwright/unit/apps/agentos/view/fleet/nameSlot.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/nameSlot.spec.mjs
@@ -1,0 +1,78 @@
+import {test, expect} from '@playwright/test';
+
+import {describeNameProvenance, NAME_PROVENANCE_STATES, resolveNameSlot} from '../../../../../../../apps/agentos/view/fleet/nameSlot.mjs';
+
+/**
+ * Contract specs for the name-slot module — the pure render-correctness rule at name grain:
+ * display name as mutable display state over the durable id, provenance stated honestly
+ * (`naming-layer` trail when wired · `declared-proxy` until then · `durable-id` when the anchor
+ * itself renders). Pure module — no Neo runtime needed; the Brain-side fold order it consumes is
+ * pinned in the assembler's own spec (`fleetCockpitStatus.spec.mjs`), deliberately NOT
+ * re-implemented here.
+ */
+test.describe('nameSlot — display state over the durable id, provenance-honest', () => {
+    test('a folded display name renders as display state, declared-proxy until a trail wires', () => {
+        const slot = resolveNameSlot({agentId: 'neo-fable', displayName: 'Mnemosyne'});
+
+        expect(slot.text).toBe('Mnemosyne');
+        expect(slot.isFallback).toBe(false);
+        expect(slot.provenance.state).toBe('declared-proxy');
+        expect(slot.provenance.trail ?? null).toBe(null);
+        // the long copy names BOTH the display-state nature and the durable anchor
+        expect(slot.provenance.label).toContain('display state');
+        expect(slot.provenance.label).toContain('neo-fable')
+    });
+
+    test('a wired nameProvenance trail sharpens to naming-layer with the trail passed through verbatim', () => {
+        const
+            trail = {sketchedBy: '@neo-opus-ada', assentAt: '2026-06-11T00:00:00Z'},
+            slot  = resolveNameSlot({agentId: 'neo-fable', displayName: 'Mnemosyne', nameProvenance: trail});
+
+        expect(slot.provenance.state).toBe('naming-layer');
+        expect(slot.provenance.trail).toBe(trail);
+        expect(slot.text).toBe('Mnemosyne')
+    });
+
+    test('no display name → the durable id renders in its place, flagged for the mono register', () => {
+        const slot = resolveNameSlot({agentId: 'guest-agent-7'});
+
+        expect(slot.text).toBe('guest-agent-7');
+        expect(slot.isFallback).toBe(true);
+        expect(slot.provenance.state).toBe('durable-id');
+        expect(slot.provenance.label).toContain('never-renamed anchor')
+    });
+
+    test('blank-string names are not names; a trail on a nameless record cannot fabricate one', () => {
+        expect(resolveNameSlot({agentId: 'x', displayName: '   '}).isFallback).toBe(true);
+        // no name → durable-id even when a stray trail object is present (a trail grounds a NAME)
+        expect(resolveNameSlot({agentId: 'x', nameProvenance: {sketchedBy: 'y'}}).provenance.state).toBe('durable-id')
+    });
+
+    test('null-everything renders the explicit empty marker, never a blank slot', () => {
+        const slot = resolveNameSlot(null);
+
+        expect(slot.text).toBe('—');
+        expect(slot.isFallback).toBe(true);
+        expect(slot.provenance.state).toBe('durable-id')
+    });
+
+    test('an array is not a trail (plain-object discipline)', () => {
+        expect(resolveNameSlot({agentId: 'x', displayName: 'X', nameProvenance: []}).provenance.state).toBe('declared-proxy')
+    });
+
+    test('the chip vocabulary is closed and maps one word per state', () => {
+        expect(NAME_PROVENANCE_STATES).toEqual(['naming-layer', 'declared-proxy', 'durable-id']);
+
+        expect(describeNameProvenance('naming-layer').text).toBe('named');
+        expect(describeNameProvenance('declared-proxy').text).toBe('declared');
+        expect(describeNameProvenance('durable-id').text).toBe('id');
+
+        // every chip carries the base class + its state class (the SCSS register contract)
+        NAME_PROVENANCE_STATES.forEach(state => {
+            const chip = describeNameProvenance(state);
+
+            expect(chip.cls).toContain('fm-name-provenance');
+            expect(chip.cls).toContain(`is-${state}`)
+        })
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/nameSlot.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/nameSlot.spec.mjs
@@ -5,10 +5,10 @@ import {describeNameProvenance, NAME_PROVENANCE_STATES, resolveNameSlot} from '.
 /**
  * Contract specs for the name-slot module — the pure render-correctness rule at name grain:
  * display name as mutable display state over the durable id, provenance stated honestly
- * (`naming-layer` trail when wired · `declared-proxy` until then · `durable-id` when the anchor
- * itself renders). Pure module — no Neo runtime needed; the Brain-side fold order it consumes is
- * pinned in the assembler's own spec (`fleetCockpitStatus.spec.mjs`), deliberately NOT
- * re-implemented here.
+ * (`declared-proxy` · `durable-id` live; `naming-layer` RESERVED until the record contract
+ * carries a trail the render can surface). Pure module — no Neo runtime needed; the Brain-side
+ * fold order it consumes is pinned in the assembler's own spec (`fleetCockpitStatus.spec.mjs`),
+ * deliberately NOT re-implemented here.
  */
 test.describe('nameSlot — display state over the durable id, provenance-honest', () => {
     test('a folded display name renders as display state, declared-proxy until a trail wires', () => {
@@ -23,14 +23,27 @@ test.describe('nameSlot — display state over the durable id, provenance-honest
         expect(slot.provenance.label).toContain('neo-fable')
     });
 
-    test('a wired nameProvenance trail sharpens to naming-layer with the trail passed through verbatim', () => {
-        const
-            trail = {sketchedBy: '@neo-opus-ada', assentAt: '2026-06-11T00:00:00Z'},
-            slot  = resolveNameSlot({agentId: 'neo-fable', displayName: 'Mnemosyne', nameProvenance: trail});
+    test('naming-layer is RESERVED: no input shape can reach it today — trail-shaped fields are ignored', () => {
+        // the live FleetAgent record contract carries no nameProvenance field, so the classifier
+        // honestly refuses the state for EVERY input shape (plain trail, Date, class instance,
+        // inherited object) — the activation leaf flips one classifier branch when the field is real
+        class FakeTrail {constructor() {this.sketchedBy = '@x'}}
 
-        expect(slot.provenance.state).toBe('naming-layer');
-        expect(slot.provenance.trail).toBe(trail);
-        expect(slot.text).toBe('Mnemosyne')
+        const shapes = [
+            {sketchedBy: '@neo-opus-ada', assentAt: '2026-06-11T00:00:00Z'},
+            new Date(),
+            new FakeTrail(),
+            Object.create({inherited: true}),
+            []
+        ];
+
+        shapes.forEach(nameProvenance => {
+            const slot = resolveNameSlot({agentId: 'neo-fable', displayName: 'Mnemosyne', nameProvenance});
+
+            expect(slot.provenance.state).toBe('declared-proxy');
+            expect(slot.text).toBe('Mnemosyne');
+            expect('trail' in slot.provenance).toBe(false)
+        })
     });
 
     test('no display name → the durable id renders in its place, flagged for the mono register', () => {
@@ -63,7 +76,8 @@ test.describe('nameSlot — display state over the durable id, provenance-honest
     test('the chip rendering is density-calibrated: word only for the divergent state, glyph for the uniform one, nothing beside the mono id', () => {
         expect(NAME_PROVENANCE_STATES).toEqual(['naming-layer', 'declared-proxy', 'durable-id']);
 
-        // naming-layer (future, divergent across cards) earns the word
+        // naming-layer (RESERVED — the activation leaf's future divergent state) already maps to
+        // the word, so activating it changes no presentation code
         expect(describeNameProvenance('naming-layer')).toMatchObject({hidden: false, text: 'named'});
         // declared-proxy (today's uniform reality) renders the quiet outline glyph
         expect(describeNameProvenance('declared-proxy')).toMatchObject({hidden: false, text: '◇'});


### PR DESCRIPTION
Resolves #14641

The card's name slot now renders the ADR 0032 §2.3.2 primitive end to end: the Brain-folded display name as MUTABLE DISPLAY STATE over the durable id, with its provenance stated honestly and reachably. A new pure module (`nameSlot.mjs`, the `agentFreshness` sibling pattern) owns the contract: the folded name renders when present, the durable id renders in the mono register when it is not (never a blank drill target), and a provenance chip states how the rendered name is grounded. **The live vocabulary is two states** — `declared-proxy` (a quiet ◇ glyph; long copy on title/aria: display state, assent trail not wired) and `durable-id` (no chip — the mono register IS the signal). **`naming-layer` is RESERVED, not live:** the `FleetAgent` record contract carries no `nameProvenance` field today, so the classifier honestly refuses to emit the state; the reserved word `named` lives only in the presentation map, and the activation belongs to the naming-layer orbit's record-contract leaf (which must also render the trail facts). The chain itself stays folded Brain-side (`fleetCockpitStatus.mjs` — now spec-pinned in the assembler's own suite); the Body module deliberately does not re-implement it.

Evidence: L3 (real Chromium over the production App-Worker wire, real Brain registry seed, Neural Link record/DOM co-assertion) → L3 required (the NL-verified-row AC). The remaining naming-layer activation residual is named explicitly below.

## Deltas from ticket

- **The provenance affordance is density-calibrated per the adopted design read** (no chip beside the mono id; ◇ glyph for the uniform declared state; the word reserved for the future divergent state) — and after the cycle-1 review, the wired-trail branch is REMOVED from live code rather than promised: the record contract cannot carry it, so the classifier does not claim it (RA-1 fork B).
- **The fallback chain is NOT re-implemented Body-side.** The ticket's chain (`displayName → name → githubUsername → id`) is folded once in the Brain assembler; this PR pins that fold order in `fleetCockpitStatus.spec.mjs` (it was previously untested) and the view module owns only the view-grain safety net (`displayName → agentId → '—'`). One truth, spec-anchored on both sides of the wire.
- **AgentDetail reuse deferred deliberately:** the detail view's name line shares this contract, but its file is concurrently touched by the open pop-out PR — folding the detail consumption in now would manufacture a cross-PR conflict. It rides the next detail-touching leaf.
- **The drill button's accessible name stays the resident's name** (the keyboard-a11y contract): the id-fallback case still names the resident correctly (the id IS the resident's durable name-of-record), and the chip is a separate non-focusable element.

## Test Evidence

- Name-slot contract (pure): `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/nameSlot.spec.mjs` — fallback register, live provenance states plus the reserved-state fail-closed battery, blank-name discipline, closed chip vocabulary.
- Card integration: `.../agentCard.spec.mjs` — the §2.3.2 rename-in-place fixture (same instance, no re-key), the durable-id mono register with no redundant chip, register flip on a later rename, chip title/aria reachability.
- Brain-side fold order (CARD-CONTRACT row, 1:1): `.../ai/services/fleet/fleetCockpitStatus.spec.mjs` — `displayName → name → githubUsername → id` pinned per step.
- NL-verified row on live roster data: `NEO_E2E_PORT=8121 NEO_TEST_SKIP_CI=true npm run test-e2e -- test/playwright/e2e/agentos/FleetCardNameSlotNL.spec.mjs --workers=1` — a real-registry resident replaces the sample seed and renders the folded name + `◇` provenance glyph; record and DOM co-asserted through the Neural Link.
- A11y regression guard: `.../FleetGridKeyboardA11y.spec.mjs` in the fleet e2e batch — the chip must not disturb the roving-focus/drill contract.
- Full fleet view suite: `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/`.

## Post-Merge Validation

- [ ] A live cockpit with real registry residents shows the ◇ declared-proxy chips with reachable title/aria copy.

Residual (explicitly out of this leaf, named per review): the naming-layer activation — `nameProvenance` entering the `FleetAgent`/DTO record contract, a feed stamping it, the classifier branch flipping, and the trail FACTS rendering into the reachable surface — belongs to the naming-layer orbit's own leaf.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 2c0a23e9-f468-4de6-9e29-ddec96103fb4
