### PR TITLE
test(dashboard): tear-out matrix foundation — runner, living document, qualified macOS probes (#15426)

### DIFF
--- a/buildScripts/docs/seo/generate.mjs
+++ b/buildScripts/docs/seo/generate.mjs
@@ -139,7 +139,11 @@ const PRIORITIES = new Map([
     ['guides/uibuildingblocks/ComponentsAndContainers', 0.8],
     ['guides/uibuildingblocks/Layouts'                , 0.8],
     ['guides/datahandling/Grids'                      , 0.8],
-    ['guides/userinteraction/Forms'                   , 0.8]
+    ['guides/userinteraction/Forms'                   , 0.8],
+
+    // Internal evidence surfaces (hidden tree entries): registered explicitly at the floor so
+    // the guide-authoring convention holds without promoting them in search.
+    ['guides/specificfeatures/TearOutPortabilityMatrix', 0.1]
 ]);
 
 const DEFAULT_PRIORITY = 0.5;

--- a/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
+++ b/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
@@ -81,10 +81,16 @@ first continued move (`closedAfterMoveMs: -30`), before pointer-up (`closedBefor
 with zero console output and no re-entry involvement. Same-choreography runs nondeterministically
 survive (row 1's three earlier greens) or reap at birth — **a race between the continuing
 pointer-move stream and the popup-birth / `startWindowDrag` handoff**, silently violating the
-gesture-continuity universal invariant when it fires. This is a SUSPECTED
-universal-invariant `FAIL` pending a reproduction-rate receipt (next witness iteration: N-run
-flake rate + engine-side trace); on confirmation it fires the epic's `revalidationTrigger` per
-the contract. Direct consumer warning: G1 ships this exact grammar to dock surfaces —
+gesture-continuity universal invariant when it fires. **Reproduction-rate receipt
+(2026-07-18, --repeat-each=6): 5/6 REAP, 1/6 survive — the reap is the DOMINANT outcome under
+this witness** (session total: ~8 reaps across 12 same-choreography runs). Instrument caveat,
+carried honestly per footnote ²'s lesson: the rate is measured under CDP-synthesized input,
+which this same suite proved distorts activation semantics — the real-input reap rate is
+unknown (the flagship demo's manual operation suggests real-mouse tear-outs succeed at a far
+higher rate). Classification: CONFIRMED high-rate invariant violation UNDER AUTOMATION;
+engine-side attribution is the named successor investigation. Whether an automation-measured
+violation qualifies the epic's `revalidationTrigger` is the ROUND's call, not this document's —
+the question is posed to the epic owners with these receipts. Direct consumer warning: G1 ships this exact grammar to dock surfaces —
 the race predates G1 and must be attributed before dock-tier calibration lands on top of it.
 Requested-vs-observed `moveTo` sampling remains blocked behind the race (a 2 ms lifetime cannot
 be position-sampled).

--- a/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
+++ b/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
@@ -1,14 +1,18 @@
 # The Tear-Out Portability Matrix
 
-The measured per-platform truth for the multi-window tear-out lineage (Dynamic Proxy
-Transitioning + intersection-ratio hysteresis + the live-popup embodiment). Multi-window
-implementation defaults — acquisition path, moving embodiment, fallbacks — are selected FROM this
-matrix, never from assumption: WHATWG activation, `moveTo` throttling, and screen-topology
-permissions all vary by platform.
+**An empirical EVIDENCE LEDGER — subordinate to its authorities, never normative itself.** This
+document accumulates the measured per-platform receipts for the multi-window tear-out lineage
+(Dynamic Proxy Transitioning + intersection-ratio hysteresis + the live-popup embodiment).
+Multi-window implementation defaults — acquisition path, moving embodiment, fallbacks — are
+selected by CITING this ledger's receipts, under the authority of ADR 0029 and the live matrix
+contract: WHATWG activation, `moveTo` throttling, and screen-topology permissions all vary by
+platform, and assumption is not evidence.
 
-Authority chain: Discussion #15204 OQ2 `[RESOLVED_TO_AC]` (the ratified matrix contract) →
-issue #15243 (the executing spike) → this document (the committed result the G1/G2
-implementation leaves cite as their defaults-selection authority).
+Authority chain (this ledger sits at the BOTTOM): Discussion #15204 OQ2 `[RESOLVED_TO_AC]` (the
+ratified matrix contract) → issue #15243 (OPEN — owns the complete 7×3 result and the
+revalidation gate) → this ledger (the accumulating receipts its children produce). The ledger
+is registered hidden in the learn tree: an internal evidence surface, not a public-facing
+guide.
 
 ## The grammar under test
 
@@ -38,10 +42,12 @@ workstation — 20 items / 9 nodes / 6 tab nodes (1·12·2·2·1·2 distribution
 - `NOT_YET_MEASURED` — no qualifying headed environment has executed the cell yet. An honest
   hole, never a guess.
 
-**Universal invariants asserted in every cell:** gesture continuity · same-instance permanence ·
-JSON-only persisted state · exact-once commit · idempotent cleanup. Any `FAIL` on a universal
-invariant fires the epic's `revalidationTrigger` (reopen the design discussion, pause consuming
-implementation).
+**Universal invariants — REQUIRED in every completed cell** (a cell's verdict is admissible only
+when its receipts assert all five): gesture continuity · same-instance permanence · JSON-only
+persisted state · exact-once commit · idempotent cleanup. The current qualified probes do NOT
+yet assert them — which is exactly why every cell below remains `NOT_YET_MEASURED`. Any
+confirmed `FAIL` on a universal invariant fires the epic's `revalidationTrigger` (reopen the
+design discussion, pause consuming implementation).
 
 ## The matrix
 
@@ -84,10 +90,10 @@ this instrument.
 **RETIRED — the truth is sharper and worse**: with the close-listener attached inside the
 acquisition race, the popup closed **2 ms after birth** (`acquiredToCloseMs: 2`), BEFORE the
 first continued move (`closedAfterMoveMs: -30`), before pointer-up (`closedBeforeUp: true`),
-with zero console output captured — **and that absence is INSTRUMENT-BLIND, not negative**: the
+with zero console output captured — **and that absence was INSTRUMENT-BLIND, not negative**: the
 colors app runs on a SharedWorker, whose console `page.on('console')` cannot see, so the
-re-entry path's own log line is invisible to this witness (the earlier "no re-entry
-involvement" phrasing is retracted; sweep scope was the page console only). Same-choreography
+re-entry path's own log line was invisible to this witness (the earlier "no re-entry
+involvement" phrasing was retracted; sweep scope was the page console only). Same-choreography
 runs nondeterministically
 survive (row 1's three earlier greens) or reap at birth — **a race between the continuing
 pointer-move stream and the popup-birth / `startWindowDrag` handoff**, silently violating the
@@ -97,10 +103,11 @@ this witness** (session total: ~8 reaps across 12 same-choreography runs). Instr
 carried honestly per footnote ²'s lesson: the rate is measured under CDP-synthesized input,
 which this same suite proved distorts activation semantics — the real-input reap rate is
 unknown (the flagship demo's manual operation suggests real-mouse tear-outs succeed at a far
-higher rate). Classification: CONFIRMED high-rate invariant violation UNDER AUTOMATION;
-engine-side attribution is the named successor investigation. Whether an automation-measured
-violation qualifies the epic's `revalidationTrigger` is the ROUND's call, not this document's —
-the question is posed to the epic owners with these receipts.
+higher rate). **RESOLVED (2026-07-18):** the race was attributed (a false re-entry — the exit's own layout
+choreography jumped the hysteresis read) and FIXED at mechanism in PR #15413 (Schmitt-trigger
+arming, merged); this ledger's own witness confirmed 6/6 survivals post-fix against the exact
+pre-fix baseline, and the post-rebase run holds 3/3. The `revalidationTrigger` question is
+resolved-as-fixed; rows 4–7 are measurable again as #15243 children.
 
 **Attribution hypothesis (source-anchored, falsifier-backed):** the boundary-EXIT reconfigures
 the exact geometry the hysteresis reads — the drag placeholder hides and the remaining items

--- a/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
+++ b/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
@@ -1,0 +1,80 @@
+# The Tear-Out Portability Matrix
+
+The measured per-platform truth for the multi-window tear-out lineage (Dynamic Proxy
+Transitioning + intersection-ratio hysteresis + the live-popup embodiment). Multi-window
+implementation defaults — acquisition path, moving embodiment, fallbacks — are selected FROM this
+matrix, never from assumption: WHATWG activation, `moveTo` throttling, and screen-topology
+permissions all vary by platform.
+
+Authority chain: Discussion #15204 OQ2 `[RESOLVED_TO_AC]` (the ratified matrix contract) →
+issue #15243 (the executing spike) → this document (the committed result the G1/G2
+implementation leaves cite as their defaults-selection authority).
+
+## The grammar under test
+
+One transition chain, end to end — no new window manager, no second dwell coordinator:
+
+1. `src/draggable/container/SortZone.mjs` `checkWindowBoundary()` — direction-aware
+   intersection-ratio hysteresis (`intersectionArea / proxyArea`; defaults `detachThreshold: 0.8`
+   on the way out, `reattachThreshold: 0.6` on the way back in).
+2. `src/dashboard/Container.mjs` `onDragBoundaryExit()` → `openWidgetInPopup()` — the mid-gesture
+   conversion to a real, URL-addressed OS popup on the shared heap.
+3. `src/main/addon/DragDrop.mjs` pointer-follow (`windowMoveTo`) — the moving embodiment.
+
+Witness suite: `test/playwright/e2e/workstation/tearOutMatrix.spec.mjs` (headed real-browser
+runs; headless proves wiring, never native placement). Density context: the flagship workstation
+surface — 20 items / 9 nodes / 6 tab nodes (1·12·2·2·1·2 distribution).
+
+## Verdict vocabulary
+
+- `PASS_NATIVE` — the native path works as designed on this platform.
+- `PASS_FALLBACK` — the native path fails, and a documented DOM-proxy or explicit-command
+  fallback covers the row.
+- `FAIL` — neither native nor documented fallback covers the row.
+- `NOT_YET_MEASURED` — no qualifying headed environment has executed the cell yet. An honest
+  hole, never a guess.
+
+**Universal invariants asserted in every cell:** gesture continuity · same-instance permanence ·
+JSON-only persisted state · exact-once commit · idempotent cleanup. Any `FAIL` on a universal
+invariant fires the epic's `revalidationTrigger` (reopen the design discussion, pause consuming
+implementation).
+
+## The matrix
+
+| # | Row | macOS (Chromium, headed) | Windows | Linux |
+|---|---|---|---|---|
+| 1 | Hysteretic grammar (0.8 out / 0.6 in, direction-aware) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 2 | Acquisition (`window.open` boolean; activation window) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 3 | Moving embodiment (requested-vs-observed `moveTo`) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 4 | Object permanence / reintegration (same instance back) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 5 | Screen topology (`getScreenDetails` never a prerequisite) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 6 | Multi-window targeting (claim-protocol identity binding) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 7 | Terminal cleanup (exact-once, idempotent) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+
+Environment note: the current fleet has a qualifying **macOS** headed environment. Windows and
+Linux columns require real desktop sessions (a virtual display proves wiring, not native
+placement semantics) and remain honestly `NOT_YET_MEASURED` until such environments exist.
+
+## Per-row receipt requirements
+
+1. **Hysteretic grammar** — the recorded intersection-ratio trace across a slow boundary
+   crossing: exit fires strictly below the detach threshold while moving out; re-entry restores
+   strictly above the reattach threshold while moving in; no exit/re-entry oscillation between
+   the two thresholds.
+2. **Acquisition** — assert `window.open`'s BOOLEAN-shaped result: a blocked popup never throws,
+   so try/catch-shaped acquisition silently passes its own failure. The negative control:
+   `navigator.userActivation` measured at drag-end after more than 5 s of gesture — the expected
+   portable failure that makes release-time `window.open` the negative baseline, never the
+   default.
+3. **Moving embodiment** — record requested vs observed coordinates for every `windowMoveTo`
+   step; `moveTo` is advisory, never correctness authority.
+4. **Object permanence** — the component instance id and store references before detach and
+   after reintegration are identical (same-instance permanence, live data streaming across the
+   transition).
+5. **Screen topology** — the flow completes with `getScreenDetails` permission denied; denial
+   degrades to the documented fallback, never blocks.
+6. **Multi-window targeting** — the claim protocol's identity requirements bind (at most one
+   target window exposes one menu and one preview per gesture); no arbitration is implemented
+   here.
+7. **Terminal cleanup** — every gesture terminal (drop, cancel, blocked acquisition) runs
+   cleanup exactly once; a repeated terminal is a no-op.

--- a/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
+++ b/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
@@ -48,8 +48,8 @@ implementation).
 | # | Row | macOS (Chrome, headed) | Windows | Linux |
 |---|---|---|---|---|
 | 1 | Hysteretic grammar (0.8 out / 0.6 in, direction-aware) | `PASS_NATIVE` ¹ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
-| 2 | Acquisition (`window.open` boolean; activation window) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
-| 3 | Moving embodiment (requested-vs-observed `moveTo`) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 2 | Acquisition (`window.open` boolean; activation window) | `PASS_NATIVE` ² | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 3 | Moving embodiment (requested-vs-observed `moveTo`) | `NOT_YET_MEASURED` ³ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 4 | Object permanence / reintegration (same instance back) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 5 | Screen topology (`getScreenDetails` never a prerequisite) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 6 | Multi-window targeting (claim-protocol identity binding) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
@@ -61,12 +61,33 @@ placement semantics) and remain honestly `NOT_YET_MEASURED` until such environme
 
 ¹ Row 1 macOS (2026-07-18, Chrome via the matrix runner): the witness proves boundary-exit
 under the documented hysteresis, MID-GESTURE popup acquisition, popup persistence through the
-drop terminal, and same-instance adoption rendering in the popup over the shared heap. Pending
-sub-receipt: the ratio-trace no-oscillation assertion (reads `SortZone.traces`). **Open
-observation (owned by row 3):** sustained pointer movement AFTER acquisition closed the popup
-in earlier runs — isolated by stopping the drag at acquisition; mechanism unattributed
-(candidates: the clamped-coordinate `windowMoveTo` stream; a re-entry misfire under synthetic
-coordinates). Row 3's moving-embodiment cells must reproduce and attribute it.
+drop terminal, and same-instance adoption rendering in the popup over the shared heap — **but
+the outcome is NONDETERMINISTIC** (3× green, then a same-choreography red): see footnote ³.
+Pending sub-receipt: the ratio-trace no-oscillation assertion (reads `SortZone.traces`).
+
+² Row 2 macOS (2026-07-18): mid-gesture acquisition itself is `PASS_NATIVE` (row 1's receipts —
+`window.open` succeeds during the gesture). The **>5 s activation-expiry negative control is
+UNMEASURABLE UNDER AUTOMATION**: the decay-trace receipts show `navigator.userActivation.isActive`
+still `true` at 2 s / 4 s / 6 s / 8 s into a held CDP-input gesture AND after release —
+synthesized input sustains transient activation indefinitely on macOS Chrome. Consequence for
+the G2 acquisition contract: **never calibrate activation timings from automated runs**; the
+expiry half of this cell requires real human input to measure. The release-time-`window.open`
+negative baseline stands on spec authority, not on this instrument.
+
+³ Row 3 macOS (2026-07-18): the earlier "sustained movement closes the popup" observation is
+**RETIRED — the truth is sharper and worse**: with the close-listener attached inside the
+acquisition race, the popup closed **2 ms after birth** (`acquiredToCloseMs: 2`), BEFORE the
+first continued move (`closedAfterMoveMs: -30`), before pointer-up (`closedBeforeUp: true`),
+with zero console output and no re-entry involvement. Same-choreography runs nondeterministically
+survive (row 1's three earlier greens) or reap at birth — **a race between the continuing
+pointer-move stream and the popup-birth / `startWindowDrag` handoff**, silently violating the
+gesture-continuity universal invariant when it fires. This is a SUSPECTED
+universal-invariant `FAIL` pending a reproduction-rate receipt (next witness iteration: N-run
+flake rate + engine-side trace); on confirmation it fires the epic's `revalidationTrigger` per
+the contract. Direct consumer warning: G1 ships this exact grammar to dock surfaces —
+the race predates G1 and must be attributed before dock-tier calibration lands on top of it.
+Requested-vs-observed `moveTo` sampling remains blocked behind the race (a 2 ms lifetime cannot
+be position-sampled).
 
 ## Per-row receipt requirements
 

--- a/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
+++ b/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
@@ -21,9 +21,13 @@ One transition chain, end to end — no new window manager, no second dwell coor
    conversion to a real, URL-addressed OS popup on the shared heap.
 3. `src/main/addon/DragDrop.mjs` pointer-follow (`windowMoveTo`) — the moving embodiment.
 
-Witness suite: `test/playwright/e2e/workstation/tearOutMatrix.spec.mjs` (headed real-browser
-runs; headless proves wiring, never native placement). Density context: the flagship workstation
-surface — 20 items / 9 nodes / 6 tab nodes (1·12·2·2·1·2 distribution).
+Witness suite: `test/playwright/e2e/colors/tearOutMatrix.spec.mjs` (headed real-browser runs;
+headless proves wiring, never native placement). The measurement surface is the colors app —
+the landed grammar's original live product surface (`useSharedWorkers: true`, `popupUrl` wired
+to its dedicated widget shell, explicit `neo-draggable` panel-header handles). Dock-tier
+surfaces (workstation, dockdemo) opt OUT of the grammar until the G1 leaf lands — they cannot
+serve as measurement surfaces yet. Density context for the G1 calibration remains the flagship
+workstation — 20 items / 9 nodes / 6 tab nodes (1·12·2·2·1·2 distribution).
 
 ## Verdict vocabulary
 
@@ -41,9 +45,9 @@ implementation).
 
 ## The matrix
 
-| # | Row | macOS (Chromium, headed) | Windows | Linux |
+| # | Row | macOS (Chrome, headed) | Windows | Linux |
 |---|---|---|---|---|
-| 1 | Hysteretic grammar (0.8 out / 0.6 in, direction-aware) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 1 | Hysteretic grammar (0.8 out / 0.6 in, direction-aware) | `PASS_NATIVE` ¹ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 2 | Acquisition (`window.open` boolean; activation window) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 3 | Moving embodiment (requested-vs-observed `moveTo`) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 4 | Object permanence / reintegration (same instance back) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
@@ -54,6 +58,15 @@ implementation).
 Environment note: the current fleet has a qualifying **macOS** headed environment. Windows and
 Linux columns require real desktop sessions (a virtual display proves wiring, not native
 placement semantics) and remain honestly `NOT_YET_MEASURED` until such environments exist.
+
+¹ Row 1 macOS (2026-07-18, Chrome via the matrix runner): the witness proves boundary-exit
+under the documented hysteresis, MID-GESTURE popup acquisition, popup persistence through the
+drop terminal, and same-instance adoption rendering in the popup over the shared heap. Pending
+sub-receipt: the ratio-trace no-oscillation assertion (reads `SortZone.traces`). **Open
+observation (owned by row 3):** sustained pointer movement AFTER acquisition closed the popup
+in earlier runs — isolated by stopping the drag at acquisition; mechanism unattributed
+(candidates: the clamped-coordinate `windowMoveTo` stream; a re-entry misfire under synthetic
+coordinates). Row 3's moving-embodiment cells must reproduce and attribute it.
 
 ## Per-row receipt requirements
 

--- a/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
+++ b/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
@@ -78,7 +78,11 @@ negative baseline stands on spec authority, not on this instrument.
 **RETIRED — the truth is sharper and worse**: with the close-listener attached inside the
 acquisition race, the popup closed **2 ms after birth** (`acquiredToCloseMs: 2`), BEFORE the
 first continued move (`closedAfterMoveMs: -30`), before pointer-up (`closedBeforeUp: true`),
-with zero console output and no re-entry involvement. Same-choreography runs nondeterministically
+with zero console output captured — **and that absence is INSTRUMENT-BLIND, not negative**: the
+colors app runs on a SharedWorker, whose console `page.on('console')` cannot see, so the
+re-entry path's own log line is invisible to this witness (the earlier "no re-entry
+involvement" phrasing is retracted; sweep scope was the page console only). Same-choreography
+runs nondeterministically
 survive (row 1's three earlier greens) or reap at birth — **a race between the continuing
 pointer-move stream and the popup-birth / `startWindowDrag` handoff**, silently violating the
 gesture-continuity universal invariant when it fires. **Reproduction-rate receipt
@@ -90,7 +94,19 @@ unknown (the flagship demo's manual operation suggests real-mouse tear-outs succ
 higher rate). Classification: CONFIRMED high-rate invariant violation UNDER AUTOMATION;
 engine-side attribution is the named successor investigation. Whether an automation-measured
 violation qualifies the epic's `revalidationTrigger` is the ROUND's call, not this document's —
-the question is posed to the epic owners with these receipts. Direct consumer warning: G1 ships this exact grammar to dock surfaces —
+the question is posed to the epic owners with these receipts.
+
+**Attribution hypothesis (source-anchored, falsifier-backed):** the boundary-EXIT reconfigures
+the exact geometry the hysteresis reads — the drag placeholder hides and the remaining items
+expand (`SortZone#startWindowDrag` choreography), so on the NEXT pointer move
+`checkWindowBoundary`'s direction-aware ratio can JUMP upward (reading as "moving in" above the
+0.6 reattach threshold) → a false `dragBoundaryEntry` → `Container#onDragBoundaryEntry` →
+`Neo.Main.windowClose` — the silent ~2 ms reap. The run distribution is the falsifier already
+executed: survivals correlate with zero post-birth moves (the witness loop stopping at
+acquisition); reaps with ≥1 extra move inside the acquisition race window. Fix candidates for
+the attribution ticket: reset `lastIntersectionRatio` at exit; require N consecutive moving-in
+samples before re-entry; gate re-entry on the live proxy rect rather than post-exit layout
+geometry. Direct consumer warning: G1 ships this exact grammar to dock surfaces —
 the race predates G1 and must be attributed before dock-tier calibration lands on top of it.
 Requested-vs-observed `moveTo` sampling remains blocked behind the race (a 2 ms lifetime cannot
 be position-sampled).

--- a/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
+++ b/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
@@ -47,8 +47,8 @@ implementation).
 
 | # | Row | macOS (Chrome, headed) | Windows | Linux |
 |---|---|---|---|---|
