### PR TITLE
fix(memory-core): a broadcast mark never denies from a projection it hasn't reconciled against WAL truth (#15322)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -2161,6 +2161,32 @@ class MailboxService extends Base {
             return { messageId, readAt, status: 'read' };
         }
 
+        // A broadcast recipient with no visible delivery edge is the one state where the projection is
+        // least likely to be telling the truth. The cheap check above (`getCachedMessageProjectionIssues`)
+        // has no DELIVERED_TO term, so a damaged per-recipient edge never triggered a repair — and
+        // denying here purely because OTHER recipients' edges survive would refuse a legitimate audience
+        // member: their own missing edge plus a peer's surviving edge reads as "not a recipient", and the
+        // healthier everyone else's edges are, the more confidently the real recipient is turned away.
+        // Never deny authorization from a projection not reconciled against durable truth. This repair
+        // is scoped to the single message (`ids`), pays no WAL read on the happy path above, and uses
+        // the WAL-backed, DELIVERED_TO-aware projection check: a recipient in the send-time audience
+        // snapshot gets their edge rebuilt from the WAL; one who never was (registered after send) gets
+        // nothing, and the denial below then correctly stands on WAL truth rather than cache staleness.
+        if (isBroadcastRecipient) {
+            await this.repairMessageGraphIntegrity({ids: [messageId], limit: 1});
+            db.getAdjacentNodes(messageId, 'both');
+
+            const repairedEdge = getBroadcastDeliveryEdge(messageId, me);
+
+            if (repairedEdge) {
+                const readAt = new Date().toISOString();
+
+                await setDeliveryEdgeReadAt(repairedEdge, readAt);
+
+                return { messageId, readAt, status: 'read' };
+            }
+        }
+
         if (isBroadcastRecipient && hasBroadcastDeliveryEdges(messageId)) {
             throw new Error(`Unauthorized: you are not the recipient of message ${messageId}`);
         }

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -870,6 +870,71 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         }
     });
 
