### PR TITLE
docs(benefits): retire the last "Neo.mjs Framework" self-description (#15495)

### DIFF
--- a/learn/benefits/body/OffTheMainThread.md
+++ b/learn/benefits/body/OffTheMainThread.md
@@ -129,7 +129,7 @@ your main App.
 * Your App will import your used Components
 * Meaning: your Component instances live within the App-Worker
 * View Models & View Controllers also live here
-* Most parts of the Neo.mjs Framework live here
+* Most parts of the Neo.mjs application engine live here
 * You can directly communicate with other Actors via remote method access (RPC)
 
 As a developer, you will probably spend 95% of your time working within this actor.


### PR DESCRIPTION
Resolves #15495

Refs #15494

One-line reword in `learn/benefits/body/OffTheMainThread.md` (L132): the App-Worker actor list said "Most parts of the Neo.mjs Framework live here" — the last branded, capital-F `Neo.mjs Framework` self-description on `learn/` substrate. It now reads "Most parts of the Neo.mjs application engine live here", aligning the page with the binding-vocabulary rule (2026-07-04: neo is never "a framework") and with the sibling benefits page `ApplicationEngine.md`. Precedent: `#14741` / PR `#14742` (ROADMAP.md, "the framework" → "the tech").

Evidence: L1 achieved (static text assertions, fully sandbox-verifiable) → L1 required (every #15495 AC is a grep/static assertion; doc-only change — the evidence-ladder trigger scope explicitly excludes doc-only). Residual: none.

## Deltas from ticket

None substantive. The verification sweep the ticket mandated falsified the broader "last self-description" premise for lowercase forms ("the framework" = Neo in live guides); that finding is routed to #15494 (filed alongside the ticket, unassigned/claimable) rather than folded into this diff — the contrast/generic usages the rule protects (e.g. L64's "An UI Framework or Library itself…") stay untouched by design.

## Test Evidence

- `grep -rn "Neo.mjs Framework" learn/` → zero hits post-change (pre-change: exactly one, L132). AC 2 ✓
- `grep -n "application engine live here" learn/benefits/body/OffTheMainThread.md` → `132:* Most parts of the Neo.mjs application engine live here`. AC 1 ✓
- `grep -n "An UI Framework or Library" learn/benefits/body/OffTheMainThread.md` → L64 intact (generic category statement about off-thread workloads). AC 3 ✓
- `npm run agent-preflight -- --no-fix learn/benefits/body/OffTheMainThread.md --pr-body <this draft>` → pass (result recorded pre-push).
- Surface coverage: learn/benefits markdown — `None found` (no spec/journey exercises this prose; the portal renders it read-only).

## Post-Merge Validation

- [ ] Portal "Off the Main Thread" benefits page renders the reworded bullet on the deployed site (crawler-visible surface).

Authored by Clio (Claude Fable 5, Claude Code). Session 248ccae6-50c8-4822-8a4a-a4290b7820ea (Memory Core offline this session — harness session id as provenance).
