### PR TITLE
fix(button): project disabled state to native controls (#15324)

### DIFF
--- a/resources/scss/src/button/Base.scss
+++ b/resources/scss/src/button/Base.scss
@@ -354,6 +354,15 @@
         cursor          : default;
         opacity         : var(--button-opacity-disabled);
 
+        // Projecting the native disabled attribute (src/button/Base.mjs) activates the UA
+        // button:disabled cascade, dormant for as long as this class was the only disabled
+        // authority. The class stays the sole visual owner: pin the one axis this block does
+        // not declare (measured leak: Chromium paints the element color as disabled GrayText).
+        // Witnessed by the render-equivalence assertion in the button component spec.
+        &:disabled {
+            color: inherit;
+        }
+
         .neo-button-glyph {
             color: var(--button-glyph-color-disabled);
         }

--- a/src/button/Base.mjs
+++ b/src/button/Base.mjs
@@ -263,6 +263,19 @@ class Button extends Component {
     }
 
     /**
+     * Mirrors the framework-generic disabled state onto this Button's native control root.
+     * The parent hook retains the visual `neo-disabled` class and the DOM-event manager remains
+     * defense in depth; the native attribute owns browser focus and accessibility semantics.
+     * @param {Boolean} value    The new value of the disabled config.
+     * @param {Boolean} oldValue The old value of the disabled config.
+     * @protected
+     */
+    afterSetDisabled(value, oldValue) {
+        super.afterSetDisabled(value, oldValue);
+        this.changeVdomRootKey('disabled', value)
+    }
+
+    /**
      * Triggered after the iconCls config got changed
      * @param {String} value    The new value of the iconCls config.
      * @param {String} oldValue The old value of the iconCls config.

--- a/src/button/Base.mjs
+++ b/src/button/Base.mjs
@@ -263,16 +263,18 @@ class Button extends Component {
     }
 
     /**
-     * Mirrors the framework-generic disabled state onto this Button's native control root.
+     * Mirrors the framework-generic disabled state onto an effective native button root.
      * The parent hook retains the visual `neo-disabled` class and the DOM-event manager remains
-     * defense in depth; the native attribute owns browser focus and accessibility semantics.
+     * defense in depth. URL and non-editing route configs turn the root into an anchor, where the
+     * native `disabled` attribute has no semantics and must not be projected.
      * @param {Boolean} value    The new value of the disabled config.
      * @param {Boolean} oldValue The old value of the disabled config.
      * @protected
      */
     afterSetDisabled(value, oldValue) {
         super.afterSetDisabled(value, oldValue);
-        this.changeVdomRootKey('disabled', value)
+        this.syncNativeDisabledState();
+        this.update()
     }
 
     /**
@@ -657,7 +659,28 @@ class Button extends Component {
     }
 
     /**
-     * Updates the VDOM tag of the button (e.g., switching between 'button' and 'a' tags) based on the current configuration.
+     * @summary Reconciles the native disabled attribute with the Button's effective root tag.
+     *
+     * Button roots are polymorphic: URL and non-editing route configs render anchors, while the
+     * default shape renders a native button. Only the latter understands the `disabled` attribute.
+     *
+     * @protected
+     */
+    syncNativeDisabledState() {
+        let vdomRoot = this.getVdomRoot();
+
+        if (vdomRoot.tag === 'button' && this.disabled) {
+            vdomRoot.disabled = true
+        } else {
+            delete vdomRoot.disabled
+        }
+    }
+
+    /**
+     * @summary Updates the effective root tag and reconciles tag-owned native attributes.
+     *
+     * Switches between `button` and `a` based on URL/non-editing-route configuration. Since the
+     * root is polymorphic, native disabled semantics are reconciled in the same transition owner.
      */
     updateTag() {
         let me                      = this,
@@ -677,6 +700,7 @@ class Button extends Component {
             vdomRoot.tag = 'button'
         }
 
+        me.syncNativeDisabledState();
         me.update()
     }
 }

