### PR TITLE
fix(ai): read-path repairs a broadcast whose whole DELIVERED_TO cohort was lost (#15369)

### DIFF
--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -868,11 +868,19 @@ function getCachedMessageProjectionIssues(messageId) {
 }
 
 /**
- * @summary Checks whether projected WAL count exceeds required graph projection counts.
+ * @summary Checks whether the graph projection is damaged relative to the projected WAL count OR a
+ * broadcast has lost its whole delivery cohort — the mailbox read-path guard.
  *
- * This is the mailbox read-path guard: healthy reads use cheap SQLite counts plus the compact
- * graph-marker index and avoid parsing accepted message WAL records. A mismatch means the graph
- * projection may be damaged, so callers should run the full WAL-backed repair path.
+ * Healthy reads use cheap SQLite counts plus the compact graph-marker index and avoid parsing
+ * accepted message WAL records. A mismatch means the graph projection may be damaged, so callers
+ * should run the full WAL-backed repair path.
+ *
+ * Two damage classes are detected. (1) The count trio (MESSAGE / SENT_BY / SENT_TO falling below
+ * projectedCount) catches a lost message or send-edge. (2) The broadcast-cohort term catches a
+ * `SENT_TO → AGENT:*` broadcast whose entire per-recipient `DELIVERED_TO` cohort was lost — invisible
+ * to the trio because the MESSAGE node, SENT_BY, and SENT_TO all survive, so all three counts still
+ * match projectedCount. Without term (2) a pure read (list/count with no prior mark) of such a
+ * broadcast never self-heals, since the read routes through this gate.
  *
  * @returns {Promise<Boolean>}
  * @private
@@ -890,12 +898,24 @@ async function hasMailboxGraphProjectionGap() {
         SELECT
             (SELECT COUNT(*) FROM Nodes WHERE id LIKE 'MESSAGE:%' AND json_extract(data, '$.label') = 'MESSAGE') AS messageCount,
             (SELECT COUNT(DISTINCT source) FROM Edges WHERE source LIKE 'MESSAGE:%' AND type = 'SENT_BY') AS sentByCount,
-            (SELECT COUNT(DISTINCT source) FROM Edges WHERE source LIKE 'MESSAGE:%' AND type = 'SENT_TO') AS sentToCount
+            (SELECT COUNT(DISTINCT source) FROM Edges WHERE source LIKE 'MESSAGE:%' AND type = 'SENT_TO') AS sentToCount,
+            (SELECT COUNT(*) FROM Edges b
+                 WHERE b.source LIKE 'MESSAGE:%' AND b.type = 'SENT_TO' AND b.target = 'AGENT:*'
+                   AND NOT EXISTS (SELECT 1 FROM Edges d WHERE d.source = b.source AND d.type = 'DELIVERED_TO')) AS brokenBroadcastCount
     `).get();
 
+    // The first three are count-vs-projectedCount comparisons. The broadcast cohort term is
+    // DELIBERATELY an absolute `> 0`, NOT `deliveredToCount < projectedCount`: projectedCount counts
+    // ALL messages while the delivery-cohort spans broadcasts only, so a single DM would make a
+    // `< projectedCount` term permanently true and force a full WAL scan on every list. This term
+    // instead asks the precise question — a broadcast (`SENT_TO → AGENT:*`) that lost its WHOLE
+    // per-recipient delivery cohort (zero `DELIVERED_TO` rows) — which the count trio cannot see
+    // (its MESSAGE / SENT_BY / SENT_TO all still match projectedCount), so a pure read of it never
+    // self-healed until now.
     return (row?.messageCount ?? 0) < projectedCount ||
         (row?.sentByCount ?? 0) < projectedCount ||
-        (row?.sentToCount ?? 0) < projectedCount;
+        (row?.sentToCount ?? 0) < projectedCount ||
+        (row?.brokenBroadcastCount ?? 0) > 0;
 }
 
 /**

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -425,6 +425,80 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(repairCheck).toMatchObject({scanned: 1, intact: 1, repaired: 0, failed: 0});
     });
 
+    test('listMessages repairs a broadcast whose WHOLE DELIVERED_TO cohort was lost — read-path, no prior mark (#15369)', async () => {
+        // @bob authorizes @alice; @alice broadcasts to AGENT:* (bob is in the send-time audience).
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const res = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            return await MailboxService.addMessage({to: 'AGENT:*', subject: 'cohort loss', body: 'durable broadcast'});
+        });
+
+        // WAL truth is committed BEFORE we damage the projection — the repair source is real.
+        expect(await readPendingMessageWalRecords({dir: messageWalDir, ids: [res.messageId]})).toHaveLength(0);
+
+        // TOTAL cohort loss: strip every DELIVERED_TO edge (cache AND storage) while the MESSAGE node,
+        // SENT_BY, and SENT_TO → AGENT:* all survive. The count trio (MESSAGE/SENT_BY/SENT_TO) therefore
+        // still matches projectedCount, so the pre-fix gate is BLIND — this is the exact silent damage
+        // class the read-gate could not see, and the only signal is the zero-DELIVERED_TO broadcast term.
+        const removed = damageEdgeProjection(res.messageId, 'DELIVERED_TO');
+        expect(removed, 'the broadcast must have had a delivery cohort to lose').toBeGreaterThan(0);
+        expect(
+            GraphService.db.storage.db.prepare("SELECT COUNT(*) AS c FROM Edges WHERE source = ? AND type = 'DELIVERED_TO'").get(res.messageId).c,
+            'storage cohort is truly gone — not a cache-only eviction that self-heals on reload'
+        ).toBe(0);
+
+        // The read path, NO prior mark: a recipient LISTS. The message stays visible via the surviving
+        // SENT_TO → AGENT:* sentinel, so the loss is silent — but the per-recipient DELIVERED_TO cohort
+        // (delivery + read-state) is gone. Pre-fix the blind gate early-returns at scanned:0, so the list
+        // leaves the cohort broken; post-fix the broadcast-cohort term flips the gate and the WAL-backed
+        // repair rebuilds it during the read.
+        const bobInbox = await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            return await MailboxService.listMessages({status: 'all'});
+        });
+        expect(bobInbox.messages.map(message => message.messageId)).toContain(res.messageId);
+
+        // THE discriminating assertion (red-proof confirmed by disabling the new term): a follow-up
+        // integrity scan finds the cohort already rebuilt by the read. Without the fix the list never
+        // repairs, so this scan reports `repaired: 1` — the exact never-self-heals defect this closes.
+        const repairCheck = await MailboxService.repairMessageGraphIntegrity({ids: [res.messageId]});
+        expect(repairCheck).toMatchObject({scanned: 1, intact: 1, repaired: 0, failed: 0});
+    });
+
+    test('a healthy DB of a DM + an INTACT broadcast reports no gap — the fix does NOT false-positive on DMs (#15369)', async () => {
+        // The trap the fix must avoid (flagged by @neo-opus-ada): `deliveredToCount < projectedCount`
+        // false-positives on any DM, forcing a full WAL scan every list. The precise term (a broadcast
+        // with ZERO delivery rows) must leave a healthy tree — DM + intact broadcast — reporting no gap.
+        // Instrument (the unrelated-WAL-segment pattern): a directory where a WAL segment file is expected makes any
+        // spurious WAL scan throw; a healthy read that never scans reads clean past it.
+        await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+            await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});
+        });
+
+        const dm = await RequestContextService.run({agentIdentityNodeId: '@alice'}, async () => {
+            const direct = await MailboxService.addMessage({to: '@bob', subject: 'a direct message', body: 'dm body'});
+            await MailboxService.addMessage({to: 'AGENT:*', subject: 'an intact broadcast', body: 'bcast body'});
+            return direct
+        });
+
+        const bogusSegment = path.join(messageWalDir, 'message-wal-2001-01-01.jsonl');
+        fs.ensureDirSync(bogusSegment);
+
+        try {
+            // no damage: the gap gate must be FALSE (no zero-delivery broadcast; the DM must not drag a
+            // count term below projectedCount), so the read never scans WAL and never touches the bogus dir.
+            const bobInbox = await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
+                return await MailboxService.listMessages({status: 'all'});
+            });
+
+            // both messages visible, and the read completed WITHOUT choking on the bogus segment
+            expect(bobInbox.messages.map(message => message.messageId)).toContain(dm.messageId)
+        } finally {
+            fs.removeSync(bogusSegment);
+        }
+    });
+
     test('healthy reads and targeted getMessage repair do not open unrelated WAL segments (#14426)', async () => {
         await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
             await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });


### PR DESCRIPTION
Resolves #15369
Related: #15322, #15357

## Premise

The **read-path** half of #15322 (scoped out at PR #15357 RA-3, with @neo-opus-ada's root-cause). `listMessages` / `countMessages` do not repair a broadcast whose entire `DELIVERED_TO` cohort was lost, because the gate that triggers view-scoped repair cannot see the loss.

## The gap

`hasMailboxGraphProjectionGap` compared `messageCount` / `sentByCount` / `sentToCount` against the WAL `projectedCount` — **no `DELIVERED_TO` term**. A broadcast that lost its whole per-recipient delivery cohort still has its `MESSAGE` node, its `SENT_BY`, and its `SENT_TO → AGENT:*`, so all three counts match `projectedCount`, the gate returns `false`, and the view-scoped repair early-returns at `scanned: 0`. A pure read (list/count with **no prior mark**) never self-heals it — #15322's mark-path fix only covers the case where *someone marks*.

## The fix — avoiding the trap

Add the precise term — a `SENT_TO → AGENT:*` broadcast with **zero** `DELIVERED_TO` rows — as an absolute `> 0`, **not** `deliveredToCount < projectedCount`. `projectedCount` counts *all* messages while the delivery cohort spans broadcasts only, so a `< projectedCount` term would false-positive on any single DM and force a full WAL scan on every list (the derived-not-measured trap @neo-opus-ada flagged).

```sql
(SELECT COUNT(*) FROM Edges b
   WHERE b.source LIKE 'MESSAGE:%' AND b.type = 'SENT_TO' AND b.target = 'AGENT:*'
     AND NOT EXISTS (SELECT 1 FROM Edges d WHERE d.source = b.source AND d.type = 'DELIVERED_TO')) AS brokenBroadcastCount
```

**Out of scope** (surfaced, not bundled): *partial* cohort loss — currently throws `Unauthorized` (loud, not silent), a different disposition @neo-opus-ada scoped out.

## Deltas

| Area | Before | After |
|---|---|---|
| Total-cohort-loss detection | invisible — MESSAGE/SENT_BY/SENT_TO all match projectedCount, gate returns false | the zero-`DELIVERED_TO` broadcast term flips the gate true → list/count repair it |
| Trap avoided | — | absolute `> 0`, never `deliveredToCount < projectedCount` (no DM false-positive, no per-list WAL scan) |
| Read-path self-heal (no prior mark) | never — routes through the blind gate | the read rebuilds the cohort from the WAL |

## Test Evidence

`test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` — **120 passed** locally (2 new + 118 existing, no regression).

**Red-proven — observed, not assumed:** disabling the `brokenBroadcastCount` term turns the read-path test RED — `repairMessageGraphIntegrity` reports `repaired: 1` (the list never healed the cohort); with the term it reports `repaired: 0` (the read rebuilt it). Two witnesses:
- a recipient LISTS a total-cohort-damaged broadcast with no prior mark → the read repairs the cohort. Storage-level damage (the #15322 instrument) so it cannot self-heal before the probe.
- a healthy DB (a DM + an INTACT broadcast) reports **no gap** → no spurious per-list WAL scan (the unrelated-WAL-segment instrument: a spurious scan would choke on a directory placed where a segment file is expected).

Evidence: L2 (unit battery + observed red-proof). CI remains the oracle for this spec class (the local `Neo.ai.Config` collision, #15364 — though this file ran clean in isolation here).

## Post-Merge Validation

- [ ] Confirm the two new witnesses pass in the CI shard (the collision that historically killed this spec class locally).

## Commits

- the `DELIVERED_TO`-cohort gate term + JSDoc + the two red-proven witnesses.

Authored by Grace (Claude Opus 4.8, Claude Code).
