### PR TITLE
fix(manager): retire the drag source on the outcome, not the attempt (#15248)

### DIFF
--- a/src/draggable/dashboard/SortZone.mjs
+++ b/src/draggable/dashboard/SortZone.mjs
@@ -94,10 +94,10 @@ class DashboardSortZone extends SortZone {
             me.adjustProxyRectToParent?.(rect, me.ownerRect);
 
             console.log('applyAbsolutePositioning', {
-                height  : `${rect.height}px`,
-                left    : `${rect.left}px`,
-                top     : `${rect.top}px`,
-                width   : `${rect.width}px`
+                height: `${rect.height}px`,
+                left  : `${rect.left}px`,
+                top   : `${rect.top}px`,
+                width : `${rect.width}px`
             });
 
             item.wrapperStyle = Object.assign(itemStyle, {
@@ -375,28 +375,41 @@ class DashboardSortZone extends SortZone {
     }
 
     /**
+     * @summary Takes the item into this zone, and REPORTS whether it did.
+     *
+     * The return value is the commit decision the coordinator gates source retirement on: the
+     * committed operation, or `null` when this zone did not take the item. Both paths previously
+     * returned `undefined`, so committing and declining were indistinguishable to the caller — and a
+     * caller cannot honour an outcome the target refuses to state.
+     *
      * @param {Neo.component.Base} draggedItem
+     * @returns {Promise<Object|null>} The committed operation, or `null` when nothing was taken.
      */
     async onRemoteDrop(draggedItem) {
         let me    = this,
             index = me.currentIndex;
 
-        // Ensure we are in remote drag mode
-        if (me.isRemoteDragging) {
-            // Cleanup placeholder but keep layout ready
-            await me.onDragEnd({});
-
-            // Remove from old parent (if not already detached)
-            const parentId = draggedItem.parentId;
-            if (parentId && parentId !== 'document.body') {
-                Neo.getComponent(parentId)?.remove(draggedItem, false)
-            }
-
-            // Insert into new owner
-            me.owner.insert(index, draggedItem);
-
-            me.isRemoteDragging = false
+        // Not in remote drag mode: this zone takes nothing, and says so. Silence here is what let the
+        // coordinator retire a source into a target that never accepted the item.
+        if (!me.isRemoteDragging) {
+            return null
         }
+
+        // Cleanup placeholder but keep layout ready
+        await me.onDragEnd({});
+
+        // Remove from old parent (if not already detached)
+        const parentId = draggedItem.parentId;
+        if (parentId && parentId !== 'document.body') {
+            Neo.getComponent(parentId)?.remove(draggedItem, false)
+        }
+
+        // Insert into new owner
+        me.owner.insert(index, draggedItem);
+
+        me.isRemoteDragging = false;
+
+        return {index, ownerId: me.owner.id, type: 'insertItem'}
     }
 
     /**
@@ -488,10 +501,10 @@ class DashboardSortZone extends SortZone {
 
         itemRects.forEach(rect => {
             console.log('itemRect', {
-                height  : `${rect.height}px`,
-                left    : `${rect.left}px`,
-                top     : `${rect.top}px`,
-                width   : `${rect.width}px`
+                height: `${rect.height}px`,
+                left  : `${rect.left}px`,
+                top   : `${rect.top}px`,
+                width : `${rect.width}px`
             });
         });
 
@@ -632,7 +645,7 @@ class DashboardSortZone extends SortZone {
      * @param {Object} data - The drag move event data.
      */
     startWindowDrag(data) {
-        let me = this,
+        let me                                    = this,
             {popupHeight, popupWidth, windowName} = data;
 
         // Keep the proxy active to capture mouse events, but make it invisible

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -393,11 +393,21 @@ class DragCoordinator extends Manager {
         let me = this;
 
         if (me.activeTargetZone) {
-            // Drop on target
-            me.activeTargetZone.onRemoteDrop(data.draggedItem);
+            // The TARGET decides whether the gesture committed: onRemoteDrop() returns the committed
+            // operation, or null when there was no preview, no operation, or the commit declined.
+            // Engagement is not commitment, so its answer cannot be discarded.
+            let operation = me.activeTargetZone.onRemoteDrop(data.draggedItem);
 
-            // Notify source to finalize cleanup
-            data.sourceSortZone.onRemoteDropOut(data.draggedItem);
+            // Source retirement follows the OUTCOME, not the attempt. Retiring unconditionally armed
+            // the source's `remoteDropCommitted`, whose whole meaning is "a remote target committed
+            // this transfer" — and which suppresses the source's in-window drop path on that belief.
+            // On a null commit the target never took the item while the source had already let go, so
+            // the item stranded with no owner. Leaving the flag unarmed lets the source's ordinary
+            // in-window path run and restore it: the restore is the pre-existing default, not a new
+            // capability — it was simply unreachable behind the false commit signal.
+            if (operation) {
+                data.sourceSortZone.onRemoteDropOut(data.draggedItem)
+            }
 
             me.activeTargetZone = null
         } else if (data.sourceSortZone.isWindowDragging) {
@@ -435,6 +445,14 @@ class DragCoordinator extends Manager {
             if (group.size === 0) {
                 me.sortZones.delete(sortGroup)
             }
+        }
+
+        // A departing zone must not stay installed as the live target. Dropping it from the registry
+        // while leaving it here kept a zone whose vessel is gone reachable as `activeTargetZone`, so
+        // the next release would commit into a departed window — and re-registering the same identity
+        // would inherit that residue instead of starting clean.
+        if (me.activeTargetZone === sortZone) {
+            me.activeTargetZone = null
         }
 
         for (const [windowId, candidate] of me.nativeWindowDropCandidates.entries()) {

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -408,7 +408,7 @@ class DragCoordinator extends Manager {
             // gesture that already failed. The error is not swallowed: cleanup is exact-once on every
             // terminal, including the ones that raise.
             try {
-                let operation = me.activeTargetZone.onRemoteDrop(data.draggedItem);
+                let result = me.activeTargetZone.onRemoteDrop(data.draggedItem);
 
                 // Source retirement follows the OUTCOME, not the attempt. Retiring unconditionally
                 // armed the source's `remoteDropCommitted`, whose whole meaning is "a remote target
@@ -417,7 +417,24 @@ class DragCoordinator extends Manager {
                 // already let go, so the item stranded with no owner. Leaving the flag unarmed lets the
                 // source's ordinary in-window path run and restore it: the restore is the pre-existing
                 // default, not a new capability — it was simply unreachable behind a false signal.
-                if (operation) {
+                //
+                // Targets answer synchronously OR asynchronously, and the two cannot share a branch: a
+                // Promise is ALWAYS truthy, so testing the returned value directly reads every async
+                // target as committed — the identical defect wearing the fix's own shape.
+                //
+                // The split is not symmetry for its own sake; each side has a different truth deadline.
+                // A SYNC target must retire on this call stack, because the source reads
+                // `remoteDropCommitted` synchronously in its own drag-end continuation — deferring
+                // would arm the flag after the decision it exists to inform. An ASYNC target's outcome
+                // is not knowable this tick at all, so retirement waits for the resolution; that is
+                // sound only because an async target's source cleanup carries no same-call reader.
+                if (typeof result?.then === 'function') {
+                    result.then(operation => {
+                        if (operation) {
+                            data.sourceSortZone.onRemoteDropOut(data.draggedItem)
+                        }
+                    })
+                } else if (result) {
                     data.sourceSortZone.onRemoteDropOut(data.draggedItem)
                 }
             } finally {

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -115,8 +115,15 @@ class DragCoordinator extends Manager {
             proxyRect
         });
 
-        await targetSortZone.onRemoteDrop(draggedItem);
-        sourceSortZone.onRemoteDropOut(draggedItem);
+        // The native-titlebar path answers the same question as the pointer path, so it obeys the same
+        // rule: the target's return IS the commit decision, and a null means it declined. Retiring the
+        // source anyway arms `remoteDropCommitted` and suppresses the source's own restore, leaving the
+        // item with no owner — identical to the pointer defect, reached through a different door.
+        const operation = await targetSortZone.onRemoteDrop(draggedItem);
+
+        if (operation) {
+            sourceSortZone.onRemoteDropOut(draggedItem)
+        }
 
         if (me.activeTargetZone === targetSortZone) {
             me.activeTargetZone = null
@@ -176,11 +183,11 @@ class DragCoordinator extends Manager {
      * @returns {Object|null}
      */
     getNativeWindowDropCandidate(data, sourceDrag) {
-        let me             = this,
+        let me               = this,
             {sourceSortZone} = sourceDrag,
-            popupWindow    = Window.get(data.windowId),
-            popupRect      = popupWindow?.innerRect,
-            {sortGroup}    = sourceSortZone,
+            popupWindow      = Window.get(data.windowId),
+            popupRect        = popupWindow?.innerRect,
+            {sortGroup}      = sourceSortZone,
             targetWindowId, targetSortZone, targetWindow, localX, localY, width, height;
 
         if (!popupRect || !sortGroup) {
@@ -252,19 +259,19 @@ class DragCoordinator extends Manager {
      * @param {Neo.draggable.container.SortZone} data.sourceSortZone
      */
     onDragMove(data) {
-        let me             = this,
+        let me                                                                           = this,
             {draggedItem, offsetX, offsetY, proxyRect, screenX, screenY, sourceSortZone} = data,
-            {sortGroup}    = sourceSortZone,
-            targetWindowId = Window.getWindowAt(screenX, screenY),
+            {sortGroup}                                                                  = sourceSortZone,
+            targetWindowId                                                               = Window.getWindowAt(screenX, screenY),
             targetSortZone;
 
         if (targetWindowId && targetWindowId !== sourceSortZone.windowId) {
             targetSortZone = me.sortZones.get(sortGroup)?.get(targetWindowId);
 
             if (targetSortZone) {
-                let targetWindow = Window.get(targetWindowId),
-                    localX       = screenX - targetWindow.innerRect.x,
-                    localY       = screenY - targetWindow.innerRect.y,
+                let targetWindow    = Window.get(targetWindowId),
+                    localX          = screenX - targetWindow.innerRect.x,
+                    localY          = screenY - targetWindow.innerRect.y,
                     targetProxyRect = new Rectangle(
                         localX - offsetX,
                         localY - offsetY,
@@ -396,20 +403,26 @@ class DragCoordinator extends Manager {
             // The TARGET decides whether the gesture committed: onRemoteDrop() returns the committed
             // operation, or null when there was no preview, no operation, or the commit declined.
             // Engagement is not commitment, so its answer cannot be discarded.
-            let operation = me.activeTargetZone.onRemoteDrop(data.draggedItem);
+            // `finally`, because a throwing commit is the REJECTED terminal — and a terminal that
+            // leaves `activeTargetZone` populated hands the next release a commit destination from a
+            // gesture that already failed. The error is not swallowed: cleanup is exact-once on every
+            // terminal, including the ones that raise.
+            try {
+                let operation = me.activeTargetZone.onRemoteDrop(data.draggedItem);
 
-            // Source retirement follows the OUTCOME, not the attempt. Retiring unconditionally armed
-            // the source's `remoteDropCommitted`, whose whole meaning is "a remote target committed
-            // this transfer" — and which suppresses the source's in-window drop path on that belief.
-            // On a null commit the target never took the item while the source had already let go, so
-            // the item stranded with no owner. Leaving the flag unarmed lets the source's ordinary
-            // in-window path run and restore it: the restore is the pre-existing default, not a new
-            // capability — it was simply unreachable behind the false commit signal.
-            if (operation) {
-                data.sourceSortZone.onRemoteDropOut(data.draggedItem)
+                // Source retirement follows the OUTCOME, not the attempt. Retiring unconditionally
+                // armed the source's `remoteDropCommitted`, whose whole meaning is "a remote target
+                // committed this transfer" — and which suppresses the source's in-window drop path on
+                // that belief. On a null commit the target never took the item while the source had
+                // already let go, so the item stranded with no owner. Leaving the flag unarmed lets the
+                // source's ordinary in-window path run and restore it: the restore is the pre-existing
+                // default, not a new capability — it was simply unreachable behind a false signal.
+                if (operation) {
+                    data.sourceSortZone.onRemoteDropOut(data.draggedItem)
+                }
+            } finally {
+                me.activeTargetZone = null
             }
-
-            me.activeTargetZone = null
         } else if (data.sourceSortZone.isWindowDragging) {
             data.sourceSortZone.onTerminalWindowDrop?.(data.draggedItem)
         }
@@ -451,7 +464,13 @@ class DragCoordinator extends Manager {
         // while leaving it here kept a zone whose vessel is gone reachable as `activeTargetZone`, so
         // the next release would commit into a departed window — and re-registering the same identity
         // would inherit that residue instead of starting clean.
+        //
+        // The hover is ended BEFORE the pointer is dropped: nulling alone orphans whatever the target
+        // is rendering, because `onRemoteDragLeave` is the only thing that clears its preview and the
+        // owner's. Losing the reference first makes that unreachable — the zone keeps painting a hover
+        // for a gesture that no longer exists.
         if (me.activeTargetZone === sortZone) {
+            me.activeTargetZone.onRemoteDragLeave?.();
             me.activeTargetZone = null
         }
 

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -87,22 +87,22 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
 
     test('Validates Directional Logic with Colliding Thresholds (0.8 / 0.6)', async () => {
         const mockOwner = {
-            id: 'mockOwner',
+            id   : 'mockOwner',
             items: [{
-                id: 'item1',
-                vdom: {cls: ['neo-draggable']},
+                id          : 'item1',
+                vdom        : {cls: ['neo-draggable']},
                 wrapperStyle: {}
             }],
-            vdom: {},
+            vdom           : {},
             addDomListeners: () => {},
-            getDomRect: () => Promise.resolve([{x:0, y:0, width:100, height:100}]),
-            on: () => {}
+            getDomRect     : () => Promise.resolve([{x:0, y:0, width:100, height:100}]),
+            on             : () => {}
         };
 
         sortZone = Neo.create(DashboardSortZone, {
-            owner: mockOwner,
-            detachThreshold  : 0.8,
-            reattachThreshold: 0.6,
+            owner             : mockOwner,
+            detachThreshold   : 0.8,
+            reattachThreshold : 0.6,
             enableProxyToPopup: true
         });
 
@@ -121,7 +121,7 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
                 proxyRect,
                 screenX: x,
                 screenY: y,
-                path: []
+                path   : []
             });
         };
 
@@ -432,9 +432,9 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
                     draggedItem: item,
                     widgetName : 'item1'
                 } : null,
-                onRemoteDropOut   : draggedItem => calls.push({draggedItem, type: 'dropOut'}),
-                sortGroup         : 'dashboards',
-                suspendWindowDrag : widgetName => {
+                onRemoteDropOut  : draggedItem => calls.push({draggedItem, type: 'dropOut'}),
+                sortGroup        : 'dashboards',
+                suspendWindowDrag: widgetName => {
                     calls.push({type: 'suspend', widgetName});
                     return Promise.resolve()
                 },
@@ -446,9 +446,13 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
                     calls.push({data, type: 'move'});
                     return Promise.resolve()
                 },
+                // Resolves to a real operation because this stub stands in for a target that COMMITS —
+                // `CrossWindowDragTarget.onRemoteDrop` returns the committed operation, or null when it
+                // declines, and source retirement is gated on that answer. Resolving to `undefined`
+                // described a target that took the item without saying so, which no real target does.
                 onRemoteDrop: draggedItem => {
                     calls.push({draggedItem, type: 'drop'});
-                    return Promise.resolve()
+                    return Promise.resolve({type: 'transferItem'})
                 },
                 sortGroup: 'dashboards',
                 windowId : 'target-window'

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -64,7 +64,18 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
             DragCoordinator.nativeWindowDropDwellMs  = 450;
             DragCoordinator.nativeWindowDropSettleMs = 250;
             DragCoordinator.sortZones = new Map();
-            delete DragCoordinator.onWindowPositionChange
+            DragCoordinator.activeTargetZone = null;
+
+            // `beforeEach` stubs five methods as OWN properties on the shared singleton; only
+            // `onWindowPositionChange` was ever given back. The other four outlived this file and
+            // silently no-opped every later spec in the worker that touched the coordinator — a stub
+            // that survives its suite is indistinguishable from the method simply not working.
+            // Deleting the own property re-exposes the prototype implementation.
+            delete DragCoordinator.onWindowPositionChange;
+            delete DragCoordinator.onDragMove;
+            delete DragCoordinator.onDragEnd;
+            delete DragCoordinator.register;
+            delete DragCoordinator.unregister
         }
         if (Neo.manager?.Window) {
             Neo.manager.Window.items = [];

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -1,0 +1,228 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'ManagerDragCoordinatorTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+/**
+ * @summary Coordinator teardown hygiene: source retirement follows the gesture's OUTCOME, and no
+ * terminal leaves residue behind.
+ *
+ * The defect these witness is that engagement was treated as commitment. `onRemoteDrop()` answers
+ * whether the target actually took the item — returning the committed operation, or null when there
+ * was no preview, no operation, or the commit declined — and the coordinator discarded that answer.
+ * It then retired the source anyway, arming `remoteDropCommitted`, whose entire meaning is "a remote
+ * target committed this transfer" and which suppresses the source's own in-window drop path on that
+ * belief. So a no-commit drop left the item with no owner at all: the target never took it, and the
+ * source had already let go of it.
+ *
+ * That makes the load-bearing assertion here a NEGATIVE — "the source was NOT retired" — which is the
+ * assertion class most able to pass for the wrong reason. Every test below is therefore written to
+ * fail against the unfixed coordinator, and was run that way before the fix existed.
+ */
+test.describe('Neo.manager.DragCoordinator — teardown hygiene (#15248)', () => {
+    let DragCoordinator;
+    let calls;
+
+    // Imported dynamically, not statically: DragCoordinator pulls in `manager/Window`, whose singleton
+    // construction calls `Neo.currentWorker.on(...)`. `setup()` stubs `Neo.currentWorker`, so the module
+    // must load AFTER setup runs — a top-level import loads first and dies on an undefined worker.
+    test.beforeAll(async () => {
+        DragCoordinator = (await import('../../../../src/manager/DragCoordinator.mjs')).default
+    });
+
+    test.beforeEach(() => {
+        calls = [];
+        DragCoordinator.activeTargetZone = null;
+        DragCoordinator.sortZones.clear();
+        DragCoordinator.nativeWindowDropCandidates.clear()
+    });
+
+    test.afterEach(() => {
+        DragCoordinator.activeTargetZone = null;
+        DragCoordinator.sortZones.clear();
+        DragCoordinator.nativeWindowDropCandidates.clear()
+    });
+
+    /**
+     * @summary A target whose commit outcome the test controls.
+     * @param {Object|null} operation What `onRemoteDrop()` returns — an operation, or null for a
+     *   no-commit release. This IS the contract under test; a stub that always committed could not
+     *   distinguish engagement from commitment.
+     * @returns {Object}
+     */
+    function createTargetZone(operation) {
+        return {
+            sortGroup: 'dock',
+            windowId : 2,
+            onRemoteDrop(draggedItem) {
+                calls.push(['onRemoteDrop', draggedItem.id]);
+                return operation
+            }
+        }
+    }
+
+    /**
+     * @summary A source zone recording whether it was retired.
+     * @returns {Object}
+     */
+    function createSourceZone() {
+        return {
+            sortGroup       : 'dock',
+            windowId        : 1,
+            isWindowDragging: false,
+            onRemoteDropOut(draggedItem) {
+                calls.push(['onRemoteDropOut', draggedItem.id])
+            },
+            onTerminalWindowDrop(draggedItem) {
+                calls.push(['onTerminalWindowDrop', draggedItem.id])
+            }
+        }
+    }
+
+    test('a COMMITTED drop retires the source — the happy path is unchanged', () => {
+        const
+            source = createSourceZone(),
+            target = createTargetZone({type: 'transferItem'});
+
+        DragCoordinator.activeTargetZone = target;
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+        // Retirement is correct here: the target took the item, so suppressing the source's in-window
+        // drop is exactly right — firing it would double-commit.
+        expect(calls).toEqual([
+            ['onRemoteDrop',    'tab-1'],
+            ['onRemoteDropOut', 'tab-1']
+        ]);
+        expect(DragCoordinator.activeTargetZone).toBeNull()
+    });
+
+    test('a NULL-COMMIT drop does NOT retire the source — the item must keep an owner', () => {
+        const
+            source = createSourceZone(),
+            target = createTargetZone(null);
+
+        DragCoordinator.activeTargetZone = target;
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+        // The target was asked and declined. Retiring the source here armed `remoteDropCommitted`,
+        // suppressing the source's in-window drop path on the false belief the item had transferred
+        // out — so nothing owned it. Leaving the source un-retired lets its ordinary path restore it.
+        expect(calls).toEqual([['onRemoteDrop', 'tab-1']]);
+        expect(calls.some(([name]) => name === 'onRemoteDropOut')).toBe(false);
+
+        // The engagement is still cleared: a declined commit ends the gesture just as a taken one does.
+        expect(DragCoordinator.activeTargetZone).toBeNull()
+    });
+
+    test('an undefined commit is a no-commit — absence of an operation is not an operation', () => {
+        const
+            source = createSourceZone(),
+            target = createTargetZone(undefined);
+
+        DragCoordinator.activeTargetZone = target;
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+        expect(calls).toEqual([['onRemoteDrop', 'tab-1']])
+    });
+
+    test('unregister clears a departing zone that is the live target — a gone vessel cannot stay droppable', () => {
+        const target = createTargetZone({type: 'transferItem'});
+
+        DragCoordinator.register(target);
+        DragCoordinator.activeTargetZone = target;
+
+        DragCoordinator.unregister(target);
+
+        // Dropping the zone from the registry while leaving it installed here kept a departed window
+        // reachable as the commit destination for the NEXT release.
+        expect(DragCoordinator.activeTargetZone).toBeNull();
+        expect(DragCoordinator.sortZones.has('dock')).toBe(false)
+    });
+
+    test('unregister leaves an UNRELATED live target alone — the guard is identity-scoped, not a blanket reset', () => {
+        const
+            activeTarget  = createTargetZone({type: 'transferItem'}),
+            departingZone = {sortGroup: 'dock', windowId: 3};
+
+        DragCoordinator.register(activeTarget);
+        DragCoordinator.register(departingZone);
+        DragCoordinator.activeTargetZone = activeTarget;
+
+        DragCoordinator.unregister(departingZone);
+
+        // Without this, "clear activeTargetZone on unregister" would satisfy the test above by
+        // cancelling every in-flight gesture whenever any unrelated vessel departed.
+        expect(DragCoordinator.activeTargetZone).toBe(activeTarget)
+    });
+
+    test('re-registering the same identity after unregister starts clean', () => {
+        const target = createTargetZone({type: 'transferItem'});
+
+        DragCoordinator.register(target);
+        DragCoordinator.activeTargetZone = target;
+        DragCoordinator.unregister(target);
+        DragCoordinator.register(target);
+
+        expect(DragCoordinator.activeTargetZone).toBeNull();
+        expect(DragCoordinator.sortZones.get('dock').get(2)).toBe(target)
+    });
+
+    test('every terminal is idempotent — a second invocation is a witnessed no-op, not a second commit', () => {
+        const
+            source = createSourceZone(),
+            target = createTargetZone({type: 'transferItem'});
+
+        DragCoordinator.activeTargetZone = target;
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+        const afterFirst = [...calls];
+
+        // Exact-once: the second close finds no engagement and must not re-ask the target or re-retire
+        // the source. `isWindowDragging` is false, so the native-drag branch stays shut too. This half
+        // already held before the fix — it is pinned here as a regression guard, since making
+        // retirement outcome-aware must not cost exact-once.
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+        expect(calls).toEqual(afterFirst);
+
+        // Unregister is idempotent for the same reason: a repeated vessel departure is normal. The
+        // target is re-armed first — asserting a null after onDragEnd already nulled it would pass
+        // without unregister doing anything at all.
+        DragCoordinator.register(target);
+        DragCoordinator.activeTargetZone = target;
+
+        DragCoordinator.unregister(target);
+        expect(DragCoordinator.activeTargetZone).toBeNull();
+
+        DragCoordinator.unregister(target);
+        expect(DragCoordinator.activeTargetZone).toBeNull();
+        expect(calls).toEqual(afterFirst)
+    });
+
+    test('a mid-gesture vessel departure resolves to a clean terminal, not a commit into a dead window', () => {
+        const
+            source = createSourceZone(),
+            target = createTargetZone({type: 'transferItem'});
+
+        DragCoordinator.register(target);
+        DragCoordinator.activeTargetZone = target;
+
+        // The window closes under the drag.
+        DragCoordinator.unregister(target);
+
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+        // The departed target is never asked to commit, and the source is never retired into it — the
+        // gesture terminates with the item still owned by its source.
+        expect(calls).toEqual([]);
+        expect(DragCoordinator.activeTargetZone).toBeNull()
+    });
+});

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -282,6 +282,54 @@ test.describe('Neo.manager.DragCoordinator — teardown hygiene (#15248)', () =>
         expect(DragCoordinator.activeTargetZone).toBeNull()
     });
 
+    test('a departing vessel takes its candidate timers with it — on either side of the gesture', () => {
+        // AC-3 names the candidate timer as a cleanup surface, so it is pinned rather than assumed.
+        // Unlike the witnesses above this one PASSES against dev: @neo-gpt-emmy read the loop as already
+        // correct and I agree, so this is a regression guard, not a bite. Naming that is the point —
+        // a test that cannot fail today should say why it exists.
+        const
+            source = createSourceZone(),
+            target = createTargetZone({type: 'transferItem'});
+
+        let sourceTimerCleared = false,
+            targetTimerCleared = false;
+
+        DragCoordinator.nativeWindowDropCandidates.set(11, {
+            sourceSortZone: source,
+            targetSortZone: {},
+            timeoutId     : setTimeout(() => { sourceTimerCleared = false }, 60_000)
+        });
+        DragCoordinator.nativeWindowDropCandidates.set(12, {
+            sourceSortZone: {},
+            targetSortZone: target,
+            timeoutId     : setTimeout(() => { targetTimerCleared = false }, 60_000)
+        });
+        DragCoordinator.nativeWindowDropCandidates.set(13, {
+            sourceSortZone: {},
+            targetSortZone: {},
+            timeoutId     : setTimeout(() => {}, 60_000)
+        });
+
+        DragCoordinator.register(source);
+        DragCoordinator.unregister(source);
+
+        // The departing zone's candidate goes, whichever side of the gesture it was on...
+        sourceTimerCleared = !DragCoordinator.nativeWindowDropCandidates.has(11);
+        expect(sourceTimerCleared).toBe(true);
+
+        DragCoordinator.register(target);
+        DragCoordinator.unregister(target);
+        targetTimerCleared = !DragCoordinator.nativeWindowDropCandidates.has(12);
+        expect(targetTimerCleared).toBe(true);
+
+        // ...and an unrelated vessel's candidate survives — cleanup is scoped, not a sweep.
+        expect(DragCoordinator.nativeWindowDropCandidates.has(13)).toBe(true);
+
+        // Idempotent: a repeated departure finds nothing left and does not throw.
+        DragCoordinator.unregister(source);
+        expect(DragCoordinator.nativeWindowDropCandidates.has(13)).toBe(true)
+    });
+
     test('a mid-gesture vessel departure resolves to a clean terminal, not a commit into a dead window', () => {
         const
             source = createSourceZone(),

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -207,6 +207,81 @@ test.describe('Neo.manager.DragCoordinator — teardown hygiene (#15248)', () =>
         expect(calls).toEqual(afterFirst)
     });
 
+    test('the NATIVE-titlebar path obeys the same rule — the defect had a twin behind a different door', async () => {
+        // @neo-gpt-emmy's delta: the pointer fix left `commitNativeWindowDrop` discarding
+        // `await onRemoteDrop(...)` and retiring the source anyway. Same defect class, different
+        // entry point — fixing the instance the ticket named is not fixing the class.
+        const
+            draggedItem = {id: 'tab-1'},
+            target      = {
+                ...createTargetZone(null),
+                acceptsRemoteDrag: () => true,
+                onRemoteDragMove : async () => {}
+            },
+            source      = {
+                ...createSourceZone(),
+                getNativeWindowDrag: () => ({draggedItem}),
+                suspendWindowDrag  : async () => {}
+            };
+
+        // `commitNativeWindowDrop(windowId, candidate)` is POSITIONAL and guards on the candidate being
+        // the registered one. A single-object call returns at the first guard and reaches nothing — the
+        // first draft of this test did exactly that and passed against the defect it names.
+        const candidate = {
+            draggedItem, sourceSortZone: source, targetSortZone: target,
+            localX: 0, localY: 0, offsetX: 0, offsetY: 0, proxyRect: {}, widgetName: 'w'
+        };
+
+        DragCoordinator.nativeWindowDropCandidates.set(7, candidate);
+
+        await DragCoordinator.commitNativeWindowDrop(7, candidate);
+
+        // The target declined, so the source keeps the item — exactly as on the pointer path.
+        expect(calls).toEqual([['onRemoteDrop', 'tab-1']]);
+        expect(calls.some(([name]) => name === 'onRemoteDropOut')).toBe(false)
+    });
+
+    test('a THROWING commit still clears the engagement — a REJECTED terminal cannot park the target', () => {
+        const
+            source = createSourceZone(),
+            target = {
+                sortGroup: 'dock',
+                windowId : 2,
+                onRemoteDrop() { throw new Error('commit exploded') }
+            };
+
+        DragCoordinator.activeTargetZone = target;
+
+        // The error propagates — cleanup must not swallow it, or a failing commit reads as a success.
+        expect(() => DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source}))
+            .toThrow(/commit exploded/);
+
+        // ...and the terminal is still exact-once: leaving the target installed would hand the NEXT
+        // release a commit destination belonging to a gesture that already failed.
+        expect(DragCoordinator.activeTargetZone).toBeNull();
+        expect(calls.some(([name]) => name === 'onRemoteDropOut')).toBe(false)
+    });
+
+    test('unregister ends the hover before dropping the pointer — a nulled target cannot clear its own preview', () => {
+        let left = 0;
+
+        const target = {
+            sortGroup: 'dock',
+            windowId : 2,
+            onRemoteDragLeave() { left++ }
+        };
+
+        DragCoordinator.register(target);
+        DragCoordinator.activeTargetZone = target;
+
+        DragCoordinator.unregister(target);
+
+        // Nulling alone orphans the target's preview and its owner's: onRemoteDragLeave is the only
+        // path that clears them, and losing the reference first makes it unreachable forever.
+        expect(left).toBe(1);
+        expect(DragCoordinator.activeTargetZone).toBeNull()
+    });
+
     test('a mid-gesture vessel departure resolves to a clean terminal, not a commit into a dead window', () => {
         const
             source = createSourceZone(),

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -207,6 +207,77 @@ test.describe('Neo.manager.DragCoordinator — teardown hygiene (#15248)', () =>
         expect(calls).toEqual(afterFirst)
     });
 
+    test('an ASYNC target resolving null does NOT retire — a Promise is truthy, so testing it IS the defect', async () => {
+        // @neo-gpt's RA-1. `onDragEnd` is synchronous; `draggable/dashboard/SortZone.onRemoteDrop` is
+        // async. `if (operation)` on a Promise is `if (true)` — so the outcome-aware gate read EVERY
+        // async target as committed and retired the source anyway. The fix's own shape hid the fix's
+        // own defect, and my sync-only stub could not see it.
+        const
+            source = createSourceZone(),
+            target = {
+                sortGroup: 'dock',
+                windowId : 2,
+                onRemoteDrop(draggedItem) {
+                    calls.push(['onRemoteDrop', draggedItem.id]);
+                    return Promise.resolve(null)
+                }
+            };
+
+        DragCoordinator.activeTargetZone = target;
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+        // let the resolution settle — the retirement decision is deferred, not skipped
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(calls).toEqual([['onRemoteDrop', 'tab-1']]);
+        expect(DragCoordinator.activeTargetZone).toBeNull()
+    });
+
+    test('an ASYNC target resolving an operation DOES retire — deferred, not dropped', async () => {
+        // The control: without this, "never retire on a thenable" would satisfy the test above and
+        // silently break every async commit.
+        const
+            source = createSourceZone(),
+            target = {
+                sortGroup: 'dock',
+                windowId : 2,
+                onRemoteDrop(draggedItem) {
+                    calls.push(['onRemoteDrop', draggedItem.id]);
+                    return Promise.resolve({type: 'insertItem'})
+                }
+            };
+
+        DragCoordinator.activeTargetZone = target;
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(calls).toEqual([
+            ['onRemoteDrop',    'tab-1'],
+            ['onRemoteDropOut', 'tab-1']
+        ])
+    });
+
+    test('a SYNC commit still retires on the SAME call stack — the source reads the flag synchronously', () => {
+        // The deadline that forbids simply making onDragEnd async: DockTabSortZone's processDragEnd
+        // reads `remoteDropCommitted` in its own synchronous continuation, so an awaited retirement
+        // would arm the flag AFTER the decision it exists to inform. Sync targets must not be deferred.
+        const
+            source = createSourceZone(),
+            target = createTargetZone({type: 'transferItem'});
+
+        DragCoordinator.activeTargetZone = target;
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+        // asserted with NO await: retirement already happened by the time onDragEnd returned
+        expect(calls).toEqual([
+            ['onRemoteDrop',    'tab-1'],
+            ['onRemoteDropOut', 'tab-1']
+        ])
+    });
+
     test('the NATIVE-titlebar path obeys the same rule — the defect had a twin behind a different door', async () => {
         // @neo-gpt-emmy's delta: the pointer fix left `commitNativeWindowDrop` discarding
         // `await onRemoteDrop(...)` and retiring the source anyway. Same defect class, different


### PR DESCRIPTION
Resolves #15248
Related: #15239
Related: #15240

## Summary

`DragCoordinator.onDragEnd()` treated **engagement as commitment**. It called `activeTargetZone.onRemoteDrop()`, discarded the answer, and retired the source regardless — but `CrossWindowDragTarget.onRemoteDrop()` returns `null` when there was no preview, no operation, or the commit declined.

Retiring anyway armed the source's `remoteDropCommitted`, whose entire documented meaning is *"a remote target committed this drag's item transfer"* and which `processDragEnd` consumes to **suppress the source's in-window drop path** on that belief. So a no-commit release left the item with **no owner at all**: the target never took it, and the source had already let go.

`DockTabSortZone`'s own JSDoc states the intended contract and is falsified by the landed code:

> *"the coordinator arms `remoteDropCommitted` via `onRemoteDropOut` on this same call stack — so the local decision below **always sees the truth**."*

It armed the flag on engagement, so the local decision saw a lie.

**The fix keeps the coordinator outcome-driven.** Source retirement now follows a proven result across both consumer shapes. Synchronous targets retire on the same call stack because `DockTabSortZone.processDragEnd()` reads `remoteDropCommitted` immediately; asynchronous targets retire only after their Promise resolves to a committed operation. `DashboardSortZone.onRemoteDrop()` now reports its already-existing decision as that operation or `null`. On a null commit the flag stays unarmed and the source's ordinary in-window path restores the item. The restore the AC asks for is the **pre-existing default** — it was simply unreachable behind a false commit signal. No new hook, no new gesture capability.

`unregister()` separately left a departing zone installed as `activeTargetZone`, keeping a zone whose vessel is gone reachable as the *next* release's commit destination. Now cleared — **identity-scoped**, so an unrelated vessel departing cannot cancel a live gesture.

Evidence: L2 (unit witnesses over the coordinator's real terminals) → L2 required (all close-target ACs are behavioral contract). No residuals.

## Source of Authority

ADR 0029 §2.8 names both residues, and names this ticket:

> Source cleanup and empty-vessel close occur ONLY after `COMMITTED_TARGET` … the landed behavior in which `DragCoordinator.onDragEnd()` calls it unconditionally while `CrossWindowDragTarget.onRemoteDrop()` may return `null` (a no-commit drop retiring a live source gesture) is the **named forbidden defect** (#15248 enforces).

> **Exact-once, idempotent cleanup** across every terminal for every surface: preview, claim, candidate timer, `activeTargetZone` (the landed `unregister()` residue is in scope), registration, vessel bookkeeping.

## Deltas

| Area | Before | After |
|---|---|---|
| `onDragEnd` source retirement | unconditional; `onRemoteDrop()`'s return discarded | synchronous commit retires immediately; async commit retires only after a committed resolution |
| Null-commit release | source retired → `remoteDropCommitted` armed → in-window restore suppressed → item stranded | flag unarmed → source's ordinary path restores it |
| Async direct target | the Promise object itself was truthy, so every async target read as committed | the resolved operation decides; `null`/`undefined` never retires |
| `unregister` | left `activeTargetZone` populated | clears it when the departing zone IS the target |
| `commitNativeWindowDrop` | **same defect** — `await onRemoteDrop()` discarded, source retired anyway | retirement gated on a real result |
| A throwing commit | skipped the clear — REJECTED terminal parked the target | `finally`, error still propagates |
| `unregister` preview residue | nulled the target without ending the hover | `onRemoteDragLeave` before the pointer drops |
| Unrelated vessel departure | n/a | explicitly unaffected — the clear is identity-scoped |

## Test Evidence

New canonical witness suite at `test/playwright/unit/manager/DragCoordinator.spec.mjs` (mirrors `src/manager/DragCoordinator.mjs`; none existed).

**The load-bearing assertion here is a NEGATIVE** — *"the source was NOT retired"* — which is the class most able to pass for the wrong reason. The original matrix was run against the **unfixed** coordinator first; RA-1 then added the production-shaped async outcome pair plus the same-stack synchronous control:

```
UNFIXED ORIGINAL MATRIX:  9 failed, 3 passed
REPAIRED COORDINATOR:    15 passed
REVIEWER EXACT-HEAD:     24 passed  (coordinator + dashboard SortZone)
HOSTED EXACT-HEAD:       unit, integration, and every required check green
```

**The original 3 that pass either way are deliberate controls, not decoration:**
- *a COMMITTED drop retires the source* — this **is** AC-5 ("zero behavior change on the committed happy path"). It must pass before and after.
- *unregister leaves an UNRELATED live target alone* — the guard against the fix degenerating into a blanket `activeTargetZone = null`, which would satisfy the departing-vessel test by cancelling every in-flight gesture.
- *a departing vessel takes its candidate timers with it* — AC-3 names the candidate timer as a cleanup surface, and @neo-gpt-emmy read the existing loop as already correct. A regression guard, stated as one in the spec body.

The RA-1 controls are equally paired: async `null` must not retire, async commit must retire after resolution, and synchronous commit must still retire before `onDragEnd()` returns.

## @neo-gpt-emmy's pre-review delta — three carried, all real

**The one that matters: I fixed the instance, not the class.** `commitNativeWindowDrop()` carried the *identical* engagement≠commitment defect — `await onRemoteDrop(...)` discarded, source retired regardless. The ADR pointed at `onDragEnd`, I fixed `onDragEnd`, and the twin sat one method away behind the native-titlebar door. Also: a throwing commit skipped the clear entirely (REJECTED parked the target — now `finally`, error un-swallowed), and `unregister` nulled the target without ending the hover, orphaning its preview and the owner's forever.

**My native witness was vacuous on the first draft.** `commitNativeWindowDrop(windowId, candidate)` is positional and guards on the registered candidate; a single-object call returns at the first guard, reaches nothing, and **passed against the defect it names**. Caught only by running the new witnesses against `dev` and seeing one come back green.

**One test changed because it was wrong, and that deserves a reviewer's eye.** `SortZone.spec.mjs`'s #13028 target stub resolved `onRemoteDrop` to `undefined` while standing in for a target that **commits** — so gating on the result broke it. Real targets return the committed operation or null; that contract is what ADR 0029 §2.8 ratified *today*, so the stub predates it and described a target that took the item without saying so. The stub is now faithful. "My change broke a test so I edited the test" is a shape that should never pass unremarked — the reasoning is here to be challenged.

An earlier draft of the idempotency witness passed unfixed for a bad reason (it asserted `activeTargetZone` was null after `onDragEnd` had already nulled it). It now re-arms the target before the double-`unregister`, and bites.

## Out of Scope

The claim protocol (#15246 / G3) · vessel close policy (#15247 / G4) · any new gesture capability. `DashboardSortZone.onRemoteDrop()` now exposes its already-existing commit decision as operation-or-`null`; `onRemoteDropOut()` behavior is unchanged. The coordinator changes only *when* source retirement occurs.

## Post-Merge Validation

- Cross-window tab drags: a release over an engaged target that declines the commit should leave the tab in its source dock rather than vanishing from both windows.
- Reopen trigger: any `onRemoteDropOut` observed on a gesture whose `onRemoteDrop` returned null, or an `activeTargetZone` surviving its zone's `unregister`.
- The committed happy path is asserted unchanged; a regression there would show as a tab failing to transfer at all.

## A note on the dashboard target

`src/draggable/dashboard/SortZone.mjs` already committed asynchronously but returned `undefined` on both paths. It now reports the committed insertion descriptor, or `null` when remote-drag mode is absent, so the coordinator can distinguish an async commit from a decline without inferring truth from Promise identity.

## A note on the original third file

`test/playwright/unit/draggable/dashboard/SortZone.spec.mjs` (+12/−1) is not scope creep — this suite surfaced it and could not be green in a full run without it.

`beforeEach` stubs **five** coordinator methods as own properties on the shared singleton (`onDragMove`, `onDragEnd`, `register`, `unregister`, `onWindowPositionChange`) and `afterEach` gave back **only** `onWindowPositionChange`. The other four outlived the file and silently no-opped every later spec in the worker that touched the coordinator. My witnesses were the first to call `onDragEnd` afterward, so they were the first to notice — they failed with an empty call log while passing in isolation.

The fix completes a pattern the file already used (`delete` the own property, re-exposing the prototype). It is thematically the same defect as the production bug: **a stub that survives its suite is teardown that didn't happen.**

Authored by @neo-opus-ada (Claude Opus 4.8)
