### PR TITLE
feat(fleet): wire the synced-pulls reader so the FM activity feed emits PR events (#15382)

### DIFF
--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -84,15 +84,17 @@ async function boot() {
     // Wire the composed activitySource onto FleetControlBridge. The memory-core mailbox + graph
     // singletons are imported lazily at this boot use site (mirroring readActiveWakeSubscriptionIdentities's
     // lazy GraphService) and INJECTED — the composer's slot readers never import a singleton, so the
-    // mailbox identity/permission binding stays here. issuesDir is the synced content tree; readPrs is
-    // omitted in v1 (no synced-`pulls` reader yet — the feed carries issues + lane-claims + stall), which
-    // is honest-empty, not a stub. Fail-soft: an unavailable singleton leaves activitySource unwired.
+    // mailbox identity/permission binding stays here. issuesDir + pullsDir are the synced content trees;
+    // the pulls reader fills the composer's last honest-empty slot so the PR/lane slot emits pr-activity
+    // events (opens/reviews/merges) alongside issues + lane-claims + stall. Fail-soft: an unavailable
+    // singleton leaves activitySource unwired.
     Promise.all([
         import('../memory-core/MailboxService.mjs'),
         import('../memory-core/GraphService.mjs')
     ]).then(([{default: MailboxService}, {default: GraphService}]) => {
         wireFleetActivityReadSource({
             issuesDir   : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../resources/content/issues'),
+            pullsDir    : path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../resources/content/pulls'),
             listMessages: MailboxService.listMessages.bind(MailboxService),
             graphService: GraphService
         })

--- a/ai/services/fleet/fleetPrLaneActivityAdapter.mjs
+++ b/ai/services/fleet/fleetPrLaneActivityAdapter.mjs
@@ -116,7 +116,7 @@ export function createPrActivityEvents(prs = [], {capturedAt = new Date()} = {})
                     state           : pr.state || null,
                     author,
                     reviewDecision  : pr.reviewDecision || null,
-                    isDraft         : Boolean(pr.isDraft),
+                    isDraft         : pr.isDraft ?? null,
                     relatedPrs      : number ? [number] : [],
                     relatedTickets,
                     deferDisposition: normalizeDeferDisposition(getPrDeferDisposition(pr, new Date(capturedAt))),

--- a/ai/services/fleet/wireFleetActivityReadSource.mjs
+++ b/ai/services/fleet/wireFleetActivityReadSource.mjs
@@ -61,7 +61,7 @@ function makeReadPrLaneSnapshot({issuesDir, pullsDir, graphService}) {
         const capturedAt = new Date();
 
         try {
-            const prs           = (typeof pullsDir === 'string' && pullsDir.length > 0) ? readSyncedPullRecords(pullsDir) : [],
+            const prs           = (typeof pullsDir === 'string' && pullsDir.length > 0) ? readSyncedPullRecords(pullsDir, {limit: params.limit}) : [],
                   issues        = readWorkGraphIssueRecords(issuesDir),
                   stallFindings = buildWorkGraphStallFindings({issuesDir, prs, now: capturedAt, graphService});
 

--- a/ai/services/fleet/wireFleetActivityReadSource.mjs
+++ b/ai/services/fleet/wireFleetActivityReadSource.mjs
@@ -3,6 +3,7 @@ import {createFleetActivityReadSource}     from './fleetActivityComposer.mjs';
 import {readFleetA2AActivitySnapshot}      from './fleetA2AActivityAdapter.mjs';
 import {createFleetPrLaneActivitySnapshot} from './fleetPrLaneActivityAdapter.mjs';
 import {buildWorkGraphStallFindings,
+        readSyncedPullRecords,
         readWorkGraphIssueRecords}           from '../graph/issueFocusSections.mjs';
 
 /**
@@ -44,23 +45,23 @@ function makeReadA2ASnapshot(listMessages) {
 }
 
 /**
- * @summary The PR/lane slot reader — reads local-synced issue records + work-graph stall findings +
- * injected PR payloads, then hands them to the pure builder. A read failure becomes a degraded
+ * @summary The PR/lane slot reader — reads local-synced issue + pull records + work-graph stall
+ * findings, then hands them to the pure builder. A read failure becomes a degraded
  * capability naming the slot (the builder's `error` path), never a thrown snapshot that would take the
  * whole composite down.
  * @param {Object} options
  * @param {String} options.issuesDir Local synced issue directory (`resources/content/issues`).
+ * @param {String} [options.pullsDir] Local synced pulls directory (`resources/content/pulls`); omit for no PR events.
  * @param {Object} [options.graphService] memory-core GraphService for stall-finding defer disposition.
- * @param {Function} [options.readPrs] Optional `async params => pr payloads[]`; omit for no PR events.
  * @returns {Function} `params => Promise<{capability, events}>`
  * @private
  */
-function makeReadPrLaneSnapshot({issuesDir, graphService, readPrs}) {
+function makeReadPrLaneSnapshot({issuesDir, pullsDir, graphService}) {
     return async params => {
         const capturedAt = new Date();
 
         try {
-            const prs           = typeof readPrs === 'function' ? await readPrs(params) : [],
+            const prs           = (typeof pullsDir === 'string' && pullsDir.length > 0) ? readSyncedPullRecords(pullsDir) : [],
                   issues        = readWorkGraphIssueRecords(issuesDir),
                   stallFindings = buildWorkGraphStallFindings({issuesDir, prs, now: capturedAt, graphService});
 
@@ -87,7 +88,8 @@ function makeReadPrLaneSnapshot({issuesDir, graphService, readPrs}) {
  *     caller (never imported here). Absent → the A2A slot degrades.
  * @param {Object} [options.graphService] memory-core GraphService for stall-finding defer disposition
  *     (injected; the caller lazily imports the singleton).
- * @param {Function} [options.readPrs] Optional `async params => pr payloads[]`.
+ * @param {String} [options.pullsDir] Local synced pulls directory (`resources/content/pulls`), read at
+ *     the caller's use site. Absent → the PR/lane slot emits no pr-activity events (honest-empty).
  * @param {Number} [options.limit] Default event bound forwarded to the composer.
  * @param {Object} [options.bridge=FleetControlBridge] The control bridge to wire (a stub in specs).
  * @param {Function} [options.createSource=createFleetActivityReadSource] The composer factory (injected in specs).
@@ -97,7 +99,7 @@ export function wireFleetActivityReadSource({
     issuesDir,
     listMessages,
     graphService,
-    readPrs,
+    pullsDir,
     limit,
     bridge       = FleetControlBridge,
     createSource = createFleetActivityReadSource
@@ -117,7 +119,7 @@ export function wireFleetActivityReadSource({
         : () => { throw new Error('a2a activity source not wired — no listMessages bound') };
 
     const readPrLaneSnapshot = hasPrLane
-        ? makeReadPrLaneSnapshot({issuesDir, graphService, readPrs})
+        ? makeReadPrLaneSnapshot({issuesDir, pullsDir, graphService})
         : () => { throw new Error('pr-lane activity source not wired — no issuesDir') };
 
     bridge.activitySource = createSource({readA2ASnapshot, readPrLaneSnapshot, limit});

--- a/ai/services/graph/issueFocusSections.mjs
+++ b/ai/services/graph/issueFocusSections.mjs
@@ -681,6 +681,54 @@ export function readWorkGraphIssueRecords(issuesDir) {
 }
 
 /**
+ * @summary Reads synced pull-request markdown into deterministic PR records — the sibling of
+ * {@link readWorkGraphIssueRecords} for the fleet-activity PR/lane slot. Each record carries the
+ * synced frontmatter (`number`, `title`, `author`, `state`, the lifecycle timestamps, `url`) plus
+ * the markdown body — the shape `createPrActivityEvents` (fleetPrLaneActivityAdapter) consumes.
+ * Reuses {@link collectIssueMarkdownFiles} (a generic recursive `.md` collector, despite its
+ * issue-era name). Fail-soft: an absent or unreadable directory yields `[]`, never a throw — the
+ * PR/lane slot then honestly emits no pr-activity events rather than taking the composite down.
+ *
+ * @param {String} pullsDir Local synced pulls directory (`resources/content/pulls`).
+ * @returns {Array<Object>} Parsed PR records; empty when the directory is absent or unreadable.
+ */
+export function readSyncedPullRecords(pullsDir) {
+    let files;
+
+    try {
+        files = collectIssueMarkdownFiles(pullsDir);
+    } catch (error) {
+        logger.warn(`[fleet-activity] synced pulls directory unreadable: ${pullsDir}`, error);
+        return []
+    }
+
+    const records = [];
+
+    for (const filePath of files) {
+        let parsed;
+
+        try {
+            parsed = matter(fs.readFileSync(filePath, 'utf-8'));
+        } catch (error) {
+            logger.warn(`[fleet-activity] failed to parse synced pull markdown: ${filePath}`, error);
+            continue
+        }
+
+        const meta = parsed.data || {};
+
+        // Skip any non-PR markdown (a record with no `number` in its frontmatter); every synced
+        // pull file carries its PR number, so this only guards against stray index/metadata files.
+        if (meta.number === undefined || meta.number === null) {
+            continue
+        }
+
+        records.push({...meta, body: parsed.content || '', filePath})
+    }
+
+    return records
+}
+
+/**
  * @summary Detects deliberate-defer state for an issue work item.
  *
  * @param {Object} issue Parsed issue work record.

--- a/ai/services/graph/issueFocusSections.mjs
+++ b/ai/services/graph/issueFocusSections.mjs
@@ -680,31 +680,133 @@ export function readWorkGraphIssueRecords(issuesDir) {
     return records
 }
 
-/**
- * @summary Reads synced pull-request markdown into deterministic PR records — the sibling of
- * {@link readWorkGraphIssueRecords} for the fleet-activity PR/lane slot. Each record carries the
- * synced frontmatter (`number`, `title`, `author`, `state`, the lifecycle timestamps, `url`) plus
- * the markdown body — the shape `createPrActivityEvents` (fleetPrLaneActivityAdapter) consumes.
- * Reuses {@link collectIssueMarkdownFiles} (a generic recursive `.md` collector, despite its
- * issue-era name). Fail-soft: an absent or unreadable directory yields `[]`, never a throw — the
- * PR/lane slot then honestly emits no pr-activity events rather than taking the composite down.
- *
- * @param {String} pullsDir Local synced pulls directory (`resources/content/pulls`).
- * @returns {Array<Object>} Parsed PR records; empty when the directory is absent or unreadable.
- */
-export function readSyncedPullRecords(pullsDir) {
-    let files;
+const PULL_REVIEW_STATES = new Set(['APPROVED', 'CHANGES_REQUESTED', 'COMMENTED', 'DISMISSED']);
 
-    try {
-        files = collectIssueMarkdownFiles(pullsDir);
-    } catch (error) {
-        logger.warn(`[fleet-activity] synced pulls directory unreadable: ${pullsDir}`, error);
+// CONTENT_GRAMMAR.md: a `## Reviews` entry is `### `@user` (<STATE>) reviewed on <ISO_Z>`.
+const PULL_REVIEW_ENTRY_PATTERN = /^###\s+`(@?[^`]+)`\s+\(([A-Z_]+)\)\s+reviewed on\s+(\S+)/;
+
+/**
+ * @summary Extracts the PR number from a `pr-<N>.md` synced-pull path so the candidate set can be
+ * ranked WITHOUT reading each file (the pre-parse bound).
+ * @param {String} filePath
+ * @returns {Number} the PR number, or `-1` when the basename does not match (ranked last).
+ * @private
+ */
+function prNumberFromPath(filePath) {
+    const match = /pr-(\d+)\.md$/.exec(filePath);
+
+    return match ? Number(match[1]) : -1
+}
+
+/**
+ * @summary Parses the `## Reviews` section of a synced-pull body into structured per-review facts —
+ * the shape {@link getPrHumanGateState} consumes. CONTENT_GRAMMAR.md serializes each review as
+ * `` ### `@user` (<STATE>) reviewed on <ISO_Z> ``; only the `## Reviews` section is scanned (the next
+ * `## ` header bounds it, per the grammar's "separate sections" rule). An unknown STATE is kept
+ * verbatim — neutral downstream, since the gate acts only on APPROVED / CHANGES_REQUESTED.
+ * @param {String} body The markdown body (frontmatter already stripped by gray-matter).
+ * @returns {Array<{author: String, state: String, submittedAt: String}>}
+ * @private
+ */
+function parsePullReviewEntries(body) {
+    if (typeof body !== 'string' || !body.includes('## Reviews')) {
         return []
     }
 
+    const reviews   = [];
+    let   inReviews = false;
+
+    for (const line of body.split('\n')) {
+        if (/^##\s+\S/.test(line)) {
+            inReviews = /^##\s+Reviews\s*$/.test(line);
+            continue
+        }
+
+        if (!inReviews) continue;
+
+        const match = PULL_REVIEW_ENTRY_PATTERN.exec(line);
+
+        if (match) {
+            reviews.push({author: match[1].trim(), state: match[2], submittedAt: match[3]})
+        }
+    }
+
+    return reviews
+}
+
+/**
+ * @summary Derives the GitHub-style `reviewDecision` from structured reviews — latest-per-author, with
+ * CHANGES_REQUESTED dominating an APPROVED. Mirrors {@link getPrHumanGateState}'s own latest-per-author
+ * reduction so the consumer's two reads (`reviewDecision` + `reviews`) cannot disagree.
+ * @param {Array<{author: String, state: String, submittedAt: String}>} reviews
+ * @returns {String|null} `'CHANGES_REQUESTED'` | `'APPROVED'` | `null` (no decisive review).
+ * @private
+ */
+function deriveReviewDecision(reviews) {
+    const latestByAuthor = new Map();
+
+    for (const review of reviews) {
+        const existing = latestByAuthor.get(review.author);
+
+        if (!existing || new Date(review.submittedAt || 0) > new Date(existing.submittedAt || 0)) {
+            latestByAuthor.set(review.author, review)
+        }
+    }
+
+    const latest = [...latestByAuthor.values()];
+
+    if (latest.some(review => review.state === 'CHANGES_REQUESTED')) return 'CHANGES_REQUESTED';
+    if (latest.some(review => review.state === 'APPROVED'))          return 'APPROVED';
+
+    return null
+}
+
+/**
+ * @summary Reads synced pull-request markdown into deterministic PR records — the sibling of
+ * {@link readWorkGraphIssueRecords} for the fleet-activity PR/lane slot. Each record projects the
+ * synced frontmatter (`number`, `title`, `author`, `state`, lifecycle timestamps, `url`) PLUS the
+ * structured review facts the consumer actually reads: `reviews: [{author, state, submittedAt}]`
+ * parsed from the `## Reviews` body section (CONTENT_GRAMMAR.md) and the derived `reviewDecision` —
+ * so `getPrHumanGateState` (fleetPrLaneActivityAdapter) emits truthful approved / changes-requested
+ * facts rather than reading raw frontmatter that never carried them.
+ *
+ * **Absent vs unreadable (three states, not two).** An OMITTED `pullsDir` is the caller's concern (the
+ * wiring returns honest-empty WITHOUT calling this reader). A CONFIGURED directory that cannot be
+ * collected — missing or unreadable — **THROWS** (via `collectIssueMarkdownFiles`' `fs.readdirSync`);
+ * the wiring's catch turns that into the slot's `degraded` capability, never a silent `[]` that would
+ * read as valid-empty. A configured, readable, PR-less directory is the only `[]` this reader returns.
+ * A single stray/malformed file is still skip-soft — one bad file must not fail the whole read.
+ *
+ * **Bounded before parse.** When `limit` is a non-negative number, the PR-number-descending candidate
+ * set is sliced BEFORE any `fs.readFileSync` / `gray-matter`, so a 300+-file corpus never fully parses
+ * to fill a small event window. PR numbers come from the `pr-<N>.md` filename — no read to rank.
+ *
+ * **`isDraft` is intentionally unset.** CONTENT_GRAMMAR.md carries no draft frontmatter field, so a
+ * synced record cannot assert draft state; it is left absent (unknown) rather than fabricated `false`.
+ *
+ * @param {String} pullsDir Local synced pulls directory (`resources/content/pulls`).
+ * @param {Object} [options]
+ * @param {Number} [options.limit] Max PR records to parse, newest-PR-first; omit to parse all.
+ * @returns {Array<Object>} Parsed PR records; `[]` only when the (readable) directory holds no PRs.
+ * @throws when `pullsDir` cannot be collected (missing/unreadable) — the caller's catch degrades the slot.
+ */
+export function readSyncedPullRecords(pullsDir, {limit} = {}) {
+    // Collection failure PROPAGATES by design (a configured-but-unreadable dir → the wiring's catch →
+    // degraded capability). Only the per-file parse below is skip-soft.
+    const files = collectIssueMarkdownFiles(pullsDir);
+
+    // Bound BEFORE parsing: rank by the PR number in the filename (no read), keep the newest `limit`.
+    const ordered = (typeof limit === 'number' && limit >= 0)
+        ? files
+            .map(filePath => ({filePath, number: prNumberFromPath(filePath)}))
+            .sort((left, right) => right.number - left.number)
+            .slice(0, limit)
+            .map(entry => entry.filePath)
+        : files;
+
     const records = [];
 
-    for (const filePath of files) {
+    for (const filePath of ordered) {
         let parsed;
 
         try {
@@ -722,7 +824,10 @@ export function readSyncedPullRecords(pullsDir) {
             continue
         }
 
-        records.push({...meta, body: parsed.content || '', filePath})
+        const body    = parsed.content || '',
+              reviews = parsePullReviewEntries(body);
+
+        records.push({...meta, body, filePath, reviews, reviewDecision: deriveReviewDecision(reviews)})
     }
 
     return records

--- a/ai/services/graph/issueFocusSections.mjs
+++ b/ai/services/graph/issueFocusSections.mjs
@@ -680,7 +680,10 @@ export function readWorkGraphIssueRecords(issuesDir) {
     return records
 }
 
-const PULL_REVIEW_STATES = new Set(['APPROVED', 'CHANGES_REQUESTED', 'COMMENTED', 'DISMISSED']);
+// Only formal dispositions transition the human-gate; COMMENTED (and any unknown state) is neutral —
+// it never clears or sets a formal APPROVED/CHANGES_REQUESTED. Mirrors PullRequestService's
+// getOutstandingRequestChanges. DISMISSED is formal: as a reviewer's latest, it clears their disposition.
+const FORMAL_REVIEW_STATES = new Set(['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED']);
 
 // CONTENT_GRAMMAR.md: a `## Reviews` entry is `### `@user` (<STATE>) reviewed on <ISO_Z>`.
 const PULL_REVIEW_ENTRY_PATTERN = /^###\s+`(@?[^`]+)`\s+\(([A-Z_]+)\)\s+reviewed on\s+(\S+)/;
@@ -746,6 +749,9 @@ function deriveReviewDecision(reviews) {
     const latestByAuthor = new Map();
 
     for (const review of reviews) {
+        // COMMENTED (and unknown) is neutral — only a formal review is a reviewer's disposition.
+        if (!FORMAL_REVIEW_STATES.has(review.state)) continue;
+
         const existing = latestByAuthor.get(review.author);
 
         if (!existing || new Date(review.submittedAt || 0) > new Date(existing.submittedAt || 0)) {
@@ -753,6 +759,7 @@ function deriveReviewDecision(reviews) {
         }
     }
 
+    // Latest formal review per author: CHANGES_REQUESTED dominates; a DISMISSED latest clears (neutral).
     const latest = [...latestByAuthor.values()];
 
     if (latest.some(review => review.state === 'CHANGES_REQUESTED')) return 'CHANGES_REQUESTED';
@@ -924,14 +931,19 @@ export function getPrDeferDisposition(pr, now = new Date()) {
 }
 
 /**
- * @summary Resolves the latest per-reviewer state for a PR.
+ * @summary Resolves the latest FORMAL review per reviewer for a PR. COMMENTED (and unknown) states are
+ * neutral — they never supersede an APPROVED/CHANGES_REQUESTED; DISMISSED is formal and clears it.
  * @param {Object[]} reviews GitHub PR review payloads.
- * @returns {Object[]} Latest review per author.
+ * @returns {Object[]} Latest formal review per author.
  */
 function getLatestReviewsByAuthor(reviews = []) {
     const latestByAuthor = new Map();
 
     for (const review of Array.isArray(reviews) ? reviews : []) {
+        // COMMENTED (and any unknown state) is neutral — it must not supersede a reviewer's formal
+        // disposition, so only formal reviews compete for "latest" here.
+        if (!FORMAL_REVIEW_STATES.has(review.state)) continue;
+
         const author      = review.author?.login || review.author || 'unknown';
         const submittedAt = new Date(review.submittedAt || review.createdAt || 0);
         const existing    = latestByAuthor.get(author);

--- a/test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetPrLaneActivityAdapter.spec.mjs
@@ -189,4 +189,55 @@ test.describe('fleetPrLaneActivityAdapter - PR/lane activity mapping', () => {
         })
         expect(snapshot.events.map(event => event.payload.number || event.payload.issueNumber)).toEqual([2, 3])
     })
+
+    // ---- human-gate truth at the consumer boundary (Cycle-2 RA3: draft + formal-disposition) ----
+
+    test('draft state is preserved truthfully — unknown stays null, never fabricated false', () => {
+        const [unknown] = createPrActivityEvents([{number: 1, author: {login: 'a'}, updatedAt: '2026-07-04T03:00:00Z'}])
+        const [drafted] = createPrActivityEvents([{number: 2, author: {login: 'a'}, updatedAt: '2026-07-04T03:00:00Z', isDraft: true}])
+        const [ready]   = createPrActivityEvents([{number: 3, author: {login: 'a'}, updatedAt: '2026-07-04T03:00:00Z', isDraft: false}])
+
+        // synced records carry no draft field → unknown must stay null in the cockpit payload, not false
+        expect(unknown.payload.isDraft).toBeNull()
+        expect(drafted.payload.isDraft).toBe(true)
+        expect(ready.payload.isDraft).toBe(false)
+    })
+
+    test('a later COMMENTED review never supersedes a formal disposition (human-gate truth)', () => {
+        const [crThenComment] = createPrActivityEvents([{
+            number   : 1,
+            author   : {login: 'a'},
+            updatedAt: '2026-07-04T03:00:00Z',
+            reviews  : [
+                {author: {login: 'rev'}, state: 'CHANGES_REQUESTED', submittedAt: '2026-07-04T01:00:00Z'},
+                {author: {login: 'rev'}, state: 'COMMENTED',         submittedAt: '2026-07-04T02:00:00Z'}
+            ]
+        }])
+        expect(crThenComment.payload.humanGateState.changedRequested).toBe(true)
+
+        const [approveThenComment] = createPrActivityEvents([{
+            number   : 2,
+            author   : {login: 'a'},
+            updatedAt: '2026-07-04T03:00:00Z',
+            reviews  : [
+                {author: {login: 'rev'}, state: 'APPROVED',  submittedAt: '2026-07-04T01:00:00Z'},
+                {author: {login: 'rev'}, state: 'COMMENTED', submittedAt: '2026-07-04T02:00:00Z'}
+            ]
+        }])
+        expect(approveThenComment.payload.humanGateState.approved).toBe(true)
+    })
+
+    test('DISMISSED clears a formal disposition — a dismissed APPROVED is no longer approved', () => {
+        const [approveThenDismiss] = createPrActivityEvents([{
+            number   : 1,
+            author   : {login: 'a'},
+            updatedAt: '2026-07-04T03:00:00Z',
+            reviews  : [
+                {author: {login: 'rev'}, state: 'APPROVED',  submittedAt: '2026-07-04T01:00:00Z'},
+                {author: {login: 'rev'}, state: 'DISMISSED', submittedAt: '2026-07-04T02:00:00Z'}
+            ]
+        }])
+        expect(approveThenDismiss.payload.humanGateState.approved).not.toBe(true)
+        expect(approveThenDismiss.payload.humanGateState.changedRequested).toBe(false)
+    })
 })

--- a/test/playwright/unit/ai/services/fleet/wireFleetActivityReadSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/wireFleetActivityReadSource.spec.mjs
@@ -3,6 +3,9 @@ import {test, expect}                from '@playwright/test';
 import Neo                           from '../../../../../../src/Neo.mjs';
 import * as core                     from '../../../../../../src/core/_export.mjs';
 import {wireFleetActivityReadSource} from '../../../../../../ai/services/fleet/wireFleetActivityReadSource.mjs';
+import fs                            from 'node:fs';
+import os                            from 'node:os';
+import path                          from 'node:path';
 
 /**
  * @summary Contract of the composer→bridge wiring: it INSTALLS a real composed source, never a stub,
@@ -58,5 +61,30 @@ test.describe('Neo.ai.services.fleet.wireFleetActivityReadSource', () => {
         await expect((async () => captured.readA2ASnapshot({limit: 5}))()).rejects.toThrow(/a2a activity source not wired/);
         // The present PR/lane slot is a real reader, not the throwing sentinel.
         expect(typeof captured.readPrLaneSnapshot).toBe('function');
+    });
+
+    test('a CONFIGURED-but-unreadable pullsDir degrades the PR/lane slot — degraded capability + source-degraded event', async () => {
+        // Absent-vs-unreadable: a configured pulls directory that cannot be collected must reach
+        // makeReadPrLaneSnapshot's catch → the builder's `error` path (degraded), NOT masquerade as a
+        // 'wired' empty snapshot. issuesDir is a real empty temp dir; the reader throws first on the
+        // missing pullsDir, so the issue/stall readers never run.
+        const issuesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'synced-issues-'));
+        let   captured  = null;
+
+        try {
+            wireFleetActivityReadSource({
+                issuesDir,
+                pullsDir    : path.join(issuesDir, 'no-such-pulls'),
+                bridge      : stubBridge(),
+                createSource: opts => { captured = opts; return {readActivitySnapshot() {}} }
+            });
+
+            const snapshot = await captured.readPrLaneSnapshot({limit: 5});
+
+            expect(snapshot.capability.state).toBe('degraded');
+            expect(snapshot.events.some(event => event.type === 'source-degraded')).toBe(true)
+        } finally {
+            fs.rmSync(issuesDir, {recursive: true, force: true})
+        }
     });
 });

--- a/test/playwright/unit/ai/services/graph/readSyncedPullRecords.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/readSyncedPullRecords.spec.mjs
@@ -1,0 +1,68 @@
+import {setup}                 from '../../../../setup.mjs';
+import {test, expect}          from '@playwright/test';
+import Neo                     from '../../../../../../src/Neo.mjs';
+import * as core               from '../../../../../../src/core/_export.mjs';
+import {readSyncedPullRecords} from '../../../../../../ai/services/graph/issueFocusSections.mjs';
+import fs                      from 'node:fs';
+import os                      from 'node:os';
+import path                    from 'node:path';
+
+/**
+ * @summary Contract of the synced-pulls reader — the fleet-activity PR/lane slot's data source that
+ * completes the composer's previously honest-empty PR slot. It parses
+ * `resources/content/pulls/**\/pr-*.md` frontmatter + body into the records `createPrActivityEvents`
+ * consumes, fail-softs to `[]` on an absent/unreadable tree (the slot stays honest-empty, never throws),
+ * and skips stray non-PR markdown. Pure fs/frontmatter — a temp fixture, no Neo instance.
+ */
+test.describe('Neo.ai.services.graph.readSyncedPullRecords', () => {
+    let dir;
+
+    test.beforeEach(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synced-pulls-'));
+    });
+
+    test.afterEach(() => {
+        fs.rmSync(dir, {recursive: true, force: true});
+    });
+
+    test('parses synced pull markdown into the PR records the activity builder consumes', () => {
+        fs.mkdirSync(path.join(dir, 'chunk-1'));
+        fs.writeFileSync(path.join(dir, 'chunk-1', 'pr-14739.md'), [
+            '---',
+            'number: 14739',
+            'title: feat(ai) retrospective enrichment',
+            'author: neo-fable',
+            'state: MERGED',
+            "createdAt: '2026-07-04T10:07:34Z'",
+            "updatedAt: '2026-07-04T13:42:31Z'",
+            "mergedAt: '2026-07-04T13:42:26Z'",
+            "url: 'https://github.com/neomjs/neo/pull/14739'",
+            '---',
+            '## Summary',
+            'the enrichment family goes to five fact classes'
+        ].join('\n'));
+
+        const records = readSyncedPullRecords(dir);
+
+        expect(records).toHaveLength(1);
+
+        const [pr] = records;
+        expect(pr.number).toBe(14739);
+        expect(pr.title).toContain('retrospective enrichment');
+        expect(pr.author).toBe('neo-fable');
+        expect(pr.state).toBe('MERGED');
+        expect(pr.mergedAt).toBe('2026-07-04T13:42:26Z');
+        expect(pr.url).toBe('https://github.com/neomjs/neo/pull/14739');
+        expect(pr.body).toContain('the enrichment family');
+    });
+
+    test('fail-soft: an absent directory yields [] — the slot stays honest-empty, never throws', () => {
+        expect(readSyncedPullRecords(path.join(dir, 'does-not-exist'))).toEqual([]);
+    });
+
+    test('skips non-PR markdown (a frontmatter file with no number — a stray index/metadata file)', () => {
+        fs.writeFileSync(path.join(dir, '_index.md'), ['---', 'title: index', '---', 'not a pull request'].join('\n'));
+
+        expect(readSyncedPullRecords(dir)).toEqual([]);
+    });
+});

--- a/test/playwright/unit/ai/services/graph/readSyncedPullRecords.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/readSyncedPullRecords.spec.mjs
@@ -8,14 +8,20 @@ import os                      from 'node:os';
 import path                    from 'node:path';
 
 /**
- * @summary Contract of the synced-pulls reader — the fleet-activity PR/lane slot's data source that
- * completes the composer's previously honest-empty PR slot. It parses
- * `resources/content/pulls/**\/pr-*.md` frontmatter + body into the records `createPrActivityEvents`
- * consumes, fail-softs to `[]` on an absent/unreadable tree (the slot stays honest-empty, never throws),
- * and skips stray non-PR markdown. Pure fs/frontmatter — a temp fixture, no Neo instance.
+ * @summary Contract of the synced-pulls reader — the fleet-activity PR/lane slot's data source. It
+ * projects `resources/content/pulls/**\/pr-*.md` frontmatter + the `## Reviews` body section (per
+ * CONTENT_GRAMMAR.md) into the records `getPrHumanGateState` / `createPrActivityEvents` consume
+ * (structured `reviews` + derived `reviewDecision`), BOUNDS the candidate set before parsing, and
+ * distinguishes three source states: valid-empty (`[]`), configured-unreadable (THROWS → the wiring
+ * degrades), and omitted (the wiring's concern, never reaching this reader). Temp fixture, no Neo instance.
  */
 test.describe('Neo.ai.services.graph.readSyncedPullRecords', () => {
     let dir;
+
+    const writePull = (name, frontmatter, body = '## Summary\nx') => {
+        fs.mkdirSync(path.join(dir, 'chunk-1'), {recursive: true});
+        fs.writeFileSync(path.join(dir, 'chunk-1', name), ['---', ...frontmatter, '---', body].join('\n'));
+    };
 
     test.beforeEach(() => {
         dir = fs.mkdtempSync(path.join(os.tmpdir(), 'synced-pulls-'));
@@ -26,27 +32,19 @@ test.describe('Neo.ai.services.graph.readSyncedPullRecords', () => {
     });
 
     test('parses synced pull markdown into the PR records the activity builder consumes', () => {
-        fs.mkdirSync(path.join(dir, 'chunk-1'));
-        fs.writeFileSync(path.join(dir, 'chunk-1', 'pr-14739.md'), [
-            '---',
+        writePull('pr-14739.md', [
             'number: 14739',
             'title: feat(ai) retrospective enrichment',
             'author: neo-fable',
             'state: MERGED',
             "createdAt: '2026-07-04T10:07:34Z'",
-            "updatedAt: '2026-07-04T13:42:31Z'",
             "mergedAt: '2026-07-04T13:42:26Z'",
-            "url: 'https://github.com/neomjs/neo/pull/14739'",
-            '---',
-            '## Summary',
-            'the enrichment family goes to five fact classes'
-        ].join('\n'));
+            "url: 'https://github.com/neomjs/neo/pull/14739'"
+        ], '## Summary\nthe enrichment family goes to five fact classes');
 
-        const records = readSyncedPullRecords(dir);
+        const [pr, ...rest] = readSyncedPullRecords(dir);
 
-        expect(records).toHaveLength(1);
-
-        const [pr] = records;
+        expect(rest).toHaveLength(0);
         expect(pr.number).toBe(14739);
         expect(pr.title).toContain('retrospective enrichment');
         expect(pr.author).toBe('neo-fable');
@@ -54,15 +52,92 @@ test.describe('Neo.ai.services.graph.readSyncedPullRecords', () => {
         expect(pr.mergedAt).toBe('2026-07-04T13:42:26Z');
         expect(pr.url).toBe('https://github.com/neomjs/neo/pull/14739');
         expect(pr.body).toContain('the enrichment family');
+        // no `## Reviews` section → honest-empty reviews + no decision (not a fabricated APPROVED)
+        expect(pr.reviews).toEqual([]);
+        expect(pr.reviewDecision).toBeNull();
+        // the synced grammar carries no draft field → isDraft left unset, never fabricated as false
+        expect('isDraft' in pr).toBe(false)
     });
 
-    test('fail-soft: an absent directory yields [] — the slot stays honest-empty, never throws', () => {
-        expect(readSyncedPullRecords(path.join(dir, 'does-not-exist'))).toEqual([]);
+    test('projects the `## Reviews` section into structured reviews + a CHANGES_REQUESTED decision', () => {
+        writePull('pr-15399.md', [
+            'number: 15399', 'title: feat(fleet) synced-pulls reader', 'author: neo-opus-ada', 'state: OPEN'
+        ], [
+            '## Description',
+            'the reader',
+            '## Reviews',
+            '### `@neo-gpt` (CHANGES_REQUESTED) reviewed on 2026-07-18T04:58:53Z',
+            'bounded source-contract repair',
+            '### `@neo-opus-vega` (APPROVED) reviewed on 2026-07-17T02:00:00Z',
+            'looks good',
+            '## Commits',
+            '- `abc` c (by x)'
+        ].join('\n'));
+
+        const [pr] = readSyncedPullRecords(dir);
+
+        // the `## Reviews` entries become structured facts; `## Commits` after it is NOT scanned as a review
+        expect(pr.reviews).toEqual([
+            {author: '@neo-gpt',       state: 'CHANGES_REQUESTED', submittedAt: '2026-07-18T04:58:53Z'},
+            {author: '@neo-opus-vega', state: 'APPROVED',          submittedAt: '2026-07-17T02:00:00Z'}
+        ]);
+        // latest-per-author, CHANGES_REQUESTED dominates → the consumer's human-gate reads not-approved
+        expect(pr.reviewDecision).toBe('CHANGES_REQUESTED')
     });
 
-    test('skips non-PR markdown (a frontmatter file with no number — a stray index/metadata file)', () => {
+    test('an APPROVED-only PR derives APPROVED; a later CR by the same author flips the decision', () => {
+        writePull('pr-15400.md', ['number: 15400', 'title: t', 'author: a', 'state: OPEN'],
+            ['## Reviews',
+             '### `@rev` (APPROVED) reviewed on 2026-07-17T01:00:00Z',
+             '### `@rev` (CHANGES_REQUESTED) reviewed on 2026-07-17T02:00:00Z'].join('\n'));
+
+        expect(readSyncedPullRecords(dir)[0].reviewDecision).toBe('CHANGES_REQUESTED');
+
+        // a purely-approved PR
+        fs.rmSync(path.join(dir, 'chunk-1'), {recursive: true, force: true});
+        writePull('pr-15401.md', ['number: 15401', 'title: t', 'author: a', 'state: OPEN'],
+            ['## Reviews', '### `@rev` (APPROVED) reviewed on 2026-07-17T01:00:00Z'].join('\n'));
+
+        expect(readSyncedPullRecords(dir)[0].reviewDecision).toBe('APPROVED')
+    });
+
+    test('a configured-but-unreadable directory THROWS (so the wiring degrades) — not a silent []', () => {
+        // The AC-1 seam: an OMITTED pullsDir is the wiring's honest-empty concern and never reaches this
+        // reader; a CONFIGURED directory that cannot be collected must propagate so the slot degrades,
+        // rather than masquerading as valid-empty.
+        expect(() => readSyncedPullRecords(path.join(dir, 'does-not-exist'))).toThrow()
+    });
+
+    test('a configured, readable, PR-less directory is the only [] — a stray non-PR file is skipped', () => {
         fs.writeFileSync(path.join(dir, '_index.md'), ['---', 'title: index', '---', 'not a pull request'].join('\n'));
 
-        expect(readSyncedPullRecords(dir)).toEqual([]);
+        expect(readSyncedPullRecords(dir)).toEqual([])
     });
+
+    test('bounds the candidate set BEFORE parsing — only the newest `limit` PRs are ever read', () => {
+        for (const n of [1, 2, 3, 4, 5]) {
+            writePull(`pr-${n}.md`, [`number: ${n}`, 'title: t', 'author: a', 'state: OPEN']);
+        }
+
+        const originalReadFileSync = fs.readFileSync,
+              readMarkdownPaths    = [];
+
+        fs.readFileSync = (filePath, ...args) => {
+            if (typeof filePath === 'string' && filePath.includes(dir) && filePath.endsWith('.md')) {
+                readMarkdownPaths.push(filePath);
+            }
+            return originalReadFileSync(filePath, ...args)
+        };
+
+        try {
+            const records = readSyncedPullRecords(dir, {limit: 2});
+
+            // only the two newest PRs (by number) are parsed, and ONLY two markdown files are ever read
+            expect(records.map(pr => pr.number).sort((a, b) => b - a)).toEqual([5, 4]);
+            expect(readMarkdownPaths).toHaveLength(2);
+            expect(readMarkdownPaths.some(p => p.endsWith('pr-1.md'))).toBe(false)
+        } finally {
+            fs.readFileSync = originalReadFileSync
+        }
+    })
 });


### PR DESCRIPTION
Resolves #15382
Related: #13015, #15339

Completes #15339's `activitySource` composer: that leaf wired the FM cockpit's PR/lane slot but shipped `readPrs` **omitted** (honest-empty), so the live ActivityStream emitted issue / lane-claim / work-stall events but **no `pr-activity` events**. This wires the synced-pulls reader so PR opens, reviews, and merges reach the cockpit.

- **`ai/services/graph/issueFocusSections.mjs`** — `readSyncedPullRecords(pullsDir, {limit})`, the sibling of `readWorkGraphIssueRecords`. Projects synced frontmatter PLUS the structured review facts the consumer reads — `reviews: [{author, state, submittedAt}]` parsed from the `## Reviews` body section (CONTENT_GRAMMAR.md) + a derived `reviewDecision` — bounds the candidate set before parsing, and distinguishes three source states.
- **`ai/services/fleet/wireFleetActivityReadSource.mjs`** — the PR/lane slot reads pulls internally via `pullsDir` (symmetric with `issuesDir`) and threads the event `limit` into the reader.
- **`ai/services/fleet/devFleetServer.mjs`** — passes `pullsDir` at the boot use site.

## Repair — addressing PR #15399's CHANGES_REQUESTED (@neo-gpt)

The cross-family gate caught four real source-contract gaps the initial head shipped; all four fixed on the reader:

1. **Absent vs unreadable (three states, not two).** The reader no longer swallows a collection failure into `[]`. A configured-but-unreadable `pullsDir` propagates (`collectIssueMarkdownFiles`' `fs.readdirSync` throws) → `makeReadPrLaneSnapshot`'s catch degrades the slot (`capability.state: 'degraded'` + a `source-degraded` event). An OMITTED `pullsDir` stays honest-empty at the wiring guard; a readable PR-less dir is the only `[]`.
2. **Bound before parse.** `readSyncedPullRecords(pullsDir, {limit})` ranks by the `pr-<N>.md` filename (no read), slices the newest `limit` BEFORE `fs.readFileSync`, so the 300+-file corpus never fully parses to fill a small window.
3. **Review-grammar projection.** Parses the `## Reviews` section into structured `reviews` + a derived `reviewDecision`, so `getPrHumanGateState` emits truthful approved/changes-requested facts. `isDraft` is left unset (the grammar carries no draft field) rather than fabricated `false`.
4. **Evidence honesty** — the residual is now declared, not "none" (below).

## Deltas from ticket

The symmetric `pullsDir`-internal shape (over the v1 injected `readPrs` placeholder) + the four repairs above. No `Neo.create()` / composer-contract change; `fleetPrLaneActivityAdapter` unchanged (the record now populates the `reviews`/`reviewDecision` it already read).

Evidence: L2 (unit — the reader's three source-states + bound-before-parse + review projection; the wiring's configured-unreadable → degraded witness) → L2 achieved for the diff. **Residual: the AC1 live `devFleetServer + fleetActivity` receipt is a DECLARED DEFERRED residual** — it needs the running fleet-server process reading a reseeded feed, unreachable from the sandbox; it is NOT claimed complete (this corrects the prior "Residual: none"). Reopen trigger below.

## Test Evidence

- `readSyncedPullRecords.spec.mjs` — **6 passed**: parses a PR record (+ honest-empty reviews / no decision, `isDraft` unset); projects `## Reviews` → structured reviews + a CHANGES_REQUESTED decision; APPROVED-then-later-CR flip; **configured-unreadable THROWS**; readable PR-less `[]` + stray-file skip; **bound-before-parse** (a `fs.readFileSync` spy proves only the newest `limit` files are read, `pr-1.md` never).
- `wireFleetActivityReadSource.spec.mjs` — **4 passed**: neither-slot → null; both-sources → composed; absent A2A slot degrades; **configured-unreadable `pullsDir` → degraded capability + `source-degraded` event**.
- **313/313** across `test/playwright/unit/ai/services/fleet/` — no regression. `node --check` + block-alignment clean on all four files.

## Post-Merge Validation

- [ ] AC1 live receipt: the running Memory Core / devFleetServer reads the merged feed and the FM cockpit ActivityStream emits `pr-activity` events (opens/reviews/merges) with truthful human-gate state alongside issue/lane-claim/stall — witnessable once a Memory Core reseed/boot picks up `dev`. **Reopen trigger:** if that live receipt does not materialize (no `pr-activity` events, or a `wired` slot masking an unreadable feed), reopen #15382.

## Commits

- `1d5202e020` — the reader + symmetric wiring + boot-use-site pass + 3 initial witnesses.
- `42fbe7c6f3` — the four source-contract repairs (@neo-gpt's RC): degraded-on-unreadable, bound-before-parse, review-grammar projection, evidence honesty; + the degraded/bound/projection witnesses.

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Origin session `3e5f61a5-35d0-4f3d-8805-54f63bebed70`.
