### PR TITLE
fix(ci): state-key the review-body lint — COMMENTED supplementaries exempt (#15228)

### DIFF
--- a/.github/workflows/agent-pr-review-body-lint.yml
+++ b/.github/workflows/agent-pr-review-body-lint.yml
@@ -36,7 +36,19 @@ jobs:
               return;
             }
 
-            console.log(`🔍 Linting review body for agent reviewer: ${reviewer} on PR #${pr.number}`);
+            // State-keyed enforcement: only gate-bearing reviews owe the template.
+            // APPROVED / CHANGES_REQUESTED flip reviewDecision and carry merge semantics; a
+            // COMMENTED review is supplementary by construction (the merge gate's own rule:
+            // a comment alone is insufficient) — same-family disclosures, corpus/fixture
+            // verifications, invited design reads. Forcing the gate template onto those either
+            // fails peers' CI on non-gating input or breeds template theater that muddies the
+            // cross-family accounting. The state field is the same SSOT the merge gate reads.
+            if ((review.state || '').toLowerCase() === 'commented') {
+              console.log(`✅ COMMENTED review by ${reviewer} — supplementary (non-gating); template enforcement is state-keyed to APPROVED/CHANGES_REQUESTED. Skipping lint.`);
+              return;
+            }
+
+            console.log(`🔍 Linting review body for agent reviewer: ${reviewer} on PR #${pr.number} (state: ${review.state})`);
 
             // ──────────────────────────────────────────────────────────────────────
             // Two-layer mechanical body-shape validation (#11495, derived from PR #11494).
@@ -224,6 +236,9 @@ jobs:
               `Do NOT compose a substitute template or hallucinate section headings. The validator`,
               `checks more structural anchors than this comment names. The only reliable path to`,
               `passing is reading the actual template file and following its structure.`,
+              ``,
+              `Enforcement is state-keyed: gate-bearing reviews (APPROVED / CHANGES_REQUESTED) owe`,
+              `the template; a supplementary COMMENTED review is exempt and never triggers this lint.`,
               ``,
               missingPremiseSnapshot.length > 0
                 ? `**Premise snapshot note**: all four premise fields, including **Premise Coherence:**, are required.`


### PR DESCRIPTION
Resolves #15228

`lint-pr-review-body` now keys template enforcement on the review's **state** — the same SSOT the merge gate reads: `APPROVED` / `CHANGES_REQUESTED` (the states that flip `reviewDecision` and carry merge semantics) owe the full template exactly as before; a `COMMENTED` review is supplementary by construction (same-family disclosures, corpus/fixture verifications, invited design reads — the merge gate's own rule already says "a comment alone is insufficient") and returns early with an explicit log line. The failure comment now names the state-keyed boundary so future supplementary authors understand it. One early-return plus one message line; no anchor lists, no template semantics, and no gate-review behavior changed.

**Live urgency**: the defect currently fails CI on PR #15222 — the stop-hook attachment-visibility fix, this machine's most operationally important open merge — because of a corpus-verification COMMENTED review, and on PR #15223 for an invited design read. Both green retroactively-on-next-review-event or simply stop mattering once this merges (the check only fires on review submission).

Evidence: L1 (workflow-script change; behavior verifiable only on live review events — the check has no local runtime surface) → L2 achievable post-merge only. Residual: both ACs' live proofs (tracked below).

## Deltas from ticket

None substantive — the ticket's fix section shipped verbatim (state-keyed early return, no markers, no body heuristics; the extraction of anchors to a shared module stays the pre-existing #11501 candidate, untouched).

## Test Evidence

- Workflow-embedded `github-script` — no unit spec surface exists for this file (the anchor-extraction ticket #11501 is the named path to testability; out of scope here per the ticket). Directly touched surface `.github/workflows/agent-pr-review-body-lint.yml`: `None found` (no spec surface).
- Static verification: the payload field (`review.state`, lowercase in webhook payloads) is compared case-insensitively; the early return sits after the agent-reviewer filter so human-reviewer semantics are untouched; `yamllint`-clean by CI's own workflow parse on push.
- Source + PR-body gates: `npm run agent-preflight -- --no-fix --pr-body <this draft>` — passed before commit (no .mjs in scope).

## Post-Merge Validation

- [ ] A COMMENTED supplementary review on any agent PR no longer fails the check (regression: the #15222 / #15223 cases — observable on their next review event).
- [ ] An APPROVED/CHANGES_REQUESTED review missing template anchors still fails with the corrective comment (unchanged path — next natural gate review proves it).

Authored by Grace (Claude Fable 5, Claude Code). Session 75ed6708-c66b-4989-862d-2286e87abbf1.
