### PR TITLE
feat(mcp): add exact Neural Link probe projection (#15186)

### DIFF
--- a/ai/mcp/ToolService.mjs
+++ b/ai/mcp/ToolService.mjs
@@ -1,4 +1,4 @@
-import fs                                                 from 'fs';
+import fs        from 'fs';
 import * as yaml from 'js-yaml';
 import {buildZodSchema,
         buildOutputZodSchema,
@@ -45,6 +45,13 @@ class ToolService_tmp extends Base {
      */
     allToolsForListing = null
     /**
+     * Valid exact tool profiles compiled from the OpenAPI-root
+     * `x-neo-exact-tool-profiles` declaration.
+     * @member {Object|null} exactToolProfiles=null
+     * @protected
+     */
+    exactToolProfiles = null
+    /**
      * OpenAPI-root projection policy for harness-embedded tool surfaces.
      * @member {Object|null} harnessToolProjection=null
      * @protected
@@ -76,7 +83,7 @@ class ToolService_tmp extends Base {
     toolHandbookMapping = null
 
     /**
-     * Executes a specific tool with the given arguments.
+     * @summary Executes a specific tool with the given arguments.
      * @param {String} toolName
      * @param {Object} args
      * @returns {Promise<any>}
@@ -92,9 +99,10 @@ class ToolService_tmp extends Base {
             throw new Error(`Tool "${effectiveToolName}" not found or not implemented.`);
         }
 
-        this.assertToolProjectionAllows(effectiveToolName, options.toolProjection);
+        this.assertToolProjectionAllows(effectiveToolName, options.toolProjection, toolName);
 
-        const validatedArgs = tool.zodSchema.parse(args);
+        const projectionSchema = this.getProjectionInputZodSchema(effectiveToolName, options.toolProjection),
+              validatedArgs    = (projectionSchema || tool.zodSchema).parse(args);
 
         if (tool.passAsObject) {
             return tool.handler(validatedArgs);
@@ -105,7 +113,7 @@ class ToolService_tmp extends Base {
     }
 
     /**
-     * Initializes the internal tool mapping and the list of tools.
+     * @summary Initializes the internal tool mapping and the list of tools.
      * Designed to be called lazily.
      */
     initializeToolMapping() {
@@ -126,6 +134,7 @@ class ToolService_tmp extends Base {
         me.allToolsForListing  = [];
         me.toolHandbookMapping = {};
         me.toolProjectionTiers = {};
+        me.exactToolProfiles   = {};
 
         const openApiDocument = yaml.load(fs.readFileSync(me.openApiFilePath, 'utf8'));
         me.harnessToolProjection = openApiDocument['x-neo-harness-tool-projection'] || null;
@@ -139,8 +148,8 @@ class ToolService_tmp extends Base {
                     const inputZodSchema  = buildZodSchema(openApiDocument, operation);
                     const inputJsonSchema = toOpenApiJsonSchema(inputZodSchema);
 
-                    const outputZodSchema = buildOutputZodSchema(openApiDocument, operation);
-                    let outputJsonSchema  = null;
+                    const outputZodSchema  = buildOutputZodSchema(openApiDocument, operation);
+                    let   outputJsonSchema = null;
                     if (outputZodSchema) {
                         outputJsonSchema = toOpenApiJsonSchema(outputZodSchema);
                     }
@@ -191,6 +200,103 @@ class ToolService_tmp extends Base {
                 }
             }
         }
+
+        me.exactToolProfiles = me.buildExactToolProfiles(openApiDocument);
+    }
+
+    /**
+     * @summary Compiles valid OpenAPI-root exact profiles into list/call policy data.
+     *
+     * A malformed profile is omitted as one atomic unit, making every request for
+     * that profile fail closed. Operation ids and constrained input schemas remain
+     * owned by the OpenAPI declaration; this service stores only their compiled form.
+     *
+     * @param {Object} openApiDocument Parsed OpenAPI document.
+     * @returns {Object} Valid exact profiles keyed by server projection mode.
+     * @protected
+     */
+    buildExactToolProfiles(openApiDocument) {
+        const
+            me           = this,
+            root         = openApiDocument['x-neo-exact-tool-profiles'],
+            declarations = root?.profiles,
+            profiles     = {},
+            isRecord     = value => Boolean(value && typeof value === 'object' && !Array.isArray(value));
+
+        if (!isRecord(root) || !isRecord(declarations)) {
+            return profiles;
+        }
+
+        for (const [profileName, declaration] of Object.entries(declarations)) {
+            const toolDeclarations = declaration?.tools;
+
+            if (
+                !profileName ||
+                profileName === 'harness-embedded' ||
+                profileName.trim() !== profileName ||
+                !isRecord(declaration) ||
+                !isRecord(toolDeclarations) ||
+                Object.keys(toolDeclarations).length === 0
+            ) {
+                continue;
+            }
+
+            const tools   = {};
+            let   isValid = true;
+
+            for (const [toolName, toolDeclaration] of Object.entries(toolDeclarations)) {
+                if (!Object.hasOwn(me.toolMapping, toolName) || !isRecord(toolDeclaration)) {
+                    isValid = false;
+                    break;
+                }
+
+                let inputJsonSchema = null,
+                    inputZodSchema  = null;
+
+                if (Object.hasOwn(toolDeclaration, 'inputSchema')) {
+                    const inputSchema = toolDeclaration.inputSchema;
+
+                    if (!isRecord(inputSchema)) {
+                        isValid = false;
+                        break;
+                    }
+
+                    try {
+                        const resolvedInputSchema = inputSchema.$ref
+                            ? resolveRef(openApiDocument, inputSchema.$ref)
+                            : inputSchema;
+
+                        if (!isRecord(resolvedInputSchema) || resolvedInputSchema.type !== 'object') {
+                            isValid = false;
+                            break;
+                        }
+
+                        inputZodSchema = buildZodSchema(openApiDocument, {
+                            requestBody: {
+                                content: {
+                                    'application/json': {schema: inputSchema}
+                                }
+                            }
+                        });
+                        inputJsonSchema = toOpenApiJsonSchema(inputZodSchema);
+                    } catch {
+                        isValid = false;
+                        break;
+                    }
+                }
+
+                tools[toolName] = {inputJsonSchema, inputZodSchema};
+            }
+
+            if (isValid) {
+                profiles[profileName] = {
+                    description: declaration.description || '',
+                    tools
+                };
+            }
+        }
+
+        return profiles;
     }
 
     /**
@@ -202,7 +308,7 @@ class ToolService_tmp extends Base {
      */
     buildToolListDescription(operation, fullDescription) {
         const
-            source = operation['x-neo-tool-summary'] || operation.summary || fullDescription || '',
+            source     = operation['x-neo-tool-summary'] || operation.summary || fullDescription || '',
             singleLine = String(source).replace(/\s+/g, ' ').trim(),
             maxLength  = this.toolListDescriptionMaxLength;
 
@@ -251,9 +357,9 @@ class ToolService_tmp extends Base {
 
         if (!entry) {
             return {
-                toolId: requestedToolId,
-                found : false,
-                code  : 'TOOL_NOT_FOUND',
+                toolId : requestedToolId,
+                found  : false,
+                code   : 'TOOL_NOT_FOUND',
                 message: `Tool "${requestedToolId}" does not exist in this MCP server.`
             };
         }
@@ -315,6 +421,18 @@ class ToolService_tmp extends Base {
             return me.allToolsForListing;
         }
 
+        const exactProfile = me.exactToolProfiles?.[context.mode];
+
+        if (exactProfile) {
+            return Object.entries(exactProfile.tools).map(([toolName, profileTool]) => {
+                const tool = me.allToolsForListing.find(candidate => candidate.name === toolName);
+
+                return profileTool.inputJsonSchema
+                    ? {...tool, inputSchema: profileTool.inputJsonSchema}
+                    : tool;
+            });
+        }
+
         return me.allToolsForListing.filter(tool => me.isToolAllowedForProjection(tool.name, context));
     }
 
@@ -322,19 +440,35 @@ class ToolService_tmp extends Base {
      * @summary Throws when a tool is not visible through the supplied projection context.
      * @param {String}             toolName
      * @param {Object|String|null} toolProjection
+     * @param {String}             [requestedToolName=toolName] Original MCP tool id before alias resolution.
      */
-    assertToolProjectionAllows(toolName, toolProjection) {
+    assertToolProjectionAllows(toolName, toolProjection, requestedToolName=toolName) {
         const me      = this,
               context = me.normalizeToolProjectionContext(toolProjection);
 
-        if (!context || me.isToolAllowedForProjection(toolName, context)) {
+        if (!context || me.isToolAllowedForProjection(toolName, context, requestedToolName)) {
             return;
         }
 
-        const error = new Error(`Tool "${toolName}" is not visible in the ${context.mode || 'unknown'} projection.`);
+        const error = new Error(`Tool "${requestedToolName}" is not visible in the ${context.mode || 'unknown'} projection.`);
         error.code   = 'POLICY_REFUSED';
         error.reason = error.message;
         throw error;
+    }
+
+    /**
+     * @summary Returns the exact-profile input validator for one visible tool.
+     * @param {String}             toolName
+     * @param {Object|String|null} toolProjection
+     * @returns {Object|null}
+     * @protected
+     */
+    getProjectionInputZodSchema(toolName, toolProjection) {
+        const context = this.normalizeToolProjectionContext(toolProjection);
+
+        return context
+            ? this.exactToolProfiles?.[context.mode]?.tools?.[toolName]?.inputZodSchema || null
+            : null;
     }
 
     /**
@@ -360,20 +494,27 @@ class ToolService_tmp extends Base {
      * Unknown projection modes and missing tiers fail closed.
      * @param {String} toolName
      * @param {Object} context
+     * @param {String} [requestedToolName=toolName] Original MCP tool id before alias resolution.
      * @returns {Boolean}
      * @protected
      */
-    isToolAllowedForProjection(toolName, context) {
+    isToolAllowedForProjection(toolName, context, requestedToolName=toolName) {
         const me = this;
 
-        if (context.mode !== 'harness-embedded') {
-            return false;
+        if (context.mode === 'harness-embedded') {
+            const visibleTiers = me.harnessToolProjection?.defaultVisibleTiers || [],
+                  toolTier     = me.toolProjectionTiers?.[toolName];
+
+            return Boolean(toolTier && visibleTiers.includes(toolTier));
         }
 
-        const visibleTiers = me.harnessToolProjection?.defaultVisibleTiers || [],
-              toolTier     = me.toolProjectionTiers?.[toolName];
+        const exactProfile = me.exactToolProfiles?.[context.mode];
 
-        return Boolean(toolTier && visibleTiers.includes(toolTier));
+        return Boolean(
+            exactProfile &&
+            requestedToolName === toolName &&
+            Object.hasOwn(exactProfile.tools, toolName)
+        );
     }
 
     /**
@@ -387,7 +528,7 @@ class ToolService_tmp extends Base {
         if (!schema) return true;
 
         if (schema.type) {
-            const type = schema.type;
+            const type      = schema.type;
             const valueType = Array.isArray(value) ? 'array' : (value === null ? 'null' : typeof value);
 
             if (type === 'integer') {

--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -14,6 +14,42 @@ x-neo-harness-tool-projection:
     Write-locked tools are withheld until Topological Locking and explicit-target
     semantics exist. Admin tools stay operator-only unless a later authorization
     leaf grants them deliberately.
+x-neo-exact-tool-profiles:
+  description: >
+    Server-pinned exact profiles declare their complete operation set and any
+    narrower input schemas here. ToolService compiles this single OpenAPI authority
+    for both tools/list visibility and tools/call validation; unknown or malformed
+    profiles fail closed.
+  profiles:
+    local-readonly-probe:
+      description: >
+        Minimal loopback interoperability probe. It exposes only health, worker
+        topology, and a depth-bounded lean component tree.
+      tools:
+        healthcheck: {}
+        get_worker_topology: {}
+        get_component_tree:
+          inputSchema:
+            type: object
+            required:
+              - depth
+            properties:
+              rootId:
+                type: string
+                description: Optional root component ID. Defaults to the App's MainView if available.
+              depth:
+                type: integer
+                minimum: 1
+                maximum: 2
+                description: Bounded structural depth. 1=Self, 2=Self+Children.
+              lean:
+                type: boolean
+                enum: [true]
+                default: true
+                description: The exact probe always returns the lean structural projection.
+              sessionId:
+                type: string
+                description: The target App Worker Session ID.
 paths:
   /health:
     post:

--- a/ai/mcp/validation/openApiValidator.mjs
+++ b/ai/mcp/validation/openApiValidator.mjs
@@ -227,6 +227,15 @@ function buildZodSchemaFromNode(doc, schema, opts = {}) {
         zodSchema = z.unknown();
     }
 
+    // `z.enum()` covers string enums above. Compile boolean enums to literals so
+    // runtime validation and the machine-readable `tools/list` schema preserve
+    // the same constraint (notably exact-profile `lean: true` contracts).
+    if (schema.type === 'boolean' && Array.isArray(schema.enum) && schema.enum.length > 0) {
+        const literals = schema.enum.map(value => z.literal(value));
+
+        zodSchema = literals.length === 1 ? literals[0] : z.union(literals);
+    }
+
     if (schema.nullable) {
         zodSchema = zodSchema.nullable();
     }
@@ -251,13 +260,13 @@ function buildZodSchemaFromNode(doc, schema, opts = {}) {
  * @returns {z.ZodType|null} A Zod schema for the output, or null if no schema is defined.
  */
 function buildOutputZodSchema(doc, operation) {
-    const response    = operation.responses?.['200'] || operation.responses?.['201'] || operation.responses?.['202'];
-    const schema      = response?.content?.['application/json']?.schema;
+    const response = operation.responses?.['200'] || operation.responses?.['201'] || operation.responses?.['202'];
+    const schema   = response?.content?.['application/json']?.schema;
     // Every `z.object(...)` produced here is emitted with `.passthrough()` so the resulting
     // JSON Schema sets `additionalProperties: true`. This is the output-side counterpart to
     // the input-side strictness: server implementations drift faster than OpenAPI contracts,
     // and strict MCP clients (GitHub Copilot) reject any response with undeclared fields.
-    const outputOpts  = {lenient: true};
+    const outputOpts = {lenient: true};
 
     if (schema) {
         let resolvedSchema = schema;

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -160,6 +160,20 @@ function getHarnessEmbeddedOperationIds(server) {
 }
 
 /**
+ * @summary Returns one exact profile declaration from a server's root OpenAPI contract.
+ * @param {Object} server      The MCP server fixture.
+ * @param {String} profileName Exact profile name.
+ * @returns {Object|null} The declared profile, or null when absent.
+ */
+function getExactToolProfile(server, profileName) {
+    const
+        openApiFile = path.join(repoRoot, server.openApiPath),
+        doc         = yaml.load(fs.readFileSync(openApiFile, 'utf8'));
+
+    return doc['x-neo-exact-tool-profiles']?.profiles?.[profileName] || null;
+}
+
+/**
  * @summary Parses the real per-server `serviceMapping` object without invoking handlers.
  * This catches OpenAPI/toolService drift while avoiding tool side effects.
  *
@@ -679,6 +693,137 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
         await expect(toolService.callTool('patch_code', {}, {toolProjection})).rejects.toThrow(
             /Tool "patch_code" is not visible in the harness-embedded projection/
         );
+    });
+
+    test('neural-link local probe lists the exact OpenAPI-owned set and constrained tree schema (#15186)', async () => {
+        const
+            server                           = servers.find(item => item.name === 'neural-link'),
+            profileName                      = 'local-readonly-probe',
+            profile                          = getExactToolProfile(server, profileName),
+            moduleUrl                        = pathToFileURL(path.join(repoRoot, server.toolServicePath)).href,
+            {listTools: listNeuralLinkTools} = await import(moduleUrl),
+            {tools}                          = listNeuralLinkTools({toolProjection: {mode: profileName}}),
+            listedNames                      = tools.map(tool => tool.name),
+            declaredNames                    = Object.keys(profile.tools),
+            treeSchema                       = tools.find(tool => tool.name === 'get_component_tree').inputSchema;
+
+        expect(declaredNames).toEqual(['healthcheck', 'get_worker_topology', 'get_component_tree']);
+        expect(listedNames).toEqual(declaredNames);
+        expect(treeSchema.required).toEqual(['depth']);
+        expect(treeSchema.properties.depth).toMatchObject({
+            type   : 'integer',
+            minimum: 1,
+            maximum: 2
+        });
+        expect(treeSchema.properties.lean).toMatchObject({
+            type   : 'boolean',
+            enum   : [true],
+            default: true
+        });
+    });
+
+    test('neural-link local probe applies one exact list/call contract and rejects widening inputs (#15186)', async () => {
+        const
+            server         = servers.find(item => item.name === 'neural-link'),
+            profileName    = 'local-readonly-probe',
+            toolProjection = {mode: profileName},
+            calls          = [],
+            toolService    = Neo.create(ToolService, {
+                openApiFilePath: path.join(repoRoot, server.openApiPath),
+                serviceMapping : {
+                    healthcheck        : async () => calls.push(['healthcheck', {}]),
+                    get_worker_topology: async () => calls.push(['get_worker_topology', {}]),
+                    get_component_tree : async args => {
+                        calls.push(['get_component_tree', args]);
+                        return args;
+                    },
+                    patch_code: async () => ({patched: true})
+                }
+            }),
+            {tools}      = toolService.listTools({toolProjection}),
+            listedNames = tools.map(tool => tool.name);
+
+        await expect(toolService.callTool('healthcheck', {}, {toolProjection})).resolves.toEqual(1);
+        await expect(toolService.callTool('get_worker_topology', {}, {toolProjection})).resolves.toEqual(2);
+        await expect(toolService.callTool('get_component_tree', {depth: 1}, {toolProjection})).resolves.toEqual({
+            depth: 1,
+            lean : true
+        });
+        await expect(toolService.callTool('get_component_tree', {
+            depth    : 2,
+            lean     : true,
+            rootId   : 'root',
+            sessionId: 'session'
+        }, {toolProjection})).resolves.toMatchObject({depth: 2, lean: true});
+
+        expect(listedNames).toEqual(calls.slice(0, 3).map(([toolName]) => toolName));
+        expect(calls[2][1]).toEqual({depth: 1, lean: true});
+
+        for (const args of [
+            {},
+            {depth: -1},
+            {depth: 3},
+            {depth: 1.5},
+            {depth: 1, lean: false}
+        ]) {
+            await expect(toolService.callTool('get_component_tree', args, {toolProjection})).rejects.toThrow();
+        }
+
+        await expect(toolService.callTool('patch_code', {}, {toolProjection})).rejects.toThrow(
+            /Tool "patch_code" is not visible in the local-readonly-probe projection/
+        );
+        await expect(toolService.callTool('neural-link__healthcheck', {}, {toolProjection})).rejects.toThrow(
+            /Tool "neural-link__healthcheck" is not visible in the local-readonly-probe projection/
+        );
+    });
+
+    test('neural-link local probe is server-pinned and unknown profile names fail closed (#15186)', async () => {
+        const
+            server      = servers.find(item => item.name === 'neural-link'),
+            profileName = 'local-readonly-probe',
+            moduleUrl   = pathToFileURL(path.join(repoRoot, 'ai/mcp/server/neural-link/Server.mjs')).href,
+            Server      = (await import(moduleUrl)).default,
+            ctx         = Server.prototype.buildToolProjectionContext,
+            toolService = Neo.create(ToolService, {
+                openApiFilePath: path.join(repoRoot, server.openApiPath),
+                serviceMapping : {healthcheck: async () => ({status: 'ok'})}
+            });
+
+        for (const request of [
+            {params: {}},
+            {params: {_meta: {}}},
+            {params: {_meta: {neoToolProjection: 'full'}}},
+            {params: {_meta: {neoToolProjection: 'harness-embedded'}}}
+        ]) {
+            expect(ctx.call({toolProjectionMode: profileName}, {request})).toEqual({mode: profileName});
+        }
+
+        for (const mode of ['unknown-profile', '', ' local-readonly-probe', 'local-readonly-probe ']) {
+            const toolProjection = {mode};
+
+            expect(toolService.listTools({toolProjection}).tools).toEqual([]);
+            await expect(toolService.callTool('healthcheck', {}, {toolProjection})).rejects.toThrow(/not visible/);
+        }
+    });
+
+    test('ToolService rejects malformed and reserved exact-profile declarations atomically (#15186)', () => {
+        const
+            server          = servers.find(item => item.name === 'neural-link'),
+            openApiFile     = path.join(repoRoot, server.openApiPath),
+            openApiDocument = yaml.load(fs.readFileSync(openApiFile, 'utf8')),
+            toolService     = Neo.create(ToolService, {openApiFilePath: openApiFile});
+
+        toolService.initializeToolMapping();
+
+        openApiDocument['x-neo-exact-tool-profiles'].profiles = {
+            'harness-embedded': {tools: {healthcheck: {}}},
+            ' unknown'        : {tools: {healthcheck: {}}},
+            unknown_tool      : {tools: {not_an_operation: {}}},
+            invalid_input     : {tools: {healthcheck: {inputSchema: {type: 'string'}}}},
+            invalid_ref       : {tools: {healthcheck: {inputSchema: {$ref: '#/components/schemas/Missing'}}}}
+        };
+
+        expect(toolService.buildExactToolProfiles(openApiDocument)).toEqual({});
     });
 
     test('neural-link server-instance forced mode is the ceiling — client cannot widen via _meta (#13106)', async () => {


### PR DESCRIPTION
Resolves #15186

Related: #15184
Related: #15187

Adds an OpenAPI-root exact-profile substrate and the `local-readonly-probe` profile for Neural Link. `ToolService` now compiles the declared operation set and constrained input schemas once, projects the same contract into `tools/list`, and applies it during `tools/call`. The profile exposes only `healthcheck`, `get_worker_topology`, and `get_component_tree`; the tree call requires integer depth 1 or 2, defaults `lean` to `true`, rejects `lean: false`, and refuses aliases or any operation outside the exact set. Existing unforced and `harness-embedded` surfaces remain unchanged.

Evidence: L2 (real OpenAPI compiler plus list/call policy exercised through focused unit coverage) → L2 required (all close-target ACs are CI-reachable). No residuals.

## Deltas from ticket

None substantive. The pre-PR architecture reflection added atomic fail-closed handling for malformed declarations and reserves the existing `harness-embedded` mode against exact-profile name collisions.

## Test Evidence

- Exact profile matrix: `NEO_CHROMA_PORT_TEST=18193 NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs --grep '#15186' --workers=1` — 4 passed.
- Full MCP list/call smoke surface: `NEO_CHROMA_PORT_TEST=18194 NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs --workers=1` — 35 passed.
- Direct compiler falsifier: exact three names and constrained schema observed; omitted depth, `-1`, `3`, non-integer depth, `lean: false`, and namespaced alias calls all refused; omitted lean was forced to `true`.
- MCP description-budget audit: no operation description or path was added; new profile property descriptions are terse, single-line, usage-focused, and below the 1024-character cap.
- `npm run agent-preflight -- ai/mcp/ToolService.mjs ai/mcp/server/neural-link/openapi.yaml ai/mcp/validation/openApiValidator.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs` — all requested gates passed.

## Post-Merge Validation

- [ ] Confirm GitHub CI is green on the merged exact head.
- [ ] Consume `local-readonly-probe` in the native closeout journey owned by `#15187` after both prerequisite leaves merge.

Authored by Euclid (OpenAI GPT-5.6 Sol Ultra, Codex Desktop). Session 7efa8a03-b5cb-46c6-b1e9-bda072fead25.
