### PR TITLE
feat(fleet): remote-tenant connect — the design-partner entry (#14574)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -1,6 +1,7 @@
 import Base                     from '../../../src/core/Base.mjs';
 import FleetManager             from './FleetManager.mjs';
 import FleetRegistryService     from './FleetRegistryService.mjs';
+import FleetTenantService       from './FleetTenantService.mjs';
 import {resolveIdentityDisplay} from './resolveIdentityDisplay.mjs';
 
 import {LAUNCHABLE_HARNESS_TYPES, getHarnessAuthMode} from './deriveHarnessLaunchSpec.mjs';
@@ -102,6 +103,13 @@ class FleetControlBridge extends Base {
      * @member {Function|null} identityResolver=null
      */
     identityResolver = null
+    /**
+     * Remote-tenant collaborator seam. Defaults (via {@link getTenantService}) to the
+     * `FleetTenantService` singleton; inject a stub in tests. A plain field, mirroring `registry` /
+     * `manager`.
+     * @member {Object|null} tenantService=null
+     */
+    tenantService = null
 
     /**
      * @returns {Object} the registry collaborator (injected stub or the default singleton).
@@ -125,6 +133,14 @@ class FleetControlBridge extends Base {
      */
     getManager() {
         return this.manager || FleetManager;
+    }
+
+    /**
+     * @returns {Object} the remote-tenant collaborator (injected stub or the default singleton).
+     * @protected
+     */
+    getTenantService() {
+        return this.tenantService || FleetTenantService;
     }
 
     // ---- capability allowlist (the ONLY pane-reachable operations) ----------
@@ -156,6 +172,30 @@ class FleetControlBridge extends Base {
 
             throw error
         }
+    }
+
+    /**
+     * @summary Connect a remote Agent-OS tenant (tenant URL + PAT) — the design-partner entry: the
+     * cockpit points at a HOSTED tenant instead of standing up the local stack. Delegates to
+     * `FleetTenantService.connectTenant`; the credential is stored encrypted Node-side and is
+     * **never** echoed back — the return is the public descriptor (`{id, endpoint, status,
+     * deploymentClass, connectedAt}`) or a controlled `{status: 'rejected', reason}` outcome. The
+     * same secret-omission boundary {@link #defineAgent} enforces for agent PATs.
+     * @param {Object} params `{tenantUrl, credential}`
+     * @returns {Promise<Object>} the public tenant descriptor, or `{status: 'rejected', reason}`.
+     */
+    connectTenant(params) {
+        return this.getTenantService().connectTenant(params);
+    }
+
+    /**
+     * @summary The connected remote tenants — public descriptors only, never a credential: the
+     * read half of the remote-tenant surface, riding the same read-observe wire class as
+     * {@link #fleetRoster}.
+     * @returns {Object[]}
+     */
+    listTenants() {
+        return this.getTenantService().listTenants();
     }
 
     /**

--- a/ai/services/fleet/FleetTenantService.mjs
+++ b/ai/services/fleet/FleetTenantService.mjs
@@ -157,18 +157,22 @@ class FleetTenantService extends Base {
         // live and cannot authenticate. Reversed, the worst case is an encrypted credential with no
         // descriptor — invisible, harmless, and overwritten by the next connect.
         const previousCredentials = this.readCredentials();
-
-        this.writeCredential(descriptor.id, credential);
+        let   credentialPublished = false;
 
         try {
+            this.writeCredential(descriptor.id, credential);
+            credentialPublished = true;
             this.writeDescriptor(descriptor)
         } catch (error) {
-            // Roll the credential back to the pre-connect snapshot. A failed rollback is swallowed
-            // deliberately: the descriptor never published, so there is no false connected state to
-            // correct, and the stored credential is unreachable without one.
-            try {
-                this.writeCredentials(previousCredentials)
-            } catch (rollbackError) {}
+            // The credential write is atomic, so a failure before it returns leaves the old snapshot
+            // untouched and needs no compensating write. A descriptor failure happens after the new
+            // credential landed, so only that branch restores the pre-connect snapshot. A failed
+            // rollback cannot be repaired synchronously here; keep the public outcome bounded.
+            if (credentialPublished) {
+                try {
+                    this.writeCredentials(previousCredentials)
+                } catch (rollbackError) {}
+            }
 
             return {status: 'rejected', reason: 'tenant connection could not be persisted'};
         }

--- a/ai/services/fleet/FleetTenantService.mjs
+++ b/ai/services/fleet/FleetTenantService.mjs
@@ -5,6 +5,42 @@ import {fileURLToPath} from 'node:url';
 import Base            from '../../../src/core/Base.mjs';
 
 /**
+ * Hosts for which plain `http:` is accepted. Deliberately an exact set rather than a range or a
+ * pattern: this is the one exception to the TLS rule that protects the bearer, so it stays small
+ * enough to audit at a glance. A developer running a tenant on a non-loopback address uses TLS.
+ *
+ * `[::1]` keeps its brackets: these are compared against `URL#hostname`, which returns the IPv6
+ * literal bracketed. Un-bracketing it here would silently stop matching.
+ */
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+/**
+ * @summary Canonical origin+path form (no trailing slash) so one endpoint maps to one tenant id.
+ * @param {URL} url
+ * @returns {String}
+ */
+function canonicalize(url) {
+    return (url.origin + url.pathname).replace(/\/+$/, '');
+}
+
+/**
+ * @summary The CLOSED public vocabulary for a failed connect.
+ *
+ * The probe is a collaborator — an injected seam in tests, and in production a function whose
+ * `reason` is shaped by whatever the remote tenant returned. Echoing its text to the caller would
+ * hand an untrusted party a channel into a public surface. So the outcome is derived from the one
+ * field we can bound (the HTTP status) and the collaborator's prose is discarded, not sanitized:
+ * an allowlist of our own sentences cannot leak what it never carries.
+ * @param {Number} [status] The probe's HTTP status, when it reported one.
+ * @returns {String}
+ */
+function rejectionReasonFor(status) {
+    if (status === 401 || status === 403) return 'tenant rejected the credential';
+
+    return Number.isInteger(status) ? `tenant health probe failed (${status})` : 'tenant authentication failed';
+}
+
+/**
  * @class Neo.ai.services.fleet.FleetTenantService
  * @extends Neo.core.Base
  * @singleton
@@ -19,8 +55,13 @@ import Base            from '../../../src/core/Base.mjs';
  * remote transport probe, and is stored reversibly encrypted (AES-256-GCM, `0600`, the same
  * `NEO_FLEET_SECRET_KEY` / generated-keyfile discipline as the agent-PAT store) because the future
  * remote transport must present the real bearer. It is **never** returned, never included in a
- * public descriptor, and never transits the browser — every read surface serves the public
- * projection only (`{id, endpoint, status, deploymentClass, connectedAt}`).
+ * public descriptor, and never persists or returns through Body state — every read surface serves
+ * the public projection only (`{id, endpoint, status, deploymentClass, connectedAt}`).
+ *
+ * Stated precisely, because the looser claim ("never transits the browser") is false and worth not
+ * believing: the PAT necessarily ARRIVES through the allowlisted Body→Brain connect request. The
+ * boundary this class holds is one-way — inbound once, never back out, and never into anything the
+ * Body can read.
  *
  * **Fail-closed:** a malformed URL, an unreachable endpoint, or a rejected bearer never persists a
  * descriptor and never throws raw transport errors upward — the caller gets a controlled
@@ -53,10 +94,11 @@ class FleetTenantService extends Base {
      */
     dataDir = null
     /**
-     * Transport-probe seam: `({endpoint, credential}) => Promise<{ok: Boolean, status?: Number,
-     * reason?: String}>`. Defaults (via {@link getProbeFn}) to {@link probeTenantEndpoint} — an
-     * authenticated HTTPS health probe. Inject a stub in tests so no spec ever needs a live tenant
-     * or a real PAT. Plain field, mirroring `FleetLifecycleService.spawnFn`.
+     * Transport-probe seam: `({endpoint, credential}) => Promise<{ok: Boolean, status?: Number}>`.
+     * Defaults (via {@link getProbeFn}) to {@link probeTenantEndpoint} — an authenticated HTTPS
+     * health probe. Any `reason` a stub returns is IGNORED: the public failure vocabulary is
+     * derived from `status` alone ({@link rejectionReasonFor}). Inject a stub in tests so no spec
+     * ever needs a live tenant or a real PAT. Plain field, mirroring `FleetLifecycleService.spawnFn`.
      * @member {Function|null} probeFn=null
      */
     probeFn = null
@@ -69,10 +111,12 @@ class FleetTenantService extends Base {
      * one `defineAgent` enforces for agent PATs. Reconnecting an existing endpoint updates its
      * descriptor + credential in place (re-auth is the point of a reconnect).
      * @param {Object} params
-     * @param {String} params.tenantUrl  The hosted tenant's base URL (http/https).
+     * @param {String} params.tenantUrl  The hosted tenant's base URL. `https` required; plain `http`
+     *     is accepted for loopback development only (the bearer must not cross a network in clear).
      * @param {String} params.credential The tenant PAT — stored encrypted, never returned.
      * @returns {Promise<Object>} `{id, endpoint, status: 'connected', deploymentClass,
-     *     connectedAt}` on success; `{status: 'rejected', reason}` on any validation/auth failure.
+     *     connectedAt}` on success; `{status: 'rejected', reason}` — reason drawn from a closed
+     *     vocabulary — on any validation, auth, or persistence failure.
      */
     async connectTenant({tenantUrl, credential} = {}) {
         const endpoint = this.normalizeEndpoint(tenantUrl);
@@ -96,7 +140,7 @@ class FleetTenantService extends Base {
         }
 
         if (!probe?.ok) {
-            return {status: 'rejected', reason: probe?.reason || 'tenant authentication failed'};
+            return {status: 'rejected', reason: rejectionReasonFor(probe?.status)};
         }
 
         const descriptor = {
@@ -107,8 +151,27 @@ class FleetTenantService extends Base {
             connectedAt    : new Date().toISOString()
         };
 
-        this.writeDescriptor(descriptor);
+        // Two-store connect transaction, mirroring `FleetRegistryService.defineAgent`: credential
+        // FIRST, public descriptor LAST. The descriptor is the surface that claims `connected`, so
+        // publishing it before the credential it depends on is what strands a tenant that reads as
+        // live and cannot authenticate. Reversed, the worst case is an encrypted credential with no
+        // descriptor — invisible, harmless, and overwritten by the next connect.
+        const previousCredentials = this.readCredentials();
+
         this.writeCredential(descriptor.id, credential);
+
+        try {
+            this.writeDescriptor(descriptor)
+        } catch (error) {
+            // Roll the credential back to the pre-connect snapshot. A failed rollback is swallowed
+            // deliberately: the descriptor never published, so there is no false connected state to
+            // correct, and the stored credential is unreachable without one.
+            try {
+                this.writeCredentials(previousCredentials)
+            } catch (rollbackError) {}
+
+            return {status: 'rejected', reason: 'tenant connection could not be persisted'};
+        }
 
         return {...descriptor};
     }
@@ -152,11 +215,18 @@ class FleetTenantService extends Base {
             return null;
         }
 
-        if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
         // A URL-embedded secret would bypass the encrypted store — reject the shape outright.
         if (url.username || url.password) return null;
 
-        return (url.origin + url.pathname).replace(/\/+$/, '');
+        // The PAT rides to this endpoint as a bearer header (see `probeTenantEndpoint`), so the
+        // endpoint's scheme decides whether the credential crosses the wire in cleartext. TLS is
+        // required for anything remote; `http:` survives only for loopback, where there is no
+        // network hop to intercept and a developer can run a tenant without a certificate.
+        if (url.protocol === 'https:') return canonicalize(url);
+
+        if (url.protocol === 'http:' && LOOPBACK_HOSTS.has(url.hostname)) return canonicalize(url);
+
+        return null;
     }
 
     /**
@@ -175,12 +245,16 @@ class FleetTenantService extends Base {
     // ---- storage (public descriptors + encrypted credentials) ---------------
 
     /**
-     * @summary Resolve (field > env > default) the fleet data directory — the registry precedent.
+     * @summary Resolve (field > default) the fleet data directory — the registry precedent, exactly.
+     *
+     * No env layer: `FleetRegistryService.getDataDir()` resolves field-then-default, and these two
+     * services share this directory. A private env override on one side could point the tenant
+     * store at a different root than the agent store while both claim the same home.
      * @returns {String}
      * @protected
      */
     getDataDir() {
-        return this.dataDir || process.env.NEO_FLEET_DATA_DIR || path.resolve(
+        return this.dataDir || path.resolve(
             path.dirname(fileURLToPath(import.meta.url)), '../../../.neo-ai-data/fleet'
         );
     }
@@ -206,19 +280,48 @@ class FleetTenantService extends Base {
     }
 
     /**
-     * @summary Upserts one public descriptor; `0600` like every fleet store file.
+     * @summary Upserts one public descriptor, published atomically; `0600` like every fleet store file.
      * @param {Object} descriptor
      * @protected
      */
     writeDescriptor(descriptor) {
-        const dir  = this.getDataDir(),
-              file = path.join(dir, 'tenants.json'),
-              map  = this.readDescriptors();
+        const map = this.readDescriptors();
 
         map[descriptor.id] = descriptor;
 
+        this.publishAtomically(
+            path.join(this.getDataDir(), 'tenants.json'),
+            JSON.stringify(map, null, 4)
+        );
+    }
+
+    /**
+     * @summary Write-then-rename, the `FleetRegistryService.writeRegistry` precedent.
+     *
+     * `writeFileSync` onto a live path truncates before it writes: a crash mid-write leaves a
+     * half-file that the fail-closed readers here would silently parse as an EMPTY store — every
+     * tenant descriptor or credential gone, indistinguishable from a fresh install. A rename is
+     * atomic on POSIX, so a reader sees either the whole prior file or the whole new one.
+     * @param {String} file
+     * @param {String|Buffer} contents
+     * @protected
+     */
+    publishAtomically(file, contents) {
+        const dir     = path.dirname(file),
+              tmpFile = `${file}.${process.pid}.${crypto.randomUUID()}.tmp`;
+
         fs.mkdirSync(dir, {recursive: true});
-        fs.writeFileSync(file, JSON.stringify(map, null, 4), {encoding: 'utf8', mode: 0o600});
+
+        try {
+            fs.writeFileSync(tmpFile, contents, {mode: 0o600});
+            fs.renameSync(tmpFile, file)
+        } catch (error) {
+            if (fs.existsSync(tmpFile)) {
+                fs.unlinkSync(tmpFile)
+            }
+
+            throw error
+        }
     }
 
     /**
@@ -243,13 +346,27 @@ class FleetTenantService extends Base {
      * @protected
      */
     writeCredential(tenantId, credential) {
-        const dir = this.getDataDir(),
-              map = this.readCredentials();
+        const map = this.readCredentials();
 
         map[tenantId] = credential;
 
-        fs.mkdirSync(dir, {recursive: true});
-        fs.writeFileSync(path.join(dir, 'tenant-credentials.enc'), this.encrypt(JSON.stringify(map)), {mode: 0o600});
+        this.writeCredentials(map);
+    }
+
+    /**
+     * @summary Encrypt + atomically publish the WHOLE credential map — the rollback seam.
+     *
+     * Separate from {@link writeCredential} because a rollback must restore a prior snapshot
+     * wholesale, not upsert one entry: re-adding the key we just wrote is not the inverse of
+     * writing it.
+     * @param {Object} map `{tenantId: pat}`
+     * @protected
+     */
+    writeCredentials(map) {
+        this.publishAtomically(
+            path.join(this.getDataDir(), 'tenant-credentials.enc'),
+            this.encrypt(JSON.stringify(map))
+        );
     }
 
     // ---- crypto (AES-256-GCM, the FleetRegistryService discipline) ----------
@@ -324,12 +441,16 @@ class FleetTenantService extends Base {
 
 /**
  * @summary The default transport probe: an authenticated GET against the tenant endpoint's health
- * path, bearer-presented, bounded timeout. Any 2xx authenticates; 401/403 is a named auth
- * rejection; everything else is unreachable.
+ * path, bearer-presented, bounded timeout. Any 2xx authenticates; everything else does not.
+ *
+ * Reports `{ok, status}` and deliberately NO prose. The caller owns the public failure vocabulary
+ * ({@link rejectionReasonFor}) because a probe's text is shaped by the remote tenant; a `reason`
+ * field here would be an open invitation for the next author to forward it, which is the boundary
+ * this split exists to close.
  * @param {Object} options
- * @param {String} options.endpoint   Normalized tenant base URL.
+ * @param {String} options.endpoint   Normalized tenant base URL (TLS, or loopback for development).
  * @param {String} options.credential The tenant PAT (used for the probe only; never logged).
- * @returns {Promise<Object>} `{ok}` plus, when available, `status` and a bounded `reason`.
+ * @returns {Promise<Object>} `{ok, status}`.
  */
 export async function probeTenantEndpoint({endpoint, credential}) {
     const response = await fetch(`${endpoint}/health`, {
@@ -337,15 +458,7 @@ export async function probeTenantEndpoint({endpoint, credential}) {
         signal : AbortSignal.timeout(10_000)
     });
 
-    if (response.ok) return {ok: true, status: response.status};
-
-    return {
-        ok    : false,
-        status: response.status,
-        reason: response.status === 401 || response.status === 403
-            ? 'tenant rejected the credential'
-            : `tenant health probe failed (${response.status})`
-    };
+    return {ok: response.ok, status: response.status};
 }
 
 export default Neo.setupClass(FleetTenantService);

--- a/ai/services/fleet/FleetTenantService.mjs
+++ b/ai/services/fleet/FleetTenantService.mjs
@@ -1,0 +1,351 @@
+import crypto          from 'node:crypto';
+import fs              from 'node:fs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import Base            from '../../../src/core/Base.mjs';
+
+/**
+ * @class Neo.ai.services.fleet.FleetTenantService
+ * @extends Neo.core.Base
+ * @singleton
+ *
+ * @summary
+ * The Brain-side (Node-only) remote-tenant connection registry — the "connect and go" half of the
+ * Fleet Manager's entry story: a design partner points the cockpit at a HOSTED Agent-OS tenant
+ * (a tenant URL + a PAT) instead of standing up the full local stack.
+ *
+ * **Two-hemisphere credential boundary (non-negotiable, mirroring `FleetRegistryService`):** the
+ * tenant PAT is a Node-side secret. It rides IN through {@link #connectTenant}, authenticates the
+ * remote transport probe, and is stored reversibly encrypted (AES-256-GCM, `0600`, the same
+ * `NEO_FLEET_SECRET_KEY` / generated-keyfile discipline as the agent-PAT store) because the future
+ * remote transport must present the real bearer. It is **never** returned, never included in a
+ * public descriptor, and never transits the browser — every read surface serves the public
+ * projection only (`{id, endpoint, status, deploymentClass, connectedAt}`).
+ *
+ * **Fail-closed:** a malformed URL, an unreachable endpoint, or a rejected bearer never persists a
+ * descriptor and never throws raw transport errors upward — the caller gets a controlled
+ * `{status: 'rejected', reason}` outcome. Connecting records `deploymentClass: 'cloud-tenant'` on
+ * the descriptor: the posture marker downstream isolation rules key off.
+ *
+ * Storage layout (under the same data-dir precedent as the registry):
+ * - `tenants.json`             — public descriptors only; safe to render anywhere.
+ * - `tenant-credentials.enc`   — the encrypted `{tenantId: pat}` map (AES-256-GCM, `0600`).
+ */
+class FleetTenantService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.fleet.FleetTenantService'
+         * @protected
+         */
+        className: 'Neo.ai.services.fleet.FleetTenantService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * Absolute data directory for the tenant stores. `null` ⇒ resolved via {@link getDataDir}
+     * (`NEO_FLEET_DATA_DIR` env, then the registry-precedent `.neo-ai-data/fleet` default). Plain
+     * field, mirroring the sibling services' tunables.
+     * @member {String|null} dataDir=null
+     */
+    dataDir = null
+    /**
+     * Transport-probe seam: `({endpoint, credential}) => Promise<{ok: Boolean, status?: Number,
+     * reason?: String}>`. Defaults (via {@link getProbeFn}) to {@link probeTenantEndpoint} — an
+     * authenticated HTTPS health probe. Inject a stub in tests so no spec ever needs a live tenant
+     * or a real PAT. Plain field, mirroring `FleetLifecycleService.spawnFn`.
+     * @member {Function|null} probeFn=null
+     */
+    probeFn = null
+
+    /**
+     * @summary Connect a remote Agent-OS tenant: validate the URL, authenticate the transport with
+     * the PAT, persist the descriptor (+ the encrypted credential), and return the PUBLIC result.
+     *
+     * The returned object never carries the credential — the secret-omission boundary is the same
+     * one `defineAgent` enforces for agent PATs. Reconnecting an existing endpoint updates its
+     * descriptor + credential in place (re-auth is the point of a reconnect).
+     * @param {Object} params
+     * @param {String} params.tenantUrl  The hosted tenant's base URL (http/https).
+     * @param {String} params.credential The tenant PAT — stored encrypted, never returned.
+     * @returns {Promise<Object>} `{id, endpoint, status: 'connected', deploymentClass,
+     *     connectedAt}` on success; `{status: 'rejected', reason}` on any validation/auth failure.
+     */
+    async connectTenant({tenantUrl, credential} = {}) {
+        const endpoint = this.normalizeEndpoint(tenantUrl);
+
+        if (!endpoint) {
+            return {status: 'rejected', reason: 'tenantUrl must be a valid http(s) URL'};
+        }
+
+        if (typeof credential !== 'string' || credential.trim() === '') {
+            return {status: 'rejected', reason: 'credential (tenant PAT) is required'};
+        }
+
+        let probe;
+
+        try {
+            probe = await this.getProbeFn()({endpoint, credential});
+        } catch (error) {
+            // The probe's own failure text can carry the endpoint's internals — keep the outcome
+            // bounded and endpoint-scoped; the secret never appears in any reason string.
+            return {status: 'rejected', reason: 'tenant endpoint unreachable'};
+        }
+
+        if (!probe?.ok) {
+            return {status: 'rejected', reason: probe?.reason || 'tenant authentication failed'};
+        }
+
+        const descriptor = {
+            id             : this.tenantIdFor(endpoint),
+            endpoint,
+            status         : 'connected',
+            deploymentClass: 'cloud-tenant',
+            connectedAt    : new Date().toISOString()
+        };
+
+        this.writeDescriptor(descriptor);
+        this.writeCredential(descriptor.id, credential);
+
+        return {...descriptor};
+    }
+
+    /**
+     * @summary The public tenant descriptors — safe to render on any surface; never a credential.
+     * @returns {Object[]}
+     */
+    listTenants() {
+        return Object.values(this.readDescriptors()).map(descriptor => ({...descriptor}));
+    }
+
+    /**
+     * @summary Resolve one tenant's stored PAT for the Node-side transport that must present it.
+     * Brain-internal only: this method is NOT on any wire allowlist and must never be added to one.
+     * @param {String} tenantId
+     * @returns {String|null}
+     * @protected
+     */
+    getCredential(tenantId) {
+        const map = this.readCredentials();
+
+        return map[tenantId] ?? null;
+    }
+
+    /**
+     * @summary Normalizes + validates the tenant URL: http/https only, no credentials-in-URL, and a
+     * canonical origin+path form (no trailing slash) so one endpoint maps to one tenant id.
+     * @param {*} tenantUrl
+     * @returns {String|null}
+     * @protected
+     */
+    normalizeEndpoint(tenantUrl) {
+        if (typeof tenantUrl !== 'string' || tenantUrl.trim() === '') return null;
+
+        let url;
+
+        try {
+            url = new URL(tenantUrl.trim());
+        } catch {
+            return null;
+        }
+
+        if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+        // A URL-embedded secret would bypass the encrypted store — reject the shape outright.
+        if (url.username || url.password) return null;
+
+        return (url.origin + url.pathname).replace(/\/+$/, '');
+    }
+
+    /**
+     * @summary Stable tenant id from the endpoint: host plus a short endpoint digest — readable in
+     * a roster row, collision-safe across paths on one host.
+     * @param {String} endpoint
+     * @returns {String}
+     * @protected
+     */
+    tenantIdFor(endpoint) {
+        const digest = crypto.createHash('sha256').update(endpoint).digest('hex').slice(0, 8);
+
+        return `${new URL(endpoint).host}-${digest}`;
+    }
+
+    // ---- storage (public descriptors + encrypted credentials) ---------------
+
+    /**
+     * @summary Resolve (field > env > default) the fleet data directory — the registry precedent.
+     * @returns {String}
+     * @protected
+     */
+    getDataDir() {
+        return this.dataDir || process.env.NEO_FLEET_DATA_DIR || path.resolve(
+            path.dirname(fileURLToPath(import.meta.url)), '../../../.neo-ai-data/fleet'
+        );
+    }
+
+    /**
+     * @returns {Function} the transport probe (injected stub or {@link probeTenantEndpoint}).
+     * @protected
+     */
+    getProbeFn() {
+        return this.probeFn || probeTenantEndpoint;
+    }
+
+    /**
+     * @returns {Object} `{tenantId: descriptor}` from `tenants.json`; `{}` when absent/corrupt (fail-closed read).
+     * @protected
+     */
+    readDescriptors() {
+        try {
+            return JSON.parse(fs.readFileSync(path.join(this.getDataDir(), 'tenants.json'), 'utf8'));
+        } catch {
+            return {};
+        }
+    }
+
+    /**
+     * @summary Upserts one public descriptor; `0600` like every fleet store file.
+     * @param {Object} descriptor
+     * @protected
+     */
+    writeDescriptor(descriptor) {
+        const dir  = this.getDataDir(),
+              file = path.join(dir, 'tenants.json'),
+              map  = this.readDescriptors();
+
+        map[descriptor.id] = descriptor;
+
+        fs.mkdirSync(dir, {recursive: true});
+        fs.writeFileSync(file, JSON.stringify(map, null, 4), {encoding: 'utf8', mode: 0o600});
+    }
+
+    /**
+     * @returns {Object} the decrypted `{tenantId: pat}` map; `{}` when absent/locked/corrupt — the
+     * fail-closed read discipline of the agent-credential store.
+     * @protected
+     */
+    readCredentials() {
+        try {
+            const raw = fs.readFileSync(path.join(this.getDataDir(), 'tenant-credentials.enc'));
+
+            return JSON.parse(this.decrypt(raw));
+        } catch {
+            return {};
+        }
+    }
+
+    /**
+     * @summary Upserts one encrypted credential; the map is re-encrypted whole (AES-256-GCM, `0600`).
+     * @param {String} tenantId
+     * @param {String} credential
+     * @protected
+     */
+    writeCredential(tenantId, credential) {
+        const dir = this.getDataDir(),
+              map = this.readCredentials();
+
+        map[tenantId] = credential;
+
+        fs.mkdirSync(dir, {recursive: true});
+        fs.writeFileSync(path.join(dir, 'tenant-credentials.enc'), this.encrypt(JSON.stringify(map)), {mode: 0o600});
+    }
+
+    // ---- crypto (AES-256-GCM, the FleetRegistryService discipline) ----------
+
+    /**
+     * @param {String} plaintext
+     * @returns {Buffer} `iv(12) | authTag(16) | ciphertext`
+     * @protected
+     */
+    encrypt(plaintext) {
+        const iv     = crypto.randomBytes(12),
+              cipher = crypto.createCipheriv('aes-256-gcm', this.getKey(), iv),
+              enc    = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+
+        return Buffer.concat([iv, cipher.getAuthTag(), enc]);
+    }
+
+    /**
+     * @param {Buffer} payload `iv(12) | authTag(16) | ciphertext`
+     * @returns {String}
+     * @protected
+     */
+    decrypt(payload) {
+        const iv       = payload.subarray(0, 12),
+              tag      = payload.subarray(12, 28),
+              data     = payload.subarray(28),
+              decipher = crypto.createDecipheriv('aes-256-gcm', this.getKey(), iv);
+
+        decipher.setAuthTag(tag);
+
+        return Buffer.concat([decipher.update(data), decipher.final()]).toString('utf8');
+    }
+
+    /**
+     * @summary Resolve the 32-byte AES key: `NEO_FLEET_SECRET_KEY` (hex or base64) if set, else the
+     * generated `fleet.key` dev file — the SAME key source as the agent-credential store, so one
+     * operator secret governs both reversible credential classes.
+     * @returns {Buffer}
+     * @protected
+     */
+    getKey() {
+        const envKey = process.env.NEO_FLEET_SECRET_KEY;
+
+        if (envKey) {
+            const buffer = /^[0-9a-f]{64}$/i.test(envKey) ? Buffer.from(envKey, 'hex') : Buffer.from(envKey, 'base64');
+
+            if (buffer.length !== 32) {
+                throw new Error('FleetTenantService: NEO_FLEET_SECRET_KEY must decode to 32 bytes (AES-256).');
+            }
+
+            return buffer;
+        }
+
+        const keyFile = path.join(this.getDataDir(), 'fleet.key');
+
+        try {
+            const key = Buffer.from(fs.readFileSync(keyFile, 'utf8').trim(), 'hex');
+
+            if (key.length === 32) return key;
+        } catch {
+            // fall through to generation
+        }
+
+        const key = crypto.randomBytes(32);
+
+        fs.mkdirSync(this.getDataDir(), {recursive: true});
+        fs.writeFileSync(keyFile, key.toString('hex'), {encoding: 'utf8', mode: 0o600});
+
+        return key;
+    }
+}
+
+/**
+ * @summary The default transport probe: an authenticated GET against the tenant endpoint's health
+ * path, bearer-presented, bounded timeout. Any 2xx authenticates; 401/403 is a named auth
+ * rejection; everything else is unreachable.
+ * @param {Object} options
+ * @param {String} options.endpoint   Normalized tenant base URL.
+ * @param {String} options.credential The tenant PAT (used for the probe only; never logged).
+ * @returns {Promise<Object>} `{ok}` plus, when available, `status` and a bounded `reason`.
+ */
+export async function probeTenantEndpoint({endpoint, credential}) {
+    const response = await fetch(`${endpoint}/health`, {
+        headers: {Authorization: `Bearer ${credential}`},
+        signal : AbortSignal.timeout(10_000)
+    });
+
+    if (response.ok) return {ok: true, status: response.status};
+
+    return {
+        ok    : false,
+        status: response.status,
+        reason: response.status === 401 || response.status === 403
+            ? 'tenant rejected the credential'
+            : `tenant health probe failed (${response.status})`
+    };
+}
+
+export default Neo.setupClass(FleetTenantService);

--- a/src/ai/fleet/fleetWireMethods.mjs
+++ b/src/ai/fleet/fleetWireMethods.mjs
@@ -24,5 +24,5 @@
 export const FLEET_WIRE_METHODS = Object.freeze([
     'defineAgent', 'configureAgent', 'setRepo', 'setAvatar', 'listAgents', 'getAgent',
     'startAgent', 'stopAgent', 'restartAgent', 'removeAgent', 'fleetStatus', 'fleetRuntimeStatus',
-    'getBootIdentity', 'fleetActivity', 'fleetRoster'
+    'getBootIdentity', 'fleetActivity', 'fleetRoster', 'connectTenant', 'listTenants'
 ]);

--- a/test/playwright/unit/ai/services/fleet/FleetTenantService.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetTenantService.spec.mjs
@@ -214,6 +214,42 @@ test.describe.serial('Neo.ai.services.fleet.FleetTenantService — connectTenant
         expect(Object.values(FleetTenantService.readCredentials())).not.toContain('pat-doomed')
     })
 
+    test('a credential-store failure returns the bounded rejection and preserves both prior stores', async () => {
+        FleetTenantService.probeFn = async () => ({ok: true})
+
+        const first = await FleetTenantService.connectTenant({tenantUrl: 'https://kept.example.com', credential: 'pat-kept'})
+
+        const descriptorBefore = fs.readFileSync(path.join(tmpDir, 'tenants.json')),
+              credentialBefore = fs.readFileSync(path.join(tmpDir, 'tenant-credentials.enc'))
+
+        const publishAtomically = FleetTenantService.publishAtomically.bind(FleetTenantService)
+
+        FleetTenantService.publishAtomically = (file, contents) => {
+            if (file.endsWith('tenant-credentials.enc')) {
+                throw new Error(`credential write failed with ${PAT}`)
+            }
+
+            return publishAtomically(file, contents)
+        }
+
+        let result
+
+        try {
+            result = await FleetTenantService.connectTenant({tenantUrl: 'https://doomed.example.com', credential: 'pat-doomed'})
+        } finally {
+            FleetTenantService.publishAtomically = publishAtomically
+        }
+
+        expect(result).toEqual({status: 'rejected', reason: 'tenant connection could not be persisted'})
+        expect(JSON.stringify(result)).not.toContain(PAT)
+        expect(fs.readFileSync(path.join(tmpDir, 'tenants.json'))).toEqual(descriptorBefore)
+        expect(fs.readFileSync(path.join(tmpDir, 'tenant-credentials.enc'))).toEqual(credentialBefore)
+        expect(FleetTenantService.listTenants().map(tenant => tenant.endpoint)).toEqual(['https://kept.example.com'])
+        expect(FleetTenantService.getCredential(first.id)).toBe('pat-kept')
+        expect(Object.values(FleetTenantService.readCredentials())).not.toContain('pat-doomed')
+        expect(fs.readdirSync(tmpDir).filter(name => name.includes('.tmp'))).toEqual([])
+    })
+
     test('publication is atomic and leaves no temp files behind', async () => {
         FleetTenantService.probeFn = async () => ({ok: true})
 

--- a/test/playwright/unit/ai/services/fleet/FleetTenantService.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetTenantService.spec.mjs
@@ -126,6 +126,101 @@ test.describe.serial('Neo.ai.services.fleet.FleetTenantService — connectTenant
         expect(FleetTenantService.listTenants()).toHaveLength(1)
         expect(FleetTenantService.getCredential(first.id)).toBe('pat-two')
     })
+
+    test('a REMOTE plain-http endpoint is refused — the bearer must not cross a network in clear', async () => {
+        const probed = []
+        FleetTenantService.probeFn = async args => { probed.push(args); return {ok: true} }
+
+        expect(await FleetTenantService.connectTenant({tenantUrl: 'http://tenant.example.com', credential: PAT}))
+            .toMatchObject({status: 'rejected'})
+
+        // Refused at validation, BEFORE the probe: the credential never reached the transport at all.
+        expect(probed).toEqual([])
+        expect(FleetTenantService.listTenants()).toEqual([])
+    })
+
+    test('plain http stays available for LOOPBACK development only — the bounded exception', async () => {
+        FleetTenantService.probeFn = async () => ({ok: true})
+
+        for (const host of ['localhost:9000', '127.0.0.1:9000', '[::1]:9000']) {
+            const result = await FleetTenantService.connectTenant({tenantUrl: `http://${host}`, credential: PAT})
+
+            expect(result).toMatchObject({status: 'connected'})
+        }
+
+        // A neighbouring host is NOT loopback, however much it looks like one.
+        expect(await FleetTenantService.connectTenant({tenantUrl: 'http://127.0.0.1.evil.example.com', credential: PAT}))
+            .toMatchObject({status: 'rejected'})
+        expect(await FleetTenantService.connectTenant({tenantUrl: 'http://localhost.evil.example.com', credential: PAT}))
+            .toMatchObject({status: 'rejected'})
+    })
+
+    test('a hostile probe reason NEVER reaches the caller — the failure vocabulary is closed, not sanitized', async () => {
+        // The probe is a collaborator whose text the remote tenant shapes. Even handed the
+        // credential verbatim plus an injection attempt, the outcome carries only our own sentence.
+        FleetTenantService.probeFn = async () => ({
+            ok    : false,
+            status: 401,
+            reason: `PAT ${PAT} rejected; contact admin@evil.example.com or run rm -rf /`
+        })
+
+        const result = await FleetTenantService.connectTenant({tenantUrl: 'https://t.example.com', credential: PAT})
+
+        expect(result).toEqual({status: 'rejected', reason: 'tenant rejected the credential'})
+        expect(JSON.stringify(result)).not.toContain(PAT)
+        expect(JSON.stringify(result)).not.toContain('evil.example.com')
+        expect(JSON.stringify(result)).not.toContain('rm -rf')
+    })
+
+    test('an unmapped probe status still yields a bounded reason, never a fabricated success', async () => {
+        FleetTenantService.probeFn = async () => ({ok: false, status: 503})
+        expect(await FleetTenantService.connectTenant({tenantUrl: 'https://t.example.com', credential: PAT}))
+            .toEqual({status: 'rejected', reason: 'tenant health probe failed (503)'})
+
+        // No status at all — the probe answered ok:false and nothing else.
+        FleetTenantService.probeFn = async () => ({ok: false})
+        expect(await FleetTenantService.connectTenant({tenantUrl: 'https://t.example.com', credential: PAT}))
+            .toEqual({status: 'rejected', reason: 'tenant authentication failed'})
+    })
+
+    test('credential-first / descriptor-last: a failed public publish rolls the credential back and strands NO connected state', async () => {
+        FleetTenantService.probeFn = async () => ({ok: true})
+
+        // Land a good tenant first, so the rollback has a prior snapshot to restore.
+        const first = await FleetTenantService.connectTenant({tenantUrl: 'https://kept.example.com', credential: 'pat-kept'})
+
+        // Now make the PUBLIC descriptor publish fail on the next connect.
+        const publishAtomically = FleetTenantService.publishAtomically.bind(FleetTenantService)
+
+        FleetTenantService.publishAtomically = (file, contents) => {
+            if (file.endsWith('tenants.json')) throw new Error('disk full')
+            return publishAtomically(file, contents)
+        }
+
+        try {
+            const result = await FleetTenantService.connectTenant({tenantUrl: 'https://doomed.example.com', credential: 'pat-doomed'})
+
+            expect(result).toMatchObject({status: 'rejected'})
+            expect(JSON.stringify(result)).not.toContain('disk full')
+        } finally {
+            FleetTenantService.publishAtomically = publishAtomically
+        }
+
+        // The failed connect left NOTHING behind: no descriptor claiming connected...
+        expect(FleetTenantService.listTenants().map(tenant => tenant.endpoint)).toEqual(['https://kept.example.com'])
+
+        // ...and no orphan credential — the prior snapshot is restored intact.
+        expect(FleetTenantService.getCredential(first.id)).toBe('pat-kept')
+        expect(Object.values(FleetTenantService.readCredentials())).not.toContain('pat-doomed')
+    })
+
+    test('publication is atomic and leaves no temp files behind', async () => {
+        FleetTenantService.probeFn = async () => ({ok: true})
+
+        await FleetTenantService.connectTenant({tenantUrl: 'https://t.example.com', credential: PAT})
+
+        expect(fs.readdirSync(tmpDir).filter(name => name.includes('.tmp'))).toEqual([])
+    })
 })
 
 test.describe.serial('FleetControlBridge + wire — the remote-tenant surface', () => {

--- a/test/playwright/unit/ai/services/fleet/FleetTenantService.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetTenantService.spec.mjs
@@ -1,0 +1,167 @@
+import {setup} from '../../../../setup.mjs'
+
+const appName = 'FleetTenantServiceTest'
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+})
+
+import {test, expect} from '@playwright/test'
+import fs             from 'node:fs'
+import os             from 'node:os'
+import path           from 'node:path'
+import Neo            from '../../../../../../src/Neo.mjs'
+import * as core      from '../../../../../../src/core/_export.mjs'
+
+import FleetTenantService     from '../../../../../../ai/services/fleet/FleetTenantService.mjs'
+import FleetControlBridge     from '../../../../../../ai/services/fleet/FleetControlBridge.mjs'
+import {dispatchFleetRequest} from '../../../../../../ai/services/fleet/dispatchFleetRequest.mjs'
+import {FLEET_WIRE_METHODS}   from '../../../../../../src/ai/fleet/fleetWireMethods.mjs'
+
+const PAT = 'glpat-SUPER-SECRET-tenant-credential-42'
+
+let sequence = 0, tmpDir
+
+/**
+ * Self-test for the remote-tenant connect surface — the design-partner entry. The binding security
+ * contract: the tenant PAT rides IN, authenticates the probe, persists ONLY encrypted (AES-256-GCM,
+ * 0600), and is never echoed by any return value, any public store file, or any wire-reachable
+ * method. Fail-closed everywhere: bad URLs, URL-embedded credentials, rejected bearers, and
+ * unreachable endpoints all yield controlled rejected outcomes with no descriptor persisted.
+ */
+test.describe.serial('Neo.ai.services.fleet.FleetTenantService — connectTenant', () => {
+    test.beforeEach(() => {
+        sequence++
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `fleet-tenant-${sequence}-`))
+        FleetTenantService.dataDir = tmpDir
+    })
+
+    test.afterEach(() => {
+        FleetTenantService.dataDir = null
+        FleetTenantService.probeFn = null
+        fs.rmSync(tmpDir, {force: true, recursive: true})
+    })
+
+    test('a successful connect returns the PUBLIC descriptor: endpoint, connected status, cloud-tenant posture — no credential', async () => {
+        FleetTenantService.probeFn = async () => ({ok: true, status: 200})
+
+        const result = await FleetTenantService.connectTenant({tenantUrl: 'https://tenant.example.com/agentos/', credential: PAT})
+
+        expect(result).toMatchObject({
+            endpoint       : 'https://tenant.example.com/agentos',
+            status         : 'connected',
+            deploymentClass: 'cloud-tenant'
+        })
+        expect(result.id).toContain('tenant.example.com')
+        expect(typeof result.connectedAt).toBe('string')
+        expect(JSON.stringify(result)).not.toContain(PAT)
+    })
+
+    test('the PAT is never echoed: not in listTenants, not in the public store file — only in the encrypted store, decryptable Brain-side', async () => {
+        FleetTenantService.probeFn = async () => ({ok: true})
+
+        const {id} = await FleetTenantService.connectTenant({tenantUrl: 'https://tenant.example.com', credential: PAT})
+
+        expect(JSON.stringify(FleetTenantService.listTenants())).not.toContain(PAT)
+
+        const publicStore = fs.readFileSync(path.join(tmpDir, 'tenants.json'), 'utf8')
+        expect(publicStore).not.toContain(PAT)
+
+        const encryptedStore = fs.readFileSync(path.join(tmpDir, 'tenant-credentials.enc'))
+        expect(encryptedStore.includes(Buffer.from(PAT))).toBe(false)
+
+        // The Brain-internal read (NOT wire-reachable) round-trips the credential for the transport.
+        expect(FleetTenantService.getCredential(id)).toBe(PAT)
+    })
+
+    test('the probe receives the credential exactly once, for authentication only', async () => {
+        const probeCalls = []
+        FleetTenantService.probeFn = async args => { probeCalls.push(args); return {ok: true} }
+
+        await FleetTenantService.connectTenant({tenantUrl: 'https://t.example.com', credential: PAT})
+
+        expect(probeCalls).toEqual([{endpoint: 'https://t.example.com', credential: PAT}])
+    })
+
+    test('fail-closed URL validation: malformed, non-http(s), and credential-embedded URLs all reject without persisting', async () => {
+        FleetTenantService.probeFn = async () => ({ok: true})
+
+        expect(await FleetTenantService.connectTenant({tenantUrl: 'not a url', credential: PAT})).toMatchObject({status: 'rejected'})
+        expect(await FleetTenantService.connectTenant({tenantUrl: 'ftp://x.example.com', credential: PAT})).toMatchObject({status: 'rejected'})
+        expect(await FleetTenantService.connectTenant({tenantUrl: 'https://user:pass@x.example.com', credential: PAT})).toMatchObject({status: 'rejected'})
+        expect(await FleetTenantService.connectTenant({tenantUrl: 'https://ok.example.com'})).toMatchObject({status: 'rejected', reason: 'credential (tenant PAT) is required'})
+
+        expect(FleetTenantService.listTenants()).toEqual([])
+        expect(fs.existsSync(path.join(tmpDir, 'tenant-credentials.enc'))).toBe(false)
+    })
+
+    test('a rejected bearer and an unreachable endpoint both fail closed with bounded reasons — nothing persisted', async () => {
+        FleetTenantService.probeFn = async () => ({ok: false, status: 401, reason: 'tenant rejected the credential'})
+        expect(await FleetTenantService.connectTenant({tenantUrl: 'https://t.example.com', credential: PAT}))
+            .toEqual({status: 'rejected', reason: 'tenant rejected the credential'})
+
+        FleetTenantService.probeFn = async () => { throw new Error(`ECONNREFUSED with ${PAT} in some transport dump`) }
+        const result = await FleetTenantService.connectTenant({tenantUrl: 'https://t.example.com', credential: PAT})
+
+        // The rejection reason is bounded and endpoint-scoped — a throwing transport can never leak
+        // the credential (or internals) into the outcome.
+        expect(result).toEqual({status: 'rejected', reason: 'tenant endpoint unreachable'})
+        expect(FleetTenantService.listTenants()).toEqual([])
+    })
+
+    test('reconnecting the same endpoint updates the descriptor in place — one endpoint, one tenant id', async () => {
+        FleetTenantService.probeFn = async () => ({ok: true})
+
+        const first  = await FleetTenantService.connectTenant({tenantUrl: 'https://t.example.com', credential: 'pat-one'}),
+              second = await FleetTenantService.connectTenant({tenantUrl: 'https://t.example.com/', credential: 'pat-two'})
+
+        expect(second.id).toBe(first.id)
+        expect(FleetTenantService.listTenants()).toHaveLength(1)
+        expect(FleetTenantService.getCredential(first.id)).toBe('pat-two')
+    })
+})
+
+test.describe.serial('FleetControlBridge + wire — the remote-tenant surface', () => {
+    test.afterEach(() => {
+        FleetControlBridge.tenantService = null
+    })
+
+    test('connectTenant and listTenants delegate through the injectable tenant seam', async () => {
+        const calls = []
+
+        FleetControlBridge.tenantService = {
+            connectTenant: async params => { calls.push(['connectTenant', params]); return {id: 't', status: 'connected'} },
+            listTenants  : () => { calls.push(['listTenants']); return [{id: 't'}] }
+        }
+
+        await expect(FleetControlBridge.connectTenant({tenantUrl: 'https://t', credential: 'x'})).resolves.toEqual({id: 't', status: 'connected'})
+        expect(FleetControlBridge.listTenants()).toEqual([{id: 't'}])
+        expect(calls).toEqual([['connectTenant', {tenantUrl: 'https://t', credential: 'x'}], ['listTenants']])
+    })
+
+    test('both verbs are on the wire allowlist; the credential reader is NOT and can never be dispatched', async () => {
+        expect(FLEET_WIRE_METHODS).toContain('connectTenant')
+        expect(FLEET_WIRE_METHODS).toContain('listTenants')
+        expect(FLEET_WIRE_METHODS).not.toContain('getCredential')
+
+        const rejected = await dispatchFleetRequest({method: 'getCredential', params: 't'})
+        expect(rejected).toEqual({ok: false, error: "fleet: method 'getCredential' is not on the control surface"})
+    })
+
+    test('a connectTenant dispatched over the wire returns the fail-closed envelope on service rejection', async () => {
+        FleetControlBridge.tenantService = {
+            connectTenant: async () => ({status: 'rejected', reason: 'tenant rejected the credential'})
+        }
+
+        const result = await dispatchFleetRequest({method: 'connectTenant', params: {tenantUrl: 'https://t', credential: 'bad'}})
+
+        expect(result).toEqual({ok: true, result: {status: 'rejected', reason: 'tenant rejected the credential'}})
+    })
+})

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -116,7 +116,7 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
             // fleet-agent operations (incl. the configureAgent scoped-config patch — never identity,
             // never credential) + the read-observe verbs (boot-identity fact + activity snapshot +
             // assembled roster DTO — advisory reads, no lifecycle-write)
