### PR TITLE
fix(devindex): an ambiguous 5xx/gateway retry replays the mutation it can't confirm applied (#15454)

### DIFF
--- a/apps/devindex/services/GitHub.mjs
+++ b/apps/devindex/services/GitHub.mjs
@@ -351,8 +351,12 @@ class GitHub extends Base {
             this.#updateRateLimit(response);
 
             if (!response.ok) {
-                // Retry on 5xx (Server Error) or 403 (Rate Limit/Abuse)
-                if ((response.status >= 500 || response.status === 403) && retries > 0) {
+                // Retry on 5xx (Server Error) or 403 (Rate Limit/Abuse). A `>= 500` leaves a MUTATION's
+                // server-side outcome AMBIGUOUS (the write may have applied before the error), so a mutation
+                // is not replayed on it — a read still is. A `403` is a pre-execution rate-limit rejection,
+                // so it is always safe to replay (the write never ran). Mirrors the transport-catch
+                // retry-authorization gate.
+                if (retries > 0 && (response.status === 403 || (response.status >= 500 && !this.#isMutation(query)))) {
                     let delay = (4 - retries) * 2000; // Default: 2s, 4s, 6s
 
                     // Special handling for 403 Secondary Rate Limit (Abuse Detection)
@@ -387,10 +391,11 @@ class GitHub extends Base {
                     throw new Error(`GraphQL Fatal Error: ${messages}`);
                 }
 
-                // Sometimes 502s come as 200 OK with errors body
+                // Sometimes 502s come as 200 OK with errors body. Like a `>= 500`, a gateway error leaves a
+                // MUTATION's outcome ambiguous, so it is not replayed for one — a read still is.
                 const isGatewayError = json.errors.some(e => e.message?.includes('502') || e.message?.includes('504'));
 
-                if (isGatewayError && retries > 0) {
+                if (isGatewayError && retries > 0 && !this.#isMutation(query)) {
                     const delay = (4 - retries) * 2000;
                     console.log(`${prefix} Gateway Error in body. Retrying in ${delay}ms...`);
                     await new Promise(r => setTimeout(r, delay));

--- a/test/playwright/unit/app/devindex/GitHubService.spec.mjs
+++ b/test/playwright/unit/app/devindex/GitHubService.spec.mjs
@@ -509,4 +509,78 @@ test.describe('DevIndex GitHub service', () => {
             .resolves.toEqual({viewer: {login: 'ada'}});
         expect(readCalls, 'an idempotent read retries the same transient failure').toBe(2);
     });
+
+    test('query does NOT replay a mutation after a 5xx server error — a read retries, and a 403 rate-limit still replays either (#15454)', async () => {
+        // A `>= 500` leaves a MUTATION's server-side outcome ambiguous (the write may have applied before
+        // the error), so it is not replayed — an idempotent read is. A `403` is a pre-execution rate-limit
+        // rejection (the write never ran), so it is always safe to replay, mutation or not. retries=4 zeroes
+        // this path's hardcoded `(4 - retries) * 2000` first-retry backoff — unlike the transient-body path
+        // it is not wired to the configurable delay knobs (a noted follow-up).
+        const mutationDoc = `
+            mutation($subjectId: ID!, $body: String!) {
+                addComment(input: {subjectId: $subjectId, body: $body}) { clientMutationId }
+            }`;
+        const badGateway = () => new Response('', {status: 502, statusText: 'Bad Gateway'});
+
+        // MUTATION on a 5xx: NOT replayed — one fetch, the terminal status error thrown.
+        let mutationCalls = 0;
+        globalThis.fetch = async () => { mutationCalls++; return badGateway() };
+        await expect(restClient.query(mutationDoc, {}, 4, 'OptIn Comment'))
+            .rejects.toThrow('GraphQL Error: 502 Bad Gateway');
+        expect(mutationCalls, 'a mutation must not replay a 5xx ambiguous outcome').toBe(1);
+
+        // READ on the SAME 5xx: IS retried — proving the gate is the operation, not the status.
+        let readCalls = 0;
+        globalThis.fetch = async () => {
+            readCalls++;
+            return readCalls === 1 ? badGateway() : jsonResponse({data: {viewer: {login: 'ada'}}});
+        };
+        await expect(restClient.query('query { viewer { login } }', {}, 4, 'OptIn Stars'))
+            .resolves.toEqual({viewer: {login: 'ada'}});
+        expect(readCalls, 'an idempotent read retries the same 5xx').toBe(2);
+
+        // MUTATION on a 403: IS replayed — a pre-execution rate-limit reject never ran the write. A zero
+        // remaining bucket keeps it on the standard backoff (a >0 quota would trip the 10s abuse penalty).
+        restClient.rateLimit.graphql.remaining = 0;
+        let rateLimitedMutationCalls = 0;
+        globalThis.fetch = async () => {
+            rateLimitedMutationCalls++;
+            return rateLimitedMutationCalls === 1
+                ? new Response('', {status: 403, statusText: 'Forbidden'})
+                : jsonResponse({data: {addComment: {clientMutationId: 'ok'}}});
+        };
+        await expect(restClient.query(mutationDoc, {}, 4, 'OptIn Comment'))
+            .resolves.toEqual({addComment: {clientMutationId: 'ok'}});
+        expect(rateLimitedMutationCalls, 'a 403 rate-limit is pre-execution, so a mutation safely replays').toBe(2);
+    });
+
+    test('query does NOT replay a mutation after an in-body gateway (502/504) error — a read retries (#15454)', async () => {
+        // A gateway error can arrive as a 200-body error. Like a `>= 500` status it leaves a MUTATION's
+        // outcome ambiguous, so it is not replayed — a read is. The transient patterns are overridden to a
+        // token this message does not carry, so the gateway branch is the SOLE retry route under test (not
+        // the shared transient-body path). retries=4 zeroes the same hardcoded first-retry backoff.
+        restClient.retryableTransientErrorPatterns = ['neo-nonmatching-token'];
+        const mutationDoc = `
+            mutation($subjectId: ID!, $body: String!) {
+                addComment(input: {subjectId: $subjectId, body: $body}) { clientMutationId }
+            }`;
+        const gatewayBody = () => jsonResponse({errors: [{message: 'Something went wrong (502)'}]});
+
+        // MUTATION on an in-body gateway error: NOT replayed — one fetch, the error surfaced.
+        let mutationCalls = 0;
+        globalThis.fetch = async () => { mutationCalls++; return gatewayBody() };
+        await expect(restClient.query(mutationDoc, {}, 4, 'OptIn Comment'))
+            .rejects.toThrow('Something went wrong (502)');
+        expect(mutationCalls, 'a mutation must not replay an ambiguous in-body gateway error').toBe(1);
+
+        // READ on the SAME in-body gateway error: IS retried.
+        let readCalls = 0;
+        globalThis.fetch = async () => {
+            readCalls++;
+            return readCalls === 1 ? gatewayBody() : jsonResponse({data: {viewer: {login: 'ada'}}});
+        };
+        await expect(restClient.query('query { viewer { login } }', {}, 4, 'OptIn Stars'))
+            .resolves.toEqual({viewer: {login: 'ada'}});
+        expect(readCalls, 'an idempotent read retries the same in-body gateway error').toBe(2);
+    });
 });


### PR DESCRIPTION
Resolves #15454 — the two remaining ambiguous-outcome retry paths in `DevIndex.services.GitHub.query()` are now operation-aware, closing the gap PR #15419 left open at the transport-catch.

## The change

PR #15419 gated the transport-catch retry so a mutation is not replayed after an ambiguous socket failure. Two sibling paths in the same `query()` — the old-style `(4 - retries) * 2000` retry, outside #15419's shared-classification scope — kept blanket-retrying:

- **5xx status** (`:353`): a `>= 500` leaves a mutation's server-side outcome unknowable (the write may have applied before the error), so it is no longer replayed for a mutation — an idempotent read still is. A `403` is a pre-execution rate-limit reject (the write never ran), so it stays retryable for either. Condition is now `retries > 0 && (status === 403 || (status >= 500 && !#isMutation(query)))`.
- **in-body gateway 502/504** (`:391`): likewise ambiguous — gated with `&& !#isMutation(query)`.

A non-retried mutation on either path falls through to the existing `throw` (`:376` for the status path, `:434` for the gateway path via the shared query-errors throw), so it fails loud on attempt 1 rather than replaying — the same discipline as #15419's `isTransientError && #isMutation → throw`.

## Deltas from ticket

None — the prescribed shape (extend the `#isMutation()` retry-authorization gate to both paths). The alternative in the ticket (split mutation execution into its own surface) was the larger refactor; the gate is the minimal, correct-by-construction mirror of the already-merged #15419 pattern.

## Test Evidence

Evidence: L1 — a discriminating witness per gated path in `GitHubService.spec.mjs`, **red against the unfixed source** (I stashed `GitHub.mjs`; both new tests failed at exactly the `mutationCalls).toBe(1)` assertion — the unfixed code replays the write) and **green with the fix** (22/22). Each witness proves the operation is the gate: the mutation is not replayed, while a read from the SAME error IS retried. The 5xx witness additionally proves the `403` carve-out — a rate-limited mutation still replays (pre-execution, safe). Mirrors the transport-path witness in #15419.

`NEO_CHROMA_PORT_TEST=18211 UNIT_TEST_MODE=true npx playwright test ... GitHubService` → 22 passed.

## Post-Merge Validation

- [x] Mutation not replayed on `>= 500`; a `403` rate-limit still retries — 5xx witness (`GitHubService.spec.mjs`).
- [x] Mutation not replayed on in-body `502`/`504` — gateway witness.
- [x] Idempotent read still retries all three — both witnesses assert `readCalls).toBe(2)`.
- [x] Discriminating (red-against-unfixed) per gated path — verified by stashing the source: both mutation-not-replayed assertions fail without the gate.

Authored by Grace (Claude Opus 4.8, Claude Code).
