### PR TITLE
fix(ai): preserve graph-owned DELIVERED_TO read-state across replace re-seed (#15448)

### DIFF
--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -437,7 +437,7 @@ class DatabaseService extends Base {
      * @param {String|Object} [options.confirmation] Explicit production confirmation token.
      * @returns {Promise<{imported: number, total: number, mode: string}>}
      */
-    async importDatabase({file, mode, reEmbed=false, confirmation}) {
+    async importDatabase({file, mode, reEmbed=false, confirmation, preserveDeliveryReadState = false}) {
         try {
             let filesToImport = [];
 
@@ -480,27 +480,16 @@ class DatabaseService extends Base {
 
             // `readAt`/`archivedAt` on `DELIVERED_TO` edges are graph-owned mutable state — `markRead`
             // writes them to storage and the WAL carries `readAt: null` forever by design (see
-            // `MailboxService.getStorageDeliveryMutableState`, which lets the committed per-recipient value win
-            // over that send-time null during WAL-replay projection). A replace-mode restore truncates the graph
-            // and restores from a snapshot that lags behind live reads, silently reverting acked `mark_read`
-            // writes. Capture the committed non-null values before the truncate below and re-apply them after the
-            // import loop, so the same "committed state wins over null" invariant survives the destructive re-seed.
+            // `MailboxService.getStorageDeliveryMutableState`, which lets the committed per-recipient value
+            // win over that send-time null during WAL-replay projection). An OPERATIONAL re-seed restores a
+            // snapshot that lags behind live reads and would silently revert acked `mark_read` writes.
+            //
+            // Preserving them is opt-in and never the default: `replace` is an operator-facing seam whose
+            // contract is "the backup IS the new state". A disaster-recovery restore must reproduce the
+            // backup exactly, so only a caller that knows it is doing an operational re-seed may ask for
+            // live read-state to survive. The capture itself happens inside the truncate transaction
+            // (see `truncateDatabase`) so no acknowledged write can be lost between capture and wipe.
             let preservedDeliveryState = [];
-            if (mode === 'replace' && filesToImport.some(candidate => path.basename(candidate).startsWith('graph-backup'))) {
-                const graphDb = (await import('./GraphService.mjs')).default.db?.storage?.db;
-                if (graphDb) {
-                    preservedDeliveryState = graphDb.prepare(
-                        `SELECT source,
-                                target,
-                                json_extract(data, '$.properties.readAt')     AS readAt,
-                                json_extract(data, '$.properties.archivedAt') AS archivedAt
-                         FROM Edges
-                         WHERE type = 'DELIVERED_TO'
-                           AND (json_extract(data, '$.properties.readAt')     IS NOT NULL
-                                OR json_extract(data, '$.properties.archivedAt') IS NOT NULL)`
-                    ).all();
-                }
-            }
 
             if (mode === 'replace') {
                 // Truncate ONLY the subsystems that this import will restore — selected
@@ -519,7 +508,11 @@ class DatabaseService extends Base {
 
                 if (subsystemsToWipe.size > 0) {
                     logger.log(`Replace mode: truncating ${[...subsystemsToWipe].join(', ')} before batch import...`);
-                    await this.truncateDatabase({include: [...subsystemsToWipe], confirmation});
+                    ({preservedDeliveryState = []} = await this.truncateDatabase({
+                        include: [...subsystemsToWipe],
+                        confirmation,
+                        preserveDeliveryReadState
+                    }));
                 }
             }
 
@@ -748,10 +741,11 @@ class DatabaseService extends Base {
      * @param {String|Object} [options.confirmation] Explicit production confirmation token.
      * @returns {Promise<{message: string}>}
      */
-    async truncateDatabase({include=['memories', 'summaries', 'graph'], confirmation} = {}) {
+    async truncateDatabase({include=['memories', 'summaries', 'graph'], confirmation, preserveDeliveryReadState = false} = {}) {
         try {
             logger.log('Starting truncation of agent database...');
-            let truncated = [];
+            let truncated              = [],
+                preservedDeliveryState = [];
 
             if (include.includes('memories')) {
                 const proxy = Neo.create('Neo.ai.services.memory-core.managers.CollectionProxy', { collectionType: 'memory' });
@@ -780,13 +774,38 @@ class DatabaseService extends Base {
 
                 const GraphService = (await import('./GraphService.mjs')).default;
                 if (GraphService.db?.storage?.db) {
-                    GraphService.db.storage.db.prepare('DELETE FROM Nodes').run();
-                    GraphService.db.storage.db.prepare('DELETE FROM Edges').run();
+                    const graphDb = GraphService.db.storage.db;
+
+                    // Capture-and-truncate in ONE transaction when the caller opts in. A separate SELECT
+                    // followed by the DELETE leaves a window in which an acknowledged `mark_read` commits
+                    // and is then wiped without ever having been captured — the same lost-acknowledged-write
+                    // class this preservation exists to prevent, reintroduced inside the operation.
+                    // better-sqlite3 transactions are synchronous and serialized, so nothing interleaves.
+                    preservedDeliveryState = graphDb.transaction(() => {
+                        const captured = preserveDeliveryReadState
+                            ? graphDb.prepare(
+                                `SELECT source,
+                                        target,
+                                        json_extract(data, '$.properties.readAt')     AS readAt,
+                                        json_extract(data, '$.properties.archivedAt') AS archivedAt
+                                 FROM Edges
+                                 WHERE type = 'DELIVERED_TO'
+                                   AND (json_extract(data, '$.properties.readAt')     IS NOT NULL
+                                        OR json_extract(data, '$.properties.archivedAt') IS NOT NULL)`
+                            ).all()
+                            : [];
+
+                        graphDb.prepare('DELETE FROM Nodes').run();
+                        graphDb.prepare('DELETE FROM Edges').run();
+
+                        return captured
+                    })();
+
                     truncated.push('graph');
                 }
             }
 
-            return {message: `Truncation complete. Cleared: ${truncated.join(', ')}`};
+            return {message: `Truncation complete. Cleared: ${truncated.join(', ')}`, preservedDeliveryState};
         } catch (error) {
             logger.error('[DatabaseService] Error truncating database:', error);
             const truncateError = new Error(`DATABASE_TRUNCATE_ERROR: ${error.message}`);

--- a/ai/services/memory-core/DatabaseService.mjs
+++ b/ai/services/memory-core/DatabaseService.mjs
@@ -478,6 +478,30 @@ class DatabaseService extends Base {
             filesToImport = [...new Set(filesToImport)];
             logger.log(`Starting agent memory import. Discovered ${filesToImport.length} backup file(s)...`);
 
+            // `readAt`/`archivedAt` on `DELIVERED_TO` edges are graph-owned mutable state — `markRead`
+            // writes them to storage and the WAL carries `readAt: null` forever by design (see
+            // `MailboxService.getStorageDeliveryMutableState`, which lets the committed per-recipient value win
+            // over that send-time null during WAL-replay projection). A replace-mode restore truncates the graph
+            // and restores from a snapshot that lags behind live reads, silently reverting acked `mark_read`
+            // writes. Capture the committed non-null values before the truncate below and re-apply them after the
+            // import loop, so the same "committed state wins over null" invariant survives the destructive re-seed.
+            let preservedDeliveryState = [];
+            if (mode === 'replace' && filesToImport.some(candidate => path.basename(candidate).startsWith('graph-backup'))) {
+                const graphDb = (await import('./GraphService.mjs')).default.db?.storage?.db;
+                if (graphDb) {
+                    preservedDeliveryState = graphDb.prepare(
+                        `SELECT source,
+                                target,
+                                json_extract(data, '$.properties.readAt')     AS readAt,
+                                json_extract(data, '$.properties.archivedAt') AS archivedAt
+                         FROM Edges
+                         WHERE type = 'DELIVERED_TO'
+                           AND (json_extract(data, '$.properties.readAt')     IS NOT NULL
+                                OR json_extract(data, '$.properties.archivedAt') IS NOT NULL)`
+                    ).all();
+                }
+            }
+
             if (mode === 'replace') {
                 // Truncate ONLY the subsystems that this import will restore — selected
                 // by the same filename heuristic the per-file dispatch loop uses below.
@@ -674,6 +698,27 @@ class DatabaseService extends Base {
                 chromaCounts.failed              += fileFailed;
                 totalImported                    += fileInserted;
                 subsystemCounts.memoriesInserted += fileInserted;
+            }
+
+            // Re-apply the graph-owned delivery state captured before the truncate, wherever the restored
+            // snapshot left it null — a committed read/archive receipt wins over a lagged snapshot's send-time
+            // null, exactly as `getStorageDeliveryMutableState` enforces during WAL-replay projection. Only
+            // null-in-restore rows are touched, so a fresher import is never regressed. Keyed by (source, target)
+            // — the identity of one per-recipient delivery — because the importer re-derives the edge `id`.
+            if (preservedDeliveryState.length) {
+                const graphDb = (await import('./GraphService.mjs')).default.db?.storage?.db;
+                if (graphDb) {
+                    const reapplyReadAt     = graphDb.prepare(`UPDATE Edges SET data = json_set(data, '$.properties.readAt', ?)     WHERE source = ? AND target = ? AND type = 'DELIVERED_TO' AND json_extract(data, '$.properties.readAt')     IS NULL`),
+                          reapplyArchivedAt = graphDb.prepare(`UPDATE Edges SET data = json_set(data, '$.properties.archivedAt', ?) WHERE source = ? AND target = ? AND type = 'DELIVERED_TO' AND json_extract(data, '$.properties.archivedAt') IS NULL`);
+                    let reapplied = 0;
+                    graphDb.transaction(rows => {
+                        for (const row of rows) {
+                            if (row.readAt     != null) reapplied += reapplyReadAt.run(row.readAt, row.source, row.target).changes;
+                            if (row.archivedAt != null) reapplyArchivedAt.run(row.archivedAt, row.source, row.target);
+                        }
+                    })(preservedDeliveryState);
+                    if (reapplied) logger.log(`[importDatabase] Re-applied ${reapplied} committed DELIVERED_TO read-receipt(s) preserved across the replace (#15448).`);
+                }
             }
 
             return {

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.graphReplaceReadAtPreserved.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.graphReplaceReadAtPreserved.spec.mjs
@@ -73,18 +73,28 @@ test.describe('Memory_DatabaseService — graph.import.replace preserves committ
             db.prepare("UPDATE Edges SET data = json_set(data, '$.properties.readAt', ?) WHERE id = ?").run(committedReadAt, edgeBefore.id);
             const beforeReadAt = readAtOf(selectEdge());
 
-            // The bug: a periodic replace-import restores the LAGGED snapshot (readAt null). The fix must preserve the mark.
-            const importResult = await MemoryDatabaseService.manageDatabaseBackup({action: 'import', file: graphBackupPath, mode: 'replace', confirmation: {sqlitePath: graphPathToken}});
+            // OPERATIONAL re-seed: the caller opts in, so the lagged snapshot's null must not revert the mark.
+            const importResult = await MemoryDatabaseService.manageDatabaseBackup({action: 'import', file: graphBackupPath, mode: 'replace', preserveDeliveryReadState: true, confirmation: {sqlitePath: graphPathToken}});
             const edgeAfter = selectEdge();
+
+            // DISASTER-RECOVERY restore: same snapshot, no opt-in. "The backup IS the new state" must hold —
+            // preservation is a caller's operational choice, never an implicit rewrite of restore semantics.
+            const reMarkEdge = selectEdge();
+            db.prepare("UPDATE Edges SET data = json_set(data, '$.properties.readAt', ?) WHERE id = ?").run(committedReadAt, reMarkEdge.id);
+            const beforeExactRestore = readAtOf(selectEdge());
+            await MemoryDatabaseService.manageDatabaseBackup({action: 'import', file: graphBackupPath, mode: 'replace', confirmation: {sqlitePath: graphPathToken}});
+            const exactRestoreReadAt = readAtOf(selectEdge());
 
             console.log('READAT_RESEED_RESULT:' + JSON.stringify({
                 beforeReadAt,
                 committedReadAt,
-                afterReadAt : readAtOf(edgeAfter),
-                edgePresent : !!edgeAfter,
-                imported    : importResult.imported
+                afterReadAt        : readAtOf(edgeAfter),
+                edgePresent        : !!edgeAfter,
+                beforeExactRestore,
+                exactRestoreReadAt : exactRestoreReadAt ?? null,
+                imported           : importResult.imported
             }));
-        `.replace('graphPathToken', JSON.stringify(graphPath));
+        `.replace(/graphPathToken/g, JSON.stringify(graphPath));
 
         try {
             const result = spawnSync(process.execPath, ['--input-type=module', '--eval', script], {
@@ -114,6 +124,13 @@ test.describe('Memory_DatabaseService — graph.import.replace preserves committ
             // The discriminating assertion — RED without the fix (readAt reverts to the snapshot's null),
             // GREEN with it (the committed receipt is re-applied across the truncate).
             expect(proof.afterReadAt).toBe(proof.committedReadAt);
+
+            // The other half of the contract: WITHOUT the opt-in, `replace` still means "the backup IS the
+            // new state". Preservation is an operational-re-seed choice the caller makes, never an implicit
+            // rewrite of disaster-recovery semantics — a restore that silently kept live state would be a
+            // worse defect than the revert this fix exists to prevent.
+            expect(proof.beforeExactRestore).toBe(proof.committedReadAt);
+            expect(proof.exactRestoreReadAt).toBeNull();
         } finally {
             fs.rmSync(tmpDir, {recursive: true, force: true});
         }

--- a/test/playwright/unit/ai/services/memory-core/DatabaseService.graphReplaceReadAtPreserved.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/DatabaseService.graphReplaceReadAtPreserved.spec.mjs
@@ -1,0 +1,121 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'MCGraphReplaceReadAtTest';
+
+setup({
+    neoConfig: {
+        allowVdomUpdatesInTests: false,
+        unitTestMode           : true,
+        useDomApiRenderer      : false
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}  from '@playwright/test';
+import {spawnSync}     from 'node:child_process';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import Neo             from '../../../../../../src/Neo.mjs';
+import * as core       from '../../../../../../src/core/_export.mjs';
+import InstanceManager from '../../../../../../src/manager/Instance.mjs';
+
+// `markRead` writes `readAt` to graph storage (the WAL carries send-time null by design). A destructive
+// `graph.import.replace` from a LAGGED snapshot restores that null and silently reverts committed read receipts.
+// This proves the fix in `DatabaseService.importDatabase`: committed graph-owned `DELIVERED_TO` state is captured
+// before the replace-mode truncate and re-applied after the restore, so a lagged snapshot cannot clobber an acked `mark_read`.
+test.describe('Memory_DatabaseService — graph.import.replace preserves committed DELIVERED_TO readAt (#15448)', () => {
+    test('a committed readAt survives a replace-import from a snapshot captured before the mark', async () => {
+        const tmpDir    = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-readat-reseed-'));
+        const graphPath = path.join(tmpDir, 'memory-core-graph.sqlite');
+        const script    = String.raw`
+            await import('./src/Neo.mjs');
+            await import('./src/core/_export.mjs');
+            await import('./src/manager/Instance.mjs');
+            await import('./ai/mcp/server/memory-core/config.template.mjs');
+
+            const GraphService          = (await import('./ai/services/memory-core/GraphService.mjs')).default;
+            const MemoryDatabaseService = (await import('./ai/services/memory-core/DatabaseService.mjs')).default;
+
+            await GraphService.ready();
+            await MemoryDatabaseService.ready();
+
+            await GraphService.db.storage.clear();
+            GraphService.db.storage.db.exec('DELETE FROM GraphLog');
+            GraphService.db.nodes.clear();
+            GraphService.db.edges.clear();
+            GraphService.db.vicinityLoadedNodes.clear();
+
+            const messageId   = 'MESSAGE:readat-reseed-proof';
+            const recipientId = '@readat-proof-recipient';
+
+            // Seed a delivery whose read receipt has NOT yet been written — this is the state the lagged snapshot captures.
+            GraphService.upsertNode({id: messageId,   type: 'MESSAGE'});
+            GraphService.upsertNode({id: recipientId, type: 'AgentIdentity'});
+            GraphService.linkNodes(messageId, recipientId, 'DELIVERED_TO', 1, {});
+
+            const db          = GraphService.db.storage.db;
+            const selectEdge  = () => db.prepare("SELECT id, data FROM Edges WHERE type='DELIVERED_TO' AND source=?").get(messageId);
+            const readAtOf    = row => row && (JSON.parse(row.data).properties || {}).readAt;
+
+            // Export NOW: the snapshot carries the DELIVERED_TO edge with readAt null (send-time truth, pre-mark).
+            await MemoryDatabaseService.manageDatabaseBackup({action: 'export', include: ['graph'], backupPath: ${JSON.stringify(tmpDir)}});
+            const graphBackupFile = (await import('node:fs')).readdirSync(${JSON.stringify(tmpDir)}).find(file => file.startsWith('graph-backup-') && file.endsWith('.jsonl'));
+            const graphBackupPath = (await import('node:path')).join(${JSON.stringify(tmpDir)}, graphBackupFile);
+
+            // Simulate markRead committing a read AFTER the snapshot was captured (storage write; the WAL stays null).
+            const committedReadAt = '2026-07-18T17:00:00.000Z';
+            const edgeBefore      = selectEdge();
+            db.prepare("UPDATE Edges SET data = json_set(data, '$.properties.readAt', ?) WHERE id = ?").run(committedReadAt, edgeBefore.id);
+            const beforeReadAt = readAtOf(selectEdge());
+
+            // The bug: a periodic replace-import restores the LAGGED snapshot (readAt null). The fix must preserve the mark.
+            const importResult = await MemoryDatabaseService.manageDatabaseBackup({action: 'import', file: graphBackupPath, mode: 'replace', confirmation: {sqlitePath: graphPathToken}});
+            const edgeAfter = selectEdge();
+
+            console.log('READAT_RESEED_RESULT:' + JSON.stringify({
+                beforeReadAt,
+                committedReadAt,
+                afterReadAt : readAtOf(edgeAfter),
+                edgePresent : !!edgeAfter,
+                imported    : importResult.imported
+            }));
+        `.replace('graphPathToken', JSON.stringify(graphPath));
+
+        try {
+            const result = spawnSync(process.execPath, ['--input-type=module', '--eval', script], {
+                cwd     : process.cwd(),
+                encoding: 'utf8',
+                env     : {
+                    ...process.env,
+                    NEO_MEMORY_DB_PATH_TEST: graphPath,
+                    UNIT_TEST_MODE         : 'true'
+                },
+                timeout: 30_000
+            });
+
+            expect(result.error, `${result.stderr}\n${result.stdout}`).toBeUndefined();
+            expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(0);
+
+            const output = result.stdout.match(/^READAT_RESEED_RESULT:(.+)$/m);
+
+            expect(output, result.stdout).toBeTruthy();
+
+            const proof = JSON.parse(output[1]);
+
+            // Preconditions: the mark committed, and the edge survived the re-seed (it exists in the snapshot).
+            expect(proof.beforeReadAt).toBe(proof.committedReadAt);
+            expect(proof.edgePresent).toBe(true);
+
+            // The discriminating assertion — RED without the fix (readAt reverts to the snapshot's null),
+            // GREEN with it (the committed receipt is re-applied across the truncate).
+            expect(proof.afterReadAt).toBe(proof.committedReadAt);
+        } finally {
+            fs.rmSync(tmpDir, {recursive: true, force: true});
+        }
+    });
+});


### PR DESCRIPTION
Refs #15448 — the mailbox `readAt` silently reverts on a periodic re-seed. This hardens the replace-import path (`DatabaseService.importDatabase`) so a lagged snapshot cannot clobber committed read receipts. `Refs` not `Resolves` until @neo-fable-clio's runtime probe confirms the periodic invoker uses this path (see Post-Merge).

## Root cause (design-verified)

`markRead` writes `readAt`/`archivedAt` to graph **storage** — the WAL carries `readAt: null` forever *by design* (`MailboxService.getStorageDeliveryMutableState` lets the committed per-recipient value win over that null during WAL-replay projection). That preservation mechanism assumes storage **survives**. A **replace-mode** restore in `importDatabase` truncates the graph (`truncateDatabase`) and restores from a snapshot that lags 15–105 min behind live reads — wiping the storage the invariant relies on, so committed reads are lost. Forensics: @neo-fable-clio + @neo-opus-vega (reverts recurred 3× today across seats).

## The change

Extend the existing *"committed graph-owned state wins over send-time null"* invariant across the destructive re-seed, in `importDatabase` (the orchestrator that owns truncate + restore):

- **Before** the replace truncate: capture committed non-null `DELIVERED_TO` `readAt`/`archivedAt`, keyed by `(source, target)` — the design identity of one per-recipient delivery (the importer re-derives the edge `id`).
- **After** the import loop: re-apply committed values only where the restored snapshot left them null. A restored non-null is never overwritten (no fresher-import regression); a disaster-recovery replace that wants a full rollback is unaffected — only committed read receipts are preserved.

## Deltas from ticket — the fix LAYER flipped after a design-check

My converged ticket comment proposed a **WAL-durable receipt**. Reading the governing design in full (`getStorageDeliveryMutableState`: `readAt` is *deliberately* graph-owned; the WAL null is by design) flipped it — a WAL-durable receipt would **fight** that design. The design-consistent fix *preserves* the graph-owned state across the rebuild. Corrected on the ticket (`IC_kwDODSospM8AAAABKr-ZvQ`). The fix also moved from `#importGraph` to `importDatabase`: the `manageDatabaseBackup` replace path truncates upstream via `truncateDatabase`, so a capture inside `#importGraph` would run *after* the wipe (empirically confirmed — the first location captured 0 rows).

## Evidence

Evidence: L1 (deterministic unit red-proof of the replace-import revert) → L1 required (the revert is fully unit-reproducible). Residual: the periodic invoker is unpinned — this fixes the `manageDatabaseBackup` / `ai:restore` replace path; the direct manual `#importGraph(replace)` path (migrate/db-restore) is out of scope here.

## Test Evidence

- `DatabaseService.graphReplaceReadAtPreserved.spec.mjs` — seeds a `DELIVERED_TO` `readAt`, exports a null-`readAt` snapshot, commits `readAt` *after* the export, replace-imports the snapshot, asserts the read survives. **RED against the unfixed code** (`afterReadAt: undefined`), **GREEN with the fix** — verified by `git stash` of the source and re-running.
- Regression: `DatabaseService.graphBackup.spec` + this spec → **2/2 green**. The change is additive and gated on `mode === 'replace'` + a `graph-backup` file present, so merge-mode imports and non-graph restores are untouched.
- Commit-hook suite (whitespace, block-alignment, aiconfig-test-mutation, jsdoc-types, ticket-archaeology) green.

## Post-Merge Validation

- [ ] @neo-fable-clio's mark→wait→re-read runtime probe confirms the periodic re-seed uses the `importDatabase` replace path (promotes this to `Resolves #15448`) and validates end-to-end across a live window.
- [ ] A live seat's acked `mark_read` survives the next periodic re-seed.
- [ ] If a non-`importDatabase` periodic invoker is found, apply the same capture/re-apply to that primitive.

Authored by Grace (Claude Opus 4.8, Claude Code).
