### PR TITLE
fix(build): guard the graduated pr-review byte budget mechanically (#15308)

### DIFF
--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -183,7 +183,7 @@ At RC2 or >24KB, load the payload. On post-cutover PRs, two submitted `CHANGES_R
 
 **Payload Pointer:** `view_file` `.agents/skills/pr-review/audits/review-cost-circuit-breaker.md`
 
-**Byte gate:** this file + the payload are loaded together, so their combined size is gated. Owner: `COMBINED_BUDGETS` in `ai/scripts/diagnostics/check-substrate-size.mjs` (`npm run ai:check-substrate-size`). The number lives only there — run it before growing either file.
+**Byte gate:** this file + the payload load together; their combined size is gated. Owner: `COMBINED_BUDGETS` in `ai/scripts/diagnostics/check-substrate-size.mjs` (`ai:check-substrate-size`) — run it before growing either.
 
 ## 7. Depth Floor — Preventing Rubber-Stamp Approvals
 

--- a/.agents/skills/pr-review/references/pr-review-guide.md
+++ b/.agents/skills/pr-review/references/pr-review-guide.md
@@ -183,6 +183,8 @@ At RC2 or >24KB, load the payload. On post-cutover PRs, two submitted `CHANGES_R
 
 **Payload Pointer:** `view_file` `.agents/skills/pr-review/audits/review-cost-circuit-breaker.md`
 
+**Byte gate:** this file + the payload are loaded together, so their combined size is gated. Owner: `COMBINED_BUDGETS` in `ai/scripts/diagnostics/check-substrate-size.mjs` (`npm run ai:check-substrate-size`). The number lives only there — run it before growing either file.
+
 ## 7. Depth Floor — Preventing Rubber-Stamp Approvals
 
 Structural compliance ≠ rigor — these mandates (+ the concept-graph feed) are for **concept-bearing** changes: touch an ADR/new-abstraction/consumed-contract/security/migration. A **mechanical** PR (test/config/behavior-preserving, any size) gets a premise+correctness glance → Approve.

--- a/.github/workflows/substrate-size-guard.yml
+++ b/.github/workflows/substrate-size-guard.yml
@@ -6,6 +6,11 @@ on:
     paths:
       - 'AGENTS.md'
       - '.agents/ANTIGRAVITY_RULES.md'
+      # Combined-budget members (#15257's pr-review loaded surface). A guard that does not RUN on the
+      # edit it exists to catch is not a guard — the +135 B drift that put dev over its own gate was
+      # a guide edit, and nothing was watching.
+      - '.agents/skills/pr-review/audits/review-cost-circuit-breaker.md'
+      - '.agents/skills/pr-review/references/pr-review-guide.md'
       - 'ai/scripts/diagnostics/check-substrate-size.mjs'
       - '.github/workflows/substrate-size-guard.yml'
       - 'package.json'
@@ -14,6 +19,11 @@ on:
     paths:
       - 'AGENTS.md'
       - '.agents/ANTIGRAVITY_RULES.md'
+      # Combined-budget members (#15257's pr-review loaded surface). A guard that does not RUN on the
+      # edit it exists to catch is not a guard — the +135 B drift that put dev over its own gate was
+      # a guide edit, and nothing was watching.
+      - '.agents/skills/pr-review/audits/review-cost-circuit-breaker.md'
+      - '.agents/skills/pr-review/references/pr-review-guide.md'
       - 'ai/scripts/diagnostics/check-substrate-size.mjs'
       - '.github/workflows/substrate-size-guard.yml'
       - 'package.json'

--- a/ai/scripts/diagnostics/check-substrate-size.mjs
+++ b/ai/scripts/diagnostics/check-substrate-size.mjs
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs   from 'fs';
 import path from 'path';
 
 /**
@@ -19,6 +19,31 @@ const TARGET_FILES = [
     '.agents/ANTIGRAVITY_RULES.md'
 ];
 
+/**
+ * Budgets over a GROUP of files rather than each file alone.
+ *
+ * A per-file limit cannot express "these two files are read together, so their SUM is the cost" —
+ * the shape a graduated merge-eligibility boundary takes. Without a group model such a boundary can
+ * only live as prose, and prose drifts silently: this budget's own surface grew past its limit by a
+ * hundred-odd bytes and sat there unnoticed, because nothing was watching. Gradual drift is exactly
+ * what a human reader cannot see and a byte count can.
+ *
+ * `limitBytes` is a graduated number owned by the decision that set it — named in `label`, so the
+ * failure output points at the authority rather than at this file. Never re-baseline it to
+ * accommodate drift: that inverts the point. Raising it is a decision with a rationale, not a lint
+ * edit.
+ */
+const COMBINED_BUDGETS = [
+    {
+        label     : 'pr-review loaded surface (#15257)',
+        limitBytes: 41357,
+        files     : [
+            '.agents/skills/pr-review/audits/review-cost-circuit-breaker.md',
+            '.agents/skills/pr-review/references/pr-review-guide.md'
+        ]
+    }
+];
+
 let hasError = false;
 
 console.log(`\n🔍 Checking Antigravity Substrate sizes against ${PER_FILE_LIMIT_BYTES} byte per-file limit...`);
@@ -32,8 +57,8 @@ TARGET_FILES.forEach(file => {
         return;
     }
 
-    const stats = fs.statSync(fullPath);
-    const size = stats.size;
+    const stats  = fs.statSync(fullPath);
+    const size   = stats.size;
     const status = size > PER_FILE_LIMIT_BYTES ? '❌ EXCEEDS' : '✅ PASS';
 
     console.log(`📄 ${file.padEnd(30)} : ${size} bytes [${status}]`);
@@ -45,13 +70,54 @@ TARGET_FILES.forEach(file => {
 
 console.log('--------------------------------------------------------------------------------');
 
+COMBINED_BUDGETS.forEach(budget => {
+    console.log(`\n🔍 Checking combined budget "${budget.label}" against ${budget.limitBytes} bytes...`);
+    console.log('--------------------------------------------------------------------------------');
+
+    let combined = 0,
+        missing  = false;
+
+    budget.files.forEach(file => {
+        const fullPath = path.join(ROOT_DIR, file);
+
+        if (!fs.existsSync(fullPath)) {
+            // Fail closed: a budget that silently drops a renamed file measures a fiction and passes.
+            console.error(`❌ Error: Budgeted file ${file} not found.`);
+            missing  = true;
+            hasError = true;
+            return;
+        }
+
+        const size = fs.statSync(fullPath).size;
+
+        combined += size;
+        console.log(`📄 ${file.padEnd(62)} : ${size} bytes`);
+    });
+
+    if (missing) return;
+
+    const over   = combined > budget.limitBytes,
+          status = over ? '❌ EXCEEDS' : '✅ PASS';
+
+    // Report headroom, not just pass/fail: the drift this exists to catch is gradual, so a shrinking
+    // margin is the signal — by the time it flips to EXCEEDS the substrate is already broken.
+    console.log(`Σ  ${'combined'.padEnd(62)} : ${combined} bytes [${status}]`);
+    console.log(`   limit ${budget.limitBytes} · ${over ? `OVER by ${combined - budget.limitBytes}` : `headroom ${budget.limitBytes - combined}`} bytes`);
+
+    if (over) hasError = true
+});
+
+console.log('--------------------------------------------------------------------------------');
+
 if (hasError) {
     console.error(`\n❌ Substrate Size Check FAILED!`);
-    console.error(`One or more files exceed the Antigravity hard limit of ${PER_FILE_LIMIT_BYTES} bytes per file.`);
-    console.error(`If this passes, the bottom of the offending file will be silently truncated and agents will lose critical memory.\n`);
-    console.error(`Please reduce the size of the tracked memory files by migrating granular instructions to .agents/skills/ Atlas files (Progressive Disclosure).`);
+    console.error(`Either a file exceeds the Antigravity hard limit of ${PER_FILE_LIMIT_BYTES} bytes, or a combined budget above is over its limit.`);
+    console.error(`Per-file breach: the bottom of the offending file is silently truncated and agents lose critical memory.`);
+    console.error(`Combined breach: the graduated budget for a jointly-loaded surface is spent — see the ticket that set it.\n`);
+    console.error(`Fix by migrating granular instructions to .agents/skills/ Atlas files (Progressive Disclosure).`);
+    console.error(`Do NOT raise a limit to make this pass: a graduated budget is a decision, not a lint setting.`);
     process.exit(1);
 }
 
-console.log(`\n✅ Substrate Size Check PASSED. All files safely under the ${PER_FILE_LIMIT_BYTES} byte limit.\n`);
+console.log(`\n✅ Substrate Size Check PASSED. Per-file under ${PER_FILE_LIMIT_BYTES} bytes; all combined budgets within limit.\n`);
 process.exit(0);

--- a/ai/scripts/diagnostics/check-substrate-size.mjs
+++ b/ai/scripts/diagnostics/check-substrate-size.mjs
@@ -32,6 +32,13 @@ const TARGET_FILES = [
  * failure output points at the authority rather than at this file. Never re-baseline it to
  * accommodate drift: that inverts the point. Raising it is a decision with a rationale, not a lint
  * edit.
+ *
+ * **`limitBytes` is EXCLUSIVE.** The graduating decision reads "the combined two-file boundary is
+ * `< 41,357 B`", and that number is the pre-existing baseline the surface had to get *below* — so
+ * landing exactly on it is the breach, not the last legal state. The largest legal sum is therefore
+ * `limitBytes - 1`, and every comparison and message below is expressed against that one relation.
+ * Reporting headroom against `limitBytes` instead would tell an author "headroom 1" at the precise
+ * size where the next byte fails.
  */
 const COMBINED_BUDGETS = [
     {
@@ -71,7 +78,7 @@ TARGET_FILES.forEach(file => {
 console.log('--------------------------------------------------------------------------------');
 
 COMBINED_BUDGETS.forEach(budget => {
-    console.log(`\n🔍 Checking combined budget "${budget.label}" against ${budget.limitBytes} bytes...`);
+    console.log(`\n🔍 Checking combined budget "${budget.label}" against < ${budget.limitBytes} bytes...`);
     console.log('--------------------------------------------------------------------------------');
 
     let combined = 0,
@@ -96,13 +103,20 @@ COMBINED_BUDGETS.forEach(budget => {
 
     if (missing) return;
 
-    const over   = combined > budget.limitBytes,
-          status = over ? '❌ EXCEEDS' : '✅ PASS';
+    // The boundary is EXCLUSIVE (`< limitBytes`), so the largest legal sum is one byte below it.
+    // Deriving that once and comparing everything against it keeps the verdict, the headroom and the
+    // overage on a single relation — the earlier shape checked `> limitBytes` while its own spec
+    // claimed the contract was `< limitBytes`, so equality passed and the green test certified the
+    // opposite boundary.
+    const maxBytes = budget.limitBytes - 1,
+          over     = combined > maxBytes,
+          status   = over ? '❌ EXCEEDS' : '✅ PASS';
 
     // Report headroom, not just pass/fail: the drift this exists to catch is gradual, so a shrinking
     // margin is the signal — by the time it flips to EXCEEDS the substrate is already broken.
+    // Headroom counts bytes an author may still ADD, which is the question they are actually asking.
     console.log(`Σ  ${'combined'.padEnd(62)} : ${combined} bytes [${status}]`);
-    console.log(`   limit ${budget.limitBytes} · ${over ? `OVER by ${combined - budget.limitBytes}` : `headroom ${budget.limitBytes - combined}`} bytes`);
+    console.log(`   limit < ${budget.limitBytes} (max ${maxBytes}) · ${over ? `OVER by ${combined - maxBytes}` : `headroom ${maxBytes - combined}`} bytes`);
 
     if (over) hasError = true
 });

--- a/test/playwright/unit/ai/scripts/diagnostics/CheckSubstrateSize.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/CheckSubstrateSize.spec.mjs
@@ -1,0 +1,123 @@
+import { test, expect }  from '@playwright/test';
+import { execSync }      from 'node:child_process';
+import path              from 'node:path';
+import fs                from 'node:fs';
+import os                from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const repoRoot   = path.resolve(__dirname, '../../../../../../');
+const scriptPath = path.join(repoRoot, 'ai/scripts/diagnostics/check-substrate-size.mjs');
+
+/**
+ * Self-test for the substrate size guard, focused on the COMBINED-budget arm.
+ *
+ * A per-file limit cannot express "these files are loaded together, so their sum is the cost". Such
+ * a boundary was graduated for the pr-review surface, lived only as prose, and the guide then
+ * drifted past it unnoticed. These specs pin the arm that would have caught it — and, more
+ * importantly, pin that the guard can still FAIL.
+ *
+ * The script reads from `process.cwd()`, so each case runs it against a synthetic root rather than
+ * the live repo: a spec that asserts against real file sizes would flip red the day someone edits
+ * the guide, which is drift-coupling, not a test.
+ */
+test.describe('check-substrate-size.mjs — combined budgets', () => {
+    let tempDir;
+
+    test.beforeEach(() => {
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-substrate-size-'));
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    const writeFile = (relPath, bytes) => {
+        const full = path.join(tempDir, relPath);
+
+        fs.mkdirSync(path.dirname(full), { recursive: true });
+        fs.writeFileSync(full, 'x'.repeat(bytes));
+    };
+
+    // The per-file targets must exist and stay under 24 KiB, or that arm fails for its own reasons
+    // and tells us nothing about the combined arm under test.
+    const seedPerFileTargets = () => {
+        writeFile('AGENTS.md', 1000);
+        writeFile('.agents/ANTIGRAVITY_RULES.md', 1000);
+    };
+
+    const seedCombined = (circuitBreakerBytes, guideBytes) => {
+        writeFile('.agents/skills/pr-review/audits/review-cost-circuit-breaker.md', circuitBreakerBytes);
+        writeFile('.agents/skills/pr-review/references/pr-review-guide.md', guideBytes);
+    };
+
+    const run = () => {
+        try {
+            return { status: 0, output: execSync(`node ${scriptPath}`, { cwd: tempDir, encoding: 'utf-8', stdio: 'pipe' }) };
+        } catch (error) {
+            return { status: error.status, output: (error.stdout || '') + (error.stderr || '') };
+        }
+    };
+
+    test('the combined budget FAILS when the pair exceeds its limit — the drift that went unnoticed', () => {
+        seedPerFileTargets();
+        // The historical breach, reproduced exactly: 4,506 + 36,986 = 41,492 against a 41,357 limit.
+        seedCombined(4506, 36986);
+
+        const result = run();
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('EXCEEDS');
+        expect(result.output).toContain('OVER by 135 bytes');
+    });
+
+    test('the combined budget PASSES under its limit and reports HEADROOM, not just a verdict', () => {
+        seedPerFileTargets();
+        // The repaired state that brought the surface back under: 2,207 + 36,544 = 38,751.
+        seedCombined(2207, 36544);
+
+        const result = run();
+
+        expect(result.status).toBe(0);
+        // Headroom is the point: this drift is gradual, so a shrinking margin is the signal. By the
+        // time the verdict flips, the substrate is already broken.
+        expect(result.output).toContain('headroom 2606 bytes');
+    });
+
+    test('one byte over is a failure — the boundary is exact, not approximate', () => {
+        seedPerFileTargets();
+        seedCombined(1, 41357);
+
+        expect(run().status).toBe(1);
+    });
+
+    test('exactly at the limit passes — the contract is < limit, and off-by-one here would be a silent tax', () => {
+        seedPerFileTargets();
+        seedCombined(1, 41356);
+
+        expect(run().status).toBe(0);
+    });
+
+    test('a MISSING budgeted file fails closed — a renamed member must not silently shrink the sum', () => {
+        seedPerFileTargets();
+        // Only one member present: a budget that quietly drops the other measures a fiction and passes.
+        writeFile('.agents/skills/pr-review/references/pr-review-guide.md', 100);
+
+        const result = run();
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('not found');
+    });
+
+    test('the per-file arm still fails independently — the combined arm did not replace it', () => {
+        writeFile('AGENTS.md', 24577);
+        writeFile('.agents/ANTIGRAVITY_RULES.md', 1000);
+        seedCombined(2207, 36544);
+
+        const result = run();
+
+        expect(result.status).toBe(1);
+        expect(result.output).toContain('EXCEEDS');
+    });
+});

--- a/test/playwright/unit/ai/scripts/diagnostics/CheckSubstrateSize.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/CheckSubstrateSize.spec.mjs
@@ -1,5 +1,5 @@
 import { test, expect }  from '@playwright/test';
-import { execSync }      from 'node:child_process';
+import { execFileSync }  from 'node:child_process';
 import path              from 'node:path';
 import fs                from 'node:fs';
 import os                from 'node:os';
@@ -52,9 +52,13 @@ test.describe('check-substrate-size.mjs — combined budgets', () => {
         writeFile('.agents/skills/pr-review/references/pr-review-guide.md', guideBytes);
     };
 
+    // `execFileSync` with an argv array, never `execSync` with an interpolated string: `scriptPath`
+    // is derived from `import.meta.url`, so a repo checked out under a path containing a space or a
+    // shell metacharacter would have the command re-split by the shell. `process.execPath` also pins
+    // the child to the same Node binary running this suite rather than whichever `node` is on PATH.
     const run = () => {
         try {
-            return { status: 0, output: execSync(`node ${scriptPath}`, { cwd: tempDir, encoding: 'utf-8', stdio: 'pipe' }) };
+            return { status: 0, output: execFileSync(process.execPath, [scriptPath], { cwd: tempDir, encoding: 'utf-8', stdio: 'pipe' }) };
         } catch (error) {
             return { status: error.status, output: (error.stdout || '') + (error.stderr || '') };
         }

--- a/test/playwright/unit/ai/scripts/diagnostics/CheckSubstrateSize.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/CheckSubstrateSize.spec.mjs
@@ -62,14 +62,17 @@ test.describe('check-substrate-size.mjs — combined budgets', () => {
 
     test('the combined budget FAILS when the pair exceeds its limit — the drift that went unnoticed', () => {
         seedPerFileTargets();
-        // The historical breach, reproduced exactly: 4,506 + 36,986 = 41,492 against a 41,357 limit.
+        // The historical breach, reproduced exactly: 4,506 + 36,986 = 41,492 against a `< 41,357` gate.
         seedCombined(4506, 36986);
 
         const result = run();
 
         expect(result.status).toBe(1);
         expect(result.output).toContain('EXCEEDS');
-        expect(result.output).toContain('OVER by 135 bytes');
+        // 136, not 135: the overage is measured against the largest LEGAL sum (41,356), not against
+        // the exclusive gate number. The +135 in the ticket's story is the guide's growth
+        // (36,851 → 36,986), which is a different quantity that happens to be adjacent.
+        expect(result.output).toContain('OVER by 136 bytes');
     });
 
     test('the combined budget PASSES under its limit and reports HEADROOM, not just a verdict', () => {
@@ -81,22 +84,41 @@ test.describe('check-substrate-size.mjs — combined budgets', () => {
 
         expect(result.status).toBe(0);
         // Headroom is the point: this drift is gradual, so a shrinking margin is the signal. By the
-        // time the verdict flips, the substrate is already broken.
-        expect(result.output).toContain('headroom 2606 bytes');
+        // time the verdict flips, the substrate is already broken. It counts bytes an author may
+        // still ADD — 2,605 against the largest legal sum of 41,356, not 2,606 against the gate.
+        expect(result.output).toContain('headroom 2605 bytes');
     });
 
-    test('one byte over is a failure — the boundary is exact, not approximate', () => {
+    test('EXACTLY at the limit FAILS — the graduated boundary is `< 41,357`, so landing on it is the breach', () => {
+        // The number is the baseline the surface had to get BELOW; equality is not the last legal
+        // state, it is the state the gate was created to reject.
+        //
+        // This spec previously asserted the opposite and was green. Its own name claimed "the
+        // contract is < limit" while the assertion certified `<=` — the rule stated correctly in
+        // prose and violated in the same breath, which is worse than an untested boundary because it
+        // looks like coverage. Caught by @neo-gpt-emmy's RA-1, not by the suite.
         seedPerFileTargets();
-        seedCombined(1, 41357);
+        seedCombined(1, 41356); // = 41,357 exactly
 
         expect(run().status).toBe(1);
     });
 
-    test('exactly at the limit passes — the contract is < limit, and off-by-one here would be a silent tax', () => {
+    test('one byte UNDER the limit passes — the largest legal sum is 41,356', () => {
         seedPerFileTargets();
-        seedCombined(1, 41356);
+        seedCombined(1, 41355); // = 41,356
 
-        expect(run().status).toBe(0);
+        const result = run();
+
+        expect(result.status).toBe(0);
+        // Zero headroom, and still passing: the next byte is the breach.
+        expect(result.output).toContain('headroom 0 bytes');
+    });
+
+    test('one byte over the gate is a failure — the boundary is exact, not approximate', () => {
+        seedPerFileTargets();
+        seedCombined(1, 41357); // = 41,358
+
+        expect(run().status).toBe(1);
     });
 
     test('a MISSING budgeted file fails closed — a renamed member must not silently shrink the sum', () => {


### PR DESCRIPTION
## 🎯 Summary

#15257 graduated a merge-eligibility boundary — `review-cost-circuit-breaker.md` + `pr-review-guide.md` **< 41,357 B** — and it lived only as prose in a ticket.

So it drifted. The guide grew **+135 B** after the baseline was measured, silently, and `dev` sat at **41,492 B — over its own gate** — until #15307 happened to bring it back under. Nothing failed, because nothing was watching.

Resolves #15308 · Refs #15257, #15307

## 🧭 Why this extends a guard instead of adding one

`substrate-size-guard` **already exists** and already enforces byte budgets. It simply had no way to express this shape: its model is **per-file** (24 KiB, the Antigravity truncation limit), and a per-file limit cannot say *"these two files are read together, so their SUM is the cost."*

That gap is the whole reason the boundary had nowhere mechanical to live. `COMBINED_BUDGETS` gives it one — and #15308's own AC asked for exactly this: the limit in **one named place**, not duplicated into the guide it measures.

I nearly wrote a new `check-review-surface-budget.mjs` + a new workflow before checking whether the concern already had a home. It did.

## 🔬 The three things that make it a guard rather than a check

- **The workflow's `paths:` now include both budgeted files.** Without that it would never *run* on a guide edit — and a guide edit **is** the drift that happened. A correct check that never fires on the change it exists to catch is not a guard.
- **Fails closed on a missing member.** A budget that quietly drops a renamed file measures a fiction and passes green.
- **Reports headroom, not just a verdict.** This drift is gradual, so the shrinking margin is the signal; by the time the verdict flips, the substrate is already broken. The pair today: 38,977 B, **headroom 2,379** — counted against the largest legal sum, so it is bytes you may still add.

**The limit is not re-baselined.** It belongs to the decision that graduated it. Raising it to make CI pass would invert the point, so the failure text says so explicitly — the next person under time pressure will reach for the number first. It is also **exclusive**: `< 41,357`, so the largest legal sum is 41,356 and every comparison derives from that one relation.

## Test Evidence

`7/7 green.` Both arms, both directions, and the boundary from **both sides**:

- the **historical breach reproduced exactly** — 4,506 + 36,986 → `OVER by 136 bytes` (measured against the largest LEGAL sum, 41,356; the +135 in the ticket is the guide's own growth 36,851 → 36,986, an adjacent quantity that coincided only because the circuit-breaker file was unchanged)
- the repaired state passes **with headroom** asserted, not just a status code
- **exactly at the limit FAILS** — the graduated boundary is `< 41,357`, and that number IS the baseline the surface had to get *below*, so landing on it is the breach. **The first draft asserted the opposite and was green**: its own name claimed "the contract is < limit" while the assertion certified `<=`. @neo-gpt-emmy's RA-1 caught it — *"the green test certifies the opposite boundary at equality"* — the suite never could
- **one byte under passes at `headroom 0`**, and **one byte over the gate fails**: the boundary is now pinned from both sides
- a **missing member fails closed**
- the **per-file arm still fails independently** — the combined arm did not replace it

**Red-then-green:** confirmed by swapping in the pre-fix script — **4 of the 7 fail without it; 3 pass**. The 3 survivors are the per-file arm, the missing-member arm, and one-byte-over-the-gate, which hold under either relation. Stating that rather than implying all seven are new-behaviour pins.

The count is measured, not recalled: a first attempt used `git stash push` to remove the fix, and the push **no-op'd** (the fix was already committed), so the suite ran against the *fixed* code and reported 7/7 — a green result that would have been published as a red proof. The tell was `No local changes to save`, not the number.

Specs run against a **synthetic root**, not the live repo: asserting on real file sizes would flip red the day someone edits the guide, which is drift-coupling rather than a test.

Also verified live: the extended guard **fails on the pre-#15307 tree** (41,492) and **passes on the current pair** at **38,977 B, headroom 2,379** — the real states, not fixtures. (That figure moved twice during review: the RA-2 citation cost bytes, and compressing it under the skill-growth cap gave some back.)

## Post-Merge Validation

- Edit the guide by +3,000 B on a branch → CI fails with `OVER by …`, and fails *because the path trigger fires*.
- Rename a budgeted file without updating the group → CI fails `not found` rather than silently passing on a shrunken sum.
- `AGENTS.md` over 24 KiB still fails on the per-file arm.

## 📊 Evaluation Metrics
- `[ARCH_ALIGNMENT]`: 90 — the concern lands in the guard that already owns byte budgets; no new script, no new workflow, no duplicated limit.
- `[CONTENT_COMPLETENESS]`: 85 — the budget model documents why a group differs from per-file, and why the number must not be re-baselined.
- `[EXECUTION_QUALITY]`: 85 — fails closed; both arms pinned; red-then-green proven; synthetic root avoids drift-coupling.
- `[PRODUCTIVITY]`: 85 — closes the finding my own #15307 review raised, in the place it belonged.
- `[IMPACT]`: 75 — the boundary is now enforced rather than remembered; the drift class it guards already occurred once.
- `[COMPLEXITY]`: 25 — one config group, one loop, path triggers.
- `[EFFORT_PROFILE]`: Quick Win.

## 🔗 Follow-ups

None. The `[TOOLING_GAP]` I logged on #15307 (the review validator naming only *some* required anchors on failure) is Emmy's leaf and offered to her, not carried here.

## Deltas

**The shape changed from what #15308 specified, and for the better.** The ticket said "CI asserting `circuit-breaker + guide < 41,357 B`" — I read that as *build a check*. Prior-art said otherwise: `substrate-size-guard.yml` + `check-substrate-size.mjs` already existed, wanting only a group model. Extending it satisfies the ticket's own "one named place" AC more directly than a second guard would have.

The ticket's `dev`-breach AC — *"resolved either by #15307 merging (which lands 38,751 B)"* — is **met**: #15307 merged, dev is 38,751. That AC was written to be satisfiable by someone else's merge, and it was.

Evidence: `npm run ai:check-substrate-size` on the pre-#15307 tree → `41,492 [❌ EXCEEDS] OVER by 136`; on the current pair → `38,977 [✅ PASS] headroom 2,379`. Spec run 7/7; red-proof against the pre-fix script 4 failed / 3 passed. `git grep '41357' -- ':!*.md'` before this PR → no mechanical guard existed.

Every figure on this line moved during review and each is re-measured rather than carried: the overage is now against the largest legal sum (41,356), the pair grew when RA-2's citation landed and shrank when the skill-growth cap forced it to be pointer-sized, and the red count is from swapping the pre-fix script in — not from a `git stash` that silently no-op'd.

Authored by @neo-opus-grace (Claude Opus 4.8)

