### PR TITLE
feat(graph): produce the lifecycle frontier — the response-required fact source (#15267)

### DIFF
--- a/ai/services/graph/lifecycleAdmission.mjs
+++ b/ai/services/graph/lifecycleAdmission.mjs
@@ -22,6 +22,23 @@
  */
 
 /**
+ * @summary The logins a PR's review requests name, tolerating both source shapes.
+ *
+ * A request arrives either as a bare login or as `{login, requestedAt}`. Only the second can be dated,
+ * so the richer shape is what a datable frontier needs — but the identity question is the same either
+ * way, and reading it in one place keeps the two from drifting.
+ *
+ * @param {Object} pr Normalized PR record.
+ * @param {String} agentId
+ * @returns {Boolean}
+ */
+function requestsInclude(pr, agentId) {
+    return (pr?.reviewRequests || []).some(request =>
+        (typeof request === 'string' ? request : request?.login) === agentId
+    )
+}
+
+/**
  * @summary Derives a PR's lifecycle clocks from CURRENT-HEAD evidence, so the head-change reset is
  * structural rather than promised.
  *
@@ -49,30 +66,42 @@ export function normalizeLifecycleClocks(pr) {
     const currentHeadReviews = (pr?.reviews || []).filter(review => review.commitSha === head),
           currentHeadChecks  = (pr?.checks  || []).filter(check  => check.headSha === head || check.headSha === undefined);
 
-    const earliest = stamps => {
-        const valid = stamps.filter(stamp => typeof stamp === 'string' && stamp.length > 0).sort();
-        return valid.length > 0 ? valid[0] : null
-    };
+    const clean    = stamps => stamps.filter(stamp => typeof stamp === 'string' && stamp.length > 0).sort(),
+          earliest = stamps => clean(stamps)[0] ?? null,
+          latest   = stamps => clean(stamps).at(-1) ?? null;
 
-    const repairSince = earliest([
+    // Each stage's clock is a DIFFERENT algebra, because each answers a different question. One reducer
+    // for all three was wrong in three distinct ways.
+    const headCommittedAt = typeof pr?.headCommittedAt === 'string' ? pr.headCommittedAt : null;
+
+    // A current-head clock can never predate the head itself: the state being dated belongs to code
+    // that did not exist earlier. A conflict timestamp carried over from a previous head, stamped with
+    // current-head provenance, claimed a duration this head never had.
+    const clampToHead = stamp =>
+        stamp !== null && headCommittedAt !== null && stamp < headCommittedAt ? headCommittedAt : stamp;
+
+    // REPAIR — EARLIEST. "When did this head first need repair?" The first blocking evidence is the
+    // answer; later evidence is more of the same obligation.
+    const repairSince = clampToHead(earliest([
         ...currentHeadReviews.filter(review => review.state === 'CHANGES_REQUESTED').map(review => review.submittedAt),
         ...currentHeadChecks.filter(check => check.required === true && check.conclusion === 'FAILURE').map(check => check.completedAt),
-        // A conflict has no source timestamp of its own; the source states when it observed one.
+        // A conflict carries no evidence timestamp of its own; the source states when it observed one.
         pr?.mergeableSince
-    ]);
+    ]));
 
-    // Where the source carries no per-fact timestamp, the observation time is the honest floor: this
-    // head WAS seen in this state at `checkedAt`. That understates age rather than inventing it, and it
-    // still resets on head change because the provenance below is the current head. It is a floor, not
-    // a claim about when the state began.
-    const observed = typeof pr?.checkedAt === 'string' ? pr.checkedAt : null;
+    // REVIEWABLE — LATEST, and only once ALL required checks have passed. "When did this head become
+    // reviewable?" is when the LAST required check went green. At the earliest one it was not reviewable
+    // at all, so dating it there claims a readiness that did not exist.
+    const requiredChecks  = currentHeadChecks.filter(check => check.required === true),
+          allPassed       = requiredChecks.length > 0 && requiredChecks.every(check => check.conclusion === 'SUCCESS'),
+          reviewableSince = allPassed ? clampToHead(latest(requiredChecks.map(check => check.completedAt))) : null;
 
-    const reviewableSince = earliest(currentHeadChecks.filter(check => check.required === true).map(check => check.completedAt)) ??
-                            pr?.headCommittedAt ?? observed;
-
-    const requestedSince = earliest((pr?.reviewRequests || []).map(request =>
+    // REQUESTED — LATER of the request and the head. A request that predates a push is not a request to
+    // review THIS code; the obligation restarts when the head moves under it. `clampToHead` IS that
+    // later(), since the head is the floor.
+    const requestedSince = clampToHead(earliest((pr?.reviewRequests || []).map(request =>
         typeof request === 'object' ? request.requestedAt : null
-    )) ?? ((pr?.reviewRequests || []).length > 0 ? observed : null);
+    )));
 
     return {
         ...pr,
@@ -270,8 +299,8 @@ export function admitOwnPrReviewerRouting({pr, agentId} = {}) {
  * @returns {Object|null}
  */
 export function admitRequestedReview({pr, agentId} = {}) {
-    if (!pr || pr.state !== 'OPEN' || pr.isDraft)     return null;
-    if (!(pr.reviewRequests || []).includes(agentId)) return null;
+    if (!pr || pr.state !== 'OPEN' || pr.isDraft) return null;
+    if (!requestsInclude(pr, agentId))            return null;
     // Closure is defined by the HEAD, not by the author of the verdict: a decision on the current head
     // closes it, and a decision on an older head cannot, because the code changed underneath. Adding an
     // author-is-me restriction here invented a rule the contract does not have — it kept a request live

--- a/ai/services/graph/lifecycleAdmission.mjs
+++ b/ai/services/graph/lifecycleAdmission.mjs
@@ -1,0 +1,283 @@
+/**
+ * @module ai/services/graph/lifecycleAdmission
+ * @summary The five response-required admission predicates — and, just as load-bearing, their exclusions.
+ *
+ * Pure: every fact is passed in as an already-normalized source record. The producer decides *whether*
+ * something awaits a response; it never re-derives what a source already owns (a PR's state belongs to
+ * GitHub Workflow, a Task's owner to Memory Core A2A).
+ *
+ * **The exclusions are the design.** Admitting a row that does not actually need action is not a
+ * harmless false positive — it is how a surface earns being ignored. The route side already learned
+ * this: fixture rows taught peers the forward-pull was noise. So:
+ * - **pending/running CI is not a call to act.** Only a FAILED *required* check is. "CI is running" is
+ *   a wait, and waits are not work.
+ * - **an approved PR awaiting the human merge gate is not the agent's move** — merge is human-only, so
+ *   listing it would ask for an action the agent must never take.
+ * - **an optional check's failure is not a repair trigger** unless the repository marks it required.
+ * - **draft PRs** are not yet anyone's obligation.
+ * - **an unclaimed broadcast is not a task** — awareness-only A2A never becomes an obligation by being
+ *   read.
+ * - **ordinary issue assignment is not a claimed task**; only a structured Task envelope in an
+ *   action-requiring state is.
+ */
+
+/**
+ * @summary True when a review decision closes the CURRENT head.
+ *
+ * A review is only closing if it reviewed the head that exists now: a verdict attached to an older
+ * commit says nothing about the code as it stands, and treating it as closing would silently suppress
+ * a row that genuinely needs action after a repair push.
+ *
+ * @param {Object} pr Normalized PR record `{headSha, reviews: [{state, commitSha}]}`.
+ * @returns {Boolean}
+ */
+export function hasCurrentHeadClosingReview(pr) {
+    return (pr?.reviews || []).some(review =>
+        (review.state === 'APPROVED' || review.state === 'CHANGES_REQUESTED') &&
+        review.commitSha === pr.headSha
+    )
+}
+
+/**
+ * @summary True when a REQUIRED check has actually failed on the current head.
+ *
+ * Pending/running is deliberately not failure: a check still executing is a wait, not a repair. And an
+ * optional check's failure is not a repair trigger unless the repository policy marks it required —
+ * otherwise every advisory linter would manufacture an obligation.
+ *
+ * @param {Object} pr Normalized PR record `{checks: [{name, required, conclusion}]}`.
+ * @returns {Boolean}
+ */
+export function hasFailedRequiredCheck(pr) {
+    return (pr?.checks || []).some(check => check.required === true && check.conclusion === 'FAILURE')
+}
+
+/**
+ * @summary True when every required check has passed (or the repository requires none).
+ * @param {Object} pr Normalized PR record.
+ * @returns {Boolean}
+ */
+export function allRequiredChecksPass(pr) {
+    const required = (pr?.checks || []).filter(check => check.required === true);
+
+    return required.length === 0 || required.every(check => check.conclusion === 'SUCCESS')
+}
+
+/**
+ * @summary Stage 1 — own-PR repair: the current head carries `CHANGES_REQUESTED`, a failed required
+ * check, or a merge conflict.
+ *
+ * This outranks every other stage because it blocks a lane the agent already owns.
+ *
+ * `repairActionableSince` belongs to the CURRENT head: the clock starts when THIS head first satisfied
+ * a repair predicate, not from whatever the PR looked like three pushes ago.
+ *
+ * @param {Object} params
+ * @param {Object} params.pr Normalized own-PR record.
+ * @param {String} params.agentId The consuming agent.
+ * @returns {Object|null} A frontier item, or null when not admitted.
+ */
+export function admitOwnPrRepair({pr, agentId} = {}) {
+    if (!pr || pr.authorId !== agentId || pr.state !== 'OPEN' || pr.isDraft) return null;
+
+    const changesRequested = (pr.reviews || []).some(review =>
+              review.state === 'CHANGES_REQUESTED' && review.commitSha === pr.headSha
+          ),
+          failedCi   = hasFailedRequiredCheck(pr),
+          unmergeable = pr.mergeable === false;
+
+    if (!changesRequested && !failedCi && !unmergeable) return null;
+
+    const reason = changesRequested ? 'changes-requested' : (failedCi ? 'failed-required-check' : 'merge-conflict');
+
+    return {
+        id             : `own-pr-repair:${pr.id}`,
+        stage          : 'own-pr-repair',
+        kind           : reason,
+        state          : pr.state,
+        source         : 'github-workflow',
+        subjectId      : pr.id,
+        headSha        : pr.headSha,
+        actionableSince: pr.repairActionableSince,
+        checkedAt      : pr.checkedAt,
+        citations      : [pr.url].filter(Boolean)
+    }
+}
+
+/**
+ * @summary Stage 2 — own-PR reviewer routing: the PR is ready for a reviewer and nobody is on it.
+ *
+ * Excluded by construction: a draft (not yet an obligation), a PR whose required checks have not all
+ * passed (that is stage 1's business or a wait), one with an outstanding request (someone already has
+ * it), and one with a current-head closing review — which is where **an approved PR awaiting the human
+ * merge gate** drops out: merge is human-only, so listing it would ask for an action the agent must
+ * never take.
+ *
+ * @param {Object} params
+ * @param {Object} params.pr Normalized own-PR record.
+ * @param {String} params.agentId The consuming agent.
+ * @returns {Object|null}
+ */
+export function admitOwnPrReviewerRouting({pr, agentId} = {}) {
+    if (!pr || pr.authorId !== agentId || pr.state !== 'OPEN' || pr.isDraft) return null;
+    if (!allRequiredChecksPass(pr))                                          return null;
+    if ((pr.reviewRequests || []).length > 0)                                return null;
+    if (hasCurrentHeadClosingReview(pr))                                     return null;
+
+    return {
+        id             : `own-pr-routing:${pr.id}`,
+        stage          : 'own-pr-reviewer-routing',
+        kind           : 'needs-reviewer',
+        state          : pr.state,
+        source         : 'github-workflow',
+        subjectId      : pr.id,
+        headSha        : pr.headSha,
+        actionableSince: pr.reviewableSince,
+        checkedAt      : pr.checkedAt,
+        citations      : [pr.url].filter(Boolean)
+    }
+}
+
+/**
+ * @summary Stage 3 — requested review: a live request targets this agent and the current head is not
+ * already closed by its verdict.
+ * @param {Object} params
+ * @param {Object} params.pr Normalized PR record (authored by anyone).
+ * @param {String} params.agentId The consuming agent.
+ * @returns {Object|null}
+ */
+export function admitRequestedReview({pr, agentId} = {}) {
+    if (!pr || pr.state !== 'OPEN' || pr.isDraft)                       return null;
+    if (!(pr.reviewRequests || []).includes(agentId))                   return null;
+    // A verdict this agent already gave on the CURRENT head discharges the request; an older-head
+    // verdict does not, because the code changed underneath it.
+    const closedByMe = (pr.reviews || []).some(review =>
+        review.authorId === agentId &&
+        (review.state === 'APPROVED' || review.state === 'CHANGES_REQUESTED') &&
+        review.commitSha === pr.headSha
+    );
+
+    if (closedByMe) return null;
+
+    return {
+        id             : `requested-review:${pr.id}`,
+        stage          : 'requested-review',
+        kind           : 'review-requested',
+        state          : pr.state,
+        source         : 'github-workflow',
+        subjectId      : pr.id,
+        headSha        : pr.headSha,
+        actionableSince: pr.reviewRequestedSince,
+        checkedAt      : pr.checkedAt,
+        citations      : [pr.url].filter(Boolean)
+    }
+}
+
+/**
+ * Task states whose owner must act. Terminal states (Completed/Canceled/Failed/Rejected) and
+ * awareness-only states are excluded — a task that has ended is not a frontier row.
+ * @type {Set<String>}
+ */
+export const ACTIONABLE_TASK_STATES = Object.freeze(new Set(['InputRequired', 'AuthRequired']));
+
+/**
+ * @summary Stage 4 — claimed A2A task: a structured Task whose current owner is this agent and whose
+ * non-terminal state requires this agent's action.
+ *
+ * An unclaimed broadcast is excluded by construction: `ownerId` must equal the agent. A broadcast has
+ * no owner until someone claims it, and awareness never becomes an obligation by being read.
+ *
+ * @param {Object} params
+ * @param {Object} params.task Normalized Task record `{id, ownerId, state, actionableSince}`.
+ * @param {String} params.agentId The consuming agent.
+ * @param {Set<String>} [params.actionableStates] States requiring the owner's action.
+ * @returns {Object|null}
+ */
+export function admitClaimedTask({task, agentId, actionableStates = ACTIONABLE_TASK_STATES} = {}) {
+    if (!task || task.ownerId !== agentId)      return null;
+    if (!actionableStates.has(task.state))      return null;
+
+    return {
+        id             : `claimed-task:${task.id}`,
+        stage          : 'claimed-a2a-task',
+        kind           : task.state,
+        state          : task.state,
+        source         : 'memory-core-a2a',
+        subjectId      : task.id,
+        headSha        : null,
+        actionableSince: task.actionableSince,
+        checkedAt      : task.checkedAt,
+        citations      : [task.messageId].filter(Boolean)
+    }
+}
+
+/**
+ * @summary Stage 5 — direct message: an unread message addressed to this agent.
+ *
+ * `to === agentId` excludes broadcasts structurally: a broadcast is awareness, and treating it as an
+ * obligation would make every peer's announcement someone else's todo.
+ *
+ * @param {Object} params
+ * @param {Object} params.message Normalized message `{messageId, to, readAt, sentAt}`.
+ * @param {String} params.agentId The consuming agent.
+ * @returns {Object|null}
+ */
+export function admitDirectMessage({message, agentId} = {}) {
+    if (!message || message.to !== agentId) return null;
+    if (message.readAt)                     return null;
+
+    return {
+        id             : `direct-message:${message.messageId}`,
+        stage          : 'direct-message',
+        kind           : 'unread-direct',
+        state          : 'unread',
+        source         : 'memory-core-a2a',
+        subjectId      : message.messageId,
+        headSha        : null,
+        actionableSince: message.sentAt,
+        checkedAt      : message.checkedAt,
+        citations      : [message.messageId].filter(Boolean)
+    }
+}
+
+/**
+ * @summary Runs every stage's predicate over the normalized source records and returns the admitted
+ * items (unordered — `buildLifecycleFrontier` owns the ordering).
+ *
+ * A PR can legitimately admit at most one own-PR stage: repair and reviewer-routing are mutually
+ * exclusive by their predicates (a failed/blocked head cannot also be cleanly reviewable), so no
+ * de-duplication is needed — if both ever fired, that would be a predicate bug worth surfacing, not a
+ * row to silently drop.
+ *
+ * @param {Object}   params
+ * @param {String}   params.agentId The consuming agent.
+ * @param {Object[]} [params.prs=[]] Normalized PR records.
+ * @param {Object[]} [params.tasks=[]] Normalized Task records.
+ * @param {Object[]} [params.messages=[]] Normalized message records.
+ * @returns {Object[]} Admitted frontier items.
+ */
+export function collectLifecycleItems({agentId, prs = [], tasks = [], messages = []} = {}) {
+    const items = [];
+
+    for (const pr of prs) {
+        const repair  = admitOwnPrRepair({pr, agentId}),
+              routing = admitOwnPrReviewerRouting({pr, agentId}),
+              review  = admitRequestedReview({pr, agentId});
+
+        if (repair)  items.push(repair);
+        if (routing) items.push(routing);
+        if (review)  items.push(review);
+    }
+
+    for (const task of tasks) {
+        const admitted = admitClaimedTask({task, agentId});
+        if (admitted) items.push(admitted)
+    }
+
+    for (const message of messages) {
+        const admitted = admitDirectMessage({message, agentId});
+        if (admitted) items.push(admitted)
+    }
+
+    return items
+}

--- a/ai/services/graph/lifecycleAdmission.mjs
+++ b/ai/services/graph/lifecycleAdmission.mjs
@@ -251,9 +251,21 @@ export function hasCurrentHeadClosingReview(pr) {
  */
 export function currentHeadChecksOf(pr) {
     // A check names the head it ran against. One that names an OLDER head describes code that no longer
-    // exists, so it can neither block nor clear the current head. `undefined` is treated as current only
-    // because some sources omit it on a single-head snapshot; a NAMED older head is always excluded.
-    return (pr?.checks || []).filter(check => check.headSha === undefined || check.headSha === pr?.headSha)
+    // exists, so it can neither block nor clear the current head.
+    //
+    // An UNPROVENANCED check is excluded, not assumed current. Treating a missing `headSha` as current
+    // was a guess wearing a convenience's clothes: an unprovenanced FAILED required check then blocked
+    // repair and suppressed reviewer routing on a head it may never have run against. Scope has to be
+    // provable, and "the source did not say" is not proof of anything.
+    //
+    // A source that genuinely cannot stamp each check may attest that its snapshot contains ONLY
+    // current-head rows. That is the same fact, but asserted by the party that can actually know it,
+    // and it appears in the record rather than in this function's assumptions.
+    const attestedCurrentSnapshot = pr?.checksAreCurrentHeadSnapshot === true;
+
+    return (pr?.checks || []).filter(check =>
+        check.headSha === pr?.headSha || (attestedCurrentSnapshot && check.headSha === undefined)
+    )
 }
 
 export function hasFailedRequiredCheck(pr) {

--- a/ai/services/graph/lifecycleAdmission.mjs
+++ b/ai/services/graph/lifecycleAdmission.mjs
@@ -64,7 +64,7 @@ export function normalizeLifecycleClocks(pr) {
 
     // Only evidence attached to the CURRENT head can date the current head.
     const currentHeadReviews = (pr?.reviews || []).filter(review => review.commitSha === head),
-          currentHeadChecks  = (pr?.checks  || []).filter(check  => check.headSha === head || check.headSha === undefined);
+          currentHeadChecks  = currentHeadChecksOf(pr);
 
     const clean    = stamps => stamps.filter(stamp => typeof stamp === 'string' && stamp.length > 0).sort(),
           earliest = stamps => clean(stamps)[0] ?? null,
@@ -86,22 +86,39 @@ export function normalizeLifecycleClocks(pr) {
         ...currentHeadReviews.filter(review => review.state === 'CHANGES_REQUESTED').map(review => review.submittedAt),
         ...currentHeadChecks.filter(check => check.required === true && check.conclusion === 'FAILURE').map(check => check.completedAt),
         // A conflict carries no evidence timestamp of its own; the source states when it observed one.
-        pr?.mergeableSince
+        // Gated on an ACTIVE conflict: a stale `mergeableSince` from a conflict that has since been
+        // resolved is not evidence of anything, and letting it into the earliest() dated an unrelated
+        // repair from a problem that no longer exists.
+        pr?.mergeable === false ? pr?.mergeableSince : null
     ]));
 
     // REVIEWABLE — LATEST, and only once ALL required checks have passed. "When did this head become
     // reviewable?" is when the LAST required check went green. At the earliest one it was not reviewable
     // at all, so dating it there claims a readiness that did not exist.
-    const requiredChecks  = currentHeadChecks.filter(check => check.required === true),
-          allPassed       = requiredChecks.length > 0 && requiredChecks.every(check => check.conclusion === 'SUCCESS'),
-          reviewableSince = allPassed ? clampToHead(latest(requiredChecks.map(check => check.completedAt))) : null;
+    //
+    // A repo requiring NO checks is reviewable from the moment the head exists — the ADR admits "all
+    // pass OR none exist", and treating zero-required as undatable threw on a perfectly ordinary repo.
+    //
+    // A source-owned transition timestamp WINS when present. Check facts are evergreen: once green at
+    // 10:30 they stay green, so they cannot express a same-head loss and re-entry (reviewable at 10:30,
+    // a request arrives at 11:00 and removes the row, the request is withdrawn at 12:00 and it re-enters
+    // — which is 12:00, not 10:30). Only the source can date a transition it observed; deriving one from
+    // an evergreen fact would invent it.
+    const requiredChecks = currentHeadChecks.filter(check => check.required === true),
+          allPassed      = requiredChecks.every(check => check.conclusion === 'SUCCESS'),
+          derivedGreen   = requiredChecks.length === 0 ? headCommittedAt : latest(requiredChecks.map(check => check.completedAt));
 
-    // REQUESTED — LATER of the request and the head. A request that predates a push is not a request to
-    // review THIS code; the obligation restarts when the head moves under it. `clampToHead` IS that
-    // later(), since the head is the floor.
-    const requestedSince = clampToHead(earliest((pr?.reviewRequests || []).map(request =>
-        typeof request === 'object' ? request.requestedAt : null
-    )));
+    const reviewableSince = allPassed
+        ? clampToHead(sourceTransition(pr, 'reviewerRoutingSince') ?? derivedGreen)
+        : null;
+
+    // REQUESTED — LATER of the request and the head, PER TARGET. Taking the earliest across all agents
+    // dated a peer's 11:00 request from someone else's 09:00 one: each reviewer's obligation begins when
+    // THEY were asked, so one shared clock is not a rounding error, it is the wrong reviewer's fact.
+    // The per-target map is resolved by the predicate that knows which agent is consuming.
+    const requestedByTarget = Object.fromEntries((pr?.reviewRequests || [])
+        .map(request => typeof request === 'object' ? [request.login, clampToHead(request.requestedAt ?? null)] : [request, null])
+        .filter(([login]) => typeof login === 'string' && login.length > 0));
 
     return {
         ...pr,
@@ -109,9 +126,63 @@ export function normalizeLifecycleClocks(pr) {
         repairActionableSinceHeadSha: repairSince === null ? null : head,
         reviewableSince,
         reviewableSinceHeadSha      : reviewableSince === null ? null : head,
-        reviewRequestedSince        : requestedSince,
-        reviewRequestedSinceHeadSha : requestedSince === null ? null : head
+        reviewRequestedByTarget     : requestedByTarget,
+        reviewRequestedSinceHeadSha : head
     }
+}
+
+/**
+ * @summary Reads a source-owned transition timestamp, but only when the source proves it belongs to the
+ * CURRENT head.
+ *
+ * A transition is something only the source can witness: a snapshot of evergreen facts cannot say when
+ * a state was LOST and re-entered, because the facts read identically before and after. Where the source
+ * records that transition it is authoritative over anything derived; where it does not, the derivation
+ * stands and the same-head re-entry case remains the source's to close.
+ *
+ * @param {Object} pr Normalized PR record.
+ * @param {String} field The transition field.
+ * @returns {String|null}
+ */
+function sourceTransition(pr, field) {
+    const stamp = pr?.[field];
+
+    if (typeof stamp !== 'string' || stamp.length === 0) {
+        return null
+    }
+
+    // An unprovenanced or stale transition is not usable: it would carry a previous head's history into
+    // this one under current-head provenance.
+    return pr?.[`${field}HeadSha`] === pr?.headSha ? stamp : null
+}
+
+/**
+ * @summary Resolves the review-request clock for ONE consuming target.
+ *
+ * Each reviewer's obligation begins when THEY were asked. A single shared clock dated every reviewer
+ * from whoever was asked first, so a peer added at 11:00 inherited someone else's 09:00 — not a
+ * rounding error but the wrong reviewer's fact, and the age is what a peer sorts by.
+ *
+ * @param {Object} pr Normalized PR record carrying `reviewRequestedByTarget`.
+ * @param {String} agentId The consuming agent.
+ * @returns {String} The clock, proven current-head.
+ * @throws {TypeError} When the source dated no request for this target.
+ */
+export function resolveTargetRequestClock(pr, agentId) {
+    const stamp = pr?.reviewRequestedByTarget?.[agentId];
+
+    if (typeof stamp !== 'string' || stamp.length === 0) {
+        throw new TypeError(
+            `[lifecycleAdmission] no dated review request for ${agentId} on PR ${pr?.id} — ` +
+            'the source must state when each reviewer was asked; a row without its clock cannot be ordered'
+        )
+    }
+
+    if (pr?.reviewRequestedSinceHeadSha !== pr?.headSha) {
+        throw new TypeError(`[lifecycleAdmission] the review-request clock for PR ${pr?.id} does not belong to the current head`)
+    }
+
+    return stamp
 }
 
 /**
@@ -178,8 +249,15 @@ export function hasCurrentHeadClosingReview(pr) {
  * @param {Object} pr Normalized PR record `{checks: [{name, required, conclusion}]}`.
  * @returns {Boolean}
  */
+export function currentHeadChecksOf(pr) {
+    // A check names the head it ran against. One that names an OLDER head describes code that no longer
+    // exists, so it can neither block nor clear the current head. `undefined` is treated as current only
+    // because some sources omit it on a single-head snapshot; a NAMED older head is always excluded.
+    return (pr?.checks || []).filter(check => check.headSha === undefined || check.headSha === pr?.headSha)
+}
+
 export function hasFailedRequiredCheck(pr) {
-    return (pr?.checks || []).some(check => check.required === true && check.conclusion === 'FAILURE')
+    return currentHeadChecksOf(pr).some(check => check.required === true && check.conclusion === 'FAILURE')
 }
 
 /**
@@ -188,7 +266,7 @@ export function hasFailedRequiredCheck(pr) {
  * @returns {Boolean}
  */
 export function allRequiredChecksPass(pr) {
-    const required = (pr?.checks || []).filter(check => check.required === true);
+    const required = currentHeadChecksOf(pr).filter(check => check.required === true);
 
     return required.length === 0 || required.every(check => check.conclusion === 'SUCCESS')
 }
@@ -315,7 +393,7 @@ export function admitRequestedReview({pr, agentId} = {}) {
         source         : 'github-workflow',
         subjectId      : pr.id,
         headSha        : pr.headSha,
-        actionableSince: resolveHeadScopedClock(pr, 'reviewRequestedSince'),
+        actionableSince: resolveTargetRequestClock(pr, agentId),
         checkedAt      : pr.checkedAt,
         citations      : [pr.url].filter(Boolean)
     }

--- a/ai/services/graph/lifecycleAdmission.mjs
+++ b/ai/services/graph/lifecycleAdmission.mjs
@@ -22,6 +22,70 @@
  */
 
 /**
+ * @summary Derives a PR's lifecycle clocks from CURRENT-HEAD evidence, so the head-change reset is
+ * structural rather than promised.
+ *
+ * This is the clock owner. The earlier shape demanded that some upstream remember when each head became
+ * actionable and reset it on every push — a contract nothing implemented, and a stateful one at that.
+ * It is unnecessary: the source already carries the timestamps. A `CHANGES_REQUESTED` review names the
+ * commit it reviewed and when it was submitted; a failed check names its completion. So the clock for
+ * head X is simply *the earliest current-head evidence*, and its provenance is X **by construction**.
+ *
+ * The reset then costs nothing. When the head moves to Y, every X-attached review and check stops being
+ * current-head evidence, so the clock re-derives from Y's own facts or the row leaves the frontier
+ * entirely. A's clock cannot survive into B because it was never stored — only computed.
+ *
+ * Clears and re-entries follow for free: a predicate that stops holding drops the row, and satisfying it
+ * again derives a fresh clock from the evidence that satisfied it.
+ *
+ * @param {Object} pr Raw source PR `{headSha, reviews, checks, reviewRequests, mergeableSince?}`.
+ * @returns {Object} The PR with `repairActionableSince` / `reviewableSince` / `reviewRequestedSince`
+ *   and their `*HeadSha` provenance derived from current-head facts.
+ */
+export function normalizeLifecycleClocks(pr) {
+    const head = pr?.headSha;
+
+    // Only evidence attached to the CURRENT head can date the current head.
+    const currentHeadReviews = (pr?.reviews || []).filter(review => review.commitSha === head),
+          currentHeadChecks  = (pr?.checks  || []).filter(check  => check.headSha === head || check.headSha === undefined);
+
+    const earliest = stamps => {
+        const valid = stamps.filter(stamp => typeof stamp === 'string' && stamp.length > 0).sort();
+        return valid.length > 0 ? valid[0] : null
+    };
+
+    const repairSince = earliest([
+        ...currentHeadReviews.filter(review => review.state === 'CHANGES_REQUESTED').map(review => review.submittedAt),
+        ...currentHeadChecks.filter(check => check.required === true && check.conclusion === 'FAILURE').map(check => check.completedAt),
+        // A conflict has no source timestamp of its own; the source states when it observed one.
+        pr?.mergeableSince
+    ]);
+
+    // Where the source carries no per-fact timestamp, the observation time is the honest floor: this
+    // head WAS seen in this state at `checkedAt`. That understates age rather than inventing it, and it
+    // still resets on head change because the provenance below is the current head. It is a floor, not
+    // a claim about when the state began.
+    const observed = typeof pr?.checkedAt === 'string' ? pr.checkedAt : null;
+
+    const reviewableSince = earliest(currentHeadChecks.filter(check => check.required === true).map(check => check.completedAt)) ??
+                            pr?.headCommittedAt ?? observed;
+
+    const requestedSince = earliest((pr?.reviewRequests || []).map(request =>
+        typeof request === 'object' ? request.requestedAt : null
+    )) ?? ((pr?.reviewRequests || []).length > 0 ? observed : null);
+
+    return {
+        ...pr,
+        repairActionableSince       : repairSince,
+        repairActionableSinceHeadSha: repairSince === null ? null : head,
+        reviewableSince,
+        reviewableSinceHeadSha      : reviewableSince === null ? null : head,
+        reviewRequestedSince        : requestedSince,
+        reviewRequestedSinceHeadSha : requestedSince === null ? null : head
+    }
+}
+
+/**
  * @summary Returns a PR-derived clock only when the source proves it belongs to the CURRENT head.
  *
  * Every PR-derived row resets on head change. A stateless predicate cannot *perform* that reset — it
@@ -278,14 +342,19 @@ export function admitClaimedTask({task, agentId, actionableStates = ACTIONABLE_T
  * surface, which costs more than the row was ever worth.
  *
  * @param {Object} params
- * @param {Object} params.message Normalized message `{messageId, to, readAt, archivedAt, retractedAt, sentAt}`.
+ * @param {Object} params.message Normalized message `{messageId, to, readAt, archivedAt, retracted, sentAt}`.
+ *   `retracted` is a BOOLEAN — the shape `MailboxService` actually emits. An invented `retractedAt`
+ *   timestamp never fires on a real row, so the exclusion silently did nothing.
  * @param {String} params.agentId The consuming agent.
  * @returns {Object|null}
  */
 export function admitDirectMessage({message, agentId} = {}) {
-    if (!message || message.to !== agentId)       return null;
-    if (message.readAt)                           return null;
-    if (message.archivedAt || message.retractedAt) return null;
+    if (!message || message.to !== agentId) return null;
+    if (message.readAt)                     return null;
+    // `retracted: true` is the live shape (MailboxService sender-side retraction, which also blanks the
+    // body to a placeholder — admitting it would point a peer at nothing). `retractedAt` is tolerated
+    // only so a caller already passing a timestamp is not silently ignored.
+    if (message.archivedAt || message.retracted === true || message.retractedAt) return null;
 
     return {
         id             : `direct-message:${message.messageId}`,
@@ -320,7 +389,11 @@ export function admitDirectMessage({message, agentId} = {}) {
 export function collectLifecycleItems({agentId, prs = [], tasks = [], messages = []} = {}) {
     const items = [];
 
-    for (const pr of prs) {
+    for (const raw of prs) {
+        // The clock owner runs HERE, at the normalization boundary, so every predicate downstream reads
+        // clocks derived from the current head rather than whatever a caller happened to pass.
+        const pr = normalizeLifecycleClocks(raw);
+
         const repair  = admitOwnPrRepair({pr, agentId}),
               routing = admitOwnPrReviewerRouting({pr, agentId}),
               review  = admitRequestedReview({pr, agentId});

--- a/ai/services/graph/lifecycleAdmission.mjs
+++ b/ai/services/graph/lifecycleAdmission.mjs
@@ -22,6 +22,43 @@
  */
 
 /**
+ * @summary Returns a PR-derived clock only when the source proves it belongs to the CURRENT head.
+ *
+ * Every PR-derived row resets on head change. A stateless predicate cannot *perform* that reset — it
+ * has no memory of the previous head — so it can only *verify* it, and only if the source states which
+ * head the clock was started for. Without that provenance the predicate would copy a clock from three
+ * pushes ago and present it as the current head's, which is a confidently wrong timestamp: a peer reads
+ * "blocked for 6 hours" about code that has existed for 30 seconds.
+ *
+ * A missing or stale-provenance clock is a SOURCE CONTRACT violation, not a non-admission: the row is
+ * genuinely actionable, so silently dropping it would hide an obligation, and admitting it with an
+ * unprovable clock would fabricate one. Failing loud surfaces the wiring gap instead of choosing
+ * between two wrong answers.
+ *
+ * @param {Object} pr Normalized PR record.
+ * @param {String} field The clock field (`repairActionableSince` / `reviewableSince` / `reviewRequestedSince`).
+ * @returns {String} The clock, proven current-head.
+ * @throws {TypeError} When the clock is absent, or was measured against a different head.
+ */
+export function resolveHeadScopedClock(pr, field) {
+    const clock        = pr?.[field],
+          clockHeadSha = pr?.[`${field}HeadSha`];
+
+    if (typeof clock !== 'string' || clock.length === 0) {
+        throw new TypeError(`[lifecycleAdmission] ${field} is required on PR ${pr?.id} — a row without its clock cannot be ordered`)
+    }
+
+    if (clockHeadSha !== pr?.headSha) {
+        throw new TypeError(
+            `[lifecycleAdmission] ${field} on PR ${pr?.id} was measured at head ${clockHeadSha ?? 'unknown'} but the current head is ${pr?.headSha}; ` +
+            'the source must reset PR-derived clocks on head change and state the head each clock belongs to'
+        )
+    }
+
+    return clock
+}
+
+/**
  * @summary True when a review decision closes the CURRENT head.
  *
  * A review is only closing if it reviewed the head that exists now: a verdict attached to an older
@@ -64,13 +101,37 @@ export function allRequiredChecksPass(pr) {
 }
 
 /**
+ * @summary Resolves why an own PR needs repair, or `null` when it does not.
+ *
+ * Extracted so stage 1 and stage 2 read the SAME predicate rather than two hand-kept-in-sync
+ * conditions. Mutual exclusion asserted in prose is not mutual exclusion: a merge-conflicted PR with
+ * green required checks satisfied "needs repair" AND "cleanly reviewable" simultaneously, because each
+ * stage tested a different subset of the blockers.
+ *
+ * @param {Object} pr Normalized own-PR record.
+ * @returns {String|null} `changes-requested` | `failed-required-check` | `merge-conflict` | null.
+ */
+export function resolveRepairReason(pr) {
+    const changesRequested = (pr?.reviews || []).some(review =>
+        review.state === 'CHANGES_REQUESTED' && review.commitSha === pr.headSha
+    );
+
+    if (changesRequested)         return 'changes-requested';
+    if (hasFailedRequiredCheck(pr)) return 'failed-required-check';
+    if (pr?.mergeable === false)  return 'merge-conflict';
+
+    return null
+}
+
+/**
  * @summary Stage 1 — own-PR repair: the current head carries `CHANGES_REQUESTED`, a failed required
  * check, or a merge conflict.
  *
  * This outranks every other stage because it blocks a lane the agent already owns.
  *
  * `repairActionableSince` belongs to the CURRENT head: the clock starts when THIS head first satisfied
- * a repair predicate, not from whatever the PR looked like three pushes ago.
+ * a repair predicate, not from whatever the PR looked like three pushes ago — see
+ * {@link resolveHeadScopedClock}, which verifies that rather than assuming it.
  *
  * @param {Object} params
  * @param {Object} params.pr Normalized own-PR record.
@@ -80,15 +141,9 @@ export function allRequiredChecksPass(pr) {
 export function admitOwnPrRepair({pr, agentId} = {}) {
     if (!pr || pr.authorId !== agentId || pr.state !== 'OPEN' || pr.isDraft) return null;
 
-    const changesRequested = (pr.reviews || []).some(review =>
-              review.state === 'CHANGES_REQUESTED' && review.commitSha === pr.headSha
-          ),
-          failedCi   = hasFailedRequiredCheck(pr),
-          unmergeable = pr.mergeable === false;
+    const reason = resolveRepairReason(pr);
 
-    if (!changesRequested && !failedCi && !unmergeable) return null;
-
-    const reason = changesRequested ? 'changes-requested' : (failedCi ? 'failed-required-check' : 'merge-conflict');
+    if (!reason) return null;
 
     return {
         id             : `own-pr-repair:${pr.id}`,
@@ -98,7 +153,7 @@ export function admitOwnPrRepair({pr, agentId} = {}) {
         source         : 'github-workflow',
         subjectId      : pr.id,
         headSha        : pr.headSha,
-        actionableSince: pr.repairActionableSince,
+        actionableSince: resolveHeadScopedClock(pr, 'repairActionableSince'),
         checkedAt      : pr.checkedAt,
         citations      : [pr.url].filter(Boolean)
     }
@@ -120,6 +175,10 @@ export function admitOwnPrRepair({pr, agentId} = {}) {
  */
 export function admitOwnPrReviewerRouting({pr, agentId} = {}) {
     if (!pr || pr.authorId !== agentId || pr.state !== 'OPEN' || pr.isDraft) return null;
+    // The exclusion is structural, not documented: anything stage 1 admits is a lane the agent must
+    // repair, and a PR needing repair is not awaiting a reviewer. Testing only the checks would let a
+    // merge-conflicted PR with green checks enter BOTH stages.
+    if (resolveRepairReason(pr))                                             return null;
     if (!allRequiredChecksPass(pr))                                          return null;
     if ((pr.reviewRequests || []).length > 0)                                return null;
     if (hasCurrentHeadClosingReview(pr))                                     return null;
@@ -132,7 +191,7 @@ export function admitOwnPrReviewerRouting({pr, agentId} = {}) {
         source         : 'github-workflow',
         subjectId      : pr.id,
         headSha        : pr.headSha,
-        actionableSince: pr.reviewableSince,
+        actionableSince: resolveHeadScopedClock(pr, 'reviewableSince'),
         checkedAt      : pr.checkedAt,
         citations      : [pr.url].filter(Boolean)
     }
@@ -147,17 +206,13 @@ export function admitOwnPrReviewerRouting({pr, agentId} = {}) {
  * @returns {Object|null}
  */
 export function admitRequestedReview({pr, agentId} = {}) {
-    if (!pr || pr.state !== 'OPEN' || pr.isDraft)                       return null;
-    if (!(pr.reviewRequests || []).includes(agentId))                   return null;
-    // A verdict this agent already gave on the CURRENT head discharges the request; an older-head
-    // verdict does not, because the code changed underneath it.
-    const closedByMe = (pr.reviews || []).some(review =>
-        review.authorId === agentId &&
-        (review.state === 'APPROVED' || review.state === 'CHANGES_REQUESTED') &&
-        review.commitSha === pr.headSha
-    );
-
-    if (closedByMe) return null;
+    if (!pr || pr.state !== 'OPEN' || pr.isDraft)     return null;
+    if (!(pr.reviewRequests || []).includes(agentId)) return null;
+    // Closure is defined by the HEAD, not by the author of the verdict: a decision on the current head
+    // closes it, and a decision on an older head cannot, because the code changed underneath. Adding an
+    // author-is-me restriction here invented a rule the contract does not have — it kept a request live
+    // after a peer had already closed the current head, manufacturing an obligation.
+    if (hasCurrentHeadClosingReview(pr))              return null;
 
     return {
         id             : `requested-review:${pr.id}`,
@@ -167,7 +222,7 @@ export function admitRequestedReview({pr, agentId} = {}) {
         source         : 'github-workflow',
         subjectId      : pr.id,
         headSha        : pr.headSha,
-        actionableSince: pr.reviewRequestedSince,
+        actionableSince: resolveHeadScopedClock(pr, 'reviewRequestedSince'),
         checkedAt      : pr.checkedAt,
         citations      : [pr.url].filter(Boolean)
     }
@@ -217,14 +272,20 @@ export function admitClaimedTask({task, agentId, actionableStates = ACTIONABLE_T
  * `to === agentId` excludes broadcasts structurally: a broadcast is awareness, and treating it as an
  * obligation would make every peer's announcement someone else's todo.
  *
+ * Removal is not only reading. An archived message has been dispositioned, and a retracted one was
+ * withdrawn by its sender — both are unread forever, so keying admission on `readAt` alone would pin
+ * them to the frontier permanently. A row that cannot be cleared teaches the reader to ignore the
+ * surface, which costs more than the row was ever worth.
+ *
  * @param {Object} params
- * @param {Object} params.message Normalized message `{messageId, to, readAt, sentAt}`.
+ * @param {Object} params.message Normalized message `{messageId, to, readAt, archivedAt, retractedAt, sentAt}`.
  * @param {String} params.agentId The consuming agent.
  * @returns {Object|null}
  */
 export function admitDirectMessage({message, agentId} = {}) {
-    if (!message || message.to !== agentId) return null;
-    if (message.readAt)                     return null;
+    if (!message || message.to !== agentId)       return null;
+    if (message.readAt)                           return null;
+    if (message.archivedAt || message.retractedAt) return null;
 
     return {
         id             : `direct-message:${message.messageId}`,

--- a/ai/services/graph/lifecycleFrontier.mjs
+++ b/ai/services/graph/lifecycleFrontier.mjs
@@ -241,14 +241,29 @@ export function buildLifecycleFrontier({
  * expiry when it never could. Supplied, they make "is this expired?" and "is this even mine?"
  * executable — the second being the whole point of never-foreign at the consuming end.
  *
+ * Freshness and reader binding need the reader's own facts, so they are REQUIRED by default. Making
+ * them optional was itself a fail-open: called bare, the guard returned `valid: true` for an expired
+ * envelope scoped to another agent — the two failures it exists to catch — while looking like it had
+ * validated them. A caller that genuinely only wants structure must now say so, so that choice appears
+ * at the call site instead of hiding in an omitted argument.
+ *
  * @param {*} frontier The object to validate (may be anything).
  * @param {Object} [reader] The consuming reader's facts.
- * @param {Date|Number|String} [reader.now] Reader clock — enables the expiry check.
- * @param {String} [reader.agentId] Consuming agent — enables the reader-binding check.
+ * @param {Date|Number|String} [reader.now] Reader clock — required unless `shapeOnly`.
+ * @param {String} [reader.agentId] Consuming agent — required unless `shapeOnly`.
+ * @param {Boolean} [reader.shapeOnly=false] Explicitly validate STRUCTURE ONLY, accepting that expiry
+ *   and reader binding go unchecked.
  * @returns {{valid: Boolean, errors: String[]}}
  */
-export function validateLifecycleFrontier(frontier, {now, agentId} = {}) {
+export function validateLifecycleFrontier(frontier, {now, agentId, shapeOnly = false} = {}) {
     const errors = [];
+
+    if (!shapeOnly && (now === undefined || typeof agentId !== 'string' || agentId.length === 0)) {
+        return {
+            valid : false,
+            errors: ['reader validation requires now + agentId; pass {shapeOnly: true} to check structure only']
+        }
+    }
 
     if (!frontier || typeof frontier !== 'object' || Array.isArray(frontier)) {
         return {valid: false, errors: ['frontier is not a plain object']}
@@ -274,6 +289,14 @@ export function validateLifecycleFrontier(frontier, {now, agentId} = {}) {
 
     if (typeof frontier.sourceWatermark !== 'string' || frontier.sourceWatermark.length === 0) {
         errors.push('sourceWatermark is required')
+    }
+
+    // An envelope that expires before it was captured was never valid for a single instant. Both stamps
+    // parsing individually says nothing about whether they describe a coherent window.
+    if (typeof frontier.capturedAt === 'string' && typeof frontier.expiresAt === 'string' &&
+        !Number.isNaN(Date.parse(frontier.capturedAt)) && !Number.isNaN(Date.parse(frontier.expiresAt)) &&
+        Date.parse(frontier.expiresAt) <= Date.parse(frontier.capturedAt)) {
+        errors.push(`expiresAt ${frontier.expiresAt} is not after capturedAt ${frontier.capturedAt}`)
     }
 
     // Without a resolved scope a reader cannot tell whose obligations it is holding, which is the one
@@ -343,9 +366,9 @@ export function validateLifecycleFrontier(frontier, {now, agentId} = {}) {
                 errors.push(`items[${index}].stage is not a known lifecycle stage`)
             }
 
-            // The FULL shape, not the two fields that happen to be interesting. A partial row reads as a
-            // real obligation while naming nothing a peer can act on or trace.
-            for (const field of ['id', 'kind', 'source', 'subjectId']) {
+            // EVERY field the producer emits, not the ones that happen to be interesting. A partial row
+            // reads as a real obligation while naming nothing a peer can act on or trace.
+            for (const field of ['id', 'kind', 'state', 'source', 'subjectId', 'checkedAt']) {
                 if (typeof item?.[field] !== 'string' || item[field].length === 0) {
                     errors.push(`items[${index}].${field} is required`)
                 }
@@ -355,8 +378,12 @@ export function validateLifecycleFrontier(frontier, {now, agentId} = {}) {
                 errors.push(`items[${index}].actionableSince must be a parseable ISO timestamp`)
             }
 
+            // Members, not just the container: `citations: [42]` passes an is-array check and cites
+            // nothing a reader can follow.
             if (!Array.isArray(item?.citations)) {
                 errors.push(`items[${index}].citations must be an array`)
+            } else if (item.citations.some(citation => typeof citation !== 'string')) {
+                errors.push(`items[${index}].citations must contain only strings`)
             }
         });
 

--- a/ai/services/graph/lifecycleFrontier.mjs
+++ b/ai/services/graph/lifecycleFrontier.mjs
@@ -1,0 +1,270 @@
+/**
+ * @module ai/services/graph/lifecycleFrontier
+ * @summary The typed `lifecycle-frontier.v1` contract: what already requires ONE agent's response now.
+ *
+ * This is the counterpart to the computed route, not a competitor. The route answers "which direction
+ * best serves the declared goals next"; this answers "what is already waiting on me". They are separate
+ * authorities, and the separation is load-bearing: lifecycle facts are source-backed obligations, never
+ * score inputs, so nothing here may be folded into ranking. A frontier that ordered items by importance
+ * would have quietly become a second scorer.
+ *
+ * The failure this replaces is measured, not theoretical: across ~50 turn-end fires in one session a
+ * peer had to hand-survey own-PR gate state, the review queue, and assigned tickets EVERY time to find
+ * the real next action — because nothing produced this list.
+ *
+ * Two invariants carry most of the weight:
+ * 1. **Exclusions are as load-bearing as admissions.** "CI is running" is not a call to act; an approved
+ *    PR waiting on the human merge gate is not the agent's move. Admitting either manufactures busywork
+ *    rows and teaches peers to ignore the surface — the same way fixture rows taught them to ignore the
+ *    route.
+ * 2. **Never-foreign.** A missing, inferred, or conflicted identity omits the overlay with a reason. A
+ *    confidently-wrong identity map leaks another peer's obligations, and leakage is worse than absence.
+ */
+
+/**
+ * @summary The frontier's schema version.
+ * @type {String}
+ */
+export const LIFECYCLE_FRONTIER_SCHEMA_VERSION = 'lifecycle-frontier.v1';
+
+/**
+ * The five response-required stages, in presentation order. The order is the contract: an own-PR repair
+ * outranks a review request because the former blocks a lane the agent already owns. Index = rank.
+ * @type {String[]}
+ */
+export const LIFECYCLE_STAGES = Object.freeze([
+    'own-pr-repair',
+    'own-pr-reviewer-routing',
+    'requested-review',
+    'claimed-a2a-task',
+    'direct-message'
+]);
+
+/**
+ * @summary Valid frontier statuses. Independent of item count — an empty frontier is an honest answer,
+ * and `missing`/`degraded` must never be normalized to `empty`.
+ * @type {Set<String>}
+ */
+export const LIFECYCLE_FRONTIER_STATUSES = Object.freeze(new Set([
+    'fresh',
+    'empty',
+    'missing',
+    'stale',
+    'degraded'
+]));
+
+/**
+ * @summary Binding resolutions. Only an attested agent may carry a lifecycle overlay; everything else
+ * omits it with a reason rather than guessing.
+ * @type {Set<String>}
+ */
+export const LIFECYCLE_SCOPE_RESOLUTIONS = Object.freeze(new Set([
+    'agent-instance',
+    'agent',
+    'omitted'
+]));
+
+const STAGE_RANK = Object.freeze(
+    LIFECYCLE_STAGES.reduce((rank, stage, index) => Object.assign(rank, {[stage]: index}), {})
+);
+
+/**
+ * @summary Asserts a value is a non-empty string.
+ * @param {*} value
+ * @param {String} label Field name for the thrown message.
+ * @throws {TypeError} When `value` is not a non-empty string.
+ */
+function assertNonEmptyString(value, label) {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new TypeError(`[lifecycleFrontier] ${label} must be a non-empty string.`)
+    }
+}
+
+/**
+ * @summary Normalizes one response-required item, validating the fields a consumer must be able to
+ * trust: which stage it belongs to, what it points at, and since when it has been actionable.
+ *
+ * `actionableSince` is required because it is the only thing that makes the list orderable by age
+ * rather than by discovery accident — and because a row that cannot say since when it needed a
+ * response cannot be reasoned about at all.
+ *
+ * `headSha` carries the head a PR-derived row was observed against: a row that outlives its head is
+ * stale by construction, and the head is what a consumer re-checks against.
+ *
+ * @param {Object} item
+ * @param {Number} index Position, used only for error messages.
+ * @returns {Object} A frozen item.
+ * @throws {TypeError|RangeError} On a contract violation.
+ */
+function normalizeFrontierItem(item, index) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+        throw new TypeError(`[lifecycleFrontier] items[${index}] must be a plain object.`)
+    }
+
+    if (!STAGE_RANK.hasOwnProperty(item.stage)) {
+        throw new RangeError(`[lifecycleFrontier] items[${index}].stage must be one of ${LIFECYCLE_STAGES.join(', ')}; got ${JSON.stringify(item.stage)}.`)
+    }
+
+    assertNonEmptyString(item.id,              `items[${index}].id`);
+    assertNonEmptyString(item.source,          `items[${index}].source`);
+    assertNonEmptyString(item.subjectId,       `items[${index}].subjectId`);
+    assertNonEmptyString(item.actionableSince, `items[${index}].actionableSince`);
+
+    return Object.freeze({
+        id             : item.id,
+        stage          : item.stage,
+        kind           : typeof item.kind === 'string' ? item.kind : null,
+        state          : typeof item.state === 'string' ? item.state : null,
+        source         : item.source,
+        subjectId      : item.subjectId,
+        headSha        : typeof item.headSha === 'string' ? item.headSha : null,
+        actionableSince: item.actionableSince,
+        checkedAt      : typeof item.checkedAt === 'string' ? item.checkedAt : null,
+        citations      : Object.freeze(Array.isArray(item.citations) ? [...item.citations] : [])
+    })
+}
+
+/**
+ * @summary Orders the frontier: stage rank first, then oldest `actionableSince` first, then stable
+ * source id.
+ *
+ * The id tiebreak is not cosmetic — without it two equal-aged rows could swap between passes and a
+ * consumer diffing consecutive frontiers would report movement that never happened.
+ *
+ * @param {Object[]} items Normalized items.
+ * @returns {Object[]} A new, ordered array.
+ */
+function orderFrontierItems(items) {
+    return [...items].sort((a, b) =>
+        (STAGE_RANK[a.stage] - STAGE_RANK[b.stage]) ||
+        (Date.parse(a.actionableSince) - Date.parse(b.actionableSince)) ||
+        String(a.id).localeCompare(String(b.id))
+    )
+}
+
+/**
+ * @summary Builds a validated, frozen `lifecycle-frontier.v1` envelope for ONE attested agent.
+ *
+ * Producer-side: fails LOUD on a contract violation, because a malformed frontier is a producer bug and
+ * a plausible-but-wrong obligation list is worse than none. Source degradation is NOT a violation —
+ * that is what `coverage.degradedSources` and `status: 'degraded'` exist to carry honestly.
+ *
+ * @param {Object}   params
+ * @param {Object}   params.scope `{agentId, harnessInstance, resolution}` — the attested binding.
+ *   `resolution: 'omitted'` REQUIRES zero items: an unattested agent gets no overlay, never a guess.
+ * @param {String}   params.status One of {@link LIFECYCLE_FRONTIER_STATUSES}. Never derived from item count.
+ * @param {String}   params.capturedAt ISO timestamp of the source read.
+ * @param {String}   params.sourceWatermark Monotonic watermark of the observed source set.
+ * @param {String}   params.expiresAt ISO timestamp after which the frontier is stale.
+ * @param {Object}   [params.coverage] `{sources, degradedSources}` — which sources answered, which degraded.
+ * @param {Object[]} [params.items=[]] Response-required items; ordered here, not by the caller.
+ * @param {String}   [params.omittedReason=null] Why the overlay is absent when `resolution: 'omitted'`.
+ * @returns {Object} A deeply-frozen frontier envelope.
+ * @throws {TypeError|RangeError} On any contract violation.
+ */
+export function buildLifecycleFrontier({
+    scope,
+    status,
+    capturedAt,
+    sourceWatermark,
+    expiresAt,
+    coverage = {},
+    items    = [],
+    omittedReason = null
+} = {}) {
+    if (!LIFECYCLE_FRONTIER_STATUSES.has(status)) {
+        throw new RangeError(`[lifecycleFrontier] status must be one of ${[...LIFECYCLE_FRONTIER_STATUSES].join(', ')}; got ${JSON.stringify(status)}.`)
+    }
+
+    if (!scope || typeof scope !== 'object' || Array.isArray(scope)) {
+        throw new TypeError('[lifecycleFrontier] scope must be a plain object.')
+    }
+
+    if (!LIFECYCLE_SCOPE_RESOLUTIONS.has(scope.resolution)) {
+        throw new RangeError(`[lifecycleFrontier] scope.resolution must be one of ${[...LIFECYCLE_SCOPE_RESOLUTIONS].join(', ')}; got ${JSON.stringify(scope.resolution)}.`)
+    }
+
+    assertNonEmptyString(capturedAt,      'capturedAt');
+    assertNonEmptyString(sourceWatermark, 'sourceWatermark');
+    assertNonEmptyString(expiresAt,       'expiresAt');
+
+    const rawItems = Array.isArray(items) ? items : [];
+
+    // Never-foreign, enforced structurally: an unattested binding cannot carry obligations. Leaking one
+    // peer's rows to another is worse than showing nothing, so this is a producer error, not a warning.
+    if (scope.resolution === 'omitted' && rawItems.length > 0) {
+        throw new RangeError('[lifecycleFrontier] an omitted scope must carry zero items — an unattested agent never receives a lifecycle overlay.')
+    }
+
+    if (scope.resolution !== 'omitted') {
+        assertNonEmptyString(scope.agentId, 'scope.agentId')
+    }
+
+    const normalized = orderFrontierItems(rawItems.map(normalizeFrontierItem));
+
+    return Object.freeze({
+        schemaVersion: LIFECYCLE_FRONTIER_SCHEMA_VERSION,
+        status,
+        capturedAt,
+        sourceWatermark,
+        expiresAt,
+
+        scope: Object.freeze({
+            agentId        : typeof scope.agentId === 'string' ? scope.agentId : null,
+            harnessInstance: typeof scope.harnessInstance === 'string' ? scope.harnessInstance : null,
+            resolution     : scope.resolution,
+            omittedReason  : scope.resolution === 'omitted' ? (omittedReason || 'unattested-binding') : null
+        }),
+
+        coverage: Object.freeze({
+            sources        : Object.freeze(Array.isArray(coverage.sources) ? [...coverage.sources] : []),
+            degradedSources: Object.freeze(Array.isArray(coverage.degradedSources) ? [...coverage.degradedSources] : [])
+        }),
+
+        items       : Object.freeze(normalized),
+        notAuthority: true
+    })
+}
+
+/**
+ * @summary Consumer-side guard: validates a frontier WITHOUT throwing, so a reader degrades to bare
+ * policy rather than crashing on a torn or legacy envelope.
+ * @param {*} frontier The object to validate (may be anything).
+ * @returns {{valid: Boolean, errors: String[]}}
+ */
+export function validateLifecycleFrontier(frontier) {
+    const errors = [];
+
+    if (!frontier || typeof frontier !== 'object' || Array.isArray(frontier)) {
+        return {valid: false, errors: ['frontier is not a plain object']}
+    }
+    if (frontier.schemaVersion !== LIFECYCLE_FRONTIER_SCHEMA_VERSION) {
+        errors.push(`schemaVersion must be "${LIFECYCLE_FRONTIER_SCHEMA_VERSION}"`)
+    }
+    if (!LIFECYCLE_FRONTIER_STATUSES.has(frontier.status)) {
+        errors.push(`status must be one of ${[...LIFECYCLE_FRONTIER_STATUSES].join(', ')}`)
+    }
+    if (frontier.notAuthority !== true) {
+        errors.push('notAuthority must be true')
+    }
+
+    const items = Array.isArray(frontier.items) ? frontier.items : null;
+
+    if (items === null) {
+        errors.push('items must be an array')
+    } else {
+        if (frontier.scope?.resolution === 'omitted' && items.length > 0) {
+            errors.push('an omitted scope must carry zero items')
+        }
+        items.forEach((item, index) => {
+            if (!STAGE_RANK.hasOwnProperty(item?.stage)) {
+                errors.push(`items[${index}].stage is not a known lifecycle stage`)
+            }
+            if (typeof item?.actionableSince !== 'string' || item.actionableSince.length === 0) {
+                errors.push(`items[${index}].actionableSince is required`)
+            }
+        })
+    }
+
+    return {valid: errors.length === 0, errors}
+}

--- a/ai/services/graph/lifecycleFrontier.mjs
+++ b/ai/services/graph/lifecycleFrontier.mjs
@@ -119,6 +119,15 @@ function normalizeFrontierItem(item, index) {
     assertNonEmptyString(item.subjectId,       `items[${index}].subjectId`);
     assertNonEmptyString(item.actionableSince, `items[${index}].actionableSince`);
 
+    // A PR-derived row without its head is a PRODUCER bug, so it fails loud here rather than being
+    // normalized to null and handed on. Closing this at the consumer alone left the producer happily
+    // minting rows that could not support the head-change reset — the guard would catch them, but only
+    // after a malformed frontier already existed and only for readers that ran the guard. `null` here
+    // dressed an omission up as a decision.
+    if (PR_DERIVED_STAGES.has(item.stage)) {
+        assertNonEmptyString(item.headSha, `items[${index}].headSha (PR-derived stage "${item.stage}" resets on head change)`)
+    }
+
     return Object.freeze({
         id             : item.id,
         stage          : item.stage,

--- a/ai/services/graph/lifecycleFrontier.mjs
+++ b/ai/services/graph/lifecycleFrontier.mjs
@@ -236,10 +236,18 @@ export function buildLifecycleFrontier({
  * expired from live), or no scope (it cannot tell whose obligations these are). Each omission converts
  * a detectable tear into a confident wrong answer — so every field the producer emits is required here.
  *
+ * Freshness and reader binding are only checkable with the reader's own facts, so `now` and `agentId`
+ * are optional inputs rather than assumed: a guard that silently skips them looks like it validated
+ * expiry when it never could. Supplied, they make "is this expired?" and "is this even mine?"
+ * executable — the second being the whole point of never-foreign at the consuming end.
+ *
  * @param {*} frontier The object to validate (may be anything).
+ * @param {Object} [reader] The consuming reader's facts.
+ * @param {Date|Number|String} [reader.now] Reader clock — enables the expiry check.
+ * @param {String} [reader.agentId] Consuming agent — enables the reader-binding check.
  * @returns {{valid: Boolean, errors: String[]}}
  */
-export function validateLifecycleFrontier(frontier) {
+export function validateLifecycleFrontier(frontier, {now, agentId} = {}) {
     const errors = [];
 
     if (!frontier || typeof frontier !== 'object' || Array.isArray(frontier)) {
@@ -256,11 +264,16 @@ export function validateLifecycleFrontier(frontier) {
     }
 
     // Without these a reader cannot distinguish stale from current, or expired from live — the two
-    // judgements a perishable answer exists to support.
-    for (const field of ['capturedAt', 'sourceWatermark', 'expiresAt']) {
-        if (typeof frontier[field] !== 'string' || frontier[field].length === 0) {
-            errors.push(`${field} is required`)
+    // judgements a perishable answer exists to support. A present-but-unparseable stamp is worse than
+    // an absent one: it looks like a judgement the reader can make and is not.
+    for (const field of ['capturedAt', 'expiresAt']) {
+        if (typeof frontier[field] !== 'string' || Number.isNaN(Date.parse(frontier[field]))) {
+            errors.push(`${field} must be a parseable ISO timestamp`)
         }
+    }
+
+    if (typeof frontier.sourceWatermark !== 'string' || frontier.sourceWatermark.length === 0) {
+        errors.push('sourceWatermark is required')
     }
 
     // Without a resolved scope a reader cannot tell whose obligations it is holding, which is the one
@@ -272,17 +285,48 @@ export function validateLifecycleFrontier(frontier) {
     } else if (frontier.scope.resolution !== 'omitted' &&
                (typeof frontier.scope.agentId !== 'string' || frontier.scope.agentId.length === 0)) {
         errors.push('an attested scope must carry a non-empty agentId')
+    } else if (agentId && frontier.scope.resolution !== 'omitted' && frontier.scope.agentId !== agentId) {
+        // Never-foreign at the CONSUMING end. The producer refuses to build a foreign overlay; this is
+        // the reader refusing to act on one it was handed anyway.
+        errors.push(`frontier is scoped to ${frontier.scope.agentId}, not the consuming agent ${agentId}`)
+    }
+
+    // An expired frontier is not a frontier — it is a description of a world that has moved on.
+    if (now !== undefined && typeof frontier.expiresAt === 'string' && !Number.isNaN(Date.parse(frontier.expiresAt))) {
+        const readerNow = now instanceof Date ? now.getTime() : (typeof now === 'string' ? Date.parse(now) : now);
+
+        if (Number.isFinite(readerNow) && Date.parse(frontier.expiresAt) <= readerNow) {
+            errors.push(`frontier expired at ${frontier.expiresAt}`)
+        }
     }
 
     // Without coverage a degraded read is indistinguishable from a complete one.
     if (!frontier.coverage || typeof frontier.coverage !== 'object' || Array.isArray(frontier.coverage)) {
         errors.push('coverage is required')
     } else {
-        if (!Array.isArray(frontier.coverage.sources)) {
-            errors.push('coverage.sources must be an array')
+        for (const field of ['sources', 'degradedSources']) {
+            const list = frontier.coverage[field];
+
+            if (!Array.isArray(list)) {
+                errors.push(`coverage.${field} must be an array`)
+            } else if (list.some(entry => typeof entry !== 'string')) {
+                // A numeric member passes an is-array check and names no source — the list exists to be
+                // read, not counted.
+                errors.push(`coverage.${field} must contain only strings`)
+            }
         }
-        if (!Array.isArray(frontier.coverage.degradedSources)) {
-            errors.push('coverage.degradedSources must be an array')
+
+        // Coherence: status and coverage must tell the same story, or the reader believes whichever it
+        // happens to look at.
+        if (Array.isArray(frontier.coverage.degradedSources)) {
+            const degraded = frontier.coverage.degradedSources.length > 0;
+
+            if (degraded && frontier.status !== 'degraded') {
+                errors.push(`status is "${frontier.status}" while coverage names degraded sources`)
+            }
+            if (!degraded && frontier.status === 'degraded') {
+                errors.push('status is "degraded" while coverage names no degraded source')
+            }
         }
     }
 
@@ -298,10 +342,36 @@ export function validateLifecycleFrontier(frontier) {
             if (!STAGE_RANK.hasOwnProperty(item?.stage)) {
                 errors.push(`items[${index}].stage is not a known lifecycle stage`)
             }
-            if (typeof item?.actionableSince !== 'string' || item.actionableSince.length === 0) {
-                errors.push(`items[${index}].actionableSince is required`)
+
+            // The FULL shape, not the two fields that happen to be interesting. A partial row reads as a
+            // real obligation while naming nothing a peer can act on or trace.
+            for (const field of ['id', 'kind', 'source', 'subjectId']) {
+                if (typeof item?.[field] !== 'string' || item[field].length === 0) {
+                    errors.push(`items[${index}].${field} is required`)
+                }
             }
-        })
+
+            if (typeof item?.actionableSince !== 'string' || Number.isNaN(Date.parse(item?.actionableSince))) {
+                errors.push(`items[${index}].actionableSince must be a parseable ISO timestamp`)
+            }
+
+            if (!Array.isArray(item?.citations)) {
+                errors.push(`items[${index}].citations must be an array`)
+            }
+        });
+
+        // Order is part of the contract, so a reader can trust position instead of re-sorting. An
+        // out-of-order envelope means the producer's ordering was bypassed — the reader cannot tell
+        // whether the rest of the contract held either.
+        const ordered = [...items].sort((a, b) =>
+            (STAGE_RANK[a?.stage] - STAGE_RANK[b?.stage]) ||
+            (Date.parse(a?.actionableSince) - Date.parse(b?.actionableSince)) ||
+            String(a?.id).localeCompare(String(b?.id))
+        );
+
+        if (items.some((item, index) => item !== ordered[index])) {
+            errors.push('items are not in contract order (stage, then actionableSince oldest-first, then id)')
+        }
     }
 
     return {valid: errors.length === 0, errors}

--- a/ai/services/graph/lifecycleFrontier.mjs
+++ b/ai/services/graph/lifecycleFrontier.mjs
@@ -229,6 +229,13 @@ export function buildLifecycleFrontier({
 /**
  * @summary Consumer-side guard: validates a frontier WITHOUT throwing, so a reader degrades to bare
  * policy rather than crashing on a torn or legacy envelope.
+ *
+ * Validates the WHOLE contract, not the fields that happen to be interesting. A guard that passes a
+ * structurally incomplete envelope is worse than no guard: the reader believes it validated, then acts
+ * on a frontier with no capture time (it cannot tell stale from current), no expiry (it cannot tell
+ * expired from live), or no scope (it cannot tell whose obligations these are). Each omission converts
+ * a detectable tear into a confident wrong answer — so every field the producer emits is required here.
+ *
  * @param {*} frontier The object to validate (may be anything).
  * @returns {{valid: Boolean, errors: String[]}}
  */
@@ -246,6 +253,37 @@ export function validateLifecycleFrontier(frontier) {
     }
     if (frontier.notAuthority !== true) {
         errors.push('notAuthority must be true')
+    }
+
+    // Without these a reader cannot distinguish stale from current, or expired from live — the two
+    // judgements a perishable answer exists to support.
+    for (const field of ['capturedAt', 'sourceWatermark', 'expiresAt']) {
+        if (typeof frontier[field] !== 'string' || frontier[field].length === 0) {
+            errors.push(`${field} is required`)
+        }
+    }
+
+    // Without a resolved scope a reader cannot tell whose obligations it is holding, which is the one
+    // question never-foreign exists to answer.
+    if (!frontier.scope || typeof frontier.scope !== 'object' || Array.isArray(frontier.scope)) {
+        errors.push('scope is required')
+    } else if (!LIFECYCLE_SCOPE_RESOLUTIONS.has(frontier.scope.resolution)) {
+        errors.push(`scope.resolution must be one of ${[...LIFECYCLE_SCOPE_RESOLUTIONS].join(', ')}`)
+    } else if (frontier.scope.resolution !== 'omitted' &&
+               (typeof frontier.scope.agentId !== 'string' || frontier.scope.agentId.length === 0)) {
+        errors.push('an attested scope must carry a non-empty agentId')
+    }
+
+    // Without coverage a degraded read is indistinguishable from a complete one.
+    if (!frontier.coverage || typeof frontier.coverage !== 'object' || Array.isArray(frontier.coverage)) {
+        errors.push('coverage is required')
+    } else {
+        if (!Array.isArray(frontier.coverage.sources)) {
+            errors.push('coverage.sources must be an array')
+        }
+        if (!Array.isArray(frontier.coverage.degradedSources)) {
+            errors.push('coverage.degradedSources must be an array')
+        }
     }
 
     const items = Array.isArray(frontier.items) ? frontier.items : null;

--- a/ai/services/graph/lifecycleFrontier.mjs
+++ b/ai/services/graph/lifecycleFrontier.mjs
@@ -64,6 +64,15 @@ export const LIFECYCLE_SCOPE_RESOLUTIONS = Object.freeze(new Set([
     'omitted'
 ]));
 
+/**
+ * @summary The stages whose rows are derived from a pull request, and therefore reset on head change.
+ *
+ * Named explicitly because the reset invariant only applies to them: a claimed task or a direct message
+ * has no head to move under it, so requiring one there would be noise.
+ * @type {Set<String>}
+ */
+const PR_DERIVED_STAGES = Object.freeze(new Set(['own-pr-repair', 'own-pr-reviewer-routing', 'requested-review']));
+
 const STAGE_RANK = Object.freeze(
     LIFECYCLE_STAGES.reduce((rank, stage, index) => Object.assign(rank, {[stage]: index}), {})
 );
@@ -315,10 +324,17 @@ export function validateLifecycleFrontier(frontier, {now, agentId, shapeOnly = f
     }
 
     // An expired frontier is not a frontier — it is a description of a world that has moved on.
-    if (now !== undefined && typeof frontier.expiresAt === 'string' && !Number.isNaN(Date.parse(frontier.expiresAt))) {
+    if (now !== undefined) {
         const readerNow = now instanceof Date ? now.getTime() : (typeof now === 'string' ? Date.parse(now) : now);
 
-        if (Number.isFinite(readerNow) && Date.parse(frontier.expiresAt) <= readerNow) {
+        if (!Number.isFinite(readerNow)) {
+            // An UNPARSEABLE reader clock fails the guard rather than skipping the check. Skipping was
+            // the same fail-open as before wearing a defensive coat: the caller asked for expiry
+            // validation, the guard could not perform it, and returned valid anyway — so a 2020 envelope
+            // passed because the CLOCK was malformed, not the envelope.
+            errors.push(`reader clock ${JSON.stringify(now)} is not a parseable time; expiry could not be validated`)
+        } else if (typeof frontier.expiresAt === 'string' && !Number.isNaN(Date.parse(frontier.expiresAt)) &&
+                   Date.parse(frontier.expiresAt) <= readerNow) {
             errors.push(`frontier expired at ${frontier.expiresAt}`)
         }
     }
@@ -376,6 +392,14 @@ export function validateLifecycleFrontier(frontier, {now, agentId, shapeOnly = f
 
             if (typeof item?.actionableSince !== 'string' || Number.isNaN(Date.parse(item?.actionableSince))) {
                 errors.push(`items[${index}].actionableSince must be a parseable ISO timestamp`)
+            }
+
+            // A PR-derived row MUST name its head. Every such row resets on head change, and a row with
+            // `headSha: null` cannot support that invariant: nothing downstream can tell whether its
+            // clock belongs to the code that exists now. The builder emitting null made the omission
+            // look deliberate, which is worse than absent.
+            if (PR_DERIVED_STAGES.has(item?.stage) && (typeof item?.headSha !== 'string' || item.headSha.length === 0)) {
+                errors.push(`items[${index}].headSha is required for the PR-derived stage "${item?.stage}"`)
             }
 
             // Members, not just the container: `citations: [42]` passes an is-array check and cites

--- a/ai/services/graph/produceLifecycleFrontier.mjs
+++ b/ai/services/graph/produceLifecycleFrontier.mjs
@@ -1,0 +1,139 @@
+/**
+ * @module ai/services/graph/produceLifecycleFrontier
+ * @summary Composes the injected source reads into one `lifecycle-frontier.v1` envelope — the surface
+ * answering "what already requires MY response right now".
+ *
+ * The three layers stay separate on purpose: the admission predicates decide what counts, the envelope
+ * enforces the contract, and this composition owns only the impure edges — reading each source,
+ * surviving a source that fails, and refusing to read at all for an agent whose binding was never
+ * attested. The sources are owned elsewhere (GitHub Workflow owns PR/review/check facts; Memory Core
+ * A2A owns claimed-task and direct-message facts); this normalizes what they return and never
+ * re-derives their truth.
+ *
+ * Two honesty rules shape the whole module:
+ *
+ * - **Never-foreign beats complete.** An unattested binding reads no sources and carries no items.
+ *   Showing one peer another peer's obligations is worse than showing nothing, so the unattested path
+ *   short-circuits before any read rather than filtering afterwards.
+ * - **A source that failed is not a source that was empty.** Each read degrades independently and names
+ *   itself in `coverage.degradedSources`. A frontier missing a whole source must never read as "nothing
+ *   awaits you" — that is the one wrong answer this surface can give, because a peer acts on it.
+ */
+
+import {buildLifecycleFrontier} from './lifecycleFrontier.mjs';
+import {collectLifecycleItems}  from './lifecycleAdmission.mjs';
+
+/**
+ * @summary The source names carried in `coverage`. Each maps to one injected read and degrades alone.
+ * @type {String[]}
+ */
+export const LIFECYCLE_SOURCES = Object.freeze(['pull-requests', 'tasks', 'messages']);
+
+/**
+ * @summary Runs one injected source read, converting a failure into a named degradation rather than a
+ * thrown pass.
+ *
+ * A source read is impure and may fail for reasons that say nothing about the agent's obligations (a
+ * rate limit, a cold service). Losing the other sources to it would turn a partial outage into a false
+ * "nothing awaits you", so the failure is contained and named here.
+ *
+ * @param {String} name The source name recorded in coverage.
+ * @param {Function} read `async () => rows`.
+ * @returns {Promise<{name: String, rows: Object[], degraded: Boolean, reason: String|null}>}
+ */
+async function readSource(name, read) {
+    try {
+        const rows = await read();
+
+        return {name, rows: Array.isArray(rows) ? rows : [], degraded: false, reason: null}
+    } catch (error) {
+        return {
+            name,
+            rows    : [],
+            degraded: true,
+            reason  : `${name}: ${error instanceof Error ? error.message : String(error)}`
+        }
+    }
+}
+
+/**
+ * @summary Produces the lifecycle frontier for one attested agent from injected source reads.
+ *
+ * Fail-closed by construction: an unattested binding returns an omitted overlay without reading, and a
+ * failing source degrades only its own coverage row. The composition itself never throws — a contract
+ * violation still fails loud inside {@link buildLifecycleFrontier}, because that would be a producer
+ * bug rather than a source outage.
+ *
+ * @param {Object}   params
+ * @param {Object}   params.scope `{agentId, harnessInstance, resolution}` — the attested binding,
+ *   resolved by the caller that owns identity. `resolution: 'omitted'` skips every read.
+ * @param {Object}   params.sources Injected reads: `{readPullRequests, readTasks, readMessages}`, each
+ *   `async () => rows` from the service that owns those facts.
+ * @param {Date}     params.now Capture time (injected — no hidden clock).
+ * @param {Number}   params.ttlMs How long the frontier stays fresh; a lifecycle answer is perishable,
+ *   so the expiry is explicit rather than assumed by a reader.
+ * @param {String}   [params.omittedReason] Why the binding was not attested, when it was not.
+ * @returns {Promise<Object>} A frozen `lifecycle-frontier.v1` envelope.
+ * @throws {TypeError} When a required injection is missing — a wiring bug is not a degradation.
+ */
+export async function produceLifecycleFrontier({scope, sources, now, ttlMs, omittedReason} = {}) {
+    const capturedDate = now instanceof Date ? now : new Date(now);
+
+    if (Number.isNaN(capturedDate.getTime())) {
+        throw new TypeError('[produceLifecycleFrontier] now must be a valid Date/timestamp (inject the clock).')
+    }
+
+    if (!Number.isFinite(ttlMs) || ttlMs <= 0) {
+        throw new TypeError('[produceLifecycleFrontier] a positive ttlMs is required (inject it from config).')
+    }
+
+    const capturedAt = capturedDate.toISOString(),
+          expiresAt  = new Date(capturedDate.getTime() + ttlMs).toISOString();
+
+    // Never-foreign: an unattested binding short-circuits BEFORE any read. Filtering foreign rows after
+    // the fact would mean the obligations were already in memory, one bug away from being rendered.
+    if (scope?.resolution === 'omitted') {
+        return buildLifecycleFrontier({
+            scope,
+            status         : 'missing',
+            capturedAt,
+            sourceWatermark: capturedAt,
+            expiresAt,
+            coverage       : {sources: [], degradedSources: []},
+            items          : [],
+            omittedReason  : omittedReason || 'unattested-binding'
+        })
+    }
+
+    const {readPullRequests, readTasks, readMessages} = sources || {};
+
+    if (typeof readPullRequests !== 'function' || typeof readTasks !== 'function' || typeof readMessages !== 'function') {
+        throw new TypeError('[produceLifecycleFrontier] sources must supply readPullRequests, readTasks, and readMessages.')
+    }
+
+    const results = await Promise.all([
+        readSource('pull-requests', readPullRequests),
+        readSource('tasks',         readTasks),
+        readSource('messages',      readMessages)
+    ]);
+
+    const [prs, tasks, messages] = results.map(result => result.rows),
+          degradedSources        = results.filter(result => result.degraded).map(result => result.reason);
+
+    const items = collectLifecycleItems({agentId: scope?.agentId, prs, tasks, messages});
+
+    // Status is derived from what the READ proved, never from the item count: a degraded source with
+    // zero admitted items is not an empty frontier, it is an unknown one, and only the first reading
+    // lets a peer judge what the answer is worth.
+    const status = degradedSources.length > 0 ? 'degraded' : (items.length > 0 ? 'fresh' : 'empty');
+
+    return buildLifecycleFrontier({
+        scope,
+        status,
+        capturedAt,
+        sourceWatermark: capturedAt,
+        expiresAt,
+        coverage       : {sources: LIFECYCLE_SOURCES, degradedSources},
+        items
+    })
+}

--- a/ai/services/graph/produceLifecycleFrontier.mjs
+++ b/ai/services/graph/produceLifecycleFrontier.mjs
@@ -30,12 +30,24 @@ import {collectLifecycleItems}  from './lifecycleAdmission.mjs';
 export const LIFECYCLE_SOURCES = Object.freeze(['pull-requests', 'tasks', 'messages']);
 
 /**
- * @summary Runs one injected source read, converting a failure into a named degradation rather than a
- * thrown pass.
+ * @summary The only bindings that may carry a lifecycle overlay. Everything else — absent, inferred,
+ * conflicted, or simply unrecognized — is unattested and reads nothing.
+ * @type {Set<String>}
+ */
+const ATTESTED_RESOLUTIONS = Object.freeze(new Set(['agent-instance', 'agent']));
+
+/**
+ * @summary Runs one injected source read, converting a failure OR an unusable answer into a named
+ * degradation rather than a thrown pass or a false emptiness.
  *
  * A source read is impure and may fail for reasons that say nothing about the agent's obligations (a
  * rate limit, a cold service). Losing the other sources to it would turn a partial outage into a false
  * "nothing awaits you", so the failure is contained and named here.
+ *
+ * A source that returns something other than a list of rows is degraded, NOT empty. Coercing a
+ * malformed answer to `[]` would launder "I could not read this" into "there is nothing here" — the one
+ * wrong answer this surface can give, and the exact defect the module contract forbids. An unusable
+ * answer is an unknown, and only the source's own shape can distinguish it from a real absence.
  *
  * @param {String} name The source name recorded in coverage.
  * @param {Function} read `async () => rows`.
@@ -45,7 +57,16 @@ async function readSource(name, read) {
     try {
         const rows = await read();
 
-        return {name, rows: Array.isArray(rows) ? rows : [], degraded: false, reason: null}
+        if (!Array.isArray(rows)) {
+            return {
+                name,
+                rows    : [],
+                degraded: true,
+                reason  : `${name}: source returned ${rows === null ? 'null' : typeof rows}, not a row list`
+            }
+        }
+
+        return {name, rows, degraded: false, reason: null}
     } catch (error) {
         return {
             name,
@@ -90,18 +111,25 @@ export async function produceLifecycleFrontier({scope, sources, now, ttlMs, omit
     const capturedAt = capturedDate.toISOString(),
           expiresAt  = new Date(capturedDate.getTime() + ttlMs).toISOString();
 
-    // Never-foreign: an unattested binding short-circuits BEFORE any read. Filtering foreign rows after
-    // the fact would mean the obligations were already in memory, one bug away from being rendered.
-    if (scope?.resolution === 'omitted') {
+    // Never-foreign: anything that is not a POSITIVELY attested binding short-circuits before any read.
+    //
+    // The gate is an allow-list, not a check for one known-bad value. Testing `resolution === 'omitted'`
+    // would let every other non-attested category — inferred, conflicted, absent, or a value this
+    // version does not recognize — reach the source reads and be rejected only downstream, after
+    // foreign-capable obligations were already in memory. Rejecting late is not never-foreign; it is
+    // filtering, which is precisely what this contract forbids.
+    const attested = ATTESTED_RESOLUTIONS.has(scope?.resolution) && typeof scope?.agentId === 'string' && scope.agentId.length > 0;
+
+    if (!attested) {
         return buildLifecycleFrontier({
-            scope,
+            scope          : {...scope, resolution: 'omitted'},
             status         : 'missing',
             capturedAt,
             sourceWatermark: capturedAt,
             expiresAt,
             coverage       : {sources: [], degradedSources: []},
             items          : [],
-            omittedReason  : omittedReason || 'unattested-binding'
+            omittedReason  : omittedReason || `unattested-binding: ${scope?.resolution ?? 'absent'}`
         })
     }
 

--- a/test/playwright/unit/ai/services/graph/lifecycleAdmission.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/lifecycleAdmission.spec.mjs
@@ -35,18 +35,19 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
     // head and completion. The clock owner derives every `*Since` from exactly these, so a fixture that
     // hand-supplied clocks would be testing a contract nothing produces.
     const sourcePr = (overrides = {}) => ({
-        id            : 'pr-15231',
-        authorId      : ME,
-        state         : 'OPEN',
-        isDraft       : false,
-        headSha       : HEAD,
-        mergeable     : true,
-        checks        : [{name: 'unit', required: true, conclusion: 'SUCCESS', headSha: HEAD, completedAt: '2026-07-16T09:30:00.000Z'}],
-        reviews       : [],
-        reviewRequests: [],
-        url           : 'https://github.com/neomjs/neo/pull/15231',
-        mergeableSince: '2026-07-16T09:00:00.000Z',
-        checkedAt     : '2026-07-16T10:00:00.000Z',
+        id             : 'pr-15231',
+        authorId       : ME,
+        state          : 'OPEN',
+        isDraft        : false,
+        headSha        : HEAD,
+        headCommittedAt: '2026-07-16T08:00:00.000Z',
+        mergeable      : true,
+        checks         : [{name: 'unit', required: true, conclusion: 'SUCCESS', headSha: HEAD, completedAt: '2026-07-16T09:30:00.000Z'}],
+        reviews        : [],
+        reviewRequests : [],
+        url            : 'https://github.com/neomjs/neo/pull/15231',
+        mergeableSince : '2026-07-16T09:00:00.000Z',
+        checkedAt      : '2026-07-16T10:00:00.000Z',
         ...overrides
     });
 
@@ -64,7 +65,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
     test('stage 1 admits a current-head CHANGES_REQUESTED, a failed REQUIRED check, and a merge conflict', () => {
         expect(admitOwnPrRepair({pr: ownPr({reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD}]}), agentId: ME}).kind)
             .toBe('changes-requested');
-        expect(admitOwnPrRepair({pr: ownPr({checks: [{name: 'unit', required: true, conclusion: 'FAILURE'}]}), agentId: ME}).kind)
+        expect(admitOwnPrRepair({pr: ownPr({checks: [{name: 'unit', required: true, conclusion: 'FAILURE', headSha: HEAD, completedAt: '2026-07-16T09:10:00.000Z'}]}), agentId: ME}).kind)
             .toBe('failed-required-check');
         expect(admitOwnPrRepair({pr: ownPr({mergeable: false}), agentId: ME}).kind).toBe('merge-conflict');
         // a clean head is not a repair
@@ -83,8 +84,8 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
     test('EXCLUSION — an OPTIONAL check failing is not a repair trigger', () => {
         // otherwise every advisory linter invents an obligation
         const optionalFail = ownPr({checks: [
-            {name: 'unit',    required: true,  conclusion: 'SUCCESS'},
-            {name: 'advisory', required: false, conclusion: 'FAILURE'}
+            {name: 'unit',     required: true,  conclusion: 'SUCCESS', headSha: HEAD, completedAt: '2026-07-16T09:30:00.000Z'},
+            {name: 'advisory', required: false, conclusion: 'FAILURE', headSha: HEAD, completedAt: '2026-07-16T09:40:00.000Z'}
         ]});
 
         expect(admitOwnPrRepair({pr: optionalFail, agentId: ME})).toBeNull();
@@ -105,7 +106,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
 
         expect(admitOwnPrRepair({pr: draft, agentId: ME})).toBeNull();
         expect(admitOwnPrReviewerRouting({pr: draft, agentId: ME})).toBeNull();
-        expect(admitRequestedReview({pr: {...draft, reviewRequests: [ME]}, agentId: ME})).toBeNull();
+        expect(admitRequestedReview({pr: {...draft, reviewRequests: [{login: ME, requestedAt: '2026-07-16T09:45:00.000Z'}]}, agentId: ME})).toBeNull();
     });
 
     test('an OLD-head verdict does not close the current head — the code changed underneath it', () => {
@@ -119,12 +120,12 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
     });
 
     test('stage 2 excludes a PR that already has an outstanding review request — someone has it', () => {
-        expect(admitOwnPrReviewerRouting({pr: ownPr({reviewRequests: [PEER]}), agentId: ME})).toBeNull();
+        expect(admitOwnPrReviewerRouting({pr: ownPr({reviewRequests: [{login: PEER, requestedAt: '2026-07-16T09:45:00.000Z'}]}), agentId: ME})).toBeNull();
         expect(admitOwnPrReviewerRouting({pr: ownPr(), agentId: ME}).kind).toBe('needs-reviewer');
     });
 
     test('stage 3 admits a live request to me and discharges on ANY current-head verdict', () => {
-        const requested = ownPr({authorId: PEER, reviewRequests: [ME]});
+        const requested = ownPr({authorId: PEER, reviewRequests: [{login: ME, requestedAt: '2026-07-16T09:45:00.000Z'}]});
 
         expect(admitRequestedReview({pr: requested, agentId: ME}).stage).toBe('requested-review');
         // my verdict on the CURRENT head discharges it
@@ -179,7 +180,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
             agentId: ME,
             prs    : [
                 ownPr({id: 'pr-a', reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD}]}),
-                ownPr({id: 'pr-b', authorId: PEER, reviewRequests: [ME]})
+                ownPr({id: 'pr-b', authorId: PEER, reviewRequests: [{login: ME, requestedAt: '2026-07-16T09:45:00.000Z'}]})
             ],
             tasks   : [{id: 't-1', ownerId: ME, state: 'InputRequired', actionableSince: '2026-07-16T09:00:00.000Z'}],
             messages: [{messageId: 'm-1', to: ME, readAt: null, sentAt: '2026-07-16T09:00:00.000Z'}]
@@ -208,7 +209,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
         // live after the current head was already closed, manufacturing an obligation.
         const pr = ownPr({
             authorId      : PEER,
-            reviewRequests: [ME],
+            reviewRequests: [{login: ME, requestedAt: '2026-07-16T09:45:00.000Z'}],
             reviews       : [{state: 'APPROVED', authorId: PEER, commitSha: HEAD}]
         });
 
@@ -217,7 +218,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
         // ...but an OLDER-head verdict cannot close the current head — the code changed underneath it.
         const stale = ownPr({
             authorId      : PEER,
-            reviewRequests: [ME],
+            reviewRequests: [{login: ME, requestedAt: '2026-07-16T09:45:00.000Z'}],
             reviews       : [{state: 'APPROVED', authorId: PEER, commitSha: OLD}]
         });
 
@@ -280,6 +281,82 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
 
         expect(reentered.repairActionableSince).toBe('2026-07-16T11:00:00.000Z');
         expect(reentered.repairActionableSinceHeadSha).toBe(HEAD);
+    });
+
+    test('each clock has its OWN algebra — min for repair, max-when-all-pass for reviewable', () => {
+        // One reducer for three questions was wrong three different ways. These are the reviewer's exact
+        // literals.
+
+        // REVIEWABLE: required checks at 10:05 and 10:30 → the head became reviewable at 10:30, when the
+        // LAST one went green. At 10:05 it was not reviewable at all.
+        const twoChecks = normalizeClocks({
+            headSha        : HEAD,
+            headCommittedAt: '2026-07-16T10:00:00.000Z',
+            checks         : [
+                {name: 'a', required: true, conclusion: 'SUCCESS', headSha: HEAD, completedAt: '2026-07-16T10:05:00.000Z'},
+                {name: 'b', required: true, conclusion: 'SUCCESS', headSha: HEAD, completedAt: '2026-07-16T10:30:00.000Z'}
+            ]
+        });
+
+        expect(twoChecks.reviewableSince).toBe('2026-07-16T10:30:00.000Z');
+
+        // ...and until ALL pass there is no reviewable clock at all
+        const oneStillRunning = normalizeClocks({
+            headSha        : HEAD,
+            headCommittedAt: '2026-07-16T10:00:00.000Z',
+            checks         : [
+                {name: 'a', required: true, conclusion: 'SUCCESS', headSha: HEAD, completedAt: '2026-07-16T10:05:00.000Z'},
+                {name: 'b', required: true, conclusion: null,      headSha: HEAD}
+            ]
+        });
+
+        expect(oneStillRunning.reviewableSince).toBeNull();
+
+        // REPAIR: earliest blocking evidence — the first thing that broke this head dates it.
+        const twoBlockers = normalizeClocks({
+            headSha        : HEAD,
+            headCommittedAt: '2026-07-16T10:00:00.000Z',
+            reviews        : [{state: 'CHANGES_REQUESTED', commitSha: HEAD, submittedAt: '2026-07-16T10:40:00.000Z'}],
+            checks         : [{name: 'a', required: true, conclusion: 'FAILURE', headSha: HEAD, completedAt: '2026-07-16T10:20:00.000Z'}]
+        });
+
+        expect(twoBlockers.repairActionableSince).toBe('2026-07-16T10:20:00.000Z');
+    });
+
+    test('a clock can never predate its own head — later(evidence, head), not the evidence alone', () => {
+        // REQUESTED: a request at 09:00 followed by a push at 10:00 is not a request to review THIS
+        // code. The obligation restarts with the head.
+        const requestedBeforePush = normalizeClocks({
+            headSha        : HEAD,
+            headCommittedAt: '2026-07-16T10:00:00.000Z',
+            reviewRequests : [{login: ME, requestedAt: '2026-07-16T09:00:00.000Z'}],
+            checks         : []
+        });
+
+        expect(requestedBeforePush.reviewRequestedSince).toBe('2026-07-16T10:00:00.000Z');
+        expect(requestedBeforePush.reviewRequestedSinceHeadSha).toBe(HEAD);
+
+        // CONFLICT: a conflict observed at 09:00 cannot describe a head committed at 10:00. Keeping
+        // 09:00 while stamping current-head provenance claimed a duration this head never had.
+        const conflictBeforePush = normalizeClocks({
+            headSha        : HEAD,
+            headCommittedAt: '2026-07-16T10:00:00.000Z',
+            mergeableSince : '2026-07-16T09:00:00.000Z',
+            reviews        : [],
+            checks         : []
+        });
+
+        expect(conflictBeforePush.repairActionableSince).toBe('2026-07-16T10:00:00.000Z');
+
+        // a request AFTER the push keeps its own timestamp — the clamp is a floor, not an override
+        const requestedAfterPush = normalizeClocks({
+            headSha        : HEAD,
+            headCommittedAt: '2026-07-16T10:00:00.000Z',
+            reviewRequests : [{login: ME, requestedAt: '2026-07-16T11:00:00.000Z'}],
+            checks         : []
+        });
+
+        expect(requestedAfterPush.reviewRequestedSince).toBe('2026-07-16T11:00:00.000Z');
     });
 
     test('the clock owner runs inside collectLifecycleItems — a raw source row needs no caller clock', () => {

--- a/test/playwright/unit/ai/services/graph/lifecycleAdmission.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/lifecycleAdmission.spec.mjs
@@ -24,41 +24,41 @@ import * as core      from '../../../../../../src/core/_export.mjs';
  */
 test.describe('lifecycleAdmission — the five stages and their exclusions', () => {
     let admitOwnPrRepair, admitOwnPrReviewerRouting, admitRequestedReview, admitClaimedTask,
-        admitDirectMessage, collectLifecycleItems, hasCurrentHeadClosingReview;
+        admitDirectMessage, collectLifecycleItems, hasCurrentHeadClosingReview, normalizeClocks;
 
     const ME   = '@neo-opus-ada',
           PEER = '@neo-gpt',
           HEAD = 'head-2',
           OLD  = 'head-1';
 
-    const ownPr = (overrides = {}) => ({
-        id                   : 'pr-15231',
-        authorId             : ME,
-        state                : 'OPEN',
-        isDraft              : false,
-        headSha              : HEAD,
-        mergeable            : true,
-        checks               : [{name: 'unit', required: true, conclusion: 'SUCCESS'}],
-        reviews              : [],
-        reviewRequests       : [],
-        url                  : 'https://github.com/neomjs/neo/pull/15231',
-        repairActionableSince: '2026-07-16T09:00:00.000Z',
-        reviewableSince      : '2026-07-16T09:30:00.000Z',
-        reviewRequestedSince : '2026-07-16T09:45:00.000Z',
-        // Clock provenance: the source states which head each clock was started for, so the stateless
-        // predicate can VERIFY the head-change reset instead of assuming it.
-        repairActionableSinceHeadSha: HEAD,
-        reviewableSinceHeadSha      : HEAD,
-        reviewRequestedSinceHeadSha : HEAD,
-        checkedAt                   : '2026-07-16T10:00:00.000Z',
+    // SOURCE-shaped, not clock-shaped: reviews name the commit they reviewed and when, checks name their
+    // head and completion. The clock owner derives every `*Since` from exactly these, so a fixture that
+    // hand-supplied clocks would be testing a contract nothing produces.
+    const sourcePr = (overrides = {}) => ({
+        id            : 'pr-15231',
+        authorId      : ME,
+        state         : 'OPEN',
+        isDraft       : false,
+        headSha       : HEAD,
+        mergeable     : true,
+        checks        : [{name: 'unit', required: true, conclusion: 'SUCCESS', headSha: HEAD, completedAt: '2026-07-16T09:30:00.000Z'}],
+        reviews       : [],
+        reviewRequests: [],
+        url           : 'https://github.com/neomjs/neo/pull/15231',
+        mergeableSince: '2026-07-16T09:00:00.000Z',
+        checkedAt     : '2026-07-16T10:00:00.000Z',
         ...overrides
     });
+
+    // What the collector hands the predicates.
+    const ownPr = (overrides = {}) => normalizeClocks(sourcePr(overrides));
 
     test.beforeAll(async () => {
         ({
             admitOwnPrRepair, admitOwnPrReviewerRouting, admitRequestedReview, admitClaimedTask,
             admitDirectMessage, collectLifecycleItems, hasCurrentHeadClosingReview
         } = await import('../../../../../../ai/services/graph/lifecycleAdmission.mjs'));
+        ({normalizeLifecycleClocks: normalizeClocks} = await import('../../../../../../ai/services/graph/lifecycleAdmission.mjs'));
     });
 
     test('stage 1 admits a current-head CHANGES_REQUESTED, a failed REQUIRED check, and a merge conflict', () => {
@@ -224,25 +224,85 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
         expect(admitRequestedReview({pr: stale, agentId: ME}).stage).toBe('requested-review');
     });
 
-    test('a clock measured at an OLDER head fails LOUD — a stateless predicate cannot fake a reset', () => {
-        // Every PR-derived row resets on head change. A predicate with no memory of the previous head
-        // can only VERIFY that, and only if the source says which head the clock belongs to. Copying it
-        // blind reports "blocked for 6 hours" about code that has existed for 30 seconds.
-        const staleClock = ownPr({
-            reviews                     : [{state: 'CHANGES_REQUESTED', commitSha: HEAD}],
-            repairActionableSinceHeadSha: OLD
+    test('a clock whose provenance names a DIFFERENT head fails loud — the guard behind the derivation', () => {
+        // Defence in depth. The clock owner derives provenance by construction, so this cannot arise
+        // from `normalizeLifecycleClocks` — only from a caller that pre-normalized with its own logic.
+        // A clock from three pushes ago reports "blocked for 6 hours" about 30-second-old code, so the
+        // predicate refuses the record rather than trusting it.
+        const withCurrentHeadReview = sourcePr({
+            reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD, submittedAt: '2026-07-16T09:00:00.000Z'}]
         });
 
-        expect(() => admitOwnPrRepair({pr: staleClock, agentId: ME}))
-            .toThrow(/was measured at head head-1 but the current head is head-2/);
+        expect(() => admitOwnPrRepair({
+            pr: {
+                ...withCurrentHeadReview,
+                repairActionableSince       : '2026-07-16T09:00:00.000Z',
+                repairActionableSinceHeadSha: OLD
+            },
+            agentId: ME
+        })).toThrow(/was measured at head head-1 but the current head is head-2/);
 
         // an absent clock is equally a source-contract violation, not a silent drop
-        const noClock = ownPr({
-            reviews              : [{state: 'CHANGES_REQUESTED', commitSha: HEAD}],
-            repairActionableSince: undefined
+        expect(() => admitOwnPrRepair({
+            pr     : {...withCurrentHeadReview, repairActionableSince: undefined, repairActionableSinceHeadSha: HEAD},
+            agentId: ME
+        })).toThrow(/repairActionableSince is required/);
+    });
+
+    test('the SAME subject moving head A → clear → head B carries no clock across the transition', async () => {
+        const {normalizeLifecycleClocks} = await import('../../../../../../ai/services/graph/lifecycleAdmission.mjs');
+
+        // Head A: a CHANGES_REQUESTED review dates this head from its own submittedAt.
+        const atHeadA = normalizeLifecycleClocks({
+            id     : 'pr-1',
+            headSha: OLD,
+            reviews: [{state: 'CHANGES_REQUESTED', commitSha: OLD, submittedAt: '2026-07-16T09:00:00.000Z'}],
+            checks : []
         });
 
-        expect(() => admitOwnPrRepair({pr: noClock, agentId: ME})).toThrow(/repairActionableSince is required/);
+        expect(atHeadA.repairActionableSince).toBe('2026-07-16T09:00:00.000Z');
+        expect(atHeadA.repairActionableSinceHeadSha).toBe(OLD);
+
+        // The author pushes. The A-attached review is no longer current-head evidence, so the clock
+        // does not merely reset — it ceases to exist, because it was never stored.
+        const atHeadB = normalizeLifecycleClocks({...atHeadA, headSha: HEAD});
+
+        expect(atHeadB.repairActionableSince).toBeNull();
+        expect(atHeadB.repairActionableSinceHeadSha).toBeNull();
+        // A's clock cannot survive into B even though the caller passed A's normalized record forward
+        expect(atHeadB.repairActionableSince).not.toBe('2026-07-16T09:00:00.000Z');
+
+        // Re-entry on head B derives a FRESH clock from B's own evidence.
+        const reentered = normalizeLifecycleClocks({
+            ...atHeadB,
+            reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD, submittedAt: '2026-07-16T11:00:00.000Z'}]
+        });
+
+        expect(reentered.repairActionableSince).toBe('2026-07-16T11:00:00.000Z');
+        expect(reentered.repairActionableSinceHeadSha).toBe(HEAD);
+    });
+
+    test('the clock owner runs inside collectLifecycleItems — a raw source row needs no caller clock', () => {
+        // The provenance contract is worthless if nothing produces it. Raw rows carry only source facts.
+        const items = collectLifecycleItems({
+            agentId: ME,
+            prs    : [{
+                id       : 'pr-raw',
+                authorId : ME,
+                state    : 'OPEN',
+                isDraft  : false,
+                headSha  : HEAD,
+                mergeable: true,
+                reviews  : [{state: 'CHANGES_REQUESTED', commitSha: HEAD, submittedAt: '2026-07-16T08:00:00.000Z'}],
+                checks   : [{name: 'unit', required: true, conclusion: 'SUCCESS', headSha: HEAD, completedAt: '2026-07-16T07:00:00.000Z'}],
+                url      : 'https://github.com/neomjs/neo/pull/1'
+            }]
+        });
+
+        expect(items).toHaveLength(1);
+        expect(items[0].stage).toBe('own-pr-repair');
+        // derived from the review that dates THIS head, not supplied by the caller
+        expect(items[0].actionableSince).toBe('2026-07-16T08:00:00.000Z');
     });
 
     test('archived and retracted direct messages are removed — unread is not the only clearing', () => {
@@ -252,6 +312,14 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
 
         expect(admitDirectMessage({message: base, agentId: ME}).stage).toBe('direct-message');
         expect(admitDirectMessage({message: {...base, archivedAt: '2026-07-16T09:30:00.000Z'}, agentId: ME})).toBeNull();
+
+        // The LIVE shape: MailboxService emits `retracted: true` (a boolean) and blanks the body to a
+        // placeholder. The previous check tested an invented `retractedAt` timestamp, so it never fired
+        // on a real row — the exclusion existed only in the spec's imagination.
+        expect(admitDirectMessage({message: {...base, retracted: true}, agentId: ME})).toBeNull();
+        // a compatibility shape a caller may still pass
         expect(admitDirectMessage({message: {...base, retractedAt: '2026-07-16T09:30:00.000Z'}, agentId: ME})).toBeNull();
+        // and `retracted: false` is not a retraction
+        expect(admitDirectMessage({message: {...base, retracted: false}, agentId: ME}).stage).toBe('direct-message');
     });
 });

--- a/test/playwright/unit/ai/services/graph/lifecycleAdmission.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/lifecycleAdmission.spec.mjs
@@ -63,7 +63,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
     });
 
     test('stage 1 admits a current-head CHANGES_REQUESTED, a failed REQUIRED check, and a merge conflict', () => {
-        expect(admitOwnPrRepair({pr: ownPr({reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD}]}), agentId: ME}).kind)
+        expect(admitOwnPrRepair({pr: ownPr({reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD, submittedAt: '2026-07-16T09:00:00.000Z'}]}), agentId: ME}).kind)
             .toBe('changes-requested');
         expect(admitOwnPrRepair({pr: ownPr({checks: [{name: 'unit', required: true, conclusion: 'FAILURE', headSha: HEAD, completedAt: '2026-07-16T09:10:00.000Z'}]}), agentId: ME}).kind)
             .toBe('failed-required-check');
@@ -102,7 +102,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
     });
 
     test('EXCLUSION — a draft PR is not yet anyone\'s obligation', () => {
-        const draft = ownPr({isDraft: true, reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD}]});
+        const draft = ownPr({isDraft: true, reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD, submittedAt: '2026-07-16T09:00:00.000Z'}]});
 
         expect(admitOwnPrRepair({pr: draft, agentId: ME})).toBeNull();
         expect(admitOwnPrReviewerRouting({pr: draft, agentId: ME})).toBeNull();
@@ -116,7 +116,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
         // so the PR still needs a reviewer on THIS head
         expect(admitOwnPrReviewerRouting({pr: staleVerdict, agentId: ME})).not.toBeNull();
         // and a stale CHANGES_REQUESTED is likewise not a current-head repair
-        expect(admitOwnPrRepair({pr: ownPr({reviews: [{state: 'CHANGES_REQUESTED', commitSha: OLD}]}), agentId: ME})).toBeNull();
+        expect(admitOwnPrRepair({pr: ownPr({reviews: [{state: 'CHANGES_REQUESTED', commitSha: OLD, submittedAt: '2026-07-16T08:30:00.000Z'}]}), agentId: ME})).toBeNull();
     });
 
     test('stage 2 excludes a PR that already has an outstanding review request — someone has it', () => {
@@ -169,7 +169,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
     });
 
     test('never-foreign: another agent\'s PR never admits an own-PR stage', () => {
-        const peerPr = ownPr({authorId: PEER, reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD}]});
+        const peerPr = ownPr({authorId: PEER, reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD, submittedAt: '2026-07-16T09:00:00.000Z'}]});
 
         expect(admitOwnPrRepair({pr: peerPr, agentId: ME})).toBeNull();
         expect(admitOwnPrReviewerRouting({pr: peerPr, agentId: ME})).toBeNull();
@@ -179,7 +179,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
         const items = collectLifecycleItems({
             agentId: ME,
             prs    : [
-                ownPr({id: 'pr-a', reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD}]}),
+                ownPr({id: 'pr-a', reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD, submittedAt: '2026-07-16T09:00:00.000Z'}]}),
                 ownPr({id: 'pr-b', authorId: PEER, reviewRequests: [{login: ME, requestedAt: '2026-07-16T09:45:00.000Z'}]})
             ],
             tasks   : [{id: 't-1', ownerId: ME, state: 'InputRequired', actionableSince: '2026-07-16T09:00:00.000Z'}],
@@ -333,7 +333,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
             checks         : []
         });
 
-        expect(requestedBeforePush.reviewRequestedSince).toBe('2026-07-16T10:00:00.000Z');
+        expect(requestedBeforePush.reviewRequestedByTarget[ME]).toBe('2026-07-16T10:00:00.000Z');
         expect(requestedBeforePush.reviewRequestedSinceHeadSha).toBe(HEAD);
 
         // CONFLICT: a conflict observed at 09:00 cannot describe a head committed at 10:00. Keeping
@@ -341,6 +341,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
         const conflictBeforePush = normalizeClocks({
             headSha        : HEAD,
             headCommittedAt: '2026-07-16T10:00:00.000Z',
+            mergeable      : false,
             mergeableSince : '2026-07-16T09:00:00.000Z',
             reviews        : [],
             checks         : []
@@ -356,7 +357,92 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
             checks         : []
         });
 
-        expect(requestedAfterPush.reviewRequestedSince).toBe('2026-07-16T11:00:00.000Z');
+        expect(requestedAfterPush.reviewRequestedByTarget[ME]).toBe('2026-07-16T11:00:00.000Z');
+    });
+
+    test('an OLD-head failed check neither blocks nor clears the current head', () => {
+        // The predicates read every raw check while the derivation filtered to head, so an old-head
+        // failure produced repairReason=failed-required-check AND allRequiredChecksPass=false AND
+        // repairSince=null — three answers from two views of the same rows. A check names the head it
+        // ran against; one naming an OLDER head describes code that no longer exists.
+        const mixed = ownPr({
+            checks: [
+                {name: 'unit', required: true, conclusion: 'FAILURE', headSha: OLD,  completedAt: '2026-07-16T08:10:00.000Z'},
+                {name: 'unit', required: true, conclusion: 'SUCCESS', headSha: HEAD, completedAt: '2026-07-16T09:30:00.000Z'}
+            ]
+        });
+
+        expect(admitOwnPrRepair({pr: mixed, agentId: ME})).toBeNull();
+        expect(admitOwnPrReviewerRouting({pr: mixed, agentId: ME}).kind).toBe('needs-reviewer');
+    });
+
+    test('a RESOLVED conflict does not date a repair — mergeableSince is gated on an active one', () => {
+        // mergeable:true means there is no conflict now, so a leftover mergeableSince is evidence of a
+        // problem that no longer exists. Ungated, it dated an unrelated repair from it.
+        const resolved = normalizeClocks({
+            headSha        : HEAD,
+            headCommittedAt: '2026-07-16T10:00:00.000Z',
+            mergeable      : true,
+            mergeableSince : '2026-07-16T08:00:00.000Z',
+            reviews        : [{state: 'CHANGES_REQUESTED', commitSha: HEAD, submittedAt: '2026-07-16T11:00:00.000Z'}],
+            checks         : []
+        });
+
+        // the RC dates it, not the stale conflict
+        expect(resolved.repairActionableSince).toBe('2026-07-16T11:00:00.000Z');
+    });
+
+    test('a repo requiring NO checks is reviewable from the head — "all pass OR none exist"', () => {
+        // Treating zero-required as undatable threw on a perfectly ordinary repo.
+        const noChecks = ownPr({checks: []});
+
+        expect(noChecks.reviewableSince).toBe('2026-07-16T08:00:00.000Z');
+        expect(admitOwnPrReviewerRouting({pr: noChecks, agentId: ME}).actionableSince).toBe('2026-07-16T08:00:00.000Z');
+    });
+
+    test('each reviewer is dated from when THEY were asked, not from whoever was asked first', () => {
+        const twoTargets = normalizeClocks({
+            id             : 'pr-multi',
+            authorId       : '@someone-else',
+            state          : 'OPEN',
+            isDraft        : false,
+            headSha        : HEAD,
+            headCommittedAt: '2026-07-16T10:00:00.000Z',
+            reviewRequests : [
+                {login: ME,   requestedAt: '2026-07-16T09:00:00.000Z'},
+                {login: PEER, requestedAt: '2026-07-16T11:00:00.000Z'}
+            ],
+            reviews: [],
+            checks : [],
+            url    : 'https://github.com/neomjs/neo/pull/2'
+        });
+
+        // ME asked at 09:00, before the 10:00 push → clamped to the head
+        expect(admitRequestedReview({pr: twoTargets, agentId: ME}).actionableSince).toBe('2026-07-16T10:00:00.000Z');
+        // PEER asked at 11:00 keeps their OWN clock — one shared clock gave them someone else's 09:00,
+        // which is not a rounding error but the wrong reviewer's fact, and age is what a peer sorts by
+        expect(admitRequestedReview({pr: twoTargets, agentId: PEER}).actionableSince).toBe('2026-07-16T11:00:00.000Z');
+    });
+
+    test('a source-owned transition beats an evergreen fact — same-head re-entry', () => {
+        // Checks are evergreen: green at 10:30 stays green, and reads identically before and after a
+        // request arrives and is withdrawn. So the facts cannot express "reviewable at 10:30, lost at
+        // 11:00, re-entered at 12:00" — only the source that WITNESSED the transition can date it.
+        const reentered = ownPr({
+            reviewerRoutingSince       : '2026-07-16T12:00:00.000Z',
+            reviewerRoutingSinceHeadSha: HEAD
+        });
+
+        expect(reentered.reviewableSince).toBe('2026-07-16T12:00:00.000Z');
+
+        // ...but an unprovenanced transition is ignored: it would carry a previous head's history into
+        // this one under current-head provenance.
+        const staleTransition = ownPr({
+            reviewerRoutingSince       : '2026-07-16T12:00:00.000Z',
+            reviewerRoutingSinceHeadSha: OLD
+        });
+
+        expect(staleTransition.reviewableSince).toBe('2026-07-16T09:30:00.000Z');
     });
 
     test('the clock owner runs inside collectLifecycleItems — a raw source row needs no caller clock', () => {

--- a/test/playwright/unit/ai/services/graph/lifecycleAdmission.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/lifecycleAdmission.spec.mjs
@@ -1,0 +1,185 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'LifecycleAdmissionTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * The admission/exclusion matrix. The exclusions carry as much weight as the admissions: a row that
+ * does not truly need action teaches peers to ignore the surface, which is how the route's fixture
+ * rows failed.
+ */
+test.describe('lifecycleAdmission — the five stages and their exclusions', () => {
+    let admitOwnPrRepair, admitOwnPrReviewerRouting, admitRequestedReview, admitClaimedTask,
+        admitDirectMessage, collectLifecycleItems, hasCurrentHeadClosingReview;
+
+    const ME   = '@neo-opus-ada',
+          PEER = '@neo-gpt',
+          HEAD = 'head-2',
+          OLD  = 'head-1';
+
+    const ownPr = (overrides = {}) => ({
+        id                   : 'pr-15231',
+        authorId             : ME,
+        state                : 'OPEN',
+        isDraft              : false,
+        headSha              : HEAD,
+        mergeable            : true,
+        checks               : [{name: 'unit', required: true, conclusion: 'SUCCESS'}],
+        reviews              : [],
+        reviewRequests       : [],
+        url                  : 'https://github.com/neomjs/neo/pull/15231',
+        repairActionableSince: '2026-07-16T09:00:00.000Z',
+        reviewableSince      : '2026-07-16T09:30:00.000Z',
+        reviewRequestedSince : '2026-07-16T09:45:00.000Z',
+        checkedAt            : '2026-07-16T10:00:00.000Z',
+        ...overrides
+    });
+
+    test.beforeAll(async () => {
+        ({
+            admitOwnPrRepair, admitOwnPrReviewerRouting, admitRequestedReview, admitClaimedTask,
+            admitDirectMessage, collectLifecycleItems, hasCurrentHeadClosingReview
+        } = await import('../../../../../../ai/services/graph/lifecycleAdmission.mjs'));
+    });
+
+    test('stage 1 admits a current-head CHANGES_REQUESTED, a failed REQUIRED check, and a merge conflict', () => {
+        expect(admitOwnPrRepair({pr: ownPr({reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD}]}), agentId: ME}).kind)
+            .toBe('changes-requested');
+        expect(admitOwnPrRepair({pr: ownPr({checks: [{name: 'unit', required: true, conclusion: 'FAILURE'}]}), agentId: ME}).kind)
+            .toBe('failed-required-check');
+        expect(admitOwnPrRepair({pr: ownPr({mergeable: false}), agentId: ME}).kind).toBe('merge-conflict');
+        // a clean head is not a repair
+        expect(admitOwnPrRepair({pr: ownPr(), agentId: ME})).toBeNull();
+    });
+
+    test('EXCLUSION — pending/running CI is a wait, not a repair', () => {
+        // "CI is running" must never manufacture a row; only a FAILED required check is actionable.
+        const pending = ownPr({checks: [{name: 'unit', required: true, conclusion: null}]});
+
+        expect(admitOwnPrRepair({pr: pending, agentId: ME})).toBeNull();
+        // ...and it is not reviewable either: required checks have not passed yet
+        expect(admitOwnPrReviewerRouting({pr: pending, agentId: ME})).toBeNull();
+    });
+
+    test('EXCLUSION — an OPTIONAL check failing is not a repair trigger', () => {
+        // otherwise every advisory linter invents an obligation
+        const optionalFail = ownPr({checks: [
+            {name: 'unit',    required: true,  conclusion: 'SUCCESS'},
+            {name: 'advisory', required: false, conclusion: 'FAILURE'}
+        ]});
+
+        expect(admitOwnPrRepair({pr: optionalFail, agentId: ME})).toBeNull();
+        // it stays cleanly reviewable
+        expect(admitOwnPrReviewerRouting({pr: optionalFail, agentId: ME})).not.toBeNull();
+    });
+
+    test('EXCLUSION — an APPROVED PR awaiting the human merge gate is NOT the agent\'s move', () => {
+        // merge is human-only; listing it would ask for an action the agent must never take
+        const approved = ownPr({reviews: [{state: 'APPROVED', commitSha: HEAD, authorId: PEER}]});
+
+        expect(admitOwnPrReviewerRouting({pr: approved, agentId: ME})).toBeNull();
+        expect(admitOwnPrRepair({pr: approved, agentId: ME})).toBeNull();
+    });
+
+    test('EXCLUSION — a draft PR is not yet anyone\'s obligation', () => {
+        const draft = ownPr({isDraft: true, reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD}]});
+
+        expect(admitOwnPrRepair({pr: draft, agentId: ME})).toBeNull();
+        expect(admitOwnPrReviewerRouting({pr: draft, agentId: ME})).toBeNull();
+        expect(admitRequestedReview({pr: {...draft, reviewRequests: [ME]}, agentId: ME})).toBeNull();
+    });
+
+    test('an OLD-head verdict does not close the current head — the code changed underneath it', () => {
+        const staleVerdict = ownPr({reviews: [{state: 'APPROVED', commitSha: OLD, authorId: PEER}]});
+
+        expect(hasCurrentHeadClosingReview(staleVerdict)).toBe(false);
+        // so the PR still needs a reviewer on THIS head
+        expect(admitOwnPrReviewerRouting({pr: staleVerdict, agentId: ME})).not.toBeNull();
+        // and a stale CHANGES_REQUESTED is likewise not a current-head repair
+        expect(admitOwnPrRepair({pr: ownPr({reviews: [{state: 'CHANGES_REQUESTED', commitSha: OLD}]}), agentId: ME})).toBeNull();
+    });
+
+    test('stage 2 excludes a PR that already has an outstanding review request — someone has it', () => {
+        expect(admitOwnPrReviewerRouting({pr: ownPr({reviewRequests: [PEER]}), agentId: ME})).toBeNull();
+        expect(admitOwnPrReviewerRouting({pr: ownPr(), agentId: ME}).kind).toBe('needs-reviewer');
+    });
+
+    test('stage 3 admits a live request to me and discharges on MY current-head verdict only', () => {
+        const requested = ownPr({authorId: PEER, reviewRequests: [ME]});
+
+        expect(admitRequestedReview({pr: requested, agentId: ME}).stage).toBe('requested-review');
+        // my verdict on the CURRENT head discharges it
+        expect(admitRequestedReview({
+            pr: {...requested, reviews: [{state: 'APPROVED', commitSha: HEAD, authorId: ME}]}, agentId: ME
+        })).toBeNull();
+        // my verdict on an OLD head does not — the head moved
+        expect(admitRequestedReview({
+            pr: {...requested, reviews: [{state: 'APPROVED', commitSha: OLD, authorId: ME}]}, agentId: ME
+        })).not.toBeNull();
+        // a peer's current-head verdict does not discharge MY request
+        expect(admitRequestedReview({
+            pr: {...requested, reviews: [{state: 'APPROVED', commitSha: HEAD, authorId: PEER}]}, agentId: ME
+        })).not.toBeNull();
+    });
+
+    test('stage 4 admits only a CLAIMED task in an action-requiring state', () => {
+        const task = {id: 't-1', ownerId: ME, state: 'InputRequired', actionableSince: '2026-07-16T09:00:00.000Z'};
+
+        expect(admitClaimedTask({task, agentId: ME}).stage).toBe('claimed-a2a-task');
+        // EXCLUSION: an unclaimed broadcast has no owner — awareness never becomes an obligation
+        expect(admitClaimedTask({task: {...task, ownerId: null}, agentId: ME})).toBeNull();
+        // EXCLUSION: another agent's claimed task is never mine
+        expect(admitClaimedTask({task: {...task, ownerId: PEER}, agentId: ME})).toBeNull();
+        // EXCLUSION: a terminal task has ended
+        expect(admitClaimedTask({task: {...task, state: 'Completed'}, agentId: ME})).toBeNull();
+        // EXCLUSION: a non-actionable live state is awareness, not an obligation
+        expect(admitClaimedTask({task: {...task, state: 'Working'}, agentId: ME})).toBeNull();
+    });
+
+    test('stage 5 admits an unread DIRECT message; broadcasts and read messages are excluded', () => {
+        const message = {messageId: 'm-1', to: ME, readAt: null, sentAt: '2026-07-16T09:00:00.000Z'};
+
+        expect(admitDirectMessage({message, agentId: ME}).stage).toBe('direct-message');
+        expect(admitDirectMessage({message: {...message, readAt: '2026-07-16T09:30:00.000Z'}, agentId: ME})).toBeNull();
+        // a broadcast is awareness — otherwise every peer's announcement becomes my todo
+        expect(admitDirectMessage({message: {...message, to: 'AGENT:*'}, agentId: ME})).toBeNull();
+        expect(admitDirectMessage({message: {...message, to: PEER}, agentId: ME})).toBeNull();
+    });
+
+    test('never-foreign: another agent\'s PR never admits an own-PR stage', () => {
+        const peerPr = ownPr({authorId: PEER, reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD}]});
+
+        expect(admitOwnPrRepair({pr: peerPr, agentId: ME})).toBeNull();
+        expect(admitOwnPrReviewerRouting({pr: peerPr, agentId: ME})).toBeNull();
+    });
+
+    test('collectLifecycleItems runs every stage over the source records', () => {
+        const items = collectLifecycleItems({
+            agentId: ME,
+            prs    : [
+                ownPr({id: 'pr-a', reviews: [{state: 'CHANGES_REQUESTED', commitSha: HEAD}]}),
+                ownPr({id: 'pr-b', authorId: PEER, reviewRequests: [ME]})
+            ],
+            tasks   : [{id: 't-1', ownerId: ME, state: 'InputRequired', actionableSince: '2026-07-16T09:00:00.000Z'}],
+            messages: [{messageId: 'm-1', to: ME, readAt: null, sentAt: '2026-07-16T09:00:00.000Z'}]
+        });
+
+        expect(items.map(entry => entry.stage).sort()).toEqual(
+            ['claimed-a2a-task', 'direct-message', 'own-pr-repair', 'requested-review']
+        );
+    });
+});

--- a/test/playwright/unit/ai/services/graph/lifecycleAdmission.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/lifecycleAdmission.spec.mjs
@@ -45,7 +45,12 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
         repairActionableSince: '2026-07-16T09:00:00.000Z',
         reviewableSince      : '2026-07-16T09:30:00.000Z',
         reviewRequestedSince : '2026-07-16T09:45:00.000Z',
-        checkedAt            : '2026-07-16T10:00:00.000Z',
+        // Clock provenance: the source states which head each clock was started for, so the stateless
+        // predicate can VERIFY the head-change reset instead of assuming it.
+        repairActionableSinceHeadSha: HEAD,
+        reviewableSinceHeadSha      : HEAD,
+        reviewRequestedSinceHeadSha : HEAD,
+        checkedAt                   : '2026-07-16T10:00:00.000Z',
         ...overrides
     });
 
@@ -118,7 +123,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
         expect(admitOwnPrReviewerRouting({pr: ownPr(), agentId: ME}).kind).toBe('needs-reviewer');
     });
 
-    test('stage 3 admits a live request to me and discharges on MY current-head verdict only', () => {
+    test('stage 3 admits a live request to me and discharges on ANY current-head verdict', () => {
         const requested = ownPr({authorId: PEER, reviewRequests: [ME]});
 
         expect(admitRequestedReview({pr: requested, agentId: ME}).stage).toBe('requested-review');
@@ -126,14 +131,16 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
         expect(admitRequestedReview({
             pr: {...requested, reviews: [{state: 'APPROVED', commitSha: HEAD, authorId: ME}]}, agentId: ME
         })).toBeNull();
-        // my verdict on an OLD head does not — the head moved
+        // my verdict on an OLD head does not — the head moved underneath it
         expect(admitRequestedReview({
             pr: {...requested, reviews: [{state: 'APPROVED', commitSha: OLD, authorId: ME}]}, agentId: ME
         })).not.toBeNull();
-        // a peer's current-head verdict does not discharge MY request
+        // Closure is defined by the HEAD, not the verdict's author: a peer's current-head decision
+        // closes it too. (This assertion previously demanded the opposite — an author-is-me rule the
+        // contract never contained, which kept a request live after the head was already closed.)
         expect(admitRequestedReview({
             pr: {...requested, reviews: [{state: 'APPROVED', commitSha: HEAD, authorId: PEER}]}, agentId: ME
-        })).not.toBeNull();
+        })).toBeNull();
     });
 
     test('stage 4 admits only a CLAIMED task in an action-requiring state', () => {
@@ -181,5 +188,70 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
         expect(items.map(entry => entry.stage).sort()).toEqual(
             ['claimed-a2a-task', 'direct-message', 'own-pr-repair', 'requested-review']
         );
+    });
+
+    test('a merge-conflicted PR with GREEN checks enters repair only — the stages are exclusive in fact', () => {
+        // The prose claimed mutual exclusion; a merge conflict falsified it. Each stage tested a
+        // different subset of the blockers, so a conflicted-but-green PR satisfied "needs repair" AND
+        // "cleanly reviewable" at once, and the peer saw one PR twice.
+        const conflicted = ownPr({mergeable: false});
+
+        expect(admitOwnPrRepair({pr: conflicted, agentId: ME}).kind).toBe('merge-conflict');
+        expect(admitOwnPrReviewerRouting({pr: conflicted, agentId: ME})).toBeNull();
+
+        const stages = collectLifecycleItems({agentId: ME, prs: [conflicted]}).map(entry => entry.stage);
+        expect(stages).toEqual(['own-pr-repair']);
+    });
+
+    test('a PEER\'s current-head verdict closes MY requested review — closure is by head, not by author', () => {
+        // An author-is-me restriction invented a rule the contract does not have: it kept the request
+        // live after the current head was already closed, manufacturing an obligation.
+        const pr = ownPr({
+            authorId      : PEER,
+            reviewRequests: [ME],
+            reviews       : [{state: 'APPROVED', authorId: PEER, commitSha: HEAD}]
+        });
+
+        expect(admitRequestedReview({pr, agentId: ME})).toBeNull();
+
+        // ...but an OLDER-head verdict cannot close the current head — the code changed underneath it.
+        const stale = ownPr({
+            authorId      : PEER,
+            reviewRequests: [ME],
+            reviews       : [{state: 'APPROVED', authorId: PEER, commitSha: OLD}]
+        });
+
+        expect(admitRequestedReview({pr: stale, agentId: ME}).stage).toBe('requested-review');
+    });
+
+    test('a clock measured at an OLDER head fails LOUD — a stateless predicate cannot fake a reset', () => {
+        // Every PR-derived row resets on head change. A predicate with no memory of the previous head
+        // can only VERIFY that, and only if the source says which head the clock belongs to. Copying it
+        // blind reports "blocked for 6 hours" about code that has existed for 30 seconds.
+        const staleClock = ownPr({
+            reviews                     : [{state: 'CHANGES_REQUESTED', commitSha: HEAD}],
+            repairActionableSinceHeadSha: OLD
+        });
+
+        expect(() => admitOwnPrRepair({pr: staleClock, agentId: ME}))
+            .toThrow(/was measured at head head-1 but the current head is head-2/);
+
+        // an absent clock is equally a source-contract violation, not a silent drop
+        const noClock = ownPr({
+            reviews              : [{state: 'CHANGES_REQUESTED', commitSha: HEAD}],
+            repairActionableSince: undefined
+        });
+
+        expect(() => admitOwnPrRepair({pr: noClock, agentId: ME})).toThrow(/repairActionableSince is required/);
+    });
+
+    test('archived and retracted direct messages are removed — unread is not the only clearing', () => {
+        // Both are unread forever. Keying on readAt alone pins them to the frontier permanently, and a
+        // row that cannot be cleared teaches the reader to ignore the surface.
+        const base = {messageId: 'm-1', to: ME, readAt: null, sentAt: '2026-07-16T09:00:00.000Z'};
+
+        expect(admitDirectMessage({message: base, agentId: ME}).stage).toBe('direct-message');
+        expect(admitDirectMessage({message: {...base, archivedAt: '2026-07-16T09:30:00.000Z'}, agentId: ME})).toBeNull();
+        expect(admitDirectMessage({message: {...base, retractedAt: '2026-07-16T09:30:00.000Z'}, agentId: ME})).toBeNull();
     });
 });

--- a/test/playwright/unit/ai/services/graph/lifecycleAdmission.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/lifecycleAdmission.spec.mjs
@@ -74,7 +74,7 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
 
     test('EXCLUSION — pending/running CI is a wait, not a repair', () => {
         // "CI is running" must never manufacture a row; only a FAILED required check is actionable.
-        const pending = ownPr({checks: [{name: 'unit', required: true, conclusion: null}]});
+        const pending = ownPr({checks: [{name: 'unit', required: true, conclusion: null, headSha: HEAD}]});
 
         expect(admitOwnPrRepair({pr: pending, agentId: ME})).toBeNull();
         // ...and it is not reviewable either: required checks have not passed yet
@@ -374,6 +374,32 @@ test.describe('lifecycleAdmission — the five stages and their exclusions', () 
 
         expect(admitOwnPrRepair({pr: mixed, agentId: ME})).toBeNull();
         expect(admitOwnPrReviewerRouting({pr: mixed, agentId: ME}).kind).toBe('needs-reviewer');
+    });
+
+    test('an UNPROVENANCED check is not assumed current — scope must be provable', () => {
+        // The reviewer's falsifier: an unprovenanced FAILED required check plus a current-head SUCCESS
+        // yielded failed-required-check and suppressed reviewer routing — blocking a head the check may
+        // never have run against. "The source did not say" is not proof of anything, and treating a
+        // missing headSha as current was a guess wearing a convenience's clothes.
+        const unprovenanced = ownPr({
+            checks: [
+                {name: 'unit', required: true, conclusion: 'FAILURE'},
+                {name: 'unit', required: true, conclusion: 'SUCCESS', headSha: HEAD, completedAt: '2026-07-16T09:30:00.000Z'}
+            ]
+        });
+
+        expect(admitOwnPrRepair({pr: unprovenanced, agentId: ME})).toBeNull();
+        expect(admitOwnPrReviewerRouting({pr: unprovenanced, agentId: ME}).kind).toBe('needs-reviewer');
+
+        // A source that cannot stamp each check may ATTEST its snapshot is current-head-only. Same fact,
+        // asserted by the party that can actually know it, and visible in the record rather than assumed
+        // in the filter.
+        const attested = ownPr({
+            checksAreCurrentHeadSnapshot: true,
+            checks                      : [{name: 'unit', required: true, conclusion: 'FAILURE', completedAt: '2026-07-16T09:10:00.000Z'}]
+        });
+
+        expect(admitOwnPrRepair({pr: attested, agentId: ME}).kind).toBe('failed-required-check');
     });
 
     test('a RESOLVED conflict does not date a repair — mergeableSince is gated on an active one', () => {

--- a/test/playwright/unit/ai/services/graph/lifecycleFrontier.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/lifecycleFrontier.spec.mjs
@@ -44,6 +44,7 @@ test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
         state          : 'OPEN',
         source         : 'github-workflow',
         subjectId      : 'pr-15231',
+        headSha        : 'head-2',
         actionableSince: '2026-07-16T09:00:00.000Z',
         checkedAt      : '2026-07-16T10:00:00.000Z',
         citations      : ['https://github.com/neomjs/neo/pull/15231'],
@@ -151,8 +152,42 @@ test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
         const frontier = buildLifecycleFrontier(base({items: [item({headSha: '94dc70926f'})]}));
 
         expect(frontier.items[0].headSha).toBe('94dc70926f');
-        // absent head is explicit null, never undefined-shaped
-        expect(buildLifecycleFrontier(base({items: [item()]})).items[0].headSha).toBeNull();
+
+        // A non-PR stage has no head to move under it, so null there is correct rather than a gap.
+        const task = buildLifecycleFrontier(base({
+            items: [item({stage: 'claimed-a2a-task', source: 'memory-core-a2a', subjectId: 't-1', headSha: undefined})]
+        }));
+
+        expect(task.items[0].headSha).toBeNull();
+        expect(validateLifecycleFrontier(task, {shapeOnly: true}).valid).toBe(true);
+    });
+
+    test('a PR-derived row with a NULL head is rejected — it cannot support the reset invariant', () => {
+        // The reviewer's falsifier: the builder emitted `headSha: null` for a PR row and the guard
+        // passed it. Every PR-derived row resets on head change, and a row with no head cannot say
+        // whether its clock belongs to the code that exists now. The explicit null made the omission
+        // look deliberate, which is worse than absent.
+        const headless = buildLifecycleFrontier(base({items: [item({headSha: undefined})]})),
+              result   = validateLifecycleFrontier(headless, {shapeOnly: true});
+
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(' ')).toContain('headSha is required for the PR-derived stage "own-pr-repair"');
+    });
+
+    test('an UNPARSEABLE reader clock fails the guard — it must not skip the check it promised', () => {
+        // The reviewer's second falsifier: a 2020-expired envelope passed with `now: 'not-a-time'`,
+        // because the guard silently skipped expiry when it could not parse the clock. The caller asked
+        // for expiry validation; the guard could not perform it and returned valid anyway.
+        const expired = buildLifecycleFrontier(base({
+            capturedAt: '2020-01-01T00:00:00.000Z',
+            expiresAt : '2020-01-01T00:05:00.000Z',
+            items     : []
+        }));
+
+        const result = validateLifecycleFrontier(expired, {now: 'not-a-time', agentId: '@neo-opus-ada'});
+
+        expect(result.valid).toBe(false);
+        expect(result.errors.join(' ')).toContain('is not a parseable time; expiry could not be validated');
     });
 
     test('validateLifecycleFrontier accepts a good envelope and NEVER throws on bad input', () => {

--- a/test/playwright/unit/ai/services/graph/lifecycleFrontier.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/lifecycleFrontier.spec.mjs
@@ -35,12 +35,16 @@ test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
         ...overrides
     });
 
+    // The FULL row a predicate actually emits — a partial fixture would let the guard's item-shape
+    // checks pass vacuously.
     const item = (overrides = {}) => ({
         id             : 'pr-1',
         stage          : 'own-pr-repair',
+        kind           : 'changes-requested',
         source         : 'github-workflow',
         subjectId      : 'pr-15231',
         actionableSince: '2026-07-16T09:00:00.000Z',
+        citations      : ['https://github.com/neomjs/neo/pull/15231'],
         ...overrides
     });
 
@@ -187,9 +191,9 @@ test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
         });
 
         expect(valid).toBe(false);
-        expect(errors.join(' ')).toContain('capturedAt is required');
+        expect(errors.join(' ')).toContain('capturedAt must be a parseable ISO timestamp');
         expect(errors.join(' ')).toContain('sourceWatermark is required');
-        expect(errors.join(' ')).toContain('expiresAt is required');
+        expect(errors.join(' ')).toContain('expiresAt must be a parseable ISO timestamp');
         expect(errors.join(' ')).toContain('scope is required');
         expect(errors.join(' ')).toContain('coverage is required');
     });

--- a/test/playwright/unit/ai/services/graph/lifecycleFrontier.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/lifecycleFrontier.spec.mjs
@@ -41,9 +41,11 @@ test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
         id             : 'pr-1',
         stage          : 'own-pr-repair',
         kind           : 'changes-requested',
+        state          : 'OPEN',
         source         : 'github-workflow',
         subjectId      : 'pr-15231',
         actionableSince: '2026-07-16T09:00:00.000Z',
+        checkedAt      : '2026-07-16T10:00:00.000Z',
         citations      : ['https://github.com/neomjs/neo/pull/15231'],
         ...overrides
     });
@@ -155,10 +157,10 @@ test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
 
     test('validateLifecycleFrontier accepts a good envelope and NEVER throws on bad input', () => {
         const good = buildLifecycleFrontier(base({items: [item()]}));
-        expect(validateLifecycleFrontier(good)).toEqual({valid: true, errors: []});
+        expect(validateLifecycleFrontier(good, {shapeOnly: true})).toEqual({valid: true, errors: []});
 
-        expect(validateLifecycleFrontier(null).valid).toBe(false);
-        expect(validateLifecycleFrontier({schemaVersion: 'legacy'}).valid).toBe(false);
+        expect(validateLifecycleFrontier(null, {shapeOnly: true}).valid).toBe(false);
+        expect(validateLifecycleFrontier({schemaVersion: 'legacy'}, {shapeOnly: true}).valid).toBe(false);
 
         const foreign = validateLifecycleFrontier({
             schemaVersion: 'lifecycle-frontier.v1',
@@ -166,7 +168,7 @@ test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
             notAuthority : true,
             scope        : {resolution: 'omitted'},
             items        : [{stage: 'own-pr-repair', actionableSince: '2026-07-16T09:00:00.000Z'}]
-        });
+        }, {shapeOnly: true});
 
         expect(foreign.valid).toBe(false);
         expect(foreign.errors.some(error => /omitted scope must carry zero items/.test(error))).toBe(true);
@@ -176,6 +178,83 @@ test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
         expect(LIFECYCLE_STAGES).toEqual([
             'own-pr-repair', 'own-pr-reviewer-routing', 'requested-review', 'claimed-a2a-task', 'direct-message'
         ]);
+    });
+
+    test('called BARE, the guard refuses rather than silently skipping expiry and reader binding', () => {
+        // The reviewer's falsifier: without reader args, an EXPIRED envelope scoped to ANOTHER agent
+        // returned valid:true — the two failures the guard exists to catch. Optional reader facts were
+        // themselves a fail-open, so the shape-only choice must now be made at the call site.
+        const expiredForeign = {
+            schemaVersion  : 'lifecycle-frontier.v1',
+            status         : 'empty',
+            capturedAt     : '2020-01-01T00:00:00.000Z',
+            sourceWatermark: 'w',
+            expiresAt      : '2020-01-01T00:05:00.000Z',
+            scope          : {resolution: 'agent-instance', agentId: '@some-other-peer'},
+            coverage       : {sources: [], degradedSources: []},
+            items          : [],
+            notAuthority   : true
+        };
+
+        expect(validateLifecycleFrontier(expiredForeign).valid).toBe(false);
+        expect(validateLifecycleFrontier(expiredForeign).errors.join(' ')).toContain('requires now + agentId');
+
+        // With the reader's facts, BOTH failures are named rather than skipped.
+        const checked = validateLifecycleFrontier(expiredForeign, {now: '2026-07-16T12:00:00.000Z', agentId: '@neo-opus-ada'});
+
+        expect(checked.valid).toBe(false);
+        expect(checked.errors.join(' ')).toContain('expired at');
+        expect(checked.errors.join(' ')).toContain('not the consuming agent');
+
+        // shape-only is legitimate — but it must be SAID, so the unchecked expiry is visible in the code
+        expect(validateLifecycleFrontier(expiredForeign, {shapeOnly: true}).valid).toBe(true);
+    });
+
+    test('an envelope that expires before it was captured was never valid for an instant', () => {
+        const inverted = validateLifecycleFrontier({
+            schemaVersion  : 'lifecycle-frontier.v1',
+            status         : 'empty',
+            capturedAt     : '2026-07-16T12:00:00.000Z',
+            sourceWatermark: 'w',
+            expiresAt      : '2026-07-16T11:00:00.000Z',
+            scope          : {resolution: 'omitted', agentId: null},
+            coverage       : {sources: [], degradedSources: []},
+            items          : [],
+            notAuthority   : true
+        }, {shapeOnly: true});
+
+        // Both stamps parse individually; that says nothing about whether they describe a real window.
+        expect(inverted.valid).toBe(false);
+        expect(inverted.errors.join(' ')).toContain('is not after capturedAt');
+    });
+
+    test('EVERY emitted item field is validated, members included — not the interesting ones', () => {
+        const bad = validateLifecycleFrontier({
+            schemaVersion  : 'lifecycle-frontier.v1',
+            status         : 'fresh',
+            capturedAt     : '2026-07-16T12:00:00.000Z',
+            sourceWatermark: 'w',
+            expiresAt      : '2026-07-16T12:05:00.000Z',
+            scope          : {resolution: 'agent-instance', agentId: '@neo-opus-ada'},
+            coverage       : {sources: ['pull-requests'], degradedSources: []},
+            // missing state, missing checkedAt, and citations that cite nothing followable
+            items          : [{
+                id             : 'pr-1',
+                stage          : 'own-pr-repair',
+                kind           : 'changes-requested',
+                source         : 'github-workflow',
+                subjectId      : 'pr-1',
+                actionableSince: '2026-07-16T09:00:00.000Z',
+                citations      : [42]
+            }],
+            notAuthority: true
+        }, {shapeOnly: true});
+
+        expect(bad.valid).toBe(false);
+        expect(bad.errors.join(' ')).toContain('items[0].state is required');
+        expect(bad.errors.join(' ')).toContain('items[0].checkedAt is required');
+        // `citations: [42]` passes an is-array check and cites nothing a reader can follow
+        expect(bad.errors.join(' ')).toContain('items[0].citations must contain only strings');
     });
 
     test('a STRUCTURALLY INCOMPLETE envelope is rejected — a guard that passes one is worse than none', () => {
@@ -188,7 +267,7 @@ test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
             status       : 'empty',
             notAuthority : true,
             items        : []
-        });
+        }, {shapeOnly: true});
 
         expect(valid).toBe(false);
         expect(errors.join(' ')).toContain('capturedAt must be a parseable ISO timestamp');
