### PR TITLE
fix(devindex): retry transient REST failures (#15328)

### DIFF
--- a/apps/devindex/services/GitHub.mjs
+++ b/apps/devindex/services/GitHub.mjs
@@ -45,6 +45,31 @@ class GitHub extends Base {
          */
         restUrl: 'https://api.github.com',
         /**
+         * Maximum retry attempts for transient REST transport failures.
+         * @member {Number} restMaxRetryAttempts=3
+         */
+        restMaxRetryAttempts: 3,
+        /**
+         * Initial REST retry delay in milliseconds.
+         * @member {Number} restRetryBaseDelayMs=1000
+         */
+        restRetryBaseDelayMs: 1000,
+        /**
+         * Maximum exponential REST retry delay in milliseconds.
+         * @member {Number} restRetryMaxDelayMs=10000
+         */
+        restRetryMaxDelayMs: 10000,
+        /**
+         * Jitter ratio applied to exponential REST retry delays.
+         * @member {Number} restRetryJitterRatio=0.2
+         */
+        restRetryJitterRatio: 0.2,
+        /**
+         * HTTP statuses that represent transient REST edge or proxy failures.
+         * @member {Number[]} restRetryableHttpStatuses=[429,502,503,504]
+         */
+        restRetryableHttpStatuses: [429, 502, 503, 504],
+        /**
          * Current Rate Limit Status
          * @member {Object} rateLimit
          */
@@ -86,6 +111,130 @@ class GitHub extends Base {
             console.error('[GitHub] Failed to get auth token from environment or `gh` CLI.');
             throw new Error('Authentication failed. Please set GH_TOKEN/GITHUB_TOKEN or run `gh auth login`.');
         }
+    }
+
+    /**
+     * @summary Calculates the delay for a transient REST retry.
+     * @param {Number}        attempt       The 1-based retry attempt.
+     * @param {Response|null} [response=null] The failed response, when available.
+     * @returns {Number} Delay in milliseconds.
+     * @private
+     */
+    #getRestRetryDelay(attempt, response=null) {
+        const retryAfter = response?.headers?.get?.('retry-after');
+
+        if (retryAfter) {
+            const seconds = Number(retryAfter);
+
+            if (Number.isFinite(seconds)) {
+                return Math.max(0, seconds * 1000);
+            }
+
+            const retryAt = Date.parse(retryAfter);
+
+            if (Number.isFinite(retryAt)) {
+                return Math.max(0, retryAt - Date.now());
+            }
+        }
+
+        const baseDelay = Math.min(
+            this.restRetryMaxDelayMs,
+            this.restRetryBaseDelayMs * 2 ** (attempt - 1)
+        );
+        const jitter = baseDelay * this.restRetryJitterRatio * Math.random();
+
+        return Math.min(this.restRetryMaxDelayMs, Math.round(baseDelay + jitter));
+    }
+
+    /**
+     * @summary Determines whether a REST fetch failure is likely transient.
+     * @param {*} error The thrown fetch error.
+     * @returns {Boolean}
+     * @private
+     */
+    #isRestRetryableNetworkError(error) {
+        const message = [
+            error?.message,
+            error?.cause?.message,
+            error?.cause?.code,
+            error?.code,
+            String(error)
+        ].filter(Boolean).join(' ').toLowerCase();
+
+        return [
+            'fetch failed',
+            'network',
+            'terminated',
+            'timeout',
+            'econnreset',
+            'etimedout',
+            'enotfound',
+            'eai_again',
+            'socket hang up'
+        ].some(pattern => message.includes(pattern));
+    }
+
+    /**
+     * @summary Determines whether a REST response status is configured as transient.
+     * @param {Number} status The HTTP response status.
+     * @returns {Boolean}
+     * @private
+     */
+    #isRestRetryableHttpStatus(status) {
+        return this.restRetryableHttpStatuses.includes(status);
+    }
+
+    /**
+     * @summary Releases a failed REST response body before opening the next connection.
+     * @param {Response} response The response whose body will no longer be consumed.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async #releaseRestResponseBody(response) {
+        const body = response?.body;
+
+        if (!body || body.locked) {
+            return;
+        }
+
+        try {
+            await body.cancel();
+        } catch {
+            // The original request failure remains authoritative when body cleanup also fails.
+        }
+    }
+
+    /**
+     * @summary Waits for a bounded REST retry delay.
+     * @param {Number} delay Delay in milliseconds.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async #sleep(delay) {
+        if (delay <= 0) {
+            return;
+        }
+
+        await new Promise(resolve => setTimeout(resolve, delay));
+    }
+
+    /**
+     * @summary Logs and waits before retrying a transient REST failure.
+     * @param {String}        prefix          Request-specific log prefix.
+     * @param {String}        reason          Safe retry reason for logs.
+     * @param {Number}        attempt         The 1-based retry attempt.
+     * @param {Response|null} [response=null] The failed response, when available.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async #waitForRestRetry(prefix, reason, attempt, response=null) {
+        const delay = this.#getRestRetryDelay(attempt, response);
+
+        console.warn(
+            `${prefix} ${reason}; retrying in ${delay}ms ` +
+            `(attempt ${attempt}/${this.restMaxRetryAttempts})`
+        );
+        await this.#sleep(delay);
     }
 
     /**
@@ -150,12 +299,12 @@ class GitHub extends Base {
      * @returns {Promise<Object>} The `data` property of the response.
      */
     async query(query, variables = {}, retries = 3, logContext = '') {
-        const token = await this.#getAuthToken();
+        const token  = await this.#getAuthToken();
         const prefix = logContext ? `[GitHub] [${logContext}]` : '[GitHub]';
 
         try {
             const response = await fetch(this.graphqlUrl, {
-                method: 'POST',
+                method : 'POST',
                 headers: {
                     'Content-Type' : 'application/json',
                     'Authorization': `bearer ${token}`,
@@ -256,30 +405,76 @@ class GitHub extends Base {
      * @returns {Promise<Object>} JSON response
      */
     async rest(endpoint, logContext = '') {
-        const token = await this.#getAuthToken();
-        const url = `${this.restUrl}/${endpoint.startsWith('/') ? endpoint.slice(1) : endpoint}`;
+        const token  = await this.#getAuthToken();
+        const url    = `${this.restUrl}/${endpoint.startsWith('/') ? endpoint.slice(1) : endpoint}`;
         const prefix = logContext ? `[GitHub] [${logContext}]` : '[GitHub]';
 
         try {
-            const response = await fetch(url, {
-                method: 'GET',
-                headers: {
-                    'Accept'       : 'application/vnd.github.v3+json',
-                    'Authorization': `bearer ${token}`,
-                    'User-Agent'   : 'Neo.mjs-DevIndex/1.0'
+            for (let attempt = 0; attempt <= this.restMaxRetryAttempts; attempt++) {
+                let response;
+
+                try {
+                    response = await fetch(url, {
+                        method : 'GET',
+                        headers: {
+                            'Accept'       : 'application/vnd.github.v3+json',
+                            'Authorization': `bearer ${token}`,
+                            'User-Agent'   : 'Neo.mjs-DevIndex/1.0'
+                        }
+                    });
+                } catch (error) {
+                    if (attempt < this.restMaxRetryAttempts && this.#isRestRetryableNetworkError(error)) {
+                        await this.#waitForRestRetry(
+                            prefix,
+                            `Transient REST transport failure (${error.message})`,
+                            attempt + 1
+                        );
+                        continue;
+                    }
+
+                    throw error;
                 }
-            });
 
-            this.#updateRateLimit(response);
+                this.#updateRateLimit(response);
 
-            if (!response.ok) {
+                if (response.ok) {
+                    try {
+                        return await response.json();
+                    } catch (error) {
+                        if (attempt < this.restMaxRetryAttempts && this.#isRestRetryableNetworkError(error)) {
+                            await this.#releaseRestResponseBody(response);
+                            await this.#waitForRestRetry(
+                                prefix,
+                                `Transient REST response-body failure (${error.message})`,
+                                attempt + 1
+                            );
+                            continue;
+                        }
+
+                        throw error;
+                    }
+                }
+
+                const error = new Error(`REST Error: ${response.status} ${response.statusText}`);
+
+                await this.#releaseRestResponseBody(response);
+
                 if (response.status === 403) {
                     this.rateLimit.core.remaining = 0;
+                    throw error;
                 }
-                throw new Error(`REST Error: ${response.status} ${response.statusText}`);
-            }
 
-            return await response.json();
+                if (response.status === 404) {
+                    throw error;
+                }
+
+                if (attempt < this.restMaxRetryAttempts && this.#isRestRetryableHttpStatus(response.status)) {
+                    await this.#waitForRestRetry(prefix, error.message, attempt + 1, response);
+                    continue;
+                }
+
+                throw error;
+            }
         } catch (error) {
             console.error(`${prefix} REST Request Failed (${endpoint}):`, error.message);
             throw error;
@@ -297,7 +492,7 @@ class GitHub extends Base {
         // We use 'node' interface which is polymorphic.
         // If the ID belongs to a User, it will return the User object.
         const query = `
-            query { 
+            query {
                 node(id: "${nodeId}") {
                     ... on User {
                         login

--- a/learn/guides/devindex/data-factory/GitHubAPI.md
+++ b/learn/guides/devindex/data-factory/GitHubAPI.md
@@ -36,8 +36,8 @@ The service tracks rate limits across multiple "buckets" (`core`, `search`, `gra
 
 For GraphQL, it also hooks into the `rateLimit` object returned within the JSON body, which provides the most accurate reflection of the complex query costs.
 
-### Graceful Degradation & Backoff
-If a request fails with a `5xx` (Server Error) or `403` (Forbidden), the service automatically initiates an exponential backoff retry loop.
+### GraphQL Backoff
+GraphQL requests retain their existing bounded retry policy for server failures and `403` responses. A `403` with quota remaining is treated as secondary abuse detection and receives a longer cooldown; a depleted quota remains visible through the tracked `graphql` bucket.
 
 ```javascript
 if ((response.status >= 500 || response.status === 403) && retries > 0) {
@@ -55,7 +55,20 @@ if ((response.status >= 500 || response.status === 403) && retries > 0) {
 }
 ```
 
-This logic specifically distinguishes between running out of quota (a hard stop) and triggering GitHub's secondary abuse detection (which requires a temporary pause to cool down).
+This path is GraphQL-specific. Its caller-supplied retry budget and secondary-abuse handling should not be confused with the independently configurable REST policy.
+
+### REST Backoff
+REST requests retry only bounded transport failures. The default retryable statuses are `429`, `502`, `503`, and `504`; recognized fetch/network failures such as connection resets and timeouts use the same attempt budget. Operators can override the policy through the service's Neo configs:
+
+- `restMaxRetryAttempts`
+- `restRetryBaseDelayMs`
+- `restRetryMaxDelayMs`
+- `restRetryJitterRatio`
+- `restRetryableHttpStatuses`
+
+When GitHub supplies `Retry-After`, the service honors either its numeric-seconds or HTTP-date form. Otherwise it uses capped exponential delay plus jitter. Every HTTP response updates the relevant `x-ratelimit-*` bucket before the service decides whether to retry.
+
+The fail-closed boundary remains explicit: `403` marks the core quota as depleted and fails immediately, while `404` and other non-transient client errors are not retried. An exhausted transient HTTP response preserves the `REST Error: <status> <statusText>` contract; an exhausted network failure rethrows its original error object. Successful response bodies are part of the transport boundary, so a terminated body stream can retry, but malformed JSON remains a fail-fast parse error.
 
 ---
 
@@ -69,13 +82,11 @@ To prevent data loss and ensure continuity, the `GitHub` service provides specif
 GitHub assigns every user an immutable integer `databaseId`. If a username lookup fails, the DevIndex pipeline can call this method using the stored `databaseId` to fetch the new, updated username.
 
 ```javascript
-const query = `
-    query { 
-        user(databaseId: ${dbId}) {
-            login
-        } 
-    }`;
+const account = await GitHub.rest(`user/${dbId}`, `DB_ID:${dbId}`);
+const login   = account?.login ?? null;
 ```
+
+Database-ID resolution is REST-owned because GitHub exposes the immutable integer lookup at `/user/{account_id}`. A `404` means the account cannot be resolved and becomes `null` at the resolver boundary; exhausted transient transport failures continue to throw so the Cleanup pipeline cannot misclassify an upstream outage as account deletion.
 
 ### `getLoginById(nodeId)`
 Similarly, GitHub uses global Base64 `nodeId`s. This method uses the polymorphic `node` interface to resolve a Node ID back to a User or Organization login.

--- a/test/playwright/unit/app/devindex/GitHubService.spec.mjs
+++ b/test/playwright/unit/app/devindex/GitHubService.spec.mjs
@@ -15,13 +15,49 @@ import GitHub         from '../../../../../apps/devindex/services/GitHub.mjs';
 
 test.describe('DevIndex GitHub service', () => {
     let originalRest;
+    let originalFetch;
+    let originalGhToken;
+    let restClient;
+
+    const jsonResponse = (data, init={}) => {
+        const {headers={}, ...responseInit} = init;
+
+        return new Response(JSON.stringify(data), {
+            status    : 200,
+            statusText: 'OK',
+            ...responseInit,
+            headers   : {
+                'content-type'         : 'application/json',
+                'x-ratelimit-resource' : 'core',
+                'x-ratelimit-remaining': '4999',
+                ...headers
+            }
+        });
+    };
 
     test.beforeEach(() => {
-        originalRest = GitHub.rest;
+        originalRest                      = GitHub.rest;
+        originalFetch                     = globalThis.fetch;
+        originalGhToken                   = process.env.GH_TOKEN;
+
+        process.env.GH_TOKEN                    = 'devindex-unit-test-token';
+        restClient                              = new GitHub.constructor();
+        restClient.restMaxRetryAttempts         = 2;
+        restClient.restRetryBaseDelayMs         = 0;
+        restClient.restRetryMaxDelayMs          = 0;
+        restClient.restRetryJitterRatio         = 0;
+        restClient.restRetryableHttpStatuses    = [429, 502, 503, 504]
     });
 
     test.afterEach(() => {
-        GitHub.rest = originalRest;
+        GitHub.rest                         = originalRest;
+        globalThis.fetch                    = originalFetch;
+
+        if (originalGhToken === undefined) {
+            delete process.env.GH_TOKEN
+        } else {
+            process.env.GH_TOKEN = originalGhToken
+        }
     });
 
     test('getLoginByDatabaseId resolves the current login via REST account id lookup', async () => {
@@ -60,5 +96,261 @@ test.describe('DevIndex GitHub service', () => {
         };
 
         await expect(GitHub.getLoginByDatabaseId(123)).rejects.toThrow('REST Error: 502 Bad Gateway');
+    });
+
+    test('rest retries a transient 503 and updates rate-limit state before the next attempt', async () => {
+        let callCount = 0;
+        let remainingBeforeSecondAttempt;
+
+        globalThis.fetch = async () => {
+            callCount++;
+
+            if (callCount === 1) {
+                return new Response('', {
+                    status    : 503,
+                    statusText: 'Service Unavailable',
+                    headers   : {
+                        'x-ratelimit-resource' : 'core',
+                        'x-ratelimit-remaining': '321'
+                    }
+                });
+            }
+
+            remainingBeforeSecondAttempt = restClient.rateLimit.core.remaining;
+            return jsonResponse({login: 'dregitsky'});
+        };
+
+        await expect(restClient.rest('user/5704244')).resolves.toEqual({login: 'dregitsky'});
+        expect(callCount).toBe(2);
+        expect(remainingBeforeSecondAttempt).toBe(321);
+    });
+
+    test('rest retries a recognized network failure and returns the eventual response', async () => {
+        let callCount = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+
+            if (callCount === 1) {
+                const error = new TypeError('request aborted');
+                error.cause = {code: 'ECONNRESET'};
+                throw error;
+            }
+
+            return jsonResponse({ok: true});
+        };
+
+        await expect(restClient.rest('meta')).resolves.toEqual({ok: true});
+        expect(callCount).toBe(2);
+    });
+
+    test('rest retries a recognized transport failure while consuming a successful response body', async () => {
+        let callCount = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+
+            if (callCount === 1) {
+                return new Response(new ReadableStream({
+                    start(controller) {
+                        controller.enqueue(new TextEncoder().encode('{"ok":'));
+                        controller.error(new TypeError('terminated'));
+                    }
+                }), {
+                    status : 200,
+                    headers: {'content-type': 'application/json'}
+                });
+            }
+
+            return jsonResponse({ok: true});
+        };
+
+        await expect(restClient.rest('meta')).resolves.toEqual({ok: true});
+        expect(callCount).toBe(2);
+    });
+
+    test('rest cancels a retryable HTTP response body before the next attempt', async () => {
+        let bodyCancelled = false;
+        let callCount     = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+
+            if (callCount === 1) {
+                return new Response(new ReadableStream({
+                    cancel() {
+                        bodyCancelled = true;
+                    }
+                }), {status: 503, statusText: 'Service Unavailable'});
+            }
+
+            expect(bodyCancelled).toBe(true);
+            return jsonResponse({ok: true});
+        };
+
+        await expect(restClient.rest('meta')).resolves.toEqual({ok: true});
+        expect(callCount).toBe(2);
+    });
+
+    test('rest preserves the terminal HTTP error after exhausting the retry budget', async () => {
+        let callCount = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+            return new Response('', {status: 503, statusText: 'Service Unavailable'});
+        };
+
+        await expect(restClient.rest('meta')).rejects.toThrow('REST Error: 503 Service Unavailable');
+        expect(callCount).toBe(3);
+    });
+
+    test('rest preserves the original network error identity after exhaustion', async () => {
+        const networkError = new TypeError('fetch failed');
+        let   callCount    = 0;
+
+        networkError.cause = {code: 'ECONNRESET'};
+        globalThis.fetch = async () => {
+            callCount++;
+            throw networkError;
+        };
+
+        await expect(restClient.rest('meta')).rejects.toBe(networkError);
+        expect(callCount).toBe(3);
+    });
+
+    test('rest fails fast for 404 and 403 responses', async () => {
+        let callCount = 0;
+
+        restClient.restRetryableHttpStatuses = [403, 404, 503];
+        globalThis.fetch = async () => {
+            callCount++;
+            return new Response('', {status: 404, statusText: 'Not Found'});
+        };
+
+        await expect(restClient.rest('missing')).rejects.toThrow('REST Error: 404 Not Found');
+        expect(callCount).toBe(1);
+
+        callCount = 0;
+        globalThis.fetch = async () => {
+            callCount++;
+            return new Response('', {status: 403, statusText: 'Forbidden'});
+        };
+
+        await expect(restClient.rest('forbidden')).rejects.toThrow('REST Error: 403 Forbidden');
+        expect(callCount).toBe(1);
+        expect(restClient.rateLimit.core.remaining).toBe(0);
+    });
+
+    test('rest honors an overridden retryable status set', async () => {
+        let callCount = 0;
+
+        restClient.restRetryableHttpStatuses = [418];
+        globalThis.fetch = async () => {
+            callCount++;
+
+            if (callCount === 1) {
+                return new Response('', {status: 418, statusText: "I'm a Teapot"});
+            }
+
+            return jsonResponse({ok: true});
+        };
+
+        await expect(restClient.rest('meta')).resolves.toEqual({ok: true});
+        expect(callCount).toBe(2);
+    });
+
+    test('rest honors numeric and HTTP-date Retry-After values', async () => {
+        const originalSetTimeout = globalThis.setTimeout;
+        const originalDateNow    = Date.now;
+        const delays             = [];
+        const fixedNow           = Date.parse('2026-07-17T00:00:00Z');
+        let   callCount          = 0;
+
+        globalThis.setTimeout = (callback, delay) => {
+            delays.push(delay);
+            callback();
+            return 0
+        };
+        Date.now = () => fixedNow;
+
+        try {
+            globalThis.fetch = async () => {
+                callCount++;
+
+                if (callCount === 1) {
+                    return new Response('', {
+                        status    : 503,
+                        statusText: 'Service Unavailable',
+                        headers   : {'retry-after': '2'}
+                    });
+                }
+
+                if (callCount === 2) {
+                    return new Response('', {
+                        status    : 503,
+                        statusText: 'Service Unavailable',
+                        headers   : {'retry-after': new Date(fixedNow + 5000).toUTCString()}
+                    });
+                }
+
+                return jsonResponse({ok: true});
+            };
+
+            await expect(restClient.rest('meta')).resolves.toEqual({ok: true});
+            expect(delays).toEqual([2000, 5000]);
+        } finally {
+            globalThis.setTimeout = originalSetTimeout;
+            Date.now              = originalDateNow
+        }
+    });
+
+    test('rest caps exponential backoff after applying jitter', async () => {
+        const originalSetTimeout = globalThis.setTimeout;
+        const originalRandom     = Math.random;
+        const delays             = [];
+        let   callCount          = 0;
+
+        restClient.restRetryBaseDelayMs = 100;
+        restClient.restRetryMaxDelayMs  = 150;
+        restClient.restRetryJitterRatio = 0.2;
+        globalThis.setTimeout = (callback, delay) => {
+            delays.push(delay);
+            callback();
+            return 0
+        };
+        Math.random = () => 1;
+
+        try {
+            globalThis.fetch = async () => {
+                callCount++;
+
+                if (callCount < 3) {
+                    return new Response('', {status: 503, statusText: 'Service Unavailable'});
+                }
+
+                return jsonResponse({ok: true});
+            };
+
+            await expect(restClient.rest('meta')).resolves.toEqual({ok: true});
+            expect(delays).toEqual([120, 150]);
+        } finally {
+            globalThis.setTimeout = originalSetTimeout;
+            Math.random           = originalRandom
+        }
+    });
+
+    test('rest does not retry JSON parse failures from successful responses', async () => {
+        let callCount = 0;
+
+        globalThis.fetch = async () => {
+            callCount++;
+            return new Response('{not-json', {
+                status : 200,
+                headers: {'content-type': 'application/json'}
+            });
+        };
+
+        await expect(restClient.rest('meta')).rejects.toBeInstanceOf(SyntaxError);
+        expect(callCount).toBe(1);
     });
 });


### PR DESCRIPTION
Resolves #15328

DevIndex REST calls now use a bounded, operator-overridable retry policy for transient HTTP, fetch, and response-body transport failures. `429`, `502`, `503`, and `504` are configurable defaults; numeric and HTTP-date `Retry-After` values take precedence over capped exponential backoff with jitter. Every response still updates the live rate-limit bucket before the retry decision.

The failure boundary stays closed: `403` depletes the core bucket and fails immediately, `404` remains fail-fast even if an override tries to classify it as transient, malformed JSON is not retried, and exhausted HTTP/network failures preserve their existing caller-visible contracts. Failed response bodies are cancelled before another connection is opened.

The DevIndex GitHub API guide now distinguishes GraphQL and REST backoff and documents the current REST-owned database-ID resolver.

Evidence: L2 (isolated transport/unit witnesses plus repository preflight) → L2 required for the local contract. A later scheduled Data Sync run is post-merge observation only; external GitHub availability is not a merge gate. No residuals.

Related: #11585, #11587

## Deltas from ticket

The implementation sweep exposed two transport cases implicit in the ticket's network-failure acceptance criterion: fetch can resolve before the response body terminates, and a retryable HTTP response must release its body before the next connection. Both are handled inside the same REST owner and covered by discriminating stream witnesses. No caller or Cleanup identity semantics changed.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/app/devindex/GitHubService.spec.mjs` — 14/14 passed; covers 503 recovery, cause-code network recovery, response-body termination recovery, body cancellation, retry exhaustion, hard 403/404 boundaries, config override, both `Retry-After` forms, jitter capping, rate-limit visibility, and malformed-JSON fail-fast behavior.
- `npm run test-unit -- test/playwright/unit/app/devindex` — 22/23 passed. Every functional sibling passed; the untouched `StoreFilterProfile` shared-machine timing assertion measured 498 ms against its 400 ms threshold.
- `npm run test-unit -- test/playwright/unit/app/devindex/StoreFilterProfile.spec.mjs` — 1/1 passed in isolation, confirming the folder-run miss was timing noise rather than a functional regression.
- `npm run agent-preflight -- --no-fix apps/devindex/services/GitHub.mjs test/playwright/unit/app/devindex/GitHubService.spec.mjs learn/guides/devindex/data-factory/GitHubAPI.md` — passed; the stale Memory-Core overlay warning is unrelated and non-blocking.
- Pre-commit whitespace, shorthand, JSDoc type, ticket archaeology, block alignment, and parse gates — passed.
- `git diff --check` — clean; all three changed files are text.

## Post-Merge Validation

- [ ] Observe a subsequent scheduled Data Sync run traversing the repaired transport. Record any distinct workflow or upstream failure as a new ticket rather than reopening this local merge gate.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session b681a37a-4353-4ed0-bbf1-b46e6f2501c7.