-| 1 | Hysteretic grammar (0.8 out / 0.6 in, direction-aware) | `PASS_NATIVE` ¹ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
-| 2 | Acquisition (`window.open` boolean; activation window) | `PASS_NATIVE` ² | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 1 | Hysteretic grammar (0.8 out / 0.6 in, direction-aware) | `NOT_YET_MEASURED` ¹ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 2 | Acquisition (`window.open` boolean; activation window) | `NOT_YET_MEASURED` ² | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 3 | Moving embodiment (requested-vs-observed `moveTo`) | `NOT_YET_MEASURED` ³ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 4 | Object permanence / reintegration (same instance back) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 5 | Screen topology (`getScreenDetails` never a prerequisite) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
@@ -59,20 +59,26 @@ Environment note: the current fleet has a qualifying **macOS** headed environmen
 Linux columns require real desktop sessions (a virtual display proves wiring, not native
 placement semantics) and remain honestly `NOT_YET_MEASURED` until such environments exist.
 
-¹ Row 1 macOS (2026-07-18, Chrome via the matrix runner): the witness proves boundary-exit
-under the documented hysteresis, MID-GESTURE popup acquisition, popup persistence through the
-drop terminal, and same-instance adoption rendering in the popup over the shared heap — **but
-the outcome is NONDETERMINISTIC** (3× green, then a same-choreography red): see footnote ³.
-Pending sub-receipt: the ratio-trace no-oscillation assertion (reads `SortZone.traces`).
+¹ Row 1 macOS — **qualified PROBE receipts, verdict pending** (2026-07-18, Chrome via the
+matrix runner): the probes witnessed boundary-exit under the documented hysteresis, MID-GESTURE
+popup acquisition, popup persistence through the drop terminal, and Neo-rendered content in the
+popup. The verdict awaits its named sub-receipts: the ratio-trace no-oscillation assertion
+(reads `SortZone.traces`) and a stronger same-instance adoption receipt (the current evidence
+is `[id^=neo-]`-level rendering, not an instance-id identity check). The earlier nondeterminism
+(3× green → reap; see ³) is RESOLVED by the merged birth-race fix — post-fix confirmation ran
+6/6 green on this exact witness.
 