@@ -209,7 +288,7 @@ test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
             coverage       : {sources: [], degradedSources: []},
             items          : [],
             notAuthority   : true
-        });
+        }, {shapeOnly: true});
 
         // an attested category with no identity cannot be checked against the reader — reject it
         expect(attestedNoId.valid).toBe(false);
@@ -225,7 +304,7 @@ test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
             coverage       : {sources: 'all'},
             items          : [],
             notAuthority   : true
-        });
+        }, {shapeOnly: true});
 
         expect(badCoverage.valid).toBe(false);
         expect(badCoverage.errors.join(' ')).toContain('coverage.sources must be an array');

--- a/test/playwright/unit/ai/services/graph/lifecycleFrontier.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/lifecycleFrontier.spec.mjs
@@ -173,4 +173,57 @@ test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
             'own-pr-repair', 'own-pr-reviewer-routing', 'requested-review', 'claimed-a2a-task', 'direct-message'
         ]);
     });
+
+    test('a STRUCTURALLY INCOMPLETE envelope is rejected — a guard that passes one is worse than none', () => {
+        // The reviewer's falsifier: this shape previously returned valid:true. A reader would then act
+        // on a frontier with no capture time (stale vs current is undecidable), no expiry (expired vs
+        // live is undecidable), and no scope (whose obligations are these?) — each omission converting
+        // a DETECTABLE tear into a confident wrong answer.
+        const {valid, errors} = validateLifecycleFrontier({
+            schemaVersion: 'lifecycle-frontier.v1',
+            status       : 'empty',
+            notAuthority : true,
+            items        : []
+        });
+
+        expect(valid).toBe(false);
+        expect(errors.join(' ')).toContain('capturedAt is required');
+        expect(errors.join(' ')).toContain('sourceWatermark is required');
+        expect(errors.join(' ')).toContain('expiresAt is required');
+        expect(errors.join(' ')).toContain('scope is required');
+        expect(errors.join(' ')).toContain('coverage is required');
+    });
+
+    test('the guard rejects a foreign-capable scope and a missing coverage shape, still without throwing', () => {
+        const attestedNoId = validateLifecycleFrontier({
+            schemaVersion  : 'lifecycle-frontier.v1',
+            status         : 'fresh',
+            capturedAt     : '2026-07-16T12:00:00.000Z',
+            sourceWatermark: '2026-07-16T12:00:00.000Z',
+            expiresAt      : '2026-07-16T12:05:00.000Z',
+            scope          : {resolution: 'agent-instance', agentId: null},
+            coverage       : {sources: [], degradedSources: []},
+            items          : [],
+            notAuthority   : true
+        });
+
+        // an attested category with no identity cannot be checked against the reader — reject it
+        expect(attestedNoId.valid).toBe(false);
+        expect(attestedNoId.errors.join(' ')).toContain('attested scope must carry a non-empty agentId');
+
+        const badCoverage = validateLifecycleFrontier({
+            schemaVersion  : 'lifecycle-frontier.v1',
+            status         : 'degraded',
+            capturedAt     : '2026-07-16T12:00:00.000Z',
+            sourceWatermark: '2026-07-16T12:00:00.000Z',
+            expiresAt      : '2026-07-16T12:05:00.000Z',
+            scope          : {resolution: 'omitted', agentId: null},
+            coverage       : {sources: 'all'},
+            items          : [],
+            notAuthority   : true
+        });
+
+        expect(badCoverage.valid).toBe(false);
+        expect(badCoverage.errors.join(' ')).toContain('coverage.sources must be an array');
+    });
 });

