### PR TITLE
feat(agentos): the S5 define-agent zone joins the cockpit rail — additive mount half (#15402)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1,4 +1,5 @@
 import ActivityStream           from './ActivityStream.mjs';
+import AddAgentForm             from './AddAgentForm.mjs';
 import AgentDetail              from './AgentDetail.mjs';
 import Button                   from '../../../../src/button/Base.mjs';
 import Component                from '../../../../src/component/Base.mjs';
@@ -845,6 +846,16 @@ class FleetCockpit extends Container {
                     cls      : [marker],
                     record   : me.detailRecord,
                     reference: 'agent-detail'
+                };
+            case 'define-agent':
+                // the S5 add-agent flow (rail tool, invoked-not-ambient per the design ruling).
+                // `agentDefinitionAccepted` walks up the component chain to the Viewport's roster
+                // seam — the same consumer Accounts feeds, so both entry points write one truth.
+                return {
+                    module   : AddAgentForm,
+                    cls      : [marker],
+                    listeners: {agentDefinitionAccepted: 'up.onAgentDefinitionAccepted'},
+                    reference: 'add-agent-form'
                 };
             default:
                 // perspectives arrives with its own leaf — an honest labelled placeholder, never a

--- a/apps/agentos/view/fleet/cockpitDockDocument.mjs
+++ b/apps/agentos/view/fleet/cockpitDockDocument.mjs
@@ -27,7 +27,10 @@ export function cockpitDockDocument() {
             fleet       : {componentRef: 'fleet-grid',      title: 'Fleet',        kind: 'panel'},
             stream      : {componentRef: 'activity-stream',  title: 'Activity',     kind: 'panel'},
             detail      : {componentRef: 'agent-detail',     title: 'Agent detail', kind: 'inspector', autoHidden: true},
-            perspectives: {componentRef: 'perspectives',     title: 'Perspectives', kind: 'tool',      autoHidden: true}
+            perspectives: {componentRef: 'perspectives',     title: 'Perspectives', kind: 'tool',      autoHidden: true},
+            // S5 define-agent (design ruling on record: rail placement, invoked-not-ambient) —
+            // the add-agent flow rides the same autoHidden tool chrome as perspectives
+            defineAgent : {componentRef: 'define-agent',     title: 'Add agent',    kind: 'tool',      autoHidden: true}
         },
         nodes: {
             // Root edge-zone: the primary split in the center, the auto-hidden chrome on the right rail.
@@ -37,7 +40,7 @@ export function cockpitDockDocument() {
             'fleet-tabs'   : {type: 'tabs', items: ['fleet'],  activeItemId: 'fleet'},
             'stream-tabs'  : {type: 'tabs', items: ['stream'], activeItemId: 'stream'},
             // Secondary panes collapse to this edge's rail (§2.7): their item records carry `autoHidden`.
-            'secondary-rail': {type: 'tabs', items: ['detail', 'perspectives'], activeItemId: 'detail'}
+            'secondary-rail': {type: 'tabs', items: ['detail', 'perspectives', 'defineAgent'], activeItemId: 'detail'}
         }
     }
 }

--- a/test/playwright/unit/apps/agentos/cockpitDockDocument.spec.mjs
+++ b/test/playwright/unit/apps/agentos/cockpitDockDocument.spec.mjs
@@ -41,10 +41,27 @@ test.describe('AgentOS.view.fleet cockpit dock document — dockZone.v1 default 
 
         const autoHidden = Object.entries(items).filter(([, i]) => i.autoHidden === true).map(([id]) => id);
         expect(autoHidden.length).toBeGreaterThan(0);
-        expect(autoHidden).toEqual(expect.arrayContaining(['detail', 'perspectives']));
+        expect(autoHidden).toEqual(expect.arrayContaining(['detail', 'perspectives', 'defineAgent']));
 
         expect(items.fleet.autoHidden).toBeUndefined();
         expect(items.stream.autoHidden).toBeUndefined()
+    });
+
+    test('carries the S5 define-agent zone: rail-resident, invoked-not-ambient tool chrome (the design ruling)', () => {
+        const doc = cockpitDockDocument();
+
+        expect(doc.items.defineAgent).toEqual({
+            componentRef: 'define-agent',
+            title       : 'Add agent',
+            kind        : 'tool',
+            autoHidden  : true
+        });
+
+        // rail membership: the zone collapses to the same secondary rail as the other invoked chrome —
+        // and it must NOT sit in either primary zone (ambient placement is what the ruling rejected)
+        expect(doc.nodes['secondary-rail'].items).toContain('defineAgent');
+        expect(doc.nodes['fleet-tabs'].items).not.toContain('defineAgent');
+        expect(doc.nodes['stream-tabs'].items).not.toContain('defineAgent')
     });
 
     test('is pure data — a fresh, equal document each call (no shared mutable singleton)', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
@@ -223,8 +223,8 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
         expect(cockpit.detachedDetailPane).toBeNull();
 
         // the placement truth: `addTab` appends by default — the restore must land the item back
-        // at its STORED index (0, before `perspectives`), not at the tail
-        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives']);
+        // at its STORED index (0, before the rest of the rail), not at the tail
+        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent']);
 
         // same instance re-adopted by the projection; the vessel was closed by name
         expect(cockpit.getReference('agent-detail')).toBe(pane);
@@ -249,7 +249,7 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
 
         // the SAME instance is docked again at its exact home; nothing was closed (nothing opened)
         expect(cockpit.getReference('agent-detail')).toBe(pane);
-        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives']);
+        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent']);
         expect(vessel.closeCalls).toHaveLength(0)
     });
 


### PR DESCRIPTION
Resolves #15402
Related: #15242

The first mount slice under Grace's S5 design ruling (`162e33d8`: TAB · zone-only+empty-state-CTA · rail): the `defineAgent` dock zone joins the secondary rail as autoHidden tool chrome (the perspectives twin), and `resolveDockComponentRef` mounts #15398's `AddAgentForm` there with `agentDefinitionAccepted` routed up the component chain to the Viewport's existing roster seam — Accounts and the cockpit zone write one truth through one consumer. Purely additive by design: zero retirement blast, so the ruled shape lands green now; the completion PR (FleetSettingsPanel retirement + empty-state CTA + config TAB + NL journey + SSOT entry) resolves #15242.

Evidence: L3 (document validation + mounted cockpit boot both executed at this head) → L3 required (#15402 ACs). Residual: none on this slice; #15242's remaining ACs stay on #15242.

## Deltas from ticket
None substantive.

## Test Evidence
- `cockpitDockDocument.spec.mjs` extended + run: **6 passed** — DockZoneModel round-trip with the new zone, S5 shape assertions (rail-resident, absent from BOTH primary zones — ambient placement is what fork-2 rejected), autoHidden coverage now includes `defineAgent`.
- `fleetCockpitPopOut.spec.mjs` updated + run: **13 passed** — the exact-index restore witnesses include `defineAgent` while preserving the re-dock invariant.
- Mounted boot: `FleetCockpitFocusInvariant.spec.mjs` (e2e, fresh port) **1 passed** — the cockpit mounts clean with the new rail tab, and the focus-order invariant now guards the mounted form's tab surface too.
- Diff: 4 files, +37/−6.

## Post-Merge Validation
- [ ] The components shard + full e2e agentos suite green on dev with the zone present.
- [ ] Grace's SSOT S5 registry entry lands with the completion PR (her ruling recorded there).

Authored by Vega (Claude Fable 5, Claude Code). Session 2dcbf336-4338-4009-82f3-79f1b1d151f1.
