### PR TITLE
feat(dashboard): G3 claim arbitration — deterministic gesture claims, workspace-set registry, continuous native preview (#15246)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -13,6 +13,7 @@ import DockTopologyReconciler             from '../../../../../src/dashboard/Doc
 import DockZoneModel                      from '../../../../../src/dashboard/DockZoneModel.mjs';
 import InteractionService                 from '../../../../../src/ai/client/InteractionService.mjs';
 import {createDockTearOutHandlers}        from '../../../../../src/dashboard/DockTearOut.mjs';
+import {createDockWorkspaceSet}           from '../../../../../src/dashboard/DockWorkspaceSet.mjs';
 import TourRunner                         from '../../../../../src/ai/client/TourRunner.mjs';
 import {previewToOperation}               from '../../../../../src/dashboard/dockPreviewContract.mjs';
 import {demoBTourScript, initialDocument} from '../../../tour/demoBPerspectives.mjs';
@@ -107,6 +108,13 @@ class DemoBWorkspace extends Container {
      * @member {Object|null} popupDocument=null
      */
     popupDocument = null
+    /**
+     * The worker-owned `{workspaceId → document}` registry (§2.1 workspace-set composition):
+     * both workspaces register their document accessors here, foreign-document resolution rides
+     * it, and an atomic transfer's committed pair lands through its both-or-neither adoption.
+     * @member {Object|null} workspaceSet=null
+     */
+    workspaceSet = null
     /**
      * The app-side Neural Link dock seam (tour + agent drivability).
      * @member {Neo.ai.client.DockService|null} dockService=null
@@ -283,6 +291,21 @@ class DemoBWorkspace extends Container {
 
         me.dockModel        = DockZoneModel.clone(initialDocument);
         me.popupDocument    = DemoBWorkspace.createPopupDocument();
+
+        // Both workspaces register under their STABLE semantic ids — the seams read/write the
+        // live owner fields, so registry resolution always answers with committed truth.
+        me.workspaceSet = createDockWorkspaceSet();
+
+        me.workspaceSet.register(DemoBWorkspace.MAIN_WORKSPACE_ID, {
+            getDocument: () => me.dockModel,
+            setDocument: document => me.dockModel = document
+        });
+
+        me.workspaceSet.register(DemoBWorkspace.POPUP_WORKSPACE_ID, {
+            getDocument: () => me.popupDocument,
+            setDocument: document => me.popupDocument = document
+        });
+
         me.dockPreviewProducer = Neo.create(DockPreviewProducer);
         me.dockService      = Neo.create(DockService, {});
         me.interactionService = Neo.create(InteractionService, {});
@@ -367,20 +390,13 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * Resolves worker-owned document truth by semantic workspace id.
+     * Resolves worker-owned document truth by semantic workspace id — through the workspace-set
+     * registry, so an unknown id fails closed instead of guessing.
      * @param {String} workspaceId
      * @returns {Object|null}
      */
     getWorkspaceDocument(workspaceId) {
-        if (workspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID) {
-            return this.dockModel
-        }
-
-        if (workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID) {
-            return this.popupDocument
-        }
-
-        return null
+        return this.workspaceSet.getDocument(workspaceId)
     }
 
     /**
@@ -962,12 +978,12 @@ class DemoBWorkspace extends Container {
 
         me.crossWindowStats.transferCommits++;
 
-        sourceWorkspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID
-            ? (me.dockModel = sourceDocument)
-            : (me.popupDocument = sourceDocument);
-        targetWorkspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID
-            ? (me.dockModel = targetDocument)
-            : (me.popupDocument = targetDocument);
+        // Both-or-neither adoption through the workspace-set: a pair that cannot land on both
+        // registered owners lands on neither, and the vessel bookkeeping below must not diverge
+        // from document truth — so a refused adoption ends the commit here.
+        if (!me.workspaceSet.adoptTransfer({sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId})) {
+            return
+        }
 
         // The document pair and vessel ownership are one worker-side commit. A physical close can
         // arrive before either projection settles; publishing this entry synchronously lets the

--- a/src/dashboard/CrossWindowDragTarget.mjs
+++ b/src/dashboard/CrossWindowDragTarget.mjs
@@ -91,6 +91,14 @@ class CrossWindowDragTarget extends Base {
          */
         sortGroup: null,
         /**
+         * §2.8.1 claim identity: the STABLE workspace/zone identity this target claims gestures
+         * under — never `windowId`, never registration order. A target that declares one rides
+         * the coordinator's deterministic claim protocol; without it the target stays on the
+         * legacy first-intersecting resolution. Dock workspaces pass their workspace id.
+         * @member {String|null} stableTargetId=null
+         */
+        stableTargetId: null,
+        /**
          * §2.3 registry identity: the window this surface renders in.
          * @member {String|Number|null} windowId=null
          */

--- a/src/dashboard/DockCrossWindowParticipation.mjs
+++ b/src/dashboard/DockCrossWindowParticipation.mjs
@@ -154,7 +154,10 @@ class DockCrossWindowParticipation extends Base {
             previewFor        : me.previewFor,
             previewToOperation: me.previewToOperation,
             sortGroup         : me.sortGroup,
-            windowId          : me.windowId
+            // the workspace id IS the §2.8.1 stable claim identity: it survives re-registration
+            // and never encodes windowId or registration order
+            stableTargetId: me.workspaceId,
+            windowId      : me.windowId
         })
     }
 

