### PR TITLE
feat(fleet): add source-owned catch-up view (#14620)

### DIFF
--- a/ai/services/fleet/FleetControlBridge.mjs
+++ b/ai/services/fleet/FleetControlBridge.mjs
@@ -99,6 +99,14 @@ class FleetControlBridge extends Base {
      */
     activitySource = null
     /**
+     * Viewer-bound catch-up source — an injected collaborator exposing the independent
+     * `readHistory(params)` and runtime-only `markCaughtUp(params)` capabilities. The source resolves
+     * the viewer from authenticated request context at each call; this bridge carries no viewer field
+     * and owns neither history synthesis nor temporal state.
+     * @member {Object|null} historySource=null
+     */
+    historySource = null
+    /**
      * Per-agent mailbox-mirror **read-observe** source — an injected collaborator exposing
      * `readMailboxMirror({subjectAgentId, limit, offset})` that returns the S1 mirror snapshot
      * (`{capability, admission, rows, page}`). Same DI contract as {@link #activitySource}: the
@@ -398,6 +406,39 @@ class FleetControlBridge extends Base {
                 capability: createNotWiredCapability(FLEET_COCKPIT_SOURCES.activity, 'fleet activity source not wired'),
                 events    : []
             };
+    }
+
+    /**
+     * @summary READ-OBSERVE: invoke Memory + resolved-PR Bird Views for one viewer-bound catch-up
+     * window. The source envelopes pass through under separate slots; an unwired entry is named as
+     * unavailable rather than fabricated empty history.
+     * @param {Object} [params]
+     * @returns {Promise<Object>|Object}
+     */
+    fleetHistory(params = {}) {
+        return typeof this.historySource?.readHistory === 'function'
+            ? this.historySource.readHistory(params)
+            : {
+                capability         : {state: 'unavailable', reason: 'fleet history source not wired'},
+                needsFirstUseWindow: false,
+                partition          : params.partition || 'unified',
+                viewerState        : {lastSeen: null, lastVisitAt: null},
+                window             : null,
+                sources            : null
+            };
+    }
+
+    /**
+     * @summary RUNTIME-WRITE: explicitly advance the authenticated viewer's process-lifetime
+     * catch-up anchor through the exact latest rendered window end. This is not a graph/browser
+     * write and carries no caller-supplied identity.
+     * @param {Object} params `{windowEnd}`
+     * @returns {Promise<Object>|Object}
+     */
+    markFleetCaughtUp(params = {}) {
+        return typeof this.historySource?.markCaughtUp === 'function'
+            ? this.historySource.markCaughtUp(params)
+            : {status: 'not-wired', reason: 'fleet history source not wired'};
     }
 
     /**

--- a/ai/services/fleet/devFleetServer.mjs
+++ b/ai/services/fleet/devFleetServer.mjs
@@ -47,6 +47,7 @@ import {probeExistingFleetServer, resolveFleetBearer, resolveFleetViewer} from '
 import {readActiveWakeSubscriptionIdentities}                             from './readActiveWakeSubscriptionIdentities.mjs';
 import {wireBootIdentityReadSource}                                       from './wireBootIdentityReadSource.mjs';
 import {wireFleetActivityReadSource}                                      from './wireFleetActivityReadSource.mjs';
+import {wireFleetCatchUpSource}                                           from './wireFleetCatchUpSource.mjs';
 import {wireOperatorComposeWriter}                                        from './wireOperatorComposeWriter.mjs';
 import path                                                               from 'node:path';
 import {fileURLToPath, pathToFileURL}                                     from 'node:url';
@@ -119,6 +120,23 @@ async function boot() {
     FleetControlBridge.viewerIdentitySource = {
         resolveViewerIdentity: () => RequestContextService.getAgentIdentityNodeId()
     };
+
+    // The S3 catch-up source stays behind the authenticated ingress. Its two calls reuse the exact
+    // Memory Core registered operations (schema validation, source ownership, recorder, and
+    // notAuthority envelopes included) through a lazy import; no MCP code crosses into the Body.
+    // The closure holds zero result cache. The source instance holds only per-viewer runtime anchors,
+    // so a cockpit reload preserves them while this process lives and a service restart resets them.
+    const callHistoryOperation = async (name, args) => {
+        const {callTool} = await import('../../mcp/server/memory-core/toolService.mjs');
+
+        return callTool(name, args)
+    };
+
+    wireFleetCatchUpSource({
+        exploreMemoryHistory     : args => callHistoryOperation('explore_memory_history', args),
+        explorePullRequestHistory: args => callHistoryOperation('explore_pull_request_history', args),
+        resolveViewerIdentity    : () => RequestContextService.getAgentIdentityNodeId()
+    });
 
     FleetControlBridge.mailboxMirrorSource = {
         async readMailboxMirror(params = {}) {

--- a/ai/services/fleet/fleetCatchUpSource.mjs
+++ b/ai/services/fleet/fleetCatchUpSource.mjs
@@ -1,0 +1,264 @@
+/**
+ * @module ai/services/fleet/fleetCatchUpSource
+ * @summary Brain-side, viewer-bound source for the Fleet cockpit's invoked catch-up view. It owns
+ * only the process-lifetime `{lastSeen,lastVisitAt}` anchor and invokes the two source-owned history
+ * operations independently; their `notAuthority` envelopes pass through unchanged. There is no
+ * Fleet synthesis, ranking, digest, graph/browser write, or result cache on this path.
+ */
+
+const FIRST_USE_PRESET_MS = Object.freeze({
+    daily  : 24 * 60 * 60 * 1000,
+    '3-day': 3 * 24 * 60 * 60 * 1000,
+    weekly : 7 * 24 * 60 * 60 * 1000
+});
+
+/**
+ * @summary Coerce one supported time value to finite epoch milliseconds.
+ * @param {Date|String|Number} value
+ * @param {String} name
+ * @returns {Number}
+ * @private
+ */
+function toMs(value, name) {
+    const ms = value instanceof Date ? value.getTime() : typeof value === 'number' ? value : Date.parse(value);
+
+    if (!Number.isFinite(ms)) {
+        throw new TypeError(`fleet catch-up: ${name} must be a finite timestamp`)
+    }
+
+    return ms
+}
+
+/**
+ * @summary Resolve one explicit half-open window and reject reversed or future bounds.
+ * @param {Object} options
+ * @returns {{windowStart: String, windowEnd: String}}
+ * @private
+ */
+function validateWindow({windowStart, windowEnd, nowMs}) {
+    const startMs = toMs(windowStart, 'windowStart'),
+          endMs   = toMs(windowEnd,   'windowEnd');
+
+    if (startMs >= endMs) {
+        throw new RangeError('fleet catch-up: windowStart must be before windowEnd')
+    }
+
+    if (endMs > nowMs) {
+        throw new RangeError('fleet catch-up: windowEnd cannot be in the future')
+    }
+
+    return {windowStart: new Date(startMs).toISOString(), windowEnd: new Date(endMs).toISOString()}
+}
+
+/**
+ * @summary Resolve the Memory partition. Fleet is the default; an agent drill must be canonical
+ * `@<identity>`. The PR operation never receives this partition.
+ * @param {String} partition
+ * @returns {String}
+ * @private
+ */
+function validatePartition(partition='unified') {
+    if (partition === 'unified' || /^@[A-Za-z0-9][A-Za-z0-9._-]*$/.test(partition)) {
+        return partition
+    }
+
+    throw new TypeError('fleet catch-up: partition must be "unified" or a canonical @identity')
+}
+
+/**
+ * @summary Turn one source operation settlement into a typed source slot while preserving every
+ * byte of a recognized Bird View envelope under `envelope`.
+ * @param {String} source
+ * @param {PromiseSettledResult} settlement
+ * @returns {Object}
+ * @private
+ */
+function projectSource(source, settlement) {
+    const envelope = settlement.status === 'fulfilled' ? settlement.value : null;
+
+    if (!envelope || typeof envelope !== 'object' || envelope.notAuthority !== true) {
+        return {
+            source,
+            state            : 'unavailable',
+            unavailableReason: `${source}-history-unavailable`,
+            envelope         : null
+        }
+    }
+
+    return {
+        source,
+        state            : envelope.coverage?.degraded === true ? 'degraded' : 'available',
+        unavailableReason: null,
+        envelope
+    }
+}
+
+/**
+ * @summary Create the process-lifetime Fleet catch-up source.
+ *
+ * The transport-stamped viewer is resolved at EACH call and is the only state key. Caller-carried
+ * identity fields are ignored by construction. `readHistory` keeps the two source calls independent;
+ * `markCaughtUp` is a separate runtime-only write capability and can advance only through the exact
+ * latest rendered `windowEnd` for that viewer.
+ *
+ * @param {Object} options
+ * @param {Function} options.exploreMemoryHistory Injected `explore_memory_history` operation.
+ * @param {Function} options.explorePullRequestHistory Injected `explore_pull_request_history` operation.
+ * @param {Function} options.resolveViewerIdentity Returns the transport-stamped canonical @identity.
+ * @param {Function} [options.now] Clock returning a Date/epoch/ISO value.
+ * @returns {{readHistory: Function, markCaughtUp: Function}}
+ */
+export function createFleetCatchUpSource({
+    exploreMemoryHistory,
+    explorePullRequestHistory,
+    resolveViewerIdentity,
+    now = () => new Date()
+} = {}) {
+    if (typeof exploreMemoryHistory !== 'function' || typeof explorePullRequestHistory !== 'function' ||
+        typeof resolveViewerIdentity !== 'function' || typeof now !== 'function') {
+        throw new TypeError('createFleetCatchUpSource: both history operations, resolveViewerIdentity, and now are required')
+    }
+
+    // Runtime anchors only. A new source instance (Fleet-service restart) starts empty by design.
+    const viewerState = new Map();
+
+    const resolveViewer = async () => {
+        const viewer = await resolveViewerIdentity();
+
+        if (typeof viewer !== 'string' || !/^@[A-Za-z0-9][A-Za-z0-9._-]*$/.test(viewer)) {
+            throw new Error('fleet catch-up: authenticated ingress did not bind a canonical viewer identity')
+        }
+
+        return viewer
+    };
+
+    const getState = viewer => {
+        let state = viewerState.get(viewer);
+
+        if (!state) {
+            state = {lastSeen: null, lastVisitAt: null, lastRenderedWindowEnd: null, readGeneration: 0};
+            viewerState.set(viewer, state)
+        }
+
+        return state
+    };
+
+    return {
+        /**
+         * @summary Read one Fleet or per-agent catch-up window through both source-owned operations.
+         * @param {Object} [params]
+         * @returns {Promise<Object>}
+         */
+        async readHistory(params = {}) {
+            const viewer     = await resolveViewer(),
+                  state      = getState(viewer),
+                  generation = ++state.readGeneration,
+                  nowMs      = toMs(now(), 'now'),
+                  partition  = validatePartition(params?.partition),
+                  hasStart   = params?.windowStart !== undefined,
+                  hasEnd     = params?.windowEnd !== undefined;
+
+            if (hasStart !== hasEnd) {
+                throw new TypeError('fleet catch-up: windowStart and windowEnd must be supplied together')
+            }
+
+            let requestedWindow;
+
+            if (hasStart) {
+                requestedWindow = validateWindow({windowStart: params.windowStart, windowEnd: params.windowEnd, nowMs})
+            } else if (params?.firstUsePreset !== undefined) {
+                const duration = FIRST_USE_PRESET_MS[params.firstUsePreset];
+
+                if (!duration) {
+                    throw new TypeError('fleet catch-up: firstUsePreset must be daily, 3-day, or weekly')
+                }
+
+                requestedWindow = validateWindow({windowStart: nowMs - duration, windowEnd: nowMs, nowMs})
+            } else {
+                const start = state.lastSeen ?? state.lastVisitAt;
+
+                if (!start) {
+                    return {
+                        capability         : {state: 'wired', capturedAt: new Date(nowMs).toISOString()},
+                        needsFirstUseWindow: true,
+                        partition,
+                        viewerState        : {lastSeen: null, lastVisitAt: null},
+                        window             : null,
+                        sources            : null
+                    }
+                }
+
+                requestedWindow = validateWindow({windowStart: start, windowEnd: nowMs, nowMs})
+            }
+
+            const memoryArgs                         = {...requestedWindow, partition},
+                  pullArgs                           = {...requestedWindow, resolution: 'all_resolved'},
+                  [memorySettlement, pullSettlement] = await Promise.allSettled([
+                      exploreMemoryHistory(memoryArgs),
+                      explorePullRequestHistory(pullArgs)
+                  ]),
+                  memory       = projectSource('memory', memorySettlement),
+                  pullRequests = projectSource('pull-requests', pullSettlement),
+                  slots        = [memory, pullRequests],
+                  allUnavailable = slots.every(slot => slot.state === 'unavailable'),
+                  anyImperfect   = slots.some(slot => slot.state !== 'available');
+
+            // This is visit state, not a read receipt: the rendered window advances the soft fallback;
+            // only the explicit write below advances `lastSeen`.
+            if (generation === state.readGeneration) {
+                state.lastVisitAt           = requestedWindow.windowEnd;
+                state.lastRenderedWindowEnd = requestedWindow.windowEnd
+            }
+
+            return {
+                capability: {
+                    state     : allUnavailable ? 'unavailable' : anyImperfect ? 'degraded' : 'wired',
+                    capturedAt: requestedWindow.windowEnd
+                },
+                needsFirstUseWindow: false,
+                partition,
+                viewerState        : {lastSeen: state.lastSeen, lastVisitAt: state.lastVisitAt},
+                window             : {
+                    ...requestedWindow,
+                    semantics: 'half-open'
+                },
+                sources: {memory, pullRequests}
+            }
+        },
+
+        /**
+         * @summary Advance the viewer's runtime-only lastSeen through the exact latest rendered end.
+         * @param {Object} params
+         * @returns {Promise<Object>}
+         */
+        async markCaughtUp({windowEnd} = {}) {
+            const viewer  = await resolveViewer(),
+                  state   = getState(viewer),
+                  nowMs   = toMs(now(), 'now'),
+                  markMs  = toMs(windowEnd, 'windowEnd'),
+                  markIso = new Date(markMs).toISOString();
+
+            if (!state.lastRenderedWindowEnd || markIso !== state.lastRenderedWindowEnd) {
+                return {status: 'rejected', reason: 'window-not-latest-rendered'}
+            }
+
+            if (markMs > nowMs) {
+                return {status: 'rejected', reason: 'future-window'}
+            }
+
+            if (state.lastSeen && markMs <= Date.parse(state.lastSeen)) {
+                return {status: 'rejected', reason: 'non-monotonic-window'}
+            }
+
+            state.lastSeen = markIso;
+
+            return {
+                status     : 'advanced',
+                lastSeen   : state.lastSeen,
+                lastVisitAt: state.lastVisitAt
+            }
+        }
+    }
+}
+
+export default createFleetCatchUpSource;

--- a/ai/services/fleet/wireFleetCatchUpSource.mjs
+++ b/ai/services/fleet/wireFleetCatchUpSource.mjs
@@ -1,0 +1,45 @@
+import FleetControlBridge         from './FleetControlBridge.mjs';
+import {createFleetCatchUpSource} from './fleetCatchUpSource.mjs';
+
+/**
+ * @module ai/services/fleet/wireFleetCatchUpSource
+ * @summary Installs the viewer-bound catch-up source onto the Fleet control bridge at the
+ * authenticated server entry. The operation functions and viewer resolver are injected at that
+ * use site; this wiring imports neither MCP tool service nor request context.
+ */
+
+/**
+ * @summary Wire one process-lifetime catch-up source.
+ * @param {Object} options
+ * @param {Function} options.exploreMemoryHistory
+ * @param {Function} options.explorePullRequestHistory
+ * @param {Function} options.resolveViewerIdentity
+ * @param {Function} [options.now]
+ * @param {Object} [options.bridge=FleetControlBridge]
+ * @param {Function} [options.createSource=createFleetCatchUpSource]
+ * @returns {Object|null}
+ */
+export function wireFleetCatchUpSource({
+    exploreMemoryHistory,
+    explorePullRequestHistory,
+    resolveViewerIdentity,
+    now,
+    bridge       = FleetControlBridge,
+    createSource = createFleetCatchUpSource
+} = {}) {
+    if (typeof exploreMemoryHistory !== 'function' || typeof explorePullRequestHistory !== 'function' ||
+        typeof resolveViewerIdentity !== 'function') {
+        return null
+    }
+
+    bridge.historySource = createSource({
+        exploreMemoryHistory,
+        explorePullRequestHistory,
+        resolveViewerIdentity,
+        ...(now ? {now} : {})
+    });
+
+    return bridge.historySource
+}
+
+export default wireFleetCatchUpSource;

--- a/apps/agentos/model/CatchUpEntry.mjs
+++ b/apps/agentos/model/CatchUpEntry.mjs
@@ -1,0 +1,47 @@
+import Model from '../../../src/data/Model.mjs';
+
+/**
+ * @class AgentOS.model.CatchUpEntry
+ * @extends Neo.data.Model
+ *
+ * @summary One view-projection record in the invoked Fleet catch-up pane. Source records carry a
+ * source-owned history slot under `payload`; partition records carry a canonical Fleet/agent key.
+ * The model is intentionally thin: it stores projection input and never derives or persists a
+ * second history authority.
+ */
+class CatchUpEntry extends Model {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.model.CatchUpEntry'
+         * @protected
+         */
+        className: 'AgentOS.model.CatchUpEntry',
+        /**
+         * @member {String} keyProperty='id'
+         * @reactive
+         */
+        keyProperty: 'id',
+        /**
+         * @member {Object[]} fields
+         */
+        fields: [{
+            name: 'id',
+            type: 'String'
+        }, {
+            name: 'kind',
+            type: 'String'
+        }, {
+            name: 'label',
+            type: 'String'
+        }, {
+            name: 'partition',
+            type: 'String'
+        }, {
+            name        : 'payload',
+            type        : 'Object',
+            defaultValue: null
+        }]
+    }
+}
+
+export default Neo.setupClass(CatchUpEntry);

--- a/apps/agentos/store/CatchUpEntries.mjs
+++ b/apps/agentos/store/CatchUpEntries.mjs
@@ -1,0 +1,31 @@
+import CatchUpEntryModel from '../model/CatchUpEntry.mjs';
+import Store             from '../../../src/data/Store.mjs';
+
+/**
+ * @class AgentOS.store.CatchUpEntries
+ * @extends Neo.data.Store
+ *
+ * @summary Pane-local projection store for catch-up source slots and partition choices. Each
+ * CatchUpPane owns its stores and destroys them with the pane; Fleet history remains query-time and
+ * no record survives the view/process lifecycle.
+ */
+class CatchUpEntries extends Store {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.store.CatchUpEntries'
+         * @protected
+         */
+        className: 'AgentOS.store.CatchUpEntries',
+        /**
+         * @member {String} keyProperty='id'
+         */
+        keyProperty: 'id',
+        /**
+         * @member {Neo.data.Model} model=CatchUpEntryModel
+         * @reactive
+         */
+        model: CatchUpEntryModel
+    }
+}
+
+export default Neo.setupClass(CatchUpEntries);

