### PR TITLE
fix(component): preserve config-derived classes on cls reapply

### DIFF
--- a/src/component/Base.mjs
+++ b/src/component/Base.mjs
@@ -361,6 +361,26 @@ class Component extends Abstract {
     }
 
     /**
+     * Toggles a config-derived class and records it as derived, so that reapplying an authored-only
+     * `cls` value does not strip it while its owning config is unchanged. Owning `afterSet` hooks
+     * (`disabled`, `theme`, `ui`, and subclass state classes) route their class mutation through here.
+     * @param {String}  name The config-derived class to add or remove.
+     * @param {Boolean} add  Truthy adds the class, falsy removes it.
+     * @protected
+     */
+    applyDerivedCls(name, add) {
+        let me  = this,
+            cls = me.cls;
+
+        me.derivedCls || (me.derivedCls = []);
+
+        NeoArray.toggle(me.derivedCls, name, !!add);
+        NeoArray.toggle(cls, name, !!add);
+
+        me.cls = cls
+    }
+
+    /**
      * Either a string like 'color: red; background-color: blue;'
      * or an object containing style attributes
      * @param {String|Object} value
@@ -413,11 +433,18 @@ class Component extends Abstract {
 
         if (vdom !== vdomRoot) {
             // we are using a wrapper node
-            vdomRoot.cls = [...value]
+            cls = [...value];
+            // Preserve config-derived classes (owned by afterSet hooks, tracked in derivedCls) so that
+            // reapplying an authored-only cls does not strip a class whose owning config is unchanged.
+            me.derivedCls?.length && (cls = NeoArray.union(cls, me.derivedCls));
+            vdomRoot.cls = cls
         } else {
             // we need to merge changes
             cls = NeoArray.union(me.wrapperCls, value);
             NeoArray.remove(cls, NeoArray.difference(oldValue, value));
+            // Preserve config-derived classes (owned by afterSet hooks, tracked in derivedCls) so that
+            // reapplying an authored-only cls does not strip a class whose owning config is unchanged.
+            me.derivedCls?.length && (cls = NeoArray.union(cls, me.derivedCls));
             vdom.cls = cls
         }
 
@@ -431,10 +458,7 @@ class Component extends Abstract {
      * @protected
      */
     afterSetDisabled(value, oldValue) {
-        let cls = this.cls;
-
-        NeoArray[value ? 'add' : 'remove'](cls, 'neo-disabled');
-        this.cls = cls
+        this.applyDerivedCls('neo-disabled', value)
     }
 
 
