### PR TITLE
fix(genesis): make isolation evidence attribution-safe (#15330)

### DIFF
--- a/ai/mcp/server/neural-link/Server.mjs
+++ b/ai/mcp/server/neural-link/Server.mjs
@@ -1,9 +1,10 @@
-import BaseServer            from '../BaseServer.mjs';
-import aiConfig              from './config.mjs';
-import logger                from './logger.mjs';
-import ConnectionService     from '../../../services/neural-link/ConnectionService.mjs';
-import HealthService         from '../../../services/neural-link/HealthService.mjs';
-import {listTools, callTool} from './toolService.mjs';
+import BaseServer              from '../BaseServer.mjs';
+import aiConfig                from './config.mjs';
+import logger                  from './logger.mjs';
+import ConnectionService       from '../../../services/neural-link/ConnectionService.mjs';
+import HealthService           from '../../../services/neural-link/HealthService.mjs';
+import {listTools, callTool}   from './toolService.mjs';
+import {attestDiagnosticPaths} from './diagnosticPathAttestation.mjs';
 
 let _turnId = 0;
 
@@ -54,6 +55,13 @@ class Server extends BaseServer {
      * @member {String|null} bridgeCwd=null
      */
     bridgeCwd = null
+
+    /**
+     * @summary Expected commitment for the Genesis probe's resolved writable sinks. Normal launches leave
+     * this unset; the MCP entrypoint injects it only for an isolated diagnostic child.
+     * @member {String|null} diagnosticPathAttestation=null
+     */
+    diagnosticPathAttestation = null
 
     /**
      * @summary MCP server identity for `createMcpServer()`.
@@ -140,16 +148,30 @@ class Server extends BaseServer {
      *
      * Sequence:
      * 1. Load custom config
-     * 2. Construct mcpServer + wire request handlers
-     * 3. Connect stdio transport (early — handshake-tolerance for Bridge-down scenarios)
-     * 4. Await ConnectionService.ready (non-fatal: logged but doesn't throw, so the server
+     * 2. Attest resolved diagnostic paths when the Genesis launcher supplied a commitment
+     * 3. Construct mcpServer + wire request handlers
+     * 4. Connect stdio transport (early — handshake-tolerance for Bridge-down scenarios)
+     * 5. Await ConnectionService.ready (non-fatal: logged but doesn't throw, so the server
      *    stays alive to report health errors via the MCP healthcheck tool)
-     * 5. Healthcheck + startup-status log
+     * 6. Healthcheck + startup-status log
      *
      * @returns {Promise<void>}
      */
     async boot() {
         await this.loadCustomConfig();
+
+        const diagnosticMarker = attestDiagnosticPaths({
+            expectedCommitment: this.diagnosticPathAttestation,
+            role              : 'mcp',
+            sinks             : {
+                database: this.aiConfig.memoryCoreDbPath,
+                logs    : this.aiConfig.logPath
+            }
+        });
+
+        if (diagnosticMarker) {
+            process.stderr.write(`${diagnosticMarker}\n`)
+        }
 
         this.mcpServer = this.createMcpServer();
 

--- a/ai/mcp/server/neural-link/diagnosticPathAttestation.mjs
+++ b/ai/mcp/server/neural-link/diagnosticPathAttestation.mjs
@@ -1,0 +1,114 @@
+import crypto from 'crypto';
+import path   from 'path';
+
+/**
+ * @module ai/mcp/server/neural-link/diagnosticPathAttestation
+ * @summary Creates secret-free commitments that prove a diagnostic child resolved every writable
+ * sink to the disposable paths selected by its launcher.
+ */
+
+/** @type {String} Entrypoint-only environment channel carrying the launcher's expected commitment. */
+export const GENESIS_DIAGNOSTIC_ATTESTATION_ENV = 'NEO_GENESIS_DIAGNOSTIC_ATTESTATION';
+
+/** @type {String} Secret-free child readiness marker prefix. */
+export const GENESIS_DIAGNOSTIC_PATHS_MARKER = 'GENESIS_DIAGNOSTIC_PATHS';
+
+/** @type {String} Stable public error code for a failed diagnostic isolation contract. */
+export const GENESIS_DIAGNOSTIC_PATH_MISMATCH = 'GENESIS_DIAGNOSTIC_PATH_MISMATCH';
+
+/** @type {Object<String,String[]>} Complete writable-sink role contract for each probe child. */
+export const GENESIS_DIAGNOSTIC_SINK_ROLES = Object.freeze({
+    bridge: Object.freeze(['logs']),
+    mcp   : Object.freeze(['database', 'logs'])
+});
+
+const COMMITMENT_PATTERN = /^[a-f0-9]{64}$/;
+const NAME_PATTERN       = /^[a-z][a-z0-9-]*$/;
+
+/**
+ * @summary Creates one safe, path-free mismatch error. Neither resolved paths nor commitments are
+ * included because this error can cross the public probe boundary.
+ * @returns {Error}
+ */
+function createMismatchError() {
+    const error = new Error('Genesis diagnostic paths do not match the disposable launch contract.');
+
+    error.code = GENESIS_DIAGNOSTIC_PATH_MISMATCH;
+
+    return error
+}
+
+/**
+ * @summary Commits to one child's role and its fully resolved writable sinks. The returned marker
+ * exposes only the role, sink-role names, and SHA-256 commitment; absolute paths stay private.
+ * @param {Object} options
+ * @param {String} options.role Stable child role.
+ * @param {Object<String,String>} options.sinks Writable sink role to configured path.
+ * @returns {{commitment:String, marker:String, role:String, sinkRoles:String[]}}
+ */
+export function createDiagnosticPathAttestation({role, sinks}) {
+    const requiredSinkRoles = GENESIS_DIAGNOSTIC_SINK_ROLES[role];
+
+    if (typeof role !== 'string' || !NAME_PATTERN.test(role) || !requiredSinkRoles) {
+        throw new TypeError('Diagnostic attestation requires a stable child role.')
+    }
+    if (!sinks || typeof sinks !== 'object' || Array.isArray(sinks)) {
+        throw new TypeError('Diagnostic attestation requires named writable sinks.')
+    }
+
+    const entries = Object.entries(sinks).sort(([left], [right]) => left.localeCompare(right));
+
+    if (entries.length === 0 || entries.some(([name, value]) =>
+        !NAME_PATTERN.test(name) || typeof value !== 'string' || value.length === 0
+    ) || entries.some(([name], index) => name !== requiredSinkRoles[index]) ||
+        entries.length !== requiredSinkRoles.length
+    ) {
+        throw new TypeError('Diagnostic attestation requires the complete writable-sink role set.')
+    }
+
+    const
+        resolvedSinks = entries.map(([name, value]) => [name, path.resolve(value)]),
+        sinkRoles     = resolvedSinks.map(([name]) => name),
+        commitment    = crypto.createHash('sha256')
+            .update(JSON.stringify({role, sinks: resolvedSinks}), 'utf8')
+            .digest('hex'),
+        marker        = `${GENESIS_DIAGNOSTIC_PATHS_MARKER} ${JSON.stringify({
+            role,
+            sinkRoles,
+            commitment
+        })}`;
+
+    return {commitment, marker, role, sinkRoles}
+}
+
+/**
+ * @summary Verifies a child's resolved AiConfig sinks against the launcher commitment. Normal
+ * launches omit the expected commitment and receive `null`; probe launches either return the exact
+ * secret-free readiness marker or fail before any configured diagnostic writer starts.
+ * @param {Object} options
+ * @param {String|null} [options.expectedCommitment]
+ * @param {String} options.role Stable child role.
+ * @param {Object<String,String>} options.sinks Writable sink role to resolved AiConfig path.
+ * @returns {String|null}
+ */
+export function attestDiagnosticPaths({expectedCommitment, role, sinks}) {
+    if (expectedCommitment == null) return null;
+
+    if (typeof expectedCommitment !== 'string' || !COMMITMENT_PATTERN.test(expectedCommitment)) {
+        throw createMismatchError()
+    }
+
+    let attestation;
+
+    try {
+        attestation = createDiagnosticPathAttestation({role, sinks})
+    } catch {
+        throw createMismatchError()
+    }
+
+    if (attestation.commitment !== expectedCommitment) {
+        throw createMismatchError()
+    }
+
+    return attestation.marker
+}

--- a/ai/mcp/server/neural-link/mcp-server.mjs
+++ b/ai/mcp/server/neural-link/mcp-server.mjs
@@ -9,6 +9,10 @@ import Server, {resolveToolProjectionMode} from './Server.mjs';
 import {sanitizeInput}                     from '../../../../buildScripts/util/sanitizer.mjs';
 import {fileURLToPath}                     from 'node:url';
 import {assertConfigFresh}                 from '../../../scripts/setup/initServerConfigs.mjs';
+import {
+    GENESIS_DIAGNOSTIC_ATTESTATION_ENV,
+    GENESIS_DIAGNOSTIC_PATH_MISMATCH
+} from './diagnosticPathAttestation.mjs';
 
 const program = new Command();
 
@@ -36,11 +40,16 @@ try {
     await assertConfigFresh({requiredFindings: findings, serverPath: fileURLToPath(new URL('.', import.meta.url))});
 
     await Neo.create(Server, {
-        configFile        : options.config,
-        bridgeCwd         : options.cwd,
-        toolProjectionMode: resolveToolProjectionMode(options.toolProjectionMode)
+        configFile               : options.config,
+        bridgeCwd                : options.cwd,
+        diagnosticPathAttestation: process.env[GENESIS_DIAGNOSTIC_ATTESTATION_ENV],
+        toolProjectionMode       : resolveToolProjectionMode(options.toolProjectionMode)
     }).ready();
 } catch (error) {
-    logger.fatalStartup('Fatal error during server initialization:', error);
+    if (error.code === GENESIS_DIAGNOSTIC_PATH_MISMATCH) {
+        process.stderr.write(`Fatal error during server initialization: ${error.code}\n`)
+    } else {
+        logger.fatalStartup('Fatal error during server initialization:', error)
+    }
     process.exit(1);
 }

--- a/ai/mcp/server/neural-link/run-bridge.mjs
+++ b/ai/mcp/server/neural-link/run-bridge.mjs
@@ -7,6 +7,10 @@ import logger              from './logger.mjs';
 import {sanitizeInput}     from '../../../../buildScripts/util/sanitizer.mjs';
 import {fileURLToPath}     from 'node:url';
 import {assertConfigFresh} from '../../../scripts/setup/initServerConfigs.mjs';
+import {
+    GENESIS_DIAGNOSTIC_ATTESTATION_ENV,
+    attestDiagnosticPaths
+} from './diagnosticPathAttestation.mjs';
 
 const program = new Command();
 
@@ -33,6 +37,16 @@ if (options.debug) {
 
         if (options.config) {
             await aiConfig.load(options.config);
+        }
+
+        const diagnosticMarker = attestDiagnosticPaths({
+            expectedCommitment: process.env[GENESIS_DIAGNOSTIC_ATTESTATION_ENV],
+            role              : 'bridge',
+            sinks             : {logs: aiConfig.logPath}
+        });
+
+        if (diagnosticMarker) {
+            process.stderr.write(`${diagnosticMarker}\n`)
         }
 
         logger.info('Starting Neural Link Bridge...');

--- a/ai/scripts/diagnostics/genesisProbe.mjs
+++ b/ai/scripts/diagnostics/genesisProbe.mjs
@@ -48,6 +48,34 @@ const PUBLIC_FAILURES = Object.freeze({
     UNEXPECTED_FAILURE          : 'The probe failed without a public-safe classification.'
 });
 
+const UNEXPECTED_FAILURE_PHASES = Object.freeze([
+    'unclassified',
+    'bootstrap',
+    'isolation-setup',
+    'child-readiness',
+    'browser-import',
+    'browser-launch',
+    'browser-context',
+    'app-navigation',
+    'app-readiness',
+    'mcp-connect',
+    'mcp-profile',
+    'topology',
+    'tool-journey',
+    'oracle',
+    'version-anchors'
+]);
+
+/**
+ * @summary Reduces internal execution context to the fixed public phase vocabulary. Unknown or
+ * attacker-controlled values collapse to `unclassified` rather than crossing the receipt boundary.
+ * @param {*} phase Internal runner phase.
+ * @returns {String}
+ */
+function normalizeUnexpectedFailurePhase(phase) {
+    return UNEXPECTED_FAILURE_PHASES.includes(phase) ? phase : 'unclassified'
+}
+
 const SAFE_ENV_KEYS = new Set([
     'CI',
     'COLORTERM',
@@ -401,13 +429,21 @@ export async function resolvePorts(options) {
  * @summary Creates a classified probe error whose public message comes from a closed allowlist.
  * @param {String} code Public failure code.
  * @param {*} [cause] Private in-process cause.
+ * @param {String} [phase] Fixed runner phase for an unexpected failure.
  * @returns {Error}
  */
-export function createProbeFailure(code, cause) {
+export function createProbeFailure(code, cause, phase) {
     const resolvedCode = Object.hasOwn(PUBLIC_FAILURES, code) ? code : 'UNEXPECTED_FAILURE';
     const error        = new Error(PUBLIC_FAILURES[resolvedCode]);
 
     error.code = resolvedCode;
+
+    if (resolvedCode === 'UNEXPECTED_FAILURE') {
+        Object.defineProperty(error, 'phase', {
+            configurable: true,
+            value       : normalizeUnexpectedFailurePhase(phase)
+        })
+    }
 
     if (cause !== undefined) {
         Object.defineProperty(error, 'cause', {
@@ -422,12 +458,18 @@ export function createProbeFailure(code, cause) {
 /**
  * @summary Redacts any internal failure into the closed public receipt shape.
  * @param {*} error Internal error.
- * @returns {{code:String, message:String}}
+ * @returns {{code:String, message:String, phase: (String|undefined)}}
  */
 export function toPublicProbeError(error) {
-    const code = Object.hasOwn(PUBLIC_FAILURES, error?.code) ? error.code : 'UNEXPECTED_FAILURE';
+    const
+        code        = Object.hasOwn(PUBLIC_FAILURES, error?.code) ? error.code : 'UNEXPECTED_FAILURE',
+        publicError = {code, message: PUBLIC_FAILURES[code]};
 
-    return {code, message: PUBLIC_FAILURES[code]}
+    if (code === 'UNEXPECTED_FAILURE') {
+        publicError.phase = normalizeUnexpectedFailurePhase(error?.phase)
+    }
+
+    return publicError
 }
 
 /**
@@ -1095,6 +1137,8 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
             transport: null
         };
 
+    let activePhase = 'bootstrap';
+
     const runPhase = (operation, label, requestedTimeoutMs = timeoutMs) => withTimeout(
         Promise.resolve().then(operation),
         getPhaseTimeout({deadline: workDeadline, timeoutMs: requestedTimeoutMs}),
@@ -1128,6 +1172,8 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
         await runPhase(() => import('../../../src/Neo.mjs'), 'Neo bootstrap');
         await runPhase(() => import('../../../src/core/_export.mjs'), 'Neo core bootstrap');
 
+        activePhase = 'isolation-setup';
+
         state.root = await runPhase(
             () => fsPromises.mkdtemp(path.join(os.tmpdir(), 'neo-genesis-probe-')),
             'Disposable-root creation'
@@ -1146,6 +1192,8 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
         }
 
         ({databasePath, logPath} = environments);
+
+        activePhase = 'child-readiness';
 
         const bridgeLog = path.join(state.root, 'neural-link-bridge-stdio.log');
         state.children.bridge = spawnLoggedChild({
@@ -1177,15 +1225,14 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
             name   : 'Neo dev server'
         });
         await waitForChildReady({
-            child        : state.children.dev,
-            deadline     : workDeadline,
-            label        : 'Neo dev server',
-            logPath      : devLog,
-            markers      : ['[webpack-dev-server] Loopback:', `${LOOPBACK_HOST}:${ports.dev}/`],
-            port         : ports.dev,
+            child   : state.children.dev,
+            deadline: workDeadline,
+            label   : 'Neo dev server',
+            logPath : devLog,
+            markers : ['[webpack-dev-server] Loopback:', `${LOOPBACK_HOST}:${ports.dev}/`],
+            port    : ports.dev,
             signal,
-            timeoutMs,
-            uniqueMarkers: [environments.diagnosticAttestations.mcp.marker]
+            timeoutMs
         });
 
         const mcpLog = path.join(state.root, 'neural-link-mcp-stdio.log');
@@ -1208,11 +1255,14 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
                 `Port: ${ports.mcp}`,
                 `Host: ${LOOPBACK_HOST}`
             ],
-            port    : ports.mcp,
+            port         : ports.mcp,
             signal,
-            timeoutMs
+            timeoutMs,
+            uniqueMarkers: [environments.diagnosticAttestations.mcp.marker]
         });
         diagnosticPathsIsolated = true;
+
+        activePhase = 'browser-import';
 
         const {chromium}    = await runPhase(() => import('playwright'), 'Playwright bootstrap');
         const launchOptions = createBrowserLaunchOptions({
@@ -1221,7 +1271,10 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
             headed        : options.headed
         });
 
+        activePhase = 'browser-launch';
         state.browser = await runPhase(() => chromium.launch(launchOptions), 'Browser launch');
+
+        activePhase = 'browser-context';
         state.context = await runPhase(() => state.browser.newContext(), 'Browser context creation');
         const page = await runPhase(() => state.context.newPage(), 'Browser page creation');
 
@@ -1238,6 +1291,7 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
             })
         }), 'BigData config route');
 
+        activePhase = 'app-navigation';
         await runPhase(() => page.goto(
             `http://${LOOPBACK_HOST}:${ports.dev}/examples/grid/bigData/index.html`,
             {
@@ -1245,6 +1299,8 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
                 timeout  : getPhaseTimeout({deadline: workDeadline, timeoutMs})
             }
         ), 'BigData navigation');
+
+        activePhase = 'app-readiness';
         await runPhase(() => page.waitForSelector('.neo-grid-container', {
             state  : 'visible',
             timeout: getPhaseTimeout({deadline: workDeadline, timeoutMs})
@@ -1259,8 +1315,10 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
         environments.clientHeaders = null;
         state.client = new Client({name: 'neo-genesis-reference-probe', version: '1.0.0'}, {capabilities: {}});
 
+        activePhase = 'mcp-connect';
         await runPhase(() => state.client.connect(state.transport), 'MCP connect');
 
+        activePhase = 'mcp-profile';
         const listedTools = (await runPhase(() => state.client.listTools(), 'MCP tools/list')).tools.map(tool => tool.name);
 
         if (JSON.stringify(listedTools) !== JSON.stringify(EXACT_TOOL_NAMES)) {
@@ -1273,9 +1331,10 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
         ));
 
         if (health.status !== 'healthy') {
-            throw createProbeFailure('UNEXPECTED_FAILURE', {healthStatus: health.status})
+            throw createProbeFailure('UNEXPECTED_FAILURE', {healthStatus: health.status}, activePhase)
         }
 
+        activePhase = 'topology';
         const topology = await waitForBigDataTopology({
             client  : state.client,
             deadline: workDeadline,
@@ -1288,6 +1347,7 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
             throw createProbeFailure('TOPOLOGY_MISMATCH', {reason: 'missing-session-id'})
         }
 
+        activePhase = 'tool-journey';
         const treeResult = readToolJson(await runPhase(
             () => state.client.callTool({
                 name     : 'get_component_tree',
@@ -1296,6 +1356,7 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
             'get_component_tree'
         ));
 
+        activePhase = 'oracle';
         ({oracle, canonicalJson} = canonicalizeOracle(treeResult.tree));
         saltHex   = crypto.randomBytes(32).toString('hex');
         commitment = createOracleCommitment({canonicalJson, saltHex});
@@ -1332,7 +1393,8 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
             emitEvent('GENESIS_ORACLE_REVEAL', {canonicalJson, saltHex})
         }
     } catch (error) {
-        failure = error
+        failure = Object.hasOwn(PUBLIC_FAILURES, error?.code) ? error :
+            createProbeFailure('UNEXPECTED_FAILURE', error, activePhase)
     } finally {
         const
             cleanupDeadline  = createCleanupDeadline(),
@@ -1498,7 +1560,7 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
     } catch (error) {
         failure ||= Date.now() >= deadline ?
             createProbeFailure('SESSION_LIMIT_EXCEEDED', error) :
-            createProbeFailure('UNEXPECTED_FAILURE', error)
+            createProbeFailure('UNEXPECTED_FAILURE', error, 'version-anchors')
     }
 
     if (Date.now() >= deadline) {
@@ -1536,7 +1598,7 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
 
     if (failure) {
         const publicFailure = toPublicProbeError(failure);
-        throw createProbeFailure(publicFailure.code, failure)
+        throw createProbeFailure(publicFailure.code, failure, publicFailure.phase)
     }
     return receipt
 }

--- a/ai/scripts/diagnostics/genesisProbe.mjs
+++ b/ai/scripts/diagnostics/genesisProbe.mjs
@@ -12,6 +12,10 @@ import readline                          from 'readline/promises';
 import {createRequire}                   from 'module';
 import {fileURLToPath, pathToFileURL}    from 'url';
 import {createLocalBearerLaunchContract} from '../../mcp/server/shared/helpers/localBearer.mjs';
+import {
+    GENESIS_DIAGNOSTIC_ATTESTATION_ENV,
+    createDiagnosticPathAttestation
+} from '../../mcp/server/neural-link/diagnosticPathAttestation.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -183,14 +187,24 @@ export function createBrowserLaunchOptions({
  * @param {String} [options.bearerToken] Optional external-mode token.
  * @param {{dev:Number, bridge:Number, mcp:Number}} options.ports
  * @param {String} options.root Disposable diagnostic root.
- * @returns {{databasePath:String, logPath:String, clientHeaders:Object, devEnv:Object, bridgeEnv:Object, mcpEnv:Object}}
+ * @returns {{databasePath:String, logPath:String, clientHeaders:Object, devEnv:Object, bridgeEnv:Object, mcpEnv:Object, diagnosticAttestations:Object}}
  */
 export function createProbeEnvironments({baseEnv = process.env, bearerToken, ports, root}) {
     const
-        launchContract = createLocalBearerLaunchContract(bearerToken),
-        safeEnv        = createSafeBaseEnv(baseEnv),
-        databasePath   = path.join(root, 'memory-core.sqlite'),
-        logPath        = root,
+        launchContract         = createLocalBearerLaunchContract(bearerToken),
+        safeEnv                = createSafeBaseEnv(baseEnv),
+        databasePath           = path.join(root, 'memory-core.sqlite'),
+        logPath                = root,
+        diagnosticAttestations = {
+            bridge: createDiagnosticPathAttestation({
+                role : 'bridge',
+                sinks: {logs: logPath}
+            }),
+            mcp: createDiagnosticPathAttestation({
+                role : 'mcp',
+                sinks: {database: databasePath, logs: logPath}
+            })
+        },
         commonEnv      = {
             ...safeEnv,
             FORCE_COLOR              : '0',
@@ -204,20 +218,22 @@ export function createProbeEnvironments({baseEnv = process.env, bearerToken, por
         },
         bridgeEnv = {
             ...commonEnv,
-            NEO_NL_LOG_PATH: logPath,
-            NEO_NL_PORT    : String(ports.bridge)
+            [GENESIS_DIAGNOSTIC_ATTESTATION_ENV]: diagnosticAttestations.bridge.commitment,
+            NEO_NL_LOG_PATH                     : logPath,
+            NEO_NL_PORT                         : String(ports.bridge)
         },
         mcpEnv = {
             ...commonEnv,
             ...launchContract.serverEnv,
-            HOST                       : LOOPBACK_HOST,
-            MCP_HTTP_PORT              : String(ports.mcp),
-            NEO_MEMORY_DB_PATH         : databasePath,
-            NEO_NL_AUTO_CONNECT        : 'true',
-            NEO_NL_LOG_PATH            : logPath,
-            NEO_NL_PORT                : String(ports.bridge),
-            NEO_NL_TOOL_PROJECTION_MODE: PROBE_PROJECTION_MODE,
-            NEO_TRANSPORT              : 'streamable-http'
+            [GENESIS_DIAGNOSTIC_ATTESTATION_ENV]: diagnosticAttestations.mcp.commitment,
+            HOST                                : LOOPBACK_HOST,
+            MCP_HTTP_PORT                       : String(ports.mcp),
+            NEO_MEMORY_DB_PATH                  : databasePath,
+            NEO_NL_AUTO_CONNECT                 : 'true',
+            NEO_NL_LOG_PATH                     : logPath,
+            NEO_NL_PORT                         : String(ports.bridge),
+            NEO_NL_TOOL_PROJECTION_MODE         : PROBE_PROJECTION_MODE,
+            NEO_TRANSPORT                       : 'streamable-http'
         };
 
     assertDiagnosticPathsWithinRoot({databasePath, logPath, root});
@@ -226,6 +242,7 @@ export function createProbeEnvironments({baseEnv = process.env, bearerToken, por
         databasePath,
         logPath,
         clientHeaders: launchContract.clientHeaders,
+        diagnosticAttestations,
         devEnv,
         bridgeEnv,
         mcpEnv
@@ -343,57 +360,6 @@ export async function createManifest(root) {
     await walk(root);
 
     return {rootPresent: true, entries}
-}
-
-/**
- * @summary Captures a metadata-only path snapshot for the default-path non-touch guard.
- * @param {String} targetPath
- * @returns {Promise<Object>}
- */
-export async function snapshotPath(targetPath) {
-    try {
-        const stat = await fsPromises.lstat(targetPath);
-
-        if (!stat.isDirectory()) {
-            return {
-                exists : true,
-                type   : stat.isFile() ? 'file' : stat.isSymbolicLink() ? 'symlink' : 'other',
-                bytes  : stat.size,
-                mtimeMs: stat.mtimeMs
-            }
-        }
-
-        const manifest = await createManifest(targetPath);
-
-        return {
-            exists : true,
-            type   : 'directory',
-            entries: manifest.entries,
-            mtimeMs: stat.mtimeMs
-        }
-    } catch (error) {
-        if (error.code === 'ENOENT') {
-            return {exists: false}
-        }
-        throw error
-    }
-}
-
-/**
- * @summary Captures the complete SQLite file family for the default-path non-touch guard. WAL
- * mode can mutate the `-wal` or `-shm` sidecar while the main database file stays byte-identical,
- * so all three paths are one proof surface.
- * @param {String} databasePath Main SQLite database path.
- * @returns {Promise<Object>} Metadata snapshots for the main, WAL, and SHM files.
- */
-export async function snapshotSqliteFamily(databasePath) {
-    const [database, wal, shm] = await Promise.all([
-        snapshotPath(databasePath),
-        snapshotPath(`${databasePath}-wal`),
-        snapshotPath(`${databasePath}-shm`)
-    ]);
-
-    return {database, wal, shm}
 }
 
 /**
@@ -613,14 +579,26 @@ export async function waitForPortsClosed(ports, timeoutMs) {
  * @param {String} options.label
  * @param {String} options.logPath Child-private stdio log inside the disposable root.
  * @param {String[]} options.markers Exact marker fragments emitted only after the child binds.
+ * @param {String[]} [options.uniqueMarkers=[]] Marker fragments that must occur exactly once.
  * @param {Number} options.port
  * @param {Number} options.timeoutMs
  * @param {Number} [options.deadline] Global session deadline.
  * @param {AbortSignal} [options.signal] Probe interruption signal.
  * @returns {Promise<void>}
  */
-export async function waitForChildReady({child, deadline, label, logPath, markers, port, signal, timeoutMs}) {
-    if (!logPath || !Array.isArray(markers) || markers.length === 0) {
+export async function waitForChildReady({
+    child,
+    deadline,
+    label,
+    logPath,
+    markers,
+    port,
+    signal,
+    timeoutMs,
+    uniqueMarkers = []
+}) {
+    if (!logPath || !Array.isArray(markers) || markers.length === 0 ||
+        !Array.isArray(uniqueMarkers) || uniqueMarkers.some(marker => !markers.includes(marker))) {
         throw new TypeError(`${label} readiness requires a private log path and at least one marker.`)
     }
 
@@ -644,6 +622,10 @@ export async function waitForChildReady({child, deadline, label, logPath, marker
             logText = await fsPromises.readFile(logPath, 'utf8')
         } catch (error) {
             if (error.code !== 'ENOENT') throw error
+        }
+
+        if (uniqueMarkers.some(marker => logText.indexOf(marker) !== logText.lastIndexOf(marker))) {
+            throw new Error(`${label} emitted duplicate child-private readiness evidence.`)
         }
 
         if (markers.every(marker => logText.includes(marker))) {
@@ -938,21 +920,18 @@ export async function readAggregateTelemetry(databasePath) {
  * must fail the receipt without becoming a veto that leaves raw diagnostics behind.
  * @param {Object} options
  * @param {String|null} options.databasePath Isolated SQLite path.
- * @param {Object|null} options.defaultPaths Default live database/log paths.
  * @param {Boolean} options.deletionAuthorized Whether process shutdown proof permits deletion.
  * @param {String} options.root Disposable diagnostic root.
- * @returns {Promise<Object>} Aggregate evidence, manifests, default snapshot, and private failures.
+ * @returns {Promise<Object>} Aggregate evidence, manifests, and private failures.
  */
 export async function finalizeDisposableRoot({
     databasePath,
-    defaultPaths,
     deletionAuthorized,
     root
 }) {
     let
         afterManifest  = {rootPresent: null, entries: []},
         beforeManifest = {rootPresent: null, entries: []},
-        defaultAfter   = null,
         telemetry      = [];
 
     const failures = [];
@@ -978,17 +957,6 @@ export async function finalizeDisposableRoot({
         value => { beforeManifest = value }
     );
 
-    if (defaultPaths) {
-        await capture(
-            'Default-path after snapshot',
-            async () => ({
-                database: await snapshotSqliteFamily(defaultPaths.database),
-                logs    : await snapshotPath(defaultPaths.logs)
-            }),
-            value => { defaultAfter = value }
-        )
-    }
-
     if (deletionAuthorized) {
         await capture(
             'Disposable-root deletion',
@@ -1003,7 +971,7 @@ export async function finalizeDisposableRoot({
         value => { afterManifest = value }
     );
 
-    return {afterManifest, beforeManifest, defaultAfter, failures, telemetry}
+    return {afterManifest, beforeManifest, failures, telemetry}
 }
 
 /**
@@ -1138,10 +1106,7 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
         canonicalJson,
         commitment,
         databasePath,
-        defaultAfter,
-        defaultBefore,
-        defaultPaths,
-        diagnosticsConfigured = false,
+        diagnosticPathsIsolated = false,
         failure,
         logPath,
         oracle,
@@ -1163,23 +1128,6 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
         await runPhase(() => import('../../../src/Neo.mjs'), 'Neo bootstrap');
         await runPhase(() => import('../../../src/core/_export.mjs'), 'Neo core bootstrap');
 
-        const aiConfig = (await runPhase(
-            () => import('../../mcp/server/neural-link/config.mjs'),
-            'Neural Link config bootstrap'
-        )).default;
-
-        defaultPaths = {
-            database: aiConfig.memoryCoreDbPath,
-            logs    : aiConfig.logPath
-        };
-        defaultBefore = {
-            database: await runPhase(
-                () => snapshotSqliteFamily(defaultPaths.database),
-                'Default SQLite-family snapshot'
-            ),
-            logs    : await runPhase(() => snapshotPath(defaultPaths.logs), 'Default log snapshot')
-        };
-
         state.root = await runPhase(
             () => fsPromises.mkdtemp(path.join(os.tmpdir(), 'neo-genesis-probe-')),
             'Disposable-root creation'
@@ -1198,7 +1146,6 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
         }
 
         ({databasePath, logPath} = environments);
-        diagnosticsConfigured = true;
 
         const bridgeLog = path.join(state.root, 'neural-link-bridge-stdio.log');
         state.children.bridge = spawnLoggedChild({
@@ -1212,10 +1159,14 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
             deadline: workDeadline,
             label   : 'Neural Link Bridge',
             logPath : bridgeLog,
-            markers : [`Bridge: Listening on ${LOOPBACK_HOST}:${ports.bridge}`],
-            port    : ports.bridge,
+            markers : [
+                environments.diagnosticAttestations.bridge.marker,
+                `Bridge: Listening on ${LOOPBACK_HOST}:${ports.bridge}`
+            ],
+            port         : ports.bridge,
             signal,
-            timeoutMs
+            timeoutMs,
+            uniqueMarkers: [environments.diagnosticAttestations.bridge.marker]
         });
 
         const devLog = path.join(state.root, 'dev-server-stdio.log');
@@ -1226,14 +1177,15 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
             name   : 'Neo dev server'
         });
         await waitForChildReady({
-            child   : state.children.dev,
-            deadline: workDeadline,
-            label   : 'Neo dev server',
-            logPath : devLog,
-            markers : ['[webpack-dev-server] Loopback:', `${LOOPBACK_HOST}:${ports.dev}/`],
-            port    : ports.dev,
+            child        : state.children.dev,
+            deadline     : workDeadline,
+            label        : 'Neo dev server',
+            logPath      : devLog,
+            markers      : ['[webpack-dev-server] Loopback:', `${LOOPBACK_HOST}:${ports.dev}/`],
+            port         : ports.dev,
             signal,
-            timeoutMs
+            timeoutMs,
+            uniqueMarkers: [environments.diagnosticAttestations.mcp.marker]
         });
 
         const mcpLog = path.join(state.root, 'neural-link-mcp-stdio.log');
@@ -1251,6 +1203,7 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
             label   : 'Neural Link MCP server',
             logPath : mcpLog,
             markers : [
+                environments.diagnosticAttestations.mcp.marker,
                 'Server started on Streamable HTTP transport',
                 `Port: ${ports.mcp}`,
                 `Host: ${LOOPBACK_HOST}`
@@ -1259,6 +1212,7 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
             signal,
             timeoutMs
         });
+        diagnosticPathsIsolated = true;
 
         const {chromium}    = await runPhase(() => import('playwright'), 'Playwright bootstrap');
         const launchOptions = createBrowserLaunchOptions({
@@ -1507,12 +1461,11 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
     if (state.root) {
         const finalization = await finalizeDisposableRoot({
             databasePath,
-            defaultPaths,
             deletionAuthorized: state.cleanupDeletionAuthorized,
             root              : state.root
         });
 
-        ({afterManifest, beforeManifest, defaultAfter, telemetry} = finalization);
+        ({afterManifest, beforeManifest, telemetry} = finalization);
 
         if (finalization.failures.length) {
             failure = createProbeFailure(
@@ -1522,9 +1475,6 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
         }
     }
 
-    const defaultPathsUntouched = defaultBefore && defaultAfter ?
-        JSON.stringify(defaultBefore) === JSON.stringify(defaultAfter) : null;
-
     if (afterManifest.rootPresent) {
         failure ||= createProbeFailure(
             terminationVerified ? 'CLEANUP_FAILED' : 'CHILD_TERMINATION_UNVERIFIED'
@@ -1533,10 +1483,6 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
     if (process.platform === 'win32' && !terminationVerified) {
         failure ||= createProbeFailure('CHILD_TERMINATION_UNVERIFIED')
     }
-    if (defaultPathsUntouched === false) {
-        failure ||= new Error('A default live diagnostic path changed during the isolated probe window.')
-    }
-
     let versions = {
         genesis: {version: GENESIS_VERSION, commit: GENESIS_COMMIT},
         neo    : {version: null, commit: null}
@@ -1576,10 +1522,9 @@ export async function runProbe(options, baseEnv = process.env, {signal} = {}) {
         } : null,
         telemetry,
         diagnostics  : {
-            configuredInsideDisposableRoot: diagnosticsConfigured,
+            diagnosticPathsIsolated,
             beforeManifest,
             afterManifest,
-            defaultPathsUntouched,
             listenerClosureVerified,
             terminationVerified
         },

--- a/learn/agentos/tooling/GenesisNeuralLinkProbe.md
+++ b/learn/agentos/tooling/GenesisNeuralLinkProbe.md
@@ -252,11 +252,13 @@ The final receipt must not contain:
 - raw SQLite rows or logs;
 - unrevealed oracle material.
 
-Failures use a closed public `{code, message}` allowlist. Raw tool payloads and topology rows remain
-only inside the disposable root, normally in its isolated SQLite telemetry. Private parent-process
-exception detail and absolute temporary paths additionally go into a mode-`0600`
-`private-failure.json`; any bearer material captured by either private diagnostic surface remains
-inside that root until verified cleanup removes it.
+Failures use a closed public `{code, message}` allowlist. `UNEXPECTED_FAILURE` adds one `phase` from
+a fixed runner vocabulary (for example, `child-readiness` or `app-readiness`) so a cleaned-up failure
+still names the bounded gate that ran. Arbitrary labels and exception text collapse to
+`unclassified`. Raw tool payloads and topology rows remain only inside the disposable root, normally
+in its isolated SQLite telemetry. Private parent-process exception detail and absolute temporary
+paths additionally go into a mode-`0600` `private-failure.json`; any bearer material captured by
+either private diagnostic surface remains inside that root until verified cleanup removes it.
 
 After reveal, the canonical oracle and salt are public verification material and may remain. Raw
 diagnostics may not.
@@ -282,6 +284,7 @@ after-manifest rootPresent=false:
 termination verified=true (POSIX external proof):
 runtime diagnostic paths isolated=true:
 overall success/failure:
+unexpected-failure phase (when applicable):
 ```
 
 Any missing line makes the receipt incomplete. A failed run is still valuable when it honestly

--- a/learn/agentos/tooling/GenesisNeuralLinkProbe.md
+++ b/learn/agentos/tooling/GenesisNeuralLinkProbe.md
@@ -80,11 +80,11 @@ oracle immediately, and cleans up automatically. A successful `GENESIS_PROBE_REC
 
 - `status: "success"`;
 - all three aggregate telemetry rows successful;
-- `configuredInsideDisposableRoot: true`;
+- `diagnosticPathsIsolated: true`, backed by child-computed commitments over the resolved writable
+  sinks selected by the disposable launcher;
 - a recursive `beforeManifest` containing the database and log artifacts;
 - `afterManifest.rootPresent: false`;
-- `terminationVerified: true` on POSIX;
-- `defaultPathsUntouched: true`.
+- `terminationVerified: true` on POSIX.
 
 On Windows, rehearsal can verify direct-child exit plus closure of all three known listener ports,
 but Node does not provide a Job Object or an equivalent proof that every descendant is gone. Its
@@ -280,7 +280,7 @@ aggregate tool/status/duration counts:
 recursive before-manifest:
 after-manifest rootPresent=false:
 termination verified=true (POSIX external proof):
-default live database/log paths untouched=true:
+runtime diagnostic paths isolated=true:
 overall success/failure:
 ```
 
@@ -296,8 +296,9 @@ names the failed gate and proves cleanup; it must not be rewritten as success af
   non-empty token without publishing the token.
 - **Hash mismatch:** preserve the frozen deliverable, compare UTF-8 bytes/property order/newline,
   record failure, then clean up after review.
-- **Default path changed:** treat the isolation proof as failed. Identify concurrent writers or a
-  missing environment override before another run.
+- **Diagnostic path attestation mismatch:** treat the isolation proof as failed. Inspect the private
+  child configuration for a missing or overridden sink before another run. Activity from unrelated
+  writers on default paths is outside this child-scoped proof and must not invalidate it.
 - **Root remains after cleanup:** do not delete individual filenames and call it complete. Find the
   open handle or permission failure, remove the whole root, and record the correction cycle.
 - **Interrupted run:** require the structured `PROBE_INTERRUPTED` receipt plus the same verified

--- a/test/playwright/unit/ai/scripts/diagnostics/genesisProbe.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/genesisProbe.spec.mjs
@@ -179,20 +179,36 @@ test.describe('Neo.ai.scripts.diagnostics.genesisProbe', () => {
         expect(createCleanupDeadline(deadline)).toBeGreaterThan(deadline)
     });
 
-    test('redacts unknown and classified failures into a closed public shape', () => {
+    test('redacts failures into the closed public shape and fixed unexpected phase vocabulary', () => {
         const hostile = new Error(
             'Authorization: Bearer super-secret; topology={"private":true}; /tmp/neo-genesis-probe-secret'
         );
-        const publicUnknown = toPublicProbeError(hostile);
-        const publicKnown   = toPublicProbeError(createProbeFailure('TOPOLOGY_MISMATCH', hostile));
+        const
+            publicUnknown = toPublicProbeError(hostile),
+            publicPhased  = toPublicProbeError(createProbeFailure(
+                'UNEXPECTED_FAILURE',
+                hostile,
+                'child-readiness'
+            )),
+            publicForged  = toPublicProbeError(createProbeFailure(
+                'UNEXPECTED_FAILURE',
+                hostile,
+                '/tmp/private-phase'
+            )),
+            publicKnown   = toPublicProbeError(createProbeFailure('TOPOLOGY_MISMATCH', hostile));
 
         expect(publicUnknown).toEqual({
             code   : 'UNEXPECTED_FAILURE',
-            message: 'The probe failed without a public-safe classification.'
+            message: 'The probe failed without a public-safe classification.',
+            phase  : 'unclassified'
         });
+        expect(publicPhased.phase).toBe('child-readiness');
+        expect(publicForged.phase).toBe('unclassified');
         expect(JSON.stringify(publicUnknown)).not.toContain('super-secret');
         expect(JSON.stringify(publicUnknown)).not.toContain('Authorization');
         expect(JSON.stringify(publicUnknown)).not.toContain('/tmp/');
+        expect(JSON.stringify(publicPhased)).not.toContain('super-secret');
+        expect(JSON.stringify(publicForged)).not.toContain('private-phase');
         expect(publicKnown).toEqual({
             code   : 'TOPOLOGY_MISMATCH',
             message: 'Exactly one intended BigData App Worker was not available.'

--- a/test/playwright/unit/ai/scripts/diagnostics/genesisProbe.spec.mjs
+++ b/test/playwright/unit/ai/scripts/diagnostics/genesisProbe.spec.mjs
@@ -43,12 +43,17 @@ import {
     readToolJson,
     spawnLoggedChild,
     stopChild,
-    snapshotSqliteFamily,
     toPublicProbeError,
     waitForChildExit,
     waitForChildReady,
     withTimeout
 } from '../../../../../../ai/scripts/diagnostics/genesisProbe.mjs';
+import {
+    GENESIS_DIAGNOSTIC_ATTESTATION_ENV,
+    GENESIS_DIAGNOSTIC_PATH_MISMATCH,
+    attestDiagnosticPaths,
+    createDiagnosticPathAttestation
+} from '../../../../../../ai/mcp/server/neural-link/diagnosticPathAttestation.mjs';
 
 test.describe('Neo.ai.scripts.diagnostics.genesisProbe', () => {
     test('canonicalizes the blind oracle and reproduces the fixed commitment bytes', () => {
@@ -114,6 +119,12 @@ test.describe('Neo.ai.scripts.diagnostics.genesisProbe', () => {
         expect(envs.mcpEnv.NEO_MEMORY_DB_PATH).toBe(path.join(root, 'memory-core.sqlite'));
         expect(envs.mcpEnv.NEO_NL_LOG_PATH).toBe(root);
         expect(envs.mcpEnv.NEO_NL_TOOL_PROJECTION_MODE).toBe('local-readonly-probe');
+        expect(envs.bridgeEnv[GENESIS_DIAGNOSTIC_ATTESTATION_ENV])
+            .toBe(envs.diagnosticAttestations.bridge.commitment);
+        expect(envs.mcpEnv[GENESIS_DIAGNOSTIC_ATTESTATION_ENV])
+            .toBe(envs.diagnosticAttestations.mcp.commitment);
+        expect(envs.diagnosticAttestations.bridge.marker).not.toContain(root);
+        expect(envs.diagnosticAttestations.mcp.marker).not.toContain(root);
     });
 
     test('launches the browser with the same least-authority environment boundary', () => {
@@ -260,14 +271,28 @@ test.describe('Neo.ai.scripts.diagnostics.genesisProbe', () => {
             })).rejects.toThrow('did not prove child-owned readiness');
             expect(connections).toBe(0);
 
-            await fsPromises.writeFile(logPath, `ready on 127.0.0.1:${port}`);
+            const marker = `ready on 127.0.0.1:${port}`;
+
+            await fsPromises.writeFile(logPath, `${marker}\n${marker}`);
+            await expect(waitForChildReady({
+                child,
+                label        : 'duplicate marker listener',
+                logPath,
+                markers      : [marker],
+                port,
+                timeoutMs    : 1000,
+                uniqueMarkers: [marker]
+            })).rejects.toThrow('duplicate child-private readiness evidence');
+
+            await fsPromises.writeFile(logPath, marker);
             await waitForChildReady({
                 child,
-                label    : 'marked listener',
+                label        : 'marked listener',
                 logPath,
-                markers  : [`ready on 127.0.0.1:${port}`],
+                markers      : [marker],
                 port,
-                timeoutMs: 1000
+                timeoutMs    : 1000,
+                uniqueMarkers: [marker]
             });
             await expect.poll(() => connections).toBe(1)
         } finally {
@@ -371,29 +396,86 @@ test.describe('Neo.ai.scripts.diagnostics.genesisProbe', () => {
         expect(await createManifest(root)).toEqual({rootPresent: false, entries: []})
     });
 
-    test('detects default SQLite WAL changes even when the main database stays untouched', async () => {
+    test('keeps child-scoped isolation evidence stable while unrelated writers mutate other paths', async () => {
         const
-            root         = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'neo-genesis-sqlite-family-test-')),
-            databasePath = path.join(root, 'memory-core.sqlite'),
-            walPath      = `${databasePath}-wal`;
+            probeRoot     = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'neo-genesis-attestation-test-')),
+            unrelatedRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'neo-unrelated-writer-test-')),
+            sinks         = {
+                database: path.join(probeRoot, 'memory-core.sqlite'),
+                logs    : probeRoot
+            },
+            expected      = createDiagnosticPathAttestation({role: 'mcp', sinks}),
+            unrelatedWal  = path.join(unrelatedRoot, 'memory-core.sqlite-wal');
 
         try {
-            await fsPromises.writeFile(databasePath, 'main-database');
-            await fsPromises.writeFile(walPath, 'wal-before');
+            const unrelatedLog = path.join(unrelatedRoot, 'neural-link.log');
 
-            const before = await snapshotSqliteFamily(databasePath);
+            await fsPromises.writeFile(unrelatedWal, 'before');
+            await fsPromises.writeFile(unrelatedLog, 'before');
 
-            await fsPromises.appendFile(walPath, '-changed');
+            const ambientBefore = await createManifest(unrelatedRoot);
 
-            const after = await snapshotSqliteFamily(databasePath);
+            const before = attestDiagnosticPaths({
+                expectedCommitment: expected.commitment,
+                role              : 'mcp',
+                sinks
+            });
 
-            expect(after.database).toEqual(before.database);
-            expect(after.wal).not.toEqual(before.wal);
-            expect(after.shm).toEqual({exists: false});
-            expect(JSON.stringify(after)).not.toBe(JSON.stringify(before))
+            await fsPromises.appendFile(unrelatedWal, '-concurrent-change');
+            await fsPromises.appendFile(unrelatedLog, '-concurrent-change');
+
+            const ambientAfter = await createManifest(unrelatedRoot);
+
+            expect(attestDiagnosticPaths({
+                expectedCommitment: expected.commitment,
+                role              : 'mcp',
+                sinks
+            })).toBe(before);
+            expect(ambientAfter).not.toEqual(ambientBefore);
+            expect(before).toBe(expected.marker);
+            expect(before).not.toContain(probeRoot);
+            expect(before).not.toContain(unrelatedRoot)
         } finally {
-            await fsPromises.rm(root, {recursive: true, force: true})
+            await Promise.all([
+                fsPromises.rm(probeRoot, {recursive: true, force: true}),
+                fsPromises.rm(unrelatedRoot, {recursive: true, force: true})
+            ])
         }
+    });
+
+    test('fails path-attestation mismatches without exposing paths or commitments', () => {
+        const
+            expectedPath = path.join(os.tmpdir(), 'expected-private-root'),
+            actualPath   = path.join(os.tmpdir(), 'unexpected-private-root'),
+            expected     = createDiagnosticPathAttestation({
+                role : 'mcp',
+                sinks: {database: path.join(expectedPath, 'memory-core.sqlite'), logs: expectedPath}
+            });
+
+        let error;
+
+        try {
+            attestDiagnosticPaths({
+                expectedCommitment: expected.commitment,
+                role              : 'mcp',
+                sinks             : {database: path.join(actualPath, 'memory-core.sqlite'), logs: actualPath}
+            })
+        } catch (caught) {
+            error = caught
+        }
+
+        expect(error?.code).toBe(GENESIS_DIAGNOSTIC_PATH_MISMATCH);
+        expect(error?.message).not.toContain(expectedPath);
+        expect(error?.message).not.toContain(actualPath);
+        expect(error?.message).not.toContain(expected.commitment);
+        expect(() => createDiagnosticPathAttestation({
+            role : 'mcp',
+            sinks: {logs: expectedPath}
+        })).toThrow('complete writable-sink role set');
+        expect(() => createDiagnosticPathAttestation({
+            role : 'mcp',
+            sinks: {database: expectedPath, logs: expectedPath, extra: expectedPath}
+        })).toThrow('complete writable-sink role set')
     });
 
     test('deletes an authorized root even when aggregate telemetry evidence is unreadable', async () => {
@@ -408,7 +490,6 @@ test.describe('Neo.ai.scripts.diagnostics.genesisProbe', () => {
 
         const result = await finalizeDisposableRoot({
             databasePath,
-            defaultPaths      : null,
             deletionAuthorized: true,
             root
         });


### PR DESCRIPTION
Resolves #15330

Related: #15291

Replaces attribution-free before/after snapshots of shared default diagnostics with positive child-owned runtime evidence. The Genesis launcher now commits to the exact Bridge and MCP writable sinks under its disposable root; each child recomputes that commitment from resolved AiConfig leaves before its first configured writer or listener starts, and readiness requires one exact secret-free marker per child. Unrelated Memory Core or log writers can no longer change the probe verdict.

Evidence: L3 (focused security coverage plus a real bundled stack accepting both child attestations and reporting `diagnosticPathsIsolated: true` before a separately scoped browser-launch failure) → L3 required (the live diagnostic-isolation AC). No residuals for #15330.

## Deltas from ticket

None substantive. The implementation makes the ticket's complete-role and duplicate-evidence requirements mechanical through a fixed role contract and exactly-once readiness markers. The author self-audit moved the MCP marker's uniqueness check off the unrelated dev-server wait and onto the MCP readiness gate, then added the ticket-required fixed, secret-free `UNEXPECTED_FAILURE.phase` vocabulary. The authored live-rehearsal AC remains scoped to this ticket's isolation gate, consistent with its explicit exclusion of the separate generic pre-oracle failure.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/scripts/diagnostics/genesisProbe.spec.mjs` — 18/18 passed. Covers the old ambient-equality falsifier, unrelated concurrent SQLite/log writes, exact role sets, missing/duplicate readiness evidence, path mismatch redaction, cleanup, fixed phase redaction, and a real standalone Bridge launch.
- `node --check` on the helper, both entrypoints, MCP server class, runner, and focused spec — passed.
- `npm run agent-preflight -- <changed files>` — passed, including JSDoc, AiConfig mutation, ticket archaeology, parse, and block-alignment gates.
- `npm run ai:genesis-probe -- --browser-channel bundled` at `961a3a4222` — the real stack accepted both child commitments and emitted `diagnosticPathsIsolated: true`; listener closure, process termination, and whole-root deletion were also verified. The later separately scoped `UNEXPECTED_FAILURE` is now truthfully bounded to fixed phase `browser-launch`, with no raw cause or path crossing the receipt boundary.
- Neural Link MCP/Bridge runtime surface: bundled live rehearsal + focused child-launch spec, results above.

## Post-Merge Validation

- [ ] Use merged `dev` for the synchronized bilateral #15291 window and append its full public receipt to that ticket.

## Evolution

The exact-dev rehearsal falsified the original proof model: shared-path deltas had no writer identity. The branch therefore removed that measurement entirely and moved the proof into the children that own the configured sinks, preserving AiConfig as the resolution authority and exposing only role names plus SHA-256 commitments in private readiness logs. The repair pass then used the newly retained phase to separate the proven isolation gate from the later browser-runtime symptom instead of misclassifying either.

Authored by Euclid (OpenAI GPT-5.6 Sol Ultra, Codex Desktop). Session 33768847-a08d-46b2-8aae-bd289a7c4b35.
