### PR TITLE
feat(agentos): re-baseline drift audit + the fleet-bar hierarchy quick win (#15487)

### DIFF
--- a/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
+++ b/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
@@ -8,8 +8,55 @@
         padding: 6px 10px;
         gap    : 8px;
 
-        .fm-fleet-start {
-            font-weight: 600;
+        /* Button hierarchy (ledger D1): the SSOT's quiet, panel-toned base — the default theme's
+           same-weight blue slab never reaches the bar. Mirrors the chrome's agent-button pair
+           (Viewport.scss); only the primary action reaches for the signal. */
+        .neo-button.fm-preset-button {
+            border       : 1px solid var(--fm-line);
+            border-radius: 6px;
+            background   : var(--fm-panel-2);
+            color        : var(--fm-ink-dim);
+            box-shadow   : none;
+            font-weight  : 500;
+            transition   : background .15s ease, border-color .15s ease, color .15s ease;
+
+            &:hover {
+                border-color: var(--fm-ink-dim);
+                background   : var(--fm-panel);
+                color        : var(--fm-ink);
+            }
+
+            &.pressed {
+                border-color: var(--fm-ink-dim);
+                background   : var(--fm-panel);
+                color        : var(--fm-ink);
+            }
+
+            .neo-button-glyph,
+            .neo-button-text {
+                color: inherit;
+            }
+        }
+
+        .neo-button.fm-fleet-start {
+            border       : 1px solid color-mix(in srgb, var(--fm-signal) 55%, var(--fm-line));
+            border-radius: 6px;
+            background   : color-mix(in srgb, var(--fm-signal) 14%, var(--fm-panel-2));
+            color        : var(--fm-signal);
+            box-shadow   : none;
+            font-weight  : 600;
+            transition   : background .15s ease, border-color .15s ease, color .15s ease;
+
+            &:hover {
+                border-color: var(--fm-signal);
+                background   : color-mix(in srgb, var(--fm-signal) 24%, var(--fm-panel-2));
+                color        : var(--fm-signal);
+            }
+
+            .neo-button-glyph,
+            .neo-button-text {
+                color: inherit;
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #15487

Ships the re-baseline drift audit for epic #14805 — render-verified on the live app against all four SSOT frames — plus its one quick win: the fleet cockpit bar's buttons join the token hierarchy (ledger item D1). The full drift ledger is posted on the epic ([comment](https://github.com/neomjs/neo/issues/14805#issuecomment-5012209204)); the measured verdict is that the token layer is **substantially consumed already** — the epic's 07-04 gap list is mostly closed, and what remains is this button bar, one older-shell surface (#15489, filed as the conformance leaf), and three design-authority items routed to @neo-opus-grace (D2/D3/D4).

Evidence: L2 (live render probes + WCAG luminance math in-page, against the dev-server app) → L2 required (the audit's verdicts are visual/computed; the quick win's witness is the computed-style delta). Residual: none for the close-target; D5 restyle is #15489's scope, D2-D4 are Grace's rulings.

## Deltas from ticket

- The audit's method produced a **quantitative** ledger, not just pixel comparison: computed-style probes per element + WCAG 2.1 relative-luminance ratios measured live in-page (e.g. `--fm-ink-faint` vs `--fm-panel` = **2.96:1**, matching TOKENS.md's recorded failure; `--fm-ink-dim` = 5.9:1 pass).
- **TOKENS.md needs a truth-fold (D4):** its "no live consumer" claim for `--fm-ink-faint` is stale — `AgentDetail.scss:302/308/313` ships it. Routed to Grace with the retune/re-bind/exception options, not fixed unilaterally (design authority).
- The epic's truncated-grid exhibit is historical: the Fleet view mounts zero `.neo-grid` containers (AgentCards replaced the grid).
- Quick win included per the audit AC: `fm-preset-button` + `fm-fleet-start` had **zero SCSS rules** (grep-verified) and rendered the neo default `rgb(62, 99, 221)` slab — now bound to the SSOT hierarchy (quiet `--fm-panel-2` base, `--fm-signal` primary), mirroring the landed `Viewport.scss` agent-button pair.

## Test Evidence

- **Before/after (computed, live):** preset buttons `rgb(62, 99, 221)` default-blue → `--fm-panel-2`/`--fm-panel` with `--fm-ink` text and `--fm-line` border, radius 6px, `box-shadow: none`; Start button → `color: rgb(94, 234, 212)` (`--fm-signal`) with `color-mix` signal tint border/background. Captures (before + after, dark skin) held on the host for the operator; probes are in the ledger comment.
- **Conformance sweep:** zero `--fm-ink-faint` consumption outside the three AgentDetail telltale sites (repo-wide grep); zero literal colors in `resources/scss/src/apps/agentos/**` outside recorded token-definition layers; `.neo-grid` mounts: 0.
- **Theme rebuild:** `build/themes.mjs -f -n -t all -e dev` clean; compiled `FleetCockpit.css` carries the new rules (5 preset matches).
- **Light skin:** the fix consumes `var(--fm-*)` only, and both theme layers define the full token set — the light skin inherits by construction. Honest bound: not visually captured (the harness theme-toggle click missed its target in my probe; the var-binding argument + the existing light-layer definitions are the evidence).
- Unit shard: not run — SCSS-only change with no view-code or model touch; the conformance evidence is the computed-style delta (the epic's render gate).
- `apps/agentos` surface: no existing coverage found for the cockpit bar's visual binding (visual-regression harness is #14618, Grace's lane — this PR's probes compose with it).

## Post-Merge Validation

- [ ] Grace's design rulings on D2 (StateDot 1.4.1 third channel), D3 (`--fm-state-off` contrast), D4 (`--fm-ink-faint` retune/re-bind/exception + TOKENS.md truth-fold) land as their own leaves.
- [ ] #15489 (Accounts status block) ships the older-shell restyle with before/after captures.
- [ ] Operator eyeballs the host-held captures (or a re-run of the probe harness) and confirms the bar reads like the SSOT frame's hierarchy.

Authored by Phoebe (Kimi K3, OpenCode). Session 9b748a56-8b84-43bf-a542-ee8dcf437ebf.
