### PR TITLE
feat(agentos): FM cockpit operator mailbox — compose + operator-scoped inbox (#15377)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1638,7 +1638,13 @@ class FleetCockpit extends Container {
         // {ok:true, agentIdentityNodeId} | {ok:false, error} (source-not-wired | unbound). Only a proven
         // identity seeds the subject; a refusal never reads a wrong inbox.
         if (outcome?.ok && outcome.agentIdentityNodeId && !me.isDestroyed) {
-            me.operatorRecord = {agentIdentityNodeId: outcome.agentIdentityNodeId};
+            const nodeId = outcome.agentIdentityNodeId;
+            // the reused MailboxPane proves possession from `record.githubUsername` — it canonicalizes it
+            // to `@<username>` and matches the mirror admission's `subjectAgentId`. Seeding only the node
+            // id fails that guard closed and the own inbox NEVER renders. The resolved node id IS the
+            // `@`-form authority, so carry both: `githubUsername` for the possession match, the node id as
+            // the explicit read subject (they canonicalize to the same value).
+            me.operatorRecord = {agentIdentityNodeId: nodeId, githubUsername: nodeId.replace(/^@/, '')};
             // a materialized pane picks up the identity live and reads; an autoHidden one materializes from
             // the held record on reveal
             me.getReference('operator-mailbox')?.set({record: me.operatorRecord})

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -562,6 +562,7 @@ class FleetCockpit extends Container {
 
         me.loadActivity();
         me.loadRoster();
+        me.loadOperatorIdentity();
         me.startLiveness()
     }
 
@@ -1609,6 +1610,39 @@ class FleetCockpit extends Container {
         }
 
         return outcome
+    }
+
+    /**
+     * @summary BOOT: resolve the operator's OWN identity from the authenticated bridge (whoami) and hold it
+     * owner-side so the operator-mailbox pane can read its own inbox — the missing bootstrap leg of "the
+     * client SAYS self, the admission stamp proves it". The mirror read requires an EXPLICIT subjectAgentId
+     * (never a viewer-default — a self-default at a trust boundary is spoof-adjacent), so the cockpit first
+     * learns its own @-id via `resolveViewerIdentity`, then the pane passes it and the mirror's admission
+     * re-stamps + proves it. Pushing the record to a materialized pane drives its first read (the pane fires
+     * `inboxPageRequest` on a newly-bound identity); an autoHidden pane materializes from the held record on
+     * reveal. Fail-closed: an unwired source / unbound context / absent bridge leaves `operatorRecord` null,
+     * so the pane stays honestly unobserved — never a fabricated or fallback identity.
+     * @protected
+     */
+    async loadOperatorIdentity() {
+        const
+            me     = this,
+            bridge = globalThis.AgentOS?.fleet?.registryBridge;
+
+        if (typeof bridge?.resolveViewerIdentity !== 'function') {
+            return
+        }
+
+        const outcome = await bridge.resolveViewerIdentity();
+
+        // {ok:true, agentIdentityNodeId} | {ok:false, error} (source-not-wired | unbound). Only a proven
+        // identity seeds the subject; a refusal never reads a wrong inbox.
+        if (outcome?.ok && outcome.agentIdentityNodeId && !me.isDestroyed) {
+            me.operatorRecord = {agentIdentityNodeId: outcome.agentIdentityNodeId};
+            // a materialized pane picks up the identity live and reads; an autoHidden one materializes from
+            // the held record on reveal
+            me.getReference('operator-mailbox')?.set({record: me.operatorRecord})
+        }
     }
 
     /**

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -13,6 +13,7 @@ import DockZoneModel            from '../../../../src/dashboard/DockZoneModel.mj
 import FleetCockpitController   from './FleetCockpitController.mjs';
 import FleetGrid                from './FleetGrid.mjs';
 import FleetRoster              from '../../store/FleetRoster.mjs';
+import OperatorMailbox          from './OperatorMailbox.mjs';
 import StateProvider            from '../../../../src/state/Provider.mjs';
 import cockpitDockDocument      from './cockpitDockDocument.mjs';
 import cockpitPresetCollection  from './cockpitPresets.mjs';
@@ -879,6 +880,16 @@ class FleetCockpit extends Container {
                     cls      : [marker],
                     listeners: {agentDefinitionAccepted: 'up.onAgentDefinitionAccepted'},
                     reference: 'add-agent-form'
+                };
+            case 'operator-mailbox':
+                // the operator's own inbox + compose surface. record / snapshot / recipientOptions
+                // are fed by the controller from state it already holds; the live inbox read and the
+                // compose verb are wired to the authenticated ingress + Brain seam as those land —
+                // until then the pane reads its honest unwired state and compose is inert-safe.
+                return {
+                    module   : OperatorMailbox,
+                    cls      : [marker],
+                    reference: 'operator-mailbox'
                 };
             default:
                 // perspectives arrives with its own leaf — an honest labelled placeholder, never a

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -420,6 +420,28 @@ class FleetCockpit extends Container {
      */
     detailRecord = null
     /**
+     * The operator's own identity — OWNER-held, resolved from the viewer the ingress boundary binds
+     * and feeds the operator-mailbox `record` and the own-inbox mirror `subjectAgentId`. `null` =
+     * the pane's honest unwired state until it resolves.
+     * @member {Object|null} operatorRecord=null
+     * @protected
+     */
+    operatorRecord = null
+    /**
+     * The last operator-inbox mailbox-mirror snapshot — OWNER-held so a re-projected operator-mailbox pane
+     * re-materializes at current truth (written by {@link #loadOperatorInbox}). `null` = `unobserved`.
+     * @member {Object|null} operatorSnapshot=null
+     * @protected
+     */
+    operatorSnapshot = null
+    /**
+     * Monotonic read-fence for the operator-inbox mirror reads — a page-request read, a post-compose
+     * re-poll, and an interval tick can be in flight at once; only the newest generation may write.
+     * @member {Number} operatorInboxReadGeneration=0
+     * @protected
+     */
+    operatorInboxReadGeneration = 0
+    /**
      * Detached-detail bookkeeping — `null` while the inspector is docked. While detached it holds
      * `{homeTabsNodeId, homeTabIndex, windowId, windowName, connectTimer}`: the tabs node + EXACT
      * index the reattach restores (`addTab` APPENDS by default — the stored index is the only
@@ -882,14 +904,19 @@ class FleetCockpit extends Container {
                     reference: 'add-agent-form'
                 };
             case 'operator-mailbox':
-                // the operator's own inbox + compose surface. record / snapshot / recipientOptions
-                // are fed by the controller from state it already holds; the live inbox read and the
-                // compose verb are wired to the authenticated ingress + Brain seam as those land —
-                // until then the pane reads its honest unwired state and compose is inert-safe.
+                // the operator's own inbox + compose surface. record / snapshot / recipientOptions are
+                // OWNER-held (materialized from state the cockpit already polls), so a pane returning from
+                // true absence re-materializes at current truth — the {@link #detailRecord} precedent. The
+                // surface is transport-blind: it fires intent-only `compose` / `inboxPageRequest`, routed up
+                // to the controller which holds the bridge (the authenticated ingress + Brain write seam).
                 return {
-                    module   : OperatorMailbox,
-                    cls      : [marker],
-                    reference: 'operator-mailbox'
+                    module          : OperatorMailbox,
+                    cls             : [marker],
+                    record          : me.operatorRecord,
+                    snapshot        : me.operatorSnapshot,
+                    recipientOptions: me.buildOperatorRecipientOptions(),
+                    listeners       : {compose: 'onOperatorCompose', inboxPageRequest: 'onOperatorInboxPageRequest'},
+                    reference       : 'operator-mailbox'
                 };
             default:
                 // perspectives arrives with its own leaf — an honest labelled placeholder, never a
@@ -1532,6 +1559,94 @@ class FleetCockpit extends Container {
             if (generation === me.gridReadGeneration && !me.isDestroyed) {
                 me.syncSpineBanner()
             }
+        }
+    }
+
+    /**
+     * @summary Build the operator-compose recipient options from the LIVE roster — `{id, name}` records
+     * the picker's ChipField store renders. The `id` is the mailbox IDENTITY (`@githubUsername`), NOT the
+     * roster `agentId` (a Fleet key like `vega`), plus the `AGENT:*` broadcast sentinel. Empty until the
+     * roster resolves — the pane picks recipients from a real current fleet, never a hand-mapped list.
+     * @returns {Object[]}
+     */
+    buildOperatorRecipientOptions() {
+        const rows = this.getReference('fleet-grid')?.store?.items ?? [];
+
+        return [
+            {id: 'AGENT:*', name: 'All agents (broadcast)'},
+            ...rows
+                .filter(row => row.githubUsername)
+                .map(row => ({id: `@${row.githubUsername}`, name: row.githubUsername}))
+        ]
+    }
+
+    /**
+     * @summary WRITE: route one operator-composed message to the authenticated `composeOperatorMessage`
+     * verb, then re-poll the operator inbox so the sent message lands at CANONICAL truth — never an
+     * optimistic insert. The cockpit is the composition root that knows the bridge; the sender is
+     * server-stamped from the bound viewer at the authenticated ingress, never carried in this payload.
+     *
+     * Fail-closed: no bridge / no verb → an honest `not-wired` refusal, nothing attempted; a `not-wired`
+     * or rejected outcome re-polls nothing (only a real send changes the inbox).
+     * @param {Object} message `{to, subject, body, priority?, wakeSuppressed?, relatedTickets?}`.
+     * @returns {Promise<Object|undefined>} the verb outcome, for the surface + tests.
+     */
+    async composeOperatorMessage(message) {
+        const
+            me     = this,
+            bridge = globalThis.AgentOS?.fleet?.registryBridge;
+
+        if (typeof bridge?.composeOperatorMessage !== 'function') {
+            return {status: 'not-wired', reason: 'fleet: operator compose verb not wired'}
+        }
+
+        const outcome = await bridge.composeOperatorMessage(message);
+
+        // a real send (a messageId came back) re-polls the inbox so the sent row appears at canonical
+        // truth; a not-wired / rejected outcome changed nothing, so there is nothing to re-read
+        if (outcome?.messageId) {
+            await me.loadOperatorInbox({offset: 0})
+        }
+
+        return outcome
+    }
+
+    /**
+     * @summary READ-OBSERVE: re-read the OPERATOR's own mailbox mirror at `offset` and route the snapshot
+     * to the operator-mailbox pane — the own-inbox twin of {@link AgentOS.view.fleet.AgentDetail#loadMailboxMirror}.
+     * Generation-fenced (older news never overwrites newer) and fail-closed (the pane stays honestly
+     * unobserved rather than inventing a snapshot). The viewer is server-resolved from the ingress request
+     * context; the subject is the operator's own identity, held owner-side.
+     * @param {Object} [params]
+     * @param {Number} [params.offset=0]
+     * @protected
+     */
+    async loadOperatorInbox({offset = 0} = {}) {
+        const
+            me      = this,
+            pane    = me.getReference('operator-mailbox'),
+            bridge  = globalThis.AgentOS?.fleet?.registryBridge,
+            subject = me.operatorRecord?.agentIdentityNodeId;
+
+        const generation = ++me.operatorInboxReadGeneration;
+
+        if (!pane || !subject || typeof bridge?.fleetMailboxMirror !== 'function') {
+            // no bound identity / no bridge / no verb IS the honest unobserved truth — never a fabricated
+            // snapshot; the pane's own `unobserved` state stands until a real read lands
+            return
+        }
+
+        try {
+            const snapshot = await bridge.fleetMailboxMirror({subjectAgentId: subject, offset});
+
+            // the fence: an interval re-poll or a post-compose re-read can race a page-request read; the
+            // loser must not write staler news over newer, and a read outliving its owner has no pane to speak for
+            if (generation === me.operatorInboxReadGeneration && !me.isDestroyed) {
+                me.operatorSnapshot = snapshot;
+                pane.snapshot       = snapshot
+            }
+        } catch (error) {
+            // fail-closed: the last-known snapshot stays; the pane never renders "no mail" for a read that did not happen
         }
     }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1583,33 +1583,61 @@ class FleetCockpit extends Container {
 
     /**
      * @summary WRITE: route one operator-composed message to the authenticated `composeOperatorMessage`
-     * verb, then re-poll the operator inbox so the sent message lands at CANONICAL truth — never an
-     * optimistic insert. The cockpit is the composition root that knows the bridge; the sender is
-     * server-stamped from the bound viewer at the authenticated ingress, never carried in this payload.
+     * verb — one, several, or the `AGENT:*` broadcast — then re-poll the operator inbox so the sent
+     * rows land at CANONICAL truth, never an optimistic insert. The cockpit is the composition root
+     * that knows the bridge; the sender is server-stamped from the bound viewer at the authenticated
+     * ingress, never carried in this payload.
      *
-     * Fail-closed: no bridge / no verb → an honest `not-wired` refusal, nothing attempted; a `not-wired`
-     * or rejected outcome re-polls nothing (only a real send changes the inbox).
-     * @param {Object} message `{to, subject, body, priority?, wakeSuppressed?, relatedTickets?}`.
-     * @returns {Promise<Object|undefined>} the verb outcome, for the surface + tests.
+     * **The verb is one-target, so SEVERAL named recipients fan out.** The compose surface emits `to`
+     * as a list; the authenticated verb accepts one `@login` or the `AGENT:*` sentinel per call, so
+     * each named recipient is a separate authenticated call and carries its OWN outcome — an operator
+     * steering three peers learns each landed (or refused) independently, never one aggregate verdict.
+     * `AGENT:*` stays a single call (the server expands the broadcast from the one sentinel target); a
+     * scalar `to` stays one call (back-compatible).
+     *
+     * Fail-closed: no bridge / no verb → an honest per-recipient `not-wired` refusal, nothing attempted;
+     * a thrown bridge promise is caught as that recipient's `error` outcome, never a detached rejection.
+     * The inbox re-polls exactly ONCE for the batch, and only when a real send landed (a `messageId`
+     * came back) — not-wired / rejected / error changed nothing.
+     * @param {Object} message `{to, subject, body, priority?, wakeSuppressed?, relatedTickets?}` — `to`
+     *     is one `@login` / `AGENT:*`, or a list of them.
+     * @returns {Promise<Object>} `{results: [{to, outcome}]}` — one entry per target, in order, each
+     *     outcome the verb's own (`{messageId, …}` sent | `{status:'not-wired'|'rejected'|'error', …}`).
      */
     async composeOperatorMessage(message) {
         const
-            me     = this,
-            bridge = globalThis.AgentOS?.fleet?.registryBridge;
+            me      = this,
+            bridge  = globalThis.AgentOS?.fleet?.registryBridge,
+            targets = Array.isArray(message.to) ? message.to : (message.to == null ? [] : [message.to]),
+            wired   = typeof bridge?.composeOperatorMessage === 'function',
+            results = [];
 
-        if (typeof bridge?.composeOperatorMessage !== 'function') {
-            return {status: 'not-wired', reason: 'fleet: operator compose verb not wired'}
+        for (const to of targets) {
+            if (!wired) {
+                results.push({to, outcome: {status: 'not-wired', reason: 'fleet: operator compose verb not wired'}});
+                continue
+            }
+
+            let outcome;
+
+            try {
+                // one target per call; the spread never mutates the caller's payload and never carries
+                // the list — and the sender is server-stamped, never a field here
+                outcome = await bridge.composeOperatorMessage({...message, to})
+            } catch (error) {
+                outcome = {status: 'error', reason: error?.message || 'compose failed'}
+            }
+
+            results.push({to, outcome})
         }
 
-        const outcome = await bridge.composeOperatorMessage(message);
-
-        // a real send (a messageId came back) re-polls the inbox so the sent row appears at canonical
-        // truth; a not-wired / rejected outcome changed nothing, so there is nothing to re-read
-        if (outcome?.messageId) {
+        // a real send anywhere (a messageId came back) re-polls the inbox ONCE so the sent rows land at
+        // canonical truth; not-wired / rejected / error changed nothing, so there is nothing to re-read
+        if (results.some(result => result.outcome?.messageId)) {
             await me.loadOperatorInbox({offset: 0})
         }
 
-        return outcome
+        return {results}
     }
 
     /**

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -195,10 +195,21 @@ class FleetCockpitController extends Controller {
      * the authenticated `composeOperatorMessage` verb — the sender is server-stamped from the bound viewer,
      * never wire-carried — and re-polls the operator inbox so a sent message lands at canonical truth,
      * never an optimistic insert.
+     * **Closing the outcome loop.** The surface fires `compose` intent-only and `Observable.fire` discards
+     * handler returns, so the fan-out's per-recipient result cannot flow back off the event. Instead the
+     * settled outcome is written back as owner-state onto the operator-mailbox surface, which relays it to
+     * the compose form to render — so a refusal / failure is never invisible (the review's P1).
      * @param {Object} data The `compose` payload `{message, source}` — Neo stamps `source`.
      */
-    onOperatorCompose(data) {
-        return this.component.composeOperatorMessage(data.message)
+    async onOperatorCompose(data) {
+        const
+            me      = this,
+            outcome = await me.component.composeOperatorMessage(data.message),
+            mailbox = me.component.getReference('operator-mailbox');
+
+        mailbox && (mailbox.composeOutcome = outcome);
+
+        return outcome
     }
 
     /**

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -186,6 +186,32 @@ class FleetCockpitController extends Controller {
     }
 
     /**
+     * @summary Relay the operator-mailbox compose intent to the fleet write verb — the operator-steering
+     * seam, symmetric with {@link #onAgentLifecycleIntent}.
+     *
+     * The operator-mailbox surface fires `compose {message}` intent-only (it holds no transport, like the
+     * cards); the cockpit is the composition root that knows the bridge. It hands the message to the
+     * cockpit's {@link AgentOS.view.fleet.FleetCockpit#composeOperatorMessage} write, which routes it to
+     * the authenticated `composeOperatorMessage` verb — the sender is server-stamped from the bound viewer,
+     * never wire-carried — and re-polls the operator inbox so a sent message lands at canonical truth,
+     * never an optimistic insert.
+     * @param {Object} data The `compose` payload `{message, source}` — Neo stamps `source`.
+     */
+    onOperatorCompose(data) {
+        return this.component.composeOperatorMessage(data.message)
+    }
+
+    /**
+     * @summary Relay the operator-mailbox paged re-read to the cockpit's own-inbox mirror read — the
+     * read-seam split mirroring {@link #onAgentSelect}'s detail drill: the surface fires the intent, the
+     * composition root holds the bridge and re-reads the operator mirror at the requested offset.
+     * @param {Object} data The `inboxPageRequest` payload `{offset, source}`.
+     */
+    onOperatorInboxPageRequest(data) {
+        return this.component.loadOperatorInbox({offset: data.offset})
+    }
+
+    /**
      * @summary Re-poll the roster once a lifecycle intent has genuinely changed runtime state.
      *
      * `loadRoster` is the ONLY path that maps live runtime truth onto the roster records, and the

--- a/apps/agentos/view/fleet/OperatorComposeForm.mjs
+++ b/apps/agentos/view/fleet/OperatorComposeForm.mjs
@@ -114,8 +114,10 @@ class OperatorComposeForm extends FormContainer {
             name         : 'priority',
             labelText    : 'Priority',
             labelPosition: 'top',
-            // the transport's own priority vocabulary; normal is the honest default
-            value         : 'normal',
+            // the transport's own priority vocabulary; HIGH is the default (AC-7): operator steering
+            // ranks first at the recipient's turn-start drain — paired with wake-off below it reads
+            // "top of your queue when you next look, but I won't interrupt you now"
+            value         : 'high',
             forceSelection: true,
             store         : {
                 data: [
@@ -179,7 +181,7 @@ class OperatorComposeForm extends FormContainer {
                 to            : values.to,
                 subject       : values.subject,
                 body          : values.body,
-                priority      : values.priority || 'normal',
+                priority      : values.priority || 'high',
                 wakeSuppressed: !values.wake
             }
         })

--- a/apps/agentos/view/fleet/OperatorComposeForm.mjs
+++ b/apps/agentos/view/fleet/OperatorComposeForm.mjs
@@ -65,6 +65,16 @@ class OperatorComposeForm extends FormContainer {
          */
         recipientOptions_: [],
         /**
+         * The send outcome, written back by the owning cockpit once the compose verb settles (this form
+         * fires the intent and holds no transport, so the RESULT returns as owner-set state, never off the
+         * fire-and-forget event): `null` = nothing sent yet, `{status:'pending', count}` while the fan-out
+         * is in flight, or `{results:[{to, outcome}]}` — one honest per-recipient verdict (sent / not-wired
+         * / rejected / error). Rendered so a refusal is never invisible.
+         * @member {Object|null} composeOutcome_=null
+         * @reactive
+         */
+        composeOutcome_: null,
+        /**
          * @member {Object} layout={ntype:'vbox',align:'stretch'}
          * @reactive
          */
@@ -164,6 +174,13 @@ class OperatorComposeForm extends FormContainer {
                 ui       : 'ghost',
                 handler  : 'up.onSendClick'
             }]
+        }, {
+            // the send-outcome surface — per-recipient verdicts land here so a refusal/failure is never
+            // silent; empty until the owner writes `composeOutcome` back (see afterSetComposeOutcome)
+            ntype    : 'component',
+            reference: 'compose-outcome',
+            cls      : ['fm-operator-compose-outcome'],
+            flex     : 'none'
         }]
     }
 
@@ -196,6 +213,9 @@ class OperatorComposeForm extends FormContainer {
 
         const values = await me.getSubmitValues();
 
+        // the honest "in flight" state — shown until the owner writes the settled per-recipient outcome back
+        me.composeOutcome = {status: 'pending', count: to.length};
+
         // The intent, in transport-natural shape. `to` is the ARRAY of chosen recipients — the owning
         // cockpit fans out one authenticated call per named target (AGENT:* is one server-expanded call).
         // `wakeSuppressed` is the transport's field, the INVERSE of the operator's "wake now" choice: wake
@@ -226,6 +246,58 @@ class OperatorComposeForm extends FormContainer {
         // feed the live roster into the multi-select list's own store, so an already-materialized picker
         // stays current across roster load / reconciliation (never snapshotted once at creation)
         list?.store && (list.store.data = value)
+    }
+
+    /**
+     * Triggered after the send outcome changed — render the per-recipient verdicts (or the pending line,
+     * or clear). The owner writes this once the compose verb settles; it is the ONLY place a refusal /
+     * failure becomes visible, since the form fires the send intent-only and never sees the promise itself.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetComposeOutcome(value, oldValue) {
+        if (!this.isConstructed) return;
+
+        const outcome = this.getReference('compose-outcome');
+
+        if (outcome) {
+            outcome.vdom.cn = this.buildOutcomeRows(value);
+            outcome.update()
+        }
+    }
+
+    /**
+     * @summary Build the outcome vdom rows: none when idle, one pending line while the fan-out is in flight,
+     * or one line PER recipient carrying its own verdict — sent (a messageId came back), not-wired, rejected,
+     * or error — each with a status class the skin colors. The several-recipient path renders several rows,
+     * so a partial batch (one sent, one refused) is shown honestly, never collapsed to a single verdict.
+     * @param {Object|null} value
+     * @returns {Object[]}
+     * @protected
+     */
+    buildOutcomeRows(value) {
+        if (!value) return [];
+
+        if (value.status === 'pending') {
+            return [{cls: ['fm-compose-outcome-row', 'is-pending'], text: `Sending to ${value.count}…`}]
+        }
+
+        return (value.results || []).map(({to, outcome}) => {
+            let cls = ['fm-compose-outcome-row'], text;
+
+            if (outcome?.messageId) {
+                cls.push('is-sent');    text = `${to} — sent`
+            } else if (outcome?.status === 'not-wired') {
+                cls.push('is-refused'); text = `${to} — not wired`
+            } else if (outcome?.status === 'rejected') {
+                cls.push('is-refused'); text = `${to} — ${outcome.reason || 'rejected'}`
+            } else {
+                cls.push('is-error');   text = `${to} — ${outcome?.reason || 'failed'}`
+            }
+
+            return {cls, text}
+        })
     }
 }
 

--- a/apps/agentos/view/fleet/OperatorComposeForm.mjs
+++ b/apps/agentos/view/fleet/OperatorComposeForm.mjs
@@ -1,7 +1,8 @@
-import ChipField     from '../../../../src/form/field/Chip.mjs';
 import ComboBoxField from '../../../../src/form/field/ComboBox.mjs';
 import FormContainer from '../../../../src/form/Container.mjs';
 import Button        from '../../../../src/button/Base.mjs';
+import Label         from '../../../../src/component/Label.mjs';
+import List          from '../../../../src/list/Base.mjs';
 import Store         from '../../../../src/data/Store.mjs';
 import SwitchField   from '../../../../src/form/field/Switch.mjs';
 import TextField     from '../../../../src/form/field/Text.mjs';
@@ -25,11 +26,12 @@ import TextAreaField from '../../../../src/form/field/TextArea.mjs';
  * contract, wake is the operator's explicit opt-in. So `wake` is a `Switch` **defaulting to off** —
  * the durable-quiet default the operator named preferred — never a class-forced always-wake.
  *
- * **Recipients** compose a `Chip` field: named peers (one or several) or the `AGENT:*` broadcast
- * sentinel, entered as canonical `@`-form / the sentinel. The picker is a real field, never a
- * hand-rolled tag input (`button.Base`/field discipline — the primitive supplies the states a raw
- * tag lacks). Broadcast and named recipients share one field because the transport's `to` already
- * unifies them; the controller splits per-recipient only if the verb requires it.
+ * **Recipients** are a real multi-select {@link Neo.list.Base} (`singleSelect:false`) over the roster
+ * store: named peers (one or several) or the `AGENT:*` broadcast row, each a canonical `@`-form / the
+ * sentinel. A genuine multi-select is load-bearing — the single-select `ComboBox`/`Chip` primitive
+ * collapses its value to one scalar (`getSelection()[0]`) and cannot express "several peers", so the
+ * shipped `singleSelect:false` selection model is the one that can. `to` is read as the ARRAY of
+ * selected ids, and the owning cockpit fans out per recipient (the compose verb is one-target).
  *
  * The form owns no `state.Provider` (a leaf form scoped by the cockpit above it) and no `data.Store`
  * of its own — recipient *options* are supplied by the owning cockpit from the live roster it already
@@ -71,27 +73,37 @@ class OperatorComposeForm extends FormContainer {
          * @member {Object[]} items
          */
         items: [{
-            module       : ChipField,
-            reference    : 'compose-recipients',
-            name         : 'to',
-            labelText    : 'To',
-            labelPosition: 'top',
-            displayField : 'name',
-            valueField   : 'id',
-            // named peers and AGENT:* share one field: the transport's `to` already unifies them
-            placeholderText: 'Named peer(s) or AGENT:* — durable delivery to each',
-            // a real data.Store of {id: canonical-@-form, name: display} records, fed by the owning
-            // cockpit's live roster via `recipientOptions` — never a hand-mapped plain array (apps/** gate)
-            store: {
-                module: Store,
-                model : {
-                    fields: [
-                        {name: 'id',   type: 'String'},
-                        {name: 'name', type: 'String'}
-                    ]
-                },
-                data: []
-            }
+            ntype : 'container',
+            cls   : ['fm-operator-compose-recipients'],
+            flex  : 'none',
+            layout: {ntype: 'vbox', align: 'stretch'},
+            items : [{
+                module: Label,
+                cls   : ['fm-operator-compose-recipients-label'],
+                text  : 'To'
+            }, {
+                module      : List,
+                reference   : 'compose-recipients',
+                cls         : ['fm-operator-compose-recipients-list'],
+                displayField: 'name',
+                height      : 132,
+                // real multi-select: one, several, or the AGENT:* broadcast row. singleSelect:false is the
+                // shipped multi-select the single-select ComboBox/Chip primitive can't express (its value is
+                // one scalar) — the operator steering several peers at once is the whole point of the surface
+                selectionModel: {ntype: 'selection-listmodel', singleSelect: false},
+                // a real data.Store of {id: canonical-@-form, name: display} records, fed by the owning
+                // cockpit's live roster via `recipientOptions` — never a hand-mapped plain array (apps/** gate)
+                store: {
+                    module: Store,
+                    model : {
+                        fields: [
+                            {name: 'id',   type: 'String'},
+                            {name: 'name', type: 'String'}
+                        ]
+                    },
+                    data: []
+                }
+            }]
         }, {
             module       : TextField,
             reference    : 'compose-subject',
@@ -162,7 +174,20 @@ class OperatorComposeForm extends FormContainer {
      * @protected
      */
     async onSendClick() {
-        let me = this;
+        let me         = this,
+            recipients = me.getReference('compose-recipients'),
+            // the recipient list is a real multi-select (not a form field), so `to` is read from its
+            // selection: each selected item id mapped back to its store record's canonical @-form / sentinel
+            to         = recipients.selectionModel.getSelection()
+                .map(itemId => recipients.store.get(recipients.getItemRecordId(itemId))?.id)
+                .filter(Boolean);
+
+        // require at least one recipient — the list carries no field-level `required`, so this is the gate:
+        // a send with no recipient is refused, never a partial or fabricated message (the visible
+        // recipient-required cue rides the outcome surface, still to land)
+        if (!to.length) {
+            return
+        }
 
         if (!await me.isValid()) {
             me.focusFirstInvalidField?.();
@@ -171,14 +196,14 @@ class OperatorComposeForm extends FormContainer {
 
         const values = await me.getSubmitValues();
 
-        // The intent, in transport-natural shape. `wakeSuppressed` is the transport's field, and it is
-        // the INVERSE of the operator's "wake now" choice: wake off ⇒ suppress the wake, keep it
-        // durable-quiet. The controller maps `to`/`subject`/`body`/`priority`/`wakeSuppressed` onto
-        // the compose verb; sender identity is added server-side, never here.
+        // The intent, in transport-natural shape. `to` is the ARRAY of chosen recipients — the owning
+        // cockpit fans out one authenticated call per named target (AGENT:* is one server-expanded call).
+        // `wakeSuppressed` is the transport's field, the INVERSE of the operator's "wake now" choice: wake
+        // off ⇒ suppress the wake, keep it durable-quiet. Sender identity is added server-side, never here.
         me.fire('compose', {
             source : me,
             message: {
-                to            : values.to,
+                to,
                 subject       : values.subject,
                 body          : values.body,
                 priority      : values.priority || 'high',
@@ -196,9 +221,11 @@ class OperatorComposeForm extends FormContainer {
     afterSetRecipientOptions(value, oldValue) {
         if (!this.isConstructed) return;
 
-        const field = this.getReference('compose-recipients');
+        const list = this.getReference('compose-recipients');
 
-        field?.store && (field.store.data = value)
+        // feed the live roster into the multi-select list's own store, so an already-materialized picker
+        // stays current across roster load / reconciliation (never snapshotted once at creation)
+        list?.store && (list.store.data = value)
     }
 }
 

--- a/apps/agentos/view/fleet/OperatorComposeForm.mjs
+++ b/apps/agentos/view/fleet/OperatorComposeForm.mjs
@@ -1,0 +1,203 @@
+import ChipField     from '../../../../src/form/field/Chip.mjs';
+import ComboBoxField from '../../../../src/form/field/ComboBox.mjs';
+import FormContainer from '../../../../src/form/Container.mjs';
+import Button        from '../../../../src/button/Base.mjs';
+import Store         from '../../../../src/data/Store.mjs';
+import SwitchField   from '../../../../src/form/field/Switch.mjs';
+import TextField     from '../../../../src/form/field/Text.mjs';
+import TextAreaField from '../../../../src/form/field/TextArea.mjs';
+
+/**
+ * The operator's compose surface — the write half of the FM operator mailbox.
+ *
+ * @summary Collects one operator steering message (recipients, subject, body, priority, wake choice)
+ * and fires it as a `compose` **intent event** — it never calls a transport itself.
+ *
+ * **Why an intent event, not a bridge call.** The submit target is the authenticated compose verb
+ * (the Brain half), whose signature is server-owned and still settling. This form fires `compose`
+ * with a natural payload and the cockpit controller maps that intent onto the verb — so the form is
+ * decoupled from the verb contract (a signature change is a mapping edit, not a form rewrite) and,
+ * like `MailboxPane`, it renders + submits but never fetches a service or authors identity: the
+ * sender identity is the authenticated transport's fact end-to-end, never a field on this form.
+ *
+ * **The wake control is the load-bearing AC (operator-stated).** A late wake is noise
+ * arriving after the recipient's turn-start drain already read the message; durability is the
+ * contract, wake is the operator's explicit opt-in. So `wake` is a `Switch` **defaulting to off** —
+ * the durable-quiet default the operator named preferred — never a class-forced always-wake.
+ *
+ * **Recipients** compose a `Chip` field: named peers (one or several) or the `AGENT:*` broadcast
+ * sentinel, entered as canonical `@`-form / the sentinel. The picker is a real field, never a
+ * hand-rolled tag input (`button.Base`/field discipline — the primitive supplies the states a raw
+ * tag lacks). Broadcast and named recipients share one field because the transport's `to` already
+ * unifies them; the controller splits per-recipient only if the verb requires it.
+ *
+ * The form owns no `state.Provider` (a leaf form scoped by the cockpit above it) and no `data.Store`
+ * of its own — recipient *options* are supplied by the owning cockpit from the live roster it already
+ * holds, injected via {@link #recipientOptions}, so this surface never reaches for a roster service.
+ *
+ * @class AgentOS.view.fleet.OperatorComposeForm
+ * @extends Neo.form.Container
+ */
+class OperatorComposeForm extends FormContainer {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.OperatorComposeForm'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.OperatorComposeForm',
+        /**
+         * @member {String} ntype='fm-operator-compose-form'
+         * @protected
+         */
+        ntype: 'fm-operator-compose-form',
+        /**
+         * @member {String[]} baseCls=['fm-operator-compose-form']
+         */
+        baseCls: ['fm-operator-compose-form'],
+        /**
+         * Recipient picker options, supplied by the owning cockpit from the live roster it already
+         * holds (canonical `@`-form identities) plus the `AGENT:*` broadcast sentinel. Injected so
+         * this leaf never reaches for a roster service; empty until wired.
+         * @member {Object[]} recipientOptions_=[]
+         * @reactive
+         */
+        recipientOptions_: [],
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            module       : ChipField,
+            reference    : 'compose-recipients',
+            name         : 'to',
+            labelText    : 'To',
+            labelPosition: 'top',
+            displayField : 'name',
+            valueField   : 'id',
+            // named peers and AGENT:* share one field: the transport's `to` already unifies them
+            placeholderText: 'Named peer(s) or AGENT:* — durable delivery to each',
+            // a real data.Store of {id: canonical-@-form, name: display} records, fed by the owning
+            // cockpit's live roster via `recipientOptions` — never a hand-mapped plain array (apps/** gate)
+            store: {
+                module: Store,
+                model : {
+                    fields: [
+                        {name: 'id',   type: 'String'},
+                        {name: 'name', type: 'String'}
+                    ]
+                },
+                data: []
+            }
+        }, {
+            module       : TextField,
+            reference    : 'compose-subject',
+            name         : 'subject',
+            labelText    : 'Subject',
+            labelPosition: 'top',
+            required     : true,
+            maxLength    : 200
+        }, {
+            module       : TextAreaField,
+            reference    : 'compose-body',
+            name         : 'body',
+            labelText    : 'Message',
+            labelPosition: 'top',
+            required     : true,
+            height       : 160
+        }, {
+            module       : ComboBoxField,
+            reference    : 'compose-priority',
+            name         : 'priority',
+            labelText    : 'Priority',
+            labelPosition: 'top',
+            // the transport's own priority vocabulary; normal is the honest default
+            value         : 'normal',
+            forceSelection: true,
+            store         : {
+                data: [
+                    {id: 'low',    name: 'low'},
+                    {id: 'normal', name: 'normal'},
+                    {id: 'high',   name: 'high'}
+                ]
+            }
+        }, {
+            module       : SwitchField,
+            reference    : 'compose-wake',
+            name         : 'wake',
+            labelText    : 'Wake recipients now',
+            labelPosition: 'top',
+            // AC-7: durable-quiet is the default the operator named preferred; wake is an explicit
+            // opt-in accelerant, never a class-forced always-wake. A message ALWAYS lands durably and
+            // is read at the recipient's turn-start; this only asks whether to also interrupt now.
+            checked      : false
+        }, {
+            ntype : 'container',
+            cls   : ['fm-operator-compose-actions'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{
+                ntype: 'component',
+                flex : 1
+            }, {
+                module   : Button,
+                reference: 'compose-submit',
+                text     : 'Send',
+                iconCls  : 'fa fa-paper-plane',
+                ui       : 'ghost',
+                handler  : 'up.onSendClick'
+            }]
+        }]
+    }
+
+    /**
+     * @summary Gather the validated form values and fire the `compose` intent — the cockpit maps it
+     * onto the compose verb. Refuses on invalid input (the form's own field validation is the gate);
+     * the send button never fabricates a partial message.
+     * @protected
+     */
+    async onSendClick() {
+        let me = this;
+
+        if (!await me.isValid()) {
+            me.focusFirstInvalidField?.();
+            return
+        }
+
+        const values = await me.getSubmitValues();
+
+        // The intent, in transport-natural shape. `wakeSuppressed` is the transport's field, and it is
+        // the INVERSE of the operator's "wake now" choice: wake off ⇒ suppress the wake, keep it
+        // durable-quiet. The controller maps `to`/`subject`/`body`/`priority`/`wakeSuppressed` onto
+        // the compose verb; sender identity is added server-side, never here.
+        me.fire('compose', {
+            source : me,
+            message: {
+                to            : values.to,
+                subject       : values.subject,
+                body          : values.body,
+                priority      : values.priority || 'normal',
+                wakeSuppressed: !values.wake
+            }
+        })
+    }
+
+    /**
+     * Triggered after the recipient options changed — feed them to the picker's own option store.
+     * @param {Object[]} value
+     * @param {Object[]} oldValue
+     * @protected
+     */
+    afterSetRecipientOptions(value, oldValue) {
+        if (!this.isConstructed) return;
+
+        const field = this.getReference('compose-recipients');
+
+        field?.store && (field.store.data = value)
+    }
+}
+
+export default Neo.setupClass(OperatorComposeForm);

--- a/apps/agentos/view/fleet/OperatorMailbox.mjs
+++ b/apps/agentos/view/fleet/OperatorMailbox.mjs
@@ -70,6 +70,14 @@ class OperatorMailbox extends Container {
          */
         recipientOptions_: [],
         /**
+         * The compose send outcome, set by the cockpit once the compose verb settles and passed straight
+         * to the compose form to render (per-recipient sent / not-wired / rejected / error). `null` = idle.
+         * This surface holds no transport — the outcome is owner-written state, never read here.
+         * @member {Object|null} composeOutcome_=null
+         * @reactive
+         */
+        composeOutcome_: null,
+        /**
          * @member {Object} layout={ntype:'vbox',align:'stretch'}
          * @reactive
          */
@@ -159,6 +167,18 @@ class OperatorMailbox extends Container {
      */
     afterSetRecipientOptions(value, oldValue) {
         this.isConstructed && (this.getReference('operator-compose-form').recipientOptions = value)
+    }
+
+    /**
+     * Triggered after the compose outcome changed — passed straight to the compose form, which renders the
+     * per-recipient verdicts. Set by the cockpit once the compose verb settles (this surface holds no
+     * transport; the outcome is owner-written state).
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetComposeOutcome(value, oldValue) {
+        this.isConstructed && (this.getReference('operator-compose-form').composeOutcome = value)
     }
 
     /**

--- a/apps/agentos/view/fleet/OperatorMailbox.mjs
+++ b/apps/agentos/view/fleet/OperatorMailbox.mjs
@@ -103,13 +103,21 @@ class OperatorMailbox extends Container {
     }
 
     /**
-     * Triggered after the operator record changed — the inbox pane's subject follows it.
+     * Triggered after the operator record changed — the inbox pane's subject follows it, and a newly-bound
+     * identity kicks the first own-inbox read. The owner (cockpit) holds the read seam, so this fires the
+     * `inboxPageRequest` relay rather than reading here: a pane materialized after boot — when the operator
+     * identity is already resolved owner-side — lands its inbox without a page gesture, exactly as
+     * {@link AgentOS.view.fleet.AgentDetail} reads on its record.
      * @param {Object|null} value
      * @param {Object|null} oldValue
      * @protected
      */
     afterSetRecord(value, oldValue) {
-        this.isConstructed && (this.getReference('operator-inbox-pane').record = value)
+        if (!this.isConstructed) return;
+
+        this.getReference('operator-inbox-pane').record = value;
+        // a real identity (null → record) triggers the first read; the owner services it against the mirror
+        value && this.onInboxPageRequest({offset: 0})
     }
 
     /**

--- a/apps/agentos/view/fleet/OperatorMailbox.mjs
+++ b/apps/agentos/view/fleet/OperatorMailbox.mjs
@@ -19,11 +19,11 @@ import OperatorComposeForm from './OperatorComposeForm.mjs';
  *
  * **Capability today = the shipped read-only pane.** The pane is read-only by its own MUST-NOT
  * (operator mark-read would mutate an agent's turn-start signal). The operator's OWN inbox is the
- * one place mark-read is legitimate (own-inbox capability) — but that affordance is keyed by the
- * server-stamped viewer↔target relation the projection delivers, so it lands with that half, not
- * here. Until then the operator inbox reads honestly (the pane's four states), and compose is live
- * once the compose verb + the ingress floor are wired: this surface is complete and inert-safe in
- * the interim, never a fake-capable one.
+ * one place mark-read is legitimate (own-inbox capability, keyed by the server-stamped viewer↔target
+ * relation) — but that write verb is NOT wired here, and this surface does not fake it: own-inbox
+ * mark-read is an EXPLICIT deferred acceptance criterion (tracked as remaining ticket work), never
+ * silently claimed as landing elsewhere. What ships is the honest read (the pane's four states) + live
+ * compose with per-recipient outcomes; the surface is complete and inert-safe for what it does not yet do.
  *
  * The container owns no `state.Provider` (the cockpit scopes it) — `record` / `snapshot` /
  * `recipientOptions` are injected by the cockpit from state it already holds, and passed straight

--- a/apps/agentos/view/fleet/OperatorMailbox.mjs
+++ b/apps/agentos/view/fleet/OperatorMailbox.mjs
@@ -90,16 +90,37 @@ class OperatorMailbox extends Container {
     }
 
     /**
-     * @summary Wire the two child intents up to the owner: the inbox's paged re-read and the
-     * compose submit. Wired explicitly (not via a string handler) — like AgentDetail, this surface
-     * carries no controller for one to resolve against.
+     * @summary Wire the two child intents up to the owner AND flush any projection-injected state to the
+     * children. Wired explicitly (not via a string handler) — like AgentDetail, this surface carries no
+     * controller for one to resolve against.
+     *
+     * The flush is load-bearing: `afterSetRecord`/`afterSetSnapshot`/`afterSetRecipientOptions` all return
+     * early while `!isConstructed`, so `record`/`snapshot`/`recipientOptions` supplied as construction
+     * configs (the normal reveal-after-boot path, when the cockpit already holds the resolved operator
+     * identity) never reached the children — the pane materialized empty and could not pass possession.
+     * Flush them here, then a construction-time identity kicks its first read exactly as a live set does.
      * @param {...*} args
      */
     onConstructed(...args) {
         super.onConstructed(...args);
 
-        this.getReference('operator-inbox-pane')?.on('pageRequest', this.onInboxPageRequest, this);
-        this.getReference('operator-compose-form')?.on('compose', this.onCompose, this)
+        const
+            me    = this,
+            inbox = me.getReference('operator-inbox-pane'),
+            form  = me.getReference('operator-compose-form');
+
+        inbox?.on('pageRequest', me.onInboxPageRequest, me);
+        form?.on('compose', me.onCompose, me);
+
+        if (inbox) {
+            me.record   && (inbox.record   = me.record);
+            me.snapshot && (inbox.snapshot = me.snapshot)
+        }
+        form && me.recipientOptions?.length && (form.recipientOptions = me.recipientOptions);
+
+        // a construction-time identity lands its first inbox read without a page gesture (afterSetRecord
+        // was skipped pre-construct, so this is the single fire for the reveal path)
+        me.record && me.onInboxPageRequest({offset: 0})
     }
 
     /**

--- a/apps/agentos/view/fleet/OperatorMailbox.mjs
+++ b/apps/agentos/view/fleet/OperatorMailbox.mjs
@@ -1,0 +1,155 @@
+import Container           from '../../../../src/container/Base.mjs';
+import MailboxPane         from './MailboxPane.mjs';
+import OperatorComposeForm from './OperatorComposeForm.mjs';
+
+/**
+ * The FM cockpit's **operator mailbox** — the operator's own inbox over the compose surface: the
+ * read half the operator asked to steer THROUGH, plus the write half that replaces prompt-only
+ * steering.
+ *
+ * @summary Composes the shipped {@link AgentOS.view.fleet.MailboxPane} (pointed at the operator's
+ * own identity) above {@link AgentOS.view.fleet.OperatorComposeForm}, and RELAYS both surfaces'
+ * intents up to the cockpit — it performs no transport itself.
+ *
+ * **Why a relay, not a doer.** Both children fire intents the OWNER services against the
+ * authenticated seam: the inbox pane fires `pageRequest` (the cockpit re-reads the operator mirror
+ * at the new offset — exactly AgentDetail's read-seam split), and the compose form fires `compose`
+ * (the cockpit maps it onto the compose verb). This surface holds neither the read seam nor the
+ * verb, so it forwards both — keeping identity a transport fact end-to-end, never authored here.
+ *
+ * **Capability today = the shipped read-only pane.** The pane is read-only by its own MUST-NOT
+ * (operator mark-read would mutate an agent's turn-start signal). The operator's OWN inbox is the
+ * one place mark-read is legitimate (own-inbox capability) — but that affordance is keyed by the
+ * server-stamped viewer↔target relation the projection delivers, so it lands with that half, not
+ * here. Until then the operator inbox reads honestly (the pane's four states), and compose is live
+ * once the compose verb + the ingress floor are wired: this surface is complete and inert-safe in
+ * the interim, never a fake-capable one.
+ *
+ * The container owns no `state.Provider` (the cockpit scopes it) — `record` / `snapshot` /
+ * `recipientOptions` are injected by the cockpit from state it already holds, and passed straight
+ * through to the children, so this surface never reaches for a service.
+ *
+ * @class AgentOS.view.fleet.OperatorMailbox
+ * @extends Neo.container.Base
+ */
+class OperatorMailbox extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.OperatorMailbox'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.OperatorMailbox',
+        /**
+         * @member {String} ntype='fm-operator-mailbox'
+         * @protected
+         */
+        ntype: 'fm-operator-mailbox',
+        /**
+         * @member {String[]} baseCls=['fm-operator-mailbox']
+         */
+        baseCls: ['fm-operator-mailbox'],
+        /**
+         * The operator identity record (only `githubUsername` is read — the pane's subject-match
+         * authority); injected by the cockpit. `null` = the inbox's honest unwired state.
+         * @member {Object|null} record_=null
+         * @reactive
+         */
+        record_: null,
+        /**
+         * One Fleet mailbox-mirror snapshot for the OPERATOR's own inbox (server-read via the
+         * authenticated viewer identity); `null` = `unobserved`. Passed straight to the inbox pane.
+         * @member {Object|null} snapshot_=null
+         * @reactive
+         */
+        snapshot_: null,
+        /**
+         * Recipient picker options (`{id, name}`), injected by the cockpit from its live roster and
+         * passed straight to the compose form.
+         * @member {Object[]} recipientOptions_=[]
+         * @reactive
+         */
+        recipientOptions_: [],
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            module   : MailboxPane,
+            flex     : 1,
+            header   : {text: 'Your inbox'},
+            reference: 'operator-inbox-pane'
+        }, {
+            module   : OperatorComposeForm,
+            flex     : 'none',
+            reference: 'operator-compose-form'
+        }]
+    }
+
+    /**
+     * @summary Wire the two child intents up to the owner: the inbox's paged re-read and the
+     * compose submit. Wired explicitly (not via a string handler) — like AgentDetail, this surface
+     * carries no controller for one to resolve against.
+     * @param {...*} args
+     */
+    onConstructed(...args) {
+        super.onConstructed(...args);
+
+        this.getReference('operator-inbox-pane')?.on('pageRequest', this.onInboxPageRequest, this);
+        this.getReference('operator-compose-form')?.on('compose', this.onCompose, this)
+    }
+
+    /**
+     * Triggered after the operator record changed — the inbox pane's subject follows it.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetRecord(value, oldValue) {
+        this.isConstructed && (this.getReference('operator-inbox-pane').record = value)
+    }
+
+    /**
+     * Triggered after the operator inbox snapshot changed — passed straight to the pane.
+     * @param {Object|null} value
+     * @param {Object|null} oldValue
+     * @protected
+     */
+    afterSetSnapshot(value, oldValue) {
+        this.isConstructed && (this.getReference('operator-inbox-pane').snapshot = value)
+    }
+
+    /**
+     * Triggered after the recipient options changed — passed straight to the compose form.
+     * @param {Object[]} value
+     * @param {Object[]} oldValue
+     * @protected
+     */
+    afterSetRecipientOptions(value, oldValue) {
+        this.isConstructed && (this.getReference('operator-compose-form').recipientOptions = value)
+    }
+
+    /**
+     * @summary Relay the inbox's page intent to the owner — the cockpit holds the read seam and
+     * re-reads the operator mirror at the requested offset.
+     * @param {Object} data The pane's `pageRequest` payload (`{offset, source}`).
+     * @protected
+     */
+    onInboxPageRequest(data) {
+        this.fire('inboxPageRequest', {...data, source: this})
+    }
+
+    /**
+     * @summary Relay the compose intent to the owner — the cockpit maps it onto the compose verb.
+     * @param {Object} data The form's `compose` payload (`{message, source}`).
+     * @protected
+     */
+    onCompose(data) {
+        this.fire('compose', {message: data.message, source: this})
+    }
+}
+
+export default Neo.setupClass(OperatorMailbox);

--- a/apps/agentos/view/fleet/cockpitDockDocument.mjs
+++ b/apps/agentos/view/fleet/cockpitDockDocument.mjs
@@ -24,13 +24,16 @@ export function cockpitDockDocument() {
         schema: 'neo.harness.dockZone.v1',
         root  : 'cockpit-root',
         items : {
-            fleet       : {componentRef: 'fleet-grid',      title: 'Fleet',        kind: 'panel'},
-            stream      : {componentRef: 'activity-stream',  title: 'Activity',     kind: 'panel'},
-            detail      : {componentRef: 'agent-detail',     title: 'Agent detail', kind: 'inspector', autoHidden: true},
-            perspectives: {componentRef: 'perspectives',     title: 'Perspectives', kind: 'tool',      autoHidden: true},
+            fleet       : {componentRef: 'fleet-grid',       title: 'Fleet',        kind: 'panel'},
+            stream      : {componentRef: 'activity-stream',   title: 'Activity',     kind: 'panel'},
+            detail      : {componentRef: 'agent-detail',      title: 'Agent detail', kind: 'inspector', autoHidden: true},
+            perspectives: {componentRef: 'perspectives',      title: 'Perspectives', kind: 'tool',      autoHidden: true},
             // S5 define-agent (design ruling on record: rail placement, invoked-not-ambient) —
             // the add-agent flow rides the same autoHidden tool chrome as perspectives
-            defineAgent : {componentRef: 'define-agent',     title: 'Add agent',    kind: 'tool',      autoHidden: true}
+            defineAgent : {componentRef: 'define-agent',      title: 'Add agent',    kind: 'tool',      autoHidden: true},
+            // the operator's own mailbox + compose surface — a secondary tool pane like
+            // perspectives, so it rides the auto-hide rail and never crowds the split
+            operator    : {componentRef: 'operator-mailbox',  title: 'Operator',     kind: 'tool',      autoHidden: true}
         },
         nodes: {
             // Root edge-zone: the primary split in the center, the auto-hidden chrome on the right rail.
@@ -40,7 +43,7 @@ export function cockpitDockDocument() {
             'fleet-tabs'   : {type: 'tabs', items: ['fleet'],  activeItemId: 'fleet'},
             'stream-tabs'  : {type: 'tabs', items: ['stream'], activeItemId: 'stream'},
             // Secondary panes collapse to this edge's rail (§2.7): their item records carry `autoHidden`.
-            'secondary-rail': {type: 'tabs', items: ['detail', 'perspectives', 'defineAgent'], activeItemId: 'detail'}
+            'secondary-rail': {type: 'tabs', items: ['detail', 'perspectives', 'defineAgent', 'operator'], activeItemId: 'detail'}
         }
     }
 }

--- a/resources/scss/src/apps/agentos/fleet/OperatorComposeForm.scss
+++ b/resources/scss/src/apps/agentos/fleet/OperatorComposeForm.scss
@@ -70,4 +70,27 @@
             }
         }
     }
+
+    /* the send-outcome surface: one row per recipient verdict, colored by status — every color a --fm-*
+       token, so both skins hold by construction. Shown only once the owner writes an outcome back. */
+    .fm-operator-compose-outcome {
+        display       : flex;
+        flex-direction: column;
+        gap           : 2px;
+
+        &:not(:empty) {
+            margin-top: 8px;
+        }
+
+        .fm-compose-outcome-row {
+            border-radius: 4px;
+            font-size    : 12px;
+            padding      : 3px 8px;
+
+            &.is-sent    { color: var(--fm-state-ok); }
+            &.is-refused { color: var(--fm-ink-dim); }
+            &.is-error   { color: var(--fm-kind-alert); }
+            &.is-pending { color: var(--fm-ink-faint); font-style: italic; }
+        }
+    }
 }

--- a/resources/scss/src/apps/agentos/fleet/OperatorComposeForm.scss
+++ b/resources/scss/src/apps/agentos/fleet/OperatorComposeForm.scss
@@ -1,0 +1,44 @@
+/* AgentOS.view.fleet.OperatorComposeForm — the operator write surface (#15377, D#15372 slice).
+   Layout + the actions rail only; every color reads from the --fm-* token layer (no hardcoded
+   colors, no CSS-in-JS — the fields inherit the theme's form-field styling). Sibling of
+   AgentDetail.scss (the read-half mailbox pane); same token vocabulary so the cockpit speaks one
+   language across read and write. */
+.fm-operator-compose-form {
+    gap    : 10px;
+    padding: 12px;
+
+    /* stacked field labels (labelPosition: top) get an even rhythm and a quiet label */
+    .neo-form-field {
+        gap: 4px;
+
+        .neo-form-field-label {
+            color      : var(--fm-ink-dim);
+            font-size  : 12px;
+            font-weight: 600;
+        }
+    }
+
+    /* the message body wants room; the mono face matches the mailbox rows it will be read beside */
+    .fm-operator-compose-body {
+        textarea {
+            font-family: var(--fm-font-mono);
+            line-height: 1.45;
+        }
+    }
+
+    /* the send rail sits under a soft divider, its control pushed to the trailing edge by the spacer */
+    .fm-operator-compose-actions {
+        gap          : 8px;
+        margin-top   : 4px;
+        padding-top  : 10px;
+        border-top   : 1px solid var(--fm-line-soft);
+
+        .neo-button {
+            /* the send affordance carries the signal accent — the one emphasized action on the form */
+            .neo-button-glyph,
+            .neo-button-text {
+                color: var(--fm-signal);
+            }
+        }
+    }
+}

--- a/resources/scss/src/apps/agentos/fleet/OperatorComposeForm.scss
+++ b/resources/scss/src/apps/agentos/fleet/OperatorComposeForm.scss
@@ -3,6 +3,14 @@
    colors, no CSS-in-JS — the fields inherit the theme's form-field styling). Sibling of
    AgentDetail.scss (the read-half mailbox pane); same token vocabulary so the cockpit speaks one
    language across read and write. */
+.fm-operator-mailbox {
+    // The auto-hide reveal slot is height-bounded. Let this flex item shrink to that bound and own
+    // the vertical overflow; otherwise the outcome rows render below the viewport with no scroll
+    // owner, making the send verdicts present in DOM truth but unreachable to the operator.
+    min-height: 0;
+    overflow-y: auto;
+}
+
 .fm-operator-compose-form {
     gap    : 10px;
     padding: 12px;

--- a/resources/scss/src/apps/agentos/fleet/OperatorComposeForm.scss
+++ b/resources/scss/src/apps/agentos/fleet/OperatorComposeForm.scss
@@ -18,6 +18,35 @@
         }
     }
 
+    /* the recipient picker is a real multi-select list (not a form field), so it carries its own quiet
+       label and a bordered, scrollable well; a selected row takes the signal accent to read as chosen —
+       every color a --fm-* token, so both skins hold by construction */
+    .fm-operator-compose-recipients {
+        gap: 4px;
+
+        .fm-operator-compose-recipients-label {
+            color      : var(--fm-ink-dim);
+            font-size  : 12px;
+            font-weight: 600;
+        }
+
+        .fm-operator-compose-recipients-list {
+            border       : 1px solid var(--fm-line-soft);
+            border-radius: 6px;
+            overflow-y   : auto;
+
+            .neo-list-item {
+                cursor : pointer;
+                padding: 6px 10px;
+
+                &.neo-selected {
+                    background: color-mix(in srgb, var(--fm-signal) 16%, transparent);
+                    color     : var(--fm-ink);
+                }
+            }
+        }
+    }
+
     /* the message body wants room; the mono face matches the mailbox rows it will be read beside */
     .fm-operator-compose-body {
         textarea {

--- a/test/playwright/e2e/agentos/OperatorMailboxNL.spec.mjs
+++ b/test/playwright/e2e/agentos/OperatorMailboxNL.spec.mjs
@@ -1,0 +1,172 @@
+import {test, expect} from '../../fixtures.mjs';
+import {createFleetMailboxMirrorSnapshot} from '../../../../ai/services/fleet/fleetMailboxMirrorAdapter.mjs';
+import {authenticatedFleetOptions, wireAuthenticatedFleetBridge} from './authenticatedFleetHarness.mjs';
+
+const rosterRows = [
+    {id: 'review-a', githubUsername: 'review-peer-a', displayName: 'Review Peer A', engineTag: 'fixture', family: 'gpt'},
+    {id: 'review-b', githubUsername: 'review-peer-b', displayName: 'Review Peer B', engineTag: 'fixture', family: 'claude'}
+];
+
+async function startOperatorMailboxFleet() {
+    const {startFleetBridgeServer} = await import('../../../../ai/services/fleet/fleetBridgeServer.mjs'),
+          requests                 = [],
+          options                  = authenticatedFleetOptions({
+              dispatch: async request => {
+                  requests.push(request);
+
+                  switch (request.method) {
+                      case 'resolveViewerIdentity':
+                          return {ok: true, result: {ok: true, agentIdentityNodeId: '@e2e-operator'}};
+                      case 'fleetRoster':
+                          return {ok: true, result: {rows: rosterRows}};
+                      case 'fleetActivity':
+                          return {ok: true, result: {capability: {state: 'wired'}, events: []}};
+                      case 'fleetMailboxMirror':
+                          return {
+                              ok    : true,
+                              result: createFleetMailboxMirrorSnapshot({
+                                  messages: [],
+                                  page    : {limit: 50, offset: request.params?.offset ?? 0},
+                                  subject : '@e2e-operator',
+                                  viewer  : '@e2e-operator'
+                              })
+                          };
+                      case 'composeOperatorMessage':
+                          return request.params?.to === '@review-peer-b'
+                              ? {ok: true, result: {status: 'rejected', reason: 'fixture rejection'}}
+                              : {ok: true, result: {messageId: `fixture-${requests.length}`, sentAt: new Date().toISOString()}};
+                      default:
+                          return {ok: false, error: `unexpected operator-mailbox method: ${request.method}`}
+                  }
+              }
+          }),
+          server                   = await startFleetBridgeServer(options);
+
+    return {
+        requests,
+        bearerToken: options.bearerToken,
+        endpoint   : `http://127.0.0.1:${server.address().port}/fleet`,
+        close      : () => new Promise(resolve => server.close(resolve))
+    }
+}
+
+test.describe('AgentOS operator mailbox mounted delivery journey (#15377)', () => {
+    test.setTimeout(120000);
+
+    test('mounted named + several + broadcast compose and both-theme reachable outcomes', async ({page, neuralLink}, testInfo) => {
+        const fleet = await startOperatorMailboxFleet();
+
+        try {
+            await page.goto(`/apps/agentos/index.html?${new URLSearchParams({fleetUrl: fleet.endpoint})}`);
+            await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
+
+            const app = await neuralLink.connectToApp('AgentOS');
+            await wireAuthenticatedFleetBridge({app, fleetUrl: fleet.endpoint, bearerToken: fleet.bearerToken});
+
+            const [cockpit] = await app.queryComponent({className: 'AgentOS.view.fleet.FleetCockpit'}, ['id']);
+            expect(cockpit?.properties?.id).toBeTruthy();
+            await app.callMethod(cockpit.properties.id, 'loadRoster');
+            await app.callMethod(cockpit.properties.id, 'loadOperatorIdentity');
+
+            const operatorRail = page.locator('.neo-dashboard-dock-rail-tab', {hasText: 'Operator'});
+            await expect(operatorRail).toHaveCount(1);
+            await operatorRail.click();
+            const overlay = page.locator('.neo-dashboard-dock-reveal-overlay');
+            await expect(overlay).toBeVisible({timeout: 10000});
+            await expect(overlay).toContainText('No active messages for @e2e-operator');
+
+            const [mailbox] = await app.queryComponent({className: 'AgentOS.view.fleet.OperatorMailbox'}, ['id', 'record', 'snapshot']),
+                  [form]    = await app.queryComponent({className: 'AgentOS.view.fleet.OperatorComposeForm'}, ['id', 'recipientOptions', 'composeOutcome']),
+                  [list]    = await app.queryComponent({reference: 'compose-recipients'}, ['id', 'selectionModel']);
+
+            expect(mailbox.properties.record).toEqual({agentIdentityNodeId: '@e2e-operator', githubUsername: 'e2e-operator'});
+            expect(mailbox.properties.snapshot.admission).toMatchObject({state: 'granted', subjectAgentId: '@e2e-operator'});
+            expect(form.properties.recipientOptions.map(row => row.id)).toEqual(['AGENT:*', '@review-peer-a', '@review-peer-b']);
+
+            const listState       = await app.getComponent(list.properties.id, ['selectionModel']),
+                  selectionModelId = listState.selectionModel.id,
+                  subject         = page.getByRole('textbox', {name: 'Subject'}),
+                  message         = page.getByRole('textbox', {name: 'Message'}),
+                  send            = page.getByRole('button', {name: 'Send'}),
+                  choose          = async name => {
+                      const row = overlay
+                          .locator('.fm-operator-compose-recipients-list')
+                          .getByRole('listitem')
+                          .filter({hasText: name});
+                      await expect(row).toHaveCount(1);
+                      await expect(row).toHaveText(name);
+                      await row.click()
+                  },
+                  clearRecipients = () => app.callMethod(selectionModelId, 'deselectAll');
+
+            await choose('review-peer-a');
+            await subject.fill('Named path');
+            await message.fill('One recipient');
+            await send.click();
+            await expect.poll(async () => (await app.getComponent(form.properties.id, ['composeOutcome'])).composeOutcome)
+                .toEqual({results: [{to: '@review-peer-a', outcome: expect.objectContaining({messageId: expect.any(String)})}]});
+
+            await clearRecipients();
+            await choose('review-peer-a');
+            await choose('review-peer-b');
+            await subject.fill('Several path');
+            await message.fill('Two recipients');
+            await send.click();
+            await expect.poll(async () => (await app.getComponent(form.properties.id, ['composeOutcome'])).composeOutcome)
+                .toEqual({results: [
+                    {to: '@review-peer-a', outcome: expect.objectContaining({messageId: expect.any(String)})},
+                    {to: '@review-peer-b', outcome: {status: 'rejected', reason: 'fixture rejection'}}
+                ]});
+            await expect(overlay).toContainText('@review-peer-a — sent');
+            await expect(overlay).toContainText('@review-peer-b — fixture rejection');
+
+            await clearRecipients();
+            await choose('All agents (broadcast)');
+            await subject.fill('Broadcast path');
+            await message.fill('One server-expanded call');
+            await send.click();
+            await expect.poll(async () => (await app.getComponent(form.properties.id, ['composeOutcome'])).composeOutcome)
+                .toEqual({results: [{to: 'AGENT:*', outcome: expect.objectContaining({messageId: expect.any(String)})}]});
+
+            const composeRequests = fleet.requests.filter(request => request.method === 'composeOperatorMessage');
+            expect(composeRequests.map(request => request.params.to)).toEqual([
+                '@review-peer-a', '@review-peer-a', '@review-peer-b', 'AGENT:*'
+            ]);
+            expect(composeRequests.every(request => request.params.from === undefined)).toBe(true);
+            expect(composeRequests.at(-1).params).toMatchObject({priority: 'high', wakeSuppressed: true});
+
+            const mailboxDom = page.locator('.fm-operator-mailbox');
+            await expect(mailboxDom).toHaveCount(1);
+            const fit = await mailboxDom.evaluate(element => {
+                const style = getComputedStyle(element);
+                return {
+                    clientHeight: element.clientHeight,
+                    scrollHeight: element.scrollHeight,
+                    overflowY   : style.overflowY
+                }
+            });
+            expect(fit.overflowY).toBe('auto');
+            expect(fit.scrollHeight).toBeGreaterThan(fit.clientHeight);
+            const finalOutcome = overlay.getByText('AGENT:* — sent', {exact: true});
+            await finalOutcome.scrollIntoViewIfNeeded();
+            await expect(finalOutcome).toBeVisible();
+
+            const [viewport]    = await app.queryComponent({className: 'AgentOS.view.Viewport'}, ['id', 'theme']),
+                  viewportState = await app.getComponent(viewport.properties.id, ['controller']),
+                  controllerId  = viewportState.controller.id;
+            const viewportDom = page.locator('.agent-os-viewport');
+
+            for (const theme of ['neo-theme-neo-light', 'neo-theme-neo-dark']) {
+                await app.callMethod(controllerId, 'setTheme', [theme, false]);
+                await expect.poll(async () => (await app.getComponent(viewport.properties.id, ['theme'])).theme).toBe(theme);
+                await expect(viewportDom).toHaveClass(new RegExp(`\\b${theme}\\b`));
+                await page.screenshot({path: testInfo.outputPath(`operator-${theme}.png`)})
+            }
+
+            const listStyles = await app.getComputedStyles(list.properties.id, ['border-top-color', 'background-color']);
+            expect(listStyles['border-top-color']).not.toBe('rgba(0, 0, 0, 0)')
+        } finally {
+            await fleet.close()
+        }
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -2030,8 +2030,9 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
         expect(cockpit.operatorRecord).toBe(null)
     });
 
-    test('identity · resolveViewerIdentity ok → seeds operatorRecord AND pushes the record to the pane', async () => {
-        setBridge({resolveViewerIdentity: async () => ({ok: true, agentIdentityNodeId: 'NODE:operator'})});
+    test('identity · resolveViewerIdentity ok → seeds operatorRecord (incl. the githubUsername possession authority) AND pushes it to the pane', async () => {
+        // a realistic @-form node id — the mailbox subject the adapter returns, not a `NODE:` placeholder
+        setBridge({resolveViewerIdentity: async () => ({ok: true, agentIdentityNodeId: '@neo-opus-grace'})});
 
         const paneSets = [],
               pane     = {set(cfg) { paneSets.push(cfg) }},
@@ -2039,9 +2040,12 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
 
         await FleetCockpit.prototype.loadOperatorIdentity.call(cockpit);
 
-        // the client learns its OWN @-id, holds it owner-side, and hands it to the pane — which reads
-        expect(cockpit.operatorRecord).toEqual({agentIdentityNodeId: 'NODE:operator'});
-        expect(paneSets).toEqual([{record: {agentIdentityNodeId: 'NODE:operator'}}])
+        // the record MUST carry `githubUsername` — MailboxPane's possession guard canonicalizes it to
+        // `@<username>` and matches the admission's subjectAgentId; seeding only the node id fails
+        // possession closed and the own inbox never renders (the exact review finding).
+        const expected = {agentIdentityNodeId: '@neo-opus-grace', githubUsername: 'neo-opus-grace'};
+        expect(cockpit.operatorRecord).toEqual(expected);
+        expect(paneSets).toEqual([{record: expected}])
     });
 
     test('identity · a refusal (ok:false — unbound / source-not-wired) never seeds a wrong subject', async () => {
@@ -2055,14 +2059,14 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
     });
 
     test('identity · an autoHidden pane (not materialized at boot) still seeds the record for a reveal-time read', async () => {
-        setBridge({resolveViewerIdentity: async () => ({ok: true, agentIdentityNodeId: 'NODE:operator'})});
+        setBridge({resolveViewerIdentity: async () => ({ok: true, agentIdentityNodeId: '@neo-opus-grace'})});
 
         // the pane is not materialized yet (getReference → null); the `?.set` no-ops but the record is held
-        // owner-side, so a later projection materializes the pane at the operator's identity and reads
+        // owner-side (with the possession authority), so a later projection materializes the pane and reads
         const cockpit = {operatorRecord: null, getReference: () => null};
 
         await FleetCockpit.prototype.loadOperatorIdentity.call(cockpit);
 
-        expect(cockpit.operatorRecord).toEqual({agentIdentityNodeId: 'NODE:operator'})
+        expect(cockpit.operatorRecord).toEqual({agentIdentityNodeId: '@neo-opus-grace', githubUsername: 'neo-opus-grace'})
     });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1800,3 +1800,221 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
         }
     })
 });
+
+/**
+ * Covers the app-side operator-mailbox seam on `FleetCockpit` — the three methods the
+ * composition root owns so the operator is a first-class Fleet participant:
+ *
+ * - `composeOperatorMessage` — the WRITE: route one composed message to the authenticated verb, then
+ *   re-poll ONLY on a real send. Its unit is the routing + conditional re-read decision, so the bridge
+ *   verb and the re-read (`loadOperatorInbox`) are both spied — this isolates "did it send, and did it
+ *   re-read exactly when a message actually landed" from how either collaborator behaves.
+ * - `buildOperatorRecipientOptions` — the pure roster→picker mapping: the mailbox IDENTITY
+ *   (`@githubUsername`), never the Fleet `agentId` key. The fixture makes the two fields DIFFER so a
+ *   read of the wrong one fails the test rather than passing by coincidence.
+ * - `loadOperatorInbox` — the READ-OBSERVE own-inbox twin of `AgentDetail.loadMailboxMirror`: the
+ *   fail-closed matrix (no identity / no verb → honestly unobserved) plus BOTH fences (a superseded
+ *   generation and a destroyed owner never write). The runtime source of `operatorRecord` is wired
+ *   separately; the method's routing is fully pinned here by setting the identity owner-side.
+ *
+ * Same lightweight harness as the `loadActivity` block above: a plain fake cockpit + the prototype
+ * method under `.call`, so each method's decision is exercised in isolation with no full instantiation.
+ */
+test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-inbox read, #15377)', () => {
+    let FleetCockpit;
+
+    // scope the mock to the `fleet` subkey ONLY (see the loadActivity block): replacing `globalThis.AgentOS`
+    // would wipe every `AgentOS.*` registration for later specs in the shared worker.
+    const clearBridge = () => { delete globalThis.AgentOS?.fleet };
+    const setBridge   = bridge => { (globalThis.AgentOS ??= {}).fleet = {registryBridge: bridge} };
+
+    // a fake owner for the compose seam: it records what `loadOperatorInbox` is (or is not) called with,
+    // so the re-poll decision is assertable without dragging in the real read's pane/subject/bridge machinery.
+    const makeComposeOwner = () => ({
+        inboxReloads: [],
+        loadOperatorInbox(params) { this.inboxReloads.push(params); return Promise.resolve() }
+    });
+
+    // a fake owner for the read seam: a spy pane, an owner-held identity, the generation counter, and the
+    // last-known snapshot — exactly the surface `loadOperatorInbox` reads and writes.
+    const makeReadOwner = ({subject = 'NODE:operator', priorSnapshot = null, generation = 0, isDestroyed = false} = {}) => {
+        const pane    = {snapshot: priorSnapshot},
+              cockpit = {
+                  getReference               : reference => reference === 'operator-mailbox' ? pane : null,
+                  operatorRecord             : subject ? {agentIdentityNodeId: subject} : null,
+                  operatorSnapshot           : priorSnapshot,
+                  operatorInboxReadGeneration: generation,
+                  isDestroyed
+              };
+
+        return {pane, cockpit}
+    };
+
+    test.beforeAll(async () => {
+        FleetCockpit = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default
+    });
+
+    test.afterEach(() => clearBridge());
+
+    // --- composeOperatorMessage: fail-closed refusal + conditional canonical re-read -------------------
+
+    test('compose · no bridge → honest not-wired refusal, nothing sent, no re-poll', async () => {
+        clearBridge();
+
+        const owner   = makeComposeOwner(),
+              outcome = await FleetCockpit.prototype.composeOperatorMessage.call(owner, {to: 'AGENT:*', body: 'hi'});
+
+        expect(outcome).toEqual({status: 'not-wired', reason: 'fleet: operator compose verb not wired'});
+        expect(owner.inboxReloads, 'a refused send must not re-poll the inbox').toHaveLength(0)
+    });
+
+    test('compose · a bridge without composeOperatorMessage → the same not-wired refusal', async () => {
+        setBridge({});
+
+        const owner   = makeComposeOwner(),
+              outcome = await FleetCockpit.prototype.composeOperatorMessage.call(owner, {to: 'AGENT:*', body: 'hi'});
+
+        expect(outcome).toEqual({status: 'not-wired', reason: 'fleet: operator compose verb not wired'});
+        expect(owner.inboxReloads).toHaveLength(0)
+    });
+
+    test('compose · a real send (messageId came back) passes the payload through UNCHANGED and re-polls once at offset 0', async () => {
+        const seen = [];
+        // frozen: if the cockpit tried to inject a sender field here (it must not — the server stamps it at
+        // the authenticated ingress), strict-mode mutation of a frozen object would throw and fail the test
+        const message = Object.freeze({to: '@neo-fable-vega', subject: 's', body: 'b', priority: 'high'});
+
+        setBridge({composeOperatorMessage: async payload => { seen.push(payload); return {messageId: 'M:42', status: 'sent'} }});
+
+        const owner   = makeComposeOwner(),
+              outcome = await FleetCockpit.prototype.composeOperatorMessage.call(owner, message);
+
+        // asserted against a fresh literal, not `message` itself, so an added/changed field would be caught
+        expect(seen).toEqual([{to: '@neo-fable-vega', subject: 's', body: 'b', priority: 'high'}]);
+        expect(outcome).toEqual({messageId: 'M:42', status: 'sent'});
+        // the ONLY re-read: from the top of the inbox, exactly once, because a message genuinely landed
+        expect(owner.inboxReloads).toEqual([{offset: 0}])
+    });
+
+    test('compose · a rejected outcome (no messageId) returns honestly and re-polls NOTHING', async () => {
+        setBridge({composeOperatorMessage: async () => ({status: 'rejected', reason: 'recipient unknown'})});
+
+        const owner   = makeComposeOwner(),
+              outcome = await FleetCockpit.prototype.composeOperatorMessage.call(owner, {to: '@ghost', body: 'b'});
+
+        expect(outcome).toEqual({status: 'rejected', reason: 'recipient unknown'});
+        expect(owner.inboxReloads, 'nothing was sent, so nothing changed to re-read').toHaveLength(0)
+    });
+
+    // --- buildOperatorRecipientOptions: the live roster → @githubUsername identity mapping -------------
+
+    test('recipients · no roster grid yet → only the broadcast sentinel', () => {
+        const owner = {getReference: () => null};
+
+        expect(FleetCockpit.prototype.buildOperatorRecipientOptions.call(owner)).toEqual([
+            {id: 'AGENT:*', name: 'All agents (broadcast)'}
+        ])
+    });
+
+    test('recipients · maps the LIVE roster to @githubUsername identities — NOT the agentId key — and drops rows with no mailbox identity', () => {
+        // agentId ('vega') deliberately differs from githubUsername ('neo-fable-vega') so the test FAILS if the
+        // mapping ever reads the wrong field; the third row has no githubUsername (an unregistered guest) and drops
+        const items = [
+            {agentId: 'vega',  githubUsername: 'neo-fable-vega'},
+            {agentId: 'grace', githubUsername: 'neo-claude-opus'},
+            {agentId: 'guest'}
+        ];
+        const owner = {getReference: reference => reference === 'fleet-grid' ? {store: {items}} : null};
+
+        expect(FleetCockpit.prototype.buildOperatorRecipientOptions.call(owner)).toEqual([
+            {id: 'AGENT:*',          name: 'All agents (broadcast)'},
+            {id: '@neo-fable-vega',  name: 'neo-fable-vega'},
+            {id: '@neo-claude-opus', name: 'neo-claude-opus'}
+        ])
+    });
+
+    // --- loadOperatorInbox: fail-closed matrix + both fences ------------------------------------------
+
+    test('inbox · no bound operator identity → stays honestly unobserved, but the read attempt still advances the generation', async () => {
+        // a snapshot that must NOT land: proving the guard fires before any read
+        setBridge({fleetMailboxMirror: async () => ({rows: ['should-not-land']})});
+
+        const {pane, cockpit} = makeReadOwner({subject: null});
+
+        await FleetCockpit.prototype.loadOperatorInbox.call(cockpit, {offset: 0});
+
+        expect(pane.snapshot, 'no subject → the pane must not receive a fabricated snapshot').toBe(null);
+        expect(cockpit.operatorSnapshot).toBe(null);
+        // starting a read invalidates any older in-flight read even when THIS one fail-closes
+        expect(cockpit.operatorInboxReadGeneration, 'the generation advances before the guard, so a slower older read cannot win').toBe(1)
+    });
+
+    test('inbox · a bridge without fleetMailboxMirror → fail-closed, no snapshot', async () => {
+        setBridge({});
+
+        const {pane, cockpit} = makeReadOwner();
+
+        await FleetCockpit.prototype.loadOperatorInbox.call(cockpit, {offset: 0});
+
+        expect(pane.snapshot).toBe(null)
+    });
+
+    test('inbox · pane + subject + verb → reads at the operator identity and offset, writes BOTH owner and pane', async () => {
+        const seen     = [],
+              snapshot = {rows: [{id: 'msg-1'}], offset: 20};
+
+        setBridge({fleetMailboxMirror: async params => { seen.push(params); return snapshot }});
+
+        const {pane, cockpit} = makeReadOwner();
+
+        await FleetCockpit.prototype.loadOperatorInbox.call(cockpit, {offset: 20});
+
+        // the subject is the operator's OWN identity, held owner-side; the offset threads through unchanged
+        expect(seen).toEqual([{subjectAgentId: 'NODE:operator', offset: 20}]);
+        expect(cockpit.operatorSnapshot).toBe(snapshot);
+        expect(pane.snapshot).toBe(snapshot)
+    });
+
+    test('inbox · a superseded read never overwrites newer news (generation fence)', async () => {
+        const fresh = {rows: ['fresh']},
+              stale = {rows: ['stale']};
+
+        const {pane, cockpit} = makeReadOwner({priorSnapshot: fresh, generation: 5});
+
+        // the verb bumps the owner's generation DURING the await — modelling a newer read that started and
+        // finished while this one was in flight; when this stale read resumes, its captured generation no longer matches
+        setBridge({fleetMailboxMirror: async () => { cockpit.operatorInboxReadGeneration++; return stale }});
+
+        await FleetCockpit.prototype.loadOperatorInbox.call(cockpit, {offset: 0});
+
+        expect(pane.snapshot, 'the loser of the race must not write staler news over newer').toBe(fresh);
+        expect(cockpit.operatorSnapshot).toBe(fresh)
+    });
+
+    test('inbox · a read that resolves after the cockpit is destroyed writes nothing', async () => {
+        const prior = {rows: ['prior']};
+
+        const {pane, cockpit} = makeReadOwner({priorSnapshot: prior, isDestroyed: true});
+
+        setBridge({fleetMailboxMirror: async () => ({rows: ['late']})});
+
+        await FleetCockpit.prototype.loadOperatorInbox.call(cockpit, {offset: 0});
+
+        expect(pane.snapshot).toBe(prior);
+        expect(cockpit.operatorSnapshot).toBe(prior)
+    });
+
+    test('inbox · the verb throwing keeps the last-known snapshot (fail-closed catch)', async () => {
+        const prior = {rows: ['prior']};
+
+        const {pane, cockpit} = makeReadOwner({priorSnapshot: prior});
+
+        setBridge({fleetMailboxMirror: async () => { throw new Error('ingress down') }});
+
+        await FleetCockpit.prototype.loadOperatorInbox.call(cockpit, {offset: 0});
+
+        // fail-closed: the pane never renders "no mail" for a read that did not happen
+        expect(pane.snapshot).toBe(prior);
+        expect(cockpit.operatorSnapshot).toBe(prior)
+    });
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -2017,4 +2017,52 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
         expect(pane.snapshot).toBe(prior);
         expect(cockpit.operatorSnapshot).toBe(prior)
     });
