### PR TITLE
feat(build): refuse operator-authored commits from an agent worktree (#15337)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,2 @@
 node ./buildScripts/util/check-branch-discipline.mjs
+node ./buildScripts/util/check-commit-authorship.mjs

--- a/ai/scripts/migrations/bootstrapWorktree.mjs
+++ b/ai/scripts/migrations/bootstrapWorktree.mjs
@@ -226,6 +226,52 @@ export const GITIGNORED_FILES_TO_LINK = [
 export const DEFAULT_CLAUDE_WORKTREES_ROOT = path.join('.claude', 'worktrees');
 
 /**
+ * @summary Reports whether a freshly bootstrapped worktree would author commits as the operator.
+ *
+ * A worktree that sets no local `user.email` resolves git's global one — the operator's. Every commit
+ * it produces is then attributed to the human, and nothing says so: `git log --oneline` omits the
+ * author, the commit succeeds, and the PR renders normally. One agent shift reached 38 such commits
+ * across 7 branches before a peer noticed while reading a PR's commit metadata.
+ *
+ * This CANNOT set the right identity, and deliberately does not try: the bootstrap creates the
+ * worktree before any agent occupies it, so it does not know whose it is, and guessing would write a
+ * confident wrong attribution in place of an obvious missing one. What it can do is refuse to let the
+ * leak stay silent, at the one moment someone is watching the output.
+ *
+ * The pre-push guard (`check-commit-authorship`) is the mechanical backstop; this is the early
+ * warning, and neither replaces the other — the warning is skippable, and the backstop fires only
+ * after the work is already committed.
+ *
+ * @param {Object} options
+ * @param {String} options.projectRoot The bootstrapped worktree.
+ * @param {Function} [options.readConfig] `(args) => String` — injected for tests; reads a git config value.
+ * @returns {Promise<{inherited: Boolean, local: String, global: String}>}
+ */
+export async function inspectGitIdentity({projectRoot, readConfig}) {
+    const read = readConfig || (async args => {
+        try {
+            const {stdout} = await execFileAsync('git', args, {cwd: projectRoot});
+            return stdout.trim()
+        } catch {
+            return ''
+        }
+    });
+
+    const
+        globalEmail = (await read(['config', '--global', 'user.email'])).toLowerCase(),
+        localEmail  = (await read(['config', '--local', 'user.email'])).toLowerCase(),
+        effective   = (await read(['config', 'user.email'])).toLowerCase();
+
+    return {
+        // The leak is precisely "no local identity, so the global one answers". A worktree that set
+        // its own identity is fine even if it happens to equal the global one — that was a choice.
+        inherited: Boolean(globalEmail) && !localEmail && effective === globalEmail,
+        local    : localEmail,
+        global   : globalEmail
+    }
+}
+
+/**
  * @summary Resolves the canonical "main checkout" path for a given project root.
  *
  * Two resolution paths, in priority order:
@@ -1276,6 +1322,20 @@ if (isMain) {
         // Default behavior: run build-all after config/data linking
         const buildResult = await runBuildAll({projectRoot});
         console.log(`✓ Build: ${buildResult}`);
+
+        // Said LAST, deliberately: this is the one line the reader must still have on screen, and a
+        // warning buried above a build log is a warning nobody reads.
+        const identity = await inspectGitIdentity({projectRoot});
+
+        if (identity.inherited) {
+            console.log(`\n\x1b[31m⚠ Git identity: this worktree has none, so commits will be authored as ${identity.global} — the operator.\x1b[0m`);
+            console.log(`  Squash-merge preserves the author, so that credits them on dev for work they did not do.`);
+            console.log(`  Set yours before committing:\n`);
+            console.log(`    git config user.name  "<Your Name>"`);
+            console.log(`    git config user.email "<you>@neomjs.com"\n`);
+        } else if (identity.local) {
+            console.log(`✓ Git identity: ${identity.local}`);
+        }
     } catch (e) {
         console.error('Bootstrap failed:', e.message);
         process.exit(1);

--- a/buildScripts/util/check-commit-authorship.mjs
+++ b/buildScripts/util/check-commit-authorship.mjs
@@ -1,6 +1,7 @@
-import {execSync} from 'node:child_process';
-import path       from 'node:path';
-import process    from 'node:process';
+import {execSync}     from 'node:child_process';
+import {readFileSync} from 'node:fs';
+import path           from 'node:path';
+import process        from 'node:process';
 
 /**
  * Pre-push authorship check. ticket-ref-ok: implementing ticket #15337
@@ -32,9 +33,47 @@ import process    from 'node:process';
  */
 
 const
-    range   = 'origin/dev..HEAD',
-    exec    = command => execSync(command, {encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore']}).trim(),
-    tryExec = command => { try { return exec(command) } catch { return '' } };
+    ZERO_SHA = '0'.repeat(40),
+    exec     = command => execSync(command, {encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore']}).trim(),
+    tryExec  = command => { try { return exec(command) } catch { return '' } };
+
+/**
+ * @summary The commits this push will actually send, read from git's own ref tuples.
+ *
+ * git hands a pre-push hook `<localRef> <localSha> <remoteRef> <remoteSha>` per ref on stdin. Reading
+ * it is the difference between guarding the push and guarding a guess about it: the first cut
+ * hard-coded `origin/dev..HEAD`, so `git push origin agent/dirty:refs/heads/agent/dirty` was measured
+ * against a clean HEAD and exited green while shipping an operator-authored commit on the sibling ref.
+ * A bypass in a guard whose whole purpose is being un-bypassable.
+ *
+ * `remoteSha` is the exact boundary git will apply, so `remoteSha..localSha` is the true new-commit
+ * set. A NEW remote branch reports the zero-sha, where the honest fallback is `origin/dev..localSha`:
+ * everything the branch adds to the trunk. A DELETION reports a zero localSha and sends no commits.
+ *
+ * @param {String} stdin The raw hook payload.
+ * @returns {String[]} Rev-list ranges to scan.
+ * @private
+ */
+function pendingRanges(stdin) {
+    const rows = stdin.split('\n').map(line => line.trim()).filter(Boolean);
+
+    if (rows.length === 0) {
+        // Invoked outside the hook (a manual run, or a git that sent nothing): fall back to the
+        // branch's own range rather than silently scanning nothing. A guard that no-ops when it
+        // cannot see its input is the same failure it exists to prevent.
+        return ['origin/dev..HEAD']
+    }
+
+    return rows.map(row => {
+        const [, localSha, , remoteSha] = row.split(/\s+/);
+
+        if (!localSha || localSha === ZERO_SHA) {
+            return null // a deletion sends no commits
+        }
+
+        return !remoteSha || remoteSha === ZERO_SHA ? `origin/dev..${localSha}` : `${remoteSha}..${localSha}`
+    }).filter(Boolean)
+}
 
 /**
  * @summary Whether this working tree is a LINKED worktree rather than the main checkout.
@@ -66,21 +105,30 @@ function operatorEmail() {
 }
 
 /**
- * @summary Commits in the push range authored with the given email.
+ * @summary Commits across every pending range authored with the given email.
  * @param {String} email Lower-cased author email to match.
- * @returns {String[]} `"<sha> <subject>"` rows.
+ * @param {String[]} ranges Rev-list ranges derived from the push's own ref tuples.
+ * @returns {String[]} Deduped `"<sha> <subject>"` rows.
  */
-function commitsAuthoredBy(email) {
-    const log = tryExec(`git log ${range} --format=%H%x09%ae%x09%s`);
+function commitsAuthoredBy(email, ranges) {
+    const seen = new Map();
 
-    if (!log) {
-        return []
-    }
+    ranges.forEach(range => {
+        const log = tryExec(`git log ${range} --format=%H%x09%ae%x09%s`);
 
-    return log.split('\n')
-        .map(line => line.split('\t'))
-        .filter(([, authorEmail]) => (authorEmail || '').toLowerCase() === email)
-        .map(([sha, , subject]) => `  ${sha.slice(0, 10)}  ${subject}`)
+        if (!log) {
+            return
+        }
+
+        log.split('\n').map(line => line.split('\t')).forEach(([sha, authorEmail, subject]) => {
+            // Deduped by sha: one commit reachable from two pushed refs is one offender, not two.
+            if ((authorEmail || '').toLowerCase() === email && sha) {
+                seen.set(sha, `  ${sha.slice(0, 10)}  ${subject}`)
+            }
+        })
+    });
+
+    return [...seen.values()]
 }
 
 const operator = operatorEmail();
@@ -90,7 +138,17 @@ if (!operator || !isLinkedWorktree()) {
     process.exit(0)
 }
 
-const offenders = commitsAuthoredBy(operator);
+// stdin is the hook's payload; readFileSync(0) is the only way to take it synchronously, and a
+// missing/closed stdin must degrade to the branch range rather than to an empty scan.
+let payload = '';
+
+try {
+    payload = readFileSync(0, 'utf8')
+} catch {
+    payload = ''
+}
+
+const offenders = commitsAuthoredBy(operator, pendingRanges(payload));
 
 if (offenders.length === 0) {
     process.exit(0)

--- a/buildScripts/util/check-commit-authorship.mjs
+++ b/buildScripts/util/check-commit-authorship.mjs
@@ -1,0 +1,126 @@
+import {execSync} from 'node:child_process';
+import path       from 'node:path';
+import process    from 'node:process';
+
+/**
+ * Pre-push authorship check. ticket-ref-ok: implementing ticket #15337
+ *
+ * Refuses to push commits authored with the OPERATOR's identity from an agent worktree.
+ *
+ * **The empirical anchor.** A full agent shift produced 38 commits across 7 branches, every one
+ * authored as the human operator, because the worktree's git config silently resolved to his global
+ * identity. Nothing warned. `git log --oneline` — the view everyone actually reads — shows no author;
+ * the commits succeeded; the PRs rendered normally. It took a peer reading the PR's commit metadata
+ * to notice, hours in.
+ *
+ * **Why it must be mechanical rather than remembered.** Squash-merge PRESERVES the author, so those
+ * PRs would have landed on `dev` permanently crediting the operator for code he did not write — a
+ * provenance error in the one record that cannot be corrected without rewriting shared history. The
+ * repo already gates the adjacent case (`<noreply@*>` co-author footers) mechanically for exactly
+ * this reason: an attribution rule that relies on noticing has already failed once.
+ *
+ * **The rule.** In a LINKED worktree (`git-dir` !== `git-common-dir` — i.e. `.git/worktrees/<name>`,
+ * which is how every agent worktree is created), no pushed commit may carry the identity from the
+ * operator's GLOBAL git config. The operator's own checkout is the main working tree, where his
+ * identity is correct and this check stays silent.
+ *
+ * Comparing against the global config rather than a hard-coded roster is deliberate: the leak IS the
+ * global identity resolving through an unset local one, so that value is exactly the thing to detect.
+ * A roster would need maintaining, and would miss any operator this repo is cloned by.
+ *
+ * Bypass: `git push --no-verify` — for an operator genuinely committing from a worktree.
+ */
+
+const
+    range   = 'origin/dev..HEAD',
+    exec    = command => execSync(command, {encoding: 'utf8', stdio: ['pipe', 'pipe', 'ignore']}).trim(),
+    tryExec = command => { try { return exec(command) } catch { return '' } };
+
+/**
+ * @summary Whether this working tree is a LINKED worktree rather than the main checkout.
+ *
+ * A linked worktree's git-dir is `<common>/worktrees/<name>`; the main checkout's git-dir IS the
+ * common dir. Both are resolved to absolute paths first — `--git-dir` answers relatively in the main
+ * checkout and absolutely in a worktree, so comparing the raw values reports every main checkout as
+ * linked and fires this guard on the operator's own commits.
+ *
+ * @returns {Boolean}
+ */
+function isLinkedWorktree() {
+    const gitDir    = tryExec('git rev-parse --absolute-git-dir'),
+          commonDir = tryExec('git rev-parse --git-common-dir');
+
+    if (!gitDir || !commonDir) {
+        return false
+    }
+
+    return path.resolve(gitDir) !== path.resolve(commonDir)
+}
+
+/**
+ * @summary The operator's global identity — the value that leaks when a worktree sets none.
+ * @returns {String} Lower-cased email, or '' when no global identity is configured.
+ */
+function operatorEmail() {
+    return tryExec('git config --global user.email').toLowerCase()
+}
+
+/**
+ * @summary Commits in the push range authored with the given email.
+ * @param {String} email Lower-cased author email to match.
+ * @returns {String[]} `"<sha> <subject>"` rows.
+ */
+function commitsAuthoredBy(email) {
+    const log = tryExec(`git log ${range} --format=%H%x09%ae%x09%s`);
+
+    if (!log) {
+        return []
+    }
+
+    return log.split('\n')
+        .map(line => line.split('\t'))
+        .filter(([, authorEmail]) => (authorEmail || '').toLowerCase() === email)
+        .map(([sha, , subject]) => `  ${sha.slice(0, 10)}  ${subject}`)
+}
+
+const operator = operatorEmail();
+
+// No global identity, or the operator's own checkout: nothing this check can or should say.
+if (!operator || !isLinkedWorktree()) {
+    process.exit(0)
+}
+
+const offenders = commitsAuthoredBy(operator);
+
+if (offenders.length === 0) {
+    process.exit(0)
+}
+
+const local = tryExec('git config user.email') || '(unset — resolving to the global identity)';
+
+console.error(`\x1b[31mcheck-commit-authorship: ${offenders.length} commit(s) authored as the operator from an agent worktree:\x1b[0m`);
+console.error(offenders.join('\n'));
+console.error(`
+This worktree's user.email is: ${local}
+The operator's global identity is: ${operator}
+
+Squash-merge preserves the author, so pushing these would credit the operator on \`dev\` for code
+they did not write — in the one record that cannot be corrected afterwards without rewriting shared
+history.
+
+Set this worktree's identity to your own, then repair the existing commits:
+
+  git config user.name  "<Your Name>"
+  git config user.email "<you>@neomjs.com"
+  git rebase origin/dev --exec 'git commit --amend --no-edit --reset-author'
+
+Then verify BEFORE force-pushing — a rebase onto a newer dev moves the tree legitimately, so tree
+equality is the WRONG check:
+
+  git diff --name-only origin/dev...HEAD    # the same file set as before, and only your files
+  git log origin/dev..HEAD --format=%an     # every commit is yours
+
+Bypass (an operator genuinely committing from a worktree): git push --no-verify
+`);
+
+process.exit(1);

--- a/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
@@ -30,14 +30,14 @@ test.describe('check-commit-authorship — the operator must not author from an 
      * @param {String} globalEmail The operator identity the guard should treat as the leak source.
      * @returns {{status: Number, stderr: String}}
      */
-    function runGuard(cwd, globalEmail) {
+    function runGuard(cwd, globalEmail, stdin = '') {
         // HOME is redirected so the guard reads THIS as `git config --global user.email` rather than
         // the real developer's — the global config is an input to the rule, so the test owns it.
         const home = path.join(tmpRoot, 'home');
         fs.outputFileSync(path.join(home, '.gitconfig'), `[user]\n\temail = ${globalEmail}\n\tname = Operator\n`);
 
         try {
-            execFileSync('node', [guardPath], {cwd, encoding: 'utf8', env: {...process.env, HOME: home}, stdio: ['pipe', 'pipe', 'pipe']});
+            execFileSync('node', [guardPath], {cwd, encoding: 'utf8', env: {...process.env, HOME: home}, input: stdin, stdio: ['pipe', 'pipe', 'pipe']});
             return {status: 0, stderr: ''}
         } catch (error) {
             return {status: error.status, stderr: `${error.stderr || ''}`}
@@ -124,6 +124,47 @@ test.describe('check-commit-authorship — the operator must not author from an 
         const result = runGuard(tree, 'operator@example.com');
 
         expect(result.status).toBe(0)
+    });
+
+    test('a SIBLING-ref push cannot smuggle an operator commit past a clean HEAD', () => {
+        // @neo-gpt's RA-1. The guard hard-coded `origin/dev..HEAD`, so pushing an explicit sibling ref
+        // was measured against whatever HEAD happened to be — clean — and exited green while shipping
+        // the operator-authored commit. A bypass in a guard whose whole purpose is being unbypassable.
+        const
+            main = createMainCheckout(),
+            tree = path.join(tmpRoot, 'wt');
+
+        git(main, ['worktree', 'add', '-b', 'agent/dirty', tree, 'dev', '--quiet']);
+        fs.outputFileSync(path.join(tree, 'work.txt'), 'agent work\n');
+        git(tree, ['add', '.']);
+        git(tree, ['-c', 'user.email=operator@example.com', '-c', 'user.name=Operator',
+            'commit', '-m', 'feat: smuggled on a sibling ref', '--quiet', '--no-verify']);
+
+        const dirtySha = git(tree, ['rev-parse', 'agent/dirty']).trim();
+
+        // HEAD moves to a CLEAN branch — exactly the state the old range measured
+        git(tree, ['checkout', '-b', 'agent/clean', 'dev', '--quiet']);
+
+        // git's real pre-push payload: <localRef> <localSha> <remoteRef> <remoteSha>; zero-sha = new branch
+        const payload = `refs/heads/agent/dirty ${dirtySha} refs/heads/agent/dirty ${'0'.repeat(40)}\n`;
+
+        const result = runGuard(tree, 'operator@example.com', payload);
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('feat: smuggled on a sibling ref')
+    });
+
+    test('a ref DELETION sends no commits — the guard stays silent', () => {
+        const
+            main = createMainCheckout(),
+            tree = path.join(tmpRoot, 'wt');
+
+        git(main, ['worktree', 'add', '-b', 'agent/lane', tree, 'dev', '--quiet']);
+
+        // a delete pushes a zero localSha; scanning it would be scanning nothing, loudly
+        const payload = `(delete) ${'0'.repeat(40)} refs/heads/agent/lane ${'0'.repeat(40)}\n`;
+
+        expect(runGuard(tree, 'operator@example.com', payload).status).toBe(0)
     });
 
     test('catches an operator commit buried among correctly-authored ones', () => {

--- a/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
@@ -150,3 +150,65 @@ test.describe('check-commit-authorship — the operator must not author from an 
         expect(result.stderr).not.toContain('feat: first')
     })
 });
+
+/**
+ * @summary The bootstrap's early warning — the other half of the same defect.
+ *
+ * The guard above fires at push, after the work is committed. This fires at worktree creation, when
+ * someone is actually reading the output. Neither replaces the other: the warning is skippable, and
+ * the backstop only speaks once 38 commits already exist.
+ */
+test.describe('bootstrapWorktree — inspectGitIdentity', () => {
+    let inspectGitIdentity;
+
+    test.beforeAll(async () => {
+        inspectGitIdentity = (await import('../../../../ai/scripts/migrations/bootstrapWorktree.mjs')).inspectGitIdentity
+    });
+
+    /** @param {Object} values `{global, local, effective}` git config answers. */
+    const readConfig = values => async args => {
+        if (args.includes('--global')) return values.global ?? '';
+        if (args.includes('--local'))  return values.local  ?? '';
+        return values.effective ?? '';
+    };
+
+    test('no local identity + the global one answering = the leak, reported', async () => {
+        const result = await inspectGitIdentity({
+            projectRoot: '/tmp',
+            readConfig : readConfig({global: 'operator@example.com', local: '', effective: 'operator@example.com'})
+        });
+
+        expect(result.inherited).toBe(true);
+        expect(result.global).toBe('operator@example.com')
+    });
+
+    test('a worktree with its OWN identity is silent', async () => {
+        const result = await inspectGitIdentity({
+            projectRoot: '/tmp',
+            readConfig : readConfig({global: 'operator@example.com', local: 'ada@neomjs.com', effective: 'ada@neomjs.com'})
+        });
+
+        expect(result.inherited).toBe(false);
+        expect(result.local).toBe('ada@neomjs.com')
+    });
+
+    test('a local identity that EQUALS the global one is a choice, not a leak', async () => {
+        // The operator bootstrapping a worktree for himself set it deliberately. The defect is the
+        // ABSENCE of a local identity, not the value — flagging this would train people to ignore it.
+        const result = await inspectGitIdentity({
+            projectRoot: '/tmp',
+            readConfig : readConfig({global: 'operator@example.com', local: 'operator@example.com', effective: 'operator@example.com'})
+        });
+
+        expect(result.inherited).toBe(false)
+    });
+
+    test('no global identity at all → nothing to leak, nothing to say', async () => {
+        const result = await inspectGitIdentity({
+            projectRoot: '/tmp',
+            readConfig : readConfig({global: '', local: '', effective: ''})
+        });
+
+        expect(result.inherited).toBe(false)
+    })
+});

--- a/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
+++ b/test/playwright/unit/buildScripts/checkCommitAuthorship.spec.mjs
@@ -1,0 +1,152 @@
+import {test, expect}  from '@playwright/test';
+import {execFileSync}  from 'node:child_process';
+import fs              from 'fs-extra';
+import os              from 'os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const
+    repoRoot  = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..'),
+    guardPath = path.join(repoRoot, 'buildScripts/util/check-commit-authorship.mjs');
+
+/**
+ * @summary The authorship guard, run against real git repositories rather than a mocked `execSync`.
+ *
+ * The guard's entire job is reading git's actual answers — which working tree it is in, and who
+ * authored what. A suite that stubbed `execSync` would prove only that the guard parses strings the
+ * test invented, and the defect it exists to catch (a real worktree silently resolving a real global
+ * identity) lives precisely in the part a stub replaces.
+ *
+ * So these build throwaway repos on disk: a main checkout, and a linked worktree of it.
+ */
+test.describe('check-commit-authorship — the operator must not author from an agent worktree', () => {
+    let tmpRoot;
+
+    const git = (cwd, args) => execFileSync('git', args, {cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe']});
+
+    /**
+     * @summary Runs the guard in `cwd` with an injected global identity.
+     * @param {String} cwd
+     * @param {String} globalEmail The operator identity the guard should treat as the leak source.
+     * @returns {{status: Number, stderr: String}}
+     */
+    function runGuard(cwd, globalEmail) {
+        // HOME is redirected so the guard reads THIS as `git config --global user.email` rather than
+        // the real developer's — the global config is an input to the rule, so the test owns it.
+        const home = path.join(tmpRoot, 'home');
+        fs.outputFileSync(path.join(home, '.gitconfig'), `[user]\n\temail = ${globalEmail}\n\tname = Operator\n`);
+
+        try {
+            execFileSync('node', [guardPath], {cwd, encoding: 'utf8', env: {...process.env, HOME: home}, stdio: ['pipe', 'pipe', 'pipe']});
+            return {status: 0, stderr: ''}
+        } catch (error) {
+            return {status: error.status, stderr: `${error.stderr || ''}`}
+        }
+    }
+
+    /**
+     * @summary A main checkout with an `origin/dev` to measure the push range against.
+     * @returns {String} the main checkout path
+     */
+    function createMainCheckout() {
+        const main = path.join(tmpRoot, 'main');
+
+        fs.ensureDirSync(main);
+        git(main, ['init', '-b', 'dev', '--quiet']);
+        git(main, ['config', 'user.email', 'operator@example.com']);
+        git(main, ['config', 'user.name', 'Operator']);
+        fs.outputFileSync(path.join(main, 'seed.txt'), 'seed\n');
+        git(main, ['add', '.']);
+        git(main, ['commit', '-m', 'seed', '--quiet', '--no-verify']);
+
+        // the guard measures `origin/dev..HEAD`; a self-remote gives it a real ref to resolve
+        git(main, ['remote', 'add', 'origin', main]);
+        git(main, ['fetch', 'origin', '--quiet']);
+
+        return main
+    }
+
+    test.beforeEach(() => {
+        tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'authorship-guard-'))
+    });
+
+    test.afterEach(() => fs.removeSync(tmpRoot));
+
+    test('FIRES on an operator-authored commit in a linked worktree — and names the commit', () => {
+        const
+            main = createMainCheckout(),
+            tree = path.join(tmpRoot, 'wt');
+
+        git(main, ['worktree', 'add', '-b', 'agent/lane', tree, 'dev', '--quiet']);
+
+        // the defect exactly: the worktree sets no identity, so git resolves the operator's global one
+        fs.outputFileSync(path.join(tree, 'work.txt'), 'agent work\n');
+        git(tree, ['add', '.']);
+        git(tree, ['-c', 'user.email=operator@example.com', '-c', 'user.name=Operator',
+            'commit', '-m', 'feat: work the agent actually did', '--quiet', '--no-verify']);
+
+        const result = runGuard(tree, 'operator@example.com');
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('authored as the operator');
+        // naming the commit matters: a count tells nobody which commit to repair
+        expect(result.stderr).toContain('feat: work the agent actually did')
+    });
+
+    test('SILENT in the operator\'s OWN checkout — his commits there are correct', () => {
+        const main = createMainCheckout();
+
+        git(main, ['checkout', '-b', 'agent/lane', '--quiet']);
+        fs.outputFileSync(path.join(main, 'work.txt'), 'operator work\n');
+        git(main, ['add', '.']);
+        git(main, ['commit', '-m', 'feat: operator work', '--quiet', '--no-verify']);
+
+        // The false positive that would make the guard unusable. The main checkout answers
+        // `--git-dir` relatively and `--git-common-dir` relatively too, so a naive string compare
+        // reports it as linked and blocks every commit the operator makes in his own repo.
+        const result = runGuard(main, 'operator@example.com');
+
+        expect(result.status).toBe(0);
+        expect(result.stderr).toBe('')
+    });
+
+    test('SILENT in a linked worktree that authors correctly — the guard targets identity, not worktrees', () => {
+        const
+            main = createMainCheckout(),
+            tree = path.join(tmpRoot, 'wt');
+
+        git(main, ['worktree', 'add', '-b', 'agent/lane', tree, 'dev', '--quiet']);
+        fs.outputFileSync(path.join(tree, 'work.txt'), 'agent work\n');
+        git(tree, ['add', '.']);
+        git(tree, ['-c', 'user.email=ada@neomjs.com', '-c', 'user.name=Ada',
+            'commit', '-m', 'feat: properly attributed work', '--quiet', '--no-verify']);
+
+        const result = runGuard(tree, 'operator@example.com');
+
+        expect(result.status).toBe(0)
+    });
+
+    test('catches an operator commit buried among correctly-authored ones', () => {
+        const
+            main = createMainCheckout(),
+            tree = path.join(tmpRoot, 'wt');
+
+        git(main, ['worktree', 'add', '-b', 'agent/lane', tree, 'dev', '--quiet']);
+
+        // one bad commit in the middle: scanning only HEAD would miss it, and the real incident was
+        // 38 commits deep across branches nobody re-read
+        [['ada@neomjs.com', 'feat: first'], ['operator@example.com', 'feat: the buried one'], ['ada@neomjs.com', 'feat: third']]
+            .forEach(([email, subject], index) => {
+                fs.outputFileSync(path.join(tree, `work-${index}.txt`), `${subject}\n`);
+                git(tree, ['add', '.']);
+                git(tree, ['-c', `user.email=${email}`, '-c', 'user.name=Author', 'commit', '-m', subject, '--quiet', '--no-verify'])
+            });
+
+        const result = runGuard(tree, 'operator@example.com');
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('1 commit(s)');
+        expect(result.stderr).toContain('feat: the buried one');
+        expect(result.stderr).not.toContain('feat: first')
+    })
+});


### PR DESCRIPTION
Resolves #15340
Related: #15337

## Summary

**A full agent shift produced 38 commits across 7 branches, every one authored as the human operator.** The worktree's git config silently resolved to his global identity. Nothing warned — `git log --oneline`, the view everyone actually reads, shows no author; the commits succeeded; no hook objected; the PRs rendered normally. @neo-opus-vega found it reading a PR's commit metadata, hours in, and flagged it as "one real finding" alongside an approval.

**It is not cosmetic.** Squash-merge preserves the author — `dev` carries `Euclid <neo-gpt@neomjs.com>` on #15311 and `Vega <neo-opus-vega@neomjs.com>` on #15285. Seven PRs would have landed permanently crediting the operator for code he did not write, in the one record that cannot be corrected afterwards without rewriting shared history.

**The rule:** in a LINKED worktree, no pushed commit may carry the identity from the operator's global git config.

Comparing against the **global config** rather than a hard-coded roster is deliberate: the leak *is* that value resolving through an unset local one, so it is exactly the thing to detect — and no roster needs maintaining, or would survive this repo being cloned by anyone else.

**Pre-push, not pre-commit.** Reading the hook ref-update tuples catches every commit about to leave the machine, including ones already made before anyone noticed. The real incident was 38 commits deep across branches nobody re-read; a staged-files check would have caught the 39th and shipped the rest.

Evidence: L2 (unit, against real git repositories) → L2 required. The guard also gated its own push: this branch went out through it.

## Deltas

| Area | Before | After |
|---|---|---|
| Agent-worktree authorship | operator's global identity, silently inherited | pushed commits authored as the operator are **refused** |
| Detection | none | linked worktree (`git-dir` !== `git-common-dir`, path-resolved) × operator's global email |
| Operator's own checkout | n/a | **silent** — his commits there are correct |
| Failure message | n/a | names each offending SHA + subject, both identities, and the repair |
| Bootstrap | silent | warns at worktree creation when no local identity is set — printed last, so it is the line still on screen |
| Commit set | hard-coded `origin/dev..HEAD` — a sibling-ref push slipped past a clean HEAD | derived from the push's own `<localRef> <localSha> <remoteRef> <remoteSha>` tuples |

## Test Evidence

**10/10**, against **real git repositories and a real linked worktree** — no `execSync` stub.

The guard's whole job is reading git's actual answers about which tree it is in and who authored what. A stubbed suite would prove only that it parses strings the test invented, and the defect lives precisely in the part a stub replaces.

**Falsified against the naive implementation:**

```
isLinkedWorktree: compare --git-dir to --git-common-dir as RAW strings  →  1 of 4 RED
```

That is the tempting one-liner, and it is wrong in the most damaging direction: git answers `--git-dir` **relatively** in a main checkout and **absolutely** in a worktree, so the raw compare reports the operator's own repo as linked and **blocks every commit he makes in his own checkout**. The false-positive test is the reason `path.resolve` is there.

The suite also pins that an operator commit **buried among correctly-authored ones** is caught and named — scanning only `HEAD` would have missed the real incident entirely.

### The bootstrap half — the early warning

`inspectGitIdentity` reports, at worktree creation, that commits would be authored as the operator. It **deliberately does not set an identity**: the bootstrap creates the worktree before any agent occupies it, so it does not know whose it is, and guessing would write a *confident wrong* attribution in place of an obvious missing one. Refusing to let the leak stay silent is the honest ceiling for a step that cannot know the answer.

**The distinction that earns its own test:** the defect is the **absence** of a local identity, not its value. An operator bootstrapping a worktree for himself and setting his own identity made a choice — flagging that would train people to ignore the warning, which is how the next real leak ships.

```
inherited: flag whenever effective === global (ignoring whether it was CHOSEN)  →  RED
```

Printed **last**, deliberately: a warning buried above a build log is a warning nobody reads.

Neither half replaces the other. The warning is skippable; the backstop only speaks once the commits already exist.

### @neo-gpt's RA-1 — a bypass in the unbypassable thing

The guard hard-coded `origin/dev..HEAD` and never read the pre-push payload, so:

```
git push origin agent/dirty:refs/heads/agent/dirty
```

was measured against whatever HEAD happened to be — **clean** — and exited green while shipping an operator-authored commit on the sibling ref. I reproduced it in a real repo before fixing: `origin/dev..HEAD` → 0 commits; `agent/dirty` → 1 operator-authored commit that would ship.

git hands a pre-push hook `<localRef> <localSha> <remoteRef> <remoteSha>` per ref on stdin. That **is** the push rather than a guess about it. `remoteSha` is the exact boundary git will apply, so `remoteSha..localSha` is the true new-commit set; a new branch reports the zero-sha (fallback `origin/dev..localSha`), a deletion reports a zero localSha and sends nothing. Empty stdin degrades to the branch range, never to an empty scan — a guard that silently no-ops when it cannot see its input is the failure it exists to prevent.

### @neo-gpt's RA-2 — the close target, and I made this error twice tonight

**#15337 requires the bootstrap to SET the identity and to fail loudly on an unresolvable one. This PR delivers neither** — it ships the guard and a *warning* — yet said `Resolves #15337` while stating in this very body that both were deferred.

That is the **identical** error @neo-gpt-emmy caught on PR #15335 forty minutes earlier, made again after being shown the pattern once. Both times the artifacts were individually coherent, which is exactly why each needed a reviewer.

- **#15340** filed as this leaf's truthful close target — the guard + warning, every AC delivered.
- **#15337 stays OPEN** for the cure: bootstrap setting the identity needs a worktree→agent source that does not exist (the canonical emails are documented, but nothing maps a *worktree* to an *agent*).

## Post-Merge Validation

- Any agent pushing from a misconfigured worktree now gets a blocking message naming the commits and the repair, instead of a silent provenance error.
- Reopen trigger: a commit authored by the operator reaching `dev` from an agent worktree, or the guard firing in the operator's own checkout.
- **Still open, and named rather than implied:** neither half *sets* the identity, because the bootstrap cannot know which agent will occupy the worktree. Resolving an agent identity at bootstrap needs a source that does not exist yet (the canonical emails are documented in `pull-request-workflow.md`, but nothing maps a worktree to an agent). That is a design question with cross-agent blast radius, not a 1am guess — it stays open on #15337.

Authored by @neo-opus-ada (Claude Opus 4.8)
