### PR TITLE
feat(build): npm run cockpit — the one-command live-by-default FM boot (#15283)

### DIFF
--- a/buildScripts/devCockpit.mjs
+++ b/buildScripts/devCockpit.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * @module buildScripts/devCockpit
+ * @summary The one-command cockpit boot: `npm run cockpit` supervises BOTH processes a live
+ * Fleet-Manager session needs — the webpack dev server (`npm run server-start`, byte-untouched)
+ * and the fleet HTTP transport (`ai/services/fleet/devFleetServer.mjs`) — so a fresh boot lands
+ * on a live cockpit instead of the fail-closed sample seeds.
+ *
+ * Placement: npm-script entries live in the buildScripts tooling family; the fleet server itself
+ * stays a Brain service under `ai/` — this file only supervises.
+ *
+ * Shared-machine honesty (multiple checkouts, one loopback): the fleet port is PROBED first.
+ * A port already serving means another checkout (or a prior run) owns the transport — the
+ * launcher REUSES it with a named log line and spawns only webpack, never a silent second
+ * server fighting over the socket. `NEO_FLEET_PORT` passes through (default 8083, matching
+ * `installFleetBridge`'s target).
+ *
+ * Signals: SIGINT/SIGTERM forward to every child this launcher spawned; a webpack exit tears
+ * the session down; a fleet-server exit logs loudly but keeps webpack serving — the cockpit
+ * degrades fail-closed to its honest seed/stale states (the operable-cold surface names it).
+ */
+import {spawn}            from 'node:child_process';
+import {createConnection} from 'node:net';
+
+const FLEET_PORT_DEFAULT = 8083;
+
+/**
+ * @summary Probes whether a loopback TCP port already accepts connections.
+ * @param {Number} port
+ * @param {Number} [timeoutMs=750]
+ * @returns {Promise<Boolean>} `true` when something is listening.
+ */
+export function probePort(port, timeoutMs = 750) {
+    return new Promise(resolve => {
+        const socket = createConnection({host: '127.0.0.1', port});
+
+        const settle = listening => {
+            socket.destroy();
+            resolve(listening)
+        };
+
+        socket.setTimeout(timeoutMs);
+        socket.once('connect', () => settle(true));
+        socket.once('timeout', () => settle(false));
+        socket.once('error',   () => settle(false))
+    })
+}
+
+/**
+ * @summary The pure boot-plan decision the witness pins: given the probed fleet-port state,
+ * which processes does the launcher spawn and what does it tell the operator?
+ * @param {Object} options
+ * @param {Boolean} options.fleetPortBusy The probe result for the fleet port.
+ * @param {Number}  options.fleetPort     The resolved fleet port.
+ * @returns {{spawnFleet: Boolean, spawnWebpack: Boolean, notes: String[]}}
+ */
+export function planCockpitBoot({fleetPortBusy, fleetPort}) {
+    return {
+        spawnFleet  : !fleetPortBusy,
+        spawnWebpack: true,
+        notes       : fleetPortBusy
+            ? [`fleet transport already serving :${fleetPort} — reusing it (another checkout or a prior run); not spawning a second server`]
+            : [`starting fleet transport on :${fleetPort}`]
+    }
+}
+
+/**
+ * @summary Process entry: probe, plan, spawn, supervise.
+ * @returns {Promise<void>}
+ * @protected
+ */
+async function main() {
+    const
+        fleetPort = Number(process.env.NEO_FLEET_PORT) || FLEET_PORT_DEFAULT,
+        busy      = await probePort(fleetPort),
+        plan      = planCockpitBoot({fleetPort, fleetPortBusy: busy}),
+        children  = [];
+
+    plan.notes.forEach(note => console.log(`[cockpit] ${note}`));
+
+    if (plan.spawnFleet) {
+        const fleet = spawn(process.execPath, ['ai/services/fleet/devFleetServer.mjs'], {
+            env  : process.env,
+            stdio: 'inherit'
+        });
+
+        children.push(fleet);
+
+        fleet.on('exit', code => {
+            // fail-closed, not fail-silent: the cockpit keeps serving on seeds/stale states,
+            // and the log names the loss so the operator knows why controls degraded
+            console.error(`[cockpit] fleet transport exited (code ${code}) — the cockpit degrades to its honest offline states; restart with: npm run ai:fleet-server`)
+        })
+    }
+
+    const npmCmd  = process.platform === 'win32' ? 'npm.cmd' : 'npm',
+          webpack = spawn(npmCmd, ['run', 'server-start'], {
+              env  : process.env,
+              stdio: 'inherit'
+          });
+
+    children.push(webpack);
+
+    webpack.on('exit', code => {
+        // the app server is the session: tear everything down with it
+        children.forEach(child => child !== webpack && !child.killed && child.kill('SIGTERM'));
+        process.exit(code ?? 0)
+    });
+
+    ['SIGINT', 'SIGTERM'].forEach(signal => {
+        process.on(signal, () => {
+            children.forEach(child => !child.killed && child.kill(signal))
+        })
+    })
+}
+
+// Process-entry only: never run on import, so the witness can import the pure helpers.
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+    main()
+}

--- a/buildScripts/devCockpit.mjs
+++ b/buildScripts/devCockpit.mjs
@@ -2,81 +2,186 @@
 /**
  * @module buildScripts/devCockpit
  * @summary The one-command cockpit boot: `npm run cockpit` supervises BOTH processes a live
- * Fleet-Manager session needs — the webpack dev server (`npm run server-start`, byte-untouched)
- * and the fleet HTTP transport (`ai/services/fleet/devFleetServer.mjs`) — so a fresh boot lands
- * on a live cockpit instead of the fail-closed sample seeds.
+ * Fleet-Manager session needs — the webpack dev server (opened DIRECTLY on the AgentOS cockpit
+ * surface via `--open-target`) and the fleet HTTP transport (`ai/services/fleet/devFleetServer.mjs`)
+ * — so a fresh boot lands on a live cockpit instead of the fail-closed sample seeds.
  *
  * Placement: npm-script entries live in the buildScripts tooling family; the fleet server itself
  * stays a Brain service under `ai/` — this file only supervises.
  *
- * Shared-machine honesty (multiple checkouts, one loopback): the fleet port is PROBED first.
- * A port already serving means another checkout (or a prior run) owns the transport — the
- * launcher REUSES it with a named log line and spawns only webpack, never a silent second
- * server fighting over the socket. `NEO_FLEET_PORT` passes through (default 8083, matching
- * `installFleetBridge`'s target).
+ * Endpoint authority (one source, fail-closed): the browser consumer (`apps/agentos/app.mjs` →
+ * `installFleetBridge`) pins the default `http://127.0.0.1:8083/fleet` endpoint. Until an endpoint
+ * propagation seam ships, a non-default `NEO_FLEET_PORT` would boot a server the browser never
+ * reaches — so this launcher REFUSES non-default ports with a named reason instead of composing a
+ * silently-broken session. (`devFleetServer` keeps honoring the env var for standalone use.)
  *
- * Signals: SIGINT/SIGTERM forward to every child this launcher spawned; a webpack exit tears
- * the session down; a fleet-server exit logs loudly but keeps webpack serving — the cockpit
- * degrades fail-closed to its honest seed/stale states (the operable-cold surface names it).
+ * Fleet identity, not "some TCP listener": before reusing a busy port, the launcher PROBES the
+ * fleet protocol — `POST /fleet {method:'__cockpit_probe__'}` answers with the wire allowlist's
+ * deterministic rejection envelope on a REAL fleet server (side-effect-free by construction: an
+ * unlisted method never reaches the control bridge). A listener that answers anything else is an
+ * INCOMPATIBLE occupant and the launcher refuses with a named reason — never a silent second
+ * server, never a false reuse.
+ *
+ * Signals: SIGINT/SIGTERM forward to every child this launcher spawned; a webpack exit tears the
+ * session down; a fleet-server exit logs loudly while the cockpit degrades to its honest
+ * seed/stale states (the operable-cold banner names it on the surface).
  */
-import {spawn}            from 'node:child_process';
-import {createConnection} from 'node:net';
+import {spawn} from 'node:child_process';
+import http    from 'node:http';
 
 const FLEET_PORT_DEFAULT = 8083;
 
 /**
- * @summary Probes whether a loopback TCP port already accepts connections.
+ * @summary The cockpit page the composed command opens — the close-target surface, not the
+ * dev-server root.
+ * @type {String}
+ */
+export const COCKPIT_OPEN_TARGET = 'apps/agentos/index.html';
+
+/**
+ * @summary The wire-protocol identity signature: `dispatchFleetRequest` rejects any method not on
+ * the `FLEET_WIRE_METHODS` allowlist with this exact envelope error — deterministic, stable, and
+ * side-effect-free (an unlisted method never reaches the control bridge), so it doubles as a
+ * fleet-service identity check.
+ * @type {String}
+ */
+export const FLEET_PROBE_METHOD = '__cockpit_probe__';
+
+/**
+ * @summary Probes what occupies the fleet endpoint. Three-way, fail-honest:
+ *  - `free` — nothing accepts connections (ECONNREFUSED / timeout on connect);
+ *  - `fleet` — the occupant speaks the fleet wire protocol (the allowlist-rejection envelope for
+ *    {@link FLEET_PROBE_METHOD} comes back HTTP 200 with `ok:false` naming the method);
+ *  - `incompatible` — SOMETHING listens but does not answer as a fleet server (wrong body, wrong
+ *    shape, non-HTTP, hang). Reuse would silently serve the wrong thing: the caller must refuse.
  * @param {Number} port
- * @param {Number} [timeoutMs=750]
- * @returns {Promise<Boolean>} `true` when something is listening.
+ * @param {Number} [timeoutMs=1500]
+ * @returns {Promise<{status: ('free'|'fleet'|'incompatible'), detail: String}>}
  */
-export function probePort(port, timeoutMs = 750) {
+export function probeFleetEndpoint(port, timeoutMs = 1500) {
     return new Promise(resolve => {
-        const socket = createConnection({host: '127.0.0.1', port});
+        const body = JSON.stringify({method: FLEET_PROBE_METHOD}),
+              req  = http.request({
+                  // one-shot socket (no keep-alive pooling): a probe must never hold a server's
+                  // close() open — and a supervisor's probe socket outliving the probe is a leak
+                  agent  : false,
+                  host   : '127.0.0.1',
+                  port,
+                  path   : '/fleet',
+                  method : 'POST',
+                  headers: {Connection: 'close', 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body)},
+                  timeout: timeoutMs
+              }, res => {
+                  let data = '';
+                  res.on('data', chunk => data += chunk);
+                  res.on('end', () => {
+                      try {
+                          const envelope = JSON.parse(data);
+                          if (envelope && envelope.ok === false &&
+                              typeof envelope.error === 'string' && envelope.error.includes(FLEET_PROBE_METHOD)) {
+                              return resolve({status: 'fleet', detail: 'wire-protocol identity confirmed'});
+                          }
+                          resolve({status: 'incompatible', detail: `listener answered, but not with the fleet envelope (${data.slice(0, 80)})`});
+                      } catch {
+                          resolve({status: 'incompatible', detail: 'listener answered non-JSON — not a fleet server'});
+                      }
+                  });
+              });
 
-        const settle = listening => {
-            socket.destroy();
-            resolve(listening)
-        };
+        req.on('timeout', () => {
+            req.destroy();
+            resolve({status: 'incompatible', detail: 'listener accepted the connection but never answered — not a fleet server'});
+        });
+        req.on('error', error => {
+            resolve(error.code === 'ECONNREFUSED'
+                ? {status: 'free', detail: 'nothing listening'}
+                : {status: 'incompatible', detail: `probe error: ${error.code || error.message}`});
+        });
 
-        socket.setTimeout(timeoutMs);
-        socket.once('connect', () => settle(true));
-        socket.once('timeout', () => settle(false));
-        socket.once('error',   () => settle(false))
-    })
+        req.end(body);
+    });
 }
 
 /**
- * @summary The pure boot-plan decision the witness pins: given the probed fleet-port state,
- * which processes does the launcher spawn and what does it tell the operator?
+ * @summary The pure boot-plan decision the witnesses pin: given the port authority and the probed
+ * endpoint occupant, which processes spawn — or why the launcher refuses.
+ *
+ * Refusals are fail-closed AND named:
+ *  - a non-default port cannot compose a working session (the browser consumer pins the default
+ *    endpoint) — refuse with the remedy;
+ *  - an incompatible occupant on the fleet port means reuse would serve the wrong thing — refuse
+ *    with the occupant detail.
  * @param {Object} options
- * @param {Boolean} options.fleetPortBusy The probe result for the fleet port.
- * @param {Number}  options.fleetPort     The resolved fleet port.
- * @returns {{spawnFleet: Boolean, spawnWebpack: Boolean, notes: String[]}}
+ * @param {Number} options.fleetPort The resolved fleet port.
+ * @param {('free'|'fleet'|'incompatible')} [options.endpointStatus] The probe result (omitted when refused pre-probe).
+ * @param {String} [options.endpointDetail=''] The probe detail line.
+ * @returns {{refuse: Boolean, spawnFleet: Boolean, spawnWebpack: Boolean, notes: String[]}}
  */
