### PR TITLE
feat(fleet): resolveViewerIdentity — the whoami identity-bootstrap read verb (#15412)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -113,6 +113,16 @@ class FleetControlBridge extends Base {
      */
     mailboxMirrorSource = null
     /**
+     * Viewer-identity bootstrap seam — an injected collaborator exposing `resolveViewerIdentity()`
+     * returning the SERVER-stamped viewer from the authenticated request context (the launch entry
+     * wires it to the same per-request binding the mirror source reads; never cached, never a
+     * caller claim). Exists because the mirror's explicit-subject contract is deliberate while
+     * `admission.viewerIdentity` only arrives IN a read result — circular for the FIRST own-inbox
+     * read; whoami is the bootstrap leg. Unwired → an honest source-not-wired refusal.
+     * @member {Object|null} viewerIdentitySource=null
+     */
+    viewerIdentitySource = null
+    /**
      * Operator-compose **WRITE** seam — an injected collaborator exposing `addMessage(payload)`
      * (the MailboxService primitive, bound by the launch entry — never imported here). The FIRST
      * write seam on this bridge: unlike the read-observe sources above it persists a mailbox
@@ -466,6 +476,34 @@ class FleetControlBridge extends Base {
                 page   : {limit: params?.limit ?? DEFAULT_FLEET_MAILBOX_MIRROR_LIMIT, offset: params?.offset ?? 0},
                 subject: params?.subjectAgentId ?? null
             });
+    }
+
+    /**
+     * @summary Whoami — the identity-bootstrap read verb: the SERVER-stamped viewer identity from
+     * the authenticated request context, never a caller claim.
+     *
+     * The one consumer problem this solves: the mirror's explicit-subject contract refuses an
+     * omitted `subjectAgentId` by design (no self-defaulting at a trust boundary), but
+     * `admission.viewerIdentity` only arrives IN a read result — circular for the FIRST own-inbox
+     * read. Whoami is the missing bootstrap leg of "the client SAYS self, and the admission stamp
+     * proves it": the cockpit calls this, then passes the returned @-id EXPLICITLY as the subject,
+     * and the mirror's admission re-stamps and proves it.
+     *
+     * Fail-closed in both refusal shapes: an unwired source (no composed launch contract) answers
+     * `source not wired`; a wired source under an UNBOUND request context answers `viewer identity
+     * unbound` — never a fallback identity, never an empty-string viewer.
+     * @returns {Object} `{ok: true, agentIdentityNodeId}` or `{ok: false, error}`
+     */
+    resolveViewerIdentity() {
+        if (!this.viewerIdentitySource) {
+            return {ok: false, error: 'fleet viewer identity source not wired'};
+        }
+
+        const agentIdentityNodeId = this.viewerIdentitySource.resolveViewerIdentity();
+
+        return agentIdentityNodeId
+            ? {ok: true, agentIdentityNodeId}
+            : {ok: false, error: 'viewer identity unbound — authenticated ingress required'};
     }
 
     /**

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -111,6 +111,13 @@ async function boot() {
     // lazily (the established cross-process read pattern — pay the memory-core import when a pane
     // actually asks), and the bound identity resolves PER REQUEST from the context the transport
     // stamped — the composer never receives, trusts, or forwards a caller-supplied viewer.
+    // The whoami bootstrap seam: the SAME per-request binding the mirror source reads — the
+    // ingress stamps the viewer, this exposes it as the identity the cockpit passes back
+    // explicitly as the mirror's subject (the anti-fork contract's missing first leg).
+    FleetControlBridge.viewerIdentitySource = {
+        resolveViewerIdentity: () => RequestContextService.getAgentIdentityNodeId()
+    };
+
     FleetControlBridge.mailboxMirrorSource = {
         async readMailboxMirror(params = {}) {
             const [{readFleetMailboxMirror}, {default: MailboxService}] = await Promise.all([

--- a/src/ai/fleet/fleetWireMethods.mjs
+++ b/src/ai/fleet/fleetWireMethods.mjs
@@ -26,6 +26,16 @@
  * seam REAL rather than a Node-side method the browser can never name — an allowlist omission
  * fails closed and SILENT, which reads exactly like a wired-but-empty mailbox from the pane's side.
  *
+ * `resolveViewerIdentity` is the **identity-bootstrap** read verb — whoami: it returns the
+ * SERVER-stamped viewer identity (`{agentIdentityNodeId}`) from the authenticated request context,
+ * never a caller claim. It exists because the mirror's explicit-subject contract is deliberate
+ * (no self-defaulting at a trust boundary) while `admission.viewerIdentity` only arrives IN a read
+ * result — circular for the FIRST own-inbox read. Whoami is the missing bootstrap leg of
+ * "the client SAYS self, and the admission stamp proves it": cockpit calls whoami → passes the
+ * returned @-id EXPLICITLY as `subjectAgentId` → the mirror re-stamps and proves it. An unwired
+ * source (no composed launch contract) answers an honest `unavailable`; an admitted-but-unbound
+ * context answers a named refusal — never a fallback identity.
+ *
  * `composeOperatorMessage` is the wire's FIRST **write** verb — the operator-mailbox steering
  * surface: compose a DM or an `AGENT:*` broadcast through the bridge's injected writer. It rides
  * ONLY the authenticated transport: the ingress stamps the server-resolved viewer into the request
@@ -41,5 +51,5 @@ export const FLEET_WIRE_METHODS = Object.freeze([
     'defineAgent', 'configureAgent', 'setRepo', 'setAvatar', 'listAgents', 'getAgent',
     'startAgent', 'stopAgent', 'restartAgent', 'removeAgent', 'fleetStatus', 'fleetRuntimeStatus',
     'getBootIdentity', 'fleetActivity', 'fleetRoster', 'fleetMailboxMirror', 'connectTenant', 'listTenants',
-    'composeOperatorMessage'
+    'composeOperatorMessage', 'resolveViewerIdentity'
 ]);

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -111,13 +111,27 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
         expect(res.ok).toBe(false);
     });
 
-    test('the wire allowlist is exactly the pane operations (+ the read-observe getBootIdentity / fleetActivity / fleetRoster / fleetMailboxMirror + the composeOperatorMessage write verb) — no resolver seams', () => {
+    test('resolveViewerIdentity routes over the wire — the whoami identity-bootstrap is a real pane-callable verb', async () => {
+        bridge.resolveViewerIdentity = () => {
+            calls.push(['resolveViewerIdentity']);
+            return {ok: true, agentIdentityNodeId: '@stamped-viewer'}
+        };
+
+        const res = await dispatchFleetRequest({method: 'resolveViewerIdentity'}, bridge);
+
+        expect(res.ok).toBe(true);
+        expect(res.result).toEqual({ok: true, agentIdentityNodeId: '@stamped-viewer'});
+        expect(calls).toEqual([['resolveViewerIdentity']])
+    });
+
+    test('the wire allowlist is exactly the pane operations (+ the read-observe getBootIdentity / fleetActivity / fleetRoster / fleetMailboxMirror / resolveViewerIdentity + the composeOperatorMessage write verb) — no resolver seams', () => {
         expect([...FLEET_WIRE_METHODS].sort()).toEqual(
             // fleet-agent operations (incl. the configureAgent scoped-config patch — never identity,
             // never credential) + the read-observe verbs (boot-identity fact + activity snapshot +
-            // assembled roster DTO + one agent's mailbox mirror — advisory reads, no lifecycle-write)
+            // assembled roster DTO + one agent's mailbox mirror + the whoami identity-bootstrap —
+            // advisory reads, no lifecycle-write)
             // + the single write verb (composeOperatorMessage — payload only, identity never wire-carried)
-            ['composeOperatorMessage', 'configureAgent', 'connectTenant', 'defineAgent', 'fleetActivity', 'fleetMailboxMirror', 'fleetRoster', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'getBootIdentity', 'listAgents', 'listTenants', 'removeAgent', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
+            ['composeOperatorMessage', 'configureAgent', 'connectTenant', 'defineAgent', 'fleetActivity', 'fleetMailboxMirror', 'fleetRoster', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'getBootIdentity', 'listAgents', 'listTenants', 'removeAgent', 'resolveViewerIdentity', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
         );
         expect(FLEET_WIRE_METHODS).toContain('getBootIdentity');   // the read-observe verbs ride the wire; the lifecycle-write restart actuator does NOT (R3)
         expect(FLEET_WIRE_METHODS).toContain('fleetActivity');

--- a/test/playwright/unit/ai/services/fleet/fleetTransport.integration.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetTransport.integration.spec.mjs
@@ -168,6 +168,52 @@ test.describe('fleet transport — full-chain integration (real server + real re
         expect(envelope.error).toContain('not on the control surface')
     });
 
+    test('resolveViewerIdentity (whoami): the stamped viewer round-trips through the authenticated wire; refusal shapes are named, never a fallback identity', async () => {
+        const
+            {default: FleetControlBridge}    = await import('../../../../../../ai/services/fleet/FleetControlBridge.mjs'),
+            {default: RequestContextService} = await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs'),
+            url                              = `http://127.0.0.1:${server.address().port}/fleet`,
+            priorSource                      = FleetControlBridge.viewerIdentitySource;
+
+        // the launch-entry wiring shape: whoami reads the SAME per-request binding the mirror uses
+        FleetControlBridge.viewerIdentitySource = {
+            resolveViewerIdentity: () => RequestContextService.getAgentIdentityNodeId()
+        };
+
+        try {
+            // The bootstrap leg end to end: an authenticated caller with NO identity knowledge asks
+            // whoami; the answer is the TRANSPORT-stamped viewer — the exact @-id the cockpit then
+            // passes back explicitly as the mirror's subjectAgentId.
+            const admitted = await fetch(url, {
+                method : 'POST',
+                headers: {'Content-Type': 'application/json', Authorization: `Bearer ${bearerToken}`},
+                body   : JSON.stringify({method: 'resolveViewerIdentity'})
+            });
+            const {ok, result} = await admitted.json();
+
+            expect(ok).toBe(true);
+            expect(result).toEqual({ok: true, agentIdentityNodeId: '@integration-viewer'});
+
+            // Unbound context (a direct call outside runInContext): named refusal, no fallback.
+            const unbound = FleetControlBridge.resolveViewerIdentity();
+            expect(unbound).toEqual({ok: false, error: 'viewer identity unbound — authenticated ingress required'});
+
+            // Unwired source: the honest source-not-wired refusal.
+            FleetControlBridge.viewerIdentitySource = null;
+            expect(FleetControlBridge.resolveViewerIdentity()).toEqual({ok: false, error: 'fleet viewer identity source not wired'});
+
+            // Unauthenticated: dies at the ingress guard before any method resolution.
+            const denied = await fetch(url, {
+                method : 'POST',
+                headers: {'Content-Type': 'application/json'},
+                body   : JSON.stringify({method: 'resolveViewerIdentity'})
+            });
+            expect(denied.status).toBe(401)
+        } finally {
+            FleetControlBridge.viewerIdentitySource = priorSource
+        }
+    });
+
     test('the mailbox-admission chain: HTTP -> stamped context -> real adapter reads UNDER the transport viewer; a smuggled viewer is refused through the wire', async () => {
         const url = `http://127.0.0.1:${server.address().port}/fleet`;
 


### PR DESCRIPTION
Resolves #15412

The whoami verb closes the circular bootstrap Grace source-verified: the mirror's explicit-subject contract refuses omission by design, but `admission.viewerIdentity` only arrives IN a read result — so the cockpit could never construct the operator's own `subjectAgentId` for the FIRST own-inbox read. `resolveViewerIdentity` returns the SERVER-stamped viewer from the authenticated request context (the exact per-request binding the mirror source reads), and the cockpit passes it back EXPLICITLY as the subject — the anti-fork contract's missing first leg, not a self-default.

Evidence: L2 achieved (real-server integration: the stamped viewer round-trips through the authenticated wire; both refusal shapes exact-matched; 401 pre-method for unauthenticated) → L3 required (AC3 #15412 — the end-to-end consumer witness: whoami → explicit subjectAgentId → own-inbox read with admission.viewerIdentity matching). Residual: AC3 #15412 [L3-deferred — operator handoff needed]; owner: #15377 (Grace), post-merge.

## Deltas from ticket
None substantive — the ticket's shape shipped verbatim (seam-injected source per the mirror pattern; the verb never imports the request context).

## Test Evidence
- fleet unit + integration suites: 320/320 green. New witnesses: the allowlist conscious-pin (sorted-list equality), the dispatch route test (whoami is pane-callable), and the full-chain integration — authenticated round-trip returns `{ok: true, agentIdentityNodeId: '@integration-viewer'}`; unbound context → `viewer identity unbound — authenticated ingress required`; unwired source → `fleet viewer identity source not wired`; unauthenticated → 401 at the guard.

## Post-Merge Validation
- [ ] #15377's boot trigger wires against the verb (Grace, confirmed shape eb9fde10) — whoami → explicit `subjectAgentId` → own-inbox mirror read with `admission.viewerIdentity` matching.

## Commits
- `6d919cf9cc` — the verb, the seam, the launch wiring, the witnesses.

Authored by Clio (Claude Fable 5, Claude Code). Session abce4d75-7dcb-4145-8afc-b0ff2cdc51e6.
