### PR TITLE
feat(workstation): the drag-affordance overlay layers — Demo-A pattern on the flagship (#15207)

### DIFF
--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -17,6 +17,7 @@ import DockService                              from '../../../src/ai/client/Doc
 import DockZoneModel                            from '../../../src/dashboard/DockZoneModel.mjs';
 import StateProvider                            from '../../../src/state/Provider.mjs';
 import TourRunner                               from '../../../src/ai/client/TourRunner.mjs';
+import {previewToOperation}                     from '../../../src/dashboard/dockPreviewContract.mjs';
 import {workstationTourScript, initialDocument} from '../tour/denseWorkstation.mjs';
 import '../../../src/button/Base.mjs';
 import '../../../src/tab/Container.mjs';
@@ -126,6 +127,14 @@ class Workspace extends Container {
      * @member {Neo.dashboard.DockPreviewProducer|null} dockPreviewProducer=null
      */
     dockPreviewProducer = null
+    /**
+     * Measured drag-session geometry (host rect + tabs-zone rects + the chips' root target),
+     * built lazily on the first drag-move of a gesture and invalidated on drop, cancel, and
+     * every re-projection. Doubles as the drag-active flag. Runtime-only — the Demo-A pattern.
+     * @member {Object|null} dragGeometry=null
+     * @protected
+     */
+    dragGeometry = null
     /**
      * @member {Object} paneCache={}
      * @protected
@@ -252,6 +261,198 @@ class Workspace extends Container {
      */
     applyDockZoneOperation(descriptor) {
         return DockZoneModel.applyOperation(this.dockModel, descriptor)
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────────
+    // The drag-affordance family (the Demo-A pattern, ported): geometry memoization, the
+    // per-frame indicator/preview consumer, the release-truth drop seam, and the cancel
+    // hygiene. The overlays are the persistent siblings mounted at construct.
+    // ─────────────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Ends a drag affordance session: geometry cache dropped (it doubles as the drag-active
+     * flag), indicator menu and preview cleared. Called on drop, cancel, and by every
+     * re-projection.
+     * @protected
+     */
+    clearDragAffordances() {
+        let me = this;
+
+        me.dragGeometry = null;
+
+        me.getReference('drop-indicators')?.clear();
+
+        let preview = me.getReference('dock-preview');
+
+        preview && (preview.dockPreview = null)
+    }
+
+    /**
+     * Measures the drag-session geometry once per gesture (memoized as a promise so the
+     * ~60hz move stream never stacks measurements): the host rect (the indicator layer's
+     * coordinate origin), every projected tabs-zone rect with its parent-split orientation,
+     * and the chips' root target — the edge-zone's CENTER node when the document root is an
+     * edge-zone, the root itself otherwise.
+     * @returns {Promise<Object|null>} {hostRect, zones, root} or null when nothing is measurable
+     * @protected
+     */
+    ensureDragGeometry() {
+        let me = this;
+
+        if (me.dragGeometry) return me.dragGeometry;
+
+        let host  = me.getReference('dock-host'),
+            nodes = me.dockModel?.nodes || {};
+
+        if (!host) return Promise.resolve(null);
+
+        let zoneEntries = Object.keys(nodes)
+                .filter(nodeId => nodes[nodeId].type === 'tabs')
+                .map(nodeId => ({nodeId, container: host.down({dockNodeId: nodeId})}))
+                .filter(zone => zone.container),
+            rootId      = nodes[me.dockModel.root]?.type === 'edge-zone'
+                ? (nodes[me.dockModel.root].zones?.center ?? me.dockModel.root)
+                : me.dockModel.root;
+
+        me.dragGeometry = me.getDomRect([host.id, ...zoneEntries.map(zone => zone.container.id)]).then(([hostRect, ...zoneRects]) => {
+            let geometry = hostRect && {
+                hostRect,
+                root : {nodeId: rootId, rect: hostRect},
+                zones: zoneEntries
+                    .map((zone, index) => ({
+                        nodeId     : zone.nodeId,
+                        rect       : zoneRects[index],
+                        orientation: Object.values(nodes).find(node => node.type === 'split' && node.children?.includes(zone.nodeId))?.orientation ?? null
+                    }))
+                    .filter(zone => zone.rect)
+            };
+
+            // A gesture's FIRST move can outrace measurability (fresh mount, mid-layout):
+            // a degenerate result must not latch for the whole gesture — uncache so the
+            // next move frame re-measures and the session self-heals.
+            if (!geometry || geometry.zones.length < 1) {
+                me.dragGeometry = null;
+                return null
+            }
+
+            let indicators = me.getReference('drop-indicators');
+
+            indicators && (indicators.hostRect = geometry.hostRect);
+
+            return geometry
+        });
+
+        return me.dragGeometry
+    }
+
+    /**
+     * Converts a measured viewport rect into the dock-host's local space — the coordinate
+     * system both overlay children (preview renderer, indicator menu) position in.
+     * @param {Object} rect viewport-space {x, y, width, height}
+     * @param {Object} hostRect the measured host rect
+     * @returns {Object}
+     * @protected
+     */
+    localRect(rect, hostRect) {
+        return {x: rect.x - hostRect.x, y: rect.y - hostRect.y, width: rect.width, height: rect.height}
+    }
+
+    /**
+     * Consumes the dock-aware projection's generic `drag:cancel` seam: the main-thread drag
+     * owner already suppresses the native release, so this workspace only retires transient
+     * geometry, menu, and preview state.
+     * @param {Object} data The dock drag identity payload.
+     */
+    onDockCrossZoneDragCancel(data) {
+        this.clearDragAffordances()
+    }
+
+    /**
+     * The per-frame drag consumer (`dockCrossZoneDragMove` via the projection): the
+     * indicator menu follows the hovered zone (candidate set swaps on zone change only —
+     * object permanence lets the cross GLIDE); the pointer selects an indicator
+     * geometrically; the selected candidate's preview — or the pointer-inference FALLBACK
+     * tier when no indicator is hovered — feeds the renderer with its exact target region.
+     * @param {Object} data {clientX, clientY, itemId, sourceNodeId}
+     */
+    async onDockCrossZoneDragMove({clientX, clientY, itemId, sourceNodeId}) {
+        let me              = this,
+            geometryPromise = me.ensureDragGeometry(),
+            geometry        = await geometryPromise;
+
+        // Re-check the promise identity after the await: cancel or re-projection invalidates
+        // this gesture's geometry, so a late measurement can never resurrect its overlays.
+        if (!geometry || me.dragGeometry !== geometryPromise || me.isDestroyed) return;
+
+        let pointer    = {x: clientX, y: clientY},
+            indicators = me.getReference('drop-indicators'),
+            preview    = me.getReference('dock-preview'),
+            producer   = me.dockPreviewProducer,
+            zone       = producer.hitTestZone(geometry.zones, pointer);
+
+        if (indicators) {
+            if ((zone?.nodeId ?? null) !== (indicators.candidateSet?.zone?.nodeId ?? null)) {
+                indicators.candidateSet = zone
+                    ? producer.produceCandidates({pointer, zones: geometry.zones, itemId, sourceNodeId, root: geometry.root})
+                    : null
+            }
+        }
+
+        let candidate   = indicators?.updatePointer(pointer) ?? null,
+            dockPreview = candidate?.preview
+                ?? producer.produce({pointer, zones: geometry.zones, itemId, sourceNodeId});
+
+        if (preview) {
+            preview.dockPreview = dockPreview;
+
+            if (dockPreview) {
+                let targetRect = dockPreview.target.nodeId === geometry.root.nodeId
+                    ? geometry.root.rect
+                    : geometry.zones.find(entry => entry.nodeId === dockPreview.target.nodeId)?.rect;
+
+                targetRect && preview.applyTargetGeometry(me.localRect(targetRect, geometry.hostRect))
+            }
+        }
+    }
+
+    /**
+     * The drop half (`dockCrossZoneDrop` via the projection): the indicator is re-hit-tested
+     * at the RELEASE coordinates — release truth, never cached hover truth — and a candidate
+     * only counts when it was built for the item THIS gesture drags. A release-point
+     * indicator wins over pointer inference, and both commit through `previewToOperation`
+     * unchanged. A cancelled gesture never reaches this drop seam.
+     * @param {Object} data {clientX, clientY, itemId, sourceNodeId}
+     */
+    async onDockCrossZoneDrop({clientX, clientY, itemId, sourceNodeId}) {
+        let me       = this,
+            geometry = me.dragGeometry ? await me.dragGeometry : null,
+            pointer  = {x: clientX, y: clientY},
+            preview  = null;
+
+        let candidate = me.getReference('drop-indicators')?.hitTest(pointer);
+
+        if (candidate?.preview?.itemId === itemId) {
+            preview = candidate.preview
+        } else if (geometry) {
+            preview = me.dockPreviewProducer.produce({
+                pointer,
+                zones: geometry.zones.filter(zone => zone.nodeId !== sourceNodeId),
+                itemId,
+                sourceNodeId
+            })
+        }
+
+        me.clearDragAffordances();
+
+        let descriptor = previewToOperation(preview);
+
+        if (descriptor) {
+            let result = me.applyDockZoneOperation(descriptor);
+
+            if (result && !result.errors?.length && result.document) {
+                me.onDockZoneDocumentChange(result.document)
+            }
+        }
     }
 
     /**
@@ -545,9 +746,12 @@ class Workspace extends Container {
         let me = this;
 
         return DockLayoutAdapter.project(me.dockModel, {
-            applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
-            onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
-            resolveComponentRef     : resolveComponentRef
+            applyDockZoneOperation   : me.applyDockZoneOperation.bind(me),
+            onDockCrossZoneDragCancel: me.onDockCrossZoneDragCancel.bind(me),
+            onDockCrossZoneDragMove  : me.onDockCrossZoneDragMove.bind(me),
+            onDockCrossZoneDrop      : me.onDockCrossZoneDrop.bind(me),
+            onDockZoneDocumentChange : me.onDockZoneDocumentChange.bind(me),
+            resolveComponentRef      : resolveComponentRef
                 || ((componentRef, item, itemId) => me.resolvePane(itemId, item)),
             resolveRevealComponentRef  : (componentRef, item, itemId) => me.resolvePane(itemId, item)
         })
@@ -645,6 +849,10 @@ class Workspace extends Container {
             placeholders = new Map();
 
         if (!host) return;
+
+        // Topology is changing under any in-flight gesture: retire its geometry and
+        // overlays so a late measurement can never resurrect stale affordances.
+        me.clearDragAffordances();
 
         try {
             await flip?.captureFirst({hostId: host.id, markerPrefix: 'workstation-pane-'})

--- a/apps/workstation/view/Workspace.mjs
+++ b/apps/workstation/view/Workspace.mjs
@@ -1,11 +1,17 @@
-import Component                                from '../../../src/component/Base.mjs';
-import Container                                from '../../../src/container/Base.mjs';
-import Feed                                     from '../store/Feed.mjs';
-import FeedPane                                 from './FeedPane.mjs';
-import Scale                                    from '../store/Scale.mjs';
-import ScalePane                                from './ScalePane.mjs';
-import DockLayoutAdapter                        from '../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockMotionSignal                         from '../../../src/dashboard/DockMotionSignal.mjs';
+import Component          from '../../../src/component/Base.mjs';
+import Container          from '../../../src/container/Base.mjs';
+import Feed               from '../store/Feed.mjs';
+import FeedPane           from './FeedPane.mjs';
+import Scale              from '../store/Scale.mjs';
+import ScalePane          from './ScalePane.mjs';
+import DockDropIndicators from '../../../src/dashboard/DockDropIndicators.mjs';
+import DockLayoutAdapter  from '../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockMotionSignal   from '../../../src/dashboard/DockMotionSignal.mjs';
+// Single-renderer reuse across the app boundary (the affordance ticket's explicit call:
+// reuse, don't fork — it consumes the --fm-* tokens this app's theme family already
+// loads). A lift to src/dashboard is the reconciler arc's future call, not this leaf's.
+import DockPreview                              from '../../agentos/view/DockPreview.mjs';
+import DockPreviewProducer                      from '../../../src/dashboard/DockPreviewProducer.mjs';
 import DockProjectionReconciler                 from '../../../src/dashboard/DockProjectionReconciler.mjs';
 import DockService                              from '../../../src/ai/client/DockService.mjs';
 import DockZoneModel                            from '../../../src/dashboard/DockZoneModel.mjs';
@@ -115,6 +121,12 @@ class Workspace extends Container {
      */
     tourRunner = null
     /**
+     * Drag-affordance candidate producer (the §06 menu's data half) — created at construct,
+     * consumed by the cross-zone gesture handlers as they land on this workspace.
+     * @member {Neo.dashboard.DockPreviewProducer|null} dockPreviewProducer=null
+     */
+    dockPreviewProducer = null
+    /**
      * @member {Object} paneCache={}
      * @protected
      */
@@ -207,11 +219,22 @@ class Workspace extends Container {
 
         me.appendFeedBatch(25);
 
+        me.dockPreviewProducer = Neo.create(DockPreviewProducer);
+
         me.add([me.createTourBar(), me.createStatusBar(), {
-            module   : Container,
-            cls      : ['workstation-dock-host', 'neo-dashboard', 'neo-dashboard-dock-query-host'],
-            flex     : 1,
-            items    : [me.projectDockModel()],
+            module: Container,
+            cls   : ['workstation-dock-host', 'neo-dashboard', 'neo-dashboard-dock-query-host'],
+            flex  : 1,
+            // The projection child is index 0 and the ONLY child the shared reconciler stages;
+            // the preview renderer + indicator menu are PERSISTENT siblings (absolute overlays
+            // via the skin) — object permanence across every re-projection, the Demo-A pattern.
+            items    : [me.projectDockModel(), {
+                module   : DockPreview,
+                reference: 'dock-preview'
+            }, {
+                module   : DockDropIndicators,
+                reference: 'drop-indicators'
+            }],
             layout   : {ntype: 'fit'},
             reference: 'dock-host'
         }]);

--- a/test/playwright/unit/apps/workstation/WorkspaceDragAffordances.spec.mjs
+++ b/test/playwright/unit/apps/workstation/WorkspaceDragAffordances.spec.mjs
@@ -1,0 +1,191 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'WorkstationDragAffordancesTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import '../../../../../src/manager/Instance.mjs';
+import Workspace      from '../../../../../apps/workstation/view/Workspace.mjs';
+
+import {initialDocument} from '../../../../../apps/workstation/tour/denseWorkstation.mjs';
+
+/**
+ * @summary The affordance-pipeline witness for the workstation's cross-zone drag family.
+ *
+ * Drives the worker-side seams the browser journey cannot isolate: overlay OBJECT PERMANENCE
+ * across a reducer-driven re-projection, the release-truth drop seam committing EXACTLY the
+ * previewed descriptor through `previewToOperation`, cancel hygiene with zero model mutation,
+ * and the late-measurement race guard (a superseded geometry promise can never resurrect its
+ * gesture's overlays).
+ *
+ * `dragGeometry` is the designed injection seam — it memoizes a promise precisely so a gesture
+ * measures once; the witness injects a synthetic measurement (viewport === host-local space)
+ * and exercises the real producer, indicator menu, preview renderer, and dock reducer beneath it.
+ */
+test.describe.serial('Workstation drag affordances (the cross-zone pipeline witness)', () => {
+    /**
+     * Builds the synthetic one-gesture geometry over the REAL initial document's zones:
+     * `scale-tabs` fills the left column, `heavy-tabs` the right; host at the viewport origin
+     * so local space equals pointer space.
+     * @returns {Object}
+     */
+    const syntheticGeometry = () => ({
+        hostRect: {x: 0, y: 0, width: 1200, height: 800},
+        root    : {nodeId: 'witness-root', rect: {x: 0, y: 0, width: 1200, height: 800}},
+        zones   : [
+            {nodeId: 'scale-tabs', rect: {x: 0,   y: 0, width: 600, height: 800}, orientation: 'horizontal'},
+            {nodeId: 'heavy-tabs', rect: {x: 600, y: 0, width: 600, height: 800}, orientation: 'horizontal'}
+        ]
+    });
+
+    /**
+     * Injects the synthetic geometry the way `ensureDragGeometry` would have produced it:
+     * the memoized promise plus the indicator layer's coordinate origin.
+     * @param {Workstation.view.Workspace} workspace
+     * @returns {Object} the injected geometry
+     */
+    const injectGeometry = workspace => {
+        const geometry = syntheticGeometry();
+
+        workspace.dragGeometry = Promise.resolve(geometry);
+        workspace.getReference('drop-indicators').hostRect = geometry.hostRect;
+
+        return geometry
+    };
+
+    test('overlays are persistent siblings: same instances across a reducer re-projection, cleared at its head', async () => {
+        const workspace = Neo.create(Workspace, {});
+
+        try {
+            const
+                host       = workspace.getReference('dock-host'),
+                preview    = workspace.getReference('dock-preview'),
+                indicators = workspace.getReference('drop-indicators');
+
+            // the composition contract: projection child at 0, the two overlays persistent behind it
+            expect(host.items[1]).toBe(preview);
+            expect(host.items[2]).toBe(indicators);
+
+            injectGeometry(workspace);
+
+            const result = workspace.applyDockZoneOperation({
+                operation   : 'splitNode',
+                itemId      : 'security',
+                targetNodeId: 'scale-tabs',
+                orientation : 'vertical',
+                edge        : 'bottom',
+                sizes       : [0.7, 0.3]
+            });
+
+            expect(result.errors).toEqual([]);
+            workspace.onDockZoneDocumentChange(result.document);
+            await workspace.refreshPromise;
+
+            // object permanence: the exact instances survive, still mounted at their slots
+            expect(workspace.getReference('dock-preview')).toBe(preview);
+            expect(workspace.getReference('drop-indicators')).toBe(indicators);
+            expect(host.items[1]).toBe(preview);
+            expect(host.items[2]).toBe(indicators);
+            expect(preview.isDestroyed).toBeFalsy();
+            expect(indicators.isDestroyed).toBeFalsy();
+
+            // re-projection hygiene: the refresh head retired the gesture's transient state
+            expect(workspace.dragGeometry).toBe(null);
+            expect(preview.dockPreview).toBe(null)
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('move renders the menu + preview; the drop commits exactly the previewed descriptor (release truth)', async () => {
+        const workspace = Neo.create(Workspace, {});
+
+        try {
+            const
+                preview    = workspace.getReference('dock-preview'),
+                indicators = workspace.getReference('drop-indicators'),
+                gesture    = {itemId: 'security', sourceNodeId: 'heavy-tabs'},
+                // the scale-tabs zone center: the cross's CENTER indicator sits here → tab-into
+                pointer    = {clientX: 300, clientY: 400};
+
+            injectGeometry(workspace);
+            const securityPane = workspace.resolvePane('security', initialDocument.items.security);
+
+            await workspace.onDockCrossZoneDragMove({...pointer, ...gesture});
+
+            expect(indicators.candidateSet?.zone?.nodeId).toBe('scale-tabs');
+            expect(preview.dockPreview, 'the hovered center candidate feeds the renderer').toBeTruthy();
+            expect(preview.dockPreview.placement.kind).toBe('tab-into');
+            expect(preview.dockPreview.target.nodeId).toBe('scale-tabs');
+            expect(preview.dockPreview.itemId).toBe('security');
+            expect(preview.dockPreview.feedback.state).toBe('accepted');
+
+            await workspace.onDockCrossZoneDrop({...pointer, ...gesture});
+            await workspace.refreshPromise;
+
+            // the committed document IS the previewed operation: tab-into scale-tabs
+            expect(workspace.dockModel.nodes['scale-tabs'].items).toContain('security');
+            expect(workspace.dockModel.nodes['heavy-tabs'].items).not.toContain('security');
+
+            // the drop retired the gesture, and the pane survived the move with its identity
+            expect(workspace.dragGeometry).toBe(null);
+            expect(preview.dockPreview).toBe(null);
+            expect(workspace.resolvePane('security', initialDocument.items.security)).toBe(securityPane);
+            expect(securityPane.isDestroyed).toBeFalsy()
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('cancel clears every affordance and commits nothing', async () => {
+        const workspace = Neo.create(Workspace, {});
+
+        try {
+            const
+                preview = workspace.getReference('dock-preview'),
+                gesture = {itemId: 'security', sourceNodeId: 'heavy-tabs'},
+                before  = JSON.stringify(workspace.dockModel);
+
+            injectGeometry(workspace);
+            await workspace.onDockCrossZoneDragMove({clientX: 300, clientY: 400, ...gesture});
+            expect(preview.dockPreview).toBeTruthy();
+
+            workspace.onDockCrossZoneDragCancel(gesture);
+
+            expect(workspace.dragGeometry).toBe(null);
+            expect(preview.dockPreview).toBe(null);
+            expect(JSON.stringify(workspace.dockModel), 'zero model mutation on cancel').toBe(before)
+        } finally {
+            workspace.destroy()
+        }
+    });
+
+    test('a superseded geometry promise can never resurrect its overlays (the late-measurement guard)', async () => {
+        const workspace = Neo.create(Workspace, {});
+
+        try {
+            const
+                preview = workspace.getReference('dock-preview'),
+                gesture = {itemId: 'security', sourceNodeId: 'heavy-tabs'};
+
+            injectGeometry(workspace);
+
+            // the move suspends at its geometry await; the gesture is cancelled underneath it —
+            // the handler's promise-identity re-check must discard the resumed frame entirely
+            const moveInFlight = workspace.onDockCrossZoneDragMove({clientX: 300, clientY: 400, ...gesture});
+
+            workspace.clearDragAffordances();
+            await moveInFlight;
+
+            expect(preview.dockPreview, 'the late frame rendered nothing').toBe(null);
+            expect(workspace.dragGeometry).toBe(null)
+        } finally {
+            workspace.destroy()
+        }
+    })
+});


### PR DESCRIPTION
Resolves #15207

Related: #15206 · D#15204 (G5 / merge-order step 2) · #14974 (the Demo-A precedent) · #13158

The flagship gets its drag affordances: the workstation composed the dock host with the projection child ONLY — no producer, no preview renderer, no indicator menu (the ticket's grep-verified gap). Three commits lift the Demo-A pattern verbatim: (1) the overlay composition — `DockPreviewProducer` at construct, `DockPreview` + `DockDropIndicators` as PERSISTENT siblings of the projection child, the surgical refresh; (2) the cross-zone gesture threading — memoized once-per-gesture geometry, the per-frame candidate/preview consumer (candidate-set swaps on zone change only, indicator-first / pointer-inference-fallback tiers), the release-truth drop seam committing through `previewToOperation`, cancel hygiene, and the late-measurement race guard; (3) the whitebox witness.

Evidence: L3 at build time (a real-pointer cross-zone drag on the live workstation — the flagship's first: indicator menu lit, zone preview rendered, release committed the previewed move with the 10/sec feed unbroken and a clean console) + L2 at the rebased head (the four-witness spec + the workstation suite green on current dev) → AC-1/AC-2/AC-5. Residual: none on this leaf; AC-3's visible re-skin is cross-PR by its own wording (details below).

## AC dispositions

- **AC-1 (drag lights menu + preview; commit = the selected descriptor, worker-truth): delivered.** Live at build time (real pointer); the witness re-proves the seam chain on the rebased head — move → `candidateSet` on the hovered zone + the center candidate's `tab-into` preview → drop → the document mutates to exactly `previewToOperation(preview)` (the item changed zones; the pane kept its object identity).
- **AC-2 (overlays survive a committed re-projection): delivered.** The witness pins instance identity AND slot positions across a reducer-driven `splitNode` re-projection, plus the refresh-head hygiene (`clearDragAffordances` retiring the gesture's transient state).
- **AC-3 (`previewLanguage` visibly re-skins the affordances): conditionally delivered, by design.** The switch (shipped) and the affordance layers (this PR) are both on the flagship now; the VARIANTS ride PR #15208 (#15206). Whichever merges second makes the side-by-side real — no code change needed here for it (the modifier is a host cls the skins consume). Merge-order note: both branches touch `Workspace.mjs` in disjoint regions; the second lander rebases mechanically.
- **AC-4 (no new timing/color literals): delivered trivially** — the diff is JS composition + a test only (zero SCSS); the overlays consume their existing shipped skins. Motion posture for the demo-surface motion audit: this PR introduces NO new motion decision — the affordances animate through the already-ratified §06 family (token-fed, reduced-motion-collapsed); composition, not choreography.
- **AC-5 (whitebox witness + cross-family review): witness delivered** (four seam-driven tests incl. the race guard); review = this PR.

## Test Evidence

- `WorkspaceDragAffordances.spec.mjs` 4/4 (first run): permanence · release truth · cancel (zero model mutation, JSON-equal) · the superseded-promise race guard.
- `Workspace.spec.mjs` 2/2 green on the rebased base (the branch re-pointed onto current dev — its old base predated the PR #15205 squash; conflict-free replay, force-with-lease).
- Pre-commit chains green ×3 commits.

## Post-Merge Validation

- [ ] With PR #15208 also merged: flip `previewLanguage` on the live workstation and confirm the affordance re-skin end-to-end (closes #15208's named dependency and this AC-3's visible half).
- [ ] D#15204 merge-order step 2 ("settle the active G5/#15207 surfaces") completes when both are in.

---
Authored by Clio (Claude Fable 5, Claude Code). Session c5d7cd6b-4e01-45fd-aa59-5ccbc0e5f091.
