### PR TITLE
feat(dashboard): dock tear-out contract tier — gesture surface + admission machine (#15407)

### DIFF
--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -274,14 +274,25 @@ class DockLayoutAdapter extends Base {
             // supplies a sortGroup makes every projected tab sort zone a coordinator-registered
             // drag SOURCE (the workspace id rides the drag payload for the receiving window's
             // `transferItem` resolution). Absent = fully in-window, the unchanged default.
-            crossWindowSortGroup     : options.crossWindowSortGroup ?? null,
-            defaultRevealFraction    : Number.isFinite(options.defaultRevealFraction) ? options.defaultRevealFraction : null,
-            dockZoneDocument         : options.dockZoneDocument || model,
+            crossWindowSortGroup : options.crossWindowSortGroup ?? null,
+            defaultRevealFraction: Number.isFinite(options.defaultRevealFraction) ? options.defaultRevealFraction : null,
+            dockZoneDocument     : options.dockZoneDocument || model,
+            // Tear-out (docking design record §2.8, additive + opt-in): a composition that enables
+            // it makes every projected tab sort zone fire the inherited window-boundary hysteresis,
+            // re-fired as dock gesture events (exit / entry / terminal / cancel) on the projected
+            // tab.Container. The HOST owns vessel acquisition + the `detachItem` commit at the
+            // terminal; the projection only threads the opt-in + the closure seams. Absent = fully
+            // in-window, the unchanged default.
+            enableDockTearOut        : options.enableDockTearOut === true,
             items                    : model.items || {},
             nodes                    : model.nodes,
             onDockCrossZoneDragCancel: options.onDockCrossZoneDragCancel,
             onDockCrossZoneDragMove  : options.onDockCrossZoneDragMove,
             onDockCrossZoneDrop      : options.onDockCrossZoneDrop,
+            onDockTearOutCancel      : options.onDockTearOutCancel,
+            onDockTearOutEntry       : options.onDockTearOutEntry,
+            onDockTearOutExit        : options.onDockTearOutExit,
+            onDockTearOutTerminal    : options.onDockTearOutTerminal,
             onDockZoneDocumentChange : options.onDockZoneDocumentChange,
             resolveComponentRef      : options.resolveComponentRef || (() => null),
             resolveRevealComponentRef: options.resolveRevealComponentRef
@@ -715,7 +726,12 @@ class DockLayoutAdapter extends Base {
                     // §2.3 source identity (opt-in): the coordinator gates registration on
                     // sortGroup, so a null group keeps this zone in-window exactly as before.
                     dockWorkspaceId: context.workspaceId,
-                    sortGroup      : context.crossWindowSortGroup
+                    // Tear-out opt-in (§2.8): arms the INHERITED window-boundary hysteresis on
+                    // this zone's drags. Only the serializable flag rides here — the gesture
+                    // handlers live on the tab.Container listeners block below, the clone-safe
+                    // closure home this projection already uses for its cross-zone events.
+                    enableProxyToPopup: context.enableDockTearOut === true,
+                    sortGroup         : context.crossWindowSortGroup
                 }
             },
             items    : projectedItems,
@@ -731,6 +747,15 @@ class DockLayoutAdapter extends Base {
                 // closure holds `context` (captured here, not serialized), so the reducer survives config
                 // cloning and needs no component-tree walk. The reducer hit-tests the target zone + commits.
                 dockCrossZoneDrop: data => context.onDockCrossZoneDrop?.(data),
+                // Tear-out gesture seams (§2.8): the zone re-fires the inherited boundary events here.
+                // Cancel retires the host's vessel with zero model mutation; entry is a resumed
+                // in-window gesture (vessel closes, no outcome); exit is where the host acquires its
+                // vessel per the admission contract (Boolean `windowOpen`, fail-closed) and engages
+                // `startWindowDrag`; terminal is the ONE seam a host may commit `detachItem` on.
+                dockTearOutCancel  : data => context.onDockTearOutCancel?.(data),
+                dockTearOutEntry   : data => context.onDockTearOutEntry?.(data),
+                dockTearOutExit    : data => context.onDockTearOutExit?.(data),
+                dockTearOutTerminal: data => context.onDockTearOutTerminal?.(data),
                 // Within-container reorder rides the container's own `moveTo` event.
                 moveTo: data => {
                     let itemId = items[data.fromIndex],

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -185,6 +185,21 @@ class DockTabSortZone extends TabHeaderSortZone {
     }
 
     /**
+     * Resumes the in-window embodiment after a detached phase ends without an outcome — the
+     * symmetric close of {@link #startWindowDrag}: the proxy becomes visible again and the base
+     * reorder un-parks. Two callers, both host-choreographed: a boundary re-entry (the gesture
+     * continues in-window) and a FAILED vessel admission (the base arms `isWindowDragging` BEFORE
+     * firing the exit event, so a blocked popup must actively restore the in-window gesture or the
+     * zone stays parked with a dead detached state).
+     */
+    endWindowDrag() {
+        let me = this;
+
+        me.dragProxy && (me.dragProxy.style = {opacity: 1});
+        me.isWindowDragging = false
+    }
+
+    /**
      * Engages the OS-window pointer-follow embodiment after the host acquired a vessel for a
      * tear-out: the in-window proxy stays alive to capture pointer events but turns invisible,
      * {@link Neo.draggable.container.SortZone#isWindowDragging} arms (which parks the base

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -14,8 +14,18 @@ import TabHeaderSortZone from '../draggable/tab/header/toolbar/SortZone.mjs';
  *
  * It reuses the existing drag lifecycle end-to-end: the base SortZone owns the proxy, the sort math, and
  * the drag data ({@link Neo.draggable.container.SortZone#onDragMove} threads `clientX`/`clientY`); this
- * class only reads the outcome and forwards it. No popup / window-detach path is involved
- * (`enableProxyToPopup` stays at its `false` default).
+ * class only reads the outcome and forwards it.
+ *
+ * **Tear-out (dock semantics over the landed boundary grammar).** With {@link #enableProxyToPopup}
+ * enabled by the composition, the INHERITED window-boundary hysteresis (direction-aware
+ * intersection-ratio detection in the base container SortZone) fires its boundary events during a
+ * tab drag. This class re-fires them as dock gesture events on the owner tab.Container —
+ * `dockTearOutExit` / `dockTearOutEntry` — plus the two gesture terminals the dock model cares
+ * about: `dockTearOutTerminal` (released while detached — the ONLY signal a host may commit a
+ * `detachItem` on) and `dockTearOutCancel` (cancelled while detached — the host closes its vessel
+ * with ZERO model mutation). The zone itself never opens windows and never mutates documents: the
+ * host owns vessel acquisition + the model commit, and the commit happens at the terminal, never at
+ * the boundary — a gesture that re-enters or cancels leaves the committed document untouched.
  *
  * **Cross-WINDOW participation (the harness docking design record, §2.3 source side).** The base tab-header
  * chain carries NO `Neo.manager.DragCoordinator` delegation (that lives only in the dashboard sort
@@ -122,7 +132,85 @@ class DockTabSortZone extends TabHeaderSortZone {
      */
     construct(config) {
         super.construct(config);
-        this.sortGroup && this.resolveDragCoordinator()
+
+        let me = this;
+
+        me.sortGroup && me.resolveDragCoordinator();
+
+        // Tear-out re-fire seam: the inherited boundary hysteresis fires these on the ZONE; the
+        // adapter's closure-captured handlers live on the tab.Container listeners block (the
+        // clone-safe home its cross-zone events already use), so the zone re-fires there. Wired
+        // unconditionally — without `enableProxyToPopup` the base never fires either event, so
+        // an in-window dock pays nothing.
+        me.on({
+            dragBoundaryEntry: me.onDockBoundaryEntry,
+            dragBoundaryExit : me.onDockBoundaryExit,
+            scope            : me
+        })
+    }
+
+    /**
+     * Re-fires the inherited `dragBoundaryEntry` (the drag re-entered the source window past the
+     * reattach threshold — the base already restored the in-window proxy state) as
+     * `dockTearOutEntry` on the owner tab.Container. The host's handler closes its vessel and
+     * clears transient tear-out state — with ZERO model mutation: re-entry is a resumed in-window
+     * gesture, not an outcome.
+     * @param {Object} data
+     */
+    onDockBoundaryEntry(data) {
+        let me     = this,
+            itemId = me.dockItemIds?.[me.startIndex];
+
+        me.owner?.up?.()?.fire('dockTearOutEntry', {
+            ...data, itemId, sortZone: me, sourceNodeId: me.dockSourceNodeId
+        })
+    }
+
+    /**
+     * Re-fires the inherited `dragBoundaryExit` (the drag left the source window past the detach
+     * threshold) as `dockTearOutExit` on the owner tab.Container. The host's handler owns what
+     * happens next — vessel acquisition per the admission contract (`windowOpen` returns a
+     * Boolean; `false` degrades the gesture to its in-window fallback) and, on success, engaging
+     * {@link #startWindowDrag}. No model mutation happens here or in the host's exit handler: the
+     * detach commits only at {@link #processDragEnd}'s `dockTearOutTerminal`.
+     * @param {Object} data
+     */
+    onDockBoundaryExit(data) {
+        let me     = this,
+            itemId = me.dockItemIds?.[me.startIndex];
+
+        me.owner?.up?.()?.fire('dockTearOutExit', {
+            ...data, itemId, sortZone: me, sourceNodeId: me.dockSourceNodeId
+        })
+    }
+
+    /**
+     * Engages the OS-window pointer-follow embodiment after the host acquired a vessel for a
+     * tear-out: the in-window proxy stays alive to capture pointer events but turns invisible,
+     * {@link Neo.draggable.container.SortZone#isWindowDragging} arms (which parks the base
+     * reorder commit), and the DragDrop main-thread addon takes over moving the popup window with
+     * the pointer. The dock-tier mirror of the dashboard SortZone's method — implemented here per
+     * the docking design record's contract-not-class constraint (dock surfaces do not inherit the
+     * dashboard sort zone). No dashboard layout re-flow: a tab strip's geometry is owned by the
+     * committed model projection, which this gesture has not touched.
+     * @param {Object} data
+     * @param {Number} data.popupHeight
+     * @param {Number} data.popupWidth
+     * @param {String} data.windowName
+     */
+    startWindowDrag(data) {
+        let me                                    = this,
+            {popupHeight, popupWidth, windowName} = data;
+
+        me.dragProxy && (me.dragProxy.style = {opacity: 0});
+        me.isWindowDragging = true;
+
+        Neo.main.addon.DragDrop.startWindowDrag({
+            popupHeight,
+            popupName: windowName,
+            popupWidth,
+            windowId : me.windowId
+        })
     }
 
     /**
@@ -235,8 +323,9 @@ class DockTabSortZone extends TabHeaderSortZone {
 
     /**
      * §2.3 mandatory source hook: a remote target engaged — the source's drag embodiment yields
-     * while the target window hosts the hover. The dock's embodiment is the in-window drag proxy
-     * (no popup path, `enableProxyToPopup` false), so suspension is hiding it.
+     * while the target window hosts the hover. On the coordinator path the dock's embodiment is
+     * the in-window drag proxy, so suspension is hiding it. (The tear-out popup embodiment closes
+     * through its own gesture terminals, never through this remote-target hook.)
      * @param {String} widgetName
      */
     suspendWindowDrag(widgetName) {
@@ -271,6 +360,11 @@ class DockTabSortZone extends TabHeaderSortZone {
      * exactly one drag-end: the item already transferred out of this document, so the in-window
      * cross-zone commit path must not fire a second, now-invalid operation. Base cleanup still runs.
      *
+     * A drag released while DETACHED ({@link Neo.draggable.container.SortZone#isWindowDragging})
+     * fires `dockTearOutTerminal` instead of the in-window drop — the one signal a host may commit
+     * a `detachItem` on; a cancel while detached fires `dockTearOutCancel` first (vessel cleanup,
+     * zero model mutation), then the regular cancel event.
+     *
      * Cross-window gestures close through {@link Neo.manager.DragCoordinator#onDragEnd} FIRST: a
      * release over an engaged remote target commits there, and the coordinator arms
      * {@link #remoteDropCommitted} via {@link #onRemoteDropOut} on this same call stack — so the
@@ -300,9 +394,23 @@ class DockTabSortZone extends TabHeaderSortZone {
 
         if (data.cancelled) {
             me.remoteDropCommitted = false;
+
+            // A cancel while detached also retires the tear-out: the host's handler closes its
+            // vessel — the committed document was never touched (zero-mutation invariant), so
+            // there is nothing to roll back.
+            if (me.isWindowDragging && itemId) {
+                tabContainer?.fire('dockTearOutCancel', {itemId, sortZone: me, sourceNodeId: me.dockSourceNodeId})
+            }
+
             itemId && tabContainer?.fire('dockCrossZoneDragCancel', {itemId, sourceNodeId: me.dockSourceNodeId})
         } else if (me.remoteDropCommitted) {
             me.remoteDropCommitted = false
+        } else if (me.isWindowDragging) {
+            // Released while detached — THE terminal a dock host may commit a `detachItem` on
+            // (model commit precedes any window close per the choreography contract). The zone
+            // itself never mutates documents; deterministic outcome order is cancel → remote
+            // transfer → tear-out terminal → in-window cross-zone drop.
+            itemId && tabContainer?.fire('dockTearOutTerminal', {itemId, sortZone: me, sourceNodeId: me.dockSourceNodeId})
         } else if (itemId && tabContainer && Neo.isNumber(clientX) && Neo.isNumber(clientY)) {
             tabContainer.fire('dockCrossZoneDrop', {clientX, clientY, itemId, sourceNodeId: me.dockSourceNodeId})
         }

--- a/src/dashboard/DockTearOut.mjs
+++ b/src/dashboard/DockTearOut.mjs
@@ -1,0 +1,138 @@
+/**
+ * @module Neo.dashboard.DockTearOut
+ * @summary The tear-out gesture choreography a dock HOST composes — the admission chain and the
+ * commit-at-terminal routing between the dock sort zone's gesture events and the host's own seams.
+ *
+ * {@link Neo.dashboard.DockTabSortZone} fires four tear-out gesture events (re-fired boundary
+ * hysteresis + the two detached terminals) and owns the drag embodiment; the dock MODEL owns the
+ * document. This module owns what sits between: WHEN a vessel may be acquired, WHEN the one model
+ * commit happens, and WHEN a vessel retires — with every seam injected, so the choreography is a
+ * pure decision machine the host parameterizes and witnesses drive without a browser.
+ *
+ * The choreography contract it implements (the docking design record's multi-window amendment):
+ * - **Admission is fail-closed.** `openVessel` resolving falsy means the popup was blocked, the
+ *   bounded connect never completed, or the host refused — the gesture DEGRADES to its in-window
+ *   fallback: the zone's window-drag embodiment is ended (the base armed it before firing the exit
+ *   event), no vessel state is retained, and the drag continues on the live in-window proxy.
+ * - **The model commits exactly once, at the detached terminal, never at the boundary.** A gesture
+ *   that re-enters or cancels leaves the committed document untouched (zero-mutation invariant);
+ *   only `dockTearOutTerminal` with an admitted vessel routes `detachItem` through the host's
+ *   operation seam. Model commit precedes any window action — on success the vessel STAYS (it owns
+ *   the item now); on a model refusal the vessel retires so no window survives showing an item the
+ *   document still owns.
+ * - **Re-entry and cancel retire the vessel with zero mutation.** Entry additionally resumes the
+ *   in-window embodiment (the gesture continues); cancel just cleans up (the gesture is over).
+ */
+
+/**
+ * Creates the four tear-out gesture handlers a dock composition threads into
+ * {@link Neo.dashboard.DockLayoutAdapter#project} (`onDockTearOutExit` / `Entry` / `Terminal` /
+ * `Cancel`), closed over one single-gesture vessel slot. One handler set serves one workspace
+ * composition — a pointer drives at most one drag per window, so the slot never needs a map.
+ * @param {Object} seams
+ * @param {Function} seams.applyOperation Host model seam: `({operation, itemId}) => {document, errors}` —
+ *     the workspace's pure reducer (`applyDockZoneOperation`). Called exactly once per successful
+ *     tear-out, with `{operation: 'detachItem', itemId}`.
+ * @param {Function} seams.closeVessel Host vessel retirement: `({itemId, windowName}) => void|Promise` —
+ *     closes the OS window a retired gesture leaves behind. Never called for a committed tear-out.
+ * @param {Function} seams.onDocumentChange Host view-sync seam: `(document, operation) => void` —
+ *     receives the committed post-detach document (the same seam shape the adapter's `moveTo`
+ *     listener feeds).
+ * @param {Function} seams.openVessel Host vessel acquisition:
+ *     `({itemId, proxyRect, sortZone}) => Promise<{popupHeight, popupWidth, windowName}|null>` —
+ *     the host performs the platform work (URL, geometry, `windowOpen`) and resolves FALSY on any
+ *     failed admission (`windowOpen` returns a Boolean — a blocked popup never throws, so the host
+ *     must check the Boolean, not catch).
+ * @returns {Object} `{onDockTearOutCancel, onDockTearOutEntry, onDockTearOutExit, onDockTearOutTerminal}`
+ */
+export function createDockTearOutHandlers({applyOperation, closeVessel, onDocumentChange, openVessel}) {
+    // The single-gesture vessel slot: `{itemId, windowName}` while a vessel is admitted, else null.
+    let activeVessel = null;
+
+    return {
+        /**
+         * Cancel while detached: the vessel retires, the document was never touched. The zone's
+         * base cleanup owns the embodiment teardown (the drag is over), so unlike entry there is
+         * no embodiment to resume.
+         * @param {Object} data
+         */
+        onDockTearOutCancel(data) {
+            let vessel = activeVessel;
+
+            if (!vessel) return;
+
+            activeVessel = null;
+            closeVessel(vessel)
+        },
+
+        /**
+         * The drag re-entered the source window past the reattach threshold: a resumed in-window
+         * gesture, not an outcome. The vessel retires with zero model mutation and the zone
+         * resumes its in-window embodiment.
+         * @param {Object} data
+         */
+        onDockTearOutEntry(data) {
+            let vessel = activeVessel;
+
+            data.sortZone?.endWindowDrag();
+
+            if (!vessel) return;
+
+            activeVessel = null;
+            closeVessel(vessel)
+        },
+
+        /**
+         * The drag left the window past the detach threshold: acquire a vessel through the host's
+         * admission seam. Falsy resolution = fail closed — end the window-drag embodiment the base
+         * armed before firing this event, retain no state, and let the gesture continue on the
+         * live in-window proxy. An admitted vessel engages the zone's OS pointer-follow.
+         * @param {Object} data
+         * @returns {Promise<void>}
+         */
+        async onDockTearOutExit(data) {
+            if (activeVessel) return;
+
+            let vessel = await openVessel({itemId: data.itemId, proxyRect: data.proxyRect, sortZone: data.sortZone});
+
+            if (!vessel) {
+                data.sortZone?.endWindowDrag();
+                return
+            }
+
+            activeVessel = {itemId: data.itemId, windowName: vessel.windowName};
+
+            data.sortZone?.startWindowDrag({
+                dragData   : data,
+                popupHeight: vessel.popupHeight,
+                popupWidth : vessel.popupWidth,
+                windowName : vessel.windowName
+            })
+        },
+
+        /**
+         * Released while detached — the ONE commit seam: `detachItem` routes through the host's
+         * reducer (tree removal, catalog preserved for vessel ownership). Success: the committed
+         * document syncs and the vessel STAYS — it owns the item now. A model refusal retires the
+         * vessel instead, so no window survives showing an item the document still owns. Without
+         * an admitted vessel (failed admission earlier in the gesture) there is nothing to commit.
+         * @param {Object} data
+         */
+        onDockTearOutTerminal(data) {
+            let vessel = activeVessel;
+
+            if (!vessel || vessel.itemId !== data.itemId) return;
+
+            activeVessel = null;
+
+            let operation = {operation: 'detachItem', itemId: data.itemId},
+                result    = applyOperation(operation);
+
+            if (result && !result.errors?.length && result.document) {
+                onDocumentChange(result.document, operation)
+            } else {
+                closeVessel(vessel)
+            }
+        }
+    }
+}

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -617,4 +617,45 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         expect(plugins).toHaveLength(1);
         expect(plugins[0].module).toBe(TabOverflowPlugin);
     });
+
+    test.describe('tear-out projection threading — opt-in flag + the clone-safe gesture seams', () => {
+        test('enableDockTearOut arms enableProxyToPopup on every projected tab sort zone and threads the four gesture seams', () => {
+            const captured = {cancel: [], entry: [], exit: [], terminal: []};
+
+            const result = DockLayoutAdapter.project(createModel(), {
+                enableDockTearOut    : true,
+                onDockTearOutCancel  : data => captured.cancel.push(data),
+                onDockTearOutEntry   : data => captured.entry.push(data),
+                onDockTearOutExit    : data => captured.exit.push(data),
+                onDockTearOutTerminal: data => captured.terminal.push(data),
+                resolveComponentRef  : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            });
+
+            const mainTabs = result.items[0];
+
+            // The serializable flag rides the sortZoneConfig; the closures live on the tab.Container
+            // listeners block — the projection's proven clone-safe closure home. A function inside
+            // sortZoneConfig would not survive config cloning; this split is the load-bearing shape.
+            expect(mainTabs.headerToolbar.sortZoneConfig.enableProxyToPopup).toBe(true);
+
+            for (const [listener, bucket] of [
+                ['dockTearOutCancel', 'cancel'], ['dockTearOutEntry', 'entry'],
+                ['dockTearOutExit', 'exit'], ['dockTearOutTerminal', 'terminal']
+            ]) {
+                const handler = mainTabs.listeners[listener];
+
+                expect(typeof handler, `${listener} must be wired`).toBe('function');
+                handler({itemId: 'swarm'});
+                expect(captured[bucket]).toEqual([{itemId: 'swarm'}])
+            }
+        });
+
+        test('absent opt-in keeps the dock fully in-window: the flag projects false (the unchanged default)', () => {
+            const result = DockLayoutAdapter.project(createModel(), {
+                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            });
+
+            expect(result.items[0].headerToolbar.sortZoneConfig.enableProxyToPopup).toBe(false)
+        })
+    });
 });

--- a/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
@@ -312,6 +312,22 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
             expect(proxyStyles).toEqual([{opacity: 0}]);   // invisible, never destroyed — it still captures pointer events
             expect(zone.isWindowDragging).toBe(true);      // parks the base reorder commit for this gesture
             expect(addonCalls).toEqual([{popupHeight: 480, popupName: 'graph', popupWidth: 640, windowId: 7}])
+        });
+
+        test('endWindowDrag is the symmetric close: proxy visible, base reorder un-parked — the failed-admission degrade path', () => {
+            const proxyStyles = [];
+            const zone        = {
+                dragProxy       : {set style(value) { proxyStyles.push(value) }},
+                isWindowDragging: true
+            };
+
+            DockTabSortZone.prototype.endWindowDrag.call(zone);
+
+            expect(proxyStyles).toEqual([{opacity: 1}]);
+            expect(zone.isWindowDragging).toBe(false);
+
+            // proxy-less call (torn down mid-gesture) stays safe — the flag still resets
+            DockTabSortZone.prototype.endWindowDrag.call({dragProxy: null, isWindowDragging: true})
         })
     })
 });

