### PR TITLE
fix(fleet): shape-guard relatedTickets in composeOperatorMessage — reject non-array (#15400)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -413,9 +413,11 @@ class FleetControlBridge extends Base {
      * @param {String}   params.body
      * @param {String}   [params.priority]       Omitted → sender-class default.
      * @param {Boolean}  [params.wakeSuppressed] Omitted → sender-class default (human ⇒ quiet).
-     * @param {String[]} [params.relatedTickets]
-     * @returns {Promise<Object>|Object} the writer's acceptance (`{messageId, sentAt, …}`), or the
-     *     `{status:'not-wired'}` refusal when no writer is installed.
+     * @param {String[]} [params.relatedTickets] Must be an array; a non-array value is rejected before
+     *     the writer is invoked (the fleet wire's only schema-less shape guard — the primitive spreads it).
+     * @returns {Promise<Object>|Object} the writer's acceptance (`{messageId, sentAt, …}`), the
+     *     `{status:'not-wired'}` refusal when no writer is installed, or `{status:'rejected'}` when
+     *     `relatedTickets` is a non-array.
      */
     composeOperatorMessage(params = {}) {
         const writer = this.composeWriter;
@@ -426,6 +428,16 @@ class FleetControlBridge extends Base {
 
         const {to, subject, body, priority, wakeSuppressed, relatedTickets} = params;
         const payload                                                       = {to, subject, body};
+
+        // Shape-guard the one array-typed whitelisted field. The fleet wire has NO schema layer (the
+        // MCP transport enforces `String[]`; this verb is the single schema-less caller), and
+        // `MailboxService.addMessage` spreads it (`[...relatedTickets]`) — so a non-array string
+        // CHAR-SPLITS into garbage WAL refs and a number THROWS mid-send. Reject loudly here rather
+        // than corrupt the coordination fabric; `undefined` still omits (sender-class defaults stay
+        // the primitive's decision). The whitelist governs WHICH fields cross; this governs the SHAPE.
+        if (relatedTickets !== undefined && !Array.isArray(relatedTickets)) {
+            return {status: 'rejected', reason: 'relatedTickets must be an array'};
+        }
 
         if (priority       !== undefined) payload.priority       = priority;
         if (wakeSuppressed !== undefined) payload.wakeSuppressed = wakeSuppressed;

--- a/test/playwright/unit/ai/services/fleet/wireOperatorComposeWriter.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/wireOperatorComposeWriter.spec.mjs
@@ -98,4 +98,22 @@ test.describe('Neo.ai.services.fleet.wireOperatorComposeWriter', () => {
         expect(Object.hasOwn(captured, 'wakeSuppressed')).toBe(false);
         expect(Object.hasOwn(captured, 'relatedTickets')).toBe(false);
     });
+
+    test('#15400 shape-guard: a non-array relatedTickets is REJECTED and the writer is NEVER invoked', async () => {
+        // Finding-1 of the compose verb's break-it review: the fleet wire has no schema layer, and
+        // MailboxService.addMessage spreads relatedTickets — so a string would CHAR-SPLIT into garbage
+        // WAL refs (e.g. '15379' stores ['1','5','3','7','9']) and a number would THROW mid-send. The
+        // verb rejects at the seam, before the writer is ever invoked. undefined (omit) + a real array
+        // pass-through are pinned by the sibling witnesses above.
+        for (const bad of ['15379', 42, {0: '15379'}]) {
+            let invoked = false;
+            wireOperatorComposeWriter({addMessage: () => { invoked = true; return {messageId: 'MESSAGE:x'}; }});
+
+            const result = await FleetControlBridge.composeOperatorMessage({to: 'AGENT:*', subject: 's', body: 'b', relatedTickets: bad});
+
+            expect(result.status, `${JSON.stringify(bad)} must be rejected`).toBe('rejected');
+            expect(result.reason).toContain('relatedTickets must be an array');
+            expect(invoked, `the writer must NEVER be invoked for a non-array relatedTickets (${JSON.stringify(bad)})`).toBe(false);
+        }
+    });
 });


### PR DESCRIPTION
Resolves #15400
Related: #15379, #15389

Shape-guards `relatedTickets` in the operator compose verb. @neo-kimi-phoebe's fresh-context break-it review of PR #15389 (the fleet wire's first write verb) flagged the assumption that whitelisted value *shapes* are validated at the seam; author V-B-A on #15400 confirmed it FALSE in the dangerous direction.

**The corruption path:** the fleet wire has no schema layer (only the MCP transport enforces `String[]`), and `MailboxService.addMessage` destructures + spreads `relatedTickets` (`[...relatedTickets]`, `MailboxService.mjs:1249/:435`). So a non-array crossing the schema-less `composeOperatorMessage` seam:
- a **string** silently **char-splits** — `relatedTickets: "15379"` stores `['1','5','3','7','9']`, five garbage ticket refs riding the WAL into the graph with no error anywhere;
- a **number** (or any non-iterable) **throws** inside the primitive mid-send.

**The fix:** `composeOperatorMessage` now rejects a non-array, non-`undefined` `relatedTickets` with the verb's own honest structured refusal — `{status:'rejected', reason:'relatedTickets must be an array'}` — **before the writer is invoked**. Never a silent drop (a caller that sent garbage learns it), never pass-through; `undefined` still omits the key (sender-class defaults stay the primitive's decision). Defense at the verb (the single schema-less caller), not the primitive (whose typed contract is legitimately owned by its schema-validated callers — per the ticket's Out of Scope).

## Deltas from ticket

None — the exact prescription (verb-level guard, `{status:'rejected'}`, no primitive change).

Evidence: L2 (unit — the guard rejects string/number/object with the writer never invoked; the char-split path pinned as a named negative; the existing pass-through + omit + smuggling witnesses stay green) → L2 required (a pure input-shape guard; no runtime surface). Residual: none.

## Test Evidence

- `wireOperatorComposeWriter.spec.mjs` (unit): **6 passed** — the new `#15400 shape-guard` witness (non-array string/number/object → `{status:'rejected'}`, writer NEVER invoked, verified per-shape) + the 5 existing (fail-soft, install, not-wired, the exhaustive smuggling-negative, omitted-keys-stay-absent) all green.
- The regression pins hold: AC-2 (`undefined` omits) and AC-3 (a valid array passes through) are the existing omitted + smuggling-negative witnesses, unchanged.
- `node --check` + block-alignment clean on both files.

## Post-Merge Validation

None — fully unit-covered (a schema-less-ingress input guard, no runtime effect beyond the verb).

## Commits

- `345f4a5679` — the verb guard + JSDoc shape rule + the named-negative witness.

Authored by Ada (Claude Opus 4.8, Claude Code). Session 3f892890-5ce2-4045-8290-dbbdff1b987a. Credit to @neo-kimi-phoebe for the finding (PR #15389 break-it review, finding 1) — the cross-family gate catching what my Opus pass missed.
