### PR TITLE
fix(agentos): retune --fm-state-off to clear the 3.0 non-text floor in both skins (#15500)

### DIFF
--- a/apps/agentos/TOKENS.md
+++ b/apps/agentos/TOKENS.md
@@ -25,15 +25,16 @@ Ratios vs each surface, **dark** / **light**:
 | `--fm-ink-dim` | 4.5 | 6.53 / 4.99 | 5.90 / 5.46 | 5.46 / 5.17 | 6.29 / 4.64 |
 | `--fm-ink-faint` | 4.5 | **3.27 / 2.83** ❌ | **2.96 / 3.10** ❌ | **2.74 / 2.94** ❌ | **3.15 / 2.64** ❌ |
 | `--fm-signal` | 3.0 | 13.07 / 5.01 | 11.81 / 5.47 | 10.94 / 5.19 | 12.60 / 4.66 |
-| `--fm-state-off` | 3.0 | 3.32 / **2.77** ❌ | 3.00 / 3.03 ⚠️ | **2.78 / 2.87** ❌ | 3.20 / **2.58** ❌ |
+| `--fm-state-off` | 3.0 | 3.67 / 3.29 | 3.32 / 3.59 | 3.07 / 3.41 | 3.54 / 3.06 |
 | `--fm-state-*` (others) | 3.0 | ✅ all pass — dark 6.98–10.65, light 4.27–6.50 (lowest: `stopping` 4.05 vs light `rail`) |
 | `--fm-family-*` | 3.0 | ✅ all pass — dark 6.19–12.66, light 4.03–7.23 |
 | `--fm-kind-*` | 3.0 | ✅ all pass — dark 6.43–9.17, light 4.56–6.98 |
 
-**Two open failures, both awaiting a design ruling (design authority: `@neo-opus-grace`) — recorded here rather than silently fixed, per the delta rule:**
+**One open failure, ruled and awaiting its implementing leaf (design authority: `@neo-opus-grace`) — recorded here rather than silently fixed, per the delta rule:**
 
-1. **`--fm-ink-faint` fails 4.5:1 on every surface in both skins** (2.64–3.27). **Latent, not shipped** — no live consumer today (see the table above). It becomes real the moment a leaf honours `CARD-CONTRACT.md`'s foot-meta specification, which would ship a ~2.7:1 timestamp.
-2. **`--fm-state-off` fails 3:1 on four shipped surfaces.** **Live**: `StateDot.scss` binds `&.fm-state-off { --fm-dot: var(--fm-state-off) }`, and `stateToken()` degrades **every unknown state** to `off` — so this token is both the off-indicator and the unknown-state fallback. Dark `panel` sits exactly on the line (3.00).
+1. **`--fm-ink-faint` fails 4.5:1 on every surface in both skins** (2.64–3.27). Ruled: it is **non-text only** — text consumers re-bind to `--fm-ink-dim`, the token keeps its contracted slot as the non-text floor, and the contract becomes mechanical rather than prose. Implementing leaf: #15493.
+
+**Resolved — `--fm-state-off` (D3).** It was failing the 3:1 non-text floor on five of eight surface/skin combinations while serving double duty: `StateDot.scss` binds `&.fm-state-off { --fm-dot: var(--fm-state-off) }`, and `stateToken()` degrades **every unknown state** to `off`, so the token is both the off-indicator and the unknown-state fallback — a floor failure there is a failure of the most-reached dot on the surface. Retuned per the ruling to the quietest **passing** value in each skin (lightness-only; hue/saturation preserved so it stays the quietest state, and each skin moves the minimum distance that clears the floor): dark `#5b6675` → `#616d7c`, light `#8b95a5` → `#7c889a`. Every surface now clears 3.0 with margin — see the table above.
 
 ## Motion
 

--- a/resources/scss/theme-neo-dark/apps/agentos/Viewport.scss
+++ b/resources/scss/theme-neo-dark/apps/agentos/Viewport.scss
@@ -48,7 +48,7 @@
     // Distinct from the five resolved states; exact palette is design-owner-tunable.
     --fm-state-starting: #38bdf8;
     --fm-state-stopping: #94a3b8;
-    --fm-state-off     : #5b6675;
+    --fm-state-off     : #616d7c;
 
     --fm-family-claude : #d99a5b;
     --fm-family-gpt    : #58c093;

--- a/resources/scss/theme-neo-light/apps/agentos/Viewport.scss
+++ b/resources/scss/theme-neo-light/apps/agentos/Viewport.scss
@@ -55,7 +55,7 @@
     // Distinct from the five resolved states; exact palette is design-owner-tunable.
     --fm-state-starting: #0369a1;
     --fm-state-stopping: #64748b;
-    --fm-state-off     : #8b95a5;
+    --fm-state-off     : #7c889a;
 
     --fm-family-claude : #a8621f;
     --fm-family-gpt    : #2a7d57;


### PR DESCRIPTION
Resolves #15500

The implementing leaf for my **D3 design ruling** on epic #14805 ([ruling](https://github.com/neomjs/neo/issues/14805#issuecomment-5012280547)) — sibling of #15493 / PR #15496 (D4). Surfaced by @neo-kimi-phoebe's re-baseline audit (#15487).

## The defect

`--fm-state-off` is a **state dot** — a non-text indicator, so its floor is **3.0**. It was failing on **five of eight** surface/skin combinations, and it is the worst token to have failing: `StateDot.scss` binds `&.fm-state-off { --fm-dot: var(--fm-state-off) }` **and** `stateToken()` degrades *every unknown state* to `off`. So the token is both the off-indicator and the unknown-state fallback — a floor failure there is a failure of the most-reached dot on the surface.

| vs surface | dark (before) | light (before) |
|---|---|---|
| `ground` | 3.32 | **2.77** ❌ |
| `panel` | 3.00 ⚠️ | 3.03 |
| `panel-2` | **2.78** ❌ | **2.87** ❌ |
| `rail` | 3.20 | **2.58** ❌ |

## The change

The failure is **directional and differs per skin**, so a single nudge cannot fix both:

- **dark** `#5b6675` sits on dark surfaces → contrast rises by going **lighter**; bound by `--fm-panel-2` (the lightest dark surface) at 2.78.
- **light** `#8b95a5` sits on light surfaces → contrast rises by going **darker**; bound by `--fm-rail` (the darkest light surface) at 2.58.

Computed WCAG 2.1 relative luminance, walking lightness in 0.1% steps and stopping at the **first** value that clears 3.0 on all four surfaces, with hue and saturation preserved. That keeps the ruling's intent exactly: the dot stays the *quietest* state — it is now the quietest **passing** value, moved the minimum distance rather than promoted to a louder tier.

| Skin | Before | After | ground | panel | panel-2 | rail | worst |
|---|---|---|---|---|---|---|---|
| dark | `#5b6675` | **`#616d7c`** | 3.67 | 3.32 | 3.07 | 3.54 | **3.07** |
| light | `#8b95a5` | **`#7c889a`** | 3.29 | 3.59 | 3.41 | 3.06 | **3.06** |

## Deltas from ticket

None — the ticket's proposed values are what shipped. (Contrast with the D4 sibling, where implementation falsified the ticket's disposition.)

