### PR TITLE
feat(build): A1 env-re-derivation rule — salvage re-land on the dev mask (#15213)

### DIFF
--- a/buildScripts/util/check-aiconfig-antipatterns.mjs
+++ b/buildScripts/util/check-aiconfig-antipatterns.mjs
@@ -36,14 +36,39 @@ export const B3_DEFENSIVE_CHAIN = new RegExp(
 export const A5_ENV_HELPER = /\bhasEnvValue\s*\(/;
 
 /*
+ * Rule A1's FILE gate — module-level env re-derivation is an antipattern ONLY where the config
+ * SSOT is already in scope. A file importing the config singleton (import-statement token or the
+ * runtime `Neo.ai.Config` root) that re-derives values from `process.env` should read the resolved
+ * leaf instead. The gate is what keeps the C1-sanctioned shape green: a genuine non-entrypoint
+ * pure-defaults module carries env literals WITHOUT any config import — by design — and must
+ * never flag.
+ */
+export const A1_IMPORT_GATE = /^\s*import\s+[^;]*\b(?:AiConfig|Memory_Config)\b[^;]*\bfrom\b|\bNeo\.ai\.Config\b/m;
+
+/*
+ * Rule A1's LINE rule — a module-level `const|let|var` declaration whose initializer reads
+ * `process.env.` on the declaration line. Column-0 anchoring is the module-level signal in this
+ * codebase's indent style: function-local reads are indented and never match. A multi-line
+ * initializer whose env read sits on a continuation line is outside this static heuristic —
+ * the escape marker covers judgment-call residue.
+ */
+export const A1_ENV_REDERIVATION = /^(?:const|let|var)\s[^;]*=\s*[^;]*\bprocess\.env\./;
+
+/*
  * Rule-scoped grandfathering: each rule carries its OWN set of repo-relative POSIX paths, so one
  * rule's existing-surface exemption can never widen another's — A5 keeps its zero-baseline ratchet
  * even inside files grandfathered for B3. A whole-file skip would silently exempt every rule at
  * once; filtering happens per HIT instead ({@link filterAllowlistedHits}). Sets shrink as the
- * cleanup subs land. B3 census: 2026-07-16 against `dev`; A5 is empty by construction (zero live
- * occurrences — any entry appearing here is a regression, not a grandfather).
+ * cleanup subs land. B3 census: 2026-07-16 against `dev`; A1 census: same day via THIS checker's
+ * own gate (a line-grep census missed the dev fleet server's multi-line import — the masked
+ * multi-line gate is the census authority); A5 is empty by construction (zero live occurrences —
+ * any entry appearing here is a regression, not a grandfather).
  */
 export const ALLOWLIST = Object.freeze({
+    A1: new Set([
+        'ai/daemons/wake/daemon.mjs',
+        'ai/services/fleet/devFleetServer.mjs'
+    ]),
     A5: new Set(),
     B3: new Set([
         'ai/mcp/server/BaseServer.mjs',
@@ -58,24 +83,41 @@ const RULES = [
 ];
 
 /**
- * @summary Scans file content for the B3 / A5 config-read antipatterns whose root token sits in code.
+ * @summary Scans file content for the A1 / B3 / A5 config-read antipatterns whose root token sits in code.
  *
  * Reuses the sibling guard's `codeMask` so an occurrence inside a string literal (a log message, a
  * spec title quoting the pattern) or a comment never flags — only executable defensive reads do.
+ * A1 is two-signal: its line rule participates only when the FILE passes the import gate
+ * ({@link A1_IMPORT_GATE}), so the C1-sanctioned pure-defaults shape (env literals, no config
+ * import) stays green by construction.
  * @param {String} content
  * @returns {Object[]} `[{line, rule, text}]` — one entry per offending line/rule (1-based line numbers).
  */
 export function findAntipatterns(content) {
-    const lines = content.split('\n'),
-          state = {inBlock: false},
-          hits  = [];
+    const lines         = content.split('\n'),
+          state         = {inBlock: false},
+          hits          = [],
+          a1Candidates  = [],
+          codeOnlyLines = [],
+          a1Global      = new RegExp(A1_ENV_REDERIVATION.source, 'g');
 
     lines.forEach((line, index) => {
+        // Mask + projection compute UNCONDITIONALLY — before the escape check. Skipping a line
+        // would corrupt block-comment state continuity AND remove the line from the gate
+        // projection: an escape marker on the IMPORT line would then silently exempt the whole
+        // file's A1 hits (the escape valve is line-scoped for HITS, never for composition).
+        const mask = codeMask(line, state),
+              // The gate must see CODE only — a JSDoc/comment mention of the config root (a config
+              // template documenting its realm, a migration note) must never open A1 for the file.
+              // Masked-out characters become spaces, preserving positions, so multi-line import
+              // statements still span lines intact.
+              codeOnly = Array.from(line, (ch, i) => (mask[i] ? ch : ' ')).join('');
+
+        codeOnlyLines.push(codeOnly);
+
         if (line.includes(ESCAPE_MARKER)) {
             return
         }
-
-        const mask = codeMask(line, state);
 
         for (const {id, pattern} of RULES) {
             for (const match of line.matchAll(pattern)) {
@@ -87,7 +129,22 @@ export function findAntipatterns(content) {
                 }
             }
         }
+
+        // A1 classifies against the code-only PROJECTION, not the raw line: the declaration
+        // keyword sits at index 0 whether or not `process.env.` is real code, so a raw-line
+        // match + a mask check at the match start would false-positive on a genuine declaration
+        // whose env token lives inside a string or comment. On the projection, masked env tokens
+        // are spaces — the regex simply cannot match them.
+        for (const match of codeOnly.matchAll(a1Global)) {
+            a1Candidates.push({line: index + 1, rule: 'A1', text: line.trim()});
+            break
+        }
     });
+
+    // A1 is two-signal: candidates emit only when the file's CODE opens the import gate.
+    if (a1Candidates.length && A1_IMPORT_GATE.test(codeOnlyLines.join('\n'))) {
+        hits.push(...a1Candidates)
+    }
 
     return hits
 }
@@ -179,7 +236,9 @@ function main() {
             violations.forEach(v => console.error('  ' + v));
             console.error('\nB3: never `?.` on an AiConfig read — the SSOT guarantees the tree; read the leaf and let it');
             console.error('fail loud (ADR-0019 §3/§5.1). A5: never a `hasEnvValue` helper — `leaf(default, env, type)`');
-            console.error(`owns the env-check (§5.2). Genuinely unavoidable line: add "${ESCAPE_MARKER}: <reason>".`);
+            console.error('owns the env-check (§5.2). A1: with AiConfig imported, never re-derive from process.env at');
+            console.error('module level — read the resolved leaf at the use site (§5.5; pure-defaults modules WITHOUT');
+            console.error(`a config import are the sanctioned C1 shape). Genuinely unavoidable: "${ESCAPE_MARKER}: <reason>".`);
         }
         process.exit(1);
     }

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -1,5 +1,6 @@
 import {test, expect}                                                      from '@playwright/test';
 import {findAntipatterns, filterAllowlistedHits, ALLOWLIST, ESCAPE_MARKER} from '../../../../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
+import {A1_IMPORT_GATE}                                                    from '../../../../../../buildScripts/util/check-aiconfig-antipatterns.mjs';
 import {spawnSync}                                                         from 'node:child_process';
 import fs                                                                  from 'node:fs';
 import path                                                                from 'node:path';
@@ -156,6 +157,112 @@ test.describe('check-aiconfig-antipatterns guard — rule-scoped allowlist compo
 
             expect(result.status).toBe(0);
             expect(result.stdout).toContain('0 new violations')
+        } finally {
+            fs.rmSync(tmpFile, {force: true})
+        }
+    })
+});
+
+/**
+ * Coverage for the A1 two-signal rule — module-level env re-derivation flags ONLY in files that
+ * import the config SSOT. The negatives are the load-bearing half: the C1-sanctioned pure-defaults
+ * module (env literals, NO config import) and function-local env reads must stay green, or the
+ * lint would fight the very shape the design prescribes for non-entrypoint helpers.
+ */
+test.describe('check-aiconfig-antipatterns guard — A1 module-level env re-derivation (two-signal)', () => {
+    const importHeader = "import AiConfig from '../ConfigProvider.mjs';\n";
+
+    test('A1: flags a module-level re-derivation when the file imports the config SSOT', () => {
+        const content = importHeader + "const DB_PATH = process.env.NEO_DB_PATH || path.join(root, 'db');\n";
+
+        expect(findAntipatterns(content).map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('A1: the Neo.ai.Config runtime root also opens the gate', () => {
+        const content = "const cfg = Neo.ai.Config;\nlet cacheDir = process.env.NEO_CACHE_DIR ?? cfg.cacheDir;\n";
+
+        expect(findAntipatterns(content).map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('A1: a comment-only config-root mention never opens the gate (config templates document their realm)', () => {
+        const content = "// Loads the Tier-1 realm root (Neo.ai.Config) so getParent() inheritance resolves.\nconst dataDir = process.env.NEO_AI_DAEMON_DIR || './data';\n";
+
+        expect(findAntipatterns(content)).toEqual([])
+    });
+
+    test('A1: a multi-line import block carrying the config token opens the gate (the line-grep blind spot)', () => {
+        const content = "import {\n    AiConfig,\n    other\n} from '../services.mjs';\nconst port = Number(process.env.NEO_FLEET_PORT) || 8083;\n";
+
+        expect(findAntipatterns(content).map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('A1: the C1-sanctioned pure-defaults module (NO config import) never flags', () => {
+        const content = "const DEFAULT_DB_PATH = process.env.NEO_DB_PATH || './data/db';\nexport {DEFAULT_DB_PATH};\n";
+
+        expect(A1_IMPORT_GATE.test(content)).toBe(false);
+        expect(findAntipatterns(content)).toEqual([])
+    });
+
+    test('A1: function-local env reads never flag (module-level anchoring)', () => {
+        const content = importHeader + "function resolve() {\n    const port = process.env.NEO_PORT || 3000;\n    return port\n}\n";
+
+        expect(findAntipatterns(content)).toEqual([])
+    });
+
+    test('A1: an env token inside a STRING on a real declaration line never flags (classify the token, not the declaration)', () => {
+        expect(findAntipatterns(importHeader + "const msg = 'reads process.env.PATH at boot';\n")).toEqual([]);
+        expect(findAntipatterns(importHeader + 'const doc = "set process.env.NEO_PORT before running";\n')).toEqual([]);
+        expect(findAntipatterns(importHeader + 'const note = `about process.env.NEO_X`;\n')).toEqual([]);
+        expect(findAntipatterns(importHeader + 'const x = compute(); /* process.env.NEO_Y */\n')).toEqual([])
+    });
+
+    test('A1: an escape marker on the IMPORT/gate line exempts only that line — other declarations still flag', () => {
+        const content = importHeader.trimEnd() + ` // ${ESCAPE_MARKER}: gate-line note\n` +
+            "const P = process.env.NEO_P || 'x';\n";
+
+        expect(findAntipatterns(content).map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('A1: comment and string occurrences never flag; the escape marker is honored', () => {
+        const commented = importHeader + "// const DB_PATH = process.env.NEO_DB_PATH || fallback;\n";
+        const escaped   = importHeader + `const BOOT_FLAG = process.env.NEO_BOOT_FLAG; // ${ESCAPE_MARKER}: bootstrap boundary, reads before the provider exists\n`;
+
+        expect(findAntipatterns(commented)).toEqual([]);
+        expect(findAntipatterns(escaped)).toEqual([])
+    });
+
+    test('A1: DOCUMENTED BOUNDARY — an env read inside a template interpolation is outside the current mask vocabulary', () => {
+        // The shared codeMask on dev classifies strings/comments only; template interpolations mask
+        // as string text, so an interpolated read is invisible to A1 by construction. This pin makes
+        // the boundary explicit: it flips to a positive when the parser-grade shared masking
+        // authority lands (the successor lane decomposed from this rule's review arc). Until then a
+        // module-level `const url = `${process.env.X}`` is the escape-marker/judgment residue class.
+        expect(findAntipatterns(importHeader + 'const url = `${process.env.NEO_HOST}`;\n')).toEqual([])
+    });
+
+    test('A1: rule-scoped grandfathering — the wake daemon is exempt for A1 only, and A1 stays independent of B3/A5 sets', () => {
+        const content = importHeader + "const DB_PATH = process.env.NEO_DB_PATH || './db';\nif (hasEnvValue('NEO_X')) { run(); }\n";
+        const hits    = findAntipatterns(content);
+
+        expect(hits.map(h => h.rule).sort()).toEqual(['A1', 'A5']);
+        expect(filterAllowlistedHits(hits, 'ai/daemons/wake/daemon.mjs').map(h => h.rule)).toEqual(['A5']);
+        expect(filterAllowlistedHits(hits, 'ai/services/fresh/NewService.mjs').map(h => h.rule).sort()).toEqual(['A1', 'A5']);
+        expect(ALLOWLIST.A1.has('ai/daemons/wake/daemon.mjs')).toBe(true)
+    });
+
+    test('A1 CLI regression: an import-gated module-level re-derivation in a fresh ai/ file exits non-zero', () => {
+        const tmpFile = path.join(repoRoot, `ai/.a1-rederivation-regression-${process.pid}.mjs`);
+
+        try {
+            fs.writeFileSync(tmpFile, "import AiConfig from './ConfigProvider.mjs';\nconst DB_PATH = process.env.NEO_DB_PATH || './db';\n", 'utf-8');
+
+            const result = spawnSync(process.execPath, [checkerPath, tmpFile], {
+                cwd     : repoRoot,
+                encoding: 'utf-8'
+            });
+
+            expect(result.status).toBe(1);
+            expect(result.stderr).toContain('[A1]')
         } finally {
             fs.rmSync(tmpFile, {force: true})
         }


### PR DESCRIPTION
Resolves #15213

The A1 salvage re-land, exactly as decomposed in the terminal verdict on the predecessor (PR #15226, closed Drop+Supersede at cycle 6): the A1 env-re-derivation rule lands on the **current dev mask** with zero shared-mask mutation. The salvage point is the cycle-2 head `22b75e4090` — the head the primary reviewer formally APPROVED for A1 semantics (her two-minute-later retraction targeted the mask's interpolation vocabulary, which the terminal decomposition routes to the successor authority lane, not to A1).

What lands: `A1_IMPORT_GATE` (import-statement token or runtime `Neo.ai.Config` root, evaluated on the code-only projection so comment/JSDoc mentions never gate), `A1_ENV_REDERIVATION` (module-level declaration reading `process.env.` — classified against the code-only projection, killing string-embedded false positives), the **rule-scoped allowlist** (per-rule Sets + per-HIT filtering — A5 keeps its zero baseline inside B3-grandfathered files; A1 seeds the two census-true files), the hit-scoped escape valve (mask computes before the escape check — a gate-line marker can neither exempt the file nor corrupt block-comment state), and the spawned-CLI A1 regression.

Evidence: L3 achieved (both checker suites green locally; live scan over the full `ai/` tree at head) → L3 required (the close-target ACs are mechanical-enforcement claims provable by suite + scan). Residual: none for A1's contract; the interpolation boundary is pinned as documented-out-of-scope (below).

## Deltas from ticket

- The ticket's A1 scope ships exactly as specified at the approved cycle-2 shape. One addition beyond the salvage point: a **documented-boundary pin** — an env read inside a template interpolation is invisible to A1 on the dev mask by construction; the spec pins the negative explicitly so it flips to a positive when the parser-grade shared masking authority (the successor lane) lands. Until then, interpolated module-level reads are the escape-marker/judgment residue class.
- Everything lexer-grade from the predecessor's cycles 3–6 (interpolation frames, continuation semantics, slash grammar) is deliberately NOT here — that corpus is the successor ticket's spec, per the terminal verdict's decomposition.

## Test Evidence

- `NEO_CHROMA_PORT_TEST=19479 npx playwright test --config=test/playwright/playwright.config.mjs <both checker specs>` — **42 passed** (26 antipattern specs incl. the 7-spec A1 set, the rule-scoped-allowlist composition set, the spawned-CLI A1 regression, and the new interpolation-boundary pin; 16 B4 sibling specs untouched-green).
- Live scan at head: `node buildScripts/util/check-aiconfig-antipatterns.mjs` — **533 `ai/` file(s) scanned, 0 new violations** (A1 gate + census allowlist hold against current dev, which grew by one file since the predecessor's scans).
- `buildScripts/util/check-aiconfig-test-mutation.mjs` (the shared-mask owner) is **byte-identical to dev** in this diff — verified via `git diff 22b75e4090 origin/dev -- <file>` returning empty.
- Directly touched surfaces: checker + its spec; no other app/feature surface touched.

## Post-Merge Validation

- [ ] The standalone `aiconfig-antipattern-lint` workflow goes green on the first post-merge `ai/`-touching PR (the A1 rule live in CI).
- [ ] The successor shared-mask ticket cites this PR's boundary pin as its flip-target.

## Review routing note

Primary reviewer: Emmy — she approved this exact A1 content at the predecessor's cycle 2 and authored the terminal decomposition this PR executes; shortest possible verification path by design. First formal review is terminal-eligible per the graduated D#15256 economics (first-review-terminal precedent: PR #15262).

Authored by Grace (Claude Fable 5, Claude Code). Session 75ed6708-c66b-4989-862d-2286e87abbf1.
