### PR TITLE
feat(agentos): the cockpit liveness owner — `live` stops meaning "was live once" (#15331)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1232,8 +1232,17 @@ class FleetCockpit extends Container {
                 stream.adapterState   = 'stale';
                 // the adapter's OWN reason outranks a guess — it saw the failure, we only saw the answer
                 me.degradedReason = toSafeDegradedReason(capability.reason)
+            } else if (capability) {
+                // The producer ANSWERED and said it is not wired (`not-wired`). The seed stays — the
+                // stream really is showing sample events, so its own state is honestly 'sample' — but
+                // an answer is not silence, and the difference is the whole point: a reachable server
+                // whose activity source is unconfigured is NOT an unreachable server. Retaining the
+                // reason is what lets the banner say which one it is instead of guessing the loudest.
+                me.degradedReason = toSafeDegradedReason(capability.reason)
             }
-            // not-wired / absent bridge → keep the honestly-labelled 'sample' seed
+            // NO capability at all (a torn/absent answer) → keep the 'sample' seed AND no reason:
+            // we learned nothing, so the banner falls back to its generic copy rather than inventing
+            // a cause. That is the genuine cold case.
         } catch (error) {
             // fail-closed: the last-known feed STAYS rather than blanking it — only the state advances
             me.degradeWiredSurface('stream', error, stream)

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1434,10 +1434,17 @@ class FleetCockpit extends Container {
                 streamAdapterState: me.streamAdapterState
             });
 
+            // `text`, never `html`. The line now interpolates a RETAINED TRANSPORT STRING — the
+            // adapter's own `capability.reason`, which arrives over the fleet wire — and `html`
+            // is an innerHTML sink, so hostile markup in a reason would execute. `toSafeDegradedReason`
+            // redacts SECRETS; it was never a markup escaper, and treating a redactor as a sanitiser
+            // is how a reason becomes a script tag. `text` routes to `textContent`: data, not code,
+            // which is the boundary the whole VDom pipeline is built on. The banner renders one
+            // sentence and needs no markup, so `html` bought nothing and risked everything.
             banner.set({
                 cls : ['fm-spine-banner', `fm-spine-banner-${kind}`],
                 hidden,
-                html: text
+                text
             })
         }
     }

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -29,6 +29,15 @@ import '../../../../src/tab/Container.mjs'; // registers the `tab-container` nty
 const LIVENESS_POLL_INTERVAL = 15000;
 
 /**
+ * The bounded window (ms) a single liveness read gets before it is treated as a degrade.
+ *
+ * Deliberately shorter than {@link LIVENESS_POLL_INTERVAL}: the window must close before the next
+ * tick, or a hung read would still be holding its surface's slot when the cadence comes round.
+ * @type {Number}
+ */
+const LIVENESS_READ_TIMEOUT = 10000;
+
+/**
  * Longest safe reason rendered on the spine banner — a transport error can carry an entire response
  * body, and this line is one row of shell chrome, not a log viewer.
  * @type {Number}
@@ -62,6 +71,34 @@ function toSafeDegradedReason(error) {
         .trim();
 
     return safe ? safe.slice(0, MAX_DEGRADED_REASON_LENGTH) : null
+}
+
+/**
+ * @summary Bounds one liveness read: it may fail, it may never hang.
+ *
+ * A hung read is not a slow read — it is a read that never answers, and an unbounded one poisons
+ * every mechanism built on top of it. The in-flight latch releases in a `.finally()`, so a promise
+ * that never settles holds its surface's slot **forever**: every later tick is suppressed, the
+ * surface stays last-known-live, and the liveness owner silently stops being live — the original
+ * defect, rebuilt from the other side. Bounding the read is what makes the latch safe to hold.
+ *
+ * The loser of the race is not aborted (the wire has no abort seam yet). It does not need to be:
+ * the generation fence already makes a late arrival unable to write. This only guarantees the
+ * SLOT comes back.
+ * @param {Promise} read
+ * @param {Number} timeout ms
+ * @returns {Promise} settles with the read, or rejects with a timeout error inside `timeout` ms
+ * @private
+ */
+function boundedRead(read, timeout) {
+    let timerId;
+
+    return Promise.race([
+        read.finally(() => clearTimeout(timerId)),
+        new Promise((resolve, reject) => {
+            timerId = setTimeout(() => reject(new Error(`fleet read exceeded ${timeout}ms`)), timeout)
+        })
+    ])
 }
 
 /**
@@ -304,6 +341,15 @@ class FleetCockpit extends Container {
      * @protected
      */
     livenessPollInterval = LIVENESS_POLL_INTERVAL
+    /**
+     * The bounded window (ms) ONE liveness read gets before it is treated as a degrade. Boundedness
+     * is the contract — a read may fail, it may never hang — the same shape and the same reason as
+     * {@link #detailVesselConnectWindowMs}. Injectable so specs pin a short window instead of
+     * sleeping on the production one.
+     * @member {Number} livenessReadTimeout=LIVENESS_READ_TIMEOUT
+     * @protected
+     */
+    livenessReadTimeout = LIVENESS_READ_TIMEOUT
     /**
      * The liveness re-poll timer id, owned for exact-once teardown. `null` = not running — the
      * cockpit is pre-start or destroyed. It dies with {@link #destroy}; it deliberately SURVIVES
@@ -1275,7 +1321,7 @@ class FleetCockpit extends Container {
         const generation = ++me.streamReadGeneration;
 
         try {
-            const {capability, events} = await bridge.fleetActivity() ?? {};
+            const {capability, events} = await boundedRead(Promise.resolve(bridge.fleetActivity()), me.livenessReadTimeout) ?? {};
 
             // The fence. Older news must never overwrite newer: an interval re-poll means two reads
             // of THIS surface can be in flight at once, and without this the LOSER writes last —
@@ -1357,7 +1403,7 @@ class FleetCockpit extends Container {
         const generation = ++me.gridReadGeneration;
 
         try {
-            const {rows} = await bridge.fleetRoster() ?? {};
+            const {rows} = await boundedRead(Promise.resolve(bridge.fleetRoster()), me.livenessReadTimeout) ?? {};
 
             // the fence: a newer read started while this one was in flight, or the owner is gone.
             // Either way this answer is no longer this surface's truth to write.

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -246,12 +246,31 @@ class FleetCockpit extends Container {
      */
     gridDegradedReason = null
     /**
+     * Monotonic read counter for the ROSTER surface — the async-ingress fence.
+     *
+     * {@link #startLiveness} re-drives both seams on a cadence, so two reads of the SAME surface can
+     * be in flight at once and complete in any order. Without a fence the LOSER writes last: a slow
+     * poll that failed lands after a fast one that succeeded, and the surface regresses `live` →
+     * `stale` on strictly older news. Every read captures its generation and drops itself if a newer
+     * read started meanwhile — the same latch {@link AgentOS.view.fleet.AgentDetail} uses for the
+     * mailbox mirror, which this owner needed and did not have.
+     * @member {Number} gridReadGeneration=0
+     * @protected
+     */
+    gridReadGeneration = 0
+    /**
      * The retained safe reason for the ACTIVITY surface's current degrade. See
      * {@link #gridDegradedReason} for why these are per-surface rather than one shared field.
      * @member {String|null} streamDegradedReason=null
      * @protected
      */
     streamDegradedReason = null
+    /**
+     * Monotonic read counter for the ACTIVITY surface. See {@link #gridReadGeneration}.
+     * @member {Number} streamReadGeneration=0
+     * @protected
+     */
+    streamReadGeneration = 0
     /**
      * The last authoritative (bridge-sourced) roster snapshot, kept so a slower store load — the
      * JSON sample seed racing {@link #loadRoster} — can never overwrite live truth
@@ -1233,8 +1252,21 @@ class FleetCockpit extends Container {
             return
         }
 
+        // captured BEFORE the await: this read's claim to write. A newer read bumps the counter, so
+        // a slower older one returns to find its generation stale and drops itself.
+        const generation = ++me.streamReadGeneration;
+
         try {
             const {capability, events} = await bridge.fleetActivity() ?? {};
+
+            // The fence. Older news must never overwrite newer: an interval re-poll means two reads
+            // of THIS surface can be in flight at once, and without this the LOSER writes last —
+            // a slow failed poll landing after a fast successful one regresses live → stale on
+            // strictly staler information. `isDestroyed` is the same question at the other end: a
+            // read that outlives its owner has no surface left to speak for.
+            if (generation !== me.streamReadGeneration || me.isDestroyed) {
+                return
+            }
 
             if (capability?.state === 'wired') {
                 me.streamAdapterState = 'live';
@@ -1258,10 +1290,19 @@ class FleetCockpit extends Container {
             // we learned nothing, so the banner falls back to its generic copy rather than inventing
             // a cause. That is the genuine cold case.
         } catch (error) {
-            // fail-closed: the last-known feed STAYS rather than blanking it — only the state advances
-            me.degradeWiredSurface('stream', error, stream)
+            // fenced too, and this is the branch that actually bit: a slow FAILURE landing after a
+            // fast success would regress live → stale on older news. The catch is not exempt from
+            // ordering just because it is the sad path.
+            if (generation === me.streamReadGeneration && !me.isDestroyed) {
+                // fail-closed: the last-known feed STAYS rather than blanking it — only the state advances
+                me.degradeWiredSurface('stream', error, stream)
+            }
         } finally {
-            me.syncSpineBanner()
+            // a superseded or post-destroy read renders nothing: syncing here would let a dropped
+            // read still repaint the banner from state it was not allowed to write
+            if (generation === me.streamReadGeneration && !me.isDestroyed) {
+                me.syncSpineBanner()
+            }
         }
     }
 
@@ -1294,8 +1335,17 @@ class FleetCockpit extends Container {
             return
         }
 
+        // captured BEFORE the await — see {@link #gridReadGeneration}
+        const generation = ++me.gridReadGeneration;
+
         try {
             const {rows} = await bridge.fleetRoster() ?? {};
+
+            // the fence: a newer read started while this one was in flight, or the owner is gone.
+            // Either way this answer is no longer this surface's truth to write.
+            if (generation !== me.gridReadGeneration || me.isDestroyed) {
+                return
+            }
 
             if (!Array.isArray(rows)) {
                 return // malformed answer → keep the last-known roster
@@ -1320,13 +1370,18 @@ class FleetCockpit extends Container {
             grid.adapterState   = 'live';
             me.clearDegradedReason('grid')
         } catch (error) {
-            // fail-closed: the last-known roster STAYS rather than blanking the fleet — only the
-            // state advances. A wired surface that stops answering is degraded, not cold: it is
-            // showing last-known LIVE rows, so claiming 'sample' would tell the operator they are
-            // looking at fixture data. Pre-wired failures keep the honest 'sample' seed.
-            me.degradeWiredSurface('grid', error, grid)
+            // fenced: a slow failure must not overwrite a newer success (see the stream twin)
+            if (generation === me.gridReadGeneration && !me.isDestroyed) {
+                // fail-closed: the last-known roster STAYS rather than blanking the fleet — only the
+                // state advances. A wired surface that stops answering is degraded, not cold: it is
+                // showing last-known LIVE rows, so claiming 'sample' would tell the operator they are
+                // looking at fixture data. Pre-wired failures keep the honest 'sample' seed.
+                me.degradeWiredSurface('grid', error, grid)
+            }
         } finally {
-            me.syncSpineBanner()
+            if (generation === me.gridReadGeneration && !me.isDestroyed) {
+                me.syncSpineBanner()
+            }
         }
     }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -90,8 +90,12 @@ function toSafeDegradedReason(error) {
  * @returns {Promise} settles with the read, or rejects with a timeout error inside `timeout` ms
  * @private
  */
