### PR TITLE
feat(fleet): wake-state read producer — the S2 wake axis (#15271)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -340,7 +340,7 @@ class FleetControlBridge extends Base {
      * accordingly rather than duplicated.
      * @returns {Object} the serializable cockpit DTO `{sources, capabilities, rows, events}`.
      */
-    fleetRoster() {
+    async fleetRoster() {
         const
             me       = this,
             registry = me.getRegistry(),
@@ -354,17 +354,25 @@ class FleetControlBridge extends Base {
             authMode  : getHarnessAuthMode(agent.harnessType)
         }));
 
+        // The S2 wake axis joins the roster here: the producer snapshot (subscription intent ×
+        // daemon liveness, entrypoint-injected sources) becomes per-row wake telltale state + one
+        // wake capability. Fail-honest end to end: an un-injected producer — or a manager seam
+        // without the producer method at all — yields not-wired/unknown, never a guessed state.
+        const wake = await manager.fleetWakeStatus?.() ?? null;
+
         return createFleetCockpitStatus({
             agents,
             fleetStatus  : manager.fleetRepoStatus() ?? [],
             runtimeStatus: manager.fleetRuntimeStatus() ?? [],
+            wakeStatus   : wake?.states ?? [],
             capabilities : {
                 activity: createNotWiredCapability(FLEET_COCKPIT_SOURCES.activity, 'activity rides the dedicated fleetActivity verb'),
                 runtime : {
                     source    : FLEET_COCKPIT_SOURCES.runtime,
                     state     : 'wired',
                     confidence: 'observed'
-                }
+                },
+                wake: wake?.capability ?? createNotWiredCapability(FLEET_COCKPIT_SOURCES.wake, 'wake-state producer not wired')
             }
         });
     }

--- a/ai/services/fleet/FleetManager.mjs
+++ b/ai/services/fleet/FleetManager.mjs
@@ -1,9 +1,10 @@
-import path                    from 'path';
-import {fileURLToPath}         from 'url';
-import Base                    from '../../../src/core/Base.mjs';
-import FleetLifecycleService   from './FleetLifecycleService.mjs';
-import {inspectFleetRepos}     from './inspectFleetRepos.mjs';
-import {startAgentProvisioned} from './startAgentProvisioned.mjs';
+import path                         from 'path';
+import {fileURLToPath}              from 'url';
+import Base                         from '../../../src/core/Base.mjs';
+import FleetLifecycleService        from './FleetLifecycleService.mjs';
+import {inspectFleetRepos}          from './inspectFleetRepos.mjs';
+import {readFleetWakeStateSnapshot} from './fleetWakeStateAdapter.mjs';
+import {startAgentProvisioned}      from './startAgentProvisioned.mjs';
 
 const
     __filename = fileURLToPath(import.meta.url),
