### PR TITLE
feat(dashboard): G4 whole-stack reintegration + vessel close — the item comes home (#15247)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -255,6 +255,16 @@ class DemoBWorkspace extends Container {
      */
     tearOutConnects = {}
     /**
+     * Exact-position return truth: `tearOutPlacements[itemId] = {tabsNodeId, index}`, captured
+     * at the detach terminal BEFORE the commit removes the item from the tree (`addTab` appends
+     * by default, so this pair is the only way home). Consumed exact-once by
+     * {@link #reintegrateTearOutItem} on vessel death; a refused detach commit deletes its own
+     * capture, so no stale placement outlives a gesture that never committed.
+     * @member {Object} tearOutPlacements={}
+     * @protected
+     */
+    tearOutPlacements = {}
+    /**
      * Plain structured result of the most recent topology reconciliation. This is rendered
      * into the workspace so remainder semantics are visible rather than buried in logs.
      * @member {Object|null} restoreReport=null
@@ -319,7 +329,7 @@ class DemoBWorkspace extends Container {
         // cancelled tear-out is zero-mutation by GUARD. Post-commit adoption uses its own
         // bookkeeping (`tearOutPanes` / `tearOutConnects`).
         me.tearOutHandlers = createDockTearOutHandlers({
-            applyOperation  : descriptor => me.applyWorkspaceOperation(DemoBWorkspace.MAIN_WORKSPACE_ID, descriptor),
+            applyOperation  : descriptor => me.applyTearOutOperation(descriptor),
             closeVessel     : vessel => me.closeTearOutVessel(vessel),
             onDocumentChange: (document, operation) => {
                 me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, document);
@@ -2163,16 +2173,82 @@ class DemoBWorkspace extends Container {
             }
         }
 
-        // Tear-out vessel death: post-adoption reintegration is the vessel-lifecycle leaf's
-        // scope — here the bookkeeping simply retires (the catalog entry stays the model truth).
-        // A pre-terminal disconnect has no entry in either map and needs nothing.
+        // Tear-out vessel death: the item comes HOME. Model commit precedes every render
+        // effect, the reintegration is exact-once and idempotent against an already-re-treed
+        // item, and the bookkeeping retires with the vessel. A pre-terminal disconnect has no
+        // entry in either map and needs nothing.
         for (const [itemId, entry] of Object.entries(me.tearOutPanes)) {
             if (entry.windowId === data.windowId) {
                 delete me.tearOutPanes[itemId];
                 delete me.tearOutConnects[itemId];
+                me.reintegrateTearOutItem(itemId);
                 break
             }
         }
+    }
+
+    /**
+     * @summary The tear-out commit seam with exact-position capture riding it: the
+     * `{tabsNodeId, index}` pair is readable only BEFORE a detach commit removes the item from
+     * the tree, and a refused commit deletes its own capture — no stale placement outlives a
+     * gesture that never committed. Every non-detach descriptor passes through untouched.
+     * @param {Object} descriptor
+     * @returns {{document:Object, errors:String[]}|null}
+     * @protected
+     */
+    applyTearOutOperation(descriptor) {
+        let me       = this,
+            isDetach = descriptor?.operation === 'detachItem',
+            captured = isDetach ? DockZoneModel.captureItemPlacement(me.dockModel, descriptor.itemId) : null,
+            result;
+
+        captured && (me.tearOutPlacements[descriptor.itemId] = captured);
+
+        result = me.applyWorkspaceOperation(DemoBWorkspace.MAIN_WORKSPACE_ID, descriptor);
+
+        isDetach && result?.errors?.length && delete me.tearOutPlacements[descriptor.itemId];
+
+        return result
+    }
+
+    /**
+     * @summary Brings a torn-out item HOME on vessel death — the exact-position return of the
+     * vessel close policy (harness docking design record §2.8; the disposition this host's
+     * pre-vessel-lifecycle comment deferred).
+     *
+     * The stored `{tabsNodeId, index}` pair (captured at the detach terminal) is the placement
+     * truth; recovery is SEMANTIC, never geometric: a stored home node that left the tree falls
+     * back to the first surviving tabs node (append), mirroring the click path's
+     * `reattachPane` fallback. Exact-once and idempotent: an item some other flow already
+     * re-treed is left where it is, and the placement record is consumed regardless — a second
+     * vessel death for the same item finds nothing to do. An item whose document no longer
+     * catalogs it, or a document with no surviving tabs node, stays catalog-only/absent — the
+     * honest terminal, with zero mutation.
+     * @param {String} itemId
+     * @protected
+     */
+    reintegrateTearOutItem(itemId) {
+        let me         = this,
+            placement  = me.tearOutPlacements[itemId],
+            doc        = me.dockModel,
+            storedHome = placement && doc.nodes?.[placement.tabsNodeId]?.type === 'tabs' ? placement.tabsNodeId : null,
+            fallback   = storedHome || Object.entries(doc.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0],
+            result;
+
+        delete me.tearOutPlacements[itemId];
+
+        if (!doc.items?.[itemId] || !fallback || DockZoneModel.findContainingTabsId(doc, itemId)) {
+            return
+        }
+
+        result = me.applyWorkspaceOperation(DemoBWorkspace.MAIN_WORKSPACE_ID, {
+            operation : 'addTab',
+            itemId,
+            tabsNodeId: fallback,
+            ...(storedHome ? {index: placement.index} : {})
+        });
+
+        result?.errors?.length === 0 && me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, result.document)
     }
 
     /**

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -520,13 +520,32 @@ class FleetCockpit extends Container {
      * Live pane instances captured at the detached terminal, keyed by item id — the cockpit's
      * projection DESTROYS un-preserved panes on reconcile, so the instance is captured
      * synchronously before the commit's re-projection runs and parked via the reconciler's
-     * `preserveItemIds` until its vessel adopts it. Released when the vessel disconnects (the
-     * popup's view-tree teardown destroys the mounted pane; the catalog entry stays the model
-     * truth and a re-treed item re-materializes from owner-held state).
+     * `preserveItemIds` until its vessel adopts it. On vessel death the handle feeds
+     * {@link #reintegrateTearOutItem}: a window disconnect never destroys the popup's view tree,
+     * so the LIVE instance survives and comes home same-instance through
+     * {@link #returningTearOutPanes} — destruction is only the no-home fallback terminal.
      * @member {Object} tearOutPaneHandles={}
      * @protected
      */
     tearOutPaneHandles = {}
