### PR TITLE
feat(agentos): keyboard parity completes — the popup-origin RETURN, the shared-affordance highlight, and the popup's own announced truth (#15485)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -16,7 +16,7 @@ import {createDockKeyboardCommands}       from '../../../../../src/dashboard/Doc
 import {createDockTearOutHandlers}        from '../../../../../src/dashboard/DockTearOut.mjs';
 import {createDockWorkspaceSet}           from '../../../../../src/dashboard/DockWorkspaceSet.mjs';
 import TourRunner                         from '../../../../../src/ai/client/TourRunner.mjs';
-import {previewToOperation}               from '../../../../../src/dashboard/dockPreviewContract.mjs';
+import {PREVIEW_SCHEMA, previewToOperation} from '../../../../../src/dashboard/dockPreviewContract.mjs';
 import {demoBTourScript, initialDocument} from '../../../tour/demoBPerspectives.mjs';
 import '../../../../../src/button/Base.mjs';   // registers the `button` ntype the bars compose
 import '../../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits
@@ -266,6 +266,31 @@ class DemoBWorkspace extends Container {
      */
     tearOutPlacements = {}
     /**
+     * Supersession token for the async keyboard-cycle highlight: every highlight call bumps it,
+     * and a paint whose measured geometry resolves after a newer call (or a clear) loses — a
+     * fast candidate cycle must never leave a stale zone lit.
+     * @member {Number} keyboardHighlightGeneration=0
+     * @protected
+     */
+    keyboardHighlightGeneration = 0
+    /**
+     * The popup workspace's announcement region instance (composed in
+     * {@link #mountCrossWindowTarget}, retired with its window). Kept as an instance ref because
+     * it lives in the popup window's view tree, outside this component's reference scope.
+     * @member {Neo.component.Base|null} kbdLivePopup=null
+     * @protected
+     */
+    kbdLivePopup = null
+    /**
+     * The window the most recent keyboard command originated in — recorded per keydown from the
+     * routing host's own `windowId`. Focus mechanics need the ORIGIN because focus-stealing rules
+     * are directional: a popup may focus its opener (it holds the keystroke's activation), while
+     * the opener focuses a popup through its named handle.
+     * @member {String|null} lastKeyboardOriginWindowId=null
+     * @protected
+     */
+    lastKeyboardOriginWindowId = null
+    /**
      * Plain structured result of the most recent topology reconciliation. This is rendered
      * into the workspace so remainder semantics are visible rather than buried in logs.
      * @member {Object|null} restoreReport=null
@@ -353,9 +378,7 @@ class DemoBWorkspace extends Container {
             commitTransfer  : data => me.commitKeyboardTransfer(data),
             enumerateTargets: request => me.enumerateKeyboardTargets(request),
             focusVessel     : vessel => me.focusNamedWindow(vessel.windowName),
-            focusWorkspace  : ({workspaceId}) => workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID
-                ? me.focusNamedWindow('demo-b-cross-window')
-                : true, // the main workspace is THIS window — the command runs focused here already
+            focusWorkspace  : ({workspaceId}) => me.focusDockWorkspaceWindow(workspaceId),
             highlightTarget : target => me.setKeyboardTargetHighlight(target),
             onDocumentChange: (document, operation) => {
                 me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, document);
@@ -436,16 +459,23 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * @summary Render a keyboard command outcome into the aria-live region — the announcement
-     * seam of the keyboard command machine. TEXT only (`.text` is inert by construction); the
-     * message is the machine's complete terminal-derived sentence.
+     * @summary Render a keyboard command outcome into EVERY live announcement region — the
+     * announcement seam of the keyboard command machine. TEXT only (`.text` is inert by
+     * construction); the message is the machine's complete terminal-derived sentence.
+     *
+     * Both windows carry the same terminal-derived truth: a command's outcome must be audible
+     * wherever the operator's focus ends up (a committed transfer moves focus ACROSS windows,
+     * so announcing only in the origin window would announce into the window they just left).
      * @param {Object} announcement `{command, itemId, terminal, focusTransferred, message}`.
      * @protected
      */
     announceKeyboardOutcome({message}) {
-        let live = this.getReference('kbd-live-b');
+        let me    = this,
+            main  = me.getReference('kbd-live-b'),
+            popup = me.kbdLivePopup;
 
-        live && (live.text = message)
+        main && (main.text = message);
+        popup && !popup.isDestroyed && (popup.text = message)
     }
 
     /**
@@ -473,6 +503,10 @@ class DemoBWorkspace extends Container {
         let me       = this,
             commands = me.keyboardCommands,
             chorded  = data.ctrlKey && data.shiftKey;
+
+        // the routing host that caught this keydown names the ORIGIN window — the directional
+        // fact focus mechanics need (a popup focuses its opener; the opener focuses by name)
+        me.lastKeyboardOriginWindowId = data.component?.windowId ?? me.windowId;
 
         if (commands.getActiveCycle()) {
             if (data.key === 'Escape') {
@@ -506,6 +540,11 @@ class DemoBWorkspace extends Container {
         if (!focused) return;
 
         if (data.key.toLowerCase() === 'd') {
+            // detach parity with the pointer projection's arming rule: tear-out arms on the
+            // MAIN workspace only — a tear-out FROM a vessel window is popup-over-popup
+            // territory, deliberately not wired on either input path
+            if (focused.workspaceId !== DemoBWorkspace.MAIN_WORKSPACE_ID) return;
+
             await commands.detachItem(focused)
         } else {
             commands.cycleStart({...focused, instructions: DemoBWorkspace.KEYBOARD_CYCLE_INSTRUCTIONS})
@@ -514,13 +553,15 @@ class DemoBWorkspace extends Container {
 
     /**
      * @summary Resolve the dock item the keydown acted on: the event path's tab-header button →
-     * its header toolbar index → the owning projected tab-container's `dockNodeId` → the
-     * DOCUMENT's tabs node items at that index. The document is the authority on purpose:
-     * DemoB's panes are LIVE instances, which the adapter's item decoration deliberately passes
-     * through untouched — only the freshly-projected CONTAINER configs carry dock metadata, so
-     * the container's node id + the committed document answer identity where the card cannot.
+     * its header toolbar index → the owning projected tab-container's `dockNodeId` → its
+     * WORKSPACE's document tabs node items at that index. The document is the authority on
+     * purpose: DemoB's panes are LIVE instances, which the adapter's item decoration deliberately
+     * passes through untouched — only the freshly-projected CONTAINER configs carry dock
+     * metadata, so the container's node id + the committed document answer identity where the
+     * card cannot. Which document is answered by host containment ({@link #resolveDockWorkspaceId}),
+     * so a popup-origin keydown resolves against the popup workspace's truth.
      * @param {Object} data The keydown DomEvent payload (carries the component path).
-     * @returns {Object|null} `{itemId, itemLabel}` or `null` when the focus is not a dock tab header.
+     * @returns {Object|null} `{itemId, itemLabel, workspaceId}` or `null` when the focus is not a dock tab header.
      * @protected
      */
     resolveFocusedDockItem(data) {
@@ -534,10 +575,12 @@ class DemoBWorkspace extends Container {
         let toolbar      = button.up({ntype: 'tab-header-toolbar'}) || button.parent,
             index        = toolbar?.items?.indexOf(button) ?? -1,
             tabContainer = toolbar?.up({ntype: 'tab-container'}),
+            workspaceId  = me.resolveDockWorkspaceId(tabContainer),
+            document     = workspaceId ? me.getWorkspaceDocument(workspaceId) : null,
             // the projection filters rail-hidden items out of the tab flow — mirror it so the
             // header index maps to the same list the strip renders
-            nodeItems    = me.dockModel?.nodes?.[tabContainer?.dockNodeId]?.items?.filter(id =>
-                me.dockModel.items?.[id]?.autoHidden !== true
+            nodeItems    = document?.nodes?.[tabContainer?.dockNodeId]?.items?.filter(id =>
+                document.items?.[id]?.autoHidden !== true
             ),
             itemId       = index > -1 && Array.isArray(nodeItems) ? nodeItems[index] : null;
 
@@ -545,8 +588,33 @@ class DemoBWorkspace extends Container {
 
         return {
             itemId,
-            itemLabel: me.dockModel?.items?.[itemId]?.title ?? itemId
+            itemLabel: document?.items?.[itemId]?.title ?? itemId,
+            workspaceId
         }
+    }
+
+    /**
+     * @summary Resolve which registered workspace a projected component belongs to, by walking
+     * its parent chain up to a live host in {@link #crossWindowHosts}. Containment is the
+     * identity mechanism on purpose: the adapter stamps `dockWorkspaceId` on SortZone configs
+     * (created lazily on first drag), while the host registry is live from composition time —
+     * one mechanism that answers for every projected child in either window, drag-armed or not.
+     * @param {Neo.component.Base|null} component
+     * @returns {String|null} The workspace id, or `null` when the component is outside every host.
+     * @protected
+     */
+    resolveDockWorkspaceId(component) {
+        let current = component;
+
+        while (current) {
+            for (const [workspaceId, host] of this.crossWindowHosts) {
+                if (host === current) return workspaceId
+            }
+
+            current = current.parent
+        }
+
+        return null
     }
 
     /**
@@ -582,7 +650,10 @@ class DemoBWorkspace extends Container {
                     nodes[nodeId].type === 'tabs' && nodeId !== sourceTabsId
                 );
 
+            // itemId rides every candidate: the highlight seam renders through the shared
+            // dockPreview contract, whose payloads are item-scoped by schema
             return tabsIds.map((tabsId, index) => ({
+                itemId,
                 label: tabsIds.length > 1
                     ? `${labels[workspaceId] ?? workspaceId}, zone ${index + 1}`
                     : (labels[workspaceId] ?? workspaceId),
@@ -593,32 +664,56 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * @summary Render (or clear) the keyboard cycle's current-candidate highlight on the target
-     * zone container. The class pairs hue with a non-color carrier (outline) in the skin — the
-     * WCAG 1.4.1 duty the command machine's seam documents.
-     * @param {Object|null} target `{workspaceId, tabsId}` or `null` to clear.
+     * @summary Render (or clear) the keyboard cycle's current-candidate highlight through the
+     * SHARED drag-affordance consumer: a hand-built `tab-into` dockPreview payload (the contract
+     * module is the pure SSOT; the fail-closed renderer validates it) drives the target host's
+     * {@link Neo.dashboard.DockPreview} — the same overlay, geometry conversion, and skin the
+     * pointer hover renders through, so one affordance model serves both input paths. The
+     * indicator MENU stays pointer-owned: its semantics are within-zone position choice, which
+     * the keyboard cycle's zone-target grammar deliberately does not offer.
+     *
+     * The overlay's whole-zone band is shape+position — inherently paired with a non-color
+     * carrier, the WCAG 1.4.1 duty the command machine's seam documents.
+     *
+     * Async by necessity (a popup target may need a first geometry measure); the generation
+     * token makes it supersession-safe — a stale measure never paints over a newer candidate
+     * or a clear. The machine treats the seam as fire-and-forget, so ordering is owned here.
+     * @param {Object|null} target `{workspaceId, tabsId, itemId}` or `null` to clear.
+     * @returns {Promise<void>}
      * @protected
      */
-    setKeyboardTargetHighlight(target) {
-        let me   = this,
-            zone = me.keyboardHighlightZone;
+    async setKeyboardTargetHighlight(target) {
+        let me         = this,
+            generation = ++me.keyboardHighlightGeneration;
 
-        if (zone && !zone.isDestroyed) {
-            zone.removeCls('agentos-kbd-target')
-        }
-
-        me.keyboardHighlightZone = null;
+        // every flip clears BOTH windows' overlays first: the previous candidate may render
+        // in the other window, and a clear (null) must reach it too
+        me.crossWindowHosts.forEach((host, workspaceId) => me.clearWorkspaceAffordances(workspaceId));
 
         if (!target) return;
 
         let host = me.crossWindowHosts.get(target.workspaceId);
 
-        zone = host && !host.isDestroyed && host.down({dockNodeId: target.tabsId});
+        if (!host || host.isDestroyed) return;
 
-        if (zone) {
-            zone.addCls('agentos-kbd-target');
-            me.keyboardHighlightZone = zone
-        }
+        let geometry = me.crossWindowGeometry.get(target.workspaceId)
+                || await me.measureWorkspaceGeometry(target.workspaceId);
+
+        if (generation !== me.keyboardHighlightGeneration || !geometry || me.isDestroyed) return;
+
+        let renderer = host.down({ntype: 'dock-preview'}),
+            zone     = geometry.zones.find(entry => entry.nodeId === target.tabsId);
+
+        if (!renderer || !zone) return;
+
+        renderer.dockPreview = {
+            feedback : {state: 'accepted'},
+            itemId   : target.itemId,
+            placement: {kind: 'tab-into'},
+            schema   : PREVIEW_SCHEMA,
+            target   : {nodeId: target.tabsId}
+        };
+        renderer.applyTargetGeometry(me.localDockRect(zone.rect, geometry.hostRect))
     }
 
     /**
@@ -684,6 +779,43 @@ class DemoBWorkspace extends Container {
     async focusNamedWindow(windowName) {
         try {
             return !!(await Neo.Main.windowFocus({windowName, windowId: this.windowId}))
+        } catch (error) {
+            return false
+        }
+    }
+
+    /**
+     * @summary Transfer focus to the window rendering a workspace — the command machine's
+     * `focusWorkspace` seam, DIRECTIONAL because focus-stealing rules are: a window may focus a
+     * popup it opened (the named handle lives in its Main actor), and a popup may focus its
+     * OPENER (it holds the keystroke's user activation) — so the route is picked from the
+     * command's recorded origin window. Same Boolean-admission discipline on every branch; a
+     * platform decline is the machine's announced degraded terminal, never a throw.
+     * @param {String} workspaceId
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async focusDockWorkspaceWindow(workspaceId) {
+        let me   = this,
+            host = me.crossWindowHosts.get(workspaceId);
+
+        if (!host || host.isDestroyed) return false;
+
+        let targetWindowId = host.windowId,
+            originWindowId = me.lastKeyboardOriginWindowId ?? me.windowId;
+
+        // the command ran in the target's own window — focus is already there
+        if (targetWindowId === originWindowId) return true;
+
+        // popup-workspace target: the MAIN window opened it, so ITS Main actor holds the handle
+        if (targetWindowId !== me.windowId) {
+            return me.focusNamedWindow('demo-b-cross-window')
+        }
+
+        // main-window target from a popup origin: route the verb to the POPUP's main thread
+        // (windowId routing) — omitting windowName makes it focus its opener
+        try {
+            return !!(await Neo.Main.windowFocus({windowId: originWindowId}))
         } catch (error) {
             return false
         }
@@ -1118,16 +1250,26 @@ class DemoBWorkspace extends Container {
     /**
      * Mounts the popup workspace projection into a newly connected render target, registers its
      * target participation, and resolves only after real DOM geometry is measurable.
+     *
+     * The keyboard surface composes here too: the popup window gets its own aria-live
+     * announcement region (same terminal-derived truth as the main window's — the a11y-parity
+     * AC) and the same chorded key routing on its host, so a focused popup item can drive the
+     * return command exactly like a main-window one. One handler, one machine, two windows.
      * @param {Neo.app.Base} app
      * @param {String} windowId
      * @returns {Promise<Object>}
      * @protected
      */
     async mountCrossWindowTarget(app, windowId) {
-        let me          = this,
-            workspaceId = DemoBWorkspace.POPUP_WORKSPACE_ID,
-            generation  = me.crossWindowStageGeneration,
-            host        = app.mainView.add({
+        let me           = this,
+            workspaceId  = DemoBWorkspace.POPUP_WORKSPACE_ID,
+            generation   = me.crossWindowStageGeneration,
+            [live, host] = app.mainView.add([{
+                cls  : ['agentos-dockdemo-kbd-live'],
+                ntype: 'component',
+                role : 'status',
+                vdom : {'aria-live': 'polite', cn: []}
+            }, {
                 module: Container,
                 cls   : ['agentos-dockdemo-dock-host', 'neo-dashboard'],
                 flex  : 1,
@@ -1137,10 +1279,15 @@ class DemoBWorkspace extends Container {
                     module: DockDropIndicators
                 }],
                 layout: {ntype: 'fit'}
-            });
+            }]);
 
         me.crossWindowTargetWindowId = windowId;
         me.crossWindowHosts.set(workspaceId, host);
+        me.kbdLivePopup = live;
+
+        host.addDomListeners([
+            {keydown: me.onDockHostKeyDown, scope: me}
+        ]);
 
         try {
             await app.mainView.promiseUpdate();
@@ -2507,6 +2654,7 @@ class DemoBWorkspace extends Container {
             me.crossWindowStageReject    = null;
             me.crossWindowGestureResolve = null;
             me.crossWindowGestureContext = null;
+            me.kbdLivePopup              = null;
 
             // A post-commit manual close is a terminal vessel event, not ownership loss.
             // A pre-commit close has no detached entry and remains a cancelled gesture.

--- a/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.scss
+++ b/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.scss
@@ -88,11 +88,6 @@
 
 // the keyboard cycle's current-candidate highlight: hue PAIRED with a non-color carrier (the
 // dashed outline geometry) — WCAG 1.4.1 requires the state to survive a colorless rendering
-.agentos-kbd-target {
-    outline       : 2px dashed var(--fm-signal);
-    outline-offset: -2px;
-}
-
 // the keyboard announcement region: visually unobtrusive, never removed from the a11y tree
 // (display:none / visibility:hidden would silence the live region — this deliberately is
 // a one-line, low-emphasis strip instead of a visually-hidden clip)

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -528,12 +528,17 @@ class Main extends core.Base {
      * opener actually lose focus to the popup), never the attempt. A keyboard-command flow rides
      * its keystroke's user activation through this verb; a `false` answer is a legitimate
      * degraded terminal for the caller to announce, not an error.
+     *
+     * Omitting `windowName` targets this window's OPENER instead — the popup-origin return path:
+     * the popup holds the keystroke's user activation, so routing the call to the popup's main
+     * thread (via `windowId`) lets IT ask its opener to take focus, the direction focus-stealing
+     * rules permit. Same Boolean-admission verification either way.
      * @param {Object} data
-     * @param {String} data.windowName
-     * @returns {Promise<Boolean>} true when the popup verifiably took focus.
+     * @param {String} [data.windowName] Named popup to focus; absent = this window's opener.
+     * @returns {Promise<Boolean>} true when the target window verifiably took focus.
      */
     async windowFocus(data) {
-        let win = this.openWindows[data.windowName]?.win;
+        let win = data.windowName ? this.openWindows[data.windowName]?.win : window.opener;
 
         if (!win || win.closed) {
             return false

--- a/test/playwright/e2e/agentos/DemoBKeyboardDetachNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBKeyboardDetachNL.spec.mjs
@@ -13,8 +13,13 @@ import {test, expect} from '../../fixtures.mjs';
  *    says "Focus stayed here" — headless platforms legitimately decline).
  * 2. **The cycle grammar:** Ctrl+Shift+M starts the move cycle (candidates announced with
  *    position + the host's chorded key grammar), Ctrl+Shift+ArrowRight advances it (the
- *    highlight tracks, paired hue + outline), and Escape cancels with ZERO model mutation —
- *    the outcome machine's CANCELLED terminal, keyboard leg.
+ *    highlight tracks THROUGH the shared drag-affordance consumer — the same `dock-preview`
+ *    overlay the pointer hover renders), and Escape cancels with ZERO model mutation — the
+ *    outcome machine's CANCELLED terminal, keyboard leg.
+ * 3. **The popup-origin RETURN:** with the cross-window stage live, the same cycle command
+ *    moves an item INTO the popup workspace and — driven from the POPUP window's own keyboard,
+ *    announced through the POPUP's own live region — back home to main. Keyboard parity is
+ *    end-to-end or it is not parity.
  */
 test.describe('AgentOS Demo B — keyboard detach + cycle grammar (Neural Link)', () => {
     test.setTimeout(120000);
@@ -85,8 +90,13 @@ test.describe('AgentOS Demo B — keyboard detach + cycle grammar (Neural Link)'
         await expect(live).toContainText('Target 1 of', {timeout: 15000});
         await expect(live).toContainText('Ctrl+Shift+Arrow keys cycle');
 
-        // the current candidate is highlighted — hue paired with the outline carrier
-        await expect(page.locator('.agentos-kbd-target')).toHaveCount(1);
+        // the current candidate is highlighted through the SHARED drag-affordance consumer:
+        // the same dock-preview overlay the pointer hover renders, as the whole-zone tab-into
+        // band (shape+position — inherently paired with a non-color carrier)
+        const affordance = page.locator('.neo-dock-preview-affordance');
+        await expect(affordance).toHaveCount(1);
+        await expect(affordance).toHaveClass(/neo-dock-preview-tab-into/);
+        await expect(affordance).toHaveClass(/neo-dock-preview-accepted/);
 
         // the chorded advance moves position AND highlight (wrap-aware: with one candidate the
         // position wraps to itself — the announcement re-renders either way)
@@ -95,17 +105,125 @@ test.describe('AgentOS Demo B — keyboard detach + cycle grammar (Neural Link)'
 
         await page.keyboard.press('Control+Shift+ArrowRight');
         await expect(live).toContainText(candidateCount > 1 ? 'Target 2 of' : 'Target 1 of');
-        await expect(page.locator('.agentos-kbd-target')).toHaveCount(1);
+        await expect(affordance).toHaveCount(1);
 
         // Escape = the CANCELLED terminal: announced, highlight cleared, ZERO model mutation
         await page.keyboard.press('Escape');
         await expect(live).toContainText('Move cancelled');
-        await expect(page.locator('.agentos-kbd-target')).toHaveCount(0);
+        await expect(affordance).toHaveCount(0);
 
         // the tab strip is byte-identical: same headers, the focused tab still home
         await expect(headers).toHaveCount(headerCountBefore);
         await expect(headers.first()).toHaveText(headerText);
 
+        expect(pageErrors).toEqual([])
+    });
+
+    test('the popup-origin RETURN: one cycle grammar moves an item out and — from the popup keyboard — home again', async ({page, neuralLink}) => {
+        const pageErrors  = [],
+              popupErrors = [];
+
+        page.on('pageerror', error => pageErrors.push(error.message));
+
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
+        await page.waitForSelector('.agentos-dockdemo-counter-pane', {timeout: 60000});
+
+        // stage the second active workspace window — a host affordance, not a keyboard step:
+        // the journey under witness is the transfer + return, not window creation
+        const app        = await neuralLink.connectToApp('AgentOSDockDemo'),
+              workspaces = await app.findInstances({className: 'AgentOS.childapps.dockdemo.view.DemoBWorkspace'}, ['id']),
+              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+
+        expect(wsId, 'the App Worker must own one DemoBWorkspace').toBeTruthy();
+
+        const popupPromise = page.waitForEvent('popup', {timeout: 30000}),
+              stage        = app.callMethod(wsId, 'openCrossWindowStage', []),
+              popup        = await popupPromise;
+
+        popup.on('pageerror', error => popupErrors.push(error.message));
+        await popup.waitForLoadState('domcontentloaded');
+        await stage;
+
+        // the popup window composes its OWN announcement region — a real live region in the
+        // accessibility tree, same terminal-derived truth as the main window's (the a11y AC)
+        const mainLive  = page.locator('.agentos-dockdemo-kbd-live'),
+              popupLive = popup.locator('.agentos-dockdemo-kbd-live');
+
+        await expect(popupLive).toHaveAttribute('role', 'status');
+        await expect(popupLive).toHaveAttribute('aria-live', 'polite');
+
+        // ---- LEG 1: the cycle moves Workbench INTO the popup workspace (main-origin) ----
+        // positional on purpose: the projected header buttons carry no text content (the pane
+        // does), and the initial document projects the center zone (workbench-tabs, one tab)
+        // before the right zone — the FIRST header is Workbench's, deterministically
+        const mainHeader = page.locator('.neo-tab-header-toolbar .neo-tab-header-button').first();
+
+        await mainHeader.focus();
+        await page.keyboard.press('Control+Shift+M');
+
+        // deterministic candidate order (workspace-set registry order): Target 1 = the main
+        // window's other tabs zone, Target 2 = the popup workspace — ONE advance, then AWAIT
+        // the announcement settling (reading raw text between presses races the async region
+        // update and over-advances the cycle)
+        await expect(mainLive).toContainText('Target 1 of 2: Main window');
+        await page.keyboard.press('Control+Shift+ArrowRight');
+        await expect(mainLive).toContainText('Target 2 of 2: Popup window');
+
+        // the shared affordance renders in the TARGET's window — the popup's own overlay,
+        // through the same dock-preview consumer the pointer path drives
+        await expect(popup.locator('.neo-dock-preview-affordance')).toHaveCount(1);
+        await expect(popup.locator('.neo-dock-preview-affordance')).toHaveClass(/neo-dock-preview-tab-into/);
+
+        await page.keyboard.press('Control+Shift+Enter');
+        await expect(mainLive).toContainText('Workbench moved to Popup window', {timeout: 15000});
+
+        // BOTH regions carry the same committed terminal
+        await expect(popupLive).toContainText('Workbench moved to Popup window');
+
+        // committed worker truth + the LIVE pane rendered in the second document
+        await expect(popup.locator('.agentos-dockdemo-counter-pane')).toBeVisible({timeout: 10000});
+
+        const moved = await app.getComponent(wsId, ['dockModel', 'popupDocument']);
+
+        expect(moved.popupDocument.nodes['popup-tabs'].items).toEqual(['workbench']);
+        expect(moved.dockModel.items.workbench).toBeUndefined();
+
+        // ---- LEG 2: the RETURN — the SAME command, driven from the POPUP's keyboard ----
+        // the popup workspace holds exactly one item post-transfer: one header, unambiguous
+        const popupHeader = popup.locator('.neo-tab-header-toolbar .neo-tab-header-button').first();
+
+        await popupHeader.focus();
+        await popup.keyboard.press('Control+Shift+M');
+
+        // the POPUP's region announces the cycle — popup-side liveness, L3-witnessed. After
+        // the transfer the main document normalized to ONE tabs zone, so the return cycle has
+        // exactly one candidate: home.
+        await expect(popupLive).toContainText('Target 1 of 1: Main window');
+
+        // the affordance now renders in MAIN — the target window — same consumer
+        await expect(page.locator('.neo-dock-preview-affordance')).toHaveCount(1);
+
+        await popup.keyboard.press('Control+Shift+Enter');
+        await expect(popupLive).toContainText('Workbench moved to Main window', {timeout: 15000});
+        await expect(mainLive).toContainText('Workbench moved to Main window');
+
+        // home again: committed worker truth, the live pane back in the main document
+        await expect(page.locator('.agentos-dockdemo-counter-pane')).toBeVisible({timeout: 10000});
+
+        const home = await app.getComponent(wsId, ['dockModel', 'popupDocument']);
+
+        expect(Object.values(home.dockModel.nodes).some(node => node.items?.includes('workbench'))).toBe(true);
+        expect(home.popupDocument.items?.workbench).toBeUndefined();
+
+        // announced focus-claim ≡ platform truth, in whichever direction the platform ruled —
+        // the return's focus subject is the MAIN document (the opener), asked directly
+        const announcement = await popupLive.textContent(),
+              claimed      = announcement.includes('Focus moved with it'),
+              actual       = await page.evaluate(() => document.hasFocus()).catch(() => false);
+
+        expect(claimed, `announcement "${announcement}" must match main-window focus=${actual}`).toBe(actual);
+
+        expect(popupErrors).toEqual([]);
         expect(pageErrors).toEqual([])
     });
 });

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
@@ -10,7 +10,10 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../../src/core/_export.mjs';
 import '../../../../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
+import Component                from '../../../../../../../src/component/Base.mjs';
+import Container                from '../../../../../../../src/container/Base.mjs';
 import DemoBWorkspace           from '../../../../../../../apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs';
+import DockPreview              from '../../../../../../../src/dashboard/DockPreview.mjs';
 import DockProjectionReconciler from '../../../../../../../src/dashboard/DockProjectionReconciler.mjs';
 import DockZoneModel            from '../../../../../../../src/dashboard/DockZoneModel.mjs';
 
@@ -672,6 +675,212 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
         expect(DockZoneModel.findContainingTabsId(doc, 'timeline')).toBe('workbench-tabs');
         expect(doc.nodes['workbench-tabs'].items.filter(id => id === 'timeline')).toHaveLength(1);
         expect(workspace.tearOutPlacements.timeline).toBeUndefined()
+    });
+
+    test('resolveDockWorkspaceId answers by host containment, in either window, and fails closed outside', () => {
+        // MAIN: a really-projected dock child resolves through the main host's parent chain
+        const sideTabs = workspace.getReference('dock-host-b').down({dockNodeId: 'side-tabs'});
+
+        expect(sideTabs, 'the main projection renders the side-tabs container').toBeTruthy();
+        expect(workspace.resolveDockWorkspaceId(sideTabs)).toBe(DemoBWorkspace.MAIN_WORKSPACE_ID);
+
+        // POPUP: a child of a registered popup host resolves to the popup workspace
+        const popupHost  = Neo.create(Container, {items: []}),
+              popupChild = popupHost.add({module: Component});
+
+        workspace.crossWindowHosts.set(DemoBWorkspace.POPUP_WORKSPACE_ID, popupHost);
+
+        expect(workspace.resolveDockWorkspaceId(popupChild)).toBe(DemoBWorkspace.POPUP_WORKSPACE_ID);
+
+        // outside every host: null, never a guess
+        const stray = Neo.create(Component, {});
+
+        expect(workspace.resolveDockWorkspaceId(stray)).toBe(null);
+        expect(workspace.resolveDockWorkspaceId(null)).toBe(null);
+
+        stray.destroy();
+        popupHost.destroy()
+    });
+
+    test('resolveFocusedDockItem answers popup-origin identity from the POPUP workspace document', () => {
+        // stage a real transfer so the popup document owns the workbench item
+        const detached = DockZoneModel.transferItem(
+            workspace.dockModel,
+            DemoBWorkspace.createPopupDocument(),
+            {
+                itemId: 'workbench', sourceWorkspaceId: 'demo-b-main', targetWorkspaceId: 'demo-b-popup',
+                target: {operation: 'addTab', tabsNodeId: 'popup-tabs'}
+            }
+        );
+
+        expect(detached.errors).toEqual([]);
+        workspace.dockModel     = detached.sourceDocument;
+        workspace.popupDocument = detached.targetDocument;
+
+        // project the popup document into a registered popup host — real tab chrome, real chain
+        const popupHost = Neo.create(Container, {items: []});
+
+        workspace.crossWindowHosts.set(DemoBWorkspace.POPUP_WORKSPACE_ID, popupHost);
+        popupHost.add(workspace.projectDockModel(null, DemoBWorkspace.POPUP_WORKSPACE_ID));
+
+        const button = popupHost.down({ntype: 'tab-header-button'});
+
+        expect(button, 'the popup projection renders a real tab header').toBeTruthy();
+
+        const focused = workspace.resolveFocusedDockItem({path: [{id: button.id}]});
+
+        expect(focused).toEqual({
+            itemId     : 'workbench',
+            itemLabel  : 'Workbench',
+            workspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID
+        });
+
+        popupHost.destroy()
+    });
+
+    test('the detach chord is gated to the MAIN workspace — popup-origin detach never opens a vessel', async () => {
+        let openCount = 0;
+
+        workspace.openTearOutVessel = async () => (openCount++, null);
+
+        const popupFocus = {itemId: 'workbench', itemLabel: 'Workbench', workspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID},
+              mainFocus  = {itemId: 'timeline',  itemLabel: 'Timeline',  workspaceId: DemoBWorkspace.MAIN_WORKSPACE_ID},
+              keyDown    = focused => {
+                  workspace.resolveFocusedDockItem = () => focused;
+                  return workspace.onDockHostKeyDown({
+                      component: {windowId: 'win-popup'},
+                      ctrlKey  : true, key: 'd', path: [], shiftKey: true
+                  })
+              };
+
+        await keyDown(popupFocus);
+        expect(openCount, 'popup-origin detach is not wired — parity with the pointer arming rule').toBe(0);
+        expect(workspace.lastKeyboardOriginWindowId, 'the origin window is recorded from the routing host').toBe('win-popup');
+
+        await keyDown(mainFocus);
+        expect(openCount, 'main-origin detach reaches the admission seam').toBe(1)
+    });
+
+    test('focusDockWorkspaceWindow routes DIRECTIONALLY from the recorded command origin', async () => {
+        const popupHost = Neo.create(Container, {items: []}),
+              verbCalls = [],
+              nameCalls = [],
+              previous  = Neo.Main.windowFocus;
+
+        popupHost.windowId = 'win-popup';
+        workspace.crossWindowHosts.set(DemoBWorkspace.POPUP_WORKSPACE_ID, popupHost);
+        workspace.focusNamedWindow = async name => (nameCalls.push(name), true);
+        Neo.Main.windowFocus       = async data => (verbCalls.push(data), true);
+
+        try {
+            // target === origin window: focus is already there, no verb rides
+            workspace.lastKeyboardOriginWindowId = 'win-popup';
+            expect(await workspace.focusDockWorkspaceWindow(DemoBWorkspace.POPUP_WORKSPACE_ID)).toBe(true);
+            expect(verbCalls).toEqual([]);
+            expect(nameCalls).toEqual([]);
+
+            // popup target from the main origin: the opener's named handle
+            workspace.lastKeyboardOriginWindowId = workspace.windowId;
+            expect(await workspace.focusDockWorkspaceWindow(DemoBWorkspace.POPUP_WORKSPACE_ID)).toBe(true);
+            expect(nameCalls).toEqual(['demo-b-cross-window']);
+
+            // MAIN target from a popup origin: the verb routes to the POPUP's main thread,
+            // windowName omitted — the opener branch
+            workspace.lastKeyboardOriginWindowId = 'win-popup';
+            expect(await workspace.focusDockWorkspaceWindow(DemoBWorkspace.MAIN_WORKSPACE_ID)).toBe(true);
+            expect(verbCalls).toEqual([{windowId: 'win-popup'}]);
+
+            // unknown / dead target workspace: false, fail-closed
+            expect(await workspace.focusDockWorkspaceWindow('demo-b-ghost')).toBe(false)
+        } finally {
+            Neo.Main.windowFocus = previous;
+            popupHost.destroy()
+        }
+    });
+
+    test('announceKeyboardOutcome carries the same terminal-derived truth into BOTH windows', () => {
+        const popupLive = Neo.create(Component, {});
+
+        workspace.kbdLivePopup = popupLive;
+        workspace.announceKeyboardOutcome({message: 'Workbench moved to Main window. Focus moved with it.'});
+
+        expect(workspace.getReference('kbd-live-b').text).toBe('Workbench moved to Main window. Focus moved with it.');
+        expect(popupLive.text).toBe('Workbench moved to Main window. Focus moved with it.');
+
+        // a destroyed popup region degrades silently — the main region still announces
+        popupLive.destroy();
+        workspace.announceKeyboardOutcome({message: 'Move cancelled. Workbench stays where it is.'});
+        expect(workspace.getReference('kbd-live-b').text).toBe('Move cancelled. Workbench stays where it is.')
+    });
+
+    test('the keyboard highlight renders through the SHARED dock-preview consumer as a whole-zone tab-into affordance', async () => {
+        const popupHost = Neo.create(Container, {items: [{module: DockPreview}]}),
+              geometry  = {
+                  hostRect: {x: 100, y: 50, width: 400, height: 300},
+                  root    : {nodeId: 'popup-root', rect: {x: 100, y: 50, width: 400, height: 300}},
+                  zones   : [{nodeId: 'popup-tabs', rect: {x: 120, y: 60, width: 300, height: 200}, orientation: null}]
+              };
+
+        workspace.crossWindowHosts.set(DemoBWorkspace.POPUP_WORKSPACE_ID, popupHost);
+        workspace.crossWindowGeometry.set(DemoBWorkspace.POPUP_WORKSPACE_ID, geometry);
+
+        await workspace.setKeyboardTargetHighlight({
+            itemId: 'workbench', tabsId: 'popup-tabs', workspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID
+        });
+
+        const renderer   = popupHost.down({ntype: 'dock-preview'}),
+              affordance = renderer.vdom.cn[0];
+
+        // the payload IS the shared contract — the fail-closed renderer accepted it
+        expect(renderer.dockPreview).toMatchObject({
+            itemId   : 'workbench',
+            placement: {kind: 'tab-into'},
+            schema   : 'neo.harness.dockPreview.v1',
+            target   : {nodeId: 'popup-tabs'}
+        });
+        expect(DockPreview.isValidPreview(renderer.dockPreview)).toBe(true);
+
+        // rendered as the whole-zone band, positioned host-locally (viewport → host conversion)
+        expect(affordance.cls).toEqual(expect.arrayContaining([
+            'neo-dock-preview-affordance', 'neo-dock-preview-tab', 'neo-dock-preview-tab-into', 'neo-dock-preview-accepted'
+        ]));
+        expect(affordance.style).toMatchObject({height: '200px', left: '20px', top: '10px', width: '300px'});
+
+        // clear reaches the other window's renderer too
+        await workspace.setKeyboardTargetHighlight(null);
+        expect(renderer.dockPreview).toBe(null);
+
+        // supersession: a SLOW geometry measure must never paint a stale candidate over a clear
+        let releaseMeasure;
+
+        workspace.crossWindowGeometry.delete(DemoBWorkspace.POPUP_WORKSPACE_ID);
+        workspace.measureWorkspaceGeometry = () => new Promise(resolve => {
+            releaseMeasure = () => resolve(geometry)
+        });
+
+        const stalePaint = workspace.setKeyboardTargetHighlight({
+            itemId: 'workbench', tabsId: 'popup-tabs', workspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID
+        });
+
+        await workspace.setKeyboardTargetHighlight(null);
+        releaseMeasure();
+        await stalePaint;
+
+        expect(renderer.dockPreview, 'the superseded paint lost against the newer clear').toBe(null);
+
+        popupHost.destroy()
+    });
+
+    test('keyboard-transfer candidates carry the item identity the shared preview contract requires', () => {
+        const candidates = workspace.enumerateKeyboardTargets({itemId: 'workbench'});
+
+        // main host only: the item sits in workbench-tabs, so side-tabs is the one legal target
+        expect(candidates).toEqual([{
+            itemId     : 'workbench',
+            label      : 'Main window',
+            tabsId     : 'side-tabs',
+            workspaceId: DemoBWorkspace.MAIN_WORKSPACE_ID
+        }])
     });
 
     test('destroy tears down the runner, seam, store, and every cached pane', () => {

--- a/test/playwright/unit/dashboard/DockKeyboardCommands.spec.mjs
+++ b/test/playwright/unit/dashboard/DockKeyboardCommands.spec.mjs
@@ -7,6 +7,11 @@ setup({
 });
 
 import {test, expect}               from '@playwright/test';
+// the machine module is deliberately pure (no Neo import), so THIS spec must populate the
+// Neo namespace setup() touches — without these, the file is green in a shared worker (a
+// sibling spec populated Neo first) and red run ALONE: a test-isolation leak, not a machine fact
+import Neo                          from '../../../../src/Neo.mjs';
+import * as core                    from '../../../../src/core/_export.mjs';
 import {createDockKeyboardCommands} from '../../../../src/dashboard/DockKeyboardCommands.mjs';
 
 /**


### PR DESCRIPTION
Resolves #15485

## Summary

The keyboard choreography's completion tranche: after PR #15483 landed the command machine + mounted detach/a11y, three legs of the graduated OQ8 disposition were not yet MOUNTED truth. This PR mounts them:

1. **The popup-origin RETURN (AC-A).** `mountCrossWindowTarget()` now composes the full keyboard surface into the popup window: its own aria-live announcement region and the same chorded key routing on its host — one handler, one machine, two windows. A focused item in the popup workspace starts the cycle and returns home by keyboard alone. Two identity/direction mechanisms carry it:
   - **Host-containment workspace identity:** `resolveFocusedDockItem` resolves which workspace document answers for a keydown by walking the component chain to a registered host (`resolveDockWorkspaceId`) — the adapter's `dockWorkspaceId` stamp lives on lazily-created SortZones, while the host registry is live from composition time.
   - **Directional focus mechanics:** focus-stealing rules are directional — a window may focus a popup it opened (named handle), and a popup may focus its OPENER (it holds the keystroke's activation). `Neo.Main.windowFocus` gains the opener branch (omitted `windowName` = focus this window's opener), and `focusDockWorkspaceWindow` routes by the command's recorded origin window. Same Boolean-admission verification on every branch; the verified answer feeds the announcement, never the attempt.

2. **The shared-affordance highlight (AC-B).** `setKeyboardTargetHighlight` retires the bespoke `agentos-kbd-target` outline (SCSS rule deleted) and renders the cycle candidate through the SHARED drag-affordance consumer: a hand-built `tab-into` `dockPreview.v1` payload (the contract module is the pure SSOT; the fail-closed renderer validates it) drives the target host's `DockPreview` — the same overlay, geometry conversion, and skin the pointer hover renders, in whichever WINDOW hosts the target zone. The indicator MENU stays pointer-owned by design: its semantics are within-zone position choice, which the keyboard's zone-target grammar deliberately does not offer. The paint is supersession-safe (a generation token — a slow popup geometry measure never paints a stale candidate over a newer one or a clear). The whole-zone band is shape+position: inherently paired with a non-color carrier (WCAG 1.4.1).

3. **The popup's announced truth (AC-D).** `announceKeyboardOutcome` broadcasts every terminal into BOTH windows' regions — a committed transfer moves focus ACROSS windows, so announcing only at the origin would announce into the window the operator just left. L3-witnessed from the popup side.

**Detach parity holds:** the pointer projection arms tear-out on the MAIN workspace only; the keyboard detach chord now carries the same gate (popup-origin `Ctrl+Shift+D` is not wired, exactly like the pointer path).

**Scope disposition:** AC-C (the matrix-fallback witness) carves out to #15504 — gated on #15245's measured platform defaults (open, blocked on #15243); witnessing a simulated matrix row before the committed matrix exists would witness a contract that does not exist yet. Narrowing recorded on #15485.

**Boy-scout (own file):** `DockKeyboardCommands.spec.mjs` (mine, PR #15483) had a test-isolation leak — the machine module is deliberately pure, so the spec was green only in a warmed worker (a sibling populated `Neo.ns` first) and red run ALONE. It now imports the namespace it consumes. Stash-baselined as pre-existing before fixing.

## Test Evidence

Evidence: all three tiers green locally at f997447822 —

- **Unit (workspace): 30/30** — 22 landed pins hold + 8 new: host-containment identity (both windows + fail-closed), popup-origin `resolveFocusedDockItem` against the POPUP document over a REAL projection, the detach MAIN-gate, the directional focus matrix (4 routes incl. the opener-verb shape `{windowId}` with no `windowName`), dual-region announcements (+ destroyed-region degradation), the shared `tab-into` affordance (contract-valid payload, whole-zone geometry `{20,10,300,200}` from viewport→host conversion, clear reaching the other window, stale-measure supersession), and candidate itemId enrichment.
- **Unit (machine): 20/20 run ALONE** — the isolation fix witnessed by the failure mode it removes (was `TypeError: Neo.ns is not a function` solo, green in CI's warmed workers).
- **E2E: 5/5** — the two landed keyboard journeys (detach + cycle/cancel, now asserting the SHARED affordance: `.neo-dock-preview-affordance` count/class tracking + Escape clearing), the NEW round-trip journey (stage → keyboard move INTO the popup workspace with the affordance rendering in the POPUP's window → both regions announce the commit → popup-origin cycle from the POPUP's keyboard → home again, worker-truth asserted via Neural Link both directions → announced focus-claim ≡ `document.hasFocus()` platform truth), and BOTH pointer-path witnesses (cross-window drag + Escape zero-mutation) proving the gesture path is unregressed by the host edits.

The e2e diagnosis receipts: the round-trip first failed on a `hasText` header locator — the projected tab headers carry no text content (the failure snapshot proved it), fixed positionally; then on a parse-adaptive cycle loop racing the async live-region update (a worker-truth probe showed the affordance correctly tracking the ACTUAL candidate while the announcement lagged) — fixed with deterministic single advances awaited through auto-retrying expects.

## Deltas

- `src/Main.mjs` — `windowFocus` opener branch (additive; the named-popup path is byte-identical).
- `apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs` — popup host composition (live region + key routing), host-containment identity, directional focus routing, dual-region announcements, the shared-consumer highlight (+ 3 fields: highlight generation, popup region ref, origin window).
- `resources/scss/.../DemoBWorkspace.scss` — `.agentos-kbd-target` retires (net skin reduction; the shared `neo-dock-preview-*` family already carries the affordance).
- `test/playwright/unit/.../DemoBWorkspace.spec.mjs` — +8 pins (209 lines).
- `test/playwright/unit/dashboard/DockKeyboardCommands.spec.mjs` — the isolation fix (+5 lines).
- `test/playwright/e2e/agentos/DemoBKeyboardDetachNL.spec.mjs` — shared-affordance asserts + the round-trip journey.

## Post-Merge Validation

- [ ] The CI unit shard executes the workspace + machine pins against the merged tree.
- [ ] The #15484 whole-stack gesture (Emmy's lane) composes against the unchanged two-phase transfer core — the keyboard side binds `transferItem` pairs today and stays pair-shape-compatible with `transferNode`.

Authored by Vega (Claude Fable 5, Claude Code). Session 53bc95c7-c03c-4f28-84e2-1f78cef59161.