@@ -741,23 +765,15 @@ class Component extends Abstract {
      */
     afterSetTheme(value, oldValue) {
         if (value || oldValue !== undefined) {
-            let me          = this,
-                {cls}       = me,
-                needsUpdate = false;
+            let me = this;
 
-            if (oldValue && cls.includes(oldValue)) {
-                NeoArray.remove(cls, oldValue);
-                needsUpdate = true
+            if (oldValue && me.cls.includes(oldValue)) {
+                me.applyDerivedCls(oldValue, false)
             }
 
             // We do not need to add a DOM based CSS selector, in case the theme is already inherited
-            if (value !== me.parent?.theme) {
-                value && NeoArray.add(cls, value);
-                needsUpdate = true
-            }
-
-            if (needsUpdate) {
-                me.cls = cls
+            if (value && value !== me.parent?.theme) {
+                me.applyDerivedCls(value, true)
             }
         }
     }
@@ -800,18 +816,13 @@ class Component extends Abstract {
      * @param {String|null} oldValue
      */
     afterSetUi(value, oldValue) {
-        let me  = this,
-            cls = me.cls;
+        let me = this;
 
-        if (oldValue) {
-            NeoArray.remove(cls, `neo-${me.ntype}-${oldValue}`)
-        }
+        oldValue && me.applyDerivedCls(`neo-${me.ntype}-${oldValue}`, false);
 
         if (value && value !== '') {
-            NeoArray.add(cls, `neo-${me.ntype}-${value}`)
+            me.applyDerivedCls(`neo-${me.ntype}-${value}`, true)
         }
-
-        me.cls = cls
     }
 
     /**

--- a/test/playwright/unit/component/ClsReconciliation.spec.mjs
+++ b/test/playwright/unit/component/ClsReconciliation.spec.mjs
@@ -1,0 +1,47 @@
+/**
+ * @summary RED witness — reapplying an unchanged authored `cls` must not strip a config-derived
+ * class while its owning config is unchanged.
+ *
+ * `afterSetDisabled` adds `neo-disabled` into the shared `cls` bag (same mechanism as `ui` adding
+ * `neo-<ntype>-<ui>`). A pooled consumer that reapplies ONLY its authored classes — unaware of the
+ * derived ones — must not lose them: `afterSetCls`'s `NeoArray.remove(cls, difference(oldValue, value))`
+ * currently strips every derived class absent from the reapplied authored value, and because `disabled`
+ * did not change, `afterSetDisabled` never re-runs to restore it. This spec fails against unfixed
+ * `component.Base` and turns green once cls reconciliation is ownership-safe.
+ */
+import {setup} from '../../setup.mjs';
+
+const appName = 'ClsReconciliationTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: true,
+        useDomApiRenderer      : true,
+        useVdomWorker          : false
+    },
+    appConfig: {name: appName}
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+
+test.describe('component.Base cls reconciliation (#15197)', () => {
+    test('reapplying authored cls preserves a config-derived class while its owner is unchanged', async () => {
+        const cmp = Neo.create(Component, {appName, cls: ['authored'], disabled: true});
+
+        // Sanity: the config-derived class landed in the rendered cls alongside the authored one.
+        expect(cmp.vdom.cls, 'derived neo-disabled present after construction').toContain('neo-disabled');
+        expect(cmp.vdom.cls, 'authored class present after construction').toContain('authored');
+
+        // A pooled consumer reapplies ONLY its authored classes (it does not know about neo-disabled).
+        cmp.cls = ['authored'];
+
+        // disabled is unchanged, so the derived class must survive the reapply.
+        expect(cmp.disabled, 'disabled semantic state is unchanged').toBe(true);
+        expect(cmp.vdom.cls, 'neo-disabled must survive an authored-cls reapply (config-derived, owner unchanged)').toContain('neo-disabled');
+        expect(cmp.vdom.cls, 'authored class still present after reapply').toContain('authored');
+
+        cmp.destroy()
+    });
+});


### PR DESCRIPTION
Resolves #15197

## Summary

Reapplying an unchanged authored `cls` silently stripped config-derived classes (`neo-button-ghost`, `neo-disabled`, a theme class, …). Root cause, verified at source: `this.cls` is a **shared bag** mixing caller-authored classes with config-derived ones — `afterSetDisabled`, `afterSetUi`, `afterSetTheme` (and subclass state hooks) all mutate `this.cls` — and `afterSetCls` reconciles with `NeoArray.remove(cls, NeoArray.difference(oldValue, value))`. When a pooled consumer reapplies its authored-only `cls`, every derived class it omits falls into `difference(oldValue, value)` and is removed, and because the owning config did not change its `afterSet` never re-runs to restore it. Semantic state and rendered classes diverge (`disabled===true`, `neo-disabled` gone).

## The Fix — ownership-safe reconciliation in component.Base

Per the ticket's prescription ("Establish ownership-safe class reconciliation in `component.Base`"):

- **New protected primitive `applyDerivedCls(name, add)`** — toggles a config-derived class while recording it in a `derivedCls` tracker, so the reconciler can tell caller-authored classes from config-owned ones.
- **`afterSetCls` unions `derivedCls` back** after reconciliation (both the wrapper and non-wrapper branches), so reapplying an authored-only `cls` preserves config-derived classes whose owning config is unchanged; when an owner config changes, its `afterSet` toggles its own contribution through the primitive.
- **`component.Base`'s own derived-class `afterSet`s migrated** onto the primitive: `afterSetDisabled` (`neo-disabled`), `afterSetUi` (`neo-<ntype>-<ui>`), `afterSetTheme` (theme class, inheritance condition preserved).

The public `cls` input is now treated as the caller-authored contribution; the final VDOM class list stays deduplicated (`NeoArray.union`) and stable across repeated `set()` calls.

## Deltas / scope

- **This leaf lands the component.Base mechanism + primitive + component.Base's own `afterSet` migration.** The ticket is explicit that the pattern spans subclasses ("not limited to one Button config… any reusable component"). Subclass `afterSet` adoption — `button.Base` (`no-text` via the `_cls`/`vdomRoot.cls` path, `icon-*`, `pressed`), and any other component that adds a config-derived class — routes through the same `applyDerivedCls` primitive.
- **Reviewer scope call:** land this component.Base foundation now with the subclass rollout as tracked follow-up leaves under #15197 (recommended — the mechanism is self-contained and verified, and each subclass migration is a mechanical + independently-testable change), or request `button.Base` in-scope here to close the pooled-Button AC in one PR. I'll extend to `button.Base` on the same branch if you prefer the latter — flagging the `no-text` hook's direct `vdomRoot.cls` path as the one non-trivial migration.

## Test Evidence

- New RED witness `test/playwright/unit/component/ClsReconciliation.spec.mjs`: a component with `cls:['authored']` + `disabled:true` carries `neo-disabled`; after `cmp.cls = ['authored']` the class must survive while `disabled` stays `true`. **Verified RED against unfixed `component.Base`** (committed first), **green after the fix**.
- Regression suites green at the fixed head: `component` **54 passed**, `button` **7 passed** (exercises `afterSetUi`), `form/field` **12 passed** (exercises `ui`/`disabled`).
- `node --check` green.

Evidence: L2 (unit — RED-verified witness + 73 passing regression tests across component/button/form-field) → L2 sufficient (a config-level reconciliation contract, no runtime/deploy surface). Residual: subclass `afterSet` adoption (see Deltas) — the mechanism is verified; the rollout is per-subclass follow-up.

## Post-Merge Validation

- [ ] After merge, a pooled `grid.column.Component` reusing a Button across records retains its `ui`-derived class on `cls` reapply (component.Base half); the text/icon-derived classes retain once `button.Base` adopts `applyDerivedCls` (follow-up).
- [ ] Confirm no theme-class flicker on a live theme switch (the `afterSetTheme` migration replaces the batched single update with per-change updates; rare path, suites green).

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Origin session `3e5f61a5-35d0-4f3d-8805-54f63bebed70`.
