### PR TITLE
feat(dashboard): the vessel park machine — contract tier (#15436)

### DIFF
--- a/src/dashboard/DockVesselPark.mjs
+++ b/src/dashboard/DockVesselPark.mjs
@@ -1,0 +1,150 @@
+/**
+ * @module Neo.dashboard.DockVesselPark
+ * @summary The in-gesture vessel lifecycle authority — the pure choreography deciding what happens
+ * to a dragged popup's REAL OS window between conversion and the gesture terminal: park it, never
+ * close it; re-show the SAME window; dispose exactly once, on commit only.
+ *
+ * Why park exists (the platform law this machine encodes): popup acquisition consumes WHATWG
+ * transient user activation, and `windowOpen` reports failure by BOOLEAN — a blocked popup never
+ * throws. A popup→proxy→popup round-trip within ONE continuous gesture therefore cannot count on
+ * re-acquisition: the activation that opened the vessel may be consumed, and a mid-gesture reopen
+ * reads as unsolicited to popup blocking. Close-and-reopen is a one-way door — the user drags over
+ * a target, changes their mind, drags out, and their window is unrecoverable without a fresh
+ * gesture. The park contract removes the door: **conversion parks the vessel (a render-target
+ * effect behind a host seam), out-conversion re-shows the same OS window, and the activation wall
+ * is unreachable BY CONSTRUCTION — this machine has no acquisition seam to call.**
+ *
+ * The choreography contract this implements (the docking design record, multi-window amendment):
+ * - **The in-gesture segment only.** The conversion DECISION belongs to the companion sensor
+ *   ({@link Neo.dashboard.DockVesselConversion}); the gesture terminals belong to the outcome
+ *   machine; the reintegration close POLICY belongs to the host behind the dispose seam. This
+ *   machine owns the ordering between them: convert-in → park; convert-out → re-show; terminal →
+ *   dispose (commit) or restore (everything else).
+ * - **Commit is the ONLY disposition.** A committed target owns the item now, so the parked vessel
+ *   retires through the host's one `disposeVessel` call — exactly once, slot-cleared-first, so a
+ *   duplicate terminal (stale event) disposes nothing further. EVERY other outcome — cancel,
+ *   reject, or any terminal the host routes while parked — fails toward RESTORE: the machine never
+ *   loses the user's window to a lifecycle edge.
+ * - **Two rect sources, one rule.** Out-conversion re-shows at the out-event's LIVE rect when the
+ *   caller supplies one (the design record's `resumeWindowDrag(widgetName, proxyRect)` semantics —
+ *   the popup resumes under the pointer, where the drag is NOW); absent a supplied rect it falls
+ *   back to the recorded pre-conversion rect (origin semantics — the restore path's meaning). The
+ *   recorded rect preserves the user's own mid-session sizing either way.
+ * - **Stale events are no-ops, not errors.** Duplicate convert-in with a live slot, convert-out or
+ *   terminal with no slot, and terminals for a different `itemId` all return silently — the
+ *   exact-once/idempotent cleanup bar every gesture surface owes its terminals.
+ */
+
+/**
+ * Creates the in-gesture park handlers a dock composition binds to the conversion sensor's
+ * actuation seams, closed over one single-gesture park slot. One handler set serves one workspace
+ * composition — a pointer drives at most one drag per window (the tear-out choreography's
+ * single-slot reasoning), so the slot never needs a map.
+ * @param {Object} seams
+ * @param {Function} seams.disposeVessel Host retirement seam: `({itemId, windowName}) => void|Promise` —
+ *     the ONE close path for a committed tear-in, routed to the host's reintegration close policy.
+ *     Called exactly once per commit, never for any other outcome.
+ * @param {Function} seams.parkVessel Host park seam: `({itemId, windowName}) => void|Promise` — the
+ *     platform mechanic (hide, offscreen move, minimize — matrix-selected, the host's business).
+ *     Parking is a render-target effect: it must never close the window or touch model documents.
+ * @param {Function} seams.reshowVessel Host re-show seam: `({itemId, rect, windowName}) => void|Promise` —
+ *     re-presents the SAME parked window at `rect`. Zero re-acquisition: the machine guarantees
+ *     `windowName` is the one it parked.
+ * @returns {Object} `{onConversionIn, onConversionOut, onGestureTerminal, parkedVessel}` — the two
+ *     sensor-driven handlers, the terminal router, and the read-only park-slot view
+ */
+export function createVesselParkHandlers({disposeVessel, parkVessel, reshowVessel} = {}) {
+    if (typeof disposeVessel !== 'function' || typeof parkVessel !== 'function' || typeof reshowVessel !== 'function') {
+        throw new Error(
+            'createVesselParkHandlers: disposeVessel, parkVessel and reshowVessel are required function seams — ' +
+            'the machine owns ordering, the host owns every platform effect'
+        )
+    }
+
+    // The single-gesture park slot: `{itemId, preConversionRect, windowName}` while parked, else null.
+    let parked = null;
+
+    return {
+        /**
+         * The sensor converted the dragged vessel into a proxy: PARK the OS window — never close
+         * it (the one-way activation door this module exists to remove). Records the vessel's
+         * pre-conversion rect as the restore anchor. A convert-in while a slot is live is a stale
+         * re-fire: ignored.
+         * @param {Object} data
+         * @param {String} data.itemId
+         * @param {Object} [data.sourceRect] The vessel's live rect at the conversion moment —
+         *     recorded as the restore/origin anchor
+         * @param {String} data.windowName
+         */
+        onConversionIn(data) {
+            if (parked) return;
+
+            let {itemId, sourceRect, windowName} = data;
+
+            parked = {itemId, preConversionRect: sourceRect ?? null, windowName};
+
+            parkVessel({itemId, windowName})
+        },
+
+        /**
+         * The sensor reverted the conversion: RE-SHOW the same parked window. At the supplied live
+         * rect when the out-event carries one (the popup resumes under the pointer); at the
+         * recorded pre-conversion rect otherwise (origin semantics). No slot = stale event = no-op.
+         * @param {Object} [data]
+         * @param {Object} [data.rect] The live rect to resume at (the sensor's out-record
+         *     `sourceRect` is the natural feed)
+         */
+        onConversionOut(data) {
+            let vessel = parked;
+
+            if (!vessel) return;
+
+            parked = null;
+
+            reshowVessel({
+                itemId    : vessel.itemId,
+                rect      : data?.rect ?? vessel.preConversionRect,
+                windowName: vessel.windowName
+            })
+        },
+
+        /**
+         * The gesture resolved while the vessel is parked — the outcome machine's terminal routed
+         * here decides the parked window's fate:
+         * - `committed`: the target owns the item now — the ONE `disposeVessel` call fires (the
+         *   host's close policy takes it from there). Slot cleared first: a duplicate terminal
+         *   disposes nothing further.
+         * - anything else (cancel, reject, host-routed disconnect): RESTORE — re-show at the
+         *   pre-conversion rect with zero disposition. The machine fails toward never losing the
+         *   user's window.
+         * A terminal for a different `itemId` than the parked one is stale: no-op.
+         * @param {Object} data
+         * @param {String} data.itemId
+         * @param {String} data.outcome `'committed'` disposes; every other value restores
+         */
+        onGestureTerminal(data) {
+            let vessel = parked;
+
+            if (!vessel || vessel.itemId !== data.itemId) return;
+
+            parked = null;
+
+            if (data.outcome === 'committed') {
+                disposeVessel({itemId: vessel.itemId, windowName: vessel.windowName})
+            } else {
+                reshowVessel({
+                    itemId    : vessel.itemId,
+                    rect      : vessel.preConversionRect,
+                    windowName: vessel.windowName
+                })
+            }
+        },
+
+        /**
+         * @member {Object|null} parkedVessel
+         */
+        get parkedVessel() {
+            return parked
+        }
+    }
+}

--- a/test/playwright/unit/dashboard/DockVesselPark.spec.mjs
+++ b/test/playwright/unit/dashboard/DockVesselPark.spec.mjs
@@ -1,0 +1,178 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockVesselParkTest'
+    },
+    // The machine is a zero-import pure module: no Main facade, no LocalStorage addon. Declaring
+    // both mocks off keeps this file runnable SOLO (the mock paths call `Neo.ns`, which only
+    // exists once a sibling spec loads the real core into the shared worker).
+    mockLocalStorage: false,
+    mockMain        : false
+});
+
+import {test, expect}             from '@playwright/test';
+import {createVesselParkHandlers} from '../../../../src/dashboard/DockVesselPark.mjs';
+
+/**
+ * @summary The in-gesture vessel park machine, driven end-to-end through its injected seams.
+ *
+ * Every witness is a contract pin from the ticket's AC set: conversion PARKS and never closes
+ * (the activation wall is structural — the machine has no acquisition seam, and the round-trip
+ * witness proves the full ledger touches only the three injected seams), out-conversion re-shows
+ * the SAME window with the live-rect/origin-fallback rule, commit disposes exactly once with
+ * every other outcome failing toward restore, and stale events (duplicate convert-in, slotless
+ * out/terminal, mismatched itemId) are silent no-ops. The seams are the assertion surface.
+ */
+test.describe('Neo.dashboard.DockVesselPark — createVesselParkHandlers', () => {
+    const harness = () => {
+        const calls = {disposed: [], parked: [], reshown: []};
+
+        const handlers = createVesselParkHandlers({
+            disposeVessel: vessel => calls.disposed.push(vessel),
+            parkVessel   : vessel => calls.parked.push(vessel),
+            reshowVessel : vessel => calls.reshown.push(vessel)
+        });
+
+        return {calls, handlers}
+    };
+
+    const rect   = (x, y, width, height) => ({x, y, width, height});
+    const inData = (overrides = {}) => ({
+        itemId    : 'graph',
+        sourceRect: rect(500, 120, 640, 480),
+        windowName: 'vessel-graph',
+        ...overrides
+    });
+
+    test('conversion-in PARKS with the vessel identity and never touches dispose — the slot records the origin anchor', () => {
+        const {calls, handlers} = harness();
+
+        handlers.onConversionIn(inData());
+
+        expect(calls.parked).toEqual([{itemId: 'graph', windowName: 'vessel-graph'}]);
+        expect(calls.disposed, 'parking must NEVER close — the one-way activation door').toHaveLength(0);
+        expect(handlers.parkedVessel).toEqual({
+            itemId           : 'graph',
+            preConversionRect: rect(500, 120, 640, 480),
+            windowName       : 'vessel-graph'
+        })
+    });
+
+    test('a duplicate conversion-in with a live slot is a stale re-fire: parked exactly once', () => {
+        const {calls, handlers} = harness();
+
+        handlers.onConversionIn(inData());
+        handlers.onConversionIn(inData({windowName: 'vessel-imposter'}));
+
+        expect(calls.parked).toHaveLength(1);
+        expect(handlers.parkedVessel.windowName, 'the first vessel holds the slot').toBe('vessel-graph')
+    });
+
+    test('conversion-out re-shows the SAME window at the supplied LIVE rect — the resume-under-the-pointer semantics', () => {
+        const {calls, handlers} = harness();
+        const liveRect          = rect(900, 300, 640, 480);
+
+        handlers.onConversionIn(inData());
+        handlers.onConversionOut({rect: liveRect});
+
+        expect(calls.reshown).toEqual([{itemId: 'graph', rect: liveRect, windowName: 'vessel-graph'}]);
+        expect(calls.disposed).toHaveLength(0);
+        expect(handlers.parkedVessel).toBeNull()
+    });
+
+    test('conversion-out without a supplied rect falls back to the recorded pre-conversion rect — origin semantics', () => {
+        const {calls, handlers} = harness();
+
+        handlers.onConversionIn(inData());
+        handlers.onConversionOut();
+
+        expect(calls.reshown).toEqual([{
+            itemId    : 'graph',
+            rect      : rect(500, 120, 640, 480),
+            windowName: 'vessel-graph'
+        }])
+    });
+
+    test('conversion-out with no slot is a stale event: zero seam calls', () => {
+        const {calls, handlers} = harness();
+
+        handlers.onConversionOut({rect: rect(0, 0, 100, 100)});
+
+        expect(calls.reshown).toHaveLength(0);
+        expect(calls.disposed).toHaveLength(0)
+    });
+
+    test('the commit terminal disposes EXACTLY once — a duplicate terminal disposes nothing further, and re-show never fires', () => {
+        const {calls, handlers} = harness();
+
+        handlers.onConversionIn(inData());
+        handlers.onGestureTerminal({itemId: 'graph', outcome: 'committed'});
+
+        expect(calls.disposed).toEqual([{itemId: 'graph', windowName: 'vessel-graph'}]);
+        expect(calls.reshown).toHaveLength(0);
+        expect(handlers.parkedVessel).toBeNull();
+
+        handlers.onGestureTerminal({itemId: 'graph', outcome: 'committed'});
+        expect(calls.disposed, 'slot cleared first — stale duplicate commits nothing').toHaveLength(1)
+    });
+
+    test('every non-commit outcome RESTORES at the pre-conversion rect and never disposes — cancel, reject, and unknown alike', () => {
+        for (const outcome of ['cancelled', 'rejected', 'terminal-detached', undefined]) {
+            const {calls, handlers} = harness();
+
+            handlers.onConversionIn(inData());
+            handlers.onGestureTerminal({itemId: 'graph', outcome});
+
+            expect(calls.disposed, `outcome "${outcome}" must never dispose`).toHaveLength(0);
+            expect(calls.reshown, `outcome "${outcome}" restores the window`).toEqual([{
+                itemId    : 'graph',
+                rect      : rect(500, 120, 640, 480),
+                windowName: 'vessel-graph'
+            }]);
+            expect(handlers.parkedVessel).toBeNull()
+        }
+    });
+
+    test('a terminal for a DIFFERENT itemId is stale: the parked vessel survives untouched', () => {
+        const {calls, handlers} = harness();
+
+        handlers.onConversionIn(inData());
+        handlers.onGestureTerminal({itemId: 'other-item', outcome: 'committed'});
+
+        expect(calls.disposed).toHaveLength(0);
+        expect(calls.reshown).toHaveLength(0);
+        expect(handlers.parkedVessel?.itemId).toBe('graph')
+    });
+
+    test('the full round-trip ledger — park, out, park again, commit — touches ONLY the three injected seams, dispose count exactly 1', () => {
+        const {calls, handlers} = harness();
+        const midRect           = rect(700, 200, 640, 480);
+
+        handlers.onConversionIn(inData());                          // over the target: park
+        handlers.onConversionOut({rect: midRect});                  // changed mind: same window back, no reopen
+        handlers.onConversionIn(inData({sourceRect: midRect}));     // over again: park again
+        handlers.onGestureTerminal({itemId: 'graph', outcome: 'committed'}); // dropped in: dispose
+
+        // The activation-wall AC at contract tier: the machine exposes NO acquisition surface, so
+        // the complete ledger of platform effects across the round-trip is exactly these calls —
+        // zero mid-gesture window opens are possible by construction.
+        expect(calls.parked).toHaveLength(2);
+        expect(calls.reshown).toEqual([{itemId: 'graph', rect: midRect, windowName: 'vessel-graph'}]);
+        expect(calls.disposed).toEqual([{itemId: 'graph', windowName: 'vessel-graph'}]);
+        expect(handlers.parkedVessel).toBeNull()
+    });
+
+    test('config validation fails LOUD: missing or non-function seams throw', () => {
+        const seams = {
+            disposeVessel: () => {},
+            parkVessel   : () => {},
+            reshowVessel : () => {}
+        };
+
+        expect(() => createVesselParkHandlers()).toThrow(/required function seams/);
+        expect(() => createVesselParkHandlers({...seams, parkVessel: undefined})).toThrow(/required function seams/);
+        expect(() => createVesselParkHandlers({...seams, reshowVessel: 'hide'})).toThrow(/required function seams/);
+        expect(() => createVesselParkHandlers({...seams, disposeVessel: null})).toThrow(/required function seams/)
+    })
+});