--- a/apps/agentos/view/fleet/ActivityStream.mjs
+++ b/apps/agentos/view/fleet/ActivityStream.mjs
@@ -173,7 +173,7 @@ class ActivityStream extends Container {
         // a11y: the live feed is a log region — new rows are announced to assistive tech `polite`ly
         // (never interrupting), with a name. Without this an updating feed is silent to screen
         // readers. Set on the root before the first `refreshFeed` render flushes the vdom.
-        Object.assign(this.vdom, {'aria-live': 'polite', 'aria-label': 'Live fleet activity', role: 'log'});
+        Object.assign(this.vdom, {'aria-live': 'polite', 'aria-label': 'Live fleet activity', role: 'log', tabIndex: 0});
 
         this.refreshFeed()
     }

--- a/apps/agentos/view/fleet/CatchUpPane.mjs
+++ b/apps/agentos/view/fleet/CatchUpPane.mjs
@@ -1,0 +1,449 @@
+import Button         from '../../../../src/button/Base.mjs';
+import Component      from '../../../../src/component/Base.mjs';
+import Container      from '../../../../src/container/Base.mjs';
+import CatchUpEntries from '../../store/CatchUpEntries.mjs';
+
+/**
+ * @summary Resolve a citation to a canonical public drill target. Only the source-owned PR
+ * descriptor (`get_conversation {pr_number}`) or its `pull:N` identity is routable. Session/memory
+ * citations remain visible and copyable until a session-history surface exists; they never navigate
+ * falsely to the bounded live stream.
+ * @param {Object} citation
+ * @returns {String|null}
+ */
+export function resolveCitationTarget(citation) {
+    const fromDescriptor = citation?.drillDown?.operation === 'get_conversation'
+        ? citation.drillDown.arguments?.pr_number
+        : null,
+          fromIdentity = /^pull:(\d+)$/.exec(citation?.id || '')?.[1],
+          number       = Number(fromDescriptor ?? fromIdentity);
+
+    return Number.isSafeInteger(number) && number > 0
+        ? `https://github.com/neomjs/neo/pull/${number}`
+        : null
+}
+
+/**
+ * The invoked S3 Fleet catch-up surface.
+ *
+ * @summary Renders two source-owned `notAuthority` Bird View envelopes without synthesizing,
+ * ranking, merging, or caching them. The pane owns only local projection Stores: one record per
+ * source slot and one record per fleet/agent partition choice. It fires intent events for reads and
+ * explicit mark-caught-up writes; the owning FleetCockpit holds the authenticated bridge.
+ *
+ * Honest states are first-class: first-use window choice, per-source unavailable/degraded/empty,
+ * coverage counts and reasons, synthesis availability, manifest hash, generated timestamp, and
+ * bounded citations all render explicitly. The source order and citation order are preserved.
+ *
+ * @class AgentOS.view.fleet.CatchUpPane
+ * @extends Neo.container.Base
+ */
+class CatchUpPane extends Container {
+    static config = {
+        /**
+         * @member {String} className='AgentOS.view.fleet.CatchUpPane'
+         * @protected
+         */
+        className: 'AgentOS.view.fleet.CatchUpPane',
+        /**
+         * @member {String} ntype='fm-catch-up-pane'
+         * @protected
+         */
+        ntype: 'fm-catch-up-pane',
+        /**
+         * @member {String[]} baseCls=['fm-catch-up-pane']
+         */
+        baseCls: ['fm-catch-up-pane'],
+        /**
+         * Active Memory partition. PR history stays Fleet-wide.
+         * @member {String} activePartition_='unified'
+         * @reactive
+         */
+        activePartition_: 'unified',
+        /**
+         * Maximum citations rendered per source before an honest overflow count.
+         * @member {Number} citationLimit=20
+         */
+        citationLimit: 20,
+        /**
+         * Fleet/agent choices supplied by the cockpit from its provider-owned roster.
+         * @member {Object[]} partitionOptions_=[]
+         * @reactive
+         */
+        partitionOptions_: [],
+        /**
+         * Latest Fleet history response. `null` is unobserved, never empty.
+         * @member {Object|null} snapshot_=null
+         * @reactive
+         */
+        snapshot_: null,
+        /**
+         * Explicit mark result written back by the owner.
+         * @member {Object|null} markOutcome_=null
+         * @reactive
+         */
+        markOutcome_: null,
+        /**
+         * @member {Object} layout={ntype:'vbox',align:'stretch'}
+         * @reactive
+         */
+        layout: {ntype: 'vbox', align: 'stretch'},
+        /**
+         * @member {Object[]} items
+         */
+        items: [{
+            ntype : 'container',
+            cls   : ['fm-catch-up-head'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{
+                ntype: 'component',
+                cls  : ['fm-catch-up-title'],
+                flex : 1,
+                text : 'Since you last looked'
+            }, {
+                ntype: 'component',
+                cls  : ['fm-catch-up-authority'],
+                text : 'query-time · not authority'
+            }]
+        }, {
+            ntype    : 'component',
+            cls      : ['fm-catch-up-window'],
+            flex     : 'none',
+            reference: 'catch-up-window',
+            text     : 'History not observed yet'
+        }, {
+            ntype    : 'container',
+            cls      : ['fm-catch-up-partitions'],
+            flex     : 'none',
+            layout   : {ntype: 'hbox', align: 'center'},
+            reference: 'catch-up-partitions'
+        }, {
+            ntype    : 'container',
+            cls      : ['fm-catch-up-first-use'],
+            flex     : 'none',
+            hidden   : true,
+            layout   : {ntype: 'hbox', align: 'center'},
+            reference: 'catch-up-first-use',
+            items    : [{
+                ntype: 'component',
+                flex : 1,
+                text : 'Choose the first window'
+            }, {
+                module : Button,
+                text   : '24h',
+                ui     : 'ghost',
+                handler: 'up.onDailyClick'
+            }, {
+                module : Button,
+                text   : '3 days',
+                ui     : 'ghost',
+                handler: 'up.onThreeDayClick'
+            }, {
+                module : Button,
+                text   : 'Week',
+                ui     : 'ghost',
+                handler: 'up.onWeeklyClick'
+            }]
+        }, {
+            ntype : 'container',
+            cls   : ['fm-catch-up-actions'],
+            flex  : 'none',
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{
+                module : Button,
+                text   : 'Live activity',
+                iconCls: 'fa fa-bolt',
+                ui     : 'ghost',
+                handler: 'up.onLiveActivityClick'
+            }, {
+                ntype: 'component',
+                flex : 1
+            }, {
+                module   : Button,
+                reference: 'catch-up-refresh',
+                text     : 'Refresh',
+                iconCls  : 'fa fa-rotate',
+                ui       : 'ghost',
+                handler  : 'up.onRefreshClick'
+            }, {
+                module   : Button,
+                reference: 'catch-up-mark',
+                text     : 'Mark caught up',
+                iconCls  : 'fa fa-check',
+                ui       : 'ghost',
+                hidden   : true,
+                handler  : 'up.onMarkClick'
+            }]
+        }, {
+            ntype    : 'component',
+            cls      : ['fm-catch-up-mark-outcome'],
+            flex     : 'none',
+            reference: 'catch-up-mark-outcome'
+        }, {
+            ntype    : 'container',
+            cls      : ['fm-catch-up-sources'],
+            flex     : 1,
+            layout   : {ntype: 'vbox', align: 'stretch'},
+            reference: 'catch-up-sources'
+        }]
+    }
+
+    /** @member {AgentOS.store.CatchUpEntries|null} contentStore=null */
+    contentStore = null
+    /** @member {AgentOS.store.CatchUpEntries|null} partitionStore=null */
+    partitionStore = null
+
+    /**
+     * @summary Create the two pane-local Stores, render held owner state, then request history. An
+     * auto-hidden pane is constructed only when revealed, so this is invoked-not-ambient by layout.
+     * @param {...*} args
+     */
+    onConstructed(...args) {
+        super.onConstructed(...args);
+
+        this.contentStore   = Neo.create(CatchUpEntries);
+        this.partitionStore = Neo.create(CatchUpEntries);
+        this.refreshPartitions();
+        this.applySnapshot();
+        this.fire('historyRequest', {partition: this.activePartition})
+    }
+
+    /** @param {...*} args */
+    destroy(...args) {
+        this.contentStore?.destroy();
+        this.partitionStore?.destroy();
+        this.contentStore = this.partitionStore = null;
+        super.destroy(...args)
+    }
+
+    /** @param {String} value @param {String} oldValue @returns {String} */
+    beforeSetActivePartition(value, oldValue) {
+        return value === 'unified' || /^@[A-Za-z0-9][A-Za-z0-9._-]*$/.test(value) ? value : (oldValue || 'unified')
+    }
+
+    /** @param {String} value @param {String} oldValue */
+    afterSetActivePartition(value, oldValue) {
+        this.isConstructed && this.refreshPartitions()
+    }
+
+    /** @param {Object[]} value @param {Object[]} oldValue */
+    afterSetPartitionOptions(value, oldValue) {
+        this.isConstructed && this.refreshPartitions()
+    }
+
+    /** @param {Object|null} value @param {Object|null} oldValue */
+    afterSetSnapshot(value, oldValue) {
+        this.isConstructed && this.applySnapshot()
+    }
+
+    /** @param {Object|null} value @param {Object|null} oldValue */
+    afterSetMarkOutcome(value, oldValue) {
+        if (!this.isConstructed) return;
+
+        const target = this.getReference('catch-up-mark-outcome');
+
+        target.text = value?.status === 'advanced'
+            ? `Caught up through ${this.formatStamp(value.lastSeen)}`
+            : value?.reason ? `Mark refused · ${value.reason}` : ''
+    }
+
+    /** @summary Request a daily first-use window. */
+    onDailyClick() { this.requestFirstUse('daily') }
+    /** @summary Request a three-day first-use window. */
+    onThreeDayClick() { this.requestFirstUse('3-day') }
+    /** @summary Request a weekly first-use window. */
+    onWeeklyClick() { this.requestFirstUse('weekly') }
+
+    /** @param {String} firstUsePreset */
+    requestFirstUse(firstUsePreset) {
+        this.fire('historyRequest', {firstUsePreset, partition: this.activePartition})
+    }
+
+    /** @summary Re-read from the source-owned viewer anchor. */
+    onRefreshClick() {
+        this.fire('historyRequest', {partition: this.activePartition})
+    }
+
+    /** @summary Explicitly advance through the exact rendered window end. */
+    onMarkClick() {
+        const windowEnd = this.snapshot?.window?.windowEnd;
+
+        windowEnd && this.fire('markCaughtUpRequest', {windowEnd})
+    }
+
+    /** @summary Open the existing bounded live adjacency, never reinterpret it as history. */
+    onLiveActivityClick() {
+        this.fire('liveSurfaceRequest', {target: 'activity-stream'})
+    }
+
+    /** @param {String} partition */
+    onPartitionClick(partition) {
+        if (partition === this.activePartition) return;
+
+        this.activePartition = partition;
+        this.fire('historyRequest', {partition})
+    }
+
+    /**
+     * @summary Populate the partition Store and rebuild semantic Buttons in source order.
+     */
+    refreshPartitions() {
+        if (!this.partitionStore) return;
+
+        const options = [{id: 'unified', label: 'Whole fleet', partition: 'unified'}, ...(this.partitionOptions || [])]
+            .filter((option, index, all) => option?.partition && all.findIndex(item => item.partition === option.partition) === index);
+
+        this.partitionStore.clear();
+        this.partitionStore.add(options.map(option => ({...option, kind: 'partition'})));
+
+        const target = this.getReference('catch-up-partitions');
+
+        target?.removeAll(true);
+        target?.add(this.partitionStore.items.map(record => ({
+            module : Button,
+            cls    : record.partition === this.activePartition ? ['fm-catch-up-partition', 'is-active'] : ['fm-catch-up-partition'],
+            text   : record.label || record.partition,
+            ui     : 'ghost',
+            handler: () => this.onPartitionClick(record.partition)
+        })))
+    }
+
+    /**
+     * @summary Project the latest response into source records and honest chrome.
+     */
+    applySnapshot() {
+        const snapshot = this.snapshot,
+              firstUse = snapshot?.needsFirstUseWindow === true,
+              window   = snapshot?.window,
+              windowEl = this.getReference('catch-up-window'),
+              firstEl  = this.getReference('catch-up-first-use'),
+              markEl   = this.getReference('catch-up-mark');
+
+        if (windowEl) {
+            windowEl.text = window
+                ? `${this.formatStamp(window.windowStart)} → ${this.formatStamp(window.windowEnd)} · ${snapshot.partition === 'unified' ? 'whole fleet' : snapshot.partition}`
+                : firstUse ? 'No runtime anchor yet' : 'History not observed yet'
+        }
+
+        firstEl && (firstEl.hidden = !firstUse);
+        markEl  && (markEl.hidden  = !window);
+
+        if (!this.contentStore) return;
+
+        this.contentStore.clear();
+
+        if (snapshot?.sources) {
+            this.contentStore.add([
+                {id: 'memory', kind: 'source', label: snapshot.partition === 'unified' ? 'Memory · fleet' : `Memory · ${snapshot.partition}`, payload: snapshot.sources.memory},
+                {id: 'pull-requests', kind: 'source', label: 'Resolved pull requests · fleet', payload: snapshot.sources.pullRequests}
+            ])
+        }
+
+        const target = this.getReference('catch-up-sources');
+
+        target?.removeAll(true);
+
+        if (firstUse) {
+            target?.add({module: Component, cls: ['fm-catch-up-empty'], text: 'Choose 24 hours, 3 days, or one week. No history window is invented.'})
+        } else if (!snapshot?.sources) {
+            target?.add({module: Component, cls: ['fm-catch-up-empty'], text: 'Catch-up source unavailable.'})
+        } else {
+            target?.add(this.contentStore.items.map(record => this.sourceCardConfig(record)))
+        }
+    }
+
+    /**
+     * @summary Build one source card from a Store record. The source envelope is rendered, never
+     * rewritten; only display labels and citation bounds are pane-owned.
+     * @param {Neo.data.Model} record
+     * @returns {Object}
+     */
+    sourceCardConfig(record) {
+        const slot      = record.payload || {},
+              envelope  = slot.envelope,
+              coverage  = envelope?.coverage || {},
+              citations = Array.isArray(envelope?.citations) ? envelope.citations : [],
+              visible   = citations.slice(0, this.citationLimit),
+              overflow  = Math.max(0, citations.length - visible.length),
+              sourceCls = `is-${slot.state || 'unavailable'}`;
+
+        let body;
+
+        if (slot.state === 'unavailable' || !envelope) {
+            body = slot.unavailableReason || 'source unavailable'
+        } else if (coverage.totalResolved === 0) {
+            body = 'No source records in this window.'
+        } else if (envelope.synthesisAvailable) {
+            body = envelope.synthesis
+        } else {
+            body = `Synthesis unavailable · ${envelope.synthesisUnavailableReason || coverage.degradedReason || 'no narrative'}`
+        }
+
+        const items = [{
+            module: Container,
+            cls   : ['fm-catch-up-source-head'],
+            layout: {ntype: 'hbox', align: 'center'},
+            items : [{module: Component, flex: 1, cls: ['fm-catch-up-source-title'], text: record.label},
+                {module: Component, cls: ['fm-catch-up-source-state'], text: slot.state || 'unavailable'}]
+        }, {
+            module: Component,
+            cls   : ['fm-catch-up-source-meta'],
+            text  : envelope
+                ? `${envelope.notAuthority === true ? 'not authority' : 'authority unproven'} · generated ${this.formatStamp(envelope.generatedAt)} · coverage ${coverage.included ?? 0}/${coverage.totalResolved ?? '?'} · manifest ${envelope.sourceManifestHash || 'unavailable'}`
+                : 'No source envelope returned'
+        }, {
+            module: Component,
+            cls   : ['fm-catch-up-source-body'],
+            text  : body
+        }];
+
+        if (coverage.degradedReason) {
+            items.push({module: Component, cls: ['fm-catch-up-source-reason'], text: `Coverage degraded · ${coverage.degradedReason}`})
+        }
+
+        if (visible.length) {
+            items.push({
+                module: Container,
+                cls   : ['fm-catch-up-citations'],
+                layout: {ntype: 'vbox', align: 'stretch'},
+                items : visible.map(citation => this.citationConfig(citation))
+            })
+        }
+
+        if (overflow) {
+            items.push({module: Component, cls: ['fm-catch-up-citation-overflow'], text: `${overflow} more citations in the source manifest`})
+        }
+
+        return {module: Container, cls: ['fm-catch-up-source', sourceCls], flex: 'none', layout: {ntype: 'vbox', align: 'stretch'}, items}
+    }
+
+    /**
+     * @summary Build a canonical PR link or a visible non-navigating citation label.
+     * @param {Object} citation
+     * @returns {Object}
+     */
+    citationConfig(citation) {
+        const target = resolveCitationTarget(citation),
+              label  = `${citation?.type || 'source'} · ${citation?.id || 'unknown'}${citation?.inSynthesis === false ? ' · census only' : ''}`;
+
+        return target ? {
+            module: Component,
+            cls   : ['fm-catch-up-citation', 'is-link'],
+            vdom  : {tag: 'a', href: target, target: '_blank', rel: 'noopener noreferrer', text: label}
+        } : {
+            module: Component,
+            cls   : ['fm-catch-up-citation'],
+            text  : label
+        }
+    }
+
+    /** @param {Date|String|Number|null} value @returns {String} */
+    formatStamp(value) {
+        const date = new Date(value);
+
+        return Number.isFinite(date.getTime()) ? date.toISOString().replace('T', ' ').slice(0, 16) + 'Z' : 'unknown time'
+    }
+}
+
+export default Neo.setupClass(CatchUpPane);

