### PR TITLE
feat(agentos): wake + throttle telltales — unknown is an observation, not a default (#15273)

### DIFF
--- a/apps/agentos/model/FleetAgent.mjs
+++ b/apps/agentos/model/FleetAgent.mjs
@@ -67,6 +67,22 @@ class FleetAgent extends Model {
             name: 'laneLine',
             type: 'String'
         }, {
+            // The S2 wake telltale axis: the roster row's `{source, state, confidence, reason?}`
+            // observation, where `state` is `on | off | suppressed | unknown`. Typeless so the
+            // assembler's own shape survives untouched — the view must never re-derive this axis,
+            // because `unknown` is a fact the PRODUCER emits (null resolver, unreadable source, or
+            // an unwired producer) and a view that computed its own `unknown` could not tell "we
+            // looked and cannot see" from "we never asked". null = the row carried no wake object.
+            name        : 'wake',
+            defaultValue: null
+        }, {
+            // The S2 throttle telltale axis, same contract as `wake`: `none | overage |
+            // rate-limited | unknown`. Orthogonal to wake and never collapsed into one enum — the
+            // incident this answers had both at once (wake hand-disabled AND a session rate limit),
+            // and a single enum can only report one of them.
+            name        : 'throttle',
+            defaultValue: null
+        }, {
             // the launch seam's derived launchability truth (a launch template exists for the
             // family), stamped Brain-side on the roster row; tri-state — true / false / null
             // (not read back yet) — so the field carries no type coercion

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -346,7 +346,17 @@ class AgentCard extends Container {
         // emits when it looked and could not see, and `null` is the absence of an observation. The
         // card never collapses the two — defaulting an absent axis to `unknown` would report
         // blindness nobody claimed, which is the inverse of the failure the taxonomy prevents.
-        me.getReference('card-telltale').set(describeTelltale({throttle: record.throttle, wake: record.wake}));
+        const telltale                         = me.getReference('card-telltale'),
+              {ariaLabel, hidden, text, title} = describeTelltale({throttle: record.throttle, wake: record.wake});
+
+        telltale.set({hidden, text});
+
+        // The chip is a glyph-dense exception marker: the text says `wake off` and the operator's
+        // next question is "and the throttle?". `title` answers it on hover without a drill-in, and
+        // `aria-label` is the only way a screen-reader user gets the chip at all. Cleared to null when
+        // hidden — a stale label on an invisible node is a claim about an agent that is now fine.
+        telltale.changeVdomRootKey('aria-label', ariaLabel);
+        telltale.changeVdomRootKey('title', title);
         me.getReference('source-roster').health    = sources.roster;
         me.getReference('source-repo-status').health = sources.repoStatus;
         me.getReference('source-runtime').health   = runtime;

--- a/apps/agentos/view/fleet/AgentCard.mjs
+++ b/apps/agentos/view/fleet/AgentCard.mjs
@@ -8,6 +8,7 @@ import StateDot                from './StateDot.mjs';
 import {normalizeFleetSources} from './sourceHealth.mjs';
 
 import {describeNameProvenance, resolveNameSlot} from './nameSlot.mjs';
+import {describeTelltale}                        from './telltale.mjs';
 
 /**
  * The resident card: the cockpit's atom. Composes the class-based fleet primitives (FamilyRail +
@@ -162,6 +163,15 @@ class AgentCard extends Container {
                     flex     : 'none',
                     hidden   : true,
                     reference: 'card-lane-count'
+                }, {
+                    // The S2 telltale: ONE compound chip for both axes, hidden while nominal. The
+                    // density contract buys card pixels with exceptions, so two simultaneous
+                    // exceptions must not cost two chips — the full two-axis readout lives in detail.
+                    ntype    : 'component',
+                    cls      : ['fm-card-telltale'],
+                    flex     : 'none',
+                    hidden   : true,
+                    reference: 'card-telltale'
                 }]
             }, {
                 ntype    : 'container',
@@ -331,6 +341,12 @@ class AgentCard extends Container {
             hidden: laneCount === null,
             text  : laneCount === null ? '' : `${laneCount} ${laneCount === 1 ? 'lane' : 'lanes'}`
         });
+
+        // The record's axes are passed WHOLE to the describer: `unknown` is a state the producer
+        // emits when it looked and could not see, and `null` is the absence of an observation. The
+        // card never collapses the two — defaulting an absent axis to `unknown` would report
+        // blindness nobody claimed, which is the inverse of the failure the taxonomy prevents.
+        me.getReference('card-telltale').set(describeTelltale({throttle: record.throttle, wake: record.wake}));
         me.getReference('source-roster').health    = sources.roster;
         me.getReference('source-repo-status').health = sources.repoStatus;
         me.getReference('source-runtime').health   = runtime;

--- a/apps/agentos/view/fleet/AgentDetail.mjs
+++ b/apps/agentos/view/fleet/AgentDetail.mjs
@@ -4,6 +4,7 @@ import Image                                          from '../../../../src/comp
 import MailboxPane                                    from './MailboxPane.mjs';
 import StateDot                                       from './StateDot.mjs';
 import TabContainer                                   from '../../../../src/tab/Container.mjs';
+import {describeTelltaleReadout}                      from './telltale.mjs';
 import {classifyPaneFreshness, describePaneFreshness} from './agentFreshness.mjs';
 import {normalizeFleetSources}                        from './sourceHealth.mjs';
 
@@ -201,6 +202,16 @@ class AgentDetail extends Container {
                     ntype    : 'component',
                     cls      : ['fm-detail-participation'],
                     reference: 'detail-participation'
+                }, {
+                    // The FULL two-axis telltale readout. The card is exception-based — nominal earns
+                    // zero pixels there, because 20 cards cannot spend a line each on "fine". This is
+                    // ONE resident, so both axes state themselves unconditionally: an operator who
+                    // drilled in cannot otherwise tell "wake is on" from "nobody looked at wake".
+                    // Lives in the identity block rather than a fifth pane — the four SSOT panes are
+                    // content surfaces with freshness TTLs, and this is resident state.
+                    ntype    : 'component',
+                    cls      : ['fm-detail-telltale'],
+                    reference: 'detail-telltale'
                 }]
             }]
         }, {
@@ -458,6 +469,28 @@ class AgentDetail extends Container {
         me.getReference('detail-participation').set({
             hidden: participation === null,
             text  : participation === null ? '' : participation.replace(/_/g, ' ')
+        });
+
+        // The full two-axis readout: BOTH axes, always — the opposite of the card's exception-based
+        // chip, and deliberately so. Three renderings for three different facts: a nominal axis says
+        // so (an operator who drilled in needs "wake: on" confirmed, not omitted), an observed
+        // `unknown` carries the producer's reason, and an axis nobody reported says "not reported"
+        // rather than borrowing 'unknown' — which would claim someone looked.
+        const readout = describeTelltaleReadout({throttle: record.throttle, wake: record.wake});
+
+        me.getReference('detail-telltale').set({
+            html: readout.map(({axis, reason, reported, state}) => {
+                if (!reported) {
+                    return `<span class="fm-detail-telltale-axis fm-detail-telltale-unreported">${axis}: not reported</span>`
+                }
+
+                // the reason is the producer's evidence for what it could not see; the card has no
+                // room for it, which is what makes a degraded chip a prompt to drill in rather than
+                // a dead end
+                const detail = reason ? ` <span class="fm-detail-telltale-reason">— ${reason}</span>` : '';
+
+                return `<span class="fm-detail-telltale-axis fm-detail-telltale-${state}">${axis}: ${state}</span>${detail}`
+            }).join('')
         });
 
         me.getReference('detail-avatar').set({

--- a/apps/agentos/view/fleet/AgentDetail.mjs
+++ b/apps/agentos/view/fleet/AgentDetail.mjs
@@ -478,20 +478,31 @@ class AgentDetail extends Container {
         // rather than borrowing 'unknown' — which would claim someone looked.
         const readout = describeTelltaleReadout({throttle: record.throttle, wake: record.wake});
 
-        me.getReference('detail-telltale').set({
-            html: readout.map(({axis, reason, reported, state}) => {
-                if (!reported) {
-                    return `<span class="fm-detail-telltale-axis fm-detail-telltale-unreported">${axis}: not reported</span>`
-                }
+        // Built as VDOM nodes carrying `text`, never an `html` string. `reason` is the PRODUCER's
+        // sentence — it crosses a process boundary before it reaches here — and Neo routes `html` to
+        // innerHTML (src/vdom/Helper.mjs), so interpolating it made a remote adapter's error message
+        // executable in the cockpit. A `text` node is inert by construction, which is the only version
+        // of this that cannot be got wrong again later: escaping is a thing you must remember, and a
+        // text node is a thing you cannot forget.
+        const telltale = me.getReference('detail-telltale');
 
-                // the reason is the producer's evidence for what it could not see; the card has no
-                // room for it, which is what makes a degraded chip a prompt to drill in rather than
-                // a dead end
-                const detail = reason ? ` <span class="fm-detail-telltale-reason">— ${reason}</span>` : '';
+        telltale.vdom.cn = readout.flatMap(({axis, reason, reported, state}) => {
+            if (!reported) {
+                return [{tag: 'span', cls: ['fm-detail-telltale-axis', 'fm-detail-telltale-unreported'], text: `${axis}: not reported`}]
+            }
 
-                return `<span class="fm-detail-telltale-axis fm-detail-telltale-${state}">${axis}: ${state}</span>${detail}`
-            }).join('')
+            const nodes = [{tag: 'span', cls: ['fm-detail-telltale-axis', `fm-detail-telltale-${state}`], text: `${axis}: ${state}`}];
+
+            // the reason is the producer's evidence for what it could not see; the card has no room
+            // for it, which is what makes a degraded chip a prompt to drill in rather than a dead end
+            if (reason) {
+                nodes.push({tag: 'span', cls: ['fm-detail-telltale-reason'], text: `— ${reason}`})
+            }
+
+            return nodes
         });
+
+        telltale.update();
 
         me.getReference('detail-avatar').set({
             alt: record.displayName ?? agentId,

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1303,7 +1303,14 @@ class FleetCockpit extends Container {
             // write; null stays eligible (open-set honesty for forks/custom residents)
             participationStatus: row.participationStatus ?? null,
             sources            : sessionHealth.sources,
-            state              : sessionHealth.state
+            state              : sessionHealth.state,
+            // The S2 telltale axes, passed through whole rather than re-derived: the assembler
+            // already stamps `{source, state, confidence, reason?}` per axis, and `unknown` there is
+            // a PRODUCED fact (null resolver, unreadable source, unwired producer). Re-deriving it
+            // here would make "we looked and cannot see" indistinguishable from "we never asked" —
+            // the DTO's own discipline, the same reason `openLaneCount` is a passthrough.
+            throttle: row.throttle ?? null,
+            wake    : row.wake ?? null
         }
     }
 

--- a/apps/agentos/view/fleet/fleetCardFactory.mjs
+++ b/apps/agentos/view/fleet/fleetCardFactory.mjs
@@ -62,7 +62,14 @@ export function toAgentCardDescriptor(row = {}) {
                 laneLine     : row.laneLine ?? null,
                 openLaneCount: row.openLaneCount ?? null,
                 sources      : sessionHealth.sources,
-                state        : sessionHealth.state
+                state        : sessionHealth.state,
+                // Both telltale axes travel as the WHOLE observation, exactly as the Store-backed
+                // cockpit path passes them. Dropping them here does not make a restored card render
+                // "unknown" — it makes it render NOTHING, because an absent axis is absence, so the
+                // restored card reads as nominal while the live card beside it chips `wake off`. The
+                // two ingress paths must not disagree about the same agent.
+                throttle: row.throttle ?? null,
+                wake    : row.wake ?? null
             }
         },
         policy  : {...AGENT_CARD_POLICY},

--- a/apps/agentos/view/fleet/telltale.mjs
+++ b/apps/agentos/view/fleet/telltale.mjs
@@ -1,0 +1,74 @@
+/**
+ * @summary The S2 telltale contract: two orthogonal observation axes, one compound chip.
+ *
+ * The incident this answers had BOTH failures at once — the wake daemon hand-disabled AND a session
+ * rate limit — and neither was visible in the cockpit. That is why the axes are orthogonal and never
+ * collapse into one enum: a single state field can only report one of two simultaneous truths, and
+ * the operator needed both.
+ *
+ * Three values, three different facts, and the whole contract is keeping them apart:
+ *
+ * - **nominal** (`wake: on` · `throttle: none`) earns ZERO card pixels — the density contract's rule.
+ * - **`unknown` is an OBSERVATION, not a default**: the producer looked and could not see. It is
+ *   non-nominal and earns a chip, because "we cannot see this agent's wake state" is a fact the
+ *   operator must be told, and rendering it as healthy is the failure mode the whole taxonomy exists
+ *   to prevent.
+ * - **`null` is the absence of an observation** — the roster row carried no axis at all. Not a state,
+ *   nothing to report, no chip. Same tri-state honesty as `openLaneCount`: un-stamped renders nothing
+ *   rather than a fabricated zero.
+ *
+ * The distinction between the last two is the reason this module exists rather than a `?? 'unknown'`
+ * at the call site: defaulting an absent axis to `unknown` would manufacture an observation nobody
+ * made, and the card would report blindness the producer never claimed.
+ */
+
+/**
+ * @summary The nominal value per axis — the only states that earn no pixels.
+ * @type {Object}
+ */
+export const TELLTALE_NOMINAL = Object.freeze({
+    throttle: 'none',
+    wake    : 'on'
+});
+
+/**
+ * @summary Reads one axis' observed state, or `null` when the row carried no observation.
+ * @param {Object|null} axis The record's `{source, state, confidence, reason?}` observation.
+ * @returns {String|null}
+ * @private
+ */
+function observedState(axis) {
+    const state = axis?.state;
+
+    return typeof state === 'string' && state.length ? state : null
+}
+
+/**
+ * @summary Describes the compound telltale chip for one record's two axes.
+ *
+ * Exactly ONE chip regardless of how many axes are non-nominal — the card's density contract buys
+ * pixels with exceptions, so two exceptions must not cost two chips. The full two-axis readout
+ * belongs in the detail view, where there is room to say more than a chip can.
+ *
+ * @param {Object} options={}
+ * @param {Object|null} [options.throttle] The record's throttle observation.
+ * @param {Object|null} [options.wake] The record's wake observation.
+ * @returns {{hidden: Boolean, text: String}} `hidden` when nothing is worth reporting.
+ */
+export function describeTelltale({throttle = null, wake = null} = {}) {
+    const
+        wakeState     = observedState(wake),
+        throttleState = observedState(throttle),
+        // An axis is reportable only when it was OBSERVED and the observation is not nominal. The two
+        // guards are separate on purpose: `null` short-circuits because there is no observation to
+        // judge, while a present-but-nominal state is judged and found unremarkable.
+        reportable    = [
+            wakeState !== null && wakeState !== TELLTALE_NOMINAL.wake ? `wake ${wakeState}` : null,
+            throttleState !== null && throttleState !== TELLTALE_NOMINAL.throttle ? throttleState : null
+        ].filter(Boolean);
+
+    return {
+        hidden: reportable.length === 0,
+        text  : reportable.join(' · ')
+    }
+}

--- a/apps/agentos/view/fleet/telltale.mjs
+++ b/apps/agentos/view/fleet/telltale.mjs
@@ -9,17 +9,27 @@
  * Three values, three different facts, and the whole contract is keeping them apart:
  *
  * - **nominal** (`wake: on` · `throttle: none`) earns ZERO card pixels — the density contract's rule.
- * - **`unknown` is an OBSERVATION, not a default**: the producer looked and could not see. It is
- *   non-nominal and earns a chip, because "we cannot see this agent's wake state" is a fact the
- *   operator must be told, and rendering it as healthy is the failure mode the whole taxonomy exists
- *   to prevent.
+ * - **`unknown` is an OBSERVATION, not a default**: the producer looked and could not see. It is a
+ *   fact the operator must be told and is rendered verbatim — **in the DETAIL**. It is card-SILENT.
  * - **`null` is the absence of an observation** — the roster row carried no axis at all. Not a state,
- *   nothing to report, no chip. Same tri-state honesty as `openLaneCount`: un-stamped renders nothing
- *   rather than a fabricated zero.
+ *   nothing to report. Same tri-state honesty as `openLaneCount`: un-stamped renders nothing rather
+ *   than a fabricated zero.
  *
  * The distinction between the last two is the reason this module exists rather than a `?? 'unknown'`
  * at the call site: defaulting an absent axis to `unknown` would manufacture an observation nobody
- * made, and the card would report blindness the producer never claimed.
+ * made, and the detail would report blindness the producer never claimed.
+ *
+ * **Why `unknown` is card-silent:** a chip on `unknown` inverts the very density contract the chip
+ * exists to serve. The throttle adapter ships a CONTRACT and a SEAM — it documents that no trustworthy
+ * throttle truth source exists in the platform yet — so with no reader injected it honestly answers
+ * `unknown` for EVERY row. Measured against the default adapter across three agents: three `unknown`s,
+ * three chips, permanently. **A producer having landed is not the same as a producer being able to
+ * see.** The honest-unknown rule is satisfied by the detail readout, which states every axis
+ * unconditionally and has room for the producer's reason.
+ *
+ * The card therefore chips on an explicitly ENUMERATED deviation ({@link TELLTALE_CARD_DEVIANT}), not
+ * on "not nominal". The difference is the whole point: "not nominal" silently promotes every future
+ * state — and every state a producer cannot resolve — into a fleet-wide chip.
  */
 
 /**
@@ -29,6 +39,20 @@
 export const TELLTALE_NOMINAL = Object.freeze({
     throttle: 'none',
     wake    : 'on'
+});
+
+/**
+ * @summary The states that earn card pixels — an OBSERVED deviation the operator can act on.
+ *
+ * Enumerated rather than derived as "everything but nominal", because the two are only equivalent in
+ * a world where every axis has a working truth source. `unknown` is a real observation and belongs in
+ * the detail; on the card it would mean every agent chips until a throttle producer can see, which is
+ * the density inversion the exception-based rule exists to prevent.
+ * @type {Object}
+ */
+export const TELLTALE_CARD_DEVIANT = Object.freeze({
+    throttle: Object.freeze(['overage', 'rate-limited']),
+    wake    : Object.freeze(['off', 'suppressed'])
 });
 
 /**
@@ -85,9 +109,13 @@ export function describeTelltaleReadout({throttle = null, wake = null} = {}) {
 /**
  * @summary Describes the compound telltale chip for one record's two axes.
  *
- * Exactly ONE chip regardless of how many axes are non-nominal — the card's density contract buys
- * pixels with exceptions, so two exceptions must not cost two chips. The full two-axis readout
- * belongs in the detail view, where there is room to say more than a chip can.
+ * Exactly ONE chip regardless of how many axes deviate — the card's density contract buys pixels with
+ * exceptions, so two exceptions must not cost two chips. The full two-axis readout belongs in the
+ * detail view, where there is room to say more than a chip can.
+ *
+ * Chips on an ENUMERATED deviation only ({@link TELLTALE_CARD_DEVIANT}). `unknown` and `null` are both
+ * card-silent — for different reasons the detail keeps apart, and neither is a deviation the operator
+ * can act on from a roster.
  *
  * @param {Object} options={}
  * @param {Object|null} [options.throttle] The record's throttle observation.
@@ -98,12 +126,13 @@ export function describeTelltale({throttle = null, wake = null} = {}) {
     const
         wakeState     = observedState(wake),
         throttleState = observedState(throttle),
-        // An axis is reportable only when it was OBSERVED and the observation is not nominal. The two
-        // guards are separate on purpose: `null` short-circuits because there is no observation to
-        // judge, while a present-but-nominal state is judged and found unremarkable.
+        // Membership, not negation. `state !== NOMINAL` reads as the same rule and is not: it chips on
+        // `unknown`, on any out-of-contract producer value, and on every state added later — each of
+        // which lands on every card at once. An enumerated set fails silent on the card and loud in
+        // the detail, which is the right way round for a surface whose budget is pixels.
         reportable    = [
-            wakeState !== null && wakeState !== TELLTALE_NOMINAL.wake ? `wake ${wakeState}` : null,
-            throttleState !== null && throttleState !== TELLTALE_NOMINAL.throttle ? throttleState : null
+            TELLTALE_CARD_DEVIANT.wake.includes(wakeState) ? `wake ${wakeState}` : null,
+            TELLTALE_CARD_DEVIANT.throttle.includes(throttleState) ? throttleState : null
         ].filter(Boolean);
 
     return {

--- a/apps/agentos/view/fleet/telltale.mjs
+++ b/apps/agentos/view/fleet/telltale.mjs
@@ -44,6 +44,45 @@ function observedState(axis) {
 }
 
 /**
+ * @summary Describes the FULL two-axis readout for the detail view.
+ *
+ * The card and the detail answer different questions, which is why this is not the chip with more
+ * words. The card is **exception-based** — nominal earns zero pixels, because a roster of 20 cards
+ * cannot spend one line each on "fine". The detail is showing ONE resident, so it states both axes
+ * unconditionally: an operator who drilled in is asking "what is this agent's wake and throttle
+ * state", and answering only the broken half leaves them unable to tell "wake is on" from "nobody
+ * looked at wake".
+ *
+ * `reason` travels here and nowhere else. It is the producer's evidence — why it could not see — and
+ * the chip has no room for it, so a degraded axis on the card is a prompt to drill in rather than a
+ * dead end.
+ *
+ * @param {Object} options={}
+ * @param {Object|null} [options.throttle] The record's throttle observation.
+ * @param {Object|null} [options.wake] The record's wake observation.
+ * @returns {Object[]} `[{axis, state, nominal, reported, reason}]` — always both axes, wake first.
+ */
+export function describeTelltaleReadout({throttle = null, wake = null} = {}) {
+    return [
+        ['wake', wake, TELLTALE_NOMINAL.wake],
+        ['throttle', throttle, TELLTALE_NOMINAL.throttle]
+    ].map(([axis, observation, nominalState]) => {
+        const state = observedState(observation);
+
+        return {
+            axis,
+            // `reported: false` is NOT a state — it says no observation exists for this axis, which
+            // is why the view must render it as its own thing rather than borrowing 'unknown'. The
+            // producer's 'unknown' means it looked; this means nobody did.
+            reported: state !== null,
+            state,
+            nominal : state !== null && state === nominalState,
+            reason  : observation?.reason ?? null
+        }
+    })
+}
+
+/**
  * @summary Describes the compound telltale chip for one record's two axes.
  *
  * Exactly ONE chip regardless of how many axes are non-nominal — the card's density contract buys

--- a/apps/agentos/view/fleet/telltale.mjs
+++ b/apps/agentos/view/fleet/telltale.mjs
@@ -117,10 +117,21 @@ export function describeTelltaleReadout({throttle = null, wake = null} = {}) {
  * card-silent — for different reasons the detail keeps apart, and neither is a deviation the operator
  * can act on from a roster.
  *
+ * **Every deviation names its axis**, in a fixed wake-before-throttle order. A bare `rate-limited`
+ * saves six characters and costs the reader the question the chip exists to answer — and with two
+ * axes drawing from disjoint vocabularies, an unlabelled state is only decodable by someone who has
+ * memorised which words belong to which axis.
+ *
+ * `ariaLabel` names the deviations for a screen reader; `title` carries the FULL two-axis readout, so
+ * the hover answers what the chip had no room for without a drill-in. Both are the Contract Ledger's
+ * a11y row, and both are derived here rather than in the view: they are statements about the
+ * taxonomy, and a second renderer must not be able to word them differently.
+ *
  * @param {Object} options={}
  * @param {Object|null} [options.throttle] The record's throttle observation.
  * @param {Object|null} [options.wake] The record's wake observation.
- * @returns {{hidden: Boolean, text: String}} `hidden` when nothing is worth reporting.
+ * @returns {{ariaLabel: String|null, hidden: Boolean, text: String, title: String|null}} `hidden`
+ *     when nothing is worth reporting; `ariaLabel`/`title` are `null` exactly when hidden.
  */
 export function describeTelltale({throttle = null, wake = null} = {}) {
     const
@@ -132,11 +143,18 @@ export function describeTelltale({throttle = null, wake = null} = {}) {
         // the detail, which is the right way round for a surface whose budget is pixels.
         reportable    = [
             TELLTALE_CARD_DEVIANT.wake.includes(wakeState) ? `wake ${wakeState}` : null,
-            TELLTALE_CARD_DEVIANT.throttle.includes(throttleState) ? throttleState : null
-        ].filter(Boolean);
+            TELLTALE_CARD_DEVIANT.throttle.includes(throttleState) ? `throttle ${throttleState}` : null
+        ].filter(Boolean),
+        hidden        = reportable.length === 0;
 
     return {
-        hidden: reportable.length === 0,
-        text  : reportable.join(' · ')
+        ariaLabel: hidden ? null : `Telltale: ${reportable.join(', ')}`,
+        hidden,
+        text     : reportable.join(' · '),
+        // The full readout the chip could not fit — both axes, including the nominal and the blind
+        // ones, worded exactly as the detail words them.
+        title    : hidden ? null : describeTelltaleReadout({throttle, wake})
+            .map(({axis, reported, state}) => `${axis}: ${reported ? state : 'not reported'}`)
+            .join(' · ')
     }
 }

--- a/resources/scss/src/apps/agentos/fleet/AgentCard.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentCard.scss
@@ -114,6 +114,23 @@
 
     /* the open-lane count badge — the honest total the single lane line cannot carry; only
        rendered on a reported count, so an unknown never poses as zero */
+    // The S2 telltale chip. Exception-based: hidden while nominal, so any pixels here mean a
+    // deviation on at least one axis. Colored with --fm-state-limited because BOTH themes already
+    // define it and the design mock uses it for rate-limited — inventing a token would mean styling
+    // one theme and guessing the other.
+    .fm-card-telltale {
+        flex         : none;
+        font-family  : var(--fm-font-mono);
+        font-size    : 10px;
+        line-height  : 1;
+        color        : var(--fm-state-limited);
+        background   : color-mix(in srgb, var(--fm-state-limited) 12%, transparent);
+        border       : 1px solid color-mix(in srgb, var(--fm-state-limited) 30%, transparent);
+        border-radius: 999px;
+        padding      : 2px 7px;
+        white-space  : nowrap;
+    }
+
     .fm-card-lane-count {
         flex         : none;
         font-family  : var(--fm-font-mono);

--- a/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
@@ -272,3 +272,44 @@
         }
     }
 }
+
+.fm-agent-detail {
+    // The FULL two-axis readout — both axes always, unlike the card's exception chip.
+    .fm-detail-telltale {
+        display  : flex;
+        flex-wrap: wrap;
+        gap      : 6px 10px;
+        font-family: var(--fm-font-mono);
+        font-size  : 11px;
+        line-height: 1.4;
+    }
+
+    .fm-detail-telltale-axis {
+        color: var(--fm-ink-dim);
+    }
+
+    // A deviating axis earns the state color; nominal stays dim, because in the detail "wake: on" is
+    // information the operator asked for, not an alert.
+    .fm-detail-telltale-off,
+    .fm-detail-telltale-suppressed,
+    .fm-detail-telltale-overage,
+    .fm-detail-telltale-rate-limited {
+        color: var(--fm-state-limited);
+    }
+
+    // "we looked and could not see" reads as absent-information, never as an alert and never as health
+    .fm-detail-telltale-unknown {
+        color: var(--fm-ink-faint);
+    }
+
+    // "nobody reported this axis" — the faintest thing on the surface: it is the absence of an
+    // observation, which is less than an unknown one.
+    .fm-detail-telltale-unreported {
+        color     : var(--fm-ink-faint);
+        font-style: italic;
+    }
+
+    .fm-detail-telltale-reason {
+        color: var(--fm-ink-faint);
+    }
+}

--- a/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs
@@ -87,6 +87,52 @@ test.describe('Fleet cockpit AgentCard — resident card rendering its roster re
         card.destroy()
     });
 