+
+    // --- loadOperatorIdentity: the whoami bootstrap (resolveViewerIdentity → seed → pane) --------------
+
+    test('identity · no resolveViewerIdentity verb → fail-closed, no operatorRecord seeded', async () => {
+        setBridge({});
+
+        const cockpit = {operatorRecord: null, getReference: () => ({set() {}})};
+
+        await FleetCockpit.prototype.loadOperatorIdentity.call(cockpit);
+
+        expect(cockpit.operatorRecord).toBe(null)
+    });
+
+    test('identity · resolveViewerIdentity ok → seeds operatorRecord AND pushes the record to the pane', async () => {
+        setBridge({resolveViewerIdentity: async () => ({ok: true, agentIdentityNodeId: 'NODE:operator'})});
+
+        const paneSets = [],
+              pane     = {set(cfg) { paneSets.push(cfg) }},
+              cockpit  = {operatorRecord: null, getReference: reference => reference === 'operator-mailbox' ? pane : null};
+
+        await FleetCockpit.prototype.loadOperatorIdentity.call(cockpit);
+
+        // the client learns its OWN @-id, holds it owner-side, and hands it to the pane — which reads
+        expect(cockpit.operatorRecord).toEqual({agentIdentityNodeId: 'NODE:operator'});
+        expect(paneSets).toEqual([{record: {agentIdentityNodeId: 'NODE:operator'}}])
+    });
+
+    test('identity · a refusal (ok:false — unbound / source-not-wired) never seeds a wrong subject', async () => {
+        setBridge({resolveViewerIdentity: async () => ({ok: false, error: 'viewer identity unbound — authenticated ingress required'})});
+
+        const cockpit = {operatorRecord: null, getReference: () => ({set() {}})};
+
+        await FleetCockpit.prototype.loadOperatorIdentity.call(cockpit);
+
+        expect(cockpit.operatorRecord, 'a refusal leaves the pane honestly unobserved, never a fallback identity').toBe(null)
+    });
+
+    test('identity · an autoHidden pane (not materialized at boot) still seeds the record for a reveal-time read', async () => {
+        setBridge({resolveViewerIdentity: async () => ({ok: true, agentIdentityNodeId: 'NODE:operator'})});
+
+        // the pane is not materialized yet (getReference → null); the `?.set` no-ops but the record is held
+        // owner-side, so a later projection materializes the pane at the operator's identity and reads
+        const cockpit = {operatorRecord: null, getReference: () => null};
+
+        await FleetCockpit.prototype.loadOperatorIdentity.call(cockpit);
+
+        expect(cockpit.operatorRecord).toEqual({agentIdentityNodeId: 'NODE:operator'})
+    });
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1821,7 +1821,7 @@ test.describe('Fleet cockpit — the liveness owner lifecycle (start/stop, #1529
  * method under `.call`, so each method's decision is exercised in isolation with no full instantiation.
  */
 test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-inbox read, #15377)', () => {
-    let FleetCockpit;
+    let FleetCockpit, FleetCockpitController;
 
     // scope the mock to the `fleet` subkey ONLY (see the loadActivity block): replacing `globalThis.AgentOS`
     // would wipe every `AgentOS.*` registration for later specs in the shared worker.
@@ -1851,7 +1851,8 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
     };
 
     test.beforeAll(async () => {
-        FleetCockpit = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default
+        FleetCockpit           = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs')).default;
+        FleetCockpitController = (await import('../../../../../../../apps/agentos/view/fleet/FleetCockpitController.mjs')).default
     });
 
     test.afterEach(() => clearBridge());