-            ['configureAgent', 'defineAgent', 'fleetActivity', 'fleetRoster', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'getBootIdentity', 'listAgents', 'removeAgent', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
+            ['configureAgent', 'connectTenant', 'defineAgent', 'fleetActivity', 'fleetRoster', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'getBootIdentity', 'listAgents', 'listTenants', 'removeAgent', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
         );
         expect(FLEET_WIRE_METHODS).toContain('getBootIdentity');   // the read-observe verbs ride the wire; the lifecycle-write restart actuator does NOT (R3)
         expect(FLEET_WIRE_METHODS).toContain('fleetActivity');
@@ -130,5 +130,7 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
         // ...and neither may its READ counterpart: getDefinition is the only surface carrying
         // metadata.launch (the public projection redacts it), so it stays off the wire too
         expect(FLEET_WIRE_METHODS).not.toContain('getDefinition');
+        // the tenant-credential reader is Brain-internal only — the PAT must never be wire-reachable
+        expect(FLEET_WIRE_METHODS).not.toContain('getCredential');
     });
 });


### PR DESCRIPTION
Resolves #14574

The design-partner entry lands: `connectTenant({tenantUrl, credential})` points the cockpit at a hosted Agent-OS tenant instead of requiring the local stack.

`FleetTenantService` validates the endpoint before any secret-bearing request: remote targets require HTTPS, while plain HTTP is restricted to the exact loopback development set; credential-bearing URLs are rejected outright. An injected bearer probe provides the transport seam with a bounded timeout and a closed public failure vocabulary. Collaborator- or remote-supplied error prose is discarded, so the result is always either a redacted public descriptor or a stable `{status: 'rejected', reason}` envelope.