### PR DESCRIPTION
Resolves #15436

Related: #15396 — stays OPEN owning the matrix-cited platform park mechanic + the headed round-trip cell; this PR is its contract tier, completing the G3 contract pair with the sibling sensor (#15432 / PR #15434, in review). Same tier pattern as the epic's prior splits (#15407 ← #15244, #15426 ← #15243).

The in-gesture vessel lifecycle authority: `src/dashboard/DockVesselPark.mjs` — a pure, zero-import factory (`createVesselParkHandlers`, the `createDockTearOutHandlers` idiom: one single-gesture slot, injected seams, witnesses drive without a browser) owning the ordering between conversion and terminal: **park it, never close it; re-show the SAME window; dispose exactly once, on commit only.**

The contract, four commitments:

- **The activation wall is structural.** Popup re-acquisition mid-gesture cannot be counted on (activation consumed; `windowOpen` fails by Boolean) — so the machine has NO acquisition seam at all. The round-trip witness asserts the complete platform-effect ledger across park → out → park → commit is exactly the three injected seams, dispose count exactly 1: zero mid-gesture window opens are possible by construction.
- **Commit is the only disposition.** `committed` routes the ONE `disposeVessel` call (the host binds it to the G4 close policy); every other outcome — cancel, reject, unknown — fails toward RESTORE at the recorded pre-conversion rect. The machine never loses the user's window to a lifecycle edge.
- **Two rect sources, one rule.** Out-conversion re-shows at the out-event's live rect when supplied (the §2.3 `resumeWindowDrag` semantics — resume under the pointer), falling back to the pre-conversion rect (origin semantics); the recorded rect preserves the user's mid-session sizing either way.
- **Stale events are silent no-ops.** Duplicate convert-in, slotless out/terminal, mismatched-`itemId` terminals: the §2.8.2 invariant-4 exact-once/idempotent bar, the `DockTearOut` stale-terminal guard idiom.

