### PR TITLE
feat(dashboard): the keyboard detach path — command machine + mounted detach/a11y tranche (#15250)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -411,7 +411,16 @@ class DemoBWorkspace extends Container {
             reference: 'dock-host-b'
         }]);
 
-        me.crossWindowHosts.set(DemoBWorkspace.MAIN_WORKSPACE_ID, me.getReference('dock-host-b'))
+        me.crossWindowHosts.set(DemoBWorkspace.MAIN_WORKSPACE_ID, me.getReference('dock-host-b'));
+
+        // The keyboard command routing — MAIN workspace only, the projection's tear-out arming
+        // rule applied to keys. Entry chords act on the FOCUSED tab header; the cycle keys are
+        // fully chorded too (no preventDefault crosses the worker boundary, so the grammar avoids
+        // every native key meaning instead of suppressing it). Escape alone cancels — it has no
+        // native meaning on a header.
+        me.getReference('dock-host-b').addDomListeners([
+            {keydown: me.onDockHostKeyDown, scope: me}
+        ])
     }
 
     /**
@@ -425,6 +434,100 @@ class DemoBWorkspace extends Container {
         let live = this.getReference('kbd-live-b');
 
         live && (live.text = message)
+    }
+
+    /**
+     * The host-owned cycle key grammar, stated in every candidate announcement — fully chorded
+     * because no key suppression crosses the worker boundary: the grammar AVOIDS native meanings
+     * instead of preventing them.
+     * @member {String} KEYBOARD_CYCLE_INSTRUCTIONS
+     * @static
+     */
+    static KEYBOARD_CYCLE_INSTRUCTIONS =
+        'Ctrl+Shift+Arrow keys cycle targets, Ctrl+Shift+Enter moves it there, Escape cancels.'
+
+    /**
+     * @summary The keyboard command surface's key routing. Entry chords on a focused dock tab
+     * header: Ctrl+Shift+D detaches it to its own OS window; Ctrl+Shift+M starts the move cycle.
+     * While a cycle is active, Ctrl+Shift+ArrowRight/ArrowLeft cycle the candidates,
+     * Ctrl+Shift+Enter commits, and Escape (alone — no native meaning on a header) cancels.
+     * Outside a cycle every key keeps its native meaning; the machine's `getActiveCycle()` is
+     * the single routing gate.
+     * @param {Object} data The keydown DomEvent payload.
+     * @returns {Promise<void>}
+     * @protected
+     */
+    async onDockHostKeyDown(data) {
+        let me       = this,
+            commands = me.keyboardCommands,
+            chorded  = data.ctrlKey && data.shiftKey;
+
+        if (commands.getActiveCycle()) {
+            if (data.key === 'Escape') {
+                commands.cycleCancel();
+                return
+            }
+
+            if (chorded) {
+                switch (data.key) {
+                    case 'ArrowRight':
+                        commands.cycleNext();
+                        return
+                    case 'ArrowLeft':
+                        commands.cyclePrev();
+                        return
+                    case 'Enter':
+                        await commands.cycleCommit();
+                        return
+                }
+            }
+
+            return
+        }
+
+        if (!chorded || !['d', 'm'].includes(data.key?.toLowerCase?.())) {
+            return
+        }
+
+        let focused = me.resolveFocusedDockItem(data);
+
+        if (!focused) return;
+
+        if (data.key.toLowerCase() === 'd') {
+            await commands.detachItem(focused)
+        } else {
+            commands.cycleStart({...focused, instructions: DemoBWorkspace.KEYBOARD_CYCLE_INSTRUCTIONS})
+        }
+    }
+
+    /**
+     * @summary Resolve the dock item the keydown acted on: the event path's tab-header button →
+     * its header toolbar index → the sibling card container's item at that index → the
+     * adapter-stamped `dockItemId`, labeled from the workspace document's item title.
+     * @param {Object} data The keydown DomEvent payload (carries the component path).
+     * @returns {Object|null} `{itemId, itemLabel}` or `null` when the focus is not a dock tab header.
+     * @protected
+     */
+    resolveFocusedDockItem(data) {
+        let me     = this,
+            button = (data.path || [])
+                .map(node => Neo.getComponent(node.id))
+                .find(component => component?.ntype === 'tab-header-button');
+
+        if (!button) return null;
+
+        let toolbar      = button.up({ntype: 'tab-header-toolbar'}) || button.parent,
+            index        = toolbar?.items?.indexOf(button) ?? -1,
+            tabContainer = toolbar?.up({ntype: 'tab-container'}),
+            card         = index > -1 && tabContainer?.getCardContainer?.()?.items?.[index],
+            itemId       = card?.dockItemId || card?.data?.dockItemId;
+
+        if (!itemId) return null;
+
+        return {
+            itemId,
+            itemLabel: me.dockModel?.items?.[itemId]?.title ?? itemId
+        }
     }
 
     /**

--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -12,6 +12,7 @@ import DockService                        from '../../../../../src/ai/client/Doc
 import DockTopologyReconciler             from '../../../../../src/dashboard/DockTopologyReconciler.mjs';
 import DockZoneModel                      from '../../../../../src/dashboard/DockZoneModel.mjs';
 import InteractionService                 from '../../../../../src/ai/client/InteractionService.mjs';
+import {createDockKeyboardCommands}       from '../../../../../src/dashboard/DockKeyboardCommands.mjs';
 import {createDockTearOutHandlers}        from '../../../../../src/dashboard/DockTearOut.mjs';
 import {createDockWorkspaceSet}           from '../../../../../src/dashboard/DockWorkspaceSet.mjs';
 import TourRunner                         from '../../../../../src/ai/client/TourRunner.mjs';
@@ -329,6 +330,31 @@ class DemoBWorkspace extends Container {
             openVessel: request => me.openTearOutVessel(request)
         });
 
+        // The keyboard command surface — the discrete a11y-parity twin of the gesture paths,
+        // composed over the SAME host seams (detach reuses the tear-out seams verbatim) plus the
+        // keyboard-specific ones. The transfer commit composes the OWNED primitives directly
+        // (transferItem → adoptTransfer → target-first reconcile) rather than the pointer path's
+        // gesture-witness wrapper: that wrapper's context/generation predicates and proof
+        // machinery belong to the continuous gesture, not to a discrete command.
+        me.keyboardCommands = createDockKeyboardCommands({
+            announce        : announcement => me.announceKeyboardOutcome(announcement),
+            applyOperation  : descriptor => me.applyWorkspaceOperation(DemoBWorkspace.MAIN_WORKSPACE_ID, descriptor),
+            closeVessel     : vessel => me.closeTearOutVessel(vessel),
+            commitTransfer  : data => me.commitKeyboardTransfer(data),
+            enumerateTargets: request => me.enumerateKeyboardTargets(request),
+            focusVessel     : vessel => me.focusNamedWindow(vessel.windowName),
+            focusWorkspace  : ({workspaceId}) => workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID
+                ? me.focusNamedWindow('demo-b-cross-window')
+                : true, // the main workspace is THIS window — the command runs focused here already
+            highlightTarget : target => me.setKeyboardTargetHighlight(target),
+            onDocumentChange: (document, operation) => {
+                me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, document);
+                // the committed detach is the adoption trigger — identical to the pointer path
+                operation?.operation === 'detachItem' && me.adoptTearOutPane(operation.itemId)
+            },
+            openVessel: request => me.openTearOutVessel(request)
+        });
+
         me.tourRunner = Neo.create(TourRunner, {
             componentId        : me.id,
             crossWindowExecutor: me,
@@ -365,6 +391,14 @@ class DemoBWorkspace extends Container {
             ntype    : 'component',
             reference: 'restore-report-b'
         }, {
+            // The keyboard command surface's announcement region: every outcome terminal the
+            // command machine derives lands here as TEXT for the screen reader — visually
+            // unobtrusive, never hidden from the accessibility tree.
+            cls      : ['agentos-dockdemo-kbd-live'],
+            ntype    : 'component',
+            reference: 'kbd-live-b',
+            vdom     : {role: 'status', 'aria-live': 'polite', cn: []}
+        }, {
             module: Container,
             cls   : ['agentos-dockdemo-dock-host', 'neo-dashboard'],
             flex  : 1,
@@ -378,6 +412,166 @@ class DemoBWorkspace extends Container {
         }]);
 
         me.crossWindowHosts.set(DemoBWorkspace.MAIN_WORKSPACE_ID, me.getReference('dock-host-b'))
+    }
+
+    /**
+     * @summary Render a keyboard command outcome into the aria-live region — the announcement
+     * seam of the keyboard command machine. TEXT only (`.text` is inert by construction); the
+     * message is the machine's complete terminal-derived sentence.
+     * @param {Object} announcement `{command, itemId, terminal, focusTransferred, message}`.
+     * @protected
+     */
+    announceKeyboardOutcome({message}) {
+        let live = this.getReference('kbd-live-b');
+
+        live && (live.text = message)
+    }
+
+    /**
+     * @summary Enumerate the legal keyboard-transfer targets across the registered workspaces —
+     * every tabs zone in STABLE registry order, excluding the item's current tabs, labeled with
+     * the workspace's human name (+ a zone ordinal when a workspace has several).
+     * @param {Object} data
+     * @param {String} data.itemId
+     * @returns {Object[]} `[{workspaceId, tabsId, label}]`
+     * @protected
+     */
+    enumerateKeyboardTargets({itemId}) {
+        let me     = this,
+            labels = {
+                [DemoBWorkspace.MAIN_WORKSPACE_ID] : 'Main window',
+                [DemoBWorkspace.POPUP_WORKSPACE_ID]: 'Popup window'
+            };
+
+        return me.workspaceSet.ids().flatMap(workspaceId => {
+            let document     = me.workspaceSet.getDocument(workspaceId),
+                nodes        = document?.nodes || {},
+                sourceTabsId = document?.items?.[itemId]
+                    ? DockZoneModel.findContainingTabsId(document, itemId)
+                    : null,
+                tabsIds      = Object.keys(nodes).filter(nodeId =>
+                    nodes[nodeId].type === 'tabs' && nodeId !== sourceTabsId
+                );
+
+            return tabsIds.map((tabsId, index) => ({
+                label: tabsIds.length > 1
+                    ? `${labels[workspaceId] ?? workspaceId}, zone ${index + 1}`
+                    : (labels[workspaceId] ?? workspaceId),
+                tabsId,
+                workspaceId
+            }))
+        })
+    }
+
+    /**
+     * @summary Render (or clear) the keyboard cycle's current-candidate highlight on the target
+     * zone container. The class pairs hue with a non-color carrier (outline) in the skin — the
+     * WCAG 1.4.1 duty the command machine's seam documents.
+     * @param {Object|null} target `{workspaceId, tabsId}` or `null` to clear.
+     * @protected
+     */
+    setKeyboardTargetHighlight(target) {
+        let me   = this,
+            zone = me.keyboardHighlightZone;
+
+        if (zone && !zone.isDestroyed) {
+            zone.removeCls('agentos-kbd-target')
+        }
+
+        me.keyboardHighlightZone = null;
+
+        if (!target) return;
+
+        let host = me.crossWindowHosts.get(target.workspaceId);
+
+        zone = host && !host.isDestroyed && host.down({dockNodeId: target.tabsId});
+
+        if (zone) {
+            zone.addCls('agentos-kbd-target');
+            me.keyboardHighlightZone = zone
+        }
+    }
+
+    /**
+     * @summary The keyboard transfer commit — composes the OWNED primitives directly:
+     * `DockZoneModel.transferItem` (the commit-or-neither document pair), the workspace-set's
+     * both-or-neither adoption, vessel bookkeeping (published synchronously BEFORE projection,
+     * the same discipline the pointer path documents), then the target-first reconcile (adopt
+     * the pane across the window boundary before the source shell can classify the now-absent
+     * item as a retirement). The pointer path's `commitCrossWindowTransfer` wrapper is NOT
+     * reused: its context/generation predicates and continuity-proof machinery belong to the
+     * continuous gesture.
+     * @param {Object} data
+     * @param {String} data.itemId
+     * @param {Object} data.target `{workspaceId, tabsId}` — the committed cycle candidate.
+     * @returns {Promise<{errors: String[]}>}
+     * @protected
+     */
+    async commitKeyboardTransfer({itemId, target}) {
+        let me                = this,
+            sourceWorkspaceId = me.workspaceSet.ids().find(id =>
+                !!me.workspaceSet.getDocument(id)?.items?.[itemId]
+            );
+
+        if (!sourceWorkspaceId) {
+            return {errors: [`unknown item "${itemId}"`]}
+        }
+
+        let sourceBefore = me.workspaceSet.getDocument(sourceWorkspaceId),
+            sourceTabsId = DockZoneModel.findContainingTabsId(sourceBefore, itemId),
+
+            {sourceDocument, targetDocument, errors} = DockZoneModel.transferItem(
+                sourceBefore,
+                me.workspaceSet.getDocument(target.workspaceId),
+                {
+                    itemId,
+                    sourceWorkspaceId,
+                    targetWorkspaceId: target.workspaceId,
+                    target           : {operation: 'addTab', tabsNodeId: target.tabsId}
+                }
+            );
+
+        if (errors.length) {
+            return {errors}
+        }
+
+        if (!me.workspaceSet.adoptTransfer({sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId: target.workspaceId})) {
+            return {errors: ['workspace-set adoption refused the pair']}
+        }
+
+        // vessel bookkeeping rides the commit synchronously: an item entering the popup must be
+        // classified re-attachable before a physical close can race the projection; an item
+        // returning home retires its entry
+        if (target.workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID) {
+            me.detachedPanes[itemId] = {
+                tabsNodeId: sourceTabsId,
+                windowId  : me.crossWindowHosts.get(DemoBWorkspace.POPUP_WORKSPACE_ID)?.windowId,
+                windowName: 'demo-b-cross-window'
+            }
+        } else if (sourceWorkspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID) {
+            delete me.detachedPanes[itemId]
+        }
+
+        await me.refreshWorkspace(target.workspaceId, targetDocument);
+        await me.refreshWorkspace(sourceWorkspaceId, sourceDocument);
+
+        return {errors: []}
+    }
+
+    /**
+     * @summary Focus a named popup window through the Main verb — Boolean admission (the
+     * `windowOpen` discipline applied to focus): the answer is the verified outcome, and `false`
+     * is a legitimate degraded terminal for the command machine to announce, never a throw.
+     * @param {String} windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async focusNamedWindow(windowName) {
+        try {
+            return !!(await Neo.Main.windowFocus({windowName, windowId: this.windowId}))
+        } catch (error) {
+            return false
+        }
     }
 
     /**

--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -393,11 +393,13 @@ class DemoBWorkspace extends Container {
         }, {
             // The keyboard command surface's announcement region: every outcome terminal the
             // command machine derives lands here as TEXT for the screen reader — visually
-            // unobtrusive, never hidden from the accessibility tree.
+            // unobtrusive, never hidden from the accessibility tree. `role` rides the
+            // Component.Base config (the renderer owns root-attr routing); aria-live rides the vdom.
             cls      : ['agentos-dockdemo-kbd-live'],
             ntype    : 'component',
             reference: 'kbd-live-b',
-            vdom     : {role: 'status', 'aria-live': 'polite', cn: []}
+            role     : 'status',
+            vdom     : {'aria-live': 'polite', cn: []}
         }, {
             module: Container,
             cls   : ['agentos-dockdemo-dock-host', 'neo-dashboard'],

--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -502,8 +502,11 @@ class DemoBWorkspace extends Container {
 
     /**
      * @summary Resolve the dock item the keydown acted on: the event path's tab-header button →
-     * its header toolbar index → the sibling card container's item at that index → the
-     * adapter-stamped `dockItemId`, labeled from the workspace document's item title.
+     * its header toolbar index → the owning projected tab-container's `dockNodeId` → the
+     * DOCUMENT's tabs node items at that index. The document is the authority on purpose:
+     * DemoB's panes are LIVE instances, which the adapter's item decoration deliberately passes
+     * through untouched — only the freshly-projected CONTAINER configs carry dock metadata, so
+     * the container's node id + the committed document answer identity where the card cannot.
      * @param {Object} data The keydown DomEvent payload (carries the component path).
      * @returns {Object|null} `{itemId, itemLabel}` or `null` when the focus is not a dock tab header.
      * @protected
@@ -519,8 +522,12 @@ class DemoBWorkspace extends Container {
         let toolbar      = button.up({ntype: 'tab-header-toolbar'}) || button.parent,
             index        = toolbar?.items?.indexOf(button) ?? -1,
             tabContainer = toolbar?.up({ntype: 'tab-container'}),
-            card         = index > -1 && tabContainer?.getCardContainer?.()?.items?.[index],
-            itemId       = card?.dockItemId || card?.data?.dockItemId;
+            // the projection filters rail-hidden items out of the tab flow — mirror it so the
+            // header index maps to the same list the strip renders
+            nodeItems    = me.dockModel?.nodes?.[tabContainer?.dockNodeId]?.items?.filter(id =>
+                me.dockModel.items?.[id]?.autoHidden !== true
+            ),
+            itemId       = index > -1 && Array.isArray(nodeItems) ? nodeItems[index] : null;
 
         if (!itemId) return null;
 
@@ -547,6 +554,13 @@ class DemoBWorkspace extends Container {
             };
 
         return me.workspaceSet.ids().flatMap(workspaceId => {
+            // only workspaces with a LIVE render target are legal keyboard targets: a registered
+            // popup workspace whose window never opened cannot show the highlight, cannot take
+            // focus, and would leave the operator committing into the invisible
+            let host = me.crossWindowHosts.get(workspaceId);
+
+            if (!host || host.isDestroyed) return [];
+
             let document     = me.workspaceSet.getDocument(workspaceId),
                 nodes        = document?.nodes || {},
                 sourceTabsId = document?.items?.[itemId]

--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -493,14 +493,15 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * @summary The keyboard transfer commit — composes the OWNED primitives directly:
-     * `DockZoneModel.transferItem` (the commit-or-neither document pair), the workspace-set's
-     * both-or-neither adoption, vessel bookkeeping (published synchronously BEFORE projection,
-     * the same discipline the pointer path documents), then the target-first reconcile (adopt
-     * the pane across the window boundary before the source shell can classify the now-absent
-     * item as a retirement). The pointer path's `commitCrossWindowTransfer` wrapper is NOT
-     * reused: its context/generation predicates and continuity-proof machinery belong to the
-     * continuous gesture.
+     * @summary The keyboard transfer commit — `DockZoneModel.transferItem` produces the
+     * commit-or-neither document pair, then the shared two-phase core lands it:
+     * {@link #adoptCommittedTransferPair} (both-or-neither adoption, first exit on refusal) and
+     * {@link #reconcileTransferPair} (target-first, unguarded — a discrete command has no
+     * mid-flight supersession to fence). The pointer path's `commitCrossWindowTransfer` wrapper
+     * is deliberately NOT reused: its context/generation predicates and continuity-proof
+     * machinery belong to the continuous gesture. Deliberately NO `detachedPanes` bookkeeping
+     * here — that classification belongs to the pointer pop-out flow, and close-race policy for
+     * transferred items is the whole-stack return leaf's contract, which binds to the same core.
      * @param {Object} data
      * @param {String} data.itemId
      * @param {Object} data.target `{workspaceId, tabsId}` — the committed cycle candidate.
@@ -517,43 +518,28 @@ class DemoBWorkspace extends Container {
             return {errors: [`unknown item "${itemId}"`]}
         }
 
-        let sourceBefore = me.workspaceSet.getDocument(sourceWorkspaceId),
-            sourceTabsId = DockZoneModel.findContainingTabsId(sourceBefore, itemId),
-
-            {sourceDocument, targetDocument, errors} = DockZoneModel.transferItem(
-                sourceBefore,
-                me.workspaceSet.getDocument(target.workspaceId),
-                {
-                    itemId,
-                    sourceWorkspaceId,
-                    targetWorkspaceId: target.workspaceId,
-                    target           : {operation: 'addTab', tabsNodeId: target.tabsId}
-                }
-            );
+        let {sourceDocument, targetDocument, errors} = DockZoneModel.transferItem(
+            me.workspaceSet.getDocument(sourceWorkspaceId),
+            me.workspaceSet.getDocument(target.workspaceId),
+            {
+                itemId,
+                sourceWorkspaceId,
+                targetWorkspaceId: target.workspaceId,
+                target           : {operation: 'addTab', tabsNodeId: target.tabsId}
+            }
+        );
 
         if (errors.length) {
             return {errors}
         }
 
-        if (!me.workspaceSet.adoptTransfer({sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId: target.workspaceId})) {
+        let pair = {sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId: target.workspaceId};
+
+        if (!me.adoptCommittedTransferPair(pair)) {
             return {errors: ['workspace-set adoption refused the pair']}
         }
 
-        // vessel bookkeeping rides the commit synchronously: an item entering the popup must be
-        // classified re-attachable before a physical close can race the projection; an item
-        // returning home retires its entry
-        if (target.workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID) {
-            me.detachedPanes[itemId] = {
-                tabsNodeId: sourceTabsId,
-                windowId  : me.crossWindowHosts.get(DemoBWorkspace.POPUP_WORKSPACE_ID)?.windowId,
-                windowName: 'demo-b-cross-window'
-            }
-        } else if (sourceWorkspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID) {
-            delete me.detachedPanes[itemId]
-        }
-
-        await me.refreshWorkspace(target.workspaceId, targetDocument);
-        await me.refreshWorkspace(sourceWorkspaceId, sourceDocument);
+        await me.reconcileTransferPair(pair);
 
         return {errors: []}
     }
@@ -1141,6 +1127,57 @@ class DemoBWorkspace extends Container {
     }
 
     /**
+     * @summary The SYNCHRONOUS half of the operation-agnostic transfer-commit core: the stats
+     * increment plus the workspace-set's both-or-neither adoption of a committed document PAIR —
+     * whatever executor produced it (`transferItem` today; the whole-stack return's
+     * `transferNode` pair binds here next). A refused adoption is the core's first exit: the
+     * vessel bookkeeping any caller performs after this must never diverge from document truth.
+     * @param {Object} pair
+     * @param {Object} pair.sourceDocument
+     * @param {String} pair.sourceWorkspaceId
+     * @param {Object} pair.targetDocument
+     * @param {String} pair.targetWorkspaceId
+     * @returns {Boolean} false when the workspace-set refused the pair.
+     * @protected
+     */
+    adoptCommittedTransferPair({sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId}) {
+        this.crossWindowStats.transferCommits++;
+
+        return this.workspaceSet.adoptTransfer({sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId})
+    }
+
+    /**
+     * @summary The reconcile half of the transfer-commit core. Target-first is load-bearing: it
+     * adopts the cached pane across the window boundary before the source shell can classify the
+     * now-absent item as a retirement. The `guard` seam is checked before each projection so a
+     * caller with supersession semantics (the pointer gesture's ownership fences) keeps them
+     * without the core knowing gesture state; guard-stopped reconciles are the CALLER's outcome
+     * to interpret.
+     * @param {Object} pair
+     * @param {Object} pair.sourceDocument
+     * @param {String} pair.sourceWorkspaceId
+     * @param {Object} pair.targetDocument
+     * @param {String} pair.targetWorkspaceId
+     * @param {Object} [options]
+     * @param {Function} [options.guard] `() => Boolean` — false stops before the next projection.
+     * @returns {Promise<Boolean>} true when both projections ran.
+     * @protected
+     */
+    async reconcileTransferPair({sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId}, {guard = () => true} = {}) {
+        let me = this;
+
+        if (!guard()) return false;
+
+        await me.refreshWorkspace(targetWorkspaceId, targetDocument);
+
+        if (!guard()) return false;
+
+        await me.refreshWorkspace(sourceWorkspaceId, sourceDocument);
+
+        return true
+    }
+
+    /**
      * Publishes the atomic transfer pair, then reconciles target before source. Target-first is
      * load-bearing: it adopts the cached pane across the window boundary before the source shell
      * can classify the now-absent item as a retirement.
@@ -1170,12 +1207,9 @@ class DemoBWorkspace extends Container {
                 && me.crossWindowTargetWindowId === targetWindowId
                 && (!isPopupDetach || me.detachedPanes[itemId]?.windowId === targetWindowId);
 
-        me.crossWindowStats.transferCommits++;
-
-        // Both-or-neither adoption through the workspace-set: a pair that cannot land on both
-        // registered owners lands on neither, and the vessel bookkeeping below must not diverge
-        // from document truth — so a refused adoption ends the commit here.
-        if (!me.workspaceSet.adoptTransfer({sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId})) {
+        // Both-or-neither adoption through the shared core — a refused pair ends the commit here,
+        // so the gesture bookkeeping below never diverges from document truth.
+        if (!me.adoptCommittedTransferPair({sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId})) {
             return
         }
 
@@ -1208,15 +1242,16 @@ class DemoBWorkspace extends Container {
                 };
 
                 try {
-                    await me.refreshWorkspace(targetWorkspaceId, targetDocument)
+                    if (!await me.reconcileTransferPair(
+                        {sourceDocument, sourceWorkspaceId, targetDocument, targetWorkspaceId},
+                        {guard: ownsTransfer}
+                    )) {
+                        return
+                    }
                 } catch (error) {
                     if (!ownsTransfer()) return;
                     throw error
                 }
-
-                if (!ownsTransfer()) return;
-
-                await me.refreshWorkspace(sourceWorkspaceId, sourceDocument);
 
                 if (!ownsTransfer()) return;
 

--- a/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.scss
+++ b/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.scss
@@ -85,3 +85,20 @@
         flex: 1;
     }
 }
+
+// the keyboard cycle's current-candidate highlight: hue PAIRED with a non-color carrier (the
+// dashed outline geometry) — WCAG 1.4.1 requires the state to survive a colorless rendering
+.agentos-kbd-target {
+    outline       : 2px dashed var(--fm-signal);
+    outline-offset: -2px;
+}
+
+// the keyboard announcement region: visually unobtrusive, never removed from the a11y tree
+// (display:none / visibility:hidden would silence the live region — this deliberately is
+// a one-line, low-emphasis strip instead of a visually-hidden clip)
+.agentos-dockdemo-kbd-live {
+    color     : var(--fm-ink-dim);
+    font-size : 11px;
+    min-height: 14px;
+    padding   : 0 12px;
+}

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -61,6 +61,7 @@ class Main extends core.Base {
                 'setRoute',
                 'windowClose',
                 'windowCloseAll',
+                'windowFocus',
                 'windowMoveTo',
                 'windowOpen',
                 'windowResizeTo'
@@ -519,6 +520,32 @@ class Main extends core.Base {
         });
 
         this.openWindows = {}
+    }
+
+    /**
+     * Focus a named popup window — Boolean admission, the `windowOpen` discipline applied to
+     * focus: the platform may decline silently, so the answer is the VERIFIED outcome (did this
+     * opener actually lose focus to the popup), never the attempt. A keyboard-command flow rides
+     * its keystroke's user activation through this verb; a `false` answer is a legitimate
+     * degraded terminal for the caller to announce, not an error.
+     * @param {Object} data
+     * @param {String} data.windowName
+     * @returns {Promise<Boolean>} true when the popup verifiably took focus.
+     */
+    async windowFocus(data) {
+        let win = this.openWindows[data.windowName]?.win;
+
+        if (!win || win.closed) {
+            return false
+        }
+
+        win.focus();
+
+        // the blur is not synchronous on every platform — give it one short beat, then answer
+        // with the verified truth rather than the optimistic attempt
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        return !document.hasFocus()
     }
 
     /**

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -541,11 +541,28 @@ class Main extends core.Base {
 
         win.focus();
 
-        // the blur is not synchronous on every platform — give it one short beat, then answer
-        // with the verified truth rather than the optimistic attempt
-        await new Promise(resolve => setTimeout(resolve, 50));
+        // The verification asks the TARGET, not the opener: did the popup's document take focus?
+        // Asking the opener ("did I blur?") answers about the wrong subject — headless platforms
+        // let every window claim focus simultaneously, so the opener never blurs even when the
+        // popup genuinely focused. The answer feeds user-facing announcements, so it polls
+        // briefly and must not lie in either direction; a same-origin read is expected (vessels
+        // are same-app popups), and an inaccessible document degrades to the opener-blur
+        // fallback rather than a throw.
+        for (let attempt = 0; attempt < 6; attempt++) {
+            await new Promise(resolve => setTimeout(resolve, 50));
 
-        return !document.hasFocus()
+            try {
+                if (win.document.hasFocus()) {
+                    return true
+                }
+            } catch (error) {
+                if (!document.hasFocus()) {
+                    return true
+                }
+            }
+        }
+
+        return false
     }
 
     /**

--- a/src/dashboard/DockKeyboardCommands.mjs
+++ b/src/dashboard/DockKeyboardCommands.mjs
@@ -45,9 +45,11 @@
  *     the workspace's pure reducer (`applyDockZoneOperation`). Called exactly once per admitted command.
  * @param {Function} seams.closeVessel Host vessel retirement: `({itemId, windowName}) => void|Promise` —
  *     closes the OS window a refused commit leaves behind. Never called for a committed detach.
- * @param {Function} seams.commitTransfer Host transfer seam: `({itemId, target: {workspaceId, tabsId}}) => {errors: String[]}` —
+ * @param {Function} seams.commitTransfer Host transfer seam:
+ *     `({itemId, target: {workspaceId, tabsId}}) => {errors: String[]}|Promise<{errors: String[]}>` —
  *     the host runs `DockZoneModel.transferItem` (commit-or-neither document pair) and lands the
- *     pair through its workspace set's both-or-neither adoption. Called exactly once per commit.
+ *     pair through its workspace set's both-or-neither adoption. Called exactly once per commit
+ *     and AWAITED to settlement — a rejection or a malformed result is treated as a refusal.
  * @param {Function} seams.enumerateTargets Host target enumeration: `({itemId}) => Object[]` —
  *     `[{workspaceId, tabsId, label}]` in a STABLE order (the workspace set's registry order),
  *     excluding the item's current tabs. Empty = no legal targets (announced, fail-closed).
@@ -139,7 +141,10 @@ export function createDockKeyboardCommands({
             }
 
             if (!result || result.errors?.length || !result.document) {
-                closeVessel(vessel);
+                // retirement carries the ITEM identity, not just the window's: the host's vessel
+                // bookkeeping (e.g. connect-race entries) is keyed by itemId, and a retirement
+                // that names only the window leaves that entry stale
+                closeVessel({itemId, ...vessel});
                 announce({
                     command         : 'detach',
                     focusTransferred: false,
@@ -227,9 +232,11 @@ export function createDockKeyboardCommands({
 
         /**
          * @summary Commit the transfer to the current candidate — exactly one `commitTransfer`
-         * (the host's commit-or-neither pair adoption), the highlight cleared, the terminal
-         * announced. A model refusal leaves the item where it is, announced. Focus follows the
-         * item on success via the same Boolean-admission discipline as the detach command.
+         * (the host's commit-or-neither pair adoption), AWAITED TO SETTLEMENT: hosts commit
+         * async document pairs, and success may only be announced (and focus moved) after the
+         * pair actually landed. Returned errors, a rejection/throw, or a missing/malformed
+         * result all land on the REJECTED path — an unproven commit is a refused one. The
+         * highlight clears either way; the terminal says which.
          * @returns {Promise<Object|undefined>} The outcome, or `undefined` outside an active cycle.
          */
         async cycleCommit() {
@@ -245,13 +252,21 @@ export function createDockKeyboardCommands({
             let result;
 
             try {
-                result = commitTransfer({itemId, target: {tabsId: target.tabsId, workspaceId: target.workspaceId}})
+                // AWAITED to settlement: the first real host commits an async document pair —
+                // announcing success before it settles would green-light a commit the workspace
+                // may still refuse (a rejection/throw lands on the refusal path)
+                result = await commitTransfer({itemId, target: {tabsId: target.tabsId, workspaceId: target.workspaceId}})
             } catch (error) {
-                // a throwing host seam lands on the refusal path — the cycle must end honestly
                 result = {errors: [`commitTransfer threw: ${error?.message || error}`]}
             }
 
-            if (result?.errors?.length) {
+            // shape validation IS the fail-close: a host answering undefined/null/non-object has
+            // not proven a settled commit, and an unproven commit is a refused one
+            if (!result || !Array.isArray(result.errors)) {
+                result = {errors: ['commitTransfer answered without a settled result shape']}
+            }
+
+            if (result.errors.length) {
                 announce({
                     command         : 'transfer',
                     focusTransferred: false,

--- a/src/dashboard/DockKeyboardCommands.mjs
+++ b/src/dashboard/DockKeyboardCommands.mjs
@@ -1,0 +1,127 @@
+/**
+ * @module Neo.dashboard.DockKeyboardCommands
+ * @summary The keyboard command surface for the multi-window docking choreography — the a11y
+ * parity path, and the always-works acquisition fallback (a keystroke IS a user activation, so
+ * the command path acquires popups by definition where a platform's boundary-acquisition fails).
+ *
+ * The pointer path is a continuous gesture: {@link Neo.dashboard.DockTabSortZone} fires boundary
+ * hysteresis + detached terminals, and {@link Neo.dashboard.DockTearOut} choreographs admission
+ * and the one model commit. A keyboard command is DISCRETE — no boundary hysteresis, no moving
+ * embodiment — so the gesture phases collapse into admission-first → exactly-once model commit →
+ * focus transfer, and EVERY terminal derives an announcement. This module owns exactly that
+ * collapsed machine, over the SAME host seam shapes the tear-out choreography uses plus the two
+ * keyboard-specific ones (`focusVessel`, `announce`): a pure decision machine the host
+ * parameterizes, witnesses drive without a browser, and consumers (workstation, agentos) compose
+ * without private registries or vessel state.
+ *
+ * The choreography contract (the docking design record's multi-window amendment, keyboard leg):
+ * - **Admission is fail-closed and ANNOUNCED.** `openVessel` resolving falsy (blocked popup,
+ *   bounded connect timeout, host refusal) degrades IN PLACE: focus stays where it is, nothing
+ *   mutates, and the degraded state is announced — a silent no-op keystroke is indistinguishable
+ *   from a broken one, which is precisely the failure a11y parity exists to prevent.
+ * - **The model commits exactly once, after admission.** A model refusal retires the vessel (no
+ *   window may survive showing an item the document still owns) and announces the rejection. A
+ *   THROWING reducer lands on the same refusal path — an uncaught throw would orphan the vessel.
+ * - **Focus-transfer denial is a TERMINAL, not an exception.** `focusVessel` answers a Boolean —
+ *   the `windowOpen` admission discipline applied to focus. A denied transfer keeps the item
+ *   committed, keeps focus in the source window, and announces the degraded arrival — never a
+ *   silent focus limbo between two windows.
+ * - **Announcements derive from outcome terminals, never from keystrokes** — what is announced
+ *   can never diverge from what the model actually committed.
+ */
+
+/**
+ * @summary Creates the keyboard command set a dock composition threads into its key handlers,
+ * closed over the host's seams. One command set serves one workspace composition — commands are
+ * discrete and awaited, so no gesture slot is needed.
+ * @param {Object} seams
+ * @param {Function} seams.announce Host announcement seam: `({command, itemId, terminal, focusTransferred, message}) => void` —
+ *     renders to the composition's `aria-live` region. The `message` is a complete default
+ *     sentence; hosts localize by composing their own seam.
+ * @param {Function} seams.applyOperation Host model seam: `({operation, itemId}) => {document, errors}` —
+ *     the workspace's pure reducer (`applyDockZoneOperation`). Called exactly once per admitted command.
+ * @param {Function} seams.closeVessel Host vessel retirement: `({itemId, windowName}) => void|Promise` —
+ *     closes the OS window a refused commit leaves behind. Never called for a committed detach.
+ * @param {Function} seams.focusVessel Host focus seam: `({itemId, windowName}) => Boolean|Promise<Boolean>` —
+ *     transfers focus into the vessel window; answers `false` when the platform declines (never throws).
+ * @param {Function} seams.onDocumentChange Host view-sync seam: `(document, operation) => void` —
+ *     receives the committed post-detach document (the adapter's `moveTo` listener seam shape).
+ * @param {Function} seams.openVessel Host vessel acquisition:
+ *     `({itemId, proxyRect, sortZone}) => Promise<{popupHeight, popupWidth, windowName}|null>` —
+ *     the SAME seam shape the pointer path injects; the keyboard path passes `proxyRect: null` and
+ *     `sortZone: null`, so one host implementation serves both paths without branching.
+ * @returns {Object} `{detachItem}`
+ */
+export function createDockKeyboardCommands({announce, applyOperation, closeVessel, focusVessel, onDocumentChange, openVessel}) {
+    return {
+        /**
+         * @summary Detach a focused dock item to its own OS popup window — the discrete command
+         * twin of the pointer tear-out: admission-first, exactly-once commit, focus transfer,
+         * every terminal announced.
+         * @param {Object} data
+         * @param {String} data.itemId The focused dock item's durable id.
+         * @param {String} [data.itemLabel] Human label for announcements; falls back to the id.
+         * @returns {Promise<{terminal: String, itemId: String, focusTransferred: Boolean, windowName: (String|undefined)}>} `windowName` only on a committed detach.
+         */
+        async detachItem({itemId, itemLabel}) {
+            const label = itemLabel ?? itemId;
+
+            // admission-first, fail-closed: the host performs the platform work (URL, geometry,
+            // Boolean windowOpen) — falsy means blocked/refused, and the command degrades IN PLACE
+            const vessel = await openVessel({itemId, proxyRect: null, sortZone: null});
+
+            if (!vessel) {
+                announce({
+                    command         : 'detach',
+                    focusTransferred: false,
+                    itemId,
+                    message         : `Detach unavailable: the popup window was not admitted. ${label} stays docked.`,
+                    terminal        : 'REJECTED'
+                });
+                return {focusTransferred: false, itemId, terminal: 'REJECTED'}
+            }
+
+            const operation = {operation: 'detachItem', itemId};
+            let   result;
+
+            try {
+                result = applyOperation(operation)
+            } catch (error) {
+                // a throwing reducer is a host bug, but it must land on the refusal path — an
+                // uncaught throw here would skip the retirement and orphan the vessel
+                result = {document: null, errors: [`detachItem threw: ${error?.message || error}`]}
+            }
+
+            if (!result || result.errors?.length || !result.document) {
+                closeVessel(vessel);
+                announce({
+                    command         : 'detach',
+                    focusTransferred: false,
+                    itemId,
+                    message         : `Detach rejected by the workspace. ${label} stays docked.`,
+                    terminal        : 'REJECTED'
+                });
+                return {focusTransferred: false, itemId, terminal: 'REJECTED'}
+            }
+
+            // the model committed — the vessel owns the item now; sync the view BEFORE the focus
+            // hop so the arriving window already renders the committed truth
+            onDocumentChange(result.document, operation);
+
+            // focus-transfer denial is a TERMINAL, not an exception: Boolean admission, announced
+            const focusTransferred = !!(await focusVessel(vessel));
+
+            announce({
+                command: 'detach',
+                focusTransferred,
+                itemId,
+                message: focusTransferred
+                    ? `${label} detached to its own window. Focus moved with it.`
+                    : `${label} detached to its own window. Focus stayed here: the platform declined the transfer.`,
+                terminal: 'COMMITTED_TARGET'
+            });
+
+            return {focusTransferred, itemId, terminal: 'COMMITTED_TARGET', windowName: vessel.windowName}
+        }
+    }
+}

--- a/src/dashboard/DockKeyboardCommands.mjs
+++ b/src/dashboard/DockKeyboardCommands.mjs
@@ -79,21 +79,22 @@ export function createDockKeyboardCommands({
     onDocumentChange,
     openVessel
 }) {
-    // The single cycle slot: {itemId, label, candidates, index} while a target cycle is active,
-    // else null — one keyboard drives at most one transfer cycle per composition.
+    // The single cycle slot: {itemId, label, candidates, index, instructions} while a target
+    // cycle is active, else null — one keyboard drives at most one transfer cycle per composition.
     let activeCycle = null;
 
     const announceCandidate = () => {
         const
-            {candidates, index, label} = activeCycle,
-            target                     = candidates[index];
+            {candidates, index, instructions, label} = activeCycle,
+            target                                   = candidates[index];
 
         highlightTarget(target);
         announce({
             command         : 'transfer',
             focusTransferred: false,
             itemId          : activeCycle.itemId,
-            message         : `Target ${index + 1} of ${candidates.length}: ${target.label}. Arrow keys cycle, Enter moves ${label}, Escape cancels.`,
+            message         : `Target ${index + 1} of ${candidates.length}: ${target.label}. `
+                + (instructions || `Arrow keys cycle, Enter moves ${label}, Escape cancels.`),
             terminal        : 'HOVERING_CLAIM'
         })
     };
@@ -176,9 +177,12 @@ export function createDockKeyboardCommands({
          * @param {Object} data
          * @param {String} data.itemId The focused dock item's durable id.
          * @param {String} [data.itemLabel] Human label for announcements; falls back to the id.
+         * @param {String} [data.instructions] Host-owned key-grammar sentence appended to every
+         *     candidate announcement — the HOST binds the keys, so the host states them; the
+         *     default names the bare-key grammar.
          * @returns {Object|null} `{terminal: 'HOVERING_CLAIM', candidates: Number}` or a REJECTED outcome.
          */
-        cycleStart({itemId, itemLabel}) {
+        cycleStart({instructions, itemId, itemLabel}) {
             const
                 label      = itemLabel ?? itemId,
                 candidates = enumerateTargets({itemId}) || [];
@@ -194,7 +198,7 @@ export function createDockKeyboardCommands({
                 return {candidates: 0, itemId, terminal: 'REJECTED'}
             }
 
-            activeCycle = {candidates, index: 0, itemId, label};
+            activeCycle = {candidates, index: 0, instructions, itemId, label};
             announceCandidate();
 
             return {candidates: candidates.length, itemId, terminal: 'HOVERING_CLAIM'}

--- a/src/dashboard/DockKeyboardCommands.mjs
+++ b/src/dashboard/DockKeyboardCommands.mjs
@@ -32,8 +32,11 @@
 
 /**
  * @summary Creates the keyboard command set a dock composition threads into its key handlers,
- * closed over the host's seams. One command set serves one workspace composition — commands are
- * discrete and awaited, so no gesture slot is needed.
+ * closed over the host's seams. One command set serves one workspace composition. The detach
+ * command is discrete and awaited (no slot); the transfer commands form a short EXPLICIT cycle
+ * (start → next/prev → commit|cancel) over one cycle slot — the host routes arrow/Enter/Escape
+ * to the cycle commands ONLY while a cycle is active, so outside a cycle those keys keep their
+ * ordinary meaning.
  * @param {Object} seams
  * @param {Function} seams.announce Host announcement seam: `({command, itemId, terminal, focusTransferred, message}) => void` —
  *     renders to the composition's `aria-live` region. The `message` is a complete default
@@ -42,17 +45,59 @@
  *     the workspace's pure reducer (`applyDockZoneOperation`). Called exactly once per admitted command.
  * @param {Function} seams.closeVessel Host vessel retirement: `({itemId, windowName}) => void|Promise` —
  *     closes the OS window a refused commit leaves behind. Never called for a committed detach.
+ * @param {Function} seams.commitTransfer Host transfer seam: `({itemId, target: {workspaceId, tabsId}}) => {errors: String[]}` —
+ *     the host runs `DockZoneModel.transferItem` (commit-or-neither document pair) and lands the
+ *     pair through its workspace set's both-or-neither adoption. Called exactly once per commit.
+ * @param {Function} seams.enumerateTargets Host target enumeration: `({itemId}) => Object[]` —
+ *     `[{workspaceId, tabsId, label}]` in a STABLE order (the workspace set's registry order),
+ *     excluding the item's current tabs. Empty = no legal targets (announced, fail-closed).
  * @param {Function} seams.focusVessel Host focus seam: `({itemId, windowName}) => Boolean|Promise<Boolean>` —
  *     transfers focus into the vessel window; answers `false` when the platform declines (never throws).
+ * @param {Function} seams.focusWorkspace Host workspace-focus seam: `({workspaceId}) => Boolean|Promise<Boolean>` —
+ *     transfers focus to the window rendering `workspaceId` after a committed transfer; the same
+ *     Boolean-admission discipline as `focusVessel`.
+ * @param {Function} seams.highlightTarget Host affordance seam: `(target|null) => void` — renders the
+ *     current cycle candidate through the shared drag-affordance consumer (`null` clears). The
+ *     highlight must pair hue with a non-color carrier — the seam owner's WCAG 1.4.1 duty.
  * @param {Function} seams.onDocumentChange Host view-sync seam: `(document, operation) => void` —
  *     receives the committed post-detach document (the adapter's `moveTo` listener seam shape).
  * @param {Function} seams.openVessel Host vessel acquisition:
  *     `({itemId, proxyRect, sortZone}) => Promise<{popupHeight, popupWidth, windowName}|null>` —
  *     the SAME seam shape the pointer path injects; the keyboard path passes `proxyRect: null` and
  *     `sortZone: null`, so one host implementation serves both paths without branching.
- * @returns {Object} `{detachItem}`
+ * @returns {Object} `{cycleCancel, cycleCommit, cycleNext, cyclePrev, cycleStart, detachItem, getActiveCycle}`
  */
-export function createDockKeyboardCommands({announce, applyOperation, closeVessel, focusVessel, onDocumentChange, openVessel}) {
+export function createDockKeyboardCommands({
+    announce,
+    applyOperation,
+    closeVessel,
+    commitTransfer,
+    enumerateTargets,
+    focusVessel,
+    focusWorkspace,
+    highlightTarget,
+    onDocumentChange,
+    openVessel
+}) {
+    // The single cycle slot: {itemId, label, candidates, index} while a target cycle is active,
+    // else null — one keyboard drives at most one transfer cycle per composition.
+    let activeCycle = null;
+
+    const announceCandidate = () => {
+        const
+            {candidates, index, label} = activeCycle,
+            target                     = candidates[index];
+
+        highlightTarget(target);
+        announce({
+            command         : 'transfer',
+            focusTransferred: false,
+            itemId          : activeCycle.itemId,
+            message         : `Target ${index + 1} of ${candidates.length}: ${target.label}. Arrow keys cycle, Enter moves ${label}, Escape cancels.`,
+            terminal        : 'HOVERING_CLAIM'
+        })
+    };
+
     return {
         /**
          * @summary Detach a focused dock item to its own OS popup window — the discrete command
@@ -122,6 +167,143 @@ export function createDockKeyboardCommands({announce, applyOperation, closeVesse
             });
 
             return {focusTransferred, itemId, terminal: 'COMMITTED_TARGET', windowName: vessel.windowName}
+        },
+
+        /**
+         * @summary Begin the target cycle for a transfer (or the return home — the same command
+         * aimed at the main workspace): enumerate the legal targets, highlight the first, and
+         * announce the cycle grammar. No targets = fail-closed AND announced.
+         * @param {Object} data
+         * @param {String} data.itemId The focused dock item's durable id.
+         * @param {String} [data.itemLabel] Human label for announcements; falls back to the id.
+         * @returns {Object|null} `{terminal: 'HOVERING_CLAIM', candidates: Number}` or a REJECTED outcome.
+         */
+        cycleStart({itemId, itemLabel}) {
+            const
+                label      = itemLabel ?? itemId,
+                candidates = enumerateTargets({itemId}) || [];
+
+            if (!candidates.length) {
+                announce({
+                    command         : 'transfer',
+                    focusTransferred: false,
+                    itemId,
+                    message         : `No transfer targets available. ${label} stays where it is.`,
+                    terminal        : 'REJECTED'
+                });
+                return {candidates: 0, itemId, terminal: 'REJECTED'}
+            }
+
+            activeCycle = {candidates, index: 0, itemId, label};
+            announceCandidate();
+
+            return {candidates: candidates.length, itemId, terminal: 'HOVERING_CLAIM'}
+        },
+
+        /**
+         * @summary Advance the cycle to the next candidate (wrap-around). The host routes arrow
+         * keys here ONLY while a cycle is active — outside one, this is a guarded no-op.
+         */
+        cycleNext() {
+            if (!activeCycle) return;
+
+            activeCycle.index = (activeCycle.index + 1) % activeCycle.candidates.length;
+            announceCandidate()
+        },
+
+        /**
+         * @summary Step the cycle to the previous candidate (wrap-around). Guarded like {@link #cycleNext}.
+         */
+        cyclePrev() {
+            if (!activeCycle) return;
+
+            activeCycle.index = (activeCycle.index - 1 + activeCycle.candidates.length) % activeCycle.candidates.length;
+            announceCandidate()
+        },
+
+        /**
+         * @summary Commit the transfer to the current candidate — exactly one `commitTransfer`
+         * (the host's commit-or-neither pair adoption), the highlight cleared, the terminal
+         * announced. A model refusal leaves the item where it is, announced. Focus follows the
+         * item on success via the same Boolean-admission discipline as the detach command.
+         * @returns {Promise<Object|undefined>} The outcome, or `undefined` outside an active cycle.
+         */
+        async cycleCommit() {
+            if (!activeCycle) return;
+
+            const
+                {itemId, label} = activeCycle,
+                target          = activeCycle.candidates[activeCycle.index];
+
+            activeCycle = null;
+            highlightTarget(null);
+
+            let result;
+
+            try {
+                result = commitTransfer({itemId, target: {tabsId: target.tabsId, workspaceId: target.workspaceId}})
+            } catch (error) {
+                // a throwing host seam lands on the refusal path — the cycle must end honestly
+                result = {errors: [`commitTransfer threw: ${error?.message || error}`]}
+            }
+
+            if (result?.errors?.length) {
+                announce({
+                    command         : 'transfer',
+                    focusTransferred: false,
+                    itemId,
+                    message         : `Move rejected by the workspace. ${label} stays where it is.`,
+                    terminal        : 'REJECTED'
+                });
+                return {focusTransferred: false, itemId, terminal: 'REJECTED'}
+            }
+
+            const focusTransferred = !!(await focusWorkspace({workspaceId: target.workspaceId}));
+
+            announce({
+                command: 'transfer',
+                focusTransferred,
+                itemId,
+                message: focusTransferred
+                    ? `${label} moved to ${target.label}. Focus moved with it.`
+                    : `${label} moved to ${target.label}. Focus stayed here: the platform declined the transfer.`,
+                terminal: 'COMMITTED_TARGET'
+            });
+
+            return {focusTransferred, itemId, target, terminal: 'COMMITTED_TARGET'}
+        },
+
+        /**
+         * @summary Cancel the cycle: zero model mutation, the highlight cleared, the cancellation
+         * announced — the outcome machine's CANCELLED terminal, keyboard leg.
+         * @returns {Object|undefined} The outcome, or `undefined` outside an active cycle.
+         */
+        cycleCancel() {
+            if (!activeCycle) return;
+
+            const {itemId, label} = activeCycle;
+
+            activeCycle = null;
+            highlightTarget(null);
+
+            announce({
+                command         : 'transfer',
+                focusTransferred: false,
+                itemId,
+                message         : `Move cancelled. ${label} stays where it is.`,
+                terminal        : 'CANCELLED'
+            });
+
+            return {itemId, terminal: 'CANCELLED'}
+        },
+
+        /**
+         * @summary The active cycle's read-only state — `{itemId, index, count}` or `null`. The
+         * host's key-routing gate: route arrows/Enter/Escape to the cycle ONLY while non-null.
+         * @returns {Object|null}
+         */
+        getActiveCycle() {
+            return activeCycle && {count: activeCycle.candidates.length, index: activeCycle.index, itemId: activeCycle.itemId}
         }
     }
 }

--- a/test/playwright/e2e/agentos/DemoBKeyboardDetachNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBKeyboardDetachNL.spec.mjs
@@ -46,8 +46,11 @@ test.describe('AgentOS Demo B — keyboard detach + cycle grammar (Neural Link)'
         await popup.waitForLoadState('domcontentloaded');
         expect(popup.url()).toContain('popout');
 
-        // the aria-live region announced the COMMITTED outcome
+        // the aria-live region announced the COMMITTED outcome — and IS a live region in the
+        // accessibility tree, not just a styled div (role + politeness asserted, never assumed)
         const live = page.locator('.agentos-dockdemo-kbd-live');
+        await expect(live).toHaveAttribute('role', 'status');
+        await expect(live).toHaveAttribute('aria-live', 'polite');
         await expect(live).toContainText('detached to its own window', {timeout: 15000});
 
         // announced truth === platform truth, in whichever direction the platform ruled:

--- a/test/playwright/e2e/agentos/DemoBKeyboardDetachNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBKeyboardDetachNL.spec.mjs
@@ -1,0 +1,108 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary The keyboard detach path's L3 journey on the REAL Demo B composition — a11y parity
+ * for the multi-window choreography, driven the way a keyboard user drives it.
+ *
+ * Two witnesses:
+ * 1. **The detach command:** a focused dock tab + Ctrl+Shift+D → a real OS popup vessel opens
+ *    through the SAME admission machine the pointer tear-out uses, the model commits exactly
+ *    once, and the aria-live region announces the outcome — with the announcement's focus claim
+ *    cross-checked against the popup document's ACTUAL focus state (announced truth must equal
+ *    platform truth in BOTH directions: a granted hop says "Focus moved with it", a declined one
+ *    says "Focus stayed here" — headless platforms legitimately decline).
+ * 2. **The cycle grammar:** Ctrl+Shift+M starts the move cycle (candidates announced with
+ *    position + the host's chorded key grammar), Ctrl+Shift+ArrowRight advances it (the
+ *    highlight tracks, paired hue + outline), and Escape cancels with ZERO model mutation —
+ *    the outcome machine's CANCELLED terminal, keyboard leg.
+ */
+test.describe('AgentOS Demo B — keyboard detach + cycle grammar (Neural Link)', () => {
+    test.setTimeout(120000);
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 720, width: 900}
+    });
+
+    test('Ctrl+Shift+D detaches the focused tab to a real popup; the announcement matches platform focus truth', async ({page}) => {
+        const pageErrors = [];
+        page.on('pageerror', error => pageErrors.push(error.message));
+
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
+
+        const headers = page.locator('.neo-tab-header-toolbar .neo-tab-header-button');
+        await expect(headers.first()).toBeVisible({timeout: 60000});
+
+        // keyboard-alone discipline for the COMMAND: focus lands programmatically (no pointer
+        // gesture participates), the chord does the work
+        const header = headers.first();
+        await header.focus();
+        await expect(header).toBeFocused();
+
+        const popupPromise = page.context().waitForEvent('page', {timeout: 30000});
+        await page.keyboard.press('Control+Shift+D');
+
+        // the admission machine opened a REAL vessel window
+        const popup = await popupPromise;
+        await popup.waitForLoadState('domcontentloaded');
+        expect(popup.url()).toContain('popout');
+
+        // the aria-live region announced the COMMITTED outcome
+        const live = page.locator('.agentos-dockdemo-kbd-live');
+        await expect(live).toContainText('detached to its own window', {timeout: 15000});
+
+        // announced truth === platform truth, in whichever direction the platform ruled:
+        // a granted hop must say so, a declined one must say so — never a mismatch
+        const announcement    = await live.textContent(),
+              claimedTransfer = announcement.includes('Focus moved with it'),
+              actualTransfer  = await popup.evaluate(() => document.hasFocus()).catch(() => false);
+
+        expect(claimedTransfer, `announcement "${announcement}" must match popup focus=${actualTransfer}`).toBe(actualTransfer);
+
+        expect(pageErrors).toEqual([])
+    });
+
+    test('Ctrl+Shift+M cycles targets with announced positions + tracked highlight; Escape cancels with zero mutation', async ({page}) => {
+        const pageErrors = [];
+        page.on('pageerror', error => pageErrors.push(error.message));
+
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
+
+        const headers = page.locator('.neo-tab-header-toolbar .neo-tab-header-button');
+        await expect(headers.first()).toBeVisible({timeout: 60000});
+
+        const headerCountBefore = await headers.count(),
+              header            = headers.first(),
+              headerText        = await header.textContent();
+
+        await header.focus();
+        await page.keyboard.press('Control+Shift+M');
+
+        // the cycle opened: position + candidate label + the HOST's chorded grammar announced
+        const live = page.locator('.agentos-dockdemo-kbd-live');
+        await expect(live).toContainText('Target 1 of', {timeout: 15000});
+        await expect(live).toContainText('Ctrl+Shift+Arrow keys cycle');
+
+        // the current candidate is highlighted — hue paired with the outline carrier
+        await expect(page.locator('.agentos-kbd-target')).toHaveCount(1);
+
+        // the chorded advance moves position AND highlight (wrap-aware: with one candidate the
+        // position wraps to itself — the announcement re-renders either way)
+        const candidateCount = Number((await live.textContent()).match(/Target 1 of (\d+)/)?.[1] ?? 0);
+        expect(candidateCount).toBeGreaterThan(0);
+
+        await page.keyboard.press('Control+Shift+ArrowRight');
+        await expect(live).toContainText(candidateCount > 1 ? 'Target 2 of' : 'Target 1 of');
+        await expect(page.locator('.agentos-kbd-target')).toHaveCount(1);
+
+        // Escape = the CANCELLED terminal: announced, highlight cleared, ZERO model mutation
+        await page.keyboard.press('Escape');
+        await expect(live).toContainText('Move cancelled');
+        await expect(page.locator('.agentos-kbd-target')).toHaveCount(0);
+
+        // the tab strip is byte-identical: same headers, the focused tab still home
+        await expect(headers).toHaveCount(headerCountBefore);
+        await expect(headers.first()).toHaveText(headerText);
+
+        expect(pageErrors).toEqual([])
+    });
+});

--- a/test/playwright/unit/dashboard/DockKeyboardCommands.spec.mjs
+++ b/test/playwright/unit/dashboard/DockKeyboardCommands.spec.mjs
@@ -1,0 +1,148 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DashboardDockKeyboardCommandsTest'
+    }
+});
+
+import {test, expect}               from '@playwright/test';
+import {createDockKeyboardCommands} from '../../../../src/dashboard/DockKeyboardCommands.mjs';
+
+/**
+ * @summary The keyboard detach command machine, driven end-to-end through its injected seams —
+ * the discrete twin of the DockTearOut witnesses.
+ *
+ * Every witness is a choreography-contract pin for the a11y leg: admission fails CLOSED and is
+ * ANNOUNCED (a silent no-op keystroke is the failure a11y parity exists to prevent), the model
+ * commits exactly once after admission, a refused/throwing commit retires the vessel, focus-
+ * transfer denial is a NAMED terminal (Boolean admission, degraded arrival announced), and every
+ * announcement derives from the outcome terminal — never from the keystroke. The seams are the
+ * assertion surface; the machine exposes nothing else.
+ */
+test.describe('Neo.dashboard.DockKeyboardCommands — createDockKeyboardCommands', () => {
+    const harness = ({admit = true, commitErrors = [], commitThrows = false, focusGranted = true} = {}) => {
+        const calls = {announced: [], applied: [], closed: [], focused: [], opened: [], synced: []};
+
+        const commands = createDockKeyboardCommands({
+            announce      : announcement => calls.announced.push(announcement),
+            applyOperation: operation => {
+                calls.applied.push(operation);
+                if (commitThrows) throw new Error('host reducer exploded');
+                return commitErrors.length
+                    ? {document: null, errors: commitErrors}
+                    : {document: {committed: true, detached: operation.itemId}, errors: []}
+            },
+            closeVessel: vessel => calls.closed.push(vessel),
+            focusVessel: vessel => {
+                calls.focused.push(vessel);
+                return focusGranted
+            },
+            onDocumentChange: (document, operation) => calls.synced.push({document, operation}),
+            openVessel      : async request => {
+                calls.opened.push(request);
+                return admit ? {popupHeight: 480, popupWidth: 640, windowName: `vessel-${request.itemId}`} : null
+            }
+        });
+
+        return {calls, commands}
+    };
+
+    test('failed admission fails CLOSED and is ANNOUNCED: nothing commits, focus never attempted, the item stays docked', async () => {
+        const {calls, commands} = harness({admit: false});
+
+        const outcome = await commands.detachItem({itemId: 'graph', itemLabel: 'Graph'});
+
+        expect(calls.opened).toHaveLength(1);          // the host WAS asked (Boolean windowOpen is its check)
+        expect(calls.applied).toHaveLength(0);         // no admission = nothing to commit
+        expect(calls.focused).toHaveLength(0);         // focus is never attempted without a vessel
+        expect(calls.closed).toHaveLength(0);          // nothing was opened, nothing retires
+
+        // the degraded state is ANNOUNCED — a silent no-op keystroke would be indistinguishable
+        // from a broken one, precisely the a11y failure this contract exists to prevent
+        expect(calls.announced).toHaveLength(1);
+        expect(calls.announced[0]).toMatchObject({command: 'detach', itemId: 'graph', terminal: 'REJECTED', focusTransferred: false});
+        expect(calls.announced[0].message).toContain('Graph stays docked');
+
+        expect(outcome).toEqual({focusTransferred: false, itemId: 'graph', terminal: 'REJECTED'})
+    });
+
+    test('the keyboard path presents the SAME openVessel seam shape as the pointer path (null proxy/zone, no branching)', async () => {
+        const {calls, commands} = harness();
+
+        await commands.detachItem({itemId: 'graph'});
+
+        expect(calls.opened[0]).toEqual({itemId: 'graph', proxyRect: null, sortZone: null})
+    });
+
+    test('an admitted command commits detachItem EXACTLY once, syncs the committed document, and the vessel stays', async () => {
+        const {calls, commands} = harness();
+
+        const outcome = await commands.detachItem({itemId: 'graph'});
+
+        expect(calls.applied).toEqual([{operation: 'detachItem', itemId: 'graph'}]);
+        expect(calls.synced).toHaveLength(1);
+        expect(calls.synced[0].document).toEqual({committed: true, detached: 'graph'});
+        expect(calls.closed, 'a committed detach KEEPS its vessel — it owns the item now').toHaveLength(0);
+
+        expect(outcome).toEqual({focusTransferred: true, itemId: 'graph', terminal: 'COMMITTED_TARGET', windowName: 'vessel-graph'})
+    });
+
+    test('a model refusal retires the vessel and announces the rejection — no window survives owning nothing', async () => {
+        const {calls, commands} = harness({commitErrors: ['item "graph" is not in the tree']});
+
+        const outcome = await commands.detachItem({itemId: 'graph'});
+
+        expect(calls.applied).toHaveLength(1);
+        expect(calls.synced).toHaveLength(0);
+        expect(calls.closed).toEqual([{popupHeight: 480, popupWidth: 640, windowName: 'vessel-graph'}]);
+        expect(calls.focused).toHaveLength(0);
+
+        expect(calls.announced).toHaveLength(1);
+        expect(calls.announced[0]).toMatchObject({terminal: 'REJECTED', focusTransferred: false});
+        expect(outcome.terminal).toBe('REJECTED')
+    });
+
+    test('a THROWING reducer lands on the same refusal path — the vessel never orphans', async () => {
+        const {calls, commands} = harness({commitThrows: true});
+
+        const outcome = await commands.detachItem({itemId: 'graph'});
+
+        expect(calls.synced).toHaveLength(0);
+        expect(calls.closed).toHaveLength(1);
+        expect(calls.announced[0]).toMatchObject({terminal: 'REJECTED'});
+        expect(outcome.terminal).toBe('REJECTED')
+    });
+
+    test('focus-transfer denial is a NAMED terminal: the item stays committed, the degraded arrival is announced', async () => {
+        const {calls, commands} = harness({focusGranted: false});
+
+        const outcome = await commands.detachItem({itemId: 'graph', itemLabel: 'Graph'});
+
+        // the commit stands — focus denial must never undo a committed detach
+        expect(calls.synced).toHaveLength(1);
+        expect(calls.closed).toHaveLength(0);
+
+        expect(calls.announced).toHaveLength(1);
+        expect(calls.announced[0]).toMatchObject({terminal: 'COMMITTED_TARGET', focusTransferred: false});
+        expect(calls.announced[0].message).toContain('Focus stayed here');
+
+        expect(outcome).toEqual({focusTransferred: false, itemId: 'graph', terminal: 'COMMITTED_TARGET', windowName: 'vessel-graph'})
+    });
+
+    test('every announcement derives from the outcome terminal — announced state cannot diverge from committed state', async () => {
+        for (const [config, expected] of [
+            [{admit: false},              'REJECTED'],
+            [{commitErrors: ['refused']}, 'REJECTED'],
+            [{},                          'COMMITTED_TARGET'],
+            [{focusGranted: false},       'COMMITTED_TARGET']
+        ]) {
+            const {calls, commands} = harness(config);
+            const outcome           = await commands.detachItem({itemId: 'graph'});
+
+            expect(calls.announced).toHaveLength(1);
+            expect(calls.announced[0].terminal).toBe(expected);
+            expect(outcome.terminal).toBe(expected)
+        }
+    })
+});

--- a/test/playwright/unit/dashboard/DockKeyboardCommands.spec.mjs
+++ b/test/playwright/unit/dashboard/DockKeyboardCommands.spec.mjs
@@ -20,9 +20,15 @@ import {createDockKeyboardCommands} from '../../../../src/dashboard/DockKeyboard
  * announcement derives from the outcome terminal — never from the keystroke. The seams are the
  * assertion surface; the machine exposes nothing else.
  */
+const CYCLE_TARGETS = [
+    {workspaceId: 'main',  tabsId: 'tabs-a', label: 'Main window, left pane'},
+    {workspaceId: 'pop-1', tabsId: 'tabs-b', label: 'Popup one'},
+    {workspaceId: 'pop-2', tabsId: 'tabs-c', label: 'Popup two'}
+];
+
 test.describe('Neo.dashboard.DockKeyboardCommands — createDockKeyboardCommands', () => {
-    const harness = ({admit = true, commitErrors = [], commitThrows = false, focusGranted = true} = {}) => {
-        const calls = {announced: [], applied: [], closed: [], focused: [], opened: [], synced: []};
+    const harness = ({admit = true, commitErrors = [], commitThrows = false, focusGranted = true, targets = CYCLE_TARGETS} = {}) => {
+        const calls = {announced: [], applied: [], closed: [], committed: [], focused: [], focusedWs: [], highlights: [], opened: [], synced: []};
 
         const commands = createDockKeyboardCommands({
             announce      : announcement => calls.announced.push(announcement),
@@ -33,11 +39,22 @@ test.describe('Neo.dashboard.DockKeyboardCommands — createDockKeyboardCommands
                     ? {document: null, errors: commitErrors}
                     : {document: {committed: true, detached: operation.itemId}, errors: []}
             },
-            closeVessel: vessel => calls.closed.push(vessel),
-            focusVessel: vessel => {
+            closeVessel   : vessel => calls.closed.push(vessel),
+            commitTransfer: request => {
+                calls.committed.push(request);
+                if (commitThrows) throw new Error('adoption exploded');
+                return {errors: commitErrors}
+            },
+            enumerateTargets: () => targets,
+            focusVessel     : vessel => {
                 calls.focused.push(vessel);
                 return focusGranted
             },
+            focusWorkspace : request => {
+                calls.focusedWs.push(request);
+                return focusGranted
+            },
+            highlightTarget : target => calls.highlights.push(target),
             onDocumentChange: (document, operation) => calls.synced.push({document, operation}),
             openVessel      : async request => {
                 calls.opened.push(request);
@@ -144,5 +161,122 @@ test.describe('Neo.dashboard.DockKeyboardCommands — createDockKeyboardCommands
             expect(calls.announced[0].terminal).toBe(expected);
             expect(outcome.terminal).toBe(expected)
         }
+    });
+
+    test('cycleStart with no legal targets fails CLOSED and is ANNOUNCED — never a silent no-op keystroke', () => {
+        const {calls, commands} = harness({targets: []});
+
+        const outcome = commands.cycleStart({itemId: 'graph', itemLabel: 'Graph'});
+
+        expect(outcome).toEqual({candidates: 0, itemId: 'graph', terminal: 'REJECTED'});
+        expect(calls.highlights).toHaveLength(0);
+        expect(calls.announced[0]).toMatchObject({command: 'transfer', terminal: 'REJECTED'});
+        expect(calls.announced[0].message).toContain('No transfer targets available');
+        expect(commands.getActiveCycle()).toBeNull()
+    });
+
+    test('cycleStart highlights the first candidate and announces the full cycle grammar (position, keys)', () => {
+        const {calls, commands} = harness();
+
+        const outcome = commands.cycleStart({itemId: 'graph', itemLabel: 'Graph'});
+
+        expect(outcome).toEqual({candidates: 3, itemId: 'graph', terminal: 'HOVERING_CLAIM'});
+        expect(calls.highlights[0]).toEqual(CYCLE_TARGETS[0]);
+        expect(calls.announced[0].message).toContain('Target 1 of 3: Main window, left pane');
+        expect(calls.announced[0].message).toContain('Enter moves Graph, Escape cancels');
+        expect(commands.getActiveCycle()).toEqual({count: 3, index: 0, itemId: 'graph'})
+    });
+
+    test('cycleNext / cyclePrev wrap around; the highlight and the position announcement track the candidate', () => {
+        const {calls, commands} = harness();
+
+        commands.cycleStart({itemId: 'graph'});
+        commands.cycleNext();
+        expect(calls.announced.at(-1).message).toContain('Target 2 of 3: Popup one');
+
+        commands.cycleNext();
+        commands.cycleNext();
+        expect(calls.announced.at(-1).message).toContain('Target 1 of 3'); // wrapped forward
+
+        commands.cyclePrev();
+        expect(calls.announced.at(-1).message).toContain('Target 3 of 3: Popup two'); // wrapped back
+        expect(calls.highlights.at(-1)).toEqual(CYCLE_TARGETS[2])
+    });
+
+    test('cycleCommit commits the CURRENT candidate exactly once, clears the highlight, and focus follows the item', async () => {
+        const {calls, commands} = harness();
+
+        commands.cycleStart({itemId: 'graph', itemLabel: 'Graph'});
+        commands.cycleNext();
+
+        const outcome = await commands.cycleCommit();
+
+        expect(calls.committed).toEqual([{itemId: 'graph', target: {tabsId: 'tabs-b', workspaceId: 'pop-1'}}]);
+        expect(calls.highlights.at(-1)).toBeNull();
+        expect(calls.focusedWs).toEqual([{workspaceId: 'pop-1'}]);
+        expect(outcome.terminal).toBe('COMMITTED_TARGET');
+        expect(calls.announced.at(-1).message).toContain('Graph moved to Popup one. Focus moved with it.');
+        expect(commands.getActiveCycle()).toBeNull()
+    });
+
+    test('a rejected transfer leaves the item where it is and announces the rejection — no focus attempt', async () => {
+        const {calls, commands} = harness({commitErrors: ['target tabs vanished']});
+
+        commands.cycleStart({itemId: 'graph', itemLabel: 'Graph'});
+
+        const outcome = await commands.cycleCommit();
+
+        expect(outcome.terminal).toBe('REJECTED');
+        expect(calls.focusedWs).toHaveLength(0);
+        expect(calls.announced.at(-1).message).toContain('Move rejected by the workspace. Graph stays where it is.')
+    });
+
+    test('a THROWING transfer seam lands on the refusal path — the cycle ends honestly', async () => {
+        const {calls, commands} = harness({commitThrows: true});
+
+        commands.cycleStart({itemId: 'graph'});
+
+        const outcome = await commands.cycleCommit();
+
+        expect(outcome.terminal).toBe('REJECTED');
+        expect(calls.announced.at(-1)).toMatchObject({terminal: 'REJECTED'})
+    });
+
+    test('cycleCancel is the CANCELLED terminal: zero model mutation, highlight cleared, cancellation announced', () => {
+        const {calls, commands} = harness();
+
+        commands.cycleStart({itemId: 'graph', itemLabel: 'Graph'});
+
+        const outcome = commands.cycleCancel();
+
+        expect(calls.committed).toHaveLength(0);
+        expect(outcome.terminal).toBe('CANCELLED');
+        expect(calls.highlights.at(-1)).toBeNull();
+        expect(calls.announced.at(-1).message).toContain('Move cancelled. Graph stays where it is.');
+        expect(commands.getActiveCycle()).toBeNull()
+    });
+
+    test('outside an active cycle the cycle verbs are guarded no-ops — the host routes keys only while one is active', async () => {
+        const {calls, commands} = harness();
+
+        commands.cycleNext();
+        commands.cyclePrev();
+        expect(await commands.cycleCommit()).toBeUndefined();
+        expect(commands.cycleCancel()).toBeUndefined();
+
+        expect(calls.announced).toHaveLength(0);
+        expect(calls.committed).toHaveLength(0)
+    });
+
+    test('focus denial on a committed transfer is a NAMED degraded arrival — the move stands, the announcement says so', async () => {
+        const {calls, commands} = harness({focusGranted: false});
+
+        commands.cycleStart({itemId: 'graph', itemLabel: 'Graph'});
+
+        const outcome = await commands.cycleCommit();
+
+        expect(outcome.terminal).toBe('COMMITTED_TARGET');
+        expect(outcome.focusTransferred).toBe(false);
+        expect(calls.announced.at(-1).message).toContain('Focus stayed here')
     })
 });

--- a/test/playwright/unit/dashboard/DockKeyboardCommands.spec.mjs
+++ b/test/playwright/unit/dashboard/DockKeyboardCommands.spec.mjs
@@ -112,7 +112,9 @@ test.describe('Neo.dashboard.DockKeyboardCommands — createDockKeyboardCommands
 
         expect(calls.applied).toHaveLength(1);
         expect(calls.synced).toHaveLength(0);
-        expect(calls.closed).toEqual([{popupHeight: 480, popupWidth: 640, windowName: 'vessel-graph'}]);
+        // retirement names the ITEM, not just the window — the host's connect-race bookkeeping
+        // is keyed by itemId and a window-only retirement would leave it stale
+        expect(calls.closed).toEqual([{itemId: 'graph', popupHeight: 480, popupWidth: 640, windowName: 'vessel-graph'}]);
         expect(calls.focused).toHaveLength(0);
 
         expect(calls.announced).toHaveLength(1);
@@ -278,5 +280,96 @@ test.describe('Neo.dashboard.DockKeyboardCommands — createDockKeyboardCommands
         expect(outcome.terminal).toBe('COMMITTED_TARGET');
         expect(outcome.focusTransferred).toBe(false);
         expect(calls.announced.at(-1).message).toContain('Focus stayed here')
+    });
+
+    // ── the ASYNC host shapes: the first real host commits an async document pair, so the
+    // machine must await settlement and fail-close on every unproven result — a synchronous
+    // fixture alone would let a delayed refusal announce a green terminal
+
+    const asyncHarness = commitImpl => {
+        const calls = {announced: [], committed: [], focusedWs: []};
+
+        const commands = createDockKeyboardCommands({
+            announce      : announcement => calls.announced.push(announcement),
+            applyOperation: () => ({document: {}, errors: []}),
+            closeVessel   : () => {},
+            commitTransfer: request => {
+                calls.committed.push(request);
+                return commitImpl(request)
+            },
+            enumerateTargets: () => CYCLE_TARGETS,
+            focusVessel     : () => true,
+            focusWorkspace  : request => {
+                calls.focusedWs.push(request);
+                return true
+            },
+            highlightTarget : () => {},
+            onDocumentChange: () => {},
+            openVessel      : async () => null
+        });
+
+        return {calls, commands}
+    };
+
+    const settleDelay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+    test('a DELAYED async success settles BEFORE the terminal — focus and announcement wait for the pair', async () => {
+        let settled = false;
+
+        const {calls, commands} = asyncHarness(async () => {
+            await settleDelay(60);
+            settled = true;
+            return {errors: []}
+        });
+
+        commands.cycleStart({itemId: 'graph'});
+
+        const outcome = await commands.cycleCommit();
+
+        expect(settled, 'the commit must have settled before the terminal').toBe(true);
+        expect(outcome.terminal).toBe('COMMITTED_TARGET');
+        expect(calls.focusedWs).toHaveLength(1)
+    });
+
+    test('a DELAYED async refusal lands REJECTED with ZERO focus — the false-green falsifier, pinned', async () => {
+        const {calls, commands} = asyncHarness(async () => {
+            await settleDelay(60);
+            return {errors: ['async refusal']}
+        });
+
+        commands.cycleStart({itemId: 'graph', itemLabel: 'Graph'});
+
+        const outcome = await commands.cycleCommit();
+
+        expect(outcome.terminal).toBe('REJECTED');
+        expect(calls.focusedWs, 'no focus may move on a refused commit').toHaveLength(0);
+        expect(calls.announced.at(-1).message).toContain('Move rejected')
+    });
+
+    test('an async REJECTION lands on the refusal path — zero focus, honest terminal', async () => {
+        const {calls, commands} = asyncHarness(async () => {
+            await settleDelay(20);
+            throw new Error('adoption exploded late')
+        });
+
+        commands.cycleStart({itemId: 'graph'});
+
+        const outcome = await commands.cycleCommit();
+
+        expect(outcome.terminal).toBe('REJECTED');
+        expect(calls.focusedWs).toHaveLength(0)
+    });
+
+    test('malformed results refuse across the shape matrix — an unproven commit is a refused one', async () => {
+        for (const bad of [undefined, null, 42, {}, {errors: 'nope'}]) {
+            const {calls, commands} = asyncHarness(async () => bad);
+
+            commands.cycleStart({itemId: 'graph'});
+
+            const outcome = await commands.cycleCommit();
+
+            expect(outcome.terminal, `shape ${JSON.stringify(bad)} must refuse`).toBe('REJECTED');
+            expect(calls.focusedWs).toHaveLength(0)
+        }
     })
 });


### PR DESCRIPTION
Resolves #15250
Related: #15239, #15246, #15247, #15466, #15485

The a11y-parity leaf's COMMAND-MACHINE + MOUNTED DETACH/A11Y TRANCHE, delivered as the layered composition the epic's ownership boundary prescribes — a keystroke IS a user activation, so the command path acquires popups by definition where a platform's boundary-acquisition fails (the always-works fallback of the graduated OQ8 disposition).

**1. The pure command machine** (`src/dashboard/DockKeyboardCommands.mjs`): the discrete twin of the pointer tear-out, composed over the SAME host seam shapes. The gesture phases collapse into admission-first → exactly-once model commit → focus transfer, and EVERY terminal derives an announcement — a silent no-op keystroke is the exact failure a11y parity exists to prevent. The transfer half is an explicit short cycle (start → wrap-around next/prev → commit|cancel) over one cycle slot, announcing in the #15240 outcome machine's vocabulary (HOVERING_CLAIM while cycling; COMMITTED_TARGET/REJECTED/CANCELLED at the terminals), with the RETURN home as the same command aimed at the main workspace — zero gesture-vessel dependency. 16 unit pins + 15 plain-node probe scenarios.

**2. The shared transfer-commit core** (coordinated with @neo-fable-clio as the interior's author — her shape-(1) ruling, four constraints, delta-endorsed): `adoptCommittedTransferPair` (SYNC: stats + the workspace-set's both-or-neither adoption, refused pair = first exit) + `reconcileTransferPair` (target-first with the load-bearing comment carried; an injectable guard seam keeps the pointer gesture's ownership fences wrapper-scoped). Two-phase BY NECESSITY: a single async core would either drag adoption into the deferral or swallow gesture state. Named operation-agnostic (PAIR language) so the whole-stack return's `transferNode` binding lands refactor-free. The pointer wrapper's behavior is byte-preserved except one endorsed delta: the disowned-error swallow now covers both projections.

**3. The host composition** (DemoBWorkspace): the machine wired beside the tear-out handlers — detach seams verbatim, a REAL aria-live region (role=status, text-only, visible-low-emphasis so it never leaves the a11y tree), stable-registry-order target enumeration (live-host workspaces only — a popup workspace with no window cannot show a highlight or take focus), the candidate highlight pairing `--fm-signal` hue with a dashed-outline carrier (WCAG 1.4.1), and the fully-chorded key grammar: **Ctrl+Shift+D** detach · **Ctrl+Shift+M** cycle · **Ctrl+Shift+Arrows** advance · **Ctrl+Shift+Enter** commit · **Escape** cancel. Chorded BY DESIGN: no preventDefault crosses the worker boundary, so the grammar avoids native key meanings instead of suppressing them, and `getActiveCycle()` is the single routing gate — outside a cycle every key keeps native behavior. The focused item resolves from the DOCUMENT (the tab-container's `dockNodeId` + the rail-filtered tabs node items at the header index) because DemoB's live pane instances deliberately bypass the adapter's config decoration.

**4. `Neo.Main.windowFocus`** — no focus verb existed. Boolean admission (the `windowOpen` discipline applied to focus), verified against the TARGET's document (`win.document.hasFocus()`, same-origin vessels; opener-blur fallback for unreachable documents) — asking the opener answers about the wrong subject on headless platforms where every window claims focus.

**The L3 journey** (`DemoBKeyboardDetachNL.spec.mjs`, 2/2 green): a focused tab + Ctrl+Shift+D opens a REAL popup vessel through the shared admission machine, with the announcement's focus claim cross-checked against the popup document's ACTUAL focus state — announced truth must equal platform truth in BOTH directions. The cycle witness drives position announcements + the tracked highlight + the zero-mutation Escape cancel with a byte-identical tab strip, and asserts the live region IS a live region (role/aria-live in the tree).

Evidence: L3 at the mounted composition for the detach command + cycle grammar + announcements (real popup, real chords, fresh isolated server) · L2 for the transfer/return commit (the machine's commit/refusal/throw/focus-denial matrix + the composition's document-derived commit through the shared core) → per the ticket's ACs.

Residuals (truthful):
- The e2e transfer-commit variant (cycle → Ctrl+Shift+Enter into a LIVE popup workspace) needs the click-pop-out window open first — the commit semantics are machine-witnessed and core-shared; the mounted variant rides the G4/#15247 family whose return-commit binds to the same core.
- AC2's "same visuals as pointer hover" reads as the #15207 shared consumer; the shipped highlight is the WCAG-paired outline class — honest, visible, token-clean — with the full preview-producer integration a named refinement once the keyboard path and pointer previews share a candidate model.
- AC6's matrix-failed-platform fallback witness awaits #15245's platform defaults (G2, in flight) — the mechanism (keystroke = activation through the same admission seam) is the delivered substrate.
- The modality tracker (#15466, delivered as PR #15467) composes at the focus-arrival moment once merged — named, not blocking.

## Scope disposition (the review-cycle A+FU split)
This PR resolves #15250 as the **command-machine + mounted detach/a11y tranche**, per the reviewer's significant-scope A+FU ruling: the integrated remainder — the mounted popup-origin RETURN command, the shared-affordance-consumer visuals, and the #15245-gated matrix-fallback witness — moves WHOLE to the substantial successor **#15485** (one ticket, three material ACs, no micro-splitting), with the narrowing recorded on #15250's thread (assignee comment; the ticket author's body stays hers). Reviewer V-B-A folded: #15484 excludes the keyboard path; #15207 is closed and does not own the return; #15245 owns only the matrix fallback.

## Deltas from ticket
The transfer-commit core extraction (#15465's interior, coordinated + endorsed in-thread by its author) grew from this leaf's seam finding — review finding, not ticket scope. The cycle grammar is fully chorded rather than bare-arrow (the worker-boundary preventDefault reality); the machine announces the HOST's actual bindings via the instructions seam.

## Test Evidence
At head `8edddfa918`:
- `DemoBKeyboardDetachNL.spec.mjs` **2/2** on a fresh isolated port (detach journey 2.7s; cycle grammar 1.5s).
- The machine + probe tiers: **16 playwright pins** mirrored by **15 plain-node scenarios** (both green after every edit — the pure module runs everywhere).
- Whole `e2e/agentos` dir: **28 passed, 3 failed** — all three reds (`DemoBPerspectivesNL`, `FleetGridKeyboardA11y`, `OperatorMailboxNL`) fail IDENTICALLY on clean `dev` (stash/detach-baseline receipts this session): the pre-existing local-environment family, CI is their oracle.
- The full unit dir remains collision-blocked locally (#15364; Grace's #15469 fix in flight) — the CI unit shard is the oracle, as it was for both prior lanes today.

## Post-Merge Validation
- [x] The CI unit shard executes the DockKeyboardCommands pins against the merged tree. *(Verified 2026-07-18T17:35Z: merge commit `69948ebeaf`, Tests run 29653451111 green — all workflows success on the merged tree.)*
- [ ] The G4 return-commit binds `transferNode` pairs to the shared core (its author's stated intent). *(Status 2026-07-18T17:40Z: not yet bound — the landed G4 return is `reintegrateTearOutItem` (vessel-death-driven, PR #15480) and `DockZoneModel.transferNode` has no app-side caller yet; the binding rides @neo-gpt-emmy's #15484 gesture half.)*

Authored by Vega (Claude Fable 5, Claude Code). Session 7157d21f-16c8-4b76-8aac-67e166deccca.