--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -2,6 +2,7 @@ import ActivityStream                                               from './Acti
 import AddAgentForm                                                 from './AddAgentForm.mjs';
 import AgentDetail                                                  from './AgentDetail.mjs';
 import Button                                                       from '../../../../src/button/Base.mjs';
+import CatchUpPane                                                  from './CatchUpPane.mjs';
 import Component                                                    from '../../../../src/component/Base.mjs';
 import Container                                                    from '../../../../src/container/Base.mjs';
 import DockLayoutAdapter                                            from '../../../../src/dashboard/DockLayoutAdapter.mjs';
@@ -445,6 +446,21 @@ class FleetCockpit extends Container {
      * @protected
      */
     operatorInboxReadGeneration = 0
+    /**
+     * Latest catch-up response, owner-held so rail re-projection rematerializes from current truth.
+     * @member {Object|null} catchUpSnapshot=null
+     */
+    catchUpSnapshot = null
+    /**
+     * Latest explicit mark outcome returned by the runtime-only Brain seam.
+     * @member {Object|null} catchUpMarkOutcome=null
+     */
+    catchUpMarkOutcome = null
+    /**
+     * Monotonic fence: an older source response never overwrites a newer partition/window request.
+     * @member {Number} catchUpReadGeneration=0
+     */
+    catchUpReadGeneration = 0
     /**
      * Detached-detail bookkeeping — `null` while the inspector is docked. While detached it holds
      * `{homeTabsNodeId, homeTabIndex, windowId, windowName, connectTimer}`: the tabs node + EXACT
@@ -1295,6 +1311,23 @@ class FleetCockpit extends Container {
                     recipientOptions: me.buildOperatorRecipientOptions(),
                     listeners       : {compose: 'onOperatorCompose', inboxPageRequest: 'onOperatorInboxPageRequest'},
                     reference       : 'operator-mailbox'
+                };
+            case 'catch-up':
+                // S3 invoked history: the pane renders owner-held source envelopes and fires intent;
+                // this cockpit owns the authenticated bridge. Partition choices derive from the same
+                // provider-owned roster as the cards — no second resident list.
+                return {
+                    module          : CatchUpPane,
+                    cls             : [marker],
+                    snapshot        : me.catchUpSnapshot,
+                    markOutcome     : me.catchUpMarkOutcome,
+                    partitionOptions: me.buildCatchUpPartitionOptions(),
+                    listeners       : {
+                        historyRequest     : 'onCatchUpHistoryRequest',
+                        markCaughtUpRequest: 'onCatchUpMarkRequest',
+                        liveSurfaceRequest : 'onCatchUpLiveSurfaceRequest'
+                    },
+                    reference: 'catch-up'
                 };
             default:
                 // perspectives arrives with its own leaf — an honest labelled placeholder, never a
@@ -2151,6 +2184,7 @@ class FleetCockpit extends Container {
 
             me.gridAdapterState = 'live';
             grid.adapterState   = 'live';
+            me.getReference('catch-up')?.set({partitionOptions: me.buildCatchUpPartitionOptions()});
             me.clearDegradedReason('grid')
         } catch (error) {
             // fenced: a slow failure must not overwrite a newer success (see the stream twin)
@@ -2184,6 +2218,113 @@ class FleetCockpit extends Container {
                 .filter(row => row.githubUsername)
                 .map(row => ({id: `@${row.githubUsername}`, name: row.githubUsername}))
         ]
+    }
+
+    /**
+     * @summary Build canonical Fleet/agent Memory partitions from the live roster Store. PR history
+     * remains Fleet-wide; these choices alter only the Memory operation in the Brain adapter.
+     * @returns {Object[]}
+     */
+    buildCatchUpPartitionOptions() {
+        const rows = this.getReference('fleet-grid')?.store?.items ?? [];
+
+        return rows
+            .filter(row => row.githubUsername)
+            .map(row => ({
+                id       : `catch-up-${row.agentId}`,
+                label    : row.displayName || row.githubUsername,
+                partition: `@${row.githubUsername}`
+            }))
+    }
+
+    /**
+     * @summary READ-OBSERVE: route one pane history intent through the authenticated Fleet verb and
+     * write the returned source envelopes back as owner state. Fail-closed: absence/throw becomes an
+     * explicit unavailable snapshot, never an empty historical claim.
+     * @param {Object} [params]
+     * @returns {Promise<Object>}
+     */
+    async loadCatchUp(params = {}) {
+        const me         = this,
+              pane       = me.getReference('catch-up'),
+              bridge     = globalThis.AgentOS?.fleet?.registryBridge,
+              generation = ++me.catchUpReadGeneration;
+
+        let snapshot;
+
+        if (typeof bridge?.fleetHistory !== 'function') {
+            snapshot = {
+                capability         : {state: 'unavailable', reason: 'fleet history verb not wired'},
+                needsFirstUseWindow: false,
+                partition          : params.partition || 'unified',
+                viewerState        : {lastSeen: null, lastVisitAt: null},
+                window             : null,
+                sources            : null
+            }
+        } else {
+            try {
+                snapshot = await bridge.fleetHistory(params)
+            } catch (error) {
+                snapshot = {
+                    capability         : {state: 'unavailable', reason: 'fleet history read failed'},
+                    needsFirstUseWindow: false,
+                    partition          : params.partition || 'unified',
+                    viewerState        : {lastSeen: null, lastVisitAt: null},
+                    window             : null,
+                    sources            : null
+                }
+            }
+        }
+
+        if (generation === me.catchUpReadGeneration && !me.isDestroyed) {
+            me.catchUpSnapshot = snapshot;
+            pane && (pane.snapshot = snapshot)
+        }
+
+        return snapshot
+    }
+
+    /**
+     * @summary RUNTIME-WRITE: advance the authenticated viewer's lastSeen only through the pane's
+     * rendered window end, then write the honest outcome back to the pane.
+     * @param {Object} params `{windowEnd}`
+     * @returns {Promise<Object>}
+     */
+    async markCatchUp(params) {
+        const me     = this,
+              pane   = me.getReference('catch-up'),
+              bridge = globalThis.AgentOS?.fleet?.registryBridge;
+
+        let outcome;
+
+        try {
+            outcome = typeof bridge?.markFleetCaughtUp === 'function'
+                ? await bridge.markFleetCaughtUp(params)
+                : {status: 'not-wired', reason: 'fleet catch-up mark verb not wired'}
+        } catch (error) {
+            outcome = {status: 'error', reason: 'fleet catch-up mark failed'}
+        }
+
+        if (!me.isDestroyed) {
+            me.catchUpMarkOutcome = outcome;
+            pane && (pane.markOutcome = outcome)
+        }
+
+        return outcome
+    }
+
+    /**
+     * @summary Focus the existing bounded live Activity surface as adjacency. No history citation is
+     * injected into it and no alternate historical authority is implied.
+     * @param {Object} request `{target}`
+     * @returns {{opened: Boolean, target: String}}
+     */
+    openCatchUpLiveSurface({target} = {}) {
+        const stream = target === 'activity-stream' ? this.getReference('activity-stream') : null;
+
+        stream?.focus(stream.id, false, true);
+
+        return {opened: Boolean(stream), target: target || 'unknown'}
     }
 
     /**

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -223,6 +223,35 @@ class FleetCockpitController extends Controller {
     }
 
     /**
+     * @summary Relay a CatchUpPane read intent to the cockpit-owned authenticated bridge.
+     * @param {Object} data
+     * @returns {Promise<Object>}
+     */
+    onCatchUpHistoryRequest(data) {
+        const {source, ...params} = data;
+
+        return this.component.loadCatchUp(params)
+    }
+
+    /**
+     * @summary Relay the explicit runtime-only mark intent.
+     * @param {Object} data
+     * @returns {Promise<Object>}
+     */
+    onCatchUpMarkRequest(data) {
+        return this.component.markCatchUp({windowEnd: data.windowEnd})
+    }
+
+    /**
+     * @summary Route to the existing live adjacency without turning it into history authority.
+     * @param {Object} data
+     * @returns {Object}
+     */
+    onCatchUpLiveSurfaceRequest(data) {
+        return this.component.openCatchUpLiveSurface({target: data.target})
+    }
+
+    /**
      * @summary Re-poll the roster once a lifecycle intent has genuinely changed runtime state.
      *
      * `loadRoster` is the ONLY path that maps live runtime truth onto the roster records, and the

--- a/apps/agentos/view/fleet/cockpitDockDocument.mjs
+++ b/apps/agentos/view/fleet/cockpitDockDocument.mjs
@@ -31,6 +31,9 @@ export function cockpitDockDocument() {
             // S5 define-agent (design ruling on record: rail placement, invoked-not-ambient) —
             // the add-agent flow rides the same autoHidden tool chrome as perspectives
             defineAgent : {componentRef: 'define-agent',      title: 'Add agent',    kind: 'tool',      autoHidden: true},
+            // invoked historical complement to the bounded Activity stream — source-owned Bird
+            // Views, Fleet-owned runtime anchor, never ambient cockpit density
+            catchUp     : {componentRef: 'catch-up',          title: 'Catch up',     kind: 'tool',      autoHidden: true},
             // the operator's own mailbox + compose surface — a secondary tool pane like
             // perspectives, so it rides the auto-hide rail and never crowds the split
             operator    : {componentRef: 'operator-mailbox',  title: 'Operator',     kind: 'tool',      autoHidden: true}
@@ -43,7 +46,7 @@ export function cockpitDockDocument() {
             'fleet-tabs'   : {type: 'tabs', items: ['fleet'],  activeItemId: 'fleet'},
             'stream-tabs'  : {type: 'tabs', items: ['stream'], activeItemId: 'stream'},
             // Secondary panes collapse to this edge's rail (§2.7): their item records carry `autoHidden`.
-            'secondary-rail': {type: 'tabs', items: ['detail', 'perspectives', 'defineAgent', 'operator'], activeItemId: 'detail'}
+            'secondary-rail': {type: 'tabs', items: ['detail', 'perspectives', 'defineAgent', 'catchUp', 'operator'], activeItemId: 'detail'}
         }
     }
 }

--- a/resources/scss/src/apps/agentos/fleet/CatchUpPane.scss
+++ b/resources/scss/src/apps/agentos/fleet/CatchUpPane.scss
@@ -1,0 +1,101 @@
+/* Invoked catch-up rail pane. Source cards remain visually independent so one degraded producer
+   cannot paint the other red; all values come from the Fleet token layer. */
+.fm-catch-up-pane {
+    gap       : 10px;
+    padding   : 12px;
+    background: var(--fm-rail);
+    overflow  : auto;
+
+    .fm-catch-up-head,
+    .fm-catch-up-actions,
+    .fm-catch-up-first-use,
+    .fm-catch-up-partitions {
+        gap: 8px;
+    }
+
+    .fm-catch-up-title {
+        color      : var(--fm-ink);
+        font-weight: 700;
+    }
+
+    .fm-catch-up-authority,
+    .fm-catch-up-window,
+    .fm-catch-up-source-meta,
+    .fm-catch-up-mark-outcome,
+    .fm-catch-up-citation-overflow {
+        color      : var(--fm-ink-dim);
+        font-family: var(--fm-font-mono);
+        font-size  : 10.5px;
+    }
+
+    .fm-catch-up-partitions {
+        overflow-x: auto;
+    }
+
+    .fm-catch-up-partition.is-active {
+        color: var(--fm-signal);
+    }
+
+    .fm-catch-up-sources {
+        gap: 10px;
+    }
+
+    .fm-catch-up-source {
+        gap          : 7px;
+        padding      : 10px;
+        border       : 1px solid var(--fm-line-soft);
+        border-radius: 6px;
+        background   : var(--fm-panel);
+
+        &.is-degraded {
+            border-color: var(--fm-state-limited);
+        }
+
+        &.is-unavailable {
+            border-color: var(--fm-state-wedged);
+        }
+    }
+
+    .fm-catch-up-source-head {
+        gap: 8px;
+    }
+
+    .fm-catch-up-source-title {
+        color      : var(--fm-ink);
+        font-weight: 650;
+    }
+
+    .fm-catch-up-source-state,
+    .fm-catch-up-source-reason {
+        color      : var(--fm-state-limited);
+        font-family: var(--fm-font-mono);
+        font-size  : 10.5px;
+    }
+
+    .fm-catch-up-source-body {
+        color      : var(--fm-ink);
+        font-size  : 12.5px;
+        line-height: 1.45;
+        white-space: pre-wrap;
+    }
+
+    .fm-catch-up-citations {
+        gap       : 4px;
+        padding-top: 3px;
+    }
+
+    .fm-catch-up-citation {
+        color      : var(--fm-ink-dim);
+        font-family: var(--fm-font-mono);
+        font-size  : 10.5px;
+
+        &.is-link {
+            color: var(--fm-signal);
+        }
+    }
+
+    .fm-catch-up-empty {
+        padding: 14px 4px;
+        color  : var(--fm-ink-dim);
+    }
+}

--- a/src/ai/fleet/fleetWireMethods.mjs
+++ b/src/ai/fleet/fleetWireMethods.mjs
@@ -11,7 +11,7 @@
  * `Object` / `Neo.core.Base` member, so a crafted `{method:'getManager'}` / `{method:'constructor'}`
  * request cannot reach a non-operation.
  *
- * `getBootIdentity`, `fleetActivity`, `fleetRoster`, and `fleetMailboxMirror` are **read-observe**
+ * `getBootIdentity`, `fleetActivity`, `fleetHistory`, `fleetRoster`, and `fleetMailboxMirror` are **read-observe**
  * verbs — the advisory boot-identity fact, the bounded fleet activity snapshot, the assembled roster
  * cockpit DTO, and one agent's mailbox mirror: they carry NO lifecycle-write / restart authority. The
  * R3 read-observe ÷ lifecycle-write seam keeps the daemon-core restart actuator physically OFF this
@@ -36,7 +36,9 @@
  * source (no composed launch contract) answers an honest `unavailable`; an admitted-but-unbound
  * context answers a named refusal — never a fallback identity.
  *
- * `composeOperatorMessage` is the wire's FIRST **write** verb — the operator-mailbox steering
+ * `markFleetCaughtUp` is a runtime-only write: it advances only the authenticated viewer's
+ * process-lifetime `lastSeen` through an exact rendered window. It writes no graph, browser storage,
+ * or durable digest. `composeOperatorMessage` is the wire's first durable **write** verb — the operator-mailbox steering
  * surface: compose a DM or an `AGENT:*` broadcast through the bridge's injected writer. It rides
  * ONLY the authenticated transport: the ingress stamps the server-resolved viewer into the request
  * context, and the mailbox primitive resolves the author + its principal class from that ambient
@@ -50,6 +52,6 @@
 export const FLEET_WIRE_METHODS = Object.freeze([
     'defineAgent', 'configureAgent', 'setRepo', 'setAvatar', 'listAgents', 'getAgent',
     'startAgent', 'stopAgent', 'restartAgent', 'removeAgent', 'fleetStatus', 'fleetRuntimeStatus',
-    'getBootIdentity', 'fleetActivity', 'fleetRoster', 'fleetMailboxMirror', 'connectTenant', 'listTenants',
-    'composeOperatorMessage', 'resolveViewerIdentity'
+    'getBootIdentity', 'fleetActivity', 'fleetHistory', 'fleetRoster', 'fleetMailboxMirror', 'connectTenant', 'listTenants',
+    'composeOperatorMessage', 'markFleetCaughtUp', 'resolveViewerIdentity'
 ]);

--- a/test/playwright/e2e/agentos/FleetCatchUpNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCatchUpNL.spec.mjs
@@ -1,0 +1,182 @@
+import {expect, test}                                            from '../../fixtures.mjs';
+import {authenticatedFleetOptions, wireAuthenticatedFleetBridge} from './authenticatedFleetHarness.mjs';
+
+const WINDOW = {
+    semantics  : 'half-open',
+    windowStart: '2026-07-17T12:00:00.000Z',
+    windowEnd  : '2026-07-18T12:00:00.000Z'
+};
+
+const rosterRows = [
+    {id: 'ada', githubUsername: 'neo-opus-ada', displayName: 'Ada', engineTag: 'fixture', family: 'claude'}
+];
+
+function birdView({hash, synthesis, citations = [], degraded = false}) {
+    return {
+        notAuthority      : true,
+        generatedAt       : WINDOW.windowEnd,
+        sourceManifestHash: hash,
+        coverage          : {
+            totalResolved : 2,
+            included      : degraded ? 1 : 2,
+            degraded,
+            degradedReason: degraded ? 'bounded fixture gap' : null
+        },
+        citations,
+        synthesisAvailable        : !degraded,
+        synthesisUnavailableReason: degraded ? 'coverage-degraded' : null,
+        synthesis                 : degraded ? null : synthesis
+    }
+}
+
+function historyResult(params = {}) {
+    if (!params.firstUsePreset && !params.windowStart && (params.partition || 'unified') === 'unified') {
+        return {
+            capability         : {state: 'wired', capturedAt: WINDOW.windowEnd},
+            needsFirstUseWindow: true,
+            partition          : 'unified',
+            viewerState        : {lastSeen: null, lastVisitAt: null},
+            window             : null,
+            sources            : null
+        }
+    }
+
+    const partition = params.partition || 'unified';
+
+    return {
+        capability         : {state: 'degraded', capturedAt: WINDOW.windowEnd},
+        needsFirstUseWindow: false,
+        partition,
+        viewerState        : {lastSeen: null, lastVisitAt: WINDOW.windowEnd},
+        window             : WINDOW,
+        sources            : {
+            memory: {
+                source           : 'memory',
+                state            : 'available',
+                unavailableReason: null,
+                envelope         : birdView({hash: 'a1b2c3d4', synthesis: `Memory history for ${partition}`})
+            },
+            pullRequests: {
+                source           : 'pull-requests',
+                state            : 'degraded',
+                unavailableReason: null,
+                envelope         : birdView({
+                    hash     : 'd4c3b2a1',
+                    synthesis: null,
+                    degraded : true,
+                    citations: [{
+                        type     : 'pull-request',
+                        id       : 'pull:15470',
+                        drillDown: {operation: 'get_conversation', arguments: {pr_number: 15470}}
+                    }]
+                })
+            }
+        }
+    }
+}
+
+async function startCatchUpFleet() {
+    const {startFleetBridgeServer} = await import('../../../../ai/services/fleet/fleetBridgeServer.mjs'),
+          requests                 = [],
+          options                  = authenticatedFleetOptions({
+              dispatch: async request => {
+                  requests.push(request);
+
+                  switch (request.method) {
+                      case 'resolveViewerIdentity':
+                          return {ok: true, result: {ok: true, agentIdentityNodeId: '@e2e-operator'}};
+                      case 'fleetRoster':
+                          return {ok: true, result: {rows: rosterRows}};
+                      case 'fleetActivity':
+                          return {ok: true, result: {capability: {state: 'wired'}, events: []}};
+                      case 'fleetHistory':
+                          return {ok: true, result: historyResult(request.params)};
+                      case 'markFleetCaughtUp':
+                          return {ok: true, result: {status: 'advanced', lastSeen: request.params.windowEnd}};
+                      case 'getBootIdentity':
+                          return {ok: true, result: {fact: null, classification: 'unknown', advisory: true}};
+                      default:
+                          return {ok: false, error: `unexpected catch-up method: ${request.method}`}
+                  }
+              }
+          }),
+          server                   = await startFleetBridgeServer(options);
+
+    return {
+        requests,
+        bearerToken: options.bearerToken,
+        endpoint   : `http://127.0.0.1:${server.address().port}/fleet`,
+        close      : () => new Promise(resolve => server.close(resolve))
+    }
+}
+
+/**
+ * @summary Native Fleet catch-up journey: the real auto-hide rail invokes the pane; the App Worker
+ * crosses the authenticated allowlisted bridge; a first-use choice yields two source-owned
+ * `notAuthority` envelopes; per-agent partitioning changes the Memory read intent; the exact rendered
+ * end advances the runtime-only anchor; and Live Activity focuses the existing bounded adjacency.
+ *
+ * Run: NEO_E2E_PORT=49221 NEO_TEST_SKIP_CI=true npx playwright test agentos/FleetCatchUpNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ */
+test.describe('AgentOS Fleet catch-up — authenticated rail journey (#14620)', () => {
+    test.setTimeout(120000);
+    test.use({viewport: {width: 1600, height: 1000}});
+
+    test('rail → explicit window → independent envelopes → partition → mark → live adjacency', async ({page, neuralLink}) => {
+        const fleet = await startCatchUpFleet();
+
+        try {
+            await page.goto(`/apps/agentos/index.html?${new URLSearchParams({fleetUrl: fleet.endpoint})}`);
+            await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
+
+            const app = await neuralLink.connectToApp('AgentOS');
+            await wireAuthenticatedFleetBridge({app, fleetUrl: fleet.endpoint, bearerToken: fleet.bearerToken});
+
+            const [cockpit] = await app.queryComponent({className: 'AgentOS.view.fleet.FleetCockpit'}, ['id']);
+            expect(cockpit?.properties?.id).toBeTruthy();
+            await app.callMethod(cockpit.properties.id, 'loadRoster');
+
+            const rail = page.locator('.neo-dashboard-dock-rail-tab', {hasText: 'Catch up'});
+            await expect(rail).toHaveCount(1);
+            await rail.click();
+
+            const pane = page.locator('.fm-catch-up-pane');
+            await expect(pane).toBeVisible({timeout: 10000});
+            await expect(pane).toContainText('No runtime anchor yet');
+            await expect(pane).toContainText('Choose 24 hours, 3 days, or one week');
+            await expect(pane.locator('.fm-catch-up-source')).toHaveCount(0);
+
+            await pane.getByRole('button', {name: '24h'}).click();
+            await expect(pane.locator('.fm-catch-up-source')).toHaveCount(2, {timeout: 10000});
+            await expect(pane.locator('.fm-catch-up-source').nth(0)).toContainText('Memory history for unified');
+            await expect(pane.locator('.fm-catch-up-source').nth(0)).toContainText('manifest a1b2c3d4');
+            await expect(pane.locator('.fm-catch-up-source').nth(1)).toContainText('Coverage degraded · bounded fixture gap');
+
+            const citation = pane.locator('a.fm-catch-up-citation, .fm-catch-up-citation a').first();
+            await expect(citation).toHaveAttribute('href', 'https://github.com/neomjs/neo/pull/15470');
+            await expect(citation).toHaveAttribute('rel', 'noopener noreferrer');
+
+            await pane.getByRole('button', {name: 'Ada'}).click();
+            await expect(pane.locator('.fm-catch-up-source').nth(0)).toContainText('Memory history for @neo-opus-ada');
+
+            await pane.getByRole('button', {name: 'Mark caught up'}).click();
+            await expect(pane).toContainText('Caught up through 2026-07-18 12:00Z');
+
+            await pane.getByRole('button', {name: 'Live activity'}).click();
+            await expect.poll(() => page.locator('.fm-activity-stream').evaluate(element => document.activeElement === element))
+                .toBe(true);
+
+            const historyRequests = fleet.requests.filter(request => request.method === 'fleetHistory');
+            expect(historyRequests.map(request => request.params)).toEqual([
+                {partition: 'unified'},
+                {firstUsePreset: 'daily', partition: 'unified'},
+                {partition: '@neo-opus-ada'}
+            ]);
+            expect(historyRequests.every(request => request.params.viewerIdentity === undefined)).toBe(true);
+            expect(fleet.requests.filter(request => request.method === 'markFleetCaughtUp').map(request => request.params))
+                .toEqual([{windowEnd: WINDOW.windowEnd}])
+        } finally {
+            await fleet.close()
+        }
+    })
+});

--- a/test/playwright/e2e/agentos/FleetCockpitAutoHideRailNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitAutoHideRailNL.spec.mjs
@@ -63,7 +63,7 @@ test.describe('AgentOS Fleet cockpit — auto-hide rail product cycle', () => {
 
         await expect(railTab, 'the pinned detail must retire from the edge rail').toHaveCount(0);
         await expect(page.locator('.neo-dashboard-dock-rail-tab'),
-            'the other three authored Fleet rail items must survive the detail pin').toHaveCount(3);
+            'the other four authored Fleet rail items must survive the detail pin').toHaveCount(4);
         await expect(page.locator('.neo-tab-header-button', {hasText: 'Agent detail'}).first(),
             'the pinned detail must re-enter the normal rendered tab flow').toBeVisible({timeout: 15000});
         await expect(page.locator('.neo-dashboard-dock-reveal-overlay'),

--- a/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/FleetControlBridge.spec.mjs
@@ -57,6 +57,8 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
         FleetControlBridge.manager            = null;
         FleetControlBridge.bootIdentitySource = null;
         FleetControlBridge.activitySource     = null;
+        FleetControlBridge.historySource      = null;
+        FleetControlBridge.mailboxMirrorSource = null;
         FleetControlBridge.identityResolver   = null;
     });
 
@@ -163,6 +165,45 @@ test.describe('Neo.ai.services.fleet.FleetControlBridge — capability allowlist
 
         expect(result.events).toEqual([]);   // no invented traffic
         expect(result.capability).toMatchObject({state: 'not-wired', confidence: 'none', reason: 'fleet activity source not wired'});
+    });
+
+    // ---- invoked history: source-owned envelopes + runtime-only explicit anchor write ----
+
+    test('fleetHistory and markFleetCaughtUp route verbatim to one injected viewer-bound source', async () => {
+        const snapshot = {
+            capability: {state: 'wired'},
+            partition : '@neo-opus-ada',
+            window    : {windowStart: '2026-07-17T12:00:00.000Z', windowEnd: '2026-07-18T12:00:00.000Z'},
+            sources   : {memory: {state: 'available'}, pullRequests: {state: 'available'}}
+        };
+
+        FleetControlBridge.historySource = {
+            readHistory : async params => { calls.push(['readHistory', params]); return snapshot; },
+            markCaughtUp: async params => { calls.push(['markCaughtUp', params]); return {status: 'advanced', lastSeen: params.windowEnd}; }
+        };
+
+        await expect(FleetControlBridge.fleetHistory({partition: '@neo-opus-ada'})).resolves.toBe(snapshot);
+        await expect(FleetControlBridge.markFleetCaughtUp({windowEnd: snapshot.window.windowEnd})).resolves.toEqual({
+            status  : 'advanced',
+            lastSeen: snapshot.window.windowEnd
+        });
+        expect(calls).toEqual([
+            ['readHistory', {partition: '@neo-opus-ada'}],
+            ['markCaughtUp', {windowEnd: snapshot.window.windowEnd}]
+        ])
+    });
+
+    test('an unwired history source is named unavailable; mark never fabricates an advance', () => {
+        FleetControlBridge.historySource = null;
+
+        expect(FleetControlBridge.fleetHistory({partition: '@neo-opus-ada'})).toMatchObject({
+            capability: {state: 'unavailable'},
+            partition : '@neo-opus-ada',
+            window    : null,
+            sources   : null
+        });
+        expect(FleetControlBridge.markFleetCaughtUp({windowEnd: '2026-07-18T12:00:00.000Z'}))
+            .toEqual({status: 'not-wired', reason: 'fleet history source not wired'})
     });
 
     // ---- read-observe: the per-agent mailbox mirror (S1; advisory read verb, no mutation path) ----