-export function planCockpitBoot({fleetPortBusy, fleetPort}) {
-    return {
-        spawnFleet  : !fleetPortBusy,
-        spawnWebpack: true,
-        notes       : fleetPortBusy
-            ? [`fleet transport already serving :${fleetPort} — reusing it (another checkout or a prior run); not spawning a second server`]
-            : [`starting fleet transport on :${fleetPort}`]
+export function planCockpitBoot({fleetPort, endpointStatus, endpointDetail = ''}) {
+    if (fleetPort !== FLEET_PORT_DEFAULT) {
+        return {
+            refuse      : true,
+            spawnFleet  : false,
+            spawnWebpack: false,
+            notes       : [
+                `REFUSED: NEO_FLEET_PORT=${fleetPort} — the browser consumer (installFleetBridge) pins the default :${FLEET_PORT_DEFAULT} endpoint, so a non-default port would boot a server the cockpit never reaches.`,
+                `Unset NEO_FLEET_PORT (or use the default) to compose a working session; endpoint propagation to the consumer is a tracked follow-up.`
+            ]
+        };
     }
+
+    if (endpointStatus === 'incompatible') {
+        return {
+            refuse      : true,
+            spawnFleet  : false,
+            spawnWebpack: false,
+            notes       : [
+                `REFUSED: :${fleetPort} is occupied by something that is NOT a fleet server (${endpointDetail}).`,
+                `Free the port or stop the foreign process — reusing it would silently serve the wrong thing.`
+            ]
+        };
+    }
+
+    if (endpointStatus === 'fleet') {
+        return {
+            refuse      : false,
+            spawnFleet  : false,
+            spawnWebpack: true,
+            notes       : [`fleet transport already serving :${fleetPort} (${endpointDetail}) — reusing it; not spawning a second server`]
+        };
+    }
+
+    return {
+        refuse      : false,
+        spawnFleet  : true,
+        spawnWebpack: true,
+        notes       : [`starting fleet transport on :${fleetPort}`]
+    };
 }
 
 /**
- * @summary Process entry: probe, plan, spawn, supervise.
+ * @summary Process entry: resolve authority, probe, plan, spawn, supervise. The webpack child is
+ * spawned via an injectable command seam (`NEO_COCKPIT_WEBPACK_CMD`, JSON `[cmd, ...args]`) so the
+ * composed-boot integration witness can substitute a stub without touching the production default.
  * @returns {Promise<void>}
  * @protected
  */
 async function main() {
     const
         fleetPort = Number(process.env.NEO_FLEET_PORT) || FLEET_PORT_DEFAULT,
-        busy      = await probePort(fleetPort),
-        plan      = planCockpitBoot({fleetPort, fleetPortBusy: busy}),
+        probe     = fleetPort === FLEET_PORT_DEFAULT ? await probeFleetEndpoint(fleetPort) : null,
+        plan      = planCockpitBoot({
+            fleetPort,
+            endpointStatus: probe?.status,
+            endpointDetail: probe?.detail ?? ''
+        }),
         children  = [];
 
     plan.notes.forEach(note => console.log(`[cockpit] ${note}`));
+
+    if (plan.refuse) {
+        process.exit(1);
+    }
 
     if (plan.spawnFleet) {
         const fleet = spawn(process.execPath, ['ai/services/fleet/devFleetServer.mjs'], {
@@ -93,11 +198,20 @@ async function main() {
         })
     }
 
-    const npmCmd  = process.platform === 'win32' ? 'npm.cmd' : 'npm',
-          webpack = spawn(npmCmd, ['run', 'server-start'], {
-              env  : process.env,
-              stdio: 'inherit'
-          });
+    let webpackCmd = ['npx', 'webpack', 'serve', '-c', './buildScripts/webpack/webpack.server.config.mjs', '--open-target', COCKPIT_OPEN_TARGET];
+    try {
+        const override = process.env.NEO_COCKPIT_WEBPACK_CMD && JSON.parse(process.env.NEO_COCKPIT_WEBPACK_CMD);
+        if (Array.isArray(override) && override.length && override.every(part => typeof part === 'string')) {
+            webpackCmd = override;
+        }
+    } catch {
+        // a malformed override is ignored — the production default stands
+    }
+
+    const webpack = spawn(webpackCmd[0], webpackCmd.slice(1), {
+        env  : process.env,
+        stdio: 'inherit'
+    });
 
     children.push(webpack);
 
@@ -114,7 +228,7 @@ async function main() {
     })
 }
 
-// Process-entry only: never run on import, so the witness can import the pure helpers.
+// Process-entry only: never run on import, so the witnesses can import the pure helpers.
 if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
     main()
 }

--- a/learn/agentos/RunningTheFleetCockpit.md
+++ b/learn/agentos/RunningTheFleetCockpit.md
@@ -1,0 +1,43 @@
+# Running the Fleet Cockpit
+
+The Fleet Manager cockpit is the operator's mission-control surface: the live agent roster, the
+activity stream, per-agent drill-in, and the lifecycle controls (start / stop / restart, the
+one-click morning start). A LIVE session needs two processes — the webpack dev server that serves
+the app, and the fleet HTTP transport the cockpit's controls and live feeds ride on.
+
+## The one command
+
+```bash
+npm run cockpit
+```
+
+That is the whole boot. The launcher (`buildScripts/devCockpit.mjs`) supervises both processes and
+opens the browser directly on the cockpit surface (`apps/agentos/index.html`). On a fresh checkout
+this lands you on a live roster with working controls — no second terminal, no manual server start.
+
+What it does, in order:
+
+1. **Probes the fleet endpoint** (`127.0.0.1:8083`) for *protocol identity* — not just "is the port
+   busy". A confirmed fleet transport (another checkout or a prior run) is **reused** with a named
+   log line; a foreign occupant (something else holding the port) makes the launcher **refuse with
+   a named reason** rather than compose a silently-broken session.
+2. **Starts the fleet transport** (`ai/services/fleet/devFleetServer.mjs`) when the endpoint is
+   free.
+3. **Starts the dev server** and opens the cockpit page.
+4. **Supervises both**: one `Ctrl-C` tears the whole session down; if the fleet transport dies
+   mid-session, the launcher logs the loss loudly and the cockpit degrades to its honest offline
+   states (clearly-labelled sample data) instead of pretending to be live.
+
+## Without the fleet transport
+
+The cockpit itself always boots — `npm run server-start` alone still serves it. Without the
+transport it shows the honestly-labelled sample roster and the controls stay inert: fail-closed,
+never fake-live. Start the transport later with `npm run ai:fleet-server` and the next poll goes
+live.
+
+## Ports
+
+The composed command runs on the default fleet endpoint (`:8083`) — the browser side of the bridge
+pins it. Setting a non-default `NEO_FLEET_PORT` makes the launcher refuse with a named reason
+rather than boot a server the cockpit can never reach (the standalone `npm run ai:fleet-server`
+keeps honoring the variable for advanced setups).

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -37,6 +37,7 @@
     {"name": "Agent OS & Conversational UIs",                          "parentId": null,                                 "isLeaf": false, "id": "AgentOS"},
         {"name": "Strategic Workflows",                                "parentId": "AgentOS",                                             "id": "agentos/StrategicWorkflows"},
         {"name": "The Flat-Peer Institution",                          "parentId": "AgentOS",                                             "id": "agentos/FlatPeerInstitution"},
+        {"name": "Running the Fleet Cockpit",                          "parentId": "AgentOS",                                             "id": "agentos/RunningTheFleetCockpit"},
         {"name": "Swarm Intelligence & Sub-Agents",                    "parentId": "AgentOS",                                             "id": "agentos/SwarmIntelligence"},
         {"name": "A2A Messaging & Wake Routing",                       "parentId": "AgentOS",                                             "id": "agentos/A2A"},
         {"name": "Identity Firewall & Governance",                     "parentId": "AgentOS",                                             "id": "agentos/IdentityFirewall"},

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
         "devindex:optin"                       : "node ./apps/devindex/services/cli.mjs optin",
         "devindex:optout"                      : "node ./apps/devindex/services/cli.mjs optout",
         "devindex:spider"                      : "node ./apps/devindex/services/cli.mjs spider",
+        "cockpit"                              : "node ./buildScripts/devCockpit.mjs",
         "devindex:update"                      : "node ./apps/devindex/services/cli.mjs update --limit 500",
         "generate-docs-json"                   : "node ./buildScripts/docs/jsdocx.mjs",
         "prepare"                              : "if [ \"$npm_config_package_lock_only\" = \"true\" ]; then exit 0; fi; husky && node ./ai/scripts/setup/initServerConfigs.mjs",

--- a/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
@@ -1,44 +1,159 @@
-import {test, expect}               from '@playwright/test';
-import {createServer}               from 'node:net';
-import {planCockpitBoot, probePort} from '../../../../../buildScripts/devCockpit.mjs';
+import {test, expect}  from '@playwright/test';
+import {spawn}         from 'node:child_process';
+import {createServer}  from 'node:net';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+// Neo namespace bootstrap (entry-point invariant): the fleet transport's module chain reaches the
+// fleet singletons' `Neo.setupClass` at load — mirror devFleetServer's bootstrap order.
+import Neo             from '../../../../../src/Neo.mjs';
+import * as core       from '../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../src/manager/Instance.mjs';
+
+import {COCKPIT_OPEN_TARGET, FLEET_PROBE_METHOD, planCockpitBoot, probeFleetEndpoint} from '../../../../../buildScripts/devCockpit.mjs';
+import {startFleetBridgeServer}                                                       from '../../../../../ai/services/fleet/fleetBridgeServer.mjs';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../..');
 
 /**
  * The boot-plan witnesses for the one-command cockpit launcher: the pure decision seam
- * (spawn-vs-reuse on the fleet port) and the probe primitive it feeds. The full two-process
- * supervision is process wiring behind the entry guard — the launcher's spawn targets
- * (`npm run server-start`, `devFleetServer.mjs`) carry their own suites.
+ * (refuse-on-authority-violation, refuse-on-incompatible-occupant, reuse-on-fleet-identity,
+ * spawn-on-free) and the identity probe run against the REAL fleet transport, a bare TCP
+ * listener, and a closed port — a listener is never presumed to be a fleet server.
  */
-test.describe('buildScripts/devCockpit — the live-by-default boot plan (#15283)', () => {
+test.describe('buildScripts/devCockpit — the live-by-default boot plan', () => {
 
-    test('a free fleet port → spawn the transport, named start note', () => {
-        const plan = planCockpitBoot({fleetPort: 8083, fleetPortBusy: false});
+    test('a non-default fleet port REFUSES with the named endpoint-authority reason', () => {
+        const plan = planCockpitBoot({fleetPort: 9999});
 
-        expect(plan.spawnFleet).toBe(true);
-        expect(plan.spawnWebpack).toBe(true);
-        expect(plan.notes[0]).toContain('starting fleet transport on :8083')
+        expect(plan.refuse).toBe(true);
+        expect(plan.spawnFleet).toBe(false);
+        expect(plan.spawnWebpack).toBe(false);
+        expect(plan.notes[0]).toContain('REFUSED');
+        expect(plan.notes[0]).toContain('installFleetBridge');
+        expect(plan.notes[0]).toContain(':8083');
+        expect(plan.notes[1]).toContain('follow-up')
     });
 
-    test('a busy fleet port → REUSE, never a silent second server (shared-machine honesty)', () => {
-        const plan = planCockpitBoot({fleetPort: 8083, fleetPortBusy: true});
+    test('an incompatible occupant REFUSES with the named occupant detail — never a false reuse', () => {
+        const plan = planCockpitBoot({fleetPort: 8083, endpointStatus: 'incompatible', endpointDetail: 'listener answered non-JSON — not a fleet server'});
 
+        expect(plan.refuse).toBe(true);
+        expect(plan.spawnFleet).toBe(false);
+        expect(plan.notes[0]).toContain('REFUSED');
+        expect(plan.notes[0]).toContain('NOT a fleet server');
+        expect(plan.notes[0]).toContain('non-JSON')
+    });
+
+    test('a confirmed fleet occupant → REUSE, never a second server', () => {
+        const plan = planCockpitBoot({fleetPort: 8083, endpointStatus: 'fleet', endpointDetail: 'wire-protocol identity confirmed'});
+
+        expect(plan.refuse).toBe(false);
         expect(plan.spawnFleet).toBe(false);
         expect(plan.spawnWebpack).toBe(true);
-        expect(plan.notes[0]).toContain('already serving :8083');
         expect(plan.notes[0]).toContain('reusing');
         expect(plan.notes[0]).toContain('not spawning a second server')
     });
 
-    test('probePort: a live loopback listener reads busy; a closed port reads free', async () => {
-        const listener = createServer();
+    test('a free endpoint → spawn the transport', () => {
+        const plan = planCockpitBoot({fleetPort: 8083, endpointStatus: 'free'});
 
-        await new Promise(resolve => listener.listen(0, '127.0.0.1', resolve));
+        expect(plan.refuse).toBe(false);
+        expect(plan.spawnFleet).toBe(true);
+        expect(plan.spawnWebpack).toBe(true);
+        expect(plan.notes[0]).toContain('starting fleet transport')
+    });
 
-        const {port} = listener.address();
+    test('probeFleetEndpoint: a REAL fleet server confirms identity; a bare listener is incompatible; a closed port is free', async () => {
+        // (a) the REAL transport with the REAL dispatch chain (the wire allowlist): the probe
+        // method is not on the allowlist, so the deterministic rejection envelope IS the identity
+        const realFleet = await startFleetBridgeServer({port: 0});
+        const realPort  = realFleet.address().port;
 
-        expect(await probePort(port)).toBe(true);
+        const probe = await probeFleetEndpoint(realPort);
+        expect(probe.status).toBe('fleet');
+        expect(probe.detail).toContain('identity confirmed');
 
-        await new Promise(resolve => listener.close(resolve));
+        await new Promise(resolve => realFleet.close(resolve));
 
-        expect(await probePort(port)).toBe(false)
+        // (b) an HTTP-ish occupant that answers with a NON-fleet envelope must read incompatible —
+        // an injected always-ok dispatch proves the probe checks the ENVELOPE, not just HTTP-ness
+        let   dispatched = 0;
+        const foreign    = await startFleetBridgeServer({
+            port    : 0,
+            dispatch: async () => { dispatched++; return {ok: true}; }
+        });
+        const foreignPort = foreign.address().port;
+
+        const foreignProbe = await probeFleetEndpoint(foreignPort);
+        expect(foreignProbe.status).toBe('incompatible');
+        expect(dispatched).toBe(1);
+
+        await new Promise(resolve => foreign.close(resolve));
+
+        // (c) a bare TCP listener that never speaks HTTP → incompatible (accepted, never answered).
+        // Track its accepted sockets: the probe's client-side destroy can leave the server-side
+        // socket lingering, and net.Server.close() waits on it — destroy them before closing.
+        const bare        = createServer(),
+              bareSockets = [];
+
+        bare.on('connection', socket => bareSockets.push(socket));
+        await new Promise(resolve => bare.listen(0, '127.0.0.1', resolve));
+        const barePort = bare.address().port;
+
+        const bareProbe = await probeFleetEndpoint(barePort, 600);
+        expect(bareProbe.status).toBe('incompatible');
+
+        bareSockets.forEach(socket => socket.destroy());
+        await new Promise(resolve => bare.close(resolve));
+
+        // (d) the now-closed port → free
+        expect((await probeFleetEndpoint(realPort)).status).toBe('free')
+    });
+
+    test('composed boot: the launcher brings the fleet transport up, supervises, and tears down on SIGTERM', async () => {
+        test.setTimeout(60000);
+
+        // pre-condition: the default endpoint must be free on this machine, else this witness
+        // cannot own the lifecycle it asserts — skip honestly rather than reuse-or-fight
+        if ((await probeFleetEndpoint(8083)).status !== 'free') {
+            test.skip(true, 'the default fleet endpoint is occupied on this machine — the composed-boot witness needs to own it');
+            return
+        }
+
+        // the webpack child is stubbed via the injectable command seam — the composed-boot witness
+        // targets the SUPERVISION + fleet identity, not a webpack build (its own suite territory)
+        const launcher = spawn(process.execPath, [path.join(repoRoot, 'buildScripts/devCockpit.mjs')], {
+            cwd: repoRoot,
+            env: {
+                ...process.env,
+                NEO_COCKPIT_WEBPACK_CMD: JSON.stringify([process.execPath, '-e', 'setInterval(() => {}, 1000)'])
+            },
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+
+        let output = '';
+        launcher.stdout.on('data', chunk => output += chunk);
+        launcher.stderr.on('data', chunk => output += chunk);
+
+        try {
+            // the fresh-boot assertion: the REAL fleet transport reaches protocol identity on the
+            // default endpoint with zero manual server starts
+            await expect.poll(async () => (await probeFleetEndpoint(8083)).status, {timeout: 30000}).toBe('fleet');
+
+            expect(output).toContain('starting fleet transport on :8083')
+        } finally {
+            // supervision teardown: one SIGTERM to the launcher ends the whole session
+            const exited = new Promise(resolve => launcher.on('exit', resolve));
+            launcher.kill('SIGTERM');
+            await exited;
+        }
+
+        await expect.poll(async () => (await probeFleetEndpoint(8083)).status, {timeout: 10000}).toBe('free')
+    });
+
+    test('the composed command opens the COCKPIT surface, not the dev-server root', () => {
+        expect(COCKPIT_OPEN_TARGET).toBe('apps/agentos/index.html');
+        expect(FLEET_PROBE_METHOD).toContain('probe')
     })
 });

--- a/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs
@@ -1,0 +1,44 @@
+import {test, expect}               from '@playwright/test';
+import {createServer}               from 'node:net';
+import {planCockpitBoot, probePort} from '../../../../../buildScripts/devCockpit.mjs';
+
+/**
+ * The boot-plan witnesses for the one-command cockpit launcher: the pure decision seam
+ * (spawn-vs-reuse on the fleet port) and the probe primitive it feeds. The full two-process
+ * supervision is process wiring behind the entry guard — the launcher's spawn targets
+ * (`npm run server-start`, `devFleetServer.mjs`) carry their own suites.
+ */
+test.describe('buildScripts/devCockpit — the live-by-default boot plan (#15283)', () => {
+
+    test('a free fleet port → spawn the transport, named start note', () => {
+        const plan = planCockpitBoot({fleetPort: 8083, fleetPortBusy: false});
+
+        expect(plan.spawnFleet).toBe(true);
+        expect(plan.spawnWebpack).toBe(true);
+        expect(plan.notes[0]).toContain('starting fleet transport on :8083')
+    });
+
+    test('a busy fleet port → REUSE, never a silent second server (shared-machine honesty)', () => {
+        const plan = planCockpitBoot({fleetPort: 8083, fleetPortBusy: true});
+
+        expect(plan.spawnFleet).toBe(false);
+        expect(plan.spawnWebpack).toBe(true);
+        expect(plan.notes[0]).toContain('already serving :8083');
+        expect(plan.notes[0]).toContain('reusing');
+        expect(plan.notes[0]).toContain('not spawning a second server')
+    });
+
+    test('probePort: a live loopback listener reads busy; a closed port reads free', async () => {
+        const listener = createServer();
+
+        await new Promise(resolve => listener.listen(0, '127.0.0.1', resolve));
+
+        const {port} = listener.address();
+
+        expect(await probePort(port)).toBe(true);
+
+        await new Promise(resolve => listener.close(resolve));
+
+        expect(await probePort(port)).toBe(false)
+    })
+});


### PR DESCRIPTION
Resolves #15283

Refs #13015

The W2 census's boot seam closed: `npm run cockpit` is now the ONE command that lands an operator on a LIVE Fleet-Manager cockpit — opened directly on the cockpit surface. The census (on the epic) established the inversion this leaf completes — the seed→live wiring had shipped end-to-end (`app.mjs` installs the bridge unconditionally; the routing matrices are spec-pinned; controls are product-wired), and the entire lived 'FM is not functional' experience was one unsupervised process: `devFleetServer` only started via a separate manual command nobody's boot ran.

**What ships:** `buildScripts/devCockpit.mjs` — a supervising launcher, not a service (the fleet server stays a Brain entry under `ai/`; `server-start` is byte-untouched):

- **Fleet identity, not "some TCP listener"** (review cycle 1, RA-2): before reusing a busy :8083, the launcher probes for *wire-protocol identity* — `POST /fleet {method:'__cockpit_probe__'}` must answer with `dispatchFleetRequest`'s deterministic allowlist-rejection envelope (side-effect-free by construction: an unlisted method never reaches the control bridge). Three-way, fail-honest: `free` → spawn · `fleet` → reuse with a named log line · `incompatible` (wrong envelope, non-JSON, non-HTTP, hang) → **refuse with the occupant detail** — never a silent second server, never a false reuse.
- **One endpoint authority** (RA-3): the browser consumer (`apps/agentos/app.mjs` → `installFleetBridge`) pins `http://127.0.0.1:8083/fleet`. A non-default `NEO_FLEET_PORT` would boot a server the cockpit never reaches, so the launcher **refuses it with a named reason + remedy** (endpoint propagation through producer AND consumer is the tracked follow-up; `devFleetServer` standalone keeps honoring the env var).
- **Cockpit launch target** (RA-1): the dev server opens `apps/agentos/index.html` via `--open-target` — the cockpit, not the App-Store root. The webpack spawn command is injectable (`NEO_COCKPIT_WEBPACK_CMD`, JSON array) purely as a witness seam; malformed overrides fall back to the production default.
- **Supervision:** SIGINT/SIGTERM forward to every spawned child; a webpack exit tears the session down; a fleet-server exit logs the loss loudly (with the restart command) while the cockpit degrades to its honest offline states — fail-closed stays intact, and the operable-cold banner sibling (#15284) names it on the surface.
- **Docs:** `learn/agentos/RunningTheFleetCockpit.md` (tree-registered) — the run-the-cockpit page: the one command, the boot behavior, without-transport fail-closed semantics, the ports rule.

Evidence: L2/L3 — the pure decision matrix, the identity probe against the REAL fleet transport (plus foreign-envelope, bare-listener, and closed-port arms), and a composed-boot integration witness that spawns the real launcher and observes fleet protocol identity reached on the default endpoint with zero manual server starts (webpack child stubbed via the seam; SIGTERM teardown returns the endpoint to `free`). → L2 required (boot-plan ACs) exceeded. Residual: the webpack arm of the composed boot (real dev-server build + browser open) stays with webpack's own suite territory; the two-checkout socket-sharing pass stays manual.

## Deltas from ticket

None. The cycle-1 review overturned the one delta the original body carried (the deferred `learn/` page): the page now ships in this PR, tree-registered, with the launch-target and endpoint-authority behavior it documents.

## Test Evidence

- `npx playwright test test/playwright/unit/ai/buildScripts/devCockpit.spec.mjs test/playwright/unit/ai/services/fleet --config test/playwright/playwright.config.unit.mjs` → **172/172, exit 0** (exit-checked, no pipe): the devCockpit witnesses (7) + the full fleet transport battery (unchanged, proving no regression from the probe's use of the real `startFleetBridgeServer`).
- devCockpit witnesses: non-default-port refusal (named `installFleetBridge` reason), incompatible-occupant refusal (named detail), fleet-reuse (never-a-second-server), free-spawn, the identity probe against a REAL fleet server / an injected always-`ok:true` dispatch (proves the probe checks the ENVELOPE — `dispatched === 1`) / a bare TCP listener / a closed port, the composed-boot lifecycle (spawn → poll to `fleet` → `starting fleet transport on :8083` in output → SIGTERM → `free`), and the open-target constant pin.
- `npm run ai:lint-tree-json` → OK (217 nodes); check-block-alignment + check-ticket-archaeology clean.

## Post-Merge Validation

- [ ] Full boot journey on a fresh checkout with a real browser: `npm run cockpit` → cockpit paints with `live` adapter states (the composed-boot witness proves transport identity; the visual paint is the manual arm).
- [ ] Shared-machine pass: second checkout runs `npm run cockpit` while the first serves :8083 → reuse note appears, no socket fight.

## Commits

- the original commit — launcher + witnesses + the `cockpit` npm script
- the cycle-1 RA response — identity probe (`probeFleetEndpoint`), endpoint-authority refusal, `--open-target` cockpit launch, composed-boot integration witness, `learn/agentos/RunningTheFleetCockpit.md` + tree registration

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 5bbd6fb6-07d8-4f7e-b3ba-cccb66eddcf3.