### PR TITLE
refactor(fleet): AgentOS Fleet primitives use component addCls/removeCls/toggleCls (#15201)

### DIFF
--- a/apps/agentos/view/fleet/EventChip.mjs
+++ b/apps/agentos/view/fleet/EventChip.mjs
@@ -1,5 +1,4 @@
 import Component              from '../../../../src/component/Base.mjs';
-import NeoArray               from '../../../../src/util/Array.mjs';
 import {kindClass, kindLabel} from './kindRegistry.mjs';
 
 /**
@@ -57,12 +56,10 @@ class EventChip extends Component {
      * @protected
      */
     afterSetKind(value, oldValue) {
-        let me  = this,
-            cls = me.cls;
+        let me = this;
 
-        oldValue !== undefined && NeoArray.remove(cls, kindClass(oldValue));
-        NeoArray.add(cls, kindClass(value));
-        me.cls = cls;
+        oldValue !== undefined && me.removeCls(kindClass(oldValue));
+        me.addCls(kindClass(value));
 
         me.updateChipText()
     }

--- a/apps/agentos/view/fleet/FamilyRail.mjs
+++ b/apps/agentos/view/fleet/FamilyRail.mjs
@@ -1,5 +1,4 @@
 import Component from '../../../../src/component/Base.mjs';
-import NeoArray  from '../../../../src/util/Array.mjs';
 
 /**
  * Maps a model-family key to its rail token (the `--fm-family-*` values live in the theme skin,
@@ -100,16 +99,13 @@ class FamilyRail extends Component {
      */
     afterSetFamily(value, oldValue) {
         let me       = this,
-            cls      = me.cls,
             oldClass = familyClass(oldValue),
             newClass = familyClass(value);
 
-        oldClass && NeoArray.remove(cls, oldClass);
-        newClass && NeoArray.add(cls, newClass);
+        oldClass && me.removeCls(oldClass);
+        newClass && me.addCls(newClass);
 
-        NeoArray[isKnownFamily(value) ? 'remove' : 'add'](cls, 'fm-family-unclassified');
-
-        me.cls = cls
+        me.toggleCls('fm-family-unclassified', !isKnownFamily(value))
     }
 }
 

--- a/apps/agentos/view/fleet/HealthBar.mjs
+++ b/apps/agentos/view/fleet/HealthBar.mjs
@@ -174,10 +174,7 @@ class HealthBar extends Container {
      * @protected
      */
     updateAnimateCls() {
-        const cls = (this.cls || []).filter(c => c !== 'fm-animate-counts');
-
-        this.animateCounts && cls.push('fm-animate-counts');
-        this.cls = cls
+        this.toggleCls('fm-animate-counts', this.animateCounts)
     }
 
     /**

--- a/apps/agentos/view/fleet/HealthSwatch.mjs
+++ b/apps/agentos/view/fleet/HealthSwatch.mjs
@@ -1,5 +1,4 @@
 import Component    from '../../../../src/component/Base.mjs';
-import NeoArray     from '../../../../src/util/Array.mjs';
 import {stateClass} from './StateDot.mjs';
 
 /**
@@ -97,12 +96,10 @@ class HealthSwatch extends Component {
      * @protected
      */
     afterSetState(value, oldValue) {
-        let me  = this,
-            cls = me.cls;
+        let me = this;
 
-        oldValue !== undefined && NeoArray.remove(cls, stateClass(oldValue));
-        NeoArray.add(cls, stateClass(value));
-        me.cls = cls;
+        oldValue !== undefined && me.removeCls(stateClass(oldValue));
+        me.addCls(stateClass(value));
 
         me.applyLabel();
         me.update()

--- a/apps/agentos/view/fleet/StateDot.mjs
+++ b/apps/agentos/view/fleet/StateDot.mjs
@@ -1,5 +1,4 @@
 import Component from '../../../../src/component/Base.mjs';
-import NeoArray  from '../../../../src/util/Array.mjs';
 
 /**
  * Maps a session-state key to its design token (the `--fm-state-*` values live in the theme skin,
@@ -98,12 +97,8 @@ class StateDot extends Component {
      * @protected
      */
     afterSetState(value, oldValue) {
-        let cls = this.cls;
-
-        oldValue !== undefined && NeoArray.remove(cls, stateClass(oldValue));
-        NeoArray.add(cls, stateClass(value));
-
-        this.cls = cls
+        oldValue !== undefined && this.removeCls(stateClass(oldValue));
+        this.addCls(stateClass(value))
     }
 
     /**
@@ -114,9 +109,7 @@ class StateDot extends Component {
      * @protected
      */
     afterSetLive(value, oldValue) {
-        let cls = this.cls;
-        NeoArray[value ? 'add' : 'remove'](cls, 'fm-live');
-        this.cls = cls
+        this.toggleCls('fm-live', value)
     }
 }
 


### PR DESCRIPTION
Resolves #15201

Five class-based AgentOS Fleet primitives manually read the aggregate component `cls` array, transform it via `NeoArray`, and assign it back — duplicating `Neo.component.Base`'s cls-mutation behavior and coupling app code to the array representation. This migrates them onto the public `addCls()` / `removeCls()` / `toggleCls()` methods (the boundary that owns this).

**Migrated (6 methods across 5 primitives):**
- `EventChip.afterSetKind` → `removeCls` / `addCls`
- `StateDot.afterSetState` → `removeCls` / `addCls`; `StateDot.afterSetLive` → `toggleCls`
- `HealthBar.updateAnimateCls` → `toggleCls`
- `HealthSwatch.afterSetState` → `removeCls` / `addCls`
- `FamilyRail.afterSetFamily` → `removeCls` / `addCls` / `toggleCls`

Net −20 lines; now-unused `NeoArray` imports pruned.

**Deliberately NOT migrated — a justified exception (premise refinement):**
`SourceHealthMarker.applyHealth` batches its cls mutation with `text` through a single `this.set({cls, text})` to satisfy the test-enforced "one coherent reactive batch" contract. The public per-class methods each publish a *separate* cls change, which breaks that atomicity — I verified this by migrating it and watching `sourceHealthMarker.spec.mjs:192` ("publishes class and text changes as one coherent reactive batch") fail, then reverted. Its cls mutation is *required*, not gratuitous, so it stays. The ticket's "six primitives / gratuitous duplication" premise holds for 5/6.

Evidence: L1-unit — fleet primitive specs 39/39 green at this head; no runtime/L3 evidence required (a pure API-boundary swap, class-driven token bindings unchanged).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/{eventChip,familyRail,healthSwatch,sourceHealthMarker,statePrimitives,fleetGrid}.spec.mjs` → **39 passed, 0 failed** at `c464a40465`.
- The SourceHealthMarker atomicity test is the falsifier that scoped the exception (a migration attempt made it fail; the revert restored 39/39).

## Post-Merge Validation

- [ ] No visual regression in the Fleet cockpit primitives — the class-driven `--fm-*` token bindings are unchanged; the migration only swaps the array-mutation mechanism for the owning public methods.

## Deltas

- Scope refinement vs the ticket's "six primitives": 5 migrated, 1 (`SourceHealthMarker`) evidenced as a justified batched exception. No behavior change in any of the six.

Authored by @neo-opus-ada.
