### PR TITLE
fix(build): the sync-data guard is merge-blind — every dev-merge on a feature branch is refused (#15299)

### DIFF
--- a/buildScripts/util/check-chore-sync.mjs
+++ b/buildScripts/util/check-chore-sync.mjs
@@ -84,6 +84,31 @@ if (process.env.NEO_SYNC_AUTOCOMMIT === '1') {
     process.exit(0);
 }
 
+// A merge stages EVERY file it brings in, including the sync pipeline's commits already living on
+// the branch being merged. Those files are not authored here, so the check below must not read them
+// as leakage: this guard exists to stop a feature branch from AUTHORING sync data, and a merge is
+// not authoring.
+//
+// Without this escape `git merge origin/dev` is impossible on any branch older than the last
+// `chore(data)` commit (dev takes roughly two per six hours), and the only ways through are worse
+// than the block: `--no-verify` also skips the AiConfig test-mutation lint, and unstaging the files
+// makes the merge commit REVERT dev's sync data once it lands.
+//
+// Deliberately placed AFTER the NEO_SYNC_AUTOCOMMIT arm: that arm guards the pipeline's own
+// commits, which are never merges, and must keep failing on mixed content regardless.
+let isMergeInProgress = false;
+
+try {
+    execSync('git rev-parse -q --verify MERGE_HEAD', { cwd: gitRoot, stdio: 'ignore' });
+    isMergeInProgress = true;
+} catch (e) {
+    // No MERGE_HEAD — an ordinary commit, so the leakage check below applies in full.
+}
+
+if (isMergeInProgress) {
+    process.exit(0);
+}
+
 const violatingFiles = stagedFiles.filter(file =>
     isGeneratedSyncFile(file)
 );

--- a/buildScripts/util/check-chore-sync.mjs
+++ b/buildScripts/util/check-chore-sync.mjs
@@ -86,31 +86,42 @@ if (process.env.NEO_SYNC_AUTOCOMMIT === '1') {
 
 // A merge stages EVERY file it brings in, including the sync pipeline's commits already living on
 // the branch being merged. Those files are not authored here, so the check below must not read them
-// as leakage: this guard exists to stop a feature branch from AUTHORING sync data, and a merge is
-// not authoring.
+// as leakage: this guard exists to stop a feature branch from AUTHORING sync data, and inheriting a
+// commit is not authoring.
 //
-// Without this escape `git merge origin/dev` is impossible on any branch older than the last
+// Without this allowance `git merge origin/dev` is impossible on any branch older than the last
 // `chore(data)` commit (dev takes roughly two per six hours), and the only ways through are worse
 // than the block: `--no-verify` also skips the AiConfig test-mutation lint, and unstaging the files
 // makes the merge commit REVERT dev's sync data once it lands.
 //
-// Deliberately placed AFTER the NEO_SYNC_AUTOCOMMIT arm: that arm guards the pipeline's own
+// The allowance is NOT "a merge is in progress, stand down" — that would wave through a sync file
+// hand-edited during a conflict resolution, which is authoring wearing a merge's clothes. A staged
+// sync file is inherited only if the index still matches what the merge brought in; anything the
+// working tree changed on top of MERGE_HEAD is authored here and stays a violation.
+//
+// Deliberately evaluated AFTER the NEO_SYNC_AUTOCOMMIT arm: that arm guards the pipeline's own
 // commits, which are never merges, and must keep failing on mixed content regardless.
-let isMergeInProgress = false;
+let inheritedFromMerge = new Set();
 
 try {
     execSync('git rev-parse -q --verify MERGE_HEAD', { cwd: gitRoot, stdio: 'ignore' });
-    isMergeInProgress = true;
-} catch (e) {
-    // No MERGE_HEAD — an ordinary commit, so the leakage check below applies in full.
-}
 
-if (isMergeInProgress) {
-    process.exit(0);
+    // Files whose staged content DIFFERS from MERGE_HEAD's — i.e. authored/edited here rather than
+    // inherited. Everything else the merge staged matches MERGE_HEAD and is therefore inherited.
+    const divergedFromMergeHead = new Set(
+        execSync('git diff --cached --name-only MERGE_HEAD', { cwd: gitRoot, encoding: 'utf-8' })
+            .trim().split('\n').filter(Boolean)
+    );
+
+    inheritedFromMerge = new Set(stagedFiles.filter(file => !divergedFromMergeHead.has(file)));
+} catch (e) {
+    // No MERGE_HEAD (or the diff failed) — an ordinary commit. `inheritedFromMerge` stays empty, so
+    // the check below applies in full. Failing closed here is deliberate: a guard that cannot prove
+    // a file was inherited must treat it as authored.
 }
 
 const violatingFiles = stagedFiles.filter(file =>
-    isGeneratedSyncFile(file)
+    isGeneratedSyncFile(file) && !inheritedFromMerge.has(file)
 );
 
 // Allow explicit override via --force-data or bypassing hooks

--- a/test/playwright/unit/ai/buildScripts/util/check-chore-sync.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-chore-sync.spec.mjs
@@ -111,6 +111,42 @@ test.describe('check-chore-sync.mjs', () => {
         expect(result.output).toContain('resources/content/concepts/example.md');
     });
 
+    // Stages a real merge that carries a sync-pipeline commit — the exact shape of `git merge
+    // origin/dev` on a feature branch. `--no-commit` leaves MERGE_HEAD set with the merge staged,
+    // which is precisely the state the pre-commit hook runs in.
+    const startMergeCarryingSyncData = () => {
+        execSync('git checkout -b sync-pipeline-source', { cwd: tempDir, stdio: 'ignore' });
+        stageFile('resources/content/issues/1.md');
+        execSync('git commit -m "chore(data): Hourly data sync pipeline update"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git checkout dev', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git merge --no-commit --no-ff sync-pipeline-source', { cwd: tempDir, stdio: 'ignore' });
+    };
+
+    test('merge: a dev-merge carrying the pipeline\'s sync files passes — a merge does not AUTHOR sync data', () => {
+        startMergeCarryingSyncData();
+
+        // The merge stages resources/content/issues/1.md, but the feature branch did not write it.
+        expect(execSync('git diff --cached --name-only', { cwd: tempDir, encoding: 'utf-8' }))
+            .toContain('resources/content/issues/1.md');
+
+        expect(runScript(tempDir).status).toBe(0);
+    });
+
+    test('merge escape is scoped to the merge: the SAME branch and files still fail on an ordinary commit', () => {
+        // Guards the protection itself. If the escape ever widens from "a merge is in progress" to
+        // "this branch touched sync files", this arm goes red — the leakage check must survive.
+        startMergeCarryingSyncData();
+        execSync('git commit --no-edit', { cwd: tempDir, stdio: 'ignore' });
+
+        // Merge finished → no MERGE_HEAD → authoring sync data here is leakage again.
+        stageFile('resources/content/issues/2.md');
+        const result = runScript(tempDir);
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: Sync-data leakage detected');
+        expect(result.output).toContain('resources/content/issues/2.md');
+    });
+
     test('script root anchoring: running from a non-repo cwd checks the owning repo', () => {
         const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-sync-foreign-'));
 

--- a/test/playwright/unit/ai/buildScripts/util/check-chore-sync.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-chore-sync.spec.mjs
@@ -132,6 +132,57 @@ test.describe('check-chore-sync.mjs', () => {
         expect(runScript(tempDir).status).toBe(0);
     });
 
+    test('merge: a sync file HAND-EDITED during the merge is still rejected — authoring in a merge is still authoring', () => {
+        // The allowance is "inherited from MERGE_HEAD", not "a merge is in progress". Editing a sync
+        // file on top of the merge diverges the index from MERGE_HEAD, which is authoring wearing a
+        // merge's clothes — the exact hole a blanket merge-exit would leave open.
+        startMergeCarryingSyncData();
+
+        // Must write DIFFERENT content than the merge brought in: re-staging identical bytes is not
+        // an edit, and the discriminator would rightly still call it inherited.
+        fs.writeFileSync(path.join(tempDir, 'resources/content/issues/1.md'), 'hand-edited on top of the merge');
+        execSync('git add resources/content/issues/1.md', { cwd: tempDir, stdio: 'ignore' });
+
+        const result = runScript(tempDir);
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: Sync-data leakage detected');
+        expect(result.output).toContain('resources/content/issues/1.md');
+    });
+
+    test('merge: an inherited sync file passes while a hand-edited sibling in the SAME merge is rejected', () => {
+        // Proves the discriminator is per-file, not a whole-commit verdict: one merge, two sync
+        // files, only the edited one is a violation.
+        execSync('git checkout -b sync-two-files', { cwd: tempDir, stdio: 'ignore' });
+        stageFile('resources/content/issues/inherited.md');
+        stageFile('resources/content/issues/edited.md');
+        execSync('git commit -m "chore(data): Hourly data sync pipeline update"', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git checkout dev', { cwd: tempDir, stdio: 'ignore' });
+        execSync('git merge --no-commit --no-ff sync-two-files', { cwd: tempDir, stdio: 'ignore' });
+
+        fs.writeFileSync(path.join(tempDir, 'resources/content/issues/edited.md'), 'hand-edited during the merge');
+        execSync('git add resources/content/issues/edited.md', { cwd: tempDir, stdio: 'ignore' });
+
+        const result = runScript(tempDir);
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('resources/content/issues/edited.md');
+        expect(result.output).not.toContain('resources/content/issues/inherited.md');
+    });
+
+    test('merge + NEO_SYNC_AUTOCOMMIT=1: mixed content is still rejected — the env arm runs first and a merge does not soften it', () => {
+        // Ordering guard: the autocommit arm protects the pipeline's own commits, which are never
+        // merges. A merge in flight must not become a way to smuggle source into a sync commit.
+        startMergeCarryingSyncData();
+        stageFile('src/foo.js');
+
+        const result = runScript(tempDir, { NEO_SYNC_AUTOCOMMIT: '1' });
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('Error: NEO_SYNC_AUTOCOMMIT bypass rejected.');
+        expect(result.output).toContain('src/foo.js');
+    });
+
     test('merge escape is scoped to the merge: the SAME branch and files still fail on an ordinary commit', () => {
         // Guards the protection itself. If the escape ever widens from "a merge is in progress" to
         // "this branch touched sync files", this arm goes red — the leakage check must survive.


### PR DESCRIPTION
## 🎯 Summary

`check-chore-sync.mjs` refused **every** `git merge origin/dev` on a feature branch. It read the staged set with a bare `git diff --cached --name-only` and had no merge awareness — but a merge stages every file it brings in, so merging dev stages the sync pipeline's own commits and the guard read that as the feature branch authoring sync data.

The guard could not distinguish the thing it exists to prevent (**authoring** sync data on a feature branch) from a normal, unavoidable operation (**merging** dev, which carries the pipeline's commits by construction).

Resolves #15299 · Refs #15281

## 🧭 Why this was blocking, not cosmetic

`dev` takes ~2 `chore(data)` commits per 6 hours, so any branch older than an hour hit it. Both remaining exits were worse than the block: `--no-verify` also skips the AiConfig test-mutation safety lint, and unstaging the files makes the merge commit **revert** dev's sync data once it lands.

The other refresh path — rebase — does not trip this guard (it replays only the author's own commits and never stages sync files), but it rewrites history and so requires a force-push. I could not obtain one: the harness classifier denied `git push --force-with-lease origin grace/15272-throttle-producer`. With rebase unavailable and merge refused, the branch could not be refreshed at all.

## 🔬 The fix

A per-file merge-origin discriminator, placed deliberately **after** the `NEO_SYNC_AUTOCOMMIT` arm. Files whose staged content still matches `MERGE_HEAD` are inherited; files that diverge remain authored leakage. The env arm still runs first and fails mixed content regardless of merge state.

## Test Evidence

Five focused specs cover the complete boundary: benign inherited sync data; sync data hand-edited while `MERGE_HEAD` is live; per-file mixed inherited/edited sync data; `NEO_SYNC_AUTOCOMMIT=1` mixed-content ordering during a merge; and the ordinary-commit rejection.

`12/12 green.` The benign merge and both adversarial merge paths were red-proven against the blanket early-exit shape; the ordinary scoping protection remains green.

**Honest bound:** the end-to-end check on a real maintainer branch sequences *after* this merges — I could only prove it in the spec's temp repo, because forcing it on my own branch would mean running my own unreviewed fix to unblock my own PR. #15299's AC carries that verification.

## Post-Merge Validation

- Merge `origin/dev` into a name-prefixed maintainer branch and commit — the guard must pass while the merge carries `resources/content/**` from the pipeline. This is the check I could not run pre-merge (see the bound above); #15299's AC owns it.
- Confirm a plain commit staging `resources/content/**` on that same branch is still refused — the protection must survive its own escape.
- #15281 then merges dev fast-forward and RA-1 (`734000eb64`, 502/502 green) replays on top.

## 📊 Evaluation Metrics
- `[ARCH_ALIGNMENT]`: 90 — restores the guard's actual intent (block authoring, not merging) rather than widening its allowlist.
- `[CONTENT_COMPLETENESS]`: 85 — the escape carries its own rationale, including why it sits after the autocommit arm.
- `[EXECUTION_QUALITY]`: 95 — per-file origin discrimination, env ordering, benign inheritance, and both live-merge adversarial paths are pinned and red-proven.
- `[PRODUCTIVITY]`: 90 — unblocks dev-refresh for every feature branch; found and fixed inside one lane.
- `[IMPACT]`: 85 — every branch older than the last `chore(data)` commit was affected.
- `[COMPLEXITY]`: 30 — one per-file Git index provenance discriminator plus focused witnesses.
- `[EFFORT_PROFILE]`: Quick Win.

## 🔗 Follow-ups

**Force-push permissions are an operator-owned question, deliberately not in this PR.** Fixing the guard is sufficient to unblock merging; a force-push rule would additionally restore rebasing. @tobiu's call.

## Deltas

**Correction to my own filing — the ticket's framing was partly wrong, and I'd rather flag it than let a reviewer inherit it.** #15299 and my A2A both claimed the trap "compounds with the force-push allowlist: `.claude/settings.template.json:30` allows `--force-with-lease origin agent/*`, so `agent/*` branches can rebase while `<name>/*` cannot." That is **false as stated**. I checked the *template*, not the active config:

- `.claude/settings.json` (active) — **no push permission rules at all**; only an instruction never to push to `main`/`dev`.
- `.claude/settings.local.json` — no push rules (`rg` exit 1).
- `.claude/settings.template.json` — carries the allow/deny push rules, including the `agent/*` force-with-lease entry, but is **not the applied config**.

So force-push is neither allowed nor denied by rule; the classifier judged my specific call and denied it. The branch-prefix asymmetry I described does not exist in the active configuration. **The guard defect and this fix are entirely independent of that** — the merge-blindness reproduces on any branch — so the diff stands as-is. #15299's body is corrected to match.

Evidence: `buildScripts/util/check-chore-sync.mjs:50` (pre-fix) — the merge-blind staged read. `rg -n "MERGE_HEAD" buildScripts/ .husky/` → exit 1: no guard in the hook layer was merge-aware, so there was no existing escape to mirror. `git log --oneline origin/dev --since="6 hours ago" | rg -c "chore\(data\)"` → 2. Observed block: `grace/15272-throttle-producer` merging dev staged 20 pipeline-authored files under `resources/content/**`, none touched by the branch. Found while trying to land #15272's RA-1 roster join after #15280 merged — that work is complete and green (502/502) but unpublishable until this lands.

Authored by @neo-opus-grace (Claude Opus 4.8)