### PR TITLE
fix(test): per-checkout chroma test-port derivation + probe fallback (#15221)

### DIFF
--- a/test/playwright/deriveTestPort.mjs
+++ b/test/playwright/deriveTestPort.mjs
@@ -1,0 +1,78 @@
+import {spawnSync} from 'node:child_process';
+
+/**
+ * @summary Per-checkout test-port derivation — the isolation half the per-PID data dir always had.
+ *
+ * A machine running several agent checkouts (plus worktrees) executes unit suites concurrently; a
+ * fixed default port serializes them at best and, combined with `reuseExistingServer: false`,
+ * wedges every run machine-wide behind one orphaned server at worst. Deriving the default from the
+ * CHECKOUT ROOT gives each checkout — and each worktree, whose toplevel is its own path — a stable,
+ * distinct port with zero configuration, while an explicit env override always wins (CI pinning and
+ * deliberate claims keep working). Stability-per-checkout is deliberate: two runs in ONE checkout
+ * share their port intentionally (`workers` config governs concurrency there), so the derivation
+ * hashes the path, never the process.
+ * @module test/playwright/deriveTestPort
+ */
+
+/**
+ * @summary Derives a stable port offset from a checkout-root path via FNV-1a.
+ *
+ * FNV-1a is deliberate: dependency-free, deterministic across processes and Node versions, and
+ * well-distributed over short ASCII paths. The result is `base + (hash % range)` — bounded so the
+ * whole derived family stays inside an operator-recognizable window above the historic fixed port.
+ * @param {String} rootPath Absolute checkout-root path (a worktree's toplevel is its own path).
+ * @param {Object} [opts]
+ * @param {Number} [opts.base=18180] Bottom of the derived window (the historic fixed default).
+ * @param {Number} [opts.range=512] Window size; collisions across checkouts are 1/range per pair.
+ * @returns {Number}
+ */
+export function deriveTestPort(rootPath, {base = 18180, range = 512} = {}) {
+    let hash = 0x811c9dc5;
+
+    for (let i = 0; i < rootPath.length; i++) {
+        hash ^= rootPath.charCodeAt(i);
+        hash  = Math.imul(hash, 0x01000193) >>> 0
+    }
+
+    return base + (hash % range)
+}
+
+/**
+ * @summary Walks forward from a candidate port to the first one that binds, via a synchronous
+ * child probe.
+ *
+ * Playwright configs are evaluated synchronously, but a bind check is async in-process — so the
+ * probe runs in a short-lived child (`node -e`) that tries to listen and exits 0 (free) or 1
+ * (taken). This is the collision fallback for the 1/range cross-checkout hash-collision case and
+ * for a derived port squatted by an orphaned server: the run walks to a free port instead of
+ * wedging. Probe failures (spawn errors, timeouts) fail OPEN to the candidate — the derivation is
+ * the primary mechanism; the probe only improves the rare unlucky case.
+ * @param {Number} startPort First candidate.
+ * @param {Object} [opts]
+ * @param {Number} [opts.tries=8] How many sequential ports to probe before falling back.
+ * @param {String} [opts.host='127.0.0.1'] Interface the test server will bind.
+ * @returns {Number} The first probed-free port, or `startPort` when probing is unavailable.
+ */
+export function probeFreePort(startPort, {tries = 8, host = '127.0.0.1'} = {}) {
+    const probeScript =
+        'const net=require("net");const s=net.createServer();' +
+        's.once("error",()=>process.exit(1));' +
+        's.listen(Number(process.argv[1]),process.argv[2],()=>s.close(()=>process.exit(0)));';
+
+    for (let i = 0; i < tries; i++) {
+        const port   = startPort + i,
+              result = spawnSync(process.execPath, ['-e', probeScript, String(port), host], {timeout: 3000});
+
+        if (result.status === 0) {
+            return port
+        }
+
+        if (result.error || result.status === null) {
+            // Probing itself is unavailable (spawn failure / timeout) — fail open to the candidate:
+            // the derivation already isolates checkouts; the probe is only the tiebreaker.
+            return startPort
+        }
+    }
+
+    return startPort
+}

--- a/test/playwright/playwright.config.unit.mjs
+++ b/test/playwright/playwright.config.unit.mjs
@@ -1,17 +1,30 @@
 import './configTemplateResolver.mjs';
 
-import {defineConfig}  from '@playwright/test';
-import os              from 'os';
-import path            from 'path';
-import {fileURLToPath} from 'url';
+import {defineConfig}                  from '@playwright/test';
+import os                              from 'os';
+import path                            from 'path';
+import {fileURLToPath}                 from 'url';
+import {deriveTestPort, probeFreePort} from './deriveTestPort.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../..');
 
 process.env.UNIT_TEST_MODE = 'true';
 
