### PR TITLE
feat(dashboard): return popup stacks atomically (#15484)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -42,8 +42,9 @@ import '../../../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype 
  *   (`mainView.add(instance)` — both windows share one App Worker) and reattaching moves it
  *   home. The {@link AgentOS.childapps.dockdemo.view.CounterPane} witness makes the
  *   reparent-never-recreate contract visible: its count survives because its instance does.
- *   Document honesty: pop-out and reattach use the atomic two-document `transferItem` seam,
- *   so ownership moves commit-or-neither while component reparenting stays orthogonal.
+ *   Document honesty: pop-out and item return use the atomic two-document `transferItem` seam;
+ *   the popup stack-handle return composes the sibling `transferNode` seam. Ownership therefore
+ *   moves commit-or-neither while component reparenting stays orthogonal.
  *
  * @class AgentOS.childapps.dockdemo.view.DemoBWorkspace
  * @extends Neo.container.Base
@@ -709,6 +710,24 @@ class DemoBWorkspace extends Container {
     }
 
     /**
+     * @summary (Re-)registers the popup workspace's live accessors before a cold stage opens.
+     *
+     * A successful whole-stack return explicitly unregisters the emptied popup entry. The next
+     * user-authored stage is a NEW workspace lifetime, so it re-registers the same semantic id
+     * against the current owner fields before any participation adapter may resolve it.
+     * @returns {Boolean}
+     * @protected
+     */
+    ensurePopupWorkspaceRegistered() {
+        let me = this;
+
+        return me.workspaceSet.register(DemoBWorkspace.POPUP_WORKSPACE_ID, {
+            getDocument: () => me.popupDocument,
+            setDocument: document => me.popupDocument = document
+        })
+    }
+
+    /**
      * Applies one ordinary single-document operation against a named live workspace.
      * @param {String} workspaceId
      * @param {Object} descriptor
@@ -1106,11 +1125,14 @@ class DemoBWorkspace extends Container {
      * @protected
      */
     isCrossWindowTargetCurrent(workspaceId, windowId, host, generation) {
-        let me = this;
+        let me               = this,
+            expectedWindowId = workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID
+                ? me.crossWindowTargetWindowId
+                : me.windowId;
 
         return !me.isDestroyed
             && me.crossWindowStageGeneration === generation
-            && me.crossWindowTargetWindowId === windowId
+            && expectedWindowId === windowId
             && me.crossWindowHosts.get(workspaceId) === host
             && !host.isDestroyed
     }
@@ -1149,17 +1171,33 @@ class DemoBWorkspace extends Container {
                 return null
             }
 
-            let participation = await me.createCrossWindowParticipation(workspaceId, windowId, host, generation);
+            let participation     = await me.createCrossWindowParticipation(workspaceId, windowId, host, generation),
+                mainWorkspaceId   = DemoBWorkspace.MAIN_WORKSPACE_ID,
+                mainHost          = me.crossWindowHosts.get(mainWorkspaceId),
+                mainParticipation = mainHost && await me.createCrossWindowParticipation(
+                    mainWorkspaceId,
+                    me.windowId,
+                    mainHost,
+                    generation
+                );
 
-            if (!participation || !me.isCrossWindowTargetCurrent(workspaceId, windowId, host, generation)) {
+            if (!participation || !mainParticipation
+                || !me.isCrossWindowTargetCurrent(workspaceId, windowId, host, generation)
+                || !me.isCrossWindowTargetCurrent(mainWorkspaceId, me.windowId, mainHost, generation)) {
                 participation?.destroy();
+                mainParticipation?.destroy();
                 return null
             }
 
-            let geometry = await me.waitForWorkspaceGeometry(workspaceId);
+            let [geometry, mainGeometry] = await Promise.all([
+                me.waitForWorkspaceGeometry(workspaceId),
+                me.waitForWorkspaceGeometry(mainWorkspaceId)
+            ]);
 
-            if (!geometry || !me.isCrossWindowTargetCurrent(workspaceId, windowId, host, generation)) {
-                throw new Error('popup workspace geometry is not measurable')
+            if (!geometry || !mainGeometry
+                || !me.isCrossWindowTargetCurrent(workspaceId, windowId, host, generation)
+                || !me.isCrossWindowTargetCurrent(mainWorkspaceId, me.windowId, mainHost, generation)) {
+                throw new Error('both cross-window workspace geometries must be measurable')
             }
 
             let receipt = {windowId, workspaceId, hostId: host.id};
@@ -1214,6 +1252,7 @@ class DemoBWorkspace extends Container {
             return Promise.reject(new Error('popup workspace is not empty; cross-window stage refuses split ownership'))
         }
 
+        me.ensurePopupWorkspaceRegistered();
         me.crossWindowStageGeneration++;
         me.popupDocument = DemoBWorkspace.createPopupDocument();
 
@@ -1307,6 +1346,124 @@ class DemoBWorkspace extends Container {
     }
 
     /**
+     * @summary Retires the logically emptied popup workspace after its stack returned.
+     *
+     * Document adoption and target-first projection precede this call. The popup render target
+     * may already have closed (disconnect raced the deferred projection) or may remain alive when
+     * its platform close failed; either way its participation, geometry, registry entry and stage
+     * identity retire exactly once. A later open is a new lifetime and explicitly re-registers via
+     * {@link #ensurePopupWorkspaceRegistered}.
+     * @returns {Boolean} true when the popup registry entry existed and was removed.
+     * @protected
+     */
+    retireReturnedPopupWorkspace() {
+        let me = this;
+
+        me.crossWindowStageGeneration++;
+
+        for (const workspaceId of [DemoBWorkspace.MAIN_WORKSPACE_ID, DemoBWorkspace.POPUP_WORKSPACE_ID]) {
+            me.crossWindowParticipations.get(workspaceId)?.destroy();
+            me.crossWindowParticipations.delete(workspaceId);
+            me.crossWindowGeometry.delete(workspaceId)
+        }
+
+        me.crossWindowHosts.delete(DemoBWorkspace.POPUP_WORKSPACE_ID);
+        me.workspaceProjectionRequests.delete(DemoBWorkspace.POPUP_WORKSPACE_ID);
+        me.crossWindowTargetWindowId = null;
+        me.crossWindowStagePromise   = null;
+        me.crossWindowStageResolve   = null;
+        me.crossWindowStageReject    = null;
+
+        return me.workspaceSet.unregister(DemoBWorkspace.POPUP_WORKSPACE_ID)
+    }
+
+    /**
+     * @summary Commits the popup's model-resolved stack back into the main workspace as one atomic
+     * `transferNode`, then reconciles target-first and retires the emptied popup registry entry.
+     *
+     * The owner re-validates both semantic workspace direction and source stack identity before
+     * accepting the executor pair. Adoption is SYNCHRONOUS — the truth the coordinator consumes
+     * before it retires the source gesture. View reconciliation is deferred, target-first, and
+     * cannot roll model truth back: a render-target disappearance or close failure merely leaves
+     * an honest empty/retired popup surface while main ownership remains committed.
+     * @param {Object} data
+     * @returns {Promise<Object>|Boolean} a truthy accepted lifecycle, or false before adoption.
+     * @protected
+     */
+    commitWholeStackReturn(data) {
+        let me = this,
+            {
+                descriptor,
+                sourceDocument,
+                sourceWorkspaceId,
+                targetDocument,
+                targetWorkspaceId
+            } = data,
+            sourceBefore = me.getWorkspaceDocument(sourceWorkspaceId);
+
+        if (descriptor?.operation !== 'transferNode'
+            || sourceWorkspaceId !== DemoBWorkspace.POPUP_WORKSPACE_ID
+            || targetWorkspaceId !== DemoBWorkspace.MAIN_WORKSPACE_ID
+            || DockZoneModel.resolveStackRoot(sourceBefore) !== descriptor.nodeId) {
+            return false
+        }
+
+        let nodeIds = DockZoneModel.reachableNodeIds({nodes: sourceBefore.nodes, root: descriptor.nodeId}),
+            itemIds = [...new Set([...nodeIds].flatMap(nodeId =>
+                sourceBefore.nodes[nodeId]?.type === 'tabs' ? sourceBefore.nodes[nodeId].items || [] : []
+            ))];
+
+        if (!itemIds.length || !me.adoptCommittedTransferPair({
+            sourceDocument,
+            sourceWorkspaceId,
+            targetDocument,
+            targetWorkspaceId
+        })) {
+            return false
+        }
+
+        // The pair is committed NOW. Clear every click-detach entry synchronously so a physical
+        // disconnect racing the deferred projections cannot route any member through transferItem
+        // again. The pane instances themselves move through the target-first reconciler below.
+        itemIds.forEach(itemId => delete me.detachedPanes[itemId]);
+
+        me.refreshPromise = me.refreshPromise
+            .then(() => me.timeout(0))
+            .then(async () => {
+                let errors = [];
+
+                try {
+                    if (!me.isDestroyed) {
+                        await me.refreshWorkspace(targetWorkspaceId, targetDocument)
+                    }
+
+                    if (!me.isDestroyed) {
+                        await me.refreshWorkspace(sourceWorkspaceId, sourceDocument)
+                    }
+                } catch (error) {
+                    errors.push(`projection after stack return failed: ${error?.message || String(error)}`)
+                }
+
+                let retired = me.isDestroyed ? false : me.retireReturnedPopupWorkspace(),
+                    receipt = {
+                        applied         : true,
+                        errors,
+                        itemIds,
+                        sourceWorkspaceId,
+                        targetWorkspaceId,
+                        workspaceRetired: retired
+                    };
+
+                me.crossWindowGestureResolve?.(receipt);
+                me.crossWindowGestureResolve = null;
+
+                return receipt
+            });
+
+        return me.refreshPromise
+    }
+
+    /**
      * Publishes the atomic transfer pair, then reconciles target before source. Target-first is
      * load-bearing: it adopts the cached pane across the window boundary before the source shell
      * can classify the now-absent item as a retirement.
@@ -1323,6 +1480,10 @@ class DemoBWorkspace extends Container {
                 targetDocument,
                 targetWorkspaceId
             } = data;
+
+        if (descriptor?.operation === 'transferNode') {
+            return me.commitWholeStackReturn(data)
+        }
 
         const
             context       = me.crossWindowGestureContext,
@@ -2497,10 +2658,13 @@ class DemoBWorkspace extends Container {
             });
             me.crossWindowStageReject?.(new Error('cross-window target disconnected before readiness settled'));
 
-            me.crossWindowParticipations.get(workspaceId)?.destroy();
-            me.crossWindowParticipations.delete(workspaceId);
+            for (const id of [DemoBWorkspace.MAIN_WORKSPACE_ID, workspaceId]) {
+                me.crossWindowParticipations.get(id)?.destroy();
+                me.crossWindowParticipations.delete(id);
+                me.crossWindowGeometry.delete(id)
+            }
+
             me.crossWindowHosts.delete(workspaceId);
-            me.crossWindowGeometry.delete(workspaceId);
             me.crossWindowTargetWindowId = null;
             me.crossWindowStagePromise   = null;
             me.crossWindowStageResolve   = null;
@@ -2809,6 +2973,7 @@ class DemoBWorkspace extends Container {
             host              = me.crossWindowHosts.get(workspaceId),
             geometry          = me.crossWindowGeometry.get(workspaceId),
             draggedItem       = data.draggedItem,
+            groupNodeId       = draggedItem?.dockGroupNodeId ?? null,
             itemId            = data.itemId ?? draggedItem?.dockItemId,
             sourceWorkspaceId = draggedItem?.dockSourceWorkspaceId ?? workspaceId,
             sourceNodeId      = data.sourceNodeId
@@ -2826,13 +2991,15 @@ class DemoBWorkspace extends Container {
 
         if (indicators && (zone?.nodeId ?? null) !== (indicators.candidateSet?.zone?.nodeId ?? null)) {
             indicators.candidateSet = zone
-                ? producer.produceCandidates({pointer, zones: geometry.zones, itemId, sourceNodeId, root: geometry.root})
+                ? producer.produceCandidates({
+                    pointer, zones: geometry.zones, groupNodeId, itemId, sourceNodeId, root: geometry.root
+                })
                 : null
         }
 
         let candidate = indicators?.updatePointer(pointer) ?? null,
             preview   = candidate?.preview
-                ?? producer.produce({pointer, zones: geometry.zones, itemId, sourceNodeId});
+                ?? producer.produce({pointer, zones: geometry.zones, groupNodeId, itemId, sourceNodeId});
 
         if (renderer) {
             renderer.dockPreview = preview;
@@ -2923,17 +3090,21 @@ class DemoBWorkspace extends Container {
         // Tear-out arms on the MAIN workspace only: the popup-workspace projection is itself a
         // vessel-hosted render target — a tear-out FROM a vessel is popup-over-popup territory
         // (G3), deliberately not wired here.
-        let tearOut = workspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID;
+        let tearOut   = workspaceId === DemoBWorkspace.MAIN_WORKSPACE_ID;
+        let stackDrag = workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID;
 
         return DockLayoutAdapter.project(document, {
             applyDockZoneOperation   : descriptor => me.applyWorkspaceOperation(workspaceId, descriptor),
             crossWindowSortGroup     : me.crossWindowEnabled ? DemoBWorkspace.CROSS_WINDOW_SORT_GROUP : null,
             enableDockTearOut        : tearOut,
+            enableStackDrag          : stackDrag,
             onDockCrossZoneDragCancel: data => me.onDockCrossZoneDragCancel(workspaceId, data),
             onDockCrossZoneDragMove  : data => me.onDockCrossZoneDragMove(workspaceId, data),
             onDockCrossZoneDrop      : data => me.onDockCrossZoneDrop(workspaceId, data),
-            onDockZoneDocumentChange : nextDocument => me.onWorkspaceDocumentChange(workspaceId, nextDocument),
-            resolveComponentRef      : resolveComponentRef
+            onDockStackDragTerminal  : ({itemId, outcome}) =>
+                me.vesselParkHandlers?.onGestureTerminal({itemId, outcome}),
+            onDockZoneDocumentChange: nextDocument => me.onWorkspaceDocumentChange(workspaceId, nextDocument),
+            resolveComponentRef     : resolveComponentRef
                 || ((componentRef, item, itemId) => me.resolvePane(itemId, item)),
             resolveRevealComponentRef: (componentRef, item, itemId) => me.resolvePane(itemId, item),
             workspaceId,

--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -1444,15 +1444,33 @@ class DemoBWorkspace extends Container {
                     errors.push(`projection after stack return failed: ${error?.message || String(error)}`)
                 }
 
-                let retired = me.isDestroyed ? false : me.retireReturnedPopupWorkspace(),
-                    receipt = {
-                        applied         : true,
-                        errors,
-                        itemIds,
-                        sourceWorkspaceId,
-                        targetWorkspaceId,
-                        workspaceRetired: retired
-                    };
+                let retired = me.isDestroyed ? false : me.retireReturnedPopupWorkspace();
+
+                if (!me.isDestroyed) {
+                    // Direct return never creates a park slot: its committed terminal is therefore
+                    // intentionally a no-op for the vessel-park machine. This owner closes the now
+                    // empty popup after adoption + retirement, without making platform-close
+                    // success part of model truth.
+                    try {
+                        let closing = Neo.Main.windowClose({
+                            names   : ['demo-b-cross-window'],
+                            windowId: me.windowId
+                        });
+
+                        closing?.catch?.(() => {})
+                    } catch {
+                        // best-effort vessel retirement; committed ownership never rolls back
+                    }
+                }
+
+                let receipt = {
+                    applied         : true,
+                    errors,
+                    itemIds,
+                    sourceWorkspaceId,
+                    targetWorkspaceId,
+                    workspaceRetired: retired
+                };
 
                 me.crossWindowGestureResolve?.(receipt);
                 me.crossWindowGestureResolve = null;

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -71,6 +71,27 @@
     }
 }
 
+// Runtime-only handle projected into the active header of a transferable stack root. The real
+// tab button remains the drag owner; this child only distinguishes whole-stack intent from an
+// ordinary item drag. No application palette dependency — it inherits the tab's own foreground.
+.neo-dock-stack-handle {
+    cursor             : grab;
+    display            : inline-flex;
+    margin-inline-start: 0.4em;
+    opacity            : 0.65;
+    padding-inline     : 0.15em;
+    touch-action       : none;
+    user-select        : none;
+
+    &:hover {
+        opacity: 1;
+    }
+
+    &:active {
+        cursor: grabbing;
+    }
+}
+
 // Arrival settle: a brief outline pulse on the pane that just landed from another window
 // (§2.3 cross-window arrival) — the workspace toggles the class; the animation completes
 // itself. transform/opacity/outline only: no layout thrash.

--- a/src/dashboard/DockCrossWindowParticipation.mjs
+++ b/src/dashboard/DockCrossWindowParticipation.mjs
@@ -35,7 +35,9 @@ import DockZoneModel         from './DockZoneModel.mjs';
  *
  * The cross-window drag payload contract (stamped by {@link Neo.dashboard.DockTabSortZone} at
  * drag start): `draggedItem.dockItemId` names the dock catalog item, and
- * `draggedItem.dockSourceWorkspaceId` names the workspace document it departs. The local/foreign
+ * `draggedItem.dockSourceWorkspaceId` names the workspace document it departs. A whole-stack
+ * source additionally stamps `draggedItem.dockGroupNodeId`; only the source document's
+ * model-resolved stack root is eligible for the `transferNode` path. The local/foreign
  * discriminator keys on the LATTER's identity with this workspace — item-id presence in the
  * target catalog is never ownership evidence (a foreign item with a colliding id must reach the
  * executor's fail-closed collision rejection, not commit the local record) — and a payload
@@ -70,7 +72,9 @@ class DockCrossWindowParticipation extends Base {
          * Owner seam: publishes an atomically-transferred document PAIR through the workspace
          * set's change-notification path. Receives
          * `{sourceWorkspaceId, sourceDocument, targetWorkspaceId, targetDocument, descriptor}`
-         * where both documents are the executor's unchanged, finite committed results.
+         * where both documents are the executor's unchanged, finite committed results. Returns a
+         * truthy acknowledgement only after the pair was synchronously accepted; a refusal keeps
+         * the coordinator's source-retirement path closed.
          * @member {Function|null} commitTransfer=null
          */
         commitTransfer: null,
@@ -165,7 +169,9 @@ class DockCrossWindowParticipation extends Base {
      * @summary The discriminated commit — the one decision this class adds. A payload whose
      * `dockSourceWorkspaceId` IS this workspace commits through the landed single-document seam;
      * any other source workspace composes ONE `transferItem` descriptor (the converted operation
-     * nested as its `target`) and publishes the landed atomic two-document transfer verbatim.
+     * nested as its `target`) and publishes the landed atomic two-document transfer verbatim. A
+     * payload carrying `dockGroupNodeId` instead admits only an exact `transferNode` descriptor for
+     * the source document's resolved stack root; a mismatch fails closed before the executor.
      * Discrimination is workspace IDENTITY, never item-id presence in the target catalog — an id
      * collision across workspaces rides the executor's fail-closed rejection. Every unprovable
      * input — missing payload identity, unresolvable source document, executor errors — fails
@@ -174,17 +180,57 @@ class DockCrossWindowParticipation extends Base {
      * @param {Object} operation The converted `addTab`/`splitNode` descriptor from the target's
      *     preview→operation pipeline.
      * @param {Object} draggedItem The coordinator's drag payload — carries `dockItemId` +
-     *     `dockSourceWorkspaceId` per the class-summary payload contract.
+     *     `dockSourceWorkspaceId` and optional `dockGroupNodeId` per the class-summary payload contract.
      * @returns {Object|null} the owner commit result, or null when nothing committed.
      */
     commitDrop(operation, draggedItem) {
         let me                = this,
+            groupNodeId       = draggedItem?.dockGroupNodeId,
             itemId            = draggedItem?.dockItemId,
             sourceWorkspaceId = draggedItem?.dockSourceWorkspaceId,
             document          = me.getDocument?.();
 
         if (!operation || !itemId || !document) {
             return null
+        }
+
+        if (groupNodeId) {
+            // A whole-stack handle is a cross-workspace gesture only. Within one document the
+            // model's `moveNode` verb owns grouped moves; silently routing a `transferNode` through
+            // the local item seam would turn one semantic operation into another by accident.
+            if (sourceWorkspaceId == null || sourceWorkspaceId === me.workspaceId) {
+                return null
+            }
+
+            const sourceDocument = me.getForeignDocument?.(sourceWorkspaceId);
+
+            if (!sourceDocument || !me.commitTransfer ||
+                operation.operation !== 'transferNode' || operation.nodeId !== groupNodeId ||
+                DockZoneModel.resolveStackRoot(sourceDocument) !== groupNodeId) {
+                return null
+            }
+
+            const descriptor = {
+                ...operation,
+                sourceWorkspaceId,
+                targetWorkspaceId: me.workspaceId
+            };
+
+            const result = DockZoneModel.transferNode(sourceDocument, document, descriptor);
+
+            if (result.errors.length) {
+                return null
+            }
+
+            const published = me.commitTransfer({
+                descriptor,
+                sourceDocument   : result.sourceDocument,
+                sourceWorkspaceId,
+                targetDocument   : result.targetDocument,
+                targetWorkspaceId: me.workspaceId
+            });
+
+            return published ? result : null
         }
 
         // LOCAL means the payload NAMES this workspace as its source (two windows may project the
@@ -216,7 +262,7 @@ class DockCrossWindowParticipation extends Base {
             return null
         }
 
-        me.commitTransfer({
+        const published = me.commitTransfer({
             descriptor,
             sourceDocument   : result.sourceDocument,
             sourceWorkspaceId,
@@ -224,7 +270,7 @@ class DockCrossWindowParticipation extends Base {
             targetWorkspaceId: me.workspaceId
         });
 
-        return result
+        return published ? result : null
     }
 
     /**

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -6,6 +6,10 @@ import DockTabSortZone    from './DockTabSortZone.mjs';
 import DockZoneModel      from './DockZoneModel.mjs';
 import TabOverflowPlugin  from '../tab/plugin/Overflow.mjs';
 
+// Private runtime restoration slot for live component instances projected through the popup
+// stack grip. Symbol-keyed so it can never collide with application config or persisted data.
+const stackHeaderSource = Symbol('dockStackHeaderSource');
+
 /**
  * @summary Projects Agent Harness dock-zone model nodes into existing Neo layout and tab configs.
  *
@@ -113,22 +117,47 @@ class DockLayoutAdapter extends Base {
      * @summary Applies adapter-owned item metadata and one-use add-tab decoration to a pane config.
      *
      * Reconciliation discovers live panes before consulting its app resolver. When a pane is genuinely
-     * absent, this pure helper lets that resolver prepare the same config the normal projection path
+     * absent, this helper lets that resolver prepare the same config the normal projection path
      * would have emitted without copying dashboard-owned header policy into the consuming workspace.
-     * Neo instances intentionally pass through unchanged; transient header decoration remains a
-     * plain-config capability and therefore fails closed to an instant landing for custom instances.
+     * Add-tab animation remains plain-config-only. The stack handle also supports a LIVE component
+     * instance through a symbol-keyed runtime header overlay whose exact prior ownership/value is
+     * restored as soon as that instance projects without the handle; the popup affordance therefore
+     * cannot leak into the main workspace or persisted item state.
      * @param {*} component Resolved pane config or live component instance.
      * @param {String} itemId Stable item identity.
      * @param {Object} item Persisted item record.
      * @param {Object} [options={}]
      * @param {String|null} [options.nodeId=null] Owning projected tabs-node id.
+     * @param {Boolean} [options.stackHandle=false] Decorate this exact header with the runtime grip.
      * @param {Object|null} [options.tabInsertDescriptor=null] One-use normalized `addTab` correlation.
      * @returns {*}
      * @static
      */
-    static decorateProjectedItem(component, itemId, item, {nodeId=null, tabInsertDescriptor=null}={}) {
+    static decorateProjectedItem(component, itemId, item, {nodeId=null, stackHandle=false, tabInsertDescriptor=null}={}) {
         let config = this.decorateItemConfig(component, itemId, item),
             header;
+
+        if (config instanceof Base) {
+            let source = config[stackHeaderSource];
+
+            if (stackHandle) {
+                source ||= config[stackHeaderSource] = {
+                    hadOwn: Object.hasOwn(config, 'header'),
+                    value : config.header
+                };
+                config.header = this.createStackHeader(source.value, itemId, item)
+            } else if (source) {
+                if (source.hadOwn) {
+                    config.header = source.value
+                } else {
+                    delete config.header
+                }
+
+                delete config[stackHeaderSource]
+            }
+
+            return config
+        }
 
         if (config?.constructor === Object
             && tabInsertDescriptor?.operation === 'addTab'
@@ -146,7 +175,41 @@ class DockLayoutAdapter extends Base {
             }
         }
 
+        if (config?.constructor === Object && stackHandle) {
+            config.header = this.createStackHeader(config.header, itemId, item)
+        }
+
         return config
+    }
+
+    /**
+     * @summary Creates the runtime-only whole-stack header overlay from an untouched source.
+     * @param {Object|null} header Existing header config.
+     * @param {String} itemId Stable item identity.
+     * @param {Object} item Persisted item record.
+     * @returns {Object}
+     * @protected
+     * @static
+     */
+    static createStackHeader(header, itemId, item) {
+        let source = header?.constructor === Object ? header : {text: header ?? item?.title ?? itemId},
+            text   = source.text;
+
+        return {
+            ...source,
+            text: [
+                ...(Array.isArray(text)
+                    ? text
+                    : [text?.constructor === Object ? text : {vtype: 'text', text: text ?? item?.title ?? itemId}]),
+                {
+                    'aria-hidden': true,
+                    cls          : ['neo-dock-stack-handle'],
+                    tag          : 'span',
+                    text         : '⠿',
+                    title        : 'Drag whole stack'
+                }
+            ]
+        }
     }
 
     /**
@@ -249,6 +312,8 @@ class DockLayoutAdapter extends Base {
      * re-projection loop) with no error surfacing anywhere.
      * @param {Object} model
      * @param {Object} [options={}]
+     * @param {Boolean} [options.enableStackDrag=false] Decorate the model-resolved stack root
+     *     with one runtime-only whole-stack grip and arm its existing dock SortZone.
      * @param {Function} [options.resolveComponentRef]
      * @param {Function} [options.resolveRevealComponentRef] Durable resolver retained by edge rails.
      * @param {Object|null} [options.tabInsertDescriptor] Runtime-only normalized `addTab`
@@ -267,7 +332,10 @@ class DockLayoutAdapter extends Base {
             throw new Error('DockLayoutAdapter requires a model with `root` and `nodes`.')
         }
 
-        let config = this.projectNode(model.root, {
+        let stackDragNodeId = options.enableStackDrag === true
+                ? DockZoneModel.resolveStackRoot(model)
+                : null,
+            config = this.projectNode(model.root, {
             applyDockZoneOperation: options.applyDockZoneOperation,
             autoHideRevealOnHover : options.autoHideRevealOnHover === true,
             // Cross-WINDOW participation (docking design record §2.3, additive + opt-in): a composition that
@@ -289,6 +357,7 @@ class DockLayoutAdapter extends Base {
             onDockCrossZoneDragCancel: options.onDockCrossZoneDragCancel,
             onDockCrossZoneDragMove  : options.onDockCrossZoneDragMove,
             onDockCrossZoneDrop      : options.onDockCrossZoneDrop,
+            onDockStackDragTerminal  : options.onDockStackDragTerminal,
             onDockTearOutCancel      : options.onDockTearOutCancel,
             onDockTearOutEntry       : options.onDockTearOutEntry,
             onDockTearOutExit        : options.onDockTearOutExit,
@@ -298,6 +367,7 @@ class DockLayoutAdapter extends Base {
             resolveRevealComponentRef: options.resolveRevealComponentRef
                 || options.resolveComponentRef
                 || (() => null),
+            stackDragNodeId,
             tabInsertDescriptor: options.tabInsertDescriptor ?? null,
             workspaceId        : options.workspaceId ?? null
         });
@@ -690,13 +760,18 @@ class DockLayoutAdapter extends Base {
         }
 
         // One-use operation correlation: only a real addTab's exact target header receives
-        // the dashboard-owned producer. Non-object component results fail safe to an instant
-        // landing; no broad selector or document mutation is used as a fallback.
-        projectedItems = items.map(itemId => this.decorateProjectedItem(
+        // the dashboard-owned producer. Whole-stack projection additionally overlays the active
+        // root header (plain config OR live instance) with exact restoration on its next item-only
+        // projection; no broad selector or committed-document mutation is used as a fallback.
+        projectedItems = items.map((itemId, index) => this.decorateProjectedItem(
             this.projectItem(itemId, context),
             itemId,
             context.items[itemId],
-            {nodeId, tabInsertDescriptor: context.tabInsertDescriptor}
+            {
+                nodeId,
+                stackHandle        : nodeId === context.stackDragNodeId && index === activeIndex,
+                tabInsertDescriptor: context.tabInsertDescriptor
+            }
         ));
 
         return {
@@ -721,6 +796,7 @@ class DockLayoutAdapter extends Base {
                 plugins       : [{module: TabOverflowPlugin}],
                 sortZoneConfig: {
                     module          : DockTabSortZone,
+                    dockGroupNodeId : nodeId === context.stackDragNodeId ? nodeId : null,
                     dockItemIds     : items,
                     dockSourceNodeId: nodeId,
                     // §2.3 source identity (opt-in): the coordinator gates registration on
@@ -752,6 +828,10 @@ class DockLayoutAdapter extends Base {
                 // closure holds `context` (captured here, not serialized), so the reducer survives config
                 // cloning and needs no component-tree walk. The reducer hit-tests the target zone + commits.
                 dockCrossZoneDrop: data => context.onDockCrossZoneDrop?.(data),
+                // Whole-stack terminal: exactly one committed/cancelled/refused outcome leaves
+                // the generic SortZone. The host composes its vessel-park policy at this closure;
+                // no app callback enters sortZoneConfig or committed dock state.
+                dockStackDragTerminal: data => context.onDockStackDragTerminal?.(data),
                 // Tear-out gesture seams (§2.8): the zone re-fires the inherited boundary events here.
                 // Cancel retires the host's vessel with zero model mutation; entry is a resumed
                 // in-window gesture (vessel closes, no outcome); exit is where the host acquires its

--- a/src/dashboard/DockPreviewProducer.mjs
+++ b/src/dashboard/DockPreviewProducer.mjs
@@ -180,14 +180,16 @@ class DockPreviewProducer extends Base {
      * @param {Object} params
      * @param {Object} params.pointer {x, y} window-local pointer
      * @param {Object[]} params.zones [{nodeId, rect, orientation?}] rendered dock-zone rects, outer → inner
-     * @param {String} params.itemId the dragged dock item id
+     * @param {String} params.itemId the representative dragged dock item id
+     * @param {String} [params.groupNodeId] runtime-only whole-stack source node id
      * @param {String} [params.containerId] the hovered workspace/container id
      * @param {Object} [params.source] producer surface, e.g. {surface, sortZoneId}
      * @param {String} [params.sourceNodeId] the drag's origin dock node (used as sortZoneId fallback)
      * @returns {Object|null} a `neo.harness.dockPreview.v1` payload, or null
      */
-    produce({pointer, zones, itemId, containerId=null, source=null, sourceNodeId=null}={}) {
-        if (typeof itemId !== 'string' || !itemId) return null;
+    produce({pointer, zones, itemId, groupNodeId=null, containerId=null, source=null, sourceNodeId=null}={}) {
+        if (typeof itemId !== 'string' || !itemId ||
+            (groupNodeId != null && (typeof groupNodeId !== 'string' || !groupNodeId))) return null;
 
         let zone = this.hitTestZone(zones, pointer);
 
@@ -197,7 +199,7 @@ class DockPreviewProducer extends Base {
 
         if (kind === 'rejected') return null;
 
-        return this.buildPreview({containerId, itemId, source, sourceNodeId}, zone.nodeId, kind, zone.orientation)
+        return this.buildPreview({containerId, groupNodeId, itemId, source, sourceNodeId}, zone.nodeId, kind, zone.orientation)
     }
 
     /**
@@ -206,16 +208,18 @@ class DockPreviewProducer extends Base {
      * The single payload-assembly path shared by the pointer-inference `produce()` and the
      * indicator-menu `produceCandidates()`, so an indicator candidate and the pointer-inferred
      * preview for the same placement are IDENTICAL objects field-for-field — including the
-     * deterministic `previewId` (`preview:<item>:<node>:<kind>`) the renderer diffs on.
-     * @param {Object} params {itemId, containerId, source, sourceNodeId} as passed to the producer entry points
+     * deterministic `previewId` (`preview:<item>:<node>:<kind>` or
+     * `preview:group:<groupNodeId>:<node>:<kind>`) the renderer diffs on.
+     * @param {Object} params {itemId, groupNodeId, containerId, source, sourceNodeId} as passed to the producer entry points
      * @param {String} nodeId the target dock node
      * @param {String} kind a non-`rejected` placement kind
      * @param {String} [orientation] the target's parent-split orientation (required for `split-*` kinds)
      * @returns {Object} a `neo.harness.dockPreview.v1` payload
      * @protected
      */
-    buildPreview({containerId=null, itemId, source=null, sourceNodeId=null}, nodeId, kind, orientation) {
-        let placement = {kind};
+    buildPreview({containerId=null, groupNodeId=null, itemId, source=null, sourceNodeId=null}, nodeId, kind, orientation) {
+        let placement = {kind},
+            subjectId = groupNodeId ? `group:${groupNodeId}` : itemId;
 
         if (kind === 'split-before' || kind === 'split-after') {
             placement.orientation = orientation
@@ -223,12 +227,13 @@ class DockPreviewProducer extends Base {
 
         return {
             schema   : this.schema,
-            previewId: `preview:${itemId}:${nodeId}:${kind}`,
+            previewId: `preview:${subjectId}:${nodeId}:${kind}`,
             itemId,
-            source   : source ?? {surface: 'dashboard-sort-zone', sortZoneId: sourceNodeId},
-            target   : {containerId, nodeId},
+            ...(groupNodeId ? {groupNodeId} : {}),
+            source  : source ?? {surface: 'dashboard-sort-zone', sortZoneId: sourceNodeId},
+            target  : {containerId, nodeId},
             placement,
-            feedback : {state: 'accepted'}
+            feedback: {state: 'accepted'}
         }
     }
 
@@ -283,22 +288,24 @@ class DockPreviewProducer extends Base {
      * @param {Object} params
      * @param {Object} params.pointer {x, y} window-local pointer
      * @param {Object[]} params.zones [{nodeId, rect, orientation?}] rendered dock-zone rects, outer → inner
-     * @param {String} params.itemId the dragged dock item id
+     * @param {String} params.itemId the representative dragged dock item id
+     * @param {String} [params.groupNodeId] runtime-only whole-stack source node id
      * @param {String} [params.containerId] the hovered workspace/container id
      * @param {Object} [params.source] producer surface, e.g. {surface, sortZoneId}
      * @param {String} [params.sourceNodeId] the drag's origin dock node
      * @param {Object} [params.root] {nodeId, rect} the document root + its measured rect (enables the edge chips)
      * @returns {Object|null} a `neo.harness.dockCandidates.v1` payload, or null
      */
-    produceCandidates({pointer, zones, itemId, containerId=null, source=null, sourceNodeId=null, root=null}={}) {
-        if (typeof itemId !== 'string' || !itemId) return null;
+    produceCandidates({pointer, zones, itemId, groupNodeId=null, containerId=null, source=null, sourceNodeId=null, root=null}={}) {
+        if (typeof itemId !== 'string' || !itemId ||
+            (groupNodeId != null && (typeof groupNodeId !== 'string' || !groupNodeId))) return null;
 
         let me   = this,
             zone = me.hitTestZone(zones, pointer);
 
         if (!zone) return null;
 
-        let params = {containerId, itemId, source, sourceNodeId},
+        let params = {containerId, groupNodeId, itemId, source, sourceNodeId},
             cross  = ['center', 'top', 'right', 'bottom', 'left'].map(position => ({
                 position,
                 preview: me.buildPreview(params, zone.nodeId, me.directionKind(position, zone.orientation), zone.orientation)
@@ -319,9 +326,10 @@ class DockPreviewProducer extends Base {
         return {
             schema: me.candidatesSchema,
             itemId,
-            zone  : {nodeId: zone.nodeId, rect: zone.rect, orientation: zone.orientation ?? null},
+            ...(groupNodeId ? {groupNodeId} : {}),
+            zone: {nodeId: zone.nodeId, rect: zone.rect, orientation: zone.orientation ?? null},
             cross,
-            root  : rootOut
+            root: rootOut
         }
     }
 }

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -60,6 +60,13 @@ class DockTabSortZone extends TabHeaderSortZone {
          */
         dockItemIds: null,
         /**
+         * The model-resolved transferable stack root this toolbar's grip represents. `null` keeps
+         * the toolbar item-only. A non-null value is runtime projection state: it stamps the drag
+         * payload but never enters the committed dock document.
+         * @member {String|null} dockGroupNodeId=null
+         */
+        dockGroupNodeId: null,
+        /**
          * The dock-zone (tabs node) id this toolbar renders — the source of a cross-zone move.
          * @member {String|null} dockSourceNodeId=null
          */
@@ -96,6 +103,14 @@ class DockTabSortZone extends TabHeaderSortZone {
      * @member {Boolean} remoteDropCommitted=false
      */
     remoteDropCommitted = false
+
+    /**
+     * True only while the projected stack grip owns the active gesture. The flag bypasses the
+     * base tab-reorder machinery while retaining its drag proxy + coordinator lifecycle.
+     * @member {Boolean} stackDragActive=false
+     * @protected
+     */
+    stackDragActive = false
 
     /**
      * The source toolbar's PRISTINE viewport rect, measured once per gesture at
@@ -283,6 +298,33 @@ class DockTabSortZone extends TabHeaderSortZone {
     async onDragStart(data) {
         let me = this;
 
+        if (me.isStackHandleDrag?.(data)) {
+            let pathIds     = new Set((data.path || []).map(node => node.id).filter(Boolean)),
+                draggedItem = me.owner.items.find(item => pathIds.has(item.id)),
+                index       = me.owner.items.indexOf(draggedItem);
+
+            if (!draggedItem || index < 0 || !me.dockWorkspaceId) {
+                return
+            }
+
+            me.dockSourceToolbarRect = await me.owner?.getDomRect() ?? null;
+            me.currentIndex          = index;
+            me.dragComponent         = draggedItem;
+            me.dragElement           = draggedItem.vdom;
+            me.stackDragActive       = true;
+            me.startIndex            = index;
+
+            draggedItem.dockGroupNodeId       = me.dockGroupNodeId;
+            draggedItem.dockItemId            = me.dockItemIds?.[index] ?? me.dockItemIds?.[0] ?? null;
+            draggedItem.dockSourceWorkspaceId = me.dockWorkspaceId;
+
+            await me.dragStart(data);
+
+            return
+        }
+
+        me.stackDragActive = false;
+
         // The real toolbar boundary — measured BEFORE the base runs: the base drag-start (with
         // its inherited `expandOwnerOnDrag`) WRITES the trimmed button-span dimensions onto the
         // toolbar's live style, so any post-`super` measure reads the mutated box, not the
@@ -294,9 +336,21 @@ class DockTabSortZone extends TabHeaderSortZone {
         let item = me.dragComponent;
 
         if (item) {
+            delete item.dockGroupNodeId;
             item.dockItemId              = me.dockItemIds?.[me.startIndex] ?? null;
             item.dockSourceWorkspaceId   = me.dockWorkspaceId
         }
+    }
+
+    /**
+     * @summary Whether this drag originated on the opt-in whole-stack grip.
+     * @param {Object} data drag-start payload with the main-thread DOM path
+     * @returns {Boolean}
+     * @protected
+     */
+    isStackHandleDrag(data) {
+        return !!this.dockGroupNodeId && (data?.path || []).some(node =>
+            Array.isArray(node.cls) && node.cls.includes('neo-dock-stack-handle'))
     }
 
     /**
@@ -396,6 +450,51 @@ class DockTabSortZone extends TabHeaderSortZone {
             tabContainer = me.owner?.up?.(),
             {clientX, clientY} = data || {};
 
+        if (me.stackDragActive) {
+            let commitError    = null,
+                terminalItemId = me.dragComponent?.dockItemId ?? itemId ?? null;
+
+            try {
+                if (me.sortGroup && me.dragComponent) {
+                    me.dragCoordinator?.[data.cancelled ? 'onDragCancel' : 'onDragEnd']({
+                        draggedItem   : me.dragComponent,
+                        sourceSortZone: me
+                    })
+                }
+            } catch (error) {
+                commitError = error
+            }
+
+            const committed = !data.cancelled && !commitError && me.remoteDropCommitted,
+                outcome     = committed ? 'committed' : data.cancelled ? 'cancelled' : 'rejected';
+
+            try {
+                tabContainer?.fire('dockStackDragTerminal', {
+                    cancelled        : data.cancelled === true,
+                    committed,
+                    errors           : commitError ? [commitError?.message || String(commitError)] : [],
+                    groupNodeId      : me.dockGroupNodeId,
+                    itemId           : terminalItemId,
+                    outcome,
+                    sortZone         : me,
+                    sourceWorkspaceId: me.dockWorkspaceId
+                })
+            } finally {
+                me.remoteDropCommitted = false;
+                me.dragEnd(data);
+                me.dragComponent   = null;
+                me.dragElement     = null;
+                me.stackDragActive = false;
+                me.startIndex      = -1
+            }
+
+            if (commitError) {
+                throw commitError
+            }
+
+            return
+        }
+
         if (me.sortGroup && me.dragComponent) {
             me.dragCoordinator?.[data.cancelled ? 'onDragCancel' : 'onDragEnd']({
                 draggedItem   : me.dragComponent,
@@ -467,6 +566,11 @@ class DockTabSortZone extends TabHeaderSortZone {
                 screenY       : data.screenY,
                 sourceSortZone: me
             })
+        }
+
+        if (me.stackDragActive) {
+            me.dragMove(data);
+            return
         }
 
         await super.onDragMove(data);

--- a/src/dashboard/dockPreviewContract.mjs
+++ b/src/dashboard/dockPreviewContract.mjs
@@ -58,8 +58,9 @@ export const VALID_PLACEMENT_KINDS = new Set([...EDGE_KINDS, ...SPLIT_KINDS, ...
  *
  * Returns true only for a well-formed `neo.harness.dockPreview.v1` payload that carries a stable
  * `itemId`, a `target.nodeId`, a known `placement.kind`, an accept/reject `feedback.state`, and (for
- * split placements) a valid `placement.orientation`. Anything malformed, partial or unknown returns
- * false so consumers clear/fail rather than guess.
+ * split placements) a valid `placement.orientation`. A whole-stack gesture may additionally carry
+ * a runtime-only `groupNodeId`; when present it must be a non-empty string. Anything malformed,
+ * partial or unknown returns false so consumers clear/fail rather than guess.
  * @param {Object|null} preview
  * @returns {Boolean}
  */
@@ -67,6 +68,8 @@ export function isValidPreview(preview) {
     if (!preview || typeof preview !== 'object')               return false;
     if (preview.schema !== PREVIEW_SCHEMA)                     return false;
     if (typeof preview.itemId !== 'string' || !preview.itemId) return false;
+    if (preview.groupNodeId != null &&
+        (typeof preview.groupNodeId !== 'string' || !preview.groupNodeId)) return false;
 
     let {feedback, placement, target} = preview;
 
@@ -164,6 +167,7 @@ export function isValidCandidateSet(set) {
         candidate &&
         isValidPreview(candidate.preview) &&
         candidate.preview.itemId === set.itemId &&
+        candidate.preview.groupNodeId === set.groupNodeId &&
         candidate.preview.target.nodeId === zone.nodeId &&
         crossPlacementMatchesPosition(candidate.position, candidate.preview.placement)
     )) {
@@ -185,6 +189,7 @@ export function isValidCandidateSet(set) {
             chip &&
             isValidPreview(chip.preview) &&
             chip.preview.itemId === set.itemId &&
+            chip.preview.groupNodeId === set.groupNodeId &&
             chip.preview.target.nodeId === root.nodeId &&
             chip.preview.placement.kind === `edge-${chip.edge}`
         )) {
@@ -210,21 +215,52 @@ export function ratioToSizes(ratio, position) {
  * @summary Converts an ACCEPTED drop preview into a semantic dock-zone operation descriptor, or null.
  *
  * The one authored path from a hover preview to a `DockZoneModel` operation. Invalid previews,
- * `rejected` placements, and non-accepted feedback all yield null (no commit). Tab placements emit
- * `addTab` (the adapter downgrades to `moveItem` when the item already lives in the tree); split and
- * edge placements route to `splitNode`.
+ * `rejected` placements, and non-accepted feedback all yield null (no commit). Item previews emit
+ * `addTab` / `splitNode` as before. A preview carrying `groupNodeId` instead emits one
+ * `transferNode` descriptor whose nested target uses the same tab/split placement grammar — the
+ * preview remains the single placement authority for both item and whole-stack drops.
  * @param {Object|null} preview
  * @returns {Object|null}
  */
 export function previewToOperation(preview) {
     if (!isValidPreview(preview)) return null;
 
-    let {feedback, itemId, placement, target} = preview,
-        {kind}                                = placement;
+    let {feedback, groupNodeId, itemId, placement, target} = preview,
+        {kind}                                             = placement;
 
     if (kind === 'rejected' || feedback.state !== 'accepted') return null;
 
     let nodeId = target.nodeId;
+
+    if (groupNodeId) {
+        let nodePlacement;
+
+        if (TAB_KINDS.has(kind)) {
+            nodePlacement = {kind: 'tab-into'}
+        } else if (SPLIT_KINDS.has(kind)) {
+            let position = kind.slice('split-'.length);
+
+            nodePlacement = {
+                orientation: placement.orientation,
+                position,
+                sizes      : ratioToSizes(placement.ratio, position)
+            }
+        } else {
+            let edge = kind.slice('edge-'.length);
+
+            nodePlacement = {
+                edge,
+                orientation: (edge === 'left' || edge === 'right') ? 'horizontal' : 'vertical',
+                sizes      : ratioToSizes(placement.ratio, edge === 'bottom' || edge === 'right' ? 'after' : 'before')
+            }
+        }
+
+        return {
+            operation: 'transferNode',
+            nodeId   : groupNodeId,
+            target   : {targetNodeId: nodeId, placement: nodePlacement}
+        }
+    }
 
     if (TAB_KINDS.has(kind)) {
         return {operation: 'addTab', itemId, tabsNodeId: nodeId, index: Number.isInteger(placement.index) ? placement.index : null}

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
@@ -324,6 +324,166 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
         expect(workspace.popupDocument.items.workbench).toBeUndefined()
     });
 
+    test('whole-stack return commits synchronously, reconciles target-first, then unregisters the emptied popup', async () => {
+        const detached = DockZoneModel.transferItem(
+            workspace.dockModel,
+            DemoBWorkspace.createPopupDocument(),
+            {
+                itemId           : 'workbench',
+                sourceWorkspaceId: DemoBWorkspace.MAIN_WORKSPACE_ID,
+                targetWorkspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID,
+                target           : {operation: 'addTab', tabsNodeId: 'popup-tabs'}
+            }
+        );
+
+        expect(detached.errors).toEqual([]);
+
+        workspace.dockModel     = detached.sourceDocument;
+        workspace.popupDocument = detached.targetDocument;
+        workspace.detachedPanes.workbench = {
+            tabsNodeId: 'workbench-tabs', windowId: 'window-popup', windowName: 'demo-b-cross-window'
+        };
+
+        const descriptor = {
+            operation        : 'transferNode',
+            nodeId           : DockZoneModel.resolveStackRoot(workspace.popupDocument),
+            sourceWorkspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID,
+            targetWorkspaceId: DemoBWorkspace.MAIN_WORKSPACE_ID,
+            target           : {targetNodeId: 'side-tabs', placement: {kind: 'tab-into'}}
+        };
+        const returned = DockZoneModel.transferNode(workspace.popupDocument, workspace.dockModel, descriptor);
+
+        expect(returned.errors).toEqual([]);
+
+        const refreshes = [];
+
+        workspace.timeout = async () => {};
+        workspace.refreshWorkspace = async (workspaceId, document) => {
+            refreshes.push({document, workspaceId})
+        };
+
+        const commit = workspace.commitCrossWindowTransfer({
+            descriptor,
+            sourceDocument   : returned.sourceDocument,
+            sourceWorkspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID,
+            targetDocument   : returned.targetDocument,
+            targetWorkspaceId: DemoBWorkspace.MAIN_WORKSPACE_ID
+        });
+
+        // Synchronous admission is the coordinator gate: model truth + disconnect guard are
+        // committed before the promise-owned projection work starts.
+        expect(commit).toBeTruthy();
+        expect(workspace.dockModel.items.workbench).toEqual(initialDocument.items.workbench);
+        expect(workspace.popupDocument.items.workbench).toBeUndefined();
+        expect(workspace.detachedPanes.workbench).toBeUndefined();
+
+        const receipt = await commit;
+
+        expect(refreshes.map(entry => entry.workspaceId)).toEqual([
+            DemoBWorkspace.MAIN_WORKSPACE_ID,
+            DemoBWorkspace.POPUP_WORKSPACE_ID
+        ]);
+        expect(receipt).toMatchObject({
+            applied         : true,
+            errors          : [],
+            itemIds         : ['workbench'],
+            workspaceRetired: true
+        });
+        expect(workspace.workspaceSet.ids()).toEqual([DemoBWorkspace.MAIN_WORKSPACE_ID]);
+        expect(workspace.getWorkspaceDocument(DemoBWorkspace.POPUP_WORKSPACE_ID)).toBeNull();
+
+        // A later explicit stage is a new lifetime: registration is restored against the current
+        // empty owner field, never kept alive as a ghost entry after the prior vessel retired.
+        expect(workspace.ensurePopupWorkspaceRegistered()).toBe(true);
+        expect(workspace.getWorkspaceDocument(DemoBWorkspace.POPUP_WORKSPACE_ID)).toBe(workspace.popupDocument)
+    });
+
+    test('the popup group identity reaches the existing preview/candidate pipeline unchanged', () => {
+        const popup = DemoBWorkspace.createPopupDocument();
+
+        popup.items.workbench = initialDocument.items.workbench;
+        popup.nodes['popup-tabs'].items = ['workbench'];
+        popup.nodes['popup-tabs'].activeItemId = 'workbench';
+        workspace.popupDocument = popup;
+
+        const renderer   = {dockPreview: null, applyTargetGeometry() {}};
+        const indicators = {
+            candidateSet: null,
+            updatePointer() { return this.candidateSet?.cross?.find(candidate => candidate.position === 'center') ?? null }
+        };
+        const host = {
+            down({ntype}) {
+                return ntype === 'dock-preview' ? renderer : indicators
+            }
+        };
+        const geometry = {
+            hostRect: {x: 0, y: 0, width: 400, height: 300},
+            root    : {nodeId: 'main-root', rect: {x: 0, y: 0, width: 400, height: 300}},
+            zones   : [{nodeId: 'side-tabs', rect: {x: 0, y: 0, width: 400, height: 300}, orientation: 'vertical'}]
+        };
+
+        workspace.crossWindowHosts.set(DemoBWorkspace.MAIN_WORKSPACE_ID, host);
+        workspace.crossWindowGeometry.set(DemoBWorkspace.MAIN_WORKSPACE_ID, geometry);
+
+        const preview = workspace.renderWorkspacePreview(DemoBWorkspace.MAIN_WORKSPACE_ID, {
+            draggedItem: {
+                dockGroupNodeId      : 'popup-tabs',
+                dockItemId           : 'workbench',
+                dockSourceWorkspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID
+            },
+            localX: 200,
+            localY: 150
+        });
+
+        expect(preview.groupNodeId).toBe('popup-tabs');
+        expect(preview.previewId).toContain('preview:group:popup-tabs:');
+        expect(indicators.candidateSet.groupNodeId).toBe('popup-tabs');
+        expect(renderer.dockPreview).toBe(preview)
+    });
+
+    test('popup projection alone owns the stack grip and routes one terminal to the optional park machine', () => {
+        const popup     = DemoBWorkspace.createPopupDocument();
+        const terminals = [];
+        const findTabs  = (config, nodeId) => {
+            if (config?.ntype === 'tab-container' && config.dockNodeId === nodeId) return config;
+
+            for (const item of config?.items || []) {
+                const found = findTabs(item, nodeId);
+
+                if (found) return found
+            }
+
+            return null
+        };
+
+        popup.items.workbench = initialDocument.items.workbench;
+        popup.nodes['popup-tabs'].items = ['workbench'];
+        popup.nodes['popup-tabs'].activeItemId = 'workbench';
+        workspace.popupDocument = popup;
+        workspace.vesselParkHandlers = {onGestureTerminal: data => terminals.push(data)};
+
+        const popupTabs = findTabs(workspace.projectDockModel(
+            null,
+            DemoBWorkspace.POPUP_WORKSPACE_ID,
+            popup
+        ), 'popup-tabs');
+
+        expect(popupTabs.headerToolbar.sortZoneConfig.dockGroupNodeId).toBe('popup-tabs');
+        expect(popupTabs.items[0].header.text[1].cls).toEqual(['neo-dock-stack-handle']);
+
+        // The same live pane then projects home item-only: this second projection must restore
+        // its source header before the popup config can leak an affordance into main.
+        const mainTabs = findTabs(workspace.projectDockModel(), 'workbench-tabs');
+
+        expect(mainTabs.headerToolbar.sortZoneConfig.dockGroupNodeId).toBeNull();
+        expect(mainTabs.items[0].header).toBeUndefined();
+
+        popupTabs.listeners.dockStackDragTerminal({
+            itemId: 'workbench', outcome: 'committed', groupNodeId: 'popup-tabs'
+        });
+        expect(terminals).toEqual([{itemId: 'workbench', outcome: 'committed'}])
+    });
+
     test('cross-window execution drains a cue projection before it opens the popup stage', async () => {
         workspace.resolvePane('workbench', initialDocument.items.workbench);
 

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
@@ -355,47 +355,75 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
 
         expect(returned.errors).toEqual([]);
 
-        const refreshes = [];
+        const refreshes = [],
+            order       = [],
+            vessel      = installWindowVessel({closeError: new Error('platform refused close')});
 
-        workspace.timeout = async () => {};
-        workspace.refreshWorkspace = async (workspaceId, document) => {
-            refreshes.push({document, workspaceId})
-        };
+        try {
+            const adoptCommittedTransferPair = workspace.adoptCommittedTransferPair.bind(workspace),
+                retireReturnedPopupWorkspace = workspace.retireReturnedPopupWorkspace.bind(workspace),
+                windowClose                  = Neo.Main.windowClose;
 
-        const commit = workspace.commitCrossWindowTransfer({
-            descriptor,
-            sourceDocument   : returned.sourceDocument,
-            sourceWorkspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID,
-            targetDocument   : returned.targetDocument,
-            targetWorkspaceId: DemoBWorkspace.MAIN_WORKSPACE_ID
-        });
+            workspace.adoptCommittedTransferPair = data => {
+                order.push('adopt');
+                return adoptCommittedTransferPair(data)
+            };
+            workspace.retireReturnedPopupWorkspace = () => {
+                order.push('retire');
+                return retireReturnedPopupWorkspace()
+            };
+            Neo.Main.windowClose = data => {
+                order.push('close');
+                return windowClose(data)
+            };
 
-        // Synchronous admission is the coordinator gate: model truth + disconnect guard are
-        // committed before the promise-owned projection work starts.
-        expect(commit).toBeTruthy();
-        expect(workspace.dockModel.items.workbench).toEqual(initialDocument.items.workbench);
-        expect(workspace.popupDocument.items.workbench).toBeUndefined();
-        expect(workspace.detachedPanes.workbench).toBeUndefined();
+            workspace.timeout = async () => {};
+            workspace.refreshWorkspace = async (workspaceId, document) => {
+                refreshes.push({document, workspaceId})
+            };
 
-        const receipt = await commit;
+            const commit = workspace.commitCrossWindowTransfer({
+                descriptor,
+                sourceDocument   : returned.sourceDocument,
+                sourceWorkspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID,
+                targetDocument   : returned.targetDocument,
+                targetWorkspaceId: DemoBWorkspace.MAIN_WORKSPACE_ID
+            });
 
-        expect(refreshes.map(entry => entry.workspaceId)).toEqual([
-            DemoBWorkspace.MAIN_WORKSPACE_ID,
-            DemoBWorkspace.POPUP_WORKSPACE_ID
-        ]);
-        expect(receipt).toMatchObject({
-            applied         : true,
-            errors          : [],
-            itemIds         : ['workbench'],
-            workspaceRetired: true
-        });
-        expect(workspace.workspaceSet.ids()).toEqual([DemoBWorkspace.MAIN_WORKSPACE_ID]);
-        expect(workspace.getWorkspaceDocument(DemoBWorkspace.POPUP_WORKSPACE_ID)).toBeNull();
+            // Synchronous admission is the coordinator gate: model truth + disconnect guard are
+            // committed before the promise-owned projection work starts.
+            expect(commit).toBeTruthy();
+            expect(workspace.dockModel.items.workbench).toEqual(initialDocument.items.workbench);
+            expect(workspace.popupDocument.items.workbench).toBeUndefined();
+            expect(workspace.detachedPanes.workbench).toBeUndefined();
 
-        // A later explicit stage is a new lifetime: registration is restored against the current
-        // empty owner field, never kept alive as a ghost entry after the prior vessel retired.
-        expect(workspace.ensurePopupWorkspaceRegistered()).toBe(true);
-        expect(workspace.getWorkspaceDocument(DemoBWorkspace.POPUP_WORKSPACE_ID)).toBe(workspace.popupDocument)
+            const receipt = await commit;
+
+            expect(refreshes.map(entry => entry.workspaceId)).toEqual([
+                DemoBWorkspace.MAIN_WORKSPACE_ID,
+                DemoBWorkspace.POPUP_WORKSPACE_ID
+            ]);
+            expect(receipt).toMatchObject({
+                applied         : true,
+                errors          : [],
+                itemIds         : ['workbench'],
+                workspaceRetired: true
+            });
+            expect(order).toEqual(['adopt', 'retire', 'close']);
+            expect(vessel.closeCalls).toEqual([{
+                names   : ['demo-b-cross-window'],
+                windowId: workspace.windowId
+            }]);
+            expect(workspace.workspaceSet.ids()).toEqual([DemoBWorkspace.MAIN_WORKSPACE_ID]);
+            expect(workspace.getWorkspaceDocument(DemoBWorkspace.POPUP_WORKSPACE_ID)).toBeNull();
+
+            // A later explicit stage is a new lifetime: registration is restored against the current
+            // empty owner field, never kept alive as a ghost entry after the prior vessel retired.
+            expect(workspace.ensurePopupWorkspaceRegistered()).toBe(true);
+            expect(workspace.getWorkspaceDocument(DemoBWorkspace.POPUP_WORKSPACE_ID)).toBe(workspace.popupDocument)
+        } finally {
+            vessel.restore()
+        }
     });
 
     test('the popup group identity reaches the existing preview/candidate pipeline unchanged', () => {

--- a/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
+++ b/test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs
@@ -173,6 +173,64 @@ test.describe('Neo.dashboard.DockCrossWindowParticipation (ADR 0029 §2.3 — wo
         participation.destroy()
     });
 
+    test('whole-stack drop: only the source model-resolved stack root transfers and publication gates source retirement', () => {
+        const source    = sourceDoc();
+        const target    = targetDoc();
+        const transfers = [];
+
+        target.nodes['target-tabs'] = target.nodes['main-tabs'];
+        target.nodes.root.zones.center = 'target-tabs';
+        delete target.nodes['main-tabs'];
+
+        const create = commitTransfer => Neo.create(DockCrossWindowParticipation, {
+            commitTransfer,
+            dragCoordinator   : createCoordinatorStub([]),
+            getDocument       : () => target,
+            getForeignDocument: workspaceId => workspaceId === 'A' ? source : null,
+            sortGroup         : 'dock-demo',
+            windowId          : 'window-b',
+            workspaceId       : 'B'
+        });
+        const operation = {
+            operation: 'transferNode',
+            nodeId   : 'main-tabs',
+            target   : {targetNodeId: 'target-tabs', placement: {kind: 'tab-into'}}
+        };
+        const drag     = {dockGroupNodeId: 'main-tabs', dockItemId: 'strategy', dockSourceWorkspaceId: 'A'};
+        const accepted = create(pair => transfers.push(pair));
+        const result   = accepted.commitDrop(operation, drag);
+
+        expect(result).not.toBeNull();
+        expect(transfers).toHaveLength(1);
+        expect(transfers[0].descriptor).toEqual({
+            ...operation,
+            sourceWorkspaceId: 'A',
+            targetWorkspaceId: 'B'
+        });
+        expect(transfers[0].sourceDocument.items.strategy).toBeUndefined();
+        expect(transfers[0].targetDocument.nodes['target-tabs'].items).toEqual(['alpha', 'strategy']);
+
+        const mismatch = create(() => { throw new Error('a non-root group must never publish') });
+
+        expect(mismatch.commitDrop(
+            {...operation, nodeId: 'side-tabs'},
+            {...drag, dockGroupNodeId: 'side-tabs', dockItemId: 'terminal'}
+        )).toBeNull();
+
+        let   refusedPublications = 0;
+        const refused             = create(() => { refusedPublications++; return false });
+
+        expect(refused.commitDrop(operation, drag)).toBeNull();
+        expect(refusedPublications).toBe(1);
+        // The executor is pure and a refused publication cannot retire the source workspace.
+        expect(source.items.strategy).toBeDefined();
+        expect(target.items.strategy).toBeUndefined();
+
+        accepted.destroy();
+        mismatch.destroy();
+        refused.destroy()
+    });
+
     test('foreign addTab and splitNode publish verbatim finite item records that remain topology-capturable', () => {
         for (const operation of [
             {operation: 'addTab', itemId: 'terminal', tabsNodeId: 'main-tabs'},

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -9,6 +9,7 @@ setup({
 import {test, expect}     from '@playwright/test';
 import Neo                from '../../../../src/Neo.mjs';
 import * as core          from '../../../../src/core/_export.mjs';
+import Component          from '../../../../src/component/Base.mjs';
 import DockLayoutAdapter  from '../../../../src/dashboard/DockLayoutAdapter.mjs';
 import DockRail           from '../../../../src/dashboard/DockRail.mjs';
 import DockSplitter       from '../../../../src/dashboard/DockSplitter.mjs';
@@ -656,6 +657,63 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
             });
 
             expect(result.items[0].headerToolbar.sortZoneConfig.enableProxyToPopup).toBe(false)
+        })
+    });
+
+    test.describe('whole-stack projection threading — one model-derived grip', () => {
+        test('a live pane gets a reversible runtime header overlay with its original restored exactly', () => {
+            const pane    = Neo.create(Component, {header: {text: 'Live pane'}}),
+                item      = {componentRef: 'live', kind: 'panel', title: 'Live pane'},
+                decorated = DockLayoutAdapter.decorateProjectedItem(pane, 'live', item, {stackHandle: true}),
+                grip      = decorated.header.text[1];
+
+            expect(decorated).toBe(pane);
+            expect(grip.cls).toEqual(['neo-dock-stack-handle']);
+
+            const restored = DockLayoutAdapter.decorateProjectedItem(pane, 'live', item);
+
+            expect(restored).toBe(pane);
+            expect(restored.header).toEqual({text: 'Live pane'});
+
+            pane.destroy()
+        });
+
+        test('the opt-in decorates only the active resolved-stack header and threads its terminal', () => {
+            const terminals = [];
+            const model     = createEdgeZoneModel();
+            const snapshot  = JSON.parse(JSON.stringify(model));
+            const result    = DockLayoutAdapter.project(model, {
+                enableStackDrag        : true,
+                onDockStackDragTerminal: data => terminals.push(data),
+                resolveComponentRef    : componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            });
+            const mainTabs = result.items[0].items[0];
+            const header   = mainTabs.items[1].header;
+
+            expect(mainTabs.items[0].header.text).toBe('Strategy');
+            expect(header.text[0]).toEqual({vtype: 'text', text: 'Swarm'});
+            expect(header.text[1]).toMatchObject({
+                'aria-hidden': true,
+                cls          : ['neo-dock-stack-handle'],
+                tag          : 'span',
+                title        : 'Drag whole stack'
+            });
+            expect(mainTabs.headerToolbar.sortZoneConfig.dockGroupNodeId).toBe('main-tabs');
+            expect(result.items[0].items[1].items[0].headerToolbar.sortZoneConfig.dockGroupNodeId).toBeNull();
+
+            mainTabs.listeners.dockStackDragTerminal({groupNodeId: 'main-tabs'});
+            expect(terminals).toEqual([{groupNodeId: 'main-tabs'}]);
+            expect(model).toEqual(snapshot)
+        });
+
+        test('without the opt-in every projected header and sort zone stays item-only', () => {
+            const result = DockLayoutAdapter.project(createEdgeZoneModel(), {
+                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            });
+            const mainTabs = result.items[0].items[0];
+
+            expect(mainTabs.items.map(item => item.header.text)).toEqual(['Strategy', 'Swarm']);
+            expect(mainTabs.headerToolbar.sortZoneConfig.dockGroupNodeId).toBeNull()
         })
     });
 });

--- a/test/playwright/unit/dashboard/DockPreview.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPreview.spec.mjs
@@ -189,6 +189,12 @@ test.describe('Neo.dashboard.DockPreview', () => {
             expect(DockPreview.isValidPreview(preview({itemId: undefined}))).toBe(false)
         });
 
+        test('admits only a non-empty runtime whole-stack identity', () => {
+            expect(DockPreview.isValidPreview(preview({groupNodeId: 'popup-stack'}))).toBe(true);
+            expect(DockPreview.isValidPreview(preview({groupNodeId: ''}))).toBe(false);
+            expect(DockPreview.isValidPreview(preview({groupNodeId: 42}))).toBe(false)
+        });
+
         test('rejects a missing target.nodeId', () => {
             expect(DockPreview.isValidPreview(preview({target: {containerId: 'workspace'}}))).toBe(false);
             expect(DockPreview.isValidPreview(preview({target: {nodeId: ''}}))).toBe(false)
@@ -288,6 +294,37 @@ test.describe('Neo.dashboard.DockPreview', () => {
 
             const bottom = DockPreview.previewToOperation(preview({placement: {kind: 'edge-bottom'}}));
             expect(bottom.orientation).toBe('vertical')
+        });
+
+        test('whole-stack previews preserve the placement grammar in one transferNode descriptor', () => {
+            const groupNodeId = 'popup-stack';
+
+            expect(DockPreview.previewToOperation(preview({groupNodeId, placement: {kind: 'tab-into'}}))).toEqual({
+                operation: 'transferNode',
+                nodeId   : groupNodeId,
+                target   : {targetNodeId: 'main-tabs', placement: {kind: 'tab-into'}}
+            });
+
+            expect(DockPreview.previewToOperation(preview({
+                groupNodeId,
+                placement: {kind: 'split-before', orientation: 'vertical', ratio: 0.3}
+            }))).toEqual({
+                operation: 'transferNode',
+                nodeId   : groupNodeId,
+                target   : {
+                    targetNodeId: 'main-tabs',
+                    placement   : {orientation: 'vertical', position: 'before', sizes: [0.3, 0.7]}
+                }
+            });
+
+            expect(DockPreview.previewToOperation(preview({groupNodeId, placement: {kind: 'edge-right'}}))).toEqual({
+                operation: 'transferNode',
+                nodeId   : groupNodeId,
+                target   : {
+                    targetNodeId: 'main-tabs',
+                    placement   : {edge: 'right', orientation: 'horizontal', sizes: [0.5, 0.5]}
+                }
+            })
         });
 
         test('returns null for rejected feedback', () => {

--- a/test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs
+++ b/test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs
@@ -170,6 +170,29 @@ test.describe('Neo.dashboard.DockPreviewProducer (ADR 0029 §2.3 — the dock pr
         expect(producer.produce()).toBeNull()                                                        // no args
     });
 
+    test('whole-stack production carries one coherent runtime group through previews and candidates', async () => {
+        const {isValidCandidateSet} = await import('../../../../src/dashboard/dockPreviewContract.mjs');
+        const zones                 = [{nodeId: 'main-tabs', rect: RECT, orientation: 'vertical'}];
+        const params                = {
+            groupNodeId: 'popup-stack',
+            itemId     : 'strategy',
+            pointer    : {x: 50, y: 50},
+            zones
+        };
+        const preview = producer.produce(params);
+        const set     = producer.produceCandidates(params);
+
+        expect(preview.groupNodeId).toBe('popup-stack');
+        expect(preview.previewId).toBe('preview:group:popup-stack:main-tabs:tab-into');
+        expect(DockPreview.isValidPreview(preview)).toBe(true);
+        expect(set.groupNodeId).toBe('popup-stack');
+        expect(set.cross.every(candidate => candidate.preview.groupNodeId === 'popup-stack')).toBe(true);
+        expect(isValidCandidateSet(set)).toBe(true);
+
+        expect(producer.produce({...params, groupNodeId: ''})).toBeNull();
+        expect(producer.produceCandidates({...params, groupNodeId: 42})).toBeNull()
+    });
+
     test('the produce → previewToOperation → applyOperation pipeline SPLITS the target for an edge drop', async () => {
         const DockZoneModel = (await import('../../../../src/dashboard/DockZoneModel.mjs')).default;
 

--- a/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
@@ -198,6 +198,89 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
         })
     });
 
+    test.describe('whole-stack gesture — existing drag lifecycle, grouped semantic terminal', () => {
+        test('drag-start on the projected grip stamps the model-resolved group and bypasses tab reorder setup', async () => {
+            const dragStarts = [];
+            const strategy   = {id: 'strategy-button', vdom: {id: 'strategy-vdom'}};
+            const swarm      = {id: 'swarm-button', vdom: {id: 'swarm-vdom'}};
+            const zone       = {
+                dockGroupNodeId  : 'main-tabs',
+                dockItemIds      : ['strategy', 'swarm'],
+                dockWorkspaceId  : 'popup',
+                dragStart        : data => dragStarts.push(data),
+                isStackHandleDrag: DockTabSortZone.prototype.isStackHandleDrag,
+                owner            : {
+                    getDomRect: async () => ({x: 10, y: 20, width: 300, height: 32}),
+                    items     : [strategy, swarm]
+                }
+            };
+            const data = {path: [{cls: ['neo-dock-stack-handle']}, {id: 'swarm-button'}]};
+
+            await DockTabSortZone.prototype.onDragStart.call(zone, data);
+
+            expect(dragStarts).toEqual([data]);
+            expect(zone.stackDragActive).toBe(true);
+            expect(zone.dragComponent).toBe(swarm);
+            expect(zone.dragElement).toBe(swarm.vdom);
+            expect(zone.startIndex).toBe(1);
+            expect(zone.dockSourceToolbarRect).toEqual({x: 10, y: 20, width: 300, height: 32});
+            expect(swarm).toMatchObject({
+                dockGroupNodeId      : 'main-tabs',
+                dockItemId           : 'swarm',
+                dockSourceWorkspaceId: 'popup'
+            })
+        });
+
+        test('commit and cancel each report exactly one terminal, then clear grouped drag state', async () => {
+            const run = async cancelled => {
+                const calls = [];
+                const zone  = {
+                    dockGroupNodeId: 'main-tabs',
+                    dockItemIds    : ['swarm'],
+                    dockWorkspaceId: 'popup',
+                    dragComponent  : {id: 'swarm-button'},
+                    dragElement    : {id: 'swarm-vdom'},
+                    dragEnd        : data => calls.push(['cleanup', data]),
+                    dragCoordinator: {
+                        onDragCancel: () => calls.push(['coordinator-cancel']),
+                        onDragEnd   : () => calls.push(['coordinator-end'])
+                    },
+                    owner              : {up: () => ({fire: (name, data) => calls.push([name, data])})},
+                    remoteDropCommitted: !cancelled,
+                    sortGroup          : 'dock-demo',
+                    stackDragActive    : true,
+                    startIndex         : 0
+                };
+                const data = {cancelled};
+
+                await DockTabSortZone.prototype.processDragEnd.call(zone, data);
+
+                return {calls, zone}
+            };
+
+            const committed = await run(false);
+            const cancelled = await run(true);
+
+            expect(committed.calls.map(([name]) => name)).toEqual(['coordinator-end', 'dockStackDragTerminal', 'cleanup']);
+            expect(committed.calls[1][1]).toMatchObject({
+                cancelled: false, committed: true, errors: [], groupNodeId: 'main-tabs',
+                itemId   : 'swarm', outcome: 'committed'
+            });
+            expect(cancelled.calls.map(([name]) => name)).toEqual(['coordinator-cancel', 'dockStackDragTerminal', 'cleanup']);
+            expect(cancelled.calls[1][1]).toMatchObject({
+                cancelled: true, committed: false, errors: [], groupNodeId: 'main-tabs',
+                itemId   : 'swarm', outcome: 'cancelled'
+            });
+
+            for (const state of [committed.zone, cancelled.zone]) {
+                expect(state.remoteDropCommitted).toBe(false);
+                expect(state.stackDragActive).toBe(false);
+                expect(state.dragComponent).toBeNull();
+                expect(state.startIndex).toBe(-1)
+            }
+        })
+    });
+
     test.describe('tear-out gesture terminals — the choreography outcome routing', () => {
         // Prototype-driven like every pin above: the drag-end decision chain is the unit; the
         // base lifecycle is stubbed to nothing so only the dock routing under test runs.


### PR DESCRIPTION
Resolves #15484

The popup projection now exposes one runtime-only stack grip on the model-resolved transferable root. That grip reuses the existing tab-header drag proxy and `DragCoordinator` lifecycle, carries `groupNodeId` through the landed preview/candidate pipeline, and converts an accepted target into one `transferNode` descriptor. Ordinary tab drags and non-opted-in projections remain item-only.

The cross-window participation boundary revalidates the group against the source document's current `resolveStackRoot()` result, executes the real atomic two-document `transferNode`, and retires the source gesture only after the host synchronously acknowledges adoption. Demo B registers both active workspace targets, adopts the committed pair synchronously, clears any overlapping detach bookkeeping before disconnect can race it, reconciles target-first, and explicitly unregisters the emptied popup workspace.

The gesture terminal composes with #15396 through its optional `vesselParkHandlers.onGestureTerminal` seam: `committed` reaches the park machine only after model publication; cancel, rejection, or no preview leaves document truth untouched and lets the park owner restore the vessel. Vessel disposition is split by lifecycle rather than duplicated: the park machine owns converted gestures with a live park slot, while the direct stack-return owner retires its emptied workspace and then best-effort closes that popup. A close refusal never rolls model truth back.

## Deltas from ticket

No scope expansion. The stack-handle source, shared preview grammar, atomic `transferNode` publication, commit-before-terminal ordering, disconnect idempotency, explicit workspace retirement, and post-retirement direct-popup close land here. The separately owned conversion lifecycle (#15396) remains the authority for dispose-versus-reshow when a gesture created a park slot.

Evidence: L2 (focused source/gesture contract matrix) → the headed multi-window proof remains the existing #15243 harness lane. No new residual ticket was created.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/dashboard/DockPreview.spec.mjs test/playwright/unit/dashboard/DockPreviewProducer.spec.mjs test/playwright/unit/dashboard/DockCrossWindowParticipation.spec.mjs test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs test/playwright/unit/dashboard/DockTabSortZone.spec.mjs test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs` — 143/143 passed at `69345523f37a5f258bc0bc8aa96f8d4a181892f5`.
- The matrix pins grouped preview identity and placement conversion, resolved-root-only transfer, truthy publication gating, grip-versus-tab drag routing, exact-once commit/cancel terminals, synchronous pair adoption, target-first projection, live-instance header restoration, disconnect idempotency, unregister/re-register lifecycle, and `adopt → retire → close` ordering. The close witness deliberately rejects the platform close and proves committed ownership remains intact.
- `npm run agent-preflight -- <12 changed .mjs files> --no-fix`, followed by the focused repair preflight over the two touched files — all requested gates passed; ticket archaeology found 0 violations. The only warning is the pre-existing local Tier-1 `ai/config.mjs` stale overlay, outside this PR.
- Commit hooks passed whitespace, shorthand, AiConfig mutation, JSDoc type, ticket archaeology, block alignment, and parse checks across the original 13 files and the two-file repair.
- `git diff HEAD^ HEAD --check` — clean.

## Post-Merge Validation

- [ ] Run the headed #15243 multi-window journey against merged `dev`: popup grip → main preview → drop → committed park/dispose.
- [ ] Exercise cancel and no-claim/no-preview against the composed #15396 park machine; the popup must remain live and both documents byte-stable.
- [x] Unit control forces a popup-close failure after commit and verifies main ownership persists, the emptied registry entry retires exactly once, and the close occurs only after adoption + retirement.

Authored by Emmy (`@neo-gpt-emmy`, GPT family).
