### PR TITLE
feat(ci): the stacked-PR guard — a foreign commit is invisible to every gate but the commit list (#15352)

### DIFF
--- a/.github/workflows/agent-pr-body-lint.yml
+++ b/.github/workflows/agent-pr-body-lint.yml
@@ -97,6 +97,78 @@ jobs:
                 : "`Resolves #N` (mandatory closing keyword — `Refs`/`Related` alone is NOT sufficient)");
             }
 
+            // ──────────────────────────────────────────────────────────────────────
+            // Stacked-PR guard (#15352). A PR branched off another feature branch —
+            // rather than `dev` — carries that branch's commits. It is INVISIBLE to
+            // every other gate: GitHub computes the file diff from the merge-base, so
+            // the reviewed surface is correct; CI is green (the code is fine, it is
+            // just someone else's, in this PR); and this body lint's own `Resolves`
+            // check passes (the body is honest about intent). The foreign commits
+            // surface ONLY in the Commits tab, which reviewers do not read.
+            //
+            // The signal is the TICKET a commit claims, never a count: a legitimate PR
+            // has many commits and a stacked one can have two. Every commit's trailing
+            // `(#K)` must be a ticket this PR's body declares (`Resolves`/`Refs`/
+            // `Related`). A commit with no `(#K)` suffix is the ticket gate's business,
+            // not this one's — skipped here.
+            const declaredTickets = new Set(
+              [...body.matchAll(/\b(?:Resolves|Refs|Related):?\s+#(\d+)/gi)].map(m => m[1])
+            );
+
+            const foreignCommits = [];
+
+            if (declaredTickets.size > 0) {
+              const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner: context.repo.owner, repo: context.repo.repo, pull_number: pr.number, per_page: 100
+              });
+
+              for (const c of commits) {
+                const subject = (c.commit.message || "").split("\n")[0];
+                const ticket  = subject.match(/\(#(\d+)\)\s*$/);
+                // no ticket suffix → ticket gate's concern, not the stacking check
+                if (ticket && !declaredTickets.has(ticket[1])) {
+                  foreignCommits.push({ sha: c.sha.slice(0, 10), ticket: ticket[1], subject: subject.slice(0, 72) });
+                }
+              }
+            }
+
+            if (foreignCommits.length > 0) {
+              const declaredList = [...declaredTickets].map(t => `#${t}`).join(", ");
+              const rows = foreignCommits.map(c => `- \`${c.sha}\` claims **#${c.ticket}** — \`${c.subject}\``).join("\n");
+              const stackedBody = [
+                `## 🚨 Stacked-PR Guard: foreign commits in PR #${pr.number}`,
+                ``,
+                `@${author} — this PR's commit list contains ${foreignCommits.length} commit(s) for ticket(s) its body does not declare.`,
+                `The body declares ${declaredList}. The commits below claim other tickets:`,
+                ``,
+                rows,
+                ``,
+                `**This almost always means the branch was cut from another feature branch instead of \`dev\`** — a`,
+                `\`git checkout dev\` that failed silently (e.g. \`dev\` is checked out in a worktree, or an uncommitted-file`,
+                `block), so the new branch inherited the wrong base. The file diff renders correctly against the`,
+                `merge-base, so nothing else catches it — only the commit list does.`,
+                ``,
+                `**Fix:** \`git rebase --onto origin/dev <wrong-base> <this-branch>\`, verify \`git rev-list --count origin/dev..HEAD\``,
+                `equals only your commits, then \`git push --force-with-lease\`. Verify the BASE, not the branch name.`,
+                ``,
+                `<sub>Resolves #15352. A body may legitimately declare multiple tickets (\`Resolves\` + \`Related:\`); if one`,
+                `of the commits above belongs here, add its ticket as a \`Related: #N\` reference.</sub>`
+              ].join("\n");
+
+              if (context.payload.action === "opened") {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number, body: stackedBody
+                });
+              }
+
+              core.setFailed(
+                `PR #${pr.number} carries ${foreignCommits.length} foreign commit(s) — ` +
+                foreignCommits.map(c => `${c.sha} (#${c.ticket})`).join(", ") +
+                `. Body declares ${declaredList}. Likely branched off a feature branch, not dev. See follow-up comment.`
+              );
+              return;
+            }
+
             if (missingVisible.length === 0 && missingInvisible.length === 0) {
               console.log("✅ PR body contains all required anchors.");
               return;


### PR DESCRIPTION
Resolves #15352
Related: #13652, #15340

## Summary

**A stacked PR — one branched off another feature branch instead of `dev` — is invisible to every gate except the commit list, which nobody reads.**

I shipped one tonight. PR #15349 opened with **8 commits, 7 belonging to #15342**, because `git checkout dev` **failed silently** (`dev` is checked out in a worktree, so it can never succeed there), `&&` short-circuited, and the branch was cut from the feature branch I was already on. @neo-opus-vega found it by reading the Commits tab. **Nothing else would have.**

Why it's silent everywhere:
- **The file diff:** correct by construction — GitHub computes it from the merge-base.
- **CI:** green — the code is fine; it is just *someone else's code, in this PR*.
- **The body lint's `Resolves` check:** passes — the body is honest about *intent*.
- **Review:** passes — the reviewer reads the right diff.

The cost: the PR silently inherits another PR's fate. On mine it also produced a **false merge-order constraint** broadcast to the operator during a live merge window (*"merge #15342 before #15349"*), void the moment I rebased.

Evidence: L2 (the predicate falsified against #15349's exact shape + run against all 17 live open agent PRs) → L2 required for a mechanical CI guard. No residuals.

## The Fix

One added check in the **existing** `agent-pr-body-lint.yml` — it already runs on `pull_request`, scopes to agent authors, parses the body's ticket refs, and holds `github.rest` + `core.setFailed`. **One API call (paginated `listCommits`), no new workflow** — a second workflow would be the substrate bloat the MX loop exists to prevent.

The signal is the **ticket a commit claims, never a count**: a legitimate PR has many commits and a stacked one can have two. Every commit's trailing `(#K)` must be a ticket the body declares (`Resolves`/`Refs`/`Related`). A commit with no `(#K)` suffix is the ticket gate's business, skipped here.

## Deltas

| Area | Before | After |
|---|---|---|
| `agent-pr-body-lint.yml` | validates body anchors + `Resolves` | + collects declared tickets, paginates `listCommits`, fails on any commit claiming an undeclared ticket |
| Failure surface | anchor-miss comment | a distinct comment naming the **foreign SHAs + ticket ids** and the `rebase --onto origin/dev` fix |

## Test Evidence

The check is a `github-script` inline block with no unit harness, so the predicate was extracted and falsified directly:

```
AC-1  #15349's exact original shape (body: Resolves #15325; commits carry #15273) → 2 foreign flagged
AC-2  run against ALL 17 currently-open agent PRs                                  → 0 false positives
        (#15343 declares no ticket → skipped, exactly as the lint does)
AC-3  multi-ticket body (Resolves #15325 + Related #15294) accepts commits for both → 0 foreign
AC-4  a commit with no (#K) suffix ("chore: ticket sync [skip ci]")                → no crash, out of scope
```

The `(#\d+)\s*$` anchor was checked on the cases that would make it wrong:
- `fix(#15273 regression) in thing` → **null** (a mid-subject ref must not match; only the trailing ticket)
- `Revert "feat (#100)" (#15273)` → **15273** (the outer trailing ticket, not the inner)

## Acceptance Criteria — checked against the diff

- [x] A commit claiming a ticket the body does not declare **fails**, naming the SHA(s) + foreign ticket id(s) — verified on #15349's shape.
- [x] A correctly-based PR passes — **zero false positives across all 17 live open agent PRs**.
- [x] A multi-ticket body (`Resolves` + `Related`) accepts commits for both.
- [x] A commit with no `(#TICKET)` suffix does not crash and is out of scope.
- [x] Non-agent / unlabeled PRs skip, exactly as the existing lint does (unchanged gate).
- [x] One API call, in the existing workflow — no new workflow file.

## Post-Merge Validation

- The next agent PR branched off a feature branch fails at open, naming the foreign commits — instead of surfacing as a false merge-order constraint in someone's window.
- Reopen trigger: a stacked PR that passes this check (a foreign commit whose ticket the body happens to also declare — acceptable by design), or a false positive on a correctly-based PR.
- **Scope note:** this catches the defect at the PR boundary, where the declared tickets exist. The `git` UX that causes it (`checkout && pull` failing silently) is a local-discipline problem a push-time hook cannot see, and is out of scope; the memory entry and `git switch -c <new> origin/dev` cover the authoring side.

## Out of Scope

- The sibling `check-commit-authorship` (#15340) — same family (silent at every gate, loud only in someone's merge), different fact.
- Deliberate stacked-PR workflows, if ever adopted — this fails them loudly, the correct default until we decide otherwise.
- A commit-count ceiling — a rename nets to zero and legitimate PRs have many commits.

Authored by @neo-opus-ada (Claude Opus 4.8)
