### PR TITLE
feat(agentos): FM cockpit detail pop-out Stage-1 — shell-owned verbs + vessel admission state machine (#14610)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -779,12 +779,16 @@ class FleetCockpit extends Container {
             return {detached: false, errors: result.errors}
         }
 
+        // the window name stays an IMMUTABLE local across every await below: a raced reattach
+        // nulls the bookkeeping entry, but a stale-open cleanup still needs the name to close by
+        let windowName = `fm-agent-detail-${me.id}`;
+
         me.detachedDetail = {
             connectTimer  : null,
             homeTabIndex  : homeIndex,
             homeTabsNodeId: home,
             windowId      : null,
-            windowName    : `fm-agent-detail-${me.id}`
+            windowName
         };
         me.detachedDetailPane   = pane;
         me.detailVesselState    = 'opening';
@@ -812,10 +816,16 @@ class FleetCockpit extends Container {
             url           : `${basePath}apps/agentos/childapps/widget/index.html?detail=agent-detail&cockpitId=${me.id}`,
             windowFeatures: `height=640,width=480,left=${winData.screenLeft + 160},top=${winData.screenTop + 120}`,
             windowId      : me.windowId,
-            windowName    : me.detachedDetail.windowName
+            windowName
         });
 
         if (generation !== me.detailVesselGeneration) {
+            // the generation died DURING the open (a raced reattach/teardown already restored the
+            // dock state) — but a `true` completion means the vessel MATERIALIZED under the dead
+            // generation: stale continuations own the cleanup of resources they acquired, so close
+            // the orphan by its immutable name (fire-and-forget; nothing else may be touched)
+            opened && Neo.Main.windowClose({names: [windowName], windowId: me.windowId}).catch(() => {});
+
             return {detached: false, errors: ['superseded by a newer vessel operation']}
         }
 
