### PR TITLE
feat(agentos): the spine banner — the cockpit names WHY it shows sample or last-known data (#15284)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1228,7 +1228,12 @@ class FleetCockpit extends Container {
      * surface names WHY it shows sample (cold) or last-known (degraded) data; a fully live
      * spine renders nothing. Render-only over existing truth: the routing matrices in
      * {@link #loadRoster} / {@link #loadActivity} stay the sole state writers, and every one
-     * of their exits (including the no-bridge guards — absence IS the cold truth) drives this.
+     * of their exits (including the no-bridge guards — absence IS the cold truth) CALLS this.
+     * A call is not a truth transition: the loads run at construction plus after successful
+     * lifecycle intents, and their failure exits fail-closed PRESERVE last-known states — so
+     * once live, a mid-session transport loss does not advance the owner truth this renders.
+     * The ongoing liveness owner (loss/recovery transitions with a retained reason) is a
+     * dedicated follow-up mechanism, not this consumer.
      * @protected
      */
     syncSpineBanner() {

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -15,6 +15,7 @@ import FleetRoster              from '../../store/FleetRoster.mjs';
 import StateProvider            from '../../../../src/state/Provider.mjs';
 import cockpitDockDocument      from './cockpitDockDocument.mjs';
 import cockpitPresetCollection  from './cockpitPresets.mjs';
+import {deriveSpineBanner}      from './spineBanner.mjs';
 import {mapFleetSessionHealth}  from './sourceHealth.mjs';
 import {previewToOperation}     from '../../../../src/dashboard/dockPreviewContract.mjs';
 import '../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the dock projection emits for tab zones
@@ -528,6 +529,15 @@ class FleetCockpit extends Container {
                     hidden   : !me.presetError,
                     html     : me.presetError || '',
                     reference: 'fleet-preset-error'
+                }, {
+                    // the per-SPINE honesty line: names WHY the surface shows sample/last-known
+                    // data (cold/degraded); a fully live spine renders nothing — zero nominal
+                    // pixels. Derived from the owner-held adapter states by syncSpineBanner.
+                    ntype    : 'component',
+                    cls      : ['fm-spine-banner'],
+                    hidden   : true,
+                    reference: 'fleet-spine-banner',
+                    role     : 'status'
                 },
                 '->', {
                     // The morning-start outcome summary — written by the controller after the
@@ -1129,6 +1139,8 @@ class FleetCockpit extends Container {
             bridge = globalThis.AgentOS?.fleet?.registryBridge;
 
         if (!stream || typeof bridge?.fleetActivity !== 'function') {
+            // no bridge/verb IS the cold truth — the spine banner must say so
+            me.syncSpineBanner();
             return
         }
 
@@ -1146,6 +1158,8 @@ class FleetCockpit extends Container {
             // not-wired / absent bridge → keep the honestly-labelled 'sample' seed
         } catch (error) {
             // fail-closed: the sample seed stays rather than blanking the feed
+        } finally {
+            me.syncSpineBanner()
         }
     }
 
@@ -1173,6 +1187,8 @@ class FleetCockpit extends Container {
             bridge = globalThis.AgentOS?.fleet?.registryBridge;
 
         if (!grid?.store || typeof bridge?.fleetRoster !== 'function') {
+            // no bridge/verb IS the cold truth — the spine banner must say so
+            me.syncSpineBanner();
             return
         }
 
@@ -1202,6 +1218,34 @@ class FleetCockpit extends Container {
             grid.adapterState   = 'live'
         } catch (error) {
             // fail-closed: the last-known roster stays rather than blanking the fleet
+        } finally {
+            me.syncSpineBanner()
+        }
+    }
+
+    /**
+     * @summary Renders the per-SPINE honesty line from the owner-held adapter states — the
+     * surface names WHY it shows sample (cold) or last-known (degraded) data; a fully live
+     * spine renders nothing. Render-only over existing truth: the routing matrices in
+     * {@link #loadRoster} / {@link #loadActivity} stay the sole state writers, and every one
+     * of their exits (including the no-bridge guards — absence IS the cold truth) drives this.
+     * @protected
+     */
+    syncSpineBanner() {
+        let me     = this,
+            banner = me.getReference('fleet-spine-banner');
+
+        if (banner) {
+            let {hidden, kind, text} = deriveSpineBanner({
+                gridAdapterState  : me.gridAdapterState,
+                streamAdapterState: me.streamAdapterState
+            });
+
+            banner.set({
+                cls : ['fm-spine-banner', `fm-spine-banner-${kind}`],
+                hidden,
+                html: text
+            })
         }
     }
 

--- a/apps/agentos/view/fleet/spineBanner.mjs
+++ b/apps/agentos/view/fleet/spineBanner.mjs
@@ -25,7 +25,7 @@ export function deriveSpineBanner({gridAdapterState, streamAdapterState}) {
         return {
             hidden: false,
             kind  : 'cold',
-            text  : 'Fleet server offline — showing sample data · start it: npm run cockpit'
+            text  : 'Fleet server offline — showing sample data · start it: npm run ai:fleet-server'
         }
     }
 

--- a/apps/agentos/view/fleet/spineBanner.mjs
+++ b/apps/agentos/view/fleet/spineBanner.mjs
@@ -1,0 +1,43 @@
+/**
+ * @module apps/agentos/view/fleet/spineBanner
+ * @summary The cockpit's per-SPINE honesty line: derives ONE shell-level status from the
+ * owner-held adapter states, so the surface names WHY it shows sample or last-known data
+ * instead of failing silent. Render-only over existing truth — this module produces no probes.
+ *
+ * Precedence: `sample` (the spine is unreachable — cold) beats `stale` (reachable but degraded)
+ * beats `live`. A fully live spine renders NOTHING — nominal earns zero pixels, the same
+ * exception-based discipline the cards follow. Per-AGENT truth (wake/throttle telltales) is a
+ * different surface; this line only speaks for the fleet transport itself.
+ */
+
+/**
+ * @summary Derives the spine banner from the two owner-held adapter states.
+ * @param {Object} options
+ * @param {String} options.gridAdapterState   `'sample'|'stale'|'live'` — the roster surface truth.
+ * @param {String} options.streamAdapterState `'sample'|'stale'|'live'` — the activity surface truth.
+ * @returns {{hidden: Boolean, kind: String, text: String}} `kind` is `'live'|'cold'|'degraded'`
+ *     — the class hook; `hidden` is `true` only for the fully live spine.
+ */
+export function deriveSpineBanner({gridAdapterState, streamAdapterState}) {
+    const states = [gridAdapterState, streamAdapterState];
+
+    if (states.includes('sample')) {
+        return {
+            hidden: false,
+            kind  : 'cold',
+            text  : 'Fleet server offline — showing sample data · start it: npm run cockpit'
+        }
+    }
+
+    if (states.includes('stale')) {
+        return {
+            hidden: false,
+            kind  : 'degraded',
+            text  : 'Fleet feed degraded — showing last-known data'
+        }
+    }
+
+    return {hidden: true, kind: 'live', text: ''}
+}
+
+export default deriveSpineBanner;

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -60,8 +60,13 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
     const routeLoadActivity = async bridge => {
         bridge ? ((globalThis.AgentOS ??= {}).fleet = {registryBridge: bridge}) : clearBridge();
 
-        const stream  = makeStream(),
-              cockpit = {getReference: reference => reference === 'activity-stream' ? stream : null};
+        const stream = makeStream(),
+              // the real banner sync runs against this fake: its getReference returns null for
+              // the banner slot, so the guard no-ops — production code, no stub drift
+              cockpit = {
+                  getReference   : reference => reference === 'activity-stream' ? stream : null,
+                  syncSpineBanner: FleetCockpit.prototype.syncSpineBanner
+              };
 
         await FleetCockpit.prototype.loadActivity.call(cockpit);
 
@@ -158,7 +163,9 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         mapRosterRow      : FleetCockpit.prototype.mapRosterRow,
         reconcileRoster   : FleetCockpit.prototype.reconcileRoster,
         reconcileSelection: FleetCockpit.prototype.reconcileSelection,
-        rosterWired
+        rosterWired,
+        // the real banner sync: null getReference for the slot → guarded no-op, no stub drift
+        syncSpineBanner   : FleetCockpit.prototype.syncSpineBanner
     });
 
     const routeLoadRoster = async (bridge, {known, items, rosterWired} = {}) => {
@@ -402,7 +409,9 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             reconcileRoster   : FleetCockpit.prototype.reconcileRoster,
             reconcileSelection: FleetCockpit.prototype.reconcileSelection,
             reconcilingRoster : false,
-            rosterWired       : false
+            rosterWired       : false,
+            // the real banner sync: null getReference for the slot → guarded no-op, no stub drift
+            syncSpineBanner   : FleetCockpit.prototype.syncSpineBanner
         };
 
         store.on({load: cockpit.onRosterStoreLoad, scope: cockpit});
@@ -943,7 +952,9 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
             reconcileRoster   : FleetCockpit.prototype.reconcileRoster,
             reconcileSelection: FleetCockpit.prototype.reconcileSelection,
             loadRoster        : FleetCockpit.prototype.loadRoster,
-            rosterWired       : false
+            rosterWired       : false,
+            // the real banner sync: null getReference for the slot → guarded no-op, no stub drift
+            syncSpineBanner   : FleetCockpit.prototype.syncSpineBanner
         };
 
         // boot: the real loadRoster reads the bridge — the agent is stopped, so the record resolves to 'off'

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -986,3 +986,99 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
         store.destroy()
     })
 });