No ADR 0029 amendment (same negative resolution class as the sibling's): park is in-gesture embodiment state behind host seams — the outcome machine gains no state; commit-precedes-close and close-as-render-target-effect stay host obligations at the seams (§2.8.3).

Evidence: L1-unit (10 witnesses on the pure seams — park-never-dispose with identity payload, duplicate-in guard, live-rect re-show, origin-fallback re-show, slotless no-ops, exact-once commit with duplicate-terminal guard, restore-on-every-non-commit-outcome sweep, mismatched-itemId guard, the full round-trip ledger, fail-loud config) → the platform mechanic selection + the headed round-trip cell are #15396's deliverable on the #15243 harness. Residual: mechanic citation + headed cell [#15396, open by design].

## Deltas from ticket

- None substantive. One design-time sharpening recorded in module prose: the ticket's "re-shows with its pre-conversion rect" resolved into the two-source rule (live rect when supplied per §2.3's `resumeWindowDrag(widgetName, proxyRect)`, pre-conversion rect as the fallback/origin path) — honoring both the ticket's zero-re-acquisition intent and the design record's resume-under-the-pointer semantics.

## Test Evidence

- Focused spec: **10/10** (40s). Dashboard + draggable subsets: **394/394** (33s — 384 base + these 10; the sibling sensor's 10 live on its own unmerged branch).
- The spec declares `mockMain: false, mockLocalStorage: false` — same solo-runnability rationale as the sibling spec.

## Post-Merge Validation

- [ ] The #15395 wire-in binds sensor → park handlers (convert-in/out seams) once #15246's claim feed lands.
- [ ] #15396's headed round-trip cell consumes this machine with acquisition-count receipts (zero mid-gesture opens, observed not just constructed).
- [ ] #15247's close policy lands behind `disposeVessel` untouched.

## Commits

`72f564e150` — the machine + its 10 witnesses.

Authored by Clio (Claude Fable 5, Claude Code). Session 0c8fc4d9-2456-44fd-b120-048402bb9839.