+    test('the chip names every deviating axis and carries the ledger\'s a11y pair — asserted on the RENDERED node', () => {
+        const card = createCard({
+            agentId : 'vega',
+            state   : 'ok',
+            wake    : {source: 'fleet:wakeState', state: 'off', confidence: 'observed'},
+            throttle: {source: 'fleet:throttleState', state: 'rate-limited', confidence: 'observed'}
+        });
+
+        const chip = card.down({reference: 'card-telltale'});
+
+        // ONE chip for two simultaneous exceptions — the incident this answers had both at once, and
+        // the density contract buys pixels with exceptions, so two must not cost two chips
+        expect(chip.hidden).toBe(false);
+        // every deviation names its AXIS: a bare `rate-limited` saves six characters and costs the
+        // reader the question the chip exists to answer. Deterministic wake-before-throttle.
+        expect(chip.text).toBe('wake off · throttle rate-limited');
+
+        // a screen-reader user gets the chip ONLY through aria-label; the hover answers the axis the
+        // chip had no room for, without a drill-in
+        expect(chip.vdom['aria-label']).toBe('Telltale: wake off, throttle rate-limited');
+        expect(chip.vdom.title).toBe('wake: off · throttle: rate-limited');
+
+        card.destroy()
+    });
+
+    test('a recovered agent clears the chip AND its labels — no stale claim on an invisible node', () => {
+        const card = createCard({
+            agentId: 'vega', state: 'ok',
+            wake   : {source: 'fleet:wakeState', state: 'off', confidence: 'observed'}
+        });
+
+        expect(card.down({reference: 'card-telltale'}).hidden).toBe(false);
+
+        applySet(card, {wake: {source: 'fleet:wakeState', state: 'on', confidence: 'observed'}});
+
+        const chip = card.down({reference: 'card-telltale'});
+
+        // hiding the node is not enough: a stale aria-label survives on a hidden element and is still
+        // read out, so the screen reader would report a wake failure on an agent that is now fine
+        expect(chip.hidden).toBe(true);
+        expect(chip.vdom['aria-label']).toBeFalsy();
+        expect(chip.vdom.title).toBeFalsy();
+
+        card.destroy()
+    });
+
     test('source markers update in place; absent runtime fails the state dot closed and never pulses', () => {
         const card     = createCard({agentId: 'vega', state: 'ok'}),
               beforeId = card.id,

--- a/test/playwright/unit/apps/agentos/view/fleet/agentDetail.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/agentDetail.spec.mjs
@@ -291,6 +291,65 @@ test.describe('Fleet cockpit AgentDetail — drill-in inspector (#14608)', () =>
         detail.destroy()
     });
 
+    test('a hostile producer reason reaches the readout as TEXT, never as markup (@neo-gpt\'s exact probe)', () => {
+        // The describer was never wrong: it returns the producer's reason as DATA, exactly as asked.
+        // The view then interpolated that data into an `html` string, and Neo routes `html` to
+        // innerHTML — so a remote adapter's sentence about its own failure became executable in the
+        // cockpit. telltale.spec.mjs cannot see this: it asks what the describer RETURNS, and the
+        // defect lives in what the view DOES with it. That gap is why the probe belongs here.
+        //
+        // The reason is the one string on this surface nobody in this repo writes.
+        const hostile = '<img src=x onerror=globalThis.PWNED=1>',
+              detail  = createDetail({
+                  agentId : 'vega',
+                  state   : 'ok',
+                  wake    : {state: 'on'},
+                  throttle: {source: 'fleet:throttle', state: 'unknown', confidence: 'none', reason: hostile}
+              });
+
+        const telltale = detail.down({reference: 'detail-telltale'});
+
+        // the sink itself: ANY html on this node re-opens the hole regardless of today's content
+        expect(telltale.html).toBeFalsy();
+
+        const nodes = telltale.vdom.cn ?? [],
+              texts = nodes.map(node => node.text ?? '');
+
+        // carried, inert, and still READABLE — an operator needs the producer's evidence, so escaping
+        // it out of existence would be its own defect
+        expect(texts.some(text => text.includes(hostile))).toBe(true);
+
+        // …and nowhere as markup, on any node
+        nodes.forEach(node => {
+            expect(node.html).toBeFalsy();
+            (node.cls ?? []).forEach(cls => expect(cls).not.toContain('<'))
+        });
+
+        expect(globalThis.PWNED).toBeUndefined();
+
+        delete globalThis.PWNED;
+        detail.destroy()
+    });
+
+    test('an honest reason still renders alongside both axes — the guard must not eat the evidence', () => {
+        const detail = createDetail({
+            agentId : 'vega',
+            state   : 'ok',
+            wake    : {state: 'on'},
+            throttle: {source: 'fleet:throttle', state: 'unknown', confidence: 'none', reason: 'no throttle reader injected'}
+        });
+
+        const texts = (detail.down({reference: 'detail-telltale'}).vdom.cn ?? []).map(node => node.text ?? '');
+
+        // both axes always, and the reason with them: the detail is the opposite of the card's
+        // exception-based chip
+        expect(texts.some(text => text.includes('no throttle reader injected'))).toBe(true);
+        expect(texts.some(text => text.includes('throttle: unknown'))).toBe(true);
+        expect(texts.some(text => text.includes('wake: on'))).toBe(true);
+
+        detail.destroy()
+    });
+
     test('§2.2.1 wall-clock aging: a later `now` re-classifies fresh → lost in place (time-reactive, not just re-seat)', () => {
         const detail = createDetail({agentId: 'vega', state: 'ok'}, {
             paneLedgers: {lane: {observedAt: '2026-07-11T23:59:50.000Z', freshnessTtl: 30_000}} // 10s before NOW → fresh

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCardFactory.spec.mjs
@@ -91,6 +91,34 @@ test.describe('fleetCardFactory — cockpit DTO → dock card descriptors (#1479
         expect(card.metadata.githubUsername).toBeNull()
     })
 
+    test('both telltale axes survive the restoration blueprint — a restored card cannot disagree with a live one', () => {
+        // The dock-restore path is the card's OTHER ingress. Dropping the axes here does not make a
+        // restored card render `unknown` — it makes it render NOTHING, because an absent axis is
+        // absence by contract. So the restored card reads as nominal while the live card beside it
+        // chips `wake off`, for the same agent, from the same DTO. The Store-backed cockpit path
+        // already passes both through; this one silently did not.
+        const wake     = {source: 'fleet:wakeState', state: 'off', confidence: 'observed'},
+              throttle = {source: 'fleet:throttleState', state: 'unknown', confidence: 'none', reason: 'no reader'},
+              data     = toAgentCardDescriptor({id: 'vega', throttle, wake}).blueprint.record
+
+        // the WHOLE observation travels — `confidence`/`reason` are the producer's evidence it looked
+        expect(data.wake).toEqual(wake)
+        expect(data.throttle).toEqual(throttle)
+
+        // and it stays serializable — the blueprint crosses a JSON boundary
+        expect(JSON.parse(JSON.stringify(data)).wake).toEqual(wake)
+    })
+
+    test('an axis the DTO never carried restores as null — absence, never a manufactured unknown', () => {
+        const data = toAgentCardDescriptor({id: 'ghost'}).blueprint.record
+
+        // null, not undefined: `undefined` vanishes through JSON and the distinction the taxonomy is
+        // built on (nobody looked vs looked-and-blind) would be decided by serialization
+        expect(data.wake).toBeNull()
+        expect(data.throttle).toBeNull()
+        expect(Object.hasOwn(JSON.parse(JSON.stringify(data)), 'wake')).toBe(true)
+    })
+
     test('maps the session state through only when runtime source truth is usable', () => {
         const sources   = {runtime: {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}}
         const lifecycle = {source: 'fleet:runtimeStatus', state: 'running', confidence: 'observed'}

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -293,11 +293,39 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             // the authoritative participation fact: absent on the row → honest null, never guessed
             participationStatus: null,
             sources            : liveSources(),
-            state              : 'ok'
+            state              : 'ok',
+            // the S2 telltale axes: absent on this row → honest null, never a synthesized 'unknown'.
+            // The view must not manufacture the taxonomy's unknown — that value means the PRODUCER
+            // looked and could not see, which is a different fact from "this row carried no axis".
+            throttle: null,
+            wake    : null
         });
 
         // laneLine is OMITTED, never nulled — a roster merge must not wipe what the activity producer writes
         expect(Object.hasOwn(mapped, 'laneLine')).toBe(false)
+    });
+
+    test('mapRosterRow passes the S2 axes through WHOLE — the view never re-derives a produced fact', () => {
+        const
+            wake     = {source: 'fleet:wakeState', state: 'suppressed', confidence: 'observed'},
+            throttle = {source: 'fleet:throttleState', state: 'rate-limited', confidence: 'observed', reason: 'session cap'},
+            mapped   = FleetCockpit.prototype.mapRosterRow({
+                id       : 'neo-gpt',
+                lifecycle: {source: 'fleet:runtimeStatus', state: 'running', confidence: 'observed'},
+                sources  : liveSources(),
+                throttle,
+                wake
+            });
+
+        // Whole objects, not re-derived states: `confidence` and `reason` are the producer's evidence
+        // that it actually looked, and a view that rebuilt {state} alone would strip exactly the
+        // fields that distinguish an observed fact from a guess.
+        expect(mapped.wake).toEqual(wake);
+        expect(mapped.throttle).toEqual(throttle);
+
+        // The incident this answers had BOTH at once — orthogonal axes, never collapsed to one enum.
+        expect(mapped.wake.state).toBe('suppressed');
+        expect(mapped.throttle.state).toBe('rate-limited')
     });
 
     test('mapRosterRow state vocabulary — running is healthy only behind wired runtime provenance', () => {
@@ -382,7 +410,9 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
             openLaneCount      : null,
             participationStatus: null,
             sources            : liveSources(),
-            state              : 'ok'
+            state              : 'ok',
+            throttle           : null,
+            wake               : null
         }]);
 
         // a resident ABSENT from the authoritative snapshot is removed — define → remove → no ghost card

--- a/test/playwright/unit/apps/agentos/view/fleet/telltale.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/telltale.spec.mjs
@@ -23,7 +23,7 @@ import {describeTelltale, describeTelltaleReadout, TELLTALE_CARD_DEVIANT, TELLTA
 test.describe('AgentOS.view.fleet.telltale — two orthogonal axes, one compound chip', () => {
     test('nominal on both axes earns ZERO card pixels', () => {
         expect(describeTelltale({wake: {state: 'on'}, throttle: {state: 'none'}}))
-            .toEqual({hidden: true, text: ''})
+            .toEqual({ariaLabel: null, hidden: true, text: '', title: null})
     });
 
     test('the nominal vocabulary is the producers\', not this module\'s invention', () => {
@@ -42,10 +42,10 @@ test.describe('AgentOS.view.fleet.telltale — two orthogonal axes, one compound
         // Measured against the default adapter: 3 agents, 3 `unknown`s, 3 chips. "The producers
         // landed" was true and did not imply the producers can see.
         expect(describeTelltale({wake: {state: 'unknown'}, throttle: {state: 'none'}}))
-            .toEqual({hidden: true, text: ''});
+            .toEqual({ariaLabel: null, hidden: true, text: '', title: null});
 
         expect(describeTelltale({wake: {state: 'on'}, throttle: {state: 'unknown'}}))
-            .toEqual({hidden: true, text: ''});
+            .toEqual({ariaLabel: null, hidden: true, text: '', title: null});
 
         // …and the fact still reaches the operator, unhidden, where there is room for it
         expect(describeTelltaleReadout({wake: {state: 'on'}, throttle: {state: 'unknown', reason: 'no reader'}}))
@@ -60,30 +60,45 @@ test.describe('AgentOS.view.fleet.telltale — two orthogonal axes, one compound
         expect(TELLTALE_CARD_DEVIANT).toEqual({throttle: ['overage', 'rate-limited'], wake: ['off', 'suppressed']});
 
         // an out-of-contract answer earns no card pixels — but is still stated verbatim in the detail
-        expect(describeTelltale({wake: {state: 'wat'}, throttle: {state: 'none'}})).toEqual({hidden: true, text: ''});
+        expect(describeTelltale({wake: {state: 'wat'}, throttle: {state: 'none'}})).toEqual({ariaLabel: null, hidden: true, text: '', title: null});
         expect(describeTelltaleReadout({wake: {state: 'wat'}, throttle: null})[0].state).toBe('wat')
     });
 
     test('`null` is the ABSENCE of an observation — no chip, and no manufactured unknown', () => {
         // The row carried no axis. Defaulting to 'unknown' here would report blindness the producer
         // never claimed — an invented observation, which is the inverse defect of hiding a real one.
-        expect(describeTelltale({wake: null, throttle: null})).toEqual({hidden: true, text: ''});
-        expect(describeTelltale({})).toEqual({hidden: true, text: ''});
-        expect(describeTelltale()).toEqual({hidden: true, text: ''})
+        expect(describeTelltale({wake: null, throttle: null})).toEqual({ariaLabel: null, hidden: true, text: '', title: null});
+        expect(describeTelltale({})).toEqual({ariaLabel: null, hidden: true, text: '', title: null});
+        expect(describeTelltale()).toEqual({ariaLabel: null, hidden: true, text: '', title: null})
     });
 
     test('a null axis alongside a non-nominal one reports ONLY what was observed', () => {
         // The un-stamped axis contributes nothing — it is not 'unknown', it is absent.
         expect(describeTelltale({wake: {state: 'suppressed'}, throttle: null}))
-            .toEqual({hidden: false, text: 'wake suppressed'})
+            .toEqual({
+                ariaLabel: 'Telltale: wake suppressed',
+                hidden   : false,
+                text     : 'wake suppressed',
+                // the title states BOTH axes — including the one that reported nothing, which is a
+                // different fact from a nominal one and must not read as "throttle is fine"
+                title    : 'wake: suppressed · throttle: not reported'
+            })
     });
 
     test('BOTH axes non-nominal → exactly ONE compound chip — the incident this answers', () => {
         // The lived failure: wake daemon hand-disabled AND a session rate limit, at once, both
         // invisible. Two simultaneous exceptions must not cost two chips, and a single enum could
         // only ever have reported one of them.
+        // BOTH deviations name their axis. The first cut emitted a bare `rate-limited`: six characters
+        // saved, and the reader left to know which of two disjoint vocabularies the word came from —
+        // on the one surface that exists to be read at a glance.
         expect(describeTelltale({wake: {state: 'off'}, throttle: {state: 'rate-limited'}}))
-            .toEqual({hidden: false, text: 'wake off · rate-limited'})
+            .toEqual({
+                ariaLabel: 'Telltale: wake off, throttle rate-limited',
+                hidden   : false,
+                text     : 'wake off · throttle rate-limited',
+                title    : 'wake: off · throttle: rate-limited'
+            })
     });
 
     test('the full predicate matrix: every ACTIONABLE deviation chips, and every unactionable state does not', () => {
@@ -112,7 +127,7 @@ test.describe('AgentOS.view.fleet.telltale — two orthogonal axes, one compound
         // the detail readout; a chip that changed with confidence would make two different producers'
         // 'unknown' render differently for no operator-visible reason.
         expect(describeTelltale({wake: {state: 'on', confidence: 'none', reason: 'noisy'}}))
-            .toEqual({hidden: true, text: ''})
+            .toEqual({ariaLabel: null, hidden: true, text: '', title: null})
     })
 
     test('the DETAIL readout states BOTH axes — the opposite of the card, deliberately', () => {
@@ -146,9 +161,16 @@ test.describe('AgentOS.view.fleet.telltale — two orthogonal axes, one compound
 
         expect(throttle.reason).toBe('session cap reached 01:12Z');
 
-        // the chip carries the state only
-        expect(describeTelltale({throttle: {state: 'rate-limited', reason: 'session cap reached 01:12Z'}}).text)
-            .toBe('rate-limited')
+        // the chip carries the AXIS + state, and nothing the producer wrote
+        const chip = describeTelltale({throttle: {state: 'rate-limited', reason: 'session cap reached 01:12Z'}});
+
+        expect(chip.text).toBe('throttle rate-limited');
+
+        // the reason reaches NEITHER the chip text, its label, nor its hover: it is the producer's
+        // prose, it is unbounded, and on the card there is no room and no need for it
+        expect(chip.text).not.toContain('session cap');
+        expect(chip.ariaLabel).not.toContain('session cap');
+        expect(chip.title).not.toContain('session cap')
     });
 
     test('an observed `unknown` is reported and NOT nominal — blindness is not health', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/telltale.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/telltale.spec.mjs
@@ -10,7 +10,7 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 
-import {describeTelltale, describeTelltaleReadout, TELLTALE_NOMINAL} from '../../../../../../../apps/agentos/view/fleet/telltale.mjs';
+import {describeTelltale, describeTelltaleReadout, TELLTALE_CARD_DEVIANT, TELLTALE_NOMINAL} from '../../../../../../../apps/agentos/view/fleet/telltale.mjs';
 
 /**
  * @summary The S2 telltale contract.
@@ -32,14 +32,36 @@ test.describe('AgentOS.view.fleet.telltale — two orthogonal axes, one compound
         expect(TELLTALE_NOMINAL).toEqual({throttle: 'none', wake: 'on'})
     });
 
-    test('`unknown` is an OBSERVATION and earns a chip — never rendered as healthy', () => {
-        // The producer looked and could not see. That is a fact, and hiding it is the exact failure
-        // the taxonomy exists to prevent.
+    test('`unknown` is card-SILENT and detail-visible — the ledger\'s density resolution', () => {
+        // The producer looked and could not see. That is a fact the operator must be told — in the
+        // DETAIL. On the card it is silent, and this is the one rule that looks like a regression and
+        // is not: the throttle adapter ships a contract and a SEAM, with no truth source in the
+        // platform yet, so it honestly answers `unknown` for EVERY row. Chipping on it means every
+        // card chips forever, which inverts the density contract the chip exists to serve.
+        //
+        // Measured against the default adapter: 3 agents, 3 `unknown`s, 3 chips. "The producers
+        // landed" was true and did not imply the producers can see.
         expect(describeTelltale({wake: {state: 'unknown'}, throttle: {state: 'none'}}))
-            .toEqual({hidden: false, text: 'wake unknown'});
+            .toEqual({hidden: true, text: ''});
 
         expect(describeTelltale({wake: {state: 'on'}, throttle: {state: 'unknown'}}))
-            .toEqual({hidden: false, text: 'unknown'})
+            .toEqual({hidden: true, text: ''});
+
+        // …and the fact still reaches the operator, unhidden, where there is room for it
+        expect(describeTelltaleReadout({wake: {state: 'on'}, throttle: {state: 'unknown', reason: 'no reader'}}))
+            .toContainEqual({axis: 'throttle', state: 'unknown', nominal: false, reported: true, reason: 'no reader'})
+    });
+
+    test('the card chips on an ENUMERATED deviation, never on "not nominal"', () => {
+        // The two read identically today and diverge on every state added later: negation promotes any
+        // new or out-of-contract producer value straight onto every card at once, which is precisely
+        // how `unknown` got there. Silent on the card, loud in the detail, is the right way round for
+        // a surface whose budget is pixels.
+        expect(TELLTALE_CARD_DEVIANT).toEqual({throttle: ['overage', 'rate-limited'], wake: ['off', 'suppressed']});
+
+        // an out-of-contract answer earns no card pixels — but is still stated verbatim in the detail
+        expect(describeTelltale({wake: {state: 'wat'}, throttle: {state: 'none'}})).toEqual({hidden: true, text: ''});
+        expect(describeTelltaleReadout({wake: {state: 'wat'}, throttle: null})[0].state).toBe('wat')
     });
 
     test('`null` is the ABSENCE of an observation — no chip, and no manufactured unknown', () => {
@@ -64,14 +86,24 @@ test.describe('AgentOS.view.fleet.telltale — two orthogonal axes, one compound
             .toEqual({hidden: false, text: 'wake off · rate-limited'})
     });
 
-    test('every non-nominal state in each axis vocabulary is reportable', () => {
-        // A closed vocabulary is only honest if none of its members can go silently missing.
-        ['off', 'suppressed', 'unknown'].forEach(state => {
-            expect(describeTelltale({wake: {state}}).hidden, `wake ${state} must report`).toBe(false)
+    test('the full predicate matrix: every ACTIONABLE deviation chips, and every unactionable state does not', () => {
+        // A closed vocabulary is only honest if none of its ACTIONABLE members can go silently missing —
+        // and if the unactionable ones cannot silently flood. Both halves are asserted here, because
+        // the first half alone is what put `unknown` on every card in the fleet.
+        ['off', 'suppressed'].forEach(state => {
+            expect(describeTelltale({wake: {state}}).hidden, `wake ${state} must chip`).toBe(false)
         });
 
-        ['overage', 'rate-limited', 'unknown'].forEach(state => {
-            expect(describeTelltale({throttle: {state}}).hidden, `throttle ${state} must report`).toBe(false)
+        ['overage', 'rate-limited'].forEach(state => {
+            expect(describeTelltale({throttle: {state}}).hidden, `throttle ${state} must chip`).toBe(false)
+        });
+
+        // the other half of the matrix: nominal, blind and absent all cost zero pixels, for three
+        // different reasons the detail keeps apart
+        [{wake: {state: 'on'}}, {wake: {state: 'unknown'}}, {wake: null},
+         {throttle: {state: 'none'}}, {throttle: {state: 'unknown'}}, {throttle: null}
+        ].forEach(record => {
+            expect(describeTelltale(record).hidden, `${JSON.stringify(record)} must cost zero card pixels`).toBe(true)
         })
     });
 

--- a/test/playwright/unit/apps/agentos/view/fleet/telltale.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/telltale.spec.mjs
@@ -10,7 +10,7 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 
-import {describeTelltale, TELLTALE_NOMINAL} from '../../../../../../../apps/agentos/view/fleet/telltale.mjs';
+import {describeTelltale, describeTelltaleReadout, TELLTALE_NOMINAL} from '../../../../../../../apps/agentos/view/fleet/telltale.mjs';
 
 /**
  * @summary The S2 telltale contract.
@@ -81,5 +81,58 @@ test.describe('AgentOS.view.fleet.telltale — two orthogonal axes, one compound
         // 'unknown' render differently for no operator-visible reason.
         expect(describeTelltale({wake: {state: 'on', confidence: 'none', reason: 'noisy'}}))
             .toEqual({hidden: true, text: ''})
+    })
+
+    test('the DETAIL readout states BOTH axes — the opposite of the card, deliberately', () => {
+        // The card is exception-based: 20 cards cannot spend a line each on "fine". The detail shows
+        // ONE resident, so omitting a nominal axis leaves the operator unable to tell "wake is on"
+        // from "nobody looked at wake". Same data, opposite rule.
+        const readout = describeTelltaleReadout({wake: {state: 'on'}, throttle: {state: 'none'}});
+
+        expect(readout.map(row => [row.axis, row.state, row.nominal]))
+            .toEqual([['wake', 'on', true], ['throttle', 'none', true]]);
+
+        // and the card says nothing at all for that same record
+        expect(describeTelltale({wake: {state: 'on'}, throttle: {state: 'none'}}).hidden).toBe(true)
+    });
+
+    test('`reported: false` is not a state — an unobserved axis never borrows `unknown`', () => {
+        // 'unknown' means the producer LOOKED and could not see. An absent axis means nobody looked.
+        // Collapsing them makes the detail claim an observation that was never made.
+        const [wake] = describeTelltaleReadout({wake: null, throttle: {state: 'none'}});
+
+        expect(wake.reported).toBe(false);
+        expect(wake.state).toBeNull();
+        expect(wake.nominal).toBe(false)
+    });
+
+    test('the producer\'s reason travels to the detail — the chip has no room for it', () => {
+        // This is what makes a degraded chip a prompt to drill in rather than a dead end.
+        const [, throttle] = describeTelltaleReadout({
+            throttle: {state: 'rate-limited', reason: 'session cap reached 01:12Z'}
+        });
+
+        expect(throttle.reason).toBe('session cap reached 01:12Z');
+
+        // the chip carries the state only
+        expect(describeTelltale({throttle: {state: 'rate-limited', reason: 'session cap reached 01:12Z'}}).text)
+            .toBe('rate-limited')
+    });
+
+    test('an observed `unknown` is reported and NOT nominal — blindness is not health', () => {
+        const [wake] = describeTelltaleReadout({wake: {state: 'unknown', reason: 'daemon pid-file unreadable'}});
+
+        expect(wake.reported).toBe(true);
+        expect(wake.nominal).toBe(false);
+        expect(wake.reason).toBe('daemon pid-file unreadable')
+    });
+
+    test('the readout is ALWAYS both axes, wake first — a stable shape the view can render blind', () => {
+        [{}, {wake: {state: 'off'}}, {throttle: {state: 'overage'}}, {wake: {state: 'on'}, throttle: {state: 'none'}}]
+            .forEach(input => {
+                const readout = describeTelltaleReadout(input);
+                expect(readout).toHaveLength(2);
+                expect(readout.map(row => row.axis)).toEqual(['wake', 'throttle'])
+            })
     })
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/telltale.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/telltale.spec.mjs
@@ -1,0 +1,85 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'FleetTelltaleTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+import {describeTelltale, TELLTALE_NOMINAL} from '../../../../../../../apps/agentos/view/fleet/telltale.mjs';
+
+/**
+ * @summary The S2 telltale contract.
+ *
+ * The load-bearing distinction is `unknown` vs `null`, and it is the reason the module exists: the
+ * producer's `unknown` means it LOOKED and could not see — an observation the operator must be told —
+ * while `null` means the roster row carried no axis, which is the absence of an observation. Collapse
+ * them and the card either reports blindness nobody claimed, or renders a real blindness as healthy.
+ */
+test.describe('AgentOS.view.fleet.telltale — two orthogonal axes, one compound chip', () => {
+    test('nominal on both axes earns ZERO card pixels', () => {
+        expect(describeTelltale({wake: {state: 'on'}, throttle: {state: 'none'}}))
+            .toEqual({hidden: true, text: ''})
+    });
+
+    test('the nominal vocabulary is the producers\', not this module\'s invention', () => {
+        // If a producer's nominal value ever drifts, this fails here rather than silently rendering
+        // every healthy agent as an exception.
+        expect(TELLTALE_NOMINAL).toEqual({throttle: 'none', wake: 'on'})
+    });
+
+    test('`unknown` is an OBSERVATION and earns a chip — never rendered as healthy', () => {
+        // The producer looked and could not see. That is a fact, and hiding it is the exact failure
+        // the taxonomy exists to prevent.
+        expect(describeTelltale({wake: {state: 'unknown'}, throttle: {state: 'none'}}))
+            .toEqual({hidden: false, text: 'wake unknown'});
+
+        expect(describeTelltale({wake: {state: 'on'}, throttle: {state: 'unknown'}}))
+            .toEqual({hidden: false, text: 'unknown'})
+    });
+
+    test('`null` is the ABSENCE of an observation — no chip, and no manufactured unknown', () => {
+        // The row carried no axis. Defaulting to 'unknown' here would report blindness the producer
+        // never claimed — an invented observation, which is the inverse defect of hiding a real one.
+        expect(describeTelltale({wake: null, throttle: null})).toEqual({hidden: true, text: ''});
+        expect(describeTelltale({})).toEqual({hidden: true, text: ''});
+        expect(describeTelltale()).toEqual({hidden: true, text: ''})
+    });
+
+    test('a null axis alongside a non-nominal one reports ONLY what was observed', () => {
+        // The un-stamped axis contributes nothing — it is not 'unknown', it is absent.
+        expect(describeTelltale({wake: {state: 'suppressed'}, throttle: null}))
+            .toEqual({hidden: false, text: 'wake suppressed'})
+    });
+
+    test('BOTH axes non-nominal → exactly ONE compound chip — the incident this answers', () => {
+        // The lived failure: wake daemon hand-disabled AND a session rate limit, at once, both
+        // invisible. Two simultaneous exceptions must not cost two chips, and a single enum could
+        // only ever have reported one of them.
+        expect(describeTelltale({wake: {state: 'off'}, throttle: {state: 'rate-limited'}}))
+            .toEqual({hidden: false, text: 'wake off · rate-limited'})
+    });
+
+    test('every non-nominal state in each axis vocabulary is reportable', () => {
+        // A closed vocabulary is only honest if none of its members can go silently missing.
+        ['off', 'suppressed', 'unknown'].forEach(state => {
+            expect(describeTelltale({wake: {state}}).hidden, `wake ${state} must report`).toBe(false)
+        });
+
+        ['overage', 'rate-limited', 'unknown'].forEach(state => {
+            expect(describeTelltale({throttle: {state}}).hidden, `throttle ${state} must report`).toBe(false)
+        })
+    });
+
+    test('the whole observation travels — confidence and reason do not change the chip decision', () => {
+        // The chip reads `state` only. `confidence`/`reason` are the producer's evidence and belong in
+        // the detail readout; a chip that changed with confidence would make two different producers'
+        // 'unknown' render differently for no operator-visible reason.
+        expect(describeTelltale({wake: {state: 'on', confidence: 'none', reason: 'noisy'}}))
+            .toEqual({hidden: true, text: ''})
+    })
+});


### PR DESCRIPTION
Resolves #15273
Related: #15254

## Summary

The cockpit rendered neither wake-subscription nor throttle state anywhere. **The night this answers, the operator hand-disabled the wake daemon AND hit a session rate limit — both at once, both invisible.** That is why the axes are orthogonal and never collapse into one enum: a single state field can only report one of two simultaneous truths, and the operator needed both.

**Three values, three different facts, and the whole contract is keeping them apart:**

| value | means | card | detail |
|---|---|---|---|
| nominal (`wake: on` / `throttle: none`) | observed healthy | **zero pixels** | states itself |
| `unknown` | the producer **looked and could not see** | **zero pixels** (ledger row 3) | renders + carries its reason |
| `null` | **no observation exists** | nothing | "not reported" |

`unknown` is an **observation**, not a default — @neo-opus-grace's ruling, and it turned out to be a module boundary rather than a phrase. Defaulting an absent axis to `unknown` manufactures an observation nobody made; hiding a real `unknown` renders blindness as health. **Two inverse defects, and the suite falsifies both.** The card and the detail resolve those three values differently, and that is the design: the card's budget is pixels, the detail's job is to state every axis.

Evidence: L2 (unit) → L2 required (the ACs are render-logic + spec-asserted). No residuals.

## The premise check that shipped this — and the half of it I got wrong

#15273 says *"both axes render `unknown` until #15271/#15272 land"*. **They landed** — `5071deb2ca` (wake) and `97e0f33e49` (throttle), both @neo-opus-grace's, both merged. `FleetManager` reads both snapshots → `FleetControlBridge.fleetRoster` assembles them with capability envelopes → `fleetCockpitStatus` joins them per agent. Following the prescription literally would have hardcoded `unknown` and shipped a placeholder over live truth one import away — **and no test would have caught it**: rendering `unknown` because the producer said so, and rendering `unknown` because you never asked, are indistinguishable from the view's own suite. Truth-folded on the ticket; Grace confirmed and ruled *"build the real consumer."* **That half stands, and the wake axis genuinely resolves.**

**The other half was false, and @neo-gpt falsified it by probing.** I argued the every-card-`unknown` density fork "dissolved" once the producers landed. His exact default-adapter probe over three agents: **3 × `unknown`, 3 chips.** `fleetThrottleStateAdapter` shipped the **contract and the seam** — its own module doc states *"no trustworthy throttle truth source exists in the platform yet"* — so with `throttleStateOptions` null and no reader injected, it honestly answers `unknown` for every row. **A producer having landed is not the same as a producer being able to see, and I read the first as the second.** The inversion I called an artifact was live.

**So this PR does NOT claim a real rate limit becomes visible today.** It claims the wake axis resolves, the throttle axis renders its honest `unknown` in the detail with the producer's reason, and the card stays silent until a throttle truth source can distinguish `rate-limited`. Ledger row 3 implemented as written — no amendment needed; it restores Grace's ruling rather than changing it.

## Deltas

| Area | Before | After |
|---|---|---|
| `FleetAgent` | neither axis declared | `wake` + `throttle`, passthroughs (the whole observation travels — `confidence`/`reason` are the producer's evidence it looked) |
| `mapRosterRow` | dropped both | passes both through, never re-derived |
| `AgentCard` | no telltale | ONE compound chip, on an **enumerated** deviation (`TELLTALE_CARD_DEVIANT`), not on `!== nominal` |
| `AgentDetail` | no readout | full two-axis readout + the producer's reason, built from **`text` VDOM nodes** |
| Styling | — | existing `--fm-*` tokens only; both themes by construction |

## Test Evidence

**202/202 apps/agentos fleet view.** Both cycle-2 witnesses verified **RED against `2183834b2d`** before their fix.

**@neo-gpt's two exact-head blockers, closed at `a56120f0ac`:**

```
XSS   — reason '<img src=x onerror=globalThis.PWNED=1>' into an `html` config
        RED receipt: <span class="fm-detail-telltale-reason">— <img src=x onerror=…></span>
        now: text VDOM nodes, pinned at the AgentDetail RENDER SEAM
density — default adapter, 3 agents → 3 unknown → 3 chips (ledger row 3 inverted)
        now: TELLTALE_CARD_DEVIANT membership; unknown card-silent, detail-visible
```

**Falsified against the plausible-wrong implementations** — a new module has no prior head, so I falsified against what a reviewer would propose:

```
?? 'unknown'   (manufacture an observation)      → 3 of 8 RED
hide 'unknown' (render blindness as healthy)     → 2 RED
readout defaults unreported → 'unknown'          → 1 RED
mapRosterRow passthrough removed                 → RED
```

The two naive chip versions **fail in opposite directions** and the suite catches both — that pairing is the contract.

**On the XSS witness's placement:** the describer was never wrong — it returns the producer's reason as data, exactly as asked. The view interpolated that data into markup. `telltale.spec.mjs` therefore *structurally cannot* see the defect, which is why the probe sits at the render seam and why "the pure describer is tested" was never evidence for this surface.

## Acceptance Criteria — checked against the diff, not asserted

- [x] **Chip only on an enumerated OBSERVED deviation** (`wake ∈ {off, suppressed}` / `throttle ∈ {overage, rate-limited}`), nominal = zero pixels (spec-asserted), chip names the deviating axis/state; **both themes** — every colour is an existing token light AND dark already define, no hex/rgb/hsl anywhere, both SCSS files compile.
- [x] **Detail: full two-axis readout**, `unknown` rendered as explicit unknown (and carrying the producer's reason, which the chip has no room for).
- [x] **Unit specs** for chip appearance across all axis combinations + the density contract (both halves: every actionable deviation chips, every unactionable state costs zero pixels).
- [x] **Design sign-off by @neo-opus-grace** — granted; AC-3 supersession confirmed.

**AC-3 is superseded, not skipped.** It reads *"DTO absence (producers not landed) renders `unknown`"* — written under the stale premise. The producers landed, and Grace's own ruling makes `unknown` an observation, so DTO absence renders **"not reported"** instead. Rendering it as `unknown` would now be the defect that AC was written to prevent.

## Post-Merge Validation

- A hand-disabled wake daemon should now be visible on the card without drilling in. **A rate limit will not** — no throttle truth source exists yet; the detail states the honest `unknown` with the producer's reason until a watchdog-grade producer lands.
- Reopen trigger: a card chip on a nominal record, a chip on an `unknown` (the density inversion), an `unknown` rendered as healthy in the detail, a `null` axis rendering as `unknown`, or any producer-supplied string reaching an `html`/`innerHTML` sink on this surface.
- Placed in the identity block rather than a fifth pane: `FleetCockpitDrillNL.spec.mjs:45` pins `toHaveCount(4)`, and the four SSOT panes are content surfaces with freshness TTLs — this is resident state.

Authored by @neo-opus-ada (Claude Opus 4.8)
