### PR TITLE
fix(test): isolate Playwright component/e2e/root configs from foreign-checkout dev servers (#15367)

### DIFF
--- a/test/playwright/e2e/neural-link/TransactionArchiveReplay.spec.mjs
+++ b/test/playwright/e2e/neural-link/TransactionArchiveReplay.spec.mjs
@@ -11,9 +11,12 @@ import { NeuralLink_InstanceService } from '../../../../ai/services.mjs';
 test.describe('Neural Link - transaction archive replay (e2e)', () => {
     test.setTimeout(120000);
 
-    test('saves a named transaction and replays it after reload into a fresh undoable build', async ({ page, neuralLink }) => {
+    test('saves a named transaction and replays it after reload into a fresh undoable build', async ({ page, neuralLink, baseURL }) => {
         const
-            appOrigin = process.env.NEO_E2E_BASE_URL || 'http://localhost:8080',
+            // Default to the runner's injected baseURL (the resolved free port); an explicit
+            // NEO_E2E_BASE_URL still wins. A default run must never fall back to a foreign :8080 server —
+            // this witness synthesizes an absolute origin, so it has to consume the same port the config resolved.
+            appOrigin = process.env.NEO_E2E_BASE_URL || baseURL,
             appUrl    = `${appOrigin}/examples/button/base/index.html?nlArchiveReplay=${Date.now()}`;
 
         await page.goto(`${appOrigin}/package.json?nlArchiveReplayPurge=${Date.now()}`);

--- a/test/playwright/playwright.config.component.mjs
+++ b/test/playwright/playwright.config.component.mjs
@@ -1,6 +1,16 @@
 import './configTemplateResolver.mjs';
 
 import {defineConfig, devices} from '@playwright/test';
+import {resolveFreePortSync}   from './resolveFreePort.mjs';
+
+// Per-process by default: this suite renders ITS OWN checkout (reuseExistingServer:false below), so a
+// fixed default would silently adopt a foreign dev-server squatting on 8080 — that server serves the
+// WRONG tree to every spec (the convicted cross-serving class). An explicit NEO_E2E_PORT pin still wins.
+const PORT = resolveFreePortSync(process.env.NEO_E2E_PORT);
+// Pin it back into the env: Playwright re-imports this config in the webServer + each worker process,
+// and resolveFreePortSync returns a FRESH port per call — without pinning, the webServer and a worker's
+// baseURL land on different ports (ERR_CONNECTION_REFUSED). Children inherit this; a real pin is a no-op.
+process.env.NEO_E2E_PORT = String(PORT);
 
 export default defineConfig({
     testDir      : './component',
@@ -11,18 +21,18 @@ export default defineConfig({
     reporter: [['list']],
 
     use: {
-        baseURL: 'http://localhost:8080',
+        baseURL: `http://localhost:${PORT}`,
         trace  : 'on-first-retry'
     },
 
     webServer: {
-        // --no-open: CI runners are headless; webpack's browser-open attempt is noise there
-        // and pointless locally under a test runner. Port/reuse semantics stay untouched:
-        // a fixed port + reuseExistingServer can still silently reuse a server from another
-        // checkout locally — that trap is a separate concern from CI enablement.
-        command            : 'npm run server-start -- --no-open',
-        url                : 'http://localhost:8080',
-        reuseExistingServer: !process.env.CI
+        // --no-open: CI runners are headless; webpack's browser-open attempt is noise there and
+        // pointless locally under a test runner. NEVER reuse: an already-listening server from a
+        // foreign clone satisfies the readiness URL and silently serves the wrong tree to every spec
+        // (false reds AND, worse, false greens) — the exact trap this suite hit repeatedly.
+        command            : `npm run server-start -- --port ${PORT} --no-open`,
+        url                : `http://localhost:${PORT}`,
+        reuseExistingServer: false
     },
 
     projects: [{

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -1,10 +1,16 @@
 import './configTemplateResolver.mjs';
 
 import {defineConfig, devices} from '@playwright/test';
+import {resolveFreePortSync}   from './resolveFreePort.mjs';
 
-// Overridable so agent/dev runs can isolate from a foreign dev-server already squatting on 8080
-// (a server started from ANOTHER checkout silently serves the wrong tree to every spec).
-const PORT = process.env.NEO_E2E_PORT || 8080;
+// Per-process by default: this suite renders ITS OWN checkout (reuseExistingServer:false below), so a
+// fixed default would silently adopt a foreign dev-server squatting on 8080 — that server serves the
+// WRONG tree to every spec (the convicted cross-serving class). An explicit NEO_E2E_PORT pin still wins.
+const PORT = resolveFreePortSync(process.env.NEO_E2E_PORT);
+// Pin it back into the env: Playwright re-imports this config in the webServer + each worker process,
+// and resolveFreePortSync returns a FRESH port per call — without pinning, the webServer and a worker's
+// baseURL land on different ports (ERR_CONNECTION_REFUSED). Children inherit this; a real pin is a no-op.
+process.env.NEO_E2E_PORT = String(PORT);
 
 export default defineConfig({
     testDir      : './e2e',
@@ -28,7 +34,9 @@ export default defineConfig({
     webServer: {
         command            : `npm run server-start -- --port ${PORT} --no-open`,
         url                : `http://localhost:${PORT}`,
-        reuseExistingServer: !process.env.CI
+        // NEVER reuse: an already-listening server from a foreign clone satisfies the readiness URL
+        // and silently serves the wrong tree to every spec (false reds AND, worse, false greens).
+        reuseExistingServer: false
     },
 
     projects: [{

--- a/test/playwright/playwright.config.mjs
+++ b/test/playwright/playwright.config.mjs
@@ -3,9 +3,19 @@ import './configTemplateResolver.mjs';
 import {defineConfig, devices} from '@playwright/test';
 import path                    from 'path';
 import {fileURLToPath}         from 'url';
+import {resolveFreePortSync}   from './resolveFreePort.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
+
+// Per-process by default: this aggregate runner loads browser-served framework code too, so a fixed
+// default would silently adopt a foreign dev-server squatting on 8080 — the WRONG tree for every spec
+// (the convicted cross-serving class). An explicit NEO_E2E_PORT pin still wins.
+const PORT = resolveFreePortSync(process.env.NEO_E2E_PORT);
+// Pin it back into the env: Playwright re-imports this config in the webServer + each worker process,
+// and resolveFreePortSync returns a FRESH port per call — without pinning, the webServer and a worker's
+// baseURL land on different ports (ERR_CONNECTION_REFUSED). Children inherit this; a real pin is a no-op.
+process.env.NEO_E2E_PORT = String(PORT);
 
 export default defineConfig({
     testDir      : __dirname,
@@ -19,14 +29,16 @@ export default defineConfig({
     reporter: [['json', {outputFile: path.join(__dirname, 'test-results/all/test-results.json')}]],
 
     use: {
-        baseURL: 'http://localhost:8080',
+        baseURL: `http://localhost:${PORT}`,
         trace  : 'on-first-retry'
     },
 
     webServer: {
-        command            : 'npm run server-start',
-        url                : 'http://localhost:8080',
-        reuseExistingServer: !process.env.CI
+        // NEVER reuse: an already-listening server from a foreign clone satisfies the readiness URL
+        // and silently serves the wrong tree to every spec (false reds AND, worse, false greens).
+        command            : `npm run server-start -- --port ${PORT} --no-open`,
+        url                : `http://localhost:${PORT}`,
+        reuseExistingServer: false
     },
 
     projects: [{


### PR DESCRIPTION
Resolves #15367

## Summary

A shared-port dev server from a DIFFERENT checkout silently satisfied `reuseExistingServer: !CI`, so the component/e2e/root Playwright suites executed the WRONG tree. The failure is silent + shape-shifting: false reds (evidence-contradictions against a peer), false framework-bug diagnoses (#15365), and — worst — false greens (a foreign tree that already contains similar behavior validates a broken branch). On a multi-checkout machine (operator checkout + per-agent worktrees + MCP-server checkout), the shared `:8080` collision is the DEFAULT condition, not an edge case.

## The fix — @neo-gpt-emmy's intake truth-fold (consume the landed primitive)

Per the intake, this drops the originally-prescribed `X-Neo-Serve-Root` header + globalSetup protocol in favor of the already-landed `resolveFreePortSync` primitive (#15225, already consumed by the unit/integration/visual/matrix configs):

- **`playwright.config.{component,e2e,mjs}`** derive an OS-assigned free port via `resolveFreePortSync(process.env.NEO_E2E_PORT)` and set `reuseExistingServer: false` — a foreign server's occupied port is never returned, so it cannot be selected. Explicit `NEO_E2E_PORT` pins still win (short-circuit) for deliberate isolation.
- **Command, URL, and baseURL share the one resolved port** (Emmy's AC): the resolved port is pinned back into the env (`process.env.NEO_E2E_PORT = String(PORT)`) so Playwright's per-worker + webServer re-imports of the config all agree.

## Deltas

- **Latent default-run bug found + fixed during verification.** `resolveFreePortSync` returns a FRESH port per call, and Playwright re-imports the config in the webServer + each worker process — so consuming the primitive *without* the env-pin makes the webServer and a worker's `baseURL` land on DIFFERENT free ports (`ERR_CONNECTION_REFUSED`). The migrated browser-nav configs dodge this by always running `NEO_E2E_PORT`-pinned (the visual config's own docstring shows it); the component/e2e/root **default** runs need the env-pin. This is the piece the "just consume the primitive" prescription doesn't spell out — the e2e verification caught it (first run: server on 59053, workers on 59080/59111).
- The `X-Neo-Serve-Root` header protocol is dropped (no absolute repo path crosses an HTTP header; no second identity contract to maintain), per the intake.

## Test Evidence

Verified **with the foreign `:8080` server (main checkout) still live**:
- `npm run test-e2e -- test/playwright/e2e/grid/SelectionMultiBody.spec.mjs` → **2 passed**; webServer on a free port (59877), `Content ... served from '.../pr-14897-ci-linter-631e75'` (THIS worktree, not `:8080`).
- `npx playwright test -c test/playwright/playwright.config.component.mjs` → **44 passed**; server on a free port (60062), served from this worktree.
- `node --check` green on all three configs.

Evidence: L3 (real browser suites run against a freshly-started own-tree server while a foreign server occupies `:8080`). Residual: none.

## Post-Merge Validation

- On any multi-checkout box, run the component/e2e suites with a foreign server on `:8080` — they must start their own server on a free port (never adopt `:8080`). CI already forces fresh servers (`reuseExistingServer:!CI` was already false there).

## Out of Scope

- The CI component-shard gap (component tests run in no workflow) — its own leaf, per the ticket.
- Killing/managing foreign servers (operator-owned processes).
- The optional hash-derived default port (the free-port primitive already prevents collision by construction).

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Origin session `3e5f61a5-35d0-4f3d-8805-54f63bebed70`.
