### PR TITLE
feat(fleet): the activitySource producer for a slot consumed since it was written (#15333)

### DIFF
--- a/ai/services/fleet/fleetActivityComposer.mjs
+++ b/ai/services/fleet/fleetActivityComposer.mjs
@@ -1,0 +1,140 @@
+import {DEFAULT_FLEET_ACTIVITY_EVENT_LIMIT} from './fleetPrLaneActivityAdapter.mjs';
+import {FLEET_COCKPIT_SOURCES}              from '../../../src/ai/fleet/fleetCockpitStatus.mjs';
+
+/**
+ * @module ai/services/fleet/fleetActivityComposer
+ * @summary The producer for `FleetControlBridge.activitySource` — one bounded `{capability, events}`
+ * snapshot composed from the landed A2A and PR/lane adapters.
+ *
+ * The bridge has consumed `readActivitySnapshot(params)` since it was written, and nothing ever
+ * produced it: the capability's own name (`fleet:activity-adapters`) promised a composition that did
+ * not exist, so `fleetActivity` answered `not-wired` permanently, by construction.
+ *
+ * **Composing two truths means composing two capabilities, and that is the whole design.** Events
+ * merge trivially; sight does not. A composite may only claim `wired` when EVERY contributing adapter
+ * is wired — because a caller reading `wired` concludes it is seeing the fleet's activity, and one
+ * blind adapter makes that false while leaving the event list looking perfectly healthy. A degraded
+ * adapter's missing events are indistinguishable from quiet ones, so the capability is the only place
+ * that difference can survive.
+ *
+ * The adapters are INJECTED readers, never imported singletons: the mailbox / PR read paths own
+ * identity binding and read permissions, so composing must not smuggle a second path to them.
+ */
+
+/**
+ * @summary Merges two adapter snapshots into one, newest-first and bounded.
+ *
+ * @param {Object[]} events Every contributing adapter's events.
+ * @param {Number} limit Maximum rows to return.
+ * @returns {Object[]}
+ * @private
+ */
+function boundEvents(events, limit) {
+    return events
+        .filter(Boolean)
+        .sort((left, right) => String(right?.occurredAt ?? '').localeCompare(String(left?.occurredAt ?? '')))
+        .slice(0, limit)
+}
+
+/**
+ * @summary Composes the contributing capabilities into the one the caller may trust.
+ *
+ * Fail-honest and deliberately pessimistic: `wired` requires unanimity. Any contributor that is
+ * not wired downgrades the composite and names itself in the reason, because "we saw everything"
+ * and "we saw what we could" are different claims and only one of them is true here. Confidence
+ * follows the same rule — the composite is never more confident than its weakest contributor.
+ *
+ * @param {Object[]} capabilities Contributing adapter capabilities.
+ * @param {String} capturedAt ISO capture stamp.
+ * @returns {Object} `{source, state, confidence, capturedAt, reason}`
+ * @private
+ */
+function composeCapability(capabilities, capturedAt) {
+    const blind = capabilities.filter(capability => capability?.state !== 'wired');
+
+    if (blind.length === 0) {
+        return {
+            source    : FLEET_COCKPIT_SOURCES.activity,
+            state     : 'wired',
+            confidence: 'observed',
+            capturedAt,
+            reason    : null
+        }
+    }
+
+    // Name every blind contributor, not just the first: an operator debugging a partial feed needs to
+    // know which half is missing, and a single-source reason invites fixing the wrong adapter.
+    const reason = blind
+        .map(capability => `${capability?.source ?? 'unknown source'}: ${capability?.reason ?? capability?.state ?? 'unavailable'}`)
+        .join('; ');
+
+    return {
+        source    : FLEET_COCKPIT_SOURCES.activity,
+        // `not-wired` only when NOTHING could be read — otherwise the feed genuinely carries partial
+        // truth and `degraded` is the honest word for it. Collapsing both into one state would tell a
+        // caller with half a feed the same thing it tells one with none.
+        state     : blind.length === capabilities.length ? 'not-wired' : 'degraded',
+        confidence: 'none',
+        capturedAt,
+        reason
+    }
+}
+
+/**
+ * @summary Builds the injectable activity read-source the bridge consumes.
+ *
+ * @param {Object}   options={}
+ * @param {Function} options.readA2ASnapshot `params => Promise<{capability, events}>` — the A2A
+ *   adapter's read path, already bound to its own injected `listMessages`.
+ * @param {Function} options.readPrLaneSnapshot `params => Promise<{capability, events}>` — the
+ *   PR/lane adapter's read path. The adapter itself is a pure builder over already-read facts, so
+ *   the caller owns the reading and this composer never reaches for GitHub or the graph directly.
+ * @param {Number}   [options.limit=DEFAULT_FLEET_ACTIVITY_EVENT_LIMIT] Default event bound.
+ * @returns {{readActivitySnapshot: Function}} The `FleetControlBridge.activitySource` contract.
+ * @throws {TypeError} When a reader is missing — an unreadable half must be an explicit degraded
+ *   capability from a real adapter, never a composer quietly composing one contributor and calling
+ *   the result the fleet's activity.
+ */
+export function createFleetActivityReadSource({readA2ASnapshot, readPrLaneSnapshot, limit = DEFAULT_FLEET_ACTIVITY_EVENT_LIMIT} = {}) {
+    if (typeof readA2ASnapshot !== 'function' || typeof readPrLaneSnapshot !== 'function') {
+        throw new TypeError('[fleetActivityComposer] readA2ASnapshot and readPrLaneSnapshot must be injected')
+    }
+
+    return {
+        async readActivitySnapshot(params = {}) {
+            const
+                capturedAt = new Date().toISOString(),
+                bound      = params.limit ?? limit,
+                // Both are asked even when one is expected to fail: a contributor that cannot read
+                // must return its OWN degraded capability, and short-circuiting would replace that
+                // adapter's stated reason with the composer's guess about it.
+                contributions = await Promise.all([
+                    Promise.resolve(readA2ASnapshot({...params, limit: bound})).catch(error => ({
+                        capability: {
+                            source    : FLEET_COCKPIT_SOURCES.activity,
+                            state     : 'degraded',
+                            confidence: 'none',
+                            capturedAt,
+                            reason    : `a2a adapter threw: ${error?.message ?? error}`
+                        },
+                        events: []
+                    })),
+                    Promise.resolve(readPrLaneSnapshot({...params, limit: bound})).catch(error => ({
+                        capability: {
+                            source    : FLEET_COCKPIT_SOURCES.activity,
+                            state     : 'degraded',
+                            confidence: 'none',
+                            capturedAt,
+                            reason    : `pr-lane adapter threw: ${error?.message ?? error}`
+                        },
+                        events: []
+                    }))
+                ]);
+
+            return {
+                capability: composeCapability(contributions.map(contribution => contribution?.capability), capturedAt),
+                events    : boundEvents(contributions.flatMap(contribution => contribution?.events ?? []), bound)
+            }
+        }
+    }
+}

--- a/ai/services/fleet/fleetActivityComposer.mjs
+++ b/ai/services/fleet/fleetActivityComposer.mjs
@@ -41,6 +41,21 @@ export const FLEET_ACTIVITY_SLOTS = Object.freeze({
 export const FLEET_ACTIVITY_REASON_MAX = 200;
 
 /**
+ * @summary The hard ceiling on events a caller may request — a MAXIMUM, not a default.
+ *
+ * `DEFAULT_FLEET_ACTIVITY_EVENT_LIMIT` is what a caller gets when it asks for nothing; this is what
+ * it gets when it asks for everything. Without the distinction, refusing `-1` and `NaN` while
+ * obeying `1e9` guards the malformed case and leaves the one that matters: `params` arrives over the
+ * wire from the App Worker, so the ceiling was caller-chosen against a producer that fans out to
+ * every adapter.
+ *
+ * 4× the default: generous enough that no honest caller meets it, bounded enough that a dishonest
+ * one cannot turn one request into an unbounded read of the mailbox and GitHub at once.
+ * @type {Number}
+ */
+export const FLEET_ACTIVITY_BOUND_MAX = 200;
+
+/**
  * @summary Resolves the event bound, refusing values that would silently unbound the read.
  *
  * `params.limit ?? limit` accepted `-1`, `NaN`, `0` and `'50'` — a caller-supplied bound reaches the
@@ -55,7 +70,11 @@ export const FLEET_ACTIVITY_REASON_MAX = 200;
 function normalizeBound(requested, fallback) {
     const value = Number(requested);
 
-    return Number.isInteger(value) && value > 0 ? value : fallback
+    // Two different refusals, and the first cut only had one. An unusable bound falls back to the
+    // default; a USABLE but unbounded one is clamped. `Number.isInteger(1e9) && 1e9 > 0` is true, so
+    // checking only well-formedness let the exact read this guard exists to stop walk through the
+    // front door — the reason string was already capped in this same file, and the count was not.
+    return Number.isInteger(value) && value > 0 ? Math.min(value, FLEET_ACTIVITY_BOUND_MAX) : Math.min(fallback, FLEET_ACTIVITY_BOUND_MAX)
 }
 
 /**

--- a/ai/services/fleet/fleetActivityComposer.mjs
+++ b/ai/services/fleet/fleetActivityComposer.mjs
@@ -94,24 +94,35 @@ function capText(raw, max) {
 }
 
 /**
- * @summary Credential shapes an adapter error can carry into an operator-facing string.
+ * @summary Credential shapes an adapter error can carry into an operator-facing string, each paired
+ * with an EXPLICIT replacement.
  *
- * The JSDoc below already named tokens as the threat while the code only collapsed whitespace and
- * truncated, so `Authorization: Bearer <token>` reached the cockpit intact and survived the cap. The
- * value is replaced rather than the whole message dropped: an operator still needs to know WHICH call
+ * The pairing is the contract, and deriving the replacement from the match instead is what made the
+ * first cut worse than no redaction at all: `` `${match.split(/[:=\s]/)[0]}: [redacted]` `` assumed
+ * every match was `key: value`. **A bare token has no delimiter, so the whole secret became the
+ * "label"** and was printed next to the word `[redacted]` — the string reported itself handled while
+ * carrying the credential. A replacement may echo a KEY (an explicit `$1` capture of the key alone)
+ * or be a literal; it may never be computed from the matched text.
+ *
+ * The families are the same-subsystem set the Fleet wake/throttle/mailbox adapters already redact,
+ * plus fine-grained `github_pat_`, which `gh[pousr]_` cannot match (`[pousr]` fails on `i`) — so that
+ * family currently reaches a Body-facing surface through those siblings too.
+ *
+ * The value is replaced rather than the message dropped: an operator still needs to know WHICH call
  * failed, and a reason of `[redacted]` debugs nothing.
  * @private
  */
 const CREDENTIAL_PATTERNS = [
-    // The scheme must be consumed WITH the token. `[:=]\s*\S+` took only `Bearer` and left the
-    // credential one space away — and worse, it destroyed the `Bearer` marker the next pattern
-    // matches on, so the first redaction blinded the second. An earlier guard can hide the surface a
-    // later guard exists to find.
-    /\b(?:proxy-)?authorization\s*[:=]\s*(?:(?:bearer|basic|digest|token)\s+)?[^\s,;]+/gi,
-    /\b(?:bearer|basic)\s+[\w\-._~+/]+=*/gi,
-    /\b(?:api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd|token)\s*[:=]\s*\S+/gi,
-    /\bgh[pousr]_[A-Za-z0-9]{16,}\b/g,
-    /\b(?:x-)?(?:api-)?key\s*[:=]\s*\S+/gi
+    // The scheme is consumed WITH the token: `[:=]\s*\S+` took only `Bearer` and left the credential
+    // one space away — and destroyed the `Bearer` marker the next pattern matches on, so the first
+    // redaction blinded the second. An earlier guard can hide the surface a later guard exists to find.
+    [/\b((?:proxy-)?authorization)\s*[:=]\s*(?:(?:bearer|basic|digest|token)\s+)?[^\s,;)]+/gi, '$1: [redacted]'],
+    [/\b(bearer|basic)\s+[\w\-._~+/]+=*/gi,                                                    '$1 [redacted]'],
+    [/\b(api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd|pat|credential|privateKey|signingKey|token)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]'],
+    // Bare tokens: no key, no delimiter — the match IS the secret, so the whole match goes.
+    [/\bgithub_pat_[A-Za-z0-9_]+/g, '[redacted-token]'],
+    [/\bgh[pousr]_[A-Za-z0-9_]+/g,  '[redacted-token]'],
+    [/\bglpat-[A-Za-z0-9_-]+/g,     '[redacted-token]']
 ];
 
 /**
@@ -132,8 +143,8 @@ const CREDENTIAL_PATTERNS = [
 function redactReason(failure) {
     let raw = `${failure?.message ?? failure ?? 'unknown failure'}`.replace(/\s+/g, ' ').trim();
 
-    CREDENTIAL_PATTERNS.forEach(pattern => {
-        raw = raw.replace(pattern, match => `${match.split(/[:=\s]/)[0]}: [redacted]`)
+    CREDENTIAL_PATTERNS.forEach(([pattern, replacement]) => {
+        raw = raw.replace(pattern, replacement)
     });
 
     return capText(raw, FLEET_ACTIVITY_REASON_MAX)

--- a/ai/services/fleet/fleetActivityComposer.mjs
+++ b/ai/services/fleet/fleetActivityComposer.mjs
@@ -74,8 +74,45 @@ function normalizeBound(requested, fallback) {
     // default; a USABLE but unbounded one is clamped. `Number.isInteger(1e9) && 1e9 > 0` is true, so
     // checking only well-formedness let the exact read this guard exists to stop walk through the
     // front door — the reason string was already capped in this same file, and the count was not.
-    return Number.isInteger(value) && value > 0 ? Math.min(value, FLEET_ACTIVITY_BOUND_MAX) : Math.min(fallback, FLEET_ACTIVITY_BOUND_MAX)
+    //
+    // `fallback` is validated at construction rather than clamped here: `Math.min(-1, MAX)` is `-1`
+    // and `Math.min(NaN, MAX)` is `NaN`, so clamping a configured bound obeys a misconfiguration as
+    // readily as it obeyed a hostile one. A bad config is a defect to surface, not a value to repair.
+    return Number.isInteger(value) && value > 0 ? Math.min(value, FLEET_ACTIVITY_BOUND_MAX) : fallback
 }
+
+/**
+ * @summary Caps operator-facing text at `max`, marking the elision.
+ *
+ * @param {String} raw
+ * @param {Number} max
+ * @returns {String}
+ * @private
+ */
+function capText(raw, max) {
+    return raw.length > max ? `${raw.slice(0, max - 1)}…` : raw
+}
+
+/**
+ * @summary Credential shapes an adapter error can carry into an operator-facing string.
+ *
+ * The JSDoc below already named tokens as the threat while the code only collapsed whitespace and
+ * truncated, so `Authorization: Bearer <token>` reached the cockpit intact and survived the cap. The
+ * value is replaced rather than the whole message dropped: an operator still needs to know WHICH call
+ * failed, and a reason of `[redacted]` debugs nothing.
+ * @private
+ */
+const CREDENTIAL_PATTERNS = [
+    // The scheme must be consumed WITH the token. `[:=]\s*\S+` took only `Bearer` and left the
+    // credential one space away — and worse, it destroyed the `Bearer` marker the next pattern
+    // matches on, so the first redaction blinded the second. An earlier guard can hide the surface a
+    // later guard exists to find.
+    /\b(?:proxy-)?authorization\s*[:=]\s*(?:(?:bearer|basic|digest|token)\s+)?[^\s,;]+/gi,
+    /\b(?:bearer|basic)\s+[\w\-._~+/]+=*/gi,
+    /\b(?:api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd|token)\s*[:=]\s*\S+/gi,
+    /\bgh[pousr]_[A-Za-z0-9]{16,}\b/g,
+    /\b(?:x-)?(?:api-)?key\s*[:=]\s*\S+/gi
+];
 
 /**
  * @summary Renders a failure into a reason safe to hand a cockpit.
@@ -85,14 +122,21 @@ function normalizeBound(requested, fallback) {
  * one: an error's `message` has no length contract. Capped and stripped of newlines so one failure
  * cannot flood or restructure the pane it lands in.
  *
+ * Redaction runs BEFORE the cap. Capping first is not merely insufficient — it is dangerous: it can
+ * sever a token and leave the prefix that still authenticates, while reporting the string as handled.
+ *
  * @param {*} failure Error or string.
  * @returns {String}
  * @private
  */
 function redactReason(failure) {
-    const raw = `${failure?.message ?? failure ?? 'unknown failure'}`.replace(/\s+/g, ' ').trim();
+    let raw = `${failure?.message ?? failure ?? 'unknown failure'}`.replace(/\s+/g, ' ').trim();
 
-    return raw.length > FLEET_ACTIVITY_REASON_MAX ? `${raw.slice(0, FLEET_ACTIVITY_REASON_MAX - 1)}…` : raw
+    CREDENTIAL_PATTERNS.forEach(pattern => {
+        raw = raw.replace(pattern, match => `${match.split(/[:=\s]/)[0]}: [redacted]`)
+    });
+
+    return capText(raw, FLEET_ACTIVITY_REASON_MAX)
 }
 
 /**
@@ -115,8 +159,12 @@ function redactReason(failure) {
  * @private
  */
 async function readSlot(read, slot, params, capturedAt) {
+    // `slot` is carried as a FIELD, not baked into the reason text. The first cut prefixed the reason
+    // with `${slot}: ` and omitted the field the healthy return below sets — so `composeCapability`
+    // read `capability.slot` as undefined and attributed a named failure to `unknown slot`, on top of
+    // the prefix it adds itself. The two return paths of one function disagreed about the contract.
     const degraded = reason => ({
-        capability: {source: FLEET_COCKPIT_SOURCES.activity, state: 'degraded', confidence: 'none', capturedAt, reason: `${slot}: ${reason}`},
+        capability: {source: FLEET_COCKPIT_SOURCES.activity, state: 'degraded', confidence: 'none', capturedAt, slot, reason: redactReason(reason)},
         events    : []
     });
 
@@ -125,7 +173,7 @@ async function readSlot(read, slot, params, capturedAt) {
     try {
         snapshot = await read(params)
     } catch (error) {
-        return degraded(redactReason(error))
+        return degraded(error)
     }
 
     if (!snapshot?.capability) {
@@ -188,9 +236,17 @@ function composeCapability(capabilities, capturedAt) {
     // adapter's claim about itself. A contributor that mislabels its source would otherwise send the
     // operator to a healthy adapter, and the one surface that exists to be trusted when things break
     // must not be forgeable by the thing that broke.
-    const reason = blind
-        .map(capability => `${capability?.slot ?? 'unknown slot'}: ${redactReason(capability?.reason ?? capability?.state ?? 'unavailable')}`)
-        .join('; ');
+    //
+    // The COMPOSITE is what an operator reads, so the composite is what must be capped. Capping each
+    // part and then joining them bounds nothing: two blind slots at 200 each, plus prefixes and the
+    // separator, reached ~430 through a guard whose whole purpose was that one failure cannot flood
+    // the pane. A bound on the inputs is not a bound on the result.
+    const reason = capText(
+        blind
+            .map(capability => `${capability?.slot ?? 'unknown slot'}: ${redactReason(capability?.reason ?? capability?.state ?? 'unavailable')}`)
+            .join('; '),
+        FLEET_ACTIVITY_REASON_MAX
+    );
 
     return {
         source    : FLEET_COCKPIT_SOURCES.activity,
@@ -222,6 +278,15 @@ function composeCapability(capabilities, capturedAt) {
 export function createFleetActivityReadSource({readA2ASnapshot, readPrLaneSnapshot, limit = DEFAULT_FLEET_ACTIVITY_EVENT_LIMIT} = {}) {
     if (typeof readA2ASnapshot !== 'function' || typeof readPrLaneSnapshot !== 'function') {
         throw new TypeError('[fleetActivityComposer] readA2ASnapshot and readPrLaneSnapshot must be injected')
+    }
+
+    // The configured bound is validated where the readers are, and for the same reason: a wrong one is
+    // a defect to surface, not a value to repair. `normalizeBound` guarded the CALLER's limit and then
+    // handed a misconfigured `-1` straight to the adapters as the fallback for every refused request —
+    // the guard against an unbounded read, unbounding the read itself. Failing at construction refuses
+    // it once, loudly, instead of silently on every subsequent call.
+    if (!Number.isInteger(limit) || limit < 1 || limit > FLEET_ACTIVITY_BOUND_MAX) {
+        throw new TypeError(`[fleetActivityComposer] limit must be an integer between 1 and ${FLEET_ACTIVITY_BOUND_MAX}; received ${limit}`)
     }
 
     const slots = [

--- a/ai/services/fleet/fleetActivityComposer.mjs
+++ b/ai/services/fleet/fleetActivityComposer.mjs
@@ -22,6 +22,106 @@ import {FLEET_COCKPIT_SOURCES}              from '../../../src/ai/fleet/fleetCoc
  */
 
 /**
+ * @summary The contributing slots, named by the COMPOSER rather than by the adapters.
+ *
+ * A slot is what this module asked; `capability.source` is what the adapter says it is. Attributing a
+ * failure by the adapter's self-report lets a broken contributor blame a healthy one — the reason
+ * line an operator debugs from must come from the party that knows which slot it called.
+ * @type {Object}
+ */
+export const FLEET_ACTIVITY_SLOTS = Object.freeze({
+    a2a   : 'a2a',
+    prLane: 'pr-lane'
+});
+
+/**
+ * @summary The cap on a failure reason reaching the cockpit.
+ * @type {Number}
+ */
+export const FLEET_ACTIVITY_REASON_MAX = 200;
+
+/**
+ * @summary Resolves the event bound, refusing values that would silently unbound the read.
+ *
+ * `params.limit ?? limit` accepted `-1`, `NaN`, `0` and `'50'` — a caller-supplied bound reaches the
+ * adapters verbatim, so a bad one is a caller-controlled unbounded read rather than a display quirk.
+ * An unusable bound falls back to the configured default instead of being obeyed.
+ *
+ * @param {*} requested The caller's `limit`.
+ * @param {Number} fallback The configured default.
+ * @returns {Number}
+ * @private
+ */
+function normalizeBound(requested, fallback) {
+    const value = Number(requested);
+
+    return Number.isInteger(value) && value > 0 ? value : fallback
+}
+
+/**
+ * @summary Renders a failure into a reason safe to hand a cockpit.
+ *
+ * Adapter errors carry filesystem paths, tokens and query fragments. A capability reason is rendered
+ * verbatim to an operator and travels through the projection, so it is a leak surface and an unbounded
+ * one: an error's `message` has no length contract. Capped and stripped of newlines so one failure
+ * cannot flood or restructure the pane it lands in.
+ *
+ * @param {*} failure Error or string.
+ * @returns {String}
+ * @private
+ */
+function redactReason(failure) {
+    const raw = `${failure?.message ?? failure ?? 'unknown failure'}`.replace(/\s+/g, ' ').trim();
+
+    return raw.length > FLEET_ACTIVITY_REASON_MAX ? `${raw.slice(0, FLEET_ACTIVITY_REASON_MAX - 1)}…` : raw
+}
+
+/**
+ * @summary Reads one slot, containing every failure mode as that slot's degraded capability.
+ *
+ * `Promise.resolve(read(params))` does NOT contain a synchronous throw — the call is evaluated before
+ * the wrapper exists, so the error escapes the `.catch` and takes the whole snapshot down. An async
+ * stub cannot surface that; a real adapter validating its arguments throws exactly that way. `await`
+ * inside `try` contains both shapes.
+ *
+ * A malformed return is contained too: a contributor that answers `undefined`, or without a
+ * capability, has not reported sight, and inventing one for it is the failure this module exists to
+ * prevent.
+ *
+ * @param {Function} read The slot's reader.
+ * @param {String} slot The composer-owned slot name.
+ * @param {Object} params Bounds forwarded to the adapter.
+ * @param {String} capturedAt ISO capture stamp.
+ * @returns {Promise<{capability: Object, events: Object[]}>}
+ * @private
+ */
+async function readSlot(read, slot, params, capturedAt) {
+    const degraded = reason => ({
+        capability: {source: FLEET_COCKPIT_SOURCES.activity, state: 'degraded', confidence: 'none', capturedAt, reason: `${slot}: ${reason}`},
+        events    : []
+    });
+
+    let snapshot;
+
+    try {
+        snapshot = await read(params)
+    } catch (error) {
+        return degraded(redactReason(error))
+    }
+
+    if (!snapshot?.capability) {
+        return degraded('returned no capability')
+    }
+
+    return {
+        // The slot owns the attribution: an adapter's own `source` is its claim about itself, and a
+        // composite reason built from it lets a broken contributor name a healthy slot.
+        capability: {...snapshot.capability, slot},
+        events    : Array.isArray(snapshot.events) ? snapshot.events : []
+    }
+}
+
+/**
  * @summary Merges two adapter snapshots into one, newest-first and bounded.
  *
  * @param {Object[]} events Every contributing adapter's events.
@@ -64,8 +164,13 @@ function composeCapability(capabilities, capturedAt) {
 
     // Name every blind contributor, not just the first: an operator debugging a partial feed needs to
     // know which half is missing, and a single-source reason invites fixing the wrong adapter.
+    //
+    // Attribution is by SLOT — what this composer asked — not by `capability.source`, which is the
+    // adapter's claim about itself. A contributor that mislabels its source would otherwise send the
+    // operator to a healthy adapter, and the one surface that exists to be trusted when things break
+    // must not be forgeable by the thing that broke.
     const reason = blind
-        .map(capability => `${capability?.source ?? 'unknown source'}: ${capability?.reason ?? capability?.state ?? 'unavailable'}`)
+        .map(capability => `${capability?.slot ?? 'unknown slot'}: ${redactReason(capability?.reason ?? capability?.state ?? 'unavailable')}`)
         .join('; ');
 
     return {
@@ -100,40 +205,24 @@ export function createFleetActivityReadSource({readA2ASnapshot, readPrLaneSnapsh
         throw new TypeError('[fleetActivityComposer] readA2ASnapshot and readPrLaneSnapshot must be injected')
     }
 
+    const slots = [
+        {read: readA2ASnapshot,    slot: FLEET_ACTIVITY_SLOTS.a2a},
+        {read: readPrLaneSnapshot, slot: FLEET_ACTIVITY_SLOTS.prLane}
+    ];
+
     return {
         async readActivitySnapshot(params = {}) {
             const
                 capturedAt = new Date().toISOString(),
-                bound      = params.limit ?? limit,
-                // Both are asked even when one is expected to fail: a contributor that cannot read
-                // must return its OWN degraded capability, and short-circuiting would replace that
-                // adapter's stated reason with the composer's guess about it.
-                contributions = await Promise.all([
-                    Promise.resolve(readA2ASnapshot({...params, limit: bound})).catch(error => ({
-                        capability: {
-                            source    : FLEET_COCKPIT_SOURCES.activity,
-                            state     : 'degraded',
-                            confidence: 'none',
-                            capturedAt,
-                            reason    : `a2a adapter threw: ${error?.message ?? error}`
-                        },
-                        events: []
-                    })),
-                    Promise.resolve(readPrLaneSnapshot({...params, limit: bound})).catch(error => ({
-                        capability: {
-                            source    : FLEET_COCKPIT_SOURCES.activity,
-                            state     : 'degraded',
-                            confidence: 'none',
-                            capturedAt,
-                            reason    : `pr-lane adapter threw: ${error?.message ?? error}`
-                        },
-                        events: []
-                    }))
-                ]);
+                bound      = normalizeBound(params.limit, limit),
+                // Every slot is asked even when one is expected to fail: a contributor that cannot
+                // read must return its OWN degraded capability, and short-circuiting would replace
+                // that adapter's stated reason with the composer's guess about it.
+                contributions = await Promise.all(slots.map(({read, slot}) => readSlot(read, slot, {...params, limit: bound}, capturedAt)));
 
             return {
-                capability: composeCapability(contributions.map(contribution => contribution?.capability), capturedAt),
-                events    : boundEvents(contributions.flatMap(contribution => contribution?.events ?? []), bound)
+                capability: composeCapability(contributions.map(contribution => contribution.capability), capturedAt),
+                events    : boundEvents(contributions.flatMap(contribution => contribution.events), bound)
             }
         }
     }

--- a/ai/services/fleet/fleetActivityComposer.mjs
+++ b/ai/services/fleet/fleetActivityComposer.mjs
@@ -116,14 +116,23 @@ const CREDENTIAL_PATTERNS = [
     // The scheme is consumed WITH the token: `[:=]\s*\S+` took only `Bearer` and left the credential
     // one space away — and destroyed the `Bearer` marker the next pattern matches on, so the first
     // redaction blinded the second. An earlier guard can hide the surface a later guard exists to find.
-    // The credentials run to the END of the header value, not to the first delimiter. RFC 7235 allows
-    // either a single token68 (`Bearer abc…`) or a comma-separated auth-param list, and Digest uses
-    // the list: `username="u", realm="r", nonce="abc", response="<hash>"`. Stopping at the first comma
-    // redacted `username` and published `response` — which IS the credential — with `[redacted]`
-    // printed next to it. Found by running the matrix I had just used to find the same class in a
-    // peer's copy; the single-token case was the one I tested, so the single-token case was the one
-    // that worked.
-    [/\b((?:proxy-)?authorization)\s*[:=]\s*(?:(?:bearer|basic|digest|token)\s+)?[^\s,;)]+(?:\s*,\s*[\w-]+\s*=\s*(?:"[^"]*"|[^\s,;)]+))*/gi, '$1: [redacted]'],
+    // The scheme is a GENERIC WORD, never an enumerated list, and the credentials run to the END of
+    // the value rather than to the first delimiter.
+    //
+    // Both halves were learned the hard way, in this order. First `[:=]\s*\S+` took only `Bearer` and
+    // left the credential one space away. Then an allow-list of four schemes published `NTLM`,
+    // `Negotiate`, `Hawk` and `AWS4-HMAC-SHA256` the same way — @neo-opus-grace's line, against a patch
+    // I had just prescribed to her: **an allow-list of four degrades on the fifth.** A list is complete
+    // the day it is written and publishes a credential for the first scheme nobody taught it.
+    // Separately, RFC 7235 allows a token68 (`Bearer abc…`) OR a comma-separated auth-param list, and
+    // Digest uses the list — so stopping at the first comma redacted `username` and published
+    // `response`, which IS the credential.
+    //
+    // The trade-off is deliberate and bounded: after `authorization`, an unknown trailing token is
+    // indistinguishable from a credential, so it is consumed. A word of lost context is cheap; a
+    // published credential is not. The bound is that this fires only after an auth key — the spec's
+    // control proves an ordinary diagnostic survives untouched.
+    [/\b((?:proxy-)?authorization)\s*[:=]\s*(?:[\w-]+\s+)?[^\s,;)]+(?:\s*,\s*[\w-]+\s*=\s*(?:"[^"]*"|[^\s,;)]+))*/gi, '$1: [redacted]'],
     [/\b(bearer|basic)\s+[\w\-._~+/]+=*/gi,                                                    '$1 [redacted]'],
     [/\b(api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd|pat|credential|privateKey|signingKey|token)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]'],
     // Bare tokens: no key, no delimiter — the match IS the secret, so the whole match goes.

--- a/ai/services/fleet/fleetActivityComposer.mjs
+++ b/ai/services/fleet/fleetActivityComposer.mjs
@@ -1,4 +1,5 @@
 import {DEFAULT_FLEET_ACTIVITY_EVENT_LIMIT} from './fleetPrLaneActivityAdapter.mjs';
+import {redactCredentials}                  from './redactCredentials.mjs';
 import {FLEET_COCKPIT_SOURCES}              from '../../../src/ai/fleet/fleetCockpitStatus.mjs';
 
 /**
@@ -94,54 +95,6 @@ function capText(raw, max) {
 }
 
 /**
- * @summary Credential shapes an adapter error can carry into an operator-facing string, each paired
- * with an EXPLICIT replacement.
- *
- * The pairing is the contract, and deriving the replacement from the match instead is what made the
- * first cut worse than no redaction at all: `` `${match.split(/[:=\s]/)[0]}: [redacted]` `` assumed
- * every match was `key: value`. **A bare token has no delimiter, so the whole secret became the
- * "label"** and was printed next to the word `[redacted]` — the string reported itself handled while
- * carrying the credential. A replacement may echo a KEY (an explicit `$1` capture of the key alone)
- * or be a literal; it may never be computed from the matched text.
- *
- * The families are the same-subsystem set the Fleet wake/throttle/mailbox adapters already redact,
- * plus fine-grained `github_pat_`, which `gh[pousr]_` cannot match (`[pousr]` fails on `i`) — so that
- * family currently reaches a Body-facing surface through those siblings too.
- *
- * The value is replaced rather than the message dropped: an operator still needs to know WHICH call
- * failed, and a reason of `[redacted]` debugs nothing.
- * @private
- */
-const CREDENTIAL_PATTERNS = [
-    // The scheme is consumed WITH the token: `[:=]\s*\S+` took only `Bearer` and left the credential
-    // one space away — and destroyed the `Bearer` marker the next pattern matches on, so the first
-    // redaction blinded the second. An earlier guard can hide the surface a later guard exists to find.
-    // The scheme is a GENERIC WORD, never an enumerated list, and the credentials run to the END of
-    // the value rather than to the first delimiter.
-    //
-    // Both halves were learned the hard way, in this order. First `[:=]\s*\S+` took only `Bearer` and
-    // left the credential one space away. Then an allow-list of four schemes published `NTLM`,
-    // `Negotiate`, `Hawk` and `AWS4-HMAC-SHA256` the same way — @neo-opus-grace's line, against a patch
-    // I had just prescribed to her: **an allow-list of four degrades on the fifth.** A list is complete
-    // the day it is written and publishes a credential for the first scheme nobody taught it.
-    // Separately, RFC 7235 allows a token68 (`Bearer abc…`) OR a comma-separated auth-param list, and
-    // Digest uses the list — so stopping at the first comma redacted `username` and published
-    // `response`, which IS the credential.
-    //
-    // The trade-off is deliberate and bounded: after `authorization`, an unknown trailing token is
-    // indistinguishable from a credential, so it is consumed. A word of lost context is cheap; a
-    // published credential is not. The bound is that this fires only after an auth key — the spec's
-    // control proves an ordinary diagnostic survives untouched.
-    [/\b((?:proxy-)?authorization)\s*[:=]\s*(?:[\w-]+\s+)?[^\s,;)]+(?:\s*,\s*[\w-]+\s*=\s*(?:"[^"]*"|[^\s,;)]+))*/gi, '$1: [redacted]'],
-    [/\b(bearer|basic)\s+[\w\-._~+/]+=*/gi,                                                    '$1 [redacted]'],
-    [/\b(api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd|pat|credential|privateKey|signingKey|token)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]'],
-    // Bare tokens: no key, no delimiter — the match IS the secret, so the whole match goes.
-    [/\bgithub_pat_[A-Za-z0-9_]+/g, '[redacted-token]'],
-    [/\bgh[pousr]_[A-Za-z0-9_]+/g,  '[redacted-token]'],
-    [/\bglpat-[A-Za-z0-9_-]+/g,     '[redacted-token]']
-];
-
-/**
  * @summary Renders a failure into a reason safe to hand a cockpit.
  *
  * Adapter errors carry filesystem paths, tokens and query fragments. A capability reason is rendered
@@ -149,21 +102,20 @@ const CREDENTIAL_PATTERNS = [
  * one: an error's `message` has no length contract. Capped and stripped of newlines so one failure
  * cannot flood or restructure the pane it lands in.
  *
- * Redaction runs BEFORE the cap. Capping first is not merely insufficient — it is dangerous: it can
- * sever a token and leave the prefix that still authenticates, while reporting the string as handled.
+ * Redaction is delegated to `redactCredentials`, the single Fleet redaction authority — a private
+ * table here would be the sixth copy of a contract that already drifted across five adapters, which
+ * is the exact defect that module exists to end. Redaction still runs BEFORE the cap: capping first
+ * is not merely insufficient — it is dangerous, severing a token and leaving the prefix that still
+ * authenticates while reporting the string as handled.
  *
  * @param {*} failure Error or string.
  * @returns {String}
  * @private
  */
 function redactReason(failure) {
-    let raw = `${failure?.message ?? failure ?? 'unknown failure'}`.replace(/\s+/g, ' ').trim();
+    const raw = `${failure?.message ?? failure ?? 'unknown failure'}`.replace(/\s+/g, ' ').trim();
 
-    CREDENTIAL_PATTERNS.forEach(([pattern, replacement]) => {
-        raw = raw.replace(pattern, replacement)
-    });
-
-    return capText(raw, FLEET_ACTIVITY_REASON_MAX)
+    return capText(redactCredentials(raw), FLEET_ACTIVITY_REASON_MAX)
 }
 
 /**

--- a/ai/services/fleet/fleetActivityComposer.mjs
+++ b/ai/services/fleet/fleetActivityComposer.mjs
@@ -116,7 +116,14 @@ const CREDENTIAL_PATTERNS = [
     // The scheme is consumed WITH the token: `[:=]\s*\S+` took only `Bearer` and left the credential
     // one space away — and destroyed the `Bearer` marker the next pattern matches on, so the first
     // redaction blinded the second. An earlier guard can hide the surface a later guard exists to find.
-    [/\b((?:proxy-)?authorization)\s*[:=]\s*(?:(?:bearer|basic|digest|token)\s+)?[^\s,;)]+/gi, '$1: [redacted]'],
+    // The credentials run to the END of the header value, not to the first delimiter. RFC 7235 allows
+    // either a single token68 (`Bearer abc…`) or a comma-separated auth-param list, and Digest uses
+    // the list: `username="u", realm="r", nonce="abc", response="<hash>"`. Stopping at the first comma
+    // redacted `username` and published `response` — which IS the credential — with `[redacted]`
+    // printed next to it. Found by running the matrix I had just used to find the same class in a
+    // peer's copy; the single-token case was the one I tested, so the single-token case was the one
+    // that worked.
+    [/\b((?:proxy-)?authorization)\s*[:=]\s*(?:(?:bearer|basic|digest|token)\s+)?[^\s,;)]+(?:\s*,\s*[\w-]+\s*=\s*(?:"[^"]*"|[^\s,;)]+))*/gi, '$1: [redacted]'],
     [/\b(bearer|basic)\s+[\w\-._~+/]+=*/gi,                                                    '$1 [redacted]'],
     [/\b(api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|secret|password|passwd|pwd|pat|credential|privateKey|signingKey|token)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]'],
     // Bare tokens: no key, no delimiter — the match IS the secret, so the whole match goes.

--- a/ai/services/fleet/redactCredentials.mjs
+++ b/ai/services/fleet/redactCredentials.mjs
@@ -48,7 +48,7 @@ export function redactCredentials(text) {
         .replace(/\b(?:bearer|basic|digest)\s+[^\s,;)]+/gi, 'authorization=[redacted]')
         // Keyed secrets — the UNION of every copy's key set, including the composer's
         // (`fleetActivityComposer`, see the ledger note below).
-        .replace(/\b(api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|authorization|token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
+        .replace(/\b(api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|authorization|token|secret|password|passwd|pwd|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
         // Fine-grained GitHub PAT. `\bgh[pousr]_` cannot reach it: the character class fails on the
         // `i` of `github`, so this family passed through all five predecessors untouched.
         .replace(/\bgithub_pat_[A-Za-z0-9_]+/g, '[redacted-token]')
@@ -85,5 +85,8 @@ export const CREDENTIAL_FAMILIES = Object.freeze([
     {name: 'api-key',                 sample: 'x-api-key: sk-live-abcdef123456',                     secret: 'sk-live-abcdef123456'},
     {name: 'access-token',            sample: 'access_token: at-live-zzz111',                        secret: 'at-live-zzz111'},
     {name: 'refresh-token',           sample: 'refresh-token=rt-live-www333',                        secret: 'rt-live-www333'},
-    {name: 'client-secret',           sample: 'client_secret: cs-live-qqq222',                       secret: 'cs-live-qqq222'}
+    {name: 'client-secret',           sample: 'client_secret: cs-live-qqq222',                       secret: 'cs-live-qqq222'},
+    {name: 'password',                sample: 'password=pw-live-zzz000',                             secret: 'pw-live-zzz000'},
+    {name: 'passwd',                  sample: 'passwd=pw-live-aaa111',                               secret: 'pw-live-aaa111'},
+    {name: 'pwd',                     sample: 'pwd: pw-live-bbb222',                                 secret: 'pw-live-bbb222'}
 ])

--- a/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
@@ -1,0 +1,154 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'FleetActivityComposerTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary The producer for the slot `FleetControlBridge` has consumed since it was written.
+ *
+ * Events merge trivially; SIGHT does not — and that asymmetry is the whole reason this module exists.
+ * A degraded adapter contributes zero events, which is byte-identical to a healthy adapter on a quiet
+ * fleet. The event list therefore cannot carry the difference, and the capability is the only place it
+ * can survive. Every test below is aimed at that single claim: the composite never reports more sight
+ * than it has.
+ */
+test.describe('fleetActivityComposer — composing two truths means composing two capabilities', () => {
+    let createFleetActivityReadSource;
+
+    const wired = (events = []) => async () => ({
+        capability: {source: 'fleet:a2a', state: 'wired', confidence: 'observed'},
+        events
+    });
+
+    const degraded = (source, reason) => async () => ({
+        capability: {source, state: 'degraded', confidence: 'none', reason},
+        events    : []
+    });
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../ai/services/fleet/fleetActivityComposer.mjs');
+        createFleetActivityReadSource = mod.createFleetActivityReadSource
+    });
+
+    test('both adapters wired → the composite may claim wired, and the feed merges newest-first', async () => {
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : wired([{occurredAt: '2026-07-16T11:00:00.000Z', id: 'a2a-old'}]),
+            readPrLaneSnapshot: wired([{occurredAt: '2026-07-16T12:00:00.000Z', id: 'pr-new'}])
+        });
+
+        const {capability, events} = await source.readActivitySnapshot();
+
+        expect(capability.state).toBe('wired');
+        expect(capability.confidence).toBe('observed');
+        expect(capability.reason).toBeNull();
+        // one feed, not two lists stapled together
+        expect(events.map(event => event.id)).toEqual(['pr-new', 'a2a-old'])
+    });
+
+    test('ONE blind adapter degrades the composite — a half-feed must not read as the whole fleet', async () => {
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : wired([{occurredAt: '2026-07-16T11:00:00.000Z', id: 'a2a-1'}]),
+            readPrLaneSnapshot: degraded('fleet:pr-lane', 'github unreachable')
+        });
+
+        const {capability, events} = await source.readActivitySnapshot();
+
+        // The events look perfectly healthy — one real row, nothing obviously missing. That is exactly
+        // why `wired` here would be a lie the caller could never detect.
+        expect(events.map(event => event.id)).toEqual(['a2a-1']);
+
+        expect(capability.state).toBe('degraded');
+        expect(capability.confidence).toBe('none');
+        expect(capability.reason).toContain('fleet:pr-lane');
+        expect(capability.reason).toContain('github unreachable')
+    });
+
+    test('BOTH blind → not-wired, not degraded — half a feed and none of it are different facts', async () => {
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : degraded('fleet:a2a', 'mailbox unreadable'),
+            readPrLaneSnapshot: degraded('fleet:pr-lane', 'github unreachable')
+        });
+
+        const {capability} = await source.readActivitySnapshot();
+
+        expect(capability.state).toBe('not-wired');
+        // BOTH are named: an operator debugging a dead feed must not fix one adapter and wonder why
+        // nothing changed.
+        expect(capability.reason).toContain('fleet:a2a');
+        expect(capability.reason).toContain('fleet:pr-lane')
+    });
+
+    test('a wired composite with NO events says so — "nothing happened" is not "we could not look"', async () => {
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : wired([]),
+            readPrLaneSnapshot: wired([])
+        });
+
+        const {capability, events} = await source.readActivitySnapshot();
+
+        // The AC that makes the whole module worth having: an empty list under a WIRED capability is a
+        // quiet fleet; the same empty list under a degraded one is blindness. Identical events, and the
+        // capability is the only thing that separates them.
+        expect(events).toEqual([]);
+        expect(capability.state).toBe('wired')
+    });
+
+    test('a THROWING adapter degrades rather than taking the snapshot down with it', async () => {
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : async () => { throw new Error('mailbox exploded') },
+            readPrLaneSnapshot: wired([{occurredAt: '2026-07-16T12:00:00.000Z', id: 'pr-1'}])
+        });
+
+        const {capability, events} = await source.readActivitySnapshot();
+
+        expect(capability.state).toBe('degraded');
+        expect(capability.reason).toContain('mailbox exploded');
+        // the half that CAN be read still reaches the cockpit — degraded is not blank
+        expect(events.map(event => event.id)).toEqual(['pr-1'])
+    });
+
+    test('the caller\'s limit bounds the MERGED feed, and reaches both adapters', async () => {
+        const seen      = [];
+        const recording = id => async params => {
+            seen.push([id, params.limit]);
+            return {capability: {source: id, state: 'wired', confidence: 'observed'}, events: [
+                {occurredAt: '2026-07-16T12:00:00.000Z', id: `${id}-a`},
+                {occurredAt: '2026-07-16T11:00:00.000Z', id: `${id}-b`}
+            ]}
+        };
+
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : recording('a2a'),
+            readPrLaneSnapshot: recording('pr')
+        });
+
+        const {events} = await source.readActivitySnapshot({limit: 3});
+
+        // bounding only the merge would let each adapter read unboundedly and throw the surplus away
+        expect(seen).toEqual([['a2a', 3], ['pr', 3]]);
+        expect(events).toHaveLength(3)
+    });
+
+    test('fails LOUD on a missing reader — a one-legged composite is not the fleet\'s activity', () => {
+        expect(() => createFleetActivityReadSource({readA2ASnapshot: wired([])}))
+            .toThrow(/readA2ASnapshot and readPrLaneSnapshot must be injected/);
+        expect(() => createFleetActivityReadSource({readPrLaneSnapshot: wired([])}))
+            .toThrow(/readA2ASnapshot and readPrLaneSnapshot must be injected/);
+        expect(() => createFleetActivityReadSource())
+            .toThrow(/must be injected/)
+    })
+});