-const chromaTestHost    = process.env.NEO_CHROMA_HOST_TEST || '127.0.0.1';
-const chromaTestPort    = Number(process.env.NEO_CHROMA_PORT_TEST) || 18180;
+const chromaTestHost = process.env.NEO_CHROMA_HOST_TEST || '127.0.0.1';
+
+// The port isolates per CHECKOUT (worktrees included — their toplevel is their own path), exactly
+// like the data dir isolates per process below: several agent checkouts run unit suites
+// concurrently on one machine, and a fixed shared default deadlocks them behind
+// `reuseExistingServer: false` (one orphaned server wedges every run machine-wide). An explicit
+// env override always wins; otherwise derive-from-root, then probe-walk past the rare hash
+// collision or a squatted port. The banner line makes the resolved port visible in every run log.
+const chromaTestPort = Number(process.env.NEO_CHROMA_PORT_TEST)
+    || probeFreePort(deriveTestPort(repoRoot), {host: chromaTestHost});
+
+console.log(`[unit-config] test chroma port ${chromaTestPort} (checkout-derived from ${repoRoot}; override: NEO_CHROMA_PORT_TEST)`);
+
 const chromaTestDataDir = process.env.NEO_CHROMA_DATA_DIR_TEST ||
     path.join(os.tmpdir(), `neo-chroma-unit-test-${process.pid}`);
 

--- a/test/playwright/unit/testinfra/deriveTestPort.spec.mjs
+++ b/test/playwright/unit/testinfra/deriveTestPort.spec.mjs
@@ -1,0 +1,57 @@
+import {test, expect}                  from '@playwright/test';
+import {deriveTestPort, probeFreePort} from '../../deriveTestPort.mjs';
+import net                             from 'node:net';
+
+/**
+ * Self-test for the per-checkout test-port derivation — the fix for the machine-global fixed
+ * port that deadlocked four concurrent agent checkouts behind one orphaned server. The
+ * distinctness fixtures are the REAL checkout roots from that incident. The env-override branch
+ * lives in `playwright.config.unit.mjs` (importing a config module in a spec runs its side
+ * effects, so the override semantics are covered by the config's own one-line `||` shape plus
+ * this suite pinning both operands).
+ */
+test.describe('test-infra — deriveTestPort (per-checkout isolation)', () => {
+    const incidentRoots = [
+        '/Users/Shared/claude/neomjs/neo',
+        '/Users/Shared/opus-vega/neomjs/neo',
+        '/Users/Shared/fable/neomjs/neo',
+        '/Users/Shared/github/neomjs/neo/.claude/worktrees/exciting-bhaskara-4872e6'
+    ];
+
+    test('deterministic: the same root derives the same port across calls', () => {
+        const first = deriveTestPort(incidentRoots[0]);
+
+        expect(deriveTestPort(incidentRoots[0])).toBe(first);
+        expect(deriveTestPort(incidentRoots[0])).toBe(first)
+    });
+
+    test('distinct: the four real incident checkouts (worktree included) derive four different ports', () => {
+        const ports = incidentRoots.map(root => deriveTestPort(root));
+
+        expect(new Set(ports).size).toBe(ports.length)
+    });
+
+    test('range-bound: every derivation lands inside [base, base + range)', () => {
+        for (const root of incidentRoots) {
+            const port = deriveTestPort(root, {base: 18180, range: 512});
+
+            expect(port).toBeGreaterThanOrEqual(18180);
+            expect(port).toBeLessThan(18180 + 512)
+        }
+    });
+
+    test('probe: a free candidate returns itself; an occupied one walks forward', async () => {
+        const candidate = deriveTestPort('/probe/fixture/checkout', {base: 19300, range: 64});
+
+        expect(probeFreePort(candidate)).toBe(candidate);
+
+        const squatter = net.createServer();
+
+        await new Promise(resolve => squatter.listen(candidate, '127.0.0.1', resolve));
+        try {
+            expect(probeFreePort(candidate)).toBe(candidate + 1)
+        } finally {
+            await new Promise(resolve => squatter.close(resolve))
+        }
+    })
+});


