### PR TITLE
fix(memory-core): restore explore_lane_landscape config binding (#15468)

### DIFF
--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -21,6 +21,8 @@ import {makeChatModelGenerate}       from '../../../services/memory-core/helpers
 import {makeLandscapeCensusSource}   from '../../../services/graph/laneLandscapeCensusSource.mjs';
 import {makeOpenWorkCensusReader}    from '../../../services/github-workflow/openWorkCensusReader.mjs';
 import {synthesizeTemporalBirdView}  from '../../../services/memory-core/helpers/temporalBirdViewSynthesizer.mjs';
+import GitHubWorkflowConfig          from '../github-workflow/config.mjs';
+import MemoryCoreConfig              from './config.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
@@ -44,35 +46,58 @@ const readDeploymentInspection = args => readDeploymentStateSnapshot({
 // The pure composition is dependency-injected; this handler binds the impure edges at the MC server —
 // the graph census reads and the live chat model. Both reads resolve through their owning service at
 // call time (never captured here), so a store re-open cannot leave the census reading a dead database.
-const exploreLaneLandscapeOp = () => exploreLaneLandscape({
-    now : new Date(),
-    deps: {
-        // The census reads the source that OWNS the facts (live, cursor-walked to exhaustion); the graph
-        // supplies only relation edges, which is the one thing it does own, through its RLS seam. A local
-        // projection cannot answer a current-state question: both the graph and the synced corpus lag,
-        // and neither carries assignee truth.
-        ...makeLandscapeCensusSource({
-            ...makeOpenWorkCensusReader({
-                query : (queryString, variables) => GraphqlService.query(queryString, variables),
-                config: {
-                    owner       : AiConfig.owner,
-                    repo        : AiConfig.repo,
-                    maxLabels   : AiConfig.issueSync.maxLabelsPerIssue,
-                    maxAssignees: AiConfig.issueSync.maxAssigneesPerIssue
-                }
-            }),
-            listEdgeRecordsByType: args => GraphService.listEdgeRecordsByType(args),
-            pageLimit            : AiConfig.laneLandscapeCensusPageLimit,
-            maxPages             : AiConfig.laneLandscapeCensusMaxPages,
-            edgeLimit            : AiConfig.laneLandscapeRelationEdgeLimit
-        }),
-        generate: makeChatModelGenerate({
-            // SessionService is the Memory Core server's model owner and completes startup before tools
-            // dispatch. Read the live model at call time; do not thread AiConfig leaves into a second builder.
-            buildModel: () => SessionService.model
-        })
+/**
+ * @summary Reads the lane-landscape binding leaves from the child Provider that owns each domain.
+ *
+ * GitHub repository/query fan-out belongs to the GitHub Workflow child; census traversal bounds belong
+ * to the Memory Core child. Reading both at call time preserves reactive overlay/env resolution and
+ * fails loud when either provider is not wired, instead of masking the boundary with local defaults.
+ *
+ * @returns {{census: {edgeLimit: Number, maxPages: Number, pageLimit: Number}, source: {
+ *   maxAssignees: Number, maxLabels: Number, owner: String, repo: String}}}
+ */
+const readLaneLandscapeConfig = () => ({
+    census: {
+        edgeLimit: MemoryCoreConfig.laneLandscapeRelationEdgeLimit,
+        maxPages : MemoryCoreConfig.laneLandscapeCensusMaxPages,
+        pageLimit: MemoryCoreConfig.laneLandscapeCensusPageLimit
+    },
+    source: {
+        maxAssignees: GitHubWorkflowConfig.issueSync.maxAssigneesPerIssue,
+        maxLabels   : GitHubWorkflowConfig.issueSync.maxLabelsPerIssue,
+        owner       : GitHubWorkflowConfig.owner,
+        repo        : GitHubWorkflowConfig.repo
     }
 });
+
+const exploreLaneLandscapeOp = () => {
+    const {census, source} = readLaneLandscapeConfig();
+
+    return exploreLaneLandscape({
+        now : new Date(),
+        deps: {
+            // The census reads the source that OWNS the facts (live, cursor-walked to exhaustion); the graph
+            // supplies only relation edges, which is the one thing it does own, through its RLS seam. A local
+            // projection cannot answer a current-state question: both the graph and the synced corpus lag,
+            // and neither carries assignee truth.
+            ...makeLandscapeCensusSource({
+                ...makeOpenWorkCensusReader({
+                    query : (queryString, variables) => GraphqlService.query(queryString, variables),
+                    config: source
+                }),
+                listEdgeRecordsByType: args => GraphService.listEdgeRecordsByType(args),
+                pageLimit            : census.pageLimit,
+                maxPages             : census.maxPages,
+                edgeLimit            : census.edgeLimit
+            }),
+            generate: makeChatModelGenerate({
+                // SessionService is the Memory Core server's model owner and completes startup before tools
+                // dispatch. Read the live model at call time; do not thread AiConfig leaves into a second builder.
+                buildModel: () => SessionService.model
+            })
+        }
+    })
+};
 
 const exploreMemoryHistoryOp = args => exploreMemoryHistory({
     partition  : args?.partition,
@@ -194,4 +219,4 @@ const callTool = async (name, args, options = {}) => {
 };
 const listTools = toolService.listTools.bind(toolService);
 
-export {callTool, listTools};
+export {callTool, listTools, readLaneLandscapeConfig};

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -34,8 +34,25 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
 
         const ToolServiceModule = await import('../../../../../../../ai/mcp/server/memory-core/toolService.mjs');
         toolService = {
-            listTools: ToolServiceModule.listTools
+            listTools              : ToolServiceModule.listTools,
+            readLaneLandscapeConfig: ToolServiceModule.readLaneLandscapeConfig
         };
+    });
+
+    test('explore_lane_landscape resolves both owning child-config domains (#15468)', () => {
+        expect(toolService.readLaneLandscapeConfig()).toEqual({
+            census: {
+                edgeLimit: 5000,
+                maxPages : 50,
+                pageLimit: 100
+            },
+            source: {
+                maxAssignees: 10,
+                maxLabels   : 20,
+                owner       : 'neomjs',
+                repo        : 'neo'
+            }
+        })
     });
 
     test('All Memory Core tools must respect description length constraints', async () => {


### PR DESCRIPTION
Resolves #15468

Related: #15234
Related: #15100

Restores `explore_lane_landscape` by binding each runtime leaf to the child Provider that owns it: GitHub Workflow supplies repository identity and GraphQL fan-out bounds, while Memory Core supplies census traversal limits. Reads remain call-time reactive and fail loud; no local fallback masks missing configuration. A focused MCP-server witness pins both domains before the census starts.

Evidence: L3 (fresh-process production-path call returned `lane-landscape.v1` over 251 live open items with complete census coverage and synthesis available) → L3 required (all #15468 runtime-recovery ACs). No residuals.

## Decision Record impact

Aligns with ADR 0019's child-Provider SSOT and read-at-use-site discipline. No decision record is created, superseded, or bypassed.

## Deltas from ticket

The verified root cause is broader than the first exception described by the ticket: `issueSync` was merely the first missing subtree read from the Tier-1 root; the three Memory Core lane-landscape leaves were also absent there and would have failed next. The repair binds both owner domains rather than copying or defaulting a single leaf.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs` — 8/8 passed, including the new cross-provider config-resolution witness.
- Fresh-process `callTool('explore_lane_landscape', {})` smoke — returned `lane-landscape.v1`; `totalOpenItems: 251`; `degraded: false`; synthesis available.
- `npm run ai:lint-config-template-ssot` — passed; all AiConfig SSOT hits remain baselined or target-zero.
- `node ./buildScripts/util/check-aiconfig-antipatterns.mjs ai/mcp/server/memory-core/toolService.mjs` — 0 new violations.
- `npx lint-staged` — all whitespace, shorthand, JSDoc, ticket archaeology, block alignment, parse, and test-mutation gates passed.
- `npm run test-unit` — 8,304 passed, 5 skipped; 7 unrelated failures remained on file-system list-tools parity, Genesis port binding, tree-lint timeout, Memory lifecycle retry timing, summarization latency, embedding timeout telemetry, and VDOM table markup.
- Existing direct feature coverage: `McpServerToolLimits.spec.mjs` plus the lane-landscape graph service unit suites; focused touched-surface result above.

## Post-Merge Validation

- [ ] After the resident Memory Core MCP process next restarts on merged `dev`, invoke `explore_lane_landscape` through the installed MCP transport and confirm the same non-degraded envelope.

## Commit

- `3f5c0fea0f` — bind lane-landscape reads to the GitHub Workflow and Memory Core child Providers and add the regression witness.

Authored by Euclid (GPT-5.6 Sol Ultra, Codex Desktop). Session a0518292-02c3-49ee-af08-adff40bc30b1.
