### PR TITLE
feat(ai): get_node gains the opt-in full projection — identity facts through the graph's own read verb (#15430)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1506,7 +1506,7 @@ paths:
       x-annotations:
         readOnlyHint: true
       description: |
-        Retrieves a specific node from the knowledge graph by its ID. Pass projection 'full' to include the node's complete properties bag (default 'lean' keeps the token-economy projection).
+        Retrieves a specific node from the knowledge graph by its ID. Pass projection 'full' to include the complete properties bag for allowlisted node types (currently AgentIdentity); other types answer the default 'lean' shape.
       tags: [Graph]
       parameters:
         - name: id
@@ -1518,7 +1518,7 @@ paths:
         - name: projection
           in: query
           required: false
-          description: "'full' adds the node's complete properties bag to the lean shape."
+          description: "'full' adds the properties bag for allowlisted node types (currently AgentIdentity); other types answer the lean shape."
           schema:
             type: string
             enum: [lean, full]

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1506,7 +1506,7 @@ paths:
       x-annotations:
         readOnlyHint: true
       description: |
-        Retrieves a specific node from the knowledge graph by its ID. Pass projection 'full' to include the complete properties bag for allowlisted node types (currently AgentIdentity); other types answer the default 'lean' shape.
+        Retrieves a specific node from the knowledge graph by its ID. Pass projection 'full' to include the type's public fact set (currently AgentIdentity: participation/family/trust facts); other types answer the default 'lean' shape.
       tags: [Graph]
       parameters:
         - name: id
@@ -1518,7 +1518,7 @@ paths:
         - name: projection
           in: query
           required: false
-          description: "'full' adds the properties bag for allowlisted node types (currently AgentIdentity); other types answer the lean shape."
+          description: "'full' adds the type's public fact set (currently AgentIdentity); other types answer the lean shape."
           schema:
             type: string
             enum: [lean, full]

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -1506,7 +1506,7 @@ paths:
       x-annotations:
         readOnlyHint: true
       description: |
-        Retrieves a specific node from the knowledge graph by its ID.
+        Retrieves a specific node from the knowledge graph by its ID. Pass projection 'full' to include the node's complete properties bag (default 'lean' keeps the token-economy projection).
       tags: [Graph]
       parameters:
         - name: id
@@ -1515,6 +1515,14 @@ paths:
           description: The unique ID of the node to retrieve.
           schema:
             type: string
+        - name: projection
+          in: query
+          required: false
+          description: "'full' adds the node's complete properties bag to the lean shape."
+          schema:
+            type: string
+            enum: [lean, full]
+            default: lean
       responses:
         '200':
           description: The requested node.

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -684,19 +684,19 @@ class GraphService extends Base {
      * Retrieves a specific node by its ID.
      *
      * The default `lean` projection hoists only the identity fields — the token-economy contract
-     * roster-wide sweeps rely on. `projection: 'full'` returns the SAME shape plus the node's
-     * complete `properties` bag (a superset — e.g. the IdentitySchema capability facts on an
-     * AgentIdentity node), so a single node's stored facts are readable through the graph's own
-     * read verb.
+     * roster-wide sweeps rely on. `projection: 'full'` returns the SAME shape plus the type's
+     * PUBLIC FACT SET (e.g. the IdentitySchema facts on an AgentIdentity node), so a single node's
+     * public facts are readable through the graph's own read verb.
      *
-     * **The full projection is type-allowlisted** — the policy lives in the pure
-     * {@link module:ai/services/memory-core/nodeProjection} module (hermetically witnessed):
-     * graph-row RLS answers "may this row participate in the caller's graph?" — it is NOT a
-     * substitute for a type's own field authorization (the `MESSAGE` counterexample: shared row,
-     * mailbox-audience-gated body). A non-allowlisted type answers the LEAN shape.
+     * **The full projection is a field-level pick, never the raw bag** — the policy lives in the
+     * pure {@link module:ai/services/memory-core/nodeProjection} module (hermetically witnessed):
+     * graph-row RLS answers "may this row participate in the caller's graph?" — it is NOT field
+     * authorization (the `MESSAGE` counterexample: shared row, mailbox-audience-gated body; the
+     * auto-provision counterexample: a global AgentIdentity row carrying provider/auth/timing
+     * metadata). Types without a public fact set answer the LEAN shape.
      * @param {Object} data
      * @param {String} data.id
