### PR TITLE
feat(agentos): measure community activity shadow coverage (#15149)

### DIFF
--- a/ai/scripts/maintenance/communityActivityShadowProbeCore.mjs
+++ b/ai/scripts/maintenance/communityActivityShadowProbeCore.mjs
@@ -1,0 +1,776 @@
+import {createHash} from 'crypto';
+import {Command}    from 'commander';
+
+/**
+ * @module ai/scripts/maintenance/communityActivityShadowProbeCore
+ *
+ * @summary Pure, dependency-injected report core for the GitHub community-activity shadow probe.
+ *
+ * The provider reader, clock, and canonical trust classifier are injected. This module never
+ * imports GitHub services, AiConfig, Memory Core, Tasks, checkpoints, wake delivery, graph state,
+ * or filesystem IO. It turns metadata-only source snapshots into a versioned lower-bound report,
+ * records two-run variance without inventing an acceptance threshold, and enforces the shadow
+ * authority firewall before returning evidence to the thin CLI.
+ */
+
+export const REPORT_SCHEMA_VERSION = 'community-activity-shadow-report.v1';
+
+export const SOURCE_MANIFEST_SCHEMA_VERSION = 'community-activity-source-manifest.v1';
+
+export const QUERY_PLAN_VERSION = 'github-community-shadow.v1';
+
+const FAMILY_NAMES = Object.freeze(['issues', 'pullRequests', 'discussions']);
+
+const ACTOR_KINDS = Object.freeze(['user', 'bot', 'organization', 'mannequin', 'enterpriseUser', 'unknown']);
+
+const TRUST_TIERS = Object.freeze([
+    'system',
+    'repo-trusted',
+    'owner',
+    'self',
+    'peer-trusted',
+    'internal-authored',
+    'external',
+    'unclassified'
+]);
+
+const POLICY_THRESHOLDS = Object.freeze({
+    acquisitionCadenceMs: null,
+    archiveThreshold    : null,
+    paginationCap       : null,
+    retentionMs         : null,
+    stewardLeaseMs      : null,
+    ttlMs               : null,
+    wakeThreshold       : null
+});
+
+const PRODUCTION_MUTATIONS = Object.freeze({
+    admittedEvents     : 0,
+    advancedCheckpoints: 0,
+    createdTasks       : 0,
+    deliveredWakes     : 0,
+    projectedCounts    : 0
+});
+
+const FUTURE_METRIC_REASON = 'requires-production-lifecycle-substrate';
+
+const KNOWN_LOWER_BOUND_GAPS = new Set([
+    'absence_is_not_a_tombstone',
+    'child_watermark_not_proven',
+    'discussion_child_watermark_lower_bound',
+    'historical_deletion_tombstones_unavailable',
+    'historical_revisions_unavailable',
+    'issue_comment_deletion_tombstones_unavailable',
+    'issue_lifecycle_history_not_acquired',
+    'issue_timeline_events_not_sampled',
+    'pull_request_comment_deletion_tombstones_unavailable',
+    'pull_request_lifecycle_history_not_acquired',
+    'pull_request_timeline_events_not_sampled',
+    'review_comment_deletion_tombstones_unavailable',
+    'search_window_has_day_granularity'
+]);
+
+/**
+ * @summary Recursively sorts object keys so evidence hashes are independent of insertion order.
+ * @param {*} value JSON-compatible input.
+ * @returns {*} Canonicalized value.
+ */
+function canonicalize(value) {
+    if (Array.isArray(value)) {
+        return value.map(canonicalize)
+    }
+
+    if (value && typeof value === 'object') {
+        return Object.fromEntries(
+            Object.keys(value)
+                .sort()
+                .filter(key => value[key] !== undefined)
+                .map(key => [key, canonicalize(value[key])])
+        )
+    }
+
+    return value
+}
+
+/**
+ * @summary Returns a full SHA-256 hex digest for JSON-compatible evidence.
+ * @param {*} value JSON-compatible input.
+ * @returns {String}
+ */
+export function hashEvidence(value) {
+    return createHash('sha256').update(JSON.stringify(canonicalize(value))).digest('hex')
+}
+
+/**
+ * @summary Creates the uniform measured/lower-bound/unknown numeric envelope.
+ * @param {String} status `measured`, `lower-bound`, `unknown`, or `not-applicable`.
+ * @param {Number|null} value Numeric value, or null for unknown/not-applicable.
+ * @param {String} unit `count`, `bytes`, `milliseconds`, or `ratio`.
+ * @param {Object} [details]
+ * @param {Number|null} [details.numerator]
+ * @param {Number|null} [details.denominator]
+ * @param {String|null} [details.reasonCode]
+ * @returns {Object}
+ */
+export function measurement(status, value, unit, {numerator=null, denominator=null, reasonCode=null}={}) {
+    const isUnknown = status === 'unknown' || status === 'not-applicable';
+
+    if (isUnknown && (value !== null || !reasonCode)) {
+        throw new Error(`measurement: ${status} requires value=null and a reasonCode`)
+    }
+
+    if (!isUnknown && (!Number.isFinite(value) || value < 0)) {
+        throw new Error(`measurement: ${status} requires a finite non-negative value`)
+    }
+
+    return {status, value, unit, numerator, denominator, reasonCode}
+}
+
+/**
+ * @summary Creates a ratio measurement, preserving its numerator and denominator.
+ * @param {Number} numerator Ratio numerator.
+ * @param {Number} denominator Ratio denominator.
+ * @param {String} [status='measured'] Evidence status when the denominator is non-zero.
+ * @param {String} [zeroReason='zero-denominator'] Unknown reason for a zero denominator.
+ * @returns {Object}
+ */
+function rate(numerator, denominator, status='measured', zeroReason='zero-denominator') {
+    return denominator === 0
+        ? measurement('unknown', null, 'ratio', {numerator, denominator, reasonCode: zeroReason})
+        : measurement(status, numerator / denominator, 'ratio', {numerator, denominator})
+}
+
+/**
+ * @summary Builds the probe CLI contract shared by help rendering and argument parsing.
+ * @returns {Command}
+ */
+function createProgram() {
+    return new Command()
+        .name('ai:probe-community-activity-shadow')
+        .description('Read-only GitHub community-activity shadow measurement; emits evidence, never authority.')
+        .helpOption('-h, --help', 'Display help.')
+        .allowExcessArguments(false)
+        .requiredOption('--owner <owner>', 'GitHub repository owner.')
+        .requiredOption('--repo <repo>', 'GitHub repository name.')
+        .requiredOption('--window-start <iso>', 'Inclusive ISO-8601 window start.')
+        .requiredOption('--window-end <iso>', 'Exclusive ISO-8601 window end.')
+        .option('--page-size <count>', 'Provider page-size coordinate (GitHub range 1..100).', value => Number(value), 100)
+        .option('--runs <count>', 'Repeated full acquisitions (minimum 2; no pass/fail variance threshold).', value => Number(value), 2)
+        .option('--output <path>', 'Optional JSON report path under the repository.')
+}
+
+/**
+ * @summary Parses and validates explicit, reproducible probe coordinates.
+ * @param {String[]} argv `process.argv.slice(2)`.
+ * @returns {Object} Normalized CLI options, or `{helpText}` for a help-only invocation.
+ */
+export function parseArgs(argv) {
+    const program = createProgram();
+
+    if (argv.some(argument => argument === '--help' || argument === '-h')) {
+        return {helpText: program.helpInformation()}
+    }
+
+    program
+        .exitOverride()
+        .configureOutput({writeErr: () => {}, writeOut: () => {}})
+        .parse(argv, {from: 'user'});
+
+    const options = program.opts();
+    const start   = Date.parse(options.windowStart);
+    const end     = Date.parse(options.windowEnd);
+
+    if (!Number.isFinite(start) || !Number.isFinite(end) || start >= end) {
+        throw new Error('parseArgs: --window-start and --window-end must form a valid half-open ISO interval')
+    }
+
+    if (!Number.isInteger(options.pageSize) || options.pageSize < 1 || options.pageSize > 100) {
+        throw new Error('parseArgs: --page-size must be an integer in GitHub\'s 1..100 provider range')
+    }
+
+    if (!Number.isInteger(options.runs) || options.runs < 2) {
+        throw new Error('parseArgs: --runs must be an integer >= 2 for repeated-run evidence')
+    }
+
+    return {
+        ...options,
+        windowEnd  : new Date(end).toISOString(),
+        windowStart: new Date(start).toISOString()
+    }
+}
+
+/**
+ * @summary Normalizes provider actor kinds without folding them into trust.
+ * @param {String|null|undefined} value REST `user.type` or GraphQL `__typename`.
+ * @returns {String}
+ */
+export function normalizeActorKind(value) {
+    const key = String(value ?? '').replace(/[^a-z]/gi, '').toLowerCase();
+
+    return ({
+        bot           : 'bot',
+        enterpriseuser: 'enterpriseUser',
+        mannequin     : 'mannequin',
+        organization  : 'organization',
+        user          : 'user'
+    })[key] || 'unknown'
+}
+
+/**
+ * @summary Creates a zero-filled counter object for a controlled vocabulary.
+ * @param {String[]} keys Counter keys.
+ * @returns {Object}
+ */
+function counters(keys) {
+    return Object.fromEntries(keys.map(key => [key, 0]))
+}
+
+/**
+ * @summary Resolves canonical trust while failing closed when collaborator authority is degraded.
+ * @param {Object} actor Provider actor metadata.
+ * @param {Object} collaboratorCensus `{status, collaborators}`.
+ * @param {Function} classifyTrust Canonical injected classifier.
+ * @returns {String}
+ */
+function resolveTrust(actor, collaboratorCensus, classifyTrust) {
+    if (!actor?.login || typeof classifyTrust !== 'function') {
+        return 'unclassified'
+    }
+
+    const censusComplete = collaboratorCensus?.status === 'complete';
+    const trustTier      = classifyTrust(actor.login, {
+        collaborators: censusComplete ? collaboratorCensus.collaborators : []
+    });
+
+    if (!TRUST_TIERS.includes(trustTier)) {
+        return 'unclassified'
+    }
+
+    // A canonical roster identity remains known without repository membership. An otherwise
+    // external result is ambiguous while the collaborator census is degraded, so it fails closed.
+    if (!censusComplete && (trustTier === 'external' || trustTier === 'repo-trusted')) {
+        return 'unclassified'
+    }
+
+    return trustTier
+}
+
+/**
+ * @summary Maps a trust tier to roster relation without conflating trust and actor kind.
+ * @param {String} trustTier Canonical trust tier.
+ * @returns {String}
+ */
+function rosterRelation(trustTier) {
+    if (['system', 'owner', 'self', 'peer-trusted', 'internal-authored'].includes(trustTier)) {
+        return 'rostered'
+    }
+
+    if (trustTier === 'external' || trustTier === 'repo-trusted') {
+        return 'notRostered'
+    }
+
+    return 'unknown'
+}
+
+/**
+ * @summary Identifies popularity telemetry excluded by AC10.
+ * @param {Object} row Provider row.
+ * @returns {Boolean}
+ */
+function isPopularity(row) {
+    const key = String(row?.eventType ?? row?.sourceFamily ?? '').toLowerCase();
+
+    return ['star', 'unstar', 'fork', 'watch', 'unwatch', 'sponsor', 'follow'].some(token => key.includes(token))
+}
+
+/**
+ * @summary Returns a stable occurrence identity for duplicate-rate measurement.
+ * @param {Object} row Metadata-only provider row.
+ * @returns {String}
+ */
+function occurrenceKey(row) {
+    const timestamps = row?.timestamps ?? row ?? {};
+
+    return [
+        row?.id ?? 'unknown-id',
+        row?.eventType ?? 'unknown-event',
+        row?.mutationKind ?? 'snapshot',
+        row?.occurredAt ?? row?.activityAt ?? timestamps.updatedAt ?? timestamps.createdAt ?? timestamps.deletedAt ?? 'unknown-time'
+    ].join('|')
+}
+
+/**
+ * @summary Produces the metadata-only row shape used for projected storage bytes.
+ * @param {Object} row Source row.
+ * @param {String} actorKind Normalized actor kind.
+ * @param {String} trustTier Canonical trust tier.
+ * @returns {Object}
+ */
+function projectStorageRow(row, actorKind, trustTier) {
+    const timestamps = row?.timestamps ?? row ?? {};
+
+    return {
+        actorKind,
+        actorRefHash   : row?.actor?.login ? hashEvidence(String(row.actor.login).toLowerCase()) : null,
+        createdAt      : timestamps.createdAt ?? null,
+        deletedAt      : timestamps.deletedAt ?? null,
+        eventType      : row?.eventType ?? 'unknown',
+        id             : row?.id ?? null,
+        mutationKind   : row?.mutationKind ?? 'snapshot',
+        occurredAt     : row?.occurredAt ?? row?.activityAt ?? null,
+        responseBearing: row?.responseBearing === true,
+        trustTier,
+        updatedAt      : timestamps.updatedAt ?? null
+    }
+}
+
+/**
+ * @summary Groups attention dispositions without retaining logins or source prose.
+ * @param {Object[]} classified Classified rows.
+ * @returns {Object[]}
+ */
+function buildDispositions(classified) {
+    const groups = new Map();
+
+    for (const item of classified) {
+        const eligible   = item.actorKind === 'user' && item.trustTier === 'external' && item.row.responseBearing === true;
+        let   reasonCode = 'eligible-external-response-bearing';
+
+        if (!eligible) {
+            if (item.actorKind !== 'user') {
+                reasonCode = `actor-kind-${item.actorKind}`;
+            } else if (item.trustTier !== 'external') {
+                reasonCode = `trust-${item.trustTier}`;
+            } else {
+                reasonCode = 'source-not-response-bearing';
+            }
+        }
+
+        const disposition = eligible ? 'eligible' : (item.trustTier === 'external' ? 'excluded' : 'context-only');
+        const key         = [item.actorKind, item.trustTier, item.rosterRelation, disposition, reasonCode].join('|');
+        const previous    = groups.get(key) || {
+            actorKind     : item.actorKind,
+            count         : 0,
+            disposition,
+            reasonCode,
+            rosterRelation: item.rosterRelation,
+            trustTier     : item.trustTier
+        };
+
+        previous.count++;
+        groups.set(key, previous);
+    }
+
+    return [...groups.values()].sort((a, b) => JSON.stringify(a).localeCompare(JSON.stringify(b)))
+}
+
+/**
+ * @summary Converts one family snapshot into aggregate-only measurement evidence.
+ * @param {String} family Family name.
+ * @param {Object} source Source family snapshot.
+ * @param {Object} context Classification context.
+ * @returns {Object}
+ */
+function buildFamilyReport(family, source={}, {classifyTrust, collaboratorCensus}) {
+    const pages          = Array.isArray(source.pages) ? source.pages : [];
+    const rawRows        = pages.flatMap(page => Array.isArray(page.rows) ? page.rows : []);
+    const popularityRows = rawRows.filter(isPopularity);
+    const inScopeRows    = rawRows.filter(row => !isPopularity(row));
+    const candidateRows  = [];
+    const actorKinds     = counters(ACTOR_KINDS);
+    const trustTiers     = counters(TRUST_TIERS);
+    const roster         = counters(['rostered', 'notRostered', 'unknown']);
+    const seen           = new Set();
+    const entityIds      = new Set();
+    const classified     = [];
+    const storageRows    = [];
+    let   duplicateRows  = 0;
+
+    for (const row of inScopeRows) {
+        const key = occurrenceKey(row);
+        if (seen.has(key)) {
+            duplicateRows++;
+            continue
+        }
+
+        const actorKind = normalizeActorKind(row?.actor?.type);
+        const trustTier = resolveTrust(row?.actor, collaboratorCensus, classifyTrust);
+        const relation  = rosterRelation(trustTier);
+
+        seen.add(key);
+        candidateRows.push(row);
+        actorKinds[actorKind]++;
+        trustTiers[trustTier]++;
+        roster[relation]++;
+        entityIds.add(String(row?.providerEntityId ?? row?.id ?? key));
+        storageRows.push(projectStorageRow(row, actorKind, trustTier));
+        classified.push({actorKind, rosterRelation: relation, row, trustTier});
+    }
+
+    const mutationCount = kind => candidateRows.filter(row => row?.mutationKind === kind).length;
+    const createRows    = mutationCount('create');
+    const revisionRows  = candidateRows.filter(row => ['revision', 'snapshot-change', 'update'].includes(row?.mutationKind)).length;
+    const tombstoneRows = candidateRows.filter(row => ['delete', 'tombstone'].includes(row?.mutationKind)
+        && (row?.explicitTombstone === true || row?.tombstone === true)).length;
+    const stateRows         = candidateRows.filter(row => ['state-transition', 'state_transition'].includes(row?.mutationKind)).length;
+    const unknownAbsence    = candidateRows.filter(row => ['unknown-absence', 'unknown_absence'].includes(row?.mutationKind)).length;
+    const stableStorageRows = storageRows
+        .map(canonicalize)
+        .sort((left, right) => {
+            const leftJson  = JSON.stringify(left);
+            const rightJson = JSON.stringify(right);
+
+            return leftJson < rightJson ? -1 : leftJson > rightJson ? 1 : 0
+        });
+    const projectedBytes = Buffer.byteLength(JSON.stringify(stableStorageRows), 'utf8');
+    const dispositions   = buildDispositions(classified);
+    const eligibleRows   = dispositions.filter(item => item.disposition === 'eligible').reduce((sum, item) => sum + item.count, 0);
+    const providerMs     = pages.reduce((sum, page) => sum + (Number.isFinite(page?.latencyMs) ? page.latencyMs : 0), 0);
+    const pageReceipts   = pages.map((page, index) => ({
+        apiSurface           : page.apiSurface ?? (Object.hasOwn(page, 'terminalReceipt') ? 'rest' : 'graphql'),
+        cursor               : page.cursor ?? null,
+        hasNextPage          : page.hasNextPage ?? page.sourceHasNextPage ?? null,
+        latencyMs            : Number.isFinite(page.latencyMs) ? page.latencyMs : null,
+        pageOrdinal          : page.pageOrdinal ?? index + 1,
+        providerCost         : Number.isFinite(page.providerCost) ? page.providerCost : (Number.isFinite(page.rateCost) ? page.rateCost : null),
+        resourceKind         : page.resourceKind ?? page.connection ?? family,
+        responseFingerprint  : page.responseFingerprint ?? hashEvidence((page.rows ?? []).map(occurrenceKey)),
+        rows                 : Array.isArray(page.rows) ? page.rows.length : 0,
+        sourceRows           : Number.isFinite(page.sourceRows) ? page.sourceRows : null,
+        terminalReceipt      : page.terminalReceipt === true,
+        windowTerminalReceipt: page.windowTerminalReceipt === true
+    }));
+    const gaps = Array.isArray(source.gaps) ? source.gaps.map(gap => ({
+        reasonCode  : gap.reasonCode ?? gap.code ?? 'unspecified-source-gap',
+        resourceKind: gap.resourceKind ?? gap.scope ?? family
+    })) : [];
+
+    return {
+        acquisition: {
+            exhausted  : source.exhausted === true,
+            gaps,
+            inScopeRows: inScopeRows.length,
+            pages      : pages.length,
+            rawRows    : rawRows.length
+        },
+        attention: {
+            dispositions,
+            eligibleRows,
+            excludedRows: candidateRows.length - eligibleRows
+        },
+        classifications: {
+            actorKinds,
+            actorTrustMatrix: dispositions.map(({actorKind, count, rosterRelation: relation, trustTier}) => ({actorKind, count, rosterRelation: relation, trustTier})),
+            rosterRelation  : roster,
+            trustTiers
+        },
+        family,
+        latency: {
+            providerAcquisitionMs: measurement('measured', providerMs, 'milliseconds'),
+            usefulResponseMs     : measurement('unknown', null, 'milliseconds', {reasonCode: FUTURE_METRIC_REASON})
+        },
+        mutationEvidence: {
+            createRows,
+            explicitTombstoneRows: tombstoneRows,
+            revisionRows,
+            stateTransitionRows  : stateRows,
+            unknownAbsenceRows   : unknownAbsence
+        },
+        observations: {
+            candidateRows         : candidateRows.length,
+            duplicateRows,
+            explicitTombstoneRows : tombstoneRows,
+            popularityExcludedRows: popularityRows.length,
+            revisionRows,
+            uniqueEntities        : entityIds.size
+        },
+        pageReceipts,
+        projectionInputs: {
+            countEligibleRows: eligibleRows,
+            wakeEligibleRows : eligibleRows
+        },
+        rates: {
+            duplicateRate    : rate(duplicateRows, inScopeRows.length),
+            pagesPerCandidate: rate(pages.length, candidateRows.length),
+            tombstoneRate    : rate(tombstoneRows, candidateRows.length, 'lower-bound'),
+            updateRate       : rate(revisionRows, candidateRows.length, 'lower-bound')
+        },
+        storage: {
+            bytesPerCandidate     : rate(projectedBytes, candidateRows.length, 'lower-bound'),
+            projectedMetadataBytes: measurement('lower-bound', projectedBytes, 'bytes')
+        },
+        inventoryHash: hashEvidence(stableStorageRows)
+    }
+}
+
+/**
+ * @summary Builds one run's aggregate evidence from one provider snapshot.
+ * @param {Object} snapshot Reader result.
+ * @param {Object} options Probe coordinates.
+ * @param {Object} deps Classification dependencies.
+ * @returns {Object}
+ */
+function buildRun(snapshot, options, deps) {
+    const collaboratorCensus = snapshot?.collaboratorCensus || {status: 'degraded', collaborators: [], gaps: [{reasonCode: 'collaborator-census-missing'}]};
+    const families           = FAMILY_NAMES.map(family => buildFamilyReport(family, snapshot?.families?.[family], {...deps, collaboratorCensus}));
+    const pageReceipts       = families.flatMap(item => item.pageReceipts.map(receipt => ({family: item.family, ...receipt})));
+    const candidateRows      = families.reduce((sum, item) => sum + item.observations.candidateRows, 0);
+    const graphqlCalls       = Array.isArray(snapshot?.transport?.graphqlCalls) ? snapshot.transport.graphqlCalls : [];
+    const restCalls          = Array.isArray(snapshot?.transport?.restCalls) ? snapshot.transport.restCalls : [];
+    const graphqlCost        = Number.isFinite(snapshot?.transport?.graphqlCost) ? snapshot.transport.graphqlCost : null;
+    const providerRequests   = graphqlCalls.length + restCalls.length;
+    const providerCostUnits  = graphqlCost == null ? null : graphqlCost + restCalls.length;
+    const sourceCoordinates  = {
+        canonicalProviderHost: 'github.com',
+        familyPlans          : FAMILY_NAMES.map(family => ({family, pageSize: options.pageSize})),
+        provider             : 'github',
+        queryPlanVersion     : QUERY_PLAN_VERSION,
+        repository           : {name: options.repo, owner: options.owner},
+        schemaVersion        : SOURCE_MANIFEST_SCHEMA_VERSION,
+        window               : {endExclusive: options.windowEnd, semantics: 'half-open', startInclusive: options.windowStart}
+    };
+    const queryPlanHash         = hashEvidence(sourceCoordinates);
+    const sourceManifestHash    = hashEvidence({pageReceipts, inventories: families.map(item => ({family: item.family, inventoryHash: item.inventoryHash}))});
+    const candidateManifestHash = hashEvidence(families.map(item => ({family: item.family, inventoryHash: item.inventoryHash})));
+    const gaps                  = [
+        ...(collaboratorCensus.gaps ?? []).map(gap => ({family: 'collaborators', reasonCode: gap.reasonCode ?? gap.code ?? 'collaborator-census-degraded'})),
+        ...families.flatMap(item => item.acquisition.gaps.map(gap => ({family: item.family, ...gap})))
+    ];
+    const exhausted    = families.every(item => item.acquisition.exhausted) && collaboratorCensus.status === 'complete';
+    const degradedGaps = gaps.filter(gap => !KNOWN_LOWER_BOUND_GAPS.has(gap.reasonCode));
+
+    return {
+        candidateManifestHash,
+        completedAt: snapshot?.completedAt ?? deps.now(),
+        coverage   : {
+            degraded               : !exhausted || degradedGaps.length > 0,
+            exhausted,
+            gaps,
+            globalCompletenessClaim: false,
+            lowerBound             : true,
+            lowerBoundReasons      : [
+                'window-bounded',
+                'unseen-intermediate-revisions-possible',
+                ...gaps.filter(gap => KNOWN_LOWER_BOUND_GAPS.has(gap.reasonCode)).map(gap => gap.reasonCode)
+            ].filter((value, index, values) => values.indexOf(value) === index),
+            unseenHistoryPossible: true
+        },
+        families,
+        pageReceipts,
+        provider: {
+            combinedCostUnits: providerCostUnits == null
+                ? measurement('unknown', null, 'provider-cost-units', {reasonCode: 'graphql-cost-unavailable'})
+                : measurement('lower-bound', providerCostUnits, 'provider-cost-units', {
+                    reasonCode: 'graphql-reported-cost-plus-one-unit-per-rest-request'
+                }),
+            graphqlCostUnits: graphqlCost == null
+                ? measurement('unknown', null, 'provider-cost-units', {reasonCode: 'graphql-cost-unavailable'})
+                : measurement('measured', graphqlCost, 'provider-cost-units'),
+            graphqlRequests: graphqlCalls.length,
+            requests       : providerRequests,
+            restRequests   : restCalls.length
+        },
+        queryPlanHash,
+        sourceCoordinates,
+        sourceManifestHash,
+        startedAt: snapshot?.startedAt ?? deps.now(),
+        totals   : {
+            attentionEligibleRows : families.reduce((sum, item) => sum + item.attention.eligibleRows, 0),
+            candidateRows,
+            duplicateRows         : families.reduce((sum, item) => sum + item.observations.duplicateRows, 0),
+            pages                 : families.reduce((sum, item) => sum + item.acquisition.pages, 0),
+            providerCostUnits,
+            providerRequests,
+            projectedMetadataBytes: families.reduce((sum, item) => sum + item.storage.projectedMetadataBytes.value, 0),
+            rawRows               : families.reduce((sum, item) => sum + item.acquisition.rawRows, 0),
+            revisionRows          : families.reduce((sum, item) => sum + item.observations.revisionRows, 0),
+            tombstoneRows         : families.reduce((sum, item) => sum + item.observations.explicitTombstoneRows, 0)
+        }
+    }
+}
+
+/**
+ * @summary Computes exact last-minus-first variance without attaching a policy threshold.
+ * @param {Object[]} runs Run evidence.
+ * @returns {Object}
+ */
+function buildRepeatability(runs) {
+    const first      = runs[0];
+    const last       = runs.at(-1);
+    const comparable = runs.every(run => run.queryPlanHash === first.queryPlanHash);
+    const keys       = [
+        'pages',
+        'providerRequests',
+        'providerCostUnits',
+        'rawRows',
+        'candidateRows',
+        'duplicateRows',
+        'revisionRows',
+        'tombstoneRows',
+        'projectedMetadataBytes',
+        'attentionEligibleRows'
+    ];
+    const variance = Object.fromEntries(keys.map(key => {
+        const firstValue = first.totals[key];
+        const lastValue  = last.totals[key];
+        const delta      = comparable && Number.isFinite(firstValue) && Number.isFinite(lastValue)
+            ? lastValue - firstValue
+            : null;
+
+        return [key, delta]
+    }));
+
+    return {
+        comparable,
+        comparisonReason: comparable ? null : 'query-plan-coordinates-differ',
+        evidenceStatus  : runs.length >= 2 ? 'two-run' : 'insufficient-runs',
+        requiredRuns    : 2,
+        runs            : runs.map((run, index) => ({
+            candidateManifestHash: run.candidateManifestHash,
+            completedAt          : run.completedAt,
+            queryPlanHash        : run.queryPlanHash,
+            runIndex             : index + 1,
+            providerCostUnits    : run.provider.combinedCostUnits,
+            providerRequests     : run.provider.requests,
+            sourceManifestHash   : run.sourceManifestHash,
+            startedAt            : run.startedAt
+        })),
+        schemaVersion: 'community-activity-repeatability.v1',
+        variance
+    }
+}
+
+/**
+ * @summary Enforces the evidence-not-authority firewall on a constructed report.
+ * @param {Object} report Shadow report.
+ * @returns {Object} The same report after validation.
+ */
+export function assertShadowFirewall(report) {
+    if (report?.authority?.notAuthority !== true || report?.authority?.mode !== 'shadow') {
+        throw new Error('assertShadowFirewall: report must remain shadow evidence, never authority')
+    }
+
+    if (Object.values(report.authority.productionMutations ?? {}).some(value => value !== 0)) {
+        throw new Error('assertShadowFirewall: production mutation counters must remain zero')
+    }
+
+    if (report?.policy?.introduced !== false || Object.values(report?.policy?.thresholds ?? {}).some(value => value !== null)) {
+        throw new Error('assertShadowFirewall: shadow measurement cannot introduce policy thresholds')
+    }
+
+    return report
+}
+
+/**
+ * @summary Runs repeated source acquisitions and returns one JSON-first lower-bound report.
+ * @param {Object} options Parsed probe options.
+ * @param {Object} deps
+ * @param {Function} deps.reader Pure injected source reader.
+ * @param {Function} deps.now Injected ISO clock.
+ * @param {Function} deps.classifyTrust Canonical author-trust classifier.
+ * @returns {Promise<{exitCode: Number, report: Object}>}
+ */
+export async function runShadowProbe(options, {reader, now, classifyTrust}) {
+    if (typeof reader !== 'function' || typeof now !== 'function' || typeof classifyTrust !== 'function') {
+        throw new Error('runShadowProbe: reader, now, and classifyTrust functions are required')
+    }
+
+    const startedAt = now();
+    const runs      = [];
+
+    for (let runIndex = 1; runIndex <= options.runs; runIndex++) {
+        const snapshot = await reader({
+            families: FAMILY_NAMES,
+            owner   : options.owner,
+            pageSize: options.pageSize,
+            provider: 'github',
+            repo    : options.repo,
+            runIndex,
+            window  : {end: options.windowEnd, start: options.windowStart}
+        });
+
+        runs.push(buildRun(snapshot, options, {classifyTrust, now}));
+    }
+
+    const primary       = runs.at(-1);
+    const repeatability = buildRepeatability(runs);
+    const generatedAt   = now();
+    const report        = {
+        authority: {
+            mode               : 'shadow',
+            notAuthority       : true,
+            permittedWrites    : {reportFiles: 1},
+            productionMutations: {...PRODUCTION_MUTATIONS}
+        },
+        coverage         : primary.coverage,
+        excludedTelemetry: {
+            popularityFamilies: ['star', 'unstar', 'fork', 'watch', 'unwatch', 'equivalents'],
+            rows              : primary.families.reduce((sum, family) => sum + family.observations.popularityExcludedRows, 0)
+        },
+        families         : primary.families.map(({pageReceipts, ...family}) => family),
+        futureMetricSlots: Object.fromEntries(Object.entries({
+            bytesPerAdmittedEvent    : 'bytes',
+            casConflictRate          : 'ratio',
+            duplicateBatchReceiptRate: 'ratio',
+            duplicateResponseRate    : 'ratio',
+            falsePositiveRate        : 'ratio',
+            hooksPerAdmittedEvent    : 'ratio',
+            opaqueCheckpointBytes    : 'bytes',
+            outboxAgeMs              : 'milliseconds',
+            replayLagMs              : 'milliseconds',
+            stewardVacancyRate       : 'ratio',
+            timeToAcknowledgeMs      : 'milliseconds',
+            timeToClaimMs            : 'milliseconds',
+            timeToRespondMs          : 'milliseconds',
+            wakesPerAdmittedEvent    : 'ratio'
+        }).map(([key, unit]) => [key, measurement('unknown', null, unit, {reasonCode: FUTURE_METRIC_REASON})])),
+        generatedAt,
+        policy  : {introduced: false, thresholds: {...POLICY_THRESHOLDS}},
+        provider: primary.provider,
+        repeatability,
+        reportId: hashEvidence({generatedAt, queryPlanHash: primary.queryPlanHash, sourceManifestHash: primary.sourceManifestHash}),
+        run     : {
+            completedAt: generatedAt,
+            durationMs : Math.max(0, Date.parse(generatedAt) - Date.parse(startedAt)),
+            runCount   : runs.length,
+            startedAt
+        },
+        schemaVersion : REPORT_SCHEMA_VERSION,
+        sourceManifest: {
+            ...primary.sourceCoordinates,
+            candidateManifestHash: primary.candidateManifestHash,
+            pageReceipts         : primary.pageReceipts,
+            queryPlanHash        : primary.queryPlanHash,
+            sourceManifestHash   : primary.sourceManifestHash
+        },
+        totals: primary.totals
+    };
+
+    report.summary = {
+        schemaVersion: 'community-activity-shadow-summary.v1',
+        text         : formatHumanSummary(report)
+    };
+
+    assertShadowFirewall(report);
+
+    return {exitCode: 0, report}
+}
+
+/**
+ * @summary Renders a deterministic compact human summary without promoting evidence to policy.
+ * @param {Object} report Versioned shadow report.
+ * @returns {String}
+ */
+export function formatHumanSummary(report) {
+    const coverage = report?.coverage?.degraded ? 'DEGRADED LOWER BOUND' : 'LOWER BOUND';
+    const totals   = report?.totals ?? {};
+    const variance = report?.repeatability?.variance ?? {};
+
+    return [
+        `[community-activity-shadow ${report?.schemaVersion}] ${coverage}`,
+        `source occurrences=${totals.candidateRows ?? 0} · attention-eligible external=${totals.attentionEligibleRows ?? 0} · pages=${totals.pages ?? 0}`,
+        `provider requests=${totals.providerRequests ?? 'unknown'} · provider cost units=${totals.providerCostUnits ?? 'unknown'}`,
+        `projected metadata=${totals.projectedMetadataBytes ?? 0} bytes · duplicates=${totals.duplicateRows ?? 0} · revisions=${totals.revisionRows ?? 0} · tombstones=${totals.tombstoneRows ?? 0}`,
+        `repeatability=${report?.repeatability?.evidenceStatus ?? 'unknown'} · candidate variance=${variance.candidateRows ?? 'unknown'} · no thresholds authorized`
+    ].join('\n')
+}

--- a/ai/scripts/maintenance/probeCommunityActivityShadow.mjs
+++ b/ai/scripts/maintenance/probeCommunityActivityShadow.mjs
@@ -1,0 +1,115 @@
+// Neo namespace bootstrap (entry-point invariant) — community-activity shadow probe CLI.
+// `InstanceManager` binds Neo.find/findFirst/get aliases + consumes pre-singleton
+// `Neo.idMap`; required before loading a Neo singleton service.
+import Neo             from '../../../src/Neo.mjs';
+import * as core       from '../../../src/core/_export.mjs';
+import InstanceManager from '../../../src/manager/Instance.mjs';
+
+import fsExtra         from 'fs-extra';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+import GraphqlService                                  from '../../services/github-workflow/GraphqlService.mjs';
+import {makeCommunityActivityShadowReader}             from '../../services/github-workflow/communityActivityShadowReader.mjs';
+import {classifyAuthorTrust}                           from '../../services/shared/contentTrust/authorTrustClassifier.mjs';
+import {formatHumanSummary, parseArgs, runShadowProbe} from './communityActivityShadowProbeCore.mjs';
+
+const __filename   = fileURLToPath(import.meta.url);
+const __dirname    = path.dirname(__filename);
+const PROJECT_ROOT = path.resolve(__dirname, '../../..');
+const REPORT_DIR   = path.join(PROJECT_ROOT, '.neo-ai-data', 'community-activity-shadow');
+
+/**
+ * @module ai/scripts/maintenance/probeCommunityActivityShadow
+ *
+ * @summary Thin, read-only GitHub wiring for the community-activity shadow measurement.
+ *
+ * The sibling pure core owns arguments, report construction, aggregation, classification,
+ * repeatability, and the human summary. This entrypoint binds only GitHub's authenticated read
+ * transports, the canonical author-trust classifier, the clock, and ignored local report IO.
+ * It never imports a syncer, Memory Core, Task, checkpoint, wake, policy, or graph-write surface.
+ *
+ * Usage:
+ *   `npm run ai:probe-community-activity-shadow -- --owner neomjs --repo neo \
+ *       --window-start 2026-06-18T00:00:00Z --window-end 2026-07-18T00:00:00Z \
+ *       --page-size 100 --runs 2`
+ */
+
+/**
+ * @summary Resolves the report path from an explicit CLI path or an ignored timestamped default.
+ * @param {String|null|undefined} requestedPath Optional path supplied through `--output`.
+ * @param {String} completedAt ISO timestamp naming the default report artifact.
+ * @returns {String}
+ */
+function resolveReportPath(requestedPath, completedAt) {
+    if (requestedPath) {
+        return path.resolve(PROJECT_ROOT, requestedPath)
+    }
+
+    const stamp = completedAt.replace(/[:.]/g, '-');
+
+    return path.join(REPORT_DIR, `report-${stamp}.json`)
+}
+
+/**
+ * @summary Persists one JSON-first shadow report under the explicit or ignored-local path.
+ * @param {Object} report Versioned community-activity shadow report.
+ * @param {String|null|undefined} requestedPath Optional CLI output path.
+ * @returns {String} Absolute report path.
+ */
+function writeReport(report, requestedPath) {
+    const completedAt = report?.run?.completedAt || report?.generatedAt || new Date().toISOString();
+    const reportPath  = resolveReportPath(requestedPath, completedAt);
+
+    fsExtra.outputJsonSync(reportPath, report, {spaces: 4});
+
+    return reportPath
+}
+
+/**
+ * @summary Runs the read-only shadow acquisition and writes its evidence artifact.
+ * @param {String[]} argv CLI arguments.
+ * @returns {Promise<Object>} Exit code plus the report and report path when acquisition runs.
+ */
+export async function main(argv=process.argv.slice(2)) {
+    const args = parseArgs(argv);
+
+    if (args.helpText) {
+        console.log(args.helpText);
+
+        return {exitCode: 0}
+    }
+
+    const reader = makeCommunityActivityShadowReader({
+        query: GraphqlService.query.bind(GraphqlService),
+        rest : GraphqlService.rest.bind(GraphqlService),
+        now  : () => Date.now()
+    });
+    const result = await runShadowProbe(args, {
+        classifyTrust: classifyAuthorTrust,
+        now          : () => new Date().toISOString(),
+        reader
+    });
+
+    if (!result.report) {
+        return result
+    }
+
+    const reportPath = writeReport(result.report, args.output);
+
+    console.log(formatHumanSummary(result.report));
+    console.log(`[probeCommunityActivityShadow] report: ${reportPath}`);
+
+    return {...result, reportPath}
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+    main()
+        .then(({exitCode=0}) => {
+            process.exitCode = exitCode;
+        })
+        .catch(error => {
+            console.error('[probeCommunityActivityShadow] Fatal:', error);
+            process.exitCode = 2;
+        });
+}

--- a/ai/services/github-workflow/communityActivityShadowReader.mjs
+++ b/ai/services/github-workflow/communityActivityShadowReader.mjs
@@ -1,0 +1,836 @@
+import {
+    FETCH_SHADOW_DISCUSSION_COMMENTS_PAGE,
+    FETCH_SHADOW_DISCUSSION_REPLIES_PAGE,
+    FETCH_SHADOW_DISCUSSION_ROOTS,
+    FETCH_SHADOW_ISSUE_ROOTS,
+    FETCH_SHADOW_PULL_REQUEST_REVIEWS_PAGE,
+    FETCH_SHADOW_PULL_REQUEST_ROOTS
+} from './queries/communityActivityShadowQueries.mjs';
+
+/**
+ * @module ai/services/github-workflow/communityActivityShadowReader
+ * @summary Window-bounded, read-only GitHub acquisition for the community-activity shadow probe.
+ *
+ * The callable returned here selects and emits metadata only. It owns no production event,
+ * checkpoint, Task, count, wake, persistence or policy authority. Source gaps stay explicit:
+ * absence is never a deletion, current revisions are never called history, and the Discussion
+ * child-watermark limitation remains a lower-bound receipt.
+ */
+
+const ALLOWED_FAMILIES = new Set(['issues', 'pullRequests', 'discussions']);
+
+const STATIC_GAPS = {
+    issues: [
+        {code: 'issue_lifecycle_history_not_acquired', scope: 'issue_timeline'},
+        {code: 'issue_comment_deletion_tombstones_unavailable', scope: 'repository_issue_comments'},
+        {code: 'historical_revisions_unavailable', scope: 'issue_comments'},
+        {code: 'absence_is_not_a_tombstone', scope: 'issues'}
+    ],
+    pullRequests: [
+        {code: 'pull_request_lifecycle_history_not_acquired', scope: 'pull_request_timeline'},
+        {code: 'pull_request_comment_deletion_tombstones_unavailable', scope: 'repository_issue_comments'},
+        {code: 'review_comment_deletion_tombstones_unavailable', scope: 'repository_review_comments'},
+        {code: 'historical_revisions_unavailable', scope: 'pull_request_comments_and_reviews'},
+        {code: 'search_window_has_day_granularity', scope: 'pull_request_roots'},
+        {code: 'absence_is_not_a_tombstone', scope: 'pull_requests'}
+    ],
+    discussions: [
+        {code: 'discussion_child_watermark_lower_bound', scope: 'discussion_comments_and_replies'},
+        {code: 'historical_revisions_unavailable', scope: 'discussion_comments_and_replies'},
+        {code: 'historical_deletion_tombstones_unavailable', scope: 'discussion_comments_and_replies'},
+        {code: 'absence_is_not_a_tombstone', scope: 'discussions'}
+    ]
+};
+
+const actorFrom = value => ({
+    login: value?.login ?? null,
+    type : value?.__typename ?? value?.type ?? null
+});
+
+const sourceId = value => {
+    const id = value?.node_id ?? value?.id;
+
+    return id == null ? null : String(id)
+};
+
+const sourceDatabaseId = value => value?.databaseId ?? value?.fullDatabaseId ?? value?.id ?? null;
+
+const occurrence = ({id, providerEntityId, eventType, actor, responseBearing, mutationKind, activityAt,
+    timestamps, values = {}}) => ({
+    id,
+    providerEntityId,
+    eventType,
+    actor,
+    responseBearing,
+    mutationKind,
+    activityAt,
+    timestamps,
+    ...values
+});
+
+const rootValues = node => ({
+    databaseId       : sourceDatabaseId(node),
+    number           : node.number,
+    sourceAssociation: node.authorAssociation ?? null,
+    state            : node.state ?? (node.closed === true ? 'CLOSED' : 'OPEN'),
+    stateReason      : node.stateReason ?? null,
+    isDraft          : node.isDraft ?? null,
+    isAnswered       : node.isAnswered ?? null,
+    locked           : node.locked ?? null
+});
+
+/** @summary Emits independent root occurrences so one preferred timestamp cannot erase another. */
+const mapRootOccurrences = (family, node) => {
+    const providerEntityId = sourceId(node);
+    const rootName         = family === 'issues' ? 'Issue' : family === 'pullRequests' ? 'PullRequest' : 'Discussion';
+    const values           = rootValues(node);
+    const rows             = [];
+
+    if (node.createdAt) {
+        rows.push(occurrence({
+            id             : `${providerEntityId}:created`,
+            providerEntityId,
+            eventType      : `${rootName}Created`,
+            actor          : actorFrom(node.author),
+            responseBearing: true,
+            mutationKind   : 'create',
+            activityAt     : node.createdAt,
+            timestamps     : {createdAt: node.createdAt},
+            values
+        }))
+    }
+    if (node.lastEditedAt && node.lastEditedAt !== node.createdAt) {
+        rows.push(occurrence({
+            id             : `${providerEntityId}:edited:${node.lastEditedAt}`,
+            providerEntityId,
+            eventType      : `${rootName}ContentRevision`,
+            actor          : actorFrom(node.author),
+            responseBearing: false,
+            mutationKind   : 'revision',
+            activityAt     : node.lastEditedAt,
+            timestamps     : {lastEditedAt: node.lastEditedAt},
+            values
+        }))
+    }
+    if (node.updatedAt && node.updatedAt !== node.createdAt && node.updatedAt !== node.lastEditedAt) {
+        rows.push(occurrence({
+            id             : `${providerEntityId}:updated:${node.updatedAt}`,
+            providerEntityId,
+            eventType      : `${rootName}SnapshotUpdate`,
+            actor          : {login: null, type: null},
+            responseBearing: false,
+            mutationKind   : 'update',
+            activityAt     : node.updatedAt,
+            timestamps     : {updatedAt: node.updatedAt},
+            values
+        }))
+    }
+
+    const stateAt = node.mergedAt || node.closedAt;
+
+    if (stateAt) {
+        const stateName = node.mergedAt ? 'Merged' : 'Closed';
+
+        rows.push(occurrence({
+            id             : `${providerEntityId}:${stateName.toLowerCase()}:${stateAt}`,
+            providerEntityId,
+            eventType      : `${rootName}${stateName}`,
+            actor          : {login: null, type: null},
+            responseBearing: false,
+            mutationKind   : 'state_transition',
+            activityAt     : stateAt,
+            timestamps     : node.mergedAt ? {mergedAt: stateAt} : {closedAt: stateAt},
+            values
+        }))
+    }
+
+    return rows
+};
+
+/** @summary Emits independent creation/revision occurrences for one REST comment snapshot. */
+const mapRestCommentOccurrences = ({node, family, parent}) => {
+    const createdAt        = node.created_at ?? null;
+    const updatedAt        = node.updated_at ?? null;
+    const isReviewComment  = family === 'pullRequests' && Boolean(node.pull_request_url);
+    const providerEntityId = sourceId(node);
+    const eventType        = isReviewComment
+        ? 'PullRequestReviewComment'
+        : family === 'pullRequests'
+            ? 'PullRequestIssueComment'
+            : 'IssueComment';
+    const values = {
+        databaseId       : node.id ?? null,
+        parentId         : sourceId(parent),
+        number           : parent.number,
+        sourceAssociation: node.author_association ?? null,
+        reviewDatabaseId : node.pull_request_review_id ?? null,
+        replyToDatabaseId: node.in_reply_to_id ?? null
+    };
+    const rows = [];
+
+    if (createdAt) {
+        rows.push(occurrence({
+            id             : `${providerEntityId}:created`,
+            providerEntityId,
+            eventType,
+            actor          : actorFrom(node.user),
+            responseBearing: true,
+            mutationKind   : 'create',
+            activityAt     : createdAt,
+            timestamps     : {createdAt},
+            values
+        }))
+    }
+
+    if (updatedAt && updatedAt !== createdAt) {
+        rows.push(occurrence({
+            id             : `${providerEntityId}:updated:${updatedAt}`,
+            providerEntityId,
+            eventType      : `${eventType}Revision`,
+            actor          : {login: null, type: null},
+            responseBearing: false,
+            mutationKind   : 'revision',
+            activityAt     : updatedAt,
+            timestamps     : {updatedAt},
+            values
+        }))
+    }
+
+    return rows
+};
+
+/** @summary Emits independent submission/revision occurrences for one review snapshot. */
+const mapReviewOccurrences = (node, pullRequest) => {
+    const createdAt        = node.createdAt ?? null;
+    const submittedAt      = node.submittedAt || createdAt;
+    const updatedAt        = node.lastEditedAt || node.updatedAt || null;
+    const providerEntityId = sourceId(node);
+    const values           = {
+        databaseId       : sourceDatabaseId(node),
+        parentId         : sourceId(pullRequest),
+        number           : pullRequest.number,
+        state            : node.state ?? null,
+        sourceAssociation: node.authorAssociation ?? null
+    };
+    const rows = [];
+
+    if (submittedAt) {
+        rows.push(occurrence({
+            id             : `${providerEntityId}:submitted`,
+            providerEntityId,
+            eventType      : 'PullRequestReview',
+            actor          : actorFrom(node.author),
+            responseBearing: true,
+            mutationKind   : 'create',
+            activityAt     : submittedAt,
+            timestamps     : {createdAt, submittedAt},
+            values
+        }))
+    }
+
+    if (updatedAt && updatedAt !== submittedAt && updatedAt !== createdAt) {
+        rows.push(occurrence({
+            id             : `${providerEntityId}:updated:${updatedAt}`,
+            providerEntityId,
+            eventType      : 'PullRequestReviewRevision',
+            actor          : {login: null, type: null},
+            responseBearing: false,
+            mutationKind   : 'revision',
+            activityAt     : updatedAt,
+            timestamps     : {updatedAt, lastEditedAt: node.lastEditedAt ?? null},
+            values
+        }))
+    }
+
+    return rows
+};
+
+/** @summary Emits independent create/revision/tombstone occurrences for a Discussion comment. */
+const mapDiscussionCommentOccurrences = (node, discussion, parentId = null) => {
+    const createdAt        = node.createdAt ?? null;
+    const updatedAt        = node.lastEditedAt || node.updatedAt || null;
+    const providerEntityId = sourceId(node);
+    const eventType        = parentId ? 'DiscussionReply' : 'DiscussionComment';
+    const values           = {
+        databaseId       : sourceDatabaseId(node),
+        parentId         : parentId || sourceId(discussion),
+        discussionId     : sourceId(discussion),
+        number           : discussion.number,
+        isAnswer         : node.isAnswer ?? null,
+        sourceAssociation: node.authorAssociation ?? null
+    };
+    const rows = [];
+
+    if (createdAt) {
+        rows.push(occurrence({
+            id             : `${providerEntityId}:created`,
+            providerEntityId,
+            eventType,
+            actor          : actorFrom(node.author),
+            responseBearing: true,
+            mutationKind   : 'create',
+            activityAt     : createdAt,
+            timestamps     : {createdAt},
+            values
+        }))
+    }
+
+    if (updatedAt && updatedAt !== createdAt) {
+        rows.push(occurrence({
+            id             : `${providerEntityId}:updated:${updatedAt}`,
+            providerEntityId,
+            eventType      : `${eventType}Revision`,
+            actor          : {login: null, type: null},
+            responseBearing: false,
+            mutationKind   : 'revision',
+            activityAt     : updatedAt,
+            timestamps     : {updatedAt, lastEditedAt: node.lastEditedAt ?? null},
+            values
+        }))
+    }
+
+    if (node.deletedAt) {
+        rows.push(occurrence({
+            id             : `${providerEntityId}:deleted:${node.deletedAt}`,
+            providerEntityId,
+            eventType      : `${eventType}Deleted`,
+            actor          : {login: null, type: null},
+            responseBearing: false,
+            mutationKind   : 'delete',
+            activityAt     : node.deletedAt,
+            timestamps     : {deletedAt: node.deletedAt},
+            values         : {...values, tombstone: true}
+        }))
+    }
+
+    return rows
+};
+
+const gap = (code, scope, error = null, values = {}) => ({
+    code,
+    scope,
+    status   : error?.status ?? error?.statusCode ?? null,
+    errorCode: error?.code == null ? null : String(error.code),
+    ...values
+});
+
+const parentNumberFrom = (node, kind) => {
+    const url   = kind === 'review' ? node.pull_request_url : node.issue_url;
+    const match = url?.match(kind === 'review' ? /\/pulls\/(\d+)$/ : /\/issues\/(\d+)$/);
+
+    return match ? Number(match[1]) : null
+};
+
+/**
+ * @summary Binds GET-only REST, GraphQL and a millisecond clock into one shadow snapshot callable.
+ * @param {Object} params
+ * @param {Function} params.query Injected `GraphqlService.query` compatible transport.
+ * @param {Function} params.rest Injected `GraphqlService.rest` compatible transport.
+ * @param {Function} params.now Millisecond clock for acquisition and latency receipts.
+ * @param {Object} [params.config] Reserved wiring config; no policy defaults are read from it.
+ * @returns {Function} `async reader({provider, owner, repo, window, pageSize, families, runIndex})`.
+ */
+export function makeCommunityActivityShadowReader({query, rest, now, config = {}} = {}) {
+    if (typeof query !== 'function') throw new Error('makeCommunityActivityShadowReader: `query` is required');
+    if (typeof rest !== 'function') throw new Error('makeCommunityActivityShadowReader: `rest` is required');
+    if (typeof now !== 'function') throw new Error('makeCommunityActivityShadowReader: `now` is required');
+    if (!config || typeof config !== 'object' || Array.isArray(config)) {
+        throw new Error('makeCommunityActivityShadowReader: `config` must be an object')
+    }
+
+    const clock = () => {
+        const value = Number(now());
+
+        if (!Number.isFinite(value)) throw new Error('communityActivityShadowReader: `now()` must return milliseconds');
+
+        return value
+    };
+
+    return async function readCommunityActivityShadowSnapshot({provider, owner, repo, window, pageSize, families,
+        runIndex} = {}) {
+        if (provider !== 'github') throw new Error('communityActivityShadowReader: provider must be github');
+        if (!owner || !repo) throw new Error('communityActivityShadowReader: owner and repo are required');
+        if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > 100) {
+            throw new Error('communityActivityShadowReader: pageSize must be an integer from 1 through 100')
+        }
+        if (!Array.isArray(families) || families.length === 0
+            || families.some(family => !ALLOWED_FAMILIES.has(family))) {
+            throw new Error('communityActivityShadowReader: families contains an unsupported source family')
+        }
+
+        const windowStart = Date.parse(window?.start || '');
+        const windowEnd   = Date.parse(window?.end || '');
+
+        if (!Number.isFinite(windowStart) || !Number.isFinite(windowEnd) || windowStart >= windowEnd) {
+            throw new Error('communityActivityShadowReader: window.start must precede window.end')
+        }
+
+        const startedMs = clock();
+        const transport = {graphqlCalls: [], restCalls: [], graphqlCost: 0};
+        const results   = Object.fromEntries([...new Set(families)].map(family => [family, {
+            pages    : [],
+            gaps     : STATIC_GAPS[family].map(item => ({...item})),
+            exhausted: true
+        }]));
+        const inWindow = row => {
+            const timestamp = Date.parse(row.activityAt || '');
+
+            return Number.isFinite(timestamp) && timestamp >= windowStart && timestamp < windowEnd
+        };
+        const addGap = (family, item) => {
+            results[family].gaps.push(item);
+            results[family].exhausted = false
+        };
+
+        const graphql = async ({family, queryName, document, variables}) => {
+            const started = clock();
+
+            try {
+                const raw       = await query(document, variables, {strict: false});
+                const completed = clock();
+                const envelope  = raw && typeof raw === 'object'
+                    && (Object.hasOwn(raw, 'data') || Object.hasOwn(raw, 'errors'));
+                const data      = envelope ? raw.data : raw;
+                const errors    = envelope && Array.isArray(raw.errors) ? raw.errors : [];
+                const rateLimit = data?.rateLimit ?? null;
+                const receipt   = {
+                    family,
+                    queryName,
+                    latencyMs : Math.max(0, completed - started),
+                    cost      : Number.isFinite(rateLimit?.cost) ? rateLimit.cost : null,
+                    remaining : Number.isFinite(rateLimit?.remaining) ? rateLimit.remaining : null,
+                    resetAt   : rateLimit?.resetAt ?? null,
+                    errorCount: errors.length
+                };
+
+                transport.graphqlCalls.push(receipt);
+                if (Number.isFinite(receipt.cost)) transport.graphqlCost += receipt.cost;
+                if (errors.length > 0) addGap(family, gap('graphql_partial_errors', queryName, null, {
+                    count: errors.length
+                }));
+
+                return {data, latencyMs: receipt.latencyMs, rateCost: receipt.cost}
+            } catch (error) {
+                const completed = clock();
+
+                transport.graphqlCalls.push({
+                    family,
+                    queryName,
+                    latencyMs : Math.max(0, completed - started),
+                    cost      : null,
+                    remaining : null,
+                    resetAt   : null,
+                    errorCount: 1
+                });
+                throw error
+            }
+        };
+
+        const restGet = async ({family, path}) => {
+            const started = clock();
+
+            try {
+                const data      = await rest('GET', path);
+                const completed = clock();
+                const latencyMs = Math.max(0, completed - started);
+
+                transport.restCalls.push({family, method: 'GET', latencyMs, rateCost: null});
+
+                return {data, latencyMs}
+            } catch (error) {
+                const completed = clock();
+
+                transport.restCalls.push({
+                    family,
+                    method   : 'GET',
+                    latencyMs: Math.max(0, completed - started),
+                    rateCost : null,
+                    failed   : true
+                });
+                throw error
+            }
+        };
+
+        const walkGraphql = async ({family, connectionName, id = null, number = null, document, queryName,
+            variablesFor, selectConnection, mapRows, windowTerminal = null}) => {
+            const sourceNodes = [];
+            const seenCursors = new Set();
+            let   cursor      = null;
+
+            while (true) {
+                let response;
+
+                try {
+                    response = await graphql({family, queryName, document, variables: variablesFor(cursor)})
+                } catch (error) {
+                    addGap(family, gap('graphql_request_failed', queryName, error, {id, number}));
+                    return sourceNodes
+                }
+
+                const source = selectConnection(response.data);
+
+                if (!source || !Array.isArray(source.nodes) || !source.pageInfo) {
+                    addGap(family, gap('graphql_connection_missing', queryName, null, {id, number}));
+                    return sourceNodes
+                }
+
+                const isWindowTerminal = typeof windowTerminal === 'function' && windowTerminal(source.nodes);
+                const rows             = source.nodes.flatMap(node => mapRows(node)).filter(Boolean);
+
+                sourceNodes.push(...source.nodes);
+                results[family].pages.push({
+                    id,
+                    number,
+                    connection           : connectionName,
+                    cursor,
+                    endCursor            : source.pageInfo.endCursor ?? null,
+                    sourceHasNextPage    : source.pageInfo.hasNextPage === true,
+                    windowTerminalReceipt: isWindowTerminal || undefined,
+                    totalCount           : Number.isFinite(source.totalCount) ? source.totalCount : null,
+                    sourceRows           : source.nodes.length,
+                    latencyMs            : response.latencyMs,
+                    rateCost             : response.rateCost,
+                    rows                 : rows.filter(inWindow)
+                });
+
+                if (isWindowTerminal || source.pageInfo.hasNextPage !== true) return sourceNodes;
+
+                const endCursor = source.pageInfo.endCursor;
+
+                if (typeof endCursor !== 'string' || endCursor.length === 0) {
+                    addGap(family, gap('graphql_missing_end_cursor', queryName, null, {id, number}));
+                    return sourceNodes
+                }
+                if (seenCursors.has(endCursor)) {
+                    addGap(family, gap('graphql_repeated_end_cursor', queryName, null, {id, number}));
+                    return sourceNodes
+                }
+
+                seenCursors.add(endCursor);
+                cursor = endCursor
+            }
+        };
+
+        const readCollaborators = async () => {
+            const collaborators = new Set();
+            const pages         = [];
+            const gaps          = [];
+            const signatures    = new Set();
+            let   page          = 1;
+
+            while (true) {
+                const path = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`
+                    + `/collaborators?affiliation=all&per_page=${pageSize}&page=${page}`;
+                let response;
+
+                try {
+                    response = await restGet({family: 'collaborators', path})
+                } catch (error) {
+                    gaps.push(gap('collaborator_census_failed', 'collaborators', error, {page}));
+                    return {
+                        status       : collaborators.size > 0 ? 'partial' : 'unavailable',
+                        collaborators: [...collaborators].sort(),
+                        pages,
+                        gaps
+                    }
+                }
+
+                if (!Array.isArray(response.data)) {
+                    gaps.push(gap('collaborator_census_malformed', 'collaborators', null, {page}));
+                    return {
+                        status       : collaborators.size > 0 ? 'partial' : 'unavailable',
+                        collaborators: [...collaborators].sort(),
+                        pages,
+                        gaps
+                    }
+                }
+
+                const terminalReceipt = response.data.length === 0;
+
+                response.data.forEach(item => {
+                    if (typeof item?.login === 'string' && item.login) collaborators.add(item.login)
+                });
+                pages.push({cursor: page, terminalReceipt, sourceRows: response.data.length,
+                    latencyMs: response.latencyMs});
+
+                if (terminalReceipt) {
+                    return {status: 'complete', collaborators: [...collaborators].sort(), pages, gaps}
+                }
+
+                const signature = response.data.map(item => item?.login ?? item?.id ?? null).join('|');
+
+                if (signatures.has(signature)) {
+                    gaps.push(gap('collaborator_census_repeated_page', 'collaborators', null, {page}));
+                    return {status: 'partial', collaborators: [...collaborators].sort(), pages, gaps}
+                }
+
+                signatures.add(signature);
+                page++
+            }
+        };
+
+        const walkRestCollection = async ({connectionName, pathForPage, targetFamilies, distribute}) => {
+            const signatures       = new Set();
+            const affectedFamilies = targetFamilies.filter(family => Object.hasOwn(results, family));
+            let   page             = 1;
+
+            while (true) {
+                let response;
+
+                try {
+                    response = await restGet({family: connectionName, path: pathForPage(page)})
+                } catch (error) {
+                    affectedFamilies.forEach(family => addGap(family,
+                        gap('rest_request_failed', connectionName, error, {page})));
+                    return
+                }
+
+                if (!Array.isArray(response.data)) {
+                    affectedFamilies.forEach(family => addGap(family,
+                        gap('rest_collection_malformed', connectionName, null, {page})));
+                    return
+                }
+
+                const terminalReceipt = response.data.length === 0;
+                const distributed     = distribute(response.data, page);
+
+                for (const family of Object.keys(results)) {
+                    if (!Object.hasOwn(distributed, family)) continue;
+
+                    results[family].pages.push({
+                        id        : null,
+                        number    : null,
+                        connection: connectionName,
+                        cursor    : page,
+                        terminalReceipt,
+                        sourceRows: response.data.length,
+                        latencyMs : response.latencyMs,
+                        rateCost  : null,
+                        rows      : distributed[family].filter(inWindow)
+                    })
+                }
+
+                if (terminalReceipt) return;
+
+                const signature = response.data.map(item => item?.node_id ?? item?.id ?? null).join('|');
+
+                if (signatures.has(signature)) {
+                    Object.keys(distributed).forEach(family => addGap(family,
+                        gap('rest_repeated_page', connectionName, null, {page})));
+                    return
+                }
+
+                signatures.add(signature);
+                page++
+            }
+        };
+
+        const collaboratorCensus = await readCollaborators();
+        const coordinates        = {owner, repo, limit: pageSize};
+        let   issueRoots         = [];
+        let   pullRequestRoots   = [];
+
+        if (results.issues) {
+            issueRoots = await walkGraphql({
+                family          : 'issues',
+                connectionName  : 'roots',
+                document        : FETCH_SHADOW_ISSUE_ROOTS,
+                queryName       : 'ShadowIssueRoots',
+                variablesFor    : cursor => ({...coordinates, cursor, windowStart: window.start}),
+                selectConnection: data => data?.repository?.issues,
+                mapRows         : node => mapRootOccurrences('issues', node)
+            })
+        }
+
+        if (results.pullRequests) {
+            const startDay    = new Date(windowStart).toISOString().slice(0, 10);
+            const searchQuery = `repo:${owner}/${repo} is:pr updated:>=${startDay}`;
+
+            pullRequestRoots = await walkGraphql({
+                family          : 'pullRequests',
+                connectionName  : 'roots',
+                document        : FETCH_SHADOW_PULL_REQUEST_ROOTS,
+                queryName       : 'ShadowPullRequestRoots',
+                variablesFor    : cursor => ({searchQuery, limit: pageSize, cursor}),
+                selectConnection: data => data?.search,
+                mapRows         : node => mapRootOccurrences('pullRequests', node)
+            });
+
+            const resultCount = results.pullRequests.pages.find(item => item.connection === 'roots')?.totalCount;
+
+            if (Number.isFinite(resultCount) && resultCount >= 1000) {
+                addGap('pullRequests', gap('github_search_1000_result_cap', 'pull_request_roots', null, {
+                    resultCount
+                }))
+            }
+        }
+
+        const issueByNumber       = new Map(issueRoots.map(item => [item.number, item]));
+        const pullRequestByNumber = new Map(pullRequestRoots.map(item => [item.number, item]));
+        const since               = encodeURIComponent(new Date(windowStart).toISOString());
+        const repoPath            = `/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+
+        if (results.issues || results.pullRequests) {
+            await walkRestCollection({
+                connectionName: 'repositoryIssueComments',
+                targetFamilies: ['issues', 'pullRequests'],
+                pathForPage   : page => `${repoPath}/issues/comments?since=${since}&sort=updated&direction=asc`
+                    + `&per_page=${pageSize}&page=${page}`,
+                distribute    : (nodes, page) => {
+                    const rows    = {issues: [], pullRequests: []};
+                    const missing = {issues: 0, pullRequests: 0};
+
+                    for (const node of nodes) {
+                        const number        = parentNumberFrom(node, 'issue');
+                        const isPullRequest = /\/pull\//.test(node.html_url || '');
+                        const family        = isPullRequest ? 'pullRequests' : 'issues';
+                        const boundedParent = family === 'pullRequests'
+                            ? pullRequestByNumber.get(number)
+                            : issueByNumber.get(number);
+                        const parent = boundedParent || (number == null ? null : {
+                            id: family === 'pullRequests' ? (node.pull_request_url ?? node.issue_url) : node.issue_url,
+                            number
+                        });
+
+                        if (parent) rows[family].push(...mapRestCommentOccurrences({node, family, parent}));
+                        else missing[family]++
+                    }
+
+                    for (const family of Object.keys(missing)) {
+                        if (missing[family] > 0 && results[family]) {
+                            addGap(family, gap('comment_parent_outside_bounded_roots',
+                                'repository_issue_comments', null, {page, count: missing[family]}))
+                        }
+                    }
+
+                    return Object.fromEntries(Object.entries(rows).filter(([family]) => results[family]))
+                }
+            })
+        }
+
+        if (results.pullRequests) {
+            await walkRestCollection({
+                connectionName: 'repositoryReviewComments',
+                targetFamilies: ['pullRequests'],
+                pathForPage   : page => `${repoPath}/pulls/comments?since=${since}&sort=updated&direction=asc`
+                    + `&per_page=${pageSize}&page=${page}`,
+                distribute    : (nodes, page) => {
+                    const rows    = [];
+                    let   missing = 0;
+
+                    for (const node of nodes) {
+                        const number = parentNumberFrom(node, 'review');
+                        const parent = pullRequestByNumber.get(number) || (number == null ? null : {
+                            id: node.pull_request_url,
+                            number
+                        });
+
+                        if (parent) rows.push(...mapRestCommentOccurrences({
+                            node,
+                            family: 'pullRequests',
+                            parent
+                        }));
+                        else missing++
+                    }
+                    if (missing > 0) addGap('pullRequests', gap('review_comment_parent_outside_bounded_roots',
+                        'repository_review_comments', null, {page, count: missing}));
+
+                    return {pullRequests: rows}
+                }
+            });
+
+            for (const pullRequest of pullRequestRoots.filter(item => {
+                const updatedAt = Date.parse(item.updatedAt || item.createdAt || '');
+
+                return Number.isFinite(updatedAt) && updatedAt >= windowStart
+            })) {
+                await walkGraphql({
+                    family          : 'pullRequests',
+                    connectionName  : 'reviews',
+                    id              : sourceId(pullRequest),
+                    number          : pullRequest.number,
+                    document        : FETCH_SHADOW_PULL_REQUEST_REVIEWS_PAGE,
+                    queryName       : 'ShadowPullRequestReviewsPage',
+                    variablesFor    : cursor => ({...coordinates, number: pullRequest.number, cursor}),
+                    selectConnection: data => data?.repository?.pullRequest?.reviews,
+                    mapRows         : node => mapReviewOccurrences(node, pullRequest)
+                })
+            }
+        }
+
+        if (results.discussions) {
+            const discussions = await walkGraphql({
+                family          : 'discussions',
+                connectionName  : 'roots',
+                document        : FETCH_SHADOW_DISCUSSION_ROOTS,
+                queryName       : 'ShadowDiscussionRoots',
+                variablesFor    : cursor => ({...coordinates, cursor}),
+                selectConnection: data => data?.repository?.discussions,
+                mapRows         : node => mapRootOccurrences('discussions', node),
+                windowTerminal  : nodes => nodes.length > 0
+                    && nodes.every(node => Date.parse(node.updatedAt || '') < windowStart)
+            });
+
+            for (const discussion of discussions.filter(item => {
+                const updatedAt = Date.parse(item.updatedAt || item.createdAt || '');
+
+                return Number.isFinite(updatedAt) && updatedAt >= windowStart
+            })) {
+                const comments = await walkGraphql({
+                    family          : 'discussions',
+                    connectionName  : 'comments',
+                    id              : sourceId(discussion),
+                    number          : discussion.number,
+                    document        : FETCH_SHADOW_DISCUSSION_COMMENTS_PAGE,
+                    queryName       : 'ShadowDiscussionCommentsPage',
+                    variablesFor    : cursor => ({...coordinates, number: discussion.number, cursor}),
+                    selectConnection: data => data?.repository?.discussion?.comments,
+                    mapRows         : node => mapDiscussionCommentOccurrences(node, discussion)
+                });
+
+                for (const comment of comments) {
+                    if (!sourceId(comment)) {
+                        addGap('discussions', gap('discussion_comment_id_missing', 'replies', null, {
+                            number: discussion.number
+                        }));
+                        continue
+                    }
+
+                    await walkGraphql({
+                        family          : 'discussions',
+                        connectionName  : 'replies',
+                        id              : sourceId(comment),
+                        number          : discussion.number,
+                        document        : FETCH_SHADOW_DISCUSSION_REPLIES_PAGE,
+                        queryName       : 'ShadowDiscussionRepliesPage',
+                        variablesFor    : cursor => ({commentId: sourceId(comment), limit: pageSize, cursor}),
+                        selectConnection: data => data?.node?.replies,
+                        mapRows         : node => mapDiscussionCommentOccurrences(node, discussion, sourceId(comment))
+                    })
+                }
+            }
+        }
+
+        const completedMs = clock();
+
+        return {
+            schemaVersion: 'github-community-shadow-source.v1',
+            notAuthority : true,
+            provider,
+            owner,
+            repo,
+            runIndex,
+            window       : {start: new Date(windowStart).toISOString(), end: new Date(windowEnd).toISOString()},
+            startedAt    : new Date(startedMs).toISOString(),
+            completedAt  : new Date(completedMs).toISOString(),
+            collaboratorCensus,
+            families     : results,
+            popularity   : {
+                status: 'excluded',
+                rows  : [],
+                gaps  : [{code: 'popularity_telemetry_out_of_scope'}]
+            },
+            transport
+        }
+    }
+}

--- a/ai/services/github-workflow/queries/communityActivityShadowQueries.mjs
+++ b/ai/services/github-workflow/queries/communityActivityShadowQueries.mjs
@@ -1,0 +1,197 @@
+/**
+ * Read-only GitHub queries for the community-activity shadow probe.
+ *
+ * @module ai/services/github-workflow/queries/communityActivityShadowQueries
+ * @summary Metadata-only, cursor-bearing source queries for issues, pull requests/reviews and
+ * Discussions. These queries intentionally select no title, body, excerpt or other prose.
+ */
+
+/** @summary Exhaust one page of repository issues whose root changed since the probe window opened. */
+export const FETCH_SHADOW_ISSUE_ROOTS = `
+  query ShadowIssueRoots(
+    $owner: String!
+    $repo: String!
+    $limit: Int!
+    $cursor: String
+    $windowStart: DateTime!
+  ) {
+    repository(owner: $owner, name: $repo) {
+      issues(
+        first: $limit
+        after: $cursor
+        states: [OPEN, CLOSED]
+        orderBy: {field: UPDATED_AT, direction: DESC}
+        filterBy: {since: $windowStart}
+      ) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          databaseId
+          number
+          state
+          stateReason
+          createdAt
+          updatedAt
+          closedAt
+          lastEditedAt
+          author { __typename login }
+          authorAssociation
+        }
+      }
+    }
+    rateLimit { cost remaining resetAt }
+  }
+`;
+
+/** @summary Exhaust one GitHub-search page of PR roots updated since the probe window opened. */
+export const FETCH_SHADOW_PULL_REQUEST_ROOTS = `
+  query ShadowPullRequestRoots($searchQuery: String!, $limit: Int!, $cursor: String) {
+    search(query: $searchQuery, type: ISSUE, first: $limit, after: $cursor) {
+      totalCount: issueCount
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        ... on PullRequest {
+          id
+          databaseId
+          number
+          state
+          isDraft
+          createdAt
+          updatedAt
+          closedAt
+          mergedAt
+          lastEditedAt
+          author { __typename login }
+          authorAssociation
+        }
+      }
+    }
+    rateLimit { cost remaining resetAt }
+  }
+`;
+
+/** @summary Exhaust one metadata-only review page for a known pull request. */
+export const FETCH_SHADOW_PULL_REQUEST_REVIEWS_PAGE = `
+  query ShadowPullRequestReviewsPage(
+    $owner: String!
+    $repo: String!
+    $number: Int!
+    $limit: Int!
+    $cursor: String
+  ) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        id
+        reviews(first: $limit, after: $cursor) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            fullDatabaseId
+            state
+            createdAt
+            updatedAt
+            submittedAt
+            lastEditedAt
+            author { __typename login }
+            authorAssociation
+          }
+        }
+      }
+    }
+    rateLimit { cost remaining resetAt }
+  }
+`;
+
+/** @summary Exhaust one page of Discussion roots without trusting their timestamps for child freshness. */
+export const FETCH_SHADOW_DISCUSSION_ROOTS = `
+  query ShadowDiscussionRoots($owner: String!, $repo: String!, $limit: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      discussions(
+        first: $limit
+        after: $cursor
+        orderBy: {field: UPDATED_AT, direction: DESC}
+      ) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          databaseId
+          number
+          closed
+          closedAt
+          locked
+          isAnswered
+          answerChosenAt
+          createdAt
+          updatedAt
+          lastEditedAt
+          author { __typename login }
+          authorAssociation
+        }
+      }
+    }
+    rateLimit { cost remaining resetAt }
+  }
+`;
+
+/** @summary Exhaust one metadata-only top-level comment page for a known Discussion. */
+export const FETCH_SHADOW_DISCUSSION_COMMENTS_PAGE = `
+  query ShadowDiscussionCommentsPage(
+    $owner: String!
+    $repo: String!
+    $number: Int!
+    $limit: Int!
+    $cursor: String
+  ) {
+    repository(owner: $owner, name: $repo) {
+      discussion(number: $number) {
+        id
+        comments(first: $limit, after: $cursor) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            databaseId
+            createdAt
+            updatedAt
+            lastEditedAt
+            deletedAt
+            isAnswer
+            author { __typename login }
+            authorAssociation
+          }
+        }
+      }
+    }
+    rateLimit { cost remaining resetAt }
+  }
+`;
+
+/** @summary Exhaust one metadata-only reply page for a known Discussion comment. */
+export const FETCH_SHADOW_DISCUSSION_REPLIES_PAGE = `
+  query ShadowDiscussionRepliesPage($commentId: ID!, $limit: Int!, $cursor: String) {
+    node(id: $commentId) {
+      ... on DiscussionComment {
+        id
+        replies(first: $limit, after: $cursor) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            databaseId
+            createdAt
+            updatedAt
+            lastEditedAt
+            deletedAt
+            isAnswer
+            author { __typename login }
+            authorAssociation
+          }
+        }
+      }
+    }
+    rateLimit { cost remaining resetAt }
+  }
+`;

--- a/learn/agentos/measurements/community-activity-shadow-2026-07-18.md
+++ b/learn/agentos/measurements/community-activity-shadow-2026-07-18.md
@@ -1,0 +1,92 @@
+# Community-Activity Shadow Measurement — 2026-07-18
+
+Issue: #15149 · Epic: #15145 · Generated: 2026-07-18T17:59:08.405Z
+
+This is a read-only, 30-day lower-bound measurement of supported GitHub issue,
+pull-request/review, and Discussion source occurrences. It is evidence, not community
+authority: the run admitted no events, advanced no checkpoints, created no Tasks, projected no
+counts, delivered no wakes, and selected no operational threshold.
+
+## Run Coordinates
+
+- Command: `npm run ai:probe-community-activity-shadow -- --owner neomjs --repo neo --window-start 2026-06-18T00:00:00Z --window-end 2026-07-18T00:00:00Z --page-size 100 --runs 2 --output .neo-ai-data/community-activity-shadow/report-2026-07-18-v2.json`
+- Repository: `neomjs/neo`
+- Window: `[2026-06-18T00:00:00.000Z, 2026-07-18T00:00:00.000Z)`
+- Report schema: `community-activity-shadow-report.v1`
+- Report ID: `79a6d84d9212d00f0f9ca8db33d517c64f0f90bfd0d2ef68fee88103bcc770dd`
+- Query-plan hash: `a8b8463178384ab810b7deee43ff1319ab9c419d3fc2df495b57023913925910`
+- Raw report: `.neo-ai-data/community-activity-shadow/report-2026-07-18-v2.json` (ignored local evidence, 1,058,632 bytes)
+- Raw-report SHA-256: `7ff1e6be32b2b9840290408332685f3c985e26533daaec63ba7431c2a917a887`
+- Wall time: `1,040,936 ms` across two complete acquisitions
+
+## Aggregate Snapshot
+
+| Measure | Value | Evidence status |
+|---|---:|---|
+| Source occurrences | 11,253 | lower-bound window |
+| Attention-eligible external occurrences | 22 | zero-authority projection input |
+| Attention-eligible density | 0.1955% | measured ratio, not a policy threshold |
+| Provider pages | 1,739 | measured per full acquisition |
+| Provider requests / cost units | 1,714 / 1,714 | 1,683 GraphQL + 31 REST; cost is a lower bound |
+| Projected metadata | 3,809,537 bytes | lower-bound projection |
+| Revisions | 2,937 | lower-bound observed revisions |
+| Explicit tombstones | 0 | lower bound; absence is not a tombstone |
+| Duplicate occurrences | 0 | measured inside the declared acquisition plan |
+
+## Family Breakdown
+
+| Family | Pages | Occurrences | Unique entities | Attention-eligible | Revisions | State transitions | Projected bytes | Provider latency |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Issues | 40 | 4,920 | 2,756 | 9 | 1,460 | 951 | 1,640,121 | 21,288 ms |
+| Pull requests / reviews | 995 | 5,664 | 3,493 | 4 | 1,364 | 863 | 1,939,843 | 320,606 ms |
+| Discussions | 704 | 669 | 543 | 9 | 113 | 38 | 229,573 | 191,005 ms |
+
+The acquisition shape is not uniform. Pull requests/reviews consume the most pages and elapsed
+provider time in absolute terms. Discussions consume `1.0523` pages per candidate versus `0.1757`
+for pull requests and `0.0081` for issues, so Discussion child traversal is the densest provider-read
+surface per observed candidate in this run. This is a measurement input only; it does not authorize
+a pagination cap or cadence.
+
+## Repeatability
+
+Both acquisitions used the same query-plan hash and produced the same order-independent candidate
+manifest:
+
+`65de1150163ec730630abf4538012ab2ec1070b04441f81fb9b92137992ee38c`
+
+Every reported numeric variance was zero: pages, provider requests/cost, raw and candidate rows,
+duplicates, revisions, tombstones, projected bytes, and attention-eligible rows.
+
+The receipt-level source-manifest hashes were intentionally recorded separately:
+
+- Run 1: `33088e5dba0e33b04e004cc17fa130bee34a3aa3e7f73ead0ad5b6bdc7608347`
+- Run 2: `b42736c6663bfcee205397b911ebc50414eb5e5833aaff8afb94c8bb8952cf60`
+
+They differ because `sourceManifestHash` includes latency-bearing page receipts as well as family
+inventory hashes. The stable candidate-manifest hash is the content-identity witness; the distinct
+source-manifest hashes preserve the two actual acquisition receipts instead of erasing run-specific
+transport evidence.
+
+## Coverage Posture
+
+- The declared family plans exhausted successfully and the run was not degraded.
+- This is still a lower bound and makes no global-completeness claim.
+- Issue and pull-request lifecycle timelines were not acquired.
+- Historical comment/review revisions may be missing.
+- Historical deletion tombstones are unavailable; zero explicit tombstones does not mean zero
+  deletions.
+- Pull-request root search has day granularity.
+- Discussion comments/replies use a child-watermark lower bound.
+- Popularity telemetry (stars, forks, watches, and equivalents) was excluded by contract and did not
+  enter candidate, storage, count, or wake inputs.
+
+## Unknowns and Non-Decisions
+
+Useful-response latency and production-lifecycle metrics remain explicitly unknown, including CAS
+conflict rate, duplicate-batch receipt rate, replay lag, outbox age, bytes/hooks/wakes per admitted
+event, steward vacancy, false-positive rate, and time to acknowledge/claim/respond.
+
+The report leaves acquisition cadence, pagination cap, retention, archive threshold, TTL, steward
+lease, and wake threshold as `null`. The observed 0.1955% attention-eligible density and provider-cost
+shape are inputs for later admission/attention decisions; they are not authorization to activate a
+count, hook, wake, Task, or policy surface.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "ai:mcp-server-neural-link"            : "node ./ai/mcp/server/neural-link/mcp-server.mjs",
         "ai:migration-census-report"           : "node ./ai/scripts/maintenance/migrationCensusReport.mjs",
         "ai:probe-business-metrics"            : "node ./ai/scripts/maintenance/probeBusinessMetrics.mjs",
+        "ai:probe-community-activity-shadow"   : "node ./ai/scripts/maintenance/probeCommunityActivityShadow.mjs",
         "ai:probe-keep-alive"                  : "node ./ai/scripts/benchmark/keep-alive-probe.mjs",
         "ai:prune-worktrees"                   : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale",
         "ai:prune-worktrees:dry-run"           : "node ./ai/scripts/migrations/bootstrapWorktree.mjs --prune-stale --dry-run",

--- a/test/playwright/unit/ai/scripts/maintenance/communityActivityShadowProbeCore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/communityActivityShadowProbeCore.spec.mjs
@@ -1,0 +1,357 @@
+import {expect, test} from '@playwright/test';
+import {
+    REPORT_SCHEMA_VERSION,
+    assertShadowFirewall,
+    formatHumanSummary,
+    measurement,
+    normalizeActorKind,
+    parseArgs,
+    runShadowProbe
+} from '../../../../../../ai/scripts/maintenance/communityActivityShadowProbeCore.mjs';
+
+const OPTIONS = {
+    owner      : 'neomjs',
+    pageSize   : 100,
+    repo       : 'neo',
+    runs       : 2,
+    windowEnd  : '2026-07-18T00:00:00.000Z',
+    windowStart: '2026-06-18T00:00:00.000Z'
+};
+
+const EXTERNAL = {login: 'outside-contributor', type: 'User'};
+const PEER     = {login: 'neo-gpt', type: 'User'};
+const BOT      = {login: 'dependabot[bot]', type: 'Bot'};
+
+function classifyTrust(login, {collaborators=[]}={}) {
+    if (login === 'neo-gpt') return 'peer-trusted';
+    if (collaborators.includes(login)) return 'repo-trusted';
+    return login ? 'external' : 'unclassified';
+}
+
+function page(resourceKind, rows, overrides={}) {
+    return {
+        apiSurface         : 'graphql',
+        hasNextPage        : false,
+        latencyMs          : 7,
+        pageOrdinal        : 1,
+        providerCost       : 1,
+        resourceKind,
+        responseFingerprint: `receipt-${resourceKind}-${rows.length}`,
+        rows,
+        ...overrides
+    };
+}
+
+function baseSnapshot({extraRows=[], popularityRows=[], collaboratorStatus='complete', gaps=[]}={}) {
+    return {
+        collaboratorCensus: {
+            collaborators: collaboratorStatus === 'complete' ? ['repo-writer'] : [],
+            gaps         : collaboratorStatus === 'complete' ? [] : [{reasonCode: 'collaborator-permission-denied'}],
+            status       : collaboratorStatus
+        },
+        completedAt: '2026-07-18T00:01:00.000Z',
+        families   : {
+            discussions: {
+                exhausted: true,
+                gaps     : [],
+                pages    : [page('discussion-comments', [
+                    {
+                        actor          : EXTERNAL,
+                        createdAt      : '2026-07-04T10:00:00Z',
+                        eventType      : 'discussion-comment',
+                        id             : 'dc-1',
+                        mutationKind   : 'create',
+                        responseBearing: true
+                    },
+                    {
+                        actor            : EXTERNAL,
+                        deletedAt        : '2026-07-05T10:00:00Z',
+                        eventType        : 'discussion-reply',
+                        explicitTombstone: true,
+                        id               : 'dr-1',
+                        mutationKind     : 'tombstone',
+                        responseBearing  : false
+                    }
+                ])]
+            },
+            issues: {
+                exhausted: true,
+                gaps,
+                pages    : [page('issues', [
+                    {
+                        actor          : EXTERNAL,
+                        createdAt      : '2026-07-01T10:00:00Z',
+                        eventType      : 'issue-root',
+                        id             : 'issue-1',
+                        mutationKind   : 'create',
+                        responseBearing: true
+                    },
+                    {
+                        actor          : EXTERNAL,
+                        createdAt      : '2026-07-01T10:00:00Z',
+                        eventType      : 'issue-root',
+                        id             : 'issue-1',
+                        mutationKind   : 'create',
+                        responseBearing: true
+                    },
+                    {
+                        actor          : BOT,
+                        eventType      : 'issue-comment',
+                        id             : 'ic-1',
+                        mutationKind   : 'revision',
+                        responseBearing: true,
+                        updatedAt      : '2026-07-02T10:00:00Z'
+                    },
+                    ...popularityRows,
+                    ...extraRows
+                ])]
+            },
+            pullRequests: {
+                exhausted: true,
+                gaps     : [],
+                pages    : [page('pull-request-reviews', [
+                    {
+                        actor          : PEER,
+                        createdAt      : '2026-07-03T10:00:00Z',
+                        eventType      : 'pull-request-root',
+                        id             : 'pr-1',
+                        mutationKind   : 'create',
+                        responseBearing: true
+                    },
+                    {
+                        actor          : {login: 'repo-writer', type: 'User'},
+                        createdAt      : '2026-07-03T11:00:00Z',
+                        eventType      : 'pull-request-review',
+                        id             : 'review-1',
+                        mutationKind   : 'create',
+                        responseBearing: true
+                    }
+                ])]
+            }
+        },
+        startedAt: '2026-07-18T00:00:00.000Z'
+    };
+}
+
+function makeClock() {
+    const times = [
+        '2026-07-18T00:00:00.000Z',
+        '2026-07-18T00:02:00.000Z',
+        '2026-07-18T00:04:00.000Z',
+        '2026-07-18T00:05:00.000Z'
+    ];
+
+    return () => times.shift() || '2026-07-18T00:05:00.000Z';
+}
+
+async function runWithSnapshots(snapshots) {
+    let index = 0;
+
+    return runShadowProbe(OPTIONS, {
+        classifyTrust,
+        now   : makeClock(),
+        reader: async () => structuredClone(snapshots[Math.min(index++, snapshots.length - 1)])
+    });
+}
+
+test.describe('communityActivityShadowProbeCore — explicit coordinates', () => {
+    test('parseArgs emits reproducible half-open coordinates and requires two runs', () => {
+        const help = parseArgs(['--help']);
+
+        expect(help.helpText).toContain('Read-only GitHub community-activity shadow measurement');
+        expect(help.helpText).toContain('--window-start <iso>');
+        expect(help.helpText).toContain('--runs <count>');
+
+        const parsed = parseArgs([
+            '--owner', 'neomjs',
+            '--repo', 'neo',
+            '--window-start', '2026-06-18T00:00:00Z',
+            '--window-end', '2026-07-18T00:00:00Z',
+            '--page-size', '50',
+            '--runs', '3',
+            '--output', '.neo-ai-data/custom.json'
+        ]);
+
+        expect(parsed).toMatchObject({owner: 'neomjs', repo: 'neo', pageSize: 50, runs: 3});
+        expect(parsed.windowStart).toBe('2026-06-18T00:00:00.000Z');
+        expect(parsed.windowEnd).toBe('2026-07-18T00:00:00.000Z');
+        expect(() => parseArgs([
+            '--owner', 'neomjs', '--repo', 'neo',
+            '--window-start', '2026-07-18T00:00:00Z',
+            '--window-end', '2026-06-18T00:00:00Z'
+        ])).toThrow('half-open');
+        expect(() => parseArgs([
+            '--owner', 'neomjs', '--repo', 'neo',
+            '--window-start', '2026-06-18T00:00:00Z',
+            '--window-end', '2026-07-18T00:00:00Z',
+            '--runs', '1'
+        ])).toThrow('>= 2');
+    });
+
+    test('normalizes provider actor kinds without treating them as trust', () => {
+        expect(['User', 'Bot', 'Organization', 'Mannequin', 'EnterpriseUser', null].map(normalizeActorKind))
+            .toEqual(['user', 'bot', 'organization', 'mannequin', 'enterpriseUser', 'unknown']);
+    });
+
+    test('unknown measurements are explicit and zero denominators never become zero ratios', async () => {
+        expect(measurement('unknown', null, 'ratio', {reasonCode: 'not-observed'})).toEqual({
+            denominator: null,
+            numerator  : null,
+            reasonCode : 'not-observed',
+            status     : 'unknown',
+            unit       : 'ratio',
+            value      : null
+        });
+
+        const {report}    = await runWithSnapshots([baseSnapshot(), baseSnapshot()]);
+        const emptyFamily = report.families.find(item => item.family === 'issues');
+        expect(emptyFamily.rates.updateRate.denominator).toBeGreaterThan(0);
+        expect(report.futureMetricSlots.timeToRespondMs.status).toBe('unknown');
+    });
+});
+
+test.describe('communityActivityShadowProbeCore — report contract', () => {
+    test('emits all three families, separate actor/trust cohorts, mutation evidence, and a human summary', async () => {
+        const {exitCode, report} = await runWithSnapshots([baseSnapshot(), baseSnapshot()]);
+
+        expect(exitCode).toBe(0);
+        expect(report.schemaVersion).toBe(REPORT_SCHEMA_VERSION);
+        expect(report.families.map(item => item.family)).toEqual(['issues', 'pullRequests', 'discussions']);
+        expect(report.families.find(item => item.family === 'issues')).toMatchObject({
+            acquisition     : {exhausted: true, pages: 1, rawRows: 3},
+            mutationEvidence: {createRows: 1, revisionRows: 1},
+            observations    : {candidateRows: 2, duplicateRows: 1}
+        });
+
+        const pullRequests = report.families.find(item => item.family === 'pullRequests');
+        expect(pullRequests.classifications.actorKinds.user).toBe(2);
+        expect(pullRequests.classifications.trustTiers['peer-trusted']).toBe(1);
+        expect(pullRequests.classifications.trustTiers['repo-trusted']).toBe(1);
+        expect(pullRequests.attention.eligibleRows).toBe(0);
+        expect(report.families.find(item => item.family === 'discussions').mutationEvidence.explicitTombstoneRows).toBe(1);
+        expect(report.summary.text).toContain('LOWER BOUND');
+        expect(formatHumanSummary(report)).toContain('no thresholds authorized');
+    });
+
+    test('counts provider entities independently from their occurrence rows', async () => {
+        const shared = {
+            actor           : EXTERNAL,
+            eventType       : 'issue-comment',
+            providerEntityId: 'provider-comment-1',
+            responseBearing : true
+        };
+        const snapshot = baseSnapshot({extraRows: [
+            {...shared, activityAt: '2026-07-10T10:00:00Z', id: 'provider-comment-1:created', mutationKind: 'create'},
+            {...shared, activityAt: '2026-07-11T10:00:00Z', id: 'provider-comment-1:updated', mutationKind: 'revision'}
+        ]});
+        const {report} = await runWithSnapshots([snapshot, snapshot]);
+        const issues   = report.families.find(item => item.family === 'issues');
+
+        expect(issues.observations.candidateRows).toBe(4);
+        expect(issues.observations.uniqueEntities).toBe(3);
+    });
+
+    test('keeps clean exhausted acquisition lower-bound without calling it degraded', async () => {
+        const snapshot = baseSnapshot({gaps: [{code: 'historical_revisions_unavailable', scope: 'issue-comments'}]});
+        const {report} = await runWithSnapshots([snapshot, snapshot]);
+
+        expect(report.coverage).toMatchObject({
+            degraded               : false,
+            exhausted              : true,
+            globalCompletenessClaim: false,
+            lowerBound             : true,
+            unseenHistoryPossible  : true
+        });
+        expect(report.coverage.lowerBoundReasons).toContain('historical_revisions_unavailable');
+    });
+
+    test('degraded collaborator authority fails external attention closed and names the gap', async () => {
+        const snapshot = baseSnapshot({collaboratorStatus: 'degraded'});
+        const {report} = await runWithSnapshots([snapshot, snapshot]);
+
+        expect(report.coverage.degraded).toBe(true);
+        expect(report.coverage.gaps).toContainEqual({family: 'collaborators', reasonCode: 'collaborator-permission-denied'});
+        expect(report.totals.attentionEligibleRows).toBe(0);
+        expect(report.families.find(item => item.family === 'issues').classifications.trustTiers.unclassified).toBe(2);
+    });
+
+    test('records two real reader calls, stable query-plan identity, and exact variance without a tolerance', async () => {
+        const second = baseSnapshot({extraRows: [{
+            actor          : EXTERNAL,
+            createdAt      : '2026-07-10T10:00:00Z',
+            eventType      : 'issue-comment',
+            id             : 'ic-new',
+            mutationKind   : 'create',
+            responseBearing: true
+        }]});
+        const {report} = await runWithSnapshots([baseSnapshot(), second]);
+
+        expect(report.repeatability.evidenceStatus).toBe('two-run');
+        expect(report.repeatability.comparable).toBe(true);
+        expect(report.repeatability.runs).toHaveLength(2);
+        expect(report.repeatability.runs[0].queryPlanHash).toBe(report.repeatability.runs[1].queryPlanHash);
+        expect(report.repeatability.runs[0].sourceManifestHash).not.toBe(report.repeatability.runs[1].sourceManifestHash);
+        expect(report.repeatability.variance.candidateRows).toBe(1);
+        expect(report.policy.thresholds.paginationCap).toBeNull();
+        expect(report.policy).not.toHaveProperty('varianceTolerance');
+    });
+
+    test('treats provider row-order jitter as the same candidate inventory', async () => {
+        const first  = baseSnapshot();
+        const second = structuredClone(first);
+
+        for (const family of Object.values(second.families)) {
+            for (const receipt of family.pages) {
+                receipt.rows.reverse();
+            }
+        }
+
+        const {report}     = await runWithSnapshots([first, second]);
+        const [run1, run2] = report.repeatability.runs;
+
+        expect(run1.candidateManifestHash).toBe(run2.candidateManifestHash);
+        expect(report.repeatability.variance.candidateRows).toBe(0);
+        expect(report.repeatability.variance.projectedMetadataBytes).toBe(0);
+    });
+
+    test('popularity telemetry changes raw receipts only, never candidates, storage, counts, wakes, or candidate identity', async () => {
+        const baseline   = await runWithSnapshots([baseSnapshot(), baseSnapshot()]);
+        const popularity = {actor: EXTERNAL, eventType: 'repository-star', id: 'star-1', mutationKind: 'create', responseBearing: false};
+        const noisy      = await runWithSnapshots([
+            baseSnapshot({popularityRows: [popularity]}),
+            baseSnapshot({popularityRows: [popularity]})
+        ]);
+
+        expect(noisy.report.excludedTelemetry.rows).toBe(1);
+        expect(noisy.report.totals.candidateRows).toBe(baseline.report.totals.candidateRows);
+        expect(noisy.report.totals.projectedMetadataBytes).toBe(baseline.report.totals.projectedMetadataBytes);
+        expect(noisy.report.totals.attentionEligibleRows).toBe(baseline.report.totals.attentionEligibleRows);
+        expect(noisy.report.sourceManifest.candidateManifestHash).toBe(baseline.report.sourceManifest.candidateManifestHash);
+
+        const noisyIssues = noisy.report.families.find(item => item.family === 'issues');
+        const baseIssues  = baseline.report.families.find(item => item.family === 'issues');
+        expect(noisyIssues.projectionInputs).toEqual(baseIssues.projectionInputs);
+    });
+
+    test('the authority firewall exposes zero production mutations and rejects policy smuggling', async () => {
+        const {report} = await runWithSnapshots([baseSnapshot(), baseSnapshot()]);
+
+        expect(report.authority).toEqual({
+            mode               : 'shadow',
+            notAuthority       : true,
+            permittedWrites    : {reportFiles: 1},
+            productionMutations: {
+                admittedEvents     : 0,
+                advancedCheckpoints: 0,
+                createdTasks       : 0,
+                deliveredWakes     : 0,
+                projectedCounts    : 0
+            }
+        });
+        expect(Object.values(report.policy.thresholds).every(value => value === null)).toBe(true);
+
+        const tampered = structuredClone(report);
+        tampered.policy.thresholds.wakeThreshold = 1;
+        expect(() => assertShadowFirewall(tampered)).toThrow('cannot introduce policy');
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/communityActivityShadowReader.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/communityActivityShadowReader.spec.mjs
@@ -1,0 +1,251 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {
+        name             : 'CommunityActivityShadowReaderTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+const WINDOW = {start: '2026-07-01T00:00:00.000Z', end: '2026-08-01T00:00:00.000Z'};
+
+const connection = (nodes, hasNextPage = false, endCursor = null) => ({
+    totalCount: nodes.length,
+    pageInfo  : {hasNextPage, endCursor},
+    nodes
+});
+
+const response = data => ({data: {...data, rateLimit: {cost: 1, remaining: 4999, resetAt: WINDOW.end}}});
+
+const operationName = queryString => queryString.match(/query\s+(\w+)/)?.[1];
+
+const advancingClock = () => {
+    let millis = Date.parse('2026-07-18T12:00:00.000Z');
+
+    return () => (millis += 5)
+};
+
+/**
+ * The source reader is the authority firewall's outer edge: source pagination receipts must survive,
+ * while prose and production-authority concepts must not cross it.
+ */
+test.describe('communityActivityShadowReader — exhaustive metadata-only source acquisition', () => {
+    let makeCommunityActivityShadowReader;
+
+    test.beforeAll(async () => {
+        ({makeCommunityActivityShadowReader} = await import(
+            '../../../../../../ai/services/github-workflow/communityActivityShadowReader.mjs'
+        ))
+    });
+
+    test('exhausts GraphQL pageInfo and REST empty terminals without leaking prose', async () => {
+        const graphqlCalls = [];
+        const restCalls    = [];
+        const issue        = {
+            id               : 'ISSUE_1', databaseId: 1, number: 15149, state: 'OPEN', stateReason: null,
+            createdAt        : '2026-07-02T00:00:00Z', updatedAt: '2026-08-02T00:00:00Z', closedAt: null,
+            lastEditedAt     : null, author: {__typename: 'User', login: 'external-author'},
+            authorAssociation: 'NONE', title: 'must never cross the seam'
+        };
+        const pullRequest = {
+            id               : 'PR_1', databaseId: 2, number: 15480, state: 'OPEN', isDraft: false,
+            createdAt        : '2026-07-03T00:00:00Z', updatedAt: '2026-07-13T00:00:00Z', closedAt: null,
+            mergedAt         : null, lastEditedAt: null, author: {__typename: 'User', login: 'neo-gpt'},
+            authorAssociation: 'MEMBER', title: 'must also stay out'
+        };
+        const discussion = {
+            id        : 'DISCUSSION_1', databaseId: 3, number: 15200, closed: false, closedAt: null, locked: false,
+            isAnswered: false, answerChosenAt: null, createdAt: '2026-07-04T00:00:00Z',
+            updatedAt : '2026-07-14T00:00:00Z', lastEditedAt: null,
+            author    : {__typename: 'User', login: 'neo-gpt-emmy'}, authorAssociation: 'MEMBER'
+        };
+        const discussionComments = [{
+            id       : 'DISCUSSION_COMMENT_1', databaseId: 31, createdAt: '2026-07-05T00:00:00Z',
+            updatedAt: '2026-07-15T00:00:00Z', lastEditedAt: '2026-07-15T00:00:00Z', deletedAt: null,
+            isAnswer : false, author: {__typename: 'User', login: 'external-author'}, authorAssociation: 'NONE',
+            body     : 'secret discussion prose'
+        }, {
+            id       : 'DISCUSSION_COMMENT_2', databaseId: 32, createdAt: '2026-07-06T00:00:00Z',
+            updatedAt: '2026-07-06T00:00:00Z', lastEditedAt: null, deletedAt: null,
+            isAnswer : false, author: {__typename: 'Bot', login: 'automation-bot'}, authorAssociation: 'NONE'
+        }];
+
+        const query = async (queryString, variables, options) => {
+            const operation = operationName(queryString);
+
+            graphqlCalls.push({queryString, variables, options, operation});
+
+            if (operation === 'ShadowIssueRoots') {
+                return response({repository: {issues: variables.cursor
+                    ? connection([], false, null)
+                    : connection([issue], true, 'ISSUE_ROOT_CURSOR')}})
+            }
+            if (operation === 'ShadowPullRequestRoots') {
+                return response({search: connection([pullRequest])})
+            }
+            if (operation === 'ShadowPullRequestReviewsPage') {
+                return response({repository: {pullRequest: {reviews: connection([{
+                    id         : 'PR_REVIEW_1', fullDatabaseId: '22', state: 'APPROVED',
+                    createdAt  : '2026-07-08T00:00:00Z', updatedAt: '2026-07-08T00:00:00Z',
+                    submittedAt: '2026-07-08T00:00:00Z', lastEditedAt: null,
+                    author     : {__typename: 'User', login: 'neo-gpt'}, authorAssociation: 'MEMBER'
+                }])}}})
+            }
+            if (operation === 'ShadowDiscussionRoots') {
+                return response({repository: {discussions: connection([discussion])}})
+            }
+            if (operation === 'ShadowDiscussionCommentsPage') {
+                const index = variables.cursor ? 1 : 0;
+
+                return response({repository: {discussion: {comments: connection(
+                    [discussionComments[index]], index === 0, index === 0 ? 'DISCUSSION_COMMENT_CURSOR' : null
+                )}}})
+            }
+            if (operation === 'ShadowDiscussionRepliesPage') {
+                const replies = variables.commentId === 'DISCUSSION_COMMENT_1' ? [{
+                    id       : 'DISCUSSION_REPLY_1', databaseId: 33, createdAt: '2026-07-16T00:00:00Z',
+                    updatedAt: '2026-07-16T00:00:00Z', lastEditedAt: null, deletedAt: null, isAnswer: false,
+                    author   : {__typename: 'User', login: 'neo-gpt-emmy'}, authorAssociation: 'MEMBER'
+                }] : [];
+
+                return response({node: {replies: connection(replies)}})
+            }
+
+            throw new Error(`Unexpected operation: ${operation}`)
+        };
+
+        const rest = async (method, path, body) => {
+            restCalls.push({method, path, body});
+            const page = Number(new URL(`https://api.github.test${path}`).searchParams.get('page'));
+
+            if (path.includes('/collaborators')) {
+                return page === 1 ? [{login: 'neo-gpt'}, {login: 'neo-gpt-emmy'}] : []
+            }
+
+            if (path.includes('/issues/comments')) {
+                return page === 1 ? [{
+                    id                : 10,
+                    node_id           : 'ISSUE_COMMENT_1',
+                    issue_url         : 'https://api.github.test/repos/neomjs/neo/issues/15149',
+                    html_url          : 'https://github.test/neomjs/neo/issues/15149#issuecomment-10',
+                    created_at        : '2026-07-08T00:00:00Z',
+                    updated_at        : '2026-07-11T00:00:00Z',
+                    author_association: 'NONE',
+                    user              : {login: 'external-author', type: 'User'},
+                    body              : 'secret issue prose'
+                }, {
+                    id                : 21,
+                    node_id           : 'PR_COMMENT_1',
+                    issue_url         : 'https://api.github.test/repos/neomjs/neo/issues/15480',
+                    html_url          : 'https://github.test/neomjs/neo/pull/15480#issuecomment-21',
+                    created_at        : '2026-07-07T00:00:00Z',
+                    updated_at        : '2026-07-07T00:00:00Z',
+                    author_association: 'CONTRIBUTOR',
+                    user              : {login: 'external-reviewer', type: 'User'},
+                    body              : 'secret PR issue-comment prose'
+                }] : []
+            }
+
+            return page === 1 ? [{
+                id                    : 23,
+                node_id               : 'PR_REVIEW_COMMENT_1',
+                pull_request_url      : 'https://api.github.test/repos/neomjs/neo/pulls/15480',
+                pull_request_review_id: 22,
+                in_reply_to_id        : null,
+                created_at            : '2026-07-09T00:00:00Z',
+                updated_at            : '2026-07-10T00:00:00Z',
+                author_association    : 'CONTRIBUTOR',
+                user                  : {login: 'external-reviewer', type: 'User'},
+                body                  : 'secret inline review prose'
+            }] : []
+        };
+
+        const reader   = makeCommunityActivityShadowReader({query, rest, now: advancingClock()});
+        const snapshot = await reader({
+            provider: 'github', owner: 'neomjs', repo: 'neo', window: WINDOW, pageSize: 2,
+            families: ['issues', 'pullRequests', 'discussions'], runIndex: 1
+        });
+
+        expect(snapshot.collaboratorCensus).toMatchObject({
+            status       : 'complete',
+            collaborators: ['neo-gpt', 'neo-gpt-emmy']
+        });
+        expect(snapshot.collaboratorCensus.pages.at(-1).terminalReceipt).toBe(true);
+        expect(restCalls.every(call => call.method === 'GET' && call.body === undefined)).toBe(true);
+        expect(restCalls.filter(call => call.path.includes('/collaborators'))).toHaveLength(2);
+        expect(restCalls.filter(call => call.path.includes('/issues/comments'))).toHaveLength(2);
+        expect(restCalls.filter(call => call.path.includes('/pulls/comments'))).toHaveLength(2);
+
+        expect(snapshot.families.issues.exhausted).toBe(true);
+        expect(snapshot.families.issues.pages.filter(page => page.connection === 'roots')).toHaveLength(2);
+        expect(snapshot.families.issues.pages[0]).toMatchObject({
+            cursor: null, endCursor: 'ISSUE_ROOT_CURSOR', sourceHasNextPage: true
+        });
+        expect(snapshot.families.pullRequests.pages.find(page => page.connection === 'repositoryReviewComments'
+            && page.terminalReceipt)).toBeTruthy();
+        expect(snapshot.families.discussions.pages.filter(page => page.connection === 'comments')).toHaveLength(2);
+        expect(snapshot.families.discussions.pages.filter(page => page.connection === 'replies')).toHaveLength(2);
+
+        const rows = Object.values(snapshot.families).flatMap(family => family.pages.flatMap(page => page.rows));
+
+        expect(rows.map(row => row.eventType)).toEqual(expect.arrayContaining([
+            'IssueCreated', 'IssueComment', 'PullRequestCreated',
+            'PullRequestIssueComment', 'PullRequestReview', 'PullRequestReviewComment',
+            'DiscussionCreated', 'DiscussionComment', 'DiscussionReply'
+        ]));
+        expect(rows.some(row => row.eventType === 'IssueSnapshotUpdate')).toBe(false);
+        expect(snapshot.families.issues.gaps).toContainEqual(expect.objectContaining({
+            code: 'issue_comment_deletion_tombstones_unavailable'
+        }));
+        expect(rows.find(row => row.eventType === 'PullRequestReviewComment')).toMatchObject({
+            actor          : {login: 'external-reviewer', type: 'User'},
+            id             : 'PR_REVIEW_COMMENT_1:created',
+            responseBearing: true,
+            mutationKind   : 'create'
+        });
+        expect(rows.find(row => row.eventType === 'PullRequestReviewCommentRevision')).toMatchObject({
+            actor          : {login: null, type: null},
+            id             : 'PR_REVIEW_COMMENT_1:updated:2026-07-10T00:00:00Z',
+            responseBearing: false,
+            mutationKind   : 'revision'
+        });
+        expect(snapshot.popularity).toEqual({
+            status: 'excluded', rows: [], gaps: [{code: 'popularity_telemetry_out_of_scope'}]
+        });
+
+        const serialized = JSON.stringify(snapshot);
+
+        expect(serialized).not.toContain('secret');
+        expect(serialized).not.toContain('must never');
+        expect(graphqlCalls.every(call => !/\bbody\b/.test(call.queryString))).toBe(true);
+        expect(graphqlCalls.every(call => call.options?.strict === false)).toBe(true);
+    });
+
+    test('fails collaborator trust closed and marks a source pagination contradiction incomplete', async () => {
+        const permissionError = Object.assign(new Error('forbidden'), {status: 403});
+        const rest            = async () => { throw permissionError };
+        const query           = async () => response({
+            repository: {issues: connection([], true, null)}
+        });
+        const reader   = makeCommunityActivityShadowReader({query, rest, now: advancingClock()});
+        const snapshot = await reader({
+            provider: 'github', owner: 'neomjs', repo: 'neo', window: WINDOW, pageSize: 100,
+            families: ['issues'], runIndex: 2
+        });
+
+        expect(snapshot.collaboratorCensus).toMatchObject({status: 'unavailable', collaborators: []});
+        expect(snapshot.collaboratorCensus.gaps[0]).toMatchObject({
+            code: 'collaborator_census_failed', status: 403
+        });
+        expect(snapshot.families.issues.exhausted).toBe(false);
+        expect(snapshot.families.issues.gaps).toContainEqual(expect.objectContaining({
+            code: 'graphql_missing_end_cursor', scope: 'ShadowIssueRoots'
+        }));
+    });
+});


### PR DESCRIPTION
Resolves #15149

Ships a read-only community-activity shadow probe that exhausts the supported issue, pull-request/review, and Discussion source families for an explicit window; separates source occurrences from attention-eligible external items; emits deterministic JSON and human summaries; and records honest lower-bound, cost, revision, storage, trust, and authority-firewall evidence without minting production policy.

Evidence: L3 (two live, non-destructive full GitHub acquisition passes plus deterministic focused tests) → L3 required (AC1–AC10 require a reproducible live shadow report with zero production mutation). No residuals.

## Measurement Receipt

- Window: `2026-06-18T00:00:00Z` → `2026-07-18T00:00:00Z`
- Report ID: `79a6d84d9212d00f0f9ca8db33d517c64f0f90bfd0d2ef68fee88103bcc770dd`
- Report SHA-256: `7ff1e6be32b2b9840290408332685f3c985e26533daaec63ba7431c2a917a887`
- Repeated candidate-manifest hash: `65de1150163ec730630abf4538012ab2ec1070b04441f81fb9b92137992ee38c`
- Source volume: 11,253 occurrences across 1,739 pages; 1,714 provider requests per pass; 3,809,537 projected bytes
- Attention density: 22 eligible external occurrences (0.195503%)
- Mutation evidence: 2,937 revisions, 0 observed tombstones (explicit lower bound), 0 duplicate occurrences
- Coverage: exhausted for the implemented queries, not degraded, globally incomplete/lower-bound because provider lifecycle histories and deletion tombstones are unavailable
- Authority: shadow-only; zero admission, Task, checkpoint, count, wake, or policy mutations; every operational threshold remains `null`

The two runs produced the same candidate manifest and zero numeric variance. Their source-receipt hashes differ only because page receipts intentionally include observed latency.

Related: #15145

## Deltas from ticket

None substantive. The implementation makes one precision explicit: the stable candidate manifest is hashed separately from latency-bearing provider receipts, so semantic repeatability is not confused with transport timing. Unsupported lifecycle history and tombstones stay explicit gaps rather than inferred facts. The raw one-megabyte report remains ignored under `.neo-ai-data/`; the dated, tracked measurement note carries the reviewable receipt.

## Slot rationale

`learn/agentos/measurements/community-activity-shadow-2026-07-18.md` is a dated reference artifact, not turn-loaded instruction substrate. It adds no rule slot or recurring context cost; later policy graduation should consume a newer dated run rather than silently treating this sample as timeless authority.

## Test Evidence

- `npm run agent-preflight -- --no-fix` — passed for all six changed `.mjs` files; only pre-existing stale-overlay advisories remained.
- `npm run test-unit -- test/playwright/unit/ai/scripts/maintenance/communityActivityShadowProbeCore.spec.mjs test/playwright/unit/ai/services/github-workflow/communityActivityShadowReader.spec.mjs` — 13/13 passed in 31.9s at the final rebased head.
- `node --check` on all four implementation modules — passed.
- `npm run ai:probe-community-activity-shadow -- --help` — passed.
- `npm run ai:probe-community-activity-shadow -- --owner neomjs --repo neo --window-start 2026-06-18T00:00:00Z --window-end 2026-07-18T00:00:00Z --page-size 100 --runs 2 --output .neo-ai-data/community-activity-shadow/report-2026-07-18-v2.json` — completed two full live passes; candidate hashes and every numeric measurement matched.
- Shadow CLI/core surface: focused unit coverage plus the live two-pass command above.
- GitHub workflow reader/query surface: focused fixture coverage plus the live provider acquisition above.

## Post-Merge Validation

- [ ] Re-run the same explicit command from fresh `dev` and confirm the package script reproduces the schema and authority-firewall counters.
- [ ] Before any operational threshold is proposed, run a newer explicit window and compare its candidate identity, provider cost, attention density, and documented gaps with this baseline.

Authored by Euclid (GPT-5.6, Codex Desktop). Session 837ad74b-c2d2-413d-9aab-b7165a93a82a.