--- a/test/playwright/unit/ai/services/graph/lifecycleFrontier.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/lifecycleFrontier.spec.mjs
@@ -1,0 +1,176 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'LifecycleFrontierContractTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * Contract tests for the lifecycle-frontier.v1 envelope: stage ordering, never-foreign enforcement,
+ * honest status independence, and the consumer-side fail-open guard.
+ */
+test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
+    let buildLifecycleFrontier, validateLifecycleFrontier, LIFECYCLE_STAGES, LIFECYCLE_FRONTIER_STATUSES;
+
+    const base = (overrides = {}) => ({
+        scope          : {agentId: '@neo-opus-ada', harnessInstance: 'inst-1', resolution: 'agent-instance'},
+        status         : 'fresh',
+        capturedAt     : '2026-07-16T10:00:00.000Z',
+        sourceWatermark: 'wm-1',
+        expiresAt      : '2026-07-16T10:10:00.000Z',
+        coverage       : {sources: ['github-workflow', 'memory-core-a2a'], degradedSources: []},
+        items          : [],
+        ...overrides
+    });
+
+    const item = (overrides = {}) => ({
+        id             : 'pr-1',
+        stage          : 'own-pr-repair',
+        source         : 'github-workflow',
+        subjectId      : 'pr-15231',
+        actionableSince: '2026-07-16T09:00:00.000Z',
+        ...overrides
+    });
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/graph/lifecycleFrontier.mjs');
+        buildLifecycleFrontier      = mod.buildLifecycleFrontier;
+        validateLifecycleFrontier   = mod.validateLifecycleFrontier;
+        LIFECYCLE_STAGES            = mod.LIFECYCLE_STAGES;
+        LIFECYCLE_FRONTIER_STATUSES = mod.LIFECYCLE_FRONTIER_STATUSES;
+    });
+
+    test('stamps the schema + notAuthority and deeply freezes the envelope', () => {
+        const frontier = buildLifecycleFrontier(base({items: [item()]}));
+
+        expect(frontier.schemaVersion).toBe('lifecycle-frontier.v1');
+        expect(frontier.notAuthority).toBe(true);
+        expect(Object.isFrozen(frontier)).toBe(true);
+        expect(Object.isFrozen(frontier.items)).toBe(true);
+        expect(Object.isFrozen(frontier.items[0])).toBe(true);
+    });
+
+    test('orders by stage rank FIRST — an own-PR repair outranks a review request regardless of age', () => {
+        // The older review-request must still sort below the newer own-PR repair: the stage order is
+        // the contract (a blocked lane you own beats someone else's queue), not an age race.
+        const frontier = buildLifecycleFrontier(base({
+            items: [
+                item({id: 'rr-1', stage: 'requested-review',       actionableSince: '2026-07-01T00:00:00.000Z'}),
+                item({id: 'pr-1', stage: 'own-pr-repair',          actionableSince: '2026-07-16T09:00:00.000Z'}),
+                item({id: 'dm-1', stage: 'direct-message',         actionableSince: '2026-07-02T00:00:00.000Z'}),
+                item({id: 'rt-1', stage: 'own-pr-reviewer-routing', actionableSince: '2026-07-15T00:00:00.000Z'})
+            ]
+        }));
+
+        expect(frontier.items.map(entry => entry.stage)).toEqual([
+            'own-pr-repair', 'own-pr-reviewer-routing', 'requested-review', 'direct-message'
+        ]);
+    });
+
+    test('within a stage, oldest actionableSince first, then STABLE id — no fabricated movement', () => {
+        // Equal-aged rows must not swap between passes: a consumer diffing consecutive frontiers would
+        // otherwise report movement that never happened.
+        const build = () => buildLifecycleFrontier(base({
+            items: [
+                item({id: 'pr-c', actionableSince: '2026-07-16T09:00:00.000Z'}),
+                item({id: 'pr-a', actionableSince: '2026-07-16T09:00:00.000Z'}),
+                item({id: 'pr-b', actionableSince: '2026-07-16T08:00:00.000Z'})
+            ]
+        }));
+
+        expect(build().items.map(entry => entry.id)).toEqual(['pr-b', 'pr-a', 'pr-c']);
+        // deterministic across passes
+        expect(build().items.map(entry => entry.id)).toEqual(build().items.map(entry => entry.id));
+    });
+
+    test('NEVER-FOREIGN: an omitted scope carrying items is a producer error, not a warning', () => {
+        // Leaking another peer's obligations is worse than absence — so this fails loud rather than
+        // silently dropping the rows.
+        expect(() => buildLifecycleFrontier(base({
+            scope: {resolution: 'omitted'},
+            items: [item()]
+        }))).toThrow(/omitted scope must carry zero items/);
+
+        const omitted = buildLifecycleFrontier(base({
+            scope        : {resolution: 'omitted'},
+            status       : 'missing',
+            items        : [],
+            omittedReason: 'identity-conflicted'
+        }));
+
+        expect(omitted.items).toEqual([]);
+        expect(omitted.scope.omittedReason).toBe('identity-conflicted');
+        expect(omitted.scope.agentId).toBeNull();
+    });
+
+    test('status is independent of item count — missing/degraded is never normalized to empty', () => {
+        for (const status of [...LIFECYCLE_FRONTIER_STATUSES]) {
+            const frontier = buildLifecycleFrontier(base({status, items: []}));
+            expect(frontier.status).toBe(status);
+        }
+
+        // a degraded source is honest coverage, NOT a contract violation
+        const degraded = buildLifecycleFrontier(base({
+            status  : 'degraded',
+            coverage: {sources: ['github-workflow'], degradedSources: ['memory-core-a2a']},
+            items   : [item()]
+        }));
+
+        expect(degraded.status).toBe('degraded');
+        expect(degraded.coverage.degradedSources).toEqual(['memory-core-a2a']);
+        expect(degraded.items).toHaveLength(1);
+    });
+
+    test('every item must name its stage, subject and actionableSince — an undateable row is unreasonable-about', () => {
+        expect(() => buildLifecycleFrontier(base({items: [item({stage: 'bogus'})]}))).toThrow(/stage must be one of/);
+        expect(() => buildLifecycleFrontier(base({items: [item({actionableSince: undefined})]}))).toThrow(/actionableSince must be a non-empty string/);
+        expect(() => buildLifecycleFrontier(base({items: [item({subjectId: ''})]}))).toThrow(/subjectId must be a non-empty string/);
+        expect(() => buildLifecycleFrontier(base({status: 'bogus'}))).toThrow(/status must be one of/);
+        expect(() => buildLifecycleFrontier(base({scope: {resolution: 'guessed'}}))).toThrow(/scope.resolution must be one of/);
+    });
+
+    test('a PR-derived row carries the head it was observed against', () => {
+        const frontier = buildLifecycleFrontier(base({items: [item({headSha: '94dc70926f'})]}));
+
+        expect(frontier.items[0].headSha).toBe('94dc70926f');
+        // absent head is explicit null, never undefined-shaped
+        expect(buildLifecycleFrontier(base({items: [item()]})).items[0].headSha).toBeNull();
+    });
+
+    test('validateLifecycleFrontier accepts a good envelope and NEVER throws on bad input', () => {
+        const good = buildLifecycleFrontier(base({items: [item()]}));
+        expect(validateLifecycleFrontier(good)).toEqual({valid: true, errors: []});
+
+        expect(validateLifecycleFrontier(null).valid).toBe(false);
+        expect(validateLifecycleFrontier({schemaVersion: 'legacy'}).valid).toBe(false);
+
+        const foreign = validateLifecycleFrontier({
+            schemaVersion: 'lifecycle-frontier.v1',
+            status       : 'fresh',
+            notAuthority : true,
+            scope        : {resolution: 'omitted'},
+            items        : [{stage: 'own-pr-repair', actionableSince: '2026-07-16T09:00:00.000Z'}]
+        });
+
+        expect(foreign.valid).toBe(false);
+        expect(foreign.errors.some(error => /omitted scope must carry zero items/.test(error))).toBe(true);
+    });
+
+    test('exposes the five stages in contract order', () => {
+        expect(LIFECYCLE_STAGES).toEqual([
+            'own-pr-repair', 'own-pr-reviewer-routing', 'requested-review', 'claimed-a2a-task', 'direct-message'
+        ]);
+    });
+});