@@ -1928,6 +1929,23 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
         ]});
         // exactly one re-poll for the whole batch, because at least one message genuinely landed
         expect(owner.inboxReloads).toEqual([{offset: 0}])
+    });
+
+    test('compose · onOperatorCompose writes the settled outcome BACK onto the operator-mailbox — closes the loop', async () => {
+        // the review's P1: the surface fires compose intent-only and Observable.fire discards handler
+        // returns, so the fan-out result must return as owner-written state. This is the ONLY path it
+        // reaches the UI — a probe mailbox catches the write-back.
+        const mailbox    = {},
+              controller = Object.create(FleetCockpitController.prototype);
+
+        controller.component = {
+            composeOperatorMessage: async () => ({results: [{to: '@a', outcome: {messageId: 'M', status: 'sent'}}]}),
+            getReference          : ref => ref === 'operator-mailbox' ? mailbox : null
+        };
+
+        await controller.onOperatorCompose({message: {to: ['@a']}, source: 'operator-mailbox'});
+
+        expect(mailbox.composeOutcome).toEqual({results: [{to: '@a', outcome: {messageId: 'M', status: 'sent'}}]})
     });
 
     // --- buildOperatorRecipientOptions: the live roster → @githubUsername identity mapping -------------

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -1858,13 +1858,14 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
 
     // --- composeOperatorMessage: fail-closed refusal + conditional canonical re-read -------------------
 
