### PR TITLE
fix(memory-core): a mark resolves through the same repair the read path uses (#15253)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -1045,6 +1045,7 @@ function hasBroadcastDeliveryEdges(messageId) {
     return getBroadcastDeliveryEdges(messageId).length > 0;
 }
 
+
 function getReadAtForMessage(messageNode, deliveryEdge=null) {
     if (deliveryEdge) {
         return getRecordProperties(deliveryEdge).readAt || null;
@@ -2113,6 +2114,20 @@ class MailboxService extends Base {
         // Trigger syncCache + lazy-reload vicinity. Ensures the SENT_TO edge
         // iteration sees peer-process writes. See listMessages for the full rationale.
         db.getAdjacentNodes(messageId, 'both');
+
+        // The read path repairs a degraded projection before serving; this path did not, so a mark
+        // resolved and authorized from a cache the reader had already healed past. That divergence is
+        // the defect: `get_message` served messages whose node or SENT_TO edge was absent here, while
+        // the same ids threw `Message not found` or `Unauthorized` from the mark in the same minute. A
+        // mark is a WRITE — resolving it from a staler source than the read that displayed the message
+        // is the worst way round, and it made unread counts inflate for every peer.
+        //
+        // Repair is surgical (`onlyIssues`) and falls back to storage truth per flagged piece, so
+        // triggering it here cannot resurrect the WAL's send-time `readAt: null` over a committed read.
+        if (getCachedMessageProjectionIssues(messageId).length > 0) {
+            await this.repairMessageGraphIntegrity({ids: [messageId], limit: 1});
+            db.getAdjacentNodes(messageId, 'both');
+        }
 
         const messageNode = db.nodes.get(messageId);
         if (!messageNode || messageNode.label !== 'MESSAGE') {

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -146,6 +146,29 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         GraphService.db.lastAccessMap.clear();
     }
 
+    /**
+     * Damages one edge type of a message's GRAPH PROJECTION — cache and storage both — while leaving
+     * the message WAL record intact. That is the state the repair path exists for: the WAL holds the
+     * truth, the projection has lost a piece, and `repairMessageGraphIntegrity` rebuilds the piece
+     * from the WAL.
+     *
+     * Evicting from cache alone proves nothing: `getAdjacentNodes` lazily reloads the vicinity from
+     * storage, so the mark heals before it resolves and a cache-only test passes against the very
+     * defect it claims to pin. autoSave stays ON here deliberately — the remove must echo through
+     * onEdgesMutate into storage.removeEdges, which is precisely what the cache-only helper suspends.
+     */
+    function damageEdgeProjection(messageId, type) {
+        const edges = GraphService.db.edges.items.filter(candidate =>
+            candidate.source === messageId && candidate.type === type
+        );
+
+        GraphService.db.edges.remove(edges);
+        GraphService.db.vicinityLoadedNodes.clear();
+        GraphService.db.lastAccessMap.clear();
+
+        return edges.length
+    }
+
     test('addMessage enforces identity and routes correctly', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
@@ -800,6 +823,30 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
 
         const node = GraphService.db.nodes.get(msgId);
         expect(node.properties.readAt).toBeTruthy();
+    });
+
+    test('#15253 a mark resolves through the same repair the read path uses — a cold cache is not a missing message', async () => {
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const {messageId} = await RequestContextService.run({agentIdentityNodeId: '@alice'}, () =>
+            MailboxService.addMessage({to: '@bob', subject: 'peer-process write', body: 'served but unmarkable'})
+        );
+
+        // The SENT_TO edge is what authorizes the mark, and it is the piece the read path repairs
+        // from the WAL before serving.
+        expect(damageEdgeProjection(messageId, 'SENT_TO')).toBeGreaterThan(0);
+
+
+        // The mark is probed WITHOUT a preceding read. A read first would repair the projection and
+        // hand the mark a healed graph — the test would then pass against the defect it claims to
+        // pin, which is exactly what the first draft of this spec did.
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            const result = await MailboxService.markRead({messageId});
+            expect(result).toMatchObject({messageId, status: 'read'});
+            expect(result.readAt).toBeTruthy();
+        });
     });
 
     test('#15027 markRead canonicalizes both bound identity and drifted direct SENT_TO targets', async () => {


### PR DESCRIPTION
Resolves #15253

## Summary

`markRead` resolved and authorized a message from whatever the cache happened to hold. `getMessage` repairs a degraded projection from the WAL **before** serving. Same process, same message, same minute: the read path healed the projection and served it, the mark path saw the unhealed graph and threw `Message not found` or `Unauthorized`.

A mark is a **write**. Resolving it from a staler source than the read that displayed the message is the worst way round — and because the failures were silent or dismissed as noise, unread counts inflated for the whole swarm. With the wake daemon disabled, mailbox triage *is* the coordination surface, so this degrades the thing we coordinate through.

`markRead` now mirrors the read path's trigger: when the cached projection has gaps, repair from the WAL, re-sync the vicinity, then resolve.

**Why this is safe.** The repair is surgical (`onlyIssues`) and falls back to storage truth per flagged piece, so triggering it here cannot resurrect the WAL's send-time `readAt: null` over a committed read — the read-state-rollback defect this repair once was. That property is load-bearing for this change and is why the fix is a trigger rather than a re-projection.

Evidence: on the prior module the new spec throws `Unauthorized: you are not the recipient of message MESSAGE:84bfd407…` for a message whose `SENT_TO` projection is damaged. With the repair, it marks. 113/113 MailboxService specs pass.

## Deltas

| Area | Before | After |
|---|---|---|
| `markRead` resolution | resolves + authorizes from the unrepaired cache | repairs a gapped projection from the WAL first, mirroring `getMessage` |
| Damaged `SENT_TO` | `Unauthorized` for a message the read path serves | marks |
| Missing message node | `Message not found` for a node the read path resolves | marks |
| Repair safety | — | surgical `onlyIssues` + per-piece storage-truth fallback; cannot roll back committed read-state |

## Test Evidence

**The falsification is the point, and it took three drafts.** The first two were green against unfixed code:

1. **Cache-only eviction proves nothing.** `getAdjacentNodes` lazily reloads the vicinity from storage, so the mark heals before it resolves. Green against the defect.
2. **Probing the mark after a read is worse.** The read *repairs* the projection and hands the mark a healed graph — the test passes against the very defect it claims to pin. My first draft called `getMessage` then `markRead`; its own setup repaired the bug.
3. **What actually bites:** damage the graph projection (cache **and** storage, WAL intact — the state the repair path exists for), then probe the mark **with no preceding read**.

Both dead ends are recorded in the spec body, because "the test's setup healed the defect" is the same class this repo keeps hitting.

```
UNFIXED:   1 failed   ← Unauthorized: you are not the recipient of MESSAGE:84bfd407…
FIXED:     113 passed
```

Verified damage lands before asserting behaviour: `storage SENT_TO rows=0 cached=0`.

## Scope — what this does NOT fix

**The broadcast success-without-persistence specimen (#15253 specimen 4) is not addressed here.** I drafted a delivery-edge trigger for it and **could not make it fail against unfixed code**, so it is not shipped. An unfalsified fix is a guess, and a spec that passes either way is decoration.

Its mechanism is traced and recorded on the ticket for a follow-up with a real reproduction: `markRead` falls through to the legacy MESSAGE-node write when the per-recipient `DELIVERED_TO` edge is absent from cache, while `getReadAtForMessage` reads `readAt` from the delivery edge once the read path restores it — so the write and the read disagree about which record carries broadcast read-state, and the mark returns success regardless.

## Post-Merge Validation

- Watch A2A unread counts across the swarm: marks on peer-written messages should stop failing, and `list_messages({status: 'unread'})` should stop re-serving messages that were already marked.
- Reopen trigger: any recurrence of `Unauthorized` / `Message not found` from `mark_read` on a message that `get_message` serves in the same minute.
- The broadcast specimen is expected to survive this PR; its recurrence is **not** a regression of this change.

Authored by @neo-opus-ada (Claude Opus 4.8)
