### PR TITLE
test(agentos): credential guards aimed at a filename stop guarding when the code moves (#15345)

### DIFF
--- a/test/playwright/unit/apps/agentos/Accounts.spec.mjs
+++ b/test/playwright/unit/apps/agentos/Accounts.spec.mjs
@@ -121,70 +121,118 @@ test.describe('AgentOS.view.Accounts credential boundary', () => {
      * have named the defect and then reproduced it one line down. Credit: @neo-opus-grace spotted the
      * twin on review.
      *
-     * The `upsert` assertion is not decoration: a run that submits NOTHING also writes and logs
-     * nothing, so without proof the accepted-add path actually executed, both empty sets are vacuous.
+     * Three things here are load-bearing, and the first draft of this test got all three wrong —
+     * @neo-gpt falsified each against the real head:
+     *
+     * 1. It drives the REAL `submitToFleetRegistryBridge` / `upsertPublicAgentDefinition` through an
+     *    injected bridge and a real store. Stubbing those seams deletes the path the credential
+     *    actually crosses: a helper extracted INSIDE the real submit method persisted the PAT while
+     *    all 23 specs stayed green. A witness that replaces the subject of its own claim proves
+     *    nothing about it.
+     * 2. The recorder is a Proxy, not a plain object. `storage[key] = value` is a real persistent
+     *    write in Chromium and calls no method, so a method-only recorder watches it in silence.
+     * 3. Teardown deletes an ABSENT global rather than restoring `undefined` (the hosted runner has
+     *    no `sessionStorage`), and unwinds LIFO so a throw mid-install still restores what was set.
+     *
+     * The positive control is not decoration: a run that submits NOTHING also writes and logs
+     * nothing, so without proof the accepted-add path actually executed through those real seams,
+     * both empty sets are vacuous.
      */
-    test('no credential byte reaches browser storage OR the console on an accepted add — behavioural, survives extraction', async () => {
+    test('no credential byte reaches browser storage OR the console on an accepted add — real seams, behavioural', async () => {
         const
-            canonical = {
+            AgentDefinition = (await import('../../../../../apps/agentos/model/AgentDefinition.mjs')).default,
+            Store           = (await import('../../../../../src/data/Store.mjs')).default,
+            canonical       = {
                 id            : 'resident-42',
                 githubUsername: 'canonical-login',
                 harnessType   : 'antigravity'
             },
-            calls     = [],
-            writes    = [],
-            logged    = [],
-            pat       = 'ghp_should_not_escape',
-            form      = {
+            pat        = 'ghp_should_not_escape',
+            writes     = [],
+            logged     = [],
+            statuses   = [],
+            store      = Neo.create(Store, {keyProperty: 'id', model: AgentDefinition, data: []}),
+            form       = {
                 getSubmitValues: async () => ({credential: pat, githubUsername: 'submitted-login', harnessType: 'codex'}),
                 validate       : async () => true
             },
-            stub      = {
-                clearCredentialField       : async () => {},
-                fire                       : () => {},
-                getReference               : reference => reference === 'agent-form' ? form : null,
-                submitToFleetRegistryBridge: async () => canonical,
-                updateBridgeStatus         : (state, message) => calls.push(['status', state, message]),
-                upsertPublicAgentDefinition: () => calls.push(['upsert'])
+            stub       = {
+                agentDefinitionsStore: store,
+                clearCredentialField : async () => {},
+                fire                 : () => {},
+                getReference         : reference => reference === 'agent-form' ? form : null,
+                updateBridgeStatus   : (state, message) => statuses.push([state, message]),
+                // the REAL credential-bearing seams. Stubbing `submitToFleetRegistryBridge` would
+                // delete the very path the credential crosses, and a helper extracted INSIDE it would
+                // leak while every assertion here stayed green — the claim would be about a boundary
+                // the test had removed.
+                submitToFleetRegistryBridge: Accounts.prototype.submitToFleetRegistryBridge,
+                upsertPublicAgentDefinition: Accounts.prototype.upsertPublicAgentDefinition
             },
-            // every mutating Storage member records instead of persisting; reads stay inert
-            recorder  = kind => ({
+            // Proxy-backed, not a plain object: `storage[key] = value` is a REAL persistent write in
+            // Chromium and reaches no method, so a method-only recorder watches it happen in silence.
+            // The trap covers the mutation surface; reads stay inert.
+            recorder   = kind => new Proxy({
                 clear     : ()     => writes.push([kind, 'clear']),
                 getItem   : ()     => null,
                 key       : ()     => null,
                 length    : 0,
                 removeItem: key    => writes.push([kind, 'removeItem', key]),
                 setItem   : (k, v) => writes.push([kind, 'setItem', k, v])
+            }, {
+                defineProperty(target, key, descriptor) {
+                    writes.push([kind, 'defineProperty', key, descriptor?.value]);
+                    return true
+                },
+                set(target, key, value) {
+                    writes.push([kind, 'set', key, value]);
+                    return true
+                }
             }),
-            kinds     = ['localStorage', 'sessionStorage'],
-            levels    = ['debug', 'error', 'info', 'log', 'warn'],
-            originals = {},
-            realLevel = {};
+            kinds      = ['localStorage', 'sessionStorage'],
+            levels     = ['debug', 'error', 'info', 'log', 'warn'],
+            realOS     = globalThis.AgentOS,
+            // LIFO teardown. Each entry is pushed BEFORE its mutation, so a throw part-way through
+            // install still unwinds everything already installed.
+            undo       = [];
 
-        kinds.forEach(kind => {
-            originals[kind] = Object.getOwnPropertyDescriptor(globalThis, kind);
-            Object.defineProperty(globalThis, kind, {configurable: true, value: recorder(kind)})
-        });
-
-        levels.forEach(level => {
-            realLevel[level] = console[level];
-            console[level]   = (...args) => logged.push([level, ...args])
-        });
+        // the injected bridge the REAL submit seam reads off globalThis
+        globalThis.AgentOS = {...realOS, fleet: {registryBridge: {defineAgent: async () => canonical}}};
 
         try {
+            kinds.forEach(kind => {
+                const original = Object.getOwnPropertyDescriptor(globalThis, kind);
+
+                // an ABSENT global must be deleted, not restored: the hosted runner has no
+                // `sessionStorage`, and defineProperty(…, undefined) throws on the way out
+                undo.push(() => original ? Object.defineProperty(globalThis, kind, original) : delete globalThis[kind]);
+                Object.defineProperty(globalThis, kind, {configurable: true, value: recorder(kind)})
+            });
+
+            levels.forEach(level => {
+                const original = console[level];
+
+                undo.push(() => {console[level] = original});
+                console[level] = (...args) => logged.push([level, ...args])
+            });
+
             await Accounts.prototype.onSubmitAgentClick.call(stub)
         } finally {
-            kinds .forEach(kind  => Object.defineProperty(globalThis, kind, originals[kind]));
-            levels.forEach(level => {console[level] = realLevel[level]})
+            undo.reverse().forEach(fn => fn());
+            globalThis.AgentOS = realOS
         }
 
-        // the positive control: the add REALLY completed, so an empty `writes`/`logged` means something
-        expect(calls, 'the accepted-add path must have run — otherwise both leak checks are vacuous')
-            .toEqual([['upsert'], ['status', 'is-live', 'Agent added. PAT was not retained in the app worker.']]);
+        // the positive control: the REAL seams ran to an accepted add, so empty sets mean something
+        expect(statuses, 'the accepted-add path must have run through the REAL seams — otherwise both leak checks are vacuous')
+            .toEqual([['is-live', 'Agent added. PAT was not retained in the app worker.']]);
+        expect(store.get('resident-42')?.githubUsername, 'the real store must hold the canonical record').toBe('canonical-login');
+        expect(store.get('resident-42')?.credential, 'and no credential byte in it').toBeUndefined();
 
         expect(writes, 'no credential byte may reach browser storage, from ANY module on this path').toEqual([]);
         expect(logged, 'no credential byte may reach the console, from ANY module on this path').toEqual([]);
-        expect(JSON.stringify([writes, logged])).not.toContain(pat)
+        expect(JSON.stringify([writes, logged])).not.toContain(pat);
+
+        store.destroy()
     });
 
     test('identity setup writes only the redacted projection to the shared roster', () => {

--- a/test/playwright/unit/apps/agentos/Accounts.spec.mjs
+++ b/test/playwright/unit/apps/agentos/Accounts.spec.mjs
@@ -114,10 +114,17 @@ test.describe('AgentOS.view.Accounts credential boundary', () => {
      * and says nothing while it happens. This one records real writes, so it follows the credential
      * into whatever module holds it.
      *
-     * The `upsert` assertion is not decoration: a run that submits NOTHING also writes nothing, so
-     * without proof the accepted-add path actually executed, `writes` being empty is a vacuous pass.
+     * Storage and console are ONE boundary, not two. The source check's sibling line makes the same
+     * mistake about `console.*` that its storage line makes about `localStorage`: a `console.log(pat)`
+     * inside that same extracted helper leaks the credential to logs by the identical mechanism, and
+     * the same refactor blinds both guards in a single commit. Covering the storage half alone would
+     * have named the defect and then reproduced it one line down. Credit: @neo-opus-grace spotted the
+     * twin on review.
+     *
+     * The `upsert` assertion is not decoration: a run that submits NOTHING also writes and logs
+     * nothing, so without proof the accepted-add path actually executed, both empty sets are vacuous.
      */
-    test('no credential byte reaches browser storage on an accepted add — behavioural, survives extraction', async () => {
+    test('no credential byte reaches browser storage OR the console on an accepted add — behavioural, survives extraction', async () => {
         const
             canonical = {
                 id            : 'resident-42',
@@ -126,6 +133,7 @@ test.describe('AgentOS.view.Accounts credential boundary', () => {
             },
             calls     = [],
             writes    = [],
+            logged    = [],
             pat       = 'ghp_should_not_escape',
             form      = {
                 getSubmitValues: async () => ({credential: pat, githubUsername: 'submitted-login', harnessType: 'codex'}),
@@ -149,25 +157,34 @@ test.describe('AgentOS.view.Accounts credential boundary', () => {
                 setItem   : (k, v) => writes.push([kind, 'setItem', k, v])
             }),
             kinds     = ['localStorage', 'sessionStorage'],
-            originals = {};
+            levels    = ['debug', 'error', 'info', 'log', 'warn'],
+            originals = {},
+            realLevel = {};
 
         kinds.forEach(kind => {
             originals[kind] = Object.getOwnPropertyDescriptor(globalThis, kind);
             Object.defineProperty(globalThis, kind, {configurable: true, value: recorder(kind)})
         });
 
+        levels.forEach(level => {
+            realLevel[level] = console[level];
+            console[level]   = (...args) => logged.push([level, ...args])
+        });
+
         try {
             await Accounts.prototype.onSubmitAgentClick.call(stub)
         } finally {
-            kinds.forEach(kind => Object.defineProperty(globalThis, kind, originals[kind]))
+            kinds .forEach(kind  => Object.defineProperty(globalThis, kind, originals[kind]));
+            levels.forEach(level => {console[level] = realLevel[level]})
         }
 
-        // the positive control: the add REALLY completed, so an empty `writes` means something
-        expect(calls, 'the accepted-add path must have run — otherwise the leak check is vacuous')
+        // the positive control: the add REALLY completed, so an empty `writes`/`logged` means something
+        expect(calls, 'the accepted-add path must have run — otherwise both leak checks are vacuous')
             .toEqual([['upsert'], ['status', 'is-live', 'Agent added. PAT was not retained in the app worker.']]);
 
         expect(writes, 'no credential byte may reach browser storage, from ANY module on this path').toEqual([]);
-        expect(JSON.stringify(writes)).not.toContain(pat)
+        expect(logged, 'no credential byte may reach the console, from ANY module on this path').toEqual([]);
+        expect(JSON.stringify([writes, logged])).not.toContain(pat)
     });
 
     test('identity setup writes only the redacted projection to the shared roster', () => {

--- a/test/playwright/unit/apps/agentos/Accounts.spec.mjs
+++ b/test/playwright/unit/apps/agentos/Accounts.spec.mjs
@@ -104,6 +104,72 @@ test.describe('AgentOS.view.Accounts credential boundary', () => {
         expect(source).not.toMatch(/console\.(log|warn|error)/)
     });
 
+    /**
+     * The behavioural half, and the load-bearing one. The source check above proves the STRING
+     * `localStorage` is absent from ONE FILE — a different claim from "no credential reaches browser
+     * storage", and the two come apart the instant any credential handling moves into a sibling
+     * module. Verified, not asserted: with a `rememberCredential()` helper extracted next to the view
+     * and persisting the PAT, the source check above still passed and the suite stayed at its exact
+     * 22/22 baseline. A guard aimed at a filename stops guarding the moment the code leaves the file,
+     * and says nothing while it happens. This one records real writes, so it follows the credential
+     * into whatever module holds it.
+     *
+     * The `upsert` assertion is not decoration: a run that submits NOTHING also writes nothing, so
+     * without proof the accepted-add path actually executed, `writes` being empty is a vacuous pass.
+     */
+    test('no credential byte reaches browser storage on an accepted add — behavioural, survives extraction', async () => {
+        const
+            canonical = {
+                id            : 'resident-42',
+                githubUsername: 'canonical-login',
+                harnessType   : 'antigravity'
+            },
+            calls     = [],
+            writes    = [],
+            pat       = 'ghp_should_not_escape',
+            form      = {
+                getSubmitValues: async () => ({credential: pat, githubUsername: 'submitted-login', harnessType: 'codex'}),
+                validate       : async () => true
+            },
+            stub      = {
+                clearCredentialField       : async () => {},
+                fire                       : () => {},
+                getReference               : reference => reference === 'agent-form' ? form : null,
+                submitToFleetRegistryBridge: async () => canonical,
+                updateBridgeStatus         : (state, message) => calls.push(['status', state, message]),
+                upsertPublicAgentDefinition: () => calls.push(['upsert'])
+            },
+            // every mutating Storage member records instead of persisting; reads stay inert
+            recorder  = kind => ({
+                clear     : ()     => writes.push([kind, 'clear']),
+                getItem   : ()     => null,
+                key       : ()     => null,
+                length    : 0,
+                removeItem: key    => writes.push([kind, 'removeItem', key]),
+                setItem   : (k, v) => writes.push([kind, 'setItem', k, v])
+            }),
+            kinds     = ['localStorage', 'sessionStorage'],
+            originals = {};
+
+        kinds.forEach(kind => {
+            originals[kind] = Object.getOwnPropertyDescriptor(globalThis, kind);
+            Object.defineProperty(globalThis, kind, {configurable: true, value: recorder(kind)})
+        });
+
+        try {
+            await Accounts.prototype.onSubmitAgentClick.call(stub)
+        } finally {
+            kinds.forEach(kind => Object.defineProperty(globalThis, kind, originals[kind]))
+        }
+
+        // the positive control: the add REALLY completed, so an empty `writes` means something
+        expect(calls, 'the accepted-add path must have run — otherwise the leak check is vacuous')
+            .toEqual([['upsert'], ['status', 'is-live', 'Agent added. PAT was not retained in the app worker.']]);
+
+        expect(writes, 'no credential byte may reach browser storage, from ANY module on this path').toEqual([]);
+        expect(JSON.stringify(writes)).not.toContain(pat)
+    });
+
     test('identity setup writes only the redacted projection to the shared roster', () => {
         const source = fs.readFileSync(viewPath, 'utf8');
 


### PR DESCRIPTION
Resolves #15345.

The define-agent surface's credential boundary has two storage/log guards. **Neither holds**, and the rebuild scheduled for this surface is exactly the operation that would silently disarm both — in one commit.

## The finding

`Accounts.spec.mjs:98` is the guard that exists to stop a PAT reaching browser storage:

```js
const source = fs.readFileSync(viewPath, 'utf8');
expect(source).not.toMatch(/localStorage|sessionStorage|indexedDB/);   // :103
expect(source).not.toMatch(/console\.(log|warn|error)/)                // :104
```

**They assert STRINGS are absent from ONE FILE.** `viewPath` (`:22`) points at `apps/agentos/view/Accounts.mjs` and nowhere else. *"The literal `localStorage` does not appear in this file"* and *"no credential reaches browser storage"* are different claims, and they come apart the instant any credential handling lives in a sibling module.

**Evidence:** I did not argue this — I falsified it. Extracting a `rememberCredential()` helper beside the view (the exact refactor the define-agent rebuild performs) and leaking the PAT from the accepted-add path at `Accounts.mjs:505`:

```
STORAGE HALF — helper calls localStorage.setItem('agentos.pat', <PAT>):
  localStorage literal in Accounts.mjs:  NO           <- the regex has nothing to match
  full suite:                            22 passed    <- the EXACT unmutated baseline

CONSOLE HALF — helper calls console.log('...pat:', <PAT>):
  console.* literal in Accounts.mjs:     NO
  old source-text guard (:104):          1 passed     <- blind
```

**The suite did not move.** The guards watched a real PAT reach `localStorage.setItem` and `console.log` and said nothing.

This is scheduled, not hypothetical. The rebuild lifts this flow out of `Accounts.mjs` into fleet primitives — **the guards are aimed at a filename, and the rebuild's whole job is moving the code out of that file.** They keep passing while they stop guarding, and the transition is invisible in CI.

## What this changes

One behavioural witness beside the source check: recording `localStorage`/`sessionStorage` installed via `Object.defineProperty` (both `configurable: true`; `indexedDB` is `undefined` under Node) **and** recording `console.debug/error/info/log/warn`, driving the real `onSubmitAgentClick` path, restoring both in `finally`, asserting neither a storage write nor a log line carries credential material. Aimed at behaviour, it follows the credential into whatever module the rebuild puts it in.

**The `upsert` assertion in it is load-bearing, not decoration.** A run that submits nothing also writes nothing *and logs nothing* — without proof the add executed, both empty sets are vacuous passes, and the replacement would inherit the very defect it replaces.

**Storage and console are one boundary, not two.** #13058's matrix names them in one breath; one refactor blinds both. Covering only the storage half would have meant naming the defect and reproducing it one line down. **The console twin is @neo-opus-grace's catch on review** — she also pointed out my ticket's scope line (*"the matrix's storage row is what has a false guard today"*) was simply false. It's corrected on #15345.

## What this does NOT change

**The code was already right.** The audit that found this cleared the surface: no browser-persistent sink, no log echo, the PAT field cleared after every bridge attempt (`:532`), the connect path credential-free, and `upsertPublicAgentDefinition` (`:588`) rejecting both a top-level secret and an exact echo before mutating the store. **`Accounts.mjs` has zero diff here.** The surface is careful; its guards were not. Those `:588` guards are in fact the shape I copied — they test what *happened*, not what the file *says*.

**The source-text checks stay.** They legitimately pin `clearCredentialField` and the fail-closed message, and fail loudly on real regressions to those. They are simply no longer the storage/log guard.

## Test Evidence

Differential control — **two instruments, same bytes, opposite verdicts** — run for both halves:

```
STORAGE:  leak wired -> new witness FAILS, catching ["localStorage","setItem","ghp_should_not_escape"]
                        old source-text guard PASSES on that identical code
CONSOLE:  leak wired -> new witness FAILS, catching ghp_should_not_escape
                        old source-text guard (:104) PASSES on that identical code
CLEAN:    23 passed  (22 baseline + 1)
```

A witness that has not been shown to fail is not evidence, so each half was made to fail before it was trusted.

**One honest note on method:** my first falsifier *did* produce a red — and it was the wrong red. Node 22 *has* `localStorage`, and its `setItem` throws without `--localstorage-file`, so the leak tripped the view's `try/catch` and broke an unrelated call-order assertion. That reads like "the guard caught it" and is not. The leak had to be made to *succeed* before the suite's silence meant anything.

## Post-Merge Validation

- `npx playwright test test/playwright/unit/apps/agentos/Accounts.spec.mjs` — expect 23 passed.
- The witness stays honest through the rebuild: when the define-agent flow moves out of these files, this test must keep passing **without** being edited to follow it. If it needs editing to keep passing, it has regressed to the class it replaces.

## Deltas

- `test/playwright/unit/apps/agentos/Accounts.spec.mjs` — +131/0 across three commits. One behavioural storage+console witness with an in-test positive control. No production diff; no other file touched.

Authored by Vega. Session 6517bb47-c5ad-4f0b-a29d-e67f1fa2d153.