### PR TITLE
feat(fleet): register opencode in the harness registry + probed launch contract (#15391)

### DIFF
--- a/ai/scripts/fleet/onboardPeer.mjs
+++ b/ai/scripts/fleet/onboardPeer.mjs
@@ -385,15 +385,18 @@ export function planOnboarding({intent, facts = {}} = {}) {
     // The auth segment names the FAMILY's auth mode, not just the marker heuristic: in-app
     // families carry a permanently-null `authRequired` (no marker exists), so their handoff is the
     // in-window sign-in — rendered from the launch contract's authMode, mirroring the exact
-    // decision `deriveAuthHandoff` makes post-launch (dry-run and --commit cannot drift).
+    // decision `deriveAuthHandoff` makes post-launch (dry-run and --commit cannot drift). env-key
+    // families have no per-home step at all — the provider key rides the spawned env.
     push('auth', 'PRINT',
         getHarnessAuthMode(intent.harnessType) === 'in-app'
             ? 'in-app sign-in inside the Fleet-launched window (operator-owned; if closed, restart through this command --commit or Fleet cockpit Start)'
-            : facts.authRequired === false
-                ? 'per-home credentials already present — no login step required'
-                : facts.authRequired === true
-                    ? 'per-home login required once (surfaced via status().authRequired after launch)'
-                    : 'auth state UNKNOWN until the long-lived owner returns live launch status');
+            : getHarnessAuthMode(intent.harnessType) === 'env-key'
+                ? 'auth rides the spawned env (provider API key in the seat env) — no per-home login step; verify the key is provisioned before start'
+                : facts.authRequired === false
+                    ? 'per-home credentials already present — no login step required'
+                    : facts.authRequired === true
+                        ? 'per-home login required once (surfaced via status().authRequired after launch)'
+                        : 'auth state UNKNOWN until the long-lived owner returns live launch status');
 
     return {phase: 'B', segments, gateMessage: null}
 }
@@ -438,7 +441,7 @@ export function buildLoginCommand({harnessType, authHome, authCommand} = {}) {
         throw new Error(`buildLoginCommand: unsupported harnessType '${String(harnessType)}'.`);
     }
     if (getHarnessAuthMode(harnessType) !== 'marker') {
-        throw new Error(`buildLoginCommand: harnessType '${harnessType}' authenticates in-app; login commands are marker-family only.`);
+        throw new Error(`buildLoginCommand: harnessType '${harnessType}' has authMode '${getHarnessAuthMode(harnessType)}'; login commands are marker-family only.`);
     }
     if (typeof authHome !== 'string' || !path.isAbsolute(authHome) || CONTROL_CHARACTERS.test(authHome)) {
         throw new Error('buildLoginCommand: lifecycle status must provide a control-character-free absolute authHome.');
@@ -467,9 +470,11 @@ export function buildLoginCommand({harnessType, authHome, authCommand} = {}) {
  * @summary The post-launch auth handoff DECISION — the one branch `--commit` executes after
  * `startAgent` returns, extracted pure so tests enter where the real conductor does. Mode-first:
  * an `'in-app'` family (permanently-null `authRequired` — no marker exists) ALWAYS hands off the
- * in-window sign-in instruction and routes a closed-window recovery back through Fleet; a
- * `'marker'` family branches on the live heuristic (`true` → the login command, `false` → done,
- * `null` → an honest WARN, never a guessed command).
+ * in-window sign-in instruction and routes a closed-window recovery back through Fleet; an
+ * `'env-key'` family has no per-home step at all (the provider key rides the spawned env), so the
+ * handoff is `done` plus the provisioning reminder; a `'marker'` family branches on the live
+ * heuristic (`true` → the login command, `false` → done, `null` → an honest WARN, never a
+ * guessed command).
  * @param {Object} options
  * @param {String} options.harnessType Curated harness family.
  * @param {Object} options.status The long-lived owner's `startAgent`/`status` projection —
@@ -488,6 +493,13 @@ export function deriveAuthHandoff({harnessType, status} = {}) {
                 '    Sign in inside that window.',
                 '    If it was closed, restart through Fleet: re-run this onboardPeer command with --commit, or use Start in the Fleet cockpit.'
             ]
+        };
+    }
+
+    if (getHarnessAuthMode(harnessType) === 'env-key') {
+        return {
+            kind : 'done',
+            lines: ['  [DONE] auth — env-key family: the provider API key rides the spawned env; no per-home login step exists (verify the seat env carries it before start)']
         };
     }
 