Persistence is a two-store transaction. The public descriptor lives in `tenants.json`; the PAT lives in the separate AES-256-GCM encrypted `tenant-credentials.enc` store with `0600` permissions. Credential publication happens first, descriptor publication last, both through same-directory temp-file + atomic rename. Descriptor failure restores the prior credential snapshot, and credential encryption/write/rename failure returns the same bounded rejection without changing either prior store. `deploymentClass: 'cloud-tenant'` is this profile's local descriptor classification, owned by #14574 rather than a retired deployment detector.

Wire surface: `connectTenant` + `listTenants` are allowlisted on `FleetControlBridge` and `FLEET_WIRE_METHODS`; the generated browser bridge exposes both automatically. The Brain-internal `getCredential` reader deliberately remains off-wire and is pinned by a dispatch-rejection spec.

Evidence: **L2 achieved and required.** The close target is a service/wire contract proven through hermetic filesystem, crypto, collaborator, and dispatch witnesses plus exact-head hosted CI. Compatibility with a real hosted tenant remains explicit Post-Merge Validation and is not claimed by the injected probe.

## Deltas from ticket

- AC-3 is delivered at the tenant grain: `listTenants` uses the same read/observe wire class as the local fleet views, carrying endpoint, status, and posture. Mirroring the hosted tenant's own AGENT roster is the named successor lane and should receive its own ticket when picked up; `getCredential` is its ready Brain-internal entry seam.
- Reconnecting an existing endpoint updates descriptor + credential in place: one normalized endpoint, one stable tenant id.
- The shared fleet secret source remains aligned with `FleetRegistryService`. Deduplicating the two crypto implementations is a separate cross-service hardening concern, not part of this entry leaf.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/FleetTenantService.spec.mjs` — **16/16 passed** at `93b0a69091`, including remote-HTTP refusal before probe, bounded collaborator failures, PAT non-disclosure, credential/descriptor rollback, atomic publication, restart reads, and the credential-store failure witness.
- Grace's repair receipt at `fd3fdfe445` — **47/47 passed** across tenant, bridge, and dispatch specs.
- Exact-head hosted CI at `93b0a69091` — **11/11 green**, including unit, integration, CodeQL, ticket archaeology, and the PR/body/config linters.
- `createFleetRegistryBridge.spec` keeps the generated browser bridge keys equal to `FLEET_WIRE_METHODS`; `dispatchFleetRequest.spec` pins the new verbs and the negative `getCredential` boundary.

## Post-Merge Validation

- [ ] Connect to a self-deployed hosted tenant with an operator-held PAT and verify the real `/health` compatibility path.
- [ ] Create the separate remote-tenant AGENT-roster mirror successor before consuming `getCredential` over a new authenticated read path.

## Review routing note

Security-sensitive credential persistence received cross-family review plus bounded maintainer polish. The final credential-write failure seam was repaired directly at `93b0a69091`; no additional correction cycle is required.

Related: #13015 (parent) · #14560 (connect UI leaf) · #14537 (blocked sibling verb).

Authored by Grace (Claude Fable 5, Claude Code). Session `f7a6fdb7-8667-45d2-8d43-cbd3f16c6027`.

Maintainer polish by Euclid (@neo-gpt) · OpenAI GPT-5.6 Sol Ultra.