+    test('#15322 a broadcast recipient whose OWN delivery edge is damaged is repaired, not denied because peers survive', async () => {
+        // Two recipients registered BEFORE the broadcast, so the send-time audience snapshot includes
+        // both and each gets a per-recipient DELIVERED_TO edge.
+        GraphService.upsertNode({id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'}});
+        GraphService.upsertNode({id: '@dana',    type: 'AgentIdentity', name: 'Dana',    properties: {accountType: 'agent'}});
+
+        const {messageId} = await RequestContextService.run({agentIdentityNodeId: '@alice'}, () =>
+            MailboxService.addMessage({to: 'AGENT:*', subject: 'broadcast to the herd', body: 'delivery edges per recipient'})
+        );
+
+        // Damage ONLY @charlie's DELIVERED_TO edge — storage AND cache, so `getAdjacentNodes` cannot
+        // lazily heal it before the mark resolves. autoSave stays on (the damage must echo to storage);
+        // this is the read-path repair lane's storage-damage instrument, narrowed to a single recipient.
+        const charlieEdges = GraphService.db.edges.items.filter(edge =>
+            edge.source === messageId && edge.type === 'DELIVERED_TO' && /charlie/i.test(String(edge.target))
+        );
+        // Control 1: the damage target exists. A scenario that damages nothing proves nothing.
+        expect(charlieEdges.length, 'charlie must have a delivery edge to damage').toBe(1);
+        GraphService.db.edges.remove(charlieEdges);
+        GraphService.db.vicinityLoadedNodes.clear();
+        GraphService.db.lastAccessMap.clear();
+
+        // Control 2: a PEER's edge survives. That surviving edge is exactly what makes
+        // `hasBroadcastDeliveryEdges` true and drives the false denial — without it, the branch that
+        // throws would never be reached and the test would pass for the wrong reason.
+        const survivingPeer = GraphService.db.edges.items.filter(edge =>
+            edge.source === messageId && edge.type === 'DELIVERED_TO' && /dana/i.test(String(edge.target))
+        );
+        expect(survivingPeer.length, "dana's edge must survive — the false-denial precondition").toBe(1);
+
+        // The defect: @charlie is a legitimate audience member, but her edge is missing from the
+        // projection while @dana's survives, and the cheap projection check has no DELIVERED_TO term,
+        // so no repair fires. markRead then throws `Unauthorized`. A mark must never deny authorization
+        // from a projection it has not reconciled against durable WAL truth.
+        const result = await RequestContextService.run({agentIdentityNodeId: '@charlie'}, () =>
+            MailboxService.markRead({messageId})
+        );
+
+        expect(result).toMatchObject({messageId, status: 'read'});
+        expect(result.readAt).toBeTruthy();
+
+        // The mark must land on the RESTORED per-recipient edge, not the shared MESSAGE node — writing
+        // the latter is the cross-recipient read-state collapse this lane also exists to prevent.
+        const restored = GraphService.db.edges.items.find(edge =>
+            edge.source === messageId && edge.type === 'DELIVERED_TO' && /charlie/i.test(String(edge.target))
+        );
+        expect(restored, 'charlie edge rebuilt from the WAL').toBeTruthy();
+        expect(restored.properties?.readAt, 'mark landed on the restored per-recipient carrier').toBeTruthy();
+    });
+
+    test('#15322 a broadcast non-recipient registered AFTER send still fails closed — repair rebuilds only the snapshot', async () => {
+        const {messageId} = await RequestContextService.run({agentIdentityNodeId: '@alice'}, () =>
+            MailboxService.addMessage({to: 'AGENT:*', subject: 'send-time audience only', body: 'no retroactive membership'})
+        );
+
+        // Registered AFTER the broadcast, so never in the WAL audience snapshot: repair must NOT invent
+        // a delivery edge, and the denial must stand — the fix reconciles against truth, it does not
+        // authorize everyone who asks.
+        GraphService.upsertNode({id: '@late', type: 'AgentIdentity', name: 'Late', properties: {accountType: 'agent'}});
+
+        await expect(RequestContextService.run({agentIdentityNodeId: '@late'}, () =>
+            MailboxService.markRead({messageId})
+        )).rejects.toThrow(/Unauthorized: you are not the recipient/);
+    });
+
     test('#15027 persisted family aliases stay fail-closed instead of changing meaning with the roster', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
             await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});


### PR DESCRIPTION
Resolves #15322

A broadcast recipient whose **own** `DELIVERED_TO` edge is missing from the local projection — while **another recipient's edge survives** — was thrown `Unauthorized: you are not the recipient`. **The healthier everyone else's delivery edges are, the more confidently the real recipient is turned away** — silently and permanently, because the repair that would rebuild the edge never ran.

Evidence: L2 (pure-logic authorization + repair-path reconciliation; red-proof + fail-closed guard added) → L2 sufficient (no runtime host; the ACs are unit-expressible). Residual: local execution blocked by the `Neo.ai.Config` namespace collision that kills every `MailboxService`-importing spec on this box (local-only, verified on #15348) — **CI is the oracle.**

Refs #15321, #15253, #13891

## The defect

#15321 gave `markRead` a cheap projection repair, but its predicate `getCachedMessageProjectionIssues` has **no `DELIVERED_TO` term**. So for a damaged per-recipient broadcast edge:

```
getCachedMessageProjectionIssues(id) → []           ← no DELIVERED_TO term ⇒ NO repair
getBroadcastDeliveryEdge(id, @charlie) → null       ← charlie's edge is gone
isBroadcastRecipient → true                         ← SENT_TO → AGENT:* intact
hasBroadcastDeliveryEdges(id) → TRUE                ← because DANA's edge survived (recipient-agnostic)
⇒ throw "Unauthorized: you are not the recipient"
```

`hasBroadcastDeliveryEdges` is recipient-**agnostic**; `getBroadcastDeliveryEdge(id, me)` is recipient-**specific**. The gap between them is the bug: charlie's *missing* edge plus dana's *present* edge reads as "charlie is not a recipient."

## The fix — never deny from a projection not reconciled against durable truth

The `isBroadcastRecipient && !deliveryEdge` state is the one place the projection is least likely to be honest. Only there, reconcile against the WAL before denying:

```js
if (isBroadcastRecipient) {
    await this.repairMessageGraphIntegrity({ids: [messageId], limit: 1});   // scoped to ONE message
    db.getAdjacentNodes(messageId, 'both');
    const repairedEdge = getBroadcastDeliveryEdge(messageId, me);
    if (repairedEdge) { /* mark the restored per-recipient edge, return read */ }
}
```

`repairMessageGraphIntegrity` uses the **WAL-backed, `DELIVERED_TO`-aware** `getMessageGraphProjectionIssues` (it emits `missing-delivered-to:${recipient}` per audience member). So a recipient in the **send-time audience snapshot** gets their edge rebuilt from the WAL and marked; one who never was (registered after send) gets nothing, and the denial then **correctly** stands on WAL truth rather than cache staleness.

## Deltas from ticket

The ticket's body framed the defect as a *read-state reversion* (a mark succeeds, then reverts to unread). Investigation on the merged #15321 head found the sharper, worse failure is a **false denial** — a legitimate recipient is refused outright, not merely reverted. The #15322 body was updated with the exact trace and the narrowed fix before this PR; this diff implements that update, not the original prescription.

## Test Evidence

- **Red proof:** `#15322 ... repaired, not denied because peers survive` — fails against the shipped denial branch (`markRead` throws `Unauthorized`), passes with the fix. Two controls: (1) the damage target exists (a scenario damaging nothing proves nothing), (2) a **peer's** edge survives (the precondition that makes `hasBroadcastDeliveryEdges` true — without it the throwing branch is never reached and the test would pass for the wrong reason). It asserts the mark lands on the **restored per-recipient edge**, not the shared `MESSAGE` node (writing the latter is the cross-recipient read-state collapse this lane also prevents).
- **Fail-closed guard:** `#15322 ... a broadcast non-recipient registered AFTER send still fails closed` — proves the fix reconciles against truth, it does not authorize everyone who asks. Passes both before and after; it is a regression guard, not a red proof.
- **Instrument reuse:** builds on @neo-opus-ada's storage-damage helper (merged #15321), narrowed to one recipient — autoSave on, storage + cache, no preceding read, so the mark cannot lazily heal before it resolves.
- **Happy path unchanged:** `getBroadcastDeliveryEdge` resolving returns before the repair — no added WAL read on the common case.

## Post-Merge Validation

- [ ] **CI is the oracle** for this spec: `MailboxService.spec.mjs` cannot execute on a local dev box (dies in `beforeAll` on `Namespace collision in unitTestMode for Neo.ai.Config`, reproduced on clean `dev`, local-environment-bound per #15348). The next CI unit run is the execution proof; confirm the two `#15322` tests appear green and total moved by +2.
- [ ] To see the red proof directly, revert only the `MailboxService.mjs` hunk on a CI run — the `repaired, not denied` test turns red (the shipped branch throws `Unauthorized`).

## Evaluation Metrics
- `[ARCH_ALIGNMENT]`: 90 — the fix sits exactly on the seam #15321 established, reuses its repair machinery, and states the invariant (never deny from an unreconciled projection) rather than special-casing.
- `[CONTENT_COMPLETENESS]`: 88 — the branch documents why this is the one place to pay for truth and why the happy path stays cheap.
- `[EXECUTION_QUALITY]`: 84 — red-proven by construction with two controls + a fail-closed guard; the −16 is honest: I could not execute locally, CI is the first green.
- `[PRODUCTIVITY]`: 88 — a bounded fix on one method; unblocks the correctness half #15321 deliberately deferred.
- `[IMPACT]`: 90 — a silent, permanent false-denial of a legitimate broadcast recipient across the whole A2A mailbox; every peer hits it once a delivery edge drifts.
- `[COMPLEXITY]`: 40 — one branch + one repair call + two tests; the reasoning (recipient-agnostic vs -specific predicates) is the load, not the code.
- `[EFFORT_PROFILE]`: Maintenance — a targeted correctness repair on an existing control.

Authored by @neo-opus-grace (Grace, Claude Opus 4.8). Root cause confirmed with @neo-opus-ada; her #15253 repair path and damage instrument are what this builds on.
