### PR TITLE
feat(agentos): the flagship fusion tour — cockpit → docked panel → OS window → share (#14789)

### DIFF
--- a/apps/agentos/tour/fusionFlagship.mjs
+++ b/apps/agentos/tour/fusionFlagship.mjs
@@ -28,7 +28,8 @@ import cockpitDockDocument from '../view/fleet/cockpitDockDocument.mjs';
  * Cue vocabulary consumed by the hosting cockpit (Leaf-2 wiring): `perspective-save`,
  * `perspective-load` (Demo-B precedent) · `perspective-export`, `perspective-import` (the
  * share round-trip — export serializes the named record to a JSON artifact, import admits
- * one back through validation) · `reattach` (pop-in).
+ * one back through validation) · `popout`, `reattach` (the detail vessel's OWN state machine —
+ * the host's full pop-out flow, never a bare document op, so the OS window actually opens).
  */
 
 /**
@@ -82,15 +83,7 @@ export const fusionTourScript = Object.freeze({
         title  : 'OS window — the pane leaves, the state does not blink',
         caption: 'detachItem: the detail becomes a real OS window on the SAME SharedWorker heap. Reparent, never recreate — the stream underneath keeps ticking through the hop.',
         steps  : [
-            {
-                type      : 'op',
-                caption   : 'detach(detail): out of the tree, catalog record kept — that record IS the vessel ownership',
-                descriptor: {operation: 'detachItem', itemId: 'detail'},
-                expect    : [
-                    {path: 'items.detail.title', equals: 'Agent detail'},
-                    {path: 'items.detail.kind',  equals: 'inspector'}
-                ]
-            },
+            {type: 'pause', ms: 900, cue: {type: 'popout', itemId: 'detail'}, caption: 'pop out(detail): the host vessel flow runs — detachItem commits, the catalog record becomes the vessel ownership, a REAL OS window opens'},
             {type: 'pause', ms: 2200, caption: 'two OS windows, one heap: the SAME component instance, the SAME live subscriptions — this is what portal architectures cannot do'},
             {type: 'pause', ms: 900, cue: {type: 'reattach', itemId: 'detail'}, caption: 'reattach(detail): home again — same instance, same state, zero re-mount'},
             {type: 'pause', ms: 1200}

--- a/apps/agentos/tour/fusionFlagship.mjs
+++ b/apps/agentos/tour/fusionFlagship.mjs
@@ -1,0 +1,121 @@
+import cockpitDockDocument from '../view/fleet/cockpitDockDocument.mjs';
+
+/**
+ * @summary The flagship fusion screenplay: cockpit → docked panel → OS window → share — the
+ * v13.2 cornerstone done-signal as `neo.tour.script.v1` data, played on the REAL Fleet Cockpit.
+ *
+ * Four beats, one continuous tour (the product story a stranger can retell):
+ *
+ * 1. **Cockpit** — the live mission-control surface: the density-ranked fleet roster over the
+ *    ticking activity stream. The opening shape is captured live as a named perspective (the
+ *    Demo-B capture pattern — no pre-baked records).
+ * 2. **Docked panel** — the agent detail leaves the auto-hidden rail and takes a real split
+ *    beside the fleet: two semantic operations through the same `execute_dock_operation` path
+ *    a live agent uses.
+ * 3. **OS window** — `detachItem`: the detail pane leaves the browser window for its own OS
+ *    window ON THE SAME SharedWorker heap. The catalog keeps the record (vessel ownership),
+ *    the instance is reparented — never recreated — and the stream keeps ticking. Return is a
+ *    host-owned `reattach` cue (the Demo-B pop-in pattern).
+ * 4. **Share** — the workspace becomes a copyable artifact: save → export → morph away →
+ *    import → restore. "Share" v1 is the perspective-JSON round-trip; no backend.
+ *
+ * Layering contract (the Demo-B lesson): every `expect`/`topology-assert` in this script is
+ * cue-independent document-truth — it holds in pure spec-mode replay where host cues are
+ * pacing no-ops. Worker-truth (instance-id continuity, stream-tick monotonicity, export/import
+ * fingerprint equality) belongs to the e2e leaf, which plays THIS script in live mode and
+ * asserts through the Neural Link.
+ *
+ * Cue vocabulary consumed by the hosting cockpit (Leaf-2 wiring): `perspective-save`,
+ * `perspective-load` (Demo-B precedent) · `perspective-export`, `perspective-import` (the
+ * share round-trip — export serializes the named record to a JSON artifact, import admits
+ * one back through validation) · `reattach` (pop-in).
+ */
+
+/**
+ * The opening stage — the Fleet Cockpit's REAL default document (SSOT §01), imported from the
+ * cockpit's own data leaf so the tour can never drift from the shipped surface.
+ * @type {Object}
+ */
+export const initialDocument = Object.freeze(cockpitDockDocument());
+
+/**
+ * The fusion tour script. Document mutations are executable `op` steps with expects; every
+ * perspective/window transition the HOST owns rides a cue on a pacing step.
+ * @type {Object}
+ */
+export const fusionTourScript = Object.freeze({
+    schema: 'neo.tour.script.v1',
+    id    : 'fusion-flagship',
+    title : 'One workspace: cockpit, dock, OS window, share',
+
+    workspace: {},
+
+    scenes: [{
+        id     : 's1',
+        title  : 'Cockpit — the fleet, live',
+        caption: 'Mission control: the agent roster ranked by activity, the event stream ticking underneath. Everything on this stage is one running app-worker.',
+        steps  : [
+            {type: 'pause', ms: 1400, caption: 'the stream is LIVE — every chip is a real fleet event, and it will not stop while the workspace changes'},
+            {type: 'pause', ms: 700, cue: {type: 'perspective-save', name: 'Mission Control'}, caption: 'save("Mission Control"): the opening stage becomes a named perspective — captured state, not a screenshot'}
+        ]
+    }, {
+        id     : 's2',
+        title  : 'Docked panel — the detail joins the workspace',
+        caption: 'The agent detail lives on the auto-hidden rail. Two semantic operations dock it beside the fleet — the same operation path a live agent drives.',
+        steps  : [
+            {
+                type      : 'op',
+                caption   : 'reveal(detail): off the rail, into the layout truth',
+                descriptor: {operation: 'setItemAutoHidden', itemId: 'detail', autoHidden: false},
+                expect    : [{path: 'items.detail.autoHidden', equals: false}]
+            },
+            {
+                type      : 'op',
+                caption   : 'split(detail → beside fleet): a real split, animated by the FLIP layer',
+                descriptor: {operation: 'splitNode', itemId: 'detail', targetNodeId: 'fleet-tabs', orientation: 'horizontal', edge: 'right', sizes: [0.62, 0.38]},
+                expect    : [{path: 'nodes.split-fleet-tabs-0.orientation', equals: 'horizontal'}]
+            },
+            {type: 'pause', ms: 1200}
+        ]
+    }, {
+        id     : 's3',
+        title  : 'OS window — the pane leaves, the state does not blink',
+        caption: 'detachItem: the detail becomes a real OS window on the SAME SharedWorker heap. Reparent, never recreate — the stream underneath keeps ticking through the hop.',
+        steps  : [
+            {
+                type      : 'op',
+                caption   : 'detach(detail): out of the tree, catalog record kept — that record IS the vessel ownership',
+                descriptor: {operation: 'detachItem', itemId: 'detail'},
+                expect    : [
+                    {path: 'items.detail.title', equals: 'Agent detail'},
+                    {path: 'items.detail.kind',  equals: 'inspector'}
+                ]
+            },
+            {type: 'pause', ms: 2200, caption: 'two OS windows, one heap: the SAME component instance, the SAME live subscriptions — this is what portal architectures cannot do'},
+            {type: 'pause', ms: 900, cue: {type: 'reattach', itemId: 'detail'}, caption: 'reattach(detail): home again — same instance, same state, zero re-mount'},
+            {type: 'pause', ms: 1200}
+        ]
+    }, {
+        id     : 's4',
+        title  : 'Share — the exact workspace, as an artifact',
+        caption: 'A workspace you can hand to a teammate: save it, export the JSON, prove the round-trip by morphing away and importing it back.',
+        steps  : [
+            {type: 'pause', ms: 700, cue: {type: 'perspective-save', name: 'Shared Session'}, caption: 'save("Shared Session"): the current shape, named'},
+            {type: 'pause', ms: 700, cue: {type: 'perspective-export', name: 'Shared Session'}, caption: 'export("Shared Session"): one copyable JSON artifact — the whole layout, no backend'},
+            {type: 'pause', ms: 1100, cue: {type: 'perspective-load', name: 'Mission Control'}, caption: 'load("Mission Control"): morph away — the shared shape is gone from the stage'},
+            {type: 'pause', ms: 1100, cue: {type: 'perspective-import', name: 'Shared Session'}, caption: 'import(artifact): the JSON comes back through validation, exactly as exported'},
+            {type: 'pause', ms: 1100, cue: {type: 'perspective-load', name: 'Shared Session'}, caption: 'load("Shared Session"): the teammate sees YOUR workspace — fingerprint-equal, asserted in the e2e leg'},
+            {
+                type   : 'topology-assert',
+                caption: 'the catalog truth that holds in every mode: the detail is a first-class workspace citizen, the fleet never left',
+                expect : [
+                    {path: 'items.detail.title', equals: 'Agent detail'},
+                    {path: 'items.fleet.title',  equals: 'Fleet'}
+                ]
+            },
+            {type: 'pause', ms: 900}
+        ]
+    }]
+});
+
+export default fusionTourScript;

--- a/apps/agentos/tour/fusionFlagship.mjs
+++ b/apps/agentos/tour/fusionFlagship.mjs
@@ -86,7 +86,7 @@ export const fusionTourScript = Object.freeze({
             {type: 'pause', ms: 900, cue: {type: 'popout', itemId: 'detail'}, caption: 'pop out(detail): the host vessel flow runs — detachItem commits, the catalog record becomes the vessel ownership, a REAL OS window opens'},
             {type: 'pause', ms: 2200, caption: 'two OS windows, one heap: the SAME component instance, the SAME live subscriptions — none of the docking libraries surveyed in ADR-0029 §4 offered this'},
             {type: 'pause', ms: 900, cue: {type: 'reattach', itemId: 'detail'}, caption: 'reattach(detail): home again — same instance, same state, zero re-mount'},
-            {type: 'pause', ms: 1200}
+            {type: 'pause', ms: 1800}
         ]
     }, {
         id     : 's4',

--- a/apps/agentos/tour/fusionFlagship.mjs
+++ b/apps/agentos/tour/fusionFlagship.mjs
@@ -97,7 +97,7 @@ export const fusionTourScript = Object.freeze({
             {type: 'pause', ms: 700, cue: {type: 'perspective-export', name: 'Shared Session'}, caption: 'export("Shared Session"): the whole layout as one JSON artifact, readable over the Neural Link — no backend'},
             {type: 'pause', ms: 1100, cue: {type: 'perspective-load', name: 'Mission Control'}, caption: 'load("Mission Control"): morph away — the shared shape is gone from the stage'},
             {type: 'pause', ms: 1100, cue: {type: 'perspective-import', name: 'Shared Session'}, caption: 'import(artifact): the JSON comes back through validation, exactly as exported'},
-            {type: 'pause', ms: 1100, cue: {type: 'perspective-load', name: 'Shared Session'}, caption: 'load("Shared Session"): the teammate sees YOUR workspace — fingerprint-equal, asserted in the e2e leg'},
+            {type: 'pause', ms: 1100, cue: {type: 'perspective-load', name: 'Shared Session'}, caption: 'load("Shared Session"): the exported artifact restores fingerprint-equal — the transfer rides the Neural Link read; cross-cockpit hand-off builds on this boundary'},
             {
                 type   : 'topology-assert',
                 caption: 'the catalog truth that holds in every mode: the detail is a first-class workspace citizen, the fleet never left',

--- a/apps/agentos/tour/fusionFlagship.mjs
+++ b/apps/agentos/tour/fusionFlagship.mjs
@@ -84,7 +84,7 @@ export const fusionTourScript = Object.freeze({
         caption: 'detachItem: the detail becomes a real OS window on the SAME SharedWorker heap. Reparent, never recreate — the stream underneath keeps ticking through the hop.',
         steps  : [
             {type: 'pause', ms: 900, cue: {type: 'popout', itemId: 'detail'}, caption: 'pop out(detail): the host vessel flow runs — detachItem commits, the catalog record becomes the vessel ownership, a REAL OS window opens'},
-            {type: 'pause', ms: 2200, caption: 'two OS windows, one heap: the SAME component instance, the SAME live subscriptions — this is what portal architectures cannot do'},
+            {type: 'pause', ms: 2200, caption: 'two OS windows, one heap: the SAME component instance, the SAME live subscriptions — none of the docking libraries surveyed in ADR-0029 §4 offered this'},
             {type: 'pause', ms: 900, cue: {type: 'reattach', itemId: 'detail'}, caption: 'reattach(detail): home again — same instance, same state, zero re-mount'},
             {type: 'pause', ms: 1200}
         ]
@@ -94,7 +94,7 @@ export const fusionTourScript = Object.freeze({
         caption: 'A workspace you can hand to a teammate: save it, export the JSON, prove the round-trip by morphing away and importing it back.',
         steps  : [
             {type: 'pause', ms: 700, cue: {type: 'perspective-save', name: 'Shared Session'}, caption: 'save("Shared Session"): the current shape, named'},
-            {type: 'pause', ms: 700, cue: {type: 'perspective-export', name: 'Shared Session'}, caption: 'export("Shared Session"): one copyable JSON artifact — the whole layout, no backend'},
+            {type: 'pause', ms: 700, cue: {type: 'perspective-export', name: 'Shared Session'}, caption: 'export("Shared Session"): the whole layout as one JSON artifact, readable over the Neural Link — no backend'},
             {type: 'pause', ms: 1100, cue: {type: 'perspective-load', name: 'Mission Control'}, caption: 'load("Mission Control"): morph away — the shared shape is gone from the stage'},
             {type: 'pause', ms: 1100, cue: {type: 'perspective-import', name: 'Shared Session'}, caption: 'import(artifact): the JSON comes back through validation, exactly as exported'},
             {type: 'pause', ms: 1100, cue: {type: 'perspective-load', name: 'Shared Session'}, caption: 'load("Shared Session"): the teammate sees YOUR workspace — fingerprint-equal, asserted in the e2e leg'},

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -676,12 +676,9 @@ class FleetCockpit extends Container {
             return {completed: false, cueErrors: [], errors: ['agent-detail is detached — reattach before a take'], log: []}
         }
 
-        // REPLAY contract: every take starts from the screenplay's own opening stage. Without
-        // this reset a second run replays against the previous run's committed document and the
-        // reducer mints differently-numbered nodes than the script's expects pin.
-        me.resetTourStage();
-        await me.refreshPromise;
-
+        // SINGLE-FLIGHT: ownership is claimed SYNCHRONOUSLY — `tourRunner` is set before any
+        // await, so a concurrent second call refuses at the guard above instead of slipping
+        // through the pre-start refresh window and double-creating runners.
         me.cuePromise  = Promise.resolve();
         me.cueReceipts = [];
         me.cueErrors   = [];
@@ -701,6 +698,13 @@ class FleetCockpit extends Container {
         });
 
         try {
+            // REPLAY contract: every take starts from the screenplay's own opening stage
+            // (without the reset, a second run replays against the previous run's committed
+            // document and the reducer mints differently-numbered nodes than the script's
+            // expects pin). Inside the try: a reset/refresh failure still releases ownership.
+            me.resetTourStage();
+            await me.refreshPromise;
+
             const result = await me.tourRunner.start();
 
             // the runner never awaits host cues (its documented contract) — the tour's OWN

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1,29 +1,29 @@
-import ActivityStream              from './ActivityStream.mjs';
-import AddAgentForm                from './AddAgentForm.mjs';
-import AgentDetail                 from './AgentDetail.mjs';
-import Button                      from '../../../../src/button/Base.mjs';
-import Component                   from '../../../../src/component/Base.mjs';
-import Container                   from '../../../../src/container/Base.mjs';
-import DockLayoutAdapter           from '../../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockMotionSignal            from '../../../../src/dashboard/DockMotionSignal.mjs';
-import DockPerspectiveStore        from '../../../../src/dashboard/DockPerspectiveStore.mjs';
-import DockPreviewProducer         from '../../../../src/dashboard/DockPreviewProducer.mjs';
-import DockProjectionReconciler    from '../../../../src/dashboard/DockProjectionReconciler.mjs';
-import DockService                 from '../../../../src/ai/client/DockService.mjs';
-import DockZoneModel               from '../../../../src/dashboard/DockZoneModel.mjs';
-import FleetCockpitController      from './FleetCockpitController.mjs';
-import FleetGrid                   from './FleetGrid.mjs';
-import FleetRoster                 from '../../store/FleetRoster.mjs';
-import OperatorMailbox             from './OperatorMailbox.mjs';
-import StateProvider               from '../../../../src/state/Provider.mjs';
-import TourRunner                  from '../../../../src/ai/client/TourRunner.mjs';
-import cockpitDockDocument         from './cockpitDockDocument.mjs';
-import cockpitPresetCollection     from './cockpitPresets.mjs';
-import {createDockTearOutHandlers} from '../../../../src/dashboard/DockTearOut.mjs';
-import {deriveSpineBanner}         from './spineBanner.mjs';
-import {fusionTourScript}          from '../../tour/fusionFlagship.mjs';
-import {mapFleetSessionHealth}     from './sourceHealth.mjs';
-import {previewToOperation}        from '../../../../src/dashboard/dockPreviewContract.mjs';
+import ActivityStream                                               from './ActivityStream.mjs';
+import AddAgentForm                                                 from './AddAgentForm.mjs';
+import AgentDetail                                                  from './AgentDetail.mjs';
+import Button                                                       from '../../../../src/button/Base.mjs';
+import Component                                                    from '../../../../src/component/Base.mjs';
+import Container                                                    from '../../../../src/container/Base.mjs';
+import DockLayoutAdapter                                            from '../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockMotionSignal                                             from '../../../../src/dashboard/DockMotionSignal.mjs';
+import DockPerspectiveStore                                         from '../../../../src/dashboard/DockPerspectiveStore.mjs';
+import DockPreviewProducer                                          from '../../../../src/dashboard/DockPreviewProducer.mjs';
+import DockProjectionReconciler                                     from '../../../../src/dashboard/DockProjectionReconciler.mjs';
+import DockService                                                  from '../../../../src/ai/client/DockService.mjs';
+import DockZoneModel                                                from '../../../../src/dashboard/DockZoneModel.mjs';
+import FleetCockpitController                                       from './FleetCockpitController.mjs';
+import FleetGrid                                                    from './FleetGrid.mjs';
+import FleetRoster                                                  from '../../store/FleetRoster.mjs';
+import OperatorMailbox                                              from './OperatorMailbox.mjs';
+import StateProvider                                                from '../../../../src/state/Provider.mjs';
+import TourRunner                                                   from '../../../../src/ai/client/TourRunner.mjs';
+import cockpitDockDocument                                          from './cockpitDockDocument.mjs';
+import cockpitPresetCollection                                      from './cockpitPresets.mjs';
+import {createDockTearOutHandlers}                                  from '../../../../src/dashboard/DockTearOut.mjs';
+import {deriveSpineBanner}                                          from './spineBanner.mjs';
+import {fusionTourScript, initialDocument as fusionInitialDocument} from '../../tour/fusionFlagship.mjs';
+import {mapFleetSessionHealth}                                      from './sourceHealth.mjs';
+import {previewToOperation}                                         from '../../../../src/dashboard/dockPreviewContract.mjs';
 import '../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the dock projection emits for tab zones
 
 /**
@@ -544,11 +544,12 @@ class FleetCockpit extends Container {
      */
     tourRunner = null
     /**
-     * The share beat's v1 artifact: the exported perspective record as a JSON string — the
-     * copyable layout a teammate could paste back. Held on the instance (no backend by design);
-     * the import cue consumes it, the e2e leg asserts round-trip fingerprint equality through it.
+     * The share beat's v1 artifact: the exported perspective record as a JSON string. The v1
+     * transfer boundary is the Neural Link property read (an agent on the shared heap reads
+     * this member and imports it on another cockpit) — deliberately NOT a UI copy affordance
+     * yet, and no backend by design. The import cue consumes it; the e2e leg asserts round-trip
+     * fingerprint equality through it.
      * @member {String|null} sharedPerspectiveArtifact=null
-     * @protected
      */
     sharedPerspectiveArtifact = null
     /**
@@ -668,6 +669,19 @@ class FleetCockpit extends Container {
             return {completed: false, cueErrors: [], errors: ['a tour is already running'], log: []}
         }
 
+        // fail-closed preconditions for a deterministic take: a detached detail pane belongs to
+        // a previous (possibly failed) vessel cycle — reattach is a host decision, never an
+        // implicit tour side-effect.
+        if (me.detachedDetail) {
+            return {completed: false, cueErrors: [], errors: ['agent-detail is detached — reattach before a take'], log: []}
+        }
+
+        // REPLAY contract: every take starts from the screenplay's own opening stage. Without
+        // this reset a second run replays against the previous run's committed document and the
+        // reducer mints differently-numbered nodes than the script's expects pin.
+        me.resetTourStage();
+        await me.refreshPromise;
+
         me.cuePromise  = Promise.resolve();
         me.cueReceipts = [];
         me.cueErrors   = [];
@@ -705,6 +719,21 @@ class FleetCockpit extends Container {
             me.tourRunner = null;
             me.setTourCaption('')
         }
+    }
+
+    /**
+     * @summary Commits the fusion screenplay's opening document as the live stage — the tour
+     * replay seam. Rides the standard commit loop ({@link #onDockZoneDocumentChange}), so the
+     * reset re-projects exactly like any committed operation; the caller awaits
+     * {@link #refreshPromise} for the settled view.
+     * @returns {Object} The freshly committed opening document.
+     */
+    resetTourStage() {
+        let me       = this,
+            document = DockZoneModel.clone(fusionInitialDocument);
+
+        me.onDockZoneDocumentChange(document);
+        return document
     }
 
     /**

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -551,6 +551,29 @@ class FleetCockpit extends Container {
      * @protected
      */
     sharedPerspectiveArtifact = null
+    /**
+     * The serialized hosting-cue chain (the Workstation settlement pattern): TourRunner fires
+     * cues synchronously and deliberately never awaits them, so every async cue consumer chains
+     * here and {@link #playFusionTour} awaits the WHOLE chain before reporting — a tour can
+     * never claim `completed` while a vessel or share beat is pending.
+     * @member {Promise} cuePromise
+     * @protected
+     */
+    cuePromise = Promise.resolve()
+    /**
+     * Observable receipts from settled cues, in execution order — `{cue, receipt}` pairs; the
+     * e2e leg reads these as the host-side settlement evidence.
+     * @member {Object[]} cueReceipts
+     * @protected
+     */
+    cueReceipts = []
+    /**
+     * Folded cue failures (`"<type>: <message>"`). A non-empty list makes the tour result
+     * `completed: false` — cue truth outranks runner truth.
+     * @member {String[]} cueErrors
+     * @protected
+     */
+    cueErrors = []
 
     /**
      * @summary Seed the layout SSOT and build the toolbar + dock projection as instance items —
@@ -642,8 +665,12 @@ class FleetCockpit extends Container {
         let me = this;
 
         if (me.tourRunner) {
-            return {completed: false, errors: ['a tour is already running'], log: []}
+            return {completed: false, cueErrors: [], errors: ['a tour is already running'], log: []}
         }
+
+        me.cuePromise  = Promise.resolve();
+        me.cueReceipts = [];
+        me.cueErrors   = [];
 
         me.tourRunner = Neo.create(TourRunner, {
             componentId: me.id,
@@ -660,7 +687,19 @@ class FleetCockpit extends Container {
         });
 
         try {
-            return await me.tourRunner.start()
+            const result = await me.tourRunner.start();
+
+            // the runner never awaits host cues (its documented contract) — the tour's OWN
+            // truth is runner-log AND settled-cue truth together, so the pending chain must
+            // drain before this report exists. Cue failures outrank a green runner log.
+            await me.cuePromise;
+
+            return {
+                ...result,
+                completed  : result.completed && me.cueErrors.length === 0,
+                cueErrors  : [...me.cueErrors],
+                cueReceipts: me.cueReceipts.length
+            }
         } finally {
             me.tourRunner?.destroy?.();
             me.tourRunner = null;
@@ -669,12 +708,10 @@ class FleetCockpit extends Container {
     }
 
     /**
-     * @summary Caption feed + the surface cues that make narrated beats EXECUTABLE (the Demo-B
-     * hosting pattern): perspective saves ride the landed DockService capture verb, loads ride
-     * {@link #activatePerspective}, export/import ride {@link #exportPerspectiveArtifact} /
-     * {@link #importPerspectiveArtifact}, and the vessel beats ride the detail vessel's OWN
-     * state machine ({@link #popOutAgentDetail} / {@link #reattachAgentDetail}) — none of them
-     * are dock-document ops, so none of them masquerade as descriptors.
+     * @summary Caption feed + the SETTLED surface cues (the Workstation hosting pattern): each
+     * cue chains serially onto {@link #cuePromise}, its consumer must return an observable
+     * receipt, and failures fold into {@link #cueErrors} — TourRunner deliberately never awaits
+     * host cues, so this chain is what {@link #playFusionTour} awaits before reporting.
      * @param {Object} data The runner's beat payload.
      */
     onTourBeat(data) {
@@ -685,17 +722,66 @@ class FleetCockpit extends Container {
 
         if (!cue) return;
 
-        cue.type === 'perspective-save'   && me.dockService.capturePerspective({
-            componentId    : me.id,
-            layoutId       : `tour-${cue.name.toLowerCase().replace(/\s+/g, '-')}`,
-            perspectiveName: cue.name,
-            replace        : true
-        }).then(() => me.syncControlBar());
-        cue.type === 'perspective-load'   && me.activatePerspective(cue.name);
-        cue.type === 'perspective-export' && me.exportPerspectiveArtifact(cue.name);
-        cue.type === 'perspective-import' && me.importPerspectiveArtifact();
-        cue.type === 'popout'             && me.popOutAgentDetail();
-        cue.type === 'reattach'           && me.reattachAgentDetail()
+        me.cuePromise = me.cuePromise.then(async () => {
+            const receipt = await me.executeTourCue(cue);
+
+            me.cueReceipts.push({cue: {...cue}, receipt})
+        }).catch(error => {
+            const message = `${cue.type}: ${error.message}`;
+
+            me.cueErrors.push(message);
+            me.setTourCaption(`Surface cue failed: ${message}`)
+        })
+    }
+
+    /**
+     * @summary Executes ONE hosting cue against the cockpit's existing verbs and returns its
+     * observable receipt — perspective saves ride the landed DockService capture verb, loads
+     * ride {@link #activatePerspective}, export/import ride the share round-trip, and the
+     * vessel beats ride the detail vessel's OWN state machine ({@link #popOutAgentDetail} /
+     * {@link #reattachAgentDetail}). None of them are dock-document ops, so none masquerade as
+     * descriptors; every refused verb THROWS so the settlement chain folds it — an unknown cue
+     * type fails closed the same way (paired with the script spec's vocabulary pin).
+     * @param {Object} cue `{type, name?, itemId?, scope?}`
+     * @returns {Promise<Object>} The verb's result object — the cue's receipt.
+     */
+    async executeTourCue(cue) {
+        let me = this, result;
+
+        switch (cue.type) {
+            case 'perspective-save':
+                result = await me.dockService.capturePerspective({
+                    componentId    : me.id,
+                    layoutId       : `tour-${cue.name.toLowerCase().replace(/\s+/g, '-')}`,
+                    perspectiveName: cue.name,
+                    replace        : true
+                });
+                me.syncControlBar();
+                if (!result.stored) throw new Error(result.errors?.[0] || 'capture not stored');
+                return result;
+            case 'perspective-load':
+                result = me.activatePerspective(cue.name);
+                if (!result.switched) throw new Error(result.errors[0] || 'perspective not switched');
+                return result;
+            case 'perspective-export':
+                result = me.exportPerspectiveArtifact(cue.name);
+                if (!result.exported) throw new Error(result.errors[0] || 'export refused');
+                return result;
+            case 'perspective-import':
+                result = me.importPerspectiveArtifact();
+                if (!result.imported) throw new Error(result.errors[0] || 'import refused');
+                return result;
+            case 'popout':
+                result = await me.popOutAgentDetail();
+                if (!result.detached) throw new Error(result.errors[0] || 'pop-out refused');
+                return result;
+            case 'reattach':
+                result = await me.reattachAgentDetail();
+                if (!result.reattached) throw new Error(result.errors[0] || 'reattach refused');
+                return result;
+            default:
+                throw new Error(`unknown cue type "${cue.type}"`)
+        }
     }
 
     /**

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -9,16 +9,19 @@ import DockMotionSignal            from '../../../../src/dashboard/DockMotionSig
 import DockPerspectiveStore        from '../../../../src/dashboard/DockPerspectiveStore.mjs';
 import DockPreviewProducer         from '../../../../src/dashboard/DockPreviewProducer.mjs';
 import DockProjectionReconciler    from '../../../../src/dashboard/DockProjectionReconciler.mjs';
+import DockService                 from '../../../../src/ai/client/DockService.mjs';
 import DockZoneModel               from '../../../../src/dashboard/DockZoneModel.mjs';
 import FleetCockpitController      from './FleetCockpitController.mjs';
 import FleetGrid                   from './FleetGrid.mjs';
 import FleetRoster                 from '../../store/FleetRoster.mjs';
 import OperatorMailbox             from './OperatorMailbox.mjs';
 import StateProvider               from '../../../../src/state/Provider.mjs';
+import TourRunner                  from '../../../../src/ai/client/TourRunner.mjs';
 import cockpitDockDocument         from './cockpitDockDocument.mjs';
 import cockpitPresetCollection     from './cockpitPresets.mjs';
 import {createDockTearOutHandlers} from '../../../../src/dashboard/DockTearOut.mjs';
 import {deriveSpineBanner}         from './spineBanner.mjs';
+import {fusionTourScript}          from '../../tour/fusionFlagship.mjs';
 import {mapFleetSessionHealth}     from './sourceHealth.mjs';
 import {previewToOperation}        from '../../../../src/dashboard/dockPreviewContract.mjs';
 import '../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the dock projection emits for tab zones
@@ -524,6 +527,30 @@ class FleetCockpit extends Container {
      * @protected
      */
     tearOutPaneHandles = {}
+    /**
+     * The cockpit-owned dock seam instance — the SAME `execute_dock_operation` path a live
+     * agent drives, injected into the tour runner so scripted ops and agent ops are one code
+     * path (this holder already implements the full contract: `getDockZoneDocument` /
+     * `applyDockZoneOperation` / `onDockZoneDocumentChange`).
+     * @member {Neo.ai.client.DockService|null} dockService=null
+     * @protected
+     */
+    dockService = null
+    /**
+     * The one-per-stage fusion-tour runner — non-null ONLY while a tour plays (lazy create,
+     * destroyed on completion/error), so a running tour is observable as `!!tourRunner`.
+     * @member {Neo.ai.client.TourRunner|null} tourRunner=null
+     * @protected
+     */
+    tourRunner = null
+    /**
+     * The share beat's v1 artifact: the exported perspective record as a JSON string — the
+     * copyable layout a teammate could paste back. Held on the instance (no backend by design);
+     * the import cue consumes it, the e2e leg asserts round-trip fingerprint equality through it.
+     * @member {String|null} sharedPerspectiveArtifact=null
+     * @protected
+     */
+    sharedPerspectiveArtifact = null
 
     /**
      * @summary Seed the layout SSOT and build the toolbar + dock projection as instance items —
@@ -537,6 +564,7 @@ class FleetCockpit extends Container {
         let me = this;
 
         me.dockPreviewProducer = Neo.create(DockPreviewProducer);
+        me.dockService         = Neo.create(DockService, {});
         me.perspectiveStore    = Neo.create(DockPerspectiveStore, {collection: cockpitPresetCollection()});
         me.dockModel           = me.dockModel || cockpitDockDocument();
 
@@ -599,6 +627,140 @@ class FleetCockpit extends Container {
         me.presetError = null;
         me.onDockZoneDocumentChange(document);
         return {errors: [], switched: true}
+    }
+
+    /**
+     * @summary Plays the flagship fusion tour on THIS live cockpit — the four-beat screenplay
+     * (cockpit → docked panel → OS window → share) through the standard runner trinity. The
+     * runner exists only while the tour plays; a second invocation while one runs is a guarded
+     * refusal (one stage, one take). Document ops ride the same `execute_dock_operation` seam a
+     * live agent drives; the vessel and perspective beats arrive as cues ({@link #onTourBeat})
+     * and reuse the cockpit's OWN machinery — no tour-only code path touches dock truth.
+     * @returns {Promise<Object>} The runner's completion result `{completed, errors, log}`.
+     */
+    async playFusionTour() {
+        let me = this;
+
+        if (me.tourRunner) {
+            return {completed: false, errors: ['a tour is already running'], log: []}
+        }
+
+        me.tourRunner = Neo.create(TourRunner, {
+            componentId: me.id,
+            dockService: me.dockService,
+            mode       : 'demo',
+            script     : fusionTourScript
+        });
+
+        me.tourRunner.on({
+            beat    : me.onTourBeat,
+            complete: me.onTourComplete,
+            error   : me.onTourComplete,
+            scope   : me
+        });
+
+        try {
+            return await me.tourRunner.start()
+        } finally {
+            me.tourRunner?.destroy?.();
+            me.tourRunner = null;
+            me.setTourCaption('')
+        }
+    }
+
+    /**
+     * @summary Caption feed + the surface cues that make narrated beats EXECUTABLE (the Demo-B
+     * hosting pattern): perspective saves ride the landed DockService capture verb, loads ride
+     * {@link #activatePerspective}, export/import ride {@link #exportPerspectiveArtifact} /
+     * {@link #importPerspectiveArtifact}, and the vessel beats ride the detail vessel's OWN
+     * state machine ({@link #popOutAgentDetail} / {@link #reattachAgentDetail}) — none of them
+     * are dock-document ops, so none of them masquerade as descriptors.
+     * @param {Object} data The runner's beat payload.
+     */
+    onTourBeat(data) {
+        let me    = this,
+            {cue} = data;
+
+        data.caption && me.setTourCaption(data.caption);
+
+        if (!cue) return;
+
+        cue.type === 'perspective-save'   && me.dockService.capturePerspective({
+            componentId    : me.id,
+            layoutId       : `tour-${cue.name.toLowerCase().replace(/\s+/g, '-')}`,
+            perspectiveName: cue.name,
+            replace        : true
+        }).then(() => me.syncControlBar());
+        cue.type === 'perspective-load'   && me.activatePerspective(cue.name);
+        cue.type === 'perspective-export' && me.exportPerspectiveArtifact(cue.name);
+        cue.type === 'perspective-import' && me.importPerspectiveArtifact();
+        cue.type === 'popout'             && me.popOutAgentDetail();
+        cue.type === 'reattach'           && me.reattachAgentDetail()
+    }
+
+    /**
+     * @summary Tour teardown on `complete` AND `error` (one handler — both are terminal): the
+     * caption clears via the shared `finally` in {@link #playFusionTour}; this hook only keeps
+     * the terminal event observable for listeners layered on the cockpit.
+     * @param {Object} data `{completed, errors, log}` (or the runner's structured error payload).
+     */
+    onTourComplete(data) {
+        // deliberately empty beyond observability: playFusionTour's finally owns the teardown
+    }
+
+    /**
+     * @summary Renders the current tour caption into the control bar's caption strip.
+     * @param {String} caption Empty string clears the strip.
+     */
+    setTourCaption(caption) {
+        let strip = this.getReference('fleet-tour-caption');
+
+        strip?.set({hidden: !caption, html: caption})
+    }
+
+    /**
+     * @summary The share beat's EXPORT half: serializes the named stored perspective to the v1
+     * artifact — one copyable JSON string held on the instance (no backend by design; the e2e
+     * leg asserts round-trip fingerprint equality through it).
+     * @param {String} name The stored perspective's name.
+     * @returns {{exported: Boolean, errors: String[]}}
+     */
+    exportPerspectiveArtifact(name) {
+        let me     = this,
+            stored = me.perspectiveStore.getPerspective(name);
+
+        if (!stored) {
+            return {errors: [`perspective "${name}" is not stored`], exported: false}
+        }
+
+        me.sharedPerspectiveArtifact = JSON.stringify(stored.layout);
+        return {errors: [], exported: true}
+    }
+
+    /**
+     * @summary The share beat's IMPORT half: admits the held JSON artifact back through the
+     * store's full validation path (`savePerspective` re-validates via the landed restore
+     * gate — a malformed artifact is refused, the live layout untouched).
+     * @returns {{imported: Boolean, errors: String[]}}
+     */
+    importPerspectiveArtifact() {
+        let me = this,
+            record;
+
+        if (!me.sharedPerspectiveArtifact) {
+            return {errors: ['no exported artifact is held'], imported: false}
+        }
+
+        try {
+            record = JSON.parse(me.sharedPerspectiveArtifact)
+        } catch (e) {
+            return {errors: [`artifact is not valid JSON: ${e.message}`], imported: false}
+        }
+
+        let {saved, errors} = me.perspectiveStore.savePerspective(record, {replace: true});
+
+        saved && me.syncControlBar();
+        return {errors, imported: saved}
     }
 
     /**
@@ -814,7 +976,25 @@ class FleetCockpit extends Container {
                     reference: 'fleet-spine-banner',
                     role     : 'status'
                 },
+                {
+                    // The live tour caption strip — fed exclusively by onTourBeat; hidden
+                    // whenever no tour plays (setTourCaption('') on teardown).
+                    ntype    : 'component',
+                    cls      : ['fm-tour-caption'],
+                    hidden   : true,
+                    reference: 'fleet-tour-caption',
+                    role     : 'status'
+                },
                 '->', {
+                    // The flagship fusion tour (cockpit → docked panel → OS window → share):
+                    // one deterministic scripted take on THIS live surface.
+                    module   : Button,
+                    cls      : ['fm-fusion-tour'],
+                    handler  : me.playFusionTour.bind(me),
+                    iconCls  : 'fa-solid fa-wand-magic-sparkles',
+                    reference: 'fusion-tour-button',
+                    text     : 'Play tour'
+                }, {
                     // The morning-start outcome summary — written by the controller after the
                     // staged bring-up settles ("N started · M rejected · K excluded"; per-member
                     // reasons ride the title). Empty + hidden until a start ran; hover reaches the
@@ -1680,6 +1860,10 @@ class FleetCockpit extends Container {
 
         me.dockPreviewProducer?.destroy();
         me.dockPreviewProducer = null;
+        me.tourRunner?.destroy?.();
+        me.tourRunner = null;
+        me.dockService?.destroy();
+        me.dockService = null;
         me.perspectiveStore?.destroy();
         me.perspectiveStore = null;
         super.destroy(...args)

--- a/test/playwright/e2e/agentos/FusionFlagshipTourNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FusionFlagshipTourNL.spec.mjs
@@ -1,0 +1,148 @@
+import {test, expect}     from '../../fixtures.mjs';
+import {fusionTourScript} from '../../../../apps/agentos/tour/fusionFlagship.mjs';
+
+/**
+ * @summary The fusion-flagship worker-truth leg: the four-beat tour (cockpit → docked panel →
+ * OS window → share) played on the LIVE Fleet cockpit, with every moat claim asserted through
+ * the Neural Link instead of narrated.
+ *
+ * What this leg proves that no unit tier can:
+ * - **Instance continuity across the OS-window hop** — the AgentDetail component keeps ITS id
+ *   through detach → popup → reattach; only its `windowId` round-trips. Reparent, never
+ *   recreate: the shared-heap claim, read from the worker that owns the instance.
+ * - **The settled-cue truth live** — after the run, the cockpit's `cueErrors` is empty and one
+ *   receipt per scripted cue exists (the settlement chain drained before the tour reported).
+ * - **The share artifact** — `sharedPerspectiveArtifact` holds the exported perspective as
+ *   parseable JSON (the v1 Neural-Link-readable transfer boundary), re-admitted by the import
+ *   cue during the same run.
+ * - **Deterministic REPLAY on the live stage** — a second take on the SAME mounted cockpit
+ *   succeeds identically (the reset seam commits the screenplay's opening document), opening a
+ *   second real popup.
+ *
+ * Run: NEO_E2E_PORT=8119 npx playwright test agentos/FusionFlagshipTourNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('AgentOS fusion flagship — four-beat tour on the live cockpit', () => {
+    test.setTimeout(180000);
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 720, width: 1100}
+    });
+
+    test('two takes: instance-id continuity through the OS-window hop, settled cues, the share artifact, deterministic replay', async ({page, neuralLink}) => {
+        const pageErrors = [];
+        let   popupCount = 0;
+
+        page.on('pageerror', error => {
+            let value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+        page.on('popup', () => popupCount++);
+
+        await page.goto('/apps/agentos/index.html');
+        await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
+        await expect(page.locator('.fm-fusion-tour')).toBeVisible({timeout: 30000});
+
+        const app       = await neuralLink.connectToApp('AgentOS'),
+              cockpits  = await app.findInstances({className: 'AgentOS.view.fleet.FleetCockpit'}, ['id']),
+              cockpitId = (Array.isArray(cockpits) ? cockpits[0] : cockpits)?.id;
+
+        expect(cockpitId, 'the FleetCockpit must exist in the App Worker').toBeTruthy();
+
+        const scriptedCueCount = fusionTourScript.scenes.flatMap(scene => scene.steps).filter(step => step.cue).length;
+
+        const readDetail = async () => {
+            const details = await app.findInstances({className: 'AgentOS.view.fleet.AgentDetail'}, ['id', 'windowId']);
+
+            return (Array.isArray(details) ? details[0] : details)
+        };
+
+        const readStream = async () => {
+            const streams = await app.findInstances({className: 'AgentOS.view.fleet.ActivityStream'}, ['id']);
+
+            return (Array.isArray(streams) ? streams[0] : streams)
+        };
+
+        const baselineStream = await readStream(),
+              mainWindowId   = (await app.getComponent(cockpitId, ['windowId'])).windowId;
+
+        expect(baselineStream?.id, 'the worker must own one ActivityStream before the tour').toBeTruthy();
+        expect(mainWindowId, 'the cockpit knows its own window').toBeTruthy();
+
+        // the detail is auto-hidden RAIL chrome: it does not exist as an instance until the
+        // tour's beat 2 materializes it — the tour BIRTHS the pane it later moves across windows
+        expect((await readDetail())?.id, 'no AgentDetail instance exists before the first take').toBeFalsy();
+
+        for (let run = 0; run < 2; run++) {
+            const popupsBefore = popupCount,
+                  popupPromise = page.waitForEvent('popup', {timeout: 60000});
+
+            await page.locator('.fm-fusion-tour').click();
+
+            // the popout beat births a REAL OS window hosting the live detail pane
+            const popup = await popupPromise;
+
+            await expect(popup.locator('.fm-agent-detail'), 'the real popup hosts the live agent detail')
+                .toBeVisible({timeout: 20000});
+
+            // worker truth mid-hop: the pane exists, and it lives in the POPUP window. The
+            // continuity claim is PER TAKE — each take materializes the rail pane fresh (the
+            // morph/reset cycle re-hides the item and the rail contract re-materializes from
+            // owner-held state), so the moat claim is the HOP, not the whole session.
+            const inPopup = await readDetail();
+
+            expect(inPopup?.id, 'the materialized detail pane is worker-owned').toBeTruthy();
+            expect(inPopup.properties.windowId, 'the detached pane lives in the popup window').not.toBe(mainWindowId);
+
+            const hopId = inPopup.id;
+
+            // THE moat witness: the popup closes on the reattach cue, and in the pre-morph
+            // window the SAME instance is home — the OS-window round trip reparented, never
+            // recreated (the later share-morphs legitimately re-materialize; that is the rail
+            // contract, asserted separately below)
+            await popup.waitForEvent('close', {timeout: 60000});
+            await expect.poll(async () => {
+                const home = await readDetail();
+
+                return home?.id === hopId && home?.properties.windowId === mainWindowId
+            }, {
+                message  : 'the SAME instance must be home in the pre-morph window — reparent, never recreate',
+                timeout  : 2500,
+                intervals: [100]
+            }).toBe(true);
+
+            // the reattach beat brings the same instance home; the tour then finishes the share
+            // beats — the tour is DONE when the runner is torn down (playFusionTour's finally)
+            await expect.poll(async () => (await app.getComponent(cockpitId, ['tourRunner']))?.tourRunner, {
+                message  : 'the take must finish and tear its runner down',
+                timeout  : 90000,
+                intervals: [500]
+            }).toBeFalsy();
+
+            const afterDetail = await readDetail(),
+                  afterStream = await readStream();
+
+            // post-tour truth: the detail is a live, home-window pane (the share-morph cycle may
+            // have re-materialized it — the rail contract re-binds content from owner-held
+            // state; the finding is ticketed, the HOP witness above carries the moat claim)
+            expect(afterDetail?.id, 'a live detail pane exists after the tour').toBeTruthy();
+            expect(afterDetail.properties.windowId, 'the pane is home again').toBe(mainWindowId);
+            expect(afterStream.id, 'the activity stream never restarted').toBe(baselineStream.id);
+
+            // the settled-cue truth + the share artifact, read over the Neural Link (the v1
+            // transfer boundary): every scripted cue produced a receipt, none folded an error
+            const state = await app.getComponent(cockpitId, ['cueErrors', 'cueReceipts', 'sharedPerspectiveArtifact']);
+
+            expect(state.cueErrors, `take ${run + 1}: no cue may fold an error`).toEqual([]);
+            expect(state.cueReceipts, `take ${run + 1}: one receipt per scripted cue`).toHaveLength(scriptedCueCount);
+
+            const artifact = JSON.parse(state.sharedPerspectiveArtifact);
+
+            expect(artifact.perspectiveName).toBe('Shared Session');
+            expect(artifact.dockZone, 'the artifact carries the whole layout document').toBeTruthy();
+
+            expect(popupCount, `take ${run + 1} opened exactly one real popup`).toBe(popupsBefore + 1)
+        }
+
+        expect(pageErrors, 'the journey must be error-free in the main window').toEqual([])
+    });
+});

--- a/test/playwright/e2e/agentos/FusionFlagshipTourNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FusionFlagshipTourNL.spec.mjs
@@ -143,6 +143,21 @@ test.describe('AgentOS fusion flagship — four-beat tour on the live cockpit', 
             expect(popupCount, `take ${run + 1} opened exactly one real popup`).toBe(popupsBefore + 1)
         }
 
+        // THE TEAMMATE PROOF, mechanical: the artifact leaves the cockpit OVER the Neural Link
+        // (the read above), and comes back OVER the Neural Link — pushed into the member from
+        // outside and imported by a Neural-Link-driven call. This exercises the v1 transfer
+        // boundary in both directions on the LIVE surface; the second-store admission semantics
+        // (validation, collision, fingerprint equality) are pinned at the unit tier on two real
+        // store instances.
+        const outbound = (await app.getComponent(cockpitId, ['sharedPerspectiveArtifact'])).sharedPerspectiveArtifact;
+
+        await app.setProperties(cockpitId, {sharedPerspectiveArtifact: outbound});
+
+        const reimport = await app.callMethod(cockpitId, 'importPerspectiveArtifact');
+
+        expect(reimport?.imported, 'the NL-transferred artifact is re-admitted through full validation').toBe(true);
+        expect(reimport?.errors).toEqual([]);
+
         expect(pageErrors, 'the journey must be error-free in the main window').toEqual([])
     });
 });

--- a/test/playwright/e2e/agentos/FusionFlagshipTourNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FusionFlagshipTourNL.spec.mjs
@@ -1,4 +1,5 @@
 import {test, expect}     from '../../fixtures.mjs';
+import DockZoneModel      from '../../../../src/dashboard/DockZoneModel.mjs';
 import {fusionTourScript} from '../../../../apps/agentos/tour/fusionFlagship.mjs';
 
 /**
@@ -139,6 +140,16 @@ test.describe('AgentOS fusion flagship — four-beat tour on the live cockpit', 
 
             expect(artifact.perspectiveName).toBe('Shared Session');
             expect(artifact.dockZone, 'the artifact carries the whole layout document').toBeTruthy();
+
+            // AC-3's LIVE equality: the tour's final beat restored "Shared Session", so the
+            // COMMITTED live document must re-fingerprint EQUAL to the exported artifact —
+            // the share round-trip restores fingerprint-equal topology on the real surface
+            const liveDocument    = (await app.getComponent(cockpitId, ['dockModel'])).dockModel,
+                  liveFingerprint = DockZoneModel.computeShapeFingerprint(liveDocument);
+
+            expect(liveFingerprint.errors).toEqual([]);
+            expect(liveFingerprint.fingerprint, `take ${run + 1}: the restored live topology is fingerprint-equal to the exported artifact`)
+                .toEqual(artifact.windowFingerprint);
 
             expect(popupCount, `take ${run + 1} opened exactly one real popup`).toBe(popupsBefore + 1)
         }

--- a/test/playwright/unit/apps/agentos/tour/fusionFlagship.spec.mjs
+++ b/test/playwright/unit/apps/agentos/tour/fusionFlagship.spec.mjs
@@ -89,14 +89,16 @@ test.describe.serial('apps/agentos/tour/fusionFlagship', () => {
         expect(result.errors).toEqual([]);
         expect(result.completed).toBe(true);
 
-        // finale document truth (cue-independent): the detail was detached by beat 3 and no
-        // reducer re-adds it (reattach is a HOST cue) — catalog record preserved, tree clean
+        // finale document truth in PURE replay (all host cues inert — pop-out/reattach and every
+        // perspective transition are host-owned): the two S2 ops are the only mutations, so the
+        // detail sits revealed in its split and the whole cast stays in the tree
         const finale = holder.dockZoneDocument;
 
         expect(finale.items.detail.title).toBe('Agent detail');
         expect(finale.items.detail.autoHidden).toBe(false);
         expect(finale.items.fleet.title).toBe('Fleet');
-        expect(DockZoneModel.findContainingTabsId(finale, 'detail')).toBeFalsy();
+        expect(finale.nodes['split-fleet-tabs-0'].orientation).toBe('horizontal');
+        expect(DockZoneModel.findContainingTabsId(finale, 'detail')).toBeTruthy();
         expect(DockZoneModel.findContainingTabsId(finale, 'fleet')).toBeTruthy();
         expect(DockZoneModel.findContainingTabsId(finale, 'stream')).toBeTruthy()
     });
@@ -117,13 +119,13 @@ test.describe.serial('apps/agentos/tour/fusionFlagship', () => {
         expect(second.log).toEqual(first.log)
     });
 
-    test('storyboard parity: four beats, operation budget S1:0 · S2:2 · S3:1 · S4:0', () => {
+    test('storyboard parity: four beats, operation budget S1:0 · S2:2 · S3:0 · S4:0 — the vessel beats are cues, never bare ops', () => {
         const opCounts = fusionTourScript.scenes.map(
             scene => scene.steps.filter(step => step.type === 'op').length
         );
 
         expect(fusionTourScript.scenes.map(scene => scene.id)).toEqual(['s1', 's2', 's3', 's4']);
-        expect(opCounts).toEqual([0, 2, 1, 0]);
+        expect(opCounts).toEqual([0, 2, 0, 0]);
 
         // every op descriptor stays inside the executable vocabulary (no invented operations)
         fusionTourScript.scenes.forEach(scene =>
@@ -141,10 +143,11 @@ test.describe.serial('apps/agentos/tour/fusionFlagship', () => {
         );
 
         // perspective-save/load ride the Demo-B precedent; export/import are the share
-        // round-trip; reattach is the pop-in. A NEW cue type added to the script without
-        // updating this pin (and the cockpit wiring) fails here first.
+        // round-trip; popout/reattach ride the detail vessel's own state machine. A NEW cue
+        // type added to the script without updating this pin (and the cockpit wiring) fails
+        // here first.
         expect([...cueTypes].sort()).toEqual([
-            'perspective-export', 'perspective-import', 'perspective-load', 'perspective-save', 'reattach'
+            'perspective-export', 'perspective-import', 'perspective-load', 'perspective-save', 'popout', 'reattach'
         ])
     });
 });

--- a/test/playwright/unit/apps/agentos/tour/fusionFlagship.spec.mjs
+++ b/test/playwright/unit/apps/agentos/tour/fusionFlagship.spec.mjs
@@ -1,0 +1,150 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'FusionFlagshipTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import DockService    from '../../../../../../src/ai/client/DockService.mjs';
+import DockZoneModel  from '../../../../../../src/dashboard/DockZoneModel.mjs';
+import TourRunner     from '../../../../../../src/ai/client/TourRunner.mjs';
+
+import {validateTourScript}                from '../../../../../../src/ai/client/tourScript.mjs';
+import {fusionTourScript, initialDocument} from '../../../../../../apps/agentos/tour/fusionFlagship.mjs';
+import cockpitDockDocument                 from '../../../../../../apps/agentos/view/fleet/cockpitDockDocument.mjs';
+
+/**
+ * @summary Verifies the flagship fusion screenplay as reviewed content: it validates
+ * fail-closed against the live executor vocabulary, plays start-to-finish on the real reducers
+ * from the REAL cockpit default document, replays deterministically, and keeps every expect
+ * cue-independent (the layering contract: spec-mode replay executes no host cues, so every
+ * scripted assertion must be document-truth the reducers alone produce).
+ */
+test.describe.serial('apps/agentos/tour/fusionFlagship', () => {
+    let originalGetComponent, runner, service;
+
+    /**
+     * Wires a fresh holder carrying the screenplay's own opening document.
+     * @returns {Object}
+     */
+    function createHolder() {
+        const holder = {dockZoneDocument: DockZoneModel.clone(initialDocument), id: 'fusion-stage'};
+
+        Neo.getComponent = () => holder;
+
+        return holder
+    }
+
+    /**
+     * @returns {Neo.ai.client.TourRunner} a spec-mode runner on a fresh stage
+     */
+    function createRunner() {
+        createHolder();
+
+        runner = Neo.create(TourRunner, {
+            componentId: 'fusion-stage',
+            dockService: service,
+            mode       : 'spec',
+            script     : fusionTourScript
+        });
+
+        return runner
+    }
+
+    test.beforeEach(() => {
+        originalGetComponent = Neo.getComponent;
+        service              = Neo.create(DockService, {})
+    });
+
+    test.afterEach(() => {
+        Neo.getComponent = originalGetComponent;
+        runner?.destroy?.();
+        runner = null;
+        service.destroy?.()
+    });
+
+    test('the screenplay validates fail-closed against the live executor vocabulary', () => {
+        const {valid, errors} = validateTourScript(fusionTourScript, {operations: DockZoneModel.operations});
+
+        expect(errors).toEqual([]);
+        expect(valid).toBe(true)
+    });
+
+    test('the opening stage IS the shipped cockpit default — imported, never forked', () => {
+        // the strongest form of the flagship claim: the tour runs on the real product surface,
+        // so a cockpit-document change that would break the tour breaks THIS witness first
+        expect(initialDocument).toEqual(cockpitDockDocument())
+    });
+
+    test('the full tour plays green on the real reducers from the real cockpit document', async () => {
+        createRunner();
+
+        const holder = Neo.getComponent('fusion-stage');
+        const result = await runner.start();
+
+        expect(result.errors).toEqual([]);
+        expect(result.completed).toBe(true);
+
+        // finale document truth (cue-independent): the detail was detached by beat 3 and no
+        // reducer re-adds it (reattach is a HOST cue) — catalog record preserved, tree clean
+        const finale = holder.dockZoneDocument;
+
+        expect(finale.items.detail.title).toBe('Agent detail');
+        expect(finale.items.detail.autoHidden).toBe(false);
+        expect(finale.items.fleet.title).toBe('Fleet');
+        expect(DockZoneModel.findContainingTabsId(finale, 'detail')).toBeFalsy();
+        expect(DockZoneModel.findContainingTabsId(finale, 'fleet')).toBeTruthy();
+        expect(DockZoneModel.findContainingTabsId(finale, 'stream')).toBeTruthy()
+    });
+
+    test('two consecutive runs replay identically — id minting stays stable through prune/re-mint', async () => {
+        createRunner();
+
+        const first = await runner.start();
+
+        expect(first.completed).toBe(true);
+
+        runner.destroy();
+        createRunner();
+
+        const second = await runner.start();
+
+        expect(second.completed).toBe(true);
+        expect(second.log).toEqual(first.log)
+    });
+
+    test('storyboard parity: four beats, operation budget S1:0 · S2:2 · S3:1 · S4:0', () => {
+        const opCounts = fusionTourScript.scenes.map(
+            scene => scene.steps.filter(step => step.type === 'op').length
+        );
+
+        expect(fusionTourScript.scenes.map(scene => scene.id)).toEqual(['s1', 's2', 's3', 's4']);
+        expect(opCounts).toEqual([0, 2, 1, 0]);
+
+        // every op descriptor stays inside the executable vocabulary (no invented operations)
+        fusionTourScript.scenes.forEach(scene =>
+            scene.steps.filter(step => step.type === 'op').forEach(step =>
+                expect(DockZoneModel.operations).toContain(step.descriptor.operation)
+            )
+        )
+    });
+
+    test('the cue vocabulary is exactly the Leaf-2 hosting contract — no unconsumed cue class ships', () => {
+        const cueTypes = new Set(
+            fusionTourScript.scenes.flatMap(scene => scene.steps)
+                .map(step => step.cue?.type)
+                .filter(Boolean)
+        );
+
+        // perspective-save/load ride the Demo-B precedent; export/import are the share
+        // round-trip; reattach is the pop-in. A NEW cue type added to the script without
+        // updating this pin (and the cockpit wiring) fails here first.
+        expect([...cueTypes].sort()).toEqual([
+            'perspective-export', 'perspective-import', 'perspective-load', 'perspective-save', 'reattach'
+        ])
+    });
+});

--- a/test/playwright/unit/apps/agentos/tour/fusionFlagship.spec.mjs
+++ b/test/playwright/unit/apps/agentos/tour/fusionFlagship.spec.mjs
@@ -103,15 +103,30 @@ test.describe.serial('apps/agentos/tour/fusionFlagship', () => {
         expect(DockZoneModel.findContainingTabsId(finale, 'stream')).toBeTruthy()
     });
 
-    test('two consecutive runs replay identically — id minting stays stable through prune/re-mint', async () => {
+    test('two consecutive runs on the SAME mounted stage replay identically — the reset seam, not a fresh holder, restores the opening document', async () => {
+        // the reviewer probe this pins: without a stage reset, run 2 replays against run 1's
+        // committed document and splitNode mints `split-fleet-tabs-1` while the script asserts
+        // `-0`. The hosting surface's resetTourStage() commits a fresh opening document; this
+        // witness reuses ONE holder and applies exactly that seam between takes.
         createRunner();
 
-        const first = await runner.start();
+        const holder = Neo.getComponent('fusion-stage');
+        const first  = await runner.start();
 
         expect(first.completed).toBe(true);
 
         runner.destroy();
-        createRunner();
+
+        // the reset seam's document semantics (clone the screenplay's opening stage), applied
+        // to the SAME holder — never a fresh one
+        holder.dockZoneDocument = DockZoneModel.clone(initialDocument);
+
+        runner = Neo.create(TourRunner, {
+            componentId: 'fusion-stage',
+            dockService: service,
+            mode       : 'spec',
+            script     : fusionTourScript
+        });
 
         const second = await runner.start();
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitFusionTour.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitFusionTour.spec.mjs
@@ -26,7 +26,8 @@ test.describe('Fleet cockpit — fusion tour hosting seam', () => {
     const proto = FleetCockpit.prototype;
 
     /**
-     * A spy host recording every collaborator call `onTourBeat` can route to.
+     * A spy host recording every collaborator call the cue executor can route to — each verb
+     * returns its REAL success shape so the receipt discipline holds.
      * @returns {Object}
      */
     function makeSpyHost() {
@@ -34,42 +35,37 @@ test.describe('Fleet cockpit — fusion tour hosting seam', () => {
 
         return {
             calls,
-            activatePerspective      : name  => calls.push(['load', name]),
-            dockService              : {capturePerspective: params => (calls.push(['save', params.perspectiveName, params.replace]), Promise.resolve({stored: true}))},
-            exportPerspectiveArtifact: name  => calls.push(['export', name]),
-            importPerspectiveArtifact: ()    => calls.push(['import']),
-            popOutAgentDetail        : ()    => calls.push(['popout']),
-            reattachAgentDetail      : ()    => calls.push(['reattach']),
+            cuePromise               : Promise.resolve(),
+            cueReceipts              : [],
+            cueErrors                : [],
+            executeTourCue           : proto.executeTourCue,
+            activatePerspective      : name  => (calls.push(['load', name]), {errors: [], switched: true}),
+            dockService              : {capturePerspective: params => (calls.push(['save', params.perspectiveName, params.replace]), Promise.resolve({errors: [], stored: true}))},
+            exportPerspectiveArtifact: name  => (calls.push(['export', name]), {errors: [], exported: true}),
+            importPerspectiveArtifact: ()    => (calls.push(['import']), {errors: [], imported: true}),
+            popOutAgentDetail        : ()    => (calls.push(['popout']), Promise.resolve({detached: true, errors: []})),
+            reattachAgentDetail      : ()    => (calls.push(['reattach']), Promise.resolve({errors: [], reattached: true})),
             setTourCaption           : text  => calls.push(['caption', text]),
             syncControlBar           : ()    => {}
         }
     }
 
-    test('onTourBeat routes every scripted cue class to exactly one collaborator — and a cue-less beat only feeds the caption', () => {
+    test('executeTourCue routes every cue class to exactly one collaborator and returns its receipt; unknown types fail closed', async () => {
         const host = makeSpyHost();
 
-        proto.onTourBeat.call(host, {caption: 'hello', cue: null});
-        expect(host.calls).toEqual([['caption', 'hello']]);
+        expect((await proto.executeTourCue.call(host, {type: 'perspective-save', name: 'Mission Control'})).stored).toBe(true);
+        expect((await proto.executeTourCue.call(host, {type: 'perspective-load', name: 'Mission Control'})).switched).toBe(true);
+        expect((await proto.executeTourCue.call(host, {type: 'perspective-export', name: 'Shared Session'})).exported).toBe(true);
+        expect((await proto.executeTourCue.call(host, {type: 'perspective-import'})).imported).toBe(true);
+        expect((await proto.executeTourCue.call(host, {type: 'popout', itemId: 'detail'})).detached).toBe(true);
+        expect((await proto.executeTourCue.call(host, {type: 'reattach', itemId: 'detail'})).reattached).toBe(true);
 
-        host.calls.length = 0;
-        proto.onTourBeat.call(host, {cue: {type: 'perspective-save', name: 'Mission Control'}});
-        proto.onTourBeat.call(host, {cue: {type: 'perspective-load', name: 'Mission Control'}});
-        proto.onTourBeat.call(host, {cue: {type: 'perspective-export', name: 'Shared Session'}});
-        proto.onTourBeat.call(host, {cue: {type: 'perspective-import'}});
-        proto.onTourBeat.call(host, {cue: {type: 'popout', itemId: 'detail'}});
-        proto.onTourBeat.call(host, {cue: {type: 'reattach', itemId: 'detail'}});
+        expect(host.calls.map(call => call[0])).toEqual(['save', 'load', 'export', 'import', 'popout', 'reattach']);
 
-        expect(host.calls).toEqual([
-            ['save', 'Mission Control', true],
-            ['load', 'Mission Control'],
-            ['export', 'Shared Session'],
-            ['import'],
-            ['popout'],
-            ['reattach']
-        ])
+        await expect(proto.executeTourCue.call(host, {type: 'no-such-cue'})).rejects.toThrow('unknown cue type')
     });
 
-    test('the script and the host agree on the cue vocabulary — every scripted cue type has a routing branch', () => {
+    test('the script and the host agree on the cue vocabulary — every scripted cue type executes to a receipt', async () => {
         const scripted = new Set(
             fusionTourScript.scenes.flatMap(scene => scene.steps)
                 .map(step => step.cue?.type)
@@ -77,11 +73,34 @@ test.describe('Fleet cockpit — fusion tour hosting seam', () => {
         );
 
         for (const type of scripted) {
-            const host = makeSpyHost();
+            const host    = makeSpyHost(),
+                  receipt = await proto.executeTourCue.call(host, {type, name: 'X', itemId: 'detail'});
 
-            proto.onTourBeat.call(host, {cue: {type, name: 'X', itemId: 'detail'}});
-            expect(host.calls.length, `cue "${type}" must route somewhere`).toBe(1)
+            expect(receipt, `cue "${type}" must produce a receipt`).toBeTruthy()
         }
+    });
+
+    test('the settlement chain (the Workstation pattern): the runner never awaits cues, so onTourBeat chains them — a REFUSED verb folds into cueErrors, cue truth outranks a green log', async () => {
+        const host = makeSpyHost();
+
+        // behavior keyed by NAME (the beat handlers chain onto microtasks, so a mutated spy
+        // would race the chain): "Ghost" refuses, everything else switches
+        host.activatePerspective = name => name === 'Ghost'
+            ? {errors: ['no such perspective'], switched: false}
+            : {errors: [], switched: true};
+
+        proto.onTourBeat.call(host, {cue: {type: 'perspective-load', name: 'Mission Control'}});
+        // the refusing verb must FOLD, not throw out of the beat handler
+        proto.onTourBeat.call(host, {cue: {type: 'perspective-load', name: 'Ghost'}});
+        // and a later healthy cue still settles — one failure never wedges the chain
+        proto.onTourBeat.call(host, {cue: {type: 'perspective-load', name: 'Recovery'}});
+
+        await host.cuePromise;
+
+        expect(host.cueReceipts.map(entry => entry.cue.name)).toEqual(['Mission Control', 'Recovery']);
+        expect(host.cueErrors).toEqual(['perspective-load: no such perspective']);
+        // the failure surfaced on the caption strip, never silently
+        expect(host.calls.filter(call => call[0] === 'caption').some(call => call[1].includes('Surface cue failed'))).toBe(true)
     });
 
     test('the share round-trip on the REAL store: export serializes the stored layout, import re-admits it through validation, fingerprint-stable', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitFusionTour.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitFusionTour.spec.mjs
@@ -1,0 +1,141 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'FleetCockpitFusionTourTest'
+    }
+});
+
+import {test, expect}       from '@playwright/test';
+import Neo                  from '../../../../../../../src/Neo.mjs';
+import * as core            from '../../../../../../../src/core/_export.mjs';
+import DockPerspectiveStore from '../../../../../../../src/dashboard/DockPerspectiveStore.mjs';
+import DockZoneModel        from '../../../../../../../src/dashboard/DockZoneModel.mjs';
+import FleetCockpit         from '../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs';
+import cockpitDockDocument  from '../../../../../../../apps/agentos/view/fleet/cockpitDockDocument.mjs';
+import {fusionTourScript}   from '../../../../../../../apps/agentos/tour/fusionFlagship.mjs';
+
+/**
+ * Covers the fusion-tour hosting seam on the cockpit — the ROUTING decisions, in isolation
+ * (the loadActivity spec's philosophy): `onTourBeat` maps each scripted cue to exactly one
+ * cockpit collaborator, the share round-trip runs on the REAL perspective store, and the
+ * one-stage guard refuses a second concurrent play. The full tour REPLAY on the real reducers
+ * lives in the tour-script spec; the live vessel/e2e truth is the e2e leaf's.
+ */
+test.describe('Fleet cockpit — fusion tour hosting seam', () => {
+    const proto = FleetCockpit.prototype;
+
+    /**
+     * A spy host recording every collaborator call `onTourBeat` can route to.
+     * @returns {Object}
+     */
+    function makeSpyHost() {
+        const calls = [];
+
+        return {
+            calls,
+            activatePerspective      : name  => calls.push(['load', name]),
+            dockService              : {capturePerspective: params => (calls.push(['save', params.perspectiveName, params.replace]), Promise.resolve({stored: true}))},
+            exportPerspectiveArtifact: name  => calls.push(['export', name]),
+            importPerspectiveArtifact: ()    => calls.push(['import']),
+            popOutAgentDetail        : ()    => calls.push(['popout']),
+            reattachAgentDetail      : ()    => calls.push(['reattach']),
+            setTourCaption           : text  => calls.push(['caption', text]),
+            syncControlBar           : ()    => {}
+        }
+    }
+
+    test('onTourBeat routes every scripted cue class to exactly one collaborator — and a cue-less beat only feeds the caption', () => {
+        const host = makeSpyHost();
+
+        proto.onTourBeat.call(host, {caption: 'hello', cue: null});
+        expect(host.calls).toEqual([['caption', 'hello']]);
+
+        host.calls.length = 0;
+        proto.onTourBeat.call(host, {cue: {type: 'perspective-save', name: 'Mission Control'}});
+        proto.onTourBeat.call(host, {cue: {type: 'perspective-load', name: 'Mission Control'}});
+        proto.onTourBeat.call(host, {cue: {type: 'perspective-export', name: 'Shared Session'}});
+        proto.onTourBeat.call(host, {cue: {type: 'perspective-import'}});
+        proto.onTourBeat.call(host, {cue: {type: 'popout', itemId: 'detail'}});
+        proto.onTourBeat.call(host, {cue: {type: 'reattach', itemId: 'detail'}});
+
+        expect(host.calls).toEqual([
+            ['save', 'Mission Control', true],
+            ['load', 'Mission Control'],
+            ['export', 'Shared Session'],
+            ['import'],
+            ['popout'],
+            ['reattach']
+        ])
+    });
+
+    test('the script and the host agree on the cue vocabulary — every scripted cue type has a routing branch', () => {
+        const scripted = new Set(
+            fusionTourScript.scenes.flatMap(scene => scene.steps)
+                .map(step => step.cue?.type)
+                .filter(Boolean)
+        );
+
+        for (const type of scripted) {
+            const host = makeSpyHost();
+
+            proto.onTourBeat.call(host, {cue: {type, name: 'X', itemId: 'detail'}});
+            expect(host.calls.length, `cue "${type}" must route somewhere`).toBe(1)
+        }
+    });
+
+    test('the share round-trip on the REAL store: export serializes the stored layout, import re-admits it through validation, fingerprint-stable', () => {
+        const store    = Neo.create(DockPerspectiveStore, {}),
+              captured = DockZoneModel.capturePerspective(cockpitDockDocument(), {layoutId: 'tour-shared-session', perspectiveName: 'Shared Session', title: 'Shared Session'});
+
+        expect(captured.errors).toEqual([]);
+        expect(store.savePerspective(captured.layout).saved).toBe(true);
+
+        // export half on a fake host carrying the real store
+        const exporter = {perspectiveStore: store, sharedPerspectiveArtifact: null};
+        const exported = proto.exportPerspectiveArtifact.call(exporter, 'Shared Session');
+
+        expect(exported).toEqual({errors: [], exported: true});
+        expect(typeof exporter.sharedPerspectiveArtifact).toBe('string');
+
+        // import half into a SECOND, empty store — the teammate's cockpit
+        const targetStore = Neo.create(DockPerspectiveStore, {}),
+              importer    = {
+                  perspectiveStore         : targetStore,
+                  sharedPerspectiveArtifact: exporter.sharedPerspectiveArtifact,
+                  syncControlBar           : () => {}
+              };
+
+        const imported = proto.importPerspectiveArtifact.call(importer);
+
+        expect(imported.errors).toEqual([]);
+        expect(imported.imported).toBe(true);
+
+        // fingerprint-stable across the trip: the re-admitted record equals the captured one
+        expect(targetStore.getPerspective('Shared Session').layout).toEqual(captured.layout);
+
+        store.destroy();
+        targetStore.destroy()
+    });
+
+    test('import fails closed: no held artifact and malformed JSON both refuse without touching the store', () => {
+        const store = Neo.create(DockPerspectiveStore, {});
+
+        expect(proto.importPerspectiveArtifact.call({perspectiveStore: store, sharedPerspectiveArtifact: null}).imported).toBe(false);
+
+        const malformed = proto.importPerspectiveArtifact.call({perspectiveStore: store, sharedPerspectiveArtifact: '{not json'});
+
+        expect(malformed.imported).toBe(false);
+        expect(malformed.errors[0]).toContain('not valid JSON');
+        expect(store.list()).toEqual([]);
+
+        store.destroy()
+    });
+
+    test('one stage, one take: a play invoked while a tour runs is a guarded refusal, not a second runner', async () => {
+        const result = await proto.playFusionTour.call({tourRunner: {}});
+
+        expect(result.completed).toBe(false);
+        expect(result.errors[0]).toContain('already running')
+    });
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitFusionTour.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitFusionTour.spec.mjs
@@ -165,6 +165,38 @@ test.describe('Fleet cockpit — fusion tour hosting seam', () => {
         expect(result.errors[0]).toContain('reattach before a take')
     });
 
+    test('single-flight under CONCURRENCY: ownership is claimed before any await, so a second call refuses while the first is parked in the refresh window', async () => {
+        // hold the pre-start refresh window OPEN — the exact window the falsifier exploited:
+        // before the fix, runner ownership was established only after this await, so a
+        // concurrent second call passed the guard and double-created runners
+        let releaseRefresh;
+
+        const host = {
+            id            : 'concurrency-stage',
+            dockService   : null,
+            detachedDetail: null,
+            tourRunner    : null,
+            refreshPromise: new Promise(resolve => releaseRefresh = resolve),
+            resetTourStage: () => {},
+            onTourBeat    : () => {},
+            onTourComplete: () => {},
+            setTourCaption: () => {}
+        };
+
+        const first  = proto.playFusionTour.call(host).catch(error => ({completed: false, errors: [String(error)], crashed: true})),
+              second = await proto.playFusionTour.call(host);
+
+        // the SECOND call refuses at the guard — ownership was already claimed synchronously
+        expect(second.completed).toBe(false);
+        expect(second.errors[0]).toContain('already running');
+
+        releaseRefresh();
+        await first;
+
+        // ownership fully released after the take settles (however it settled on the bare host)
+        expect(host.tourRunner).toBeNull()
+    });
+
     test('resetTourStage commits a fresh opening document through the standard commit loop — the replay seam', () => {
         const commits = [];
         const host    = {onDockZoneDocumentChange: document => commits.push(document)};

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitFusionTour.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitFusionTour.spec.mjs
@@ -157,4 +157,24 @@ test.describe('Fleet cockpit — fusion tour hosting seam', () => {
         expect(result.completed).toBe(false);
         expect(result.errors[0]).toContain('already running')
     });
+
+    test('a detached detail pane refuses the take fail-closed — reattach is a host decision, never an implicit tour side-effect', async () => {
+        const result = await proto.playFusionTour.call({tourRunner: null, detachedDetail: {windowName: 'x'}});
+
+        expect(result.completed).toBe(false);
+        expect(result.errors[0]).toContain('reattach before a take')
+    });
+
+    test('resetTourStage commits a fresh opening document through the standard commit loop — the replay seam', () => {
+        const commits = [];
+        const host    = {onDockZoneDocumentChange: document => commits.push(document)};
+
+        const returned = proto.resetTourStage.call(host);
+
+        expect(commits).toHaveLength(1);
+        expect(commits[0]).toBe(returned);
+        // the committed stage IS the screenplay's opening document (fresh clone, never the frozen original)
+        expect(returned).toEqual(cockpitDockDocument());
+        expect(Object.isFrozen(returned)).toBe(false)
+    });
 });


### PR DESCRIPTION
Resolves #14789

Related: #13158, #14781, #15252, #15251

**READY — the four-beat flagship fusion tour** (cockpit → docked panel → OS window → share), driven under the operator's v13.2 highest-ROI directive. Rebased onto merged dev at `6632c240d3` (both stack predecessors in: #15456's tear-out consumer COMPOSED — zero duplicate vessel code, exactly the recorded seam split — and #15427's mailbox untouched by the tour); rebased-head receipts: units 35/35 + the live e2e 1/1 (48.9s). Six compose-dependencies verified CLOSED-as-landed before claim (#14615, #14779, #14640, #14669, #14599, #14755) — the tour composes shipped substrate only, and the cockpit hosts it on its OWN machinery: zero new vessel code, zero new capture code. **Correction (Euclid's draft-gate): #14782 is CLOSED NOT_PLANNED** — the measurement-hook claims are removed from this arc (state ≠ disposition; the original "all seven" sweep read CLOSED as landed), and #14790 is reach-deferred, not a release dependency of this leaf.

Evidence: L3 — ALL FOUR LEAVES LANDED: the full unit ladder + the live worker-truth e2e (two takes, 48s, the moat claim read from the owning worker). **The e2e earned its tier on arrival** (the G1 pattern repeating): it exposed that an `autoHidden` perspective morph DESTROYS a materialized rail pane (re-minted on reveal) — the unit tiers were structurally blind to it; the hop-continuity witness is now scoped precisely (per-take, pre-morph — the moat claim holds), and the rail-contract finding is routed to the owning epic (#13158, comment on the ticket). Residual: NONE on content — the draft awaits only the recorded stack order (one rebase after #15456 + #15427 land, then ready for Emmy's seat).

## The arc (entry map — leaves land as commits on this PR)

| Leaf | Content | State |
|---|---|---|
| **1 — the screenplay (data)** | `apps/agentos/tour/fusionFlagship.mjs`: the four-beat `neo.tour.script.v1` script on the REAL cockpit default document (imported from `cockpitDockDocument.mjs`, never forked). Beat 3 is CUE-driven (`popout`/`reattach` ride the detail vessel's own state machine — the host's full OS-window flow, never a bare document op) | landed `91bd683de3`, corrected in `fc6cfc6334` |
| **2 — cockpit wiring** | `playFusionTour()` (lazy one-stage runner, guarded) + `onTourBeat` routing ALL SIX cues to EXISTING machinery: save → the landed DockService capture verb (the cockpit already implements the full dock-holder contract); load → `activatePerspective`; popout/reattach → the detail vessel state machine (`popOutAgentDetail`/`reattachAgentDetail` — disjoint from #15251's gesture seam per the recorded seam split). Plus the `Play tour` control-bar button + caption strip + destroy cleanup | landed `fc6cfc6334` |
| **3 — share round-trip** | COLLAPSED INTO LEAF 2 (the store API sufficed): `exportPerspectiveArtifact` (stored layout → one JSON string, the v1 copyable artifact) + `importPerspectiveArtifact` (re-admitted through the store's full validation; malformed JSON refused, live layout untouched) | landed `fc6cfc6334` |
| **4 — e2e (worker-truth)** | `FusionFlagshipTourNL.spec.mjs` — TWO live takes on the real cockpit: per-take instance-id continuity through the OS-window hop (mid-hop + pre-morph home reads), settled-cue truth (6 receipts/take, zero folded errors), the NL-readable share artifact parsed, deterministic replay via the reset seam, 2 real popups, zero page errors | **landed `cad807a06c`** — 1/1 in 48s (headed local, e2e-not-in-CI per machine topology) |

## Deltas

| Area | Before | After |
|---|---|---|
| The v13.2 cornerstone done-signal | unticketed → ticketed but unclaimed; each pillar demos alone | the four-beat fusion tour exists as reviewed `neo.tour.script.v1` data + a hosted play path on the live cockpit |
| Cockpit tour capability | none (Demo-B workspaces only) | `playFusionTour()` + caption strip + `Play tour` button; the runner rides the cockpit's landed dock-holder contract |
| Perspective share | store save/load only | export/import round-trip: one copyable JSON artifact, re-admitted through full validation — "share" v1 per the ticket (no backend by design) |
| Cue hosting | Demo-B pattern in dockdemo | the cockpit consumes six cue classes by routing to EXISTING verbs — no tour-only code path touches dock truth |
| Cue settlement | fire-and-forget (a tour could report `completed` past a pending/failed vessel or share beat) | the serialized `cuePromise` chain + observable receipts + error-fold: every refused verb THROWS into `cueErrors`, `playFusionTour` awaits the drained chain, cue truth outranks the runner log |

## Test Evidence

- `test/playwright/unit/apps/agentos/tour/fusionFlagship.spec.mjs` — 6 witnesses: fail-closed validation against the live executor vocabulary; **the imported-not-forked pin** (`initialDocument` deep-equals `cockpitDockDocument()`); full spec-mode replay green on the real reducers (finale = pure-replay truth: cues inert, the two S2 ops the only mutations); two-run replay determinism; storyboard parity (op budget S1:0 · S2:2 · S3:0 · S4:0 — vessel beats are cues, never bare ops); **the cue-vocabulary pin** (exactly the six hosting cues).
- `test/playwright/unit/apps/agentos/view/fleet/fleetCockpitFusionTour.spec.mjs` — 6 witnesses on the hosting seam (the loadActivity philosophy: the unit is the ROUTING decision, collaborators are spies, the store is real): `executeTourCue` routes every cue class to exactly one collaborator AND returns its receipt, unknown types fail closed; **the script↔host agreement witness** (every scripted cue type executes to a receipt); **the settlement witness** (a refusing verb folds into `cueErrors` + the caption strip, receipts skip it, one failure never wedges the chain); the share round-trip on REAL stores across two instances, fingerprint-stable; import fails closed (no artifact / malformed JSON — store untouched); the one-stage play guard.
- Suites: seam+tour+cockpit+pop-out **89/89**; full fleet view dir **264 passed**, the only 2 failures attributed PRE-EXISTING on pristine dev by stash/clean-base run AND CI-green on the same base (`configIntentRoundTrip` #15242 pair — local-only, the #15364 class; corrected + flagged via A2A, not this PR's surface).

## Stack order (Emmy's mechanical evidence, accepted)

This PR conflicts pairwise in `FleetCockpit.mjs` with #15456 (tear-out consumer) and #15427 (mailbox surface) — the tour is therefore the LAST integration layer by design: it stays draft through Leaf 4 (new-file e2e, no conflict growth), rebases ONCE after both land (composing #15456's vessel consumer, never duplicating it), then flips ready for the GPT-family seat (Emmy).

## Post-Merge Validation

- [ ] Leaf 4 lands: the live-mode e2e proves the moat claim (instance-id + live state survive the OS-window hop) through the Neural Link, consuming the settled-cue receipts, then this draft flips ready.
- [ ] The recorded take (`record` mode, reduced-motion probed false) becomes the release cut's source material (the launch-sequencing consumer is reach-deferred with #14790 — not a dependency of this leaf).
- [ ] The #15251 gesture seam (Clio) composes: when her cockpit tear-out consumer lands, the tour's pop-out beat can gain the drag variant without script changes (cue consumers are the seam).

## Commits

- `91bd683de3` — Leaf 1: the screenplay + witnesses.
- `fc6cfc6334` — Leaves 2+3: cockpit hosting (runner mount, six cue consumers, share round-trip) + the beat-3 cue correction + seam witnesses.
- `5b585315bd` — the draft-gate hardening: `executeTourCue` receipts + the serialized settlement chain + error-fold; `playFusionTour` drains the chain before reporting (Euclid's fire-and-forget catch).
- `a930aa96e0` — the remaining-three: `resetTourStage()` (every take starts from the screenplay's opening document through the standard commit loop — Euclid's exact-probe replay defect: run 2 minted `split-fleet-tabs-1` against the script's `-0`) + the same-MOUNTED-stage two-run pin replacing the fresh-holder unit + the detached-detail fail-closed take refusal + the share boundary narrowed honestly (the v1 transfer surface is the Neural Link property read, member now public with the contract documented — a UI copy affordance is deliberately post-v1) + both captions tightened to ADR-0029 §4 survey-bounded wording.
- `cad807a06c` — Leaf 4: the worker-truth e2e (two live takes; per-take hop continuity + settled cues + the share artifact + deterministic replay) + the reattach-window pacing (900→1800ms, the witness window) + the rail-contract finding routed to #13158.
- `f2fb122b0a` — the mechanical NL transfer proof: the artifact leaves the cockpit over the Neural Link and returns over the Neural Link (property write + NL-driven `importPerspectiveArtifact` → `{imported: true}` live).
- `48b0580a3d` — AC-3's LIVE equality (Euclid's convergence cluster): the restored live topology re-fingerprints EQUAL to the exported artifact's `windowFingerprint`, per take; the share caption narrowed survey-precise (the transfer rides the NL read; cross-cockpit hand-off builds on this boundary). Source ticket reconciled in the same wave (#14782 AC struck with audit trail).
- `32d5408eb5` — the single-flight repair (Euclid's concurrency falsifier): `tourRunner` ownership is claimed SYNCHRONOUSLY before any await (the reset/refresh moved inside the `try`, so a reset failure still releases), and the held-window concurrency witness pins it — a second call refuses while the first is parked in the pre-start refresh window.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 89818500-8a12-4162-b41f-8947703b1b06.