--- a/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
@@ -196,5 +196,122 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
             expect(decide(H_RECT, {clientX: undefined, clientY: 400})).toBe(false);
             expect(decide(H_RECT, {})).toBe(false)
         })
+    });
+
+    test.describe('tear-out gesture terminals — the choreography outcome routing', () => {
+        // Prototype-driven like every pin above: the drag-end decision chain is the unit; the
+        // base lifecycle is stubbed to nothing so only the dock routing under test runs.
+        const zoneFor = (fired, overrides = {}) => ({
+            dockItemIds        : ['audit', 'graph', 'inbox'],
+            dockSourceNodeId   : 'tabs-main',
+            dragComponent      : null,
+            isWindowDragging   : false,
+            owner              : {up: () => ({fire: (name, data) => fired.push([name, data])})},
+            releaseVoidsReorder: () => false,
+            remoteDropCommitted: false,
+            sortGroup          : null,
+            startIndex         : 1,
+            ...overrides
+        });
+
+        const runDragEnd = async (zone, data) => {
+            const original = TabHeaderSortZone.prototype.processDragEnd;
+
+            TabHeaderSortZone.prototype.processDragEnd = async function() {};
+
+            try {
+                await DockTabSortZone.prototype.processDragEnd.call(zone, data)
+            } finally {
+                TabHeaderSortZone.prototype.processDragEnd = original
+            }
+        };
+
+        test('released while DETACHED fires the terminal — the one detachItem seam — never the in-window drop', async () => {
+            const fired = [];
+            const zone  = zoneFor(fired, {isWindowDragging: true});
+
+            await runDragEnd(zone, {cancelled: false, clientX: 5000, clientY: 400});
+
+            expect(fired.map(([name]) => name)).toEqual(['dockTearOutTerminal']);
+            expect(fired[0][1]).toEqual({itemId: 'graph', sortZone: zone, sourceNodeId: 'tabs-main'})
+        });
+
+        test('cancelled while DETACHED retires the vessel FIRST, then the regular cancel — zero commit events', async () => {
+            const fired = [];
+            const zone  = zoneFor(fired, {isWindowDragging: true});
+
+            await runDragEnd(zone, {cancelled: true});
+
+            // order matters: vessel cleanup precedes the generic cancel affordance reset
+            expect(fired.map(([name]) => name)).toEqual(['dockTearOutCancel', 'dockCrossZoneDragCancel']);
+            // neither terminal nor drop — the zero-model-mutation invariant has no commit seam to reach
+            expect(fired.some(([name]) => name === 'dockTearOutTerminal')).toBe(false);
+            expect(fired.some(([name]) => name === 'dockCrossZoneDrop')).toBe(false)
+        });
+
+        test('an in-window release still routes the cross-zone drop exactly as before (regression pin)', async () => {
+            const fired = [];
+            const zone  = zoneFor(fired);
+
+            await runDragEnd(zone, {cancelled: false, clientX: 300, clientY: 400});
+
+            expect(fired.map(([name]) => name)).toEqual(['dockCrossZoneDrop']);
+            expect(fired[0][1]).toEqual({clientX: 300, clientY: 400, itemId: 'graph', sourceNodeId: 'tabs-main'})
+        });
+
+        test('a committed remote transfer outranks the tear-out terminal — deterministic outcome order, no double commit', async () => {
+            const fired = [];
+            const zone  = zoneFor(fired, {isWindowDragging: true, remoteDropCommitted: true});
+
+            await runDragEnd(zone, {cancelled: false, clientX: 5000, clientY: 400});
+
+            expect(fired, 'the item already left this document — every local commit seam stays silent').toEqual([]);
+            expect(zone.remoteDropCommitted, 'the one-shot flag is consumed').toBe(false)
+        });
+
+        test('the boundary events re-fire on the tab.Container with the dock identity attached', () => {
+            const fired = [];
+            const zone  = zoneFor(fired);
+            const data  = {intersectionRatio: 0.42, proxyRect: {x: 1, y: 2}};
+
+            DockTabSortZone.prototype.onDockBoundaryExit.call(zone, data);
+            DockTabSortZone.prototype.onDockBoundaryEntry.call(zone, data);
+
+            expect(fired.map(([name]) => name)).toEqual(['dockTearOutExit', 'dockTearOutEntry']);
+
+            for (const [, payload] of fired) {
+                expect(payload.itemId).toBe('graph');
+                expect(payload.sourceNodeId).toBe('tabs-main');
+                expect(payload.sortZone).toBe(zone);
+                expect(payload.intersectionRatio).toBe(0.42) // the base payload rides along
+            }
+        });
+
+        test('startWindowDrag arms the detached embodiment: proxy invisible-but-alive, base reorder parked, addon engaged', () => {
+            const addonCalls  = [];
+            const proxyStyles = [];
+            const zone        = {
+                dragProxy       : {set style(value) { proxyStyles.push(value) }},
+                isWindowDragging: false,
+                windowId        : 7
+            };
+
+            const hadDragDrop = Object.hasOwn(Neo.main.addon, 'DragDrop'),
+                  original    = Neo.main.addon.DragDrop;
+
+            Neo.main.addon.DragDrop = {startWindowDrag: data => addonCalls.push(data)};
+
+            try {
+                DockTabSortZone.prototype.startWindowDrag.call(zone, {
+                    popupHeight: 480, popupWidth: 640, windowName: 'graph'
+                });
+            } finally {
+                if (hadDragDrop) { Neo.main.addon.DragDrop = original } else { delete Neo.main.addon.DragDrop }
+            }
+
+            expect(proxyStyles).toEqual([{opacity: 0}]);   // invisible, never destroyed — it still captures pointer events
+            expect(zone.isWindowDragging).toBe(true);      // parks the base reorder commit for this gesture
+            expect(addonCalls).toEqual([{popupHeight: 480, popupName: 'graph', popupWidth: 640, windowId: 7}])
+        })
     })
 });

