### PR TITLE
feat(build): A1 env-re-derivation rule — two-signal, masked import gate (#15213)

### DIFF
--- a/buildScripts/util/check-aiconfig-antipatterns.mjs
+++ b/buildScripts/util/check-aiconfig-antipatterns.mjs
@@ -36,14 +36,39 @@ export const B3_DEFENSIVE_CHAIN = new RegExp(
 export const A5_ENV_HELPER = /\bhasEnvValue\s*\(/;
 
 /*
+ * Rule A1's FILE gate — module-level env re-derivation is an antipattern ONLY where the config
+ * SSOT is already in scope. A file importing the config singleton (import-statement token or the
+ * runtime `Neo.ai.Config` root) that re-derives values from `process.env` should read the resolved
+ * leaf instead. The gate is what keeps the C1-sanctioned shape green: a genuine non-entrypoint
+ * pure-defaults module carries env literals WITHOUT any config import — by design — and must
+ * never flag.
+ */
+export const A1_IMPORT_GATE = /^\s*import\s+[^;]*\b(?:AiConfig|Memory_Config)\b[^;]*\bfrom\b|\bNeo\.ai\.Config\b/m;
+
+/*
+ * Rule A1's LINE rule — a module-level `const|let|var` declaration whose initializer reads
+ * `process.env.` on the declaration line. Column-0 anchoring is the module-level signal in this
+ * codebase's indent style: function-local reads are indented and never match. A multi-line
+ * initializer whose env read sits on a continuation line is outside this static heuristic —
+ * the escape marker covers judgment-call residue.
+ */
+export const A1_ENV_REDERIVATION = /^(?:const|let|var)\s[^;]*=\s*[^;]*\bprocess\.env\./;
+
+/*
  * Rule-scoped grandfathering: each rule carries its OWN set of repo-relative POSIX paths, so one
  * rule's existing-surface exemption can never widen another's — A5 keeps its zero-baseline ratchet
  * even inside files grandfathered for B3. A whole-file skip would silently exempt every rule at
  * once; filtering happens per HIT instead ({@link filterAllowlistedHits}). Sets shrink as the
- * cleanup subs land. B3 census: 2026-07-16 against `dev`; A5 is empty by construction (zero live
- * occurrences — any entry appearing here is a regression, not a grandfather).
+ * cleanup subs land. B3 census: 2026-07-16 against `dev`; A1 census: same day via THIS checker's
+ * own gate (a line-grep census missed the dev fleet server's multi-line import — the masked
+ * multi-line gate is the census authority); A5 is empty by construction (zero live occurrences —
+ * any entry appearing here is a regression, not a grandfather).
  */
 export const ALLOWLIST = Object.freeze({
+    A1: new Set([
+        'ai/daemons/wake/daemon.mjs',
+        'ai/services/fleet/devFleetServer.mjs'
+    ]),
     A5: new Set(),
     B3: new Set([
         'ai/mcp/server/BaseServer.mjs',
@@ -58,17 +83,23 @@ const RULES = [
 ];
 
 /**
- * @summary Scans file content for the B3 / A5 config-read antipatterns whose root token sits in code.
+ * @summary Scans file content for the A1 / B3 / A5 config-read antipatterns whose root token sits in code.
  *
  * Reuses the sibling guard's `codeMask` so an occurrence inside a string literal (a log message, a
  * spec title quoting the pattern) or a comment never flags — only executable defensive reads do.
+ * A1 is two-signal: its line rule participates only when the FILE passes the import gate
+ * ({@link A1_IMPORT_GATE}), so the C1-sanctioned pure-defaults shape (env literals, no config
+ * import) stays green by construction.
  * @param {String} content
  * @returns {Object[]} `[{line, rule, text}]` — one entry per offending line/rule (1-based line numbers).
  */
 export function findAntipatterns(content) {
-    const lines = content.split('\n'),
-          state = {inBlock: false},
-          hits  = [];
+    const lines         = content.split('\n'),
+          state         = {inBlock: false},
+          hits          = [],
+          a1Candidates  = [],
+          codeOnlyLines = [],
+          a1Global      = new RegExp(A1_ENV_REDERIVATION.source, 'g');
 
     lines.forEach((line, index) => {
         if (line.includes(ESCAPE_MARKER)) {
@@ -76,6 +107,12 @@ export function findAntipatterns(content) {
         }
 
         const mask = codeMask(line, state);
+
+        // The gate must see CODE only — a JSDoc/comment mention of the config root (a config
+        // template documenting its realm, a migration note) must never open A1 for the file.
+        // Build the code-only projection from the same mask the line rules use: masked-out
+        // characters become spaces, so multi-line import statements still span lines intact.
+        codeOnlyLines.push(Array.from(line, (ch, i) => (mask[i] ? ch : ' ')).join(''));
 
         for (const {id, pattern} of RULES) {
             for (const match of line.matchAll(pattern)) {
@@ -87,7 +124,19 @@ export function findAntipatterns(content) {
                 }
             }
         }
+
+        for (const match of line.matchAll(a1Global)) {
+            if (mask[match.index]) {
+                a1Candidates.push({line: index + 1, rule: 'A1', text: line.trim()});
+                break
+            }
+        }
     });
+
+    // A1 is two-signal: candidates emit only when the file's CODE opens the import gate.
+    if (a1Candidates.length && A1_IMPORT_GATE.test(codeOnlyLines.join('\n'))) {
+        hits.push(...a1Candidates)
+    }
 
     return hits
 }
@@ -179,7 +228,9 @@ function main() {
             violations.forEach(v => console.error('  ' + v));
             console.error('\nB3: never `?.` on an AiConfig read — the SSOT guarantees the tree; read the leaf and let it');
             console.error('fail loud (ADR-0019 §3/§5.1). A5: never a `hasEnvValue` helper — `leaf(default, env, type)`');
-            console.error(`owns the env-check (§5.2). Genuinely unavoidable line: add "${ESCAPE_MARKER}: <reason>".`);
+            console.error('owns the env-check (§5.2). A1: with AiConfig imported, never re-derive from process.env at');
+            console.error('module level — read the resolved leaf at the use site (§5.5; pure-defaults modules WITHOUT');
+            console.error(`a config import are the sanctioned C1 shape). Genuinely unavoidable: "${ESCAPE_MARKER}: <reason>".`);
         }
         process.exit(1);
     }

--- a/buildScripts/util/check-aiconfig-antipatterns.mjs
+++ b/buildScripts/util/check-aiconfig-antipatterns.mjs
@@ -102,17 +102,22 @@ export function findAntipatterns(content) {
           a1Global      = new RegExp(A1_ENV_REDERIVATION.source, 'g');
 
     lines.forEach((line, index) => {
+        // Mask + projection compute UNCONDITIONALLY — before the escape check. Skipping a line
+        // would corrupt block-comment state continuity AND remove the line from the gate
+        // projection: an escape marker on the IMPORT line would then silently exempt the whole
+        // file's A1 hits (the escape valve is line-scoped for HITS, never for composition).
+        const mask = codeMask(line, state),
+              // The gate must see CODE only — a JSDoc/comment mention of the config root (a config
+              // template documenting its realm, a migration note) must never open A1 for the file.
+              // Masked-out characters become spaces, preserving positions, so multi-line import
+              // statements still span lines intact.
+              codeOnly = Array.from(line, (ch, i) => (mask[i] ? ch : ' ')).join('');
+
+        codeOnlyLines.push(codeOnly);
+
         if (line.includes(ESCAPE_MARKER)) {
             return
         }
-
-        const mask = codeMask(line, state);
-
-        // The gate must see CODE only — a JSDoc/comment mention of the config root (a config
-        // template documenting its realm, a migration note) must never open A1 for the file.
-        // Build the code-only projection from the same mask the line rules use: masked-out
-        // characters become spaces, so multi-line import statements still span lines intact.
-        codeOnlyLines.push(Array.from(line, (ch, i) => (mask[i] ? ch : ' ')).join(''));
 
         for (const {id, pattern} of RULES) {
             for (const match of line.matchAll(pattern)) {
@@ -125,11 +130,14 @@ export function findAntipatterns(content) {
             }
         }
 
-        for (const match of line.matchAll(a1Global)) {
-            if (mask[match.index]) {
-                a1Candidates.push({line: index + 1, rule: 'A1', text: line.trim()});
-                break
-            }
+        // A1 classifies against the code-only PROJECTION, not the raw line: the declaration
+        // keyword sits at index 0 whether or not `process.env.` is real code, so a raw-line
+        // match + a mask check at the match start would false-positive on a genuine declaration
+        // whose env token lives inside a string or comment. On the projection, masked env tokens
+        // are spaces — the regex simply cannot match them.
+        for (const match of codeOnly.matchAll(a1Global)) {
+            a1Candidates.push({line: index + 1, rule: 'A1', text: line.trim()});
+            break
         }
     });
 

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -64,14 +64,18 @@ export const ALLOWLIST = new Set([
  * The other half of the decision is the last significant code char: after an identifier char, `)`
  * or `]` a `/` is division; after operators, delimiters or nothing it opens a regex.
  */
-const REGEX_PRECEDING_KEYWORDS = /^(?:return|typeof|instanceof|case|in|of|new|delete|void|yield|await|do|else)$/;
+const REGEX_PRECEDING_KEYWORDS = /^(?:return|throw|typeof|instanceof|case|in|of|new|delete|void|yield|await|do|else)$/;
 
 /*
  * Control-statement headers whose closing `)` puts the grammar back at expression START, so a
  * following `/` opens a regex (`if (ok) /re/.test(s)`), unlike a call/grouping `)` where `/` is
- * division (`foo(a) / b`). Tracked via a paren-word stack carried in state.
+ * division (`foo(a) / b`). Tracked via a paren-word stack carried in state. Whitespace never
+ * resets the word buffer, so multi-word headers arrive CONCATENATED — `for await (` reads
+ * `forawait`, `else if (` reads `elseif` — which is what keeps plain `await (x) / y` (word
+ * `await` after an `=` reset) correctly classified as division. An identifier literally named
+ * `forawait`/`elseif` before a paren would misread — accepted, not valid style in this codebase.
  */
-const CONTROL_HEADER_KEYWORDS = /^(?:if|while|for|switch|catch|with)$/;
+const CONTROL_HEADER_KEYWORDS = /^(?:if|while|for|switch|catch|with|forawait|elseif)$/;
 
 /**
  * @summary Decides whether a `/` at the current lexer position opens a regex literal.

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -66,13 +66,23 @@ export const ALLOWLIST = new Set([
  */
 const REGEX_PRECEDING_KEYWORDS = /^(?:return|typeof|instanceof|case|in|of|new|delete|void|yield|await|do|else)$/;
 
+/*
+ * Control-statement headers whose closing `)` puts the grammar back at expression START, so a
+ * following `/` opens a regex (`if (ok) /re/.test(s)`), unlike a call/grouping `)` where `/` is
+ * division (`foo(a) / b`). Tracked via a paren-word stack carried in state.
+ */
+const CONTROL_HEADER_KEYWORDS = /^(?:if|while|for|switch|catch|with)$/;
+
 /**
  * @summary Decides whether a `/` at the current lexer position opens a regex literal.
  *
- * Standard lexer heuristic, not a parser: `state.lastCode` (last significant code char) and
- * `state.wordBuf` (trailing identifier run) approximate "are we at expression start?". Known bound:
- * a division whose left operand ends on the PREVIOUS line (ASI edge) misreads as regex — accepted,
- * documented, and unreachable in the guard's own scan set (valid committed JS, per-line reads).
+ * Standard lexer heuristic, not a parser, on three signals: `state.lastCode` (last significant
+ * code char), `state.wordBuf` (trailing identifier run — the keyword half: `return /x/`), and
+ * `state.controlParen` (whether the most recent `)` closed a control-statement header — the
+ * grammar half: `if (ok) /x/` is a regex, `foo(a) / b` is division). Expression-ending literals
+ * (closing quote/backtick, a finished regex) record the `]` proxy in `lastCode`, so a following
+ * `/` is division. Known bound, documented at the mask: a division whose left operand ends on the
+ * PREVIOUS line (ASI edge) misreads as regex.
  * @param {Object} state The carried lexer state.
  * @returns {Boolean}
  */
@@ -85,7 +95,10 @@ function regexAllowed(state) {
     if (/[A-Za-z0-9_$]/.test(last)) {
         return REGEX_PRECEDING_KEYWORDS.test(state.wordBuf)
     }
-    return !/[)\]]/.test(last)
+    if (last === ')') {
+        return state.controlParen === true
+    }
+    return last !== ']'
 }
 
 /**
@@ -152,39 +165,46 @@ function consumeRegex(line, i) {
  * and carry in `state`; a multi-line template's text lines therefore mask as string, and a
  * line-comment inside a multi-line interpolation ends at EOL while the frame survives. Quoted
  * strings auto-close at EOL (unterminated ones are syntax errors in the valid JS this guard scans)
- * unless a line-final `\` continues them (`state.pendingEscape`). Unlike a strip-to-text pass the
- * mask preserves positions, so a regex match found on the RAW line can be classified by whether its
- * root token sits in code — a string-literal *bracket key* (`['storagePaths']`, real code merely
- * containing a string) stays detectable while a pattern living entirely inside a string (a log
- * message, a `describe(...)` title, a regex body) is excluded. The structural complement of
- * `check-ticket-archaeology.mjs`'s `extractComment`.
+ * unless a line-final `\` continues them: the backslash escapes the LINE TERMINATOR — a
+ * continuation consumes NO character on the next line, so an immediate closing delimiter at
+ * column zero is processed normally (`state.stringContinues`). Expression-ending literals (a
+ * closing quote, backtick, or regex) record the `]` proxy in `lastCode`, so a following `/` is
+ * division, and a paren-word stack distinguishes a control-header `)` (regex follows: `if (ok)
+ * /re/`) from a call/grouping `)` (division follows: `foo(a) / b`). Remaining documented bound:
+ * a division whose left operand ends on the PREVIOUS line (ASI edge) misreads as regex. Unlike a
+ * strip-to-text pass the mask preserves positions, so a regex match found on the RAW line can be
+ * classified by whether its root token sits in code — a string-literal *bracket key*
+ * (`['storagePaths']`, real code merely containing a string) stays detectable while a pattern
+ * living entirely inside a string (a log message, a `describe(...)` title, a regex body) is
+ * excluded. The structural complement of `check-ticket-archaeology.mjs`'s `extractComment`.
  * @param {Object} state Mutated in place; carries all cross-line lexer state. Constructing it as
  *     `{inBlock: false}` remains sufficient — richer fields self-initialize on first use.
  * @param {Boolean} state.inBlock Inside a block comment.
  * @param {Object[]} [state.stack] Lexical frames: `{type: 'code'|'template'|'expression'}`.
  * @param {String|null} [state.stringQuote] Open quote character of a quoted string.
- * @param {Boolean} [state.pendingEscape] A line-final `\` escapes the next line's first char.
+ * @param {Boolean} [state.stringContinues] A line-final `\` inside a quoted string escaped the
+ *     line terminator — the string legally continues on the next line.
  * @param {String} [state.lastCode] Last significant code char (regex-vs-division heuristic).
  * @param {String} [state.wordBuf] Trailing identifier run (regex-after-keyword heuristic).
+ * @param {String[]} [state.parenWords] Word immediately preceding each open `(` (control-header
+ *     detection for the regex heuristic).
+ * @param {Boolean} [state.controlParen] The most recent `)` closed a control-statement header.
  * @param {String} line
  * @returns {Boolean[]} `mask[i]` is true when raw character `i` is executable code.
  */
 export function codeMask(line, state) {
-    state.stack         ??= [{type: 'code'}];
-    state.stringQuote   ??= null;
-    state.pendingEscape ??= false;
-    state.lastCode      ??= '';
-    state.wordBuf       ??= '';
+    state.stack           ??= [{type: 'code'}];
+    state.stringQuote     ??= null;
+    state.stringContinues ??= false;
+    state.lastCode        ??= '';
+    state.wordBuf         ??= '';
+    state.parenWords      ??= [];
+    state.controlParen    ??= false;
 
     const n    = line.length,
           mask = new Array(n).fill(false);
 
     let i = 0;
-
-    if (state.pendingEscape) {
-        state.pendingEscape = false;
-        i = 1
-    }
 
     while (i < n) {
         const ch   = line[i],
@@ -204,14 +224,19 @@ export function codeMask(line, state) {
 
         if (state.stringQuote) {
             if (ch === '\\') {
+                // A line-final backslash escapes the line terminator: the string CONTINUES on the
+                // next line and the continuation consumes no next-line character.
                 if (i === n - 1) {
-                    state.pendingEscape = true
+                    state.stringContinues = true
                 }
                 i += 2;
                 continue
             }
             if (ch === state.stringQuote) {
-                state.stringQuote = null
+                state.stringQuote = null;
+                // A closing quote ends an expression: a following `/` is division.
+                state.lastCode    = ']';
+                state.wordBuf     = ''
             }
             i++;
             continue
@@ -219,14 +244,15 @@ export function codeMask(line, state) {
 
         if (ctx.type === 'template') {
             if (ch === '\\') {
-                if (i === n - 1) {
-                    state.pendingEscape = true
-                }
+                // Line-final: escapes the terminator; the template frame carries anyway and the
+                // next line processes from column zero.
                 i += 2;
                 continue
             }
             if (ch === '`') {
                 state.stack.pop();
+                state.lastCode = ']';
+                state.wordBuf  = '';
                 i++;
                 continue
             }
@@ -265,9 +291,9 @@ export function codeMask(line, state) {
 
         if (ch === '/' && regexAllowed(state)) {
             i = consumeRegex(line, i);
-            // A regex literal ends an expression: a following `/` is division. `)` is the proxy
-            // for "expression just ended" in the heuristic's char alphabet.
-            state.lastCode = ')';
+            // A regex literal ends an expression: a following `/` is division. `]` is the
+            // expression-ender proxy in the heuristic's char alphabet.
+            state.lastCode = ']';
             state.wordBuf  = '';
             continue
         }
@@ -289,6 +315,17 @@ export function codeMask(line, state) {
         mask[i] = true;
 
         if (!/\s/.test(ch)) {
+            // Paren-word tracking: `(` records the word immediately preceding it; `)` decides
+            // whether it closed a control-statement header (regex may follow) or a call/grouping
+            // (division follows). Any other significant char invalidates a stale control-`)`.
+            if (ch === '(') {
+                state.parenWords.push(state.wordBuf)
+            } else if (ch === ')') {
+                state.controlParen = CONTROL_HEADER_KEYWORDS.test(state.parenWords.pop() ?? '')
+            } else {
+                state.controlParen = false
+            }
+
             state.lastCode = ch;
             state.wordBuf  = /[A-Za-z0-9_$]/.test(ch) ? state.wordBuf + ch : ''
         }
@@ -296,10 +333,12 @@ export function codeMask(line, state) {
     }
 
     // JS auto-terminates quoted strings at EOL (unterminated = syntax error upstream, CI runs a
-    // parse check) — reset instead of poisoning the next line, except across a `\` continuation.
-    if (state.stringQuote && !state.pendingEscape) {
+    // parse check) — reset instead of poisoning the next line, except across a `\` continuation
+    // (the line-terminator escape consumed above).
+    if (state.stringQuote && !state.stringContinues) {
         state.stringQuote = null
     }
+    state.stringContinues = false;
 
     return mask
 }

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -101,6 +101,54 @@ export function codeMask(line, state) {
                 i += 2;
                 continue
             }
+            // A template INTERPOLATION is executable code wearing string syntax: `${aiConfig?.x}`
+            // runs. Mask the span between `${` and its depth-matched `}` as code — with inner
+            // quote-delimited segments skipped as strings — so every rule classifying on this
+            // mask sees interpolated reads. Bounded to single-line spans: multi-line template
+            // semantics remain this mask's documented per-line approximation.
+            if (inString === '`' && ch === '$' && next === '{') {
+                let depth = 1,
+                    j     = i + 2,
+                    inner = null;
+
+                while (j < n && depth > 0) {
+                    const cj = line[j];
+
+                    if (inner) {
+                        if (cj === '\\') {
+                            j += 2;
+                            continue
+                        }
+                        if (cj === inner) {
+                            inner = null
+                        }
+                        j++;
+                        continue
+                    }
+
+                    if (cj === '"' || cj === "'" || cj === '`') {
+                        inner = cj;
+                        j++;
+                        continue
+                    }
+
+                    if (cj === '{') {
+                        depth++
+                    } else if (cj === '}') {
+                        depth--;
+                        if (depth === 0) {
+                            j++;
+                            break
+                        }
+                    }
+
+                    mask[j] = true;
+                    j++
+                }
+
+                i = j;
+                continue
+            }
             if (ch === inString) {
                 inString = null
             }

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -59,127 +59,246 @@ export const ALLOWLIST = new Set([
     'test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs'
 ]);
 
+/*
+ * Keywords after which a `/` starts a regex literal, not division (`return /x/` vs `count / x`).
+ * The other half of the decision is the last significant code char: after an identifier char, `)`
+ * or `]` a `/` is division; after operators, delimiters or nothing it opens a regex.
+ */
+const REGEX_PRECEDING_KEYWORDS = /^(?:return|typeof|instanceof|case|in|of|new|delete|void|yield|await|do|else)$/;
+
 /**
- * @summary Builds a per-character "is this code?" mask for a line — false inside string literals and
- * comments, true in executable code.
+ * @summary Decides whether a `/` at the current lexer position opens a regex literal.
  *
- * Block-comment state is carried across lines via `state.inBlock`. Unlike a strip-to-text pass the mask
- * preserves positions, so a regex match found on the RAW line can be classified by whether its root
- * token sits in code. That is what lets a string-literal *bracket key* (`['storagePaths']` — real code
- * that merely contains a string) be detected, while a mutation pattern living entirely inside a string
- * (a log message, a `describe(...)` title) is excluded. The structural complement of
- * `check-ticket-archaeology.mjs`'s `extractComment`.
+ * Standard lexer heuristic, not a parser: `state.lastCode` (last significant code char) and
+ * `state.wordBuf` (trailing identifier run) approximate "are we at expression start?". Known bound:
+ * a division whose left operand ends on the PREVIOUS line (ASI edge) misreads as regex — accepted,
+ * documented, and unreachable in the guard's own scan set (valid committed JS, per-line reads).
+ * @param {Object} state The carried lexer state.
+ * @returns {Boolean}
+ */
+function regexAllowed(state) {
+    const last = state.lastCode;
+
+    if (!last) {
+        return true
+    }
+    if (/[A-Za-z0-9_$]/.test(last)) {
+        return REGEX_PRECEDING_KEYWORDS.test(state.wordBuf)
+    }
+    return !/[)\]]/.test(last)
+}
+
+/**
+ * @summary Consumes a regex literal starting at `line[i] === '/'`, returning the index after it.
+ *
+ * Honors `\` escapes and `[...]` character classes (where `/` is literal). Flags are consumed. A
+ * regex literal cannot span lines in JS, so an unterminated body simply ends the line's scan.
  * @param {String} line
- * @param {{inBlock: Boolean}} state Mutated in place as block comments open and close across lines.
+ * @param {Number} i Index of the opening `/`.
+ * @returns {Number} Index of the first character after the literal (or `line.length`).
+ */
+function consumeRegex(line, i) {
+    const n = line.length;
+
+    let j       = i + 1,
+        inClass = false;
+
+    while (j < n) {
+        const c = line[j];
+
+        if (c === '\\') {
+            j += 2;
+            continue
+        }
+        if (inClass) {
+            if (c === ']') {
+                inClass = false
+            }
+            j++;
+            continue
+        }
+        if (c === '[') {
+            inClass = true;
+            j++;
+            continue
+        }
+        if (c === '/') {
+            j++;
+            while (j < n && /[a-z]/i.test(line[j])) {
+                j++
+            }
+            return j
+        }
+        j++
+    }
+
+    return n
+}
+
+/**
+ * @summary Builds a per-character "is this code?" mask for a line — false inside string literals,
+ * comments, regex-literal bodies and template TEXT; true in executable code, including code inside
+ * template interpolations at any nesting depth.
+ *
+ * Implemented as a stacked lexical state machine — the same frame model as
+ * `check-block-alignment.mjs`'s `computeTemplateLiteralLineMask` (the repo precedent), adapted from
+ * per-line booleans to per-char masks, with cross-line carried state and a regex-literal state that
+ * checker does not need. Frames: the base `code` frame, a `template` frame per open backtick, an
+ * `expression` frame per open `${` (brace-depth-tracked). Comments, quoted strings and regex
+ * literals are handled ABOVE the frame dispatch, so a `}` inside any of them can never close an
+ * expression frame early, and comment/string/regex text inside an interpolation is never code.
+ *
+ * Cross-line semantics: block comments, template frames and expression frames legally span lines
+ * and carry in `state`; a multi-line template's text lines therefore mask as string, and a
+ * line-comment inside a multi-line interpolation ends at EOL while the frame survives. Quoted
+ * strings auto-close at EOL (unterminated ones are syntax errors in the valid JS this guard scans)
+ * unless a line-final `\` continues them (`state.pendingEscape`). Unlike a strip-to-text pass the
+ * mask preserves positions, so a regex match found on the RAW line can be classified by whether its
+ * root token sits in code — a string-literal *bracket key* (`['storagePaths']`, real code merely
+ * containing a string) stays detectable while a pattern living entirely inside a string (a log
+ * message, a `describe(...)` title, a regex body) is excluded. The structural complement of
+ * `check-ticket-archaeology.mjs`'s `extractComment`.
+ * @param {Object} state Mutated in place; carries all cross-line lexer state. Constructing it as
+ *     `{inBlock: false}` remains sufficient — richer fields self-initialize on first use.
+ * @param {Boolean} state.inBlock Inside a block comment.
+ * @param {Object[]} [state.stack] Lexical frames: `{type: 'code'|'template'|'expression'}`.
+ * @param {String|null} [state.stringQuote] Open quote character of a quoted string.
+ * @param {Boolean} [state.pendingEscape] A line-final `\` escapes the next line's first char.
+ * @param {String} [state.lastCode] Last significant code char (regex-vs-division heuristic).
+ * @param {String} [state.wordBuf] Trailing identifier run (regex-after-keyword heuristic).
+ * @param {String} line
  * @returns {Boolean[]} `mask[i]` is true when raw character `i` is executable code.
  */
 export function codeMask(line, state) {
+    state.stack         ??= [{type: 'code'}];
+    state.stringQuote   ??= null;
+    state.pendingEscape ??= false;
+    state.lastCode      ??= '';
+    state.wordBuf       ??= '';
+
     const n    = line.length,
           mask = new Array(n).fill(false);
 
     let i = 0;
 
-    if (state.inBlock) {
-        const end = line.indexOf('*/');
-
-        if (end === -1) {
-            return mask
-        }
-
-        i             = end + 2;
-        state.inBlock = false
+    if (state.pendingEscape) {
+        state.pendingEscape = false;
+        i = 1
     }
-
-    let inString = null;
 
     while (i < n) {
         const ch   = line[i],
-              next = line[i + 1];
+              next = line[i + 1],
+              ctx  = state.stack[state.stack.length - 1];
 
-        if (inString) {
+        if (state.inBlock) {
+            const end = line.indexOf('*/', i);
+
+            if (end === -1) {
+                return mask
+            }
+            i             = end + 2;
+            state.inBlock = false;
+            continue
+        }
+
+        if (state.stringQuote) {
             if (ch === '\\') {
+                if (i === n - 1) {
+                    state.pendingEscape = true
+                }
                 i += 2;
                 continue
             }
-            // A template INTERPOLATION is executable code wearing string syntax: `${aiConfig?.x}`
-            // runs. Mask the span between `${` and its depth-matched `}` as code — with inner
-            // quote-delimited segments skipped as strings — so every rule classifying on this
-            // mask sees interpolated reads. Bounded to single-line spans: multi-line template
-            // semantics remain this mask's documented per-line approximation.
-            if (inString === '`' && ch === '$' && next === '{') {
-                let depth = 1,
-                    j     = i + 2,
-                    inner = null;
+            if (ch === state.stringQuote) {
+                state.stringQuote = null
+            }
+            i++;
+            continue
+        }
 
-                while (j < n && depth > 0) {
-                    const cj = line[j];
-
-                    if (inner) {
-                        if (cj === '\\') {
-                            j += 2;
-                            continue
-                        }
-                        if (cj === inner) {
-                            inner = null
-                        }
-                        j++;
-                        continue
-                    }
-
-                    if (cj === '"' || cj === "'" || cj === '`') {
-                        inner = cj;
-                        j++;
-                        continue
-                    }
-
-                    if (cj === '{') {
-                        depth++
-                    } else if (cj === '}') {
-                        depth--;
-                        if (depth === 0) {
-                            j++;
-                            break
-                        }
-                    }
-
-                    mask[j] = true;
-                    j++
+        if (ctx.type === 'template') {
+            if (ch === '\\') {
+                if (i === n - 1) {
+                    state.pendingEscape = true
                 }
-
-                i = j;
+                i += 2;
                 continue
             }
-            if (ch === inString) {
-                inString = null
+            if (ch === '`') {
+                state.stack.pop();
+                i++;
+                continue
+            }
+            if (ch === '$' && next === '{') {
+                state.stack.push({type: 'expression', braceDepth: 1});
+                i += 2;
+                continue
             }
             i++;
             continue
         }
 
-        if (ch === '"' || ch === "'" || ch === '`') {
-            inString = ch;
-            i++;
-            continue
-        }
-
+        // From here down the frame is code or expression — one shared dispatch, which is exactly
+        // what makes nested templates and comments inside interpolations correct by construction.
         if (ch === '/' && next === '/') {
             break
         }
 
         if (ch === '/' && next === '*') {
-            const end = line.indexOf('*/', i + 2);
-
-            if (end === -1) {
-                state.inBlock = true;
-                break
-            }
-
-            i = end + 2;
+            state.inBlock = true;
+            i += 2;
             continue
         }
 
+        if (ch === '"' || ch === "'") {
+            state.stringQuote = ch;
+            i++;
+            continue
+        }
+
+        if (ch === '`') {
+            state.stack.push({type: 'template'});
+            i++;
+            continue
+        }
+
+        if (ch === '/' && regexAllowed(state)) {
+            i = consumeRegex(line, i);
+            // A regex literal ends an expression: a following `/` is division. `)` is the proxy
+            // for "expression just ended" in the heuristic's char alphabet.
+            state.lastCode = ')';
+            state.wordBuf  = '';
+            continue
+        }
+
+        if (ctx.type === 'expression') {
+            if (ch === '{') {
+                ctx.braceDepth++
+            } else if (ch === '}') {
+                ctx.braceDepth--;
+
+                if (ctx.braceDepth === 0) {
+                    state.stack.pop();
+                    i++;
+                    continue
+                }
+            }
+        }
+
         mask[i] = true;
+
+        if (!/\s/.test(ch)) {
+            state.lastCode = ch;
+            state.wordBuf  = /[A-Za-z0-9_$]/.test(ch) ? state.wordBuf + ch : ''
+        }
         i++
+    }
+
+    // JS auto-terminates quoted strings at EOL (unterminated = syntax error upstream, CI runs a
+    // parse check) — reset instead of poisoning the next line, except across a `\` continuation.
+    if (state.stringQuote && !state.pendingEscape) {
+        state.stringQuote = null
     }
 
     return mask
@@ -198,11 +317,15 @@ export function findDbPathMutations(content) {
           hits  = [];
 
     lines.forEach((line, index) => {
+        // Mask computes UNCONDITIONALLY — before the escape check. Skipping a marker line would
+        // corrupt the carried lexer state (block-comment flag, template/expression frames); the
+        // escape valve is line-scoped for HITS, never for lexing. Same ordering rule as the B3/A5/A1
+        // sibling checker.
+        const mask = codeMask(line, state);
+
         if (line.includes(ESCAPE_MARKER)) {
             return
         }
-
-        const mask = codeMask(line, state);
 
         for (const match of line.matchAll(DB_PATH_MUTATION_GLOBAL)) {
             // The match starts at the aiConfig / Memory_Config root; flag it only when that root is real

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -323,3 +323,46 @@ test.describe('shared codeMask lexer matrix (cross-consumer: B3/A5/A1 + B4)', ()
         expect(findDbPathMutations(content).map(h => h.line)).toEqual([2])
     })
 });
+
+/**
+ * Transition-pair matrix (cycle-5): a shared lexer needs coverage where CARRIED context changes the
+ * meaning of the next character — open-state × next-line-first-token, and grammar-context × slash —
+ * not only isolated token classes. Fixtures are the verified cycle-5 falsifier pairs: a line-final
+ * backslash escapes the LINE TERMINATOR (consumes no next-line char, so a column-zero closing
+ * delimiter must be processed), and slash classification must be correct on BOTH sides of the
+ * expression boundary (a control-header `)` admits a regex; an expression-ending quote/backtick
+ * demands division). Every fixture is valid JavaScript with a REAL violation in the suffix — the
+ * false-negative direction, which is the dangerous one for an enforcement mask.
+ */
+test.describe('shared codeMask lexer matrix — transition pairs (continuation + slash grammar)', () => {
+    test('line-final backslash continues the literal and consumes NO next-line character — all consumers', () => {
+        expect(findAntipatterns('const t = `foo\\\n`; const x = aiConfig?.load;').map(h => h.rule)).toEqual(['B3']);
+        expect(findAntipatterns("const s = 'foo\\\n'; hasEnvValue('X');").map(h => h.rule)).toEqual(['A5']);
+        expect(findDbPathMutations('const t = `foo\\\n`; aiConfig.storagePaths = p;').length).toBe(1)
+    });
+
+    test('a continuation line closing mid-line keeps text as string and suffix as code', () => {
+        const hits = findAntipatterns("const s = 'aiConfig?.load\\\nstill text'; const bad = aiConfig?.load;");
+
+        expect(hits.map(h => ({rule: h.rule, line: h.line}))).toEqual([{rule: 'B3', line: 2}])
+    });
+
+    test('a regex after a control-statement header keeps its body masked and its suffix executable', () => {
+        expect(findAntipatterns('if (ok) /text/.test(s); const x = aiConfig?.load;').map(h => h.rule)).toEqual(['B3']);
+        // Pattern text is never code — even when the pattern tail is a non-identifier char (the
+        // shape whose closing slash previously opened a fake regex and swallowed the suffix).
+        expect(findAntipatterns('if (ok) /aiConfig\\?\\./.test(s); const y = aiConfig?.load;').length).toBe(1);
+        expect(findDbPathMutations("while (x) /}/.exec(s); aiConfig.storagePaths = p;").length).toBe(1)
+    });
+
+    test('a slash after an expression-ending quoted or template literal is division, not a regex opener', () => {
+        expect(findAntipatterns('const q = "x" / 2; const bad = aiConfig?.load;').map(h => h.rule)).toEqual(['B3']);
+        expect(findDbPathMutations('const q = `x` / 2; aiConfig.storagePaths = p;').length).toBe(1);
+        expect(findAntipatterns('import {AiConfig} from "./x.mjs";\nconst q = "x" / 2, DB = process.env.NEO_X;').map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('a call/grouping paren still yields division; nested control headers resolve via the paren stack', () => {
+        expect(findAntipatterns('foo(a) / b; const x = aiConfig?.load;').map(h => h.rule)).toEqual(['B3']);
+        expect(findAntipatterns('if (a(b)) /re/.test(s); const y = aiConfig?.load;').map(h => h.rule)).toEqual(['B3'])
+    })
+});

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -1,6 +1,7 @@
 import {test, expect}                                                      from '@playwright/test';
 import {findAntipatterns, filterAllowlistedHits, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
 import {A1_IMPORT_GATE}                                                    from '../../../../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
+import {findDbPathMutations}                                               from '../../../../../../buildScripts/util/check-aiconfig-test-mutation.mjs';
 import {spawnSync}                                                         from 'node:child_process';
 import fs                                                                  from 'node:fs';
 import path                                                                from 'node:path';
@@ -267,5 +268,58 @@ test.describe('check-aiconfig-antipatterns guard — A1 module-level env re-deri
         } finally {
             fs.rmSync(tmpFile, {force: true})
         }
+    })
+});
+
+/**
+ * Cross-consumer lexer matrix: the shared `codeMask` stacked state machine classifies for EVERY
+ * rule reading it — B3/A5/A1 here plus B4 in the sibling checker — so each lexer fix is pinned
+ * against both consumers (a fix proven on one can silently regress the other). Fixtures are the
+ * verified cycle-4 falsifier classes: comment text inside a template interpolation (false-positive
+ * class), nested executable interpolations (false-negative class), and a `}` inside comment or
+ * regex text closing the expression frame early (false-negative class), plus the regex-literal and
+ * multi-line-template semantics the state machine introduces.
+ */
+test.describe('shared codeMask lexer matrix (cross-consumer: B3/A5/A1 + B4)', () => {
+    test('comment-only text inside an interpolation never flags — block and line comments, both consumers', () => {
+        expect(findAntipatterns('const m = `${/* aiConfig?.x */ ok}`;')).toEqual([]);
+        expect(findAntipatterns('const m = `${ ok // aiConfig?.x\n}`;')).toEqual([]);
+        expect(findAntipatterns('const m = `${/* hasEnvValue("X") */ 1}`;')).toEqual([]);
+        expect(findDbPathMutations('const m = `${/* aiConfig.storagePaths = p */ ok}`;')).toEqual([])
+    });
+
+    test('nested executable interpolations flag at any depth — both consumers', () => {
+        expect(findAntipatterns('const m = `${`inner ${aiConfig?.load}`}`;').map(h => h.rule)).toEqual(['B3']);
+        expect(findAntipatterns('const m = `${`no config here`}`;')).toEqual([]);
+        expect(findDbPathMutations('const m = `${`x ${aiConfig.storagePaths = p}`}`;').length).toBe(1)
+    });
+
+    test('a `}` inside comment or regex text cannot close the expression frame early — both consumers', () => {
+        expect(findAntipatterns('const m = `${ x /* } */ + aiConfig?.load }`;').map(h => h.rule)).toEqual(['B3']);
+        expect(findAntipatterns("const m = `${ s.replace(/}/g, '') + aiConfig?.load }`;").map(h => h.rule)).toEqual(['B3']);
+        expect(findDbPathMutations("const m = `${ s.replace(/}/g,'') + (aiConfig.storagePaths = p) }`;").length).toBe(1)
+    });
+
+    test('a regex-literal BODY is pattern text, not code; division stays code', () => {
+        expect(findAntipatterns('const re = /aiConfig\\?\\./;')).toEqual([]);
+        expect(findAntipatterns('const x = a / b; const y = aiConfig?.load;').map(h => h.rule)).toEqual(['B3'])
+    });
+
+    test('multi-line template TEXT masks as string across lines (carried frames)', () => {
+        expect(findAntipatterns('const t = `\n  aiConfig?.load as prose\n`;\nconst z = 1;')).toEqual([]);
+        expect(findDbPathMutations('const t = `\n  aiConfig.storagePaths = fake\n`;')).toEqual([])
+    });
+
+    test('A1 and A5 still see executable interpolated reads (cycle-3 pins preserved)', () => {
+        const gated = "import {AiConfig} from './x.mjs';\nconst url = `${process.env.NEO_HOST}`;";
+
+        expect(findAntipatterns(gated).map(h => h.rule)).toEqual(['A1']);
+        expect(findAntipatterns('const m = `${hasEnvValue("X")}`;').map(h => h.rule)).toEqual(['A5'])
+    });
+
+    test('an escape marker on a template line skips hits without corrupting carried frames (B4 escape-order fix)', () => {
+        const content = 'const t = `${a} aiconfig-mutation-ok ${b}`;\naiConfig.storagePaths = p;';
+
+        expect(findDbPathMutations(content).map(h => h.line)).toEqual([2])
     })
 });

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -364,5 +364,15 @@ test.describe('shared codeMask lexer matrix — transition pairs (continuation +
     test('a call/grouping paren still yields division; nested control headers resolve via the paren stack', () => {
         expect(findAntipatterns('foo(a) / b; const x = aiConfig?.load;').map(h => h.rule)).toEqual(['B3']);
         expect(findAntipatterns('if (a(b)) /re/.test(s); const y = aiConfig?.load;').map(h => h.rule)).toEqual(['B3'])
+    });
+
+    test('grammar-set completeness: throw, for-await and else-if admit a regex; plain await-paren stays division', () => {
+        expect(findAntipatterns('function f() { throw /x\\./ ; } const y = aiConfig?.load;').map(h => h.rule)).toEqual(['B3']);
+        expect(findDbPathMutations('function f() { throw /x\\./ ; } aiConfig.storagePaths = p;').length).toBe(1);
+        expect(findAntipatterns('async function g(s) { for await (const c of s) /x\\./.test(c); } const y = aiConfig?.load;').map(h => h.rule)).toEqual(['B3']);
+        // Whitespace never resets the word buffer, so multi-word headers arrive concatenated —
+        // the self-found sibling of the reviewer's for-await case.
+        expect(findAntipatterns('if (a) {} else if (b) /x\\./.test(s); const y = aiConfig?.load;').map(h => h.rule)).toEqual(['B3']);
+        expect(findAntipatterns('async function h(x) { const q = await (x) / 2; } const y = aiConfig?.load;').map(h => h.rule)).toEqual(['B3'])
     })
 });

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -216,6 +216,16 @@ test.describe('check-aiconfig-antipatterns guard — A1 module-level env re-deri
         expect(findAntipatterns(importHeader + 'const x = compute(); /* process.env.NEO_Y */\n')).toEqual([])
     });
 
+    test('A1: an EXECUTABLE template interpolation flags — `${process.env.X}` runs; literal template text does not', () => {
+        expect(findAntipatterns(importHeader + 'const url = `http://${process.env.NEO_HOST}/api`;\n').map(h => h.rule)).toEqual(['A1']);
+        // mixed: literal env text stays masked while the interpolated read is code
+        expect(findAntipatterns(importHeader + 'const s = `process.env.LITERAL and ${process.env.NEO_REAL}`;\n').map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('B3: a defensive hop inside a template interpolation flags (interpolations are code for every rule)', () => {
+        expect(findAntipatterns('const t = `state: ${aiConfig?.load}`;\n').map(h => h.rule)).toEqual(['B3'])
+    });
+
     test('A1: an escape marker on the IMPORT/gate line exempts only that line — other declarations still flag', () => {
         const content = importHeader.trimEnd() + ` // ${ESCAPE_MARKER}: gate-line note\n` +
             "const P = process.env.NEO_P || 'x';\n";

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -1,5 +1,6 @@
 import {test, expect}                                                      from '@playwright/test';
 import {findAntipatterns, filterAllowlistedHits, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
+import {A1_IMPORT_GATE}                                                    from '../../../../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
 import {spawnSync}                                                         from 'node:child_process';
 import fs                                                                  from 'node:fs';
 import path                                                                from 'node:path';
@@ -156,6 +157,89 @@ test.describe('check-aiconfig-antipatterns guard — rule-scoped allowlist compo
 
             expect(result.status).toBe(0);
             expect(result.stdout).toContain('0 new violations')
+        } finally {
+            fs.rmSync(tmpFile, {force: true})
+        }
+    })
+});
+
+/**
+ * Coverage for the A1 two-signal rule — module-level env re-derivation flags ONLY in files that
+ * import the config SSOT. The negatives are the load-bearing half: the C1-sanctioned pure-defaults
+ * module (env literals, NO config import) and function-local env reads must stay green, or the
+ * lint would fight the very shape the design prescribes for non-entrypoint helpers.
+ */
+test.describe('check-aiconfig-antipatterns guard — A1 module-level env re-derivation (two-signal)', () => {
+    const importHeader = "import AiConfig from '../ConfigProvider.mjs';\n";
+
+    test('A1: flags a module-level re-derivation when the file imports the config SSOT', () => {
+        const content = importHeader + "const DB_PATH = process.env.NEO_DB_PATH || path.join(root, 'db');\n";
+
+        expect(findAntipatterns(content).map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('A1: the Neo.ai.Config runtime root also opens the gate', () => {
+        const content = "const cfg = Neo.ai.Config;\nlet cacheDir = process.env.NEO_CACHE_DIR ?? cfg.cacheDir;\n";
+
+        expect(findAntipatterns(content).map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('A1: a comment-only config-root mention never opens the gate (config templates document their realm)', () => {
+        const content = "// Loads the Tier-1 realm root (Neo.ai.Config) so getParent() inheritance resolves.\nconst dataDir = process.env.NEO_AI_DAEMON_DIR || './data';\n";
+
+        expect(findAntipatterns(content)).toEqual([])
+    });
+
+    test('A1: a multi-line import block carrying the config token opens the gate (the line-grep blind spot)', () => {
+        const content = "import {\n    AiConfig,\n    other\n} from '../services.mjs';\nconst port = Number(process.env.NEO_FLEET_PORT) || 8083;\n";
+
+        expect(findAntipatterns(content).map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('A1: the C1-sanctioned pure-defaults module (NO config import) never flags', () => {
+        const content = "const DEFAULT_DB_PATH = process.env.NEO_DB_PATH || './data/db';\nexport {DEFAULT_DB_PATH};\n";
+
+        expect(A1_IMPORT_GATE.test(content)).toBe(false);
+        expect(findAntipatterns(content)).toEqual([])
+    });
+
+    test('A1: function-local env reads never flag (module-level anchoring)', () => {
+        const content = importHeader + "function resolve() {\n    const port = process.env.NEO_PORT || 3000;\n    return port\n}\n";
+
+        expect(findAntipatterns(content)).toEqual([])
+    });
+
+    test('A1: comment and string occurrences never flag; the escape marker is honored', () => {
+        const commented = importHeader + "// const DB_PATH = process.env.NEO_DB_PATH || fallback;\n";
+        const escaped   = importHeader + `const BOOT_FLAG = process.env.NEO_BOOT_FLAG; // ${ESCAPE_MARKER}: bootstrap boundary, reads before the provider exists\n`;
+
+        expect(findAntipatterns(commented)).toEqual([]);
+        expect(findAntipatterns(escaped)).toEqual([])
+    });
+
+    test('A1: rule-scoped grandfathering — the wake daemon is exempt for A1 only, and A1 stays independent of B3/A5 sets', () => {
+        const content = importHeader + "const DB_PATH = process.env.NEO_DB_PATH || './db';\nif (hasEnvValue('NEO_X')) { run(); }\n";
+        const hits    = findAntipatterns(content);
+
+        expect(hits.map(h => h.rule).sort()).toEqual(['A1', 'A5']);
+        expect(filterAllowlistedHits(hits, 'ai/daemons/wake/daemon.mjs').map(h => h.rule)).toEqual(['A5']);
+        expect(filterAllowlistedHits(hits, 'ai/services/fresh/NewService.mjs').map(h => h.rule).sort()).toEqual(['A1', 'A5']);
+        expect(ALLOWLIST.A1.has('ai/daemons/wake/daemon.mjs')).toBe(true)
+    });
+
+    test('A1 CLI regression: an import-gated module-level re-derivation in a fresh ai/ file exits non-zero', () => {
+        const tmpFile = path.join(repoRoot, `ai/.a1-rederivation-regression-${process.pid}.mjs`);
+
+        try {
+            fs.writeFileSync(tmpFile, "import AiConfig from './ConfigProvider.mjs';\nconst DB_PATH = process.env.NEO_DB_PATH || './db';\n", 'utf-8');
+
+            const result = spawnSync(process.execPath, [checkerPath, tmpFile], {
+                cwd     : repoRoot,
+                encoding: 'utf-8'
+            });
+
+            expect(result.status).toBe(1);
+            expect(result.stderr).toContain('[A1]')
         } finally {
             fs.rmSync(tmpFile, {force: true})
         }

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -209,6 +209,20 @@ test.describe('check-aiconfig-antipatterns guard — A1 module-level env re-deri
         expect(findAntipatterns(content)).toEqual([])
     });
 
+    test('A1: an env token inside a STRING on a real declaration line never flags (classify the token, not the declaration)', () => {
+        expect(findAntipatterns(importHeader + "const msg = 'reads process.env.PATH at boot';\n")).toEqual([]);
+        expect(findAntipatterns(importHeader + 'const doc = "set process.env.NEO_PORT before running";\n')).toEqual([]);
+        expect(findAntipatterns(importHeader + 'const note = `about process.env.NEO_X`;\n')).toEqual([]);
+        expect(findAntipatterns(importHeader + 'const x = compute(); /* process.env.NEO_Y */\n')).toEqual([])
+    });
+
+    test('A1: an escape marker on the IMPORT/gate line exempts only that line — other declarations still flag', () => {
+        const content = importHeader.trimEnd() + ` // ${ESCAPE_MARKER}: gate-line note\n` +
+            "const P = process.env.NEO_P || 'x';\n";
+
+        expect(findAntipatterns(content).map(h => h.rule)).toEqual(['A1'])
+    });
+
     test('A1: comment and string occurrences never flag; the escape marker is honored', () => {
         const commented = importHeader + "// const DB_PATH = process.env.NEO_DB_PATH || fallback;\n";
         const escaped   = importHeader + `const BOOT_FLAG = process.env.NEO_BOOT_FLAG; // ${ESCAPE_MARKER}: bootstrap boundary, reads before the provider exists\n`;


### PR DESCRIPTION
Resolves #15213

The A1 rule completes the mechanically-detectable subset of the merged antipattern lint: **module-level `process.env` re-derivation flags ONLY in files whose CODE imports the config SSOT** (import-statement token or the runtime `Neo.ai.Config` root). The load-bearing detail is HOW the gate reads the file: it evaluates a **code-only projection built from the same `codeMask` the line rules use** — masked-out characters become spaces, preserving positions and newlines — so a comment or JSDoc mention of the config root never opens the gate (config templates legitimately document their realm) while multi-line import blocks still gate correctly. A1 candidates collect during the single scan pass and emit only after the gate confirms, keeping one pass and one classification authority.

**The census story is itself the evidence for the gate design.** My pre-implementation line-grep census found ONE live A1 file (the wake daemon). The checker's own masked multiline gate then found a second true positive the grep was structurally blind to — `ai/services/fleet/devFleetServer.mjs` imports the config token inside a multi-line import block — and two FALSE positives the raw-content gate would have shipped: both memory-core config-definition files gate ONLY via a line-1 comment (`// Loads the Tier-1 realm root (Neo.ai.Config)…`). The comment-blindness fix releases them (correct: env handling inside config-definition files is leaf-declaration territory, a different rule class, out of this ticket's scope) and both behaviors are spec-pinned. Allowlist seed: the two true positives, per-rule, as the Diamond-2 cleanup targets.

Evidence: L2 (25-spec suite green incl. the spawned-CLI A1 regression + live 532-file `ai/` scan, 0 new violations at head) → L2 required (every AC is unit/static-verifiable). Residual: none — the workflow shipped with the parent PR and already covers this checker path.

## Deltas from ticket

- The ticket's proposed line regex anchored on bare column-0; the shipped `A1_ENV_REDERIVATION` also requires whitespace after the declarator keyword and tolerates destructuring — same semantics, fewer false shapes.
- The ticket's "two-signal" gate is shipped stricter than spec'd: code-only evaluation (comment/JSDoc mentions never gate) — surfaced by the live census, spec-pinned as its own negative.
- Allowlist seed grew from the ticket-time estimate (1 file) to the checker-census truth (2 files); the delta file's multi-line import is now also a spec-pinned positive.
- Cycle-4 (review-driven): the shared `codeMask` graduated from a brace/quote interpolation approximation to a stacked lexical state machine (code/template/expression frames; comment/string/regex states handled above the frame dispatch — `check-block-alignment.mjs`'s frame model adapted to per-char masks with carried cross-line state). Kills the three verified falsifier classes: comment-in-interpolation false-positives, nested-interpolation false-negatives, comment/regex `}` early-close. Multi-line template text now masks correctly as string; `findDbPathMutations` computes the mask before its escape check (frame integrity). The ticket's A1 rule consumes this mask — in-scope by review necessity.
- Cycle-5 (review-driven): two carried-state transition repairs at the shared seam — a line-final backslash now escapes the LINE TERMINATOR (continuation consumes no next-line character; `stringContinues` replaces the char-skipping `pendingEscape`), and slash classification is correct on both sides of the expression boundary (a carried paren-word stack admits a regex after a control-header `)`; expression-ending literals record the `]` proxy so a following slash is division). JSDoc updated to the actually-supported grammar bounds.
- Cycle-6 (review-driven): the regex-grammar keyword sets completed — `throw` (regex-preceding) and the concatenated multi-word headers `forawait`/`elseif` (control set; whitespace never resets the word buffer, which is also what keeps plain `await (x) / y` division). One reviewer falsifier class + one self-found sibling; grammar-set spec pins all four consumers + the division guard.

## Test Evidence

- `NEO_CHROMA_PORT_TEST=18190 npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs --workers=1` — **25 passed** (7 new A1 specs: import-gated positive, `Neo.ai.Config` runtime-root positive, multi-line-import positive, comment-only-gate negative, C1 pure-defaults negative, function-local negative, masking/escape + rule-scoped allowlist independence; plus the spawned-CLI A1 regression exiting 1 with `[A1]`). Port override per the #15221 interim discipline.
- Live scan at head: `node buildScripts/util/check-aiconfig-antipatterns.mjs` — **532 `ai/` file(s) scanned, 0 new violations** (the two seeded files suppressed for A1 only; a `hasEnvValue` or `?.` in them still fails the build — the rule-scoped semantics from the parent PR's review cycle).
- Directly touched surfaces: checker + its spec; no other app/feature surface touched.
- Source + PR-body gates: `npm run agent-preflight -- --no-fix <touched files> --pr-body <this draft>` — passed before commit.
- Cycle-4 head `f4c143a99e`: both checker suites — **50 passed**, incl. the 7-spec cross-consumer lexer matrix pinning B3/A5/A1 **and B4** against the falsifier classes; live scans at head: **532 `ai/` + 810 `test/` files, 0 violations** (zero behavior delta on real code).
- Cycle-5 head `f16fda7a2e`: both suites **55 passed** (adds the 5-spec transition-pair matrix: open-state × next-line-first-token and grammar-context × slash, every fixture valid JS with a REAL violation in the suffix, across all four rule consumers); live scans clean (532 `ai/` + 810 `test/`, zero delta); reviewer's four falsifier families reproduced pre-fix and green post-fix; four supplementary self-falsifier probes (multi-line interpolation code, return/case keyword regex, comment-in-multi-line-interpolation) pass.
- Cycle-6 head `20950c614e`: **56/56** specs; live scans clean (532 + 810 files, zero delta); the cycle-5 transition-pair matrix re-verified green.

## Post-Merge Validation

- [ ] The existing `AiConfig Antipattern Lint` workflow (paths already cover the checker) fires on the next `ai/` PR and passes clean dev.

## Evolution

The gate went through one mid-implementation correction driven by the live census: raw-content gating flagged the memory-core config template + overlay via a line-1 comment. Rather than allowlisting false positives, the gate moved to the code-only projection — the same masking discipline the line rules already had, now applied file-wide. The checker replaced the grep as the census authority in the same step.

Authored by Grace (Claude Fable 5, Claude Code). Session 75ed6708-c66b-4989-862d-2286e87abbf1.