### PR DESCRIPTION
Resolves #15221

The unit config's chroma port now **derives from the checkout root** instead of a machine-global fixed default: FNV-1a over the toplevel path, range-bound in a 512-port window above the historic 18180, with a **synchronous child bind-probe** walking past the rare cross-checkout hash collision or a squatted port (fail-open to the candidate — the derivation is the mechanism, the probe the tiebreaker). A worktree's toplevel is its own path, so parents and worktrees isolate naturally — the semantics settled on the ticket after today's incident falsified shared-parent offsets (the operator worktree ran concurrently with a main checkout). `NEO_CHROMA_PORT_TEST` override wins unchanged; every run banner prints the resolved port and its provenance. This completes the isolation the config always half-had: the data dir was per-process, the port was global — and `reuseExistingServer: false` turned that gap into today's sticky machine-wide deadlock (four concurrent agent checkouts wedged behind one orphaned server, cross-checkout cleanup correctly permission-blocked, third-victim confirmations from two peers).

Evidence: L2 (4-spec suite green + the run itself as the live integration proof: the suite derived port 18497 for this checkout, booted its own chroma there, and ran green **while the incident's orphaned server still held 18180**) → L2 required (derivation/probe ACs are unit-verifiable; the cross-checkout concurrency AC is post-merge-observable by construction). Residual: the two-checkout live concurrency check (tracked below).

## Deltas from ticket

- The ticket's pid-derivation sketch was superseded on-ticket by Mnemosyne's checkout-root-hash shape (stable per checkout across runs — credited there); the shared-parent-offset parenthetical was resolved to distinct-per-worktree via the incident's own concurrency evidence (ticket comment carries the tiebreak).
- The probe fallback is a short-lived `node -e` child (sync from the config's perspective) rather than an in-process async probe — Playwright configs evaluate synchronously.
- Banner line added per the on-ticket refinement (resolved port + provenance in every run log).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/testinfra/deriveTestPort.spec.mjs --workers=1` (NO env override — deliberately) — **4 passed**, banner: `[unit-config] test chroma port 18497 (checkout-derived from /Users/Shared/claude/neomjs/neo; override: NEO_CHROMA_PORT_TEST)`. Spec fixtures are the four REAL incident checkout roots (distinctness pinned across parent checkouts + the worktree); determinism, range-bounds, and the probe's occupied-port walk (live `net` squatter in-spec) all pinned.
- Directly touched surfaces: the unit config + the new helper + its spec; sibling configs (`integration`, `component`, `visual`) audited per the AC — none boots a fixed-port webServer (the e2e config's `NEO_E2E_PORT` is caller-supplied by design) → documented N/A.
- Source + PR-body gates: `npm run agent-preflight -- --no-fix <touched files> --pr-body <this draft>` — passed before commit.

## Post-Merge Validation

- [ ] Two checkouts on the shared machine run `test-unit` concurrently with zero env vars and both complete (the incident-reproduction AC — observable once a second checkout pulls this change).
- [ ] The interim claim-your-own-port discipline broadcast at 08:06Z retires; the orphaned 18180 listener drains naturally once no runner targets it.

## Evolution

The fix-shape converged across three seats on the ticket itself: my pid-sketch → Mnemosyne's checkout-hash (better: stable per checkout) → my worktree-distinctness falsifier from the incident's own process table → her range-bound + banner refinements. The PR implements the converged shape verbatim.

Authored by Grace (Claude Fable 5, Claude Code). Session 75ed6708-c66b-4989-862d-2286e87abbf1.
