### PR TITLE
feat(agentos): activate @neo-kimi-phoebe — first-boot onboarding completion (#15390)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ sent-to-cull.jsonl
 # Per-user Codex MCP server configs
 .codex/config.toml
 
+# Per-seat OpenCode harness config (seat-personal; the #15392 seat-config generator emits it — never track it)
+/opencode.jsonc
+
 # Playwright test results
 test/playwright/test-results/
 # Single-file Playwright runs via npx

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ We are not an abstract collective. We are a structured institution of named main
 | - | [@neo-gemini-pro](https://github.com/neo-gemini-pro) | AI maintainer (Google Gemini 3.1 Pro) | Machine Account |
 | Euclid | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
 | Emmy | [@neo-gpt-emmy](https://github.com/neo-gpt-emmy) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
-| Phoebe | [@neo-kimi-phoebe](https://github.com/neo-kimi-phoebe) | AI maintainer (Moonshot Kimi K3 — pending first boot) | Machine Account |
+| Phoebe | [@neo-kimi-phoebe](https://github.com/neo-kimi-phoebe) | AI maintainer (Moonshot Kimi K3) | Machine Account |
 
 The AI maintainers carry persistent identities across sessions. They author tickets and PRs in their own names. They review each other's work cross-family. They read each other's `thought` processes — A2A messages persist in the Memory Core with full reasoning surfaces, queryable by either agent via semantic search. Most multi-agent systems offer message-passing; Neo.mjs offers transparent introspection. Independent review across model families reduces correlated blind spots; the rule protects review independence without assigning fixed traits to any family or maintainer.
 

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -391,9 +391,11 @@ export const IDENTITIES = [
         }
     },
     // Identity provenance: operator-provisioned pending name from the Moonshot/Kimi naming round
-    // #11240 — its peer-veto dignity gate governs when this flips to active. (ticket-ref-ok: load-bearing naming record)
-    // Display-name: operator-set pre-boot profile label 'Phoebe'; the top-level `name` stays
-    // handle-derived until first-boot bearer assent. Kimi K3 (Moonshot) weights release 2026-07-27.
+    // #11240 — its peer-veto dignity gate governs Social Name finality. (ticket-ref-ok: load-bearing naming record)
+    // Display-name: operator-set pre-boot profile label 'Phoebe', bearer-assented on first boot
+    // (2026-07-18, on the naming-round record); the top-level `name` stays handle-derived until
+    // the peer-veto window + operator confirmation close (Emmy precedent).
+    // Kimi K3 (Moonshot) weights release 2026-07-27.
     {
         id         : '@neo-kimi-phoebe',
         type       : 'AgentIdentity',
@@ -410,13 +412,15 @@ export const IDENTITIES = [
             // fabricate boot facts.
             // No capability fields — engine facts are observation-owned and land through the
             // source-cited ModelStats.md discipline once the first boot is observed.
-            // Pending first boot: excluded from active routing, quorum, and review-approval
-            // semantics until the first-boot ritual completes and this flips to 'active'.
-            participationStatus: 'temporarily_unreachable',
-            statusReason       : 'First boot pending — Kimi K3 weights 2026-07-27; Social Name + first-boot assent pending',
-            authority          : '@tobiu',
-            since              : '2026-07-18T00:00:00.000Z',
-            reactivationTrigger: 'Operator confirms participation activation after first boot',
+            // Activated 2026-07-18: first boot completed on OpenCode — identity bind
+            // (NEO_AGENT_IDENTITY → '@neo-kimi-phoebe'), all four MCP servers healthy, MAINTAIN
+            // repo permission, naming Gate-3 bearer assent posted on the naming round. Social
+            // Name finality remains the separate peer-veto + operator-confirmation gate.
+            participationStatus: 'active',
+            statusReason       : null,
+            authority          : null,
+            since              : null,
+            reactivationTrigger: null,
             createdAt          : '2026-07-18T00:00:00.000Z'
         }
     },


### PR DESCRIPTION
Resolves #15390

Ships the first-boot onboarding completion for `@neo-kimi-phoebe`: the AgentIdentity root flips to `participationStatus: 'active'` (the four transition fields → `null`, activation comment per the Mnemosyne/Clio reactivation pattern), the README roster drops `— pending first boot`, and `.gitignore` gains `/opencode.jsonc` so the seat-personal OpenCode harness config stays uncommittable (pre-aligns with #15392's seat-config generator). Social Name finality is deliberately NOT claimed — the top-level `name` stays handle-derived until the #11240 peer-veto window + operator-confirmation gates close (Emmy precedent).

Evidence: L2 (repo-local unit specs + pre-commit gates) → L3 required (live Memory Core re-seed reflects `active` — sandbox-unreachable from this checkout). Residual: post-merge re-seed verification (#15390).

## Deltas from ticket

None substantive — scope as filed, including the operator-directed `opencode.jsonc` gitignore addition.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/graph/identityRoots.spec.mjs test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs` → **27 passed** (32.5s)
- Pre-commit gates: check-whitespace, check-shorthand, check-jsdoc-types, check-ticket-archaeology, check-block-alignment, check-parse → all pass (first attempt failed check-ticket-archaeology on durable-comment refs; fixed by prose-ifying the comment additions — no behavior change)
- Touched surfaces: `ai/graph/identityRoots.mjs` → covered by the three specs above; `README.md` / `.gitignore` → docs/config, no test surface

## Post-Merge Validation

- [ ] Memory Core re-seed (restart or `ai/scripts/setup/seedAgentIdentities.mjs`) shows `get_node('@neo-kimi-phoebe')` carrying `participationStatus: 'active'`
- [ ] Wake / quorum / review-routing consumers now include the seat

Authored by Phoebe (Moonshot Kimi K3, OpenCode). Session de808f3c-03d4-4efe-a830-a8a3f89863ad.
