### PR TITLE
fix(ai): record the two hookProjection leaves the parity baseline missed (#15362)

### DIFF
--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -414,6 +414,8 @@
         "healthcheck.chromaProbeTimeoutMs",
         "healthcheck.embeddingWriteCanaryTimeoutMs",
         "healthcheck.remAxisTimeoutMs",
+        "hookProjectionLeaseTtlMs",
+        "hookProjectionRoot",
         "laneLandscapeCensusMaxPages",
         "laneLandscapeCensusPageLimit",
         "laneLandscapeRelationEdgeLimit",


### PR DESCRIPTION
Resolves #15362

Heals the dev-wide unit-shard red: the #15349 leaf-parity baseline (`config-leaf-parity.json`) was generated on the guard branch's pre-rebase state, so #15298's `hookProjectionLeaseTtlMs` + `hookProjectionRoot` — already in its merge ancestry — were missing from the committed snapshot. Every PR whose CI classification triggers the unit shard inherited 3 `lintConfigTemplateSsot.spec.mjs` failures (first billed: PR #15361, a one-file agentos e2e diff). Dev itself LOOKS green because docs-only pushes skip the shard — the red is real on plain dev, verified locally at `635164bdc4`.

The fix is the guard's own prescribed remediation: `node ai/scripts/lint/lint-config-template-ssot.mjs --update-parity`, committed in one commit. The two leaves are deliberate, reviewed surface (PR #15298, merged); recording them is mechanical completion. ADR-0019 gate 10 read: this touches only the lint's baseline artifact, not config resolution — no §3 antipattern surface.

Evidence: L3 (the failing guard executed locally against the real tree, red→green across the exact commit) → L3 required (#15362 ACs are runs of the guard itself). Residual: none.

## Deltas from ticket
None substantive.

## Test Evidence
- Red baseline (plain dev, `635164bdc4`): `npx playwright test test/playwright/unit/ai/scripts/lint/lintConfigTemplateSsot.spec.mjs -c test/playwright/playwright.config.unit.mjs` → **3 failed / 43 passed**, failure naming the exact 2 paths.
- Green at this head (`2a0ae2634c` tree): same command → **46 passed (31.8s)**.
- Snapshot delta audited: exactly `+hookProjectionLeaseTtlMs`, `+hookProjectionRoot` under memory-core — 2 insertions, nothing else.
- Touched surface `ai/scripts/lint`: the spec above IS the surface's coverage.

## Post-Merge Validation
- [ ] The next ai-touching PR's unit shard runs green (the inherited red is gone from the queue).
- [ ] PR #15361's unit shard passes on re-run against merged dev.

## Deltas
None substantive — one generated file, two lines.

Authored by Vega (Claude Fable 5, Claude Code). Session 2dcbf336-4338-4009-82f3-79f1b1d151f1.