### PR TITLE
feat(agentos): the mission-control walkthrough — one screenplay as demo, e2e, and recording (#14646)

### DIFF
--- a/apps/agentos/tour/missionControlWalkthrough.mjs
+++ b/apps/agentos/tour/missionControlWalkthrough.mjs
@@ -1,0 +1,101 @@
+import cockpitDockDocument from '../view/fleet/cockpitDockDocument.mjs';
+
+/**
+ * @summary The mission-control walkthrough: "watch a real AI engineering team run" — the
+ * cockpit's public story as `neo.tour.script.v1` data, played on the LIVE Fleet Cockpit over
+ * its real roster.
+ *
+ * Five beats, one continuous minute (the story no competitor can film):
+ *
+ * 1. **The fleet, live** — the density-ranked agent roster over the ticking activity stream:
+ *    real maintainers, real events, one running app-worker.
+ * 2. **The stream speaks** — a burst of fleet activity arrives and the stream coalesces it
+ *    live (the `activity-burst` cue drives the stream's own reactive seam).
+ * 3. **Drill** — one resident's detail opens through the production selection seam (the
+ *    `drill` cue is NAME-addressed against the public roster, so every run drills the same
+ *    agent deterministically).
+ * 4. **The pane leaves the window** — the detail becomes a real OS window on the shared heap
+ *    and comes home (the shipped vessel state machine; reparent, never recreate).
+ * 5. **The close** — the line the whole surface earns: the team on screen built the app the
+ *    viewer is watching.
+ *
+ * The morning-start cascade is deliberately NOT a scripted beat in v1: its live effects need
+ *  the real fleet bridge, so the recorded demo narrates it over the health bar instead (the
+ * scoping is recorded on the owning ticket).
+ *
+ * Layering contract (the established tour law): this screenplay is nearly pure narration —
+ * every transition rides a cue the hosting cockpit consumes with an observable receipt; no
+ * step asserts host-owned effects, so pure spec-mode replay stays deterministic and the
+ * worker-truth assertions live in the walkthrough's e2e leg (the trinity: one script = the
+ * demo, the e2e, the recording).
+ *
+ * Cue vocabulary consumed by the hosting cockpit: `activity-burst` (inject `count` synthetic
+ * fleet events through the stream's reactive seam) · `drill` (select the resident whose
+ * record `agentId` matches `name`, through the production selection seam) · `popout`,
+ * `reattach` (the detail vessel's own state machine).
+ */
+
+/**
+ * The opening stage — the Fleet Cockpit's REAL default document, imported from the cockpit's
+ * own data leaf so the walkthrough can never drift from the shipped surface.
+ * @type {Object}
+ */
+export const initialDocument = Object.freeze(cockpitDockDocument());
+
+/**
+ * The walkthrough script. Every transition is a cue on a pacing step; document truth stays
+ * untouched by the script itself (the projection follows the cues' host effects).
+ * @type {Object}
+ */
+export const missionControlTourScript = Object.freeze({
+    schema: 'neo.tour.script.v1',
+    id    : 'mission-control-walkthrough',
+    title : 'Mission control: watch a real AI engineering team run',
+
+    workspace: {},
+
+    scenes: [{
+        id     : 's1',
+        title  : 'The fleet, live',
+        caption: 'This is mission control for an AI engineering team. Every card is a real maintainer; the stream below is their real activity. One running app-worker owns everything on this stage.',
+        steps  : [
+            {type: 'pause', ms: 2600, caption: 'the roster ranks itself by activity — the fleet you see is the fleet that is working right now'}
+        ]
+    }, {
+        id     : 's2',
+        title  : 'The stream speaks',
+        caption: 'Fleet events arrive as they happen. Watch the stream take a burst and coalesce it live — no refresh, no polling, the worker pushes truth.',
+        steps  : [
+            {type: 'pause', ms: 900, cue: {type: 'activity-burst', count: 40}, caption: 'forty events land: the window keeps the newest, folds the rest, and names the fold honestly'},
+            {type: 'pause', ms: 2200}
+        ]
+    }, {
+        id     : 's3',
+        title  : 'Drill',
+        caption: 'One click opens any agent\'s detail — identity, thought stream, current lane, repository state — through the same selection path an operator drives.',
+        steps  : [
+            {type: 'pause', ms: 900, cue: {type: 'drill', name: 'neo-fable'}, caption: 'drill(neo-fable): the inspector reveals from the rail and renders THAT resident — four panes, each with its own freshness truth'},
+            {type: 'pause', ms: 2400}
+        ]
+    }, {
+        id     : 's4',
+        title  : 'The pane leaves the window',
+        caption: 'The detail detaches to its OWN OS window — same component instance, same live subscriptions, one shared-memory heap across both windows.',
+        steps  : [
+            {type: 'pause', ms: 900, cue: {type: 'popout', itemId: 'detail'}, caption: 'pop out: a real second window opens and the SAME instance renders there — reparent, never recreate'},
+            {type: 'pause', ms: 2600, caption: 'the stream keeps ticking, the detail keeps updating — none of the docking libraries surveyed in the decision record offered live cross-window state like this'},
+            {type: 'pause', ms: 900, cue: {type: 'reattach', itemId: 'detail'}, caption: 'and home again — same instance, zero re-mount'},
+            {type: 'pause', ms: 1400}
+        ]
+    }, {
+        id     : 's5',
+        title  : 'The close',
+        caption: 'The morning-start cascade, the perspectives, the tear-out gestures — all of it runs from this surface. One line matters more than any feature:',
+        steps  : [
+            {type: 'pause', ms: 2600, caption: '…and this team built the app you are watching.'},
+            {type: 'pause', ms: 1200}
+        ]
+    }]
+});
+
+export default missionControlTourScript;

--- a/apps/agentos/tour/missionControlWalkthrough.mjs
+++ b/apps/agentos/tour/missionControlWalkthrough.mjs
@@ -7,10 +7,11 @@ import cockpitDockDocument from '../view/fleet/cockpitDockDocument.mjs';
  *
  * Five beats, one continuous minute (the story no competitor can film):
  *
- * 1. **The fleet, live** — the density-ranked agent roster over the ticking activity stream:
- *    real maintainers, real events, one running app-worker.
- * 2. **The stream speaks** — a burst of fleet activity arrives and the stream coalesces it
- *    live (the `activity-burst` cue drives the stream's own reactive seam).
+ * 1. **The fleet, live** — the density-ranked agent roster over the activity stream: real
+ *    maintainers, one running app-worker.
+ * 2. **The stream speaks** — a CONTROLLED demonstration burst (tour provenance, explicitly
+ *    bounded, restored at the take terminal) drives the stream's own reactive seam — the demo
+ *    shows the mechanism, never poses generated data as Memory Core arrival.
  * 3. **Drill** — one resident's detail opens through the production selection seam (the
  *    `drill` cue is NAME-addressed against the public roster, so every run drills the same
  *    agent deterministically).
@@ -29,9 +30,10 @@ import cockpitDockDocument from '../view/fleet/cockpitDockDocument.mjs';
  * worker-truth assertions live in the walkthrough's e2e leg (the trinity: one script = the
  * demo, the e2e, the recording).
  *
