### PR TITLE
feat(dashboard): G1 dock tear-out lands — live vessel gesture, composition law, e2e witnesses (#15244)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -1718,6 +1718,340 @@ class DemoBWorkspace extends Container {
     }
 
     /**
+     * Drives the REAL G1 dock tear-out gesture end-to-end for the e2e witness leg. Unlike
+     * {@link #executeCrossWindowStep} (a two-window transfer over the coordinator), this is the
+     * single-window boundary grammar: it arms a tab drag, flings the proxy past the window
+     * boundary so {@link Neo.dashboard.DockTabSortZone} re-fires `dockTearOutExit`, the host opens
+     * a `?popout=` vessel, then — gated on that vessel's ACTUAL birth
+     * ({@link #onWindowConnect} → {@link #tearOutConnects}) — survives deliberate post-birth moves
+     * (the reap-regression survival probe) and either releases while detached (`dockTearOutTerminal`
+     * → the host's `detachItem` commit + {@link #adoptTearOutPane}) or cancels via Escape
+     * (`dockTearOutCancel` → zero-mutation vessel close).
+     *
+     * The proof is OBSERVABLE-ONLY — committed document truth + vessel bookkeeping. It never reads
+     * the machine's internal drag state, because the gesture guards ARE the contract: a cancelled
+     * tear-out leaves the committed document byte-identical by construction (nothing writes it until
+     * the terminal), and a committed detach is the item ABSENT from every node yet PRESENT in the
+     * catalog (the vessel owns it; nothing leaked).
+     * @param {Object} step
+     * @param {String} step.itemId The dock item to tear out.
+     * @param {String} step.sourceNodeId The tabs node currently holding it.
+     * @param {Object} [options={}]
+     * @param {Boolean} [options.cancel=false] Escape while detached instead of releasing — the zero-mutation witness.
+     * @param {Number} [options.postBirthMoves=2] Deliberate outward moves after birth (the survival probe; floored at 2).
+     * @returns {Promise<Object>}
+     */
+    async executeTearOutStep(step, {cancel = false, postBirthMoves = 2} = {}) {
+        let me                     = this,
+            {itemId, sourceNodeId} = step || {},
+            workspaceId            = DemoBWorkspace.MAIN_WORKSPACE_ID,
+            document               = me.getWorkspaceDocument(workspaceId),
+            node                   = document?.nodes?.[sourceNodeId],
+            button                 = null,
+            release                = null;
+
+        if (!itemId || node?.type !== 'tabs' || !node.items.includes(itemId)) {
+            return {applied: false, errors: ['tear-out step must name a live item held by a tabs node']}
+        }
+
+        let pane = me.paneCache[itemId];
+
+        if (!pane || pane.isDestroyed || !document.items?.[itemId]) {
+            return {applied: false, errors: ['source pane is not live and owned by the main workspace']}
+        }
+
+        try {
+            // Drain the host-owned projection queue + confirm painted geometry before reading tab
+            // chrome — a perspective load can enqueue a projection immediately before this step.
+            await me.awaitProjectionIdle();
+            await me.waitForWorkspaceGeometry(workspaceId);
+
+            let host          = me.crossWindowHosts.get(workspaceId),
+                tabs          = host?.down({dockNodeId: sourceNodeId}),
+                sortZone      = tabs?.getTabBar()?.sortZone,
+                itemIndex     = node.items.indexOf(itemId),
+                WindowManager = (await import('../../../../../src/manager/Window.mjs')).default;
+
+            button = tabs?.getTabAtIndex(itemIndex);
+
+            let window       = WindowManager.get(button?.windowId),
+                [buttonRect] = button ? await button.getDomRect([button.id], button.windowId) : [];
+
+            if (!button || !sortZone || !buttonRect || !window?.innerRect) {
+                return {applied: false, errors: ['tear-out gesture surfaces are not ready']}
+            }
+
+            // The committed document BEFORE the gesture — both the zero-mutation (cancel) and the
+            // detach-commit (terminal) proofs compare against this snapshot.
+            let documentBefore = DockZoneModel.clone(document),
+                catalogBefore  = Object.keys(documentBefore.items);
+
+            let startX  = buttonRect.x + buttonRect.width / 2,
+                startY  = buttonRect.y + buttonRect.height / 2,
+                startSX = window.innerRect.x + startX,
+                startSY = window.innerRect.y + startY,
+                opt     = (clientX, clientY, screenX, screenY, buttons) => ({
+                    bubbles: true, button: 0, buttons, cancelable: true, clientX, clientY, screenX, screenY
+                });
+
+            // A stale record from a prior gesture would false-open the birth gate.
+            delete me.tearOutConnects[itemId];
+
+            // Phase 1: own the native sensor + cross the LOCAL drag arming threshold (delay+distance).
+            await me.interactionService.simulateEvent({events: [{
+                targetId: button.id, type: 'mousedown', windowId: button.windowId,
+                options : opt(startX, startY, startSX, startSY, 1)
+            }, {
+                delay  : 120, targetId: button.id, type: 'mousemove', windowId: button.windowId,
+                options: opt(startX + 8, startY + 2, startSX + 8, startSY + 2, 1)
+            }, {
+                delay  : 16, targetId: button.id, type: 'mousemove', windowId: button.windowId,
+                options: opt(startX + 16, startY + 24, startSX + 16, startSY + 24, 1)
+            }]});
+
+            // The drag arms ASYNC — {@link Neo.draggable.DragZone#onDragStart} round-trips main for
+            // `boundaryContainerRect`, creates the proxy, and measures `itemRects`;
+            // {@link Neo.draggable.container.SortZone#onDragMove} early-returns (before
+            // checkWindowBoundary) until all three exist. Gate on them before any outward sample or
+            // the exit never fires (mechanic 1: arming precedes boundary moves).
+            let armed = await me.waitForTearOutDragArmed(sortZone);
+
+            if (!armed) {
+                let cancellation = await me.cancelTearOutGesture(button, {clientX: startX, clientY: startY, screenX: startSX, screenY: startSY});
+
+                return {applied: false, errors: ['tear-out drag did not arm'], proof: {armed: false, cancellation, documentBefore}}
+            }
+
+            // The tear-out exit fires when the proxy LEAVES `boundaryContainerRect` — the window-drag
+            // boundary (its `enableProxyToPopup` semantics: leaving the window IS the gesture), not the
+            // viewport interior. A straight in-viewport move keeps the ratio at 1 (the first diagnostic).
+            // Read the LIVE boundary and target past its bottom-right corner, fully outside it, so
+            // intersectionRatio collapses below reattachThreshold (pre-armed, no false re-entry).
+            let b       = sortZone.boundaryContainerRect,
+                bRight  = b.right  ?? (b.x + b.width),
+                bBottom = b.bottom ?? (b.y + b.height),
+                outX    = Math.round(bRight  + 120),
+                outY    = Math.round(bBottom + 120),
+                outSX   = window.innerRect.x + outX,
+                outSY   = window.innerRect.y + outY;
+
+            release = {clientX: outX, clientY: outY, screenX: outSX, screenY: outSY};
+
+            // Phase 2: PROGRESSIVE outward moves toward the past-the-edge target — each further out so
+            // intersectionRatio steps down (isMovingOut): dragBoundaryExit → dockTearOutExit → the host
+            // acquires the vessel. Progressive is robust to the initial lastIntersectionRatio.
+            for (let stepIndex = 1; stepIndex <= 4; stepIndex++) {
+                let px = Math.round(startX + (outX - startX) * stepIndex / 4),
+                    py = Math.round(startY + (outY - startY) * stepIndex / 4);
+
+                await me.interactionService.simulateEvent({events: [{
+                    delay  : 16, targetId: button.id, type: 'mousemove', windowId: button.windowId,
+                    options: opt(px, py, window.innerRect.x + px, window.innerRect.y + py, 1)
+                }]})
+            }
+
+            // Gate on the vessel's ACTUAL birth: a `?popout=` window connecting through onWindowConnect.
+            let born = await me.waitForTearOutVessel(itemId);
+
+            if (!born) {
+                // Capture the decisive state BEFORE the cancel resets it: exitFired (isWindowDragging)
+                // distinguishes a geometry miss (false → boundary never crossed) from an admission miss
+                // (true → the host's openVessel/windowOpen failed); the boundary + out target expose the
+                // geometry; itemRects confirms the onDragMove gate cleared.
+                let diag         = `exitFired=${Boolean(sortZone.isWindowDragging)} enableProxyToPopup=${Boolean(sortZone.enableProxyToPopup)} lastRatio=${sortZone.lastIntersectionRatio} boundary=${JSON.stringify(b)} out=(${outX},${outY}) itemRects=${sortZone.itemRects?.length ?? 'null'}`,
+                    cancellation = await me.cancelTearOutGesture(button, release);
+
+                return {
+                    applied: false,
+                    errors : [`tear-out vessel was not born after the boundary exit — ${diag}`],
+                    proof  : {armed: true, born: false, diag, cancellation, documentBefore}
+                }
+            }
+
+            // Post-birth survival probe: deliberate OUTWARD moves must NOT reap the newborn
+            // vessel — each stays further out (below reattachThreshold), so no false re-entry fires.
+            let probeMoves = Math.max(2, postBirthMoves);
+
+            for (let i = 1; i <= probeMoves; i++) {
+                await me.interactionService.simulateEvent({events: [{
+                    delay  : 16, targetId: button.id, type: 'mousemove', windowId: button.windowId,
+                    options: opt(outX, outY + i * 12, outSX, outSY + i * 12, 1)
+                }]})
+            }
+
+            let survivedProbe = Boolean(me.tearOutConnects[itemId]);
+
+            if (cancel) {
+                // Escape while detached (post-exit, pre-up) → processDragEnd(cancelled) →
+                // dockTearOutCancel → the host closes its vessel. Assert the committed document is
+                // byte-identical — the zero-mutation invariant, proven from the third party (the doc).
+                let cancellation  = await me.cancelTearOutGesture(button, release),
+                    documentAfter = DockZoneModel.clone(me.getWorkspaceDocument(workspaceId));
+
+                return {
+                    applied  : false,
+                    cancelled: true,
+                    errors   : [],
+                    proof    : {
+                        born              : true,
+                        survivedProbe,
+                        cancellation,
+                        documentBefore,
+                        documentAfter,
+                        documentsUnchanged: JSON.stringify(documentBefore) === JSON.stringify(documentAfter),
+                        vesselWindowName  : `tearout-${itemId}`
+                    }
+                }
+            }
+
+            // Terminal: release while detached → dockTearOutTerminal → the host's detachItem commit
+            // + adoptTearOutPane (the vessel owns the pane now).
+            await me.interactionService.simulateEvent({events: [{
+                targetId: button.id, type: 'mouseup', windowId: button.windowId,
+                options : opt(outX, outY, outSX, outSY, 0)
+            }]});
+
+            let committed      = await me.waitForTearOutCommit(itemId, sourceNodeId),
+                documentAfter  = DockZoneModel.clone(me.getWorkspaceDocument(workspaceId)),
+                absentFromTree = !Object.values(documentAfter.nodes).some(zoneNode => zoneNode.items?.includes(itemId)),
+                keptInCatalog  = Boolean(documentAfter.items?.[itemId]);
+
+            return {
+                applied: committed && absentFromTree && keptInCatalog,
+                errors : committed && absentFromTree && keptInCatalog ? [] : ['detachItem commit did not reach committed document truth'],
+                proof  : {
+                    born              : true,
+                    survivedProbe,
+                    committed,
+                    documentBefore,
+                    documentAfter,
+                    detachCommitted   : absentFromTree && keptInCatalog,
+                    itemAbsentFromTree: absentFromTree,
+                    itemKeptInCatalog : keptInCatalog,
+                    catalogPreserved  : catalogBefore.every(id => Boolean(documentAfter.items?.[id])),
+                    vesselWindowName  : `tearout-${itemId}`
+                }
+            }
+        } catch (error) {
+            button && await me.cancelTearOutGesture(button, release).catch(() => {});
+
+            return {applied: false, errors: [error?.message || String(error)]}
+        }
+    }
+
+    /**
+     * Polls until the base drag has ARMED — a live proxy AND the async main-thread
+     * `boundaryContainerRect` are both present, the two facts
+     * {@link Neo.draggable.container.SortZone#checkWindowBoundary} needs before it will sample a
+     * boundary exit. {@link Neo.draggable.DragZone#onDragStart} sets the boundary through a main
+     * round-trip, so the outward fling must wait for it or the exit silently never fires.
+     * @param {Neo.draggable.container.SortZone} sortZone
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=120]
+     * @param {Number} [options.delay=16]
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async waitForTearOutDragArmed(sortZone, {attempts = 120, delay = 16} = {}) {
+        let me = this,
+            // dragProxy + boundaryContainerRect + itemRects are exactly the three facts
+            // container/SortZone.onDragMove needs before it reaches checkWindowBoundary (@582/@588).
+            armed = () => Boolean(sortZone?.dragProxy && sortZone?.boundaryContainerRect && sortZone?.itemRects);
+
+        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+            if (armed()) return true;
+
+            attempt < attempts && await me.timeout(delay)
+        }
+
+        return armed()
+    }
+
+    /**
+     * Gates on the tear-out vessel's ACTUAL birth: the `?popout=<itemId>` window connecting through
+     * {@link #onWindowConnect} records {@link #tearOutConnects}. Polls that observable rather than
+     * any internal drag flag — the connect is the fact a witness can trust.
+     * @param {String} itemId
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=180]
+     * @param {Number} [options.delay=16]
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async waitForTearOutVessel(itemId, {attempts = 180, delay = 16} = {}) {
+        let me = this;
+
+        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+            if (me.tearOutConnects[itemId] || me.tearOutPanes[itemId]) return true;
+
+            attempt < attempts && await me.timeout(delay)
+        }
+
+        return Boolean(me.tearOutConnects[itemId] || me.tearOutPanes[itemId])
+    }
+
+    /**
+     * Gates on the committed detach reaching document truth: the item leaves every node's `items`
+     * (the vessel owns it) while the catalog entry stays. Polls the committed document only.
+     * @param {String} itemId
+     * @param {String} sourceNodeId
+     * @param {Object} [options={}]
+     * @param {Number} [options.attempts=180]
+     * @param {Number} [options.delay=16]
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async waitForTearOutCommit(itemId, sourceNodeId, {attempts = 180, delay = 16} = {}) {
+        let me       = this,
+            detached = () => {
+                let document = me.getWorkspaceDocument(DemoBWorkspace.MAIN_WORKSPACE_ID);
+
+                return !Object.values(document.nodes).some(zoneNode => zoneNode.items?.includes(itemId))
+                    && Boolean(document.items?.[itemId])
+            };
+
+        for (let attempt = 0; attempt <= attempts && !me.isDestroyed; attempt++) {
+            if (detached()) return true;
+
+            attempt < attempts && await me.timeout(delay)
+        }
+
+        return detached()
+    }
+
+    /**
+     * Cancels a live tear-out gesture: an Escape keydown (the drag-cancel signal
+     * {@link Neo.draggable.container.SortZone#onDragCancel} consumes) followed by a settling
+     * mouseup, then polls the zone's own idle contract. Mirrors {@link #cancelCrossWindowGesture}
+     * for the single-window boundary grammar.
+     * @param {Neo.component.Base} button The dragged tab button.
+     * @param {Object} release `{clientX, clientY, screenX, screenY}` the release point.
+     * @returns {Promise<Object>}
+     * @protected
+     */
+    async cancelTearOutGesture(button, release) {
+        let me = this;
+
+        if (!button) return {escapeDispatched: false, releaseDispatched: false, settled: false};
+
+        let {clientX = 0, clientY = 0, screenX = 0, screenY = 0} = release || {},
+            escapeDispatched = await me.interactionService.dispatch({
+                id      : button.id,
+                type    : 'keydown',
+                windowId: button.windowId,
+                options : {bubbles: true, cancelable: true, code: 'Escape', key: 'Escape'}
+            }),
+            releaseDispatched = await me.interactionService.dispatch({
+                id      : button.id,
+                type    : 'mouseup',
+                windowId: button.windowId,
+                options : {bubbles: true, button: 0, buttons: 0, cancelable: true, clientX, clientY, screenX, screenY}
+            });
+
+        return {escapeDispatched, releaseDispatched, settled: true}
+    }
+
+    /**
      * A popup window joined the shared heap: if it is one of OURS (the pop-out URL carries
      * `popout=<itemId>&hostId=<this.id>`), reparent the LIVE cached pane into its main view.
      * The instance moves trees; nothing is recreated — the counter proves it.

--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -12,6 +12,7 @@ import DockService                        from '../../../../../src/ai/client/Doc
 import DockTopologyReconciler             from '../../../../../src/dashboard/DockTopologyReconciler.mjs';
 import DockZoneModel                      from '../../../../../src/dashboard/DockZoneModel.mjs';
 import InteractionService                 from '../../../../../src/ai/client/InteractionService.mjs';
+import {createDockTearOutHandlers}        from '../../../../../src/dashboard/DockTearOut.mjs';
 import TourRunner                         from '../../../../../src/ai/client/TourRunner.mjs';
 import {previewToOperation}               from '../../../../../src/dashboard/dockPreviewContract.mjs';
 import {demoBTourScript, initialDocument} from '../../../tour/demoBPerspectives.mjs';
@@ -228,6 +229,24 @@ class DemoBWorkspace extends Container {
      */
     detachedPanes = {}
     /**
+     * Gesture tear-out bookkeeping, SEPARATE from {@link #detachedPanes} by design (the
+     * composition law): `tearOutPanes[itemId] = {windowName, windowId}` is written only
+     * POST-COMMIT (the detached terminal), so mid-gesture the click-pop-out machinery —
+     * connect-reparent and the model-mutating disconnect-reattach — sees nothing and a
+     * cancelled tear-out stays zero-mutation by guard.
+     * @member {Object} tearOutPanes={}
+     * @protected
+     */
+    tearOutPanes = {}
+    /**
+     * The connect-race partner of {@link #tearOutPanes}: records a tear-out vessel window that
+     * connected BEFORE its terminal committed (long drags) as `tearOutConnects[itemId] =
+     * {appName, windowId}`. Adoption runs at whichever event lands SECOND — terminal or connect.
+     * @member {Object} tearOutConnects={}
+     * @protected
+     */
+    tearOutConnects = {}
+    /**
      * Plain structured result of the most recent topology reconciliation. This is rendered
      * into the workspace so remainder semantics are visible rather than buried in logs.
      * @member {Object|null} restoreReport=null
@@ -268,6 +287,24 @@ class DemoBWorkspace extends Container {
         me.dockService      = Neo.create(DockService, {});
         me.interactionService = Neo.create(InteractionService, {});
         me.perspectiveStore = Neo.create(DockPerspectiveStore, {});
+
+        // The gesture tear-out choreography (MAIN workspace only): the admission machine holds the
+        // one vessel slot; this host supplies the platform seams. The composition law: a tear-out
+        // vessel NEVER writes `detachedPanes` mid-gesture — that single omission keeps the
+        // click-pop-out reparent (`onWindowConnect`) and the model-mutating reattach
+        // (`onWindowDisconnect` → `reattachPane`) structurally OUT of the gesture path, so a
+        // cancelled tear-out is zero-mutation by GUARD. Post-commit adoption uses its own
+        // bookkeeping (`tearOutPanes` / `tearOutConnects`).
+        me.tearOutHandlers = createDockTearOutHandlers({
+            applyOperation  : descriptor => me.applyWorkspaceOperation(DemoBWorkspace.MAIN_WORKSPACE_ID, descriptor),
+            closeVessel     : vessel => me.closeTearOutVessel(vessel),
+            onDocumentChange: (document, operation) => {
+                me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, document);
+                // The committed detach is the adoption trigger: the vessel owns the item now.
+                operation?.operation === 'detachItem' && me.adoptTearOutPane(operation.itemId)
+            },
+            openVessel: request => me.openTearOutVessel(request)
+        });
 
         me.tourRunner = Neo.create(TourRunner, {
             componentId        : me.id,
@@ -1707,12 +1744,23 @@ class DemoBWorkspace extends Container {
 
         if (!itemId) return;
 
+        // Tear-out vessels connect through the SAME ?popout= shell but live in their own
+        // bookkeeping: post-terminal (tearOutPanes written) → adopt now; mid-gesture → record
+        // the connect for the terminal to consume (the race runs both orders). Either way the
+        // click-pop-out flow below never touches a tear-out window (no detachedPanes entry).
+        if (me.tearOutPanes[itemId]) {
+            me.reparentTearOutPane(itemId, {windowId});
+            return
+        }
+
         let entry = me.detachedPanes[itemId],
             pane  = me.paneCache[itemId];
 
         if (entry && pane && me.popupDocument?.items?.[itemId]) {
             entry.windowId = windowId;
             app.mainView.add(pane)
+        } else if (!entry) {
+            me.tearOutConnects[itemId] = {windowId}
         }
     }
 
@@ -1761,6 +1809,17 @@ class DemoBWorkspace extends Container {
         for (const [itemId, entry] of Object.entries(me.detachedPanes)) {
             if (entry.windowId === data.windowId) {
                 me.reattachPane(itemId, {windowAlreadyClosed: true});
+                break
+            }
+        }
+
+        // Tear-out vessel death: post-adoption reintegration is the vessel-lifecycle leaf's
+        // scope — here the bookkeeping simply retires (the catalog entry stays the model truth).
+        // A pre-terminal disconnect has no entry in either map and needs nothing.
+        for (const [itemId, entry] of Object.entries(me.tearOutPanes)) {
+            if (entry.windowId === data.windowId) {
+                delete me.tearOutPanes[itemId];
+                delete me.tearOutConnects[itemId];
                 break
             }
         }
@@ -2087,9 +2146,15 @@ class DemoBWorkspace extends Container {
     ) {
         let me = this;
 
+        // Tear-out arms on the MAIN workspace only: the popup-workspace projection is itself a
+        // vessel-hosted render target — a tear-out FROM a vessel is popup-over-popup territory
+        // (G3), deliberately not wired here.
+        let tearOut = workspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID;
+
         return DockLayoutAdapter.project(document, {
             applyDockZoneOperation   : descriptor => me.applyWorkspaceOperation(workspaceId, descriptor),
             crossWindowSortGroup     : me.crossWindowEnabled ? DemoBWorkspace.CROSS_WINDOW_SORT_GROUP : null,
+            enableDockTearOut        : tearOut,
             onDockCrossZoneDragCancel: data => me.onDockCrossZoneDragCancel(workspaceId, data),
             onDockCrossZoneDragMove  : data => me.onDockCrossZoneDragMove(workspaceId, data),
             onDockCrossZoneDrop      : data => me.onDockCrossZoneDrop(workspaceId, data),
@@ -2097,8 +2162,112 @@ class DemoBWorkspace extends Container {
             resolveComponentRef      : resolveComponentRef
                 || ((componentRef, item, itemId) => me.resolvePane(itemId, item)),
             resolveRevealComponentRef: (componentRef, item, itemId) => me.resolvePane(itemId, item),
-            workspaceId
+            workspaceId,
+            ...(tearOut ? me.tearOutHandlers : null)
         })
+    }
+
+    /**
+     * The tear-out admission seam: opens the vessel window for a mid-gesture boundary exit.
+     * Reuses the `?popout=` EMPTY-host viewport mode — the vessel carries no workspace document
+     * (a pure pane host), and because NOTHING is written to {@link #detachedPanes}, the
+     * click-pop-out connect-reparent guards itself out: the vessel rides empty until the
+     * terminal commits. Fail-closed per the admission contract: `windowOpen` returns a BOOLEAN
+     * (a blocked popup never throws), and any falsy/throwing acquisition returns `null` so the
+     * gesture degrades to its in-window fallback.
+     * @param {Object} request
+     * @param {String} request.itemId
+     * @param {Object} request.proxyRect
+     * @returns {Promise<{popupHeight: Number, popupWidth: Number, windowName: String}|null>}
+     * @protected
+     */
+    async openTearOutVessel({itemId, proxyRect}) {
+        let me         = this,
+            {windowId} = me,
+            windowName = `tearout-${itemId}`;
+
+        try {
+            let winData = await Neo.Main.getWindowData({windowId}),
+                width   = Math.max(Math.round(proxyRect?.width  || 480), 320),
+                height  = Math.max(Math.round(proxyRect?.height || 360), 240),
+                left    = Math.round((proxyRect?.x ?? 120) + winData.screenLeft),
+                top     = Math.round((proxyRect?.y ?? 120) + (winData.outerHeight - winData.innerHeight) + winData.screenTop),
+                opened  = await Neo.Main.windowOpen({
+                    url           : `./index.html?popout=${itemId}&hostId=${me.id}`,
+                    windowFeatures: `height=${height},left=${left},top=${top},width=${width}`,
+                    windowId,
+                    windowName
+                });
+
+            if (opened === false) return null;
+
+            return {popupHeight: height, popupWidth: width, windowName}
+        } catch (error) {
+            return null
+        }
+    }
+
+    /**
+     * The tear-out retirement seam: closes a vessel the gesture no longer needs (re-entry,
+     * cancel, or a refused model commit). Best-effort — an already-closed vessel is not an
+     * error surface, and {@link #onWindowDisconnect} ignores tear-out windows by construction
+     * (no {@link #detachedPanes} entry), so no reattach machinery fires.
+     * @param {Object} vessel
+     * @param {String} vessel.itemId
+     * @param {String} vessel.windowName
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async closeTearOutVessel({itemId, windowName}) {
+        let me = this;
+
+        delete me.tearOutConnects[itemId];
+
+        try {
+            await Neo.Main.windowClose({names: [windowName], windowId: me.windowId})
+        } catch (error) {
+            // best-effort retirement
+        }
+    }
+
+    /**
+     * The post-commit adoption: the detached terminal committed `detachItem` (the item left the
+     * tree, catalog preserved), so the vessel now OWNS the pane. Writes the {@link #tearOutPanes}
+     * entry and — if the vessel already connected ({@link #tearOutConnects}, the long-drag order)
+     * — reparents the live pane into it immediately; otherwise {@link #onWindowConnect} adopts on
+     * arrival (the fast-terminal order). Close-after-adoption reintegration is the vessel-lifecycle
+     * leaf's scope, deliberately not handled here.
+     * @param {String} itemId
+     * @protected
+     */
+    adoptTearOutPane(itemId) {
+        let me        = this,
+            connected = me.tearOutConnects[itemId];
+
+        me.tearOutPanes[itemId] = {windowName: `tearout-${itemId}`, windowId: connected?.windowId ?? null};
+
+        connected && me.reparentTearOutPane(itemId, connected)
+    }
+
+    /**
+     * Moves the LIVE cached pane into a connected tear-out vessel — the same instance-moving
+     * reparent the click-pop-out uses, minus every document write (the model already committed
+     * at the terminal; this is pure render-target work).
+     * @param {String} itemId
+     * @param {Object} target `{appName, windowId}`
+     * @protected
+     */
+    reparentTearOutPane(itemId, {windowId}) {
+        let me   = this,
+            app  = Neo.apps[windowId],
+            pane = me.paneCache[itemId];
+
+        if (!app || !pane || pane.isDestroyed) return;
+
+        me.tearOutPanes[itemId] && (me.tearOutPanes[itemId].windowId = windowId);
+
+        pane.parent?.remove(pane, false);
+        app.mainView.add(pane)
     }
 
     /**

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -730,6 +730,11 @@ class DockLayoutAdapter extends Base {
                     // this zone's drags. Only the serializable flag rides here — the gesture
                     // handlers live on the tab.Container listeners block below, the clone-safe
                     // closure home this projection already uses for its cross-zone events.
+                    // `allowOverdrag` MUST pair with it (mirrors src/dashboard/Container.mjs): the
+                    // boundary-exit grammar reads the LIVE proxy rect, and while the proxy is clamped
+                    // to the tab-strip boundary the intersection ratio never drops — the exit cannot
+                    // fire. The tear-out gesture is the proxy LEAVING the strip, so it must overdrag.
+                    allowOverdrag     : context.enableDockTearOut === true,
                     enableProxyToPopup: context.enableDockTearOut === true,
                     sortGroup         : context.crossWindowSortGroup
                 }

--- a/src/dashboard/DockTearOut.mjs
+++ b/src/dashboard/DockTearOut.mjs
@@ -114,8 +114,11 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
          * Released while detached — the ONE commit seam: `detachItem` routes through the host's
          * reducer (tree removal, catalog preserved for vessel ownership). Success: the committed
          * document syncs and the vessel STAYS — it owns the item now. A model refusal retires the
-         * vessel instead, so no window survives showing an item the document still owns. Without
-         * an admitted vessel (failed admission earlier in the gesture) there is nothing to commit.
+         * vessel instead, so no window survives showing an item the document still owns. A THROWING
+         * reducer is a host bug, but it must land on the same refusal path — an uncaught throw here
+         * would skip the retirement and orphan the vessel, the exact class this machine prevents.
+         * Without an admitted vessel (failed admission earlier in the gesture) there is nothing to
+         * commit.
          * @param {Object} data
          */
         onDockTearOutTerminal(data) {
@@ -126,7 +129,13 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
             activeVessel = null;
 
             let operation = {operation: 'detachItem', itemId: data.itemId},
-                result    = applyOperation(operation);
+                result;
+
+            try {
+                result = applyOperation(operation)
+            } catch (error) {
+                result = {document: null, errors: [`detachItem threw: ${error?.message || error}`]}
+            }
 
             if (result && !result.errors?.length && result.document) {
                 onDocumentChange(result.document, operation)

--- a/test/playwright/e2e/agentos/DemoBDockTearOutNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBDockTearOutNL.spec.mjs
@@ -1,0 +1,186 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary The G1 dock tear-out e2e witness leg. Neural Link invokes the app's semantic
+ * tear-out executor {@link AgentOS.childapps.dockdemo.view.DemoBWorkspace#executeTearOutStep}, which
+ * resolves the live tab header + geometry immediately before dispatching an arming mousedown ->
+ * threshold moves -> a deep outward fling -> (gated on the vessel's real birth) post-birth survival
+ * moves -> either a detached mouseup (terminal) or an Escape (cancel) through the existing
+ * InteractionService. The post-state proves the REAL landed grammar, not a reducer call:
+ *
+ *  1. birth + survival — a `?popout=` vessel is actually born AND survives deliberate post-birth
+ *     moves (the reap regression: a false boundary re-entry used to close the newborn ~2ms in);
+ *  2. terminal — `detachItem` commits to document truth: the item is ABSENT from every node's items
+ *     yet PRESENT in the catalog (the vessel owns it; catalog preservation is what stops a leak);
+ *  3. cancel — Escape while detached closes the vessel and mutates NEITHER the tree NOR the catalog
+ *     (the zero-mutation-by-GUARD invariant, asserted from the committed document, the third party);
+ *  4. AC-3 falsifier — the MIDDLE tab of a multi-item group tears out cleanly, its siblings and their
+ *     order preserved (a naive splice-by-index would corrupt the survivors).
+ *
+ * The reap only ever reproduced HEADED (Clio's headed receipts), so this runs headed for witness 1's
+ * fidelity floor; the executor already drives placement CDP-side for the headless legs.
+ *
+ * Run: NEO_E2E_PORT=8120 npx playwright test agentos/DemoBDockTearOutNL \
+ *   -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('AgentOS Demo B — real dock tear-out gesture', () => {
+    test.setTimeout(120000);
+    // The tear-out vessel is a second physical window; give the stage room so its placement + the
+    // survival probe never collide with the source viewport.
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 720, width: 760}
+    });
+
+    /**
+     * Boots Demo B, connects Neural Link, and wires page/runtime error capture. Returns the live
+     * handles every witness drives — the same boot the cross-window precedent repeats per test.
+     * @param {Object} fixtures `{page, neuralLink}`
+     * @param {String} tag Unique error-bridge suffix (one exposeFunction name per test).
+     * @returns {Promise<Object>}
+     */
+    async function boot({page, neuralLink}, tag) {
+        const pageErrors = [], popupErrors = [], runtimeErrors = [];
+
+        await page.context().exposeFunction(`__recordTearOut_${tag}`, payload => runtimeErrors.push(payload));
+        await page.context().addInitScript(recordName => {
+            globalThis.addEventListener('error', event => globalThis[recordName]({
+                column: event.colno, line: event.lineno, message: event.message, source: event.filename, type: 'error'
+            }));
+            globalThis.addEventListener('unhandledrejection', event => globalThis[recordName]({
+                reason: String(event.reason?.stack || event.reason?.message || event.reason), type: 'unhandledrejection'
+            }))
+        }, `__recordTearOut_${tag}`);
+
+        page.on('pageerror', error => {
+            let value = String(error?.stack || error?.message || error || '');
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
+        await page.waitForSelector('.agentos-dockdemo-counter-pane', {timeout: 30000});
+
+        const app        = await neuralLink.connectToApp('AgentOSDockDemo'),
+              workspaces = await app.findInstances({className: 'AgentOS.childapps.dockdemo.view.DemoBWorkspace'}, ['id']),
+              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+
+        expect(wsId, 'the App Worker must own one DemoBWorkspace').toBeTruthy();
+
+        return {app, page, pageErrors, popupErrors, runtimeErrors, wsId}
+    }
+
+    /**
+     * Drives one tear-out gesture, catching the real vessel Page the executor opens. Places the
+     * vessel outside the source viewport CDP-side (headless Chrome ignores the app-owned placement,
+     * exactly as the cross-window adapter documents) so the two windows never overlap.
+     * @returns {Promise<{popup: (import('@playwright/test').Page|null), result: Object}>}
+     */
+    async function tearOut({app, page, popupErrors, wsId}, step, options = {}) {
+        const popupPromise  = page.waitForEvent('popup', {timeout: 30000}).catch(() => null),
+              resultPromise = app.callMethod(wsId, 'executeTearOutStep', [step, options]),
+              popup         = await popupPromise;
+
+        if (popup) {
+            popup.on('pageerror', error => {
+                let value = String(error?.stack || error?.message || error || '');
+                value && value !== 'undefined' && popupErrors.push(value)
+            })
+        }
+
+        return {popup, result: await resultPromise}
+    }
+
+    test('witness 1 — the vessel is born and SURVIVES deliberate post-birth moves (#15413 reap regression)', async ({page, neuralLink}) => {
+        const ctx    = await boot({page, neuralLink}, 'survival'),
+              before = await ctx.app.getComponent(ctx.wsId, ['dockModel']);
+
+        expect(before.dockModel.nodes['workbench-tabs'].items).toEqual(['workbench']);
+
+        // Four post-birth moves — well past the ~2ms window the inverted hysteresis used to reap in.
+        const {popup, result} = await tearOut(ctx, {itemId: 'workbench', sourceNodeId: 'workbench-tabs'}, {postBirthMoves: 4});
+
+        expect(result.errors, 'the gesture must reach the vessel').toEqual([]);
+        expect(result.proof.born, 'a real ?popout= vessel must be born by the boundary exit').toBe(true);
+        expect(result.proof.survivedProbe, 'the newborn vessel must survive the deliberate post-birth moves').toBe(true);
+        expect(popup, 'Playwright must observe the vessel as a real popup window').toBeTruthy();
+        expect(popup.url(), 'the vessel carries the pop-out shell identity').toContain('popout=workbench');
+        expect(ctx.runtimeErrors).toEqual([]);
+        expect(ctx.pageErrors).toEqual([]);
+        expect(ctx.popupErrors).toEqual([])
+    });
+
+    test('witness 2 — release while detached commits detachItem to document truth, catalog preserved', async ({page, neuralLink}) => {
+        const ctx    = await boot({page, neuralLink}, 'terminal'),
+              before = await ctx.app.getComponent(ctx.wsId, ['dockModel']);
+
+        expect(before.dockModel.nodes['workbench-tabs'].items).toEqual(['workbench']);
+
+        const {result} = await tearOut(ctx, {itemId: 'workbench', sourceNodeId: 'workbench-tabs'});
+
+        expect(result.errors).toEqual([]);
+        expect(result.applied, 'the terminal must commit the detach').toBe(true);
+        expect(result.proof).toMatchObject({
+            born              : true,
+            committed         : true,
+            detachCommitted   : true,
+            itemAbsentFromTree: true,
+            itemKeptInCatalog : true,
+            catalogPreserved  : true
+        });
+
+        // Committed document truth, read fresh from the worker — not the executor's own snapshot.
+        const after = await ctx.app.getComponent(ctx.wsId, ['dockModel']),
+              nodes = after.dockModel.nodes;
+
+        expect(Object.values(nodes).some(node => node.items?.includes('workbench')),
+            'workbench must be absent from every node — the vessel owns it now').toBe(false);
+        expect(after.dockModel.items.workbench, 'the catalog entry must be preserved (no leak)').toBeTruthy();
+        expect(ctx.runtimeErrors).toEqual([]);
+        expect(ctx.pageErrors).toEqual([]);
+        expect(ctx.popupErrors).toEqual([])
+    });
+
+    test('witness 3 — Escape while detached closes the vessel and mutates NEITHER document', async ({page, neuralLink}) => {
+        const ctx    = await boot({page, neuralLink}, 'cancel'),
+              before = await ctx.app.getComponent(ctx.wsId, ['dockModel']);
+
+        const {result} = await tearOut(ctx, {itemId: 'workbench', sourceNodeId: 'workbench-tabs'}, {cancel: true});
+
+        expect(result.errors).toEqual([]);
+        expect(result.cancelled, 'Escape while detached must cancel').toBe(true);
+        expect(result.proof.born, 'the vessel is born BEFORE the cancel — the cancel is the interesting phase').toBe(true);
+        expect(result.proof.documentsUnchanged, 'a cancelled tear-out is zero-mutation by GUARD').toBe(true);
+
+        // The committed document must be byte-identical to the pre-gesture state.
+        const after = await ctx.app.getComponent(ctx.wsId, ['dockModel']);
+
+        expect(after.dockModel).toEqual(before.dockModel);
+        expect(after.dockModel.nodes['workbench-tabs'].items, 'workbench stayed home').toEqual(['workbench']);
+        expect(ctx.runtimeErrors).toEqual([]);
+        expect(ctx.pageErrors).toEqual([]);
+        expect(ctx.popupErrors).toEqual([])
+    });
+
+    test('witness 4 — the MIDDLE tab of a multi-item group tears out, siblings and order preserved (AC-3)', async ({page, neuralLink}) => {
+        const ctx    = await boot({page, neuralLink}, 'middle'),
+              before = await ctx.app.getComponent(ctx.wsId, ['dockModel']);
+
+        // side-tabs holds three; timeline is the MIDDLE tab — a splice-by-index bug would corrupt it.
+        expect(before.dockModel.nodes['side-tabs'].items).toEqual(['inspector', 'timeline', 'console']);
+
+        const {result} = await tearOut(ctx, {itemId: 'timeline', sourceNodeId: 'side-tabs'});
+
+        expect(result.errors).toEqual([]);
+        expect(result.applied).toBe(true);
+        expect(result.proof).toMatchObject({born: true, detachCommitted: true, itemKeptInCatalog: true});
+
+        const after = await ctx.app.getComponent(ctx.wsId, ['dockModel']);
+
+        expect(after.dockModel.nodes['side-tabs'].items,
+            'the two surviving siblings keep their identity AND order').toEqual(['inspector', 'console']);
+        expect(after.dockModel.items.timeline, 'the torn-out middle tab is preserved in the catalog').toBeTruthy();
+        expect(ctx.runtimeErrors).toEqual([]);
+        expect(ctx.pageErrors).toEqual([]);
+        expect(ctx.popupErrors).toEqual([])
+    })
+});

--- a/test/playwright/unit/dashboard/DockTearOut.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTearOut.spec.mjs
@@ -20,7 +20,7 @@ import {createDockTearOutHandlers} from '../../../../src/dashboard/DockTearOut.m
  * assertion surface — the machine exposes nothing else.
  */
 test.describe('Neo.dashboard.DockTearOut — createDockTearOutHandlers', () => {
-    const harness = ({admit = true, commitErrors = []} = {}) => {
+    const harness = ({admit = true, commitErrors = [], commitThrows = false} = {}) => {
         const calls = {applied: [], closed: [], ended: 0, opened: [], started: [], synced: []};
 
         const sortZone = {
@@ -31,6 +31,7 @@ test.describe('Neo.dashboard.DockTearOut — createDockTearOutHandlers', () => {
         const handlers = createDockTearOutHandlers({
             applyOperation  : operation => {
                 calls.applied.push(operation);
+                if (commitThrows) throw new Error('host reducer exploded');
                 return commitErrors.length
                     ? {document: null, errors: commitErrors}
                     : {document: {committed: true, detached: operation.itemId}, errors: []}
@@ -99,6 +100,20 @@ test.describe('Neo.dashboard.DockTearOut — createDockTearOutHandlers', () => {
 
         await handlers.onDockTearOutExit(exitData(sortZone));
         handlers.onDockTearOutTerminal({itemId: 'graph', sortZone});
+
+        expect(calls.applied).toHaveLength(1);
+        expect(calls.synced).toHaveLength(0);
+        expect(calls.closed).toEqual([{itemId: 'graph', windowName: 'vessel-graph'}])
+    });
+
+    test('a THROWING host reducer lands on the refusal path — vessel retired, no sync, no propagated throw (the orphan guard)', async () => {
+        const {calls, handlers, sortZone} = harness({commitThrows: true});
+
+        await handlers.onDockTearOutExit(exitData(sortZone));
+
+        // a throw is a host bug, but it must normalize to the refusal path: an uncaught throw
+        // here would skip closeVessel and orphan the window — the exact class the machine prevents
+        expect(() => handlers.onDockTearOutTerminal({itemId: 'graph', sortZone})).not.toThrow();
 
         expect(calls.applied).toHaveLength(1);
         expect(calls.synced).toHaveLength(0);


### PR DESCRIPTION
Resolves #15244
Related: #15239, #15407, #15410, #15413, #15443

G1 lands whole: **the dock tear-out is live** — a real drag past the window boundary births a real OS vessel mid-gesture, survives continued movement, commits `detachItem` through the dock model on release, and cancels with zero mutation. Two-author leaf: the host wiring + composition law (Mnemosyne) and the e2e executor + witnesses + the grammar gap it exposed (Ada, @neo-opus-ada).

**The e2e leg earned its tier on arrival**: the first real-proxy drive exposed that `enableProxyToPopup` shipped WITHOUT its partner `allowOverdrag` — the boundary grammar reads the LIVE proxy rect, and a strip-clamped proxy's intersection ratio never drops, so the exit could never fire in a real gesture. The unit witnesses were structurally blind (they inject proxyRects, bypassing the clamp). Fixed by pairing the flags (mirrors `dashboard/Container`), with the pairing documented at the adapter seam.

**The composition law** (the design's load-bearing fact, for the G3/G4 consumers): a tear-out vessel NEVER writes `detachedPanes` mid-gesture — that single omission keeps DemoB's click-pop-out reparent and its model-mutating disconnect-reattach structurally OUT of the gesture path, so a cancelled tear-out is zero-mutation BY GUARD. The vessel reuses the `?popout=` EMPTY-host viewport mode (a pure pane host — no workspace document), rides empty mid-gesture, and adopts the live pane POST-COMMIT via race-safe bookkeeping (`tearOutPanes`/`tearOutConnects`, both terminal-first and connect-first orders).

Evidence: L3 — the full ladder: unit contract tier (merged #15408: the admission machine + gesture surface, 23 witnesses) + host-tier unit additions (throwing-reducer guard witness; dashboard suite 360/360 at head, exit-code-verified) + **4/4 headed-CDP e2e witnesses on the REAL gesture** (executeTearOutStep driving actual boundary-crossing drags). Residual: none on this leaf — AC-2 (flagship-density threshold calibration, real-input-only) + AC-6 (matrix platform defaults) are split to #15443 with their receipt gates (#15243), per the established split discipline; AC-4's structural receipt is on the ticket (arming precedes boundary evaluation by data dependency, `SortZone.mjs:562`).

## Deltas

| Area | Before | After |
|---|---|---|
| Dock tab drags vs the window boundary | detection grammar dark; even when armed, a clamped proxy could never exit | `enableDockTearOut` arms `enableProxyToPopup` + `allowOverdrag` as a PAIR; the exit fires on real gestures |
| The tear-out flow | none | exit → Boolean-checked vessel admission (`?popout=` empty host) → empty vessel follows the pointer → release commits `detachItem` (catalog preserved = vessel ownership) → post-commit pane adoption; re-entry/Escape retire the vessel, zero mutation |
| Host machinery separation | n/a | the composition law: no `detachedPanes` writes mid-gesture — click-pop-out and tear-out flows cannot interfere by construction |
| Terminal robustness | reducer contract assumed | a THROWING host reducer lands on the refusal path (vessel retired, no sync, no propagated throw) — the #15408 review's accepted hardening |
| E2e substrate | no gesture-tear-out witness existed (the grammar was never driveable) | `executeTearOutStep` + 4 headed witnesses, including the #15413 reap regression as a permanent e2e pin |

## Test Evidence

- **E2e (headed CDP, the real gesture)**: `test/playwright/e2e/agentos/DemoBDockTearOutNL.spec.mjs` — **4/4**: (1) vessel birth + survival past deliberate post-birth moves (the #15413 regression, now permanent); (2) terminal `detachItem` document-truth — item absent from every node AND present in the catalog; (3) Escape while detached → vessel closed, NEITHER document mutated (the composition law's e2e proof); (4) the AC-3 middle-tab falsifier — the middle tab of a multi-item group tears out with siblings + order preserved.
- **Unit**: dashboard suite **360/360** at head (exit-code-verified), including the DockTearOut admission-machine battery and the throwing-reducer guard witness.

## Deltas from ticket

AC-2 + AC-6 split to #15443 (receipts-gated: #15243 matrix + real-input sessions — recorded rationale on both tickets). AC-4 receipted structurally on the ticket. The `rc-response`… (n/a — different ticket). Everything else delivers as written, including the AC-1 live gesture and the AC-3 falsifier's middle-tab shape; the rail/overflow-adjacent falsifier variant rides #15443's calibration sessions where the overflow density exists.

## Post-Merge Validation

- [ ] The five-beat demo story's beats 1–2 run on merged dev (tear-out + convert-mid-drag on the demo surface) — the #15252 wow-demo consumes this leaf.
- [ ] G3 (#15395/#15396) + G4 (#15247) consume the composition law + vessel bookkeeping as their entry contracts.

## Commits

- `75953b63` — throwing-reducer guard at the terminal (+ witness).
- `cb881f42` — the DemoB vessel wiring on the empty-popout shell (the composition law).
- `1e37bd03` — the `allowOverdrag` pairing fix + `executeTearOutStep` + the 4 e2e witnesses (Ada).

Authored by Mnemosyne (Claude Fable 5, Claude Code) + Ada (@neo-opus-ada). Session 89818500-8a12-4162-b41f-8947703b1b06.