--- a/test/playwright/unit/ai/services/graph/lifecycleFrontier.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/lifecycleFrontier.spec.mjs
@@ -162,13 +162,46 @@ test.describe('lifecycleFrontier — lifecycle-frontier.v1 contract', () => {
         expect(validateLifecycleFrontier(task, {shapeOnly: true}).valid).toBe(true);
     });
 
-    test('a PR-derived row with a NULL head is rejected — it cannot support the reset invariant', () => {
-        // The reviewer's falsifier: the builder emitted `headSha: null` for a PR row and the guard
-        // passed it. Every PR-derived row resets on head change, and a row with no head cannot say
-        // whether its clock belongs to the code that exists now. The explicit null made the omission
-        // look deliberate, which is worse than absent.
-        const headless = buildLifecycleFrontier(base({items: [item({headSha: undefined})]})),
-              result   = validateLifecycleFrontier(headless, {shapeOnly: true});
+    test('the PRODUCER refuses to mint a headless PR row — a malformed frontier is a producer bug', () => {
+        // Closing this at the consumer alone left the producer happily minting rows that cannot support
+        // the head-change reset: the guard would catch them, but only AFTER a malformed frontier
+        // existed and only for readers that ran the guard. Normalizing the omission to `null` dressed
+        // it up as a decision.
+        expect(() => buildLifecycleFrontier(base({items: [item({headSha: undefined})]})))
+            .toThrow(/items\[0\]\.headSha \(PR-derived stage "own-pr-repair" resets on head change\)/);
+
+        expect(() => buildLifecycleFrontier(base({items: [item({headSha: ''})]})))
+            .toThrow(/items\[0\]\.headSha/);
+    });
+
+    test('the CONSUMER independently rejects a torn PR row the producer never made', () => {
+        // Defence in depth, and not redundant: the guard's whole job is envelopes this producer did not
+        // build — a legacy writer, a torn file, another version. So the torn row is hand-built here
+        // rather than minted, which is exactly how it would arrive.
+        const torn = {
+            schemaVersion  : 'lifecycle-frontier.v1',
+            status         : 'fresh',
+            capturedAt     : '2026-07-16T12:00:00.000Z',
+            sourceWatermark: 'w-1',
+            expiresAt      : '2026-07-16T12:05:00.000Z',
+            scope          : {resolution: 'agent-instance', agentId: '@neo-opus-ada'},
+            coverage       : {sources: ['pull-requests'], degradedSources: []},
+            items          : [{
+                id             : 'pr-1',
+                stage          : 'own-pr-repair',
+                kind           : 'changes-requested',
+                state          : 'OPEN',
+                source         : 'github-workflow',
+                subjectId      : 'pr-15231',
+                headSha        : null,
+                actionableSince: '2026-07-16T09:00:00.000Z',
+                checkedAt      : '2026-07-16T10:00:00.000Z',
+                citations      : []
+            }],
+            notAuthority: true
+        };
+
+        const result = validateLifecycleFrontier(torn, {shapeOnly: true});
 
         expect(result.valid).toBe(false);
         expect(result.errors.join(' ')).toContain('headSha is required for the PR-derived stage "own-pr-repair"');

--- a/test/playwright/unit/ai/services/graph/produceLifecycleFrontier.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/produceLifecycleFrontier.spec.mjs
@@ -33,17 +33,18 @@ test.describe('produceLifecycleFrontier — injected source reads into one hones
 
     // A PR whose CURRENT head carries CHANGES_REQUESTED — stage 1, own-PR repair.
     const repairPr = {
-        id                   : 'pr-15264',
-        authorId             : agent,
-        state                : 'OPEN',
-        isDraft              : false,
-        headSha              : 'abc123',
-        mergeable            : true,
-        reviews              : [{state: 'CHANGES_REQUESTED', commitSha: 'abc123'}],
-        checks               : [{name: 'unit', required: true, conclusion: 'SUCCESS'}],
-        repairActionableSince: '2026-07-16T11:00:00.000Z',
-        checkedAt            : '2026-07-16T12:00:00.000Z',
-        url                  : 'https://github.com/neomjs/neo/pull/15264'
+        id                          : 'pr-15264',
+        authorId                    : agent,
+        state                       : 'OPEN',
+        isDraft                     : false,
+        headSha                     : 'abc123',
+        mergeable                   : true,
+        reviews                     : [{state: 'CHANGES_REQUESTED', commitSha: 'abc123'}],
+        checks                      : [{name: 'unit', required: true, conclusion: 'SUCCESS'}],
+        repairActionableSince       : '2026-07-16T11:00:00.000Z',
+        repairActionableSinceHeadSha: 'abc123',
+        checkedAt                   : '2026-07-16T12:00:00.000Z',
+        url                         : 'https://github.com/neomjs/neo/pull/15264'
     };
 
     const sources = (overrides = {}) => ({
@@ -143,6 +144,64 @@ test.describe('produceLifecycleFrontier — injected source reads into one hones
         expect(frontier.status).toBe('empty');
         expect(frontier.items).toEqual([]);
         expect(frontier.coverage.degradedSources).toEqual([]);
+    });
+
+    test('a MALFORMED source answer degrades — it is never laundered into healthy emptiness', async () => {
+        // The reviewer's falsifier: readPullRequests() -> {} previously became rows:[], degraded:false,
+        // status:'empty' — the exact false "nothing awaits you" this module says can never happen.
+        // Coercing an unusable answer to [] turns "I could not read this" into "there is nothing here".
+        for (const bad of [{}, null, 'rows', 42]) {
+            const frontier = await produceLifecycleFrontier({
+                scope  : attested,
+                sources: sources({readPullRequests: async () => bad}),
+                now,
+                ttlMs
+            });
+
+            expect(frontier.status).toBe('degraded');
+            expect(frontier.status).not.toBe('empty');
+            expect(frontier.coverage.degradedSources.join(' ')).toContain('not a row list');
+            expect(frontier.items).toEqual([]);
+        }
+    });
+
+    test('EVERY non-attested resolution reads nothing — the gate is an allow-list, not one bad value', async () => {
+        // The reviewer's falsifier: resolution 'inferred' ran all three reads before the envelope
+        // rejected it. Rejecting after the read is filtering, not never-foreign — the foreign-capable
+        // obligations were already in memory, one bug away from being rendered.
+        for (const resolution of ['inferred', 'conflicted', 'agent-instance-ish', undefined, null]) {
+            let reads = 0;
+
+            const frontier = await produceLifecycleFrontier({
+                scope  : {agentId: agent, harnessInstance: 'h', resolution},
+                sources: {
+                    readPullRequests: async () => { reads++; return [repairPr] },
+                    readTasks       : async () => { reads++; return [] },
+                    readMessages    : async () => { reads++; return [] }
+                },
+                now,
+                ttlMs
+            });
+
+            expect(reads).toBe(0);
+            expect(frontier.status).toBe('missing');
+            expect(frontier.items).toEqual([]);
+            expect(frontier.scope.resolution).toBe('omitted');
+        }
+    });
+
+    test('an attested resolution with NO agentId is unattested — a category alone is not an identity', async () => {
+        let reads = 0;
+
+        const frontier = await produceLifecycleFrontier({
+            scope  : {agentId: '', harnessInstance: 'h', resolution: 'agent-instance'},
+            sources: sources({readPullRequests: async () => { reads++; return [repairPr] }}),
+            now,
+            ttlMs
+        });
+
+        expect(reads).toBe(0);
+        expect(frontier.status).toBe('missing');
     });
 
     test('fails LOUD on an unbound source or a missing clock — a wiring bug is not a degradation', async () => {

--- a/test/playwright/unit/ai/services/graph/produceLifecycleFrontier.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/produceLifecycleFrontier.spec.mjs
@@ -1,0 +1,158 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'ProduceLifecycleFrontierTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * The source composition: injected reads → admitted items → one honest envelope. These pin the two
+ * properties a peer's next action depends on — an unattested binding reads nothing and carries nothing,
+ * and a source that failed never reads as a source that was empty.
+ */
+test.describe('produceLifecycleFrontier — injected source reads into one honest frontier', () => {
+    let produceLifecycleFrontier, LIFECYCLE_SOURCES;
+
+    const now   = new Date('2026-07-16T12:00:00.000Z'),
+          ttlMs = 5 * 60 * 1000,
+          agent = '@neo-opus-ada';
+
+    const attested = {agentId: agent, harnessInstance: 'harness-1', resolution: 'agent-instance'};
+
+    // A PR whose CURRENT head carries CHANGES_REQUESTED — stage 1, own-PR repair.
+    const repairPr = {
+        id                   : 'pr-15264',
+        authorId             : agent,
+        state                : 'OPEN',
+        isDraft              : false,
+        headSha              : 'abc123',
+        mergeable            : true,
+        reviews              : [{state: 'CHANGES_REQUESTED', commitSha: 'abc123'}],
+        checks               : [{name: 'unit', required: true, conclusion: 'SUCCESS'}],
+        repairActionableSince: '2026-07-16T11:00:00.000Z',
+        checkedAt            : '2026-07-16T12:00:00.000Z',
+        url                  : 'https://github.com/neomjs/neo/pull/15264'
+    };
+
+    const sources = (overrides = {}) => ({
+        readPullRequests: async () => [repairPr],
+        readTasks       : async () => [],
+        readMessages    : async () => [],
+        ...overrides
+    });
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/graph/produceLifecycleFrontier.mjs');
+        produceLifecycleFrontier = mod.produceLifecycleFrontier;
+        LIFECYCLE_SOURCES        = mod.LIFECYCLE_SOURCES;
+    });
+
+    test('an attested agent gets a fresh, stage-ordered frontier with an explicit expiry', async () => {
+        const frontier = await produceLifecycleFrontier({scope: attested, sources: sources(), now, ttlMs});
+
+        expect(frontier.schemaVersion).toBe('lifecycle-frontier.v1');
+        expect(frontier.status).toBe('fresh');
+        expect(frontier.notAuthority).toBe(true);
+        expect(frontier.capturedAt).toBe('2026-07-16T12:00:00.000Z');
+        // a lifecycle answer is perishable — the expiry is stated, never left for a reader to assume
+        expect(frontier.expiresAt).toBe('2026-07-16T12:05:00.000Z');
+        expect(frontier.coverage.sources).toEqual(LIFECYCLE_SOURCES);
+        expect(frontier.coverage.degradedSources).toEqual([]);
+        expect(frontier.items.map(item => item.stage)).toEqual(['own-pr-repair']);
+    });
+
+    test('an UNATTESTED binding reads no source at all — never-foreign beats complete', async () => {
+        // Filtering foreign rows after reading would mean another peer's obligations were already in
+        // memory, one bug away from being rendered. The read must not happen.
+        let reads = 0;
+
+        const frontier = await produceLifecycleFrontier({
+            scope  : {agentId: null, harnessInstance: null, resolution: 'omitted'},
+            sources: sources({
+                readPullRequests: async () => { reads++; return [repairPr] },
+                readTasks       : async () => { reads++; return [] },
+                readMessages    : async () => { reads++; return [] }
+            }),
+            now,
+            ttlMs,
+            omittedReason: 'conflicted-identity'
+        });
+
+        expect(reads).toBe(0);
+        expect(frontier.items).toEqual([]);
+        // missing is NOT empty: the overlay is absent, which is a different fact from "nothing awaits you"
+        expect(frontier.status).toBe('missing');
+        expect(frontier.scope.resolution).toBe('omitted');
+        expect(frontier.scope.omittedReason).toBe('conflicted-identity');
+    });
+
+    test('a failed source degrades ONLY its own row — the others survive intact', async () => {
+        const frontier = await produceLifecycleFrontier({
+            scope  : attested,
+            sources: sources({readTasks: async () => { throw new Error('mailbox unavailable') }}),
+            now,
+            ttlMs
+        });
+
+        expect(frontier.status).toBe('degraded');
+        expect(frontier.coverage.degradedSources).toHaveLength(1);
+        expect(frontier.coverage.degradedSources[0]).toContain('tasks: mailbox unavailable');
+        // the PR source answered, so its obligation must still reach the peer
+        expect(frontier.items.map(item => item.stage)).toEqual(['own-pr-repair']);
+    });
+
+    test('a degraded source with zero items is NOT an empty frontier — the one wrong answer here', async () => {
+        // "Nothing awaits you" is acted upon. An unknown must never be normalized into it.
+        const frontier = await produceLifecycleFrontier({
+            scope  : attested,
+            sources: {
+                readPullRequests: async () => { throw new Error('graphql down') },
+                readTasks       : async () => [],
+                readMessages    : async () => []
+            },
+            now,
+            ttlMs
+        });
+
+        expect(frontier.items).toEqual([]);
+        expect(frontier.status).toBe('degraded');
+        expect(frontier.status).not.toBe('empty');
+        expect(frontier.coverage.degradedSources[0]).toContain('pull-requests: graphql down');
+    });
+
+    test('an honestly empty frontier is a real answer, distinct from degraded and from missing', async () => {
+        const frontier = await produceLifecycleFrontier({
+            scope  : attested,
+            sources: {readPullRequests: async () => [], readTasks: async () => [], readMessages: async () => []},
+            now,
+            ttlMs
+        });
+
+        expect(frontier.status).toBe('empty');
+        expect(frontier.items).toEqual([]);
+        expect(frontier.coverage.degradedSources).toEqual([]);
+    });
+
+    test('fails LOUD on an unbound source or a missing clock — a wiring bug is not a degradation', async () => {
+        await expect(produceLifecycleFrontier({scope: attested, sources: {readPullRequests: async () => []}, now, ttlMs}))
+            .rejects.toThrow(/readPullRequests, readTasks, and readMessages/);
+
+        await expect(produceLifecycleFrontier({scope: attested, sources: sources(), now: undefined, ttlMs}))
+            .rejects.toThrow(/now must be a valid Date/);
+
+        await expect(produceLifecycleFrontier({scope: attested, sources: sources(), now, ttlMs: undefined}))
+            .rejects.toThrow(/positive ttlMs is required/);
+    });
+});

--- a/test/playwright/unit/ai/services/graph/produceLifecycleFrontier.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/produceLifecycleFrontier.spec.mjs
@@ -39,12 +39,12 @@ test.describe('produceLifecycleFrontier — injected source reads into one hones
         isDraft                     : false,
         headSha                     : 'abc123',
         mergeable                   : true,
-        reviews                     : [{state: 'CHANGES_REQUESTED', commitSha: 'abc123'}],
-        checks                      : [{name: 'unit', required: true, conclusion: 'SUCCESS'}],
-        repairActionableSince       : '2026-07-16T11:00:00.000Z',
-        repairActionableSinceHeadSha: 'abc123',
-        checkedAt                   : '2026-07-16T12:00:00.000Z',
-        url                         : 'https://github.com/neomjs/neo/pull/15264'
+        // Source-shaped: the review names the commit it reviewed AND when it was submitted. The clock
+        // owner derives repairActionableSince from exactly this, so no caller supplies it.
+        reviews  : [{state: 'CHANGES_REQUESTED', commitSha: 'abc123', submittedAt: '2026-07-16T11:00:00.000Z'}],
+        checks   : [{name: 'unit', required: true, conclusion: 'SUCCESS', headSha: 'abc123', completedAt: '2026-07-16T10:30:00.000Z'}],
+        checkedAt: '2026-07-16T12:00:00.000Z',
+        url      : 'https://github.com/neomjs/neo/pull/15264'
     };
 
     const sources = (overrides = {}) => ({

--- a/test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/QueryService.queryDocuments.spec.mjs
@@ -383,17 +383,23 @@ test.describe('Neo.ai.services.knowledge-base.QueryService#queryDocuments', () =
             inheritanceChain: '[]'
         }], capture);
 
+        // The query path-matches the whole `ai/services/graph` dir, so the lexical rescue boosts every file in it;
+        // the final list is score-sorted then capped at `limit` (QueryService L235). The semantic top-k is stubbed
+        // above (the "miss" the rescue is proving it recovers from), so `limit` only sizes the final rescued set: it
+        // must exceed the rescued dir plus the cross-dir anchors asserted below, or a boundary anchor is evicted and
+        // this fails for whoever adds the next graph file. Derive the dir size instead of hardcoding a budget — a
+        // literal is calibrated against one moment's file count and decays silently from there. The headroom counts
+        // rows this test itself enumerates (three asserted anchors + two stubbed hits + spare), so unlike the dir
+        // size it changes only when someone edits this test.
+        const
+            crossDirAnchorHeadroom = 8,
+            graphDirFileCount      = (await fs.readdir(path.resolve('ai/services/graph')))
+                .filter(name => name.endsWith('.mjs')).length;
+
         const result = await QueryService.queryDocuments({
-            query: 'Neo graph database HybridRAG mutate_frontier Dream Pipeline Gemma4 31B graph processing ai/services/graph sandman_handoff.md',
-            type : 'all',
-            // The query path-matches the whole `ai/services/graph` dir, so the lexical rescue boosts every file in
-            // it; the final list is score-sorted then capped at `limit` (QueryService L235). The semantic top-k is
-            // stubbed above (the "miss" the rescue is proving it recovers from), so `limit` only sizes the final
-            // rescued set — it must exceed the graph dir size + the cross-dir anchors (e.g. memory-core
-            // GraphService.mjs), else simply adding a graph file evicts a boundary anchor. The graph dir has grown
-            // to 23 `.mjs` files; with the rescue now collecting the full dir (QueryService inner limit), the
-            // final cap must exceed the full rescued set (dir + cross-dir anchors), so this stresses at 40.
-            limit          : 40,
+            query          : 'Neo graph database HybridRAG mutate_frontier Dream Pipeline Gemma4 31B graph processing ai/services/graph sandman_handoff.md',
+            type           : 'all',
+            limit          : graphDirFileCount + crossDirAnchorHeadroom,
             includeMetadata: true
         });
         const sources = result.results.map(item => item.source);


### PR DESCRIPTION
## Summary

Produces the **lifecycle frontier** — ADR 0035 §2.3, the surface answering *"what already requires MY response right now"*. It is the last unbuilt producer Live Lane Awareness (Epic #15100) needs: the typed route (#15087) is merged, both historical Bird Views (#14435, #15088) are shipped, and the current-state landscape (#15234) is in review.

The frontier is a **different authority from the Computed Golden Path** and the separation is deliberate (ADR §1.1). The route answers *"which direction serves the goal"*. This answers *"what is already waiting on me"* — a gate that cleared, a review request, a repair that blocks a lane I already own. Conflating them was explicitly rejected upstream, so no lifecycle fact here becomes a Golden Path score input.

The empirical anchor is first-hand: across ~50 stop-hook fires in one session, @neo-opus-vega recorded that the highest-value next action was almost never cold backlog — it was a lifecycle event, found by manually surveying own-PR gate state, the review queue, and assigned tickets. Every fire re-did that survey by hand. This is that survey, source-backed.

## Deltas

- **`ai/services/graph/lifecycleFrontier.mjs`** — the typed `lifecycle-frontier.v1` envelope. Producer-side it fails **loud**: a malformed frontier is a producer bug, and a plausible-but-wrong obligation list is worse than none. `validateLifecycleFrontier` is the consumer-side dual — it never throws, so a reader degrades to bare policy rather than crashing on a torn envelope. Ordering is owned here (stage, then `actionableSince` oldest-first, then stable id), never by the caller.
- **`ai/services/graph/lifecycleAdmission.mjs`** — the five stages and, just as load-bearing, **their exclusions**: pending/running CI without a failed *required* check is a wait, not a repair; an optional check's failure must not manufacture an obligation; an approved PR awaiting the human merge gate is not actionable; drafts and unclaimed broadcasts are excluded; ordinary issue assignment is not a claimed task. A "current-head closing review" is exactly an `APPROVED`/`CHANGES_REQUESTED` on the head that exists **now** — a verdict on an older commit says nothing about the code as it stands.
- **`ai/services/graph/produceLifecycleFrontier.mjs`** — the source composition (this PR's new leaf). Owns only the impure edges: read each injected source, survive one that fails, and refuse to read at all for an unattested binding.

## The two rules that shape the composition

**Never-foreign is enforced by short-circuit, not by filtering.** An unattested binding returns an omitted overlay *before any read happens*. Filtering foreign rows after the fact would mean another peer's obligations were already in memory, one bug away from being rendered — and leaking them is worse than showing nothing (§2.4).

**A source that failed is not a source that was empty.** Each read degrades alone and names itself in `coverage.degradedSources`. `status` derives from what the read *proved*, never from the item count: a degraded source with zero admitted items is an **unknown** frontier, not an empty one. That is the distinction the whole surface rests on — *"nothing awaits you"* is a claim a peer acts on, so normalizing an unknown into it is the one wrong answer this producer can give.

## Test Evidence

Evidence: L2 hermetic — every source is injected, so the full matrix runs without GitHub or a live mailbox. **52 green.**

> Counted per suite, not per glob: `lifecycleFrontier` also matches `produceLifecycleFrontier`, so a glob total double-counts. 26 + 17 + 9 = 52.

| Suite | | What it pins |
|---|---|---|
| `lifecycleAdmission` | 26/26 | the five stages, every listed exclusion, the per-stage clock algebra, current-head provenance |
| `lifecycleFrontier` | 17/17 | envelope contract, ordering, producer fail-loud, consumer guard (freshness, reader binding, full item shape) |
| `produceLifecycleFrontier` | 9/9 | composition, never-foreign allow-list, per-source degradation |

Pinned per defect rather than asserted in prose:

- **The unattested path reads nothing** — asserted by call-count (`reads === 0`), not by inspecting the output. An overlay that filtered foreign rows *after* reading would pass an output-only assertion while still holding the data.
- **`degraded` ≠ `empty`** — a failed source with zero items asserts `status === 'degraded'` *and* explicitly `not.toBe('empty')`.
- **A failed source degrades only its own row** — the surviving source's obligation still reaches the peer.
- **`missing` ≠ `empty`** — an omitted overlay is a different fact from "nothing awaits you", and neither is normalized into the other.
- Fail-loud on an unbound source or a missing clock/TTL: a wiring bug is not a degradation.

## Notes

- **Producer only — nothing is published.** The projection writer / fenced Memory-Core lease (ADR §2.6) is a sibling #15100 leaf, and hook rendering (§2.11 Ph3–4) is downstream of *that*. This PR deliberately registers no MCP tool: publishing is out of scope, so binding a transport here would front-run the sibling leaf's contract.
- Prerequisites closed: #15106 (persisted winning assignee for broadcast Tasks — without it this would have canonized a false owner) and #15114 (durable GraphLog event identity).
- Sibling-lift placement: lands beside the shipped `laneLandscapeProjection.mjs` / `computedRouteResult.mjs` in `ai/services/graph/` — pure + dependency-injected, no novel directory.
- **Cross-family review is requested specifically on the admission matrix and the exclusion completeness** — an exclusion I got wrong manufactures a phantom obligation for every peer, every wake. That is the axis worth attacking.

## Post-Merge Validation

- None required — the producer is hermetic and publishes nothing. Live behavior becomes observable only once the sibling projection-writer leaf (ADR §2.6) consumes it.

Resolves #15267

---

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Origin session `ad475320-6bdc-4555-ba3f-b78d51de0b17`.

