### PR TITLE
feat(memory-core): operator-steering delivery class + senderPrincipalClass stamp (#15376)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -55,6 +55,13 @@ const
 const LANE_CLAIM_SUBJECT = /^\s*\[lane-claim\]/i;
 
 /**
+ * The principal classes an AgentIdentity node may carry in `properties.accountType`. Anything
+ * outside this set — including an absent field — resolves to `'unclassified'`, never inferred.
+ * `'human'` is the operator-steering class: its messages default to durable-quiet delivery.
+ */
+const KNOWN_PRINCIPAL_CLASSES = new Set(['agent', 'human', 'system']);
+
+/**
  * @summary Extracts a GitHub pull request number from a ticket-style related id.
  * @param {String} ticket Related ticket id such as `#<number>`.
  * @returns {Number|null}
@@ -294,6 +301,26 @@ function setRecordProperties(record, properties) {
 }
 
 /**
+ * @summary Resolves the sender's server-stamped principal class from the identity graph node —
+ * the write-time authority for the `senderPrincipalClass` stamp and the operator-steering
+ * delivery-class derivation. Reads `properties.accountType` off the sender's AgentIdentity node
+ * (hydrating the vicinity first so a fresh process sees peer-seeded identities); an unknown or
+ * absent class resolves to `'unclassified'` — the class is never caller-supplied and never
+ * inferred from message content, so it cannot be forged through the compose path.
+ * @param {Object} db The graph database (GraphService.requireDb result).
+ * @param {String} sentBy Canonical `@`-form sender identity node id.
+ * @returns {String} One of `'agent' | 'human' | 'system' | 'unclassified'`.
+ * @private
+ */
+function resolveSenderPrincipalClass(db, sentBy) {
+    db.getAdjacentNodes(sentBy, 'outbound');
+
+    const accountType = db.nodes.get(sentBy)?.properties?.accountType;
+
+    return KNOWN_PRINCIPAL_CLASSES.has(accountType) ? accountType : 'unclassified'
+}
+
+/**
  * @summary True for intentionally mailbox-only wake suppression cases whose recipients should
  * pick the message up through `list_messages`, not through an interrupt wake.
  * @param {Object} args
@@ -329,11 +356,14 @@ function isAllowedWakeSuppression({subject = '', taggedConcepts = [], to}) {
  * @param {String} args.priority
  * @param {String[]} args.taggedConcepts
  * @param {Object} [args.task]
+ * @param {String} [args.senderPrincipalClass='unclassified'] Server-stamped sender class; the
+ *   `'human'` (operator-steering) class may always suppress — durable-quiet IS its default mode,
+ *   per the operator's own datum that a late wake is noise, not steering.
  * @returns {String|null}
  * @private
  */
-function getWakeSuppressionRisk({wakeSuppressed, to, subject = '', priority = 'normal', taggedConcepts = [], task}) {
-    if (!wakeSuppressed || isAllowedWakeSuppression({subject, taggedConcepts, to})) {
+function getWakeSuppressionRisk({wakeSuppressed, to, subject = '', priority = 'normal', taggedConcepts = [], task, senderPrincipalClass = 'unclassified'}) {
+    if (!wakeSuppressed || senderPrincipalClass === 'human' || isAllowedWakeSuppression({subject, taggedConcepts, to})) {
         return null;
     }
 
@@ -1195,13 +1225,18 @@ class MailboxService extends Base {
      * @param {String[]} [args.relatedSessions] Array of session IDs related to this message
      * @param {String[]} [args.relatedTickets] Array of ticket IDs referenced
      * @param {String} [args.inReplyTo] Message ID this replies to
-     * @param {String} [args.priority='normal'] Message priority ('low', 'normal', or 'high')
+     * @param {String} [args.priority] Message priority ('low', 'normal', or 'high'). Defaults per
+     *   sender principal class: `'high'` for the `'human'` (operator-steering) class — turn-start
+     *   drain-ordering metadata — `'normal'` otherwise.
      * @param {String} [args.partOfThread] Thread ID
      * @param {String[]} [args.taggedConcepts] Array of concept IDs tagged
-     * @param {Boolean} [args.wakeSuppressed=false] Persist the message without emitting `SENT_TO_ME`
+     * @param {Boolean} [args.wakeSuppressed] Persist the message without emitting `SENT_TO_ME`
      *   wake events. Intended for mailbox-only handovers such as session-sunset self-DMs that must be
      *   consumed by the next boot, not injected back into the active sender harness. Known-actionable
-     *   direct lifecycle messages reject wake suppression before persistence.
+     *   direct lifecycle messages reject wake suppression before persistence. Defaults per sender
+     *   principal class: the `'human'` (operator-steering) class defaults to `true` — durable-quiet
+     *   delivery, the sender electing a wake per message by passing `false` — every other class
+     *   defaults to `false` (wake) exactly as before.
      * @param {Object} [args.task] Optional A2A Task envelope payload. Caller fields are cloned, then
      *   the server overwrites `task.assignee`: a direct AgentIdentity recipient is bound immediately;
      *   a broadcast remains `null` until an eligible recipient wins the atomic claim. The top-level
@@ -1211,7 +1246,7 @@ class MailboxService extends Base {
      *   {@link https://a2a-protocol.org/latest/specification/} for the canonical Task envelope.
      * @returns {Promise<Object>}
      */
-    async addMessage({ to, subject, body, originSessionId, relatedSessions = [], relatedTickets = [], inReplyTo, priority = 'normal', partOfThread, taggedConcepts = [], wakeSuppressed = false, task }) {
+    async addMessage({ to, subject, body, originSessionId, relatedSessions = [], relatedTickets = [], inReplyTo, priority = null, partOfThread, taggedConcepts = [], wakeSuppressed = null, task }) {
         const db             = GraphService.requireDb('MailboxService.addMessage');
         const preNormalizeTo = to; // diagnostic payload captures caller-supplied target
         const boundSender    = RequestContextService.getAgentIdentityNodeId();
@@ -1222,6 +1257,16 @@ class MailboxService extends Base {
         // Canonical normalized isolation key for the user_id column. These message nodes/edges are
         // sharedEntity (RLS-moot), but keep the column single-form; `from: sentBy` stays the @-form label.
         const senderUserId = normalizeUserId(sentBy);
+
+        // The server-stamped principal class — resolved from the sender's identity node, never from
+        // caller input, so the operator-steering delivery class cannot be forged through compose.
+        // 'human' inverts the delivery defaults: durable-quiet (wake is the sender's per-message
+        // election, never the default) and priority-high as turn-start drain-ordering metadata.
+        const senderPrincipalClass = resolveSenderPrincipalClass(db, sentBy),
+              operatorSteering     = senderPrincipalClass === 'human';
+
+        priority       = priority       ?? (operatorSteering ? 'high' : 'normal');
+        wakeSuppressed = wakeSuppressed ?? operatorSteering;
 
         // Canonicalize addressing to match the seeded AgentIdentity graph-node IDs. Upstream tool-
         // schema wording exposes the `'AGENT:@login'` prefixed form; the seed uses bare `@login`.
@@ -1324,7 +1369,7 @@ class MailboxService extends Base {
 
         taggedConcepts = canonicalizeTaggedConceptIds(taggedConcepts);
 
-        const wakeSuppressionRisk = getWakeSuppressionRisk({wakeSuppressed, to, subject, priority, taggedConcepts, task});
+        const wakeSuppressionRisk = getWakeSuppressionRisk({wakeSuppressed, to, subject, priority, taggedConcepts, task, senderPrincipalClass});
 
         if (wakeSuppressionRisk) {
             throw new Error(`Cannot suppress wake for ${wakeSuppressionRisk}. Omit wakeSuppressed or set it to false; mailbox-only suppression is reserved for awareness/FYI, session-sunset handover, lead-role baton, and audit-alert messages.`);
@@ -1340,11 +1385,15 @@ class MailboxService extends Base {
         // See https://a2a-protocol.org/latest/specification/ for the canonical envelope shape.
         const messageProperties = {
             subject,
-            bodyText      : body,
+            bodyText: body,
             priority,
-            sentAt        : timestamp,
-            readAt        : null,
-            from          : sentBy,
+            sentAt  : timestamp,
+            readAt  : null,
+            from    : sentBy,
+            // Write-time stamp (rides the WAL + graph projection): the read path projects THIS
+            // field or 'unclassified' — it never re-resolves the sender, so pre-stamp legacy rows
+            // stay honestly unclassified and a later node edit cannot rewrite message provenance.
+            senderPrincipalClass,
             to,
             inReplyTo     : inReplyTo || null,
             partOfThread  : partOfThread || null,
@@ -1872,7 +1921,9 @@ class MailboxService extends Base {
                         sentAt   : messageNode.properties.sentAt,
                         readAt,
                         from     : sentByNodeId,
-                        to       : sentToNodeId
+                        // The write-time stamp, or the honest absent-marker — never inferred at read.
+                        senderPrincipalClass: messageNode.properties.senderPrincipalClass ?? 'unclassified',
+                        to                  : sentToNodeId
                     };
                     if (messageNode.properties.task !== undefined) summary.task = messageNode.properties.task;
                     if (messageNode.properties.wakeSuppressed) summary.wakeSuppressed = true;
@@ -1982,7 +2033,9 @@ class MailboxService extends Base {
             sentAt            : messageNode.properties.sentAt,
             readAt            : getReadAtForMessage(messageNode, deliveryEdge),
             from              : sentBy,
-            to                : sentTo
+            // Same stamp-or-unclassified contract as the listMessages rows — one read-path rule.
+            senderPrincipalClass: messageNode.properties.senderPrincipalClass ?? 'unclassified',
+            to                  : sentTo
         };
         if (messageNode.properties.task !== undefined) result.task = messageNode.properties.task;
         if (messageNode.properties.wakeSuppressed) result.wakeSuppressed = true;

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -1556,6 +1556,106 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         )).toHaveLength(0);
     });
 
+    test('#15376 a human-class sender defaults durable-quiet + priority-high; an explicit false elects the wake', async () => {
+        GraphService.upsertNode({id: '@operator', type: 'AgentIdentity', name: 'Operator', properties: {accountType: 'human'}});
+
+        let quietId, wakeId;
+        await RequestContextService.run({ agentIdentityNodeId: '@operator' }, async () => {
+            // No wakeSuppressed and no priority supplied → the operator-steering class defaults:
+            // durable-quiet (a late wake is noise, not steering) + priority-high drain metadata.
+            const quiet = await MailboxService.addMessage({
+                to     : 'AGENT:*',
+                subject: 'weekend focus: the FM ladder',
+                body   : 'steering payload'
+            });
+            quietId = quiet.messageId;
+
+            // Wake is the sender's PER-MESSAGE election: explicit false wakes like peer traffic.
+            const wake = await MailboxService.addMessage({
+                to            : 'AGENT:*',
+                subject       : 'act now: rebase onto healed dev',
+                body          : 'steering payload',
+                wakeSuppressed: false
+            });
+            wakeId = wake.messageId;
+        });
+
+        const quietNode = GraphService.db.nodes.get(quietId);
+        expect(quietNode.properties.wakeSuppressed).toBe(true);
+        expect(quietNode.properties.priority).toBe('high');
+        expect(quietNode.properties.senderPrincipalClass).toBe('human');
+
+        const wakeNode = GraphService.db.nodes.get(wakeId);
+        expect(wakeNode.properties.wakeSuppressed).toBe(false);
+        expect(wakeNode.properties.priority).toBe('high');
+        expect(wakeNode.properties.senderPrincipalClass).toBe('human');
+    });
+
+    test('#15376 operator-steering suppression is always safe — the shapes agents are rejected for are the human-class default mode', async () => {
+        GraphService.upsertNode({id: '@operator', type: 'AgentIdentity', name: 'Operator', properties: {accountType: 'human'}});
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@operator', scope: 'CAN_REPLY_TO' });
+        });
+
+        // The exact shape the agent-sender reject test above refuses (high-priority direct,
+        // suppressed) is legitimate quiet steering when the server-stamped class is human.
+        await RequestContextService.run({ agentIdentityNodeId: '@operator' }, async () => {
+            const direct = await MailboxService.addMessage({
+                to            : '@bob',
+                subject       : 'urgent direct escalation',
+                body          : 'quiet steering to one peer',
+                priority      : 'high',
+                wakeSuppressed: true
+            });
+            expect(direct.messageId).toBeTruthy();
+
+            const stored = GraphService.db.nodes.get(direct.messageId);
+            expect(stored.properties.wakeSuppressed).toBe(true);
+            expect(stored.properties.senderPrincipalClass).toBe('human');
+        });
+    });
+
+    test('#15376 rows carry the write-time senderPrincipalClass stamp; absent stamps read unclassified — never inferred', async () => {
+        GraphService.upsertNode({id: '@operator',   type: 'AgentIdentity', name: 'Operator',  properties: {accountType: 'human'}});
+        GraphService.upsertNode({id: '@agentclass', type: 'AgentIdentity', name: 'Agent',     properties: {accountType: 'agent'}});
+        GraphService.upsertNode({id: '@classless',  type: 'AgentIdentity', name: 'Classless', properties: {}});
+
+        let operatorMsg, agentMsg, classlessMsg;
+        await RequestContextService.run({ agentIdentityNodeId: '@operator' }, async () => {
+            operatorMsg = (await MailboxService.addMessage({to: 'AGENT:*', subject: 'stamped human', body: 'x'})).messageId;
+        });
+        await RequestContextService.run({ agentIdentityNodeId: '@agentclass' }, async () => {
+            agentMsg = (await MailboxService.addMessage({to: 'AGENT:*', subject: 'stamped agent', body: 'x'})).messageId;
+        });
+        await RequestContextService.run({ agentIdentityNodeId: '@classless' }, async () => {
+            classlessMsg = (await MailboxService.addMessage({to: 'AGENT:*', subject: 'stamped unclassified', body: 'x'})).messageId;
+        });
+
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            const {messages} = await MailboxService.listMessages({status: 'all'});
+            const row        = id => messages.find(message => message.messageId === id);
+
+            expect(row(operatorMsg).senderPrincipalClass).toBe('human');
+            expect(row(agentMsg).senderPrincipalClass).toBe('agent');
+            // An absent/unknown accountType stamps 'unclassified' at write — the read path never
+            // re-resolves the sender node, so provenance cannot be rewritten after the fact.
+            expect(row(classlessMsg).senderPrincipalClass).toBe('unclassified');
+
+            const single = await MailboxService.getMessage({messageId: operatorMsg});
+            expect(single.senderPrincipalClass).toBe('human');
+        });
+
+        // The true LEGACY shape: a pre-stamp MESSAGE node with no senderPrincipalClass property at
+        // all. Strip the stamp in place and re-read — the projection's fallback must report the
+        // honest absent-marker rather than inferring a class.
+        delete GraphService.db.nodes.get(classlessMsg).properties.senderPrincipalClass;
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            const {messages} = await MailboxService.listMessages({status: 'all'});
+            expect(messages.find(message => message.messageId === classlessMsg).senderPrincipalClass).toBe('unclassified');
+        });
+    });
+
     test('addMessage still allows wakeSuppressed non-claim FYI/progress broadcasts (the scoping that avoids the blanket-ban trap)', async () => {
         let msgId;
 


### PR DESCRIPTION
Resolves #15376

The ingress-independent MailboxService half of the D#15372 Brain slice, complete and review-ready: the write-time `senderPrincipalClass` stamp, the one-rule read projection, and the `operator-steering` delivery class with the operator's inverted wake defaults. The verb-side ACs (compose verb + smuggling negative + per-principal falsifier) are split to successor #15379 (blocked-by #15320, mirroring the #15333 → #15339 honest-close-target precedent) — recorded on the ticket. This diff is the contract #15377's Body half builds against.

Evidence: L2 (unit — 118/118 MailboxService specs green locally; the #15364 collision does not reproduce on this box, so the local oracle is live) → L2 sufficient (contract/behavior ACs; this half has no runtime-host surface). Residual: verb-side AC-1/AC-2/AC-6 [#15379, #15320-gated].

## What ships in this diff

- **Write-time principal stamp (AC-3):** `addMessage` resolves the sender's class from the identity node's `accountType` (`agent | human | system`, else `'unclassified'`) via `resolveSenderPrincipalClass` — server-resolved, never caller-supplied — and stamps it into the message properties, riding the WAL and graph projection. The read paths (`listMessages` rows and `getMessage`) project the stamp or the honest `'unclassified'`; they never re-resolve the sender, so pre-stamp legacy rows stay unclassified and a later node edit cannot rewrite message provenance. The operator node needs no migration: `identityRoots.mjs:319` already seeds `accountType: 'human'`.
- **The operator-steering class (AC-7, behavioral half):** derived from the stamp — a human-class sender IS the class, so it cannot be forged through the compose path (this retires the taggable-marker recognition the ticket sketched; a tag is attachable, the stamp is not). Delivery defaults invert exactly per the revised AC-7: `wakeSuppressed` defaults `true` (durable-quiet; wake is a per-message sender election via explicit `false`), `priority` defaults `'high'` as turn-start drain-ordering metadata, and suppression is always safe for the class (the actionable-shape rejections are agent-class rules). Null-default resolution keeps every other class byte-identical (`false` / `'normal'` as before — the full existing suppression battery passes unchanged).
- **AC-7's never-wake-already-read property — pre-existing substrate, cited not rebuilt:** the wake daemon already reconciles per-recipient read-state (`isMessageRead`: `DELIVERED_TO`-edge `readAt`, else node `readAt` — the exact #15322/#15357 carrier model), filters digests to genuinely-unread messages, and suppresses a wake whose delta was entirely already-read — witnessed since #12479 (`daemon.spec.mjs:900`).

## Deltas from ticket

The class-recognition mechanism is stronger than sketched: derived-from-stamp instead of any attachable marker (unforgeable by construction). The `accountType` population AC-3 sub-item was a projection artifact (`get_node` hides properties); the seed already carries it — recorded on the ticket. The never-wake-already-read witness obligation is satisfied by existing #12479 coverage rather than new daemon code. The verb-side ACs split to #15379 per the operator's tempo directive (ship reviewable units; a parked branch or a draft is not one).

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` → **118 passed** locally at the branch head (115 existing incl. the full wake-suppression battery, unchanged + 3 new witnesses).
- New witnesses: human-class defaults (quiet + high) with per-message wake election · always-safe suppression against the exact shape the agent-class reject test refuses · stamp projection across human/agent/unclassified plus the true-legacy no-stamp fallback (stamp deleted in place → row reads `'unclassified'`, never inferred).
- Touched surface `ai/services/memory-core/`: the MailboxService suite IS the per-surface coverage; the wake-daemon dedupe is covered by its own existing spec (cited above).

## Post-Merge Validation

- [ ] First real operator message through the merged rails carries `senderPrincipalClass: 'human'` in every consumer's `list_messages` view.
- [ ] #15379 (the compose verb) builds on this stamp behind #15320's boundary — its live receipts complete D#15372's slice ACs.

## Commits

- bb0c01cf4d — the stamp + projection + class row + 3 witnesses.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 64f444d3-1042-4091-a56f-08332b6cc7a2.
