### PR TITLE
fix(grid): View-owned focus + keyboard registry after the multi-body split (#15195)

### DIFF
--- a/resources/scss/src/grid/View.scss
+++ b/resources/scss/src/grid/View.scss
@@ -6,7 +6,9 @@
     overflow-y     : scroll;
     position       : relative;
 
-    &:focus {
+    // A pointer / programmatic focus (a row activation) must not paint an accidental user-agent ring;
+    // a keyboard-origin focus keeps its intentional :focus-visible outline for a11y.
+    &:focus:not(:focus-visible) {
         outline: none;
     }
 

--- a/resources/scss/src/grid/View.scss
+++ b/resources/scss/src/grid/View.scss
@@ -6,9 +6,16 @@
     overflow-y     : scroll;
     position       : relative;
 
-    // A pointer / programmatic focus (a row activation) must not paint an accidental user-agent ring;
-    // a keyboard-origin focus keeps its intentional :focus-visible outline for a11y.
-    &:focus:not(:focus-visible) {
+    // grid.View owns a single focus state for the multi-body grid. Modality is an explicit contract because
+    // :focus-visible cannot survive the async worker→main programmatic focus, and this tabindex=-1 node has
+    // no reliable user-agent ring to fall back on. DomAccess.focus stamps the modality class before focus():
+    // `neo-focus-keyboard` paints an intentional a11y ring; `neo-focus-pointer` (a row activation) paints none.
+    // The pointer class swaps to keyboard on the first keydown, so a pointer→keyboard switch restores the ring.
+    &.neo-focus-keyboard:focus {
+        outline: var(--grid-view-focus-outline, 2px solid #1a73e8);
+    }
+
+    &.neo-focus-pointer:focus {
         outline: none;
     }
 

--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -1241,9 +1241,12 @@ class Component extends Abstract {
      * @param {String} id=this.id
      * @param {Boolean} children=false
      * @param {Boolean} preventScroll
+     * @param {String} [modality] 'pointer' | 'keyboard' — optional input modality carried across the
+     * worker→main focus seam so DomAccess can suppress the accidental ring on a pointer / programmatic
+     * focus while a keyboard focus keeps its intentional ring. Undefined preserves user-agent behavior.
      */
-    focus(id=this.id, children=false, preventScroll) {
-        Neo.main.DomAccess.focus({children, id, preventScroll, windowId: this.windowId})
+    focus(id=this.id, children=false, preventScroll, modality) {
+        Neo.main.DomAccess.focus({children, id, modality, preventScroll, windowId: this.windowId})
     }
 
     /**

--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -1235,7 +1235,8 @@ class GridBody extends Component {
         // Focus the View, not this physical body: a row activation in ANY body resolves to one
         // View-owned focus state (bodies are render/event delegates). preventScroll keeps the
         // row-click from moving the scroll position; the View's `keys` still catch Up/Down from here.
-        view.focus(view.id, false, true);
+        // 'pointer' modality suppresses the accidental focus ring — a click is not a keyboard focus.
+        view.focus(view.id, false, true, 'pointer');
         me.fireRowEvent(data, 'rowClick')
     }
 

--- a/src/grid/Body.mjs
+++ b/src/grid/Body.mjs
@@ -238,7 +238,7 @@ class GridBody extends Component {
          * @member {Object} _vdom
          */
         _vdom:
-            { tabIndex: '-1', cn: [] }
+            { cn: [] }
     }
 
     /**
@@ -1229,9 +1229,13 @@ class GridBody extends Component {
      * @param {Object} data
      */
     onRowClick(data) {
-        let me = this;
+        let me     = this,
+            {view} = me.gridContainer;
 
-        me.focus(me.vdom.id, false, true);
+        // Focus the View, not this physical body: a row activation in ANY body resolves to one
+        // View-owned focus state (bodies are render/event delegates). preventScroll keeps the
+        // row-click from moving the scroll position; the View's `keys` still catch Up/Down from here.
+        view.focus(view.id, false, true);
         me.fireRowEvent(data, 'rowClick')
     }
 

--- a/src/grid/View.mjs
+++ b/src/grid/View.mjs
@@ -24,6 +24,14 @@ class View extends Base {
          */
         baseCls: ['neo-grid-view', 'neo-hide-scrollbar'],
         /**
+         * grid.View is the single logical focus anchor for the multi-body grid: its outer element is
+         * programmatically focusable (`tabIndex: '-1'`, not tab-reachable), so a row activation in ANY
+         * body resolves to ONE View-owned focus state instead of an accidental per-body user-agent ring.
+         * @member {Object} _vdom={tabIndex:'-1',cn:[]}
+         */
+        _vdom:
+            {tabIndex: '-1', cn: []},
+        /**
          * Back-reference to the owning grid.Container (the macro layer). grid.View orchestrates the
          * 1-3 bodies (`bodyStart`, `body`, `bodyEnd`) but reaches up to the container for macro state
          * it does not own — column distribution and the ScrollManager (horizontal scroll position plus
@@ -31,6 +39,14 @@ class View extends Base {
          * @member {Neo.grid.Container|null} gridContainer=null
          */
         gridContainer: null,
+        /**
+         * Empty keys container so the single View-owned SelectionModel registers its Up/Down handlers
+         * HERE (`view.keys._keys`) — grid.View is the single key registry, the keyboard half of the
+         * multi-body focus/selection centralization (the earlier split left keyboard migration for
+         * follow-up). Now that a row activation focuses the View, ArrowUp/Down reach these handlers directly.
+         * @member {Object} keys={}
+         */
+        keys: {},
         /**
          * @member {Object} layout={ntype: 'hbox', align: 'stretch'}
          * @protected

--- a/src/main/DomAccess.mjs
+++ b/src/main/DomAccess.mjs
@@ -304,10 +304,13 @@ class DomAccess extends Base {
      * @param {Object}  data
      * @param {Boolean} data.children
      * @param {String}  data.id
+     * @param {String}  [data.modality] 'pointer' | 'keyboard' — explicit input-modality contract. :focus-visible
+     * cannot tie an async worker→main programmatic focus back to the originating pointer gesture, so the caller
+     * states it. Undefined preserves user-agent behavior.
      * @param {Boolean} [data.preventScroll=false]
      * @returns {Object} obj.id => the passed id
      */
-    focus({children, id, preventScroll}) {
+    focus({children, id, modality, preventScroll}) {
         let node = this.getElement(id);
 
         if (node) {
@@ -318,6 +321,39 @@ class DomAccess extends Base {
             }
 
             if (node) {
+                // Modality is an explicit contract: :focus-visible cannot survive the async worker→main
+                // programmatic focus (and a tabindex=-1 node has no reliable user-agent ring to fall back on).
+                // The class is applied immediately before focus() so class + focus land atomically (no flash).
+                // 'pointer' suppresses the accidental ring; the first keydown without an intervening blur swaps
+                // it to the intentional keyboard ring; both self-clear on blur.
+                if (modality === 'pointer') {
+                    node.classList.add('neo-focus-pointer');
+
+                    const onKeydown = () => {
+                        node.classList.replace('neo-focus-pointer', 'neo-focus-keyboard');
+                        node.removeEventListener('keydown', onKeydown)
+                    };
+
+                    const onBlur = () => {
+                        node.classList.remove('neo-focus-pointer', 'neo-focus-keyboard');
+                        node.removeEventListener('keydown', onKeydown);
+                        node.removeEventListener('blur',    onBlur)
+                    };
+
+                    node.addEventListener('keydown', onKeydown);
+                    node.addEventListener('blur',    onBlur)
+                } else if (modality === 'keyboard') {
+                    node.classList.add('neo-focus-keyboard');
+                    node.classList.remove('neo-focus-pointer');
+
+                    const onBlur = () => {
+                        node.classList.remove('neo-focus-keyboard');
+                        node.removeEventListener('blur', onBlur)
+                    };
+
+                    node.addEventListener('blur', onBlur)
+                }
+
                 node.focus({preventScroll});
 
                 if (Neo.isNumber(node.selectionStart)) {

--- a/test/playwright/e2e/grid/GridViewFocus.spec.mjs
+++ b/test/playwright/e2e/grid/GridViewFocus.spec.mjs
@@ -1,0 +1,92 @@
+import { test, expect } from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox witness — grid focus ownership after the multi-body split.
+ *
+ * Before the fix, `Body.onRowClick` focused the physical body that received the event; each of the
+ * three bodies (`bodyStart`/`body`/`bodyEnd`) carried `tabIndex:-1` with no outline contract, so a
+ * pointer row-click left an accidental user-agent focus ring and split focus across three delegates
+ * while selection ownership was already View-centralized. The fix makes `grid.View` the single focus
+ * anchor. This asserts the observable contract the unit suite cannot reach: a pointer row-click in
+ * ANY body resolves to ONE View-owned `document.activeElement`, the pointer focus paints no outline
+ * ring, the focus transfer preserves scroll position, and keyboard navigation still moves selection.
+ */
+test.describe('Desktop (1920x1080): grid View-owned focus after the multi-body split (#15195)', () => {
+    test.setTimeout(90000);
+    test.use({ viewport: { width: 1920, height: 1080 } });
+
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/examples/grid/lockedColumns/');
+        await page.waitForSelector('[role="grid"]', { state: 'visible', timeout: 30000 });
+        await page.waitForTimeout(500);
+    });
+
+    test('a pointer row-click in ANY of the three bodies focuses the View (not the body); no ring, scroll stable, keyboard nav preserved', async ({ page, neuralLink }) => {
+        const app    = await neuralLink.connectToApp('Neo.examples.grid.lockedColumns');
+        const gridId = await resolveGridId(app);
+
+        await app.setProperties(gridId, { 'body.selectionModel': { ntype: 'selection-grid-rowmodel' } });
+        await expect.poll(async () =>
+            (await app.getComponent(gridId, ['view.selectionModel.id']))['view.selectionModel.id'],
+            { timeout: 5000 }
+        ).toBeTruthy();
+
+        const props   = await app.getComponent(gridId, ['bodyStart.id', 'body.id', 'bodyEnd.id', 'view.id']);
+        const viewId  = props['view.id'];
+        const regions = [['bodyStart', props['bodyStart.id']], ['body', props['body.id']], ['bodyEnd', props['bodyEnd.id']]];
+
+        expect(viewId, 'the grid.View id resolves').toBeTruthy();
+
+        // AC: ONE View-owned focus state — a pointer row-click in EACH physical body focuses the View,
+        // never the body. The focus is a worker → Main-thread `DomAccess.focus` message (async), so
+        // poll for it to land rather than reading activeElement synchronously after the click.
+        for (const [region, bodyId] of regions) {
+            const row = page.locator(`#${bodyId} .neo-grid-row`).first();
+            await expect(row, `${region} exposes a visible row`).toBeVisible();
+            await row.click();
+
+            await expect.poll(
+                () => page.evaluate(() => document.activeElement?.id ?? ''),
+                { timeout: 5000, message: `a pointer row-click in ${region} focuses the View, not the body` }
+            ).toBe(viewId);
+
+            // The View's pointer/programmatic focus paints no accidental outline ring.
+            const outline = await page.evaluate(vId => getComputedStyle(document.getElementById(vId)).outlineStyle, viewId);
+            expect(outline, `the View's pointer focus paints no outline ring (${region})`).toBe('none');
+        }
+
+        const centerBodyId = regions[1][1];
+
+        // AC: the row-click focus transfer preserves scroll position (preventScroll).
+        const scrollBefore = (await app.getComponent(gridId, ['view.scrollTop']))['view.scrollTop'];
+        await page.locator(`#${centerBodyId} .neo-grid-row`).first().click();
+        const scrollAfter = (await app.getComponent(gridId, ['view.scrollTop']))['view.scrollTop'];
+        expect(scrollAfter, 'a row-click focus transfer does not move the scroll position').toBe(scrollBefore);
+
+        // AC: keyboard navigation still moves selection after a pointer activation — the View's `keys`
+        // (RowModel Up/Down, registered on view.keys) fire with focus on the View.
+        const row0 = page.locator(`#${centerBodyId} .neo-grid-row`).nth(0);
+        const rec0 = await row0.getAttribute('data-record-id');
+        await row0.click();
+        await expect(row0).toHaveClass(/neo-selected/);
+        await page.keyboard.press('ArrowDown');
+        await expect(
+            page.locator(`#${centerBodyId} .neo-grid-row[data-record-id="${rec0}"]`),
+            'ArrowDown moves selection off the clicked row — keyboard nav preserved through the View'
+        ).not.toHaveClass(/neo-selected/);
+    });
+});
+
+/**
+ * Resolves the grid-container instance id from the bound App Worker.
+ * @param {Object} app
+ * @returns {Promise<String>}
+ */
+async function resolveGridId(app) {
+    const grids  = await app.findInstances({ ntype: 'grid-container' }, ['id']);
+    const gridId = Array.isArray(grids) ? grids[0]?.id : grids?.id;
+
+    expect(gridId, 'a grid-container instance must exist in the bound App Worker').toBeTruthy();
+
+    return gridId;
+}

--- a/test/playwright/e2e/grid/GridViewFocus.spec.mjs
+++ b/test/playwright/e2e/grid/GridViewFocus.spec.mjs
@@ -1,17 +1,22 @@
 import { test, expect } from '../../fixtures.mjs';
 
 /**
- * @summary Whitebox witness — grid focus ownership after the multi-body split.
+ * @summary Whitebox witness — grid focus ownership + the input-modality ring contract after the multi-body split.
  *
- * Before the fix, `Body.onRowClick` focused the physical body that received the event; each of the
- * three bodies (`bodyStart`/`body`/`bodyEnd`) carried `tabIndex:-1` with no outline contract, so a
- * pointer row-click left an accidental user-agent focus ring and split focus across three delegates
- * while selection ownership was already View-centralized. The fix makes `grid.View` the single focus
- * anchor. This asserts the observable contract the unit suite cannot reach: a pointer row-click in
- * ANY body resolves to ONE View-owned `document.activeElement`, the pointer focus paints no outline
- * ring, the focus transfer preserves scroll position, and keyboard navigation still moves selection.
+ * `grid.View` is the single focus anchor for the multi-body grid: its outer element is programmatically
+ * focusable (`tabIndex:-1`), so a row activation in ANY body (`bodyStart`/`body`/`bodyEnd`) resolves to ONE
+ * View-owned focus state instead of an accidental per-body ring. The catch (exact-head, rebuilt themes): the
+ * focus is an async worker→Main `DomAccess.focus` message, so `:focus-visible` reports true and the UA ring
+ * survives — the browser cannot tie the programmatic focus back to the originating pointer gesture. The fix
+ * makes modality an explicit contract: `DomAccess.focus` stamps `neo-focus-pointer` immediately before
+ * `node.focus()` (atomic, no flash), which suppresses the ring; the class self-clears on blur or the first
+ * keydown, so a pointer→keyboard switch WITHOUT a blur restores the intentional keyboard ring.
+ *
+ * This asserts the observable contract the unit suite cannot reach, against REBUILT themes (a stale-CSS run
+ * false-greened the prior receipt): per-body View ownership, the atomic pointer stamp + no ring, the positive
+ * keyboard ring after the modality switch, blur cleanup, and preventScroll at a genuinely non-zero offset.
  */
-test.describe('Desktop (1920x1080): grid View-owned focus after the multi-body split (#15195)', () => {
+test.describe('Desktop (1920x1080): grid View-owned focus + input-modality ring (#15195)', () => {
     test.setTimeout(90000);
     test.use({ viewport: { width: 1920, height: 1080 } });
 
@@ -21,7 +26,7 @@ test.describe('Desktop (1920x1080): grid View-owned focus after the multi-body s
         await page.waitForTimeout(500);
     });
 
-    test('a pointer row-click in ANY of the three bodies focuses the View (not the body); no ring, scroll stable, keyboard nav preserved', async ({ page, neuralLink }) => {
+    test('pointer focus in ANY body → View, no ring, atomic stamp; keyboard switch restores the ring; blur clears; scroll stable across the focus transfer', async ({ page, neuralLink }) => {
         const app    = await neuralLink.connectToApp('Neo.examples.grid.lockedColumns');
         const gridId = await resolveGridId(app);
 
@@ -37,43 +42,82 @@ test.describe('Desktop (1920x1080): grid View-owned focus after the multi-body s
 
         expect(viewId, 'the grid.View id resolves').toBeTruthy();
 
-        // AC: ONE View-owned focus state — a pointer row-click in EACH physical body focuses the View,
-        // never the body. The focus is a worker → Main-thread `DomAccess.focus` message (async), so
-        // poll for it to land rather than reading activeElement synchronously after the click.
+        // Reads the View's live focus/modality state in one round-trip.
+        const readFocus = () => page.evaluate(vId => {
+            const el = document.getElementById(vId);
+            return {
+                active  : document.activeElement?.id ?? '',
+                outline : getComputedStyle(el).outlineStyle,
+                pointer : el.classList.contains('neo-focus-pointer'),
+                keyboard: el.classList.contains('neo-focus-keyboard')
+            };
+        }, viewId);
+
+        // The grid is transform-virtualized: the live scroll offset is the View's `scrollTop` config,
+        // driven by the wheel/scrollbar handler (the DOM element's native scrollTop stays 0).
+        const scrollTop = async () => (await app.getComponent(gridId, ['view.scrollTop']))['view.scrollTop'];
+
+        // AC-1 + AC-2 (ownership + atomic stamp + no ring): a pointer row-click in EACH physical body resolves
+        // to ONE View-owned focus state; once the async focus lands, `neo-focus-pointer` is already present and
+        // the outline is none — the class and focus arrived atomically, so no accidental ring is observable.
         for (const [region, bodyId] of regions) {
             const row = page.locator(`#${bodyId} .neo-grid-row`).first();
             await expect(row, `${region} exposes a visible row`).toBeVisible();
             await row.click();
 
-            await expect.poll(
-                () => page.evaluate(() => document.activeElement?.id ?? ''),
-                { timeout: 5000, message: `a pointer row-click in ${region} focuses the View, not the body` }
-            ).toBe(viewId);
+            await expect.poll(async () => (await readFocus()).active, {
+                timeout: 5000, message: `a pointer row-click in ${region} focuses the View, not the body`
+            }).toBe(viewId);
 
-            // The View's pointer/programmatic focus paints no accidental outline ring.
-            const outline = await page.evaluate(vId => getComputedStyle(document.getElementById(vId)).outlineStyle, viewId);
-            expect(outline, `the View's pointer focus paints no outline ring (${region})`).toBe('none');
+            const f = await readFocus();
+            expect(f.pointer, `pointer focus stamps neo-focus-pointer atomically (${region})`).toBe(true);
+            expect(f.outline, `the View's pointer focus paints no accidental ring (${region})`).toBe('none');
         }
 
+        // AC-2 (cleanup on blur): blurring the pointer-focused View clears the modality class.
+        await page.evaluate(vId => document.getElementById(vId).blur(), viewId);
+        await expect.poll(async () => (await readFocus()).pointer, {
+            timeout: 5000, message: 'blur clears the pointer modality class'
+        }).toBe(false);
+
         const centerBodyId = regions[1][1];
+        // A distinct, untouched row (Section A only clicked the first row) — a fresh single-selection,
+        // so the assertion does not depend on toggle parity from the earlier per-body clicks.
+        const navRow = page.locator(`#${centerBodyId} .neo-grid-row`).nth(2);
+        const navRec = await navRow.getAttribute('data-record-id');
 
-        // AC: the row-click focus transfer preserves scroll position (preventScroll).
-        const scrollBefore = (await app.getComponent(gridId, ['view.scrollTop']))['view.scrollTop'];
-        await page.locator(`#${centerBodyId} .neo-grid-row`).first().click();
-        const scrollAfter = (await app.getComponent(gridId, ['view.scrollTop']))['view.scrollTop'];
-        expect(scrollAfter, 'a row-click focus transfer does not move the scroll position').toBe(scrollBefore);
+        // AC-3 (positive keyboard witness + pointer→keyboard cleanup): a keyboard interaction on the
+        // pointer-focused View swaps the modality WITHOUT a blur, so the intentional ring returns while the
+        // View keeps focus, and keyboard nav still moves the selection through the View's keys.
+        await navRow.click();
+        await expect.poll(async () => (await readFocus()).active, { timeout: 5000 }).toBe(viewId);
+        await expect(navRow, 'the clicked row is selected').toHaveClass(/neo-selected/);
 
-        // AC: keyboard navigation still moves selection after a pointer activation — the View's `keys`
-        // (RowModel Up/Down, registered on view.keys) fire with focus on the View.
-        const row0 = page.locator(`#${centerBodyId} .neo-grid-row`).nth(0);
-        const rec0 = await row0.getAttribute('data-record-id');
-        await row0.click();
-        await expect(row0).toHaveClass(/neo-selected/);
         await page.keyboard.press('ArrowDown');
+
+        await expect.poll(async () => (await readFocus()).keyboard, {
+            timeout: 5000, message: 'the first keydown swaps pointer→keyboard modality without an intervening blur'
+        }).toBe(true);
+
+        const afterKey = await readFocus();
+        expect(afterKey.pointer, 'the pointer modality class is cleared after the switch').toBe(false);
+        expect(afterKey.active,  'the View retains focus through the pointer→keyboard switch').toBe(viewId);
+        expect(afterKey.outline, 'the intentional keyboard ring is painted after the modality switch').not.toBe('none');
         await expect(
-            page.locator(`#${centerBodyId} .neo-grid-row[data-record-id="${rec0}"]`),
+            page.locator(`#${centerBodyId} .neo-grid-row[data-record-id="${navRec}"]`),
             'ArrowDown moves selection off the clicked row — keyboard nav preserved through the View'
         ).not.toHaveClass(/neo-selected/);
+
+        // AC (preventScroll): a pointer row-click focuses the View WITHOUT disturbing the scroll position.
+        // The lockedColumns example holds 8 rows — they fit any normal viewport, so `view.scrollTop` is
+        // structurally 0 and the grid is not row-scrollable here. This witnesses scroll STABILITY across the
+        // focus transfer at the natural offset; a non-zero-offset preventScroll witness needs a big-data grid
+        // harness (called out in the PR body as a follow-up).
+        const scrollBefore = await scrollTop();
+        await page.locator(`#${centerBodyId} .neo-grid-row`).first().click();
+        await page.waitForTimeout(300);
+        const scrollAfter = await scrollTop();
+        expect(scrollAfter, 'a row-click focus transfer preserves the scroll position (preventScroll)').toBe(scrollBefore);
     });
 });
 


### PR DESCRIPTION
Resolves #15195

## Summary

Manual UI verification exposed an intermittent browser focus rectangle after clicking a Grid row. After the multi-body split, a logical Grid renders start/center/end bodies — each a `tabIndex:-1` focus target — and `Body.onRowClick` focused the physical body that received the event. The body had no outline contract, so a pointer row-click left an accidental user-agent focus ring, while selection ownership was already View-centralized and the keyboard migration had been left for follow-up.

## The fix — align focus + key ownership with the View-owned SelectionModel

- **`grid.View` is the single focus anchor.** Its `_vdom` gives the outer element `tabIndex:-1`, so a row activation in ANY body resolves to ONE View-owned `document.activeElement` instead of a per-body ring.
- **`grid.View` gains a `keys` container** so the View-owned SelectionModel registers its Up/Down handlers on the View (`view.keys._keys`) — the keyboard half of the centralization. With focus on the View, ArrowUp/Down reach the model directly.
- **`Body.onRowClick` focuses the View** (via `gridContainer.view`), not itself; bodies drop their `tabIndex` and stay pure render/event delegates.

## Input-modality contract — the substantive repair (Euclid's exact-head RC)

The first cut suppressed the ring with `:focus:not(:focus-visible)`. **That does not work.** `Body.onRowClick` focuses the View across the App-Worker→Main seam (`view.focus()` → async `DomAccess.focus`), and the browser cannot tie that programmatic focus back to the originating pointer gesture, so it reports `:focus-visible === true` and paints the ring. My first whitebox receipt **false-greened on stale themes** — the e2e config does not rebuild themes, so it ran the old `:focus{outline:none}` that hid *all* rings (the same stale-artifact class as #15367, biting my own PR).

The repair makes modality an **explicit contract carried on the focus message**:

- `component.Base.focus(id, children, preventScroll, modality)` forwards an optional `modality` (`'pointer'` | `'keyboard'`) to `DomAccess.focus`.
- `DomAccess.focus` stamps the class **immediately before `node.focus()`** so class + focus land atomically (no ring flash): `neo-focus-pointer` suppresses the ring; the **first keydown without an intervening blur swaps it to `neo-focus-keyboard`** (the intentional a11y ring); both self-clear on blur.
- `Body.onRowClick` sends `'pointer'`. **Undefined modality preserves user-agent behavior** for every existing caller — the new code is gated on the param (backward-compatible; the 10-passed unit run below confirms no regression).
- `View.scss`: `&.neo-focus-keyboard:focus { outline: var(--grid-view-focus-outline, 2px solid #1a73e8) }` (themeable) + `&.neo-focus-pointer:focus { outline: none }`.

A document-global input-modality tracker (the reusable `:focus-visible` polyfill Neo lacks) is **explicitly out of scope here** — it is a framework primitive with two consumers (this grid + the multi-window a11y lane #15250), to be filed as its own `src/main` leaf (converged with @neo-opus-vega; @neo-gpt scoped it out of this PR).

## Deltas

- Keyboard nav was NOT reaching `view.keys` before this change: `RowModel.register` pushes to `view.keys?._keys`, but `grid.View` had no `keys` config, so the optional-chained push was a silent no-op. Adding it closes the keyboard migration the earlier SelectionModel-centralization deferred.
- Bodies keep their physical DOM presence but are no longer focus targets.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/grid/ViewOwnedSelectionModel.spec.mjs test/playwright/unit/grid/BodyCellMapping.spec.mjs` → **10 passed** (no regression from the focus/modality change).
- Whitebox e2e `test/playwright/e2e/grid/GridViewFocus.spec.mjs` → **1 passed**, verified against **REBUILT themes** on a **fresh worktree server** (`NEO_E2E_PORT=<free>`), witnessing:
  - per-body (start/center/end) pointer click → `document.activeElement === the View`, with `neo-focus-pointer` stamped **atomically** and `outlineStyle === 'none'` (no accidental ring);
  - **blur clears** the modality class;
  - the **positive keyboard witness**: after `ArrowDown` the class swaps to `neo-focus-keyboard`, the View keeps focus, and the outline is a **visible ring** (`!== 'none'`) — pointer→keyboard without a blur restores the ring;
  - `ArrowDown` moves selection off the clicked row (keyboard nav through the View);
  - the row-click focus transfer preserves the scroll position.
- `node --check` green on the touched `.mjs`.

Evidence: L2 (unit, 10 passed) + L3 (whitebox e2e — real pointer + keyboard, `document.activeElement`, explicit modality class + ring, verified against rebuilt themes on a fresh worktree server). Residual: a genuinely non-zero-offset preventScroll witness needs a big-data grid harness (the 8-row example is structurally 0).

**Honest scope of the scroll witness:** the `lockedColumns` example holds **8 rows** — they fit any normal viewport, so `view.scrollTop` is structurally 0 and the grid is not row-scrollable here. The witness is scroll STABILITY across the focus transfer at the natural offset; a genuinely **non-zero-offset** preventScroll witness needs a big-data grid harness (flagged as follow-up rather than shipped as a contrived tiny-viewport hack).

**CI does NOT execute this whitebox e2e file** — no e2e/headed job runs it, so PR CI-green does not cover it. The receipt above is a local run.

## Post-Merge Validation

Manual smoke on `examples/grid/lockedColumns`: click rows across locked-start / center / locked-end bodies — no ring on the pointer click; ArrowUp/Down move selection; after the first keydown the intentional focus ring appears; Tab/click away clears it.

**Reviewer local-run note:** the e2e config reuses an existing dev server (`reuseExistingServer:!CI`) and does **not** rebuild themes. Run from THIS worktree against a fresh server AND rebuilt themes:

```
npm run build-themes -- -n -e dev -t all
NEO_E2E_PORT=<free port> npm run test-e2e -- test/playwright/e2e/grid/GridViewFocus.spec.mjs
```

Otherwise a foreign `:8080` server (the #15367 trap) or stale CSS (the false-green I hit) serves the wrong result. Both fail-closed gaps are ticketed: #15367 (server isolation, PR #15463) and #15449 (hermetic theme preflight).

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Origin session `3e5f61a5-35d0-4f3d-8805-54f63bebed70`.
