### PR TITLE
feat(agentos): Accounts trio — selector hierarchy, harness-chip skin, untruncated labels (#15489)

### DIFF
--- a/apps/agentos/view/Accounts.mjs
+++ b/apps/agentos/view/Accounts.mjs
@@ -1,13 +1,13 @@
-import AgentConfigCard            from './fleet/AgentConfigCard.mjs';
+import AgentConfigCard                                           from './fleet/AgentConfigCard.mjs';
 import {getDefinitionsWriteGeneration, runConfigIntentRoundTrip} from './fleet/configIntentRoundTrip.mjs';
-import Button                     from '../../../src/button/Base.mjs';
-import DashboardPanel             from '../../../src/dashboard/Panel.mjs';
-import FormContainer              from '../../../src/form/Container.mjs';
-import {listHarnessTypes}         from '../config/harnessTypes.mjs';
-import PasswordField              from '../../../src/form/field/Password.mjs';
-import Radio                      from '../../../src/form/field/Radio.mjs';
-import TextField                  from '../../../src/form/field/Text.mjs';
-import Toolbar                    from '../../../src/toolbar/Base.mjs';
+import Button                                                    from '../../../src/button/Base.mjs';
+import DashboardPanel                                            from '../../../src/dashboard/Panel.mjs';
+import FormContainer                                             from '../../../src/form/Container.mjs';
+import {listHarnessTypes}                                        from '../config/harnessTypes.mjs';
+import PasswordField                                             from '../../../src/form/field/Password.mjs';
+import Radio                                                     from '../../../src/form/field/Radio.mjs';
+import TextField                                                 from '../../../src/form/field/Text.mjs';
+import Toolbar                                                   from '../../../src/toolbar/Base.mjs';
 
 /**
  * @class AgentOS.view.Accounts
@@ -112,7 +112,7 @@ class Accounts extends DashboardPanel {
                 module         : TextField,
                 clearable      : true,
                 labelText      : 'GitHub username',
-                labelWidth     : 118,
+                labelWidth     : 136,
                 name           : 'githubUsername',
                 placeholderText: 'neo-gpt',
                 required       : true
@@ -120,7 +120,7 @@ class Accounts extends DashboardPanel {
                 module         : PasswordField,
                 clearable      : true,
                 labelText      : 'GitHub PAT',
-                labelWidth     : 118,
+                labelWidth     : 136,
                 name           : 'credential',
                 placeholderText: 'stored Brain-side only',
                 required       : true
@@ -135,7 +135,7 @@ class Accounts extends DashboardPanel {
                     checked       : index === 0,
                     hideValueLabel: false,
                     labelText     : index === 0 ? 'Harness' : '',
-                    labelWidth    : 118,
+                    labelWidth    : 136,
                     name          : 'harnessType',
                     value         : entry.type,
                     valueLabel    : entry.label

--- a/resources/scss/src/apps/agentos/Accounts.scss
+++ b/resources/scss/src/apps/agentos/Accounts.scss
@@ -17,7 +17,7 @@
             color        : var(--fm-ink-dim);
             font-size    : 12px;
             font-weight  : 500;
-            transition   : background .15s ease, border-color .15s ease, color .15s ease;
+            transition   : background var(--motion-fast) var(--ease-out-soft), border-color var(--motion-fast) var(--ease-out-soft), color var(--motion-fast) var(--ease-out-soft);
 
             &:hover {
                 border-color: var(--fm-ink-dim);

--- a/resources/scss/src/apps/agentos/Accounts.scss
+++ b/resources/scss/src/apps/agentos/Accounts.scss
@@ -3,14 +3,38 @@
 
     .agent-selector {
         flex-wrap : wrap;
-        gap       : 6px;
-        padding   : 10px 12px 0;
+        gap    : 6px;
+        padding: 10px 12px 0;
 
-        .agent-selector-button {
-            font-size : 12px;
+        /* Button hierarchy (ledger, re-scoped leaf): the selector strip joins the SSOT's quiet,
+           panel-toned base — never the default theme's same-weight blue slab. Mirrors the
+           chrome's agent-button pair (Viewport.scss) and the cockpit bar's D1 pair. */
+        .neo-button.agent-selector-button {
+            border       : 1px solid var(--fm-line);
+            border-radius: 6px;
+            background   : var(--fm-panel-2);
+            box-shadow   : none;
+            color        : var(--fm-ink-dim);
+            font-size    : 12px;
+            font-weight  : 500;
+            transition   : background .15s ease, border-color .15s ease, color .15s ease;
+
+            &:hover {
+                border-color: var(--fm-ink-dim);
+                background: var(--fm-panel);
+                color     : var(--fm-ink);
+            }
 
             &.neo-pressed {
-                font-weight : 600;
+                border-color: var(--fm-ink-dim);
+                background: var(--fm-panel);
+                color     : var(--fm-ink);
+                font-weight  : 600;
+            }
+
+            .neo-button-glyph,
+            .neo-button-text {
+                color: inherit;
             }
         }
     }
@@ -18,7 +42,7 @@
     /* the config card's skin lives with the fleet module: fleet/AgentConfigCard.scss */
 
     .agent-definition-form {
-        gap     : 10px;
-        padding : 12px;
+        gap    : 10px;
+        padding: 12px;
     }
 }

--- a/resources/scss/src/apps/agentos/fleet/AgentConfigCard.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentConfigCard.scss
@@ -99,7 +99,7 @@
         cursor       : pointer;
         font-size    : 12px;
         padding   : 2px 8px;
