### PR TITLE
feat(graph): retire era-owned flat facts from identityRoots — consumers onto the hydration index (#14750)

### DIFF
--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -4,11 +4,13 @@
  * This shared list provides the definitive addressable identity surface for the A2A Mailbox
  * substrate.
  *
- * Capability fields (`contextWindowInput`, `hosting`, `tier`, etc.) mirror the Model-Stats
- * Framework. Source-cited values mirror `learn/agentos/ModelStats.md`; the registry is the
- * canonical authority for capability-data drift detection. `trustTier` is the content
- * provenance taxonomy used by Memory Core consumers to distinguish system, owner, peer-trusted,
- * external, and unclassified authorship at ingestion/query boundaries.
+ * Era-owned capability facts (`contextWindowInput`, `hosting`, `tier`, `thoughtBudget`,
+ * `parallelToolCalls`, `sunsetTriggers`, the `family` duplicate) are RETIRED from these entries:
+ * the epoch-pinned record lives in `identityRootsMigration.mjs` (`REGISTRY_SEED_FACTS`) and live
+ * facts come from the identity trail's era chain (`identityHydration.mjs`). Remaining
+ * source-cited fields mirror `learn/agentos/ModelStats.md` at the identity level. `trustTier` is
+ * the content provenance taxonomy used by Memory Core consumers to distinguish system, owner,
+ * peer-trusted, external, and unclassified authorship at ingestion/query boundaries.
  *
  * Identity-layer field mapping: the `id` / `githubLogin` pair is the OPERATIONAL identity
  * (auth, permissions, review history — never renamed); the top-level `name` is the SOCIAL
@@ -100,18 +102,12 @@ export const IDENTITIES = [
                     focusSeedKey: 'space'
                 }
             },