--- a/test/playwright/unit/dashboard/DockTearOut.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTearOut.spec.mjs
@@ -1,0 +1,158 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockTearOutTest'
+    }
+});
+
+import {test, expect}              from '@playwright/test';
+import {createDockTearOutHandlers} from '../../../../src/dashboard/DockTearOut.mjs';
+
+/**
+ * @summary The tear-out admission machine, driven end-to-end through its injected seams.
+ *
+ * Every witness here is a choreography-contract pin: admission fails CLOSED (a blocked popup
+ * degrades the gesture to its in-window fallback — the base armed the detached state before the
+ * exit event, so the machine must actively end it), the model commits exactly once at the
+ * detached terminal (never at a boundary), re-entry/cancel retire the vessel with zero mutation,
+ * and a committed tear-out KEEPS its vessel while a refused commit retires it. The seams are the
+ * assertion surface — the machine exposes nothing else.
+ */
+test.describe('Neo.dashboard.DockTearOut — createDockTearOutHandlers', () => {
+    const harness = ({admit = true, commitErrors = []} = {}) => {
+        const calls = {applied: [], closed: [], ended: 0, opened: [], started: [], synced: []};
+
+        const sortZone = {
+            endWindowDrag  : () => calls.ended++,
+            startWindowDrag: data => calls.started.push(data)
+        };
+
+        const handlers = createDockTearOutHandlers({
+            applyOperation  : operation => {
+                calls.applied.push(operation);
+                return commitErrors.length
+                    ? {document: null, errors: commitErrors}
+                    : {document: {committed: true, detached: operation.itemId}, errors: []}
+            },
+            closeVessel     : vessel => calls.closed.push(vessel),
+            onDocumentChange: (document, operation) => calls.synced.push({document, operation}),
+            openVessel      : async request => {
+                calls.opened.push(request);
+                return admit ? {popupHeight: 480, popupWidth: 640, windowName: `vessel-${request.itemId}`} : null
+            }
+        });
+
+        return {calls, handlers, sortZone}
+    };
+
+    const exitData = (sortZone, itemId = 'graph') => ({itemId, proxyRect: {x: 5, y: 6, width: 640, height: 430}, sortZone});
+
+    test('failed admission fails CLOSED: embodiment ended, pointer-follow never engaged, and a later terminal commits nothing', async () => {
+        const {calls, handlers, sortZone} = harness({admit: false});
+
+        await handlers.onDockTearOutExit(exitData(sortZone));
+
+        expect(calls.opened).toHaveLength(1);           // the host WAS asked (Boolean windowOpen is its check)
+        expect(calls.ended).toBe(1);                    // the base armed the detached state pre-event — degrade must end it
+        expect(calls.started).toHaveLength(0);          // the OS pointer-follow never engages without a vessel
+
+        handlers.onDockTearOutTerminal({itemId: 'graph', sortZone});
+
+        expect(calls.applied, 'no admitted vessel = nothing to commit').toHaveLength(0);
+        expect(calls.closed).toHaveLength(0)
+    });
+
+    test('an admitted vessel engages the pointer-follow with the vessel geometry + the original gesture data', async () => {
+        const {calls, handlers, sortZone} = harness();
+        const data                        = exitData(sortZone);
+
+        await handlers.onDockTearOutExit(data);
+
+        expect(calls.opened[0]).toEqual({itemId: 'graph', proxyRect: data.proxyRect, sortZone});
+        expect(calls.ended).toBe(0);
+        expect(calls.started).toEqual([{
+            dragData: data, popupHeight: 480, popupWidth: 640, windowName: 'vessel-graph'
+        }])
+    });
+
+    test('the detached terminal commits detachItem EXACTLY once, syncs the committed document, and the vessel STAYS', async () => {
+        const {calls, handlers, sortZone} = harness();
+
+        await handlers.onDockTearOutExit(exitData(sortZone));
+        handlers.onDockTearOutTerminal({itemId: 'graph', sortZone});
+
+        expect(calls.applied).toEqual([{operation: 'detachItem', itemId: 'graph'}]);
+        expect(calls.synced).toEqual([{
+            document : {committed: true, detached: 'graph'},
+            operation: {operation: 'detachItem', itemId: 'graph'}
+        }]);
+        expect(calls.closed, 'a committed tear-out keeps its vessel — it owns the item now').toHaveLength(0);
+
+        // the slot is consumed: a duplicate terminal (stale event) commits nothing further
+        handlers.onDockTearOutTerminal({itemId: 'graph', sortZone});
+        expect(calls.applied).toHaveLength(1)
+    });
+
+    test('a model refusal at the terminal retires the vessel instead of syncing — no window survives showing a still-docked item', async () => {
+        const {calls, handlers, sortZone} = harness({commitErrors: ['item "graph" is not in the tree']});
+
+        await handlers.onDockTearOutExit(exitData(sortZone));
+        handlers.onDockTearOutTerminal({itemId: 'graph', sortZone});
+
+        expect(calls.applied).toHaveLength(1);
+        expect(calls.synced).toHaveLength(0);
+        expect(calls.closed).toEqual([{itemId: 'graph', windowName: 'vessel-graph'}])
+    });
+
+    test('re-entry retires the vessel with ZERO model mutation and resumes the in-window embodiment', async () => {
+        const {calls, handlers, sortZone} = harness();
+
+        await handlers.onDockTearOutExit(exitData(sortZone));
+        handlers.onDockTearOutEntry({itemId: 'graph', sortZone});
+
+        expect(calls.closed).toEqual([{itemId: 'graph', windowName: 'vessel-graph'}]);
+        expect(calls.ended).toBe(1);
+        expect(calls.applied).toHaveLength(0);
+
+        // entry without a vessel (nothing admitted) still resumes the embodiment, retires nothing
+        handlers.onDockTearOutEntry({itemId: 'graph', sortZone});
+        expect(calls.closed).toHaveLength(1);
+        expect(calls.ended).toBe(2)
+    });
+
+    test('cancel while detached retires the vessel with zero mutation — base cleanup owns the embodiment teardown', async () => {
+        const {calls, handlers, sortZone} = harness();
+
+        await handlers.onDockTearOutExit(exitData(sortZone));
+        handlers.onDockTearOutCancel({itemId: 'graph', sortZone});
+
+        expect(calls.closed).toEqual([{itemId: 'graph', windowName: 'vessel-graph'}]);
+        expect(calls.applied).toHaveLength(0);
+        expect(calls.ended, 'cancel ends the drag — no embodiment to resume').toBe(0)
+    });
+
+    test('the hysteresis re-crossing arc: exit → entry → exit → terminal yields two vessels, ONE commit, one retirement', async () => {
+        const {calls, handlers, sortZone} = harness();
+
+        await handlers.onDockTearOutExit(exitData(sortZone));    // vessel 1 admitted
+        handlers.onDockTearOutEntry({itemId: 'graph', sortZone}); // vessel 1 retired, zero mutation
+        await handlers.onDockTearOutExit(exitData(sortZone));    // vessel 2 admitted
+        handlers.onDockTearOutTerminal({itemId: 'graph', sortZone}); // vessel 2 commits + stays
+
+        expect(calls.opened).toHaveLength(2);
+        expect(calls.closed).toHaveLength(1);
+        expect(calls.applied).toEqual([{operation: 'detachItem', itemId: 'graph'}]);
+        expect(calls.synced).toHaveLength(1)
+    });
+
+    test('a terminal for a DIFFERENT item than the admitted vessel commits nothing (stale-identity guard)', async () => {
+        const {calls, handlers, sortZone} = harness();
+
+        await handlers.onDockTearOutExit(exitData(sortZone, 'graph'));
+        handlers.onDockTearOutTerminal({itemId: 'inbox', sortZone});
+
+        expect(calls.applied).toHaveLength(0);
+        expect(calls.synced).toHaveLength(0)
+    })
+});