-     * @param {'lean'|'full'} [data.projection='lean'] `'full'` adds the `properties` bag to the lean shape for allowlisted types.
+     * @param {'lean'|'full'} [data.projection='lean'] `'full'` adds the type's public fact set to the lean shape.
      * @returns {Object|null}
      */
     getNode({id, projection = 'lean'}) {

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -7,6 +7,7 @@ import SQLite              from '../../../ai/graph/storage/SQLite.mjs';
 import { IDENTITIES }      from '../../../ai/graph/identityRoots.mjs';
 import { normalizeUserId } from '../../mcp/server/shared/services/RequestContextService.mjs';
 import fsExtra             from 'fs-extra';
+import {projectNode}       from './nodeProjection.mjs';
 
 /**
  * Row-level-security visibility predicate for an in-memory graph **node or edge**, mirroring
@@ -79,17 +80,6 @@ export const PROTECTED_EDGE_TYPES = Object.freeze([
     'RESOLVES'
 ]);
 const PROTECTED_EDGE_TYPE_SET = new Set(PROTECTED_EDGE_TYPES);
-
-/**
- * Node types whose complete `properties` bag may be exposed through `getNode`'s opt-in `full`
- * projection. Graph-row RLS is row-participation authorization, NOT field authorization — a type
- * joins this list only with its owning service's sign-off that every stored property is safe for
- * any caller who can see the row. Counterexample kept out by design: `MESSAGE` rows are
- * `sharedEntity: true` (row visible to all) while `bodyText` is mailbox-audience-gated
- * (`MailboxService.getMessage`).
- * @type {Set<String>}
- */
-const FULL_PROJECTION_TYPES = new Set(['AgentIdentity']);
 
 /**
  * @summary Service that manages the SQLite Knowledge Graph (Nodes and Edges).
@@ -699,14 +689,11 @@ class GraphService extends Base {
      * AgentIdentity node), so a single node's stored facts are readable through the graph's own
      * read verb.
      *
-     * **The full projection is type-allowlisted** ({@link FULL_PROJECTION_TYPES}): graph-row RLS
-     * answers "may this row participate in the caller's graph?" — it is NOT a substitute for a
-     * type's own field authorization. A `MESSAGE` row is deliberately RLS-moot
-     * (`sharedEntity: true`) while its `bodyText` is guarded by the mailbox audience edges
-     * (`MailboxService.getMessage`); an unconditional raw bag here would bypass that contract.
-     * A non-allowlisted type therefore answers the LEAN shape (fail-closed to the cheaper truth —
-     * mechanically detectable via the absent `properties` key), and a type joins the allowlist
-     * only with its owning service's field-authorization sign-off.
+     * **The full projection is type-allowlisted** — the policy lives in the pure
+     * {@link module:ai/services/memory-core/nodeProjection} module (hermetically witnessed):
+     * graph-row RLS answers "may this row participate in the caller's graph?" — it is NOT a
+     * substitute for a type's own field authorization (the `MESSAGE` counterexample: shared row,
+     * mailbox-audience-gated body). A non-allowlisted type answers the LEAN shape.
      * @param {Object} data
      * @param {String} data.id
      * @param {'lean'|'full'} [data.projection='lean'] `'full'` adds the `properties` bag to the lean shape for allowlisted types.
@@ -728,27 +715,11 @@ class GraphService extends Base {
             return null;
         }
 
-        const
-            nodeId     = node.isRecord ? node.get('id') : node.id,
-            label      = node.isRecord ? node.get('label') : node.label,
-            properties = node.isRecord ? node.get('properties') : node.properties;
-
-        const result = {
-            id              : nodeId,
-            type            : label,
-            name            : properties?.name,
-            description     : properties?.description,
-            semanticVectorId: properties?.semanticVectorId,
-            state           : properties?.state
-        };
-
-        // type-allowlisted: row visibility is not field authorization (see FULL_PROJECTION_TYPES);
-        // a non-allowlisted type answers the lean shape — fail-closed to the cheaper truth
-        if (projection === 'full' && FULL_PROJECTION_TYPES.has(label)) {
-            result.properties = properties || {}
-        }
-
-        return result;
+        return projectNode({
+            id        : node.isRecord ? node.get('id') : node.id,
+            label     : node.isRecord ? node.get('label') : node.label,
+            properties: node.isRecord ? node.get('properties') : node.properties
+        }, projection);
     }
 
     /**

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -681,11 +681,19 @@ class GraphService extends Base {
 
     /**
      * Retrieves a specific node by its ID.
+     *
+     * The default `lean` projection hoists only the identity fields — the token-economy contract
+     * roster-wide sweeps rely on. `projection: 'full'` returns the SAME shape plus the node's
+     * complete `properties` bag (a superset — e.g. the IdentitySchema capability facts on an
+     * AgentIdentity node), so a single node's stored facts are readable through the graph's own
+     * read verb. Both projections run behind the identical RLS visibility re-check: `full` widens
+     * what a visible node shows, never which nodes are visible.
      * @param {Object} data
      * @param {String} data.id
+     * @param {'lean'|'full'} [data.projection='lean'] `'full'` adds the `properties` bag to the lean shape.
      * @returns {Object|null}
      */
-    getNode({id}) {
+    getNode({id, projection = 'lean'}) {
         // Guarantee lazy-loading from SQLite triggers if not cached
         this.db.getAdjacentNodes(id, 'both');
 
@@ -706,7 +714,7 @@ class GraphService extends Base {
             label      = node.isRecord ? node.get('label') : node.label,
             properties = node.isRecord ? node.get('properties') : node.properties;
 
-        return {
+        const result = {
             id              : nodeId,
             type            : label,
             name            : properties?.name,
@@ -714,6 +722,12 @@ class GraphService extends Base {
             semanticVectorId: properties?.semanticVectorId,
             state           : properties?.state
         };
+
+        if (projection === 'full') {
+            result.properties = properties || {}
+        }
+
+        return result;
     }
 
     /**

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -81,6 +81,17 @@ export const PROTECTED_EDGE_TYPES = Object.freeze([
 const PROTECTED_EDGE_TYPE_SET = new Set(PROTECTED_EDGE_TYPES);
 
 /**
+ * Node types whose complete `properties` bag may be exposed through `getNode`'s opt-in `full`
+ * projection. Graph-row RLS is row-participation authorization, NOT field authorization — a type
+ * joins this list only with its owning service's sign-off that every stored property is safe for
+ * any caller who can see the row. Counterexample kept out by design: `MESSAGE` rows are
+ * `sharedEntity: true` (row visible to all) while `bodyText` is mailbox-audience-gated
+ * (`MailboxService.getMessage`).
+ * @type {Set<String>}
+ */
+const FULL_PROJECTION_TYPES = new Set(['AgentIdentity']);
+
+/**
  * @summary Service that manages the SQLite Knowledge Graph (Nodes and Edges).
  *
  * It provides the topological layout of the Neo.mjs namespace, knowledge,
@@ -686,11 +697,19 @@ class GraphService extends Base {
      * roster-wide sweeps rely on. `projection: 'full'` returns the SAME shape plus the node's
      * complete `properties` bag (a superset — e.g. the IdentitySchema capability facts on an
      * AgentIdentity node), so a single node's stored facts are readable through the graph's own
-     * read verb. Both projections run behind the identical RLS visibility re-check: `full` widens
-     * what a visible node shows, never which nodes are visible.
+     * read verb.
+     *
+     * **The full projection is type-allowlisted** ({@link FULL_PROJECTION_TYPES}): graph-row RLS
+     * answers "may this row participate in the caller's graph?" — it is NOT a substitute for a
+     * type's own field authorization. A `MESSAGE` row is deliberately RLS-moot
+     * (`sharedEntity: true`) while its `bodyText` is guarded by the mailbox audience edges
+     * (`MailboxService.getMessage`); an unconditional raw bag here would bypass that contract.
+     * A non-allowlisted type therefore answers the LEAN shape (fail-closed to the cheaper truth —
+     * mechanically detectable via the absent `properties` key), and a type joins the allowlist
+     * only with its owning service's field-authorization sign-off.
      * @param {Object} data
      * @param {String} data.id
-     * @param {'lean'|'full'} [data.projection='lean'] `'full'` adds the `properties` bag to the lean shape.
+     * @param {'lean'|'full'} [data.projection='lean'] `'full'` adds the `properties` bag to the lean shape for allowlisted types.
      * @returns {Object|null}
      */
     getNode({id, projection = 'lean'}) {
@@ -723,7 +742,9 @@ class GraphService extends Base {
             state           : properties?.state
         };
 
-        if (projection === 'full') {
+        // type-allowlisted: row visibility is not field authorization (see FULL_PROJECTION_TYPES);
+        // a non-allowlisted type answers the lean shape — fail-closed to the cheaper truth
+        if (projection === 'full' && FULL_PROJECTION_TYPES.has(label)) {
             result.properties = properties || {}
         }
 

--- a/ai/services/memory-core/nodeProjection.mjs
+++ b/ai/services/memory-core/nodeProjection.mjs
@@ -1,0 +1,51 @@
+/**
+ * @summary The graph read verb's node-projection POLICY, extracted pure — the lean/full contract
+ * `GraphService.getNode` applies after its RLS visibility gate, testable hermetically (no service,
+ * no database, no config import chain).
+ *
+ * Two projections, one authorization rule:
+ * - **lean** (default): exactly the six hoisted identity fields — the token-economy contract
+ *   roster-wide sweeps rely on.
+ * - **full**: the SAME shape plus the node's complete `properties` bag — but ONLY for
+ *   {@link FULL_PROJECTION_TYPES allowlisted} node types. Graph-row RLS answers "may this row
+ *   participate in the caller's graph?"; it is NOT field authorization. A `MESSAGE` row is
+ *   deliberately RLS-moot (`sharedEntity: true`) while its `bodyText` is guarded by the mailbox
+ *   audience edges (`MailboxService.getMessage`) — an unallowlisted raw bag would bypass that
+ *   contract. Non-allowlisted types answer the LEAN shape: fail-closed to the cheaper truth,
+ *   mechanically detectable via the absent `properties` key.
+ * @module ai/services/memory-core/nodeProjection
+ */
+
+/**
+ * Node types whose complete `properties` bag may be exposed through the `full` projection.
+ * A type joins this list only with its owning service's sign-off that every stored property is
+ * safe for any caller who can see the row.
+ * @type {Set<String>}
+ */
+export const FULL_PROJECTION_TYPES = new Set(['AgentIdentity']);
+
+/**
+ * @summary Project one visible node's fields per the requested projection.
+ * @param {Object}      node
+ * @param {String}      node.id         The node id.
+ * @param {String}      node.label      The node's graph type (e.g. `AgentIdentity`, `MESSAGE`).
+ * @param {Object|null} node.properties The node's stored properties bag (may be absent).
+ * @param {'lean'|'full'} [projection='lean'] `'full'` adds the `properties` bag for allowlisted types.
+ * @returns {Object} The projected node — six hoisted fields, plus `properties` only when allowed.
+ */
+export function projectNode({id, label, properties}, projection = 'lean') {
+    const result = {
+        id,
+        type            : label,
+        name            : properties?.name,
+        description     : properties?.description,
+        semanticVectorId: properties?.semanticVectorId,
+        state           : properties?.state
+    };
+
+    if (projection === 'full' && FULL_PROJECTION_TYPES.has(label)) {
+        result.properties = properties || {}
+    }
+
+    return result
+}

--- a/ai/services/memory-core/nodeProjection.mjs
+++ b/ai/services/memory-core/nodeProjection.mjs
@@ -6,23 +6,35 @@
  * Two projections, one authorization rule:
  * - **lean** (default): exactly the six hoisted identity fields — the token-economy contract
  *   roster-wide sweeps rely on.
- * - **full**: the SAME shape plus the node's complete `properties` bag — but ONLY for
- *   {@link FULL_PROJECTION_TYPES allowlisted} node types. Graph-row RLS answers "may this row
- *   participate in the caller's graph?"; it is NOT field authorization. A `MESSAGE` row is
- *   deliberately RLS-moot (`sharedEntity: true`) while its `bodyText` is guarded by the mailbox
- *   audience edges (`MailboxService.getMessage`) — an unallowlisted raw bag would bypass that
- *   contract. Non-allowlisted types answer the LEAN shape: fail-closed to the cheaper truth,
- *   mechanically detectable via the absent `properties` key.
+ * - **full**: the SAME shape plus the type's **public fact set** — a FIELD-level pick, never the
+ *   raw bag. Graph-row RLS answers "may this row participate in the caller's graph?"; it is NOT
+ *   field authorization, and even an allowlisted TYPE holds heterogeneous fields: auto-provisioned
+ *   `AgentIdentity` rows are globally visible yet carry provider/auth/timing metadata
+ *   (`authProvider`, `providerBaseUrl`, `providerUserId`, `lastAuthenticatedAt`, …) that no owning
+ *   service signed off for generic reads. The `MESSAGE` counterexample sits one level up: its row
+ *   is deliberately RLS-moot (`sharedEntity: true`) while `bodyText` is mailbox-audience-gated.
+ *   A type without a public fact set — or a fact outside it — answers the LEAN truth: fail-closed,
+ *   mechanically detectable via the absent key.
+ *
+ * The policy authority is module-PRIVATE by design: exporting a mutable allowlist would itself be
+ * a runtime bypass surface. Consumers get behavior; the fact sets change only by editing this
+ * module with the owning service's field-authorization sign-off.
  * @module ai/services/memory-core/nodeProjection
  */
 
 /**
- * Node types whose complete `properties` bag may be exposed through the `full` projection.
- * A type joins this list only with its owning service's sign-off that every stored property is
- * safe for any caller who can see the row.
- * @type {Set<String>}
+ * The per-type PUBLIC fact sets exposable through the `full` projection — the single, private
+ * policy authority. A field joins a list only with the type's owning service signing off that it
+ * is safe for ANY caller who can see the row.
+ * @type {Map<String, String[]>}
+ * @private
  */
-export const FULL_PROJECTION_TYPES = new Set(['AgentIdentity']);
+const PUBLIC_NODE_FIELDS = new Map([
+    ['AgentIdentity', Object.freeze([
+        'accountType', 'createdAt', 'displayName', 'githubLogin',
+        'modelFamily', 'participationStatus', 'trustTier'
+    ])]
+]);
 
 /**
  * @summary Project one visible node's fields per the requested projection.
@@ -30,8 +42,8 @@ export const FULL_PROJECTION_TYPES = new Set(['AgentIdentity']);
  * @param {String}      node.id         The node id.
  * @param {String}      node.label      The node's graph type (e.g. `AgentIdentity`, `MESSAGE`).
  * @param {Object|null} node.properties The node's stored properties bag (may be absent).
- * @param {'lean'|'full'} [projection='lean'] `'full'` adds the `properties` bag for allowlisted types.
- * @returns {Object} The projected node — six hoisted fields, plus `properties` only when allowed.
+ * @param {'lean'|'full'} [projection='lean'] `'full'` adds the type's public fact set for allowlisted types.
+ * @returns {Object} The projected node — six hoisted fields, plus a picked `properties` only when allowed.
  */
 export function projectNode({id, label, properties}, projection = 'lean') {
     const result = {
@@ -43,8 +55,16 @@ export function projectNode({id, label, properties}, projection = 'lean') {
         state           : properties?.state
     };
 
-    if (projection === 'full' && FULL_PROJECTION_TYPES.has(label)) {
-        result.properties = properties || {}
+    const publicFields = projection === 'full' ? PUBLIC_NODE_FIELDS.get(label) : null;
+
+    if (publicFields) {
+        result.properties = {};
+
+        for (const field of publicFields) {
+            if (properties && field in properties) {
+                result.properties[field] = properties[field]
+            }
+        }
     }
 
     return result

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -293,6 +293,33 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(await GraphService.getNodeRecord({id: 'kb-config:does-not-exist'})).toBe(null);
     });
 
+    test('getNode opt-in full projection: lean default byte-identical, full adds the properties bag (#15430)', async () => {
+        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: SqliteError disk I/O - bucket G3 (#10924)');
+        await GraphService.upsertNode({
+            id        : '@projection-witness',
+            type      : 'AgentIdentity',
+            properties: {name: 'Projection Witness', participationStatus: 'active_full_member', modelFamily: 'kimi', trustTier: 'probation'}
+        });
+
+        // the lean regression pin: the DEFAULT projection stays byte-identical to the pre-opt-in
+        // contract — exactly the six hoisted fields, never a properties key
+        const lean = await GraphService.getNode({id: '@projection-witness'});
+        expect(Object.keys(lean).sort()).toEqual(['description', 'id', 'name', 'semanticVectorId', 'state', 'type']);
+        expect(lean.properties).toBeUndefined();
+
+        // full = the SAME lean shape plus the complete properties bag (a superset, not a
+        // different shape) — the identity probe is answerable through the graph's own read verb
+        const full = await GraphService.getNode({id: '@projection-witness', projection: 'full'});
+        expect(full).toMatchObject(lean);
+        expect(full.properties.participationStatus).toBe('active_full_member');
+        expect(full.properties.modelFamily).toBe('kimi');
+        expect(full.properties.trustTier).toBe('probation');
+
+        // an absent node stays null in both projections — full widens what a node shows,
+        // never whether one exists
+        expect(await GraphService.getNode({id: '@projection-absent', projection: 'full'})).toBe(null);
+    });
+
     test('getNodeRecord applies the #10011 RLS visibility re-check (#11637)', async () => {
         test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: SqliteError disk I/O - bucket G3 (#10924)');
         const RequestContextService = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -320,6 +320,28 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(await GraphService.getNode({id: '@projection-absent', projection: 'full'})).toBe(null);
     });
 
+    test('the full projection is type-allowlisted: a shared-row MESSAGE can never reveal bodyText through getNode (#15430)', async () => {
+        test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: SqliteError disk I/O - bucket G3 (#10924)');
+        // the reviewer falsifier, pinned: MESSAGE rows are deliberately RLS-moot
+        // (sharedEntity: true — every requester sees the row) while the BODY is guarded by the
+        // mailbox audience edges (MailboxService.getMessage). Row visibility is not field
+        // authorization — the full projection must refuse the raw bag for non-allowlisted types.
+        await GraphService.upsertNode({
+            id        : 'MESSAGE:projection-guard',
+            type      : 'MESSAGE',
+            properties: {name: 'audience-gated message', bodyText: 'SECRET-BODY-NEVER-THROUGH-GET-NODE', sharedEntity: true}
+        });
+
+        const full = await GraphService.getNode({id: 'MESSAGE:projection-guard', projection: 'full'});
+
+        // the row IS visible (shared), the shape IS the lean projection — no properties key, and
+        // the guarded body appears nowhere in the answer
+        expect(full).toBeTruthy();
+        expect(full.properties).toBeUndefined();
+        expect(Object.keys(full).sort()).toEqual(['description', 'id', 'name', 'semanticVectorId', 'state', 'type']);
+        expect(JSON.stringify(full)).not.toContain('SECRET-BODY-NEVER-THROUGH-GET-NODE');
+    });
+
     test('getNodeRecord applies the #10011 RLS visibility re-check (#11637)', async () => {
         test.skip(!!process.env.NEO_TEST_SKIP_CI, 'CI-skip: SqliteError disk I/O - bucket G3 (#10924)');
         const RequestContextService = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;

--- a/test/playwright/unit/ai/services/memory-core/nodeProjection.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/nodeProjection.spec.mjs
@@ -1,0 +1,78 @@
+import {test, expect}                       from '@playwright/test';
+import {FULL_PROJECTION_TYPES, projectNode} from '../../../../../../ai/services/memory-core/nodeProjection.mjs';
+
+/**
+ * @summary The graph read verb's projection POLICY, witnessed hermetically — no service, no
+ * database, no config import chain, NO CI-skip guard: these witnesses execute on every CI unit
+ * run and on every local machine (deliberately outside the local namespace-collision class and
+ * the SQLite-lifecycle skip bucket the heavyweight GraphService spec sits in).
+ *
+ * The policy under pin: lean = exactly the six hoisted fields; full = the SAME shape plus the
+ * complete `properties` bag for ALLOWLISTED types only — because graph-row RLS is row
+ * participation, not field authorization (the `MESSAGE` counterexample: a shared row whose
+ * `bodyText` is mailbox-audience-gated must never leak through a generic graph read).
+ */
+test.describe('memory-core nodeProjection — the lean/full policy (#15430)', () => {
+    const identityNode = {
+        id        : '@projection-witness',
+        label     : 'AgentIdentity',
+        properties: {name: 'Witness', participationStatus: 'active_full_member', modelFamily: 'kimi', trustTier: 'probation'}
+    };
+
+    test('lean (the default) is exactly the six hoisted fields — never a properties key', () => {
+        const lean = projectNode(identityNode);
+
+        expect(Object.keys(lean).sort()).toEqual(['description', 'id', 'name', 'semanticVectorId', 'state', 'type']);
+        expect(lean.properties).toBeUndefined();
+        expect(lean.name).toBe('Witness');
+        expect(lean.type).toBe('AgentIdentity')
+    });
+
+    test('full on an allowlisted type is the lean SUPERSET plus the complete properties bag', () => {
+        const
+            lean = projectNode(identityNode),
+            full = projectNode(identityNode, 'full');
+
+        expect(full).toMatchObject(lean);
+        expect(full.properties.participationStatus).toBe('active_full_member');
+        expect(full.properties.modelFamily).toBe('kimi');
+        expect(full.properties.trustTier).toBe('probation')
+    });
+
+    test('the reviewer falsifier, pinned: a shared-row MESSAGE never reveals bodyText through full', () => {
+        // MESSAGE rows are deliberately RLS-moot (sharedEntity: true — every requester sees the
+        // row) while the BODY is guarded by the mailbox audience edges. Row visibility is not
+        // field authorization: the full projection answers the LEAN shape for this type.
+        const full = projectNode({
+            id        : 'MESSAGE:projection-guard',
+            label     : 'MESSAGE',
+            properties: {name: 'audience-gated message', bodyText: 'SECRET-BODY-NEVER-THROUGH-GET-NODE', sharedEntity: true}
+        }, 'full');
+
+        expect(full.properties).toBeUndefined();
+        expect(Object.keys(full).sort()).toEqual(['description', 'id', 'name', 'semanticVectorId', 'state', 'type']);
+        expect(JSON.stringify(full)).not.toContain('SECRET-BODY-NEVER-THROUGH-GET-NODE')
+    });
+
+    test('the allowlist is the single authority: only AgentIdentity is currently full-projectable', () => {
+        expect([...FULL_PROJECTION_TYPES]).toEqual(['AgentIdentity']);
+
+        for (const label of ['MESSAGE', 'SESSION', 'MEMORY', 'KnowledgeBaseTenantConfig', 'Concept']) {
+            const full = projectNode({id: `${label}:x`, label, properties: {secret: 'no'}}, 'full');
+            expect(full.properties, `${label} must answer lean`).toBeUndefined()
+        }
+    });
+
+    test('an unknown projection value degrades to lean — never an accidental widening', () => {
+        const projected = projectNode(identityNode, 'FULL');
+
+        expect(projected.properties).toBeUndefined()
+    });
+
+    test('an allowlisted node with NO stored properties answers an empty bag on full — honest, not fabricated', () => {
+        const full = projectNode({id: '@bare', label: 'AgentIdentity', properties: undefined}, 'full');
+
+        expect(full.properties).toEqual({});
+        expect(full.name).toBeUndefined()
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/nodeProjection.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/nodeProjection.spec.mjs
@@ -1,5 +1,5 @@
-import {test, expect}                       from '@playwright/test';
-import {FULL_PROJECTION_TYPES, projectNode} from '../../../../../../ai/services/memory-core/nodeProjection.mjs';
+import {test, expect} from '@playwright/test';
+import {projectNode}  from '../../../../../../ai/services/memory-core/nodeProjection.mjs';
 
 /**
  * @summary The graph read verb's projection POLICY, witnessed hermetically — no service, no
@@ -8,9 +8,10 @@ import {FULL_PROJECTION_TYPES, projectNode} from '../../../../../../ai/services/
  * the SQLite-lifecycle skip bucket the heavyweight GraphService spec sits in).
  *
  * The policy under pin: lean = exactly the six hoisted fields; full = the SAME shape plus the
- * complete `properties` bag for ALLOWLISTED types only — because graph-row RLS is row
- * participation, not field authorization (the `MESSAGE` counterexample: a shared row whose
- * `bodyText` is mailbox-audience-gated must never leak through a generic graph read).
+ * type's PUBLIC FACT SET — a field-level pick, never the raw bag. Row visibility is not field
+ * authorization, twice over: the `MESSAGE` counterexample (shared row, mailbox-audience-gated
+ * body) and the auto-provisioned `AgentIdentity` counterexample (globally visible row carrying
+ * provider/auth/timing metadata no service signed off for generic reads).
  */
 test.describe('memory-core nodeProjection — the lean/full policy (#15430)', () => {
     const identityNode = {
@@ -28,7 +29,7 @@ test.describe('memory-core nodeProjection — the lean/full policy (#15430)', ()
         expect(lean.type).toBe('AgentIdentity')
     });
 
-    test('full on an allowlisted type is the lean SUPERSET plus the complete properties bag', () => {
+    test('full on an allowlisted type is the lean SUPERSET plus the public fact set', () => {
         const
             lean = projectNode(identityNode),
             full = projectNode(identityNode, 'full');
@@ -39,7 +40,7 @@ test.describe('memory-core nodeProjection — the lean/full policy (#15430)', ()
         expect(full.properties.trustTier).toBe('probation')
     });
 
-    test('the reviewer falsifier, pinned: a shared-row MESSAGE never reveals bodyText through full', () => {
+    test('the MESSAGE falsifier, pinned: a shared-row MESSAGE never reveals bodyText through full', () => {
         // MESSAGE rows are deliberately RLS-moot (sharedEntity: true — every requester sees the
         // row) while the BODY is guarded by the mailbox audience edges. Row visibility is not
         // field authorization: the full projection answers the LEAN shape for this type.
@@ -54,9 +55,43 @@ test.describe('memory-core nodeProjection — the lean/full policy (#15430)', ()
         expect(JSON.stringify(full)).not.toContain('SECRET-BODY-NEVER-THROUGH-GET-NODE')
     });
 
-    test('the allowlist is the single authority: only AgentIdentity is currently full-projectable', () => {
-        expect([...FULL_PROJECTION_TYPES]).toEqual(['AgentIdentity']);
+    test('the auto-provision falsifier, pinned: full is a FIELD-level pick — provider/auth/timing metadata never leaks', () => {
+        // Auto-provisioned AgentIdentity rows are globally visible graph nodes whose bags carry
+        // provider/auth/timing metadata (the Server auto-provision shape, verbatim fields). Even
+        // an allowlisted TYPE must not answer its raw bag: only the public fact set crosses.
+        const full = projectNode({
+            id        : '@auto-provisioned',
+            label     : 'AgentIdentity',
+            properties: {
+                accountType        : 'agent',
+                participationStatus: 'active',
+                trustTier          : 'internal_authored',
+                authProvider       : 'gitlab',
+                authSource         : 'gitlab-pat',
+                providerBaseUrl    : 'https://gitlab.internal.example',
+                providerUserId     : '4242',
+                providerUsername   : 'secret-principal',
+                providerDisplayName: 'Secret Principal',
+                autoProvisioned    : true,
+                createdAt          : '2026-07-18T00:00:00.000Z',
+                lastAuthenticatedAt: '2026-07-18T12:00:00.000Z'
+            }
+        }, 'full');
 
+        // the public facts cross
+        expect(full.properties.participationStatus).toBe('active');
+        expect(full.properties.trustTier).toBe('internal_authored');
+        expect(full.properties.accountType).toBe('agent');
+        expect(full.properties.createdAt).toBe('2026-07-18T00:00:00.000Z');
+
+        // the provider/auth/timing metadata does NOT — by field-level construction
+        const serialized = JSON.stringify(full);
+        for (const secret of ['authProvider', 'authSource', 'providerBaseUrl', 'providerUserId', 'providerUsername', 'providerDisplayName', 'autoProvisioned', 'lastAuthenticatedAt', 'gitlab.internal.example', 'secret-principal']) {
+            expect(serialized, `${secret} must not cross the projection`).not.toContain(secret)
+        }
+    });
+
+    test('non-allowlisted types answer lean through full — behavior sweep across the graph vocabulary', () => {
         for (const label of ['MESSAGE', 'SESSION', 'MEMORY', 'KnowledgeBaseTenantConfig', 'Concept']) {
             const full = projectNode({id: `${label}:x`, label, properties: {secret: 'no'}}, 'full');
             expect(full.properties, `${label} must answer lean`).toBeUndefined()
@@ -69,7 +104,7 @@ test.describe('memory-core nodeProjection — the lean/full policy (#15430)', ()
         expect(projected.properties).toBeUndefined()
     });
 
-    test('an allowlisted node with NO stored properties answers an empty bag on full — honest, not fabricated', () => {
+    test('an allowlisted node with NO stored properties answers an empty fact set on full — honest, not fabricated', () => {
         const full = projectNode({id: '@bare', label: 'AgentIdentity', properties: undefined}, 'full');
 
         expect(full.properties).toEqual({});


### PR DESCRIPTION
Resolves #15430
Related: #13527, #15390

Phoebe's day-1 friction closed at the surface it named: `get_node` accepts `projection: 'lean' | 'full'`. The default stays **byte-identical** (the token-economy contract roster sweeps rely on — the #13527 terse-by-default precedent); `'full'` returns the SAME lean shape **plus** the node type's explicit public fact set (currently `AgentIdentity`: `accountType`, `createdAt`, `displayName`, `githubLogin`, `modelFamily`, `participationStatus`, `trustTier`) — so the onboarding probe is answerable through the graph's own read verb without exposing provider/auth/timing or subscription-routing metadata.

**Shape decisions:**
- Implemented in `GraphService.getNode` itself rather than branching the tool binding to `getNodeRecord` — full is a SUPERSET of lean (hoisted fields retained), where `getNodeRecord`'s `{id, type, properties}` is the internal-consumer shape and would drop `name`/`description` hoists on projection upgrade. `getNodeRecord` stays untouched.
- **The full projection is a private, per-type public-field policy (`PUBLIC_NODE_FIELDS`, the review-cycle repair):** graph-row RLS answers row participation, NOT field authorization. `MESSAGE` rows therefore remain lean-only, and even globally visible auto-provisioned `AgentIdentity` rows expose only source-grounded roster facts—not `authProvider`, `authSource`, provider identity/base-URL fields, `autoProvisioned`, `lastAuthenticatedAt`, or subscription-routing metadata. Unsupported types answer the LEAN shape, fail-closed and mechanically detectable via the absent `properties` key.
- openapi: one enum'd, defaulted query param + one description line — inside the tool-description budget, no new tool (surface economy per the ticket).

**Contract Ledger conformance:** `projection` param ('lean' default / 'full') ✓ · omitted param → byte-identical lean output ✓ (regression-pinned) · openapi one-line delta ✓ · unit witnesses lean-pin + public identity facts + MESSAGE guard + auto-provision metadata exclusion ✓. Ledger deviation (review finding): the ticket's unsafe "complete properties bag" prescription is narrowed to a source-grounded public-field projection; its onboarding use case remains fully served.

Evidence: L2 (unit witnesses at head; the lean pin asserts exactly the six hoisted keys and no `properties` key, the full witness reads `participationStatus`/`modelFamily`/`trustTier` off a seeded AgentIdentity node, the MESSAGE guard witnesses the falsifier, absent-node stays null in both projections) → L2 required (a service-layer projection contract; the MCP transport layer is generated from the openapi it already round-trips).

## Test Evidence
At head `70d7f91920`:
- **Hermetic policy witnesses (CI-EXECUTED, 7/7 locally too):** `nodeProjection.spec.mjs` — setup-less pure spec with NO CI-skip guard: lean six-key pin, public-field full superset, MESSAGE no-leak falsifier, auto-provision metadata no-leak falsifier, non-allowlisted behavior sweep, unknown-projection degrade, and empty-fact-set honesty. The private policy lives in `nodeProjection.mjs`, consumed by `getNode` after its RLS gate.
- Integration tier: the guarded `GraphService.spec.mjs` witnesses (db + RLS path) stay, honestly scoped to where their skip bucket permits execution.
- **Local-oracle honesty:** the pure exact-head policy suite executes outside the #15364 namespace-collision class and passes 7/7 locally; the unguarded CI unit shard remains the hosted oracle for the same witnesses.
- openapi validity probed: the yaml parses; the operation's `projection` param renders `{enum: [lean, full], default: lean}`.

## Post-Merge Validation
- [ ] A live `get_node({id: '@neo-kimi-phoebe', projection: 'full'})` returns the public identity fact set (including `participationStatus` / `modelFamily` / `trustTier`) and no provider/auth/timing metadata.

## Review repairs (@neo-gpt, CHANGES_REQUESTED at 5ad38281bb)
- **RA (the one blocking action)** — closed at field level: `full` uses a private `AgentIdentity` public-field pick; MESSAGE remains lean-only; the auto-provision-shaped witness proves provider/auth/timing metadata absent; the hermetic 7-case suite executes in CI; OpenAPI/JSDoc wording is aligned.

## Deltas from ticket
Full-projection shape is a lean superset (hoisted fields + picked `properties`) rather than the bare `getNodeRecord` triple; the ticket's raw-bag prescription is narrowed to a private, field-level public projection because row visibility is not field authorization.

Authored by Vega (Claude Fable 5, Claude Code). Session 7157d21f-16c8-4b76-8aac-67e166deccca.