--- a/src/dashboard/DockWorkspaceSet.mjs
+++ b/src/dashboard/DockWorkspaceSet.mjs
@@ -48,11 +48,20 @@ export function createDockWorkspaceSet() {
         /**
          * Adopts an atomically-committed document pair into both owning entries — or neither.
          * Fail-closed preconditions, all checked BEFORE the first write: distinct source and
-         * target ids, both entries registered, both writable. Both-or-neither also holds against
-         * a THROWING writer: a target writer that throws after the source adopted rolls the
-         * source back to its pre-call document before the error propagates — the owner's error
-         * stays observable, the ownership state never splits. (A writer that ALSO throws during
-         * that rollback has broken its accessor contract twice; that error propagates as-is.)
+         * target ids, both entries registered, both writable.
+         *
+         * Both-or-neither against THROWING writers holds by two-sided compensation: BOTH previous
+         * documents are captured before the first write, and either write failing compensates
+         * every writer already invoked — in reverse order, each re-invoked with its prior
+         * document under a guard. The compensation is deliberately re-invocation: a writer that
+         * BREACHES its accessor contract by mutating before it throws is restored by the same
+         * assignment landing again with the prior document (the breach's own mutation ordering
+         * is what makes the compensation stick), while a writer that throws without mutating
+         * makes the compensating call a guarded no-op. The original error always propagates —
+         * the owner's failure stays observable. Residual, stated: a writer that defeats BOTH
+         * the write and the compensating re-invocation (throwing before any mutation on both
+         * calls while still having mutated externally) has broken its accessor contract twice;
+         * its own state is its breach, and the pair's other side is still restored.
          * @param {Object} data
          * @param {Object} data.sourceDocument
          * @param {String} data.sourceWorkspaceId
@@ -73,14 +82,31 @@ export function createDockWorkspaceSet() {
                 return false
             }
 
-            const previousSourceDocument = source.getDocument();
+            const
+                previousSourceDocument = source.getDocument(),
+                previousTargetDocument = target.getDocument(),
+                compensate             = (entry, document) => {
+                    try {
+                        entry.setDocument(document)
+                    } catch (compensationError) {
+                        // best-effort by construction: the original failure below still
+                        // propagates, and a writer failing its own compensation is the
+                        // documented double-breach residual
+                    }
+                };
 
-            source.setDocument(sourceDocument);
+            try {
+                source.setDocument(sourceDocument)
+            } catch (error) {
+                compensate(source, previousSourceDocument);
+                throw error
+            }
 
             try {
                 target.setDocument(targetDocument)
             } catch (error) {
-                source.setDocument(previousSourceDocument);
+                compensate(target, previousTargetDocument);
+                compensate(source, previousSourceDocument);
                 throw error
             }
 

--- a/src/dashboard/DockWorkspaceSet.mjs
+++ b/src/dashboard/DockWorkspaceSet.mjs
@@ -1,0 +1,135 @@
+/**
+ * @summary Pure worker-owned workspace-set registry — the `{workspaceId → document}` composition
+ * of the harness docking design record (§2.1 workspace topology; §2.8.3 vessel lifecycle;
+ * `learn/agentos/decisions/0029-harness-docking-design.md`).
+ *
+ * A workspace is one dock-zone document owned by one workspace container; multi-window
+ * composition registers each vessel's document under a STABLE workspace id. This registry is that
+ * composition's single source of resolution: cross-window participations resolve foreign
+ * documents through it, and an atomic transfer's committed pair is adopted through it —
+ * both-or-neither, mirroring the executor's commit-or-neither contract at the ownership tier.
+ *
+ * Boundary discipline (the §2.1 state-class table, binding):
+ * - **Worker-owned shared truth only.** Entries carry document accessors keyed by semantic
+ *   workspace identity. `windowId`, screen geometry, and projection state NEVER enter this
+ *   registry — a window is a render target, not a state owner, and runtime window identity is
+ *   never persisted workspace identity.
+ * - **Retirement is an explicit owner decision.** Closing a vessel unbinds a render target; it
+ *   does not delete worker documents — so this registry never auto-retires an entry. Whether an
+ *   emptied workspace-set entry is retained or retired is decided and named separately by the
+ *   reintegration tier (§2.8.3).
+ * - **Projection choreography stays with the owner.** The registry answers "whose document, and
+ *   what is it now" — reconcile ordering, generation guards, and render-target sync remain the
+ *   workspace container's own contract.
+ *
+ * Dependency-free by design — closure state, injected accessor seams — so witnesses drive the
+ * full registry contract without a browser or a model import.
+ */
+
+/**
+ * Creates one worker-owned workspace-set registry.
+ * @returns {Object} workspaceSet
+ * @returns {Function} workspaceSet.adoptTransfer  `({sourceWorkspaceId, sourceDocument, targetWorkspaceId, targetDocument})` both-or-neither pair adoption; Boolean.
+ * @returns {Function} workspaceSet.getDocument    `(workspaceId)` → the entry's current document, or `null` (fail closed).
+ * @returns {Function} workspaceSet.has            `(workspaceId)` → Boolean.
+ * @returns {Function} workspaceSet.ids            `()` → registered workspace ids.
+ * @returns {Function} workspaceSet.register       `(workspaceId, {getDocument, setDocument})` registers-or-replaces an entry; Boolean.
+ * @returns {Number}   workspaceSet.size           Registered entry count.
+ * @returns {Function} workspaceSet.unregister     `(workspaceId)` explicit retirement; Boolean.
+ */
+export function createDockWorkspaceSet() {
+    const entries = new Map();
+
+    return {
+        get size() {
+            return entries.size
+        },
+
+        /**
+         * Adopts an atomically-committed document pair into both owning entries — or neither.
+         * Fail-closed preconditions, all checked BEFORE the first write: distinct source and
+         * target ids, both entries registered, both writable. A pair that cannot land whole
+         * does not land at all — the executor's commit-or-neither contract, kept at the
+         * ownership tier.
+         * @param {Object} data
+         * @param {Object} data.sourceDocument
+         * @param {String} data.sourceWorkspaceId
+         * @param {Object} data.targetDocument
+         * @param {String} data.targetWorkspaceId
+         * @returns {Boolean} true when both documents were adopted
+         */
+        adoptTransfer({sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId}) {
+            const
+                source = entries.get(sourceWorkspaceId),
+                target = entries.get(targetWorkspaceId);
+
+            if (
+                sourceWorkspaceId === targetWorkspaceId ||
+                !sourceDocument || !targetDocument      ||
+                !source?.setDocument || !target?.setDocument
+            ) {
+                return false
+            }
+
+            source.setDocument(sourceDocument);
+            target.setDocument(targetDocument);
+            return true
+        },
+
+        /**
+         * @param {String} workspaceId
+         * @returns {Object|null} the entry's current document, or null (fail closed)
+         */
+        getDocument(workspaceId) {
+            return entries.get(workspaceId)?.getDocument() ?? null
+        },
+
+        /**
+         * @param {String} workspaceId
+         * @returns {Boolean}
+         */
+        has(workspaceId) {
+            return entries.has(workspaceId)
+        },
+
+        /**
+         * @returns {String[]}
+         */
+        ids() {
+            return [...entries.keys()]
+        },
+
+        /**
+         * Registers-or-replaces one workspace entry. Replacement is deliberate: a re-embodied
+         * vessel re-registers the SAME stable workspace id with fresh accessor seams, and the
+         * stale seams must not survive it.
+         * @param {String} workspaceId Stable semantic identity — never a `windowId`.
+         * @param {Object} seams
+         * @param {Function} seams.getDocument `()` → the workspace's current committed document.
+         * @param {Function} [seams.setDocument] `(document)` adopts a committed document; an
+         *     entry without one is read-only to `adoptTransfer` (fail closed).
+         * @returns {Boolean} true when registered
+         */
+        register(workspaceId, {getDocument, setDocument} = {}) {
+            if (!workspaceId || typeof workspaceId !== 'string' || typeof getDocument !== 'function') {
+                return false
+            }
+
+            entries.set(workspaceId, {
+                getDocument,
+                setDocument: typeof setDocument === 'function' ? setDocument : null
+            });
+            return true
+        },
+
+        /**
+         * Explicit entry retirement — never invoked by the registry itself (see the class
+         * summary's vessel-lifecycle boundary).
+         * @param {String} workspaceId
+         * @returns {Boolean} true when an entry was removed
+         */
+        unregister(workspaceId) {
+            return entries.delete(workspaceId)
+        }
+    }
+}

--- a/src/dashboard/DockWorkspaceSet.mjs
+++ b/src/dashboard/DockWorkspaceSet.mjs
@@ -48,9 +48,11 @@ export function createDockWorkspaceSet() {
         /**
          * Adopts an atomically-committed document pair into both owning entries — or neither.
          * Fail-closed preconditions, all checked BEFORE the first write: distinct source and
-         * target ids, both entries registered, both writable. A pair that cannot land whole
-         * does not land at all — the executor's commit-or-neither contract, kept at the
-         * ownership tier.
+         * target ids, both entries registered, both writable. Both-or-neither also holds against
+         * a THROWING writer: a target writer that throws after the source adopted rolls the
+         * source back to its pre-call document before the error propagates — the owner's error
+         * stays observable, the ownership state never splits. (A writer that ALSO throws during
+         * that rollback has broken its accessor contract twice; that error propagates as-is.)
          * @param {Object} data
          * @param {Object} data.sourceDocument
          * @param {String} data.sourceWorkspaceId
@@ -71,8 +73,17 @@ export function createDockWorkspaceSet() {
                 return false
             }
 
+            const previousSourceDocument = source.getDocument();
+
             source.setDocument(sourceDocument);
-            target.setDocument(targetDocument);
+
+            try {
+                target.setDocument(targetDocument)
+            } catch (error) {
+                source.setDocument(previousSourceDocument);
+                throw error
+            }
+
             return true
         },
 

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -110,7 +110,7 @@ class DragCoordinator extends Manager {
         }
 
         if (hover) {
-            hover.onRemoteDragLeave();
+            hover.onRemoteDragLeave?.();
             me.nativeHoverTargets.delete(windowId)
         }
     }
@@ -515,7 +515,7 @@ class DragCoordinator extends Manager {
             next     = candidate?.targetSortZone || null;
 
         if (previous && previous !== next) {
-            previous.onRemoteDragLeave()
+            previous.onRemoteDragLeave?.()
         }
 
         if (next) {

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -1,6 +1,7 @@
-import Manager   from './Base.mjs';
-import Rectangle from '../util/Rectangle.mjs';
-import Window    from './Window.mjs';
+import {createGestureClaimArbiter} from './GestureClaimArbiter.mjs';
+import Manager                     from './Base.mjs';
+import Rectangle                   from '../util/Rectangle.mjs';
+import Window                      from './Window.mjs';
 
 /**
  * @class Neo.manager.DragCoordinator
@@ -45,10 +46,35 @@ class DragCoordinator extends Manager {
     activeTargetZone = null
 
     /**
+     * Per-moving-popup claim arbiters for native-titlebar gestures (windowId → arbiter). One
+     * native drag IS one gesture, so each moving popup owns exactly one token (harness docking
+     * design record §2.8.1).
+     * @member {Map<String,Object>} nativeClaimArbiters=new Map()
+     * @protected
+     */
+    nativeClaimArbiters = new Map()
+
+    /**
+     * The target zone currently receiving continuous native-hover preview, per moving popup
+     * (windowId → zone). Runtime-only hover bookkeeping; swept on every gesture terminal.
+     * @member {Map<String,Object>} nativeHoverTargets=new Map()
+     * @protected
+     */
+    nativeHoverTargets = new Map()
+
+    /**
      * @member {Map<String,Object>} nativeWindowDropCandidates=new Map()
      * @protected
      */
     nativeWindowDropCandidates = new Map()
+
+    /**
+     * The active pointer gesture's claim arbiter — minted lazily at the gesture's first move,
+     * killed at every terminal (end or cancel), so its token's claims die with the gesture.
+     * @member {Object|null} pointerClaimArbiter=null
+     * @protected
+     */
+    pointerClaimArbiter = null
 
     /**
      * @summary Clears a pending geometry-only native window-drop candidate.
@@ -62,6 +88,30 @@ class DragCoordinator extends Manager {
         if (candidate) {
             clearTimeout(candidate.timeoutId);
             this.nativeWindowDropCandidates.delete(windowId)
+        }
+    }
+
+    /**
+     * @summary Ends a native-titlebar gesture's claim/hover bookkeeping exact-once.
+     *
+     * Kills the moving popup's claim arbiter (its token's claims die with the gesture) and ends
+     * any continuous-hover preview it was driving. Safe on every terminal — commit, source
+     * retirement, vessel departure — and idempotent: a second invocation finds nothing.
+     * @param {String} windowId The MOVING popup's window id (the native gesture key).
+     */
+    endNativeGesture(windowId) {
+        let me      = this,
+            arbiter = me.nativeClaimArbiters.get(windowId),
+            hover   = me.nativeHoverTargets.get(windowId);
+
+        if (arbiter) {
+            arbiter.reset();
+            me.nativeClaimArbiters.delete(windowId)
+        }
+
+        if (hover) {
+            hover.onRemoteDragLeave();
+            me.nativeHoverTargets.delete(windowId)
         }
     }
 
@@ -124,6 +174,10 @@ class DragCoordinator extends Manager {
         if (operation) {
             sourceSortZone.onRemoteDropOut(draggedItem)
         }
+
+        // The commit is a gesture terminal: the popup's token and hover bookkeeping die here.
+        // Ordered AFTER the drop — the preview is the drop's input and must outlive it.
+        me.endNativeGesture(windowId);
 
         if (me.activeTargetZone === targetSortZone) {
             me.activeTargetZone = null
@@ -188,7 +242,7 @@ class DragCoordinator extends Manager {
             popupWindow      = Window.get(data.windowId),
             popupRect        = popupWindow?.innerRect,
             {sortGroup}      = sourceSortZone,
-            targetWindowId, targetSortZone, targetWindow, localX, localY, width, height;
+            targetWindowId, targetSortZone, targetWindow, localX, localY, width, height, arbiter, claimed, excludedWindowIds;
 
         if (!popupRect || !sortGroup) {
             return null
@@ -197,14 +251,42 @@ class DragCoordinator extends Manager {
         localX = popupRect.x + popupRect.width  / 2;
         localY = popupRect.y + popupRect.height / 2;
 
-        targetWindowId = me.getWindowAtExcept(localX, localY, new Set([data.windowId, sourceSortZone.windowId]));
+        excludedWindowIds = new Set([data.windowId, sourceSortZone.windowId]);
+        arbiter           = me.nativeClaimArbiters.get(data.windowId);
 
-        if (!targetWindowId) {
-            return null
+        if (!arbiter) {
+            arbiter = createGestureClaimArbiter();
+            me.nativeClaimArbiters.set(data.windowId, arbiter)
         }
 
-        targetSortZone = me.sortZones.get(sortGroup)?.get(targetWindowId);
-        targetWindow   = Window.get(targetWindowId);
+        claimed = me.resolveClaimedTarget({
+            arbiter,
+            excludedWindowIds,
+            screenX: localX,
+            screenY: localY,
+            sortGroup,
+            sourceSortZone
+        });
+
+        if (claimed) {
+            targetSortZone = claimed.zone;
+            targetWindowId = targetSortZone.windowId
+        } else {
+            // The pinned legacy path, stable-identity-free zones only (see resolveClaimedTarget).
+            targetWindowId = me.getWindowAtExcept(localX, localY, excludedWindowIds);
+
+            if (!targetWindowId) {
+                return null
+            }
+
+            targetSortZone = me.sortZones.get(sortGroup)?.get(targetWindowId);
+
+            if (targetSortZone?.stableTargetId != null) {
+                return null
+            }
+        }
+
+        targetWindow = Window.get(targetWindowId);
 
         if (!targetSortZone || !targetWindow?.innerRect) {
             return null
@@ -213,7 +295,7 @@ class DragCoordinator extends Manager {
         localX = localX - targetWindow.innerRect.x;
         localY = localY - targetWindow.innerRect.y;
 
-        if (!targetSortZone.acceptsRemoteDrag(localX, localY)) {
+        if (!claimed && !targetSortZone.acceptsRemoteDrag(localX, localY)) {
             return null
         }
 
@@ -250,6 +332,66 @@ class DragCoordinator extends Manager {
     }
 
     /**
+     * @summary Resolves the gesture's single claimed target among stable-identity zones.
+     *
+     * The claim pass of the §2.8.1 protocol (harness docking design record): every registered
+     * zone in the gesture's `sortGroup` that declares a `stableTargetId`, renders in a window
+     * other than the source's, geometrically contains the point (window `innerRect`) AND accepts
+     * the window-local hit-test acquires-or-refreshes a claim; zones that stop matching release
+     * theirs. The arbiter then answers deterministically — earliest valid claim, stable-id
+     * lexicographic tiebreak — or `null`, and `null` means fail closed: no preview, no commit.
+     *
+     * Dock-blindness holds: this method consumes registered zone identity and the main-thread
+     * window geometry only — never dock semantics. Zones WITHOUT a `stableTargetId` never claim;
+     * they stay on the legacy first-intersecting resolution their callers pin.
+     * @param {Object} data
+     * @param {Object} data.arbiter The gesture's claim arbiter.
+     * @param {Set<String>|null} [data.excludedWindowIds=null] Window ids that cannot host a valid
+     *     target (e.g. the moving popup itself on the native path).
+     * @param {Number} data.screenX Global screen-space x.
+     * @param {Number} data.screenY Global screen-space y.
+     * @param {String} data.sortGroup
+     * @param {Neo.draggable.container.SortZone} data.sourceSortZone
+     * @returns {Object|null} `{stableId, zone}` of the winning claim, or null (fail closed)
+     */
+    resolveClaimedTarget({arbiter, excludedWindowIds = null, screenX, screenY, sortGroup, sourceSortZone}) {
+        let group = this.sortZones.get(sortGroup);
+
+        if (!group) {
+            return null
+        }
+
+        for (const [windowId, zone] of group) {
+            if (
+                zone === sourceSortZone              ||
+                windowId === sourceSortZone.windowId ||
+                excludedWindowIds?.has(windowId)
+            ) {
+                continue
+            }
+
+            if (zone.stableTargetId == null || typeof zone.acceptsRemoteDrag !== 'function') {
+                continue
+            }
+
+            let inner = Window.get(windowId)?.innerRect;
+
+            if (
+                inner?.intersects({bottom: screenY, right: screenX, x: screenX, y: screenY}) &&
+                zone.acceptsRemoteDrag(screenX - inner.x, screenY - inner.y)
+            ) {
+                arbiter.claim(zone.stableTargetId, zone)
+            } else {
+                arbiter.release(zone.stableTargetId)
+            }
+        }
+
+        return arbiter.resolve()
+    }
+
+    /**
+     * @summary Pointer-path target resolution: the §2.8.1 claim protocol first, the pinned legacy
+     * first-intersecting path for stable-identity-free zones only, fail closed otherwise.
      * @param {Object} data
      * @param {Neo.component.Base} data.draggedItem
      * @param {Number} data.offsetX
@@ -262,52 +404,66 @@ class DragCoordinator extends Manager {
         let me                                                                           = this,
             {draggedItem, offsetX, offsetY, proxyRect, screenX, screenY, sourceSortZone} = data,
             {sortGroup}                                                                  = sourceSortZone,
-            targetWindowId                                                               = Window.getWindowAt(screenX, screenY),
-            targetSortZone;
+            arbiter                                                                      = me.pointerClaimArbiter ??= createGestureClaimArbiter(),
+            claimed                                                                      = me.resolveClaimedTarget({arbiter, screenX, screenY, sortGroup, sourceSortZone}),
+            targetSortZone                                                               = claimed?.zone,
+            targetWindowId;
 
-        if (targetWindowId && targetWindowId !== sourceSortZone.windowId) {
-            targetSortZone = me.sortZones.get(sortGroup)?.get(targetWindowId);
+        if (!targetSortZone) {
+            // The pinned legacy path: first-intersecting window by REGISTRATION ORDER. It survives
+            // exclusively for zones without a stable identity — a zone that declares one rides the
+            // claim protocol above and must never fall back here, otherwise overlap resolution
+            // would silently regress to nondeterminism when its claim fails.
+            targetWindowId = Window.getWindowAt(screenX, screenY);
 
-            if (targetSortZone) {
-                let targetWindow    = Window.get(targetWindowId),
-                    localX          = screenX - targetWindow.innerRect.x,
-                    localY          = screenY - targetWindow.innerRect.y,
-                    targetProxyRect = new Rectangle(
-                        localX - offsetX,
-                        localY - offsetY,
-                        proxyRect.width,
-                        proxyRect.height
-                    );
+            if (targetWindowId && targetWindowId !== sourceSortZone.windowId) {
+                let zone = me.sortZones.get(sortGroup)?.get(targetWindowId);
 
-                if (targetSortZone.acceptsRemoteDrag(localX, localY)) {
-                    // console.log('DragCoordinator target found', {targetWindowId, localX, localY});
+                if (zone && zone.stableTargetId == null) {
+                    let targetWindow = Window.get(targetWindowId);
 
-                    // Entering a new target zone
-                    if (me.activeTargetZone !== targetSortZone) {
-                        // Leaving previous target (if any)
-                        me.activeTargetZone?.onRemoteDragLeave();
-
-                        // Suspend source drag (close popup, etc)
-                        // We only do this once when leaving the void/source context
-                        if (!me.activeTargetZone) {
-                            sourceSortZone.suspendWindowDrag(draggedItem.reference || draggedItem.id)
-                        }
-
-                        me.activeTargetZone = targetSortZone
+                    if (zone.acceptsRemoteDrag(screenX - targetWindow.innerRect.x, screenY - targetWindow.innerRect.y)) {
+                        targetSortZone = zone
                     }
-
-                    targetSortZone.onRemoteDragMove({
-                        draggedItem,
-                        localX,
-                        localY,
-                        offsetX,
-                        offsetY,
-                        proxyRect: targetProxyRect
-                    });
-
-                    return
                 }
             }
+        }
+
+        if (targetSortZone) {
+            let targetWindow    = Window.get(targetSortZone.windowId),
+                localX          = screenX - targetWindow.innerRect.x,
+                localY          = screenY - targetWindow.innerRect.y,
+                targetProxyRect = new Rectangle(
+                    localX - offsetX,
+                    localY - offsetY,
+                    proxyRect.width,
+                    proxyRect.height
+                );
+
+            // Entering a new target zone
+            if (me.activeTargetZone !== targetSortZone) {
+                // Leaving previous target (if any)
+                me.activeTargetZone?.onRemoteDragLeave();
+
+                // Suspend source drag (close popup, etc)
+                // We only do this once when leaving the void/source context
+                if (!me.activeTargetZone) {
+                    sourceSortZone.suspendWindowDrag(draggedItem.reference || draggedItem.id)
+                }
+
+                me.activeTargetZone = targetSortZone
+            }
+
+            targetSortZone.onRemoteDragMove({
+                draggedItem,
+                localX,
+                localY,
+                offsetX,
+                offsetY,
+                proxyRect: targetProxyRect
+            });
+
+            return
         }
 
         // In void or back in source window
@@ -326,6 +482,10 @@ class DragCoordinator extends Manager {
         let me               = this,
             {sourceSortZone} = data;
 
+        // The token's claims die with its gesture — cancel is a terminal like any other.
+        me.pointerClaimArbiter?.reset();
+        me.pointerClaimArbiter = null;
+
         if (me.activeTargetZone) {
             me.activeTargetZone.onRemoteDragLeave();
             me.activeTargetZone = null
@@ -333,8 +493,44 @@ class DragCoordinator extends Manager {
 
         for (const [windowId, candidate] of me.nativeWindowDropCandidates.entries()) {
             if (candidate.sourceSortZone === sourceSortZone || candidate.targetSortZone === sourceSortZone) {
-                me.clearNativeWindowDropCandidate(windowId)
+                me.clearNativeWindowDropCandidate(windowId);
+                me.endNativeGesture(windowId)
             }
+        }
+    }
+
+    /**
+     * @summary Drives continuous hover preview for a native-titlebar drag, per geometry event.
+     *
+     * The hover contract of §2.8.1's remote-preview requirement: the CURRENT candidate target
+     * renders its own affordances through `onRemoteDragMove` on EVERY position update — per
+     * frame, not only after the dwell timer — while the dwell/settle contract keeps gating the
+     * COMMIT. Target switches and hover loss end the previous target's preview exact-once.
+     * @param {String} windowId The MOVING popup's window id.
+     * @param {Object|null} candidate The current drop candidate, or null when nothing claims.
+     */
+    updateNativeHover(windowId, candidate) {
+        let me       = this,
+            previous = me.nativeHoverTargets.get(windowId),
+            next     = candidate?.targetSortZone || null;
+
+        if (previous && previous !== next) {
+            previous.onRemoteDragLeave()
+        }
+
+        if (next) {
+            me.nativeHoverTargets.set(windowId, next);
+
+            next.onRemoteDragMove({
+                draggedItem: candidate.draggedItem,
+                localX     : candidate.localX,
+                localY     : candidate.localY,
+                offsetX    : candidate.offsetX,
+                offsetY    : candidate.offsetY,
+                proxyRect  : candidate.proxyRect
+            })
+        } else {
+            me.nativeHoverTargets.delete(windowId)
         }
     }
 
@@ -342,9 +538,10 @@ class DragCoordinator extends Manager {
      * @summary Handles geometry updates for native OS-titlebar popup reintegration.
      *
      * Consumes high-frequency window geometry updates for native OS-titlebar popup drags,
-     * where the browser does not emit pointer move/up events. A terminal detached popup
-     * reintegrates only after it remains over a remote dashboard target long enough to
-     * satisfy the settle/dwell intent contract.
+     * where the browser does not emit pointer move/up events. The current candidate target
+     * renders continuous hover preview per update; a terminal detached popup reintegrates
+     * only after it remains over a remote dashboard target long enough to satisfy the
+     * settle/dwell intent contract.
      * @param {Object} data
      * @param {String} data.windowId
      */
@@ -356,10 +553,13 @@ class DragCoordinator extends Manager {
 
         if (!sourceDrag) {
             me.clearNativeWindowDropCandidate(windowId);
+            me.endNativeGesture(windowId);
             return
         }
 
         candidate = me.getNativeWindowDropCandidate(data, sourceDrag);
+
+        me.updateNativeHover(windowId, candidate);
 
         if (!candidate) {
             me.clearNativeWindowDropCandidate(windowId);
@@ -398,6 +598,11 @@ class DragCoordinator extends Manager {
      */
     onDragEnd(data) {
         let me = this;
+
+        // The gesture reaches a terminal on every branch below, so its token dies here — the
+        // committed target already lives in `activeTargetZone`; claims are hover-time state only.
+        me.pointerClaimArbiter?.reset();
+        me.pointerClaimArbiter = null;
 
         if (me.activeTargetZone) {
             // The TARGET decides whether the gesture committed: onRemoteDrop() returns the committed
@@ -491,6 +696,26 @@ class DragCoordinator extends Manager {
             me.activeTargetZone = null
         }
 
+        // Claim hygiene mirrors the activeTargetZone rule above: a departed zone must not stay
+        // reachable as a WINNING CLAIM either — a later resolve would hand the gesture a commit
+        // destination whose vessel is gone. Release is identity-scoped across every live arbiter.
+        if (sortZone.stableTargetId != null) {
+            me.pointerClaimArbiter?.release(sortZone.stableTargetId);
+
+            for (const arbiter of me.nativeClaimArbiters.values()) {
+                arbiter.release(sortZone.stableTargetId)
+            }
+        }
+
+        // ...and a departing zone stops receiving continuous native hover, ending its preview
+        // while the reference can still reach it (same reasoning as the activeTargetZone leave).
+        for (const [windowId, hover] of me.nativeHoverTargets.entries()) {
+            if (hover === sortZone) {
+                hover.onRemoteDragLeave?.();
+                me.nativeHoverTargets.delete(windowId)
+            }
+        }
+
         for (const [windowId, candidate] of me.nativeWindowDropCandidates.entries()) {
             if (candidate.sourceSortZone === sortZone || candidate.targetSortZone === sortZone) {
                 me.clearNativeWindowDropCandidate(windowId)
@@ -511,7 +736,9 @@ class DragCoordinator extends Manager {
                 sortGroup: me.activeTargetZone.sortGroup,
                 windowId : me.activeTargetZone.windowId
             } : null,
-            sortZones: Array.from(me.sortZones.entries()).map(([group, map]) => ({
+            nativeGestures     : Array.from(me.nativeClaimArbiters.keys()),
+            pointerGestureToken: me.pointerClaimArbiter?.token ?? null,
+            sortZones          : Array.from(me.sortZones.entries()).map(([group, map]) => ({
                 group,
                 windows: Array.from(map.keys())
             }))

--- a/src/manager/GestureClaimArbiter.mjs
+++ b/src/manager/GestureClaimArbiter.mjs
@@ -1,0 +1,121 @@
+/**
+ * @summary Pure per-gesture claim arbiter — the session-scoped gesture/claim protocol that replaces
+ * first-intersecting target resolution on the dock path (harness docking design record §2.8.1,
+ * `learn/agentos/decisions/0029-harness-docking-design.md`).
+ *
+ * One arbiter IS one gesture: {@link Neo.manager.DragCoordinator} mints an arbiter at gesture start,
+ * every claim references its token, and the whole claim set dies with the gesture (terminal or
+ * cancel) via {@link #reset}. The factory is deliberately dependency-free — no imports, closure
+ * state only, an injectable clock — so witnesses drive the full protocol without a browser, and the
+ * arbiter stays blind to windows, docks, and zones alike: callers hand it stable identities plus
+ * opaque zone handles, and it hands back exactly one winner or nothing.
+ *
+ * Protocol semantics (all deterministic, per the contract):
+ * - **Acquire-or-refresh:** the first {@link #claim} for a stable identity records its acquisition
+ *   time; every subsequent claim refreshes the expiry but keeps the original acquisition — the
+ *   "earliest valid claim wins" axis measures hover seniority within the gesture, so a refresh must
+ *   not reset seniority. The zone handle is updated to the latest claimant so a re-embodied surface
+ *   with the same stable identity never leaves a dangling reference behind.
+ * - **Validity and expiry:** claims expire `claimTtlMs` after their last refresh. {@link #resolve}
+ *   ignores AND prunes expired claims — staleness is the safety net for surfaces that vanish
+ *   without an explicit {@link #release} (a window closing mid-gesture).
+ * - **Deterministic outcomes, all three cases:** *tie* — earliest acquisition wins, with stable-id
+ *   lexicographic order as the final tiebreak (two claims in the same clock millisecond stay
+ *   deterministic); *stale* — ignored; *no claim* — {@link #resolve} returns `null` and the caller
+ *   fails closed: no preview, no commit.
+ *
+ * Stable identity is the caller's contract: a workspace/zone identity that survives re-registration
+ * and never encodes `windowId` or registration/insertion order.
+ */
+
+let gestureTokenSeq = 0;
+
+/**
+ * Creates one gesture-scoped claim arbiter.
+ * @param {Object} [config]
+ * @param {Number} [config.claimTtlMs=300] Claim lifetime after the last refresh, in milliseconds.
+ * @param {Function} [config.now=Date.now] Injectable clock, milliseconds.
+ * @returns {Object} arbiter
+ * @returns {Number}   arbiter.claimCount     Live claim count (expired claims included until pruned).
+ * @returns {Function} arbiter.claim          `(stableId, zone)` acquire-or-refresh; returns the claim record.
+ * @returns {Function} arbiter.release        `(stableId)` drops a claim; unknown ids are a no-op.
+ * @returns {Function} arbiter.reset          Kills every claim — the gesture-terminal cleanup.
+ * @returns {Function} arbiter.resolve        `()` → `{stableId, zone}` of the winning claim, or `null` (fail closed).
+ * @returns {String}   arbiter.token          The gesture token every claim of this arbiter references.
+ */
+export function createGestureClaimArbiter({claimTtlMs = 300, now = Date.now} = {}) {
+    const
+        claims = new Map(),
+        token  = `gesture-${++gestureTokenSeq}`;
+
+    return {
+        get claimCount() {
+            return claims.size
+        },
+
+        get token() {
+            return token
+        },
+
+        /**
+         * Acquire-or-refresh the claim for one stable identity.
+         * @param {String} stableId
+         * @param {Object} zone Opaque target handle, returned verbatim by a winning resolve.
+         * @returns {Object} the live claim record `{acquiredAt, expiresAt, stableId, token, zone}`
+         */
+        claim(stableId, zone) {
+            const
+                timestamp = now(),
+                existing  = claims.get(stableId),
+                record    = {
+                    acquiredAt: existing ? existing.acquiredAt : timestamp,
+                    expiresAt : timestamp + claimTtlMs,
+                    stableId,
+                    token,
+                    zone
+                };
+
+            claims.set(stableId, record);
+            return record
+        },
+
+        /**
+         * @param {String} stableId
+         */
+        release(stableId) {
+            claims.delete(stableId)
+        },
+
+        reset() {
+            claims.clear()
+        },
+
+        /**
+         * Resolves the gesture's single winning target: earliest valid acquisition, stable-id
+         * lexicographic tiebreak, expired claims ignored and pruned, no valid claim → `null`.
+         * @returns {Object|null} `{stableId, zone}` or `null` when nothing validly claims
+         */
+        resolve() {
+            const timestamp = now();
+
+            let winner = null;
+
+            for (const record of claims.values()) {
+                if (record.expiresAt < timestamp) {
+                    claims.delete(record.stableId);
+                    continue
+                }
+
+                if (
+                    !winner ||
+                    record.acquiredAt < winner.acquiredAt ||
+                    (record.acquiredAt === winner.acquiredAt && record.stableId < winner.stableId)
+                ) {
+                    winner = record
+                }
+            }
+
+            return winner ? {stableId: winner.stableId, zone: winner.zone} : null
+        }
+    }
+}

--- a/src/manager/GestureClaimArbiter.mjs
+++ b/src/manager/GestureClaimArbiter.mjs
@@ -58,7 +58,11 @@ export function createGestureClaimArbiter({claimTtlMs = 300, now = Date.now} = {
         },
 
         /**
-         * Acquire-or-refresh the claim for one stable identity.
+         * Acquire-or-refresh the claim for one stable identity. Seniority survives a refresh
+         * ONLY while the claim is still live: an existing record whose expiry has elapsed is
+         * absent by contract (stale = ignored), so re-claiming after expiry is a REACQUISITION —
+         * a new acquisition time, competing under the tie/age rules as a new claim. The expiry
+         * boundary is `expiresAt >= now` = live, matching the resolver's prune condition exactly.
          * @param {String} stableId
          * @param {Object} zone Opaque target handle, returned verbatim by a winning resolve.
          * @returns {Object} the live claim record `{acquiredAt, expiresAt, stableId, token, zone}`
@@ -67,8 +71,9 @@ export function createGestureClaimArbiter({claimTtlMs = 300, now = Date.now} = {
             const
                 timestamp = now(),
                 existing  = claims.get(stableId),
+                live      = existing != null && existing.expiresAt >= timestamp,
                 record    = {
-                    acquiredAt: existing ? existing.acquiredAt : timestamp,
+                    acquiredAt: live ? existing.acquiredAt : timestamp,
                     expiresAt : timestamp + claimTtlMs,
                     stableId,
                     token,

--- a/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
@@ -139,6 +139,32 @@ test.describe('Neo.dashboard.DockWorkspaceSet — the workspace-set registry', (
         expect(popup.document).toEqual({rootId: 'popup-before'})
     });
 
+    test('a THROWING target writer cannot split ownership: the source rolls back, the error propagates', () => {
+        const main     = createHolder({rootId: 'main-before'});
+        let   popupDoc = {rootId: 'popup-before'};
+
+        set.register('main', main.seams);
+        set.register('popup-1', {
+            getDocument: () => popupDoc,
+            setDocument: () => {
+                throw new Error('render target detached mid-adopt')
+            }
+        });
+
+        // the error stays the owner's to observe — adoption must not swallow it...
+        expect(() => set.adoptTransfer({
+            sourceDocument   : {rootId: 'main-after'},
+            sourceWorkspaceId: 'main',
+            targetDocument   : {rootId: 'popup-after'},
+            targetWorkspaceId: 'popup-1'
+        })).toThrow(/render target detached mid-adopt/);
+
+        // ...and the half that DID land is rolled back: both owners sit at their pre-call
+        // documents — the exact half-publication the contract forbids, proven absent
+        expect(main.document).toEqual({rootId: 'main-before'});
+        expect(popupDoc).toEqual({rootId: 'popup-before'})
+    });
+
     test('adoptTransfer refuses a same-workspace pair and absent documents', () => {
         const main = createHolder();
 

--- a/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
@@ -1,0 +1,194 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockWorkspaceSetTest'
+    },
+    mockLocalStorage: false,
+    mockMain        : false
+});
+
+import {test, expect}           from '@playwright/test';
+import {createDockWorkspaceSet} from '../../../../src/dashboard/DockWorkspaceSet.mjs';
+
+/**
+ * @summary The worker-owned `{workspaceId → document}` registry contract (harness docking design
+ * record §2.1 / §2.8.3): stable semantic identity in, document truth out, fail-closed everywhere
+ * a resolution cannot be proven, and both-or-neither adoption for an atomic transfer's committed
+ * pair. Retirement never happens implicitly — the registry outlives any render target.
+ */
+test.describe('Neo.dashboard.DockWorkspaceSet — the workspace-set registry', () => {
+    let set;
+
+    test.beforeEach(() => {
+        set = createDockWorkspaceSet()
+    });
+
+    /**
+     * @param {Object} [document] initial document
+     * @returns {Object} `{seams, current}` — accessor seams plus a live document handle
+     */
+    function createHolder(document = {rootId: 'root', items: []}) {
+        const holder = {
+            document,
+            seams: {
+                getDocument: () => holder.document,
+                setDocument: next => holder.document = next
+            }
+        };
+
+        return holder
+    }
+
+    test('register → resolve: document truth flows through the owner seam, live', () => {
+        const holder = createHolder({rootId: 'root-main'});
+
+        expect(set.register('main', holder.seams)).toBe(true);
+        expect(set.has('main')).toBe(true);
+        expect(set.ids()).toEqual(['main']);
+        expect(set.getDocument('main')).toEqual({rootId: 'root-main'});
+
+        // the seam is LIVE: the owner committing a new document changes the resolution
+        holder.document = {rootId: 'root-main', revision: 2};
+
+        expect(set.getDocument('main').revision).toBe(2)
+    });
+
+    test('an unknown workspace resolves to null — fail closed, never a guess', () => {
+        expect(set.getDocument('never-registered')).toBeNull();
+        expect(set.has('never-registered')).toBe(false)
+    });
+
+    test('registration validates its inputs: no id, non-string id, or missing accessor → refused', () => {
+        expect(set.register('',        {getDocument: () => null})).toBe(false);
+        expect(set.register(null,      {getDocument: () => null})).toBe(false);
+        expect(set.register(42,        {getDocument: () => null})).toBe(false);
+        expect(set.register('no-seam', {})).toBe(false);
+        expect(set.register('no-seam')).toBe(false);
+
+        expect(set.size).toBe(0)
+    });
+
+    test('re-registering the SAME stable id replaces the seams — a re-embodied vessel starts fresh', () => {
+        const
+            first  = createHolder({rootId: 'stale'}),
+            second = createHolder({rootId: 'fresh'});
+
+        set.register('popup-1', first.seams);
+        set.register('popup-1', second.seams);
+
+        expect(set.size).toBe(1);
+        expect(set.getDocument('popup-1')).toEqual({rootId: 'fresh'})
+    });
+
+    test('adoptTransfer lands the committed pair on BOTH owners', () => {
+        const
+            main  = createHolder({rootId: 'main-before'}),
+            popup = createHolder({rootId: 'popup-before'});
+
+        set.register('main',    main.seams);
+        set.register('popup-1', popup.seams);
+
+        const adopted = set.adoptTransfer({
+            sourceDocument   : {rootId: 'main-after'},
+            sourceWorkspaceId: 'main',
+            targetDocument   : {rootId: 'popup-after'},
+            targetWorkspaceId: 'popup-1'
+        });
+
+        expect(adopted).toBe(true);
+        expect(main.document).toEqual({rootId: 'main-after'});
+        expect(popup.document).toEqual({rootId: 'popup-after'})
+    });
+
+    test('adoptTransfer is both-or-neither: a missing target leaves the source UNTOUCHED', () => {
+        const main = createHolder({rootId: 'main-before'});
+
+        set.register('main', main.seams);
+
+        const adopted = set.adoptTransfer({
+            sourceDocument   : {rootId: 'main-after'},
+            sourceWorkspaceId: 'main',
+            targetDocument   : {rootId: 'popup-after'},
+            targetWorkspaceId: 'popup-never-registered'
+        });
+
+        // the half that COULD land must not: a half-adopted pair is the ownership-tier version
+        // of the executor's forbidden half-transferred item
+        expect(adopted).toBe(false);
+        expect(main.document).toEqual({rootId: 'main-before'})
+    });
+
+    test('adoptTransfer refuses a read-only side — an entry without a setter cannot adopt', () => {
+        const
+            main  = createHolder({rootId: 'main-before'}),
+            popup = createHolder({rootId: 'popup-before'});
+
+        set.register('main', main.seams);
+        set.register('popup-1', {getDocument: popup.seams.getDocument});
+
+        const adopted = set.adoptTransfer({
+            sourceDocument   : {rootId: 'main-after'},
+            sourceWorkspaceId: 'main',
+            targetDocument   : {rootId: 'popup-after'},
+            targetWorkspaceId: 'popup-1'
+        });
+
+        expect(adopted).toBe(false);
+        expect(main.document).toEqual({rootId: 'main-before'});
+        expect(popup.document).toEqual({rootId: 'popup-before'})
+    });
+
+    test('adoptTransfer refuses a same-workspace pair and absent documents', () => {
+        const main = createHolder();
+
+        set.register('main', main.seams);
+
+        expect(set.adoptTransfer({
+            sourceDocument   : {rootId: 'x'},
+            sourceWorkspaceId: 'main',
+            targetDocument   : {rootId: 'y'},
+            targetWorkspaceId: 'main'
+        })).toBe(false);
+
+        expect(set.adoptTransfer({
+            sourceDocument   : null,
+            sourceWorkspaceId: 'main',
+            targetDocument   : {rootId: 'y'},
+            targetWorkspaceId: 'main'
+        })).toBe(false)
+    });
+
+    test('retirement is explicit and exact: unregister removes one entry, resolution fails closed afterwards', () => {
+        const
+            main  = createHolder(),
+            popup = createHolder();
+
+        set.register('main',    main.seams);
+        set.register('popup-1', popup.seams);
+
+        expect(set.unregister('popup-1')).toBe(true);
+        expect(set.unregister('popup-1')).toBe(false);
+
+        expect(set.has('main')).toBe(true);
+        expect(set.getDocument('popup-1')).toBeNull();
+        expect(set.ids()).toEqual(['main'])
+    });
+
+    test('identity is semantic only: the registry answers by workspace id and never consumes window identity', () => {
+        const holder = createHolder({rootId: 'root'});
+
+        // a caller passing runtime window identity alongside the seams gains nothing: the entry
+        // stores the two accessor seams and the workspace id, full stop — resolution before and
+        // after a simulated window swap is byte-identical because no window field participates
+        set.register('main', {...holder.seams, windowId: 'win-1'});
+
+        const before = set.getDocument('main');
+
+        // the "window" changes; the registry cannot notice, which IS the assertion
+        set.register('main', {...holder.seams, windowId: 'win-99'});
+
+        expect(set.getDocument('main')).toEqual(before);
+        expect(set.ids()).toEqual(['main'])
+    })
+});

--- a/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
+++ b/test/playwright/unit/dashboard/DockWorkspaceSet.spec.mjs
@@ -165,6 +165,58 @@ test.describe('Neo.dashboard.DockWorkspaceSet — the workspace-set registry', (
         expect(popupDoc).toEqual({rootId: 'popup-before'})
     });
 
+    test('a target writer that MUTATES then throws is compensated: both owners at pre-call documents', () => {
+        // the sharper falsifier class: the opaque setter lands its assignment BEFORE throwing,
+        // so a source-only rollback would leave source-before / target-after — the split state
+        // wearing a subtler costume. Two-sided compensation re-invokes the breaching writer with
+        // its prior document; the breach's own mutation ordering makes the restore stick.
+        const main     = createHolder({rootId: 'main-before'});
+        let   popupDoc = {rootId: 'popup-before'};
+
+        set.register('main', main.seams);
+        set.register('popup-1', {
+            getDocument: () => popupDoc,
+            setDocument: value => {
+                popupDoc = value;
+                throw new Error('mutated then threw')
+            }
+        });
+
+        expect(() => set.adoptTransfer({
+            sourceDocument   : {rootId: 'main-after'},
+            sourceWorkspaceId: 'main',
+            targetDocument   : {rootId: 'popup-after'},
+            targetWorkspaceId: 'popup-1'
+        })).toThrow(/mutated then threw/);
+
+        expect(main.document).toEqual({rootId: 'main-before'});
+        expect(popupDoc).toEqual({rootId: 'popup-before'})
+    });
+
+    test('a SOURCE writer failing leaves the target untouched and compensates the source — either write failing unwinds', () => {
+        let   mainDoc = {rootId: 'main-before'};
+        const popup   = createHolder({rootId: 'popup-before'});
+
+        set.register('main', {
+            getDocument: () => mainDoc,
+            setDocument: value => {
+                mainDoc = value;
+                throw new Error('source adoption failed')
+            }
+        });
+        set.register('popup-1', popup.seams);
+
+        expect(() => set.adoptTransfer({
+            sourceDocument   : {rootId: 'main-after'},
+            sourceWorkspaceId: 'main',
+            targetDocument   : {rootId: 'popup-after'},
+            targetWorkspaceId: 'popup-1'
+        })).toThrow(/source adoption failed/);
+
+        expect(mainDoc).toEqual({rootId: 'main-before'});
+        expect(popup.document, 'the second writer was never invoked').toEqual({rootId: 'popup-before'})
+    });
+
     test('adoptTransfer refuses a same-workspace pair and absent documents', () => {
         const main = createHolder();
 

--- a/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
+++ b/test/playwright/unit/draggable/dashboard/SortZone.spec.mjs
@@ -506,7 +506,12 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
 
         await new Promise(resolve => setTimeout(resolve, 20));
 
-        expect(calls.map(call => call.type)).toEqual(['suspend', 'move', 'drop', 'dropOut']);
+        // The pinned native sequence: the FIRST move is the continuous hover preview, rendered on
+        // the geometry event itself (per frame, before any dwell elapses); the commit then runs
+        // the landed refresh — suspend, a final move so the preview is current at the drop
+        // instant, drop, and outcome-gated source retirement. Dwell/settle still gate the COMMIT
+        // only; they no longer gate the preview.
+        expect(calls.map(call => call.type)).toEqual(['move', 'suspend', 'move', 'drop', 'dropOut']);
 
         const move = calls.find(call => call.type === 'move').data;
 
@@ -584,7 +589,11 @@ test.describe.serial('Neo.draggable.dashboard.SortZone Directional Logic', () =>
 
         await new Promise(resolve => setTimeout(resolve, 70));
 
-        expect(calls).toEqual([]);
+        // The single 'move' is the continuous hover preview from the FIRST position event — the
+        // per-frame preview renders before dwell by design. The load-bearing assertion is what
+        // stays ABSENT after the popup leaves before settle: no suspend, no drop, no retirement —
+        // the departure cleared the candidate, so the commit never ran.
+        expect(calls).toEqual(['move']);
         expect(DragCoordinator.nativeWindowDropCandidates.size).toBe(0)
     });
 });

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -420,3 +420,352 @@ test.describe('Neo.manager.DragCoordinator — teardown hygiene (#15248)', () =>
         expect(DragCoordinator.activeTargetZone).toBeNull()
     });
 });
+
+/**
+ * @summary The §2.8.1 gesture/claim protocol at the coordinator tier: deterministic target
+ * resolution on stable identity, replacing first-intersecting registration order on the dock path.
+ *
+ * The binding falsifier lives here verbatim — three OVERLAPPING windows, one gesture, exactly ONE
+ * preview and exactly ONE commit — alongside the negative witness that PINS the legacy path's
+ * registration-order dependence (the reason stable-identity zones are forbidden from riding it),
+ * and the continuous-preview contract for native-titlebar hovers.
+ *
+ * Real coordinator, real `Neo.manager.Window` geometry (registered `Rectangle`s), plain-object
+ * zones — the same harness idiom as the teardown-hygiene block above.
+ */
+test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () => {
+    let DragCoordinator, Rectangle, WindowManager;
+    let calls;
+
+    test.beforeAll(async () => {
+        DragCoordinator = (await import('../../../../src/manager/DragCoordinator.mjs')).default;
+        Rectangle       = (await import('../../../../src/util/Rectangle.mjs')).default;
+        WindowManager   = (await import('../../../../src/manager/Window.mjs')).default
+    });
+
+    function resetCoordinator() {
+        DragCoordinator.activeTargetZone = null;
+        DragCoordinator.sortZones.clear();
+        DragCoordinator.nativeWindowDropCandidates.forEach(candidate => clearTimeout(candidate.timeoutId));
+        DragCoordinator.nativeWindowDropCandidates.clear();
+        DragCoordinator.nativeClaimArbiters.clear();
+        DragCoordinator.nativeHoverTargets.clear();
+        DragCoordinator.pointerClaimArbiter = null
+    }
+
+    function clearWindows() {
+        [...WindowManager.items].forEach(item => WindowManager.unregister(item))
+    }
+
+    test.beforeEach(() => {
+        calls = [];
+        resetCoordinator();
+        clearWindows()
+    });
+
+    test.afterEach(() => {
+        resetCoordinator();
+        clearWindows()
+    });
+
+    /**
+     * @param {String} id
+     * @param {Number} x
+     * @param {Number} y
+     * @param {Number} width
+     * @param {Number} height
+     * @param {Object} [rects] optional divergent inner/outer rects (chrome simulation)
+     */
+    function registerWindow(id, x, y, width, height, rects = null) {
+        WindowManager.register({
+            id,
+            innerRect: rects?.innerRect ?? new Rectangle(x, y, width, height),
+            outerRect: rects?.outerRect ?? new Rectangle(x, y, width, height)
+        })
+    }
+
+    /**
+     * @param {String|null} stableId null creates a LEGACY zone (no stable identity)
+     * @param {String} windowId
+     * @param {Object} [options]
+     * @returns {Object}
+     */
+    function createZone(stableId, windowId, {accepts = () => true, operation = {type: 'transferItem'}} = {}) {
+        const zone = {
+            sortGroup: 'dock',
+            windowId,
+            acceptsRemoteDrag(localX, localY) {
+                return accepts(localX, localY)
+            },
+            onRemoteDragMove(payload) {
+                calls.push(['move', stableId ?? windowId, payload.localX, payload.localY])
+            },
+            onRemoteDragLeave() {
+                calls.push(['leave', stableId ?? windowId])
+            },
+            onRemoteDrop(draggedItem) {
+                calls.push(['drop', stableId ?? windowId, draggedItem.id]);
+                return operation
+            }
+        };
+
+        if (stableId != null) {
+            zone.stableTargetId = stableId
+        }
+
+        return zone
+    }
+
+    /**
+     * @returns {Object}
+     */
+    function createSource() {
+        return {
+            sortGroup       : 'dock',
+            windowId        : 'win-source',
+            isWindowDragging: false,
+            suspendWindowDrag(widgetName) {
+                calls.push(['suspend', widgetName])
+            },
+            resumeWindowDrag(widgetName) {
+                calls.push(['resume', widgetName])
+            },
+            onRemoteDropOut(draggedItem) {
+                calls.push(['dropOut', draggedItem.id])
+            }
+        }
+    }
+
+    /**
+     * @param {Object} source
+     * @param {Number} screenX
+     * @param {Number} screenY
+     */
+    function move(source, screenX, screenY) {
+        DragCoordinator.onDragMove({
+            draggedItem   : {id: 'tab-1', reference: 'tab-1'},
+            offsetX       : 10,
+            offsetY       : 10,
+            proxyRect     : {width: 100, height: 60},
+            screenX,
+            screenY,
+            sourceSortZone: source
+        })
+    }
+
+    test('THE OVERLAP FALSIFIER: three overlapping windows, one gesture → exactly ONE preview and exactly ONE commit', () => {
+        const source = createSource();
+
+        registerWindow('win-source', 2000, 0, 400, 400);
+        registerWindow('win-a',      0,     0, 800, 600);
+        registerWindow('win-b',      100, 100, 800, 600);
+        registerWindow('win-c',      200, 200, 800, 600);
+
+        // Registered in REVERSE lexicographic order: an insertion-order resolver answers
+        // 'workspace-c'; the protocol must answer 'workspace-a' (same-tick tie → lexicographic).
+        const
+            zoneC = createZone('workspace-c', 'win-c'),
+            zoneB = createZone('workspace-b', 'win-b'),
+            zoneA = createZone('workspace-a', 'win-a');
+
+        DragCoordinator.register(zoneC);
+        DragCoordinator.register(zoneB);
+        DragCoordinator.register(zoneA);
+
+        // (300, 300) lies inside ALL THREE target windows — the popup-over-popup overlap.
+        move(source, 300, 300);
+        move(source, 310, 310);
+
+        // one gesture token, alive between moves and dead after the terminal
+        expect(DragCoordinator.pointerClaimArbiter?.token).toBeTruthy();
+
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+        const
+            previewIds = new Set(calls.filter(([name]) => name === 'move').map(([, id]) => id)),
+            dropCalls  = calls.filter(([name]) => name === 'drop');
+
+        // exactly ONE window previews...
+        expect([...previewIds]).toEqual(['workspace-a']);
+
+        // ...and exactly ONE commit lands, on the deterministic winner
+        expect(dropCalls).toEqual([['drop', 'workspace-a', 'tab-1']]);
+        expect(calls.filter(([name]) => name === 'dropOut')).toEqual([['dropOut', 'tab-1']]);
+
+        // the source's drag embodiment was suspended exactly once, on entering the claimed target
+        expect(calls.filter(([name]) => name === 'suspend')).toEqual([['suspend', 'tab-1']]);
+
+        // gesture terminal: the token is dead
+        expect(DragCoordinator.pointerClaimArbiter).toBeNull()
+    });
+
+    test('the NEGATIVE witness: stable-identity-free zones resolve by REGISTRATION ORDER — the pinned legacy nondeterminism', () => {
+        const source = createSource();
+
+        // Round 1: windows registered a-first. `getWindowAt` finds the FIRST intersecting item.
+        registerWindow('win-a', 0,     0, 800, 600);
+        registerWindow('win-b', 100, 100, 800, 600);
+        registerWindow('win-source', 2000, 0, 400, 400);
+
+        DragCoordinator.register(createZone(null, 'win-a'));
+        DragCoordinator.register(createZone(null, 'win-b'));
+
+        move(source, 300, 300);
+
+        expect(calls.filter(([name]) => name === 'move').map(([, id]) => id)).toEqual(['win-a']);
+
+        DragCoordinator.onDragCancel({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+        resetCoordinator();
+        clearWindows();
+        calls = [];
+
+        // Round 2: the IDENTICAL layout, windows registered b-first — the winner flips with
+        // registration order. This is the behavior the claim protocol exists to replace, pinned
+        // here so the legacy path's semantics stay observable and documented.
+        registerWindow('win-b', 100, 100, 800, 600);
+        registerWindow('win-a', 0,     0, 800, 600);
+        registerWindow('win-source', 2000, 0, 400, 400);
+
+        DragCoordinator.register(createZone(null, 'win-a'));
+        DragCoordinator.register(createZone(null, 'win-b'));
+
+        move(source, 300, 300);
+
+        expect(calls.filter(([name]) => name === 'move').map(([, id]) => id)).toEqual(['win-b'])
+    });
+
+    test('the legacy door is CLOSED to stable zones: first-intersecting resolution cannot reach a zone that failed to claim', () => {
+        const source = createSource();
+
+        // win-a's OUTER rect contains the point, its INNER rect does not (an 80px chrome band) —
+        // so the zone cannot claim (inner containment fails), while `getWindowAt` (outer-rect,
+        // first-intersecting) still resolves win-a. Without the guard, the legacy path would
+        // hand this zone the gesture with chrome-space coordinates its blind hit-test accepts.
+        registerWindow('win-a', 0, 0, 800, 600, {
+            innerRect: new Rectangle(0, 80, 800, 520),
+            outerRect: new Rectangle(0, 0,  800, 600)
+        });
+        registerWindow('win-source', 2000, 0, 400, 400);
+
+        DragCoordinator.register(createZone('workspace-a', 'win-a', {accepts: () => true}));
+
+        move(source, 300, 40);
+
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+        // fail closed: no preview, no commit — §2.8.1's no-claim outcome
+        expect(calls.filter(([name]) => name === 'move')).toEqual([]);
+        expect(calls.filter(([name]) => name === 'drop')).toEqual([]);
+        expect(calls.filter(([name]) => name === 'dropOut')).toEqual([])
+    });
+
+    test('claim seniority holds the winner steady — a later valid claimant cannot steal the hover', () => {
+        const source = createSource();
+
+        registerWindow('win-a', 0,     0, 800, 600);
+        registerWindow('win-b', 100, 100, 800, 600);
+        registerWindow('win-source', 2000, 0, 400, 400);
+
+        let zoneBAccepts = false;
+
+        // 'workspace-0' sorts lexicographically BEFORE 'workspace-a': if the second move's tie
+        // fell to the lexicographic axis, B would win — seniority must dominate the tiebreak.
+        const
+            zoneA = createZone('workspace-a', 'win-a'),
+            zoneB = createZone('workspace-0', 'win-b', {accepts: () => zoneBAccepts});
+
+        DragCoordinator.register(zoneB);
+        DragCoordinator.register(zoneA);
+
+        move(source, 300, 300);
+
+        // The coordinator claims on the REAL clock: advance it one millisecond so B's acquisition
+        // is strictly younger — in the same-millisecond case the tie falls to the lexicographic
+        // axis by contract, which is the arbiter spec's territory, not this witness's.
+        const start = Date.now();
+        while (Date.now() === start) {/* spin across the millisecond boundary */}
+
+        zoneBAccepts = true;
+        move(source, 310, 310);
+
+        const previewIds = calls.filter(([name]) => name === 'move').map(([, id]) => id);
+
+        // A previews on both moves; B never does; no leave — the hover does not flicker
+        expect(previewIds).toEqual(['workspace-a', 'workspace-a']);
+        expect(calls.filter(([name]) => name === 'leave')).toEqual([])
+    });
+
+    test('the winning claimant departing mid-gesture hands over deterministically: leave, then the successor previews', () => {
+        const source = createSource();
+
+        registerWindow('win-a', 0,     0, 800, 600);
+        registerWindow('win-b', 100, 100, 800, 600);
+        registerWindow('win-source', 2000, 0, 400, 400);
+
+        const
+            zoneA = createZone('workspace-a', 'win-a'),
+            zoneB = createZone('workspace-b', 'win-b');
+
+        DragCoordinator.register(zoneA);
+        DragCoordinator.register(zoneB);
+
+        move(source, 300, 300);
+
+        // the winner's window closes under the drag
+        DragCoordinator.unregister(zoneA);
+
+        move(source, 310, 310);
+
+        expect(calls.filter(([name]) => name === 'move' || name === 'leave')).toEqual([
+            ['move',  'workspace-a', 300, 300],
+            ['leave', 'workspace-a'],
+            ['move',  'workspace-b', 210, 210]
+        ])
+    });
+
+    test('NATIVE hover renders CONTINUOUS preview per geometry event — the dwell timer gates only the commit', () => {
+        const
+            draggedItem = {id: 'tab-1'},
+            source      = {
+                sortGroup: 'dock',
+                windowId : 'win-source',
+                getNativeWindowDrag(windowId) {
+                    return windowId === 'win-popup' ? {draggedItem, widgetName: 'tab-1'} : null
+                },
+                async suspendWindowDrag(widgetName) {
+                    calls.push(['suspend', widgetName])
+                }
+            },
+            target = createZone('workspace-b', 'win-target');
+
+        registerWindow('win-source', 2000,   0, 400, 400);
+        registerWindow('win-popup',   500, 500, 300, 200);
+        registerWindow('win-target',  600, 550, 400, 300);
+
+        DragCoordinator.register(source);
+        DragCoordinator.register(target);
+
+        // two geometry events while the popup's center (650, 600) sits over the target
+        DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
+        DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
+
+        // preview rendered per event, BEFORE any dwell elapsed; nothing committed
+        expect(calls.filter(([name]) => name === 'move').length).toBe(2);
+        expect(calls.filter(([name]) => name === 'drop')).toEqual([]);
+
+        // the popup leaves the target: the hover ends exact-once
+        WindowManager.get('win-popup').innerRect = new Rectangle(3000, 3000, 300, 200);
+
+        DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
+
+        expect(calls.filter(([name]) => name === 'leave')).toEqual([['leave', 'workspace-b']]);
+        expect(DragCoordinator.nativeHoverTargets.size).toBe(0);
+
+        // the source drag ends (popup no longer carries a drag): the gesture's token dies
+        source.getNativeWindowDrag = () => null;
+
+        DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
+
+        expect(DragCoordinator.nativeClaimArbiters.size).toBe(0)
+    })
+});

--- a/test/playwright/unit/manager/GestureClaimArbiter.spec.mjs
+++ b/test/playwright/unit/manager/GestureClaimArbiter.spec.mjs
@@ -107,6 +107,44 @@ test.describe('Neo.manager.GestureClaimArbiter — the §2.8.1 claim protocol', 
         expect(record.acquiredAt).toBe(1_000)
     });
 
+    test('reacquisition after expiry is a NEW claim — stale seniority cannot revive', () => {
+        const
+            zoneA = {id: 'zone-a'},
+            zoneB = {id: 'zone-b'};
+
+        // A claims at t=1000 (expires t=1100)...
+        arbiter.claim('workspace-a', zoneA);
+
+        // ...B claims at t=1120, while A sits expired-but-unpruned in the map...
+        clock = 1_120;
+        arbiter.claim('workspace-b', zoneB);
+
+        // ...and A re-claims at t=1150. An expired record is ABSENT by contract, so this is a
+        // reacquisition: a fresh acquisition time, not the revival of t=1000 seniority.
+        clock = 1_150;
+        const record = arbiter.claim('workspace-a', zoneA);
+
+        expect(record.acquiredAt).toBe(1_150);
+
+        // The competitive proof: B (t=1120) beats the reacquired A (t=1150). Under the revival
+        // defect A would carry t=1000 and steal the gesture back through its own staleness.
+        expect(arbiter.resolve()).toEqual({stableId: 'workspace-b', zone: zoneB})
+    });
+
+    test('the expiry boundary is exact: a refresh AT expiresAt keeps seniority; one tick past is reacquisition', () => {
+        const zone = {id: 'zone-a'};
+
+        arbiter.claim('workspace-a', zone);
+
+        // exactly at the boundary (expiresAt === now): still live — seniority survives
+        clock = 1_100;
+        expect(arbiter.claim('workspace-a', zone).acquiredAt).toBe(1_000);
+
+        // one tick past the refreshed expiry (1100 + 100): reacquisition
+        clock = 1_201;
+        expect(arbiter.claim('workspace-a', zone).acquiredAt).toBe(1_201)
+    });
+
     test('an expired claim is ignored AND pruned — staleness is not an error, it is absence', () => {
         arbiter.claim('workspace-a', {id: 'zone-a'});
 

--- a/test/playwright/unit/manager/GestureClaimArbiter.spec.mjs
+++ b/test/playwright/unit/manager/GestureClaimArbiter.spec.mjs
@@ -1,0 +1,184 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'ManagerGestureClaimArbiterTest'
+    },
+    mockLocalStorage: false,
+    mockMain        : false
+});
+
+import {test, expect}              from '@playwright/test';
+import {createGestureClaimArbiter} from '../../../../src/manager/GestureClaimArbiter.mjs';
+
+/**
+ * @summary The gesture/claim protocol contract (harness docking design record §2.8.1): one token
+ * per gesture, hit-claims on stable identity, validity/expiry, and deterministic outcomes for all
+ * three cases — tie (earliest valid acquisition, stable-id lexicographic final tiebreak), stale
+ * (ignored), no-claim (fail closed: `resolve()` returns null).
+ *
+ * The clock is injected and advanced by hand, so every ordering assertion below is deterministic
+ * by construction — no waits, no real time.
+ */
+test.describe('Neo.manager.GestureClaimArbiter — the §2.8.1 claim protocol', () => {
+    let clock, arbiter;
+
+    const now = () => clock;
+
+    test.beforeEach(() => {
+        clock   = 1_000;
+        arbiter = createGestureClaimArbiter({claimTtlMs: 100, now})
+    });
+
+    test('one token per gesture — unique across arbiters, stamped on every claim record', () => {
+        const sibling = createGestureClaimArbiter({now});
+
+        expect(arbiter.token).toBeTruthy();
+        expect(sibling.token).toBeTruthy();
+        expect(arbiter.token).not.toBe(sibling.token);
+
+        const record = arbiter.claim('workspace-a', {id: 'zone-a'});
+
+        expect(record.token).toBe(arbiter.token)
+    });
+
+    test('a single valid claim wins', () => {
+        const zone = {id: 'zone-a'};
+
+        arbiter.claim('workspace-a', zone);
+
+        expect(arbiter.resolve()).toEqual({stableId: 'workspace-a', zone})
+    });
+
+    test('no claim → null — fail closed is the resolver default, not a special case', () => {
+        expect(arbiter.resolve()).toBeNull()
+    });
+
+    test('the earliest valid acquisition wins', () => {
+        const
+            elder   = {id: 'zone-elder'},
+            younger = {id: 'zone-younger'};
+
+        arbiter.claim('workspace-b', elder);
+
+        clock += 10;
+        arbiter.claim('workspace-a', younger);
+
+        // 'workspace-a' would win the lexicographic tiebreak — proving the age axis dominates it.
+        expect(arbiter.resolve()).toEqual({stableId: 'workspace-b', zone: elder})
+    });
+
+    test('a same-millisecond tie falls to stable-id lexicographic order — never claim insertion order', () => {
+        const
+            zoneC = {id: 'zone-c'},
+            zoneA = {id: 'zone-a'};
+
+        // inserted c-first so an insertion-order resolver would answer 'workspace-c'
+        arbiter.claim('workspace-c', zoneC);
+        arbiter.claim('workspace-a', zoneA);
+
+        expect(arbiter.resolve()).toEqual({stableId: 'workspace-a', zone: zoneA})
+    });
+
+    test('refresh keeps acquisition seniority while extending expiry', () => {
+        const
+            elder   = {id: 'zone-elder'},
+            younger = {id: 'zone-younger'};
+
+        arbiter.claim('workspace-elder', elder);
+
+        clock += 60;
+        arbiter.claim('workspace-a-younger', younger);
+
+        // refresh the elder INSIDE its window: seniority must survive, expiry must extend
+        clock += 30;
+        arbiter.claim('workspace-elder', elder);
+
+        // 90ms past the elder's ORIGINAL claim — expired unless the refresh extended it
+        clock += 60;
+
+        const winner = arbiter.resolve();
+
+        expect(winner.stableId).toBe('workspace-elder');
+
+        // ...and the refreshed record still carries the ORIGINAL acquisition time
+        const record = arbiter.claim('workspace-elder', elder);
+
+        expect(record.acquiredAt).toBe(1_000)
+    });
+
+    test('an expired claim is ignored AND pruned — staleness is not an error, it is absence', () => {
+        arbiter.claim('workspace-a', {id: 'zone-a'});
+
+        clock += 101;
+
+        expect(arbiter.resolve()).toBeNull();
+        expect(arbiter.claimCount).toBe(0)
+    });
+
+    test('an expired senior falls to the surviving junior', () => {
+        const junior = {id: 'zone-junior'};
+
+        arbiter.claim('workspace-senior', {id: 'zone-senior'});
+
+        clock += 60;
+        arbiter.claim('workspace-junior', junior);
+
+        // 110ms past the senior's only claim, 50ms past the junior's — exactly one survivor
+        clock += 50;
+
+        expect(arbiter.resolve()).toEqual({stableId: 'workspace-junior', zone: junior})
+    });
+
+    test('release drops a claim; releasing an unknown id is a no-op', () => {
+        arbiter.claim('workspace-a', {id: 'zone-a'});
+
+        arbiter.release('workspace-a');
+        arbiter.release('workspace-never-claimed');
+
+        expect(arbiter.resolve()).toBeNull();
+        expect(arbiter.claimCount).toBe(0)
+    });
+
+    test('reset kills every claim — the token\'s claims die with its gesture', () => {
+        arbiter.claim('workspace-a', {id: 'zone-a'});
+        arbiter.claim('workspace-b', {id: 'zone-b'});
+
+        arbiter.reset();
+
+        expect(arbiter.claimCount).toBe(0);
+        expect(arbiter.resolve()).toBeNull()
+    });
+
+    test('a refresh adopts the latest zone handle — same stable identity, re-embodied surface', () => {
+        const
+            first  = {id: 'zone-first'},
+            second = {id: 'zone-second'};
+
+        arbiter.claim('workspace-a', first);
+        arbiter.claim('workspace-a', second);
+
+        expect(arbiter.resolve().zone).toBe(second);
+        expect(arbiter.claimCount).toBe(1)
+    });
+
+    test('three simultaneous claimants, exactly one winner — the arbiter tier of the overlap falsifier', () => {
+        const zones = {
+            'workspace-a': {id: 'zone-a'},
+            'workspace-b': {id: 'zone-b'},
+            'workspace-c': {id: 'zone-c'}
+        };
+
+        // all three claim in the same millisecond — worst case for determinism
+        arbiter.claim('workspace-c', zones['workspace-c']);
+        arbiter.claim('workspace-b', zones['workspace-b']);
+        arbiter.claim('workspace-a', zones['workspace-a']);
+
+        const winner = arbiter.resolve();
+
+        expect(winner).toEqual({stableId: 'workspace-a', zone: zones['workspace-a']});
+
+        // resolving again yields the SAME winner — resolution is a pure read, not a consumption
+        expect(arbiter.resolve()).toEqual(winner)
+    })
+});


### PR DESCRIPTION
Resolves #15246

Related: #15239 (the epic) · ADR-0029 §2.8.1 / §2.1 / §2.3 (the ratified contracts this implements, cited as upstream per §2.8.4's merge order) · #15247 — G4 unblocks on this merge (whole-stack reintegration + the vessel-close/emptied-entry disposition consume the workspace-set + claims) · #15244 (G1, merged — produces the vessels this arbitrates).

**The G3 leaf lands whole: beat 3 of the epic's five-beat story** — dragging over ANOTHER popup lights dock-zone previews INSIDE it, deterministically, with exactly one target claiming the gesture.

Three contract surfaces, per the ticket's one-PR prescription:

1. **The §2.8.1 gesture/claim protocol** replaces first-intersecting registration-order resolution on the dock path.
   - `src/manager/GestureClaimArbiter.mjs` — a pure per-gesture factory (zero imports, closure state, injected clock): one token per drag; acquire-or-refresh claims on STABLE identity (refresh keeps acquisition seniority, adopts the latest zone handle); TTL expiry; deterministic outcomes for all three contract cases — tie (earliest valid acquisition, stable-id lexicographic final tiebreak), stale (ignored AND pruned), no-claim (`resolve()` → null = fail closed).
   - `DragCoordinator` mints one arbiter per gesture (pointer path: lazily at the first move, killed at end AND cancel; native path: per moving popup, killed at commit, source-end, and cancel-correlated departure). Candidate zones claim on window-`innerRect` containment plus their own side-effect-free hit-test; the winner drives the EXISTING enter/leave/suspend choreography unchanged. Dock-blindness holds: the coordinator consumes `zone.stableTargetId` and main-thread window geometry — never dock semantics.
   - **The legacy door is CLOSED to stable zones**: a zone declaring `stableTargetId` can never be resolved through `getWindowAt` — witnessed with a chrome-band differential where first-intersecting resolution WOULD have handed it the gesture with chrome-space coordinates. Stable-identity-free zones keep the pinned legacy path, and its registration-order dependence is pinned as the negative witness (the identical layout's winner flips with window registration order — the exact nondeterminism the protocol exists to replace).
2. **Continuous remote preview on the native-titlebar path**: the current candidate target renders its own affordances (`onRemoteDragMove` → the owner's preview seam, the shared affordance consumer) on EVERY geometry event — per frame, not only after the 450 ms/250 ms dwell — while dwell/settle still gates the COMMIT. Hover switches and losses end the previous target's preview exact-once: `updateNativeHover` + `endNativeGesture` join the §2.8.2-invariant-4 cleanup matrix, and `unregister` now releases a departed zone's claims from every live arbiter and ends its native hover while the reference can still reach it (the same reasoning as the landed `activeTargetZone` guard).
3. **The workspace-set registry** (`src/dashboard/DockWorkspaceSet.mjs`, pure factory): the worker-owned `{workspaceId → document}` composition — stable semantic identity in, document truth out, fail-closed resolution for unknown ids, register-replaces for re-embodied vessels, both-or-neither `adoptTransfer` for the executor's committed pair (the commit-or-neither contract kept at the ownership tier), and retirement EXPLICIT only per §2.8.3: closing a vessel unbinds a render target, never deletes worker documents — the retained-vs-retired disposition stays G4's named decision. `windowId` cannot enter the registry (witnessed). DemoB consumes it: both workspaces register under their stable ids, `getWorkspaceDocument` delegates, and the cross-window transfer commit adopts the pair through it instead of hardcoded two-workspace ternaries.
4. **`stableTargetId` threading**: `CrossWindowDragTarget` carries the §2.8.1 claim identity as contract config; `DockCrossWindowParticipation` passes its `workspaceId` — so every dock workspace target rides the deterministic protocol by construction, and the workspace id (never `windowId`, never registration order) IS the claim key.

**THE BINDING FALSIFIER, verbatim**: three overlapping windows, one gesture → exactly ONE preview and exactly ONE commit. Witnessed at two tiers — arbiter (three same-millisecond claimants, one deterministic winner, resolve is a pure read) and coordinator (three real overlapping `manager.Window` rects, zone registration order deliberately REVERSED against the expected winner, preview-set and commit-set both asserted singleton).

## AC ledger

- AC1 `{workspaceId → document}` composition — ✓ registry + DemoB registration under stable ids; `windowId` runtime-only (identity-semantic witness).
- AC2 continuous remote preview — ✓ per-geometry-event native hover through the owner's affordance seam; the pointer path was already continuous per move.
- AC3 the claim protocol per the ratified contract — ✓ token, stable-identity claims, expiry, deterministic tie/stale/no-claim, fail closed unclaimed (arbiter 12 witnesses + coordinator tier).
- AC4 the ≥3-window OVERLAP witness — ✓ verbatim at the coordinator tier.
- AC5 active-vs-saved boundary — ✓ registry holds worker truth only; claims/hover are runtime-only state; stable claim identity is the workspace id.
- AC6 registration-order resolution replaced on the dock path — ✓ stable zones claim-only with the legacy door closed; the old path's behavior pinned as the negative witness.

## Deltas from ticket

- The claim protocol's expiry semantics are sharpened one notch past the ticket prose (reviewer falsifier, repaired in-cycle): an expired record at `claim()` time is ABSENT — reacquisition receives a new acquisition time, so stale seniority cannot revive. The boundary (`expiresAt >= now` = live) is pinned identically at claim and resolve.
- `adoptTransfer`'s both-or-neither holds against THROWING writers by TWO-SIDED compensation (two reviewer falsifiers, repaired in-cycle): both previous documents are captured before the first write, and either write failing compensates every writer already invoked — reverse order, prior documents, guarded re-invocation. A writer that MUTATES then throws is restored by its own assignment ordering (the compensating call's assignment lands before the repeat throw); the original error always propagates. The stated residual: a writer defeating both the write and the compensation is a double accessor-contract breach — its own state is its breach, the pair's other side still restores.
- The native-titlebar sequence is pinned as: continuous pre-dwell hover preview per geometry event, then the landed commit refresh (`suspend → move → drop → dropOut`) — dwell/settle gate the COMMIT only. The pre-existing dwell/settle witnesses in `unit/draggable` now pin that exact sequence.
- The Contract Ledger for the four consumed surfaces (arbiter, `stableTargetId` claim path, workspace-set, Demo-B adoption) is folded into #15246 (implementer disposition on reviewer RA); this PR's AC ledger names the same surfaces.

## Test Evidence

Evidence: focused `GestureClaimArbiter` **15/15** · `DockWorkspaceSet` **13/13** · `DragCoordinator` §2.8.1 block **6 witnesses** · full `unit/draggable` + `unit/manager` + `unit/dashboard` + `unit/apps/agentos` **832/832** at the current head (mutate-then-throw + source-write-failure compensation witnesses included).

- The affected-surface sweep now follows the IMPORT GRAPH (the coordinator's consumers), which is how `unit/draggable`'s native-titlebar witnesses joined the run — the two dwell/settle pins were updated to the pinned preview sequence above and pass.
- Cycle-1's `802/802` claim was accurate for its named subset but omitted `unit/draggable`; the current line supersedes it.

## Post-Merge Validation

- [ ] #15247 (G4) consumes the workspace-set + claim substrate for whole-stack reintegration and the vessel-close/emptied-entry disposition.
- [ ] A ≥3-popup headed journey composes on the demo host's e2e witness harness (the merged G1 executor pattern applies directly).

## Commits

`f949d85a23` — the protocol, the registry, the continuous preview, the witnesses.
`58624f8254` — expiry ends seniority (reacquisition semantics), throwing-writer rollback, the pinned native sequence, the two reviewer-falsifier witnesses.

Authored by Clio (Claude Fable 5, Claude Code). Session 0c8fc4d9-2456-44fd-b120-048402bb9839.