+    /**
+     * Exact-position return truth: `tearOutPlacements[itemId] = {tabsNodeId, index}`, captured
+     * at the detach terminal BEFORE the commit removes the item (`addTab` appends by default,
+     * so this pair is the only way home). A refused detach commit deletes its own capture;
+     * {@link #reintegrateTearOutItem} consumes the record exact-once on vessel death.
+     * @member {Object} tearOutPlacements={}
+     * @protected
+     */
+    tearOutPlacements = {}
+    /**
+     * The one-refresh handoff slot for a pane coming HOME on vessel death:
+     * {@link #resolveDockComponentRef} consumes it FIRST — before the torn stand-in guard — and
+     * returns the LIVE instance into the projection (the {@link #detachedDetailPane} re-adoption
+     * precedent, generalized to gesture vessels). Same instance, never a recreation.
+     * @member {Object} returningTearOutPanes={}
+     * @protected
+     */
+    returningTearOutPanes = {}
     /**
      * The cockpit-owned dock seam instance — the SAME `execute_dock_operation` path a live
      * agent drives, injected into the tour runner so scripted ops and agent ops are one code
@@ -600,7 +619,7 @@ class FleetCockpit extends Container {
         // pathways converge only through guards (the toggle disables while `detail` is torn;
         // a click-windowed `detail` has no projected tab for the gesture to arm on).
         me.tearOutHandlers = createDockTearOutHandlers({
-            applyOperation  : descriptor => me.applyDockZoneOperation(descriptor),
+            applyOperation  : descriptor => me.applyTearOutOperation(descriptor),
             closeVessel     : vessel => me.closeTearOutVessel(vessel),
             onDocumentChange: (document, operation) => {
                 let detached = operation?.operation === 'detachItem';
@@ -1199,13 +1218,29 @@ class FleetCockpit extends Container {
      * @returns {Object}
      */
     resolveDockComponentRef(componentRef, item, itemId) {
-        let me     = this,
-            marker = `dock-flip-item-${encodeURIComponent(itemId)}`;
+        let me        = this,
+            marker    = `dock-flip-item-${encodeURIComponent(itemId)}`,
+            returning = me.returningTearOutPanes?.[itemId];
+
+        // vessel-death re-adoption FIRST — before the torn stand-in guard, because the records
+        // are already retired when the handoff slot is armed: the LIVE pane returns into the
+        // projection, same instance, never a recreation (the detachedDetailPane precedent
+        // below, generalized to gesture vessels). A slot holding a destroyed pane is consumed
+        // and falls through to normal materialization.
+        if (returning) {
+            delete me.returningTearOutPanes[itemId];
+
+            if (!returning.isDestroyed) {
+                returning.parent?.remove(returning, false);
+                return returning
+            }
+        }
 
         // a GESTURE-torn item's live pane is vessel-owned: a preset restore (or NL addTab)
         // re-treeing the item while torn must not steal or duplicate the instance — an honest
         // stand-in holds the slot (the same discipline as the click-detached inspector below);
-        // whole-stack reintegration is the G4 leaf's scope. Optional-chained like every sibling
+        // the vessel-death return path above swaps it for the live pane when the vessel dies.
+        // Optional-chained like every sibling
         // field read: the projection specs drive these prototype methods over controlled state.
         if (me.tearOutPaneHandles?.[itemId] && !me.tearOutPaneHandles[itemId].isDestroyed) {
             return {
@@ -1468,9 +1503,10 @@ class FleetCockpit extends Container {
     /**
      * The owner-destroy exit for every live tear-out record: closes each admitted vessel
      * (fire-and-forget — the disconnect listener is already detached by the destroy path, so no
-     * re-entry) and settles every owner-held pane exactly once with the same detach + destroy
-     * disposition the vessel-death path uses. Cockpit teardown must not leave an OS vessel open
-     * or a live pane orphaned under a popup view tree the worker never destroys.
+     * re-entry) and settles every owner-held pane exactly once — captured handles AND armed
+     * returning slots alike (cockpit teardown is a terminal, so the bring-home handoff has no
+     * refresh left to land in). Cockpit teardown must not leave an OS vessel open or a live
+     * pane orphaned under a popup view tree the worker never destroys.
      * @protected
      */
     retireTearOutState() {
@@ -1480,16 +1516,105 @@ class FleetCockpit extends Container {
             windowName && Neo.Main.windowClose({names: [windowName], windowId: me.windowId}).catch(() => {})
         }
 
-        for (const pane of Object.values(me.tearOutPaneHandles || {})) {
+        for (const pane of [...Object.values(me.tearOutPaneHandles || {}), ...Object.values(me.returningTearOutPanes || {})]) {
             if (pane && !pane.isDestroyed) {
                 pane.parent?.remove(pane, false);
                 pane.destroy()
             }
         }
 
-        me.tearOutPanes       = {};
-        me.tearOutConnects    = {};
-        me.tearOutPaneHandles = {}
+        me.tearOutPanes          = {};
+        me.tearOutConnects       = {};
+        me.tearOutPaneHandles    = {};
+        me.tearOutPlacements     = {};
+        me.returningTearOutPanes = {}
+    }
+
+    /**
+     * @summary The tear-out commit seam with exact-position capture riding it: the
+     * `{tabsNodeId, index}` pair is readable only BEFORE a detach commit removes the item from
+     * the tree, and a refused commit deletes its own capture — no stale placement outlives a
+     * gesture that never committed. Every non-detach descriptor passes through untouched.
+     * @param {Object} descriptor
+     * @returns {{document:Object, errors:String[]}}
+     * @protected
+     */
+    applyTearOutOperation(descriptor) {
+        let me       = this,
+            isDetach = descriptor?.operation === 'detachItem',
+            captured = isDetach ? DockZoneModel.captureItemPlacement(me.dockModel, descriptor.itemId) : null,
+            result;
+
+        captured && ((me.tearOutPlacements ??= {})[descriptor.itemId] = captured);
+
+        result = me.applyDockZoneOperation(descriptor);
+
+        isDetach && result?.errors?.length && delete me.tearOutPlacements?.[descriptor.itemId];
+
+        return result
+    }
+
+    /**
+     * @summary Brings a torn-out item HOME on vessel death — same instance, exact stored
+     * position (the vessel close policy of the harness docking design record §2.8).
+     *
+     * A window disconnect never destroys the popup's view tree, so the captured pane survives
+     * LIVE; it hands off through {@link #returningTearOutPanes} and the resolver returns it
+     * into the projection (the {@link #detachedDetailPane} re-adoption precedent). Placement
+     * recovery is SEMANTIC, never geometric: the stored `{tabsNodeId, index}` pair when its
+     * node survives, the first surviving tabs node (append) when it left the tree. An item some
+     * other flow already re-treed keeps that placement — the refresh simply swaps its stand-in
+     * for the live pane. Destruction remains only the no-home fallback terminal (no catalog
+     * record, no surviving tabs node, or a failed return commit) — ownership always settles,
+     * nothing is ever orphaned under a dead vessel's view.
+     * @param {String} itemId
+     * @param {Neo.component.Base|null} pane The captured handle, already released from the maps.
+     * @protected
+     */
+    reintegrateTearOutItem(itemId, pane) {
+        let me         = this,
+            placement  = me.tearOutPlacements?.[itemId],
+            doc        = me.dockModel,
+            storedHome = placement && doc?.nodes?.[placement.tabsNodeId]?.type === 'tabs' ? placement.tabsNodeId : null,
+            fallback   = storedHome || Object.entries(doc?.nodes || {}).find(([, node]) => node.type === 'tabs')?.[0],
+            live       = pane && !pane.isDestroyed,
+            settle     = () => {
+                if (live) {
+                    pane.parent?.remove(pane, false);
+                    pane.destroy()
+                }
+            },
+            result;
+
+        delete me.tearOutPlacements?.[itemId];
+
+        if (!doc?.items?.[itemId] || !fallback) {
+            settle();
+            return
+        }
+
+        live && ((me.returningTearOutPanes ??= {})[itemId] = pane);
+
+        if (DockZoneModel.findContainingTabsId(doc, itemId)) {
+            // already re-treed by another flow (preset restore, NL addTab): the model is
+            // truthful as-is — the refresh swaps the stand-in for the returning live pane
+            me.refreshDockWorkspace();
+            return
+        }
+
+        result = me.applyDockZoneOperation({
+            operation : 'addTab',
+            itemId,
+            tabsNodeId: fallback,
+            ...(storedHome ? {index: placement.index} : {})
+        });
+
+        if (result?.errors?.length === 0) {
+            me.onDockZoneDocumentChange(result.document)
+        } else {
+            delete me.returningTearOutPanes?.[itemId];
+            settle()
+        }
     }
 
     /**
@@ -1867,26 +1992,21 @@ class FleetCockpit extends Container {
             return
         }
 
-        // Tear-out vessel death: a window disconnect is a render-target signal ONLY — the worker
-        // fires `disconnect` without destroying the popup application or its view tree, so the
-        // reparented pane SURVIVES under the dead vessel's mainView. Ownership is therefore
-        // settled explicitly before the handle is retired: detach + destroy, which keeps the
-        // catalog entry the single model truth and lets a later re-tree materialize exactly ONE
-        // successor from owner-held state (a retained hidden instance would duplicate it).
-        // Post-adoption reintegration (bringing the item HOME on vessel close) is the G4
-        // vessel-lifecycle leaf's scope.
+        // Tear-out vessel death: the item comes HOME. A window disconnect is a render-target
+        // signal ONLY — the worker fires `disconnect` without destroying the popup application
+        // or its view tree, so the captured pane survives LIVE and ownership settles through
+        // {@link #reintegrateTearOutItem}: same instance back at its stored position, semantic
+        // fallback when the home node left the tree, destruction only as the no-home terminal.
+        // The records retire BEFORE the reintegration so the torn stand-in guard cannot fire on
+        // the returning item's re-projection.
         for (const [itemId, entry] of Object.entries(me.tearOutPanes || {})) {
             if (entry.windowId === data.windowId) {
                 let pane = me.tearOutPaneHandles?.[itemId];
 
-                if (pane && !pane.isDestroyed) {
-                    pane.parent?.remove(pane, false);
-                    pane.destroy()
-                }
-
                 delete me.tearOutPanes[itemId];
                 delete me.tearOutConnects?.[itemId];
                 delete me.tearOutPaneHandles?.[itemId];
+                me.reintegrateTearOutItem(itemId, pane || null);
                 me.syncControlBar();
                 break
             }

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -513,6 +513,28 @@ class DockZoneModel extends Base {
     }
 
     /**
+     * @summary Captures an item's exact tree placement — the stored-position half of
+     * exact-position reintegration (harness docking design record §2.8,
+     * `learn/agentos/decisions/0029-harness-docking-design.md`).
+     *
+     * `addTab` appends by default, so a detached item's way back to its ORIGINAL slot exists
+     * only if this pair was captured while the item was still in the tree — capture happens
+     * BEFORE the detach commit, restore passes the pair straight into `addTab`'s clamped
+     * `index`. Fail-closed: an item no tabs node currently holds captures `null` (catalog
+     * presence is not placement; there is nothing to restore to).
+     * @param {Object} document
+     * @param {String} itemId
+     * @returns {{tabsNodeId: String, index: Number}|null}
+     * @static
+     */
+    static captureItemPlacement(document, itemId) {
+        let tabsNodeId = DockZoneModel.findContainingTabsId(document, itemId),
+            index      = tabsNodeId ? document.nodes[tabsNodeId].items.indexOf(itemId) : -1;
+
+        return index >= 0 ? {tabsNodeId, index} : null
+    }
+
+    /**
      * @summary Finds the parent node id + the slot key pointing at `nodeId`.
      *
      * For a `split` parent the slot is the child index (Number); for an `edge-zone` parent it is the

--- a/src/dashboard/DockZoneModel.mjs
+++ b/src/dashboard/DockZoneModel.mjs
@@ -2010,6 +2010,37 @@ class DockZoneModel extends Base {
     }
 
     /**
+     * @summary Resolves a workspace document's transferable STACK ROOT — the explicit source-side
+     * projection for whole-stack reintegration (harness docking design record §2.8,
+     * `learn/agentos/decisions/0029-harness-docking-design.md`).
+     *
+     * The canonical vessel document shape is an `edge-zone` ROOT (window chrome) whose `center`
+     * zone names the subtree holding the vessel's content — so "the whole stack" is the root's
+     * center child, never the document root itself. Resolving it keeps `transferNode`'s root
+     * rejection byte-identical: whole-stack transfer is explicit resolution composed with the
+     * landed two-document executor, and an implicit root transfer stays impossible.
+     *
+     * Fail-closed: a missing document, a missing root node, a root that is not an `edge-zone`,
+     * or a center zone that is absent or names an unknown node all resolve `null` — a document
+     * that cannot prove its stack root never transfers.
+     * @param {Object} document a committed dock-zone document
+     * @returns {String|null} the stack-root node id, or null
+     * @static
+     */
+    static resolveStackRoot(document) {
+        let root = document?.nodes?.[document?.root],
+            centerId;
+
+        if (!root || root.type !== 'edge-zone') {
+            return null
+        }
+
+        centerId = root.zones?.center;
+
+        return centerId && document.nodes[centerId] ? centerId : null
+    }
+
+    /**
      * @summary Atomically transfers the subtree rooted at `nodeId` out of `sourceDocument` and into
      * `targetDocument` in one commit-or-neither step — the cross-window grouped-drag transfer. It is
      * the two-document sibling of `moveNode`: `transferItem` atomicity applied to a whole subtree. The

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
@@ -586,6 +586,94 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
         expect(workspace.dockModel).toEqual(initialDocument)
     });
 
+    test('tear-out vessel death brings the item HOME at its EXACT stored position', () => {
+        // 'timeline' sits at side-tabs index 1 of ['inspector', 'timeline', 'console'] — the
+        // middle slot, so an append-shaped return would betray itself immediately.
+        const before = workspace.getDockZoneDocument().nodes['side-tabs'].items;
+
+        expect(before).toEqual(['inspector', 'timeline', 'console']);
+
+        // the detach terminal commits through the seam the projection threads — capture rides it
+        const result = workspace.applyTearOutOperation({operation: 'detachItem', itemId: 'timeline'});
+
+        expect(result.errors).toEqual([]);
+        expect(workspace.tearOutPlacements.timeline).toEqual({tabsNodeId: 'side-tabs', index: 1});
+
+        workspace.onWorkspaceDocumentChange('demo-b-main', result.document);
+        expect(workspace.getDockZoneDocument().nodes['side-tabs'].items).toEqual(['inspector', 'console']);
+
+        // the vessel dies: the disconnect correlates by windowId and the item returns home
+        workspace.tearOutPanes.timeline = {windowName: 'demo-b-tearout-timeline', windowId: 'tear-win-9'};
+        workspace.onWindowDisconnect({windowId: 'tear-win-9'});
+
+        expect(workspace.getDockZoneDocument().nodes['side-tabs'].items, 'identical order, not append order').toEqual(['inspector', 'timeline', 'console']);
+        expect(workspace.tearOutPanes.timeline).toBeUndefined();
+        expect(workspace.tearOutPlacements.timeline, 'the placement record is consumed exact-once').toBeUndefined();
+
+        // idempotent: a duplicate disconnect for the same window finds nothing and mutates nothing
+        const stable = JSON.stringify(workspace.getDockZoneDocument());
+
+        workspace.onWindowDisconnect({windowId: 'tear-win-9'});
+        expect(JSON.stringify(workspace.getDockZoneDocument())).toBe(stable)
+    });
+
+    test('a stored home that left the tree falls back SEMANTICALLY to a surviving tabs node', () => {
+        const detach = workspace.applyTearOutOperation({operation: 'detachItem', itemId: 'timeline'});
+
+        expect(detach.errors).toEqual([]);
+        workspace.onWorkspaceDocumentChange('demo-b-main', detach.document);
+
+        // the remembered home leaves the tree: move the two remaining side-tabs items into the
+        // workbench node — the emptied side-tabs collapses out on normalize
+        for (const itemId of ['inspector', 'console']) {
+            const moved = workspace.applyDockZoneOperation({operation: 'addTab', itemId, tabsNodeId: 'workbench-tabs'});
+
+            expect(moved.errors).toEqual([]);
+            workspace.onWorkspaceDocumentChange('demo-b-main', moved.document)
+        }
+
+        expect(workspace.getDockZoneDocument().nodes['side-tabs']).toBeUndefined();
+
+        workspace.tearOutPanes.timeline = {windowName: 'demo-b-tearout-timeline', windowId: 'tear-win-10'};
+        workspace.onWindowDisconnect({windowId: 'tear-win-10'});
+
+        // semantic recovery: the first surviving tabs node, append — never a resurrected node,
+        // never geometry
+        const home = workspace.getDockZoneDocument().nodes['workbench-tabs'].items;
+
+        expect(home).toContain('timeline');
+        expect(home[home.length - 1]).toBe('timeline')
+    });
+
+    test('a refused detach commit deletes its own capture — no stale placement survives', () => {
+        const result = workspace.applyTearOutOperation({operation: 'detachItem', itemId: 'ghost-item'});
+
+        expect(result.errors.length).toBeGreaterThan(0);
+        expect(workspace.tearOutPlacements['ghost-item']).toBeUndefined()
+    });
+
+    test('reintegration is idempotent against an item some other flow already re-treed', () => {
+        const detach = workspace.applyTearOutOperation({operation: 'detachItem', itemId: 'timeline'});
+
+        workspace.onWorkspaceDocumentChange('demo-b-main', detach.document);
+
+        // another flow re-trees the item mid-vessel (preset restore, NL addTab)
+        const readd = workspace.applyDockZoneOperation({operation: 'addTab', itemId: 'timeline', tabsNodeId: 'workbench-tabs'});
+
+        workspace.onWorkspaceDocumentChange('demo-b-main', readd.document);
+
+        workspace.tearOutPanes.timeline = {windowName: 'demo-b-tearout-timeline', windowId: 'tear-win-11'};
+        workspace.onWindowDisconnect({windowId: 'tear-win-11'});
+
+        // the reintegration finds the item already placed and leaves it EXACTLY there — one
+        // occurrence, in the node the other flow chose, placement record still consumed
+        const doc = workspace.getDockZoneDocument();
+
+        expect(DockZoneModel.findContainingTabsId(doc, 'timeline')).toBe('workbench-tabs');
+        expect(doc.nodes['workbench-tabs'].items.filter(id => id === 'timeline')).toHaveLength(1);
+        expect(workspace.tearOutPlacements.timeline).toBeUndefined()
+    });
+
     test('destroy tears down the runner, seam, store, and every cached pane', () => {
         const pane                                        = workspace.resolvePane('workbench', initialDocument.items.workbench);
         const {dockService, perspectiveStore, tourRunner} = workspace;

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitTearOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitTearOut.spec.mjs
@@ -11,6 +11,7 @@ import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import '../../../../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
 import Container     from '../../../../../../../src/container/Base.mjs';
+import DockZoneModel from '../../../../../../../src/dashboard/DockZoneModel.mjs';
 import FleetCockpit  from '../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs';
 import FleetRoster   from '../../../../../../../apps/agentos/store/FleetRoster.mjs';
 import StateProvider from '../../../../../../../src/state/Provider.mjs';
@@ -70,9 +71,10 @@ function installWindowVessel({openResult = true, popupUrl = null} = {}) {
  * 5. convergence-by-guard with the click pop-out: the toggle goes inert while `detail` is torn,
  *    a torn item re-treed mid-flight renders a stand-in (never steals the instance), and the
  *    accessor still resolves the live pane;
- * 6. vessel disconnect SETTLES pane ownership — a disconnect is a render-target signal, never
- *    implicit destruction: the pane is disposed (not orphaned under the dead vessel's view), the
- *    records retire, and a re-tree yields exactly one successor;
+ * 6. vessel death brings the item HOME — a disconnect is a render-target signal, never implicit
+ *    destruction: the SAME live instance returns to the projection at its stored position
+ *    (semantic fallback when the home node left the tree), every record is consumed exact-once,
+ *    and destruction remains only the no-home fallback terminal;
  * 7. the owner-destroy exit: cockpit teardown closes admitted vessels and settles every
  *    owner-held pane exactly once (idempotent).
  *
@@ -299,13 +301,16 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — gesture tear-out seam 
         expect(detailPane.isDestroyed).toBeFalsy()
     });
 
-    test('vessel disconnect SETTLES pane ownership: the orphan view keeps no live pane, and a re-tree yields exactly one successor', async () => {
+    test('vessel death brings the item HOME — same instance, no orphan under the dead view, semantic fallback placement', async () => {
         vessel = installWindowVessel();
 
         const streamPane = cockpit.getReference('activity-stream');
         const zone       = await tearOutExit('stream');
 
         cockpit.tearOutHandlers.onDockTearOutTerminal({itemId: 'stream', sortZone: zone});
+
+        // capture rode the detach commit: 'stream' lived alone in stream-tabs at index 0
+        expect(cockpit.tearOutPlacements.stream).toEqual({tabsNodeId: 'stream-tabs', index: 0});
 
         vessel.restore();
         vessel = installWindowVessel({popupUrl: `https://unit.test/widget/index.html?tearout=stream&cockpitId=${cockpit.id}`});
@@ -319,31 +324,90 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — gesture tear-out seam 
         expect(mainView.items).toContain(streamPane);
 
         cockpit.onWindowDisconnect({windowId: 'tearout-win-3'});
+        await cockpit.refreshPromise;
 
         // A window disconnect does NOT destroy the popup application or its view tree — the
-        // worker only fires the event — so ownership must be settled EXPLICITLY. The load-bearing
-        // assertions: the dead vessel's mainView holds no forgotten live pane, and the instance
-        // itself is disposed, not merely forgotten by the bookkeeping.
-        expect(mainView.items, 'the orphan view keeps no live pane').not.toContain(streamPane);
-        expect(streamPane.isDestroyed, 'ownership settled: the pane is disposed, not orphaned').toBeTruthy();
+        // worker only fires the event — so the captured pane survives LIVE and comes HOME:
+        // the same instance, out of the dead vessel's view, back in the projection. The
+        // emptied stream-tabs node collapsed at detach, so placement recovery is the SEMANTIC
+        // fallback (a surviving tabs node), never a resurrected node, never geometry.
+        expect(mainView.items, 'the dead vessel view keeps no pane').not.toContain(streamPane);
+        expect(streamPane.isDestroyed, 'same-instance return: the pane is never destroyed').toBeFalsy();
+        expect(cockpit.getReference('activity-stream'), 'the projection resolves the ORIGINAL instance').toBe(streamPane);
+        expect(DockZoneModel.findContainingTabsId(cockpit.dockModel, 'stream'), 'the item is back in the tree').toBeTruthy();
 
+        // every record is consumed exact-once
         expect(cockpit.tearOutPanes.stream).toBeUndefined();
         expect(cockpit.tearOutConnects.stream).toBeUndefined();
         expect(cockpit.tearOutPaneHandles.stream).toBeUndefined();
+        expect(cockpit.tearOutPlacements.stream).toBeUndefined();
+        expect(cockpit.returningTearOutPanes.stream).toBeUndefined()
+    });
 
-        // Re-treeing the item materializes exactly ONE successor from owner-held state — the
-        // catalog record stayed the model truth, and no hidden retained instance can duplicate it.
-        const readd = cockpit.applyDockZoneOperation({operation: 'addTab', itemId: 'stream', tabsNodeId: 'secondary-rail'});
+    test('a surviving home node gets the EXACT stored position back — not append order', async () => {
+        vessel = installWindowVessel();
 
-        expect(readd.errors).toEqual([]);
-        cockpit.onDockZoneDocumentChange(readd.document);
+        // pre-arrange a two-item strip so the emptied-node collapse cannot hide append-shaped
+        // returns: 'stream' at index 0 AHEAD of 'perspectives'
+        const arrange = cockpit.applyDockZoneOperation({operation: 'addTab', itemId: 'perspectives', tabsNodeId: 'stream-tabs'});
+
+        expect(arrange.errors).toEqual([]);
+        cockpit.onDockZoneDocumentChange(arrange.document);
         await cockpit.refreshPromise;
 
-        const successor = cockpit.getReference('activity-stream');
+        const move = cockpit.applyDockZoneOperation({operation: 'moveItem', itemId: 'stream', targetNodeId: 'stream-tabs', index: 0});
 
-        expect(successor, 'exactly one valid pane materializes').toBeTruthy();
-        expect(successor).not.toBe(streamPane);
-        expect(successor.isDestroyed).toBeFalsy()
+        expect(move.errors).toEqual([]);
+        cockpit.onDockZoneDocumentChange(move.document);
+        await cockpit.refreshPromise;
+        expect(cockpit.dockModel.nodes['stream-tabs'].items).toEqual(['stream', 'perspectives']);
+
+        const zone = await tearOutExit('stream');
+
+        cockpit.tearOutHandlers.onDockTearOutTerminal({itemId: 'stream', sortZone: zone});
+        expect(cockpit.tearOutPlacements.stream).toEqual({tabsNodeId: 'stream-tabs', index: 0});
+        expect(cockpit.dockModel.nodes['stream-tabs'].items).toEqual(['perspectives']);
+
+        cockpit.tearOutPanes.stream = {windowName: `fm-tearout-stream-${cockpit.id}`, windowId: 'tearout-win-5'};
+        cockpit.onWindowDisconnect({windowId: 'tearout-win-5'});
+        await cockpit.refreshPromise;
+
+        expect(cockpit.dockModel.nodes['stream-tabs'].items, 'identical order, not append order').toEqual(['stream', 'perspectives'])
+    });
+
+    test('the no-home terminal still settles ownership: a closed-out item\'s pane is destroyed, never orphaned', async () => {
+        vessel = installWindowVessel();
+
+        const streamPane = cockpit.getReference('activity-stream');
+        const zone       = await tearOutExit('stream');
+
+        cockpit.tearOutHandlers.onDockTearOutTerminal({itemId: 'stream', sortZone: zone});
+
+        vessel.restore();
+        vessel = installWindowVessel({popupUrl: `https://unit.test/widget/index.html?tearout=stream&cockpitId=${cockpit.id}`});
+
+        const mainView = Neo.create(Container, {});
+        Neo.apps ??= {};
+        Neo.apps['tearout-win-6'] = {mainView};
+
+        await cockpit.onWindowConnect({windowId: 'tearout-win-6'});
+        expect(mainView.items).toContain(streamPane);
+
+        // the catalog record leaves while the item is vessel-owned: no home exists to return to
+        const closed = cockpit.applyDockZoneOperation({operation: 'closeItem', itemId: 'stream'});
+
+        expect(closed.errors).toEqual([]);
+        cockpit.onDockZoneDocumentChange(closed.document);
+        await cockpit.refreshPromise;
+        expect(cockpit.dockModel.items.stream).toBeUndefined();
+
+        cockpit.onWindowDisconnect({windowId: 'tearout-win-6'});
+
+        // the fallback terminal: ownership settles by destruction — nothing orphans, nothing returns
+        expect(streamPane.isDestroyed).toBeTruthy();
+        expect(mainView.items).not.toContain(streamPane);
+        expect(cockpit.returningTearOutPanes.stream).toBeUndefined();
+        expect(cockpit.tearOutPlacements.stream).toBeUndefined()
     });
 
     test('the owner-destroy exit: cockpit teardown closes admitted vessels and settles every owner-held pane exactly once', async () => {

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -1474,6 +1474,55 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
         }
     });
 
+    test.describe('captureItemPlacement (exact-position return, stored half)', () => {
+        test('captures the holding tabs node and the exact index', () => {
+            expect(DockZoneModel.captureItemPlacement(doc(), 'strategy')).toEqual({tabsNodeId: 'main-tabs', index: 0});
+            expect(DockZoneModel.captureItemPlacement(doc(), 'swarm')).toEqual({tabsNodeId: 'main-tabs', index: 1});
+            expect(DockZoneModel.captureItemPlacement(doc(), 'terminal')).toEqual({tabsNodeId: 'side-tabs', index: 0})
+        });
+
+        test('fails closed when no tabs node holds the item — catalog presence is not placement', () => {
+            expect(DockZoneModel.captureItemPlacement(doc(), 'ghost')).toBeNull();
+
+            // a DETACHED item stays in the catalog but has no placement to capture
+            const {document: detached, errors} = DockZoneModel.applyOperation(doc(), {operation: 'detachItem', itemId: 'strategy'});
+
+            expect(errors).toEqual([]);
+            expect(detached.items.strategy).toBeTruthy();
+            expect(DockZoneModel.captureItemPlacement(detached, 'strategy')).toBeNull()
+        });
+
+        test('the ROUND TRIP: capture → detach → addTab with the stored pair restores the ORIGINAL order, not append order', () => {
+            const source = doc();
+
+            // 'strategy' sits at index 0 of ['strategy', 'swarm'] — the append default would
+            // put it BACK at index 1, which is exactly the defect the stored pair compensates
+            const placement = DockZoneModel.captureItemPlacement(source, 'strategy');
+
+            expect(placement).toEqual({tabsNodeId: 'main-tabs', index: 0});
+
+            const {document: detached} = DockZoneModel.applyOperation(source, {operation: 'detachItem', itemId: 'strategy'});
+
+            const {document: restored, errors} = DockZoneModel.applyOperation(detached, {
+                operation : 'addTab',
+                itemId    : 'strategy',
+                tabsNodeId: placement.tabsNodeId,
+                index     : placement.index
+            });
+
+            expect(errors).toEqual([]);
+            expect(restored.nodes['main-tabs'].items, 'identical order, not append order').toEqual(['strategy', 'swarm']);
+
+            // the control: WITHOUT the stored index the item lands at the tail — the append
+            // default alone cannot deliver exact-position return
+            const {document: appended} = DockZoneModel.applyOperation(detached, {
+                operation: 'addTab', itemId: 'strategy', tabsNodeId: 'main-tabs'
+            });
+
+            expect(appended.nodes['main-tabs'].items).toEqual(['swarm', 'strategy'])
+        })
+    });
+
     test.describe('resolveStackRoot (whole-stack source projection)', () => {
         // The canonical vessel document: an edge-zone ROOT (window chrome) whose center zone
         // holds the stack — so the transferable whole is the root's center child, never the root.

--- a/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
+++ b/test/playwright/unit/dashboard/DockZoneModel.spec.mjs
@@ -1474,6 +1474,95 @@ test.describe('Neo.dashboard.DockZoneModel', () => {
         }
     });
 
+    test.describe('resolveStackRoot (whole-stack source projection)', () => {
+        // The canonical vessel document: an edge-zone ROOT (window chrome) whose center zone
+        // holds the stack — so the transferable whole is the root's center child, never the root.
+        const vessel = () => ({
+            schema: 'neo.harness.dockZone.v1',
+            root  : 'popup-root',
+            items : {
+                drill : {componentRef: 'drill',  title: 'Drill',  kind: 'panel'},
+                stream: {componentRef: 'stream', title: 'Stream', kind: 'panel'}
+            },
+            nodes : {
+                'popup-root': {type: 'edge-zone', zones: {center: 'popup-tabs'}},
+                'popup-tabs': {type: 'tabs', items: ['drill', 'stream'], activeItemId: 'drill'}
+            }
+        });
+
+        test('resolves the canonical vessel shape: the root edge-zone\'s center child IS the stack', () => {
+            expect(DockZoneModel.resolveStackRoot(vessel())).toBe('popup-tabs');
+
+            // the shared main-document fixture resolves too — the rule is the document shape,
+            // not a vessel special case
+            expect(DockZoneModel.resolveStackRoot(doc())).toBe('main-tabs')
+        });
+
+        test('fails closed on every unprovable shape', () => {
+            expect(DockZoneModel.resolveStackRoot(null)).toBeNull();
+            expect(DockZoneModel.resolveStackRoot({})).toBeNull();
+
+            const missingRoot = vessel();
+            delete missingRoot.nodes['popup-root'];
+            expect(DockZoneModel.resolveStackRoot(missingRoot)).toBeNull();
+
+            // a degenerate workspace whose root IS a tabs node has no projectable stack
+            expect(DockZoneModel.resolveStackRoot({
+                schema: 'neo.harness.dockZone.v1',
+                root  : 'only-tabs',
+                items : {},
+                nodes : {'only-tabs': {type: 'tabs', items: [], activeItemId: null}}
+            })).toBeNull();
+
+            const noCenter = vessel();
+            delete noCenter.nodes['popup-root'].zones.center;
+            expect(DockZoneModel.resolveStackRoot(noCenter)).toBeNull();
+
+            const ghostCenter = vessel();
+            ghostCenter.nodes['popup-root'].zones.center = 'ghost';
+            expect(DockZoneModel.resolveStackRoot(ghostCenter)).toBeNull()
+        });
+
+        test('COMPOSES with transferNode: the resolved stack transfers whole and atomically — while the root door stays shut', () => {
+            // the negative control first: the DOCUMENT ROOT still rejects — explicit resolution
+            // is the only path to a whole-stack transfer
+            const rejected = DockZoneModel.transferNode(vessel(), doc(), {
+                nodeId           : 'popup-root',
+                sourceWorkspaceId: 'popup-1',
+                targetWorkspaceId: 'main',
+                target           : {targetNodeId: 'main-tabs', placement: {orientation: 'horizontal', edge: 'right'}}
+            });
+
+            expect(rejected.errors.join(' ')).toContain('cannot transfer the root node');
+
+            // the resolved stack: ONE atomic two-document transfer through the landed executor
+            const
+                source    = vessel(),
+                stackRoot = DockZoneModel.resolveStackRoot(source);
+
+            const {sourceDocument, targetDocument, errors} = DockZoneModel.transferNode(source, doc(), {
+                nodeId           : stackRoot,
+                sourceWorkspaceId: 'popup-1',
+                targetWorkspaceId: 'main',
+                target           : {targetNodeId: 'main-tabs', placement: {orientation: 'horizontal', edge: 'right'}}
+            });
+
+            expect(errors).toEqual([]);
+
+            // target: the stack node arrived INTACT — same node id, same member order, same active item
+            expect(targetDocument.nodes['popup-tabs']).toEqual({type: 'tabs', items: ['drill', 'stream'], activeItemId: 'drill'});
+            expect(targetDocument.items.drill).toBeTruthy();
+            expect(targetDocument.items.stream).toBeTruthy();
+
+            // source: emptied but VALID — the vessel document survives its stack's departure,
+            // which is the precondition for the separate emptied-entry disposition decision
+            expect(sourceDocument.nodes['popup-tabs']).toBeUndefined();
+            expect(sourceDocument.items.drill).toBeUndefined();
+            expect(sourceDocument.items.stream).toBeUndefined();
+            expect(DockZoneModel.validate(sourceDocument)).toEqual([])
+        })
+    });
+
     test.describe('transferItem (atomic two-document transfer)', () => {
         // A second workspace document with a distinct catalog, so a transfer into it never
         // collides on item id with the source doc()'s 'terminal'.


### PR DESCRIPTION
Resolves #15247

Split disposition (recorded on the ticket): the GESTURE half — stack-handle drag, return-drop hints, commit-precedes-close for the whole-stack commit, emptied-entry retirement — moves whole to #15484 with its own contract; a stack return is a pointer gesture, so its commit enters through the host's stable transfer wrapper and the #15250 core extraction changes nothing about its entry point.

Related: #15239 (the epic — this is G4, the final implementation leaf) · ADR-0029 §2.8.2/§2.8.3 (the outcome-machine terminals + vessel lifecycle this implements) · #15246/PR #15465 (G3, merged — the workspace-set + claims substrate) · #15251/PR #15456 (the cockpit consumption whose pre-G4 disposition this deliberately SUPERSEDES) · #15250 (Vega's keyboard leg — the shared adoption core this PR's final tranche binds to).

**G4's delivered half: exact-position return + the vessel close policy — the item comes HOME.**

## OQ5a — resolved in-leaf (AC2's design record)

**Stack-root RESOLUTION, not root-rejection lift.** The canonical vessel document is an `edge-zone` ROOT (window chrome) whose center zone holds the stack — so the whole popup stack is NOT the document root, and `DockZoneModel.transferNode` on the root's center child is already legal and already atomic. What G4 adds at the model tier is `resolveStackRoot(document)`: a pure resolver (edge-zone root → center child; every unprovable shape → null, fail closed) — `transferNode`'s root rejection stays byte-identical, witnessed as the negative control. **Consequence: no `dockLayout.v2` schema field is added; the epic's `revalidationTrigger` is not armed.** The composition witness runs the whole-stack transfer end-to-end at the model tier and yields the load-bearing datum that the emptied vessel document VALIDATES CLEAN — the emptied-entry disposition needs no normalization step.

## What lands in this draft (four commits, all witnessed)

1. **`DockZoneModel.resolveStackRoot`** — the whole-stack source projection (3 witnesses incl. the root-door negative control and the intact-stack atomic transfer).
2. **`DockZoneModel.captureItemPlacement`** — the stored half of exact-position return: `{tabsNodeId, index} | null`, fail-closed on the subtle case (catalog presence is NOT placement). The round-trip witness proves capture → detach → `addTab` with the stored pair restores the ORIGINAL order, with the no-index append control proving the default alone cannot deliver the AC. (`addTab` already accepted a clamped `index` — the ticket's append premise is about the default; only capture was missing.)
3. **Demo-B bring-home** — capture rides the commit seam (`applyTearOutOperation`: readable only pre-detach; a refused commit deletes its own capture), and `reintegrateTearOutItem` delivers the close policy on vessel death: home at the stored pair, SEMANTIC fallback to the first surviving tabs node (the `reattachPane` precedent — never geometry), exact-once, idempotent against duplicate disconnects and foreign re-trees (4 witnesses; the middle-slot discriminator makes append-shapes betray themselves).
4. **Cockpit bring-home, SAME-INSTANCE** — the flagship upgrade: a window disconnect never destroys the popup's view tree, so the captured pane survives LIVE and returns through the one-refresh `returningTearOutPanes` handoff slot, consumed by the resolver BEFORE the torn stand-in guard (the `detachedDetailPane` re-adoption precedent generalized — the resolver already returned live instances for the click path). Destruction remains only the no-home fallback terminal. This SUPERSEDES the pre-G4 detach+destroy disposition exactly as PR #15456's body deferred ("bringing the item HOME on vessel close is G4's contract"): the witness contract flips from destroyed-plus-successor to same-instance-home (`getReference('activity-stream') === streamPane` after vessel death), with exact-stored-position and no-home-terminal witnesses alongside (10/10).

## AC ledger (post-split; disposition on the ticket)

- AC1 — the atomic whole-stack transfer is witnessed at the MODEL tier (one `transferNode` transaction, commit-or-neither, stack intact); the drag AFFORDANCE is #15484's contract.
- AC2 OQ5a design — ✓ this body + `resolveStackRoot` (no schema field; `revalidationTrigger` not armed; root rejection byte-identical).
- AC3 exact-position return — ✓ model round-trip + both hosts (stored pair, semantic fallback, append-control witnessed).
- AC4 — ✓ the disconnect side on both hosts (idempotent, ownership always settled, same-instance on the cockpit); the whole-stack commit-precedes-close side is #15484's.
- AC5 emptied-entry disposition — DECIDED here (retire explicitly; the registry ships retirement-explicit-only, and the composition witness proves the emptied vessel document validates clean); the executing path is #15484's.
- AC6 return-drop hints — #15484's (rides the landed preview pipeline with the gesture).

## Deltas from ticket

- OQ5a resolves as source-side resolution over the landed executor — no new operation, no schema field, `revalidationTrigger` not armed (any future hint-field addition ships migration + fail-closed tests per the ticket's Contract Ledger row).
- The cockpit's disposition change is the DESIGNED SUCCESSION from PR #15456's recorded pre-G4 contract, not a reversal — stated there, delivered here.
- The gesture half's split to #15484 is the epic's established contract-tier boundary (substrate ships witnessed; the consuming affordance follows), recorded on the ticket with assignee authority.

## Test Evidence

Evidence: model `DockZoneModel` **118/118** (6 new) · Demo-B **23/23** (4 new) · cockpit tear-out **10/10** (contract rewritten) · full `unit/apps/agentos` + `unit/dashboard` + `unit/manager` + `unit/draggable` **914/914** at `6e0cf5cac0`.

## Post-Merge Validation

- [ ] The ≥3-popup headed journey composes on the demo host's e2e harness (Ada's queued G3/G4 e2e legs).
- [ ] #15250's keyboard transfer cycle and this PR's stack return ride the one shared adoption core.

## Commits

`000a1ed2d4` — resolveStackRoot (the OQ5a design as code).
`1873a96a37` — captureItemPlacement (the stored half, round-trip witnessed).
`cfcf5bb731` — Demo-B vessel-death bring-home (exact position, semantic fallback).
`6e0cf5cac0` — cockpit same-instance bring-home (the returning-slot re-adoption).

Authored by Clio (Claude Fable 5, Claude Code). Session 0c8fc4d9-2456-44fd-b120-048402bb9839.
