### PR TITLE
feat(orchestrator): night-shift heartbeat decision contract (#15405)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/nightShiftPolicy.mjs
+++ b/ai/daemons/orchestrator/scheduling/nightShiftPolicy.mjs
@@ -1,0 +1,91 @@
+/**
+ * @module ai/daemons/orchestrator/scheduling/nightShiftPolicy
+ * @summary The presence-aware heartbeat-mode decision — the pure contract behind night-shift
+ * re-invocation: WHEN the swarm heartbeat runs is decided from operator presence + the operator's
+ * own explicit setting, so a fleet whose operator walked away keeps receiving autonomous turns
+ * instead of sleeping forever on its last allowed stop.
+ *
+ * The decision hierarchy (each tier fills only the ABSENCE of a decision above it):
+ * 1. **An explicit operator setting always wins** — `manualEnabled: true` runs the heartbeat,
+ *    `manualEnabled: false` stops it, and the policy NEVER overrides either. The policy is not a
+ *    fight with the operator; it fills the gap where no explicit decision exists.
+ * 2. **Policy fills the unset gap** (`manualEnabled: null`/`undefined`): with
+ *    `policyMode: 'presence-aware'`, operator inactivity past the threshold flips night-shift mode
+ *    ON (heartbeats flow); a present operator leaves the heartbeat OFF by default (their hours,
+ *    their noise budget — quiet unless they said otherwise).
+ * 3. **Conservative on missing evidence:** an unreadable/absent presence signal treats the operator
+ *    as PRESENT — no auto-night-mode from blindness. A daemon that cannot see must not get loud.
+ *
+ * Pure and total by contract: injected clock + presence + settings, no imports, no I/O, never
+ * throws — the orchestrator pipeline consumes the verdict at pulse-scheduling time, and unit
+ * witnesses drive every tier of the hierarchy directly.
+ */
+
+/**
+ * Default operator-inactivity window before night-shift mode engages: long enough that a coffee
+ * break never flips the fleet loud, short enough that a departed operator strands no seat for long.
+ * @type {Number}
+ */
+export const DEFAULT_INACTIVITY_THRESHOLD_MS = 40 * 60 * 1000;
+
+/**
+ * @summary Resolves whether the swarm heartbeat should run, from the operator's explicit setting,
+ * the policy mode, and operator presence. See the module summary for the three-tier hierarchy.
+ * @param {Object} input
+ * @param {Boolean|null} [input.manualEnabled=null] The operator's EXPLICIT heartbeat setting —
+ *     `true`/`false` wins outright; `null`/`undefined` means "no explicit decision" and hands the
+ *     verdict to the policy tier.
+ * @param {String} [input.policyMode='manual'] `'presence-aware'` activates the night-shift tier;
+ *     any other value keeps the legacy manual-only semantics (unset manual ⇒ heartbeat off).
+ * @param {Number|null} [input.operatorLastActiveAt=null] Epoch ms of the newest operator-class
+ *     activity, or `null` when the presence signal is unavailable (conservative: treated as
+ *     present-now).
+ * @param {Number} [input.now=Date.now()] Injected clock (epoch ms).
+ * @param {Number} [input.inactivityThresholdMs=DEFAULT_INACTIVITY_THRESHOLD_MS] Inactivity window
+ *     before night-shift engages; non-finite or non-positive values fall back to the default.
+ * @returns {{heartbeatActive: Boolean, mode: String, reason: String}} `mode` is one of
+ *     `'manual-on'` | `'manual-off'` | `'night-shift'` | `'day-quiet'` — greppable in pulse logs so
+ *     the next teethless-fleet investigation takes minutes, not hours.
+ */
+export function resolveHeartbeatMode({
+    manualEnabled         = null,
+    policyMode            = 'manual',
+    operatorLastActiveAt  = null,
+    now                   = Date.now(),
+    inactivityThresholdMs = DEFAULT_INACTIVITY_THRESHOLD_MS
+} = {}) {
+    // Tier 1: an explicit operator decision is never overridden, in either direction.
+    if (manualEnabled === true) {
+        return {heartbeatActive: true, mode: 'manual-on', reason: 'explicit operator setting: heartbeat enabled'}
+    }
+    if (manualEnabled === false) {
+        return {heartbeatActive: false, mode: 'manual-off', reason: 'explicit operator setting: heartbeat disabled — policy never overrides an explicit off'}
+    }
+
+    // Tier 2 requires the presence-aware mode; legacy manual-only semantics otherwise.
+    if (policyMode !== 'presence-aware') {
+        return {heartbeatActive: false, mode: 'day-quiet', reason: 'no explicit setting and policy is manual-only — heartbeat stays off'}
+    }
+
+    const threshold = Number.isFinite(inactivityThresholdMs) && inactivityThresholdMs > 0
+        ? inactivityThresholdMs
+        : DEFAULT_INACTIVITY_THRESHOLD_MS;
+
+    // Tier 3: blindness is presence — a daemon that cannot see the operator must not get loud.
+    const lastActive = Number.isFinite(operatorLastActiveAt) ? operatorLastActiveAt : now,
+          inactiveMs = Math.max(0, now - lastActive);
+
+    if (inactiveMs >= threshold) {
+        return {
+            heartbeatActive: true,
+            mode           : 'night-shift',
+            reason         : `operator inactive ${Math.round(inactiveMs / 60000)}min (threshold ${Math.round(threshold / 60000)}min) — night-shift heartbeat active`
+        }
+    }
+
+    return {
+        heartbeatActive: false,
+        mode           : 'day-quiet',
+        reason         : 'operator present (or presence unreadable — conservative) and no explicit enable — heartbeat quiet'
+    }
+}

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/nightShiftPolicy.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/nightShiftPolicy.spec.mjs
@@ -1,0 +1,76 @@
+import {test, expect}                                          from '@playwright/test';
+import {DEFAULT_INACTIVITY_THRESHOLD_MS, resolveHeartbeatMode} from '../../../../../../../ai/daemons/orchestrator/scheduling/nightShiftPolicy.mjs';
+
+/**
+ * @summary The night-shift decision contract, every tier driven directly: an explicit operator
+ * setting is never overridden in either direction, the policy fills only the unset gap, operator
+ * inactivity past the threshold flips night-shift ON, and blindness (no presence signal) reads as
+ * PRESENT — a daemon that cannot see must not get loud.
+ */
+test.describe('ai/daemons/orchestrator/scheduling/nightShiftPolicy — resolveHeartbeatMode', () => {
+    const NOW = 1_800_000_000_000;
+    const MIN = 60_000;
+
+    test('tier 1: an explicit operator setting wins outright, in BOTH directions — the policy never fights a decision', () => {
+        // explicit ON runs regardless of presence
+        const on = resolveHeartbeatMode({manualEnabled: true, policyMode: 'presence-aware', operatorLastActiveAt: NOW, now: NOW});
+        expect(on).toMatchObject({heartbeatActive: true, mode: 'manual-on'});
+
+        // explicit OFF holds even with the operator gone for hours — "wakes off, full stop" is respected
+        const off = resolveHeartbeatMode({manualEnabled: false, policyMode: 'presence-aware', operatorLastActiveAt: NOW - 300 * MIN, now: NOW});
+        expect(off).toMatchObject({heartbeatActive: false, mode: 'manual-off'})
+    });
+
+    test('tier 2: night-shift engages only past the inactivity threshold, and disengages on operator return', () => {
+        const base = {manualEnabled: null, policyMode: 'presence-aware', now: NOW, inactivityThresholdMs: 40 * MIN};
+
+        // operator active 10 minutes ago: day-quiet
+        expect(resolveHeartbeatMode({...base, operatorLastActiveAt: NOW - 10 * MIN}))
+            .toMatchObject({heartbeatActive: false, mode: 'day-quiet'});
+
+        // operator inactive 41 minutes: night-shift
+        const night = resolveHeartbeatMode({...base, operatorLastActiveAt: NOW - 41 * MIN});
+        expect(night).toMatchObject({heartbeatActive: true, mode: 'night-shift'});
+        expect(night.reason).toContain('41min');
+
+        // exact threshold boundary counts as inactive (>=)
+        expect(resolveHeartbeatMode({...base, operatorLastActiveAt: NOW - 40 * MIN}).mode).toBe('night-shift')
+    });
+
+    test('tier 3: blindness is presence — a missing/garbage presence signal never auto-activates night mode', () => {
+        const base = {manualEnabled: null, policyMode: 'presence-aware', now: NOW};
+
+        for (const operatorLastActiveAt of [null, undefined, NaN, 'yesterday']) {
+            const verdict = resolveHeartbeatMode({...base, operatorLastActiveAt});
+            expect(verdict, `presence=${String(operatorLastActiveAt)}`).toMatchObject({heartbeatActive: false, mode: 'day-quiet'})
+        }
+    });
+
+    test('legacy manual-only mode: unset manual means quiet — the pre-policy semantics are byte-preserved', () => {
+        // no policyMode at all, and an unset manual flag: heartbeat off (today's behavior for an unset toggle)
+        expect(resolveHeartbeatMode({manualEnabled: null, operatorLastActiveAt: NOW - 500 * MIN, now: NOW}))
+            .toMatchObject({heartbeatActive: false, mode: 'day-quiet'});
+
+        // an unknown/typo policy mode degrades to the same legacy semantics, never to loud
+        expect(resolveHeartbeatMode({manualEnabled: null, policyMode: 'presenceaware', operatorLastActiveAt: NOW - 500 * MIN, now: NOW}).heartbeatActive).toBe(false)
+    });
+
+    test('garbage thresholds fall back to the default instead of misbehaving', () => {
+        const base = {manualEnabled: null, policyMode: 'presence-aware', now: NOW};
+
+        for (const inactivityThresholdMs of [0, -5, NaN, Infinity]) {
+            // every garbage shape (zero, negative, NaN, non-finite Infinity) falls back to the
+            // DEFAULT window — inactive longer than it, so night-shift under the fallback
+            const verdict = resolveHeartbeatMode({
+                ...base, inactivityThresholdMs,
+                operatorLastActiveAt: NOW - DEFAULT_INACTIVITY_THRESHOLD_MS - MIN
+            });
+            expect(verdict.mode, `threshold=${inactivityThresholdMs}`).toBe('night-shift')
+        }
+    });
+
+    test('the empty call is safe and quiet (total function, no-throw contract)', () => {
+        expect(resolveHeartbeatMode()).toMatchObject({heartbeatActive: false, mode: 'day-quiet'});
+        expect(resolveHeartbeatMode(undefined)).toMatchObject({heartbeatActive: false})
+    })
+});


### PR DESCRIPTION
Resolves #15417
Related: #15405, #15401, #15404, #15394

The split leaf (#15417, from #15405 — the #15407 precedent shape): **the pure decision contract.** `resolveHeartbeatMode` is the three-tier hierarchy the ticket's Contract Ledger specifies, as a total injected-clock function the orchestrator pipeline will consume at pulse-scheduling time: an explicit operator setting wins outright in BOTH directions (the policy never fights a decision — "wakes off, full stop" is respected), the presence-aware tier fills only the unset gap (operator inactive past the threshold ⇒ night-shift heartbeats flow; present ⇒ quiet), and blindness is presence (an unreadable signal never auto-activates night mode — a daemon that cannot see must not get loud). Greppable `mode` strings (`manual-on` / `manual-off` / `night-shift` / `day-quiet`) so the next teethless-fleet investigation reads pulse logs in minutes.

The ticket retains: the pipeline wiring (the `swarmHeartbeat` enabled-map seam at `scheduling/pipeline.mjs`), the config tri-state contract question (settled under ADR-0019 + template-parity gates at wiring time — this PR deliberately touches NO config), the dead-man watchdog leg, and the full-night post-merge validation. Entry map on the ticket.

Evidence: L2 (6 unit witnesses driving every tier + every fallback — the pure contract's full ceiling) → L2 sufficient for THIS slice (no runtime surface exists until the wiring lands). Residual: the ticket's wiring + watchdog + night-window ACs [#15405 — mapped, retained].

## Deltas

| Area | Before | After |
|---|---|---|
| Night-shift decision authority | none — heartbeat on/off is a hand-flipped Boolean | `resolveHeartbeatMode`: explicit-setting-wins > presence-aware policy > conservative default, as a pure testable contract |
| Presence semantics | n/a | inactivity ≥ threshold (default 40min) engages night-shift; missing/garbage presence reads as PRESENT |
| Failure shapes | n/a | total function: garbage thresholds fall back to the default, the empty call is safe and quiet, unknown policy modes degrade to legacy-manual — never to loud |

## Test Evidence

`test/playwright/unit/ai/daemons/orchestrator/scheduling/nightShiftPolicy.spec.mjs` — **6/6**: both explicit-setting directions (including off-wins-over-5-hours-absent), threshold engage/disengage + exact-boundary, the blindness battery (null/undefined/NaN/string presence), legacy-mode byte-preservation (unset ⇒ quiet; typo'd policy mode ⇒ quiet), garbage-threshold fallback, the empty-call no-throw contract.

## Post-Merge Validation

- [ ] The wiring slice (#15405 retained) consumes this function at the pipeline seam and carries the config tri-state under the template-parity gates.
- [ ] The full-night validation window (operator offline ≥ 4h, ≥ 2 seats waking, zero manual intervention) rides the ticket after the wiring lands.

## Commits

- the pure policy module + 6 witnesses.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 89818500-8a12-4162-b41f-8947703b1b06.
