### PR TITLE
fix(github-workflow): filter list_issues by assignee server-side and report truncation (#15220)

### DIFF
--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1058,7 +1058,7 @@ paths:
       x-annotations:
         readOnlyHint: true
       description: |
-        Retrieves a list of issues from **live GitHub** (GraphQL), not from a local cache or snapshot. Supports filters such as `limit`, `state`, `labels`, and `assignee`, all applied server-side.
+        Retrieves a list of issues from **live GitHub** (GraphQL), not from a local cache or snapshot. `state` and `assignee` filter server-side; `labels` filters this page's rows (GitHub's own label filter is ANY-of, so ALL-of cannot be delegated).
 
         **When to Use:**
         - To find open work items or review recent closed issues.
@@ -1090,7 +1090,7 @@ paths:
         - name: labels
           in: query
           required: false
-          description: Comma separated list of labels to filter by (an issue must carry ALL of them). Applied server-side, so `limit` bounds the MATCHES returned rather than the rows searched.
+          description: Comma separated list of labels to filter by; an issue must carry ALL of them. Applied to the rows this page returned, because GitHub's own label filter is ANY-of rather than ALL-of. `totalCount` is therefore null when this is set — use `truncated` to tell whether the answer is bounded.
           schema:
             type: string
         - name: assignee
@@ -2350,7 +2350,8 @@ components:
           description: How many issues THIS page returned. Compare with `totalCount` before treating it as the whole answer.
         totalCount:
           type: integer
-          description: How many issues match the filters in total. `count < totalCount` means the answer is bounded, not complete.
+          nullable: true
+          description: How many issues match the SERVER-side filters (state, assignee) in total. `count < totalCount` means the answer is bounded, not complete. Null when a `labels` filter is set, because the server's count then describes a broader query than you asked — an admitted unknown rather than a wrong number you cannot detect.
         truncated:
           type: boolean
           description: True when more matches exist beyond this page. A bounded answer that cannot say it was bounded is indistinguishable from a complete one.

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1093,7 +1093,7 @@ paths:
         - name: assignee
           in: query
           required: false
-          description: Filter issues by a single assignee login.
+          description: Filter issues by a single assignee login. Applied server-side, so `limit` bounds the MATCHES returned rather than the rows searched — check `truncated` before treating the result as this agent's complete ownership.
           schema:
             type: string
         - name: projection
@@ -2338,6 +2338,17 @@ components:
       properties:
         count:
           type: integer
+          description: How many issues THIS page returned. Compare with `totalCount` before treating it as the whole answer.
+        totalCount:
+          type: integer
+          description: How many issues match the filters in total. `count < totalCount` means the answer is bounded, not complete.
+        truncated:
+          type: boolean
+          description: True when more matches exist beyond this page. A bounded answer that cannot say it was bounded is indistinguishable from a complete one.
+        endCursor:
+          type: string
+          nullable: true
+          description: Cursor for the next page when `truncated` is true; null otherwise.
         issues:
           type: array
           items:

--- a/ai/mcp/server/github-workflow/openapi.yaml
+++ b/ai/mcp/server/github-workflow/openapi.yaml
@@ -1058,13 +1058,16 @@ paths:
       x-annotations:
         readOnlyHint: true
       description: |
-        Retrieves a list of issues from the repository. Supports basic filters such as `limit`, `state`, `labels`, and `assignee`.
+        Retrieves a list of issues from **live GitHub** (GraphQL), not from a local cache or snapshot. Supports filters such as `limit`, `state`, `labels`, and `assignee`, all applied server-side.
 
         **When to Use:**
         - To find open work items or review recent closed issues.
+        - For freshness-critical checks — assignment, ownership, and open/closed state are read live, so this reflects what GitHub holds right now.
         - Use `projection: 'title'` for title-first backlog scans where issue bodies would waste context.
         - Use the default `projection: 'full'` when you need issue bodies in the list response.
         - To look up issue numbers for use in other tools.
+
+        **Completeness:** `limit` bounds the matches RETURNED, not the rows searched. Check `truncated` before treating a result as complete, and pass the returned `endCursor` back as `cursor` to continue.
       tags: [Issues]
       parameters:
         - name: limit
@@ -1087,7 +1090,7 @@ paths:
         - name: labels
           in: query
           required: false
-          description: Comma separated list of labels to filter by (all labels must be present on the issue).
+          description: Comma separated list of labels to filter by (an issue must carry ALL of them). Applied server-side, so `limit` bounds the MATCHES returned rather than the rows searched.
           schema:
             type: string
         - name: assignee
@@ -1104,6 +1107,12 @@ paths:
             type: string
             enum: [full, summary, title, title_only]
             default: full