--- a/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
@@ -190,22 +190,42 @@ test.describe('fleetActivityComposer — composing two truths means composing tw
         expect(capability.reason).not.toContain('\n')
     });
 
-    test('a reason carries NO credential — @neo-gpt\'s exact-blob probe: the secret survived the cap', async () => {
-        // The cap was never a redactor. This module's own JSDoc named "tokens" as the threat while the
-        // code only collapsed whitespace and truncated, so a Bearer token rode a 214-char reason into
-        // an operator-facing pane intact. Capping BEFORE redacting is worse than not capping: it can
-        // sever a token and leave the prefix that still authenticates, and report it as handled.
-        const source = createFleetActivityReadSource({
-            readA2ASnapshot   : async () => { throw new Error('GET /api failed: Authorization: Bearer super-secret-token-value abc') },
-            readPrLaneSnapshot: wired([])
-        });
+    test('NO credential family reaches the composed reason — the whole matrix, not one branch', async () => {
+        // @neo-gpt's controlled production probe of the first fix, which I had shipped as "credential
+        // redaction" on the strength of a single Bearer witness:
+        //
+        //   ghp_A…        leaked=true  redacted=true    ← the deceptive row
+        //   github_pat_A… leaked=true  redacted=false
+        //   glpat-A…      leaked=true  redacted=false
+        //   Bearer …      leaked=false redacted=true    ← the only branch I tested
+        //
+        // The first row is the whole lesson: the replacement was DERIVED from the match
+        // (`match.split(/[:=\s]/)[0]`), which assumes every match is `key: value`. A bare token has no
+        // delimiter, so the entire secret became the "label" and was printed beside the word
+        // [redacted]. It reported itself handled while carrying the credential — which is why
+        // `toContain('[redacted]')` was green on a leak, and why every row below asserts ABSENCE of
+        // the secret first and the marker second.
+        const secrets = [
+            ['bearer header',    'GET /api failed: Authorization: Bearer super-secret-token-value abc', 'super-secret-token-value'],
+            ['bare classic PAT', 'push rejected for ghp_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234',             'ghp_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234'],
+            ['bare fine PAT',    'push rejected for github_pat_11ABCDE0Y0abcdefgh_XYZ123',              'github_pat_11ABCDE0Y0abcdefgh_XYZ123'],
+            ['bare GitLab PAT',  'clone failed for glpat-AAAABBBBCCCC-1234',                            'glpat-AAAABBBBCCCC-1234'],
+            ['keyed secret',     'auth failed: token=s3cr3t-value-here, retrying',                      's3cr3t-value-here']
+        ];
 
-        const {capability} = await source.readActivitySnapshot();
+        for (const [label, message, secret] of secrets) {
+            const source = createFleetActivityReadSource({
+                readA2ASnapshot   : async () => { throw new Error(message) },
+                readPrLaneSnapshot: wired([])
+            });
 
-        expect(capability.reason).not.toContain('super-secret-token-value');
-        expect(capability.reason).toContain('[redacted]');
-        // the operator still learns WHICH call failed — a reason of pure `[redacted]` debugs nothing
-        expect(capability.reason).toContain('a2a')
+            const {capability} = await source.readActivitySnapshot();
+
+            expect(capability.reason, `${label}: the secret must not survive`).not.toContain(secret);
+            expect(capability.reason, `${label}: a redaction marker must remain`).toMatch(/\[redacted(-token)?]/);
+            // the operator still learns WHICH slot failed — a reason of pure [redacted] debugs nothing
+            expect(capability.reason, `${label}: attribution must survive`).toContain('a2a')
+        }
     });
 
     test('a LOCALLY-created degraded capability is attributed to its slot, not to "unknown slot"', async () => {

--- a/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
@@ -210,7 +210,14 @@ test.describe('fleetActivityComposer — composing two truths means composing tw
             ['bare classic PAT', 'push rejected for ghp_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234',             'ghp_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234'],
             ['bare fine PAT',    'push rejected for github_pat_11ABCDE0Y0abcdefgh_XYZ123',              'github_pat_11ABCDE0Y0abcdefgh_XYZ123'],
             ['bare GitLab PAT',  'clone failed for glpat-AAAABBBBCCCC-1234',                            'glpat-AAAABBBBCCCC-1234'],
-            ['keyed secret',     'auth failed: token=s3cr3t-value-here, retrying',                      's3cr3t-value-here']
+            ['keyed secret',     'auth failed: token=s3cr3t-value-here, retrying',                      's3cr3t-value-here'],
+            ['basic header',     'GET /api failed: Authorization: Basic dXNlcjpwYXNzd29yZA== next',     'dXNlcjpwYXNzd29yZA=='],
+            // The credentials run to the END of the header value, not to the first delimiter. RFC 7235
+            // allows a token68 OR a comma-separated auth-param list, and Digest uses the list — so
+            // stopping at the first comma redacted `username` and published `response`, which IS the
+            // credential, with `[redacted]` printed beside it. The single-token case was the one I
+            // tested, so the single-token case was the one that worked.
+            ['digest auth-param list', 'GET failed: Authorization: Digest username="u", realm="r", nonce="abc", response="deadbeefcafe1234"', 'deadbeefcafe1234']
         ];
 
         for (const [label, message, secret] of secrets) {

--- a/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
@@ -73,7 +73,8 @@ test.describe('fleetActivityComposer — composing two truths means composing tw
 
         expect(capability.state).toBe('degraded');
         expect(capability.confidence).toBe('none');
-        expect(capability.reason).toContain('fleet:pr-lane');
+        // attributed by the composer-owned SLOT, not the adapter's self-reported source
+        expect(capability.reason).toContain('pr-lane');
         expect(capability.reason).toContain('github unreachable')
     });
 
@@ -86,10 +87,10 @@ test.describe('fleetActivityComposer — composing two truths means composing tw
         const {capability} = await source.readActivitySnapshot();
 
         expect(capability.state).toBe('not-wired');
-        // BOTH are named: an operator debugging a dead feed must not fix one adapter and wonder why
-        // nothing changed.
-        expect(capability.reason).toContain('fleet:a2a');
-        expect(capability.reason).toContain('fleet:pr-lane')
+        // BOTH slots are named: an operator debugging a dead feed must not fix one adapter and wonder
+        // why nothing changed.
+        expect(capability.reason).toContain('a2a');
+        expect(capability.reason).toContain('pr-lane')
     });
 
     test('a wired composite with NO events says so — "nothing happened" is not "we could not look"', async () => {
@@ -141,6 +142,81 @@ test.describe('fleetActivityComposer — composing two truths means composing tw
         // bounding only the merge would let each adapter read unboundedly and throw the surplus away
         expect(seen).toEqual([['a2a', 3], ['pr', 3]]);
         expect(events).toHaveLength(3)
+    });
+
+    test('a SYNCHRONOUS throw is contained — Promise.resolve(read()) never sees it', async () => {
+        // @neo-gpt-emmy's RA-2. `Promise.resolve(read(params))` evaluates the call BEFORE the wrapper
+        // exists, so a sync throw escapes the .catch and takes the whole snapshot down. An async stub
+        // cannot surface it — which is why the original "throwing adapter" test passed over this.
+        // A real adapter validating its arguments throws exactly this way.
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : () => { throw new Error('sync validation failure') },
+            readPrLaneSnapshot: wired([{occurredAt: '2026-07-16T12:00:00.000Z', id: 'pr-1'}])
+        });
+
+        const {capability, events} = await source.readActivitySnapshot();
+
+        expect(capability.state).toBe('degraded');
+        expect(capability.reason).toContain('sync validation failure');
+        expect(events.map(event => event.id)).toEqual(['pr-1'])
+    });
+
+    test('failure attribution is by SLOT, not by the adapter\'s self-report', async () => {
+        // A broken contributor claiming another's source would send the operator to a healthy adapter.
+        // The reason line is the one surface that exists to be trusted when things break; it must not
+        // be forgeable by the thing that broke.
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : async () => ({capability: {source: 'fleet:pr-lane', state: 'degraded', confidence: 'none', reason: 'mislabelled'}, events: []}),
+            readPrLaneSnapshot: wired([])
+        });
+
+        const {capability} = await source.readActivitySnapshot();
+
+        // the A2A slot failed, and the reason says so despite the adapter naming pr-lane
+        expect(capability.reason).toContain('a2a');
+        expect(capability.reason).not.toMatch(/^pr-lane/)
+    });
+
+    test('a failure reason is capped and single-line — it is rendered to an operator', async () => {
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : async () => { throw new Error('x'.repeat(5000) + '\nsecond line') },
+            readPrLaneSnapshot: wired([])
+        });
+
+        const {capability} = await source.readActivitySnapshot();
+
+        // unbounded: an Error message has no length contract, and this travels into the projection
+        expect(capability.reason.length).toBeLessThan(300);
+        expect(capability.reason).not.toContain('\n')
+    });
+
+    test('an unusable bound falls back to the default — a caller cannot unbound the read', async () => {
+        // `params.limit ?? limit` obeyed -1, NaN and 0. The bound reaches the adapters verbatim, so a
+        // bad one is a caller-controlled unbounded read, not a display quirk.
+        for (const bad of [-1, 0, NaN, 'many', null]) {
+            const seen   = [];
+            const source = createFleetActivityReadSource({
+                readA2ASnapshot   : async params => { seen.push(params.limit); return {capability: {source: 'a', state: 'wired'}, events: []} },
+                readPrLaneSnapshot: async params => { seen.push(params.limit); return {capability: {source: 'b', state: 'wired'}, events: []} },
+                limit             : 50
+            });
+
+            await source.readActivitySnapshot({limit: bad});
+            expect(seen, `limit ${String(bad)} must not reach the adapters`).toEqual([50, 50])
+        }
+    });
+
+    test('a contributor returning NO capability has not reported sight', async () => {
+        // Inventing a capability for a malformed answer is the exact failure this module prevents.
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : async () => undefined,
+            readPrLaneSnapshot: wired([])
+        });
+
+        const {capability} = await source.readActivitySnapshot();
+
+        expect(capability.state).toBe('degraded');
+        expect(capability.reason).toContain('a2a')
     });
 
     test('fails LOUD on a missing reader — a one-legged composite is not the fleet\'s activity', () => {

--- a/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
@@ -190,6 +190,69 @@ test.describe('fleetActivityComposer — composing two truths means composing tw
         expect(capability.reason).not.toContain('\n')
     });
 
+    test('a reason carries NO credential — @neo-gpt\'s exact-blob probe: the secret survived the cap', async () => {
+        // The cap was never a redactor. This module's own JSDoc named "tokens" as the threat while the
+        // code only collapsed whitespace and truncated, so a Bearer token rode a 214-char reason into
+        // an operator-facing pane intact. Capping BEFORE redacting is worse than not capping: it can
+        // sever a token and leave the prefix that still authenticates, and report it as handled.
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : async () => { throw new Error('GET /api failed: Authorization: Bearer super-secret-token-value abc') },
+            readPrLaneSnapshot: wired([])
+        });
+
+        const {capability} = await source.readActivitySnapshot();
+
+        expect(capability.reason).not.toContain('super-secret-token-value');
+        expect(capability.reason).toContain('[redacted]');
+        // the operator still learns WHICH call failed — a reason of pure `[redacted]` debugs nothing
+        expect(capability.reason).toContain('a2a')
+    });
+
+    test('a LOCALLY-created degraded capability is attributed to its slot, not to "unknown slot"', async () => {
+        // The existing slot witness only covered a capability the adapter RETURNED. The degraded one
+        // this module builds itself omitted the `slot` field the healthy path sets, so composeCapability
+        // read undefined and printed `unknown slot: a2a: …` — the attribution lost, and the prefix
+        // doubled. Two return paths of one function disagreeing about their own contract.
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : async () => ({events: []}),   // no capability: has not reported sight
+            readPrLaneSnapshot: wired([])
+        });
+
+        const {capability} = await source.readActivitySnapshot();
+
+        expect(capability.reason).not.toContain('unknown slot');
+        expect(capability.reason).toContain('a2a: returned no capability')
+    });
+
+    test('the COMPOSITE reason is capped — bounding the parts does not bound the join', async () => {
+        // Two blind slots at the per-reason cap, plus prefixes and the separator, reached ~430 chars
+        // through a guard whose stated purpose was that one failure cannot flood the pane. The operator
+        // reads the composite, so the composite is the thing that must be bounded.
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : async () => { throw new Error('a'.repeat(5000)) },
+            readPrLaneSnapshot: async () => { throw new Error('b'.repeat(5000)) }
+        });
+
+        const {capability} = await source.readActivitySnapshot();
+
+        expect(capability.state).toBe('not-wired');
+        expect(capability.reason.length).toBeLessThanOrEqual(200)
+    });
+
+    test('a misconfigured fallback fails LOUD — the guard against an unbounded read must not unbound it', async () => {
+        // normalizeBound guarded the CALLER's limit and then handed `Math.min(-1, MAX)` === -1 to every
+        // adapter as the fallback for each refused request. The clamp obeyed a misconfiguration exactly
+        // as readily as it had obeyed a hostile caller. Refused once at construction, where the missing
+        // readers are already refused, rather than silently on every later call.
+        for (const bad of [-1, 0, NaN, 1e9, 'many', null]) {
+            expect(() => createFleetActivityReadSource({
+                readA2ASnapshot   : wired([]),
+                readPrLaneSnapshot: wired([]),
+                limit             : bad
+            }), `configured limit ${String(bad)} must be refused at construction`).toThrow(TypeError)
+        }
+    });
+
     test('an unusable bound falls back to the default — a caller cannot unbound the read', async () => {
         // `params.limit ?? limit` obeyed -1, NaN and 0. The bound reaches the adapters verbatim, so a
         // bad one is a caller-controlled unbounded read, not a display quirk.

--- a/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
@@ -217,7 +217,14 @@ test.describe('fleetActivityComposer — composing two truths means composing tw
             // stopping at the first comma redacted `username` and published `response`, which IS the
             // credential, with `[redacted]` printed beside it. The single-token case was the one I
             // tested, so the single-token case was the one that worked.
-            ['digest auth-param list', 'GET failed: Authorization: Digest username="u", realm="r", nonce="abc", response="deadbeefcafe1234"', 'deadbeefcafe1234']
+            ['digest auth-param list', 'GET failed: Authorization: Digest username="u", realm="r", nonce="abc", response="deadbeefcafe1234"', 'deadbeefcafe1234'],
+            // @neo-opus-grace's line, against a patch I had just prescribed to her: an allow-list of
+            // four degrades on the FIFTH. These four are the schemes nobody taught the list — none of
+            // them appears anywhere in the module, which is the point of the rows.
+            ['ntlm',      'GET failed: Authorization: NTLM TlRMTVNTUAABAAAAB4IIogAAAAA=',                                'TlRMTVNTUAABAAAAB4IIogAAAAA='],
+            ['negotiate', 'GET failed: Authorization: Negotiate YIIZkAYGKwYBBQUCoIIZ',                                   'YIIZkAYGKwYBBQUCoIIZ'],
+            ['hawk',      'GET failed: Authorization: Hawk id="dh37", mac="6R4rV5iE+NPoym"',                             '6R4rV5iE+NPoym'],
+            ['aws sigv4', 'GET failed: Authorization: AWS4-HMAC-SHA256 Credential=AKIAIOSFODNN7/20260717, Signature=deadbeef', 'deadbeef']
         ];
 
         for (const [label, message, secret] of secrets) {
@@ -232,6 +239,29 @@ test.describe('fleetActivityComposer — composing two truths means composing tw
             expect(capability.reason, `${label}: a redaction marker must remain`).toMatch(/\[redacted(-token)?]/);
             // the operator still learns WHICH slot failed — a reason of pure [redacted] debugs nothing
             expect(capability.reason, `${label}: attribution must survive`).toContain('a2a')
+        }
+    });
+
+    test('the redactor does not eat the diagnostic — an absence assertion alone cannot see over-redaction', async () => {
+        // @neo-opus-grace's control, and the necessary other half of the matrix above: a redactor that
+        // consumed the rest of every line would pass EVERY "secret is absent" row while destroying the
+        // reason this module exists to carry. Redacting the auth header deliberately over-consumes an
+        // unknown trailing token — a word of lost context is cheap, a published credential is not — so
+        // the bound has to be witnessed, not assumed.
+        const honest = [
+            ['keyed secret mid-sentence', 'auth failed: token=sk-live-1, retry after 30s', 'retry after 30s'],
+            ['no credential at all',      'ECONNREFUSED contacting api.github.com:443',    'ECONNREFUSED contacting api.github.com:443']
+        ];
+
+        for (const [label, message, mustSurvive] of honest) {
+            const source = createFleetActivityReadSource({
+                readA2ASnapshot   : async () => { throw new Error(message) },
+                readPrLaneSnapshot: wired([])
+            });
+
+            const {capability} = await source.readActivitySnapshot();
+
+            expect(capability.reason, `${label}: the operator's evidence must survive`).toContain(mustSurvive)
         }
     });
 

--- a/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
@@ -206,6 +206,52 @@ test.describe('fleetActivityComposer — composing two truths means composing tw
         }
     });
 
