### PR TITLE
docs(adr): ADR-0004 §2.2.1 — an ordinal is only meaningful against COMPLETE membership (#15354)

### DIFF
--- a/learn/agentos/decisions/0004-github-content-architecture.md
+++ b/learn/agentos/decisions/0004-github-content-architecture.md
@@ -95,6 +95,14 @@ For any content collection (e.g., active issues, archived discussions for v12.1.
 
 **This is OUR OWN mathematically sound real-100.** It does NOT derive from GitHub IDs. Two collections of the same size produce identically-shaped chunks regardless of GitHub-ID gaps.
 
+### 2.2.1 Precondition: an ordinal is only meaningful against COMPLETE membership
+
+`itemIndex` (§2.2) is a position *within a bucket*, so it is correct only when computed against that bucket's **complete membership** — a precondition the rule assumes and, until this amendment, never wrote down. That silence is why it was violated silently, by more than one syncer.
+
+**A partial collection yields a DIFFERENT ordinal, not an approximate one.** An ordinal derived from a fraction of a bucket is not a smaller truth: the item lands in a chunk the complete ordering would never have chosen, beside the copy already there. The corpus on disk is the *only* complete membership that exists — the files outlive every cache that describes them. `metadata.{type}` and each run's delta fetch are **partial by design** (the delta sync rebuilds its cache from each run's fetch), so a planner reading only those is not "optimising" — it is computing a different number, and the failure is silent: a wrong ordinal produces a *valid-looking* artifact in a *plausible* chunk. Empirical anchor: #15130 / #15319 repaired 2,015 stale index entries → 0 and restored 27 divergent duplicate artifacts.
+
+**Complete membership costs a full scan of both tiers, per type, per sync — and that is the correct price.** The only alternative is a membership cache that must never drift, which is exactly the thing that already failed (§1.2's substrate-bypass anti-pattern). `ai/services/github-workflow/shared/contentInventory.mjs` (`buildContentInventory` — active tier + every archive bucket, recursive) is the reference implementation and the canonical way to satisfy this precondition; a planner that computes placement from `metadata.{type}` plus a delta fetch does not satisfy it, and is free to reintroduce the defect until it reads complete membership.
+
 ### 2.3 Retired primitives
 
 - **`ai/services/github-workflow/shared/chunkPath.mjs`** (3-line `String(id).padStart(4,'0').slice(0,-2) + 'xx'`) — RETIRED. ID-range chunking abandoned everywhere.


### PR DESCRIPTION
Resolves #15354 — the ADR amendment ships here; AC-5's audit is recorded and its named two-syncer follow-up is filed as #15452, so all of #15354's ACs are delivered.

## Premise

ADR-0004 mandates universal ordinal-100 chunking but never stated the precondition that makes an ordinal computable: **an ordinal is only meaningful against COMPLETE membership.** That silent omission is the root cause the duplicate-artifact repairs (#15130 / #15319) fixed rather than removed — a planner reading `metadata.{type}` + a delta fetch computes an ordinal against a *fraction* of a bucket, landing the item in a chunk the complete ordering would never have chosen, beside the copy already there.

## The change

New **§2.2.1** under the chunking contract (~15 lines, in the ADR's own voice): the invariant (a partial collection yields a **different** ordinal, not an approximate one), the corpus-on-disk as the only complete membership that exists, `metadata.{type}` / delta fetches as **partial by design**, the full-scan cost (both tiers, per type, per sync) as the correct price vs a never-drift cache (the thing that already failed, §1.2), and `contentInventory.mjs` (`buildContentInventory`) as the reference implementation.

## Deltas from ticket

None — the prescribed shape: an amendment recording a precondition of the accepted design, an ADR-0004 edit rather than a new ADR. Explicitly NOT re-opening ordinal-100, the sealed-chunk rule, or §1.3.

## Test Evidence

L1 — the audit IS the V-B-A. AC-5 audit, verified against the code and recorded on #15354:
- **PullRequestSyncer conforms** — reads complete membership via `buildContentInventory` (repaired by #15319), and reasons explicitly about "COMPLETE bucket membership."
- **IssueSyncer#planBuckets + DiscussionSyncer#planBuckets are VULNERABLE** — build `combined` from `metadata.{type}` + the delta fetch (partial by construction), no `contentInventory`. Structurally free to repeat the defect.

Evidence: L1 — a docs/ADR amendment; no runtime, API, or persistence surface changed. The AC-5 audit (verified against the code) is the V-B-A. Residual: none.

## Post-Merge Validation

- [x] AC-5 second half — the named two-syncer follow-up is filed as **#15452** (IssueSyncer + DiscussionSyncer adopt complete-membership ordinal placement via `buildContentInventory`, mirroring #15319). All of #15354's ACs are now delivered.

## Net-bytes disposition

+~15 lines, justified by decay-mitigation (Substrate Accretion Defense): the precondition was discoverable only by reading a repair PR's module JSDoc — exactly the substrate-bypass anti-pattern §1.2 exists to prevent. Recording it in the governing ADR is the fix, not the accretion.

Authored by Grace (Claude Opus 4.8, Claude Code).