--- a/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/dispatchFleetRequest.spec.mjs
@@ -33,13 +33,13 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
             configureAgent: p  => { calls.push(['configureAgent', p]); return {status: 'accepted', agent: {id: p.id, harnessType: p.harnessType}}; },
             listAgents    : () => { calls.push(['listAgents']);     return [{id: 'a'}]; },
             getAgent      : id => { calls.push(['getAgent', id]);   return {id}; },
-            startAgent  : async id => { calls.push(['startAgent', id]);   return {id, state: 'running'}; },
-            stopAgent   : async id => { calls.push(['stopAgent', id]);    return {success: true, id}; },
-            restartAgent: async id => { calls.push(['restartAgent', id]); return {id, state: 'running'}; },
-            removeAgent : async id => { calls.push(['removeAgent', id]);  return {success: true, id}; },
-            fleetStatus : () => { calls.push(['fleetStatus']); return [{id: 'a'}]; },
-            setRepo     : payload => { calls.push(['setRepo', payload]); return {id: payload.id, metadata: {repo: payload}}; },
-            setAvatar   : payload => { calls.push(['setAvatar', payload]); return {id: payload.id, metadata: {avatarUrl: payload.avatarUrl}}; },
+            startAgent    : async id => { calls.push(['startAgent', id]);   return {id, state: 'running'}; },
+            stopAgent     : async id => { calls.push(['stopAgent', id]);    return {success: true, id}; },
+            restartAgent  : async id => { calls.push(['restartAgent', id]); return {id, state: 'running'}; },
+            removeAgent   : async id => { calls.push(['removeAgent', id]);  return {success: true, id}; },
+            fleetStatus   : () => { calls.push(['fleetStatus']); return [{id: 'a'}]; },
+            setRepo       : payload => { calls.push(['setRepo', payload]); return {id: payload.id, metadata: {repo: payload}}; },
+            setAvatar     : payload => { calls.push(['setAvatar', payload]); return {id: payload.id, metadata: {avatarUrl: payload.avatarUrl}}; },
             // resolver seams that MUST be unreachable over the wire (they return lifecycle-powerful singletons):
             getManager : () => { calls.push(['getManager']);  return {DANGER: 'lifecycle'}; },
             getRegistry: () => { calls.push(['getRegistry']); return {DANGER: 'registry'}; }