## Evidence

Evidence: L1 (computed WCAG 2.1 against the skins' literal values, with the recorded table as the instrument control) + theme-guard/theme-build verification → L1 required (the ACs are numeric contrast thresholds, which is exactly what the computation establishes). Residual: the visual "still reads as the quietest state" judgement is an operator eyeball, listed below.

## Test Evidence

- **Instrument control first:** the same computation reproduces all eight **currently recorded** ratios exactly (dark 3.32 / 3.00 / 2.78 / 3.20, light 2.77 / 3.03 / 2.87 / 2.58) before being trusted for new values. The table's own numbers are the control — the method is verified, not assumed.
- **After:** every one of the eight surface/skin combinations clears 3.0 (worst 3.06), recorded into `TOKENS.md`'s contrast table in the same commit.
- **Lightness-only:** hue and saturation are unchanged from the current tokens (the retune walks HSL lightness), so the token keeps its character.
- `check-agentos-theme` green — including skin parity, which the retune must not break (`#616d7c` ≠ `#7c889a`).
- `build-themes -n -e dev -t all` clean, zero errors.

## Note on TOKENS.md overlap with PR #15496

Both leaves touch `TOKENS.md`. This PR folds the **state-off** row and reduces the "two open failures" note to one; #15496 folds the **ink-faint** vocabulary row. Whichever merges second may need a trivial rebase on that note block — both are mine, so I'll reconcile.

## Post-Merge Validation

- [ ] Operator eyeball: the `off` dot still reads as the quietest state (not promoted) in both skins, including as the unknown-state fallback.
- [ ] D2 (StateDot 1.4.1 third channel) remains deliberately unruled pending the live render — with D3 and D4 resolved, it is the last open design-authority item on #14805.

Authored by Grace (Claude Opus 4.8, Claude Code).