### PR DESCRIPTION
Resolves #15407
Related: #15244, #15239

G1's contract tier: the dock becomes a consumer of the landed window-boundary grammar with **zero parallel drag system** — the base container SortZone's hysteresis detection (the #8160 lineage) was inherited by the dock tab chain all along; this PR arms it, routes its events dock-semantically, and ships the admission machine that decides when a vessel may exist and when the ONE model commit happens. The host tier (flagship wiring, calibration receipts, e2e gesture witnesses, matrix-fed platform defaults) is #15244's retained half — split per the honest-close-target discipline so tonight's complete, witnessed engine work is reviewable now instead of parked.

Evidence: L2 (23 unit witnesses across the three touched surfaces + full 359-spec dashboard suite at exact head — the contract tier's ceiling; the live mid-drag popup is host-tier work) → L2 required (#15407 ACs are unit-floor by the epic family's own evidence language). Residual: none for this leaf; #15244 retains the L3 tiers.

## Deltas

| Area | Before | After |
|---|---|---|
| Dock tab drags vs window boundary | detection grammar inherited but permanently dark (`enableProxyToPopup` false, hard-coded comment) | armed by composition opt-in; boundary events re-fired as dock gesture events on the tab.Container (the clone-safe closure home) |
| Detached-gesture terminals | none — a window-drag release fell through the in-window drop chain | `dockTearOutTerminal` (the ONE `detachItem` seam) + `dockTearOutCancel` (zero-mutation retirement); deterministic order cancel → remote transfer → terminal → in-window drop |
| Vessel choreography | none | `Neo.dashboard.DockTearOut` — `createDockTearOutHandlers`: fail-closed admission (blocked popup ⇒ `endWindowDrag` degrade, load-bearing because the base arms `isWindowDragging` BEFORE firing the exit event), commit-at-terminal-never-at-boundary, committed tear-out keeps its vessel / model refusal retires it, re-crossing = two vessels · one commit · one retirement |
| OS pointer-follow embodiment | dashboard-SortZone-only (`startWindowDrag`) | dock-tier `startWindowDrag`/`endWindowDrag` per the §2.3 contract-not-class constraint |
| Adapter projection | no tear-out surface | `enableDockTearOut` → `enableProxyToPopup` per projected zone + four gesture seams on tab.Container listeners; absent = unchanged in-window default (pinned) |

## Test Evidence

- `DockTabSortZone.spec.mjs`: outcome routing (terminal vs cancel vs remote-suppression vs in-window regression pin), boundary re-fires with dock identity, `startWindowDrag`/`endWindowDrag` embodiment pins — the base lifecycle stubbed so only the dock routing under test runs.
- `DockTearOut.spec.mjs` (new): the admission machine end-to-end through its injected seams — failed-admission fail-closed (engage never happens, later terminal commits NOTHING), commit-exactly-once + vessel-stays, model-refusal retirement, entry/cancel zero-mutation, the hysteresis re-crossing arc, stale-identity guard.
- `DockLayoutAdapter.spec.mjs`: opt-in threading (flag + four seams live-invoked) + the default-off pin.
- Full dashboard suite: **359/359** (`test/playwright/unit/dashboard/`, unit config). CI green at head required before merge.

## Deltas from ticket

#15407 is the split leaf scoped to exactly these commits; no deltas. #15244 retains host wiring + AC-2/3/4/6 with its #15243 seam recorded on the ticket.

## Post-Merge Validation

- [ ] The host tier (#15244's retained half) wires a live composition against these seams — the first real mid-drag tear-out on a wired host is the contract's end-to-end validation; any seam friction discovered there lands as review-input on #15244, not silent adaptation.
- [ ] No operational steps: contract-tier code, no seeds, no daemons, no config.

## Commits

- 6518195cd5 — the gesture surface: boundary grammar armed, four terminals routed dock-semantically, dock-tier `startWindowDrag`.
- e9c69067d5 — the admission machine + `endWindowDrag` degrade path + 9 witnesses.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 89818500-8a12-4162-b41f-8947703b1b06.
