### PR TITLE
feat(agentos): the FM cockpit consumes the dock tear-out seam (#15251)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1167,6 +1167,33 @@ class FleetCockpit extends Container {
     }
 
     /**
+     * The owner-destroy exit for every live tear-out record: closes each admitted vessel
+     * (fire-and-forget — the disconnect listener is already detached by the destroy path, so no
+     * re-entry) and settles every owner-held pane exactly once with the same detach + destroy
+     * disposition the vessel-death path uses. Cockpit teardown must not leave an OS vessel open
+     * or a live pane orphaned under a popup view tree the worker never destroys.
+     * @protected
+     */
+    retireTearOutState() {
+        let me = this;
+
+        for (const {windowName} of Object.values(me.tearOutPanes || {})) {
+            windowName && Neo.Main.windowClose({names: [windowName], windowId: me.windowId}).catch(() => {})
+        }
+
+        for (const pane of Object.values(me.tearOutPaneHandles || {})) {
+            if (pane && !pane.isDestroyed) {
+                pane.parent?.remove(pane, false);
+                pane.destroy()
+            }
+        }
+
+        me.tearOutPanes       = {};
+        me.tearOutConnects    = {};
+        me.tearOutPaneHandles = {}
+    }
+
+    /**
      * Captures the live projected pane at the detached terminal — synchronously, BEFORE the
      * commit's re-projection can destroy it — parking it via the reconciler's `preserveItemIds`
      * until the vessel adopts it. A miss is fail-safe: admission already verified resolvability,
@@ -1541,12 +1568,23 @@ class FleetCockpit extends Container {
             return
         }
 
-        // Tear-out vessel death: the popup's view-tree teardown destroyed the mounted pane, so
-        // the handle is released too — the catalog entry stays the model truth, and a later
-        // re-tree re-materializes the pane from owner-held state. Post-adoption reintegration
-        // (bringing the item HOME on vessel close) is the G4 vessel-lifecycle leaf's scope.
+        // Tear-out vessel death: a window disconnect is a render-target signal ONLY — the worker
+        // fires `disconnect` without destroying the popup application or its view tree, so the
+        // reparented pane SURVIVES under the dead vessel's mainView. Ownership is therefore
+        // settled explicitly before the handle is retired: detach + destroy, which keeps the
+        // catalog entry the single model truth and lets a later re-tree materialize exactly ONE
+        // successor from owner-held state (a retained hidden instance would duplicate it).
+        // Post-adoption reintegration (bringing the item HOME on vessel close) is the G4
+        // vessel-lifecycle leaf's scope.
         for (const [itemId, entry] of Object.entries(me.tearOutPanes || {})) {
             if (entry.windowId === data.windowId) {
+                let pane = me.tearOutPaneHandles?.[itemId];
+
+                if (pane && !pane.isDestroyed) {
+                    pane.parent?.remove(pane, false);
+                    pane.destroy()
+                }
+
                 delete me.tearOutPanes[itemId];
                 delete me.tearOutConnects?.[itemId];
                 delete me.tearOutPaneHandles?.[itemId];
@@ -1611,7 +1649,8 @@ class FleetCockpit extends Container {
      * producer; the provider tears the owned store itself down. A still-detached inspector is
      * OWNED state outside any projection: bump the generation (in-flight admission continuations
      * go inert), clear the connect timer, close its vessel (fire-and-forget — the guard in
-     * {@link #onWindowDisconnect} keeps a late event inert) and destroy the instance.
+     * {@link #onWindowDisconnect} keeps a late event inert) and destroy the instance. Live
+     * tear-out vessels and their owner-held panes retire through {@link #retireTearOutState}.
      * @param {...*} args
      */
     destroy(...args) {
@@ -1636,6 +1675,8 @@ class FleetCockpit extends Container {
 
         me.detachedDetailPane?.destroy();
         me.detachedDetailPane = null;
+
+        me.retireTearOutState();
 
         me.dockPreviewProducer?.destroy();
         me.dockPreviewProducer = null;

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1,25 +1,26 @@
-import ActivityStream           from './ActivityStream.mjs';
-import AddAgentForm             from './AddAgentForm.mjs';
-import AgentDetail              from './AgentDetail.mjs';
-import Button                   from '../../../../src/button/Base.mjs';
-import Component                from '../../../../src/component/Base.mjs';
-import Container                from '../../../../src/container/Base.mjs';
-import DockLayoutAdapter        from '../../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockMotionSignal         from '../../../../src/dashboard/DockMotionSignal.mjs';
-import DockPerspectiveStore     from '../../../../src/dashboard/DockPerspectiveStore.mjs';
-import DockPreviewProducer      from '../../../../src/dashboard/DockPreviewProducer.mjs';
-import DockProjectionReconciler from '../../../../src/dashboard/DockProjectionReconciler.mjs';
-import DockZoneModel            from '../../../../src/dashboard/DockZoneModel.mjs';
-import FleetCockpitController   from './FleetCockpitController.mjs';
-import FleetGrid                from './FleetGrid.mjs';
-import FleetRoster              from '../../store/FleetRoster.mjs';
-import OperatorMailbox          from './OperatorMailbox.mjs';
-import StateProvider            from '../../../../src/state/Provider.mjs';
-import cockpitDockDocument      from './cockpitDockDocument.mjs';
-import cockpitPresetCollection  from './cockpitPresets.mjs';
-import {deriveSpineBanner}      from './spineBanner.mjs';
-import {mapFleetSessionHealth}  from './sourceHealth.mjs';
-import {previewToOperation}     from '../../../../src/dashboard/dockPreviewContract.mjs';
+import ActivityStream              from './ActivityStream.mjs';
+import AddAgentForm                from './AddAgentForm.mjs';
+import AgentDetail                 from './AgentDetail.mjs';
+import Button                      from '../../../../src/button/Base.mjs';
+import Component                   from '../../../../src/component/Base.mjs';
+import Container                   from '../../../../src/container/Base.mjs';
+import DockLayoutAdapter           from '../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockMotionSignal            from '../../../../src/dashboard/DockMotionSignal.mjs';
+import DockPerspectiveStore        from '../../../../src/dashboard/DockPerspectiveStore.mjs';
+import DockPreviewProducer         from '../../../../src/dashboard/DockPreviewProducer.mjs';
+import DockProjectionReconciler    from '../../../../src/dashboard/DockProjectionReconciler.mjs';
+import DockZoneModel               from '../../../../src/dashboard/DockZoneModel.mjs';
+import FleetCockpitController      from './FleetCockpitController.mjs';
+import FleetGrid                   from './FleetGrid.mjs';
+import FleetRoster                 from '../../store/FleetRoster.mjs';
+import OperatorMailbox             from './OperatorMailbox.mjs';
+import StateProvider               from '../../../../src/state/Provider.mjs';
+import cockpitDockDocument         from './cockpitDockDocument.mjs';
+import cockpitPresetCollection     from './cockpitPresets.mjs';
+import {createDockTearOutHandlers} from '../../../../src/dashboard/DockTearOut.mjs';
+import {deriveSpineBanner}         from './spineBanner.mjs';
+import {mapFleetSessionHealth}     from './sourceHealth.mjs';
+import {previewToOperation}        from '../../../../src/dashboard/dockPreviewContract.mjs';
 import '../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the dock projection emits for tab zones
 
 /**
@@ -494,6 +495,35 @@ class FleetCockpit extends Container {
      * @protected
      */
     lastDetailVesselFailure = null
+    /**
+     * Gesture tear-out bookkeeping, SEPARATE from the click pop-out's {@link #detachedDetail}
+     * machinery by design (the composition law the reference host proved): written only
+     * POST-COMMIT (the detached terminal), so mid-gesture the click-vessel state machine sees
+     * nothing and a cancelled tear-out stays zero-mutation by guard.
+     * `tearOutPanes[itemId] = {windowName, windowId}`.
+     * @member {Object} tearOutPanes={}
+     * @protected
+     */
+    tearOutPanes = {}
+    /**
+     * The connect-race partner of {@link #tearOutPanes}: a tear-out vessel window that connected
+     * BEFORE its terminal committed (long drags) records here as
+     * `tearOutConnects[itemId] = {windowId}`; adoption runs at whichever event lands second.
+     * @member {Object} tearOutConnects={}
+     * @protected
+     */
+    tearOutConnects = {}
+    /**
+     * Live pane instances captured at the detached terminal, keyed by item id — the cockpit's
+     * projection DESTROYS un-preserved panes on reconcile, so the instance is captured
+     * synchronously before the commit's re-projection runs and parked via the reconciler's
+     * `preserveItemIds` until its vessel adopts it. Released when the vessel disconnects (the
+     * popup's view-tree teardown destroys the mounted pane; the catalog entry stays the model
+     * truth and a re-treed item re-materializes from owner-held state).
+     * @member {Object} tearOutPaneHandles={}
+     * @protected
+     */
+    tearOutPaneHandles = {}
 
     /**
      * @summary Seed the layout SSOT and build the toolbar + dock projection as instance items —
@@ -509,6 +539,29 @@ class FleetCockpit extends Container {
         me.dockPreviewProducer = Neo.create(DockPreviewProducer);
         me.perspectiveStore    = Neo.create(DockPerspectiveStore, {collection: cockpitPresetCollection()});
         me.dockModel           = me.dockModel || cockpitDockDocument();
+
+        // The gesture tear-out choreography — the epic seam's product consumption: the admission
+        // machine holds the one vessel slot; this cockpit supplies the platform seams. The
+        // composition law (proved by the reference host): a tear-out NEVER touches the click
+        // pop-out's `detachedDetail` machinery mid-gesture — post-commit adoption uses its own
+        // bookkeeping, so a cancelled tear-out is zero-mutation by GUARD, and the two vessel
+        // pathways converge only through guards (the toggle disables while `detail` is torn;
+        // a click-windowed `detail` has no projected tab for the gesture to arm on).
+        me.tearOutHandlers = createDockTearOutHandlers({
+            applyOperation  : descriptor => me.applyDockZoneOperation(descriptor),
+            closeVessel     : vessel => me.closeTearOutVessel(vessel),
+            onDocumentChange: (document, operation) => {
+                let detached = operation?.operation === 'detachItem';
+
+                // capture the live pane SYNCHRONOUSLY before the commit's re-projection can
+                // destroy it — the reconciler parks it via preserveItemIds from here on
+                detached && me.captureTearOutPane(operation.itemId);
+                me.onDockZoneDocumentChange(document);
+                // the committed detach is the adoption trigger: the vessel owns the item now
+                detached && me.adoptTearOutPane(operation.itemId)
+            },
+            openVessel: request => me.openTearOutVessel(request)
+        });
 
         // vessel lifecycle: the popped-out inspector reparents on connect, comes home on disconnect
         Neo.currentWorker.on({
@@ -653,8 +706,12 @@ class FleetCockpit extends Container {
             nextConfig,
             placeholders,
             // a detached inspector is owner-preserved: the reconciler parks the pane (never
-            // destroys it) and retires only its obsolete tab button
-            preserveItemIds: me.detachedDetailPane ? ['detail'] : [],
+            // destroys it) and retires only its obsolete tab button. Tear-out captures park the
+            // same way — their vessels adopt the parked instances post-commit.
+            preserveItemIds: [
+                ...(me.detachedDetailPane ? ['detail'] : []),
+                ...Object.keys(me.tearOutPaneHandles)
+            ],
             resolveItem    : itemId => {
                 const item = document.items[itemId];
 
@@ -702,11 +759,14 @@ class FleetCockpit extends Container {
 
         if (toggle) {
             let state = me.detailVesselState,
-                out   = state === 'opening' || state === 'connected' || state === 'windowed';
+                out   = state === 'opening' || state === 'connected' || state === 'windowed',
+                // convergence-by-guard: while a GESTURE tear-out owns the detail pane, the click
+                // toggle is inert — one vessel pathway at a time (G4 owns richer convergence)
+                torn  = Boolean(me.tearOutPanes.detail || me.tearOutPaneHandles.detail);
 
             toggle.set({
-                disabled: state === 'reattaching',
-                text    : out ? 'Reattach detail' : 'Pop out detail'
+                disabled: state === 'reattaching' || torn,
+                text    : torn ? 'Detail torn out' : (out ? 'Reattach detail' : 'Pop out detail')
             })
         }
     }
@@ -797,11 +857,16 @@ class FleetCockpit extends Container {
 
         return DockLayoutAdapter.project(document, {
             applyDockZoneOperation  : me.applyDockZoneOperation.bind(me),
+            // the epic seam: arms the landed boundary grammar (enableProxyToPopup + allowOverdrag)
+            // on every projected tab strip; the four gesture handlers below route admission,
+            // the one commit, and retirement through this cockpit's vessel seams
+            enableDockTearOut       : true,
             onDockCrossZoneDrop     : me.onDockCrossZoneDrop.bind(me),
             onDockZoneDocumentChange: me.onDockZoneDocumentChange.bind(me),
             resolveComponentRef     : resolveComponentRef
                 || me.resolveDockComponentRef.bind(me),
-            resolveRevealComponentRef   : me.resolveDockComponentRef.bind(me)
+            resolveRevealComponentRef   : me.resolveDockComponentRef.bind(me),
+            ...me.tearOutHandlers
         })
     }
 
@@ -837,6 +902,18 @@ class FleetCockpit extends Container {
     resolveDockComponentRef(componentRef, item, itemId) {
         let me     = this,
             marker = `dock-flip-item-${encodeURIComponent(itemId)}`;
+
+        // a GESTURE-torn item's live pane is vessel-owned: a preset restore (or NL addTab)
+        // re-treeing the item while torn must not steal or duplicate the instance — an honest
+        // stand-in holds the slot (the same discipline as the click-detached inspector below);
+        // whole-stack reintegration is the G4 leaf's scope
+        if (me.tearOutPaneHandles[itemId] && !me.tearOutPaneHandles[itemId].isDestroyed) {
+            return {
+                ntype: 'component',
+                cls  : [marker, 'fm-pane-placeholder'],
+                html : `${item?.title ?? componentRef ?? itemId} is open in its own window`
+            }
+        }
 
         switch (componentRef) {
             case 'fleet-grid':
@@ -1001,15 +1078,162 @@ class FleetCockpit extends Container {
 
     /**
      * @summary Resolve the live {@link AgentOS.view.fleet.AgentDetail} instance wherever it
-     * currently renders — the projected tree while docked, the owner-held handle while detached.
-     * A vessel-mounted pane lives in the popup's view tree, out of this cockpit's `down()` /
-     * `getReference` reach, so every detail consumer (record mutation, selection reconciliation,
-     * the card→detail drill) routes through this accessor — the popped-out inspector stays as
-     * live as the docked one.
+     * currently renders — the projected tree while docked, the owner-held handle while detached
+     * (click pop-out OR gesture tear-out). A vessel-mounted pane lives in the popup's view tree,
+     * out of this cockpit's `down()` / `getReference` reach, so every detail consumer (record
+     * mutation, selection reconciliation, the card→detail drill) routes through this accessor —
+     * the windowed inspector stays as live as the docked one on either vessel pathway.
      * @returns {Neo.container.Base|null} The detail pane, or `null` before its first materialization.
      */
     getAgentDetailPane() {
-        return this.detachedDetailPane || this.getReference('agent-detail')
+        return this.detachedDetailPane || this.tearOutPaneHandles.detail || this.getReference('agent-detail')
+    }
+
+    /**
+     * The tear-out admission seam: opens the vessel window for a mid-gesture boundary exit,
+     * reusing the SAME widget-childapp shell the click pop-out proves (an empty pane host — the
+     * cockpit reparents on connect). Fail-closed per the admission contract: `Neo.Main.windowOpen`
+     * resolves **Boolean** (a blocked popup never throws), and any refused precondition — an
+     * unresolvable live pane (placeholder items), an item already vessel-owned on EITHER pathway —
+     * or falsy/throwing acquisition returns `null`, degrading the gesture to its in-window
+     * fallback with zero vessel state.
+     * @param {Object} request
+     * @param {String} request.itemId
+     * @param {Object} request.proxyRect
+     * @returns {Promise<{popupHeight: Number, popupWidth: Number, windowName: String}|null>}
+     * @protected
+     */
+    async openTearOutVessel({itemId, proxyRect}) {
+        let me         = this,
+            windowName = `fm-tearout-${itemId}-${me.id}`;
+
+        // fail-closed preconditions: only a live, projected, singly-owned pane may embody
+        if (
+            me.tearOutPanes[itemId] || me.tearOutPaneHandles[itemId] ||
+            (itemId === 'detail' && me.detachedDetail) ||
+            !me.findProjectedDockPane(itemId)
+        ) {
+            return null
+        }
+
+        try {
+            let {windowConfigs} = Neo,
+                firstWindowId   = Object.keys(windowConfigs)[0],
+                {basePath}      = windowConfigs[firstWindowId],
+                winData         = await Neo.Main.getWindowData({windowId: me.windowId}),
+                width           = Math.max(Math.round(proxyRect?.width  || 480), 320),
+                height          = Math.max(Math.round(proxyRect?.height || 360), 240),
+                left            = Math.round((proxyRect?.x ?? 120) + winData.screenLeft),
+                top             = Math.round((proxyRect?.y ?? 120) + (winData.outerHeight - winData.innerHeight) + winData.screenTop),
+                opened          = await Neo.Main.windowOpen({
+                    url           : `${basePath}apps/agentos/childapps/widget/index.html?tearout=${itemId}&cockpitId=${me.id}`,
+                    windowFeatures: `height=${height},left=${left},top=${top},width=${width}`,
+                    windowId      : me.windowId,
+                    windowName
+                });
+
+            if (opened === false) return null;
+
+            return {popupHeight: height, popupWidth: width, windowName}
+        } catch (error) {
+            return null
+        }
+    }
+
+    /**
+     * The tear-out retirement seam: closes a vessel the gesture no longer needs (re-entry,
+     * cancel, or a refused model commit) and releases every tear-out record for the item —
+     * including a captured pane handle, so the next projection re-adopts or re-materializes it
+     * normally. Best-effort on the window close; {@link #onWindowDisconnect}'s tear-out branch
+     * only matches ADOPTED vessels (`tearOutPanes`), so a pre-commit retirement never re-enters.
+     * @param {Object} vessel
+     * @param {String} vessel.itemId
+     * @param {String} vessel.windowName
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async closeTearOutVessel({itemId, windowName}) {
+        let me = this;
+
+        delete me.tearOutConnects[itemId];
+        delete me.tearOutPaneHandles[itemId];
+
+        try {
+            await Neo.Main.windowClose({names: [windowName], windowId: me.windowId})
+        } catch (error) {
+            // best-effort retirement
+        }
+    }
+
+    /**
+     * Captures the live projected pane at the detached terminal — synchronously, BEFORE the
+     * commit's re-projection can destroy it — parking it via the reconciler's `preserveItemIds`
+     * until the vessel adopts it. A miss is fail-safe: admission already verified resolvability,
+     * and an unexpectedly-missing pane simply leaves the vessel empty (model truth unharmed).
+     * @param {String} itemId
+     * @protected
+     */
+    captureTearOutPane(itemId) {
+        let pane = this.findProjectedDockPane(itemId);
+
+        pane && !pane.isDestroyed && (this.tearOutPaneHandles[itemId] = pane)
+    }
+
+    /**
+     * Resolves a dock item's LIVE pane instance from the projected tree by the stable reference
+     * names {@link #resolveDockComponentRef} assigns. Items whose resolver yields an unreferenced
+     * placeholder (sibling-leaf panes) resolve `null` — which is exactly the admission refusal:
+     * a placeholder cannot embody into a vessel.
+     * @param {String} itemId
+     * @returns {Neo.component.Base|null}
+     * @protected
+     */
+    findProjectedDockPane(itemId) {
+        let componentRef = this.dockModel?.items?.[itemId]?.componentRef,
+            reference    = componentRef === 'define-agent' ? 'add-agent-form' : componentRef;
+
+        return reference ? (this.getReference(reference) || null) : null
+    }
+
+    /**
+     * The post-commit adoption: the detached terminal committed `detachItem` (the item left the
+     * tree, catalog preserved), so the vessel now OWNS the captured pane. Records the
+     * {@link #tearOutPanes} entry and — if the vessel already connected (the long-drag order) —
+     * reparents the live pane immediately; otherwise {@link #onWindowConnect}'s tear-out branch
+     * adopts on arrival (the fast-terminal order). Close-after-adoption reintegration is the G4
+     * vessel-lifecycle leaf's scope, deliberately not handled here.
+     * @param {String} itemId
+     * @protected
+     */
+    adoptTearOutPane(itemId) {
+        let me        = this,
+            connected = me.tearOutConnects[itemId];
+
+        me.tearOutPanes[itemId] = {windowName: `fm-tearout-${itemId}-${me.id}`, windowId: connected?.windowId ?? null};
+
+        connected && me.reparentTearOutPane(itemId, connected);
+        me.syncControlBar()
+    }
+
+    /**
+     * Moves the LIVE captured pane into a connected tear-out vessel — the same instance-moving
+     * reparent the click pop-out uses, minus every document write (the model already committed
+     * at the terminal; this is pure render-target work on the one shared heap).
+     * @param {String} itemId
+     * @param {Object} target `{windowId}`
+     * @protected
+     */
+    reparentTearOutPane(itemId, {windowId}) {
+        let me   = this,
+            app  = Neo.apps[windowId],
+            pane = me.tearOutPaneHandles[itemId];
+
+        if (!app || !pane || pane.isDestroyed) return;
+
+        me.tearOutPanes[itemId] && (me.tearOutPanes[itemId].windowId = windowId);
+
+        pane.parent?.remove(pane, false);
+        app.mainView.add(pane)
     }
 
     /**
@@ -1249,17 +1473,36 @@ class FleetCockpit extends Container {
             app        = Neo.apps[windowId],
             generation = me.detailVesselGeneration;
 
-        if (!app || me.isDestroyed || !me.detachedDetail || !me.detachedDetailPane) {
+        if (!app || me.isDestroyed) {
             return
         }
 
         let url    = await Neo.Main.getByPath({path: 'document.URL', windowId}),
             params = new URL(url).searchParams;
 
+        if (me.isDestroyed || params.get('cockpitId') !== me.id) {
+            return
+        }
+
+        // Tear-out vessels connect through the same widget shell but live in their own
+        // bookkeeping: post-terminal (adopted) → reparent the captured pane now; mid-gesture →
+        // record the connect for the terminal to consume (the race runs both orders). The click
+        // pop-out branch below never sees a tear-out window.
+        let tearOutItemId = params.get('tearout');
+
+        if (tearOutItemId) {
+            if (me.tearOutPanes[tearOutItemId]) {
+                me.reparentTearOutPane(tearOutItemId, {windowId})
+            } else {
+                me.tearOutConnects[tearOutItemId] = {windowId}
+            }
+            return
+        }
+
         if (
-            generation !== me.detailVesselGeneration ||
-            me.detailVesselState !== 'opening'       ||
-            params.get('cockpitId') !== me.id        ||
+            !me.detachedDetail || !me.detachedDetailPane ||
+            generation !== me.detailVesselGeneration     ||
+            me.detailVesselState !== 'opening'           ||
             params.get('detail') !== 'agent-detail'
         ) {
             return
@@ -1290,8 +1533,25 @@ class FleetCockpit extends Container {
     onWindowDisconnect(data) {
         let me = this;
 
-        if (!me.isDestroyed && me.detachedDetail?.windowId === data.windowId) {
-            me.reattachAgentDetail({windowAlreadyClosed: true})
+        if (me.isDestroyed) return;
+
+        if (me.detachedDetail?.windowId === data.windowId) {
+            me.reattachAgentDetail({windowAlreadyClosed: true});
+            return
+        }
+
+        // Tear-out vessel death: the popup's view-tree teardown destroyed the mounted pane, so
+        // the handle is released too — the catalog entry stays the model truth, and a later
+        // re-tree re-materializes the pane from owner-held state. Post-adoption reintegration
+        // (bringing the item HOME on vessel close) is the G4 vessel-lifecycle leaf's scope.
+        for (const [itemId, entry] of Object.entries(me.tearOutPanes)) {
+            if (entry.windowId === data.windowId) {
+                delete me.tearOutPanes[itemId];
+                delete me.tearOutConnects[itemId];
+                delete me.tearOutPaneHandles[itemId];
+                me.syncControlBar();
+                break
+            }
         }
     }
 

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -710,7 +710,7 @@ class FleetCockpit extends Container {
             // same way — their vessels adopt the parked instances post-commit.
             preserveItemIds: [
                 ...(me.detachedDetailPane ? ['detail'] : []),
-                ...Object.keys(me.tearOutPaneHandles)
+                ...Object.keys(me.tearOutPaneHandles || {})
             ],
             resolveItem    : itemId => {
                 const item = document.items[itemId];
@@ -762,7 +762,7 @@ class FleetCockpit extends Container {
                 out   = state === 'opening' || state === 'connected' || state === 'windowed',
                 // convergence-by-guard: while a GESTURE tear-out owns the detail pane, the click
                 // toggle is inert — one vessel pathway at a time (G4 owns richer convergence)
-                torn  = Boolean(me.tearOutPanes.detail || me.tearOutPaneHandles.detail);
+                torn  = Boolean(me.tearOutPanes?.detail || me.tearOutPaneHandles?.detail);
 
             toggle.set({
                 disabled: state === 'reattaching' || torn,
@@ -906,8 +906,9 @@ class FleetCockpit extends Container {
         // a GESTURE-torn item's live pane is vessel-owned: a preset restore (or NL addTab)
         // re-treeing the item while torn must not steal or duplicate the instance — an honest
         // stand-in holds the slot (the same discipline as the click-detached inspector below);
-        // whole-stack reintegration is the G4 leaf's scope
-        if (me.tearOutPaneHandles[itemId] && !me.tearOutPaneHandles[itemId].isDestroyed) {
+        // whole-stack reintegration is the G4 leaf's scope. Optional-chained like every sibling
+        // field read: the projection specs drive these prototype methods over controlled state.
+        if (me.tearOutPaneHandles?.[itemId] && !me.tearOutPaneHandles[itemId].isDestroyed) {
             return {
                 ntype: 'component',
                 cls  : [marker, 'fm-pane-placeholder'],
@@ -1086,7 +1087,7 @@ class FleetCockpit extends Container {
      * @returns {Neo.container.Base|null} The detail pane, or `null` before its first materialization.
      */
     getAgentDetailPane() {
-        return this.detachedDetailPane || this.tearOutPaneHandles.detail || this.getReference('agent-detail')
+        return this.detachedDetailPane || this.tearOutPaneHandles?.detail || this.getReference('agent-detail')
     }
 
     /**
@@ -1109,7 +1110,7 @@ class FleetCockpit extends Container {
 
         // fail-closed preconditions: only a live, projected, singly-owned pane may embody
         if (
-            me.tearOutPanes[itemId] || me.tearOutPaneHandles[itemId] ||
+            me.tearOutPanes?.[itemId] || me.tearOutPaneHandles?.[itemId] ||
             (itemId === 'detail' && me.detachedDetail) ||
             !me.findProjectedDockPane(itemId)
         ) {
@@ -1491,10 +1492,10 @@ class FleetCockpit extends Container {
         let tearOutItemId = params.get('tearout');
 
         if (tearOutItemId) {
-            if (me.tearOutPanes[tearOutItemId]) {
+            if (me.tearOutPanes?.[tearOutItemId]) {
                 me.reparentTearOutPane(tearOutItemId, {windowId})
             } else {
-                me.tearOutConnects[tearOutItemId] = {windowId}
+                (me.tearOutConnects ??= {})[tearOutItemId] = {windowId}
             }
             return
         }
@@ -1544,11 +1545,11 @@ class FleetCockpit extends Container {
         // the handle is released too — the catalog entry stays the model truth, and a later
         // re-tree re-materializes the pane from owner-held state. Post-adoption reintegration
         // (bringing the item HOME on vessel close) is the G4 vessel-lifecycle leaf's scope.
-        for (const [itemId, entry] of Object.entries(me.tearOutPanes)) {
+        for (const [itemId, entry] of Object.entries(me.tearOutPanes || {})) {
             if (entry.windowId === data.windowId) {
                 delete me.tearOutPanes[itemId];
-                delete me.tearOutConnects[itemId];
-                delete me.tearOutPaneHandles[itemId];
+                delete me.tearOutConnects?.[itemId];
+                delete me.tearOutPaneHandles?.[itemId];
                 me.syncControlBar();
                 break
             }

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitTearOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitTearOut.spec.mjs
@@ -1,0 +1,321 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'FleetCockpitTearOutTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import '../../../../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
+import Container     from '../../../../../../../src/container/Base.mjs';
+import FleetCockpit  from '../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs';
+import FleetRoster   from '../../../../../../../apps/agentos/store/FleetRoster.mjs';
+import StateProvider from '../../../../../../../src/state/Provider.mjs';
+
+/**
+ * @summary Installs deterministic popup-vessel seams — the same call grammar the pop-out suite
+ * pins (`Neo.Main.windowOpen` resolves a **Boolean**; a blocked popup resolves `false`, never
+ * throws), reused here for the GESTURE tear-out pathway.
+ * @param {Object} [options={}]
+ * @returns {Object} spy state + `restore()`.
+ */
+function installWindowVessel({openResult = true, popupUrl = null} = {}) {
+    let previous = {
+            getByPath    : Neo.Main.getByPath,
+            getWindowData: Neo.Main.getWindowData,
+            windowClose  : Neo.Main.windowClose,
+            windowOpen   : Neo.Main.windowOpen
+        },
+        previousWindowConfigs = Neo.windowConfigs,
+        state = {closeCalls: [], openCalls: []};
+
+    Neo.windowConfigs = {'unit-window': {basePath: './'}};
+
+    Neo.Main.getByPath     = async () => popupUrl;
+    Neo.Main.getWindowData = async () => ({innerHeight: 900, outerHeight: 960, screenLeft: 10, screenTop: 20});
+    Neo.Main.windowOpen    = data => {
+        state.openCalls.push(data);
+        return Promise.resolve(openResult)
+    };
+    Neo.Main.windowClose   = async data => {
+        state.closeCalls.push(data)
+    };
+
+    return {
+        get closeCalls() { return state.closeCalls },
+        get openCalls()  { return state.openCalls },
+        restore() {
+            Object.assign(Neo.Main, previous);
+            Neo.windowConfigs = previousWindowConfigs
+        }
+    }
+}
+
+/**
+ * Contract specs for the cockpit's seam consumption: the cockpit rides the EPIC's gesture tear-out
+ * machinery (`createDockTearOutHandlers` + the projected boundary grammar) instead of any
+ * cockpit-local gesture system. The pins:
+ *
+ * 1. the projection ARMS the landed grammar (`enableProxyToPopup` + `allowOverdrag` on every
+ *    projected tab strip) and threads the four gesture handlers;
+ * 2. admission is fail-closed on the cockpit's own preconditions — placeholder panes, items
+ *    already vessel-owned on EITHER pathway, and the Boolean `windowOpen` grammar;
+ * 3. the detached terminal commits document truth while the LIVE pane is captured, parked
+ *    across the re-projection, and adopted by its vessel in BOTH connect/terminal orders —
+ *    reparent-never-recreate;
+ * 4. cancel retires the vessel with ZERO document mutation and no leaked capture;
+ * 5. convergence-by-guard with the click pop-out: the toggle goes inert while `detail` is torn,
+ *    a torn item re-treed mid-flight renders a stand-in (never steals the instance), and the
+ *    accessor still resolves the live pane;
+ * 6. vessel disconnect retires every tear-out record.
+ *
+ * The real two-window journey stays the E2E witness tier's; these seams isolate the choreography
+ * without weakening the call contract (the pop-out suite's proven discipline).
+ */
+test.describe.serial('AgentOS.view.fleet.FleetCockpit — gesture tear-out seam consumption', () => {
+    let cockpit, vessel;
+
+    const sortZoneStub = () => {
+        const calls = {ended: 0, started: []};
+
+        return {
+            calls,
+            endWindowDrag  : () => calls.ended++,
+            startWindowDrag: data => calls.started.push(data)
+        }
+    };
+
+    const proxyRect = {x: 40, y: 50, width: 640, height: 420};
+
+    /**
+     * Drives the seam's exit → (optional) terminal for one item through the REAL handler set the
+     * projection threads, against the stubbed vessel grammar.
+     * @param {String} itemId
+     * @returns {Promise<Object>} the zone stub
+     */
+    async function tearOutExit(itemId) {
+        const zone = sortZoneStub();
+
+        await cockpit.tearOutHandlers.onDockTearOutExit({itemId, proxyRect, sortZone: zone});
+        return zone
+    }
+
+    test.beforeEach(() => {
+        cockpit = Neo.create(FleetCockpit, {
+            stateProvider: {
+                module: StateProvider,
+                stores: {fleetRoster: {module: FleetRoster, autoLoad: false}}
+            }
+        })
+    });
+
+    test.afterEach(() => {
+        cockpit?.destroy();
+        cockpit = null;
+        vessel?.restore();
+        vessel = null;
+        Neo.apps = {}
+    });
+
+    test('the projection arms the landed boundary grammar on every tab strip and threads the seam handlers', () => {
+        const config    = cockpit.projectDockModel(),
+              sortZones = [];
+
+        (function walk(node) {
+            if (!node || typeof node !== 'object') return;
+            node.sortZoneConfig && sortZones.push(node.sortZoneConfig);
+            [].concat(node.items || [], node.headerToolbar || []).forEach(walk);
+            Object.values(node).forEach(value => {
+                Array.isArray(value) && value.forEach(walk);
+                value?.sortZoneConfig && !sortZones.includes(value.sortZoneConfig) && sortZones.push(value.sortZoneConfig)
+            })
+        })(config);
+
+        expect(sortZones.length, 'the projection carries at least one tab-strip sort zone').toBeGreaterThan(0);
+        sortZones.forEach(zoneConfig => {
+            expect(zoneConfig.enableProxyToPopup, 'the tear-out grammar is armed').toBe(true);
+            expect(zoneConfig.allowOverdrag, 'overdrag pairs with the boundary grammar').toBe(true)
+        });
+
+        // the four seam handlers are the cockpit's OWN handler set — no parallel gesture system
+        ['onDockTearOutCancel', 'onDockTearOutEntry', 'onDockTearOutExit', 'onDockTearOutTerminal'].forEach(name => {
+            expect(typeof cockpit.tearOutHandlers[name]).toBe('function')
+        })
+    });
+
+    test('admission fails CLOSED: placeholder panes and already-owned items never open a vessel; a blocked popup degrades in-window', async () => {
+        vessel = installWindowVessel();
+
+        // 'perspectives' resolves to an unreferenced placeholder — not embodiable
+        const zonePlaceholder = await tearOutExit('perspectives');
+
+        expect(vessel.openCalls, 'no vessel for a placeholder pane').toHaveLength(0);
+        expect(zonePlaceholder.calls.ended, 'the gesture degrades to its in-window fallback').toBe(1);
+
+        // a click-detached detail is already vessel-owned on the OTHER pathway
+        cockpit.detachedDetail = {windowName: 'x'};
+        const zoneDetail = await tearOutExit('detail');
+
+        expect(vessel.openCalls).toHaveLength(0);
+        expect(zoneDetail.calls.ended).toBe(1);
+        cockpit.detachedDetail = null;
+
+        // Boolean grammar: windowOpen resolving false degrades the same way
+        vessel.restore();
+        vessel = installWindowVessel({openResult: false});
+        const zoneBlocked = await tearOutExit('stream');
+
+        expect(vessel.openCalls, 'the host WAS asked').toHaveLength(1);
+        expect(zoneBlocked.calls.ended).toBe(1);
+        expect(zoneBlocked.calls.started, 'no pointer-follow without a vessel').toHaveLength(0);
+        expect(cockpit.tearOutPaneHandles.stream, 'no capture without admission').toBeUndefined()
+    });
+
+    test('exit + terminal: document truth commits, the LIVE pane is captured, parked across the re-projection, and adopted (terminal-first order)', async () => {
+        vessel = installWindowVessel();
+
+        const streamPane = cockpit.getReference('activity-stream');
+
+        expect(streamPane).toBeTruthy();
+
+        const zone = await tearOutExit('stream');
+
+        expect(vessel.openCalls).toHaveLength(1);
+        expect(vessel.openCalls[0].url).toContain('tearout=stream');
+        expect(vessel.openCalls[0].url).toContain(`cockpitId=${cockpit.id}`);
+        expect(zone.calls.started, 'an admitted vessel engages the pointer-follow').toHaveLength(1);
+
+        cockpit.tearOutHandlers.onDockTearOutTerminal({itemId: 'stream', sortZone: zone});
+
+        // document truth: absent from every node, preserved in the catalog
+        const doc = cockpit.getDockZoneDocument();
+
+        expect(Object.values(doc.nodes).some(node => node.items?.includes('stream'))).toBe(false);
+        expect(doc.items.stream).toBeTruthy();
+
+        // the capture parked the SAME live instance; the re-projection did not destroy it
+        expect(cockpit.tearOutPaneHandles.stream).toBe(streamPane);
+        await cockpit.refreshPromise;
+        expect(streamPane.isDestroyed).toBeFalsy();
+        expect(cockpit.tearOutPanes.stream).toMatchObject({windowId: null});
+
+        // the vessel connects AFTER the terminal: the connect branch reparents the captured pane
+        vessel.restore();
+        vessel = installWindowVessel({popupUrl: `https://unit.test/widget/index.html?tearout=stream&cockpitId=${cockpit.id}`});
+
+        const mainView = Neo.create(Container, {});
+        Neo.apps ??= {};
+        Neo.apps['tearout-win-1'] = {mainView};
+
+        await cockpit.onWindowConnect({windowId: 'tearout-win-1'});
+
+        expect(mainView.items, 'reparent-never-recreate').toContain(streamPane);
+        expect(cockpit.tearOutPanes.stream.windowId).toBe('tearout-win-1')
+    });
+
+    test('connect-first order: a vessel connecting mid-gesture is recorded and adopted at the terminal', async () => {
+        vessel = installWindowVessel({popupUrl: `https://unit.test/widget/index.html?tearout=fleet&cockpitId=WILL-BE-SET`});
+
+        const fleetPane = cockpit.getReference('fleet-grid');
+        const zone      = await tearOutExit('fleet');
+
+        expect(vessel.openCalls).toHaveLength(1);
+
+        // the vessel connects BEFORE the terminal (long drag)
+        vessel.restore();
+        vessel = installWindowVessel({popupUrl: `https://unit.test/widget/index.html?tearout=fleet&cockpitId=${cockpit.id}`});
+
+        const mainView = Neo.create(Container, {});
+        Neo.apps ??= {};
+        Neo.apps['tearout-win-2'] = {mainView};
+
+        await cockpit.onWindowConnect({windowId: 'tearout-win-2'});
+
+        expect(cockpit.tearOutConnects.fleet, 'mid-gesture connect recorded, not adopted').toMatchObject({windowId: 'tearout-win-2'});
+        expect(mainView.items).not.toContain(fleetPane);
+
+        cockpit.tearOutHandlers.onDockTearOutTerminal({itemId: 'fleet', sortZone: zone});
+
+        expect(mainView.items, 'the terminal consumed the recorded connect').toContain(fleetPane);
+        expect(cockpit.tearOutPanes.fleet.windowId).toBe('tearout-win-2')
+    });
+
+    test('cancel while detached: the vessel retires with ZERO document mutation and no leaked capture', async () => {
+        vessel = installWindowVessel();
+
+        const before = JSON.stringify(cockpit.getDockZoneDocument());
+        const zone   = await tearOutExit('stream');
+
+        expect(vessel.openCalls).toHaveLength(1);
+
+        cockpit.tearOutHandlers.onDockTearOutCancel({itemId: 'stream', sortZone: zone});
+        await Promise.resolve();
+
+        expect(JSON.stringify(cockpit.getDockZoneDocument()), 'zero-mutation by guard').toBe(before);
+        expect(vessel.closeCalls).toHaveLength(1);
+        expect(cockpit.tearOutPaneHandles.stream, 'the capture never happened — nothing to leak').toBeUndefined();
+        expect(cockpit.tearOutPanes.stream).toBeUndefined()
+    });
+
+    test('convergence-by-guard: a torn detail disables the click toggle, re-treeing renders a stand-in, and the accessor resolves the live pane', async () => {
+        vessel = installWindowVessel();
+
+        // reveal the auto-hidden inspector so it is a projected, tearable pane
+        const reveal = cockpit.applyDockZoneOperation({operation: 'setItemAutoHidden', itemId: 'detail', autoHidden: false});
+        cockpit.onDockZoneDocumentChange(reveal.document);
+        await cockpit.refreshPromise;
+
+        const detailPane = cockpit.getReference('agent-detail');
+        const zone       = await tearOutExit('detail');
+
+        expect(vessel.openCalls).toHaveLength(1);
+        cockpit.tearOutHandlers.onDockTearOutTerminal({itemId: 'detail', sortZone: zone});
+        await cockpit.refreshPromise;
+
+        // the click affordance is inert while the gesture vessel owns the pane
+        const toggle = cockpit.getReference('detail-window-toggle');
+
+        expect(toggle.disabled).toBe(true);
+        expect(toggle.text).toBe('Detail torn out');
+
+        // the accessor still reaches the live instance (the drill stays live)
+        expect(cockpit.getAgentDetailPane()).toBe(detailPane);
+
+        // re-treeing the torn item renders a STAND-IN — the live instance is never stolen back
+        const readd = cockpit.applyDockZoneOperation({operation: 'addTab', itemId: 'detail', tabsNodeId: 'secondary-rail'});
+
+        expect(readd.errors).toEqual([]);
+        cockpit.onDockZoneDocumentChange(readd.document);
+        await cockpit.refreshPromise;
+
+        expect(cockpit.tearOutPaneHandles.detail).toBe(detailPane);
+        expect(detailPane.isDestroyed).toBeFalsy()
+    });
+
+    test('vessel disconnect retires every tear-out record for the window', async () => {
+        vessel = installWindowVessel();
+
+        const zone = await tearOutExit('stream');
+
+        cockpit.tearOutHandlers.onDockTearOutTerminal({itemId: 'stream', sortZone: zone});
+
+        vessel.restore();
+        vessel = installWindowVessel({popupUrl: `https://unit.test/widget/index.html?tearout=stream&cockpitId=${cockpit.id}`});
+
+        const mainView = Neo.create(Container, {});
+        Neo.apps ??= {};
+        Neo.apps['tearout-win-3'] = {mainView};
+
+        await cockpit.onWindowConnect({windowId: 'tearout-win-3'});
+        expect(cockpit.tearOutPanes.stream.windowId).toBe('tearout-win-3');
+
+        cockpit.onWindowDisconnect({windowId: 'tearout-win-3'});
+
+        expect(cockpit.tearOutPanes.stream).toBeUndefined();
+        expect(cockpit.tearOutConnects.stream).toBeUndefined();
+        expect(cockpit.tearOutPaneHandles.stream).toBeUndefined()
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitTearOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitTearOut.spec.mjs
@@ -70,7 +70,11 @@ function installWindowVessel({openResult = true, popupUrl = null} = {}) {
  * 5. convergence-by-guard with the click pop-out: the toggle goes inert while `detail` is torn,
  *    a torn item re-treed mid-flight renders a stand-in (never steals the instance), and the
  *    accessor still resolves the live pane;
- * 6. vessel disconnect retires every tear-out record.
+ * 6. vessel disconnect SETTLES pane ownership — a disconnect is a render-target signal, never
+ *    implicit destruction: the pane is disposed (not orphaned under the dead vessel's view), the
+ *    records retire, and a re-tree yields exactly one successor;
+ * 7. the owner-destroy exit: cockpit teardown closes admitted vessels and settles every
+ *    owner-held pane exactly once (idempotent).
  *
  * The real two-window journey stays the E2E witness tier's; these seams isolate the choreography
  * without weakening the call contract (the pop-out suite's proven discipline).
@@ -295,10 +299,11 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — gesture tear-out seam 
         expect(detailPane.isDestroyed).toBeFalsy()
     });
 
-    test('vessel disconnect retires every tear-out record for the window', async () => {
+    test('vessel disconnect SETTLES pane ownership: the orphan view keeps no live pane, and a re-tree yields exactly one successor', async () => {
         vessel = installWindowVessel();
 
-        const zone = await tearOutExit('stream');
+        const streamPane = cockpit.getReference('activity-stream');
+        const zone       = await tearOutExit('stream');
 
         cockpit.tearOutHandlers.onDockTearOutTerminal({itemId: 'stream', sortZone: zone});
 
@@ -311,11 +316,77 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — gesture tear-out seam 
 
         await cockpit.onWindowConnect({windowId: 'tearout-win-3'});
         expect(cockpit.tearOutPanes.stream.windowId).toBe('tearout-win-3');
+        expect(mainView.items).toContain(streamPane);
 
         cockpit.onWindowDisconnect({windowId: 'tearout-win-3'});
 
+        // A window disconnect does NOT destroy the popup application or its view tree — the
+        // worker only fires the event — so ownership must be settled EXPLICITLY. The load-bearing
+        // assertions: the dead vessel's mainView holds no forgotten live pane, and the instance
+        // itself is disposed, not merely forgotten by the bookkeeping.
+        expect(mainView.items, 'the orphan view keeps no live pane').not.toContain(streamPane);
+        expect(streamPane.isDestroyed, 'ownership settled: the pane is disposed, not orphaned').toBeTruthy();
+
         expect(cockpit.tearOutPanes.stream).toBeUndefined();
         expect(cockpit.tearOutConnects.stream).toBeUndefined();
-        expect(cockpit.tearOutPaneHandles.stream).toBeUndefined()
+        expect(cockpit.tearOutPaneHandles.stream).toBeUndefined();
+
+        // Re-treeing the item materializes exactly ONE successor from owner-held state — the
+        // catalog record stayed the model truth, and no hidden retained instance can duplicate it.
+        const readd = cockpit.applyDockZoneOperation({operation: 'addTab', itemId: 'stream', tabsNodeId: 'secondary-rail'});
+
+        expect(readd.errors).toEqual([]);
+        cockpit.onDockZoneDocumentChange(readd.document);
+        await cockpit.refreshPromise;
+
+        const successor = cockpit.getReference('activity-stream');
+
+        expect(successor, 'exactly one valid pane materializes').toBeTruthy();
+        expect(successor).not.toBe(streamPane);
+        expect(successor.isDestroyed).toBeFalsy()
+    });
+
+    test('the owner-destroy exit: cockpit teardown closes admitted vessels and settles every owner-held pane exactly once', async () => {
+        vessel = installWindowVessel();
+
+        const streamPane = cockpit.getReference('activity-stream');
+        const zone       = await tearOutExit('stream');
+
+        cockpit.tearOutHandlers.onDockTearOutTerminal({itemId: 'stream', sortZone: zone});
+
+        vessel.restore();
+        vessel = installWindowVessel({popupUrl: `https://unit.test/widget/index.html?tearout=stream&cockpitId=${cockpit.id}`});
+
+        const mainView = Neo.create(Container, {});
+        Neo.apps ??= {};
+        Neo.apps['tearout-win-4'] = {mainView};
+
+        await cockpit.onWindowConnect({windowId: 'tearout-win-4'});
+        expect(mainView.items).toContain(streamPane);
+
+        // count disposals so "exactly once" is a measurement, not an inference
+        const originalDestroy = streamPane.destroy.bind(streamPane);
+        let   disposals       = 0;
+
+        streamPane.destroy = (...args) => {
+            disposals++;
+            return originalDestroy(...args)
+        };
+
+        const vesselWindowName = cockpit.tearOutPanes.stream.windowName;
+
+        cockpit.destroy();
+
+        // the admitted OS vessel is closed, the pane is settled exactly once, nothing is orphaned
+        expect(vessel.closeCalls.some(call => call.names?.includes(vesselWindowName)), 'route/app teardown closes the OS vessel').toBeTruthy();
+        expect(disposals).toBe(1);
+        expect(streamPane.isDestroyed).toBeTruthy();
+        expect(mainView.items).not.toContain(streamPane);
+
+        // idempotent: a second retirement pass finds settled state and disposes nothing again
+        cockpit.retireTearOutState();
+        expect(disposals).toBe(1);
+
+        cockpit = null
     })
 });


### PR DESCRIPTION
Resolves #15251

Related: #15239 (the epic) · #15247 — G4 owns gesture-vessel reintegration (the AC fold on the ticket names the split) · #15246 — arbitration untouched · #15245 — platform defaults untouched (the merged admission machine's fail-closed mechanism is what this consumes).

**The epic's first PRODUCT consumer:** the FM cockpit now rides the merged G1 tear-out seam — drag any projected dock tab (fleet grid, activity stream, the revealed inspector) past the window boundary and it embodies into a real OS vessel through `createDockTearOutHandlers`, with zero cockpit-local gesture machinery. The choreography proven on the demo surface now runs on the flagship product surface.

What the consumption wires, per the reference host's composition law:

- **The projection arms the landed grammar** — `enableDockTearOut: true` threads `enableProxyToPopup` + `allowOverdrag` onto every projected tab strip, and the four seam handlers ride the same context (witnessed: the projected `sortZoneConfig`s carry both flags).
- **Admission is fail-closed on the cockpit's own preconditions** — placeholder panes (sibling-leaf items) refuse at `openVessel` (a placeholder cannot embody), an item already vessel-owned on EITHER pathway refuses, and the Boolean `windowOpen` grammar degrades a blocked popup to the in-window fallback with zero vessel state.
- **Capture-park-adopt:** the cockpit's projection DESTROYS un-preserved panes on reconcile — so the live pane is captured synchronously at the detached terminal (before the commit's re-projection), parked via the reconciler's `preserveItemIds`, and adopted by its vessel in BOTH orders of the connect/terminal race. Reparent-never-recreate: the identical instance moves trees on the one shared heap — the drill's live data streams uninterrupted (AC1's same-instance permanence).
- **Convergence-by-guard with the click pop-out** (the two vessel pathways never merge state machines): the shell toggle goes inert while `detail` is gesture-torn ("Detail torn out"); a click-windowed detail has no projected tab for the gesture to arm on (structural); a torn item re-treed mid-flight (preset restore, NL `addTab`) renders an honest stand-in — the live instance is never stolen or duplicated; and `getAgentDetailPane` routes the tear-out handle so every detail consumer stays live.
- **Disconnect retirement:** a closed vessel retires all three tear-out records; the catalog entry stays the model truth and a re-treed item re-materializes from owner-held state. Bringing the item HOME on vessel close is G4's contract (#15247) — stated in code and in the ticket's folded AC2.

Evidence: L1-unit (7 seam-consumption witnesses: grammar-armed projection, three-way fail-closed admission, terminal-first capture/park/adopt with document truth, connect-first adoption, zero-mutation cancel, the convergence guards + stand-in + live accessor, disconnect retirement) + full agentos/dashboard regression 741/741 → the real two-window journey is the epic witness tier's (the merged G1 e2e on the demo host proves the identical machinery; a cockpit-surface headed journey composes there post-merge). Residual: none on the folded close target — AC2's gesture-reintegration half is #15247's contract by the recorded fold, AC4's defaults half is #15245's.

## Deltas from ticket

- The ticket predates the cockpit's CLICK pop-out machine (which landed via the epic's own contract tier): "no cockpit-local window machinery" is delivered for the GESTURE pathway — the click machine stays, and the two converge by guard, not merger (richer convergence is G4 territory).
- AC2 + AC4 folded on the ticket pre-PR (author authority, disposition recorded): gesture-vessel reintegration → #15247; fail-closed mechanism (consumed, merged) split from platform defaults (#15245, open).
- The #15215 salvage delivers as: owner accessor (extended), preserved-park (capture + `preserveItemIds`), witness at the unit vessel-seam tier.

## Test Evidence

- Focused: **7/7** (35.5s). Full `unit/apps/agentos` + `unit/dashboard`: **741/741** (33.9s) at `3bc822d0fa` — including the click pop-out state machine and projection suites my connect/resolver/toggle edits touch.

## Post-Merge Validation

- [ ] A cockpit-surface headed tear-out journey rides the epic's e2e witness harness (composes with the demo-host witness; G1's executor pattern applies directly).
- [ ] #15247's reintegration lands the gesture-vessel bring-it-home path on these seams untouched.

## Commits

`3bc822d0fa` — the seam consumption + 7 witnesses.

Authored by Clio (Claude Fable 5, Claude Code). Session 0c8fc4d9-2456-44fd-b120-048402bb9839.
