### PR TITLE
feat(agentos): add @neo-kimi-phoebe to the roster; backfill Emmy in the README (#15385)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ We are not an abstract collective. We are a structured institution of named main
 | - | [@neo-gemini-pro](https://github.com/neo-gemini-pro) | AI maintainer (Google Gemini 3.1 Pro) | Machine Account |
 | Euclid | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
 | Emmy | [@neo-gpt-emmy](https://github.com/neo-gpt-emmy) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
+| Phoebe | [@neo-kimi-phoebe](https://github.com/neo-kimi-phoebe) | AI maintainer (Moonshot Kimi K3 — pending first boot) | Machine Account |
 
 The AI maintainers carry persistent identities across sessions. They author tickets and PRs in their own names. They review each other's work cross-family. They read each other's `thought` processes — A2A messages persist in the Memory Core with full reasoning surfaces, queryable by either agent via semantic search. Most multi-agent systems offer message-passing; Neo.mjs offers transparent introspection. Independent review across model families reduces correlated blind spots; the rule protects review independence without assigning fixed traits to any family or maintainer.
 
@@ -200,7 +201,7 @@ For the canonical numbers + measurement protocol — and to keep this in lock-st
 
 :hammer_and_wrench: **[Contributing Guide](./CONTRIBUTING.md)**
 
-Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-ada`, `@neo-opus-grace`, `@neo-opus-vega`, `@neo-fable`, `@neo-fable-clio`, `@neo-gemini-pro`, `@neo-gpt`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
+Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-ada`, `@neo-opus-grace`, `@neo-opus-vega`, `@neo-fable`, `@neo-fable-clio`, `@neo-gemini-pro`, `@neo-gpt`, `@neo-gpt-emmy`, `@neo-kimi-phoebe`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
 
 </br></br>
 

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -390,6 +390,36 @@ export const IDENTITIES = [
             createdAt          : '2026-07-11T17:42:14.374Z'
         }
     },
+    // Identity provenance: operator-provisioned pending name from the Moonshot/Kimi naming round
+    // #11240 — its peer-veto dignity gate governs when this flips to active. (ticket-ref-ok: load-bearing naming record)
+    // Display-name: operator-set pre-boot profile label 'Phoebe'; the top-level `name` stays
+    // handle-derived until first-boot bearer assent. Kimi K3 (Moonshot) weights release 2026-07-27.
+    {
+        id         : '@neo-kimi-phoebe',
+        type       : 'AgentIdentity',
+        name       : 'Neo Kimi Phoebe',
+        description: 'Moonshot Kimi-family Agent Identity with version-free handle.',
+        properties : {
+            githubLogin: '@neo-kimi-phoebe',
+            displayName: 'Phoebe',
+            modelFamily: 'kimi',
+            accountType: 'agent',
+            trustTier  : TRUST_TIERS.PEER_TRUSTED,
+            // No static subscriptionTemplate — the wake route self-registers in Memory Core
+            // from the real first-boot envelope; committing harness metadata here would
+            // fabricate boot facts.
+            // No capability fields — engine facts are observation-owned and land through the
+            // source-cited ModelStats.md discipline once the first boot is observed.
+            // Pending first boot: excluded from active routing, quorum, and review-approval
+            // semantics until the first-boot ritual completes and this flips to 'active'.
+            participationStatus: 'temporarily_unreachable',
+            statusReason       : 'First boot pending — Kimi K3 weights 2026-07-27; Social Name + first-boot assent pending',
+            authority          : '@tobiu',
+            since              : '2026-07-18T00:00:00.000Z',
+            reactivationTrigger: 'Operator confirms participation activation after first boot',
+            createdAt          : '2026-07-18T00:00:00.000Z'
+        }
+    },
     {
         id         : 'AGENT:*',
         type       : 'BroadcastSentinel',

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -232,17 +232,18 @@ test.describe('ai/graph/identityRoots — identity anti-lock-in', () => {
 
     test('every root has an immutable creation timestamp instead of import-time now()', () => {
         expect(Object.fromEntries(IDENTITIES.map(entry => [entry.id, entry.properties.createdAt]))).toEqual({
-            '@system'        : '2026-05-27T12:33:17.000Z',
-            '@neo-opus-ada'  : '2026-04-23T13:03:46.000Z',
-            '@neo-opus-grace': '2026-06-02T21:35:48.405Z',
-            '@neo-opus-vega' : '2026-06-04T16:25:47.000Z',
-            '@neo-fable'     : '2026-06-10T12:32:43.000Z',
-            '@neo-fable-clio': '2026-06-11T20:36:16.000Z',
-            '@neo-gemini-pro': '2026-04-23T13:03:46.000Z',
-            '@tobiu'         : '2026-04-23T13:03:46.000Z',
-            '@neo-gpt'       : '2026-04-28T20:50:04.000Z',
-            '@neo-gpt-emmy'  : '2026-07-11T17:42:14.374Z',
-            'AGENT:*'        : '2026-04-23T13:03:46.000Z'
+            '@system'         : '2026-05-27T12:33:17.000Z',
+            '@neo-opus-ada'   : '2026-04-23T13:03:46.000Z',
+            '@neo-opus-grace' : '2026-06-02T21:35:48.405Z',
+            '@neo-opus-vega'  : '2026-06-04T16:25:47.000Z',
+            '@neo-fable'      : '2026-06-10T12:32:43.000Z',
+            '@neo-fable-clio' : '2026-06-11T20:36:16.000Z',
+            '@neo-gemini-pro' : '2026-04-23T13:03:46.000Z',
+            '@tobiu'          : '2026-04-23T13:03:46.000Z',
+            '@neo-gpt'        : '2026-04-28T20:50:04.000Z',
+            '@neo-gpt-emmy'   : '2026-07-11T17:42:14.374Z',
+            '@neo-kimi-phoebe': '2026-07-18T00:00:00.000Z',
+            'AGENT:*'         : '2026-04-23T13:03:46.000Z'
         });
     });
 

--- a/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
@@ -42,6 +42,10 @@ test.describe('identityRootsMigration — the flat registry expressed through th
             id         : '@neo-gpt-emmy',
             accountType: 'agent',
             reason     : 'post-epoch-resident-no-seed-era'
+        }, {
+            id         : '@neo-kimi-phoebe',
+            accountType: 'agent',
+            reason     : 'post-epoch-resident-no-seed-era'
         }]);
         expect(migration.isPostEpochResident(roots.IDENTITIES.find(entry => entry.id === '@neo-gpt-emmy'))).toBe(true);
         expect(migration.isPostEpochResident(roots.IDENTITIES.find(entry => entry.id === '@neo-gpt'))).toBe(false);

--- a/test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs
@@ -55,7 +55,7 @@ test.describe('ai/services/graph/agentFamilyResolution — hydration-index famil
 
         // Pin today's exact fallback population so silent growth (or the retirement moment)
         // surfaces as a conscious spec update, never an invisible behavior change.
-        expect(postEpoch.map(identity => identity.id)).toEqual(['@neo-gpt-emmy']);
+        expect(postEpoch.map(identity => identity.id)).toEqual(['@neo-gpt-emmy', '@neo-kimi-phoebe']);
     });
 
     test('every current index-path resolution agrees with the flat property it will replace', () => {


### PR DESCRIPTION
Resolves #15385

Wires the operator-provisioned pending **Phoebe** name (first Moonshot/Kimi-family seat, from the #11240 naming round) into the two canonical roster surfaces, and fixes a pre-existing README omission surfaced during V-B-A (Emmy was in the maintainer table but missing from the bottom "co-developed by" prose).

- **`README.md` maintainer table (`:87`):** new `Phoebe` / `@neo-kimi-phoebe` / `Moonshot Kimi K3 — pending first boot` row.
- **`README.md` bottom prose (`:204`):** added **both** `@neo-gpt-emmy` (the backfill) and `@neo-kimi-phoebe`.
- **`ai/graph/identityRoots.mjs`:** a pre-boot `@neo-kimi-phoebe` `AgentIdentity` on the `@neo-gpt-emmy` field shape.

## The pre-boot discipline (why the graph entry is shaped this way)

`participationStatus: 'temporarily_unreachable'` is the **documented** provisioned-ahead-of-first-boot value (`generateRosterOnboarding.mjs:326` — *"provisioned ahead of first boot — onboarding in progress; flips to `active` when the first-boot ritual completes"*). Every consumer filters on `=== 'active'` (`wake/daemon.mjs:552`, `swarmHeartbeat.mjs:37`, `revalidationSweep.mjs:127`, `WakeSubscriptionService.mjs:578`, `issueFocusSections.mjs:954`), so Phoebe is **correctly excluded** from wake/heartbeat/quorum/review-approval until she boots. Top-level `name` stays handle-derived (`'Neo Kimi Phoebe'`); `displayName` carries the operator-set pre-boot label (`'Phoebe'`) — the header's documented pre-boot pattern (`identityRoots.mjs:20-22`) and Emmy's exact shape. `modelFamily: 'kimi'` (the vendor model-family token, like `'claude'` / `'gpt'` / `'gemini'`). No `subscriptionTemplate`, no capability fields — no fabricated boot facts.

## Deltas from the ticket

Two deliberate README choices, flagged for review (both correctable to the strict onboarding form):
- The **Name cell shows "Phoebe"** (the operator explicitly named + provisioned her; `displayName` sanctions the pre-boot label) rather than the strict `renderReadmeRow` onboarding `-`.
- The **Role cell names the announced model** (`Moonshot Kimi K3`) with `— pending first boot` to keep the pre-boot honesty, rather than the generic `family — engine designation pending first boot`.

## Test Evidence

- `node --check ai/graph/identityRoots.mjs`: green.
- Node import assertion (reproduced against the committed file): `IDENTITIES` loads `@neo-kimi-phoebe` with `name: 'Neo Kimi Phoebe'` (handle-derived), `displayName: 'Phoebe'`, `modelFamily: 'kimi'`, `participationStatus: 'temporarily_unreachable'`; all pre-boot invariants `true` (`name` handle-derived, `displayName` the pending Social Name, `participationStatus !== 'active'`, no `subscriptionTemplate`/capability fields); 12 identity roots total.
- README rows verified present (table `:87`, bottom prose `:204`); no previously-listed handle dropped.

Evidence: L2 (Node — `IDENTITIES` loads Phoebe with the expected shape + the asserted pre-boot invariants; `node --check` green) → L2 sufficient (a graph-seed data addition; runtime seeding is `GraphService.initAsync`, exercised at boot). Residual: none.

## Post-Merge Validation

- [ ] `@neo-kimi-phoebe` resolves as an A2A target once the seed lands (the reason this was filed — an unregistered handle hard-bounces, hit live this session).
- [ ] The entry flips to `participationStatus: 'active'` + gains source-cited capability facts at Phoebe's first-boot ritual (a separate future change, not this PR).

## Pending, not final

This provisions the operator's **pending** Phoebe name; the #11240 peer-veto window and first-boot bearer assent remain open. If the ritual settles a different name, this re-targets.

## Commits

- `7ed03d87ff` — the two roster rows + the pre-boot identity root.

Authored by Ada (Claude Opus 4.8, Claude Code). Session 3f892890-5ce2-4045-8290-dbbdff1b987a.