-    test('compose · no bridge → honest not-wired refusal, nothing sent, no re-poll', async () => {
+    test('compose · no bridge → honest per-recipient not-wired refusal, nothing sent, no re-poll', async () => {
         clearBridge();
 
         const owner   = makeComposeOwner(),
               outcome = await FleetCockpit.prototype.composeOperatorMessage.call(owner, {to: 'AGENT:*', body: 'hi'});
 
-        expect(outcome).toEqual({status: 'not-wired', reason: 'fleet: operator compose verb not wired'});
+        // one result per target, each an honest not-wired refusal — the surface renders each recipient's state
+        expect(outcome).toEqual({results: [{to: 'AGENT:*', outcome: {status: 'not-wired', reason: 'fleet: operator compose verb not wired'}}]});
         expect(owner.inboxReloads, 'a refused send must not re-poll the inbox').toHaveLength(0)
     });
 
@@ -1874,7 +1875,7 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
         const owner   = makeComposeOwner(),
               outcome = await FleetCockpit.prototype.composeOperatorMessage.call(owner, {to: 'AGENT:*', body: 'hi'});
 
-        expect(outcome).toEqual({status: 'not-wired', reason: 'fleet: operator compose verb not wired'});
+        expect(outcome).toEqual({results: [{to: 'AGENT:*', outcome: {status: 'not-wired', reason: 'fleet: operator compose verb not wired'}}]});
         expect(owner.inboxReloads).toHaveLength(0)
     });
 