+
+/**
+ * The slot-sync consumer witness: `syncSpineBanner` against a REAL recording banner slot — the
+ * derivation lands on the component (cls hook + hidden + html), a missing slot stays a guarded
+ * no-op, and the owner-truth immobility boundary is pinned as a spec: once live, a failure exit
+ * PRESERVES live and the slot stays hidden (the loss/recovery transition belongs to the
+ * dedicated liveness owner, not this consumer).
+ */
+test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', () => {
+    let FleetCockpit;
+
+    test.beforeAll(async () => {
+        FleetCockpit = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default
+    });
+
+    const makeBanner = () => {
+        const calls = [];
+
+        return {calls, set(config) { calls.push(config) }}
+    };
+
+    const makeHost = (gridAdapterState, streamAdapterState, banner) => ({
+        getReference   : reference => reference === 'fleet-spine-banner' ? banner : null,
+        gridAdapterState,
+        streamAdapterState,
+        syncSpineBanner: FleetCockpit.prototype.syncSpineBanner
+    });
+
+    test('a cold owner writes the REAL slot: cold class hook, visible, cause + shipped remedy', () => {
+        const banner = makeBanner();
+
+        makeHost('sample', 'sample', banner).syncSpineBanner();
+
+        expect(banner.calls).toHaveLength(1);
+
+        const {cls, hidden, html} = banner.calls[0];
+
+        expect(cls).toEqual(['fm-spine-banner', 'fm-spine-banner-cold']);
+        expect(hidden).toBe(false);
+        expect(html).toContain('Fleet server offline');
+        expect(html).toContain('npm run ai:fleet-server')
+    });
+
+    test('a degraded owner writes the degraded hook + last-known copy', () => {
+        const banner = makeBanner();
+
+        makeHost('live', 'stale', banner).syncSpineBanner();
+
+        const {cls, hidden, html} = banner.calls[0];
+
+        expect(cls).toEqual(['fm-spine-banner', 'fm-spine-banner-degraded']);
+        expect(hidden).toBe(false);
+        expect(html).toContain('last-known')
+    });
+
+    test('a fully live owner hides the REAL slot with empty copy — zero nominal pixels', () => {
+        const banner = makeBanner();
+
+        makeHost('live', 'live', banner).syncSpineBanner();
+
+        expect(banner.calls[0]).toEqual({cls: ['fm-spine-banner', 'fm-spine-banner-live'], hidden: true, html: ''})
+    });
+
+    test('owner-truth immobility: once live, a thrown load PRESERVES live and the slot stays hidden', async () => {
+        // the boundary this leaf does NOT cross, pinned as a spec: the loads fail-closed PRESERVE
+        // owner states, so a post-live transport loss never advances the truth this consumer
+        // renders — the loss/recovery transition is the dedicated liveness owner's contract
+        const banner = makeBanner(),
+              stream = {adapterState: 'live', set() {}},
+              host   = {
+                  getReference: reference =>
+                      reference === 'fleet-spine-banner' ? banner :
+                      reference === 'activity-stream'    ? stream : null,
+                  gridAdapterState  : 'live',
+                  streamAdapterState: 'live',
+                  loadActivity      : FleetCockpit.prototype.loadActivity,
+                  syncSpineBanner   : FleetCockpit.prototype.syncSpineBanner
+              };
+
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetActivity: async () => { throw new Error('transport lost') }}};
+
+        try {
+            await host.loadActivity()
+        } finally {
+            delete globalThis.AgentOS?.fleet
+        }
+
+        expect(host.streamAdapterState).toBe('live');
+        expect(banner.calls).toHaveLength(1);
+        expect(banner.calls[0].hidden).toBe(true)
+    });
+
+    test('a missing slot is a guarded no-op — never a throw', () => {
+        expect(() => makeHost('sample', 'sample', null).syncSpineBanner()).not.toThrow()
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
@@ -1,0 +1,48 @@
+import {test, expect}      from '@playwright/test';
+import {deriveSpineBanner} from '../../../../../../../apps/agentos/view/fleet/spineBanner.mjs';
+
+/**
+ * The full derivation matrix for the cockpit's per-SPINE honesty line: `sample` (cold — the
+ * spine is unreachable) beats `stale` (reachable but degraded) beats `live`; ONLY the fully
+ * live spine hides the banner (nominal earns zero pixels). The sync wiring in the cockpit is
+ * a five-line consumer of this pure seam and rides the load-routing suites.
+ */
+test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
+
+    const STATES = ['sample', 'stale', 'live'];
+
+    test('the full 3×3 matrix: cold beats degraded beats live; only live+live hides', () => {
+        for (const gridAdapterState of STATES) {
+            for (const streamAdapterState of STATES) {
+                const result   = deriveSpineBanner({gridAdapterState, streamAdapterState}),
+                      anyCold  = gridAdapterState === 'sample' || streamAdapterState === 'sample',
+                      anyStale = gridAdapterState === 'stale'  || streamAdapterState === 'stale',
+                      expected = anyCold ? 'cold' : anyStale ? 'degraded' : 'live';
+
+                expect(result.kind, `${gridAdapterState}×${streamAdapterState}`).toBe(expected);
+                expect(result.hidden, `${gridAdapterState}×${streamAdapterState}`).toBe(expected === 'live')
+            }
+        }
+    });
+
+    test('cold names the cause AND the one-command remedy', () => {
+        const {text} = deriveSpineBanner({gridAdapterState: 'sample', streamAdapterState: 'live'});
+
+        expect(text).toContain('Fleet server offline');
+        expect(text).toContain('sample data');
+        expect(text).toContain('npm run cockpit')
+    });
+
+    test('degraded names the honest data state', () => {
+        const {text} = deriveSpineBanner({gridAdapterState: 'live', streamAdapterState: 'stale'});
+
+        expect(text).toContain('degraded');
+        expect(text).toContain('last-known')
+    });
+
+    test('a fully live spine renders NOTHING — zero nominal pixels', () => {
+        const result = deriveSpineBanner({gridAdapterState: 'live', streamAdapterState: 'live'});
+
+        expect(result).toEqual({hidden: true, kind: 'live', text: ''})
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
@@ -4,8 +4,10 @@ import {deriveSpineBanner} from '../../../../../../../apps/agentos/view/fleet/sp
 /**
  * The full derivation matrix for the cockpit's per-SPINE honesty line: `sample` (cold — the
  * spine is unreachable) beats `stale` (reachable but degraded) beats `live`; ONLY the fully
- * live spine hides the banner (nominal earns zero pixels). The sync wiring in the cockpit is
- * a five-line consumer of this pure seam and rides the load-routing suites.
+ * live spine hides the banner (nominal earns zero pixels). The slot-sync consumer is witnessed
+ * directly in fleetCockpit.spec.mjs against a recording banner slot — including the owner-truth
+ * immobility boundary (once live, failure exits preserve live; the transition is the dedicated
+ * liveness owner's contract, not this reducer's).
  */
 test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
 
@@ -25,12 +27,14 @@ test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
         }
     });
 
-    test('cold names the cause AND the one-command remedy', () => {
+    test('cold names the cause AND a remedy that EXISTS at this head', () => {
         const {text} = deriveSpineBanner({gridAdapterState: 'sample', streamAdapterState: 'live'});
 
         expect(text).toContain('Fleet server offline');
         expect(text).toContain('sample data');
-        expect(text).toContain('npm run cockpit')
+        // the shipped transport command — also the correct mid-session restart remedy once a
+        // composed launcher exists, since the app server survives a fleet-transport loss
+        expect(text).toContain('npm run ai:fleet-server')
     });
 
     test('degraded names the honest data state', () => {


### PR DESCRIPTION
Resolves #15284 (narrowed to the initial-cold slice — the scope narrow + Contract Ledger live on the ticket)

Refs #13015 · liveness successor: #15293 (non-optional)

The cockpit's per-SPINE honesty line: when the surface shows sample (cold) or last-known (degraded) data, ONE shell-level banner names WHY and the shipped remedy — instead of failing silent. Nominal earns zero pixels: a fully live spine renders nothing, the same exception-based discipline the cards follow.

**The cycle-1 truth-fold (what this PR now honestly is):** Emmy's review falsified the ticket's liveness premise against source — the loads run at construction (plus a roster refresh only after *successful* lifecycle intents), and failure exits fail-closed **preserve** last-known owner states. A correct reducer cannot create truth its owner never updates: once live, a mid-session transport loss never advances `gridAdapterState`/`streamAdapterState`, so the banner cannot appear for it. "No new probes" is binding on this leaf, so the liveness owner (loss/recovery transitions without reload, retained degraded reason, the NL live→loss→recovery journey) moved to **#15293** as a non-optional successor carrying those original ACs. #15284 is narrowed accordingly (ledger on the ticket). This PR ships the initial-cold slice — which is real on every fresh boot without a running transport, today's default experience.

**What ships:**

- `apps/agentos/view/fleet/spineBanner.mjs` — the pure `deriveSpineBanner` reducer over the two owner-held adapter states: `sample` (cold) beats `stale` (degraded) beats `live`; only live+live hides. Cold copy names the cause AND a remedy that **exists at this head**: `npm run ai:fleet-server` (the shipped transport command — and the correct mid-session restart remedy even after #15288's composed launcher lands, since the app server survives a fleet-transport loss).
- The `fleet-spine-banner` shell slot (toolbar, `role: 'status'`) + `syncSpineBanner()` — a render-only consumer called from every load exit including the no-bridge guards (absence IS the cold truth). Its JSDoc now states the boundary instead of overshooting it: **a call is not a truth transition**; the liveness owner is #15293's contract.
- Zero new literal styling — cls hooks only (`fm-spine-banner`, `fm-spine-banner-{cold|degraded|live}`), SCSS token/skin layers own the paint.

**Evidence:** L2 — the 3×3 derivation matrix; a REAL recording-slot consumer witness (cold/degraded/live writes land cls+hidden+html on the component; missing slot = guarded no-op, never a throw); and the **owner-truth immobility boundary pinned as a spec** (once live, a thrown load preserves live and the slot stays hidden — the exact falsifier from cycle 1, now the executable statement of where this leaf ends and #15293 begins). → meets the narrowed close target. Residuals: loss/recovery transition + retained reason + NL journey → #15293 (tracked, non-optional); both-theme design signoff (Grace) → receipt to be recorded on this PR before merge.

## Deltas from ticket

The ticket is narrowed (comment on #15284): transition/NL ACs → #15293. Within the narrowed scope: none.

## Test Evidence

- `npx playwright test test/playwright/unit/apps/agentos --config test/playwright/playwright.config.unit.mjs` → **314/314, exit 0** (exit-checked, no pipe) at 416244a04: the spineBanner matrix + copy specs, the new slot-sync witness block (5 specs incl. the immobility falsifier), and the full untouched cockpit battery.
- check-block-alignment / check-ticket-archaeology / pre-commit gates green.

## Pre-Merge Gates

- [ ] Grace's both-theme design signoff on the banner shape (requested; receipt recorded here).

## Post-Merge Validation

- [ ] Fresh boot without transport on a real browser: cold banner visible with the shipped remedy; `npm run ai:fleet-server` + reload → banner gone.

## Commits

- 5768e58ed — the reducer + shell slot + sync seam
- 416244a04 — cycle-1 truth-fold: shipped remedy, honest liveness boundary, real slot witness + immobility spec

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 5bbd6fb6-07d8-4f7e-b3ba-cccb66eddcf3.