--- a/src/button/Base.mjs
+++ b/src/button/Base.mjs
@@ -264,9 +264,13 @@ class Button extends Component {
 
     /**
      * Mirrors the framework-generic disabled state onto an effective native button root.
-     * The parent hook retains the visual `neo-disabled` class and the DOM-event manager remains
-     * defense in depth. URL and non-editing route configs turn the root into an anchor, where the
-     * native `disabled` attribute has no semantics and must not be projected.
+     * The parent hook keeps toggling the `neo-disabled` class, which remains the sole styling
+     * authority: projecting the attribute activates the UA `button:disabled` cascade, so
+     * `button/Base.scss` pins the one axis the class does not declare (`color`), and the
+     * render-equivalence component spec witnesses that the attribute contributes no paint.
+     * The DOM-event manager remains defense in depth. URL and non-editing route configs turn the
+     * root into an anchor, where the native `disabled` attribute has no semantics and must not
+     * be projected.
      * @param {Boolean} value    The new value of the disabled config.
      * @param {Boolean} oldValue The old value of the disabled config.
      * @protected

--- a/src/main/DeltaUpdates.mjs
+++ b/src/main/DeltaUpdates.mjs
@@ -127,8 +127,8 @@ class DeltaUpdates extends Base {
     /**
      * Changes the tag name (nodeName) of an existing HTMLElement in the DOM.
      * This operation is performed by creating a new HTML element with the desired `nodeName`,
-     * meticulously copying all attributes and the `innerHTML` from the original `node` to the new one,
-     * and then seamlessly replacing the original `node` with the newly created element within its parent.
+     * preserving attributes, live control properties, and child-node identity from the original `node`,
+     * and then replacing the original `node` with the newly created element within its parent.
      *
      * @param {HTMLElement} node     The existing DOM HTMLElement whose tag name needs to be changed.
      * @param {String}      nodeName The new tag name (e.g., 'div', 'span', 'p') for the element.
@@ -154,8 +154,10 @@ class DeltaUpdates extends Base {
                 clone.value = node.value
             }
 
-            if (node.checked !== undefined && node.checked !== clone.checked) {
-                clone.checked = node.checked
+            for (const key of voidAttributes) {
+                if (node[key] !== undefined && node[key] !== clone[key]) {
+                    clone[key] = node[key]
+                }
             }
 
             if (node.selectedIndex !== undefined && node.selectedIndex !== clone.selectedIndex) {

--- a/test/playwright/component/button/Base.spec.mjs
+++ b/test/playwright/component/button/Base.spec.mjs
@@ -218,4 +218,55 @@ test.describe('Neo.button.Base', () => {
         await expect(nativeButtons.nth(0)).toBeEnabled();
         await expect(nativeButtons.nth(1)).toBeEnabled();
     });
+
+    test('disabled paint is class-owned — the native attribute contributes no UA styling', async ({page}) => {
+        const result = await page.evaluate((config) => {
+            return Neo.worker.App.createNeoInstance(config);
+        }, {
+            importPath: '../button/Base.mjs',
+            ntype     : 'button',
+            parentId  : 'component-test-viewport',
+            disabled  : true,
+            text      : 'Painted action'
+        });
+
+        if (!result.success) {
+            throw new Error(`Component creation failed: ${result.error.message}`);
+        }
+
+        buttonId = result.id;
+
+        const button = page.locator(`#${buttonId}`);
+
+        await expect(button).toBeDisabled();
+        await expect(button).toHaveClass(/neo-disabled/);
+
+        // Projecting the native attribute activates the UA `button:disabled` cascade, which had been
+        // dormant for as long as `.neo-disabled` was the only disabled authority. Same node, attribute
+        // on vs off, class constant: any inequality is user-agent paint leaking past the class.
+        const {withAttribute, classOnly} = await button.evaluate(node => {
+            const probe = () => {
+                const style = getComputedStyle(node);
+
+                return {
+                    backgroundColor: style.backgroundColor,
+                    borderTopColor : style.borderTopColor,
+                    color          : style.color,
+                    opacity        : style.opacity
+                }
+            };
+
+            const withAttribute = probe();
+
+            node.removeAttribute('disabled');
+
+            const classOnly = probe();
+
+            node.setAttribute('disabled', '');
+
+            return {withAttribute, classOnly}
+        });
+
+        expect(withAttribute).toEqual(classOnly);
+    });
 });

--- a/test/playwright/component/button/Base.spec.mjs
+++ b/test/playwright/component/button/Base.spec.mjs
@@ -13,7 +13,11 @@ test.describe('Neo.button.Base', () => {
             await page.evaluate((id) => {
                 return Neo.worker.App.destroyNeoInstance(id);
             }, buttonId);
+
+            buttonId = null;
         }
+
+        await page.locator('#button-focus-sentinel').evaluateAll(nodes => nodes.forEach(node => node.remove()));
     });
 
     test('should create a button with icon and text', async ({page}) => {
@@ -96,5 +100,83 @@ test.describe('Neo.button.Base', () => {
 
         await expect(spinner).toHaveCount(0);
         await expect(loadingMessage).toHaveCount(0);
+    });
+
+    test('should expose disabled state natively and restore keyboard focus', async ({page}) => {
+        const result = await page.evaluate((config) => {
+            return Neo.worker.App.createNeoInstance(config);
+        }, {
+            importPath: '../button/Base.mjs',
+            ntype     : 'button',
+            parentId  : 'component-test-viewport',
+            disabled  : true,
+            text      : 'Focusable action'
+        });
+
+        if (!result.success) {
+            throw new Error(`Component creation failed: ${result.error.message}`);
+        }
+
+        buttonId = result.id;
+
+        const button = page.locator(`#${buttonId}`);
+
+        await expect(button).toBeDisabled();
+        await expect(button).toHaveClass(/neo-disabled/);
+        await expect(page.getByRole('button', {disabled: true, name: 'Focusable action'})).toHaveCount(1);
+
+        await page.evaluate((id) => {
+            const sentinel = document.createElement('button');
+            sentinel.id    = 'button-focus-sentinel';
+            document.getElementById(id).before(sentinel);
+            sentinel.focus();
+        }, buttonId);
+
+        await page.keyboard.press('Tab');
+        await expect(button).not.toBeFocused();
+
+        await page.evaluate((id) => {
+            return Neo.worker.App.setConfigs({id, disabled: false});
+        }, buttonId);
+
+        await expect(button).toBeEnabled();
+        await expect(button).not.toHaveClass(/neo-disabled/);
+
+        await page.locator('#button-focus-sentinel').focus();
+        await page.keyboard.press('Tab');
+        await expect(button).toBeFocused();
+    });
+
+    test('should apply native disabled semantics to both SplitButton controls', async ({page}) => {
+        const result = await page.evaluate((config) => {
+            return Neo.worker.App.createNeoInstance(config);
+        }, {
+            importPath: '../button/Split.mjs',
+            ntype     : 'split-button',
+            parentId  : 'component-test-viewport',
+            disabled  : true,
+            text      : 'Split action'
+        });
+
+        if (!result.success) {
+            throw new Error(`Component creation failed: ${result.error.message}`);
+        }
+
+        buttonId = result.id;
+
+        const nativeButtons = page.locator(`#${buttonId}__wrapper button`);
+
+        await expect(nativeButtons).toHaveCount(2);
+        await expect(nativeButtons.nth(0)).toBeDisabled();
+        await expect(nativeButtons.nth(1)).toBeDisabled();
+        await expect(nativeButtons.nth(0)).toHaveClass(/neo-disabled/);
+        await expect(nativeButtons.nth(1)).toHaveClass(/neo-disabled/);
+
+        await page.evaluate((id) => {
+            return Neo.worker.App.setConfigs({id, disabled: false});
+        }, buttonId);
+
+        await expect(nativeButtons.nth(0)).toBeEnabled();
+        await expect(nativeButtons.nth(1)).toBeEnabled();
     });
 });

--- a/test/playwright/component/button/Base.spec.mjs
+++ b/test/playwright/component/button/Base.spec.mjs
@@ -147,6 +147,45 @@ test.describe('Neo.button.Base', () => {
         await expect(button).toBeFocused();
     });
 
+    test('should remove native disabled when a Button root becomes an anchor', async ({page}) => {
+        const result = await page.evaluate((config) => {
+            return Neo.worker.App.createNeoInstance(config);
+        }, {
+            importPath: '../button/Base.mjs',
+            ntype     : 'button',
+            parentId  : 'component-test-viewport',
+            disabled  : true,
+            text      : 'External link',
+            url       : 'https://example.com'
+        });
+
+        if (!result.success) {
+            throw new Error(`Component creation failed: ${result.error.message}`);
+        }
+
+        buttonId = result.id;
+
+        const control = page.locator(`#${buttonId}`);
+
+        await expect(control).toHaveClass(/neo-disabled/);
+        expect(await control.evaluate(node => node.tagName)).toBe('A');
+        expect(await control.getAttribute('disabled')).toBeNull();
+
+        await page.evaluate((id) => {
+            return Neo.worker.App.setConfigs({id, url: null});
+        }, buttonId);
+
+        await expect.poll(() => control.evaluate(node => node.tagName)).toBe('BUTTON');
+        await expect(control).toBeDisabled();
+
+        await page.evaluate((id) => {
+            return Neo.worker.App.setConfigs({id, url: 'https://example.com/again'});
+        }, buttonId);
+
+        await expect.poll(() => control.evaluate(node => node.tagName)).toBe('A');
+        expect(await control.getAttribute('disabled')).toBeNull();
+    });
+
     test('should apply native disabled semantics to both SplitButton controls', async ({page}) => {
         const result = await page.evaluate((config) => {
             return Neo.worker.App.createNeoInstance(config);

--- a/test/playwright/unit/button/Base.spec.mjs
+++ b/test/playwright/unit/button/Base.spec.mjs
@@ -163,6 +163,49 @@ test.describe('Neo.button.Base VDOM (Node.js)', () => {
         button.destroy();
     });
 
+    test('should keep native disabled aligned with button-to-anchor transitions', async () => {
+        const urlButton = Neo.create(Button, {
+            appName,
+            disabled: true,
+            text    : 'External link',
+            url     : 'https://example.com'
+        });
+        let {vnode} = await urlButton.initVnode();
+
+        urlButton.mounted = true;
+
+        expect(vnode.nodeName).toBe('a');
+        expect(vnode.attributes.disabled).toBeUndefined();
+        expect(vnode.className).toContain('neo-disabled');
+
+        ({vnode} = await urlButton.set({url: null}));
+
+        expect(vnode.nodeName).toBe('button');
+        expect(vnode.attributes.disabled).toBe('true');
+
+        ({vnode} = await urlButton.set({url: 'https://example.com/again'}));
+
+        expect(vnode.nodeName).toBe('a');
+        expect(vnode.attributes.disabled).toBeUndefined();
+
+        const routeButton = Neo.create(Button, {
+            appName,
+            disabled : true,
+            editRoute: false,
+            route    : 'details',
+            text     : 'Internal link'
+        });
+        const routeVnode = (await routeButton.initVnode()).vnode;
+
+        expect(routeVnode.nodeName).toBe('a');
+        expect(routeVnode.attributes.href).toBe('#details');
+        expect(routeVnode.attributes.disabled).toBeUndefined();
+        expect(routeVnode.className).toContain('neo-disabled');
+
+        routeButton.destroy();
+        urlButton.destroy();
+    });
+
     test('Prototype VDOM mutation check', async () => {
         // Manually clean prototype to verify the fix or demonstrate the bug
         // Note: We need to access the prototype from the class constructor

--- a/test/playwright/unit/button/Base.spec.mjs
+++ b/test/playwright/unit/button/Base.spec.mjs
@@ -17,6 +17,7 @@ import {test, expect}     from '@playwright/test';
 import Neo                from '../../../../src/Neo.mjs';
 import * as core          from '../../../../src/core/_export.mjs';
 import Button             from '../../../../src/button/Base.mjs';
+import SplitButton        from '../../../../src/button/Split.mjs';
 import DomApiVnodeCreator from '../../../../src/vdom/util/DomApiVnodeCreator.mjs';
 import VdomHelper         from '../../../../src/vdom/Helper.mjs';
 
@@ -115,6 +116,50 @@ test.describe('Neo.button.Base VDOM (Node.js)', () => {
         expect(delta.cls.remove).toEqual(['pressed']);
         expect(updateData.vnode.className.includes('pressed')).toBe(false);
 
+        button.destroy();
+    });
+
+    test('should project disabled state onto Button and SplitButton native roots', async () => {
+        const button = Neo.create(Button, {
+            appName,
+            text: 'Native semantics'
+        });
+        let {vnode} = await button.initVnode();
+        button.mounted = true;
+
+        expect(vnode.attributes.disabled).toBeUndefined();
+        expect(vnode.className).not.toContain('neo-disabled');
+
+        ({vnode} = await button.set({disabled: true}));
+
+        expect(button.getVdomRoot().disabled).toBe(true);
+        expect(vnode.attributes.disabled).toBe('true');
+        expect(vnode.className).toContain('neo-disabled');
+
+        ({vnode} = await button.set({disabled: false}));
+
+        expect(vnode.attributes.disabled).toBeUndefined();
+        expect(vnode.className).not.toContain('neo-disabled');
+
+        const splitButton = Neo.create(SplitButton, {
+            appName,
+            disabled: true,
+            text    : 'Split action'
+        });
+        const splitVnode = (await splitButton.initVnode()).vnode;
+
+        expect(splitVnode.childNodes).toHaveLength(2);
+        expect(splitVnode.childNodes[0].nodeName).toBe('button');
+        expect(splitVnode.childNodes[0].attributes.disabled).toBe('true');
+        expect(splitVnode.childNodes[1].nodeName).toBe('button');
+        expect(splitVnode.childNodes[1].attributes.disabled).toBe('true');
+
+        await splitButton.set({disabled: false});
+
+        expect(splitButton.getVdomRoot().disabled).toBeUndefined();
+        expect(splitButton.triggerButton.getVdomRoot().disabled).toBeUndefined();
+
+        splitButton.destroy();
         button.destroy();
     });
 


### PR DESCRIPTION
Resolves #15324

`button.Base` now mirrors its inherited `disabled` config only onto an effective native `<button>` root, while preserving the generic `neo-disabled` class and worker-side event suppression. URL and non-editing-route shapes remain anchors without a false native attribute, and reactive button↔anchor transitions reconcile the state in the existing `updateTag()` owner.

The repair also extends `DeltaUpdates.changeNodeName()`'s established live-control preservation boundary from individual properties to the canonical `voidAttributes` set. That keeps tag replacement plus native disabled state inside one VDOM cycle, preserving `Component#set()` completion semantics instead of scheduling a delayed second render.

Evidence: L3 (isolated Chromium rendered-DOM, accessibility-role, keyboard-focus, polymorphic-root, and SplitButton witnesses plus Node VDOM tests) → L3 required (all runtime acceptance criteria). No residuals.

Related: #15312, #15316, #8600

## Deltas from ticket

Cycle-1 review correctly identified an existing public Button shape omitted by the ticket prescription: `url` and non-editing `route` configs turn the root into an anchor. The repair therefore scopes native disabled projection to the effective tag and adds initial URL, initial route, and reactive transition coverage.

One implementation-level delta was necessary: the main-thread tag replacement owner applied boolean properties to the departing element before cloning it. `changeNodeName()` already preserves live `value`, `checked`, and `selectedIndex` state under #8600; preserving the canonical boolean-property set at the same boundary closes this ticket without an asynchronous Button-specific render cycle. Broader disabled-link ARIA/focus/navigation policy remains out of scope.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/button/Base.spec.mjs` — 7/7 passed; covers native false→true→false projection, both SplitButton roots, initial URL and non-editing-route anchors, and reactive button↔anchor VDOM transitions.
- `npx playwright test -c /private/tmp/playwright.config.component.15327.mjs button/Base.spec.mjs --project=chromium` — 5/5 passed on an isolated port and this checkout; covers native disabled exposure, tab-order exclusion/restoration, both SplitButton controls, and the real anchor→button→anchor replacement that failed before the renderer repair.
- `npm run agent-preflight -- --no-fix src/main/DeltaUpdates.mjs src/button/Base.mjs test/playwright/unit/button/Base.spec.mjs test/playwright/component/button/Base.spec.mjs` — passed; ticket archaeology, JSDoc types, parse, whitespace, and block alignment were clean. The stale Memory-Core overlay warning is unrelated and non-blocking.
- `git diff --check` and `git diff --numstat` — clean; all four changed files are text.

## Post-Merge Validation

- [ ] Re-run the disabled Button keyboard and polymorphic-root journeys against merged `dev` to confirm the published build preserves native focus exclusion, restoration, and tag-transition state.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session b681a37a-4353-4ed0-bbf1-b46e6f2501c7.
