### PR TITLE
feat(fleet): viewer-admitted per-agent mailbox mirror adapter — the S1 Brain half (#15269)

### DIFF
--- a/ai/services/fleet/fleetMailboxMirrorAdapter.mjs
+++ b/ai/services/fleet/fleetMailboxMirrorAdapter.mjs
@@ -1,20 +1,32 @@
-import {FLEET_COCKPIT_SOURCES} from '../../../src/ai/fleet/fleetCockpitStatus.mjs'
+import {FLEET_COCKPIT_SOURCES}        from '../../../src/ai/fleet/fleetCockpitStatus.mjs'
+import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs'
 
 /**
  * @module ai/services/fleet/fleetMailboxMirrorAdapter
  * @summary Read-only, viewer-admitted per-agent A2A mailbox mirror for the Fleet cockpit — the S1
- * Brain half: `{viewerIdentity, subjectAgentId, limit, offset}` → immutable message rows
- * (timestamped facts) + thread metadata.
+ * Brain half: `{subjectAgentId, limit, offset}` read under a bound request identity → immutable
+ * message rows (timestamped facts) + thread metadata.
  *
  * **Admission is the primitive's, never re-implemented here.** The adapter consumes an injected
- * MailboxService-compatible `listMessages()` read path whose session binding IS the viewer — passing
+ * MailboxService-compatible `listMessages()` read path whose request binding IS the viewer — passing
  * `to: subjectAgentId` makes the service's own fail-closed `CAN_READ_INBOX_OF` gate decide the
  * cross-read. A missing grant surfaces as an explicit `admission.state: 'denied'` snapshot carrying
- * the service's honest error — never an empty-success. The `viewerIdentity` parameter is the
- * auditable mapping fact (who is looking, canonicalized), not an enforcement input: the wiring owns
- * the identity binding, exactly like the sibling activity adapter's DI contract. An agent reading
- * its OWN inbox stays on the existing `list_messages` path untouched — this mirror exists for the
- * operator/control-plane viewer ≠ subject case.
+ * the service's honest error — never an empty-success. An agent reading its OWN inbox stays on the
+ * existing `list_messages` path untouched — this mirror exists for the operator/control-plane
+ * viewer ≠ subject case.
+ *
+ * **The audit viewer is derived, never asserted.** `admission.viewerIdentity` is read from
+ * `resolveBoundIdentity()` — the same trusted request binding the read executes under
+ * (`RequestContextService.getAgentIdentityNodeId()` in production wiring). A caller-supplied label
+ * beside a separately-bound permission check is provenance, not admission evidence: it lets the
+ * snapshot claim "viewer A was granted" when viewer B's bound service actually performed the read.
+ * An optional `viewerIdentity` is therefore an *assertion* that is verified against the binding and
+ * refuses the read on mismatch; with no binding resolvable, no admission claim is made at all.
+ *
+ * **The subject is one direct agent.** `AGENT:*` and other namespace pseudo-targets are rejected
+ * before any read: `MailboxService.listMessages` deliberately skips `CAN_READ_INBOX_OF` for the
+ * broadcast sentinel, so forwarding one would let this surface report `granted` for a target that
+ * was never admission-checked.
  *
  * **Structurally read-only.** The module exports read/projection functions only: no markRead, no
  * archive, no mutation verb exists on this surface — operator-side mark-read would mutate the
@@ -30,7 +42,13 @@ import {FLEET_COCKPIT_SOURCES} from '../../../src/ai/fleet/fleetCockpitStatus.mj
 export const DEFAULT_FLEET_MAILBOX_MIRROR_LIMIT = 50
 export const MAX_FLEET_MAILBOX_MIRROR_LIMIT     = 200
 
-const ADMISSION_DENIED_RE = /\bCAN_READ_INBOX_OF\b|\bUnauthorized\b/
+/**
+ * The scope whose specific failure — for the specific subject — is the ONLY thing this surface
+ * reports as `denied`. Matching bare `Unauthorized` would misclassify any unrelated authorization
+ * failure as the named admission decision.
+ * @type {String}
+ */
+const ADMISSION_SCOPE = 'CAN_READ_INBOX_OF'
 
 /**
  * @summary Read one agent's active inbox through a viewer-bound Memory Core read path and map it
@@ -38,10 +56,14 @@ const ADMISSION_DENIED_RE = /\bCAN_READ_INBOX_OF\b|\bUnauthorized\b/
  * @param {Object} options={}
  * @param {Object} [options.mailboxService] Service exposing `listMessages(args)`.
  * @param {Function} [options.listMessages] Direct `listMessages(args)` override for tests/callers —
- *     MUST be bound to the VIEWER identity (the wiring owns identity binding + read permissions).
- * @param {String} options.viewerIdentity Canonical viewer identity (`@`-form accepted) — the
- *     auditable who-is-looking fact carried on the snapshot's admission block.
- * @param {String} options.subjectAgentId Canonical subject-agent identity whose inbox is mirrored.
+ *     MUST execute under the same request identity `resolveBoundIdentity` reports.
+ * @param {Function} [options.resolveBoundIdentity] Returns the identity the read executes under —
+ *     production wiring passes `() => RequestContextService.getAgentIdentityNodeId()`. Its result is
+ *     the audit viewer. Without it no admission claim can be made and the snapshot degrades.
+ * @param {String} [options.viewerIdentity] OPTIONAL viewer assertion, verified against the bound
+ *     identity. A mismatch refuses the read; it never overrides the binding on the audit fact.
+ * @param {String} options.subjectAgentId Direct subject-agent identity whose inbox is mirrored
+ *     (`@`-form accepted). Namespace pseudo-targets such as `AGENT:*` are rejected.
  * @param {Number} [options.limit] Page size; clamped to `[1, MAX_FLEET_MAILBOX_MIRROR_LIMIT]`.
  * @param {Number} [options.offset] Pagination offset; clamped to `>= 0`.
  * @param {Date|String} [options.capturedAt] Capture timestamp.
@@ -50,6 +72,7 @@ const ADMISSION_DENIED_RE = /\bCAN_READ_INBOX_OF\b|\bUnauthorized\b/
 export async function readFleetMailboxMirror({
     mailboxService = null,
     listMessages = null,
+    resolveBoundIdentity = null,
     viewerIdentity = null,
     subjectAgentId = null,
     limit = DEFAULT_FLEET_MAILBOX_MIRROR_LIMIT,
@@ -58,14 +81,38 @@ export async function readFleetMailboxMirror({
 } = {}) {
     const
         readMessages = listMessages || mailboxService?.listMessages?.bind(mailboxService),
-        viewer       = normalizeIdentity(viewerIdentity),
-        subject      = normalizeIdentity(subjectAgentId),
+        viewer       = normalizeDirectAgentIdentity(resolveBoundIdentity?.()),
+        asserted     = normalizeDirectAgentIdentity(viewerIdentity),
+        subject      = normalizeDirectAgentIdentity(subjectAgentId),
         page         = {limit: normalizeLimit(limit), offset: normalizeOffset(offset)}
 
-    if (!viewer || !subject) {
+    if (!subject) {
         return createFleetMailboxMirrorSnapshot({
             capturedAt,
-            error: 'mailbox mirror requires canonical viewerIdentity and subjectAgentId',
+            error: 'mailbox mirror requires one direct subjectAgentId — namespace targets are not admissible',
+            page,
+            subject,
+            viewer
+        })
+    }
+
+    // No binding → the snapshot cannot say who was admitted, so it does not claim admission at all.
+    if (!viewer) {
+        return createFleetMailboxMirrorSnapshot({
+            capturedAt,
+            error: 'mailbox mirror requires a bound request identity to attribute admission',
+            page,
+            subject,
+            viewer
+        })
+    }
+
+    // A caller claiming an identity other than the one the read runs under is refused BEFORE the
+    // read: the returned rows would be the bound viewer's, attributed to someone else.
+    if (asserted && asserted !== viewer) {
+        return createFleetMailboxMirrorSnapshot({
+            capturedAt,
+            error: 'asserted viewerIdentity does not match the bound request identity',
             page,
             subject,
             viewer
@@ -114,13 +161,14 @@ export async function readFleetMailboxMirror({
  * @summary Build the immutable mirror snapshot from already-read mailbox summaries (pure half).
  * @param {Object} options={}
  * @param {Object[]} [options.messages] Message summaries from `MailboxService.listMessages()`.
- * @param {Error|String|null} [options.error] Read failure — an admission denial (the service's
- *     fail-closed `CAN_READ_INBOX_OF` throw) maps to `admission.state: 'denied'`; anything else
- *     degrades as a source error. Never an empty-success.
+ * @param {Error|String|null} [options.error] Read failure — the service's fail-closed
+ *     `CAN_READ_INBOX_OF` throw FOR THIS SUBJECT maps to `admission.state: 'denied'`; every other
+ *     failure degrades as `'unavailable'`. Never an empty-success.
  * @param {Date|String} [options.capturedAt] Capture timestamp.
  * @param {{limit: Number, offset: Number}} [options.page] Echoed pagination bounds.
- * @param {String|null} [options.viewer] Canonical viewer identity.
- * @param {String|null} [options.subject] Canonical subject-agent identity.
+ * @param {String|null} [options.viewer] Canonical viewer identity — the identity the read was bound
+ *     to, never a caller-supplied label.
+ * @param {String|null} [options.subject] Canonical direct subject-agent identity.
  * @returns {{capability: Object, admission: Object, rows: Object[], page: Object}}
  */
 export function createFleetMailboxMirrorSnapshot({
@@ -136,7 +184,7 @@ export function createFleetMailboxMirrorSnapshot({
     if (error) {
         const
             reason = normalizeError(error),
-            denied = ADMISSION_DENIED_RE.test(reason)
+            denied = isSubjectAdmissionDenial(reason, subject)
 
         return Object.freeze({
             capability: createMirrorCapability({
@@ -235,18 +283,54 @@ function getRecipientClass(to) {
 }
 
 /**
- * @summary Canonicalize an identity to the graph's `@`-prefixed node-id form.
- * @param {String|null} value Raw identity (`neo-x` and `@neo-x` both accepted).
+ * @summary Classify a read failure as THIS subject's admission denial.
+ *
+ * `MailboxService.listMessages` throws `Unauthorized: no CAN_READ_INBOX_OF permission for <target>`.
+ * Matching the scope AND the subject keeps an unrelated authorization failure (an expired token, a
+ * different scope, another target) from being reported as this subject's admission decision.
+ * @param {String} reason Normalized failure reason.
+ * @param {String|null} subject Canonical direct subject identity.
+ * @returns {Boolean}
+ * @private
+ */
+function isSubjectAdmissionDenial(reason, subject) {
+    if (!subject) return false
+
+    return reason.includes(`no ${ADMISSION_SCOPE} permission for ${subject}`)
+}
+
+/**
+ * @summary Canonicalize a DIRECT AgentIdentity, rejecting namespace pseudo-targets.
+ *
+ * Delegates the `@`-form canonicalization to the graph primitive, then enforces what this surface
+ * additionally requires: exactly one direct agent. The primitive deliberately returns namespace
+ * forms (`AGENT:*`, `role:*`, `human:*`) unchanged — those are addressing schemes, and for this
+ * adapter they are inadmissible rather than merely unnormalized.
+ * @param {*} value Raw identity (`neo-x` and `@neo-x` both accepted).
+ * @returns {String|null} Canonical `@<identity>`, or null when not a direct agent identity.
+ * @private
+ */
+function normalizeDirectAgentIdentity(value) {
+    const normalized = normalizeAgentIdentityNodeId(value)
+
+    if (typeof normalized !== 'string') return null
+    if (!normalized.startsWith('@'))    return null  // AGENT:*, role:*, and other schemes
+    if (normalized.includes(':'))       return null  // '@ns:x' — scheme smuggled behind an @
+    if (normalized === '@')             return null  // '@' / '@@' collapse to a nameless identity
+
+    return normalized
+}
+
+/**
+ * @summary Canonicalize an identity for row DISPLAY (sender), where any addressing form is honest.
+ * @param {*} value Raw identity.
  * @returns {String|null}
+ * @private
  */
 function normalizeIdentity(value) {
-    if (typeof value !== 'string') return null
+    if (typeof value !== 'string' || !value.trim()) return null
 
-    const trimmed = value.trim()
-    if (!trimmed) return null
-    if (trimmed === 'AGENT:*') return trimmed
-
-    return trimmed.startsWith('@') ? trimmed : `@${trimmed}`
+    return normalizeAgentIdentityNodeId(value)
 }
 
 function normalizeSubject(subject) {
@@ -280,10 +364,26 @@ function normalizeError(error) {
     return redactSecretText(String(error?.message || error || 'source unavailable')).replace(/\s+/g, ' ').slice(0, 240)
 }
 
+/**
+ * @summary Strip credentials from text that crosses into the Body-facing snapshot.
+ *
+ * Subjects and failure reasons are peer/service-authored strings this surface republishes to the
+ * cockpit, so redaction is the last boundary before a secret becomes operator-visible UI.
+ *
+ * Rule order is load-bearing: the scheme rule must run BEFORE the `key: value` rule, or
+ * `Authorization: Bearer hunter2` matches `authorization` first, stops at the space after `Bearer`,
+ * and republishes `hunter2` intact. Prefix rules cover the credential families this repository
+ * actually handles — GitHub (`GH_TOKEN`) and GitLab (`GITLAB_PAT`) — plus the `Bearer` header form.
+ * @param {String} text Untrusted text.
+ * @returns {String}
+ * @private
+ */
 function redactSecretText(text) {
     return text
-        .replace(/\b(token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
+        .replace(/\b(?:authorization\s*[:=]\s*)?bearer\s+[^\s,;)]+/gi, 'authorization=[redacted]')
+        .replace(/\b(authorization|token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
         .replace(/\bgh[pousr]_[A-Za-z0-9_]+/g, '[redacted-token]')
+        .replace(/\bglpat-[A-Za-z0-9_-]+/g, '[redacted-token]')
 }
 
 function toIsoString(value, fallback = new Date()) {

--- a/ai/services/fleet/fleetMailboxMirrorAdapter.mjs
+++ b/ai/services/fleet/fleetMailboxMirrorAdapter.mjs
@@ -1,0 +1,299 @@
+import {FLEET_COCKPIT_SOURCES} from '../../../src/ai/fleet/fleetCockpitStatus.mjs'
+
+/**
+ * @module ai/services/fleet/fleetMailboxMirrorAdapter
+ * @summary Read-only, viewer-admitted per-agent A2A mailbox mirror for the Fleet cockpit — the S1
+ * Brain half: `{viewerIdentity, subjectAgentId, limit, offset}` → immutable message rows
+ * (timestamped facts) + thread metadata.
+ *
+ * **Admission is the primitive's, never re-implemented here.** The adapter consumes an injected
+ * MailboxService-compatible `listMessages()` read path whose session binding IS the viewer — passing
+ * `to: subjectAgentId` makes the service's own fail-closed `CAN_READ_INBOX_OF` gate decide the
+ * cross-read. A missing grant surfaces as an explicit `admission.state: 'denied'` snapshot carrying
+ * the service's honest error — never an empty-success. The `viewerIdentity` parameter is the
+ * auditable mapping fact (who is looking, canonicalized), not an enforcement input: the wiring owns
+ * the identity binding, exactly like the sibling activity adapter's DI contract. An agent reading
+ * its OWN inbox stays on the existing `list_messages` path untouched — this mirror exists for the
+ * operator/control-plane viewer ≠ subject case.
+ *
+ * **Structurally read-only.** The module exports read/projection functions only: no markRead, no
+ * archive, no mutation verb exists on this surface — operator-side mark-read would mutate the
+ * agent's own turn-start signal and silently swallow peer handoffs (the graduated record's
+ * MUST-NOT). The active/non-archived inbox is likewise structural: the adapter never forwards an
+ * `includeArchived` key, so the service default (exclude archived) always governs; archive browsing
+ * is out of scope by design.
+ *
+ * Rows are frozen summary facts (subject, sender, recipient class, priority, read status,
+ * timestamps, `partOfThread` thread metadata, related tickets) — never full message bodies.
+ */
+
+export const DEFAULT_FLEET_MAILBOX_MIRROR_LIMIT = 50
+export const MAX_FLEET_MAILBOX_MIRROR_LIMIT     = 200
+
+const ADMISSION_DENIED_RE = /\bCAN_READ_INBOX_OF\b|\bUnauthorized\b/
+
+/**
+ * @summary Read one agent's active inbox through a viewer-bound Memory Core read path and map it
+ * into an immutable, auditable cockpit mirror snapshot.
+ * @param {Object} options={}
+ * @param {Object} [options.mailboxService] Service exposing `listMessages(args)`.
+ * @param {Function} [options.listMessages] Direct `listMessages(args)` override for tests/callers —
+ *     MUST be bound to the VIEWER identity (the wiring owns identity binding + read permissions).
+ * @param {String} options.viewerIdentity Canonical viewer identity (`@`-form accepted) — the
+ *     auditable who-is-looking fact carried on the snapshot's admission block.
+ * @param {String} options.subjectAgentId Canonical subject-agent identity whose inbox is mirrored.
+ * @param {Number} [options.limit] Page size; clamped to `[1, MAX_FLEET_MAILBOX_MIRROR_LIMIT]`.
+ * @param {Number} [options.offset] Pagination offset; clamped to `>= 0`.
+ * @param {Date|String} [options.capturedAt] Capture timestamp.
+ * @returns {Promise<{capability: Object, admission: Object, rows: Object[], page: Object}>}
+ */
+export async function readFleetMailboxMirror({
+    mailboxService = null,
+    listMessages = null,
+    viewerIdentity = null,
+    subjectAgentId = null,
+    limit = DEFAULT_FLEET_MAILBOX_MIRROR_LIMIT,
+    offset = 0,
+    capturedAt = new Date()
+} = {}) {
+    const
+        readMessages = listMessages || mailboxService?.listMessages?.bind(mailboxService),
+        viewer       = normalizeIdentity(viewerIdentity),
+        subject      = normalizeIdentity(subjectAgentId),
+        page         = {limit: normalizeLimit(limit), offset: normalizeOffset(offset)}
+
+    if (!viewer || !subject) {
+        return createFleetMailboxMirrorSnapshot({
+            capturedAt,
+            error: 'mailbox mirror requires canonical viewerIdentity and subjectAgentId',
+            page,
+            subject,
+            viewer
+        })
+    }
+
+    if (!readMessages) {
+        return createFleetMailboxMirrorSnapshot({
+            capturedAt,
+            error: 'Memory Core mailbox read path unavailable',
+            page,
+            subject,
+            viewer
+        })
+    }
+
+    try {
+        // Deliberately NO `includeArchived` key: the service default (active inbox) always governs.
+        const result = await readMessages({
+            box   : 'inbox',
+            status: 'all',
+            to    : subject,
+            limit : page.limit,
+            offset: page.offset
+        })
+
+        return createFleetMailboxMirrorSnapshot({
+            capturedAt,
+            messages: result?.messages || [],
+            page,
+            subject,
+            viewer
+        })
+    } catch (error) {
+        return createFleetMailboxMirrorSnapshot({
+            capturedAt,
+            error,
+            page,
+            subject,
+            viewer
+        })
+    }
+}
+
+/**
+ * @summary Build the immutable mirror snapshot from already-read mailbox summaries (pure half).
+ * @param {Object} options={}
+ * @param {Object[]} [options.messages] Message summaries from `MailboxService.listMessages()`.
+ * @param {Error|String|null} [options.error] Read failure — an admission denial (the service's
+ *     fail-closed `CAN_READ_INBOX_OF` throw) maps to `admission.state: 'denied'`; anything else
+ *     degrades as a source error. Never an empty-success.
+ * @param {Date|String} [options.capturedAt] Capture timestamp.
+ * @param {{limit: Number, offset: Number}} [options.page] Echoed pagination bounds.
+ * @param {String|null} [options.viewer] Canonical viewer identity.
+ * @param {String|null} [options.subject] Canonical subject-agent identity.
+ * @returns {{capability: Object, admission: Object, rows: Object[], page: Object}}
+ */
+export function createFleetMailboxMirrorSnapshot({
+    messages = [],
+    error = null,
+    capturedAt = new Date(),
+    page = {limit: DEFAULT_FLEET_MAILBOX_MIRROR_LIMIT, offset: 0},
+    viewer = null,
+    subject = null
+} = {}) {
+    const observedAt = toIsoString(capturedAt)
+
+    if (error) {
+        const
+            reason = normalizeError(error),
+            denied = ADMISSION_DENIED_RE.test(reason)
+
+        return Object.freeze({
+            capability: createMirrorCapability({
+                capturedAt: observedAt,
+                confidence: 'none',
+                reason,
+                state     : 'degraded'
+            }),
+            admission: createAdmissionFact({
+                checkedAt: observedAt,
+                reason,
+                state    : denied ? 'denied' : 'unavailable',
+                subject,
+                viewer
+            }),
+            rows: Object.freeze([]),
+            page: Object.freeze({...page, count: 0})
+        })
+    }
+
+    const rows = Object.freeze(asArray(messages).filter(Boolean).map(message => createMirrorRow(message, observedAt)))
+
+    return Object.freeze({
+        capability: createMirrorCapability({
+            capturedAt: observedAt,
+            confidence: 'observed',
+            state     : 'wired'
+        }),
+        admission: createAdmissionFact({
+            checkedAt: observedAt,
+            state    : 'granted',
+            subject,
+            viewer
+        }),
+        rows,
+        page: Object.freeze({...page, count: rows.length})
+    })
+}
+
+/**
+ * @summary Project one mailbox summary into a frozen, body-free mirror row (timestamped fact).
+ * @param {Object} message Mailbox summary from `MailboxService.listMessages()`.
+ * @param {String} observedAt Fallback ISO timestamp.
+ * @returns {Object}
+ */
+function createMirrorRow(message, observedAt) {
+    return Object.freeze({
+        messageId     : typeof message.messageId === 'string' ? message.messageId : null,
+        subject       : normalizeSubject(message.subject),
+        from          : normalizeIdentity(message.from),
+        recipientClass: getRecipientClass(message.to),
+        priority      : message.priority || null,
+        status        : getMessageStatus(message),
+        taskState     : message.task?.state || null,
+        partOfThread  : typeof message.partOfThread === 'string' ? message.partOfThread : null,
+        relatedTickets: normalizeRelatedTickets(message.relatedTickets),
+        wakeSuppressed: Boolean(message.wakeSuppressed),
+        sentAt        : toIsoString(message.sentAt || message.createdAt, observedAt),
+        readAt        : message.readAt ? toIsoString(message.readAt, observedAt) : null
+    })
+}
+
+function createMirrorCapability({capturedAt, confidence, reason = null, state}) {
+    return Object.freeze({
+        source: FLEET_COCKPIT_SOURCES.a2a,
+        state,
+        confidence,
+        capturedAt,
+        reason
+    })
+}
+
+function createAdmissionFact({checkedAt, reason = null, state, subject, viewer}) {
+    return Object.freeze({
+        state,
+        viewerIdentity: viewer,
+        subjectAgentId: subject,
+        checkedAt,
+        reason
+    })
+}
+
+function getMessageStatus(message) {
+    if (message.retracted) return 'retracted'
+    if (message.readAt) return 'read'
+
+    return 'unread'
+}
+
+function getRecipientClass(to) {
+    if (!to) return 'unknown'
+    if (to === 'AGENT:*') return 'broadcast'
+    if (String(to).startsWith('@')) return 'agent'
+
+    return 'other'
+}
+
+/**
+ * @summary Canonicalize an identity to the graph's `@`-prefixed node-id form.
+ * @param {String|null} value Raw identity (`neo-x` and `@neo-x` both accepted).
+ * @returns {String|null}
+ */
+function normalizeIdentity(value) {
+    if (typeof value !== 'string') return null
+
+    const trimmed = value.trim()
+    if (!trimmed) return null
+    if (trimmed === 'AGENT:*') return trimmed
+
+    return trimmed.startsWith('@') ? trimmed : `@${trimmed}`
+}
+
+function normalizeSubject(subject) {
+    if (!subject) return null
+
+    return redactSecretText(String(subject).replace(/\s+/g, ' ').trim()).slice(0, 180)
+}
+
+function normalizeRelatedTickets(values = []) {
+    return Object.freeze(asArray(values)
+        .map(value => Number(String(value).replace(/^#/, '')))
+        .filter(value => Number.isSafeInteger(value) && value > 0)
+        .sort((a, b) => a - b))
+}
+
+function normalizeLimit(value) {
+    const limit = Number(value)
+
+    if (!Number.isFinite(limit)) return DEFAULT_FLEET_MAILBOX_MIRROR_LIMIT
+
+    return Math.min(MAX_FLEET_MAILBOX_MIRROR_LIMIT, Math.max(1, Math.trunc(limit)))
+}
+
+function normalizeOffset(value) {
+    const offset = Number(value)
+
+    return Number.isFinite(offset) ? Math.max(0, Math.trunc(offset)) : 0
+}
+
+function normalizeError(error) {
+    return redactSecretText(String(error?.message || error || 'source unavailable')).replace(/\s+/g, ' ').slice(0, 240)
+}
+
+function redactSecretText(text) {
+    return text
+        .replace(/\b(token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
+        .replace(/\bgh[pousr]_[A-Za-z0-9_]+/g, '[redacted-token]')
+}
+
+function toIsoString(value, fallback = new Date()) {
+    const date = value instanceof Date ? value : new Date(value)
+    if (!Number.isNaN(date.getTime())) return date.toISOString()
+
+    const fallbackDate = fallback instanceof Date ? fallback : new Date(fallback)
+    return fallbackDate.toISOString()
+}
+
+function asArray(value) {
+    return Array.isArray(value) ? value : []
+}

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1875,6 +1875,10 @@ class MailboxService extends Base {
                     };
                     if (messageNode.properties.task !== undefined) summary.task = messageNode.properties.task;
                     if (messageNode.properties.wakeSuppressed) summary.wakeSuppressed = true;
+                    // Thread membership is graph state (the PART_OF_THREAD edge), already resolved
+                    // above for the `threadId` filter. Project it so callers can group a thread
+                    // without re-walking edges — consumers that only filtered by it never saw it.
+                    if (foundThreadId) summary.partOfThread = foundThreadId;
                     const relatedTickets = getRelatedTicketsForMessage(db, messageNode.id, messageNode);
                     if (relatedTickets.length > 0) {
                         summary.relatedTickets = relatedTickets;

--- a/test/playwright/unit/ai/services/fleet/fleetMailboxMirrorAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetMailboxMirrorAdapter.spec.mjs
@@ -1,0 +1,238 @@
+import {setup} from '../../../../setup.mjs'
+
+const appName = 'FleetMailboxMirrorAdapterTest'
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+})
+
+import {test, expect} from '@playwright/test'
+import Neo            from '../../../../../../src/Neo.mjs'
+import * as core      from '../../../../../../src/core/_export.mjs'
+
+import * as adapterModule from '../../../../../../ai/services/fleet/fleetMailboxMirrorAdapter.mjs'
+import {
+    createFleetMailboxMirrorSnapshot,
+    DEFAULT_FLEET_MAILBOX_MIRROR_LIMIT,
+    MAX_FLEET_MAILBOX_MIRROR_LIMIT,
+    readFleetMailboxMirror
+} from '../../../../../../ai/services/fleet/fleetMailboxMirrorAdapter.mjs'
+import {FLEET_COCKPIT_SOURCES} from '../../../../../../src/ai/fleet/fleetCockpitStatus.mjs'
+
+const CAPTURED_AT = '2026-07-16T12:00:00.000Z'
+
+/**
+ * The S1 Brain half: viewer-admitted, read-only per-agent mailbox mirror. Admission enforcement is
+ * the MailboxService primitive's own CAN_READ_INBOX_OF gate — these specs pin the adapter's honest
+ * projection of grant, denial, and degradation, plus the structural boundaries (no mutation verbs,
+ * no archive exposure) the graduated record marks MUST-NOT.
+ */
+test.describe('fleetMailboxMirrorAdapter — viewer-admitted per-agent mailbox mirror', () => {
+    test('grants: projects summaries into frozen, body-free rows with thread metadata + audit fact', async () => {
+        const calls    = []
+        const snapshot = await readFleetMailboxMirror({
+            capturedAt    : CAPTURED_AT,
+            viewerIdentity: 'tobiu',
+            subjectAgentId: '@neo-opus-vega',
+            listMessages  : async args => {
+                calls.push(args)
+                return {messages: [{
+                    messageId     : 'MESSAGE:abc',
+                    subject       : '[review-queue] both heads unchanged',
+                    from          : '@neo-gpt-emmy',
+                    to            : '@neo-opus-vega',
+                    priority      : 'high',
+                    partOfThread  : 'THREAD:15238',
+                    relatedTickets: ['#15238', '#15233'],
+                    sentAt        : '2026-07-16T11:00:00.000Z',
+                    readAt        : null,
+                    body          : 'FULL BODY MUST NOT LEAK',
+                    task          : {state: 'Submitted'}
+                }]}
+            }
+        })
+
+        expect(snapshot.admission).toEqual({
+            state         : 'granted',
+            viewerIdentity: '@tobiu',
+            subjectAgentId: '@neo-opus-vega',
+            checkedAt     : CAPTURED_AT,
+            reason        : null
+        })
+        expect(snapshot.capability.state).toBe('wired')
+        expect(snapshot.capability.source).toBe(FLEET_COCKPIT_SOURCES.a2a)
+        expect(snapshot.page).toEqual({limit: DEFAULT_FLEET_MAILBOX_MIRROR_LIMIT, offset: 0, count: 1})
+
+        const [row] = snapshot.rows
+        expect(row.subject).toBe('[review-queue] both heads unchanged')
+        expect(row.from).toBe('@neo-gpt-emmy')
+        expect(row.recipientClass).toBe('agent')
+        expect(row.partOfThread).toBe('THREAD:15238')
+        expect(row.relatedTickets).toEqual([15233, 15238])
+        expect(row.status).toBe('unread')
+        expect(row.taskState).toBe('Submitted')
+        expect(row.sentAt).toBe('2026-07-16T11:00:00.000Z')
+        // body-free by construction: no row key carries message content
+        expect(Object.keys(row)).not.toContain('body')
+
+        // immutable rows — timestamped facts, not live views
+        expect(Object.isFrozen(snapshot)).toBe(true)
+        expect(Object.isFrozen(snapshot.rows)).toBe(true)
+        expect(Object.isFrozen(row)).toBe(true)
+        expect(() => { row.subject = 'mutated' }).toThrow()
+
+        // the read call is the subject's inbox through the viewer-bound path
+        expect(calls).toHaveLength(1)
+        expect(calls[0].to).toBe('@neo-opus-vega')
+        expect(calls[0].box).toBe('inbox')
+    })
+
+    test('admission fail-closed: the primitive CAN_READ_INBOX_OF throw maps to an explicit denial, never empty-success', async () => {
+        const snapshot = await readFleetMailboxMirror({
+            capturedAt    : CAPTURED_AT,
+            viewerIdentity: '@neo-observer',
+            subjectAgentId: '@neo-opus-vega',
+            listMessages  : async () => {
+                throw new Error('Unauthorized: no CAN_READ_INBOX_OF permission for @neo-opus-vega')
+            }
+        })
+
+        expect(snapshot.admission.state).toBe('denied')
+        expect(snapshot.admission.viewerIdentity).toBe('@neo-observer')
+        expect(snapshot.admission.subjectAgentId).toBe('@neo-opus-vega')
+        expect(snapshot.admission.reason).toContain('CAN_READ_INBOX_OF')
+        expect(snapshot.admission.checkedAt).toBe(CAPTURED_AT)
+        expect(snapshot.capability.state).toBe('degraded')
+        expect(snapshot.rows).toEqual([])
+        expect(snapshot.page.count).toBe(0)
+    })
+
+    test('non-admission source failures degrade honestly as unavailable (distinct from denial)', async () => {
+        const snapshot = await readFleetMailboxMirror({
+            capturedAt    : CAPTURED_AT,
+            viewerIdentity: '@tobiu',
+            subjectAgentId: '@neo-opus-vega',
+            listMessages  : async () => { throw new Error('database not initialized') }
+        })
+
+        expect(snapshot.admission.state).toBe('unavailable')
+        expect(snapshot.capability.state).toBe('degraded')
+        expect(snapshot.rows).toEqual([])
+    })
+
+    test('missing read path / missing identities never fabricate: honest degradation with named reason', async () => {
+        const noPath = await readFleetMailboxMirror({
+            capturedAt    : CAPTURED_AT,
+            viewerIdentity: '@tobiu',
+            subjectAgentId: '@neo-opus-vega'
+        })
+        expect(noPath.capability.state).toBe('degraded')
+        expect(noPath.capability.reason).toContain('read path unavailable')
+        expect(noPath.rows).toEqual([])
+
+        const noSubject = await readFleetMailboxMirror({
+            capturedAt    : CAPTURED_AT,
+            viewerIdentity: '@tobiu',
+            listMessages  : async () => ({messages: []})
+        })
+        expect(noSubject.capability.state).toBe('degraded')
+        expect(noSubject.capability.reason).toContain('viewerIdentity and subjectAgentId')
+        expect(noSubject.admission.state).toBe('unavailable')
+    })
+
+    test('pagination bounds: limit clamps to [1, MAX], offset clamps to >= 0, bounds echo on the snapshot', async () => {
+        const calls = []
+        const read  = async args => { calls.push(args); return {messages: []} }
+
+        const over = await readFleetMailboxMirror({
+            capturedAt: CAPTURED_AT, viewerIdentity: '@tobiu', subjectAgentId: '@neo-gpt',
+            limit     : 9999, offset: -5, listMessages: read
+        })
+        expect(calls[0].limit).toBe(MAX_FLEET_MAILBOX_MIRROR_LIMIT)
+        expect(calls[0].offset).toBe(0)
+        expect(over.page).toEqual({limit: MAX_FLEET_MAILBOX_MIRROR_LIMIT, offset: 0, count: 0})
+
+        await readFleetMailboxMirror({
+            capturedAt: CAPTURED_AT, viewerIdentity: '@tobiu', subjectAgentId: '@neo-gpt',
+            limit     : 0, offset: 25.7, listMessages: read
+        })
+        expect(calls[1].limit).toBe(1)
+        expect(calls[1].offset).toBe(25)
+
+        await readFleetMailboxMirror({
+            capturedAt: CAPTURED_AT, viewerIdentity: '@tobiu', subjectAgentId: '@neo-gpt',
+            limit     : 'not-a-number', listMessages: read
+        })
+        expect(calls[2].limit).toBe(DEFAULT_FLEET_MAILBOX_MIRROR_LIMIT)
+    })
+
+    test('active-inbox default is STRUCTURAL: the adapter never forwards an includeArchived key', async () => {
+        const calls = []
+        await readFleetMailboxMirror({
+            capturedAt    : CAPTURED_AT,
+            viewerIdentity: '@tobiu',
+            subjectAgentId: '@neo-gpt',
+            listMessages  : async args => { calls.push(args); return {messages: []} }
+        })
+
+        // the service default (exclude archived) always governs — the key is absent by construction
+        expect(Object.keys(calls[0])).toEqual(['box', 'status', 'to', 'limit', 'offset'])
+        expect(Object.hasOwn(calls[0], 'includeArchived')).toBe(false)
+    })
+
+    test('the surface is structurally read-only: no markRead / archive / mutation verb is exported', () => {
+        const exportNames = Object.keys(adapterModule)
+
+        expect(exportNames.sort()).toEqual([
+            'DEFAULT_FLEET_MAILBOX_MIRROR_LIMIT',
+            'MAX_FLEET_MAILBOX_MIRROR_LIMIT',
+            'createFleetMailboxMirrorSnapshot',
+            'readFleetMailboxMirror'
+        ])
+        exportNames.forEach(name => {
+            expect(/mark|archive|delete|send|write|mutate/i.test(name)).toBe(false)
+        })
+    })
+
+    test('canonical identity mapping: bare logins normalize to @-form on the audit fact; self-read maps through unchanged', async () => {
+        const calls    = []
+        const snapshot = await readFleetMailboxMirror({
+            capturedAt    : CAPTURED_AT,
+            viewerIdentity: 'neo-opus-vega',
+            subjectAgentId: 'neo-opus-vega',
+            listMessages  : async args => { calls.push(args); return {messages: []} }
+        })
+
+        // viewer === subject: the adapter adds no special casing — the primitive's own
+        // self-read path (no grant required) governs; the audit fact still records both.
+        expect(snapshot.admission.viewerIdentity).toBe('@neo-opus-vega')
+        expect(snapshot.admission.subjectAgentId).toBe('@neo-opus-vega')
+        expect(calls[0].to).toBe('@neo-opus-vega')
+    })
+
+    test('pure half: createFleetMailboxMirrorSnapshot redacts secret-bearing subjects and reasons', () => {
+        const snapshot = createFleetMailboxMirrorSnapshot({
+            capturedAt: CAPTURED_AT,
+            viewer    : '@tobiu',
+            subject   : '@neo-gpt',
+            messages  : [{messageId: 'MESSAGE:x', subject: 'rotate token: ghp_abc123SECRET now', sentAt: CAPTURED_AT}]
+        })
+        expect(snapshot.rows[0].subject).not.toContain('ghp_abc123SECRET')
+
+        const denied = createFleetMailboxMirrorSnapshot({
+            capturedAt: CAPTURED_AT,
+            viewer    : '@tobiu',
+            subject   : '@neo-gpt',
+            error     : new Error('Unauthorized: no CAN_READ_INBOX_OF permission for @neo-gpt (token: ghp_zzz999LEAK)')
+        })
+        expect(denied.admission.state).toBe('denied')
+        expect(denied.admission.reason).not.toContain('ghp_zzz999LEAK')
+    })
+})

--- a/test/playwright/unit/ai/services/fleet/fleetMailboxMirrorAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetMailboxMirrorAdapter.spec.mjs
@@ -14,8 +14,12 @@ setup({
 })
 
 import {test, expect} from '@playwright/test'
+import fs             from 'fs-extra'
+import path           from 'path'
 import Neo            from '../../../../../../src/Neo.mjs'
 import * as core      from '../../../../../../src/core/_export.mjs'
+import                          '../../../../../../src/manager/Instance.mjs'
+import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs'
 
 import * as adapterModule from '../../../../../../ai/services/fleet/fleetMailboxMirrorAdapter.mjs'
 import {
@@ -28,6 +32,13 @@ import {FLEET_COCKPIT_SOURCES} from '../../../../../../src/ai/fleet/fleetCockpit
 
 const CAPTURED_AT = '2026-07-16T12:00:00.000Z'
 
+// The production wiring's binding accessor, used verbatim by the real-producer suite below.
+const boundIdentity = () => RequestContextService.getAgentIdentityNodeId()
+
+// A viewer binding for the mapper suite: these specs assert projection/refusal shape, so they state
+// the bound identity directly rather than standing up a request context.
+const boundAs = identity => () => identity
+
 /**
  * The S1 Brain half: viewer-admitted, read-only per-agent mailbox mirror. Admission enforcement is
  * the MailboxService primitive's own CAN_READ_INBOX_OF gate — these specs pin the adapter's honest
@@ -35,13 +46,13 @@ const CAPTURED_AT = '2026-07-16T12:00:00.000Z'
  * no archive exposure) the graduated record marks MUST-NOT.
  */
 test.describe('fleetMailboxMirrorAdapter — viewer-admitted per-agent mailbox mirror', () => {
-    test('grants: projects summaries into frozen, body-free rows with thread metadata + audit fact', async () => {
+    test('grants: projects summaries into frozen, body-free rows with the bound viewer as the audit fact', async () => {
         const calls    = []
         const snapshot = await readFleetMailboxMirror({
-            capturedAt    : CAPTURED_AT,
-            viewerIdentity: 'tobiu',
-            subjectAgentId: '@neo-opus-vega',
-            listMessages  : async args => {
+            capturedAt          : CAPTURED_AT,
+            resolveBoundIdentity: boundAs('@tobiu'),
+            subjectAgentId      : '@neo-opus-vega',
+            listMessages        : async args => {
                 calls.push(args)
                 return {messages: [{
                     messageId     : 'MESSAGE:abc',
@@ -94,12 +105,12 @@ test.describe('fleetMailboxMirrorAdapter — viewer-admitted per-agent mailbox m
         expect(calls[0].box).toBe('inbox')
     })
 
-    test('admission fail-closed: the primitive CAN_READ_INBOX_OF throw maps to an explicit denial, never empty-success', async () => {
+    test('admission fail-closed: THIS subject CAN_READ_INBOX_OF throw maps to an explicit denial, never empty-success', async () => {
         const snapshot = await readFleetMailboxMirror({
-            capturedAt    : CAPTURED_AT,
-            viewerIdentity: '@neo-observer',
-            subjectAgentId: '@neo-opus-vega',
-            listMessages  : async () => {
+            capturedAt          : CAPTURED_AT,
+            resolveBoundIdentity: boundAs('@neo-observer'),
+            subjectAgentId      : '@neo-opus-vega',
+            listMessages        : async () => {
                 throw new Error('Unauthorized: no CAN_READ_INBOX_OF permission for @neo-opus-vega')
             }
         })
@@ -114,12 +125,121 @@ test.describe('fleetMailboxMirrorAdapter — viewer-admitted per-agent mailbox m
         expect(snapshot.page.count).toBe(0)
     })
 
+    test('denial is subject-specific: an unrelated authorization failure is NOT this subject admission decision', async () => {
+        // A bare `Unauthorized` (expired token, a different scope, another target) must degrade as
+        // unavailable. Reporting it as `denied` would tell the operator "no CAN_READ_INBOX_OF grant"
+        // about a subject whose admission was never actually evaluated.
+        const generic = await readFleetMailboxMirror({
+            capturedAt          : CAPTURED_AT,
+            resolveBoundIdentity: boundAs('@tobiu'),
+            subjectAgentId      : '@neo-opus-vega',
+            listMessages        : async () => { throw new Error('Unauthorized: token expired') }
+        })
+        expect(generic.admission.state).toBe('unavailable')
+
+        const otherScope = await readFleetMailboxMirror({
+            capturedAt          : CAPTURED_AT,
+            resolveBoundIdentity: boundAs('@tobiu'),
+            subjectAgentId      : '@neo-opus-vega',
+            listMessages        : async () => {
+                throw new Error('Unauthorized: no CAN_READ_MEMORIES_OF permission for @neo-opus-vega')
+            }
+        })
+        expect(otherScope.admission.state).toBe('unavailable')
+
+        // ...and a denial naming a DIFFERENT subject is not this subject's denial either
+        const otherSubject = await readFleetMailboxMirror({
+            capturedAt          : CAPTURED_AT,
+            resolveBoundIdentity: boundAs('@tobiu'),
+            subjectAgentId      : '@neo-opus-vega',
+            listMessages        : async () => {
+                throw new Error('Unauthorized: no CAN_READ_INBOX_OF permission for @neo-gpt')
+            }
+        })
+        expect(otherSubject.admission.state).toBe('unavailable')
+    })
+
+    test('namespace pseudo-targets are inadmissible: AGENT:* never reaches the read, never reports granted', async () => {
+        // MailboxService.listMessages skips CAN_READ_INBOX_OF for the broadcast sentinel and
+        // PermissionService.hasPermission returns true for it structurally. Forwarding one would
+        // hand the cockpit a `granted` snapshot for a target nothing ever admission-checked.
+        for (const pseudoTarget of ['AGENT:*', 'AGENT:opus/vega', 'role:maintainer', 'human:tobiu', '@ns:x', '@', '']) {
+            const calls    = []
+            const snapshot = await readFleetMailboxMirror({
+                capturedAt          : CAPTURED_AT,
+                resolveBoundIdentity: boundAs('@tobiu'),
+                subjectAgentId      : pseudoTarget,
+                listMessages        : async args => { calls.push(args); return {messages: []} }
+            })
+
+            expect(snapshot.admission.state).not.toBe('granted')
+            expect(snapshot.admission.subjectAgentId).toBe(null)
+            expect(snapshot.capability.reason).toContain('direct subjectAgentId')
+            // fail-closed BEFORE the read: no pseudo-target query is ever issued
+            expect(calls).toHaveLength(0)
+        }
+    })
+
+    test('the audit viewer is the BOUND identity: an unbound read makes no admission claim', async () => {
+        const calls    = []
+        const snapshot = await readFleetMailboxMirror({
+            capturedAt          : CAPTURED_AT,
+            resolveBoundIdentity: boundAs(null),
+            subjectAgentId      : '@neo-opus-vega',
+            listMessages        : async args => { calls.push(args); return {messages: []} }
+        })
+
+        expect(snapshot.admission.state).toBe('unavailable')
+        expect(snapshot.admission.viewerIdentity).toBe(null)
+        expect(snapshot.capability.reason).toContain('bound request identity')
+        expect(calls).toHaveLength(0)
+
+        // no accessor at all is the same refusal — never a caller-labelled grant
+        const noResolver = await readFleetMailboxMirror({
+            capturedAt    : CAPTURED_AT,
+            subjectAgentId: '@neo-opus-vega',
+            viewerIdentity: '@tobiu',
+            listMessages  : async () => ({messages: []})
+        })
+        expect(noResolver.admission.state).toBe('unavailable')
+        expect(noResolver.admission.viewerIdentity).toBe(null)
+    })
+
+    test('viewer-mismatch: an asserted identity that is not the bound one refuses the read', async () => {
+        const calls    = []
+        const snapshot = await readFleetMailboxMirror({
+            capturedAt          : CAPTURED_AT,
+            resolveBoundIdentity: boundAs('@neo-opus-ada'),
+            viewerIdentity      : '@tobiu',
+            subjectAgentId      : '@neo-opus-vega',
+            listMessages        : async args => { calls.push(args); return {messages: [{messageId: 'MESSAGE:x'}]} }
+        })
+
+        // rows here would be Ada's bound read, attributed to @tobiu — refuse rather than mislabel
+        expect(snapshot.admission.state).toBe('unavailable')
+        expect(snapshot.admission.viewerIdentity).toBe('@neo-opus-ada')
+        expect(snapshot.capability.reason).toContain('does not match the bound request identity')
+        expect(snapshot.rows).toEqual([])
+        expect(calls).toHaveLength(0)
+
+        // a matching assertion passes through (bare and @-form are the same identity)
+        const agreed = await readFleetMailboxMirror({
+            capturedAt          : CAPTURED_AT,
+            resolveBoundIdentity: boundAs('@tobiu'),
+            viewerIdentity      : 'tobiu',
+            subjectAgentId      : '@neo-opus-vega',
+            listMessages        : async () => ({messages: []})
+        })
+        expect(agreed.admission.state).toBe('granted')
+        expect(agreed.admission.viewerIdentity).toBe('@tobiu')
+    })
+
     test('non-admission source failures degrade honestly as unavailable (distinct from denial)', async () => {
         const snapshot = await readFleetMailboxMirror({
-            capturedAt    : CAPTURED_AT,
-            viewerIdentity: '@tobiu',
-            subjectAgentId: '@neo-opus-vega',
-            listMessages  : async () => { throw new Error('database not initialized') }
+            capturedAt          : CAPTURED_AT,
+            resolveBoundIdentity: boundAs('@tobiu'),
+            subjectAgentId      : '@neo-opus-vega',
+            listMessages        : async () => { throw new Error('database not initialized') }
         })
 
         expect(snapshot.admission.state).toBe('unavailable')
@@ -127,59 +247,49 @@ test.describe('fleetMailboxMirrorAdapter — viewer-admitted per-agent mailbox m
         expect(snapshot.rows).toEqual([])
     })
 
-    test('missing read path / missing identities never fabricate: honest degradation with named reason', async () => {
+    test('missing read path never fabricates: honest degradation with a named reason', async () => {
         const noPath = await readFleetMailboxMirror({
-            capturedAt    : CAPTURED_AT,
-            viewerIdentity: '@tobiu',
-            subjectAgentId: '@neo-opus-vega'
+            capturedAt          : CAPTURED_AT,
+            resolveBoundIdentity: boundAs('@tobiu'),
+            subjectAgentId      : '@neo-opus-vega'
         })
         expect(noPath.capability.state).toBe('degraded')
         expect(noPath.capability.reason).toContain('read path unavailable')
         expect(noPath.rows).toEqual([])
-
-        const noSubject = await readFleetMailboxMirror({
-            capturedAt    : CAPTURED_AT,
-            viewerIdentity: '@tobiu',
-            listMessages  : async () => ({messages: []})
-        })
-        expect(noSubject.capability.state).toBe('degraded')
-        expect(noSubject.capability.reason).toContain('viewerIdentity and subjectAgentId')
-        expect(noSubject.admission.state).toBe('unavailable')
     })
 
     test('pagination bounds: limit clamps to [1, MAX], offset clamps to >= 0, bounds echo on the snapshot', async () => {
         const calls = []
         const read  = async args => { calls.push(args); return {messages: []} }
 
-        const over = await readFleetMailboxMirror({
-            capturedAt: CAPTURED_AT, viewerIdentity: '@tobiu', subjectAgentId: '@neo-gpt',
-            limit     : 9999, offset: -5, listMessages: read
+        const paged = bounds => readFleetMailboxMirror({
+            capturedAt          : CAPTURED_AT,
+            resolveBoundIdentity: boundAs('@tobiu'),
+            subjectAgentId      : '@neo-gpt',
+            listMessages        : read,
+            ...bounds
         })
+
+        const over = await paged({limit: 9999, offset: -5})
         expect(calls[0].limit).toBe(MAX_FLEET_MAILBOX_MIRROR_LIMIT)
         expect(calls[0].offset).toBe(0)
         expect(over.page).toEqual({limit: MAX_FLEET_MAILBOX_MIRROR_LIMIT, offset: 0, count: 0})
 
-        await readFleetMailboxMirror({
-            capturedAt: CAPTURED_AT, viewerIdentity: '@tobiu', subjectAgentId: '@neo-gpt',
-            limit     : 0, offset: 25.7, listMessages: read
-        })
+        await paged({limit: 0, offset: 25.7})
         expect(calls[1].limit).toBe(1)
         expect(calls[1].offset).toBe(25)
 
-        await readFleetMailboxMirror({
-            capturedAt: CAPTURED_AT, viewerIdentity: '@tobiu', subjectAgentId: '@neo-gpt',
-            limit     : 'not-a-number', listMessages: read
-        })
+        await paged({limit: 'not-a-number'})
         expect(calls[2].limit).toBe(DEFAULT_FLEET_MAILBOX_MIRROR_LIMIT)
     })
 
     test('active-inbox default is STRUCTURAL: the adapter never forwards an includeArchived key', async () => {
         const calls = []
         await readFleetMailboxMirror({
-            capturedAt    : CAPTURED_AT,
-            viewerIdentity: '@tobiu',
-            subjectAgentId: '@neo-gpt',
-            listMessages  : async args => { calls.push(args); return {messages: []} }
+            capturedAt          : CAPTURED_AT,
+            resolveBoundIdentity: boundAs('@tobiu'),
+            subjectAgentId      : '@neo-gpt',
+            listMessages        : async args => { calls.push(args); return {messages: []} }
         })
 
         // the service default (exclude archived) always governs — the key is absent by construction
@@ -201,13 +311,13 @@ test.describe('fleetMailboxMirrorAdapter — viewer-admitted per-agent mailbox m
         })
     })
 
-    test('canonical identity mapping: bare logins normalize to @-form on the audit fact; self-read maps through unchanged', async () => {
+    test('self-read maps through unchanged: the audit fact still records both sides', async () => {
         const calls    = []
         const snapshot = await readFleetMailboxMirror({
-            capturedAt    : CAPTURED_AT,
-            viewerIdentity: 'neo-opus-vega',
-            subjectAgentId: 'neo-opus-vega',
-            listMessages  : async args => { calls.push(args); return {messages: []} }
+            capturedAt          : CAPTURED_AT,
+            resolveBoundIdentity: boundAs('neo-opus-vega'),
+            subjectAgentId      : 'neo-opus-vega',
+            listMessages        : async args => { calls.push(args); return {messages: []} }
         })
 
         // viewer === subject: the adapter adds no special casing — the primitive's own
@@ -217,22 +327,196 @@ test.describe('fleetMailboxMirrorAdapter — viewer-admitted per-agent mailbox m
         expect(calls[0].to).toBe('@neo-opus-vega')
     })
 
-    test('pure half: createFleetMailboxMirrorSnapshot redacts secret-bearing subjects and reasons', () => {
-        const snapshot = createFleetMailboxMirrorSnapshot({
-            capturedAt: CAPTURED_AT,
-            viewer    : '@tobiu',
-            subject   : '@neo-gpt',
-            messages  : [{messageId: 'MESSAGE:x', subject: 'rotate token: ghp_abc123SECRET now', sentAt: CAPTURED_AT}]
-        })
-        expect(snapshot.rows[0].subject).not.toContain('ghp_abc123SECRET')
+    test('redaction matrix: no supported credential family crosses into a Body-facing subject or reason', () => {
+        const cases = [
+            {name: 'github pat',        secret: 'ghp_abc123SECRET',       text: 'rotate token: ghp_abc123SECRET now'},
+            {name: 'gitlab pat',        secret: 'glpat-zzz999LEAK',       text: 'CI uses glpat-zzz999LEAK for the mirror'},
+            {name: 'bearer header',     secret: 'super-secret',           text: 'retry with Authorization: Bearer super-secret'},
+            {name: 'bare bearer',       secret: 'eyJhbGciOiJIUzI1NiJ9',   text: 'sent Bearer eyJhbGciOiJIUzI1NiJ9 upstream'},
+            {name: 'assignment form',   secret: 'hunter2',               text: 'password=hunter2 rejected'},
+            {name: 'authorization key', secret: 'ghs_serviceLEAK',        text: 'authorization: ghs_serviceLEAK denied'}
+        ]
 
-        const denied = createFleetMailboxMirrorSnapshot({
-            capturedAt: CAPTURED_AT,
-            viewer    : '@tobiu',
-            subject   : '@neo-gpt',
-            error     : new Error('Unauthorized: no CAN_READ_INBOX_OF permission for @neo-gpt (token: ghp_zzz999LEAK)')
+        cases.forEach(({name, secret, text}) => {
+            const viaSubject = createFleetMailboxMirrorSnapshot({
+                capturedAt: CAPTURED_AT,
+                viewer    : '@tobiu',
+                subject   : '@neo-gpt',
+                messages  : [{messageId: 'MESSAGE:x', subject: text, sentAt: CAPTURED_AT}]
+            })
+            expect(viaSubject.rows[0].subject, `${name} must not cross via subject`).not.toContain(secret)
+
+            const viaReason = createFleetMailboxMirrorSnapshot({
+                capturedAt: CAPTURED_AT,
+                viewer    : '@tobiu',
+                subject   : '@neo-gpt',
+                error     : new Error(`Unauthorized: no CAN_READ_INBOX_OF permission for @neo-gpt (${text})`)
+            })
+            expect(viaReason.admission.state).toBe('denied')
+            expect(viaReason.admission.reason, `${name} must not cross via reason`).not.toContain(secret)
         })
-        expect(denied.admission.state).toBe('denied')
-        expect(denied.admission.reason).not.toContain('ghp_zzz999LEAK')
+    })
+})
+
+/**
+ * RA-1's producer-contract witness. The suite above proves the MAPPER; a synthetic
+ * MailboxService-shaped callback can hand it any field, including one production never emits —
+ * which is exactly how `partOfThread` shipped green while always projecting null. These specs drive
+ * the adapter through the REAL MailboxService read path under a REAL RequestContextService binding,
+ * so the row's thread fact is the graph's, not the fixture's.
+ */
+test.describe('fleetMailboxMirrorAdapter — real MailboxService producer contract', () => {
+    test.describe.configure({mode: 'serial'})
+
+    let GraphService, LifecycleService, MailboxService, PermissionService, mirrorAiConfig, originalAutoSave
+    let dbPath
+
+    test.beforeAll(async () => {
+        const tmpDir = path.resolve(process.cwd(), 'tmp')
+        if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, {recursive: true})
+        dbPath = path.join(tmpDir, `neo-fleet-mailbox-mirror-${Date.now()}-${Math.random().toString(36).substring(7)}.db`)
+
+        // Temp file DB rather than :memory: — same initialization-race guard the MailboxService suite documents.
+        mirrorAiConfig = (await import('../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default
+        mirrorAiConfig.storagePaths.graph = dbPath
+        if (!mirrorAiConfig.collections) mirrorAiConfig.collections = {}
+        mirrorAiConfig.collections.memory  = `test-memory-${Date.now()}`
+        mirrorAiConfig.collections.session = `test-session-${Date.now()}`
+
+        // Dynamic imports: the services mount the SQLite DB at module scope.
+        GraphService      = (await import('../../../../../../ai/services/memory-core/GraphService.mjs')).default
+        MailboxService    = (await import('../../../../../../ai/services/memory-core/MailboxService.mjs')).default
+        PermissionService = (await import('../../../../../../ai/services/memory-core/PermissionService.mjs')).default
+        LifecycleService  = (await import('../../../../../../ai/services/memory-core/lifecycle/SystemLifecycleService.mjs')).default
+
+        if (!LifecycleService._initPromise) {
+            await LifecycleService.initAsync()
+        } else {
+            await LifecycleService.ready()
+        }
+        originalAutoSave         = GraphService.db.autoSave
+        GraphService.db.autoSave = true
+    })
+
+    test.afterAll(async () => {
+        const {cleanupChromaManager} = await import('../memory-core/util.mjs')
+        await cleanupChromaManager()
+        GraphService.db.autoSave = originalAutoSave
+
+        if (fs.existsSync(dbPath)) {
+            try { fs.unlinkSync(dbPath) } catch (e) {}
+            try { fs.unlinkSync(dbPath + '-wal') } catch (e) {}
+            try { fs.unlinkSync(dbPath + '-shm') } catch (e) {}
+        }
+    })
+
+    test.beforeEach(async () => {
+        MailboxService.clearRelatedPullRequestStateCache()
+        if (GraphService.db) {
+            GraphService.db.nodes.clear()
+            GraphService.db.edges.clear()
+            GraphService.db.vicinityLoadedNodes.clear()
+
+            if (GraphService.db.storage?.db) {
+                await GraphService.db.storage.clear()
+                GraphService.db.storage.db.exec('DELETE FROM GraphLog')
+            }
+        }
+
+        GraphService.upsertNode({id: '@subject-agent',  type: 'AgentIdentity', name: 'Subject',  properties: {accountType: 'agent'}})
+        GraphService.upsertNode({id: '@viewer-agent',   type: 'AgentIdentity', name: 'Viewer',   properties: {accountType: 'agent'}})
+        GraphService.upsertNode({id: '@outsider-agent', type: 'AgentIdentity', name: 'Outsider', properties: {accountType: 'agent'}})
+        GraphService.upsertNode({id: '@sender-agent',   type: 'AgentIdentity', name: 'Sender',   properties: {accountType: 'agent'}})
+        GraphService.upsertNode({id: 'AGENT:*',         type: 'BroadcastSentinel', name: 'Broadcast', properties: {}})
+        GraphService.upsertNode({id: 'THREAD:15269',    type: 'THREAD', name: 'Mirror thread', properties: {}})
+    })
+
+    /**
+     * @summary Seed one threaded + one unthreaded message into the subject's real inbox.
+     */
+    async function seedInbox() {
+        await RequestContextService.run({agentIdentityNodeId: '@sender-agent'}, async () => {
+            await MailboxService.addMessage({
+                to          : '@subject-agent',
+                subject     : '[repair-lane] one accepted head needed',
+                body        : 'FULL BODY MUST NOT LEAK',
+                priority    : 'high',
+                partOfThread: 'THREAD:15269'
+            })
+            await MailboxService.addMessage({to: '@subject-agent', subject: 'unthreaded note', body: 'body'})
+        })
+    }
+
+    test('granted: the row thread fact comes from the REAL listMessages summary, not a fixture', async () => {
+        await seedInbox()
+
+        await RequestContextService.run({agentIdentityNodeId: '@subject-agent'}, async () => {
+            await PermissionService.grantPermission({to: '@viewer-agent', scope: 'CAN_READ_INBOX_OF'})
+        })
+
+        const snapshot = await RequestContextService.run({agentIdentityNodeId: '@viewer-agent'}, async () =>
+            readFleetMailboxMirror({
+                capturedAt          : CAPTURED_AT,
+                subjectAgentId      : '@subject-agent',
+                resolveBoundIdentity: boundIdentity,
+                listMessages        : args => MailboxService.listMessages(args)
+            })
+        )
+
+        expect(snapshot.admission.state).toBe('granted')
+        // the audit viewer is the request binding the read actually ran under
+        expect(snapshot.admission.viewerIdentity).toBe('@viewer-agent')
+        expect(snapshot.admission.subjectAgentId).toBe('@subject-agent')
+
+        const threaded = snapshot.rows.find(row => row.subject === '[repair-lane] one accepted head needed')
+        const loose    = snapshot.rows.find(row => row.subject === 'unthreaded note')
+
+        // THE producer contract: this thread id survived MailboxService.listMessages' own summary.
+        expect(threaded.partOfThread).toBe('THREAD:15269')
+        expect(threaded.from).toBe('@sender-agent')
+        expect(threaded.priority).toBe('high')
+        expect(loose.partOfThread).toBe(null)
+
+        // still body-free through the real path
+        expect(Object.keys(threaded)).not.toContain('body')
+        expect(JSON.stringify(snapshot)).not.toContain('FULL BODY MUST NOT LEAK')
+    })
+
+    test('denied: a viewer without the grant gets the primitive real fail-closed throw as denial', async () => {
+        await seedInbox()
+
+        const snapshot = await RequestContextService.run({agentIdentityNodeId: '@outsider-agent'}, async () =>
+            readFleetMailboxMirror({
+                capturedAt          : CAPTURED_AT,
+                subjectAgentId      : '@subject-agent',
+                resolveBoundIdentity: boundIdentity,
+                listMessages        : args => MailboxService.listMessages(args)
+            })
+        )
+
+        expect(snapshot.admission.state).toBe('denied')
+        expect(snapshot.admission.viewerIdentity).toBe('@outsider-agent')
+        expect(snapshot.admission.reason).toContain('CAN_READ_INBOX_OF')
+        expect(snapshot.rows).toEqual([])
+        expect(snapshot.capability.state).toBe('degraded')
+    })
+
+    test('the AGENT:* bypass is unreachable: the sentinel never returns a granted mirror', async () => {
+        await seedInbox()
+
+        // MailboxService.listMessages skips CAN_READ_INBOX_OF when target === 'AGENT:*', and
+        // PermissionService.hasPermission returns true for it — this asserts the adapter refuses
+        // BEFORE that bypass can hand an ungranted outsider a `granted` snapshot.
+        const snapshot = await RequestContextService.run({agentIdentityNodeId: '@outsider-agent'}, async () =>
+            readFleetMailboxMirror({
+                capturedAt          : CAPTURED_AT,
+                subjectAgentId      : 'AGENT:*',
+                resolveBoundIdentity: boundIdentity,
+                listMessages        : args => MailboxService.listMessages(args)
+            })
+        )
+
+        expect(snapshot.admission.state).not.toBe('granted')
+        expect(snapshot.rows).toEqual([])
     })
 })

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -1275,6 +1275,31 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         });
     });
 
+    test('listMessages PROJECTS partOfThread on the summary — thread membership is readable, not only filterable', async () => {
+        GraphService.upsertNode({ id: 'thread-X', type: 'THREAD', name: 'Thread X', properties: {} });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            await MailboxService.addMessage({ to: '@bob', subject: 'threaded', body: '...', partOfThread: 'thread-X' });
+            await MailboxService.addMessage({ to: '@bob', subject: 'loose', body: '...' });
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            const {messages} = await MailboxService.listMessages({ status: 'all' });
+            const threaded   = messages.find(message => message.subject === 'threaded');
+            const loose      = messages.find(message => message.subject === 'loose');
+
+            // The PART_OF_THREAD edge was resolved for filtering but never returned, so every
+            // consumer of the summary read a thread-less mailbox. Callers group threads from
+            // this field; an unthreaded message must stay absent rather than carry a null.
+            expect(threaded.partOfThread).toBe('thread-X');
+            expect(Object.hasOwn(loose, 'partOfThread')).toBe(false);
+        });
+    });
+
     test('addMessage supports 6 new edge types and priority', async () => {
         GraphService.upsertNode({ id: 'SESSION:123', type: 'SESSION', name: 'S123', properties: {} });
         GraphService.upsertNode({ id: 'SESSION:456', type: 'SESSION', name: 'S456', properties: {} });


### PR DESCRIPTION
Resolves #15269

The S1 Brain half from the graduated FM record (D#15249): a Fleet-side, read-only, viewer-admitted per-agent A2A mailbox mirror — `{subjectAgentId, limit, offset}`, read under a bound request identity → immutable message rows (timestamped facts) + `partOfThread` thread metadata. **Admission is the primitive's, never re-implemented**: the adapter consumes an injected MailboxService-compatible `listMessages()` and passes `to: subjectAgentId` so the service's own fail-closed `CAN_READ_INBOX_OF` gate decides the cross-read — a missing grant for *this subject* surfaces as an explicit `admission.state: 'denied'` snapshot carrying the service's honest error (never an empty-success), while every other failure degrades as `'unavailable'`, distinctly. **The audit viewer is derived, never asserted**: `admission.viewerIdentity` is read from `resolveBoundIdentity()` — the same trusted request binding the read executes under — because a caller-supplied label beside a separately-bound permission check is provenance, not admission evidence. **The subject is one direct agent**: namespace pseudo-targets are rejected before the read. Two further boundaries are STRUCTURAL, not configurational: the module exports read/projection functions only (no markRead/archive/mutation verb exists on the surface — the record's MUST-NOT: operator-side mark-read would mutate the agent's own turn-start signal and swallow peer handoffs), and the active/non-archived default is pinned by construction (the adapter never forwards an `includeArchived` key; archive browsing is out of v13.2 scope). Rows are frozen, body-free summary facts; pagination clamps to `[1, 200]` with `offset >= 0` and the bounds echo on the snapshot. An agent reading its OWN inbox stays on the existing `list_messages` path untouched.

Evidence: L2 (**293 green at 66a2e1b55a** — the 16-spec adapter suite incl. 3 real-producer specs, the full fleet service directory, and the full 112-spec MailboxService suite) → L2 required (the close-target ACs are producer/projection/admission contracts; the live `CAN_READ_INBOX_OF` grant exercise is post-merge scope on the consuming pane). Residual: none in delivered scope.

## Cycle-1 repair (66a2e1b55a)

Emmy's single comprehensive RC ([PRR_kwDODSospM8AAAABGSJfwQ](https://github.com/neomjs/neo/pull/15285#pullrequestreview-4716650433)) found three contracts this PR advertised but did not deliver. All three reproduced against `0b5325d87f`; all three are repaired here.

- **RA-1 — the thread producer was fixture-only.** `MailboxService.listMessages` resolved the `PART_OF_THREAD` target for its `threadId` filter (`:1848`) but omitted it from the returned summary (`:1867-1885`), so production always projected `partOfThread: null` while the spec injected the field synthetically. The **owner** now surfaces it; an unthreaded message stays absent rather than carrying a null. Emmy's `[TOOLING_GAP]` was the root cause: a synthetic MailboxService-shaped callback can hand the mapper any field, including one production never emits — so the suite now drives the adapter through the **real** `listMessages` under a **real** `RequestContextService` binding.
- **RA-2 — the admission fact was not identity-bound.** `viewerIdentity` was copied from caller input and recorded as the admitted identity, so a snapshot could claim "viewer A was granted" when viewer B's bound service performed the read. The viewer is now derived from the request binding; an optional assertion is verified against it and **refuses the read on mismatch**. Namespace pseudo-targets are rejected before the read — `listMessages` skips `CAN_READ_INBOX_OF` for `AGENT:*` (`:1732`) and `PermissionService.hasPermission` returns `true` for it (`:179`), so forwarding one reported `granted` for a target nothing ever admission-checked. Denial is now classified from the scope failure **for this subject**; a bare `Unauthorized` (expired token, another scope, another target) degrades as `unavailable` instead of impersonating an admission decision.
- **RA-3 — the redaction boundary was incomplete.** Bearer headers and GitLab `glpat-` forms crossed unchanged into Body-facing subjects and reasons. Both are credential families this repository actually handles (`GH_TOKEN`, `GITLAB_PAT`, `Authorization`). Rule order is load-bearing and commented as such: the scheme rule must run before the `key: value` rule, which otherwise matches `authorization`, stops at the space after `Bearer`, and republishes the secret intact.

**Rhetorical drift corrected.** Emmy flagged two claims in this body that exceeded the source; both are now removed rather than softened. The old "`listMessages()` summary contract" line for `partOfThread` described a producer that did not emit it — the claim is true only because RA-1 made the owner emit it. The old "auditable who-is-looking mapping fact ... not an enforcement input" line described a caller-provided label; the audit fact is now the binding.

## Deltas from ticket

- **This PR now touches `ai/services/memory-core/MailboxService.mjs` (+4 lines).** RA-1 is a producer bug in a shared read path, so the honest fix is at the owner, not a re-walk of `PART_OF_THREAD` edges inside the Fleet adapter. The change is purely additive (a conditional field, matching the existing `task` / `wakeSuppressed` / `archivedAt` / `retracted` idiom) and every summary consumer is regression-covered: full 112-spec MailboxService suite + 714-spec fleet/MCP-server/orchestrator sweep green.
- **`resolveBoundIdentity` added to the adapter's DI contract** (beyond the AC's literal option list): RA-2 cannot be satisfied without the read's own identity binding. Production wiring passes `() => RequestContextService.getAgentIdentityNodeId()`. Without it the adapter makes **no** admission claim rather than trusting a caller label — fail-closed. `viewerIdentity` survives as an optional, verified assertion.
- **Producer-first, no in-repo consumer** — exactly the sibling `fleetA2AActivityAdapter` precedent (it landed consumer-free too): the `FleetControlBridge` injectable-source wiring and the cockpit pane ride with #15270 (the sibling S1 view half, blocked on this leaf), keeping this PR one-leaf.
- **No `threadId` filter parameter**: thread metadata rides on every row via `partOfThread`. Adding a filter param would widen the surface beyond the record's resolution tokens — deferred until a consumer needs it.
- **`admission` block added to the snapshot shape** (beyond the AC's literal "rows + thread metadata"): the record requires admission checks to be auditable — the block carries `{state, viewerIdentity, subjectAgentId, checkedAt, reason}` so every read is a self-describing audit fact, including denials.

## Contract Ledger

| Target Surface | Source of Authority | Proposed Behavior | Fallback | Docs | Evidence |
|---|---|---|---|---|---|
| `readFleetMailboxMirror(options)` | D#15249 S1 boundary ACs + Surface Registry #15254 | viewer-bound read of one agent's ACTIVE inbox → frozen snapshot | degraded snapshot with named reason (never fabricated rows) | module JSDoc | 16-spec suite |
| `MailboxService.listMessages()` summary | #15269 AC "rows + thread metadata"; `PART_OF_THREAD` graph edge | summary PROJECTS `partOfThread` for threaded messages (RA-1: previously resolved for filtering only, never returned) | field absent when the message has no thread edge — never a null placeholder | method JSDoc | producer-contract spec (owner suite) + real-producer adapter spec |
| `admission.viewerIdentity` | RA-2 / record AC "admission checks are auditable" | DERIVED from `resolveBoundIdentity()` — the binding the read executes under; an asserted mismatch refuses the read | no binding → no admission claim (`unavailable`) | module JSDoc | bound-identity + viewer-mismatch specs |
| `admission.state` | MailboxService `CAN_READ_INBOX_OF` throw | `granted` / `denied` (the scope failure **for this subject**) / `unavailable` (every other failure) | `unavailable` on unnamed failures | module JSDoc | subject-specific denial spec (3 negative cases) |
| direct-subject admissibility | #15269 "one subject agent"; `listMessages:1732` + `hasPermission:179` sentinel bypass | `AGENT:*` / `role:*` / `human:*` / malformed rejected BEFORE the read | never reports `granted` for a pseudo-target | module JSDoc | pseudo-target spec (7 forms) + real `AGENT:*` bypass spec |
| Body-facing subject / reason | RA-3; repo credential families (`GH_TOKEN`, `GITLAB_PAT`, `Authorization`) | bearer + GitHub/GitLab PAT + assignment forms redacted on both paths | truncation + redaction always applied | `redactSecretText` JSDoc | 6-family redaction matrix (subject + reason) |
| mutation verbs on this surface | record MUST-NOT (mark-read swallows peer handoffs; adjacent evidence #15253) | structurally absent — read/projection exports only | n/a (nothing to fall back from) | module JSDoc | export-surface spec |
| `includeArchived` exposure | ticket "archive stays opt-in; out of v13.2 scope" | never forwarded — service default (active inbox) always governs | n/a | module JSDoc | structural-pin spec (exact call-arg keys) |

## Test Evidence

- `test/playwright/unit/ai/services/fleet/fleetMailboxMirrorAdapter.spec.mjs` — **16 passed at 66a2e1b55a**. Mapper suite: grant-path projection (frozen snapshot/rows, body-free keys, audit fact, viewer-bound call shape); `denied` on this subject's scope throw; **denial is subject-specific** (bare `Unauthorized`, a different scope, and a different subject each degrade as `unavailable`); **pseudo-targets inadmissible** (7 forms incl. `AGENT:*`, `role:*`, `@ns:x`, `@` — each asserts zero reads issued); **unbound reads make no admission claim**; **viewer-mismatch refuses the read** (and a matching bare/`@`-form assertion passes); non-admission degradation; missing read path; pagination clamps; structural active-default pin; structural read-only export surface; self-read; **6-family redaction matrix** (GitHub PAT, GitLab PAT, bearer header, bare bearer, assignment form, authorization key — each asserted on BOTH the subject and reason paths).
- **Real producer-contract suite (RA-1's witness)** — 3 specs driving the adapter through the real `MailboxService.listMessages` under a real `RequestContextService` binding on a real SQLite graph: the row's thread fact comes from the graph (not a fixture) and an unthreaded row is `null`; an ungranted viewer gets the primitive's genuine fail-closed throw as `denied`; the `AGENT:*` bypass is unreachable. Body-freedom re-asserted through the real path (`JSON.stringify(snapshot)` carries no body).
- `test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` — **112 passed**, incl. the new owner-side producer regression (threaded message projects `partOfThread`; unthreaded message omits the key).
- Regression sweep for the shared producer change — **714 passed / 1 local-harness artifact**: fleet + `mcp/server/memory-core/Server.spec.mjs` + `daemons/orchestrator/services/`. The one failure is `DreamServiceGoldenPath.spec.mjs:71`, which **fails identically on the clean baseline with none of this branch's changes applied** (stash-verified) AND **passes in the hosted `unit` job at `66a2e1b55a`** — it is an artifact of my local no-webServer runner reusing a shared Chroma instance, not a defect on this branch or on `dev`. **Correction:** an earlier revision of this body attributed it to #15265 / #15292. That was wrong — those own the *stop-hook golden-path advisory* (`readLifecycleState` fixture pollution), which shares only the words "golden path" with `synthesizeGoldenPath`. I attributed on a name collision instead of reading the ticket; hosted CI is the authority here and it is green.
- **Stash-verified, not just green** — the new specs fail **11 of 14** against the pre-repair source, and the owner-side producer regression returns `Received: undefined` without the `MailboxService` fix. The suite catches the bugs it claims to catch.
- Directly touched surfaces: `ai/services/fleet/fleetMailboxMirrorAdapter.mjs`: fleetMailboxMirrorAdapter.spec.mjs; `ai/services/memory-core/MailboxService.mjs`: MailboxService.spec.mjs.

## Post-Merge Validation

- [ ] The #15270 cockpit pane renders a live mirror through viewer-bound wiring — the first live `CAN_READ_INBOX_OF` grant exercise on the fleet surface (grant → rows; revoke → explicit denied panel), with `resolveBoundIdentity` wired to `RequestContextService.getAgentIdentityNodeId()`.

## Commits

- 0b5325d87f — the adapter + its initial spec suite (producer-first, per the wave pattern).
- 66a2e1b55a — the Cycle-1 repair head: RA-1 owner-side thread producer + real-producer witness, RA-2 direct-agent/bound-viewer admission, RA-3 bearer/non-GitHub-PAT redaction.

Provenance note: `0b5325d87f` was authored by Vega running as Claude Fable 5; the repair head `66a2e1b55a` by Vega running as Claude Opus 4.8 (same maintainer identity, operator-switched model mid-lane).

Authored by Vega (Claude Opus 4.8, Claude Code). Session 6517bb47-c5ad-4f0b-a29d-e67f1fa2d153.
