### PR TITLE
feat(hooks): the audited clean-terminal acceptance — the one autonomous stop (#15274)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -1,14 +1,21 @@
 #!/usr/bin/env node
 /**
  * @module .claude/hooks/laneStateStopHook
- * @summary Claude Code `Stop` hook — REFUSES every turn-end except a live operator dialogue.
+ * @summary Claude Code `Stop` hook — REFUSES every turn-end except a live operator dialogue or an
+ * audited CLEAN TERMINAL (valid terminal + fully handed-off gates + the session drive-ratchet).
  * DRY-RUN (log-only) by default; ENFORCE via `NEO_LANE_STATE_ENFORCE=1`.
  *
  * Fires at every agent turn-end (the `Stop` event). The decision rule: there is NO valid voluntary
  * stop except a **live operator dialogue** — a turn that directly replied to a genuine human-operator
- * message, where the human takes the next turn (turn-taking, not idling). A "valid" fenced ```lane-state
- * block is a RECORD (the directive's context + the external substance record), NOT a license to stop:
- * declaring a lane and halting is the announce-without-execute idle-out the hook exists to prevent.
+ * message, where the human takes the next turn (turn-taking, not idling) — or the ONE autonomous
+ * edge, a **clean terminal**: a valid lane-state terminal whose named gates ALL await non-self actors,
+ * after ≥2 compliant refused drives already proved the no-hold principle was honored this session
+ * (the drive count is read from the hook's OWN audit log, the self identity from `NEO_AGENT_IDENTITY`
+ * harness wiring — absent wiring keeps the edge inert, fail-closed). Acceptance is audited
+ * (`[clean-terminal]` line + a transcript systemMessage), never silent. Outside that edge a "valid"
+ * fenced ```lane-state block is a RECORD (the directive's context + the external substance record),
+ * NOT a license to stop: declaring a lane and halting is the announce-without-execute idle-out the
+ * hook exists to prevent.
  *
  * Mechanism:
  *  - `operatorInLoop` (the one allow) is determined EXTERNALLY by `isOperatorInLoop`, never
@@ -51,6 +58,7 @@ import {buildDeferenceStopHookDirective,
         classifyPromptingContext,
         decideDeferenceStopHookAction,
         decideStopHookAction,
+        evaluateCleanTerminalAcceptance,
         isOperatorInLoop,
         LANE_STATE_SCHEMA_HINT,
         parseOutcomeToVerdict,
@@ -101,27 +109,57 @@ function auditLog(line) {
 
 /**
  * @summary Pure decision — maps a terminal `verdict` + the mode (`enforcing`) + whether a live human
- * operator prompted this turn (`operatorInLoop`) to the Stop-hook action. The heart of the idle-out
- * mechanism; exported + unit-tested.
+ * operator prompted this turn (`operatorInLoop`) + the adapter-evaluated clean-terminal acceptance
+ * to the Stop-hook action. The heart of the idle-out mechanism; exported + unit-tested.
  *
  * The ONE legitimate voluntary stop is a **live operator dialogue** — this turn directly replied to a
  * genuine human-operator message, so the human takes the next turn (turn-taking, not idling). That is
  * `operatorInLoop`, and it ALWAYS allows. `operatorInLoop` is determined EXTERNALLY (the prompting
  * message type — see the entry `main`), never self-declared, so it cannot be gamed.
  *
- * Every OTHER turn-end is an idle-out. A "valid" lane-state terminal is a declaration, not a license
- * to stop (the announce-without-execute loophole the prior `verdict.valid → allow` branch left open).
- * ENFORCE refuses it (block); DRY-RUN previews it (would-block, the false-positive audit path). The
- * `verdict` no longer gates the action — it only supplies the `reason` for the injected directive and
- * the external substance record. The only autonomous stop is a hard external limit (Claude Code's
+ * The ONE legitimate AUTONOMOUS stop is a **clean terminal** — a valid lane-state terminal on a fully
+ * handed-off board (every named gate awaiting a non-self actor) after the session drive-ratchet proved
+ * the no-hold principle was honored (`evaluateCleanTerminalAcceptance`; the drive count comes from the
+ * hook's OWN audit trail, never the agent's claim). Acceptance emits a `[clean-terminal]` audit line —
+ * the boundary is observable, not silent. Everything else is unchanged: a first valid terminal still
+ * refuses (ratchet), ENFORCE blocks, DRY-RUN previews (would-block), and the `verdict` supplies the
+ * directive `reason`. The remaining autonomous stops are hard external limits (Claude Code's
  * consecutive-block force-override, context-sunset, or an operator halt).
  * @param {{valid: Boolean, reason: String}} verdict
  * @param {Boolean} enforcing
  * @param {Boolean} [operatorInLoop=false] True iff a genuine human-operator message prompted this turn.
+ * @param {{accept: Boolean, reason: String}|null} [cleanTerminal=null] Adapter-evaluated acceptance.
  * @returns {{action: ('allow'|'block'|'would-block'), reason: String}}
  */
-export function decideHookAction(verdict, enforcing, operatorInLoop = false) {
-    return decideStopHookAction(verdict, {enforcing, operatorInLoop, blockInjectionSupported: true});
+export function decideHookAction(verdict, enforcing, operatorInLoop = false, cleanTerminal = null) {
+    return decideStopHookAction(verdict, {enforcing, operatorInLoop, blockInjectionSupported: true, cleanTerminal});
+}
+
+/**
+ * @summary Counts this session's COMPLIANT REFUSED terminals from the hook's own append-only audit
+ * log — the external drive-ratchet source for {@link evaluateCleanTerminalAcceptance}. Every
+ * `BLOCK … : valid lane-state terminal` line is one turn where the agent emitted a fully valid
+ * terminal and the hook refused it anyway (so a real drive followed); the count is therefore
+ * hook-written evidence the agent cannot self-declare. Deference blocks and invalid-terminal blocks
+ * do not count. WOULD-BLOCK (dry-run) lines do not count — no chain formed. Fail-CLOSED: a missing /
+ * unreadable log or an unknown session returns 0, so a broken audit trail can never mint a
+ * stop-license. Exported + unit-tested.
+ * @param {String} sessionId The Stop payload's `session_id`.
+ * @returns {Number}
+ */
+export function countSessionCompliantRefusals(sessionId) {
+    if (!sessionId || sessionId === '?') return 0;
+
+    try {
+        // `] BLOCK (session=` excludes WOULD-BLOCK lines (they read `] WOULD-BLOCK (session=`);
+        // the trailing comma pins the exact session id (no prefix collisions between ids).
+        const needle = `] BLOCK (session=${sessionId},`;
+
+        return fs.readFileSync(LOG_FILE, 'utf8').split('\n')
+            .filter(line => line.includes(needle) && line.includes(': valid lane-state terminal')).length;
+    } catch {
+        return 0;
+    }
 }
 
 // The curated no-hold-state directive injected on a block. References the always-loaded
@@ -285,23 +323,59 @@ export function formatGoldenPathDirection(state) {
 }
 
 /**
+ * @summary Formats the capacity-aware advisory weighting — when the agent's own open-PR count crosses
+ * the review-capacity threshold, the refuse-directive weights REVIEW seats above new-artifact
+ * production (review-cost marginal-value economics applied at the turn boundary: every own open PR
+ * consumes a peer review seat, so more refused terminals converted into NEW artifacts grow queue
+ * depth, not throughput). Advisory only — it reorders emphasis, never auto-reprioritizes. The richer
+ * open-PRs-per-active-REVIEWER ratio needs reviewer-liveness data the lifecycle-state producer does
+ * not write yet; own-open-PRs is the v1 proxy carried by the existing file. Fail-open + total (any
+ * malformed shape → `''`); exported + unit-tested.
+ * @param {Object|null} state `{openPRs, ...}` from {@link readLifecycleState}.
+ * @param {Object} [options]
+ * @param {Number} [options.threshold=3] Own-open-PR count at which review seats outrank new artifacts.
+ * @returns {String}
+ */
+export function formatCapacityAdvisory(state, {threshold = 3} = {}) {
+    try {
+        if (!state || typeof state !== 'object') return '';
+
+        const prs  = Array.isArray(state.openPRs) ? state.openPRs : [],
+              open = prs.filter(pr => pr && typeof pr === 'object' &&
+                  (typeof pr.number === 'number' || typeof pr.number === 'string'));
+
+        if (open.length < threshold) return '';
+
+        return `\nCapacity: ${open.length} own PRs already open — each one consumes a peer review seat. ` +
+            `Weight REVIEW work above new artifacts now: clear CHANGES_REQUESTED on your own PRs or take a ` +
+            `peer's review seat before opening another artifact lane (review-cost economics, marginal-value discipline).`;
+    } catch {
+        // Belt-and-suspenders: any unforeseen shape degrades to the bare reminder, never throws.
+        return '';
+    }
+}
+
+/**
  * @summary Composes the directive injected on a block — the curated `IDLE_REMINDER` (lifecycle +
- * teeth-test) + the Computed Golden Path release-goal direction (the release-goal anchor) + the agent's
+ * teeth-test) + the Computed Golden Path release-goal direction (the release-goal anchor) + the
+ * capacity advisory (review seats outrank new artifacts past the own-open-PR threshold) + the agent's
  * live lane-state board + the always-present mirror-pointer (discoverability) + the self-improvability
  * clause (the floor is mutable substrate) + the trigger `cause`. Reminder is WHAT-to-do, the direction
- * is WHICH-lane-serves-the-release-goal, the board is WHAT'S-actionable-now, the mirror-pointer is
- * WHY-this-is-not-a-leash, the clause is HOW-to-fix-it-when-wrong, the cause is WHY-blocked. Fail-open
- * on the direction + board (missing/bad file → bare reminder). ONE best-effort file read shared by both
- * formatters; exported + unit-tested.
+ * is WHICH-lane-serves-the-release-goal, capacity is WHICH-KIND-of-lane-first, the board is
+ * WHAT'S-actionable-now, the mirror-pointer is WHY-this-is-not-a-leash, the clause is
+ * HOW-to-fix-it-when-wrong, the cause is WHY-blocked. Fail-open on the direction + capacity + board
+ * (missing/bad file → bare reminder). ONE best-effort file read shared by all three formatters;
+ * exported + unit-tested.
  * @param {String} cause The terminal-evidence violation that triggered the block (the verdict reason).
  * @returns {String}
  */
 export function composeBlockDirective(cause, holdMatches = []) {
     const state     = readLifecycleState(),
           direction = formatGoldenPathDirection(state),
+          capacity  = formatCapacityAdvisory(state),
           board     = formatLifecycleBoard(state),
           costume   = formatHoldCostumeCallout(holdMatches);
-    return `${IDLE_REMINDER}${direction}${board}${costume}\n\n${MIRROR_POINTER}\n\n${SELF_IMPROVABILITY_CLAUSE}\n\n(Stop-hook trigger: ${cause})`;
+    return `${IDLE_REMINDER}${direction}${capacity}${board}${costume}\n\n${MIRROR_POINTER}\n\n${SELF_IMPROVABILITY_CLAUSE}\n\n(Stop-hook trigger: ${cause})`;
 }
 
 /**
@@ -629,8 +703,35 @@ async function main() {
         process.exit(0);
     }
 
-    const session          = input.session_id || '?',
-          {action, reason} = decideHookAction(verdict, ENFORCING, operatorInLoop);
+    const session = input.session_id || '?';
+
+    // The clean-terminal edge (the ONE autonomous stop): evaluated ONLY on a valid terminal outside
+    // operator dialogue. Inputs are external by construction — the drive count comes from the hook's
+    // own audit log ({@link countSessionCompliantRefusals}), the self identity from harness wiring
+    // (`NEO_AGENT_IDENTITY`; absent → fail-closed, the edge stays inert), the operator-turn waiver from
+    // the SAME human-filtered classification the allow path uses. The descriptor contributes only its
+    // gates' nextActor declarations, and gaming those is bounded: acceptance still requires the
+    // ratchet's hook-written drives, and the boundary emits an audited, peer-visible line.
+    let cleanTerminal = null;
+    if (verdict.valid && !operatorInLoop) {
+        cleanTerminal = evaluateCleanTerminalAcceptance({
+            verdictValid    : true,
+            namedGates      : Array.isArray(descriptor?.namedGates) ? descriptor.namedGates : [],
+            selfIdentity    : process.env.NEO_AGENT_IDENTITY || '',
+            compliantDrives : countSessionCompliantRefusals(session),
+            operatorTurnNext: midChainOperator
+        });
+    }
+
+    const {action, reason} = decideHookAction(verdict, ENFORCING, operatorInLoop, cleanTerminal);
+
+    if (action === 'allow' && cleanTerminal?.accept === true) {
+        // The audited boundary: the acceptance is observable (log + a best-effort systemMessage into
+        // the transcript), never a silent stop. Exit only after stdout drains.
+        auditLog(`CLEAN-TERMINAL ALLOW (session=${session}, midChainOperator=${midChainOperator}): ${reason}`);
+        process.stdout.write(JSON.stringify({systemMessage: reason}), () => process.exit(0));
+        return;
+    }
 
     if (action === 'block') {
         // Costume-tripwire: scan the agent's OWN turn-final text for the sophisticated-hold lexicon so

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -17,8 +17,8 @@ export const LANE_STATE_SCHEMA_HINT = `Machine lane-state block to emit with you
 \`\`\`lane-state
 {"wakeDisposition":"awareness","laneContinuation":"next-lane","namedGates":[],"awaitingOwnPrOnly":false}
 \`\`\`
-Validator gotchas: if an own PR is only awaiting merge/review/CI, use laneContinuation "next-lane"; "active-lane" + awaitingOwnPrOnly:true is invalid. Every namedGates[] entry needs a same-turn checkedAt; PR-shaped gates also need same-turn fetch evidence in the tool history; mergeClaim must use field "mergedAt".
-Consumption honesty: namedGates[] is audit/coordination payload (peer-visible gate state; the audit ledger). In autonomous mode it explains the block reason; it is not a stop-license.`;
+Validator gotchas: if an own PR is only awaiting merge/review/CI, use laneContinuation "next-lane"; "active-lane" + awaitingOwnPrOnly:true is invalid. Every namedGates[] entry needs a same-turn checkedAt; PR-shaped gates also need same-turn fetch evidence in the tool history; mergeClaim must use field "mergedAt". Each entry SHOULD carry nextActor ("@peer"|"operator"|"ci") — the non-self party the gate awaits.
+Consumption honesty: namedGates[] is audit/coordination payload (peer-visible gate state; the audit ledger). In autonomous mode it explains the block reason; it is not a stop-license. The hook MAY accept a clean terminal (all gates non-self + the session drive-ratchet met) with a [clean-terminal] audit line — that acceptance is the hook's external call, never self-declarable.`;
 
 /**
  * @summary Compact cross-harness turn-end options hint for Stop-hook injections.
@@ -172,25 +172,119 @@ export function isOperatorInLoop({stopHookActive, promptingText = '', promptingT
 }
 
 /**
+ * The default clean-terminal drive-ratchet: how many compliant refused terminals (each one a real
+ * drive the hook already blocked) must precede an acceptance in the same session chain. 2 keeps
+ * single-fire discipline intact — the first and second valid terminals still refuse and force
+ * drives; the third valid terminal on a fully handed-off board may be accepted. The observed value
+ * inversion (drives 2–4 produced real PRs; 5–9 produced bookkeeping) sits exactly past this point.
+ * @type {Number}
+ */
+export const DEFAULT_MIN_COMPLIANT_DRIVES = 2;
+
+/**
+ * @summary Evaluates the clean-terminal acceptance condition — the ONE edge where an autonomous
+ * chain may end: a valid terminal on a genuinely handed-off board, after the no-hold principle was
+ * demonstrably honored. ALL of:
+ *
+ *  1. the terminal verdict is valid (parse + evidence rules already passed);
+ *  2. at least one named gate exists, and EVERY gate carries a `nextActor` that is a non-empty
+ *     string different from the agent's own identity — a board with no named gates, or any gate
+ *     waiting on the agent itself, is not handed off;
+ *  3. the session drive-ratchet: ≥ `minCompliantDrives` compliant refused terminals already
+ *     occurred in this chain (externally counted — the hook's own audit trail, never self-declared),
+ *     OR `operatorTurnNext` waives the ratchet (a live operator turn is turn-taking, not a dodge);
+ *  4. `selfIdentity` is known — an adapter that cannot name the agent fails CLOSED (no acceptance),
+ *     so the whole edge is opt-in per harness wiring.
+ *
+ * The no-hold PRINCIPLE is untouched: a first valid terminal still refuses (ratchet), unnamed
+ * gates still fail the validator upstream, hold-costume prose still trips its own tripwire. This
+ * targets exactly the infinite re-fire on genuinely-dispatched boards. Pure + total.
+ * @param {Object} input
+ * @param {Boolean} [input.verdictValid=false] The upstream terminal verdict (validity, not a re-check).
+ * @param {Object[]} [input.namedGates=[]] The descriptor's gates: `[{ref, checkedAt, nextActor?, ...}]`.
+ * @param {String} [input.selfIdentity=''] The agent's own handle (e.g. `@neo-fable`); adapter-supplied.
+ * @param {Number} [input.compliantDrives=0] Externally-counted compliant refused terminals this session.
+ * @param {Number} [input.minCompliantDrives=DEFAULT_MIN_COMPLIANT_DRIVES] The ratchet threshold.
+ * @param {Boolean} [input.operatorTurnNext=false] Adapter-computed operator-turn evidence (never descriptor-declared).
+ * @returns {{accept: Boolean, reason: String}} On accept, `reason` is the `[clean-terminal]` audit line.
+ */
+export function evaluateCleanTerminalAcceptance({
+    verdictValid       = false,
+    namedGates         = [],
+    selfIdentity       = '',
+    compliantDrives    = 0,
+    minCompliantDrives = DEFAULT_MIN_COMPLIANT_DRIVES,
+    operatorTurnNext   = false
+} = {}) {
+    if (!verdictValid) {
+        return {accept: false, reason: 'terminal verdict not valid — acceptance requires a valid lane-state terminal'};
+    }
+
+    // Identity comparison is canonical-form-agnostic: gates carry `@`-prefixed canonical actors
+    // (`@neo-fable`) while `NEO_AGENT_IDENTITY` wiring provides the bare handle (`neo-fable`) —
+    // without stripping the prefix on BOTH sides, a self-awaiting gate in canonical form would
+    // pass as non-self and mint an unearned acceptance.
+    const self = typeof selfIdentity === 'string' ? selfIdentity.trim().toLowerCase().replace(/^@/, '') : '';
+    if (!self) {
+        return {accept: false, reason: 'agent identity unknown (no selfIdentity wired) — clean-terminal acceptance is fail-closed'};
+    }
+
+    const gates = Array.isArray(namedGates) ? namedGates : [];
+    if (!gates.length) {
+        return {accept: false, reason: 'no named gates — a board with nothing handed off is not a clean terminal'};
+    }
+
+    for (const gate of gates) {
+        const actor = typeof gate?.nextActor === 'string' ? gate.nextActor.trim().toLowerCase().replace(/^@/, '') : '';
+        if (!actor) {
+            return {accept: false, reason: `named gate ${gate?.ref ?? '(unnamed)'} carries no nextActor — every gate must name the non-self party it awaits`};
+        }
+        if (actor === self) {
+            return {accept: false, reason: `named gate ${gate?.ref ?? '(unnamed)'} awaits the agent itself (${gate.nextActor}) — the board is not handed off`};
+        }
+    }
+
+    if (!operatorTurnNext && compliantDrives < minCompliantDrives) {
+        return {accept: false, reason: `drive-ratchet not met: ${compliantDrives}/${minCompliantDrives} compliant refused drives this session — drive a lane first`};
+    }
+
+    return {
+        accept: true,
+        reason: `[clean-terminal] valid terminal accepted — ${gates.length} gate(s) all awaiting non-self actors, ` +
+            (operatorTurnNext ? 'operator turn next (ratchet waived)' : `${compliantDrives} compliant drives this session`) +
+            '; the boundary is audited, not silent'
+    };
+}
+
+/**
  * @summary Shared no-hold Stop-hook decision. The one voluntary allow is live operator dialogue;
- * every other turn-end is blocked when the harness has a proven block/inject contract, or would-block
- * when dry-run / fail-open transport semantics apply. The `verdict` reason is evidence, not a gate.
+ * the one AUTONOMOUS allow is an adapter-evaluated clean terminal ({@link evaluateCleanTerminalAcceptance}
+ * — valid terminal, fully handed-off gates, drive-ratchet met); every other turn-end is blocked when
+ * the harness has a proven block/inject contract, or would-block when dry-run / fail-open transport
+ * semantics apply. The `verdict` reason is evidence, not a gate.
  * @param {{valid: Boolean, reason: String}} verdict
  * @param {Object} [options]
  * @param {Boolean} [options.enforcing=false]
  * @param {Boolean} [options.operatorInLoop=false]
  * @param {Boolean} [options.blockInjectionSupported=true]
  * @param {String} [options.blockUnsupportedReason='']
+ * @param {{accept: Boolean, reason: String}|null} [options.cleanTerminal=null] The adapter-evaluated
+ * clean-terminal acceptance; only `accept === true` changes the action (an allow with its audit line).
  * @returns {{action: ('allow'|'block'|'would-block'), reason: String}}
  */
 export function decideStopHookAction(verdict, {
     enforcing               = false,
     operatorInLoop          = false,
     blockInjectionSupported = true,
-    blockUnsupportedReason  = ''
+    blockUnsupportedReason  = '',
+    cleanTerminal           = null
 } = {}) {
     if (operatorInLoop) {
         return {action: 'allow', reason: 'live operator dialogue — yielding for the human turn'};
+    }
+
+    if (cleanTerminal?.accept === true) {
+        return {action: 'allow', reason: cleanTerminal.reason};
     }
 
     if (enforcing && blockInjectionSupported) {

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -1,8 +1,9 @@
 import {test, expect}                                                                              from '@playwright/test';
-import {composeBlockDirective, composeDeferenceDirective, decideHookAction, isOperatorInLoop, parseOutcomeToVerdict,
+import {composeBlockDirective, composeDeferenceDirective, countSessionCompliantRefusals, decideHookAction,
+        isOperatorInLoop, parseOutcomeToVerdict,
         extractFinalAssistantText, extractLastAssistantTextFromJsonl, extractLastUserTextFromJsonl,
         extractLatestHumanUserTextFromJsonl,
-        formatLifecycleBoard, formatGoldenPathDirection, formatHoldCostumeCallout} from '../../../../.claude/hooks/laneStateStopHook.mjs';
+        formatCapacityAdvisory, formatLifecycleBoard, formatGoldenPathDirection, formatHoldCostumeCallout} from '../../../../.claude/hooks/laneStateStopHook.mjs';
 import {spawn} from 'node:child_process';
 import fs      from 'node:fs';
 import os      from 'node:os';
@@ -525,15 +526,21 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
      * @param {{enforce: Boolean, promptingText: (String|null), stopHookActive: Boolean, toolCommand: String|null}} [opts]
      * @returns {Promise<{stdout: String, log: String}>}
      */
-    function runHook(finalText, {enforce = false, promptingText = null, stopHookActive = false, lifecycleState = null, toolCommand = null, transcriptRecords = null} = {}) {
+    function runHook(finalText, {enforce = false, promptingText = null, stopHookActive = false, lifecycleState = null, toolCommand = null, transcriptRecords = null, preseedLog = null, extraEnv = null} = {}) {
         return new Promise((resolve, reject) => {
             const dir            = fs.mkdtempSync(path.join(os.tmpdir(), 'lane-hook-e2e-')),
                   transcriptPath = path.join(dir, 'transcript.jsonl'),
-                  env            = {...process.env, NEO_AI_DAEMON_DIR: dir},
+                  env            = {...process.env, NEO_AI_DAEMON_DIR: dir, ...(extraEnv || {})},
                   payload        = {stop_hook_active: stopHookActive, session_id: 'e2e'};
 
             if (lifecycleState !== null) {
                 fs.writeFileSync(path.join(dir, 'lifecycle-state.json'), JSON.stringify(lifecycleState), 'utf8');
+            }
+
+            if (preseedLog !== null) {
+                // The drive-ratchet source: pre-seed the hook's OWN audit log (prior-session-turn
+                // BLOCK lines) so acceptance reads hook-written history, exactly as in production.
+                fs.writeFileSync(path.join(dir, 'lane-state-stop-hook.log'), preseedLog.join('\n') + '\n', 'utf8');
             }
 
             if (transcriptRecords !== null) {
@@ -841,5 +848,149 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
         const decision = JSON.parse(stdout);
         expect(decision.decision).toBe('block');
         expect(decision.reason).not.toContain('Release-goal direction');
+    });
+
+    // ── the clean-terminal acceptance edge — the ONE audited autonomous stop ────────────────────
+
+    // A fully handed-off valid terminal: next-lane, one issue-shaped gate with a same-turn checkedAt
+    // and a NON-SELF nextActor (issue-shaped refs need no PR fetch evidence, keeping the fixture pure).
+    const handedOffTerminal = `Both PRs at responded-head.\n\n${block(
+        '{"laneContinuation":"next-lane","awaitingOwnPrOnly":false,"namedGates":[' +
+        '{"ref":"#15274","checkedAt":"2026-07-16T18:00:00Z","nextActor":"@neo-gpt-emmy"}]}'
+    )}`;
+
+    // Two prior compliant refused drives — the hook's own audit-log lines, exactly as production writes them.
+    const twoCompliantRefusals = [
+        '[2026-07-16T17:00:00.000Z] BLOCK (session=e2e, operatorInLoop=false, midChainOperator=false, autonomousHandoff=false, handoffReason=none, handoffWindowMs=none): valid lane-state terminal',
+        '[2026-07-16T17:20:00.000Z] BLOCK (session=e2e, operatorInLoop=false, midChainOperator=false, autonomousHandoff=false, handoffReason=none, handoffWindowMs=none): valid lane-state terminal'
+    ];
+
+    test('clean terminal: valid + non-self gates + ratchet met + identity wired → audited ALLOW, never silent', async () => {
+        const {stdout, log} = await runHook(handedOffTerminal, {
+            enforce      : true,
+            extraEnv     : {NEO_AGENT_IDENTITY: '@neo-fable'},
+            preseedLog   : twoCompliantRefusals,
+            promptingText: '[WAKE] 1 event'
+        });
+
+        expect(log).toContain('CLEAN-TERMINAL ALLOW');
+        expect(log).toContain('2 compliant drives');
+
+        // the peer-visible boundary: a systemMessage, NOT a block decision
+        const emission = JSON.parse(stdout);
+        expect(emission.decision).toBeUndefined();
+        expect(emission.systemMessage).toContain('[clean-terminal]');
+        expect(emission.systemMessage).toContain('non-self actors');
+    });
+
+    test('the ratchet holds: only ONE prior compliant drive → still BLOCK (first/second valid terminals refuse)', async () => {
+        const {stdout, log} = await runHook(handedOffTerminal, {
+            enforce      : true,
+            extraEnv     : {NEO_AGENT_IDENTITY: '@neo-fable'},
+            preseedLog   : [twoCompliantRefusals[0]],
+            promptingText: '[WAKE] 1 event'
+        });
+
+        expect(log).toContain('BLOCK');
+        expect(JSON.parse(stdout).decision).toBe('block');
+    });
+
+    test('a self-awaiting gate defeats acceptance — the board is not handed off', async () => {
+        const selfGate = `Done.\n\n${block(
+            '{"laneContinuation":"next-lane","awaitingOwnPrOnly":false,"namedGates":[' +
+            '{"ref":"#15274","checkedAt":"2026-07-16T18:00:00Z","nextActor":"@neo-fable"}]}'
+        )}`;
+
+        const {stdout} = await runHook(selfGate, {
+            enforce      : true,
+            extraEnv     : {NEO_AGENT_IDENTITY: '@neo-fable'},
+            preseedLog   : twoCompliantRefusals,
+            promptingText: '[WAKE] 1 event'
+        });
+
+        expect(JSON.parse(stdout).decision).toBe('block');
+    });
+
+    test('no NEO_AGENT_IDENTITY wiring → the edge is inert (fail-closed): BLOCK exactly as before', async () => {
+        const {stdout} = await runHook(handedOffTerminal, {
+            enforce   : true,
+            // Explicitly CLEARED, not ambiently absent: real agent boxes export NEO_AGENT_IDENTITY,
+            // so relying on the parent env lacking it makes this test box-dependent.
+            extraEnv     : {NEO_AGENT_IDENTITY: ''},
+            preseedLog   : twoCompliantRefusals,
+            promptingText: '[WAKE] 1 event'
+        });
+
+        expect(JSON.parse(stdout).decision).toBe('block');
+    });
+
+    test('WOULD-BLOCK and deference audit lines never feed the ratchet — only compliant BLOCK refusals count', async () => {
+        const {stdout} = await runHook(handedOffTerminal, {
+            enforce   : true,
+            extraEnv  : {NEO_AGENT_IDENTITY: '@neo-fable'},
+            preseedLog: [
+                // dry-run previews (no chain formed) + a deference block + an invalid-terminal block:
+                // none of these are compliant refused drives.
+                '[2026-07-16T17:00:00.000Z] WOULD-BLOCK (session=e2e, operatorInLoop=false, midChainOperator=false, autonomousHandoff=false, handoffReason=none, handoffWindowMs=none): valid lane-state terminal',
+                '[2026-07-16T17:05:00.000Z] BLOCK (session=e2e, operatorInLoop=false, midChainOperator=false, autonomousHandoff=false, handoffReason=none, handoffWindowMs=none): deference phrase "your call" at turn-terminal',
+                '[2026-07-16T17:10:00.000Z] BLOCK (session=e2e, operatorInLoop=false, midChainOperator=false, autonomousHandoff=false, handoffReason=none, handoffWindowMs=none): no lane-state block emitted at turn-terminal',
+                // a DIFFERENT session's compliant refusal must not leak in either:
+                '[2026-07-16T17:15:00.000Z] BLOCK (session=other, operatorInLoop=false, midChainOperator=false, autonomousHandoff=false, handoffReason=none, handoffWindowMs=none): valid lane-state terminal'
+            ],
+            promptingText: '[WAKE] 1 event'
+        });
+
+        expect(JSON.parse(stdout).decision).toBe('block');
+    });
+
+    test('capacity advisory: past the own-open-PR threshold the block directive weights review seats first', async () => {
+        const {stdout} = await runHook(block('{"laneContinuation":"verified-no-lane"}'), {
+            enforce      : true,
+            promptingText: '[WAKE] 1 event',
+            // freshness is contract: an unproven-fresh lifecycle-state serves NOTHING — the
+            // capacity advisory included — so the fixture must carry a live generatedAt.
+            lifecycleState: {generatedAt: new Date().toISOString(), openPRs: [{number: 1, state: 'OPEN'}, {number: 2, state: 'OPEN'}, {number: 3, state: 'OPEN'}]}
+        });
+
+        const decision = JSON.parse(stdout);
+        expect(decision.decision).toBe('block');
+        expect(decision.reason).toContain('Capacity: 3 own PRs already open');
+        expect(decision.reason).toContain('review seat');
+    });
+});
+
+/**
+ * Unit layer for the clean-terminal support functions — the ratchet counter guards and the
+ * capacity-advisory formatter matrix (the e2e layer above covers their composed behavior).
+ */
+test.describe('laneStateStopHook — clean-terminal support units', () => {
+    test('countSessionCompliantRefusals: empty / unknown session ids fail closed to 0', () => {
+        expect(countSessionCompliantRefusals('')).toBe(0);
+        expect(countSessionCompliantRefusals('?')).toBe(0);
+        expect(countSessionCompliantRefusals(undefined)).toBe(0);
+        // an id that cannot exist in any real log → 0 (missing log/lines fail closed, never throw)
+        expect(countSessionCompliantRefusals(`spec-never-${Date.now()}`)).toBe(0);
+    });
+
+    test('formatCapacityAdvisory: below threshold / malformed shapes → "" (fail-open, total)', () => {
+        expect(formatCapacityAdvisory(null)).toBe('');
+        expect(formatCapacityAdvisory('garbage')).toBe('');
+        expect(formatCapacityAdvisory({})).toBe('');
+        expect(formatCapacityAdvisory({openPRs: 'not-an-array'})).toBe('');
+        expect(formatCapacityAdvisory({openPRs: [null, {}, {number: 1}]})).toBe('');          // 1 valid < 3
+        expect(formatCapacityAdvisory({openPRs: [{number: 1}, {number: 2}]})).toBe('');       // 2 < 3
+        expect(() => formatCapacityAdvisory({openPRs: [null]})).not.toThrow();
+    });
+
+    test('formatCapacityAdvisory: at/past threshold → the review-seats-first line; threshold is tunable', () => {
+        const line = formatCapacityAdvisory({openPRs: [{number: 1}, {number: 2}, {number: 3}]});
+        expect(line).toContain('Capacity: 3 own PRs already open');
+        expect(line).toContain('review seat');
+        expect(line).toContain('CHANGES_REQUESTED');
+
+        // tunable threshold: 2 open PRs trip a threshold of 2
+        expect(formatCapacityAdvisory({openPRs: [{number: 1}, {number: 2}]}, {threshold: 2})).toContain('Capacity: 2 own PRs');
+        // malformed entries are excluded from the count (only 2 valid of 4 → below default threshold)
+        expect(formatCapacityAdvisory({openPRs: [null, {}, {number: 1}, {number: 2}]})).toBe('');
     });
 });

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -4,7 +4,9 @@ import {
     classifyPromptingContext,
     decideDeferenceStopHookAction,
     decideStopHookAction,
+    DEFAULT_MIN_COMPLIANT_DRIVES,
     detectAutonomousHandoffPrompt,
+    evaluateCleanTerminalAcceptance,
     extractAutonomousHandoffWindowMs,
     isOperatorDialogueText,
     isOperatorInLoop,
@@ -331,5 +333,117 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — scanHoldLexicon (hold-c
         expect(scanHoldLexicon(null)).toEqual([]);
         expect(scanHoldLexicon(undefined)).toEqual([]);
         expect(scanHoldLexicon(42)).toEqual([]);
+    });
+});
+
+/**
+ * The clean-terminal acceptance seam — the ONE audited autonomous stop. Full condition matrix at
+ * the pure layer (the adapter e2e covers composition): validity, gate hand-off, self-identity
+ * fail-closed, the drive-ratchet, and the operator-turn waiver. The no-hold principle stays the
+ * default: every rejection reason names what to do instead of stopping.
+ */
+test.describe('stopHookDecision — evaluateCleanTerminalAcceptance (the audited autonomous stop)', () => {
+    const nonSelfGate = {ref: '#15274', checkedAt: '2026-07-16T18:00:00Z', nextActor: '@neo-gpt-emmy'},
+          selfGate    = {ref: 'PR #15288', checkedAt: '2026-07-16T18:00:00Z', nextActor: '@neo-fable'},
+          base        = {
+              verdictValid   : true,
+              namedGates     : [nonSelfGate],
+              selfIdentity   : '@neo-fable',
+              compliantDrives: 2
+          };
+
+    test('the accepting shape: valid + ≥1 gate, all non-self + ratchet met + identity known → [clean-terminal]', () => {
+        const result = evaluateCleanTerminalAcceptance(base);
+        expect(result.accept).toBe(true);
+        expect(result.reason).toContain('[clean-terminal]');
+        expect(result.reason).toContain('non-self actors');
+        expect(result.reason).toContain('2 compliant drives');
+
+        // The real harness wiring provides the BARE handle (`NEO_AGENT_IDENTITY=neo-fable`); the
+        // canonical `@`-form gate actor must still read as non-self-vs-self correctly either way.
+        expect(evaluateCleanTerminalAcceptance({...base, selfIdentity: 'neo-fable'}).accept).toBe(true);
+    });
+
+    test('an invalid verdict never accepts — acceptance sits ON TOP of the validator, not beside it', () => {
+        const result = evaluateCleanTerminalAcceptance({...base, verdictValid: false});
+        expect(result.accept).toBe(false);
+        expect(result.reason).toContain('valid lane-state terminal');
+    });
+
+    test('no named gates → no acceptance (nothing handed off is not a clean terminal)', () => {
+        expect(evaluateCleanTerminalAcceptance({...base, namedGates: []}).accept).toBe(false);
+        expect(evaluateCleanTerminalAcceptance({...base, namedGates: 'nope'}).accept).toBe(false);
+    });
+
+    test('a gate without nextActor, or awaiting the agent itself, defeats acceptance (case-insensitive)', () => {
+        expect(evaluateCleanTerminalAcceptance({...base, namedGates: [{ref: '#1', checkedAt: 'now'}]}).accept).toBe(false);
+        expect(evaluateCleanTerminalAcceptance({...base, namedGates: [nonSelfGate, selfGate]}).accept).toBe(false);
+        expect(evaluateCleanTerminalAcceptance({...base, namedGates: [{...selfGate, nextActor: '@NEO-FABLE'}]}).accept).toBe(false);
+        expect(evaluateCleanTerminalAcceptance({...base, namedGates: [{...nonSelfGate, nextActor: '   '}]}).accept).toBe(false);
+        // Cross-form self-detection: a bare `NEO_AGENT_IDENTITY` self vs a canonical `@`-form gate
+        // actor (and the inverse) — without `@`-prefix normalization on BOTH sides, a self-awaiting
+        // gate written in the other form passed as non-self and minted an unearned acceptance.
+        expect(evaluateCleanTerminalAcceptance({...base, selfIdentity: 'neo-fable', namedGates: [selfGate]}).accept).toBe(false);
+        expect(evaluateCleanTerminalAcceptance({...base, namedGates: [{...selfGate, nextActor: 'neo-fable'}]}).accept).toBe(false);
+    });
+
+    test('unknown self-identity fails CLOSED — the edge is opt-in per harness wiring', () => {
+        expect(evaluateCleanTerminalAcceptance({...base, selfIdentity: ''}).accept).toBe(false);
+        expect(evaluateCleanTerminalAcceptance({...base, selfIdentity: undefined}).accept).toBe(false);
+    });
+
+    test('the drive-ratchet: below DEFAULT_MIN_COMPLIANT_DRIVES refuses with the count named', () => {
+        expect(DEFAULT_MIN_COMPLIANT_DRIVES).toBe(2);
+
+        const zero = evaluateCleanTerminalAcceptance({...base, compliantDrives: 0}),
+              one  = evaluateCleanTerminalAcceptance({...base, compliantDrives: 1});
+
+        expect(zero.accept).toBe(false);
+        expect(zero.reason).toContain('0/2 compliant refused drives');
+        expect(one.accept).toBe(false);
+        expect(one.reason).toContain('drive a lane first');
+        // the threshold is tunable at the seam
+        expect(evaluateCleanTerminalAcceptance({...base, compliantDrives: 1, minCompliantDrives: 1}).accept).toBe(true);
+    });
+
+    test('the operator-turn waiver: a live operator turn is turn-taking, not a dodge — ratchet waived', () => {
+        const result = evaluateCleanTerminalAcceptance({...base, compliantDrives: 0, operatorTurnNext: true});
+        expect(result.accept).toBe(true);
+        expect(result.reason).toContain('operator turn next (ratchet waived)');
+        // the waiver does NOT bypass the gate conditions:
+        expect(evaluateCleanTerminalAcceptance({...base, namedGates: [selfGate], compliantDrives: 0, operatorTurnNext: true}).accept).toBe(false);
+    });
+
+    test('decideStopHookAction: an accepted clean terminal ALLOWS with its audit line — even enforcing', () => {
+        const accepted = {accept: true, reason: '[clean-terminal] valid terminal accepted — audited'};
+
+        expect(decideStopHookAction({valid: true, reason: 'ok'}, {enforcing: true, cleanTerminal: accepted}))
+            .toEqual({action: 'allow', reason: accepted.reason});
+        expect(decideStopHookAction({valid: true, reason: 'ok'}, {enforcing: false, cleanTerminal: accepted}).action)
+            .toBe('allow');
+    });
+
+    test('decideStopHookAction: a rejected/absent evaluation changes nothing — block/would-block as before', () => {
+        const rejected = {accept: false, reason: 'drive-ratchet not met'};
+
+        expect(decideStopHookAction({valid: true, reason: 'ok'}, {enforcing: true, cleanTerminal: rejected}).action).toBe('block');
+        expect(decideStopHookAction({valid: true, reason: 'ok'}, {enforcing: true, cleanTerminal: null}).action).toBe('block');
+        // a malformed acceptance object (truthy accept that is not === true) stays a block: fail-closed
+        expect(decideStopHookAction({valid: true, reason: 'ok'}, {enforcing: true, cleanTerminal: {accept: 'yes'}}).action).toBe('block');
+    });
+
+    test('decideStopHookAction: operator dialogue still wins with its own reason (precedence unchanged)', () => {
+        const accepted = {accept: true, reason: '[clean-terminal] x'},
+              result   = decideStopHookAction({valid: true, reason: 'ok'}, {enforcing: true, operatorInLoop: true, cleanTerminal: accepted});
+
+        expect(result.action).toBe('allow');
+        expect(result.reason).toContain('live operator dialogue');
+    });
+
+    test('LANE_STATE_SCHEMA_HINT documents nextActor + the audited acceptance without minting a self-license', () => {
+        expect(LANE_STATE_SCHEMA_HINT).toContain('nextActor');
+        expect(LANE_STATE_SCHEMA_HINT).toContain('[clean-terminal]');
+        expect(LANE_STATE_SCHEMA_HINT).toContain('never self-declarable');
+        expect(LANE_STATE_SCHEMA_HINT).toContain('not a stop-license');
     });
 });


### PR DESCRIPTION
Resolves #15274

Ships the clean-terminal acceptance the ticket converged: in autonomous mode, a valid lane-state terminal whose named gates ALL await non-self actors is ALLOWED after ≥2 hook-audited compliant refused drives this session — with a peer-visible `[clean-terminal]` audit line and a transcript systemMessage, never silently. A live operator turn waives the ratchet (turn-taking is not a hold-dodge). Past an own-open-PR threshold the refuse-directive now weights REVIEW seats above new-artifact production (the capacity-aware advisory the ticket's second accepted dimension asked for). Everything else is unchanged: a first valid terminal still refuses, deference and invalid-terminal blocks still fire, dry-run still previews, and absent identity wiring keeps the edge inert.

Evidence: L2 (131-test unit + spawned-hook e2e run at head; acceptance edge, ratchet sourcing, fail-closed paths, and advisory all pinned) → L2 sufficient for the decision logic, plus live dogfood observation: this implementation ran AS the authoring session's own Stop hook — 3 real fires behaved per design (1 invalid-terminal block; 2 valid-terminal refusals building the ratchet). Residual: first live autonomous `[clean-terminal]` acceptance lands post-merge (see Post-Merge Validation).

## Deltas from ticket

- **Identity wiring:** the WIP-era draft read a hypothetical `NEO_AGENT_HANDLE`; shipped on the repo-standard `NEO_AGENT_IDENTITY` (present on every agent box) — a var that exists nowhere would have kept the edge permanently inert everywhere. Identity comparison now strips the canonical `@` prefix on BOTH sides: gates carry `@`-form actors while the env provides the bare handle, and without normalization a self-awaiting gate written in either form passed as non-self and minted an unearned acceptance. Regression-pinned at both spec layers.
- **Capacity advisory v1 proxy:** the ticket's open-PRs-per-active-REVIEWER ratio needs reviewer-liveness data the lifecycle-state producer does not write yet; shipped on own-open-PRs (threshold 3, tunable) carried by the existing file — the richer ratio is documented in the formatter JSDoc as the successor shape.
- **Freshness interaction:** rebasing onto the merged stale-state fix (#15292) surfaced that the capacity advisory must ALSO serve only from provable-fresh lifecycle-state — consistent with that fix's contract; the e2e fixture carries a live `generatedAt`.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/hooks/stopHookDecision.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs` → **131 passed** at the pushed head (rebased onto dev including the #15363 parity heal and the #15292 freshness gate).
- Coverage added — evaluator matrix: accepting shape · invalid-verdict · no-gates · self-gate (cross-form `@`/bare + case-insensitive) · unknown-identity fail-closed · drive-ratchet counts · operator waiver. Precedence: operator dialogue > clean-terminal > block/would-block, unchanged elsewhere. Spawned-hook e2e: audited ALLOW with systemMessage; self-gate defeat; inert edge with an EXPLICITLY-cleared env var (ambient absence is box-dependent — the first run of that spec failed precisely because real boxes export the var, which doubles as wiring evidence); ratchet purity (WOULD-BLOCK, deference blocks, invalid-terminal blocks, and other sessions' lines never count). Capacity advisory: formatter matrix + e2e directive weighting.
- Hook surface (`.claude/hooks/`): exercised by the spawned-hook e2e layer; no separate app surface touched.

## Post-Merge Validation

- [ ] First autonomous `[clean-terminal]` acceptance in a live session: the audit log carries `CLEAN-TERMINAL ALLOW (session=…)` and the transcript shows the systemMessage — an observable boundary, not silence.
- [ ] Ratchet integrity across a real re-fire chain: refusals 1–2 refuse; an all-non-self valid terminal at drive count ≥2 accepts.
- [ ] Operator-dialogue waiver: a mid-chain operator turn terminates the loop without the ratchet.

## Commits

- c2b330d5b0 — the full implementation (hook edge + decision-module evaluator + both spec layers), rebased onto healed dev.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 64f444d3-1042-4091-a56f-08332b6cc7a2.
