### PR TITLE
docs(agentos): mark AiConfigModel.md non-authoritative under ADR 0019 (#15235)

### DIFF
--- a/learn/agentos/AiConfigModel.md
+++ b/learn/agentos/AiConfigModel.md
@@ -1,5 +1,7 @@
 # The aiConfig configuration model
 
+> **Non-authoritative intent notes.** The authority for every AiConfig pattern, antipattern, and sanctioned shape is [ADR 0019](decisions/0019-aiconfig-reactive-provider-ssot.md) — the read-gate every `ai/` config touch must consult first. If this page and the ADR ever disagree, the ADR wins.
+
 > The Brain's configuration (`aiConfig`) is **hierarchical nested data**: a tree of `Neo.state.Provider`s where each layer owns only its slice and inherits the rest up a parent chain. This page is the *intent* behind that shape. Read it before changing how config is loaded, merged, or migrated — the model quietly makes several "obvious" approaches (source-level drift detection, overlay cloning, hand-written merge) the **wrong layer**.
 
 ## The shape


### PR DESCRIPTION
Resolves #15235

The one-line OQ1 residual from the #12456 epic-resolution pass: `AiConfigModel.md` (the reduced intent-notes survivor) now opens with the explicit non-authoritative marker and the ADR 0019 pointer the source Discussion's OQ1 criterion required — retire / pointer / explicitly-non-authoritative, of which none previously held (grep-verified zero mentions of the ADR or authority). The split-brain sliver is closed: a reader landing on the intent notes is routed to the read-gate authority before acting.

Evidence: L1 (static docs change; the AC's own grep is the witness) → L1 required (docs-only AC). No residuals.

## Deltas from ticket

None substantive.

## Test Evidence

- AC grep: `grep -c "0019" learn/agentos/AiConfigModel.md` → 1 (was 0).
- Docs-only change; no runtime surface. Cross-family gate: docs micro-change exception per `pull-request-workflow.md §6.1` (pure documentation, +2 lines), stated here per the exception's own requirement.

## Post-Merge Validation

- [ ] None — the AC is fully static.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 2c0a23e9-f468-4de6-9e29-ddec96103fb4
