### PR TITLE
fix(ai): reserve review-budget provenance on create (#15309)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -813,7 +813,7 @@ paths:
       description: |
         Create or update one formal PR review. Read `.agents/skills/pr-review/SKILL.md` and use its exact cycle template. Create requires `pr_number`, `state`, and `body`; update requires `review_id` and `body`.
 
-        APPROVED requires reviewer-keyed `acknowledgedRequestChanges` for outstanding current-head RCs. REQUEST_CHANGES is budgeted on post-cutover PRs: two submitted RCs, then COMMENT/APPROVED or one complete terminal Drop+Supersede. Incomplete history fails closed. `reviewBudgetOverrideReason` is a disclosed exceptional bypass persisted in the review body. Direct gh/UI submission is outside this pre-submit gate and only receives workflow telemetry.
+        APPROVED requires reviewer-keyed `acknowledgedRequestChanges` for outstanding current-head RCs. REQUEST_CHANGES is budgeted on post-cutover PRs: two submitted RCs, then COMMENT/APPROVED or one complete terminal Drop+Supersede. Incomplete history fails closed. `reviewBudgetOverrideReason` is a disclosed exceptional bypass persisted in the review body. CREATE bodies must not supply service-owned `[review-budget-managed]` / `[review-budget-override]` marker lines or their reserved audit-field list entries; the service rejects them before GitHub access and appends the canonical receipt itself when applicable. Direct gh/UI submission is outside this pre-submit gate and only receives workflow telemetry.
       tags: [PullRequests]
       parameters:
         - name: pr_number
@@ -848,7 +848,7 @@ paths:
                   example: APPROVED
                 body:
                   type: string
-                  description: The review body.
+                  description: The human-authored review body. For `create`, service-owned review-budget marker lines and reserved audit-field list entries are rejected.
                 review_id:
                   type: string
                   description: The GraphQL node ID of the existing review (required for `update`, e.g. `PRR_*`).

--- a/ai/services/github-workflow/PullRequestService.mjs
+++ b/ai/services/github-workflow/PullRequestService.mjs
@@ -895,6 +895,17 @@ function appendReviewBudgetManagedAudit(body, audit) {
 }
 
 /**
+ * @summary Returns machine-owned review-budget audit fields found in the supplied lines.
+ * @param {String[]} lines Review-body lines to inspect.
+ * @returns {String[]} Reserved audit-field labels present in the lines.
+ */
+function getReviewBudgetAuditFields(lines) {
+    return REVIEW_BUDGET_AUDIT_FIELDS.filter(label =>
+        lines.some(line => line.trim().startsWith(`- ${label}:`))
+    )
+}
+
+/**
  * @summary Captures the exact machine-owned review-budget suffix and rejects ambiguous duplicates.
  * @param {String} body Review body.
  * @returns {{auditFieldsOutsideTail: String[], managedCount: Number, overrideCount: Number, structureValid: Boolean, tail: String}}
@@ -918,9 +929,7 @@ function getReviewBudgetAuditSnapshot(body) {
         ? Math.min(...allIndices.map(index => Math.max(0, index - 1)))
         : -1;
     const prefixLines            = firstBlockLine >= 0 ? lines.slice(0, firstBlockLine) : lines;
-    const auditFieldsOutsideTail = allIndices.length === 0 ? [] : REVIEW_BUDGET_AUDIT_FIELDS.filter(label =>
-        prefixLines.some(line => line.trim().startsWith(`- ${label}:`))
-    );
+    const auditFieldsOutsideTail = allIndices.length === 0 ? [] : getReviewBudgetAuditFields(prefixLines);
 
     return {
         auditFieldsOutsideTail,
@@ -928,6 +937,30 @@ function getReviewBudgetAuditSnapshot(body) {
         overrideCount: overrideIndices.length,
         structureValid,
         tail         : firstBlockLine >= 0 ? lines.slice(firstBlockLine).join('\n').trimEnd() : ''
+    }
+}
+
+/**
+ * @summary Rejects caller-authored review-budget provenance before a review CREATE reaches GitHub.
+ * @param {String} body Candidate review body.
+ * @returns {Object|null} Structured validation failure or `null` when no reserved provenance exists.
+ */
+function getReviewBudgetCreateAuditValidationFailure(body) {
+    const lines                          = body.replace(/\r\n/g, '\n').split('\n');
+    const snapshot                       = getReviewBudgetAuditSnapshot(body);
+    const reservedReviewBudgetProvenance = [
+        ...(snapshot.managedCount > 0 ? [REVIEW_BUDGET_MANAGED_MARKER] : []),
+        ...(snapshot.overrideCount > 0 ? [REVIEW_BUDGET_OVERRIDE_MARKER] : []),
+        ...getReviewBudgetAuditFields(lines)
+    ];
+
+    if (reservedReviewBudgetProvenance.length === 0) return null;
+
+    return {
+        error  : 'PR Review Budget Audit Validation Failed',
+        message: 'A review CREATE body cannot supply service-owned review-budget provenance. Remove the reserved marker or audit fields; manage_pr_review appends the canonical receipt when applicable.',
+        code   : 'PR_REVIEW_BUDGET_AUDIT_RESERVED',
+        reservedReviewBudgetProvenance
     }
 }
 
@@ -1741,6 +1774,12 @@ class PullRequestService extends Base {
                     message: `Invalid state '${state}'. Must be one of: ${Object.keys(stateToEvent).join(', ')}.`,
                     code   : 'INVALID_ARGUMENTS'
                 };
+            }
+
+            const reviewBudgetAuditValidationFailure = getReviewBudgetCreateAuditValidationFailure(body);
+
+            if (reviewBudgetAuditValidationFailure) {
+                return reviewBudgetAuditValidationFailure
             }
 
             if (MICRO_DELTA_COMMENTED_CLOSURE_PATTERN.test(body) && event !== 'COMMENT') {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs
@@ -1115,6 +1115,99 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(result.state).toBe('CHANGES_REQUESTED');
     });
 