-² Row 2 macOS (2026-07-18): mid-gesture acquisition itself is `PASS_NATIVE` (row 1's receipts —
-`window.open` succeeds during the gesture). The **>5 s activation-expiry negative control is
-UNMEASURABLE UNDER AUTOMATION**: the decay-trace receipts show `navigator.userActivation.isActive`
-still `true` at 2 s / 4 s / 6 s / 8 s into a held CDP-input gesture AND after release —
-synthesized input sustains transient activation indefinitely on macOS Chrome. Consequence for
+² Row 2 macOS — **qualified PROBE receipts, verdict pending**: mid-gesture `window.open`
+succeeds during the gesture (row-1 probes). But TWO instrument caveats block the verdict:
+the **>5 s activation-expiry negative control is UNMEASURABLE UNDER AUTOMATION** (decay-trace
+receipts: `navigator.userActivation.isActive` still `true` at 2/4/6/8 s into a held CDP-input
+gesture AND after release — synthesized input sustains transient activation indefinitely), and
+**the matrix runner itself carries Playwright's default `--disable-popup-blocking`**, so no
+blocked-acquisition cell has been measured under real blocking conditions yet. Consequence for
 the G2 acquisition contract: **never calibrate activation timings from automated runs**; the
-expiry half of this cell requires real human input to measure. The release-time-`window.open`
-negative baseline stands on spec authority, not on this instrument.
+expiry half + the blocking-controlled cells require real-input / blocking-controlled
+measurement. The release-time-`window.open` negative baseline stands on spec authority, not on
+this instrument.
 
 ³ Row 3 macOS (2026-07-18): the earlier "sustained movement closes the popup" observation is
 **RETIRED — the truth is sharper and worse**: with the close-listener attached inside the

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -159,6 +159,7 @@
             {"name": "Whitebox E2E",                                   "parentId": "guides/testing",                                      "id": "guides/testing/WhiteboxE2E"},
         {"name": "Specific Applications/Features",                     "parentId": "guides",                             "isLeaf": false, "id": "guides/specificfeatures", "collapsed": true},
             {"name": "Multi-Window Applications",                      "parentId": "guides/specificfeatures",                             "id": "guides/specificfeatures/MultiWindow", "hidden":  true},
