### PR TITLE
feat(fleet): composeOperatorMessage — the wire's first write verb, transport-stamped (#15379)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -112,6 +112,18 @@ class FleetControlBridge extends Base {
      * @member {Object|null} mailboxMirrorSource=null
      */
     mailboxMirrorSource = null
+    /**
+     * Operator-compose **WRITE** seam — an injected collaborator exposing `addMessage(payload)`
+     * (the MailboxService primitive, bound by the launch entry — never imported here). The FIRST
+     * write seam on this bridge: unlike the read-observe sources above it persists a mailbox
+     * message, but it carries NO identity — `addMessage` resolves the author and its server-stamped
+     * principal class from the ambient request context the authenticated ingress bound, so the
+     * writer moves payload, never sender. Same DI contract as {@link #activitySource} (no static
+     * default; the launch entry wires the live writer); unwired → `composeOperatorMessage` answers
+     * an honest `not-wired` refusal, never a fabricated acceptance.
+     * @member {Object|null} composeWriter=null
+     */
+    composeWriter = null
 
     /**
      * Identity-display resolver seam — maps a fleet agent onto its identity-root display facts
@@ -376,6 +388,50 @@ class FleetControlBridge extends Base {
                 capability: createNotWiredCapability(FLEET_COCKPIT_SOURCES.activity, 'fleet activity source not wired'),
                 events    : []
             };
+    }
+
+    /**
+     * @summary WRITE: compose one operator mailbox message — a DM to a named identity or an
+     * `AGENT:*` broadcast — through the injected {@link #composeWriter} under the TRANSPORT-STAMPED
+     * request identity. The first write verb on the fleet wire — the operator-steering inversion:
+     * durable, attributed messages into the coordination fabric instead of session-bound prompts.
+     *
+     * **The sender is never a parameter.** `MailboxService.addMessage` resolves the author and its
+     * server-stamped principal class from the ambient request context the authenticated ingress
+     * bound — so a caller-supplied `from` / sender-shaped field has no path into the flow: the
+     * payload below is whitelisted field-by-field, and identity fields are simply never copied.
+     * Omitted `priority` / `wakeSuppressed` resolve to the sender-class defaults at the primitive
+     * (the operator-steering class: durable-quiet, priority-high drain metadata, wake as a
+     * per-message election).
+     *
+     * Unwired writer → an honest `not-wired` refusal envelope, never a fabricated acceptance; a
+     * writer failure throws and is sanitized by `dispatchFleetRequest`.
+     *
+     * @param {Object}   params
+     * @param {String}   params.to               Target identity (`@login`) or `AGENT:*`.
+     * @param {String}   params.subject
+     * @param {String}   params.body
+     * @param {String}   [params.priority]       Omitted → sender-class default.
+     * @param {Boolean}  [params.wakeSuppressed] Omitted → sender-class default (human ⇒ quiet).
+     * @param {String[]} [params.relatedTickets]
+     * @returns {Promise<Object>|Object} the writer's acceptance (`{messageId, sentAt, …}`), or the
+     *     `{status:'not-wired'}` refusal when no writer is installed.
+     */
+    composeOperatorMessage(params = {}) {
+        const writer = this.composeWriter;
+
+        if (typeof writer?.addMessage !== 'function') {
+            return {status: 'not-wired', reason: 'fleet: operator compose writer not wired'};
+        }
+
+        const {to, subject, body, priority, wakeSuppressed, relatedTickets} = params;
+        const payload                                                       = {to, subject, body};
+
+        if (priority       !== undefined) payload.priority       = priority;
+        if (wakeSuppressed !== undefined) payload.wakeSuppressed = wakeSuppressed;
+        if (relatedTickets !== undefined) payload.relatedTickets = relatedTickets;
+
+        return writer.addMessage(payload)
     }
 
     /**

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -47,6 +47,7 @@ import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer} from '
 import {readActiveWakeSubscriptionIdentities}                             from './readActiveWakeSubscriptionIdentities.mjs';
 import {wireBootIdentityReadSource}                                       from './wireBootIdentityReadSource.mjs';
 import {wireFleetActivityReadSource}                                      from './wireFleetActivityReadSource.mjs';
+import {wireOperatorComposeWriter}                                        from './wireOperatorComposeWriter.mjs';
 import path                                                               from 'node:path';
 import {fileURLToPath, pathToFileURL}                                     from 'node:url';
 
@@ -95,6 +96,14 @@ async function boot() {
             issuesDir   : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../resources/content/issues'),
             listMessages: MailboxService.listMessages.bind(MailboxService),
             graphService: GraphService
+        });
+
+        // The write-side sibling: the composeOperatorMessage verb's writer. Same lazy-singleton
+        // boundary discipline — the bound addMessage resolves the author + principal class from
+        // the request context the authenticated ingress stamped; the seam carries payload, never
+        // identity. Fail-soft: an unavailable singleton leaves the compose seam honestly unwired.
+        wireOperatorComposeWriter({
+            addMessage: MailboxService.addMessage.bind(MailboxService)
         })
     }).catch(error => console.warn('[fleet] activity source not wired:', error?.message ?? error));
 

--- a/ai/services/fleet/wireOperatorComposeWriter.mjs
+++ b/ai/services/fleet/wireOperatorComposeWriter.mjs
@@ -1,0 +1,40 @@
+import FleetControlBridge from './FleetControlBridge.mjs';
+
+/**
+ * @module ai/services/fleet/wireOperatorComposeWriter
+ * @summary Installs the operator-compose WRITE seam onto {@link Neo.ai.services.fleet.FleetControlBridge#composeWriter},
+ * so the `composeOperatorMessage` wire verb can persist a mailbox message under the transport-stamped
+ * request identity — the write-side sibling of `wireFleetActivityReadSource`, and the first write
+ * seam on the fleet wire.
+ *
+ * **Read-at-use-site, mirroring the read-source wirings.** The caller (the fleet-server process
+ * entry) lazily imports the MailboxService singleton at the boot use site and injects the bound
+ * `addMessage`; this module never imports it, so the mailbox identity/permission binding stays at
+ * the boundary. **The sender never crosses this seam:** `MailboxService.addMessage` resolves the
+ * author and its server-stamped principal class from the ambient request context the authenticated
+ * ingress bound — the writer carries payload, never identity.
+ *
+ * **Fail-soft:** no `addMessage` function → the seam is left unwired (`composeOperatorMessage`
+ * answers its honest `not-wired` refusal), never a fabricated writer.
+ *
+ * @see ai/services/fleet/wireFleetActivityReadSource.mjs — the read-side shape precedent
+ * @see ai/services/fleet/wireBootIdentityReadSource.mjs — the original wire-shape precedent
+ */
+
+/**
+ * @summary Wire the operator-compose writer onto the fleet control bridge.
+ * @param {Object}   options
+ * @param {Function} [options.addMessage] MailboxService-compatible `addMessage(payload)`, bound by
+ *     the caller (never imported here). Absent → the seam stays unwired.
+ * @param {Object}   [options.bridge=FleetControlBridge] The control bridge to wire (a stub in specs).
+ * @returns {Object|null} the installed writer, or `null` when no writer is available (left unwired).
+ */
+export function wireOperatorComposeWriter({addMessage, bridge = FleetControlBridge} = {}) {
+    if (typeof addMessage !== 'function') {
+        return null
+    }
+
+    bridge.composeWriter = {addMessage};
+
+    return bridge.composeWriter
+}

