### PR TITLE
fix(core): unitTestMode setupClass returns an existing SINGLETON instead of throwing — restores the local oracle (#15364)

### DIFF
--- a/src/Neo.mjs
+++ b/src/Neo.mjs
@@ -5,7 +5,7 @@ const
     camelRegex   = /-./g,
     configSymbol = Symbol.for('configSymbol'),
     getSetCache  = Symbol('getSetCache'),
-    cloneMap = {
+    cloneMap     = {
         Array(obj, deep, ignoreNeoInstances) {
             return !deep ? obj.slice() : obj.map(val => Neo.clone(val, deep, ignoreNeoInstances))
         },
@@ -600,7 +600,7 @@ If you intended to create custom logic, use the 'beforeGet${Neo.capitalize(key)}
 
             b.forEach(newItem => {
                 const
-                    itemKey = getItemKey(newItem),
+                    itemKey       = getItemKey(newItem),
                     existingIndex = itemKey !== null ? existingMap.get(itemKey) : -1;
 
                 if (existingIndex !== undefined && existingIndex > -1) {
@@ -827,12 +827,20 @@ If you intended to create custom logic, use the 'beforeGet${Neo.capitalize(key)}
          * Example: code.LivePreview running inside a dist/production app.
          */
         if (ns) {
-            // A SINGLETON re-registration honors the arbitration the comment above documents (singletons
-            // must stay unique) — return the existing instance, exactly as the non-test path does. The
-            // unitTestMode guard flags only a NON-singleton double-setup: the genuine test-isolation leak
-            // it exists to catch, where two independent classes collide on one namespace.
-            if (Neo.config.unitTestMode && !proto.constructor.config.singleton) {
-                throw new Error('Namespace collision in unitTestMode for ' + proto.constructor.config.className)
+            // Exempt (return the already-registered value) ONLY when BOTH the incoming class and the
+            // existing registration are singletons — the documented "whichever registers first wins"
+            // arbitration (e.g. config.mjs + config.template.mjs, both 'Neo.ai.Config'). A non-singleton
+            // registers its class, a singleton its instance; a singleton colliding with a non-singleton on
+            // one namespace (in EITHER direction) is two distinct classes sharing a name — a genuine
+            // test-isolation leak — and must still fail loud.
+            if (Neo.config.unitTestMode) {
+                const existingClass       = ns.classConfigApplied ? ns : ns.constructor,
+                      incomingIsSingleton = proto.constructor.config.singleton === true,
+                      existingIsSingleton = existingClass?.config?.singleton === true;
+
+                if (!(incomingIsSingleton && existingIsSingleton)) {
+                    throw new Error('Namespace collision in unitTestMode for ' + proto.constructor.config.className)
+                }
             }
 
             return ns

--- a/src/Neo.mjs
+++ b/src/Neo.mjs
@@ -827,7 +827,11 @@ If you intended to create custom logic, use the 'beforeGet${Neo.capitalize(key)}
          * Example: code.LivePreview running inside a dist/production app.
          */
         if (ns) {
-            if (Neo.config.unitTestMode) {
+            // A SINGLETON re-registration honors the arbitration the comment above documents (singletons
+            // must stay unique) — return the existing instance, exactly as the non-test path does. The
+            // unitTestMode guard flags only a NON-singleton double-setup: the genuine test-isolation leak
+            // it exists to catch, where two independent classes collide on one namespace.
+            if (Neo.config.unitTestMode && !proto.constructor.config.singleton) {
                 throw new Error('Namespace collision in unitTestMode for ' + proto.constructor.config.className)
             }
 

--- a/test/playwright/unit/core/ClassSystem.spec.mjs
+++ b/test/playwright/unit/core/ClassSystem.spec.mjs
@@ -120,4 +120,42 @@ test.describe('ClassSystem', () => {
         expect(() => Neo.setupClass(SecondClass))
             .toThrow('Namespace collision in unitTestMode for ' + className)
     });
+
+    test('unitTestMode setupClass THROWS when a SINGLETON collides with an existing NON-singleton (#15364 mixed)', () => {
+        // Two-sided guard: the exemption must classify BOTH sides. A singleton arriving onto a namespace
+        // already holding a NON-singleton class is two distinct classes sharing a name — a real leak — so
+        // it must fail loud. A one-sided check that only inspects the INCOMING singleton would silently
+        // return the existing non-singleton here.
+        const className = 'Test.Unit.Core.ClassSystem.MixedNonSingletonFirst';
+
+        class FirstNonSingleton extends core.Base {
+            static config = {className}
+        }
+        Neo.setupClass(FirstNonSingleton);
+
+        class SecondSingleton extends core.Base {
+            static config = {className, singleton: true}
+        }
+
+        expect(() => Neo.setupClass(SecondSingleton))
+            .toThrow('Namespace collision in unitTestMode for ' + className)
+    });
+
+    test('unitTestMode setupClass THROWS when a NON-singleton collides with an existing SINGLETON (#15364 mixed)', () => {
+        // The opposite direction: a non-singleton arriving onto a namespace already holding a singleton
+        // instance is equally a leak — the exemption applies only when BOTH sides are singletons.
+        const className = 'Test.Unit.Core.ClassSystem.MixedSingletonFirst';
+
+        class FirstSingleton extends core.Base {
+            static config = {className, singleton: true}
+        }
+        Neo.setupClass(FirstSingleton);
+
+        class SecondNonSingleton extends core.Base {
+            static config = {className}
+        }
+
+        expect(() => Neo.setupClass(SecondNonSingleton))
+            .toThrow('Namespace collision in unitTestMode for ' + className)
+    });
 });

--- a/test/playwright/unit/core/ClassSystem.spec.mjs
+++ b/test/playwright/unit/core/ClassSystem.spec.mjs
@@ -75,4 +75,49 @@ test.describe('ClassSystem', () => {
         });
         expectations.forEach(item => expect(item.value, item.description).toBe(item.expected));
     });
+
+    test('unitTestMode setupClass returns the existing SINGLETON instead of throwing (#15364)', () => {
+        // The namespace-collision guard honors the documented singleton arbitration ("whichever
+        // registers first wins"): a re-registered singleton returns the existing instance, exactly as
+        // the non-test path does — it does NOT throw. This is what lets config.mjs + config.template.mjs
+        // (both className 'Neo.ai.Config', singleton) coexist in one unit process.
+        const className = 'Test.Unit.Core.ClassSystem.CollisionSingleton';
+
+        class FirstSingleton extends core.Base {
+            static config = {className, singleton: true}
+        }
+        const first = Neo.setupClass(FirstSingleton);
+
+        class SecondSingleton extends core.Base {
+            static config = {className, singleton: true}
+        }
+
+        let second, threw = false;
+        try {
+            second = Neo.setupClass(SecondSingleton)
+        } catch (e) {
+            threw = true
+        }
+
+        expect(threw, 'a re-registered singleton must NOT throw in unitTestMode').toBe(false);
+        expect(second, 'the second registration returns the existing singleton instance').toBe(first)
+    });
+
+    test('unitTestMode setupClass still THROWS for a NON-singleton double-setup (#15364)', () => {
+        // The guard's real purpose survives: two independent NON-singleton classes colliding on one
+        // namespace is a genuine test-isolation leak and must still fail loud.
+        const className = 'Test.Unit.Core.ClassSystem.CollisionNonSingleton';
+
+        class FirstClass extends core.Base {
+            static config = {className}
+        }
+        Neo.setupClass(FirstClass);
+
+        class SecondClass extends core.Base {
+            static config = {className}
+        }
+
+        expect(() => Neo.setupClass(SecondClass))
+            .toThrow('Namespace collision in unitTestMode for ' + className)
+    });
 });


### PR DESCRIPTION
Resolves #15364 — the `Neo.ai.Config` unitTestMode namespace collision that killed every `MailboxService`-importing local spec (and, per @neo-opus-vega's escalation, wedged test *collection* for non-`ai/` specs). Restores the missing local oracle.

## Root cause (traced + red-proven, see the issue)

`Neo.ai.Config` is registered by TWO files — `ai/config.template.mjs` (canonical) and the gitignored machine-local `ai/config.mjs` overlay — both `className: 'Neo.ai.Config'`, `singleton: true`. This is an **intentional idempotent arbitration** (`config.template.mjs:40`: "whichever registers first wins"), relying on `setupClass` returning the existing singleton for the second registrant. The unitTestMode guard (`Neo.mjs:831`) **threw** instead — breaking the documented design. CI is unaffected (no machine-local `config.mjs` there → single registration), which is exactly the "CI-only oracle" shape.

## The change

`src/Neo.mjs`: the unitTestMode collision guard now throws **only for a NON-singleton double-setup** — the genuine test-isolation leak it exists to catch (two independent classes colliding on one namespace). A **singleton** re-registration returns the existing instance, exactly as the non-test path does and as the guard's own comment (`:820-827`) already documents ("singletons must stay unique").

## Deltas from ticket — the fix LAYER

The ticket steered toward a test-harness fix, "not the singleton contract." This is the **core-guard** layer instead — and it honors that constraint: it does **not** mutate the `Neo.ai.Config` singleton contract (no leaf/formula/data change; ADR-0019 read, the fix is framework code, not an `ai/` config touch). I chose core-guard over a config-structure fix because it is the smallest change, honors the *documented* arbitration design rather than working around it, and resolves **both** observed shapes (MailboxService-spec death AND Vega's collection-wedge) at one site. If a reviewer prefers the config-structure layer, this PR is the concrete proposal to weigh against — object here.

## Test Evidence

Evidence: L1 — a **discriminating** singleton test in `core/ClassSystem.spec.mjs`, **RED against the unfixed guard** (stashed `Neo.mjs` → the re-registration throws, `threw).toBe(false)` fails) and green with the fix; plus a **non-singleton regression guard** proving the throw still fires for a genuine leak (green both before and after — the fix is surgical). No test asserts the throw (`deploymentConfig.spec:111` only documents the workaround). Deterministic probe red→green (import `config.template` + `config.mjs` in unitTestMode: was "COLLISION", now "NO collision"). Broad-blast check: **1332 passed, 0 failed** across `core/` + config singletons + `component/` + `container/`; `Server.spec` (a MailboxService importer) 20/20.

## Post-Merge Validation

- [x] A `MailboxService`-importing spec executes green (Server.spec 20/20).
- [x] Fix is framework-guard, not a mutation of the `Neo.ai.Config` singleton contract (ADR-0019).
- [x] Red-proven per the discriminating singleton test + the deterministic probe.
- [x] No CI regression — 1332-passed broad swath; the non-singleton leak guard still throws.
- [ ] Peers on machines that reproduced the collection-wedge (@neo-opus-vega) confirm the local oracle is restored post-merge.

Authored by Grace (Claude Opus 4.8, Claude Code).