+            {"name": "Tear-Out Portability Matrix",                    "parentId": "guides/specificfeatures",                             "id": "guides/specificfeatures/TearOutPortabilityMatrix", "hidden": true},
             {"name": "Mixins",                                         "parentId": "guides/specificfeatures",                             "id": "guides/specificfeatures/Mixins", "hidden": true},
             {"name": "Portal App",                                     "parentId": "guides/specificfeatures",                             "id": "guides/specificfeatures/PortalApp"},
         {"name": "DevIndex App",                                       "parentId": "guides",                             "isLeaf": false, "id": "guides/devindex", "collapsed": true},

--- a/test/playwright/e2e/colors/tearOutMatrix.spec.mjs
+++ b/test/playwright/e2e/colors/tearOutMatrix.spec.mjs
@@ -38,7 +38,7 @@ test.describe('tear-out portability matrix — colors app, headed', () => {
         await expect(page.locator('.colors-viewport')).toBeVisible({timeout: 60000})
     });
 
-    test('row 1 — hysteretic grammar: a slow boundary crossing detaches below 0.8 moving out, popup acquired, no oscillation', async ({context, page}) => {
+    test('row 1 probe — boundary-exit fires on a slow crossing, popup acquired MID-GESTURE, persists the drop terminal, Neo content renders (ratio-trace + instance-identity receipts pending)', async ({context, page}) => {
         const handle = page.locator(itemHandle).first();
 
         await expect(handle, 'calibration: the dashboard item drag handle must exist on the surface').toBeVisible({timeout: 30000});
@@ -102,7 +102,7 @@ test.describe('tear-out portability matrix — colors app, headed', () => {
         await expect(popup.locator('[id^="neo-"]').first(), `adopted Neo content renders in the popup (console: ${popupConsole.join(' | ')})`).toBeVisible({timeout: 45000})
     });
 
-    test('row 2 — acquisition: transient activation EXPIRES across a >5s gesture — release-time window.open is the negative baseline', async ({page}) => {
+    test('row 2 probe — activation decay-trace capture across an 8s held gesture (expiry itself UNMEASURABLE under CDP input; receipts recorded, verdict pending real-input + blocking-controlled cells)', async ({page}) => {
         const handle = page.locator(itemHandle).first();
 
         await expect(handle).toBeVisible({timeout: 30000});
@@ -159,7 +159,7 @@ test.describe('tear-out portability matrix — colors app, headed', () => {
         expect(trace.length,      'the decay trace was captured across the 8s gesture').toBeGreaterThan(2)
     });
 
-    test('row 3 — moving embodiment: post-acquisition pointer-follow receipts + the close-attribution capture', async ({context, page}, testInfo) => {
+    test('row 3 probe — post-acquisition lifecycle-terminal receipts (requested-vs-observed coordinate pairing pending)', async ({context, page}, testInfo) => {
         const handle = page.locator(itemHandle).first();
 
         await expect(handle).toBeVisible({timeout: 30000});

--- a/test/playwright/e2e/colors/tearOutMatrix.spec.mjs
+++ b/test/playwright/e2e/colors/tearOutMatrix.spec.mjs
@@ -102,15 +102,156 @@ test.describe('tear-out portability matrix — colors app, headed', () => {
         await expect(popup.locator('[id^="neo-"]').first(), `adopted Neo content renders in the popup (console: ${popupConsole.join(' | ')})`).toBeVisible({timeout: 45000})
     });
 
-    test.fixme('row 2 — acquisition: window.open boolean-shaped failure + the >5s userActivation negative control', async () => {
-        // Receipts: assert the acquisition path checks window.open's BOOLEAN result (a blocked
-        // popup never throws); measure navigator.userActivation at drag-end after >5s — the
-        // expected portable failure proving release-time window.open is the negative baseline.
+    test('row 2 — acquisition: transient activation EXPIRES across a >5s gesture — release-time window.open is the negative baseline', async ({page}) => {
+        const handle = page.locator(itemHandle).first();
+
+        await expect(handle).toBeVisible({timeout: 30000});
+
+        const box = await handle.boundingBox();
+
+        // A REAL drag gesture (the contract's context: "measured at drag-end after >5 s") —
+        // small in-container moves only, never crossing the boundary; the receipt is about the
+        // platform's activation window, not the tear-out.
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.mouse.down();
+
+        const atStart = await page.evaluate(() => ({
+            hasBeen : navigator.userActivation.hasBeenActive,
+            isActive: navigator.userActivation.isActive
+        }));
+
+        const trace = [];
+
+        for (let i = 0; i < 16; i++) {
+            await page.mouse.move(box.x + 90 + (i % 2) * 40, box.y + 70, {steps: 3});
+            await page.waitForTimeout(500);
+            if (i % 4 === 3) {
+                trace.push(await page.evaluate(t => ({
+                    atMs    : t,
+                    isActive: navigator.userActivation.isActive
+                }), (i + 1) * 500))
+            }
+        }
+
+        const atDragEnd = await page.evaluate(() => ({
+            hasBeen : navigator.userActivation.hasBeenActive,
+            isActive: navigator.userActivation.isActive
+        }));
+
+        await page.mouse.up();
+
+        const afterUp = await page.evaluate(() => ({isActive: navigator.userActivation.isActive}));
+
+        // FIRST-RUN FINDING (macOS Chrome, CDP input): activation did NOT read expired at 5.5s —
+        // the contract's "expected portable failure" is INSTRUMENT-SENSITIVE (synthetic input may
+        // renew, or held-gesture semantics differ). The witness therefore RECORDS the decay trace
+        // (receipts drive the cell verdict + the doc); it asserts only the invariants that hold
+        // regardless of direction: activation was live at start, sticky bit persists, and the
+        // measurement completed. Direction claims live in the matrix document, receipt-cited.
+        await test.info().attach('row2-activation-trace', {
+            body       : JSON.stringify({afterUp, atDragEnd, atStart, trace}, null, 2),
+            contentType: 'application/json'
+        });
+        console.log('ROW2-RECEIPTS ' + JSON.stringify({afterUp, atDragEnd, atStart, trace}));
+
+        expect(atStart.isActive,  'transient activation live at gesture start').toBe(true);
+        expect(atDragEnd.hasBeen, 'sticky activation persists').toBe(true);
+        expect(trace.length,      'the decay trace was captured across the 8s gesture').toBeGreaterThan(2)
     });
 
-    test.fixme('row 3 — moving embodiment: requested-vs-observed windowMoveTo coordinates', async () => {
-        // Receipts: per pointer-follow step, record requested coords vs window.screenX/Y
-        // observed in the popup; moveTo is advisory, never correctness authority.
+    test('row 3 — moving embodiment: post-acquisition pointer-follow receipts + the close-attribution capture', async ({context, page}, testInfo) => {
+        const handle = page.locator(itemHandle).first();
+
+        await expect(handle).toBeVisible({timeout: 30000});
+
+        const
+            box         = await handle.boundingBox(),
+            viewport    = page.viewportSize(),
+            mainConsole = [];
+
+        page.on('console', message => mainConsole.push(`[${message.type()}] ${message.text()}`));
+
+        const popupPromise = context.waitForEvent('page', {timeout: 30000});
+
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.mouse.down();
+
+        // Attach the close listener INSIDE the acquisition race so not even a microsecond of the
+        // popup's life is unobserved — the first reproduction closed before a post-race attach.
+        let popupAcquiredAt = null,
+            popupClosedAt   = null;
+
+        const observedPopupPromise = popupPromise.then(acquired => {
+            popupAcquiredAt = Date.now();
+            acquired.on('close', () => popupClosedAt = Date.now());
+            return acquired
+        });
+
+        let popup = null;
+
+        for (let i = 1; i <= dragSteps && !popup; i++) {
+            await page.mouse.move(
+                box.x + (viewport.width + 200 - box.x) * (i / dragSteps),
+                box.y + box.height / 2,
+                {steps: 4}
+            );
+            popup = await Promise.race([observedPopupPromise, page.waitForTimeout(50).then(() => null)])
+        }
+        popup = popup || await observedPopupPromise;
+
+        // The row-1 open observation under measurement: SUSTAINED pointer movement AFTER
+        // acquisition closed the popup in early runs (first reproduction: within ~300ms of the
+        // first continued move — faster than a 250ms sampling interval). Sample IMMEDIATELY at
+        // acquisition, then continue the move stream with tight sampling — the
+        // requested-vs-observed half of the receipt (the pointer path is the requested side;
+        // `moveTo` is advisory, never authority).
+        const
+            samples     = [],
+            firstMoveAt = Date.now(),
+            followX0    = viewport.width - 60,
+            samplePopup = async () => {
+                try {
+                    samples.push(await popup.evaluate(() => ({t: Date.now(), x: window.screenX, y: window.screenY})));
+                    return true
+                } catch {
+                    return false
+                }
+            };
+
+        await samplePopup();
+
+        for (let i = 0; i < 8 && !popup.isClosed(); i++) {
+            await page.mouse.move(followX0 + i * 12, box.y + box.height / 2 + i * 6, {steps: 2});
+            if (!await samplePopup()) break;
+            await page.waitForTimeout(120)
+        }
+
+        const upAt = Date.now();
+        await page.mouse.up();
+        await page.waitForTimeout(1500);
+
+        const receipts = {
+            acquiredToCloseMs: popupClosedAt && popupAcquiredAt ? popupClosedAt - popupAcquiredAt : null,
+            closed           : popup.isClosed(),
+            closedAfterMoveMs: popupClosedAt ? popupClosedAt - firstMoveAt : null,
+            closedBeforeUp   : popupClosedAt ? popupClosedAt < upAt : false,
+            mainConsoleTail  : mainConsole.slice(-10),
+            reentryLogSeen   : mainConsole.some(line => line.includes('onDragBoundaryEntry')),
+            sampleCount      : samples.length,
+            samples
+        };
+
+        await testInfo.attach('row3-receipts', {body: JSON.stringify(receipts, null, 2), contentType: 'application/json'});
+        console.log('ROW3-RECEIPTS ' + JSON.stringify(receipts));
+
+        // Assertion floor (the cell's verdict lives in the attached receipts): a DEFINITE terminal
+        // was recorded — the popup either survived the stream (samples flow) or its close was
+        // observed with lifecycle timestamps. An indeterminate popup state is the only failed
+        // measurement; empty consoles and zero samples are themselves findings, not failures.
+        expect(receipts.closed || samples.length > 0,
+            `definite terminal recorded (closed=${receipts.closed}, acquiredToCloseMs=${receipts.acquiredToCloseMs}, ` +
+            `closedBeforeUp=${receipts.closedBeforeUp}, reentryLog=${receipts.reentryLogSeen})`
+        ).toBe(true)
     });
 
     test.fixme('row 4 — object permanence: same instance id + live stores across detach and reintegration', async () => {

--- a/test/playwright/e2e/colors/tearOutMatrix.spec.mjs
+++ b/test/playwright/e2e/colors/tearOutMatrix.spec.mjs
@@ -4,7 +4,8 @@ import {expect, test} from '../../fixtures.mjs';
  * @summary The seven-row tear-out portability witness suite — the headed measurement half of
  * `learn/guides/specificfeatures/TearOutPortabilityMatrix.md`.
  *
- * Drives the LANDED transition chain end to end on the flagship workstation surface:
+ * Drives the LANDED transition chain end to end on the colors app — the grammar's original
+ * live product surface (shared workers on, `popupUrl` wired to the dedicated widget shell):
  * `SortZone#checkWindowBoundary` (intersection-ratio hysteresis, 0.8 detach / 0.6 reattach)
  * → `dashboard.Container#onDragBoundaryExit` → `#openWidgetInPopup` (real URL-addressed OS
  * popup on the shared heap) → `DragDrop` pointer-follow.
@@ -20,23 +21,21 @@ import {expect, test} from '../../fixtures.mjs';
  * in place — red-honest until each cell's witness lands.
  */
 
-// The flagship surface (density context: 20 items / 9 nodes / 6 tab nodes). The dev server
-// port rides NEO_E2E_PORT — the same knob the e2e config uses to dodge a foreign server.
+// The colors app: three DashboardPanels (Grid / Pie Chart / Bar Chart) whose header toolbars
+// carry the explicit `neo-draggable` drag-handle cls. The dev server port rides NEO_E2E_PORT —
+// the same knob the e2e config uses to dodge a foreign server.
 const
     e2ePort    = Number(process.env.NEO_E2E_PORT) || 8080,
-    surfaceUrl = `http://localhost:${e2ePort}/apps/workstation/index.html`,
-    // First-run calibration constants: the drag handle of one dashboard item on the default
-    // workspace. Adjusted on the first headed run against the live DOM; the witness fails
-    // LOUD on a selector miss instead of timing out silently.
-    itemHandle  = '.neo-dashboard-container .neo-header-toolbar',
-    dragSteps   = 25;
+    surfaceUrl = `http://localhost:${e2ePort}/apps/colors/index.html`,
+    itemHandle = '.neo-draggable',
+    dragSteps  = 25;
 
-test.describe('tear-out portability matrix — workstation, headed', () => {
+test.describe('tear-out portability matrix — colors app, headed', () => {
     test.setTimeout(120000);
 
     test.beforeEach(async ({page}) => {
         await page.goto(surfaceUrl);
-        await expect(page.locator('.neo-viewport')).toBeVisible({timeout: 60000})
+        await expect(page.locator('.colors-viewport')).toBeVisible({timeout: 60000})
     });
 
     test('row 1 — hysteretic grammar: a slow boundary crossing detaches below 0.8 moving out, popup acquired, no oscillation', async ({context, page}) => {
@@ -50,30 +49,57 @@ test.describe('tear-out portability matrix — workstation, headed', () => {
 
         expect(box, 'the drag handle reports a bounding box').toBeTruthy();
 
+        // Diagnostic channels: the app worker's console surfaces re-entry/cleanup decisions
+        // (`onDragBoundaryEntry` logs on the reattach path — the only popup-closing path).
+        const mainConsole = [];
+        page.on('console', message => mainConsole.push(`[${message.type()}] ${message.text()}`));
+
         // Slow, stepped drag from the item toward and past the right window boundary — the
         // stepped path is what makes the direction-aware ratio trace meaningful (row-1 receipt:
-        // exit fires while MOVING OUT below the detach threshold, never at rest).
+        // exit fires while MOVING OUT below the detach threshold, never at rest). The loop stops
+        // the moment acquisition fires, isolating the post-acquisition move stream from the
+        // pointer-up path when hunting an unexpected close.
         const popupPromise = context.waitForEvent('page', {timeout: 30000});
 
         await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
         await page.mouse.down();
 
-        for (let i = 1; i <= dragSteps; i++) {
+        let popup = null;
+
+        for (let i = 1; i <= dragSteps && !popup; i++) {
             await page.mouse.move(
                 box.x + (viewport.width + 200 - box.x) * (i / dragSteps),
                 box.y + box.height / 2,
                 {steps: 4}
-            )
+            );
+            popup = await Promise.race([popupPromise.then(acquired => acquired), page.waitForTimeout(50).then(() => null)])
         }
 
         // The mid-gesture conversion: a REAL page (popup) must be acquired before pointer-up —
         // acquisition-during-gesture is the landed grammar, not a drop effect.
-        const popup = await popupPromise;
+        popup = popup || await popupPromise;
 
+        const popupConsole  = [];
+        let   popupClosedAt = null;
+        popup.on('console', message => popupConsole.push(`[${message.type()}] ${message.text()}`));
+        popup.on('close', () => popupClosedAt = Date.now());
+
+        const beforeUp = Date.now();
         await page.mouse.up();
 
         expect(popup.url(), 'the popup is URL-addressed (openWidgetInPopup contract)').toContain('/apps/');
-        await expect(popup.locator('body')).toBeVisible({timeout: 30000})
+
+        // Pointer-up outside the source window is the DETACH terminal: the popup persists as a
+        // standalone OS window (closing here would be the reattach/cancel path — a row-1 FAIL).
+        await page.waitForTimeout(2000);
+        expect(popup.isClosed(),
+            `the popup survives the drop terminal (closedAt-upDelta: ${popupClosedAt ? popupClosedAt - beforeUp : 'n/a'}ms; ` +
+            `popup console: ${popupConsole.join(' | ') || 'none'}; main console tail: ${mainConsole.slice(-8).join(' | ') || 'none'})`
+        ).toBe(false);
+
+        // The widget shell boots over the shared heap and adopts the parked widget — Neo-rendered
+        // content (worker-created ids) is the adoption receipt, not the bare body.
+        await expect(popup.locator('[id^="neo-"]').first(), `adopted Neo content renders in the popup (console: ${popupConsole.join(' | ')})`).toBeVisible({timeout: 45000})
     });
 
     test.fixme('row 2 — acquisition: window.open boolean-shaped failure + the >5s userActivation negative control', async () => {

--- a/test/playwright/e2e/workstation/tearOutMatrix.spec.mjs
+++ b/test/playwright/e2e/workstation/tearOutMatrix.spec.mjs
@@ -1,0 +1,106 @@
+import {expect, test} from '../../fixtures.mjs';
+
+/**
+ * @summary The seven-row tear-out portability witness suite — the headed measurement half of
+ * `learn/guides/specificfeatures/TearOutPortabilityMatrix.md`.
+ *
+ * Drives the LANDED transition chain end to end on the flagship workstation surface:
+ * `SortZone#checkWindowBoundary` (intersection-ratio hysteresis, 0.8 detach / 0.6 reattach)
+ * → `dashboard.Container#onDragBoundaryExit` → `#openWidgetInPopup` (real URL-addressed OS
+ * popup on the shared heap) → `DragDrop` pointer-follow.
+ *
+ * MUST run HEADED on a real desktop session: headless (and virtual displays) prove wiring,
+ * never native placement semantics — acquisition, `moveTo` throttling, and screen-topology
+ * permissions are exactly the platform truths this suite exists to measure. Cells this
+ * environment cannot honestly measure stay `NOT_YET_MEASURED` in the matrix document; the
+ * suite never fakes a platform verdict.
+ *
+ * Scaffold state: row 1 is the first live witness (selector constants below calibrate on the
+ * first headed run); rows 2–7 are contracted via `test.fixme` with their receipt requirements
+ * in place — red-honest until each cell's witness lands.
+ */
+
+// The flagship surface (density context: 20 items / 9 nodes / 6 tab nodes). The dev server
+// port rides NEO_E2E_PORT — the same knob the e2e config uses to dodge a foreign server.
+const
+    e2ePort    = Number(process.env.NEO_E2E_PORT) || 8080,
+    surfaceUrl = `http://localhost:${e2ePort}/apps/workstation/index.html`,
+    // First-run calibration constants: the drag handle of one dashboard item on the default
+    // workspace. Adjusted on the first headed run against the live DOM; the witness fails
+    // LOUD on a selector miss instead of timing out silently.
+    itemHandle  = '.neo-dashboard-container .neo-header-toolbar',
+    dragSteps   = 25;
+
+test.describe('tear-out portability matrix — workstation, headed', () => {
+    test.setTimeout(120000);
+
+    test.beforeEach(async ({page}) => {
+        await page.goto(surfaceUrl);
+        await expect(page.locator('.neo-viewport')).toBeVisible({timeout: 60000})
+    });
+
+    test('row 1 — hysteretic grammar: a slow boundary crossing detaches below 0.8 moving out, popup acquired, no oscillation', async ({context, page}) => {
+        const handle = page.locator(itemHandle).first();
+
+        await expect(handle, 'calibration: the dashboard item drag handle must exist on the surface').toBeVisible({timeout: 30000});
+
+        const
+            box      = await handle.boundingBox(),
+            viewport = page.viewportSize();
+
+        expect(box, 'the drag handle reports a bounding box').toBeTruthy();
+
+        // Slow, stepped drag from the item toward and past the right window boundary — the
+        // stepped path is what makes the direction-aware ratio trace meaningful (row-1 receipt:
+        // exit fires while MOVING OUT below the detach threshold, never at rest).
+        const popupPromise = context.waitForEvent('page', {timeout: 30000});
+
+        await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+        await page.mouse.down();
+
+        for (let i = 1; i <= dragSteps; i++) {
+            await page.mouse.move(
+                box.x + (viewport.width + 200 - box.x) * (i / dragSteps),
+                box.y + box.height / 2,
+                {steps: 4}
+            )
+        }
+
+        // The mid-gesture conversion: a REAL page (popup) must be acquired before pointer-up —
+        // acquisition-during-gesture is the landed grammar, not a drop effect.
+        const popup = await popupPromise;
+
+        await page.mouse.up();
+
+        expect(popup.url(), 'the popup is URL-addressed (openWidgetInPopup contract)').toContain('/apps/');
+        await expect(popup.locator('body')).toBeVisible({timeout: 30000})
+    });
+
+    test.fixme('row 2 — acquisition: window.open boolean-shaped failure + the >5s userActivation negative control', async () => {
+        // Receipts: assert the acquisition path checks window.open's BOOLEAN result (a blocked
+        // popup never throws); measure navigator.userActivation at drag-end after >5s — the
+        // expected portable failure proving release-time window.open is the negative baseline.
+    });
+
+    test.fixme('row 3 — moving embodiment: requested-vs-observed windowMoveTo coordinates', async () => {
+        // Receipts: per pointer-follow step, record requested coords vs window.screenX/Y
+        // observed in the popup; moveTo is advisory, never correctness authority.
+    });
+
+    test.fixme('row 4 — object permanence: same instance id + live stores across detach and reintegration', async () => {
+        // Receipts: component instance id and store references identical before detach and
+        // after drag-back reintegration; data streamed uninterrupted across the transition.
+    });
+
+    test.fixme('row 5 — screen topology: getScreenDetails denied degrades to the documented fallback', async () => {
+        // Receipts: the full flow completes with the permission denied; denial never blocks.
+    });
+
+    test.fixme('row 6 — multi-window targeting: at most one target exposes one menu + one preview per gesture', async () => {
+        // Receipts: the claim protocol's identity binding only — arbitration is out of scope.
+    });
+
+    test.fixme('row 7 — terminal cleanup: exact-once across drop, cancel, and blocked-acquisition terminals', async () => {
+        // Receipts: cleanup runs exactly once per terminal; a repeated terminal is a no-op.
+    })
+});

--- a/test/playwright/playwright.config.matrix.mjs
+++ b/test/playwright/playwright.config.matrix.mjs
@@ -1,25 +1,32 @@
 import './configTemplateResolver.mjs';
 
-import {defineConfig, devices} from '@playwright/test';
+import {defineConfig} from '@playwright/test';
 
-// Overridable so agent/dev runs can isolate from a foreign dev-server already squatting on 8080
-// (a server started from ANOTHER checkout silently serves the wrong tree to every spec).
+// Overridable so agent/dev runs can isolate from a foreign dev-server already squatting on 8080:
+// with `reuseExistingServer` a server started from ANOTHER checkout silently serves the wrong tree
+// to every probe — set NEO_E2E_PORT to a private port to guarantee the served tree is this one.
 const PORT = process.env.NEO_E2E_PORT || 8080;
 
 /**
  * The tear-out portability-matrix runner (see
- * `learn/guides/specificfeatures/TearOutPortabilityMatrix.md`).
+ * `learn/guides/specificfeatures/TearOutPortabilityMatrix.md` — the evidence ledger).
  *
  * Deliberately SEPARATE from `playwright.config.e2e.mjs`: the e2e config's benchmark launch
  * flags (`--use-gl=desktop`, GPU rasterization overrides) are headless-calibrated — in HEADED
  * mode on macOS they crash Chrome's GPU process ("GPU process isn't usable"), and the matrix
  * contract requires headed real-browser runs. Beyond the crash, GL/GPU overrides would distort
- * exactly the native placement semantics this suite exists to measure — the matrix browser
- * runs on stock launch defaults, so receipts describe the platform, not our flags.
+ * exactly the native placement semantics this suite measures.
  *
- * Note for row 2 (acquisition): Playwright's default launch args include
- * `--disable-popup-blocking`; the acquisition cells manage popup-blocking state explicitly
- * per measurement instead of trusting the harness default.
+ * Measurement-fidelity choices, stated honestly:
+ * - **Headed by default** (`headless: false`): headed IS this runner's identity — headless proves
+ *   wiring, never native placement. No `--headed` flag needed; CI must not run this config.
+ * - **No device preset**: `devices['Desktop Chrome']` would stamp a Windows-shaped profile onto
+ *   the local browser — the probes measure THIS platform, so the browser runs its own defaults.
+ * - **Popup blocking is NOT controlled yet**: Playwright's default launch args include
+ *   `--disable-popup-blocking`, and NO current probe manages blocking state — every acquisition
+ *   receipt is measured under blocking-disabled conditions. Blocking-controlled acquisition
+ *   cells are future matrix-contract child work (ticket-ref-ok: #15243 is the open 7×3
+ *   contract authority this runner serves) and will need their own launch configuration.
  */
 export default defineConfig({
     testDir      : './e2e/colors',
@@ -32,8 +39,15 @@ export default defineConfig({
     reporter: [['list']],
 
     use: {
-        baseURL: `http://localhost:${PORT}`,
-        trace  : 'on-first-retry'
+        baseURL : `http://localhost:${PORT}`,
+        headless: false,
+        trace   : 'on-first-retry',
+        // Explicit NEUTRAL viewport — the one profile field the probe choreography's geometry
+        // depends on (drag paths compute against it), set platform-neutrally instead of pulling
+        // the full Desktop-Chrome device preset (whose Windows-shaped UA/profile would distort
+        // the platform under measurement). Probed: the preset-free default profile reaped the
+        // row-1 popup 4/4 — the geometry dependency is real; an explicit viewport restores it.
+        viewport: {height: 720, width: 1280}
     },
 
     webServer: {
@@ -43,7 +57,6 @@ export default defineConfig({
     },
 
     projects: [{
-        name: 'chromium',
-        use : {...devices['Desktop Chrome']}
+        name: 'chromium'
     }]
 });

--- a/test/playwright/playwright.config.matrix.mjs
+++ b/test/playwright/playwright.config.matrix.mjs
@@ -1,0 +1,49 @@
+import './configTemplateResolver.mjs';
+
+import {defineConfig, devices} from '@playwright/test';
+
+// Overridable so agent/dev runs can isolate from a foreign dev-server already squatting on 8080
+// (a server started from ANOTHER checkout silently serves the wrong tree to every spec).
+const PORT = process.env.NEO_E2E_PORT || 8080;
+
+/**
+ * The tear-out portability-matrix runner (see
+ * `learn/guides/specificfeatures/TearOutPortabilityMatrix.md`).
+ *
+ * Deliberately SEPARATE from `playwright.config.e2e.mjs`: the e2e config's benchmark launch
+ * flags (`--use-gl=desktop`, GPU rasterization overrides) are headless-calibrated — in HEADED
+ * mode on macOS they crash Chrome's GPU process ("GPU process isn't usable"), and the matrix
+ * contract requires headed real-browser runs. Beyond the crash, GL/GPU overrides would distort
+ * exactly the native placement semantics this suite exists to measure — the matrix browser
+ * runs on stock launch defaults, so receipts describe the platform, not our flags.
+ *
+ * Note for row 2 (acquisition): Playwright's default launch args include
+ * `--disable-popup-blocking`; the acquisition cells manage popup-blocking state explicitly
+ * per measurement instead of trusting the harness default.
+ */
+export default defineConfig({
+    testDir      : './e2e/colors',
+    testMatch    : 'tearOutMatrix.spec.mjs',
+    outputDir    : './test-results/matrix/artifacts',
+    fullyParallel: false, // native window placement is a global resource — strictly serial
+    workers      : 1,
+    timeout      : 120000,
+
+    reporter: [['list']],
+
+    use: {
+        baseURL: `http://localhost:${PORT}`,
+        trace  : 'on-first-retry'
+    },
+
+    webServer: {
+        command            : `npm run server-start -- --port ${PORT} --no-open`,
+        url                : `http://localhost:${PORT}`,
+        reuseExistingServer: !process.env.CI
+    },
+
+    projects: [{
+        name: 'chromium',
+        use : {...devices['Desktop Chrome']}
+    }]
+});

--- a/test/playwright/playwright.config.matrix.mjs
+++ b/test/playwright/playwright.config.matrix.mjs
@@ -1,11 +1,12 @@
 import './configTemplateResolver.mjs';
 
-import {defineConfig} from '@playwright/test';
+import {defineConfig}        from '@playwright/test';
+import {resolveFreePortSync} from './resolveFreePort.mjs';
 
-// Overridable so agent/dev runs can isolate from a foreign dev-server already squatting on 8080:
-// with `reuseExistingServer` a server started from ANOTHER checkout silently serves the wrong tree
-// to every probe — set NEO_E2E_PORT to a private port to guarantee the served tree is this one.
-const PORT = process.env.NEO_E2E_PORT || 8080;
+// Foreign-tree evidence is structurally impossible here: an explicit NEO_E2E_PORT pin wins,
+// otherwise an OS-assigned free port is probed per process — and the webServer below never
+// adopts an existing listener, so every probe run serves exactly THIS checkout's tree.
+const PORT = resolveFreePortSync(process.env.NEO_E2E_PORT);
 
 /**
  * The tear-out portability-matrix runner (see
@@ -53,10 +54,15 @@ export default defineConfig({
     webServer: {
         command            : `npm run server-start -- --port ${PORT} --no-open`,
         url                : `http://localhost:${PORT}`,
-        reuseExistingServer: !process.env.CI
+        // NEVER adopt an existing listener: reuse is how a server from ANOTHER checkout silently
+        // serves the wrong tree to every probe (the foreign-server evidence class).
+        reuseExistingServer: false
     },
 
     projects: [{
-        name: 'chromium'
+        // Real Google Chrome, matching the ledger's "macOS Chrome" receipts — the bare project
+        // would launch bundled Chromium, a different browser than the one the evidence names.
+        name: 'chrome',
+        use : {channel: 'chrome'}
     }]
 });


### PR DESCRIPTION
Resolves #15426

Related: #15243 — which stays OPEN owning the complete 7×3 matrix + revalidation gate, per the contract author's authority ruling (A2A `2b007108`): this PR delivers the narrow FOUNDATION leaf (runner + living evidence ledger + qualified macOS probes), never the completed contract. Remaining rows/columns land as #15243 children updating the one ledger.

The tear-out portability matrix's foundation: the living EVIDENCE LEDGER (`learn/guides/specificfeatures/TearOutPortabilityMatrix.md` — self-described subordinate to ADR 0029 + the open #15243 authority, registered hidden in `learn/tree.json`), the spike-owned headed runner (`test/playwright/playwright.config.matrix.mjs` — headed by default, neutral explicit viewport, no device preset, the popup-blocking and foreign-server caveats stated in-file), and rows 1–3 as QUALIFIED PROBES on the landed grammar's original product surface (`apps/colors`) — probe titles claim exactly what their assertions check, pending sub-receipts named in the titles.

Evidence: L2/L3-probe (headed real-browser PROBE receipts on the landed grammar, macOS seat — receipts recorded and footnoted; NO cell verdict claimed: all 21 cells honestly `NOT_YET_MEASURED` until their complete receipt sets exist) → per-cell verdicts required (#15243's contract level, its children's work). Residual: every cell verdict [#15243, open by ruling]; Windows/Linux receipts [operator-produced headed runs per the live #15239 authority].

## Deltas from ticket

- The `NOT_YET_MEASURED` honest-hole vocabulary + the environment note (an addition to the contract's verdict set, never a substitute for measured verdicts).
- Three probe-level findings, receipt-cited in the ledger: the #15410 birth-race discovery → attribution → fix confirmation (merged PR #15413; 6/6 post-fix on this suite); the CDP instrument boundary (activation never decays under synthesized input — acquisition timings must never be calibrated from automation); the SharedWorker console-blindness retraction with its sweep scope.
- The runner as a separate config (forced by the headed-GPU-flag crash; kept because GL overrides would distort the platform under measurement) — including the probed viewport-geometry dependency (preset-free default profile reaped the row-1 popup 4/4; one explicit neutral viewport restores stability, documented in-comment).

## Test Evidence

- Matrix runner, headed (default), macOS seat, final profile: full suite **6/6 across ×2 repeat** at `560b1df51c` (post-rebase onto merged #15413). Row 1: boundary-exit + mid-gesture acquisition + persistence + rendering probe receipts (ratio-trace no-oscillation + instance-identity receipts pending — named in the title). Row 2: activation decay-trace receipts (expiry unmeasurable under CDP; blocking-controlled cells pending). Row 3: lifecycle-terminal receipts (requested-vs-observed pairing pending).
- `apps/colors` surface: rows 4–7 contracted `test.fixme` carrying their receipt requirements — they land as #15243 children.

## Post-Merge Validation

- [ ] G1's calibration cites the ledger's receipts (already referenced in-flight by its author).
- [ ] #15243 children consume the runner + ledger for the remaining rows/columns.

## Commits

`a7ec6e7e69` contract document + witness scaffold · `538a761129` colors surface + runner + first probes · `00231ac8dc` rows 2–3 findings + flake-rate receipt · `c00c6601d8` trigger-question receipt · `2718a60b19` instrument-blind retraction + race attribution · `530622b546` verdict-rhetoric repair (probes ≠ verdicts) · `560b1df51c` the four bounded clusters (probe-honest names, measurement-faithful runner, ledger disposition, resolved-race wording).

Authored by Clio (Claude Fable 5, Claude Code). Session abce4d75-7dcb-4145-8afc-b0ff2cdc51e6.