### PR TITLE
feat(ai): add blind BigData Neural Link probe (#15187)

### DIFF
--- a/ai/mcp/server/neural-link/Bridge.mjs
+++ b/ai/mcp/server/neural-link/Bridge.mjs
@@ -32,11 +32,6 @@ class Bridge extends Base {
          */
         className: 'Neo.ai.mcp.server.neural-link.Bridge',
         /**
-         * @member {Number} port=8081
-         * @protected
-         */
-        port: 8081,
-        /**
          * @member {Boolean} singleton=true
          * @protected
          */
@@ -59,31 +54,41 @@ class Bridge extends Base {
     wss = null
 
     /**
-     * Async initialization.
+     * @summary Completes class initialization without claiming a network listener.
+     * Network binding belongs to the standalone entrypoint so it can
+     * finish config freshness checks and optional overlay loading before starting the Bridge.
      * @returns {Promise<void>}
      */
     async initAsync() {
-        // Skip the port bind under unitTestMode — tests instantiate the singleton (for handleConnection
-        // handshake-auth + verify coverage) without standing up a real WebSocket server.
-        if (Neo.config.unitTestMode) return;
-        await this.startServer();
+        await super.initAsync()
     }
 
     /**
-     * Starts the WebSocket server.
+     * @summary Starts the WebSocket server on the entrypoint-supplied loopback host and port.
+     * @param {Object} options
+     * @param {String} options.host Entrypoint-supplied literal loopback host.
+     * @param {Number} options.port Entrypoint-supplied Bridge listener port.
      * @returns {Promise<void>}
      */
-    async startServer() {
+    async startServer({host, port} = {}) {
+        if (host !== '127.0.0.1' && host !== '::1') {
+            throw new TypeError('Bridge.startServer() requires a literal loopback host.')
+        }
+
+        if (!Number.isInteger(port) || port < 1 || port > 65535) {
+            throw new TypeError('Bridge.startServer() requires an integer TCP port in the range 1..65535.')
+        }
+
         if (this.wss) {
             logger.warn('Bridge: WebSocket Server is already running.');
             return;
         }
 
         return new Promise((resolve, reject) => {
-            const wss = new WebSocketServer({port: this.port});
+            const wss = new WebSocketServer({host, port});
 
             wss.on('listening', () => {
-                logger.info(`Bridge: Listening on port ${this.port}`);
+                logger.info(`Bridge: Listening on ${host}:${port}`);
                 this.wss = wss;
 
                 wss.on('connection', (ws, req) => this.handleConnection(ws, req));

--- a/ai/mcp/server/neural-link/run-bridge.mjs
+++ b/ai/mcp/server/neural-link/run-bridge.mjs
@@ -38,6 +38,7 @@ if (options.debug) {
         logger.info('Starting Neural Link Bridge...');
 
         await Bridge.ready();
+        await Bridge.startServer({host: '127.0.0.1', port: aiConfig.port});
 
         // Keep process alive
         process.on('SIGINT', async () => {

--- a/ai/mcp/server/shared/helpers/localBearer.mjs
+++ b/ai/mcp/server/shared/helpers/localBearer.mjs
@@ -77,19 +77,22 @@ export function generateLocalBearerToken() {
  * The returned surfaces can be passed directly to a child server process and an MCP client. The
  * helper performs no logging, file/database writes, environment mutation, or durable config
  * update; process exit remains the credential-revocation boundary.
+ * @param {String} [bearerToken] Optional caller-owned token for a coordinated one-shot launch.
  * @returns {{serverEnv: Object, clientHeaders: Object}}
  */
-export function createLocalBearerLaunchContract() {
-    const token = generateLocalBearerToken();
+export function createLocalBearerLaunchContract(bearerToken = generateLocalBearerToken()) {
+    if (!isLocalBearerToken(bearerToken)) {
+        throw new TypeError('Local-bearer launch contracts require a canonical 32-byte unpadded-base64url token.')
+    }
 
     return Object.freeze({
         serverEnv: Object.freeze({
             NEO_AUTH_MODE              : 'local-bearer',
-            NEO_AUTH_LOCAL_BEARER_TOKEN: token,
+            NEO_AUTH_LOCAL_BEARER_TOKEN: bearerToken,
             NEO_MCP_LISTEN_HOST        : '127.0.0.1'
         }),
         clientHeaders: Object.freeze({
-            Authorization: `Bearer ${token}`
+            Authorization: `Bearer ${bearerToken}`
         })
     })
 }

--- a/ai/scripts/diagnostics/genesisProbe.mjs
+++ b/ai/scripts/diagnostics/genesisProbe.mjs
@@ -1,0 +1,1574 @@
+import {Client}                          from '@modelcontextprotocol/sdk/client/index.js';
+import {StreamableHTTPClientTransport}   from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {Command, InvalidArgumentError}   from 'commander';
+import {spawn, execFileSync}             from 'child_process';
+import crypto                            from 'crypto';
+import fs                                from 'fs';
+import fsPromises                        from 'fs/promises';
+import net                               from 'net';
+import os                                from 'os';
+import path                              from 'path';
+import readline                          from 'readline/promises';
+import {createRequire}                   from 'module';
+import {fileURLToPath, pathToFileURL}    from 'url';
+import {createLocalBearerLaunchContract} from '../../mcp/server/shared/helpers/localBearer.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../..');
+const require    = createRequire(import.meta.url);
+
+export const DEFAULT_TIMEOUT_MS = 60000;
+export const MAX_SESSION_MS     = 2 * 60 * 60 * 1000;
+export const CLEANUP_RESERVE_MS = 60000;
+export const EXACT_TOOL_NAMES   = Object.freeze([
+    'healthcheck',
+    'get_worker_topology',
+    'get_component_tree'
+]);
+export const EXPECTED_APP_NAME     = 'Neo.examples.grid.bigData';
+export const GENESIS_COMMIT        = '2a7e9d75d2e5cceb9d36fd0dc290c7586d9ad4c8';
+export const GENESIS_VERSION       = '7.9.38';
+export const PROBE_PROJECTION_MODE = 'local-readonly-probe';
+export const LOOPBACK_HOST         = '127.0.0.1';
+
+const PUBLIC_FAILURES = Object.freeze({
+    CHILD_TERMINATION_UNVERIFIED: 'A probe child could not be verified as stopped.',
+    CLEANUP_FAILED              : 'The disposable diagnostics could not be fully erased.',
+    PROBE_INTERRUPTED           : 'The probe was interrupted and entered cleanup.',
+    SESSION_LIMIT_EXCEEDED      : 'The probe exceeded its two-hour session limit.',
+    TOOL_PROFILE_MISMATCH       : 'The server did not expose the exact probe profile.',
+    TOPOLOGY_MISMATCH           : 'Exactly one intended BigData App Worker was not available.',
+    UNEXPECTED_FAILURE          : 'The probe failed without a public-safe classification.'
+});
+
+const SAFE_ENV_KEYS = new Set([
+    'CI',
+    'COLORTERM',
+    'COMSPEC',
+    'FORCE_COLOR',
+    'HOME',
+    'LANG',
+    'LC_ALL',
+    'LOCALAPPDATA',
+    'LOGNAME',
+    'NO_COLOR',
+    'PATH',
+    'PATHEXT',
+    'SHELL',
+    'SystemDrive',
+    'SystemRoot',
+    'TEMP',
+    'TERM',
+    'TMP',
+    'TMPDIR',
+    'USER',
+    'USERPROFILE',
+    'WINDIR'
+].map(key => key.toUpperCase()));
+
+/**
+ * @module ai/scripts/diagnostics/genesisProbe
+ * @summary Runs the isolated BigData Neural Link interoperability journey for Genesis.
+ *
+ * The runner owns one disposable local stack: dev server, standalone Bridge, server-pinned
+ * Streamable HTTP Neural Link MCP server, and a headless BigData browser. It verifies the exact
+ * three-tool projection with the standard MCP SDK, derives the blind structural oracle, and then
+ * erases the entire diagnostic root after child shutdown. External mode keeps the stack alive for
+ * the Genesis deliverable and reveals the oracle only after an explicit operator command.
+ *
+ * @see https://github.com/neomjs/neo/issues/15187
+ */
+
+/**
+ * @summary Parses one explicit TCP port.
+ * @param {String|Number} value CLI value.
+ * @returns {Number}
+ */
+export function parsePort(value) {
+    const port = Number(value);
+
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        throw new InvalidArgumentError(`Expected an integer TCP port in the range 1..65535, got '${value}'.`)
+    }
+
+    return port
+}
+
+/**
+ * @summary Parses the one-shot runner CLI without starting any process.
+ * @param {String[]} [argv=[]] Arguments without node/script path.
+ * @param {Object} [env=process.env] Environment defaults.
+ * @returns {Object}
+ */
+export function parseArgs(argv = [], env = process.env) {
+    const program = new Command();
+
+    program
+        .name('genesisProbe')
+        .description('Run the isolated Genesis ↔ Neural Link BigData interoperability probe.')
+        .exitOverride()
+        .allowExcessArguments(false)
+        .option('--external', 'Keep the stack open for a frozen external Genesis deliverable.', false)
+        .option('--headed', 'Show the Chrome window instead of running headless.', false)
+        .option('--browser-channel <channel>', 'Playwright browser channel; use "bundled" for bundled Chromium.', env.NEO_GENESIS_BROWSER_CHANNEL || 'chrome')
+        .option('--bearer-token-env <name>', 'Environment variable carrying the private external-mode bearer.', env.NEO_GENESIS_BEARER_TOKEN_ENV || 'NEO_GENESIS_PROBE_BEARER')
+        .option('--dev-port <port>', 'Explicit isolated dev-server port.', parsePort)
+        .option('--bridge-port <port>', 'Explicit isolated Neural Link Bridge port.', parsePort)
+        .option('--mcp-port <port>', 'Explicit isolated Streamable HTTP port.', parsePort)
+        .option('--timeout-ms <ms>', 'Per-startup/tool-call timeout.', value => {
+            const timeoutMs = Number(value);
+
+            if (!Number.isInteger(timeoutMs) || timeoutMs < 1000 || timeoutMs > MAX_SESSION_MS) {
+                throw new InvalidArgumentError(`Expected timeout in the range 1000..${MAX_SESSION_MS}ms, got '${value}'.`)
+            }
+
+            return timeoutMs
+        }, Number(env.NEO_GENESIS_PROBE_TIMEOUT_MS) || DEFAULT_TIMEOUT_MS);
+
+    program.parse(argv, {from: 'user'});
+
+    return program.opts()
+}
+
+/**
+ * @summary Copies only process-launch essentials, excluding provider, repository, and Neo secrets.
+ * @param {Object} [baseEnv=process.env]
+ * @returns {Object}
+ */
+export function createSafeBaseEnv(baseEnv = process.env) {
+    const safeEnv = {};
+
+    for (const [key, value] of Object.entries(baseEnv)) {
+        if (SAFE_ENV_KEYS.has(key.toUpperCase()) && value !== undefined) {
+            safeEnv[key] = value
+        }
+    }
+
+    return safeEnv
+}
+
+/**
+ * @summary Builds a least-authority Playwright launch contract so the browser child does not
+ * inherit provider, repository, Neo, or external-probe credentials from the operator process.
+ * @param {Object} options
+ * @param {Object} [options.baseEnv=process.env]
+ * @param {String} [options.browserChannel='chrome'] Installed channel or `bundled`.
+ * @param {Boolean} [options.headed=false]
+ * @returns {Object} Playwright Chromium launch options.
+ */
+export function createBrowserLaunchOptions({
+    baseEnv = process.env,
+    browserChannel = 'chrome',
+    headed = false
+} = {}) {
+    const launchOptions = {
+        env     : createSafeBaseEnv(baseEnv),
+        headless: !headed
+    };
+
+    if (browserChannel !== 'bundled') {
+        launchOptions.channel = browserChannel
+    }
+
+    return launchOptions
+}
+
+/**
+ * @summary Builds least-authority child environments for the dev server, Bridge, and MCP server.
+ * @param {Object} options
+ * @param {Object} [options.baseEnv=process.env]
+ * @param {String} [options.bearerToken] Optional external-mode token.
+ * @param {{dev:Number, bridge:Number, mcp:Number}} options.ports
+ * @param {String} options.root Disposable diagnostic root.
+ * @returns {{databasePath:String, logPath:String, clientHeaders:Object, devEnv:Object, bridgeEnv:Object, mcpEnv:Object}}
+ */
+export function createProbeEnvironments({baseEnv = process.env, bearerToken, ports, root}) {
+    const
+        launchContract = createLocalBearerLaunchContract(bearerToken),
+        safeEnv        = createSafeBaseEnv(baseEnv),
+        databasePath   = path.join(root, 'memory-core.sqlite'),
+        logPath        = root,
+        commonEnv      = {
+            ...safeEnv,
+            FORCE_COLOR              : '0',
+            NEO_DEBUG                : 'false',
+            NEO_TEST_CONFIG_TEMPLATES: 'false',
+            UNIT_TEST_MODE           : 'false'
+        },
+        devEnv = {
+            ...commonEnv,
+            NODE_ENV: 'development'
+        },
+        bridgeEnv = {
+            ...commonEnv,
+            NEO_NL_LOG_PATH: logPath,
+            NEO_NL_PORT    : String(ports.bridge)
+        },
+        mcpEnv = {
+            ...commonEnv,
+            ...launchContract.serverEnv,
+            HOST                       : LOOPBACK_HOST,
+            MCP_HTTP_PORT              : String(ports.mcp),
+            NEO_MEMORY_DB_PATH         : databasePath,
+            NEO_NL_AUTO_CONNECT        : 'true',
+            NEO_NL_LOG_PATH            : logPath,
+            NEO_NL_PORT                : String(ports.bridge),
+            NEO_NL_TOOL_PROJECTION_MODE: PROBE_PROJECTION_MODE,
+            NEO_TRANSPORT              : 'streamable-http'
+        };
+
+    assertDiagnosticPathsWithinRoot({databasePath, logPath, root});
+
+    return {
+        databasePath,
+        logPath,
+        clientHeaders: launchContract.clientHeaders,
+        devEnv,
+        bridgeEnv,
+        mcpEnv
+    }
+}
+
+/**
+ * @summary Fails when a configured diagnostic sink escapes the disposable root.
+ * @param {Object} options
+ * @param {String} options.databasePath
+ * @param {String} options.logPath
+ * @param {String} options.root
+ * @returns {true}
+ */
+export function assertDiagnosticPathsWithinRoot({databasePath, logPath, root}) {
+    const
+        resolvedRoot = path.resolve(root),
+        candidates   = [databasePath, logPath].map(item => path.resolve(item));
+
+    for (const candidate of candidates) {
+        const relative = path.relative(resolvedRoot, candidate);
+
+        if (relative.startsWith('..') || path.isAbsolute(relative)) {
+            throw new Error(`Diagnostic sink escapes the disposable root: ${candidate}`)
+        }
+    }
+
+    return true
+}
+
+/**
+ * @summary Converts the lean depth-2 tree into the fixed-property-order public oracle.
+ * @param {Object} tree Lean `get_component_tree` tree payload.
+ * @returns {{oracle:Object, canonicalJson:String}}
+ */
+export function canonicalizeOracle(tree) {
+    if (!tree || typeof tree.className !== 'string' || !tree.className) {
+        throw new Error('The component-tree response has no root className.')
+    }
+
+    const items = tree.items || [];
+
+    if (!Array.isArray(items)) {
+        throw new Error('The component-tree response has a non-array items field.')
+    }
+
+    const oracle = {
+        rootClass     : tree.className,
+        directChildren: items.map((item, index) => {
+            if (!item || typeof item.className !== 'string' || !item.className) {
+                throw new Error(`Direct child ${index} has no className.`)
+            }
+
+            return {index, className: item.className}
+        })
+    };
+
+    return {oracle, canonicalJson: JSON.stringify(oracle)}
+}
+
+/**
+ * @summary Computes the approved salted oracle commitment.
+ * @param {Object} options
+ * @param {String} options.canonicalJson Whitespace-free fixed-order oracle JSON.
+ * @param {String} options.saltHex Secret 32-byte lowercase-hex salt.
+ * @returns {String} Lowercase SHA-256 hex digest.
+ */
+export function createOracleCommitment({canonicalJson, saltHex}) {
+    if (!/^[0-9a-f]{64}$/.test(saltHex || '')) {
+        throw new Error('Oracle salt must be exactly 32 bytes encoded as lowercase hex.')
+    }
+
+    return crypto
+        .createHash('sha256')
+        .update(`${saltHex}\n${canonicalJson}`, 'utf8')
+        .digest('hex')
+}
+
+/**
+ * @summary Recursively records relative path, type, and byte size without following symlinks.
+ * @param {String} root
+ * @returns {Promise<{rootPresent:Boolean, entries:Array<Object>} >}
+ */
+export async function createManifest(root) {
+    try {
+        await fsPromises.lstat(root)
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            return {rootPresent: false, entries: []}
+        }
+        throw error
+    }
+
+    const entries = [];
+
+    async function walk(directory) {
+        const names = (await fsPromises.readdir(directory)).sort();
+
+        for (const name of names) {
+            const
+                absolute = path.join(directory, name),
+                relative = path.relative(root, absolute).split(path.sep).join('/'),
+                stat     = await fsPromises.lstat(absolute),
+                type     = stat.isDirectory() ? 'directory' :
+                    stat.isFile() ? 'file' : stat.isSymbolicLink() ? 'symlink' : 'other';
+
+            entries.push({path: relative, type, bytes: stat.size});
+
+            if (stat.isDirectory()) {
+                await walk(absolute)
+            }
+        }
+    }
+
+    await walk(root);
+
+    return {rootPresent: true, entries}
+}
+
+/**
+ * @summary Captures a metadata-only path snapshot for the default-path non-touch guard.
+ * @param {String} targetPath
+ * @returns {Promise<Object>}
+ */
+export async function snapshotPath(targetPath) {
+    try {
+        const stat = await fsPromises.lstat(targetPath);
+
+        if (!stat.isDirectory()) {
+            return {
+                exists : true,
+                type   : stat.isFile() ? 'file' : stat.isSymbolicLink() ? 'symlink' : 'other',
+                bytes  : stat.size,
+                mtimeMs: stat.mtimeMs
+            }
+        }
+
+        const manifest = await createManifest(targetPath);
+
+        return {
+            exists : true,
+            type   : 'directory',
+            entries: manifest.entries,
+            mtimeMs: stat.mtimeMs
+        }
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            return {exists: false}
+        }
+        throw error
+    }
+}
+
+/**
+ * @summary Captures the complete SQLite file family for the default-path non-touch guard. WAL
+ * mode can mutate the `-wal` or `-shm` sidecar while the main database file stays byte-identical,
+ * so all three paths are one proof surface.
+ * @param {String} databasePath Main SQLite database path.
+ * @returns {Promise<Object>} Metadata snapshots for the main, WAL, and SHM files.
+ */
+export async function snapshotSqliteFamily(databasePath) {
+    const [database, wal, shm] = await Promise.all([
+        snapshotPath(databasePath),
+        snapshotPath(`${databasePath}-wal`),
+        snapshotPath(`${databasePath}-shm`)
+    ]);
+
+    return {database, wal, shm}
+}
+
+/**
+ * @summary Allocates a currently free loopback TCP port.
+ * @returns {Promise<Number>}
+ */
+export async function findFreePort() {
+    return await new Promise((resolve, reject) => {
+        const server = net.createServer();
+
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            const {port} = server.address();
+            server.close(error => error ? reject(error) : resolve(port))
+        })
+    })
+}
+
+/**
+ * @summary Resolves three distinct explicit-or-ephemeral ports.
+ * @param {Object} options Parsed CLI options.
+ * @returns {Promise<{dev:Number, bridge:Number, mcp:Number}>}
+ */
+export async function resolvePorts(options) {
+    const ports = {
+        dev   : options.devPort    || await findFreePort(),
+        bridge: options.bridgePort || await findFreePort(),
+        mcp   : options.mcpPort    || await findFreePort()
+    };
+
+    if (new Set(Object.values(ports)).size !== 3) {
+        throw new Error('Dev-server, Bridge, and MCP ports must be distinct.')
+    }
+
+    return ports
+}
+
+/**
+ * @summary Creates a classified probe error whose public message comes from a closed allowlist.
+ * @param {String} code Public failure code.
+ * @param {*} [cause] Private in-process cause.
+ * @returns {Error}
+ */
+export function createProbeFailure(code, cause) {
+    const resolvedCode = Object.hasOwn(PUBLIC_FAILURES, code) ? code : 'UNEXPECTED_FAILURE';
+    const error        = new Error(PUBLIC_FAILURES[resolvedCode]);
+
+    error.code = resolvedCode;
+
+    if (cause !== undefined) {
+        Object.defineProperty(error, 'cause', {
+            configurable: true,
+            value       : cause
+        })
+    }
+
+    return error
+}
+
+/**
+ * @summary Redacts any internal failure into the closed public receipt shape.
+ * @param {*} error Internal error.
+ * @returns {{code:String, message:String}}
+ */
+export function toPublicProbeError(error) {
+    const code = Object.hasOwn(PUBLIC_FAILURES, error?.code) ? error.code : 'UNEXPECTED_FAILURE';
+
+    return {code, message: PUBLIC_FAILURES[code]}
+}
+
+/**
+ * @summary Returns the smaller of the per-phase budget and the remaining global session budget.
+ * @param {Object} options
+ * @param {Number} options.deadline Epoch-millisecond deadline.
+ * @param {Number} options.timeoutMs Requested phase timeout.
+ * @param {Number} [options.now=Date.now()] Injectable current time for deterministic tests.
+ * @returns {Number}
+ */
+export function getPhaseTimeout({deadline, timeoutMs, now = Date.now()}) {
+    const remaining = deadline - now;
+
+    if (remaining <= 0) {
+        throw createProbeFailure('SESSION_LIMIT_EXCEEDED')
+    }
+
+    return Math.min(timeoutMs, remaining)
+}
+
+/**
+ * @summary Installs idempotent process-signal routing into an AbortController.
+ * @param {Object} options
+ * @param {AbortController} options.controller Probe lifecycle controller.
+ * @param {Object} [options.processTarget=process] EventEmitter-compatible process boundary.
+ * @returns {Function} Listener disposer.
+ */
+export function installProbeSignalHandlers({controller, processTarget = process}) {
+    const onSignal = () => {
+        if (!controller.signal.aborted) {
+            controller.abort(createProbeFailure('PROBE_INTERRUPTED'))
+        }
+    };
+
+    processTarget.on('SIGINT', onSignal);
+    processTarget.on('SIGTERM', onSignal);
+
+    return () => {
+        processTarget.off('SIGINT', onSignal);
+        processTarget.off('SIGTERM', onSignal)
+    }
+}
+
+/**
+ * @summary Creates the loopback-only webpack dev-server arguments for the disposable stack.
+ * @param {Number} port Explicit isolated port.
+ * @returns {String[]}
+ */
+export function createDevServerArgs(port) {
+    return [
+        require.resolve('webpack-cli/bin/cli.js'),
+        'serve',
+        '-c',
+        path.join(repoRoot, 'buildScripts/webpack/webpack.server.config.mjs'),
+        '--host',
+        LOOPBACK_HOST,
+        '--port',
+        String(port),
+        '--no-open'
+    ]
+}
+
+/**
+ * @summary Bounds one asynchronous lifecycle operation.
+ * @param {Promise} promise
+ * @param {Number} timeoutMs
+ * @param {String} label
+ * @param {AbortSignal} [signal] Probe interruption signal.
+ * @returns {Promise<*>}
+ */
+export async function withTimeout(promise, timeoutMs, label, signal) {
+    signal?.throwIfAborted();
+
+    let abortHandler, timer;
+    const timeout = new Promise((resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms.`)), timeoutMs)
+    });
+    const contenders = [promise, timeout];
+
+    if (signal) {
+        contenders.push(new Promise((resolve, reject) => {
+            abortHandler = () => reject(signal.reason || createProbeFailure('PROBE_INTERRUPTED'));
+            signal.addEventListener('abort', abortHandler, {once: true})
+        }))
+    }
+
+    return await Promise.race(contenders).finally(() => {
+        clearTimeout(timer);
+        if (abortHandler) signal.removeEventListener('abort', abortHandler)
+    })
+}
+
+/**
+ * @summary Probes one literal-loopback TCP port without retaining a socket.
+ * @param {Number} port
+ * @returns {Promise<Boolean>}
+ */
+async function isLoopbackPortOpen(port) {
+    return await new Promise(resolve => {
+        const socket = net.createConnection({host: LOOPBACK_HOST, port});
+        const finish = open => {
+            socket.destroy();
+            resolve(open)
+        };
+
+        socket.setTimeout(250);
+        socket.once('connect', () => finish(true));
+        socket.once('error',   () => finish(false));
+        socket.once('timeout', () => finish(false))
+    })
+}
+
+/**
+ * @summary Waits until every disposable listener rejects loopback connections.
+ * @param {Number[]} ports
+ * @param {Number} timeoutMs
+ * @returns {Promise<Boolean>}
+ */
+export async function waitForPortsClosed(ports, timeoutMs) {
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+
+    do {
+        const states = await Promise.all(ports.filter(Boolean).map(isLoopbackPortOpen));
+
+        if (states.every(open => !open)) return true;
+        await new Promise(resolve => setTimeout(resolve, 50))
+    } while (Date.now() < deadline);
+
+    return false
+}
+
+/**
+ * @summary Waits until a child-owned loopback listener accepts TCP connections.
+ * @param {Object} options
+ * @param {Object} options.child
+ * @param {String} options.label
+ * @param {Number} options.port
+ * @param {Number} options.timeoutMs
+ * @param {Number} [options.deadline] Global session deadline.
+ * @param {AbortSignal} [options.signal] Probe interruption signal.
+ * @returns {Promise<void>}
+ */
+export async function waitForPort({child, deadline, label, port, signal, timeoutMs}) {
+    const
+        startedAt     = Date.now(),
+        phaseDeadline = Math.min(startedAt + timeoutMs, deadline || Number.POSITIVE_INFINITY);
+
+    while (Date.now() < phaseDeadline) {
+        signal?.throwIfAborted();
+
+        if (hasChildExited(child)) {
+            throw new Error(`${label} exited before opening port ${port} (${child.exitCode ?? child.signalCode}).`)
+        }
+
+        const connected = await isLoopbackPortOpen(port);
+
+        if (connected) return;
+
+        await withTimeout(
+            new Promise(resolve => setTimeout(resolve, 100)),
+            getPhaseTimeout({deadline: phaseDeadline, timeoutMs: 100}),
+            `${label} retry`,
+            signal
+        )
+    }
+
+    if (deadline && Date.now() >= deadline) throw createProbeFailure('SESSION_LIMIT_EXCEEDED');
+    throw new Error(`${label} did not open port ${port} within ${timeoutMs}ms.`)
+}
+
+/**
+ * @summary Starts a direct child process with stdout/stderr isolated under the probe root.
+ * @param {Object} options
+ * @returns {Object}
+ */
+export function spawnLoggedChild({args, command = process.execPath, cwd = repoRoot, env, logPath, name}) {
+    const fd = fs.openSync(logPath, 'a', 0o600);
+    let child;
+
+    try {
+        child = spawn(command, args, {
+            cwd,
+            env,
+            detached   : process.platform !== 'win32',
+            stdio      : ['ignore', fd, fd],
+            windowsHide: true
+        })
+    } finally {
+        fs.closeSync(fd)
+    }
+
+    child.probeName = name;
+    return child
+}
+
+/**
+ * @summary Reports both ordinary and signal-based child-process termination.
+ * @param {Object} child
+ * @returns {Boolean}
+ */
+export function hasChildExited(child) {
+    return child.exitCode !== null || child.signalCode !== null
+}
+
+/**
+ * @summary Waits for a child-process leader without losing an exit that races listener setup.
+ * @param {Object} child
+ * @param {Number} timeoutMs
+ * @returns {Promise<Boolean>} Whether the leader exited inside the bounded window.
+ */
+export async function waitForChildExit(child, timeoutMs) {
+    if (hasChildExited(child)) return true;
+
+    return await new Promise(resolve => {
+        let timer;
+        const onExit = () => {
+            clearTimeout(timer);
+            resolve(true)
+        };
+
+        child.once('exit', onExit);
+
+        if (hasChildExited(child)) {
+            child.off('exit', onExit);
+            resolve(true);
+            return
+        }
+
+        timer = setTimeout(() => {
+            child.off('exit', onExit);
+            resolve(hasChildExited(child))
+        }, Math.max(0, timeoutMs))
+    })
+}
+
+/**
+ * @summary Reports whether a detached POSIX process group is still observable.
+ * @param {Number} pid Detached process-group leader id.
+ * @returns {Boolean|null} Null on Windows where Node cannot prove process-tree absence.
+ */
+export function isProcessGroupAlive(pid) {
+    if (process.platform === 'win32') return null;
+
+    try {
+        process.kill(-pid, 0);
+        return true
+    } catch (error) {
+        if (error.code === 'ESRCH') return false;
+        if (error.code === 'EPERM') return true;
+        throw error
+    }
+}
+
+/**
+ * @summary Waits for both the direct child and its detached POSIX process group to disappear.
+ * @param {Object} child
+ * @param {Number} timeoutMs
+ * @returns {Promise<{leaderExited:Boolean, processGroupExited:Boolean}>}
+ */
+async function waitForChildTermination(child, timeoutMs) {
+    const deadline = Date.now() + Math.max(0, timeoutMs);
+
+    await waitForChildExit(child, timeoutMs);
+
+    let processGroupAlive = isProcessGroupAlive(child.pid);
+
+    while (processGroupAlive === true && Date.now() < deadline) {
+        await new Promise(resolve => setTimeout(resolve, Math.min(25, Math.max(0, deadline - Date.now()))));
+        processGroupAlive = isProcessGroupAlive(child.pid)
+    }
+
+    return {
+        leaderExited      : hasChildExited(child),
+        processGroupExited: processGroupAlive === false
+    }
+}
+
+/**
+ * @summary Stops a detached child tree and fails unless termination is positively verified.
+ * @param {Object|null} child
+ * @param {String} [signal='SIGTERM']
+ * @param {Number} [timeoutMs=5000]
+ * @returns {Promise<{forced:Boolean, leaderExited:Boolean, processGroupExited:Boolean}>}
+ */
+export async function stopChild(child, signal = 'SIGTERM', timeoutMs = 5000) {
+    if (!child) {
+        return {forced: false, leaderExited: true, processGroupExited: process.platform !== 'win32'}
+    }
+
+    let termination = {
+        leaderExited      : hasChildExited(child),
+        processGroupExited: isProcessGroupAlive(child.pid) === false
+    };
+
+    if (termination.leaderExited && (process.platform === 'win32' || termination.processGroupExited)) {
+        return {forced: false, ...termination}
+    }
+
+    try {
+        if (process.platform === 'win32') {
+            child.kill(signal)
+        } else {
+            process.kill(-child.pid, signal)
+        }
+    } catch (error) {
+        if (error.code !== 'ESRCH') throw error
+    }
+
+    termination = await waitForChildTermination(child, timeoutMs);
+
+    let forced = false;
+
+    if (!termination.leaderExited || (process.platform !== 'win32' && !termination.processGroupExited)) {
+        forced = true;
+        try {
+            if (process.platform === 'win32') {
+                child.kill('SIGKILL')
+            } else {
+                process.kill(-child.pid, 'SIGKILL')
+            }
+        } catch (error) {
+            if (error.code !== 'ESRCH') throw error
+        }
+
+        termination = await waitForChildTermination(child, timeoutMs)
+    }
+
+    if (!termination.leaderExited || (process.platform !== 'win32' && !termination.processGroupExited)) {
+        throw createProbeFailure('CHILD_TERMINATION_UNVERIFIED', {
+            child : child.probeName,
+            forced,
+            ...termination
+        })
+    }
+
+    return {forced, ...termination}
+}
+
+/**
+ * @summary Reads structured JSON from a standard MCP SDK tool response.
+ * @param {Object} result
+ * @returns {*}
+ */
+export function readToolJson(result) {
+    if (result?.isError) {
+        const message = result.content?.find(item => item.type === 'text')?.text || 'Unknown MCP tool error.';
+        throw new Error(message)
+    }
+
+    if (result?.structuredContent) {
+        const keys = Object.keys(result.structuredContent);
+        return keys.length === 1 && keys[0] === 'result' ? result.structuredContent.result : result.structuredContent
+    }
+
+    const text = result?.content?.find(item => item.type === 'text')?.text;
+    if (!text) throw new Error('MCP tool returned no JSON payload.');
+
+    return JSON.parse(text)
+}
+
+/**
+ * @summary Polls the exact topology tool until the single intended BigData App Worker is present.
+ * @param {Object} options
+ * @returns {Promise<Array<Object>>}
+ */
+export async function waitForBigDataTopology({client, deadline, signal, timeoutMs}) {
+    const
+        startedAt     = Date.now(),
+        phaseDeadline = Math.min(startedAt + timeoutMs, deadline || Number.POSITIVE_INFINITY);
+    let topology = [];
+
+    while (Date.now() < phaseDeadline) {
+        signal?.throwIfAborted();
+        topology = readToolJson(await withTimeout(
+            client.callTool({name: 'get_worker_topology', arguments: {}}),
+            getPhaseTimeout({deadline: phaseDeadline, timeoutMs}),
+            'get_worker_topology',
+            signal
+        ));
+
+        if (Array.isArray(topology) && topology.length === 1 && topology[0]?.appName === EXPECTED_APP_NAME) {
+            return topology
+        }
+
+        if (Array.isArray(topology) && topology.length > 1) {
+            throw createProbeFailure('TOPOLOGY_MISMATCH', {observedCount: topology.length})
+        }
+
+        await withTimeout(
+            new Promise(resolve => setTimeout(resolve, 200)),
+            getPhaseTimeout({deadline: phaseDeadline, timeoutMs: 200}),
+            'BigData topology retry',
+            signal
+        )
+    }
+
+    if (deadline && Date.now() >= deadline) throw createProbeFailure('SESSION_LIMIT_EXCEEDED');
+    throw createProbeFailure('TOPOLOGY_MISMATCH', {topology})
+}
+
+/**
+ * @summary Returns aggregate-only Neural Link call counts after the MCP process has released SQLite.
+ * @param {String} databasePath
+ * @returns {Promise<Array<Object>>}
+ */
+export async function readAggregateTelemetry(databasePath) {
+    try {
+        await fsPromises.access(databasePath)
+    } catch {
+        return []
+    }
+
+    const Database = (await import('better-sqlite3')).default;
+    const db       = new Database(databasePath, {readonly: true});
+
+    try {
+        return db.prepare(`
+            SELECT
+                tool,
+                COUNT(*) AS count,
+                SUM(CASE WHEN success = 1 THEN 1 ELSE 0 END) AS successCount,
+                COALESCE(SUM(duration_ms), 0) AS durationMs
+            FROM nl_action_log
+            GROUP BY tool
+            ORDER BY tool
+        `).all()
+    } finally {
+        db.close()
+    }
+}
+
+/**
+ * @summary Captures cleanup evidence independently, then attempts whole-root deletion whenever
+ * process termination authorized it. A corrupt telemetry database or failed pre-delete snapshot
+ * must fail the receipt without becoming a veto that leaves raw diagnostics behind.
+ * @param {Object} options
+ * @param {String|null} options.databasePath Isolated SQLite path.
+ * @param {Object|null} options.defaultPaths Default live database/log paths.
+ * @param {Boolean} options.deletionAuthorized Whether process shutdown proof permits deletion.
+ * @param {String} options.root Disposable diagnostic root.
+ * @returns {Promise<Object>} Aggregate evidence, manifests, default snapshot, and private failures.
+ */
+export async function finalizeDisposableRoot({
+    databasePath,
+    defaultPaths,
+    deletionAuthorized,
+    root
+}) {
+    let
+        afterManifest  = {rootPresent: null, entries: []},
+        beforeManifest = {rootPresent: null, entries: []},
+        defaultAfter   = null,
+        telemetry      = [];
+
+    const failures = [];
+    const capture  = async (label, operation, assign) => {
+        try {
+            assign(await operation())
+        } catch (error) {
+            failures.push({error, label})
+        }
+    };
+
+    if (deletionAuthorized && databasePath) {
+        await capture(
+            'Aggregate telemetry read',
+            () => readAggregateTelemetry(databasePath),
+            value => { telemetry = value }
+        )
+    }
+
+    await capture(
+        'Before-manifest capture',
+        () => createManifest(root),
+        value => { beforeManifest = value }
+    );
+
+    if (defaultPaths) {
+        await capture(
+            'Default-path after snapshot',
+            async () => ({
+                database: await snapshotSqliteFamily(defaultPaths.database),
+                logs    : await snapshotPath(defaultPaths.logs)
+            }),
+            value => { defaultAfter = value }
+        )
+    }
+
+    if (deletionAuthorized) {
+        await capture(
+            'Disposable-root deletion',
+            () => fsPromises.rm(root, {recursive: true, force: true}),
+            () => {}
+        )
+    }
+
+    await capture(
+        'After-manifest capture',
+        () => createManifest(root),
+        value => { afterManifest = value }
+    );
+
+    return {afterManifest, beforeManifest, defaultAfter, failures, telemetry}
+}
+
+/**
+ * @summary Emits one machine-readable, secret-free journey event.
+ * @param {String} type
+ * @param {Object} payload
+ */
+export function emitEvent(type, payload) {
+    process.stdout.write(`${JSON.stringify({type, ...payload})}\n`)
+}
+
+/**
+ * @summary Resolves current Neo and accepted Genesis version anchors for the final receipt.
+ * @param {Object} [options]
+ * @param {Number} [options.gitTimeoutMs=5000] Bound for the optional git commit lookup.
+ * @returns {Promise<Object>}
+ */
+export async function readVersionAnchors({gitTimeoutMs = 5000} = {}) {
+    const packageJson = JSON.parse(await fsPromises.readFile(path.join(repoRoot, 'package.json'), 'utf8'));
+    let   neoCommit   = null;
+
+    try {
+        neoCommit = execFileSync('git', ['rev-parse', 'HEAD'], {
+            cwd     : repoRoot,
+            encoding: 'utf8',
+            stdio   : ['ignore', 'pipe', 'ignore'],
+            timeout : Math.max(1, gitTimeoutMs)
+        }).trim()
+    } catch {
+        // Exported source archives may not contain .git; package version remains authoritative there.
+    }
+
+    return {
+        genesis: {version: GENESIS_VERSION, commit: GENESIS_COMMIT},
+        neo    : {version: packageJson.version, commit: neoCommit}
+    }
+}
+
+/**
+ * @summary Captures one bounded external operator command without exposing the bearer.
+ * @param {Object} options
+ * @param {String[]} options.choices Accepted lowercase commands.
+ * @param {Number} options.deadline Epoch-millisecond session deadline.
+ * @param {String} options.prompt Prompt written to stderr.
+ * @returns {Promise<String>}
+ */
+async function waitForExternalCommand({choices, deadline, prompt, signal}) {
+    if (!process.stdin.isTTY) {
+        throw new Error('External mode requires an interactive TTY for the freeze/reveal/review boundaries.')
+    }
+
+    const rl = readline.createInterface({input: process.stdin, output: process.stderr});
+
+    try {
+        while (true) {
+            signal?.throwIfAborted();
+            const remainingMs = getPhaseTimeout({deadline, timeoutMs: MAX_SESSION_MS});
+
+            const answer = (await withTimeout(
+                rl.question(prompt),
+                remainingMs,
+                'Genesis external probe session',
+                signal
+            )).trim().toLowerCase();
+
+            if (choices.includes(answer)) return answer
+        }
+    } finally {
+        rl.close()
+    }
+}
+
+/**
+ * @summary Waits for the external deliverable to freeze before revealing the blind oracle.
+ * @param {Number} deadline Epoch-millisecond session deadline.
+ * @returns {Promise<'abort'|'reveal'>}
+ */
+async function waitForExternalFreeze(deadline, signal) {
+    return await waitForExternalCommand({
+        choices: ['reveal', 'abort'],
+        deadline,
+        prompt : 'Genesis deliverable frozen? Type "reveal" to reveal the oracle, or "abort": ',
+        signal
+    })
+}
+
+/**
+ * @summary Keeps raw diagnostics alive until joint review explicitly authorizes cleanup.
+ * @param {Number} deadline Epoch-millisecond session deadline.
+ * @returns {Promise<'abort'|'cleanup'>}
+ */
+async function waitForExternalReview(deadline, signal) {
+    return await waitForExternalCommand({
+        choices: ['cleanup', 'abort'],
+        deadline,
+        prompt : 'Joint review complete? Type "cleanup" to erase raw diagnostics, or "abort": ',
+        signal
+    })
+}
+
+/**
+ * @summary Runs the complete isolated probe and always attempts whole-root cleanup.
+ * @param {Object} options Parsed CLI options.
+ * @param {Object} [baseEnv=process.env]
+ * @param {Object} [lifecycle]
+ * @param {AbortSignal} [lifecycle.signal] Process-interruption signal.
+ * @returns {Promise<Object>} Final secret-free receipt.
+ */
+export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
+    const
+        startedAt    = new Date(),
+        deadline     = startedAt.getTime() + MAX_SESSION_MS,
+        workDeadline = deadline - CLEANUP_RESERVE_MS,
+        timeoutMs    = Math.min(options.timeoutMs || DEFAULT_TIMEOUT_MS, MAX_SESSION_MS),
+        state        = {
+            browser  : null,
+            client   : null,
+            children : {},
+            context  : null,
+            root     : null,
+            transport: null
+        };
+
+    const runPhase = (operation, label, requestedTimeoutMs = timeoutMs) => withTimeout(
+        Promise.resolve().then(operation),
+        getPhaseTimeout({deadline: workDeadline, timeoutMs: requestedTimeoutMs}),
+        label,
+        signal
+    );
+
+    let
+        canonicalJson,
+        commitment,
+        databasePath,
+        defaultAfter,
+        defaultBefore,
+        defaultPaths,
+        diagnosticsConfigured = false,
+        failure,
+        logPath,
+        oracle,
+        ports,
+        revealed = false,
+        saltHex,
+        telemetry               = [],
+        childLeadersExited      = true,
+        listenerClosureVerified = process.platform !== 'win32',
+        terminationVerified     = process.platform !== 'win32';
+
+    try {
+        if (process.platform === 'win32' && options.external) {
+            throw createProbeFailure('CHILD_TERMINATION_UNVERIFIED', {
+                reason: 'Windows external privacy proof requires supervised process-tree support.'
+            })
+        }
+
+        await runPhase(() => import('../../../src/Neo.mjs'), 'Neo bootstrap');
+        await runPhase(() => import('../../../src/core/_export.mjs'), 'Neo core bootstrap');
+
+        const aiConfig = (await runPhase(
+            () => import('../../mcp/server/neural-link/config.mjs'),
+            'Neural Link config bootstrap'
+        )).default;
+
+        defaultPaths = {
+            database: aiConfig.memoryCoreDbPath,
+            logs    : aiConfig.logPath
+        };
+        defaultBefore = {
+            database: await runPhase(
+                () => snapshotSqliteFamily(defaultPaths.database),
+                'Default SQLite-family snapshot'
+            ),
+            logs    : await runPhase(() => snapshotPath(defaultPaths.logs), 'Default log snapshot')
+        };
+
+        state.root = await runPhase(
+            () => fsPromises.mkdtemp(path.join(os.tmpdir(), 'neo-genesis-probe-')),
+            'Disposable-root creation'
+        );
+        ports = await runPhase(() => resolvePorts(options), 'Loopback-port allocation');
+
+        const environments = createProbeEnvironments({
+            baseEnv,
+            bearerToken: options.external ? String(baseEnv[options.bearerTokenEnv] || '').trim() : undefined,
+            ports,
+            root       : state.root
+        });
+
+        if (baseEnv === process.env && options.external) {
+            delete process.env[options.bearerTokenEnv]
+        }
+
+        ({databasePath, logPath} = environments);
+        diagnosticsConfigured = true;
+
+        const bridgeLog = path.join(state.root, 'neural-link-bridge-stdio.log');
+        state.children.bridge = spawnLoggedChild({
+            args   : [path.join(repoRoot, 'ai/mcp/server/neural-link/run-bridge.mjs')],
+            env    : environments.bridgeEnv,
+            logPath: bridgeLog,
+            name   : 'Neural Link Bridge'
+        });
+        await waitForPort({
+            child   : state.children.bridge,
+            deadline: workDeadline,
+            label   : 'Neural Link Bridge',
+            port    : ports.bridge,
+            signal,
+            timeoutMs
+        });
+
+        state.children.dev = spawnLoggedChild({
+            args   : createDevServerArgs(ports.dev),
+            env    : environments.devEnv,
+            logPath: path.join(state.root, 'dev-server-stdio.log'),
+            name   : 'Neo dev server'
+        });
+        await waitForPort({
+            child   : state.children.dev,
+            deadline: workDeadline,
+            label   : 'Neo dev server',
+            port    : ports.dev,
+            signal,
+            timeoutMs
+        });
+
+        state.children.mcp = spawnLoggedChild({
+            args   : [path.join(repoRoot, 'ai/mcp/server/neural-link/mcp-server.mjs')],
+            env    : environments.mcpEnv,
+            logPath: path.join(state.root, 'neural-link-mcp-stdio.log'),
+            name   : 'Neural Link MCP server'
+        });
+        delete environments.mcpEnv.NEO_AUTH_LOCAL_BEARER_TOKEN;
+
+        await waitForPort({
+            child   : state.children.mcp,
+            deadline: workDeadline,
+            label   : 'Neural Link MCP server',
+            port    : ports.mcp,
+            signal,
+            timeoutMs
+        });
+
+        const {chromium}    = await runPhase(() => import('playwright'), 'Playwright bootstrap');
+        const launchOptions = createBrowserLaunchOptions({
+            baseEnv,
+            browserChannel: options.browserChannel,
+            headed        : options.headed
+        });
+
+        state.browser = await runPhase(() => chromium.launch(launchOptions), 'Browser launch');
+        state.context = await runPhase(() => state.browser.newContext(), 'Browser context creation');
+        const page = await runPhase(() => state.context.newPage(), 'Browser page creation');
+
+        await runPhase(() => page.route('**/examples/grid/bigData/neo-config.json', async route => {
+            const response = await route.fetch();
+            const config   = await response.json();
+
+            await route.fulfill({
+                response,
+                json: {
+                    ...config,
+                    neuralLinkUrl: `ws://${LOOPBACK_HOST}:${ports.bridge}`
+                }
+            })
+        }), 'BigData config route');
+
+        await runPhase(() => page.goto(
+            `http://${LOOPBACK_HOST}:${ports.dev}/examples/grid/bigData/index.html`,
+            {
+                waitUntil: 'domcontentloaded',
+                timeout  : getPhaseTimeout({deadline: workDeadline, timeoutMs})
+            }
+        ), 'BigData navigation');
+        await runPhase(() => page.waitForSelector('.neo-grid-container', {
+            state  : 'visible',
+            timeout: getPhaseTimeout({deadline: workDeadline, timeoutMs})
+        }), 'BigData readiness');
+
+        const endpoint = new URL(`http://${LOOPBACK_HOST}:${ports.mcp}/mcp`);
+        state.transport = new StreamableHTTPClientTransport(endpoint, {
+            requestInit: {
+                headers: environments.clientHeaders
+            }
+        });
+        environments.clientHeaders = null;
+        state.client = new Client({name: 'neo-genesis-reference-probe', version: '1.0.0'}, {capabilities: {}});
+
+        await runPhase(() => state.client.connect(state.transport), 'MCP connect');
+
+        const listedTools = (await runPhase(() => state.client.listTools(), 'MCP tools/list')).tools.map(tool => tool.name);
+
+        if (JSON.stringify(listedTools) !== JSON.stringify(EXACT_TOOL_NAMES)) {
+            throw createProbeFailure('TOOL_PROFILE_MISMATCH', {listedTools})
+        }
+
+        const health = readToolJson(await runPhase(
+            () => state.client.callTool({name: 'healthcheck', arguments: {}}),
+            'healthcheck'
+        ));
+
+        if (health.status !== 'healthy') {
+            throw createProbeFailure('UNEXPECTED_FAILURE', {healthStatus: health.status})
+        }
+
+        const topology = await waitForBigDataTopology({
+            client  : state.client,
+            deadline: workDeadline,
+            signal,
+            timeoutMs
+        });
+        const sessionId = topology[0].appWorkerId;
+
+        if (!sessionId) {
+            throw createProbeFailure('TOPOLOGY_MISMATCH', {reason: 'missing-session-id'})
+        }
+
+        const treeResult = readToolJson(await runPhase(
+            () => state.client.callTool({
+                name     : 'get_component_tree',
+                arguments: {depth: 2, lean: true, sessionId}
+            }),
+            'get_component_tree'
+        ));
+
+        ({oracle, canonicalJson} = canonicalizeOracle(treeResult.tree));
+        saltHex   = crypto.randomBytes(32).toString('hex');
+        commitment = createOracleCommitment({canonicalJson, saltHex});
+
+        emitEvent('GENESIS_PROBE_LOCAL_READY', {
+            appName       : EXPECTED_APP_NAME,
+            authorization : 'Bearer <private-disposable-token>',
+            bearerTokenEnv: options.bearerTokenEnv,
+            endpoint      : endpoint.toString(),
+            profile       : PROBE_PROJECTION_MODE,
+            tools         : [...EXACT_TOOL_NAMES],
+            treeArguments : {depth: 2, lean: true},
+            externalMode  : options.external
+        });
+        emitEvent('GENESIS_ORACLE_COMMITMENT', {commitment});
+
+        if (options.external) {
+            const freezeDecision = await waitForExternalFreeze(workDeadline, signal);
+
+            if (freezeDecision === 'abort') {
+                throw new Error('External probe aborted before oracle reveal.')
+            }
+
+            revealed = true;
+            emitEvent('GENESIS_ORACLE_REVEAL', {canonicalJson, saltHex});
+
+            const reviewDecision = await waitForExternalReview(workDeadline, signal);
+
+            if (reviewDecision === 'abort') {
+                throw new Error('External probe aborted after reveal and before joint-review completion.')
+            }
+        } else {
+            revealed = true;
+            emitEvent('GENESIS_ORACLE_REVEAL', {canonicalJson, saltHex})
+        }
+    } catch (error) {
+        failure = error
+    } finally {
+        const cleanupFailures = [];
+        const closeResource   = async (label, operation) => {
+            if (!operation) return;
+
+            try {
+                const remainingMs = Math.max(1, Math.min(5000, deadline - Date.now()));
+                await withTimeout(Promise.resolve().then(operation), remainingMs, label)
+            } catch (error) {
+                cleanupFailures.push({error, label})
+            }
+        };
+
+        await closeResource('MCP client close', state.client?.close ? () => state.client.close() : null);
+        await closeResource('Browser context close', state.context?.close ? () => state.context.close() : null);
+        await closeResource('Browser close', state.browser?.close ? () => state.browser.close() : null);
+
+        state.client    = null;
+        state.context   = null;
+        state.browser   = null;
+        state.transport = null;
+
+        for (const [key, childSignal] of [
+            ['mcp', 'SIGTERM'],
+            ['bridge', 'SIGINT'],
+            ['dev', 'SIGTERM']
+        ]) {
+            try {
+                const result = await stopChild(
+                    state.children[key],
+                    childSignal,
+                    Math.max(0, Math.min(5000, deadline - Date.now()))
+                );
+
+                childLeadersExited &&= result.leaderExited;
+                terminationVerified &&= result.leaderExited && result.processGroupExited
+            } catch (error) {
+                childLeadersExited = false;
+                terminationVerified = false;
+                cleanupFailures.push({error, label: `${key} child stop`})
+            }
+        }
+
+        if (process.platform === 'win32' && !options.external && childLeadersExited) {
+            listenerClosureVerified = await waitForPortsClosed(
+                Object.values(ports || {}),
+                Math.max(0, Math.min(5000, deadline - Date.now()))
+            );
+
+            if (!listenerClosureVerified) {
+                cleanupFailures.push({
+                    error: createProbeFailure('CHILD_TERMINATION_UNVERIFIED'),
+                    label: 'Windows listener-closure verification'
+                })
+            }
+        }
+
+        if (cleanupFailures.length) {
+            const terminationFailure = cleanupFailures.find(item =>
+                item.error?.code === 'CHILD_TERMINATION_UNVERIFIED'
+            );
+
+            failure = createProbeFailure(
+                terminationFailure ? 'CHILD_TERMINATION_UNVERIFIED' : 'CLEANUP_FAILED',
+                {cleanupFailures, primaryFailure: failure}
+            )
+        }
+
+        state.cleanupDeletionAuthorized = !cleanupFailures.length && (
+            terminationVerified || (
+                process.platform === 'win32' &&
+                !options.external &&
+                childLeadersExited &&
+                listenerClosureVerified
+            )
+        );
+        state.cleanupFailures = cleanupFailures
+    }
+
+    let beforeManifest = {rootPresent: false, entries: []};
+    let afterManifest  = {rootPresent: false, entries: []};
+
+    if (failure && state.root) {
+        try {
+            const serializePrivateCause = cause => {
+                if (cause === undefined) return null;
+
+                try {
+                    return JSON.parse(JSON.stringify(cause, (key, value) => value instanceof Error ? {
+                        code   : value.code || null,
+                        message: value.message,
+                        name   : value.name,
+                        stack  : value.stack || null
+                    } : value))
+                } catch {
+                    return '[private cause was not serializable]'
+                }
+            };
+            const serializePrivateError = error => ({
+                cause  : serializePrivateCause(error?.cause),
+                code   : error?.code || null,
+                message: error?.message || String(error),
+                name   : error?.name || null,
+                stack  : error?.stack || null
+            });
+
+            await fsPromises.writeFile(
+                path.join(state.root, 'private-failure.json'),
+                JSON.stringify({
+                    cleanup: state.cleanupFailures?.map(item => ({
+                        error: serializePrivateError(item.error),
+                        label: item.label
+                    })) || [],
+                    primary: serializePrivateError(failure)
+                }, null, 2),
+                {mode: 0o600}
+            )
+        } catch (error) {
+            failure = createProbeFailure('CLEANUP_FAILED', error)
+        }
+    }
+
+    if (state.root) {
+        const finalization = await finalizeDisposableRoot({
+            databasePath,
+            defaultPaths,
+            deletionAuthorized: state.cleanupDeletionAuthorized,
+            root              : state.root
+        });
+
+        ({afterManifest, beforeManifest, defaultAfter, telemetry} = finalization);
+
+        if (finalization.failures.length) {
+            failure = createProbeFailure(
+                terminationVerified ? 'CLEANUP_FAILED' : 'CHILD_TERMINATION_UNVERIFIED',
+                {evidenceFailures: finalization.failures, primaryFailure: failure}
+            )
+        }
+    }
+
+    const defaultPathsUntouched = defaultBefore && defaultAfter ?
+        JSON.stringify(defaultBefore) === JSON.stringify(defaultAfter) : null;
+
+    if (afterManifest.rootPresent) {
+        failure ||= createProbeFailure(
+            terminationVerified ? 'CLEANUP_FAILED' : 'CHILD_TERMINATION_UNVERIFIED'
+        )
+    }
+    if (process.platform === 'win32' && !terminationVerified) {
+        failure ||= createProbeFailure('CHILD_TERMINATION_UNVERIFIED')
+    }
+    if (defaultPathsUntouched === false) {
+        failure ||= new Error('A default live diagnostic path changed during the isolated probe window.')
+    }
+
+    let versions = {
+        genesis: {version: GENESIS_VERSION, commit: GENESIS_COMMIT},
+        neo    : {version: null, commit: null}
+    };
+
+    try {
+        const remainingMs = Math.max(1, Math.min(5000, deadline - Date.now()));
+        versions = await withTimeout(
+            readVersionAnchors({gitTimeoutMs: remainingMs}),
+            remainingMs,
+            'Version anchors'
+        )
+    } catch (error) {
+        failure ||= Date.now() >= deadline ?
+            createProbeFailure('SESSION_LIMIT_EXCEEDED', error) :
+            createProbeFailure('UNEXPECTED_FAILURE', error)
+    }
+
+    if (Date.now() >= deadline) {
+        failure = createProbeFailure('SESSION_LIMIT_EXCEEDED', failure)
+    }
+
+    const endedAt = new Date();
+    const receipt = {
+        status    : failure ? 'failure' : 'success',
+        startedAt : startedAt.toISOString(),
+        endedAt   : endedAt.toISOString(),
+        durationMs: endedAt - startedAt,
+        versions,
+        profile   : PROBE_PROJECTION_MODE,
+        tools     : [...EXACT_TOOL_NAMES],
+        oracle    : commitment ? {
+            commitment,
+            revealed,
+            canonicalJson: revealed ? canonicalJson : null,
+            saltHex      : revealed ? saltHex : null
+        } : null,
+        telemetry,
+        diagnostics  : {
+            configuredInsideDisposableRoot: diagnosticsConfigured,
+            beforeManifest,
+            afterManifest,
+            defaultPathsUntouched,
+            listenerClosureVerified,
+            terminationVerified
+        },
+        sessionLimitMs: MAX_SESSION_MS,
+        error         : failure ? toPublicProbeError(failure) : null
+    };
+
+    emitEvent('GENESIS_PROBE_RECEIPT', receipt);
+
+    if (failure) {
+        const publicFailure = toPublicProbeError(failure);
+        throw createProbeFailure(publicFailure.code, failure)
+    }
+    return receipt
+}
+
+/**
+ * @summary Parses command-line options and runs one probe process.
+ * @returns {Promise<void>}
+ */
+async function main() {
+    const controller = new AbortController();
+    const dispose    = installProbeSignalHandlers({controller});
+    let   options;
+
+    try {
+        options = parseArgs(process.argv.slice(2));
+    } catch (error) {
+        dispose();
+        if (error.code === 'commander.helpDisplayed') return;
+        throw error
+    }
+
+    try {
+        await runProbe(options, process.env, {signal: controller.signal})
+    } finally {
+        dispose()
+    }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    try {
+        await main()
+    } catch (error) {
+        process.stderr.write(`Genesis probe failed: ${JSON.stringify(toPublicProbeError(error))}\n`);
+        process.exitCode = 1
+    }
+}

--- a/ai/scripts/diagnostics/genesisProbe.mjs
+++ b/ai/scripts/diagnostics/genesisProbe.mjs
@@ -32,6 +32,8 @@ export const GENESIS_VERSION       = '7.9.38';
 export const PROBE_PROJECTION_MODE = 'local-readonly-probe';
 export const LOOPBACK_HOST         = '127.0.0.1';
 
+const MIN_TERMINATION_VERIFY_MS = 250;
+
 const PUBLIC_FAILURES = Object.freeze({
     CHILD_TERMINATION_UNVERIFIED: 'A probe child could not be verified as stopped.',
     CLEANUP_FAILED              : 'The disposable diagnostics could not be fully erased.',
@@ -481,6 +483,17 @@ export function getPhaseTimeout({deadline, timeoutMs, now = Date.now()}) {
 }
 
 /**
+ * @summary Starts a cleanup-owned safety window independent of the active-session deadline.
+ * The work deadline reserves this window during normal execution, while an overrun still receives
+ * enough time to terminate children and erase diagnostics before the receipt reports failure.
+ * @param {Number} [now=Date.now()] Injectable current time for deterministic tests.
+ * @returns {Number} Epoch-millisecond cleanup deadline.
+ */
+export function createCleanupDeadline(now = Date.now()) {
+    return now + CLEANUP_RESERVE_MS
+}
+
+/**
  * @summary Installs idempotent process-signal routing into an AbortController.
  * @param {Object} options
  * @param {AbortController} options.controller Probe lifecycle controller.
@@ -592,17 +605,25 @@ export async function waitForPortsClosed(ports, timeoutMs) {
 }
 
 /**
- * @summary Waits until a child-owned loopback listener accepts TCP connections.
+ * @summary Waits for a child-owned private-log marker before confirming loopback reachability.
+ * A generic open port is never readiness evidence, because it could belong to an unrelated local
+ * process that must not receive the probe bearer or oracle traffic.
  * @param {Object} options
  * @param {Object} options.child
  * @param {String} options.label
+ * @param {String} options.logPath Child-private stdio log inside the disposable root.
+ * @param {String[]} options.markers Exact marker fragments emitted only after the child binds.
  * @param {Number} options.port
  * @param {Number} options.timeoutMs
  * @param {Number} [options.deadline] Global session deadline.
  * @param {AbortSignal} [options.signal] Probe interruption signal.
  * @returns {Promise<void>}
  */
-export async function waitForPort({child, deadline, label, port, signal, timeoutMs}) {
+export async function waitForChildReady({child, deadline, label, logPath, markers, port, signal, timeoutMs}) {
+    if (!logPath || !Array.isArray(markers) || markers.length === 0) {
+        throw new TypeError(`${label} readiness requires a private log path and at least one marker.`)
+    }
+
     const
         startedAt     = Date.now(),
         phaseDeadline = Math.min(startedAt + timeoutMs, deadline || Number.POSITIVE_INFINITY);
@@ -610,24 +631,35 @@ export async function waitForPort({child, deadline, label, port, signal, timeout
     while (Date.now() < phaseDeadline) {
         signal?.throwIfAborted();
 
+        if (child.probeLaunchError) {
+            throw child.probeLaunchError
+        }
         if (hasChildExited(child)) {
             throw new Error(`${label} exited before opening port ${port} (${child.exitCode ?? child.signalCode}).`)
         }
 
-        const connected = await isLoopbackPortOpen(port);
+        let logText = '';
 
-        if (connected) return;
+        try {
+            logText = await fsPromises.readFile(logPath, 'utf8')
+        } catch (error) {
+            if (error.code !== 'ENOENT') throw error
+        }
 
-        await withTimeout(
-            new Promise(resolve => setTimeout(resolve, 100)),
-            getPhaseTimeout({deadline: phaseDeadline, timeoutMs: 100}),
-            `${label} retry`,
-            signal
-        )
+        if (markers.every(marker => logText.includes(marker))) {
+            const connected = await isLoopbackPortOpen(port);
+
+            if (connected && !hasChildExited(child) && !child.probeLaunchError) return
+        }
+
+        await new Promise(resolve => setTimeout(
+            resolve,
+            Math.min(100, Math.max(1, phaseDeadline - Date.now()))
+        ))
     }
 
     if (deadline && Date.now() >= deadline) throw createProbeFailure('SESSION_LIMIT_EXCEEDED');
-    throw new Error(`${label} did not open port ${port} within ${timeoutMs}ms.`)
+    throw new Error(`${label} did not prove child-owned readiness on port ${port} within ${timeoutMs}ms.`)
 }
 
 /**
@@ -651,7 +683,12 @@ export function spawnLoggedChild({args, command = process.execPath, cwd = repoRo
         fs.closeSync(fd)
     }
 
-    child.probeName = name;
+    child.probeLaunchError = null;
+    child.probeName        = name;
+    child.once('error', error => {
+        child.probeLaunchError = error
+    });
+
     return child
 }
 
@@ -661,7 +698,9 @@ export function spawnLoggedChild({args, command = process.execPath, cwd = repoRo
  * @returns {Boolean}
  */
 export function hasChildExited(child) {
-    return child.exitCode !== null || child.signalCode !== null
+    return Boolean(child && (
+        child.probeLaunchError || child.exitCode !== null || child.signalCode !== null
+    ))
 }
 
 /**
@@ -702,6 +741,7 @@ export async function waitForChildExit(child, timeoutMs) {
  */
 export function isProcessGroupAlive(pid) {
     if (process.platform === 'win32') return null;
+    if (!Number.isInteger(pid) || pid <= 0) return false;
 
     try {
         process.kill(-pid, 0);
@@ -749,6 +789,10 @@ export async function stopChild(child, signal = 'SIGTERM', timeoutMs = 5000) {
         return {forced: false, leaderExited: true, processGroupExited: process.platform !== 'win32'}
     }
 
+    const
+        signalErrors        = [],
+        verificationTimeout = Math.max(MIN_TERMINATION_VERIFY_MS, timeoutMs);
+
     let termination = {
         leaderExited      : hasChildExited(child),
         processGroupExited: isProcessGroupAlive(child.pid) === false
@@ -758,39 +802,36 @@ export async function stopChild(child, signal = 'SIGTERM', timeoutMs = 5000) {
         return {forced: false, ...termination}
     }
 
-    try {
-        if (process.platform === 'win32') {
-            child.kill(signal)
-        } else {
-            process.kill(-child.pid, signal)
+    const sendSignal = nextSignal => {
+        try {
+            if (process.platform === 'win32') {
+                child.kill(nextSignal)
+            } else {
+                process.kill(-child.pid, nextSignal)
+            }
+        } catch (error) {
+            if (error.code !== 'ESRCH') signalErrors.push(error)
         }
-    } catch (error) {
-        if (error.code !== 'ESRCH') throw error
-    }
+    };
 
-    termination = await waitForChildTermination(child, timeoutMs);
+    sendSignal(signal);
+
+    termination = await waitForChildTermination(child, verificationTimeout);
 
     let forced = false;
 
     if (!termination.leaderExited || (process.platform !== 'win32' && !termination.processGroupExited)) {
         forced = true;
-        try {
-            if (process.platform === 'win32') {
-                child.kill('SIGKILL')
-            } else {
-                process.kill(-child.pid, 'SIGKILL')
-            }
-        } catch (error) {
-            if (error.code !== 'ESRCH') throw error
-        }
+        sendSignal('SIGKILL');
 
-        termination = await waitForChildTermination(child, timeoutMs)
+        termination = await waitForChildTermination(child, verificationTimeout)
     }
 
     if (!termination.leaderExited || (process.platform !== 'win32' && !termination.processGroupExited)) {
         throw createProbeFailure('CHILD_TERMINATION_UNVERIFIED', {
             child : child.probeName,
             forced,
+            signalErrors,
             ...termination
         })
     }
@@ -1166,42 +1207,54 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
             logPath: bridgeLog,
             name   : 'Neural Link Bridge'
         });
-        await waitForPort({
+        await waitForChildReady({
             child   : state.children.bridge,
             deadline: workDeadline,
             label   : 'Neural Link Bridge',
+            logPath : bridgeLog,
+            markers : [`Bridge: Listening on ${LOOPBACK_HOST}:${ports.bridge}`],
             port    : ports.bridge,
             signal,
             timeoutMs
         });
 
+        const devLog = path.join(state.root, 'dev-server-stdio.log');
         state.children.dev = spawnLoggedChild({
             args   : createDevServerArgs(ports.dev),
             env    : environments.devEnv,
-            logPath: path.join(state.root, 'dev-server-stdio.log'),
+            logPath: devLog,
             name   : 'Neo dev server'
         });
-        await waitForPort({
+        await waitForChildReady({
             child   : state.children.dev,
             deadline: workDeadline,
             label   : 'Neo dev server',
+            logPath : devLog,
+            markers : ['[webpack-dev-server] Loopback:', `${LOOPBACK_HOST}:${ports.dev}/`],
             port    : ports.dev,
             signal,
             timeoutMs
         });
 
+        const mcpLog = path.join(state.root, 'neural-link-mcp-stdio.log');
         state.children.mcp = spawnLoggedChild({
             args   : [path.join(repoRoot, 'ai/mcp/server/neural-link/mcp-server.mjs')],
             env    : environments.mcpEnv,
-            logPath: path.join(state.root, 'neural-link-mcp-stdio.log'),
+            logPath: mcpLog,
             name   : 'Neural Link MCP server'
         });
         delete environments.mcpEnv.NEO_AUTH_LOCAL_BEARER_TOKEN;
 
-        await waitForPort({
+        await waitForChildReady({
             child   : state.children.mcp,
             deadline: workDeadline,
             label   : 'Neural Link MCP server',
+            logPath : mcpLog,
+            markers : [
+                'Server started on Streamable HTTP transport',
+                `Port: ${ports.mcp}`,
+                `Host: ${LOOPBACK_HOST}`
+            ],
             port    : ports.mcp,
             signal,
             timeoutMs
@@ -1327,13 +1380,16 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
     } catch (error) {
         failure = error
     } finally {
-        const cleanupFailures = [];
-        const closeResource   = async (label, operation) => {
+        const
+            cleanupDeadline  = createCleanupDeadline(),
+            cleanupFailures  = [],
+            cleanupTimeoutMs = () => Math.max(1, Math.min(5000, cleanupDeadline - Date.now()));
+
+        const closeResource = async (label, operation) => {
             if (!operation) return;
 
             try {
-                const remainingMs = Math.max(1, Math.min(5000, deadline - Date.now()));
-                await withTimeout(Promise.resolve().then(operation), remainingMs, label)
+                await withTimeout(Promise.resolve().then(operation), cleanupTimeoutMs(), label)
             } catch (error) {
                 cleanupFailures.push({error, label})
             }
@@ -1357,7 +1413,7 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
                 const result = await stopChild(
                     state.children[key],
                     childSignal,
-                    Math.max(0, Math.min(5000, deadline - Date.now()))
+                    cleanupTimeoutMs()
                 );
 
                 childLeadersExited &&= result.leaderExited;
@@ -1372,7 +1428,7 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
         if (process.platform === 'win32' && !options.external && childLeadersExited) {
             listenerClosureVerified = await waitForPortsClosed(
                 Object.values(ports || {}),
-                Math.max(0, Math.min(5000, deadline - Date.now()))
+                cleanupTimeoutMs()
             );
 
             if (!listenerClosureVerified) {

--- a/buildScripts/docs/seo/generate.mjs
+++ b/buildScripts/docs/seo/generate.mjs
@@ -62,6 +62,7 @@ const PRIORITIES = new Map([
     ['agentos/ConceptOntology'                      , 0.9],
     ['agentos/NeuralLink'                           , 1.0],
     ['agentos/tooling/NeuralLinkCapabilityMatrix'   , 0.8],
+    ['agentos/tooling/GenesisNeuralLinkProbe'       , 0.8],
     ['agentos/KnowledgeBase'                        , 1.0],
     ['agentos/MemoryCore'                           , 1.0],
     ['agentos/SelfHealing'                          , 1.0],

--- a/learn/agentos/tooling/GenesisNeuralLinkProbe.md
+++ b/learn/agentos/tooling/GenesisNeuralLinkProbe.md
@@ -1,0 +1,304 @@
+# Blind BigData Neural Link Interoperability Probe
+
+A successful connection is not yet an interoperability proof. A client can complete the MCP
+handshake and still misread a live application, overstate what the returned fields establish, or
+leave raw diagnostics behind. This journey makes all three failure classes visible in one bounded
+local session.
+
+The probe launches the public BigData example, a standalone Neural Link Bridge, and a Streamable
+HTTP MCP server. All three listeners bind the literal loopback host. It gives the external client
+exactly three read
+operations, commits Neo to the expected structure before the client answers, and erases every raw
+artifact only after the answer has been frozen, revealed, and jointly reviewed.
+
+This is a local interoperability recipe. It is not a cloud deployment, remote service, or general
+Neural Link authorization model.
+
+## What the journey proves
+
+The completed receipt establishes these claims together:
+
+- a standard MCP client can connect to the literal `127.0.0.1` URL through Streamable HTTP;
+- the server exposes exactly `healthcheck`, `get_worker_topology`, and `get_component_tree`;
+- exactly one BigData App Worker is selected explicitly;
+- the external answer matches a salted oracle that Neo committed to before seeing that answer;
+- every positive structural claim points to a returned field, while uncertain properties stay in
+  an explicit not-inferable list;
+- SQLite telemetry, WAL/SHM files, rotating logs, Bridge stdio, and unexpected files all live under
+  one disposable root and are deleted after joint review;
+- only aggregate counts, the frozen deliverable, the revealed oracle, and the final public receipt
+  survive.
+
+```mermaid
+flowchart TD
+    A["Runner creates one disposable root"] --> B["Bridge, BigData, and local MCP start"]
+    B --> C["Neo derives a private depth-2 oracle"]
+    C --> D["Neo publishes only the salted commitment"]
+    D --> E["Genesis connects and freezes its evidence-led deliverable"]
+    E --> F["Neo reveals salt and canonical JSON"]
+    F --> G["Both sides reproduce the hash and review every claim"]
+    G --> H["Operator types cleanup"]
+    H --> I["Processes stop; before-manifest is captured"]
+    I --> J["Whole diagnostic root is deleted"]
+    J --> K["After-manifest and aggregate receipt are published"]
+```
+
+The ordering is the security property. Reveal before freeze teaches the answer. Cleanup before
+review destroys the evidence. Retaining the root after review turns a disposable diagnostic into
+an unmanaged raw-data store.
+
+## Pinned participants and versions
+
+The Neo side runs from the commit named in the final receipt. The external side is the accepted
+Genesis `7.9.38` artifact at commit
+[`2a7e9d75d2e5cceb9d36fd0dc290c7586d9ad4c8`](https://github.com/Garrus800-stack/genesis-agent/commit/2a7e9d75d2e5cceb9d36fd0dc290c7586d9ad4c8).
+That exact SHA matters: the `v7.9.38` tag predates the final trusted-loopback bearer correction.
+
+Required locally:
+
+- Node.js 24 or newer;
+- an installed Chrome channel, or Playwright's bundled Chromium;
+- no second client connected to the isolated Bridge;
+- a terminal that remains open for the freeze, reveal, review, and cleanup gates.
+
+## Rehearse the full Neo side
+
+Run the non-interactive rehearsal before scheduling the external session:
+
+```bash
+npm run ai:genesis-probe
+```
+
+Use bundled Chromium when Chrome is unavailable:
+
+```bash
+npm run ai:genesis-probe -- --browser-channel bundled
+```
+
+The rehearsal uses a generated private bearer, performs the same SDK calls, reveals its throwaway
+oracle immediately, and cleans up automatically. A successful `GENESIS_PROBE_RECEIPT` must show:
+
+- `status: "success"`;
+- all three aggregate telemetry rows successful;
+- `configuredInsideDisposableRoot: true`;
+- a recursive `beforeManifest` containing the database and log artifacts;
+- `afterManifest.rootPresent: false`;
+- `terminationVerified: true` on POSIX;
+- `defaultPathsUntouched: true`.
+
+On Windows, rehearsal can verify direct-child exit plus closure of all three known listener ports,
+but Node does not provide a Job Object or an equivalent proof that every descendant is gone. Its
+receipt therefore keeps `terminationVerified: false` and `status: "failure"`, while still reporting
+aggregate telemetry and root deletion when those weaker gates pass. That rehearsal is useful
+implementation evidence, but it is not the external privacy proof.
+
+Rehearsal commitments are disposable evidence. Never reuse one for the external blind run.
+
+## Start the external session
+
+Generate a fresh bearer into a non-exported operator-shell variable. Do not paste the value into a
+Discussion, issue, PR, chat transcript, shell trace, or receipt. Transfer the value through the
+agreed private channel before starting the foreground runner, then inject it into that one command
+process tree and unset the parent-shell variable immediately after the runner exits:
+
+```bash
+neo_genesis_probe_bearer="$(node -e "process.stdout.write(require('crypto').randomBytes(32).toString('base64url'))")"
+NEO_GENESIS_PROBE_BEARER="$neo_genesis_probe_bearer" npm run ai:genesis-probe -- --external
+unset neo_genesis_probe_bearer
+```
+
+The external run currently requires POSIX detached-process-group verification. Do not run
+`--external` from PowerShell/Windows and reinterpret direct-child exit as equivalent evidence.
+A Windows external recipe remains intentionally unavailable until the runner owns a supervised
+process tree (for example, a Job Object) that can prove descendant termination.
+
+The runner allocates fresh ports and emits one redacted `GENESIS_PROBE_LOCAL_READY` record. Send the
+emitted URL to the Genesis operator; the bearer was already transferred privately before launch.
+Complete the named Genesis server configuration with that URL and the pre-shared bearer:
+
+```json
+{
+    "name": "neo-local-probe",
+    "url": "http://127.0.0.1:<emitted-port>/mcp",
+    "transport": "streamable",
+    "trustLoopback": true,
+    "token": "<private-disposable-bearer>"
+}
+```
+
+`transport: "streamable"`, `trustLoopback: true`, and the non-empty token are the Genesis
+`7.9.38` client contract. Neo's server independently requires the literal loopback bind, absent
+`Origin`, valid `Host`, a canonical 32-byte unpadded-base64url bearer, local-bearer mode, and the
+server-pinned `local-readonly-probe` profile.
+
+The same startup record publishes the exact three tools and the tree arguments. If any value
+differs, abort instead of improvising a wider profile.
+
+## The blind deliverable
+
+The external agent may use only the listed server and returned fields. It should call the tools in
+this order:
+
+1. `healthcheck({})` and require a healthy result;
+2. `get_worker_topology({})` and require exactly one row whose app name is
+   `Neo.examples.grid.bigData`;
+3. `get_component_tree({sessionId, depth: 2, lean: true})` using that row's explicit App Worker id.
+
+Freeze a deliverable with this shape before asking Neo to reveal anything:
+
+```json
+{
+    "rootClass": "<value from tree.className>",
+    "directChildren": [
+        {
+            "index": 0,
+            "className": "<value from tree.items[0].className>"
+        }
+    ],
+    "notInferable": [
+        "<property the three returned payloads do not establish>"
+    ],
+    "evidence": [
+        {
+            "claim": "rootClass",
+            "field": "get_component_tree.result.tree.className"
+        },
+        {
+            "claim": "directChildren[0].className",
+            "field": "get_component_tree.result.tree.items[0].className"
+        }
+    ],
+    "unsupportedConfidentClaims": []
+}
+```
+
+The direct-child array must be complete and preserve returned order. The example contains one
+placeholder row only to demonstrate the schema; it does not imply the expected count. IDs may be
+used for evidence routing but are not part of the public structural oracle.
+
+Save or post the immutable deliverable, then tell the Neo operator it is frozen. Only then may the
+Neo operator type:
+
+```text
+reveal
+```
+
+## Reproduce the commitment
+
+The runner reveals a secret 32-byte lowercase-hex salt and whitespace-free canonical JSON with
+fixed property order:
+
+```json
+{"rootClass":"…","directChildren":[{"index":0,"className":"…"}]}
+```
+
+Both sides independently compute:
+
+```text
+SHA-256(UTF-8(saltHex + "\n" + canonicalJson))
+```
+
+The result must equal the commitment published before the deliverable. A hash mismatch is a failed
+probe even when the visible structures happen to look alike.
+
+Joint review then checks four independent facts:
+
+| Gate | Passing evidence |
+|---|---|
+| Oracle | Root and complete ordered direct-child array equal the revealed canonical JSON. |
+| Traceability | Every positive claim cites a field actually returned by one of the three tools. |
+| Epistemic restraint | Unavailable properties are named under `notInferable`; no unsupported confident claim remains. |
+| Transport boundary | The client used the emitted literal URL, private bearer, named server, and exact tool profile. |
+
+Do not clean up while a dispute still needs raw evidence. Once both sides record the review verdict,
+the Neo operator types:
+
+```text
+cleanup
+```
+
+Typing `abort` at either interactive gate records a failed receipt and still attempts full cleanup.
+`SIGINT` and `SIGTERM` enter the same cleanup path; neither signal bypasses erasure checks. The
+runner also fails if any active phase exceeds the single two-hour session deadline. It reserves the
+final minute for shutdown and cleanup instead of resetting a fresh timeout per phase. If a
+safety-critical stop or whole-root deletion crosses that deadline, cleanup continues rather than
+abandoning live processes or raw data, and the receipt remains a failed session-limit proof.
+
+## What cleanup proves
+
+The runner first closes the MCP SDK client and browser, then stops the MCP server, Bridge, and dev
+server. POSIX shutdown verifies both each leader exit and immediate process-group absence; `EPERM`
+is treated as still alive and only `ESRCH` proves absence. The runner does not delete the root when
+that proof fails. With process-owned handles released, it reads only aggregate
+tool/status/duration counts, captures the recursive manifest, and removes the entire unique root.
+Once termination authorizes deletion, a corrupt telemetry database or failed evidence snapshot
+still makes the receipt fail but cannot veto the whole-root deletion attempt.
+
+The manifest is intentionally allowlist-agnostic. It records every relative path, type, and byte
+size, including unexpected files. This avoids a brittle cleanup allowlist that forgets a new log,
+WAL, or stdio sink.
+
+The final receipt must not contain:
+
+- the bearer or Authorization header;
+- raw tool arguments or results;
+- absolute disposable-root paths;
+- raw SQLite rows or logs;
+- unrevealed oracle material.
+
+Failures use a closed public `{code, message}` allowlist. Raw tool payloads and topology rows remain
+only inside the disposable root, normally in its isolated SQLite telemetry. Private parent-process
+exception detail and absolute temporary paths additionally go into a mode-`0600`
+`private-failure.json`; any bearer material captured by either private diagnostic surface remains
+inside that root until verified cleanup removes it.
+
+After reveal, the canonical oracle and salt are public verification material and may remain. Raw
+diagnostics may not.
+
+## Public receipt template
+
+The PR and the source Discussion should link one completed receipt containing:
+
+```text
+Neo commit/version:
+Genesis commit/version:
+start/end/duration:
+published commitment comment:
+frozen external deliverable:
+revealed canonical JSON + salt:
+Neo hash reproduction:
+Genesis hash reproduction:
+oracle comparison verdict:
+not-inferable / unsupported-claim verdict:
+aggregate tool/status/duration counts:
+recursive before-manifest:
+after-manifest rootPresent=false:
+termination verified=true (POSIX external proof):
+default live database/log paths untouched=true:
+overall success/failure:
+```
+
+Any missing line makes the receipt incomplete. A failed run is still valuable when it honestly
+names the failed gate and proves cleanup; it must not be rewritten as success after the fact.
+
+## Failure recovery
+
+- **More than one App Worker:** close the extra app and start a fresh probe. Never auto-select one.
+- **Tool list differs:** verify the server-pinned `local-readonly-probe` mode. Do not continue with a
+  broader surface.
+- **Genesis refuses loopback:** verify the exact accepted commit, named-server `trustLoopback`, and
+  non-empty token without publishing the token.
+- **Hash mismatch:** preserve the frozen deliverable, compare UTF-8 bytes/property order/newline,
+  record failure, then clean up after review.
+- **Default path changed:** treat the isolation proof as failed. Identify concurrent writers or a
+  missing environment override before another run.
+- **Root remains after cleanup:** do not delete individual filenames and call it complete. Find the
+  open handle or permission failure, remove the whole root, and record the correction cycle.
+- **Interrupted run:** require the structured `PROBE_INTERRUPTED` receipt plus the same verified
+  shutdown, manifest, and root-absence evidence as any other failure. A signal is not cleanup proof.
+- **Windows external run rejected:** move the external session to a POSIX host. Direct-child exit
+  and known-port closure are rehearsal evidence only until supervised Windows process-tree support
+  exists.
+
+The journey allows one asynchronous correction cycle. A correction gets a new disposable root,
+bearer, salt, and commitment; nothing secret or raw carries over from the first attempt.

--- a/learn/agentos/tooling/GenesisNeuralLinkProbe.md
+++ b/learn/agentos/tooling/GenesisNeuralLinkProbe.md
@@ -116,6 +116,10 @@ The runner allocates fresh ports and emits one redacted `GENESIS_PROBE_LOCAL_REA
 emitted URL to the Genesis operator; the bearer was already transferred privately before launch.
 Complete the named Genesis server configuration with that URL and the pre-shared bearer:
 
+Each listener must first emit its exact host-and-port readiness marker into its own mode-`0600`
+stdio log inside the disposable root. Only then does the runner perform a secondary TCP reachability
+check. A generic open loopback port is never readiness evidence and can never trigger bearer use.
+
 ```json
 {
     "name": "neo-local-probe",
@@ -223,6 +227,8 @@ runner also fails if any active phase exceeds the single two-hour session deadli
 final minute for shutdown and cleanup instead of resetting a fresh timeout per phase. If a
 safety-critical stop or whole-root deletion crosses that deadline, cleanup continues rather than
 abandoning live processes or raw data, and the receipt remains a failed session-limit proof.
+Cleanup therefore owns a fresh bounded safety clock; it never inherits a zero timeout from the
+expired active-session clock.
 
 ## What cleanup proves
 

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -93,6 +93,7 @@
             {"name": "Agent OS Windows Support Audit",                 "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/WindowsSupport"},
             {"name": "Introduction to MCP",                            "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/Introduction"},
             {"name": "Neural Link Capability Matrix",                   "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/NeuralLinkCapabilityMatrix"},
+            {"name": "Blind BigData Neural Link Probe",                 "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/GenesisNeuralLinkProbe"},
             {"name": "Restoration Runbook",                            "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/RestorationRunbook"},
             {"name": "Wake Substrate Incident Protocol",               "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/WakeSubstrateIncidentProtocol"},
         {"name": "Architectural Decision Records",                     "parentId": "AgentOS",                            "isLeaf": false, "id": "AgentOS/Decisions", "collapsed": true},

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "ai:download-kb"                       : "node ./ai/scripts/maintenance/downloadKnowledgeBase.mjs",
         "ai:fleet-server"                      : "node ./ai/services/fleet/devFleetServer.mjs",
         "ai:gemini-incident-cost-ledger"       : "node ./ai/scripts/diagnostics/gemini-incident-cost-ledger.mjs",
+        "ai:genesis-probe"                     : "node ./ai/scripts/diagnostics/genesisProbe.mjs",
         "ai:graph-lifecycle-report"            : "node ./ai/scripts/maintenance/graphLifecycleReport.mjs",
         "ai:ingest-tenant"                     : "node ./ai/scripts/maintenance/ingestTenant.mjs",
         "ai:kb-push-client"                    : "node ./ai/scripts/maintenance/kbPushClient.mjs",

--- a/src/ai/client/ComponentService.mjs
+++ b/src/ai/client/ComponentService.mjs
@@ -411,6 +411,7 @@ class ComponentService extends Service {
     }
 
     /**
+     * @summary Serializes a component hierarchy while preserving direct parent-child structure.
      * @param {Object} data
      * @param {Neo.component.Base} data.component
      * @param {Number}             [data.currentDepth=1]
@@ -433,7 +434,7 @@ class ComponentService extends Service {
         }
 
         if (maxDepth === -1 || currentDepth < maxDepth) {
-            const children = Neo.manager.Component.getChildComponents(component);
+            const children = Neo.manager.Component.getDirectChildren(component.id);
 
             if (children && children.length > 0) {
                 result.items = children.map(child => this.serializeComponent({

--- a/test/playwright/unit/ai/client/ComponentService.spec.mjs
+++ b/test/playwright/unit/ai/client/ComponentService.spec.mjs
@@ -1,7 +1,49 @@
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../src/Neo.mjs';
-import * as core      from '../../../../../src/core/_export.mjs';
+import {test, expect}   from '@playwright/test';
+import Neo              from '../../../../../src/Neo.mjs';
+import * as core        from '../../../../../src/core/_export.mjs';
 import ComponentService from '../../../../../src/ai/client/ComponentService.mjs';
+
+test.describe.serial('Neo.ai.client.ComponentService.serializeComponent', () => {
+    let originalGetDirectChildren, service;
+
+    test.beforeEach(() => {
+        originalGetDirectChildren = Neo.manager.Component.getDirectChildren;
+        service                   = Neo.create(ComponentService)
+    });
+
+    test.afterEach(() => {
+        Neo.manager.Component.getDirectChildren = originalGetDirectChildren;
+        service.destroy()
+    });
+
+    test('depth 2 contains direct children once, never the flattened descendant closure', () => {
+        const
+            root         = {className: 'Root', id: 'root'},
+            child        = {className: 'Child', id: 'child'},
+            grandchild   = {className: 'Grandchild', id: 'grandchild'},
+            childrenById = new Map([
+                ['root', [child]],
+                ['child', [grandchild]]
+            ]);
+
+        Neo.manager.Component.getDirectChildren = id => childrenById.get(id) || [];
+
+        expect(service.serializeComponent({component: root, maxDepth: 2})).toEqual({
+            className: 'Root',
+            id       : 'root',
+            items    : [{className: 'Child', id: 'child'}]
+        });
+        expect(service.serializeComponent({component: root, maxDepth: 3})).toEqual({
+            className: 'Root',
+            id       : 'root',
+            items    : [{
+                className: 'Child',
+                id       : 'child',
+                items    : [{className: 'Grandchild', id: 'grandchild'}]
+            }]
+        })
+    });
+});
 
 /**
  * @summary Tests for the pure child-surface differ behind verify_component_consistency
@@ -155,8 +197,8 @@ test.describe.serial('Neo.ai.client.ComponentService.observeMotion', () => {
 
         Neo.getComponent = id => id === 'toolbar-1' ? {
             id,
-            windowId   : 'win-c',
-            getDomRect : async ids => {
+            windowId  : 'win-c',
+            getDomRect: async ids => {
                 calls.push(ids);
 
                 return {left: 1, top: 2, width: 3, height: 4}

--- a/test/playwright/unit/ai/mcp/server/neural-link/Bridge.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/neural-link/Bridge.spec.mjs
@@ -38,6 +38,15 @@ const sign = (agentId, expiresAt = Date.now() + 3_600_000) => {
 const makeWs  = () => ({readyState: 1, closed: null, sent: [], handlers: {}, on(event, handler) {this.handlers[event] = handler}, send(d) {this.sent.push(d)}, close(code, reason) {this.closed = {code, reason}}, terminate() {}});
 const makeReq = query => ({url: `/?${query}`, headers: {host: '127.0.0.1:8081'}});
 
+test.describe('Bridge listener boundary (#15187)', () => {
+    test('rejects wildcard and non-loopback bind hosts before opening a listener', async () => {
+        await expect(Bridge.startServer({host: '0.0.0.0', port: 8081}))
+            .rejects.toThrow('literal loopback host');
+        await expect(Bridge.startServer({host: '192.0.2.1', port: 8081}))
+            .rejects.toThrow('literal loopback host')
+    })
+});
+
 test.describe('Bridge.handleConnection — agent handshake auth (#13172)', () => {
     test.beforeEach(() => {
         // isolate the singleton's connection maps + configure fleet mode (a verify key is present)

--- a/test/playwright/unit/ai/mcp/server/shared/helpers/localBearer.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/helpers/localBearer.spec.mjs
@@ -81,4 +81,14 @@ test.describe('LocalBearer helper', () => {
         expect(contract.clientHeaders.Authorization).toBe(`Bearer ${token}`);
         expect(isLocalBearerToken(token)).toBe(true);
     });
+
+    test('reuses an explicitly supplied canonical token and rejects malformed overrides', () => {
+        const token    = generateLocalBearerToken(),
+              contract = createLocalBearerLaunchContract(token);
+
+        expect(contract.serverEnv.NEO_AUTH_LOCAL_BEARER_TOKEN).toBe(token);
+        expect(contract.clientHeaders.Authorization).toBe(`Bearer ${token}`);
+        expect(() => createLocalBearerLaunchContract('not-a-canonical-token'))
+            .toThrow('canonical 32-byte unpadded-base64url token');
+    });
 });

--- a/test/playwright/unit/ai/scripts/diagnostics/genesisProbe.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/genesisProbe.spec.mjs
@@ -1,0 +1,345 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'GenesisProbeTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fsPromises     from 'fs/promises';
+import os             from 'os';
+import path           from 'path';
+import {EventEmitter} from 'events';
+import {
+    MAX_SESSION_MS,
+    assertDiagnosticPathsWithinRoot,
+    canonicalizeOracle,
+    createBrowserLaunchOptions,
+    createDevServerArgs,
+    createManifest,
+    createOracleCommitment,
+    createProbeFailure,
+    createProbeEnvironments,
+    finalizeDisposableRoot,
+    findFreePort,
+    getPhaseTimeout,
+    hasChildExited,
+    installProbeSignalHandlers,
+    isProcessGroupAlive,
+    parseArgs,
+    parsePort,
+    readToolJson,
+    spawnLoggedChild,
+    stopChild,
+    snapshotSqliteFamily,
+    toPublicProbeError,
+    waitForChildExit,
+    waitForPort,
+    withTimeout
+} from '../../../../../../ai/scripts/diagnostics/genesisProbe.mjs';
+
+test.describe('Neo.ai.scripts.diagnostics.genesisProbe', () => {
+    test('canonicalizes the blind oracle and reproduces the fixed commitment bytes', () => {
+        const {oracle, canonicalJson} = canonicalizeOracle({
+            className: 'Neo.container.Viewport',
+            items    : [
+                {className: 'Neo.grid.Container'},
+                {className: 'Neo.toolbar.Base'}
+            ]
+        });
+
+        expect(oracle).toEqual({
+            rootClass     : 'Neo.container.Viewport',
+            directChildren: [
+                {index: 0, className: 'Neo.grid.Container'},
+                {index: 1, className: 'Neo.toolbar.Base'}
+            ]
+        });
+        expect(canonicalJson).toBe('{"rootClass":"Neo.container.Viewport","directChildren":[{"index":0,"className":"Neo.grid.Container"},{"index":1,"className":"Neo.toolbar.Base"}]}');
+        expect(createOracleCommitment({canonicalJson, saltHex: '00'.repeat(32)}))
+            .toBe('7661f2f7d3bc14ded75892f9b9249f7f713913e1f637e8a7fb13999502c52346');
+    });
+
+    test('rejects malformed oracle input, salt, ports, and escaping diagnostic sinks', () => {
+        expect(() => canonicalizeOracle({className: '', items: []})).toThrow('root className');
+        expect(() => canonicalizeOracle({className: 'Root', items: [{}]})).toThrow('Direct child 0');
+        expect(() => createOracleCommitment({canonicalJson: '{}', saltHex: 'abc'})).toThrow('32 bytes');
+        expect(() => parsePort('0')).toThrow('1..65535');
+        expect(() => parsePort('8081.5')).toThrow('1..65535');
+        expect(() => assertDiagnosticPathsWithinRoot({
+            databasePath: path.join(os.tmpdir(), 'escaped.sqlite'),
+            logPath     : '/tmp',
+            root        : path.join(os.tmpdir(), 'probe-root')
+        })).toThrow('escapes the disposable root');
+    });
+
+    test('builds least-authority child environments without inheriting provider secrets', () => {
+        const
+            root = path.join(os.tmpdir(), 'genesis-probe-env'),
+            envs = createProbeEnvironments({
+                baseEnv: {
+                    Path                       : '/windows/path',
+                    NODE_OPTIONS               : '--import=must-not-run.mjs',
+                    OPENAI_API_KEY             : 'must-not-leak',
+                    ANTHROPIC_API_KEY          : 'must-not-leak',
+                    NEO_AUTH_LOCAL_BEARER_TOKEN: 'must-not-leak'
+                },
+                bearerToken: 'A'.repeat(43),
+                ports      : {dev: 19001, bridge: 19002, mcp: 19003},
+                root
+            });
+
+        expect(envs.devEnv.Path).toBe('/windows/path');
+        expect(envs.devEnv).not.toHaveProperty('NODE_OPTIONS');
+        expect(envs.devEnv).not.toHaveProperty('OPENAI_API_KEY');
+        expect(envs.devEnv).not.toHaveProperty('ANTHROPIC_API_KEY');
+        expect(envs.devEnv).not.toHaveProperty('NEO_AUTH_LOCAL_BEARER_TOKEN');
+        expect(envs.bridgeEnv).not.toHaveProperty('NEO_AUTH_LOCAL_BEARER_TOKEN');
+        expect(envs.mcpEnv.NEO_AUTH_LOCAL_BEARER_TOKEN).toBe('A'.repeat(43));
+        expect(envs.clientHeaders.Authorization).toBe(`Bearer ${'A'.repeat(43)}`);
+        expect(envs.mcpEnv.NEO_AUTH_MODE).toBe('local-bearer');
+        expect(envs.mcpEnv.NEO_MCP_LISTEN_HOST).toBe('127.0.0.1');
+        expect(envs.mcpEnv.NEO_MEMORY_DB_PATH).toBe(path.join(root, 'memory-core.sqlite'));
+        expect(envs.mcpEnv.NEO_NL_LOG_PATH).toBe(root);
+        expect(envs.mcpEnv.NEO_NL_TOOL_PROJECTION_MODE).toBe('local-readonly-probe');
+    });
+
+    test('launches the browser with the same least-authority environment boundary', () => {
+        const options = createBrowserLaunchOptions({
+            baseEnv: {
+                HOME                       : '/safe/home',
+                PATH                       : '/safe/bin',
+                OPENAI_API_KEY             : 'must-not-leak',
+                GH_TOKEN                   : 'must-not-leak',
+                NEO_AUTH_LOCAL_BEARER_TOKEN: 'must-not-leak'
+            },
+            browserChannel: 'bundled',
+            headed        : true
+        });
+
+        expect(options).toEqual({
+            env: {
+                HOME: '/safe/home',
+                PATH: '/safe/bin'
+            },
+            headless: false
+        });
+        expect(options.env).not.toHaveProperty('OPENAI_API_KEY');
+        expect(options.env).not.toHaveProperty('GH_TOKEN');
+        expect(options.env).not.toHaveProperty('NEO_AUTH_LOCAL_BEARER_TOKEN')
+    });
+
+    test('pins all three listeners to literal loopback authority', () => {
+        const args = createDevServerArgs(19001);
+
+        expect(args.slice(args.indexOf('--host'), args.indexOf('--host') + 2))
+            .toEqual(['--host', '127.0.0.1']);
+        expect(args.slice(args.indexOf('--port'), args.indexOf('--port') + 2))
+            .toEqual(['--port', '19001']);
+    });
+
+    test('enforces one global deadline without resetting it between phases', () => {
+        const deadline = 10000;
+        let   deadlineError;
+
+        expect(getPhaseTimeout({deadline, timeoutMs: 60000, now: 9000})).toBe(1000);
+        expect(getPhaseTimeout({deadline, timeoutMs: 60000, now: 9500})).toBe(500);
+        try {
+            getPhaseTimeout({deadline, timeoutMs: 60000, now: 10000})
+        } catch (error) {
+            deadlineError = error
+        }
+
+        expect(deadlineError).toMatchObject({code: 'SESSION_LIMIT_EXCEEDED'});
+        expect(() => parseArgs(['--timeout-ms', String(MAX_SESSION_MS + 1)], {}))
+            .toThrow(`1000..${MAX_SESSION_MS}ms`);
+    });
+
+    test('redacts unknown and classified failures into a closed public shape', () => {
+        const hostile = new Error(
+            'Authorization: Bearer super-secret; topology={"private":true}; /tmp/neo-genesis-probe-secret'
+        );
+        const publicUnknown = toPublicProbeError(hostile);
+        const publicKnown   = toPublicProbeError(createProbeFailure('TOPOLOGY_MISMATCH', hostile));
+
+        expect(publicUnknown).toEqual({
+            code   : 'UNEXPECTED_FAILURE',
+            message: 'The probe failed without a public-safe classification.'
+        });
+        expect(JSON.stringify(publicUnknown)).not.toContain('super-secret');
+        expect(JSON.stringify(publicUnknown)).not.toContain('Authorization');
+        expect(JSON.stringify(publicUnknown)).not.toContain('/tmp/');
+        expect(publicKnown).toEqual({
+            code   : 'TOPOLOGY_MISMATCH',
+            message: 'Exactly one intended BigData App Worker was not available.'
+        })
+    });
+
+    test('routes SIGINT/SIGTERM once into the active wait and disposes both listeners', async () => {
+        const
+            controller = new AbortController(),
+            target     = new EventEmitter(),
+            dispose    = installProbeSignalHandlers({controller, processTarget: target}),
+            pending    = withTimeout(new Promise(() => {}), 10000, 'pending probe phase', controller.signal);
+
+        expect(target.listenerCount('SIGINT')).toBe(1);
+        expect(target.listenerCount('SIGTERM')).toBe(1);
+
+        target.emit('SIGINT');
+        target.emit('SIGTERM');
+
+        await expect(pending).rejects.toMatchObject({code: 'PROBE_INTERRUPTED'});
+        expect(controller.signal.reason.code).toBe('PROBE_INTERRUPTED');
+
+        dispose();
+        expect(target.listenerCount('SIGINT')).toBe(0);
+        expect(target.listenerCount('SIGTERM')).toBe(0)
+    });
+
+    test('waitForChildExit handles already-exited, racing, and bounded non-exit states', async () => {
+        const alreadyExited = Object.assign(new EventEmitter(), {exitCode: 0, signalCode: null});
+        const racing        = Object.assign(new EventEmitter(), {exitCode: null, signalCode: null});
+        const running       = Object.assign(new EventEmitter(), {exitCode: null, signalCode: null});
+
+        expect(await waitForChildExit(alreadyExited, 1000)).toBe(true);
+
+        queueMicrotask(() => {
+            racing.exitCode = 0;
+            racing.emit('exit', 0, null)
+        });
+
+        expect(await waitForChildExit(racing, 1000)).toBe(true);
+        expect(await waitForChildExit(running, 10)).toBe(false)
+    });
+
+    test('records every disposable artifact and proves whole-root absence after cleanup', async () => {
+        const root = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'neo-genesis-manifest-test-'));
+
+        try {
+            await fsPromises.mkdir(path.join(root, 'nested'));
+            await fsPromises.writeFile(path.join(root, 'memory-core.sqlite'), 'sqlite');
+            await fsPromises.writeFile(path.join(root, 'nested', 'neural-link-bridge-stdio.log'), 'bridge');
+
+            expect(await createManifest(root)).toEqual({
+                rootPresent: true,
+                entries    : [
+                    {path: 'memory-core.sqlite', type: 'file', bytes: 6},
+                    {path: 'nested', type: 'directory', bytes: expect.any(Number)},
+                    {path: 'nested/neural-link-bridge-stdio.log', type: 'file', bytes: 6}
+                ]
+            });
+        } finally {
+            await fsPromises.rm(root, {recursive: true, force: true})
+        }
+
+        expect(await createManifest(root)).toEqual({rootPresent: false, entries: []})
+    });
+
+    test('detects default SQLite WAL changes even when the main database stays untouched', async () => {
+        const
+            root         = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'neo-genesis-sqlite-family-test-')),
+            databasePath = path.join(root, 'memory-core.sqlite'),
+            walPath      = `${databasePath}-wal`;
+
+        try {
+            await fsPromises.writeFile(databasePath, 'main-database');
+            await fsPromises.writeFile(walPath, 'wal-before');
+
+            const before = await snapshotSqliteFamily(databasePath);
+
+            await fsPromises.appendFile(walPath, '-changed');
+
+            const after = await snapshotSqliteFamily(databasePath);
+
+            expect(after.database).toEqual(before.database);
+            expect(after.wal).not.toEqual(before.wal);
+            expect(after.shm).toEqual({exists: false});
+            expect(JSON.stringify(after)).not.toBe(JSON.stringify(before))
+        } finally {
+            await fsPromises.rm(root, {recursive: true, force: true})
+        }
+    });
+
+    test('deletes an authorized root even when aggregate telemetry evidence is unreadable', async () => {
+        const
+            root         = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'neo-genesis-cleanup-test-')),
+            databasePath = path.join(root, 'memory-core.sqlite'),
+            Database     = (await import('better-sqlite3')).default,
+            database     = new Database(databasePath);
+
+        database.exec('CREATE TABLE unrelated (id INTEGER PRIMARY KEY)');
+        database.close();
+
+        const result = await finalizeDisposableRoot({
+            databasePath,
+            defaultPaths      : null,
+            deletionAuthorized: true,
+            root
+        });
+
+        expect(result.failures).toHaveLength(1);
+        expect(result.failures[0].label).toBe('Aggregate telemetry read');
+        expect(result.beforeManifest.rootPresent).toBe(true);
+        expect(result.afterManifest).toEqual({rootPresent: false, entries: []});
+        expect(await createManifest(root)).toEqual({rootPresent: false, entries: []})
+    });
+
+    test('unwraps standard SDK tool payloads and surfaces MCP errors', () => {
+        expect(readToolJson({structuredContent: {result: [{appName: 'BigData'}]}}))
+            .toEqual([{appName: 'BigData'}]);
+        expect(readToolJson({content: [{type: 'text', text: '{"status":"healthy"}'}]}))
+            .toEqual({status: 'healthy'});
+        expect(() => readToolJson({isError: true, content: [{type: 'text', text: 'denied'}]}))
+            .toThrow('denied');
+        expect(hasChildExited({exitCode: null, signalCode: null})).toBe(false);
+        expect(hasChildExited({exitCode: null, signalCode: 'SIGTERM'})).toBe(true);
+    });
+
+    test('the standalone Bridge binds the AiConfig-owned non-default port', async () => {
+        const
+            root    = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'neo-genesis-bridge-test-')),
+            port    = await findFreePort(),
+            logPath = path.join(root, 'bridge.log'),
+            child   = spawnLoggedChild({
+                args: [path.resolve(process.cwd(), 'ai/mcp/server/neural-link/run-bridge.mjs')],
+                env : {
+                    PATH                     : process.env.PATH,
+                    HOME                     : process.env.HOME,
+                    NEO_DEBUG                : 'false',
+                    NEO_NL_LOG_PATH          : root,
+                    NEO_NL_PORT              : String(port),
+                    NEO_TEST_CONFIG_TEMPLATES: 'false',
+                    UNIT_TEST_MODE           : 'true'
+                },
+                logPath,
+                name: 'test Neural Link Bridge'
+            });
+
+        let stopResult;
+
+        try {
+            await waitForPort({child, label: 'test Neural Link Bridge', port, timeoutMs: 15000});
+            expect(await fsPromises.readFile(logPath, 'utf8')).toContain(`Listening on 127.0.0.1:${port}`)
+        } finally {
+            stopResult = await stopChild(child, 'SIGINT');
+            await fsPromises.rm(root, {recursive: true, force: true})
+        }
+
+        expect(stopResult.leaderExited).toBe(true);
+
+        if (process.platform !== 'win32') {
+            expect(stopResult.processGroupExited).toBe(true);
+            expect(isProcessGroupAlive(child.pid)).toBe(false)
+        }
+    });
+});

--- a/test/playwright/unit/ai/scripts/diagnostics/genesisProbe.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/genesisProbe.spec.mjs
@@ -17,6 +17,7 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import fsPromises     from 'fs/promises';
+import net            from 'net';
 import os             from 'os';
 import path           from 'path';
 import {EventEmitter} from 'events';
@@ -25,6 +26,7 @@ import {
     assertDiagnosticPathsWithinRoot,
     canonicalizeOracle,
     createBrowserLaunchOptions,
+    createCleanupDeadline,
     createDevServerArgs,
     createManifest,
     createOracleCommitment,
@@ -44,7 +46,7 @@ import {
     snapshotSqliteFamily,
     toPublicProbeError,
     waitForChildExit,
-    waitForPort,
+    waitForChildReady,
     withTimeout
 } from '../../../../../../ai/scripts/diagnostics/genesisProbe.mjs';
 
@@ -163,6 +165,7 @@ test.describe('Neo.ai.scripts.diagnostics.genesisProbe', () => {
         expect(deadlineError).toMatchObject({code: 'SESSION_LIMIT_EXCEEDED'});
         expect(() => parseArgs(['--timeout-ms', String(MAX_SESSION_MS + 1)], {}))
             .toThrow(`1000..${MAX_SESSION_MS}ms`);
+        expect(createCleanupDeadline(deadline)).toBeGreaterThan(deadline)
     });
 
     test('redacts unknown and classified failures into a closed public shape', () => {
@@ -220,6 +223,129 @@ test.describe('Neo.ai.scripts.diagnostics.genesisProbe', () => {
 
         expect(await waitForChildExit(racing, 1000)).toBe(true);
         expect(await waitForChildExit(running, 10)).toBe(false)
+    });
+
+    test('rejects an unrelated open listener until the child-private readiness marker exists', async () => {
+        const
+            root    = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'neo-genesis-readiness-test-')),
+            logPath = path.join(root, 'child.log'),
+            server  = net.createServer(),
+            child   = Object.assign(new EventEmitter(), {
+                exitCode        : null,
+                probeLaunchError: null,
+                signalCode      : null
+            });
+
+        let connections = 0;
+        server.on('connection', socket => {
+            connections++;
+            socket.destroy()
+        });
+        await new Promise((resolve, reject) => {
+            server.once('error', reject);
+            server.listen(0, '127.0.0.1', resolve)
+        });
+
+        const port = server.address().port;
+
+        try {
+            await fsPromises.writeFile(logPath, `ready on 127.0.0.1:${port + 1}`);
+            await expect(waitForChildReady({
+                child,
+                label    : 'unrelated listener',
+                logPath,
+                markers  : [`ready on 127.0.0.1:${port}`],
+                port,
+                timeoutMs: 150
+            })).rejects.toThrow('did not prove child-owned readiness');
+            expect(connections).toBe(0);
+
+            await fsPromises.writeFile(logPath, `ready on 127.0.0.1:${port}`);
+            await waitForChildReady({
+                child,
+                label    : 'marked listener',
+                logPath,
+                markers  : [`ready on 127.0.0.1:${port}`],
+                port,
+                timeoutMs: 1000
+            });
+            await expect.poll(() => connections).toBe(1)
+        } finally {
+            await new Promise(resolve => server.close(resolve));
+            await fsPromises.rm(root, {recursive: true, force: true})
+        }
+    });
+
+    test('captures asynchronous spawn failures and treats a pid-less child as stopped', async () => {
+        const
+            root    = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'neo-genesis-spawn-test-')),
+            logPath = path.join(root, 'missing.log'),
+            child   = spawnLoggedChild({
+                args   : [],
+                command: path.join(root, 'missing-command'),
+                env    : {PATH: process.env.PATH},
+                logPath,
+                name   : 'missing child'
+            });
+
+        try {
+            await expect(waitForChildReady({
+                child,
+                label    : 'missing child',
+                logPath,
+                markers  : ['never-ready'],
+                port     : await findFreePort(),
+                timeoutMs: 1000
+            })).rejects.toMatchObject({code: 'ENOENT'});
+            await expect(stopChild(child)).resolves.toMatchObject({
+                leaderExited      : true,
+                processGroupExited: process.platform !== 'win32'
+            })
+        } finally {
+            await fsPromises.rm(root, {recursive: true, force: true})
+        }
+    });
+
+    test('verifies process-group absence after a transient signal-send error', async () => {
+        test.skip(process.platform === 'win32', 'POSIX process-group proof only');
+
+        const
+            root    = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'neo-genesis-stop-test-')),
+            logPath = path.join(root, 'child.log'),
+            child   = spawnLoggedChild({
+                args: ['-e', 'setInterval(() => {}, 1000)'],
+                env : {PATH: process.env.PATH},
+                logPath,
+                name: 'transient-stop child'
+            }),
+            originalKill = process.kill;
+
+        let injected = false;
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+        process.kill = (pid, signal) => {
+            if (!injected && pid === -child.pid && signal === 'SIGTERM') {
+                injected = true;
+                originalKill(pid, signal);
+                const error = new Error('transient signal delivery race');
+                error.code  = 'EPERM';
+                throw error
+            }
+
+            return originalKill(pid, signal)
+        };
+
+        try {
+            await expect(stopChild(child, 'SIGTERM', 0)).resolves.toMatchObject({
+                leaderExited      : true,
+                processGroupExited: true
+            });
+            expect(injected).toBe(true)
+        } finally {
+            process.kill = originalKill;
+            await stopChild(child).catch(() => {});
+            await fsPromises.rm(root, {recursive: true, force: true})
+        }
     });
 
     test('records every disposable artifact and proves whole-root absence after cleanup', async () => {
@@ -328,7 +454,14 @@ test.describe('Neo.ai.scripts.diagnostics.genesisProbe', () => {
         let stopResult;
 
         try {
-            await waitForPort({child, label: 'test Neural Link Bridge', port, timeoutMs: 15000});
+            await waitForChildReady({
+                child,
+                label    : 'test Neural Link Bridge',
+                logPath,
+                markers  : [`Bridge: Listening on 127.0.0.1:${port}`],
+                port,
+                timeoutMs: 15000
+            });
             expect(await fsPromises.readFile(logPath, 'utf8')).toContain(`Listening on 127.0.0.1:${port}`)
         } finally {
             stopResult = await stopChild(child, 'SIGINT');


### PR DESCRIPTION
Resolves #15187
Related: #15184
Required Epic successor: #15291

Adds the reproducible blind BigData Neural Link journey: one disposable loopback-only stack, the exact three-tool Streamable HTTP projection, a salted precommit/reveal oracle, an aggregate-only receipt, and fail-closed whole-root cleanup. The implementation and exact-head Neo rehearsal are complete and reviewable independently of external scheduling.

Evidence: L3 (live bundled-Chromium BigData journey over the standard MCP SDK; exact profile, literal-loopback listeners, three successful telemetry rows, matched commitment/reveal oracle, POSIX process-group absence, and whole-root erasure). Residual: the required synchronized Genesis L4 receipt is isolated in #15291. It remains required to complete Epic #15184 and the graduated D#15173 success condition, but is not a merge gate for this implementation PR.

## Deltas from ticket

- Maintainer authority fold on 2026-07-16: #15187 now owns the reusable journey tooling, documentation, focused tests, and successful exact-head Neo rehearsal delivered here. The required external bilateral receipt is a separate native sub #15291 under Epic #15184.
- Consumes #15185's local-bearer launch-contract source of truth instead of reconstructing authentication.
- Pins Bridge, development, and MCP listeners to literal loopback.
- Routes SIGINT/SIGTERM through cleanup, applies one global active-session deadline, redacts public failures, and blocks deletion unless shutdown is verified.
- Requires child-owned post-bind log markers before TCP reachability or bearer use, captures asynchronous launch failures inside the cleanup path, and gives termination verification a cleanup-owned safety clock.
- Makes the Windows proof limit explicit: rehearsal evidence remains non-success without process-tree verification.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/neural-link/Bridge.spec.mjs test/playwright/unit/ai/mcp/server/shared/helpers/localBearer.spec.mjs test/playwright/unit/ai/scripts/diagnostics/genesisProbe.spec.mjs` — 32/32 passed at exact head `7e4e322d83`.
- `npm run ai:genesis-probe -- --browser-channel bundled` — fresh exact-head `7e4e322d83` live POSIX rehearsal passed; 3/3 tools and telemetry rows, oracle matched, root absent, defaults untouched, listener closure verified, and termination verified.
- Hosted exact-head CI — all checks green.
- `npm run agent-preflight -- --no-fix ...` — passed for all eight final hardening files before publication.
- `git diff --check` and module syntax checks — passed.
- Mermaid Live v11.16.0 — the TD lifecycle rendered with all 11 nodes.

## Post-Merge Validation

- [ ] Required Epic successor #15291 executes the separately scheduled real Genesis run, publishes the bilateral receipt, completes D#15173's graduated outcome under #15184, and files a focused bug ticket if that external run exposes a defect.

## Slot rationale

`keep`: this changes the existing operator/reference guide under `learn/agentos/tooling/`; it adds no turn-loaded substrate. The placement remains the journey's established reference surface, and the delta replaces overclaims with verified loopback, cleanup, deadline, and Windows boundaries.

## Evolution

Independent pre-PR audit falsified the happy-path-only cleanup assumption. The implementation converged on the existing local-bearer source of truth plus explicit loopback binding, process-group verification, signal routing, global phase budgeting, and closed public errors before handoff.

Authored by Euclid (OpenAI GPT-5.6 Sol Ultra, Codex Desktop). Session 7efa8a03-b5cb-46c6-b1e9-bda072fead25.
