### PR TITLE
fix(agentos): the spine banner ships unstyled — no SCSS in any layer (#15301)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -87,9 +87,14 @@ class FleetCockpit extends Container {
          * plain containers, so per-class loading never fetches it; the consuming workspace
          * declares the dependency (the projection root carries the matching `.neo-dashboard`
          * scope class itself).
-         * @member {String[]} additionalThemeFiles=['Neo.dashboard.Container']
+         * Theme files this view needs that its own namespace does not pull in. `SpineBanner` is here
+         * because the banner is a plain component slot (`fleet-spine-banner`) rather than its own
+         * class — nothing requests `AgentOS.view.fleet.SpineBanner`, so without this entry the
+         * stylesheet is built and never loaded, and the banner renders unstyled. Any future
+         * class-less slot with its own SCSS needs the same registration.
+         * @member {String[]} additionalThemeFiles=['Neo.dashboard.Container','AgentOS.view.fleet.SpineBanner']
          */
-        additionalThemeFiles: ['Neo.dashboard.Container'],
+        additionalThemeFiles: ['Neo.dashboard.Container', 'AgentOS.view.fleet.SpineBanner'],
         /**
          * @member {String[]} baseCls=['fm-fleet-cockpit']
          */

--- a/resources/scss/src/apps/agentos/fleet/SpineBanner.scss
+++ b/resources/scss/src/apps/agentos/fleet/SpineBanner.scss
@@ -1,0 +1,48 @@
+/* The spine's honesty line: names WHY the surface is showing sample or last-known data. Exception-only
+   chrome — a live spine sets `hidden`, and the default `hideMode: 'removeDom'` takes the element out of
+   the DOM entirely, so nominal state costs zero pixels without this file guarding against it. That
+   inverts the usual styling brief: this element is only ever on screen when something is wrong, so it
+   has to read as an exception rather than as toolbar furniture, which is exactly what unstyled inline
+   text reads as.
+
+   Color is supplemental and token-only, per the SourceHealthMarker discipline: the text already carries
+   the whole message (cause AND remedy for cold), and the accent bar carries severity in geometry — so
+   neither channel is load-bearing alone, and the line survives a viewer who cannot separate the two
+   state hues. Both-theme adaptation is automatic: every value resolves through --fm-* tokens, which
+   theme-neo-{light,dark}/apps/agentos/Viewport.scss defines per theme. */
+.fm-spine-banner {
+    /* Local indirection so the state classes rebind ONE token instead of restating the ruleset —
+       the StateDot / SourceHealthMarker pattern. The default is the neutral ink: if a future `kind`
+       ever reaches the DOM without a matching class below, it renders quiet and readable rather
+       than borrowing a severity colour it did not earn. */
+    --fm-spine-mark: var(--fm-ink-dim);
+
+    display      : inline-flex;
+    align-items  : center;
+    flex         : none;
+    min-width    : 0;
+    max-width    : 100%;
+    padding      : 2px 8px;
+    border-left  : 3px solid var(--fm-spine-mark);
+    border-radius: 2px;
+    background   : color-mix(in srgb, var(--fm-spine-mark) 10%, transparent);
+    color        : var(--fm-ink);
+    font-family  : var(--fm-font-mono);
+    font-size    : 11px;
+    line-height  : 1.4;
+    white-space  : nowrap;
+    overflow     : hidden;
+    text-overflow: ellipsis;
+
+    /* cold — the spine is unreachable and the roster is SAMPLE data. The most severe thing this line
+       can say: everything on screen is fiction, and an operator must not mistake it for the fleet. */
+    &.fm-spine-banner-cold {
+        --fm-spine-mark: var(--fm-state-wedged);
+    }
+
+    /* degraded — reachable, serving last-known data. Real, but behind: a weaker claim than cold, and
+       the colour says so rather than flattening both into one alarm. */
+    &.fm-spine-banner-degraded {
+        --fm-spine-mark: var(--fm-state-idle);
+    }
+}


### PR DESCRIPTION
## 🎯 Summary

#15290 landed the spine banner's derivation — and it's right. What it landed without is the shape.

`FleetCockpit.mjs` renders the slot as `cls: ['fm-spine-banner', 'fm-spine-banner-<kind>']`, correctly keeping style out of the JS. But **no rule for either class existed in any layer**. The banner shipped as unstyled inline text, identical in light and dark because nothing themed it.

This PR adds the missing structural stylesheet and explicitly binds its namespace to the `FleetCockpit` runtime loader.

Resolves #15301 · Refs #15284, #15290

## 🧭 Why this is a bug, not polish

This element only ever appears when something is wrong — a live spine sets `hidden`, and the default `hideMode: 'removeDom'` takes it out of the DOM entirely. Its whole value is *being noticeable in the moment it shows up*. Unstyled, it read as toolbar furniture exactly when it must read as an exception — which re-opens the fail-silent half of "FM is not functional" one layer above where #15290 closed it.

I raised this as a bounded design objection on #15290 (comment 4995738210) rather than a signoff; it merged on its cross-family approval, which was Emmy's call. This carries the gap forward instead of letting it evaporate with the merge.

## 🔬 The shape

**One structural stylesheet plus one runtime-load edge, consuming existing tokens.** Both-theme adaptation is automatic and needs no per-theme half: every value resolves through `--fm-*`, which `theme-neo-{light,dark}/apps/agentos/Viewport.scss` defines per theme. That is how all 11 fleet components work; there are zero fleet SCSS files in the theme layers.

**Severity in two independent channels**, per the `SourceHealthMarker` discipline that colour is supplemental and token-only: the text already states cause *and* remedy, and the accent bar states severity in geometry. Neither channel is load-bearing alone, so the line survives a viewer who cannot separate crimson from amber.

- **cold** — the roster is sample data; everything on screen is fiction → `--fm-state-wedged`
- **degraded** — real, but behind → `--fm-state-idle`

The two claims stay distinguishable rather than flattening into one alarm. The local `--fm-spine-mark` indirection follows `StateDot`/`SourceHealthMarker`: state classes rebind one token instead of restating the ruleset, and the neutral default means a future `kind` reaching the DOM without a matching class renders quiet rather than borrowing a severity colour it did not earn.

## Test Evidence

- `npx sass --load-path=resources/scss …/SpineBanner.scss` → compiles clean, **exit 0**.
- **Every consumed token verified present in BOTH theme halves** — `fm-ink`, `fm-ink-dim`, `fm-font-mono`, `fm-state-wedged`, `fm-state-idle`, each `light=1 dark=1`. A token missing from one half would ship a banner that works in light and breaks in dark; that's the failure this check exists to catch.
- Zero hardcoded colours. The slot remains `cls`-only; the bounded `FleetCockpit.mjs` delta only declares `AgentOS.view.fleet.SpineBanner` in `additionalThemeFiles`, with the class-less ownership reason documented.
- Zero-pixel-when-live holds **by construction**, not by styling discipline: `hideMode_: 'removeDom'` (`src/component/Base.mjs:146`) removes the element from the DOM, so no padding/border can survive `hidden`.

**Reviewer visual receipt — completed at exact head `8bc5a123ea`.** The reviewer rebuilt both Neo development themes, loaded the real AgentOS cockpit, and confirmed the runtime requested `/dist/development/css/src/apps/agentos/fleet/SpineBanner.css`. Cold rendered rose and degraded rendered amber in both Neo dark and Neo light; each used a 3px geometric accent plus explicit cause text. A fully live spine removed `.fm-spine-banner` from the DOM (`count=0`, no rectangle) in both themes. Browser and Neural Link error logs were empty.

## Post-Merge Validation

None required — the visual acceptance gate was completed before approval at exact head `8bc5a123ea`.

## Pre-Merge Visual Validation

- [x] Cold and degraded rendered as exception chrome in Neo dark and Neo light at exact head `8bc5a123ea`.
- [x] Cold rose and degraded amber remained distinguishable by both geometry and explicit text.
- [x] A fully live spine rendered zero pixels: `.fm-spine-banner` was absent from the DOM in both themes.

## 📊 Evaluation Metrics
- `[ARCH_ALIGNMENT]`: 90 — consumes the token architecture as-is; no per-theme duplicate, no CSS-in-JS, no new token vocabulary.
- `[CONTENT_COMPLETENESS]`: 85 — the file carries why it exists, why it inverts the usual styling brief, and why colour is not load-bearing.
- `[EXECUTION_QUALITY]`: 85 — house idiom (`color-mix`, local-token indirection); tokens verified in both halves rather than assumed.
- `[PRODUCTIVITY]`: 80 — completes a just-merged feature that shipped incomplete, in one bounded stylesheet-plus-load-edge diff.
- `[IMPACT]`: 75 — restores the visibility of the cockpit's only "don't trust this data" signal.
- `[COMPLEXITY]`: 15 — one SCSS file, no logic.
- `[EFFORT_PROFILE]`: Quick Win.

## 🔗 Follow-ups

None. The derivation in `spineBanner.mjs` is shipped and correct; this was purely the missing presentation layer.

## Deltas

**My own filing was wrong about the fix shape, and I corrected it before building.** #15301's original ACs (and my #15290 receipt) claimed the precedent was a symmetric per-theme pair — `theme-neo-light/apps/agentos/fleet/SpineBanner.scss` plus a dark half, mirroring `theme-neo-light/apps/agentos/DockPreview.scss`. **That precedent does not exist on `dev`.** I read it off an older branch's working tree; the dark `Viewport.scss:68` records the consolidation — *"DockPreview domain-alias projections (moved here from the app's DockPreview theme file)"*. The real architecture is tokens-per-theme in `Viewport.scss` + a single consuming file in `src/`, which is what this PR does. Corrected on the ticket (comment 4995886604) before writing a line of SCSS.

The underlying defect was never in doubt — `fm-spine-banner` genuinely had zero rules anywhere — only my prescription was.

Evidence: `rg -n "fm-spine-banner" resources/ --glob '*.scss'` → exit 1 (genuinely absent; surface sanity-checked against `HealthSwatch.scss` / `FamilyRail.scss` / `theme-neo-light/apps/agentos/Viewport.scss`, which do carry `fm-` rules). Token definitions: `theme-neo-light/apps/agentos/Viewport.scss:46` (`--fm-ink-dim: #5a6b80`) vs `theme-neo-dark/apps/agentos/Viewport.scss:39` (`#8b97a8`). Class contract: `FleetCockpit.mjs:1250`. Zero-pixel guarantee: `src/component/Base.mjs:146`.

Authored by @neo-opus-grace (Claude Opus 4.8)
