### PR TITLE
feat(main): add per-window input modality tracker (#15466)

### DIFF
--- a/src/main/addon/InputModality.mjs
+++ b/src/main/addon/InputModality.mjs
@@ -1,0 +1,145 @@
+import Base from './Base.mjs';
+
+/**
+ * @summary Owns pointer-versus-keyboard input truth for one main-thread document.
+ *
+ * Every Neo window has its own Main realm and therefore its own addon instance. Native document
+ * input updates that realm's marker directly, while App-Worker callers route `setModality()` through
+ * Remote Method Access with a `windowId` to stamp the focus-arrival document deterministically.
+ * Consumers can key CSS on `data-input-modality` without moving DOM ownership into the App Worker.
+ *
+ * @class Neo.main.addon.InputModality
+ * @extends Neo.main.addon.Base
+ */
+class InputModality extends Base {
+    static config = {
+        /**
+         * Attribute written onto this realm's `documentElement`.
+         * @member {String} attributeName='data-input-modality'
+         */
+        attributeName: 'data-input-modality',
+        /**
+         * @member {String} className='Neo.main.addon.InputModality'
+         * @protected
+         */
+        className: 'Neo.main.addon.InputModality',
+        /**
+         * No external files need to delay remote readiness.
+         * @member {Boolean} preloadFilesDelay=false
+         * @protected
+         */
+        preloadFilesDelay: false,
+        /**
+         * App-Worker access to the modality query and named-window stamp.
+         * @member {Object} remote
+         * @protected
+         */
+        remote: {
+            app: [
+                'getModality',
+                'setModality'
+            ]
+        }
+    }
+
+    /**
+     * The document captured by this Main realm. Keeping the reference makes teardown independent
+     * from later global changes in tests and from popup lifecycle timing.
+     * @member {Document|null} documentRef=null
+     * @protected
+     */
+    documentRef = null
+    /**
+     * Shared listener options. `capture` observes the native cause before component handlers and
+     * `passive` guarantees that modality tracking never changes event behavior.
+     * @member {Object} listenerOptions
+     * @protected
+     */
+    listenerOptions = {capture: true, passive: true}
+
+    /**
+     * @param {Object} config
+     */
+    construct(config) {
+        super.construct(config);
+
+        const documentRef = this.documentRef = globalThis.document;
+
+        if (documentRef?.documentElement) {
+            documentRef.addEventListener('pointerdown', this.onPointerDown, this.listenerOptions);
+            documentRef.addEventListener('mousedown',   this.onPointerDown, this.listenerOptions);
+            documentRef.addEventListener('keydown',     this.onKeyDown,     this.listenerOptions)
+        }
+    }
+
+    /**
+     * Removes the realm-owned listeners and marker before the addon lifecycle ends.
+     * @returns {void}
+     */
+    destroy() {
+        const {attributeName, documentRef, listenerOptions} = this;
+
+        if (documentRef?.documentElement) {
+            documentRef.removeEventListener('pointerdown', this.onPointerDown, listenerOptions);
+            documentRef.removeEventListener('mousedown',   this.onPointerDown, listenerOptions);
+            documentRef.removeEventListener('keydown',     this.onKeyDown,     listenerOptions);
+            documentRef.documentElement.removeAttribute(attributeName)
+        }
+
+        super.destroy()
+    }
+
+    /**
+     * Reads this window document's current marker. App-Worker callers include `windowId` in the
+     * first argument so Remote Method Access selects the intended Main realm before this executes.
+     * @param {Object} [data]
+     * @param {String} [data.windowId] Routing metadata consumed by Remote Method Access.
+     * @returns {String|null}
+     */
+    getModality(data) {
+        const root = this.documentRef?.documentElement;
+
+        return root?.getAttribute(this.attributeName) || null
+    }
+
+    /**
+     * Native keyboard input establishes keyboard modality for this document.
+     * @returns {void}
+     * @protected
+     */
+    onKeyDown = () => {
+        this.setModality({modality: 'keyboard'})
+    }
+
+    /**
+     * Native pointer or mouse input establishes pointer modality for this document.
+     * @returns {void}
+     * @protected
+     */
+    onPointerDown = () => {
+        this.setModality({modality: 'pointer'})
+    }
+
+    /**
+     * Stamps this Main realm's document with an explicit modality. The App Worker must pass the
+     * target `windowId`; Remote Method Access consumes it for routing and this method owns only the
+     * selected document mutation.
+     * @param {Object} data
+     * @param {'keyboard'|'pointer'} data.modality
+     * @param {String} [data.windowId] Routing metadata consumed by Remote Method Access.
+     * @returns {Boolean} Whether a marker was written.
+     */
+    setModality({modality} = {}) {
+        const root = this.documentRef?.documentElement;
+
+        if (!root || (modality !== 'keyboard' && modality !== 'pointer')) {
+            return false
+        }
+
+        root.setAttribute(this.attributeName, modality);
+
+        return true
+    }
+}
+
+export default Neo.setupClass(InputModality);

--- a/test/playwright/e2e/rendering/InputModalityMultiWindow.spec.mjs
+++ b/test/playwright/e2e/rendering/InputModalityMultiWindow.spec.mjs
@@ -1,0 +1,120 @@
+import {test, expect} from '@playwright/test';
+
+let probeSequence = 0;
+
+/**
+ * @summary Executes a unique test-only module in the real App Worker.
+ *
+ * `Neo.worker.App.loadModule()` is called through its Main-to-App RMA proxy. The imported module then
+ * uses the production App-Worker `getAddon()` path, so a named-window stamp traverses App Worker →
+ * target Main instead of being simulated with a direct page-realm method call.
+ * @param {import('@playwright/test').Page} page
+ * @param {String} source
+ * @returns {Promise<Object>}
+ */
+async function runInAppWorker(page, source) {
+    const path = `data:text/javascript;charset=utf-8,${encodeURIComponent(`${source}\n// input-modality-probe-${++probeSequence}`)}`;
+
+    return page.evaluate(modulePath => Neo.worker.App.loadModule({path: modulePath}), path)
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @param {String} windowId
+ * @param {'keyboard'|'pointer'} [modality]
+ * @returns {Promise<void>}
+ */
+async function loadOrStampTracker(page, windowId, modality) {
+    const lines = [
+        `const addon = await Neo.currentWorker.getAddon('InputModality', ${JSON.stringify(windowId)});`
+    ];
+
+    if (modality) {
+        lines.push(`await addon.setModality(${JSON.stringify({modality, windowId})});`)
+    }
+
+    const result = await runInAppWorker(page, lines.join('\n'));
+
+    expect(result?.data ?? result).toMatchObject({success: true})
+}
+
+/**
+ * @param {import('@playwright/test').Page} page
+ * @param {Boolean} [includeWorkerId=true]
+ * @returns {Promise<{windowId: String, workerId: String|undefined}>}
+ */
+async function getRealmIdentity(page, includeWorkerId = true) {
+    await page.waitForFunction(requireWorkerId =>
+        Neo?.worker?.Manager?.windowId && (!requireWorkerId || Neo?.worker?.App?.getWorkerId), includeWorkerId, {
+        timeout: 30000
+    });
+
+    return page.evaluate(async requireWorkerId => {
+        const workerReply = requireWorkerId ? await Neo.worker.App.getWorkerId() : undefined;
+
+        return {
+            windowId: Neo.worker.Manager.windowId,
+            workerId: typeof workerReply === 'string' ? workerReply : workerReply?.data
+        }
+    }, includeWorkerId)
+}
+
+/**
+ * @summary Real two-window proof for document-local input tracking and named-window worker stamps.
+ */
+test.describe('#15466 per-window input modality tracker', () => {
+    test.setTimeout(120000);
+
+    test('isolates real input per document and routes a worker stamp to the named popup', async ({page}) => {
+        let popup;
+
+        await page.goto('/apps/agentos/index.html');
+        await expect(page.locator('.agent-shell')).toBeVisible({timeout: 60000});
+        await expect(page.locator('html')).not.toHaveAttribute('data-input-modality');
+
+        const sourceRealm = await getRealmIdentity(page);
+
+        expect(sourceRealm.windowId).toBeTruthy();
+        expect(sourceRealm.workerId).toBeTruthy();
+
+        try {
+            [popup] = await Promise.all([
+                page.waitForEvent('popup'),
+                page.evaluate(() => Boolean(window.open('/apps/agentos/index.html?input-modality-popup', 'input-modality-popup')))
+            ]);
+
+            await popup.waitForLoadState('domcontentloaded');
+            await expect(popup.locator('.agent-shell')).toBeVisible({timeout: 60000});
+            await expect(popup.locator('html')).not.toHaveAttribute('data-input-modality');
+
+            const popupRealm = await getRealmIdentity(popup, false);
+
+            expect(popupRealm.windowId).toBeTruthy();
+            expect(popupRealm.windowId).not.toBe(sourceRealm.windowId);
+
+            await loadOrStampTracker(page, sourceRealm.windowId);
+            await loadOrStampTracker(page, popupRealm.windowId);
+
+            await expect(page.locator('html')).not.toHaveAttribute('data-input-modality');
+            await expect(popup.locator('html')).not.toHaveAttribute('data-input-modality');
+
+            await page.keyboard.press('Tab');
+            await expect(page.locator('html')).toHaveAttribute('data-input-modality', 'keyboard');
+            await expect(popup.locator('html')).not.toHaveAttribute('data-input-modality');
+
+            await popup.mouse.click(5, 5);
+            await expect(popup.locator('html')).toHaveAttribute('data-input-modality', 'pointer');
+            await expect(page.locator('html')).toHaveAttribute('data-input-modality', 'keyboard');
+
+            await page.mouse.click(5, 5);
+            await expect(page.locator('html')).toHaveAttribute('data-input-modality', 'pointer');
+
+            await loadOrStampTracker(page, popupRealm.windowId, 'keyboard');
+
+            await expect(popup.locator('html')).toHaveAttribute('data-input-modality', 'keyboard');
+            await expect(page.locator('html')).toHaveAttribute('data-input-modality', 'pointer')
+        } finally {
+            await popup?.close().catch(() => {})
+        }
+    })
+});

--- a/test/playwright/unit/main/addon/InputModality.spec.mjs
+++ b/test/playwright/unit/main/addon/InputModality.spec.mjs
@@ -1,0 +1,145 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'InputModalityTest'
+    },
+    neoConfig: {
+        unitTestMode: true
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import InputModality  from '../../../../../src/main/addon/InputModality.mjs';
+
+/**
+ * @summary Creates the minimal document surface owned by the addon.
+ * @returns {Document}
+ */
+function createDocument() {
+    const
+        attributes  = new Map(),
+        documentRef = new EventTarget();
+
+    documentRef.documentElement = {
+        getAttribute(name) {
+            return attributes.get(name) ?? null
+        },
+        removeAttribute(name) {
+            attributes.delete(name)
+        },
+        setAttribute(name, value) {
+            attributes.set(name, String(value))
+        }
+    };
+
+    return documentRef
+}
+
+/**
+ * @param {Document} documentRef
+ * @returns {Promise<Neo.main.addon.InputModality>}
+ */
+async function createTracker(documentRef) {
+    globalThis.document = documentRef;
+
+    const tracker = Neo.create(InputModality);
+
+    await tracker.ready();
+
+    return tracker
+}
+
+test.describe('Neo.main.addon.InputModality', () => {
+    let originalDocument,
+        trackers;
+
+    test.beforeEach(() => {
+        originalDocument = globalThis.document;
+        trackers         = []
+    });
+
+    test.afterEach(() => {
+        trackers.forEach(tracker => tracker.destroy());
+
+        originalDocument === undefined ? delete globalThis.document : globalThis.document = originalDocument
+    });
+
+    test('flips the document marker on native pointer, mouse, and keyboard input', async () => {
+        const
+            documentRef = createDocument(),
+            tracker     = await createTracker(documentRef);
+
+        trackers.push(tracker);
+
+        expect(tracker.getModality()).toBeNull();
+
+        documentRef.dispatchEvent(new Event('pointerdown'));
+        expect(tracker.getModality()).toBe('pointer');
+
+        documentRef.dispatchEvent(new Event('keydown'));
+        expect(tracker.getModality()).toBe('keyboard');
+
+        documentRef.dispatchEvent(new Event('mousedown'));
+        expect(tracker.getModality()).toBe('pointer')
+    });
+
+    test('keeps modality truth isolated per document instance', async () => {
+        const
+            firstDocument  = createDocument(),
+            firstTracker   = await createTracker(firstDocument),
+            secondDocument = createDocument(),
+            secondTracker  = await createTracker(secondDocument);
+
+        trackers.push(firstTracker, secondTracker);
+
+        firstDocument.dispatchEvent(new Event('keydown'));
+
+        expect(firstTracker.getModality()).toBe('keyboard');
+        expect(secondTracker.getModality()).toBeNull();
+
+        secondDocument.dispatchEvent(new Event('pointerdown'));
+
+        expect(firstTracker.getModality()).toBe('keyboard');
+        expect(secondTracker.getModality()).toBe('pointer')
+    });
+
+    test('accepts a named-window worker stamp and rejects unknown marker values', async () => {
+        const tracker = await createTracker(createDocument());
+
+        trackers.push(tracker);
+
+        expect(tracker.setModality({modality: 'keyboard', windowId: 'popup-window'})).toBe(true);
+        expect(tracker.getModality({windowId: 'popup-window'})).toBe('keyboard');
+        expect(tracker.setModality({modality: 'touch', windowId: 'popup-window'})).toBe(false);
+        expect(tracker.getModality()).toBe('keyboard')
+    });
+
+    test('removes listeners and the owned marker on destroy', async () => {
+        const
+            documentRef = createDocument(),
+            tracker     = await createTracker(documentRef);
+
+        documentRef.dispatchEvent(new Event('keydown'));
+        expect(tracker.getModality()).toBe('keyboard');
+
+        tracker.destroy();
+        documentRef.dispatchEvent(new Event('pointerdown'));
+
+        expect(documentRef.documentElement.getAttribute('data-input-modality')).toBeNull()
+    });
+
+    test('fails safe when no document exists', async () => {
+        delete globalThis.document;
+
+        const tracker = Neo.create(InputModality);
+
+        trackers.push(tracker);
+        await tracker.ready();
+
+        expect(tracker.getModality()).toBeNull();
+        expect(tracker.setModality({modality: 'keyboard', windowId: 'missing-window'})).toBe(false)
+    })
+});


### PR DESCRIPTION
Resolves #15466

Adds a document-owned input-modality primitive for Neo's multi-window runtime. Each Main realm tracks native pointer and keyboard input independently, publishes the result through `data-input-modality`, and exposes App-Worker RMA methods that can read or stamp one explicitly named window before an asynchronous focus arrival.

Evidence: L3 achieved — a real Chromium journey opened two AgentOS documents sharing one App Worker, proved fresh independent markers, drove native keyboard/pointer flips in both realms, and routed an App-Worker stamp exclusively to the named popup. Residual: none.

## Deltas from ticket

- The worker API uses the RMA-required object shape, `setModality({modality, windowId})`, instead of the ticket's shorthand string example.
- The E2E witness loads the addon lazily through the production `Neo.currentWorker.getAddon()` path, preserving the ticket's absent-addon fallback before opt-in.
- No consumer retrofits were added; #15195 and #15250 remain independent consumer lanes.

## Test Evidence

- Main-addon contract: `npm run test-unit -- test/playwright/unit/main/addon/InputModality.spec.mjs` — 5/5 passed.
- Multi-window runtime: `NEO_E2E_PORT=49128 npx playwright test rendering/InputModalityMultiWindow -c test/playwright/playwright.config.e2e.mjs --workers=1` — 1/1 passed.
- Source and test formatting: `git diff --check` — passed.
- Existing non-CI coverage for this new surface: none; the focused unit and E2E witnesses are introduced here.

## Post-Merge Validation

- [ ] Run the focused multi-window witness from `dev` and confirm the App-Worker stamp still changes only the named popup document.
- [ ] Confirm #15250 consumes the primitive through a target `windowId` without moving document ownership into the App Worker.

## Evolution

The first browser control used Neural Link topology and exposed unrelated same-name-session bridge cross-talk. The final witness removes that dependency while retaining the stronger production path: Main RMA invokes the shared App Worker, which lazy-loads and stamps the explicitly named Main realm.

Authored by Emmy (@neo-gpt-emmy, GPT-5.6, Codex). Session `019f6981-3a8c-7530-a68b-50a2788698d0`.
