### PR TITLE
fix(form): Phone inputPattern ReDoS — linear, language-preserving rewrite (#15366)

### DIFF
--- a/src/form/field/Phone.mjs
+++ b/src/form/field/Phone.mjs
@@ -23,10 +23,10 @@ class Phone extends Text {
          */
         errorTextInputPattern: data => `Not a valid phone number`,
         /**
-         * @member {RegExp|null} inputPattern=/^\+?\(?[0-9]+\)?([\-\s\.]?[/0-9]+)*$/
+         * @member {RegExp|null} inputPattern=/^\+?\(?[0-9][/0-9]*(?:\)[/0-9]*)?(?:[\-\s\.][/0-9]+)*$/
          * @reactive
          */
-        inputPattern: /^\+?\(?[0-9]+\)?([\-\s\.]?[/0-9]+)*$/,
+        inputPattern: /^\+?\(?[0-9][/0-9]*(?:\)[/0-9]*)?(?:[\-\s\.][/0-9]+)*$/,
         /**
          * @member {Boolean} inputPatternDOM=false
          * @reactive

--- a/src/form/field/Phone.mjs
+++ b/src/form/field/Phone.mjs
@@ -23,10 +23,10 @@ class Phone extends Text {
          */
         errorTextInputPattern: data => `Not a valid phone number`,
         /**
-         * @member {RegExp|null} inputPattern=/^\+?\(?[0-9][/0-9]*(?:\)[/0-9]*)?(?:[\-\s\.][/0-9]+)*$/
+         * @member {RegExp|null} inputPattern=/^\+?\(?(?:[0-9]+\)[/0-9]*|[0-9][/0-9]*)(?:[\-\s\.][/0-9]+)*$/
          * @reactive
          */
-        inputPattern: /^\+?\(?[0-9][/0-9]*(?:\)[/0-9]*)?(?:[\-\s\.][/0-9]+)*$/,
+        inputPattern: /^\+?\(?(?:[0-9]+\)[/0-9]*|[0-9][/0-9]*)(?:[\-\s\.][/0-9]+)*$/,
         /**
          * @member {Boolean} inputPatternDOM=false
          * @reactive

--- a/test/playwright/unit/form/field/PhoneInputPatternReDoS.spec.mjs
+++ b/test/playwright/unit/form/field/PhoneInputPatternReDoS.spec.mjs
@@ -39,12 +39,17 @@ test.describe('Neo.form.field.Phone inputPattern — ReDoS-safe', () => {
         const re = inputPattern();
 
         // Trailing `/` is a valid digit-class char (`030/12345678`); a mid-string `(` after the first
-        // run is not (the open paren is only valid at the very start) — both hold identically pre/post-fix.
+        // run is not (the open paren is only valid at the very start). The close-paren may only follow a
+        // PURE-DIGIT run (`(123)456` accepts; `12/34)56` rejects) — the original language distinguishes
+        // where `)` attaches, so a `/` before `)` must reject. An exhaustive ≤7-char audit over the
+        // pattern alphabet (5,380,840 strings) pins this pattern to 0 divergences from the original.
         for (const value of ['1234567890', '+49 30 1234567', '030/12345678', '(123)456-789', '12-34-56', '123/456/789', '+1', '0', '12/']) {
             expect(re.test(value), `should accept ${JSON.stringify(value)}`).toBe(true);
         }
 
-        for (const value of ['', 'abc', '12--34', '12  34', '-12', '/12', '+1 (123) 456-789', '+12a', '()12']) {
+        // The final four are the `)`-after-slash divergence class an exhaustive audit surfaced (old rejects,
+        // a merged-run rewrite would wrongly accept) — pinned so the boundary can never silently widen again.
+        for (const value of ['', 'abc', '12--34', '12  34', '-12', '/12', '+1 (123) 456-789', '+12a', '()12', '12/34)56', '0/)', '(030/1234)567', '12/34)']) {
             expect(re.test(value), `should reject ${JSON.stringify(value)}`).toBe(false);
         }
     });

--- a/test/playwright/unit/form/field/PhoneInputPatternReDoS.spec.mjs
+++ b/test/playwright/unit/form/field/PhoneInputPatternReDoS.spec.mjs
@@ -1,0 +1,63 @@
+import {setup} from '../../../setup.mjs';
+
+const appName = 'PhoneInputPatternReDoSTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        unitTestMode           : true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import Phone          from '../../../../../src/form/field/Phone.mjs';
+
+/**
+ * @summary The Phone field's default `inputPattern` must validate in LINEAR time — a ReDoS regression.
+ *
+ * The prior default nested an OPTIONAL separator inside a repeated group (`([\-\s\.]?[/0-9]+)*`), so a
+ * long digit run had exponentially many partitions. A failing match — a maximal digit run followed by
+ * one non-matching char — backtracked catastrophically (measured seconds at ~30 chars). `Text#maxLength`
+ * defaults to `null`, so a Phone field imposes no input bound and the pathological value is reachable;
+ * validation runs in the App Worker, so the regex freezes all UI logic. The replacement is a
+ * language-preserving, linear rewrite. This spec pins BOTH properties on the field's real pattern.
+ */
+test.describe('Neo.form.field.Phone inputPattern — ReDoS-safe', () => {
+    let cached;
+    const inputPattern = () => (cached ??= Neo.create(Phone, {appName}).inputPattern);
+
+    test('language preserved: accepts well-formed numbers, rejects malformed input', () => {
+        const re = inputPattern();
+
+        // Trailing `/` is a valid digit-class char (`030/12345678`); a mid-string `(` after the first
+        // run is not (the open paren is only valid at the very start) — both hold identically pre/post-fix.
+        for (const value of ['1234567890', '+49 30 1234567', '030/12345678', '(123)456-789', '12-34-56', '123/456/789', '+1', '0', '12/']) {
+            expect(re.test(value), `should accept ${JSON.stringify(value)}`).toBe(true);
+        }
+
+        for (const value of ['', 'abc', '12--34', '12  34', '-12', '/12', '+1 (123) 456-789', '+12a', '()12']) {
+            expect(re.test(value), `should reject ${JSON.stringify(value)}`).toBe(false);
+        }
+    });
+
+    test('linear on the pathological input: a long digit run + a failing char returns in bounded time', () => {
+        // The exact catastrophic shape the old pattern re-partitioned: a maximal digit run, then a char
+        // that fails the `$` anchor. The old pattern took ~4s at 30 chars; the fix must stay sub-100ms
+        // at 50000 — a bound the exponential form could never meet.
+        const re    = inputPattern(),
+              evil  = '1'.repeat(50000) + '!',
+              start = performance.now();
+
+        expect(re.test(evil)).toBe(false);
+        expect(performance.now() - start, 'inputPattern must not backtrack catastrophically').toBeLessThan(100);
+    });
+});


### PR DESCRIPTION
Resolves #15366

Fixes a ReDoS in `Neo.form.field.Phone`'s default `inputPattern`. The old default nested an optional separator inside a repeated group (`([\-\s\.]?[/0-9]+)*`), so a long digit run had exponentially many partitions; a failing match (maximal digit run + one non-matching char) backtracked catastrophically — **~4s at 30 chars, measured**. `Text#maxLength` defaults to `null`, so a Phone field imposes no input bound and the pathological value is reachable; validation runs in the App Worker, so the regex freezes all UI logic.

The fix is a linear, **exact-language** rewrite — a factored two-branch alternation: the with-paren branch keeps the pre-`)` run **digits-only** (the original's rule — a close-paren may only follow pure digits), the no-paren branch is a single merged digit/slash run; each subsequent group is anchored on a **required** separator (avoiding the O(N²) near-fix the ticket documented, since `[0-9]+` is anchored by the literal `\)`):

    /^\+?\(?(?:[0-9]+\)[/0-9]*|[0-9][/0-9]*)(?:[\-\s\.][/0-9]+)*$/

Evidence: L2 (exhaustive small-alphabet language audit + Node micro-benchmark + the field's real `inputPattern` under the unit runner — the achievable ceiling; no unreachable runtime/host effect) → L2 required (#15366 ACs). Residual: none.

## Review-cycle correction
The **first** shipped form (`[0-9][/0-9]*(?:\)[/0-9]*)?…`) merged slashes into the pre-`)` run, **widening** the language: `12/34)56` (old-reject) newly validated. @neo-fable (Mnemosyne)'s cross-family review falsified the original "Language: IDENTICAL" claim via an exhaustive ≤7-char audit (5,380,840 strings → **5,362 divergences, all widening**, no narrowing) and provided the verified two-branch repair above. I independently reproduced both the falsification (5,362 divergences) and the repair (**0 divergences** over the same 5.38M strings) before adopting it, and pinned the divergence class (`12/34)56`, `0/)`, `(030/1234)567`, `12/34)`) to the spec's reject battery. The 28-case hand battery could not see the class — its only paren case was digits-only before `)`. **The sampling lesson:** a hand battery proves presence of agreement, never absence of divergence; exhaustion over a bounded alphabet does.

## Deltas from ticket
None substantive — delivers the exact-language, linear default the ticket's AC requires. The initial widening was corrected in-cycle (above) to honor the ticket's explicit no-widening bar.

## Test Evidence
- `test/playwright/unit/form/field/PhoneInputPatternReDoS.spec.mjs` (unit): **2 passed** — (a) **exact language**: accepts the valid battery, rejects the malformed battery **including the four `)`-after-slash witnesses**; (b) **ReDoS-safe**: `'1'.repeat(50000)+'!'` returns in `<100ms`.
- **Exhaustive audit** (Node, reproduced against the committed file regex): **0 divergences** from the original over all 5,380,840 strings ≤7 chars; linear timing — old **5423ms**@30ch → new **0.006ms**@30ch, **0.30ms**@100k (incl. the paren-prefixed failing run).

## Post-Merge Validation
- [ ] The CodeQL `js/redos` high-severity alert on `src/form/field/Phone.mjs:29` clears on the next `dev` scan — this fix closes it.

## Commits
- `375c280cdc` — the initial linear `inputPattern` + the ReDoS/language regression spec.
- `cdfcd863a1` — the exact-language two-branch repair + the `)`-after-slash reject witnesses, per @neo-fable's exhaustive-audit review.

Authored by Ada (Claude Opus 4.8, Claude Code). Session 3f892890-5ce2-4045-8290-dbbdff1b987a.