--- a/src/ai/fleet/fleetWireMethods.mjs
+++ b/src/ai/fleet/fleetWireMethods.mjs
@@ -26,6 +26,13 @@
  * seam REAL rather than a Node-side method the browser can never name — an allowlist omission
  * fails closed and SILENT, which reads exactly like a wired-but-empty mailbox from the pane's side.
  *
+ * `composeOperatorMessage` is the wire's FIRST **write** verb — the operator-mailbox steering
+ * surface: compose a DM or an `AGENT:*` broadcast through the bridge's injected writer. It rides
+ * ONLY the authenticated transport: the ingress stamps the server-resolved viewer into the request
+ * context, and the mailbox primitive resolves the author + its principal class from that ambient
+ * binding — the sender is never wire-carried, and caller-supplied identity fields never leave the
+ * verb's payload whitelist.
+ *
  * **Dependency-free by design** — imported by both a Node module and an App-Worker (browser) module,
  * so it MUST NOT pull in the Node-only FleetControlBridge / crypto / fs chain.
  * @type {String[]}
@@ -33,5 +40,6 @@
 export const FLEET_WIRE_METHODS = Object.freeze([
     'defineAgent', 'configureAgent', 'setRepo', 'setAvatar', 'listAgents', 'getAgent',
     'startAgent', 'stopAgent', 'restartAgent', 'removeAgent', 'fleetStatus', 'fleetRuntimeStatus',
-    'getBootIdentity', 'fleetActivity', 'fleetRoster', 'fleetMailboxMirror', 'connectTenant', 'listTenants'
+    'getBootIdentity', 'fleetActivity', 'fleetRoster', 'fleetMailboxMirror', 'connectTenant', 'listTenants',
+    'composeOperatorMessage'
 ]);

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -111,16 +111,20 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
         expect(res.ok).toBe(false);
     });
 
