### PR TITLE
feat(memory-core): tenant-scoped community source registration (#15150)

### DIFF
--- a/ai/services/memory-core/SourceRegistryService.mjs
+++ b/ai/services/memory-core/SourceRegistryService.mjs
@@ -61,7 +61,18 @@ class SourceRegistryService extends Base {
          * @summary SQLite connection to the Memory Core database (dedicated table, not the graph).
          * @protected
          */
-        db: null
+        db: null,
+        /**
+         * @member {String|null} localSubjectId=null
+         * @summary The subject an explicit local-single-user deployment equates with its tenant.
+         *
+         * Bound ONCE at the trusted server/deployment boundary (startup injection) — never supplied
+         * by a caller, and never defaulted. `null` means this process is not an explicit
+         * local-single-user deployment, so no caller holds source-admin authority and control-plane
+         * mutation fails closed. Hosted operator-authorized provisioning is a separate, deferred
+         * authority; an ordinary authenticated hosted subject is NOT a source admin.
+         */
+        localSubjectId: null
     }
 
     /**
@@ -133,28 +144,45 @@ class SourceRegistryService extends Base {
     }
 
     /**
-     * @summary Resolves the server-authoritative tenant key. NEVER caller-supplied.
+     * @summary Resolves the READ-scope tenant key. NEVER caller-supplied.
      *
      * The isolation key is the request-context `userId` (bound at the auth boundary via
-     * `RequestContextService.run`, per its contract `getUserId()` is the tenant-isolation key). In an
-     * explicit local-single-user bootstrap the caller opts in with `allowLocalBootstrap` AND the
-     * request context still resolves no hosted tenant; only then does the local subject stand in.
-     * Hosted or ambiguous contexts with no resolved tenant return `null`, so callers fail closed.
-     * @param {Object}  [options]
-     * @param {Boolean} [options.allowLocalBootstrap=false] Opt into the explicit local-single-user path.
-     * @param {String}  [options.localSubjectId] The explicit local subject to equate with the tenant.
+     * `RequestContextService.run`; per its contract `getUserId()` is the tenant-isolation key). With
+     * no request context, an explicit local-single-user deployment reads as its injected subject.
+     * Anything else resolves `null`, so reads fail closed rather than spanning tenants.
+     *
+     * Read scope is deliberately wider than mutation authority: any authenticated subject may read
+     * its own registrations, but reading is not source-admin authority — see {@link #resolveAdminTenantId}.
      * @returns {String|null}
      */
-    resolveTenantId({allowLocalBootstrap = false, localSubjectId} = {}) {
-        const tenantId = RequestContextService.getUserId?.();
+    resolveTenantId() {
+        return RequestContextService.getUserId?.() || this.localSubjectId || null
+    }
 
-        if (tenantId) return tenantId;
+    /**
+     * @summary Resolves the tenant key for a CONTROL-PLANE mutation, or throws.
+     *
+     * Source-admin authority is a deployment property, not a session property. Only an explicit
+     * local-single-user deployment — whose subject the server injected at startup — may register or
+     * transition sources today. An ordinary authenticated hosted subject is NOT a source admin: that
+     * authority belongs to an operator-authorized hosted provisioning path which does not exist yet,
+     * so this fails closed with a stable, distinguishable error instead of silently self-serving.
+     * @returns {String} The server-owned tenant key for the mutation.
+     * @throws {Error} `SOURCE_REGISTRATION_AUTHORITY_UNAVAILABLE` for a hosted subject (deferred authority).
+     * @throws {Error} `SOURCE_REGISTRATION_NO_TENANT` when no deployment authority resolves at all.
+     */
+    resolveAdminTenantId() {
+        const {localSubjectId} = this;
 
-        if (allowLocalBootstrap && localSubjectId) {
-            return localSubjectId;
+        if (!localSubjectId) {
+            // A hosted subject is authenticated but not a source admin; distinguish it from the
+            // no-authority case so callers can surface the right operator-facing message.
+            throw new Error(RequestContextService.getUserId?.()
+                ? 'SOURCE_REGISTRATION_AUTHORITY_UNAVAILABLE'
+                : 'SOURCE_REGISTRATION_NO_TENANT')
         }
 
-        return null;
+        return localSubjectId
     }
 
     /**
@@ -172,18 +200,12 @@ class SourceRegistryService extends Base {
      * @param {String}  [data.displayLocator]
      * @param {String}  [data.grantRef]
      * @param {Object}  [data.providerCapabilities]
-     * @param {Object}  [context]
-     * @param {Boolean} [context.allowLocalBootstrap=false]
-     * @param {String}  [context.localSubjectId]
      * @returns {Object} The stored registration row (camelCase).
-     * @throws {Error} `SOURCE_REGISTRATION_NO_TENANT` when no server tenant resolves (fail closed).
+     * @throws {Error} `SOURCE_REGISTRATION_AUTHORITY_UNAVAILABLE` | `SOURCE_REGISTRATION_NO_TENANT` —
+     * registration is a control-plane mutation, so it requires deployment-bound source-admin authority.
      */
-    register(data, context = {}) {
-        const tenantId = this.resolveTenantId(context);
-
-        if (!tenantId) {
-            throw new Error('SOURCE_REGISTRATION_NO_TENANT');
-        }
+    register(data) {
+        const tenantId = this.resolveAdminTenantId();
 
         const
             {provider, canonicalProviderHost, resourceKind, providerResourceId, displayLocator = null, grantRef = null, providerCapabilities = null} = data,
@@ -199,7 +221,7 @@ class SourceRegistryService extends Base {
                  WHERE tenant_id = ? AND source_instance_id = ?`
             ).run(displayLocator, grantRef, now, tenantId, existing.source_instance_id);
 
-            return this.getRegistration(existing.source_instance_id, context);
+            return this.getRegistration(existing.source_instance_id);
         }
 
         const sourceInstanceId = crypto.randomUUID();
@@ -217,18 +239,17 @@ class SourceRegistryService extends Base {
             now, now
         );
 
-        return this.getRegistration(sourceInstanceId, context);
+        return this.getRegistration(sourceInstanceId);
     }
 
     /**
-     * Loads one registration, always scoped by the resolved server tenant + the source id, so a
+     * Loads one registration, always scoped by the resolved read tenant + the source id, so a
      * caller can never read another tenant's row (AC4). Returns `null` when absent for this tenant.
      * @param {String} sourceInstanceId
-     * @param {Object} [context]
      * @returns {Object|null}
      */
-    getRegistration(sourceInstanceId, context = {}) {
-        const tenantId = this.resolveTenantId(context);
+    getRegistration(sourceInstanceId) {
+        const tenantId = this.resolveTenantId();
 
         if (!tenantId) return null;
 
@@ -240,47 +261,49 @@ class SourceRegistryService extends Base {
     }
 
     /**
-     * @summary Advances a registration's lifecycle through a validated transition, epoch-fenced.
+     * @summary Advances a registration's lifecycle as one compare-and-swap against the control
+     * generation the caller observed — the stale-writer fence.
      *
-     * Rejects any transition not permitted by {@link LIFECYCLE_TRANSITIONS} (AC2). Entering
-     * `PROVISIONED` mints a strictly higher `registration_epoch`, fencing any connector still holding
-     * the prior epoch (AC2/AC8). All work is scoped by `(tenant_id, source_instance_id)`.
+     * A read-then-write transition is not a fence: between the read and the write another actor can
+     * revoke, and an unconditional UPDATE would silently resurrect the superseded state. So the
+     * caller must present the `(expectedState, expectedEpoch)` it observed, and that generation joins
+     * tenant + source in the UPDATE predicate, making the whole transition a single atomic statement.
+     * A superseded writer matches zero rows and fails with `SOURCE_REGISTRATION_STALE_CONTROL` instead
+     * of overwriting newer truth. Entering `PROVISIONED` mints a strictly higher epoch, so a retry
+     * holding pre-revoke authority can never traverse `REVOKED -> PROVISIONED -> ACTIVE` (AC2/AC8).
      * @param {String} sourceInstanceId
      * @param {String} toState One of REQUESTED|PROVISIONED|ACTIVE|REVOKED.
-     * @param {Object} [context]
+     * @param {Object} generation The control generation the caller observed.
+     * @param {String} generation.expectedState
+     * @param {Number} generation.expectedEpoch
      * @returns {Object} The updated registration row.
-     * @throws {Error} `SOURCE_REGISTRATION_NO_TENANT` | `SOURCE_REGISTRATION_NOT_FOUND` | `SOURCE_REGISTRATION_INVALID_TRANSITION`.
+     * @throws {Error} `SOURCE_REGISTRATION_AUTHORITY_UNAVAILABLE` | `SOURCE_REGISTRATION_NO_TENANT` |
+     * `SOURCE_REGISTRATION_CONTROL_GENERATION_REQUIRED` | `SOURCE_REGISTRATION_INVALID_TRANSITION` |
+     * `SOURCE_REGISTRATION_STALE_CONTROL`.
      */
-    transitionLifecycle(sourceInstanceId, toState, context = {}) {
-        const tenantId = this.resolveTenantId(context);
+    transitionLifecycle(sourceInstanceId, toState, {expectedState, expectedEpoch} = {}) {
+        const tenantId = this.resolveAdminTenantId();
 
-        if (!tenantId) {
-            throw new Error('SOURCE_REGISTRATION_NO_TENANT');
+        if (!expectedState || !Number.isInteger(expectedEpoch)) {
+            throw new Error('SOURCE_REGISTRATION_CONTROL_GENERATION_REQUIRED');
         }
 
-        const current = this.db.prepare(
-            `SELECT lifecycle_state, registration_epoch FROM mc_source_registration
-             WHERE tenant_id = ? AND source_instance_id = ?`
-        ).get(tenantId, sourceInstanceId);
-
-        if (!current) {
-            throw new Error('SOURCE_REGISTRATION_NOT_FOUND');
-        }
-
-        if (!LIFECYCLE_TRANSITIONS[current.lifecycle_state]?.includes(toState)) {
+        if (!LIFECYCLE_TRANSITIONS[expectedState]?.includes(toState)) {
             throw new Error('SOURCE_REGISTRATION_INVALID_TRANSITION');
         }
 
-        const nextEpoch = EPOCH_ADVANCING_STATES.has(toState)
-            ? current.registration_epoch + 1
-            : current.registration_epoch;
+        const
+            nextEpoch = EPOCH_ADVANCING_STATES.has(toState) ? expectedEpoch + 1 : expectedEpoch,
+            result    = this.db.prepare(
+                `UPDATE mc_source_registration SET lifecycle_state = ?, registration_epoch = ?, updated_at = ?
+                 WHERE tenant_id = ? AND source_instance_id = ? AND lifecycle_state = ? AND registration_epoch = ?`
+            ).run(toState, nextEpoch, Date.now(), tenantId, sourceInstanceId, expectedState, expectedEpoch);
 
-        this.db.prepare(
-            `UPDATE mc_source_registration SET lifecycle_state = ?, registration_epoch = ?, updated_at = ?
-             WHERE tenant_id = ? AND source_instance_id = ?`
-        ).run(toState, nextEpoch, Date.now(), tenantId, sourceInstanceId);
+        if (result.changes === 0) {
+            throw new Error('SOURCE_REGISTRATION_STALE_CONTROL');
+        }
 
-        return this.getRegistration(sourceInstanceId, context);
+        return this.getRegistration(sourceInstanceId);
     }
 
     /**
@@ -288,11 +311,10 @@ class SourceRegistryService extends Base {
      * current server-owned state (AC3/AC8). A stale or revoked epoch can never admit.
      * @param {String} sourceInstanceId
      * @param {Number} submittedEpoch
-     * @param {Object} [context]
      * @returns {Boolean}
      */
-    canAdmit(sourceInstanceId, submittedEpoch, context = {}) {
-        const registration = this.getRegistration(sourceInstanceId, context);
+    canAdmit(sourceInstanceId, submittedEpoch) {
+        const registration = this.getRegistration(sourceInstanceId);
 
         return !!registration
             && registration.lifecycleState   === 'ACTIVE'

--- a/ai/services/memory-core/SourceRegistryService.mjs
+++ b/ai/services/memory-core/SourceRegistryService.mjs
@@ -156,7 +156,7 @@ class SourceRegistryService extends Base {
      * @returns {String|null}
      */
     resolveTenantId() {
-        return RequestContextService.getUserId?.() || this.localSubjectId || null
+        return RequestContextService.getUserId() || this.localSubjectId || null
     }
 
     /**
@@ -177,7 +177,7 @@ class SourceRegistryService extends Base {
         if (!localSubjectId) {
             // A hosted subject is authenticated but not a source admin; distinguish it from the
             // no-authority case so callers can surface the right operator-facing message.
-            throw new Error(RequestContextService.getUserId?.()
+            throw new Error(RequestContextService.getUserId()
                 ? 'SOURCE_REGISTRATION_AUTHORITY_UNAVAILABLE'
                 : 'SOURCE_REGISTRATION_NO_TENANT')
         }
@@ -189,9 +189,10 @@ class SourceRegistryService extends Base {
      * @summary Registers (or idempotently returns) a neutral source identity in the REQUESTED state.
      *
      * Idempotent on the tenant-private provider identity `(host, resourceKind, providerResourceId)`:
-     * a repeat call returns the existing `sourceInstanceId` and updates only the mutable
-     * `display_locator` (rename), so identity survives rename and grant rotation (AC1). No secret is
-     * stored — `grantRef` is a non-secret binding; `credentialRef` never enters this table (AC5).
+     * a repeat call returns the existing `sourceInstanceId` and refreshes the two mutable bindings —
+     * `display_locator` (rename) and `grant_ref` (grant rotation) — so durable identity survives both
+     * (AC1). No secret is stored: `grantRef` is a non-secret binding and `credentialRef` never enters
+     * this table (AC5).
      * @param {Object}  data
      * @param {String}  data.provider
      * @param {String}  data.canonicalProviderHost

--- a/ai/services/memory-core/SourceRegistryService.mjs
+++ b/ai/services/memory-core/SourceRegistryService.mjs
@@ -1,0 +1,328 @@
+import fs                    from 'fs-extra';
+import path                  from 'path';
+import crypto                from 'crypto';
+import Base                  from '../../../src/core/Base.mjs';
+import config                from '../../mcp/server/memory-core/config.mjs';
+import logger                from '../../mcp/server/memory-core/logger.mjs';
+import RequestContextService from '../../mcp/server/shared/services/RequestContextService.mjs';
+
+/**
+ * @summary The neutral source-registration lifecycle transitions Memory Core owns.
+ *
+ * Only an `ACTIVE` registration whose submitted `registrationEpoch` matches server-owned state may
+ * admit a batch. Reprovisioning (`REVOKED -> PROVISIONED`) and each fresh provision bump the epoch,
+ * fencing stale connectors WITHOUT changing the durable `sourceInstanceId` FK. There is no direct
+ * path back to `ACTIVE` from `REVOKED`: a revoked source must be re-provisioned (new epoch) first,
+ * which is what makes a crash/retry unable to reactivate a revoked or stale epoch (AC8).
+ * @member {Object<String, String[]>}
+ */
+const LIFECYCLE_TRANSITIONS = {
+    REQUESTED  : ['PROVISIONED'],
+    PROVISIONED: ['ACTIVE', 'REVOKED'],
+    ACTIVE     : ['REVOKED'],
+    REVOKED    : ['PROVISIONED']
+};
+
+/**
+ * @summary States whose entry mints a fresh (higher) registrationEpoch, so any connector holding a
+ * prior epoch is fenced. Entering `PROVISIONED` is the only epoch-advancing transition.
+ * @member {Set<String>}
+ */
+const EPOCH_ADVANCING_STATES = new Set(['PROVISIONED']);
+
+/**
+ * @summary Server-authoritative, tenant-scoped registry of neutral community source identities.
+ *
+ * This is a dedicated Memory-Core operational table — NOT the Native Edge Graph, NOT the Knowledge
+ * Base `SourceRegistry`, and NOT AiConfig — source registrations are operational records, not
+ * configuration. Because GraphService RLS does not protect new tables, **every** read and write re-applies a server-authoritative
+ * `(tenant_id, source_instance_id)` (or `(tenant_id, provider identity)`) predicate in-query. The
+ * `tenantId` is resolved server-side from the request context and is never caller-supplied.
+ *
+ * @class Neo.ai.services.memory-core.SourceRegistryService
+ * @extends Neo.core.Base
+ * @singleton
+ * @see learn/agentos/decisions/0036-durable-community-activity-authority.md
+ */
+class SourceRegistryService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.memory-core.SourceRegistryService'
+         * @protected
+         */
+        className: 'Neo.ai.services.memory-core.SourceRegistryService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * @member {Object|null} db=null
+         * @summary SQLite connection to the Memory Core database (dedicated table, not the graph).
+         * @protected
+         */
+        db: null
+    }
+
+    /**
+     * Opens the SQLite connection and ensures the dedicated registration schema.
+     * @returns {Promise<void>}
+     */
+    async initAsync() {
+        await super.initAsync();
+
+        if (this.db) return;
+
+        try {
+            const dbPath = config.storagePaths.graph;
+
+            if (!dbPath) {
+                logger.warn('[SourceRegistryService] storagePaths.graph not configured. Registry disabled.');
+                return;
+            }
+
+            if (dbPath !== ':memory:') {
+                await fs.ensureDir(path.dirname(dbPath));
+            }
+
+            const Database = (await import('better-sqlite3')).default;
+
+            this.db = new Database(dbPath, {verbose: null});
+
+            if (dbPath !== ':memory:') {
+                this.db.pragma('journal_mode = WAL');
+            }
+
+            this.ensureSchema();
+            logger.info('[SourceRegistryService] Connected to Memory Core mc_source_registration.');
+        } catch (err) {
+            logger.warn('[SourceRegistryService] Failed to initialize SQLite connection:', err.message);
+        }
+    }
+
+    /**
+     * Creates the dedicated registration table and indexes if absent. The UNIQUE identity index is
+     * scoped by `tenant_id` so provider identity is tenant-private; a rename updates
+     * `display_locator` without forking `source_instance_id`.
+     * @returns {void}
+     */
+    ensureSchema() {
+        if (!this.db) return;
+
+        this.db.exec(`
+            CREATE TABLE IF NOT EXISTS mc_source_registration (
+                source_instance_id      TEXT    PRIMARY KEY,
+                tenant_id               TEXT    NOT NULL,
+                provider                TEXT    NOT NULL,
+                canonical_provider_host TEXT    NOT NULL,
+                resource_kind           TEXT    NOT NULL,
+                provider_resource_id    TEXT    NOT NULL,
+                display_locator         TEXT,
+                grant_ref               TEXT,
+                provider_capabilities   TEXT,
+                registration_epoch      INTEGER NOT NULL DEFAULT 1,
+                lifecycle_state         TEXT    NOT NULL DEFAULT 'REQUESTED',
+                created_at              INTEGER NOT NULL,
+                updated_at              INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_mc_source_registration_tenant
+                ON mc_source_registration(tenant_id);
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_mc_source_registration_identity
+                ON mc_source_registration(tenant_id, canonical_provider_host, resource_kind, provider_resource_id);
+        `);
+    }
+
+    /**
+     * @summary Resolves the server-authoritative tenant key. NEVER caller-supplied.
+     *
+     * The isolation key is the request-context `userId` (bound at the auth boundary via
+     * `RequestContextService.run`, per its contract `getUserId()` is the tenant-isolation key). In an
+     * explicit local-single-user bootstrap the caller opts in with `allowLocalBootstrap` AND the
+     * request context still resolves no hosted tenant; only then does the local subject stand in.
+     * Hosted or ambiguous contexts with no resolved tenant return `null`, so callers fail closed.
+     * @param {Object}  [options]
+     * @param {Boolean} [options.allowLocalBootstrap=false] Opt into the explicit local-single-user path.
+     * @param {String}  [options.localSubjectId] The explicit local subject to equate with the tenant.
+     * @returns {String|null}
+     */
+    resolveTenantId({allowLocalBootstrap = false, localSubjectId} = {}) {
+        const tenantId = RequestContextService.getUserId?.();
+
+        if (tenantId) return tenantId;
+
+        if (allowLocalBootstrap && localSubjectId) {
+            return localSubjectId;
+        }
+
+        return null;
+    }
+
+    /**
+     * @summary Registers (or idempotently returns) a neutral source identity in the REQUESTED state.
+     *
+     * Idempotent on the tenant-private provider identity `(host, resourceKind, providerResourceId)`:
+     * a repeat call returns the existing `sourceInstanceId` and updates only the mutable
+     * `display_locator` (rename), so identity survives rename and grant rotation (AC1). No secret is
+     * stored — `grantRef` is a non-secret binding; `credentialRef` never enters this table (AC5).
+     * @param {Object}  data
+     * @param {String}  data.provider
+     * @param {String}  data.canonicalProviderHost
+     * @param {String}  data.resourceKind
+     * @param {String}  data.providerResourceId
+     * @param {String}  [data.displayLocator]
+     * @param {String}  [data.grantRef]
+     * @param {Object}  [data.providerCapabilities]
+     * @param {Object}  [context]
+     * @param {Boolean} [context.allowLocalBootstrap=false]
+     * @param {String}  [context.localSubjectId]
+     * @returns {Object} The stored registration row (camelCase).
+     * @throws {Error} `SOURCE_REGISTRATION_NO_TENANT` when no server tenant resolves (fail closed).
+     */
+    register(data, context = {}) {
+        const tenantId = this.resolveTenantId(context);
+
+        if (!tenantId) {
+            throw new Error('SOURCE_REGISTRATION_NO_TENANT');
+        }
+
+        const
+            {provider, canonicalProviderHost, resourceKind, providerResourceId, displayLocator = null, grantRef = null, providerCapabilities = null} = data,
+            now      = Date.now(),
+            existing = this.db.prepare(
+                `SELECT source_instance_id FROM mc_source_registration
+                 WHERE tenant_id = ? AND canonical_provider_host = ? AND resource_kind = ? AND provider_resource_id = ?`
+            ).get(tenantId, canonicalProviderHost, resourceKind, providerResourceId);
+
+        if (existing) {
+            this.db.prepare(
+                `UPDATE mc_source_registration SET display_locator = ?, grant_ref = ?, updated_at = ?
+                 WHERE tenant_id = ? AND source_instance_id = ?`
+            ).run(displayLocator, grantRef, now, tenantId, existing.source_instance_id);
+
+            return this.getRegistration(existing.source_instance_id, context);
+        }
+
+        const sourceInstanceId = crypto.randomUUID();
+
+        this.db.prepare(
+            `INSERT INTO mc_source_registration (
+                source_instance_id, tenant_id, provider, canonical_provider_host, resource_kind,
+                provider_resource_id, display_locator, grant_ref, provider_capabilities,
+                registration_epoch, lifecycle_state, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 'REQUESTED', ?, ?)`
+        ).run(
+            sourceInstanceId, tenantId, provider, canonicalProviderHost, resourceKind,
+            providerResourceId, displayLocator, grantRef,
+            providerCapabilities ? JSON.stringify(providerCapabilities) : null,
+            now, now
+        );
+
+        return this.getRegistration(sourceInstanceId, context);
+    }
+
+    /**
+     * Loads one registration, always scoped by the resolved server tenant + the source id, so a
+     * caller can never read another tenant's row (AC4). Returns `null` when absent for this tenant.
+     * @param {String} sourceInstanceId
+     * @param {Object} [context]
+     * @returns {Object|null}
+     */
+    getRegistration(sourceInstanceId, context = {}) {
+        const tenantId = this.resolveTenantId(context);
+
+        if (!tenantId) return null;
+
+        const row = this.db.prepare(
+            `SELECT * FROM mc_source_registration WHERE tenant_id = ? AND source_instance_id = ?`
+        ).get(tenantId, sourceInstanceId);
+
+        return row ? this.#toCamel(row) : null;
+    }
+
+    /**
+     * @summary Advances a registration's lifecycle through a validated transition, epoch-fenced.
+     *
+     * Rejects any transition not permitted by {@link LIFECYCLE_TRANSITIONS} (AC2). Entering
+     * `PROVISIONED` mints a strictly higher `registration_epoch`, fencing any connector still holding
+     * the prior epoch (AC2/AC8). All work is scoped by `(tenant_id, source_instance_id)`.
+     * @param {String} sourceInstanceId
+     * @param {String} toState One of REQUESTED|PROVISIONED|ACTIVE|REVOKED.
+     * @param {Object} [context]
+     * @returns {Object} The updated registration row.
+     * @throws {Error} `SOURCE_REGISTRATION_NO_TENANT` | `SOURCE_REGISTRATION_NOT_FOUND` | `SOURCE_REGISTRATION_INVALID_TRANSITION`.
+     */
+    transitionLifecycle(sourceInstanceId, toState, context = {}) {
+        const tenantId = this.resolveTenantId(context);
+
+        if (!tenantId) {
+            throw new Error('SOURCE_REGISTRATION_NO_TENANT');
+        }
+
+        const current = this.db.prepare(
+            `SELECT lifecycle_state, registration_epoch FROM mc_source_registration
+             WHERE tenant_id = ? AND source_instance_id = ?`
+        ).get(tenantId, sourceInstanceId);
+
+        if (!current) {
+            throw new Error('SOURCE_REGISTRATION_NOT_FOUND');
+        }
+
+        if (!LIFECYCLE_TRANSITIONS[current.lifecycle_state]?.includes(toState)) {
+            throw new Error('SOURCE_REGISTRATION_INVALID_TRANSITION');
+        }
+
+        const nextEpoch = EPOCH_ADVANCING_STATES.has(toState)
+            ? current.registration_epoch + 1
+            : current.registration_epoch;
+
+        this.db.prepare(
+            `UPDATE mc_source_registration SET lifecycle_state = ?, registration_epoch = ?, updated_at = ?
+             WHERE tenant_id = ? AND source_instance_id = ?`
+        ).run(toState, nextEpoch, Date.now(), tenantId, sourceInstanceId);
+
+        return this.getRegistration(sourceInstanceId, context);
+    }
+
+    /**
+     * @summary The admission gate: true only for an ACTIVE registration whose submitted epoch matches
+     * current server-owned state (AC3/AC8). A stale or revoked epoch can never admit.
+     * @param {String} sourceInstanceId
+     * @param {Number} submittedEpoch
+     * @param {Object} [context]
+     * @returns {Boolean}
+     */
+    canAdmit(sourceInstanceId, submittedEpoch, context = {}) {
+        const registration = this.getRegistration(sourceInstanceId, context);
+
+        return !!registration
+            && registration.lifecycleState   === 'ACTIVE'
+            && registration.registrationEpoch === submittedEpoch;
+    }
+
+    /**
+     * Maps a snake_case DB row to the camelCase neutral shape. `credentialRef` is
+     * intentionally absent — it is connector-only and never stored here.
+     * @param {Object} row
+     * @returns {Object}
+     * @private
+     */
+    #toCamel(row) {
+        return {
+            sourceInstanceId     : row.source_instance_id,
+            tenantId             : row.tenant_id,
+            provider             : row.provider,
+            canonicalProviderHost: row.canonical_provider_host,
+            resourceKind         : row.resource_kind,
+            providerResourceId   : row.provider_resource_id,
+            displayLocator       : row.display_locator,
+            grantRef             : row.grant_ref,
+            providerCapabilities : row.provider_capabilities ? JSON.parse(row.provider_capabilities) : null,
+            registrationEpoch    : row.registration_epoch,
+            lifecycleState       : row.lifecycle_state,
+            createdAt            : row.created_at,
+            updatedAt            : row.updated_at
+        };
+    }
+}
+
+export default Neo.setupClass(SourceRegistryService);

--- a/test/playwright/unit/ai/services/memory-core/SourceRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SourceRegistryService.spec.mjs
@@ -16,13 +16,17 @@ setup({
 import {test, expect}        from '@playwright/test';
 import Neo                   from '../../../../../../src/Neo.mjs';
 import * as core             from '../../../../../../src/core/_export.mjs';
+import crypto                from 'crypto';
 import fs                    from 'fs';
 import path                  from 'path';
 import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
 
 /**
  * @summary Security matrix for the tenant-scoped community source registry.
- * Every case maps to a stated AC; the cross-tenant and epoch cases are the load-bearing ones.
+ *
+ * Two properties carry the weight: source-admin authority is a deployment property (never a caller
+ * or session property), and every lifecycle transition is a compare-and-swap against the control
+ * generation the caller observed, so a superseded writer cannot resurrect revoked state.
  */
 test.describe('Neo.ai.services.memory-core.SourceRegistryService', () => {
     const sample = {
@@ -35,7 +39,33 @@ test.describe('Neo.ai.services.memory-core.SourceRegistryService', () => {
 
     let SourceRegistryService, originalEnv, testDbPath;
 
-    const asTenant = (userId, fn) => RequestContextService.run({userId}, fn);
+    const
+        asTenant = (userId, fn) => RequestContextService.run({userId}, fn),
+
+        /**
+         * Seeds a row for an arbitrary tenant directly, bypassing authority — a fixture for the
+         * read-isolation case, which must be provable independently of who may mutate.
+         */
+        seed = tenantId => {
+            const id  = crypto.randomUUID(),
+                  now = Date.now();
+
+            SourceRegistryService.db.prepare(
+                `INSERT INTO mc_source_registration (
+                    source_instance_id, tenant_id, provider, canonical_provider_host, resource_kind,
+                    provider_resource_id, display_locator, grant_ref, provider_capabilities,
+                    registration_epoch, lifecycle_state, created_at, updated_at
+                 ) VALUES (?, ?, 'github', 'github.com', 'repository', 'neomjs/neo', 'neomjs/neo', null, null, 1, 'REQUESTED', ?, ?)`
+            ).run(id, tenantId, now, now);
+
+            return id
+        },
+
+        /** Registers under an explicit local-single-user deployment. */
+        registerLocally = (subject, data = sample) => {
+            SourceRegistryService.localSubjectId = subject;
+            return SourceRegistryService.register(data)
+        };
 
     test.beforeAll(async () => {
         originalEnv = {
@@ -66,86 +96,139 @@ test.describe('Neo.ai.services.memory-core.SourceRegistryService', () => {
 
     test.beforeEach(() => {
         SourceRegistryService.db.exec('DELETE FROM mc_source_registration;');
+        // Fail-closed default: this process is NOT an explicit local-single-user deployment.
+        SourceRegistryService.localSubjectId = null;
     });
 
-    test('AC4 — a tenant cannot read or transition another tenant\'s registration', async () => {
-        const reg = await asTenant('u-alice', () => SourceRegistryService.register(sample));
-        expect(reg.tenantId).toBe('u-alice');
+    // ---------------------------------------------------------------- authority (AC6/AC7)
 
-        const bobView = await asTenant('u-bob', () => SourceRegistryService.getRegistration(reg.sourceInstanceId));
-        expect(bobView, 'bob cannot read alice\'s row').toBeNull();
-
-        await asTenant('u-bob', () => {
-            expect(() => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'PROVISIONED'))
-                .toThrow('SOURCE_REGISTRATION_NOT_FOUND');
+    test('an ordinary authenticated hosted subject is not a source admin', async () => {
+        await asTenant('u-alice', () => {
+            expect(() => SourceRegistryService.register(sample)).toThrow('SOURCE_REGISTRATION_AUTHORITY_UNAVAILABLE');
         });
 
-        const aliceView = await asTenant('u-alice', () => SourceRegistryService.getRegistration(reg.sourceInstanceId));
-        expect(aliceView.sourceInstanceId, 'alice still sees her own row').toBe(reg.sourceInstanceId);
+        expect(SourceRegistryService.db.prepare('SELECT count(*) AS c FROM mc_source_registration').get().c).toBe(0);
     });
 
-    test('AC1 — rename + grant rotation preserve sourceInstanceId', async () => {
-        const a = await asTenant('u-alice', () => SourceRegistryService.register({...sample, grantRef: 'grant-1'}));
-        const b = await asTenant('u-alice', () => SourceRegistryService.register({...sample, displayLocator: 'neomjs/neo-renamed', grantRef: 'grant-2'}));
+    test('a caller cannot spoof local authority — authority is deployment-bound, not request-bound', async () => {
+        // The old caller-supplied opt-in shape is inert: extra keys confer nothing.
+        await asTenant('u-mallory', () => {
+            expect(() => SourceRegistryService.register({...sample, allowLocalBootstrap: true, localSubjectId: 'u-mallory'}))
+                .toThrow('SOURCE_REGISTRATION_AUTHORITY_UNAVAILABLE');
+        });
+
+        // And with no request context at all, it still refuses without an injected deployment subject.
+        expect(() => SourceRegistryService.register({...sample, allowLocalBootstrap: true, localSubjectId: 'nobody'}))
+            .toThrow('SOURCE_REGISTRATION_NO_TENANT');
+
+        expect(SourceRegistryService.db.prepare('SELECT count(*) AS c FROM mc_source_registration').get().c).toBe(0);
+    });
+
+    test('an explicit local-single-user deployment registers under its injected subject', () => {
+        const reg = registerLocally('local-subject');
+
+        expect(reg.tenantId).toBe('local-subject');
+        expect(reg.lifecycleState).toBe('REQUESTED');
+        expect(reg.registrationEpoch).toBe(1);
+    });
+
+    // ---------------------------------------------------------------- isolation (AC4)
+
+    test('a tenant cannot read another tenant\'s registration', async () => {
+        const aliceRow = seed('u-alice');
+
+        expect(await asTenant('u-bob', () => SourceRegistryService.getRegistration(aliceRow)), 'bob cannot read alice\'s row').toBeNull();
+        expect((await asTenant('u-alice', () => SourceRegistryService.getRegistration(aliceRow))).sourceInstanceId).toBe(aliceRow);
+    });
+
+    // ---------------------------------------------------------------- identity (AC1) + secrets (AC5)
+
+    test('rename + grant rotation preserve sourceInstanceId', () => {
+        const a = registerLocally('local-subject', {...sample, grantRef: 'grant-1'}),
+              b = registerLocally('local-subject', {...sample, displayLocator: 'neomjs/neo-renamed', grantRef: 'grant-2'});
 
         expect(b.sourceInstanceId, 'rename does not fork identity').toBe(a.sourceInstanceId);
         expect(b.displayLocator).toBe('neomjs/neo-renamed');
-        expect(b.grantRef, 'grant rotation updates the non-secret binding').toBe('grant-2');
+        expect(b.grantRef).toBe('grant-2');
     });
 
-    test('AC2 — an invalid lifecycle transition is rejected', async () => {
-        const reg = await asTenant('u-alice', () => SourceRegistryService.register(sample));
-        expect(reg.lifecycleState).toBe('REQUESTED');
-
-        await asTenant('u-alice', () => {
-            expect(() => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'ACTIVE'))
-                .toThrow('SOURCE_REGISTRATION_INVALID_TRANSITION');
-        });
-    });
-
-    test('AC2/AC3/AC8 — epoch fences stale + revoked admission', async () => {
-        const reg = await asTenant('u-alice', () => SourceRegistryService.register(sample));
-        expect(reg.registrationEpoch).toBe(1);
-
-        const provisioned = await asTenant('u-alice', () => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'PROVISIONED'));
-        expect(provisioned.registrationEpoch, 'provisioning bumps the epoch').toBe(2);
-
-        await asTenant('u-alice', () => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'ACTIVE'));
-
-        await asTenant('u-alice', () => {
-            expect(SourceRegistryService.canAdmit(reg.sourceInstanceId, 2), 'current epoch admits').toBe(true);
-            expect(SourceRegistryService.canAdmit(reg.sourceInstanceId, 1), 'stale epoch is fenced').toBe(false);
-        });
-
-        await asTenant('u-alice', () => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'REVOKED'));
-        await asTenant('u-alice', () => {
-            expect(SourceRegistryService.canAdmit(reg.sourceInstanceId, 2), 'revoked cannot admit').toBe(false);
-        });
-
-        const reprovisioned = await asTenant('u-alice', () => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'PROVISIONED'));
-        expect(reprovisioned.registrationEpoch, 'reprovision bumps epoch again, fencing the old connector').toBe(3);
-    });
-
-    test('AC5 — no secret column and no credentialRef in the neutral shape', async () => {
-        const reg  = await asTenant('u-alice', () => SourceRegistryService.register({...sample, grantRef: 'grant-x'}));
-        const cols = SourceRegistryService.db.prepare('PRAGMA table_info(mc_source_registration)').all().map(c => c.name);
+    test('no secret column and no credentialRef in the neutral shape', () => {
+        const reg  = registerLocally('local-subject', {...sample, grantRef: 'grant-x'}),
+              cols = SourceRegistryService.db.prepare('PRAGMA table_info(mc_source_registration)').all().map(c => c.name);
 
         expect(reg).not.toHaveProperty('credentialRef');
         expect(cols).not.toContain('credential_ref');
-        expect(cols, 'grant_ref (non-secret) is retained').toContain('grant_ref');
+        expect(cols).toContain('grant_ref');
     });
 
-    test('AC6/AC7 — fail closed without a tenant; explicit local bootstrap opts in; hosted tenant wins', async () => {
-        // No request context + no explicit local subject -> fail closed.
-        expect(() => SourceRegistryService.register(sample)).toThrow('SOURCE_REGISTRATION_NO_TENANT');
+    // ---------------------------------------------------------------- lifecycle + fencing (AC2/AC3/AC8)
 
-        // Explicit local-single-user bootstrap.
-        const local = SourceRegistryService.register(sample, {allowLocalBootstrap: true, localSubjectId: 'local-subject'});
-        expect(local.tenantId).toBe('local-subject');
+    test('a transition without a control generation is refused', () => {
+        const reg = registerLocally('local-subject');
 
-        // A hosted tenant context is never overridden by an allowLocalBootstrap flag.
-        const hosted = await asTenant('u-alice', () =>
-            SourceRegistryService.register({...sample, providerResourceId: 'neomjs/other'}, {allowLocalBootstrap: true, localSubjectId: 'local-subject'}));
-        expect(hosted.tenantId, 'the real server tenant wins over a local-bootstrap request').toBe('u-alice');
+        expect(() => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'PROVISIONED'))
+            .toThrow('SOURCE_REGISTRATION_CONTROL_GENERATION_REQUIRED');
+    });
+
+    test('an invalid lifecycle transition is rejected', () => {
+        const reg = registerLocally('local-subject');
+
+        expect(() => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'ACTIVE', {expectedState: 'REQUESTED', expectedEpoch: 1}))
+            .toThrow('SOURCE_REGISTRATION_INVALID_TRANSITION');
+    });
+
+    test('epoch fences stale and revoked admission', () => {
+        const reg = registerLocally('local-subject'),
+              id  = reg.sourceInstanceId;
+
+        const provisioned = SourceRegistryService.transitionLifecycle(id, 'PROVISIONED', {expectedState: 'REQUESTED', expectedEpoch: 1});
+        expect(provisioned.registrationEpoch, 'provisioning advances the epoch').toBe(2);
+
+        SourceRegistryService.transitionLifecycle(id, 'ACTIVE', {expectedState: 'PROVISIONED', expectedEpoch: 2});
+
+        expect(SourceRegistryService.canAdmit(id, 2), 'current epoch admits').toBe(true);
+        expect(SourceRegistryService.canAdmit(id, 1), 'stale epoch is fenced').toBe(false);
+
+        SourceRegistryService.transitionLifecycle(id, 'REVOKED', {expectedState: 'ACTIVE', expectedEpoch: 2});
+        expect(SourceRegistryService.canAdmit(id, 2), 'revoked cannot admit').toBe(false);
+    });
+
+    test('revoke wins over a stale activate — the superseded writer cannot resurrect ACTIVE', () => {
+        const id = registerLocally('local-subject').sourceInstanceId;
+
+        SourceRegistryService.transitionLifecycle(id, 'PROVISIONED', {expectedState: 'REQUESTED', expectedEpoch: 1});
+
+        // Writer A observed PROVISIONED@2 and intends to activate.
+        const staleGeneration = {expectedState: 'PROVISIONED', expectedEpoch: 2};
+
+        // An intervening revoke lands first.
+        SourceRegistryService.transitionLifecycle(id, 'REVOKED', {expectedState: 'PROVISIONED', expectedEpoch: 2});
+
+        // Writer A now finishes against its superseded generation.
+        expect(() => SourceRegistryService.transitionLifecycle(id, 'ACTIVE', staleGeneration))
+            .toThrow('SOURCE_REGISTRATION_STALE_CONTROL');
+
+        expect(SourceRegistryService.getRegistration(id).lifecycleState, 'the revocation survives').toBe('REVOKED');
+    });
+
+    test('a pre-revoke retry cannot reprovision or reactivate across the fence', () => {
+        const id = registerLocally('local-subject').sourceInstanceId;
+
+        SourceRegistryService.transitionLifecycle(id, 'PROVISIONED', {expectedState: 'REQUESTED', expectedEpoch: 1});
+        SourceRegistryService.transitionLifecycle(id, 'ACTIVE',      {expectedState: 'PROVISIONED', expectedEpoch: 2});
+        SourceRegistryService.transitionLifecycle(id, 'REVOKED',     {expectedState: 'ACTIVE', expectedEpoch: 2});
+
+        // A retry replaying pre-revoke authority is refused.
+        expect(() => SourceRegistryService.transitionLifecycle(id, 'REVOKED', {expectedState: 'ACTIVE', expectedEpoch: 2}))
+            .toThrow('SOURCE_REGISTRATION_STALE_CONTROL');
+
+        // A legitimate reprovision advances the epoch, invalidating every older generation.
+        const reprovisioned = SourceRegistryService.transitionLifecycle(id, 'PROVISIONED', {expectedState: 'REVOKED', expectedEpoch: 2});
+        expect(reprovisioned.registrationEpoch).toBe(3);
+
+        // The pre-revoke generation still cannot activate after the fence advanced.
+        expect(() => SourceRegistryService.transitionLifecycle(id, 'ACTIVE', {expectedState: 'PROVISIONED', expectedEpoch: 2}))
+            .toThrow('SOURCE_REGISTRATION_STALE_CONTROL');
+        expect(SourceRegistryService.canAdmit(id, 2), 'the old epoch never admits again').toBe(false);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/SourceRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SourceRegistryService.spec.mjs
@@ -1,0 +1,151 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'SourceRegistryServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../../src/Neo.mjs';
+import * as core             from '../../../../../../src/core/_export.mjs';
+import fs                    from 'fs';
+import path                  from 'path';
+import RequestContextService from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
+
+/**
+ * @summary Security matrix for the tenant-scoped community source registry.
+ * Every case maps to a stated AC; the cross-tenant and epoch cases are the load-bearing ones.
+ */
+test.describe('Neo.ai.services.memory-core.SourceRegistryService', () => {
+    const sample = {
+        provider             : 'github',
+        canonicalProviderHost: 'github.com',
+        resourceKind         : 'repository',
+        providerResourceId   : 'neomjs/neo',
+        displayLocator       : 'neomjs/neo'
+    };
+
+    let SourceRegistryService, originalEnv, testDbPath;
+
+    const asTenant = (userId, fn) => RequestContextService.run({userId}, fn);
+
+    test.beforeAll(async () => {
+        originalEnv = {
+            NEO_MEMORY_DB_PATH_TEST: process.env.NEO_MEMORY_DB_PATH_TEST,
+            UNIT_TEST_MODE         : process.env.UNIT_TEST_MODE
+        };
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, {recursive: true});
+
+        testDbPath = path.join(tmpDir, `mc-source-registry-test-${process.pid}-${Date.now()}.sqlite`);
+        for (const suffix of ['', '-wal', '-shm']) {
+            try { fs.unlinkSync(`${testDbPath}${suffix}`); } catch (e) {}
+        }
+
+        process.env.UNIT_TEST_MODE          = 'true';
+        process.env.NEO_MEMORY_DB_PATH_TEST = testDbPath;
+
+        SourceRegistryService = (await import('../../../../../../ai/services/memory-core/SourceRegistryService.mjs')).default;
+        await SourceRegistryService.initAsync();
+    });
+
+    test.afterAll(() => {
+        Object.entries(originalEnv).forEach(([k, v]) => {
+            v === undefined ? delete process.env[k] : (process.env[k] = v);
+        });
+    });
+
+    test.beforeEach(() => {
+        SourceRegistryService.db.exec('DELETE FROM mc_source_registration;');
+    });
+
+    test('AC4 — a tenant cannot read or transition another tenant\'s registration', async () => {
+        const reg = await asTenant('u-alice', () => SourceRegistryService.register(sample));
+        expect(reg.tenantId).toBe('u-alice');
+
+        const bobView = await asTenant('u-bob', () => SourceRegistryService.getRegistration(reg.sourceInstanceId));
+        expect(bobView, 'bob cannot read alice\'s row').toBeNull();
+
+        await asTenant('u-bob', () => {
+            expect(() => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'PROVISIONED'))
+                .toThrow('SOURCE_REGISTRATION_NOT_FOUND');
+        });
+
+        const aliceView = await asTenant('u-alice', () => SourceRegistryService.getRegistration(reg.sourceInstanceId));
+        expect(aliceView.sourceInstanceId, 'alice still sees her own row').toBe(reg.sourceInstanceId);
+    });
+
+    test('AC1 — rename + grant rotation preserve sourceInstanceId', async () => {
+        const a = await asTenant('u-alice', () => SourceRegistryService.register({...sample, grantRef: 'grant-1'}));
+        const b = await asTenant('u-alice', () => SourceRegistryService.register({...sample, displayLocator: 'neomjs/neo-renamed', grantRef: 'grant-2'}));
+
+        expect(b.sourceInstanceId, 'rename does not fork identity').toBe(a.sourceInstanceId);
+        expect(b.displayLocator).toBe('neomjs/neo-renamed');
+        expect(b.grantRef, 'grant rotation updates the non-secret binding').toBe('grant-2');
+    });
+
+    test('AC2 — an invalid lifecycle transition is rejected', async () => {
+        const reg = await asTenant('u-alice', () => SourceRegistryService.register(sample));
+        expect(reg.lifecycleState).toBe('REQUESTED');
+
+        await asTenant('u-alice', () => {
+            expect(() => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'ACTIVE'))
+                .toThrow('SOURCE_REGISTRATION_INVALID_TRANSITION');
+        });
+    });
+
+    test('AC2/AC3/AC8 — epoch fences stale + revoked admission', async () => {
+        const reg = await asTenant('u-alice', () => SourceRegistryService.register(sample));
+        expect(reg.registrationEpoch).toBe(1);
+
+        const provisioned = await asTenant('u-alice', () => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'PROVISIONED'));
+        expect(provisioned.registrationEpoch, 'provisioning bumps the epoch').toBe(2);
+
+        await asTenant('u-alice', () => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'ACTIVE'));
+
+        await asTenant('u-alice', () => {
+            expect(SourceRegistryService.canAdmit(reg.sourceInstanceId, 2), 'current epoch admits').toBe(true);
+            expect(SourceRegistryService.canAdmit(reg.sourceInstanceId, 1), 'stale epoch is fenced').toBe(false);
+        });
+
+        await asTenant('u-alice', () => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'REVOKED'));
+        await asTenant('u-alice', () => {
+            expect(SourceRegistryService.canAdmit(reg.sourceInstanceId, 2), 'revoked cannot admit').toBe(false);
+        });
+
+        const reprovisioned = await asTenant('u-alice', () => SourceRegistryService.transitionLifecycle(reg.sourceInstanceId, 'PROVISIONED'));
+        expect(reprovisioned.registrationEpoch, 'reprovision bumps epoch again, fencing the old connector').toBe(3);
+    });
+
+    test('AC5 — no secret column and no credentialRef in the neutral shape', async () => {
+        const reg  = await asTenant('u-alice', () => SourceRegistryService.register({...sample, grantRef: 'grant-x'}));
+        const cols = SourceRegistryService.db.prepare('PRAGMA table_info(mc_source_registration)').all().map(c => c.name);
+
+        expect(reg).not.toHaveProperty('credentialRef');
+        expect(cols).not.toContain('credential_ref');
+        expect(cols, 'grant_ref (non-secret) is retained').toContain('grant_ref');
+    });
+
+    test('AC6/AC7 — fail closed without a tenant; explicit local bootstrap opts in; hosted tenant wins', async () => {
+        // No request context + no explicit local subject -> fail closed.
+        expect(() => SourceRegistryService.register(sample)).toThrow('SOURCE_REGISTRATION_NO_TENANT');
+
+        // Explicit local-single-user bootstrap.
+        const local = SourceRegistryService.register(sample, {allowLocalBootstrap: true, localSubjectId: 'local-subject'});
+        expect(local.tenantId).toBe('local-subject');
+
+        // A hosted tenant context is never overridden by an allowLocalBootstrap flag.
+        const hosted = await asTenant('u-alice', () =>
+            SourceRegistryService.register({...sample, providerResourceId: 'neomjs/other'}, {allowLocalBootstrap: true, localSubjectId: 'local-subject'}));
+        expect(hosted.tenantId, 'the real server tenant wins over a local-bootstrap request').toBe('u-alice');
+    });
+});


### PR DESCRIPTION
Resolves #15150

## Summary

Adds `SourceRegistryService` — the dedicated tenant-keyed Memory-Core registry of neutral community source identities, the foundational leaf of the community-activity-authority arc (Epic #15145). Per the durable-community-activity ADR §2.2–2.5: a server-owned `sourceInstanceId` FK, provider identity kept distinct from display/grant/delivery ids, a CAS-fenced `REQUESTED → PROVISIONED → ACTIVE → REVOKED` lifecycle, and deployment-bound registration authority.

Security spine:
- **Registration authority is a deployment property, not a session property** — the local-single-user subject is injected once at the trusted server/deployment boundary (`localSubjectId`, fail-closed `null` by default); callers cannot supply local-mode opt-in or subject. An ordinary authenticated hosted subject is **not** a source admin and receives a stable `SOURCE_REGISTRATION_AUTHORITY_UNAVAILABLE` refusal until an operator-authorized hosted provisioning path exists (ADR §2.5 defers hosted self-service V/X).
- **Read scope is separate from mutation authority** — reads resolve the request-context tenant (or the injected local subject) and re-apply a `(tenant_id, source_instance_id)` predicate on every query, because GraphService RLS does not protect new tables. Any authenticated subject may read its own registrations; none may mutate without deployment authority.
- **Stale-writer fence (CAS)** — `transitionLifecycle` is a single compare-and-swap: the caller presents the `(expectedState, expectedEpoch)` it observed, and that generation joins tenant + source in the UPDATE predicate. A superseded writer matches zero rows and fails `SOURCE_REGISTRATION_STALE_CONTROL` instead of resurrecting revoked state. Entering `PROVISIONED` advances the epoch, so a pre-revoke retry can never traverse `REVOKED → PROVISIONED → ACTIVE`.
- **No secrets** — `grantRef` is a non-secret binding; `credentialRef` never enters this table, and rows are tenant-keyed by construction (never `sharedEntity`/`visibility:'team'`).
- **Rename-safe** — register is idempotent on the tenant-private provider identity; a rename updates `display_locator` without forking `sourceInstanceId`.

## Deltas from ticket

No scope expansion. The service is the whole #15150 deliverable; batch admission and reconciliation are the successor leaves (#15151+) that consume this registry via `canAdmit(sourceInstanceId, epoch)`. Hosted operator-authorized provisioning is explicitly deferred (deferred authority returns a stable error rather than silently self-serving). The shared-RLS-helper extraction for the reconciliation leaves remains a deferrable follow-up — the predicate is inline here.

## Test Evidence

- `test/playwright/unit/ai/services/memory-core/SourceRegistryService.spec.mjs` — 11 AC-mapped security cases, **11 passed** via `npm run test-unit`:
  - **Authority (AC6/AC7)** — hosted-subject denial · caller cannot spoof local authority (the old opt-in shape is inert, and no-context still refuses) · explicit local deployment registers under its injected subject.
  - **Isolation (AC4)** — a tenant cannot read another tenant's registration.
  - **Identity/secrets (AC1/AC5)** — rename + grant rotation preserve `sourceInstanceId` · no secret column, no `credentialRef`.
  - **Lifecycle + fencing (AC2/AC3/AC8)** — control generation required · invalid transition rejected · epoch fences stale and revoked admission · **revoke wins over a stale activate** · **a pre-revoke retry cannot reprovision or reactivate across the fence**.
- **Both stale-writer witnesses RED-verified**: with the CAS predicate defeated (`AND (lifecycle_state = ? OR 1=1) …`), both fail with "Received function did not throw" — reproducing the reviewer's `ACTIVE@2`-after-revoke finding; restoring the fence turns them green.
- **AC4 RED-verified**: with the tenant predicate broken (`OR 1=1`), bob reads alice's row; restored → green.
- Sibling `MemoryCoreRecorderService` suite still green (6 passed) — no regression. `node --check` green on both files.

Evidence: L2 (unit — a RED-verified security matrix at the real service seam, including the two concurrency-property witnesses) → L2 required and sufficient (a server-internal registry with no runtime/deploy surface in this leaf). Residual: hosted operator-authorized provisioning is deferred by design and returns a stable error.

## Post-Merge Validation

- [ ] Confirm hosted CI is green at the human merge head.
- [ ] When the batch-admission leaf (#15151) lands, confirm it consumes `canAdmit(sourceInstanceId, epoch)` as its admission gate and presents a control generation to `transitionLifecycle` — that is the fence seam this leaf exposes.
- [ ] When operator-authorized hosted provisioning is designed, replace the `AUTHORITY_UNAVAILABLE` refusal with the server-owned target-tenant path.

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Origin session `3e5f61a5-35d0-4f3d-8805-54f63bebed70`.