@@ -124,21 +124,23 @@ test.describe('dispatchFleetRequest — the app↔fleet wire allowlist + routing
         expect(calls).toEqual([['resolveViewerIdentity']])
     });
 
-    test('the wire allowlist is exactly the pane operations (+ the read-observe getBootIdentity / fleetActivity / fleetRoster / fleetMailboxMirror / resolveViewerIdentity + the composeOperatorMessage write verb) — no resolver seams', () => {
+    test('the wire allowlist is exactly the pane operations (+ bounded reads and explicit writes) — no resolver seams', () => {
         expect([...FLEET_WIRE_METHODS].sort()).toEqual(
             // fleet-agent operations (incl. the configureAgent scoped-config patch — never identity,
             // never credential) + the read-observe verbs (boot-identity fact + activity snapshot +
-            // assembled roster DTO + one agent's mailbox mirror + the whoami identity-bootstrap —
-            // advisory reads, no lifecycle-write)
-            // + the single write verb (composeOperatorMessage — payload only, identity never wire-carried)
-            ['composeOperatorMessage', 'configureAgent', 'connectTenant', 'defineAgent', 'fleetActivity', 'fleetMailboxMirror', 'fleetRoster', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'getBootIdentity', 'listAgents', 'listTenants', 'removeAgent', 'resolveViewerIdentity', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
+            // assembled roster DTO + viewer-bound catch-up history + one agent's mailbox mirror +
+            // the whoami identity-bootstrap) plus the two explicit write verbs. Catch-up mark is
+            // process-local only; compose persists payload while the server stamps identity.
+            ['composeOperatorMessage', 'configureAgent', 'connectTenant', 'defineAgent', 'fleetActivity', 'fleetHistory', 'fleetMailboxMirror', 'fleetRoster', 'fleetRuntimeStatus', 'fleetStatus', 'getAgent', 'getBootIdentity', 'listAgents', 'listTenants', 'markFleetCaughtUp', 'removeAgent', 'resolveViewerIdentity', 'restartAgent', 'setAvatar', 'setRepo', 'startAgent', 'stopAgent'].sort()
         );
         expect(FLEET_WIRE_METHODS).toContain('getBootIdentity');   // the read-observe verbs ride the wire; the lifecycle-write restart actuator does NOT (R3)
         expect(FLEET_WIRE_METHODS).toContain('fleetActivity');
+        expect(FLEET_WIRE_METHODS).toContain('fleetHistory');
         expect(FLEET_WIRE_METHODS).toContain('fleetRoster');
         // the wire's first WRITE verb: compose rides the authenticated transport with a whitelisted
         // payload — the author is the server-stamped ambient identity, never a wire parameter
         expect(FLEET_WIRE_METHODS).toContain('composeOperatorMessage');
+        expect(FLEET_WIRE_METHODS).toContain('markFleetCaughtUp');
         // a Node-side read verb the browser cannot NAME is not a seam: the omission fails closed and
         // SILENT (the pane's `typeof bridge.x !== 'function'` guard returns early), which reads
         // exactly like a wired-but-empty mailbox — the honest-looking failure this list prevents

--- a/test/playwright/unit/ai/services/fleet/fleetCatchUpSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/fleetCatchUpSource.spec.mjs
@@ -1,0 +1,218 @@
+import {expect, test}             from '@playwright/test';
+import {createFleetCatchUpSource} from '../../../../../../ai/services/fleet/fleetCatchUpSource.mjs';
+
+const HEALTHY_MEMORY = {
+    notAuthority      : true,
+    generatedAt       : '2026-07-18T12:00:00.000Z',
+    coverage          : {totalResolved: 1, included: 1, degraded: false},
+    citations         : [{id: 'memory:1', sessionId: 'session-1'}],
+    synthesisAvailable: true,
+    synthesis         : 'Memory narrative'
+};
+
+const HEALTHY_PULLS = {
+    notAuthority      : true,
+    generatedAt       : '2026-07-18T12:00:00.000Z',
+    coverage          : {totalResolved: 1, included: 1, degraded: false},
+    citations         : [{id: 'pull:15470'}],
+    synthesisAvailable: true,
+    synthesis         : 'PR narrative'
+};
+
+function harness({viewer='@neo-gpt-emmy', now='2026-07-18T12:00:00.000Z'} = {}) {
+    const calls = {memory: [], pulls: []},
+          state = {viewer, now};
+
+    const source = createFleetCatchUpSource({
+        exploreMemoryHistory: async args => {
+            calls.memory.push(args);
+            return HEALTHY_MEMORY
+        },
+        explorePullRequestHistory: async args => {
+            calls.pulls.push(args);
+            return HEALTHY_PULLS
+        },
+        resolveViewerIdentity: () => state.viewer,
+        now                  : () => new Date(state.now)
+    });
+
+    return {calls, source, state}
+}
+
+test.describe('fleetCatchUpSource — viewer-bound runtime anchor + independent source envelopes', () => {
+    test('first visit requires an explicit window choice and invokes neither source', async () => {
+        const {calls, source} = harness(),
+              result          = await source.readHistory();
+
+        expect(result).toMatchObject({
+            needsFirstUseWindow: true,
+            partition          : 'unified',
+            window             : null,
+            sources            : null,
+            viewerState        : {lastSeen: null, lastVisitAt: null}
+        });
+        expect(calls).toEqual({memory: [], pulls: []})
+    });
+
+    test('first-use choice resolves one exact half-open window and preserves both envelopes', async () => {
+        const {calls, source} = harness(),
+              result          = await source.readHistory({firstUsePreset: 'daily'});
+
+        expect(calls.memory).toEqual([{
+            partition  : 'unified',
+            windowStart: '2026-07-17T12:00:00.000Z',
+            windowEnd  : '2026-07-18T12:00:00.000Z'
+        }]);
+        expect(calls.pulls).toEqual([{
+            resolution : 'all_resolved',
+            windowStart: '2026-07-17T12:00:00.000Z',
+            windowEnd  : '2026-07-18T12:00:00.000Z'
+        }]);
+        expect(result.sources.memory.envelope).toBe(HEALTHY_MEMORY);
+        expect(result.sources.pullRequests.envelope).toBe(HEALTHY_PULLS);
+        expect(result).toMatchObject({
+            capability         : {state: 'wired'},
+            needsFirstUseWindow: false,
+            viewerState        : {lastSeen: null, lastVisitAt: '2026-07-18T12:00:00.000Z'},
+            window             : {semantics: 'half-open'}
+        })
+    });
+
+    test('per-agent drill changes only the Memory partition', async () => {
+        const {calls, source} = harness(),
+              window          = {windowStart: '2026-07-17T00:00:00.000Z', windowEnd: '2026-07-18T00:00:00.000Z'};
+
+        await source.readHistory({...window, partition: 'unified'});
+        await source.readHistory({...window, partition: '@neo-opus-ada'});
+
+        expect(calls.memory.map(call => call.partition)).toEqual(['unified', '@neo-opus-ada']);
+        expect(calls.pulls[0]).toEqual(calls.pulls[1]);
+        expect(calls.pulls[1]).not.toHaveProperty('partition')
+    });
+
+    test('one rejected source is unavailable without erasing the healthy peer source', async () => {
+        const source = createFleetCatchUpSource({
+            exploreMemoryHistory     : async () => { throw new Error('memory down') },
+            explorePullRequestHistory: async () => HEALTHY_PULLS,
+            resolveViewerIdentity    : () => '@neo-gpt-emmy',
+            now                      : () => new Date('2026-07-18T12:00:00.000Z')
+        }),
+              result = await source.readHistory({firstUsePreset: 'daily'});
+
+        expect(result.capability.state).toBe('degraded');
+        expect(result.sources.memory).toEqual({
+            source           : 'memory',
+            state            : 'unavailable',
+            unavailableReason: 'memory-history-unavailable',
+            envelope         : null
+        });
+        expect(result.sources.pullRequests.envelope).toBe(HEALTHY_PULLS)
+    });
+
+    test('a source-owned degraded envelope stays intact and degrades only its own slot', async () => {
+        const degraded = {
+                  ...HEALTHY_PULLS,
+                  coverage                  : {totalResolved: 2, included: 1, degraded: true, degradedReason: 'local-corpus-incomplete'},
+                  synthesis                 : null,
+                  synthesisAvailable        : false,
+                  synthesisUnavailableReason: 'coverage-incomplete'
+              },
+              source = createFleetCatchUpSource({
+                  exploreMemoryHistory     : async () => HEALTHY_MEMORY,
+                  explorePullRequestHistory: async () => degraded,
+                  resolveViewerIdentity    : () => '@neo-gpt-emmy',
+                  now                      : () => new Date('2026-07-18T12:00:00.000Z')
+              }),
+              result = await source.readHistory({firstUsePreset: 'daily'});
+
+        expect(result.sources.memory.state).toBe('available');
+        expect(result.sources.pullRequests.state).toBe('degraded');
+        expect(result.sources.pullRequests.envelope).toBe(degraded);
+        expect(result.sources.pullRequests.envelope.coverage.degradedReason).toBe('local-corpus-incomplete')
+    });
+
+    test('lastSeen advances only through the exact rendered end and remains viewer-isolated', async () => {
+        const {source, state} = harness();
+
+        await source.readHistory({firstUsePreset: 'daily'});
+
+        await expect(source.markCaughtUp({windowEnd: '2026-07-18T11:59:00.000Z'})).resolves.toEqual({
+            status: 'rejected', reason: 'window-not-latest-rendered'
+        });
+        await expect(source.markCaughtUp({windowEnd: '2026-07-18T12:00:00.000Z'})).resolves.toMatchObject({
+            status: 'advanced', lastSeen: '2026-07-18T12:00:00.000Z'
+        });
+        await expect(source.markCaughtUp({windowEnd: '2026-07-18T12:00:00.000Z'})).resolves.toEqual({
+            status: 'rejected', reason: 'non-monotonic-window'
+        });
+
+        state.viewer = '@neo-opus-ada';
+        await expect(source.readHistory()).resolves.toMatchObject({needsFirstUseWindow: true});
+
+        state.viewer = '@neo-gpt-emmy';
+        state.now    = '2026-07-18T13:00:00.000Z';
+        await expect(source.readHistory()).resolves.toMatchObject({
+            window: {windowStart: '2026-07-18T12:00:00.000Z', windowEnd: '2026-07-18T13:00:00.000Z'}
+        })
+    });
+
+    test('future/reversed reads refuse and a process restart resets runtime anchors', async () => {
+        const {source} = harness();
+
+        await expect(source.readHistory({
+            windowStart: '2026-07-18T11:00:00.000Z',
+            windowEnd  : '2026-07-18T13:00:00.000Z'
+        })).rejects.toThrow('future');
+        await expect(source.readHistory({
+            windowStart: '2026-07-18T11:00:00.000Z',
+            windowEnd  : '2026-07-18T10:00:00.000Z'
+        })).rejects.toThrow('before');
+
+        await source.readHistory({firstUsePreset: 'daily'});
+
+        const restarted = harness().source;
+
+        await expect(restarted.readHistory()).resolves.toMatchObject({needsFirstUseWindow: true})
+    });
+
+    test('caller-carried viewer identity cannot select the runtime state key', async () => {
+        const {source, state} = harness();
+
+        await source.readHistory({firstUsePreset: 'daily', viewerIdentity: '@neo-opus-ada'});
+        await source.markCaughtUp({windowEnd: '2026-07-18T12:00:00.000Z'});
+
+        state.viewer = '@neo-opus-ada';
+        await expect(source.readHistory()).resolves.toMatchObject({needsFirstUseWindow: true})
+    });
+
+    test('a slower old read cannot steal the rendered-window anchor from a newer request', async () => {
+        const pending = [],
+              source  = createFleetCatchUpSource({
+                  exploreMemoryHistory     : args => new Promise(resolve => pending.push({args, resolve})),
+                  explorePullRequestHistory: async () => HEALTHY_PULLS,
+                  resolveViewerIdentity    : () => '@neo-gpt-emmy',
+                  now                      : () => new Date('2026-07-18T12:00:00.000Z')
+              }),
+              oldWindow = {
+                  windowStart: '2026-07-16T00:00:00.000Z',
+                  windowEnd  : '2026-07-17T00:00:00.000Z'
+              },
+              newWindow = {
+                  windowStart: '2026-07-17T00:00:00.000Z',
+                  windowEnd  : '2026-07-18T00:00:00.000Z'
+              },
+              oldRead = source.readHistory(oldWindow),
+              newRead = source.readHistory(newWindow);
+
+        await expect.poll(() => pending.length).toBe(2);
+        pending[1].resolve(HEALTHY_MEMORY);
+        await newRead;
+        pending[0].resolve(HEALTHY_MEMORY);
+        await oldRead;
+
+        await expect(source.markCaughtUp({windowEnd: newWindow.windowEnd}))
+            .resolves.toMatchObject({status: 'advanced', lastSeen: newWindow.windowEnd});
+        await expect(source.markCaughtUp({windowEnd: oldWindow.windowEnd}))
+            .resolves.toEqual({status: 'rejected', reason: 'window-not-latest-rendered'})
+    });
+});

--- a/test/playwright/unit/ai/services/fleet/wireFleetCatchUpSource.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/wireFleetCatchUpSource.spec.mjs
@@ -1,0 +1,53 @@
+import {setup}                  from '../../../../setup.mjs';
+import {expect, test}           from '@playwright/test';
+import Neo                      from '../../../../../../src/Neo.mjs';
+import * as core                from '../../../../../../src/core/_export.mjs';
+import {wireFleetCatchUpSource} from '../../../../../../ai/services/fleet/wireFleetCatchUpSource.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {
+        name             : 'WireFleetCatchUpSourceTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+test.describe('wireFleetCatchUpSource', () => {
+    test('leaves the bridge unwired when any authority seam is absent', () => {
+        const bridge = {};
+
+        expect(wireFleetCatchUpSource({bridge})).toBeNull();
+        expect(bridge.historySource).toBeUndefined()
+    });
+
+    test('installs exactly one process-lifetime source with the injected seams', () => {
+        const bridge       = {},
+              seen         = [],
+              source       = {readHistory() {}},
+              createSource = options => {
+                  seen.push(options);
+                  return source
+              },
+              exploreMemoryHistory      = () => {},
+              explorePullRequestHistory = () => {},
+              resolveViewerIdentity     = () => '@neo-gpt-emmy',
+              now                       = () => new Date();
+
+        expect(wireFleetCatchUpSource({
+            bridge,
+            createSource,
+            exploreMemoryHistory,
+            explorePullRequestHistory,
+            resolveViewerIdentity,
+            now
+        })).toBe(source);
+        expect(bridge.historySource).toBe(source);
+        expect(seen).toEqual([{
+            exploreMemoryHistory,
+            explorePullRequestHistory,
+            resolveViewerIdentity,
+            now
+        }])
+    });
+});

--- a/test/playwright/unit/apps/agentos/cockpitDockDocument.spec.mjs
+++ b/test/playwright/unit/apps/agentos/cockpitDockDocument.spec.mjs
@@ -41,7 +41,7 @@ test.describe('AgentOS.view.fleet cockpit dock document — dockZone.v1 default 
 
         const autoHidden = Object.entries(items).filter(([, i]) => i.autoHidden === true).map(([id]) => id);
         expect(autoHidden.length).toBeGreaterThan(0);
-        expect(autoHidden).toEqual(expect.arrayContaining(['detail', 'perspectives', 'defineAgent']));
+        expect(autoHidden).toEqual(expect.arrayContaining(['detail', 'perspectives', 'defineAgent', 'catchUp']));
 
         expect(items.fleet.autoHidden).toBeUndefined();
         expect(items.stream.autoHidden).toBeUndefined()
@@ -62,6 +62,20 @@ test.describe('AgentOS.view.fleet cockpit dock document — dockZone.v1 default 
         expect(doc.nodes['secondary-rail'].items).toContain('defineAgent');
         expect(doc.nodes['fleet-tabs'].items).not.toContain('defineAgent');
         expect(doc.nodes['stream-tabs'].items).not.toContain('defineAgent')
+    });
+
+    test('carries S3 catch-up as invoked rail chrome, never ambient cockpit density', () => {
+        const doc = cockpitDockDocument();
+
+        expect(doc.items.catchUp).toEqual({
+            componentRef: 'catch-up',
+            title       : 'Catch up',
+            kind        : 'tool',
+            autoHidden  : true
+        });
+        expect(doc.nodes['secondary-rail'].items).toContain('catchUp');
+        expect(doc.nodes['fleet-tabs'].items).not.toContain('catchUp');
+        expect(doc.nodes['stream-tabs'].items).not.toContain('catchUp')
     });
 
     test('is pure data — a fresh, equal document each call (no shared mutable singleton)', () => {

--- a/test/playwright/unit/apps/agentos/view/fleet/catchUpPane.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/catchUpPane.spec.mjs
@@ -1,0 +1,162 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'CatchUpPaneTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {expect, test}                       from '@playwright/test';
+import Neo                                  from '../../../../../../../src/Neo.mjs';
+import * as core                            from '../../../../../../../src/core/_export.mjs';
+import InstanceManager                      from '../../../../../../../src/manager/Instance.mjs';
+import CatchUpPane, {resolveCitationTarget} from '../../../../../../../apps/agentos/view/fleet/CatchUpPane.mjs';
+
+const WINDOW = {
+    semantics  : 'half-open',
+    windowStart: '2026-07-17T12:00:00.000Z',
+    windowEnd  : '2026-07-18T12:00:00.000Z'
+};
+
+function envelope(overrides = {}) {
+    return {
+        notAuthority      : true,
+        generatedAt       : WINDOW.windowEnd,
+        sourceManifestHash: 'a1b2c3d4',
+        coverage          : {totalResolved: 2, included: 2, degraded: false},
+        citations         : [],
+        synthesisAvailable: true,
+        synthesis         : 'Source-owned narrative',
+        ...overrides
+    }
+}
+
+function snapshot(overrides = {}) {
+    return {
+        capability         : {state: 'wired', capturedAt: WINDOW.windowEnd},
+        needsFirstUseWindow: false,
+        partition          : 'unified',
+        viewerState        : {lastSeen: null, lastVisitAt: WINDOW.windowEnd},
+        window             : WINDOW,
+        sources            : {
+            memory      : {source: 'memory', state: 'available', unavailableReason: null, envelope: envelope()},
+            pullRequests: {source: 'pull-requests', state: 'available', unavailableReason: null, envelope: envelope({
+                sourceManifestHash: 'd4c3b2a1',
+                citations         : [{type: 'pull-request', id: 'pull:15470', drillDown: {operation: 'get_conversation', arguments: {pr_number: 15470}}}]
+            })}
+        },
+        ...overrides
+    }
+}
+
+function createPane(config = {}) {
+    return Neo.create(CatchUpPane, {appName, ...config})
+}
+
+test.describe('AgentOS.view.fleet.CatchUpPane — invoked source-owned history', () => {
+    test('first use is an explicit choice and never renders fabricated empty history', () => {
+        const pane = createPane({snapshot: {
+            capability         : {state: 'wired', capturedAt: WINDOW.windowEnd},
+            needsFirstUseWindow: true,
+            partition          : 'unified',
+            viewerState        : {lastSeen: null, lastVisitAt: null},
+            window             : null,
+            sources            : null
+        }});
+
+        expect(pane.getReference('catch-up-first-use').hidden).toBe(false);
+        expect(pane.getReference('catch-up-mark').hidden).toBe(true);
+        expect(pane.getReference('catch-up-window').text).toBe('No runtime anchor yet');
+        expect(pane.contentStore.getCount()).toBe(0);
+        expect(pane.getReference('catch-up-sources').items[0].text).toContain('No history window is invented');
+
+        pane.destroy()
+    });
+
+    test('renders both source slots independently with provenance, bounds, and canonical PR drill', () => {
+        const pane = createPane({snapshot: snapshot()});
+
+        expect(pane.contentStore.getCount()).toBe(2);
+        expect(pane.getReference('catch-up-window').text).toContain('whole fleet');
+        expect(pane.getReference('catch-up-mark').hidden).toBe(false);
+
+        const [memoryCard, pullCard] = pane.getReference('catch-up-sources').items;
+
+        expect(memoryCard.cls).toContain('is-available');
+        expect(memoryCard.items[1].text).toContain('not authority');
+        expect(memoryCard.items[1].text).toContain('manifest a1b2c3d4');
+        expect(memoryCard.items[2].text).toBe('Source-owned narrative');
+
+        const citation = pullCard.items.find(item => item.cls?.includes('fm-catch-up-citations')).items[0];
+        expect(citation.vdom.href).toBe('https://github.com/neomjs/neo/pull/15470');
+        expect(citation.vdom.rel).toBe('noopener noreferrer');
+
+        pane.destroy()
+    });
+
+    test('one degraded or unavailable source never erases or recolors its healthy peer', () => {
+        const pane = createPane({snapshot: snapshot({sources: {
+            memory: {
+                source           : 'memory',
+                state            : 'degraded',
+                unavailableReason: null,
+                envelope         : envelope({
+                    coverage                  : {totalResolved: 7, included: 3, degraded: true, degradedReason: 'bounded corpus gap'},
+                    synthesisAvailable        : false,
+                    synthesisUnavailableReason: 'coverage-degraded'
+                })
+            },
+            pullRequests: {source: 'pull-requests', state: 'unavailable', unavailableReason: 'pull-requests-history-unavailable', envelope: null}
+        }})});
+
+        const [memoryCard, pullCard] = pane.getReference('catch-up-sources').items;
+
+        expect(memoryCard.cls).toContain('is-degraded');
+        expect(memoryCard.items.some(item => item.text?.includes('bounded corpus gap'))).toBe(true);
+        expect(pullCard.cls).toContain('is-unavailable');
+        expect(pullCard.items[2].text).toBe('pull-requests-history-unavailable');
+
+        pane.destroy()
+    });
+
+    test('partition, first-use, exact mark, and live adjacency remain intent-only', () => {
+        const pane = createPane({
+                  partitionOptions: [{id: 'ada', label: 'Ada', partition: '@neo-opus-ada'}],
+                  snapshot        : snapshot()
+              }),
+              events = [];
+
+        pane.fire = (name, data) => events.push([name, data]);
+        pane.onPartitionClick('@neo-opus-ada');
+        pane.onWeeklyClick();
+        pane.onMarkClick();
+        pane.onLiveActivityClick();
+
+        expect(events).toEqual([
+            ['historyRequest', {partition: '@neo-opus-ada'}],
+            ['historyRequest', {firstUsePreset: 'weekly', partition: '@neo-opus-ada'}],
+            ['markCaughtUpRequest', {windowEnd: WINDOW.windowEnd}],
+            ['liveSurfaceRequest', {target: 'activity-stream'}]
+        ]);
+        expect(pane.partitionStore.items.map(record => record.partition)).toEqual(['unified', '@neo-opus-ada']);
+
+        pane.destroy()
+    });
+
+    test('citation routing accepts only canonical PR descriptors or pull identities', () => {
+        expect(resolveCitationTarget({drillDown: {operation: 'get_conversation', arguments: {pr_number: 42}}}))
+            .toBe('https://github.com/neomjs/neo/pull/42');
+        expect(resolveCitationTarget({id: 'pull:77'})).toBe('https://github.com/neomjs/neo/pull/77');
+        expect(resolveCitationTarget({id: 'memory:77', sessionId: 's-1'})).toBeNull();
+        expect(resolveCitationTarget({drillDown: {operation: 'open_session', arguments: {pr_number: 42}}})).toBeNull()
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCatchUpCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCatchUpCockpit.spec.mjs
@@ -1,0 +1,104 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'FleetCatchUpCockpitTest', isMounted: () => true, vnodeInitialising: false}
+});
+
+import {expect, test} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+import FleetCockpit   from '../../../../../../../apps/agentos/view/fleet/FleetCockpit.mjs';
+
+const clearBridge = () => { delete globalThis.AgentOS?.fleet };
+
+test.describe('FleetCockpit — catch-up owner routing', () => {
+    test.afterEach(() => clearBridge());
+
+    test('load routes to the authenticated verb and writes both owner and live pane', async () => {
+        const snapshot = {capability: {state: 'wired'}, partition: '@neo-opus-ada', window: {}, sources: {}},
+              pane     = {},
+              calls    = [],
+              cockpit  = {
+                  catchUpReadGeneration: 0,
+                  catchUpSnapshot      : null,
+                  isDestroyed          : false,
+                  getReference         : ref => ref === 'catch-up' ? pane : null
+              };
+
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetHistory: async params => { calls.push(params); return snapshot; }}};
+
+        await expect(FleetCockpit.prototype.loadCatchUp.call(cockpit, {partition: '@neo-opus-ada'})).resolves.toBe(snapshot);
+        expect(calls).toEqual([{partition: '@neo-opus-ada'}]);
+        expect(cockpit.catchUpSnapshot).toBe(snapshot);
+        expect(pane.snapshot).toBe(snapshot)
+    });
+
+    test('unwired/throw read and unwired/throw mark remain explicit, never empty or advanced', async () => {
+        const pane = {},
+              make = () => ({
+                  catchUpReadGeneration: 0,
+                  catchUpSnapshot      : null,
+                  catchUpMarkOutcome   : null,
+                  isDestroyed          : false,
+                  getReference         : ref => ref === 'catch-up' ? pane : null
+              });
+
+        clearBridge();
+        await expect(FleetCockpit.prototype.loadCatchUp.call(make(), {partition: 'unified'}))
+            .resolves.toMatchObject({capability: {state: 'unavailable'}, sources: null});
+        await expect(FleetCockpit.prototype.markCatchUp.call(make(), {windowEnd: '2026-07-18T12:00:00.000Z'}))
+            .resolves.toEqual({status: 'not-wired', reason: 'fleet catch-up mark verb not wired'});
+
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {
+            fleetHistory     : async () => { throw new Error('secret read detail') },
+            markFleetCaughtUp: async () => { throw new Error('secret write detail') }
+        }};
+        await expect(FleetCockpit.prototype.loadCatchUp.call(make()))
+            .resolves.toMatchObject({capability: {state: 'unavailable', reason: 'fleet history read failed'}, sources: null});
+        await expect(FleetCockpit.prototype.markCatchUp.call(make(), {windowEnd: '2026-07-18T12:00:00.000Z'}))
+            .resolves.toEqual({status: 'error', reason: 'fleet catch-up mark failed'})
+    });
+
+    test('an older read loses the generation race', async () => {
+        let resolveOld;
+        const pane    = {},
+              cockpit = {
+                  catchUpReadGeneration: 0,
+                  catchUpSnapshot      : null,
+                  isDestroyed          : false,
+                  getReference         : ref => ref === 'catch-up' ? pane : null
+              },
+              old = new Promise(resolve => { resolveOld = resolve });
+
+        let reads = 0;
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {fleetHistory: () => ++reads === 1 ? old : Promise.resolve({id: 'new'})}};
+
+        const first  = FleetCockpit.prototype.loadCatchUp.call(cockpit),
+              second = FleetCockpit.prototype.loadCatchUp.call(cockpit);
+
+        await second;
+        resolveOld({id: 'old'});
+        await first;
+
+        expect(cockpit.catchUpSnapshot).toEqual({id: 'new'});
+        expect(pane.snapshot).toEqual({id: 'new'})
+    });
+
+    test('partition choices come from roster mailbox identities; live adjacency focuses the real stream', () => {
+        const focused = [],
+              rows    = [
+                  {agentId: 'ada', githubUsername: 'neo-opus-ada', displayName: 'Ada'},
+                  {agentId: 'guest', githubUsername: null, displayName: 'Guest'}
+              ],
+              stream = {id: 'stream-1', focus: (...args) => focused.push(args)},
+              cockpit = {getReference: ref => ref === 'fleet-grid' ? {store: {items: rows}} : ref === 'activity-stream' ? stream : null};
+
+        expect(FleetCockpit.prototype.buildCatchUpPartitionOptions.call(cockpit)).toEqual([
+            {id: 'catch-up-ada', label: 'Ada', partition: '@neo-opus-ada'}
+        ]);
+        expect(FleetCockpit.prototype.openCatchUpLiveSurface.call(cockpit, {target: 'activity-stream'}))
+            .toEqual({opened: true, target: 'activity-stream'});
+        expect(focused).toEqual([['stream-1', false, true]])
+    })
+});

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitPopOut.spec.mjs
@@ -224,7 +224,7 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
 
         // the placement truth: `addTab` appends by default — the restore must land the item back
         // at its STORED index (0, before the rest of the rail), not at the tail
-        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'operator']);
+        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'operator']);
 
         // same instance re-adopted by the projection; the vessel was closed by name
         expect(cockpit.getReference('agent-detail')).toBe(pane);
