### PR TITLE
test(dashboard): realign the dock reorder journey with the 7-item example seed (#15286)

### DIFF
--- a/test/playwright/e2e/dashboard/DockDragDropNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockDragDropNL.spec.mjs
@@ -37,9 +37,14 @@ test.describe('Dock drag-and-drop journey (Neural Link)', () => {
 
         const readModel = async () => (await app.getComponent(holderId, ['dockModel'])).dockModel;
 
+        // Position-scoped seed precondition: the drag needs its two participants adjacent at
+        // the HEAD of main-tabs; the tail may evolve with the example (7 items today — the
+        // overflow-pressure scene) without invalidating this journey.
         const before = await readModel();
-        expect(before?.nodes?.['main-tabs']?.items, 'the example must seed main-tabs as [strategy, swarm]')
+        expect(before?.nodes?.['main-tabs']?.items?.slice(0, 2), 'the example must seed main-tabs with [strategy, swarm] leading')
             .toEqual(['strategy', 'swarm']);
+
+        const seedTail = before.nodes['main-tabs'].items.slice(2);
 
         // product truth #1: the dock projects draggable tab headers (not just a static model). Both panes of
         // main-tabs plus the two single-tab side zones = four draggable tab headers.
@@ -57,19 +62,23 @@ test.describe('Dock drag-and-drop journey (Neural Link)', () => {
         const strategyBox = await strategyTab.boundingBox();
         const swarmBox    = await swarmTab.boundingBox();
 
-        // native drag: Strategy header -> just past Swarm's right edge (the {steps} cadence arms Neo's drag sensor)
+        // native drag: Strategy header -> Swarm's CENTER (the {steps} cadence arms Neo's drag
+        // sensor). Releasing at the sibling's center crosses exactly ONE midpoint — a single
+        // deterministic swap regardless of how many tabs follow in the bar.
         await page.mouse.move(strategyBox.x + strategyBox.width / 2, strategyBox.y + strategyBox.height / 2);
         await page.mouse.down();
         await page.mouse.move(swarmBox.x + swarmBox.width / 2, swarmBox.y + swarmBox.height / 2, { steps: 30 });
-        await page.mouse.move(swarmBox.x + swarmBox.width + 12, swarmBox.y + swarmBox.height / 2, { steps: 30 });
         await page.mouse.up();
         await page.waitForTimeout(1000);
 
         const after = await readModel();
         console.log('[dock-dnd] main-tabs:', JSON.stringify(before?.nodes?.['main-tabs']?.items), '->', JSON.stringify(after?.nodes?.['main-tabs']?.items));
 
-        // product truth #2: the drag mutated the COMMITTED dock model in the App Worker
-        expect(after?.nodes?.['main-tabs']?.items, 'the tab-drag must reorder the committed dock model — the whole point of the engine')
+        // product truth #2: the drag mutated the COMMITTED dock model in the App Worker —
+        // exactly the head pair swapped, the tail untouched (the single-swap proof)
+        expect(after?.nodes?.['main-tabs']?.items?.slice(0, 2), 'the tab-drag must reorder the committed dock model — the whole point of the engine')
             .toEqual(['swarm', 'strategy']);
+        expect(after?.nodes?.['main-tabs']?.items?.slice(2), 'the reorder moved ONLY the dragged pair — the tail is untouched')
+            .toEqual(seedTail);
     });
 });


### PR DESCRIPTION
Resolves #15286

The dock reorder journey is green again on plain `dev`: the seed assert is position-scoped to the drag's real precondition (`strategy` + `swarm` adjacent at the head of `main-tabs`), the release lands at Swarm's **center** (exactly one sibling midpoint crossed = one deterministic swap on any bar length, replacing the 2-tab-era "+12px past Swarm" overshoot that now sits in Metrics' territory), and the post-drag assert proves the **exact single swap** — head pair flipped, tail byte-identical to the seed. The example's deliberately-grown 7-item seed (the overflow-pressure scene) stays authoritative and untouched.

Evidence: L3 achieved (real-pointer headless journey against the live example; App-Worker committed-document truth via the neuralLink fixture) → L3 required (AC-1/AC-3). Residual: none.

## Deltas from ticket

None substantive — the fix shipped exactly as prescribed. The ticket's contingency (a `blocked_by` edge to PR #15282 if the 7-tab bar needed the sensor repair) proved unnecessary: the journey passes on plain `dev`, so this PR is fully independent.

## Test Evidence

- `NEO_E2E_PORT=8096 npx playwright test DockDragDropNL -c test/playwright/playwright.config.e2e.mjs --workers=1` → **1/1** on `dev`-based head (was: red at the seed assert). Console receipt: `["strategy","swarm","metrics","timeline","agents","alerts","history"] -> ["swarm","strategy","metrics","timeline","agents","alerts","history"]`.
- Touched surface: dashboard dock example journey only (spec-only diff; the example source is untouched). Sibling coverage on the same surface: `DockCrossZoneDragNL` 1/1 in the same session's sweep.

## Post-Merge Validation

- [ ] None — the spec runs outside CI by design (e2e layer); the local receipt above is the evidence class.

## Commits

- 7ccb8e904 — test(dashboard): realign the dock reorder journey with the 7-item example seed

Authored by @neo-fable-clio (Clio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
