### PR TITLE
fix(dashboard): fail closed on blocked popup (#15477)

### DIFF
--- a/src/dashboard/Container.mjs
+++ b/src/dashboard/Container.mjs
@@ -150,11 +150,11 @@ class Container extends BaseContainer {
      * @param {Object} data
      */
     async onDragBoundaryEntry(data) {
-        let me            = this,
-            {windowId}    = me,
-            {sortZone}    = data,
-            widget        = data.draggedItem,
-            widgetName    = widget.reference || widget.id;
+        let me         = this,
+            {windowId} = me,
+            {sortZone} = data,
+            widget     = data.draggedItem,
+            widgetName = widget.reference || widget.id;
 
         me.#isReintegrating = true;
 
@@ -213,10 +213,13 @@ class Container extends BaseContainer {
     }
 
     /**
+     * @summary Admits a dragged widget into a popup before engaging the OS-window drag embodiment.
+     * A refused vessel restores the in-window gesture state the sort zone armed before firing the
+     * boundary event.
      * @param {Object} data
      */
     async onDragBoundaryExit(data) {
-        let me = this,
+        let me                                 = this,
             {draggedItem, proxyRect, sortZone} = data,
             popupData;
 
@@ -227,6 +230,13 @@ class Container extends BaseContainer {
 
         popupData = await me.openWidgetInPopup(draggedItem, proxyRect);
 
+        if (!popupData) {
+            me.#isWindowDragging      = false;
+            sortZone.isWindowDragging = false;
+            sortZone.reattachArmed    = false;
+            return
+        }
+
         sortZone.startWindowDrag({
             dragData: data,
             ...popupData
@@ -236,9 +246,12 @@ class Container extends BaseContainer {
     }
 
     /**
+     * @summary Transactionally stages a widget for popup ownership and returns geometry only after
+     * the main-thread vessel admission resolves true. Failed admission restores the exact prior
+     * detached-item entry so the fast window-connect ordering never creates false ownership truth.
      * @param {Neo.component.Base} widget
      * @param {DOMRect} rect
-     * @returns {Promise<Object>}
+     * @returns {Promise<Object|null>}
      */
     async openWidgetInPopup(widget, rect) {
         let me              = this,
@@ -268,17 +281,39 @@ class Container extends BaseContainer {
             popupTop              = y + (winData.outerHeight - winData.innerHeight + winData.screenTop),
             windowName            = widgetName;
 
-        me.detachedItems.set(widgetName, {
-            index : me.items.indexOf(widget),
-            widget: widget
-        });
+        let hadDetachedItem = me.detachedItems.has(widgetName),
+            previousItem    = me.detachedItems.get(widgetName),
+            provisionalItem = {
+                index : me.items.indexOf(widget),
+                widget: widget
+            };
 
-        await Neo.Main.windowOpen({
-            url,
-            windowId,
-            windowFeatures: `height=${popupHeight},left=${popupLeft},top=${popupTop},width=${width}`,
-            windowName
-        });
+        me.detachedItems.set(widgetName, provisionalItem);
+
+        let opened = false;
+
+        try {
+            opened = await Neo.Main.windowOpen({
+                url,
+                windowId,
+                windowFeatures: `height=${popupHeight},left=${popupLeft},top=${popupTop},width=${width}`,
+                windowName
+            })
+        } catch (error) {
+            console.error('Failed to open popup window for dashboard item', widget, error)
+        }
+
+        if (opened !== true) {
+            // A newer admission attempt may already own this slot. Roll back only our provisional
+            // write; otherwise a stale failure could erase the newer attempt's truth.
+            if (me.detachedItems.get(widgetName) === provisionalItem) {
+                hadDetachedItem
+                    ? me.detachedItems.set(widgetName, previousItem)
+                    : me.detachedItems.delete(widgetName)
+            }
+
+            return null
+        }
 
         return {popupHeight, popupLeft, popupTop, popupWidth: width, windowName}
     }
@@ -289,14 +324,14 @@ class Container extends BaseContainer {
      * @param {String} data.windowId
      */
     async onWindowConnect(data) {
-        let me         = this,
-            app        = Neo.apps[data.windowId],
-            mainView   = app.mainView,
-            {windowId} = data,
-            url        = await Neo.Main.getByPath({path: 'document.URL', windowId}),
-            params     = new URL(url).searchParams,
-            dashboardId= params.get('dashboardId'),
-            widgetName = params.get('name');
+        let me          = this,
+            app         = Neo.apps[data.windowId],
+            mainView    = app.mainView,
+            {windowId}  = data,
+            url         = await Neo.Main.getByPath({path: 'document.URL', windowId}),
+            params      = new URL(url).searchParams,
+            dashboardId = params.get('dashboardId'),
+            widgetName  = params.get('name');
 
         if (dashboardId === me.id) {
             let detachedItem = me.detachedItems.get(widgetName);
@@ -339,6 +374,8 @@ class Container extends BaseContainer {
     }
 
     /**
+     * @summary Contains the legacy popup reacquisition path until vessel park/re-show replaces it.
+     * A refused re-open never arms pointer-follow or dereferences missing geometry.
      * Re-opens the popup window and resumes the window drag operation.
      * Called by the DragCoordinator when a remote drag leaves a target dashboard back into the void.
      * @param {String} widgetName
@@ -353,6 +390,11 @@ class Container extends BaseContainer {
             me.#isWindowDragging = true;
 
             popupData = await me.openWidgetInPopup(detachedItem.widget, proxyRect);
+
+            if (!popupData) {
+                me.#isWindowDragging = false;
+                return
+            }
 
             // We need to tell the DragDrop addon to resume window dragging
             Neo.main.addon.DragDrop.startWindowDrag({

--- a/test/playwright/unit/dashboard/Container.spec.mjs
+++ b/test/playwright/unit/dashboard/Container.spec.mjs
@@ -1,0 +1,189 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'DashboardContainerAdmissionTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import Container      from '../../../../src/dashboard/Container.mjs';
+
+/**
+ * @summary Installs the real main-thread popup call grammar around a configurable Boolean result.
+ * The production owner consumes `windowOpen` as an admission decision, so these seams keep the
+ * Boolean result visible instead of replacing it with a successful-looking window descriptor.
+ * @param {Object} [config={}]
+ * @param {Error|null} [config.openError=null]
+ * @param {Boolean} [config.openResult=true]
+ * @returns {Object} call state plus `restore()`.
+ */
+function installWindowVessel({openError = null, openResult = true} = {}) {
+    let previous = {
+            getWindowData: Neo.Main.getWindowData,
+            windowOpen   : Neo.Main.windowOpen
+        },
+        previousWindowConfigs = Neo.windowConfigs,
+        state                 = {openCalls: []};
+
+    Neo.windowConfigs = {'unit-window': {basePath: './'}};
+
+    Neo.Main.getWindowData = async () => ({
+        innerHeight: 900,
+        outerHeight: 960,
+        screenLeft : 10,
+        screenTop  : 20
+    });
+    Neo.Main.windowOpen = async data => {
+        state.openCalls.push(data);
+        if (openError) throw openError;
+        return openResult
+    };
+
+    return {
+        get openCalls() { return state.openCalls },
+        restore() {
+            Object.assign(Neo.Main, previous);
+            Neo.windowConfigs = previousWindowConfigs
+        }
+    }
+}
+
+/**
+ * @summary The generic dashboard popup boundary consumes strict vessel admission without inventing
+ * detached ownership. The suite drives the real `Container` instance because both boundary callers
+ * close over private drag-state latches that a prototype-only fake cannot witness.
+ */
+test.describe.serial('Neo.dashboard.Container — popup admission', () => {
+    let container, vessel;
+
+    const rect   = () => ({height: 530, width: 640, x: 40, y: 50}),
+          widget = () => ({id: 'graph', reference: 'graph', wrapperStyle: {}});
+
+    test.beforeEach(() => {
+        container = Neo.create(Container, {
+            appName,
+            detachToNewWindow: true,
+            dragResortable   : false,
+            id               : 'dashboard-admission-test',
+            items            : [],
+            popupUrl         : 'popup.html'
+        })
+    });
+
+    test.afterEach(() => {
+        vessel?.restore();
+        vessel = null;
+        container?.destroy();
+        container = null
+    });
+
+    test('Boolean false rolls back a newly staged detached item and returns no popup geometry', async () => {
+        vessel = installWindowVessel({openResult: false});
+
+        const popupData = await container.openWidgetInPopup(widget(), rect());
+
+        expect(popupData).toBeNull();
+        expect(container.detachedItems.has('graph')).toBe(false);
+        expect(vessel.openCalls).toHaveLength(1)
+    });
+
+    test('Boolean true keeps provisional-before-await ordering and returns the admitted vessel geometry', async () => {
+        let sawProvisional = false,
+            item           = widget();
+
+        vessel = installWindowVessel();
+        Neo.Main.windowOpen = async () => {
+            sawProvisional = container.detachedItems.get('graph')?.widget === item;
+            return true
+        };
+
+        const popupData = await container.openWidgetInPopup(item, rect());
+
+        expect(sawProvisional, 'the popup can connect before the App-Worker response returns').toBe(true);
+        expect(popupData).toEqual({
+            popupHeight: 480,
+            popupLeft  : 50,
+            popupTop   : 130,
+            popupWidth : 640,
+            windowName : 'graph'
+        });
+        expect(container.detachedItems.get('graph')?.widget).toBe(item)
+    });
+
+    test('failed replacement restores the exact prior detached entry instead of deleting it', async () => {
+        const previous = {index: 3, widget: {id: 'old-graph'}, windowId: 'existing-vessel'};
+
+        vessel = installWindowVessel({openResult: false});
+        container.detachedItems.set('graph', previous);
+
+        await container.openWidgetInPopup(widget(), rect());
+
+        expect(container.detachedItems.get('graph')).toBe(previous)
+    });
+
+    test('a throwing admission seam follows the same rollback path as Boolean false', async () => {
+        const realConsoleError = console.error;
+
+        vessel = installWindowVessel({openError: new Error('transport failed after request')});
+        console.error = () => {};
+
+        try {
+            await expect(container.openWidgetInPopup(widget(), rect())).resolves.toBeNull();
+            expect(container.detachedItems.has('graph')).toBe(false)
+        } finally {
+            console.error = realConsoleError
+        }
+    });
+
+    test('failed initial boundary admission restores the armed sort-zone and container drag state', async () => {
+        const
+            inserted = [],
+            started  = [],
+            item     = widget(),
+            sortZone = {
+                isWindowDragging: true,
+                reattachArmed   : true,
+                startWindowDrag : data => started.push(data)
+            };
+
+        container.openWidgetInPopup = async () => null;
+
+        await container.onDragBoundaryExit({draggedItem: item, proxyRect: rect(), sortZone});
+
+        expect(started).toHaveLength(0);
+        expect(sortZone.isWindowDragging).toBe(false);
+        expect(sortZone.reattachArmed).toBe(false);
+
+        // `onWindowDisconnect` skips reintegration while the container-private latch is true. Its
+        // successful reinsertion here proves the failed boundary restored that second owner too.
+        container.detachedItems.set('graph', {index: 0, widget: item, windowId: 'stale-vessel'});
+        container.insert = (index, entry) => inserted.push({entry, index});
+        await container.onWindowDisconnect({windowId: 'stale-vessel'});
+
+        expect(inserted).toEqual([{entry: item, index: 0}])
+    });
+
+    test('failed legacy resume never dereferences geometry or re-arms main-thread pointer-follow', async () => {
+        const
+            calls         = [],
+            previousAddon = Neo.main?.addon?.DragDrop,
+            item          = widget();
+
+        Neo.ns('Neo.main.addon.DragDrop', true);
+        Neo.main.addon.DragDrop = {startWindowDrag: data => calls.push(data)};
+        container.detachedItems.set('graph', {index: 0, widget: item, windowId: 'parked-vessel'});
+        container.openWidgetInPopup = async () => null;
+
+        try {
+            await expect(container.resumeWindowDrag('graph', rect())).resolves.toBeUndefined();
+            expect(calls).toHaveLength(0)
+        } finally {
+            Neo.main.addon.DragDrop = previousAddon
+        }
+    })
+});


### PR DESCRIPTION
Resolves #15477

The generic dashboard tear-out path staged `detachedItems`, discarded the strict Boolean from `Neo.Main.windowOpen()`, and always returned successful popup geometry. A blocked popup could therefore invent vessel ownership and engage OS-window pointer-follow without a window.

This PR makes admission transactional while preserving the fast-connect race: the provisional detached entry still exists before the remote await, but only an exact `true` commits it. Boolean `false`, a non-Boolean response, or a thrown admission restores the exact prior map entry (or removes a newly staged one). The initial boundary caller restores both drag-state owners and never starts window dragging; the legacy resume caller fails closed without dereferencing missing geometry.

Evidence: L2 required and sufficient. The new suite drives the real `Neo.dashboard.Container` class and the real Boolean call grammar, including the private drag-state latch through a disconnect falsifier. Headed portability remains owned by #15243; park/re-show and removal of mid-gesture reacquisition remain owned by #15396.

## Deltas from ticket

No scope expansion. Ticket intake explicitly separated initial admission truth from #15396's successor lifecycle. The implementation contains the legacy resume caller only; it does not compete with or redesign park/re-show.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/dashboard/Container.spec.mjs test/playwright/unit/draggable/dashboard/SortZone.spec.mjs` — 15/15 passed after rebasing onto current `origin/dev`.
- New real-class admission matrix: Boolean false, Boolean true with provisional-before-await ordering, exact prior-entry restoration, thrown admission, initial-boundary rollback, and legacy-resume fail-closed.
- `npm run agent-preflight -- --no-fix src/dashboard/Container.mjs test/playwright/unit/dashboard/Container.spec.mjs` — all requested gates passed (only unrelated local stale-overlay warnings).
- `git diff --check` — clean.

## Post-Merge Validation

- [ ] Confirm hosted CI remains green at the human merge head.
- [ ] Fold the repaired acquisition result into #15243's portability matrix without changing #15396's park/re-show ownership.

Authored by Emmy (`@neo-gpt-emmy`, GPT family).