+    test('#15309: create reserves service-owned review-budget provenance before GraphQL', async () => {
+        const reservedAuditFields = [
+            'outcome',
+            'ordinary-limit',
+            'activation-issue',
+            'activation-pr',
+            'activated-at',
+            'reason',
+            'submitted-request-changes'
+        ];
+        const cases = [{
+            name : 'displaced managed marker',
+            state: 'APPROVED',
+            body : `${VALID_REVIEW_BODY}\n\n[review-budget-managed]`,
+            field: '[review-budget-managed]'
+        }, {
+            name : 'duplicate managed marker',
+            state: 'COMMENT',
+            body : `${VALID_REVIEW_BODY}\n\n---\n[review-budget-managed]\n\n---\n[review-budget-managed]`,
+            field: '[review-budget-managed]'
+        }, {
+            name : 'override marker without service provenance',
+            state: 'COMMENT',
+            body : `${VALID_REVIEW_BODY}\n\n[review-budget-override]`,
+            field: '[review-budget-override]'
+        }, ...reservedAuditFields.map((field, index) => ({
+            name : `reserved audit field ${field}`,
+            state: ['APPROVED', 'COMMENT', 'REQUEST_CHANGES'][index % 3],
+            body : `${VALID_REVIEW_BODY}\n\n- ${field}: caller-authored`,
+            field
+        }))];
+
+        for (const item of cases) {
+            let graphqlCallCount = 0;
+            GraphqlService.query = async () => {
+                graphqlCallCount++;
+                return pullRequestLookup()
+            };
+
+            const result = await PullRequestService.managePrReview({
+                action   : 'create',
+                pr_number: 15309,
+                state    : item.state,
+                body     : item.body
+            });
+
+            expect(result.code, item.name).toBe('PR_REVIEW_BUDGET_AUDIT_RESERVED');
+            expect(result.reservedReviewBudgetProvenance, item.name).toContain(item.field);
+            expect(graphqlCallCount, item.name).toBe(0)
+        }
+    });
+
+    test('#15309: incidental prose passes while managed CREATE appends one canonical receipt', async () => {
+        let capturedVariables;
+
+        GraphqlService.query = async (queryString, variables) => {
+            if (queryString.includes('GetPullRequestId')) return pullRequestLookup();
+
+            capturedVariables = variables;
+            return {addPullRequestReview: {pullRequestReview: {...REVIEW_NODE, state: 'COMMENTED'}}}
+        };
+
+        const proseResult = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 15309,
+            state    : 'COMMENT',
+            body     : `The strings [review-budget-managed] and "- outcome:" are discussed inline, not supplied as machine fields.\n\n${VALID_REVIEW_BODY}`
+        });
+
+        expect(proseResult.error).toBeUndefined();
+        expect(capturedVariables.event).toBe('COMMENT');
+
+        GraphqlService.query = async (queryString, variables) => {
+            if (queryString.includes('GetPullRequestId')) {
+                return pullRequestLookup({createdAt: '2026-07-16T13:57:04Z'})
+            }
+
+            capturedVariables = variables;
+            return {addPullRequestReview: {pullRequestReview: {...REVIEW_NODE, state: 'CHANGES_REQUESTED'}}}
+        };
+
+        const managedResult = await PullRequestService.managePrReview({
+            action   : 'create',
+            pr_number: 15309,
+            state    : 'REQUEST_CHANGES',
+            body     : VALID_FOLLOWUP_REVIEW_BODY.replace('**Status:** Approved', '**Status:** Request Changes')
+        });
+
+        expect(managedResult.error).toBeUndefined();
+        expect(capturedVariables.body.match(/^\[review-budget-managed\]$/gm)).toHaveLength(1);
+        expect(capturedVariables.body.match(/^\[review-budget-override\]$/gm)).toBeNull()
+    });
+
     test('#15257: post-cutover third ordinary RC is refused across heads, reviewers, and an honest retraction', async () => {
         let   mutationCallCount = 0;
         const reviews           = [
@@ -1195,15 +1288,20 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(lookupVariables.activationIssueNumber).toBe(15257);
     });
 
-    test('#15257: OpenAPI admits the null pre-activation cutover receipt', () => {
+    test('#15257/#15309: OpenAPI documents the cutover receipt and reserved CREATE provenance', () => {
         const openApi = yaml.load(fs.readFileSync(
             path.resolve(process.cwd(), 'ai/mcp/server/github-workflow/openapi.yaml'),
             'utf8'
         ));
-        const activatedAt = openApi.paths['/pulls/{pr_number}/review/manage']
-            .post.responses['200'].content['application/json'].schema
+        const operation   = openApi.paths['/pulls/{pr_number}/review/manage'].post;
+        const bodySchema  = operation.requestBody.content['application/json'].schema.properties.body;
+        const activatedAt = operation.responses['200'].content['application/json'].schema
             .properties.reviewBudget.properties.activatedAt;
 
+        expect(operation.description).toContain('[review-budget-managed]');
+        expect(operation.description).toContain('[review-budget-override]');
+        expect(operation.description).toContain('rejects them before GitHub access');
+        expect(bodySchema.description).toContain('reserved audit-field list entries are rejected');
         expect(activatedAt.type).toBe('string');
         expect(activatedAt.format).toBe('date-time');
         expect(activatedAt.nullable).toBe(true)
@@ -1445,7 +1543,7 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         }
     });
 
-    test('#15257: reason-bearing override is persisted and echoed after RC2', async () => {
+    test('#15257/#15309: reason-bearing override appends one canonical override and managed receipt', async () => {
         let capturedVariables;
 
         GraphqlService.query = async (queryString, variables) => {
@@ -1474,7 +1572,8 @@ test.describe('Neo.ai.services.github-workflow.PullRequestService — managePrRe
         expect(result.error).toBeUndefined();
         expect(result.reviewBudget.outcome).toBe('disclosed-override');
         expect(result.reviewBudget.overrideReason).toContain('release safety exception');
-        expect(capturedVariables.body).toContain('[review-budget-override]');
+        expect(capturedVariables.body.match(/^\[review-budget-override\]$/gm)).toHaveLength(1);
+        expect(capturedVariables.body.match(/^\[review-budget-managed\]$/gm)).toHaveLength(1);
         expect(capturedVariables.body).toContain('- submitted-request-changes: 2');
         expect(capturedVariables.body).toContain('- ordinary-limit: 2');
     });


### PR DESCRIPTION
Resolves #15309

CREATE review bodies can no longer counterfeit service-owned review-budget provenance. `PullRequestService.managePrReview()` now rejects exact managed/override markers and reserved audit-field entries before any GitHub lookup, while preserving the canonical managed and disclosed-override receipt paths. The consumed OpenAPI surface documents the boundary, and the focused suite pins rejection, false-positive avoidance, UPDATE compatibility, and one-receipt success behavior.

Evidence: L2 (stubbed GraphQL dispatch plus exact service/OpenAPI contract tests) → L2 required (all close-target ACs are deterministic service-boundary checks). No residuals.

## Deltas from ticket

None substantive. The implementation reuses the existing audit grammar, returns the ticketed `PR_REVIEW_BUDGET_AUDIT_RESERVED` envelope, and keeps the independent byte-budget lane in `#15308` untouched.

## Test Evidence

- Current-`dev` pre-fix falsifier: caller-seeded override provenance dispatched with `calls: 2`, `managedCount: 1`, `overrideCount: 1`, and `outcome: within-budget`.
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs` — 85 passed.
- `npm run test-unit -- test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` — 162 passed.
- `npm run agent-preflight -- --no-fix ai/services/github-workflow/PullRequestService.mjs ai/mcp/server/github-workflow/openapi.yaml test/playwright/unit/ai/services/github-workflow/PullRequestService.spec.mjs` — all requested gates passed; unrelated stale-overlay warnings only.
- `git diff --check` — passed.

Directly touched surfaces:

- Review CREATE admission: adversarial APPROVED / COMMENT / REQUEST_CHANGES cases prove the stable error and zero GraphQL calls.
- Managed review issuance: ordinary REQUEST_CHANGES and disclosed override each retain exactly one canonical receipt sequence.
- OpenAPI/MCP projection: YAML contract assertions, strict-validator compliance, and real `listTools()` smoke passed.

## Post-Merge Validation

- [ ] Confirm the refreshed GitHub Workflow MCP handbook exposes the reserved CREATE-provenance contract.
- [ ] Observe that the next naturally submitted managed REQUEST_CHANGES review carries exactly one canonical managed receipt.

Authored by Euclid (GPT-5.6 Sol Ultra, Codex). Session 1200dbd1-5159-45be-84c3-b7e323ad4979.