@@ -1889,9 +1890,10 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
         const owner   = makeComposeOwner(),
               outcome = await FleetCockpit.prototype.composeOperatorMessage.call(owner, message);
 
-        // asserted against a fresh literal, not `message` itself, so an added/changed field would be caught
+        // asserted against a fresh literal, not `message` itself, so an added/changed field would be caught;
+        // the single target passes through with `to` set to that one recipient (never the list)
         expect(seen).toEqual([{to: '@neo-fable-vega', subject: 's', body: 'b', priority: 'high'}]);
-        expect(outcome).toEqual({messageId: 'M:42', status: 'sent'});
+        expect(outcome).toEqual({results: [{to: '@neo-fable-vega', outcome: {messageId: 'M:42', status: 'sent'}}]});
         // the ONLY re-read: from the top of the inbox, exactly once, because a message genuinely landed
         expect(owner.inboxReloads).toEqual([{offset: 0}])
     });
@@ -1902,8 +1904,30 @@ test.describe('Fleet cockpit — operator mailbox (compose · recipients · own-
         const owner   = makeComposeOwner(),
               outcome = await FleetCockpit.prototype.composeOperatorMessage.call(owner, {to: '@ghost', body: 'b'});
 
-        expect(outcome).toEqual({status: 'rejected', reason: 'recipient unknown'});
+        expect(outcome).toEqual({results: [{to: '@ghost', outcome: {status: 'rejected', reason: 'recipient unknown'}}]});
         expect(owner.inboxReloads, 'nothing was sent, so nothing changed to re-read').toHaveLength(0)
+    });
+
+    test('compose · SEVERAL named recipients FAN OUT — one call each, per-target outcome, one re-poll for the batch', async () => {
+        const seen = [];
+        // vega sends, ghost is rejected — a discriminating mix a single aggregate verdict could not produce
+        setBridge({composeOperatorMessage: async payload => {
+            seen.push(payload.to);
+            return payload.to === '@ghost' ? {status: 'rejected', reason: 'recipient unknown'} : {messageId: 'M:' + payload.to, status: 'sent'}
+        }});
+
+        const owner   = makeComposeOwner(),
+              outcome = await FleetCockpit.prototype.composeOperatorMessage.call(owner, {to: ['@neo-fable-vega', '@ghost'], subject: 's', body: 'b', priority: 'high'});
+
+        // one authenticated call per named target, in order — the verb is one-target, the fan-out is the cockpit's
+        expect(seen).toEqual(['@neo-fable-vega', '@ghost']);
+        // each recipient carries its OWN result: vega landed, ghost was refused
+        expect(outcome).toEqual({results: [
+            {to: '@neo-fable-vega', outcome: {messageId: 'M:@neo-fable-vega', status: 'sent'}},
+            {to: '@ghost',          outcome: {status: 'rejected', reason: 'recipient unknown'}}
+        ]});
+        // exactly one re-poll for the whole batch, because at least one message genuinely landed
+        expect(owner.inboxReloads).toEqual([{offset: 0}])
     });
 
     // --- buildOperatorRecipientOptions: the live roster → @githubUsername identity mapping -------------

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
@@ -224,7 +224,7 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
 
         // the placement truth: `addTab` appends by default — the restore must land the item back
         // at its STORED index (0, before the rest of the rail), not at the tail
