### PR TITLE
feat(dashboard): the dual-window conversion sensor — contract tier (#15432)

### DIFF
--- a/src/dashboard/DockVesselConversion.mjs
+++ b/src/dashboard/DockVesselConversion.mjs
@@ -35,9 +35,12 @@
  *   idempotently: gesture terminals (commit, cancel, vessel close, park) are choreographed by the
  *   outcome machine and the vessel-lifecycle leaves; a sensor emitting on reset would double-drive
  *   the actuators the terminal choreography already owns.
- * - **Garbage geometry fails CLOSED.** Missing, zero-extent, or non-finite rects compose to 0 — a
- *   converted sensor fed garbage REVERTS. Without the guard, `NaN` poisons both threshold
- *   comparisons to false and a converted sensor would hold its conversion forever.
+ * - **Garbage geometry fails CLOSED and DOMINATES composition.** Missing, zero-extent, or
+ *   non-finite rects force the sample to 0 WITHOUT consulting the composition seam — an injected
+ *   composer (average, weighted sum, anything non-`min`-shaped) can never elevate a degenerate
+ *   axis's valid-looking `0` back above a threshold. A converted sensor fed garbage REVERTS.
+ *   Without the non-finite guard, `NaN` would additionally poison both threshold comparisons to
+ *   false and freeze a converted sensor forever.
  *
  * The shipped thresholds are REVIEWABLE PLACEHOLDERS: the dead-band width mirrors the landed
  * grammar's proven 0.2 spread; the absolute positions and the composition pick (`min` vs product)
@@ -67,6 +70,23 @@ function assertThreshold(name, value) {
  */
 function clampRatio(value) {
     return Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0
+}
+
+/**
+ * Whether one `{x, y, width, height}` rect is measurable window geometry: every field finite,
+ * both extents strictly positive. The VALIDITY gate the composition seam sits behind — a
+ * degenerate axis yields a valid-LOOKING `0` ratio, and an injected composer that is not
+ * `min`-shaped (an average, a weighted sum) could elevate that zero back above a threshold, so
+ * invalid geometry must dominate BEFORE composition, never inside it.
+ * @param {Object} rect
+ * @returns {Boolean}
+ * @private
+ */
+function isMeasurableRect(rect) {
+    return Boolean(rect) &&
+        Number.isFinite(rect.x) && Number.isFinite(rect.y) &&
+        Number.isFinite(rect.width)  && rect.width  > 0 &&
+        Number.isFinite(rect.height) && rect.height > 0
 }
 
 /**
@@ -176,12 +196,16 @@ export function createVesselConversionSensor(config = {}) {
          *     sourceRect, targetRect}` — `converted` reflects the POST-decision state
          */
         sample({pointerInTarget, sourceRect, targetRect} = {}) {
+            // Invalid geometry DOMINATES: a missing, degenerate, or non-finite rect forces the
+            // whole sample to zero WITHOUT consulting the composition seam — a degenerate axis
+            // produces a valid-looking 0 ratio, and a non-min injected composer could elevate it
+            // back above the convert threshold, silently defeating the fail-closed contract.
             const
-                bothRects = Boolean(sourceRect && targetRect),
-                pointer   = pointerInTarget === true,
-                rx        = bothRects ? axisRatio(sourceRect, targetRect, 'x', 'width')  : 0,
-                ry        = bothRects ? axisRatio(sourceRect, targetRect, 'y', 'height') : 0,
-                composed  = clampRatio(composeRatios({rx, ry}));
+                measurable = isMeasurableRect(sourceRect) && isMeasurableRect(targetRect),
+                pointer    = pointerInTarget === true,
+                rx         = measurable ? axisRatio(sourceRect, targetRect, 'x', 'width')  : 0,
+                ry         = measurable ? axisRatio(sourceRect, targetRect, 'y', 'height') : 0,
+                composed   = measurable ? clampRatio(composeRatios({rx, ry})) : 0;
 
             let event = null;
 

--- a/src/dashboard/DockVesselConversion.mjs
+++ b/src/dashboard/DockVesselConversion.mjs
@@ -1,0 +1,205 @@
+/**
+ * @module Neo.dashboard.DockVesselConversion
+ * @summary The dual-window conversion decision authority — the pure sensor deciding WHEN a dragged
+ * popup converts into a semi-transparent drag proxy over a target vessel, and when it converts back.
+ *
+ * The landed tear-out grammar's intersection ratio ({@link Neo.draggable.container.SortZone#checkWindowBoundary},
+ * `area(intersection) / area(dragged)`) is a SELF-retention measure against one window and is
+ * mathematically broken for popup-over-vessel: with the dragged window as denominator, a large
+ * window over a small target caps at `area(target) / area(dragged)` — for a 2× size difference the
+ * ratio can never exceed 0.5, so any usable threshold is UNREACHABLE; the mirror denominator fails
+ * the mirror case. Both windows are freely resizable mid-session, so no creation-time basis works
+ * either. This module's metric is reachable for EVERY size pair in both directions: per-axis
+ * overlap normalized by the SMALLER extent per axis — `rx = overlapWidth / min(widthA, widthB)`,
+ * `ry` likewise — composed through an injectable seam (default `min(rx, ry)`: both axes must
+ * substantially cover the smaller footprint). Composed = 1.0 exactly when the smaller per-axis
+ * footprint is fully covered, whichever window is bigger. Ratios derive from the LIVE rects of
+ * every sample, so a mid-session resize re-normalizes on the next frame.
+ *
+ * The choreography contract this implements (the docking design record, multi-window amendment):
+ * - **Conversion is a transition predicate, never a new state.** Convert-in IS the geometric
+ *   condition for the outcome machine's existing `DETACHED_MOVING → HOVERING_CLAIM` transition;
+ *   convert-out is its inverse. The design record's source-hook pair (`suspendWindowDrag` /
+ *   `resumeWindowDrag`) is the contract-named actuator set a host binds the two seams to — the
+ *   record's outcome machine gains NO state and needs NO amendment for this capability.
+ * - **The pointer gate holds in BOTH directions.** Rect overlap alone never converts (intent stays
+ *   pointer-owned: convert-in requires the pointer inside the target's dock-accepting region, the
+ *   claim-protocol feed) — and rect overlap alone never HOLDS a conversion: the pointer leaving
+ *   the target reverts at any ratio, so a stale claim can never pin a converted vessel.
+ * - **The dead band IS the Schmitt trigger.** `convertThreshold` (in) sits strictly above
+ *   `revertThreshold` (out), validated fail-loud; a decision fires only on crossing its OWN
+ *   threshold, so the convert-in moment lies above the revert band by construction — the false-flip
+ *   class the landed grammar needed an arming flag for (its exit fires INSIDE its reattach zone)
+ *   is structurally excluded here, no arming state required.
+ * - **Terminals are not the sensor's business.** `reset()` clears conversion state SILENTLY and
+ *   idempotently: gesture terminals (commit, cancel, vessel close, park) are choreographed by the
+ *   outcome machine and the vessel-lifecycle leaves; a sensor emitting on reset would double-drive
+ *   the actuators the terminal choreography already owns.
+ * - **Garbage geometry fails CLOSED.** Missing, zero-extent, or non-finite rects compose to 0 — a
+ *   converted sensor fed garbage REVERTS. Without the guard, `NaN` poisons both threshold
+ *   comparisons to false and a converted sensor would hold its conversion forever.
+ *
+ * The shipped thresholds are REVIEWABLE PLACEHOLDERS: the dead-band width mirrors the landed
+ * grammar's proven 0.2 spread; the absolute positions and the composition pick (`min` vs product)
+ * await the parent leaf's empirical calibration on the headed matrix harness. Calibration swaps
+ * config values and the `composeRatios` seam — never this contract.
+ */
+
+/**
+ * Validates one threshold config value: a finite number in (0, 1].
+ * @param {String} name The config key, for the fail-loud message
+ * @param {Number} value
+ * @private
+ */
+function assertThreshold(name, value) {
+    if (!Number.isFinite(value) || value <= 0 || value > 1) {
+        throw new Error(`createVesselConversionSensor: ${name} must be a finite number in (0, 1] — got ${value}`)
+    }
+}
+
+/**
+ * Clamps one ratio into [0, 1], failing CLOSED on non-finite input: garbage geometry must read as
+ * "no overlap", never as "hold the current decision" (NaN compares false against every threshold,
+ * which would freeze a converted sensor permanently).
+ * @param {Number} value
+ * @returns {Number}
+ * @private
+ */
+function clampRatio(value) {
+    return Number.isFinite(value) ? Math.min(1, Math.max(0, value)) : 0
+}
+
+/**
+ * One axis of the min-extent-normalized overlap metric over `{x, y, width, height}` rects.
+ * @param {Object} a
+ * @param {Object} b
+ * @param {String} axis 'x' or 'y'
+ * @param {String} extent 'width' or 'height'
+ * @returns {Number} overlap along the axis divided by the smaller extent, clamped fail-closed
+ * @private
+ */
+function axisRatio(a, b, axis, extent) {
+    const
+        overlap   = Math.min(a[axis] + a[extent], b[axis] + b[extent]) - Math.max(a[axis], b[axis]),
+        minExtent = Math.min(a[extent], b[extent]);
+
+    return minExtent > 0 ? clampRatio(Math.max(0, overlap) / minExtent) : 0
+}
+
+/**
+ * Creates one dual-window conversion sensor for one gesture surface, closed over one conversion
+ * flag. One sensor serves one drag surface — a pointer drives at most one window-drag per window
+ * (the same single-slot reasoning as the tear-out choreography), so the flag never needs a map.
+ *
+ * Decisions flow through the two injected seams exclusively; the per-sample geometry record is the
+ * observability surface. A host binds the seams to the design record's named source-hook actuators:
+ * `onConvertIn → suspendWindowDrag` territory (the popup yields, the proxy embodies over the
+ * target), `onConvertOut → resumeWindowDrag` territory (the popup embodiment resumes — the emitted
+ * record's `sourceRect` is the live rect to resume at).
+ * @param {Object} config
+ * @param {Function} [config.composeRatios] `({rx, ry}) => Number` — composes the two per-axis
+ *     ratios into the one decision ratio. Defaults to `Math.min(rx, ry)` (both axes must cover the
+ *     smaller footprint). The calibration seam: the parent leaf's empirical pick lands here. A
+ *     non-finite return fails closed to 0.
+ * @param {Number} [config.convertThreshold=0.55] Composed ratio at/above which — pointer gate
+ *     satisfied — a detached vessel converts to a proxy. Must sit strictly above `revertThreshold`.
+ * @param {Number} [config.revertThreshold=0.35] Composed ratio below which a converted vessel
+ *     reverts to its detached embodiment. The gap to `convertThreshold` is the flicker-free dead band.
+ * @param {Function} config.onConvertIn Actuation seam, fired exactly once per conversion with the
+ *     final sample record: the host suspends the popup embodiment and embodies the proxy.
+ * @param {Function} config.onConvertOut Actuation seam, fired exactly once per reversion with the
+ *     final sample record: the host resumes the popup embodiment at the record's `sourceRect`.
+ * @returns {Object} `{converted, reset, sample}` — the live conversion flag (getter), the silent
+ *     idempotent terminal reset, and the per-frame sampler
+ */
+export function createVesselConversionSensor(config = {}) {
+    const {
+        composeRatios   = ({rx, ry}) => Math.min(rx, ry),
+        convertThreshold = 0.55,
+        revertThreshold  = 0.35,
+        onConvertIn,
+        onConvertOut
+    } = config;
+
+    assertThreshold('convertThreshold', convertThreshold);
+    assertThreshold('revertThreshold',  revertThreshold);
+
+    if (convertThreshold <= revertThreshold) {
+        throw new Error(
+            'createVesselConversionSensor: convertThreshold must sit strictly above revertThreshold — ' +
+            `the dead band between them is the flicker-free hysteresis contract (got in: ${convertThreshold}, out: ${revertThreshold})`
+        )
+    }
+
+    if (typeof composeRatios !== 'function') {
+        throw new Error('createVesselConversionSensor: composeRatios must be a function seam')
+    }
+
+    if (typeof onConvertIn !== 'function' || typeof onConvertOut !== 'function') {
+        throw new Error(
+            'createVesselConversionSensor: onConvertIn and onConvertOut are required function seams — ' +
+            'decisions flow through the actuators, never through polling'
+        )
+    }
+
+    // The single-gesture conversion flag: true while the dragged vessel embodies as a proxy.
+    let converted = false;
+
+    return {
+        /**
+         * @member {Boolean} converted
+         */
+        get converted() {
+            return converted
+        },
+
+        /**
+         * Terminal reset — SILENT and idempotent by contract: gesture terminals (commit, cancel,
+         * close, park) are the outcome machine's choreography; the sensor only forgets. The next
+         * gesture's samples decide fresh.
+         */
+        reset() {
+            converted = false
+        },
+
+        /**
+         * One gesture-frame decision over the LIVE rects. Fires at most one seam per sample:
+         * convert-in on crossing `convertThreshold` with the pointer inside the target,
+         * convert-out on crossing below `revertThreshold` OR the pointer leaving the target.
+         * Samples inside the dead band (gate unchanged) fire nothing — the hysteresis hold.
+         * @param {Object} data
+         * @param {Boolean} data.pointerInTarget The claim-protocol feed: pointer inside the
+         *     target's dock-accepting region. Gates conversion in BOTH directions.
+         * @param {Object} data.sourceRect Live `{x, y, width, height}` of the dragged vessel
+         * @param {Object} data.targetRect Live `{x, y, width, height}` of the target vessel
+         * @returns {Object} The sample record `{composed, converted, pointerInTarget, rx, ry,
+         *     sourceRect, targetRect}` — `converted` reflects the POST-decision state
+         */
+        sample({pointerInTarget, sourceRect, targetRect} = {}) {
+            const
+                bothRects = Boolean(sourceRect && targetRect),
+                pointer   = pointerInTarget === true,
+                rx        = bothRects ? axisRatio(sourceRect, targetRect, 'x', 'width')  : 0,
+                ry        = bothRects ? axisRatio(sourceRect, targetRect, 'y', 'height') : 0,
+                composed  = clampRatio(composeRatios({rx, ry}));
+
+            let event = null;
+
+            if (!converted) {
+                if (pointer && composed >= convertThreshold) {
+                    converted = true;
+                    event     = onConvertIn
+                }
+            } else if (!pointer || composed < revertThreshold) {
+                converted = false;
+                event     = onConvertOut
+            }
+
+            const record = {composed, converted, pointerInTarget: pointer, rx, ry, sourceRect, targetRect};
+
+            event?.(record);
+
+            return record
+        }
+    }
+}

--- a/test/playwright/unit/dashboard/DockVesselConversion.spec.mjs
+++ b/test/playwright/unit/dashboard/DockVesselConversion.spec.mjs
@@ -219,6 +219,35 @@ test.describe('Neo.dashboard.DockVesselConversion — createVesselConversionSens
         expect(garbageSensor.calls.converted).toHaveLength(0)
     });
 
+    test('invalid geometry DOMINATES the composition seam: a finite non-min composer can never elevate a degenerate rect', () => {
+        // the escape: width 0 yields rx = 0 but ry = 1 — an AVERAGING composer would read 0.5
+        // and clear a 0.45 threshold. The validity gate must force 0 BEFORE composition.
+        const averaging = harness({
+            composeRatios   : ({rx, ry}) => (rx + ry) / 2,
+            convertThreshold: 0.45,
+            revertThreshold : 0.25
+        });
+
+        const degenerate = averaging.sensor.sample({
+            pointerInTarget: true,
+            sourceRect     : rect(0, 0, 100, 100),
+            targetRect     : rect(0, 0, 0, 100)     // zero width, full-height overlap
+        });
+
+        expect(degenerate.composed, 'the composer was never consulted — invalid geometry is 0').toBe(0);
+        expect(degenerate.rx).toBe(0);
+        expect(degenerate.ry).toBe(0);
+        expect(averaging.calls.converted).toHaveLength(0);
+
+        // convert legitimately under the same composer, then feed the degenerate rect: REVERT
+        averaging.sensor.sample({pointerInTarget: true, sourceRect: rect(0, 0, 100, 100), targetRect: rect(0, 0, 100, 100)});
+        expect(averaging.sensor.converted).toBe(true);
+
+        averaging.sensor.sample({pointerInTarget: true, sourceRect: rect(0, 0, 100, 100), targetRect: rect(0, 0, 0, 100)});
+        expect(averaging.sensor.converted, 'a converted sensor fed degenerate geometry reverts').toBe(false);
+        expect(averaging.calls.reverted).toHaveLength(1)
+    });
+
     test('the convert-in record carries the full geometry + gate truth for the actuator', () => {
         const {calls, sensor} = harness();
         const source          = rect(10, 20, 300, 200),

--- a/test/playwright/unit/dashboard/DockVesselConversion.spec.mjs
+++ b/test/playwright/unit/dashboard/DockVesselConversion.spec.mjs
@@ -1,0 +1,256 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockVesselConversionTest'
+    },
+    // The sensor is a zero-import pure module: no Main facade, no LocalStorage addon. Declaring
+    // both mocks off keeps this file runnable SOLO — the mock paths call `Neo.ns`, which only
+    // exists once a sibling spec has loaded the real core into the shared worker.
+    mockLocalStorage: false,
+    mockMain        : false
+});
+
+import {test, expect}                 from '@playwright/test';
+import {createVesselConversionSensor} from '../../../../src/dashboard/DockVesselConversion.mjs';
+
+/**
+ * @summary The dual-window conversion sensor, driven end-to-end through its injected seams.
+ *
+ * Every witness is a contract pin from the ticket's AC set: the min-axis metric is REACHABLE for
+ * any size pair in both directions (the single-denominator formula it replaces provably is not),
+ * the dead band fires each decision exactly once across a slow crossing (zero flicker), the
+ * pointer gate holds in BOTH directions (rect overlap alone neither converts nor holds a
+ * conversion), live rects renormalize per sample, terminals reset silently, and garbage geometry
+ * fails CLOSED — a converted sensor fed NaN reverts instead of freezing. The seams are the
+ * decision surface; the returned sample record is the geometry surface.
+ */
+test.describe('Neo.dashboard.DockVesselConversion — createVesselConversionSensor', () => {
+    const harness = (config = {}) => {
+        const calls = {converted: [], reverted: []};
+
+        const sensor = createVesselConversionSensor({
+            onConvertIn : record => calls.converted.push(record),
+            onConvertOut: record => calls.reverted.push(record),
+            ...config
+        });
+
+        return {calls, sensor}
+    };
+
+    const rect = (x, y, width, height) => ({x, y, width, height});
+
+    // Slides a 100×100 source across a 100×100 target at (0,0) along x: composed = (100 - bx) / 100
+    // (ry stays 1), so each sample's ratio is chosen directly by the source's x offset.
+    const slideSample = (sensor, bx, pointerInTarget = true) => sensor.sample({
+        pointerInTarget,
+        sourceRect: rect(bx, 0, 100, 100),
+        targetRect: rect(0, 0, 100, 100)
+    });
+
+    test('reachability: composed attains 1.0 and converts for EVERY size-pair direction — small over large, large over small, near-equal, extreme aspect', () => {
+        const pairs = [
+            {name: 'small source fully over a large target', source: rect(100, 100, 200, 150), target: rect(0, 0, 1200, 800)},
+            {name: 'large source fully covering a small target', source: rect(0, 0, 1200, 800), target: rect(300, 200, 200, 150)},
+            {name: 'near-equal windows aligned', source: rect(0, 0, 640, 480), target: rect(0, 0, 600, 500)},
+            {name: 'extreme aspect ratios crossing', source: rect(0, 300, 1600, 200), target: rect(100, 0, 300, 900)}
+        ];
+
+        for (const {name, source, target} of pairs) {
+            const {calls, sensor} = harness();
+            const record          = sensor.sample({pointerInTarget: true, sourceRect: source, targetRect: target});
+
+            expect(record.composed, `${name}: the min-axis metric must reach 1.0`).toBe(1);
+            expect(record.rx).toBe(1);
+            expect(record.ry).toBe(1);
+            expect(calls.converted, `${name}: full min-extent coverage converts`).toHaveLength(1);
+            expect(sensor.converted).toBe(true)
+        }
+    });
+
+    test('single-fire hysteresis: one convert-in on the crossing, silence inside the dead band, one convert-out on the retreat', () => {
+        const {calls, sensor} = harness();
+
+        // approach below the convert threshold: nothing fires
+        [100, 80, 50].forEach(bx => slideSample(sensor, bx));
+        expect(calls.converted).toHaveLength(0);
+
+        // crossing at 0.60 ≥ 0.55 fires exactly once
+        slideSample(sensor, 40);
+        expect(calls.converted).toHaveLength(1);
+        expect(sensor.converted).toBe(true);
+
+        // jitter INSIDE the dead band (0.50, 0.40 — both between 0.35 and 0.55): zero events
+        [50, 60].forEach(bx => slideSample(sensor, bx));
+        expect(calls.converted).toHaveLength(1);
+        expect(calls.reverted).toHaveLength(0);
+
+        // dropping below the revert threshold (0.34 < 0.35) fires convert-out exactly once
+        slideSample(sensor, 66);
+        expect(calls.reverted).toHaveLength(1);
+        expect(sensor.converted).toBe(false);
+
+        // continued retreat stays silent
+        slideSample(sensor, 80);
+        expect(calls.reverted).toHaveLength(1)
+    });
+
+    test('threshold boundary semantics: composed exactly AT convertThreshold converts; exactly AT revertThreshold holds', () => {
+        const {calls, sensor} = harness();
+
+        slideSample(sensor, 45); // (100 - 45) / 100 = 0.55 — at-threshold converts (>=)
+        expect(calls.converted).toHaveLength(1);
+
+        slideSample(sensor, 65); // 0.35 — at-threshold is still inside the band: holds (< reverts)
+        expect(calls.reverted).toHaveLength(0);
+        expect(sensor.converted).toBe(true)
+    });
+
+    test('pointer gate, both directions: overlap alone never converts, and overlap alone never HOLDS a conversion', () => {
+        const {calls, sensor} = harness();
+        const source          = rect(0, 0, 100, 100),
+              target          = rect(0, 0, 100, 100);
+
+        // full overlap, pointer outside: no conversion, ever
+        for (let i = 0; i < 3; i++) {
+            const record = sensor.sample({pointerInTarget: false, sourceRect: source, targetRect: target});
+            expect(record.composed).toBe(1);
+            expect(record.converted).toBe(false)
+        }
+        expect(calls.converted).toHaveLength(0);
+
+        // pointer enters: converts
+        sensor.sample({pointerInTarget: true, sourceRect: source, targetRect: target});
+        expect(calls.converted).toHaveLength(1);
+
+        // pointer leaves at UNCHANGED full overlap: reverts — the gate holds the conversion, not the rects
+        sensor.sample({pointerInTarget: false, sourceRect: source, targetRect: target});
+        expect(calls.reverted).toHaveLength(1);
+        expect(calls.reverted[0].composed, 'reversion happened at full rect overlap').toBe(1);
+        expect(calls.reverted[0].sourceRect, 'the out record anchors the resume rect').toBe(source);
+
+        // pointer re-enters above threshold: re-converts
+        sensor.sample({pointerInTarget: true, sourceRect: source, targetRect: target});
+        expect(calls.converted).toHaveLength(2)
+    });
+
+    test('live-rect renormalization: a mid-sequence target resize re-derives the ratios per sample', () => {
+        const {calls, sensor} = harness();
+        const source          = rect(60, 0, 100, 100);
+
+        // 40px x-overlap against a 100-wide target: rx = 40 / min(100, 100) = 0.4
+        const before = sensor.sample({pointerInTarget: true, sourceRect: source, targetRect: rect(0, 0, 100, 100)});
+        expect(before.composed).toBe(0.4);
+
+        // the target resizes to 80 wide: overlap 20px, min extent 80 → rx = 0.25 — same source, new truth
+        const after = sensor.sample({pointerInTarget: true, sourceRect: source, targetRect: rect(0, 0, 80, 100)});
+        expect(after.composed).toBe(0.25);
+
+        expect(calls.converted).toHaveLength(0)
+    });
+
+    test('reset is SILENT and idempotent: no seam emission, and the next gesture decides fresh', () => {
+        const {calls, sensor} = harness();
+        const source          = rect(0, 0, 100, 100),
+              target          = rect(0, 0, 100, 100);
+
+        sensor.sample({pointerInTarget: true, sourceRect: source, targetRect: target});
+        expect(calls.converted).toHaveLength(1);
+
+        sensor.reset();
+        sensor.reset(); // idempotent — a second terminal cleanup pass is harmless
+
+        expect(sensor.converted).toBe(false);
+        expect(calls.reverted, 'terminals belong to the outcome machine — reset never actuates').toHaveLength(0);
+
+        // the next gesture's crossing re-fires cleanly
+        sensor.sample({pointerInTarget: true, sourceRect: source, targetRect: target});
+        expect(calls.converted).toHaveLength(2)
+    });
+
+    test('garbage geometry fails CLOSED: degenerate and non-finite rects compose to 0, and a converted sensor REVERTS on them', () => {
+        const {calls, sensor} = harness();
+
+        // zero-extent target: composed 0, no division artifact
+        expect(sensor.sample({pointerInTarget: true, sourceRect: rect(0, 0, 100, 100), targetRect: rect(0, 0, 0, 100)}).composed).toBe(0);
+
+        // missing rects: composed 0, no throw
+        expect(sensor.sample({pointerInTarget: true, sourceRect: rect(0, 0, 100, 100)}).composed).toBe(0);
+        expect(sensor.sample().composed).toBe(0);
+        expect(calls.converted).toHaveLength(0);
+
+        // convert legitimately, then feed NaN: NaN comparisons would freeze the conversion — the
+        // fail-closed clamp reads garbage as "no overlap" and reverts instead
+        sensor.sample({pointerInTarget: true, sourceRect: rect(0, 0, 100, 100), targetRect: rect(0, 0, 100, 100)});
+        expect(sensor.converted).toBe(true);
+
+        sensor.sample({pointerInTarget: true, sourceRect: rect(NaN, 0, 100, 100), targetRect: rect(0, 0, 100, 100)});
+        expect(sensor.converted).toBe(false);
+        expect(calls.reverted).toHaveLength(1);
+        expect(calls.reverted[0].composed).toBe(0)
+    });
+
+    test('the composition seam owns the decision: an injected composer changes the verdict, and a garbage composer fails closed', () => {
+        // rx = 0.8, ry = 0.6: min composes to 0.6 (converts at 0.55) — product composes to 0.48 (does not)
+        const sample = sensor => sensor.sample({
+            pointerInTarget: true,
+            sourceRect     : rect(20, 0, 100, 100),
+            targetRect     : rect(0, 40, 100, 100)
+        });
+
+        const minSensor = harness();
+        const record    = sample(minSensor.sensor);
+        expect(record.rx).toBe(0.8);
+        expect(record.ry).toBe(0.6);
+        expect(minSensor.calls.converted).toHaveLength(1);
+
+        const productSensor = harness({composeRatios: ({rx, ry}) => rx * ry});
+        expect(sample(productSensor.sensor).composed).toBeCloseTo(0.48, 10);
+        expect(productSensor.calls.converted).toHaveLength(0);
+
+        // a composer returning non-finite output must read as 0, even at full overlap + pointer
+        const garbageSensor = harness({composeRatios: () => NaN});
+        const garbageRecord = garbageSensor.sensor.sample({
+            pointerInTarget: true,
+            sourceRect     : rect(0, 0, 100, 100),
+            targetRect     : rect(0, 0, 100, 100)
+        });
+        expect(garbageRecord.composed).toBe(0);
+        expect(garbageSensor.calls.converted).toHaveLength(0)
+    });
+
+    test('the convert-in record carries the full geometry + gate truth for the actuator', () => {
+        const {calls, sensor} = harness();
+        const source          = rect(10, 20, 300, 200),
+              target          = rect(0, 0, 1000, 700);
+
+        sensor.sample({pointerInTarget: true, sourceRect: source, targetRect: target});
+
+        expect(calls.converted[0]).toEqual({
+            composed       : 1,
+            converted      : true,
+            pointerInTarget: true,
+            rx             : 1,
+            ry             : 1,
+            sourceRect     : source,
+            targetRect     : target
+        })
+    });
+
+    test('config validation fails LOUD: inverted or degenerate bands, out-of-range thresholds, missing or non-function seams', () => {
+        const seams = {onConvertIn: () => {}, onConvertOut: () => {}};
+
+        expect(() => createVesselConversionSensor({...seams, convertThreshold: 0.3, revertThreshold: 0.5}))
+            .toThrow(/strictly above/);
+        expect(() => createVesselConversionSensor({...seams, convertThreshold: 0.4, revertThreshold: 0.4}))
+            .toThrow(/strictly above/);
+        expect(() => createVesselConversionSensor({...seams, convertThreshold: 1.2}))
+            .toThrow(/finite number in \(0, 1\]/);
+        expect(() => createVesselConversionSensor({...seams, revertThreshold: 0}))
+            .toThrow(/finite number in \(0, 1\]/);
+        expect(() => createVesselConversionSensor({onConvertIn: () => {}}))
+            .toThrow(/required function seams/);
+        expect(() => createVesselConversionSensor({...seams, composeRatios: 'min'}))
+            .toThrow(/composeRatios must be a function seam/)
+    })
+});


### PR DESCRIPTION
Resolves #15432

Related: #15395 — stays OPEN owning the empirical remainder (threshold + composition calibration, the wire-in behind #15246's claim feed, headed matrix cells), per the epic's twice-proven tier split (#15407 ← #15244, #15426 ← #15243). This PR is its contract tier.

The dual-window conversion decision authority: `src/dashboard/DockVesselConversion.mjs` — a pure, zero-import factory (`createVesselConversionSensor`, the `createDockTearOutHandlers` idiom: closure state, injected seams, witnesses drive without a browser) deciding WHEN a dragged popup converts into a semi-transparent proxy over a target vessel, and when it converts back.

The contract, four commitments:

- **Min-axis metric.** Per-axis overlap normalized by the SMALLER extent per axis, composed through an injectable seam (default `min(rx, ry)`). Reachable (composed = 1.0) for EVERY size pair in both directions — the single-denominator ratio it replaces provably caps unreachable for large-over-small and mirror (#15395's core finding). Live rects every sample: a mid-session resize renormalizes on the next frame.
- **Dead-band hysteresis.** `convertThreshold` strictly above `revertThreshold`, validated fail-loud. Each decision fires only on crossing its OWN threshold, so the #15413 false-flip class is structurally excluded with NO arming state — the convert-in moment sits above the revert band by construction, the inverse of the landed exit-inside-reattach-zone geometry that required Schmitt arming.
- **Pointer gate, both directions.** Rect overlap alone never converts AND never holds a conversion — intent stays pointer-owned (the claim-protocol feed), so a stale overlap can never pin a converted vessel.
- **Fail-closed geometry.** Degenerate/non-finite rects compose to 0; a converted sensor fed NaN REVERTS (NaN compares false against both thresholds — unguarded, it would freeze converted forever).

**Design-time resolution recorded — the negative answer to the "may amend ADR 0029" clause carried by the parent leaf:** conversion-in/out is the geometric predicate for the outcome machine's EXISTING `DETACHED_MOVING ⇄ HOVERING_CLAIM` transition (ADR 0029 §2.8.2); the §2.3 source hooks `suspendWindowDrag` / `resumeWindowDrag` are the contract-named actuators. No new state, no amendment — the mapping lives in the module's contract prose.

Evidence: L1-unit (10 witnesses on the pure seam — reachability sweep across four size-pair classes, single-fire hysteresis with in-band jitter, at-threshold boundary semantics, the pointer-gate truth table including overlap-cannot-hold, live-rect renormalization, silent idempotent reset, fail-closed garbage geometry, composition-seam decision ownership + garbage-composer fail-closed, the full actuator record shape, fail-loud config) → the wire-in's L2/L3 witnesses are #15395's deliverable behind #15246. Residual: calibrated threshold/composition values + wire-in + headed cells [#15395, open by design].

## Deltas from ticket

- None on scope. One evidence-honesty note: the shipped defaults (0.55 / 0.35, `min` composer) are REVIEWABLE PLACEHOLDERS documented as such in-module — the dead-band width mirrors the landed grammar's proven 0.2 spread; absolute positions await #15395's headed calibration.

## Test Evidence

- Focused spec: **10/10** (35s). Dashboard + draggable subsets: **394/394** (32s). Full unit suite: **8126 passed, exit 0** at this tree (a rerun showed known infra-flaky timeouts in ChromaDB-backed `ai/services` specs + `lintTreeJson` — disjoint from this delta: the module imports nothing, nothing imports it yet, and the branch touches neither `ai/` nor `learn/`).
- The spec declares `mockMain: false, mockLocalStorage: false` — the sensor needs neither, and declaring it keeps the file runnable SOLO (the mock paths call `Neo.ns`, which only exists once a sibling spec loads the real core into the shared worker).

## Post-Merge Validation

- [ ] #15395's wire-in binds the sensor once #15246's claim feed lands (no geometry re-derivation — Contract Ledger row 3).
- [ ] #15396's park actuation consumes convert-in/out through the same seams.

## Commits

`b7d56d555b` — the sensor + its 10 witnesses.

Authored by Clio (Claude Fable 5, Claude Code). Session 0c8fc4d9-2456-44fd-b120-048402bb9839.