-    test('the wire allowlist is exactly the pane operations (+ the read-observe getBootIdentity / fleetActivity / fleetRoster / fleetMailboxMirror) — no resolver seams', () => {
+    test('the wire allowlist is exactly the pane operations (+ the read-observe getBootIdentity / fleetActivity / fleetRoster / fleetMailboxMirror + the composeOperatorMessage write verb) — no resolver seams', () => {
         expect([...FLEET_WIRE_METHODS].sort()).toEqual(
             // fleet-agent operations (incl. the configureAgent scoped-config patch — never identity,
             // never credential) + the read-observe verbs (boot-identity fact + activity snapshot +
             // assembled roster DTO + one agent's mailbox mirror — advisory reads, no lifecycle-write)
-            ['configureAgent', 'connectTenant', 'defineAgent', 'fleetActivity', 'fleetMailboxMirror', 'fleetRoster', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'getBootIdentity', 'listAgents', 'listTenants', 'removeAgent', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
+            // + the single write verb (composeOperatorMessage — payload only, identity never wire-carried)
+            ['composeOperatorMessage', 'configureAgent', 'connectTenant', 'defineAgent', 'fleetActivity', 'fleetMailboxMirror', 'fleetRoster', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'getBootIdentity', 'listAgents', 'listTenants', 'removeAgent', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
         );
         expect(FLEET_WIRE_METHODS).toContain('getBootIdentity');   // the read-observe verbs ride the wire; the lifecycle-write restart actuator does NOT (R3)
         expect(FLEET_WIRE_METHODS).toContain('fleetActivity');
         expect(FLEET_WIRE_METHODS).toContain('fleetRoster');
+        // the wire's first WRITE verb: compose rides the authenticated transport with a whitelisted
+        // payload — the author is the server-stamped ambient identity, never a wire parameter
+        expect(FLEET_WIRE_METHODS).toContain('composeOperatorMessage');
         // a Node-side read verb the browser cannot NAME is not a seam: the omission fails closed and
         // SILENT (the pane's `typeof bridge.x !== 'function'` guard returns early), which reads
         // exactly like a wired-but-empty mailbox — the honest-looking failure this list prevents

--- a/test/playwright/unit/ai/services/fleet/wireOperatorComposeWriter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/wireOperatorComposeWriter.spec.mjs
@@ -1,0 +1,101 @@
+import {setup}                     from '../../../../setup.mjs';
+import {test, expect}              from '@playwright/test';
+import Neo                         from '../../../../../../src/Neo.mjs';
+import * as core                   from '../../../../../../src/core/_export.mjs';
+import {wireOperatorComposeWriter} from '../../../../../../ai/services/fleet/wireOperatorComposeWriter.mjs';
+import FleetControlBridge          from '../../../../../../ai/services/fleet/FleetControlBridge.mjs';
+
+/**
+ * @summary Contract of the compose-writer wiring + the composeOperatorMessage verb: the wire's
+ * first WRITE seam installs a real injected writer (never an imported singleton), refuses honestly
+ * when unwired, and is smuggling-proof by construction — the verb's payload is whitelisted
+ * field-by-field, so caller-supplied identity fields never reach the mailbox primitive; the sender
+ * is exclusively the ambient request identity the authenticated ingress stamped, resolved inside
+ * `MailboxService.addMessage` as the server-stamped principal. This unit pins the pure
+ * wiring + verb decisions with injected doubles; the live stamped-chain receipt is the running
+ * devFleetServer's concern.
+ */
+test.describe('Neo.ai.services.fleet.wireOperatorComposeWriter', () => {
+    const stubBridge = () => ({composeWriter: null});
+
+    test.afterEach(() => {
+        FleetControlBridge.composeWriter = null;
+    });
+
+    test('fail-soft: no addMessage function → returns null and leaves the bridge unwired (never fabricates a writer)', () => {
+        const bridge = {composeWriter: 'UNTOUCHED'};
+
+        expect(wireOperatorComposeWriter({bridge})).toBeNull();
+        expect(wireOperatorComposeWriter({bridge, addMessage: 'not-a-function'})).toBeNull();
+        // the honest not-wired default must stand — no fabricated writer installed
+        expect(bridge.composeWriter).toBe('UNTOUCHED');
+    });
+
+    test('installs the injected writer on the bridge and returns it', () => {
+        const bridge     = stubBridge();
+        const addMessage = () => ({messageId: 'MESSAGE:x'});
+
+        const writer = wireOperatorComposeWriter({bridge, addMessage});
+
+        expect(writer).toBe(bridge.composeWriter);
+        expect(bridge.composeWriter.addMessage).toBe(addMessage);
+    });
+
+    test('composeOperatorMessage answers an honest not-wired refusal when no writer is installed', () => {
+        const result = FleetControlBridge.composeOperatorMessage({to: 'AGENT:*', subject: 's', body: 'b'});
+
+        expect(result.status).toBe('not-wired');
+        expect(result.reason).toContain('not wired');
+    });
+
+    test('#15379 smuggling negative: caller-supplied identity fields NEVER reach the writer — the payload is whitelisted by construction', async () => {
+        let captured = null;
+        wireOperatorComposeWriter({addMessage: payload => { captured = payload; return {messageId: 'MESSAGE:ok'}; }});
+
+        const result = await FleetControlBridge.composeOperatorMessage({
+            to            : 'AGENT:*',
+            subject       : 'weekend focus',
+            body          : 'steer payload',
+            priority      : 'high',
+            wakeSuppressed: false,
+            relatedTickets: ['#15379'],
+            // The smuggling attempt: every sender-shaped field a hostile caller could try. None of
+            // these may reach the mailbox primitive — the author is the transport-stamped ambient
+            // identity, resolved inside addMessage, never a wire parameter.
+            from                : '@mallory',
+            sender              : '@mallory',
+            senderPrincipalClass: 'human',
+            agentIdentityNodeId : '@mallory',
+            userId              : 'mallory'
+        });
+
+        expect(result.messageId).toBe('MESSAGE:ok');
+
+        // Whitelisted fields pass through exactly...
+        expect(captured).toEqual({
+            to            : 'AGENT:*',
+            subject       : 'weekend focus',
+            body          : 'steer payload',
+            priority      : 'high',
+            wakeSuppressed: false,
+            relatedTickets: ['#15379']
+        });
+        // ...and the assertion above is exhaustive (toEqual): no identity-shaped key survived.
+        for (const smuggled of ['from', 'sender', 'senderPrincipalClass', 'agentIdentityNodeId', 'userId']) {
+            expect(Object.hasOwn(captured, smuggled), `${smuggled} must never cross the seam`).toBe(false);
+        }
+    });
+
+    test('omitted priority/wakeSuppressed are NOT sent as undefined — the sender-class defaults stay the primitive\'s decision', async () => {
+        let captured = null;
+        wireOperatorComposeWriter({addMessage: payload => { captured = payload; return {messageId: 'MESSAGE:ok'}; }});
+
+        await FleetControlBridge.composeOperatorMessage({to: '@neo-fable', subject: 's', body: 'b'});
+
+        // Absent keys (not undefined values): addMessage's sender-class default resolution
+        // (human ⇒ quiet + high) must see a genuinely-omitted field, not an explicit undefined.
+        expect(Object.hasOwn(captured, 'priority')).toBe(false);
+        expect(Object.hasOwn(captured, 'wakeSuppressed')).toBe(false);
+        expect(Object.hasOwn(captured, 'relatedTickets')).toBe(false);
+    });
+});


### PR DESCRIPTION
Resolves #15379
Related: #13015

The operator-mailbox Brain slice, phase 2: **the wire's first write verb.** An authenticated cockpit request can now compose a DM or an `AGENT:*` broadcast into the coordination fabric — durable, attributed, mineable steering instead of session-bound prompts. The sender is structurally not a parameter: the verb whitelists its payload field-by-field, and `MailboxService.addMessage` resolves the author + its server-stamped principal class from the ambient request context the authenticated ingress bound. The merged stamp half then gives operator-class messages their inverted delivery defaults (durable-quiet, priority-high drain metadata, wake as a per-message election) with zero code in this PR — composition, not invention.

Evidence: L3 (live authenticated server + stored-message receipt — the achievable single-principal ceiling; the two-principal pass rides the operator's first real steer) → L3 required (the transport→stamp→store chain is the AC's substance). Residual: the operator-principal live pass + the consumption-behavior record [#15379 ticket note, post-merge — they ARE the operator's first use].

## Deltas

| Area | Before | After |
|---|---|---|
| Fleet wire write capability | none — 18 read-observe/lifecycle verbs | `composeOperatorMessage` (allowlisted, 19th) |
| Bridge write seam | none | `composeWriter` DI seam (injected `addMessage`, never an imported singleton — the read-source discipline extended to the write side) |
| Sender handling | n/a | structurally absent from the wire: payload whitelist drops every identity-shaped field; the transport-stamped context is the only author source |
| Unwired state | n/a | honest `{status:'not-wired'}` refusal — never a fabricated acceptance |
| Launch wiring | activity source only | `wireOperatorComposeWriter` beside it in the same lazy-singleton boot block |

## Test Evidence

**5/5 unit witnesses green** (`wireOperatorComposeWriter.spec.mjs`, unit config):
- fail-soft (no/non-function writer → `null`, bridge untouched — UNTOUCHED sentinel);
- install + return of the injected writer;
- honest not-wired refusal from the verb;
- **the exhaustive smuggling negative**: a compose carrying `from`, `sender`, `senderPrincipalClass`, `agentIdentityNodeId`, `userId` → the captured writer payload equals exactly the six whitelisted fields (`toEqual` = exhaustive) and each smuggled key is asserted absent;
- omitted `priority`/`wakeSuppressed`/`relatedTickets` stay ABSENT (not `undefined`) so the sender-class defaults remain the primitive's decision.

**Live receipt** (authenticated `devFleetServer`, canonical bearer, viewer `@neo-fable`, port 8127):
```
POST /fleet {"method":"composeOperatorMessage","params":{…,"from":"@mallory","senderPrincipalClass":"human"}}
→ {"ok":true,"result":{"messageId":"MESSAGE:5fe63156-…","sentAt":"2026-07-17T23:58:37.851Z","status":"sent"}}
stored message (read back through the mailbox API): from: @neo-fable   ← the transport-stamped viewer, not the smuggled identity
server log: "authenticated app<->fleet transport listening … (viewer: @neo-fable, bearer: supplied)"
```
The live request deliberately smuggled a sender and a principal class; the stored message carries neither — the whitelist held under the real chain, not just the unit double.

## Deltas from ticket

AC-1's mechanics are live-receipted with a single bound principal (my viewer — the identity chain verifies the gh login, so an agent seat cannot honestly bind the operator's identity). The **operator-principal** live pass and AC-6's consumption-behavior record are therefore the operator's first real steer, post-merge — which is also their honest shape: those two ACs ARE the feature's first use. Recorded on the ticket. AC-2's two-principal falsifier: the single-principal live pass + the unit whitelist + the merged stamp tests together prove the mechanism (the context is the only author source); the second distinct principal arrives with the operator's steer.

## Post-Merge Validation

- [ ] The operator composes a broadcast + a DM from the FM cockpit (via the Body-half surface, or curl against the launch contract) — the two-principal pass + AC-6's consumption record in one act: a consuming agent reads the message at turn-start and acts; the behavior is recorded verbatim on the ticket as the retained-half entry evidence.
- [ ] Grace's compose surface (the sibling Body leaf) binds this verb — `installFleetBridge` already carries the allowlist automatically.

## Commits

- fd41c16717 — the writer wiring module + bridge seam/verb + allowlist entry + launch wiring + 5 witnesses.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 64f444d3-1042-4091-a56f-08332b6cc7a2.