-        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent']);
+        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'operator']);
 
         // same instance re-adopted by the projection; the vessel was closed by name
         expect(cockpit.getReference('agent-detail')).toBe(pane);
@@ -249,7 +249,7 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
 
         // the SAME instance is docked again at its exact home; nothing was closed (nothing opened)
         expect(cockpit.getReference('agent-detail')).toBe(pane);
-        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent']);
+        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'operator']);
         expect(vessel.closeCalls).toHaveLength(0)
     });
 

--- a/test/playwright/unit/apps/agentos/view/fleet/operatorComposeForm.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/operatorComposeForm.spec.mjs
@@ -1,0 +1,103 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'OperatorComposeFormTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary The operator compose surface's load-bearing contract: the wake semantics and the intent
+ * seam. These assert the pane's OWN logic (`onSendClick`),
+ * not `form.Container` validation (already covered upstream) — so `isValid` is stubbed to isolate the
+ * unit under test: does the send button respect validity, and does it translate the operator's
+ * "wake now" choice into the transport's `wakeSuppressed` correctly?
+ */
+test.describe('AgentOS OperatorComposeForm — operator write surface (#15377, D#15372 AC-7)', () => {
+    let OperatorComposeForm;
+
+    const createForm = cfg => Neo.create(OperatorComposeForm, {appName, ...cfg});
+
+    /**
+     * Force the mount-dependent field validation to a known verdict, set the fields, and capture the
+     * fired `compose` intent — isolating `onSendClick`'s own logic from `form.Container.isValid`.
+     */
+    const composeWith = async (form, {subject = 'S', body = 'B', wake, valid = true} = {}) => {
+        form.isValid = async () => valid;
+
+        form.getReference('compose-subject').value = subject;
+        form.getReference('compose-body').value    = body;
+        wake !== undefined && (form.getReference('compose-wake').checked = wake);
+
+        let captured = null;
+        form.on('compose', data => {captured = data});
+        await form.onSendClick();
+        return captured
+    };
+
+    test.beforeAll(async () => {
+        OperatorComposeForm = (await import('../../../../../../../apps/agentos/view/fleet/OperatorComposeForm.mjs')).default
+    });
+
+    test('the wake control defaults OFF — durable-quiet is the operator-preferred default (AC-7)', () => {
+        const form = createForm();
+
+        expect(form.getReference('compose-wake').checked).toBe(false);
+
+        form.destroy()
+    });
+
+    test('wake OFF sends wakeSuppressed:true — durable, non-interrupting (AC-7 default)', async () => {
+        const form     = createForm(),
+              captured = await composeWith(form, {subject: 'Ship it', body: 'now', wake: false});
+
+        expect(captured).toBeTruthy();
+        // the inversion is the whole point: "wake now = off" ⇒ suppress the wake, keep it durable-quiet
+        expect(captured.message.wakeSuppressed).toBe(true);
+        expect(captured.message.subject).toBe('Ship it');
+        expect(captured.message.priority).toBe('normal');
+
+        form.destroy()
+    });
+
+    test('wake ON sends wakeSuppressed:false — the operator explicitly elected the interrupt', async () => {
+        const form     = createForm(),
+              captured = await composeWith(form, {wake: true});
+
+        expect(captured.message.wakeSuppressed).toBe(false);
+
+        form.destroy()
+    });
+
+    test('invalid input fires NO compose — the send button never fabricates a partial message', async () => {
+        const form     = createForm(),
+              captured = await composeWith(form, {valid: false});
+
+        expect(captured).toBeNull();
+
+        form.destroy()
+    });
+
+    test('recipientOptions injection feeds the picker store — same field, no principal-class branch (Vega AC)', () => {
+        const form = createForm();
+
+        form.recipientOptions = [
+            {id: '@neo-opus-ada', name: 'Ada'},
+            {id: 'AGENT:*',       name: 'All agents (broadcast)'}
+        ];
+
+        expect(form.getReference('compose-recipients').store.getCount()).toBe(2);
+
+        form.destroy()
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/operatorComposeForm.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/operatorComposeForm.spec.mjs
@@ -165,5 +165,55 @@ test.describe('AgentOS OperatorComposeForm — operator write surface (#15377, D
         expect(captured).toBeNull();
 
         form.destroy()
+    });
+
+    test('composeOutcome renders one verdict row PER recipient — a partial batch (sent + refused) is not collapsed', () => {
+        const form = createForm();
+
+        // the outcome the owner writes back after the fan-out settles — Ada sent, ghost refused
+        form.composeOutcome = {results: [
+            {to: '@neo-opus-ada', outcome: {messageId: 'M:1', status: 'sent'}},
+            {to: '@ghost',        outcome: {status: 'rejected', reason: 'recipient unknown'}}
+        ]};
+
+        const rows = form.getReference('compose-outcome').vdom.cn;
+        expect(rows).toHaveLength(2);
+        expect(rows[0].text).toBe('@neo-opus-ada — sent');
+        expect(rows[0].cls).toContain('is-sent');
+        // the refusal is VISIBLE and carries its reason — the review's P1 (invisible refusals) closed
+        expect(rows[1].text).toBe('@ghost — recipient unknown');
+        expect(rows[1].cls).toContain('is-refused');
+
+        form.destroy()
+    });
+
+    test('composeOutcome not-wired → a visible refusal row; pending → one in-flight line; null → cleared', () => {
+        const form = createForm();
+
+        form.composeOutcome = {results: [{to: 'AGENT:*', outcome: {status: 'not-wired', reason: 'x'}}]};
+        expect(form.getReference('compose-outcome').vdom.cn[0].text).toBe('AGENT:* — not wired');
+        expect(form.getReference('compose-outcome').vdom.cn[0].cls).toContain('is-refused');
+
+        form.composeOutcome = {status: 'pending', count: 3};
+        const pending = form.getReference('compose-outcome').vdom.cn;
+        expect(pending).toHaveLength(1);
+        expect(pending[0].cls).toContain('is-pending');
+        expect(pending[0].text).toBe('Sending to 3…');
+
+        form.composeOutcome = null;
+        expect(form.getReference('compose-outcome').vdom.cn).toEqual([]);
+
+        form.destroy()
+    });
+
+    test('onSendClick sets the pending outcome before firing — the honest in-flight state the owner overwrites', async () => {
+        const form = createForm();
+
+        await composeWith(form, {recipients: ['@neo-opus-ada', 'AGENT:*']});
+
+        // pending reflects the batch size; nothing overwrites it here (no owner wired in this unit)
+        expect(form.composeOutcome).toEqual({status: 'pending', count: 2});
+
+        form.destroy()
     })
 });

--- a/test/playwright/unit/apps/agentos/view/fleet/operatorComposeForm.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/operatorComposeForm.spec.mjs
@@ -33,11 +33,23 @@ test.describe('AgentOS OperatorComposeForm — operator write surface (#15377, D
     const createForm = cfg => Neo.create(OperatorComposeForm, {appName, ...cfg});
 
     /**
-     * Force the mount-dependent field validation to a known verdict, set the fields, and capture the
-     * fired `compose` intent — isolating `onSendClick`'s own logic from `form.Container.isValid`.
+     * Force the mount-dependent field validation to a known verdict, SELECT recipients through the real
+     * multi-select list (never a hand-fired `to` array), set the fields, and capture the fired `compose`
+     * intent — isolating `onSendClick`'s own logic from `form.Container.isValid`.
      */
-    const composeWith = async (form, {subject = 'S', body = 'B', wake, valid = true} = {}) => {
+    const composeWith = async (form, {subject = 'S', body = 'B', wake, valid = true, recipients = ['@neo-opus-ada']} = {}) => {
         form.isValid = async () => valid;
+
+        // feed the roster and select recipients through the REAL selection model — actual picker
+        // selection, so the fired `to` array is produced by the component, not asserted into existence
+        form.recipientOptions = [
+            {id: '@neo-opus-ada',  name: 'Ada'},
+            {id: '@neo-opus-vega', name: 'Vega'},
+            {id: 'AGENT:*',        name: 'All agents (broadcast)'}
+        ];
+
+        const list = form.getReference('compose-recipients');
+        list.selectionModel.select(recipients.map(id => list.store.get(id)));
 
         form.getReference('compose-subject').value = subject;
         form.getReference('compose-body').value    = body;
@@ -113,6 +125,44 @@ test.describe('AgentOS OperatorComposeForm — operator write surface (#15377, D
         ];
 
         expect(form.getReference('compose-recipients').store.getCount()).toBe(2);
+
+        form.destroy()
+    });
+
+    test('SEVERAL selected recipients fire as the `to` ARRAY — a real multi-select, not one scalar', async () => {
+        // the whole reason the picker is a list.Base(singleSelect:false) and not a Chip/ComboBox: two
+        // selections must survive as two, which the single-select primitive's getSelection()[0] cannot
+        const form     = createForm(),
+              captured = await composeWith(form, {recipients: ['@neo-opus-ada', '@neo-opus-vega']});
+
+        expect(captured.message.to).toEqual(['@neo-opus-ada', '@neo-opus-vega']);
+
+        form.destroy()
+    });
+
+    test('the AGENT:* broadcast row selects as a single-entry `to` — the cockpit sends it once, server-expanded', async () => {
+        const form     = createForm(),
+              captured = await composeWith(form, {recipients: ['AGENT:*']});
+
+        expect(captured.message.to).toEqual(['AGENT:*']);
+
+        form.destroy()
+    });
+
+    test('NO recipient selected → NO compose fired (a recipient is required; no partial message)', async () => {
+        const form = createForm();
+
+        // valid fields, but zero recipients selected — the send must refuse, never fabricate a send with
+        // no destination (the required gate lives in onSendClick since the list has no field-level required)
+        form.getReference('compose-subject').value = 'S';
+        form.getReference('compose-body').value    = 'B';
+        form.isValid = async () => true;
+
+        let captured = null;
+        form.on('compose', data => {captured = data});
+        await form.onSendClick();
+
+        expect(captured).toBeNull();
 
         form.destroy()
     })

--- a/test/playwright/unit/apps/agentos/view/fleet/operatorComposeForm.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/operatorComposeForm.spec.mjs
@@ -15,6 +15,10 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
+// registers Neo.get — the ComboBox/Chip fields build an internal source-bound collection whose
+// afterSetSourceId calls it; without this the spec crashes in isolation (green only when a sibling
+// in the shared worker imported it first). Mirrors fleetCockpit.spec's robust import.
+import Instance       from '../../../../../../../src/manager/Instance.mjs';
 
 /**
  * @summary The operator compose surface's load-bearing contract: the wake semantics and the intent
@@ -65,7 +69,19 @@ test.describe('AgentOS OperatorComposeForm — operator write surface (#15377, D
         // the inversion is the whole point: "wake now = off" ⇒ suppress the wake, keep it durable-quiet
         expect(captured.message.wakeSuppressed).toBe(true);
         expect(captured.message.subject).toBe('Ship it');
-        expect(captured.message.priority).toBe('normal');
+
+        form.destroy()
+    });
+
+    test('priority defaults to HIGH — operator steering ranks first at the recipient turn-start drain (AC-7)', async () => {
+        // priority left untouched, so the sent value IS the field default — asserted on the fired
+        // intent (the real contract), not the ComboBox's `.value` record
+        const form     = createForm(),
+              captured = await composeWith(form, {subject: 'steer', body: 'now'});
+
+        // the AC-7 sender-side pairing: HIGH priority (ranked first when the recipient next drains) yet
+        // wake OFF by default (durable-quiet) — "top of your queue when you next look, but no interrupt now"
+        expect(captured.message.priority).toBe('high');
 
         form.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
@@ -1,0 +1,100 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'OperatorMailboxTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true
+    },
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary The OperatorMailbox container's own contract: it COMPOSES the inbox pane + compose form
+ * and RELAYS their intents up to the owner (never doing
+ * transport itself), and it passes its injected state straight through to the right child. These
+ * assert the relay/passthrough seams — the pieces that hold without the server halves wired.
+ */
+test.describe('AgentOS OperatorMailbox — the operator mailbox surface (#15377)', () => {
+    let OperatorMailbox;
+
+    const createBox = cfg => Neo.create(OperatorMailbox, {appName, ...cfg});
+
+    test.beforeAll(async () => {
+        OperatorMailbox = (await import('../../../../../../../apps/agentos/view/fleet/OperatorMailbox.mjs')).default
+    });
+
+    test('composes the read-half inbox pane above the write-half compose form', () => {
+        const box = createBox();
+
+        expect(box.getReference('operator-inbox-pane')).toBeTruthy();
+        expect(box.getReference('operator-compose-form')).toBeTruthy();
+
+        box.destroy()
+    });
+
+    test('relays the compose intent to the owner — re-sourced to the container, not the form', () => {
+        const box = createBox();
+
+        let relayed = null;
+        box.on('compose', data => {relayed = data});
+
+        box.getReference('operator-compose-form').fire('compose', {
+            message: {to: ['@neo-opus-ada'], subject: 'S', body: 'B', priority: 'normal', wakeSuppressed: true},
+            source : 'the-form'
+        });
+
+        expect(relayed).toBeTruthy();
+        expect(relayed.message.subject).toBe('S');
+        expect(relayed.message.wakeSuppressed).toBe(true);
+        expect(relayed.source).toBe(box); // the owner sees the surface, not the inner field
+
+        box.destroy()
+    });
+
+    test('relays the inbox page intent to the owner — the cockpit holds the read seam', () => {
+        const box = createBox();
+
+        let relayed = null;
+        box.on('inboxPageRequest', data => {relayed = data});
+
+        box.getReference('operator-inbox-pane').fire('pageRequest', {offset: 60, source: 'the-pane'});
+
+        expect(relayed?.offset).toBe(60);
+        expect(relayed.source).toBe(box);
+
+        box.destroy()
+    });
+
+    test('passes the operator snapshot straight to the inbox pane', () => {
+        const
+            box  = createBox(),
+            snap = {capability: {state: 'wired'}, admission: {state: 'granted'}, rows: [], page: {limit: 10, offset: 0, count: 0}};
+
+        box.snapshot = snap;
+
+        expect(box.getReference('operator-inbox-pane').snapshot).toBe(snap);
+
+        box.destroy()
+    });
+
+    test('passes recipientOptions straight to the compose form', () => {
+        const box = createBox();
+
+        box.recipientOptions = [{id: '@neo-opus-ada', name: 'Ada'}, {id: 'AGENT:*', name: 'All agents'}];
+
+        expect(box.getReference('operator-compose-form').recipientOptions).toEqual([
+            {id: '@neo-opus-ada', name: 'Ada'},
+            {id: 'AGENT:*',       name: 'All agents'}
+        ]);
+
+        box.destroy()
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
@@ -15,6 +15,10 @@ setup({
 import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
+// registers Neo.get — the composed compose-form's ComboBox/Chip fields build an internal
+// source-bound collection whose afterSetSourceId calls it; without this the spec crashes in
+// isolation (green only when a sibling in the shared worker imported it first).
+import Instance       from '../../../../../../../src/manager/Instance.mjs';
 
 /**
  * @summary The OperatorMailbox container's own contract: it COMPOSES the inbox pane + compose form
@@ -54,7 +58,9 @@ test.describe('AgentOS OperatorMailbox — the operator mailbox surface (#15377)
         expect(relayed).toBeTruthy();
         expect(relayed.message.subject).toBe('S');
         expect(relayed.message.wakeSuppressed).toBe(true);
-        expect(relayed.source).toBe(box); // the owner sees the surface, not the inner field
+        // Neo stamps the fired `source` as the component id (the owner resolves it via
+        // Neo.getComponent); this is the box's id, not the inner form's — the re-source landed
+        expect(relayed.source).toBe(box.id)
 
         box.destroy()
     });
@@ -68,7 +74,7 @@ test.describe('AgentOS OperatorMailbox — the operator mailbox surface (#15377)
         box.getReference('operator-inbox-pane').fire('pageRequest', {offset: 60, source: 'the-pane'});
 
         expect(relayed?.offset).toBe(60);
-        expect(relayed.source).toBe(box);
+        expect(relayed.source).toBe(box.id);
 
         box.destroy()
     });
@@ -80,7 +86,9 @@ test.describe('AgentOS OperatorMailbox — the operator mailbox surface (#15377)
 
         box.snapshot = snap;
 
-        expect(box.getReference('operator-inbox-pane').snapshot).toBe(snap);
+        // deep-equal, not reference: the shipped MailboxPane clones its snapshot config on set —
+        // the passthrough delivers the full content, which is what "straight to the pane" means
+        expect(box.getReference('operator-inbox-pane').snapshot).toStrictEqual(snap);
 
         box.destroy()
     });

--- a/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
@@ -125,7 +125,7 @@ test.describe('AgentOS OperatorMailbox — the operator mailbox surface (#15377)
     });
 
     test('clearing the record (→ null) fires NO read — there is no subject to read', () => {
-        const box = createBox({record: {agentIdentityNodeId: 'NODE:operator'}});
+        const box = createBox({record: {agentIdentityNodeId: '@neo-opus-grace', githubUsername: 'neo-opus-grace'}});
 
         let fired = 0;
         box.on('inboxPageRequest', () => {fired++});
@@ -133,6 +133,25 @@ test.describe('AgentOS OperatorMailbox — the operator mailbox surface (#15377)
         box.record = null;
 
         expect(fired).toBe(0);
+
+        box.destroy()
+    });
+
+    test('reveal-after-boot: state injected as CONSTRUCTION configs reaches the children (real component, review RA-1)', () => {
+        // the normal reveal path: the projection materializes the pane with the operator identity, its
+        // snapshot, and recipient options ALREADY resolved owner-side, supplied as construction configs.
+        // Before the onConstructed flush, afterSet* skipped these (isConstructed false) and the children
+        // materialized EMPTY — the pane could not pass possession. This is the real composed component,
+        // not a spy or a post-construction assignment.
+        const record   = {agentIdentityNodeId: '@neo-opus-grace', githubUsername: 'neo-opus-grace'},
+              snapshot = {capability: {state: 'wired'}, admission: {state: 'granted', subjectAgentId: '@neo-opus-grace'}, rows: [], page: {limit: 10, offset: 0, count: 0}},
+              options  = [{id: '@neo-opus-ada', name: 'Ada'}, {id: 'AGENT:*', name: 'All agents'}];
+
+        const box = createBox({record, snapshot, recipientOptions: options});
+
+        expect(box.getReference('operator-inbox-pane').record).toEqual(record);
+        expect(box.getReference('operator-inbox-pane').snapshot).toStrictEqual(snapshot);
+        expect(box.getReference('operator-compose-form').recipientOptions).toEqual(options);
 
         box.destroy()
     })

--- a/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
@@ -106,6 +106,21 @@ test.describe('AgentOS OperatorMailbox — the operator mailbox surface (#15377)
         box.destroy()
     });
 
+    test('passes the compose outcome straight to the compose form — the per-recipient render source', () => {
+        const box     = createBox(),
+              outcome = {results: [{to: '@neo-opus-ada', outcome: {messageId: 'M:1', status: 'sent'}}]};
+
+        // the cockpit writes the settled outcome onto this surface; it relays straight to the form, which
+        // renders the per-recipient verdicts (this surface holds no transport of its own)
+        box.composeOutcome = outcome;
+
+        // deep-equal, not reference: the reactive config clones on set (as snapshot does) — the passthrough
+        // delivers the full content, which is what "straight to the form" means
+        expect(box.getReference('operator-compose-form').composeOutcome).toStrictEqual(outcome);
+
+        box.destroy()
+    });
+
     test('a newly-bound operator record fires the initial own-inbox read (relayed inboxPageRequest, offset 0)', () => {
         const box = createBox();
 

--- a/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/operatorMailbox.spec.mjs
@@ -104,5 +104,36 @@ test.describe('AgentOS OperatorMailbox — the operator mailbox surface (#15377)
         ]);
 
         box.destroy()
+    });
+
+    test('a newly-bound operator record fires the initial own-inbox read (relayed inboxPageRequest, offset 0)', () => {
+        const box = createBox();
+
+        let relayed = null;
+        box.on('inboxPageRequest', data => {relayed = data});
+
+        // AgentDetail-style read-on-record: a pane materialized after boot, when the operator identity is
+        // already resolved owner-side, lands its inbox without a page gesture
+        box.record = {agentIdentityNodeId: 'NODE:operator'};
+
+        expect(relayed?.offset).toBe(0);
+        expect(relayed.source).toBe(box.id);
+        // and the subject still flows to the inbox pane
+        expect(box.getReference('operator-inbox-pane').record).toEqual({agentIdentityNodeId: 'NODE:operator'});
+
+        box.destroy()
+    });
+
+    test('clearing the record (→ null) fires NO read — there is no subject to read', () => {
+        const box = createBox({record: {agentIdentityNodeId: 'NODE:operator'}});
+
+        let fired = 0;
+        box.on('inboxPageRequest', () => {fired++});
+
+        box.record = null;
+
+        expect(fired).toBe(0);
+
+        box.destroy()
     })
 });


### PR DESCRIPTION
Refs #15377 — read + compose + the per-recipient outcome loop ship here; own-inbox mark-read is the remaining #15377 AC (this PR no longer auto-closes the ticket).
Related: #15376, #15320, #15412, #15373

> **Converged repair, rebase pending.** RA-1 possession+reveal, RA-2 real multi-recipient, RA-3 the outcome loop, and RA-4 honest scope are landed. Reviewer polish `c140bb8` closes RA-5's mounted whitebox journey, reachable-outcome geometry, and both-theme design sign-off. The sole remaining merge gate is rebasing onto current `dev` while preserving the `operator` + `defineAgent` rail superset.

## Premise

The Body half of the D#15372 slice: the operator's own mailbox becomes visible AND writable in the FM cockpit — an operator-scoped inbox plus a compose surface (one named peer / **several** / `AGENT:*` broadcast) with the wake-or-not choice the operator asked for at send time. Brain half (compose verb + delivery class): #15376 (merged). Identity bootstrap: #15412 / resolveViewerIdentity (merged as #15418).

## The fix

Every surface is a composed real component; zero principal-class branches; the pane holds no transport — identity is the authenticated transport's fact end-to-end.

- **Operator-scoped inbox** (AC-5): `OperatorMailbox` composes the shipped `MailboxPane` (pointed at the operator's own identity, seeded with `record.githubUsername` so the pane's own possession guard passes) above `OperatorComposeForm`. Read is generation-fenced + fail-closed. The reveal lifecycle flushes projection-injected state in `onConstructed` (the `afterSet*` guards skip it pre-construct), so an autoHidden pane revealed after boot renders its retained state instead of empty.
- **Compose surface — real multi-recipient** (AC-1 sender half, AC-7): the recipient picker is a real multi-select `list.Base(singleSelect:false)` over the roster store — the single-select `Chip`/`ComboBox` collapses to one scalar (`getSelection()[0]`) and cannot express "several peers". `to` is the ARRAY of selected ids; a recipient is required. subject/body, priority **HIGH** default (turn-start drain ranks first), wake `Switch` **OFF** default (`wakeSuppressed = !wake`).
- **Fan-out + per-recipient outcomes** (AC-1, the compose verb is one-target): the cockpit fans out one authenticated call per named recipient (`AGENT:*` one server-expanded call), each with its OWN outcome. The outcome loop closes the review's P1 — the form fires intent-only and `Observable.fire` discards the return, so the settled `{results:[{to,outcome}]}` is written BACK onto the surface and rendered: one row per recipient (sent / not-wired / rejected / error) + a pending line on send. No refusal is invisible; no partial batch collapsed to one verdict.
- **Capability asymmetry, structural** (AC-4 partial): compose lives ONLY in the operator's own-inbox surface, structurally absent from the agent-inbox (`AgentDetail`) vdom. Own-inbox **mark-read** is an EXPLICIT deferred AC — a real write verb, not wired here and not faked (honest scope, never a phantom "other half").
- **The identity bootstrap** (unblocked by #15412): the mirror read requires an EXPLICIT `subjectAgentId` (a self-default at a trust boundary is spoof-adjacent), so `loadOperatorIdentity` calls `resolveViewerIdentity` (whoami) → seeds `operatorRecord` owner-side → the pane reads its own inbox; the admission re-stamps + proves it. Fail-closed on both refusal shapes (`source-not-wired` / `unbound`).

## Deltas

Delta from the ticket contract, driven by @neo-gpt's RC:

| Area | Contract (pre-rework) | This PR |
|---|---|---|
| Recipient picker | a `Chip` field | a real multi-select `list.Base(singleSelect:false)` — the single-select primitive collapses to `getSelection()[0]` and cannot express "several" |
| Compose result | "renders fail-closed refusals" (shape unspecified) | an explicit per-recipient outcome loop written back owner-side (sent / not-wired / rejected / error + pending) |
| Own-inbox mark-read (AC-4) | required capability | an EXPLICIT deferred AC — not wired, not faked |
| Close target | `Resolves #15377` | **`Refs #15377`** because own-inbox `markRead` remains an explicit deferred AC; the mounted journey and both-theme sign-off now land in this PR |

## Test Evidence

Full fleet unit dir: **290 passed**. Real-component witnesses (not spies / hand-fired arrays — the review's coverage gap): recipient multi-select through the REAL selection model (several→array, `AGENT:*`→single, none→refused); the fan-out (several recipients, one sent + one rejected — a shape a single aggregate verdict cannot produce); the outcome render (per-recipient rows, not-wired / pending / null); the controller write-back loop-closer; possession + reveal-lifecycle on the real composed component; the identity bootstrap.

Evidence: L2 (unit battery across the cockpit + the two leaf surfaces). The compose verb, mirror read, and resolveViewerIdentity are merged real bridge verbs — wired, not stubbed. Reviewer-polish evidence at `c140bb8`: **96/96** focused units plus **1/1** mounted Neural Link E2E covering named, several (sent + rejected), and `AGENT:*` broadcast delivery, server-stamped sender authority, high+quiet wake semantics, scroll-reachable verdicts, and explicit rendered light + dark states.

## Post-Merge Validation

Pre-merge gate status (the PR remains `Refs` because own-inbox mark-read stays with #15377):

- [ ] Rebase onto current dev preserving the operator + defineAgent rail superset + exact-index tests.
- [x] Whitebox e2e — mounted named / several / broadcast journey against an authenticated loopback Fleet server, including a mixed sent + rejected batch.
- [x] Design sign-off — explicit rendered light + dark states visually checked; verdict rows remain scroll-reachable inside the height-bounded reveal pane.

## Commits (this rework)

RA-1 possession (`f33d8de`) + reveal (`5b98aba`) · RA-2 fan-out (`f83eda1e`) + form multi-select (`5b02a43`) · RA-3 outcome loop (`0b17cf1`) · RA-4 mark-read honest scope (`d691c75`) · RA-5 reviewer polish: reachable outcomes + mounted E2E (`c140bb8`).

Authored by Grace (Claude Opus 4.8, Claude Code).
