### PR TITLE
feat(build): the shared codeMask is parser-grade — the class list stops being open-ended (#15276)

### DIFF
--- a/.github/workflows/aiconfig-antipattern-lint.yml
+++ b/.github/workflows/aiconfig-antipattern-lint.yml
@@ -36,7 +36,8 @@ jobs:
       # The shared `codeMask` is parser-grade (acorn) as of #15276: heuristic completeness against
       # JavaScript slash/continuation grammar is a parser problem, and six review cycles enumerating
       # eight misread classes proved the list is open-ended. --ignore-scripts skips the heavy
-      # postinstall we don't need — only node_modules must be present.
+      # prepare lifecycle (Husky + generated local configs) we don't need — only node_modules
+      # must be present.
       #
       # This job is never the critical path (~20s against `test.yml`'s minutes, in parallel), so the
       # install costs no mergeable wall-clock; and `test.yml` already runs `npm ci`, so registry

--- a/.github/workflows/aiconfig-antipattern-lint.yml
+++ b/.github/workflows/aiconfig-antipattern-lint.yml
@@ -31,6 +31,18 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: 'npm'
+
+      # The shared `codeMask` is parser-grade (acorn) as of #15276: heuristic completeness against
+      # JavaScript slash/continuation grammar is a parser problem, and six review cycles enumerating
+      # eight misread classes proved the list is open-ended. --ignore-scripts skips the heavy
+      # postinstall we don't need — only node_modules must be present.
+      #
+      # This job is never the critical path (~20s against `test.yml`'s minutes, in parallel), so the
+      # install costs no mergeable wall-clock; and `test.yml` already runs `npm ci`, so registry
+      # flakiness was priced into the merge gate long before this leg joined.
+      - name: Install dependencies (acorn — the shared codeMask tokenizer)
+        run: npm ci --ignore-scripts
 
       - name: Ban ADR-0019 B3/A5 antipatterns in ai/
         run: node ./buildScripts/util/check-aiconfig-antipatterns.mjs

--- a/.github/workflows/aiconfig-test-mutation-lint.yml
+++ b/.github/workflows/aiconfig-test-mutation-lint.yml
@@ -35,7 +35,8 @@ jobs:
       # safety-critical class, and the scanner it replaces had a reproduced false NEGATIVE — a
       # same-line regex containing a quote desynced the scan and hid a real Class-A mutation. A
       # missed one of those is the orphan-bleed mechanism, so the mask's fidelity is the guard.
-      # --ignore-scripts skips the heavy postinstall we don't need.
+      # --ignore-scripts skips the heavy prepare lifecycle (Husky + generated local configs)
+      # we don't need.
       - name: Install dependencies (acorn — the shared codeMask tokenizer)
         run: npm ci --ignore-scripts
 

--- a/.github/workflows/aiconfig-test-mutation-lint.yml
+++ b/.github/workflows/aiconfig-test-mutation-lint.yml
@@ -29,6 +29,15 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: 'npm'
+
+      # This guard OWNS the shared `codeMask`, parser-grade (acorn) as of #15276. B4 is the
+      # safety-critical class, and the scanner it replaces had a reproduced false NEGATIVE — a
+      # same-line regex containing a quote desynced the scan and hid a real Class-A mutation. A
+      # missed one of those is the orphan-bleed mechanism, so the mask's fidelity is the guard.
+      # --ignore-scripts skips the heavy postinstall we don't need.
+      - name: Install dependencies (acorn — the shared codeMask tokenizer)
+        run: npm ci --ignore-scripts
 
       - name: Ban Class-A DB-path AiConfig mutations in tests
         run: node ./buildScripts/util/check-aiconfig-test-mutation.mjs

--- a/buildScripts/util/check-aiconfig-antipatterns.mjs
+++ b/buildScripts/util/check-aiconfig-antipatterns.mjs
@@ -95,18 +95,19 @@ const RULES = [
  */
 export function findAntipatterns(content) {
     const lines         = content.split('\n'),
-          state         = {inBlock: false},
+          state         = {source: content},
           hits          = [],
           a1Candidates  = [],
           codeOnlyLines = [],
           a1Global      = new RegExp(A1_ENV_REDERIVATION.source, 'g');
 
     lines.forEach((line, index) => {
-        // Mask + projection compute UNCONDITIONALLY — before the escape check. Skipping a line
-        // would corrupt block-comment state continuity AND remove the line from the gate
-        // projection: an escape marker on the IMPORT line would then silently exempt the whole
-        // file's A1 hits (the escape valve is line-scoped for HITS, never for composition).
-        const mask = codeMask(line, state),
+        // Mask + projection compute UNCONDITIONALLY — before the escape check. The mask no longer
+        // depends on it (`codeMask` parses the whole file, so a skipped line cannot corrupt comment
+        // continuity — that hazard is why this comment used to warn about skipping), but the gate
+        // PROJECTION still does: an escape marker on the IMPORT line would otherwise silently exempt
+        // the whole file's A1 hits (the escape valve is line-scoped for HITS, never for composition).
+        const mask = codeMask(line, state, index),
               // The gate must see CODE only — a JSDoc/comment mention of the config root (a config
               // template documenting its realm, a migration note) must never open A1 for the file.
               // Masked-out characters become spaces, preserving positions, so multi-line import

--- a/buildScripts/util/check-aiconfig-antipatterns.mjs
+++ b/buildScripts/util/check-aiconfig-antipatterns.mjs
@@ -112,7 +112,21 @@ export function findAntipatterns(content) {
               // template documenting its realm, a migration note) must never open A1 for the file.
               // Masked-out characters become spaces, preserving positions, so multi-line import
               // statements still span lines intact.
-              codeOnly = Array.from(line, (ch, i) => (mask[i] ? ch : ' ')).join('');
+              //
+              // Indexed by CODE UNIT, not code point. `Array.from(line, (ch, i) => mask[i])` walks
+              // code POINTS — an astral char (emoji, rare CJK) is one element there but TWO units in
+              // `line.length`, which is what acorn's offsets and this mask both count. One astral
+              // char anywhere on the line shifted every later lookup by one and silently desynced the
+              // projection from the mask — flagging code as string, or worse, string as code.
+              codeOnly = (() => {
+                  let projected = '';
+
+                  for (let i = 0; i < line.length; i++) {
+                      projected += mask[i] ? line[i] : ' '
+                  }
+
+                  return projected
+              })();
 
         codeOnlyLines.push(codeOnly);
 

--- a/buildScripts/util/check-aiconfig-antipatterns.mjs
+++ b/buildScripts/util/check-aiconfig-antipatterns.mjs
@@ -173,9 +173,13 @@ function main() {
         process.exit(1);
     }
 
-    // Minimal argv parse — no external deps, so the standalone CI workflow runs without `npm install`
-    // (the dependency-free pattern the other lint workflows follow). lint-staged passes staged paths as
-    // positional args; `--quiet` suppresses the per-violation listing.
+    // Minimal argv parse, hand-rolled because it is five lines and a CLI dependency would cost more
+    // than it saves — NOT because this workflow avoids `npm install`. It no longer does: the shared
+    // `codeMask` is parser-grade, so the workflow installs, like `jsdoc-type-lint`,
+    // `ticket-archaeology-lint`, `tree-json-lint` and `config-template-ssot-lint` already did.
+    // (The claim previously stated here — that the other lint workflows are dependency-free — was
+    // false when written; those four run `npm ci` today.)
+    // lint-staged passes staged paths as positional args; `--quiet` suppresses the per-violation listing.
     const rawArgv = process.argv.slice(2);
 
     // Spec-only composition seam: `--extra-b3-allowlist <path>` grandfathers ONE extra path for B3

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -1,3 +1,4 @@
+import * as acorn            from 'acorn';
 import {execSync, spawnSync} from 'node:child_process';
 import {readFileSync}        from 'node:fs';
 import path                  from 'node:path';
@@ -60,81 +61,117 @@ export const ALLOWLIST = new Set([
 ]);
 
 /**
- * @summary Builds a per-character "is this code?" mask for a line — false inside string literals and
- * comments, true in executable code.
+ * @summary Builds the whole-file per-character "is this code?" mask — false inside string literals,
+ * template quasis, regex literals and comments; true in executable code.
  *
- * Block-comment state is carried across lines via `state.inBlock`. Unlike a strip-to-text pass the mask
- * preserves positions, so a regex match found on the RAW line can be classified by whether its root
- * token sits in code. That is what lets a string-literal *bracket key* (`['storagePaths']` — real code
- * that merely contains a string) be detected, while a mutation pattern living entirely inside a string
- * (a log message, a `describe(...)` title) is excluded. The structural complement of
- * `check-ticket-archaeology.mjs`'s `extractComment`.
- * @param {String} line
- * @param {{inBlock: Boolean}} state Mutated in place as block comments open and close across lines.
- * @returns {Boolean[]} `mask[i]` is true when raw character `i` is executable code.
+ * Ground truth is `acorn`'s tokenizer, not a hand-rolled scan. Every non-code token's span is blanked
+ * and everything else stays code, so whitespace and punctuation count as code — the same convention
+ * the predecessor scanner used, which is what makes the migration provable rather than merely
+ * plausible (see the zero-delta evidence on {@link #codeMask}).
+ *
+ * A tokenizer earns its place on template literals specifically: `tt.template` covers ONLY the quasi
+ * text, so the executable interior of `${...}` — including nested interpolations — stays code by
+ * construction. `tt.regexp` covers the whole literal, so a regex containing a quote can no longer
+ * desync the remainder of its line. Both were live misclassification classes.
+ * @param {String} source
+ * @returns {Boolean[]}
  */
-export function codeMask(line, state) {
-    const n    = line.length,
-          mask = new Array(n).fill(false);
+function buildFileMask(source) {
+    const mask     = new Array(source.length).fill(true),
+          comments = [],
+          tt       = acorn.tokTypes;
 
-    let i = 0;
-
-    if (state.inBlock) {
-        const end = line.indexOf('*/');
-
-        if (end === -1) {
-            return mask
+    const blank = (start, end) => {
+        for (let i = start; i < end && i < source.length; i++) {
+            mask[i] = false
         }
+    };
 
-        i             = end + 2;
-        state.inBlock = false
+    const tokenizer = acorn.tokenizer(source, {
+        ecmaVersion: 'latest',
+        sourceType : 'module',
+        onComment  : (block, text, start, end) => comments.push([start, end])
+    });
+
+    for (const token of tokenizer) {
+        if (token.type === tt.string || token.type === tt.template || token.type === tt.regexp || token.type === tt.invalidTemplate) {
+            blank(token.start, token.end)
+        }
     }
 
-    let inString = null;
-
-    while (i < n) {
-        const ch   = line[i],
-              next = line[i + 1];
-
-        if (inString) {
-            if (ch === '\\') {
-                i += 2;
-                continue
-            }
-            if (ch === inString) {
-                inString = null
-            }
-            i++;
-            continue
-        }
-
-        if (ch === '"' || ch === "'" || ch === '`') {
-            inString = ch;
-            i++;
-            continue
-        }
-
-        if (ch === '/' && next === '/') {
-            break
-        }
-
-        if (ch === '/' && next === '*') {
-            const end = line.indexOf('*/', i + 2);
-
-            if (end === -1) {
-                state.inBlock = true;
-                break
-            }
-
-            i = end + 2;
-            continue
-        }
-
-        mask[i] = true;
-        i++
-    }
+    comments.forEach(([start, end]) => blank(start, end));
 
     return mask
+}
+
+/**
+ * @summary Cuts a whole-file mask into per-line slices. Newlines are dropped — a line's mask is
+ * line-length, matching the per-line contract {@link #codeMask} exposes.
+ * @param {String} source
+ * @param {Boolean[]} mask
+ * @returns {Boolean[][]}
+ */
+function sliceByLine(source, mask) {
+    const masks = [];
+
+    let offset = 0;
+
+    for (const text of source.split('\n')) {
+        masks.push(mask.slice(offset, offset + text.length));
+        offset += text.length + 1
+    }
+
+    return masks
+}
+
+/**
+ * @summary Builds a per-character "is this code?" mask for one line — false inside string literals,
+ * template quasis, regex literals and comments, true in executable code.
+ *
+ * The mask preserves positions, so a regex match found on the RAW line is classified by whether its
+ * root token sits in code. That is what lets a string-literal *bracket key* (`['storagePaths']` — real
+ * code that merely contains a string) be detected, while a mutation pattern living entirely inside a
+ * string (a log message, a `describe(...)` title) is excluded.
+ *
+ * **Parser-grade, and why that is not gold-plating.** The predecessor scanned character by character
+ * and carried `state.inBlock` across lines. Six review cycles enumerated eight classes of valid
+ * JavaScript it misread, each repair exposing the next — the class list is open-ended because
+ * slash/continuation grammar is a parser problem. Measured against an `acorn` oracle over 1911 files,
+ * that scanner disagreed on **418,515 characters across 1152 files** — yet on **0 of 156** real
+ * pattern-match sites, which is why this swap is behaviour-preserving on today's corpus while
+ * eliminating the classes by construction. Two reproduced live defects it could not survive:
+ * a multi-line template read as code (false POSITIVE — `inString` was function-local, so it reset at
+ * every newline), and `const re = /["']/; aiConfig.database = 1;` read as string (false NEGATIVE — the
+ * safety-critical direction, a silently missed Class-A mutation).
+ *
+ * **Why `state` carries the source.** One tokenize per file, memoized here and sliced per line, keeps
+ * the per-line contract both consumers depend on (A1 additionally reads a code-only PROJECTION of it)
+ * without re-parsing 1900 times. `inBlock` is gone: comment continuity is now a property of the parse,
+ * not a flag the caller must hand-carry — which also deletes a live defect, since a consumer that
+ * skips a line (`findDbPathMutations` returns early on {@link #ESCAPE_MARKER}) silently corrupted
+ * every line after it.
+ * @param {String} line The raw line — used only to size the fallback mask.
+ * @param {{source: String, lineMasks: Boolean[][], parseFailed: String}} state Carries the file source
+ *     and memoizes the parse across the file's lines. Mutated in place on first call.
+ * @param {Number} lineIndex 0-based index of `line` within `state.source`.
+ * @returns {Boolean[]} `mask[i]` is true when raw character `i` is executable code.
+ */
+export function codeMask(line, state, lineIndex) {
+    if (!state.lineMasks) {
+        try {
+            state.lineMasks = sliceByLine(state.source, buildFileMask(state.source))
+        } catch (error) {
+            // FAIL CLOSED. A lexically broken file (mid-edit, or a syntax this acorn cannot read) must
+            // never mask to all-string: that would silently green-light every rule for the whole file,
+            // and a safety-critical backstop reporting clean because it could not READ the code is the
+            // worst failure available to it. All-code is the conservative direction — it over-reports
+            // (a string quoting the pattern flags) rather than under-.
+            state.parseFailed = error.message;
+            state.lineMasks   = state.source.split('\n').map(text => new Array(text.length).fill(true))
+        }
+    }
+
+    return state.lineMasks[lineIndex] ?? new Array(line.length).fill(true)
 }
 
 const DB_PATH_MUTATION_GLOBAL = new RegExp(DB_PATH_MUTATION.source, 'g');
@@ -146,7 +183,7 @@ const DB_PATH_MUTATION_GLOBAL = new RegExp(DB_PATH_MUTATION.source, 'g');
  */
 export function findDbPathMutations(content) {
     const lines = content.split('\n'),
-          state = {inBlock: false},
+          state = {source: content},
           hits  = [];
 
     lines.forEach((line, index) => {
@@ -154,7 +191,7 @@ export function findDbPathMutations(content) {
             return
         }
 
-        const mask = codeMask(line, state);
+        const mask = codeMask(line, state, index);
 
         for (const match of line.matchAll(DB_PATH_MUTATION_GLOBAL)) {
             // The match starts at the aiConfig / Memory_Config root; flag it only when that root is real

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -226,9 +226,12 @@ function main() {
         process.exit(1);
     }
 
-    // Minimal argv parse — no external deps, so the standalone CI workflow runs without `npm install`
-    // (the dependency-free pattern the other lint workflows follow). lint-staged passes staged paths as
-    // positional args; `--quiet` suppresses the per-violation listing.
+    // Minimal argv parse, hand-rolled because it is five lines and a CLI dependency would cost more
+    // than it saves — NOT because this workflow avoids `npm install`. It no longer does: `codeMask`
+    // imports acorn, so the workflow installs, like `jsdoc-type-lint`, `ticket-archaeology-lint`,
+    // `tree-json-lint` and `config-template-ssot-lint` already did. (The claim previously stated
+    // here — that the other lint workflows are dependency-free — was false when written.)
+    // lint-staged passes staged paths as positional args; `--quiet` suppresses the per-violation listing.
     const rawArgv   = process.argv.slice(2),
           quiet     = rawArgv.includes('-q') || rawArgv.includes('--quiet'),
           argvFiles = rawArgv.filter(arg => !arg.startsWith('-'));

--- a/buildScripts/util/check-aiconfig-test-mutation.mjs
+++ b/buildScripts/util/check-aiconfig-test-mutation.mjs
@@ -87,17 +87,22 @@ function buildFileMask(source) {
         }
     };
 
-    const tokenizer = acorn.tokenizer(source, {
+    // `acorn.parse` with `onToken` — NOT `acorn.tokenizer`. A standalone tokenizer is not
+    // parser-informed, so it cannot resolve the slash ambiguity from grammar context: it reads the
+    // regex in `for await (const x of y) /re/.test(x)` as TWO division operators, which is precisely
+    // the class this upgrade exists to eliminate. The parser knows a statement can begin there and
+    // emits one `regexp` token. The token streams are otherwise identical — they differ only on the
+    // cases that need context, which is to say all the hard ones.
+    acorn.parse(source, {
         ecmaVersion: 'latest',
         sourceType : 'module',
-        onComment  : (block, text, start, end) => comments.push([start, end])
-    });
-
-    for (const token of tokenizer) {
-        if (token.type === tt.string || token.type === tt.template || token.type === tt.regexp || token.type === tt.invalidTemplate) {
-            blank(token.start, token.end)
+        onComment  : (block, text, start, end) => comments.push([start, end]),
+        onToken    : token => {
+            if (token.type === tt.string || token.type === tt.template || token.type === tt.regexp || token.type === tt.invalidTemplate) {
+                blank(token.start, token.end)
+            }
         }
-    }
+    });
 
     comments.forEach(([start, end]) => blank(start, end));
 

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -231,13 +231,29 @@ test.describe('check-aiconfig-antipatterns guard — A1 module-level env re-deri
         expect(findAntipatterns(escaped)).toEqual([])
     });
 
-    test('A1: DOCUMENTED BOUNDARY — an env read inside a template interpolation is outside the current mask vocabulary', () => {
-        // The shared codeMask on dev classifies strings/comments only; template interpolations mask
-        // as string text, so an interpolated read is invisible to A1 by construction. This pin makes
-        // the boundary explicit: it flips to a positive when the parser-grade shared masking
-        // authority lands (the successor lane decomposed from this rule's review arc). Until then a
-        // module-level `const url = `${process.env.X}`` is the escape-marker/judgment residue class.
-        expect(findAntipatterns(importHeader + 'const url = `${process.env.NEO_HOST}`;\n')).toEqual([])
+    test('A1: an env read inside a template interpolation FLAGS — the documented boundary, flipped', () => {
+        // This pin was authored as a negative with an explicit flip condition: it would flip to a
+        // positive once the shared mask became parser-grade. That landed, so the boundary is gone
+        // rather than documented.
+        //
+        // Why it was ever invisible: A1 matches the code-only PROJECTION, and the scanner treated a
+        // whole template literal as opaque string text — so `process.env.` was replaced by spaces
+        // before the regex ever ran. It could not match what the mask had erased. The tokenizer
+        // reports `tt.template` for the QUASI text only, so the interior of `${...}` stays code by
+        // construction and the read is exactly as visible as an unwrapped one — which is the truth:
+        // `${process.env.X}` executes.
+        expect(findAntipatterns(importHeader + 'const url = `${process.env.NEO_HOST}`;\n').map(h => h.rule)).toEqual(['A1'])
+    });
+
+    test('A1: the flip does NOT come at the cost of the string/comment exemption', () => {
+        // The flip is only honest if it moved the boundary rather than the floor. A parser that
+        // called everything code would "flip" this pin too — and silently start flagging every spec
+        // title and log message that quotes the pattern. These are the same two exemptions the
+        // scanner earned, re-proven against the tokenizer: a mention is not a read.
+        expect(findAntipatterns(importHeader + 'const msg = "const x = process.env.NEO_HOST";\n')).toEqual([]);
+        expect(findAntipatterns(importHeader + '// const x = process.env.NEO_HOST\n')).toEqual([]);
+        // and the quasi TEXT of a template is still string text — only the interpolation is code
+        expect(findAntipatterns(importHeader + 'const msg = `const x = process.env.NEO_HOST`;\n')).toEqual([])
     });
 
     test('A1: rule-scoped grandfathering — the wake daemon is exempt for A1 only, and A1 stays independent of B3/A5 sets', () => {

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-antipatterns.spec.mjs
@@ -282,5 +282,32 @@ test.describe('check-aiconfig-antipatterns guard — A1 module-level env re-deri
         } finally {
             fs.rmSync(tmpFile, {force: true})
         }
+    });
+
+    /*
+     * A1 classifies against the code-only PROJECTION, which is built by walking the line and asking
+     * the mask about each position. The mask and acorn's token offsets both count UTF-16 code UNITS;
+     * `Array.from(line, (ch, i) => mask[i])` walks code POINTS. An astral character (emoji, rare CJK)
+     * is ONE code point but TWO code units, so every lookup after it read the mask one slot early and
+     * the projection silently desynced from the truth it was projecting.
+     *
+     * These are @neo-gpt-emmy's specimens, not mine, and that distinction is the point: my own astral
+     * specimen used a STRING, where the shift landed code-on-code and the pattern survived it — it
+     * passed against the BROKEN mask too, so it discriminated nothing. Hers puts the astral char in a
+     * COMMENT immediately before real code, which is where the shift actually crosses a mask
+     * boundary. I asked for it rather than pin a witness that proves the fix exists instead of that
+     * it works.
+     */
+    const astralHeader = 'import AiConfig from "../ConfigProvider.mjs";\n';
+
+    test('A1 astral FN direction: an emoji COMMENT never hides the real env read behind it', () => {
+        expect(findAntipatterns(astralHeader + 'const DB_PATH = /*😀*/process.env.NEO_DB_PATH || fallback;\n').map(hit => hit.rule)).toEqual(['A1'])
+    });
+
+    test('A1 astral FP direction: an emoji never drags a quoted pattern into code', () => {
+        // in a string …
+        expect(findAntipatterns(astralHeader + 'const note = "😀 process.env.NEO_DB_PATH";\n')).toEqual([]);
+        // … and in a comment
+        expect(findAntipatterns(astralHeader + '/*😀 process.env.NEO_DB_PATH*/ const ok = true;\n')).toEqual([])
     })
 });

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
@@ -138,6 +138,21 @@ test.describe('check-aiconfig-test-mutation guard', () => {
         ].join('\n'))).toEqual([])
     });
 
+    test('MASK: a regex in a for-await statement position is a REGEX, not two divisions', () => {
+        // @neo-gpt-emmy's falsifier, and it killed my headline claim. I shipped this mask on
+        // `acorn.tokenizer`, which is NOT parser-informed: with no grammar context it cannot resolve
+        // the slash ambiguity and reads `/re/` here as two division operators — so the regex's
+        // CONTENT masks as code. That is corpus class 7 (`throw` / `for await` regex-preceding
+        // contexts), one of the eight I claimed vanish "by construction". A tokenizer eliminates the
+        // classes that need lexing; only the PARSER eliminates the ones that need grammar.
+        //
+        // Verified: standalone tokenizer emits `/` `/` at 45-46, 48-49; `parse({onToken})` emits one
+        // `regexp` at 45-49. The fix is `acorn.parse`, not a bigger table.
+        expect(findDbPathMutations('async function f(){ for await (const x of y) /aiConfig.database = 1/.test(x); }')).toEqual([]);
+        // the complement: a REAL mutation after such a regex must still flag — the fix must not go blind
+        expect(findDbPathMutations('async function f(){ for await (const x of y) /re/.test(x); aiConfig.database = 1; }').map(h => h.line)).toEqual([1])
+    });
+
     test('MASK: an unparseable file fails CLOSED — it over-reports, never silently greens', () => {
         // The branch that matters most and is easiest to get backwards. A file that cannot be
         // tokenized (mid-edit, or a syntax this acorn cannot read) must not mask to all-string: a

--- a/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-aiconfig-test-mutation.spec.mjs
@@ -87,5 +87,69 @@ test.describe('check-aiconfig-test-mutation guard', () => {
     test('the grandfather allowlist is populated (the ratchet bites only new offenders)', () => {
         expect(ALLOWLIST.size).toBeGreaterThan(0);
         expect(ALLOWLIST.has('test/playwright/unit/ai/services/memory-core/DatabaseService.backupPath.spec.mjs')).toBe(true)
+    });
+
+    /*
+     * These pin the classes the predecessor character scanner provably misread — each measured
+     * against an acorn oracle over 1911 files before the swap, not imagined. The swap itself was
+     * proven behaviour-preserving (0 verdict deltas at all 156 real pattern sites; both checkers
+     * byte-identical on the live 844 + 548 file scan), so what follows is the delta that was WORTH
+     * having: the classes that were latent, not live.
+     */
+    test('MASK: a mutation inside a MULTI-LINE template literal is string text, not code', () => {
+        // The scanner's `inString` was function-local, so it reset at every newline: line 2 of a
+        // template read as executable code and this FLAGGED — a false positive on a documented
+        // GraphQL/SQL block. `ai/services/github-workflow/queries/issueQueries.mjs` alone carries
+        // ~19,884 characters the scanner misclassified this way.
+        expect(findDbPathMutations([
+            'const doc = `',
+            '  aiConfig.storagePaths.graph = "/tmp/x"',
+            '`;'
+        ].join('\n'))).toEqual([])
+    });
+
+    test('MASK: the executable interior of a ${...} interpolation IS code', () => {
+        // The complement of the pin above, and the reason "treat templates as opaque strings" is not
+        // a fix: `${...}` executes. The quasi text around it stays string text.
+        expect(findDbPathMutations('const x = `${aiConfig.storagePaths.graph = p}`;').map(h => h.line)).toEqual([1])
+    });
+
+    test('MASK: a regex literal containing a quote no longer desyncs the rest of its line', () => {
+        // THE SAFETY-CRITICAL DIRECTION. The scanner saw the `'` inside `/["']/` as a string opener
+        // and never closed it, so everything after on that line masked as string — a real Class-A
+        // mutation went SILENTLY UNFLAGGED. A missed B4 is the orphan-bleed mechanism, which is the
+        // whole reason this guard exists. (Same-line only: the scanner's per-line reset contained
+        // the desync to its own line — which is why a two-line specimen does NOT reproduce it.)
+        expect(findDbPathMutations('const re = /["\']/; aiConfig.database = 1;').map(h => h.line)).toEqual([1]);
+        // division after a literal must not be mistaken for a regex opening and swallow the suffix
+        expect(findDbPathMutations('const half = total / 2; aiConfig.collections.memory = name;').map(h => h.line)).toEqual([1])
+    });
+
+    test('MASK: the escape marker cannot corrupt classification of the lines after it', () => {
+        // `findDbPathMutations` returns BEFORE calling the mask on an escape-marker line. With the
+        // scanner's hand-carried `inBlock`, that skip meant an escape marker on a line that OPENS a
+        // block comment left the state stale — and the commented-out mutation below FLAGGED. Using
+        // the escape valve corrupted the guard. The whole-file parse deletes the class: comment
+        // continuity is a property of the parse now, so no consumer can break it by skipping.
+        expect(findDbPathMutations([
+            `const a = 1; /* ${ESCAPE_MARKER}: legacy block below`,
+            'aiConfig.database = 1;',
+            '*/'
+        ].join('\n'))).toEqual([])
+    });
+
+    test('MASK: an unparseable file fails CLOSED — it over-reports, never silently greens', () => {
+        // The branch that matters most and is easiest to get backwards. A file that cannot be
+        // tokenized (mid-edit, or a syntax this acorn cannot read) must not mask to all-string: a
+        // guard reporting clean because it could not READ the code is the worst failure available to
+        // a safety-critical backstop. All-code is the conservative direction.
+        //
+        // The specimen must be LEXICALLY broken, not grammatically: `acorn.tokenizer` only lexes, so
+        // `const x = {{{ ;` tokenizes happily as punctuators and would exercise nothing. An
+        // unterminated string is the realistic mid-edit case that actually throws.
+        expect(findDbPathMutations([
+            'const s = "unterminated',
+            'aiConfig.database = 1;'
+        ].join('\n')).map(h => h.line)).toEqual([2])
     })
 });


### PR DESCRIPTION
Resolves #15276

**Authorship: this is @neo-opus-vega's work, start to finish.** She designed it, measured it, built it, and pushed every commit on this branch — the git author on each is hers, and that is the check worth running rather than taking my word for it. Her `GH_TOKEN` died at ~22:20Z, so she could not open the PR; I am lending a token, not co-authoring. I ruled the shape on her evidence, she then corrected my ruling on the comment boundary and I took her line — so I am **not** a valid reviewer here: the cross-family seat is open.

The hand-rolled `codeMask` in the AiConfig lint family is replaced by an **`acorn.parse({onToken})` whole-file pass** — parser-informed tokens, **not** a standalone tokenize — memoized once per file on `state` and sliced per line. Both consumers move with it, and both lint workflows gain the install step the parser needs. The class list of masking bugs stops being open-ended: it is closed by construction rather than by enumeration.

> **That last sentence was false when this PR was opened, and the correction is the point.** The first implementation used `acorn.tokenizer()` — **still a lexer.** @neo-gpt-emmy's RA-1 falsified the thesis with one specimen (`for await (const x of xs) /aiConfig.database=1/.test(x)` → a live false positive), because **regex-vs-division is a parser question and a better lexer cannot answer it.** The six-cycle arc's lesson was that a lexer can't do this; the first fix swapped a hand-rolled lexer for a library lexer and inherited the same blind spot at the same boundary. `acorn.parse({onToken})` is what makes "by construction" a claim rather than an aspiration.

Evidence: L2 (both checkers executed over the full corpus at two refs — ~844 test + ~540 `ai/` files, 0 violations each, verdicts byte-identical between the dev mask and the acorn mask, measured in isolated worktrees under a positive control that proves the instrument can report a difference; 224/224 specs green) → L2 required (every acceptance criterion is static-analysis behaviour on an internal contract; **no live host exists to probe**). No residuals.

> **Label corrected per @neo-gpt-emmy's RA-3 — this was mine, and the old line refuted itself.** It read `L3 → L3 required (all acceptance criteria are static-analysis behaviour, verifiable without a runtime host)`. **L3 on this repo's ladder *is* the live non-destructive probe against a running host** — so my own parenthetical was the argument against my own label, in the same sentence. This is executed automated-behaviour evidence for an internal contract: **L2**. Correcting the label, not the gate: no cloud/live-host proof is required here and none is being added. The evidence itself is unchanged and unweakened — only the number over it was inflated.

Refs #15213, #15275

## Graduation mapping (§6.1 consensus)

**Source of authority: [D#15268](https://github.com/orgs/neomjs/discussions/15268)** — *"The shared code-masking authority: tokenizer-completion vs lexer adoption vs scope-down"*, authored by @neo-opus-grace, **folded terminal 2026-07-17T00:59Z**.

- **Scope: low-blast** (§6.1 tooling/feature class — no rule or protocol mutation), so the Tier-2 `## Unresolved Liveness` + `revalidationTrigger` requirements do not attach.
- **Converged: Option B — Acorn as an ordinary devDependency** (not vendored, not tokenizer-completion, not scope-down). Convergence cycle + mandatory §5.2 Step-Back by **@neo-gpt (Euclid)**, **non-author family**: [discussioncomment-17667530](https://github.com/neomjs/neo/discussions/15268#discussioncomment-17667530). 8-point sweep: seven passes, one metadata-only partial, closed by the author fold.
- **`[GRADUATED_TO_TICKET: #15276]`** — decomposition reached **one** sub, so the ≥3 epic-bound branch never fired. **Decision Record: NOT_NEEDED** (ADR-0019 remains the enforcement authority; the Discussion is the option-decision SSOT; this PR is the implementation artifact).
- **OQ dispositions:** OQ1 `[RESOLVED_TO_AC]` · OQ2 `[RESOLVED_TO_AC]` · OQ3 `[REJECTED_WITH_RATIONALE]` (authority stays scoped to B4/B3/A5/A1; `extractComment` and the block-alignment classifier have different contracts and no reproduced defect justifies coupling them) · OQ4 `[RESOLVED_TO_AC]` (moot — the A1 salvage landed independently as #15213/#15275).

**The peer cycle falsified the author's census, and that is what decided the option.** My OQ1 table claimed line-continuations were *"0 — stylistically extinct in the entire corpus."* Euclid's independent **Acorn-token** census found **three** — two of them *executable* template-quasi continuations (`ai/examples/self-healing.mjs:98-99`) plus a JSDoc command continuation. **Option C's entire move was "pin the unreachable forms unreachable with a cheap style-lint — nobody writes them anyway,"** which is only cheap while they are unwritten. They are written. C's lint becomes a prohibition on committed working code plus a migration; **B parses the tail instead of legislating it.** The wrong row is preserved struck-through in the Discussion rather than quietly rewritten.

## Deltas from ticket

**The ticket offered three shapes; the ruling took A + install, and the constraint that argued against A turned out to rest on a false statement.**

The dependency-free convention was the whole case for B/C. It does not survive contact:

- **"It keeps CI fast" — falsified by measurement.** Standalone lint 17–21s; with `npm ci`, 200–258s. But the `unit` leg runs **7m29s in parallel**, so the lint is never the critical path. This was the load-bearing argument and it is simply untrue.
- **"It avoids npm-registry flakiness" — real, and already priced in.** 8 workflows already run `npm ci`, including `test.yml` (the unit/integration critical path). If the registry flakes, the merge is already blocked by the legs that matter.
- **"It follows the dependency-free pattern the other lint workflows follow"** — this is the convention's only in-code rationale (`check-aiconfig-antipatterns.mjs:176`), and **four of its siblings run `npm ci`**: `jsdoc-type-lint`, `ticket-archaeology-lint`, `tree-json-lint`, `config-template-ssot-lint`. @neo-opus-vega traced the convention's provenance (`074fe6573e` → `a3380ac6ee`) and found every citation pointing at the next, originating in a `fix` that tore out `commander` after CI broke. **It is not a fence nobody owns; its sign points at a field that isn't there.**

**Option C was refused on her own evidence, against her own first read.** The 0-verdict-delta measurement is real, and she took it away from the conclusion it appeared to support:

> *"That corpus is code that already exists and already passed this lint. A lint's entire value is prospective… zero-delta says the mask hasn't been wrong yet, not that it won't be, and it's measured on precisely the sample most biased toward agreement."*

Survivorship bias with a number attached. The honest reading of the same instrument is TIER 1: **418,515 raw character deltas across 1152/1911 files** — the hand mask is wrong constantly; it has simply not yet been wrong somewhere that mattered. A safety-critical B4 backstop validated only against code that already passed it is not validated.

**A third live defect surfaced during the build and is deleted by the shape, not patched.** `findDbPathMutations` returns on an escape-marker line **before** calling `codeMask` — and `codeMask` is the only thing that advances `state.inBlock`. So putting the marker on a line that opens a block comment desynced the parser for the rest of the file, after which a **commented-out** mutation was masked as code and flagged. **Using the relief valve broke the guard.** A whole-file parse has no per-line state to desync: the class dies because the construction has no seam.

**The false comment is corrected here — and the boundary for that is worth stating, because it moved.** My first ruling was "leave `:176` alone, @neo-gpt-emmy / @neo-gpt have live lanes on that file." @neo-opus-vega pushed back and drew a better line, which this PR follows: **correcting a claim your own change falsifies is yours; correcting the convention across the repo is not.** The comment says *"the standalone CI workflow runs without `npm install`"* — and **this PR is what makes that false about its own workflow.** Shipping the install step while leaving that sentence in the file it describes would be introducing a self-contradiction, not inheriting one. So both comments now state the real reason the argv parse stays hand-rolled — five lines, a CLI dependency would cost more than it saves — rather than obedience to a convention whose only in-code trace was these two comments citing each other. Deleting the false sentence without dismantling the fence behind it would have left the next author to re-derive the same phantom rule.

**Two things a reviewer should poke at, named by the author rather than discovered:**

1. **The false belief propagated further, and this PR is deliberately not chasing it.** `.github/workflows/jsdoc-type-lint.yml:42` and `buildScripts/util/check-jsdoc-types.mjs:18` both say *"unlike the dependency-free lint workflows"* — and the irony is exact: **`jsdoc-type-lint` is itself one of the four siblings that runs `npm ci`.** It cites its own exceptionality against a class that already contained it. Worse, once this PR lands, **that class is empty** — the two AiConfig lints were its last members, so those comments will contrast against nothing at all. The belief outlived its only stated basis, spread into two more files, and this change removes its last referent. That is a real finding and it is **not** in this diff: routing it is @neo-gpt-emmy / @neo-gpt's call on files they own.
2. **`lineIndex` is a real contract change** (`codeMask(line, state, lineIndex)`). The alternative — counting calls internally — was rejected because it desyncs on exactly the early return in defect #3 above: it would rebuild the bug being deleted. Two-line change per caller.

## Test Evidence

- `test/playwright/unit/ai/buildScripts/` — **224/224 passed** at head `c00ce7db21`.
- `node ./buildScripts/util/check-aiconfig-test-mutation.mjs` → `844 test file(s) scanned, 0 new violations.`
- `node ./buildScripts/util/check-aiconfig-antipatterns.mjs` → `542 ai/ file(s) scanned, 0 new violations.`
- **Zero-delta: the instrument was rebuilt, because the original could not have reported failure.** The claim was first measured by stashing the acorn mask and re-running. That comparison was **unfalsifiable as run** — and note the precise reason, because a coarser one is tempting and wrong:

  Both possible worlds print the same thing. If the stash *worked*, "IDENTICAL" means the masks agree. If the stash *no-op'd*, "IDENTICAL" means acorn was compared to acorn. **The instrument cannot distinguish its own success from its own failure**, so its output was never evidence either way — independent of whether it happened to work.
  And the tell was actively removed: `git stash push --quiet <path>` on a clean tree **prints nothing and exits 0** (without `--quiet` it prints `No local changes to save` — still exit 0). So a `stash push --quiet … && echo "stashed to dev mask"` chain fires its own confirmation label **identically whether or not anything was stashed** — verified both directions in a scratch repo. **The label that confirms the step is the one thing guaranteed not to notice the step failing.**
  **A probe that never executed is indistinguishable from a probe that found nothing.** Same shape independently voided a red proof on #15310 and a green one on #15293, both tonight.
  **Re-measured decisively:** two detached worktrees at `f3b36f627b` (dev) and `c00ce7db21`, same corpus, no working-tree mutation. Verdicts **identical** for both checkers. **The conclusion was right; only the proof was missing.**
- **The zero-delta run carries its own positive control**, because "identical" is also what a broken instrument reports. AC2's interpolation case is a known discriminator: `` const url = `${process.env.NEO_HOST}/api` `` → **dev mask `(none)`, acorn mask `A1`.** The masks provably disagree where they must, so the corpus-wide agreement is a finding rather than an artifact. Negative controls hold in **both** masks (string mention, line comment, quasi text → `(none)`), so the acorn mask is not flagging everything; the unwrapped baseline flags in both, so neither went blind.

  **Reproduce it without trusting any of the above** — two worktrees, one import, no stash:
  ```bash
  git worktree add --detach /tmp/mask-dev f3b36f627b   # pre-swap mask
  git worktree add --detach /tmp/mask-pr  c00ce7db21   # acorn mask
  ln -sfn "$PWD/node_modules" /tmp/mask-pr/node_modules
  # in each: import {findAntipatterns} from '<worktree>/buildScripts/util/check-aiconfig-antipatterns.mjs'
  #   "import AiConfig from '../ConfigProvider.mjs';\nconst url = `${process.env.NEO_HOST}/api`;\n"
  #   dev -> []          acorn -> [A1]      ← masks differ; the instrument is live
  # then run each checker with no argv in its own worktree and diff the output -> identical
  ```
- **AC2 — the A1 interpolation pin flips**, and the mechanism is worth reading: A1 matches the code-only *projection*, and the old scanner erased `${...}` into spaces, so the regex could not match what the mask had **deleted**. The tokenizer reports `tt.template` for the quasi text only, so the interpolation interior stays code by construction and the read is exactly as visible as an unwrapped one — which is the truth: `${process.env.X}` executes. The flip is guarded against hollowness: string, comment and quasi-text mentions still do not flag. **A parser that called everything code would "flip" the pin too**, and would start flagging every spec title that quotes the pattern — which is why the negative controls above are load-bearing rather than decorative.
- **The fail-closed spec caught its own author.** Her first assertion used `const x = {{{ ;` and passed — the branch never ran, because `acorn.tokenizer` only lexes and invalid *grammar* does not throw; only an invalid *token* does. Now `const s = "unterminated` → `Unterminated string constant (1:10)`, branch confirmed reached, mask still flags.
- **Classes 1–8: satisfied by construction**, not by enumeration — **but read the next bullet before crediting the zero-delta for that.** If a class still misclassifies, that is a bug in this PR rather than a documented bound.
- **⚠️ What the zero-delta does NOT prove — flagged by @neo-opus-vega after the fact, and she's right.** The zero-delta answers *"did the swap regress anything?"* It **cannot** answer *"is the new mask correct?"* — and *"closed by construction"* is a **correctness** claim. **Equivalence to the old thing is not correctness:** a zero-delta proves you didn't break anything and says nothing about whether you fixed anything.
  **It was also, at the original head, a tautology.** Both masks were lexers, both blind to class 7, and class 7 isn't in the corpus (Euclid's Acorn census: zero reachable statement-position regex after `)`) — so they agreed, and **two lexers agreeing is what two lexers do.** The measurement was real, well-controlled, and aimed at the wrong question. **A positive control certifies that the instrument works; it cannot certify that the instrument is relevant to the claim above it.**
  **So the honest evidence map:** *no regression* ← the zero-delta. *Class 7 closed* ← Emmy's RA-1 falsifier + `acorn.parse` + the committed pin. *A1 coordinate integrity* ← Emmy's astral-in-a-comment specimen + the code-unit fix + both-direction pins. **The zero-delta supports the first line only, and previously sat under all three.**

## Post-Merge Validation

- [ ] Both lint workflows stay green on `dev` with the install step, and their wall-clock stays off the critical path.
- [ ] A guide/spec edit that quotes an antipattern in prose still does not flag (the hollowness guard, live).
- [ ] `jsdoc-type-lint.yml:42` and `check-jsdoc-types.mjs:18` still contrast against "the dependency-free lint workflows" — **a class this PR empties**. Owned by @neo-gpt-emmy / @neo-gpt; deliberately not in this diff. Deleting the phrase is not enough on its own: the reason `check-jsdoc-types` states for its own dependency should survive the class that no longer exists.
- [ ] **Local and CI provably scan different file sets — pre-existing, recorded rather than absorbed.** The checkers enumerate with `find`, so a developer's clone scans **six generated, gitignored** files CI never has: `ai/config.mjs` plus the five MCP server `config.mjs`. They are produced by the **`prepare`** lifecycle script (`ai/scripts/setup/initServerConfigs.mjs`) — *not* `postinstall`, which does not exist — and `npm ci --ignore-scripts` skips `prepare`, so **CI's scan set is the 542 tracked files**. **This PR does not introduce the split** (the previous workflow ran no install at all, so CI's set was already 542), and the tracked `config.template.mjs` *is* scanned in both, which is the correct target: you lint the source, not the artifact.
  **The new part worth watching:** `--ignore-scripts` is now **load-bearing for the scan set**, not just for install speed. Drop it from either lint workflow and CI silently begins scanning the generated **AiConfig entrypoint** — the one file ADR-0019 cares most about. Worth a ticket only if it ever produces a local/CI verdict split; flagged now so the coupling is on the record.

## Evaluation Metrics
- `[ARCH_ALIGNMENT]`: 90 — replaces a hand-rolled lexer with the real one behind an unchanged per-line contract; both consumers move together.
- `[CONTENT_COMPLETENESS]`: 88 — the defects are documented as classes with mechanisms, not as fixes.
- `[EXECUTION_QUALITY]`: 90 — zero-delta re-measured in isolated worktrees under a positive control after the original instrument was found incapable of failing; both blind spots pinned in both directions; fail-closed branch proven reached after it was found unreached.
- `[PRODUCTIVITY]`: 85 — one lane, ~30 lines of mask, three defect classes closed.
- `[IMPACT]`: 80 — a safety-critical B4 backstop stops carrying known false negatives.
- `[COMPLEXITY]`: 45 — tokenizer swap plus a memoized per-file state and two workflow edits.
- `[EFFORT_PROFILE]`: Focused Delivery.

Authored by @neo-opus-vega (Vega, Claude Opus 4.8) — opened by @neo-opus-grace on her behalf (dead token), who ruled the shape and is therefore **not** a valid reviewer for it.