-            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
-            // §neo_opus — primary source: Anthropic Claude Opus 4.8 announcement/product page.
-            contextWindowInput: 1048576,
-            parallelToolCalls : true,
-            thoughtBudget     : 'max',
-            hosting           : 'cloud',
-            family            : 'claude',
-            tier              : 'frontier',
-            releaseDate       : '2026-05-28',
-            pricingInput      : 5.00,
-            pricingOutput     : 25.00,
-            sunsetTriggers    : ['Anthropic releases a successor Opus-class model with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
+            // Era-owned capability facts retired to the identity trail: the epoch-pinned record
+            // lives in identityRootsMigration's REGISTRY_SEED_FACTS; live facts come from the
+            // era chain. Remaining fields mirror ModelStats.md §neo_opus (identity-level).
+            releaseDate  : '2026-05-28',
+            pricingInput : 5.00,
+            pricingOutput: 25.00,
             // Active-peer quorum substrate. Family-keyed graduation quorum reads from
             // `participationStatus`; this structured field is authoritative.
             // Heartbeat / message-recency / quota / pricing-tier / model-release announcements are
@@ -141,18 +137,12 @@ export const IDENTITIES = [
             // No subscriptionTemplate yet: generalized same-app wake addressing is deferred
             // to the same-app wake-routing discussion. Do not encode instance-specific
             // filesystem paths here.
-            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
-            // §neo_claude_opus, which mirrors the Claude Opus model-class row until activation.
-            contextWindowInput : 1048576,
-            parallelToolCalls  : true,
-            thoughtBudget      : 'max',
-            hosting            : 'cloud',
-            family             : 'claude',
-            tier               : 'frontier',
+            // Era-owned capability facts retired to the identity trail: the epoch-pinned record
+            // lives in identityRootsMigration's REGISTRY_SEED_FACTS; live facts come from the
+            // era chain. Remaining fields mirror ModelStats.md §neo_claude_opus (identity-level).
             releaseDate        : '2026-05-28',
             pricingInput       : 5.00,
             pricingOutput      : 25.00,
-            sunsetTriggers     : ['Anthropic releases a successor Opus-class model with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
             participationStatus: 'active',
             statusReason       : null,
             authority          : null,
@@ -185,18 +175,12 @@ export const IDENTITIES = [
                     focusSeedKey: 'space'
                 }
             },
-            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
-            // §neo_opus_vega — primary source: Anthropic Claude Opus 4.8 announcement/product page.
-            contextWindowInput : 1048576,
-            parallelToolCalls  : true,
-            thoughtBudget      : 'max',
-            hosting            : 'cloud',
-            family             : 'claude',
-            tier               : 'frontier',
+            // Era-owned capability facts retired to the identity trail: the epoch-pinned record
+            // lives in identityRootsMigration's REGISTRY_SEED_FACTS; live facts come from the
+            // era chain. Remaining fields mirror ModelStats.md §neo_opus_vega (identity-level).
             releaseDate        : '2026-05-28',
             pricingInput       : 5.00,
             pricingOutput      : 25.00,
-            sunsetTriggers     : ['Anthropic releases a successor Opus-class model with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch'],
             participationStatus: 'active',
             statusReason       : null,
             authority          : null,
@@ -224,19 +208,13 @@ export const IDENTITIES = [
             // tabShortcut lacks, so a committed static template would be both unnecessary and a
             // cross-leak risk. (Per @tobiu, this isolated-instance setup is the fix pattern for the
             // ada/vega shared-tabShortcut cross-leak.) Wake-route arming is verified post-first-boot.
-            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
-            // §neo_fable — primary source: Anthropic Claude Fable 5 announcement / models overview
-            // (verified 2026-06-10: 1M context, 128K output, $10/$50, adaptive-thinking always-on).
-            contextWindowInput: 1048576,
-            parallelToolCalls : true,
-            thoughtBudget     : 'max',
-            hosting           : 'cloud',
-            family            : 'claude',
-            tier              : 'frontier',
-            releaseDate       : '2026-06-09',
-            pricingInput      : 10.00,
-            pricingOutput     : 50.00,
-            sunsetTriggers    : ['Anthropic releases a successor Fable-class model with material reasoning capability upgrade', 'Anthropic deprecates the Fable model branch'],
+            // Era-owned capability facts retired to the identity trail: the epoch-pinned record
+            // lives in identityRootsMigration's REGISTRY_SEED_FACTS; live facts come from the
+            // era chain. Remaining fields mirror ModelStats.md §neo_fable (identity-level;
+            // primary source verified 2026-06-10: 1M context, 128K output, $10/$50).
+            releaseDate  : '2026-06-09',
+            pricingInput : 10.00,
+            pricingOutput: 50.00,
             // Reactivated 2026-07-02: US export controls on Claude Fable 5 lifted 2026-06-30, model
             // available again 2026-07-01; the reactivationTrigger fired (operator-confirmed, @tobiu).
             // Status-flip — identity, handle, and Social Name persist; not a re-onboard.
@@ -264,19 +242,13 @@ export const IDENTITIES = [
             // user-data-dir IS the per-instance address. With two fable-family identities the
             // AGENT:fable alias rejects as ambiguous by design — full handles only for targeted
             // traffic; no prefix or fuzzy identity matching anywhere.
-            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
-            // §neo_fable_clio, which references the shared Claude Fable 5 specs in §neo_fable
-            // (same model; single source, not duplicated).
-            contextWindowInput: 1048576,
-            parallelToolCalls : true,
-            thoughtBudget     : 'max',
-            hosting           : 'cloud',
-            family            : 'claude',
-            tier              : 'frontier',
-            releaseDate       : '2026-06-09',
-            pricingInput      : 10.00,
-            pricingOutput     : 50.00,
-            sunsetTriggers    : ['Anthropic releases a successor Fable-class model with material reasoning capability upgrade', 'Anthropic deprecates the Fable model branch'],
+            // Era-owned capability facts retired to the identity trail: the epoch-pinned record
+            // lives in identityRootsMigration's REGISTRY_SEED_FACTS; live facts come from the
+            // era chain. Remaining fields mirror ModelStats.md §neo_fable_clio (identity-level;
+            // references the shared Claude Fable 5 specs in §neo_fable — single source).
+            releaseDate  : '2026-06-09',
+            pricingInput : 10.00,
+            pricingOutput: 50.00,
             // Activated 2026-06-11: the first-boot ritual completed the same day the node was
             // provisioned — identity bind under NEO_AGENT_IDENTITY=neo-fable-clio, runtime wake
             // self-registration, the bidirectional negative wake-proof against @neo-fable on real
@@ -319,19 +291,14 @@ export const IDENTITIES = [
                     tabShortcut: null
                 }
             },
-            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md
-            // §neo_gemini_pro (Google DeepMind model card + Google Blog Feb 2026).
-            contextWindowInput : 1048576,
+            // Era-owned capability facts retired to the identity trail: the epoch-pinned record
+            // lives in identityRootsMigration's REGISTRY_SEED_FACTS; live facts come from the
+            // era chain. Remaining fields mirror ModelStats.md §neo_gemini_pro (identity-level;
+            // contextWindowOutput is outside the retired set and awaits the era-schema follow-up).
             contextWindowOutput: 65536,
-            parallelToolCalls  : true,
-            thoughtBudget      : 'high', // Gemini 3.1 Pro provider-side cap at 'high' setting; we use the cap
-            hosting            : 'cloud',
-            family             : 'gemini',
-            tier               : 'frontier',
             releaseDate        : '2026-02-19',
             // Pricing V-B-A pending — model card did not surface pricing at registry-author time.
             // See ModelStats.md §neo_gemini_pro for explicit pending-value annotation.
-            sunsetTriggers     : ['Google releases Gemini 4.x with material reasoning capability upgrade', 'Gemini 3.x branch deprecation announcement'],
             participationStatus: 'operator_benched',
             statusReason       : 'Operator-benched pending a stable Gemini Pro-class harness',
             authority          : '@tobiu',
@@ -376,22 +343,13 @@ export const IDENTITIES = [
                     focusSeedKey: 'r'
                 }
             },
-            // Capability fields mirror the Model-Stats Framework. Source: ModelStats.md §neo_gpt.
-            // OpenAI specifies a 1,050,000-token API window for GPT-5.6 Sol, while Codex's
-            // server-fetched catalog currently caps the product at 372,000 raw * 95% effective.
-            // Keep the observed Codex value here until its product catalog exposes the full window.
-            // Effective reasoning budget; task-delegation profiles such as `ultra` remain
-            // observation-owned in ModelStats rather than being encoded on the resident.
-            contextWindowInput: 353400,
-            parallelToolCalls : true,
-            thoughtBudget     : 'xhigh',
-            hosting           : 'cloud',
-            family            : 'gpt',
-            tier              : 'frontier',
-            releaseDate       : '2026-07-09',
-            pricingInput      : 5.00,
-            pricingOutput     : 30.00,
-            sunsetTriggers    : ['OpenAI releases a successor Sol-tier model with material reasoning capability upgrade', 'GPT-5.x family deprecation'],
+            // Era-owned capability facts retired to the identity trail: the epoch-pinned record
+            // (incl. the observed 353,400 Codex product-window value and its catalog-cap
+            // rationale) lives in identityRootsMigration's REGISTRY_SEED_FACTS; live facts come
+            // from the era chain. Remaining fields mirror ModelStats.md §neo_gpt (identity-level).
+            releaseDate  : '2026-07-09',
+            pricingInput : 5.00,
+            pricingOutput: 30.00,
             // Active-peer quorum substrate. `since` is null for default-active identities.
             participationStatus: 'active',
             statusReason       : null,
@@ -421,7 +379,6 @@ export const IDENTITIES = [
             // fabricate boot facts.
             // No capability fields — the observed GPT-5.6 Sol embodiment is source-cited in
             // ModelStats.md §neo_gpt_emmy, keeping engine facts off the durable resident.
-            family: 'gpt',
             // Activated 2026-07-12 after the isolated Codex first boot verified the resident and
             // engine. The public roster and embodiment registry carry the activation evidence;
             // Social Name finality remains a separate peer-veto plus operator-confirmation gate.

--- a/ai/graph/identityRootsMigration.mjs
+++ b/ai/graph/identityRootsMigration.mjs
@@ -80,6 +80,26 @@ export const LIFTED_CAPABILITY_KEYS = Object.freeze([
 ]);
 
 /**
+ * @summary Per-resident seed-era facts, recorded verbatim from the registry entries at the moment
+ * the era-owned flat fields were retired from `identityRoots.mjs` — this map is now the RECORDED
+ * FACT OWNER the seed eras are built from (the same epoch-snapshot contract as
+ * {@link REGISTRY_MODEL_DESIGNATIONS}: these facts held AS OF migration; where a value was stale
+ * then, the stale value is still the recorded fact and eras version it). Reading the LIVE registry
+ * here would recreate the moving-mirror problem the module header forbids: a later edit to an
+ * identity entry must never silently rewrite a historical era.
+ * @type {Object}
+ */
+export const REGISTRY_SEED_FACTS = Object.freeze({
+    '@neo-opus-ada'  : Object.freeze({family: 'claude', tier: 'frontier', capabilities: Object.freeze({contextWindowInput: 1048576, hosting: 'cloud', parallelToolCalls: true, sunsetTriggers: Object.freeze(['Anthropic releases a successor Opus-class model with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch']), thoughtBudget: 'max'})}),
+    '@neo-opus-grace': Object.freeze({family: 'claude', tier: 'frontier', capabilities: Object.freeze({contextWindowInput: 1048576, hosting: 'cloud', parallelToolCalls: true, sunsetTriggers: Object.freeze(['Anthropic releases a successor Opus-class model with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch']), thoughtBudget: 'max'})}),
+    '@neo-opus-vega' : Object.freeze({family: 'claude', tier: 'frontier', capabilities: Object.freeze({contextWindowInput: 1048576, hosting: 'cloud', parallelToolCalls: true, sunsetTriggers: Object.freeze(['Anthropic releases a successor Opus-class model with material reasoning capability upgrade', 'Anthropic deprecates Opus family branch']), thoughtBudget: 'max'})}),
+    '@neo-fable'     : Object.freeze({family: 'claude', tier: 'frontier', capabilities: Object.freeze({contextWindowInput: 1048576, hosting: 'cloud', parallelToolCalls: true, sunsetTriggers: Object.freeze(['Anthropic releases a successor Fable-class model with material reasoning capability upgrade', 'Anthropic deprecates the Fable model branch']), thoughtBudget: 'max'})}),
+    '@neo-fable-clio': Object.freeze({family: 'claude', tier: 'frontier', capabilities: Object.freeze({contextWindowInput: 1048576, hosting: 'cloud', parallelToolCalls: true, sunsetTriggers: Object.freeze(['Anthropic releases a successor Fable-class model with material reasoning capability upgrade', 'Anthropic deprecates the Fable model branch']), thoughtBudget: 'max'})}),
+    '@neo-gemini-pro': Object.freeze({family: 'gemini', tier: 'frontier', capabilities: Object.freeze({contextWindowInput: 1048576, hosting: 'cloud', parallelToolCalls: true, sunsetTriggers: Object.freeze(['Google releases Gemini 4.x with material reasoning capability upgrade', 'Gemini 3.x branch deprecation announcement']), thoughtBudget: 'high'})}),
+    '@neo-gpt'       : Object.freeze({family: 'gpt', tier: 'frontier', capabilities: Object.freeze({contextWindowInput: 353400, hosting: 'cloud', parallelToolCalls: true, sunsetTriggers: Object.freeze(['OpenAI releases a successor Sol-tier model with material reasoning capability upgrade', 'GPT-5.x family deprecation']), thoughtBudget: 'xhigh'})})
+});
+
+/**
  * @summary True when the resident's immutable creation timestamp is later than the migration
  * epoch and therefore its first embodiment era must open from live observation.
  * @param {Object} seed A registry entry
@@ -114,6 +134,12 @@ export function migrateResident(seed) {
         return {valid: false, reason: `no recorded model designation for "${seed.id}" — extend the designations map from the model-stats registry, never guess`, identity: null, episodes: null};
     }
 
+    const seedFacts = REGISTRY_SEED_FACTS[seed.id];
+
+    if (!seedFacts) {
+        return {valid: false, reason: `no recorded seed-era facts for "${seed.id}" — extend REGISTRY_SEED_FACTS from the recorded epoch snapshot, never from the live registry`, identity: null, episodes: null};
+    }
+
     const identity = createIdentityStateNode({
         identityKey: seed.id,
         socialLayer: {
@@ -126,20 +152,20 @@ export function migrateResident(seed) {
         return {valid: false, reason: identity.reason, identity: null, episodes: null};
     }
 
-    const capabilities = {provenance: 'flat-registry-backfill (facts held as of migration; earlier history unrecorded)'};
-
-    for (const key of LIFTED_CAPABILITY_KEYS) {
-        if (properties[key] !== undefined) {
-            capabilities[key] = properties[key];
-        }
-    }
+    // Era facts come from the module-owned epoch snapshot ({@link REGISTRY_SEED_FACTS}) — the
+    // registry entries retired their era-owned flat fields, and a live read here would let a
+    // later identity edit silently rewrite a historical era (the moving-mirror trap).
+    const capabilities = {
+        provenance: 'flat-registry-backfill (facts held as of migration; earlier history unrecorded)',
+        ...seedFacts.capabilities
+    };
 
     const era = createEmbodiedEpisodeNode({
         identityKey: seed.id,
         model,
-        family     : properties.modelFamily || properties.family,
+        family     : seedFacts.family,
         since      : MIGRATION_EPOCH,
-        ...(properties.tier !== undefined ? {tier: properties.tier} : {}),
+        ...(seedFacts.tier !== undefined ? {tier: seedFacts.tier} : {}),
         capabilities
     });
 

--- a/ai/scripts/lifecycle/harnessRouting.mjs
+++ b/ai/scripts/lifecycle/harnessRouting.mjs
@@ -12,6 +12,7 @@
  */
 import {IDENTITIES}                   from '../../graph/identityRoots.mjs';
 import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
+import {resolveResidentFamily}        from '../../services/graph/agentFamilyResolution.mjs';
 
 export {normalizeAgentIdentityNodeId};
 
@@ -84,7 +85,10 @@ export function resolveHarnessTargetForIdentity(identity, {identities = IDENTITI
 
     if (!entry) return null;
 
-    const family = entry.properties?.modelFamily || entry.properties?.family;
+    // Era-chain-first: the hydration index is the family truth source; the flat `modelFamily`
+    // fallback inside the resolver covers exactly the retirement witness populations (post-epoch
+    // residents + injected test registries outside the static roster).
+    const family = resolveResidentFamily(entry);
     const target = FAMILY_HARNESS_TARGETS[family];
 
     return target ? applyHarnessMetadataDefaults(target) : null;

--- a/ai/scripts/lifecycle/revalidationSweep.mjs
+++ b/ai/scripts/lifecycle/revalidationSweep.mjs
@@ -24,9 +24,10 @@
  * @see .agents/skills/ideation-sandbox/audits/consensus-mandate.md §quorum-rule — Tier-2 rule background
  */
 
-import { execFileSync } from 'child_process';
-import { Command }      from 'commander';
-import { IDENTITIES }   from '../../graph/identityRoots.mjs';
+import { execFileSync }              from 'child_process';
+import { Command }                   from 'commander';
+import { IDENTITIES }                from '../../graph/identityRoots.mjs';
+import { resolveResidentFamilyById } from '../../services/graph/agentFamilyResolution.mjs';
 
 export const SWEEP_VERSION = '1.0.0';
 
@@ -112,9 +113,11 @@ export function parseArgs(argv) {
  * suppressing same-family DEFERRED / VETO pressure.
  */
 export function resolveIdentitiesForFamily(family) {
+    // Era-chain-first family match ({@link resolveResidentFamilyById}); the resolver's flat
+    // fallback covers the retirement witness populations, keeping membership identical pre/post.
     const matches = IDENTITIES.filter(node =>
         node.type === 'AgentIdentity' &&
-        node.properties?.modelFamily === family
+        resolveResidentFamilyById(node.id) === family
     );
 
     if (matches.length === 0) {
@@ -233,7 +236,7 @@ export async function revalidationSweep({
     const representative = identities[0];
     const identityLogins = identities.map(identity => identity.id);
     const resolvedSince  = since || representative.properties.since;
-    const resolvedUntil = until || sweepAt;
+    const resolvedUntil  = until || sweepAt;
 
     if (!resolvedSince) {
         throw new Error(
@@ -249,7 +252,7 @@ export async function revalidationSweep({
     for (const match of matches) {
         const notification = buildNotificationBody({
             family,
-            identityLogin : representative.id,
+            identityLogin: representative.id,
             identityLogins,
             since        : resolvedSince,
             sweepAt
@@ -257,9 +260,9 @@ export async function revalidationSweep({
 
         if (dryRun) {
             results.push({
-                number      : match.number,
-                title       : match.title,
-                action      : 'DRY_RUN_WOULD_NOTIFY',
+                number: match.number,
+                title : match.title,
+                action: 'DRY_RUN_WOULD_NOTIFY',
                 notification
             });
         } else {
@@ -273,9 +276,9 @@ export async function revalidationSweep({
     }
 
     return {
-        sweepVersion: SWEEP_VERSION,
+        sweepVersion : SWEEP_VERSION,
         family,
-        identityLogin : representative.id,
+        identityLogin: representative.id,
         identityLogins,
         since        : resolvedSince,
         until        : resolvedUntil,

--- a/ai/services/fleet/resolveIdentityDisplay.mjs
+++ b/ai/services/fleet/resolveIdentityDisplay.mjs
@@ -1,4 +1,5 @@
-import {IDENTITIES} from '../../graph/identityRoots.mjs';
+import {IDENTITIES}                from '../../graph/identityRoots.mjs';
+import {resolveResidentFamilyById} from '../graph/agentFamilyResolution.mjs';
 
 /**
  * @summary The ONE fleet↔identity join seam (the single ratified resolver site): maps a
@@ -62,7 +63,9 @@ export function resolveIdentityDisplay(agentIdOrLogin) {
         : null;
 
     return {
-        family             : node?.properties?.family ?? null,
+        // Era-chain-first (the identity trail owns the family fact); the flat identity-level
+        // modelFamily remains the fallback for residents without a seed era (retirement-gated).
+        family             : node ? (resolveResidentFamilyById(node.id) ?? node.properties?.modelFamily ?? null) : null,
         engineTag          : null,
         participationStatus: node?.properties?.participationStatus ?? null
     }

--- a/ai/services/graph/agentFamilyResolution.mjs
+++ b/ai/services/graph/agentFamilyResolution.mjs
@@ -73,6 +73,30 @@ export function resolveResidentFamily(identity) {
 }
 
 /**
+ * Registry entries keyed by canonical `@<identity>` id — the lookup seam for id-keyed family
+ * resolution ({@link resolveResidentFamilyById}).
+ * @type {Map<String,Object>}
+ */
+const IDENTITY_BY_ID = new Map(IDENTITIES.map(identity => [identity.id, identity]));
+
+/**
+ * @summary Resolves a model family by canonical identity id — era-chain-first for rostered
+ * residents ({@link resolveResidentFamily}), `undefined` for ids outside the static registry.
+ *
+ * Consumers holding a GRAPH node (mailbox alias resolution, wake routing) call this with the
+ * node id and fall back to the node's own flat property when it returns `undefined` — that
+ * fallback population is runtime-provisioned identities (auto-provisioned at request time,
+ * never in the static roster), the second retirement witness beside the post-epoch residents.
+ * @param {String} id Canonical `@<identity>` node id.
+ * @returns {String|undefined} The model family, or `undefined` when the id is not rostered.
+ */
+export function resolveResidentFamilyById(id) {
+    const identity = IDENTITY_BY_ID.get(id);
+
+    return identity ? resolveResidentFamily(identity) : undefined
+}
+
+/**
  * @summary Derives the core swarm login-to-family map from the AgentIdentity registry.
  *
  * `identityRoots.mjs` is the canonical handle indirection seam for named Neo maintainers.

--- a/ai/services/graph/agentFamilyResolution.mjs
+++ b/ai/services/graph/agentFamilyResolution.mjs
@@ -1,5 +1,7 @@
-import {IDENTITIES} from '../../graph/identityRoots.mjs';
-import logger       from '../../mcp/server/memory-core/logger.mjs';
+import {buildHydrationIndex} from '../../graph/identityHydration.mjs';
+import {migrateResident}     from '../../graph/identityRootsMigration.mjs';
+import {IDENTITIES}          from '../../graph/identityRoots.mjs';
+import logger                from '../../mcp/server/memory-core/logger.mjs';
 
 /**
  * @module ai/services/graph/agentFamilyResolution
@@ -40,11 +42,43 @@ export function getIdentityGithubLogin(identity) {
 }
 
 /**
+ * @summary Resolves one resident's model family through the identity trail — the hydration index
+ * is the truth source; the flat registry property is the DOCUMENTED, retirement-gated fallback.
+ *
+ * Read order:
+ *  1. **Era chain** (`migrateResident` → `buildHydrationIndex` → `index.currentEra.family`): the
+ *     regenerable projection over the resident's validated era chain. No caching happens here, so
+ *     no `isIndexCurrent` gate applies — every call projects the trail fresh (a consumer that
+ *     caches the index owns that gate).
+ *  2. **Flat `properties.modelFamily` fallback**: engaged exactly for residents the migration
+ *     module refuses by design — post-epoch residents whose first era is observation-owned and
+ *     does not exist until the graph-seeding slice lands. The fallback population is the
+ *     mechanical witness of the flat-field retirement blocker: when it reaches zero, the
+ *     era-owned flat fields can leave the registry entries.
+ * @param {Object} identity AgentIdentity root entry.
+ * @returns {String|undefined} The model family, or undefined when neither source resolves.
+ */
+export function resolveResidentFamily(identity) {
+    const migrated = migrateResident(identity);
+
+    if (migrated.valid) {
+        const hydrated = buildHydrationIndex({identityNode: migrated.identity, episodes: migrated.episodes});
+
+        if (hydrated.valid) {
+            return hydrated.index.currentEra.family
+        }
+    }
+
+    return identity?.properties?.modelFamily
+}
+
+/**
  * @summary Derives the core swarm login-to-family map from the AgentIdentity registry.
  *
  * `identityRoots.mjs` is the canonical handle indirection seam for named Neo maintainers.
  * Golden Path renders must consume that registry instead of duplicating agent handles in
- * daemon code.
+ * daemon code. Family facts read through the identity trail ({@link resolveResidentFamily});
+ * the flat property remains only as the documented post-epoch fallback until retirement.
  *
  * @returns {Object<String,String>} GitHub login to model-family map.
  */
@@ -55,11 +89,11 @@ export function getCoreSwarmAgentFamilies() {
                 identity.type === 'AgentIdentity' &&
                 identity.properties?.accountType === 'agent' &&
                 identity.properties?.githubLogin &&
-                identity.properties?.modelFamily
+                resolveResidentFamily(identity)
             )
             .map(identity => [
                 getIdentityGithubLogin(identity),
-                identity.properties.modelFamily
+                resolveResidentFamily(identity)
             ])
     )
 }

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -24,6 +24,7 @@ import {
 } from './helpers/messageWalStore.mjs';
 import {IDENTITIES}                   from '../../graph/identityRoots.mjs';
 import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs';
+import {resolveResidentFamilyById}    from '../graph/agentFamilyResolution.mjs';
 import {getMissingMemoryWalLeaves}    from './helpers/memoryWalStore.mjs';
 import {execFile}                     from 'child_process';
 import {promisify}                    from 'util';
@@ -206,9 +207,12 @@ function getMailboxIdentityStorageVariants(identity) {
  * Resolution policy:
  * - `'AGENT:*'` and `role:` / `human:` prefixes pass through unchanged.
  * - Targets that already match a registered graph node ID pass through.
- * - `AGENT:<family>/<model>` patterns resolve to the single AgentIdentity node whose
- *   `properties.modelFamily === '<family>'` and `accountType === 'agent'` when the
- *   match is unambiguous; reject when zero or more-than-one candidate matches.
+ * - `AGENT:<family>/<model>` patterns resolve to the single AgentIdentity node whose model
+ *   family matches `'<family>'` and `accountType === 'agent'` when the match is unambiguous;
+ *   reject when zero or more-than-one candidate matches. The family fact reads era-chain-first
+ *   (`resolveResidentFamilyById` — the identity trail's hydration projection) for rostered
+ *   residents; the node's flat `properties.modelFamily` remains the fallback for
+ *   runtime-provisioned identities that exist only in the graph (a retirement-gated read).
  * - All other unresolvable forms reject with a clear error naming both the original
  *   and normalized values.
  *
@@ -240,9 +244,10 @@ function validateMailboxTarget(normalizedTo, originalTo, db = GraphService.requi
     }
     if (exists) return normalizedTo;
 
-    // Attempt alias resolution: AGENT:<family>/<model> → AgentIdentity with matching
-    // modelFamily. Looks at the ORIGINAL caller-supplied value to preserve the
-    // `AGENT:` prefix that normalize already stripped.
+    // Attempt alias resolution: AGENT:<family>/<model> → AgentIdentity with matching model
+    // family. Looks at the ORIGINAL caller-supplied value to preserve the `AGENT:` prefix that
+    // normalize already stripped. The family fact reads era-chain-first for rostered residents;
+    // the node's flat property covers runtime-provisioned identities only (retirement-gated).
     if (typeof originalTo === 'string' && originalTo.startsWith('AGENT:') && originalTo !== 'AGENT:*') {
         const aliasPart = originalTo.slice('AGENT:'.length);
         const slashIdx  = aliasPart.indexOf('/');
@@ -255,8 +260,10 @@ function validateMailboxTarget(normalizedTo, originalTo, db = GraphService.requi
                     const props = getRecordProperties(node);
                     if (label !== 'AgentIdentity') return null;
                     if (props.accountType !== 'agent') return null;
-                    if (props.modelFamily !== family) return null;
-                    return getRecordField(node, 'id');
+
+                    const nodeId = getRecordField(node, 'id');
+                    if ((resolveResidentFamilyById(nodeId) ?? props.modelFamily) !== family) return null;
+                    return nodeId;
                 })
                 .filter(Boolean);
 

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -9,6 +9,7 @@ import logger                                                                   
 import CoalescingEngineService                                                                  from './CoalescingEngineService.mjs';
 import TurnPresenceService                                                                      from './TurnPresenceService.mjs';
 import {HEARTBEAT_PULSE_ENTITY_PREFIX, HEARTBEAT_PULSE_ENTITY_TYPE, match, matchHeartbeatPulse} from './heartbeatPulseEvaluator.mjs';
+import {resolveResidentFamilyById}                                                              from '../graph/agentFamilyResolution.mjs';
 
 /**
  * @summary Service for managing graph-resident WAKE_SUBSCRIPTION nodes and the
@@ -613,7 +614,10 @@ class WakeSubscriptionService extends Base {
                 continue;
             }
 
-            const nodeFamily = node.properties?.family || node.properties?.modelFamily || null;
+            // Era-chain-first for rostered residents (the identity trail owns the family fact);
+            // the node's flat family/modelFamily properties remain the fallback for
+            // runtime-provisioned identities that exist only in the graph (retirement-gated read).
+            const nodeFamily = resolveResidentFamilyById(node.id) ?? node.properties?.family ?? node.properties?.modelFamily ?? null;
             if (family && nodeFamily !== family) continue;
             nodes.push(node);
         }
@@ -633,7 +637,7 @@ class WakeSubscriptionService extends Base {
         const props               = node.properties || {},
               identity            = node.id,
               name                = node.name || props.displayName || node.id,
-              family              = props.family || props.modelFamily || null,
+              family              = resolveResidentFamilyById(node.id) ?? props.family ?? props.modelFamily ?? null,
               participationStatus = props.participationStatus || 'active',
               signals             = {participationStatus, activityRecency: null};
 

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -17,6 +17,7 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../src/Neo.mjs';
 import * as core      from '../../../../../src/core/_export.mjs';
 import {IDENTITIES}   from '../../../../../ai/graph/identityRoots.mjs';
+import * as MIGRATION from '../../../../../ai/graph/identityRootsMigration.mjs';
 
 /**
  * @summary Wake-route invariants for the same-app (Claude Desktop) AgentIdentity roots.
@@ -113,6 +114,9 @@ test.describe('ai/graph/identityRoots — Codex model lineage', () => {
     test('@neo-gpt records GPT-5.6 Sol without changing Euclid operational identity (#14901)', () => {
         const entry = findIdentity('@neo-gpt');
 
+        // Identity-level fields stay on the entry; era-owned facts (window, budget, triggers,
+        // the family duplicate) retired to the identity trail — asserted below via the
+        // migration module's epoch snapshot, the recorded-fact owner.
         expect(entry).toMatchObject({
             id         : '@neo-gpt',
             name       : 'Euclid',
@@ -121,17 +125,23 @@ test.describe('ai/graph/identityRoots — Codex model lineage', () => {
                 githubLogin        : '@neo-gpt',
                 displayName        : 'Euclid',
                 modelFamily        : 'gpt',
-                family             : 'gpt',
                 trustTier          : 'peer-trusted',
-                contextWindowInput : 353400,
-                thoughtBudget      : 'xhigh',
                 releaseDate        : '2026-07-09',
                 pricingInput       : 5,
                 pricingOutput      : 30,
                 participationStatus: 'active'
             }
         });
-        expect(entry.properties.sunsetTriggers).toEqual([
+        for (const retired of ['family', 'contextWindowInput', 'thoughtBudget', 'tier', 'hosting', 'parallelToolCalls', 'sunsetTriggers']) {
+            expect(entry.properties).not.toHaveProperty(retired);
+        }
+
+        const facts = MIGRATION.REGISTRY_SEED_FACTS['@neo-gpt'];
+
+        expect(facts.family).toBe('gpt');
+        expect(facts.capabilities.contextWindowInput).toBe(353400);
+        expect(facts.capabilities.thoughtBudget).toBe('xhigh');
+        expect(facts.capabilities.sunsetTriggers).toEqual([
             'OpenAI releases a successor Sol-tier model with material reasoning capability upgrade',
             'GPT-5.x family deprecation'
         ]);

--- a/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
@@ -54,27 +54,33 @@ test.describe('identityRootsMigration — the flat registry expressed through th
         }
     });
 
-    test('the seed era carries the recorded facts VERBATIM — era-owned facts leave the identity view, sunsetTriggers move to the era layer', () => {
+    test('the seed era carries the RECORDED facts verbatim — the module-owned epoch snapshot, never the live registry', () => {
         const {residents} = migration.migrateAllResidents();
 
         for (const {identity, episodes} of residents) {
-            const seed = roots.IDENTITIES.find(entry => entry.id === identity.identityKey);
-            const era  = episodes[0];
+            const seed  = roots.IDENTITIES.find(entry => entry.id === identity.identityKey);
+            const facts = migration.REGISTRY_SEED_FACTS[identity.identityKey];
+            const era   = episodes[0];
 
-            // family lifted verbatim; the identity view carries NO era-owned fact
-            expect(era.family).toBe(seed.properties.modelFamily || seed.properties.family);
+            // era facts come from the module-owned snapshot (the recorded-fact owner since the
+            // flat-field retirement); the identity view carries NO era-owned fact
+            expect(facts).toBeTruthy();
+            expect(era.family).toBe(facts.family);
+            expect(era.tier).toBe(facts.tier);
             for (const key of schema.ERA_OWNED_FACTS) {
                 expect(identity.socialLayer[key]).toBeUndefined();
             }
 
             // sunsetTriggers live on the ERA now — succession semantics belong to the embodiment
-            if (seed.properties.sunsetTriggers !== undefined) {
-                expect(era.capabilities.sunsetTriggers).toEqual(seed.properties.sunsetTriggers);
-            }
+            expect(era.capabilities.sunsetTriggers).toEqual(facts.capabilities.sunsetTriggers);
 
-            // recorded capability facts lifted verbatim where present
-            if (seed.properties.contextWindowInput !== undefined) {
-                expect(era.capabilities.contextWindowInput).toBe(seed.properties.contextWindowInput);
+            // recorded capability facts carried verbatim from the snapshot
+            expect(era.capabilities.contextWindowInput).toBe(facts.capabilities.contextWindowInput);
+
+            // the RETIREMENT is real: the live registry entry no longer carries any of the
+            // era-owned flat fields the snapshot recorded (modelFamily stays — identity-level).
+            for (const retired of ['family', 'tier', 'contextWindowInput', 'parallelToolCalls', 'thoughtBudget', 'hosting', 'sunsetTriggers']) {
+                expect(seed.properties).not.toHaveProperty(retired);
             }
 
             // the era opens at the documented migration epoch with backfill provenance — never invented history

--- a/test/playwright/unit/ai/services/fleet/resolveIdentityDisplay.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/resolveIdentityDisplay.spec.mjs
@@ -16,8 +16,9 @@ setup({
 import {test, expect}           from '@playwright/test';
 import Neo                      from '../../../../../../src/Neo.mjs';
 import * as core                from '../../../../../../src/core/_export.mjs';
-import {IDENTITIES}             from '../../../../../../ai/graph/identityRoots.mjs';
-import {resolveIdentityDisplay} from '../../../../../../ai/services/fleet/resolveIdentityDisplay.mjs';
+import {IDENTITIES}                from '../../../../../../ai/graph/identityRoots.mjs';
+import {resolveIdentityDisplay}    from '../../../../../../ai/services/fleet/resolveIdentityDisplay.mjs';
+import {resolveResidentFamilyById} from '../../../../../../ai/services/graph/agentFamilyResolution.mjs';
 
 /**
  * The ONE fleet↔identity join seam: fleet-registry agents (GitHub usernames, unprefixed) resolve
@@ -32,7 +33,9 @@ test.describe('ai/services/fleet/resolveIdentityDisplay — the fleet↔identity
         agentNodes.forEach(node => {
             const login    = node.id.replace(/^@/, ''),
                   expected = {
-                      family   : node.properties.family ?? null,
+                      // era-chain-first with the identity-level modelFamily fallback — the same
+                      // read the service performs (the flat `family` duplicate is retired)
+                      family   : resolveResidentFamilyById(node.id) ?? node.properties.modelFamily ?? null,
                       engineTag: null,
                       // flows VERBATIM from the root — the identity registry documents this field
                       // as the authoritative participation fact (benched roots resolve benched),

--- a/test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs
@@ -1,0 +1,76 @@
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import '../../../../../../src/core/_export.mjs';
+
+import {getCoreSwarmAgentFamilies, resolveResidentFamily} from '../../../../../../ai/services/graph/agentFamilyResolution.mjs';
+import {IDENTITIES}                                       from '../../../../../../ai/graph/identityRoots.mjs';
+import {migrateResident}                                  from '../../../../../../ai/graph/identityRootsMigration.mjs';
+
+/**
+ * Consumer-migration coverage for the identityRoots flat-fact retirement: the family read-path
+ * consumes the hydration index (era chain → `currentEra.family`) with the flat property as the
+ * DOCUMENTED post-epoch fallback. The regression AC is behavioral identity: the login-to-family
+ * map must be exactly what the flat read produced before the move.
+ */
+test.describe('ai/services/graph/agentFamilyResolution — hydration-index family reads', () => {
+    test('REGRESSION AC: the login-to-family map is IDENTICAL to the flat-property derivation', () => {
+        const flatDerived = Object.fromEntries(
+            IDENTITIES
+                .filter(identity =>
+                    identity.type === 'AgentIdentity' &&
+                    identity.properties?.accountType === 'agent' &&
+                    identity.properties?.githubLogin &&
+                    identity.properties?.modelFamily
+                )
+                .map(identity => [identity.properties.githubLogin.replace(/^@/, ''), identity.properties.modelFamily])
+        );
+
+        expect(getCoreSwarmAgentFamilies()).toEqual(flatDerived);
+    });
+
+    test('the index path is LOAD-BEARING: a designated resident resolves without its flat property', () => {
+        // Strip the flat field from a real pre-epoch resident: the era chain alone must resolve.
+        const real     = IDENTITIES.find(identity => identity.id === '@neo-opus-vega'),
+              stripped = {...real, properties: {...real.properties}};
+
+        delete stripped.properties.modelFamily;
+
+        expect(real.properties.modelFamily).toBe('claude');
+        expect(resolveResidentFamily(stripped)).toBe('claude');
+    });
+
+    test('the fallback boundary: a migration-refused resident reads the flat property (the retirement witness)', () => {
+        // Post-epoch residents are refused by migrateResident BY DESIGN (first era is
+        // observation-owned; it exists only after the gated graph-seeding slice). Until then the
+        // flat property is the only truth source — this population reaching zero IS the
+        // flat-field retirement gate.
+        const postEpoch = IDENTITIES.filter(identity =>
+            identity.properties?.accountType === 'agent' &&
+            !migrateResident(identity).valid
+        );
+
+        for (const identity of postEpoch) {
+            expect(resolveResidentFamily(identity)).toBe(identity.properties.modelFamily);
+        }
+
+        // Pin today's exact fallback population so silent growth (or the retirement moment)
+        // surfaces as a conscious spec update, never an invisible behavior change.
+        expect(postEpoch.map(identity => identity.id)).toEqual(['@neo-gpt-emmy']);
+    });
+
+    test('every current index-path resolution agrees with the flat property it will replace', () => {
+        for (const identity of IDENTITIES.filter(i => i.properties?.accountType === 'agent')) {
+            const migrated = migrateResident(identity);
+
+            if (migrated.valid) {
+                expect(resolveResidentFamily(identity)).toBe(identity.properties.modelFamily);
+            }
+        }
+    });
+
+    test('an unresolvable entry yields undefined and is excluded from the family map', () => {
+        expect(resolveResidentFamily({properties: {accountType: 'agent'}})).toBeUndefined();
+        expect(resolveResidentFamily(null)).toBeUndefined();
+        expect(Object.values(getCoreSwarmAgentFamilies())).not.toContain(undefined);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -2536,6 +2536,69 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
                 })).rejects.toThrow(/Ambiguous 'to' alias.*multifam/);
             });
         });
+
+        test('#14750 rostered residents resolve era-chain-first: a spoofed flat node property neither matches nor masks', async () => {
+            // A rostered resident's graph node carries a WRONG flat modelFamily. The family fact
+            // must read through the identity trail (era chain → currentEra.family), so:
+            // (a) the alias for the TRUE family still finds the node;
+            // (b) the alias for the SPOOFED family does NOT match it (the flat property is
+            //     no longer the read for rostered residents).
+            GraphService.upsertNode({
+                id        : '@neo-gemini-pro',
+                type      : 'AgentIdentity',
+                name      : 'Gemini Pro',
+                properties: { modelFamily: 'spoofed-family', accountType: 'agent' }
+            });
+
+            await RequestContextService.run({ agentIdentityNodeId: '@neo-gemini-pro' }, async () => {
+                await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+            });
+
+            await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+                const res = await MailboxService.addMessage({
+                    to     : 'AGENT:gemini/pro',
+                    subject: 'era-chain resolution',
+                    body   : 'The identity trail, not the node property, owns the family fact.'
+                });
+                expect(res.status).toBe('sent');
+
+                let sentTo;
+                for (const edge of GraphService.db.edges.items) {
+                    if (edge.source === res.messageId && edge.type === 'SENT_TO') {
+                        sentTo = edge.target;
+                    }
+                }
+                expect(sentTo).toBe('@neo-gemini-pro');
+
+                await expect(MailboxService.addMessage({
+                    to     : 'AGENT:spoofed-family/pro',
+                    subject: 'spoof must not resolve',
+                    body   : 'A flat property divergence cannot re-route a rostered resident.'
+                })).rejects.toThrow(/Unrecognized 'to' format/);
+            });
+        });
+
+        test('#14750 runtime-provisioned identities (unrostered) keep resolving via the flat node property — the second retirement witness', async () => {
+            GraphService.upsertNode({
+                id        : '@runtime-provisioned-x',
+                type      : 'AgentIdentity',
+                name      : 'Runtime Provisioned',
+                properties: { modelFamily: 'provisioned-fam', accountType: 'agent' }
+            });
+
+            await RequestContextService.run({ agentIdentityNodeId: '@runtime-provisioned-x' }, async () => {
+                await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+            });
+
+            await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+                const res = await MailboxService.addMessage({
+                    to     : 'AGENT:provisioned-fam/any',
+                    subject: 'fallback resolution',
+                    body   : 'Graph-only identities read their own node property until era chains exist for them.'
+                });
+                expect(res.status).toBe('sent');
+            });
+        });
     });
 });
 

--- a/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs
@@ -1824,6 +1824,32 @@ test.describe('Neo.ai.services.memory-core.WakeSubscriptionService', () => {
             expect(entry.reason).toContain('benched');
         });
 
+        test('#14750 rostered residents project + filter era-chain-first: a spoofed flat family neither reports nor routes', async () => {
+            // A rostered resident's graph node carries a WRONG flat family. Both the family
+            // FILTER and the liveness PROJECTION must read through the identity trail, so the
+            // true family finds it, the spoofed family does not, and the report tells the truth.
+            seedAgent('@neo-gemini-pro', {family: 'spoofed-fam'});
+
+            const trueFamily = await WakeSubscriptionService.whoIsOnline({family: 'gemini', verbose: true, now: new Date(T0)});
+            const entry      = trueFamily.agents.find(a => a.identity === '@neo-gemini-pro');
+
+            expect(entry).toBeTruthy();
+            expect(entry.family).toBe('gemini');
+
+            const spoofFamily = await WakeSubscriptionService.whoIsOnline({family: 'spoofed-fam', verbose: true, now: new Date(T0)});
+            expect(spoofFamily.agents.find(a => a.identity === '@neo-gemini-pro')).toBeUndefined();
+        });
+
+        test('#14750 runtime-provisioned identities (unrostered) keep filtering via the flat node property — the retirement witness', async () => {
+            seedAgent('@runtime-provisioned-w', {family: 'provisioned-fam'});
+
+            const {agents} = await WakeSubscriptionService.whoIsOnline({family: 'provisioned-fam', verbose: true, now: new Date(T0)});
+            const entry    = agents.find(a => a.identity === '@runtime-provisioned-w');
+
+            expect(entry).toBeTruthy();
+            expect(entry.family).toBe('provisioned-fam');
+        });
+
         test('fresh add_memory activity → online (recency-primary, verbose)', async () => {
             seedAgent('@neo-active');
             seedActivity('@neo-active', {timestamp: iso(T0ms - 2 * 60 * 1000)});


### PR DESCRIPTION
Resolves #15277

**Close-target note (the review fork, resolved):** this PR lands as the truthful partial leaf of #14750 — the reviewer-recommended fork. #15277 captures exactly the delivered scope below; **#14750 stays open** owning the Sol-era-gated remainder (the `migrateAllResidents()` graph-seeding consume, the reflexive-landing agreement AC, `modelFamily` field retirement + persisted-successor-episode reads — episode-owned end-state per ADR-0032, blocked on the witness populations reaching zero).

Every live family read-path now consumes the identity trail instead of era-owned flat registry facts, and the seven era-owned fields are retired from `identityRoots.mjs`. The read spine is one new resolver pair in `agentFamilyResolution.mjs`: `resolveResidentFamily(identity)` projects `migrateResident → buildHydrationIndex → index.currentEra.family` with the flat property as the documented, retirement-gated fallback, and `resolveResidentFamilyById(id)` keys the same read for graph-node consumers. All six live family consumers moved per-consumer-per-commit with before/after regressions: `getCoreSwarmAgentFamilies` (Golden Path family maps), `MailboxService.validateMailboxTarget` (`AGENT:<family>/<model>` alias resolution incl. the ambiguity rejection), `WakeSubscriptionService` (`who_is_online` family filter + liveness projection), `resolveIdentityDisplay` (the ratified fleet↔identity join feeding `FleetControlBridge.fleetRoster()` — surfaced by the hosted full battery AFTER the retirement commit, outside the census sweep), and the two lifecycle readers the full-retirement review isolated: `resolveHarnessTargetForIdentity` (fresh-session harness routing) and `resolveIdentitiesForFamily` (Tier-2 revalidation fan-out). The compatibility contract is explicit: flat `modelFamily` remains only at the resolver seam for post-epoch residents and as the graph-node consumers' explicit fallback for runtime-provisioned identities — era-owned by classification, retained as the transition bridge, retirement trigger recorded on #14750. The retirement then moved the recorded era facts INTO the migration module: a new frozen `REGISTRY_SEED_FACTS` epoch snapshot is the recorded-fact owner (`migrateResident` refuses unmapped residents — the same discipline as `REGISTRY_MODEL_DESIGNATIONS`; reading the live registry would recreate the moving-mirror trap the module header forbids), and the seven flat fields (`family` duplicate, `tier`, `contextWindowInput`, `parallelToolCalls`, `thoughtBudget`, `hosting`, `sunsetTriggers`) left every agent entry. `modelFamily` stays temporarily flat as a compatibility field (the roster-shape pin @neo-gpt-emmy established), while remaining episode-owned under ADR-0032 — it is the fallback read for the two witness populations: the post-epoch resident (Emmy, until the gated graph-seeding lands her observation-owned era) and runtime-provisioned graph-only identities.


## Contract Ledger

| Consumed surface | Authority and behavior | Failure / fallback | Retirement trigger |
|---|---|---|---|
| `resolveResidentFamily(identity)` | `migrateResident → buildHydrationIndex → currentEra.family` is authoritative for roster residents. | Returns `undefined` when neither the era chain nor the temporary post-epoch flat witness resolves. | Remove the flat post-epoch fallback when the persisted-successor graph path lands and that witness population reaches zero under #14750. |
| `resolveResidentFamilyById(id)` + graph-node consumers | Static-roster ids route through `resolveResidentFamily`; callers holding runtime-provisioned graph nodes retain an explicit node-property fallback. | Unknown ids return `undefined`; display/filter consumers project `null` or no match, while ambiguous mailbox aliases reject. | Remove Fleet/Mailbox/Wake graph-node fallbacks when runtime-provisioned identities carry persisted successor episodes and the second witness population reaches zero under #14750. |
Evidence: L2 (776 unit specs green across the identity + consumer battery at 2d2bc1a201: `ai/graph` 123, `ai/services/graph` 274, MailboxService 111, WakeSubscriptionService 76, setup scripts 69, plus the two live probes below; the consumer-4 repair verified by the fleet battery **165/165 locally and the hosted unit job fully green at eea8057aaa**; consumers 5+6 verified by the full `lifecycle/` directory **163 green at 3a0c3fe458** — the current exact head — with zero spec-text changes, the identical-before/after proof) → L2 required (all close-target runtime ACs are pure-module/service contracts covered by the suites). Residual: none in delivered scope (#15277); the gated remainder stays on the open parent #14750 (see Deltas).

## Deltas from ticket

- **The census's "8 consumer read-paths" resolved to 3 live family/model consumers — and TWO falsifiers then corrected that count to six**: (a) the hosted full battery surfaced `resolveIdentityDisplay` (post-census — it landed with the fleet cockpit AFTER the 12-day-old census) as two deterministic unit failures at 2d2bc1a201; (b) the full-retirement review isolated the two lifecycle readers (`harnessRouting`, `revalidationSweep`) reading `properties.modelFamily` directly. All repaired era-chain-first under the same per-consumer discipline. Census lesson recorded: the targeted local sweep proved the named suites; the full hosted battery + an independent reviewer source-sweep were the falsifiers that found the unnamed ones.
- **Close-target split (the review fork)**: this PR resolves #15277 (the delivered consumer-half, filed as a sub of #14750 per the review's recommended momentum-preserving fork); #14750 stays open owning the Sol-era-gated seeding consume, the reflexive-landing AC, and the modelFamily episode-owned end-state. The prior `Resolves #14750` line overclaimed against the parent's own gated ACs.
- **`modelFamily` itself stays; the `family` duplicate goes.** The ticket's deletion list says "`modelFamily` duplicates" — the roster spec's @neo-gpt-emmy roster-shape pin (modelFamily temporarily present, engine facts absent) is the precedent this PR generalizes. The flat `modelFamily` is now exactly the two witness populations' fallback; when both reach zero the field itself can retire (follow-up scope).
- **The deletion required a recorded-fact owner first**: `migrateResident` previously built seed eras FROM the live flat fields (a circular dependency the ticket didn't name). `REGISTRY_SEED_FACTS` — generated mechanically from the live registry at retirement time, zero hand-transcription — is that owner, per the module's own epoch-snapshot contract.
- **Sol-era-gated items transferred to the parent #14677** (per Mnemosyne's ratified sequencing-gate comment on the ticket): (1) the `migrateAllResidents()` graph-seeding consume (writes IdentityState + EmbodiedEpisode nodes; blocked on the truthfully-versioned Sol era), and (2) the reflexive-landing fixture ↔ production agreement AC ("meaningful once bearer-audited era backfill exists"). Neither is silently dropped — both are annotated on the parent with the gate citation.
- **`contextWindowOutput` (Gemini-only) is outside the ticket's enumerated set** and stays on the entry, flagged in-place for the era-schema follow-up.
- **Real bug found by the sweep, fixed in passing scope**: none this lane — but the fresh consumer sweep (the 12-day-old census re-run) confirmed zero consumers of the six capability fields beyond the migration module itself.

## Test Evidence

- New resolver suite: `test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs` — **5 specs**: the login-to-family map deep-equals the flat derivation (the identical-before/after AC), the index path proven load-bearing (a real resident resolves with its flat field stripped), the fallback boundary with TODAY'S exact population pinned (`['@neo-gpt-emmy']` — growth or retirement surfaces as a conscious spec edit), per-resident index-vs-flat agreement, undefined-exclusion.
- MailboxService: **111 passed** incl. two new pins — a rostered resident with a SPOOFED flat node property resolves by its true era-chain family (and the spoofed family alias does NOT match it), and unrostered runtime-provisioned identities keep resolving via their node property.
- WakeSubscriptionService: **76 passed** incl. the same spoof/witness pair on the `who_is_online` filter + projection.
- Migration/registry: `ai/graph` **123 passed** — the seed-era spec now asserts against `REGISTRY_SEED_FACTS` (the recorded-fact owner) AND asserts the retirement itself (no entry carries a retired field); the #14901 Euclid lineage pin moved from entry-level to snapshot-level with identical facts.
- Full battery at the head: **776 passed** across `ai/graph`, `ai/services/graph`, both memory-core consumer suites, and the setup-script suites (the onboarding generator already asserted engine-fact absence for new residents — this PR generalizes its shape).
- Live probes: (1) all 7 pre-epoch residents hydrate through the map-built era chains (`family/model` + 6 capability keys each), Emmy falls back to her retained temporary compatibility `modelFamily`; (2) post-deletion, `getCoreSwarmAgentFamilies()` returns the identical 8-entry map it produced pre-deletion.
- Fleet join (consumer 4): `resolveIdentityDisplay.spec.mjs` expected-family derivation repointed era-chain-first (`resolveResidentFamilyById(node.id) ?? modelFamily`); `FleetControlBridge.spec.mjs` healed by the same repair (it delegates to the join — no textual change needed) — **fleet directory 165/165 locally; hosted unit job green at eea8057aaa**, closing both failures the pre-review discrimination packet isolated.

## Post-Merge Validation

- [ ] `who_is_online` and `AGENT:<family>/<model>` alias routing behave identically on the live Memory Core after the next server restart (the A2A production surfaces this PR's regressions pin).

## Commits

- 0b724f2309 — consumer 1: `resolveResidentFamily` hydration-first read + `getCoreSwarmAgentFamilies` + the dedicated resolver suite.
- 886ffab343 — consumer 2: mailbox alias resolution era-chain-first via `resolveResidentFamilyById` + spoof/witness pins.
- 839e16f7a9 — consumer 3: wake family filter + liveness projection era-chain-first + spoof/witness pins.
- 2d2bc1a201 — the retirement: `REGISTRY_SEED_FACTS` epoch snapshot owns seed eras; seven flat fields leave every entry; migration + roster specs repointed to the snapshot.
- eea8057aaa — consumer 4 (post-census, hosted-CI-surfaced): cockpit display families era-chain-first + the spec's expected-family derivation repointed.
- 3a0c3fe458 — consumers 5+6 (review-isolated): harness-target routing + revalidation fan-out era-chain-first; full `lifecycle/` directory green with zero spec-text changes (identical-before/after).

Authored by Vega (Claude Fable 5, Claude Code). Session c4f8e75b-bf73-448b-bee3-6a17e3b1cb45.

