### PR TITLE
fix(fleet): inject the dev bridge endpoint

### DIFF
--- a/apps/agentos/app.mjs
+++ b/apps/agentos/app.mjs
@@ -2,9 +2,14 @@ import Viewport             from './view/Viewport.mjs';
 import {installFleetBridge} from '../../src/ai/fleet/installFleetBridge.mjs';
 
 export const onStart = () => {
+    const params   = new URLSearchParams(Neo.config.url.search),
+          fleetUrl = params.has('fleetUrl')
+              ? params.get('fleetUrl')
+              : 'http://127.0.0.1:8083/fleet';
+
     // Wire the dev-server (Option B) app<->fleet HTTP transport so the Accounts pane's fail-closed
     // registry-bridge submit path goes live. The Electron shell (Option A) installs this in-process.
-    installFleetBridge();
+    installFleetBridge({url: fleetUrl});
 
     Neo.app({
         appThemeFolder: 'agentos',

--- a/src/ai/fleet/installFleetBridge.mjs
+++ b/src/ai/fleet/installFleetBridge.mjs
@@ -12,15 +12,32 @@ import {createFleetRegistryBridge} from './createFleetRegistryBridge.mjs';
  * Electron shell (Option A) installs an equivalent bridge in-process instead of calling this — the
  * pane consumes the same `globalThis.AgentOS.fleet.registryBridge` contract either way.
  *
- * @param {Object}   [opts]
- * @param {String}   [opts.url='http://127.0.0.1:8083/fleet'] The fleet HTTP endpoint (see fleetBridgeServer).
- * @param {Function} [opts.fetchImpl=globalThis.fetch]        Injectable fetch for tests.
- * @param {Object}   [opts.target=globalThis]                 Injectable global for tests.
+ * @param {Object}   opts
+ * @param {String}   opts.url                              Absolute loopback fleet HTTP endpoint (see fleetBridgeServer).
+ * @param {Function} [opts.fetchImpl=globalThis.fetch]     Injectable fetch for tests.
+ * @param {Object}   [opts.target=globalThis]              Injectable global for tests.
  * @returns {Object} the installed registry bridge (also reachable at `target.AgentOS.fleet.registryBridge`).
  */
-export function installFleetBridge({url = 'http://127.0.0.1:8083/fleet', fetchImpl = globalThis.fetch, target = globalThis} = {}) {
+export function installFleetBridge({url, fetchImpl = globalThis.fetch, target = globalThis} = {}) {
+    const endpointError = 'installFleetBridge requires an absolute loopback HTTP(S) fleet URL';
+    let fleetUrl;
+
+    if (typeof url !== 'string' || !url.trim()) {
+        throw new TypeError(endpointError)
+    }
+
+    try {
+        fleetUrl = new URL(url)
+    } catch {
+        throw new TypeError(endpointError)
+    }
+
+    if (!['http:', 'https:'].includes(fleetUrl.protocol) || !['127.0.0.1', 'localhost', '[::1]'].includes(fleetUrl.hostname)) {
+        throw new TypeError(endpointError)
+    }
+
     const send = async request => {
-        const response = await fetchImpl(url, {
+        const response = await fetchImpl(fleetUrl.href, {
             method : 'POST',
             headers: {'Content-Type': 'application/json'},
             body   : JSON.stringify(request)

--- a/test/playwright/e2e/agentos/AccountsConfigSurface.spec.mjs
+++ b/test/playwright/e2e/agentos/AccountsConfigSurface.spec.mjs
@@ -42,10 +42,10 @@ test.describe('AgentOS Accounts — agent-scoped configuration surface', () => {
         let server;
 
         try {
-            // Fixed product port by design. EADDRINUSE is a hard red: never reuse a foreign server
-            // and accidentally test another checkout's tree.
-            server = await startFleetBridgeServer({port: 8083});
-            await page.goto('/apps/agentos/index.html');
+            server = await startFleetBridgeServer({port: 0});
+            const fleetUrl = `http://127.0.0.1:${server.address().port}/fleet`;
+
+            await page.goto(`/apps/agentos/index.html?${new URLSearchParams({fleetUrl})}`);
 
             await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
 

--- a/test/playwright/e2e/agentos/FleetCardNameSlotNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCardNameSlotNL.spec.mjs
@@ -29,10 +29,11 @@ test.describe('AgentOS Fleet card — name slot on live roster data (Neural Link
             harnessType   : 'codex'
         });
 
-        const server = await startFleetBridgeServer();
+        const server   = await startFleetBridgeServer({port: 0}),
+              fleetUrl = `http://127.0.0.1:${server.address().port}/fleet`;
 
         try {
-            await page.goto('/apps/agentos/index.html');
+            await page.goto(`/apps/agentos/index.html?${new URLSearchParams({fleetUrl})}`);
             await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
 
             // the authoritative roster replaces the sample seed: exactly the seeded resident renders

--- a/test/playwright/e2e/agentos/FleetCockpitLifecycleNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitLifecycleNL.spec.mjs
@@ -13,13 +13,13 @@ const TEST_AGENT_ID = 'nl-proof-agent';
  * server only replaces the Brain-side transport target for deterministic e2e assertions.
  * @param {Object} [options]
  * @param {Boolean} [options.rejectStart=false]
- * @returns {Promise<{close: Function, requests: Object[]}>}
+ * @returns {Promise<{close: Function, endpoint: String, requests: Object[]}>}
  */
 async function startRecordingFleetBridge({rejectStart = false} = {}) {
     const {startFleetBridgeServer} = await import('../../../../ai/services/fleet/fleetBridgeServer.mjs'),
           requests                 = [],
           server                   = await startFleetBridgeServer({
-              port    : 8083,
+              port    : 0,
               dispatch: async request => {
                   requests.push(request);
 
@@ -47,7 +47,8 @@ async function startRecordingFleetBridge({rejectStart = false} = {}) {
 
     return {
         requests,
-        close: () => new Promise(resolve => server.close(resolve))
+        endpoint: `http://127.0.0.1:${server.address().port}/fleet`,
+        close   : () => new Promise(resolve => server.close(resolve))
     }
 }
 
@@ -134,7 +135,7 @@ test.describe('AgentOS Fleet cockpit lifecycle controls (Neural Link)', () => {
         const fleet = await startRecordingFleetBridge();
 
         try {
-            await page.goto('/apps/agentos/index.html');
+            await page.goto(`/apps/agentos/index.html?${new URLSearchParams({fleetUrl: fleet.endpoint})}`);
             // the FleetSettingsPanel lifecycle surface is the 'Control' keeper-view in the shell rail
             await page.locator('.agent-shell').getByText('Control', {exact: true}).click();
             await expect(page.locator('.agent-panel-settings')).toBeVisible({timeout: 30000});
@@ -190,7 +191,7 @@ test.describe('AgentOS Fleet cockpit lifecycle controls (Neural Link)', () => {
         const fleet = await startRecordingFleetBridge({rejectStart: true});
 
         try {
-            await page.goto('/apps/agentos/index.html');
+            await page.goto(`/apps/agentos/index.html?${new URLSearchParams({fleetUrl: fleet.endpoint})}`);
             // the FleetSettingsPanel lifecycle surface is the 'Control' keeper-view in the shell rail
             await page.locator('.agent-shell').getByText('Control', {exact: true}).click();
             await expect(page.locator('.agent-panel-settings')).toBeVisible({timeout: 30000});

--- a/test/playwright/unit/ai/services/fleet/installFleetBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/installFleetBridge.spec.mjs
@@ -23,12 +23,13 @@ import {FLEET_WIRE_METHODS} from '../../../../../../src/ai/fleet/fleetWireMethod
 // Tests inject a `target` object (instead of the real globalThis) + a stub `fetchImpl`, so the global
 // slot + the fetch round-trip are asserted without touching the runtime global or the network.
 
-const okFetch = () => async () => ({json: async () => ({ok: true, result: null})});
+const fleetUrl = 'http://127.0.0.1:8083/fleet',
+      okFetch  = () => async () => ({json: async () => ({ok: true, result: null})});
 
 test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->fleet HTTP transport', () => {
     test('publishes AgentOS.fleet.registryBridge with exactly the wire operations', () => {
         const target = {};
-        const bridge = installFleetBridge({fetchImpl: okFetch(), target});
+        const bridge = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target});
 
         expect(target.AgentOS.fleet.registryBridge).toBe(bridge);
         expect(Object.keys(bridge).sort()).toEqual([...FLEET_WIRE_METHODS].sort())
@@ -39,12 +40,12 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
         const fetchImpl = async (url, init) => { calls.push({url, init}); return {json: async () => ({ok: true, result: {id: 'alice'}})} };
         const target    = {};
 
-        installFleetBridge({url: 'http://x/fleet', fetchImpl, target});
+        installFleetBridge({url: 'http://localhost:9191/fleet', fetchImpl, target});
         const res = await target.AgentOS.fleet.registryBridge.defineAgent({githubUsername: 'alice', harnessType: 'codex'});
 
         expect(res).toEqual({id: 'alice'});
         expect(calls).toHaveLength(1);
-        expect(calls[0].url).toBe('http://x/fleet');
+        expect(calls[0].url).toBe('http://localhost:9191/fleet');
         expect(calls[0].init.method).toBe('POST');
         expect(JSON.parse(calls[0].init.body)).toEqual({method: 'defineAgent', params: {githubUsername: 'alice', harnessType: 'codex'}})
     });
@@ -52,7 +53,7 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
     test('is additive — preserves an existing AgentOS.neuralLink slot', () => {
         const target = {AgentOS: {neuralLink: {connectionBridge: {}}}};
 
-        installFleetBridge({fetchImpl: okFetch(), target});
+        installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target});
         expect(target.AgentOS.neuralLink.connectionBridge).toBeDefined();
         expect(target.AgentOS.fleet.registryBridge).toBeDefined()
     });
@@ -60,8 +61,18 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
     test('is idempotent — a second install re-publishes without throwing', () => {
         const target = {};
 
-        installFleetBridge({fetchImpl: okFetch(), target});
-        const second = installFleetBridge({fetchImpl: okFetch(), target});
+        installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target});
+        const second = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target});
         expect(target.AgentOS.fleet.registryBridge).toBe(second)
+    });
+
+    test('fails loud before publishing when the fleet endpoint is missing or invalid', () => {
+        const install = url => () => installFleetBridge({url, fetchImpl: okFetch(), target: {}});
+
+        expect(install()).toThrow('installFleetBridge requires an absolute loopback HTTP(S) fleet URL');
+        expect(install('')).toThrow('installFleetBridge requires an absolute loopback HTTP(S) fleet URL');
+        expect(install('not-a-url')).toThrow('installFleetBridge requires an absolute loopback HTTP(S) fleet URL');
+        expect(install('file:///tmp/fleet')).toThrow('installFleetBridge requires an absolute loopback HTTP(S) fleet URL');
+        expect(install('https://example.com/fleet')).toThrow('installFleetBridge requires an absolute loopback HTTP(S) fleet URL')
     });
 });


### PR DESCRIPTION
Resolves #15323

The AgentOS entry point now owns the visible default Fleet endpoint and accepts an optional page-level `fleetUrl` override through the existing page-to-App-Worker query bridge. `installFleetBridge` requires an explicit absolute loopback HTTP(S) URL before it publishes anything. Every current fixed-port Fleet E2E now binds its own ephemeral server and passes that exact endpoint into the app, so a running dev Fleet server can keep port 8083 without colliding with the witnesses.

Evidence: L3 (real App Worker + Brain Fleet bridge + Neural Link E2E with the product dev server deliberately occupying 8083) → L3 required for this cross-realm runtime seam. No residuals.

## Deltas from ticket

The ticket's `FleetGridKeyboardA11y.spec.mjs` example had already drifted: that spec no longer starts a Fleet server on current `dev`. The live fixed-port consumers were `FleetCockpitLifecycleNL.spec.mjs`, `AccountsConfigSurface.spec.mjs`, and `FleetCardNameSlotNL.spec.mjs`; those are the witnesses repaired here. Open PR #15318 remains unstacked and untouched.

A security step-back also narrowed the new page-controlled override to loopback hosts (`127.0.0.1`, `localhost`, or `[::1]`). The dev Fleet server is explicitly unauthenticated and loopback-only, so permitting an arbitrary remote HTTP(S) target would have widened the credential boundary beyond the ticket's test-owned-loopback intent.

## Test Evidence

- Proper red control 1: the new fail-loud unit test failed because a missing endpoint silently selected the old hidden default.
- Proper red control 2: after absolute HTTP(S) validation landed, the same test still failed because `https://example.com/fleet` was accepted; the final loopback guard closes that exfiltration path.
- `npm run test-unit -- test/playwright/unit/ai/services/fleet/installFleetBridge.spec.mjs test/playwright/unit/ai/services/fleet/fleetTransport.integration.spec.mjs` — 12/12 passed.
- With `node ai/services/fleet/devFleetServer.mjs` actively listening on port 8083: `NEO_E2E_PORT=19143 npm run test-e2e -- test/playwright/e2e/agentos/FleetCockpitLifecycleNL.spec.mjs test/playwright/e2e/agentos/AccountsConfigSurface.spec.mjs test/playwright/e2e/agentos/FleetCardNameSlotNL.spec.mjs` — 4/4 passed against this checkout and test-owned ephemeral Fleet endpoints.
- `npm run agent-preflight -- --no-fix` over all six changed files — passed; only the pre-existing stale Memory-Core overlay warning was emitted.
- Repository pre-commit whitespace, shorthand, AiConfig test-mutation, JSDoc type, ticket archaeology, block-alignment, and parse gates — passed.
- `git diff --check origin/dev...HEAD` — clean.

## Post-Merge Validation

- [x] None required — the runtime seam is local-dev-only, and the exact cross-realm behavior is covered by real-browser Neural Link E2E while the competing product port is occupied.

## Evolution

The first E2E invocation reused a foreign checkout's existing server on port 8080 and therefore loaded stale AgentOS code, producing four false failures. The E2E config already exposes `NEO_E2E_PORT` for this exact hazard; rerunning this checkout on isolated ports produced the real 4/4 signal. No new workaround or follow-up ticket was needed.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session b681a37a-4353-4ed0-bbf1-b46e6f2501c7.
