### PR TITLE
refactor(fleet): enforce single-class toggles (#15201)

### DIFF
--- a/apps/agentos/view/fleet/HealthBar.mjs
+++ b/apps/agentos/view/fleet/HealthBar.mjs
@@ -174,10 +174,7 @@ class HealthBar extends Container {
      * @protected
      */
     updateAnimateCls() {
-        const cls = (this.cls || []).filter(c => c !== 'fm-animate-counts');
-
-        this.animateCounts && cls.push('fm-animate-counts');
-        this.cls = cls
+        this.toggleCls('fm-animate-counts', this.animateCounts)
     }
 
     /**

--- a/apps/agentos/view/fleet/StateDot.mjs
+++ b/apps/agentos/view/fleet/StateDot.mjs
@@ -114,9 +114,7 @@ class StateDot extends Component {
      * @protected
      */
     afterSetLive(value, oldValue) {
-        let cls = this.cls;
-        NeoArray[value ? 'add' : 'remove'](cls, 'fm-live');
-        this.cls = cls
+        this.toggleCls('fm-live', value)
     }
 }
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetGrid.spec.mjs
@@ -258,6 +258,35 @@ test.describe('Fleet cockpit FleetGrid + HealthBar — Store-backed density-rank
         bar.destroy()
     });
 
+    test('HealthBar animateCounts enforces one class membership without disturbing caller or base classes (#15201)', () => {
+        const
+            bar      = Neo.create(HealthBar, {animateCounts: false, appName}),
+            observed = [];
+
+        bar.addCls('caller-authored');
+
+        const cleanup = bar.observeConfig(bar, 'cls', cls => observed.push([...cls]));
+
+        bar.animateCounts = true;
+        bar.animateCounts = true;
+
+        expect(observed).toHaveLength(1);
+        expect(observed[0]).toContain('fm-health-bar');
+        expect(observed[0]).toContain('caller-authored');
+        expect(observed[0].filter(cls => cls === 'fm-animate-counts')).toHaveLength(1);
+
+        bar.animateCounts = false;
+        bar.animateCounts = false;
+
+        expect(observed).toHaveLength(2);
+        expect(observed[1]).toContain('fm-health-bar');
+        expect(observed[1]).toContain('caller-authored');
+        expect(observed[1]).not.toContain('fm-animate-counts');
+
+        cleanup();
+        bar.destroy()
+    });
+
     test('degrades honestly on adapter loss — a stale header, never a blanked grid', () => {
         const grid = Neo.create(FleetGrid, {appName, adapterState: 'stale', store: makeStore(roster(['ok', 'idle', 'off']))});
 

--- a/test/playwright/unit/apps/agentos/view/fleet/statePrimitives.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/statePrimitives.spec.mjs
@@ -81,6 +81,36 @@ test.describe('Fleet cockpit StateDot — session-state token mapping + reduced-
         dot.destroy()
     });
 
+    test('StateDot live enforces one class membership without disturbing caller or base classes (#15201)', async () => {
+        const
+            dot      = Neo.create(StateDot, {appName, state: 'ok', live: false}),
+            observed = [];
+
+        await dot.initVnode();
+        dot.addCls('caller-authored');
+
+        const cleanup = dot.observeConfig(dot, 'cls', cls => observed.push([...cls]));
+
+        dot.live = true;
+        dot.live = true;
+
+        expect(observed).toHaveLength(1);
+        expect(observed[0]).toContain('fm-state-dot');
+        expect(observed[0]).toContain('caller-authored');
+        expect(observed[0].filter(cls => cls === 'fm-live')).toHaveLength(1);
+
+        dot.live = false;
+        dot.live = false;
+
+        expect(observed).toHaveLength(2);
+        expect(observed[1]).toContain('fm-state-dot');
+        expect(observed[1]).toContain('caller-authored');
+        expect(observed[1]).not.toContain('fm-live');
+
+        cleanup();
+        dot.destroy()
+    });
+
     test('StateDot binds the transitional starting/stopping classes in place (#14978)', async () => {
         const dot = Neo.create(StateDot, {appName, state: 'starting'});
         await dot.initVnode();


### PR DESCRIPTION
Resolves #15201

Replaces the two remaining Boolean-only Fleet class-array rewrites with the existing enforced `toggleCls(name, shouldExist)` boundary. `StateDot.live` and `HealthBar.animateCounts` now each publish one effective `cls` change when membership moves, preserve base and caller-authored classes, remain idempotent, and cannot duplicate their marker class. The four old→new replacement hooks and `SourceHealthMarker` stay untouched, preserving the atomicity boundary established during ticket intake.

Evidence: L2 (focused component/unit witnesses exercise both directions, repeated-state idempotence, one-publication cardinality, unrelated-class preservation, and duplicate prevention) → L2 required (the close target is a component API-consumer refactor with no visual or host-only AC). Residual: none.

## Deltas from ticket

None substantive from the corrected ticket body. The earlier six-site prescription was already narrowed on-ticket after the atomicity falsifier; this PR implements exactly the surviving two Boolean-marker sites and creates no successor micro-ticket.

## Test Evidence

- `npx playwright test apps/agentos/view/fleet/statePrimitives apps/agentos/view/fleet/fleetGrid -c test/playwright/playwright.config.unit.mjs --workers=1` — 20/20 passed on rebased head.
- `StateDot`: true→false and false→true, exactly one observed `cls` publication per membership change, repeated-state idempotence, one `fm-live`, base/caller class preservation.
- `HealthBar`: the same matrix for `fm-animate-counts`.
- Existing non-CI coverage for these class-consumer seams: None found; the behavior is fully exercised in the focused unit layer.

## Post-Merge Validation

- [ ] Confirm hosted CI remains green at the human merge head.

Authored by Emmy (`@neo-gpt-emmy`, GPT family).