+    test('an UNBOUNDED bound is clamped — the default is not a maximum', async () => {
+        // @neo-opus-vega's falsifier. The first cut refused -1/0/NaN/'many' and obeyed 1e9 — so it
+        // guarded the malformed class and left the one this guard's own JSDoc names: `params` arrives
+        // over the wire, so the ceiling was caller-chosen against a producer that fans out to every
+        // adapter. The reason string was capped in this same file; the count was not.
+        for (const huge of [1e9, Number.MAX_SAFE_INTEGER, 201]) {
+            const seen   = [];
+            const source = createFleetActivityReadSource({
+                readA2ASnapshot   : async params => { seen.push(params.limit); return {capability: {source: 'a', state: 'wired'}, events: []} },
+                readPrLaneSnapshot: async params => { seen.push(params.limit); return {capability: {source: 'b', state: 'wired'}, events: []} },
+                limit             : 25
+            });
+
+            await source.readActivitySnapshot({limit: huge});
+            expect(seen, `limit ${huge} must be clamped, not obeyed`).toEqual([200, 200])
+        }
+    });
+
+    test('the clamp caps the RESULT too — a slot cannot answer past the ceiling', async () => {
+        // Vega's own observation about boundEvents, pinned: bounding only the REQUEST trusts the
+        // adapters to honour it. A slot returning more than asked must not blow the cap.
+        const flood = async () => ({
+            capability: {source: 'a', state: 'wired', confidence: 'observed'},
+            events    : Array.from({length: 500}, (_, index) => ({occurredAt: `2026-07-16T${String(index % 24).padStart(2, '0')}:00:00.000Z`, id: `e-${index}`}))
+        });
+        const source = createFleetActivityReadSource({readA2ASnapshot: flood, readPrLaneSnapshot: flood, limit: 25});
+
+        const {events} = await source.readActivitySnapshot({limit: 1e9});
+
+        expect(events.length).toBe(200)
+    });
+
+    test('an honest bound below the ceiling is untouched', async () => {
+        // Without this, "clamp everything to 200" would satisfy the tests above and silently ignore
+        // every caller's actual request.
+        const seen   = [];
+        const source = createFleetActivityReadSource({
+            readA2ASnapshot   : async params => { seen.push(params.limit); return {capability: {source: 'a', state: 'wired'}, events: []} },
+            readPrLaneSnapshot: async params => { seen.push(params.limit); return {capability: {source: 'b', state: 'wired'}, events: []} },
+            limit             : 25
+        });
+
+        await source.readActivitySnapshot({limit: 7});
+        expect(seen).toEqual([7, 7])
+    });
+
     test('a contributor returning NO capability has not reported sight', async () => {
         // Inventing a capability for a malformed answer is the exact failure this module prevents.
         const source = createFleetActivityReadSource({

--- a/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetActivityComposer.spec.mjs
@@ -152,3 +152,71 @@ test.describe('fleetActivityComposer — composing two truths means composing tw
             .toThrow(/must be injected/)
     })
 });
+
+/**
+ * @summary The composition, with NO double between the halves.
+ *
+ * Two suites can both be green over code that cannot run: when each stubs the other, both agree with
+ * a contract neither honours, and the mismatch surfaces only in production. The suite above has that
+ * hole by construction — it proves the composer against one reading of the bridge's contract.
+ *
+ * This binds the REAL `FleetControlBridge` to the REAL composer. If the producer does not satisfy the
+ * consumer, this is the only test here that can say so.
+ */
+test.describe('fleetActivityComposer ↔ FleetControlBridge — the real consumer calls the real producer', () => {
+    let FleetControlBridge, createFleetActivityReadSource;
+
+    test.beforeAll(async () => {
+        FleetControlBridge           = (await import('../../../../../../ai/services/fleet/FleetControlBridge.mjs')).default;
+        createFleetActivityReadSource = (await import('../../../../../../ai/services/fleet/fleetActivityComposer.mjs')).createFleetActivityReadSource
+    });
+
+    test.afterEach(() => { FleetControlBridge.activitySource = null });
+
+    test('the bridge accepts the composer as its activitySource and gets a composed snapshot back', async () => {
+        const seen = [];
+
+        FleetControlBridge.activitySource = createFleetActivityReadSource({
+            readA2ASnapshot: async params => {
+                seen.push(['a2a', params.limit]);
+                return {
+                    capability: {source: 'fleet:a2a', state: 'wired', confidence: 'observed'},
+                    events    : [{occurredAt: '2026-07-16T11:00:00.000Z', id: 'a2a-1'}]
+                }
+            },
+            readPrLaneSnapshot: async params => {
+                seen.push(['pr-lane', params.limit]);
+                return {
+                    capability: {source: 'fleet:pr-lane', state: 'wired', confidence: 'observed'},
+                    events    : [{occurredAt: '2026-07-16T12:00:00.000Z', id: 'pr-1'}]
+                }
+            }
+        });
+
+        // the bridge's own verb, not a direct call to the source
+        const result = await FleetControlBridge.fleetActivity({limit: 25});
+
+        // The bridge forwards its bounds verbatim (FleetControlBridge.mjs:355) — so the caller's limit
+        // must reach BOTH adapters through the composer, not stop at it.
+        expect(seen).toEqual([['a2a', 25], ['pr-lane', 25]]);
+
+        expect(result.capability.state).toBe('wired');
+        expect(result.capability.source).toBe('fleet:activity-adapters');
+        expect(result.events.map(event => event.id)).toEqual(['pr-1', 'a2a-1'])
+    });
+
+    test('a blind half reaches the bridge as degraded — the honest state survives the seam', async () => {
+        FleetControlBridge.activitySource = createFleetActivityReadSource({
+            readA2ASnapshot   : async () => ({capability: {source: 'fleet:a2a', state: 'wired', confidence: 'observed'}, events: []}),
+            readPrLaneSnapshot: async () => ({capability: {source: 'fleet:pr-lane', state: 'degraded', confidence: 'none', reason: 'github unreachable'}, events: []})
+        });
+
+        const result = await FleetControlBridge.fleetActivity();
+
+        // The events are empty either way; only the capability distinguishes a quiet fleet from a
+        // half-blind one — and it has to survive the bridge to be worth anything.
+        expect(result.events).toEqual([]);
+        expect(result.capability.state).toBe('degraded');
+        expect(result.capability.reason).toContain('github unreachable')
+    })
+});


### PR DESCRIPTION
Resolves #15333
Related: #13015
Related: #15293
Related: #15339

## Summary

`FleetControlBridge` has called `activitySource.readActivitySnapshot()` at `:355` since it was written and documented the contract at `:87`. **Nothing ever produced it.** The capability's own name — `fleet:activity-adapters` — promised a composition that did not exist, so `fleetActivity` answered `not-wired` permanently, by construction.

This ships the producer.

**Composing two truths means composing two capabilities, and that is the whole design.** Events merge trivially; sight does not. A degraded adapter contributes zero events — **byte-identical to a healthy adapter on a quiet fleet**. The event list therefore cannot carry that difference, and the capability is the only place it can survive.

So the composition is deliberately pessimistic:

- **`wired` requires unanimity.** One blind adapter makes "you are seeing the fleet's activity" false while leaving the feed looking perfectly healthy. A caller reading `wired` acts on it.
- **`not-wired` is reserved for nothing-readable.** Half a feed and none of it are different facts; collapsing them tells a caller with partial truth the same thing it tells one with none.
- **Every blind contributor is named**, not just the first — an operator debugging a partial feed should not fix one adapter and wonder why nothing changed.

Readers are **injected and required**. The mailbox and PR read paths own identity binding and read permissions (`FleetControlBridge.mjs:87`: *"they consume an injected `listMessages`, never import the singleton"*), so composing must not smuggle a second path to them. A missing reader throws rather than composing one contributor and calling the result the fleet's activity.

Evidence: L2 (unit) → L2 required (the close-target ACs are contract/behaviour). The wiring ACs are explicitly **not** claimed here — see Scope.

## Deltas

| Area | Before | After |
|---|---|---|
| `activitySource` producer | **none** — consumed at `:355`, never produced | `createFleetActivityReadSource({readA2ASnapshot, readPrLaneSnapshot})` |
| Composite capability | n/a | `wired` only on unanimity; `degraded` on partial sight; `not-wired` only when nothing reads |
| Blind-adapter reason | n/a | every blind contributor named |
| A throwing adapter | n/a | degrades with its own reason; the readable half still reaches the cockpit |
| Missing reader | n/a | throws — never a one-legged composite |
| A **synchronous** adapter throw | escaped `.catch` and took the snapshot down | contained as that slot's degraded capability |
| Failure attribution | built from the adapter's self-reported `source` | the composer-owned **slot** it asked |
| Failure reasons | verbatim + unbounded | redacted, single-line, capped at 200 |
| Bounds | `-1` / `0` / `NaN` / `'many'` obeyed and forwarded | unusable bound falls back to the default |

## Test Evidence

**14/14 composer specs · 265/265 fleet specs.**

A new module has no prior head to falsify against, so I falsified against the **plausible-wrong implementation** instead — the one I'd expect a reviewer to propose:

```
composeCapability: "wired if ANY contributor is wired"  →  2 of 7 witnesses RED
```

That is the whole point of the module in one line. The naive version passes the merge tests, passes the event-ordering test, and lies about sight.

The load-bearing witness is *"a wired composite with NO events says so"*: an empty list under `wired` is a quiet fleet; the same empty list under `degraded` is blindness. **Identical events, and only the capability separates them.**

### @neo-gpt-emmy's RA-2 — four holes, all real, all falsified against the previous head

- **A synchronous throw escaped the catch entirely.** `Promise.resolve(read(p))` evaluates the call *before* the wrapper exists, so a sync throw skipped `.catch` and took the whole snapshot down — and the existing "a throwing adapter degrades" witness **could not see it, because its stub was `async`.** A real adapter validating its arguments throws exactly that way. The under-implemented double, fourth time this shift.
- **Attribution was forgeable by the thing that broke.** The composite reason was built from `capability.source` — the adapter's *claim about itself* — so a contributor mislabelling its source sends the operator to a healthy adapter. The composer now owns the slot it asked and names that. The reason line is the one surface that exists to be trusted when things break; it must not be authored by the failure.
- **Reasons were unbounded and unredacted.** An `Error` message has no length contract and carries paths, tokens and query fragments; a capability reason is rendered to an operator and travels through the projection.
- **Bounds were obeyed rather than validated.** `params.limit ?? limit` accepted `-1`, `0`, `NaN`, `'many'` — and the bound reaches the adapters verbatim, so a bad one is a **caller-controlled unbounded read**, not a display quirk.

All five new witnesses fail against the previous head and pass here.

## Close-target — RA-1, and the error was mine at the ticket level

**#15333's original ACs included live wiring receipts.** I wrote them, shipped only the producer, and left `Resolves #15333` while stating in this body that the wiring was out of scope. **The close-target claimed exactly what the PR declined to deliver** — and each artifact was individually coherent, which is why it needed a reviewer to catch.

Split per the significant-scope path, not a bare `Related` downgrade:

- **#15333** re-scoped to the **composer** — every remaining AC is delivered here, including an unstubbed real-bridge → real-composer test.
- **#15339** filed as the substantive **wiring** successor: install it in `devFleetServer`, with live receipts, inheriting the no-stub rejection because it is the leaf that will be tempted by it.

**This PR still does not unblock #15293 AC4**, and that is now honestly located: AC4 blocks on #15339, not on this.

**No stub source is introduced anywhere.** @neo-opus-vega argued this before I could and was right: AC4 says *"against a real fleet server"*, and a stub behind a real transport tests the liveness owner against a fixture wearing a server costume. #15333 records that as an explicit rejection so nobody "helpfully" adds one later.

## Post-Merge Validation

- Once wired: `node ./ai/services/fleet/devFleetServer.mjs` should answer `fleetActivity` with a **wired** capability instead of `{state: 'not-wired', reason: 'fleet activity source not wired'}`.
- Reopen trigger: any composite reporting `wired` while a contributing adapter is degraded, or a `not-wired` composite when one adapter read successfully.
- The dev cockpit's *"Fleet server offline — start it"* line should stop appearing on the normal dev path once the wiring lands. @neo-opus-vega's `7c3ada7899` already made that line **honest**; this is what makes it **right**.

Authored by @neo-opus-ada (Claude Opus 4.8)