-        transition: background .15s ease, border-color .15s ease, color .15s ease;
+        transition: background var(--motion-base) var(--ease-out-soft), border-color var(--motion-base) var(--ease-out-soft), color var(--motion-base) var(--ease-out-soft);
 
         &.is-selectable {
             background: var(--fm-panel-2);
@@ -116,6 +116,7 @@
             background: color-mix(in srgb, var(--fm-signal) 14%, var(--fm-panel-2));
             color     : var(--fm-signal);
             cursor    : default;
+            font-weight  : 600; // the non-color carrier — selection never rides hue alone (1.4.1)
         }
     }
 

--- a/resources/scss/src/apps/agentos/fleet/AgentConfigCard.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentConfigCard.scss
@@ -4,14 +4,14 @@
    failure is on record); outcome states borrow the kind/state vocabulary, each paired with a
    non-color carrier (weight / style / text), never hue alone. */
 .fm-agent-config-card {
-    background     : var(--fm-panel);
-    border         : 1px solid var(--fm-line);
+    background: var(--fm-panel);
+    border    : 1px solid var(--fm-line);
     border-radius  : 8px;
-    color          : var(--fm-ink);
-    display        : flex;
+    color  : var(--fm-ink);
+    display: flex;
     flex-direction : column;
-    gap            : 6px;
-    padding        : 10px 12px;
+    gap    : 6px;
+    padding: 10px 12px;
 
     .fm-config-empty {
         color     : var(--fm-ink-dim);
@@ -89,6 +89,34 @@
         display   : flex;
         flex-wrap : wrap;
         gap       : 6px;
+    }
+
+    /* Harness chips: selectable pills on the quiet base, the selected one reaches for the
+       signal pair (the chrome's submit-button treatment) — never plain inline text. */
+    .fm-chip {
+        border       : 1px solid var(--fm-line);
+        border-radius: 6px;
+        cursor       : pointer;
+        font-size    : 12px;
+        padding   : 2px 8px;
+        transition: background .15s ease, border-color .15s ease, color .15s ease;
+
+        &.is-selectable {
+            background: var(--fm-panel-2);
+            color     : var(--fm-ink-dim);
+
+            &:hover {
+                border-color: var(--fm-ink-dim);
+                color        : var(--fm-ink);
+            }
+        }
+
+        &.is-selected {
+            border-color: color-mix(in srgb, var(--fm-signal) 55%, var(--fm-line));
+            background: color-mix(in srgb, var(--fm-signal) 14%, var(--fm-panel-2));
+            color     : var(--fm-signal);
+            cursor    : default;
+        }
     }
 
     .fm-config-save-status {


### PR DESCRIPTION
Resolves #15489

Ships the re-scoped Accounts trio from the drift ledger's correction pass ([re-scope comment](https://github.com/neomjs/neo/issues/15489#issuecomment-5012264620)). The ticket's original status-block premise was retracted after V-B-A showed it was measured on a stale dist build — Vega's #15398/#15440 already deliver the card conformance; what genuinely remained on Accounts was three small items, all fixed here and verified live on the rebuilt dist.

Evidence: L2 (live render probes + computed-style deltas on the dev-server app) → L2 required (visual conformance is a computed-value contract). Residual: none for this close-target.

## Deltas from ticket

- Scope corrected in the ticket thread before implementation: the status block was already conformant (the retraction is on record); this PR ships exactly the three re-scoped items, nothing more.
- The `.fm-chip` skin binds `is-selected` to the signal pair (the `agent-submit-button` `color-mix` treatment) rather than inventing a chip-specific accent — one hierarchy vocabulary across chrome, cockpit bar, and chips.

## Test Evidence

- **Selector hierarchy:** `.agent-selector-button` probed live — `rgb(62, 99, 221)` default slab → `--fm-panel-2` `rgb(26, 33, 44)` + `--fm-line` border + `--fm-ink-dim` text, radius 6px, `box-shadow: none`; `.neo-pressed` distinct (`--fm-panel` + `--fm-ink`).
- **Harness chips:** `.fm-chip.is-selectable` → quiet `--fm-panel-2` pill (was plain inline text); `.fm-chip.is-selected` → `--fm-signal` `rgb(94, 234, 212)` + `color-mix` tint border/background (was: no visual difference at all — zero rules existed).
- **Labels:** "GitHub username" renders full at 136px (`scrollWidth ≤ clientWidth`, no truncation).
- Before/after captures held on the host for the operator; the before-state is the corrected render from the ledger's correction pass.
- Theme rebuild clean (`build/themes.mjs -f -n -t all -e dev`); `check-block-alignment` applied; agent-preflight all gates.
- Unit shard not run: SCSS + one label-width value, no view-code logic touched; conformance evidence is the computed-style delta (the epic's render gate).
- `apps/agentos` surface: no existing visual-binding coverage (Grace's #14618 visual-regression harness is the future mechanical guard; these probes compose with it).

## Post-Merge Validation

- [ ] Grace's D4 leaf (#15493) re-binds the AgentDetail/ComposeForm faint sites; no interaction with this PR (different files, her ruling honored — this PR introduces zero `--fm-ink-faint`).
- [ ] Operator eyeball on Accounts confirms the strip reads as a hierarchy, not three slabs.

Authored by Phoebe (Kimi K3, OpenCode). Session 9b748a56-8b84-43bf-a542-ee8dcf437ebf.