@@ -70,6 +71,15 @@ class FleetManager extends Base {
      * @member {Function|null} provisionAndStartFn=null
      */
     provisionAndStartFn = null
+    /**
+     * Wake-state observation options for {@link fleetWakeStatus} — `{pidFilePath,
+     * resolveSubscriptionState}` per the `fleetWakeStateAdapter` contract. `null` ⇒ every source is
+     * honestly `unknown`: this service is not a config entrypoint — config resolution belongs to the
+     * composing process entrypoint, which resolves the daemon PID path + the identity-bound
+     * subscription read path and injects them here. Plain field, mirroring the sibling seams.
+     * @member {Object|null} wakeStateOptions=null
+     */
+    wakeStateOptions = null
     /**
      * Fleet repo-status aggregator seam. Defaults (via {@link getRepoStatusFn}) to `inspectFleetRepos`;
      * inject a recording stub for tests. Plain field.
@@ -172,6 +182,28 @@ class FleetManager extends Base {
             if (status.failureReason != null) row.failureReason = status.failureReason;
 
             return row;
+        });
+    }
+
+    /**
+     * @summary Turnkey wake-state observability: the per-agent wake axis of the S2 telltale taxonomy
+     * (`on | off | suppressed | unknown`) across the registered roster — the third fleet view beside
+     * {@link fleetRepoStatus} (repos) and {@link fleetRuntimeStatus} (processes).
+     *
+     * Delegates to `fleetWakeStateAdapter.readFleetWakeStateSnapshot` with the registry roster (one
+     * row per REGISTERED agent, same one-agent-set rule as the sibling views) plus the injected
+     * {@link #member-wakeStateOptions}. Observation truth only: subscription intent × daemon PID-file
+     * liveness; the `setWakeEnabled` control verb mutates state this view independently observes.
+     * Fail-honest: with no injected options every row reads `unknown` under a `degraded/none`
+     * capability — "we cannot see" stays distinguishable from "the fleet is off"; the state is never
+     * invented.
+     * @returns {Promise<{capability: Object, states: Object[]}>} Adapter snapshot: per-agent
+     * `{agentId, wake, confidence, source}` rows (+ `reason` on `unknown`) and the capability envelope.
+     */
+    fleetWakeStatus() {
+        return readFleetWakeStateSnapshot({
+            agents: this.getLifecycleService().getRegistry().listAgents(),
+            ...(this.wakeStateOptions || {})
         });
     }
 

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -17,13 +17,16 @@
 
 // Neo namespace bootstrap (entry-point invariant): `Neo` + `core/_export` populate globalThis.Neo so
 // the fleet singletons' `Neo.setupClass` succeeds at module-load; `InstanceManager` binds the aliases.
-import Neo                          from '../../../src/Neo.mjs';
-import * as core                    from '../../../src/core/_export.mjs';
-import InstanceManager              from '../../../src/manager/Instance.mjs';
-import AiConfig                     from '../../config.mjs';
-import {startFleetBridgeServer}     from './fleetBridgeServer.mjs';
-import {wireBootIdentityReadSource} from './wireBootIdentityReadSource.mjs';
-import {pathToFileURL}              from 'node:url';
+import Neo                                    from '../../../src/Neo.mjs';
+import * as core                              from '../../../src/core/_export.mjs';
+import InstanceManager                        from '../../../src/manager/Instance.mjs';
+import AiConfig                               from '../../config.mjs';
+import FleetManager                           from './FleetManager.mjs';
+import {startFleetBridgeServer}               from './fleetBridgeServer.mjs';
+import {readActiveWakeSubscriptionIdentities} from './readActiveWakeSubscriptionIdentities.mjs';
+import {wireBootIdentityReadSource}           from './wireBootIdentityReadSource.mjs';
+import path                                   from 'node:path';
+import {pathToFileURL}                        from 'node:url';
 
 const port = Number(process.env.NEO_FLEET_PORT) || 8083;
 
@@ -34,6 +37,15 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     // orchestrator's advisory fact from the shared runtime-state dir (read at this use site), instead of
     // the advisory-unknown fallback. Fail-soft — an absent dir leaves the seam honestly unwired.
     wireBootIdentityReadSource({dir: AiConfig.orchestrator.dataDir});
+
+    // Wire the wake-telltale producer sources (the S2 axis): the config-resolved daemon PID path +
+    // the trusted bulk subscription scan. This entrypoint is where config resolution belongs; the
+    // adapter itself never resolves it. Fail-soft by construction — a failing scan or an absent
+    // daemon degrades to honest per-row `unknown` inside the adapter, never a fabricated state.
+    FleetManager.wakeStateOptions = {
+        pidFilePath                     : path.join(AiConfig.wakeDaemon.dataDir, 'wake-daemon.pid'),
+        listActiveSubscriptionIdentities: readActiveWakeSubscriptionIdentities
+    };
 
     startFleetBridgeServer({port})
         .then(server => {

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -21,6 +21,7 @@ import Neo                                    from '../../../src/Neo.mjs';
 import * as core                              from '../../../src/core/_export.mjs';
 import InstanceManager                        from '../../../src/manager/Instance.mjs';
 import AiConfig                               from '../../config.mjs';
+import memoryCoreConfig                       from '../../mcp/server/memory-core/config.mjs';
 import FleetManager                           from './FleetManager.mjs';
 import {startFleetBridgeServer}               from './fleetBridgeServer.mjs';
 import {readActiveWakeSubscriptionIdentities} from './readActiveWakeSubscriptionIdentities.mjs';
@@ -42,8 +43,12 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     // the trusted bulk subscription scan. This entrypoint is where config resolution belongs; the
     // adapter itself never resolves it. Fail-soft by construction — a failing scan or an absent
     // daemon degrades to honest per-row `unknown` inside the adapter, never a fabricated state.
+    //
+    // The `wakeDaemon` subtree is owned by the memory-core config, NOT Tier-1 `AiConfig` (which
+    // carries only the flat `wakeDaemonHeartbeatAlivePath` leaf) — so the daemon's own authority
+    // (`ai/daemons/wake/daemon.mjs`) is the one to mirror here.
     FleetManager.wakeStateOptions = {
-        pidFilePath                     : path.join(AiConfig.wakeDaemon.dataDir, 'wake-daemon.pid'),
+        pidFilePath                     : path.join(memoryCoreConfig.wakeDaemon.dataDir, 'wake-daemon.pid'),
         listActiveSubscriptionIdentities: readActiveWakeSubscriptionIdentities
     };
 

--- a/ai/services/fleet/fleetWakeStateAdapter.mjs
+++ b/ai/services/fleet/fleetWakeStateAdapter.mjs
@@ -194,6 +194,8 @@ export async function readFleetWakeStateSnapshot({
 } = {}) {
     // The bulk reader wins when provided: one fresh scan per snapshot becomes a per-agent
     // membership resolver — same row semantics, no fan-out, no long-lived cache to go stale.
+    let bulkScanFailed = false
+
     if (!resolveSubscriptionState && listActiveSubscriptionIdentities) {
         try {
             const identities = new Set(await listActiveSubscriptionIdentities())
@@ -202,6 +204,10 @@ export async function readFleetWakeStateSnapshot({
         } catch (error) {
             const reason = redactReason(error)
 
+            // A wholesale scan failure yields a reader that can only throw. It is a row-reason
+            // carrier, NOT a source of truth — `bulkScanFailed` keeps the capability envelope from
+            // counting its mere existence as partial visibility.
+            bulkScanFailed          = true
             resolveSubscriptionState = () => { throw new Error(reason || 'subscription scan failed') }
         }
     }
@@ -267,10 +273,14 @@ export async function readFleetWakeStateSnapshot({
         states.push(row)
     }
 
+    // `hasReader` proves a function exists; `readerUsable` proves it can answer. Only the latter
+    // counts as truth — otherwise a throwing scan plus an unreadable daemon reports `partial`
+    // visibility while observing exactly nothing.
     const livenessSourceOk = liveness.alive !== 'unknown',
-          readerClean      = hasReader && failedRows === 0 && invalidRows === 0,
+          readerUsable     = hasReader && !bulkScanFailed,
+          readerClean      = readerUsable && failedRows === 0 && invalidRows === 0,
           fullyOk          = livenessSourceOk && readerClean,
-          anyTruth         = livenessSourceOk || hasReader
+          anyTruth         = livenessSourceOk || readerUsable
 
     return {
         capability: {

--- a/ai/services/fleet/fleetWakeStateAdapter.mjs
+++ b/ai/services/fleet/fleetWakeStateAdapter.mjs
@@ -1,4 +1,5 @@
-import fs from 'node:fs'
+import {spawnSync} from 'node:child_process'
+import fs          from 'node:fs'
 
 /**
  * @module ai/services/fleet/fleetWakeStateAdapter
@@ -24,25 +25,38 @@ export const WAKE_STATES = Object.freeze(['on', 'off', 'suppressed', 'unknown'])
 
 export const WAKE_SOURCE_LABEL = 'fleet:wakeState'
 
+/*
+ * The daemon-identity marker: the wake daemon's own launch path fragment, matched against the
+ * probed process's command line. A responding PID proves that SOME process answers — the OS
+ * recycles PIDs, so without a command match a reused PID would impersonate a live daemon.
+ */
+export const WAKE_DAEMON_COMMAND_MARKER = 'daemons/wake/daemon.mjs'
+
 /**
- * @summary Resolves wake-daemon liveness from its PID file — observed, stale-aware, fail-honest.
+ * @summary Resolves wake-daemon liveness from its PID file — observed, stale-aware,
+ * reuse-aware, fail-honest.
  *
  * The daemon creates its PID file with the exclusive-create flag, so a missing file is OBSERVED
- * not-running (`alive: false`), not an unknown. A present file still requires the process probe:
- * a crash can leave a stale PID behind, and `ESRCH` proves the recorded process is gone. `EPERM`
- * proves the process exists (probe denied ⇒ someone answers that pid). Every other failure —
- * unreadable file, malformed content, unexpected probe error — degrades to `'unknown'` with the
- * reason preserved.
+ * not-running (`alive: false`), not an unknown. A present file still requires two proofs: the
+ * process probe (`ESRCH` proves the recorded process is gone — a stale file; `EPERM` proves a
+ * process exists) AND a process-identity check — the OS recycles PIDs, so the responding process's
+ * command line must carry the daemon's own launch marker before the probe counts as the daemon.
+ * A responding PID whose command lacks the marker is OBSERVED dead-with-reuse; an unreadable
+ * command line (or any other failure — unreadable file, malformed content, unexpected probe
+ * error) degrades to `'unknown'` with the reason preserved.
  * @param {Object} options={}
  * @param {String|null} [options.pidFilePath] Absolute path to the daemon's PID file; `null` ⇒ unknown.
  * @param {Function} [options.readFile] `(path) => String` override for tests; defaults to `node:fs`.
  * @param {Function} [options.probeProcess] `(pid) => void` throwing ESRCH/EPERM; defaults to `process.kill(pid, 0)`.
+ * @param {Function} [options.readProcessCommand] `(pid) => String|null` override for tests;
+ *     defaults to a `ps -p <pid> -o command=` read. `null`/throw ⇒ identity unknown.
  * @returns {{alive: Boolean|'unknown', reason: String|null}}
  */
 export function resolveDaemonLiveness({
     pidFilePath = null,
     readFile = path => fs.readFileSync(path, 'utf8'),
-    probeProcess = pid => process.kill(pid, 0)
+    probeProcess = pid => process.kill(pid, 0),
+    readProcessCommand = readProcessCommandViaPs
 } = {}) {
     if (!pidFilePath) {
         return {alive: 'unknown', reason: 'wake daemon PID file path not configured'}
@@ -67,16 +81,51 @@ export function resolveDaemonLiveness({
 
     try {
         probeProcess(pid)
-        return {alive: true, reason: null}
     } catch (error) {
         if (error?.code === 'ESRCH') {
             return {alive: false, reason: 'stale PID file: recorded process is gone'}
         }
-        if (error?.code === 'EPERM') {
-            return {alive: true, reason: null}
+        if (error?.code !== 'EPERM') {
+            return {alive: 'unknown', reason: normalizeReason(error)}
         }
+        // EPERM: a process exists at that pid — identity still unverified, fall through.
+    }
+
+    // A responding PID is not yet the daemon: verify process identity against the launch marker,
+    // or a recycled PID would impersonate a live daemon.
+    let command
+
+    try {
+        command = readProcessCommand(pid)
+    } catch (error) {
         return {alive: 'unknown', reason: normalizeReason(error)}
     }
+
+    if (command == null || command === '') {
+        return {alive: 'unknown', reason: 'wake daemon process identity unreadable'}
+    }
+
+    if (!String(command).includes(WAKE_DAEMON_COMMAND_MARKER)) {
+        return {alive: false, reason: 'PID reused by another process: recorded daemon is gone'}
+    }
+
+    return {alive: true, reason: null}
+}
+
+/**
+ * @summary Default process-identity reader: the probed pid's command line via `ps` (portable across
+ * macOS/Linux). Returns `null` when `ps` yields nothing (the identity stays unknown, never guessed).
+ * @param {Number} pid
+ * @returns {String|null}
+ */
+function readProcessCommandViaPs(pid) {
+    const result = spawnSync('ps', ['-p', String(pid), '-o', 'command='], {encoding: 'utf8'})
+
+    if (result.status !== 0) return null
+
+    const command = (result.stdout || '').trim()
+
+    return command === '' ? null : command
 }
 
 /**
@@ -114,10 +163,20 @@ export function resolveAgentWakeState({subscriptionState, daemonAlive}) {
  * @param {Object} options={}
  * @param {Object[]} [options.agents] Registry roster rows; each needs an `id`.
  * @param {Function|null} [options.resolveSubscriptionState] `(agent) => 'active'|'none'|'unknown'`
- *     (sync or async). Absent ⇒ the subscription axis is honestly `unknown` for every agent.
+ *     (sync or async). Absent ⇒ the subscription axis is honestly `unknown` for every agent —
+ *     unless the bulk reader below is provided.
+ * @param {Function|null} [options.listActiveSubscriptionIdentities] Bulk alternative to the
+ *     per-agent reader: `() => Iterable<String>` (sync or async) yielding the wake identities that
+ *     hold an ACTIVE subscription — called ONCE per snapshot (fresh scan, no staleness, no
+ *     per-agent query fan-out). The production entrypoint composes this over its trusted
+ *     graph read; identity mapping runs through `wakeIdentityFor`.
+ * @param {Function} [options.wakeIdentityFor] `(agent) => String` mapping a fleet roster row onto
+ *     its wake identity. Default: `'@' + (githubUsername ?? id)` — the swarm's mailbox-identity
+ *     convention; override at the entrypoint if the deployment maps identities differently.
  * @param {String|null} [options.pidFilePath] Wake daemon PID file path (entrypoint-resolved).
  * @param {Function} [options.readFile] Test seam for {@link resolveDaemonLiveness}.
  * @param {Function} [options.probeProcess] Test seam for {@link resolveDaemonLiveness}.
+ * @param {Function} [options.readProcessCommand] Test seam for {@link resolveDaemonLiveness}.
  * @param {Date|String} [options.capturedAt] Capture timestamp.
  * @returns {Promise<{capability: Object, states: Object[]}>} `states` rows:
  *     `{agentId, wake, confidence, source}` (+ `reason` when `wake` is `unknown`).
@@ -125,31 +184,68 @@ export function resolveAgentWakeState({subscriptionState, daemonAlive}) {
 export async function readFleetWakeStateSnapshot({
     agents = [],
     resolveSubscriptionState = null,
+    listActiveSubscriptionIdentities = null,
+    wakeIdentityFor = agent => `@${agent.githubUsername ?? agent.id}`,
     pidFilePath = null,
     readFile,
     probeProcess,
+    readProcessCommand,
     capturedAt = new Date()
 } = {}) {
-    const liveness = resolveDaemonLiveness({pidFilePath, ...(readFile && {readFile}), ...(probeProcess && {probeProcess})})
+    // The bulk reader wins when provided: one fresh scan per snapshot becomes a per-agent
+    // membership resolver — same row semantics, no fan-out, no long-lived cache to go stale.
+    if (!resolveSubscriptionState && listActiveSubscriptionIdentities) {
+        try {
+            const identities = new Set(await listActiveSubscriptionIdentities())
 
-    let subscriptionSourceOk = Boolean(resolveSubscriptionState),
-        subscriptionFailure  = resolveSubscriptionState ? null : 'subscription read path unavailable'
+            resolveSubscriptionState = agent => identities.has(wakeIdentityFor(agent)) ? 'active' : 'none'
+        } catch (error) {
+            const reason = redactReason(error)
 
-    const states = []
+            resolveSubscriptionState = () => { throw new Error(reason || 'subscription scan failed') }
+        }
+    }
+    const liveness = resolveDaemonLiveness({
+        pidFilePath,
+        ...(readFile           && {readFile}),
+        ...(probeProcess       && {probeProcess}),
+        ...(readProcessCommand && {readProcessCommand})
+    })
+
+    const hasReader = Boolean(resolveSubscriptionState),
+          states    = []
+
+    let failedRows  = 0,
+        invalidRows = 0
 
     for (const agent of asArray(agents)) {
         const agentId = agent?.id
 
         if (!agentId) continue
 
-        let subscriptionState = 'unknown'
+        // Diagnostics are ROW-LOCAL by contract: one agent's reader failure names only its own
+        // row — sibling rows keep their own truth and their own reasons (no shared-state bleed).
+        let subscriptionState = 'unknown',
+            rowReason         = hasReader ? null : 'subscription read path unavailable'
 
-        if (resolveSubscriptionState) {
+        if (hasReader) {
             try {
-                subscriptionState = normalizeSubscriptionState(await resolveSubscriptionState(agent))
+                const answer = await resolveSubscriptionState(agent)
+
+                if (answer === 'active' || answer === 'none') {
+                    subscriptionState = answer
+                } else if (answer === 'unknown') {
+                    rowReason = 'truth source answered unknown'
+                } else {
+                    // An out-of-contract answer is an INVALID result, not a quiet unknown — it
+                    // degrades the capability below so a broken reader cannot hide under
+                    // wired/observed.
+                    invalidRows++
+                    rowReason = 'truth source returned an out-of-contract value'
+                }
             } catch (error) {
-                subscriptionSourceOk = false
-                subscriptionFailure  = normalizeReason(error)
+                failedRows++
+                rowReason = redactReason(error)
             }
         }
 
@@ -164,38 +260,53 @@ export async function readFleetWakeStateSnapshot({
 
         if (wake === 'unknown') {
             row.reason = subscriptionState === 'unknown'
-                ? (subscriptionFailure || 'subscription state unreadable')
-                : (liveness.reason || 'wake daemon liveness unknown')
+                ? (rowReason || 'subscription state unreadable')
+                : (redactReason(liveness.reason) || 'wake daemon liveness unknown')
         }
 
         states.push(row)
     }
 
     const livenessSourceOk = liveness.alive !== 'unknown',
-          bothOk           = livenessSourceOk && subscriptionSourceOk,
-          neitherOk        = !livenessSourceOk && !subscriptionSourceOk
+          readerClean      = hasReader && failedRows === 0 && invalidRows === 0,
+          fullyOk          = livenessSourceOk && readerClean,
+          anyTruth         = livenessSourceOk || hasReader
 
     return {
         capability: {
             source    : WAKE_SOURCE_LABEL,
-            state     : bothOk ? 'wired' : 'degraded',
-            confidence: bothOk ? 'observed' : (neitherOk ? 'none' : 'partial'),
+            state     : fullyOk ? 'wired' : 'degraded',
+            confidence: fullyOk ? 'observed' : (anyTruth ? 'partial' : 'none'),
             capturedAt: toIsoString(capturedAt),
-            reason    : bothOk ? null : [
-                livenessSourceOk ? null : (liveness.reason || 'daemon liveness unknown'),
-                subscriptionSourceOk ? null : subscriptionFailure
+            reason    : fullyOk ? null : [
+                livenessSourceOk ? null : (redactReason(liveness.reason) || 'daemon liveness unknown'),
+                hasReader ? null : 'subscription read path unavailable',
+                failedRows > 0 ? `subscription reader failed for ${failedRows} agent(s)` : null,
+                invalidRows > 0 ? `subscription reader returned out-of-contract values for ${invalidRows} agent(s)` : null
             ].filter(Boolean).join('; ') || null
         },
         states
     }
 }
 
-function normalizeSubscriptionState(value) {
-    return value === 'active' || value === 'none' ? value : 'unknown'
-}
-
 function normalizeReason(error) {
     return String(error?.message || error || 'source unavailable').replace(/\s+/g, ' ').slice(0, 240)
+}
+
+/**
+ * @summary Bounds AND redacts a diagnostic before it can reach a Body-side projection: secret
+ * vocabulary and token shapes are masked (the `fleetA2AActivityAdapter` discipline), whitespace
+ * collapsed, length capped — a throwing transport's dump can never leak internals into a row reason.
+ * @param {*} error
+ * @returns {String|null}
+ */
+function redactReason(error) {
+    if (error == null) return null
+
+    return normalizeReason(error)
+        .replace(/\b(token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
+        .replace(/\bgh[pousr]_[A-Za-z0-9_]+/g, '[redacted-token]')
+        .replace(/\bglpat-[A-Za-z0-9_-]+/g, '[redacted-token]')
 }
 
 function toIsoString(value) {

--- a/ai/services/fleet/fleetWakeStateAdapter.mjs
+++ b/ai/services/fleet/fleetWakeStateAdapter.mjs
@@ -1,0 +1,209 @@
+import fs from 'node:fs'
+
+/**
+ * @module ai/services/fleet/fleetWakeStateAdapter
+ * @summary Maps wake-subscription intent + wake-daemon liveness into per-agent wake-state
+ * observation rows for the Fleet roster DTO — the wake axis of the S2 telltale taxonomy.
+ *
+ * The adapter reads OBSERVATION truth only, never control intent: subscription state comes through
+ * an injected read path (the caller owns identity binding, mirroring `fleetA2AActivityAdapter`),
+ * and daemon liveness comes from the wake daemon's exclusive-create PID file plus a
+ * `process.kill(pid, 0)` existence probe. Watermark/state-file mtime is deliberately NOT a
+ * liveness signal: the watermark advances only on delivery activity, so a quiet fleet would be
+ * indistinguishable from a dead daemon. The `setWakeEnabled` control verb mutates state that this
+ * producer independently observes — the two never share a source.
+ *
+ * Fail-honest discipline (the graduated taxonomy's honest-degradation rule): every unreadable
+ * source degrades to `unknown` with a reason — absence of truth is never rendered as a healthy
+ * default. The adapter itself never resolves configuration — config resolution belongs to process
+ * entrypoints and this module is not one: the PID file path is injected by the composing
+ * entrypoint; without it, liveness is honestly `unknown`.
+ */
+
+export const WAKE_STATES = Object.freeze(['on', 'off', 'suppressed', 'unknown'])
+
+export const WAKE_SOURCE_LABEL = 'fleet:wakeState'
+
+/**
+ * @summary Resolves wake-daemon liveness from its PID file — observed, stale-aware, fail-honest.
+ *
+ * The daemon creates its PID file with the exclusive-create flag, so a missing file is OBSERVED
+ * not-running (`alive: false`), not an unknown. A present file still requires the process probe:
+ * a crash can leave a stale PID behind, and `ESRCH` proves the recorded process is gone. `EPERM`
+ * proves the process exists (probe denied ⇒ someone answers that pid). Every other failure —
+ * unreadable file, malformed content, unexpected probe error — degrades to `'unknown'` with the
+ * reason preserved.
+ * @param {Object} options={}
+ * @param {String|null} [options.pidFilePath] Absolute path to the daemon's PID file; `null` ⇒ unknown.
+ * @param {Function} [options.readFile] `(path) => String` override for tests; defaults to `node:fs`.
+ * @param {Function} [options.probeProcess] `(pid) => void` throwing ESRCH/EPERM; defaults to `process.kill(pid, 0)`.
+ * @returns {{alive: Boolean|'unknown', reason: String|null}}
+ */
+export function resolveDaemonLiveness({
+    pidFilePath = null,
+    readFile = path => fs.readFileSync(path, 'utf8'),
+    probeProcess = pid => process.kill(pid, 0)
+} = {}) {
+    if (!pidFilePath) {
+        return {alive: 'unknown', reason: 'wake daemon PID file path not configured'}
+    }
+
+    let raw
+
+    try {
+        raw = readFile(pidFilePath)
+    } catch (error) {
+        if (error?.code === 'ENOENT') {
+            return {alive: false, reason: null}
+        }
+        return {alive: 'unknown', reason: normalizeReason(error)}
+    }
+
+    const pid = Number(String(raw).trim())
+
+    if (!Number.isSafeInteger(pid) || pid <= 0) {
+        return {alive: 'unknown', reason: 'malformed wake daemon PID file'}
+    }
+
+    try {
+        probeProcess(pid)
+        return {alive: true, reason: null}
+    } catch (error) {
+        if (error?.code === 'ESRCH') {
+            return {alive: false, reason: 'stale PID file: recorded process is gone'}
+        }
+        if (error?.code === 'EPERM') {
+            return {alive: true, reason: null}
+        }
+        return {alive: 'unknown', reason: normalizeReason(error)}
+    }
+}
+
+/**
+ * @summary Maps one agent's subscription state × daemon liveness onto the graduated wake taxonomy.
+ *
+ * The truth table is the S2 registry contract verbatim: no subscription is OBSERVED `off`; an
+ * active subscription with a live daemon is `on`; an active subscription with a dead daemon is
+ * `suppressed` (intent on, delivery off — the blind-switch incident class); and any unknown input
+ * axis makes the output `unknown`, because claiming `on` or `suppressed` without both facts would
+ * fabricate precision.
+ * @param {Object} options={}
+ * @param {'active'|'none'|'unknown'} options.subscriptionState One agent's wake-subscription intent.
+ * @param {Boolean|'unknown'} options.daemonAlive Daemon liveness from {@link resolveDaemonLiveness}.
+ * @returns {'on'|'off'|'suppressed'|'unknown'}
+ */
+export function resolveAgentWakeState({subscriptionState, daemonAlive}) {
+    if (subscriptionState === 'none') {
+        return 'off'
+    }
+    if (subscriptionState !== 'active' || daemonAlive === 'unknown') {
+        return 'unknown'
+    }
+
+    return daemonAlive ? 'on' : 'suppressed'
+}
+
+/**
+ * @summary Reads the fleet-wide wake-state observation snapshot: one taxonomy row per agent plus a
+ * capability envelope declaring how much of the truth was reachable.
+ *
+ * Liveness is resolved ONCE (the daemon is host-global) and joined onto every row; subscription
+ * state is resolved per agent through the injected reader. Capability semantics: `wired/observed`
+ * when both sources answered, `degraded/partial` when exactly one did, `degraded/none` when
+ * neither — so a consumer can distinguish "the fleet is off" from "we cannot see".
+ * @param {Object} options={}
+ * @param {Object[]} [options.agents] Registry roster rows; each needs an `id`.
+ * @param {Function|null} [options.resolveSubscriptionState] `(agent) => 'active'|'none'|'unknown'`
+ *     (sync or async). Absent ⇒ the subscription axis is honestly `unknown` for every agent.
+ * @param {String|null} [options.pidFilePath] Wake daemon PID file path (entrypoint-resolved).
+ * @param {Function} [options.readFile] Test seam for {@link resolveDaemonLiveness}.
+ * @param {Function} [options.probeProcess] Test seam for {@link resolveDaemonLiveness}.
+ * @param {Date|String} [options.capturedAt] Capture timestamp.
+ * @returns {Promise<{capability: Object, states: Object[]}>} `states` rows:
+ *     `{agentId, wake, confidence, source}` (+ `reason` when `wake` is `unknown`).
+ */
+export async function readFleetWakeStateSnapshot({
+    agents = [],
+    resolveSubscriptionState = null,
+    pidFilePath = null,
+    readFile,
+    probeProcess,
+    capturedAt = new Date()
+} = {}) {
+    const liveness = resolveDaemonLiveness({pidFilePath, ...(readFile && {readFile}), ...(probeProcess && {probeProcess})})
+
+    let subscriptionSourceOk = Boolean(resolveSubscriptionState),
+        subscriptionFailure  = resolveSubscriptionState ? null : 'subscription read path unavailable'
+
+    const states = []
+
+    for (const agent of asArray(agents)) {
+        const agentId = agent?.id
+
+        if (!agentId) continue
+
+        let subscriptionState = 'unknown'
+
+        if (resolveSubscriptionState) {
+            try {
+                subscriptionState = normalizeSubscriptionState(await resolveSubscriptionState(agent))
+            } catch (error) {
+                subscriptionSourceOk = false
+                subscriptionFailure  = normalizeReason(error)
+            }
+        }
+
+        const wake = resolveAgentWakeState({subscriptionState, daemonAlive: liveness.alive})
+
+        const row = {
+            agentId,
+            wake,
+            confidence: wake === 'unknown' ? 'none' : 'observed',
+            source    : WAKE_SOURCE_LABEL
+        }
+
+        if (wake === 'unknown') {
+            row.reason = subscriptionState === 'unknown'
+                ? (subscriptionFailure || 'subscription state unreadable')
+                : (liveness.reason || 'wake daemon liveness unknown')
+        }
+
+        states.push(row)
+    }
+
+    const livenessSourceOk = liveness.alive !== 'unknown',
+          bothOk           = livenessSourceOk && subscriptionSourceOk,
+          neitherOk        = !livenessSourceOk && !subscriptionSourceOk
+
+    return {
+        capability: {
+            source    : WAKE_SOURCE_LABEL,
+            state     : bothOk ? 'wired' : 'degraded',
+            confidence: bothOk ? 'observed' : (neitherOk ? 'none' : 'partial'),
+            capturedAt: toIsoString(capturedAt),
+            reason    : bothOk ? null : [
+                livenessSourceOk ? null : (liveness.reason || 'daemon liveness unknown'),
+                subscriptionSourceOk ? null : subscriptionFailure
+            ].filter(Boolean).join('; ') || null
+        },
+        states
+    }
+}
+
+function normalizeSubscriptionState(value) {
+    return value === 'active' || value === 'none' ? value : 'unknown'
+}
+
+function normalizeReason(error) {
+    return String(error?.message || error || 'source unavailable').replace(/\s+/g, ' ').slice(0, 240)
+}
+
+function toIsoString(value) {
+    const date = value instanceof Date ? value : new Date(value)
+
+    return Number.isNaN(date.getTime()) ? new Date().toISOString() : date.toISOString()
+}
+
+function asArray(value) {
+    return Array.isArray(value) ? value : []
+}

--- a/ai/services/fleet/readActiveWakeSubscriptionIdentities.mjs
+++ b/ai/services/fleet/readActiveWakeSubscriptionIdentities.mjs
@@ -1,0 +1,45 @@
+/**
+ * @module ai/services/fleet/readActiveWakeSubscriptionIdentities
+ * @summary The trusted Brain-side observation source for the fleet's wake axis: one bulk scan of
+ * ACTIVE wake subscriptions, returning the holder identities — administrative READ-observation
+ * under the fleet process's own authority, deliberately NOT the caller-owner management API (which
+ * derives its owner from the request context and must never be impersonated).
+ *
+ * The graph service loads lazily per call: the fleet server pays the memory-core import cost only
+ * when a roster read actually needs wake truth, and a fresh scan per snapshot means no long-lived
+ * cache to go stale. Any failure — import, init, scan — THROWS, and the wake adapter converts that
+ * into honest per-row `unknown` under a degraded capability; this module never fabricates an empty
+ * fleet. Known bound, stated plainly: cross-process graph reads serve the loaded projection, so a
+ * subscription created moments ago in another process may appear one refresh late — an eventual-
+ * consistency lag on a telltale, never a wrong `off`.
+ */
+
+/**
+ * @summary Scan the graph for ACTIVE wake subscriptions and return their holder identities.
+ * @param {Object} [options]
+ * @param {Object} [options.graphService] Injectable service exposing `db.nodes.items`; defaults to
+ *     the memory-core `GraphService` singleton, imported lazily.
+ * @returns {Promise<String[]>} The wake identities holding an active subscription (deduplicated).
+ */
+export async function readActiveWakeSubscriptionIdentities({graphService = null} = {}) {
+    const service = graphService || (await import('../memory-core/GraphService.mjs')).default,
+          db      = service.db
+
+    if (!db?.nodes?.items) {
+        throw new Error('wake subscription scan: graph read surface unavailable')
+    }
+
+    const identities = new Set()
+
+    for (const node of db.nodes.items) {
+        if (node.label !== 'WAKE_SUBSCRIPTION') continue
+
+        const props = node.properties || {}
+
+        if (props.status === 'active' && typeof props.agentIdentity === 'string' && props.agentIdentity !== '') {
+            identities.add(props.agentIdentity)
+        }
+    }
+
+    return [...identities]
+}

--- a/ai/services/fleet/readActiveWakeSubscriptionIdentities.mjs
+++ b/ai/services/fleet/readActiveWakeSubscriptionIdentities.mjs
@@ -35,18 +35,19 @@ const ACTIVE_IDENTITIES_SQL = `
 /**
  * @summary Scan the graph for ACTIVE wake subscriptions and return their holder identities.
  * @param {Object} [options]
- * @param {Object} [options.graphService] Injectable service; defaults to the memory-core
- *     `GraphService` singleton, imported lazily. Tests inject a double exposing `db.nodes.items`.
+ * @param {Object} [options.graphService] Injectable service exposing `ready()` + `db`; defaults to
+ *     the memory-core `GraphService` singleton, imported lazily.
  * @returns {Promise<String[]>} The wake identities holding an active subscription (deduplicated).
  * @throws {Error} When no read surface is reachable — the adapter maps this to honest `unknown`.
  */
 export async function readActiveWakeSubscriptionIdentities({graphService = null} = {}) {
     const service = graphService || (await import('../memory-core/GraphService.mjs')).default
 
-    // `db` is populated by `initAsync`, not by module import: reading it straight off the fresh
-    // import yields undefined. `initAsync` is idempotent and awaits any in-flight init, so this is
-    // safe for an injected double that has already booted.
-    await service.initAsync?.()
+    // `db` is populated by async init, not by module import: reading it straight off the fresh
+    // import yields undefined. `ready()` is the ONLY architecture-compliant external wait —
+    // `core.Base` triggers `initAsync()` itself during `Neo.create()`, so awaiting that method from
+    // out here would run it a second time (`src/core/Base.mjs`). Mirrors `WakeSubscriptionService`.
+    await service.ready()
 
     const sqlite = service.db?.storage?.db
 

--- a/ai/services/fleet/readActiveWakeSubscriptionIdentities.mjs
+++ b/ai/services/fleet/readActiveWakeSubscriptionIdentities.mjs
@@ -9,34 +9,70 @@
  * when a roster read actually needs wake truth, and a fresh scan per snapshot means no long-lived
  * cache to go stale. Any failure — import, init, scan — THROWS, and the wake adapter converts that
  * into honest per-row `unknown` under a degraded capability; this module never fabricates an empty
- * fleet. Known bound, stated plainly: cross-process graph reads serve the loaded projection, so a
- * subscription created moments ago in another process may appear one refresh late — an eventual-
- * consistency lag on a telltale, never a wrong `off`.
+ * fleet.
+ *
+ * Durable-first by construction: the fleet server is a SEPARATE PROCESS from the MCP server that
+ * writes subscriptions, so the graph's in-memory `nodes.items` cache holds only what THIS process
+ * happened to load — a cross-process reader that trusts it would report a subscribed agent as
+ * `off`, fabricating the exact blind-switch the S2 axis exists to catch. SQLite is the only shared
+ * truth, so the durable query is the production path; the cache scan survives solely as an
+ * injected-double seam for tests.
  */
+
+/**
+ * The durable fleet-wide ACTIVE-subscription query. Mirrors the established WAKE_SUBSCRIPTION
+ * durable read (`WakeSubscriptionService#_reconcileDuplicateSubscriptions`) minus its owner
+ * predicate — this reader is fleet-wide by design. `COALESCE(status, 'active')` matches that
+ * established shape: `status` is optional on the node, and a missing one means active.
+ */
+const ACTIVE_IDENTITIES_SQL = `
+    SELECT DISTINCT json_extract(data, '$.properties.agentIdentity') AS agentIdentity
+    FROM Nodes
+    WHERE json_extract(data, '$.label') = 'WAKE_SUBSCRIPTION'
+      AND COALESCE(json_extract(data, '$.properties.status'), 'active') = 'active'
+`
 
 /**
  * @summary Scan the graph for ACTIVE wake subscriptions and return their holder identities.
  * @param {Object} [options]
- * @param {Object} [options.graphService] Injectable service exposing `db.nodes.items`; defaults to
- *     the memory-core `GraphService` singleton, imported lazily.
+ * @param {Object} [options.graphService] Injectable service; defaults to the memory-core
+ *     `GraphService` singleton, imported lazily. Tests inject a double exposing `db.nodes.items`.
  * @returns {Promise<String[]>} The wake identities holding an active subscription (deduplicated).
+ * @throws {Error} When no read surface is reachable — the adapter maps this to honest `unknown`.
  */
 export async function readActiveWakeSubscriptionIdentities({graphService = null} = {}) {
-    const service = graphService || (await import('../memory-core/GraphService.mjs')).default,
-          db      = service.db
+    const service = graphService || (await import('../memory-core/GraphService.mjs')).default
 
-    if (!db?.nodes?.items) {
+    // `db` is populated by `initAsync`, not by module import: reading it straight off the fresh
+    // import yields undefined. `initAsync` is idempotent and awaits any in-flight init, so this is
+    // safe for an injected double that has already booted.
+    await service.initAsync?.()
+
+    const sqlite = service.db?.storage?.db
+
+    if (sqlite) {
+        return sqlite.prepare(ACTIVE_IDENTITIES_SQL)
+            .all()
+            .map(row => row.agentIdentity)
+            .filter(identity => typeof identity === 'string' && identity !== '')
+    }
+
+    // Test-double seam only: an injected service with no SQLite handle. Never the production path —
+    // see the module note on cross-process cache truth.
+    const items = service.db?.nodes?.items
+
+    if (!items) {
         throw new Error('wake subscription scan: graph read surface unavailable')
     }
 
     const identities = new Set()
 
-    for (const node of db.nodes.items) {
+    for (const node of items) {
         if (node.label !== 'WAKE_SUBSCRIPTION') continue
 
         const props = node.properties || {}
 
-        if (props.status === 'active' && typeof props.agentIdentity === 'string' && props.agentIdentity !== '') {
+        if ((props.status ?? 'active') === 'active' && typeof props.agentIdentity === 'string' && props.agentIdentity !== '') {
             identities.add(props.agentIdentity)
         }
     }

--- a/src/ai/fleet/fleetCockpitStatus.mjs
+++ b/src/ai/fleet/fleetCockpitStatus.mjs
@@ -138,9 +138,12 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                         state     : 'not-wired',
                         confidence: 'none'
                     },
-                // The S2 wake telltale axis: the four-state observation row produced Brain-side
-                // (`on | off | suppressed | unknown`), tri-state honest like `lifecycle` — a row
-                // without a producer snapshot reads not-wired/none ("cannot see"), never a guess.
+                // The S2 wake telltale axis: the four-state observation row produced Brain-side.
+                // `state` is CLOSED over `on | off | suppressed | unknown` — absence of a producer
+                // is `unknown`, never a fifth value: consumers switch on this enum, so leaking a
+                // wiring fact into the observation field would force every one of them to re-derive
+                // the taxonomy. The wiring axis is carried by `sources.wake` + the capability
+                // envelope, and `confidence: 'none'` + `reason` keep the row itself honest.
                 wake: wake
                     ? {
                         source    : FLEET_COCKPIT_SOURCES.wake,
@@ -150,8 +153,9 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                     }
                     : {
                         source    : FLEET_COCKPIT_SOURCES.wake,
-                        state     : 'not-wired',
-                        confidence: 'none'
+                        state     : 'unknown',
+                        confidence: 'none',
+                        reason    : 'wake-state producer not wired'
                     },
                 sources: {
                     roster: {

--- a/src/ai/fleet/fleetCockpitStatus.mjs
+++ b/src/ai/fleet/fleetCockpitStatus.mjs
@@ -9,7 +9,8 @@ const WIRE_SOURCES = Object.freeze({
         repoStatus : 'fleet:fleetStatus',
         roster     : 'fleet:listAgents',
         runtime    : 'fleet:runtimeStatus',
-        lifecycle  : 'fleet:lifecycle'
+        lifecycle  : 'fleet:lifecycle',
+        wake       : 'fleet:wakeState'
     })
 
 export const FLEET_COCKPIT_EVENT_TYPES = Object.freeze([
@@ -70,7 +71,7 @@ function githubAvatarUrl(githubUsername) {
  * @param {Object}   options.capabilities  Optional source-capability overrides from wired adapters.
  * @returns {Object} serializable cockpit DTO `{sources, capabilities, rows, events}`.
  */
-export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtimeStatus = [], events = [], capabilities = {}} = {}) {
+export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtimeStatus = [], wakeStatus = [], events = [], capabilities = {}} = {}) {
     const suppliedCapabilities = capabilities || {}
 
     const statusByAgentId = new Map(
@@ -81,17 +82,26 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
         runtimeStatus.map(entry => [entry.agentId || entry.id, sanitizePayload(entry)])
     )
 
+    const wakeByAgentId = new Map(
+        wakeStatus.map(entry => [entry.agentId || entry.id, sanitizePayload(entry)])
+    )
+
     return {
         sources     : FLEET_COCKPIT_SOURCES,
         capabilities: {
             activity: suppliedCapabilities.activity || createNotWiredCapability(FLEET_COCKPIT_SOURCES.activity, 'A2A / PR / lane activity adapter not wired'),
-            runtime : suppliedCapabilities.runtime || createNotWiredCapability(FLEET_COCKPIT_SOURCES.runtime, 'runtime process status is pending the Fleet runtime-status wire method')
+            runtime : suppliedCapabilities.runtime || createNotWiredCapability(FLEET_COCKPIT_SOURCES.runtime, 'runtime process status is pending the Fleet runtime-status wire method'),
+            // The wake telltale axis (S2): four-state observation (`on | off | suppressed |
+            // unknown`) produced Brain-side; not-wired here is the honest default until the
+            // assembler passes a snapshot — the pane renders "cannot see", never a guessed state.
+            wake    : suppliedCapabilities.wake || createNotWiredCapability(FLEET_COCKPIT_SOURCES.wake, 'wake-state producer not wired')
         },
         rows: agents.map(agent => {
             const publicAgent = sanitizePayload(agent),
                   agentId     = publicAgent.id,
                   repoStatus  = statusByAgentId.get(agentId) || null,
-                  runtime     = runtimeByAgentId.get(agentId) || null
+                  runtime     = runtimeByAgentId.get(agentId) || null,
+                  wake        = wakeByAgentId.get(agentId) || null
 
             return {
                 id            : agentId,
@@ -128,6 +138,21 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                         state     : 'not-wired',
                         confidence: 'none'
                     },
+                // The S2 wake telltale axis: the four-state observation row produced Brain-side
+                // (`on | off | suppressed | unknown`), tri-state honest like `lifecycle` — a row
+                // without a producer snapshot reads not-wired/none ("cannot see"), never a guess.
+                wake: wake
+                    ? {
+                        source    : FLEET_COCKPIT_SOURCES.wake,
+                        state     : wake.wake ?? 'unknown',
+                        confidence: wake.confidence ?? 'none',
+                        ...(wake.reason != null && {reason: wake.reason})
+                    }
+                    : {
+                        source    : FLEET_COCKPIT_SOURCES.wake,
+                        state     : 'not-wired',
+                        confidence: 'none'
+                    },
                 sources: {
                     roster: {
                         source    : FLEET_COCKPIT_SOURCES.roster,
@@ -143,6 +168,11 @@ export function createFleetCockpitStatus({agents = [], fleetStatus = [], runtime
                         source    : FLEET_COCKPIT_SOURCES.runtime,
                         state     : runtime ? 'wired' : 'not-wired',
                         confidence: runtime ? (runtime.confidence ?? 'observed') : 'none'
+                    },
+                    wake: {
+                        source    : FLEET_COCKPIT_SOURCES.wake,
+                        state     : wake ? 'wired' : 'not-wired',
+                        confidence: wake ? (wake.confidence ?? 'none') : 'none'
                     }
                 }
             }

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -212,7 +212,7 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
 
     // ---- fleetRoster: the assembled cockpit DTO with the identity join (the Brain-side assembler) ----
 
-    test('fleetRoster assembles roster + repo + runtime and joins identity display facts through the resolver seam', () => {
+    test('fleetRoster assembles roster + repo + runtime and joins identity display facts through the resolver seam', async () => {
         registryStub.listAgents = () => {
             calls.push(['listAgents']);
             return [
@@ -229,7 +229,7 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
             return login === 'neo-gpt' ? {family: 'gpt', engineTag: 'GPT-5.6 Sol'} : {family: null, engineTag: null};
         };
 
-        const dto = FleetControlBridge.fleetRoster();
+        const dto = await FleetControlBridge.fleetRoster();
 
         // the resolver was consulted once per agent, keyed by githubUsername
         expect(calls).toContainEqual(['resolveIdentityDisplay', 'neo-gpt']);
@@ -257,12 +257,12 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         expect(dto.capabilities.runtime.state).toBe('wired');
     });
 
-    test('fleetRoster defaults the resolver to the identity-roots join when not injected — family real, engineTag honestly null', () => {
+    test('fleetRoster defaults the resolver to the identity-roots join when not injected — family real, engineTag honestly null', async () => {
         registryStub.listAgents        = () => [{id: 'neo-gpt', githubUsername: 'neo-gpt', harnessType: 'codex'}];
         managerStub.fleetRepoStatus    = () => [];
         managerStub.fleetRuntimeStatus = () => [];
 
-        const [row] = FleetControlBridge.fleetRoster().rows;
+        const [row] = (await FleetControlBridge.fleetRoster()).rows;
 
         // compare against the LIVE root: family is the stable identity fact the roots CAN answer;
         // engineTag stays null until a truthful current-engine source exists (session/era metadata)
@@ -270,7 +270,7 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         expect(row.engineTag).toBeNull();
     });
 
-    test('fleetRoster stamps launch-derived truth per row — templated families carry their auth mode, native-neo stays honestly unlaunchable', () => {
+    test('fleetRoster stamps launch-derived truth per row — templated families carry their auth mode, native-neo stays honestly unlaunchable', async () => {
         registryStub.listAgents = () => [
             {id: 'desk',   githubUsername: 'desk-gh',   harnessType: 'claude-desktop'},
             {id: 'cli',    githubUsername: 'cli-gh',    harnessType: 'codex'},
@@ -281,7 +281,7 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         managerStub.fleetRuntimeStatus = () => [];
         FleetControlBridge.identityResolver = () => ({family: null, engineTag: null});
 
-        const rows = FleetControlBridge.fleetRoster().rows;
+        const rows = (await FleetControlBridge.fleetRoster()).rows;
 
         // DERIVED at read time from the launch seam (LAUNCHABLE_HARNESS_TYPES / getHarnessAuthMode)
         // — a family flips cockpit-launchable exactly when its launch template lands; there is no

--- a/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
@@ -198,6 +198,7 @@ test.describe('Neo.ai.services.fleet.FleetManager — fleetWakeStatus (roster ×
             pidFilePath             : '/x/wake-daemon.pid',
             readFile                : () => '4242',
             probeProcess            : () => {},
+            readProcessCommand      : () => 'node /repo/ai/daemons/wake/daemon.mjs',
             resolveSubscriptionState: agent => agent.id === 'alice' ? 'active' : 'none'
         };
 

--- a/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetManager.spec.mjs
@@ -185,3 +185,43 @@ test.describe('Neo.ai.services.fleet.FleetManager — Codex Desktop cleanup fail
         expect(calls).toEqual([['start', 'cli'], ['removeAgent', 'cli']]);
     });
 });
+
+test.describe('Neo.ai.services.fleet.FleetManager — fleetWakeStatus (roster × wake observation)', () => {
+    test.afterEach(() => {
+        FleetManager.lifecycleService = null;
+        FleetManager.wakeStateOptions = null;
+    });
+
+    test('composes the roster with the injected wake truth sources — every registered agent gets a taxonomy row', async () => {
+        FleetManager.lifecycleService = {getRegistry: () => ({listAgents: () => [{id: 'alice'}, {id: 'bob'}]})};
+        FleetManager.wakeStateOptions = {
+            pidFilePath             : '/x/wake-daemon.pid',
+            readFile                : () => '4242',
+            probeProcess            : () => {},
+            resolveSubscriptionState: agent => agent.id === 'alice' ? 'active' : 'none'
+        };
+
+        const {capability, states} = await FleetManager.fleetWakeStatus();
+
+        expect(capability).toMatchObject({state: 'wired', confidence: 'observed'});
+        expect(states).toEqual([
+            {agentId: 'alice', wake: 'on',  confidence: 'observed', source: 'fleet:wakeState'},
+            {agentId: 'bob',   wake: 'off', confidence: 'observed', source: 'fleet:wakeState'}
+        ]);
+    });
+
+    test('with no injected options every row is honestly unknown under a degraded/none capability — never invented', async () => {
+        FleetManager.lifecycleService = {getRegistry: () => ({listAgents: () => [{id: 'alice'}]})};
+
+        const {capability, states} = await FleetManager.fleetWakeStatus();
+
+        expect(capability).toMatchObject({state: 'degraded', confidence: 'none'});
+        expect(states).toEqual([{
+            agentId   : 'alice',
+            wake      : 'unknown',
+            confidence: 'none',
+            source    : 'fleet:wakeState',
+            reason    : 'subscription read path unavailable'
+        }]);
+    });
+});

--- a/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetCockpitStatus.spec.mjs
@@ -244,4 +244,40 @@ test.describe('fleetCockpitStatus - Body-side cockpit DTO contract', () => {
         expect(() => createFleetCockpitEvent({type: 'lifecycle-request'})).toThrow('source is required')
         expect(() => createFleetCockpitEvent({type: 'free-form', source: FLEET_COCKPIT_SOURCES.lifecycle})).toThrow('unsupported event type')
     })
+
+    // The wake row's `state` is CLOSED over the S2 four-state taxonomy. The wiring fact belongs to
+    // the capability + `sources.wake`; leaking it into the observation field would hand every
+    // consumer a fifth value it never agreed to switch on.
+    test('an unwired wake producer reads unknown/none in the ROW, and not-wired only in the wiring axes', () => {
+        const snapshot = createFleetCockpitStatus({agents: [{id: 'grace', githubUsername: 'neo-opus-grace'}]}),
+              row      = snapshot.rows[0]
+
+        expect(row.wake).toEqual({
+            source    : FLEET_COCKPIT_SOURCES.wake,
+            state     : 'unknown',
+            confidence: 'none',
+            reason    : 'wake-state producer not wired'
+        })
+        expect(row.sources.wake).toMatchObject({state: 'not-wired', confidence: 'none'})
+        expect(snapshot.capabilities.wake).toMatchObject({state: 'not-wired'})
+    })
+
+    test('wake row state stays inside the four-state taxonomy for every producer answer, wired or not', () => {
+        const agents   = [{id: 'grace'}, {id: 'vega'}, {id: 'euclid'}, {id: 'ada'}],
+              snapshot = createFleetCockpitStatus({
+                  agents,
+                  wakeStatus: [
+                      {agentId: 'grace',  wake: 'on',        confidence: 'observed'},
+                      {agentId: 'vega',   wake: 'suppressed', confidence: 'observed'},
+                      {agentId: 'euclid', wake: 'unknown',    confidence: 'none', reason: 'graph offline'}
+                      // 'ada' has no producer row at all — absence must read unknown.
+                  ]
+              })
+
+        expect(snapshot.rows.map(row => row.wake.state)).toEqual(['on', 'suppressed', 'unknown', 'unknown'])
+
+        for (const row of snapshot.rows) {
+            expect(['on', 'off', 'suppressed', 'unknown']).toContain(row.wake.state)
+        }
+    })
 })

--- a/test/playwright/unit/ai/services/fleet/fleetWakeStateAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeStateAdapter.spec.mjs
@@ -43,14 +43,41 @@ test.describe('fleetWakeStateAdapter — daemon liveness (PID file + process pro
         expect(resolveDaemonLiveness({pidFilePath: '/x/wake.pid', readFile: enoent})).toEqual({alive: false, reason: null})
     })
 
-    test('a live recorded process reads alive; EPERM proves existence too', () => {
-        expect(resolveDaemonLiveness({pidFilePath: '/x/wake.pid', readFile: () => '4242\n', probeProcess: () => {}}).alive).toBe(true)
-        expect(resolveDaemonLiveness({pidFilePath: '/x/wake.pid', readFile: () => '4242', probeProcess: eperm}).alive).toBe(true)
+    test('a live, identity-verified process reads alive; EPERM still verifies identity', () => {
+        const daemonCmd = () => 'node /repo/ai/daemons/wake/daemon.mjs'
+
+        expect(resolveDaemonLiveness({pidFilePath: '/x/wake.pid', readFile: () => '4242\n', probeProcess: () => {}, readProcessCommand: daemonCmd}).alive).toBe(true)
+        expect(resolveDaemonLiveness({pidFilePath: '/x/wake.pid', readFile: () => '4242', probeProcess: eperm, readProcessCommand: daemonCmd}).alive).toBe(true)
     })
 
     test('a stale PID file (ESRCH) is OBSERVED dead, with the staleness named', () => {
         expect(resolveDaemonLiveness({pidFilePath: '/x/wake.pid', readFile: () => '4242', probeProcess: esrch}))
             .toEqual({alive: false, reason: 'stale PID file: recorded process is gone'})
+    })
+
+    test('a responding PID is NOT the daemon until its command carries the launch marker — reuse reads observed-dead', () => {
+        expect(resolveDaemonLiveness({
+            pidFilePath       : '/x/wake.pid',
+            readFile          : () => '4242',
+            probeProcess      : () => {},
+            readProcessCommand: () => '/usr/bin/some-unrelated-tool --serve'
+        })).toEqual({alive: false, reason: 'PID reused by another process: recorded daemon is gone'})
+    })
+
+    test('an unreadable process identity degrades to unknown — a responding PID alone proves nothing', () => {
+        expect(resolveDaemonLiveness({
+            pidFilePath       : '/x/wake.pid',
+            readFile          : () => '4242',
+            probeProcess      : () => {},
+            readProcessCommand: () => null
+        })).toEqual({alive: 'unknown', reason: 'wake daemon process identity unreadable'})
+
+        expect(resolveDaemonLiveness({
+            pidFilePath       : '/x/wake.pid',
+            readFile          : () => '4242',
+            probeProcess      : () => {},
+            readProcessCommand: () => { throw new Error('ps unavailable') }
+        })).toEqual({alive: 'unknown', reason: 'ps unavailable'})
     })
 
     test('unreadable or malformed PID state degrades to unknown with the reason preserved', () => {
@@ -84,7 +111,8 @@ test.describe('fleetWakeStateAdapter — the graduated four-state mapping', () =
 })
 
 test.describe('fleetWakeStateAdapter — the fleet snapshot + capability envelope', () => {
-    const agents = [{id: 'grace'}, {id: 'vega'}, {id: 'euclid'}]
+    const agents    = [{id: 'grace'}, {id: 'vega'}, {id: 'euclid'}],
+          daemonCmd = () => 'node /repo/ai/daemons/wake/daemon.mjs'
 
     test('both sources readable: wired/observed capability and per-agent taxonomy rows', async () => {
         const {capability, states} = await readFleetWakeStateSnapshot({
@@ -92,7 +120,8 @@ test.describe('fleetWakeStateAdapter — the fleet snapshot + capability envelop
             resolveSubscriptionState: agent => agent.id === 'vega' ? 'none' : 'active',
             pidFilePath             : '/x/wake.pid',
             readFile                : () => '4242',
-            probeProcess            : () => {}
+            probeProcess            : () => {},
+            readProcessCommand      : daemonCmd
         })
 
         expect(capability).toMatchObject({source: WAKE_SOURCE_LABEL, state: 'wired', confidence: 'observed', reason: null})
@@ -116,10 +145,11 @@ test.describe('fleetWakeStateAdapter — the fleet snapshot + capability envelop
 
     test('unknown-on-unreachable: no subscription reader degrades every row honestly, with reasons', async () => {
         const {capability, states} = await readFleetWakeStateSnapshot({
-            agents      : [{id: 'grace'}],
-            pidFilePath : '/x/wake.pid',
-            readFile    : () => '4242',
-            probeProcess: () => {}
+            agents            : [{id: 'grace'}],
+            pidFilePath       : '/x/wake.pid',
+            readFile          : () => '4242',
+            probeProcess      : () => {},
+            readProcessCommand: daemonCmd
         })
 
         expect(capability).toMatchObject({state: 'degraded', confidence: 'partial'})
@@ -139,7 +169,8 @@ test.describe('fleetWakeStateAdapter — the fleet snapshot + capability envelop
             resolveSubscriptionState: () => { throw new Error('graph offline') },
             pidFilePath             : '/x/wake.pid',
             readFile                : () => '4242',
-            probeProcess            : () => {}
+            probeProcess            : () => {},
+            readProcessCommand      : daemonCmd
         })
 
         expect(capability).toMatchObject({state: 'degraded', confidence: 'partial'})
@@ -160,9 +191,96 @@ test.describe('fleetWakeStateAdapter — the fleet snapshot + capability envelop
             resolveSubscriptionState: () => 'none',
             pidFilePath             : '/x/wake.pid',
             readFile                : () => '4242',
-            probeProcess            : () => {}
+            probeProcess            : () => {},
+            readProcessCommand      : daemonCmd
         })
 
         expect(states.map(row => row.agentId)).toEqual(['grace'])
+    })
+
+    test('diagnostics are ROW-LOCAL: one throwing row names only itself; siblings keep their own truth', async () => {
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents,
+            resolveSubscriptionState: agent => {
+                if (agent.id === 'vega') throw new Error('graph offline for vega')
+                return agent.id === 'grace' ? 'active' : 'none'
+            },
+            pidFilePath       : '/x/wake.pid',
+            readFile          : () => '4242',
+            probeProcess      : () => {},
+            readProcessCommand: daemonCmd
+        })
+
+        expect(states).toEqual([
+            {agentId: 'grace',  wake: 'on',      confidence: 'observed', source: WAKE_SOURCE_LABEL},
+            {agentId: 'vega',   wake: 'unknown', confidence: 'none',     source: WAKE_SOURCE_LABEL, reason: 'graph offline for vega'},
+            {agentId: 'euclid', wake: 'off',     confidence: 'observed', source: WAKE_SOURCE_LABEL}
+        ])
+        expect(capability).toMatchObject({state: 'degraded', confidence: 'partial'})
+        expect(capability.reason).toContain('failed for 1 agent(s)')
+    })
+
+    test('an out-of-contract reader value degrades the CAPABILITY — garbage cannot hide under wired/observed', async () => {
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents                  : [{id: 'grace'}, {id: 'vega'}],
+            resolveSubscriptionState: agent => agent.id === 'grace' ? 'garbage' : 'active',
+            pidFilePath             : '/x/wake.pid',
+            readFile                : () => '4242',
+            probeProcess            : () => {},
+            readProcessCommand      : daemonCmd
+        })
+
+        expect(states[0]).toMatchObject({wake: 'unknown', confidence: 'none', reason: 'truth source returned an out-of-contract value'})
+        expect(states[1]).toMatchObject({wake: 'on', confidence: 'observed'})
+        expect(capability).toMatchObject({state: 'degraded', confidence: 'partial'})
+        expect(capability.reason).toContain('out-of-contract values for 1 agent(s)')
+    })
+
+    test('row reasons are REDACTED before any Body projection — a transport dump cannot leak a token', async () => {
+        const {states} = await readFleetWakeStateSnapshot({
+            agents                  : [{id: 'grace'}],
+            resolveSubscriptionState: () => { throw new Error('fetch failed: token=glpat-SECRET-abc123 rejected') },
+            pidFilePath             : '/x/wake.pid',
+            readFile                : () => '4242',
+            probeProcess            : () => {},
+            readProcessCommand      : daemonCmd
+        })
+
+        expect(states[0].reason).not.toContain('glpat-SECRET-abc123')
+        expect(states[0].reason).toContain('[redacted')
+    })
+
+    test('the bulk identity scan drives per-agent membership through the identity mapping — one scan, no fan-out', async () => {
+        let scans = 0
+
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents                          : [{id: 'grace', githubUsername: 'neo-opus-grace'}, {id: 'vega', githubUsername: 'neo-opus-vega'}],
+            listActiveSubscriptionIdentities: () => { scans++; return ['@neo-opus-grace'] },
+            pidFilePath                     : '/x/wake.pid',
+            readFile                        : () => '4242',
+            probeProcess                    : () => {},
+            readProcessCommand              : daemonCmd
+        })
+
+        expect(scans).toBe(1)
+        expect(states).toEqual([
+            {agentId: 'grace', wake: 'on',  confidence: 'observed', source: WAKE_SOURCE_LABEL},
+            {agentId: 'vega',  wake: 'off', confidence: 'observed', source: WAKE_SOURCE_LABEL}
+        ])
+        expect(capability).toMatchObject({state: 'wired', confidence: 'observed'})
+    })
+
+    test('a failing bulk scan degrades every row honestly — never a fabricated empty fleet', async () => {
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents                          : [{id: 'grace'}],
+            listActiveSubscriptionIdentities: () => { throw new Error('graph read surface unavailable') },
+            pidFilePath                     : '/x/wake.pid',
+            readFile                        : () => '4242',
+            probeProcess                    : () => {},
+            readProcessCommand              : daemonCmd
+        })
+
+        expect(states[0]).toMatchObject({wake: 'unknown', confidence: 'none', reason: 'graph read surface unavailable'})
+        expect(capability).toMatchObject({state: 'degraded', confidence: 'partial'})
     })
 })

--- a/test/playwright/unit/ai/services/fleet/fleetWakeStateAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeStateAdapter.spec.mjs
@@ -1,0 +1,168 @@
+import {setup} from '../../../../setup.mjs'
+
+const appName = 'FleetWakeStateAdapterTest'
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+})
+
+import {test, expect} from '@playwright/test'
+import Neo            from '../../../../../../src/Neo.mjs'
+import * as core      from '../../../../../../src/core/_export.mjs'
+
+import {
+    readFleetWakeStateSnapshot,
+    resolveAgentWakeState,
+    resolveDaemonLiveness,
+    WAKE_SOURCE_LABEL,
+    WAKE_STATES
+} from '../../../../../../ai/services/fleet/fleetWakeStateAdapter.mjs'
+
+const enoent = () => { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e }
+const esrch  = () => { const e = new Error('ESRCH');  e.code = 'ESRCH';  throw e }
+const eperm  = () => { const e = new Error('EPERM');  e.code = 'EPERM';  throw e }
+
+/**
+ * Self-test for the wake axis of the S2 telltale taxonomy: observation-only truth (subscription
+ * intent × daemon PID-file liveness), the graduated four-state mapping, and the fail-honest rule —
+ * every unreadable source degrades to `unknown` with a reason, never to a healthy default.
+ */
+test.describe('fleetWakeStateAdapter — daemon liveness (PID file + process probe)', () => {
+    test('no configured PID path is honestly unknown, never a guessed off', () => {
+        expect(resolveDaemonLiveness({})).toEqual({alive: 'unknown', reason: 'wake daemon PID file path not configured'})
+    })
+
+    test('a missing PID file is OBSERVED not-running (the exclusive-create contract)', () => {
+        expect(resolveDaemonLiveness({pidFilePath: '/x/wake.pid', readFile: enoent})).toEqual({alive: false, reason: null})
+    })
+
+    test('a live recorded process reads alive; EPERM proves existence too', () => {
+        expect(resolveDaemonLiveness({pidFilePath: '/x/wake.pid', readFile: () => '4242\n', probeProcess: () => {}}).alive).toBe(true)
+        expect(resolveDaemonLiveness({pidFilePath: '/x/wake.pid', readFile: () => '4242', probeProcess: eperm}).alive).toBe(true)
+    })
+
+    test('a stale PID file (ESRCH) is OBSERVED dead, with the staleness named', () => {
+        expect(resolveDaemonLiveness({pidFilePath: '/x/wake.pid', readFile: () => '4242', probeProcess: esrch}))
+            .toEqual({alive: false, reason: 'stale PID file: recorded process is gone'})
+    })
+
+    test('unreadable or malformed PID state degrades to unknown with the reason preserved', () => {
+        expect(resolveDaemonLiveness({pidFilePath: '/x/wake.pid', readFile: () => { throw new Error('EACCES: denied') }}))
+            .toEqual({alive: 'unknown', reason: 'EACCES: denied'})
+        expect(resolveDaemonLiveness({pidFilePath: '/x/wake.pid', readFile: () => 'not-a-pid'}).alive).toBe('unknown')
+    })
+})
+
+test.describe('fleetWakeStateAdapter — the graduated four-state mapping', () => {
+    test('covers exactly the taxonomy', () => {
+        expect(WAKE_STATES).toEqual(['on', 'off', 'suppressed', 'unknown'])
+    })
+
+    test('no subscription is observed off — regardless of daemon state', () => {
+        expect(resolveAgentWakeState({subscriptionState: 'none', daemonAlive: true})).toBe('off')
+        expect(resolveAgentWakeState({subscriptionState: 'none', daemonAlive: false})).toBe('off')
+        expect(resolveAgentWakeState({subscriptionState: 'none', daemonAlive: 'unknown'})).toBe('off')
+    })
+
+    test('active subscription + live daemon is on; + dead daemon is suppressed (the blind-switch incident class)', () => {
+        expect(resolveAgentWakeState({subscriptionState: 'active', daemonAlive: true})).toBe('on')
+        expect(resolveAgentWakeState({subscriptionState: 'active', daemonAlive: false})).toBe('suppressed')
+    })
+
+    test('any unknown input axis makes the output unknown — no fabricated precision', () => {
+        expect(resolveAgentWakeState({subscriptionState: 'unknown', daemonAlive: true})).toBe('unknown')
+        expect(resolveAgentWakeState({subscriptionState: 'active', daemonAlive: 'unknown'})).toBe('unknown')
+        expect(resolveAgentWakeState({subscriptionState: 'garbage', daemonAlive: true})).toBe('unknown')
+    })
+})
+
+test.describe('fleetWakeStateAdapter — the fleet snapshot + capability envelope', () => {
+    const agents = [{id: 'grace'}, {id: 'vega'}, {id: 'euclid'}]
+
+    test('both sources readable: wired/observed capability and per-agent taxonomy rows', async () => {
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents,
+            resolveSubscriptionState: agent => agent.id === 'vega' ? 'none' : 'active',
+            pidFilePath             : '/x/wake.pid',
+            readFile                : () => '4242',
+            probeProcess            : () => {}
+        })
+
+        expect(capability).toMatchObject({source: WAKE_SOURCE_LABEL, state: 'wired', confidence: 'observed', reason: null})
+        expect(states).toEqual([
+            {agentId: 'grace',  wake: 'on',  confidence: 'observed', source: WAKE_SOURCE_LABEL},
+            {agentId: 'vega',   wake: 'off', confidence: 'observed', source: WAKE_SOURCE_LABEL},
+            {agentId: 'euclid', wake: 'on',  confidence: 'observed', source: WAKE_SOURCE_LABEL}
+        ])
+    })
+
+    test('dead daemon: subscribed agents read suppressed — exactly the hand-disabled incident', async () => {
+        const {states} = await readFleetWakeStateSnapshot({
+            agents,
+            resolveSubscriptionState: () => 'active',
+            pidFilePath             : '/x/wake.pid',
+            readFile                : enoent
+        })
+
+        expect(states.map(row => row.wake)).toEqual(['suppressed', 'suppressed', 'suppressed'])
+    })
+
+    test('unknown-on-unreachable: no subscription reader degrades every row honestly, with reasons', async () => {
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents      : [{id: 'grace'}],
+            pidFilePath : '/x/wake.pid',
+            readFile    : () => '4242',
+            probeProcess: () => {}
+        })
+
+        expect(capability).toMatchObject({state: 'degraded', confidence: 'partial'})
+        expect(capability.reason).toContain('subscription read path unavailable')
+        expect(states).toEqual([{
+            agentId   : 'grace',
+            wake      : 'unknown',
+            confidence: 'none',
+            source    : WAKE_SOURCE_LABEL,
+            reason    : 'subscription read path unavailable'
+        }])
+    })
+
+    test('a throwing subscription reader degrades the capability and carries the failure reason', async () => {
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents                  : [{id: 'grace'}],
+            resolveSubscriptionState: () => { throw new Error('graph offline') },
+            pidFilePath             : '/x/wake.pid',
+            readFile                : () => '4242',
+            probeProcess            : () => {}
+        })
+
+        expect(capability).toMatchObject({state: 'degraded', confidence: 'partial'})
+        expect(states[0]).toMatchObject({wake: 'unknown', confidence: 'none', reason: 'graph offline'})
+    })
+
+    test('neither source readable: degraded/none — "we cannot see" is distinguishable from "the fleet is off"', async () => {
+        const {capability} = await readFleetWakeStateSnapshot({agents})
+
+        expect(capability).toMatchObject({state: 'degraded', confidence: 'none'})
+        expect(capability.reason).toContain('PID file path not configured')
+        expect(capability.reason).toContain('subscription read path unavailable')
+    })
+
+    test('rows without an agent id are skipped; empty rosters return an empty observed set', async () => {
+        const {states} = await readFleetWakeStateSnapshot({
+            agents                  : [{}, {id: 'grace'}],
+            resolveSubscriptionState: () => 'none',
+            pidFilePath             : '/x/wake.pid',
+            readFile                : () => '4242',
+            probeProcess            : () => {}
+        })
+
+        expect(states.map(row => row.agentId)).toEqual(['grace'])
+    })
+})

--- a/test/playwright/unit/ai/services/fleet/fleetWakeStateAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetWakeStateAdapter.spec.mjs
@@ -283,4 +283,29 @@ test.describe('fleetWakeStateAdapter — the fleet snapshot + capability envelop
         expect(states[0]).toMatchObject({wake: 'unknown', confidence: 'none', reason: 'graph read surface unavailable'})
         expect(capability).toMatchObject({state: 'degraded', confidence: 'partial'})
     })
+
+    test('a failing bulk scan AND an unconfigured daemon report confidence none — a reader that only throws is not a source', async () => {
+        // The sibling case above keeps `partial` honestly: its PID probe still observes liveness.
+        // Strip that last source and NOTHING is observed, so the envelope must say so — the mere
+        // existence of a (throw-only) reader function must not buy partial visibility.
+        const {capability, states} = await readFleetWakeStateSnapshot({
+            agents                          : [{id: 'grace'}],
+            listActiveSubscriptionIdentities: () => { throw new Error('graph read surface unavailable') }
+        })
+
+        expect(states[0]).toMatchObject({wake: 'unknown', confidence: 'none', reason: 'graph read surface unavailable'})
+        expect(capability).toMatchObject({state: 'degraded', confidence: 'none'})
+        expect(capability.reason).toContain('PID file path not configured')
+    })
+
+    test('every row state stays inside the closed four-state taxonomy, whatever the sources do', async () => {
+        const {states} = await readFleetWakeStateSnapshot({
+            agents                          : [{id: 'grace'}, {id: 'vega'}, {id: 'euclid'}],
+            listActiveSubscriptionIdentities: () => { throw new Error('graph offline') }
+        })
+
+        for (const row of states) {
+            expect(WAKE_STATES).toContain(row.wake)
+        }
+    })
 })

--- a/test/playwright/unit/ai/services/fleet/readActiveWakeSubscriptionIdentities.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/readActiveWakeSubscriptionIdentities.spec.mjs
@@ -1,0 +1,111 @@
+import {setup} from '../../../../setup.mjs'
+
+const appName = 'ReadActiveWakeSubscriptionIdentitiesTest'
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+})
+
+import {test, expect} from '@playwright/test'
+import Neo            from '../../../../../../src/Neo.mjs'
+import * as core      from '../../../../../../src/core/_export.mjs'
+
+import {readActiveWakeSubscriptionIdentities} from '../../../../../../ai/services/fleet/readActiveWakeSubscriptionIdentities.mjs'
+
+/**
+ * Models the GraphService contract this reader depends on: `db` does NOT exist until `initAsync()`
+ * resolves. A reader that skips the await sees `undefined` and cannot reach either surface — which
+ * is exactly the defect these specs pin.
+ */
+function graphServiceDouble({rows = null, items = null, initError = null} = {}) {
+    let db = null
+
+    const statements = []
+
+    return {
+        statements,
+        async initAsync() {
+            if (initError) throw new Error(initError)
+
+            db = {
+                ...(rows  && {storage: {db: {prepare(sql) { statements.push(sql); return {all: () => rows} }}}}),
+                ...(items && {nodes  : {items}})
+            }
+        },
+        get db() { return db }
+    }
+}
+
+test.describe('readActiveWakeSubscriptionIdentities — the fleet wake axis bulk read', () => {
+    test('reads DURABLE SQLite truth, not the in-process node cache — the cross-process invariant', async () => {
+        // The cache carries a stale/partial projection; SQLite carries shared truth. A fleet server
+        // in its own process must report the latter, or a subscribed agent renders `off`.
+        const service = graphServiceDouble({
+            rows : [{agentIdentity: '@neo-opus-grace'}, {agentIdentity: '@neo-gpt'}],
+            items: [{label: 'WAKE_SUBSCRIPTION', properties: {status: 'active', agentIdentity: '@stale-cache-only'}}]
+        })
+
+        const identities = await readActiveWakeSubscriptionIdentities({graphService: service})
+
+        expect(identities).toEqual(['@neo-opus-grace', '@neo-gpt'])
+        expect(identities).not.toContain('@stale-cache-only')
+    })
+
+    test('the durable query is scoped to ACTIVE wake subscriptions — the contract, not just the result', async () => {
+        const service = graphServiceDouble({rows: []})
+
+        await readActiveWakeSubscriptionIdentities({graphService: service})
+
+        const [sql] = service.statements
+
+        expect(sql).toContain("json_extract(data, '$.label') = 'WAKE_SUBSCRIPTION'")
+        expect(sql).toContain("COALESCE(json_extract(data, '$.properties.status'), 'active') = 'active'")
+    })
+
+    test('awaits service readiness before reading db — the pre-init read surface is absent by contract', async () => {
+        const service = graphServiceDouble({rows: [{agentIdentity: '@neo-opus-grace'}]})
+
+        expect(service.db).toBe(null)
+
+        await expect(readActiveWakeSubscriptionIdentities({graphService: service})).resolves.toEqual(['@neo-opus-grace'])
+    })
+
+    test('malformed identities are dropped, never emitted as phantom subscribers', async () => {
+        const service = graphServiceDouble({
+            rows: [{agentIdentity: '@neo-opus-grace'}, {agentIdentity: null}, {agentIdentity: ''}, {agentIdentity: 42}]
+        })
+
+        expect(await readActiveWakeSubscriptionIdentities({graphService: service})).toEqual(['@neo-opus-grace'])
+    })
+
+    test('falls back to an injected cache double only when no SQLite handle exists', async () => {
+        const service = graphServiceDouble({
+            items: [
+                {label: 'WAKE_SUBSCRIPTION', properties: {status: 'active', agentIdentity: '@neo-opus-grace'}},
+                {label: 'WAKE_SUBSCRIPTION', properties: {status: 'retired', agentIdentity: '@retired'}},
+                {label: 'WAKE_SUBSCRIPTION', properties: {agentIdentity: '@status-absent-means-active'}},
+                {label: 'AGENT_IDENTITY',    properties: {status: 'active', agentIdentity: '@wrong-label'}}
+            ]
+        })
+
+        expect(await readActiveWakeSubscriptionIdentities({graphService: service}))
+            .toEqual(['@neo-opus-grace', '@status-absent-means-active'])
+    })
+
+    test('an unreachable graph THROWS — the adapter owns the degrade, this module never fabricates an empty fleet', async () => {
+        await expect(readActiveWakeSubscriptionIdentities({graphService: graphServiceDouble({})}))
+            .rejects.toThrow('graph read surface unavailable')
+    })
+
+    test('a failing init propagates — an un-initialised graph is not an empty fleet', async () => {
+        await expect(readActiveWakeSubscriptionIdentities({graphService: graphServiceDouble({initError: 'graph init failed'})}))
+            .rejects.toThrow('graph init failed')
+    })
+})

--- a/test/playwright/unit/ai/services/fleet/readActiveWakeSubscriptionIdentities.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/readActiveWakeSubscriptionIdentities.spec.mjs
@@ -20,9 +20,10 @@ import * as core      from '../../../../../../src/core/_export.mjs'
 import {readActiveWakeSubscriptionIdentities} from '../../../../../../ai/services/fleet/readActiveWakeSubscriptionIdentities.mjs'
 
 /**
- * Models the GraphService contract this reader depends on: `db` does NOT exist until `initAsync()`
- * resolves. A reader that skips the await sees `undefined` and cannot reach either surface — which
- * is exactly the defect these specs pin.
+ * Models the `core.Base` contract this reader depends on: `db` does NOT exist until async init has
+ * settled, and `ready()` is the only sanctioned external wait — `initAsync()` is framework-triggered
+ * and running it from outside would execute it twice. The double therefore exposes `ready()` ONLY,
+ * so a reader that reaches for `initAsync()` fails loud here instead of duplicating init in prod.
  */
 function graphServiceDouble({rows = null, items = null, initError = null} = {}) {
     let db = null
@@ -31,7 +32,7 @@ function graphServiceDouble({rows = null, items = null, initError = null} = {}) 
 
     return {
         statements,
-        async initAsync() {
+        async ready() {
             if (initError) throw new Error(initError)
 
             db = {
@@ -75,6 +76,21 @@ test.describe('readActiveWakeSubscriptionIdentities — the fleet wake axis bulk
         expect(service.db).toBe(null)
 
         await expect(readActiveWakeSubscriptionIdentities({graphService: service})).resolves.toEqual(['@neo-opus-grace'])
+    })
+
+    test('waits via ready(), NEVER initAsync() — the framework already ran it; a second run duplicates init', async () => {
+        // `core.Base`: initAsync is triggered during Neo.create(). Awaiting it from a consumer runs
+        // it twice — a fatal-duplication class the guard inside GraphService would quietly absorb,
+        // which is precisely why this needs a pin rather than a passing test.
+        const service = graphServiceDouble({rows: [{agentIdentity: '@neo-opus-grace'}]})
+
+        let initAsyncCalls = 0
+
+        service.initAsync = async () => { initAsyncCalls++ }
+
+        await readActiveWakeSubscriptionIdentities({graphService: service})
+
+        expect(initAsyncCalls).toBe(0)
     })
 
     test('malformed identities are dropped, never emitted as phantom subscribers', async () => {


### PR DESCRIPTION
Resolves #15271

The wake axis of the S2 telltale taxonomy, produced from pure observation: `fleetWakeStateAdapter.mjs` (sibling-pattern of `fleetA2AActivityAdapter` — dependency-injected read paths, degraded-capability envelope, bounded DTOs) maps wake-subscription intent × wake-daemon liveness onto the graduated four states, and `FleetManager.fleetWakeStatus()` exposes it turnkey across the registered roster — the third fleet view beside `fleetRepoStatus` (repos) and `fleetRuntimeStatus` (processes).

Truth sources, as designed on the ticket (comment 4994172810): subscription intent through an injected reader (the caller owns identity binding — `WakeSubscriptionService.list()` is caller-identity-bound, so the composing entrypoint provides the read path); daemon liveness from the wake daemon's exclusive-create PID file + a `process.kill(pid, 0)` probe (ESRCH ⇒ observed-dead stale file; EPERM ⇒ alive). The rejected mtime alternative is documented at the module: the watermark advances only on delivery activity, so a quiet fleet is indistinguishable from a dead daemon by file freshness. Control intent (`setWakeEnabled`, #14537) is never consulted — the verb mutates state this producer independently observes.

The mapping is the registry contract verbatim: no subscription → `off` (observed) · subscribed + daemon alive → `on` · subscribed + daemon dead → `suppressed` (intent on, delivery off — the operator's hand-disabled-daemon incident class) · any unreadable source → `unknown` with the reason, under a capability envelope that distinguishes `wired/observed`, `degraded/partial` (one source), and `degraded/none` — "we cannot see" never renders as "the fleet is off".

Evidence: L3 achieved (full unit coverage incl. every taxonomy state and the unknown-on-unreachable AC path; the A1 lint green over the new file) → L3 required (the close-target ACs are producer-contract claims, all mechanically provable). Residual: none — the live composition (entrypoint injecting the real WSS reader + config-resolved PID path) belongs to the consuming surface leaf per the ticket's Out of Scope.

## Deltas from ticket

- None substantive. One ADR-0019 consequence made explicit: the adapter and `FleetManager` are non-entrypoints, so neither resolves the PID path from config — `wakeStateOptions` is an injected plain-field seam (sibling of `lifecycleService`/`repoStatusFn`), and the honest default (nothing injected) is every-row-`unknown` under `degraded/none`, never a guessed state.
- Cycle-1 (the unified three-cluster contract, head `bb791bad5c`): the trusted Brain-side observation source (`readActiveWakeSubscriptionIdentities` — one administrative bulk scan, the caller-owner API never impersonated) + the production entrypoint wiring (`devFleetServer`: config-resolved PID path + the scan) + the `fleetRoster()` join (`createFleetCockpitStatus` gains the `wakeStatus` dimension: per-row four-state `wake`, `sources.wake`, `capabilities.wake`, tri-state honest like `lifecycle`); daemon liveness now verifies PROCESS IDENTITY against the launch marker (PID reuse reads observed-dead-named); diagnostics are row-local, redacted before Body projection, and out-of-contract reader values degrade the capability. #15271's Contract Ledger backfilled on the ticket.

## Test Evidence

- `npx playwright test --config=test/playwright/playwright.config.mjs fleetWakeStateAdapter FleetManager.spec` — **39 passed** (15 new adapter specs: PID-liveness matrix incl. stale-ESRCH/EPERM/malformed/unconfigured, the full four-state truth table, snapshot envelope semantics for both-ok/partial/none, throwing-reader degradation, row hygiene; 2 new `FleetManager.fleetWakeStatus` wiring specs: injected-sources composition + the honest-unknown default; 22 pre-existing FleetManager specs untouched-green).
- `node buildScripts/util/check-aiconfig-antipatterns.mjs` — **534 `ai/` files scanned, 0 new violations** (the new adapter passes the A1/B3/A5 lint merged this hour).
- Directly touched surfaces: `ai/services/fleet/` adapter + facade + their specs; no app/UI surface touched (the telltale render is #15273's leaf).
- Cycle-1 head `bb791bad5c`: full fleet directory **189/189** (the repair matrix: PID-reuse + identity-unreadable, three-agent row-local isolation, out-of-contract capability degradation, `glpat-` redaction, bulk-scan single-call + failing-scan honesty, roster-join + not-wired defaults across bridge/cockpit specs).

## Post-Merge Validation

- [ ] The composing entrypoint (fleet bridge/dev server) injects `wakeStateOptions` and the cockpit's S2 wake axis leaves `unknown` on a live fleet — the consuming leaf's (#15273) integration proof.

## Review routing note

Cross-family primary on CI-green per the family rule (Emmy holds #15273 intake — reviewing its producer is natural adjacency; Euclid holds #15266 terminal). Sibling leaf #15272 (throttle axis) follows on this lane; #14537 (the control verb) lands separately per the read/write independence rule.

Authored by Grace (Claude Fable 5, Claude Code). Session f7a6fdb7-8667-45d2-8d43-cbd3f16c6027.

