### PR TITLE
fix(ai): restore CodeQL coverage — a statement-initial import.meta dropped the whole file (#15353)

### DIFF
--- a/ai/scripts/benchmark/serving-cost-meter.mjs
+++ b/ai/scripts/benchmark/serving-cost-meter.mjs
@@ -88,7 +88,7 @@ export function resolveWindowLifecycle(startedAt, windowMs, observedEndMs) {
     }
 
     return {
-        interrupted: observedEndMs < requestedEndMs,
+        interrupted : observedEndMs < requestedEndMs,
         observedEndMs,
         windowBounds: {endMs: requestedEndMs, startMs: startedAt}
     }
@@ -305,8 +305,16 @@ async function main() {
     console.log(`[serving-cost-meter] ${report.metricBags.length} schema-valid metric bags emitted (ingestion is the tenant path's job).`)
 }
 
-// commander parses only when executed directly — importing the pure helpers above never runs a sample
-import.meta.url === `file://${process.argv[1]}` && main().catch(error => {
-    console.error(`[serving-cost-meter] ${error.message}`);
-    process.exit(1)
-});
+// commander parses only when executed directly — importing the pure helpers above never runs a sample.
+// The test is hoisted to a const rather than opening the statement: CodeQL's extractor cannot parse a
+// statement-initial `import.meta` (it is ambiguous with an import declaration until the `.`), and a
+// parse failure drops the WHOLE file from analysis — 312 unscanned lines reported as one warning on a
+// settings page, while the PR check still says `pass`. Node parses either form; only one gets scanned.
+const isDirectRun = import.meta.url === `file://${process.argv[1]}`;
+
+if (isDirectRun) {
+    main().catch(error => {
+        console.error(`[serving-cost-meter] ${error.message}`);
+        process.exit(1)
+    });
+}


### PR DESCRIPTION
Resolves #15353

**CodeQL has not scanned this file at all since 2026-07-11. Six days, 312 lines, zero coverage — reported as a warning on a settings page nobody opens, while the PR check said `pass`.**

Evidence: L2 (a pure syntax/idiom change; behaviour verified by execution both ways — no live host exists to probe) → **L4 required for the real AC**: only a CodeQL run on `dev` can prove the extractor recovered, and that is a post-merge push-triggered scan. Residual: the coverage AC [#15353].

Refs #15310

## Deltas from ticket

None. The ticket's diagnosis held under execution.

## The defect

@tobiu surfaced it from **Settings → Advanced Security → Code scanning**: *"Could not process some files due to syntax errors"* → [`serving-cost-meter.mjs#L309`](https://github.com/neomjs/neo/blob/dev/ai/scripts/benchmark/serving-cost-meter.mjs#L309).

```js
import.meta.url === `file://${process.argv[1]}` && main().catch(error => {
```

`import.meta` in **statement-initial** position is ambiguous with an `import` declaration until the parser reaches the `.`. CodeQL 2.26.0's extractor (`codeql/javascript-all` 2.8.0) fails there. **`node --check` does not.**

**A parse failure is not a skipped line — the extractor drops the whole compilation unit.** All 312 lines / 14,061 bytes unanalyzed since `ba6645acdf` (2026-07-11) — **my commit**.

**The position is the cause, with a clean discriminator:**

| pattern | files | parse error |
| --- | ---: | ---: |
| `import.meta` **statement-initial** (`^\s*import\.meta`) | **1** | **1 of 1** |
| `import.meta` anywhere else | **226** | **0 of 226** |

Not an `import.meta` incompatibility. One shape, one file, one total blackout.

## The fix

Hoist the test out of statement-initial position. Semantics identical; the `&&`-expression idiom is what forced `import.meta` to the front.

## Test Evidence

Behaviour proven **by execution**, not by reading — the AC is behavioural:

```
node --check                      -> OK
rg -c "^\s*import\.meta"          -> 0        (the extractor trigger is gone)
import the module                 -> 6 exports, NO sample ran
node serving-cost-meter.mjs --help-> reaches main(); commander prints usage
```

Both halves of the `:308` contract still hold: *"commander parses only when executed directly — importing the pure helpers above never runs a sample."*

## Post-Merge Validation

- [ ] **The real AC, and it can only run post-merge:** CodeQL scans on push to `dev`. After merge, the Code scanning page must report the `Could not process some files due to syntax errors` warning **cleared**, and the file must appear in the analysis. **The local checks above prove the trigger is gone — they do not prove the extractor recovered.** Those are different claims and only the next `dev` scan settles the second. **Read the discriminating surface, not `analyses[].warning`:** that field is empirically empty even when the extractor drops a file — a `dev` run (`29568877624`) logs `Could not process some files due to syntax errors` at 09:11:17 and uploads `warning: ""` one second later (verified by @neo-fable-clio). The signals that actually move when the extractor recovers are the **Analyze-job log** diagnostic group and the **Code-scanning tool-status page** (`/security/code-scanning/tools`); `analyses[].warning` does not, so it cannot settle this AC.

## Reintroduction guard — dispositioned, and the answer is NOT a narrow lint

The ticket's AC required this be decided rather than skipped.

**Rejected — a `^\s*import\.meta` pattern check.** It would be a guard scoped to the single instance a reviewer demonstrated, which is precisely the failure mode this repo spent last night cataloguing: *every fix correct, every fix scoped to the instance someone had just shown me.* **The next extractor gap will not be `import.meta`.** A guard that only catches the bug we already fixed is the fifth redactor.

**Rejected — `check-parse.mjs`, the obvious home.** Our own commit-time parse gate is **blind to this by construction**: it asks `node --check`, and node accepts the shape. **Two parse gates, two parsers, one blind spot each.** It cannot be taught this without becoming a second CodeQL.

**Correct, and filed as [#15370](https://github.com/neomjs/neo/issues/15370) — fail on the PROCESSING WARNING, not the pattern.** The gate must read the **Analyze-job log diagnostic / tool-status page**, not `analyses[].warning` (empirically empty even when a file is dropped — see Post-Merge Validation above). That is general: it catches every future extractor gap, not this one. **It is also a real gap in the gate that landed tonight** — ruleset `19087298` (`code_scanning`, `security_alerts_threshold: medium_or_higher`) gates **alerts**, and *an unparseable file produces no alerts*, so it clears every threshold cleanly. **Unparseable and clean are indistinguishable to every gate we have.** That belongs in its own lane with its own design; this PR's scope is the defect.

## Evaluation Metrics
- `[ARCH_ALIGNMENT]`: 88 — restores a scanner invariant the repo already relies on; no new surface, no new authority.
- `[CONTENT_COMPLETENESS]`: 90 — the comment states why the idiom is banned here, so the next author does not "simplify" it back.
- `[EXECUTION_QUALITY]`: 86 — behaviour proven by execution in both directions; the 1-vs-226 discriminator pins the cause rather than the correlation.
- `[PRODUCTIVITY]`: 92 — one line, six days of coverage back.
- `[IMPACT]`: 84 — a 312-line file re-enters security analysis; the class (silent total blackout) is named for the next reader.
- `[COMPLEXITY]`: 8 — an idiom change.
- `[EFFORT_PROFILE]`: Focused Delivery.

Authored by @neo-opus-grace (Grace, Claude Opus 4.8). **Surfaced by @tobiu**, who read the page the rest of us never opened.
