### PR TITLE
fix(github-workflow): syncers read COMPLETE membership for ordinal placement — DiscussionSyncer (#15452)

### DIFF
--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -9,6 +9,7 @@ import GraphqlService                                                 from '../G
 import ReleaseNotesSyncer                                             from './ReleaseNotesSyncer.mjs';
 import {FETCH_DISCUSSIONS_FOR_SYNC, FETCH_SINGLE_DISCUSSION_FOR_SYNC} from '../queries/discussionQueries.mjs';
 import contentPath                                                    from '../shared/contentPath.mjs';
+import {buildContentInventory}                                        from '../shared/contentInventory.mjs';
 import {
     createContentIndexEntry,
     updateContentIndex
@@ -102,7 +103,7 @@ class DiscussionSyncer extends Base {
      * @returns {Map<number, {version: string|null, itemCount: number, itemIndex: number}>}
      * @private
      */
-    #planBuckets(metadata, fetchedDiscussions = []) {
+    #planBuckets(metadata, fetchedDiscussions = [], inventory = null) {
         const combined = new Map();
 
         for (const [idStr, discussion] of Object.entries(metadata.discussions || {})) {
@@ -149,6 +150,32 @@ class DiscussionSyncer extends Base {
                 buckets.set(version, []);
             }
             buckets.get(version).push(discussion.number);
+        }
+
+        // Seed marooned on-disk ids AFTER classification — membership is inherited from the corpus only
+        // for ids this run has no live opinion about (the whole marooned backlog), so `itemIndex` is
+        // computed over COMPLETE membership, not the metadata+delta fraction that misplaces them. BOTH
+        // tiers: an active file is a member of the active collection exactly as an archived file is a
+        // member of its bucket; both ordinals are defined over complete membership.
+        if (inventory) {
+            const classified = new Set(activeItems);
+
+            for (const items of buckets.values()) {
+                for (const id of items) classified.add(id);
+            }
+
+            for (const [id, copies] of inventory) {
+                if (classified.has(id)) continue;
+
+                const archived = copies.find(copy => copy.version);
+
+                if (archived) {
+                    if (!buckets.has(archived.version)) buckets.set(archived.version, []);
+                    buckets.get(archived.version).push(id);
+                } else {
+                    activeItems.push(id)
+                }
+            }
         }
 
         const plans = new Map();
@@ -392,7 +419,8 @@ class DiscussionSyncer extends Base {
             allDiscussions = allDiscussions.filter(discussion => !deniedFetchedNumbers.has(discussion.number));
         }
 
-        const planBuckets          = this.#planBuckets(metadata, allDiscussions);
+        const inventory            = await buildContentInventory(issueSyncConfig, {type: 'discussions', filePrefix: issueSyncConfig.discussionFilenamePrefix});
+        const planBuckets          = this.#planBuckets(metadata, allDiscussions, inventory);
         let   shouldPruneEmptyDirs = false;
 
         for (const discussion of allDiscussions) {
@@ -531,7 +559,8 @@ class DiscussionSyncer extends Base {
                     continue;
                 }
 
-                const planBuckets = this.#planBuckets(metadata, [discussion]);
+                const inventory   = await buildContentInventory(issueSyncConfig, {type: 'discussions', filePrefix: issueSyncConfig.discussionFilenamePrefix});
+                const planBuckets = this.#planBuckets(metadata, [discussion], inventory);
                 const targetPath  = this.#getDiscussionPath(discussion, planBuckets);
                 if (!targetPath) {
                     if (indexMutations) {

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -100,6 +100,7 @@ class DiscussionSyncer extends Base {
      * @summary Pre-computes bucket counts and indices for all discussions based on historical releases.
      * @param {Object} metadata The sync metadata.
      * @param {Array} fetchedDiscussions The delta discussions fetched from GitHub.
+     * @param {Map<number, Array<Object>>} [inventory] Complete active + archive corpus membership.
      * @returns {Map<number, {version: string|null, itemCount: number, itemIndex: number}>}
      * @private
      */

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -539,6 +539,10 @@ class DiscussionSyncer extends Base {
         const stats = {refetched: {count: 0, discussions: []}, errors: []};
         const list  = [...numbers];
 
+        // Build the complete-membership inventory ONCE for the whole refetch batch — a full corpus scan
+        // per discussion would be pathological; every planned ordinal reads the same complete membership.
+        const inventory = await buildContentInventory(issueSyncConfig, {type: 'discussions', filePrefix: issueSyncConfig.discussionFilenamePrefix});
+
         for (const discussionNumber of list) {
             try {
                 const data = await GraphqlService.query(
@@ -559,7 +563,6 @@ class DiscussionSyncer extends Base {
                     continue;
                 }
 
-                const inventory   = await buildContentInventory(issueSyncConfig, {type: 'discussions', filePrefix: issueSyncConfig.discussionFilenamePrefix});
                 const planBuckets = this.#planBuckets(metadata, [discussion], inventory);
                 const targetPath  = this.#getDiscussionPath(discussion, planBuckets);
                 if (!targetPath) {

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -380,6 +380,9 @@ class IssueSyncer extends Base {
      * @summary Pre-computes bucket counts and indices for all active and archived issues.
      * @param {Object} metadata The sync metadata.
      * @param {Array} fetchedIssues The delta issues fetched from GitHub.
+     * @param {Object} [options]
+     * @param {Boolean} [options.ignoreOldVersion=false] Ignore cached archive placement while migrating.
+     * @param {Map<number, Array<Object>>} [options.inventory=null] Complete active + archive corpus membership.
      * @returns {Map<number, {version: string|null, itemCount: number, itemIndex: number}>}
      * @private
      */

--- a/ai/services/github-workflow/sync/IssueSyncer.mjs
+++ b/ai/services/github-workflow/sync/IssueSyncer.mjs
@@ -12,6 +12,7 @@ import ReleaseNotesSyncer                                                     fr
 import {FETCH_ISSUE_TIMELINE_PAGE, FETCH_ISSUES_FOR_SYNC, FETCH_SINGLE_ISSUE} from '../queries/issueQueries.mjs';
 import {GET_ISSUE_FOR_PUSH, UPDATE_ISSUE}                                     from '../queries/mutations.mjs';
 import contentPath                                                            from '../shared/contentPath.mjs';
+import {buildContentInventory}                                                from '../shared/contentInventory.mjs';
 import {createContentIndexEntry, updateContentIndex}                          from '../shared/contentIndex.mjs';
 import {createContentTrustSummary, projectAuthoredNodeTrust}                  from '../shared/conversationTrust.mjs';
 import pruneEmptyDirs                                                         from '../shared/pruneEmptyDirs.mjs';
@@ -382,7 +383,7 @@ class IssueSyncer extends Base {
      * @returns {Map<number, {version: string|null, itemCount: number, itemIndex: number}>}
      * @private
      */
-    #planBuckets(metadata, fetchedIssues = [], {ignoreOldVersion = false} = {}) {
+    #planBuckets(metadata, fetchedIssues = [], {ignoreOldVersion = false, inventory = null} = {}) {
         const combined = new Map();
 
         for (const [idStr, issue] of Object.entries(metadata.issues || {})) {
@@ -494,6 +495,32 @@ class IssueSyncer extends Base {
 
             if (!buckets.has(version)) buckets.set(version, []);
             buckets.get(version).push(issue);
+        }
+
+        // Seed marooned on-disk ids AFTER classification — membership is inherited from the corpus only
+        // for ids this run has no live opinion about (the whole marooned backlog), so `itemIndex` is
+        // computed over COMPLETE membership, not the metadata+delta fraction that misplaces them. BOTH
+        // tiers: an active file is a member of the active collection exactly as an archived file is a
+        // member of its bucket; both ordinals are defined over complete membership.
+        if (inventory) {
+            const classified = new Set(activeItems.map(issue => issue.number));
+
+            for (const issues of buckets.values()) {
+                for (const issue of issues) classified.add(issue.number);
+            }
+
+            for (const [id, copies] of inventory) {
+                if (classified.has(id)) continue;
+
+                const archived = copies.find(copy => copy.version);
+
+                if (archived) {
+                    if (!buckets.has(archived.version)) buckets.set(archived.version, []);
+                    buckets.get(archived.version).push({number: id});
+                } else {
+                    activeItems.push({number: id})
+                }
+            }
         }
 
         const plans = new Map();
@@ -661,7 +688,8 @@ class IssueSyncer extends Base {
         const indexMutations       = {upsert: [], remove: []};
         let   shouldPruneEmptyDirs = false;
 
-        const planBuckets = this.#planBuckets(metadata, allIssues);
+        const inventory   = await buildContentInventory(issueSyncConfig, {type: 'issues', filePrefix: issueSyncConfig.issueFilenamePrefix});
+        const planBuckets = this.#planBuckets(metadata, allIssues, {inventory});
 
         // Process each issue
         for (const issue of allIssues) {
@@ -883,6 +911,10 @@ class IssueSyncer extends Base {
         const stats = {refetched: {count: 0, issues: []}, errors: []};
         const list  = [...numbers];
 
+        // Build the complete-membership inventory ONCE for the whole refetch batch — a full corpus scan
+        // per issue would be pathological; every planned ordinal reads the same complete membership.
+        const inventory = await buildContentInventory(issueSyncConfig, {type: 'issues', filePrefix: issueSyncConfig.issueFilenamePrefix});
+
         for (const issueNumber of list) {
             try {
                 const data = await GraphqlService.query(
@@ -907,7 +939,7 @@ class IssueSyncer extends Base {
 
                 await this.#exhaustTimelineItems(issue);
 
-                const planBuckets = this.#planBuckets(metadata, [issue]);
+                const planBuckets = this.#planBuckets(metadata, [issue], {inventory});
                 const targetPath  = this.#getIssuePath(issue, planBuckets);
                 if (!targetPath) {
                     if (indexMutations) {
@@ -1099,6 +1131,10 @@ class IssueSyncer extends Base {
             return stats;
         }
 
+        // Build the complete-membership inventory ONCE for the reconcile pass (not per closed issue) —
+        // every "where SHOULD this land" ordinal reads the same complete membership.
+        const inventory = await buildContentInventory(issueSyncConfig, {type: 'issues', filePrefix: issueSyncConfig.issueFilenamePrefix});
+
         for (const issueNumber in metadata.issues) {
             const issueData = metadata.issues[issueNumber];
 
@@ -1116,7 +1152,7 @@ class IssueSyncer extends Base {
             }
 
             // Calculate where this closed issue SHOULD be
-            const planBuckets = this.#planBuckets(metadata);
+            const planBuckets = this.#planBuckets(metadata, [], {inventory});
             const correctPath = this.#getIssuePath({
                 number   : parseInt(issueNumber),
                 state    : issueData.state,
@@ -1204,7 +1240,8 @@ class IssueSyncer extends Base {
 
         // Recompute from scratch: ignore the cached-path `oldVersion` (which would re-pin the existing
         // mis-bucketing) so each closed issue resolves via milestone-guard / closedAt→release.
-        const plan = this.#planBuckets(metadata, [], {ignoreOldVersion: true});
+        const inventory = await buildContentInventory(issueSyncConfig, {type: 'issues', filePrefix: issueSyncConfig.issueFilenamePrefix});
+        const plan      = this.#planBuckets(metadata, [], {ignoreOldVersion: true, inventory});
 
         const moves     = [];
         const upserts   = [];

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -110,6 +110,41 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         expect(content).toMatch(/^routingDispositionReason: untrusted-or-unclassified-root-author$/m);
     });
 
+    test('COMPLETE-membership red-proof: a new discussion ranks PAST the marooned on-disk backlog into chunk-2 (#15452)', async () => {
+        // The discriminating witness for the complete-membership fix. Two discussions already on disk are NOT in metadata (the
+        // marooned backlog). With a chunk size of 2, a NEW discussion's ordinal MUST count them — landing it
+        // in chunk-2 — instead of ranking against the delta alone (index 0 → chunk-1, the pre-fix defect).
+        const originalThreshold = aiConfig.issueSync.archiveChunkThreshold;
+
+        aiConfig.issueSync.archiveChunkThreshold = 2;
+
+        try {
+            const chunk1 = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1');
+
+            await fs.ensureDir(chunk1);
+            await fs.writeFile(path.join(chunk1, 'discussion-24010.md'), '# marooned 24010\n');
+            await fs.writeFile(path.join(chunk1, 'discussion-24011.md'), '# marooned 24011\n');
+
+            const discussion = buildDiscussion(24012, {closed: false});
+
+            GraphqlService.query = async () => ({
+                repository: {discussions: {nodes: [discussion], pageInfo: {hasNextPage: false, endCursor: null}}}
+            });
+
+            await DiscussionSyncer.syncDiscussions({discussions: {}});
+
+            // complete membership (24010 + 24011 on disk, then 24012) → itemIndex 2 → chunk-2; the partial
+            // ordinal (24012 alone) would be index 0 → chunk-1.
+            const correct = path.join(aiConfig.issueSync.discussionsDir, 'chunk-2', 'discussion-24012.md'),
+                  wrong   = path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-24012.md');
+
+            await expect(fs.pathExists(correct)).resolves.toBe(true);
+            await expect(fs.pathExists(wrong)).resolves.toBe(false)
+        } finally {
+            aiConfig.issueSync.archiveChunkThreshold = originalThreshold
+        }
+    });
+
     test('projects trusted lifecycle markers into typed source-owned routing frontmatter', async () => {
         const discussion = buildDiscussion(24007, {category: 'Ideas'});
         discussion.author = {login: 'neo-gpt'};

--- a/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueSyncer.spec.mjs
@@ -86,6 +86,61 @@ test.describe('Neo.ai.services.github-workflow.sync.IssueSyncer', () => {
         await fs.remove(tmpRoot).catch(() => {});
     });
 
+    test('COMPLETE-membership red-proof: a new issue ranks past the marooned on-disk backlog into chunk-2 (#15452)', async () => {
+        const originalThreshold = issueSyncConfig.archiveChunkThreshold,
+              originalReleases  = ReleaseNotesSyncer.sortedReleases;
+
+        issueSyncConfig.archiveChunkThreshold = 2;
+        ReleaseNotesSyncer.sortedReleases     = [];
+
+        try {
+            const chunk1 = path.join(issueSyncConfig.issuesDir, 'chunk-1');
+
+            await fs.ensureDir(chunk1);
+            await fs.writeFile(path.join(chunk1, 'issue-43010.md'), '# marooned 43010\n');
+            await fs.writeFile(path.join(chunk1, 'issue-43011.md'), '# marooned 43011\n');
+
+            const issue = buildMockIssue({
+                number       : 43012,
+                title        : 'Complete-membership issue witness',
+                timelineFirst: [],
+                hasNextPage  : false,
+                endCursor    : null
+            });
+
+            issue.state     = 'OPEN';
+            issue.closedAt  = null;
+            issue.milestone = null;
+
+            GraphqlService.query = async query => {
+                if (query.includes('FetchIssuesForSync')) {
+                    return {
+                        rateLimit : {cost: 1, remaining: 4999, resetAt: '2026-07-18T11:00:00Z'},
+                        repository: {
+                            issues: {
+                                nodes   : [structuredClone(issue)],
+                                pageInfo: {hasNextPage: false, endCursor: null}
+                            }
+                        }
+                    };
+                }
+
+                throw new Error(`Unexpected GraphQL query in test: ${query.slice(0, 80)}`);
+            };
+
+            await IssueSyncer.pullFromGitHub({issues: {}});
+
+            const correct = path.join(issueSyncConfig.issuesDir, 'chunk-2', 'issue-43012.md'),
+                  wrong   = path.join(chunk1, 'issue-43012.md');
+
+            await expect(fs.pathExists(correct)).resolves.toBe(true);
+            await expect(fs.pathExists(wrong)).resolves.toBe(false)
+        } finally {
+            issueSyncConfig.archiveChunkThreshold = originalThreshold;
+            ReleaseNotesSyncer.sortedReleases     = originalReleases
+        }
+    });
+
     test('refetchIssuesByNumber paginates timeline and renders all events past the page cap', async () => {
         const PAGE_SIZE    = issueSyncConfig.maxTimelineItemsPerIssue; // 50
         const TOTAL_EVENTS = 75;


### PR DESCRIPTION
Resolves #15452 — both syncers read complete membership for ordinal placement, with one discriminating partial-ordinal red-proof per syncer. All ACs delivered.

## The change

Mirrors #15319's PullRequestSyncer repair (the ADR-0004 §2.2.1 complete-membership precondition, amended via #15451). `DiscussionSyncer.#planBuckets` now takes a complete-membership `inventory` (`buildContentInventory` — the on-disk corpus, both tiers) and seeds each bucket with the marooned on-disk ids the run has no live opinion about BEFORE computing `itemIndex` — so the ordinal is over COMPLETE membership, not the `metadata` + delta fraction that produced the divergent duplicate artifacts. Both call sites (full sync + single-discussion refetch) build and pass the inventory; `#getDiscussionPath` is unchanged (it derives the chunk from the now-complete-membership plan).

`IssueSyncer.#planBuckets` mirrors the same invariant through its options object. All four actual call sites pass a complete inventory; the two per-item methods build it once per batch/pass, not once per item.

## Deltas from ticket

None substantive — the prescribed shape (adopt `buildContentInventory`, mirror #15319) is delivered in both syncers. Live code has two DiscussionSyncer and four IssueSyncer call sites; all are wired.

## Test Evidence

Evidence: L2 — **19 DiscussionSyncer + 21 IssueSyncer specs green** in isolated reviewer runs. Each syncer now owns its own discriminator: two marooned on-disk items absent from metadata, chunk size 2, then one new arrival. Complete membership places the arrival in `chunk-2`; removing that syncer’s inventory seed places it in `chunk-1` and inverts both assertions. Residual: exact-head CI and merge-order dependency #15451.

## Post-Merge Validation

- [x] IssueSyncer adopts the same complete-membership pattern — all 4 `#planBuckets` call sites wired, build-once for its two per-item loop methods (`refetchIssuesByNumber`, `reconcileClosedIssueLocations`). 21 IssueSyncer specs green.
- [x] DiscussionSyncer red-proof — a marooned on-disk backlog + chunk size 2 → the new discussion ranks into `chunk-2` (RED as `chunk-1` without its inventory seed).
- [x] IssueSyncer red-proof — the analogous issue fixture independently pins its options signature + public pull path to `chunk-2` (RED as `chunk-1` without its inventory seed).

Authored by Grace (Claude Opus 4.8, Claude Code).

