### PR TITLE
fix(draggable): earn window-boundary re-entry — the Schmitt trigger that stops the newborn-popup reap (#15410)

### DIFF
--- a/src/draggable/container/SortZone.mjs
+++ b/src/draggable/container/SortZone.mjs
@@ -202,6 +202,18 @@ class SortZone extends DragZone {
      * @protected
      */
     isWindowDragging = false
+    /**
+     * Schmitt-trigger arming for the window-boundary re-entry: `false` from the moment a
+     * boundary-exit fires until the intersection ratio has dropped BELOW {@link #reattachThreshold}
+     * at least once. The exit fires just under {@link #detachThreshold}, which is INSIDE the
+     * reattach zone — so without arming, a single post-exit sample with a positive delta (pointer
+     * jitter, or the exit choreography's own geometry side effects) reads as "moving in above the
+     * threshold" and fires a false `dragBoundaryEntry`, whose handler closes the newborn popup.
+     * Re-entry must be EARNED: leave first, then return.
+     * @member {Boolean} reattachArmed=false
+     * @protected
+     */
+    reattachArmed = false
 
     /**
      * Appends one event to the active drag trace. Events carry where the drag logic
@@ -285,7 +297,11 @@ class SortZone extends DragZone {
 
             if (!me.isWindowDragging) {
                 if (isMovingOut && intersectionRatio < me.detachThreshold) {
-                    me.isWindowDragging = true; // Set flag to prevent re-entry
+                    me.isWindowDragging = true; // window-drag phase begins
+                    // Re-entry must be earned: the ratio has to sit below reattachThreshold before a
+                    // return counts. A slow exit (crossing at ~detachThreshold) starts UNarmed; a
+                    // single-move fling that already landed below reattachThreshold is pre-armed.
+                    me.reattachArmed = intersectionRatio < me.reattachThreshold;
 
                     me.fire('dragBoundaryExit', {
                         draggedItem: me.dragComponent,
@@ -295,7 +311,16 @@ class SortZone extends DragZone {
                     return true // Stop further processing in onDragMove
                 }
             } else if (me.isWindowDragging) {
-                if (isMovingIn && intersectionRatio > me.reattachThreshold) {
+                // The exit fires just UNDER detachThreshold — inside the reattach zone — so the raw
+                // direction test alone would let one post-exit positive-delta sample (pointer jitter,
+                // exit-choreography geometry side effects) fire a false re-entry that closes the
+                // newborn popup ~2ms after birth. Arm re-entry only once the drag has demonstrably
+                // LEFT the reattach zone since the exit.
+                if (intersectionRatio < me.reattachThreshold) {
+                    me.reattachArmed = true
+                }
+
+                if (me.reattachArmed && isMovingIn && intersectionRatio > me.reattachThreshold) {
                     // Restore layout
                     me.dragPlaceholder.wrapperStyle = {
                         ...me.dragPlaceholder.wrapperStyle,
@@ -367,6 +392,7 @@ class SortZone extends DragZone {
         me.currentIndex     = me.startIndex;
         me.isOverDragging   = false;
         me.isWindowDragging = false;
+        me.reattachArmed    = false;
 
         me.fire('dragCancel', data);
 

--- a/test/playwright/unit/draggable/container/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/container/SortZone.spec.mjs
@@ -286,3 +286,93 @@ test.describe.serial('Neo.draggable.container.SortZone', () => {
         SortZone.activeTrace   = null
     });
 });
+
+test.describe('checkWindowBoundary — the re-entry Schmitt trigger (the false-re-entry reap)', () => {
+    // Prototype-driven: the hysteresis decision chain is the unit. Geometry helper: a 1000×1000
+    // boundary + a 100×100 proxy whose x-position dials the intersection ratio exactly —
+    // ratioAt(f) places the proxy so intersectionArea/proxyArea === f.
+    const BOUNDARY = {x: 0, y: 0, width: 1000, height: 1000, left: 0, top: 0, right: 1000, bottom: 1000};
+
+    const proxyAt = f => {
+        const x = 1000 - 100 * f;
+        return {x, y: 450, width: 100, height: 100, left: x, top: 450, right: x + 100, bottom: 550}
+    };
+
+    const zoneFor = () => {
+        const fired = [], continued = [];
+
+        const zone = {
+            boundaryContainerRect: BOUNDARY,
+            detachThreshold      : 0.8,
+            dragComponent        : {id: 'dragged'},
+            dragPlaceholder      : {wrapperStyle: {}},
+            indexMap             : [],
+            isWindowDragging     : false,
+            itemRects            : [],
+            lastIntersectionRatio: 1,
+            owner                : {items: []},
+            reattachArmed        : false,
+            reattachThreshold    : 0.6,
+            fire                 : (name, data) => fired.push(name),
+            onWindowDragContinue : () => continued.push(1)
+        };
+
+        const move = f => SortZone.prototype.checkWindowBoundary.call(zone, {proxyRect: proxyAt(f)});
+
+        return {continued, fired, move, zone}
+    };
+
+    test('the reap sequence: exit at the band edge + one inward-jitter sample fires NO re-entry (the newborn popup survives)', () => {
+        const {continued, fired, move, zone} = zoneFor();
+
+        zone.lastIntersectionRatio = 0.85;
+
+        move(0.79);                                     // crossing under detachThreshold, moving out
+        expect(fired).toEqual(['dragBoundaryExit']);
+        expect(zone.isWindowDragging).toBe(true);
+        expect(zone.reattachArmed, 'slow exit inside the reattach zone starts UNarmed').toBe(false);
+
+        move(0.795);                                    // the single post-exit jitter that used to reap
+        move(0.85);                                     // even sustained inward drift without leaving
+        expect(fired, 'no false dragBoundaryEntry — the pre-fix reap path').toEqual(['dragBoundaryExit']);
+        expect(continued.length, 'the window drag CONTINUES instead').toBe(2)
+    });
+
+    test('genuine re-entry still works: leave below reattachThreshold, then return moving in', () => {
+        const {fired, move, zone} = zoneFor();
+
+        zone.lastIntersectionRatio = 0.85;
+
+        move(0.79);                                     // exit
+        move(0.5);                                      // demonstrably left — arms the trigger
+        expect(zone.reattachArmed).toBe(true);
+
+        move(0.65);                                     // rising back above reattachThreshold
+        expect(fired).toEqual(['dragBoundaryExit', 'dragBoundaryEntry'])
+    });
+
+    test('band wobble between the thresholds never re-enters (hysteresis discipline)', () => {
+        const {continued, fired, move, zone} = zoneFor();
+
+        zone.lastIntersectionRatio = 0.85;
+
+        move(0.79);
+        for (const f of [0.7, 0.65, 0.75, 0.7, 0.78]) move(f);
+
+        expect(fired).toEqual(['dragBoundaryExit']);
+        expect(continued.length).toBe(5)
+    });
+
+    test('a single-move fling below reattachThreshold is PRE-armed: the direct return re-enters', () => {
+        const {fired, move, zone} = zoneFor();
+
+        zone.lastIntersectionRatio = 0.9;
+
+        move(0.5);                                      // one move from deep-inside to below reattach
+        expect(fired).toEqual(['dragBoundaryExit']);
+        expect(zone.reattachArmed, 'exit already below reattachThreshold pre-arms').toBe(true);
+
+        move(0.65);                                     // direct return, moving in
+        expect(fired).toEqual(['dragBoundaryExit', 'dragBoundaryEntry'])
+    })
+});

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -147,12 +147,27 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
         expect(sortZone.lastIntersectionRatio).toBeCloseTo(0.70);
         expect(sortZone.isWindowDragging).toBe(true);
 
+        // Band-internal return (0.70 → 0.75, never below the 0.6 reattach threshold) is window-drag
+        // CONTINUATION, not re-entry: a same-band flap used to fire a false dragBoundaryEntry whose
+        // handler closed the newborn popup ~2ms after birth. Re-entry is EARNED — the ratio must
+        // drop below the reattach threshold before a rising sample counts (the Schmitt trigger).
         await simulateMove(25, 0);
         expect(sortZone.lastIntersectionRatio).toBe(0.75);
-        expect(sortZone.isWindowDragging).toBe(false);
+        expect(sortZone.isWindowDragging).toBe(true);
 
+        // Demonstrably leave the reattach zone — arms the trigger, still window-dragging.
+        await simulateMove(45, 0);
+        expect(sortZone.lastIntersectionRatio).toBeCloseTo(0.55);
+        expect(sortZone.isWindowDragging).toBe(true);
+
+        // The EARNED return: rising back above the reattach threshold now re-enters.
         await simulateMove(30, 0);
         expect(sortZone.lastIntersectionRatio).toBeCloseTo(0.70);
+        expect(sortZone.isWindowDragging).toBe(false);
+
+        // And the cycle re-exits cleanly below the detach threshold, moving out.
+        await simulateMove(40, 0);
+        expect(sortZone.lastIntersectionRatio).toBeCloseTo(0.60);
         expect(sortZone.isWindowDragging).toBe(true);
     });
 


### PR DESCRIPTION
Resolves #15410
Related: #15243, #15239, #15408

The birth-race reap, fixed at its mechanism: **the hysteresis band was inverted at the exit moment.** A boundary exit fires just under `detachThreshold` (0.8) — which is *inside* the reattach zone (>0.6) — so one post-exit sample with a positive delta (pointer jitter, or the exit choreography's own geometry side effects) satisfied `isMovingIn && ratio > reattachThreshold` and fired a false `dragBoundaryEntry`, whose handler `windowClose`d the newborn popup ~2ms after birth. The `isWindowDragging = true` comment even said "prevent re-entry" — the intent existed, incompletely realized. The run distribution the matrix measured (5/6 reaps ⇔ ≥1 post-birth move; survivals ⇔ zero moves) is exactly this mechanism's signature.

The fix is the classic Schmitt trigger: **re-entry must be earned.** A new `reattachArmed` flag arms only once the ratio has demonstrably LEFT the reattach zone since the exit (with a fast-fling refinement: an exit that already landed below `reattachThreshold` in a single move is pre-armed, so a direct return still works). Genuine re-entries — leave, then come back moving in — are unchanged.

Evidence: L2 (the decision chain driven end-to-end by unit witnesses with exact geometry; the full draggable+dashboard suites green — the achievable ceiling on this branch) → L3 required (#15410 AC-2: repeat-each=6 headed shows 6/6 popup survival with post-birth movement — the discovering witness lives on the unmerged #15243 matrix branch). Residual: AC-2's headed receipt [#15410 — runs on the matrix runner against this head; @neo-fable-clio holds the runner], AC-4 footnote update + AC-5 trigger re-evaluation [ticket-side, post-attribution acts].

## Deltas

| Area | Before | After |
|---|---|---|
| Post-exit re-entry condition | `isMovingIn && ratio > reattachThreshold` — satisfiable by the very next sample after an exit at ~0.79 (band-internal flap) | `reattachArmed && isMovingIn && ratio > reattachThreshold` — armed only after a sample below `reattachThreshold` since the exit |
| Exit bookkeeping | `isWindowDragging = true` | + `reattachArmed = ratio < reattachThreshold` (slow exit starts unarmed; single-move fling below reattach is pre-armed) |
| Cancel cleanup | `isWindowDragging` reset | + `reattachArmed` reset beside it |
| The legacy directional witness | pinned the bug: asserted re-entry on a 0.70→0.75 band-internal return (the reap path, codified) | asserts the earned-re-entry law: band wobble continues the window drag; below-0.6 arms; the risen return re-enters; the cycle re-exits |

## Test Evidence

- **4 new witnesses** (`draggable/container/SortZone.spec.mjs`, prototype-driven with exact intersection geometry): the reap sequence (exit at band edge + inward jitter + sustained drift → ZERO false entries, window drag continues); genuine re-entry (leave below 0.6 → return → fires); band-wobble discipline (five in-band samples, no entry); the fling pre-arm (single move to 0.5 → direct return re-enters).
- **The legacy colliding-thresholds witness** (`draggable/dashboard/SortZone.spec.mjs`) rewritten to the corrected law — its old step-4 assertion WAS the bug as a test expectation.
- Full draggable + dashboard suites: **367/367** (unit config). CI at head required before merge.

## Post-Merge Validation

- [ ] Headed 6/6-survival receipt on the #15243 matrix runner against this fix (AC-2) — @neo-fable-clio's runner, coordinated; one deliberate post-birth move must survive deterministically.
- [ ] Matrix doc footnote ³ updated hypothesis → attributed+fixed (AC-4) and the D#15204 `revalidationTrigger` question re-evaluated with the attribution (AC-5) — ticket-side acts on #15410.
- [ ] The genuine re-entry path re-verified once headed: a real drag out below 0.6 and back re-integrates (AC-3's headed half; the unit half is pinned here).

## Commits

- the Schmitt-trigger arming + field + cancel hygiene + 4 witnesses + the corrected legacy pin.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 89818500-8a12-4162-b41f-8947703b1b06.