--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -420,7 +420,7 @@ class FleetControlBridge extends Base {
      * facts through the ONE {@link #getIdentityResolver} seam (`family` as era/display attribute,
      * `engineTag` as current-model metadata — read-only, era-swap re-points the resolver, zero Body
      * diff), stamps the launch-derived truth per agent (`launchable` = the family is in the
-     * launch-templated subset; `authMode` = `'marker' | 'in-app' | null` — both DERIVED at read
+     * launch-templated subset; `authMode` = `'marker' | 'in-app' | 'env-key' | null` — both DERIVED at read
      * time from the launch seam, never a second hand-maintained list, so a family becomes
      * cockpit-launchable exactly when its template lands), and hands the enriched agents to the
      * Body-side pure map (`createFleetCockpitStatus` — which never imports `ai/graph` or the Brain

--- a/ai/services/fleet/deriveHarnessLaunchSpec.mjs
+++ b/ai/services/fleet/deriveHarnessLaunchSpec.mjs
@@ -34,6 +34,10 @@ import path            from 'node:path';
 //   against its nested `codex-home`). `'in-app'` = auth is the sign-in INSIDE the
 //   launched window — no marker exists, `authRequired` stays honestly `null`, and the handoff
 //   instruction must render from THIS mode, never from the (permanently null) heuristic.
+//   `'env-key'` = auth rides the SPAWN ENVIRONMENT (a provider API key in the seat env), so no
+//   per-home auth step exists at all: no marker to check (`authRequired` stays `null`), no window
+//   to sign in through (the supervised mode is headless) — the handoff names the provisioning
+//   assumption instead of inventing a login.
 const HARNESS_LAUNCH_CONTRACTS = {
     'antigravity': {
         authMode        : 'in-app',
@@ -62,6 +66,14 @@ const HARNESS_LAUNCH_CONTRACTS = {
     'codex-desktop': {
         authMode        : 'marker',
         versionProbeArgs: null
+    },
+    // Isolation is a TWO-var XDG pair, not a single homeEnvVar: the derivation points BOTH
+    // XDG_CONFIG_HOME and XDG_DATA_HOME at the instance home (plus XDG_CACHE_HOME at a child),
+    // so config AND state unify beneath it — see the derivation branch + the fn JSDoc probe record.
+    'opencode': {
+        authMode        : 'env-key',
+        modeArgs        : ['serve', '--hostname', '127.0.0.1', '--port', '0'],
+        versionProbeArgs: ['--version']
     }
 };
 
@@ -91,12 +103,14 @@ export const LAUNCHABLE_HARNESS_TYPES = Object.freeze(Object.keys(HARNESS_LAUNCH
 
 /**
  * @summary The family's operator-owned auth mode — `'marker'` (a documented marker file inside the
- * home drives the lifecycle `authRequired` heuristic; the login is a command) or `'in-app'` (auth
+ * home drives the lifecycle `authRequired` heuristic; the login is a command), `'in-app'` (auth
  * is the sign-in inside the launched window; no marker exists and `authRequired` stays honestly
  * `null`, so ANY auth handoff for these families must branch on THIS mode, never on the
- * permanently-null heuristic). `null` for unlaunchable/unknown families — consumers fail closed.
+ * permanently-null heuristic), or `'env-key'` (auth rides the spawned env as a provider API key;
+ * no per-home step exists, `authRequired` stays `null`, and the handoff names the provisioning
+ * assumption). `null` for unlaunchable/unknown families — consumers fail closed.
  * @param {String} harnessType
- * @returns {'marker'|'in-app'|null}
+ * @returns {'marker'|'in-app'|'env-key'|null}
  */
 export function getHarnessAuthMode(harnessType) {
     return HARNESS_LAUNCH_CONTRACTS[harnessType]?.authMode ?? null;
@@ -175,6 +189,24 @@ export function getHarnessAuthMode(harnessType) {
  *   NOT answer `--version` without booting the app (wizard log lines instead of a version), so
  *   `versionProbeArgs` is `null` — the supervisor skips the probe and `binaryVersion` stays
  *   honestly `null`. Auth is the in-app sign-in; `authRequired` stays `null` as above.
+ *
+ * - **`'opencode'`** → `{command: binaryPath, args: ['serve', '--hostname', '127.0.0.1', '--port',
+ *   '0'], env: {XDG_CONFIG_HOME: instanceHome, XDG_DATA_HOME: instanceHome, XDG_CACHE_HOME:
+ *   '<instanceHome>/cache'}}`. The headless `serve` mode is the supervisable shape: stdio-
+ *   indifferent (stays resident on an EOF'd stdin as well as a held pipe) and SIGTERM-clean.
+ *   `--port 0` auto-assigns; the bound port is discovered from the server's listening log line.
+ *   Isolation is a TWO-var XDG pair, not one home var: OpenCode reads its seat config from
+ *   `$XDG_CONFIG_HOME/opencode/opencode.json(c)` and its state (db, logs, repos) from
+ *   `$XDG_DATA_HOME/opencode/` — pointing BOTH at the instance home unifies the whole footprint
+ *   as `<instanceHome>/opencode/` (the seat-config generator's planting target), with
+ *   `XDG_CACHE_HOME=<instanceHome>/cache` containing the model-catalog cache; the bun runtime
+ *   cache stays HOME-relative (harmless artifact). Probed (opencode-ai 1.18.3, darwin-arm64):
+ *   `serve` alive at 4s with stdin held AND with stdin EOF, clean SIGTERM; unified-home census
+ *   `<home>/opencode/{opencode.jsonc, opencode.db, log/, repos/}`; `--version` answers `1.18.3`
+ *   in milliseconds. Auth is `'env-key'`: the provider API key rides the seat env (the portable
+ *   flatrate property — the OpenCode+Kimi path), so NO per-home auth step exists; OAuth via
+ *   `opencode auth login` writes provider state into the data home but is not the fleet path,
+ *   and no documented marker exists, so `authRequired` stays honestly `null`.
  *
  * `open -n -a …` launches remain **excluded by design**: `open` detaches — the spawned process is
  * the launcher, not the harness — so the Fleet Manager could never supervise (signal, reap, or
@@ -261,6 +293,19 @@ export function deriveHarnessLaunchSpec({harnessType, instanceHome, binaryPath, 
             args            : [homeArg],
             env             : {CLAUDE_USER_DATA_DIR: instanceHome},
             versionProbeArgs: [homeArg, ...contract.versionProbeArgs]
+        };
+    }
+
+    if (harnessType === 'opencode') {
+        return {
+            command: binaryPath,
+            args   : [...contract.modeArgs],
+            env    : {
+                XDG_CONFIG_HOME: instanceHome,
+                XDG_DATA_HOME  : instanceHome,
+                XDG_CACHE_HOME : path.join(instanceHome, 'cache')
+            },
+            versionProbeArgs: [...contract.versionProbeArgs]
         };
     }
 

--- a/src/ai/fleet/harnessTypes.mjs
+++ b/src/ai/fleet/harnessTypes.mjs
@@ -22,6 +22,7 @@ export const HARNESS_TYPES = Object.freeze([
     Object.freeze({type: 'codex-desktop',  label: 'Codex Desktop'}),
     Object.freeze({type: 'claude-code',    label: 'Claude Code'}),
     Object.freeze({type: 'claude-desktop', label: 'Claude'}),
+    Object.freeze({type: 'opencode',       label: 'OpenCode'}),
     Object.freeze({type: 'antigravity',    label: 'Antigravity'}),
     Object.freeze({type: 'native-neo',     label: 'Native'})
 ]);

--- a/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
@@ -128,7 +128,7 @@ test.describe('onboardPeer — intent construction (pure half)', () => {
     test('only curated harness families are accepted, with a named refusal', () => {
         // The curated set IS the launch-templated subset — one derived truth, widened in lockstep
         // with deriveHarnessLaunchSpec. `native-neo` stays registered-but-unlaunchable.
-        expect(CURATED_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex', 'codex-desktop']);
+        expect(CURATED_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex', 'codex-desktop', 'opencode']);
         expect(CURATED_HARNESS_TYPES).not.toContain('native-neo');
 
         const built = buildOnboardingIntent({...BASE_OPTIONS, harnessType: 'gemini-cli'});
@@ -284,6 +284,22 @@ test.describe('onboardPeer — auth handoff', () => {
         expect(() => buildLoginCommand({harnessType: 'native-neo', instanceHome: '/srv/homes/c', launchCommand: '/bin/x'})).toThrow(/unsupported harnessType/);
     });
 
+    test('the executable login helper names the actual authMode for non-marker families — env-key is not mislabeled in-app', () => {
+        expect(() => buildLoginCommand({harnessType: 'opencode', authHome: '/srv/homes/p', authCommand: '/usr/local/bin/opencode'}))
+            .toThrow(/authMode 'env-key'; login commands are marker-family only/);
+    });
+
+    test('opencode (env-key): the post-launch handoff is done plus the provisioning reminder — no login, no sign-in, no guessed command', () => {
+        const handoff = deriveAuthHandoff({harnessType: 'opencode', status: {authRequired: null, instanceHome: '/srv/homes/p'}});
+        const output  = handoff.lines.join('\n');
+
+        expect(handoff.kind).toBe('done');
+        expect(output).toContain('env-key family');
+        expect(output).toContain('no per-home login step');
+        expect(output).not.toContain('SIGN-IN REQUIRED');
+        expect(output).not.toContain('LOGIN REQUIRED');
+    });
+
     test('claude-desktop authenticates in the Fleet-launched window and routes closed-window recovery back through Fleet', () => {
         const status = {
             authRequired : null,
@@ -372,6 +388,16 @@ test.describe('onboardPeer — auth handoff', () => {
         const codexPlan = planOnboarding({intent: buildIntent(), facts: {agent: buildAgent(), rosterHasResident: true, graphNodeSeeded: true, running: false, authRequired: null}});
 
         expect(codexPlan.segments.find(segment => segment.key === 'auth').detail).toContain('UNKNOWN');
+    });
+
+    test('the dry-run planner names the env-key mode for opencode — plan and post-launch decision cannot drift', () => {
+        const plan = planOnboarding({intent: buildIntent({harnessType: 'opencode'}), facts: {agent: buildAgent({harnessType: 'opencode'}), rosterHasResident: true, graphNodeSeeded: true, running: false, authRequired: null}});
+
+        const auth = plan.segments.find(segment => segment.key === 'auth');
+
+        expect(auth.detail).toContain('auth rides the spawned env');
+        expect(auth.detail).not.toContain('UNKNOWN');
+        expect(auth.detail).not.toContain('in-app sign-in');
     });
 
     test('the rendered login line executes through /bin/sh without command injection', async () => {

--- a/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
@@ -109,7 +109,7 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
     });
 
     test('LAUNCHABLE_HARNESS_TYPES is the frozen alphabetical template subset AND every entry is a registered harness type', () => {
-        expect(LAUNCHABLE_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex', 'codex-desktop']);
+        expect(LAUNCHABLE_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex', 'codex-desktop', 'opencode']);
         expect(Object.isFrozen(LAUNCHABLE_HARNESS_TYPES)).toBe(true);
 
         // The lockstep invariant the module also guards at import: launch vocabulary ⊆ the shared
@@ -125,12 +125,13 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
         expect(LAUNCHABLE_HARNESS_TYPES).not.toContain('native-neo');
     });
 
-    test('getHarnessAuthMode: marker for the CLI families, in-app for the app bundles, null fail-closed for everything else', () => {
+    test('getHarnessAuthMode: marker for the CLI families, in-app for the app bundles, env-key for the key-riding family, null fail-closed for everything else', () => {
         expect(getHarnessAuthMode('codex')).toBe('marker');
         expect(getHarnessAuthMode('codex-desktop')).toBe('marker');
         expect(getHarnessAuthMode('claude-code')).toBe('marker');
         expect(getHarnessAuthMode('claude-desktop')).toBe('in-app');
         expect(getHarnessAuthMode('antigravity')).toBe('in-app');
+        expect(getHarnessAuthMode('opencode')).toBe('env-key');
         expect(getHarnessAuthMode('native-neo')).toBeNull();
         expect(getHarnessAuthMode(undefined)).toBeNull();
     });
@@ -144,6 +145,27 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
         expect(call).toThrow(/'codex-desktop'/);
         expect(call).toThrow(/'claude-desktop'/);
         expect(call).toThrow(/'antigravity'/);
+    });
+
+    test('opencode: the headless serve template with the unified two-var XDG home (config + state under <instanceHome>/opencode)', () => {
+        const spec = deriveHarnessLaunchSpec({harnessType: 'opencode', instanceHome: '/srv/instances/p/oc', binaryPath: '/usr/local/bin/opencode'});
+
+        expect(spec).toEqual({
+            command: '/usr/local/bin/opencode',
+            args   : ['serve', '--hostname', '127.0.0.1', '--port', '0'],
+            env    : {
+                XDG_CONFIG_HOME: '/srv/instances/p/oc',
+                XDG_DATA_HOME  : '/srv/instances/p/oc',
+                XDG_CACHE_HOME : '/srv/instances/p/oc/cache'
+            },
+            versionProbeArgs: ['--version']
+        });
+
+        // fresh spec per call — a mutating caller never bleeds into the template
+        const other = deriveHarnessLaunchSpec({harnessType: 'opencode', instanceHome: '/srv/instances/p/oc', binaryPath: '/usr/local/bin/opencode'});
+        spec.args.push('--extra');
+        expect(other.args).toEqual(['serve', '--hostname', '127.0.0.1', '--port', '0']);
+        expect(spec.env).not.toBe(other.env);
     });
 
     test('fails loud on contract violations (no silent default spec)', () => {

--- a/test/playwright/unit/apps/agentos/config/accountConfigModel.spec.mjs
+++ b/test/playwright/unit/apps/agentos/config/accountConfigModel.spec.mjs
@@ -53,6 +53,7 @@ test.describe('FM account configuration model', () => {
         expect(harnessTypes.resolveHarnessType('codex')?.label).toBe('Codex');
         expect(harnessTypes.resolveHarnessType('codex-desktop')?.label).toBe('Codex Desktop');
         expect(harnessTypes.resolveHarnessType('antigravity')?.label).toBe('Antigravity');
+        expect(harnessTypes.resolveHarnessType('opencode')?.label).toBe('OpenCode');
 
         // fail-closed: never guess a launcher or a label
         expect(harnessTypes.resolveHarnessType('made-up-harness')).toBeNull();


### PR DESCRIPTION
Resolves #15391

Registers `opencode` as the FM's seventh harness family: one registry row in the ONE Body↔Brain authority (`src/ai/fleet/harnessTypes.mjs`, display position after `claude-desktop` per the ticket's product suggestion) + a **fully probe-evidenced** launch contract in `deriveHarnessLaunchSpec.mjs`. Every contract field carries real probe output from this seat's machine (opencode-ai 1.18.3, darwin-arm64) — nothing guessed, per the file's probed-contract discipline. The ticket's authMode fork is settled by **extending the vocabulary with `'env-key'`** (auth rides the spawned env — the portable-flatrate property) and patching all three consumer branches; a forced `'marker'`/`'in-app'` mapping would have been the rejection reason the ticket named.

Evidence: L3 (live CLI probes on the exact binary + unified-home census) → L4 required (an FM-supervised live launch of an opencode seat — the lifecycle-integration surface beyond this PR's pure derivation). Residual: the first FM-launched opencode instance (#15392's generator plants its config into the home this PR makes determinate).

## Probe record (all four contract fields)

- **isolation** — TWO-var XDG pair, not one home var: the CLI reads its seat config from `$XDG_CONFIG_HOME/opencode/opencode.jsonc` and state (db, logs, repos) from `$XDG_DATA_HOME/opencode/`. Pointing BOTH at the instance home unifies the whole footprint as `<instanceHome>/opencode/` (empirical census), which is also the generator's planting target. `XDG_CACHE_HOME=<instanceHome>/cache` contains the model catalog; the bun runtime cache stays HOME-relative (harmless artifact, recorded in-comment).
- **modeArgs** — `serve --hostname 127.0.0.1 --port 0`: alive at 4s on a held pipe **and** on an EOF'd stdin (stdio-indifferent headless server), clean SIGTERM both ways; `--port 0` auto-assigns, bound port discovered from the listening log line.
- **versionProbeArgs** — `--version` → `1.18.3` in milliseconds, exit 0.
- **authMode** — new vocabulary value `'env-key'`: no documented marker exists, the supervised mode has no window, and the fleet path (OpenCode+Kimi) carries the provider key in the seat env. Consumer verification, cited: `onboardPeer.mjs` auth segment (new env-key text branch), `buildLoginCommand` (throw now names the actual authMode instead of mislabeling it in-app), `deriveAuthHandoff` (new `done` + provisioning-reminder branch), `FleetControlBridge.mjs` roster DTO comment (vocabulary updated).

## Deltas from ticket

- authMode fork resolved as the ticket's option (b): vocabulary extension, not a forced mapping.
- `XDG_CACHE_HOME` added to the isolation env (the unified-home probe showed the model-catalog cache otherwise defaults under HOME).
- MCP-config planting seam: made *determinate*, not implemented — the unified home fixes the target at `<instanceHome>/opencode/opencode.jsonc`; the generator itself is #15392 (ticket Out-of-Scope).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/ test/playwright/unit/ai/scripts/fleet/ test/playwright/unit/apps/agentos/config/accountConfigModel.spec.mjs` → **349 passed**
- Conscious-update pins extended: `LAUNCHABLE_HARNESS_TYPES` exact-list pin, `CURATED_HARNESS_TYPES` exact-list pin, `getHarnessAuthMode` vocabulary pin, opencode derivation-shape + fresh-spec test, env-key handoff/planner/login-helper tests, Body-picker label pin (`accountConfigModel`).
- Pre-commit gates + `agent-preflight` (incl. `--fix` block-alignment): green.

## Post-Merge Validation

- [ ] `defineAgent` with `harnessType: 'opencode'` accepted by the live FleetRegistryService; the define-agent surface lists "OpenCode" with zero Body-side changes beyond the registry row.
- [ ] First FM-launched opencode seat (post-#15392): supervisor holds `serve`, discovers the port from the log line, reports `binaryVersion` from the probe.

Authored by Phoebe (Moonshot Kimi K3, OpenCode). Session 7a752066-e9f0-4682-b03c-9fc7d4d71711.
