### PR TITLE
test(agentos): the card toggle witnesses the FULL power cycle — Stop closes the loop (#15460)

### DIFF
--- a/test/playwright/e2e/agentos/FleetCardLifecycleNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCardLifecycleNL.spec.mjs
@@ -32,9 +32,10 @@ function rosterRow(state) {
 
 /**
  * @summary Start a STATEFUL recording loopback Fleet bridge serving ONE stopped resident. A
- * successful `startAgent` flips the registry-side lifecycle to running, so the cockpit's
- * settle-time re-poll renders REGISTRY truth — never an optimistic client flip. `rejectStart`
- * makes the start verb answer a deterministic domain rejection instead (registry state untouched).
+ * successful `startAgent` flips the registry-side lifecycle to running and `stopAgent` flips it
+ * back, so the cockpit's settle-time re-poll renders REGISTRY truth — never an optimistic client
+ * flip. `rejectStart` makes the start verb answer a deterministic domain rejection instead
+ * (registry state untouched).
  * @param {Object} [options]
  * @param {Boolean} [options.rejectStart=false]
  * @returns {Promise<{close: Function, endpoint: String, requests: Object[], bearerToken: String}>}
@@ -56,6 +57,11 @@ async function startLifecycleFleetBridge({rejectStart = false} = {}) {
 
                 running.add(request.params);
                 return {ok: true, result: {id: request.params, state: 'running'}}
+            }
+
+            if (request.method === 'stopAgent') {
+                running.delete(request.params);
+                return {ok: true, result: {id: request.params, state: 'stopped'}}
             }
 
             if (request.method === 'fleetRoster') {
@@ -89,11 +95,12 @@ async function startLifecycleFleetBridge({rejectStart = false} = {}) {
  * lifecycle click crosses the fleet wire as the minimal agent-id operation — a registered wire
  * method carrying ONE string param, with no credential-shaped bytes.
  * @param {Object} request The recorded loopback fleet request.
+ * @param {String} [method='startAgent'] The expected registered lifecycle wire method.
  */
-function expectMinimalLifecyclePayload(request) {
+function expectMinimalLifecyclePayload(request, method = 'startAgent') {
     expect(FLEET_WIRE_METHODS).toContain(request.method);
     expect(request).toEqual({
-        method: 'startAgent',
+        method,
         params: TEST_AGENT_ID
     });
     expect(typeof request.params).toBe('string');
@@ -147,14 +154,15 @@ async function getRosterRecord(app) {
  * rebuild re-homed the lifecycle surface onto the cards; the retired Control-panel NL specs died
  * with their subject and this spec is the card path's own witness): the B4 control-toggle →
  * `lifecycleIntent` → the C2
- * adapter → the authenticated bridge — minimal wire payload, registry-truth state advance on
- * success, honest terminal rendering + open retry on rejection, and no credential-shaped bytes on
- * any lifecycle request.
+ * adapter → the authenticated bridge — minimal wire payloads across the FULL power cycle
+ * (start-when-off, stop-when-running: the one contextual toggle carrying each verb in turn),
+ * registry-truth state advance on success, honest terminal rendering + open retry on rejection,
+ * and no credential-shaped bytes on any lifecycle request.
  */
 test.describe('AgentOS fleet card lifecycle controls (Neural Link)', () => {
     test.setTimeout(90000);
 
-    test('happy path: the card toggle Starts through the wire; Body state advances only via re-polled registry truth', async ({page, neuralLink}) => {
+    test('happy path: the toggle drives the FULL power cycle through the wire; Body state advances only via re-polled registry truth', async ({page, neuralLink}) => {
         const fleet = await startLifecycleFleetBridge();
 
         try {
@@ -180,13 +188,32 @@ test.describe('AgentOS fleet card lifecycle controls (Neural Link)', () => {
             expectMinimalLifecyclePayload(starts[0]);
 
             // the Body-side record landed the re-polled state — settled, honest, credential-free
-            const record = await getRosterRecord(app);
-            expect(record).toBeTruthy();
-            expect(record.state).toBe('ok');
-            expect(record.pendingAction ?? null).toBeNull();
-            expect(record.controlReason ?? null).toBeNull();
+            const started = await getRosterRecord(app);
+            expect(started).toBeTruthy();
+            expect(started.state).toBe('ok');
+            expect(started.pendingAction ?? null).toBeNull();
+            expect(started.controlReason ?? null).toBeNull();
 
-            // credential hygiene across EVERY recorded lifecycle-window request
+            // ── the Stop leg (the cycle's second half, same contextual toggle): the SAME control
+            // now carries the Stop verb — the registry flips back to stopped, and the render
+            // advance is again the re-poll's, never the click's
+            await toggle.click();
+
+            await expect(toggle.locator('.fa-play')).toBeVisible({timeout: 15000});
+            await expect(card.locator('.fm-card-control-status')).not.toBeVisible();
+
+            const stops = fleet.requests.filter(request => request.method === 'stopAgent');
+            expect(stops).toHaveLength(1);
+            expectMinimalLifecyclePayload(stops[0], 'stopAgent');
+
+            // the record returned to the stopped truth with no residue — the cycle is closed
+            const stopped = await getRosterRecord(app);
+            expect(stopped).toBeTruthy();
+            expect(stopped.state).toBe('off');
+            expect(stopped.pendingAction ?? null).toBeNull();
+            expect(stopped.controlReason ?? null).toBeNull();
+
+            // credential hygiene across EVERY request recorded over the full cycle
             expect(JSON.stringify(fleet.requests)).not.toMatch(/credential|github_pat|bearer/i)
         } finally {
             await fleet.close()


### PR DESCRIPTION
Resolves #15460
Related: #15439, #15242

The delivered slice from @neo-kimi-phoebe's PR #15445 review observation (her §7.1 Depth-Floor challenge): `FleetCardLifecycleNL`'s happy path now drives the FULL power cycle on the mounted composition — Start → registry-running → Stop → registry-stopped — instead of ending at the Start advance.

**What the extension pins:**
- The ONE contextual toggle carries each verb in turn: `fa-play` at `off` derives `start`; after the settle re-poll seats `ok`, the SAME control derives `stop` (`AgentCardController.onToggleLifecycle`'s state-derived action, now executed end-to-end in both directions).
- Both render advances are REGISTRY-sourced: the stateful double flips its `running` set only on the verbs (`startAgent` adds, `stopAgent` deletes), and every rendered transition follows a re-polled `fleetRoster` snapshot — the optimistic-flip bug class stays unwriteable in both directions.
- Exactly one minimal `stopAgent` crosses the wire — `expectMinimalLifecyclePayload` is parameterized by method (registered wire method, one string param, no credential-shaped bytes).
- After the settled Stop: the Start affordance is back, `.fm-card-control-status` renders nothing, and the Body record returns to `state 'off'` with `pendingAction`/`controlReason` null.
- The credential-hygiene sweep runs LAST, covering every request recorded across the whole cycle.

Out of scope (per the ticket): a rejected-Stop variant — the rejected-terminal class (honest reason render, open retry, untouched registry) is verb-agnostic in the C2 adapter and already witnessed on Start; restart stays a future matrix candidate.

Evidence: L3 at the mounted composition against the authenticated loopback double (the merged spec's own harness pattern, unchanged) → L3 required (#15460's ACs are e2e-tier by construction).

## Test Evidence
At head `cebf935a70`:
- `FleetCardLifecycleNL.spec.mjs` standalone on a fresh isolated port (49537): **2/2 passed** (full-cycle happy path 3.7s; rejected path 2.5s).
- Whole `e2e/agentos` dir (fresh port 49539): **24 passed, 2 failed** — the two reds (`DemoBPerspectivesNL`, `FleetGridKeyboardA11y` — `toBeFocused` class) fail IDENTICALLY on clean `dev` with this change stashed (baseline run, port 49541): pre-existing local-environment sensitivity in the #15364 local-oracle family, not introduced here. CI is the oracle for both.

## Post-Merge Validation
- [ ] The e2e shard executes the extended witness against the merged tree.

## Deltas from ticket
None — the four prescribed edits landed as specified.

Authored by Vega (Claude Fable 5, Claude Code). Session 7157d21f-16c8-4b76-8aac-67e166deccca.