- * Cue vocabulary consumed by the hosting cockpit: `activity-burst` (inject `count` synthetic
- * fleet events through the stream's reactive seam) · `drill` (select the resident whose
- * record `agentId` matches `name`, through the production selection seam) · `popout`,
+ * Cue vocabulary consumed by the hosting cockpit: `activity-burst` (inject an explicitly
+ * bounded `count` of TOUR-provenance demo events through the stream's reactive seam; the
+ * displaced owner-held state restores at the take terminal) · `drill` (select the resident
+ * whose record `agentId` matches `name`, through the production selection seam) · `popout`,
  * `reattach` (the detail vessel's own state machine).
  */
 
@@ -57,16 +59,16 @@ export const missionControlTourScript = Object.freeze({
     scenes: [{
         id     : 's1',
         title  : 'The fleet, live',
-        caption: 'This is mission control for an AI engineering team. Every card is a real maintainer; the stream below is their real activity. One running app-worker owns everything on this stage.',
+        caption: 'This is mission control for an AI engineering team. Every card is a real maintainer; the stream below carries fleet activity. One running app-worker owns everything on this stage.',
         steps  : [
-            {type: 'pause', ms: 2600, caption: 'the roster ranks itself by activity — the fleet you see is the fleet that is working right now'}
+            {type: 'pause', ms: 2600, caption: 'the roster ranks itself by activity — the fleet you see is the fleet this workspace watches'}
         ]
     }, {
         id     : 's2',
         title  : 'The stream speaks',
-        caption: 'Fleet events arrive as they happen. Watch the stream take a burst and coalesce it live — no refresh, no polling, the worker pushes truth.',
+        caption: 'Fleet events arrive through one reactive seam — no refresh, no polling, the worker pushes truth. Watch the stream take a CONTROLLED demonstration burst through that exact seam.',
         steps  : [
-            {type: 'pause', ms: 900, cue: {type: 'activity-burst', count: 40}, caption: 'forty events land: the window keeps the newest, folds the rest, and names the fold honestly'},
+            {type: 'pause', ms: 900, cue: {type: 'activity-burst', count: 40}, caption: 'forty demo events land the same way real ones do: the window keeps the newest, folds the rest, and names the fold honestly'},
             {type: 'pause', ms: 2200}
         ]
     }, {

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -554,14 +554,23 @@ class FleetCockpit extends Container {
      */
     sharedPerspectiveArtifact = null
     /**
-     * The last settled tour report (`{completed, cueErrors, cueReceipts, errors, log}`) —
-     * stamped by {@link #playTour} at every terminal so an NL-driven take can FIRE the play
-     * and read the report AFTER teardown (a long take outlives the transport's request
-     * window, so awaiting the call over the wire is not the contract; polling
-     * `tourRunner === null` then reading this member is).
+     * The CURRENT ATTEMPT's settled tour report (`{completed, cueErrors, cueReceipts, errors,
+     * log}`) — cleared SYNCHRONOUSLY when a take claims ownership and stamped at EVERY owned
+     * terminal (success AND thrown reset/refresh/start), so the NL contract — fire, poll
+     * `tourRunner === null`, read this member — can never attribute a previous take's success
+     * to a failed current attempt. `null` means "no settled report for the latest attempt";
+     * pre-ownership refusals return their report to the caller directly and never touch it.
      * @member {Object|null} lastTourReport=null
      */
     lastTourReport = null
+    /**
+     * The owner-held activity-stream state (`{adapterState, events}`) an `activity-burst` cue
+     * displaced — captured once per take at first injection, restored by
+     * {@link #restoreTourStream} at the take terminal. `null` when no burst ran.
+     * @member {Object|null} tourStreamRestore=null
+     * @protected
+     */
+    tourStreamRestore = null
     /**
      * The serialized hosting-cue chain (the Workstation settlement pattern): TourRunner fires
      * cues synchronously and deliberately never awaits them, so every async cue consumer chains
@@ -709,10 +718,13 @@ class FleetCockpit extends Container {
 
         // SINGLE-FLIGHT: ownership is claimed SYNCHRONOUSLY — `tourRunner` is set before any
         // await, so a concurrent second call refuses at the guard above instead of slipping
-        // through the pre-start refresh window and double-creating runners.
-        me.cuePromise  = Promise.resolve();
-        me.cueReceipts = [];
-        me.cueErrors   = [];
+        // through the pre-start refresh window and double-creating runners. The stale report
+        // clears in the SAME synchronous window: a reader polling `tourRunner === null` can
+        // never attribute a previous take's success to this attempt.
+        me.cuePromise     = Promise.resolve();
+        me.cueReceipts    = [];
+        me.cueErrors      = [];
+        me.lastTourReport = null;
 
         me.tourRunner = Neo.create(TourRunner, {
             componentId: me.id,
@@ -751,11 +763,39 @@ class FleetCockpit extends Container {
             };
 
             return me.lastTourReport
+        } catch (error) {
+            // CURRENT-ATTEMPT terminal truth: a thrown reset/refresh/start still publishes a
+            // structured failed report for THIS invocation before ownership releases — a prior
+            // successful terminal is never a valid fallback for a failed current attempt.
+            me.lastTourReport = {
+                completed  : false,
+                cueErrors  : [...me.cueErrors],
+                cueReceipts: me.cueReceipts.length,
+                errors     : [error?.message || String(error)],
+                log        : []
+            };
+
+            return me.lastTourReport
         } finally {
+            me.restoreTourStream();
             me.tourRunner?.destroy?.();
             me.tourRunner = null;
             me.setTourCaption('')
         }
+    }
+
+    /**
+     * @summary Restores the owner-held activity-stream state an `activity-burst` cue displaced —
+     * the take-terminal half of the burst's reversibility contract. Inert when no burst ran.
+     */
+    restoreTourStream() {
+        let me      = this,
+            restore = me.tourStreamRestore;
+
+        if (!restore) return;
+
+        me.tourStreamRestore = null;
+        me.getReference('activity-stream')?.set(restore)
     }
 
     /**
@@ -848,24 +888,35 @@ class FleetCockpit extends Container {
                 if (!result.reattached) throw new Error(result.errors[0] || 'reattach refused');
                 return result;
             case 'activity-burst': {
-                // the walkthrough's stream beat: inject `count` synthetic fleet events through
-                // the stream's OWN reactive seam (distinct actors + monotone timestamps, so
-                // coalescing never collapses them) — the same mechanic the burst witnesses drive
+                // the walkthrough's stream beat: inject `count` DEMO events through the stream's
+                // OWN reactive seam (distinct actors + monotone timestamps, so coalescing never
+                // collapses them). Honest by construction: the count is an explicit bounded
+                // positive integer (no hidden host default), the events carry TOUR provenance —
+                // never a Memory Core source — the surface's adapter state is NOT touched (a
+                // sample surface stays labeled sample), and the displaced owner-held state is
+                // captured once for the take-terminal restore ({@link #restoreTourStream}).
                 const stream = me.getReference('activity-stream');
 
                 if (!stream) throw new Error('no activity stream is mounted');
 
-                const count  = cue.count ?? 40,
-                      events = Array.from({length: count}, (_, i) => ({
-                          agentId   : `tour-burst-${i}`,
-                          occurredAt: new Date(Date.UTC(2026, 6, 18, 12, 0, 0) + i * 60000).toISOString(),
-                          payload   : {text: `fleet event ${i}`},
-                          source    : 'memory-core:mailbox',
-                          type      : 'a2a-activity'
-                      }));
+                const count = cue.count;
 
-                stream.set({adapterState: 'live', events});
-                return {injected: count}
+                if (!Number.isInteger(count) || count < 1 || count > 200) {
+                    throw new Error(`activity-burst needs an explicit integer count 1-200, got "${count}"`)
+                }
+
+                me.tourStreamRestore ??= {adapterState: stream.adapterState, events: stream.events};
+
+                const events = Array.from({length: count}, (_, i) => ({
+                    agentId   : `tour-burst-${i}`,
+                    occurredAt: new Date(Date.UTC(2026, 6, 18, 12, 0, 0) + i * 60000).toISOString(),
+                    payload   : {text: `demo fleet event ${i}`},
+                    source    : 'tour:demo-burst',
+                    type      : 'a2a-activity'
+                }));
+
+                stream.set({events});
+                return {injected: count, provenance: 'tour:demo-burst'}
             }
             case 'drill': {
                 // the walkthrough's selection beat: NAME-addressed against the public roster

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -1,29 +1,30 @@
-import ActivityStream                                               from './ActivityStream.mjs';
-import AddAgentForm                                                 from './AddAgentForm.mjs';
-import AgentDetail                                                  from './AgentDetail.mjs';
-import Button                                                       from '../../../../src/button/Base.mjs';
-import Component                                                    from '../../../../src/component/Base.mjs';
-import Container                                                    from '../../../../src/container/Base.mjs';
-import DockLayoutAdapter                                            from '../../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockMotionSignal                                             from '../../../../src/dashboard/DockMotionSignal.mjs';
-import DockPerspectiveStore                                         from '../../../../src/dashboard/DockPerspectiveStore.mjs';
-import DockPreviewProducer                                          from '../../../../src/dashboard/DockPreviewProducer.mjs';
-import DockProjectionReconciler                                     from '../../../../src/dashboard/DockProjectionReconciler.mjs';
-import DockService                                                  from '../../../../src/ai/client/DockService.mjs';
-import DockZoneModel                                                from '../../../../src/dashboard/DockZoneModel.mjs';
-import FleetCockpitController                                       from './FleetCockpitController.mjs';
-import FleetGrid                                                    from './FleetGrid.mjs';
-import FleetRoster                                                  from '../../store/FleetRoster.mjs';
-import OperatorMailbox                                              from './OperatorMailbox.mjs';
-import StateProvider                                                from '../../../../src/state/Provider.mjs';
-import TourRunner                                                   from '../../../../src/ai/client/TourRunner.mjs';
-import cockpitDockDocument                                          from './cockpitDockDocument.mjs';
-import cockpitPresetCollection                                      from './cockpitPresets.mjs';
-import {createDockTearOutHandlers}                                  from '../../../../src/dashboard/DockTearOut.mjs';
-import {deriveSpineBanner}                                          from './spineBanner.mjs';
-import {fusionTourScript, initialDocument as fusionInitialDocument} from '../../tour/fusionFlagship.mjs';
-import {mapFleetSessionHealth}                                      from './sourceHealth.mjs';
-import {previewToOperation}                                         from '../../../../src/dashboard/dockPreviewContract.mjs';
+import ActivityStream              from './ActivityStream.mjs';
+import AddAgentForm                from './AddAgentForm.mjs';
+import AgentDetail                 from './AgentDetail.mjs';
+import Button                      from '../../../../src/button/Base.mjs';
+import Component                   from '../../../../src/component/Base.mjs';
+import Container                   from '../../../../src/container/Base.mjs';
+import DockLayoutAdapter           from '../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockMotionSignal            from '../../../../src/dashboard/DockMotionSignal.mjs';
+import DockPerspectiveStore        from '../../../../src/dashboard/DockPerspectiveStore.mjs';
+import DockPreviewProducer         from '../../../../src/dashboard/DockPreviewProducer.mjs';
+import DockProjectionReconciler    from '../../../../src/dashboard/DockProjectionReconciler.mjs';
+import DockService                 from '../../../../src/ai/client/DockService.mjs';
+import DockZoneModel               from '../../../../src/dashboard/DockZoneModel.mjs';
+import FleetCockpitController      from './FleetCockpitController.mjs';
+import FleetGrid                   from './FleetGrid.mjs';
+import FleetRoster                 from '../../store/FleetRoster.mjs';
+import OperatorMailbox             from './OperatorMailbox.mjs';
+import StateProvider               from '../../../../src/state/Provider.mjs';
+import TourRunner                  from '../../../../src/ai/client/TourRunner.mjs';
+import cockpitDockDocument         from './cockpitDockDocument.mjs';
+import cockpitPresetCollection     from './cockpitPresets.mjs';
+import {createDockTearOutHandlers} from '../../../../src/dashboard/DockTearOut.mjs';
+import {deriveSpineBanner}         from './spineBanner.mjs';
+import {fusionTourScript}          from '../../tour/fusionFlagship.mjs';
+import {missionControlTourScript}  from '../../tour/missionControlWalkthrough.mjs';
+import {mapFleetSessionHealth}     from './sourceHealth.mjs';
+import {previewToOperation}        from '../../../../src/dashboard/dockPreviewContract.mjs';
 import '../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the dock projection emits for tab zones
 
 /**
@@ -553,6 +554,15 @@ class FleetCockpit extends Container {
      */
     sharedPerspectiveArtifact = null
     /**
+     * The last settled tour report (`{completed, cueErrors, cueReceipts, errors, log}`) —
+     * stamped by {@link #playTour} at every terminal so an NL-driven take can FIRE the play
+     * and read the report AFTER teardown (a long take outlives the transport's request
+     * window, so awaiting the call over the wire is not the contract; polling
+     * `tourRunner === null` then reading this member is).
+     * @member {Object|null} lastTourReport=null
+     */
+    lastTourReport = null
+    /**
      * The serialized hosting-cue chain (the Workstation settlement pattern): TourRunner fires
      * cues synchronously and deliberately never awaits them, so every async cue consumer chains
      * here and {@link #playFusionTour} awaits the WHOLE chain before reporting — a tour can
@@ -655,14 +665,35 @@ class FleetCockpit extends Container {
 
     /**
      * @summary Plays the flagship fusion tour on THIS live cockpit — the four-beat screenplay
-     * (cockpit → docked panel → OS window → share) through the standard runner trinity. The
-     * runner exists only while the tour plays; a second invocation while one runs is a guarded
-     * refusal (one stage, one take). Document ops ride the same `execute_dock_operation` seam a
-     * live agent drives; the vessel and perspective beats arrive as cues ({@link #onTourBeat})
-     * and reuse the cockpit's OWN machinery — no tour-only code path touches dock truth.
+     * (cockpit → docked panel → OS window → share). Delegates to {@link #playTour}.
      * @returns {Promise<Object>} The runner's completion result `{completed, errors, log}`.
      */
-    async playFusionTour() {
+    playFusionTour() {
+        return this.playTour(fusionTourScript)
+    }
+
+    /**
+     * @summary Plays the mission-control walkthrough — the cockpit's public story ("watch a
+     * real AI engineering team run") — on THIS live cockpit. Delegates to {@link #playTour};
+     * driven over the Neural Link by the walkthrough's e2e leg and the recording pipeline.
+     * @returns {Promise<Object>} The runner's completion result `{completed, errors, log}`.
+     */
+    playWalkthroughTour() {
+        return this.playTour(missionControlTourScript)
+    }
+
+    /**
+     * @summary Plays ONE `neo.tour.script.v1` screenplay on THIS live cockpit through the
+     * standard runner trinity — the shared play seam every cockpit tour rides (the fusion
+     * four-beat, the mission-control walkthrough, and any future screenplay). The runner
+     * exists only while the tour plays; a second invocation while one runs is a guarded
+     * refusal (one stage, one take). Document ops ride the same `execute_dock_operation` seam
+     * a live agent drives; every host transition arrives as a cue ({@link #onTourBeat}) and
+     * reuses the cockpit's OWN machinery — no tour-only code path touches dock truth.
+     * @param {Object} script The `neo.tour.script.v1` screenplay to play.
+     * @returns {Promise<Object>} The runner's completion result `{completed, errors, log}`.
+     */
+    async playTour(script) {
         let me = this;
 
         if (me.tourRunner) {
@@ -687,7 +718,7 @@ class FleetCockpit extends Container {
             componentId: me.id,
             dockService: me.dockService,
             mode       : 'demo',
-            script     : fusionTourScript
+            script
         });
 
         me.tourRunner.on({
@@ -712,12 +743,14 @@ class FleetCockpit extends Container {
             // drain before this report exists. Cue failures outrank a green runner log.
             await me.cuePromise;
 
-            return {
+            me.lastTourReport = {
                 ...result,
                 completed  : result.completed && me.cueErrors.length === 0,
                 cueErrors  : [...me.cueErrors],
                 cueReceipts: me.cueReceipts.length
-            }
+            };
+
+            return me.lastTourReport
         } finally {
             me.tourRunner?.destroy?.();
             me.tourRunner = null;
@@ -734,7 +767,7 @@ class FleetCockpit extends Container {
      */
     resetTourStage() {
         let me       = this,
-            document = DockZoneModel.clone(fusionInitialDocument);
+            document = cockpitDockDocument();
 
         me.onDockZoneDocumentChange(document);
         return document
@@ -770,11 +803,13 @@ class FleetCockpit extends Container {
     /**
      * @summary Executes ONE hosting cue against the cockpit's existing verbs and returns its
      * observable receipt — perspective saves ride the landed DockService capture verb, loads
-     * ride {@link #activatePerspective}, export/import ride the share round-trip, and the
-     * vessel beats ride the detail vessel's OWN state machine ({@link #popOutAgentDetail} /
-     * {@link #reattachAgentDetail}). None of them are dock-document ops, so none masquerade as
-     * descriptors; every refused verb THROWS so the settlement chain folds it — an unknown cue
-     * type fails closed the same way (paired with the script spec's vocabulary pin).
+     * ride {@link #activatePerspective}, export/import ride the share round-trip, the vessel
+     * beats ride the detail vessel's OWN state machine ({@link #popOutAgentDetail} /
+     * {@link #reattachAgentDetail}), the walkthrough's `activity-burst` rides the stream's
+     * reactive seam, and `drill` rides the production selection seam. None of them are
+     * dock-document ops, so none masquerade as descriptors; every refused verb THROWS so the
+     * settlement chain folds it — an unknown cue type fails closed the same way (paired with
+     * each script spec's vocabulary pin).
      * @param {Object} cue `{type, name?, itemId?, scope?}`
      * @returns {Promise<Object>} The verb's result object — the cue's receipt.
      */
@@ -812,6 +847,39 @@ class FleetCockpit extends Container {
                 result = await me.reattachAgentDetail();
                 if (!result.reattached) throw new Error(result.errors[0] || 'reattach refused');
                 return result;
+            case 'activity-burst': {
+                // the walkthrough's stream beat: inject `count` synthetic fleet events through
+                // the stream's OWN reactive seam (distinct actors + monotone timestamps, so
+                // coalescing never collapses them) — the same mechanic the burst witnesses drive
+                const stream = me.getReference('activity-stream');
+
+                if (!stream) throw new Error('no activity stream is mounted');
+
+                const count  = cue.count ?? 40,
+                      events = Array.from({length: count}, (_, i) => ({
+                          agentId   : `tour-burst-${i}`,
+                          occurredAt: new Date(Date.UTC(2026, 6, 18, 12, 0, 0) + i * 60000).toISOString(),
+                          payload   : {text: `fleet event ${i}`},
+                          source    : 'memory-core:mailbox',
+                          type      : 'a2a-activity'
+                      }));
+
+                stream.set({adapterState: 'live', events});
+                return {injected: count}
+            }
+            case 'drill': {
+                // the walkthrough's selection beat: NAME-addressed against the public roster
+                // (deterministic across runs), through the production selection seam — the same
+                // path the operator's click drives
+                const controller = me.getController(),
+                      grid       = me.getReference('fleet-grid'),
+                      record     = grid?.store?.items?.find(item => item.agentId === cue.name);
+
+                if (!record) throw new Error(`no roster resident "${cue.name}"`);
+
+                controller.onAgentSelect({agentId: record.agentId});
+                return {drilled: record.agentId}
+            }
             default:
                 throw new Error(`unknown cue type "${cue.type}"`)
         }

--- a/test/playwright/e2e/agentos/MissionControlWalkthroughNL.spec.mjs
+++ b/test/playwright/e2e/agentos/MissionControlWalkthroughNL.spec.mjs
@@ -1,0 +1,93 @@
+import {test, expect}             from '../../fixtures.mjs';
+import {missionControlTourScript} from '../../../../apps/agentos/tour/missionControlWalkthrough.mjs';
+
+/**
+ * @summary The mission-control walkthrough's trinity proof: the SAME screenplay that narrates
+ * the public demo runs here as the e2e — two consecutive live takes with identical beat
+ * sequences (the ticket's determinism AC), driven over the Neural Link on the real cockpit.
+ *
+ * Per-take worker truth: every scripted cue settles into a receipt with zero folded errors
+ * (burst injection through the stream's seam, the NAME-addressed drill through the production
+ * selection path, the real OS-window round trip), the popup terminally closes on reattach,
+ * and the committed dock document survives byte-identical (the screenplay is pure narration —
+ * the projection follows cues, never script-owned ops).
+ *
+ * Recording note (the trinity's third face): a screen capture of `playWalkthroughTour()` in
+ * demo mode IS the video — the runner refuses record mode unless reduced-motion is probed
+ * false by the hosting surface, so a capture can never record a motion-reduced lie.
+ *
+ * Run: NEO_E2E_PORT=8119 npx playwright test agentos/MissionControlWalkthroughNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('AgentOS mission control — the walkthrough trinity (demo = e2e = recording)', () => {
+    test.setTimeout(180000);
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 720, width: 1100}
+    });
+
+    test('two live takes: identical beat logs, settled cue receipts, the real vessel round trip, a byte-identical stage', async ({page, neuralLink}) => {
+        const pageErrors = [];
+
+        page.on('pageerror', error => {
+            const value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/agentos/index.html');
+        await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
+        await expect(page.locator('.fm-agent-card').first()).toBeVisible({timeout: 30000});
+
+        const app       = await neuralLink.connectToApp('AgentOS'),
+              cockpits  = await app.findInstances({className: 'AgentOS.view.fleet.FleetCockpit'}, ['id']),
+              cockpitId = (Array.isArray(cockpits) ? cockpits[0] : cockpits)?.id;
+
+        expect(cockpitId, 'the FleetCockpit must exist in the App Worker').toBeTruthy();
+
+        const scriptedCueCount = missionControlTourScript.scenes.flatMap(scene => scene.steps).filter(step => step.cue).length;
+        const logs             = [];
+
+        for (let run = 0; run < 2; run++) {
+            const popupPromise = page.waitForEvent('popup', {timeout: 90000});
+
+            // the walkthrough is NL-driven by design: FIRE the take without awaiting the
+            // transport (a full demo-paced take outlives the request window — the cockpit's
+            // documented contract is `lastTourReport` after teardown), and swallow the
+            // transport's own timeout if it fires
+            app.callMethod(cockpitId, 'playWalkthroughTour').catch(() => {});
+
+            // the popout beat births the real vessel window mid-take…
+            const popup = await popupPromise;
+
+            await expect(popup.locator('.fm-agent-detail'), 'the vessel hosts the live detail').toBeVisible({timeout: 30000});
+
+            // …and the reattach beat terminally closes it — observed, never inferred
+            await popup.waitForEvent('close', {timeout: 60000});
+
+            // the take is DONE when the runner tears down; the settled report is worker truth
+            await expect.poll(async () => (await app.getComponent(cockpitId, ['tourRunner']))?.tourRunner, {
+                message  : 'the take must finish and tear its runner down',
+                timeout  : 60000,
+                intervals: [500]
+            }).toBeFalsy();
+
+            const result = (await app.getComponent(cockpitId, ['lastTourReport'])).lastTourReport;
+
+            expect(result.completed, `take ${run + 1} completes with cue truth folded in`).toBe(true);
+            expect(result.cueErrors, `take ${run + 1}: no cue folded an error`).toEqual([]);
+            expect(result.cueReceipts, `take ${run + 1}: one receipt per scripted cue`).toBe(scriptedCueCount);
+
+            logs.push(result.log);
+
+            // the drill beat seated the NAME-addressed resident through the production seam
+            const details = await app.queryComponent({className: 'AgentOS.view.fleet.AgentDetail'}, ['record']),
+                  detail  = (Array.isArray(details) ? details : [details]).filter(Boolean)[0];
+
+            expect(detail?.properties?.record?.agentId, 'the drill seated the deterministic resident').toBe('neo-fable')
+        }
+
+        // the determinism AC: two consecutive runs, identical beat sequence
+        expect(logs[1], 'two takes replay the identical beat log').toEqual(logs[0]);
+
+        expect(pageErrors, 'the journey must be error-free in the main window').toEqual([])
+    });
+});

--- a/test/playwright/e2e/agentos/MissionControlWalkthroughNL.spec.mjs
+++ b/test/playwright/e2e/agentos/MissionControlWalkthroughNL.spec.mjs
@@ -46,6 +46,16 @@ test.describe('AgentOS mission control — the walkthrough trinity (demo = e2e =
         const scriptedCueCount = missionControlTourScript.scenes.flatMap(scene => scene.steps).filter(step => step.cue).length;
         const logs             = [];
 
+        // the owner-held stream state BEFORE any take — the burst's reversibility baseline
+        const readStream = async () => {
+            const streams = await app.findInstances({className: 'AgentOS.view.fleet.ActivityStream'}, ['adapterState', 'events']),
+                  stream  = Array.isArray(streams) ? streams[0] : streams;
+
+            return {adapterState: stream?.properties?.adapterState, eventCount: stream?.properties?.events?.length ?? 0}
+        };
+
+        const streamBaseline = await readStream();
+
         for (let run = 0; run < 2; run++) {
             const popupPromise = page.waitForEvent('popup', {timeout: 90000});
 
@@ -82,7 +92,10 @@ test.describe('AgentOS mission control — the walkthrough trinity (demo = e2e =
             const details = await app.queryComponent({className: 'AgentOS.view.fleet.AgentDetail'}, ['record']),
                   detail  = (Array.isArray(details) ? details : [details]).filter(Boolean)[0];
 
-            expect(detail?.properties?.record?.agentId, 'the drill seated the deterministic resident').toBe('neo-fable')
+            expect(detail?.properties?.record?.agentId, 'the drill seated the deterministic resident').toBe('neo-fable');
+
+            // the burst is REVERSIBLE: the owner-held stream state is back exactly at the terminal
+            expect(await readStream(), `take ${run + 1}: the displaced stream state restored`).toEqual(streamBaseline)
         }
 
         // the determinism AC: two consecutive runs, identical beat sequence

--- a/test/playwright/unit/apps/agentos/tour/missionControlWalkthrough.spec.mjs
+++ b/test/playwright/unit/apps/agentos/tour/missionControlWalkthrough.spec.mjs
@@ -1,0 +1,130 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'MissionControlWalkthroughTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import DockService    from '../../../../../../src/ai/client/DockService.mjs';
+import DockZoneModel  from '../../../../../../src/dashboard/DockZoneModel.mjs';
+import TourRunner     from '../../../../../../src/ai/client/TourRunner.mjs';
+
+import {validateTourScript}                        from '../../../../../../src/ai/client/tourScript.mjs';
+import {missionControlTourScript, initialDocument} from '../../../../../../apps/agentos/tour/missionControlWalkthrough.mjs';
+import cockpitDockDocument                         from '../../../../../../apps/agentos/view/fleet/cockpitDockDocument.mjs';
+
+/**
+ * @summary Verifies the mission-control walkthrough screenplay as reviewed content: it
+ * validates fail-closed against the live executor vocabulary, plays start-to-finish in pure
+ * spec-mode replay (the screenplay is pure narration + cues — ZERO document ops, so the
+ * committed stage must be byte-identical after a full run), replays deterministically, and
+ * pins its cue vocabulary against the hosting contract.
+ */
+test.describe.serial('apps/agentos/tour/missionControlWalkthrough', () => {
+    let originalGetComponent, runner, service;
+
+    /**
+     * Wires a fresh holder carrying the screenplay's own opening document.
+     * @returns {Object}
+     */
+    function createHolder() {
+        const holder = {dockZoneDocument: DockZoneModel.clone(initialDocument), id: 'walkthrough-stage'};
+
+        Neo.getComponent = () => holder;
+
+        return holder
+    }
+
+    /**
+     * @returns {Neo.ai.client.TourRunner} a spec-mode runner on a fresh stage
+     */
+    function createRunner() {
+        createHolder();
+
+        runner = Neo.create(TourRunner, {
+            componentId: 'walkthrough-stage',
+            dockService: service,
+            mode       : 'spec',
+            script     : missionControlTourScript
+        });
+
+        return runner
+    }
+
+    test.beforeEach(() => {
+        originalGetComponent = Neo.getComponent;
+        service              = Neo.create(DockService, {})
+    });
+
+    test.afterEach(() => {
+        Neo.getComponent = originalGetComponent;
+        runner?.destroy?.();
+        runner = null;
+        service.destroy?.()
+    });
+
+    test('the screenplay validates fail-closed against the live executor vocabulary', () => {
+        const {valid, errors} = validateTourScript(missionControlTourScript, {operations: DockZoneModel.operations});
+
+        expect(errors).toEqual([]);
+        expect(valid).toBe(true)
+    });
+
+    test('the opening stage IS the shipped cockpit default — imported, never forked', () => {
+        expect(initialDocument).toEqual(cockpitDockDocument())
+    });
+
+    test('pure narration: ZERO document ops, so a full spec-mode replay leaves the committed stage byte-identical', async () => {
+        createRunner();
+
+        const holder = Neo.getComponent('walkthrough-stage');
+        const before = DockZoneModel.clone(holder.dockZoneDocument);
+        const result = await runner.start();
+
+        expect(result.errors).toEqual([]);
+        expect(result.completed).toBe(true);
+        expect(holder.dockZoneDocument).toEqual(before);
+
+        // the storyboard shape: five scenes, no op steps anywhere
+        expect(missionControlTourScript.scenes.map(scene => scene.id)).toEqual(['s1', 's2', 's3', 's4', 's5']);
+        expect(missionControlTourScript.scenes.flatMap(scene => scene.steps).filter(step => step.type === 'op')).toHaveLength(0)
+    });
+
+    test('two consecutive runs replay identically', async () => {
+        createRunner();
+
+        const first = await runner.start();
+
+        expect(first.completed).toBe(true);
+
+        runner.destroy();
+        createRunner();
+
+        const second = await runner.start();
+
+        expect(second.completed).toBe(true);
+        expect(second.log).toEqual(first.log)
+    });
+
+    test('the cue vocabulary is exactly the hosting contract — deterministic name-addressed drill included', () => {
+        const cues = missionControlTourScript.scenes.flatMap(scene => scene.steps)
+            .map(step => step.cue)
+            .filter(Boolean);
+
+        expect([...new Set(cues.map(cue => cue.type))].sort()).toEqual([
+            'activity-burst', 'drill', 'popout', 'reattach'
+        ]);
+
+        // the drill beat is NAME-addressed (deterministic across runs, public roster identity)
+        const drill = cues.find(cue => cue.type === 'drill');
+
+        expect(drill.name).toBe('neo-fable');
+
+        // the burst carries its count (the consumer's injection size)
+        expect(cues.find(cue => cue.type === 'activity-burst').count).toBe(40)
+    });
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitFusionTour.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitFusionTour.spec.mjs
@@ -152,17 +152,48 @@ test.describe('Fleet cockpit — fusion tour hosting seam', () => {
     });
 
     test('one stage, one take: a play invoked while a tour runs is a guarded refusal, not a second runner', async () => {
-        const result = await proto.playFusionTour.call({tourRunner: {}});
+        const result = await proto.playFusionTour.call({playTour: proto.playTour, tourRunner: {}});
 
         expect(result.completed).toBe(false);
         expect(result.errors[0]).toContain('already running')
     });
 
     test('a detached detail pane refuses the take fail-closed — reattach is a host decision, never an implicit tour side-effect', async () => {
-        const result = await proto.playFusionTour.call({tourRunner: null, detachedDetail: {windowName: 'x'}});
+        const result = await proto.playFusionTour.call({playTour: proto.playTour, tourRunner: null, detachedDetail: {windowName: 'x'}});
 
         expect(result.completed).toBe(false);
         expect(result.errors[0]).toContain('reattach before a take')
+    });
+
+    test('the walkthrough cues route to their seams with receipts: activity-burst injects through the stream, drill selects through the controller — refusals fail closed', async () => {
+        const streamSets = [];
+        const selected   = [];
+
+        const host = {
+            getReference : name => name === 'activity-stream'
+                ? {set: config => streamSets.push(config)}
+                : name === 'fleet-grid'
+                    ? {store: {items: [{agentId: 'neo-fable'}, {agentId: 'neo-opus-ada'}]}}
+                    : null,
+            getController: () => ({onAgentSelect: data => selected.push(data.agentId)})
+        };
+
+        const burst = await proto.executeTourCue.call(host, {type: 'activity-burst', count: 7});
+
+        expect(burst).toEqual({injected: 7});
+        expect(streamSets[0].adapterState).toBe('live');
+        expect(streamSets[0].events).toHaveLength(7);
+        // distinct actors + monotone timestamps: coalescing can never collapse the burst
+        expect(new Set(streamSets[0].events.map(event => event.agentId)).size).toBe(7);
+
+        const drill = await proto.executeTourCue.call(host, {type: 'drill', name: 'neo-fable'});
+
+        expect(drill).toEqual({drilled: 'neo-fable'});
+        expect(selected).toEqual(['neo-fable']);
+
+        // fail-closed refusals: an unknown resident and a missing stream both THROW into the fold
+        await expect(proto.executeTourCue.call(host, {type: 'drill', name: 'no-such-agent'})).rejects.toThrow('no roster resident');
+        await expect(proto.executeTourCue.call({getReference: () => null}, {type: 'activity-burst', count: 3})).rejects.toThrow('no activity stream')
     });
 
     test('single-flight under CONCURRENCY: ownership is claimed before any await, so a second call refuses while the first is parked in the refresh window', async () => {
@@ -175,6 +206,7 @@ test.describe('Fleet cockpit — fusion tour hosting seam', () => {
             id            : 'concurrency-stage',
             dockService   : null,
             detachedDetail: null,
+            playTour      : proto.playTour,
             tourRunner    : null,
             refreshPromise: new Promise(resolve => releaseRefresh = resolve),
             resetTourStage: () => {},

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitFusionTour.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitFusionTour.spec.mjs
@@ -165,35 +165,93 @@ test.describe('Fleet cockpit — fusion tour hosting seam', () => {
         expect(result.errors[0]).toContain('reattach before a take')
     });
 
-    test('the walkthrough cues route to their seams with receipts: activity-burst injects through the stream, drill selects through the controller — refusals fail closed', async () => {
+    test('the walkthrough cues route to their seams with receipts: the burst is bounded/honest/reversible, the drill selects through the controller — refusals fail closed', async () => {
         const streamSets = [];
         const selected   = [];
 
         const host = {
-            getReference : name => name === 'activity-stream'
-                ? {set: config => streamSets.push(config)}
+            tourStreamRestore: null,
+            getReference     : name => name === 'activity-stream'
+                ? {adapterState: 'sample', events: [{agentId: 'owner-held'}], set: config => streamSets.push(config)}
                 : name === 'fleet-grid'
                     ? {store: {items: [{agentId: 'neo-fable'}, {agentId: 'neo-opus-ada'}]}}
                     : null,
-            getController: () => ({onAgentSelect: data => selected.push(data.agentId)})
+            getController    : () => ({onAgentSelect: data => selected.push(data.agentId)})
         };
 
         const burst = await proto.executeTourCue.call(host, {type: 'activity-burst', count: 7});
 
-        expect(burst).toEqual({injected: 7});
-        expect(streamSets[0].adapterState).toBe('live');
+        expect(burst).toEqual({injected: 7, provenance: 'tour:demo-burst'});
+        // the surface's adapter state is NOT touched: a sample surface stays labeled sample
+        expect(streamSets[0].adapterState).toBeUndefined();
         expect(streamSets[0].events).toHaveLength(7);
+        // TOUR provenance on every event — generated data never poses as Memory Core arrival
+        expect(streamSets[0].events.every(event => event.source === 'tour:demo-burst')).toBe(true);
         // distinct actors + monotone timestamps: coalescing can never collapse the burst
         expect(new Set(streamSets[0].events.map(event => event.agentId)).size).toBe(7);
+        // the displaced owner-held state is captured for the take-terminal restore
+        expect(host.tourStreamRestore).toEqual({adapterState: 'sample', events: [{agentId: 'owner-held'}]});
 
         const drill = await proto.executeTourCue.call(host, {type: 'drill', name: 'neo-fable'});
 
         expect(drill).toEqual({drilled: 'neo-fable'});
         expect(selected).toEqual(['neo-fable']);
 
-        // fail-closed refusals: an unknown resident and a missing stream both THROW into the fold
+        // fail-closed refusals: unknown resident, missing stream, and every dishonest count
         await expect(proto.executeTourCue.call(host, {type: 'drill', name: 'no-such-agent'})).rejects.toThrow('no roster resident');
-        await expect(proto.executeTourCue.call({getReference: () => null}, {type: 'activity-burst', count: 3})).rejects.toThrow('no activity stream')
+        await expect(proto.executeTourCue.call({getReference: () => null}, {type: 'activity-burst', count: 3})).rejects.toThrow('no activity stream');
+        for (const bad of [undefined, 0, -5, 2.5, 201, 'many']) {
+            await expect(proto.executeTourCue.call(host, {type: 'activity-burst', count: bad}), `count "${bad}" must refuse`)
+                .rejects.toThrow('explicit integer count')
+        }
+    });
+
+    test('restoreTourStream puts the owner-held state back exactly and goes inert after — the burst is reversible at the take terminal', () => {
+        const streamSets = [];
+        const host       = {
+            tourStreamRestore: {adapterState: 'sample', events: [{agentId: 'owner-held'}]},
+            getReference     : name => name === 'activity-stream' ? {set: config => streamSets.push(config)} : null
+        };
+
+        proto.restoreTourStream.call(host);
+
+        expect(streamSets).toEqual([{adapterState: 'sample', events: [{agentId: 'owner-held'}]}]);
+        expect(host.tourStreamRestore).toBeNull();
+
+        // inert when nothing was displaced
+        proto.restoreTourStream.call(host);
+        expect(streamSets).toHaveLength(1)
+    });
+
+    test('CURRENT-ATTEMPT terminal truth: a thrown refresh publishes a failed report for THIS take — a seeded stale success can never masquerade (the RA-1 falsifier)', async () => {
+        const restored = [];
+        const host     = {
+            id               : 'truth-stage',
+            dockService      : null,
+            detachedDetail   : null,
+            playTour         : proto.playTour,
+            restoreTourStream: () => restored.push(true),
+            tourRunner       : null,
+            tourStreamRestore: null,
+            // the seeded STALE SUCCESS from a previous take — the exact masquerade RA-1 names
+            lastTourReport: {completed: true, cueErrors: [], cueReceipts: 6, errors: [], log: ['old']},
+            refreshPromise: Promise.reject(new Error('refresh rejected by the falsifier')),
+            resetTourStage: () => {},
+            onTourBeat    : () => {},
+            onTourComplete: () => {},
+            setTourCaption: () => {}
+        };
+
+        const report = await proto.playFusionTour.call(host);
+
+        // the readable report is CURRENT + FAILED — never stale + green
+        expect(report.completed).toBe(false);
+        expect(report.errors[0]).toContain('refresh rejected');
+        expect(host.lastTourReport).toBe(report);
+        expect(host.lastTourReport.log).toEqual([]);
+        // ownership released through the same terminal, restore ran
+        expect(host.tourRunner).toBeNull();
+        expect(restored).toEqual([true])
     });
 
     test('single-flight under CONCURRENCY: ownership is claimed before any await, so a second call refuses while the first is parked in the refresh window', async () => {
@@ -203,16 +261,18 @@ test.describe('Fleet cockpit — fusion tour hosting seam', () => {
         let releaseRefresh;
 
         const host = {
-            id            : 'concurrency-stage',
-            dockService   : null,
-            detachedDetail: null,
-            playTour      : proto.playTour,
-            tourRunner    : null,
-            refreshPromise: new Promise(resolve => releaseRefresh = resolve),
-            resetTourStage: () => {},
-            onTourBeat    : () => {},
-            onTourComplete: () => {},
-            setTourCaption: () => {}
+            id               : 'concurrency-stage',
+            dockService      : null,
+            detachedDetail   : null,
+            playTour         : proto.playTour,
+            restoreTourStream: () => {},
+            tourRunner       : null,
+            tourStreamRestore: null,
+            refreshPromise   : new Promise(resolve => releaseRefresh = resolve),
+            resetTourStage   : () => {},
+            onTourBeat       : () => {},
+            onTourComplete   : () => {},
+            setTourCaption   : () => {}
         };
 
         const first  = proto.playFusionTour.call(host).catch(error => ({completed: false, errors: [String(error)], crashed: true})),


### PR DESCRIPTION
Resolves #14646

Related: #14560, #14613, #14789, #15470

The mission-control walkthrough — "watch a real AI engineering team run" — lands as the trinity the ticket demands: ONE screenplay is the demo, the e2e, and the recording script. Driven as the operator-directed next-high-ROI lane, composing TODAY'S merges end-to-end: the tour hosting seam (#14789/PR #15455), the drill/vessel mechanics (#14613/PR #15470), and the burst injection pattern.

Evidence: L3 — the full ladder: the screenplay as pure data (5 witnesses incl. the pure-narration byte-identity pin), the cockpit hosting extension (the shared `playTour` seam + two new cue consumers with receipts + fail-closed refusals), and the live trinity e2e — **two consecutive takes, identical beat logs, 1/1 in 50s**. Fusion e2e re-run green (35.8s) proving the `playTour` extraction disturbed nothing. Residual: the recording capture itself (an operator-run screen capture of `playWalkthroughTour()` in demo mode — the pipeline is documented in the e2e header; reach categories attach at publication per the guardrail).

## Deltas

| Area | Before | After |
|---|---|---|
| The cockpit's public story | no artifact a stranger can watch | the five-beat walkthrough: fleet live → activity burst → name-addressed drill → real OS-window round trip → "…and this team built the app you're watching" |
| The play seam | `playFusionTour` hardcoded its script | `playTour(script)` — one guarded/reset/settled seam every screenplay rides; `playFusionTour` + `playWalkthroughTour` delegate |
| Cue vocabulary | six classes (fusion) | +`activity-burst` (injects synthetic fleet events through the stream's OWN reactive seam — distinct actors, monotone timestamps) and +`drill` (NAME-addressed resident selection through the production seam) — receipts + fail-closed refusals like every class |
| NL-driven takes | awaiting the play call over the wire (times out on demo-paced takes) | the `lastTourReport` contract: fire the take, poll `tourRunner === null`, read the settled report — worker truth after teardown |
| Determinism | asserted per-script in spec mode | proven LIVE: two consecutive takes replay the identical beat log on the real module |

## Test Evidence

- `test/playwright/unit/apps/agentos/tour/missionControlWalkthrough.spec.mjs` — 5 witnesses: fail-closed validation; the imported-not-forked pin; **the pure-narration pin** (ZERO ops → a full spec-mode replay leaves the committed stage byte-identical); two-run determinism; the cue-vocabulary pin (exactly the four hosting cues, the drill NAME-addressed to the public roster identity `neo-fable`, the burst count pinned).
- `fleetCockpitFusionTour.spec.mjs` +1 — the walkthrough cues route with receipts (`{injected: n}` with distinct-actor monotone events; `{drilled: agentId}` through the controller seam) and refusals THROW into the fold (unknown resident; missing stream). The delegation-aware guards re-pinned.
- `test/playwright/e2e/agentos/MissionControlWalkthroughNL.spec.mjs` — **the trinity proof, 1/1 in 50s**: two live takes, identical beat logs, one receipt per scripted cue with zero folds, the vessel window born AND terminally closed per take (observed, never inferred), the drill seating the deterministic resident, zero page errors.
- Regression: tour+seam units 28/28; the fusion e2e re-run **1/1 in 35.8s** on the extracted seam.

## Post-Merge Validation

- [ ] The recorded take: screen-capture `playWalkthroughTour()` in demo mode on the workstation (record mode's reduced-motion refusal documented in the e2e header) — the publication artifact.
- [ ] Reach categories attached at publication per the #14442 discipline.
- [ ] The morning-start cascade beat joins the screenplay when a demo-safe bridge fixture exists (scoped OUT of v1 on the ticket — the live cascade needs the real fleet bridge).

## Commits

- `d2fcf48700` — the screenplay + the `playTour` seam + burst/drill cue consumers + `lastTourReport` + the trinity e2e + witnesses.

Authored by Mnemosyne (Claude Fable 5, Claude Code). Session 89818500-8a12-4162-b41f-8947703b1b06.
