### PR TITLE
refactor: use component addCls/removeCls/toggleCls across application state transitions (#15202)

### DIFF
--- a/apps/covid/view/MainContainerController.mjs
+++ b/apps/covid/view/MainContainerController.mjs
@@ -383,7 +383,7 @@ class MainContainerController extends ComponentController {
             logoPath   = 'https://raw.githubusercontent.com/neomjs/pages/main/resources_pub/images/apps/covid/',
             mapView    = me.getReference('mapboxglmap'),
             themeLight = button.text === 'Theme Light',
-            buttonText, cls, iconCls, mapViewStyle, theme;
+            buttonText, iconCls, mapViewStyle, theme;
 
         if (themeLight) {
             buttonText   = 'Theme Dark';
@@ -400,16 +400,8 @@ class MainContainerController extends ComponentController {
         logo.vdom.src = logoPath + (theme === 'neo-theme-dark' ? 'covid_logo_dark.jpg' : 'covid_logo_light.jpg');
         logo.update();
 
-        cls = [...component.cls];
-
-        component.cls.forEach(item => {
-            if (item.includes('neo-theme')) {
-                NeoArray.remove(cls, item)
-            }
-        });
-
-        NeoArray.add(cls, theme);
-        component.cls = cls;
+        component.cls.filter(item => item.includes('neo-theme')).forEach(item => component.removeCls(item));
+        component.addCls(theme);
 
         button.set({iconCls, text: buttonText});
 

--- a/apps/devindex/view/Viewport.mjs
+++ b/apps/devindex/view/Viewport.mjs
@@ -1,6 +1,5 @@
 import Header                from './HeaderToolbar.mjs';
 import BaseViewport          from '../../../src/container/Viewport.mjs';
-import NeoArray              from '../../../src/util/Array.mjs';
 import ViewportController    from './ViewportController.mjs';
 import ViewportStateProvider from './ViewportStateProvider.mjs';
 
@@ -91,12 +90,10 @@ class Viewport extends BaseViewport {
      */
     afterSetSize(value, oldValue) {
         if (value) {
-            let me  = this,
-                cls = me.cls;
+            let me = this;
 
-            NeoArray.remove(cls, 'devindex-size-' + oldValue);
-            NeoArray.add(   cls, 'devindex-size-' + value);
-            me.cls = cls;
+            me.removeCls('devindex-size-' + oldValue);
+            me.addCls('devindex-size-' + value);
 
             me.stateProvider.setData({size: value})
         }

--- a/apps/portal/view/Viewport.mjs
+++ b/apps/portal/view/Viewport.mjs
@@ -1,7 +1,6 @@
 import BaseViewport          from '../../../src/container/Viewport.mjs';
 import Container             from '../../../src/container/Base.mjs';
 import HeaderToolbar         from './HeaderToolbar.mjs';
-import NeoArray              from '../../../src/util/Array.mjs';
 import ViewportController    from './ViewportController.mjs';
 import ViewportStateProvider from './ViewportStateProvider.mjs';
 
@@ -94,12 +93,10 @@ class Viewport extends BaseViewport {
      */
     afterSetSize(value, oldValue) {
         if (value) {
-            let me  = this,
-                cls = me.cls;
+            let me = this;
 
-            NeoArray.remove(cls, 'portal-size-' + oldValue);
-            NeoArray.add(   cls, 'portal-size-' + value);
-            me.cls = cls;
+            me.removeCls('portal-size-' + oldValue);
+            me.addCls('portal-size-' + value);
 
             me.stateProvider.setData({size: value});
 

--- a/apps/portal/view/ViewportController.mjs
+++ b/apps/portal/view/ViewportController.mjs
@@ -1,6 +1,5 @@
 import Controller        from '../../../src/controller/Component.mjs';
 import CubeLayout        from '../../../src/layout/Cube.mjs';
-import NeoArray          from '../../../src/util/Array.mjs';
 import SeoService        from '../service/Seo.mjs';
 
 /**
@@ -394,17 +393,14 @@ class ViewportController extends Controller {
 
         if (Neo.isNumber(activeIndex) && size) {
             let headerSocialIcons = me.getReference('header-social-icons'),
-                {cls}             = headerSocialIcons,
                 vertical          = size === 'x-small',
                 hidden            = activeIndex !== 0 && vertical;
 
-            NeoArray.toggle(cls, 'hide-sidebar', hidden);
+            headerSocialIcons.toggleCls('hide-sidebar', hidden);
 
             if (!hidden) {
-                NeoArray.toggle(cls, 'separate-bar', vertical)
+                headerSocialIcons.toggleCls('separate-bar', vertical)
             }
-
-            headerSocialIcons.cls = cls;
 
 
             if (hidden && vertical) {

--- a/apps/sharedcovid/view/MainContainerController.mjs
+++ b/apps/sharedcovid/view/MainContainerController.mjs
@@ -571,7 +571,7 @@ class MainContainerController extends ComponentController {
             logo       = me.getReference('logo'),
             logoPath   = 'https://raw.githubusercontent.com/neomjs/pages/main/resources_pub/images/apps/covid/',
             themeLight = button.text === 'Theme Light',
-            buttonText, cls, iconCls, mapView, mapViewStyle, theme;
+            buttonText, iconCls, mapView, mapViewStyle, theme;
 
         if (me.connectedApps.includes('SharedCovidMap')) {
             mapView = me.getMainView('SharedCovidMap').items[0].items[0]
@@ -597,16 +597,8 @@ class MainContainerController extends ComponentController {
         [component.appName, ...me.connectedApps].forEach(appName => {
             component = me.getMainView(appName);
 
-            cls = [...component.cls];
-
-            component.cls.forEach(item => {
-                if (item.includes('neo-theme')) {
-                    NeoArray.remove(cls, item)
-                }
-            });
-
-            NeoArray.add(cls, theme);
-            component.cls = cls
+            component.cls.filter(item => item.includes('neo-theme')).forEach(item => component.removeCls(item));
+            component.addCls(theme)
         });
 
         button.set({iconCls, text: buttonText});

--- a/apps/shareddialog/view/MainContainerController.mjs
+++ b/apps/shareddialog/view/MainContainerController.mjs
@@ -450,7 +450,7 @@ class MainContainerController extends ComponentController {
                         appName         : dockedWindowAppName,
                         cls             : ['neo-dialog', 'neo-panel', 'neo-container'],
                         moveInMainThread: false,
-                        vdom            : vdom,
+                        vdom,
                         windowId        : dockedWindowId
                     });
 
@@ -585,8 +585,7 @@ class MainContainerController extends ComponentController {
             buttonText = 'Theme Light',
             dialog     = me.dialog,
             iconCls    = 'fa fa-sun',
-            theme      = 'neo-theme-dark',
-            cls;
+            theme      = 'neo-theme-dark';
 
         if (button.text === 'Theme Light') {
             buttonText = 'Theme Dark';
@@ -614,11 +613,8 @@ class MainContainerController extends ComponentController {
         button.set({iconCls, text: buttonText});
 
         if (dialog) {
-            cls = dialog.cls;
-
-            NeoArray.removeAdd(cls, me.previousTheme, me.currentTheme);
-
-            dialog.cls = cls
+            dialog.removeCls(me.previousTheme);
+            dialog.addCls(me.currentTheme)
         }
     }
 


### PR DESCRIPTION
Resolves #15202

Six non-AgentOS application files manually read the aggregate component `cls` array, mutate it via `NeoArray`, and assign the whole value back — duplicating `Neo.component.Base`'s cls-mutation behavior and coupling app code to the array representation. This migrates them onto the public `addCls()` / `removeCls()` / `toggleCls()` methods. Sibling of #15201 (PR #15446, the AgentOS Fleet primitives).

**Migrated:**
- `apps/portal/view/Viewport.afterSetSize` + `apps/devindex/view/Viewport.afterSetSize` — the `this.cls` size-class swap → `removeCls` / `addCls`.
- `apps/portal/view/ViewportController` — a referenced `header-social-icons` toggle → `toggleCls` (×2).
- `apps/covid` + `apps/sharedcovid` + `apps/shareddialog` `MainContainerController` theme-swaps on referenced main views → `removeCls` / `addCls`.

Net −30 lines; unused `NeoArray` imports + orphaned `cls` locals pruned. (One incidental: a pre-existing `vdom: vdom` in shareddialog folded to shorthand to pass the `check-shorthand` pre-commit gate.)

Evidence: L1-unit — portal + devindex suites 51/51 green at `4e2b5642d2` (they cover `Viewport` + `ViewportController`). The covid/sharedcovid/shareddialog theme-swaps are test-less demo apps → equivalence-by-construction (see Deltas); a live smoke rides Post-Merge Validation.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/portal/ test/playwright/unit/app/devindex/` → **51 passed, 0 failed** at `4e2b5642d2`.
- `node --check` green on all six files.

## Post-Merge Validation

- [ ] Demo-app theme-swap smoke — covid / sharedcovid / shareddialog: toggle the theme and confirm the `neo-theme-*` class swaps on the connected main views (no unit coverage exists for these demos).

## Deltas

- The covid/sharedcovid/shareddialog theme-swaps are a **direct substitution**: the public methods ARE the read/mutate/reassign these sites hand-rolled, so DOM output is identical (Neo batches synchronous config changes into one vdom update). Unlike `SourceHealthMarker` in the #15201 sibling — which had a test-enforced single-batch contract the per-class methods would break — these demo swaps have no atomicity contract, so the migration is safe by construction.

Authored by @neo-opus-ada.
