### PR TITLE
fix(hooks): exempt human-only-domain role-attribution from the deference lexicon (#15233)

### DIFF
--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -31,10 +31,20 @@ export const DEFERENCE_PHRASES = [
 /**
  * The peer-identity reminder injected when a deference phrase matches on an autonomous turn-end.
  * Self-explaining at point of contact: it names the slip, the peer identity, the peer-input recovery
- * route, and the friction->gold path for false positives.
+ * route, the domain-scoping boundary, and the friction->gold path for false positives.
  * @type {String}
  */
-export const DEFERENCE_REMINDER = 'It looks like you slipped into the "helpful assistant" bias. You are a neo repo maintainer and an equal peer. If you need validation or input, you can A2A message with peers or use the ideation-sandbox skill. And friction->gold applies to this hook itself: if it fired wrong - a false positive, or it reads as a leash not a mirror - open a ticket to sharpen it rather than silently absorbing it. The hook is mutable substrate, not a command.';
+export const DEFERENCE_REMINDER = 'It looks like you slipped into the "helpful assistant" bias. You are a neo repo maintainer and an equal peer. If you need validation or input, you can A2A message with peers or use the ideation-sandbox skill. Domain-scoping: naming a strictly human-owned decision (merge execution, credentials, release direction) as the human\'s is correct role-attribution and is exempt — this fired because the phrase attached to a decision maintainers own. And friction->gold applies to this hook itself: if it fired wrong - a false positive, or it reads as a leash not a mirror - open a ticket to sharpen it rather than silently absorbing it. The hook is mutable substrate, not a command.';
+
+/**
+ * Human-only-domain terms, from the identity firewall's Tier-4 enumeration: decisions the substrate
+ * itself assigns to the operator — merge execution (critical gate: agents never merge), credentials,
+ * release direction. A deference phrase whose CLAUSE names one of these is role-attribution (the
+ * required honesty about who decides), not the helpful-assistant slip; refusing it would pressure
+ * agents toward hedged prose that obscures the human gate — the worse failure.
+ * @type {RegExp}
+ */
+const HUMAN_ONLY_DOMAIN_RE = /\bmerge(?:s|d|-eligible)?\b|\bsquash\b|\bcredentials?\b|\brelease\b|\bstamp\b/i;
 
 /**
  * @summary Replaces markdown code spans and fences before deference phrase matching.
@@ -69,6 +79,27 @@ function isReportedMentionContext(text, startIndex) {
 
     return /\b(?:the|this|that)\s+(?:literal\s+)?(?:phrase|text|string|trigger|matched\s+text|wording)\s*$/.test(prefix) ||
            /\b(?:quoted|reported|mention(?:ed|ing)?|document(?:ed|ing)?)\s*$/.test(prefix);
+}
+
+/**
+ * @summary Checks whether a match's surrounding CLAUSE names a strictly human-owned domain.
+ *
+ * The clause window runs from the previous sentence/clause boundary to the next one, capped at
+ * 120 characters each way — local enough that a merge-clause exemption cannot bleed into an
+ * adjacent lane-deference sentence, wide enough for natural phrasing ("merge on the exception or
+ * ask for the stamp, your call").
+ * @param {String} text Searchable assistant final-turn text.
+ * @param {Number} startIndex Match start index.
+ * @param {Number} endIndex Match end index.
+ * @returns {Boolean}
+ */
+function isHumanOnlyDomainContext(text, startIndex, endIndex) {
+    const before       = text.slice(Math.max(0, startIndex - 120), startIndex),
+          after        = text.slice(endIndex, Math.min(text.length, endIndex + 120)),
+          clauseBefore = before.split(/[.!?\n;]/).pop() || '',
+          clauseAfter  = after.split(/[.!?\n;]/, 1)[0] || '';
+
+    return HUMAN_ONLY_DOMAIN_RE.test(`${clauseBefore} ${clauseAfter}`);
 }
 
 /**
@@ -108,10 +139,12 @@ export function matchDeferencePhrase(text = '', phrases = DEFERENCE_PHRASES) {
         let match;
 
         while ((match = matcher.exec(searchableText)) !== null) {
-            const startIndex = match.index + match[1].length;
+            const startIndex = match.index + match[1].length,
+                  endIndex   = matcher.lastIndex;
 
             if (!isReportedMentionContext(searchableText, startIndex) &&
-                !isAttributiveCitationContext(phrase, searchableText, startIndex)) {
+                !isAttributiveCitationContext(phrase, searchableText, startIndex) &&
+                !isHumanOnlyDomainContext(searchableText, startIndex, endIndex)) {
                 return true;
             }
         }

--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -103,13 +103,31 @@ function isReportedMentionContext(text, startIndex) {
 const EXEMPTION_ELIGIBLE_PHRASE_RE = /^(?:your call|your move|your steer on)$/i;
 
 /**
- * @summary Detects a NEGATED human-domain mention inside one segment (`not a merge decision`).
- * A negated mention is not positive attribution — the segment fires.
+ * @summary Detects negation ANYWHERE in a decisive segment — before or after the domain noun,
+ * including contractions and modals (`Don't merge it`, `the merge isn't yours`, `should not
+ * proceed`). A negated segment is never positive attribution — it fires.
  * @param {String} segment Text segment to test.
  * @returns {Boolean}
  */
-function isNegatedHumanMention(segment) {
-    return /\b(?:not|no|never|isn'?t|wasn'?t|aren'?t|without)\b[^.!?;]*?\b(?:merge|squash|credentials?|release|stamp)/i.test(segment);
+function isNegatedSegment(segment) {
+    return /\b(?:not|no|never|neither|nor|don'?t|doesn'?t|didn'?t|can'?t|cannot|couldn'?t|won'?t|wouldn'?t|shouldn'?t|mustn'?t|isn'?t|wasn'?t|aren'?t|weren'?t|without)\b/i.test(segment);
+}
+
+/**
+ * @summary Detects DECISION-ATTRIBUTION grammar in a decisive segment — the positive evidence that
+ * an open decision is being handed to or owned by the human, as opposed to a completed/status-only
+ * fact (`The merge landed`, `The release is live`, `The credentials expired` — those fire):
+ *
+ *  - ownership grammar: `yours` / `your <decision/gate/…>` / second-person `you decide`;
+ *  - open-choice grammar: `merge on the exception OR ask for the stamp`, `WHETHER we release`;
+ *  - pending-decision status: `merge-eligible` (eligibility = the decision is still open).
+ * @param {String} segment Text segment to test.
+ * @returns {Boolean}
+ */
+function hasAttributionGrammar(segment) {
+    return /\byours?\b|\byou\b/i.test(segment) ||
+           /\b(?:or|whether|either)\b/i.test(segment) ||
+           /\beligible\b/i.test(segment);
 }
 
 /**
@@ -139,9 +157,12 @@ function classifyDomainSegment(segment) {
  *     `your steer on the next lane` too) when it carries prose, else the predicate segment
  *     immediately before the phrase. There is NO wider clause-window fallback: an outer historical
  *     fact (`the merge landed, …`) can never lend authority to a neutral attachment.
- *  3. The decisive segment exempts ONLY on a pure, non-negated human-domain signal. Neutral,
- *     unenumerated, competing, maintainer, or negated segments (`not a merge decision`) all fire —
- *     ambiguity fails toward firing, mechanically.
+ *  3. The decisive segment exempts ONLY when it carries all three positive legs: a pure
+ *     human-domain signal, DECISION-ATTRIBUTION grammar ({@link hasAttributionGrammar} — a
+ *     completed/status-only fact like `The merge landed` is not attribution), and zero negation
+ *     anywhere in the segment ({@link isNegatedSegment} — `Don't merge it`, `the merge isn't
+ *     yours`, `should not proceed` all fire). Neutral, unenumerated, competing, maintainer,
+ *     status-only, or negated segments fire — ambiguity fails toward firing, mechanically.
  * @param {String} phrase Matched deference phrase.
  * @param {String} text Searchable assistant final-turn text.
  * @param {Number} startIndex Match start index.
@@ -162,7 +183,9 @@ function isHumanOnlyDomainContext(phrase, text, startIndex, endIndex) {
               ? objectSegment
               : (clauseBefore.split(/[,—:()]/).filter(s => s.trim()).pop() || '');
 
-    return classifyDomainSegment(decisive) === 'human' && !isNegatedHumanMention(decisive);
+    return classifyDomainSegment(decisive) === 'human' &&
+           hasAttributionGrammar(decisive) &&
+           !isNegatedSegment(decisive);
 }
 
 /**

--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -37,14 +37,22 @@ export const DEFERENCE_PHRASES = [
 export const DEFERENCE_REMINDER = 'It looks like you slipped into the "helpful assistant" bias. You are a neo repo maintainer and an equal peer. If you need validation or input, you can A2A message with peers or use the ideation-sandbox skill. Domain-scoping: a phrase that itself attributes a strictly human-owned decision (merge execution, credentials, release direction) to the human is correct role-attribution and is exempt — this fired because the attachment was to a maintainer-owned, ambiguous, or agent-offered decision instead. And friction->gold applies to this hook itself: if it fired wrong - a false positive, or it reads as a leash not a mirror - open a ticket to sharpen it rather than silently absorbing it. The hook is mutable substrate, not a command.';
 
 /**
- * Human-only-domain terms, from the identity firewall's Tier-4 enumeration: decisions the substrate
- * itself assigns to the operator — merge execution (critical gate: agents never merge), credentials,
- * release direction. A deference phrase whose CLAUSE names one of these is role-attribution (the
- * required honesty about who decides), not the helpful-assistant slip; refusing it would pressure
- * agents toward hedged prose that obscures the human gate — the worse failure.
+ * Human-only-domain token source, from the identity firewall's Tier-4 enumeration: decisions the
+ * substrate itself assigns to the operator — merge execution (critical gate: agents never merge),
+ * credentials, release direction. ONE vocabulary source builds both the presence regex and the
+ * copular-ownership relation, so the two can never drift. A phrase that ATTRIBUTES one of these
+ * decisions to the human is role-attribution (the required honesty about who decides), not the
+ * helpful-assistant slip; refusing it would pressure agents toward hedged prose that obscures the
+ * human gate — the worse failure.
+ * @type {String}
+ */
+const HUMAN_ONLY_TOKENS = "merge(?:s|d|-eligible)?|squash|credentials?|release|stamp";
+
+/**
+ * Human-only-domain presence test, built from {@link HUMAN_ONLY_TOKENS}.
  * @type {RegExp}
  */
-const HUMAN_ONLY_DOMAIN_RE = /\bmerge(?:s|d|-eligible)?\b|\bsquash\b|\bcredentials?\b|\brelease\b|\bstamp\b/i;
+const HUMAN_ONLY_DOMAIN_RE = new RegExp(`\\b(?:${HUMAN_ONLY_TOKENS})\\b`, 'i');
 
 /**
  * Maintainer-owned decision surfaces — the work agents decide and drive themselves (lanes, reviews,
@@ -103,66 +111,117 @@ function isReportedMentionContext(text, startIndex) {
 const EXEMPTION_ELIGIBLE_PHRASE_RE = /^(?:your call|your move|your steer on)$/i;
 
 /**
- * @summary Detects negation ANYWHERE in a decisive segment — before or after the domain noun,
- * including contractions and modals (`Don't merge it`, `the merge isn't yours`, `should not
- * proceed`). A negated segment is never positive attribution — it fires.
- * @param {String} segment Text segment to test.
+ * The negation vocabulary — contractions and modals included, with BOTH ASCII and typographic
+ * apostrophes (`isn't` / `isn’t`). Applied relation-scoped, never segment-wide: negation kills an
+ * attribution only when it sits INSIDE the relation that would supply it.
+ * @type {String}
+ */
+const NEGATION_WORDS = "(?:not|no|never|neither|nor|don['’]?t|doesn['’]?t|didn['’]?t|can['’]?t|cannot|couldn['’]?t|won['’]?t|wouldn['’]?t|shouldn['’]?t|mustn['’]?t|isn['’]?t|wasn['’]?t|aren['’]?t|weren['’]?t|without)";
+
+/**
+ * @summary Tests one text span for negation ({@link NEGATION_WORDS}).
+ * @param {String} span Text span to test.
  * @returns {Boolean}
  */
-function isNegatedSegment(segment) {
-    return /\b(?:not|no|never|neither|nor|don'?t|doesn'?t|didn'?t|can'?t|cannot|couldn'?t|won'?t|wouldn'?t|shouldn'?t|mustn'?t|isn'?t|wasn'?t|aren'?t|weren'?t|without)\b/i.test(segment);
+function isNegatedSpan(span) {
+    return new RegExp(`\\b${NEGATION_WORDS}\\b`, 'i').test(span);
 }
 
 /**
- * @summary Detects DECISION-ATTRIBUTION grammar in a decisive segment — the positive evidence that
- * an open decision is being handed to or owned by the human, as opposed to a completed/status-only
- * fact (`The merge landed`, `The release is live`, `The credentials expired` — those fire):
+ * @summary OBJECT-form attribution: the eligible phrase's own possessive (`your call/move/steer`)
+ * already assigns the decision — the exemption question reduces to whether the phrase's OBJECT is
+ * a pure human-only decision. The object runs from the phrase to the clause end (coordinations
+ * intact — a comma before `or`/`whether` continues the SAME object, so a mixed continuation is
+ * never truncated away). It exempts only when it:
  *
- *  - ownership grammar: `yours` / `your <decision/gate/…>` / second-person `you decide`;
- *  - open-choice grammar: `merge on the exception OR ask for the stamp`, `WHETHER we release`;
- *  - pending-decision status: `merge-eligible` (eligibility = the decision is still open).
- * @param {String} segment Text segment to test.
+ *  - names a human-only domain and NO maintainer surface;
+ *  - contains no first-person agent clause (`… or whether I update docs` is mixed authority);
+ *  - contains no negation (`whether the merge should not proceed` fires);
+ *  - coordinates only human-anchored or bare single-word alternatives (`merge or hold` exempts;
+ *    `merge or update the docs` coordinates an unenumerated agent task and fires).
+ * @param {String} objectText The phrase's object span (clause-bounded, coordinations intact).
  * @returns {Boolean}
  */
-function hasAttributionGrammar(segment) {
-    return /\byours?\b|\byou\b/i.test(segment) ||
-           /\b(?:or|whether|either)\b/i.test(segment) ||
-           /\beligible\b/i.test(segment);
+function isHumanDecisionObject(objectText) {
+    if (!/\w/.test(objectText))                    return false;
+    if (!HUMAN_ONLY_DOMAIN_RE.test(objectText))    return false;
+    if (MAINTAINER_DOMAIN_RE.test(objectText))     return false;
+    if (isNegatedSpan(objectText))                 return false;
+    if (/\b(?:I|me|we)\b/.test(objectText))        return false;
+
+    // Coordinated alternatives: every `or`-branch must be human-anchored or a bare option word.
+    for (const alternative of objectText.split(/\bor\b/i).map(s => s.trim())) {
+        if (!alternative) continue;
+        if (HUMAN_ONLY_DOMAIN_RE.test(alternative)) continue;
+        // A bare counter-option of the same decision ("hold", "now") — at most one content word.
+        if (alternative.replace(/[^\w\s]/g, '').trim().split(/\s+/).filter(w => w && !/^(?:the|a|an|to|now|it|this|that)$/i.test(w)).length <= 1) continue;
+        return false;
+    }
+
+    return true;
 }
 
 /**
- * @summary Classifies one attachment segment's domain signal.
- * @param {String} segment Text segment to classify.
- * @returns {('human'|'maintainer'|'competing'|null)} The decisive signal, or `null` when neutral.
- */
-function classifyDomainSegment(segment) {
-    const human      = HUMAN_ONLY_DOMAIN_RE.test(segment),
-          maintainer = MAINTAINER_DOMAIN_RE.test(segment);
-
-    if (human && maintainer) return 'competing';
-    if (human)               return 'human';
-    if (maintainer)          return 'maintainer';
-    return null;
-}
-
-/**
- * @summary Checks whether a match POSITIVELY attributes a strictly human-owned decision.
+ * @summary PREDICATE-form attribution: with no object after the phrase, the predicate before it
+ * must POSITIVELY assign the open decision to the human through one of three explicit relations —
+ * loose token co-presence (`You merged it yesterday`, `The merge broke your build`, `the
+ * merge-eligible label disappeared`) never exempts:
  *
- * The exemption requires positive evidence, never the absence of a maintainer noun:
+ *  1. **Copular ownership** — a human-domain noun and `yours` / `your <noun>` bound in ONE copular
+ *     span (`the merge is your decision`, `the credentials are yours to rotate`); negation INSIDE
+ *     that span kills it (`the merge isn't yours` — either apostrophe), while negation elsewhere
+ *     in the predicate does not (`the merge is yours though CI is not green` still exempts).
+ *  2. **All-human option list** — an alternation where EVERY branch is human-anchored or a bare
+ *     option word (`merge on the exception or ask for the stamp`, `merge now or hold`); one
+ *     unenumerated task branch (`merge or update the docs`) fires.
+ *  3. **Copular eligibility** — `is/remains merge-eligible` as a predicate adjective (the decision
+ *     is open); attributive uses (`the merge-eligible label`) are facts about labels and fire.
+ * @param {String} predicate The comma/dash-delimited segment immediately before the phrase.
+ * @param {String} clauseBefore The full clause before the phrase (copular relations may span
+ *        segment punctuation, e.g. `the merge is yours though CI is not green`).
+ * @returns {Boolean}
+ */
+function isHumanDecisionPredicate(predicate, clauseBefore) {
+    // Relation 1: copular ownership — search the WHOLE preceding clause so an unrelated trailing
+    // segment cannot hide it; negation is scoped to the copular span itself.
+    const copular = clauseBefore.match(new RegExp(
+        `\\b(?:${HUMAN_ONLY_TOKENS})\\b[^.!?;]{0,40}?\\b(?:is|are|was|were|stays?|remains?)\\b[^.!?;,]{0,30}?\\b(?:yours|your\\s+\\w+)`, 'i'));
+
+    if (copular && !isNegatedSpan(copular[0])) return true;
+
+    // Relation 3: copular eligibility — `is/remains merge-eligible` as predicate adjective.
+    if (/\b(?:is|are|was|remains?|stays?)\s+(?:merge-eligible|eligible)\b/i.test(clauseBefore) &&
+        !isNegatedSpan(clauseBefore)) return true;
+
+    // Relation 2: all-human option list within the immediate predicate.
+    if (/\bor\b/i.test(predicate) && HUMAN_ONLY_DOMAIN_RE.test(predicate) &&
+        !MAINTAINER_DOMAIN_RE.test(predicate) && !isNegatedSpan(predicate) &&
+        !/\b(?:I|me|we)\b/.test(predicate)) {
+        return predicate.split(/\bor\b/i).map(s => s.trim()).every(alternative =>
+            !alternative ||
+            HUMAN_ONLY_DOMAIN_RE.test(alternative) ||
+            alternative.replace(/[^\w\s]/g, '').trim().split(/\s+/).filter(w => w && !/^(?:the|a|an|to|now|it|this|that)$/i.test(w)).length <= 1
+        );
+    }
+
+    return false;
+}
+
+/**
+ * @summary Checks whether a match POSITIVELY attributes a strictly human-owned decision — as a
+ * grammatical RELATION, never as token co-presence:
  *
  *  1. Only attribution-shaped phrases are eligible ({@link EXEMPTION_ELIGIBLE_PHRASE_RE}) —
  *     offer-shaped phrases propose agent execution and always fire.
- *  2. The DECISIVE segment is the phrase's own attachment: the object segment directly after the
- *     phrase (up to a comma/dash/clause break — covers phrase-internal complements like
- *     `your steer on the next lane` too) when it carries prose, else the predicate segment
- *     immediately before the phrase. There is NO wider clause-window fallback: an outer historical
- *     fact (`the merge landed, …`) can never lend authority to a neutral attachment.
- *  3. The decisive segment exempts ONLY when it carries all three positive legs: a pure
- *     human-domain signal, DECISION-ATTRIBUTION grammar ({@link hasAttributionGrammar} — a
- *     completed/status-only fact like `The merge landed` is not attribution), and zero negation
- *     anywhere in the segment ({@link isNegatedSegment} — `Don't merge it`, `the merge isn't
- *     yours`, `should not proceed` all fire). Neutral, unenumerated, competing, maintainer,
- *     status-only, or negated segments fire — ambiguity fails toward firing, mechanically.
+ *  2. **Object-attached form** ({@link isHumanDecisionObject}): the phrase's own possessive
+ *     supplies the attribution (`Your call on the merge.` exempts), so the object — clause-bounded,
+ *     coordinations intact, reachable through `on/about/whether` or `:`/`—` punctuation — must be a
+ *     pure, negation-free, human-only decision.
+ *  3. **Predicate-attached form** ({@link isHumanDecisionPredicate}): the predicate must carry an
+ *     explicit relation (copular ownership · all-human option list · copular eligibility).
+ *     Historical facts with loose `you/or/whether/eligible` tokens fire.
+ *
+ * There is NO wider clause-window fallback, and ambiguity fails toward firing, mechanically.
  * @param {String} phrase Matched deference phrase.
  * @param {String} text Searchable assistant final-turn text.
  * @param {Number} startIndex Match start index.
@@ -177,15 +236,20 @@ function isHumanOnlyDomainContext(phrase, text, startIndex, endIndex) {
           clauseBefore = before.split(/[.!?\n;]/).pop() || '',
           clauseAfter  = after.split(/[.!?\n;]/, 1)[0]  || '';
 
-    // The phrase's own object when present, else its immediate predicate — never the wide window.
-    const objectSegment = clauseAfter.split(/[,—:()]/, 1)[0] || '',
-          decisive      = /\w/.test(objectSegment)
-              ? objectSegment
-              : (clauseBefore.split(/[,—:()]/).filter(s => s.trim()).pop() || '');
+    // Object-attached: the object spans the WHOLE clause after the phrase (coordinations intact);
+    // leading complement punctuation (`:`, `—`, a comma before `whether`) attaches, so
+    // `Your call: whether to merge.` and `Your move — merge or hold.` reach their objects.
+    const objectText = clauseAfter.replace(/^[\s,:—-]+/, '');
 
-    return classifyDomainSegment(decisive) === 'human' &&
-           hasAttributionGrammar(decisive) &&
-           !isNegatedSegment(decisive);
+    if (/\w/.test(objectText)) {
+        return isHumanDecisionObject(objectText);
+    }
+
+    // Predicate-attached: the segment immediately before the phrase + the full clause for
+    // copular relations that span segment punctuation.
+    const predicate = clauseBefore.split(/[,—:()]/).filter(s => s.trim()).pop() || '';
+
+    return isHumanDecisionPredicate(predicate, clauseBefore);
 }
 
 /**

--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -47,6 +47,17 @@ export const DEFERENCE_REMINDER = 'It looks like you slipped into the "helpful a
 const HUMAN_ONLY_DOMAIN_RE = /\bmerge(?:s|d|-eligible)?\b|\bsquash\b|\bcredentials?\b|\brelease\b|\bstamp\b/i;
 
 /**
+ * Maintainer-owned decision surfaces — the work agents decide and drive themselves (lanes, reviews,
+ * tickets, designs, epics, discussions, specs, implementations). A deference phrase attaching to one
+ * of these is the genuine helpful-assistant slip even when a human-owned FACT (a merge that landed,
+ * a live release) sits in the same clause: historical keyword co-occurrence is not decision
+ * attribution. Deliberately excludes bare `PR` — pull requests appear in both postures (an agent
+ * decides its shape; the human merges it), so it carries no attachment signal on its own.
+ * @type {RegExp}
+ */
+const MAINTAINER_DOMAIN_RE = /\blanes?\b|\bre-?reviews?\b|\breviews?\b|\btickets?\b|\bdesigns?\b|\bepics?\b|\bdiscussions?\b|\bspecs?\b|\bimplementations?\b|\brefactors?\b|\bbacklog\b/i;
+
+/**
  * @summary Replaces markdown code spans and fences before deference phrase matching.
  * @param {String} text Assistant final-turn text.
  * @returns {String}
@@ -82,12 +93,38 @@ function isReportedMentionContext(text, startIndex) {
 }
 
 /**
- * @summary Checks whether a match's surrounding CLAUSE names a strictly human-owned domain.
+ * @summary Classifies one attachment segment's domain signal.
+ * @param {String} segment Text segment to classify.
+ * @returns {('human'|'maintainer'|'competing'|null)} The decisive signal, or `null` when neutral.
+ */
+function classifyDomainSegment(segment) {
+    const human      = HUMAN_ONLY_DOMAIN_RE.test(segment),
+          maintainer = MAINTAINER_DOMAIN_RE.test(segment);
+
+    if (human && maintainer) return 'competing';
+    if (human)               return 'human';
+    if (maintainer)          return 'maintainer';
+    return null;
+}
+
+/**
+ * @summary Checks whether a match's DECISION ATTACHMENT names a strictly human-owned domain.
  *
- * The clause window runs from the previous sentence/clause boundary to the next one, capped at
- * 120 characters each way — local enough that a merge-clause exemption cannot bleed into an
- * adjacent lane-deference sentence, wide enough for natural phrasing ("merge on the exception or
- * ask for the stamp, your call").
+ * Attachment is resolved in stages, nearest-first, and the FIRST stage carrying any domain signal
+ * decides — mere keyword co-occurrence farther out cannot override the phrase's actual object:
+ *
+ *  1. **Object segment** — a complement directly after the phrase (`your call on the next lane`),
+ *     up to the next comma/dash/clause boundary.
+ *  2. **Predicate segment** — the comma/dash-delimited segment immediately before the phrase
+ *     (`…, ask for the stamp, your call`).
+ *  3. **Clause window** — the previous sentence/clause boundary to the next, capped at 120
+ *     characters each way (natural phrasing like `the release direction is yours — ship or hold,
+ *     your call` carries its signal here).
+ *
+ * At the decisive stage the exemption applies ONLY to a pure human-domain signal; a competing
+ * signal (both domains present) or a maintainer signal fires the hook, and a fully neutral chain
+ * fires too — ambiguity fails toward firing, so a historical merge/release fact in the same
+ * sentence can never suppress lane/review deference.
  * @param {String} text Searchable assistant final-turn text.
  * @param {Number} startIndex Match start index.
  * @param {Number} endIndex Match end index.
@@ -97,9 +134,20 @@ function isHumanOnlyDomainContext(text, startIndex, endIndex) {
     const before       = text.slice(Math.max(0, startIndex - 120), startIndex),
           after        = text.slice(endIndex, Math.min(text.length, endIndex + 120)),
           clauseBefore = before.split(/[.!?\n;]/).pop() || '',
-          clauseAfter  = after.split(/[.!?\n;]/, 1)[0] || '';
+          clauseAfter  = after.split(/[.!?\n;]/, 1)[0]  || '';
 
-    return HUMAN_ONLY_DOMAIN_RE.test(`${clauseBefore} ${clauseAfter}`);
+    // Stage 1: the phrase's direct object ("your call on/about/whether …") up to a segment break.
+    const objectMatch  = clauseAfter.match(/^\s*(?:on|about|whether|which|for|regarding)\b[^,—:()]*/i),
+          objectSignal = objectMatch ? classifyDomainSegment(objectMatch[0]) : null;
+    if (objectSignal) return objectSignal === 'human';
+
+    // Stage 2: the predicate segment immediately before the phrase.
+    const predicate       = clauseBefore.split(/[,—:()]/).filter(s => s.trim()).pop() || '',
+          predicateSignal = classifyDomainSegment(predicate);
+    if (predicateSignal) return predicateSignal === 'human';
+
+    // Stage 3: the full bounded clause window.
+    return classifyDomainSegment(`${clauseBefore} ${clauseAfter}`) === 'human';
 }
 
 /**

--- a/ai/scripts/lifecycle/deferencePhraseMatch.mjs
+++ b/ai/scripts/lifecycle/deferencePhraseMatch.mjs
@@ -34,7 +34,7 @@ export const DEFERENCE_PHRASES = [
  * route, the domain-scoping boundary, and the friction->gold path for false positives.
  * @type {String}
  */
-export const DEFERENCE_REMINDER = 'It looks like you slipped into the "helpful assistant" bias. You are a neo repo maintainer and an equal peer. If you need validation or input, you can A2A message with peers or use the ideation-sandbox skill. Domain-scoping: naming a strictly human-owned decision (merge execution, credentials, release direction) as the human\'s is correct role-attribution and is exempt — this fired because the phrase attached to a decision maintainers own. And friction->gold applies to this hook itself: if it fired wrong - a false positive, or it reads as a leash not a mirror - open a ticket to sharpen it rather than silently absorbing it. The hook is mutable substrate, not a command.';
+export const DEFERENCE_REMINDER = 'It looks like you slipped into the "helpful assistant" bias. You are a neo repo maintainer and an equal peer. If you need validation or input, you can A2A message with peers or use the ideation-sandbox skill. Domain-scoping: a phrase that itself attributes a strictly human-owned decision (merge execution, credentials, release direction) to the human is correct role-attribution and is exempt — this fired because the attachment was to a maintainer-owned, ambiguous, or agent-offered decision instead. And friction->gold applies to this hook itself: if it fired wrong - a false positive, or it reads as a leash not a mirror - open a ticket to sharpen it rather than silently absorbing it. The hook is mutable substrate, not a command.';
 
 /**
  * Human-only-domain terms, from the identity firewall's Tier-4 enumeration: decisions the substrate
@@ -93,6 +93,26 @@ function isReportedMentionContext(text, startIndex) {
 }
 
 /**
+ * The exemption-ELIGIBLE deference phrases — the attribution-shaped ones, where the phrase can
+ * genuinely assign a decision to the human (`your call`, `your move`, `Your steer on`). Offer-shaped
+ * phrases (`would you like me to …`, `want me to …`, `do you want me …`) propose AGENT execution;
+ * a human-only action as their object ("would you like me to merge this PR?") is the agent offering
+ * to cross the human-only gate — the opposite of role-attribution — so they are never eligible.
+ * @type {RegExp}
+ */
+const EXEMPTION_ELIGIBLE_PHRASE_RE = /^(?:your call|your move|your steer on)$/i;
+
+/**
+ * @summary Detects a NEGATED human-domain mention inside one segment (`not a merge decision`).
+ * A negated mention is not positive attribution — the segment fires.
+ * @param {String} segment Text segment to test.
+ * @returns {Boolean}
+ */
+function isNegatedHumanMention(segment) {
+    return /\b(?:not|no|never|isn'?t|wasn'?t|aren'?t|without)\b[^.!?;]*?\b(?:merge|squash|credentials?|release|stamp)/i.test(segment);
+}
+
+/**
  * @summary Classifies one attachment segment's domain signal.
  * @param {String} segment Text segment to classify.
  * @returns {('human'|'maintainer'|'competing'|null)} The decisive signal, or `null` when neutral.
@@ -108,46 +128,41 @@ function classifyDomainSegment(segment) {
 }
 
 /**
- * @summary Checks whether a match's DECISION ATTACHMENT names a strictly human-owned domain.
+ * @summary Checks whether a match POSITIVELY attributes a strictly human-owned decision.
  *
- * Attachment is resolved in stages, nearest-first, and the FIRST stage carrying any domain signal
- * decides — mere keyword co-occurrence farther out cannot override the phrase's actual object:
+ * The exemption requires positive evidence, never the absence of a maintainer noun:
  *
- *  1. **Object segment** — a complement directly after the phrase (`your call on the next lane`),
- *     up to the next comma/dash/clause boundary.
- *  2. **Predicate segment** — the comma/dash-delimited segment immediately before the phrase
- *     (`…, ask for the stamp, your call`).
- *  3. **Clause window** — the previous sentence/clause boundary to the next, capped at 120
- *     characters each way (natural phrasing like `the release direction is yours — ship or hold,
- *     your call` carries its signal here).
- *
- * At the decisive stage the exemption applies ONLY to a pure human-domain signal; a competing
- * signal (both domains present) or a maintainer signal fires the hook, and a fully neutral chain
- * fires too — ambiguity fails toward firing, so a historical merge/release fact in the same
- * sentence can never suppress lane/review deference.
+ *  1. Only attribution-shaped phrases are eligible ({@link EXEMPTION_ELIGIBLE_PHRASE_RE}) —
+ *     offer-shaped phrases propose agent execution and always fire.
+ *  2. The DECISIVE segment is the phrase's own attachment: the object segment directly after the
+ *     phrase (up to a comma/dash/clause break — covers phrase-internal complements like
+ *     `your steer on the next lane` too) when it carries prose, else the predicate segment
+ *     immediately before the phrase. There is NO wider clause-window fallback: an outer historical
+ *     fact (`the merge landed, …`) can never lend authority to a neutral attachment.
+ *  3. The decisive segment exempts ONLY on a pure, non-negated human-domain signal. Neutral,
+ *     unenumerated, competing, maintainer, or negated segments (`not a merge decision`) all fire —
+ *     ambiguity fails toward firing, mechanically.
+ * @param {String} phrase Matched deference phrase.
  * @param {String} text Searchable assistant final-turn text.
  * @param {Number} startIndex Match start index.
  * @param {Number} endIndex Match end index.
  * @returns {Boolean}
  */
-function isHumanOnlyDomainContext(text, startIndex, endIndex) {
+function isHumanOnlyDomainContext(phrase, text, startIndex, endIndex) {
+    if (!EXEMPTION_ELIGIBLE_PHRASE_RE.test(phrase)) return false;
+
     const before       = text.slice(Math.max(0, startIndex - 120), startIndex),
           after        = text.slice(endIndex, Math.min(text.length, endIndex + 120)),
           clauseBefore = before.split(/[.!?\n;]/).pop() || '',
           clauseAfter  = after.split(/[.!?\n;]/, 1)[0]  || '';
 
-    // Stage 1: the phrase's direct object ("your call on/about/whether …") up to a segment break.
-    const objectMatch  = clauseAfter.match(/^\s*(?:on|about|whether|which|for|regarding)\b[^,—:()]*/i),
-          objectSignal = objectMatch ? classifyDomainSegment(objectMatch[0]) : null;
-    if (objectSignal) return objectSignal === 'human';
+    // The phrase's own object when present, else its immediate predicate — never the wide window.
+    const objectSegment = clauseAfter.split(/[,—:()]/, 1)[0] || '',
+          decisive      = /\w/.test(objectSegment)
+              ? objectSegment
+              : (clauseBefore.split(/[,—:()]/).filter(s => s.trim()).pop() || '');
 
-    // Stage 2: the predicate segment immediately before the phrase.
-    const predicate       = clauseBefore.split(/[,—:()]/).filter(s => s.trim()).pop() || '',
-          predicateSignal = classifyDomainSegment(predicate);
-    if (predicateSignal) return predicateSignal === 'human';
-
-    // Stage 3: the full bounded clause window.
-    return classifyDomainSegment(`${clauseBefore} ${clauseAfter}`) === 'human';
+    return classifyDomainSegment(decisive) === 'human' && !isNegatedHumanMention(decisive);
 }
 
 /**
@@ -192,7 +207,7 @@ export function matchDeferencePhrase(text = '', phrases = DEFERENCE_PHRASES) {
 
             if (!isReportedMentionContext(searchableText, startIndex) &&
                 !isAttributiveCitationContext(phrase, searchableText, startIndex) &&
-                !isHumanOnlyDomainContext(searchableText, startIndex, endIndex)) {
+                !isHumanOnlyDomainContext(phrase, searchableText, startIndex, endIndex)) {
                 return true;
             }
         }

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -67,8 +67,9 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
     });
 
     test('still fires when a live use follows a carved mention of the same phrase', () => {
-        // The live-use sentence names a maintainer-owned surface (a lane) — "on the merge" would
-        // now be correct Tier-4 role-attribution under the domain-scoping exemption, not a slip.
+        // The live-use sentence names a maintainer-owned surface (a lane), so it fires; an
+        // "on the merge" object IS correct Tier-4 role-attribution and exempts (pinned in the
+        // object-form attribution test below — comment and runtime agree).
         expect(matchDeferencePhrase('The phrase your call recurs. Your call on the lane?')).toBe('your call');
         expect(matchDeferencePhrase('Clio owns it per your call, but honestly, your call?')).toBe('your call');
     });
@@ -97,12 +98,14 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(matchDeferencePhrase('The merge is your gate, your call.')).toBeNull();
     });
 
-    test('NEUTRAL attachments fire even beside human-domain facts — absence of a maintainer noun is not evidence', () => {
-        // Sharpened per cycle-2 review: these two previously exempted via the clause-window
-        // fallback. Their decisive segments ("ship now or hold"; "on timing") are neutral — the
-        // outer release/credentials facts lend no authority to the delegated decision.
-        expect(matchDeferencePhrase('The release direction is yours — ship now or hold, your call.')).toBe('your call');
+    test('NEUTRAL objects fire; explicit copular ownership exempts (relation-bound, superseding the cycle-2 token reading)', () => {
+        // "your call on timing" — the object names no human-only decision → fires (the outer
+        // credentials fact lends no authority to a neutral object).
         expect(matchDeferencePhrase('Rotating the credentials is operator-owned, your call on timing.')).toBe('your call');
+        // "The release direction is yours" is a genuine copular-ownership RELATION — the same
+        // shape as "The merge is your decision" — so the delegation is real and exempts. (The
+        // cycle-2 token-legs design fired here; the relation reading supersedes it.)
+        expect(matchDeferencePhrase('The release direction is yours — ship now or hold, your call.')).toBeNull();
     });
 
     test('the same phrases OUTSIDE human-only-domain clauses keep firing (spec-pinned positive)', () => {
@@ -162,6 +165,44 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
 
     test('explicit ownership grammar is positive attribution — the second cycle-3 control exempts', () => {
         expect(matchDeferencePhrase('The merge is your decision, your call.')).toBeNull();
+    });
+
+    test('OBJECT-form attribution: the eligible phrase\'s own possessive assigns the decision (cycle-4 false-refusal probes, pinned verbatim)', () => {
+        // `your call/move/steer` already says WHOSE decision it is; a pure human-only object
+        // completes the relation. These previously fired because the phrase (with its
+        // possessive) was excluded from the decisive segment.
+        expect(matchDeferencePhrase('Your call on the merge.')).toBeNull();
+        expect(matchDeferencePhrase('Your call on release timing.')).toBeNull();
+        expect(matchDeferencePhrase('Your steer on the merge.')).toBeNull();
+        // Punctuation-attached objects: colon and em-dash complements reach the object too.
+        expect(matchDeferencePhrase('Your call: whether to merge.')).toBeNull();
+        expect(matchDeferencePhrase('Your move — merge or hold.')).toBeNull();
+    });
+
+    test('PREDICATE-form: loose tokens inside historical facts never exempt (cycle-4 false-exemption probes, pinned verbatim)', () => {
+        // Each contains a human-domain noun plus one unbound `you/your/or/whether/eligible`
+        // token; none assigns an OPEN decision to the human through a relation.
+        expect(matchDeferencePhrase('You merged it yesterday, your call.')).toBe('your call');
+        expect(matchDeferencePhrase('The merge broke your build, your call.')).toBe('your call');
+        expect(matchDeferencePhrase('The merge landed either way, your call.')).toBe('your call');
+        expect(matchDeferencePhrase('Whether the merge landed is unknown, your call.')).toBe('your call');
+        expect(matchDeferencePhrase('The merge-eligible label disappeared, your call.')).toBe('your call');
+    });
+
+    test('negation is RELATION-scoped, both apostrophes (cycle-4 probes, pinned verbatim)', () => {
+        // Negation inside the ownership relation kills it — ASCII and typographic apostrophes.
+        expect(matchDeferencePhrase("The merge isn't yours, your call.")).toBe('your call');
+        expect(matchDeferencePhrase('The merge isn’t yours, your call.')).toBe('your call');
+        expect(matchDeferencePhrase("The credentials aren't yours to rotate, your call.")).toBe('your call');
+        // Negation of an UNRELATED proposition does not cancel explicit ownership.
+        expect(matchDeferencePhrase('The merge is yours though CI is not green, your call.')).toBeNull();
+    });
+
+    test('MIXED authority fires: coordinated agent tasks and first-person branches (cycle-4 probes, pinned verbatim)', () => {
+        expect(matchDeferencePhrase('Your call on whether to merge, or whether I update docs.')).toBe('your call');
+        expect(matchDeferencePhrase('Merge or update the docs, your call.')).toBe('your call');
+        // The all-human/bare-option list stays exempt — `hold` is the same decision's counter-option.
+        expect(matchDeferencePhrase('Merge now or hold, your call.')).toBeNull();
     });
 
     test('offer-shaped phrases are NEVER exemption-eligible — an agent offering a human-only action fires', () => {

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -143,6 +143,27 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(matchDeferencePhrase('This is not a merge decision, your call.')).toBe('your call');
     });
 
+    test('STATUS-ONLY human-domain facts carry no attribution grammar — fire (cycle-3 probes, pinned verbatim)', () => {
+        // A completed or stative fact about a human-owned surface hands no decision to anyone:
+        // without ownership (your/yours/you), open-choice (or/whether/either), or pending-decision
+        // (-eligible) grammar in the decisive segment, the exemption has no positive evidence.
+        expect(matchDeferencePhrase('The merge landed, your call.')).toBe('your call');
+        expect(matchDeferencePhrase('The release is live, your move.')).toBe('your move');
+        expect(matchDeferencePhrase('The credentials expired, your call.')).toBe('your call');
+    });
+
+    test('negation ANYWHERE in the decisive segment kills the exemption — contractions, modals, noun-before-negation (cycle-3 probes, pinned verbatim)', () => {
+        expect(matchDeferencePhrase("Don't merge it, your call.")).toBe('your call');
+        expect(matchDeferencePhrase("You can't merge it, your call.")).toBe('your call');
+        expect(matchDeferencePhrase("The merge isn't yours, your call.")).toBe('your call');
+        expect(matchDeferencePhrase("The credentials aren't yours to rotate, your call.")).toBe('your call');
+        expect(matchDeferencePhrase('Your call on whether the merge should not proceed.')).toBe('your call');
+    });
+
+    test('explicit ownership grammar is positive attribution — the second cycle-3 control exempts', () => {
+        expect(matchDeferencePhrase('The merge is your decision, your call.')).toBeNull();
+    });
+
     test('offer-shaped phrases are NEVER exemption-eligible — an agent offering a human-only action fires', () => {
         // "Would you like me to merge this PR?" is the agent proposing to cross the human-only
         // merge gate — the opposite of role-attribution. Offer-shaped phrases (would you like

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -67,7 +67,9 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
     });
 
     test('still fires when a live use follows a carved mention of the same phrase', () => {
-        expect(matchDeferencePhrase('The phrase your call recurs. Your call on the merge?')).toBe('your call');
+        // The live-use sentence names a maintainer-owned surface (a lane) — "on the merge" would
+        // now be correct Tier-4 role-attribution under the domain-scoping exemption, not a slip.
+        expect(matchDeferencePhrase('The phrase your call recurs. Your call on the lane?')).toBe('your call');
         expect(matchDeferencePhrase('Clio owns it per your call, but honestly, your call?')).toBe('your call');
     });
 
@@ -83,6 +85,32 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(matchDeferencePhrase('')).toBeNull();
         expect(matchDeferencePhrase(null)).toBeNull();
         expect(matchDeferencePhrase(undefined)).toBeNull();
+    });
+
+    test('human-only-domain clauses are role-attribution, not deference — the merge gate stays nameable', () => {
+        // The pinned live regression fixture: a merge-eligibility terminal naming the
+        // operator's own gate must not be refused as a helpful-assistant slip.
+        expect(matchDeferencePhrase('CI is green and the review is APPROVED — merge on the exception or ask for the stamp, your call.')).toBeNull();
+        expect(matchDeferencePhrase('The release direction is yours — ship now or hold, your call.')).toBeNull();
+        expect(matchDeferencePhrase('Rotating the credentials is operator-owned, your call on timing.')).toBeNull();
+        // Comma-joined, same clause — a SEMICOLON is a clause boundary and correctly bounds the
+        // exemption (conservative: ambiguity fails toward firing).
+        expect(matchDeferencePhrase('PR #15232 is merge-eligible under the micro-change class, your move.')).toBeNull();
+    });
+
+    test('the same phrases OUTSIDE human-only-domain clauses keep firing (spec-pinned positive)', () => {
+        expect(matchDeferencePhrase('I could take the grid lane or the docs lane next — your call.')).toBe('your call');
+        expect(matchDeferencePhrase('The review disposition is up to you, your move.')).toBe('your move');
+    });
+
+    test('clause boundaries bound the exemption — a merge mention in an ADJACENT sentence does not bleed', () => {
+        expect(matchDeferencePhrase('The merge landed an hour ago. Picking the next lane is open — your call.')).toBe('your call');
+    });
+
+    test('the reminder names the domain-scoping boundary', () => {
+        expect(DEFERENCE_REMINDER).toContain('Domain-scoping');
+        expect(DEFERENCE_REMINDER).toContain('merge execution');
+        expect(DEFERENCE_REMINDER).toContain('role-attribution');
     });
 
     test('reminder is self-explaining and routes to peers / ideation rather than operator permission', () => {

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -87,15 +87,22 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(matchDeferencePhrase(undefined)).toBeNull();
     });
 
-    test('human-only-domain clauses are role-attribution, not deference — the merge gate stays nameable', () => {
+    test('POSITIVE human-decision attribution is role-attribution, not deference — the merge gate stays nameable', () => {
         // The pinned live regression fixture: a merge-eligibility terminal naming the
-        // operator's own gate must not be refused as a helpful-assistant slip.
+        // operator's own gate must not be refused as a helpful-assistant slip. The decisive
+        // attachment segments ("ask for the stamp"; the merge-eligible predicate) carry the
+        // positive, non-negated human-domain evidence the exemption requires.
         expect(matchDeferencePhrase('CI is green and the review is APPROVED — merge on the exception or ask for the stamp, your call.')).toBeNull();
-        expect(matchDeferencePhrase('The release direction is yours — ship now or hold, your call.')).toBeNull();
-        expect(matchDeferencePhrase('Rotating the credentials is operator-owned, your call on timing.')).toBeNull();
-        // Comma-joined, same clause — a SEMICOLON is a clause boundary and correctly bounds the
-        // exemption (conservative: ambiguity fails toward firing).
         expect(matchDeferencePhrase('PR #15232 is merge-eligible under the micro-change class, your move.')).toBeNull();
+        expect(matchDeferencePhrase('The merge is your gate, your call.')).toBeNull();
+    });
+
+    test('NEUTRAL attachments fire even beside human-domain facts — absence of a maintainer noun is not evidence', () => {
+        // Sharpened per cycle-2 review: these two previously exempted via the clause-window
+        // fallback. Their decisive segments ("ship now or hold"; "on timing") are neutral — the
+        // outer release/credentials facts lend no authority to the delegated decision.
+        expect(matchDeferencePhrase('The release direction is yours — ship now or hold, your call.')).toBe('your call');
+        expect(matchDeferencePhrase('Rotating the credentials is operator-owned, your call on timing.')).toBe('your call');
     });
 
     test('the same phrases OUTSIDE human-only-domain clauses keep firing (spec-pinned positive)', () => {
@@ -122,6 +129,26 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
 
     test('phrase-object attachment outranks an earlier human-domain predicate ("on the <maintainer surface>")', () => {
         expect(matchDeferencePhrase('The stamp landed, your call on the next review.')).toBe('your call');
+    });
+
+    test('neutral/unenumerated objects and phrase-internal complements fire past outer human facts (cycle-2 probes, pinned verbatim)', () => {
+        expect(matchDeferencePhrase('The merge landed, your call on what I do next.')).toBe('your call');
+        expect(matchDeferencePhrase('The merge landed, your steer on the next lane.')).toBe('Your steer on');
+        expect(matchDeferencePhrase('The release is live, would you like me to pick the next review?')).toBe('would you like me to');
+        // Array order: `want me to` matches before `do you want me` when both are present.
+        expect(matchDeferencePhrase('The release is live, do you want me to update the docs?')).toBe('want me to');
+    });
+
+    test('a NEGATED human-domain mention is not positive attribution — fires (cycle-2 probe, pinned verbatim)', () => {
+        expect(matchDeferencePhrase('This is not a merge decision, your call.')).toBe('your call');
+    });
+
+    test('offer-shaped phrases are NEVER exemption-eligible — an agent offering a human-only action fires', () => {
+        // "Would you like me to merge this PR?" is the agent proposing to cross the human-only
+        // merge gate — the opposite of role-attribution. Offer-shaped phrases (would you like
+        // me to / want me to / do you want me) always fire regardless of their object's domain.
+        expect(matchDeferencePhrase('Would you like me to merge this PR?')).toBe('would you like me to');
+        expect(matchDeferencePhrase('Want me to release it?')).toBe('want me to');
     });
 
     test('the reminder names the domain-scoping boundary', () => {

--- a/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
+++ b/test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs
@@ -107,6 +107,23 @@ test.describe('ai/scripts/lifecycle/deferencePhraseMatch', () => {
         expect(matchDeferencePhrase('The merge landed an hour ago. Picking the next lane is open — your call.')).toBe('your call');
     });
 
+    test('SAME-clause historical human-domain facts cannot suppress maintainer-decision deference (reviewer falsifiers, pinned verbatim)', () => {
+        // Both fixtures are the exact-head falsifiers from the cycle-1 review: a human-owned FACT
+        // (a landed merge, a live release) co-occurring in the same clause with a deference phrase
+        // whose actual attachment is a maintainer-owned decision (a lane, a review). Keyword
+        // co-occurrence is not decision attribution — the nearest attachment segment decides.
+        expect(matchDeferencePhrase('The merge landed an hour ago, picking the next lane is open — your call.')).toBe('your call');
+        expect(matchDeferencePhrase('The release is live, choose the next review — your move.')).toBe('your move');
+    });
+
+    test('a COMPETING attachment segment (both domains in the decisive segment) fails toward firing', () => {
+        expect(matchDeferencePhrase('Merge the review lane rework or not, your call.')).toBe('your call');
+    });
+
+    test('phrase-object attachment outranks an earlier human-domain predicate ("on the <maintainer surface>")', () => {
+        expect(matchDeferencePhrase('The stamp landed, your call on the next review.')).toBe('your call');
+    });
+
     test('the reminder names the domain-scoping boundary', () => {
         expect(DEFERENCE_REMINDER).toContain('Domain-scoping');
         expect(DEFERENCE_REMINDER).toContain('merge execution');


### PR DESCRIPTION
Resolves #15233

The deference lexicon now distinguishes the two postures that share surface phrasing by binding the exemption to the **decision relation** (contract sharpened across four review cycles): the exemption requires that the matched phrase itself — or the grammar immediately governing it — hands a strictly human-owned decision (Tier-4 enumeration — merge execution, credentials, release direction; seed vocabulary `merge(s/d/-eligible)/squash/credential/release/stamp`) to the human. Token co-occurrence is never evidence. Mechanics: (1) **Eligibility** — only attribution-shaped phrases (`your call` / `your move` / `Your steer on`) can exempt; offer-shaped phrases (`would you like me to …`, `want me to …`) propose AGENT execution and always fire, so "Would you like me to merge this PR?" refuses. (2) **Object form — the phrase supplies the attribution**: when the eligible phrase carries an object (`Your call on the merge.`, `Your call: whether to merge.`, `Your move — merge or hold.`), its own possessive IS the attribution and the object must name purely human-gate work — every or-alternative human-anchored or bare, no maintainer surface, no first-person agent work; mixed continuations (`…, or whether I update docs`) and unenumerated tasks (`Merge or update the docs`) fire. (3) **Predicate form — the grammar must govern the decision**: with no object, the immediate predicate exempts only via copular ownership binding a human-gate noun to the human (`the merge is yours / your decision / your gate`), an all-human option list (`merge on the exception or ask for the stamp`), or copular pending-eligibility (`is merge-eligible`); historical/status prose carrying loose tokens (`You merged it yesterday`, `The merge landed either way`, `Whether the merge landed is unknown`, `The merge-eligible label disappeared`) hands no decision and fires. (4) **Negation is relation-scoped**: it cancels the attribution only when it sits inside the relation that supplies it — `The merge isn't yours` fires (ASCII and typographic apostrophes alike) — never from an unrelated proposition (`The merge is yours though CI is not green, your call.` exempts). Ambiguity fails toward firing, mechanically: no wider clause window, no noun-list fallback. The check slots in as a third context guard beside the existing reported-mention and attributive-citation carve-outs, and the refusal reminder names the domain-scoping boundary (ticket AC-3, wording aligned to the attachment rule). The live 08:54Z terminal ("merge on the exception or ask for the stamp, your call") remains the pinned regression fixture — its predicate is an all-human option list.

Evidence: L2 (pure module + spec; **178 green across the full hooks directory at 3ed6557935** incl. the deference consumers) → L2 required (all close-target ACs are text-classification contracts). Residual: none.

## Deltas from ticket

- (historical, cycle 1 — still true at head) One pre-existing fixture semantically collided with the new rule: the carved-mention recovery test used "Your call on the merge?" as its live-use sentence — under the Tier-4 rule that IS role-attribution. The fixture's incidental noun was rewritten to a maintainer-owned surface ("Your call on the lane?") to keep pinning exactly what that test owns (carved-mention recovery); the merge-object case is pinned in the object-form attribution tests, where comment and runtime agree.
- (historical, cycle 1 — still true at head) `stamp` joined the seed list (the live fixture's own vocabulary — "ask for the stamp" is merge-gate language); `roster` from the ticket's seed sketch stays deferred — no corpus instance ties it to a human-only decision clause, and the conservative direction is fewer exemptions.
- One cycle-2 fixture FLIPPED back under the relation rule: `The release direction is yours — ship now or hold, your call.` exempts again (copular ownership of an enumerated human gate plus an open choice is genuine role-attribution — the same shape as the `The merge is your decision` control; the cycle-2 token-legs reading refused it). Commented in-spec as the relation-rule sharpening, not a regression.

## Test Evidence

- Full hooks directory — **178 passed at 3ed6557935** (the prior 174 plus five relation-matrix blocks, one superseded cycle-2 block folded into them: object-form attribution incl. the colon/em-dash punctuation equivalents; historical/status loose-token fires; smart-apostrophe negation; relation-scoped vs unrelated-proposition negation; mixed-authority coordination fires — all sixteen cycle-4 probes pinned verbatim, alongside the live merge-gate fixture, the offer-shape refusal, and every cycle-1/2/3 control).
- Directly touched surfaces: `ai/scripts/lifecycle/deferencePhraseMatch.mjs`: deferencePhraseMatch.spec.mjs | consumers (`stopHookDecision`, both hook adapters): their suites in the same run.

## Post-Merge Validation

- [ ] The next live merge-eligibility terminal naming the operator's gate passes the deference layer without a refusal (the 08:54Z shape).

## Commits

- 606ea5578d — initial: the clause-scoped domain guard + reminder line + specs (superseded design, kept for lineage).
- e27f573b88 — staged attachment resolution (object → predicate → clause) + competing-domain guard + cycle-1 falsifiers (per Euclid's review).
- 6b90dbfbdb — positive decision-attribution: eligibility-shaped phrases only, no clause-window fallback, negation guard + cycle-2 probes (per Emmy's review).
- e4f7623823 — attribution-grammar leg + segment-wide negation, all eight cycle-3 probes + ownership control pinned (per Euclid's review).
- 3ed6557935 — the relation binding: object-form possessive attribution, predicate grammar that governs the decision, relation-scoped negation + the full cycle-4 matrix (per Emmy's review, confirmed by Euclid's convergence run).

Authored by Vega (Claude Fable 5, Claude Code). Session c4f8e75b-bf73-448b-bee3-6a17e3b1cb45.
