### PR TITLE
feat(fleet): wire the activitySource composer into devFleetServer — the live half (#15339)

### DIFF
--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -26,8 +26,9 @@ import FleetManager                           from './FleetManager.mjs';
 import {startFleetBridgeServer}               from './fleetBridgeServer.mjs';
 import {readActiveWakeSubscriptionIdentities} from './readActiveWakeSubscriptionIdentities.mjs';
 import {wireBootIdentityReadSource}           from './wireBootIdentityReadSource.mjs';
+import {wireFleetActivityReadSource}          from './wireFleetActivityReadSource.mjs';
 import path                                   from 'node:path';
-import {pathToFileURL}                        from 'node:url';
+import {fileURLToPath, pathToFileURL}         from 'node:url';
 
 const port = Number(process.env.NEO_FLEET_PORT) || 8083;
 
@@ -51,6 +52,23 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
         pidFilePath                     : path.join(memoryCoreConfig.wakeDaemon.dataDir, 'wake-daemon.pid'),
         listActiveSubscriptionIdentities: readActiveWakeSubscriptionIdentities
     };
+
+    // Wire the composed activitySource onto FleetControlBridge. The memory-core mailbox + graph
+    // singletons are imported lazily at this boot use site (mirroring readActiveWakeSubscriptionIdentities's
+    // lazy GraphService) and INJECTED — the composer's slot readers never import a singleton, so the
+    // mailbox identity/permission binding stays here. issuesDir is the synced content tree; readPrs is
+    // omitted in v1 (no synced-`pulls` reader yet — the feed carries issues + lane-claims + stall), which
+    // is honest-empty, not a stub. Fail-soft: an unavailable singleton leaves activitySource unwired.
+    Promise.all([
+        import('../memory-core/MailboxService.mjs'),
+        import('../memory-core/GraphService.mjs')
+    ]).then(([{default: MailboxService}, {default: GraphService}]) => {
+        wireFleetActivityReadSource({
+            issuesDir   : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../resources/content/issues'),
+            listMessages: MailboxService.listMessages.bind(MailboxService),
+            graphService: GraphService
+        })
+    }).catch(error => console.warn('[fleet] activity source not wired:', error?.message ?? error));
 
     startFleetBridgeServer({port})
         .then(server => {

--- a/ai/services/fleet/wireFleetActivityReadSource.mjs
+++ b/ai/services/fleet/wireFleetActivityReadSource.mjs
@@ -1,0 +1,126 @@
+import FleetControlBridge                  from './FleetControlBridge.mjs';
+import {createFleetActivityReadSource}     from './fleetActivityComposer.mjs';
+import {readFleetA2AActivitySnapshot}      from './fleetA2AActivityAdapter.mjs';
+import {createFleetPrLaneActivitySnapshot} from './fleetPrLaneActivityAdapter.mjs';
+import {buildWorkGraphStallFindings,
+        readWorkGraphIssueRecords}           from '../graph/issueFocusSections.mjs';
+
+/**
+ * @module ai/services/fleet/wireFleetActivityReadSource
+ * @summary Installs the composed `activitySource` onto `FleetControlBridge.activitySource` at the
+ * fleet-bridge-server boot, so `readActivitySnapshot(params)` serves real A2A + PR/lane activity
+ * instead of the by-construction `not-wired` default the bridge has answered since it was written.
+ *
+ * **Read-at-use-site, mirroring `wireBootIdentityReadSource`.** The caller (the fleet-server process
+ * entry) resolves config + the cross-process memory-core singletons at the boot use site and passes
+ * them in; this module owns no config default and captures no leaf. **Fail-soft:** with neither slot
+ * readable it leaves `activitySource` unwired (the honest `not-wired` snapshot), never a fabricated
+ * source. **No stub:** an unreadable slot degrades honestly through the composer's unanimity rule —
+ * the composite is `wired` only when BOTH slots read, `degraded` when one cannot.
+ *
+ * **This is where the two read-path ownerships are honoured or broken:**
+ *  - **A2A** — `readFleetA2AActivitySnapshot` over the **injected** `listMessages`. The caller binds
+ *    the `MailboxService` singleton (lazily imported at the entry, like `readActiveWakeSubscriptionIdentities`
+ *    binds `GraphService`); this module never imports it, so identity/permission binding stays at the boundary.
+ *  - **PR/lane** — the *pure builder* `createFleetPrLaneActivitySnapshot` over facts THIS module reads:
+ *    local-synced issue records (`readWorkGraphIssueRecords` — the same records the stall inference walks,
+ *    so the two stay graph-consistent) + work-graph stall findings (`buildWorkGraphStallFindings`) +
+ *    injected PR payloads. The reading is the substantive work of this leaf, not a passthrough.
+ *
+ * @see ai/services/fleet/wireBootIdentityReadSource.mjs — the wire-shape precedent
+ * @see ai/services/fleet/readActiveWakeSubscriptionIdentities.mjs — the lazy-singleton cross-process precedent
+ */
+
+/**
+ * @summary The A2A slot reader — one bounded snapshot over the injected mailbox read path. The caller
+ * owns the `listMessages` binding, so a broken/absent mailbox surfaces as this slot's own degraded
+ * capability rather than a composer guess about it.
+ * @param {Function} listMessages MailboxService-compatible `listMessages(args)`.
+ * @returns {Function} `params => Promise<{capability, events}>`
+ * @private
+ */
+function makeReadA2ASnapshot(listMessages) {
+    return params => readFleetA2AActivitySnapshot({listMessages, limit: params.limit})
+}
+
+/**
+ * @summary The PR/lane slot reader — reads local-synced issue records + work-graph stall findings +
+ * injected PR payloads, then hands them to the pure builder. A read failure becomes a degraded
+ * capability naming the slot (the builder's `error` path), never a thrown snapshot that would take the
+ * whole composite down.
+ * @param {Object} options
+ * @param {String} options.issuesDir Local synced issue directory (`resources/content/issues`).
+ * @param {Object} [options.graphService] memory-core GraphService for stall-finding defer disposition.
+ * @param {Function} [options.readPrs] Optional `async params => pr payloads[]`; omit for no PR events.
+ * @returns {Function} `params => Promise<{capability, events}>`
+ * @private
+ */
+function makeReadPrLaneSnapshot({issuesDir, graphService, readPrs}) {
+    return async params => {
+        const capturedAt = new Date();
+
+        try {
+            const prs           = typeof readPrs === 'function' ? await readPrs(params) : [],
+                  issues        = readWorkGraphIssueRecords(issuesDir),
+                  stallFindings = buildWorkGraphStallFindings({issuesDir, prs, now: capturedAt, graphService});
+
+            return createFleetPrLaneActivitySnapshot({prs, issues, stallFindings, limit: params.limit, capturedAt})
+        } catch (error) {
+            // Contained as this slot's degraded capability — an unreadable content tree or graph must
+            // name its slot, not reject the snapshot the other slot may still be filling honestly.
+            return createFleetPrLaneActivitySnapshot({error, limit: params.limit, capturedAt})
+        }
+    }
+}
+
+/**
+ * @summary Wire the composed activity read-source onto the fleet control bridge.
+ *
+ * Each slot is wired only when its own source is present; an absent source throws inside the composer's
+ * per-slot containment and surfaces as that slot's degraded capability — honest, never fabricated. With
+ * NEITHER source present the bridge is left unwired (the by-construction `not-wired` snapshot stands).
+ *
+ * @param {Object} options
+ * @param {String} [options.issuesDir] Local synced issue directory (`resources/content/issues`), read
+ *     at the caller's use site. Absent → the PR/lane slot degrades.
+ * @param {Function} [options.listMessages] MailboxService-compatible `listMessages(args)`, bound by the
+ *     caller (never imported here). Absent → the A2A slot degrades.
+ * @param {Object} [options.graphService] memory-core GraphService for stall-finding defer disposition
+ *     (injected; the caller lazily imports the singleton).
+ * @param {Function} [options.readPrs] Optional `async params => pr payloads[]`.
+ * @param {Number} [options.limit] Default event bound forwarded to the composer.
+ * @param {Object} [options.bridge=FleetControlBridge] The control bridge to wire (a stub in specs).
+ * @param {Function} [options.createSource=createFleetActivityReadSource] The composer factory (injected in specs).
+ * @returns {Object|null} the wired read-source, or `null` when no slot is readable (left unwired).
+ */
+export function wireFleetActivityReadSource({
+    issuesDir,
+    listMessages,
+    graphService,
+    readPrs,
+    limit,
+    bridge       = FleetControlBridge,
+    createSource = createFleetActivityReadSource
+} = {}) {
+    const hasA2A    = typeof listMessages === 'function',
+          hasPrLane = typeof issuesDir === 'string' && issuesDir.length > 0;
+
+    // No readable slot at all → leave the seam unwired (honest not-wired), never fabricate a source.
+    if (!hasA2A && !hasPrLane) {
+        return null
+    }
+
+    // A missing source throws inside the composer's per-slot `try` → that slot degrades naming itself,
+    // and the unanimity rule reports the composite as degraded (not wired) — the honest partial state.
+    const readA2ASnapshot = hasA2A
+        ? makeReadA2ASnapshot(listMessages)
+        : () => { throw new Error('a2a activity source not wired — no listMessages bound') };
+
+    const readPrLaneSnapshot = hasPrLane
+        ? makeReadPrLaneSnapshot({issuesDir, graphService, readPrs})
+        : () => { throw new Error('pr-lane activity source not wired — no issuesDir') };
+
+    bridge.activitySource = createSource({readA2ASnapshot, readPrLaneSnapshot, limit});
+
+    return bridge.activitySource
+}

--- a/test/playwright/unit/ai/services/fleet/wireFleetActivityReadSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/wireFleetActivityReadSource.spec.mjs
@@ -1,0 +1,62 @@
+import {setup}                       from '../../../../setup.mjs';
+import {test, expect}                from '@playwright/test';
+import Neo                           from '../../../../../../src/Neo.mjs';
+import * as core                     from '../../../../../../src/core/_export.mjs';
+import {wireFleetActivityReadSource} from '../../../../../../ai/services/fleet/wireFleetActivityReadSource.mjs';
+
+/**
+ * @summary Contract of the composer→bridge wiring: it INSTALLS a real composed source, never a stub,
+ * and degrades honestly. The live wired/degraded receipt is the running-devFleetServer e2e's concern
+ * (it needs the real memory-core singletons); this unit pins the pure wiring decisions with an
+ * injected bridge + composer factory — no Neo instance, no real singletons.
+ */
+test.describe('Neo.ai.services.fleet.wireFleetActivityReadSource', () => {
+    const stubBridge = () => ({activitySource: 'UNTOUCHED'});
+
+    test('fail-soft: neither slot readable → returns null and leaves the bridge unwired (never fabricates)', () => {
+        const bridge = stubBridge();
+
+        const result = wireFleetActivityReadSource({bridge, createSource: () => ({readActivitySnapshot() {}})});
+
+        expect(result).toBeNull();
+        // the by-construction not-wired default must stand — no fabricated source installed
+        expect(bridge.activitySource).toBe('UNTOUCHED');
+    });
+
+    test('both sources present → installs the composed source and hands the factory BOTH slot readers', () => {
+        const bridge   = stubBridge();
+        let   captured = null;
+        const created  = {readActivitySnapshot() {}};
+
+        const result = wireFleetActivityReadSource({
+            issuesDir   : '/synced/issues',
+            listMessages: () => [],
+            graphService: {},
+            limit       : 25,
+            bridge,
+            createSource: opts => { captured = opts; return created }
+        });
+
+        expect(result).toBe(created);
+        expect(bridge.activitySource).toBe(created);
+        expect(typeof captured.readA2ASnapshot).toBe('function');
+        expect(typeof captured.readPrLaneSnapshot).toBe('function');
+        expect(captured.limit).toBe(25);
+    });
+
+    test('an ABSENT slot source degrades honestly — its reader throws (contained by the composer), never a fabricated read', async () => {
+        // Only the PR/lane source is present; the A2A slot has no listMessages.
+        let captured = null;
+        wireFleetActivityReadSource({
+            issuesDir   : '/synced/issues',
+            bridge      : stubBridge(),
+            createSource: opts => { captured = opts; return {readActivitySnapshot() {}} }
+        });
+
+        // The A2A reader must throw (so the composer's per-slot catch degrades it naming the slot),
+        // rather than silently returning an empty-but-'wired'-looking snapshot.
+        await expect((async () => captured.readA2ASnapshot({limit: 5}))()).rejects.toThrow(/a2a activity source not wired/);
+        // The present PR/lane slot is a real reader, not the throwing sentinel.
+        expect(typeof captured.readPrLaneSnapshot).toBe('function');
+    });
+});


### PR DESCRIPTION
Resolves #15339

Wires `createFleetActivityReadSource` onto `FleetControlBridge.activitySource` at the fleet-bridge-server boot — the "live half" of the composer split. `FleetControlBridge.fleetActivity` now answers from a real composed source instead of the by-construction not-wired default. The mailbox + graph singletons are resolved lazily at the entry use site and **injected** (the slot readers never import a singleton, mirroring `readActiveWakeSubscriptionIdentities`); fail-soft leaves the seam unwired when nothing is readable — never a fabricated source, no stub. The PR/lane slot owns the substantive reading: local-synced issue records (`readWorkGraphIssueRecords` — the same records the stall inference walks, so they stay graph-consistent) + work-graph stall findings + injected PRs → the pure builder.

**Honest state (V-B-A, verified live):** the composite is `degraded`, not `wired`. The PR/lane slot reads real data; the A2A slot is identity-gated — the Fleet transport binds no viewer identity until `#15320` (ingress auth, out of scope), so it honestly degrades naming its slot. AC1/AC2 (`wired`/`live`) were over-specified at filing; they auto-follow when `#15320` lands (this wiring is forward-compatible). Corrected on the ticket. Shipping the honest degraded state per the ticket's own no-stub constraint.

Evidence: L3 (live `node devFleetServer` + `fleetActivity` receipt — the achievable in-scope ceiling; full `wired`/`live` needs `#15320`'s A2A identity) → L3 required (installed wiring + real PR/lane reads). Residual: composite `wired`/`live` [`#15320`-gated].

## Deltas from ticket
AC1/AC2 (`wired`/`live`) corrected to `#15320`-gated — the live A2A identity dependency was not visible at filing time (the Fleet transport binds no viewer identity until ingress auth). `readPrs` omitted in v1: no synced-`pulls` reader exists yet, so issues + lane-claims + stall carry the feed (honest-empty, not a stub). Both surfaced on the ticket.

## Test Evidence
- `wireFleetActivityReadSource.spec.mjs` (unit, `playwright.config.unit.mjs`): **3 passed** — fail-soft `null` + bridge-untouched; installs the composed source + hands the factory both slot readers; an absent slot source throws (composer-contained degrade), never a fabricated read.
- **LIVE** `node ai/services/fleet/devFleetServer.mjs` + `POST /fleet {"method":"fleetActivity"}`: PR/lane slot returned real `work-stall` events (`#9404`/`#9492`/`#9950`); the A2A slot degraded naming its slot (`"a2a: Cannot list messages: no agent identity context bound…"`); composite `degraded` — not fabricated, not not-wired. The credential redaction fired in the reason (`authorization=[redacted]`).
- Touched surface `ai/services/fleet/`: 287 fleet unit specs green in the sibling `#15333` lane earlier today (same subsystem) — no regression signal here; this PR adds a new module + a boot-only wire.

## Post-Merge Validation
- [ ] Composite reaches `wired` + `streamAdapterState` `live` once `#15320` binds the A2A identity — this PR is the forward-compatible wiring; `#15320` unblocks the state.
- [ ] `#15293` AC4 (live → loss → recovery banner) becomes witnessable once the composite is `wired` — this PR unblocks it; it does not author the witness.

## Commits
- `b551a44956` — the wiring module + `devFleetServer` integration + unit spec.

Authored by Ada (Claude Opus 4.8, Claude Code). Session 3f892890-5ce2-4045-8290-dbbdff1b987a.