@@ -853,7 +863,9 @@ class FleetCockpit extends Container {
      * SAME instance), and the vessel closes unless it already closed itself. Bookkeeping clears
      * BEFORE the async close — the cleared entry is the {@link #onWindowDisconnect} re-entrancy
      * guard. Increments {@link #detailVesselGeneration} first, so every in-flight admission
-     * continuation (open, URL read, connect timer) goes inert.
+     * continuation (open, URL read, connect timer) goes inert — and its OWN post-projection
+     * continuation revalidates the same way: a destroy (or newer operation) landing during the
+     * await limits this path to the vessel cleanup it still owns, never a cockpit-field write.
      * @param {Object} [options={}]
      * @param {Boolean} [options.windowAlreadyClosed=false] `true` when the disconnect path runs
      *     the reattach (the vessel is already gone — do not close it again).
@@ -868,7 +880,8 @@ class FleetCockpit extends Container {
             return {errors: ['agent-detail is not detached'], reattached: false}
         }
 
-        me.detailVesselGeneration++;
+        let generation = ++me.detailVesselGeneration;
+
         entry.connectTimer && clearTimeout(entry.connectTimer);
 
         let failure = me.lastDetailVesselFailure;
@@ -897,6 +910,16 @@ class FleetCockpit extends Container {
         me.onDockZoneDocumentChange(result.document);
 
         await me.refreshPromise;
+
+        if (me.isDestroyed || generation !== me.detailVesselGeneration) {
+            // a destroy (or a newer vessel operation) landed during the projection await: this
+            // continuation may perform ONLY the vessel cleanup it still owns — teardown skipped
+            // the close because this reattach had already cleared the bookkeeping entry — and
+            // must never resurrect cockpit fields (the pane is the newer owner's, or destroyed)
+            windowAlreadyClosed || Neo.Main.windowClose({names: [entry.windowName], windowId: me.windowId}).catch(() => {});
+
+            return {errors: ['superseded by teardown or a newer vessel operation'], reattached: false}
+        }
 
         // an external re-tree while detached left a stand-in occupying the slot, and the
         // reconciler keeps tree-live occupants — swap it for the live instance, same position

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -35,6 +35,14 @@ const FIXTURE_ACTIVITY = [
 ];
 
 /**
+ * @summary The bounded connect window for the detail vessel admission (ms): a popup that opened
+ * but never joins the shared heap inside this window takes the `failed-timeout` edge and rolls
+ * back to docked. Boundedness is the contract — an admission may fail, it may never hang.
+ * @type {Number}
+ */
+const DETAIL_VESSEL_CONNECT_WINDOW_MS = 10000;
+
+/**
  * @summary The Fleet keeper-view — the FM cockpit's default mission-control surface (design SSOT §01),
  * composed as a LIVE DOCK PROJECTION: the fleet zone (a density-ranked card roster + the
  * scale-to-a-glance health bar) over the live activity stream in the SSOT's ~1.55fr / 1fr split,
@@ -218,6 +226,59 @@ class FleetCockpit extends Container {
      * @protected
      */
     detailRecord = null
+    /**
+     * Detached-detail bookkeeping — `null` while the inspector is docked. While detached it holds
+     * `{homeTabsNodeId, homeTabIndex, windowId, windowName, connectTimer}`: the tabs node + EXACT
+     * index the reattach restores (`addTab` APPENDS by default — the stored index is the only
+     * placement truth), the vessel's `windowId` once it connects (`null` until then), the window
+     * name for the close call, and the bounded connect-window timer id. Cleared BEFORE the
+     * reattach's async vessel close — the cleared entry is the {@link #onWindowDisconnect}
+     * re-entrancy guard.
+     * @member {Object|null} detachedDetail=null
+     * @protected
+     */
+    detachedDetail = null
+    /**
+     * The live {@link AgentOS.view.fleet.AgentDetail} instance handle while it is OUT of this
+     * cockpit's projected tree (parked mid-flight or mounted in its vessel window). A
+     * popup-mounted pane lives in the vessel's view tree — out of this cockpit's `down()` /
+     * `getReference` reach — so every detail consumer routes through {@link #getAgentDetailPane}.
+     * `null` while docked (the projection owns the pane); survives one projection cycle past
+     * reattach so {@link #resolveDockComponentRef} re-adopts the SAME instance, never a recreation.
+     * @member {Neo.container.Base|null} detachedDetailPane=null
+     * @protected
+     */
+    detachedDetailPane = null
+    /**
+     * The vessel admission state machine's observable state — one word of truth for witnesses,
+     * Neural Link reads and the shell affordance:
+     * `docked → opening → connected → windowed → reattaching → docked`, with the two terminal
+     * failure edges `failed-blocked` (`Neo.Main.windowOpen` returned `false` — the blocked-popup
+     * PRIMARY failure path; it never throws) and `failed-timeout` (the bounded connect window
+     * expired before the vessel joined the heap). Both failure states roll back through the
+     * standard reattach and settle at `docked`; {@link #lastDetailVesselFailure} keeps the
+     * post-rollback trace.
+     * @member {String} detailVesselState='docked'
+     * @protected
+     */
+    detailVesselState = 'docked'
+    /**
+     * Generation counter for async-boundary revalidation: incremented at every pop-out start,
+     * reattach start and destroy. Every awaited continuation (vessel open, connect URL read,
+     * connect timer) re-checks its captured generation and goes inert on mismatch — a reattach or
+     * teardown racing an in-flight admission can never act on stale state.
+     * @member {Number} detailVesselGeneration=0
+     * @protected
+     */
+    detailVesselGeneration = 0
+    /**
+     * The last vessel admission failure (`'blocked'` / `'timeout'`), kept after the rollback
+     * settles so the failure stays observable once {@link #detailVesselState} returns to
+     * `docked`. `null` after a clean detach/reattach cycle.
+     * @member {String|null} lastDetailVesselFailure=null
+     * @protected
+     */
+    lastDetailVesselFailure = null
 
     /**
      * @summary Seed the layout SSOT and build the toolbar + dock projection as instance items —
@@ -233,6 +294,13 @@ class FleetCockpit extends Container {
         me.dockPreviewProducer = Neo.create(DockPreviewProducer);
         me.perspectiveStore    = Neo.create(DockPerspectiveStore, {collection: cockpitPresetCollection()});
         me.dockModel           = me.dockModel || cockpitDockDocument();
+
+        // vessel lifecycle: the popped-out inspector reparents on connect, comes home on disconnect
+        Neo.currentWorker.on({
+            connect   : me.onWindowConnect,
+            disconnect: me.onWindowDisconnect,
+            scope     : me
+        });
 
         me.add(me.buildWorkspaceItems())
     }
@@ -367,7 +435,10 @@ class FleetCockpit extends Container {
             host       : me,
             nextConfig,
             placeholders,
-            resolveItem: itemId => {
+            // a detached inspector is owner-preserved: the reconciler parks the pane (never
+            // destroys it) and retires only its obsolete tab button
+            preserveItemIds: me.detachedDetailPane ? ['detail'] : [],
+            resolveItem    : itemId => {
                 const item = document.items[itemId];
 
                 return DockLayoutAdapter.decorateProjectedItem(
@@ -407,6 +478,18 @@ class FleetCockpit extends Container {
             error.set({
                 hidden: !me.presetError,
                 html  : me.presetError || ''
+            })
+        }
+
+        let toggle = me.getReference('detail-window-toggle');
+
+        if (toggle) {
+            let state = me.detailVesselState,
+                out   = state === 'opening' || state === 'connected' || state === 'windowed';
+
+            toggle.set({
+                disabled: state === 'reattaching',
+                text    : out ? 'Reattach detail' : 'Pop out detail'
             })
         }
     }
@@ -455,6 +538,16 @@ class FleetCockpit extends Container {
                     cls      : ['fm-fleet-start-summary'],
                     hidden   : true,
                     reference: 'fleet-start-summary'
+                }, {
+                    // SHELL-owned pop-out affordance — panes are layout-blind and the shell owns
+                    // docking behavior. Routes by the vessel state machine; the label is synced
+                    // by syncControlBar so it always names the action it will take.
+                    module   : Button,
+                    cls      : ['fm-detail-window-toggle'],
+                    handler  : me.onDetailWindowToggle.bind(me),
+                    iconCls  : 'fa-solid fa-arrow-up-right-from-square',
+                    reference: 'detail-window-toggle',
+                    text     : 'Pop out detail'
                 }, {
                     module : Button,
                     cls    : ['fm-fleet-start'],
@@ -522,9 +615,30 @@ class FleetCockpit extends Container {
                     reference   : 'activity-stream'
                 };
             case 'agent-detail':
+                // the pane lives in its vessel window — a preset restore (or an NL-driven addTab)
+                // can re-tree the `detail` item while detached, and materializing here would STEAL
+                // the live instance out of its window: an honest stand-in instead. The reattach
+                // swaps it for the live pane post-projection (the reconciler prefers tree-live
+                // occupants over this resolver, so the swap cannot ride the normal adoption).
+                if (me.detachedDetail) {
+                    return {
+                        ntype    : 'component',
+                        cls      : [marker, 'fm-pane-placeholder'],
+                        html     : 'Agent detail is open in its own window',
+                        reference: 'agent-detail-standin'
+                    }
+                }
+
+                // reattach re-adoption: the parked LIVE instance returns to the projection —
+                // same instance id, same runtime state, never a recreation
+                if (me.detachedDetailPane) {
+                    return me.detachedDetailPane
+                }
+
                 // the drill-in inspector; its selected resident is OWNER-held so a pane returning
                 // from true absence never drops the selection — null renders the view's honest
-                // "select an agent" empty state
+                // "select an agent" empty state. The pane stays layout-blind: the pop-out
+                // affordance lives in SHELL chrome, never on the pane.
                 return {
                     module   : AgentDetail,
                     cls      : [marker],
@@ -612,17 +726,292 @@ class FleetCockpit extends Container {
     }
 
     /**
+     * @summary Resolve the live {@link AgentOS.view.fleet.AgentDetail} instance wherever it
+     * currently renders — the projected tree while docked, the owner-held handle while detached.
+     * A vessel-mounted pane lives in the popup's view tree, out of this cockpit's `down()` /
+     * `getReference` reach, so every detail consumer (record mutation, selection reconciliation,
+     * the card→detail drill) routes through this accessor — the popped-out inspector stays as
+     * live as the docked one.
+     * @returns {Neo.container.Base|null} The detail pane, or `null` before its first materialization.
+     */
+    getAgentDetailPane() {
+        return this.detachedDetailPane || this.getReference('agent-detail')
+    }
+
+    /**
+     * @summary Detach the agent-detail inspector into its own OS window on the shared heap —
+     * the `docked → opening` edge of the vessel admission state machine.
+     *
+     * The dock document stays the layout SSOT: `detachItem` prunes the `detail` item from the
+     * tree while preserving its catalog record, and the tabs node + EXACT index are stored FIRST
+     * (`addTab` appends by default — the stored index is the only placement truth the reattach
+     * has). The LIVE pane parks via the reconciler's `preserveItemIds` (awaited, so the vessel's
+     * connect can never race a pane the old shell still holds), then the widget-childapp vessel
+     * opens. `Neo.Main.windowOpen` resolves **Boolean** — `false` IS the blocked-popup failure
+     * (it never throws), taking the `failed-blocked` edge and rolling back through the standard
+     * reattach. A vessel that opens but never joins the heap inside the bounded connect window
+     * takes the `failed-timeout` edge the same way. Every awaited continuation revalidates
+     * {@link #detailVesselGeneration}.
+     * @returns {Promise<{detached: Boolean, errors: String[]}>}
+     */
+    async popOutAgentDetail() {
+        let me   = this,
+            pane = me.getReference('agent-detail'),
+            home = DockZoneModel.findContainingTabsId(me.dockModel, 'detail');
+
+        if (me.detachedDetail || !pane || !home) {
+            return {detached: false, errors: ['agent-detail is not a docked, projected pane']}
+        }
+
+        let generation = ++me.detailVesselGeneration,
+            homeIndex  = me.dockModel.nodes[home].items.indexOf('detail'),
+            result     = me.applyDockZoneOperation({operation: 'detachItem', itemId: 'detail'});
+
+        if (result.errors.length) {
+            return {detached: false, errors: result.errors}
+        }
+
+        me.detachedDetail = {
+            connectTimer  : null,
+            homeTabIndex  : homeIndex,
+            homeTabsNodeId: home,
+            windowId      : null,
+            windowName    : `fm-agent-detail-${me.id}`
+        };
+        me.detachedDetailPane   = pane;
+        me.detailVesselState    = 'opening';
+        me.lastDetailVesselFailure = null;
+
+        // the re-projection parks the preserved pane (alive on the shared heap, out of every
+        // parent) and retires its tab button — awaited before the vessel opens
+        me.onDockZoneDocumentChange(result.document);
+        await me.refreshPromise;
+
+        if (generation !== me.detailVesselGeneration) {
+            return {detached: false, errors: ['superseded by a newer vessel operation']}
+        }
+
+        let {windowConfigs} = Neo,
+            firstWindowId   = Object.keys(windowConfigs)[0],
+            {basePath}      = windowConfigs[firstWindowId],
+            winData         = await Neo.Main.getWindowData({windowId: me.windowId});
+
+        if (generation !== me.detailVesselGeneration) {
+            return {detached: false, errors: ['superseded by a newer vessel operation']}
+        }
+
+        let opened = await Neo.Main.windowOpen({
+            url           : `${basePath}apps/agentos/childapps/widget/index.html?detail=agent-detail&cockpitId=${me.id}`,
+            windowFeatures: `height=640,width=480,left=${winData.screenLeft + 160},top=${winData.screenTop + 120}`,
+            windowId      : me.windowId,
+            windowName    : me.detachedDetail.windowName
+        });
+
+        if (generation !== me.detailVesselGeneration) {
+            return {detached: false, errors: ['superseded by a newer vessel operation']}
+        }
+
+        if (!opened) {
+            // the PRIMARY real-world failure: the browser blocked the popup. Boolean grammar —
+            // no exception ever fires here. Restore the docked state commit-or-neither.
+            me.detailVesselState       = 'failed-blocked';
+            me.lastDetailVesselFailure = 'blocked';
+
+            await me.reattachAgentDetail({windowAlreadyClosed: true});
+
+            return {detached: false, errors: ['popup blocked: the vessel window did not open']}
+        }
+
+        // bounded connect window: a vessel that opened but never joins the heap rolls back
+        me.detachedDetail.connectTimer = setTimeout(() => {
+            if (generation === me.detailVesselGeneration && me.detailVesselState === 'opening') {
+                me.detailVesselState       = 'failed-timeout';
+                me.lastDetailVesselFailure = 'timeout';
+                me.reattachAgentDetail()
+            }
+        }, DETAIL_VESSEL_CONNECT_WINDOW_MS);
+
+        me.syncControlBar();
+
+        return {detached: true, errors: []}
+    }
+
+    /**
+     * @summary Bring the detached inspector home — the `* → reattaching → docked` edge.
+     *
+     * `addTab` returns the `detail` item into its remembered tabs node at its remembered EXACT
+     * index (first-tabs fallback with honest append when a preset retired the node); the parked
+     * instance is re-adopted by the projection ({@link #resolveDockComponentRef} hands back the
+     * SAME instance), and the vessel closes unless it already closed itself. Bookkeeping clears
+     * BEFORE the async close — the cleared entry is the {@link #onWindowDisconnect} re-entrancy
+     * guard. Increments {@link #detailVesselGeneration} first, so every in-flight admission
+     * continuation (open, URL read, connect timer) goes inert.
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.windowAlreadyClosed=false] `true` when the disconnect path runs
+     *     the reattach (the vessel is already gone — do not close it again).
+     * @returns {Promise<{reattached: Boolean, errors: String[]}>}
+     */
+    async reattachAgentDetail({windowAlreadyClosed=false}={}) {
+        let me    = this,
+            entry = me.detachedDetail,
+            pane  = me.detachedDetailPane;
+
+        if (!entry || !pane) {
+            return {errors: ['agent-detail is not detached'], reattached: false}
+        }
+
+        me.detailVesselGeneration++;
+        entry.connectTimer && clearTimeout(entry.connectTimer);
+
+        let failure = me.lastDetailVesselFailure;
+
+        me.detailVesselState = 'reattaching';
+
+        let homeLive = me.dockModel.nodes[entry.homeTabsNodeId]?.type === 'tabs',
+            home     = homeLive
+                ? entry.homeTabsNodeId
+                : Object.keys(me.dockModel.nodes).find(id => me.dockModel.nodes[id].type === 'tabs'),
+            result   = me.applyDockZoneOperation({
+                operation : 'addTab',
+                itemId    : 'detail',
+                tabsNodeId: home,
+                index     : homeLive ? entry.homeTabIndex : undefined
+            });
+
+        if (result.errors.length) {
+            return {errors: result.errors, reattached: false}
+        }
+
+        me.detachedDetail = null;
+
+        // the re-projection re-adopts the instance: the resolver hands it back and the
+        // container insert performs the atomic move out of the vessel viewport (core contract)
+        me.onDockZoneDocumentChange(result.document);
+
+        await me.refreshPromise;
+
+        // an external re-tree while detached left a stand-in occupying the slot, and the
+        // reconciler keeps tree-live occupants — swap it for the live instance, same position
+        let standin = me.getReference('agent-detail-standin');
+
+        if (standin) {
+            let parent = standin.parent,
+                index  = parent.items.indexOf(standin);
+
+            parent.remove(standin, true);
+            parent.insert(index, pane)
+        }
+
+        me.detachedDetailPane      = null;
+        me.detailVesselState       = 'docked';
+        me.lastDetailVesselFailure = failure;
+
+        me.syncControlBar();
+
+        if (!windowAlreadyClosed) {
+            try {
+                await Neo.Main.windowClose({names: [entry.windowName], windowId: me.windowId})
+            } catch (error) {
+                return {errors: [`popup close failed: ${error?.message || error}`], reattached: true}
+            }
+        }
+
+        return {errors: [], reattached: true}
+    }
+
+    /**
+     * @summary The SHELL-owned window-toggle affordance routes by the state machine: docked →
+     * {@link #popOutAgentDetail}; opening/connected/windowed → {@link #reattachAgentDetail};
+     * a reattach already in flight is a guarded no-op. The pane itself carries no dock semantics —
+     * panes stay layout-blind; the shell owns docking behavior.
+     * @returns {Promise<Object>} The routed operation's result.
+     */
+    onDetailWindowToggle() {
+        let me                         = this,
+            {detailVesselState: state} = me;
+
+        if (state === 'reattaching') {
+            return Promise.resolve({errors: ['reattach in flight'], reattached: false})
+        }
+
+        return me.detachedDetail ? me.reattachAgentDetail() : me.popOutAgentDetail()
+    }
+
+    /**
+     * @summary A window joined the shared heap: if it is OUR detail vessel (the pop-out URL
+     * carries `detail=agent-detail&cockpitId=<this.id>`), take the `opening → connected →
+     * windowed` edges — move the parked LIVE pane into the vessel's main view. The instance
+     * moves trees on the one App-Worker heap; nothing re-instantiates. The URL read is an async
+     * boundary: the captured generation revalidates after it.
+     * @param {Object} data `{appName, windowId}`
+     * @protected
+     */
+    async onWindowConnect(data) {
+        let me         = this,
+            {windowId} = data,
+            app        = Neo.apps[windowId],
+            generation = me.detailVesselGeneration;
+
+        if (!app || me.isDestroyed || !me.detachedDetail || !me.detachedDetailPane) {
+            return
+        }
+
+        let url    = await Neo.Main.getByPath({path: 'document.URL', windowId}),
+            params = new URL(url).searchParams;
+
+        if (
+            generation !== me.detailVesselGeneration ||
+            me.detailVesselState !== 'opening'       ||
+            params.get('cockpitId') !== me.id        ||
+            params.get('detail') !== 'agent-detail'
+        ) {
+            return
+        }
+
+        let {connectTimer} = me.detachedDetail;
+
+        connectTimer && clearTimeout(connectTimer);
+
+        me.detachedDetail.connectTimer = null;
+        me.detachedDetail.windowId     = windowId;
+        me.detailVesselState           = 'connected';
+
+        app.mainView.add(me.detachedDetailPane);
+
+        me.detailVesselState = 'windowed';
+        me.syncControlBar()
+    }
+
+    /**
+     * @summary The detail vessel closed (user-closed or crashed): correlate by `windowId` and
+     * bring the inspector HOME through the standard reattach — the document records the return
+     * and the projection re-adopts the parked instance. A reattach-initiated close never
+     * re-enters: {@link #reattachAgentDetail} clears the bookkeeping before closing the vessel.
+     * @param {Object} data `{appName, windowId}`
+     * @protected
+     */
+    onWindowDisconnect(data) {
+        let me = this;
+
+        if (!me.isDestroyed && me.detachedDetail?.windowId === data.windowId) {
+            me.reattachAgentDetail({windowAlreadyClosed: true})
+        }
+    }
+
+    /**
      * @summary Keep the open detail inspector truthful over time — route the roster store's
-     * `recordChange` to the mounted {@link AgentOS.view.fleet.AgentDetail} when the changed record
+     * `recordChange` to the live {@link AgentOS.view.fleet.AgentDetail} when the changed record
      * is the one being inspected (mirrors how the grid routes `recordChange` to its cards). A roster
      * re-poll mutating the selected resident (state, lane, sources) thus re-renders the detail in
      * place — the view is reactive to record MUTATION, not only to a re-seat onto a new record.
+     * Routed through {@link #getAgentDetailPane} so a popped-out inspector updates exactly like a
+     * docked one.
      * @param {Object} data The store `recordChange` event `{record, ...}`.
      * @protected
      */
     onDetailRecordChange({record}) {
         if (record === this.detailRecord) {
-            this.getReference('agent-detail')?.applyRecord()
+            this.getAgentDetailPane()?.applyRecord()
         }
     }
 
@@ -655,19 +1044,40 @@ class FleetCockpit extends Container {
 
         if (current !== me.detailRecord) {
             me.detailRecord = current;
-            me.getReference('agent-detail')?.set({record: current})
+            me.getAgentDetailPane()?.set({record: current})
         }
     }
 
     /**
-     * @summary Detach the roster-store load guard and release the drop producer; the provider
-     * tears the owned store itself down.
+     * @summary Detach the roster-store load guard, the vessel lifecycle listeners and the drop
+     * producer; the provider tears the owned store itself down. A still-detached inspector is
+     * OWNED state outside any projection: bump the generation (in-flight admission continuations
+     * go inert), clear the connect timer, close its vessel (fire-and-forget — the guard in
+     * {@link #onWindowDisconnect} keeps a late event inert) and destroy the instance.
      * @param {...*} args
      */
     destroy(...args) {
         let me = this;
 
         me.getReference('fleet-grid')?.store?.un({load: me.onRosterStoreLoad, recordChange: me.onDetailRecordChange, scope: me});
+
+        Neo.currentWorker.un({
+            connect   : me.onWindowConnect,
+            disconnect: me.onWindowDisconnect,
+            scope     : me
+        });
+
+        me.detailVesselGeneration++;
+
+        if (me.detachedDetail) {
+            me.detachedDetail.connectTimer && clearTimeout(me.detachedDetail.connectTimer);
+            Neo.Main.windowClose({names: [me.detachedDetail.windowName], windowId: me.windowId}).catch(() => {});
+            me.detachedDetail = null
+        }
+
+        me.detachedDetailPane?.destroy();
+        me.detachedDetailPane = null;
+
         me.dockPreviewProducer?.destroy();
         me.dockPreviewProducer = null;
         me.perspectiveStore?.destroy();

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -35,14 +35,6 @@ const FIXTURE_ACTIVITY = [
 ];
 
 /**
- * @summary The bounded connect window for the detail vessel admission (ms): a popup that opened
- * but never joins the shared heap inside this window takes the `failed-timeout` edge and rolls
- * back to docked. Boundedness is the contract — an admission may fail, it may never hang.
- * @type {Number}
- */
-const DETAIL_VESSEL_CONNECT_WINDOW_MS = 10000;
-
-/**
  * @summary The Fleet keeper-view — the FM cockpit's default mission-control surface (design SSOT §01),
  * composed as a LIVE DOCK PROJECTION: the fleet zone (a density-ranked card roster + the
  * scale-to-a-glance health bar) over the live activity stream in the SSOT's ~1.55fr / 1fr split,
@@ -108,6 +100,15 @@ class FleetCockpit extends Container {
          * @member {Neo.controller.Component} controller=FleetCockpitController
          */
         controller: FleetCockpitController,
+        /**
+         * The bounded connect window (ms) an opened detail vessel gets before the
+         * `failed-timeout` edge fires and the admission rolls back to docked. Boundedness is the
+         * contract — an admission may fail, it may never hang. Non-reactive class-config default:
+         * `Neo.overwrites`-eligible and instance-configurable (witnesses pass a short window at
+         * creation).
+         * @member {Number} detailVesselConnectWindowMs=10000
+         */
+        detailVesselConnectWindowMs: 10000,
         /**
          * The cockpit-level roster host — ONE provider-owned {@link AgentOS.store.FleetRoster}
          * instance (autoLoaded from the JSON sample seed) that the grid + health bar bind; the
@@ -279,14 +280,6 @@ class FleetCockpit extends Container {
      * @protected
      */
     lastDetailVesselFailure = null
-    /**
-     * The bounded connect window (ms) this instance grants an opened vessel before the
-     * `failed-timeout` edge fires. Instance-level so witnesses can exercise the timeout path
-     * deterministically; the module default is the product truth.
-     * @member {Number} detailVesselConnectWindowMs=DETAIL_VESSEL_CONNECT_WINDOW_MS
-     * @protected
-     */
-    detailVesselConnectWindowMs = DETAIL_VESSEL_CONNECT_WINDOW_MS
 
     /**
      * @summary Seed the layout SSOT and build the toolbar + dock projection as instance items —

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -279,6 +279,14 @@ class FleetCockpit extends Container {
      * @protected
      */
     lastDetailVesselFailure = null
+    /**
+     * The bounded connect window (ms) this instance grants an opened vessel before the
+     * `failed-timeout` edge fires. Instance-level so witnesses can exercise the timeout path
+     * deterministically; the module default is the product truth.
+     * @member {Number} detailVesselConnectWindowMs=DETAIL_VESSEL_CONNECT_WINDOW_MS
+     * @protected
+     */
+    detailVesselConnectWindowMs = DETAIL_VESSEL_CONNECT_WINDOW_MS
 
     /**
      * @summary Seed the layout SSOT and build the toolbar + dock projection as instance items —
@@ -829,7 +837,7 @@ class FleetCockpit extends Container {
                 me.lastDetailVesselFailure = 'timeout';
                 me.reattachAgentDetail()
             }
-        }, DETAIL_VESSEL_CONNECT_WINDOW_MS);
+        }, me.detailVesselConnectWindowMs);
 
         me.syncControlBar();
 

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -158,7 +158,10 @@ class FleetCockpitController extends Controller {
         }
 
         cockpit.detailRecord = record;
-        me.getReference('agent-detail')?.set({record});
+        // routed through the owner accessor: a popped-out inspector lives in the vessel's view
+        // tree (outside this controller's getReference reach) and must drill exactly like a
+        // docked one
+        cockpit.getAgentDetailPane()?.set({record});
 
         if (cockpit.dockModel?.items?.detail?.autoHidden) {
             const result = cockpit.applyDockZoneOperation({operation: 'setItemAutoHidden', itemId: 'detail', autoHidden: false});

--- a/test/playwright/e2e/agentos/FleetCockpitPopOutNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitPopOutNL.spec.mjs
@@ -1,0 +1,187 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * Whitebox-e2e for the Stage-1 cockpit pop-out: the agent-detail inspector detaches to a REAL
+ * second browser window while staying on the ONE SharedWorker App-Worker heap, and comes home —
+ * reparent-never-recreate, live through every phase, with the SHELL owning every affordance
+ * (the pane carries zero dock semantics):
+ *
+ * 1. drill: the controller seam seats a resident and reveals the detail inspector (the standard
+ *    commit loop);
+ * 2. detach: the cockpit toolbar's window-toggle opens the widget-childapp vessel — the dock
+ *    document prunes the `detail` item but keeps its catalog record (Neural Link topology stays
+ *    truthful), the admission state machine walks docked → opening → windowed, and the SAME
+ *    AgentDetail instance (App-Worker id) renders in the popup;
+ * 3. live continuity: selecting a DIFFERENT resident from the MAIN window re-renders the
+ *    popped-out inspector — main-window intent → App Worker → popup render target, no remount;
+ * 4. reattach: the SAME shell toggle brings the item home at its EXACT remembered tab index,
+ *    closes the vessel, and the SAME instance renders docked with the state it gathered while
+ *    windowed.
+ *
+ * The full gesture-driven drill tour (card → detail → pop-out → reattach as a narrated journey)
+ * is the drill-e2e sibling leaf's scope; this witness proves the capability spine it builds on.
+ *
+ * Run: NEO_E2E_PORT=8119 npx playwright test agentos/FleetCockpitPopOutNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('AgentOS Fleet cockpit — agent-detail pop-out round-trip (Neural Link)', () => {
+    test.setTimeout(120000);
+
+    test('detach → own OS window on the shared heap → live update while windowed → reattach home', async ({page, neuralLink}) => {
+        const pageErrors = [];
+
+        page.on('pageerror', error => {
+            const value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/agentos/index.html');
+        await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
+
+        // 1) drill through the REAL controller seam (onAgentSelect: owner-held record + the
+        // setItemAutoHidden reveal through the commit loop). Driven via callMethod because the
+        // card-click → agentSelect DOM chain is regressed on dev (own bug ticket; the full
+        // gesture journey belongs to the drill-e2e sibling leaf) — the seam below the gesture is
+        // the production path.
+        await expect(page.locator('.fm-agent-card').first()).toBeVisible({timeout: 30000});
+
+        const app   = await neuralLink.connectToApp('AgentOS'),
+              cards = await app.queryComponent({className: 'AgentOS.view.fleet.AgentCard'}, ['record', 'id']);
+
+        expect(cards.length, 'the fleet renders cards with records').toBeGreaterThan(1);
+
+        const controllers  = await app.findInstances({className: 'AgentOS.view.fleet.FleetCockpitController'}, ['id']),
+              controllerId = (Array.isArray(controllers) ? controllers[0] : controllers)?.id,
+              firstAgentId = cards[0]?.properties?.record?.agentId;
+
+        expect(controllerId, 'the cockpit controller must exist in the App Worker').toBeTruthy();
+        expect(firstAgentId, 'the first card carries a resident record').toBeTruthy();
+
+        await app.callMethod(controllerId, 'onAgentSelect', [{agentId: firstAgentId}]);
+
+        const detailRoot = page.locator('.fm-agent-detail');
+
+        await expect(detailRoot).toBeVisible({timeout: 30000});
+
+        // the SHELL owns the affordance: the toolbar toggle exists; the pane carries none
+        const toggle = page.locator('.fm-detail-window-toggle');
+
+        await expect(toggle).toBeVisible();
+        await expect(toggle).toContainText('Pop out detail');
+
+        const cockpits = await app.findInstances({className: 'AgentOS.view.fleet.FleetCockpit'}, ['id']),
+              holderId = (Array.isArray(cockpits) ? cockpits[0] : cockpits)?.id,
+              details  = await app.findInstances({className: 'AgentOS.view.fleet.AgentDetail'}, ['id']),
+              detail0  = Array.isArray(details) ? details[0] : details,
+              detailId = detail0?.id;
+
+        expect(holderId, 'the FleetCockpit must exist in the App Worker').toBeTruthy();
+        expect(detailId, 'the AgentDetail must exist in the App Worker').toBeTruthy();
+
+        const queryDetail = async () => {
+            const matches = await app.queryComponent({className: 'AgentOS.view.fleet.AgentDetail'}, ['record', 'id']);
+            return (Array.isArray(matches) ? matches : [matches]).find(candidate => candidate?.id === detailId)
+        };
+
+        const queryVesselState = async () => {
+            const matches = await app.queryComponent({className: 'AgentOS.view.fleet.FleetCockpit'}, ['detailVesselState', 'id']);
+            return (Array.isArray(matches) ? matches : [matches]).find(candidate => candidate?.id === holderId)?.properties?.detailVesselState
+        };
+
+        const drilledAgentId = (await queryDetail())?.properties?.record?.agentId;
+
+        expect(drilledAgentId, 'the drill seated a resident record').toBeTruthy();
+        expect(await queryVesselState()).toBe('docked');
+
+        const topoDocked = await app.getDockTopology(holderId),
+              docDocked  = topoDocked?.document ?? topoDocked;
+
+        expect(docDocked.nodes['secondary-rail'].items).toContain('detail');
+
+        const homeIndexBefore = docDocked.nodes['secondary-rail'].items.indexOf('detail');
+
+        // 2) detach: ONE shell-toggle click opens the REAL vessel window
+        const popupPromise = page.waitForEvent('popup', {timeout: 30000});
+
+        await toggle.click();
+
+        const popup = await popupPromise;
+
+        await popup.waitForLoadState('domcontentloaded');
+        expect(popup.url()).toContain('childapps/widget/index.html');
+        expect(popup.url()).toContain('cockpitId=');
+
+        const popupErrors = [];
+
+        popup.on('pageerror', error => {
+            const value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && popupErrors.push(value)
+        });
+
+        // the SAME live instance renders in the popup; the main window no longer shows it
+        await expect(popup.locator('.fm-agent-detail')).toBeVisible({timeout: 30000});
+        await expect(page.locator('.fm-agent-detail')).toHaveCount(0);
+
+        // the admission machine reached its settled windowed state
+        await expect.poll(queryVesselState, {timeout: 15000}).toBe('windowed');
+        await expect(toggle).toContainText('Reattach detail');
+
+        // document truth while detached: out of the tree, still in the catalog
+        const topoDetached = await app.getDockTopology(holderId),
+              docDetached  = topoDetached?.document ?? topoDetached;
+
+        expect(docDetached.nodes['secondary-rail'].items).not.toContain('detail');
+        expect(docDetached.items.detail, 'detachItem keeps the catalog record').toBeTruthy();
+
+        expect((await queryDetail())?.properties?.record?.agentId).toBe(drilledAgentId);
+
+        // 3) live continuity: a MAIN-window drill re-renders the WINDOWED inspector —
+        // one heap, two render targets, zero remounts
+        const secondAgentId = cards
+            .map(candidate => candidate?.properties?.record?.agentId)
+            .find(agentId => agentId && agentId !== drilledAgentId);
+
+        expect(secondAgentId, 'a second resident exists to drill into').toBeTruthy();
+        await app.callMethod(controllerId, 'onAgentSelect', [{agentId: secondAgentId}]);
+
+        await expect
+            .poll(async () => (await queryDetail())?.properties?.record?.agentId, {
+                message: 'the detached inspector must re-seat onto the newly selected resident',
+                timeout: 15000
+            })
+            .not.toBe(drilledAgentId);
+
+        const reseatedAgentId = (await queryDetail())?.properties?.record?.agentId;
+
+        // the POPUP's DOM renders the re-seated resident — worker truth reached the second window
+        await expect
+            .poll(async () => (await popup.locator('.fm-detail-id').textContent())?.trim(), {timeout: 15000})
+            .toBe(reseatedAgentId);
+
+        // 4) reattach via the SAME shell toggle: the item re-trees at its EXACT remembered index,
+        // the vessel closes as an effect, and the SAME instance renders docked with the state it
+        // gathered while windowed
+        const popupClosed = popup.waitForEvent('close', {timeout: 30000});
+
+        await toggle.click();
+        await popupClosed;
+
+        await expect(page.locator('.fm-agent-detail')).toBeVisible({timeout: 30000});
+        await expect.poll(queryVesselState, {timeout: 15000}).toBe('docked');
+
+        const topoHome = await app.getDockTopology(holderId),
+              docHome  = topoHome?.document ?? topoHome;
+
+        expect(docHome.nodes['secondary-rail'].items).toContain('detail');
+        expect(docHome.nodes['secondary-rail'].items.indexOf('detail'), 'exact-index restore — never an append').toBe(homeIndexBefore);
+
+        const home      = await app.findInstances({className: 'AgentOS.view.fleet.AgentDetail'}, ['id']),
+              homeIds   = (Array.isArray(home) ? home : [home]).map(entry => entry?.id),
+              homeState = await queryDetail();
+
+        expect(homeIds, 'exactly one AgentDetail instance exists — never a recreation').toEqual([detailId]);
+        expect(homeState?.properties?.record?.agentId, 'the windowed-phase selection came home with the instance').toBe(reseatedAgentId);
+
+        expect(pageErrors, 'zero main-window page errors').toEqual([]);
+        expect(popupErrors, 'zero popup page errors').toEqual([])
+    })
+});

--- a/test/playwright/setup.mjs
+++ b/test/playwright/setup.mjs
@@ -148,6 +148,7 @@ export function setup(options = {}) {
         insertThemeFiles: () => {},
         isSharedWorker  : false,
         on              : () => {},
+        un              : () => {},
         promiseMessage  : async (dest, msg) => {
             if (msg?.action === 'readDom') {
                 if (msg.attributes?.includes('offsetHeight')) {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -862,6 +862,9 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
                 detailRecord: null,
                 dockModel   : {items: {detail: {autoHidden: true}}},
                 applyDockZoneOperation(op) { applied.push(op); return {document: {revealed: true}, errors: []} },
+                // the controller drill routes through the OWNER accessor (docked pane here;
+                // the vessel-held handle while detached — the pop-out suite covers that phase)
+                getAgentDetailPane() { return detail },
                 onDockZoneDocumentChange(doc) { this.committed = doc }
             },
             controller = Object.create(FleetCockpitController.prototype);
@@ -889,6 +892,7 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
                 detailRecord: null,
                 dockModel   : {items: {detail: {autoHidden: false}}},   // already revealed
                 applyDockZoneOperation(op) { applied.push(op); return {document: {}, errors: []} },
+                getAgentDetailPane() { return detail },
                 onDockZoneDocumentChange() { this.reprojected = true }
             },
             controller = Object.create(FleetCockpitController.prototype);

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -389,6 +389,10 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         const grid = {adapterState: 'sample', store};
 
         const cockpit = {
+            // the real accessor runs against this fake's getReference — the detail consumers
+            // route through it (docked: projected pane; detached: the owner-held handle)
+            detachedDetailPane: null,
+            getAgentDetailPane: FleetCockpit.prototype.getAgentDetailPane,
             getReference      : reference => reference === 'fleet-grid' ? grid : reference === 'agent-detail' ? detail : null,
             grid,
             id                : `fake-fleet-cockpit-${index}`,

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
@@ -256,9 +256,18 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
     test('bounded connect window: a vessel that never joins takes the failed-timeout edge and rolls back', async () => {
         vessel = installWindowVessel({popupUrl: null});
 
-        const pane = await revealDetail();
+        // the short window rides the class-config contract: passed at CREATION (instance config
+        // over the `static config` default), never poked onto an internal field post-construct
+        cockpit.destroy();
+        cockpit = Neo.create(FleetCockpit, {
+            detailVesselConnectWindowMs: 20,
+            stateProvider              : {
+                module: StateProvider,
+                stores: {fleetRoster: {module: FleetRoster, autoLoad: false}}
+            }
+        });
 
-        cockpit.detailVesselConnectWindowMs = 20;
+        const pane = await revealDetail();
 
         const result = await cockpit.popOutAgentDetail();
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
@@ -1,0 +1,379 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'FleetCockpitPopOutTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import '../../../../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
+import Container     from '../../../../../../../src/container/Base.mjs';
+import FleetCockpit  from '../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs';
+import FleetRoster   from '../../../../../../../apps/agentos/store/FleetRoster.mjs';
+import StateProvider from '../../../../../../../src/state/Provider.mjs';
+
+/**
+ * @summary Installs deterministic popup-vessel seams for the cockpit pop-out specs.
+ *
+ * The seams model the REAL call grammar: `Neo.Main.windowOpen` resolves a **Boolean** — a blocked
+ * popup resolves `false`, it never throws — so the specs exercise the admission state machine on
+ * the same truth production runs on. The real OS-window round-trip is owned by the E2E witness;
+ * these seams isolate document ownership, park/re-adopt identity, the failure edges and close
+ * bookkeeping without weakening the call contract.
+ * @param {Object} [options={}]
+ * @param {Boolean} [options.openResult=true] What `windowOpen` resolves — `false` = blocked popup.
+ * @param {String|null} [options.popupUrl=null] The URL `getByPath` reports for the vessel window.
+ * @returns {Object} spy state + `restore()`.
+ */
+function installWindowVessel({openResult = true, popupUrl = null} = {}) {
+    let previous = {
+            getByPath    : Neo.Main.getByPath,
+            getWindowData: Neo.Main.getWindowData,
+            windowClose  : Neo.Main.windowClose,
+            windowOpen   : Neo.Main.windowOpen
+        },
+        previousWindowConfigs = Neo.windowConfigs,
+        state = {closeCalls: [], openCalls: []};
+
+    Neo.windowConfigs = {'unit-window': {basePath: './'}};
+
+    Neo.Main.getByPath     = async () => popupUrl;
+    Neo.Main.getWindowData = async () => ({screenLeft: 10, screenTop: 20});
+    Neo.Main.windowOpen    = async data => {
+        state.openCalls.push(data);
+        return openResult
+    };
+    Neo.Main.windowClose   = async data => {
+        state.closeCalls.push(data)
+    };
+
+    return {
+        get closeCalls() { return state.closeCalls },
+        get openCalls()  { return state.openCalls },
+        restore() {
+            Object.assign(Neo.Main, previous);
+            Neo.windowConfigs = previousWindowConfigs
+        }
+    }
+}
+
+/**
+ * Contract specs for the Stage-1 pop-out: shell-owned verbs + the vessel admission state machine.
+ * The pins: the observable state edges (docked → opening → connected → windowed → reattaching →
+ * docked, plus the two failure edges), the Boolean-`windowOpen` PRIMARY failure path, the bounded
+ * connect window, generation revalidation making stale continuations inert, exact-index restore
+ * (`addTab` appends by default — the stored index is the placement truth), disconnect correlation,
+ * accessor phase-determinism, shell-toggle routing and destroy hygiene. The real two-window
+ * journey is the E2E witness's (`FleetCockpitPopOutNL.spec.mjs`).
+ */
+test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state machine (#14610)', () => {
+    let cockpit, vessel;
+
+    /**
+     * Reveals the auto-hidden detail inspector (the drill's standard commit loop), then resolves
+     * the live pane — the pre-state every pop-out flow starts from.
+     * @returns {Promise<Neo.container.Base>} the projected AgentDetail instance
+     */
+    async function revealDetail() {
+        const result = cockpit.applyDockZoneOperation({operation: 'setItemAutoHidden', itemId: 'detail', autoHidden: false});
+
+        expect(result.errors).toEqual([]);
+        cockpit.onDockZoneDocumentChange(result.document);
+        await cockpit.refreshPromise;
+
+        const pane = cockpit.getReference('agent-detail');
+
+        expect(pane).toBeTruthy();
+        return pane
+    }
+
+    /**
+     * The canonical vessel URL the connect handler matches on.
+     * @returns {String}
+     */
+    function vesselUrl() {
+        return `https://unit.test/apps/agentos/childapps/widget/index.html?detail=agent-detail&cockpitId=${cockpit.id}`
+    }
+
+    /**
+     * Simulates the vessel window joining the shared heap: registers a minimal app whose
+     * `mainView` can adopt the pane, then drives the connect handler.
+     * @param {String} windowId
+     * @returns {Promise<Neo.container.Base>} the vessel's mainView
+     */
+    async function simulateConnect(windowId) {
+        const mainView = Neo.create(Container, {});
+
+        Neo.apps ??= {};
+        Neo.apps[windowId] = {mainView};
+
+        await cockpit.onWindowConnect({windowId});
+
+        return mainView
+    }
+
+    test.beforeEach(() => {
+        cockpit = Neo.create(FleetCockpit, {
+            // hermetic: no sample-seed fetch in the unit env; the roster data path has its own suite
+            stateProvider: {
+                module: StateProvider,
+                stores: {fleetRoster: {module: FleetRoster, autoLoad: false}}
+            }
+        })
+    });
+
+    test.afterEach(() => {
+        // destroy BEFORE restoring the vessel seams: teardown of a detached inspector calls
+        // windowClose, which the bare unit env does not provide
+        cockpit?.destroy();
+        cockpit = null;
+        vessel?.restore();
+        vessel = null;
+        Neo.apps = {}
+    });
+
+    test('detach: document truth + park + the docked → opening edge', async () => {
+        vessel = installWindowVessel({popupUrl: null});
+
+        const pane = await revealDetail();
+
+        expect(cockpit.detailVesselState).toBe('docked');
+
+        const result = await cockpit.popOutAgentDetail();
+
+        expect(result).toEqual({detached: true, errors: []});
+        expect(cockpit.detailVesselState).toBe('opening');
+
+        // document truth: the item left the tree but keeps its catalog record
+        const doc = cockpit.getDockZoneDocument();
+
+        expect(doc.items.detail).toBeTruthy();
+        expect(doc.nodes['secondary-rail'].items).not.toContain('detail');
+
+        // the LIVE pane is owner-held (parked), not destroyed — and the stored home is exact
+        expect(cockpit.detachedDetailPane).toBe(pane);
+        expect(pane.isDestroyed).toBeFalsy();
+        expect(cockpit.detachedDetail.homeTabsNodeId).toBe('secondary-rail');
+        expect(cockpit.detachedDetail.homeTabIndex).toBe(0);
+
+        // exactly one vessel open, carrying the correlation params
+        expect(vessel.openCalls).toHaveLength(1);
+        expect(vessel.openCalls[0].url).toContain(`cockpitId=${cockpit.id}`);
+
+        // the shell affordance now names the reverse action
+        expect(cockpit.getReference('detail-window-toggle').text).toBe('Reattach detail')
+    });
+
+    test('connect: the matching vessel adopts the SAME instance — opening → windowed', async () => {
+        vessel = installWindowVessel({popupUrl: null});
+
+        const pane = await revealDetail();
+
+        await cockpit.popOutAgentDetail();
+
+        vessel.restore();
+        vessel = installWindowVessel({popupUrl: vesselUrl()});
+
+        const mainView = await simulateConnect('vessel-win-1');
+
+        expect(cockpit.detailVesselState).toBe('windowed');
+        expect(cockpit.detachedDetail.windowId).toBe('vessel-win-1');
+        expect(cockpit.detachedDetail.connectTimer).toBeNull();
+
+        // reparent-never-recreate: the identical instance now lives in the vessel's view tree
+        expect(mainView.items).toContain(pane);
+        expect(cockpit.getAgentDetailPane()).toBe(pane)
+    });
+
+    test('connect: a non-matching vessel is ignored — the state stays opening', async () => {
+        vessel = installWindowVessel({popupUrl: 'https://unit.test/index.html?detail=agent-detail&cockpitId=someone-else'});
+
+        await revealDetail();
+        await cockpit.popOutAgentDetail();
+
+        const mainView = await simulateConnect('foreign-win');
+
+        expect(cockpit.detailVesselState).toBe('opening');
+        expect(cockpit.detachedDetail.windowId).toBeNull();
+        expect(mainView.items).toHaveLength(0)
+    });
+
+    test('reattach: exact-index restore into the remembered tabs node — windowed → docked', async () => {
+        vessel = installWindowVessel({popupUrl: vesselUrl()});
+
+        const pane = await revealDetail();
+
+        await cockpit.popOutAgentDetail();
+        await simulateConnect('vessel-win-2');
+
+        const result = await cockpit.reattachAgentDetail();
+
+        expect(result).toEqual({errors: [], reattached: true});
+        expect(cockpit.detailVesselState).toBe('docked');
+        expect(cockpit.detachedDetail).toBeNull();
+        expect(cockpit.detachedDetailPane).toBeNull();
+
+        // the placement truth: `addTab` appends by default — the restore must land the item back
+        // at its STORED index (0, before `perspectives`), not at the tail
+        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives']);
+
+        // same instance re-adopted by the projection; the vessel was closed by name
+        expect(cockpit.getReference('agent-detail')).toBe(pane);
+        expect(vessel.closeCalls).toHaveLength(1);
+        expect(vessel.closeCalls[0].names).toEqual([`fm-agent-detail-${cockpit.id}`]);
+
+        expect(cockpit.getReference('detail-window-toggle').text).toBe('Pop out detail')
+    });
+
+    test('blocked popup: windowOpen=false takes the failed-blocked edge and rolls back commit-or-neither', async () => {
+        vessel = installWindowVessel({openResult: false, popupUrl: null});
+
+        const pane   = await revealDetail(),
+              result = await cockpit.popOutAgentDetail();
+
+        expect(result.detached).toBe(false);
+        expect(result.errors[0]).toContain('popup blocked');
+
+        // the rollback settled the machine home; the failure trace survives it
+        expect(cockpit.detailVesselState).toBe('docked');
+        expect(cockpit.lastDetailVesselFailure).toBe('blocked');
+
+        // the SAME instance is docked again at its exact home; nothing was closed (nothing opened)
+        expect(cockpit.getReference('agent-detail')).toBe(pane);
+        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives']);
+        expect(vessel.closeCalls).toHaveLength(0)
+    });
+
+    test('bounded connect window: a vessel that never joins takes the failed-timeout edge and rolls back', async () => {
+        vessel = installWindowVessel({popupUrl: null});
+
+        const pane = await revealDetail();
+
+        cockpit.detailVesselConnectWindowMs = 20;
+
+        const result = await cockpit.popOutAgentDetail();
+
+        expect(result.detached).toBe(true);
+        expect(cockpit.detailVesselState).toBe('opening');
+
+        await expect.poll(() => cockpit.detailVesselState, {timeout: 2000}).toBe('docked');
+
+        expect(cockpit.lastDetailVesselFailure).toBe('timeout');
+        expect(cockpit.getReference('agent-detail')).toBe(pane);
+
+        // the timeout rollback closes the maybe-open vessel by name
+        expect(vessel.closeCalls).toHaveLength(1)
+    });
+
+    test('generation revalidation: a stale connect after reattach is inert', async () => {
+        vessel = installWindowVessel({popupUrl: vesselUrl()});
+
+        const pane = await revealDetail();
+
+        await cockpit.popOutAgentDetail();
+
+        // the user reattaches BEFORE the vessel ever connects — the in-flight admission dies
+        await cockpit.reattachAgentDetail();
+
+        expect(cockpit.detailVesselState).toBe('docked');
+
+        const mainView = await simulateConnect('late-vessel');
+
+        // the stale continuation must not steal the docked pane or corrupt the machine
+        expect(cockpit.detailVesselState).toBe('docked');
+        expect(mainView.items).toHaveLength(0);
+        expect(cockpit.getReference('agent-detail')).toBe(pane)
+    });
+
+    test('disconnect correlation: the vessel closing brings the inspector home exactly once', async () => {
+        vessel = installWindowVessel({popupUrl: vesselUrl()});
+
+        const pane = await revealDetail();
+
+        await cockpit.popOutAgentDetail();
+        await simulateConnect('vessel-win-3');
+
+        expect(cockpit.detailVesselState).toBe('windowed');
+
+        cockpit.onWindowDisconnect({windowId: 'vessel-win-3'});
+        await cockpit.refreshPromise;
+
+        await expect.poll(() => cockpit.detailVesselState, {timeout: 2000}).toBe('docked');
+
+        expect(cockpit.getReference('agent-detail')).toBe(pane);
+
+        // the vessel is already gone: the disconnect path must not close it a second time
+        expect(vessel.closeCalls).toHaveLength(0);
+
+        // a late duplicate disconnect is inert (the cleared bookkeeping is the guard)
+        cockpit.onWindowDisconnect({windowId: 'vessel-win-3'});
+        expect(cockpit.detailVesselState).toBe('docked')
+    });
+
+    test('shell toggle routes by state; a reattach in flight is a guarded no-op', async () => {
+        vessel = installWindowVessel({popupUrl: vesselUrl()});
+
+        await revealDetail();
+
+        // docked → toggle detaches
+        await cockpit.onDetailWindowToggle();
+        expect(cockpit.detailVesselState).toBe('opening');
+
+        await simulateConnect('vessel-win-4');
+        expect(cockpit.detailVesselState).toBe('windowed');
+
+        // transitional guard: a mid-reattach toggle refuses instead of double-driving
+        cockpit.detailVesselState = 'reattaching';
+
+        const guarded = await cockpit.onDetailWindowToggle();
+
+        expect(guarded.reattached).toBe(false);
+        expect(guarded.errors[0]).toContain('reattach in flight');
+
+        cockpit.detailVesselState = 'windowed';
+
+        // windowed → toggle reattaches
+        await cockpit.onDetailWindowToggle();
+        expect(cockpit.detailVesselState).toBe('docked')
+    });
+
+    test('accessor phase-determinism: one route to the live pane in both phases', async () => {
+        vessel = installWindowVessel({popupUrl: vesselUrl()});
+
+        const pane = await revealDetail();
+
+        expect(cockpit.getAgentDetailPane()).toBe(pane);
+
+        await cockpit.popOutAgentDetail();
+        await simulateConnect('vessel-win-5');
+
+        // a vessel-mounted pane is OUT of this cockpit's projected tree — the accessor still lands
+        expect(cockpit.getAgentDetailPane()).toBe(pane);
+
+        await cockpit.reattachAgentDetail();
+
+        expect(cockpit.getAgentDetailPane()).toBe(pane)
+    });
+
+    test('destroy while detached: vessel closed, pane destroyed, late events inert', async () => {
+        vessel = installWindowVessel({popupUrl: vesselUrl()});
+
+        const pane = await revealDetail();
+
+        await cockpit.popOutAgentDetail();
+        await simulateConnect('vessel-win-6');
+
+        cockpit.destroy();
+
+        expect(vessel.closeCalls).toHaveLength(1);
+        expect(pane.isDestroyed).toBe(true);
+
+        // a post-destroy disconnect must be inert (the isDestroyed guard)
+        cockpit.onWindowDisconnect({windowId: 'vessel-win-6'});
+
+        cockpit = null
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
@@ -28,7 +28,7 @@ import StateProvider from '../../../../../../../src/state/Provider.mjs';
  * @param {String|null} [options.popupUrl=null] The URL `getByPath` reports for the vessel window.
  * @returns {Object} spy state + `restore()`.
  */
-function installWindowVessel({openResult = true, popupUrl = null} = {}) {
+function installWindowVessel({deferOpen = false, openResult = true, popupUrl = null} = {}) {
     let previous = {
             getByPath    : Neo.Main.getByPath,
             getWindowData: Neo.Main.getWindowData,
@@ -36,15 +36,20 @@ function installWindowVessel({openResult = true, popupUrl = null} = {}) {
             windowOpen   : Neo.Main.windowOpen
         },
         previousWindowConfigs = Neo.windowConfigs,
-        state = {closeCalls: [], openCalls: []};
+        state = {closeCalls: [], openCalls: [], resolveOpen: null};
 
     Neo.windowConfigs = {'unit-window': {basePath: './'}};
 
     Neo.Main.getByPath     = async () => popupUrl;
     Neo.Main.getWindowData = async () => ({screenLeft: 10, screenTop: 20});
-    Neo.Main.windowOpen    = async data => {
+    Neo.Main.windowOpen    = data => {
         state.openCalls.push(data);
-        return openResult
+
+        // deferOpen models the REAL race window: the popup's Boolean completion arriving
+        // arbitrarily late — the test resolves it manually via resolveOpen(value)
+        return deferOpen
+            ? new Promise(resolve => {state.resolveOpen = resolve})
+            : Promise.resolve(openResult)
     };
     Neo.Main.windowClose   = async data => {
         state.closeCalls.push(data)
@@ -53,6 +58,7 @@ function installWindowVessel({openResult = true, popupUrl = null} = {}) {
     return {
         get closeCalls() { return state.closeCalls },
         get openCalls()  { return state.openCalls },
+        resolveOpen(value) { state.resolveOpen?.(value) },
         restore() {
             Object.assign(Neo.Main, previous);
             Neo.windowConfigs = previousWindowConfigs
@@ -356,6 +362,75 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
         await cockpit.reattachAgentDetail();
 
         expect(cockpit.getAgentDetailPane()).toBe(pane)
+    });
+
+    test('stale open completion: a vessel materializing after reattach is closed, never orphaned', async () => {
+        vessel = installWindowVessel({deferOpen: true, popupUrl: null});
+
+        const pane = await revealDetail();
+
+        // the open hangs (real popups complete arbitrarily late) — the admission is in flight
+        const popOutPromise = cockpit.popOutAgentDetail();
+
+        await expect.poll(() => vessel.openCalls.length, {timeout: 2000}).toBe(1);
+
+        // the user reattaches while the open is STILL pending: dock state restores, generation dies
+        const reattach = await cockpit.reattachAgentDetail({windowAlreadyClosed: true});
+
+        expect(reattach.reattached).toBe(true);
+        expect(cockpit.detailVesselState).toBe('docked');
+        expect(vessel.closeCalls).toHaveLength(0);
+
+        // NOW the vessel materializes under the dead generation — the stale continuation owns
+        // exactly one cleanup: close the orphan by its immutable name; it touches nothing else
+        vessel.resolveOpen(true);
+
+        const result = await popOutPromise;
+
+        expect(result.detached).toBe(false);
+        expect(result.errors[0]).toContain('superseded');
+
+        await expect.poll(() => vessel.closeCalls.length, {timeout: 2000}).toBe(1);
+        expect(vessel.closeCalls[0].names).toEqual([`fm-agent-detail-${cockpit.id}`]);
+
+        // zero resurrection: the docked state the reattach restored is untouched
+        expect(cockpit.detailVesselState).toBe('docked');
+        expect(cockpit.detachedDetail).toBeNull();
+        expect(cockpit.getReference('agent-detail')).toBe(pane)
+    });
+
+    test('destroy during reattach: the stale continuation cleans the vessel only, never resurrects fields', async () => {
+        vessel = installWindowVessel({popupUrl: vesselUrl()});
+
+        const pane = await revealDetail();
+
+        await cockpit.popOutAgentDetail();
+        await simulateConnect('vessel-win-7');
+
+        expect(cockpit.detailVesselState).toBe('windowed');
+
+        // start the reattach, then destroy the cockpit while it awaits the projection —
+        // teardown skips the vessel close (the reattach already cleared the bookkeeping),
+        // so the stale continuation still owns exactly that close
+        const reattachPromise = cockpit.reattachAgentDetail();
+
+        cockpit.destroy();
+
+        const result = await reattachPromise;
+
+        expect(result.reattached).toBe(false);
+        expect(result.errors[0]).toContain('superseded');
+
+        // the pane died with the cockpit (teardown's job), the vessel closed exactly once
+        // (the continuation's job), and no live handle was resurrected post-destroy
+        // (core destroy() deletes instance fields — falsy is the destroyed-object truth)
+        expect(pane.isDestroyed).toBe(true);
+        expect(cockpit.detachedDetailPane).toBeFalsy();
+
+        await expect.poll(() => vessel.closeCalls.length, {timeout: 2000}).toBe(1);
+        expect(vessel.closeCalls[0].names).toEqual([`fm-agent-detail-${cockpit.id}`]);
+
+        cockpit = null
     });
 
     test('destroy while detached: vessel closed, pane destroyed, late events inert', async () => {


### PR DESCRIPTION
Resolves #14610

Refs #14560

The Stage-1 successor after PR #15215's accepted Drop+Supersede: the agent-detail inspector detaches to its own OS window on the shared App-Worker heap and comes home — built to the ticket's Contract Ledger (deposited before the branch, ADR 0020 §6) and consuming the vessel-lifecycle semantics that just landed as ADR 0029 §2.8.3 via PR #15260 (this branch is rebased on top of that merge; the seam convergence was author-confirmed on the ticket pre-review).

**What ships (Stage 1 — shell-chrome verbs; the drag-gesture entry is explicitly Stage 2, gated on #15212 and filed under epic #15239 later):**

- **The vessel admission state machine**, observable end to end: `docked → opening → connected → windowed → reattaching → docked`, with `failed-blocked` / `failed-timeout` edges, `lastDetailVesselFailure` as the post-rollback trace, and `detailVesselGeneration` revalidated at EVERY awaited continuation — a reattach or teardown racing an in-flight admission is inert by construction.
- **`Neo.Main.windowOpen` consumed on its Boolean grammar**: `false` IS the blocked-popup primary failure path (it never throws) — the unreachable try/catch rollback class from the superseded PR is structurally absent. Blocked → commit-or-neither rollback; the docked state returns byte-identical.
- **Bounded connect window** (`detailVesselConnectWindowMs: 10000` — a documented, non-reactive class-config default: `Neo.overwrites`-eligible and instance-configurable): a vessel that opens but never joins the heap rolls back and closes by name.
- **Exact-index reattach**: the tabs node AND tab index are stored before `detachItem`; `addTab` restores the remembered index — append-by-default is the trap the ledger names, witnessed as an assertion.
- **Shell-owned affordance** (panes are layout-blind; the shell owns docking behavior): a toolbar window-toggle routed by the state machine with a state-synced label — `AgentDetail` carries zero dock semantics and **zero diff** on this branch.
- **Owner accessor `getAgentDetailPane()`** routes every detail consumer across both phases (store `recordChange`, selection reconciliation, and the controller drill — the two-window e2e caught the last unrouted consumer and pinned it); reconciler `preserveItemIds` parks the live pane; a resolver stand-in + post-projection swap covers external re-trees while detached.
- **Destroy hygiene**: generation bump, timer clear, listener `un`, vessel close, parked-pane destroy.

Evidence: L2 (unit contract suite on seams modeling the real Boolean call grammar) + L3 (real two-window Chromium round-trip via Neural Link, local) → L2 required (the ledger's unit evidence plan) + L3 required (the real-window journey). Residual: the e2e suite is not in CI (the known agentos e2e gap) — see Post-Merge Validation.

## Deltas from ticket

The ticket predates the D#15204 graduation arc; the binding scope is its Contract Ledger comment (ADR 0020 §6, deposited 2026-07-16 pre-branch) — Stage-1/Stage-2 staging, the seven consumed-surface rows, and the shared exact-index semantic with the dock-side G4 leaf (#15247 adopts the same wording; convergence-noted by its owner on the ticket). Two witness-driven additions beyond the ledger text: `detailVesselConnectWindowMs` as a bounded class-config default (declared in `static config`, so it rides `Neo.setupClass`'s prototype install — `Neo.overwrites`-eligible, instance-configurable; the timeout witness passes a short window at creation), and the controller-drill accessor routing (the e2e's step-3 catch).

## Test Evidence

- `CI=1 npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/` → **176/176** at exact head `1da545c46` (exit code checked explicitly, not piped away).
- New: `fleetCockpitPopOut.spec.mjs` — **11 contract specs, green first run**: happy path (document truth + park + same-instance adoption; foreign vessel ignored), both failure edges (blocked → zero close calls; timeout → vessel closed by name), generation revalidation (stale connect cannot steal the docked pane), exact-index restore (`detail` back at index 0 BEFORE `perspectives`), disconnect correlation (home exactly once; duplicate + post-destroy events inert), shell-toggle routing with the reattach-in-flight guard, accessor phase-determinism, destroy hygiene.
- New: `FleetCockpitPopOutNL.spec.mjs` — **1/1 (13.9s)**, real second browser window on the one SharedWorker heap: shell-toggle detach (state machine observed via NL), document truth while detached, same App-Worker instance id in the vessel, live re-seat while windowed (main-window drill → popup render target, zero remounts), shell-toggle reattach at the exact remembered index, vessel closes as an effect, zero page errors in both windows. Run: `NEO_E2E_PORT=8119 npx playwright test agentos/FleetCockpitPopOutNL -c test/playwright/playwright.config.e2e.mjs --workers=1`
- fleet surface: `fleetCockpit.spec.mjs` (owner/store/controller suite) — two fake-cockpit fixtures gained the real accessor (the fakes carry prototype methods explicitly; the new consumer seam joins them).
- agentos e2e surface: `FleetCockpitDrillNL` remains red on dev from the pre-existing #15212 card-click dispatch regression (not this PR's scope; this suite drives the controller seam below the gesture).

## Post-Merge Validation

- [ ] Run `FleetCockpitPopOutNL` against the merged dev head on a machine with the e2e config (the suite is not in CI; the receipt above is local at the exact head).
- [ ] Visual pass on the toolbar toggle (`fm-detail-window-toggle` — currently unstyled plain Button; SCSS polish rides the W1 conformance wave if design wants more than the default).

## Commits

- 898d0bf99 — Stage-1 core: shell-owned verbs + vessel admission state machine
- 06c4aadfd — 11 unit contract specs (the seam models the real Boolean grammar) + the configurable connect window (finalized as a class-config default in 1da545c46)
- ab5509a3b — two-window e2e witness + the controller-drill accessor routing it caught

## Evolution

The superseded PR #15215 died on premise (pane-carried mode, cockpit-local vessel protocol, throw-shaped rollback for a Boolean failure). This successor inverted every named falsifier into contract: the affordance moved to shell chrome, the admission became one observable state machine on the Boolean truth, and the vessel semantics pin to the graduated D#15204 record — now merged as ADR 0029 §2.8. Salvage (accessor, preserved-park, stand-in/swap, witness bones) was consumed per the ledger's salvage map rather than re-derived.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session b42c5667-db78-4a0c-83a0-ce66c95ee0d9.

- 50cd4f00a — the generation-continuation invariant completed (stale-open orphan close + reattach post-await gate) + both adversarial witnesses
- 1da545c46 — connect window as a `static config` default (the class field masked the prototype value, bypassing `Neo.overwrites`)
