### PR TITLE
test(agentos): repair native Fleet drill E2E witnesses (#15212)

### DIFF
--- a/test/playwright/e2e/agentos/FleetCockpitDrillNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitDrillNL.spec.mjs
@@ -1,23 +1,22 @@
 import {test, expect} from '../../fixtures.mjs';
 
 /**
- * @summary The FM cockpit card→detail drill, proven LIVE over the REAL DOM click — the basic
- * "live drill" the detail-view AC requires. A click on a resident card (the avatar is the
- * always-sized, non-control region the whole-card domListener catches) reveals the auto-hidden
- * AgentDetail inspector and renders THAT resident: the whole chain — domListener → onCardSelect →
- * `agentSelect` → cockpit `onAgentSelect` → owner-held `detailRecord` → dock `setItemAutoHidden`
- * reveal → projection — is exercised end-to-end, never via a controller call. Whitebox: the DOM
- * proves the render, the possessed component proves the engine truth (the mounted inspector holds
- * the clicked resident's record).
+ * @summary The FM cockpit card→detail drill, proven LIVE over the dedicated native drill Button —
+ * the basic "live drill" the detail-view AC requires. Activating one resident's name Button reveals
+ * the auto-hidden AgentDetail inspector and renders THAT resident: the whole chain — native DOM
+ * click → `onCardSelect` → `agentSelect` → cockpit `onAgentSelect` → owner-held `detailRecord`
+ * → dock `setItemAutoHidden` reveal → projection — is exercised end-to-end, never via a
+ * controller call. Whitebox: the DOM proves the render, the possessed component proves the engine
+ * truth (the mounted inspector holds the activated resident's record).
  *
  * @see apps/agentos/view/fleet/AgentDetail.mjs
  * @see apps/agentos/view/fleet/FleetCockpitController.mjs (onAgentSelect)
  * @see test/playwright/e2e/agentos/FleetActivityStreamBurstNL.spec.mjs (sibling possession pattern)
  */
-test.describe('AgentOS fleet cockpit — card→detail live drill over the real DOM click (#14608)', () => {
+test.describe('AgentOS fleet cockpit — native Button→detail live drill (#14608, #15212)', () => {
     test.setTimeout(90000);
 
-    test('a card click reveals the AgentDetail inspector rendering that agent + its four panes', async ({page, neuralLink}) => {
+    test('a resident drill Button reveals the AgentDetail inspector rendering that agent + its four panes', async ({page, neuralLink}) => {
         await page.goto('/apps/agentos/index.html');
         await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
         await expect(page.locator('.fm-agent-card').first()).toBeVisible({timeout: 30000});
@@ -26,17 +25,17 @@ test.describe('AgentOS fleet cockpit — card→detail live drill over the real 
               cards = await app.queryComponent({className: 'AgentOS.view.fleet.AgentCard'}, ['record', 'id']);
         expect(cards.length, 'the fleet should render cards with records').toBeGreaterThan(0);
 
-        // pin ONE specific card and derive its EXACT durable identity + its DOM element id (=== the
-        // component id) — so the click and the assertion reference the same resident, not the set.
+        // Pin ONE specific card and derive its EXACT durable identity + DOM element id (=== the
+        // component id) — so activation and assertion reference the same resident, not the set.
         const target = cards.find(entry => entry?.properties?.record?.agentId && entry?.properties?.id);
         expect(target, 'a card exposes both a record agentId and a component id').toBeTruthy();
 
         const expectedAgentId = target.properties.record.agentId,
               targetCardId    = target.properties.id;
 
-        // the REAL DOM click — on THAT card's always-sized avatar (a non-control region the whole-card
-        // domListener catches; the flex body can render narrow), addressed by the card's own element id
-        await page.locator(`[id="${targetCardId}"] .fm-card-avatar`).click();
+        // The REAL DOM click targets THAT card's dedicated native drill Button. The non-interactive
+        // listitem/card and its avatar deliberately do not own activation after native-button convergence.
+        await page.locator(`[id="${targetCardId}"] .fm-card-drill`).click();
 
         // the auto-hidden inspector reveals + renders a resident + the four SSOT panes
         const detail = page.locator('.fm-agent-detail');
@@ -44,9 +43,9 @@ test.describe('AgentOS fleet cockpit — card→detail live drill over the real 
         await expect(detail.locator('.fm-detail-name')).not.toBeEmpty();
         await expect(detail.locator('.fm-detail-pane')).toHaveCount(4);
 
-        // engine truth: the mounted inspector holds the EXACT clicked resident — equality, not
-        // set-membership. The click routed through the owner-held selection to the exact durable id.
+        // Engine truth: the mounted inspector holds the EXACT activated resident — equality, not
+        // set-membership. The Button routed through owner-held selection to the exact durable id.
         const [d] = await app.queryComponent({className: 'AgentOS.view.fleet.AgentDetail'}, ['record']);
-        expect(d?.properties?.record?.agentId, 'the inspector drilled into the exact clicked resident').toBe(expectedAgentId)
+        expect(d?.properties?.record?.agentId, 'the inspector drilled into the exact activated resident').toBe(expectedAgentId)
     })
 });

--- a/test/playwright/e2e/agentos/FleetCockpitDrillNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitDrillNL.spec.mjs
@@ -21,9 +21,13 @@ test.describe('AgentOS fleet cockpit — native Button→detail live drill (#146
         await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
         await expect(page.locator('.fm-agent-card').first()).toBeVisible({timeout: 30000});
 
-        const app   = await neuralLink.connectToApp('AgentOS'),
-              cards = await app.queryComponent({className: 'AgentOS.view.fleet.AgentCard'}, ['record', 'id']);
+        const
+            app       = await neuralLink.connectToApp('AgentOS'),
+            cards     = await app.queryComponent({className: 'AgentOS.view.fleet.AgentCard'}, ['record', 'id']),
+            [cockpit] = await app.queryComponent({className: 'AgentOS.view.fleet.FleetCockpit'}, ['id']);
+
         expect(cards.length, 'the fleet should render cards with records').toBeGreaterThan(0);
+        expect(cockpit?.properties?.id, 'the cockpit should expose its committed dock document').toBeTruthy();
 
         // Pin ONE specific card and derive its EXACT durable identity + DOM element id (=== the
         // component id) — so activation and assertion reference the same resident, not the set.
@@ -33,15 +37,33 @@ test.describe('AgentOS fleet cockpit — native Button→detail live drill (#146
         const expectedAgentId = target.properties.record.agentId,
               targetCardId    = target.properties.id;
 
-        // The REAL DOM click targets THAT card's dedicated native drill Button. The non-interactive
-        // listitem/card and its avatar deliberately do not own activation after native-button convergence.
+        const
+            detail        = page.locator('.fm-agent-detail'),
+            readDockModel = async () => (await app.getComponent(cockpit.properties.id, ['dockModel'])).dockModel,
+            dockBefore    = await readDockModel();
+
+        expect(dockBefore.items.detail.autoHidden, 'the Fleet preset starts with detail auto-hidden').toBe(true);
+
+        // Negative boundary: the avatar/listitem is inert. A redundant whole-card click listener would
+        // keep the positive Button journey green while silently restoring mouse-only activation, so pin
+        // the committed dock document byte-for-byte before exercising the dedicated control.
+        await page.locator(`[id="${targetCardId}"] .fm-card-avatar`).click();
+        await page.waitForTimeout(250); // allow a wrongly-restored main→worker click route to commit
+
+        const dockAfterAvatar = await readDockModel();
+        expect(dockAfterAvatar, 'avatar activation must not mutate the committed dock document').toEqual(dockBefore);
+        await expect(detail, 'avatar activation must not reveal the inspector').not.toBeVisible();
+
+        // The positive REAL DOM click targets THAT card's dedicated native drill Button.
         await page.locator(`[id="${targetCardId}"] .fm-card-drill`).click();
 
         // the auto-hidden inspector reveals + renders a resident + the four SSOT panes
-        const detail = page.locator('.fm-agent-detail');
         await expect(detail).toBeVisible({timeout: 15000});
         await expect(detail.locator('.fm-detail-name')).not.toBeEmpty();
         await expect(detail.locator('.fm-detail-pane')).toHaveCount(4);
+
+        const dockAfterDrill = await readDockModel();
+        expect(dockAfterDrill.items.detail.autoHidden, 'the dedicated Button must commit the reveal').toBe(false);
 
         // Engine truth: the mounted inspector holds the EXACT activated resident — equality, not
         // set-membership. The Button routed through owner-held selection to the exact durable id.

--- a/test/playwright/e2e/agentos/FleetGridKeyboardA11y.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetGridKeyboardA11y.spec.mjs
@@ -1,5 +1,81 @@
-import {test, expect}                                       from '../../fixtures.mjs';
-import {NeuralLink_DataService, NeuralLink_InstanceService} from '../../../../ai/services.mjs';
+import {test, expect}           from '../../fixtures.mjs';
+import {NeuralLink_DataService} from '../../../../ai/services.mjs';
+
+const KEYBOARD_SOURCES = {
+    roster    : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
+    repoStatus: {source: 'fleet:fleetStatus',   state: 'wired', confidence: 'observed'},
+    runtime   : {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}
+};
+
+/**
+ * @summary Build one production-shaped Fleet roster DTO row for the keyboard witness.
+ * @param {Object} row Stable identity/display fields.
+ * @returns {Object}
+ */
+function createKeyboardRosterRow(row) {
+    return {
+        ...row,
+        avatarUrl: '',
+        lifecycle: {source: KEYBOARD_SOURCES.runtime.source, state: 'running', confidence: 'observed'},
+        sources  : KEYBOARD_SOURCES
+    }
+}
+
+const KEYBOARD_ROSTER_ROWS = [
+    {id: 'a11y-b', displayName: 'Bravo',   engineTag: 'fixture', family: 'claude'},
+    {id: 'a11y-c', displayName: 'Charlie', engineTag: 'fixture', family: 'claude'},
+    {id: 'a11y-d', displayName: 'Delta',   engineTag: 'fixture', family: 'claude'}
+].map(createKeyboardRosterRow);
+
+/**
+ * @summary Start a test-owned Fleet bridge which serves three wired residents, records lifecycle
+ * requests, and rejects Stop. The app still exercises its production `installFleetBridge` /
+ * `createFleetRegistryBridge` client. A deterministic rejection keeps the card-local status visible
+ * without a success-driven roster refresh, making lifecycle intent evidence observable without
+ * inferring from transient UI.
+ * @returns {Promise<{close: Function, requests: Object[], setRosterRows: Function}>}
+ */
+async function startRejectingFleetBridge() {
+    const
+        {startFleetBridgeServer} = await import('../../../../ai/services/fleet/fleetBridgeServer.mjs'),
+        requests                 = [];
+
+    let rosterRows = KEYBOARD_ROSTER_ROWS;
+
+    const
+        server                   = await startFleetBridgeServer({
+            port    : 8083,
+            dispatch: async request => {
+                requests.push(request);
+
+                if (request.method === 'stopAgent') {
+                    return {ok: false, error: 'fleet: stop rejected by keyboard witness'}
+                }
+
+                if (request.method === 'fleetRoster') {
+                    return {ok: true, result: {rows: rosterRows}}
+                }
+
+                if (request.method === 'fleetActivity') {
+                    return {
+                        ok    : true,
+                        result: {
+                            capability: {source: 'fleet:test', state: 'wired', confidence: 'observed'},
+                            events    : []
+                        }
+                    }
+                }
+
+                return {ok: false, error: `fleet: unexpected keyboard-witness method '${request.method}'`}
+            }
+        });
+
+    return {
+        requests,
+        close        : () => new Promise(resolve => server.close(resolve)),
+        setRosterRows: rows => rosterRows = rows
+    }
+}
 
 /**
  * @summary The FM cockpit keyboard-a11y contract proven on the MOUNTED grid via Neural Link possession —
@@ -7,9 +83,10 @@ import {NeuralLink_DataService, NeuralLink_InstanceService} from '../../../../ai
  * `role=list` owner of NON-interactive `role=listitem` cards, each with a dedicated native drill
  * `<button>` (the resident name) + sibling lifecycle Buttons in ordinary Tab order. This spec EXECUTES —
  * not merely infers — every claimed path: native Enter AND Space activation on the drill; a lifecycle
- * Button that fires its intent WITHOUT drilling; the optional drill-only Up/Down jump with zero page
- * scroll; and gate-3 focus continuity restoring the resident's EXACT semantic child (drill AND toggle)
- * across an index-shifting rebuild. Zero uncaught page errors throughout.
+ * Button that fires its intent WITHOUT drilling (proven by a test-owned recording/rejecting Fleet
+ * loopback); the optional drill-only Up/Down jump with zero page scroll; and gate-3 focus continuity
+ * restoring the resident's EXACT semantic child (drill AND toggle) across an index-shifting rebuild.
+ * Zero uncaught page errors throughout.
  *
  * @see apps/agentos/view/fleet/AgentCard.mjs
  * @see apps/agentos/view/fleet/FleetGrid.mjs
@@ -18,6 +95,16 @@ import {NeuralLink_DataService, NeuralLink_InstanceService} from '../../../../ai
 test.describe('AgentOS fleet grid — keyboard a11y (native list/listitem + drill Button, Neural Link, #14619)', () => {
     test.setTimeout(90000);
 
+    let fleet;
+
+    test.beforeEach(async () => {
+        fleet = await startRejectingFleetBridge()
+    });
+
+    test.afterEach(async () => {
+        await fleet?.close()
+    });
+
     test('list/listitem topology + native drill Enter/Space + lifecycle isolation + drill jump + gate-3 restoration (drill AND toggle)', async ({page, neuralLink}) => {
         const pageErrors = [];
         page.on('pageerror', err => pageErrors.push(err.message));
@@ -25,34 +112,28 @@ test.describe('AgentOS fleet grid — keyboard a11y (native list/listitem + dril
         await page.goto('/apps/agentos/index.html');
         await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
         await expect(page.locator('.fm-fleet-grid')).toBeVisible({timeout: 30000});
-        await expect(page.locator('.fm-fleet-title')).not.toHaveText('Fleet · 0 agents', {timeout: 30000});
+        // The production fleetRoster read path, backed by the test-owned loopback, must replace the
+        // sample roster with the three deterministic residents before any keyboard claim.
+        await expect(page.locator('.fm-fleet-title')).toHaveText('Fleet · 3 agents', {timeout: 30000});
 
         const
             app       = await neuralLink.connectToApp('AgentOS'),
             sessionId = app.sessionId,
-            stores    = await NeuralLink_DataService.listStores({sessionId}),
-            roster    = stores.stores.find(candidate => candidate.model === 'AgentOS.model.FleetAgent');
+            [grid]    = await app.queryComponent({className: 'AgentOS.view.fleet.FleetGrid'}, ['id']),
+            [cockpit] = await app.queryComponent({className: 'AgentOS.view.fleet.FleetCockpit'}, ['id']);
 
-        expect(roster, 'the provider-hosted FleetRoster store should be registered').toBeTruthy();
+        expect(grid, 'the mounted FleetGrid should be possessable').toBeTruthy();
+        expect(cockpit, 'the mounted FleetCockpit should own roster reconciliation').toBeTruthy();
 
-        // three ONLINE cards with DISTINCT names so identity is provable across a rebuild (sorted by
-        // agentId → Bravo, Charlie, Delta)
-        // wired sources so the lifecycle Buttons are ENABLED (focusable — gate-3 can restore focus to a
-        // control) AND the control-status starts HIDDEN, so its appearance after a lifecycle activation
-        // proves the emitted INTENT rendered, not a not-wired source banner.
-        const wired = {
-            roster    : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
-            repoStatus: {source: 'fleet:fleetStatus',   state: 'wired', confidence: 'observed'},
-            runtime   : {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}
-        };
-        const fixture = [
-            {agentId: 'a11y-b', state: 'ok', displayName: 'Bravo',   engineTag: 'fixture', family: 'claude', laneLine: 'kbd fixture', avatarUrl: '', sources: wired},
-            {agentId: 'a11y-c', state: 'ok', displayName: 'Charlie', engineTag: 'fixture', family: 'claude', laneLine: 'kbd fixture', avatarUrl: '', sources: wired},
-            {agentId: 'a11y-d', state: 'ok', displayName: 'Delta',   engineTag: 'fixture', family: 'claude', laneLine: 'kbd fixture', avatarUrl: '', sources: wired}
-        ];
+        const
+            cockpitId = cockpit.properties.id,
+            gridState = await app.getComponent(grid.properties.id, ['store.id']),
+            rosterId  = gridState['store.id'];
 
-        await NeuralLink_InstanceService.callMethod({sessionId, id: roster.id, method: 'clear'});
-        await NeuralLink_InstanceService.callMethod({sessionId, id: roster.id, method: 'add', args: [fixture]});
+        expect(rosterId, 'the mounted FleetGrid should expose its exact bound FleetRoster store').toBeTruthy();
+
+        const seeded = await NeuralLink_DataService.inspectStore({sessionId, storeId: rosterId, limit: 10});
+        expect(seeded.count, 'the grid-bound roster should hold the three loopback residents').toBe(3);
 
         const cards  = page.locator('.fm-fleet-cards .fm-agent-card');
         const drills = page.locator('.fm-fleet-cards .fm-agent-card .fm-card-drill');
@@ -67,7 +148,9 @@ test.describe('AgentOS fleet grid — keyboard a11y (native list/listitem + dril
         // the drill is a dedicated NATIVE <button>; the toggle is a SEPARATE native <button> (Tab isolation)
         expect(await drills.nth(0).evaluate(el => el.tagName)).toBe('BUTTON');
         await expect(drills.nth(0)).toContainText('Bravo');
-        const bravoToggle = cards.nth(0).locator('.fm-card-control-verbs button').first();
+        const
+            bravoCard   = cards.filter({has: page.locator('.fm-card-drill', {hasText: 'Bravo'})}),
+            bravoToggle = bravoCard.locator('.fm-card-control-verbs button').first();
         expect(await bravoToggle.evaluate(el => el.tagName)).toBe('BUTTON');
 
         // ── NATIVE drill activation — BOTH Enter AND Space (native <button> semantics) ──
@@ -87,45 +170,50 @@ test.describe('AgentOS fleet grid — keyboard a11y (native list/listitem + dril
         expect(await page.evaluate(() => window.scrollY)).toBe(scrollBefore);
 
         // ── LIFECYCLE ISOLATION: activating a control Button fires its lifecycle intent WITHOUT drilling ──
-        // Bravo is 'ok' → its toggle is the STOP verb; activating it must NOT switch the detail pane (no
-        // drill leakage), and the emitted intent → Lane-C round-trip renders a control-status on Bravo's
-        // card (the visible proof the intent was emitted + handled, not swallowed into a drill).
+        // Bravo is 'ok' → its toggle is the STOP verb. The test-owned bridge records exactly one
+        // minimal stop request and rejects it with a named reason; the detail must stay on Charlie
+        // (no drill leakage), while Bravo renders the honest terminal rejection.
         await bravoToggle.focus();
         expect(await page.evaluate(() => !!document.activeElement?.closest?.('.fm-card-control-verbs'))).toBe(true);
         await page.keyboard.press('Enter');
+        await expect.poll(
+            () => fleet.requests.filter(request => ['startAgent', 'stopAgent', 'restartAgent'].includes(request.method)),
+            {message: 'the lifecycle Button should emit exactly one minimal Stop request'}
+        ).toEqual([{method: 'stopAgent', params: 'a11y-b'}]);
         await expect(page.locator('.fm-agent-detail')).toContainText('Charlie'); // no drill leakage — still Charlie
-        await expect(cards.nth(0).locator('.fm-card-control-status')).toBeVisible({timeout: 10000});
+        await expect(bravoCard.locator('.fm-card-control-status')).toContainText(
+            '⚠ rejected: fleet: stop rejected by keyboard witness',
+            {timeout: 10000}
+        );
 
         // ── gate-3 focus continuity across an index-shifting rebuild — for BOTH drill AND a lifecycle control ──
         // (a) DRILL: focus Charlie's drill, add a joiner that sorts above → focus follows Charlie's drill
-        await drills.nth(1).focus();
+        const
+            charlieCard  = cards.filter({has: page.locator('.fm-card-drill', {hasText: 'Charlie'})}),
+            charlieDrill = charlieCard.locator('.fm-card-drill');
+
+        await charlieDrill.focus();
         await page.waitForTimeout(500); // let focusin reach the App-Worker (containsFocus) before the rebuild
-        await NeuralLink_InstanceService.callMethod({sessionId, id: roster.id, method: 'add', args: [[
-            {agentId: 'a11y-a', state: 'ok', displayName: 'Alpha', engineTag: 'fixture', family: 'claude', laneLine: 'joiner', avatarUrl: '', sources: wired}
-        ]]});
+        const alpha = createKeyboardRosterRow({id: 'a11y-a', displayName: 'Alpha', engineTag: 'fixture', family: 'claude'});
+        fleet.setRosterRows([...KEYBOARD_ROSTER_ROWS, alpha]);
+        await app.callMethod(cockpitId, 'loadRoster');
         await expect(cards).toHaveCount(4);
-        await expect.poll(async () => page.evaluate(() => document.activeElement?.textContent)).toContain('Charlie');
-        expect(await page.evaluate(() => document.activeElement?.classList?.contains('fm-card-drill'))).toBe(true);
+        await expect(charlieDrill).toBeFocused();
 
         // (b) TOGGLE: focus Charlie's TOGGLE, add another joiner → focus follows Charlie's TOGGLE (the exact
         // semantic child, NOT the drill) — proves gate-3 restores the specific control, not just the drill
-        const charlieCard   = cards.filter({has: page.locator('.fm-card-drill', {hasText: 'Charlie'})});
         const charlieToggle = charlieCard.locator('.fm-card-control-verbs button').first();
         await charlieToggle.focus();
         // let the focusin propagate to the App-Worker (manager.Focus → containsFocus) BEFORE the rebuild:
         // gate-3 reads worker-side containsFocus, which lags the synchronous DOM focus by one main↔worker
         // hop. A real async roster rebuild never races freshly-set focus this tightly; the wait models that.
         await page.waitForTimeout(500);
-        await NeuralLink_InstanceService.callMethod({sessionId, id: roster.id, method: 'add', args: [[
-            {agentId: 'a11y-0', state: 'ok', displayName: 'Zero', engineTag: 'fixture', family: 'claude', laneLine: 'joiner2', avatarUrl: '', sources: wired}
-        ]]});
+        const zero = createKeyboardRosterRow({id: 'a11y-0', displayName: 'Zero', engineTag: 'fixture', family: 'claude'});
+        fleet.setRosterRows([...KEYBOARD_ROSTER_ROWS, alpha, zero]);
+        await app.callMethod(cockpitId, 'loadRoster');
         await expect(cards).toHaveCount(5);
-        // focus landed on a control-verb Button INSIDE Charlie's card (not the drill, not <body>)
-        await expect.poll(async () => page.evaluate(() => {
-            const el = document.activeElement;
-            return el?.closest?.('.fm-agent-card')?.querySelector('.fm-card-drill')?.textContent ?? null;
-        })).toContain('Charlie');
-        expect(await page.evaluate(() => !!document.activeElement?.closest?.('.fm-card-control-verbs'))).toBe(true);
+        // Focus landed on Charlie's exact toggle (not merely some control, the drill, or <body>).
+        await expect(charlieToggle).toBeFocused();
 
         expect(pageErrors, 'no uncaught page errors during the keyboard journey').toEqual([])
     })


### PR DESCRIPTION
Resolves #15212

Related: #14619
Related: #15094

Repairs the two stale Fleet cockpit Whitebox witnesses without changing production interaction semantics. The drill journey first proves the resident avatar leaves the committed dock document byte-identical and the inspector hidden, then activates the exact mounted resident's native drill Button and possesses that resident in `AgentDetail`. The keyboard journey runs against a test-owned Fleet loopback which proves one minimal rejected Stop request, no drill leakage, and both focus-restoration rebuilds through the production roster reconciliation path.

Evidence: L3 (browser-rendered Chromium interactions plus Neural Link engine/store possession) → L3 required (all close-target runtime and accessibility ACs). No residuals.

## Deltas from ticket

- The original regression premise was superseded during intake: the retired avatar/body activation and persistent-success-status assumptions belonged to the pre-native-Button witness, not current production behavior.
- The native-button boundary is pinned in both directions: avatar activation cannot mutate `dockModel` or reveal detail, while the dedicated Button must commit the reveal.
- The deterministic loopback owns a mutable roster source. Index-shifting focus rebuilds update that source and invoke `FleetCockpit.loadRoster()`, preserving the live roster's sole-writer contract instead of mutating the Store behind it.
- Production `AgentCard`, `AgentCardController`, Fleet lifecycle, and dock-projection files remain unchanged.

## Test Evidence

- Final avatar-inert + native-Button drill boundary: `NEO_E2E_PORT=8227 NEO_TEST_SKIP_CI=true npm run test-e2e -- test/playwright/e2e/agentos/FleetCockpitDrillNL.spec.mjs --workers=1` — 1 passed (4.4s).
- Fleet keyboard/accessibility surface: `NEO_E2E_PORT=8221 NEO_TEST_SKIP_CI=true npm run test-e2e -- test/playwright/e2e/agentos/FleetGridKeyboardA11y.spec.mjs --workers=1` — 1 passed.
- Final paired run: `NEO_E2E_PORT=8222 NEO_TEST_SKIP_CI=true npm run test-e2e -- test/playwright/e2e/agentos/FleetCockpitDrillNL.spec.mjs test/playwright/e2e/agentos/FleetGridKeyboardA11y.spec.mjs --workers=1` — 2 passed.
- Agent preflight: check-only source + PR-body validation — all requested gates passed.

## Post-Merge Validation

- [ ] Re-run the paired Fleet Whitebox witnesses after the next `dev` integration batch.

## Evolution

Fresh falsification rejected the initial whole-card-listener repair: it would have reintroduced competing activation authority around the native drill and lifecycle Buttons. The final repair instead updates only the stale witnesses. A second falsifier showed that direct Store mutation is no longer the correct rebuild seam once the test-owned live roster is authoritative, so the journey now changes that source and exercises the production reconciliation writer.

Authored by Euclid (OpenAI GPT-5.6 Sol Ultra, Codex Desktop). Session 019f6120-ef4d-79f0-83f5-43e6d27f36f5.
