### PR TITLE
fix(devindex): don't replay GraphQL mutations on ambiguous 5xx / gateway failures (#15454)

### DIFF
--- a/apps/devindex/services/GitHub.mjs
+++ b/apps/devindex/services/GitHub.mjs
@@ -353,6 +353,13 @@ class GitHub extends Base {
             if (!response.ok) {
                 // Retry on 5xx (Server Error) or 403 (Rate Limit/Abuse)
                 if ((response.status >= 500 || response.status === 403) && retries > 0) {
+                    // A 5xx leaves a mutation's server-side outcome ambiguous (the write may have
+                    // applied before the error), so it is not replayed; a 403 is a pre-execution
+                    // rate-limit rejection, safe to replay. Idempotent reads retry either.
+                    if (response.status >= 500 && this.#isMutation(query)) {
+                        throw new Error(`GraphQL Error: ${response.status} ${response.statusText} — mutation not replayed after an ambiguous server error`);
+                    }
+
                     let delay = (4 - retries) * 2000; // Default: 2s, 4s, 6s
 
                     // Special handling for 403 Secondary Rate Limit (Abuse Detection)
@@ -389,6 +396,13 @@ class GitHub extends Base {
 
                 // Sometimes 502s come as 200 OK with errors body
                 const isGatewayError = json.errors.some(e => e.message?.includes('502') || e.message?.includes('504'));
+
+                // A gateway 502/504 is ambiguous for a mutation — the request may have reached the
+                // backend and applied before the gateway failed — so a mutation fails loud rather than
+                // replay; idempotent reads retry.
+                if (isGatewayError && this.#isMutation(query)) {
+                    throw new Error(`GraphQL Gateway Error: ${messages} — mutation not replayed after an ambiguous gateway failure`);
+                }
 
                 if (isGatewayError && retries > 0) {
                     const delay = (4 - retries) * 2000;

--- a/test/playwright/unit/app/devindex/GitHubService.spec.mjs
+++ b/test/playwright/unit/app/devindex/GitHubService.spec.mjs
@@ -419,6 +419,66 @@ test.describe('DevIndex GitHub service', () => {
         expect(readCalls, 'an idempotent read retries the same transient body error').toBe(2);
     });
 
+    test('query does NOT replay a mutation after a 5xx server error — a read from the SAME 5xx retries', async () => {
+        const mutationDoc = `
+            mutation($issueId: ID!) {
+                closeIssue(input: {issueId: $issueId}) { clientMutationId }
+            }`;
+
+        // MUTATION: a 5xx leaves the write's server-side outcome ambiguous, so it fails loud on the
+        // first response instead of replaying — one fetch, no duplicate write.
+        let mutationCalls = 0;
+        globalThis.fetch = async () => {
+            mutationCalls++;
+            return new Response('', {status: 500, statusText: 'Internal Server Error'});
+        };
+        await expect(restClient.query(mutationDoc, {}, 3, 'OptIn Close'))
+            .rejects.toThrow(/mutation not replayed after an ambiguous server error/);
+        expect(mutationCalls, 'a mutation must not replay a 5xx').toBe(1);
+
+        // READ: the SAME 5xx IS retried — the gate is the operation, not the status.
+        let readCalls = 0;
+        globalThis.fetch = async () => {
+            readCalls++;
+            return readCalls === 1
+                ? new Response('', {status: 500, statusText: 'Internal Server Error'})
+                : jsonResponse({data: {viewer: {login: 'ada'}}});
+        };
+        await expect(restClient.query('query { viewer { login } }', {}, 3, 'OptIn Stars'))
+            .resolves.toEqual({viewer: {login: 'ada'}});
+        expect(readCalls, 'an idempotent read retries the same 5xx').toBe(2);
+    });
+
+    test('query does NOT replay a mutation after an in-body gateway (502/504) error — a read from the SAME error retries', async () => {
+        const mutationDoc = `
+            mutation($subjectId: ID!, $body: String!) {
+                addComment(input: {subjectId: $subjectId, body: $body}) { clientMutationId }
+            }`;
+
+        // MUTATION: an in-body 502 is ambiguous for a mutation (the write may have reached the backend
+        // before the gateway failed), so it fails loud rather than replay — one fetch.
+        let mutationCalls = 0;
+        globalThis.fetch = async () => {
+            mutationCalls++;
+            return jsonResponse({errors: [{message: 'Something failed: 502 Bad Gateway'}]});
+        };
+        await expect(restClient.query(mutationDoc, {}, 3, 'OptIn Comment'))
+            .rejects.toThrow(/mutation not replayed after an ambiguous gateway failure/);
+        expect(mutationCalls, 'a mutation must not replay an in-body gateway error').toBe(1);
+
+        // READ: the SAME in-body gateway error IS retried.
+        let readCalls = 0;
+        globalThis.fetch = async () => {
+            readCalls++;
+            return readCalls === 1
+                ? jsonResponse({errors: [{message: 'Something failed: 502 Bad Gateway'}]})
+                : jsonResponse({data: {viewer: {login: 'ada'}}});
+        };
+        await expect(restClient.query('query { viewer { login } }', {}, 3, 'OptIn Stars'))
+            .resolves.toEqual({viewer: {login: 'ada'}});
+        expect(readCalls, 'an idempotent read retries the same in-body gateway error').toBe(2);
+    });
+
     test('query exhausts the bounded budget on a persistent transient error, then throws (no infinite retry)', async () => {
         let callCount = 0;
 


### PR DESCRIPTION
Resolves #15454

## Summary

Surfaced during the #15359 / PR #15419 review — @neo-gpt's RC established that `DevIndex.services.GitHub.query()` must not replay a non-idempotent GraphQL mutation after an ambiguous outcome. PR #15419 (merged) closed the two shared-classifier paths (transport catch + 200-body). This closes the two PRE-EXISTING sibling paths #15419's scope deliberately left: the **5xx/403 retry** and the **in-body 502/504 gateway retry**, which still replayed mutations.

## The fix — extend the retry-authorization gate to all ambiguous paths

Retry *classification* (is it transient?) and retry *authorization* (is replay safe?) are separate decisions. A 5xx server error or an in-body 502/504 gateway error leaves a mutation's server-side outcome unknowable — the write (`OptIn` `addComment` / issue-close) may have applied before the failure — so replaying it can duplicate.

- **5xx (`>= 500`) now fails loud for a mutation** via the same `#isMutation` gate #15419 introduced; a **403** rate-limit is a pre-execution rejection (safe to replay) and stays retryable.
- **The in-body 502/504 gateway path now fails loud for a mutation** likewise.
- Idempotent reads (`query`) retry all four paths unchanged.

`GitHub.query()` is now uniformly mutation-safe across all four ambiguous retry paths: transport disconnect + 200-body (#15419) and 5xx + in-body-gateway (this PR).

## Deltas from ticket

None — the prescribed shape (extend the `#isMutation` authorization gate to the 5xx/gateway paths). The `#isMutation` helper + the transport/200-body gates are already on dev via the merged #15419.

Evidence: L2 (unit witnesses over both transports' real terminals) → L2 required (a retry-authorization contract; no runtime surface). Residual: none.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/app/devindex/GitHubService.spec.mjs` → **22 passed** (2 new discriminating witnesses + the 20 from #15419).
- New witnesses: `query does NOT replay a mutation after a 5xx server error — a read from the SAME 5xx retries` + `query does NOT replay a mutation after an in-body gateway (502/504) error — a read from the SAME error retries`. Each proves the gate is the OPERATION, not the status: the mutation throws after **1** fetch (`— mutation not replayed after an ambiguous …`) while the read retries and succeeds on **2**. Red against the pre-fix ungated code (a mutation replayed to the budget).
- `node --check` green.

## Post-Merge Validation

- Watch the `Data Sync Pipeline` `Run DevIndex Opt-In` runs: after a 5xx / gateway blip mid-write, no duplicate `addComment` / issue-close — the mutation fails loud, not replays.
- Reopen trigger: a duplicated opt-in mutation after a 5xx / gateway.

## Out of Scope

- The 403 rate-limit retry (correctly retained — a pre-execution rejection is safe to replay).
- REST-path retries (idempotent GETs).

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Origin session `3e5f61a5-35d0-4f3d-8805-54f63bebed70`.