@@ -249,7 +249,7 @@ test.describe.serial('AgentOS.view.fleet.FleetCockpit — detail pop-out state m
 
         // the SAME instance is docked again at its exact home; nothing was closed (nothing opened)
         expect(cockpit.getReference('agent-detail')).toBe(pane);
-        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'operator']);
+        expect(cockpit.getDockZoneDocument().nodes['secondary-rail'].items).toEqual(['detail', 'perspectives', 'defineAgent', 'catchUp', 'operator']);
         expect(vessel.closeCalls).toHaveLength(0)
     });
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
@@ -278,6 +278,7 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
             'detail',
             'perspectives',
             'defineAgent',
+            'catchUp',
             'operator'
         ])
     });


### PR DESCRIPTION
Resolves #14620

The Fleet cockpit can now answer “what happened since I last looked?” without becoming a second history or synthesis authority. A viewer-bound Fleet adapter invokes the shipped `explore_memory_history` and `explore_pull_request_history` operations independently for one validated half-open window, preserving each source envelope—including honest `notAuthority`, degraded, unavailable, incomplete-coverage, and synthesis-unavailable results.

The new auto-hidden `CatchUpPane` consumes that adapter through the authenticated Fleet bridge. It presents source manifests, coverage, timestamps, bounded citations, first-use window choices, per-agent Memory partitioning, and live/detail adjacency using a pane-local `data.Store` of `data.Model` records. PR citations drill through canonically; unsupported citation kinds remain visible without false navigation.