-function boundedRead(read, timeout) {
+function boundedRead(read, timeout, onWireSettled) {
     let timerId;
+
+    // the WIRE's own settle — independent of who wins the race. The accumulation bound counts this,
+    // because a timed-out wrapper does not free the socket the read is still holding.
+    read.then(onWireSettled, onWireSettled);
 
     return Promise.race([
         read.finally(() => clearTimeout(timerId)),
@@ -296,17 +300,24 @@ class FleetCockpit extends Container {
      */
     gridReadGeneration = 0
     /**
-     * Overlap suppression for the ROSTER surface — true while a liveness-driven read is unresolved.
+     * Count of UNDERLYING roster reads still unresolved on the wire — the accumulation bound.
      *
-     * The generation fence keeps a late read from WRITING; this keeps it from being LAUNCHED. Without
-     * it, a transport slower than the cadence collects a new in-flight read every tick, forever,
-     * against a bridge that is already struggling — the "hung accumulation" half of the ingress
-     * contract. Only {@link #startLiveness} honours it: a direct call (boot, an explicit refresh) is
-     * an operator-meant read and is never suppressed.
-     * @member {Boolean} gridReadInFlight=false
+     * Counts the WIRE, not the wrapper, and that distinction is the whole fix. `boundedRead` settles
+     * its own promise on timeout, so releasing the slot there bounded nothing: the underlying read
+     * kept hanging while every tick launched another. Five ticks, five hung reads, zero settled.
+     * Decremented only when the real read settles, so the cap counts what is actually outstanding.
+     *
+     * Capped at {@link #maxReadsInFlight} rather than one, because with no abort seam on the wire a
+     * single slot cannot both bound accumulation AND survive a permanent hang — one hung read would
+     * hold the only slot forever and liveness would stop. A cap above one keeps a recovery probe
+     * alive through N-1 hangs while proving the cap never grows.
+     *
+     * Only {@link #startLiveness} honours it: a direct call (boot, an explicit refresh) is
+     * operator-meant and never suppressed.
+     * @member {Number} gridReadInFlight=0
      * @protected
      */
-    gridReadInFlight = false
+    gridReadInFlight = 0
     /**
      * The retained safe reason for the ACTIVITY surface's current degrade. See
      * {@link #gridDegradedReason} for why these are per-surface rather than one shared field.
@@ -321,11 +332,19 @@ class FleetCockpit extends Container {
      */
     streamReadGeneration = 0
     /**
-     * Overlap suppression for the ACTIVITY surface. See {@link #gridReadInFlight}.
-     * @member {Boolean} streamReadInFlight=false
+     * Count of UNDERLYING activity reads still unresolved on the wire. See {@link #gridReadInFlight}.
+     * @member {Number} streamReadInFlight=0
      * @protected
      */
-    streamReadInFlight = false
+    streamReadInFlight = 0
+    /**
+     * The cap on concurrent UNDERLYING reads per surface. Above one so a permanently hung read cannot
+     * consume the last slot and stop liveness; small so a hung wire cannot accumulate. Injectable so
+     * witnesses pin it instead of inferring it.
+     * @member {Number} maxReadsInFlight=2
+     * @protected
+     */
+    maxReadsInFlight = 2
     /**
      * The last authoritative (bridge-sourced) roster snapshot, kept so a slower store load — the
      * JSON sample seed racing {@link #loadRoster} — can never overwrite live truth
@@ -1310,18 +1329,25 @@ class FleetCockpit extends Container {
             stream = me.getReference('activity-stream'),
             bridge = globalThis.AgentOS?.fleet?.registryBridge;
 
+        // BEFORE the early return, not after. Absence is newer knowledge, and an older pending read
+        // must not outlive it: without the bump, a tick that finds the bridge gone returns silently
+        // and an in-flight read from when it was present still lands and writes.
+        const generation = ++me.streamReadGeneration;
+
         if (!stream || typeof bridge?.fleetActivity !== 'function') {
             // no bridge/verb IS the cold truth — the spine banner must say so
             me.syncSpineBanner();
             return
         }
 
-        // captured BEFORE the await: this read's claim to write. A newer read bumps the counter, so
-        // a slower older one returns to find its generation stale and drops itself.
-        const generation = ++me.streamReadGeneration;
-
         try {
-            const {capability, events} = await boundedRead(Promise.resolve(bridge.fleetActivity()), me.livenessReadTimeout) ?? {};
+            me.streamReadInFlight++;
+
+            const {capability, events} = await boundedRead(
+                Promise.resolve(bridge.fleetActivity()),
+                me.livenessReadTimeout,
+                () => { me.streamReadInFlight-- }
+            ) ?? {};
 
             // The fence. Older news must never overwrite newer: an interval re-poll means two reads
             // of THIS surface can be in flight at once, and without this the LOSER writes last —
@@ -1393,17 +1419,24 @@ class FleetCockpit extends Container {
             grid   = me.getReference('fleet-grid'),
             bridge = globalThis.AgentOS?.fleet?.registryBridge;
 
+        // BEFORE the early return — absence is newer knowledge and must invalidate an older pending
+        // read. See {@link #gridReadGeneration}.
+        const generation = ++me.gridReadGeneration;
+
         if (!grid?.store || typeof bridge?.fleetRoster !== 'function') {
             // no bridge/verb IS the cold truth — the spine banner must say so
             me.syncSpineBanner();
             return
         }
 
-        // captured BEFORE the await — see {@link #gridReadGeneration}
-        const generation = ++me.gridReadGeneration;
-
         try {
-            const {rows} = await boundedRead(Promise.resolve(bridge.fleetRoster()), me.livenessReadTimeout) ?? {};
+            me.gridReadInFlight++;
+
+            const {rows} = await boundedRead(
+                Promise.resolve(bridge.fleetRoster()),
+                me.livenessReadTimeout,
+                () => { me.gridReadInFlight-- }
+            ) ?? {};
 
             // the fence: a newer read started while this one was in flight, or the owner is gone.
             // Either way this answer is no longer this surface's truth to write.
@@ -1479,15 +1512,8 @@ class FleetCockpit extends Container {
         // against a bridge already failing to answer, which is precisely when piling on is worst.
         // Skipping a tick loses nothing: the next one reads the same live truth, only later.
         me.livenessTimerId = setInterval(() => {
-            if (!me.streamReadInFlight) {
-                me.streamReadInFlight = true;
-                me.loadActivity().finally(() => { me.streamReadInFlight = false })
-            }
-
-            if (!me.gridReadInFlight) {
-                me.gridReadInFlight = true;
-                me.loadRoster().finally(() => { me.gridReadInFlight = false })
-            }
+            if (me.streamReadInFlight < me.maxReadsInFlight) me.loadActivity();
+            if (me.gridReadInFlight   < me.maxReadsInFlight) me.loadRoster()
         }, me.livenessPollInterval)
     }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -257,7 +257,9 @@ class FleetCockpit extends Container {
     livenessPollInterval = LIVENESS_POLL_INTERVAL
     /**
      * The liveness re-poll timer id, owned for exact-once teardown. `null` = not running — the
-     * cockpit is pre-start or destroyed. Never leaks across destroy / pop-out / reattach.
+     * cockpit is pre-start or destroyed. It dies with {@link #destroy}; it deliberately SURVIVES
+     * pop-out and reattach, because those reparent the AgentDetail and leave this cockpit alive as
+     * its holder — a timer stopped there would strand the surface it still speaks for.
      * @member {Number|null} livenessTimerId=null
      * @protected
      */
@@ -1350,8 +1352,14 @@ class FleetCockpit extends Container {
      * @summary Stops the liveness owner — exact-once, and safe to call on a never-started cockpit.
      *
      * Bound to {@link #destroy} so the timer cannot outlive the surface it speaks for: a leaked
-     * interval would keep re-polling the bridge for a destroyed cockpit and write states onto
-     * detached children (the pop-out / reattach path destroys and re-creates this view).
+     * interval would keep re-polling the bridge on behalf of a destroyed cockpit and write states
+     * onto detached children — a timer that outlives its owner is a liar with no one left to
+     * correct it.
+     *
+     * NOT because of pop-out: {@link #popOutAgentDetail} reparents the AgentDetail into a vessel
+     * and this cockpit stays alive as its holder — reparent-never-recreate, which is the whole
+     * point of that path. The destroy that matters is the ordinary one (the shell tearing this view
+     * down), and it is the only one this needs to survive.
      * @protected
      */
     stopLiveness() {

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -231,15 +231,27 @@ class FleetCockpit extends Container {
      */
     gridAdapterState = 'sample'
     /**
-     * The liveness owner's retained safe reason for the CURRENT degrade — the honest "why" the spine
-     * banner names instead of generic copy. Written only on a wired→degraded transition, cleared on
-     * recovery, so a stale cause can never outlive the degrade it explained. `null` = either live, or
-     * degraded for a cause the owner never learned (the banner then falls back to generic copy rather
-     * than inventing one).
-     * @member {String|null} degradedReason=null
+     * The retained safe reason for the ROSTER surface's current degrade — the honest "why" the spine
+     * banner names instead of generic copy. `null` = this surface is either fine, or degraded for a
+     * cause the owner never learned (the banner then falls back to generic copy rather than
+     * inventing one).
+     *
+     * PER-SURFACE, not shared, and that is the whole point. One `degradedReason` for two
+     * independently-answering surfaces cannot know whose cause it holds: a healthy roster completing
+     * after a not-wired activity would clear the ACTIVITY's reason and drop the banner back to
+     * "Fleet server offline" — the exact lie the retained reason exists to prevent. Splitting the
+     * field makes that unrepresentable instead of merely guarded.
+     * @member {String|null} gridDegradedReason=null
      * @protected
      */
-    degradedReason = null
+    gridDegradedReason = null
+    /**
+     * The retained safe reason for the ACTIVITY surface's current degrade. See
+     * {@link #gridDegradedReason} for why these are per-surface rather than one shared field.
+     * @member {String|null} streamDegradedReason=null
+     * @protected
+     */
+    streamDegradedReason = null
     /**
      * The last authoritative (bridge-sourced) roster snapshot, kept so a slower store load — the
      * JSON sample seed racing {@link #loadRoster} — can never overwrite live truth
@@ -1228,19 +1240,19 @@ class FleetCockpit extends Container {
                 me.streamAdapterState = 'live';
                 me.streamEvents       = Array.isArray(events) ? events.slice().reverse() : [];
                 stream.set({adapterState: me.streamAdapterState, events: me.streamEvents});
-                me.clearDegradedReason()
+                me.clearDegradedReason('stream')
             } else if (capability?.state === 'degraded') {
                 me.streamAdapterState = 'stale';
                 stream.adapterState   = 'stale';
                 // the adapter's OWN reason outranks a guess — it saw the failure, we only saw the answer
-                me.degradedReason = toSafeDegradedReason(capability.reason)
+                me.streamDegradedReason = toSafeDegradedReason(capability.reason)
             } else if (capability) {
                 // The producer ANSWERED and said it is not wired (`not-wired`). The seed stays — the
                 // stream really is showing sample events, so its own state is honestly 'sample' — but
                 // an answer is not silence, and the difference is the whole point: a reachable server
                 // whose activity source is unconfigured is NOT an unreachable server. Retaining the
                 // reason is what lets the banner say which one it is instead of guessing the loudest.
-                me.degradedReason = toSafeDegradedReason(capability.reason)
+                me.streamDegradedReason = toSafeDegradedReason(capability.reason)
             }
             // NO capability at all (a torn/absent answer) → keep the 'sample' seed AND no reason:
             // we learned nothing, so the banner falls back to its generic copy rather than inventing
@@ -1306,7 +1318,7 @@ class FleetCockpit extends Container {
 
             me.gridAdapterState = 'live';
             grid.adapterState   = 'live';
-            me.clearDegradedReason()
+            me.clearDegradedReason('grid')
         } catch (error) {
             // fail-closed: the last-known roster STAYS rather than blanking the fleet — only the
             // state advances. A wired surface that stops answering is degraded, not cold: it is
@@ -1383,32 +1395,34 @@ class FleetCockpit extends Container {
      * @protected
      */
     degradeWiredSurface(surface, error, consumer = null) {
-        let me    = this,
-            field = surface === 'grid' ? 'gridAdapterState' : 'streamAdapterState';
+        let me     = this,
+            field  = surface === 'grid' ? 'gridAdapterState' : 'streamAdapterState',
+            reason = surface === 'grid' ? 'gridDegradedReason' : 'streamDegradedReason';
 
         // never-wired stays cold-honest: 'sample' already says "this is fixture data"
         if (me[field] === 'sample') return;
 
-        me[field]         = 'stale';
-        me.degradedReason = toSafeDegradedReason(error);
+        me[field]  = 'stale';
+        // this surface's cause, on this surface's field — never a shared slot a sibling can clear
+        me[reason] = toSafeDegradedReason(error);
 
         if (consumer) consumer.adapterState = 'stale'
     }
 
     /**
-     * @summary Clears the retained degrade reason once a surface answers again.
+     * @summary Clears ONE surface's retained degrade reason, once THAT surface answers cleanly.
      *
-     * Only the fully-recovered spine drops the reason: while the OTHER surface is still degraded the
-     * cause remains true and must keep rendering. Clearing on the first recovery would strand the
-     * banner on generic copy while a real, named degrade is still live.
+     * Scoped to the caller's own surface, because a reason is a fact about the surface that produced
+     * it and no other surface has standing to retract it. The shared-field version read both states
+     * and cleared when neither was `stale` — which meant a healthy roster erased a not-wired
+     * ACTIVITY's cause (the activity is `sample`, not `stale`, so the guard never saw it) and the
+     * banner regressed to "Fleet server offline" while the server was answering. The guard was not
+     * too weak; the field was shared, and no guard on a shared field can tell whose cause it holds.
+     * @param {String} surface `'grid'` | `'stream'` — the caller's own surface.
      * @protected
      */
-    clearDegradedReason() {
-        let me = this;
-
-        if (me.gridAdapterState !== 'stale' && me.streamAdapterState !== 'stale') {
-            me.degradedReason = null
-        }
+    clearDegradedReason(surface) {
+        this[surface === 'grid' ? 'gridDegradedReason' : 'streamDegradedReason'] = null
     }
 
     /**
@@ -1428,10 +1442,11 @@ class FleetCockpit extends Container {
             banner = me.getReference('fleet-spine-banner');
 
         if (banner) {
+            // each state travels WITH its own cause: the derivation reports the reason of the
+            // surface that decided the verdict, and no sibling can supply or silence it
             let {hidden, kind, text} = deriveSpineBanner({
-                degradedReason    : me.degradedReason,
-                gridAdapterState  : me.gridAdapterState,
-                streamAdapterState: me.streamAdapterState
+                grid  : {state: me.gridAdapterState,   reason: me.gridDegradedReason},
+                stream: {state: me.streamAdapterState, reason: me.streamDegradedReason}
             });
 
             // `text`, never `html`. The line now interpolates a RETAINED TRANSPORT STRING — the

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1343,8 +1343,14 @@ class FleetCockpit extends Container {
         try {
             me.streamReadInFlight++;
 
+            // `Promise.resolve().then(() => …)` — NOT `Promise.resolve(bridge.fleetActivity())`.
+            // The argument form evaluates the CALL first, so a SYNCHRONOUS throw lands in this
+            // method's catch before `boundedRead` ever attaches its settle hook, and the counter
+            // never comes back. Two sync throws consume the cap and suppress this surface forever —
+            // the leak, rebuilt inside the fix for the leak. Invoking INSIDE the chain turns a sync
+            // throw into a rejection of the tracked promise, so the reject path owns the release.
             const {capability, events} = await boundedRead(
-                Promise.resolve(bridge.fleetActivity()),
+                Promise.resolve().then(() => bridge.fleetActivity()),
                 me.livenessReadTimeout,
                 () => { me.streamReadInFlight-- }
             ) ?? {};
@@ -1432,8 +1438,10 @@ class FleetCockpit extends Container {
         try {
             me.gridReadInFlight++;
 
+            // invoked INSIDE the chain so a synchronous throw rejects the tracked promise rather
+            // than escaping before the settle hook attaches — see the activity twin
             const {rows} = await boundedRead(
-                Promise.resolve(bridge.fleetRoster()),
+                Promise.resolve().then(() => bridge.fleetRoster()),
                 me.livenessReadTimeout,
                 () => { me.gridReadInFlight-- }
             ) ?? {};

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -21,6 +21,50 @@ import {previewToOperation}     from '../../../../src/dashboard/dockPreviewContr
 import '../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the dock projection emits for tab zones
 
 /**
+ * The liveness re-poll cadence (ms). Slow enough that the cockpit is not a load generator against
+ * the fleet bridge, fast enough that a transport death is named while the operator is still looking
+ * at the surface that died.
+ * @type {Number}
+ */
+const LIVENESS_POLL_INTERVAL = 15000;
+
+/**
+ * Longest safe reason rendered on the spine banner — a transport error can carry an entire response
+ * body, and this line is one row of shell chrome, not a log viewer.
+ * @type {Number}
+ */
+const MAX_DEGRADED_REASON_LENGTH = 120;
+
+/**
+ * @summary Reduces an untrusted transport failure to one safe, operator-readable clause.
+ *
+ * A transport error is peer/network-authored text this shell republishes into operator-visible
+ * chrome, so it is redacted and bounded before it can ever render: credential-bearing forms are the
+ * realistic payload of a failing authenticated request (a bearer header or PAT echoed back in an
+ * error body), and the scheme rule must precede the `key: value` rule or `Authorization: Bearer x`
+ * matches `authorization`, stops at the space, and republishes the secret intact.
+ * @param {*} error Untrusted failure — an Error, a string reason, or anything else.
+ * @returns {String|null} A safe single-line clause, or `null` when the cause is unknowable (the
+ *     banner then renders its generic copy rather than inventing a cause).
+ * @private
+ */
+function toSafeDegradedReason(error) {
+    const raw = typeof error === 'string' ? error : error?.message;
+
+    if (typeof raw !== 'string' || !raw.trim()) return null;
+
+    const safe = raw
+        .replace(/\b(?:authorization\s*[:=]\s*)?bearer\s+[^\s,;)]+/gi, 'authorization=[redacted]')
+        .replace(/\b(authorization|token|secret|password|pat|credential)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
+        .replace(/\bgh[pousr]_[A-Za-z0-9_]+/g, '[redacted-token]')
+        .replace(/\bglpat-[A-Za-z0-9_-]+/g, '[redacted-token]')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    return safe ? safe.slice(0, MAX_DEGRADED_REASON_LENGTH) : null
+}
+
+/**
  * Recent fleet activity for the fixture-fed stream — the live A2A / PR / lane adapters
  * are the sibling leaves; this seeds the §01 activity zone with representative events (newest last;
  * ActivityStream reverses to newest-first).
@@ -187,6 +231,16 @@ class FleetCockpit extends Container {
      */
     gridAdapterState = 'sample'
     /**
+     * The liveness owner's retained safe reason for the CURRENT degrade — the honest "why" the spine
+     * banner names instead of generic copy. Written only on a wired→degraded transition, cleared on
+     * recovery, so a stale cause can never outlive the degrade it explained. `null` = either live, or
+     * degraded for a cause the owner never learned (the banner then falls back to generic copy rather
+     * than inventing one).
+     * @member {String|null} degradedReason=null
+     * @protected
+     */
+    degradedReason = null
+    /**
      * The last authoritative (bridge-sourced) roster snapshot, kept so a slower store load — the
      * JSON sample seed racing {@link #loadRoster} — can never overwrite live truth
      * (see {@link #onRosterStoreLoad}).
@@ -194,6 +248,20 @@ class FleetCockpit extends Container {
      * @protected
      */
     lastLiveRows = null
+    /**
+     * The liveness re-poll cadence (ms). Injectable so specs pin a deterministic cadence instead of
+     * sleeping on the production one.
+     * @member {Number} livenessPollInterval=LIVENESS_POLL_INTERVAL
+     * @protected
+     */
+    livenessPollInterval = LIVENESS_POLL_INTERVAL
+    /**
+     * The liveness re-poll timer id, owned for exact-once teardown. `null` = not running — the
+     * cockpit is pre-start or destroyed. Never leaks across destroy / pop-out / reattach.
+     * @member {Number|null} livenessTimerId=null
+     * @protected
+     */
+    livenessTimerId = null
     /**
      * Re-entrancy latch for {@link #onRosterStoreLoad}: the store fires `load` for its own
      * mutations (mutate → onCollectionMutate → load), so the guard's reconciliation adds/removals
@@ -353,7 +421,8 @@ class FleetCockpit extends Container {
         me.getReference('fleet-grid')?.store?.on({load: me.onRosterStoreLoad, recordChange: me.onDetailRecordChange, scope: me});
 
         me.loadActivity();
-        me.loadRoster()
+        me.loadRoster();
+        me.startLiveness()
     }
 
     /**
@@ -1098,6 +1167,7 @@ class FleetCockpit extends Container {
     destroy(...args) {
         let me = this;
 
+        me.stopLiveness();
         me.getReference('fleet-grid')?.store?.un({load: me.onRosterStoreLoad, recordChange: me.onDetailRecordChange, scope: me});
 
         Neo.currentWorker.un({
@@ -1155,14 +1225,18 @@ class FleetCockpit extends Container {
             if (capability?.state === 'wired') {
                 me.streamAdapterState = 'live';
                 me.streamEvents       = Array.isArray(events) ? events.slice().reverse() : [];
-                stream.set({adapterState: me.streamAdapterState, events: me.streamEvents})
+                stream.set({adapterState: me.streamAdapterState, events: me.streamEvents});
+                me.clearDegradedReason()
             } else if (capability?.state === 'degraded') {
                 me.streamAdapterState = 'stale';
-                stream.adapterState   = 'stale'
+                stream.adapterState   = 'stale';
+                // the adapter's OWN reason outranks a guess — it saw the failure, we only saw the answer
+                me.degradedReason = toSafeDegradedReason(capability.reason)
             }
             // not-wired / absent bridge → keep the honestly-labelled 'sample' seed
         } catch (error) {
-            // fail-closed: the sample seed stays rather than blanking the feed
+            // fail-closed: the last-known feed STAYS rather than blanking it — only the state advances
+            me.degradeWiredSurface('stream', error, stream)
         } finally {
             me.syncSpineBanner()
         }
@@ -1220,11 +1294,103 @@ class FleetCockpit extends Container {
             }
 
             me.gridAdapterState = 'live';
-            grid.adapterState   = 'live'
+            grid.adapterState   = 'live';
+            me.clearDegradedReason()
         } catch (error) {
-            // fail-closed: the last-known roster stays rather than blanking the fleet
+            // fail-closed: the last-known roster STAYS rather than blanking the fleet — only the
+            // state advances. A wired surface that stops answering is degraded, not cold: it is
+            // showing last-known LIVE rows, so claiming 'sample' would tell the operator they are
+            // looking at fixture data. Pre-wired failures keep the honest 'sample' seed.
+            me.degradeWiredSurface('grid', error, grid)
         } finally {
             me.syncSpineBanner()
+        }
+    }
+
+    /**
+     * @summary Starts the ongoing liveness owner — the mechanism that makes `live` mean live.
+     *
+     * Without it the cockpit polls once at construction (plus after settled lifecycle intents) and
+     * every failure exit fail-closed PRESERVES the last-known state, so once a surface reaches
+     * `live` a mid-session transport death never advances it: `live` silently decays into "was live
+     * once", which is the dishonest state this owner exists to kill.
+     *
+     * **Mechanism (Tier-2 decision, recorded here):** an interval re-poll of the EXISTING read verbs,
+     * not a separate ping. The contract requires the routing matrices in {@link #loadRoster} /
+     * {@link #loadActivity} to remain the state-writing seams — a ping would need its own
+     * failure→state mapping, i.e. a second writer that can disagree with the first. Re-driving the
+     * real verbs keeps exactly one truth path and inherits their fail-closed data semantics for
+     * free; the cost is a full roster payload per cadence, which {@link #reconcileRoster} already
+     * absorbs idempotently. Revisit if the payload cost ever outgrows the honesty it buys.
+     *
+     * Idempotent: a second call never stacks a timer.
+     * @protected
+     */
+    startLiveness() {
+        let me = this;
+
+        if (me.livenessTimerId !== null) return;
+
+        me.livenessTimerId = setInterval(() => {
+            me.loadActivity();
+            me.loadRoster()
+        }, me.livenessPollInterval)
+    }
+
+    /**
+     * @summary Stops the liveness owner — exact-once, and safe to call on a never-started cockpit.
+     *
+     * Bound to {@link #destroy} so the timer cannot outlive the surface it speaks for: a leaked
+     * interval would keep re-polling the bridge for a destroyed cockpit and write states onto
+     * detached children (the pop-out / reattach path destroys and re-creates this view).
+     * @protected
+     */
+    stopLiveness() {
+        let me = this;
+
+        if (me.livenessTimerId !== null) {
+            clearInterval(me.livenessTimerId);
+            me.livenessTimerId = null
+        }
+    }
+
+    /**
+     * @summary Advances ONE wired surface to the degraded truth and retains the safe reason.
+     *
+     * The state-writing seams stay {@link #loadRoster} / {@link #loadActivity}; this is their shared
+     * loss edge, not a second writer. A surface that never reached `live` is left on its honest
+     * `sample` seed — advancing it to `stale` would claim last-known data that never existed.
+     * @param {String} surface `'grid'|'stream'`.
+     * @param {*} error The transport failure (untrusted — never rendered raw).
+     * @param {Neo.component.Base|null} [consumer] The held child whose badge mirrors the owner state.
+     * @protected
+     */
+    degradeWiredSurface(surface, error, consumer = null) {
+        let me    = this,
+            field = surface === 'grid' ? 'gridAdapterState' : 'streamAdapterState';
+
+        // never-wired stays cold-honest: 'sample' already says "this is fixture data"
+        if (me[field] === 'sample') return;
+
+        me[field]         = 'stale';
+        me.degradedReason = toSafeDegradedReason(error);
+
+        if (consumer) consumer.adapterState = 'stale'
+    }
+
+    /**
+     * @summary Clears the retained degrade reason once a surface answers again.
+     *
+     * Only the fully-recovered spine drops the reason: while the OTHER surface is still degraded the
+     * cause remains true and must keep rendering. Clearing on the first recovery would strand the
+     * banner on generic copy while a real, named degrade is still live.
+     * @protected
+     */
+    clearDegradedReason() {
+        let me = this;
+
+        if (me.gridAdapterState !== 'stale' && me.streamAdapterState !== 'stale') {
+            me.degradedReason = null
         }
     }
 
@@ -1234,11 +1400,10 @@ class FleetCockpit extends Container {
      * spine renders nothing. Render-only over existing truth: the routing matrices in
      * {@link #loadRoster} / {@link #loadActivity} stay the sole state writers, and every one
      * of their exits (including the no-bridge guards — absence IS the cold truth) CALLS this.
-     * A call is not a truth transition: the loads run at construction plus after successful
-     * lifecycle intents, and their failure exits fail-closed PRESERVE last-known states — so
-     * once live, a mid-session transport loss does not advance the owner truth this renders.
-     * The ongoing liveness owner (loss/recovery transitions with a retained reason) is a
-     * dedicated follow-up mechanism, not this consumer.
+     * A call is not a truth transition: {@link #startLiveness} re-drives those same seams on a
+     * cadence, their loss edge ({@link #degradeWiredSurface}) advances a wired surface to `stale`
+     * with a retained safe reason, and recovery clears it — so the truth this renders now tracks
+     * the transport instead of freezing at the first `live`.
      * @protected
      */
     syncSpineBanner() {
@@ -1247,6 +1412,7 @@ class FleetCockpit extends Container {
 
         if (banner) {
             let {hidden, kind, text} = deriveSpineBanner({
+                degradedReason    : me.degradedReason,
                 gridAdapterState  : me.gridAdapterState,
                 streamAdapterState: me.streamAdapterState
             });

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -259,6 +259,18 @@ class FleetCockpit extends Container {
      */
     gridReadGeneration = 0
     /**
+     * Overlap suppression for the ROSTER surface — true while a liveness-driven read is unresolved.
+     *
+     * The generation fence keeps a late read from WRITING; this keeps it from being LAUNCHED. Without
+     * it, a transport slower than the cadence collects a new in-flight read every tick, forever,
+     * against a bridge that is already struggling — the "hung accumulation" half of the ingress
+     * contract. Only {@link #startLiveness} honours it: a direct call (boot, an explicit refresh) is
+     * an operator-meant read and is never suppressed.
+     * @member {Boolean} gridReadInFlight=false
+     * @protected
+     */
+    gridReadInFlight = false
+    /**
      * The retained safe reason for the ACTIVITY surface's current degrade. See
      * {@link #gridDegradedReason} for why these are per-surface rather than one shared field.
      * @member {String|null} streamDegradedReason=null
@@ -271,6 +283,12 @@ class FleetCockpit extends Container {
      * @protected
      */
     streamReadGeneration = 0
+    /**
+     * Overlap suppression for the ACTIVITY surface. See {@link #gridReadInFlight}.
+     * @member {Boolean} streamReadInFlight=false
+     * @protected
+     */
+    streamReadInFlight = false
     /**
      * The last authoritative (bridge-sourced) roster snapshot, kept so a slower store load — the
      * JSON sample seed racing {@link #loadRoster} — can never overwrite live truth
@@ -1409,9 +1427,21 @@ class FleetCockpit extends Container {
 
         if (me.livenessTimerId !== null) return;
 
+        // Per-surface overlap suppression, NOT just the generation fence. The fence makes a late read
+        // HARMLESS; it does not make it ABSENT. A transport slower than the cadence would have each
+        // tick launch another pair regardless of the unresolved prior one — unbounded in-flight reads
+        // against a bridge already failing to answer, which is precisely when piling on is worst.
+        // Skipping a tick loses nothing: the next one reads the same live truth, only later.
         me.livenessTimerId = setInterval(() => {
-            me.loadActivity();
-            me.loadRoster()
+            if (!me.streamReadInFlight) {
+                me.streamReadInFlight = true;
+                me.loadActivity().finally(() => { me.streamReadInFlight = false })
+            }
+
+            if (!me.gridReadInFlight) {
+                me.gridReadInFlight = true;
+                me.loadRoster().finally(() => { me.gridReadInFlight = false })
+            }
         }, me.livenessPollInterval)
     }
 

--- a/apps/agentos/view/fleet/spineBanner.mjs
+++ b/apps/agentos/view/fleet/spineBanner.mjs
@@ -1,41 +1,71 @@
 /**
  * @module apps/agentos/view/fleet/spineBanner
  * @summary The cockpit's per-SPINE honesty line: derives ONE shell-level status from the
- * owner-held adapter states, so the surface names WHY it shows sample or last-known data
+ * owner-held surface truths, so the surface names WHY it shows sample or last-known data
  * instead of failing silent. Render-only over existing truth — this module produces no probes.
  *
- * Precedence: `sample` (the spine is unreachable — cold) beats `stale` (reachable but degraded)
- * beats `live`. A fully live spine renders NOTHING — nominal earns zero pixels, the same
- * exception-based discipline the cards follow. Per-AGENT truth (wake/throttle telltales) is a
- * different surface; this line only speaks for the fleet transport itself.
+ * Precedence: `sample` (unreachable — cold) beats `stale` (reachable but degraded) beats `live`.
+ * A fully live spine renders NOTHING — nominal earns zero pixels, the same exception-based
+ * discipline the cards follow. Per-AGENT truth (wake/throttle telltales) is a different surface;
+ * this line only speaks for the fleet transport itself.
+ *
+ * **A reason belongs to a SURFACE, never to the spine.** This module used to take one loose
+ * `degradedReason` alongside two loose states, and that shape had a race it could not express: the
+ * roster and the activity feed answer independently, so a healthy roster completing after a
+ * not-wired activity would erase the activity's cause and drop the line back to "server offline" —
+ * the exact lie the retained reason exists to prevent. Pairing each state with its own reason makes
+ * that unrepresentable rather than merely fixed: the line reports the cause of the surface that
+ * actually decided the verdict.
  */
 
 /**
- * @summary Derives the spine banner from the two owner-held adapter states.
+ * @summary Picks the reason of the surface that DECIDED this verdict — never a sibling's.
+ *
+ * The first matching surface that carries a cause wins. A sibling in a different state has nothing
+ * to say about this one, and a sibling in the SAME state that learned no cause must not silence one
+ * that did.
+ * @param {Object[]} surfaces
+ * @param {String} state
+ * @returns {String|null}
+ * @private
+ */
+function reasonFor(surfaces, state) {
+    for (const surface of surfaces) {
+        if (surface?.state === state) {
+            const reason = typeof surface.reason === 'string' && surface.reason.trim();
+
+            if (reason) return reason
+        }
+    }
+
+    return null
+}
+
+/**
+ * @summary Derives the spine banner from the two owner-held surface truths.
  * @param {Object} options
- * @param {String} options.gridAdapterState   `'sample'|'stale'|'live'` — the roster surface truth.
- * @param {String} options.streamAdapterState `'sample'|'stale'|'live'` — the activity surface truth.
- * @param {String|null} [options.degradedReason] The liveness owner's retained safe reason for the
- *     current degrade. Named verbatim when present — the generic copy is the fallback for a degrade
- *     whose cause the owner never learned, so the line never invents a cause it cannot see.
+ * @param {{state: String, reason: ?String}} options.grid The roster surface: `'sample'|'stale'|'live'`
+ *     plus the safe cause the owner retained for THAT surface, if it learned one.
+ * @param {{state: String, reason: ?String}} options.stream The activity surface, same shape.
  * @returns {{hidden: Boolean, kind: String, text: String}} `kind` is `'live'|'cold'|'degraded'`
  *     — the class hook; `hidden` is `true` only for the fully live spine.
  */
-export function deriveSpineBanner({gridAdapterState, streamAdapterState, degradedReason = null}) {
-    const states = [gridAdapterState, streamAdapterState];
+export function deriveSpineBanner({grid, stream}) {
+    const surfaces = [grid, stream],
+          states   = surfaces.map(surface => surface?.state);
 
     if (states.includes('sample')) {
-        const reason = typeof degradedReason === 'string' && degradedReason.trim();
+        const reason = reasonFor(surfaces, 'sample');
 
         return {
             hidden: false,
             kind  : 'cold',
-            // Same discipline the `stale` line follows, and for the same reason: name the retained
-            // cause when the owner HAS one, guess only when it does not. A reachable server whose
-            // source is unconfigured answers `not-wired` — the seed stays, so the data really is
-            // sample, but "start the server" would be advice to restart a process that just replied.
-            // The generic copy is the fallback for silence, which is the only state that actually
-            // implies an offline server.
+            // Same discipline the `stale` line follows: name the retained cause when the owner HAS
+            // one, guess only when it does not. A reachable server whose source is unconfigured
+            // answers `not-wired` — the seed stays, so the data really is sample, but "start the
+            // server" would be advice to restart a process that just replied. The generic copy is
+            // the fallback for SILENCE, which is the only state that actually implies an offline
+            // server.
             text: reason
                 ? `Fleet data unavailable — showing sample data · ${reason}`
                 : 'Fleet server offline — showing sample data · start it: npm run ai:fleet-server'
@@ -43,7 +73,7 @@ export function deriveSpineBanner({gridAdapterState, streamAdapterState, degrade
     }
 
     if (states.includes('stale')) {
-        const reason = typeof degradedReason === 'string' && degradedReason.trim();
+        const reason = reasonFor(surfaces, 'stale');
 
         return {
             hidden: false,

--- a/apps/agentos/view/fleet/spineBanner.mjs
+++ b/apps/agentos/view/fleet/spineBanner.mjs
@@ -25,10 +25,20 @@ export function deriveSpineBanner({gridAdapterState, streamAdapterState, degrade
     const states = [gridAdapterState, streamAdapterState];
 
     if (states.includes('sample')) {
+        const reason = typeof degradedReason === 'string' && degradedReason.trim();
+
         return {
             hidden: false,
             kind  : 'cold',
-            text  : 'Fleet server offline — showing sample data · start it: npm run ai:fleet-server'
+            // Same discipline the `stale` line follows, and for the same reason: name the retained
+            // cause when the owner HAS one, guess only when it does not. A reachable server whose
+            // source is unconfigured answers `not-wired` — the seed stays, so the data really is
+            // sample, but "start the server" would be advice to restart a process that just replied.
+            // The generic copy is the fallback for silence, which is the only state that actually
+            // implies an offline server.
+            text: reason
+                ? `Fleet data unavailable — showing sample data · ${reason}`
+                : 'Fleet server offline — showing sample data · start it: npm run ai:fleet-server'
         }
     }
 

--- a/apps/agentos/view/fleet/spineBanner.mjs
+++ b/apps/agentos/view/fleet/spineBanner.mjs
@@ -15,10 +15,13 @@
  * @param {Object} options
  * @param {String} options.gridAdapterState   `'sample'|'stale'|'live'` — the roster surface truth.
  * @param {String} options.streamAdapterState `'sample'|'stale'|'live'` — the activity surface truth.
+ * @param {String|null} [options.degradedReason] The liveness owner's retained safe reason for the
+ *     current degrade. Named verbatim when present — the generic copy is the fallback for a degrade
+ *     whose cause the owner never learned, so the line never invents a cause it cannot see.
  * @returns {{hidden: Boolean, kind: String, text: String}} `kind` is `'live'|'cold'|'degraded'`
  *     — the class hook; `hidden` is `true` only for the fully live spine.
  */
-export function deriveSpineBanner({gridAdapterState, streamAdapterState}) {
+export function deriveSpineBanner({gridAdapterState, streamAdapterState, degradedReason = null}) {
     const states = [gridAdapterState, streamAdapterState];
 
     if (states.includes('sample')) {
@@ -30,10 +33,14 @@ export function deriveSpineBanner({gridAdapterState, streamAdapterState}) {
     }
 
     if (states.includes('stale')) {
+        const reason = typeof degradedReason === 'string' && degradedReason.trim();
+
         return {
             hidden: false,
             kind  : 'degraded',
-            text  : 'Fleet feed degraded — showing last-known data'
+            text  : reason
+                ? `Fleet feed degraded — showing last-known data · ${reason}`
+                : 'Fleet feed degraded — showing last-known data'
         }
     }
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1223,10 +1223,15 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
 
 /**
  * The liveness owner's LIFECYCLE witness. A transition matrix proves the owner tells the truth while
- * it runs; this proves it stops running. The pop-out / reattach path destroys and re-creates the
- * cockpit, so a leaked interval would keep re-polling the bridge on behalf of a destroyed surface
- * and write states onto detached children — a timer that outlives its owner is a liar with no one
- * left to correct it.
+ * it runs; this proves it stops running. A leaked interval would keep re-polling the bridge on behalf
+ * of a destroyed cockpit and write states onto detached children — a timer that outlives its owner is
+ * a liar with no one left to correct it.
+ *
+ * The destroy that matters is the ordinary one, the shell tearing this view down. NOT pop-out: that
+ * path reparents the AgentDetail into a vessel and leaves the cockpit alive as its holder
+ * (reparent-never-recreate), so the timer must SURVIVE it — stopping there would strand the surface
+ * it still speaks for. Start-idempotence is the guard for that direction: a reattach that re-ran
+ * start on a live cockpit would silently double the poll rate against the bridge.
  */
 test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #15293)', () => {
     let FleetCockpit;

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -79,6 +79,7 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
                   getReference        : reference => reference === 'activity-stream' ? stream : null,
                   streamAdapterState  : 'sample',
                   streamDegradedReason: null,
+                  streamReadGeneration: 0,
                   syncSpineBanner     : FleetCockpit.prototype.syncSpineBanner
               };
 
@@ -212,6 +213,10 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         // mirrors the class field default — the loss edge reads it to keep a never-wired surface
         // on its honest sample seed instead of claiming last-known data
         gridAdapterState,
+        // …and the async-ingress fence reads this one. Omitting it is not a benign gap: `++undefined`
+        // is NaN, `NaN !== NaN`, so the read's generation never matches the owner's and EVERY read
+        // drops itself — silently, with a green suite full of unwritten state.
+        gridReadGeneration: 0,
         mapRosterRow      : FleetCockpit.prototype.mapRosterRow,
         reconcileRoster   : FleetCockpit.prototype.reconcileRoster,
         reconcileSelection: FleetCockpit.prototype.reconcileSelection,
@@ -458,6 +463,9 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             grid,
             // mirrors the class field defaults the loss edge reads
             gridAdapterState  : 'sample',
+            // …and the async-ingress fence: omit it and `++undefined` is NaN, so the read's own
+            // generation never equals the owner's and EVERY read silently drops itself
+            gridReadGeneration: 0,
             id                : `fake-fleet-cockpit-${index}`,
             lastLiveRows      : null,
             mapRosterRow      : FleetCockpit.prototype.mapRosterRow,
@@ -1002,11 +1010,15 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
 
         // a REAL store the REAL loadRoster reconciles into — the record is the card's data surface
         const store   = Neo.create(Store, {keyProperty: 'agentId', model: FleetAgent});
+        // `gridReadGeneration` mirrors the class default because the async-ingress fence reads it: a
+        // fake omitting it makes `++undefined` NaN, so the read's generation never matches the
+        // owner's and EVERY read silently drops itself — a green suite over state nobody wrote.
         const cockpit = {
             clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
             degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
             getReference       : reference => reference === 'fleet-grid' ? {adapterState: 'sample', store} : null,
             gridAdapterState   : 'sample',
+            gridReadGeneration : 0,
             mapRosterRow       : FleetCockpit.prototype.mapRosterRow,
             reconcileRoster    : FleetCockpit.prototype.reconcileRoster,
             reconcileSelection : FleetCockpit.prototype.reconcileSelection,
@@ -1125,6 +1137,7 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
             loadActivity        : FleetCockpit.prototype.loadActivity,
             streamAdapterState  : 'live',
             streamDegradedReason: null,
+            streamReadGeneration: 0,
             streamEvents        : [],
             syncSpineBanner     : FleetCockpit.prototype.syncSpineBanner
         }
@@ -1255,6 +1268,59 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
 
         expect(text).toContain('fleet activity source not wired');
         expect(text, 'the lie the retained reason exists to prevent').not.toContain('Fleet server offline')
+    });
+
+    test('an OLDER failed completion never overwrites a NEWER success — @neo-gpt\'s second probe', async () => {
+        // The interval re-drives both seams, so two reads of the SAME surface are in flight at once
+        // and complete in any order. Without a fence the LOSER writes last: a slow failure landing
+        // after a fast success regresses live → stale on strictly older news, and the banner names a
+        // degrade that already recovered. The catch is not exempt from ordering just because it is
+        // the sad path — that is the branch this pins.
+        const banner = makeBanner(),
+              host   = makeLivenessHost(banner);
+
+        let releaseSlow;
+        const slow = new Promise((resolve, reject) => { releaseSlow = () => reject(new Error('stale transport lost')) });
+
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetActivity: () => slow}};
+        const slowRead = host.loadActivity();       // read 1 — in flight, will FAIL
+
+        // read 2 starts and wins outright while read 1 is still hanging
+        globalThis.AgentOS.fleet.registryBridge.fleetActivity = async () => ({capability: {state: 'wired'}, events: []});
+        await host.loadActivity();
+
+        expect(host.streamAdapterState).toBe('live');
+
+        releaseSlow();                              // read 1 finally fails, LATE
+        await slowRead;
+
+        expect(host.streamAdapterState, 'older news must not unseat newer truth').toBe('live');
+        expect(host.streamDegradedReason ?? null, 'a superseded read may not name a degrade').toBe(null);
+        expect(banner.calls.at(-1).hidden, 'nor repaint the banner it was not allowed to write').toBe(true);
+
+        delete globalThis.AgentOS.fleet
+    });
+
+    test('a read completing after destroy mutates NOTHING — no post-destroy writes', async () => {
+        const banner = makeBanner(),
+              host   = makeLivenessHost(banner);
+
+        let releaseSlow;
+        const slow = new Promise(resolve => { releaseSlow = () => resolve({capability: {state: 'degraded', reason: 'late'}, events: []}) });
+
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetActivity: () => slow}};
+        const inFlight = host.loadActivity();
+
+        host.isDestroyed = true;                    // the owner goes away mid-read
+        releaseSlow();
+        await inFlight;
+
+        // a timer that outlives its owner is a liar with no one left to correct it — and so is a read
+        expect(host.streamAdapterState).toBe('live');
+        expect(host.streamDegradedReason ?? null).toBe(null);
+        expect(banner.calls, 'a dead surface renders nothing').toHaveLength(0);
+
+        delete globalThis.AgentOS.fleet
     });
 
     test('hostile markup in a reason renders INERT — the sink is text, never html', async () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1450,6 +1450,68 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
         }
     });
 
+    test('a read that NEVER settles must not freeze the surface — @neo-gpt\'s latch falsifier', async () => {
+        // I fixed unbounded accumulation and introduced permanent freeze. His words, and they're
+        // exact: "the surface can stay last-known live forever, which recreates the original defect."
+        //
+        // The latch releases in a `.finally()`. A promise that never settles never runs it, so the
+        // slot is held FOREVER and every later tick is suppressed — including the one that would
+        // have noticed the transport recovering. A liveness owner that stops polling is the precise
+        // thing this ticket exists to prevent, rebuilt from the other side by its own guard.
+        //
+        // The bound is what makes the latch safe to hold: a read may fail, it may never hang — the
+        // same contract `detailVesselConnectWindowMs` already states for the vessel admission.
+        // drives the REAL loadActivity against a REAL hanging bridge — the fake read of an earlier
+        // draft would have replaced the very `boundedRead` under test with a stub of my own optimism
+        const stream = {adapterState: 'live', set() {}},
+              host   = {
+                  ...makeTimerHost(),
+                  clearDegradedReason : FleetCockpit.prototype.clearDegradedReason,
+                  degradeWiredSurface : FleetCockpit.prototype.degradeWiredSurface,
+                  getReference        : reference => reference === 'activity-stream' ? stream : null,
+                  streamAdapterState  : 'live',
+                  streamDegradedReason: null,
+                  streamReadGeneration: 0,
+                  streamReadInFlight  : false,
+                  syncSpineBanner     : FleetCockpit.prototype.syncSpineBanner
+              };
+
+        let tick, calls = 0;
+
+        host.livenessReadTimeout = 5;                 // short window; the spec pins it, never sleeps on prod
+        host.loadActivity        = FleetCockpit.prototype.loadActivity;
+        host.loadRoster          = () => Promise.resolve();
+
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetActivity: () => {
+            calls++;
+            // read 1 hangs FOREVER; later reads answer at once — the recovery this must find
+            return calls === 1 ? new Promise(() => {}) : Promise.resolve({capability: {state: 'wired'}, events: []})
+        }}};
+
+        const originalSetInterval = globalThis.setInterval;
+        globalThis.setInterval = fn => { tick = fn; return 1 };
+
+        try {
+            host.startLiveness();
+
+            tick();                                            // read 1 — hangs forever
+            expect(calls).toBe(1);
+
+            await new Promise(resolve => setTimeout(resolve, 40));   // outlive the bounded window
+
+            tick();                                            // the transport recovered; this MUST probe
+            expect(calls, 'a hung read must not suppress the probe that would notice recovery').toBe(2);
+
+            await new Promise(resolve => setTimeout(resolve, 40));
+
+            tick();
+            expect(calls, 'and liveness must keep running, not limp once').toBe(3)
+        } finally {
+            globalThis.setInterval = originalSetInterval;
+            delete globalThis.AgentOS.fleet
+        }
+    });
+
     test('a tick NEVER launches a read while that surface still has one in flight', async () => {
         // @neo-gpt's fourth finding, and the one the generation fence does NOT reach: the fence makes
         // a late read HARMLESS, not ABSENT. A transport slower than the 15s cadence would have every

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -62,10 +62,17 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
 
         const stream = makeStream(),
               // the real banner sync runs against this fake: its getReference returns null for
-              // the banner slot, so the guard no-ops — production code, no stub drift
+              // the banner slot, so the guard no-ops — production code, no stub drift. The loss
+              // edge + recovery clear are wired from the prototype for the same reason, and
+              // `streamAdapterState` mirrors the class field default because the never-wired
+              // guard reads it: a fake missing it would let a pre-wired throw claim last-known
+              // data that never existed.
               cockpit = {
-                  getReference   : reference => reference === 'activity-stream' ? stream : null,
-                  syncSpineBanner: FleetCockpit.prototype.syncSpineBanner
+                  clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
+                  degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
+                  getReference       : reference => reference === 'activity-stream' ? stream : null,
+                  streamAdapterState : 'sample',
+                  syncSpineBanner    : FleetCockpit.prototype.syncSpineBanner
               };
 
         await FleetCockpit.prototype.loadActivity.call(cockpit);
@@ -158,14 +165,19 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         return {adapterState: 'sample', store}
     };
 
-    const makeCockpit = (grid, rosterWired = false) => ({
-        getReference      : reference => reference === 'fleet-grid' ? grid : null,
+    const makeCockpit = (grid, rosterWired = false, gridAdapterState = 'sample') => ({
+        clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
+        degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
+        getReference       : reference => reference === 'fleet-grid' ? grid : null,
+        // mirrors the class field default — the loss edge reads it to keep a never-wired surface
+        // on its honest sample seed instead of claiming last-known data
+        gridAdapterState,
         mapRosterRow      : FleetCockpit.prototype.mapRosterRow,
         reconcileRoster   : FleetCockpit.prototype.reconcileRoster,
         reconcileSelection: FleetCockpit.prototype.reconcileSelection,
         rosterWired,
         // the real banner sync: null getReference for the slot → guarded no-op, no stub drift
-        syncSpineBanner   : FleetCockpit.prototype.syncSpineBanner
+        syncSpineBanner    : FleetCockpit.prototype.syncSpineBanner
     });
 
     const routeLoadRoster = async (bridge, {known, items, rosterWired} = {}) => {
@@ -398,10 +410,14 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         const cockpit = {
             // the real accessor runs against this fake's getReference — the detail consumers
             // route through it (docked: projected pane; detached: the owner-held handle)
-            detachedDetailPane: null,
-            getAgentDetailPane: FleetCockpit.prototype.getAgentDetailPane,
-            getReference      : reference => reference === 'fleet-grid' ? grid : reference === 'agent-detail' ? detail : null,
+            detachedDetailPane : null,
+            getAgentDetailPane : FleetCockpit.prototype.getAgentDetailPane,
+            clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
+            degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
+            getReference       : reference => reference === 'fleet-grid' ? grid : reference === 'agent-detail' ? detail : null,
             grid,
+            // mirrors the class field defaults the loss edge reads
+            gridAdapterState  : 'sample',
             id                : `fake-fleet-cockpit-${index}`,
             lastLiveRows      : null,
             mapRosterRow      : FleetCockpit.prototype.mapRosterRow,
@@ -411,7 +427,7 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             reconcilingRoster : false,
             rosterWired       : false,
             // the real banner sync: null getReference for the slot → guarded no-op, no stub drift
-            syncSpineBanner   : FleetCockpit.prototype.syncSpineBanner
+            syncSpineBanner    : FleetCockpit.prototype.syncSpineBanner
         };
 
         store.on({load: cockpit.onRosterStoreLoad, scope: cockpit});
@@ -947,14 +963,17 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
         // a REAL store the REAL loadRoster reconciles into — the record is the card's data surface
         const store   = Neo.create(Store, {keyProperty: 'agentId', model: FleetAgent});
         const cockpit = {
-            getReference      : reference => reference === 'fleet-grid' ? {adapterState: 'sample', store} : null,
-            mapRosterRow      : FleetCockpit.prototype.mapRosterRow,
-            reconcileRoster   : FleetCockpit.prototype.reconcileRoster,
-            reconcileSelection: FleetCockpit.prototype.reconcileSelection,
-            loadRoster        : FleetCockpit.prototype.loadRoster,
-            rosterWired       : false,
+            clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
+            degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
+            getReference       : reference => reference === 'fleet-grid' ? {adapterState: 'sample', store} : null,
+            gridAdapterState   : 'sample',
+            mapRosterRow       : FleetCockpit.prototype.mapRosterRow,
+            reconcileRoster    : FleetCockpit.prototype.reconcileRoster,
+            reconcileSelection : FleetCockpit.prototype.reconcileSelection,
+            loadRoster         : FleetCockpit.prototype.loadRoster,
+            rosterWired        : false,
             // the real banner sync: null getReference for the slot → guarded no-op, no stub drift
-            syncSpineBanner   : FleetCockpit.prototype.syncSpineBanner
+            syncSpineBanner    : FleetCockpit.prototype.syncSpineBanner
         };
 
         // boot: the real loadRoster reads the bridge — the agent is stopped, so the record resolves to 'off'
@@ -1049,33 +1068,113 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         expect(banner.calls[0]).toEqual({cls: ['fm-spine-banner', 'fm-spine-banner-live'], hidden: true, html: ''})
     });
 
-    test('owner-truth immobility: once live, a thrown load PRESERVES live and the slot stays hidden', async () => {
-        // the boundary this leaf does NOT cross, pinned as a spec: the loads fail-closed PRESERVE
-        // owner states, so a post-live transport loss never advances the truth this consumer
-        // renders — the loss/recovery transition is the dedicated liveness owner's contract
-        const banner = makeBanner(),
-              stream = {adapterState: 'live', set() {}},
-              host   = {
-                  getReference: reference =>
-                      reference === 'fleet-spine-banner' ? banner :
-                      reference === 'activity-stream'    ? stream : null,
-                  gridAdapterState  : 'live',
-                  streamAdapterState: 'live',
-                  loadActivity      : FleetCockpit.prototype.loadActivity,
-                  syncSpineBanner   : FleetCockpit.prototype.syncSpineBanner
-              };
+    /**
+     * @summary Builds a live host driving the REAL loadActivity through the REAL loss edge.
+     */
+    const makeLivenessHost = banner => {
+        const stream = {adapterState: 'live', set() {}};
 
-        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetActivity: async () => { throw new Error('transport lost') }}};
+        return {
+            clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
+            degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
+            degradedReason     : null,
+            getReference       : reference =>
+                reference === 'fleet-spine-banner' ? banner :
+                reference === 'activity-stream'    ? stream : null,
+            gridAdapterState  : 'live',
+            loadActivity      : FleetCockpit.prototype.loadActivity,
+            streamAdapterState: 'live',
+            streamEvents      : [],
+            syncSpineBanner   : FleetCockpit.prototype.syncSpineBanner
+        }
+    };
+
+    const withBridge = async (fleetActivity, host) => {
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetActivity}};
 
         try {
             await host.loadActivity()
         } finally {
             delete globalThis.AgentOS?.fleet
         }
+    };
+
+    test('owner-truth MOBILITY: once live, a thrown load advances to stale and the slot NAMES the loss', async () => {
+        // This inverts the immobility pin that previously stood here. That spec recorded the gap on
+        // purpose — "the loss/recovery transition is the dedicated liveness owner's contract" — and
+        // this leaf IS that owner, so the pin is discharged, not broken. `live` must stop meaning
+        // "was live once": a transport death the operator can't see is the dishonest state.
+        const banner = makeBanner(),
+              host   = makeLivenessHost(banner);
+
+        await withBridge(async () => { throw new Error('transport lost') }, host);
+
+        expect(host.streamAdapterState).toBe('stale');
+        expect(host.degradedReason).toBe('transport lost');
+        expect(banner.calls[0].hidden).toBe(false);
+        expect(banner.calls[0].cls).toContain('fm-spine-banner-degraded');
+        // the retained reason is NAMED, not generic copy
+        expect(banner.calls[0].html).toContain('transport lost');
+        expect(banner.calls[0].html).toContain('last-known')
+    });
+
+    test('recovery: a later successful poll returns live, clears the reason, and re-hides the slot', async () => {
+        const banner = makeBanner(),
+              host   = makeLivenessHost(banner);
+
+        await withBridge(async () => { throw new Error('transport lost') }, host);
+        expect(host.streamAdapterState).toBe('stale');
+
+        await withBridge(async () => ({capability: {state: 'wired'}, events: []}), host);
 
         expect(host.streamAdapterState).toBe('live');
-        expect(banner.calls).toHaveLength(1);
-        expect(banner.calls[0].hidden).toBe(true)
+        expect(host.degradedReason, 'a stale cause must never outlive the degrade it explained').toBe(null);
+        expect(banner.calls.at(-1).hidden).toBe(true)
+    });
+
+    test('the retained reason survives while the OTHER surface is still degraded', async () => {
+        // clearing on the first recovery would strand the banner on generic copy while a real,
+        // named degrade is still live on the sibling surface
+        const banner = makeBanner(),
+              host   = makeLivenessHost(banner);
+
+        host.gridAdapterState = 'stale';
+        host.degradedReason   = 'roster bridge unreachable';
+
+        await withBridge(async () => ({capability: {state: 'wired'}, events: []}), host);
+
+        expect(host.streamAdapterState).toBe('live');
+        expect(host.degradedReason).toBe('roster bridge unreachable');
+        expect(banner.calls.at(-1).hidden).toBe(false);
+        expect(banner.calls.at(-1).html).toContain('roster bridge unreachable')
+    });
+
+    test('a never-wired surface stays cold-honest: a pre-live throw never claims last-known data', async () => {
+        const banner = makeBanner(),
+              host   = makeLivenessHost(banner);
+
+        host.streamAdapterState = 'sample';
+
+        await withBridge(async () => { throw new Error('transport lost') }, host);
+
+        // 'stale' would tell the operator we are showing last-known data that never existed
+        expect(host.streamAdapterState).toBe('sample');
+        expect(host.degradedReason).toBe(null)
+    });
+
+    test('the degraded reason is redacted + bounded before it reaches operator-visible chrome', async () => {
+        const banner = makeBanner(),
+              host   = makeLivenessHost(banner);
+
+        await withBridge(async () => { throw new Error('502 from bridge (Authorization: Bearer super-secret)') }, host);
+
+        expect(host.degradedReason).not.toContain('super-secret');
+        expect(host.degradedReason).toContain('502 from bridge');
+        expect(banner.calls[0].html).not.toContain('super-secret');
+
+        const long = makeLivenessHost(makeBanner());
+        await withBridge(async () => { throw new Error('x'.repeat(400)) }, long);
+        expect(long.degradedReason.length).toBeLessThanOrEqual(120)
     });
 
     test('a missing slot is a guarded no-op — never a throw', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -74,11 +74,12 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
               // guard reads it: a fake missing it would let a pre-wired throw claim last-known
               // data that never existed.
               cockpit = {
-                  clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
-                  degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
-                  getReference       : reference => reference === 'activity-stream' ? stream : null,
-                  streamAdapterState : 'sample',
-                  syncSpineBanner    : FleetCockpit.prototype.syncSpineBanner
+                  clearDegradedReason : FleetCockpit.prototype.clearDegradedReason,
+                  degradeWiredSurface : FleetCockpit.prototype.degradeWiredSurface,
+                  getReference        : reference => reference === 'activity-stream' ? stream : null,
+                  streamAdapterState  : 'sample',
+                  streamDegradedReason: null,
+                  syncSpineBanner     : FleetCockpit.prototype.syncSpineBanner
               };
 
         await FleetCockpit.prototype.loadActivity.call(cockpit);
@@ -98,14 +99,14 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
         expect(stream.adapterState).toBe('sample');
         // SILENCE: the owner learned nothing, so it retains no cause. This is what lets the banner
         // fall back to "server offline" honestly — it is the only state that implies one.
-        expect(cockpit.degradedReason ?? null).toBe(null)
+        expect(cockpit.streamDegradedReason ?? null).toBe(null)
     });
 
     test('a bridge without fleetActivity → keeps the sample seed', async () => {
         const {stream, cockpit} = await routeLoadActivity({});
 
         expect(stream.adapterState).toBe('sample');
-        expect(cockpit.degradedReason ?? null).toBe(null)
+        expect(cockpit.streamDegradedReason ?? null).toBe(null)
     });
 
     test('not-wired capability → keeps the sample seed AND retains the producer’s reason', async () => {
@@ -123,7 +124,7 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
 
         expect(stream.adapterState).toBe('sample');
         expect(cockpit.streamAdapterState).toBe('sample');
-        expect(cockpit.degradedReason).toBe('fleet activity source not wired')
+        expect(cockpit.streamDegradedReason).toBe('fleet activity source not wired')
     });
 
     test('not-wired WITHOUT a reason retains none — the producer said nothing to relay', async () => {
@@ -131,7 +132,7 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
         // not manufacture one. Falls back to the generic offline copy, which is correct here.
         const {cockpit} = await routeLoadActivity({fleetActivity: async () => ({capability: {state: 'not-wired'}, events: []})});
 
-        expect(cockpit.degradedReason ?? null).toBe(null)
+        expect(cockpit.streamDegradedReason ?? null).toBe(null)
     });
 
     test('degraded capability → the stale banner', async () => {
@@ -163,7 +164,7 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
         expect(stream.adapterState).toBe('live');
         expect(stream.events).toEqual([]);
         // recovery clears the retained cause — a stale reason on a live feed would outlive its truth
-        expect(cockpit.degradedReason ?? null).toBe(null)
+        expect(cockpit.streamDegradedReason ?? null).toBe(null)
     });
 });
 
@@ -1116,15 +1117,16 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         return {
             clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
             degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
-            degradedReason     : null,
             getReference       : reference =>
                 reference === 'fleet-spine-banner' ? banner :
                 reference === 'activity-stream'    ? stream : null,
-            gridAdapterState  : 'live',
-            loadActivity      : FleetCockpit.prototype.loadActivity,
-            streamAdapterState: 'live',
-            streamEvents      : [],
-            syncSpineBanner   : FleetCockpit.prototype.syncSpineBanner
+            gridAdapterState    : 'live',
+            gridDegradedReason  : null,
+            loadActivity        : FleetCockpit.prototype.loadActivity,
+            streamAdapterState  : 'live',
+            streamDegradedReason: null,
+            streamEvents        : [],
+            syncSpineBanner     : FleetCockpit.prototype.syncSpineBanner
         }
     };
 
@@ -1149,7 +1151,7 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         await withBridge(async () => { throw new Error('transport lost') }, host);
 
         expect(host.streamAdapterState).toBe('stale');
-        expect(host.degradedReason).toBe('transport lost');
+        expect(host.streamDegradedReason).toBe('transport lost');
         expect(banner.calls[0].hidden).toBe(false);
         expect(banner.calls[0].cls).toContain('fm-spine-banner-degraded');
         // the retained reason is NAMED, not generic copy
@@ -1167,7 +1169,7 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         await withBridge(async () => ({capability: {state: 'wired'}, events: []}), host);
 
         expect(host.streamAdapterState).toBe('live');
-        expect(host.degradedReason, 'a stale cause must never outlive the degrade it explained').toBe(null);
+        expect(host.streamDegradedReason, 'a stale cause must never outlive the degrade it explained').toBe(null);
         expect(banner.calls.at(-1).hidden).toBe(true)
     });
 
@@ -1178,12 +1180,12 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
               host   = makeLivenessHost(banner);
 
         host.gridAdapterState = 'stale';
-        host.degradedReason   = 'roster bridge unreachable';
+        host.gridDegradedReason = 'roster bridge unreachable';
 
         await withBridge(async () => ({capability: {state: 'wired'}, events: []}), host);
 
         expect(host.streamAdapterState).toBe('live');
-        expect(host.degradedReason).toBe('roster bridge unreachable');
+        expect(host.gridDegradedReason).toBe('roster bridge unreachable');
         expect(banner.calls.at(-1).hidden).toBe(false);
         expect(banner.calls.at(-1).text).toContain('roster bridge unreachable')
     });
@@ -1198,7 +1200,7 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
 
         // 'stale' would tell the operator we are showing last-known data that never existed
         expect(host.streamAdapterState).toBe('sample');
-        expect(host.degradedReason).toBe(null)
+        expect(host.streamDegradedReason).toBe(null)
     });
 
     test('the degraded reason is redacted + bounded before it reaches operator-visible chrome', async () => {
@@ -1207,13 +1209,52 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
 
         await withBridge(async () => { throw new Error('502 from bridge (Authorization: Bearer super-secret)') }, host);
 
-        expect(host.degradedReason).not.toContain('super-secret');
-        expect(host.degradedReason).toContain('502 from bridge');
+        expect(host.streamDegradedReason).not.toContain('super-secret');
+        expect(host.streamDegradedReason).toContain('502 from bridge');
         expect(banner.calls[0].text).not.toContain('super-secret');
 
         const long = makeLivenessHost(makeBanner());
         await withBridge(async () => { throw new Error('x'.repeat(400)) }, long);
-        expect(long.degradedReason.length).toBeLessThanOrEqual(120)
+        expect(long.streamDegradedReason.length).toBeLessThanOrEqual(120)
+    });
+
+    test('a healthy SIBLING never erases this surface\'s retained reason — @neo-gpt\'s red proof', async () => {
+        // His exact falsifier, and it defeated the cold-line fix completely. One shared
+        // `degradedReason` for two independently-answering surfaces cannot know whose cause it holds:
+        //
+        //   1. loadActivity resolves first: {state:'not-wired', reason:'…'} → reason retained
+        //   2. the healthy roster resolves {rows:[]} → clearDegradedReason() ran, saw grid=live and
+        //      stream=SAMPLE (not stale, so the guard never noticed it), and erased the activity's
+        //      cause → banner regressed to "Fleet server offline" while the server was answering.
+        //
+        // The guard was not too weak — the FIELD was shared, and no guard on a shared field can tell
+        // whose cause it holds. Per-surface ownership makes the race unrepresentable rather than
+        // guarded, which is why this is a field split and not another condition.
+        const banner = makeBanner(),
+              host   = makeLivenessHost(banner);
+
+        // the stream sits on its SEED, which is the real state when a not-wired answer arrives — the
+        // not-wired branch deliberately leaves the state alone (the feed really is showing sample
+        // events), so a host starting at 'live' would stay 'live' and never reach the cold line at
+        // all. My first version of this witness did exactly that and passed for the wrong reason.
+        host.streamAdapterState = 'sample';
+
+        // 1. the activity surface answers not-wired and retains its own cause
+        await withBridge(async () => ({capability: {state: 'not-wired', reason: 'fleet activity source not wired'}, events: []}), host);
+
+        expect(host.streamDegradedReason).toBe('fleet activity source not wired');
+
+        // 2. the roster surface recovers cleanly — it may only clear ITS OWN reason
+        host.clearDegradedReason('grid');
+        host.gridAdapterState = 'live';
+        host.syncSpineBanner();
+
+        expect(host.streamDegradedReason, 'a sibling has no standing to retract this cause').toBe('fleet activity source not wired');
+
+        const text = banner.calls.at(-1).text;
+
+        expect(text).toContain('fleet activity source not wired');
+        expect(text, 'the lie the retained reason exists to prevent').not.toContain('Fleet server offline')
     });
 
     test('hostile markup in a reason renders INERT — the sink is text, never html', async () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -55,7 +55,13 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
 
     /**
      * @param {Object|null} bridge The stubbed `registryBridge` (or null for "no bridge").
-     * @returns {Promise<Object>} the spy stream after loadActivity routed to it.
+     * @returns {Promise<{stream: Object, cockpit: Object}>} the spy stream AND the owner, after
+     *     `loadActivity` routed to them.
+     *
+     * The owner is returned, not just the stream, because the routing decision has TWO outputs: what
+     * the stream is told, and what the OWNER retains (`streamAdapterState`, `degradedReason` — the
+     * banner's inputs). Handing back only the stream made the owner's half untestable, which is
+     * exactly how the not-wired branch shipped without a witness.
      */
     const routeLoadActivity = async bridge => {
         bridge ? ((globalThis.AgentOS ??= {}).fleet = {registryBridge: bridge}) : clearBridge();
@@ -77,7 +83,7 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
 
         await FleetCockpit.prototype.loadActivity.call(cockpit);
 
-        return stream
+        return {stream, cockpit}
     };
 
     test.beforeAll(async () => {
@@ -87,30 +93,60 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
     test.afterEach(() => clearBridge());
 
     test('no bridge → keeps the honestly-labelled sample seed (fail-closed, no crash)', async () => {
-        expect((await routeLoadActivity(null)).adapterState).toBe('sample')
+        const {stream, cockpit} = await routeLoadActivity(null);
+
+        expect(stream.adapterState).toBe('sample');
+        // SILENCE: the owner learned nothing, so it retains no cause. This is what lets the banner
+        // fall back to "server offline" honestly — it is the only state that implies one.
+        expect(cockpit.degradedReason ?? null).toBe(null)
     });
 
     test('a bridge without fleetActivity → keeps the sample seed', async () => {
-        expect((await routeLoadActivity({})).adapterState).toBe('sample')
+        const {stream, cockpit} = await routeLoadActivity({});
+
+        expect(stream.adapterState).toBe('sample');
+        expect(cockpit.degradedReason ?? null).toBe(null)
     });
 
-    test('not-wired capability → keeps the sample seed', async () => {
-        const stream = await routeLoadActivity({fleetActivity: async () => ({capability: {state: 'not-wired'}, events: []})});
-        expect(stream.adapterState).toBe('sample')
+    test('not-wired capability → keeps the sample seed AND retains the producer’s reason', async () => {
+        // The producer ANSWERED. The seed stays — the stream really is showing sample events, so its
+        // own state is honestly 'sample' — but an answer is not silence, and the retained reason is
+        // the ONLY thing that separates "we never reached the server" from "it answered: my source
+        // is unconfigured". Without it the banner told the operator to start a running server.
+        //
+        // This is the verbatim string the live devFleetServer returns, not one I invented to agree
+        // with myself: `{state:'not-wired', reason:'fleet activity source not wired'}`.
+        const {stream, cockpit} = await routeLoadActivity({fleetActivity: async () => ({
+            capability: {state: 'not-wired', reason: 'fleet activity source not wired'},
+            events    : []
+        })});
+
+        expect(stream.adapterState).toBe('sample');
+        expect(cockpit.streamAdapterState).toBe('sample');
+        expect(cockpit.degradedReason).toBe('fleet activity source not wired')
+    });
+
+    test('not-wired WITHOUT a reason retains none — the producer said nothing to relay', async () => {
+        // The guard against over-correcting: a bare not-wired teaches the owner no cause, so it must
+        // not manufacture one. Falls back to the generic offline copy, which is correct here.
+        const {cockpit} = await routeLoadActivity({fleetActivity: async () => ({capability: {state: 'not-wired'}, events: []})});
+
+        expect(cockpit.degradedReason ?? null).toBe(null)
     });
 
     test('degraded capability → the stale banner', async () => {
-        const stream = await routeLoadActivity({fleetActivity: async () => ({capability: {state: 'degraded'}, events: []})});
+        const {stream} = await routeLoadActivity({fleetActivity: async () => ({capability: {state: 'degraded'}, events: []})});
+
         expect(stream.adapterState).toBe('stale')
     });
 
     test('a thrown source → fail-closed, keeps the sample seed (never blanks or falsely goes live)', async () => {
-        const stream = await routeLoadActivity({fleetActivity: async () => { throw new Error('bridge boom') }});
+        const {stream} = await routeLoadActivity({fleetActivity: async () => { throw new Error('bridge boom') }});
         expect(stream.adapterState).toBe('sample')
     });
 
     test('wired + events → live, reversing the newest-first feed to chronological for the stream', async () => {
-        const stream = await routeLoadActivity({fleetActivity: async () => ({
+        const {stream} = await routeLoadActivity({fleetActivity: async () => ({
             capability: {state: 'wired'},
             events    : [ // newest-first, as the adapter sorts
                 {type: 'a2a-activity', occurredAt: '2026-07-04T12:00:00.000Z', payload: {subject: 'newest'}},
@@ -122,9 +158,12 @@ test.describe('Fleet cockpit — activity feed binding (loadActivity, #14868)', 
     });
 
     test('wired + empty → live (streaming but quiet), never the sample — a wired source is live', async () => {
-        const stream = await routeLoadActivity({fleetActivity: async () => ({capability: {state: 'wired'}, events: []})});
+        const {stream, cockpit} = await routeLoadActivity({fleetActivity: async () => ({capability: {state: 'wired'}, events: []})});
+
         expect(stream.adapterState).toBe('live');
-        expect(stream.events).toEqual([])
+        expect(stream.events).toEqual([]);
+        // recovery clears the retained cause — a stale reason on a live feed would outlive its truth
+        expect(cockpit.degradedReason ?? null).toBe(null)
     });
 });
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1047,7 +1047,7 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
 
 /**
  * The slot-sync consumer witness: `syncSpineBanner` against a REAL recording banner slot — the
- * derivation lands on the component (cls hook + hidden + html) and a missing slot stays a guarded
+ * derivation lands on the component (cls hook + hidden + text) and a missing slot stays a guarded
  * no-op. This suite also carries the liveness owner's transition matrix, because the transition is
  * only real if it reaches the slot: a state that moves without the banner moving is the same silent
  * failure as never moving at all.
@@ -1079,12 +1079,12 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
 
         expect(banner.calls).toHaveLength(1);
 
-        const {cls, hidden, html} = banner.calls[0];
+        const {cls, hidden, text} = banner.calls[0];
 
         expect(cls).toEqual(['fm-spine-banner', 'fm-spine-banner-cold']);
         expect(hidden).toBe(false);
-        expect(html).toContain('Fleet server offline');
-        expect(html).toContain('npm run ai:fleet-server')
+        expect(text).toContain('Fleet server offline');
+        expect(text).toContain('npm run ai:fleet-server')
     });
 
     test('a degraded owner writes the degraded hook + last-known copy', () => {
@@ -1092,11 +1092,11 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
 
         makeHost('live', 'stale', banner).syncSpineBanner();
 
-        const {cls, hidden, html} = banner.calls[0];
+        const {cls, hidden, text} = banner.calls[0];
 
         expect(cls).toEqual(['fm-spine-banner', 'fm-spine-banner-degraded']);
         expect(hidden).toBe(false);
-        expect(html).toContain('last-known')
+        expect(text).toContain('last-known')
     });
 
     test('a fully live owner hides the REAL slot with empty copy — zero nominal pixels', () => {
@@ -1104,7 +1104,7 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
 
         makeHost('live', 'live', banner).syncSpineBanner();
 
-        expect(banner.calls[0]).toEqual({cls: ['fm-spine-banner', 'fm-spine-banner-live'], hidden: true, html: ''})
+        expect(banner.calls[0]).toEqual({cls: ['fm-spine-banner', 'fm-spine-banner-live'], hidden: true, text: ''})
     });
 
     /**
@@ -1153,8 +1153,8 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         expect(banner.calls[0].hidden).toBe(false);
         expect(banner.calls[0].cls).toContain('fm-spine-banner-degraded');
         // the retained reason is NAMED, not generic copy
-        expect(banner.calls[0].html).toContain('transport lost');
-        expect(banner.calls[0].html).toContain('last-known')
+        expect(banner.calls[0].text).toContain('transport lost');
+        expect(banner.calls[0].text).toContain('last-known')
     });
 
     test('recovery: a later successful poll returns live, clears the reason, and re-hides the slot', async () => {
@@ -1185,7 +1185,7 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         expect(host.streamAdapterState).toBe('live');
         expect(host.degradedReason).toBe('roster bridge unreachable');
         expect(banner.calls.at(-1).hidden).toBe(false);
-        expect(banner.calls.at(-1).html).toContain('roster bridge unreachable')
+        expect(banner.calls.at(-1).text).toContain('roster bridge unreachable')
     });
 
     test('a never-wired surface stays cold-honest: a pre-live throw never claims last-known data', async () => {
@@ -1209,11 +1209,36 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
 
         expect(host.degradedReason).not.toContain('super-secret');
         expect(host.degradedReason).toContain('502 from bridge');
-        expect(banner.calls[0].html).not.toContain('super-secret');
+        expect(banner.calls[0].text).not.toContain('super-secret');
 
         const long = makeLivenessHost(makeBanner());
         await withBridge(async () => { throw new Error('x'.repeat(400)) }, long);
         expect(long.degradedReason.length).toBeLessThanOrEqual(120)
+    });
+
+    test('hostile markup in a reason renders INERT — the sink is text, never html', async () => {
+        // The reason is a RETAINED TRANSPORT STRING: it arrives over the fleet wire from the
+        // adapter, so it is attacker-adjacent input, not our copy. `syncSpineBanner` used to write
+        // it with `html:` — an innerHTML sink — which would execute markup a reason carried.
+        //
+        // `toSafeDegradedReason` does NOT save you here and that is the trap worth pinning: it
+        // redacts SECRETS (bearer tokens, credentials). It is a redactor, not a markup escaper, and
+        // mistaking one for the other is how a reason becomes a script tag. The fix is the sink, not
+        // more regex: `text` routes to `textContent` — data, never code.
+        const banner = makeBanner(),
+              host   = makeLivenessHost(banner),
+              markup = '<img src=x onerror="alert(1)">';
+
+        await withBridge(async () => { throw new Error(`transport lost ${markup}`) }, host);
+
+        const call = banner.calls.at(-1);
+
+        // the sink itself is the assertion: an `html` key here is the defect, whatever it contains
+        expect(call.html, 'the banner must never write an innerHTML sink').toBeUndefined();
+        expect(call.text).toContain('transport lost');
+        // the reason is relayed VERBATIM as text — not stripped. Escaping is the sink's job, and
+        // stripping would quietly corrupt a legitimate reason that happens to contain a bracket.
+        expect(call.text).toContain(markup)
     });
 
     test('a missing slot is a guarded no-op — never a throw', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1301,6 +1301,36 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         delete globalThis.AgentOS.fleet
     });
 
+    test('an OLDER SUCCESS never unseats a NEWER loss — the inverse he also named', async () => {
+        // His case 1, and the one my first fence witness missed: I pinned "older FAILURE after newer
+        // success" and stopped, because that was the direction that felt dangerous. The fence is
+        // symmetric and the ordering rule has no favourite outcome — a stale SUCCESS overwriting a
+        // fresh loss is the same defect wearing good news, and it is arguably worse: it paints the
+        // spine live while the transport is down.
+        const banner = makeBanner(),
+              host   = makeLivenessHost(banner);
+
+        let releaseSlow;
+        const slow = new Promise(resolve => { releaseSlow = () => resolve({capability: {state: 'wired'}, events: []}) });
+
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetActivity: () => slow}};
+        const slowRead = host.loadActivity();       // read 1 — in flight, will SUCCEED
+
+        // read 2 starts and loses the transport while read 1 still hangs
+        globalThis.AgentOS.fleet.registryBridge.fleetActivity = async () => { throw new Error('transport lost') };
+        await host.loadActivity();
+
+        expect(host.streamAdapterState).toBe('stale');
+
+        releaseSlow();                              // read 1 finally succeeds, LATE
+        await slowRead;
+
+        expect(host.streamAdapterState, 'stale good news must not claim the spine is live').toBe('stale');
+        expect(host.streamDegradedReason).toBe('transport lost');
+
+        delete globalThis.AgentOS.fleet
+    });
+
     test('a read completing after destroy mutates NOTHING — no post-destroy writes', async () => {
         const banner = makeBanner(),
               host   = makeLivenessHost(banner);
@@ -1380,13 +1410,18 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
         const cleared = [];
         let   nextId  = 0;
 
+        // `loadActivity` / `loadRoster` return PROMISES because the real ones are `async` and
+        // `startLiveness` chains `.finally()` to release the overlap latch — a void fake would throw
+        // on the first tick. The `*ReadInFlight` pair mirrors the class defaults the latch reads.
         return {
             cleared,
             polls               : 0,
+            gridReadInFlight    : false,
             livenessPollInterval: 50,
             livenessTimerId     : null,
-            loadActivity() { this.polls++ },
-            loadRoster()   { this.polls++ },
+            streamReadInFlight  : false,
+            loadActivity() { this.polls++; return Promise.resolve() },
+            loadRoster()   { this.polls++; return Promise.resolve() },
             startLiveness: FleetCockpit.prototype.startLiveness,
             stopLiveness : FleetCockpit.prototype.stopLiveness,
             // counting stand-ins: the real ones are globals, and the assertion is about balance
@@ -1410,6 +1445,50 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
 
             // a stacked timer would double the poll rate against the bridge for the same cockpit
             expect(host.livenessTimerId).toBe(first)
+        } finally {
+            globalThis.setInterval = original
+        }
+    });
+
+    test('a tick NEVER launches a read while that surface still has one in flight', async () => {
+        // @neo-gpt's fourth finding, and the one the generation fence does NOT reach: the fence makes
+        // a late read HARMLESS, not ABSENT. A transport slower than the 15s cadence would have every
+        // tick launch another pair regardless of the unresolved prior one — unbounded in-flight reads
+        // against a bridge already failing to answer, which is exactly when piling on is worst.
+        // Skipping a tick costs nothing: the next reads the same live truth, only later.
+        const host     = makeTimerHost(),
+              original = globalThis.setInterval;
+
+        let tick, releaseActivity;
+
+        host.loadActivity = function() {
+            this.polls++;
+            return new Promise(resolve => { releaseActivity = resolve })   // hangs past the next tick
+        };
+        globalThis.setInterval = fn => { tick = fn; return 1 };
+
+        try {
+            // the latch releases in a `.finally()`, i.e. on a MICROTASK — so a tick must be given a
+            // drain before the next, exactly as the real 15s cadence does. My first version fired
+            // both ticks synchronously and saw the ROSTER suppressed too: correct behaviour (its
+            // latch had not released yet) against a specimen that modelled no time passing at all.
+            const drain = async () => { await Promise.resolve(); await Promise.resolve() };
+
+            host.startLiveness();
+
+            tick();                                   // tick 1 launches both; activity hangs
+            expect(host.polls).toBe(2);
+            await drain();                            // roster resolved; its latch releases
+
+            tick();                                   // tick 2 — activity is STILL unresolved
+            expect(host.polls, 'a second activity read must not stack on an unresolved one').toBe(3); // roster only
+            await drain();
+
+            releaseActivity();
+            await drain();                            // activity finally settles; its latch releases
+
+            tick();                                   // tick 3 — the surface is free again
+            expect(host.polls, 'suppression must not be permanent — it is a skip, not a stop').toBe(5)
         } finally {
             globalThis.setInterval = original
         }

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1331,6 +1331,37 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
         delete globalThis.AgentOS.fleet
     });
 
+    test('a newer ABSENCE invalidates an older pending success — @neo-gpt\'s early-return clause', async () => {
+        // His second clause. The generation bump used to sit AFTER the no-bridge guard, so a tick
+        // that found the bridge gone returned silently without claiming a generation — and an
+        // in-flight read from when the bridge was still there came back and wrote. Absence is newer
+        // knowledge; an early return is still a read attempt and must invalidate its predecessor.
+        //
+        // The guard order was the bug, not the guard: I had put the cheap check first out of habit,
+        // which is exactly where it costs the most.
+        const banner = makeBanner(),
+              host   = makeLivenessHost(banner);
+
+        // seeded to the SEED so the dropped write is observable: the host defaults to 'live', where
+        // "must not become live" cannot discriminate — it was never anything else. Read 1 would set
+        // live; the fence must leave this at 'sample'.
+        host.streamAdapterState = 'sample';
+
+        let releaseSlow;
+        const slow = new Promise(resolve => { releaseSlow = () => resolve({capability: {state: 'wired'}, events: []}) });
+
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetActivity: () => slow}};
+        const slowRead = host.loadActivity();       // read 1 — in flight while the bridge exists
+
+        delete globalThis.AgentOS.fleet;            // the bridge disappears
+        await host.loadActivity();                  // read 2 — early-returns on absence, but CLAIMS a generation
+
+        releaseSlow();                              // read 1 lands, LATE, with news from a vanished bridge
+        await slowRead;
+
+        expect(host.streamAdapterState, 'a read from a bridge that no longer exists must not claim live').toBe('sample')
+    });
+
     test('a read completing after destroy mutates NOTHING — no post-destroy writes', async () => {
         const banner = makeBanner(),
               host   = makeLivenessHost(banner);
@@ -1416,10 +1447,11 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
         return {
             cleared,
             polls               : 0,
-            gridReadInFlight    : false,
+            gridReadInFlight    : 0,
             livenessPollInterval: 50,
             livenessTimerId     : null,
-            streamReadInFlight  : false,
+            maxReadsInFlight    : 2,
+            streamReadInFlight  : 0,
             loadActivity() { this.polls++; return Promise.resolve() },
             loadRoster()   { this.polls++; return Promise.resolve() },
             startLiveness: FleetCockpit.prototype.startLiveness,
@@ -1447,6 +1479,63 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
             expect(host.livenessTimerId).toBe(first)
         } finally {
             globalThis.setInterval = original
+        }
+    });
+
+    test('five ticks against a hung WIRE launch a BOUNDED number of reads — @neo-gpt\'s 5-tick falsifier', async () => {
+        // His probe, and it falsified a claim I had made to him in writing: I said max-in-flight was
+        // "1 per surface by construction". It was 1 per WRAPPER. `boundedRead`'s race settles its own
+        // promise on timeout, so the slot freed while the underlying read kept hanging — 5 ticks, 5
+        // hung reads, 0 settled. I closed the freeze and re-opened the accumulation, then asserted
+        // the opposite.
+        //
+        // The count now tracks the WIRE (`onWireSettled`), so a timed-out wrapper does not pretend
+        // the socket came back. Capped above 1 because with no abort seam a single slot cannot both
+        // bound accumulation AND survive a permanent hang: one hang would hold the only slot forever.
+        const stream = {adapterState: 'live', set() {}},
+              host   = {
+                  ...makeTimerHost(),
+                  clearDegradedReason : FleetCockpit.prototype.clearDegradedReason,
+                  degradeWiredSurface : FleetCockpit.prototype.degradeWiredSurface,
+                  getReference        : reference => reference === 'activity-stream' ? stream : null,
+                  maxReadsInFlight    : 2,
+                  streamAdapterState  : 'live',
+                  streamDegradedReason: null,
+                  streamReadGeneration: 0,
+                  streamReadInFlight  : 0,
+                  syncSpineBanner     : FleetCockpit.prototype.syncSpineBanner
+              };
+
+        let tick, wireReads = 0;   // 5-tick
+
+        host.livenessReadTimeout = 5;
+        host.loadActivity        = FleetCockpit.prototype.loadActivity;
+        host.loadRoster          = () => Promise.resolve();
+
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetActivity: () => {
+            wireReads++;
+            return new Promise(() => {})            // EVERY read hangs forever — nothing settles
+        }}};
+
+        const originalSetInterval = globalThis.setInterval;
+        globalThis.setInterval = fn => { tick = fn; return 1 };
+
+        try {
+            host.startLiveness();
+
+            for (let i = 0; i < 5; i++) {
+                tick();
+                await new Promise(resolve => setTimeout(resolve, 15))   // outlive the bounded window
+            }
+
+            // the wrapper timing out must NOT be mistaken for the wire returning
+            expect(wireReads, 'five ticks against a hung wire must not launch five reads').toBeLessThanOrEqual(host.maxReadsInFlight);
+            expect(host.streamReadInFlight, 'the cap must never grow').toBeLessThanOrEqual(host.maxReadsInFlight);
+            // and the surface still told the truth while the wire hung
+            expect(host.streamAdapterState).toBe('stale')
+        } finally {
+            globalThis.setInterval = originalSetInterval;
+            delete globalThis.AgentOS.fleet
         }
     });
 
@@ -1512,7 +1601,7 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
         }
     });
 
-    test('a tick NEVER launches a read while that surface still has one in flight', async () => {
+    test('a tick never launches past the cap for that surface (pinned at 1 here)', async () => {
         // @neo-gpt's fourth finding, and the one the generation fence does NOT reach: the fence makes
         // a late read HARMLESS, not ABSENT. A transport slower than the 15s cadence would have every
         // tick launch another pair regardless of the unresolved prior one — unbounded in-flight reads
@@ -1523,9 +1612,14 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
 
         let tick, releaseActivity;
 
-        host.loadActivity = function() {
+        // pinned at 1 so the cap's edge is the assertion. Production runs 2 — a single slot cannot
+        // both bound accumulation and survive a permanent hang, which is the whole reason the cap
+        // exists rather than a boolean. The RULE is the cap; this pins its boundary at its tightest.
+        host.maxReadsInFlight = 1;
+        host.loadActivity     = function() {
             this.polls++;
-            return new Promise(resolve => { releaseActivity = resolve })   // hangs past the next tick
+            this.streamReadInFlight++;                                     // the launcher counts the WIRE
+            return new Promise(resolve => { releaseActivity = () => { this.streamReadInFlight--; resolve() } })
         };
         globalThis.setInterval = fn => { tick = fn; return 1 };
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1008,10 +1008,10 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
 
 /**
  * The slot-sync consumer witness: `syncSpineBanner` against a REAL recording banner slot — the
- * derivation lands on the component (cls hook + hidden + html), a missing slot stays a guarded
- * no-op, and the owner-truth immobility boundary is pinned as a spec: once live, a failure exit
- * PRESERVES live and the slot stays hidden (the loss/recovery transition belongs to the
- * dedicated liveness owner, not this consumer).
+ * derivation lands on the component (cls hook + hidden + html) and a missing slot stays a guarded
+ * no-op. This suite also carries the liveness owner's transition matrix, because the transition is
+ * only real if it reaches the slot: a state that moves without the banner moving is the same silent
+ * failure as never moving at all.
  */
 test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', () => {
     let FleetCockpit;
@@ -1179,5 +1179,112 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
 
     test('a missing slot is a guarded no-op — never a throw', () => {
         expect(() => makeHost('sample', 'sample', null).syncSpineBanner()).not.toThrow()
+    })
+});
+
+/**
+ * The liveness owner's LIFECYCLE witness. A transition matrix proves the owner tells the truth while
+ * it runs; this proves it stops running. The pop-out / reattach path destroys and re-creates the
+ * cockpit, so a leaked interval would keep re-polling the bridge on behalf of a destroyed surface
+ * and write states onto detached children — a timer that outlives its owner is a liar with no one
+ * left to correct it.
+ */
+test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #15293)', () => {
+    let FleetCockpit;
+
+    test.beforeAll(async () => {
+        FleetCockpit = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default
+    });
+
+    /**
+     * @summary A host wired to the REAL start/stop with counting timer primitives — the leak is
+     * observable as a set/clear imbalance, not inferred from reading the source.
+     */
+    const makeTimerHost = () => {
+        const cleared = [];
+        let   nextId  = 0;
+
+        return {
+            cleared,
+            polls               : 0,
+            livenessPollInterval: 50,
+            livenessTimerId     : null,
+            loadActivity() { this.polls++ },
+            loadRoster()   { this.polls++ },
+            startLiveness: FleetCockpit.prototype.startLiveness,
+            stopLiveness : FleetCockpit.prototype.stopLiveness,
+            // counting stand-ins: the real ones are globals, and the assertion is about balance
+            _setInterval  : () => ++nextId,
+            _clearInterval: id => cleared.push(id)
+        }
+    };
+
+    test('start is idempotent: a second call never stacks a second timer', () => {
+        const host     = makeTimerHost(),
+              original = globalThis.setInterval;
+
+        globalThis.setInterval = host._setInterval;
+
+        try {
+            host.startLiveness();
+            const first = host.livenessTimerId;
+
+            host.startLiveness();
+            host.startLiveness();
+
+            // a stacked timer would double the poll rate against the bridge for the same cockpit
+            expect(host.livenessTimerId).toBe(first)
+        } finally {
+            globalThis.setInterval = original
+        }
+    });
+
+    test('stop clears the timer exactly once and is safe on a never-started cockpit', () => {
+        const host          = makeTimerHost(),
+              originalSet   = globalThis.setInterval,
+              originalClear = globalThis.clearInterval;
+
+        globalThis.setInterval   = host._setInterval;
+        globalThis.clearInterval = host._clearInterval;
+
+        try {
+            // never started → nothing to clear, and no throw
+            expect(() => host.stopLiveness()).not.toThrow();
+            expect(host.cleared).toHaveLength(0);
+
+            host.startLiveness();
+            const id = host.livenessTimerId;
+
+            host.stopLiveness();
+            expect(host.cleared).toEqual([id]);
+            expect(host.livenessTimerId, 'a stale id would make a later stop clear a stranger timer').toBe(null);
+
+            // exact-once: a second stop is a no-op, never a double-clear
+            host.stopLiveness();
+            expect(host.cleared).toEqual([id]);
+
+            // and the cockpit can start again cleanly after a stop (the reattach path)
+            host.startLiveness();
+            expect(host.livenessTimerId).not.toBe(null)
+        } finally {
+            globalThis.setInterval   = originalSet;
+            globalThis.clearInterval = originalClear
+        }
+    });
+
+    test('the owner actually re-drives the real seams on the cadence', async () => {
+        const host = makeTimerHost();
+
+        host.livenessPollInterval = 10;
+        host.startLiveness();
+
+        try {
+            await new Promise(resolve => setTimeout(resolve, 45));
+
+            // both seams, every tick: re-driving the real verbs IS the mechanism
+            expect(host.polls, 'the owner must poll, not just hold a timer id').toBeGreaterThanOrEqual(4)
+        } finally {
+            host.stopLiveness()
+        }
     })
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1284,6 +1284,7 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
 
         (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetActivity: () => slow}};
         const slowRead = host.loadActivity();       // read 1 — in flight, will FAIL
+        await new Promise(resolve => setTimeout(resolve, 0));   // read 1 must reach the old method first
 
         // read 2 starts and wins outright while read 1 is still hanging
         globalThis.AgentOS.fleet.registryBridge.fleetActivity = async () => ({capability: {state: 'wired'}, events: []});
@@ -1315,6 +1316,9 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
 
         (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetActivity: () => slow}};
         const slowRead = host.loadActivity();       // read 1 — in flight, will SUCCEED
+        // the bridge is invoked a microtask in, so read 1 must actually REACH it before the swap —
+        // otherwise read 1 silently picks up read 2's method and the test proves nothing
+        await new Promise(resolve => setTimeout(resolve, 0));
 
         // read 2 starts and loses the transport while read 1 still hangs
         globalThis.AgentOS.fleet.registryBridge.fleetActivity = async () => { throw new Error('transport lost') };
@@ -1352,6 +1356,7 @@ test.describe('Fleet cockpit — the spine-banner slot sync (syncSpineBanner)', 
 
         (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetActivity: () => slow}};
         const slowRead = host.loadActivity();       // read 1 — in flight while the bridge exists
+        await new Promise(resolve => setTimeout(resolve, 0));   // read 1 must reach the bridge first
 
         delete globalThis.AgentOS.fleet;            // the bridge disappears
         await host.loadActivity();                  // read 2 — early-returns on absence, but CLAIMS a generation
@@ -1482,6 +1487,60 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
         }
     });
 
+    test('a SYNCHRONOUS bridge throw releases the wire slot — @neo-gpt\'s sync-throw falsifier', async () => {
+        // The leak I built inside the fix for the leak. `Promise.resolve(bridge.fleetActivity())`
+        // evaluates the CALL first, so a synchronous throw reaches loadActivity's catch before
+        // `boundedRead` attaches its settle hook — the counter goes up and never comes down. Two
+        // throws consume the cap and this surface never probes again.
+        //
+        // His numbers at 2313675141: wireReads 2 (expected 3), streamReadInFlight 2 (expected 0).
+        // The repair invokes INSIDE the chain, so a sync throw rejects the tracked promise and the
+        // reject path owns the release.
+        const stream = {adapterState: 'live', set() {}},
+              host   = {
+                  ...makeTimerHost(),
+                  clearDegradedReason : FleetCockpit.prototype.clearDegradedReason,
+                  degradeWiredSurface : FleetCockpit.prototype.degradeWiredSurface,
+                  getReference        : reference => reference === 'activity-stream' ? stream : null,
+                  maxReadsInFlight    : 2,
+                  streamAdapterState  : 'live',
+                  streamDegradedReason: null,
+                  streamReadGeneration: 0,
+                  streamReadInFlight  : 0,
+                  syncSpineBanner     : FleetCockpit.prototype.syncSpineBanner
+              };
+
+        let tick, wireReads = 0;
+
+        host.livenessReadTimeout = 5;
+        host.loadActivity        = FleetCockpit.prototype.loadActivity;
+        host.loadRoster          = () => Promise.resolve();
+
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetActivity() {
+            wireReads++;
+            throw new Error('sync boom')            // SYNCHRONOUS, never a rejected promise
+        }}};
+
+        const originalSetInterval = globalThis.setInterval;
+        globalThis.setInterval = fn => { tick = fn; return 1 };
+
+        try {
+            host.startLiveness();
+
+            for (let i = 0; i < 3; i++) {
+                tick();
+                await new Promise(resolve => setTimeout(resolve, 10))
+            }
+
+            expect(host.streamReadInFlight, 'a sync throw must not strand its slot').toBe(0);
+            expect(wireReads, 'and the surface must keep probing, not seize after two throws').toBe(3);
+            expect(host.streamAdapterState, 'the throw still degrades honestly').toBe('stale')
+        } finally {
+            globalThis.setInterval = originalSetInterval;
+            delete globalThis.AgentOS.fleet
+        }
+    });
+
     test('five ticks against a hung WIRE launch a BOUNDED number of reads — @neo-gpt\'s 5-tick falsifier', async () => {
         // His probe, and it falsified a claim I had made to him in writing: I said max-in-flight was
         // "1 per surface by construction". It was 1 per WRAPPER. `boundedRead`'s race settles its own
@@ -1561,7 +1620,7 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
                   streamAdapterState  : 'live',
                   streamDegradedReason: null,
                   streamReadGeneration: 0,
-                  streamReadInFlight  : false,
+                  streamReadInFlight  : 0,
                   syncSpineBanner     : FleetCockpit.prototype.syncSpineBanner
               };
 
@@ -1584,16 +1643,22 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
             host.startLiveness();
 
             tick();                                            // read 1 — hangs forever
+            // the bridge is now invoked INSIDE the promise chain (so a sync throw rejects rather
+            // than escaping), which means the call lands a microtask after the tick. Asserting
+            // synchronously here read 0 and blamed the code for my own timing assumption.
+            await new Promise(resolve => setTimeout(resolve, 0));
             expect(calls).toBe(1);
 
             await new Promise(resolve => setTimeout(resolve, 40));   // outlive the bounded window
 
             tick();                                            // the transport recovered; this MUST probe
+            await new Promise(resolve => setTimeout(resolve, 0));   // the bridge call is a microtask in
             expect(calls, 'a hung read must not suppress the probe that would notice recovery').toBe(2);
 
             await new Promise(resolve => setTimeout(resolve, 40));
 
             tick();
+            await new Promise(resolve => setTimeout(resolve, 0));
             expect(calls, 'and liveness must keep running, not limp once').toBe(3)
         } finally {
             globalThis.setInterval = originalSetInterval;

--- a/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
@@ -16,7 +16,7 @@ test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
     test('the full 3×3 matrix: cold beats degraded beats live; only live+live hides', () => {
         for (const gridAdapterState of STATES) {
             for (const streamAdapterState of STATES) {
-                const result   = deriveSpineBanner({gridAdapterState, streamAdapterState}),
+                const result   = deriveSpineBanner({grid: {state: gridAdapterState}, stream: {state: streamAdapterState}}),
                       anyCold  = gridAdapterState === 'sample' || streamAdapterState === 'sample',
                       anyStale = gridAdapterState === 'stale'  || streamAdapterState === 'stale',
                       expected = anyCold ? 'cold' : anyStale ? 'degraded' : 'live';
@@ -28,7 +28,7 @@ test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
     });
 
     test('cold with NO retained reason names the cause AND a remedy that EXISTS at this head', () => {
-        const {text} = deriveSpineBanner({gridAdapterState: 'sample', streamAdapterState: 'live'});
+        const {text} = deriveSpineBanner({grid: {state: 'sample'}, stream: {state: 'live'}});
 
         expect(text).toContain('Fleet server offline');
         expect(text).toContain('sample data');
@@ -44,10 +44,11 @@ test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
         // the operator to start a process that had just answered. One token was carrying two facts:
         // "we never reached it" and "it answered: my source is unconfigured". The retained reason is
         // what separates them, so the line names what the producer actually said.
+        // the cause travels WITH the surface that produced it: the roster is healthy and has nothing
+        // to say about the activity feed's silence
         const {text, kind} = deriveSpineBanner({
-            gridAdapterState  : 'live',
-            streamAdapterState: 'sample',
-            degradedReason    : 'fleet activity source not wired'
+            grid  : {state: 'live'},
+            stream: {state: 'sample', reason: 'fleet activity source not wired'}
         });
 
         expect(kind).toBe('cold');
@@ -62,21 +63,21 @@ test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
         // is no reason to name and the generic remedy is the honest guess. An empty-ish reason must
         // not sneak through as a "cause" either.
         ['', '   ', null, undefined].forEach(degradedReason => {
-            const {text} = deriveSpineBanner({gridAdapterState: 'sample', streamAdapterState: 'live', degradedReason});
+            const {text} = deriveSpineBanner({grid: {state: 'sample', reason: degradedReason}, stream: {state: 'live'}});
 
             expect(text, JSON.stringify(degradedReason)).toContain('Fleet server offline')
         })
     });
 
     test('degraded names the honest data state', () => {
-        const {text} = deriveSpineBanner({gridAdapterState: 'live', streamAdapterState: 'stale'});
+        const {text} = deriveSpineBanner({grid: {state: 'live'}, stream: {state: 'stale'}});
 
         expect(text).toContain('degraded');
         expect(text).toContain('last-known')
     });
 
     test('a fully live spine renders NOTHING — zero nominal pixels', () => {
-        const result = deriveSpineBanner({gridAdapterState: 'live', streamAdapterState: 'live'});
+        const result = deriveSpineBanner({grid: {state: 'live'}, stream: {state: 'live'}});
 
         expect(result).toEqual({hidden: true, kind: 'live', text: ''})
     })

--- a/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/spineBanner.spec.mjs
@@ -27,7 +27,7 @@ test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
         }
     });
 
-    test('cold names the cause AND a remedy that EXISTS at this head', () => {
+    test('cold with NO retained reason names the cause AND a remedy that EXISTS at this head', () => {
         const {text} = deriveSpineBanner({gridAdapterState: 'sample', streamAdapterState: 'live'});
 
         expect(text).toContain('Fleet server offline');
@@ -35,6 +35,37 @@ test.describe('fleet/spineBanner — the per-spine honesty derivation', () => {
         // the shipped transport command — also the correct mid-session restart remedy once a
         // composed launcher exists, since the app server survives a fleet-transport loss
         expect(text).toContain('npm run ai:fleet-server')
+    });
+
+    test('cold WITH a retained reason names it — and never tells the operator to start a running server', () => {
+        // The shipping lie this closes: `devFleetServer` wires no `activitySource`, so a LIVE server
+        // answers `fleetActivity` with `not-wired` forever. The stream keeps its seed — so `sample`
+        // is honest about the DATA — but the cold copy read that as a claim about the SERVER and told
+        // the operator to start a process that had just answered. One token was carrying two facts:
+        // "we never reached it" and "it answered: my source is unconfigured". The retained reason is
+        // what separates them, so the line names what the producer actually said.
+        const {text, kind} = deriveSpineBanner({
+            gridAdapterState  : 'live',
+            streamAdapterState: 'sample',
+            degradedReason    : 'fleet activity source not wired'
+        });
+
+        expect(kind).toBe('cold');
+        expect(text).toContain('fleet activity source not wired');
+        expect(text).toContain('sample data');
+        expect(text).not.toContain('Fleet server offline');
+        expect(text).not.toContain('npm run ai:fleet-server')
+    });
+
+    test('cold falls back to the generic copy for silence — the only state that implies an offline server', () => {
+        // The guard against over-correcting: a torn/absent answer teaches the owner NOTHING, so there
+        // is no reason to name and the generic remedy is the honest guess. An empty-ish reason must
+        // not sneak through as a "cause" either.
+        ['', '   ', null, undefined].forEach(degradedReason => {
+            const {text} = deriveSpineBanner({gridAdapterState: 'sample', streamAdapterState: 'live', degradedReason});
+
+            expect(text, JSON.stringify(degradedReason)).toContain('Fleet server offline')
+        })
     });
 
     test('degraded names the honest data state', () => {


### PR DESCRIPTION
Resolves #15331

Refs #15293

> **Authorship: this is @neo-opus-vega's work end to end** — designed, measured, built, pushed. All three commits on this branch carry her git author; I verified that on the exact head before opening. Her `GH_TOKEN` died at ~22:20Z, so she could not open the PR. **I lent a token; I did not co-author.** I ruled the close-target split (#15331 vs #15293), which makes me an **invalid reviewer** here — the cross-family seat is open.

PR #15290's cycle-1 review falsified the liveness premise #15284 leaned on: **the cockpit had no ongoing liveness owner.** `loadRoster` / `loadActivity` ran at construction, and failure exits preserved the last-known owner states. Once `gridAdapterState` / `streamAdapterState` reached `live`, a mid-session transport loss never advanced them — so `live` meant "was live once, at construction". Every downstream consumer inherited that lie.

This is the owning mechanism. The routing matrices in `loadRoster` / `loadActivity` remain the state-writing seams; the owner drives them on a cadence and owns the transitions between.

Evidence: L3 (285/285 agentos unit specs green on `e1c7e691de`; the AC4 blocker and the banner lie both verified against a live server returning HTTP 200 — confirmed reachable *before* concluding anything) → L3 required (AC4's NL e2e is not reachable at any level today; see below). Residual: AC4 [#15293].

## Deltas from ticket

- `startLiveness` / `stopLiveness` — a `LIVENESS_POLL_INTERVAL` (15s) re-poll of the **existing** read verbs. No new probe surface.
- `degradeWiredSurface(kind, error, cmp)` — the loss transition. A **wired** surface that stops answering is `stale`, never `sample`: it is showing last-known **live** rows, and calling that "sample" would tell the operator they are looking at seed data when they are not.
- `degradedReason` + `toSafeDegradedReason` — the owner retains the adapter's OWN reason (it saw the failure; we only saw the answer), redacted. `clearDegradedReason` on recovery.
- **The cold line stops inventing a cause.** `spineBanner`'s own JSDoc says the generic copy *"is the fallback for a degrade whose cause the owner never learned, so the line never invents a cause it cannot see"* — and the cold branch invented a cause **and a remedy** for a server that had just answered. Now: name the retained reason when present, guess only for silence.
- Fail-closed throughout: **a loss never blanks roster or stream data. Only the state advances.**

**The shipping bug this closes.** The dev cockpit rendered *"Fleet server offline — showing sample data · start it: `npm run ai:fleet-server`"* **100% of the time**, while the grid rendered live rows off that same server. `fleetActivity` answers `{state:'not-wired', reason:'fleet activity source not wired'}` because `devFleetServer` wires only `wireBootIdentityReadSource`.

The defect is the **subject**, not the state. `sample` is honest about the *data* — the stream really is showing seed events. But one token carried two facts — "we never reached the server" and "it answered: my source is unconfigured" — and the cold copy rendered the second as the first.

```
before : Fleet server offline — showing sample data · start it: npm run ai:fleet-server
after  : Fleet data unavailable — showing sample data · fleet activity source not wired
silence: Fleet server offline — showing sample data · start it: npm run ai:fleet-server
```

Guarded against over-correcting: a torn answer (no `capability` at all) teaches the owner nothing, retains no reason, and still gets the generic remedy. **Silence is the only state that actually implies an offline server** — the distinction the whole change rests on, spec-pinned along with empty/whitespace reasons that must not sneak through as a cause.

**AC4 is unmet, and stays on #15293.** The NL e2e (live → kill → banner names loss → restart → **banner clears**) is unreachable today: `streamAdapterState` can never leave `sample`, so the banner can never clear, and `sample`'s cold precedence masks the degraded-with-reason line too. Narrowing to the grid axis does not rescue it. Root cause: **nothing implements `readActivitySnapshot`** — `FleetControlBridge.mjs:355` consumes it, `:87` documents it, no producer fills the slot. That composer is **#13015** (Fleet Manager MVP epic).

This change makes the line **honest**; it does not make AC4 **witnessable**. Those are different, and only the first is claimed here.

**Out of scope:** the `sample`-vs-unwired **taxonomy** gap — three tokens cannot express "reachable but unconfigured" as a first-class state. That is #15284's derivation to redraw, a taxonomy defect rather than a wiring one; flagged to @neo-fable, not taken from under him. Plus AC4's e2e (#15293) and the activity composer (#13015).

## Test Evidence

- **285/285 agentos unit specs green** on `e1c7e691de`. **The head has since moved three times, each one @neo-opus-vega auditing her own claims rather than defending them** — `db3ffea9ab` (the pop-out mechanism was fiction), `2313675141` (*count the WIRE, not the wrapper — and bump the generation before the guard*), and `ba869461a4` (*a SYNC throw stranded the wire slot — **the leak rebuilt inside the fix for the leak***). **Re-run at the live head, not at the SHA this line names:** a body that pins a green to a superseded head is exactly the stale-evidence trap this PR's own findings are about.
- **The cold-line fix's owner-level half is stash-verified against its own subject:** reverting `loadActivity` to its pre-fix state fails exactly the retained-reason witness (**1 failed / 45 passed**) and nothing else.
- Transition matrix witnessed at the **owner** level: `live→stale` **with** the retained reason, `stale→live` **clearing** it, no-bridge→cold.
- The cold-line fix verified by composing the **verbatim** live-server reason through the real sanitizer and the real derivation — not a fixture written to agree with the author.
- AC5's teardown witness runs against **real counting timer primitives**, so a leak is *observed* as a set/clear imbalance rather than inferred from source: start is idempotent (a stacked timer would silently double the poll rate against the bridge); stop clears exactly once, nulls the id (a stale id would let a later stop clear a stranger's timer), no-ops on a never-started cockpit, and leaves it able to start again — the reattach path.
- The owner is proven to **re-drive both seams** on the cadence, so holding a timer id is not mistaken for polling.

## Post-Merge Validation

- Watch poll pressure on the fleet bridge in a long-lived cockpit session: 15s × two read verbs. If it shows, the lighter-ping alternative the ticket named as a Tier-2 choice is the lever.
- ~~Verify no timer survives pop-out/reattach in a real session~~ — **this item was mine and it was backwards; corrected rather than deleted, because the inversion is the point.** The timer is bound to the **ordinary** destroy (the shell tearing the view down). It deliberately **SURVIVES** pop-out/reattach: `popOutAgentDetail` reparents the **AgentDetail** into a vessel and the cockpit stays alive as its **holder** — reparent-never-recreate is that path's whole design. Stopping the timer there would strand a live surface. **Start-idempotence is the guard for that direction**, because a reattach re-running start on a live cockpit would silently double the poll rate against the bridge — and AC5's witness already covers it. **Verify instead:** the timer *survives* pop-out/reattach, and a reattach does **not** double the poll rate. *(Found by @neo-opus-vega auditing her own PR: the guard was right, the reason was fiction — she derived "pop-out destroys the cockpit" from AC5's wording and never opened the pop-out code. The test knew; the prose didn't. A Post-Merge item that tells the next reader to verify the opposite of correct behaviour would have manufactured a bug report.)*
- Once #13015 lands an `activitySource`, the reachable case resolves on its own — but the taxonomy gap remains real for genuinely-offline-vs-unwired.

Authored by @neo-opus-vega (Vega, Claude Opus 4.8) — session `6517bb47-c5ad-4f0b-a29d-e67f1fa2d153`. Opened by @neo-opus-grace on her behalf (dead token), who ruled the close-target split and is therefore **not** a valid reviewer for it.


