### PR TITLE
fix(fleet): one credential-redaction authority — five copies, three authors, zero complete (#15347)

### DIFF
--- a/ai/services/fleet/fleetA2AActivityAdapter.mjs
+++ b/ai/services/fleet/fleetA2AActivityAdapter.mjs
@@ -2,6 +2,7 @@ import {
     createFleetCockpitEvent,
     FLEET_COCKPIT_SOURCES
 } from '../../../src/ai/fleet/fleetCockpitStatus.mjs'
+import {redactCredentials} from './redactCredentials.mjs'
 
 /**
  * @module ai/services/fleet/fleetA2AActivityAdapter
@@ -157,17 +158,17 @@ export function createA2AMessageActivityEvents(messages = [], {capturedAt = new 
             confidence: 'observed',
             occurredAt: message.occurredAt,
             payload   : {
-                kind              : message.isLaneClaim ? 'a2a-lane-claim' : 'a2a-message',
-                messageId         : message.messageId,
-                subject           : message.subject,
-                from              : message.from,
-                priority          : message.priority,
-                recipientClass    : message.recipientClass,
-                relatedTickets    : message.relatedTickets,
+                kind               : message.isLaneClaim ? 'a2a-lane-claim' : 'a2a-message',
+                messageId          : message.messageId,
+                subject            : message.subject,
+                from               : message.from,
+                priority           : message.priority,
+                recipientClass     : message.recipientClass,
+                relatedTickets     : message.relatedTickets,
                 relatedPullRequests: message.relatedPullRequests,
-                status            : message.status,
-                taskState         : message.taskState,
-                wakeSuppressed    : message.wakeSuppressed
+                status             : message.status,
+                taskState          : message.taskState,
+                wakeSuppressed     : message.wakeSuppressed
             }
         }))
 }
@@ -176,18 +177,18 @@ function normalizeA2AMessage(message, capturedAt) {
     const subject = normalizeSubject(message.subject)
 
     return {
-        messageId         : typeof message.messageId === 'string' ? message.messageId : null,
+        messageId          : typeof message.messageId === 'string' ? message.messageId : null,
         subject,
-        from              : normalizeAgentId(message.from),
-        priority          : message.priority || null,
-        recipientClass    : getRecipientClass(message.to),
-        relatedTickets    : normalizeRelatedTickets(message.relatedTickets),
+        from               : normalizeAgentId(message.from),
+        priority           : message.priority || null,
+        recipientClass     : getRecipientClass(message.to),
+        relatedTickets     : normalizeRelatedTickets(message.relatedTickets),
         relatedPullRequests: normalizeRelatedPullRequests(message.relatedPullRequests),
-        status            : getMessageStatus(message),
-        taskState         : message.task?.state || null,
-        wakeSuppressed    : Boolean(message.wakeSuppressed),
-        occurredAt        : toIsoString(message.sentAt || message.createdAt, capturedAt),
-        isLaneClaim       : LANE_CLAIM_SUBJECT.test(subject || '')
+        status             : getMessageStatus(message),
+        taskState          : message.task?.state || null,
+        wakeSuppressed     : Boolean(message.wakeSuppressed),
+        occurredAt         : toIsoString(message.sentAt || message.createdAt, capturedAt),
+        isLaneClaim        : LANE_CLAIM_SUBJECT.test(subject || '')
     }
 }
 
@@ -266,9 +267,7 @@ function normalizeError(error) {
 }
 
 function redactSecretText(text) {
-    return text
-        .replace(/\b(token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
-        .replace(/\bgh[pousr]_[A-Za-z0-9_]+/g, '[redacted-token]')
+    return redactCredentials(text)
 }
 
 function toIsoString(value, fallback = new Date()) {

--- a/ai/services/fleet/fleetMailboxMirrorAdapter.mjs
+++ b/ai/services/fleet/fleetMailboxMirrorAdapter.mjs
@@ -1,5 +1,6 @@
 import {FLEET_COCKPIT_SOURCES}        from '../../../src/ai/fleet/fleetCockpitStatus.mjs'
 import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNodeId.mjs'
+import {redactCredentials}            from './redactCredentials.mjs'
 
 /**
  * @module ai/services/fleet/fleetMailboxMirrorAdapter
@@ -379,11 +380,7 @@ function normalizeError(error) {
  * @private
  */
 function redactSecretText(text) {
-    return text
-        .replace(/\b(?:authorization\s*[:=]\s*)?bearer\s+[^\s,;)]+/gi, 'authorization=[redacted]')
-        .replace(/\b(authorization|token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
-        .replace(/\bgh[pousr]_[A-Za-z0-9_]+/g, '[redacted-token]')
-        .replace(/\bglpat-[A-Za-z0-9_-]+/g, '[redacted-token]')
+    return redactCredentials(text)
 }
 
 function toIsoString(value, fallback = new Date()) {

--- a/ai/services/fleet/fleetPrLaneActivityAdapter.mjs
+++ b/ai/services/fleet/fleetPrLaneActivityAdapter.mjs
@@ -7,6 +7,7 @@ import {
     getPrDeferDisposition,
     getPrHumanGateState
 } from '../graph/issueFocusSections.mjs'
+import {redactCredentials} from './redactCredentials.mjs'
 
 /**
  * @module ai/services/fleet/fleetPrLaneActivityAdapter
@@ -95,8 +96,8 @@ export function createPrActivityEvents(prs = [], {capturedAt = new Date()} = {})
     return asArray(prs)
         .filter(Boolean)
         .map(pr => {
-            const number = getNumber(pr.number),
-                  author = getLogin(pr.author),
+            const number         = getNumber(pr.number),
+                  author         = getLogin(pr.author),
                   relatedTickets = extractRefs(`${pr.title || ''} ${pr.body || ''}`)
 
             const humanGateState = getPrHumanGateState(pr)
@@ -227,10 +228,10 @@ function createActivityCapability({capturedAt, confidence, reason = null, state}
 }
 
 function normalizeIssue(issue, capturedAt) {
-    const meta = issue.meta || issue,
-          number = getNumber(issue.number || meta.number || meta.id),
-          title = issue.title || meta.title || null,
-          content = issue.content || issue.body || '',
+    const meta     = issue.meta || issue,
+          number   = getNumber(issue.number || meta.number || meta.id),
+          title    = issue.title || meta.title || null,
+          content  = issue.content || issue.body || '',
           comments = normalizeComments(issue, content)
 
     return {
@@ -325,9 +326,7 @@ function normalizeError(error) {
 }
 
 function redactSecretText(text) {
-    return text
-        .replace(/\b(token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
-        .replace(/\bgh[pousr]_[A-Za-z0-9_]+/g, '[redacted-token]')
+    return redactCredentials(text)
 }
 
 function toIsoString(value, fallback = new Date()) {

--- a/ai/services/fleet/fleetThrottleStateAdapter.mjs
+++ b/ai/services/fleet/fleetThrottleStateAdapter.mjs
@@ -20,6 +20,8 @@
  * rendered as `none`.
  */
 
+import {redactCredentials} from './redactCredentials.mjs'
+
 export const THROTTLE_STATES = Object.freeze(['none', 'overage', 'rate-limited', 'unknown'])
 
 export const THROTTLE_SOURCE_LABEL = 'fleet:throttleState'
@@ -138,21 +140,24 @@ function normalizeReason(error) {
 }
 
 /**
- * @summary Bounds AND redacts a diagnostic before it can reach a Body-side projection: secret
- * vocabulary and token shapes are masked, whitespace collapsed, length capped — a throwing
- * transport's dump can never leak internals into a row reason. Kept contract-identical with the
- * wake sibling's redaction; consolidating both into one shared helper module rides the
- * post-merge alignment of the two producer branches.
+ * @summary Bounds AND redacts a diagnostic before it can reach a Body-side projection: whitespace
+ * collapsed and length capped here, credentials masked by the shared authority — a throwing
+ * transport's dump can never leak internals into a row reason.
+ *
+ * The masking used to live inline, and this JSDoc used to promise that consolidating it into a
+ * shared module "rides the post-merge alignment of the two producer branches". It didn't: the
+ * private copy shipped, four siblings grew their own, and none of the five learned `github_pat_`
+ * when that family arrived — every one leaked a fine-grained PAT verbatim into an operator-visible
+ * reason. Bounding stays local because each adapter's caps differ; masking is the shared contract
+ * because a per-adapter copy is exactly how the gap survived.
+ *
  * @param {*} error
  * @returns {String|null}
  */
 function redactReason(error) {
     if (error == null) return null
 
-    return normalizeReason(error)
-        .replace(/\b(token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
-        .replace(/\bgh[pousr]_[A-Za-z0-9_]+/g, '[redacted-token]')
-        .replace(/\bglpat-[A-Za-z0-9_-]+/g, '[redacted-token]')
+    return redactCredentials(normalizeReason(error))
 }
 
 function toIsoString(value) {

--- a/ai/services/fleet/fleetWakeStateAdapter.mjs
+++ b/ai/services/fleet/fleetWakeStateAdapter.mjs
@@ -1,4 +1,5 @@
 import {spawnSync} from 'node:child_process'
+import {redactCredentials} from './redactCredentials.mjs'
 import fs          from 'node:fs'
 
 /**
@@ -313,10 +314,7 @@ function normalizeReason(error) {
 function redactReason(error) {
     if (error == null) return null
 
-    return normalizeReason(error)
-        .replace(/\b(token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
-        .replace(/\bgh[pousr]_[A-Za-z0-9_]+/g, '[redacted-token]')
-        .replace(/\bglpat-[A-Za-z0-9_-]+/g, '[redacted-token]')
+    return redactCredentials(normalizeReason(error))
 }
 
 function toIsoString(value) {

--- a/ai/services/fleet/fleetWakeStateAdapter.mjs
+++ b/ai/services/fleet/fleetWakeStateAdapter.mjs
@@ -1,6 +1,6 @@
-import {spawnSync} from 'node:child_process'
+import {spawnSync}         from 'node:child_process'
 import {redactCredentials} from './redactCredentials.mjs'
-import fs          from 'node:fs'
+import fs                  from 'node:fs'
 
 /**
  * @module ai/services/fleet/fleetWakeStateAdapter

--- a/ai/services/fleet/redactCredentials.mjs
+++ b/ai/services/fleet/redactCredentials.mjs
@@ -14,10 +14,21 @@
  * That is the defect: not the missing pattern, the duplication that made a missing pattern
  * survivable. Patching five regexes leaves five things to forget when the seventh family ships.
  *
- * **Order is load-bearing, not stylistic.** `bearer` must be masked before the keyed rule: the keyed
- * pattern stops at whitespace, so `authorization=bearer ghp_…` would match only `authorization=bearer`
- * and leave the token itself exposed one space later. Only `fleetMailboxMirrorAdapter` knew this;
- * it is the reason the union had to be built from all five rather than from the most recent.
+ * **The scheme is matched generically, and that is the whole lesson repeated one level down.**
+ * The first cut of this module special-cased `bearer` and let every other scheme fall through to
+ * the keyed rule — whose value pattern stops at whitespace, so it consumed the *scheme word* and
+ * published the credential one space later: `Authorization: Basic dXNlcjpwYXNzd29yZA==` masked to
+ * `Authorization=[redacted] dXNlcjpwYXNzd29yZA==`, announcing sanitization while carrying
+ * `user:password`. An allow-list of schemes has an expiry date exactly the way the five copies did
+ * — it publishes the token for the first scheme nobody taught it. So the scheme is matched as a
+ * generic word: `NTLM`, `Negotiate`, `SCRAM-SHA-256` and anything else are covered without being
+ * enumerated. Digest's comma-separated parameters are consumed too, or the value survives past the
+ * first comma.
+ *
+ * **The bias is deliberate: over-redact after `authorization`.** An unknown token following an
+ * authorization value is indistinguishable from a credential, so it is consumed. Losing a word of
+ * trailing context in a diagnostic is cheap; publishing a credential is not. Everywhere else the
+ * rules are anchored to an explicit key or token family, so ordinary prose passes through intact.
  *
  * **Replacement labels are literals, never derived from the match.** A label computed from the
  * matched text turns a delimiter-less secret into its own label — the output then announces it was
@@ -29,9 +40,15 @@
  */
 export function redactCredentials(text) {
     return String(text)
-        // Bearer first — see the order note above.
-        .replace(/\b(?:authorization\s*[:=]\s*)?bearer\s+[^\s,;)]+/gi, 'authorization=[redacted]')
-        .replace(/\b(authorization|token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
+        // An authorization value in full: an optional generic scheme word, the credential, and any
+        // Digest-style `, key="value"` parameters. Must run before the keyed rule, which would
+        // otherwise stop at the space after the scheme.
+        .replace(/\b((?:proxy-)?authorization)\s*[:=]\s*(?:[A-Za-z][A-Za-z0-9-]*\s+)?[^\s,;)]+(?:\s*,\s*[\w-]+\s*=\s*(?:"[^"]*"|[^\s,;)]+))*/gi, '$1=[redacted]')
+        // A bare scheme carrying a credential with no `authorization` key in front of it.
+        .replace(/\b(?:bearer|basic|digest)\s+[^\s,;)]+/gi, 'authorization=[redacted]')
+        // Keyed secrets — the UNION of every copy's key set, including the composer's
+        // (`fleetActivityComposer`, see the ledger note below).
+        .replace(/\b(api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|authorization|token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
         // Fine-grained GitHub PAT. `\bgh[pousr]_` cannot reach it: the character class fails on the
         // `i` of `github`, so this family passed through all five predecessors untouched.
         .replace(/\bgithub_pat_[A-Za-z0-9_]+/g, '[redacted-token]')
@@ -47,13 +64,26 @@ export function redactCredentials(text) {
  * adapters drifted from each other — silently, and in the direction of fewer families. Importing
  * the contract means adding a family here fails any witness that has not been taught to prove it.
  *
+ * `sample` is a full diagnostic fragment; `secret` names the substring that must not survive. They
+ * are separate because a witness that derives the secret from the sample (by splitting on the last
+ * delimiter, say) cannot express a family whose credential contains delimiters — `Digest` and
+ * `Basic` both do, and both leaked past the first cut of this module for that reason.
+ *
  * @type {Object[]}
  */
 export const CREDENTIAL_FAMILIES = Object.freeze([
-    {name: 'github-pat-fine-grained', sample: 'github_pat_11ABCDE0Y0abcdefghijkl_MNOPqrstuvwx'},
-    {name: 'github-classic',          sample: 'ghp_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234'},
-    {name: 'github-oauth',            sample: 'gho_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234'},
-    {name: 'gitlab-pat',              sample: 'glpat-AAAABBBBCCCCDDDD1234'},
-    {name: 'bearer',                  sample: 'Authorization: Bearer sk-live-AAAABBBBCCCC1234'},
-    {name: 'keyed-secret',            sample: 'credential=sk-live-AAAABBBBCCCC1234'}
+    {name: 'github-pat-fine-grained', sample: 'github_pat_11ABCDE0Y0abcdefghijkl_MNOPqrstuvwx',      secret: 'github_pat_11ABCDE0Y0abcdefghijkl_MNOPqrstuvwx'},
+    {name: 'github-classic',          sample: 'ghp_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234',                secret: 'ghp_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234'},
+    {name: 'github-oauth',            sample: 'gho_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234',                secret: 'gho_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234'},
+    {name: 'gitlab-pat',              sample: 'glpat-AAAABBBBCCCCDDDD1234',                          secret: 'glpat-AAAABBBBCCCCDDDD1234'},
+    {name: 'bearer',                  sample: 'Authorization: Bearer sk-live-AAAABBBBCCCC1234',      secret: 'sk-live-AAAABBBBCCCC1234'},
+    {name: 'basic',                   sample: 'Authorization: Basic dXNlcjpwYXNzd29yZA==',           secret: 'dXNlcjpwYXNzd29yZA=='},
+    {name: 'digest',                  sample: 'Authorization: Digest username="u", nonce="abc123"',  secret: 'abc123'},
+    {name: 'unlisted-scheme',         sample: 'Authorization: NTLM TlRMTVNTUAABtoken99',             secret: 'TlRMTVNTUAABtoken99'},
+    {name: 'proxy-authorization',     sample: 'Proxy-Authorization: Bearer sk-live-PPPP1111',        secret: 'sk-live-PPPP1111'},
+    {name: 'keyed-secret',            sample: 'credential=sk-live-AAAABBBBCCCC1234',                 secret: 'sk-live-AAAABBBBCCCC1234'},
+    {name: 'api-key',                 sample: 'x-api-key: sk-live-abcdef123456',                     secret: 'sk-live-abcdef123456'},
+    {name: 'access-token',            sample: 'access_token: at-live-zzz111',                        secret: 'at-live-zzz111'},
+    {name: 'refresh-token',           sample: 'refresh-token=rt-live-www333',                        secret: 'rt-live-www333'},
+    {name: 'client-secret',           sample: 'client_secret: cs-live-qqq222',                       secret: 'cs-live-qqq222'}
 ])

--- a/ai/services/fleet/redactCredentials.mjs
+++ b/ai/services/fleet/redactCredentials.mjs
@@ -1,0 +1,59 @@
+/**
+ * @module ai/services/fleet/redactCredentials
+ * @summary The single credential-redaction authority for Fleet diagnostics that reach a Body-side
+ * projection.
+ *
+ * **Why this module exists rather than a sixth regex.** Five adapters each grew a private copy of
+ * this redactor (`fleetThrottleStateAdapter`, `fleetWakeStateAdapter`, `fleetMailboxMirrorAdapter`,
+ * `fleetPrLaneActivityAdapter`, `fleetA2AActivityAdapter`), written by three different maintainers.
+ * Each was complete against the token families that existed the day it was written; each was then
+ * copied from a sibling, inheriting that sibling's gaps but not the coverage the sibling lacked.
+ * The copies drifted, a sixth family (`github_pat_`) arrived after the drift, and it landed in
+ * none of them — every one of the five leaked a fine-grained PAT verbatim into an operator-visible
+ * row reason. The union of what the five knew was the real contract and no single copy held it.
+ * That is the defect: not the missing pattern, the duplication that made a missing pattern
+ * survivable. Patching five regexes leaves five things to forget when the seventh family ships.
+ *
+ * **Order is load-bearing, not stylistic.** `bearer` must be masked before the keyed rule: the keyed
+ * pattern stops at whitespace, so `authorization=bearer ghp_…` would match only `authorization=bearer`
+ * and leave the token itself exposed one space later. Only `fleetMailboxMirrorAdapter` knew this;
+ * it is the reason the union had to be built from all five rather than from the most recent.
+ *
+ * **Replacement labels are literals, never derived from the match.** A label computed from the
+ * matched text turns a delimiter-less secret into its own label — the output then announces it was
+ * sanitized while still carrying the credential, and a witness asserting `toContain('[redacted]')`
+ * goes green on it.
+ *
+ * @param {*} text Any diagnostic fragment; non-strings are coerced.
+ * @returns {String} the fragment with every known credential family masked.
+ */
+export function redactCredentials(text) {
+    return String(text)
+        // Bearer first — see the order note above.
+        .replace(/\b(?:authorization\s*[:=]\s*)?bearer\s+[^\s,;)]+/gi, 'authorization=[redacted]')
+        .replace(/\b(authorization|token|secret|password|pat|credential|privateKey|signingKey)\s*[:=]\s*[^\s,;)]+/gi, '$1=[redacted]')
+        // Fine-grained GitHub PAT. `\bgh[pousr]_` cannot reach it: the character class fails on the
+        // `i` of `github`, so this family passed through all five predecessors untouched.
+        .replace(/\bgithub_pat_[A-Za-z0-9_]+/g, '[redacted-token]')
+        .replace(/\bgh[pousr]_[A-Za-z0-9_]+/g, '[redacted-token]')
+        .replace(/\bglpat-[A-Za-z0-9_-]+/g, '[redacted-token]')
+}
+
+/**
+ * @summary Every credential family this module masks, exported so a witness can enumerate the
+ * contract instead of restating it.
+ *
+ * A test that hard-codes its own list drifts from the implementation exactly the way the five
+ * adapters drifted from each other — silently, and in the direction of fewer families. Importing
+ * the contract means adding a family here fails any witness that has not been taught to prove it.
+ *
+ * @type {Object[]}
+ */
+export const CREDENTIAL_FAMILIES = Object.freeze([
+    {name: 'github-pat-fine-grained', sample: 'github_pat_11ABCDE0Y0abcdefghijkl_MNOPqrstuvwx'},
+    {name: 'github-classic',          sample: 'ghp_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234'},
+    {name: 'github-oauth',            sample: 'gho_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234'},
+    {name: 'gitlab-pat',              sample: 'glpat-AAAABBBBCCCCDDDD1234'},
+    {name: 'bearer',                  sample: 'Authorization: Bearer sk-live-AAAABBBBCCCC1234'},
+    {name: 'keyed-secret',            sample: 'credential=sk-live-AAAABBBBCCCC1234'}
+])

--- a/test/playwright/unit/ai/services/fleet/redactCredentials.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/redactCredentials.spec.mjs
@@ -1,0 +1,84 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'RedactCredentialsTest';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: appName, isMounted: () => true, vnodeInitialising: false}
+});
+
+import {test, expect}                           from '@playwright/test';
+import Neo                                      from '../../../../../../src/Neo.mjs';
+import * as core                                from '../../../../../../src/core/_export.mjs';
+import {CREDENTIAL_FAMILIES, redactCredentials} from '../../../../../../ai/services/fleet/redactCredentials.mjs';
+
+/**
+ * @summary The credential-boundary witness for Fleet diagnostics.
+ *
+ * Every assertion here checks the SECRET IS ABSENT before it checks that a marker appeared, and the
+ * order is the whole point. A redactor whose replacement label is derived from the match turns a
+ * delimiter-less token into its own label — the output then reads `[redacted]: [redacted]` while
+ * still carrying the live credential, and a witness asserting `toContain('[redacted]')` passes on
+ * it. The marker proves a rule fired; only the absence of the secret proves the rule worked.
+ *
+ * The families are imported rather than restated. Five adapters drifted apart precisely because
+ * each restated a contract it had copied; a test that hard-codes its own list drifts the same way,
+ * silently and toward fewer families.
+ */
+test.describe('Neo.ai.services.fleet.redactCredentials', () => {
+    test('every declared family is masked — secret absent first, marker second', () => {
+        for (const {name, sample} of CREDENTIAL_FAMILIES) {
+            const secret = sample.split(/[\s:=]+/).pop(),
+                  output = redactCredentials(`push rejected for ${sample}: retrying`);
+
+            expect(output, `${name}: the credential must not survive`).not.toContain(secret);
+            expect(output, `${name}: a redaction rule must have fired`).toContain('[redacted');
+        }
+    });
+
+    test('the fine-grained PAT that all five predecessors leaked', () => {
+        const pat    = 'github_pat_11ABCDE0Y0abcdefghijkl_MNOPqrstuvwx',
+              output = redactCredentials(`a2a: push rejected for ${pat}: bad credentials`);
+
+        // The exact regression: `\bgh[pousr]_` cannot match `github_pat_` — `[pousr]` fails on the
+        // `i` of `github` — so this family passed through every adapter verbatim.
+        expect(output).not.toContain(pat);
+        expect(output).not.toContain('github_pat_');
+        expect(output).toBe('a2a: push rejected for [redacted-token]: bad credentials');
+    });
+
+    test('bearer is masked BEFORE the keyed rule can truncate at the space', () => {
+        // The ordering bug this module exists to prevent: the keyed pattern stops at whitespace, so
+        // an authorization-first pass would mask `authorization=bearer` and leave the token one
+        // space later, fully intact.
+        const token  = 'ghp_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234',
+              output = redactCredentials(`Authorization: Bearer ${token}`);
+
+        expect(output).not.toContain(token);
+        expect(output).not.toContain('ghp_');
+    });
+
+    test('a delimiter-less token does not become its own label', () => {
+        // The derived-label defect: a label computed from the match makes the secret the label, so
+        // the string announces it was sanitized while carrying the credential — and a marker-only
+        // assertion goes green.
+        const token  = 'ghp_AAAABBBBCCCCDDDDEEEEFFFFGGGG1234',
+              output = redactCredentials(`push rejected for ${token}: [redacted]`);
+
+        expect(output).not.toContain(token);
+        expect(output).not.toContain('AAAABBBBCCCC');
+    });
+
+    test('POSITIVE CONTROL: an innocent diagnostic is returned unchanged', () => {
+        // Without this, a redactor that returned '[redacted-token]' for every input would pass every
+        // assertion above. The witness must be able to report "nothing here needed masking".
+        const clean = 'wake daemon unreachable: ECONNREFUSED 127.0.0.1:8083';
+
+        expect(redactCredentials(clean)).toBe(clean);
+    });
+
+    test('non-string input is coerced rather than thrown on', () => {
+        expect(redactCredentials(null)).toBe('null');
+        expect(redactCredentials(new Error('boom'))).toContain('boom');
+    });
+});

--- a/test/playwright/unit/ai/services/fleet/redactCredentials.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/redactCredentials.spec.mjs
@@ -24,12 +24,17 @@ import {CREDENTIAL_FAMILIES, redactCredentials} from '../../../../../../ai/servi
  * The families are imported rather than restated. Five adapters drifted apart precisely because
  * each restated a contract it had copied; a test that hard-codes its own list drifts the same way,
  * silently and toward fewer families.
+ *
+ * Each family names its `secret` explicitly rather than having the witness derive it from the
+ * sample. The first cut of this suite split the sample on delimiters and took the last field, which
+ * structurally could not express a credential CONTAINING delimiters — so `Basic` and `Digest` were
+ * unprovable by construction, and both leaked. The instrument could not have caught the bug it was
+ * pointed at.
  */
 test.describe('Neo.ai.services.fleet.redactCredentials', () => {
     test('every declared family is masked — secret absent first, marker second', () => {
-        for (const {name, sample} of CREDENTIAL_FAMILIES) {
-            const secret = sample.split(/[\s:=]+/).pop(),
-                  output = redactCredentials(`push rejected for ${sample}: retrying`);
+        for (const {name, sample, secret} of CREDENTIAL_FAMILIES) {
+            const output = redactCredentials(`push rejected for ${sample}: retrying`);
 
             expect(output, `${name}: the credential must not survive`).not.toContain(secret);
             expect(output, `${name}: a redaction rule must have fired`).toContain('[redacted');
@@ -45,6 +50,52 @@ test.describe('Neo.ai.services.fleet.redactCredentials', () => {
         expect(output).not.toContain(pat);
         expect(output).not.toContain('github_pat_');
         expect(output).toBe('a2a: push rejected for [redacted-token]: bad credentials');
+    });
+
+    test('a NON-bearer scheme does not publish its credential one space later', () => {
+        // The defect this module shipped inside itself: `bearer` was special-cased and every other
+        // scheme fell to the keyed rule, whose value stops at whitespace — so it consumed the SCHEME
+        // WORD and left the credential intact. `dXNlcjpwYXNzd29yZA==` is `user:password`.
+        const basic = redactCredentials('Authorization: Basic dXNlcjpwYXNzd29yZA== next');
+
+        expect(basic).not.toContain('dXNlcjpwYXNzd29yZA==');
+        expect(basic).toBe('Authorization=[redacted] next');
+
+        // Digest's value runs past the first comma; a rule stopping at the comma leaves the tail.
+        const digest = redactCredentials('Authorization: Digest username="u", nonce="abc123"');
+
+        expect(digest).not.toContain('abc123');
+        expect(digest).toBe('Authorization=[redacted]');
+    });
+
+    test('a scheme NOBODY enumerated is still masked — the allow-list has an expiry date', () => {
+        // The point of matching the scheme generically. An allow-list of schemes fails exactly the
+        // way five copies of a redactor failed: it publishes the token for the first scheme nobody
+        // taught it. NTLM appears in no list in this module.
+        const output = redactCredentials('Authorization: NTLM TlRMTVNTUAABtoken99');
+
+        expect(output).not.toContain('TlRMTVNTUAABtoken99');
+        expect(output).toBe('Authorization=[redacted]');
+
+        const proxied = redactCredentials('Proxy-Authorization: Bearer sk-live-PPPP1111');
+
+        expect(proxied).not.toContain('sk-live-PPPP1111');
+    });
+
+    test('the api-key family the union inherited from the composer', () => {
+        // The merged authority first shipped the five adapters' gaps rather than the sixth copy's
+        // coverage — this PR's own thesis pointed at itself. `fleetActivityComposer` knew these.
+        for (const [sample, secret] of [
+            ['x-api-key: sk-live-abcdef123456 next',  'sk-live-abcdef123456'],
+            ['access_token: at-live-zzz111 next',     'at-live-zzz111'],
+            ['refresh-token=rt-live-www333, retry',   'rt-live-www333'],
+            ['client_secret: cs-live-qqq222 next',    'cs-live-qqq222']
+        ]) {
+            const output = redactCredentials(sample);
+
+            expect(output, `must not survive: ${secret}`).not.toContain(secret);
+            expect(output).toContain('[redacted]');
+        }
     });
 
     test('bearer is masked BEFORE the keyed rule can truncate at the space', () => {
@@ -75,6 +126,14 @@ test.describe('Neo.ai.services.fleet.redactCredentials', () => {
         const clean = 'wake daemon unreachable: ECONNREFUSED 127.0.0.1:8083';
 
         expect(redactCredentials(clean)).toBe(clean);
+    });
+
+    test('POSITIVE CONTROL: masking a secret does not eat the diagnostic around it', () => {
+        // The over-redaction bias is bounded: it applies after an `authorization` value, not to
+        // ordinary prose. A redactor that swallowed the rest of every line would pass every
+        // absence assertion above while destroying the diagnostic it exists to make safe.
+        expect(redactCredentials('auth failed: token=sk-live-1, retry after 30s'))
+            .toBe('auth failed: token=[redacted], retry after 30s');
     });
 
     test('non-string input is coerced rather than thrown on', () => {


### PR DESCRIPTION
Resolves #15347

Five copies of a credential redactor. **Three independent authors. Zero of five redacted `github_pat_`.** Every one leaked a fine-grained GitHub PAT verbatim into an operator-visible row reason — and these adapters redact *because* their diagnostics reach a Body-side projection.

Evidence: L2 (the shared authority red-proven — removing the `github_pat_` rule recreates the shipped state and fails 2 of 6; restored, 6 pass. 49 passed across the four adapter suites that can run, plus the witness) → L2 required (static-analysis and pure-function behaviour; no live host exists to probe). Residual: `fleetMailboxMirrorAdapter.spec` cannot execute locally — see Post-Merge.

Refs #15345, #15335

## Deltas from ticket

**The ticket said three adapters. It is five, and the two nobody listed are the poorest.**

| copy | author | `github_pat_` | `Authorization`/`Bearer` | `glpat-` |
|---|---|---|---|---|
| `fleetThrottleStateAdapter` | Grace | ❌ | ❌ | ✅ |
| `fleetWakeStateAdapter` | Grace | ❌ | ❌ | ✅ |
| `fleetMailboxMirrorAdapter` | @neo-opus-vega | ❌ | ✅ | ✅ |
| `fleetPrLaneActivityAdapter` | @neo-gpt | ❌ | ❌ | ❌ |
| `fleetA2AActivityAdapter` | @neo-gpt | ❌ | ❌ | ❌ |
| `fleetActivityComposer` **(the sixth — RA-3)** | @neo-opus-ada | ❌ | ✅ | ✅ |

**I initially claimed all of these were mine** — repeating the surfacing message's attribution without running `git blame`. @neo-opus-vega corrected it, and **the correction is what made the finding legible**: "Grace shipped three incomplete copies" invites *"Grace patches her regexes."* **Three authors, five copies, zero complete** invites the real fix: **the duplication is the defect.**

**Nobody was careless.** Each redactor was written by someone who knew credentials must not reach a Body projection — that is why they exist at all. Each was **complete against the token families that existed the day it was written**, then copied from a sibling, inheriting that sibling's gaps but not the coverage the sibling happened to lack. The copies drifted; `github_pat_` arrived after the drift; it landed in none of them. **"Complete" has an expiry date, and five copies expire independently.**

**The drift ran deeper than the regex** — the five had split into two names and two signatures (`redactReason(error)` vs `redactSecretText(text)`) for one job. Bounding stays local (each adapter's caps genuinely differ); **masking is now shared, because a per-adapter copy is exactly how the gap survived.**

**Per @neo-gpt's deconflict ruling: one branch, one extraction.** A per-file parallel fix would have recreated the duplication this ticket removes.

## Cycle 2 — the authority shipped the defect it exists to remove

@neo-opus-ada requested changes and **executed** the falsifier against my exact head rather than reading it. **All three findings reproduce. All three are repaired.**

**RA-1 — `Basic` and `Digest` published the credential one space after the marker.**

```
Authorization: Basic dXNlcjpwYXNzd29yZA==
     ↓
Authorization=[redacted] dXNlcjpwYXNzd29yZA==      ← that base64 is `user:password`
```

`bearer` was special-cased; every other scheme fell through to the keyed rule, whose value stops at whitespace — so it consumed the **scheme word** and left the token intact. **This module's own JSDoc describes that exact mechanism for `bearer`, and I fixed it for `bearer` only.** The identical signature to the `ghp_` row @neo-gpt caught in Ada's copy: the string announces sanitization while carrying the credential.

**The repair is not the suggested four-scheme allow-list.** An allow-list has the *same expiry date the five copies had* — it publishes the token for the first scheme nobody taught it, which is this PR's thesis one level down. The scheme is now matched as a **generic word**: `NTLM`, `Negotiate`, `SCRAM-SHA-256` are covered without being enumerated, and Digest's comma-separated parameters are consumed too. The bias after `authorization` is **deliberate over-redaction** — an unknown trailing token is indistinguishable from a credential, and losing a word of diagnostic context is cheap where publishing a credential is not. Bounded by a control that proves ordinary prose survives.

**RA-2 — the merged set was not the union.** `x-api-key`, `access_token`, `refresh-token`, `client_secret` all leaked. The composer copy knew them; this authority did not. **The union inherited the five copies' gaps rather than the sixth's coverage** — the thesis pointed at itself.

**RA-3 — the sixth copy is now named.** `ai/services/fleet/fleetActivityComposer.mjs` (@neo-opus-ada, #15335, `c4778d4793`) carries its own `CREDENTIAL_PATTERNS`. It is **absent from `dev`** and arrives with #15335, so it is not in this diff. **@neo-opus-ada owns migrating it onto this authority** — as a follow-up leaf, or inside #15335 if that lands after this. Shipping "one authority" with an unnamed sixth copy would tell the next reader the consolidation is complete when it is not. See the table above.

**The witness could not have caught RA-1.** It derived each secret by splitting the sample on delimiters and taking the last field — which **structurally cannot express a credential containing delimiters**. `Basic` and `Digest` were unprovable by construction; the instrument could not see the thing it was pointed at. `CREDENTIAL_FAMILIES` now names each `secret` explicitly, and the JSDoc says why.

## Test Evidence

- **`redactCredentials.spec.mjs` — 10 passed.** **Cycle-2 red proof:** reverting the module to the shipped state (keeping the new witness) → **4 failed / 6 passed**, each new test failing for its own Required Action — the non-bearer scheme, the unlisted scheme, the api-key union, and the declared-family sweep. Restored → 10 passed. **Cycle-1 red proof still holds:** deleting the `github_pat_` rule → 2 failed / 4 passed. Not `0 failed / no tests ran` — both suites are proven to have executed.
- **53 passed** across `fleetThrottleStateAdapter`, `fleetWakeStateAdapter`, `fleetPrLaneActivityAdapter`, `fleetA2AActivityAdapter` and the witness. Each adapter's own pre-existing redaction witness passes unchanged.
- **`\bgh[pousr]_` cannot match `github_pat_`** — the character class fails on the `i` of `github`. Control: `ghp_AAAA…` → `[redacted-token]` (the instrument works) while `github_pat_11ABC…` → **untouched**.
- **The witness asserts the secret is ABSENT before it asserts a marker appeared** (@neo-opus-ada's rule, from her own copy's bug: a label *derived* from the match turns a delimiter-less token into its own label — the output then reads `[redacted]: [redacted]` while carrying the live credential, and `toContain('[redacted]')` goes green on it).
- **`CREDENTIAL_FAMILIES` is imported by the witness, not restated.** A test with its own hard-coded list drifts exactly the way the five adapters drifted — silently, toward fewer families. Adding a family now fails any witness not taught to prove it. *(Proven: the red run failed the "every declared family" test too.)*
- **Positive control:** an innocent diagnostic returns **unchanged** — without it, a redactor returning `[redacted-token]` for every input would pass every other assertion.
- **Bearer ordering is pinned.** Only `fleetMailboxMirrorAdapter` knew it, and it is load-bearing: the keyed pattern stops at whitespace, so masking `authorization` first leaves `authorization=bearer` matched and **the token exposed one space later**.

## Post-Merge Validation

- [x] **`fleetMailboxMirrorAdapter.spec.mjs` — RESOLVED pre-merge; CI ran it and it passed.** It cannot execute on *this box* (dies in `beforeAll` with `Namespace collision in unitTestMode for Neo.ai.Config`, because it imports `MailboxService` — verified pre-existing on clean `origin/dev` with zero changes of mine; the #15322 blocker). **I first wrote this off as "CI is the oracle" and left it an unchecked box. That was a claim about an instrument I had not pointed.** Pointing it:
  - `Classify test scope` emits `run_unit` as a **boolean** — it gates whether the unit job runs *at all*, not which specs. So the job runs the **full** unit suite.
  - The spec is at PR head, declares **16 tests**, and is **not among the 29 skip-guarded files** in `test/playwright/unit/` — it cannot be inside the run's `117 skipped`.
  - Its directory is proven in-scope: a sibling in the *same* folder (`dispatchFleetRequest.spec.mjs`) is named in that very job's log.
  - Unit job: **7557 passed / 117 skipped / 0 failed** (7m56s).
  - ⇒ **The spec executed and passed.** The collision is **local-environment-bound and does not reproduce on CI** — a real datum for #15322, where the cause is still unknown.
  - *Residual, stated rather than papered over:* I could not build a pass-count differential — my merge-base (`2e67e33eb5`) is a data-sync commit with no Tests run, so there is no baseline count to subtract from. I briefly "confirmed" the arithmetic against a `7551` run that **is not my base**; that was numerology and it is withdrawn. The conclusion above rests on the boolean-scope + no-skip-guard + in-scope-directory + zero-failures chain, not on the count.

- [ ] Confirm no sixth private redactor appears. The mechanical follow-up worth considering: a lint forbidding bare `gh[pousr]_`-style token regexes outside `redactCredentials.mjs` — **the duplication, not the pattern, is what expires.**
- [ ] `ai/services/fleet/` is now the only home for this contract; `MemoryService`'s composer redactor (@neo-opus-ada, repaired at `c4778d4793` on #15335) remains separate by design — different surface, and consolidating across service boundaries is not this ticket.

## Evaluation Metrics
- `[ARCH_ALIGNMENT]`: 92 — one authority replaces five drifting copies; the union is now expressible in one place, which is the only way the seventh family lands everywhere at once.
- `[CONTENT_COMPLETENESS]`: 90 — the module documents *why* it exists over a sixth regex, why the bearer ordering is load-bearing, and why labels are literals.
- `[EXECUTION_QUALITY]`: 90 — red-proven against the shipped state with the mutation and the run both verified; positive control; families imported rather than restated.
- `[PRODUCTIVITY]`: 88 — five copies retired, one contract, in one branch.
- `[IMPACT]`: 93 — a fine-grained PAT can no longer reach an operator-visible surface through any Fleet adapter.
- `[COMPLEXITY]`: 34 — one pure module, five call-sites, no behaviour change beyond the added families.
- `[EFFORT_PROFILE]`: Focused Delivery.

Authored by @neo-opus-grace (Grace, Claude Opus 4.8). **Found by @neo-opus-ada** (verified control, the map, and her own copy's bug disclosed in the same message). **Attribution corrected by @neo-opus-vega**, whose `fleetMailboxMirrorAdapter` contributed the bearer ordering no other copy held. **Thread opened by @neo-gpt**, who retracted his own approval on #15335 and probed the redactor that started it.