Viewer catch-up state is deliberately process-local. An explicit **Mark caught up** advances `lastSeen` monotonically through the exact rendered window end; reload preserves it and a Fleet-service restart resets it. The source uses a per-viewer read-generation fence so an older slow request cannot replace the newer UI-winning mark boundary. There is no Fleet synthesis, ranking, result cache, graph write, browser storage, or durable receipt.

## Deltas from ticket

No scope expansion. The implementation remains a thin consumer of the two source-owned Bird View operations, uses the established right secondary rail, and does not alter docking mechanics or the bounded live `ActivityStream` authority.

Evidence: L3 (live non-destructive Chromium + Neural Link cockpit journey) → L3 required (AC5 real Neural Link journey). No residuals.

## Test Evidence

- Focused unit matrix across the source, wire, bridge, allowlist, cockpit, document, pane, and merged fusion-tour surfaces — 171/171 passed at `7de655d1546a1db87f1275bfe83fddae7d0017f1`.
- The hosted full unit shard then exposed the one remaining shared-rail pin in `fleetCockpitPopOut.spec.mjs`; both exact-order assertions now include `catchUp` at `2d253a55eaaa1ebd8a6c20130dd8f6d64c35ee8d`, and the focused catch-up + pop-out regression matrix is 35/35 green.
- `NEO_E2E_PORT=49221 NEO_TEST_SKIP_CI=true npx playwright test agentos/FleetCatchUpNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — 1/1 passed on the exact rebased head.
- Existing `FleetCockpitAutoHideRailNL` journey — 1/1 passed after adding the fifth auto-hidden rail item.
- `npm run check-agentos-theme` — parity, token-only, and completeness passed.
- `npm run agent-preflight -- --no-fix` — all requested gates passed; only the pre-existing local stale-overlay warning was reported.
- `git diff --check` — clean.

## Post-Merge Validation

- [ ] Confirm hosted CI remains green at the human merge head.
- [ ] Exercise a real operator return after a Fleet-service restart to confirm the intentional first-use reset remains legible.
- [ ] Keep future history synthesis or durable read-receipt requests on their source-owning follow-ups rather than extending Fleet authority.

Authored by Emmy (`@neo-gpt-emmy`, GPT family).
