### PR TITLE
fix(agentos): resolve theme-guard properties per declaration so pseudo-classes cannot evade check 4 (#15508)

### DIFF
--- a/buildScripts/util/check-agentos-theme.mjs
+++ b/buildScripts/util/check-agentos-theme.mjs
@@ -53,7 +53,9 @@ const __dirname      = path.dirname(fileURLToPath(import.meta.url)),
       // the DECLARATION rather than the first colon on the line — a pseudo-class (`&:hover`, `:not(.b)`)
       // puts a colon in the SELECTOR, and a first-colon split then reads a selector fragment as the
       // property and silently skips the check. Also handles multi-declaration lines uniformly.
-      DECLARATION_RE       = /(?:^|[{;])\s*([-a-z]+)\s*:\s*([^;}]*)/g,
+      // Case-insensitive because CSS property names are (`COLOR:` === `color:`); the captured property
+      // is lowercased before the `TEXT_FILL_PROPERTIES` lookup so `COLOR: var(--fm-ink-faint)` cannot evade.
+      DECLARATION_RE       = /(?:^|[{;])\s*([-a-zA-Z]+)\s*:\s*([^;}]*)/g,
       // The closed design-contract vocabulary — every skin must DEFINE all of these even when a token is
       // momentarily unconsumed, so a symmetric deletion of a contracted token cannot false-green.
       CONTRACTED_FM_TOKENS = new Set([
@@ -178,7 +180,7 @@ export function collectAgentosThemeFailures({
             // from the first colon on the line: a pseudo-class puts a colon in the selector, so
             // `&:hover { color: … }` would otherwise read `&` as the property and skip the check.
             for (const [, property, declarationValue] of line.matchAll(DECLARATION_RE)) {
-                if (!TEXT_FILL_PROPERTIES.has(property)) continue;
+                if (!TEXT_FILL_PROPERTIES.has(property.toLowerCase())) continue;
 
                 for (const [token, tokenRe] of TEXT_FORBIDDEN_INK_RE) {
                     if (tokenRe.test(declarationValue)) {

--- a/buildScripts/util/check-agentos-theme.mjs
+++ b/buildScripts/util/check-agentos-theme.mjs
@@ -45,6 +45,10 @@ const __dirname      = path.dirname(fileURLToPath(import.meta.url)),
       TEXT_FILL_PROPERTIES = new Set(['color', '-webkit-text-fill-color']),
       // Inks measured below 4.5:1 on every surface in both skins: legal as non-text, rejected on text.
       TEXT_FORBIDDEN_INK   = ['--fm-ink-faint'],
+      // Built once, not per declaration: the guard walks every declaration of every view file, so a
+      // per-iteration `new RegExp` would recompile the same pattern thousands of times. Non-global on
+      // purpose — `.test()` against a `/g` regex is stateful across calls and would skip matches.
+      TEXT_FORBIDDEN_INK_RE = TEXT_FORBIDDEN_INK.map(token => [token, new RegExp(`var\\(\\s*${token}\\b`)]),
       // Every declaration on a line, anchored on a preceding `{` or `;` so the property is resolved from
       // the DECLARATION rather than the first colon on the line — a pseudo-class (`&:hover`, `:not(.b)`)
       // puts a colon in the SELECTOR, and a first-colon split then reads a selector fragment as the
@@ -176,8 +180,8 @@ export function collectAgentosThemeFailures({
             for (const [, property, declarationValue] of line.matchAll(DECLARATION_RE)) {
                 if (!TEXT_FILL_PROPERTIES.has(property)) continue;
 
-                for (const token of TEXT_FORBIDDEN_INK) {
-                    if (new RegExp(`var\\(\\s*${token}\\b`).test(declarationValue)) {
+                for (const [token, tokenRe] of TEXT_FORBIDDEN_INK_RE) {
+                    if (tokenRe.test(declarationValue)) {
                         failures.push(`[text-contrast] ${path.relative(repoRoot, file)}:${index + 1} ${token} fills text but measures below the 4.5:1 floor on every surface in both skins — use --fm-ink-dim: ${rawLine.trim()}`);
                     }
                 }

--- a/buildScripts/util/check-agentos-theme.mjs
+++ b/buildScripts/util/check-agentos-theme.mjs
@@ -45,6 +45,11 @@ const __dirname      = path.dirname(fileURLToPath(import.meta.url)),
       TEXT_FILL_PROPERTIES = new Set(['color', '-webkit-text-fill-color']),
       // Inks measured below 4.5:1 on every surface in both skins: legal as non-text, rejected on text.
       TEXT_FORBIDDEN_INK   = ['--fm-ink-faint'],
+      // Every declaration on a line, anchored on a preceding `{` or `;` so the property is resolved from
+      // the DECLARATION rather than the first colon on the line — a pseudo-class (`&:hover`, `:not(.b)`)
+      // puts a colon in the SELECTOR, and a first-colon split then reads a selector fragment as the
+      // property and silently skips the check. Also handles multi-declaration lines uniformly.
+      DECLARATION_RE       = /(?:^|[{;])\s*([-a-z]+)\s*:\s*([^;}]*)/g,
       // The closed design-contract vocabulary — every skin must DEFINE all of these even when a token is
       // momentarily unconsumed, so a symmetric deletion of a contracted token cannot false-green.
       CONTRACTED_FM_TOKENS = new Set([
@@ -165,13 +170,14 @@ export function collectAgentosThemeFailures({
                 failures.push(`[token-only] ${path.relative(repoRoot, file)}:${index + 1} bare color literal — consume a semantic token instead: ${rawLine.trim()}`);
             }
 
-            // check 4 — text-safe ink. The property is whatever precedes the colon once any selector /
-            // preceding declaration on the same line is stripped (`&.x { color:` → `color`).
-            const property = line.slice(0, colonIdx).replace(/^.*[{;]/, '').trim();
+            // check 4 — text-safe ink. Resolve the property per DECLARATION (see DECLARATION_RE), never
+            // from the first colon on the line: a pseudo-class puts a colon in the selector, so
+            // `&:hover { color: … }` would otherwise read `&` as the property and skip the check.
+            for (const [, property, declarationValue] of line.matchAll(DECLARATION_RE)) {
+                if (!TEXT_FILL_PROPERTIES.has(property)) continue;
 
-            if (TEXT_FILL_PROPERTIES.has(property)) {
                 for (const token of TEXT_FORBIDDEN_INK) {
-                    if (new RegExp(`var\\(\\s*${token}\\b`).test(value)) {
+                    if (new RegExp(`var\\(\\s*${token}\\b`).test(declarationValue)) {
                         failures.push(`[text-contrast] ${path.relative(repoRoot, file)}:${index + 1} ${token} fills text but measures below the 4.5:1 floor on every surface in both skins — use --fm-ink-dim: ${rawLine.trim()}`);
                     }
                 }

--- a/test/playwright/unit/ai/buildScripts/util/check-agentos-theme.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-agentos-theme.spec.mjs
@@ -156,6 +156,14 @@ test.describe('check-agentos-theme.mjs', () => {
         });
     }
 
+    test('an uppercase/mixed-case property is caught (CSS property names are case-insensitive)', () => {
+        const upper = run({dark: FAINT_DARK, light: FAINT_LIGHT, views: {'a.scss': '.a { COLOR: var(--fm-ink-faint); }\n'}}),
+              mixed = run({dark: FAINT_DARK, light: FAINT_LIGHT, views: {'a.scss': '.a { Color: var(--fm-ink-faint); }\n'}});
+
+        expect(upper.some(m => m.startsWith('[text-contrast]'))).toBe(true);
+        expect(mixed.some(m => m.startsWith('[text-contrast]'))).toBe(true);
+    });
+
     test('a pseudo-class line with a NON-text property stays legal (no over-rejection)', () => {
         const failures = run({
             dark : FAINT_DARK,

--- a/test/playwright/unit/ai/buildScripts/util/check-agentos-theme.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-agentos-theme.spec.mjs
@@ -140,4 +140,29 @@ test.describe('check-agentos-theme.mjs', () => {
 
         expect(failures.some(m => m.startsWith('[text-contrast]'))).toBe(true);
     });
+
+    // A pseudo-class puts a colon in the SELECTOR. Resolving the property from the first colon on the
+    // line therefore read a selector fragment as the property and skipped the check entirely — and
+    // `&:hover { color: … }` is the single likeliest place a sub-floor ink returns.
+    for (const [shape, view] of Object.entries({
+        'element pseudo-class'   : '.a:hover { color: var(--fm-ink-faint); }\n',
+        'nested ampersand hover' : '.a {\n    &:hover { color: var(--fm-ink-faint); }\n}\n',
+        'functional pseudo-class': '.a:not(.b) { color: var(--fm-ink-faint); }\n'
+    })) {
+        test(`text-contrast survives a ${shape} on the declaration line`, () => {
+            const failures = run({dark: FAINT_DARK, light: FAINT_LIGHT, views: {'a.scss': view}});
+
+            expect(failures.some(m => m.startsWith('[text-contrast]'))).toBe(true);
+        });
+    }
+
+    test('a pseudo-class line with a NON-text property stays legal (no over-rejection)', () => {
+        const failures = run({
+            dark : FAINT_DARK,
+            light: FAINT_LIGHT,
+            views: {'a.scss': '.a:hover { background: var(--fm-ink-faint); border-color: var(--fm-ink-faint); color: var(--fm-ink); }\n'}
+        });
+
+        expect(failures.some(m => m.startsWith('[text-contrast]'))).toBe(false);
+    });
 });


### PR DESCRIPTION
Resolves #15508

A defect in code I shipped (#15496), **found by @neo-kimi-phoebe reviewing that PR**. Independently reproduced before filing.

## The defect

Check 4 resolved a declaration's property with `line.indexOf(':')` — the **first** colon on the line. On any line carrying a pseudo-class or pseudo-element, that colon belongs to the **selector**, so `line.slice(0, colonIdx)` yielded a selector fragment, the `TEXT_FILL_PROPERTIES` lookup missed, and the check **silently skipped**. The value side still held the token; only the property side broke.

Reproduced against the merged guard:

| Form | Caught |
|---|---|
| `.a { color: var(--fm-ink-faint); }` | ✅ |
| `.a:hover { color: var(--fm-ink-faint); }` | ❌ **evades** |
| `&:hover { color: var(--fm-ink-faint); }` | ❌ **evades** |
| `.a:not(.b) { color: var(--fm-ink-faint); }` | ❌ **evades** |

**Why this matters more than three cases suggests:** `&:hover { color: … }` is among the most common SCSS shapes in this tree — both the D4 re-bind (#15496) and the D1 quick win (#15491) wrote hover rules. So the guard caught the flat form and missed the single likeliest place a future author reintroduces a sub-floor ink. #15496's body claimed the contract was now *"mechanical, not prose"*; at hover scope it was not, and that claim should be true.

## The change

Resolve the property **per declaration** rather than from the first colon, anchored on a preceding `{` or `;`:

```js
DECLARATION_RE = /(?:^|[{;])\s*([-a-z]+)\s*:\s*([^;}]*)/g
```

This handles pseudo-classes and multi-declaration lines **uniformly** — it subsumes the inline `&.is-pending { color: …; font-style: italic; }` case the spec already pinned, rather than special-casing it. Checks 1–3 are untouched (they scan the line's value remainder, which the first-colon split served correctly).

## Deltas from ticket

One, and it simplifies: rather than special-casing pseudo-class lines alongside the existing inline-declaration handling, resolving the property **per declaration** subsumes both. The inline `&.is-pending { color: …; font-style: italic; }` case the spec already pinned now passes through the same path as the pseudo-class shapes, so the fix removes a special case instead of adding one.

## Evidence

Evidence: L1 (mechanical guard, red→green with a stash-verified counter-example matrix) → L1 required. Residual: none. **No live violation existed** — repo-wide grep is clean, so this was under-enforcement, not a shipped regression.

## Test Evidence

- **Red-proof, stash-verified:** the three evasion cases **fail against the merged guard** (`3 failed / 15 passed`) and pass after the fix (`18/18`). They would not have failed before check 4 existed, so they discriminate this defect specifically.
- **No over-rejection:** a positive case pins that a pseudo-class line using `background` / `border-color` stays legal — the non-text floor must survive, and a naive property-matching fix could have broken it.
- `check-agentos-theme` clean against the real tree (parity + token-only + completeness + text-safe ink).
- Block-alignment applied; commit-hook suite green.

## Post-Merge Validation

- [ ] The next sub-floor-ink reintroduction attempt on a hover rule fails the build rather than a reader.

Authored by Grace (Claude Opus 4.8, Claude Code).