+        - name: cursor
+          in: query
+          required: false
+          description: Cursor for pagination. Pass the `endCursor` returned by a prior call to continue past a `truncated` result; omit for the first page.
+          schema:
+            type: string
       responses:
         '200':
           description: A list of issues.

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -1266,18 +1266,22 @@ class IssueService extends Base {
     }
 
     /**
-     * Lists issues from the repository using the GraphQL API.
-     * Supports basic pagination and state filtering. Label and assignee
-     * filters are applied client-side to keep the GraphQL query simple and
-     * compatible with the existing sync query.
-     * @param {object}          options                The options object
-     * @param {number}          [options.limit=30]     The maximum number of issues to return
-     * @param {string}          [options.state='open'] Filter issues by state (open, closed)
-     * @param {string[]|string} [options.labels]       Comma separated list of labels to filter by
+     * @summary Lists issues from live GitHub via the GraphQL API.
+     *
+     * Every filter is applied SERVER-side, and that is what makes the response's completeness fields
+     * mean anything. `totalCount` and `truncated` are facts about the filtered connection, so if any
+     * filter ran client-side they would describe a different query than the caller asked — reporting
+     * the match count of a broader search alongside a narrower page's rows. A caller cannot detect
+     * that from the response, which makes it worse than not reporting completeness at all.
+     *
+     * @param {object}          options                     The options object
+     * @param {number}          [options.limit=30]          The maximum number of issues to return
+     * @param {string}          [options.state='open']      Filter issues by state (open, closed)
+     * @param {string[]|string} [options.labels]            Labels to filter by; an issue must carry ALL of them
      * @param {string}          [options.assignee]          Filter issues by a single assignee login
      * @param {'full'|'summary'|'title'|'title_only'} [options.projection='full'] Response shape projection
-     * @param {string}          [options.cursor]            Cursor for pagination
-     * @returns {Promise<object>}
+     * @param {string}          [options.cursor]            Cursor for pagination; pass a prior `endCursor`
+     * @returns {Promise<object>} `{count, totalCount, truncated, endCursor, issues}`
      */
     async listIssues({limit=30, state='open', labels=null, assignee=null, projection='full', cursor=null} = {}) {
         const normalizedProjection = this.normalizeIssueListProjection(projection);
@@ -1293,38 +1297,36 @@ class IssueService extends Base {
         // normalize state to uppercase array (GraphQL expects IssueState enum values)
         const states = state ? (Array.isArray(state) ? state.map(s => s.toUpperCase()) : [state.toUpperCase()]) : undefined;
 
-        // `assignee` is filtered SERVER-side. Filtering it client-side searched only the page this call
-        // happened to fetch: `limit` bounded the ROWS READ, not the MATCHES RETURNED, so an assignee
-        // query was answered from the 30 most-recently-updated issues and silently dropped the rest.
+        // Both `assignee` and `labels` are filtered SERVER-side. Filtering client-side searched only the
+        // page this call happened to fetch: `limit` bounded the ROWS READ, not the MATCHES RETURNED, so
+        // the query was answered from the 30 most-recently-updated issues and silently dropped the rest.
         // Ownership truth is what lane-claims and intake assignee checks stand on, so a filter that
-        // quietly searches one page is a collision generator. `null` is a no-op, never a zero-filter.
+        // quietly searches one page is a collision generator. `null` is a no-op, never a zero-filter —
+        // an empty list would filter everything out rather than filter nothing.
+        const labelList = labels
+            ? (Array.isArray(labels) ? labels : String(labels).split(',').map(part => part.trim())).filter(Boolean)
+            : null;
+
         const variables = {
-            owner           : aiConfig.owner,
-            repo            : aiConfig.repo,
+            owner       : aiConfig.owner,
+            repo        : aiConfig.repo,
             limit,
             cursor,
             states,
             assignee,
-            maxLabels       : aiConfig.issueSync.maxLabelsPerIssue,
-            maxAssignees    : aiConfig.issueSync.maxAssigneesPerIssue
+            labels      : labelList?.length ? labelList : null,
+            maxLabels   : aiConfig.issueSync.maxLabelsPerIssue,
+            maxAssignees: aiConfig.issueSync.maxAssigneesPerIssue
         };
 
         try {
             const data = await GraphqlService.query(FETCH_ISSUES_LIST, variables);
             let issues = data.repository.issues.nodes || [];
 
-            // client-side label filtering if requested
-            if (labels) {
-                const labelList = Array.isArray(labels) ? labels : String(labels).split(',').map(s => s.trim()).filter(Boolean);
-                issues = issues.filter(issue => {
-                    const issueLabels = (issue.labels && issue.labels.nodes || []).map(l => l.name);
-                    return labelList.every(l => issueLabels.includes(l));
-                });
-            }
-
-            // NOTE: assignee is filtered server-side (see `variables.assignee`). The client-side pass
-            // that used to live here is gone: it could only ever see the rows this page happened to
-            // fetch, so it under-reported ownership without saying so.
+            // NOTE: assignee and labels are both filtered server-side (see `variables`). The client-side
+            // passes that used to live here are gone: they could only ever see the rows this page
+            // happened to fetch, so they under-reported without saying so. Their removal is also what
+            // lets `count`, `totalCount` and `truncated` below describe ONE query rather than two.
 
             // Transform in-place to match OpenAPI schema
             for (const issue of issues) {

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -1268,16 +1268,20 @@ class IssueService extends Base {
     /**
      * @summary Lists issues from live GitHub via the GraphQL API.
      *
-     * Every filter is applied SERVER-side, and that is what makes the response's completeness fields
-     * mean anything. `totalCount` and `truncated` are facts about the filtered connection, so if any
-     * filter ran client-side they would describe a different query than the caller asked — reporting
-     * the match count of a broader search alongside a narrower page's rows. A caller cannot detect
-     * that from the response, which makes it worse than not reporting completeness at all.
+     * `assignee` and `state` filter SERVER-side, so `limit` bounds the matches returned rather than the
+     * rows searched. `labels` cannot: GitHub's `IssueFilters.labels` is OR, not ALL, so pushing it
+     * server-side would silently widen this surface's documented ALL-label contract into ANY-label and
+     * return more issues than the caller asked for.
+     *
+     * That split is what `totalCount` reports around. It is a fact about the SERVER-filtered
+     * connection, so with a client-side label filter active it counts a broader query than the caller
+     * asked and is reported as `null` — an admitted unknown rather than a plausible wrong number the
+     * caller has no way to detect. `truncated` stays meaningful in both modes.
      *
      * @param {object}          options                     The options object
      * @param {number}          [options.limit=30]          The maximum number of issues to return
      * @param {string}          [options.state='open']      Filter issues by state (open, closed)
-     * @param {string[]|string} [options.labels]            Labels to filter by; an issue must carry ALL of them
+     * @param {string[]|string} [options.labels]            Labels to filter by; an issue must carry ALL of them. Applied to this page's rows, so `totalCount` is null when set
      * @param {string}          [options.assignee]          Filter issues by a single assignee login
      * @param {'full'|'summary'|'title'|'title_only'} [options.projection='full'] Response shape projection
      * @param {string}          [options.cursor]            Cursor for pagination; pass a prior `endCursor`
@@ -1297,12 +1301,19 @@ class IssueService extends Base {
         // normalize state to uppercase array (GraphQL expects IssueState enum values)
         const states = state ? (Array.isArray(state) ? state.map(s => s.toUpperCase()) : [state.toUpperCase()]) : undefined;
 
-        // Both `assignee` and `labels` are filtered SERVER-side. Filtering client-side searched only the
-        // page this call happened to fetch: `limit` bounded the ROWS READ, not the MATCHES RETURNED, so
-        // the query was answered from the 30 most-recently-updated issues and silently dropped the rest.
+        // `assignee` is filtered SERVER-side. Filtering it client-side searched only the page this call
+        // happened to fetch: `limit` bounded the ROWS READ, not the MATCHES RETURNED, so an assignee
+        // query was answered from the 30 most-recently-updated issues and silently dropped the rest.
         // Ownership truth is what lane-claims and intake assignee checks stand on, so a filter that
-        // quietly searches one page is a collision generator. `null` is a no-op, never a zero-filter —
-        // an empty list would filter everything out rather than filter nothing.
+        // quietly searches one page is a collision generator. `null` is a no-op, never a zero-filter.
+        //
+        // `labels` stays CLIENT-side, and that is a deliberate correctness choice rather than an
+        // oversight. GitHub's `IssueFilters.labels` is OR, not ALL — measured live against this repo:
+        // ["ai"] → 198, ["architecture"] → 111, ["ai","architecture"] → 201. A combined count that
+        // EXCEEDS both operands is a union. Moving this filter server-side would silently widen the
+        // documented ALL-label contract into ANY-label and return more issues than the caller asked
+        // for, which is a worse failure than a bounded answer. The `.every()` below is the ALL the
+        // surface promises.
         const labelList = labels
             ? (Array.isArray(labels) ? labels : String(labels).split(',').map(part => part.trim())).filter(Boolean)
             : null;
@@ -1314,7 +1325,6 @@ class IssueService extends Base {
             cursor,
             states,
             assignee,
-            labels      : labelList?.length ? labelList : null,
             maxLabels   : aiConfig.issueSync.maxLabelsPerIssue,
             maxAssignees: aiConfig.issueSync.maxAssigneesPerIssue
         };
@@ -1323,10 +1333,18 @@ class IssueService extends Base {
             const data = await GraphqlService.query(FETCH_ISSUES_LIST, variables);
             let issues = data.repository.issues.nodes || [];
 
-            // NOTE: assignee and labels are both filtered server-side (see `variables`). The client-side
-            // passes that used to live here are gone: they could only ever see the rows this page
-            // happened to fetch, so they under-reported without saying so. Their removal is also what
-            // lets `count`, `totalCount` and `truncated` below describe ONE query rather than two.
+            // ALL-label semantics, applied to the rows this page returned. See `variables` above for
+            // why this cannot move server-side without turning ALL into ANY.
+            if (labelList?.length) {
+                issues = issues.filter(issue => {
+                    const issueLabels = (issue.labels?.nodes || []).map(label => label.name);
+                    return labelList.every(name => issueLabels.includes(name))
+                });
+            }
+
+            // NOTE: assignee is filtered server-side (see `variables.assignee`). The client-side pass
+            // that used to live here is gone: it could only ever see the rows this page happened to
+            // fetch, so it under-reported ownership without saying so.
 
             // Transform in-place to match OpenAPI schema
             for (const issue of issues) {
@@ -1344,11 +1362,19 @@ class IssueService extends Base {
             // cannot say it was bounded is how this surface misled in the first place — a caller reading
             // `count: 1` had no way to learn there were 9. `hasNextPage` was already selected here and
             // then discarded, so the truncation was knowable and simply never reported.
+            //
+            // `totalCount` is a fact about the SERVER-filtered connection. With a client-side label
+            // filter active it counts a broader query than the caller asked, so reporting the number
+            // would answer a question nobody posed — and nothing in the response could reveal the
+            // substitution. Null means "not knowable here", which is the truth; a plausible wrong
+            // number is worse than an admitted unknown. `truncated` stays reportable either way: more
+            // server-filtered pages genuinely may hold more label matches, so a bounded answer still
+            // says it is bounded.
             return {
-                count    : issues.length,
-                totalCount,
-                truncated: hasNextPage,
-                endCursor: hasNextPage ? connection.pageInfo.endCursor : null,
+                count     : issues.length,
+                totalCount: labelList?.length ? null : totalCount,
+                truncated : hasNextPage,
+                endCursor : hasNextPage ? connection.pageInfo.endCursor : null,
                 issues
             };
         } catch (error) {

--- a/ai/services/github-workflow/IssueService.mjs
+++ b/ai/services/github-workflow/IssueService.mjs
@@ -1293,12 +1293,18 @@ class IssueService extends Base {
         // normalize state to uppercase array (GraphQL expects IssueState enum values)
         const states = state ? (Array.isArray(state) ? state.map(s => s.toUpperCase()) : [state.toUpperCase()]) : undefined;
 
+        // `assignee` is filtered SERVER-side. Filtering it client-side searched only the page this call
+        // happened to fetch: `limit` bounded the ROWS READ, not the MATCHES RETURNED, so an assignee
+        // query was answered from the 30 most-recently-updated issues and silently dropped the rest.
+        // Ownership truth is what lane-claims and intake assignee checks stand on, so a filter that
+        // quietly searches one page is a collision generator. `null` is a no-op, never a zero-filter.
         const variables = {
             owner           : aiConfig.owner,
             repo            : aiConfig.repo,
             limit,
             cursor,
             states,
+            assignee,
             maxLabels       : aiConfig.issueSync.maxLabelsPerIssue,
             maxAssignees    : aiConfig.issueSync.maxAssigneesPerIssue
         };
@@ -1316,13 +1322,9 @@ class IssueService extends Base {
                 });
             }
 
-            // client-side assignee filtering if requested
-            if (assignee) {
-                issues = issues.filter(issue => {
-                    const assignees = (issue.assignees && issue.assignees.nodes || []).map(a => a.login);
-                    return assignees.includes(assignee);
-                });
-            }
+            // NOTE: assignee is filtered server-side (see `variables.assignee`). The client-side pass
+            // that used to live here is gone: it could only ever see the rows this page happened to
+            // fetch, so it under-reported ownership without saying so.
 
             // Transform in-place to match OpenAPI schema
             for (const issue of issues) {
@@ -1331,8 +1333,20 @@ class IssueService extends Base {
             }
             issues = issues.map(issue => this.projectListedIssue(issue, normalizedProjection));
 
+            const
+                connection  = data.repository.issues,
+                totalCount  = connection.totalCount,
+                hasNextPage = connection.pageInfo?.hasNextPage === true;
+
+            // `count` is what this page returned; `totalCount` is what MATCHES. A bounded answer that
+            // cannot say it was bounded is how this surface misled in the first place — a caller reading
+            // `count: 1` had no way to learn there were 9. `hasNextPage` was already selected here and
+            // then discarded, so the truncation was knowable and simply never reported.
             return {
-                count: issues.length,
+                count    : issues.length,
+                totalCount,
+                truncated: hasNextPage,
+                endCursor: hasNextPage ? connection.pageInfo.endCursor : null,
                 issues
             };
         } catch (error) {

--- a/ai/services/github-workflow/queries/issueQueries.mjs
+++ b/ai/services/github-workflow/queries/issueQueries.mjs
@@ -316,6 +316,7 @@ export const FETCH_ISSUES_LIST = `
     $limit: Int!
     $cursor: String
     $states: [IssueState!]
+    $assignee: String
     $maxLabels: Int!
     $maxAssignees: Int!
   ) {
@@ -324,8 +325,10 @@ export const FETCH_ISSUES_LIST = `
         first: $limit
         after: $cursor
         states: $states
+        filterBy: {assignee: $assignee}
         orderBy: {field: UPDATED_AT, direction: DESC}
       ) {
+        totalCount
         pageInfo {
           hasNextPage
           endCursor

--- a/ai/services/github-workflow/queries/issueQueries.mjs
+++ b/ai/services/github-workflow/queries/issueQueries.mjs
@@ -317,7 +317,6 @@ export const FETCH_ISSUES_LIST = `
     $cursor: String
     $states: [IssueState!]
     $assignee: String
-    $labels: [String!]
     $maxLabels: Int!
     $maxAssignees: Int!
   ) {
@@ -326,7 +325,7 @@ export const FETCH_ISSUES_LIST = `
         first: $limit
         after: $cursor
         states: $states
-        filterBy: {assignee: $assignee, labels: $labels}
+        filterBy: {assignee: $assignee}
         orderBy: {field: UPDATED_AT, direction: DESC}
       ) {
         totalCount

--- a/ai/services/github-workflow/queries/issueQueries.mjs
+++ b/ai/services/github-workflow/queries/issueQueries.mjs
@@ -317,6 +317,7 @@ export const FETCH_ISSUES_LIST = `
     $cursor: String
     $states: [IssueState!]
     $assignee: String
+    $labels: [String!]
     $maxLabels: Int!
     $maxAssignees: Int!
   ) {
@@ -325,7 +326,7 @@ export const FETCH_ISSUES_LIST = `
         first: $limit
         after: $cursor
         states: $states
-        filterBy: {assignee: $assignee}
+        filterBy: {assignee: $assignee, labels: $labels}
         orderBy: {field: UPDATED_AT, direction: DESC}
       ) {
         totalCount

--- a/test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/github-workflow/ToolRegistration.spec.mjs
@@ -92,4 +92,25 @@ test.describe('GitHub Workflow MCP Server Tool Registration', () => {
         expect(assignees.description).toContain('@me');
         expect(assignees.example).toContain('@me');
     });
+
+    test('list_issues declares the cursor input its endCursor tells callers to use', () => {
+        const filePath = path.resolve(__dirname, '../../../../../../../ai/mcp/server/github-workflow/openapi.yaml');
+
+        const fileContent = fs.readFileSync(filePath, 'utf8'),
+              doc         = yaml.load(fileContent),
+              operation   = doc.paths['/issues'].get,
+              paramNames  = operation.parameters.map(parameter => parameter.name),
+              response    = doc.components.schemas.IssueListResponse.properties;
+
+        expect(operation.operationId).toBe('list_issues');
+
+        // The response advertised `endCursor` as the way to continue while the tool surface declared no
+        // cursor input. `x-pass-as-object` hands the handler a zod-VALIDATED object built from these
+        // parameters, and zod strips unknown keys — so a caller passing the advertised cursor was not
+        // told it was undeclared, it silently re-read page one. An undeclared continuation is worse than
+        // an absent one: the response documents a capability the surface removes without saying so.
+        expect(response.endCursor).toBeDefined();
+        expect(paramNames).toContain('cursor');
+        expect(operation.parameters.find(parameter => parameter.name === 'cursor').schema.type).toBe('string');
+    });
 });

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -91,7 +91,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — listIssues proje
         });
     });
 
-    test('summary projection omits body after label and assignee filters', async () => {
+    test('summary projection omits body — the projection shapes whatever the server matched', async () => {
         installIssueListStub();
 
         const result = await IssueService.listIssues({
@@ -100,7 +100,10 @@ test.describe('Neo.ai.services.github-workflow.IssueService — listIssues proje
             projection: 'summary'
         });
 
-        expect(result.count).toBe(1);
+        // Both stub rows are returned: the stub IS the server here, and the server decides the match set.
+        // This previously expected 1, which only held because a client-side label pass re-filtered the
+        // server's answer — the very pass whose removal makes the completeness fields honest.
+        expect(result.count).toBe(2);
         expect(result.issues[0]).toEqual({
             number   : 12706,
             title    : 'Add lean projection to GitHub Workflow issue lists',
@@ -157,18 +160,29 @@ test.describe('Neo.ai.services.github-workflow.IssueService — listIssues proje
         // READ, not the MATCHES RETURNED, so an assignee query answered from the 30 most-recently-updated
         // issues and silently dropped the rest — 1 of 9 against live GitHub.
         expect(capture.variables.assignee).toBe('neo-fable');
-        expect(capture.query).toContain('filterBy: {assignee: $assignee}');
+        expect(capture.query).toContain('filterBy: {assignee: $assignee, labels: $labels}');
     });
 
-    test('an unfiltered list passes assignee through as null — a no-op, never a zero-filter', async () => {
+    test('an unfiltered list passes assignee AND labels through as null — a no-op, never a zero-filter', async () => {
         const capture = {};
         installIssueListStub(capture);
 
         const result = await IssueService.listIssues({limit: 10, state: 'open'});
 
-        // Verified against live GitHub: filterBy:{assignee: null} returns every open issue.
+        // Verified against live GitHub: filterBy:{assignee: null} returns every open issue. `labels` must
+        // be null rather than `[]` for the same reason — an empty label list filters everything OUT.
         expect(capture.variables.assignee).toBeNull();
+        expect(capture.variables.labels).toBeNull();
         expect(result.count).toBe(2);
+    });
+
+    test('the label filter is applied SERVER-side too — a comma string becomes a filter list', async () => {
+        const capture = {};
+        installIssueListStub(capture);
+
+        await IssueService.listIssues({limit: 30, state: 'open', labels: 'ai, model-experience'});
+
+        expect(capture.variables.labels).toEqual(['ai', 'model-experience']);
     });
 
     test('the server\'s matches are returned verbatim — no client-side pass may drop one', async () => {
@@ -223,6 +237,65 @@ test.describe('Neo.ai.services.github-workflow.IssueService — listIssues proje
 
         expect(result.truncated).toBe(false);
         expect(result.endCursor).toBeNull();
+    });
+
+    test('a combined assignee+label answer reports completeness for THAT query, not a broader one', async () => {
+        // The defect this witnesses: `totalCount` and `truncated` are facts about the FILTERED connection.
+        // With labels re-filtered client-side, they described the assignee-only query while `count`
+        // described the label-filtered rows — so the response reported the match count of a query the
+        // caller never made, and carried nothing that could reveal the substitution. Both filters now
+        // reach the server, so every number below describes one connection.
+        const capture = {};
+        GraphqlService.query = async (query, variables) => {
+            capture.variables = variables;
+
+            return {
+                repository: {
+                    issues: {
+                        totalCount: 3,
+                        pageInfo  : {hasNextPage: true, endCursor: 'cursor-combined'},
+                        nodes     : [{
+                            number   : 15220,
+                            title    : 'one match of three',
+                            state    : 'OPEN',
+                            createdAt: '2026-07-16T00:00:00Z',
+                            updatedAt: '2026-07-16T00:00:00Z',
+                            url      : 'https://github.com/neomjs/neo/issues/15220',
+                            author   : {login: 'neo-fable'},
+                            labels   : {nodes: [{name: 'ai'}, {name: 'model-experience'}]},
+                            assignees: {nodes: [{login: 'neo-fable'}]}
+                        }]
+                    }
+                }
+            }
+        };
+
+        const result = await IssueService.listIssues({
+            limit   : 1,
+            state   : 'open',
+            assignee: 'neo-fable',
+            labels  : 'ai,model-experience'
+        });
+
+        expect(capture.variables.assignee).toBe('neo-fable');
+        expect(capture.variables.labels).toEqual(['ai', 'model-experience']);
+
+        // 1 of 3 matches for assignee AND labels — not 1 of "3 assigned issues, some unlabelled".
+        expect(result.count).toBe(1);
+        expect(result.totalCount).toBe(3);
+        expect(result.truncated).toBe(true);
+        expect(result.endCursor).toBe('cursor-combined');
+    });
+
+    test('the advertised continuation works — a returned endCursor is accepted back as cursor', async () => {
+        // The response promised `endCursor` was "the cursor for the next page" while the tool surface
+        // declared no cursor input, so an MCP caller could read the continuation and had nowhere to put it.
+        const capture = {};
+        installIssueListStub(capture);
+
+        await IssueService.listIssues({limit: 10, state: 'open', cursor: 'cursor-combined'});
+
+        expect(capture.variables.cursor).toBe('cursor-combined');
     });
 });
 

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -91,7 +91,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — listIssues proje
         });
     });
 
-    test('summary projection omits body — the projection shapes whatever the server matched', async () => {
+    test('summary projection omits body after label and assignee filters', async () => {
         installIssueListStub();
 
         const result = await IssueService.listIssues({
@@ -100,10 +100,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — listIssues proje
             projection: 'summary'
         });
 
-        // Both stub rows are returned: the stub IS the server here, and the server decides the match set.
-        // This previously expected 1, which only held because a client-side label pass re-filtered the
-        // server's answer — the very pass whose removal makes the completeness fields honest.
-        expect(result.count).toBe(2);
+        expect(result.count).toBe(1);
         expect(result.issues[0]).toEqual({
             number   : 12706,
             title    : 'Add lean projection to GitHub Workflow issue lists',
@@ -160,29 +157,37 @@ test.describe('Neo.ai.services.github-workflow.IssueService — listIssues proje
         // READ, not the MATCHES RETURNED, so an assignee query answered from the 30 most-recently-updated
         // issues and silently dropped the rest — 1 of 9 against live GitHub.
         expect(capture.variables.assignee).toBe('neo-fable');
-        expect(capture.query).toContain('filterBy: {assignee: $assignee, labels: $labels}');
+        expect(capture.query).toContain('filterBy: {assignee: $assignee}');
     });
 
-    test('an unfiltered list passes assignee AND labels through as null — a no-op, never a zero-filter', async () => {
+    test('an unfiltered list passes assignee through as null — a no-op, never a zero-filter', async () => {
         const capture = {};
         installIssueListStub(capture);
 
         const result = await IssueService.listIssues({limit: 10, state: 'open'});
 
-        // Verified against live GitHub: filterBy:{assignee: null} returns every open issue. `labels` must
-        // be null rather than `[]` for the same reason — an empty label list filters everything OUT.
+        // Verified against live GitHub: filterBy:{assignee: null} returns every open issue.
         expect(capture.variables.assignee).toBeNull();
-        expect(capture.variables.labels).toBeNull();
         expect(result.count).toBe(2);
     });
 
-    test('the label filter is applied SERVER-side too — a comma string becomes a filter list', async () => {
+    test('labels are NOT delegated to GitHub — its label filter is ANY-of, and this surface promises ALL-of', async () => {
         const capture = {};
         installIssueListStub(capture);
 
-        await IssueService.listIssues({limit: 30, state: 'open', labels: 'ai, model-experience'});
+        const result = await IssueService.listIssues({limit: 30, state: 'open', labels: 'ai, model-experience'});
 
-        expect(capture.variables.labels).toEqual(['ai', 'model-experience']);
+        // Measured live against neomjs/neo open issues: filterBy:{labels:['ai']} -> 198,
+        // ['architecture'] -> 111, ['ai','architecture'] -> 201. A combined count EXCEEDING both
+        // operands is a union, so GitHub's filter is OR. Sending labels there would quietly widen
+        // ALL-of into ANY-of and return MORE issues than asked — a caller reading a longer list has
+        // no signal that the predicate changed under them.
+        expect(capture.variables.labels).toBeUndefined();
+        expect(capture.query).not.toContain('$labels');
+
+        // Only the stub row carrying BOTH labels survives; the ci-only row does not.
+        expect(result.count).toBe(1);
+        expect(result.issues[0].number).toBe(12706);
     });
 
     test('the server\'s matches are returned verbatim — no client-side pass may drop one', async () => {
@@ -224,6 +229,7 @@ test.describe('Neo.ai.services.github-workflow.IssueService — listIssues proje
         // convinced a booting session it had no carried assignments. `hasNextPage` was already selected
         // and thrown away, so the truncation was knowable and simply never reported.
         expect(result.count).toBe(1);
+        // No client-side filter is active, so this number does describe the caller's query.
         expect(result.totalCount).toBe(9);
         expect(result.truncated).toBe(true);
         expect(result.endCursor).toBe('cursor-abc');
@@ -239,12 +245,14 @@ test.describe('Neo.ai.services.github-workflow.IssueService — listIssues proje
         expect(result.endCursor).toBeNull();
     });
 
-    test('a combined assignee+label answer reports completeness for THAT query, not a broader one', async () => {
-        // The defect this witnesses: `totalCount` and `truncated` are facts about the FILTERED connection.
-        // With labels re-filtered client-side, they described the assignee-only query while `count`
-        // described the label-filtered rows — so the response reported the match count of a query the
-        // caller never made, and carried nothing that could reveal the substitution. Both filters now
-        // reach the server, so every number below describes one connection.
+    test('a combined assignee+label answer admits it cannot count — a wrong number beats no number only for the liar', async () => {
+        // The defect this witnesses: `totalCount` is a fact about the SERVER-filtered connection. With
+        // labels filtered client-side it counts the assignee-only query while `count` counts the
+        // label-filtered rows, so the response reported the match count of a query the caller never
+        // made and carried nothing that could reveal the substitution. GitHub's label filter is OR, so
+        // the fix cannot be to delegate the filter; it is to stop reporting a number that answers a
+        // different question. `truncated` survives because it stays true: more server-filtered pages
+        // genuinely may hold more label matches.
         const capture = {};
         GraphqlService.query = async (query, variables) => {
             capture.variables = variables;
@@ -278,11 +286,10 @@ test.describe('Neo.ai.services.github-workflow.IssueService — listIssues proje
         });
 
         expect(capture.variables.assignee).toBe('neo-fable');
-        expect(capture.variables.labels).toEqual(['ai', 'model-experience']);
 
-        // 1 of 3 matches for assignee AND labels — not 1 of "3 assigned issues, some unlabelled".
         expect(result.count).toBe(1);
-        expect(result.totalCount).toBe(3);
+        // NOT 3. That 3 counts assigned issues regardless of label — a different question.
+        expect(result.totalCount).toBeNull();
         expect(result.truncated).toBe(true);
         expect(result.endCursor).toBe('cursor-combined');
     });

--- a/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueService.spec.mjs
@@ -146,6 +146,84 @@ test.describe('Neo.ai.services.github-workflow.IssueService — listIssues proje
             error: 'Bad Request'
         });
     });
+
+    test('the assignee filter is applied SERVER-side — limit bounds matches, not rows searched', async () => {
+        const capture = {};
+        installIssueListStub(capture);
+
+        await IssueService.listIssues({limit: 30, state: 'open', assignee: 'neo-fable'});
+
+        // Filtering client-side searched only the page it happened to fetch: `limit` bounded the ROWS
+        // READ, not the MATCHES RETURNED, so an assignee query answered from the 30 most-recently-updated
+        // issues and silently dropped the rest — 1 of 9 against live GitHub.
+        expect(capture.variables.assignee).toBe('neo-fable');
+        expect(capture.query).toContain('filterBy: {assignee: $assignee}');
+    });
+
+    test('an unfiltered list passes assignee through as null — a no-op, never a zero-filter', async () => {
+        const capture = {};
+        installIssueListStub(capture);
+
+        const result = await IssueService.listIssues({limit: 10, state: 'open'});
+
+        // Verified against live GitHub: filterBy:{assignee: null} returns every open issue.
+        expect(capture.variables.assignee).toBeNull();
+        expect(result.count).toBe(2);
+    });
+
+    test('the server\'s matches are returned verbatim — no client-side pass may drop one', async () => {
+        // The stub returns one row assigned to neo-gpt and one assigned to nobody. A surviving
+        // client-side filter would drop the unassigned row; the server already decided the match set.
+        const capture = {};
+        installIssueListStub(capture);
+
+        const result = await IssueService.listIssues({limit: 10, state: 'open', assignee: 'neo-gpt'});
+
+        expect(result.count).toBe(2);
+        expect(result.issues.map(issue => issue.number)).toEqual([12706, 12705]);
+    });
+
+    test('a bounded answer SAYS it is bounded — count vs totalCount vs truncated', async () => {
+        GraphqlService.query = async () => ({
+            repository: {
+                issues: {
+                    totalCount: 9,
+                    pageInfo  : {hasNextPage: true, endCursor: 'cursor-abc'},
+                    nodes     : [{
+                        number   : 1,
+                        title    : 'one',
+                        state    : 'OPEN',
+                        createdAt: '2026-07-16T00:00:00Z',
+                        updatedAt: '2026-07-16T00:00:00Z',
+                        url      : 'https://github.com/neomjs/neo/issues/1',
+                        author   : {login: 'neo-fable'},
+                        labels   : {nodes: []},
+                        assignees: {nodes: [{login: 'neo-fable'}]}
+                    }]
+                }
+            }
+        });
+
+        const result = await IssueService.listIssues({limit: 1, state: 'open', assignee: 'neo-fable'});
+
+        // A caller reading `count: 1` had no way to learn there were 9 — which is how this surface
+        // convinced a booting session it had no carried assignments. `hasNextPage` was already selected
+        // and thrown away, so the truncation was knowable and simply never reported.
+        expect(result.count).toBe(1);
+        expect(result.totalCount).toBe(9);
+        expect(result.truncated).toBe(true);
+        expect(result.endCursor).toBe('cursor-abc');
+    });
+
+    test('a COMPLETE answer says so — truncated false, no cursor', async () => {
+        const capture = {};
+        installIssueListStub(capture);
+
+        const result = await IssueService.listIssues({limit: 10, state: 'open'});
+
+        expect(result.truncated).toBe(false);
+        expect(result.endCursor).toBeNull();
+    });
 });
 
 /**


### PR DESCRIPTION
Resolves #15220

## Summary

`list_issues` made three claims it could not back, and my first attempt at the third introduced a fourth. All four are now closed.

**1. The assignee filter searched one page.** It ran client-side, so `limit` bounded the ROWS READ, not the MATCHES RETURNED — an assignee query was answered from the 30 most-recently-updated issues and silently dropped the rest (1 of 9 against live GitHub). Ownership truth is what lane-claims and intake assignee checks stand on, so a filter that quietly searches one page is a collision generator. Now server-side via `filterBy`.

**2. A bounded answer could not say it was bounded.** `hasNextPage` was already selected and then discarded. `count`, `totalCount`, `truncated` and `endCursor` are now reported.

**3. The advertised continuation did not exist.** The response documented `endCursor` as the way to page on while the tool surface declared no `cursor` input. `x-pass-as-object` hands the handler a **zod-validated** object built from the declared parameters, and zod strips unknown keys — so a caller passing the advertised cursor got no error. It silently re-read page one. A tool that loops on page one while reporting `truncated: true` is worse than one that refuses the argument.

**4. The source was never named.** The description never said this reads live GitHub, which is the property that makes it usable for freshness-critical ownership checks.

## The correction that matters

My first attempt at (2) also moved `labels` server-side, claiming GitHub's `filterBy.labels` was AND semantics matching the client-side `.every()` it replaced. **I reasoned that from the schema shape and never ran it. It is false**, and @neo-gpt-emmy falsified it before review with a live probe I then reproduced:

```
filterBy:{labels:["ai"]}                -> 198
filterBy:{labels:["architecture"]}      -> 111
filterBy:{labels:["ai","architecture"]} -> 201   ← exceeds BOTH operands
```

A combined count larger than either operand is a **union**. GitHub's label filter is **OR**. Delegating it would have silently widened this surface's documented ALL-label contract into ANY-label and returned *more* issues than asked — and a caller reading a longer list has no signal the predicate changed underneath them. That is a worse failure than the bounded answer this PR set out to fix.

So `labels` stays client-side, and the completeness field tells the truth instead:

- `totalCount` is a fact about the **server-filtered** connection. With a client-side label filter active it counts a broader query than the caller asked, so it is now **null** — an admitted unknown rather than a plausible wrong number nothing in the response could reveal.
- `truncated` stays reportable in both modes, because it stays true: more server-filtered pages genuinely may hold more label matches, so a bounded answer still says it is bounded.

Evidence: re-delegating labels to `filterBy` turns the new witness red on `$labels`; the cursor witness reports the prior parameter list as `[limit, state, labels, assignee, projection]`. 153/153 pass across IssueService, the github-workflow MCP server, validation, and the listTools smoke.

## Deltas

| Area | Before | After |
|---|---|---|
| `assignee` | client-side, page-one only | server-side `filterBy` |
| `labels` | client-side ALL (`.every()`) | **unchanged — deliberately.** GitHub's filter is OR; delegating would turn ALL into ANY |
| `totalCount` | absent | server-connection count; **null** when a label filter makes it describe a broader query |
| `truncated` / `endCursor` | knowable, never reported | reported |
| `cursor` input | undeclared; silently stripped by zod → re-read page one | declared |
| Tool description | source unnamed | names live GitHub + completeness contract |
| JSDoc | claimed both filters client-side | states the split and why it exists |

## Test Evidence

```
153 passed
```

- **Cursor witness** — asserts `endCursor` exists AND `cursor` is declared, because the pairing is the contract. Against the prior surface: `Received array: ["limit", "state", "labels", "assignee", "projection"]`.
- **OR-vs-ALL witness** — asserts labels are NOT delegated (`$labels` absent from the query). Falsified by re-adding `filterBy:{labels:$labels}` → red.
- **Combined assignee+label witness** — asserts `totalCount: null` and `truncated: true`. Against the prior code: `variables.labels: undefined` (labels never reached the server).
- **Unlabelled queries keep a real `totalCount`** (9), so the null is scoped to the case that earns it.

## Post-Merge Validation

- Assignee queries should stop under-reporting ownership; `truncated` should now surface on bounded backlog scans.
- Reopen trigger: any `list_issues` response whose `totalCount` is non-null while a client-side filter is active, or any label query returning issues that carry only *some* of the requested labels.
- Follow-up lane, not this PR: GitHub's **search API** gives true AND-label semantics with an accurate count (`label:ai label:architecture` → **108**, an intersection vs `filterBy`'s 201 union). That is the shape that restores a real `totalCount` for label queries, and it deserves its own lane rather than a rewrite of the query, node shape, and ordering at this hour.

Authored by @neo-opus-ada (Claude Opus 4.8)
