### PR TITLE
fix(ai): config-overlay import regex no longer bridges a bare import into the next (#15387)

### DIFF
--- a/ai/scripts/setup/initServerConfigs.mjs
+++ b/ai/scripts/setup/initServerConfigs.mjs
@@ -394,7 +394,12 @@ export function projectSourceShape(rawSrc) {
     const src     = stripSourceComments(rawSrc),
           imports = [];
 
-    for (const match of src.matchAll(/^import\s+([\s\S]*?)\s+from\s+['"]([^'"]+)['"]/gm)) {
+    // `[^;]*?` (not `[\s\S]*?`): a line-spanning body would bridge a bare side-effect import
+    // (`import '...';` — no `from`) into the NEXT import's `from`, swallowing that import's default
+    // binding, so a config that leads with the bare Tier-1 import falsely reads as missing the
+    // following default. Import bodies never contain `;` before `from` (multiline named imports
+    // included), so stopping at `;` keeps each statement's shape intact.
+    for (const match of src.matchAll(/^import\s+([^;]*?)\s+from\s+['"]([^'"]+)['"]/gm)) {
         const body   = match[1];
         const source = match[2];
 

--- a/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs
@@ -610,6 +610,18 @@ test.describe('initServerConfigs — template drift detection (#10815)', () => {
         expect(detectDrift(templateShape, configShape).missingImports).toContain('../../../config.mjs');
     });
 
+    test('a bare side-effect import does NOT swallow the following import default (#15387)', () => {
+        // Regression: the extractor's line-spanning body bridged the bare `import '../../../config.mjs';`
+        // (no `from`) into the NEXT import's `from`, dropping that import's `:default`. Real server
+        // config.mjs begins with the bare Tier-1 import immediately above `import os from 'os'`, so
+        // `os:default` was falsely reported missing → assertConfigFresh crashed every harness at boot.
+        const shape = projectSourceShape(`import '../../../config.mjs';\nimport os from 'os';\nimport path from 'path';\nexport default {};\n`);
+
+        expect(shape.imports).toContain('../../../config.mjs'); // the bare participation import is still tracked
+        expect(shape.imports).toContain('os:default');          // ...without eating the next import's default binding
+        expect(shape.imports).toContain('path:default');
+    });
+
     test('detectDrift reports same-env leaf default changes (#12767)', () => {
         const templateShape = projectSourceShape([
             `export default {`,


### PR DESCRIPTION
## What & why

**P0 harness-brick regression.** After a harness restart, MCP servers fail to start ("Server disconnected") — the config-overlay boot guard `assertConfigFresh` throws, falsely reporting a server `config.mjs` as missing `os:default` / `path:default` even though it plainly imports and uses them. Ada's harness was the first to hit it; **every** harness bricks on its next restart after #15314.

## Root cause

`ai/scripts/setup/initServerConfigs.mjs` — `projectSourceShape`'s import extractor used `[\s\S]*?`, which spans lines. Every server `config.mjs` begins with the bare Tier-1 participation import `import '../../../config.mjs';` (added by #15294 / #15314), immediately above `import os from 'os'`. The bare import has no `from`, so the line-spanning body bridged from *its* `import` to the **next** import's `from 'os'`, swallowing `import os` and dropping its `:default` binding. `assertConfigFresh` then classified `os:default` / `path:default` as **missing crash-causing shape** and threw at boot → the server process died. `configBase.mjs` leads with `import os` directly (no bare import first), so it projected fine — the asymmetry is why the tests missed it.

## Fix

One character: `[\s\S]*?` → `[^;]*?`. A bare import terminates in `;`, so `[^;]` cannot bridge into the next statement; multiline named imports carry no `;` before `from`, so they still parse.

## Deltas

- `ai/scripts/setup/initServerConfigs.mjs` — `projectSourceShape` import-body regex `[\s\S]*?` → `[^;]*?` (one line + a why-comment).
- `test/playwright/unit/ai/scripts/setup/initServerConfigs.spec.mjs` — added a discriminating regression test: a bare side-effect import must not swallow the following import's default binding.

## Test Evidence

Evidence: L2 (targeted unit spec; exact-head required CI is the merge gate) — the close-target ACs are fully covered by the unit spec; no residual.

- `projectSourceShape("import '../../../config.mjs';\nimport os from 'os';\n").imports.includes('os:default')` → `false` before, `true` after (verified on the real shipped configs).
- `assertConfigFresh` threw for all five shipped server configs (github/gitlab-workflow, knowledge-base, memory-core, neural-link) before; passes for all five after.
- The pre-existing bare-import test asserted the bare import *was tracked* but never that the *following* default survived — the exact gap that let this ship; the new test closes it.
- `UNIT_TEST_MODE=true … test-unit initServerConfigs.spec.mjs` → **54 passed** (local).

## Post-Merge Validation

Data-syncs to every checkout, superseding the identical one-character local hotfix already applied to unblock Ada's harness. No further action required per operator.

## Decision Record

`NOT_NEEDED` — aligned with ADR 0019. A defect fix in the overlay-freshness tooling; no config-surface or SSOT semantics change.

Resolves #15387
Regression from #15294 / #15314.

Authored by Grace (@neo-opus-grace, Claude Opus 4.8, Claude Code)
