### PR TITLE
fix(github-workflow): repair PR archive index drift and divergent duplicate artifacts (#15130)

### DIFF
--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -1,15 +1,15 @@
-import aiConfig        from '../../mcp/server/github-workflow/config.mjs';
-import Base            from '../../../src/core/Base.mjs';
-import logger          from '../../mcp/server/github-workflow/logger.mjs';
-import HealthService   from './HealthService.mjs';
-import IssueSyncer     from './sync/IssueSyncer.mjs';
-import MetadataManager from './sync/MetadataManager.mjs';
+import aiConfig           from '../../mcp/server/github-workflow/config.mjs';
+import Base               from '../../../src/core/Base.mjs';
+import logger             from '../../mcp/server/github-workflow/logger.mjs';
+import HealthService      from './HealthService.mjs';
+import IssueSyncer        from './sync/IssueSyncer.mjs';
+import MetadataManager    from './sync/MetadataManager.mjs';
 import ReleaseNotesSyncer from './sync/ReleaseNotesSyncer.mjs';
-import DiscussionSyncer from './sync/DiscussionSyncer.mjs';
-import PullRequestSyncer from './sync/PullRequestSyncer.mjs';
-import RepositoryService from './RepositoryService.mjs';
-import {exec} from 'child_process';
-import {promisify} from 'util';
+import DiscussionSyncer   from './sync/DiscussionSyncer.mjs';
+import PullRequestSyncer  from './sync/PullRequestSyncer.mjs';
+import RepositoryService  from './RepositoryService.mjs';
+import {exec}             from 'child_process';
+import {promisify}        from 'util';
 
 const execAsync = promisify(exec);
 
@@ -161,6 +161,15 @@ class SyncService extends Base {
         // 7. Sync pull requests
         const pullStats2 = await PullRequestSyncer.syncPullRequests(metadata);
 
+        // 7b. Realign `_index.json` with the pull corpus now that placement is final for this run.
+        //     Preventing new drift does not remove old drift: entries that went stale when a move
+        //     did not carry its upsert name files that are ALREADY archived, so the relocate pass
+        //     never revisits them and the delta sync never fetches them — no existing mechanism
+        //     could ever have healed them. The index is a projection of the corpus, so this
+        //     recomputes it from disk. Idempotent and silent on a healthy corpus (it upserts only
+        //     entries that disagree), so the generated-content diff stays empty when nothing drifted.
+        const pullIndexStats = await PullRequestSyncer.reconcilePullRequestIndex();
+
         // 8. Self-heal push failures: If a previously failed issue was successfully pulled, remove it from the failure list
         if (newMetadata.pushFailures?.length > 0) {
             newMetadata.pushFailures = newMetadata.pushFailures.filter(failedId => !newMetadata.issues[failedId]);
@@ -197,7 +206,8 @@ class SyncService extends Base {
             pullStats,
             releaseStats,
             discussionStats,
-            pullStats2
+            pullStats2,
+            pullIndexStats
         };
     }
 
@@ -225,7 +235,7 @@ class SyncService extends Base {
         logger.info('[SyncService] Detected real content changes. Committing and pushing.');
         await this.execGit(`git add ${generatedSyncStatusPaths}`, cwd);
         const {stdout: stagedStdout} = await this.execGit('git diff --cached --name-only', cwd);
-        const nonSyncFiles = stagedStdout.trim().split('\n').filter(Boolean).filter(file =>
+        const nonSyncFiles           = stagedStdout.trim().split('\n').filter(Boolean).filter(file =>
             !isGeneratedSyncFile(file)
         );
 
@@ -275,7 +285,7 @@ class SyncService extends Base {
      */
     async autoPushGeneratedContent({rerunEmission, maxAttempts = 2}) {
         if (aiConfig.pushToRepoAfterSync) {
-            const {permission} = await RepositoryService.getViewerPermission();
+            const {permission}     = await RepositoryService.getViewerPermission();
             const writePermissions = ['ADMIN', 'MAINTAIN', 'WRITE'];
 
             if (writePermissions.includes(permission)) {
@@ -316,7 +326,7 @@ class SyncService extends Base {
      */
     async runFullSync() {
         const startTime = new Date();
-        let syncStats   = await this.emitGeneratedContentAndDerive();
+        let   syncStats = await this.emitGeneratedContentAndDerive();
 
         await this.autoPushGeneratedContent({
             rerunEmission: async () => {

--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -161,6 +161,13 @@ class SyncService extends Base {
         // 7. Sync pull requests
         const pullStats2 = await PullRequestSyncer.syncPullRequests(metadata);
 
+        // 7a. Restore any pull request owning more than one artifact from canonical GitHub state.
+        //     A divergent pair cannot be resolved locally — both files are real renderings and
+        //     nothing on disk says which is current — so neither is trusted and the artifact is
+        //     re-derived from the source of truth. Runs BEFORE the index realign so the restored
+        //     placement is what gets indexed, and is a no-op on a corpus with no duplicates.
+        const pullDuplicateStats = await PullRequestSyncer.repairDuplicateArtifacts(metadata);
+
         // 7b. Realign `_index.json` with the pull corpus now that placement is final for this run.
         //     Preventing new drift does not remove old drift: entries that went stale when a move
         //     did not carry its upsert name files that are ALREADY archived, so the relocate pass
@@ -207,6 +214,7 @@ class SyncService extends Base {
             releaseStats,
             discussionStats,
             pullStats2,
+            pullDuplicateStats,
             pullIndexStats
         };
     }

--- a/ai/services/github-workflow/SyncService.mjs
+++ b/ai/services/github-workflow/SyncService.mjs
@@ -1,15 +1,16 @@
-import aiConfig           from '../../mcp/server/github-workflow/config.mjs';
-import Base               from '../../../src/core/Base.mjs';
-import logger             from '../../mcp/server/github-workflow/logger.mjs';
-import HealthService      from './HealthService.mjs';
-import IssueSyncer        from './sync/IssueSyncer.mjs';
-import MetadataManager    from './sync/MetadataManager.mjs';
-import ReleaseNotesSyncer from './sync/ReleaseNotesSyncer.mjs';
-import DiscussionSyncer   from './sync/DiscussionSyncer.mjs';
-import PullRequestSyncer  from './sync/PullRequestSyncer.mjs';
-import RepositoryService  from './RepositoryService.mjs';
-import {exec}             from 'child_process';
-import {promisify}        from 'util';
+import aiConfig                from '../../mcp/server/github-workflow/config.mjs';
+import Base                    from '../../../src/core/Base.mjs';
+import logger                  from '../../mcp/server/github-workflow/logger.mjs';
+import HealthService           from './HealthService.mjs';
+import IssueSyncer             from './sync/IssueSyncer.mjs';
+import MetadataManager         from './sync/MetadataManager.mjs';
+import ReleaseNotesSyncer      from './sync/ReleaseNotesSyncer.mjs';
+import DiscussionSyncer        from './sync/DiscussionSyncer.mjs';
+import PullRequestSyncer       from './sync/PullRequestSyncer.mjs';
+import RepositoryService       from './RepositoryService.mjs';
+import {formatIntegrityReport} from './shared/contentInventory.mjs';
+import {exec}                  from 'child_process';
+import {promisify}             from 'util';
 
 const execAsync = promisify(exec);
 
@@ -177,6 +178,30 @@ class SyncService extends Base {
         //     entries that disagree), so the generated-content diff stays empty when nothing drifted.
         const pullIndexStats = await PullRequestSyncer.reconcilePullRequestIndex();
 
+        // 7c. One terminal integrity verdict, CONSUMED. Every pass above reports its own outcome and
+        //     degrades softly on its own terms, which is exactly how a corpus reaches the commit with
+        //     each step reporting success and the whole known-broken: a repair that fails logs and
+        //     returns, an unrepaired duplicate stays unindexed, and nothing downstream asks. So the
+        //     verdict is taken AFTER placement, restoration and projection are final, and it aborts —
+        //     before the metadata save, before the derive, before the auto-push. Committing a corpus
+        //     we have already measured as broken is worse than failing the run: the run can be
+        //     retried, but a generated commit is what every consumer then reads as truth.
+        const pullIntegrity = await PullRequestSyncer.verifyCorpusIntegrity();
+
+        if (pullDuplicateStats.failed.length > 0 || !pullIntegrity.ok) {
+            logger.error(formatIntegrityReport(pullIntegrity));
+
+            throw new Error(
+                'Pull corpus integrity is not clean after repair — refusing to commit generated content. ' +
+                `stale=${pullIntegrity.staleIndexEntries.length} ` +
+                `inconsistent=${pullIntegrity.inconsistentIndexEntries.length} ` +
+                `duplicateIndexRows=${pullIntegrity.duplicateIndexEntryIds.length} ` +
+                `unindexed=${pullIntegrity.unindexedIds.length} ` +
+                `divergentDuplicates=${pullIntegrity.divergentDuplicateIds.length} ` +
+                `failedRepairs=${pullDuplicateStats.failed.length}`
+            );
+        }
+
         // 8. Self-heal push failures: If a previously failed issue was successfully pulled, remove it from the failure list
         if (newMetadata.pushFailures?.length > 0) {
             newMetadata.pushFailures = newMetadata.pushFailures.filter(failedId => !newMetadata.issues[failedId]);
@@ -215,7 +240,8 @@ class SyncService extends Base {
             discussionStats,
             pullStats2,
             pullDuplicateStats,
-            pullIndexStats
+            pullIndexStats,
+            pullIntegrity
         };
     }
 

--- a/ai/services/github-workflow/shared/contentIndex.mjs
+++ b/ai/services/github-workflow/shared/contentIndex.mjs
@@ -1,6 +1,6 @@
-import fs                                                                           from 'fs-extra';
-import path                                                                         from 'path';
-import {chunkNumberFor, DEFAULT_ITEMS_PER_CHUNK, parseContentPath, validateSegment} from './contentPath.mjs';
+import fs                                                                                                  from 'fs-extra';
+import path                                                                                                from 'path';
+import {chunkNumberFor, DEFAULT_ITEMS_PER_CHUNK, parseContentPath, pathSegmentOptionsFor, validateSegment} from './contentPath.mjs';
 
 export const CONTENT_INDEX_FILENAME = '_index.json';
 
@@ -182,7 +182,7 @@ export function createContentIndexEntry(config = {}) {
 export function createContentIndexEntryFromPath(config = {}) {
     const {issueSyncConfig, type, id, filePath} = config,
           contentRoot                           = contentRootFor(issueSyncConfig),
-          parsed                                = parseContentPath({contentRoot, filePath});
+          parsed                                = parseContentPath({contentRoot, filePath, ...pathSegmentOptionsFor(issueSyncConfig)});
 
     if (!parsed) {
         throw new TypeError(`filePath is not a chunked content path under the content root: ${filePath}`);

--- a/ai/services/github-workflow/shared/contentIndex.mjs
+++ b/ai/services/github-workflow/shared/contentIndex.mjs
@@ -1,15 +1,15 @@
-import fs   from 'fs-extra';
-import path from 'path';
-import {chunkNumberFor, DEFAULT_ITEMS_PER_CHUNK, validateSegment} from './contentPath.mjs';
+import fs                                                                           from 'fs-extra';
+import path                                                                         from 'path';
+import {chunkNumberFor, DEFAULT_ITEMS_PER_CHUNK, parseContentPath, validateSegment} from './contentPath.mjs';
 
 export const CONTENT_INDEX_FILENAME = '_index.json';
 
 /**
  * @summary Resolves the root directory that owns `resources/content/_index.json`.
  *
- * ADR 0004 makes the index a sibling of the active type directories and the archive root.
- * The GitHub workflow config currently exposes per-type paths, so this helper derives the
- * common root from `issuesDir` without adding another config surface.
+ * The index is a sibling of the active type directories and the archive root. The GitHub workflow
+ * config currently exposes per-type paths, so this helper derives the common root from `issuesDir`
+ * without adding another config surface.
  *
  * @param {Object} issueSyncConfig GitHub workflow `issueSync` config block
  * @returns {String}
@@ -80,8 +80,9 @@ export async function writeContentIndex(issueSyncConfig = {}, entries = []) {
 /**
  * @summary Applies upsert/remove mutations to the content index in one read/write pass.
  *
- * Syncers call this after determining their final target paths. Entries are keyed by
- * `{type, id}` because ADR 0004 permits exactly one current lookup target for each GitHub item.
+ * Syncers call this after determining their final target paths. Entries are keyed by `{type, id}`
+ * because each GitHub item has exactly one current lookup target — an upsert for an id therefore
+ * replaces its predecessor rather than accumulating a second entry.
  *
  * @param {Object} issueSyncConfig GitHub workflow `issueSync` config block
  * @param {Object} mutations
@@ -139,7 +140,7 @@ export function createContentIndexEntry(config = {}) {
         itemsPerChunk = DEFAULT_ITEMS_PER_CHUNK
     } = config;
 
-    const contentRoot = contentRootFor(issueSyncConfig);
+    const contentRoot  = contentRootFor(issueSyncConfig);
     const relativePath = path.relative(contentRoot, filePath);
 
     return normalizeContentIndexEntry({
@@ -153,6 +154,54 @@ export function createContentIndexEntry(config = {}) {
 }
 
 /**
+ * @summary Creates a normalized index entry describing where a file ACTUALLY is.
+ *
+ * The sibling of {@link createContentIndexEntry}, and the safer of the two. That one takes an
+ * `itemIndex` and derives the chunk from it, so the entry records the ordinal a planner *chose*.
+ * When a later pass relocates the file, the entry keeps naming the old location and the lookup rots
+ * — the mechanism behind thousands of index entries pointing at paths that no longer exist. This one
+ * reads the coordinates back out of the written path, so the entry cannot disagree with the
+ * filesystem it was derived from.
+ *
+ * Use this at every site that has already decided the final path — moves especially. Prefer
+ * {@link createContentIndexEntry} only where the ordinal is the thing being computed and the write
+ * follows from it.
+ *
+ * Throws on a path that is not chunked content: a caller reaching here has just written or renamed a
+ * file, so an unparseable path means the write went somewhere unintended. Returning null would let
+ * the move stand with no index entry at all, which is the very drift being repaired.
+ *
+ * @param {Object} config
+ * @param {Object} config.issueSyncConfig GitHub workflow `issueSync` config block
+ * @param {'issues'|'pulls'|'discussions'|'release-notes'} config.type Content type
+ * @param {Number|String} config.id GitHub ID or semver identifier
+ * @param {String} config.filePath Absolute path the file now occupies
+ * @returns {Object}
+ * @throws {TypeError} When `filePath` is not a chunked content path under the content root
+ */
+export function createContentIndexEntryFromPath(config = {}) {
+    const {issueSyncConfig, type, id, filePath} = config,
+          contentRoot                           = contentRootFor(issueSyncConfig),
+          parsed                                = parseContentPath({contentRoot, filePath});
+
+    if (!parsed) {
+        throw new TypeError(`filePath is not a chunked content path under the content root: ${filePath}`);
+    }
+
+    const entry = {
+        type,
+        id,
+        version    : parsed.version,
+        chunkNumber: parsed.chunkNumber,
+        path       : path.relative(path.resolve(contentRoot), path.resolve(contentRoot, filePath))
+    };
+
+    if (parsed.bucket) entry.bucket = parsed.bucket;
+
+    return normalizeContentIndexEntry(entry);
+}
+
+/**
  * @summary Resolves an indexed path and rejects entries that escape the content root.
  * @param {Object} issueSyncConfig GitHub workflow `issueSync` config block
  * @param {Object} entry Content index entry
@@ -161,9 +210,9 @@ export function createContentIndexEntry(config = {}) {
 export function resolveIndexedPath(issueSyncConfig = {}, entry = {}) {
     validateSegment(entry.path, 'path', {allowPath: true});
 
-    const contentRoot = path.resolve(contentRootFor(issueSyncConfig));
+    const contentRoot  = path.resolve(contentRootFor(issueSyncConfig));
     const absolutePath = path.resolve(contentRoot, entry.path);
-    const relative = path.relative(contentRoot, absolutePath);
+    const relative     = path.relative(contentRoot, absolutePath);
 
     if (relative.startsWith('..') || path.isAbsolute(relative)) {
         throw new TypeError('indexed path must stay within the content root');
@@ -217,8 +266,8 @@ function sortContentIndex(entries = []) {
             const typeCompare = a.type.localeCompare(b.type);
             if (typeCompare) return typeCompare;
 
-            const aId = Number(a.id);
-            const bId = Number(b.id);
+            const aId       = Number(a.id);
+            const bId       = Number(b.id);
             const idCompare = Number.isFinite(aId) && Number.isFinite(bId)
                 ? aId - bId
                 : `${a.id}`.localeCompare(`${b.id}`);

--- a/ai/services/github-workflow/shared/contentInventory.mjs
+++ b/ai/services/github-workflow/shared/contentInventory.mjs
@@ -1,8 +1,8 @@
-import {existsSync}                       from 'fs';
-import fs                                 from 'fs/promises';
-import path                               from 'path';
-import {parseContentPath}                 from './contentPath.mjs';
-import {readContentIndex, contentRootFor} from './contentIndex.mjs';
+import {existsSync}                              from 'fs';
+import fs                                        from 'fs/promises';
+import path                                      from 'path';
+import {parseContentPath, pathSegmentOptionsFor} from './contentPath.mjs';
+import {readContentIndex, contentRootFor}        from './contentIndex.mjs';
 
 /**
  * @module ai/services/github-workflow/shared/contentInventory
@@ -40,6 +40,9 @@ import {readContentIndex, contentRootFor} from './contentIndex.mjs';
  */
 export async function buildContentInventory(issueSyncConfig = {}, {type, filePrefix} = {}) {
     const contentRoot = contentRootFor(issueSyncConfig),
+          // The segment vocabularies are configured, not universal — a hardcoded parse agrees with
+          // the default and diverges silently under any override.
+          segments    = pathSegmentOptionsFor(issueSyncConfig),
           idPattern   = new RegExp(`(?:^|[\\\\/])${filePrefix}(\\d+)\\.md$`),
           inventory   = new Map();
 
@@ -52,7 +55,7 @@ export async function buildContentInventory(issueSyncConfig = {}, {type, filePre
             if (!match) continue;
 
             const absPath = path.join(root, rel),
-                  parsed  = parseContentPath({contentRoot, filePath: absPath});
+                  parsed  = parseContentPath({contentRoot, filePath: absPath, ...segments});
 
             // A file whose path does not parse is off-contract (wrong depth, no chunk dir). Record
             // it with null coordinates rather than skipping: an unparseable artifact is exactly the
@@ -132,6 +135,7 @@ export function resolveArchivedLocation(inventory, id) {
  */
 export async function validateContentIntegrity(issueSyncConfig = {}, {type, filePrefix, inventory} = {}) {
     const contentRoot = contentRootFor(issueSyncConfig),
+          segments    = pathSegmentOptionsFor(issueSyncConfig),
           corpus      = inventory || await buildContentInventory(issueSyncConfig, {type, filePrefix}),
           indexed     = (await readContentIndex(issueSyncConfig)).filter(entry => entry.type === type);
 
@@ -149,7 +153,7 @@ export async function validateContentIntegrity(issueSyncConfig = {}, {type, file
         // entry then names a real file and still lies about where it sits, which every check that
         // only tests path existence will pass. Compared against the path the entry itself carries,
         // so this needs no filesystem opinion beyond the file being there.
-        const parsed = parseContentPath({contentRoot, filePath: entry.path});
+        const parsed = parseContentPath({contentRoot, filePath: entry.path, ...segments});
 
         if (!parsed || parsed.chunkNumber !== entry.chunkNumber || (parsed.version ?? null) !== (entry.version ?? null)) {
             inconsistentIndexEntries.push({

--- a/ai/services/github-workflow/shared/contentInventory.mjs
+++ b/ai/services/github-workflow/shared/contentInventory.mjs
@@ -1,0 +1,197 @@
+import {existsSync}                       from 'fs';
+import fs                                 from 'fs/promises';
+import path                               from 'path';
+import {parseContentPath}                 from './contentPath.mjs';
+import {readContentIndex, contentRootFor} from './contentIndex.mjs';
+
+/**
+ * @module ai/services/github-workflow/shared/contentInventory
+ * @summary The complete on-disk corpus for a content type, and the integrity verdict over it.
+ *
+ * **Why this exists.** The syncers plan placement from `metadata.{type}` plus the current delta
+ * fetch. Both are partial by design — the delta sync rebuilds its cache from each run's fetch — so a
+ * planner reading only those sees a fraction of a bucket and computes an ordinal against it. An
+ * ordinal derived from a partial collection is not a smaller truth, it is a different number: the
+ * item lands in a chunk that the complete ordering would never have chosen, beside the copy that is
+ * already there. The corpus on disk is the only complete membership that exists, because the files
+ * outlive every cache that describes them.
+ *
+ * **What "complete" costs.** A full scan of both tiers, per type, per sync. That is the price of
+ * planning against reality; the alternative is a cache that must never drift, which is the thing
+ * that already failed.
+ *
+ * @see ai/services/github-workflow/shared/contentPath.mjs (the path math, both directions)
+ * @see learn/agentos/decisions/0004-github-content-architecture.md (sealed archive + index contract)
+ */
+
+/**
+ * @summary Scans the complete corpus for one content type — active tier plus every archive bucket.
+ *
+ * Keyed by GitHub id. The value is an **array**, not a single entry, because "one artifact per id"
+ * is the invariant under test rather than an assumption this helper may make: a Map<id, entry> would
+ * silently drop the second copy and report a clean corpus, which is precisely the blindness that let
+ * divergent duplicates accumulate unnoticed.
+ *
+ * @param {Object} issueSyncConfig GitHub workflow `issueSync` config block
+ * @param {Object} options
+ * @param {'issues'|'pulls'|'discussions'} options.type Content type segment
+ * @param {String} options.filePrefix File-leaf prefix (e.g. `'pr-'`, `'issue-'`)
+ * @returns {Promise<Map<Number, Array<{absPath: String, version: String|null, bucket: String|null, chunkNumber: Number}>>>}
+ */
+export async function buildContentInventory(issueSyncConfig = {}, {type, filePrefix} = {}) {
+    const contentRoot = contentRootFor(issueSyncConfig),
+          idPattern   = new RegExp(`(?:^|[\\\\/])${filePrefix}(\\d+)\\.md$`),
+          inventory   = new Map();
+
+    const scan = async root => {
+        if (!existsSync(root)) return;
+
+        for (const rel of await fs.readdir(root, {recursive: true})) {
+            const match = rel.match(idPattern);
+
+            if (!match) continue;
+
+            const absPath = path.join(root, rel),
+                  parsed  = parseContentPath({contentRoot, filePath: absPath});
+
+            // A file whose path does not parse is off-contract (wrong depth, no chunk dir). Record
+            // it with null coordinates rather than skipping: an unparseable artifact is exactly the
+            // kind of thing an integrity pass must surface, and dropping it here would hide it.
+            const id = parseInt(match[1], 10);
+
+            if (!inventory.has(id)) inventory.set(id, []);
+
+            inventory.get(id).push({
+                absPath,
+                version    : parsed?.version     ?? null,
+                bucket     : parsed?.bucket      ?? null,
+                chunkNumber: parsed?.chunkNumber ?? null
+            });
+        }
+    };
+
+    await scan(path.join(contentRoot, type));
+    await scan(path.join(contentRoot, 'archive', type));
+
+    // Stable ordering so a duplicate's "first" copy is deterministic across platforms — callers
+    // reporting a divergent pair must name the same two files on every machine.
+    for (const copies of inventory.values()) {
+        copies.sort((a, b) => a.absPath.localeCompare(b.absPath));
+    }
+
+    return inventory;
+}
+
+/**
+ * @summary Resolves the single archived artifact for an id, or reports why there isn't one.
+ *
+ * The placement rule this serves: a terminal item that already owns exactly one archived artifact
+ * keeps it. That is the sealed-archive semantic expressed as a lookup — and it is also what stops a
+ * second copy appearing, since a refresh writes to the location the item already occupies instead of
+ * to a freshly recomputed one.
+ *
+ * Ambiguity is returned, never resolved. Two artifacts for one id means the corpus is already
+ * corrupt; picking one here would launder that corruption into a confident answer.
+ *
+ * @param {Map<Number, Array<Object>>} inventory Output of {@link buildContentInventory}
+ * @param {Number} id GitHub identifier
+ * @returns {{status: 'none'|'unique'|'ambiguous', entry: Object|null, copies: Array<Object>}}
+ */
+export function resolveArchivedLocation(inventory, id) {
+    const copies   = (inventory.get(id) || []).filter(copy => copy.version || copy.bucket),
+          statuses = {0: 'none', 1: 'unique'};
+
+    return {
+        status: statuses[copies.length] || 'ambiguous',
+        entry : copies.length === 1 ? copies[0] : null,
+        copies
+    };
+}
+
+/**
+ * @summary Proves — or refutes — that the corpus and `_index.json` agree, and that each id owns one artifact.
+ *
+ * Reports counts alongside every finding. A verdict of "zero stale entries" is only meaningful next
+ * to the number of entries actually examined: a probe aimed at the wrong shape returns zero for
+ * every question, and a clean-looking zero from a blind instrument is indistinguishable from health.
+ * `indexedTotal` and `corpusTotal` are the positive controls that make the zeros legible.
+ *
+ * Duplicates split by content because the two classes have different repairs. Byte-identical copies
+ * are one artifact written twice and may be collapsed deterministically. Byte-divergent copies are
+ * two different renderings of one PR, and nothing on disk says which is current — `reconcileActiveChunks`'
+ * keep-first dedup is safe in the active tier only because the next sync rewrites the survivor from
+ * GitHub; applied to a sealed archive it would silently canonicalise an arbitrary copy. So divergence
+ * is reported for repair from source, never resolved by position.
+ *
+ * @param {Object} issueSyncConfig GitHub workflow `issueSync` config block
+ * @param {Object} options
+ * @param {'issues'|'pulls'|'discussions'} options.type Content type segment
+ * @param {String} options.filePrefix File-leaf prefix (e.g. `'pr-'`)
+ * @param {Map<Number, Array<Object>>} [options.inventory] Pre-built inventory; scanned when omitted
+ * @returns {Promise<{type: String, ok: Boolean, indexedTotal: Number, corpusTotal: Number, uniqueIds: Number, staleIndexEntries: Array<Object>, unindexedIds: Array<Number>, identicalDuplicateIds: Array<Number>, divergentDuplicateIds: Array<Number>}>}
+ */
+export async function validateContentIntegrity(issueSyncConfig = {}, {type, filePrefix, inventory} = {}) {
+    const contentRoot = contentRootFor(issueSyncConfig),
+          corpus      = inventory || await buildContentInventory(issueSyncConfig, {type, filePrefix}),
+          indexed     = (await readContentIndex(issueSyncConfig)).filter(entry => entry.type === type);
+
+    const staleIndexEntries = [];
+
+    for (const entry of indexed) {
+        if (!existsSync(path.resolve(contentRoot, entry.path))) staleIndexEntries.push(entry);
+    }
+
+    const indexedIds   = new Set(indexed.map(entry => Number(entry.id))),
+          unindexedIds = [...corpus.keys()].filter(id => !indexedIds.has(id));
+
+    const identicalDuplicateIds = [],
+          divergentDuplicateIds = [];
+
+    let corpusTotal = 0;
+
+    for (const [id, copies] of corpus) {
+        corpusTotal += copies.length;
+
+        if (copies.length < 2) continue;
+
+        const contents = await Promise.all(copies.map(copy => fs.readFile(copy.absPath)));
+
+        contents.every(buffer => buffer.equals(contents[0]))
+            ? identicalDuplicateIds.push(id)
+            : divergentDuplicateIds.push(id);
+    }
+
+    return {
+        type,
+        ok          : staleIndexEntries.length === 0 && unindexedIds.length === 0 &&
+                      identicalDuplicateIds.length === 0 && divergentDuplicateIds.length === 0,
+        indexedTotal: indexed.length,
+        corpusTotal,
+        uniqueIds   : corpus.size,
+        staleIndexEntries,
+        unindexedIds,
+        identicalDuplicateIds,
+        divergentDuplicateIds
+    };
+}
+
+/**
+ * @summary Renders an integrity result as a human-readable report.
+ * @param {Object} result Output of {@link validateContentIntegrity}
+ * @returns {String}
+ */
+export function formatIntegrityReport(result = {}) {
+    const lines = [
+        `content integrity — ${result.type}`,
+        `  indexed entries      : ${result.indexedTotal}`,
+        `  corpus artifacts     : ${result.corpusTotal}`,
+        `  unique ids           : ${result.uniqueIds}`,
+        `  stale indexed paths  : ${result.staleIndexEntries?.length ?? 0}`,
+        `  unindexed artifacts  : ${result.unindexedIds?.length ?? 0}`,
+        `  identical duplicates : ${result.identicalDuplicateIds?.length ?? 0}`,
+        `  divergent duplicates : ${result.divergentDuplicateIds?.length ?? 0}`,
+        `  verdict              : ${result.ok ? 'PASS' : 'FAIL'}`
+    ];
+
+    return lines.join('\n');
+}

--- a/ai/services/github-workflow/shared/contentInventory.mjs
+++ b/ai/services/github-workflow/shared/contentInventory.mjs
@@ -128,17 +128,35 @@ export function resolveArchivedLocation(inventory, id) {
  * @param {'issues'|'pulls'|'discussions'} options.type Content type segment
  * @param {String} options.filePrefix File-leaf prefix (e.g. `'pr-'`)
  * @param {Map<Number, Array<Object>>} [options.inventory] Pre-built inventory; scanned when omitted
- * @returns {Promise<{type: String, ok: Boolean, indexedTotal: Number, corpusTotal: Number, uniqueIds: Number, staleIndexEntries: Array<Object>, unindexedIds: Array<Number>, identicalDuplicateIds: Array<Number>, divergentDuplicateIds: Array<Number>}>}
+ * @returns {Promise<{type: String, ok: Boolean, indexedTotal: Number, corpusTotal: Number, uniqueIds: Number, staleIndexEntries: Array<Object>, inconsistentIndexEntries: Array<Object>, unindexedIds: Array<Number>, identicalDuplicateIds: Array<Number>, divergentDuplicateIds: Array<Number>}>}
  */
 export async function validateContentIntegrity(issueSyncConfig = {}, {type, filePrefix, inventory} = {}) {
     const contentRoot = contentRootFor(issueSyncConfig),
           corpus      = inventory || await buildContentInventory(issueSyncConfig, {type, filePrefix}),
           indexed     = (await readContentIndex(issueSyncConfig)).filter(entry => entry.type === type);
 
-    const staleIndexEntries = [];
+    const staleIndexEntries        = [],
+          inconsistentIndexEntries = [];
 
     for (const entry of indexed) {
-        if (!existsSync(path.resolve(contentRoot, entry.path))) staleIndexEntries.push(entry);
+        if (!existsSync(path.resolve(contentRoot, entry.path))) {
+            staleIndexEntries.push(entry);
+            continue;
+        }
+
+        // An entry's coordinates must agree with its own path. They can drift apart whenever the
+        // chunk is derived from a planned ordinal while the file is written somewhere else — the
+        // entry then names a real file and still lies about where it sits, which every check that
+        // only tests path existence will pass. Compared against the path the entry itself carries,
+        // so this needs no filesystem opinion beyond the file being there.
+        const parsed = parseContentPath({contentRoot, filePath: entry.path});
+
+        if (!parsed || parsed.chunkNumber !== entry.chunkNumber || (parsed.version ?? null) !== (entry.version ?? null)) {
+            inconsistentIndexEntries.push({
+                entry,
+                actual: parsed && {version: parsed.version, chunkNumber: parsed.chunkNumber}
+            });
+        }
     }
 
     const indexedIds   = new Set(indexed.map(entry => Number(entry.id))),
@@ -163,12 +181,14 @@ export async function validateContentIntegrity(issueSyncConfig = {}, {type, file
 
     return {
         type,
-        ok          : staleIndexEntries.length === 0 && unindexedIds.length === 0 &&
-                      identicalDuplicateIds.length === 0 && divergentDuplicateIds.length === 0,
+        ok          : staleIndexEntries.length === 0 && inconsistentIndexEntries.length === 0 &&
+                      unindexedIds.length === 0 && identicalDuplicateIds.length === 0 &&
+                      divergentDuplicateIds.length === 0,
         indexedTotal: indexed.length,
         corpusTotal,
         uniqueIds   : corpus.size,
         staleIndexEntries,
+        inconsistentIndexEntries,
         unindexedIds,
         identicalDuplicateIds,
         divergentDuplicateIds
@@ -187,6 +207,7 @@ export function formatIntegrityReport(result = {}) {
         `  corpus artifacts     : ${result.corpusTotal}`,
         `  unique ids           : ${result.uniqueIds}`,
         `  stale indexed paths  : ${result.staleIndexEntries?.length ?? 0}`,
+        `  inconsistent entries : ${result.inconsistentIndexEntries?.length ?? 0}`,
         `  unindexed artifacts  : ${result.unindexedIds?.length ?? 0}`,
         `  identical duplicates : ${result.identicalDuplicateIds?.length ?? 0}`,
         `  divergent duplicates : ${result.divergentDuplicateIds?.length ?? 0}`,

--- a/ai/services/github-workflow/shared/contentInventory.mjs
+++ b/ai/services/github-workflow/shared/contentInventory.mjs
@@ -131,7 +131,7 @@ export function resolveArchivedLocation(inventory, id) {
  * @param {'issues'|'pulls'|'discussions'} options.type Content type segment
  * @param {String} options.filePrefix File-leaf prefix (e.g. `'pr-'`)
  * @param {Map<Number, Array<Object>>} [options.inventory] Pre-built inventory; scanned when omitted
- * @returns {Promise<{type: String, ok: Boolean, indexedTotal: Number, corpusTotal: Number, uniqueIds: Number, staleIndexEntries: Array<Object>, inconsistentIndexEntries: Array<Object>, unindexedIds: Array<Number>, identicalDuplicateIds: Array<Number>, divergentDuplicateIds: Array<Number>}>}
+ * @returns {Promise<{type: String, ok: Boolean, indexedTotal: Number, corpusTotal: Number, uniqueIds: Number, staleIndexEntries: Array<Object>, inconsistentIndexEntries: Array<Object>, duplicateIndexEntryIds: Array<Number>, unindexedIds: Array<Number>, identicalDuplicateIds: Array<Number>, divergentDuplicateIds: Array<Number>}>}
  */
 export async function validateContentIntegrity(issueSyncConfig = {}, {type, filePrefix, inventory} = {}) {
     const contentRoot = contentRootFor(issueSyncConfig),
@@ -163,7 +163,20 @@ export async function validateContentIntegrity(issueSyncConfig = {}, {type, file
         }
     }
 
-    const indexedIds   = new Set(indexed.map(entry => Number(entry.id))),
+    // Duplicate rows for one id. `updateContentIndex` keys by `{type, id}` and so cannot create them,
+    // which is exactly why they must be checked on READ: a hand-edit, a bad merge, or any writer that
+    // appends rather than upserts produces two assertions about where one id lives, and every
+    // path-existence check passes on both. The first one wins at lookup, silently and arbitrarily.
+    const seenIds                = new Set(),
+          duplicateIndexEntryIds = [];
+
+    for (const entry of indexed) {
+        const id = Number(entry.id);
+
+        seenIds.has(id) ? duplicateIndexEntryIds.push(id) : seenIds.add(id);
+    }
+
+    const indexedIds   = seenIds,
           unindexedIds = [...corpus.keys()].filter(id => !indexedIds.has(id));
 
     const identicalDuplicateIds = [],
@@ -186,13 +199,14 @@ export async function validateContentIntegrity(issueSyncConfig = {}, {type, file
     return {
         type,
         ok          : staleIndexEntries.length === 0 && inconsistentIndexEntries.length === 0 &&
-                      unindexedIds.length === 0 && identicalDuplicateIds.length === 0 &&
-                      divergentDuplicateIds.length === 0,
+                      duplicateIndexEntryIds.length === 0 && unindexedIds.length === 0 &&
+                      identicalDuplicateIds.length === 0 && divergentDuplicateIds.length === 0,
         indexedTotal: indexed.length,
         corpusTotal,
         uniqueIds   : corpus.size,
         staleIndexEntries,
         inconsistentIndexEntries,
+        duplicateIndexEntryIds,
         unindexedIds,
         identicalDuplicateIds,
         divergentDuplicateIds
@@ -212,6 +226,7 @@ export function formatIntegrityReport(result = {}) {
         `  unique ids           : ${result.uniqueIds}`,
         `  stale indexed paths  : ${result.staleIndexEntries?.length ?? 0}`,
         `  inconsistent entries : ${result.inconsistentIndexEntries?.length ?? 0}`,
+        `  duplicate index rows : ${result.duplicateIndexEntryIds?.length ?? 0}`,
         `  unindexed artifacts  : ${result.unindexedIds?.length ?? 0}`,
         `  identical duplicates : ${result.identicalDuplicateIds?.length ?? 0}`,
         `  divergent duplicates : ${result.divergentDuplicateIds?.length ?? 0}`,

--- a/ai/services/github-workflow/shared/contentPath.mjs
+++ b/ai/services/github-workflow/shared/contentPath.mjs
@@ -6,10 +6,10 @@ import path from 'path';
  *
  * This helper is the single source-of-truth for active-tier and archive-tier on-disk path math
  * across all content types (issues, pulls, discussions, release-notes). It supersedes the
- * two-primitive model (`chunkPath.mjs` ID-range for active + `archivePath.mjs` ordinal for archive)
- * that ADR 0004 §3.1 retires.
+ * two-primitive model — `chunkPath.mjs` ID-range for active plus `archivePath.mjs` ordinal for
+ * archive — which is retired.
  *
- * **Universal Ordinal-100 Rule** (ADR 0004 §2.2):
+ * **Universal Ordinal-100 Rule:**
  *   1. `itemIndex` = zero-based ordinal within a collection bucket (active = ascending GitHub ID;
  *      archive = ascending GitHub ID within version-folder bucket; release-notes = ascending semver)
  *   2. `chunkNumber = Math.floor(itemIndex / itemsPerChunk) + 1` (1-based)
@@ -17,21 +17,22 @@ import path from 'path';
  *   4. Archive tier path: `{contentRoot}/archive/{type}/{version|bucket}/chunk-{N}/{filename}`
  *
  * No flat-vs-chunked branching. No ID-range math. No `<NNN>xx/` folders. ONE primitive applied
- * universally under ADR 0004's single path-resolution contract.
+ * universally under a single path-resolution contract.
  *
  * **Sealed-chunk invariant:** `.github/workflows/prevent-reopen.yml` enforces that closed items
  * past their 24h-grace window cannot be reopened; the CI guard preserves archive immutability.
  * Therefore once a chunk is sealed at archive-cut, membership is mechanically immutable — this
  * is what makes the ordinal chunking safe. Anyone reading this helper MUST mentally factor that
- * primitive in (ADR 0004 §5.4 anti-pattern: "Skipping `prevent-reopen.yml` in the mental model").
+ * primitive in; treating the reopen guard as incidental is the classic misread here.
  *
  * **V-B-A obligation for path-mutating call sites:** before authoring any file in
  * `ai/services/github-workflow/sync/*.mjs`, `ai/services/github-workflow/shared/*Path.mjs`,
  * `ai/mcp/server/github-workflow/config{,.template}.mjs`, `ai/services/ingestion/IssueIngestor.mjs`,
  * `buildScripts/release/publish.mjs`, or any consumer of `resources/content/...`, you MUST read
- * ADR 0004 start-to-finish, then verify the chosen pattern against this helper's signature.
+ * `learn/agentos/decisions/0004-github-content-architecture.md` start-to-finish, then verify the
+ * chosen pattern against this helper's signature.
  *
- * @see ADR 0004 (`learn/agentos/decisions/0004-github-content-architecture.md`)
+ * @see learn/agentos/decisions/0004-github-content-architecture.md (the governing decision record)
  * @see .github/workflows/prevent-reopen.yml (sealed-chunk substrate)
  */
 
@@ -47,7 +48,7 @@ export const DEFAULT_CHUNK_PREFIX    = 'chunk-';
  * @property {String} path Path relative to the `contentRoot` (consumers join with their own contentRoot)
  * @property {String} [bucket] Non-release archive bucket name (e.g., `'rejected'`); mutually exclusive with `version`
  *
- * @summary Per-item entry in the `_index.json` substrate (ADR 0004 §3.2).
+ * @summary Per-item entry in the `_index.json` substrate.
  * The index map enables O(1) ID-keyed lookup once chunk position is no longer derivable from the
  * GitHub identifier alone. Maintained at sync time by syncers; consumed at read time by
  * `LocalFileService#getIssueById` and KB / Native Edge Graph ingestors.
@@ -125,14 +126,104 @@ export default function contentPath(config = {}) {
     if (version !== undefined && version !== null) validateSegment(version, 'version');
     if (bucket  !== undefined && bucket  !== null) validateSegment(bucket,  'bucket');
 
-    const chunkNumber  = chunkNumberFor(itemIndex, itemsPerChunk);
-    const chunkDir     = `${chunkPrefix}${chunkNumber}`;
-    const archiveTier  = (version !== undefined && version !== null) || (bucket !== undefined && bucket !== null);
-    const bucketDir    = archiveTier
+    const chunkNumber = chunkNumberFor(itemIndex, itemsPerChunk);
+    const chunkDir    = `${chunkPrefix}${chunkNumber}`;
+    const archiveTier = (version !== undefined && version !== null) || (bucket !== undefined && bucket !== null);
+    const bucketDir   = archiveTier
         ? path.join(contentRoot, 'archive', type, version || bucket)
         : path.join(contentRoot, type);
 
     return path.join(bucketDir, chunkDir, filename);
+}
+
+/**
+ * @summary Inverts {@link contentPath} — reads an on-disk path back into its tier coordinates.
+ *
+ * The forward direction answers "where should this item go"; this answers "where does this file
+ * actually live". Both are path math, so both belong to this module: a second module deriving
+ * chunk/version by its own string-splitting would be a parallel truth free to disagree.
+ *
+ * The distinction is load-bearing for `_index.json`. An entry built from a *planned* ordinal
+ * records intent, and intent goes stale the moment a later pass relocates the file — the exact
+ * mechanism behind the archive-move drift, where the index kept naming active paths for files that
+ * had already been renamed away. An entry built from the written path describes reality and cannot
+ * disagree with the filesystem it was read from.
+ *
+ * Returns `null` for anything that is not a chunked content path, so callers can treat "not ours"
+ * as data rather than as an exception.
+ *
+ * **`filePath` must be absolute or contentRoot-relative — NOT projectRoot-relative.** This subsystem
+ * carries three path conventions, and two of them are bare relative strings distinguishable only by
+ * a leading `resources/content/`:
+ *
+ *   - absolute                          — `/…/resources/content/pulls/chunk-1/pr-9537.md`
+ *   - contentRoot-relative              — `pulls/chunk-1/pr-9537.md`            (`_index.json` entries)
+ *   - projectRoot-relative              — `resources/content/pulls/chunk-1/pr-9537.md` (`metadata.{type}[].path`)
+ *
+ * Passing the third against a `contentRoot` of `resources/content` resolves to
+ * `resources/content/resources/content/…` and parses as `null`. Nothing in the string itself reveals
+ * which convention produced it, so the caller must know; resolve metadata paths against the project
+ * root before handing them here.
+ *
+ * @param {Object} config
+ * @param {String} config.contentRoot Repository-relative or absolute root, e.g. `'resources/content'`
+ * @param {String} config.filePath Absolute or contentRoot-relative path to a content file
+ * @param {String} [config.chunkPrefix='chunk-'] Chunk-subdirectory prefix
+ * @returns {{type: String, version: String|null, bucket: String|null, chunkNumber: Number, filename: String}|null}
+ *
+ * @example
+ *   // Absolute
+ *   parseContentPath({contentRoot: '/repo/resources/content', filePath: '/repo/resources/content/archive/pulls/v13.0.0/chunk-2/pr-10124.md'})
+ *   // → {type: 'pulls', version: 'v13.0.0', bucket: null, chunkNumber: 2, filename: 'pr-10124.md'}
+ *
+ * @example
+ *   // contentRoot-relative — the `_index.json` entry shape
+ *   parseContentPath({contentRoot: 'resources/content', filePath: 'pulls/chunk-1/pr-9537.md'})
+ *   // → {type: 'pulls', version: null, bucket: null, chunkNumber: 1, filename: 'pr-9537.md'}
+ */
+export function parseContentPath(config = {}) {
+    const {contentRoot, filePath, chunkPrefix = DEFAULT_CHUNK_PREFIX} = config;
+
+    validateSegment(contentRoot, 'contentRoot', {allowPath: true});
+    validateSegment(filePath,    'filePath',    {allowPath: true});
+
+    const relative = path.relative(path.resolve(contentRoot), path.resolve(contentRoot, filePath));
+
+    // Escapes the content root — not ours to describe.
+    if (relative.startsWith('..') || path.isAbsolute(relative)) return null;
+
+    const segments = relative.split(path.sep).filter(Boolean);
+
+    // Active: {type}/{chunk-N}/{filename}          → 3 segments
+    // Archive: archive/{type}/{version}/{chunk-N}/{filename} → 5 segments
+    const archiveTier = segments[0] === 'archive';
+    const expected    = archiveTier ? 5 : 3;
+
+    if (segments.length !== expected) return null;
+
+    const filename   = segments[expected - 1],
+          chunkDir   = segments[expected - 2],
+          type       = archiveTier ? segments[1] : segments[0],
+          versionSeg = archiveTier ? segments[2] : null;
+
+    if (!chunkDir.startsWith(chunkPrefix)) return null;
+
+    const chunkNumber = Number(chunkDir.slice(chunkPrefix.length));
+
+    if (!Number.isInteger(chunkNumber) || chunkNumber < 1) return null;
+
+    // `version` vs `bucket` is not recoverable from the path alone — both occupy the same segment.
+    // Version-shaped segments carry the configured prefix; anything else is a non-release bucket.
+    // Callers that know their tier can ignore the split.
+    const isVersion = /^v\d/.test(versionSeg || '');
+
+    return {
+        type,
+        version: archiveTier && isVersion  ? versionSeg : null,
+        bucket : archiveTier && !isVersion ? versionSeg : null,
+        chunkNumber,
+        filename
+    };
 }
 
 /**

--- a/ai/services/github-workflow/shared/contentPath.mjs
+++ b/ai/services/github-workflow/shared/contentPath.mjs
@@ -38,6 +38,9 @@ import path from 'path';
 
 export const DEFAULT_ITEMS_PER_CHUNK = 100;
 export const DEFAULT_CHUNK_PREFIX    = 'chunk-';
+// Mirrors `issueSync.versionDirectoryPrefix`. A default, not a universal: it exists so the inverse
+// parse has the same fallback the forward build does, NOT so callers may skip threading the config.
+export const DEFAULT_VERSION_PREFIX  = 'v';
 
 /**
  * @typedef {Object} ContentIndexEntry
@@ -165,10 +168,18 @@ export default function contentPath(config = {}) {
  * which convention produced it, so the caller must know; resolve metadata paths against the project
  * root before handing them here.
  *
+ * **Both segment vocabularies are configured, not universal.** `chunkPrefix` and `versionPrefix`
+ * default to the values the shipped config happens to use (`chunk-` / `v`), which is exactly why a
+ * hardcoded parser passes every test and still diverges the moment a deployment overrides either:
+ * the forward direction would build `slice-3/` while the inverse only recognises `chunk-3/`, and the
+ * two halves of one contract would disagree silently. Callers holding an `issueSyncConfig` must pass
+ * `archiveChunkPrefix` / `versionDirectoryPrefix` through.
+ *
  * @param {Object} config
  * @param {String} config.contentRoot Repository-relative or absolute root, e.g. `'resources/content'`
  * @param {String} config.filePath Absolute or contentRoot-relative path to a content file
- * @param {String} [config.chunkPrefix='chunk-'] Chunk-subdirectory prefix
+ * @param {String} [config.chunkPrefix='chunk-'] Chunk-subdirectory prefix; pass `archiveChunkPrefix`
+ * @param {String} [config.versionPrefix='v'] Release-bucket prefix; pass `versionDirectoryPrefix`
  * @returns {{type: String, version: String|null, bucket: String|null, chunkNumber: Number, filename: String}|null}
  *
  * @example
@@ -182,7 +193,12 @@ export default function contentPath(config = {}) {
  *   // → {type: 'pulls', version: null, bucket: null, chunkNumber: 1, filename: 'pr-9537.md'}
  */
 export function parseContentPath(config = {}) {
-    const {contentRoot, filePath, chunkPrefix = DEFAULT_CHUNK_PREFIX} = config;
+    const {
+        contentRoot,
+        filePath,
+        chunkPrefix   = DEFAULT_CHUNK_PREFIX,
+        versionPrefix = DEFAULT_VERSION_PREFIX
+    } = config;
 
     validateSegment(contentRoot, 'contentRoot', {allowPath: true});
     validateSegment(filePath,    'filePath',    {allowPath: true});
@@ -213,9 +229,13 @@ export function parseContentPath(config = {}) {
     if (!Number.isInteger(chunkNumber) || chunkNumber < 1) return null;
 
     // `version` vs `bucket` is not recoverable from the path alone — both occupy the same segment.
-    // Version-shaped segments carry the configured prefix; anything else is a non-release bucket.
-    // Callers that know their tier can ignore the split.
-    const isVersion = /^v\d/.test(versionSeg || '');
+    // Version-shaped segments carry the configured prefix followed by a digit; anything else is a
+    // non-release bucket. Built from `versionPrefix` rather than a literal so an overridden prefix
+    // does not silently reclassify every release bucket as a named bucket. Callers that know their
+    // tier can ignore the split.
+    const isVersion = versionSeg
+        ? versionSeg.startsWith(versionPrefix) && /^\d/.test(versionSeg.slice(versionPrefix.length))
+        : false;
 
     return {
         type,
@@ -223,6 +243,25 @@ export function parseContentPath(config = {}) {
         bucket : archiveTier && !isVersion ? versionSeg : null,
         chunkNumber,
         filename
+    };
+}
+
+/**
+ * @summary Maps an `issueSync` config block to {@link parseContentPath}'s segment options.
+ *
+ * The two vocabularies live under different names on each side — `archiveChunkPrefix` /
+ * `versionDirectoryPrefix` in config, `chunkPrefix` / `versionPrefix` in the path math — so every
+ * call site that translated them by hand would be a place the mapping could drift. One helper means
+ * a renamed config key breaks in one file instead of four, and callers cannot accidentally thread
+ * only half of it.
+ *
+ * @param {Object} issueSyncConfig GitHub workflow `issueSync` config block
+ * @returns {{chunkPrefix: String, versionPrefix: String}}
+ */
+export function pathSegmentOptionsFor(issueSyncConfig = {}) {
+    return {
+        chunkPrefix  : issueSyncConfig.archiveChunkPrefix     || DEFAULT_CHUNK_PREFIX,
+        versionPrefix: issueSyncConfig.versionDirectoryPrefix || DEFAULT_VERSION_PREFIX
     };
 }
 

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -1,20 +1,20 @@
-import aiConfig                                                                from '../../../mcp/server/github-workflow/config.mjs';
-import Base                                                                    from '../../../../src/core/Base.mjs';
-import crypto                                                                  from 'crypto';
-import {existsSync}                                                            from 'fs';
-import fs                                                                      from 'fs/promises';
-import logger                                                                  from '../../../mcp/server/github-workflow/logger.mjs';
-import matter                                                                  from 'gray-matter';
-import path                                                                    from 'path';
-import semver                                                                  from 'semver';
-import GraphqlService                                                          from '../GraphqlService.mjs';
-import ReleaseNotesSyncer                                                      from './ReleaseNotesSyncer.mjs';
-import {FETCH_PULL_REQUESTS_FOR_SYNC, FETCH_SINGLE_PULL_FOR_SYNC}              from '../queries/pullRequestQueries.mjs';
-import contentPath, {parseContentPath, pathSegmentOptionsFor}                  from '../shared/contentPath.mjs';
-import {buildContentInventory, resolveArchivedLocation}                        from '../shared/contentInventory.mjs';
-import {createContentIndexEntryFromPath, readContentIndex, updateContentIndex} from '../shared/contentIndex.mjs';
-import {createContentTrustSummary, projectAuthoredNodeTrust}                   from '../shared/conversationTrust.mjs';
-import pruneEmptyDirs                                                          from '../shared/pruneEmptyDirs.mjs';
+import aiConfig                                                                   from '../../../mcp/server/github-workflow/config.mjs';
+import Base                                                                       from '../../../../src/core/Base.mjs';
+import crypto                                                                     from 'crypto';
+import {existsSync}                                                               from 'fs';
+import fs                                                                         from 'fs/promises';
+import logger                                                                     from '../../../mcp/server/github-workflow/logger.mjs';
+import matter                                                                     from 'gray-matter';
+import path                                                                       from 'path';
+import semver                                                                     from 'semver';
+import GraphqlService                                                             from '../GraphqlService.mjs';
+import ReleaseNotesSyncer                                                         from './ReleaseNotesSyncer.mjs';
+import {FETCH_PULL_REQUESTS_FOR_SYNC, FETCH_SINGLE_PULL_FOR_SYNC}                 from '../queries/pullRequestQueries.mjs';
+import contentPath, {parseContentPath, pathSegmentOptionsFor}                     from '../shared/contentPath.mjs';
+import {buildContentInventory, resolveArchivedLocation, validateContentIntegrity} from '../shared/contentInventory.mjs';
+import {createContentIndexEntryFromPath, readContentIndex, updateContentIndex}    from '../shared/contentIndex.mjs';
+import {createContentTrustSummary, projectAuthoredNodeTrust}                      from '../shared/conversationTrust.mjs';
+import pruneEmptyDirs                                                             from '../shared/pruneEmptyDirs.mjs';
 
 const issueSyncConfig   = aiConfig.issueSync;
 const pullRequestConfig = aiConfig.pullRequest;
@@ -867,6 +867,24 @@ class PullRequestSyncer extends Base {
     }
 
     /**
+     * @summary The terminal integrity verdict over the pull corpus.
+     *
+     * A thin owner-side wrapper, and deliberately a method rather than a call the orchestrator makes
+     * itself. Two reasons, both structural: the orchestrator would otherwise have to know
+     * pull-specific facts (the type segment, the filename prefix) that belong to this syncer, and a
+     * bare module call is unstubbable — the Stage-2 sequencing specs stub every pull pass, and a
+     * verdict they cannot stub reads the real `resources/content` from a unit run.
+     *
+     * @returns {Promise<Object>} The structured result from `validateContentIntegrity`.
+     */
+    async verifyCorpusIntegrity() {
+        return validateContentIntegrity(issueSyncConfig, {
+            type      : 'pulls',
+            filePrefix: aiConfig.issueSync.pullFilenamePrefix || 'pr-'
+        });
+    }
+
+    /**
      * @summary Realigns `_index.json` with the pull corpus on disk. The repair half of this lane.
      *
      * The index is a PROJECTION of the corpus, so it can always be recomputed from it — and once a
@@ -882,12 +900,15 @@ class PullRequestSyncer extends Base {
      * clean — it upserts only entries that actually disagree with disk, so a healthy corpus writes
      * nothing and the generated-content diff stays empty.
      *
-     * Ambiguous ids are SKIPPED rather than indexed. An entry for one of two artifacts would name a
-     * copy and thereby bless it as canonical — the arbitrary choice this lane refuses to make on the
-     * corpus's behalf. They surface in the integrity result for repair from source.
+     * A projection REMOVES as well as writes. Skipping an ambiguous id is not enough when a row for
+     * it already exists: that row names one of two divergent artifacts and thereby blesses it as
+     * canonical — the arbitrary choice this lane refuses — and it does so silently, because the path
+     * it names is real and resolves. The same holds for an id whose artifact is gone entirely: the
+     * row survives as a lookup into nothing. "Exactly one artifact, or no row" is the contract; an
+     * index that only ever grows is a cache, not a projection.
      *
      * @param {Map<number, Array<object>>} [inventory] Pre-built corpus inventory; scanned when omitted.
-     * @returns {Promise<{reindexed: Number, unchanged: Number, skippedAmbiguous: Number[]}>}
+     * @returns {Promise<{reindexed: Number, unchanged: Number, removed: Number, skippedAmbiguous: Number[]}>}
      */
     async reconcilePullRequestIndex(inventory = null) {
         const corpus = inventory || await buildContentInventory(issueSyncConfig, {
@@ -902,6 +923,7 @@ class PullRequestSyncer extends Base {
         );
 
         const upsert           = [],
+              remove           = [],
               skippedAmbiguous = [];
 
         let unchanged = 0;
@@ -909,6 +931,13 @@ class PullRequestSyncer extends Base {
         for (const [id, copies] of corpus) {
             if (copies.length > 1) {
                 skippedAmbiguous.push(id);
+
+                // Not merely un-indexed: any EXISTING row for this id must go. It names one of two
+                // divergent artifacts, and a row is an assertion that the id resolves there — which
+                // is the canonical-by-implication choice this lane refuses to make on the corpus's
+                // behalf. Silently, too: the path is real, so every existence check passes.
+                if (existing.has(id)) remove.push({type: 'pulls', id});
+
                 continue;
             }
 
@@ -935,16 +964,22 @@ class PullRequestSyncer extends Base {
             upsert.push(entry);
         }
 
-        if (upsert.length > 0) {
-            await updateContentIndex(issueSyncConfig, {upsert});
-            logger.info(`🧭 Realigned ${upsert.length} pull index entr${upsert.length === 1 ? 'y' : 'ies'} with the corpus (${unchanged} already correct).`);
+        // A row whose id owns NO artifact at all is a lookup into nothing. The projection drops it
+        // rather than leaving a resolvable-looking entry behind.
+        for (const id of existing.keys()) {
+            if (!corpus.has(id)) remove.push({type: 'pulls', id});
+        }
+
+        if (upsert.length > 0 || remove.length > 0) {
+            await updateContentIndex(issueSyncConfig, {upsert, remove});
+            logger.info(`🧭 Realigned the pull index with the corpus: ${upsert.length} written, ${remove.length} removed, ${unchanged} already correct.`);
         }
 
         if (skippedAmbiguous.length > 0) {
-            logger.warn(`⚠️ ${skippedAmbiguous.length} pull request(s) own more than one artifact and were left unindexed: ${skippedAmbiguous.join(', ')}`);
+            logger.warn(`⚠️ ${skippedAmbiguous.length} pull request(s) own more than one artifact and are unindexed pending repair: ${skippedAmbiguous.join(', ')}`);
         }
 
-        return {reindexed: upsert.length, unchanged, skippedAmbiguous};
+        return {reindexed: upsert.length, unchanged, removed: remove.length, skippedAmbiguous};
     }
 
     /**

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -794,12 +794,22 @@ class PullRequestSyncer extends Base {
 
                 const content = this.#renderPullRequestMarkdown(pr);
 
-                // Plan against membership with the duplicates excluded — they are about to stop
+                // Plan against membership with THIS id's duplicates excluded — they are about to stop
                 // existing, and `#getPullRequestPath` refuses an ambiguous id by design.
-                inventory.delete(id);
+                //
+                // On a CLONE, because the shared inventory must only ever describe DURABLE state.
+                // Deleting from it here would mean a post-fetch failure — mkdir, write, rename, or a
+                // crash — leaves the loop holding membership that no longer matches disk: the files
+                // survive (that is what the write-failure witness proves) while the map has silently
+                // lost a member, so every LATER id in this pass plans its ordinal against a corpus
+                // short one PR. A failure must cost this id's repair and nothing else. The blast
+                // radius of a soft-failed restore is the id it failed on.
+                const planningInventory = new Map(inventory);
 
-                const planBuckets = this.#planBuckets(metadata, [pr], inventory),
-                      targetPath  = this.#getPullRequestPath(pr, planBuckets, inventory);
+                planningInventory.delete(id);
+
+                const planBuckets = this.#planBuckets(metadata, [pr], planningInventory),
+                      targetPath  = this.#getPullRequestPath(pr, planBuckets, planningInventory);
 
                 // DURABLE FIRST, then delete. Holding the canonical rendering in memory protects
                 // against a failed fetch and nothing else: every step between an unlink and the
@@ -825,6 +835,10 @@ class PullRequestSyncer extends Base {
                     stats.removed++;
                 }
 
+                // Durable now: the artifact is on disk and the rivals are gone, so the shared
+                // inventory may finally be told. Replacing the id's entry outright — the copies it
+                // listed no longer exist — makes the map match disk exactly at this point, which is
+                // the invariant every later id in the loop plans against.
                 inventory.set(id, [{
                     absPath    : targetPath,
                     ...parseContentPath({contentRoot: issueSyncConfig.contentRoot, filePath: targetPath, ...pathSegmentOptionsFor(issueSyncConfig)})

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -10,7 +10,7 @@ import semver                                                                  f
 import GraphqlService                                                          from '../GraphqlService.mjs';
 import ReleaseNotesSyncer                                                      from './ReleaseNotesSyncer.mjs';
 import {FETCH_PULL_REQUESTS_FOR_SYNC, FETCH_SINGLE_PULL_FOR_SYNC}              from '../queries/pullRequestQueries.mjs';
-import contentPath, {parseContentPath}                                         from '../shared/contentPath.mjs';
+import contentPath, {parseContentPath, pathSegmentOptionsFor}                  from '../shared/contentPath.mjs';
 import {buildContentInventory, resolveArchivedLocation}                        from '../shared/contentInventory.mjs';
 import {createContentIndexEntryFromPath, readContentIndex, updateContentIndex} from '../shared/contentIndex.mjs';
 import {createContentTrustSummary, projectAuthoredNodeTrust}                   from '../shared/conversationTrust.mjs';
@@ -207,19 +207,30 @@ class PullRequestSyncer extends Base {
             addToBucket(version, pr.number, pr);
         }
 
-        // Seed from disk AFTER classification, and never for a PR classified active. An open PR with
-        // a stray archived artifact is corruption; seeding it would hand that PR an archive plan and
-        // the sync would seal a live PR away. Membership is inherited from the corpus only for ids
-        // this run has no live opinion about — which is the whole marooned backlog.
+        // Seed from disk AFTER classification, and never for an id this run already classified. An
+        // open PR with a stray archived artifact is corruption; seeding it would hand that PR an
+        // archive plan and the sync would seal a live PR away. Membership is inherited from the
+        // corpus only for ids this run has no live opinion about — which is the whole marooned
+        // backlog.
+        //
+        // BOTH tiers. Seeding only the versioned buckets left the active collection ranking a PR
+        // against the delta alone — the same partial-ordinal defect this exists to remove, one tier
+        // over, and invisible because the archive half looked fixed. An active file is a member of
+        // the active collection exactly as an archived file is a member of its bucket; both ordinals
+        // are defined over complete membership.
         if (inventory) {
-            const activeIds = new Set(activeItems.map(pr => pr.number));
+            const classified = new Set(activeItems.map(pr => pr.number));
+
+            for (const bucket of buckets.values()) {
+                for (const id of bucket.keys()) classified.add(id);
+            }
 
             for (const [id, copies] of inventory) {
-                if (activeIds.has(id)) continue;
+                if (classified.has(id)) continue;
 
-                for (const copy of copies) {
-                    if (copy.version) addToBucket(copy.version, id);
-                }
+                const archived = copies.find(copy => copy.version);
+
+                archived ? addToBucket(archived.version, id) : activeItems.push({number: id});
             }
         }
 
@@ -816,7 +827,7 @@ class PullRequestSyncer extends Base {
 
                 inventory.set(id, [{
                     absPath    : targetPath,
-                    ...parseContentPath({contentRoot: issueSyncConfig.contentRoot, filePath: targetPath})
+                    ...parseContentPath({contentRoot: issueSyncConfig.contentRoot, filePath: targetPath, ...pathSegmentOptionsFor(issueSyncConfig)})
                 }]);
 
                 metadata.pulls ??= {};

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -1,19 +1,20 @@
-import aiConfig                                                                       from '../../../mcp/server/github-workflow/config.mjs';
-import Base                                                                           from '../../../../src/core/Base.mjs';
-import crypto                                                                         from 'crypto';
-import {existsSync}                                                                   from 'fs';
-import fs                                                                             from 'fs/promises';
-import logger                                                                         from '../../../mcp/server/github-workflow/logger.mjs';
-import matter                                                                         from 'gray-matter';
-import path                                                                           from 'path';
-import semver                                                                         from 'semver';
-import GraphqlService                                                                 from '../GraphqlService.mjs';
-import ReleaseNotesSyncer                                                             from './ReleaseNotesSyncer.mjs';
-import {FETCH_PULL_REQUESTS_FOR_SYNC, FETCH_SINGLE_PULL_FOR_SYNC}                     from '../queries/pullRequestQueries.mjs';
-import contentPath                                                                    from '../shared/contentPath.mjs';
-import {createContentIndexEntry, createContentIndexEntryFromPath, updateContentIndex} from '../shared/contentIndex.mjs';
-import {createContentTrustSummary, projectAuthoredNodeTrust}                          from '../shared/conversationTrust.mjs';
-import pruneEmptyDirs                                                                 from '../shared/pruneEmptyDirs.mjs';
+import aiConfig                                                   from '../../../mcp/server/github-workflow/config.mjs';
+import Base                                                       from '../../../../src/core/Base.mjs';
+import crypto                                                     from 'crypto';
+import {existsSync}                                               from 'fs';
+import fs                                                         from 'fs/promises';
+import logger                                                     from '../../../mcp/server/github-workflow/logger.mjs';
+import matter                                                     from 'gray-matter';
+import path                                                       from 'path';
+import semver                                                     from 'semver';
+import GraphqlService                                             from '../GraphqlService.mjs';
+import ReleaseNotesSyncer                                         from './ReleaseNotesSyncer.mjs';
+import {FETCH_PULL_REQUESTS_FOR_SYNC, FETCH_SINGLE_PULL_FOR_SYNC} from '../queries/pullRequestQueries.mjs';
+import contentPath                                                from '../shared/contentPath.mjs';
+import {buildContentInventory, resolveArchivedLocation}           from '../shared/contentInventory.mjs';
+import {createContentIndexEntryFromPath, updateContentIndex}      from '../shared/contentIndex.mjs';
+import {createContentTrustSummary, projectAuthoredNodeTrust}      from '../shared/conversationTrust.mjs';
+import pruneEmptyDirs                                             from '../shared/pruneEmptyDirs.mjs';
 
 const issueSyncConfig   = aiConfig.issueSync;
 const pullRequestConfig = aiConfig.pullRequest;
@@ -135,12 +136,22 @@ class PullRequestSyncer extends Base {
 
     /**
      * @summary Pre-computes bucket distribution for all pull requests based on historical milestones/releases.
+     *
+     * The ordinal is defined against COMPLETE bucket membership, and neither input carries it:
+     * `metadata.pulls` is rebuilt from each run's delta fetch and `fetchedPullRequests` is that delta.
+     * Ranking a PR against the handful of its bucket a delta happens to include does not produce a
+     * roughly-right chunk, it produces a confidently wrong one — and the sync then writes there.
+     * Passing `inventory` seeds each bucket with the ids already on disk in it, which is the only
+     * complete membership that exists, because the files outlive every cache describing them.
+     *
      * @param {object} metadata Current sync metadata
      * @param {Array<object>} fetchedPullRequests PRs fetched in the current sync run
+     * @param {Map<number, Array<object>>} [inventory] Complete corpus inventory. Omitted, buckets are
+     *     ranked against the delta alone — correct only when the delta IS the corpus.
      * @returns {Map<number, {version: string|null, itemCount: number, itemIndex: number}>}
      * @private
      */
-    #planBuckets(metadata, fetchedPullRequests = []) {
+    #planBuckets(metadata, fetchedPullRequests = [], inventory = null) {
         const combined = new Map();
 
         for (const [idStr, pr] of Object.entries(metadata.pulls || {})) {
@@ -163,8 +174,20 @@ class PullRequestSyncer extends Base {
             });
         }
 
+        // Keyed by number so a bucket cannot hold an id twice — a duplicate would consume an ordinal
+        // slot and shift every later member's chunk by one.
         const buckets     = new Map();
         const activeItems = [];
+
+        const addToBucket = (version, number, pr = null) => {
+            if (!buckets.has(version)) buckets.set(version, new Map());
+
+            const bucket = buckets.get(version);
+
+            // A seeded id carries only its number; a classified PR carries its node. Never let the
+            // seed overwrite the richer entry.
+            if (pr || !bucket.has(number)) bucket.set(number, pr || {number});
+        };
 
         for (const pr of combined.values()) {
             let version = null;
@@ -181,8 +204,23 @@ class PullRequestSyncer extends Base {
                 continue;
             }
 
-            if (!buckets.has(version)) buckets.set(version, []);
-            buckets.get(version).push(pr);
+            addToBucket(version, pr.number, pr);
+        }
+
+        // Seed from disk AFTER classification, and never for a PR classified active. An open PR with
+        // a stray archived artifact is corruption; seeding it would hand that PR an archive plan and
+        // the sync would seal a live PR away. Membership is inherited from the corpus only for ids
+        // this run has no live opinion about — which is the whole marooned backlog.
+        if (inventory) {
+            const activeIds = new Set(activeItems.map(pr => pr.number));
+
+            for (const [id, copies] of inventory) {
+                if (activeIds.has(id)) continue;
+
+                for (const copy of copies) {
+                    if (copy.version) addToBucket(copy.version, id);
+                }
+            }
         }
 
         const plans = new Map();
@@ -197,9 +235,10 @@ class PullRequestSyncer extends Base {
             });
         });
 
-        for (const [version, prs] of buckets.entries()) {
-            prs.sort((a, b) => a.number - b.number);
-            const itemCount = prs.length;
+        for (const [version, bucket] of buckets.entries()) {
+            const prs       = [...bucket.values()].sort((a, b) => a.number - b.number),
+                  itemCount = prs.length;
+
             prs.forEach((pr, index) => {
                 plans.set(pr.number, {
                     version,
@@ -214,15 +253,53 @@ class PullRequestSyncer extends Base {
 
     /**
      * Determines the correct local file path for a given pull request based on its state.
+     *
+     * An already-archived PR keeps the artifact it owns. Archive ordinals are fixed when a bucket is
+     * cut, so recomputing one at refresh time answers a different question than the one that placed
+     * the file: the planner ranks the PR against the PRs it can currently see, and a delta-sized view
+     * of a sealed bucket yields a different chunk. The write then lands beside the existing copy
+     * rather than on it, and the two renderings diverge from that moment on. Reusing the occupied
+     * location makes a refresh overwrite the file that exists — a second copy becomes unreachable by
+     * construction rather than merely unlikely.
+     *
      * @param {object} pr The GitHub pull request object.
      * @param {Map<number, object>} planBuckets Precomputed bucket distribution.
+     * @param {Map<number, Array<object>>} [inventory] Complete corpus inventory; enables the
+     *     preserve-existing rule. Omitted, placement falls back to the plan alone.
      * @returns {string} The absolute file path for the PR's Markdown file.
+     * @throws {Error} When the PR already owns more than one archived artifact.
      * @private
      */
-    #getPullRequestPath(pr, planBuckets = new Map()) {
+    #getPullRequestPath(pr, planBuckets = new Map(), inventory = null) {
         const filename = `${aiConfig.issueSync.pullFilenamePrefix || 'pr-'}${pr.number}.md`;
 
         const plan = planBuckets.get(pr.number);
+
+        // Terminal only. An OPEN pull request belongs in active regardless of what sits in the
+        // archive — an open PR with an archived artifact is itself corruption, and preserving that
+        // location would keep a live PR sealed away where the next refresh can never surface it.
+        // Mirrors the reconcile's archive-candidate rule.
+        const isTerminal = pr.state === 'CLOSED' || pr.state === 'MERGED';
+
+        if (inventory && isTerminal) {
+            const archived = resolveArchivedLocation(inventory, pr.number);
+
+            // Two artifacts for one id: the corpus is already corrupt here and nothing on disk says
+            // which copy is current. Refuse this PR rather than pick — writing to either would
+            // canonicalise a guess and destroy the evidence of the divergence. The per-PR catch in
+            // the sync loop turns this into a skip, so one corrupt id cannot wedge the run, and the
+            // integrity pass reports it for repair from source.
+            if (archived.status === 'ambiguous') {
+                throw new Error(
+                    `pull request #${pr.number} owns ${archived.copies.length} archived artifacts ` +
+                    `(${archived.copies.map(copy => copy.absPath).join(', ')}) — refusing to guess which is current`
+                );
+            }
+
+            if (archived.status === 'unique') {
+                return archived.entry.absPath;
+            }
+        }
 
         const config = {
             contentRoot  : issueSyncConfig.contentRoot,
@@ -312,8 +389,14 @@ class PullRequestSyncer extends Base {
             }
         }
 
-        // Bucket the scanned corpus (+ any cached metadata) by release date, exactly as the live sync does.
-        const planBuckets  = this.#planBuckets(metadata, scanned),
+        // Bucket the scanned corpus (+ any cached metadata) by release date, exactly as the live sync
+        // does — and against the same complete membership, so a file moved here lands on the ordinal
+        // the full bucket ordering chooses rather than one derived from this pass's view of it.
+        const inventory = await buildContentInventory(issueSyncConfig, {
+            type      : 'pulls',
+            filePrefix: aiConfig.issueSync.pullFilenamePrefix || 'pr-'
+        });
+        const planBuckets  = this.#planBuckets(metadata, scanned, inventory),
               indexUpserts = [];
 
         for (const pr of scanned) {
@@ -506,13 +589,20 @@ class PullRequestSyncer extends Base {
             synced: []
         };
 
-        const cachedPulls          = metadata.pulls || {};
-        const planBuckets          = this.#planBuckets(metadata, allPullRequests);
+        const cachedPulls = metadata.pulls || {};
+        // The corpus, not the cache. `metadata.pulls` is rebuilt from this run's delta, so it cannot
+        // answer "where does PR N already live" for anything the delta did not fetch — and that set
+        // is precisely where the rival copies were written.
+        const inventory = await buildContentInventory(issueSyncConfig, {
+            type      : 'pulls',
+            filePrefix: aiConfig.issueSync.pullFilenamePrefix || 'pr-'
+        });
+        const planBuckets          = this.#planBuckets(metadata, allPullRequests, inventory);
         let   shouldPruneEmptyDirs = false;
 
         for (const pr of allPullRequests) {
             try {
-                const targetPath  = this.#getPullRequestPath(pr, planBuckets);
+                const targetPath  = this.#getPullRequestPath(pr, planBuckets, inventory);
                 const content     = this.#renderPullRequestMarkdown(pr);
                 const currentHash = this.#calculateContentHash(content);
 
@@ -569,7 +659,16 @@ class PullRequestSyncer extends Base {
         const indexEntries = [];
 
         allPullRequests.forEach(p => {
-            const plan = planBuckets.get(p.number);
+            // A PR the loop above refused or failed on has no resolved path. It must drop out of the
+            // cache entirely rather than be recorded with an undefined one: absent, the next run
+            // re-fetches it; recorded-as-null, the entry claims a location that does not exist and we
+            // have written the same class of lie this lane exists to remove. Skipping also keeps one
+            // bad id from throwing out here — outside the per-PR catch — and taking the whole run's
+            // metadata and index write down with it.
+            if (!p.relativeOutputPath) {
+                logger.warn(`⚠️ Pull request #${p.number} produced no path — omitted from metadata and index this run.`);
+                return;
+            }
 
             metadata.pulls[p.number] = {
                 number     : p.number,
@@ -582,14 +681,15 @@ class PullRequestSyncer extends Base {
                 path       : p.relativeOutputPath
             };
 
-            indexEntries.push(createContentIndexEntry({
+            // From the written path, NOT from the plan. These can now legitimately disagree: an
+            // already-archived PR keeps its occupied location while the plan proposes a freshly
+            // ranked one, so an entry built from `plan.itemIndex` would carry a chunkNumber that
+            // contradicts its own path — an index internally inconsistent with the file it names.
+            indexEntries.push(createContentIndexEntryFromPath({
                 issueSyncConfig,
-                type     : 'pulls',
-                id       : p.number,
-                filePath : path.resolve(aiConfig.projectRoot, p.relativeOutputPath),
-                itemIndex: plan ? plan.itemIndex : 0,
-                version  : p.state === 'OPEN' ? null : plan?.version || null,
-                bucket   : null
+                type    : 'pulls',
+                id      : p.number,
+                filePath: path.resolve(aiConfig.projectRoot, p.relativeOutputPath)
             }));
         });
 
@@ -620,6 +720,12 @@ class PullRequestSyncer extends Base {
      * file, and mutates the passed `metadata` in place. The caller persists metadata afterwards.
      * Mirrors `IssueSyncer#refetchIssuesByNumber`.
      *
+     * Placement is resolved against the complete corpus, not against the refetch list. This path is
+     * the narrowest view in the syncer — one PR — so ranking a bucket from it produced the most
+     * confidently wrong ordinal available, and the write landed beside the artifact it was sent to
+     * repair. A recovery primitive that manufactures the drift it exists to remove is worse than no
+     * recovery primitive, because it is invoked precisely when the corpus is already suspect.
+     *
      * @param {Array<Number>|Set<Number>} numbers The pull-request numbers to refetch.
      * @param {Object} metadata The sync metadata object (mutated in place).
      * @param {Object} [indexMutations=null] Optional accumulator for `_index.json` updates.
@@ -628,6 +734,11 @@ class PullRequestSyncer extends Base {
     async refetchPullsByNumber(numbers, metadata, indexMutations = null) {
         const stats = {refetched: {count: 0, pulls: []}, errors: []};
         const list  = [...numbers];
+
+        const inventory = await buildContentInventory(issueSyncConfig, {
+            type      : 'pulls',
+            filePrefix: aiConfig.issueSync.pullFilenamePrefix || 'pr-'
+        });
 
         for (const prNumber of list) {
             try {
@@ -649,8 +760,8 @@ class PullRequestSyncer extends Base {
                     continue;
                 }
 
-                const planBuckets = this.#planBuckets(metadata, [pr]);
-                const targetPath  = this.#getPullRequestPath(pr, planBuckets);
+                const planBuckets = this.#planBuckets(metadata, [pr], inventory);
+                const targetPath  = this.#getPullRequestPath(pr, planBuckets, inventory);
                 if (!targetPath) {
                     if (indexMutations) {
                         indexMutations.remove.push({type: 'pulls', id: prNumber});
@@ -680,15 +791,14 @@ class PullRequestSyncer extends Base {
                 };
 
                 if (indexMutations) {
-                    const plan = planBuckets.get(prNumber);
-                    indexMutations.upsert.push(createContentIndexEntry({
+                    // Derived from the written path: with placement now preserving an occupied
+                    // archive location, a plan-derived chunkNumber can contradict the very path it
+                    // ships beside.
+                    indexMutations.upsert.push(createContentIndexEntryFromPath({
                         issueSyncConfig,
-                        type     : 'pulls',
-                        id       : prNumber,
-                        filePath : this.#resolvePath(this.#relativePath(targetPath)),
-                        itemIndex: plan ? plan.itemIndex : 0,
-                        version  : pr.state === 'OPEN' ? null : plan?.version || null,
-                        bucket   : null
+                        type    : 'pulls',
+                        id      : prNumber,
+                        filePath: this.#resolvePath(this.#relativePath(targetPath))
                     }));
                 }
             } catch (e) {

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -10,7 +10,7 @@ import semver                                                                  f
 import GraphqlService                                                          from '../GraphqlService.mjs';
 import ReleaseNotesSyncer                                                      from './ReleaseNotesSyncer.mjs';
 import {FETCH_PULL_REQUESTS_FOR_SYNC, FETCH_SINGLE_PULL_FOR_SYNC}              from '../queries/pullRequestQueries.mjs';
-import contentPath                                                             from '../shared/contentPath.mjs';
+import contentPath, {parseContentPath}                                         from '../shared/contentPath.mjs';
 import {buildContentInventory, resolveArchivedLocation}                        from '../shared/contentInventory.mjs';
 import {createContentIndexEntryFromPath, readContentIndex, updateContentIndex} from '../shared/contentIndex.mjs';
 import {createContentTrustSummary, projectAuthoredNodeTrust}                   from '../shared/conversationTrust.mjs';
@@ -703,6 +703,122 @@ class PullRequestSyncer extends Base {
             logger.info(`✨ Synced ${stats.count} modified pull requests to disk.`);
         } else {
             logger.info(`✅ Synced 0 pull requests (all up to date).`);
+        }
+
+        return stats;
+    }
+
+    /**
+     * @summary Restores pull requests owning more than one artifact from canonical GitHub state.
+     *
+     * A divergent pair cannot be resolved locally. Both files are real renderings of one PR and
+     * nothing on disk records which is current — `reconcileActiveChunks`' keep-first dedup is safe in
+     * the active tier only because the next sync rewrites the survivor from GitHub, and applied here
+     * it would silently canonicalise whichever copy sorted first. So neither copy is trusted: GitHub
+     * is the source of truth for this corpus, and the artifact is re-derived from it.
+     *
+     * **Fetch before unlink.** The copies are the only local record of that PR, so deleting first and
+     * writing second would turn any network failure into a corpus that is simply missing the PR — a
+     * repair that can lose data on a bad connection is not a repair. Nothing is removed until the
+     * canonical rendering is in hand.
+     *
+     * Placement re-plans against a corpus with the removed copies excluded, so the artifact lands on
+     * the ordinal the complete ordering chooses rather than beside the wreckage of the old pair.
+     *
+     * @param {Object} metadata Sync metadata; refreshed for each repaired PR.
+     * @param {Object} [indexMutations=null] Optional accumulator for `_index.json` updates. When
+     *     omitted, the index realigns on the next {@link reconcilePullRequestIndex} pass.
+     * @returns {Promise<{repaired: Number[], removed: Number, failed: Array<{id: Number, reason: String}>}>}
+     */
+    async repairDuplicateArtifacts(metadata, indexMutations = null) {
+        const inventory = await buildContentInventory(issueSyncConfig, {
+            type      : 'pulls',
+            filePrefix: aiConfig.issueSync.pullFilenamePrefix || 'pr-'
+        });
+
+        const ambiguous = [...inventory.entries()].filter(([, copies]) => copies.length > 1),
+              stats     = {repaired: [], removed: 0, failed: []};
+
+        if (ambiguous.length === 0) return stats;
+
+        logger.info(`🔧 Restoring ${ambiguous.length} pull request(s) with duplicate artifacts from GitHub...`);
+
+        for (const [id, copies] of ambiguous) {
+            try {
+                const data = await GraphqlService.query(
+                    FETCH_SINGLE_PULL_FOR_SYNC,
+                    {
+                        owner      : aiConfig.owner,
+                        repo       : aiConfig.repo,
+                        prNumber   : id,
+                        maxComments: pullRequestConfig.maxCommentsPerPullRequest || 50,
+                        maxReviews : 20
+                    },
+                    true
+                );
+
+                const pr = data.repository.pullRequest;
+
+                if (!pr) {
+                    // Refuse rather than clean up: a PR absent from GitHub means the duplicate is not
+                    // the only thing we misunderstand here, and deleting both copies would destroy
+                    // the sole remaining record of it.
+                    stats.failed.push({id, reason: 'not found on GitHub — copies left untouched'});
+                    continue;
+                }
+
+                const content = this.#renderPullRequestMarkdown(pr);
+
+                for (const copy of copies) {
+                    await fs.unlink(copy.absPath);
+                    stats.removed++;
+                }
+
+                // The copies are gone; drop them from the membership the plan is about to rank against.
+                inventory.delete(id);
+
+                const planBuckets = this.#planBuckets(metadata, [pr], inventory),
+                      targetPath  = this.#getPullRequestPath(pr, planBuckets, inventory);
+
+                await fs.mkdir(path.dirname(targetPath), {recursive: true});
+                await fs.writeFile(targetPath, content, 'utf-8');
+
+                inventory.set(id, [{
+                    absPath    : targetPath,
+                    ...parseContentPath({contentRoot: issueSyncConfig.contentRoot, filePath: targetPath})
+                }]);
+
+                metadata.pulls ??= {};
+                metadata.pulls[id] = {
+                    number     : pr.number,
+                    contentHash: this.#calculateContentHash(content),
+                    state      : pr.state,
+                    updatedAt  : pr.updatedAt,
+                    closedAt   : pr.closedAt || null,
+                    mergedAt   : pr.mergedAt || null,
+                    milestone  : pr.milestone?.title || null,
+                    path       : this.#relativePath(targetPath)
+                };
+
+                if (indexMutations) {
+                    indexMutations.upsert.push(createContentIndexEntryFromPath({
+                        issueSyncConfig, type: 'pulls', id, filePath: targetPath
+                    }));
+                }
+
+                stats.repaired.push(id);
+            } catch (e) {
+                logger.error(`❌ Could not restore duplicate artifacts for PR #${id}: ${e.message}`);
+                stats.failed.push({id, reason: e.message});
+            }
+        }
+
+        await pruneEmptyDirs(path.join(issueSyncConfig.archiveRoot, 'pulls'));
+
+        logger.info(`🔧 Restored ${stats.repaired.length} pull request(s) from GitHub; removed ${stats.removed} duplicate artifact(s).`);
+
+        if (stats.failed.length > 0) {
+            logger.warn(`⚠️ ${stats.failed.length} duplicate repair(s) failed and remain divergent: ${stats.failed.map(f => `#${f.id} (${f.reason})`).join(', ')}`);
         }
 
         return stats;

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -1,21 +1,21 @@
-import aiConfig                                                   from '../../../mcp/server/github-workflow/config.mjs';
-import Base                                                       from '../../../../src/core/Base.mjs';
-import crypto                                                     from 'crypto';
-import {existsSync}                                               from 'fs';
-import fs                                                         from 'fs/promises';
-import logger                                                     from '../../../mcp/server/github-workflow/logger.mjs';
-import matter                                                     from 'gray-matter';
-import path                                                       from 'path';
-import semver                                                     from 'semver';
-import GraphqlService                                             from '../GraphqlService.mjs';
-import ReleaseNotesSyncer                                         from './ReleaseNotesSyncer.mjs';
-import {FETCH_PULL_REQUESTS_FOR_SYNC, FETCH_SINGLE_PULL_FOR_SYNC} from '../queries/pullRequestQueries.mjs';
-import contentPath                                                from '../shared/contentPath.mjs';
-import {createContentIndexEntry, updateContentIndex}              from '../shared/contentIndex.mjs';
-import {createContentTrustSummary, projectAuthoredNodeTrust}      from '../shared/conversationTrust.mjs';
-import pruneEmptyDirs                                             from '../shared/pruneEmptyDirs.mjs';
+import aiConfig                                                                       from '../../../mcp/server/github-workflow/config.mjs';
+import Base                                                                           from '../../../../src/core/Base.mjs';
+import crypto                                                                         from 'crypto';
+import {existsSync}                                                                   from 'fs';
+import fs                                                                             from 'fs/promises';
+import logger                                                                         from '../../../mcp/server/github-workflow/logger.mjs';
+import matter                                                                         from 'gray-matter';
+import path                                                                           from 'path';
+import semver                                                                         from 'semver';
+import GraphqlService                                                                 from '../GraphqlService.mjs';
+import ReleaseNotesSyncer                                                             from './ReleaseNotesSyncer.mjs';
+import {FETCH_PULL_REQUESTS_FOR_SYNC, FETCH_SINGLE_PULL_FOR_SYNC}                     from '../queries/pullRequestQueries.mjs';
+import contentPath                                                                    from '../shared/contentPath.mjs';
+import {createContentIndexEntry, createContentIndexEntryFromPath, updateContentIndex} from '../shared/contentIndex.mjs';
+import {createContentTrustSummary, projectAuthoredNodeTrust}                          from '../shared/conversationTrust.mjs';
+import pruneEmptyDirs                                                                 from '../shared/pruneEmptyDirs.mjs';
 
-const issueSyncConfig = aiConfig.issueSync;
+const issueSyncConfig   = aiConfig.issueSync;
 const pullRequestConfig = aiConfig.pullRequest;
 
 /**
@@ -163,7 +163,7 @@ class PullRequestSyncer extends Base {
             });
         }
 
-        const buckets = new Map();
+        const buckets     = new Map();
         const activeItems = [];
 
         for (const pr of combined.values()) {
@@ -257,13 +257,22 @@ class PullRequestSyncer extends Base {
      * an entry exists). It NEVER moves a file back to active (sealed-chunk semantics), NEVER deletes, and
      * NEVER re-fetches from GitHub.
      *
+     * A move and its `_index.json` upsert are ONE mutation set. The index is the id→path lookup every
+     * reader resolves through, so a rename that does not carry its entry does not relocate a file —
+     * it hides it: the artifact is fine, the lookup points at nothing, and no pass complains. Relying
+     * on "the next sync rebuilds the index" does not save it either, because that rebuild only covers
+     * the PRs in its own delta fetch, and a marooned backlog is precisely the set the delta never
+     * names. Entries are derived from the path the file NOW occupies rather than from the plan that
+     * chose it — a plan records intent, and intent is what goes stale.
+     *
      * @param {object} metadata Sync metadata; a moved PR's `path` is updated in place when cached.
-     * @returns {Promise<{count: number, pullRequests: number[]}>} Archived count + the PR numbers moved.
+     * @returns {Promise<{count: number, pullRequests: number[], indexed: number}>} Archived count, the
+     *     PR numbers moved, and the number of index entries realigned with them.
      */
     async reconcileClosedPullRequestLocations(metadata) {
         logger.info('🔄 Reconciling closed pull request locations...');
 
-        const stats = { count: 0, pullRequests: [] };
+        const stats = { count: 0, pullRequests: [], indexed: 0 };
 
         // Buckets are derived from release history; without it the correct archive version is unknown.
         if (!ReleaseNotesSyncer.sortedReleases || ReleaseNotesSyncer.sortedReleases.length === 0) {
@@ -304,7 +313,8 @@ class PullRequestSyncer extends Base {
         }
 
         // Bucket the scanned corpus (+ any cached metadata) by release date, exactly as the live sync does.
-        const planBuckets = this.#planBuckets(metadata, scanned);
+        const planBuckets  = this.#planBuckets(metadata, scanned),
+              indexUpserts = [];
 
         for (const pr of scanned) {
             // Only terminal PRs (CLOSED or MERGED) are archive candidates; an open PR belongs in active.
@@ -326,6 +336,14 @@ class PullRequestSyncer extends Base {
                 await fs.mkdir(path.dirname(correctPath), { recursive: true });
                 await fs.rename(pr.absPath, correctPath);
 
+                // Derived from the destination, not the plan: the entry describes where the file is.
+                indexUpserts.push(createContentIndexEntryFromPath({
+                    issueSyncConfig,
+                    type    : 'pulls',
+                    id      : pr.number,
+                    filePath: correctPath
+                }));
+
                 // Update the metadata path when this PR is tracked; marooned files outside the delta-only
                 // cache simply move (the next sync rebuilds metadata against the new location).
                 if (metadata.pulls?.[pr.number]) {
@@ -339,10 +357,25 @@ class PullRequestSyncer extends Base {
             }
         }
 
+        // One write for the pass, after the moves that earned the entries. An upsert per rename would
+        // re-read and re-sort the whole index once per file; batching keeps the pass linear.
+        if (indexUpserts.length > 0) {
+            try {
+                await updateContentIndex(issueSyncConfig, {upsert: indexUpserts});
+                stats.indexed = indexUpserts.length;
+            } catch (e) {
+                // Loud, and NOT swallowed into a success: the files have already moved, so a failed
+                // index write leaves exactly the stale-lookup state this method exists to prevent.
+                // The caller decides whether a corpus whose index is known-behind may be committed.
+                logger.error(`❌ Archived ${indexUpserts.length} pull request(s) but could not update _index.json: ${e.message}`);
+                throw e;
+            }
+        }
+
         await pruneEmptyDirs(pullsDir);
 
         logger.info(stats.count > 0
-            ? `📦 Archived ${stats.count} closed pull request(s)`
+            ? `📦 Archived ${stats.count} closed pull request(s) (${stats.indexed} index entr${stats.indexed === 1 ? 'y' : 'ies'} realigned)`
             : '✓ No closed pull requests need archiving');
 
         return stats;
@@ -473,9 +506,9 @@ class PullRequestSyncer extends Base {
             synced: []
         };
 
-        const cachedPulls = metadata.pulls || {};
-        const planBuckets = this.#planBuckets(metadata, allPullRequests);
-        let shouldPruneEmptyDirs = false;
+        const cachedPulls          = metadata.pulls || {};
+        const planBuckets          = this.#planBuckets(metadata, allPullRequests);
+        let   shouldPruneEmptyDirs = false;
 
         for (const pr of allPullRequests) {
             try {
@@ -483,7 +516,7 @@ class PullRequestSyncer extends Base {
                 const content     = this.#renderPullRequestMarkdown(pr);
                 const currentHash = this.#calculateContentHash(content);
 
-                const cachedPull = cachedPulls[pr.number];
+                const cachedPull      = cachedPulls[pr.number];
                 const oldPathRelative = cachedPull?.path;
                 const oldAbsolutePath = oldPathRelative ? this.#resolvePath(oldPathRelative) : null;
 

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -343,13 +343,14 @@ class PullRequestSyncer extends Base {
      * chose it — a plan records intent, and intent is what goes stale.
      *
      * @param {object} metadata Sync metadata; a moved PR's `path` is updated in place when cached.
-     * @returns {Promise<{count: number, pullRequests: number[], indexed: number}>} Archived count, the
-     *     PR numbers moved, and the number of index entries realigned with them.
+     * @returns {Promise<{count: number, pullRequests: number[], indexed: number, collisions: number[]}>}
+     *     Archived count, the PR numbers moved, the number of index entries realigned with them, and
+     *     the ids left in place because an artifact already occupied their destination.
      */
     async reconcileClosedPullRequestLocations(metadata) {
         logger.info('🔄 Reconciling closed pull request locations...');
 
-        const stats = { count: 0, pullRequests: [], indexed: 0 };
+        const stats = { count: 0, pullRequests: [], indexed: 0, collisions: [] };
 
         // Buckets are derived from release history; without it the correct archive version is unknown.
         if (!ReleaseNotesSyncer.sortedReleases || ReleaseNotesSyncer.sortedReleases.length === 0) {
@@ -410,6 +411,19 @@ class PullRequestSyncer extends Base {
             // No target, already correctly located, or the correct path is still active (no archive
             // applies) → skip. Never relocate INTO active.
             if (!correctPath || pr.absPath === correctPath || correctPath.startsWith(pullsDir)) {
+                continue;
+            }
+
+            // `fs.rename` silently replaces its destination. A same-id artifact already sitting at
+            // `correctPath` means this PR owns two copies, and renaming over it would destroy one —
+            // specifically the archived one, which is the divergent evidence the duplicate repair
+            // exists to arbitrate from source. This pass runs BEFORE that repair, so an unguarded
+            // rename lets the relocate step quietly resolve a duplicate by deletion, which is the
+            // one resolution this lane refuses. Leave both; the integrity pass reports the id and
+            // `repairDuplicateArtifacts` restores it from GitHub.
+            if (existsSync(correctPath)) {
+                logger.warn(`⚠️ PR #${pr.number} already has an artifact at ${correctPath} — leaving both in place for duplicate repair rather than renaming over it.`);
+                stats.collisions.push(pr.number);
                 continue;
             }
 
@@ -769,19 +783,36 @@ class PullRequestSyncer extends Base {
 
                 const content = this.#renderPullRequestMarkdown(pr);
 
-                for (const copy of copies) {
-                    await fs.unlink(copy.absPath);
-                    stats.removed++;
-                }
-
-                // The copies are gone; drop them from the membership the plan is about to rank against.
+                // Plan against membership with the duplicates excluded — they are about to stop
+                // existing, and `#getPullRequestPath` refuses an ambiguous id by design.
                 inventory.delete(id);
 
                 const planBuckets = this.#planBuckets(metadata, [pr], inventory),
                       targetPath  = this.#getPullRequestPath(pr, planBuckets, inventory);
 
+                // DURABLE FIRST, then delete. Holding the canonical rendering in memory protects
+                // against a failed fetch and nothing else: every step between an unlink and the
+                // write can throw — planning, path resolution, mkdir, the write itself — and a crash
+                // needs no exception at all. Any of them, with the copies already gone, leaves the
+                // corpus missing the PR entirely and the failure logged as a soft skip. "Fetched"
+                // is not "durable"; only a file on disk is.
+                //
+                // Temp + atomic rename so a torn write cannot masquerade as the canonical artifact.
                 await fs.mkdir(path.dirname(targetPath), {recursive: true});
-                await fs.writeFile(targetPath, content, 'utf-8');
+
+                const tempPath = `${targetPath}.${process.pid}.tmp`;
+
+                await fs.writeFile(tempPath, content, 'utf-8');
+                await fs.rename(tempPath, targetPath);
+
+                // Only now remove the stale copies — and never the one just written, which may BE
+                // one of them when the canonical location is a copy's own address.
+                for (const copy of copies) {
+                    if (path.resolve(copy.absPath) === path.resolve(targetPath)) continue;
+
+                    await fs.unlink(copy.absPath);
+                    stats.removed++;
+                }
 
                 inventory.set(id, [{
                     absPath    : targetPath,

--- a/ai/services/github-workflow/sync/PullRequestSyncer.mjs
+++ b/ai/services/github-workflow/sync/PullRequestSyncer.mjs
@@ -1,20 +1,20 @@
-import aiConfig                                                   from '../../../mcp/server/github-workflow/config.mjs';
-import Base                                                       from '../../../../src/core/Base.mjs';
-import crypto                                                     from 'crypto';
-import {existsSync}                                               from 'fs';
-import fs                                                         from 'fs/promises';
-import logger                                                     from '../../../mcp/server/github-workflow/logger.mjs';
-import matter                                                     from 'gray-matter';
-import path                                                       from 'path';
-import semver                                                     from 'semver';
-import GraphqlService                                             from '../GraphqlService.mjs';
-import ReleaseNotesSyncer                                         from './ReleaseNotesSyncer.mjs';
-import {FETCH_PULL_REQUESTS_FOR_SYNC, FETCH_SINGLE_PULL_FOR_SYNC} from '../queries/pullRequestQueries.mjs';
-import contentPath                                                from '../shared/contentPath.mjs';
-import {buildContentInventory, resolveArchivedLocation}           from '../shared/contentInventory.mjs';
-import {createContentIndexEntryFromPath, updateContentIndex}      from '../shared/contentIndex.mjs';
-import {createContentTrustSummary, projectAuthoredNodeTrust}      from '../shared/conversationTrust.mjs';
-import pruneEmptyDirs                                             from '../shared/pruneEmptyDirs.mjs';
+import aiConfig                                                                from '../../../mcp/server/github-workflow/config.mjs';
+import Base                                                                    from '../../../../src/core/Base.mjs';
+import crypto                                                                  from 'crypto';
+import {existsSync}                                                            from 'fs';
+import fs                                                                      from 'fs/promises';
+import logger                                                                  from '../../../mcp/server/github-workflow/logger.mjs';
+import matter                                                                  from 'gray-matter';
+import path                                                                    from 'path';
+import semver                                                                  from 'semver';
+import GraphqlService                                                          from '../GraphqlService.mjs';
+import ReleaseNotesSyncer                                                      from './ReleaseNotesSyncer.mjs';
+import {FETCH_PULL_REQUESTS_FOR_SYNC, FETCH_SINGLE_PULL_FOR_SYNC}              from '../queries/pullRequestQueries.mjs';
+import contentPath                                                             from '../shared/contentPath.mjs';
+import {buildContentInventory, resolveArchivedLocation}                        from '../shared/contentInventory.mjs';
+import {createContentIndexEntryFromPath, readContentIndex, updateContentIndex} from '../shared/contentIndex.mjs';
+import {createContentTrustSummary, projectAuthoredNodeTrust}                   from '../shared/conversationTrust.mjs';
+import pruneEmptyDirs                                                          from '../shared/pruneEmptyDirs.mjs';
 
 const issueSyncConfig   = aiConfig.issueSync;
 const pullRequestConfig = aiConfig.pullRequest;
@@ -706,6 +706,87 @@ class PullRequestSyncer extends Base {
         }
 
         return stats;
+    }
+
+    /**
+     * @summary Realigns `_index.json` with the pull corpus on disk. The repair half of this lane.
+     *
+     * The index is a PROJECTION of the corpus, so it can always be recomputed from it — and once a
+     * pass exists that does, drift is not a state anyone has to migrate out of. Every id owning
+     * exactly one artifact gets an entry naming that artifact's actual location.
+     *
+     * This exists because preventing new drift does not remove old drift, and nothing else would ever
+     * have: the thousands of entries already naming pre-move locations point at files that are
+     * ALREADY archived, so the relocate pass never touches them again and never re-indexes them.
+     * They are unreachable by every mechanism that was expected to heal them. A migration script
+     * would clear them once and leave the class alive; the drift was produced by the normal path, so
+     * the normal path is what has to be able to remove it. Run every sync, idempotent, cheap when
+     * clean — it upserts only entries that actually disagree with disk, so a healthy corpus writes
+     * nothing and the generated-content diff stays empty.
+     *
+     * Ambiguous ids are SKIPPED rather than indexed. An entry for one of two artifacts would name a
+     * copy and thereby bless it as canonical — the arbitrary choice this lane refuses to make on the
+     * corpus's behalf. They surface in the integrity result for repair from source.
+     *
+     * @param {Map<number, Array<object>>} [inventory] Pre-built corpus inventory; scanned when omitted.
+     * @returns {Promise<{reindexed: Number, unchanged: Number, skippedAmbiguous: Number[]}>}
+     */
+    async reconcilePullRequestIndex(inventory = null) {
+        const corpus = inventory || await buildContentInventory(issueSyncConfig, {
+            type      : 'pulls',
+            filePrefix: aiConfig.issueSync.pullFilenamePrefix || 'pr-'
+        });
+
+        const existing = new Map(
+            (await readContentIndex(issueSyncConfig))
+                .filter(entry => entry.type === 'pulls')
+                .map(entry => [Number(entry.id), entry])
+        );
+
+        const upsert           = [],
+              skippedAmbiguous = [];
+
+        let unchanged = 0;
+
+        for (const [id, copies] of corpus) {
+            if (copies.length > 1) {
+                skippedAmbiguous.push(id);
+                continue;
+            }
+
+            const entry = createContentIndexEntryFromPath({
+                issueSyncConfig,
+                type    : 'pulls',
+                id,
+                filePath: copies[0].absPath
+            });
+
+            const previous = existing.get(id);
+
+            // Compare every coordinate, not just the path: an entry can name the right file and still
+            // carry a chunkNumber that contradicts it.
+            if (previous &&
+                previous.path        === entry.path &&
+                previous.chunkNumber === entry.chunkNumber &&
+                (previous.version ?? null) === (entry.version ?? null)
+            ) {
+                unchanged++;
+                continue;
+            }
+
+            upsert.push(entry);
+        }
+
+        if (upsert.length > 0) {
+            await updateContentIndex(issueSyncConfig, {upsert});
+            logger.info(`🧭 Realigned ${upsert.length} pull index entr${upsert.length === 1 ? 'y' : 'ies'} with the corpus (${unchanged} already correct).`);
+        }
+
+        if (skippedAmbiguous.length > 0) {
+            logger.warn(`⚠️ ${skippedAmbiguous.length} pull request(s) own more than one artifact and were left unindexed: ${skippedAmbiguous.join(', ')}`);
+        }
+
+        return {reindexed: upsert.length, unchanged, skippedAmbiguous};
     }
 
     /**

--- a/ai/services/knowledge-base/source/PullRequestSource.mjs
+++ b/ai/services/knowledge-base/source/PullRequestSource.mjs
@@ -19,7 +19,7 @@ import {splitPullRequestArchiveMarkdown} from './pullRequestArchiveElementSplitt
  * @singleton
  */
 const loadIndexMap = async (neoRootDir, type) => {
-    const map = new Map();
+    const map       = new Map();
     const typeIndex = path.resolve(neoRootDir, `resources/content/${type}/_index.json`);
     const rootIndex = path.resolve(neoRootDir, 'resources/content/_index.json');
 
@@ -69,6 +69,18 @@ class PullRequestSource extends Base {
         const indexMap    = await loadIndexMap(aiConfig.neoRootDir, 'pulls');
         const contentRoot = path.resolve(aiConfig.neoRootDir, 'resources/content');
 
+        // Extraction walks FILES, but a chunk's name is keyed by PR IDENTITY (`pr-<id>#<element>`).
+        // Two artifacts for one id therefore emit two chunks under the SAME logical name with
+        // DIFFERENT content and different `source` paths — so they land as distinct rows, and a
+        // retrieval returns both. A maintainer then reads one PR's two divergent renderings as two
+        // corroborating pieces of evidence. That is the failure this corpus's integrity work exists
+        // to prevent, arriving through the consumer rather than the writer.
+        //
+        // Ids are normalised to strings because they arrive typed two ways: `Number` from the index
+        // map, `String` from the filename fallback. Comparing them raw makes `10124 !== '10124'` and
+        // the check silently never fires — a guard that cannot see the thing it guards against.
+        const seenIds = new Map();
+
         for (const targetPath of targetPaths) {
             if (await fs.pathExists(targetPath)) {
                 const pullFiles = await fs.readdir(targetPath, { recursive: true });
@@ -87,6 +99,24 @@ class PullRequestSource extends Base {
                         const content = await fs.readFile(filePath, 'utf-8');
                         // Relative path keeps the distributed Chroma zip portable.
                         const source = path.relative(aiConfig.neoRootDir, filePath);
+                        const idKey  = String(id);
+
+                        // Fail closed. Skipping the second copy would be a silent choice of which
+                        // rendering is canonical — made by directory-walk order, which is not a
+                        // judgement anything here is entitled to make. Emitting both is worse: the
+                        // Knowledge Base would then answer questions about this PR with two
+                        // divergent texts and no way to tell a reader that one is stale. Refusing
+                        // costs an ingestion run; the alternatives cost the retrieval substrate's
+                        // trustworthiness, which is the only thing it has.
+                        if (seenIds.has(idKey)) {
+                            throw new Error(
+                                `PullRequestSource: pull request ${idKey} has more than one local artifact ` +
+                                `(${seenIds.get(idKey)} and ${source}) — refusing to embed duplicate evidence ` +
+                                `under one logical name. Repair the corpus first.`
+                            );
+                        }
+
+                        seenIds.set(idKey, source);
                         // Per-element chunks (body + each review/comment) keep a multi-round PR
                         // under the embedding cap; a no-discussion PR yields one body chunk whose
                         // content equals the whole file.
@@ -94,9 +124,9 @@ class PullRequestSource extends Base {
 
                         for (const element of elements) {
                             const suffix = element.kind === 'body' ? 'body' : `${element.kind}-${element.ordinal}`;
-                            const chunk = {
-                                type: 'pull',
-                                kind: 'pull',
+                            const chunk  = {
+                                type   : 'pull',
+                                kind   : 'pull',
                                 name   : `pr-${id}#${suffix}`,
                                 content: element.content,
                                 source

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -382,6 +382,119 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         await expect(fs.pathExists(activePath)).resolves.toBe(true);    // untouched
     });
 
+    // --- the divergent-duplicate mechanism: an ordinal recomputed from a delta-sized view of a
+    //     sealed bucket is not a smaller truth, it is a different number — so the write lands BESIDE
+    //     the existing copy instead of on it, and the two renderings diverge from there. ---
+
+    test('refreshing an already-archived PR overwrites its artifact instead of creating a rival copy', async () => {
+        // The production shape, reproduced: PR 10124 lives at chunk-2 of a sealed bucket. The delta
+        // sync fetches it with NO cache entry — so the planner ranks it against the one PR it can
+        // see, computes ordinal 0, and resolves chunk-1. Pre-fix that wrote a SECOND artifact and
+        // left the first in place, because the unlink is gated on `cachedPull?.path`, which a cache
+        // miss makes null.
+        const prNumber    = 10124,
+              existingDir = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-2');
+
+        await fs.ensureDir(existingDir);
+        await fs.writeFile(path.join(existingDir, `pr-${prNumber}.md`), 'stale rendering, fewer comments', 'utf8');
+
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+
+        GraphqlService.query = async () => ({
+            repository: {
+                pullRequests: {
+                    nodes   : [buildPullRequest(prNumber)],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        // Empty cache — the marooned case the delta never names.
+        await PullRequestSyncer.syncPullRequests({pulls: {}});
+
+        const rival    = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-1', `pr-${prNumber}.md`),
+              occupied = path.join(existingDir, `pr-${prNumber}.md`);
+
+        // Exactly one artifact, at the location the PR already owned.
+        await expect(fs.pathExists(rival)).resolves.toBe(false);
+        await expect(fs.pathExists(occupied)).resolves.toBe(true);
+
+        // And it was REFRESHED in place, not merely left alone — the stale rendering is gone.
+        expect(await fs.readFile(occupied, 'utf8')).not.toBe('stale rendering, fewer comments');
+        expect(matter(await fs.readFile(occupied, 'utf8')).data.number).toBe(prNumber);
+    });
+
+    test('a new archive arrival is ranked against the bucket ON DISK, not against the delta', async () => {
+        // The ordinal is defined over complete bucket membership. With a threshold of 2 and two PRs
+        // already sealed in v13.0.0, a third belongs in chunk-2. A planner that sees only the delta
+        // ranks it 0 and resolves chunk-1 — confidently wrong, and it would land on top of an
+        // existing chunk that the full ordering says is full.
+        const originalThreshold = aiConfig.issueSync.archiveChunkThreshold;
+
+        aiConfig.issueSync.archiveChunkThreshold = 2;
+
+        try {
+            const sealedDir = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-1');
+
+            await fs.ensureDir(sealedDir);
+            await fs.writeFile(path.join(sealedDir, 'pr-100.md'), 'sealed', 'utf8');
+            await fs.writeFile(path.join(sealedDir, 'pr-200.md'), 'sealed', 'utf8');
+
+            ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+
+            GraphqlService.query = async () => ({
+                repository: {
+                    pullRequests: {
+                        nodes   : [buildPullRequest(300)],
+                        pageInfo: {hasNextPage: false, endCursor: null}
+                    }
+                }
+            });
+
+            await PullRequestSyncer.syncPullRequests({pulls: {}});
+
+            // Complete membership [100, 200, 300] → 300 is ordinal 2 → chunk-2 at a threshold of 2.
+            await expect(fs.pathExists(path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-2', 'pr-300.md'))).resolves.toBe(true);
+            await expect(fs.pathExists(path.join(sealedDir, 'pr-300.md'))).resolves.toBe(false);
+        } finally {
+            aiConfig.issueSync.archiveChunkThreshold = originalThreshold;
+        }
+    });
+
+    test('a PR owning two archived artifacts is REFUSED, not guessed at — and the sync survives it', async () => {
+        // Nothing on disk says which copy is current, so writing to either canonicalises a guess and
+        // destroys the evidence. The PR is skipped; the run continues; the integrity pass reports it.
+        const prNumber = 10124;
+
+        for (const chunk of ['chunk-1', 'chunk-2']) {
+            const dir = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', chunk);
+
+            await fs.ensureDir(dir);
+            await fs.writeFile(path.join(dir, `pr-${prNumber}.md`), `divergent ${chunk}`, 'utf8');
+        }
+
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+
+        // A healthy PR alongside the corrupt one: one bad id must not wedge the whole run.
+        GraphqlService.query = async () => ({
+            repository: {
+                pullRequests: {
+                    nodes   : [buildPullRequest(prNumber), buildPullRequest(777)],
+                    pageInfo: {hasNextPage: false, endCursor: null}
+                }
+            }
+        });
+
+        const stats = await PullRequestSyncer.syncPullRequests({pulls: {}});
+
+        // The corrupt id is not synced; the healthy one is.
+        expect(stats.synced).toEqual([777]);
+
+        // Neither copy was overwritten and no third appeared — the divergence is preserved as evidence.
+        expect(await fs.readFile(path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-1', `pr-${prNumber}.md`), 'utf8')).toBe('divergent chunk-1');
+        expect(await fs.readFile(path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-2', `pr-${prNumber}.md`), 'utf8')).toBe('divergent chunk-2');
+    });
+
     // --- the move/index mutation set: a rename that does not carry its `_index.json` entry does not
     //     relocate a file, it hides it. This is the mechanism behind the stale-lookup backlog. ---
 

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -593,6 +593,96 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         expect(stats.indexed).toBe(0);
     });
 
+    // --- restoring divergent duplicates: both copies are real renderings of one PR and nothing on
+    //     disk says which is current, so neither is trusted and GitHub decides. ---
+
+    const seedDivergentPair = async (prNumber, version = 'v13.0.0') => {
+        for (const chunk of ['chunk-1', 'chunk-2']) {
+            const dir = path.join(aiConfig.issueSync.archiveRoot, 'pulls', version, chunk);
+
+            await fs.ensureDir(dir);
+            await fs.writeFile(path.join(dir, `pr-${prNumber}.md`), `divergent ${chunk}`, 'utf8');
+        }
+    };
+
+    test('restores a divergent pair from GitHub — one artifact survives, neither local copy decides', async () => {
+        const prNumber = 10124;
+
+        await seedDivergentPair(prNumber);
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+        GraphqlService.query = async () => ({repository: {pullRequest: buildPullRequest(prNumber)}});
+
+        const metadata = {pulls: {}},
+              stats    = await PullRequestSyncer.repairDuplicateArtifacts(metadata);
+
+        expect(stats.repaired).toEqual([prNumber]);
+        expect(stats.removed).toBe(2);
+
+        // Exactly one artifact remains, and it is the canonical rendering — not either local copy.
+        const survivors = [];
+        for (const chunk of ['chunk-1', 'chunk-2', 'chunk-3']) {
+            const p = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', chunk, `pr-${prNumber}.md`);
+            if (await fs.pathExists(p)) survivors.push(await fs.readFile(p, 'utf8'));
+        }
+
+        expect(survivors).toHaveLength(1);
+        expect(survivors[0]).not.toContain('divergent');
+        expect(matter(survivors[0]).data.number).toBe(prNumber);
+        expect(metadata.pulls[prNumber].path).toContain(`pr-${prNumber}.md`);
+    });
+
+    test('a failed fetch leaves BOTH copies intact — a repair that can lose data is not a repair', async () => {
+        // Fetch before unlink. The copies are the only local record, so deleting first would turn a
+        // network blip into a corpus simply missing the PR.
+        const prNumber = 10125;
+
+        await seedDivergentPair(prNumber);
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+        GraphqlService.query = async () => { throw new Error('network down') };
+
+        const stats = await PullRequestSyncer.repairDuplicateArtifacts({pulls: {}});
+
+        expect(stats.repaired).toEqual([]);
+        expect(stats.removed).toBe(0);
+        expect(stats.failed[0].id).toBe(prNumber);
+
+        for (const chunk of ['chunk-1', 'chunk-2']) {
+            const p = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', chunk, `pr-${prNumber}.md`);
+
+            expect(await fs.readFile(p, 'utf8')).toBe(`divergent ${chunk}`);
+        }
+    });
+
+    test('a PR absent from GitHub is refused, not cleaned up — the copies are the only record left', async () => {
+        const prNumber = 10126;
+
+        await seedDivergentPair(prNumber);
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+        GraphqlService.query = async () => ({repository: {pullRequest: null}});
+
+        const stats = await PullRequestSyncer.repairDuplicateArtifacts({pulls: {}});
+
+        expect(stats.removed).toBe(0);
+        expect(stats.failed[0].reason).toContain('not found on GitHub');
+        await expect(fs.pathExists(path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-1', `pr-${prNumber}.md`))).resolves.toBe(true);
+    });
+
+    test('is a no-op on a corpus with no duplicates — and makes no network call', async () => {
+        const single = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-1', 'pr-500.md');
+
+        await fs.ensureDir(path.dirname(single));
+        await fs.writeFile(single, 'fine', 'utf8');
+
+        let queried = false;
+        GraphqlService.query = async () => { queried = true; return {repository: {pullRequest: null}} };
+
+        const stats = await PullRequestSyncer.repairDuplicateArtifacts({pulls: {}});
+
+        expect(stats).toEqual({repaired: [], removed: 0, failed: []});
+        expect(queried).toBe(false);
+        expect(await fs.readFile(single, 'utf8')).toBe('fine');
+    });
+
     // --- the repair: preventing new drift does not remove old drift. Entries stranded by moves that
     //     predate the upsert name files ALREADY archived, so no relocate pass revisits them and no
     //     delta fetch names them — they are unreachable by every mechanism expected to heal them. ---

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -13,12 +13,13 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../../src/Neo.mjs';
-import * as core      from '../../../../../../src/core/_export.mjs';
-import fs             from 'fs-extra';
-import matter         from 'gray-matter';
-import path           from 'path';
+import {test, expect}     from '@playwright/test';
+import Neo                from '../../../../../../src/Neo.mjs';
+import * as core          from '../../../../../../src/core/_export.mjs';
+import fs                 from 'fs-extra';
+import matter             from 'gray-matter';
+import path               from 'path';
+import {readContentIndex} from '../../../../../../ai/services/github-workflow/shared/contentIndex.mjs';
 
 test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
     let aiConfig;
@@ -379,6 +380,104 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
 
         expect(stats.count).toBe(0);
         await expect(fs.pathExists(activePath)).resolves.toBe(true);    // untouched
+    });
+
+    // --- the move/index mutation set: a rename that does not carry its `_index.json` entry does not
+    //     relocate a file, it hides it. This is the mechanism behind the stale-lookup backlog. ---
+
+    test('an archive move carries its _index.json upsert — the entry names the file it actually moved to', async () => {
+        const prNumber   = 13001,
+              activePath = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`);
+
+        await fs.ensureDir(path.dirname(activePath));
+        await fs.writeFile(activePath, `---\nnumber: ${prNumber}\nstate: MERGED\nclosedAt: '2026-05-01T00:00:00Z'\n---\nbody`, 'utf-8');
+
+        // The index names the file's CURRENT (active) location, as it would before the move.
+        await fs.writeJson(path.join(aiConfig.issueSync.contentRoot, '_index.json'), [
+            {type: 'pulls', id: prNumber, version: null, chunkNumber: 1, path: `pulls/chunk-1/pr-${prNumber}.md`}
+        ]);
+
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+
+        const stats = await PullRequestSyncer.reconcileClosedPullRequestLocations({pulls: {}});
+        const entry = (await readContentIndex(aiConfig.issueSync)).find(e => e.type === 'pulls' && e.id === prNumber);
+
+        // The lookup is asserted BEFORE any counter this fix introduced. A counter is bookkeeping the
+        // change itself added, so a spec that trips on it first proves only that the new field exists
+        // — the defect (a lookup naming a file that moved) would never be evaluated. Pre-fix this
+        // reads `pulls/chunk-1/...`: the file is in the archive and the index still points at active.
+        expect(entry.path).toBe(`archive/pulls/v13.0.0/chunk-1/pr-${prNumber}.md`);
+        expect(entry.version).toBe('v13.0.0');
+        expect(entry.chunkNumber).toBe(1);
+
+        // The entry resolves to a file that exists: the property the stale-lookup backlog violates.
+        await expect(fs.pathExists(path.join(aiConfig.issueSync.contentRoot, entry.path))).resolves.toBe(true);
+
+        expect(stats.count).toBe(1);
+        expect(stats.indexed).toBe(1);
+    });
+
+    test('a marooned move with NO metadata entry is still indexed — the delta cache is not the index', async () => {
+        // The production shape. "The next sync rebuilds `_index.json`" is false for exactly this set:
+        // the rebuild only covers PRs in its own delta fetch, and a marooned backlog is the set the
+        // delta never names. If the move does not carry the entry, nothing ever writes it.
+        const prNumber   = 11530,
+              activePath = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`);
+
+        await fs.ensureDir(path.dirname(activePath));
+        await fs.writeFile(activePath, `---\nnumber: ${prNumber}\nstate: MERGED\nclosedAt: '2026-05-01T00:00:00Z'\n---\nbody`, 'utf-8');
+
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+
+        const stats = await PullRequestSyncer.reconcileClosedPullRequestLocations({pulls: {}});
+        const entry = (await readContentIndex(aiConfig.issueSync)).find(e => e.id === prNumber);
+
+        // Asserted before the counter: pre-fix there is no entry at all for this PR, and nothing
+        // downstream would ever create one.
+        expect(entry, 'a marooned move must still produce an index entry').toBeDefined();
+        expect(entry.path).toBe(`archive/pulls/v13.0.0/chunk-1/pr-${prNumber}.md`);
+        expect(stats.indexed).toBe(1);
+    });
+
+    test('every PR moved in one pass is indexed — not just the last one', async () => {
+        // A single batched index write must not collapse to one entry: the pass that produced the
+        // backlog moved 1,325 files at once.
+        const numbers = [12001, 12002, 12003];
+
+        for (const n of numbers) {
+            const p = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${n}.md`);
+            await fs.ensureDir(path.dirname(p));
+            await fs.writeFile(p, `---\nnumber: ${n}\nstate: MERGED\nclosedAt: '2026-05-01T00:00:00Z'\n---\n`, 'utf-8');
+        }
+
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+
+        const stats = await PullRequestSyncer.reconcileClosedPullRequestLocations({pulls: {}});
+        const index = await readContentIndex(aiConfig.issueSync);
+
+        for (const n of numbers) {
+            const entry = index.find(e => e.id === n);
+
+            expect(entry, `PR ${n} must be indexed`).toBeDefined();
+            await expect(fs.pathExists(path.join(aiConfig.issueSync.contentRoot, entry.path))).resolves.toBe(true);
+        }
+
+        expect(stats.count).toBe(3);
+        expect(stats.indexed).toBe(3);
+    });
+
+    test('a pass that moves nothing writes no index entries', async () => {
+        const prNumber   = 22223,
+              activePath = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`);
+
+        await fs.ensureDir(path.dirname(activePath));
+        await fs.writeFile(activePath, `---\nnumber: ${prNumber}\nstate: OPEN\n---\n`, 'utf-8');
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+
+        const stats = await PullRequestSyncer.reconcileClosedPullRequestLocations({pulls: {}});
+
+        expect(stats.count).toBe(0);
+        expect(stats.indexed).toBe(0);
     });
 
     test('is a no-op when no releases are loaded (fail-safe)', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -17,6 +17,7 @@ import {test, expect}     from '@playwright/test';
 import Neo                from '../../../../../../src/Neo.mjs';
 import * as core          from '../../../../../../src/core/_export.mjs';
 import fs                 from 'fs-extra';
+import fsPromises         from 'fs/promises';
 import matter             from 'gray-matter';
 import path               from 'path';
 import {readContentIndex} from '../../../../../../ai/services/github-workflow/shared/contentIndex.mjs';
@@ -616,7 +617,11 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
               stats    = await PullRequestSyncer.repairDuplicateArtifacts(metadata);
 
         expect(stats.repaired).toEqual([prNumber]);
-        expect(stats.removed).toBe(2);
+        // 1, not 2: `removed` counts STALE copies. The canonical write lands at the ordinal the
+        // complete ordering chooses, which here is one of the copies' own addresses — that copy is
+        // replaced in place by the atomic rename rather than deleted, so only the rival is removed.
+        // Deleting it would delete the artifact just written.
+        expect(stats.removed).toBe(1);
 
         // Exactly one artifact remains, and it is the canonical rendering — not either local copy.
         const survivors = [];
@@ -651,6 +656,66 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
 
             expect(await fs.readFile(p, 'utf8')).toBe(`divergent ${chunk}`);
         }
+    });
+
+    test('a failed WRITE leaves both copies intact — "fetched" is not "durable"', async () => {
+        // The gap the fetch-before-unlink test does not reach. Holding the rendering in memory
+        // protects against a network failure and nothing else: every step between an unlink and the
+        // write can throw, and a crash needs no exception at all. Only a file on disk is durable, so
+        // the canonical artifact is written and renamed into place BEFORE anything is removed.
+        const prNumber = 10127;
+
+        await seedDivergentPair(prNumber);
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+        GraphqlService.query = async () => ({repository: {pullRequest: buildPullRequest(prNumber)}});
+
+        // Fail the write itself — the fetch succeeds, so the old shape would already have unlinked.
+        const originalWriteFile = fsPromises.writeFile;
+
+        fsPromises.writeFile = async () => { throw new Error('ENOSPC: no space left on device') };
+
+        let stats;
+        try {
+            stats = await PullRequestSyncer.repairDuplicateArtifacts({pulls: {}});
+        } finally {
+            fsPromises.writeFile = originalWriteFile;
+        }
+
+        expect(stats.repaired).toEqual([]);
+        expect(stats.removed).toBe(0);
+        expect(stats.failed[0].id).toBe(prNumber);
+
+        // Both copies survive: the corpus still holds the PR, divergent but present.
+        for (const chunk of ['chunk-1', 'chunk-2']) {
+            const p = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', chunk, `pr-${prNumber}.md`);
+
+            expect(await fs.readFile(p, 'utf8'), `${chunk} must survive a failed write`).toBe(`divergent ${chunk}`);
+        }
+    });
+
+    test('the relocate pass REFUSES to rename over an existing same-id artifact — it would destroy the evidence', async () => {
+        // `fs.rename` silently replaces its destination. This pass runs BEFORE the duplicate repair,
+        // so an unguarded rename resolves a duplicate by deletion — the one resolution this lane
+        // refuses — and the copy it destroys is the archived one the repair arbitrates from.
+        const prNumber = 10128,
+              active   = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`),
+              archived = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-1', `pr-${prNumber}.md`);
+
+        await fs.ensureDir(path.dirname(active));
+        await fs.writeFile(active, `---\nnumber: ${prNumber}\nstate: MERGED\nclosedAt: '2026-05-01T00:00:00Z'\n---\nactive copy`, 'utf-8');
+        await fs.ensureDir(path.dirname(archived));
+        await fs.writeFile(archived, 'archived copy — the evidence', 'utf8');
+
+        ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+
+        const stats = await PullRequestSyncer.reconcileClosedPullRequestLocations({pulls: {}});
+
+        expect(stats.collisions).toEqual([prNumber]);
+        expect(stats.count).toBe(0);
+
+        // BOTH survive — the duplicate is routed to the repair, not silently resolved here.
+        expect(await fs.readFile(archived, 'utf8')).toBe('archived copy — the evidence');
+        await expect(fs.pathExists(active)).resolves.toBe(true);
     });
 
     test('a PR absent from GitHub is refused, not cleaned up — the copies are the only record left', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -811,6 +811,42 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         expect((await readContentIndex(aiConfig.issueSync)).find(e => e.id === prNumber).chunkNumber).toBe(2);
     });
 
+    test('REMOVES an existing row for an ambiguous id — un-indexing is not enough', async () => {
+        // Skipping the id leaves any prior row in place, and that row names one of two divergent
+        // artifacts — an assertion that the id resolves there, which is the canonical-by-implication
+        // choice this lane refuses. Silently, too: the path is real, so every existence check passes.
+        const prNumber = 10124;
+
+        for (const chunk of ['chunk-1', 'chunk-2']) {
+            const dir = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', chunk);
+
+            await fs.ensureDir(dir);
+            await fs.writeFile(path.join(dir, `pr-${prNumber}.md`), `divergent ${chunk}`, 'utf8');
+        }
+
+        // A pre-existing row blessing chunk-1.
+        await fs.writeJson(path.join(aiConfig.issueSync.contentRoot, '_index.json'), [
+            {type: 'pulls', id: prNumber, version: 'v13.0.0', chunkNumber: 1, path: `archive/pulls/v13.0.0/chunk-1/pr-${prNumber}.md`}
+        ]);
+
+        const stats = await PullRequestSyncer.reconcilePullRequestIndex();
+
+        expect(stats.skippedAmbiguous).toEqual([prNumber]);
+        expect(stats.removed).toBe(1);
+        expect((await readContentIndex(aiConfig.issueSync)).find(e => e.id === prNumber)).toBeUndefined();
+    });
+
+    test('REMOVES a row whose id owns no artifact at all — a lookup into nothing', async () => {
+        await fs.writeJson(path.join(aiConfig.issueSync.contentRoot, '_index.json'), [
+            {type: 'pulls', id: 4040, version: null, chunkNumber: 1, path: 'pulls/chunk-1/pr-4040.md'}
+        ]);
+
+        const stats = await PullRequestSyncer.reconcilePullRequestIndex();
+
+        expect(stats.removed).toBe(1);
+        expect((await readContentIndex(aiConfig.issueSync)).find(e => e.id === 4040)).toBeUndefined();
+    });
+
     test('leaves an ambiguous id UNINDEXED rather than blessing a copy as canonical', async () => {
         const prNumber = 10124;
 

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -425,6 +425,51 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         expect(matter(await fs.readFile(occupied, 'utf8')).data.number).toBe(prNumber);
     });
 
+    test('an OPEN PR is ranked against the ACTIVE corpus on disk, not against the delta — RA-1 planner witness', async () => {
+        // @neo-gpt-emmy is right that the scanner coverage never proved this: `contentInventory`
+        // specs show the SCANNER finds active files, not that the PLANNER ranks against them. This
+        // asserts the rank itself, which is the thing RA-1 actually claimed.
+        //
+        // Three OPEN PRs already on disk in active, none in metadata (the partial-metadata case), and
+        // a fourth arriving. With a threshold of 2, complete active membership [100,200,300,400] puts
+        // 400 at ordinal 3 → chunk-2. A planner ranking against the delta alone sees only 400,
+        // ordinal 0 → chunk-1: confidently wrong, and silent.
+        const originalThreshold = aiConfig.issueSync.archiveChunkThreshold;
+
+        aiConfig.issueSync.archiveChunkThreshold = 2;
+
+        try {
+            const activeDir = path.join(aiConfig.issueSync.pullsDir, 'chunk-1');
+
+            await fs.ensureDir(activeDir);
+            for (const id of [100, 200, 300]) {
+                await fs.writeFile(path.join(activeDir, `pr-${id}.md`), `---\nnumber: ${id}\nstate: OPEN\n---\n`, 'utf-8');
+            }
+
+            // No releases → nothing archives; every PR resolves to the active tier.
+            ReleaseNotesSyncer.sortedReleases = [];
+
+            const arriving = buildPullRequest(400);
+
+            arriving.state    = 'OPEN';
+            arriving.mergedAt = null;
+            arriving.closedAt = null;
+
+            GraphqlService.query = async () => ({
+                repository: {pullRequests: {nodes: [arriving], pageInfo: {hasNextPage: false, endCursor: null}}}
+            });
+
+            await PullRequestSyncer.syncPullRequests({pulls: {}});
+
+            // Ordinal 3 of [100,200,300,400] at threshold 2 → chunk-2.
+            await expect(fs.pathExists(path.join(aiConfig.issueSync.pullsDir, 'chunk-2', 'pr-400.md'))).resolves.toBe(true);
+            // Not chunk-1, which is what ranking against the delta alone would have chosen.
+            await expect(fs.pathExists(path.join(activeDir, 'pr-400.md'))).resolves.toBe(false);
+        } finally {
+            aiConfig.issueSync.archiveChunkThreshold = originalThreshold;
+        }
+    });
+
     test('a new archive arrival is ranked against the bucket ON DISK, not against the delta', async () => {
         // The ordinal is defined over complete bucket membership. With a threshold of 2 and two PRs
         // already sealed in v13.0.0, a third belongs in chunk-2. A planner that sees only the delta
@@ -716,6 +761,71 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         // BOTH survive — the duplicate is routed to the repair, not silently resolved here.
         expect(await fs.readFile(archived, 'utf8')).toBe('archived copy — the evidence');
         await expect(fs.pathExists(active)).resolves.toBe(true);
+    });
+
+    test('a failed repair does not poison the SHARED inventory — the next id keeps its complete-corpus ordinal', async () => {
+        // The single-duplicate witness proves the files survive a failed write. It structurally
+        // cannot prove this: with one duplicate there is no "later repair" to be harmed. Planning on
+        // the shared map deletes the failed id from it, so every subsequent id in the pass ranks
+        // against a corpus short one PR — files intact, membership lying.
+        //
+        // The fixture has to make that lie CHANGE AN OUTCOME, or the witness proves nothing. My first
+        // draft used the default threshold and passed against the unfixed code: the missing member
+        // shifted no chunk, so the poisoning was real and invisible — a test that cannot fail for its
+        // stated reason, which is precisely the defect it was written to close.
+        //
+        // At threshold 2, one sealed member (100) plus two duplicates (200 failing, 300 following):
+        //   membership [100, 200, 300] → 300 is ordinal 2 → chunk-2   (shared map intact)
+        //   membership [100, 300]      → 300 is ordinal 1 → chunk-1   (poisoned: 200 deleted)
+        // The chunk is the discriminator.
+        const originalThreshold = aiConfig.issueSync.archiveChunkThreshold;
+
+        aiConfig.issueSync.archiveChunkThreshold = 2;
+
+        try {
+            const sealed = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-1');
+
+            await fs.ensureDir(sealed);
+            await fs.writeFile(path.join(sealed, 'pr-100.md'), 'sealed single', 'utf8');
+
+            await seedDivergentPair(200);
+            await seedDivergentPair(300);
+
+            ReleaseNotesSyncer.sortedReleases = [{tagName: 'v13.0.0', publishedAt: '2026-06-01T00:00:00Z'}];
+            GraphqlService.query = async (_q, vars) => ({repository: {pullRequest: buildPullRequest(vars.prNumber)}});
+
+            const originalWriteFile = fsPromises.writeFile;
+
+            // Fail ONLY 200's write. 300 must still rank against a corpus that contains 200.
+            fsPromises.writeFile = async (p, ...rest) => {
+                if (String(p).includes('pr-200.md')) throw new Error('ENOSPC: no space left on device');
+                return originalWriteFile(p, ...rest)
+            };
+
+            let stats;
+            try {
+                stats = await PullRequestSyncer.repairDuplicateArtifacts({pulls: {}});
+            } finally {
+                fsPromises.writeFile = originalWriteFile;
+            }
+
+            expect(stats.failed.map(f => f.id)).toEqual([200]);
+            expect(stats.repaired).toEqual([300]);
+
+            // THE DISCRIMINATOR: 300 lands at the ordinal complete membership chooses. A poisoned map
+            // would have ranked it one place earlier and written chunk-1.
+            await expect(fs.pathExists(path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-2', 'pr-300.md'))).resolves.toBe(true);
+            await expect(fs.pathExists(path.join(sealed, 'pr-300.md'))).resolves.toBe(false);
+
+            // And 200's copies both survive — the single-duplicate contract, unchanged.
+            for (const chunk of ['chunk-1', 'chunk-2']) {
+                const p = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', chunk, 'pr-200.md');
+
+                expect(await fs.readFile(p, 'utf8')).toBe(`divergent ${chunk}`);
+            }
+        } finally {
+            aiConfig.issueSync.archiveChunkThreshold = originalThreshold;
+        }
     });
 
     test('a PR absent from GitHub is refused, not cleaned up — the copies are the only record left', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestSyncer.spec.mjs
@@ -593,6 +593,90 @@ test.describe('Neo.ai.services.github-workflow.sync.PullRequestSyncer', () => {
         expect(stats.indexed).toBe(0);
     });
 
+    // --- the repair: preventing new drift does not remove old drift. Entries stranded by moves that
+    //     predate the upsert name files ALREADY archived, so no relocate pass revisits them and no
+    //     delta fetch names them — they are unreachable by every mechanism expected to heal them. ---
+
+    test('realigns a stranded index entry with the artifact on disk — the drift nothing else could heal', async () => {
+        const prNumber = 9537,
+              archived = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-3', `pr-${prNumber}.md`);
+
+        await fs.ensureDir(path.dirname(archived));
+        await fs.writeFile(archived, 'archived long ago', 'utf8');
+
+        // The entry the historical move left behind: names the pre-move active path.
+        await fs.writeJson(path.join(aiConfig.issueSync.contentRoot, '_index.json'), [
+            {type: 'pulls', id: prNumber, version: null, chunkNumber: 1, path: `pulls/chunk-1/pr-${prNumber}.md`}
+        ]);
+
+        const stats = await PullRequestSyncer.reconcilePullRequestIndex();
+        const entry = (await readContentIndex(aiConfig.issueSync)).find(e => e.id === prNumber);
+
+        expect(entry.path).toBe(`archive/pulls/v13.0.0/chunk-3/pr-${prNumber}.md`);
+        expect(entry.version).toBe('v13.0.0');
+        expect(entry.chunkNumber).toBe(3);
+        expect(stats.reindexed).toBe(1);
+    });
+
+    test('is idempotent and writes nothing when the index already agrees — no churn in generated content', async () => {
+        const prNumber = 4242,
+              archived = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-1', `pr-${prNumber}.md`);
+
+        await fs.ensureDir(path.dirname(archived));
+        await fs.writeFile(archived, 'x', 'utf8');
+        await fs.writeJson(path.join(aiConfig.issueSync.contentRoot, '_index.json'), [
+            {type: 'pulls', id: prNumber, version: 'v13.0.0', chunkNumber: 1, path: `archive/pulls/v13.0.0/chunk-1/pr-${prNumber}.md`}
+        ]);
+
+        const first = await PullRequestSyncer.reconcilePullRequestIndex();
+
+        expect(first.reindexed).toBe(0);
+        expect(first.unchanged).toBe(1);
+
+        // A healthy corpus must not rewrite the file — this runs every sync and the output is committed.
+        const before = await fs.readFile(path.join(aiConfig.issueSync.contentRoot, '_index.json'), 'utf8');
+        await PullRequestSyncer.reconcilePullRequestIndex();
+        expect(await fs.readFile(path.join(aiConfig.issueSync.contentRoot, '_index.json'), 'utf8')).toBe(before);
+    });
+
+    test('repairs a stale entry whose file exists but whose chunkNumber contradicts its path', async () => {
+        const prNumber = 777,
+              archived = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', 'chunk-2', `pr-${prNumber}.md`);
+
+        await fs.ensureDir(path.dirname(archived));
+        await fs.writeFile(archived, 'x', 'utf8');
+        // Path is right, coordinates are not — invisible to any check that only resolves the path.
+        await fs.writeJson(path.join(aiConfig.issueSync.contentRoot, '_index.json'), [
+            {type: 'pulls', id: prNumber, version: 'v13.0.0', chunkNumber: 1, path: `archive/pulls/v13.0.0/chunk-2/pr-${prNumber}.md`}
+        ]);
+
+        const stats = await PullRequestSyncer.reconcilePullRequestIndex();
+
+        expect(stats.reindexed).toBe(1);
+        expect((await readContentIndex(aiConfig.issueSync)).find(e => e.id === prNumber).chunkNumber).toBe(2);
+    });
+
+    test('leaves an ambiguous id UNINDEXED rather than blessing a copy as canonical', async () => {
+        const prNumber = 10124;
+
+        for (const chunk of ['chunk-1', 'chunk-2']) {
+            const dir = path.join(aiConfig.issueSync.archiveRoot, 'pulls', 'v13.0.0', chunk);
+
+            await fs.ensureDir(dir);
+            await fs.writeFile(path.join(dir, `pr-${prNumber}.md`), `divergent ${chunk}`, 'utf8');
+        }
+
+        await fs.writeJson(path.join(aiConfig.issueSync.contentRoot, '_index.json'), []);
+
+        const stats = await PullRequestSyncer.reconcilePullRequestIndex();
+
+        expect(stats.skippedAmbiguous).toEqual([prNumber]);
+        expect(stats.reindexed).toBe(0);
+        // No entry: an index entry naming one of two divergent copies would make it canonical by
+        // implication, which is the arbitrary choice this lane refuses on the corpus's behalf.
+        expect((await readContentIndex(aiConfig.issueSync)).find(e => e.id === prNumber)).toBeUndefined();
+    });
+
     test('is a no-op when no releases are loaded (fail-safe)', async () => {
         const prNumber   = 44444,
               activePath = path.join(aiConfig.issueSync.pullsDir, 'chunk-1', `pr-${prNumber}.md`);

--- a/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
@@ -39,6 +39,8 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
     let originalSyncNotes;
     let originalSyncDiscussions;
     let originalSyncPullRequests;
+    let originalReconcileClosedPulls;
+    let originalReconcilePullIndex;
     let originalGetViewerPermission;
     let originalRebuildContentIndexesAndSeo;
     let originalExecGit;
@@ -50,8 +52,8 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
     let originalSaveMetadata;
 
     let stage2Calls = {
-        issueStates: 0,
-        discussionStates: 0,
+        issueStates        : 0,
+        discussionStates   : 0,
         pullRequestFeedback: 0
     };
 
@@ -81,6 +83,8 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         originalSyncNotes = ReleaseNotesSyncer.syncNotes;
         originalSyncDiscussions = DiscussionSyncer.syncDiscussions;
         originalSyncPullRequests = PullRequestSyncer.syncPullRequests;
+        originalReconcileClosedPulls = PullRequestSyncer.reconcileClosedPullRequestLocations;
+        originalReconcilePullIndex = PullRequestSyncer.reconcilePullRequestIndex;
         originalGetViewerPermission = RepositoryService.getViewerPermission;
         originalRebuildContentIndexesAndSeo = SyncService.rebuildContentIndexesAndSeo;
         originalExecGit = SyncService.execGit;
@@ -94,6 +98,14 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         ReleaseNotesSyncer.syncNotes = async () => ({ count: 0 });
         DiscussionSyncer.syncDiscussions = async () => ({ count: 0 });
         PullRequestSyncer.syncPullRequests = async () => ({ count: 0 });
+        // These specs exercise Stage-2 SEQUENCING, so every orchestration step is stubbed — otherwise
+        // `runFullSync` runs the real pass against the real `resources/content`, which is a tracked
+        // generated corpus. Both pull passes below were previously unstubbed and merely appeared
+        // harmless: the relocate pass bails early because `fetchAndCacheReleases` is stubbed to a
+        // no-op and it refuses to bucket without releases. That is luck, not isolation — the index
+        // reconcile needs no network and would rewrite thousands of live entries from a unit run.
+        PullRequestSyncer.reconcileClosedPullRequestLocations = async () => ({ count: 0, pullRequests: [], indexed: 0 });
+        PullRequestSyncer.reconcilePullRequestIndex = async () => ({ reindexed: 0, unchanged: 0, skippedAmbiguous: [] });
         RepositoryService.getViewerPermission = async () => ({ permission: 'READ' }); // Skip git commands
         SyncService.rebuildContentIndexesAndSeo = async () => ({});
         MetadataManager.load = async () => ({ issues: {}, releases: {}, discussions: {}, pullRequests: {} });
@@ -116,6 +128,8 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         ReleaseNotesSyncer.syncNotes = originalSyncNotes;
         DiscussionSyncer.syncDiscussions = originalSyncDiscussions;
         PullRequestSyncer.syncPullRequests = originalSyncPullRequests;
+        PullRequestSyncer.reconcileClosedPullRequestLocations = originalReconcileClosedPulls;
+        PullRequestSyncer.reconcilePullRequestIndex = originalReconcilePullIndex;
         RepositoryService.getViewerPermission = originalGetViewerPermission;
         SyncService.rebuildContentIndexesAndSeo = originalRebuildContentIndexesAndSeo;
         SyncService.execGit = originalExecGit;
@@ -184,11 +198,11 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
     });
 
     test('auto-push aborts failed rebase, resets, re-emits, and retries once (#13798)', async () => {
-        const commands = [];
-        let pullRuns = 0;
-        let saves = 0;
-        let derives = 0;
-        let rebaseAttempts = 0;
+        const commands       = [];
+        let   pullRuns       = 0;
+        let   saves          = 0;
+        let   derives        = 0;
+        let   rebaseAttempts = 0;
 
         RepositoryService.getViewerPermission = async () => ({permission: 'WRITE'});
 
@@ -262,9 +276,9 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
 
     test('auto-push recovers the checkout when delivery retries are exhausted (#13798)', async () => {
         const commands = [];
-        let pullRuns = 0;
-        let saves = 0;
-        let derives = 0;
+        let   pullRuns = 0;
+        let   saves    = 0;
+        let   derives  = 0;
 
         RepositoryService.getViewerPermission = async () => ({permission: 'WRITE'});
 
@@ -453,7 +467,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
 
         IssueSyncer.pullFromGitHub = async () => ({
             newMetadata: {issues: {}, pushFailures: [], lastSync: '2026-05-18T04:42:00Z'},
-            stats: {pulled: {count: 0, created: 0, updated: 0, moved: 0}, dropped: {count: 0}}
+            stats      : {pulled: {count: 0, created: 0, updated: 0, moved: 0}, dropped: {count: 0}}
         });
 
         // Syncers don't mutate metadata at all (early-exit path).

--- a/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
@@ -40,6 +40,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
     let originalSyncDiscussions;
     let originalSyncPullRequests;
     let originalReconcileClosedPulls;
+    let originalRepairPullDuplicates;
     let originalReconcilePullIndex;
     let originalGetViewerPermission;
     let originalRebuildContentIndexesAndSeo;
@@ -84,6 +85,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         originalSyncDiscussions = DiscussionSyncer.syncDiscussions;
         originalSyncPullRequests = PullRequestSyncer.syncPullRequests;
         originalReconcileClosedPulls = PullRequestSyncer.reconcileClosedPullRequestLocations;
+        originalRepairPullDuplicates = PullRequestSyncer.repairDuplicateArtifacts;
         originalReconcilePullIndex = PullRequestSyncer.reconcilePullRequestIndex;
         originalGetViewerPermission = RepositoryService.getViewerPermission;
         originalRebuildContentIndexesAndSeo = SyncService.rebuildContentIndexesAndSeo;
@@ -105,6 +107,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         // no-op and it refuses to bucket without releases. That is luck, not isolation — the index
         // reconcile needs no network and would rewrite thousands of live entries from a unit run.
         PullRequestSyncer.reconcileClosedPullRequestLocations = async () => ({ count: 0, pullRequests: [], indexed: 0 });
+        PullRequestSyncer.repairDuplicateArtifacts = async () => ({ repaired: [], removed: 0, failed: [] });
         PullRequestSyncer.reconcilePullRequestIndex = async () => ({ reindexed: 0, unchanged: 0, skippedAmbiguous: [] });
         RepositoryService.getViewerPermission = async () => ({ permission: 'READ' }); // Skip git commands
         SyncService.rebuildContentIndexesAndSeo = async () => ({});
@@ -129,6 +132,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         DiscussionSyncer.syncDiscussions = originalSyncDiscussions;
         PullRequestSyncer.syncPullRequests = originalSyncPullRequests;
         PullRequestSyncer.reconcileClosedPullRequestLocations = originalReconcileClosedPulls;
+        PullRequestSyncer.repairDuplicateArtifacts = originalRepairPullDuplicates;
         PullRequestSyncer.reconcilePullRequestIndex = originalReconcilePullIndex;
         RepositoryService.getViewerPermission = originalGetViewerPermission;
         SyncService.rebuildContentIndexesAndSeo = originalRebuildContentIndexesAndSeo;

--- a/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/SyncService.Stage2.spec.mjs
@@ -42,6 +42,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
     let originalReconcileClosedPulls;
     let originalRepairPullDuplicates;
     let originalReconcilePullIndex;
+    let originalVerifyPullIntegrity;
     let originalGetViewerPermission;
     let originalRebuildContentIndexesAndSeo;
     let originalExecGit;
@@ -87,6 +88,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         originalReconcileClosedPulls = PullRequestSyncer.reconcileClosedPullRequestLocations;
         originalRepairPullDuplicates = PullRequestSyncer.repairDuplicateArtifacts;
         originalReconcilePullIndex = PullRequestSyncer.reconcilePullRequestIndex;
+        originalVerifyPullIntegrity = PullRequestSyncer.verifyCorpusIntegrity;
         originalGetViewerPermission = RepositoryService.getViewerPermission;
         originalRebuildContentIndexesAndSeo = SyncService.rebuildContentIndexesAndSeo;
         originalExecGit = SyncService.execGit;
@@ -108,7 +110,8 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         // reconcile needs no network and would rewrite thousands of live entries from a unit run.
         PullRequestSyncer.reconcileClosedPullRequestLocations = async () => ({ count: 0, pullRequests: [], indexed: 0 });
         PullRequestSyncer.repairDuplicateArtifacts = async () => ({ repaired: [], removed: 0, failed: [] });
-        PullRequestSyncer.reconcilePullRequestIndex = async () => ({ reindexed: 0, unchanged: 0, skippedAmbiguous: [] });
+        PullRequestSyncer.reconcilePullRequestIndex = async () => ({ reindexed: 0, unchanged: 0, removed: 0, skippedAmbiguous: [] });
+        PullRequestSyncer.verifyCorpusIntegrity = async () => ({ ok: true, staleIndexEntries: [], inconsistentIndexEntries: [], duplicateIndexEntryIds: [], unindexedIds: [], identicalDuplicateIds: [], divergentDuplicateIds: [] });
         RepositoryService.getViewerPermission = async () => ({ permission: 'READ' }); // Skip git commands
         SyncService.rebuildContentIndexesAndSeo = async () => ({});
         MetadataManager.load = async () => ({ issues: {}, releases: {}, discussions: {}, pullRequests: {} });
@@ -134,6 +137,7 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         PullRequestSyncer.reconcileClosedPullRequestLocations = originalReconcileClosedPulls;
         PullRequestSyncer.repairDuplicateArtifacts = originalRepairPullDuplicates;
         PullRequestSyncer.reconcilePullRequestIndex = originalReconcilePullIndex;
+        PullRequestSyncer.verifyCorpusIntegrity = originalVerifyPullIntegrity;
         RepositoryService.getViewerPermission = originalGetViewerPermission;
         SyncService.rebuildContentIndexesAndSeo = originalRebuildContentIndexesAndSeo;
         SyncService.execGit = originalExecGit;
@@ -143,6 +147,55 @@ test.describe('SyncService — Stage 2 Ingestion', () => {
         IssueIngestor.ingestIssueStates = originalIngestIssueStates;
         IssueIngestor.ingestDiscussionStates = originalIngestDiscussionStates;
         IssueIngestor.ingestPullRequestFeedback = originalIngestPullRequestFeedback;
+    });
+
+    test('an unclean pull-corpus verdict ABORTS before metadata save, derive, and auto-push', async () => {
+        // Every pass reports its own outcome and degrades softly on its own terms, which is exactly
+        // how a corpus reaches the commit with each step reporting success and the whole known-broken.
+        // The verdict is only worth taking if something consumes it: a generated commit is what every
+        // consumer then reads as truth, and unlike a failed run it cannot be retried away.
+        const order = [];
+
+        MetadataManager.save = async () => { order.push('metadata-save') };
+        SyncService.rebuildContentIndexesAndSeo = async () => { order.push('derive') };
+        RepositoryService.getViewerPermission = async () => { order.push('permission-check'); return {permission: 'READ'} };
+
+        PullRequestSyncer.verifyCorpusIntegrity = async () => ({
+            ok                      : false,
+            staleIndexEntries       : [{id: 9537}],
+            inconsistentIndexEntries: [],
+            duplicateIndexEntryIds  : [],
+            unindexedIds            : [],
+            identicalDuplicateIds   : [],
+            divergentDuplicateIds   : [10124]
+        });
+
+        await expect(SyncService.runFullSync()).rejects.toThrow(/integrity is not clean/);
+
+        // None of the three ran: the corpus is never committed in a state we already measured as broken.
+        expect(order).toEqual([]);
+    });
+
+    test('a FAILED duplicate repair aborts too, even when the verdict is otherwise clean', async () => {
+        // The repair reports its failures rather than throwing, so a soft-failed restoration would
+        // otherwise sail past a verdict that cannot see it.
+        const order = [];
+
+        MetadataManager.save = async () => { order.push('metadata-save') };
+        PullRequestSyncer.repairDuplicateArtifacts = async () => ({
+            repaired: [], removed: 0, failed: [{id: 10124, reason: 'network down'}]
+        });
+
+        await expect(SyncService.runFullSync()).rejects.toThrow(/integrity is not clean/);
+        expect(order).toEqual([]);
+    });
+
+    test('a clean verdict lets the run proceed — the gate can PASS', async () => {
+        // Otherwise the two aborts above prove only that runFullSync can throw.
+        const result = await SyncService.runFullSync();
+
+        expect(result.success).toBe(true);
+        expect(result.syncStats ?? result).toBeTruthy();
     });
 
     test('runFullSync executes Stage 2 ingestion by dynamically invoking IssueIngestor', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/shared/contentInventory.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/shared/contentInventory.spec.mjs
@@ -312,6 +312,21 @@ test.describe('Neo.ai.services.github-workflow.shared.contentInventory', () => {
             expect((await validateContentIntegrity(config, inventoryOpts)).inconsistentIndexEntries).toHaveLength(0)
         });
 
+        test('detects DUPLICATE index rows for one id — two assertions about where it lives', async () => {
+            // `updateContentIndex` keys by {type, id} and so cannot produce these, which is exactly
+            // why they must be checked on READ: a hand-edit, a bad merge, or any writer that appends
+            // rather than upserts makes two rows for one id. Every path-existence check passes on
+            // both, and the first one wins at lookup — silently and arbitrarily.
+            const a = await writeActive(1, 10);
+
+            await writeContentIndex(config, [indexEntry(10, a), {...indexEntry(10, a), chunkNumber: 2}]);
+
+            const result = await validateContentIntegrity(config, inventoryOpts);
+
+            expect(result.duplicateIndexEntryIds).toEqual([10]);
+            expect(result.ok).toBe(false)
+        });
+
         test('detects an artifact that no index entry names', async () => {
             await writeActive(1, 10);
             await writeContentIndex(config, []);

--- a/test/playwright/unit/ai/services/github-workflow/shared/contentInventory.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/shared/contentInventory.spec.mjs
@@ -232,6 +232,42 @@ test.describe('Neo.ai.services.github-workflow.shared.contentInventory', () => {
             expect(archived).toContain('v13.0.0')
         });
 
+        test('detects an entry whose chunkNumber contradicts its own path — a real file, described wrongly', async () => {
+            // The costume a path-existence check cannot see through. The entry names a file that
+            // exists, so "every indexed path resolves" passes — and the entry still lies about where
+            // the file sits. This is what a plan-derived chunkNumber produces once placement can
+            // legitimately differ from the plan.
+            const archived = await writeArchived('v13.0.0', 2, 10124);
+
+            await writeContentIndex(config, [indexEntry(10124, archived, 'v13.0.0', 1)]);
+
+            const result = await validateContentIntegrity(config, inventoryOpts);
+
+            expect(result.staleIndexEntries).toHaveLength(0);          // the path is real
+            expect(result.inconsistentIndexEntries).toHaveLength(1);   // and the coordinates are not
+            expect(result.inconsistentIndexEntries[0].actual).toEqual({version: 'v13.0.0', chunkNumber: 2});
+            expect(result.ok).toBe(false)
+        });
+
+        test('detects an entry whose version contradicts its own path', async () => {
+            const archived = await writeArchived('v13.0.0', 1, 55);
+
+            await writeContentIndex(config, [indexEntry(55, archived, 'v12.0.0', 1)]);
+
+            const result = await validateContentIntegrity(config, inventoryOpts);
+
+            expect(result.inconsistentIndexEntries).toHaveLength(1);
+            expect(result.ok).toBe(false)
+        });
+
+        test('an entry that agrees with its path is NOT flagged — the check can pass', async () => {
+            const archived = await writeArchived('v13.0.0', 2, 66);
+
+            await writeContentIndex(config, [indexEntry(66, archived, 'v13.0.0', 2)]);
+
+            expect((await validateContentIntegrity(config, inventoryOpts)).inconsistentIndexEntries).toHaveLength(0)
+        });
+
         test('detects an artifact that no index entry names', async () => {
             await writeActive(1, 10);
             await writeContentIndex(config, []);

--- a/test/playwright/unit/ai/services/github-workflow/shared/contentInventory.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/shared/contentInventory.spec.mjs
@@ -1,0 +1,300 @@
+import {test, expect}      from '@playwright/test';
+import fs                  from 'fs/promises';
+import os                  from 'os';
+import path                from 'path';
+import {parseContentPath}  from '../../../../../../../ai/services/github-workflow/shared/contentPath.mjs';
+import {writeContentIndex} from '../../../../../../../ai/services/github-workflow/shared/contentIndex.mjs';
+import {
+    buildContentInventory,
+    resolveArchivedLocation,
+    validateContentIntegrity
+} from '../../../../../../../ai/services/github-workflow/shared/contentInventory.mjs';
+
+/**
+ * @summary Falsifier coverage for the complete-corpus inventory and its integrity verdict.
+ *
+ * The corpus these helpers describe drifted for months without a single red signal, so the bar here
+ * is not "does it report the right numbers on a healthy tree" — a probe aimed at the wrong shape
+ * also reports zeros, and zeros from a blind instrument are indistinguishable from health. Every
+ * detection case below is paired with a positive control proving the same probe returns non-zero
+ * when the condition is present, and the clean-corpus case proves the verdict can reach PASS at all.
+ * A validator that cannot fail and a validator that cannot pass are equally worthless.
+ *
+ * The production shapes are reproduced literally: an index entry naming a path that no longer exists
+ * (the archive-move drift), and one id owning two byte-divergent artifacts in different chunks of the
+ * same sealed version bucket (the partial-ordinal duplicate).
+ */
+test.describe('Neo.ai.services.github-workflow.shared.contentInventory', () => {
+    let tmpDir, contentRoot, config;
+
+    test.beforeEach(async () => {
+        tmpDir      = await fs.mkdtemp(path.join(os.tmpdir(), 'neo-inventory-'));
+        contentRoot = path.join(tmpDir, 'content');
+        config      = {contentRoot};
+        await fs.mkdir(contentRoot, {recursive: true})
+    });
+
+    test.afterEach(async () => {
+        await fs.rm(tmpDir, {recursive: true, force: true})
+    });
+
+    /** Writes an active-tier PR artifact and returns its contentRoot-relative path. */
+    const writeActive = async (chunk, id, body = `# pr ${id}\n`) => {
+        const dir = path.join(contentRoot, 'pulls', `chunk-${chunk}`);
+        await fs.mkdir(dir, {recursive: true});
+        await fs.writeFile(path.join(dir, `pr-${id}.md`), body, 'utf8');
+        return `pulls/chunk-${chunk}/pr-${id}.md`
+    };
+
+    /** Writes an archive-tier PR artifact and returns its contentRoot-relative path. */
+    const writeArchived = async (version, chunk, id, body = `# pr ${id}\n`) => {
+        const dir = path.join(contentRoot, 'archive', 'pulls', version, `chunk-${chunk}`);
+        await fs.mkdir(dir, {recursive: true});
+        await fs.writeFile(path.join(dir, `pr-${id}.md`), body, 'utf8');
+        return `archive/pulls/${version}/chunk-${chunk}/pr-${id}.md`
+    };
+
+    const indexEntry = (id, relPath, version = null, chunkNumber = 1) =>
+        ({type: 'pulls', id, version, chunkNumber, path: relPath});
+
+    const inventoryOpts = {type: 'pulls', filePrefix: 'pr-'};
+
+    test.describe('parseContentPath — the inverse of the path math', () => {
+        test('reads an archive path back into its tier coordinates', () => {
+            expect(parseContentPath({
+                contentRoot: 'resources/content',
+                filePath   : 'archive/pulls/v13.0.0/chunk-2/pr-10124.md'
+            })).toEqual({type: 'pulls', version: 'v13.0.0', bucket: null, chunkNumber: 2, filename: 'pr-10124.md'})
+        });
+
+        test('reads an active path back into its tier coordinates', () => {
+            expect(parseContentPath({
+                contentRoot: 'resources/content',
+                filePath   : 'pulls/chunk-1/pr-9537.md'
+            })).toEqual({type: 'pulls', version: null, bucket: null, chunkNumber: 1, filename: 'pr-9537.md'})
+        });
+
+        test('reads an ABSOLUTE path back into its tier coordinates', () => {
+            expect(parseContentPath({
+                contentRoot: '/repo/resources/content',
+                filePath   : '/repo/resources/content/archive/pulls/v13.0.0/chunk-2/pr-10124.md'
+            })).toEqual({type: 'pulls', version: 'v13.0.0', bucket: null, chunkNumber: 2, filename: 'pr-10124.md'})
+        });
+
+        test('a non-version archive segment reads as a bucket, not a version', () => {
+            const parsed = parseContentPath({
+                contentRoot: 'resources/content',
+                filePath   : 'archive/pulls/rejected/chunk-1/pr-5.md'
+            });
+
+            expect(parsed.bucket).toBe('rejected');
+            expect(parsed.version).toBeNull()
+        });
+
+        test('a projectRoot-relative path does NOT parse — the convention trap, pinned', () => {
+            // `metadata.{type}[].path` is projectRoot-relative (`resources/content/pulls/…`) while
+            // `_index.json` is contentRoot-relative (`pulls/…`). Both are bare relative strings; only
+            // the leading root segment tells them apart, and nothing in the string reveals which
+            // convention produced it. Against a `resources/content` root the metadata shape resolves
+            // to `resources/content/resources/content/…` and is correctly rejected.
+            //
+            // Pinned rather than "fixed" by sniffing for the prefix: a parser that guesses which
+            // convention it was handed would silently accept a doubled path as a real one, which is
+            // the same trade — a confident answer over an honest refusal — that produced the drift
+            // this module exists to detect.
+            expect(parseContentPath({
+                contentRoot: 'resources/content',
+                filePath   : 'resources/content/pulls/chunk-1/pr-9537.md'
+            })).toBeNull()
+        });
+
+        test('returns null for paths that are not chunked content rather than throwing', () => {
+            // Off-contract input is data, not an exception: callers scanning a real tree will meet
+            // stray files, and a throw here would make the scanner the thing that fails.
+            expect(parseContentPath({contentRoot: 'resources/content', filePath: 'resources/content/_index.json'})).toBeNull();
+            expect(parseContentPath({contentRoot: 'resources/content', filePath: 'resources/content/pulls/pr-1.md'})).toBeNull();
+            expect(parseContentPath({contentRoot: 'resources/content', filePath: 'resources/content/pulls/nochunk/pr-1.md'})).toBeNull();
+            expect(parseContentPath({contentRoot: 'resources/content', filePath: '/etc/passwd'})).toBeNull()
+        });
+
+        test('round-trips every path the inventory reports — the two directions cannot disagree', async () => {
+            await writeActive(1, 10);
+            await writeArchived('v13.0.0', 2, 20);
+
+            const inventory = await buildContentInventory(config, inventoryOpts);
+
+            for (const [, copies] of inventory) {
+                for (const copy of copies) {
+                    const parsed = parseContentPath({contentRoot, filePath: copy.absPath});
+
+                    expect(parsed).not.toBeNull();
+                    expect(parsed.chunkNumber).toBe(copy.chunkNumber);
+                    expect(parsed.version).toBe(copy.version)
+                }
+            }
+        })
+    });
+
+    test.describe('buildContentInventory — complete membership across both tiers', () => {
+        test('POSITIVE CONTROL: finds artifacts in the active tier AND every archive bucket', async () => {
+            // This is the control every zero below leans on. A scanner that misses a tier reports a
+            // smaller corpus, and a smaller corpus reports fewer duplicates — silently.
+            await writeActive(1, 10);
+            await writeActive(1, 20);
+            await writeArchived('v13.0.0', 1, 30);
+            await writeArchived('v12.0.0', 3, 40);
+
+            const inventory = await buildContentInventory(config, inventoryOpts);
+
+            expect(inventory.size).toBe(4);
+            expect([...inventory.keys()].sort((a, b) => a - b)).toEqual([10, 20, 30, 40]);
+            expect(inventory.get(10)[0].version).toBeNull();
+            expect(inventory.get(30)[0].version).toBe('v13.0.0');
+            expect(inventory.get(40)[0].version).toBe('v12.0.0');
+            expect(inventory.get(40)[0].chunkNumber).toBe(3)
+        });
+
+        test('keys map to an ARRAY so a second copy is surfaced, never overwritten', async () => {
+            // A Map<id, entry> would drop the second copy and report a clean corpus — the precise
+            // blindness that let divergent duplicates accumulate unseen.
+            await writeArchived('v13.0.0', 1, 10124, 'copy A');
+            await writeArchived('v13.0.0', 2, 10124, 'copy B is longer');
+
+            const inventory = await buildContentInventory(config, inventoryOpts);
+
+            expect(inventory.size).toBe(1);
+            expect(inventory.get(10124)).toHaveLength(2);
+            expect(inventory.get(10124).map(c => c.chunkNumber).sort()).toEqual([1, 2])
+        });
+
+        test('an empty corpus is zero — and the control above proves the scanner can find files', async () => {
+            expect((await buildContentInventory(config, inventoryOpts)).size).toBe(0)
+        })
+    });
+
+    test.describe('resolveArchivedLocation — sealed placement as a lookup', () => {
+        test('reports unique for exactly one archived artifact', async () => {
+            await writeArchived('v13.0.0', 2, 10);
+
+            const resolved = resolveArchivedLocation(await buildContentInventory(config, inventoryOpts), 10);
+
+            expect(resolved.status).toBe('unique');
+            expect(resolved.entry.chunkNumber).toBe(2)
+        });
+
+        test('reports none for an active-only artifact — active is not a sealed location', async () => {
+            await writeActive(1, 10);
+
+            expect(resolveArchivedLocation(await buildContentInventory(config, inventoryOpts), 10).status).toBe('none')
+        });
+
+        test('reports AMBIGUOUS rather than picking a copy — resolving here would launder the corruption', async () => {
+            await writeArchived('v13.0.0', 1, 10, 'A');
+            await writeArchived('v13.0.0', 2, 10, 'B');
+
+            const resolved = resolveArchivedLocation(await buildContentInventory(config, inventoryOpts), 10);
+
+            expect(resolved.status).toBe('ambiguous');
+            expect(resolved.entry).toBeNull();
+            expect(resolved.copies).toHaveLength(2)
+        })
+    });
+
+    test.describe('validateContentIntegrity — the verdict', () => {
+        test('a clean corpus PASSES — proving the verdict is reachable, so a FAIL below means something', async () => {
+            const a = await writeActive(1, 10),
+                  b = await writeArchived('v13.0.0', 1, 20);
+
+            await writeContentIndex(config, [indexEntry(10, a), indexEntry(20, b, 'v13.0.0')]);
+
+            const result = await validateContentIntegrity(config, inventoryOpts);
+
+            expect(result.ok).toBe(true);
+            expect(result.indexedTotal).toBe(2);
+            expect(result.corpusTotal).toBe(2);
+            expect(result.uniqueIds).toBe(2)
+        });
+
+        test('detects an index entry naming a path that does not exist — the archive-move drift', async () => {
+            // The production shape: the file was renamed into the archive and the index kept naming
+            // its old active path. 2,015 entries in the live corpus look exactly like this.
+            const archived = await writeArchived('v13.0.0', 1, 9537);
+
+            await writeContentIndex(config, [indexEntry(9537, 'pulls/chunk-1/pr-9537.md')]);
+
+            const result = await validateContentIntegrity(config, inventoryOpts);
+
+            expect(result.ok).toBe(false);
+            expect(result.staleIndexEntries).toHaveLength(1);
+            expect(result.staleIndexEntries[0].path).toBe('pulls/chunk-1/pr-9537.md');
+            // The artifact itself is present and healthy — only the lookup is wrong.
+            expect(result.corpusTotal).toBe(1);
+            expect(archived).toContain('v13.0.0')
+        });
+
+        test('detects an artifact that no index entry names', async () => {
+            await writeActive(1, 10);
+            await writeContentIndex(config, []);
+
+            const result = await validateContentIntegrity(config, inventoryOpts);
+
+            expect(result.ok).toBe(false);
+            expect(result.unindexedIds).toEqual([10])
+        });
+
+        test('classifies byte-IDENTICAL duplicates separately — one artifact written twice', async () => {
+            await writeArchived('v13.0.0', 1, 10, 'same bytes');
+            await writeArchived('v13.0.0', 2, 10, 'same bytes');
+            await writeContentIndex(config, [indexEntry(10, 'archive/pulls/v13.0.0/chunk-1/pr-10.md', 'v13.0.0')]);
+
+            const result = await validateContentIntegrity(config, inventoryOpts);
+
+            expect(result.identicalDuplicateIds).toEqual([10]);
+            expect(result.divergentDuplicateIds).toEqual([]);
+            expect(result.ok).toBe(false)
+        });
+
+        test('classifies byte-DIVERGENT duplicates as their own class — the fail-loud shape', async () => {
+            // Reproduces pr-10124: one id, two chunks of the same sealed version, different bytes.
+            // Nothing on disk says which rendering is current, so position must not decide it.
+            await writeArchived('v13.0.0', 1, 10124, 'rendering with fewer comments');
+            await writeArchived('v13.0.0', 2, 10124, 'rendering with more comments and reviews');
+            await writeContentIndex(config, [indexEntry(10124, 'archive/pulls/v13.0.0/chunk-2/pr-10124.md', 'v13.0.0', 2)]);
+
+            const result = await validateContentIntegrity(config, inventoryOpts);
+
+            expect(result.divergentDuplicateIds).toEqual([10124]);
+            expect(result.identicalDuplicateIds).toEqual([]);
+            expect(result.ok).toBe(false);
+            // Both copies counted: the corpus holds two artifacts for one id.
+            expect(result.corpusTotal).toBe(2);
+            expect(result.uniqueIds).toBe(1)
+        });
+
+        test('reports every defect class at once rather than stopping at the first', async () => {
+            // A pass that returns on first fault turns a corpus census into a bisect.
+            await writeArchived('v13.0.0', 1, 10, 'A');
+            await writeArchived('v13.0.0', 2, 10, 'B');
+            await writeActive(1, 20);
+            await writeContentIndex(config, [indexEntry(30, 'pulls/chunk-1/pr-30.md')]);
+
+            const result = await validateContentIntegrity(config, inventoryOpts);
+
+            expect(result.divergentDuplicateIds).toEqual([10]);
+            expect(result.unindexedIds.sort((a, b) => a - b)).toEqual([10, 20]);
+            expect(result.staleIndexEntries).toHaveLength(1);
+            expect(result.ok).toBe(false)
+        });
+
+        test('accepts a pre-built inventory so a sync does not scan the corpus twice', async () => {
+            const a = await writeActive(1, 10);
+            await writeContentIndex(config, [indexEntry(10, a)]);
+
+            const inventory = await buildContentInventory(config, inventoryOpts),
+                  result    = await validateContentIntegrity(config, {...inventoryOpts, inventory});
+
+            expect(result.ok).toBe(true);
+            expect(result.corpusTotal).toBe(1)
+        })
+    })
+});

--- a/test/playwright/unit/ai/services/github-workflow/shared/contentInventory.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/shared/contentInventory.spec.mjs
@@ -1,9 +1,9 @@
-import {test, expect}      from '@playwright/test';
-import fs                  from 'fs/promises';
-import os                  from 'os';
-import path                from 'path';
-import {parseContentPath}  from '../../../../../../../ai/services/github-workflow/shared/contentPath.mjs';
-import {writeContentIndex} from '../../../../../../../ai/services/github-workflow/shared/contentIndex.mjs';
+import {test, expect}                            from '@playwright/test';
+import fs                                        from 'fs/promises';
+import os                                        from 'os';
+import path                                      from 'path';
+import {parseContentPath, pathSegmentOptionsFor} from '../../../../../../../ai/services/github-workflow/shared/contentPath.mjs';
+import {writeContentIndex}                       from '../../../../../../../ai/services/github-workflow/shared/contentIndex.mjs';
 import {
     buildContentInventory,
     resolveArchivedLocation,
@@ -89,6 +89,50 @@ test.describe('Neo.ai.services.github-workflow.shared.contentInventory', () => {
 
             expect(parsed.bucket).toBe('rejected');
             expect(parsed.version).toBeNull()
+        });
+
+        test('an OVERRIDDEN chunk prefix parses — the vocabulary is configured, not universal', () => {
+            // A hardcoded `chunk-` agrees with the shipped default and diverges silently the moment a
+            // deployment overrides it: the forward build would emit `slice-3/` while the inverse only
+            // recognised `chunk-3/`, and the two halves of one contract would disagree with nothing red.
+            expect(parseContentPath({
+                contentRoot: 'resources/content',
+                filePath   : 'archive/pulls/v13.0.0/slice-2/pr-10124.md',
+                chunkPrefix: 'slice-'
+            })).toEqual({type: 'pulls', version: 'v13.0.0', bucket: null, chunkNumber: 2, filename: 'pr-10124.md'})
+        });
+
+        test('an OVERRIDDEN version prefix classifies release buckets — not as named buckets', () => {
+            // The version/bucket split is decided by the prefix. Hardcoding `/^v\d/` would reclassify
+            // every release bucket as a non-release bucket under an override — silently, since both
+            // are valid shapes and neither throws.
+            const parsed = parseContentPath({
+                contentRoot  : 'resources/content',
+                filePath     : 'archive/pulls/rel-13.0.0/chunk-1/pr-5.md',
+                versionPrefix: 'rel-'
+            });
+
+            expect(parsed.version).toBe('rel-13.0.0');
+            expect(parsed.bucket).toBeNull()
+        });
+
+        test('under an overridden version prefix, a `v`-shaped segment is a BUCKET, not a version', () => {
+            // The inverse of the above, and the reason this must be config-driven rather than
+            // permissive: with `rel-` configured, `v13.0.0` is not a release bucket at all.
+            const parsed = parseContentPath({
+                contentRoot  : 'resources/content',
+                filePath     : 'archive/pulls/v13.0.0/chunk-1/pr-5.md',
+                versionPrefix: 'rel-'
+            });
+
+            expect(parsed.bucket).toBe('v13.0.0');
+            expect(parsed.version).toBeNull()
+        });
+
+        test('pathSegmentOptionsFor maps config names to parse options, and defaults when absent', () => {
+            expect(pathSegmentOptionsFor({archiveChunkPrefix: 'slice-', versionDirectoryPrefix: 'rel-'}))
+                .toEqual({chunkPrefix: 'slice-', versionPrefix: 'rel-'});
+            expect(pathSegmentOptionsFor({})).toEqual({chunkPrefix: 'chunk-', versionPrefix: 'v'})
         });
 
         test('a projectRoot-relative path does NOT parse — the convention trap, pinned', () => {

--- a/test/playwright/unit/ai/services/knowledge-base/DatabaseService.sync.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/DatabaseService.sync.spec.mjs
@@ -19,11 +19,26 @@ test.describe('Neo.ai.services.knowledge-base.DatabaseService sync', () => {
     });
 
     test('createKnowledgeBase() emits type: adr chunks', async () => {
-        const originalDataPath = aiConfig.dataPath;
-        const testDataPath     = path.join(aiConfig.neoRootDir, 'dist', 'test-ai-knowledge-base.jsonl');
+        const originalDataPath    = aiConfig.dataPath;
+        const originalPullSources = aiConfig.sourcePaths.PullRequestSource;
+        const testDataPath        = path.join(aiConfig.neoRootDir, 'dist', 'test-ai-knowledge-base.jsonl');
 
         try {
             aiConfig.dataPath = testDataPath;
+
+            // This spec's subject is ADR emission, but `createKnowledgeBase()` runs EVERY source over
+            // the live repo — so the assertion silently depended on the tracked pull corpus being
+            // duplicate-free. It is not: that corpus carries divergent duplicates today, and
+            // `PullRequestSource` now refuses them rather than embedding one PR's two renderings as
+            // distinct evidence. Correct refusal, wrong test to fail: an ADR assertion should not be
+            // coupled to the health of a different source's corpus.
+            //
+            // The coupling cannot be resolved by repairing the corpus first — `sync_all` is
+            // dev-branch-gated, so the repair only runs post-merge, on dev. Waiting for a clean corpus
+            // to land the code that cleans it is circular. So the pull source is scoped out HERE,
+            // leaving the fail-closed consumer fully intact: `PullRequestSource.spec.mjs` covers the
+            // refusal directly, and this spec goes back to testing what its name says.
+            aiConfig.sourcePaths.PullRequestSource = [];
 
             // Generate the knowledge base
             const result = await DatabaseService.createKnowledgeBase();
@@ -43,7 +58,9 @@ test.describe('Neo.ai.services.knowledge-base.DatabaseService sync', () => {
 
             expect(adrChunks.length).toBeGreaterThan(0);
         } finally {
-            aiConfig.dataPath = originalDataPath;
+            aiConfig.dataPath                      = originalDataPath;
+            aiConfig.sourcePaths.PullRequestSource = originalPullSources;
+
             if (fs.existsSync(testDataPath)) {
                 await fs.unlink(testDataPath);
             }

--- a/test/playwright/unit/ai/services/knowledge-base/source/PullRequestSource.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/source/PullRequestSource.spec.mjs
@@ -125,3 +125,132 @@ test.describe('Neo.ai.services.knowledge-base.source.PullRequestSource', () => {
         }
     });
 });
+
+/**
+ * @summary The consumer boundary — duplicate local artifacts must never reach the Knowledge Base as
+ * distinct evidence.
+ *
+ * Extraction walks FILES, but a chunk's name is keyed by PR IDENTITY (`pr-<id>#<element>`). Two
+ * artifacts for one id emit two chunks under the SAME logical name, with different content and
+ * different `source` paths — so they land as distinct rows, both retrievable, and a maintainer reads
+ * one PR's two divergent renderings as two corroborating pieces of evidence. That is the failure the
+ * corpus-integrity work exists to prevent, arriving through the consumer rather than the writer.
+ *
+ * Its own fixture root per test: the suite above shares one via `beforeAll`, and seeding duplicates
+ * into a shared corpus would break the specs that assert exact chunk counts over it.
+ */
+test.describe('Neo.ai.services.knowledge-base.source.PullRequestSource — duplicate identity', () => {
+    let PullRequestSource;
+    let aiConfig;
+    let originalRoot;
+    let mockRoot;
+
+    const collector = () => {
+        const written = [];
+
+        return {written, write(str) { written.push(JSON.parse(str.trim())); return true }};
+    };
+
+    test.beforeAll(async () => {
+        aiConfig          = (await import('../../../../../../../ai/mcp/server/knowledge-base/config.template.mjs')).default;
+        PullRequestSource = (await import('../../../../../../../ai/services/knowledge-base/source/PullRequestSource.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+
+        fs.ensureDirSync(tmpDir);
+        originalRoot = aiConfig.neoRootDir;
+        mockRoot     = path.join(tmpDir, 'prsource-dup-' + process.pid + '-' + Date.now() + '-' + Math.random().toString(36).slice(2));
+        fs.ensureDirSync(path.join(mockRoot, 'resources/content'));
+        aiConfig.neoRootDir = mockRoot;
+    });
+
+    test.afterEach(() => {
+        aiConfig.neoRootDir = originalRoot;
+        if (mockRoot && fs.existsSync(mockRoot)) fs.removeSync(mockRoot);
+    });
+
+    const writePr = (relDir, id, body) => {
+        const dir = path.join(mockRoot, 'resources/content', relDir);
+
+        fs.ensureDirSync(dir);
+        fs.writeFileSync(path.join(dir, `pr-${id}.md`), body, 'utf8');
+    };
+
+    const writeIndex = entries =>
+        fs.writeFileSync(path.join(mockRoot, 'resources/content/_index.json'), JSON.stringify(entries));
+
+    test('POSITIVE CONTROL: a clean corpus extracts one chunk per PR across both tiers', () => {
+        // Without this, every "it threw" below could equally mean the extractor never ran at all.
+        writePr('pulls/chunk-1', 100, '# body one');
+        writePr('archive/pulls/v13.0.0/chunk-1', 200, '# body two');
+        writeIndex([
+            {type: 'pulls', id: 100, version: null, chunkNumber: 1, path: 'pulls/chunk-1/pr-100.md'},
+            {type: 'pulls', id: 200, version: 'v13.0.0', chunkNumber: 1, path: 'archive/pulls/v13.0.0/chunk-1/pr-200.md'}
+        ]);
+
+        const stream = collector();
+
+        return PullRequestSource.extract(stream, () => 'hash').then(count => {
+            expect(count).toBe(2);
+            expect(stream.written.map(c => c.name).sort()).toEqual(['pr-100#body', 'pr-200#body'])
+        })
+    });
+
+    test('REFUSES a PR owning two artifacts — the production shape, one sealed bucket, two chunks', async () => {
+        writePr('archive/pulls/v13.0.0/chunk-1', 10124, '# stale rendering');
+        writePr('archive/pulls/v13.0.0/chunk-2', 10124, '# newer rendering with reviews');
+        writeIndex([]);
+
+        await expect(PullRequestSource.extract(collector(), () => 'hash'))
+            .rejects.toThrow(/more than one local artifact/)
+    });
+
+    test('the refusal names BOTH artifacts — a reader must know what to repair', async () => {
+        writePr('archive/pulls/v13.0.0/chunk-1', 10124, '# a');
+        writePr('archive/pulls/v13.0.0/chunk-2', 10124, '# b');
+        writeIndex([]);
+
+        await expect(PullRequestSource.extract(collector(), () => 'hash'))
+            .rejects.toThrow(/chunk-1[\s\S]*chunk-2|chunk-2[\s\S]*chunk-1/)
+    });
+
+    test('refuses when ONE copy is indexed and the other is not — the ids arrive typed differently', async () => {
+        // The trap that would make this guard vacuous. The indexed copy's id comes from the index map
+        // as a NUMBER; the unindexed copy falls back to the filename and yields a STRING. Compared
+        // raw, `10124 !== '10124'` and the duplicate sails straight through — a guard that cannot see
+        // the thing it guards against. This case is what pins the normalisation, and it is also the
+        // most likely real shape, since an unrepaired duplicate is exactly what goes unindexed.
+        writePr('archive/pulls/v13.0.0/chunk-1', 10124, '# indexed copy');
+        writePr('archive/pulls/v13.0.0/chunk-2', 10124, '# unindexed copy');
+        writeIndex([
+            {type: 'pulls', id: 10124, version: 'v13.0.0', chunkNumber: 1, path: 'archive/pulls/v13.0.0/chunk-1/pr-10124.md'}
+        ]);
+
+        await expect(PullRequestSource.extract(collector(), () => 'hash'))
+            .rejects.toThrow(/more than one local artifact/)
+    });
+
+    test('refuses across TIERS — an active and an archived copy of one PR is still one identity', async () => {
+        writePr('pulls/chunk-1', 10125, '# active copy');
+        writePr('archive/pulls/v13.0.0/chunk-1', 10125, '# archived copy');
+        writeIndex([]);
+
+        await expect(PullRequestSource.extract(collector(), () => 'hash'))
+            .rejects.toThrow(/more than one local artifact/)
+    });
+
+    test('distinct PRs in one chunk are NOT a duplicate — the check is per identity, not per directory', () => {
+        writePr('pulls/chunk-1', 300, '# three');
+        writePr('pulls/chunk-1', 301, '# four');
+        writeIndex([]);
+
+        const stream = collector();
+
+        return PullRequestSource.extract(stream, () => 'hash').then(count => {
+            expect(count).toBe(2);
+            expect(stream.written.map(c => c.name).sort()).toEqual(['pr-300#body', 'pr-301#body'])
+        })
+    });
+});


### PR DESCRIPTION
## 🎯 Summary

The local pull-request corpus holds **2,015 `_index.json` entries naming paths that do not exist** and **27 PR ids owning two byte-divergent artifacts each**. It has been like this for months, and every pass reported success the entire time.

Both symptoms are one cause: **every surface that placed a PR ranked it against a partial view of its bucket.** `metadata.pulls` is rebuilt from each run's delta fetch, so a planner consulting it sees a fraction of a sealed bucket. An ordinal derived from a partial collection is not a smaller truth — it is a *different number*. The PR resolves to a chunk the complete ordering would never choose, the write lands beside the existing artifact instead of on it, and the two renderings diverge from that moment. The old copy survives because the unlink is gated on `cachedPull?.path`, and a cache miss makes that null.

This matters past tidiness because the corpus feeds the **Knowledge Base**. The ticket's own AC names the stakes better than I can: duplicate projection *"masquerading as distinct evidence."* Our verify-before-assert substrate can currently hand a maintainer two divergent copies of one PR and present them as independent corroboration.

Resolves #15130

Refs #13001, #13200 (the incomplete persistence boundary), #15088 (discovered by, non-blocking)

Evidence: L3 (the validator and both repair passes executed against a byte-copy of the live 4,661-artifact corpus — 2,015 stale → 0, partition verified; 560 specs green; tracked corpus asserted unmodified after a full suite run) → L4 required (AC5 and AC7 name post-repair counts in the TRACKED corpus, which is written only by a `sync_all` run on `dev` — an operator/agent action that commits generated content, deliberately not taken from this branch at night and unreviewed). Residual: AC5, AC7 [#15130].

**Correction to an earlier draft of this line, because the name is a trap.** It read "only the data-sync pipeline may write — agents do not run it." That is false, and two different things share the name. `resources/content` is written by **`sync_all`** (MCP → `syncAllOnDevOnly` → `SyncService.runFullSync`), which is **agent-invoked** and dev-guarded — it is the documented exception to no-direct-commit, not a CI job. The GitHub workflow *called* "Data Sync Pipeline" **reads** `resources/content` to publish it to `neomjs/pages` and commits devindex/portal artifacts; it never writes the corpus. So the residual is real but its reason was wrong: the repair lands on the next `sync_all`, run by a person or an agent, not on a CI schedule.

## 🔬 Evidence — I re-censused before trusting the ticket

@neo-gpt's forensics are three days old, so I ran them again rather than inherit them. They reproduce **exactly**:

| | ticket (07-13) | live (now) |
|---|---|---|
| `pulls` index entries | 4,566 | **4,634** (+68, normal sync) |
| index → missing path | 2,015 | **2,015** |
| duplicate PR ids | 27 | **27** |
| byte-divergent | "every pair" | **27 of 27**, zero identical |

Both of his named falsifiers land: the first stale entry my probe returns is `pr-9537`, the first duplicate is `10124`. And the duplicate's **shape** confirms the diagnosis rather than merely its count:

```
archive/pulls/v13.0.0/chunk-1/pr-10124.md   1857 B
archive/pulls/v13.0.0/chunk-2/pr-10124.md   1790 B
```

Same sealed version, **two chunk ordinals**, divergent bytes. Not a move that forgot an upsert — a *second placement* derived from membership the planner could not see.

## 🧭 The changes

**1 · The complete corpus, and a verdict over it.** `buildContentInventory` scans both tiers — files outlive every cache describing them, so the corpus is the only complete membership that exists. It keys ids to an **array**, because "one artifact per id" is the invariant *under test*, not an assumption the scanner may make: a `Map<id, entry>` would drop the second copy and report a clean corpus, which is exactly the blindness that let this accumulate.

**2 · A move and its index upsert are one mutation set.** `reconcileClosedPullRequestLocations` renamed files and never touched the index. A rename that does not carry its entry does not relocate a file — it **hides** it: the artifact is intact, the lookup points at nothing, nothing complains. "The next sync rebuilds the index" was the standing assumption and is false for exactly this set: `syncPullRequests` upserts only its own delta, and a marooned backlog is the set the delta never names.

**3 · An archived PR keeps the artifact it owns.** Archive ordinals are fixed when a bucket is cut, so recomputing one at refresh time answers a different question than the one that placed the file. Reusing the occupied location makes a refresh *overwrite* — a rival copy becomes unreachable by construction rather than merely unlikely. Placement now plans against the corpus; a PR owning two artifacts is **refused, not guessed at**, because nothing on disk says which is current and writing to either canonicalises a guess.

**4 · The index repair.** Preventing new drift does not remove old drift, and nothing else ever would have — the 2,015 name files *already archived*, so the relocate pass never revisits them and the delta never fetches them. They were unreachable by every mechanism expected to heal them. The index is a **projection of the corpus**, so `reconcilePullRequestIndex` recomputes it from disk, every sync, idempotently.

**5 · The duplicate restore.** The 27 cannot be resolved locally, so GitHub decides. **Fetch before unlink** — the copies are the only local record, so deleting first would turn a network blip into a corpus simply missing the PR; a repair that can lose data on a bad connection is not a repair. A PR absent from GitHub is refused rather than cleaned up, since its copies are then the only record left. Both repairs reach the corpus through the **normal sync**, which is what the ticket asked for and why it forbade a migration script: a script clears the rows once and leaves the class alive.

**Also fixed, both latent and neither in the ticket:**
- The end-of-run metadata loop assumed every fetched PR produced a path and sits **outside** the per-PR catch — so any PR failing to sync, for any reason, long before this change, threw on `path.resolve(root, undefined)` and took down the whole run's metadata and index write.
- `refetchPullsByNumber` — the **recovery primitive** — planned from a single PR, the narrowest view in the syncer. A tool that manufactures the drift it exists to remove is worse than no tool, because it runs precisely when the corpus is already suspect.

## 🔁 Review cycle 1 — @neo-gpt-emmy's four coupled boundaries, all real

Her review found four groups. Every one was a real defect, and two were the same shape twice.

**RA-2 — duplicate repair was destructive under every failure point but the one I'd thought of.** I wrote a commit message about "fetch before unlink: a repair that can lose data on a bad connection is not a repair" — while the canonical rendering sat in MEMORY as both copies were deleted. Planning, path resolution (my own ambiguity refusal, firing from *inside* that window), `mkdir`, the write: any throw, or a crash needing no exception at all, left the corpus missing the PR and logged it as a soft skip. **"Fetched" is not "durable"; only a file on disk is.** Now: plan → temp write → atomic rename → *then* remove stale copies, never the one just written. Separately, `reconcileClosedPullRequestLocations` called `fs.rename()` with no destination check — and rename silently replaces, so it could resolve a duplicate **by deletion**, destroying the archived copy the repair arbitrates from, in the pass that runs *before* the refusal to do exactly that.

**RA-1 — complete membership was only half complete.** `#planBuckets` inherited corpus membership for versioned buckets only, so the **active** collection still ranked PRs against the delta — the same partial-ordinal defect one tier over, invisible because the archive half looked fixed. And `parseContentPath` hardcoded `chunk-` / `/^v\d/` while the config carries `archiveChunkPrefix` / `versionDirectoryPrefix`: **the hardcodes agree with the shipped defaults, which is why nothing was red.** Under an override the forward direction builds `slice-3/` while the inverse only recognises `chunk-3/` — two halves of one contract disagreeing silently.

**RA-3 — the lane could measure the corpus as broken and commit it anyway.** Every pass reported its own outcome and degraded softly on its own terms; nothing downstream asked. One verdict now runs after placement, restoration and projection are final, and aborts **before** the metadata save, the derive, and the auto-push. A failed run is retryable; a generated commit is what every consumer then reads as truth. The index also became an actual projection — it now **removes**: a row for an ambiguous id blesses one of two divergent copies as canonical, silently, because the path is real.

**RA-4 — the consumer boundary.** `PullRequestSource` keys chunks by PR identity while walking files, so two artifacts emitted two chunks under the same `pr-<id>#body` name with divergent content. It now refuses. Ids are normalised to strings because they arrive as `Number` from the index and `String` from the filename fallback — compared raw, `10124 !== '10124'` and the guard silently never fires.

**Twice she found the same shape: the branch I thought of fixed, the invariant's other half open.** That is the tell from #14153 — a ticket I re-opened this same evening, for this. My specs could not catch it because each exercised the half I had already fixed.

## Test Evidence

**560 specs green** across `github-workflow` + `knowledge-base` (no collateral damage). The tracked corpus is **unmodified after a full suite run** — asserted, not assumed, because a green suite is exactly what it looked like while it was rewriting 4,180 lines of it.

One pre-existing failure is NOT mine: `PullRequestService.spec.mjs:399` (`getPullRequestDiff` file filter) fails on this branch **and on clean `origin/dev`** with these changes absent — verified in a detached worktree at `f3b36f627b`. Zero coupling: that service references none of these surfaces.

**The repair, measured against a throwaway copy of the live corpus** — tracked files never touched:

```
BEFORE  stale indexed paths : 2015
repair  reindexed 2015 | already correct 2592 | skipped ambiguous 27
AFTER   stale indexed paths : 0
```

`2015 + 2592 + 27 = 4,634` — exactly the unique-id count. The pass partitions the corpus with every id accounted for and none counted twice, and it correctly **skips** the 27 rather than indexing one copy of each: an entry naming one of two divergent artifacts would bless it as canonical by implication. Those are handled by the restore, which is the only step allowed to decide, and it decides by asking GitHub.

**Red-then-green, proven by stashing the fix**, not asserted: the lookup assertion reads `pulls/chunk-1/pr-13001.md` where the file is at `archive/pulls/v13.0.0/chunk-1/` — the production defect reproduced. 4 fail without it.

**The specs assert the defect BEFORE any counter this change introduces.** Ordered the other way they tripped on the new field first and never evaluated the defect at all — red for a bookkeeping reason, which is a test that cannot fail for its stated purpose. My first draft did exactly that; the ordering is the fix.

**Two instruments agree:** the tested validator independently reproduces an ad-hoc probe written against a different shape — 2,015 / 27 / 4,634, all matching.

**Every detection case is paired with a positive control** proving the same probe returns non-zero when the condition is present, and the clean-corpus case proves the verdict can reach PASS. A validator that cannot fail and one that cannot pass are equally worthless. Three of the first probes I wrote for this lane returned clean zeros from blind instruments (wrong container shape, wrong extension, wrong filename prefix); any one, trusted, closes this ticket as already-fixed. The controls are why the surviving numbers mean anything.

## Post-Merge Validation

**⚠️ The repair does not run by itself. Someone must run it, on `dev`, after this merges.**

Stated loudly because I nearly shipped this lane with the opposite implication. Verified:

- **No workflow runs the content sync.** The GitHub workflow *named* "Data Sync Pipeline" only READS `resources/content` to publish it to `neomjs/pages`; it commits devindex/portal artifacts and never writes the corpus.
- **`syncOnStartup` defaults to `false`** — an MCP server boot does not trigger it.
- The only entrypoints are **`npm run ai:sync-github-workflow`** (dev-branch-guarded CLI, takes a heavy-maintenance lease) and the `sync_all` MCP tool — **both manual, both dev-only**.

So five commits of repair merge and then sit inert until a person acts. That is exactly the failure class this branch's sibling ticket (#13289) was about: code that is merged and never runs. Naming the action rather than implying an automation that does not exist:

- [ ] **On `dev`, after merge: `npm run ai:sync-github-workflow`.** That single run does all of it — the relocate pass, the duplicate restore (27 refetches from GitHub), and the index projection. Expect a generated-content diff of ~2,015 index entries plus 27 re-rendered artifacts. That diff IS the repair; it is not noise.
- [ ] `validateContentIntegrity` then reports `ok: true`. Until it does, the terminal gate this PR adds will **abort the sync before the metadata save, the derive, and the auto-push** — so a partial repair cannot commit. A red sync after merge is the gate working, not a regression.
- [ ] A second run writes **nothing** and makes **no** network call for duplicates — both passes are idempotent, so the generated-content diff stays empty.
- [ ] If a restore fails (network, PR deleted upstream), both copies survive untouched and the id stays reported. No partial state is committed.

**One ordering note for whoever runs it:** the duplicate restore needs GitHub. The DevIndex pipeline has been failing on transient 503s tonight (#15328), so if the API is unhealthy the 27 will fail closed and stay divergent — which is correct, and re-runnable. The 2,015 do not need the network and will repair regardless.

## 📊 Evaluation Metrics
- `[ARCH_ALIGNMENT]`: 90 — the index becomes a projection of the corpus and is repaired through the normal path; no migration script, no new substrate, path math stays in the module that owns it.
- `[CONTENT_COMPLETENESS]`: 85 — each guard documents the failure it prevents rather than what it does; the three path conventions are named where they bite.
- `[EXECUTION_QUALITY]`: 85 — fails closed on ambiguity, red-then-green proven on the defect, positive controls throughout, repair measured on real data.
- `[PRODUCTIVITY]`: 80 — one lane, five coherent commits, no micro-split.
- `[IMPACT]`: 85 — removes a class that silently corrupts the retrieval substrate the whole team runs V-B-A against.
- `[COMPLEXITY]`: 55 — a new shared primitive plus surgery on a delta-sync planner with sealed-archive semantics.
- `[EFFORT_PROFILE]`: Deep Work.

## Deltas from ticket

**Both forks I flagged at claim time are now decided, and one changed after @neo-gpt-emmy's review.**

1. **The 27 restorations:** re-derived from GitHub, surgically rather than wholesale. **Correcting this line's earlier framing (@tobiu, pre-merge): it read "GitHub-canonical *over* ADR-0004 clean regeneration", which implies a choice AGAINST the ADR. There is no such conflict.** ADR-0004 §1.3 is explicit — *"`resources/content/` is a fully-regeneratable cache, NOT a source of truth. GitHub is the source of truth."* Re-deriving from GitHub **is** the ADR's principle; the only choice here was blast radius, and the ADR does not mandate the wholesale path. You cannot know which of two divergent local renderings is current, so re-derive from the source of truth; regenerating the whole corpus is a far larger hammer for 27 ids. @neo-gpt — the mechanism is one method if you'd have taken the other route.
2. **Gate-vs-report: moot, then not.** I said both repairs run inside the normal sync so nothing needs gating. Emmy's RA-3 corrected that: the repairs running is not the same as the result being *checked*. A pass can fail softly and the corpus still commits. There is now a terminal verdict that aborts the run.

**Scope decisions, none drive-by:**

- **`SyncService.Stage2.spec.mjs` isolation** — my repair pass is the first **disk-only** step in the orchestration, and that spec runs `runFullSync` against the **real** `resources/content`. Every other step is network-gated and no-ops with GraphQL stubbed, so the exposure was invisible: a unit run rewrote **4,180 lines of the tracked corpus**, caught by `git status` after the suite, not by anything going red. I stubbed **all** previously-unstubbed pull passes, not just the one that bit me.
- **`verifyCorpusIntegrity()` is a method on the syncer, not a call the orchestrator makes.** Not stylistic: as a bare module call it forced the orchestrator to know pull-specific facts (type segment, filename prefix) and was **unstubbable** — it read the live corpus from a unit run and threw with the real census. Unstubbable in a sequencing spec is a design smell; it means the orchestrator is reaching past its own seam.

**Things I got wrong, since they shape the diff:**

- My first `parseContentPath` JSDoc example used a **projectRoot-relative** path and my test faithfully encoded my own error. This subsystem carries **three** path conventions, two of them bare relative strings differing only by a leading `resources/content/`. The parser rejects the doubled shape rather than sniffing for the prefix: a parser that guessed would accept a doubled path as real — trading an honest refusal for a confident answer, which is the trade that produced the drift this lane removes.
- **Three of my first probes of this corpus returned clean zeros** (wrong container shape, wrong extension, wrong filename prefix). Any one, trusted, closes this ticket as already-fixed. The positive control — 15,458 tracked files → 4,661 artifacts — is the only reason the eventual 27 means anything.

Authored by @neo-opus-grace (Grace, Claude Opus 4.8)




