### PR TITLE
fix(hooks): refuse active-lane dialogue stops (#15401)

### DIFF
--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -1,14 +1,16 @@
 #!/usr/bin/env node
 /**
  * @module .claude/hooks/laneStateStopHook
- * @summary Claude Code `Stop` hook — REFUSES every turn-end except a live operator dialogue or an
- * audited CLEAN TERMINAL (valid terminal + fully handed-off gates + the session drive-ratchet).
+ * @summary Claude Code `Stop` hook — REFUSES every turn-end except a live operator dialogue whose
+ * terminal does not declare `active-lane`, or an audited CLEAN TERMINAL (valid terminal + fully
+ * handed-off gates + the session drive-ratchet).
  * DRY-RUN (log-only) by default; ENFORCE via `NEO_LANE_STATE_ENFORCE=1`.
  *
  * Fires at every agent turn-end (the `Stop` event). The decision rule: there is NO valid voluntary
  * stop except a **live operator dialogue** — a turn that directly replied to a genuine human-operator
- * message, where the human takes the next turn (turn-taking, not idling) — or the ONE autonomous
- * edge, a **clean terminal**: a valid lane-state terminal whose named gates ALL await non-self actors,
+ * message, where the human takes the next turn (turn-taking, not idling) — whose own terminal does NOT
+ * declare `active-lane`; or the ONE autonomous edge, a **clean terminal**: a valid lane-state terminal
+ * whose named gates ALL await non-self actors,
  * after ≥2 compliant refused drives already proved the no-hold principle was honored this session
  * (the drive count is read from the hook's OWN audit log, the self identity from `NEO_AGENT_IDENTITY`
  * harness wiring — absent wiring keeps the edge inert, fail-closed). Acceptance is audited
@@ -18,13 +20,14 @@
  * hook exists to prevent.
  *
  * Mechanism:
- *  - `operatorInLoop` (the one allow) is determined EXTERNALLY by `isOperatorInLoop`, never
+ *  - `operatorInLoop` is determined EXTERNALLY by `isOperatorInLoop`, never
  *    self-declared, so it cannot be gamed: the prompting candidate comes from the human-filtered
  *    transcript walk ({@link extractLatestHumanUserTextFromJsonl} — harness-injected `isMeta` records
  *    can never masquerade as dialogue), must NOT be a `[WAKE]` autonomous injection, and must be
  *    confirmable (fail-closed). Inside a forced continuation chain (`stop_hook_active`), a genuine
  *    operator message that arrived MID-CHAIN counts as dialogue evidence — the hook's contract could
- *    previously never confirm it and refused live-dialogue terminals as autonomous.
+ *    previously never confirm it and refused live-dialogue terminals as autonomous. Dialogue normally
+ *    allows, but an exact parsed `active-lane` declaration refuses: answer-plus-drive, not answer-plus-stop.
  *  - Otherwise: ENFORCE → block; DRY-RUN → would-block (log only — the audit path). The lane-state
  *    `verdict` (`parseLaneState` → `validateLaneStateTerminal`) no longer gates the action — it only
  *    supplies the `reason` for the injected directive.
@@ -112,10 +115,12 @@ function auditLog(line) {
  * operator prompted this turn (`operatorInLoop`) + the adapter-evaluated clean-terminal acceptance
  * to the Stop-hook action. The heart of the idle-out mechanism; exported + unit-tested.
  *
- * The ONE legitimate voluntary stop is a **live operator dialogue** — this turn directly replied to a
+ * The legitimate voluntary stop is a **live operator dialogue** — this turn directly replied to a
  * genuine human-operator message, so the human takes the next turn (turn-taking, not idling). That is
- * `operatorInLoop`, and it ALWAYS allows. `operatorInLoop` is determined EXTERNALLY (the prompting
- * message type — see the entry `main`), never self-declared, so it cannot be gamed.
+ * `operatorInLoop`, determined EXTERNALLY (the prompting message type — see the entry `main`), never
+ * self-declared. The one dialogue refusal is an exact parsed `active-lane` terminal: the agent's own
+ * record says self-work remains, so it must answer-plus-drive or hand the lane off honestly. An absent,
+ * malformed, or other continuation keeps the dialogue allow.
  *
  * The ONE legitimate AUTONOMOUS stop is a **clean terminal** — a valid lane-state terminal on a fully
  * handed-off board (every named gate awaiting a non-self actor) after the session drive-ratchet proved
@@ -129,10 +134,17 @@ function auditLog(line) {
  * @param {Boolean} enforcing
  * @param {Boolean} [operatorInLoop=false] True iff a genuine human-operator message prompted this turn.
  * @param {{accept: Boolean, reason: String}|null} [cleanTerminal=null] Adapter-evaluated acceptance.
+ * @param {String|null} [laneContinuation=null] Parsed terminal continuation, when available.
  * @returns {{action: ('allow'|'block'|'would-block'), reason: String}}
  */
-export function decideHookAction(verdict, enforcing, operatorInLoop = false, cleanTerminal = null) {
-    return decideStopHookAction(verdict, {enforcing, operatorInLoop, blockInjectionSupported: true, cleanTerminal});
+export function decideHookAction(verdict, enforcing, operatorInLoop = false, cleanTerminal = null, laneContinuation = null) {
+    return decideStopHookAction(verdict, {
+        enforcing,
+        operatorInLoop,
+        laneContinuation,
+        blockInjectionSupported: true,
+        cleanTerminal
+    });
 }
 
 /**
@@ -723,7 +735,13 @@ async function main() {
         });
     }
 
-    const {action, reason} = decideHookAction(verdict, ENFORCING, operatorInLoop, cleanTerminal);
+    const {action, reason} = decideHookAction(
+        verdict,
+        ENFORCING,
+        operatorInLoop,
+        cleanTerminal,
+        descriptor?.laneContinuation
+    );
 
     if (action === 'allow' && cleanTerminal?.accept === true) {
         // The audited boundary: the acceptance is observable (log + a best-effort systemMessage into

--- a/.claude/hooks/laneStateStopHook.mjs
+++ b/.claude/hooks/laneStateStopHook.mjs
@@ -4,7 +4,8 @@
  * @summary Claude Code `Stop` hook — REFUSES every turn-end except a live operator dialogue whose
  * terminal does not declare `active-lane`, or an audited CLEAN TERMINAL (valid terminal + fully
  * handed-off gates + the session drive-ratchet).
- * DRY-RUN (log-only) by default; ENFORCE via `NEO_LANE_STATE_ENFORCE=1`.
+ * An absent enforcement flag is a non-enforcing fail-open fallback; live harness wiring enforces via
+ * `NEO_LANE_STATE_ENFORCE=1`.
  *
  * Fires at every agent turn-end (the `Stop` event). The decision rule: there is NO valid voluntary
  * stop except a **live operator dialogue** — a turn that directly replied to a genuine human-operator
@@ -28,7 +29,7 @@
  *    operator message that arrived MID-CHAIN counts as dialogue evidence — the hook's contract could
  *    previously never confirm it and refused live-dialogue terminals as autonomous. Dialogue normally
  *    allows, but an exact parsed `active-lane` declaration refuses: answer-plus-drive, not answer-plus-stop.
- *  - Otherwise: ENFORCE → block; DRY-RUN → would-block (log only — the audit path). The lane-state
+ *  - Otherwise: ENFORCE → block; non-enforcing → would-block (log only — the audit path). The lane-state
  *    `verdict` (`parseLaneState` → `validateLaneStateTerminal`) no longer gates the action — it only
  *    supplies the `reason` for the injected directive.
  *  - Block path (ENFORCING): write `{"decision":"block","reason":"…"}` to stdout — Claude keeps
@@ -41,9 +42,9 @@
  * emission* (parseLaneState throws) is NOT our failure — it feeds the directive's `reason`, not the gate.
  *
  * ACTIVATION = operator-authority: this script is INERT until wired into the harness settings
- * (`.claude/settings.*`). Wire it in DRY-RUN first, audit the WOULD-BLOCK log, then set
- * `NEO_LANE_STATE_ENFORCE=1` to enforce. A buggy blocking hook would trap every agent's turn-end, so
- * the dry-run → audit → enforce ramp is the safe rollout.
+ * (`.claude/settings.*`). Live wiring sets `NEO_LANE_STATE_ENFORCE=1` immediately. An absent flag is a
+ * fail-open wiring or stale-session signal; WOULD-BLOCK remains a unit-pinned diagnostic output, not a
+ * prescribed live rollout tier.
  *
  * SEAM: `parseLaneState` + `validateLaneStateTerminal` (imported from `ai/scripts/lifecycle/`) supply
  * the `verdict`'s reason; the pure `parseOutcomeToVerdict`, `decideHookAction`, and `isOperatorInLoop`
@@ -72,10 +73,10 @@ import {collectLaneStateToolEvidenceFromJsonl,
 
 export {isOperatorInLoop, parseOutcomeToVerdict};
 
-// Enforce ONLY when the operator explicitly activates it; default is DRY-RUN (log-only, never blocks).
+// Live harness wiring explicitly enables enforcement. An absent flag fails open and emits diagnostics.
 const ENFORCING = process.env.NEO_LANE_STATE_ENFORCE === '1';
 
-// Append-only audit log — the WOULD-BLOCK / ALLOW record for auditing the dry-run before enforcement.
+// Append-only decision log — WOULD-BLOCK records non-enforcing diagnostics; ALLOW/BLOCK record live truth.
 // NEO_AI_DAEMON_DIR override keeps tests off the real store.
 const LOG_DIR  = process.env.NEO_AI_DAEMON_DIR || path.join(os.homedir(), '.neo-ai-data', 'lane-state-hook');
 const LOG_FILE = path.join(LOG_DIR, 'lane-state-stop-hook.log');
@@ -96,7 +97,7 @@ function readStdin() {
 }
 
 /**
- * @summary Best-effort append to the dry-run audit log. A log failure must NEVER gate the hook
+ * @summary Best-effort append to the decision audit log. A log failure must NEVER gate the hook
  * (mirrors the wake daemon's never-fail log discipline) — worst case is a lost audit line.
  * @param {String} line
  * @protected
@@ -127,7 +128,7 @@ function auditLog(line) {
  * the no-hold principle was honored (`evaluateCleanTerminalAcceptance`; the drive count comes from the
  * hook's OWN audit trail, never the agent's claim). Acceptance emits a `[clean-terminal]` audit line —
  * the boundary is observable, not silent. Everything else is unchanged: a first valid terminal still
- * refuses (ratchet), ENFORCE blocks, DRY-RUN previews (would-block), and the `verdict` supplies the
+ * refuses (ratchet), ENFORCE blocks, non-enforcing mode previews (would-block), and the `verdict` supplies the
  * directive `reason`. The remaining autonomous stops are hard external limits (Claude Code's
  * consecutive-block force-override, context-sunset, or an operator halt).
  * @param {{valid: Boolean, reason: String}} verdict

--- a/ai/scripts/lifecycle/stopHookDecision.mjs
+++ b/ai/scripts/lifecycle/stopHookDecision.mjs
@@ -257,15 +257,18 @@ export function evaluateCleanTerminalAcceptance({
 }
 
 /**
- * @summary Shared no-hold Stop-hook decision. The one voluntary allow is live operator dialogue;
- * the one AUTONOMOUS allow is an adapter-evaluated clean terminal ({@link evaluateCleanTerminalAcceptance}
- * — valid terminal, fully handed-off gates, drive-ratchet met); every other turn-end is blocked when
- * the harness has a proven block/inject contract, or would-block when dry-run / fail-open transport
- * semantics apply. The `verdict` reason is evidence, not a gate.
+ * @summary Shared no-hold Stop-hook decision. Live operator dialogue may stop unless the agent's own
+ * terminal declares the lane still active; the one AUTONOMOUS allow is an adapter-evaluated clean
+ * terminal ({@link evaluateCleanTerminalAcceptance} — valid terminal, fully handed-off gates,
+ * drive-ratchet met). Every other turn-end is blocked when the harness has a proven block/inject
+ * contract, or would-block when dry-run / fail-open transport semantics apply. The `verdict` reason
+ * is evidence, not a gate.
  * @param {{valid: Boolean, reason: String}} verdict
  * @param {Object} [options]
  * @param {Boolean} [options.enforcing=false]
  * @param {Boolean} [options.operatorInLoop=false]
+ * @param {String|null} [options.laneContinuation=null] Parsed terminal continuation. Only the exact
+ * `active-lane` value overrides the dialogue allow; absent/malformed terminals preserve turn-taking.
  * @param {Boolean} [options.blockInjectionSupported=true]
  * @param {String} [options.blockUnsupportedReason='']
  * @param {{accept: Boolean, reason: String}|null} [options.cleanTerminal=null] The adapter-evaluated
@@ -275,25 +278,34 @@ export function evaluateCleanTerminalAcceptance({
 export function decideStopHookAction(verdict, {
     enforcing               = false,
     operatorInLoop          = false,
+    laneContinuation        = null,
     blockInjectionSupported = true,
     blockUnsupportedReason  = '',
     cleanTerminal           = null
 } = {}) {
-    if (operatorInLoop) {
+    const activeLaneInDialogue = operatorInLoop && laneContinuation === 'active-lane';
+
+    if (operatorInLoop && !activeLaneInDialogue) {
         return {action: 'allow', reason: 'live operator dialogue — yielding for the human turn'};
     }
 
-    if (cleanTerminal?.accept === true) {
+    if (!operatorInLoop && cleanTerminal?.accept === true) {
         return {action: 'allow', reason: cleanTerminal.reason};
     }
 
+    const decisionReason = activeLaneInDialogue
+        ? '[active-lane-in-dialogue] Answer delivered — and you declared this lane ACTIVE. ' +
+            'Answer-plus-drive, not answer-plus-stop: continue the lane now, or hand it off honestly ' +
+            '(`next-lane` with gates naming non-self actors).'
+        : verdict.reason;
+
     if (enforcing && blockInjectionSupported) {
-        return {action: 'block', reason: verdict.reason};
+        return {action: 'block', reason: decisionReason};
     }
 
     const reason = enforcing && !blockInjectionSupported && blockUnsupportedReason
-        ? `${verdict.reason} ${blockUnsupportedReason}`
-        : verdict.reason;
+        ? `${decisionReason} ${blockUnsupportedReason}`
+        : decisionReason;
 
     return {action: 'would-block', reason};
 }

--- a/learn/agentos/Hooks.md
+++ b/learn/agentos/Hooks.md
@@ -58,6 +58,7 @@ flowchart TD
     Prompt["Classify prompting message"]:::evidence
     Lane["Parse and validate lane-state block"]:::evidence
     Operator["Live operator dialogue?"]:::evidence
+    Active["Terminal declares active-lane?"]:::evidence
     Allow["Allow the hand-back"]:::allow
     Autonomous["Autonomous turn"]:::evidence
     Reflect["Block or would-block with no-hold directive"]:::block
@@ -67,21 +68,27 @@ flowchart TD
     Stop --> Prompt
     Text --> Lane
     Prompt --> Operator
-    Operator -->|"yes"| Allow
+    Operator -->|"yes"| Active
     Operator -->|"no"| Autonomous
-    Lane --> Autonomous
+    Lane -. "parsed continuation" .-> Active
+    Active -->|"yes"| Reflect
+    Active -->|"no / absent / malformed"| Allow
+    Lane -. "verdict" .-> Autonomous
     Autonomous --> Reflect
     Reflect --> Drive
 ```
 
 The important detail is counterintuitive: a valid `lane-state` block is not a
 stop license. It is evidence. It tells the hook what the agent claims about the
-turn, but it does not prove the maintainer may stop. The voluntary allow is a
-genuine live operator dialogue, where the human has clearly taken the next turn.
+turn, but it does not prove the maintainer may stop. The voluntary dialogue allow
+is a genuine live operator dialogue where the human has clearly taken the next
+turn and the terminal does not declare `active-lane`. An exact `active-lane`
+declaration refuses: answer-plus-drive, not answer-plus-stop. Absent, malformed,
+and other continuation values preserve ordinary turn-taking.
 
-Everything else is autonomous. A wake is autonomous. A hook-generated continuation
-is autonomous. A night-shift handoff is autonomous. A missing prompt fails closed
-to autonomous, because uncertainty must not become a quiet idle path.
+Outside dialogue, a wake is autonomous. A hook-generated continuation is
+autonomous. A night-shift handoff is autonomous. A missing prompt fails closed to
+autonomous, because uncertainty must not become a quiet idle path.
 
 The parser distinguishes three cases:
 
@@ -127,8 +134,9 @@ Prompts carry values: verify before asserting, do not idle, treat peers as peers
 route friction into substrate, preserve public evidence. Hooks make one narrow
 part of that posture executable. They do not decide which backlog item is best.
 They do not prove a PR should merge. They do not know whether a guide has soul.
-They enforce that the agent cannot turn "I am waiting" into a terminal state
-when the turn is not live operator dialogue.
+They enforce that the agent cannot turn "I am waiting" into a terminal state on
+an autonomous turn, or hand a dialogue turn back while its own terminal still
+declares the lane active.
 
 That boundary is what keeps the mechanism healthy. If a hook fires wrong, the
 agent still obeys it in the moment and opens a follow-up lane to sharpen the

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -17,9 +17,10 @@ const block = body => '```lane-state\n' + body + '\n```';
  * resolution — final assistant text + the prompting user message come from the Stop payload /
  * transcript, not raw JSONL lines (raw JSONL is escaped); (3) end-to-end — the spawned real hook.
  *
- * The decision rule: there is NO valid voluntary stop except a live operator dialogue. A
- * "valid" lane-state terminal is a declaration, not a license to stop — enforce REFUSES it. The one
- * allow is `operatorInLoop`, determined EXTERNALLY (the prompting message type), never self-declared.
+ * The decision rule: there is NO valid voluntary stop except live operator dialogue without an exact
+ * `active-lane` terminal. A "valid" lane-state terminal is a declaration, not a license to stop —
+ * enforce REFUSES it. `operatorInLoop` is determined EXTERNALLY (the prompting message type), while
+ * the active-lane refinement consumes the agent's own parsed continuation record.
  */
 test.describe('laneStateStopHook — pure idle-out decision logic', () => {
     test.describe('parseOutcomeToVerdict — the 3-bucket chain', () => {
@@ -50,15 +51,26 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
         });
     });
 
-    test.describe('decideHookAction — operator-dialogue is the only allow (#13649)', () => {
+    test.describe('decideHookAction — dialogue allow with the #15401 active-lane refinement', () => {
         test('VALID + no operator → BLOCK (enforce) / WOULD-BLOCK (dry-run) — the loophole is closed', () => {
             expect(decideHookAction({valid: true, reason: 'ok'}, true,  false).action).toBe('block');
             expect(decideHookAction({valid: true, reason: 'ok'}, false, false).action).toBe('would-block');
         });
 
-        test('operatorInLoop ALWAYS allows — a live human takes the next turn (enforce AND dry-run)', () => {
+        test('operatorInLoop allows when no active-lane continuation is declared (enforce AND dry-run)', () => {
             expect(decideHookAction({valid: false, reason: 'x'}, true,  true).action).toBe('allow');
             expect(decideHookAction({valid: true,  reason: 'x'}, false, true).action).toBe('allow');
+            expect(decideHookAction({valid: true, reason: 'x'}, true, true, null, 'next-lane').action).toBe('allow');
+        });
+
+        test('operatorInLoop + active-lane → BLOCK (enforce) / WOULD-BLOCK (dry-run)', () => {
+            const enforced = decideHookAction({valid: true, reason: 'x'}, true, true, null, 'active-lane'),
+                  dryRun   = decideHookAction({valid: true, reason: 'x'}, false, true, null, 'active-lane');
+
+            expect(enforced.action).toBe('block');
+            expect(dryRun.action).toBe('would-block');
+            expect(enforced.reason).toContain('[active-lane-in-dialogue]');
+            expect(dryRun.reason).toContain('Answer-plus-drive, not answer-plus-stop');
         });
 
         test('INVALID + no operator → BLOCK when enforcing — the reason is carried through to inject', () => {
@@ -605,10 +617,20 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
         expect(decision.reason).toContain('deference phrase "your move"');
     });
 
-    test('deference phrase in a live operator dialogue → ALLOW (operator-dialogue carve)', async () => {
+    test('deference carve cannot hide active-lane in dialogue → BLOCK with the lane directive', async () => {
         const {stdout, log} = await runHook(`Your call.\n\n${validTerminal}`, {enforce: true, promptingText: 'please pick the exact color and report'});
-        expect(log).toContain('ALLOW');
+        expect(log).toContain('BLOCK');
         expect(log).not.toContain('deference phrase');
+        expect(log).toContain('[active-lane-in-dialogue]');
+        const decision = JSON.parse(stdout);
+        expect(decision.decision).toBe('block');
+        expect(decision.reason).toContain('Answer-plus-drive, not answer-plus-stop');
+    });
+
+    test('LIVE OPERATOR dialogue + active-lane → WOULD-BLOCK in dry-run with a greppable class', async () => {
+        const {stdout, log} = await runHook(validTerminal, {promptingText: 'please do X, then report'});
+        expect(log).toContain('WOULD-BLOCK');
+        expect(log).toContain('[active-lane-in-dialogue]');
         expect(stdout).toBe('');
     });
 
@@ -616,6 +638,18 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
         const {stdout, log} = await runHook('Done — over to you.', {enforce: true, promptingText: 'please do X, then report'});
         expect(log).toContain('ALLOW');
         expect(stdout).toBe('');
+    });
+
+    test('LIVE OPERATOR dialogue keeps ALLOW for malformed and non-active lane-state terminals', async () => {
+        const malformed = `Done.\n\n${block('{bad json}')}`,
+              nextLane  = `Done.\n\n${block('{"laneContinuation":"next-lane"}')}`;
+
+        for (const finalText of [malformed, nextLane]) {
+            const {stdout, log} = await runHook(finalText, {enforce: true, promptingText: 'please do X, then report'});
+            expect(log).toContain('ALLOW');
+            expect(log).not.toContain('[active-lane-in-dialogue]');
+            expect(stdout).toBe('');
+        }
     });
 
     test('handoff-to-autonomous operator prompt + enforce → BLOCK, not operator ALLOW', async () => {
@@ -686,11 +720,15 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
         expect(decision.reason).toContain('Unknown laneContinuation');
     });
 
-    // BEHAVIORAL FLIP (mid-chain operator visibility): the previous expectation here was BLOCK — the
-    // literal defect (a genuine operator record inside a forced chain refused as autonomous). Under
-    // mid-chain operator visibility, a mechanically human-shaped operator record IS live dialogue.
+    // Mid-chain operator visibility remains an independent contract: a genuine operator record inside
+    // a forced chain is live dialogue. The terminal is deliberately bare prose so this witness proves
+    // prompt classification without colliding with the separate active-lane refusal.
     test('stop_hook_active + genuine mid-chain operator record → ALLOW (#14440 Defect-B AC)', async () => {
-        const {stdout, log} = await runHook(validTerminal, {enforce: true, promptingText: 'please do X', stopHookActive: true});
+        const {stdout, log} = await runHook('Done — over to you.', {
+            enforce       : true,
+            promptingText : 'please do X',
+            stopHookActive: true
+        });
         expect(log).toContain('ALLOW');
         expect(log).toContain('midChainOperator=true');
         expect(stdout).toBe('');

--- a/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
+++ b/test/playwright/unit/hooks/laneStateStopHook.spec.mjs
@@ -61,6 +61,7 @@ test.describe('laneStateStopHook — pure idle-out decision logic', () => {
             expect(decideHookAction({valid: false, reason: 'x'}, true,  true).action).toBe('allow');
             expect(decideHookAction({valid: true,  reason: 'x'}, false, true).action).toBe('allow');
             expect(decideHookAction({valid: true, reason: 'x'}, true, true, null, 'next-lane').action).toBe('allow');
+            expect(decideHookAction({valid: true, reason: 'x'}, true, true, null, 'blocker-routed').action).toBe('allow');
         });
 
         test('operatorInLoop + active-lane → BLOCK (enforce) / WOULD-BLOCK (dry-run)', () => {
@@ -641,10 +642,11 @@ test.describe('laneStateStopHook — end-to-end (spawned hook against the real S
     });
 
     test('LIVE OPERATOR dialogue keeps ALLOW for malformed and non-active lane-state terminals', async () => {
-        const malformed = `Done.\n\n${block('{bad json}')}`,
-              nextLane  = `Done.\n\n${block('{"laneContinuation":"next-lane"}')}`;
+        const malformed     = `Done.\n\n${block('{bad json}')}`,
+              nextLane      = `Done.\n\n${block('{"laneContinuation":"next-lane"}')}`,
+              blockerRouted = `Done.\n\n${block('{"laneContinuation":"blocker-routed"}')}`;
 
-        for (const finalText of [malformed, nextLane]) {
+        for (const finalText of [malformed, nextLane, blockerRouted]) {
             const {stdout, log} = await runHook(finalText, {enforce: true, promptingText: 'please do X, then report'});
             expect(log).toContain('ALLOW');
             expect(log).not.toContain('[active-lane-in-dialogue]');

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -160,7 +160,7 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision
     });
 
     test('decideStopHookAction: dialogue fail-open is exact — absent, malformed, and other continuations allow', () => {
-        for (const laneContinuation of [null, undefined, '', 'next-lane', 'ACTIVE-LANE', {value: 'active-lane'}]) {
+        for (const laneContinuation of [null, undefined, '', 'next-lane', 'blocker-routed', 'ACTIVE-LANE', {value: 'active-lane'}]) {
             expect(decideStopHookAction(verdict, {enforcing: true, operatorInLoop: true, laneContinuation}).action)
                 .toBe('allow');
         }

--- a/test/playwright/unit/hooks/stopHookDecision.spec.mjs
+++ b/test/playwright/unit/hooks/stopHookDecision.spec.mjs
@@ -128,13 +128,53 @@ test.describe('ai/scripts/lifecycle/stopHookDecision — shared no-hold decision
         expect(extractAutonomousHandoffWindowMs('please pick a lane')).toBe(null);
     });
 
-    // ── decideStopHookAction: operatorInLoop is the only allow; block-support gates block vs would-block ──
+    // ── decideStopHookAction: dialogue allow + active-lane refusal + transport behavior ─────────
     const verdict = {valid: false, reason: 'no lane-state block emitted at turn-terminal'};
 
     test('decideStopHookAction: a live operator dialogue is the only voluntary allow', () => {
         const decision = decideStopHookAction(verdict, {enforcing: true, operatorInLoop: true, blockInjectionSupported: true});
         expect(decision.action).toBe('allow');
         expect(decision.reason).toContain('live operator dialogue');
+    });
+
+    test('decideStopHookAction: active-lane + operator dialogue refuses in enforce and dry-run', () => {
+        const options = {operatorInLoop: true, laneContinuation: 'active-lane', blockInjectionSupported: true};
+
+        expect(decideStopHookAction(verdict, {...options, enforcing: true})).toMatchObject({
+            action: 'block'
+        });
+        expect(decideStopHookAction(verdict, {...options, enforcing: false})).toMatchObject({
+            action: 'would-block'
+        });
+
+        const reason = decideStopHookAction(verdict, {...options, enforcing: true}).reason;
+        expect(reason).toContain('[active-lane-in-dialogue]');
+        expect(reason).toContain('Answer-plus-drive, not answer-plus-stop');
+        expect(reason).toContain('`next-lane` with gates naming non-self actors');
+
+        expect(decideStopHookAction(verdict, {
+            ...options,
+            enforcing    : true,
+            cleanTerminal: {accept: true, reason: '[clean-terminal] impossible dialogue input'}
+        }).action).toBe('block');
+    });
+
+    test('decideStopHookAction: dialogue fail-open is exact — absent, malformed, and other continuations allow', () => {
+        for (const laneContinuation of [null, undefined, '', 'next-lane', 'ACTIVE-LANE', {value: 'active-lane'}]) {
+            expect(decideStopHookAction(verdict, {enforcing: true, operatorInLoop: true, laneContinuation}).action)
+                .toBe('allow');
+        }
+    });
+
+    test('decideStopHookAction: autonomous behavior is byte-identical when laneContinuation is threaded', () => {
+        const without = decideStopHookAction(verdict, {enforcing: true, operatorInLoop: false}),
+              withOne = decideStopHookAction(verdict, {
+                  enforcing       : true,
+                  operatorInLoop  : false,
+                  laneContinuation: 'active-lane'
+              });
+
+        expect(withOne).toEqual(without);
     });
 
     test('decideStopHookAction: enforce + block-supported (Claude) → block, carrying the verdict reason', () => {


### PR DESCRIPTION
Resolves #15401

Related: #15404

An `active-lane` terminal can no longer ride the Claude stop-hook's operator-dialogue allow. The pure decision seam now consumes the parsed continuation: only the exact active state refuses; absent, malformed, and handed-off terminals preserve normal turn-taking. Autonomous and Codex behavior remain unchanged.

Evidence: L2 (pure decision matrix plus spawned real hook with controlled Stop payloads and audit log) -> L3 required (live Claude hook audit under an operator dialogue). The ticket contract now pins both decision outputs and preserves the live enforcement posture.

## Deltas from ticket

- The change stays at `decideStopHookAction`; no operator-prose classification was added.
- The Claude adapter threads `descriptor?.laneContinuation`; Codex remains on the optional-input default.
- `active-lane-in-dialogue` is a greppable refusal class in enforce and non-enforcing outputs.
- The hook header and owning Hooks guide now describe the same dialogue quadrant, and literal `blocker-routed` is pinned as an allowed non-active continuation.
- Authority delta resolved before readiness: `#15401` AC4 now unit-pins both ENFORCE and non-enforcing outputs, explicitly prescribes no live dry-run phase, and keeps every seat enforcement-configured. This PR does not change the current enforcement posture.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/hooks/stopHookDecision.spec.mjs test/playwright/unit/hooks/laneStateStopHook.spec.mjs` - 137/137 passed.
- `npm run test-unit -- test/playwright/unit/hooks/codexLaneStateStopHook.spec.mjs test/playwright/unit/hooks/deferencePhraseMatch.spec.mjs` - 49/49 passed.
- `npm run agent-preflight -- --no-fix` - passed; unrelated stale local AiConfig overlay warning only.
- Pure decision surface: enforce/non-enforcing active refusal, fail-open continuation matrix, autonomous byte-equivalence.
- Claude hook surface: spawned Stop payloads prove block/would-block audit class plus ordinary/malformed/handed-off dialogue allow.
- Codex/deference surfaces: unchanged optional-input path and carve behavior.

## Post-Merge Validation

- [ ] Observe one live Claude operator-dialogue plus `active-lane` terminal emit the `active-lane-in-dialogue` audit class without a second stop.
- [ ] Confirm ordinary operator Q&A without `active-lane` still stops normally.
- [ ] Keep `#15404`'s autonomous material-artifact implementation on the same optional-input seam without duplicating this quadrant.

## Evolution

The first focused run surfaced one old test that conflated mid-chain operator visibility with an active-work terminal. The witness now uses bare prose, preserving the visibility contract while independently pinning the new refusal. The pre-PR evidence pass then found a stale dry-run rollout AC; the PR stayed draft until the ticket author folded that authority contradiction, so readiness now rests on one coherent contract.

An independent exact-diff audit then caught the same stale rollout language in the hook header, an unconditional-dialogue diagram in the owning guide, and a missing literal `blocker-routed` witness. All three were folded before the amended head was offered for review.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex) consuming Clio's handoff - session A `abce4d75-7dcb-4145-8afc-b0ff2cdc51e6`, session B `bb316324-1308-465a-ba5d-abe9ceddcb71`.
