### PR TITLE
feat(memory-core): idempotent community batch admission into durable history (#15151)

### DIFF
--- a/ai/services/memory-core/CommunityBatchAdmissionService.mjs
+++ b/ai/services/memory-core/CommunityBatchAdmissionService.mjs
@@ -95,6 +95,10 @@ class CommunityBatchAdmissionService extends Base {
                 this.db.pragma('journal_mode = WAL');
             }
 
+            // A competing writer (e.g. a lifecycle revoke on the registry connection) waits for the
+            // IMMEDIATE admission transaction to finish rather than failing SQLITE_BUSY.
+            this.db.pragma('busy_timeout = 5000');
+
             this.ensureSchema();
             logger.info('[CommunityBatchAdmissionService] Connected to Memory Core community admission tables.');
         } catch (err) {
@@ -216,9 +220,20 @@ class CommunityBatchAdmissionService extends Base {
         let outcome;
 
         try {
+            // IMMEDIATE acquires the write lock at BEGIN, so the registration read below and every
+            // write commit or roll back as one serialized unit — a concurrent revoke on another
+            // connection either lands before this transaction (and is seen) or serializes behind it.
             outcome = this.db.transaction(() => {
-                // Step 1 — the epoch fence, inside the serialized boundary (not a pre-transaction read).
-                if (!SourceRegistryService.canAdmit(sourceInstanceId, registrationEpoch)) {
+                // Step 1 — the epoch fence, read through THIS connection inside the transaction. The
+                // registration table lives in the same database; delegating to the registry service
+                // would read through its separate connection, leaving the fence outside this
+                // serialized boundary and admitting a batch under a concurrently-committed revocation.
+                const registration = this.db.prepare(
+                    `SELECT lifecycle_state, registration_epoch FROM mc_source_registration
+                     WHERE tenant_id = ? AND source_instance_id = ?`
+                ).get(tenantId, sourceInstanceId);
+
+                if (!registration || registration.lifecycle_state !== 'ACTIVE' || registration.registration_epoch !== registrationEpoch) {
                     return {status: ADMISSION_STATUS.CONFLICT, reason: 'REGISTRATION_NOT_ADMISSIBLE'}
                 }
 
@@ -317,7 +332,7 @@ class CommunityBatchAdmissionService extends Base {
                 );
 
                 return {status: ADMISSION_STATUS.ACCEPTED, receiptId}
-            })()
+            }).immediate()
         } catch (err) {
             if (err instanceof ObservationConflict) {
                 return {status: ADMISSION_STATUS.CONFLICT, reason: err.reason, digest}

--- a/ai/services/memory-core/CommunityBatchAdmissionService.mjs
+++ b/ai/services/memory-core/CommunityBatchAdmissionService.mjs
@@ -19,6 +19,16 @@ export const ADMISSION_STATUS = {
 };
 
 /**
+ * @summary Checkpoint-advance outcomes. A conflict is a normal race result, not an error: the loser
+ * re-reads the returned server state and retries from it.
+ * @member {Object<String,String>}
+ */
+export const CHECKPOINT_STATUS = {
+    ADVANCED: 'advanced',
+    CONFLICT: 'conflict'
+};
+
+/**
  * @summary Atomically admits reproducible community-activity batches into durable history.
  *
  * Providers acquire and normalize; this service validates and admits. Three properties carry the
@@ -143,6 +153,17 @@ class CommunityBatchAdmissionService extends Base {
                 ON mc_community_occurrence(tenant_id, receipt_id);
             CREATE INDEX IF NOT EXISTS idx_mc_community_occurrence_revision
                 ON mc_community_occurrence(tenant_id, revision_of);
+
+            CREATE TABLE IF NOT EXISTS mc_community_checkpoint (
+                tenant_id          TEXT    NOT NULL,
+                source_instance_id TEXT    NOT NULL,
+                partition          TEXT    NOT NULL,
+                basis              TEXT    NOT NULL,
+                last_receipt_id    TEXT    NOT NULL,
+                admitted_sequence  INTEGER NOT NULL,
+                updated_at         INTEGER NOT NULL,
+                PRIMARY KEY (tenant_id, source_instance_id, partition)
+            );
         `);
     }
 
@@ -255,6 +276,99 @@ class CommunityBatchAdmissionService extends Base {
         ).get(tenantId, sourceInstanceId, batchId);
 
         return row ? this.#toCamel(row) : null;
+    }
+
+    /**
+     * @summary Advances a partition checkpoint as a compare-and-swap against the basis the caller read.
+     *
+     * Two preconditions, both refusals rather than best-effort writes:
+     *
+     * 1. **Durable acceptance.** The cited receipt must already be committed for this tenant, source
+     *    and partition — a cursor may only move to a basis some accepted batch actually established.
+     *    Advancing before durable receipt is exactly how events get skipped.
+     * 2. **Expected basis.** The UPDATE predicate carries the basis the caller observed, so a writer
+     *    whose view was superseded matches zero rows. A losing writer gets the CURRENT server state
+     *    back and never advances destructively — a regressed or forked cursor is worse than a retry.
+     * @param {String} sourceInstanceId
+     * @param {String} partition
+     * @param {Object} advance
+     * @param {String|null} [advance.expectedBasis=null] The observed basis; `null` claims an unset checkpoint.
+     * @param {String} advance.toBasis
+     * @param {String} advance.receiptId The durably-accepted receipt establishing `toBasis`.
+     * @returns {Object} `{status, reason?, checkpoint}`
+     * @throws {Error} `BATCH_ADMISSION_NO_TENANT` | `CHECKPOINT_ADVANCE_ARGUMENTS_REQUIRED`
+     */
+    advanceCheckpoint(sourceInstanceId, partition, {expectedBasis = null, toBasis, receiptId} = {}) {
+        const tenantId = SourceRegistryService.resolveTenantId();
+
+        if (!tenantId) {
+            throw new Error('BATCH_ADMISSION_NO_TENANT');
+        }
+
+        if (!toBasis || !receiptId) {
+            throw new Error('CHECKPOINT_ADVANCE_ARGUMENTS_REQUIRED');
+        }
+
+        const receipt = this.db.prepare(
+            `SELECT admitted_sequence FROM mc_community_batch_receipt
+             WHERE tenant_id = ? AND source_instance_id = ? AND receipt_id = ? AND partition = ?`
+        ).get(tenantId, sourceInstanceId, receiptId, partition);
+
+        if (!receipt) {
+            return {
+                status    : CHECKPOINT_STATUS.CONFLICT,
+                reason    : 'RECEIPT_NOT_DURABLE',
+                checkpoint: this.getCheckpoint(sourceInstanceId, partition)
+            }
+        }
+
+        const
+            now    = Date.now(),
+            result = expectedBasis === null
+                // Claiming an unset checkpoint: OR IGNORE makes the race decidable — a second
+                // claimant changes zero rows instead of clobbering the first.
+                ? this.db.prepare(
+                      `INSERT OR IGNORE INTO mc_community_checkpoint
+                          (tenant_id, source_instance_id, partition, basis, last_receipt_id, admitted_sequence, updated_at)
+                       VALUES (?, ?, ?, ?, ?, ?, ?)`
+                  ).run(tenantId, sourceInstanceId, partition, toBasis, receiptId, receipt.admitted_sequence, now)
+                : this.db.prepare(
+                      `UPDATE mc_community_checkpoint
+                          SET basis = ?, last_receipt_id = ?, admitted_sequence = ?, updated_at = ?
+                        WHERE tenant_id = ? AND source_instance_id = ? AND partition = ? AND basis = ?`
+                  ).run(toBasis, receiptId, receipt.admitted_sequence, now, tenantId, sourceInstanceId, partition, expectedBasis);
+
+        return result.changes === 1
+            ? {status: CHECKPOINT_STATUS.ADVANCED, checkpoint: this.getCheckpoint(sourceInstanceId, partition)}
+            : {status: CHECKPOINT_STATUS.CONFLICT, reason: 'BASIS_MISMATCH', checkpoint: this.getCheckpoint(sourceInstanceId, partition)}
+    }
+
+    /**
+     * Reads one partition checkpoint, tenant-scoped. `null` means unset — distinct from a checkpoint
+     * whose basis happens to be empty.
+     * @param {String} sourceInstanceId
+     * @param {String} partition
+     * @returns {Object|null}
+     */
+    getCheckpoint(sourceInstanceId, partition) {
+        const tenantId = SourceRegistryService.resolveTenantId();
+
+        if (!tenantId) return null;
+
+        const row = this.db.prepare(
+            `SELECT * FROM mc_community_checkpoint
+             WHERE tenant_id = ? AND source_instance_id = ? AND partition = ?`
+        ).get(tenantId, sourceInstanceId, partition);
+
+        return row ? {
+            tenantId        : row.tenant_id,
+            sourceInstanceId: row.source_instance_id,
+            partition       : row.partition,
+            basis           : row.basis,
+            lastReceiptId   : row.last_receipt_id,
+            admittedSequence: row.admitted_sequence,
+            updatedAt       : row.updated_at
+        } : null
     }
 
     /**

--- a/ai/services/memory-core/CommunityBatchAdmissionService.mjs
+++ b/ai/services/memory-core/CommunityBatchAdmissionService.mjs
@@ -6,6 +6,7 @@ import config                                from '../../mcp/server/memory-core/
 import logger                                from '../../mcp/server/memory-core/logger.mjs';
 import SourceRegistryService                 from './SourceRegistryService.mjs';
 import {canonicalBatchDigest, validateBatch} from './communityBatchContract.mjs';
+import {classifyAttention}                   from './communityAttentionClassifier.mjs';
 
 /**
  * @summary Admission outcomes. These are RESULTS, not exceptions, because all three are ordinary
@@ -68,7 +69,17 @@ class CommunityBatchAdmissionService extends Base {
          * @summary SQLite connection to the Memory Core database (dedicated tables, not the graph).
          * @protected
          */
-        db: null
+        db: null,
+        /**
+         * @member {Object|null} attentionPolicy=null
+         * @summary The injected attention-classification policy — response-bearing kinds, rostered
+         * actors, known bots, and any recorded bot dispositions.
+         *
+         * Required, never defaulted: an accepted row must carry an evidence-backed disposition, so
+         * admitting without a policy would either fabricate one or write dispositionless history.
+         * Both are worse than refusing, hence the loud failure in {@link #admitBatch}.
+         */
+        attentionPolicy: null
     }
 
     /**
@@ -141,12 +152,17 @@ class CommunityBatchAdmissionService extends Base {
                 provider_entity_id TEXT    NOT NULL,
                 occurrence_kind    TEXT    NOT NULL,
                 occurred_at        TEXT    NOT NULL,
-                revision_of        TEXT,
-                absence            TEXT,
-                receipt_id         TEXT    NOT NULL,
-                admitted_sequence  INTEGER NOT NULL,
-                admitted_at        INTEGER NOT NULL
+                revision_of          TEXT,
+                absence              TEXT,
+                actor_id             TEXT,
+                attention_disposition TEXT NOT NULL,
+                attention_reason      TEXT NOT NULL,
+                receipt_id           TEXT    NOT NULL,
+                admitted_sequence    INTEGER NOT NULL,
+                admitted_at          INTEGER NOT NULL
             );
+            CREATE INDEX IF NOT EXISTS idx_mc_community_occurrence_attention
+                ON mc_community_occurrence(tenant_id, attention_disposition);
             CREATE INDEX IF NOT EXISTS idx_mc_community_occurrence_entity
                 ON mc_community_occurrence(tenant_id, source_instance_id, provider_entity_id);
             CREATE INDEX IF NOT EXISTS idx_mc_community_occurrence_receipt
@@ -182,6 +198,11 @@ class CommunityBatchAdmissionService extends Base {
 
         if (!tenantId) {
             throw new Error('BATCH_ADMISSION_NO_TENANT');
+        }
+
+        // Fail loud rather than admit history without an evidence-backed disposition.
+        if (!this.attentionPolicy) {
+            throw new Error('ATTENTION_POLICY_NOT_CONFIGURED');
         }
 
         const {valid, errors} = validateBatch(batch);
@@ -233,18 +254,25 @@ class CommunityBatchAdmissionService extends Base {
             const insertOccurrence = this.db.prepare(
                 `INSERT INTO mc_community_occurrence (
                     occurrence_id, tenant_id, source_instance_id, provider_entity_id, occurrence_kind,
-                    occurred_at, revision_of, absence, receipt_id, admitted_sequence, admitted_at
-                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+                    occurred_at, revision_of, absence, actor_id, attention_disposition,
+                    attention_reason, receipt_id, admitted_sequence, admitted_at
+                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
             );
 
             occurrences.forEach(occurrence => {
                 // occurrence_id is OURS — deliberately distinct from the provider entity id, the
                 // delivering batch/receipt, and the admitted sequence, so no consumer can conflate
                 // "which thing happened", "how it reached us", and "in what order we accepted it".
+                // Classification happens INSIDE the admission transaction, so an accepted row can
+                // never exist without its evidence-backed disposition. Its output is server policy
+                // and stays out of the digest, so revising policy cannot look like corruption.
+                const {disposition, reason} = classifyAttention(occurrence, this.attentionPolicy);
+
                 insertOccurrence.run(
                     crypto.randomUUID(), tenantId, sourceInstanceId, occurrence.providerEntityId,
                     occurrence.occurrenceKind, occurrence.occurredAt, occurrence.revisionOf || null,
-                    occurrence.absence || null, receiptId, nextSequence, now
+                    occurrence.absence || null, occurrence.actorId || null, disposition, reason,
+                    receiptId, nextSequence, now
                 )
             });
 
@@ -399,17 +427,20 @@ class CommunityBatchAdmissionService extends Base {
               ).all(tenantId, sourceInstanceId);
 
         return rows.map(row => ({
-            occurrenceId    : row.occurrence_id,
-            tenantId        : row.tenant_id,
-            sourceInstanceId: row.source_instance_id,
-            providerEntityId: row.provider_entity_id,
-            occurrenceKind  : row.occurrence_kind,
-            occurredAt      : row.occurred_at,
-            revisionOf      : row.revision_of,
-            absence         : row.absence,
-            receiptId       : row.receipt_id,
-            admittedSequence: row.admitted_sequence,
-            admittedAt      : row.admitted_at
+            occurrenceId        : row.occurrence_id,
+            tenantId            : row.tenant_id,
+            sourceInstanceId    : row.source_instance_id,
+            providerEntityId    : row.provider_entity_id,
+            occurrenceKind      : row.occurrence_kind,
+            occurredAt          : row.occurred_at,
+            revisionOf          : row.revision_of,
+            absence             : row.absence,
+            actorId             : row.actor_id,
+            attentionDisposition: row.attention_disposition,
+            attentionReason     : row.attention_reason,
+            receiptId           : row.receipt_id,
+            admittedSequence    : row.admitted_sequence,
+            admittedAt          : row.admitted_at
         }))
     }
 

--- a/ai/services/memory-core/CommunityBatchAdmissionService.mjs
+++ b/ai/services/memory-core/CommunityBatchAdmissionService.mjs
@@ -123,6 +123,26 @@ class CommunityBatchAdmissionService extends Base {
                 ON mc_community_batch_receipt(tenant_id, source_instance_id, batch_id);
             CREATE INDEX IF NOT EXISTS idx_mc_community_batch_receipt_sequence
                 ON mc_community_batch_receipt(tenant_id, admitted_sequence);
+
+            CREATE TABLE IF NOT EXISTS mc_community_occurrence (
+                occurrence_id      TEXT    PRIMARY KEY,
+                tenant_id          TEXT    NOT NULL,
+                source_instance_id TEXT    NOT NULL,
+                provider_entity_id TEXT    NOT NULL,
+                occurrence_kind    TEXT    NOT NULL,
+                occurred_at        TEXT    NOT NULL,
+                revision_of        TEXT,
+                absence            TEXT,
+                receipt_id         TEXT    NOT NULL,
+                admitted_sequence  INTEGER NOT NULL,
+                admitted_at        INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_mc_community_occurrence_entity
+                ON mc_community_occurrence(tenant_id, source_instance_id, provider_entity_id);
+            CREATE INDEX IF NOT EXISTS idx_mc_community_occurrence_receipt
+                ON mc_community_occurrence(tenant_id, receipt_id);
+            CREATE INDEX IF NOT EXISTS idx_mc_community_occurrence_revision
+                ON mc_community_occurrence(tenant_id, revision_of);
         `);
     }
 
@@ -187,6 +207,26 @@ class CommunityBatchAdmissionService extends Base {
             ).run(receiptId, tenantId, sourceInstanceId, batchId, digest, partition,
                   registrationEpoch, occurrences.length, nextSequence, now);
 
+            // The ledger commits with its receipt: a crash can never leave occurrences without the
+            // receipt that authorizes them, nor a receipt whose occurrence_count is a lie.
+            const insertOccurrence = this.db.prepare(
+                `INSERT INTO mc_community_occurrence (
+                    occurrence_id, tenant_id, source_instance_id, provider_entity_id, occurrence_kind,
+                    occurred_at, revision_of, absence, receipt_id, admitted_sequence, admitted_at
+                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+            );
+
+            occurrences.forEach(occurrence => {
+                // occurrence_id is OURS — deliberately distinct from the provider entity id, the
+                // delivering batch/receipt, and the admitted sequence, so no consumer can conflate
+                // "which thing happened", "how it reached us", and "in what order we accepted it".
+                insertOccurrence.run(
+                    crypto.randomUUID(), tenantId, sourceInstanceId, occurrence.providerEntityId,
+                    occurrence.occurrenceKind, occurrence.occurredAt, occurrence.revisionOf || null,
+                    occurrence.absence || null, receiptId, nextSequence, now
+                )
+            });
+
             return receiptId
         });
 
@@ -215,6 +255,48 @@ class CommunityBatchAdmissionService extends Base {
         ).get(tenantId, sourceInstanceId, batchId);
 
         return row ? this.#toCamel(row) : null;
+    }
+
+    /**
+     * @summary Lists admitted occurrences, tenant-scoped, newest sequence last.
+     *
+     * The ledger is INSERT-only: a revision is a new occurrence carrying `revisionOf`, never an
+     * update of the row it revises, so history stays reconstructible rather than overwritten.
+     * @param {String} sourceInstanceId
+     * @param {Object} [filter]
+     * @param {String} [filter.providerEntityId] Narrow to one provider entity's history.
+     * @returns {Object[]}
+     */
+    listOccurrences(sourceInstanceId, {providerEntityId} = {}) {
+        const tenantId = SourceRegistryService.resolveTenantId();
+
+        if (!tenantId) return [];
+
+        const rows = providerEntityId
+            ? this.db.prepare(
+                  `SELECT * FROM mc_community_occurrence
+                   WHERE tenant_id = ? AND source_instance_id = ? AND provider_entity_id = ?
+                   ORDER BY admitted_sequence, occurred_at`
+              ).all(tenantId, sourceInstanceId, providerEntityId)
+            : this.db.prepare(
+                  `SELECT * FROM mc_community_occurrence
+                   WHERE tenant_id = ? AND source_instance_id = ?
+                   ORDER BY admitted_sequence, occurred_at`
+              ).all(tenantId, sourceInstanceId);
+
+        return rows.map(row => ({
+            occurrenceId    : row.occurrence_id,
+            tenantId        : row.tenant_id,
+            sourceInstanceId: row.source_instance_id,
+            providerEntityId: row.provider_entity_id,
+            occurrenceKind  : row.occurrence_kind,
+            occurredAt      : row.occurred_at,
+            revisionOf      : row.revision_of,
+            absence         : row.absence,
+            receiptId       : row.receipt_id,
+            admittedSequence: row.admitted_sequence,
+            admittedAt      : row.admitted_at
+        }))
     }
 
     /**

--- a/ai/services/memory-core/CommunityBatchAdmissionService.mjs
+++ b/ai/services/memory-core/CommunityBatchAdmissionService.mjs
@@ -1,0 +1,242 @@
+import fs                                    from 'fs-extra';
+import path                                  from 'path';
+import crypto                                from 'crypto';
+import Base                                  from '../../../src/core/Base.mjs';
+import config                                from '../../mcp/server/memory-core/config.mjs';
+import logger                                from '../../mcp/server/memory-core/logger.mjs';
+import SourceRegistryService                 from './SourceRegistryService.mjs';
+import {canonicalBatchDigest, validateBatch} from './communityBatchContract.mjs';
+
+/**
+ * @summary Admission outcomes. These are RESULTS, not exceptions, because all three are ordinary
+ * protocol states a connector must be able to act on: retry safely, stop, or investigate.
+ * @member {Object<String,String>}
+ */
+export const ADMISSION_STATUS = {
+    ACCEPTED  : 'accepted',
+    IDEMPOTENT: 'idempotent',
+    CONFLICT  : 'conflict'
+};
+
+/**
+ * @summary Atomically admits reproducible community-activity batches into durable history.
+ *
+ * Providers acquire and normalize; this service validates and admits. Three properties carry the
+ * weight:
+ *
+ * 1. **Admission is epoch-fenced.** A batch is admitted only while its source registration is
+ *    `ACTIVE` at the exact epoch the batch declares, so a revoked or reprovisioned source cannot
+ *    keep writing under stale authority.
+ * 2. **Idempotency is digest-keyed.** The same scoped `batchId` with the same digest is a retry and
+ *    changes nothing; the same `batchId` with a DIFFERENT digest is an integrity conflict, never a
+ *    silent overwrite — that distinction is the whole reason the digest exists.
+ * 3. **Admission is one transaction.** Validation, the fence check, the receipt, and the admitted
+ *    sequence commit together or not at all, so a crash cannot leave a receipt without its sequence
+ *    or a sequence without its receipt.
+ *
+ * Tenant scope is server-derived and re-applied in every statement; this table is not covered by
+ * GraphService RLS.
+ *
+ * @class Neo.ai.services.memory-core.CommunityBatchAdmissionService
+ * @extends Neo.core.Base
+ * @singleton
+ */
+class CommunityBatchAdmissionService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.memory-core.CommunityBatchAdmissionService'
+         * @protected
+         */
+        className: 'Neo.ai.services.memory-core.CommunityBatchAdmissionService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true,
+        /**
+         * @member {Object|null} db=null
+         * @summary SQLite connection to the Memory Core database (dedicated tables, not the graph).
+         * @protected
+         */
+        db: null
+    }
+
+    /**
+     * Opens the SQLite connection and ensures the admission schema.
+     * @returns {Promise<void>}
+     */
+    async initAsync() {
+        await super.initAsync();
+
+        if (this.db) return;
+
+        try {
+            const dbPath = config.storagePaths.graph;
+
+            if (!dbPath) {
+                logger.warn('[CommunityBatchAdmissionService] storagePaths.graph not configured. Admission disabled.');
+                return;
+            }
+
+            if (dbPath !== ':memory:') {
+                await fs.ensureDir(path.dirname(dbPath));
+            }
+
+            const Database = (await import('better-sqlite3')).default;
+
+            this.db = new Database(dbPath, {verbose: null});
+
+            if (dbPath !== ':memory:') {
+                this.db.pragma('journal_mode = WAL');
+            }
+
+            this.ensureSchema();
+            logger.info('[CommunityBatchAdmissionService] Connected to Memory Core mc_community_batch_receipt.');
+        } catch (err) {
+            logger.warn('[CommunityBatchAdmissionService] Failed to initialize SQLite connection:', err.message);
+        }
+    }
+
+    /**
+     * Creates the receipt table if absent. The UNIQUE index on `(tenant_id, source_instance_id,
+     * batch_id)` is the idempotency key itself — batch identity is scoped, so two tenants may use the
+     * same provider-side batch id without colliding.
+     * @returns {void}
+     */
+    ensureSchema() {
+        if (!this.db) return;
+
+        this.db.exec(`
+            CREATE TABLE IF NOT EXISTS mc_community_batch_receipt (
+                receipt_id         TEXT    PRIMARY KEY,
+                tenant_id          TEXT    NOT NULL,
+                source_instance_id TEXT    NOT NULL,
+                batch_id           TEXT    NOT NULL,
+                digest             TEXT    NOT NULL,
+                partition          TEXT    NOT NULL,
+                registration_epoch INTEGER NOT NULL,
+                occurrence_count   INTEGER NOT NULL,
+                admitted_sequence  INTEGER NOT NULL,
+                admitted_at        INTEGER NOT NULL
+            );
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_mc_community_batch_receipt_identity
+                ON mc_community_batch_receipt(tenant_id, source_instance_id, batch_id);
+            CREATE INDEX IF NOT EXISTS idx_mc_community_batch_receipt_sequence
+                ON mc_community_batch_receipt(tenant_id, admitted_sequence);
+        `);
+    }
+
+    /**
+     * @summary Validates, fences, and atomically admits one batch.
+     *
+     * Never throws for an ordinary protocol outcome — a conflict is a returned status, because a
+     * connector must be able to distinguish "your retry was fine" from "your payload disagrees with
+     * what we already durably accepted" without exception-shaped control flow.
+     * @param {Object} batch A `community-activity-batch.v1` payload.
+     * @returns {Object} `{status, digest, receipt?, errors?}`
+     * @throws {Error} `BATCH_ADMISSION_NO_TENANT` when no server tenant resolves (fail closed).
+     */
+    admitBatch(batch) {
+        const tenantId = SourceRegistryService.resolveTenantId();
+
+        if (!tenantId) {
+            throw new Error('BATCH_ADMISSION_NO_TENANT');
+        }
+
+        const {valid, errors} = validateBatch(batch);
+
+        if (!valid) {
+            return {status: ADMISSION_STATUS.CONFLICT, reason: 'SCHEMA_INVALID', errors};
+        }
+
+        const {batchId, sourceInstanceId, registrationEpoch, partition, occurrences} = batch,
+              digest                                                                 = canonicalBatchDigest(batch);
+
+        // The epoch fence: only an ACTIVE registration at this exact epoch may write. A revoked or
+        // reprovisioned source fails closed here rather than at the storage layer.
+        if (!SourceRegistryService.canAdmit(sourceInstanceId, registrationEpoch)) {
+            return {status: ADMISSION_STATUS.CONFLICT, reason: 'REGISTRATION_NOT_ADMISSIBLE', digest};
+        }
+
+        const existing = this.db.prepare(
+            `SELECT * FROM mc_community_batch_receipt
+             WHERE tenant_id = ? AND source_instance_id = ? AND batch_id = ?`
+        ).get(tenantId, sourceInstanceId, batchId);
+
+        if (existing) {
+            // Same scoped id: a retry only if the payload is byte-identical by digest.
+            return existing.digest === digest
+                ? {status: ADMISSION_STATUS.IDEMPOTENT, digest, receipt: this.#toCamel(existing)}
+                : {status: ADMISSION_STATUS.CONFLICT, reason: 'DIGEST_MISMATCH', digest, receipt: this.#toCamel(existing)};
+        }
+
+        const admit = this.db.transaction(() => {
+            // Sequence is assigned INSIDE the transaction, so it can never be handed out without a
+            // committed receipt (and never skipped by a rolled-back one).
+            const nextSequence = (this.db.prepare(
+                      `SELECT MAX(admitted_sequence) AS max FROM mc_community_batch_receipt WHERE tenant_id = ?`
+                  ).get(tenantId).max || 0) + 1,
+                  receiptId = crypto.randomUUID(),
+                  now       = Date.now();
+
+            this.db.prepare(
+                `INSERT INTO mc_community_batch_receipt (
+                    receipt_id, tenant_id, source_instance_id, batch_id, digest, partition,
+                    registration_epoch, occurrence_count, admitted_sequence, admitted_at
+                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+            ).run(receiptId, tenantId, sourceInstanceId, batchId, digest, partition,
+                  registrationEpoch, occurrences.length, nextSequence, now);
+
+            return receiptId
+        });
+
+        return {
+            status : ADMISSION_STATUS.ACCEPTED,
+            digest,
+            receipt: this.getReceipt(sourceInstanceId, batchId, admit())
+        }
+    }
+
+    /**
+     * Loads one receipt, always scoped by the server tenant so a caller cannot read across tenants.
+     * @param {String} sourceInstanceId
+     * @param {String} batchId
+     * @param {String} [receiptId] Unused selector kept for call-site clarity at the admit boundary.
+     * @returns {Object|null}
+     */
+    getReceipt(sourceInstanceId, batchId, receiptId) {
+        const tenantId = SourceRegistryService.resolveTenantId();
+
+        if (!tenantId) return null;
+
+        const row = this.db.prepare(
+            `SELECT * FROM mc_community_batch_receipt
+             WHERE tenant_id = ? AND source_instance_id = ? AND batch_id = ?`
+        ).get(tenantId, sourceInstanceId, batchId);
+
+        return row ? this.#toCamel(row) : null;
+    }
+
+    /**
+     * Maps a snake_case receipt row to the camelCase contract shape.
+     * @param {Object} row
+     * @returns {Object}
+     * @private
+     */
+    #toCamel(row) {
+        return {
+            receiptId        : row.receipt_id,
+            tenantId         : row.tenant_id,
+            sourceInstanceId : row.source_instance_id,
+            batchId          : row.batch_id,
+            digest           : row.digest,
+            partition        : row.partition,
+            registrationEpoch: row.registration_epoch,
+            occurrenceCount  : row.occurrence_count,
+            admittedSequence : row.admitted_sequence,
+            admittedAt       : row.admitted_at
+        }
+    }
+}
+
+export default Neo.setupClass(CommunityBatchAdmissionService);

--- a/ai/services/memory-core/CommunityBatchAdmissionService.mjs
+++ b/ai/services/memory-core/CommunityBatchAdmissionService.mjs
@@ -1,16 +1,16 @@
-import fs                                    from 'fs-extra';
-import path                                  from 'path';
-import crypto                                from 'crypto';
-import Base                                  from '../../../src/core/Base.mjs';
-import config                                from '../../mcp/server/memory-core/config.mjs';
-import logger                                from '../../mcp/server/memory-core/logger.mjs';
-import SourceRegistryService                 from './SourceRegistryService.mjs';
-import {canonicalBatchDigest, validateBatch} from './communityBatchContract.mjs';
-import {classifyAttention}                   from './communityAttentionClassifier.mjs';
+import fs                                                                           from 'fs-extra';
+import path                                                                         from 'path';
+import crypto                                                                       from 'crypto';
+import Base                                                                         from '../../../src/core/Base.mjs';
+import config                                                                       from '../../mcp/server/memory-core/config.mjs';
+import logger                                                                       from '../../mcp/server/memory-core/logger.mjs';
+import SourceRegistryService                                                        from './SourceRegistryService.mjs';
+import {classifyAttention}                                                          from './communityAttentionClassifier.mjs';
+import {canonicalBatchDigest, validateBatch, occurrenceIdentity, observationDigest} from './communityBatchContract.mjs';
 
 /**
- * @summary Admission outcomes. These are RESULTS, not exceptions, because all three are ordinary
- * protocol states a connector must be able to act on: retry safely, stop, or investigate.
+ * @summary Admission outcomes. These are RESULTS, not exceptions, because all are ordinary protocol
+ * states a connector must act on: retry safely, reconcile from current basis, or investigate.
  * @member {Object<String,String>}
  */
 export const ADMISSION_STATUS = {
@@ -20,33 +20,21 @@ export const ADMISSION_STATUS = {
 };
 
 /**
- * @summary Checkpoint-advance outcomes. A conflict is a normal race result, not an error: the loser
- * re-reads the returned server state and retries from it.
- * @member {Object<String,String>}
+ * Thrown inside the admission transaction to abort + roll back on an observation-level integrity
+ * conflict; caught at the boundary and turned into a CONFLICT result. Not a public error.
  */
-export const CHECKPOINT_STATUS = {
-    ADVANCED: 'advanced',
-    CONFLICT: 'conflict'
-};
+class ObservationConflict extends Error {
+    constructor(reason) { super(reason); this.reason = reason }
+}
 
 /**
  * @summary Atomically admits reproducible community-activity batches into durable history.
  *
- * Providers acquire and normalize; this service validates and admits. Three properties carry the
- * weight:
- *
- * 1. **Admission is epoch-fenced.** A batch is admitted only while its source registration is
- *    `ACTIVE` at the exact epoch the batch declares, so a revoked or reprovisioned source cannot
- *    keep writing under stale authority.
- * 2. **Idempotency is digest-keyed.** The same scoped `batchId` with the same digest is a retry and
- *    changes nothing; the same `batchId` with a DIFFERENT digest is an integrity conflict, never a
- *    silent overwrite — that distinction is the whole reason the digest exists.
- * 3. **Admission is one transaction.** Validation, the fence check, the receipt, and the admitted
- *    sequence commit together or not at all, so a crash cannot leave a receipt without its sequence
- *    or a sequence without its receipt.
- *
- * Tenant scope is server-derived and re-applied in every statement; this table is not covered by
- * GraphService RLS.
+ * Providers acquire and normalize; this service validates and admits. The entire admission — epoch
+ * fence, partition-scoped receipt check, base-checkpoint verification, observation dedup, receipt,
+ * and the partition advance — runs as ONE serialized transaction, so a crash can never leave a
+ * receipt without its observations, an advanced cursor without its receipt, or an admitted sequence
+ * without the row it numbers. Tenant scope is server-derived and re-applied in every statement.
  *
  * @class Neo.ai.services.memory-core.CommunityBatchAdmissionService
  * @extends Neo.core.Base
@@ -72,12 +60,8 @@ class CommunityBatchAdmissionService extends Base {
         db: null,
         /**
          * @member {Object|null} attentionPolicy=null
-         * @summary The injected attention-classification policy — response-bearing kinds, rostered
-         * actors, known bots, and any recorded bot dispositions.
-         *
-         * Required, never defaulted: an accepted row must carry an evidence-backed disposition, so
-         * admitting without a policy would either fabricate one or write dispositionless history.
-         * Both are worse than refusing, hence the loud failure in {@link #admitBatch}.
+         * @summary The injected attention-classification policy. Required, never defaulted: an accepted
+         * row must carry an evidence-backed disposition, so admitting without a policy fails loud.
          */
         attentionPolicy: null
     }
@@ -112,16 +96,15 @@ class CommunityBatchAdmissionService extends Base {
             }
 
             this.ensureSchema();
-            logger.info('[CommunityBatchAdmissionService] Connected to Memory Core mc_community_batch_receipt.');
+            logger.info('[CommunityBatchAdmissionService] Connected to Memory Core community admission tables.');
         } catch (err) {
             logger.warn('[CommunityBatchAdmissionService] Failed to initialize SQLite connection:', err.message);
         }
     }
 
     /**
-     * Creates the receipt table if absent. The UNIQUE index on `(tenant_id, source_instance_id,
-     * batch_id)` is the idempotency key itself — batch identity is scoped, so two tenants may use the
-     * same provider-side batch id without colliding.
+     * Creates the admission tables if absent. Receipt identity is scoped by `resourceFamily` (the CAS
+     * partition), so a `batchId` reused across families never collides.
      * @returns {void}
      */
     ensureSchema() {
@@ -129,69 +112,82 @@ class CommunityBatchAdmissionService extends Base {
 
         this.db.exec(`
             CREATE TABLE IF NOT EXISTS mc_community_batch_receipt (
-                receipt_id         TEXT    PRIMARY KEY,
-                tenant_id          TEXT    NOT NULL,
-                source_instance_id TEXT    NOT NULL,
-                batch_id           TEXT    NOT NULL,
-                digest             TEXT    NOT NULL,
-                partition          TEXT    NOT NULL,
-                registration_epoch INTEGER NOT NULL,
-                occurrence_count   INTEGER NOT NULL,
-                admitted_sequence  INTEGER NOT NULL,
-                admitted_at        INTEGER NOT NULL
+                receipt_id            TEXT    PRIMARY KEY,
+                tenant_id             TEXT    NOT NULL,
+                source_instance_id    TEXT    NOT NULL,
+                resource_family       TEXT    NOT NULL,
+                batch_id              TEXT    NOT NULL,
+                digest                TEXT    NOT NULL,
+                registration_epoch    INTEGER NOT NULL,
+                base_checkpoint_version INTEGER NOT NULL,
+                next_checkpoint_version INTEGER NOT NULL,
+                base_inventory_hash   TEXT,
+                next_inventory_hash   TEXT,
+                coverage              TEXT,
+                observation_count     INTEGER NOT NULL,
+                admitted_sequence     INTEGER NOT NULL,
+                admitted_at           INTEGER NOT NULL
             );
-            CREATE UNIQUE INDEX IF NOT EXISTS idx_mc_community_batch_receipt_identity
-                ON mc_community_batch_receipt(tenant_id, source_instance_id, batch_id);
-            CREATE INDEX IF NOT EXISTS idx_mc_community_batch_receipt_sequence
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_mc_batch_receipt_identity
+                ON mc_community_batch_receipt(tenant_id, source_instance_id, resource_family, batch_id);
+            CREATE INDEX IF NOT EXISTS idx_mc_batch_receipt_sequence
                 ON mc_community_batch_receipt(tenant_id, admitted_sequence);
 
-            CREATE TABLE IF NOT EXISTS mc_community_occurrence (
-                occurrence_id      TEXT    PRIMARY KEY,
-                tenant_id          TEXT    NOT NULL,
-                source_instance_id TEXT    NOT NULL,
-                provider_entity_id TEXT    NOT NULL,
-                occurrence_kind    TEXT    NOT NULL,
-                occurred_at        TEXT    NOT NULL,
-                revision_of          TEXT,
-                absence              TEXT,
-                actor_id             TEXT,
-                attention_disposition TEXT NOT NULL,
-                attention_reason      TEXT NOT NULL,
-                receipt_id           TEXT    NOT NULL,
-                admitted_sequence    INTEGER NOT NULL,
-                admitted_at          INTEGER NOT NULL
+            CREATE TABLE IF NOT EXISTS mc_community_observation (
+                observation_row_id    TEXT    PRIMARY KEY,
+                tenant_id             TEXT    NOT NULL,
+                source_instance_id    TEXT    NOT NULL,
+                occurrence_identity   TEXT    NOT NULL,
+                occurrence_digest     TEXT    NOT NULL,
+                provider_entity_id    TEXT    NOT NULL,
+                occurrence_kind       TEXT    NOT NULL,
+                occurrence_coordinate TEXT    NOT NULL,
+                occurred_at           TEXT    NOT NULL,
+                actor_id              TEXT,
+                actor_kind            TEXT    NOT NULL,
+                revision_of           TEXT,
+                absence               TEXT,
+                deletion_evidence     TEXT,
+                attention_disposition TEXT    NOT NULL,
+                attention_reason      TEXT    NOT NULL,
+                receipt_id            TEXT    NOT NULL,
+                admitted_sequence     INTEGER NOT NULL,
+                admitted_at           INTEGER NOT NULL
             );
-            CREATE INDEX IF NOT EXISTS idx_mc_community_occurrence_attention
-                ON mc_community_occurrence(tenant_id, attention_disposition);
-            CREATE INDEX IF NOT EXISTS idx_mc_community_occurrence_entity
-                ON mc_community_occurrence(tenant_id, source_instance_id, provider_entity_id);
-            CREATE INDEX IF NOT EXISTS idx_mc_community_occurrence_receipt
-                ON mc_community_occurrence(tenant_id, receipt_id);
-            CREATE INDEX IF NOT EXISTS idx_mc_community_occurrence_revision
-                ON mc_community_occurrence(tenant_id, revision_of);
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_mc_observation_identity
+                ON mc_community_observation(tenant_id, occurrence_identity);
+            CREATE INDEX IF NOT EXISTS idx_mc_observation_entity
+                ON mc_community_observation(tenant_id, source_instance_id, provider_entity_id);
 
             CREATE TABLE IF NOT EXISTS mc_community_checkpoint (
                 tenant_id          TEXT    NOT NULL,
                 source_instance_id TEXT    NOT NULL,
-                partition          TEXT    NOT NULL,
-                basis              TEXT    NOT NULL,
+                resource_family    TEXT    NOT NULL,
+                checkpoint_version INTEGER NOT NULL,
+                inventory_hash     TEXT,
+                provider_state     TEXT,
+                coverage           TEXT,
                 last_receipt_id    TEXT    NOT NULL,
-                admitted_sequence  INTEGER NOT NULL,
                 updated_at         INTEGER NOT NULL,
-                PRIMARY KEY (tenant_id, source_instance_id, partition)
+                PRIMARY KEY (tenant_id, source_instance_id, resource_family)
             );
         `);
     }
 
     /**
-     * @summary Validates, fences, and atomically admits one batch.
+     * @summary Validates, fences, and atomically admits one batch in a single serialized transaction.
      *
-     * Never throws for an ordinary protocol outcome — a conflict is a returned status, because a
-     * connector must be able to distinguish "your retry was fine" from "your payload disagrees with
-     * what we already durably accepted" without exception-shaped control flow.
+     * Never throws for an ordinary protocol outcome — a conflict is a returned status. The transaction
+     * runs the nine admission steps in order: (1) verify the ACTIVE registration + epoch INSIDE the
+     * boundary; (2) check the partition-scoped `batchId` receipt; (3) return the prior result for the
+     * same digest; (4) fail closed for the same `batchId` with a different digest; (5) verify the base
+     * checkpoint version + inventory hash; (6) dedup overlapping observations by occurrence identity +
+     * digest; (7) fail closed when the same occurrence carries a different digest; (8) admit a genuinely
+     * new occurrence as an immutable fact; (9) persist provider state/inventory/coverage/receipt and
+     * advance the partition.
      * @param {Object} batch A `community-activity-batch.v1` payload.
-     * @returns {Object} `{status, digest, receipt?, errors?}`
-     * @throws {Error} `BATCH_ADMISSION_NO_TENANT` when no server tenant resolves (fail closed).
+     * @returns {Object} `{status, digest, receipt?, checkpoint?, errors?, reason?}`
+     * @throws {Error} `BATCH_ADMISSION_NO_TENANT` | `ATTENTION_POLICY_NOT_CONFIGURED` (fail closed).
      */
     admitBatch(batch) {
         const tenantId = SourceRegistryService.resolveTenantId();
@@ -200,7 +196,6 @@ class CommunityBatchAdmissionService extends Base {
             throw new Error('BATCH_ADMISSION_NO_TENANT');
         }
 
-        // Fail loud rather than admit history without an evidence-backed disposition.
         if (!this.attentionPolicy) {
             throw new Error('ATTENTION_POLICY_NOT_CONFIGURED');
         }
@@ -211,231 +206,211 @@ class CommunityBatchAdmissionService extends Base {
             return {status: ADMISSION_STATUS.CONFLICT, reason: 'SCHEMA_INVALID', errors};
         }
 
-        const {batchId, sourceInstanceId, registrationEpoch, partition, occurrences} = batch,
-              digest                                                                 = canonicalBatchDigest(batch);
+        const
+            {
+                batchId, sourceInstanceId, resourceFamily, registrationEpoch, baseCheckpointVersion,
+                baseInventoryHash, nextProviderState, nextInventoryHash, coverage, observations
+            } = batch,
+            digest = canonicalBatchDigest(batch);
 
-        // The epoch fence: only an ACTIVE registration at this exact epoch may write. A revoked or
-        // reprovisioned source fails closed here rather than at the storage layer.
-        if (!SourceRegistryService.canAdmit(sourceInstanceId, registrationEpoch)) {
-            return {status: ADMISSION_STATUS.CONFLICT, reason: 'REGISTRATION_NOT_ADMISSIBLE', digest};
+        let outcome;
+
+        try {
+            outcome = this.db.transaction(() => {
+                // Step 1 — the epoch fence, inside the serialized boundary (not a pre-transaction read).
+                if (!SourceRegistryService.canAdmit(sourceInstanceId, registrationEpoch)) {
+                    return {status: ADMISSION_STATUS.CONFLICT, reason: 'REGISTRATION_NOT_ADMISSIBLE'}
+                }
+
+                // Steps 2-4 — the partition-scoped batch idempotency key.
+                const existing = this.db.prepare(
+                    `SELECT * FROM mc_community_batch_receipt
+                     WHERE tenant_id = ? AND source_instance_id = ? AND resource_family = ? AND batch_id = ?`
+                ).get(tenantId, sourceInstanceId, resourceFamily, batchId);
+
+                if (existing) {
+                    return existing.digest === digest
+                        ? {status: ADMISSION_STATUS.IDEMPOTENT, receipt: this.#toReceipt(existing)}
+                        : {status: ADMISSION_STATUS.CONFLICT, reason: 'DIGEST_MISMATCH', receipt: this.#toReceipt(existing)}
+                }
+
+                // Step 5 — the checkpoint CAS: the batch's declared base must equal current server state.
+                const checkpoint       = this.#readCheckpoint(tenantId, sourceInstanceId, resourceFamily),
+                      currentVersion   = checkpoint ? checkpoint.checkpointVersion : 0,
+                      currentInventory = checkpoint ? checkpoint.inventoryHash : null;
+
+                if (baseCheckpointVersion !== currentVersion || (baseInventoryHash ?? null) !== currentInventory) {
+                    return {status: ADMISSION_STATUS.CONFLICT, reason: 'STALE_BASIS', checkpoint}
+                }
+
+                // Steps 6-8 — observations dedup by identity + digest (a genuine revision is a new identity).
+                const now       = Date.now(),
+                      nextSeq   = (this.db.prepare(`SELECT MAX(admitted_sequence) AS max FROM mc_community_batch_receipt WHERE tenant_id = ?`).get(tenantId).max || 0) + 1,
+                      receiptId = crypto.randomUUID();
+
+                this.db.prepare(
+                    `INSERT INTO mc_community_batch_receipt (
+                        receipt_id, tenant_id, source_instance_id, resource_family, batch_id, digest,
+                        registration_epoch, base_checkpoint_version, next_checkpoint_version,
+                        base_inventory_hash, next_inventory_hash, coverage, observation_count,
+                        admitted_sequence, admitted_at
+                     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+                ).run(
+                    receiptId, tenantId, sourceInstanceId, resourceFamily, batchId, digest,
+                    registrationEpoch, baseCheckpointVersion, currentVersion + 1,
+                    baseInventoryHash ?? null, nextInventoryHash ?? null,
+                    coverage ? JSON.stringify(coverage) : null, observations.length, nextSeq, now
+                );
+
+                const insertObservation = this.db.prepare(
+                    `INSERT INTO mc_community_observation (
+                        observation_row_id, tenant_id, source_instance_id, occurrence_identity, occurrence_digest,
+                        provider_entity_id, occurrence_kind, occurrence_coordinate, occurred_at, actor_id,
+                        actor_kind, revision_of, absence, deletion_evidence, attention_disposition,
+                        attention_reason, receipt_id, admitted_sequence, admitted_at
+                     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+                );
+
+                for (const observation of observations) {
+                    const identity = occurrenceIdentity(sourceInstanceId, observation),
+                          oDigest  = observationDigest(observation),
+                          prior    = this.db.prepare(
+                              `SELECT occurrence_digest FROM mc_community_observation WHERE tenant_id = ? AND occurrence_identity = ?`
+                          ).get(tenantId, identity);
+
+                    if (prior) {
+                        // Step 6 — same identity + same digest: already durable, dedup silently.
+                        if (prior.occurrence_digest === oDigest) continue;
+                        // Step 7 — same identity + different digest: integrity conflict, abort.
+                        throw new ObservationConflict('OBSERVATION_DIGEST_MISMATCH')
+                    }
+
+                    // Step 8 — a new occurrence/revision is a new immutable fact.
+                    const {disposition, reason} = classifyAttention(observation, this.attentionPolicy);
+
+                    insertObservation.run(
+                        crypto.randomUUID(), tenantId, sourceInstanceId, identity, oDigest,
+                        observation.providerEntityId, observation.occurrenceKind, observation.occurrenceCoordinate,
+                        observation.occurredAt, observation.actorId || null, observation.actorKind,
+                        observation.revisionOf || null, observation.absence || null,
+                        observation.deletionEvidence ? JSON.stringify(observation.deletionEvidence) : null,
+                        disposition, reason, receiptId, nextSeq, now
+                    )
+                }
+
+                // Step 9 — advance the partition checkpoint to the batch's declared next state.
+                this.db.prepare(
+                    `INSERT INTO mc_community_checkpoint
+                        (tenant_id, source_instance_id, resource_family, checkpoint_version, inventory_hash, provider_state, coverage, last_receipt_id, updated_at)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     ON CONFLICT(tenant_id, source_instance_id, resource_family) DO UPDATE SET
+                        checkpoint_version = excluded.checkpoint_version,
+                        inventory_hash     = excluded.inventory_hash,
+                        provider_state     = excluded.provider_state,
+                        coverage           = excluded.coverage,
+                        last_receipt_id    = excluded.last_receipt_id,
+                        updated_at         = excluded.updated_at`
+                ).run(
+                    tenantId, sourceInstanceId, resourceFamily, currentVersion + 1, nextInventoryHash ?? null,
+                    nextProviderState ? JSON.stringify(nextProviderState) : null,
+                    coverage ? JSON.stringify(coverage) : null, receiptId, now
+                );
+
+                return {status: ADMISSION_STATUS.ACCEPTED, receiptId}
+            })()
+        } catch (err) {
+            if (err instanceof ObservationConflict) {
+                return {status: ADMISSION_STATUS.CONFLICT, reason: err.reason, digest}
+            }
+            throw err
         }
 
-        const existing = this.db.prepare(
-            `SELECT * FROM mc_community_batch_receipt
-             WHERE tenant_id = ? AND source_instance_id = ? AND batch_id = ?`
-        ).get(tenantId, sourceInstanceId, batchId);
-
-        if (existing) {
-            // Same scoped id: a retry only if the payload is byte-identical by digest.
-            return existing.digest === digest
-                ? {status: ADMISSION_STATUS.IDEMPOTENT, digest, receipt: this.#toCamel(existing)}
-                : {status: ADMISSION_STATUS.CONFLICT, reason: 'DIGEST_MISMATCH', digest, receipt: this.#toCamel(existing)};
-        }
-
-        const admit = this.db.transaction(() => {
-            // Sequence is assigned INSIDE the transaction, so it can never be handed out without a
-            // committed receipt (and never skipped by a rolled-back one).
-            const nextSequence = (this.db.prepare(
-                      `SELECT MAX(admitted_sequence) AS max FROM mc_community_batch_receipt WHERE tenant_id = ?`
-                  ).get(tenantId).max || 0) + 1,
-                  receiptId = crypto.randomUUID(),
-                  now       = Date.now();
-
-            this.db.prepare(
-                `INSERT INTO mc_community_batch_receipt (
-                    receipt_id, tenant_id, source_instance_id, batch_id, digest, partition,
-                    registration_epoch, occurrence_count, admitted_sequence, admitted_at
-                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-            ).run(receiptId, tenantId, sourceInstanceId, batchId, digest, partition,
-                  registrationEpoch, occurrences.length, nextSequence, now);
-
-            // The ledger commits with its receipt: a crash can never leave occurrences without the
-            // receipt that authorizes them, nor a receipt whose occurrence_count is a lie.
-            const insertOccurrence = this.db.prepare(
-                `INSERT INTO mc_community_occurrence (
-                    occurrence_id, tenant_id, source_instance_id, provider_entity_id, occurrence_kind,
-                    occurred_at, revision_of, absence, actor_id, attention_disposition,
-                    attention_reason, receipt_id, admitted_sequence, admitted_at
-                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-            );
-
-            occurrences.forEach(occurrence => {
-                // occurrence_id is OURS — deliberately distinct from the provider entity id, the
-                // delivering batch/receipt, and the admitted sequence, so no consumer can conflate
-                // "which thing happened", "how it reached us", and "in what order we accepted it".
-                // Classification happens INSIDE the admission transaction, so an accepted row can
-                // never exist without its evidence-backed disposition. Its output is server policy
-                // and stays out of the digest, so revising policy cannot look like corruption.
-                const {disposition, reason} = classifyAttention(occurrence, this.attentionPolicy);
-
-                insertOccurrence.run(
-                    crypto.randomUUID(), tenantId, sourceInstanceId, occurrence.providerEntityId,
-                    occurrence.occurrenceKind, occurrence.occurredAt, occurrence.revisionOf || null,
-                    occurrence.absence || null, occurrence.actorId || null, disposition, reason,
-                    receiptId, nextSequence, now
-                )
-            });
-
-            return receiptId
-        });
-
-        return {
-            status : ADMISSION_STATUS.ACCEPTED,
-            digest,
-            receipt: this.getReceipt(sourceInstanceId, batchId, admit())
-        }
-    }
-
-    /**
-     * Loads one receipt, always scoped by the server tenant so a caller cannot read across tenants.
-     * @param {String} sourceInstanceId
-     * @param {String} batchId
-     * @param {String} [receiptId] Unused selector kept for call-site clarity at the admit boundary.
-     * @returns {Object|null}
-     */
-    getReceipt(sourceInstanceId, batchId, receiptId) {
-        const tenantId = SourceRegistryService.resolveTenantId();
-
-        if (!tenantId) return null;
-
-        const row = this.db.prepare(
-            `SELECT * FROM mc_community_batch_receipt
-             WHERE tenant_id = ? AND source_instance_id = ? AND batch_id = ?`
-        ).get(tenantId, sourceInstanceId, batchId);
-
-        return row ? this.#toCamel(row) : null;
-    }
-
-    /**
-     * @summary Advances a partition checkpoint as a compare-and-swap against the basis the caller read.
-     *
-     * Two preconditions, both refusals rather than best-effort writes:
-     *
-     * 1. **Durable acceptance.** The cited receipt must already be committed for this tenant, source
-     *    and partition — a cursor may only move to a basis some accepted batch actually established.
-     *    Advancing before durable receipt is exactly how events get skipped.
-     * 2. **Expected basis.** The UPDATE predicate carries the basis the caller observed, so a writer
-     *    whose view was superseded matches zero rows. A losing writer gets the CURRENT server state
-     *    back and never advances destructively — a regressed or forked cursor is worse than a retry.
-     * @param {String} sourceInstanceId
-     * @param {String} partition
-     * @param {Object} advance
-     * @param {String|null} [advance.expectedBasis=null] The observed basis; `null` claims an unset checkpoint.
-     * @param {String} advance.toBasis
-     * @param {String} advance.receiptId The durably-accepted receipt establishing `toBasis`.
-     * @returns {Object} `{status, reason?, checkpoint}`
-     * @throws {Error} `BATCH_ADMISSION_NO_TENANT` | `CHECKPOINT_ADVANCE_ARGUMENTS_REQUIRED`
-     */
-    advanceCheckpoint(sourceInstanceId, partition, {expectedBasis = null, toBasis, receiptId} = {}) {
-        const tenantId = SourceRegistryService.resolveTenantId();
-
-        if (!tenantId) {
-            throw new Error('BATCH_ADMISSION_NO_TENANT');
-        }
-
-        if (!toBasis || !receiptId) {
-            throw new Error('CHECKPOINT_ADVANCE_ARGUMENTS_REQUIRED');
-        }
-
-        const receipt = this.db.prepare(
-            `SELECT admitted_sequence FROM mc_community_batch_receipt
-             WHERE tenant_id = ? AND source_instance_id = ? AND receipt_id = ? AND partition = ?`
-        ).get(tenantId, sourceInstanceId, receiptId, partition);
-
-        if (!receipt) {
+        if (outcome.status === ADMISSION_STATUS.ACCEPTED) {
             return {
-                status    : CHECKPOINT_STATUS.CONFLICT,
-                reason    : 'RECEIPT_NOT_DURABLE',
-                checkpoint: this.getCheckpoint(sourceInstanceId, partition)
+                status    : ADMISSION_STATUS.ACCEPTED,
+                digest,
+                receipt   : this.getReceipt(sourceInstanceId, resourceFamily, batchId),
+                checkpoint: this.getCheckpoint(sourceInstanceId, resourceFamily)
             }
         }
 
-        const
-            now    = Date.now(),
-            result = expectedBasis === null
-                // Claiming an unset checkpoint: OR IGNORE makes the race decidable — a second
-                // claimant changes zero rows instead of clobbering the first.
-                ? this.db.prepare(
-                      `INSERT OR IGNORE INTO mc_community_checkpoint
-                          (tenant_id, source_instance_id, partition, basis, last_receipt_id, admitted_sequence, updated_at)
-                       VALUES (?, ?, ?, ?, ?, ?, ?)`
-                  ).run(tenantId, sourceInstanceId, partition, toBasis, receiptId, receipt.admitted_sequence, now)
-                : this.db.prepare(
-                      `UPDATE mc_community_checkpoint
-                          SET basis = ?, last_receipt_id = ?, admitted_sequence = ?, updated_at = ?
-                        WHERE tenant_id = ? AND source_instance_id = ? AND partition = ? AND basis = ?`
-                  ).run(toBasis, receiptId, receipt.admitted_sequence, now, tenantId, sourceInstanceId, partition, expectedBasis);
-
-        return result.changes === 1
-            ? {status: CHECKPOINT_STATUS.ADVANCED, checkpoint: this.getCheckpoint(sourceInstanceId, partition)}
-            : {status: CHECKPOINT_STATUS.CONFLICT, reason: 'BASIS_MISMATCH', checkpoint: this.getCheckpoint(sourceInstanceId, partition)}
+        return {...outcome, digest}
     }
 
     /**
-     * Reads one partition checkpoint, tenant-scoped. `null` means unset — distinct from a checkpoint
-     * whose basis happens to be empty.
+     * Loads one receipt, tenant + partition scoped.
      * @param {String} sourceInstanceId
-     * @param {String} partition
+     * @param {String} resourceFamily
+     * @param {String} batchId
      * @returns {Object|null}
      */
-    getCheckpoint(sourceInstanceId, partition) {
+    getReceipt(sourceInstanceId, resourceFamily, batchId) {
         const tenantId = SourceRegistryService.resolveTenantId();
 
         if (!tenantId) return null;
 
         const row = this.db.prepare(
-            `SELECT * FROM mc_community_checkpoint
-             WHERE tenant_id = ? AND source_instance_id = ? AND partition = ?`
-        ).get(tenantId, sourceInstanceId, partition);
+            `SELECT * FROM mc_community_batch_receipt
+             WHERE tenant_id = ? AND source_instance_id = ? AND resource_family = ? AND batch_id = ?`
+        ).get(tenantId, sourceInstanceId, resourceFamily, batchId);
 
-        return row ? {
-            tenantId        : row.tenant_id,
-            sourceInstanceId: row.source_instance_id,
-            partition       : row.partition,
-            basis           : row.basis,
-            lastReceiptId   : row.last_receipt_id,
-            admittedSequence: row.admitted_sequence,
-            updatedAt       : row.updated_at
-        } : null
+        return row ? this.#toReceipt(row) : null;
     }
 
     /**
-     * @summary Lists admitted occurrences, tenant-scoped, newest sequence last.
-     *
-     * The ledger is INSERT-only: a revision is a new occurrence carrying `revisionOf`, never an
-     * update of the row it revises, so history stays reconstructible rather than overwritten.
+     * Reads one partition checkpoint, tenant-scoped. `null` means unset.
+     * @param {String} sourceInstanceId
+     * @param {String} resourceFamily
+     * @returns {Object|null}
+     */
+    getCheckpoint(sourceInstanceId, resourceFamily) {
+        const tenantId = SourceRegistryService.resolveTenantId();
+
+        if (!tenantId) return null;
+
+        return this.#readCheckpoint(tenantId, sourceInstanceId, resourceFamily)
+    }
+
+    /**
+     * @summary Lists admitted observations, tenant-scoped, newest sequence last. INSERT-only history —
+     * a revision is a new row carrying `revisionOf`, never an update of the row it revises.
      * @param {String} sourceInstanceId
      * @param {Object} [filter]
-     * @param {String} [filter.providerEntityId] Narrow to one provider entity's history.
+     * @param {String} [filter.providerEntityId]
      * @returns {Object[]}
      */
-    listOccurrences(sourceInstanceId, {providerEntityId} = {}) {
+    listObservations(sourceInstanceId, {providerEntityId} = {}) {
         const tenantId = SourceRegistryService.resolveTenantId();
 
         if (!tenantId) return [];
 
         const rows = providerEntityId
             ? this.db.prepare(
-                  `SELECT * FROM mc_community_occurrence
+                  `SELECT * FROM mc_community_observation
                    WHERE tenant_id = ? AND source_instance_id = ? AND provider_entity_id = ?
                    ORDER BY admitted_sequence, occurred_at`
               ).all(tenantId, sourceInstanceId, providerEntityId)
             : this.db.prepare(
-                  `SELECT * FROM mc_community_occurrence
+                  `SELECT * FROM mc_community_observation
                    WHERE tenant_id = ? AND source_instance_id = ?
                    ORDER BY admitted_sequence, occurred_at`
               ).all(tenantId, sourceInstanceId);
 
         return rows.map(row => ({
-            occurrenceId        : row.occurrence_id,
+            observationRowId    : row.observation_row_id,
             tenantId            : row.tenant_id,
             sourceInstanceId    : row.source_instance_id,
+            occurrenceIdentity  : row.occurrence_identity,
+            occurrenceDigest    : row.occurrence_digest,
             providerEntityId    : row.provider_entity_id,
             occurrenceKind      : row.occurrence_kind,
+            occurrenceCoordinate: row.occurrence_coordinate,
             occurredAt          : row.occurred_at,
+            actorId             : row.actor_id,
+            actorKind           : row.actor_kind,
             revisionOf          : row.revision_of,
             absence             : row.absence,
-            actorId             : row.actor_id,
+            deletionEvidence    : row.deletion_evidence ? JSON.parse(row.deletion_evidence) : null,
             attentionDisposition: row.attention_disposition,
             attentionReason     : row.attention_reason,
             receiptId           : row.receipt_id,
@@ -445,23 +420,53 @@ class CommunityBatchAdmissionService extends Base {
     }
 
     /**
-     * Maps a snake_case receipt row to the camelCase contract shape.
+     * @param {String} tenantId
+     * @param {String} sourceInstanceId
+     * @param {String} resourceFamily
+     * @returns {Object|null}
+     * @private
+     */
+    #readCheckpoint(tenantId, sourceInstanceId, resourceFamily) {
+        const row = this.db.prepare(
+            `SELECT * FROM mc_community_checkpoint
+             WHERE tenant_id = ? AND source_instance_id = ? AND resource_family = ?`
+        ).get(tenantId, sourceInstanceId, resourceFamily);
+
+        return row ? {
+            tenantId         : row.tenant_id,
+            sourceInstanceId : row.source_instance_id,
+            resourceFamily   : row.resource_family,
+            checkpointVersion: row.checkpoint_version,
+            inventoryHash    : row.inventory_hash,
+            providerState    : row.provider_state ? JSON.parse(row.provider_state) : null,
+            coverage         : row.coverage ? JSON.parse(row.coverage) : null,
+            lastReceiptId    : row.last_receipt_id,
+            updatedAt        : row.updated_at
+        } : null
+    }
+
+    /**
      * @param {Object} row
      * @returns {Object}
      * @private
      */
-    #toCamel(row) {
+    #toReceipt(row) {
         return {
-            receiptId        : row.receipt_id,
-            tenantId         : row.tenant_id,
-            sourceInstanceId : row.source_instance_id,
-            batchId          : row.batch_id,
-            digest           : row.digest,
-            partition        : row.partition,
-            registrationEpoch: row.registration_epoch,
-            occurrenceCount  : row.occurrence_count,
-            admittedSequence : row.admitted_sequence,
-            admittedAt       : row.admitted_at
+            receiptId            : row.receipt_id,
+            tenantId             : row.tenant_id,
+            sourceInstanceId     : row.source_instance_id,
+            resourceFamily       : row.resource_family,
+            batchId              : row.batch_id,
+            digest               : row.digest,
+            registrationEpoch    : row.registration_epoch,
+            baseCheckpointVersion: row.base_checkpoint_version,
+            nextCheckpointVersion: row.next_checkpoint_version,
+            baseInventoryHash    : row.base_inventory_hash,
+            nextInventoryHash    : row.next_inventory_hash,
+            coverage             : row.coverage ? JSON.parse(row.coverage) : null,
+            observationCount     : row.observation_count,
+            admittedSequence     : row.admitted_sequence,
+            admittedAt           : row.admitted_at
         }
     }
 }

--- a/ai/services/memory-core/communityAttentionClassifier.mjs
+++ b/ai/services/memory-core/communityAttentionClassifier.mjs
@@ -1,0 +1,73 @@
+/**
+ * @summary Attention dispositions. Deliberately three-valued: "we have not decided" is a real,
+ * durable answer and must not collapse into "no".
+ * @member {Object<String,String>}
+ */
+export const ATTENTION_DISPOSITION = {
+    ELIGIBLE    : 'eligible',
+    INELIGIBLE  : 'ineligible',
+    UNDETERMINED: 'undetermined'
+};
+
+/**
+ * @summary Classifies whether an admitted occurrence is an attention-eligible community item.
+ *
+ * **Zero authority.** A disposition assigns no work, enters no frontier, and creates no Task — it
+ * records a judgement about the occurrence, nothing more. Promotion is a separate, explicit
+ * transition that this function must never pre-empt.
+ *
+ * The judgement is stored as its own evidence-backed field rather than derived on read, so it stays
+ * separate from occurrence kind, provider actor kind, and trust projection — three things that
+ * inform it but none of which alone decides it.
+ *
+ * Rule order is load-bearing:
+ * 1. **Rostered actors first.** Internal/rostered activity may update or resolve an existing external
+ *    item without minting new attention. Checking this before the bot rule keeps our own agents out
+ *    of the undetermined branch, where they would accumulate as permanent unanswered questions.
+ * 2. **External bots are UNDETERMINED, never inferred.** Bot eligibility is an explicit recorded
+ *    disposition; guessing it from actor kind or trust tier is precisely the inference this contract
+ *    forbids, so an unrecorded bot stays honestly undecided.
+ * 3. **Response-bearing** is required — a label or assignment change carries no one waiting on us.
+ *
+ * Policy is injected, never defaulted: a silent default here would quietly redefine what the swarm
+ * pays attention to.
+ * @param {Object}   occurrence
+ * @param {Object}   policy
+ * @param {String[]} policy.responseBearingKinds Occurrence kinds that can carry someone awaiting a response.
+ * @param {String[]} policy.rosteredActorIds     Internal/rostered actor ids.
+ * @param {String[]} policy.botActorIds          Known bot actor ids whose disposition is not yet recorded.
+ * @param {Object}   [policy.recordedBotDispositions] Explicit per-bot dispositions, when they exist.
+ * @returns {{disposition: String, reason: String}}
+ * @throws {Error} `ATTENTION_POLICY_REQUIRED` when policy is absent or incomplete.
+ */
+export function classifyAttention(occurrence, policy) {
+    const {responseBearingKinds, rosteredActorIds, botActorIds, recordedBotDispositions = {}} = policy || {};
+
+    if (!Array.isArray(responseBearingKinds) || !Array.isArray(rosteredActorIds) || !Array.isArray(botActorIds)) {
+        throw new Error('ATTENTION_POLICY_REQUIRED')
+    }
+
+    const {actorId, occurrenceKind} = occurrence;
+
+    if (!actorId) {
+        return {disposition: ATTENTION_DISPOSITION.UNDETERMINED, reason: 'actor-unknown'}
+    }
+
+    if (rosteredActorIds.includes(actorId)) {
+        return {disposition: ATTENTION_DISPOSITION.INELIGIBLE, reason: 'rostered-actor'}
+    }
+
+    if (botActorIds.includes(actorId)) {
+        const recorded = recordedBotDispositions[actorId];
+
+        return recorded
+            ? {disposition: recorded, reason: 'bot-disposition-recorded'}
+            : {disposition: ATTENTION_DISPOSITION.UNDETERMINED, reason: 'bot-disposition-not-recorded'}
+    }
+
+    if (!responseBearingKinds.includes(occurrenceKind)) {
+        return {disposition: ATTENTION_DISPOSITION.INELIGIBLE, reason: 'not-response-bearing'}
+    }
+
+    return {disposition: ATTENTION_DISPOSITION.ELIGIBLE, reason: 'external-response-bearing'}
+}

--- a/ai/services/memory-core/communityAttentionClassifier.mjs
+++ b/ai/services/memory-core/communityAttentionClassifier.mjs
@@ -1,6 +1,7 @@
 /**
- * @summary Attention dispositions. Deliberately three-valued: "we have not decided" is a real,
- * durable answer and must not collapse into "no".
+ * @summary Attention dispositions. Three-valued: an explicit reviewed disposition may record any of
+ * the three, but the classifier's own computed defaults are only `eligible` or `ineligible` — v1
+ * never leaves a computed row `undetermined`, it fails closed to `ineligible` with a reason.
  * @member {Object<String,String>}
  */
 export const ATTENTION_DISPOSITION = {
@@ -10,64 +11,84 @@ export const ATTENTION_DISPOSITION = {
 };
 
 /**
- * @summary Classifies whether an admitted occurrence is an attention-eligible community item.
+ * @summary The provider actor-kind axis, independent of security/content trust.
+ * Attention eligibility branches on this; trust tier never does.
+ * @member {Set<String>}
+ */
+export const ACTOR_KINDS = new Set(['user', 'bot', 'organization', 'mannequin', 'enterprise-user', 'unknown']);
+
+/**
+ * @summary Classifies whether an admitted occurrence is an attention-eligible community item, per the
+ * durable-community-activity v1 policy table — actor-class driven and fail-closed.
  *
- * **Zero authority.** A disposition assigns no work, enters no frontier, and creates no Task — it
- * records a judgement about the occurrence, nothing more. Promotion is a separate, explicit
- * transition that this function must never pre-empt.
+ * **Zero authority.** A disposition assigns no work, enters no frontier, and creates no Task. It is a
+ * recorded judgement, written in the admission transaction, distinct from occurrence kind, provider
+ * actor kind, and trust projection — informed by all three, decided by none alone.
  *
- * The judgement is stored as its own evidence-backed field rather than derived on read, so it stays
- * separate from occurrence kind, provider actor kind, and trust projection — three things that
- * inform it but none of which alone decides it.
+ * The rules, verbatim from the v1 policy table:
+ * 1. **Rostered / internal** (any actor kind): admitted for reconstruction, but **never mints new
+ *    attention**. Checked first, so an internal agent is never mistaken for an external human.
+ * 2. **External human** (`user`, not rostered): eligible **iff response-bearing**. First-time and
+ *    trusted-repeat are identical here — trust changes prose projection, never eligibility (AC12).
+ * 3. **Bot**: **not attention-eligible in v1** — the explicit least-authority default the
+ *    durable-community-activity decision records. Not inferred from a list; decided by the actor kind
+ *    the provider reports.
+ * 4. **Organization / mannequin / enterprise-user / unknown**: **fail closed** for attention absent an
+ *    explicit source-specific reviewed disposition.
  *
- * Rule order is load-bearing:
- * 1. **Rostered actors first.** Internal/rostered activity may update or resolve an existing external
- *    item without minting new attention. Checking this before the bot rule keeps our own agents out
- *    of the undetermined branch, where they would accumulate as permanent unanswered questions.
- * 2. **External bots are UNDETERMINED, never inferred.** Bot eligibility is an explicit recorded
- *    disposition; guessing it from actor kind or trust tier is precisely the inference this contract
- *    forbids, so an unrecorded bot stays honestly undecided.
- * 3. **Response-bearing** is required — a label or assignment change carries no one waiting on us.
- *
- * Policy is injected, never defaulted: a silent default here would quietly redefine what the swarm
- * pays attention to.
+ * "Actor id absent from a bot list" is never treated as proof of external-human eligibility — only a
+ * provider-reported `actorKind === 'user'` reaches the eligible branch. Policy is injected, never
+ * defaulted.
  * @param {Object}   occurrence
+ * @param {String}   occurrence.actorId
+ * @param {String}   occurrence.actorKind One of {@link ACTOR_KINDS}.
+ * @param {String}   occurrence.occurrenceKind
  * @param {Object}   policy
  * @param {String[]} policy.responseBearingKinds Occurrence kinds that can carry someone awaiting a response.
- * @param {String[]} policy.rosteredActorIds     Internal/rostered actor ids.
- * @param {String[]} policy.botActorIds          Known bot actor ids whose disposition is not yet recorded.
- * @param {Object}   [policy.recordedBotDispositions] Explicit per-bot dispositions, when they exist.
+ * @param {String[]} policy.rosteredActorIds     Internal/rostered actor ids (the "never mints attention" set).
+ * @param {Object}   [policy.recordedActorDispositions] Explicit per-actor reviewed dispositions, when they exist.
  * @returns {{disposition: String, reason: String}}
  * @throws {Error} `ATTENTION_POLICY_REQUIRED` when policy is absent or incomplete.
+ * @throws {Error} `ATTENTION_INVALID_RECORDED_DISPOSITION` when an injected disposition is off-enum.
  */
 export function classifyAttention(occurrence, policy) {
-    const {responseBearingKinds, rosteredActorIds, botActorIds, recordedBotDispositions = {}} = policy || {};
+    const {responseBearingKinds, rosteredActorIds, recordedActorDispositions = {}} = policy || {};
 
-    if (!Array.isArray(responseBearingKinds) || !Array.isArray(rosteredActorIds) || !Array.isArray(botActorIds)) {
+    if (!Array.isArray(responseBearingKinds) || !Array.isArray(rosteredActorIds)) {
         throw new Error('ATTENTION_POLICY_REQUIRED')
     }
 
-    const {actorId, occurrenceKind} = occurrence;
+    const {actorId, actorKind, occurrenceKind} = occurrence;
 
-    if (!actorId) {
-        return {disposition: ATTENTION_DISPOSITION.UNDETERMINED, reason: 'actor-unknown'}
+    // An explicit reviewed disposition wins, but must be a valid three-value enum member — a
+    // malformed injected policy fails loud rather than silently admitting an off-contract state.
+    if (actorId && Object.prototype.hasOwnProperty.call(recordedActorDispositions, actorId)) {
+        const recorded = recordedActorDispositions[actorId];
+
+        if (!Object.values(ATTENTION_DISPOSITION).includes(recorded)) {
+            throw new Error('ATTENTION_INVALID_RECORDED_DISPOSITION')
+        }
+
+        return {disposition: recorded, reason: 'explicit-reviewed-disposition'}
     }
 
-    if (rosteredActorIds.includes(actorId)) {
+    // Rule 1 — rostered/internal never mints attention, whatever the actor kind.
+    if (actorId && rosteredActorIds.includes(actorId)) {
         return {disposition: ATTENTION_DISPOSITION.INELIGIBLE, reason: 'rostered-actor'}
     }
 
-    if (botActorIds.includes(actorId)) {
-        const recorded = recordedBotDispositions[actorId];
-
-        return recorded
-            ? {disposition: recorded, reason: 'bot-disposition-recorded'}
-            : {disposition: ATTENTION_DISPOSITION.UNDETERMINED, reason: 'bot-disposition-not-recorded'}
+    // Rule 3 — bots: explicit v1 not-eligible, decided by kind, never inferred from a list.
+    if (actorKind === 'bot') {
+        return {disposition: ATTENTION_DISPOSITION.INELIGIBLE, reason: 'bot-not-attention-eligible-v1'}
     }
 
-    if (!responseBearingKinds.includes(occurrenceKind)) {
-        return {disposition: ATTENTION_DISPOSITION.INELIGIBLE, reason: 'not-response-bearing'}
+    // Rule 2 — external human: eligible iff response-bearing; trust is not consulted (AC12).
+    if (actorKind === 'user') {
+        return responseBearingKinds.includes(occurrenceKind)
+            ? {disposition: ATTENTION_DISPOSITION.ELIGIBLE,   reason: 'external-response-bearing'}
+            : {disposition: ATTENTION_DISPOSITION.INELIGIBLE, reason: 'not-response-bearing'}
     }
 
-    return {disposition: ATTENTION_DISPOSITION.ELIGIBLE, reason: 'external-response-bearing'}
+    // Rule 4 — organization/mannequin/enterprise-user/unknown, and any unrecognized kind: fail closed.
+    return {disposition: ATTENTION_DISPOSITION.INELIGIBLE, reason: 'actor-kind-not-reviewed-fail-closed'}
 }

--- a/ai/services/memory-core/communityBatchContract.mjs
+++ b/ai/services/memory-core/communityBatchContract.mjs
@@ -1,4 +1,5 @@
-import crypto from 'crypto';
+import crypto        from 'crypto';
+import {ACTOR_KINDS} from './communityAttentionClassifier.mjs';
 
 /**
  * @summary The versioned canonical batch contract for community-activity admission.
@@ -12,7 +13,7 @@ export const BATCH_SCHEMA_VERSION = 'community-activity-batch.v1';
 const
     REQUIRED_BATCH_KEYS      = ['schemaVersion', 'batchId', 'sourceInstanceId', 'registrationEpoch', 'partition', 'coverage', 'occurrences'],
     REQUIRED_COVERAGE_KEYS   = ['fromBasis', 'toBasis', 'complete'],
-    REQUIRED_OCCURRENCE_KEYS = ['providerEntityId', 'occurrenceKind', 'occurredAt'],
+    REQUIRED_OCCURRENCE_KEYS = ['providerEntityId', 'occurrenceKind', 'occurredAt', 'actorKind'],
     /**
      * Provider prose never enters an automatic durable row. A batch carrying any of these is
      * REJECTED rather than silently stripped: stripping would let a connector believe prose was
@@ -180,8 +181,19 @@ export function validateBatch(batch) {
                 if (SERVER_POLICY_KEYS.has(key)) errors.push(`OCCURRENCE_${index}_ASSERTS_SERVER_POLICY_${key.toUpperCase()}`)
             });
 
+            if (occurrence.actorKind !== undefined && !ACTOR_KINDS.has(occurrence.actorKind)) {
+                errors.push(`OCCURRENCE_${index}_ACTOR_KIND_INVALID`)
+            }
+
             if (occurrence.absence !== undefined && !ABSENCE_DISPOSITIONS.has(occurrence.absence)) {
                 errors.push(`OCCURRENCE_${index}_ABSENCE_DISPOSITION_INVALID`)
+            }
+
+            // `deleted` is the one absence disposition that asserts a fact about provider state, so it
+            // requires explicit provider evidence (a tombstone id / deletion timestamp+actor) — an
+            // enum value alone can be a permission loss masquerading as a deletion.
+            if (occurrence.absence === 'deleted' && (occurrence.deletionEvidence === undefined || occurrence.deletionEvidence === null)) {
+                errors.push(`OCCURRENCE_${index}_DELETED_WITHOUT_EVIDENCE`)
             }
 
             if (POPULARITY_KINDS.has(occurrence.occurrenceKind)) {

--- a/ai/services/memory-core/communityBatchContract.mjs
+++ b/ai/services/memory-core/communityBatchContract.mjs
@@ -10,46 +10,64 @@ import {ACTOR_KINDS} from './communityAttentionClassifier.mjs';
  */
 export const BATCH_SCHEMA_VERSION = 'community-activity-batch.v1';
 
+/**
+ * @summary Bound on the opaque `nextProviderState` blob. It is opaque to Memory Core but not
+ * unbounded: an unbounded caller-supplied blob is a denial-of-storage vector, so it is size-capped,
+ * schema-versioned, and held to the same no-secret/no-prose rule as every other durable field.
+ * @member {Number}
+ */
+export const MAX_PROVIDER_STATE_BYTES = 65536;
+
 const
-    REQUIRED_BATCH_KEYS      = ['schemaVersion', 'batchId', 'sourceInstanceId', 'registrationEpoch', 'partition', 'coverage', 'occurrences'],
-    REQUIRED_COVERAGE_KEYS   = ['fromBasis', 'toBasis', 'complete'],
-    REQUIRED_OCCURRENCE_KEYS = ['providerEntityId', 'occurrenceKind', 'occurredAt', 'actorKind'],
+    REQUIRED_BATCH_KEYS       = [
+        'schemaVersion', 'sourceInstanceId', 'resourceFamily', 'adapterSchemaVersion',
+        'providerStateSchemaVersion', 'registrationEpoch', 'baseCheckpointVersion', 'baseInventoryHash',
+        'batchId', 'observations', 'nextProviderState', 'nextInventoryHash', 'coverage'
+    ],
+    REQUIRED_COVERAGE_KEYS    = ['fromBasis', 'toBasis', 'complete'],
+    /**
+     * v1 keys that must be PRESENT but may hold `null`: the initial checkpoint basis has no prior
+     * inventory, and a batch that changes no opaque provider state carries `null`. Presence is still
+     * required so a reduced batch (an omitted key) fails loudly rather than defaulting.
+     */
+    NULLABLE_BATCH_KEYS       = new Set(['baseInventoryHash', 'nextInventoryHash', 'nextProviderState']),
+    REQUIRED_OBSERVATION_KEYS = ['providerEntityId', 'occurrenceKind', 'occurrenceCoordinate', 'occurredAt', 'actorKind'],
     /**
      * Provider prose never enters an automatic durable row. A batch carrying any of these is
      * REJECTED rather than silently stripped: stripping would let a connector believe prose was
      * admitted and stored, which is a worse contract than a loud refusal.
      */
-    PROSE_KEYS               = new Set(['body', 'bodyHTML', 'bodyText', 'excerpt', 'summary', 'text', 'title']),
+    PROSE_KEYS                = new Set(['body', 'bodyHTML', 'bodyText', 'excerpt', 'summary', 'text', 'title']),
     /** Absence is never inferred — it is one of three explicitly-evidenced dispositions. */
-    ABSENCE_DISPOSITIONS     = new Set(['deleted', 'inaccessible', 'unknown']),
+    ABSENCE_DISPOSITIONS      = new Set(['deleted', 'inaccessible', 'unknown']),
     /**
      * Popularity telemetry sits OUTSIDE the community-event source families. It is refused at the
      * boundary rather than admitted-then-filtered, because an admitted row is durable history that
      * later surfaces (counts, Bird View, wake, claim) would have to keep re-excluding forever.
      */
-    POPULARITY_KINDS         = new Set([
+    POPULARITY_KINDS          = new Set([
         'repository.forked', 'repository.starred', 'repository.unstarred', 'repository.watched', 'repository.unwatched'
     ]),
     /**
      * Server-owned policy output. Attention eligibility is a zero-authority judgement made by a
      * server-side classifier and written in the same admission transaction — it is NOT connector
      * payload. Two consequences, both enforced here: a connector may not self-assert it (validation
-     * refuses), and it never enters the digest (so revising our policy can never masquerade as
+     * refuses), and it never enters any digest (so revising our policy can never masquerade as
      * connector corruption on an otherwise-identical batch).
      */
-    SERVER_POLICY_KEYS       = new Set(['attentionDisposition', 'attentionReason', 'eligibility', 'eligibilityReason', 'trustProjection']);
+    SERVER_POLICY_KEYS        = new Set(['attentionDisposition', 'attentionReason', 'eligibility', 'eligibilityReason', 'trustProjection']);
 
 /**
- * Returns an occurrence without server-owned policy fields, so the digest is computed over
- * connector-supplied payload only and stays stable across policy revisions.
- * @param {Object} occurrence
+ * Returns an observation without server-owned policy fields, so digests are computed over
+ * connector-supplied payload only and stay stable across policy revisions.
+ * @param {Object} observation
  * @returns {Object}
  */
-function connectorPayloadOf(occurrence) {
-    return Object.keys(occurrence)
+function connectorPayloadOf(observation) {
+    return Object.keys(observation)
         .filter(key => !SERVER_POLICY_KEYS.has(key))
         .reduce((out, key) => {
-            out[key] = occurrence[key];
+            out[key] = observation[key];
             return out
         }, {})
 }
@@ -60,7 +78,7 @@ function connectorPayloadOf(occurrence) {
  * Object keys are sorted. Arrays deliberately keep their order here: array-ordering policy is a
  * per-collection semantic decision, not a global one, and a blanket sort is exactly the trap that
  * would silently weaken corruption detection. The one collection whose order is normalized is the
- * occurrence list, and that happens once, explicitly, in {@link canonicalBatchDigest}.
+ * observation list, and that happens once, explicitly, in {@link canonicalBatchDigest}.
  * @param {*} value
  * @returns {String}
  */
@@ -77,48 +95,83 @@ function canonicalize(value) {
 }
 
 /**
- * @summary The corruption detector: a stable digest over a batch's semantic payload.
+ * @summary The stable identity of one observed change — the same across retries, distinct per
+ * revision. It is derived from `(sourceInstanceId, providerEntityId, occurrenceKind,
+ * occurrenceCoordinate)`, NOT minted per insert, so the same observation arriving in two different
+ * batches shares one identity (dedup) while a genuine revision — which carries a different
+ * `occurrenceCoordinate` — is a new identity and a new immutable fact.
+ * @param {String} sourceInstanceId
+ * @param {Object} observation
+ * @returns {String} `occ:<hex>`
+ */
+export function occurrenceIdentity(sourceInstanceId, observation) {
+    const key = canonicalize([sourceInstanceId, observation.providerEntityId, observation.occurrenceKind, observation.occurrenceCoordinate]);
+
+    return `occ:${crypto.createHash('sha256').update(key).digest('hex')}`
+}
+
+/**
+ * @summary The per-observation content digest over its connector payload. Admission uses
+ * `(occurrenceIdentity, observationDigest)` as the dedup key: same identity + same digest is a
+ * retry; same identity + different digest is an integrity conflict.
+ * @param {Object} observation
+ * @returns {String} `sha256:<hex>`
+ */
+export function observationDigest(observation) {
+    return `sha256:${crypto.createHash('sha256').update(canonicalize(connectorPayloadOf(observation))).digest('hex')}`
+}
+
+/**
+ * @summary The batch corruption detector: a stable digest over the whole v1 connector payload.
  *
  * Admission treats `batchId` + this digest as the idempotency key — same id and same digest is a
- * retry, same id and a different digest is an integrity conflict. Transport-only fields are excluded
- * so a redelivery cannot masquerade as corruption.
+ * retry, same id and a different digest is an integrity conflict. Server policy is excluded so a
+ * policy revision cannot masquerade as corruption; everything else the connector supplies (including
+ * the opaque `nextProviderState` and the base/next checkpoint+inventory anchors) participates,
+ * because a batch that advances to a different next-state IS a different batch.
  *
- * **Ordering decision (deliberate, witness-pinned):** the occurrence collection is normalized
- * order-INSENSITIVELY. Ordering authority does not live in the payload — the admitted sequence is
- * server-assigned and distinct from batch identity — so array position carries no durable meaning,
- * and sorting normalizes away a non-authoritative field rather than discarding information. The
- * alternative would raise an integrity conflict every time a connector re-serializes from a map.
- *
- * Normalization is a SORT, never a de-duplication: duplicate multiplicity stays digest-visible,
- * because two occurrences of the same fact is a materially different claim from one.
+ * **Ordering decision (witness-pinned):** the observation collection is normalized order-INSENSITIVELY
+ * (ordering authority is the server-assigned admitted sequence, not payload position) but never
+ * de-duplicated — duplicate multiplicity stays digest-visible. Ordering inside an observation is
+ * preserved.
  * @param {Object} batch
  * @returns {String} `sha256:<hex>`
  */
 export function canonicalBatchDigest(batch) {
     const
-        {batchId, sourceInstanceId, registrationEpoch, partition, coverage, occurrences = []} = batch,
-        // Sort by each occurrence's own canonical form: a total, input-order-independent order.
-        // Server policy is stripped first so classification cannot shift a connector's digest.
-        orderedOccurrences = occurrences
-            .map(occurrence => canonicalize(connectorPayloadOf(occurrence)))
+        {
+            batchId, sourceInstanceId, resourceFamily, adapterSchemaVersion, providerStateSchemaVersion,
+            registrationEpoch, baseCheckpointVersion, baseInventoryHash, nextProviderState, nextInventoryHash,
+            coverage, observations = []
+        } = batch,
+        orderedObservations = observations
+            .map(observation => canonicalize(connectorPayloadOf(observation)))
             .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
         payload = canonicalize({
+            adapterSchemaVersion,
+            baseCheckpointVersion,
+            baseInventoryHash,
             batchId,
             coverage,
-            partition,
+            nextInventoryHash,
+            nextProviderState,
+            providerStateSchemaVersion,
             registrationEpoch,
+            resourceFamily,
             schemaVersion: BATCH_SCHEMA_VERSION,
             sourceInstanceId
         });
 
-    return `sha256:${crypto.createHash('sha256').update(`${payload}|[${orderedOccurrences.join(',')}]`).digest('hex')}`
+    return `sha256:${crypto.createHash('sha256').update(`${payload}|[${orderedObservations.join(',')}]`).digest('hex')}`
 }
 
 /**
  * @summary Validates a batch against the v1 contract. Pure — no I/O, no tenant resolution.
  *
- * Structural validity only: identity/authority checks (registration epoch currency, tenant scoping)
- * belong to the admission service, which owns the server-side authority those decisions require.
+ * Structural + type validity of the complete v1 shape: authority checks (registration epoch currency,
+ * tenant scoping, base checkpoint/inventory verification) belong to the admission service, which owns
+ * the server-side state those decisions require. A reduced shape must NOT validate — minting a
+ * versioned contract means the whole contract, or a loud refusal.
  * @param {Object} batch
  * @returns {{valid: Boolean, errors: String[]}}
  */
@@ -134,11 +187,38 @@ export function validateBatch(batch) {
     }
 
     REQUIRED_BATCH_KEYS.forEach(key => {
-        if (batch[key] === undefined || batch[key] === null) errors.push(`BATCH_MISSING_${key.toUpperCase()}`)
+        const present  = Object.prototype.hasOwnProperty.call(batch, key),
+              nullable = NULLABLE_BATCH_KEYS.has(key);
+
+        if (!present || (batch[key] === undefined) || (batch[key] === null && !nullable)) {
+            errors.push(`BATCH_MISSING_${key.toUpperCase()}`)
+        }
     });
 
     if (!Number.isInteger(batch.registrationEpoch) || batch.registrationEpoch < 1) {
         errors.push('BATCH_REGISTRATION_EPOCH_INVALID')
+    }
+
+    if (!Number.isInteger(batch.baseCheckpointVersion) || batch.baseCheckpointVersion < 0) {
+        errors.push('BATCH_BASE_CHECKPOINT_VERSION_INVALID')
+    }
+
+    // nextProviderState is opaque but bounded, schema-versioned, and prose/secret-free.
+    if (batch.nextProviderState !== undefined && batch.nextProviderState !== null) {
+        let bytes = 0;
+        try {
+            bytes = Buffer.byteLength(JSON.stringify(batch.nextProviderState), 'utf8')
+        } catch {
+            errors.push('BATCH_NEXT_PROVIDER_STATE_NOT_SERIALIZABLE')
+        }
+
+        if (bytes > MAX_PROVIDER_STATE_BYTES) errors.push('BATCH_NEXT_PROVIDER_STATE_TOO_LARGE');
+
+        if (batch.nextProviderState && typeof batch.nextProviderState === 'object') {
+            Object.keys(batch.nextProviderState).forEach(key => {
+                if (PROSE_KEYS.has(key)) errors.push(`BATCH_NEXT_PROVIDER_STATE_CARRIES_PROSE_${key.toUpperCase()}`)
+            })
+        }
     }
 
     const {coverage} = batch;
@@ -163,41 +243,41 @@ export function validateBatch(batch) {
         }
     }
 
-    if (!Array.isArray(batch.occurrences)) {
-        errors.push('BATCH_OCCURRENCES_NOT_AN_ARRAY')
+    if (!Array.isArray(batch.observations)) {
+        errors.push('BATCH_OBSERVATIONS_NOT_AN_ARRAY')
     } else {
-        batch.occurrences.forEach((occurrence, index) => {
-            if (!occurrence || typeof occurrence !== 'object') {
-                errors.push(`OCCURRENCE_${index}_NOT_AN_OBJECT`);
+        batch.observations.forEach((observation, index) => {
+            if (!observation || typeof observation !== 'object') {
+                errors.push(`OBSERVATION_${index}_NOT_AN_OBJECT`);
                 return
             }
 
-            REQUIRED_OCCURRENCE_KEYS.forEach(key => {
-                if (occurrence[key] === undefined || occurrence[key] === null) errors.push(`OCCURRENCE_${index}_MISSING_${key.toUpperCase()}`)
+            REQUIRED_OBSERVATION_KEYS.forEach(key => {
+                if (observation[key] === undefined || observation[key] === null) errors.push(`OBSERVATION_${index}_MISSING_${key.toUpperCase()}`)
             });
 
-            Object.keys(occurrence).forEach(key => {
-                if (PROSE_KEYS.has(key))         errors.push(`OCCURRENCE_${index}_CARRIES_PROSE_${key.toUpperCase()}`);
-                if (SERVER_POLICY_KEYS.has(key)) errors.push(`OCCURRENCE_${index}_ASSERTS_SERVER_POLICY_${key.toUpperCase()}`)
+            Object.keys(observation).forEach(key => {
+                if (PROSE_KEYS.has(key))         errors.push(`OBSERVATION_${index}_CARRIES_PROSE_${key.toUpperCase()}`);
+                if (SERVER_POLICY_KEYS.has(key)) errors.push(`OBSERVATION_${index}_ASSERTS_SERVER_POLICY_${key.toUpperCase()}`)
             });
 
-            if (occurrence.actorKind !== undefined && !ACTOR_KINDS.has(occurrence.actorKind)) {
-                errors.push(`OCCURRENCE_${index}_ACTOR_KIND_INVALID`)
+            if (observation.actorKind !== undefined && !ACTOR_KINDS.has(observation.actorKind)) {
+                errors.push(`OBSERVATION_${index}_ACTOR_KIND_INVALID`)
             }
 
-            if (occurrence.absence !== undefined && !ABSENCE_DISPOSITIONS.has(occurrence.absence)) {
-                errors.push(`OCCURRENCE_${index}_ABSENCE_DISPOSITION_INVALID`)
+            if (observation.absence !== undefined && !ABSENCE_DISPOSITIONS.has(observation.absence)) {
+                errors.push(`OBSERVATION_${index}_ABSENCE_DISPOSITION_INVALID`)
             }
 
             // `deleted` is the one absence disposition that asserts a fact about provider state, so it
             // requires explicit provider evidence (a tombstone id / deletion timestamp+actor) — an
             // enum value alone can be a permission loss masquerading as a deletion.
-            if (occurrence.absence === 'deleted' && (occurrence.deletionEvidence === undefined || occurrence.deletionEvidence === null)) {
-                errors.push(`OCCURRENCE_${index}_DELETED_WITHOUT_EVIDENCE`)
+            if (observation.absence === 'deleted' && (observation.deletionEvidence === undefined || observation.deletionEvidence === null)) {
+                errors.push(`OBSERVATION_${index}_DELETED_WITHOUT_EVIDENCE`)
             }
 
-            if (POPULARITY_KINDS.has(occurrence.occurrenceKind)) {
-                errors.push(`OCCURRENCE_${index}_POPULARITY_TELEMETRY_OUT_OF_SCOPE`)
+            if (POPULARITY_KINDS.has(observation.occurrenceKind)) {
+                errors.push(`OBSERVATION_${index}_POPULARITY_TELEMETRY_OUT_OF_SCOPE`)
             }
         })
     }

--- a/ai/services/memory-core/communityBatchContract.mjs
+++ b/ai/services/memory-core/communityBatchContract.mjs
@@ -22,6 +22,14 @@ const
     /** Absence is never inferred — it is one of three explicitly-evidenced dispositions. */
     ABSENCE_DISPOSITIONS     = new Set(['deleted', 'inaccessible', 'unknown']),
     /**
+     * Popularity telemetry sits OUTSIDE the community-event source families. It is refused at the
+     * boundary rather than admitted-then-filtered, because an admitted row is durable history that
+     * later surfaces (counts, Bird View, wake, claim) would have to keep re-excluding forever.
+     */
+    POPULARITY_KINDS         = new Set([
+        'repository.forked', 'repository.starred', 'repository.unstarred', 'repository.watched', 'repository.unwatched'
+    ]),
+    /**
      * Server-owned policy output. Attention eligibility is a zero-authority judgement made by a
      * server-side classifier and written in the same admission transaction — it is NOT connector
      * payload. Two consequences, both enforced here: a connector may not self-assert it (validation
@@ -174,6 +182,10 @@ export function validateBatch(batch) {
 
             if (occurrence.absence !== undefined && !ABSENCE_DISPOSITIONS.has(occurrence.absence)) {
                 errors.push(`OCCURRENCE_${index}_ABSENCE_DISPOSITION_INVALID`)
+            }
+
+            if (POPULARITY_KINDS.has(occurrence.occurrenceKind)) {
+                errors.push(`OCCURRENCE_${index}_POPULARITY_TELEMETRY_OUT_OF_SCOPE`)
             }
         })
     }

--- a/ai/services/memory-core/communityBatchContract.mjs
+++ b/ai/services/memory-core/communityBatchContract.mjs
@@ -1,0 +1,154 @@
+import crypto from 'crypto';
+
+/**
+ * @summary The versioned canonical batch contract for community-activity admission.
+ * Providers acquire and normalize; Memory Core validates and admits. Bumping this string is a
+ * breaking contract change — admission refuses any batch that does not declare exactly this version,
+ * so an older connector fails loudly at the boundary instead of half-admitting an unknown shape.
+ * @member {String}
+ */
+export const BATCH_SCHEMA_VERSION = 'community-activity-batch.v1';
+
+const
+    REQUIRED_BATCH_KEYS      = ['schemaVersion', 'batchId', 'sourceInstanceId', 'registrationEpoch', 'partition', 'coverage', 'occurrences'],
+    REQUIRED_COVERAGE_KEYS   = ['fromBasis', 'toBasis', 'complete'],
+    REQUIRED_OCCURRENCE_KEYS = ['providerEntityId', 'occurrenceKind', 'occurredAt'],
+    /**
+     * Provider prose never enters an automatic durable row. A batch carrying any of these is
+     * REJECTED rather than silently stripped: stripping would let a connector believe prose was
+     * admitted and stored, which is a worse contract than a loud refusal.
+     */
+    PROSE_KEYS               = new Set(['body', 'bodyHTML', 'bodyText', 'excerpt', 'summary', 'text', 'title']),
+    /** Absence is never inferred — it is one of three explicitly-evidenced dispositions. */
+    ABSENCE_DISPOSITIONS     = new Set(['deleted', 'inaccessible', 'unknown']);
+
+/**
+ * @summary Deterministically serializes a value so equal payloads yield equal strings.
+ *
+ * Object keys are sorted. Arrays deliberately keep their order here: array-ordering policy is a
+ * per-collection semantic decision, not a global one, and a blanket sort is exactly the trap that
+ * would silently weaken corruption detection. The one collection whose order is normalized is the
+ * occurrence list, and that happens once, explicitly, in {@link canonicalBatchDigest}.
+ * @param {*} value
+ * @returns {String}
+ */
+function canonicalize(value) {
+    if (Array.isArray(value)) {
+        return `[${value.map(canonicalize).join(',')}]`
+    }
+
+    if (value && typeof value === 'object') {
+        return `{${Object.keys(value).sort().map(key => `${JSON.stringify(key)}:${canonicalize(value[key])}`).join(',')}}`
+    }
+
+    return JSON.stringify(value === undefined ? null : value)
+}
+
+/**
+ * @summary The corruption detector: a stable digest over a batch's semantic payload.
+ *
+ * Admission treats `batchId` + this digest as the idempotency key — same id and same digest is a
+ * retry, same id and a different digest is an integrity conflict. Transport-only fields are excluded
+ * so a redelivery cannot masquerade as corruption.
+ *
+ * **Ordering decision (deliberate, witness-pinned):** the occurrence collection is normalized
+ * order-INSENSITIVELY. Ordering authority does not live in the payload — the admitted sequence is
+ * server-assigned and distinct from batch identity — so array position carries no durable meaning,
+ * and sorting normalizes away a non-authoritative field rather than discarding information. The
+ * alternative would raise an integrity conflict every time a connector re-serializes from a map.
+ * @param {Object} batch
+ * @returns {String} `sha256:<hex>`
+ */
+export function canonicalBatchDigest(batch) {
+    const
+        {batchId, sourceInstanceId, registrationEpoch, partition, coverage, occurrences = []} = batch,
+        // Sort by each occurrence's own canonical form: a total, input-order-independent order.
+        orderedOccurrences = occurrences
+            .map(canonicalize)
+            .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
+        payload = canonicalize({
+            batchId,
+            coverage,
+            partition,
+            registrationEpoch,
+            schemaVersion: BATCH_SCHEMA_VERSION,
+            sourceInstanceId
+        });
+
+    return `sha256:${crypto.createHash('sha256').update(`${payload}|[${orderedOccurrences.join(',')}]`).digest('hex')}`
+}
+
+/**
+ * @summary Validates a batch against the v1 contract. Pure — no I/O, no tenant resolution.
+ *
+ * Structural validity only: identity/authority checks (registration epoch currency, tenant scoping)
+ * belong to the admission service, which owns the server-side authority those decisions require.
+ * @param {Object} batch
+ * @returns {{valid: Boolean, errors: String[]}}
+ */
+export function validateBatch(batch) {
+    const errors = [];
+
+    if (!batch || typeof batch !== 'object') {
+        return {valid: false, errors: ['BATCH_NOT_AN_OBJECT']}
+    }
+
+    if (batch.schemaVersion !== BATCH_SCHEMA_VERSION) {
+        errors.push('BATCH_SCHEMA_VERSION_UNSUPPORTED')
+    }
+
+    REQUIRED_BATCH_KEYS.forEach(key => {
+        if (batch[key] === undefined || batch[key] === null) errors.push(`BATCH_MISSING_${key.toUpperCase()}`)
+    });
+
+    if (!Number.isInteger(batch.registrationEpoch) || batch.registrationEpoch < 1) {
+        errors.push('BATCH_REGISTRATION_EPOCH_INVALID')
+    }
+
+    const {coverage} = batch;
+
+    if (coverage && typeof coverage === 'object') {
+        REQUIRED_COVERAGE_KEYS.forEach(key => {
+            if (coverage[key] === undefined || coverage[key] === null) errors.push(`COVERAGE_MISSING_${key.toUpperCase()}`)
+        });
+
+        if (typeof coverage.complete === 'boolean') {
+            const gaps = coverage.gaps || [];
+
+            if (!Array.isArray(gaps)) {
+                errors.push('COVERAGE_GAPS_NOT_AN_ARRAY')
+            } else if (coverage.complete && gaps.length) {
+                // A window cannot be simultaneously complete and gapped — that is a dishonest
+                // coverage claim, and honest gaps are the whole point of carrying them.
+                errors.push('COVERAGE_COMPLETE_CONTRADICTS_GAPS')
+            } else if (!coverage.complete && !gaps.length) {
+                errors.push('COVERAGE_INCOMPLETE_WITHOUT_GAPS')
+            }
+        }
+    }
+
+    if (!Array.isArray(batch.occurrences)) {
+        errors.push('BATCH_OCCURRENCES_NOT_AN_ARRAY')
+    } else {
+        batch.occurrences.forEach((occurrence, index) => {
+            if (!occurrence || typeof occurrence !== 'object') {
+                errors.push(`OCCURRENCE_${index}_NOT_AN_OBJECT`);
+                return
+            }
+
+            REQUIRED_OCCURRENCE_KEYS.forEach(key => {
+                if (occurrence[key] === undefined || occurrence[key] === null) errors.push(`OCCURRENCE_${index}_MISSING_${key.toUpperCase()}`)
+            });
+
+            Object.keys(occurrence).forEach(key => {
+                if (PROSE_KEYS.has(key)) errors.push(`OCCURRENCE_${index}_CARRIES_PROSE_${key.toUpperCase()}`)
+            });
+
+            if (occurrence.absence !== undefined && !ABSENCE_DISPOSITIONS.has(occurrence.absence)) {
+                errors.push(`OCCURRENCE_${index}_ABSENCE_DISPOSITION_INVALID`)
+            }
+        })
+    }
+
+    return {valid: errors.length === 0, errors}
+}

--- a/ai/services/memory-core/communityBatchContract.mjs
+++ b/ai/services/memory-core/communityBatchContract.mjs
@@ -20,7 +20,30 @@ const
      */
     PROSE_KEYS               = new Set(['body', 'bodyHTML', 'bodyText', 'excerpt', 'summary', 'text', 'title']),
     /** Absence is never inferred — it is one of three explicitly-evidenced dispositions. */
-    ABSENCE_DISPOSITIONS     = new Set(['deleted', 'inaccessible', 'unknown']);
+    ABSENCE_DISPOSITIONS     = new Set(['deleted', 'inaccessible', 'unknown']),
+    /**
+     * Server-owned policy output. Attention eligibility is a zero-authority judgement made by a
+     * server-side classifier and written in the same admission transaction — it is NOT connector
+     * payload. Two consequences, both enforced here: a connector may not self-assert it (validation
+     * refuses), and it never enters the digest (so revising our policy can never masquerade as
+     * connector corruption on an otherwise-identical batch).
+     */
+    SERVER_POLICY_KEYS       = new Set(['attentionDisposition', 'attentionReason', 'eligibility', 'eligibilityReason', 'trustProjection']);
+
+/**
+ * Returns an occurrence without server-owned policy fields, so the digest is computed over
+ * connector-supplied payload only and stays stable across policy revisions.
+ * @param {Object} occurrence
+ * @returns {Object}
+ */
+function connectorPayloadOf(occurrence) {
+    return Object.keys(occurrence)
+        .filter(key => !SERVER_POLICY_KEYS.has(key))
+        .reduce((out, key) => {
+            out[key] = occurrence[key];
+            return out
+        }, {})
+}
 
 /**
  * @summary Deterministically serializes a value so equal payloads yield equal strings.
@@ -56,6 +79,9 @@ function canonicalize(value) {
  * server-assigned and distinct from batch identity — so array position carries no durable meaning,
  * and sorting normalizes away a non-authoritative field rather than discarding information. The
  * alternative would raise an integrity conflict every time a connector re-serializes from a map.
+ *
+ * Normalization is a SORT, never a de-duplication: duplicate multiplicity stays digest-visible,
+ * because two occurrences of the same fact is a materially different claim from one.
  * @param {Object} batch
  * @returns {String} `sha256:<hex>`
  */
@@ -63,8 +89,9 @@ export function canonicalBatchDigest(batch) {
     const
         {batchId, sourceInstanceId, registrationEpoch, partition, coverage, occurrences = []} = batch,
         // Sort by each occurrence's own canonical form: a total, input-order-independent order.
+        // Server policy is stripped first so classification cannot shift a connector's digest.
         orderedOccurrences = occurrences
-            .map(canonicalize)
+            .map(occurrence => canonicalize(connectorPayloadOf(occurrence)))
             .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0)),
         payload = canonicalize({
             batchId,
@@ -141,7 +168,8 @@ export function validateBatch(batch) {
             });
 
             Object.keys(occurrence).forEach(key => {
-                if (PROSE_KEYS.has(key)) errors.push(`OCCURRENCE_${index}_CARRIES_PROSE_${key.toUpperCase()}`)
+                if (PROSE_KEYS.has(key))         errors.push(`OCCURRENCE_${index}_CARRIES_PROSE_${key.toUpperCase()}`);
+                if (SERVER_POLICY_KEYS.has(key)) errors.push(`OCCURRENCE_${index}_ASSERTS_SERVER_POLICY_${key.toUpperCase()}`)
             });
 
             if (occurrence.absence !== undefined && !ABSENCE_DISPOSITIONS.has(occurrence.absence)) {

--- a/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
@@ -22,10 +22,9 @@ import {BATCH_SCHEMA_VERSION} from '../../../../../../ai/services/memory-core/co
 import RequestContextService  from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
 
 /**
- * @summary Admission witnesses: the epoch fence and the digest-keyed idempotency contract.
- *
- * The two that matter most are the conflict paths — a same-id/different-digest batch must never
- * silently overwrite durable history, and a stale or revoked registration epoch must never admit.
+ * @summary Admission witnesses for the full v1 contract: the folded serialized transaction, the epoch
+ * fence inside the boundary, partition-scoped receipts, observation-identity dedup, and the base→next
+ * checkpoint CAS. The four reviewer boundary probes appear as the last five cases.
  */
 test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () => {
     let AdmissionService, SourceRegistryService, originalEnv, testDbPath;
@@ -42,32 +41,47 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
         },
 
         ATTENTION_POLICY = {
-            responseBearingKinds     : ['issue.opened', 'issue.comment', 'pull.opened', 'discussion.created'],
+            responseBearingKinds     : ['issue.opened', 'issue.comment', 'pull.opened'],
             rosteredActorIds         : ['neo-opus-ada', 'neo-gpt'],
             recordedActorDispositions: {}
         },
 
-        occurrence = (id, over = {}) => ({
-            providerEntityId: id,
-            occurrenceKind  : 'issue.opened',
-            occurredAt      : '2026-07-18T10:00:00Z',
-            actorId         : 'external-human',
-            actorKind       : 'user',
+        observation = (entityId, over = {}) => ({
+            providerEntityId    : entityId,
+            occurrenceKind      : 'issue.opened',
+            occurrenceCoordinate: `${entityId}:create`,
+            occurredAt          : '2026-07-18T10:00:00Z',
+            actorId             : 'external-human',
+            actorKind           : 'user',
             ...over
         }),
 
-        batch = (sourceInstanceId, over = {}) => ({
-            schemaVersion    : BATCH_SCHEMA_VERSION,
-            batchId          : 'batch-1',
+        // A v1 batch declaring an explicit checkpoint basis (default: the initial 0/null).
+        batchAt = (sourceInstanceId, {batchId = 'batch-1', resourceFamily = 'issues', baseCheckpointVersion = 0,
+                                       baseInventoryHash = null, observations, ...over} = {}) => ({
+            schemaVersion             : BATCH_SCHEMA_VERSION,
             sourceInstanceId,
-            registrationEpoch: 2,
-            partition        : 'issues',
-            coverage         : {fromBasis: 'c1', toBasis: 'c9', complete: true},
-            occurrences      : [occurrence('e1'), occurrence('e2')],
+            resourceFamily,
+            adapterSchemaVersion      : 'github-issue.v1',
+            providerStateSchemaVersion: 'gh-state.v1',
+            registrationEpoch         : 2,
+            baseCheckpointVersion,
+            baseInventoryHash,
+            batchId,
+            observations              : observations || [observation('e1'), observation('e2')],
+            nextProviderState         : {cursor: batchId},
+            nextInventoryHash         : `inv-${batchId}`,
+            coverage                  : {fromBasis: 'c1', toBasis: 'c9', complete: true},
             ...over
         }),
 
-        /** Registers a source and drives it to ACTIVE@2, returning its id. */
+        // Chains a follow-on batch onto the basis a prior receipt established.
+        chained = (sourceInstanceId, priorReceipt, over = {}) => batchAt(sourceInstanceId, {
+            baseCheckpointVersion: priorReceipt.nextCheckpointVersion,
+            baseInventoryHash    : priorReceipt.nextInventoryHash,
+            ...over
+        }),
+
         activeSource = () => {
             SourceRegistryService.localSubjectId = SUBJECT;
 
@@ -112,56 +126,57 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
     });
 
     test.beforeEach(() => {
-        AdmissionService.db.exec('DELETE FROM mc_community_batch_receipt;');
-        AdmissionService.db.exec('DELETE FROM mc_community_occurrence; DELETE FROM mc_community_checkpoint;');
+        AdmissionService.db.exec('DELETE FROM mc_community_batch_receipt; DELETE FROM mc_community_observation; DELETE FROM mc_community_checkpoint;');
         SourceRegistryService.db.exec('DELETE FROM mc_source_registration;');
         SourceRegistryService.localSubjectId = SUBJECT;
-        AdmissionService.attentionPolicy     = ATTENTION_POLICY;
+        AdmissionService.attentionPolicy      = ATTENTION_POLICY;
     });
 
-    test('a valid batch on an ACTIVE source at the current epoch is admitted with a receipt', () => {
+    // ---------------------------------------------------------------- admission + fence
+
+    test('a valid batch on an ACTIVE source admits, receipts, and advances the checkpoint in one step', () => {
         const id     = activeSource(),
-              result = AdmissionService.admitBatch(batch(id));
+              result = AdmissionService.admitBatch(batchAt(id));
 
         expect(result.status).toBe('accepted');
         expect(result.receipt.admittedSequence).toBe(1);
-        expect(result.receipt.occurrenceCount).toBe(2);
-        expect(result.receipt.digest).toBe(result.digest);
+        expect(result.receipt.observationCount).toBe(2);
+        expect(result.receipt.nextCheckpointVersion).toBe(1);
+        expect(result.checkpoint.checkpointVersion, 'the partition advanced atomically with the receipt').toBe(1);
+        expect(result.checkpoint.inventoryHash).toBe('inv-batch-1');
     });
 
-    test('the same batchId with the same digest is an idempotent retry — no second receipt', () => {
+    test('the same batchId + same digest is an idempotent retry — no second receipt', () => {
         const id    = activeSource(),
-              first = AdmissionService.admitBatch(batch(id));
+              first = AdmissionService.admitBatch(batchAt(id));
 
-        // Same payload, occurrences deliberately reordered: still the same batch.
-        const retry = AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e2'), occurrence('e1')]}));
+        const retry = AdmissionService.admitBatch(batchAt(id, {observations: [observation('e2'), observation('e1')]}));
 
         expect(retry.status).toBe('idempotent');
         expect(retry.receipt.receiptId).toBe(first.receipt.receiptId);
-        expect(retry.receipt.admittedSequence).toBe(1);
-        expect(receiptCount(), 'a retry must not mint a second receipt').toBe(1);
-    });
-
-    test('the same batchId with a DIFFERENT digest is an integrity conflict, never an overwrite', () => {
-        const id    = activeSource(),
-              first = AdmissionService.admitBatch(batch(id));
-
-        const conflicting = AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {occurrenceKind: 'issue.closed'})]}));
-
-        expect(conflicting.status).toBe('conflict');
-        expect(conflicting.reason).toBe('DIGEST_MISMATCH');
         expect(receiptCount()).toBe(1);
-        expect(AdmissionService.getReceipt(id, 'batch-1').digest, 'durable history is preserved')
-            .toBe(first.digest);
     });
 
-    test('a stale registration epoch cannot admit', () => {
-        const id = activeSource(), // ACTIVE@2
-              result = AdmissionService.admitBatch(batch(id, {registrationEpoch: 1}));
+    test('the same batchId + a DIFFERENT digest is an integrity conflict, never an overwrite', () => {
+        const id = activeSource();
+
+        AdmissionService.admitBatch(batchAt(id));
+
+        const conflict = AdmissionService.admitBatch(batchAt(id, {observations: [observation('e1', {occurrenceKind: 'issue.closed'})]}));
+
+        expect(conflict.status).toBe('conflict');
+        expect(conflict.reason).toBe('DIGEST_MISMATCH');
+        expect(receiptCount()).toBe(1);
+    });
+
+    test('a stale registration epoch cannot admit (fence is inside the transaction)', () => {
+        const id     = activeSource(),
+              result = AdmissionService.admitBatch(batchAt(id, {registrationEpoch: 1}));
 
         expect(result.status).toBe('conflict');
         expect(result.reason).toBe('REGISTRATION_NOT_ADMISSIBLE');
         expect(receiptCount()).toBe(0);
+        expect(AdmissionService.getCheckpoint(id, 'issues'), 'no partial checkpoint advance').toBeNull();
     });
 
     test('a revoked source cannot admit, even at its last-active epoch', () => {
@@ -169,339 +184,205 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
 
         SourceRegistryService.transitionLifecycle(id, 'REVOKED', {expectedState: 'ACTIVE', expectedEpoch: 2});
 
-        const result = AdmissionService.admitBatch(batch(id));
-
-        expect(result.status).toBe('conflict');
-        expect(result.reason).toBe('REGISTRATION_NOT_ADMISSIBLE');
+        expect(AdmissionService.admitBatch(batchAt(id)).reason).toBe('REGISTRATION_NOT_ADMISSIBLE');
         expect(receiptCount()).toBe(0);
     });
 
     test('a schema-invalid batch is refused and writes nothing', () => {
         const id     = activeSource(),
-              result = AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {title: 'prose'})]}));
+              result = AdmissionService.admitBatch(batchAt(id, {observations: [observation('e1', {title: 'prose'})]}));
 
         expect(result.status).toBe('conflict');
         expect(result.reason).toBe('SCHEMA_INVALID');
-        expect(result.errors).toContain('OCCURRENCE_0_CARRIES_PROSE_TITLE');
+        expect(result.errors).toContain('OBSERVATION_0_CARRIES_PROSE_TITLE');
         expect(receiptCount()).toBe(0);
     });
 
-    test('admitted sequence is monotonic across distinct batches', () => {
-        const id = activeSource();
+    // ---------------------------------------------------------------- checkpoint CAS (folded)
 
-        expect(AdmissionService.admitBatch(batch(id, {batchId: 'batch-1'})).receipt.admittedSequence).toBe(1);
-        expect(AdmissionService.admitBatch(batch(id, {batchId: 'batch-2'})).receipt.admittedSequence).toBe(2);
-        expect(AdmissionService.admitBatch(batch(id, {batchId: 'batch-3'})).receipt.admittedSequence).toBe(3);
-    });
-
-    // ---------------------------------------------------------------- the occurrence ledger
-
-    test('the ledger commits with its receipt and carries a distinct occurrence identity', () => {
-        const id     = activeSource(),
-              result = AdmissionService.admitBatch(batch(id)),
-              ledger = AdmissionService.listOccurrences(id);
-
-        expect(ledger).toHaveLength(2);
-        expect(ledger[0].receiptId, 'each occurrence names the receipt that admitted it').toBe(result.receipt.receiptId);
-        expect(ledger[0].admittedSequence).toBe(result.receipt.admittedSequence);
-
-        // The four identities stay separable — that separation IS the contract.
-        const [first] = ledger;
-        expect(first.occurrenceId).not.toBe(first.providerEntityId);
-        expect(first.occurrenceId).not.toBe(first.receiptId);
-        expect(first.occurrenceId).not.toBe(String(first.admittedSequence));
-        expect(new Set(ledger.map(o => o.occurrenceId)).size, 'occurrence ids are unique per fact').toBe(2);
-    });
-
-    test('an idempotent retry does NOT duplicate ledger rows', () => {
-        const id = activeSource();
-
-        AdmissionService.admitBatch(batch(id));
-        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e2'), occurrence('e1')]}));
-
-        expect(AdmissionService.listOccurrences(id), 'a retry must not double durable history').toHaveLength(2);
-    });
-
-    test('a rejected batch writes no ledger rows', () => {
-        const id = activeSource();
-
-        AdmissionService.admitBatch(batch(id, {registrationEpoch: 1}));                              // fenced
-        AdmissionService.admitBatch(batch(id, {batchId: 'b2', occurrences: [occurrence('e1', {title: 'p'})]})); // invalid
-
-        expect(AdmissionService.listOccurrences(id)).toHaveLength(0);
-    });
-
-    test('a revision is a NEW occurrence — the row it revises is never mutated', () => {
-        const id       = activeSource(),
-              admitted = AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1')]})),
-              original = AdmissionService.listOccurrences(id, {providerEntityId: 'e1'})[0];
-
-        AdmissionService.admitBatch(batch(id, {
-            batchId    : 'batch-2',
-            occurrences: [occurrence('e1', {occurrenceKind: 'issue.edited', revisionOf: original.occurrenceId})]
-        }));
-
-        const history = AdmissionService.listOccurrences(id, {providerEntityId: 'e1'});
-
-        expect(history, 'both the original and its revision are durable').toHaveLength(2);
-        expect(history[0].occurrenceId).toBe(original.occurrenceId);
-        expect(history[0].occurrenceKind, 'the original is untouched').toBe('issue.opened');
-        expect(history[1].revisionOf).toBe(original.occurrenceId);
-        expect(history[1].admittedSequence).toBeGreaterThan(history[0].admittedSequence);
-        expect(admitted.status).toBe('accepted');
-    });
-
-    test('an evidenced absence disposition is persisted verbatim', () => {
-        const id = activeSource();
-
-        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {absence: 'deleted', deletionEvidence: {tombstoneId: 't-1', deletedAt: '2026-07-18T11:00:00Z'}})]}));
-
-        expect(AdmissionService.listOccurrences(id)[0].absence).toBe('deleted');
-    });
-
-    // ---------------------------------------------------------------- checkpoint CAS
-
-    test('a checkpoint claims an unset partition only on a durably-accepted receipt', () => {
-        const id      = activeSource(),
-              receipt = AdmissionService.admitBatch(batch(id)).receipt,
-              result  = AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c9', receiptId: receipt.receiptId});
-
-        expect(result.status).toBe('advanced');
-        expect(result.checkpoint.basis).toBe('c9');
-        expect(result.checkpoint.lastReceiptId).toBe(receipt.receiptId);
-    });
-
-    test('a checkpoint never advances on a receipt that is not durable', () => {
-        const id = activeSource();
-
-        AdmissionService.admitBatch(batch(id));
-
-        const result = AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c9', receiptId: 'no-such-receipt'});
-
-        expect(result.status).toBe('conflict');
-        expect(result.reason).toBe('RECEIPT_NOT_DURABLE');
-        expect(AdmissionService.getCheckpoint(id, 'issues'), 'nothing was written').toBeNull();
-    });
-
-    test('advancing from the current basis succeeds; a STALE basis conflicts without regressing', () => {
+    test('a chained batch advances; a stale base is refused without regressing', () => {
         const id = activeSource(),
-              r1 = AdmissionService.admitBatch(batch(id, {batchId: 'b1'})).receipt,
-              r2 = AdmissionService.admitBatch(batch(id, {batchId: 'b2'})).receipt;
+              r1 = AdmissionService.admitBatch(batchAt(id, {batchId: 'b1'})).receipt;
 
-        AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c9', receiptId: r1.receiptId});
+        const good = AdmissionService.admitBatch(chained(id, r1, {batchId: 'b2', observations: [observation('e3')]}));
+        expect(good.status).toBe('accepted');
+        expect(good.checkpoint.checkpointVersion).toBe(2);
 
-        const good = AdmissionService.advanceCheckpoint(id, 'issues', {expectedBasis: 'c9', toBasis: 'c14', receiptId: r2.receiptId});
-        expect(good.status).toBe('advanced');
-        expect(good.checkpoint.basis).toBe('c14');
-
-        // A writer still holding the pre-advance view must not drag the cursor backwards.
-        const stale = AdmissionService.advanceCheckpoint(id, 'issues', {expectedBasis: 'c9', toBasis: 'c11', receiptId: r2.receiptId});
-
+        // A connector still on the original basis 0 must not clobber the advanced cursor.
+        const stale = AdmissionService.admitBatch(batchAt(id, {batchId: 'b3', baseCheckpointVersion: 0, observations: [observation('e4')]}));
         expect(stale.status).toBe('conflict');
-        expect(stale.reason).toBe('BASIS_MISMATCH');
-        expect(stale.checkpoint.basis, 'the conflict returns current server state, unadvanced').toBe('c14');
+        expect(stale.reason).toBe('STALE_BASIS');
+        expect(AdmissionService.getCheckpoint(id, 'issues').checkpointVersion, 'unadvanced').toBe(2);
     });
 
-    test('two writers racing from the same observed basis — exactly one advances', () => {
+    test('the receipt binds the exact transition it established (a receipt for c1 to c9 cannot advance elsewhere)', () => {
         const id = activeSource(),
-              r1 = AdmissionService.admitBatch(batch(id, {batchId: 'b1'})).receipt,
-              r2 = AdmissionService.admitBatch(batch(id, {batchId: 'b2'})).receipt;
+              r1 = AdmissionService.admitBatch(batchAt(id, {batchId: 'b1'})).receipt;
 
-        AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c9', receiptId: r1.receiptId});
-
-        const winner = AdmissionService.advanceCheckpoint(id, 'issues', {expectedBasis: 'c9', toBasis: 'c20', receiptId: r2.receiptId}),
-              loser  = AdmissionService.advanceCheckpoint(id, 'issues', {expectedBasis: 'c9', toBasis: 'c30', receiptId: r2.receiptId});
-
-        expect([winner.status, loser.status]).toEqual(['advanced', 'conflict']);
-        expect(AdmissionService.getCheckpoint(id, 'issues').basis, 'the loser did not overwrite the winner').toBe('c20');
+        // The receipt persisted base 0 -> next 1 with next inventory inv-b1; any batch claiming a base
+        // other than exactly (1, inv-b1) is refused, so the transition is not free-floating.
+        expect(AdmissionService.admitBatch(batchAt(id, {batchId: 'b2', baseCheckpointVersion: 1, baseInventoryHash: 'inv-WRONG', observations: [observation('e3')]})).reason).toBe('STALE_BASIS');
+        expect(r1.baseCheckpointVersion).toBe(0);
+        expect(r1.nextCheckpointVersion).toBe(1);
     });
 
-    test('a second claimant on an unset partition conflicts rather than clobbering', () => {
+    test('admitted sequence is monotonic across chained batches', () => {
         const id = activeSource(),
-              r1 = AdmissionService.admitBatch(batch(id, {batchId: 'b1'})).receipt,
-              r2 = AdmissionService.admitBatch(batch(id, {batchId: 'b2'})).receipt;
+              r1 = AdmissionService.admitBatch(batchAt(id, {batchId: 'b1'})).receipt,
+              r2 = AdmissionService.admitBatch(chained(id, r1, {batchId: 'b2', observations: [observation('e3')]})).receipt,
+              r3 = AdmissionService.admitBatch(chained(id, r2, {batchId: 'b3', observations: [observation('e4')]})).receipt;
 
-        expect(AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c9', receiptId: r1.receiptId}).status).toBe('advanced');
-
-        const second = AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c99', receiptId: r2.receiptId});
-
-        expect(second.status).toBe('conflict');
-        expect(second.checkpoint.basis).toBe('c9');
+        expect([r1.admittedSequence, r2.admittedSequence, r3.admittedSequence]).toEqual([1, 2, 3]);
     });
 
-    test('checkpoints are per-partition, not per-source', () => {
-        const id      = activeSource(),
-              receipt = AdmissionService.admitBatch(batch(id)).receipt;
-
-        AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c9', receiptId: receipt.receiptId});
-
-        expect(AdmissionService.getCheckpoint(id, 'pulls'), 'a sibling partition is independently unset').toBeNull();
-    });
-
-    // ---------------------------------------------------------------- attention eligibility
-
-    test('popularity telemetry cannot be admitted at all', () => {
+    test('checkpoints are per resource family — a sibling family is independently unset', () => {
         const id = activeSource();
 
-        ['repository.starred', 'repository.forked', 'repository.watched'].forEach((kind, i) => {
-            const result = AdmissionService.admitBatch(batch(id, {
-                batchId    : `pop-${i}`,
-                occurrences: [occurrence('e1', {occurrenceKind: kind})]
-            }));
+        AdmissionService.admitBatch(batchAt(id, {resourceFamily: 'issues'}));
 
-            expect(result.status).toBe('conflict');
-            expect(result.errors).toContain('OCCURRENCE_0_POPULARITY_TELEMETRY_OUT_OF_SCOPE');
-        });
-
-        expect(AdmissionService.listOccurrences(id), 'no popularity row ever becomes durable history').toHaveLength(0);
+        expect(AdmissionService.getCheckpoint(id, 'pulls')).toBeNull();
     });
+
+    test('the same batchId in two resource families does not collide (receipts are partition-scoped)', () => {
+        const id = activeSource();
+
+        expect(AdmissionService.admitBatch(batchAt(id, {batchId: 'shared', resourceFamily: 'issues'})).status).toBe('accepted');
+        expect(AdmissionService.admitBatch(batchAt(id, {batchId: 'shared', resourceFamily: 'pulls', observations: [observation('p1', {occurrenceKind: 'pull.opened'})]})).status).toBe('accepted');
+        expect(receiptCount()).toBe(2);
+    });
+
+    // ---------------------------------------------------------------- observation ledger (dedup / revision)
+
+    test('overlapping observations across different batchIds dedup by identity + digest', () => {
+        const id = activeSource(),
+              r1 = AdmissionService.admitBatch(batchAt(id, {batchId: 'b1', observations: [observation('e1')]})).receipt;
+
+        // b2 carries the SAME observation (same identity + digest) plus a new one.
+        AdmissionService.admitBatch(chained(id, r1, {batchId: 'b2', observations: [observation('e1'), observation('e2')]}));
+
+        const rows = AdmissionService.listObservations(id);
+        expect(rows, 'e1 admitted once despite arriving in two batches').toHaveLength(2);
+        expect(rows.filter(r => r.providerEntityId === 'e1')).toHaveLength(1);
+    });
+
+    test('the same occurrence identity with a different digest is an integrity conflict', () => {
+        const id = activeSource(),
+              r1 = AdmissionService.admitBatch(batchAt(id, {batchId: 'b1', observations: [observation('e1')]})).receipt;
+
+        // Same coordinate (identity) but mutated content -> different observation digest -> conflict.
+        const conflict = AdmissionService.admitBatch(chained(id, r1, {batchId: 'b2', observations: [observation('e1', {occurredAt: '2099-01-01T00:00:00Z'})]}));
+
+        expect(conflict.status).toBe('conflict');
+        expect(conflict.reason).toBe('OBSERVATION_DIGEST_MISMATCH');
+        expect(AdmissionService.listObservations(id), 'the conflicting batch rolled back entirely').toHaveLength(1);
+        expect(receiptCount(), 'no receipt for the aborted batch').toBe(1);
+    });
+
+    test('a genuine revision (new coordinate) is a new immutable fact, leaving the original untouched', () => {
+        const id = activeSource(),
+              r1 = AdmissionService.admitBatch(batchAt(id, {batchId: 'b1', observations: [observation('e1')]})).receipt;
+
+        AdmissionService.admitBatch(chained(id, r1, {batchId: 'b2', observations: [
+            observation('e1', {occurrenceKind: 'issue.edited', occurrenceCoordinate: 'e1:edit-1', revisionOf: 'e1:create'})
+        ]}));
+
+        const history = AdmissionService.listObservations(id, {providerEntityId: 'e1'});
+        expect(history).toHaveLength(2);
+        expect(history[0].occurrenceKind).toBe('issue.opened');
+        expect(history[1].occurrenceKind, 'the original is not overwritten').toBe('issue.edited');
+        expect(history[1].revisionOf).toBe('e1:create');
+    });
+
+    // ---------------------------------------------------------------- attention (§2.1)
 
     test('an external response-bearing occurrence is attention-eligible', () => {
         const id = activeSource();
 
-        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1')]}));
+        AdmissionService.admitBatch(batchAt(id, {observations: [observation('e1')]}));
 
-        const [row] = AdmissionService.listOccurrences(id);
+        const [row] = AdmissionService.listObservations(id);
         expect(row.attentionDisposition).toBe('eligible');
         expect(row.attentionReason).toBe('external-response-bearing');
     });
 
-    test('a rostered actor updates an item WITHOUT minting new attention', () => {
+    test('a bot is not attention-eligible in v1', () => {
         const id = activeSource();
 
-        AdmissionService.admitBatch(batch(id, {occurrences: [
-            occurrence('e1', {actorId: 'external-human'}),
-            occurrence('e1', {actorId: 'neo-opus-ada', occurrenceKind: 'issue.comment'})
-        ]}));
+        AdmissionService.admitBatch(batchAt(id, {observations: [observation('e1', {actorId: 'dependabot', actorKind: 'bot'})]}));
 
-        const rows = AdmissionService.listOccurrences(id, {providerEntityId: 'e1'});
-
-        expect(rows, 'the rostered occurrence is still durable history').toHaveLength(2);
-        expect(rows.filter(r => r.attentionDisposition === 'eligible')).toHaveLength(1);
-        expect(rows.find(r => r.actorId === 'neo-opus-ada').attentionReason).toBe('rostered-actor');
-    });
-
-    test('a bot is not attention-eligible in v1 — the explicit least-authority disposition', () => {
-        const id = activeSource();
-
-        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {actorId: 'dependabot', actorKind: 'bot'})]}));
-
-        const [row] = AdmissionService.listOccurrences(id);
-        expect(row.attentionDisposition).toBe('ineligible');
-        expect(row.attentionReason).toBe('bot-not-attention-eligible-v1');
+        expect(AdmissionService.listObservations(id)[0].attentionReason).toBe('bot-not-attention-eligible-v1');
     });
 
     test('a non-human actor kind fails closed — absent-from-any-list is NOT external-human eligibility', () => {
         const id = activeSource();
 
-        AdmissionService.admitBatch(batch(id, {occurrences: [
-            occurrence('e1', {actorId: 'some-org', actorKind: 'organization'}),
-            occurrence('e2', {actorId: 'a-puppet',  actorKind: 'mannequin'}),
-            occurrence('e3', {actorId: 'who',        actorKind: 'unknown'})
+        AdmissionService.admitBatch(batchAt(id, {observations: [
+            observation('e1', {actorId: 'an-org', actorKind: 'organization'}),
+            observation('e2', {actorId: 'a-bot-account', actorKind: 'unknown'})
         ]}));
 
-        const rows = AdmissionService.listOccurrences(id);
-        expect(rows.every(r => r.attentionDisposition === 'ineligible')).toBe(true);
-        expect(rows.every(r => r.attentionReason === 'actor-kind-not-reviewed-fail-closed')).toBe(true);
+        expect(AdmissionService.listObservations(id).every(r => r.attentionReason === 'actor-kind-not-reviewed-fail-closed')).toBe(true);
     });
 
-    test('first-time and trusted-repeat external humans share basic eligibility (AC12)', () => {
+    test('a rostered actor updates an item WITHOUT minting new attention', () => {
         const id = activeSource();
 
-        AdmissionService.admitBatch(batch(id, {occurrences: [
-            occurrence('e1', {actorId: 'first-timer'}),
-            occurrence('e2', {actorId: 'repeat-contributor'})
+        AdmissionService.admitBatch(batchAt(id, {observations: [
+            observation('e1'),
+            observation('e1', {occurrenceKind: 'issue.comment', occurrenceCoordinate: 'e1:c1', actorId: 'neo-opus-ada'})
         ]}));
 
-        const rows = AdmissionService.listOccurrences(id);
-        expect(rows.every(r => r.attentionDisposition === 'eligible'), 'trust does not gate eligibility').toBe(true);
+        const rows = AdmissionService.listObservations(id, {providerEntityId: 'e1'});
+        expect(rows.filter(r => r.attentionDisposition === 'eligible')).toHaveLength(1);
+        expect(rows.find(r => r.actorId === 'neo-opus-ada').attentionReason).toBe('rostered-actor');
     });
 
-    test('a non-response-bearing kind is ineligible', () => {
+    test('popularity telemetry cannot be admitted at all', () => {
+        const id     = activeSource(),
+              result = AdmissionService.admitBatch(batchAt(id, {observations: [observation('e1', {occurrenceKind: 'repository.starred'})]}));
+
+        expect(result.status).toBe('conflict');
+        expect(result.errors).toContain('OBSERVATION_0_POPULARITY_TELEMETRY_OUT_OF_SCOPE');
+        expect(AdmissionService.listObservations(id)).toHaveLength(0);
+    });
+
+    test('deleted requires provider evidence; an evidenced deletion persists it', () => {
         const id = activeSource();
 
-        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {occurrenceKind: 'issue.labeled'})]}));
+        expect(AdmissionService.admitBatch(batchAt(id, {batchId: 'no-ev', observations: [observation('e1', {absence: 'deleted'})]})).reason).toBe('SCHEMA_INVALID');
 
-        expect(AdmissionService.listOccurrences(id)[0].attentionReason).toBe('not-response-bearing');
+        AdmissionService.admitBatch(batchAt(id, {observations: [observation('e9', {absence: 'deleted', deletionEvidence: {tombstoneId: 't1', deletedAt: '2026-07-18T11:00:00Z'}})]}));
+        expect(AdmissionService.listObservations(id)[0].deletionEvidence.tombstoneId).toBe('t1');
     });
 
-    test('admission fails loud without an injected attention policy — never dispositionless history', () => {
-        const id = activeSource();
+    // ---------------------------------------------------------------- ingress parity + fail-loud
 
-        AdmissionService.attentionPolicy = null;
-
-        expect(() => AdmissionService.admitBatch(batch(id))).toThrow('ATTENTION_POLICY_NOT_CONFIGURED');
-        expect(AdmissionService.listOccurrences(id)).toHaveLength(0);
-    });
-
-    // ---------------------------------------------------------------- ingress parity + delivery hazards
-
-    test('local and remote ingress reach ONE service and produce the same receipt contract', async () => {
+    test('local and remote ingress reach one service and produce the same receipt contract', async () => {
         const id    = activeSource(),
-              local = AdmissionService.admitBatch(batch(id));
+              local = AdmissionService.admitBatch(batchAt(id));
 
-        // "Remote": the same tenant arriving through an authenticated request context instead of the
-        // deployment subject. Same method, same durable state — the facades differ only in how the
-        // tenant is established.
         const remote = await RequestContextService.run({userId: SUBJECT}, () =>
-            AdmissionService.admitBatch(batch(id, {batchId: 'batch-2'})));
+            AdmissionService.admitBatch(batchAt(id)));   // same batchId + digest -> idempotent against the same row
 
-        expect(remote.status).toBe('accepted');
-        expect(Object.keys(remote.receipt).sort(), 'byte-equivalent receipt shape').toEqual(Object.keys(local.receipt).sort());
-
-        // The strongest parity evidence: a REMOTE retry of the LOCALLY admitted batch resolves
-        // idempotent against the very same durable row.
-        const crossRetry = await RequestContextService.run({userId: SUBJECT}, () =>
-            AdmissionService.admitBatch(batch(id)));
-
-        expect(crossRetry.status).toBe('idempotent');
-        expect(crossRetry.receipt.receiptId).toBe(local.receipt.receiptId);
+        expect(remote.status).toBe('idempotent');
+        expect(remote.receipt.receiptId).toBe(local.receipt.receiptId);
     });
 
     test('an auth failure cannot partially admit', () => {
         const id = activeSource();
 
-        SourceRegistryService.localSubjectId = null; // no deployment subject, no request context
-
-        expect(() => AdmissionService.admitBatch(batch(id))).toThrow('BATCH_ADMISSION_NO_TENANT');
+        SourceRegistryService.localSubjectId = null;
+        expect(() => AdmissionService.admitBatch(batchAt(id))).toThrow('BATCH_ADMISSION_NO_TENANT');
 
         SourceRegistryService.localSubjectId = SUBJECT;
-        expect(receiptCount(), 'nothing was written').toBe(0);
-        expect(AdmissionService.listOccurrences(id)).toHaveLength(0);
+        expect(receiptCount()).toBe(0);
     });
 
-    test('a lost-response retry returns the original receipt rather than re-admitting', () => {
-        const id    = activeSource(),
-              first = AdmissionService.admitBatch(batch(id)),
-              // The connector never saw the response and retries the identical batch.
-              retry = AdmissionService.admitBatch(batch(id));
-
-        expect(retry.status).toBe('idempotent');
-        expect(retry.receipt).toEqual(first.receipt);
-        expect(receiptCount()).toBe(1);
-        expect(AdmissionService.listOccurrences(id)).toHaveLength(2);
-    });
-
-    test('out-of-order delivery: admitted sequence records ACCEPTANCE order, not occurrence time', () => {
+    test('admission fails loud without an injected attention policy', () => {
         const id = activeSource();
 
-        const later = AdmissionService.admitBatch(batch(id, {
-            batchId    : 'b-late',
-            occurrences: [occurrence('e9', {occurredAt: '2026-07-18T20:00:00Z'})]
-        }));
-
-        const earlier = AdmissionService.admitBatch(batch(id, {
-            batchId    : 'b-early',
-            occurrences: [occurrence('e1', {occurredAt: '2026-07-18T08:00:00Z'})]
-        }));
-
-        expect(later.receipt.admittedSequence).toBe(1);
-        expect(earlier.receipt.admittedSequence, 'sequence is ours, not the provider clock').toBe(2);
-
-        const rows = AdmissionService.listOccurrences(id);
-        expect(rows).toHaveLength(2);
-        expect(rows.map(r => r.occurredAt), 'occurrence time is preserved verbatim').toEqual(
-            ['2026-07-18T20:00:00Z', '2026-07-18T08:00:00Z']
-        );
+        AdmissionService.attentionPolicy = null;
+        expect(() => AdmissionService.admitBatch(batchAt(id))).toThrow('ATTENTION_POLICY_NOT_CONFIGURED');
+        expect(AdmissionService.listObservations(id)).toHaveLength(0);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
@@ -1,0 +1,185 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'CommunityBatchAdmissionServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}         from '@playwright/test';
+import Neo                    from '../../../../../../src/Neo.mjs';
+import * as core              from '../../../../../../src/core/_export.mjs';
+import fs                     from 'fs';
+import path                   from 'path';
+import {BATCH_SCHEMA_VERSION} from '../../../../../../ai/services/memory-core/communityBatchContract.mjs';
+
+/**
+ * @summary Admission witnesses: the epoch fence and the digest-keyed idempotency contract.
+ *
+ * The two that matter most are the conflict paths — a same-id/different-digest batch must never
+ * silently overwrite durable history, and a stale or revoked registration epoch must never admit.
+ */
+test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () => {
+    let AdmissionService, SourceRegistryService, originalEnv, testDbPath;
+
+    const
+        SUBJECT = 'local-subject',
+
+        source = {
+            provider             : 'github',
+            canonicalProviderHost: 'github.com',
+            resourceKind         : 'repository',
+            providerResourceId   : 'neomjs/neo',
+            displayLocator       : 'neomjs/neo'
+        },
+
+        occurrence = (id, over = {}) => ({
+            providerEntityId: id,
+            occurrenceKind  : 'issue.opened',
+            occurredAt      : '2026-07-18T10:00:00Z',
+            ...over
+        }),
+
+        batch = (sourceInstanceId, over = {}) => ({
+            schemaVersion    : BATCH_SCHEMA_VERSION,
+            batchId          : 'batch-1',
+            sourceInstanceId,
+            registrationEpoch: 2,
+            partition        : 'issues',
+            coverage         : {fromBasis: 'c1', toBasis: 'c9', complete: true},
+            occurrences      : [occurrence('e1'), occurrence('e2')],
+            ...over
+        }),
+
+        /** Registers a source and drives it to ACTIVE@2, returning its id. */
+        activeSource = () => {
+            SourceRegistryService.localSubjectId = SUBJECT;
+
+            const {sourceInstanceId} = SourceRegistryService.register(source);
+
+            SourceRegistryService.transitionLifecycle(sourceInstanceId, 'PROVISIONED', {expectedState: 'REQUESTED', expectedEpoch: 1});
+            SourceRegistryService.transitionLifecycle(sourceInstanceId, 'ACTIVE',      {expectedState: 'PROVISIONED', expectedEpoch: 2});
+
+            return sourceInstanceId
+        },
+
+        receiptCount = () => AdmissionService.db.prepare('SELECT count(*) AS c FROM mc_community_batch_receipt').get().c;
+
+    test.beforeAll(async () => {
+        originalEnv = {
+            NEO_MEMORY_DB_PATH_TEST: process.env.NEO_MEMORY_DB_PATH_TEST,
+            UNIT_TEST_MODE         : process.env.UNIT_TEST_MODE
+        };
+
+        const tmpDir = path.resolve(process.cwd(), 'tmp');
+        if (!fs.existsSync(tmpDir)) fs.mkdirSync(tmpDir, {recursive: true});
+
+        testDbPath = path.join(tmpDir, `mc-batch-admission-test-${process.pid}-${Date.now()}.sqlite`);
+        for (const suffix of ['', '-wal', '-shm']) {
+            try { fs.unlinkSync(`${testDbPath}${suffix}`); } catch (e) {}
+        }
+
+        process.env.UNIT_TEST_MODE          = 'true';
+        process.env.NEO_MEMORY_DB_PATH_TEST = testDbPath;
+
+        SourceRegistryService = (await import('../../../../../../ai/services/memory-core/SourceRegistryService.mjs')).default;
+        AdmissionService      = (await import('../../../../../../ai/services/memory-core/CommunityBatchAdmissionService.mjs')).default;
+
+        await SourceRegistryService.initAsync();
+        await AdmissionService.initAsync();
+    });
+
+    test.afterAll(() => {
+        Object.entries(originalEnv).forEach(([k, v]) => {
+            v === undefined ? delete process.env[k] : (process.env[k] = v);
+        });
+    });
+
+    test.beforeEach(() => {
+        AdmissionService.db.exec('DELETE FROM mc_community_batch_receipt;');
+        SourceRegistryService.db.exec('DELETE FROM mc_source_registration;');
+        SourceRegistryService.localSubjectId = SUBJECT;
+    });
+
+    test('a valid batch on an ACTIVE source at the current epoch is admitted with a receipt', () => {
+        const id     = activeSource(),
+              result = AdmissionService.admitBatch(batch(id));
+
+        expect(result.status).toBe('accepted');
+        expect(result.receipt.admittedSequence).toBe(1);
+        expect(result.receipt.occurrenceCount).toBe(2);
+        expect(result.receipt.digest).toBe(result.digest);
+    });
+
+    test('the same batchId with the same digest is an idempotent retry — no second receipt', () => {
+        const id    = activeSource(),
+              first = AdmissionService.admitBatch(batch(id));
+
+        // Same payload, occurrences deliberately reordered: still the same batch.
+        const retry = AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e2'), occurrence('e1')]}));
+
+        expect(retry.status).toBe('idempotent');
+        expect(retry.receipt.receiptId).toBe(first.receipt.receiptId);
+        expect(retry.receipt.admittedSequence).toBe(1);
+        expect(receiptCount(), 'a retry must not mint a second receipt').toBe(1);
+    });
+
+    test('the same batchId with a DIFFERENT digest is an integrity conflict, never an overwrite', () => {
+        const id    = activeSource(),
+              first = AdmissionService.admitBatch(batch(id));
+
+        const conflicting = AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {occurrenceKind: 'issue.closed'})]}));
+
+        expect(conflicting.status).toBe('conflict');
+        expect(conflicting.reason).toBe('DIGEST_MISMATCH');
+        expect(receiptCount()).toBe(1);
+        expect(AdmissionService.getReceipt(id, 'batch-1').digest, 'durable history is preserved')
+            .toBe(first.digest);
+    });
+
+    test('a stale registration epoch cannot admit', () => {
+        const id = activeSource(), // ACTIVE@2
+              result = AdmissionService.admitBatch(batch(id, {registrationEpoch: 1}));
+
+        expect(result.status).toBe('conflict');
+        expect(result.reason).toBe('REGISTRATION_NOT_ADMISSIBLE');
+        expect(receiptCount()).toBe(0);
+    });
+
+    test('a revoked source cannot admit, even at its last-active epoch', () => {
+        const id = activeSource();
+
+        SourceRegistryService.transitionLifecycle(id, 'REVOKED', {expectedState: 'ACTIVE', expectedEpoch: 2});
+
+        const result = AdmissionService.admitBatch(batch(id));
+
+        expect(result.status).toBe('conflict');
+        expect(result.reason).toBe('REGISTRATION_NOT_ADMISSIBLE');
+        expect(receiptCount()).toBe(0);
+    });
+
+    test('a schema-invalid batch is refused and writes nothing', () => {
+        const id     = activeSource(),
+              result = AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {title: 'prose'})]}));
+
+        expect(result.status).toBe('conflict');
+        expect(result.reason).toBe('SCHEMA_INVALID');
+        expect(result.errors).toContain('OCCURRENCE_0_CARRIES_PROSE_TITLE');
+        expect(receiptCount()).toBe(0);
+    });
+
+    test('admitted sequence is monotonic across distinct batches', () => {
+        const id = activeSource();
+
+        expect(AdmissionService.admitBatch(batch(id, {batchId: 'batch-1'})).receipt.admittedSequence).toBe(1);
+        expect(AdmissionService.admitBatch(batch(id, {batchId: 'batch-2'})).receipt.admittedSequence).toBe(2);
+        expect(AdmissionService.admitBatch(batch(id, {batchId: 'batch-3'})).receipt.admittedSequence).toBe(3);
+    });
+});

--- a/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
@@ -184,8 +184,51 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
 
         SourceRegistryService.transitionLifecycle(id, 'REVOKED', {expectedState: 'ACTIVE', expectedEpoch: 2});
 
-        expect(AdmissionService.admitBatch(batchAt(id)).reason).toBe('REGISTRATION_NOT_ADMISSIBLE');
+        // The fence is step 1 of the transaction, so a rejected registration writes NOTHING —
+        // no receipt, no observations, no checkpoint advance (full atomicity of the gate).
+        const result = AdmissionService.admitBatch(batchAt(id));
+        expect(result.reason).toBe('REGISTRATION_NOT_ADMISSIBLE');
         expect(receiptCount()).toBe(0);
+        expect(AdmissionService.listObservations(id)).toHaveLength(0);
+        expect(AdmissionService.getCheckpoint(id, 'issues')).toBeNull();
+    });
+
+    test('the fence reads the registration through the admission connection, inside the transaction', () => {
+        const id = activeSource();
+
+        // A revoke committed through a SEPARATE connection to the same database (standing in for the
+        // registry connection or any concurrent lifecycle writer). If the fence read through a cached
+        // or foreign connection outside the admission transaction, it could admit under this revoke —
+        // exactly the two-connection interleaving that produced an accepted batch under REVOKED truth.
+        const Database = AdmissionService.db.constructor,
+              probe    = new Database(testDbPath);
+
+        probe.pragma('busy_timeout = 5000');
+        probe.prepare(
+            `UPDATE mc_source_registration SET lifecycle_state = 'REVOKED', updated_at = 1
+             WHERE source_instance_id = ?`
+        ).run(id);
+        probe.close();
+
+        const result = AdmissionService.admitBatch(batchAt(id));
+
+        expect(result.reason, 'the fence sees the cross-connection committed revoke').toBe('REGISTRATION_NOT_ADMISSIBLE');
+        expect(receiptCount()).toBe(0);
+        expect(AdmissionService.getCheckpoint(id, 'issues')).toBeNull();
+    });
+
+    test('an epoch bump from reprovisioning fences a batch declaring the old epoch', () => {
+        const id = activeSource();   // ACTIVE@2
+
+        AdmissionService.admitBatch(batchAt(id, {batchId: 'b1'}));   // valid at epoch 2
+
+        SourceRegistryService.transitionLifecycle(id, 'REVOKED',     {expectedState: 'ACTIVE', expectedEpoch: 2});
+        SourceRegistryService.transitionLifecycle(id, 'PROVISIONED', {expectedState: 'REVOKED', expectedEpoch: 2});   // epoch -> 3
+        SourceRegistryService.transitionLifecycle(id, 'ACTIVE',      {expectedState: 'PROVISIONED', expectedEpoch: 3});
+
+        // A batch still claiming epoch 2 is fenced even though the source is ACTIVE again at epoch 3.
+        expect(AdmissionService.admitBatch(batchAt(id, {batchId: 'b2', registrationEpoch: 2, observations: [observation('e9')]})).reason)
+            .toBe('REGISTRATION_NOT_ADMISSIBLE');
     });
 
     test('a schema-invalid batch is refused and writes nothing', () => {

--- a/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
@@ -182,4 +182,69 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
         expect(AdmissionService.admitBatch(batch(id, {batchId: 'batch-2'})).receipt.admittedSequence).toBe(2);
         expect(AdmissionService.admitBatch(batch(id, {batchId: 'batch-3'})).receipt.admittedSequence).toBe(3);
     });
+
+    // ---------------------------------------------------------------- the occurrence ledger
+
+    test('the ledger commits with its receipt and carries a distinct occurrence identity', () => {
+        const id     = activeSource(),
+              result = AdmissionService.admitBatch(batch(id)),
+              ledger = AdmissionService.listOccurrences(id);
+
+        expect(ledger).toHaveLength(2);
+        expect(ledger[0].receiptId, 'each occurrence names the receipt that admitted it').toBe(result.receipt.receiptId);
+        expect(ledger[0].admittedSequence).toBe(result.receipt.admittedSequence);
+
+        // The four identities stay separable — that separation IS the contract.
+        const [first] = ledger;
+        expect(first.occurrenceId).not.toBe(first.providerEntityId);
+        expect(first.occurrenceId).not.toBe(first.receiptId);
+        expect(first.occurrenceId).not.toBe(String(first.admittedSequence));
+        expect(new Set(ledger.map(o => o.occurrenceId)).size, 'occurrence ids are unique per fact').toBe(2);
+    });
+
+    test('an idempotent retry does NOT duplicate ledger rows', () => {
+        const id = activeSource();
+
+        AdmissionService.admitBatch(batch(id));
+        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e2'), occurrence('e1')]}));
+
+        expect(AdmissionService.listOccurrences(id), 'a retry must not double durable history').toHaveLength(2);
+    });
+
+    test('a rejected batch writes no ledger rows', () => {
+        const id = activeSource();
+
+        AdmissionService.admitBatch(batch(id, {registrationEpoch: 1}));                              // fenced
+        AdmissionService.admitBatch(batch(id, {batchId: 'b2', occurrences: [occurrence('e1', {title: 'p'})]})); // invalid
+
+        expect(AdmissionService.listOccurrences(id)).toHaveLength(0);
+    });
+
+    test('a revision is a NEW occurrence — the row it revises is never mutated', () => {
+        const id       = activeSource(),
+              admitted = AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1')]})),
+              original = AdmissionService.listOccurrences(id, {providerEntityId: 'e1'})[0];
+
+        AdmissionService.admitBatch(batch(id, {
+            batchId    : 'batch-2',
+            occurrences: [occurrence('e1', {occurrenceKind: 'issue.edited', revisionOf: original.occurrenceId})]
+        }));
+
+        const history = AdmissionService.listOccurrences(id, {providerEntityId: 'e1'});
+
+        expect(history, 'both the original and its revision are durable').toHaveLength(2);
+        expect(history[0].occurrenceId).toBe(original.occurrenceId);
+        expect(history[0].occurrenceKind, 'the original is untouched').toBe('issue.opened');
+        expect(history[1].revisionOf).toBe(original.occurrenceId);
+        expect(history[1].admittedSequence).toBeGreaterThan(history[0].admittedSequence);
+        expect(admitted.status).toBe('accepted');
+    });
+
+    test('an evidenced absence disposition is persisted verbatim', () => {
+        const id = activeSource();
+
+        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {absence: 'deleted'})]}));
+
+        expect(AdmissionService.listOccurrences(id)[0].absence).toBe('deleted');
+    });
 });

--- a/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
@@ -40,10 +40,18 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
             displayLocator       : 'neomjs/neo'
         },
 
+        ATTENTION_POLICY = {
+            responseBearingKinds   : ['issue.opened', 'issue.comment', 'pull.opened', 'discussion.created'],
+            rosteredActorIds       : ['neo-opus-ada', 'neo-gpt'],
+            botActorIds            : ['dependabot'],
+            recordedBotDispositions: {}
+        },
+
         occurrence = (id, over = {}) => ({
             providerEntityId: id,
             occurrenceKind  : 'issue.opened',
             occurredAt      : '2026-07-18T10:00:00Z',
+            actorId         : 'external-human',
             ...over
         }),
 
@@ -104,8 +112,10 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
 
     test.beforeEach(() => {
         AdmissionService.db.exec('DELETE FROM mc_community_batch_receipt;');
+        AdmissionService.db.exec('DELETE FROM mc_community_occurrence; DELETE FROM mc_community_checkpoint;');
         SourceRegistryService.db.exec('DELETE FROM mc_source_registration;');
         SourceRegistryService.localSubjectId = SUBJECT;
+        AdmissionService.attentionPolicy     = ATTENTION_POLICY;
     });
 
     test('a valid batch on an ACTIVE source at the current epoch is admitted with a receipt', () => {
@@ -325,5 +335,75 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
         AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c9', receiptId: receipt.receiptId});
 
         expect(AdmissionService.getCheckpoint(id, 'pulls'), 'a sibling partition is independently unset').toBeNull();
+    });
+
+    // ---------------------------------------------------------------- attention eligibility
+
+    test('popularity telemetry cannot be admitted at all', () => {
+        const id = activeSource();
+
+        ['repository.starred', 'repository.forked', 'repository.watched'].forEach((kind, i) => {
+            const result = AdmissionService.admitBatch(batch(id, {
+                batchId    : `pop-${i}`,
+                occurrences: [occurrence('e1', {occurrenceKind: kind})]
+            }));
+
+            expect(result.status).toBe('conflict');
+            expect(result.errors).toContain('OCCURRENCE_0_POPULARITY_TELEMETRY_OUT_OF_SCOPE');
+        });
+
+        expect(AdmissionService.listOccurrences(id), 'no popularity row ever becomes durable history').toHaveLength(0);
+    });
+
+    test('an external response-bearing occurrence is attention-eligible', () => {
+        const id = activeSource();
+
+        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1')]}));
+
+        const [row] = AdmissionService.listOccurrences(id);
+        expect(row.attentionDisposition).toBe('eligible');
+        expect(row.attentionReason).toBe('external-response-bearing');
+    });
+
+    test('a rostered actor updates an item WITHOUT minting new attention', () => {
+        const id = activeSource();
+
+        AdmissionService.admitBatch(batch(id, {occurrences: [
+            occurrence('e1', {actorId: 'external-human'}),
+            occurrence('e1', {actorId: 'neo-opus-ada', occurrenceKind: 'issue.comment'})
+        ]}));
+
+        const rows = AdmissionService.listOccurrences(id, {providerEntityId: 'e1'});
+
+        expect(rows, 'the rostered occurrence is still durable history').toHaveLength(2);
+        expect(rows.filter(r => r.attentionDisposition === 'eligible')).toHaveLength(1);
+        expect(rows.find(r => r.actorId === 'neo-opus-ada').attentionReason).toBe('rostered-actor');
+    });
+
+    test('an unrecorded external bot is UNDETERMINED, never inferred either way', () => {
+        const id = activeSource();
+
+        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {actorId: 'dependabot'})]}));
+
+        const [row] = AdmissionService.listOccurrences(id);
+        expect(row.attentionDisposition).toBe('undetermined');
+        expect(row.attentionReason).toBe('bot-disposition-not-recorded');
+    });
+
+    test('a non-response-bearing kind is ineligible', () => {
+        const id = activeSource();
+
+        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {occurrenceKind: 'issue.labeled'})]}));
+
+        expect(AdmissionService.listOccurrences(id)[0].attentionReason).toBe('not-response-bearing');
+    });
+
+    test('admission fails loud without an injected attention policy — never dispositionless history', () => {
+        const id = activeSource();
+
+        AdmissionService.attentionPolicy = null;
+
+        expect(() => AdmissionService.admitBatch(batch(id))).toThrow('ATTENTION_POLICY_NOT_CONFIGURED');
+        expect(AdmissionService.listOccurrences(id)).toHaveLength(0);
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
@@ -42,10 +42,9 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
         },
 
         ATTENTION_POLICY = {
-            responseBearingKinds   : ['issue.opened', 'issue.comment', 'pull.opened', 'discussion.created'],
-            rosteredActorIds       : ['neo-opus-ada', 'neo-gpt'],
-            botActorIds            : ['dependabot'],
-            recordedBotDispositions: {}
+            responseBearingKinds     : ['issue.opened', 'issue.comment', 'pull.opened', 'discussion.created'],
+            rosteredActorIds         : ['neo-opus-ada', 'neo-gpt'],
+            recordedActorDispositions: {}
         },
 
         occurrence = (id, over = {}) => ({
@@ -53,6 +52,7 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
             occurrenceKind  : 'issue.opened',
             occurredAt      : '2026-07-18T10:00:00Z',
             actorId         : 'external-human',
+            actorKind       : 'user',
             ...over
         }),
 
@@ -254,7 +254,7 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
     test('an evidenced absence disposition is persisted verbatim', () => {
         const id = activeSource();
 
-        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {absence: 'deleted'})]}));
+        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {absence: 'deleted', deletionEvidence: {tombstoneId: 't-1', deletedAt: '2026-07-18T11:00:00Z'}})]}));
 
         expect(AdmissionService.listOccurrences(id)[0].absence).toBe('deleted');
     });
@@ -381,14 +381,40 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
         expect(rows.find(r => r.actorId === 'neo-opus-ada').attentionReason).toBe('rostered-actor');
     });
 
-    test('an unrecorded external bot is UNDETERMINED, never inferred either way', () => {
+    test('a bot is not attention-eligible in v1 — the explicit least-authority disposition', () => {
         const id = activeSource();
 
-        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {actorId: 'dependabot'})]}));
+        AdmissionService.admitBatch(batch(id, {occurrences: [occurrence('e1', {actorId: 'dependabot', actorKind: 'bot'})]}));
 
         const [row] = AdmissionService.listOccurrences(id);
-        expect(row.attentionDisposition).toBe('undetermined');
-        expect(row.attentionReason).toBe('bot-disposition-not-recorded');
+        expect(row.attentionDisposition).toBe('ineligible');
+        expect(row.attentionReason).toBe('bot-not-attention-eligible-v1');
+    });
+
+    test('a non-human actor kind fails closed — absent-from-any-list is NOT external-human eligibility', () => {
+        const id = activeSource();
+
+        AdmissionService.admitBatch(batch(id, {occurrences: [
+            occurrence('e1', {actorId: 'some-org', actorKind: 'organization'}),
+            occurrence('e2', {actorId: 'a-puppet',  actorKind: 'mannequin'}),
+            occurrence('e3', {actorId: 'who',        actorKind: 'unknown'})
+        ]}));
+
+        const rows = AdmissionService.listOccurrences(id);
+        expect(rows.every(r => r.attentionDisposition === 'ineligible')).toBe(true);
+        expect(rows.every(r => r.attentionReason === 'actor-kind-not-reviewed-fail-closed')).toBe(true);
+    });
+
+    test('first-time and trusted-repeat external humans share basic eligibility (AC12)', () => {
+        const id = activeSource();
+
+        AdmissionService.admitBatch(batch(id, {occurrences: [
+            occurrence('e1', {actorId: 'first-timer'}),
+            occurrence('e2', {actorId: 'repeat-contributor'})
+        ]}));
+
+        const rows = AdmissionService.listOccurrences(id);
+        expect(rows.every(r => r.attentionDisposition === 'eligible'), 'trust does not gate eligibility').toBe(true);
     });
 
     test('a non-response-bearing kind is ineligible', () => {

--- a/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
@@ -19,6 +19,7 @@ import * as core              from '../../../../../../src/core/_export.mjs';
 import fs                     from 'fs';
 import path                   from 'path';
 import {BATCH_SCHEMA_VERSION} from '../../../../../../ai/services/memory-core/communityBatchContract.mjs';
+import RequestContextService  from '../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs';
 
 /**
  * @summary Admission witnesses: the epoch fence and the digest-keyed idempotency contract.
@@ -405,5 +406,76 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
 
         expect(() => AdmissionService.admitBatch(batch(id))).toThrow('ATTENTION_POLICY_NOT_CONFIGURED');
         expect(AdmissionService.listOccurrences(id)).toHaveLength(0);
+    });
+
+    // ---------------------------------------------------------------- ingress parity + delivery hazards
+
+    test('local and remote ingress reach ONE service and produce the same receipt contract', async () => {
+        const id    = activeSource(),
+              local = AdmissionService.admitBatch(batch(id));
+
+        // "Remote": the same tenant arriving through an authenticated request context instead of the
+        // deployment subject. Same method, same durable state — the facades differ only in how the
+        // tenant is established.
+        const remote = await RequestContextService.run({userId: SUBJECT}, () =>
+            AdmissionService.admitBatch(batch(id, {batchId: 'batch-2'})));
+
+        expect(remote.status).toBe('accepted');
+        expect(Object.keys(remote.receipt).sort(), 'byte-equivalent receipt shape').toEqual(Object.keys(local.receipt).sort());
+
+        // The strongest parity evidence: a REMOTE retry of the LOCALLY admitted batch resolves
+        // idempotent against the very same durable row.
+        const crossRetry = await RequestContextService.run({userId: SUBJECT}, () =>
+            AdmissionService.admitBatch(batch(id)));
+
+        expect(crossRetry.status).toBe('idempotent');
+        expect(crossRetry.receipt.receiptId).toBe(local.receipt.receiptId);
+    });
+
+    test('an auth failure cannot partially admit', () => {
+        const id = activeSource();
+
+        SourceRegistryService.localSubjectId = null; // no deployment subject, no request context
+
+        expect(() => AdmissionService.admitBatch(batch(id))).toThrow('BATCH_ADMISSION_NO_TENANT');
+
+        SourceRegistryService.localSubjectId = SUBJECT;
+        expect(receiptCount(), 'nothing was written').toBe(0);
+        expect(AdmissionService.listOccurrences(id)).toHaveLength(0);
+    });
+
+    test('a lost-response retry returns the original receipt rather than re-admitting', () => {
+        const id    = activeSource(),
+              first = AdmissionService.admitBatch(batch(id)),
+              // The connector never saw the response and retries the identical batch.
+              retry = AdmissionService.admitBatch(batch(id));
+
+        expect(retry.status).toBe('idempotent');
+        expect(retry.receipt).toEqual(first.receipt);
+        expect(receiptCount()).toBe(1);
+        expect(AdmissionService.listOccurrences(id)).toHaveLength(2);
+    });
+
+    test('out-of-order delivery: admitted sequence records ACCEPTANCE order, not occurrence time', () => {
+        const id = activeSource();
+
+        const later = AdmissionService.admitBatch(batch(id, {
+            batchId    : 'b-late',
+            occurrences: [occurrence('e9', {occurredAt: '2026-07-18T20:00:00Z'})]
+        }));
+
+        const earlier = AdmissionService.admitBatch(batch(id, {
+            batchId    : 'b-early',
+            occurrences: [occurrence('e1', {occurredAt: '2026-07-18T08:00:00Z'})]
+        }));
+
+        expect(later.receipt.admittedSequence).toBe(1);
+        expect(earlier.receipt.admittedSequence, 'sequence is ours, not the provider clock').toBe(2);
+
+        const rows = AdmissionService.listOccurrences(id);
+        expect(rows).toHaveLength(2);
+        expect(rows.map(r => r.occurredAt), 'occurrence time is preserved verbatim').toEqual(
+            ['2026-07-18T20:00:00Z', '2026-07-18T08:00:00Z']
+        );
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
@@ -247,4 +247,83 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
 
         expect(AdmissionService.listOccurrences(id)[0].absence).toBe('deleted');
     });
+
+    // ---------------------------------------------------------------- checkpoint CAS
+
+    test('a checkpoint claims an unset partition only on a durably-accepted receipt', () => {
+        const id      = activeSource(),
+              receipt = AdmissionService.admitBatch(batch(id)).receipt,
+              result  = AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c9', receiptId: receipt.receiptId});
+
+        expect(result.status).toBe('advanced');
+        expect(result.checkpoint.basis).toBe('c9');
+        expect(result.checkpoint.lastReceiptId).toBe(receipt.receiptId);
+    });
+
+    test('a checkpoint never advances on a receipt that is not durable', () => {
+        const id = activeSource();
+
+        AdmissionService.admitBatch(batch(id));
+
+        const result = AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c9', receiptId: 'no-such-receipt'});
+
+        expect(result.status).toBe('conflict');
+        expect(result.reason).toBe('RECEIPT_NOT_DURABLE');
+        expect(AdmissionService.getCheckpoint(id, 'issues'), 'nothing was written').toBeNull();
+    });
+
+    test('advancing from the current basis succeeds; a STALE basis conflicts without regressing', () => {
+        const id = activeSource(),
+              r1 = AdmissionService.admitBatch(batch(id, {batchId: 'b1'})).receipt,
+              r2 = AdmissionService.admitBatch(batch(id, {batchId: 'b2'})).receipt;
+
+        AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c9', receiptId: r1.receiptId});
+
+        const good = AdmissionService.advanceCheckpoint(id, 'issues', {expectedBasis: 'c9', toBasis: 'c14', receiptId: r2.receiptId});
+        expect(good.status).toBe('advanced');
+        expect(good.checkpoint.basis).toBe('c14');
+
+        // A writer still holding the pre-advance view must not drag the cursor backwards.
+        const stale = AdmissionService.advanceCheckpoint(id, 'issues', {expectedBasis: 'c9', toBasis: 'c11', receiptId: r2.receiptId});
+
+        expect(stale.status).toBe('conflict');
+        expect(stale.reason).toBe('BASIS_MISMATCH');
+        expect(stale.checkpoint.basis, 'the conflict returns current server state, unadvanced').toBe('c14');
+    });
+
+    test('two writers racing from the same observed basis — exactly one advances', () => {
+        const id = activeSource(),
+              r1 = AdmissionService.admitBatch(batch(id, {batchId: 'b1'})).receipt,
+              r2 = AdmissionService.admitBatch(batch(id, {batchId: 'b2'})).receipt;
+
+        AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c9', receiptId: r1.receiptId});
+
+        const winner = AdmissionService.advanceCheckpoint(id, 'issues', {expectedBasis: 'c9', toBasis: 'c20', receiptId: r2.receiptId}),
+              loser  = AdmissionService.advanceCheckpoint(id, 'issues', {expectedBasis: 'c9', toBasis: 'c30', receiptId: r2.receiptId});
+
+        expect([winner.status, loser.status]).toEqual(['advanced', 'conflict']);
+        expect(AdmissionService.getCheckpoint(id, 'issues').basis, 'the loser did not overwrite the winner').toBe('c20');
+    });
+
+    test('a second claimant on an unset partition conflicts rather than clobbering', () => {
+        const id = activeSource(),
+              r1 = AdmissionService.admitBatch(batch(id, {batchId: 'b1'})).receipt,
+              r2 = AdmissionService.admitBatch(batch(id, {batchId: 'b2'})).receipt;
+
+        expect(AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c9', receiptId: r1.receiptId}).status).toBe('advanced');
+
+        const second = AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c99', receiptId: r2.receiptId});
+
+        expect(second.status).toBe('conflict');
+        expect(second.checkpoint.basis).toBe('c9');
+    });
+
+    test('checkpoints are per-partition, not per-source', () => {
+        const id      = activeSource(),
+              receipt = AdmissionService.admitBatch(batch(id)).receipt;
+
+        AdmissionService.advanceCheckpoint(id, 'issues', {toBasis: 'c9', receiptId: receipt.receiptId});
+
+        expect(AdmissionService.getCheckpoint(id, 'pulls'), 'a sibling partition is independently unset').toBeNull();
+    });
 });

--- a/test/playwright/unit/ai/services/memory-core/communityBatchContract.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/communityBatchContract.spec.mjs
@@ -13,157 +13,139 @@ setup({
     }
 });
 
-import {test, expect}                                              from '@playwright/test';
-import Neo                                                         from '../../../../../../src/Neo.mjs';
-import * as core                                                   from '../../../../../../src/core/_export.mjs';
-import {BATCH_SCHEMA_VERSION, canonicalBatchDigest, validateBatch} from '../../../../../../ai/services/memory-core/communityBatchContract.mjs';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {
+    BATCH_SCHEMA_VERSION, MAX_PROVIDER_STATE_BYTES, canonicalBatchDigest, validateBatch,
+    occurrenceIdentity, observationDigest
+} from '../../../../../../ai/services/memory-core/communityBatchContract.mjs';
 
 /**
- * @summary Contract witnesses for community-activity batch admission.
- *
- * The load-bearing pair is the ordering pin: the occurrence COLLECTION is order-insensitive (a
- * connector re-serializing from a map must not raise an integrity conflict), while ordering INSIDE
- * an occurrence is preserved (nothing in the contract makes nested array order non-authoritative, and
- * silently normalizing it is precisely how corruption detection weakens without a test noticing).
+ * @summary Contract witnesses for the community-activity-batch.v1 shape: the corruption digest with
+ * its ordering decision, the stable occurrence identity, and full-shape validation.
  */
 test.describe('community-activity-batch.v1 contract', () => {
-    const occurrence = (id, over = {}) => ({
-        providerEntityId: id,
-        occurrenceKind  : 'issue.opened',
-        occurredAt      : '2026-07-18T10:00:00Z',
-        actorKind       : 'user',
+    const observation = (entityId, over = {}) => ({
+        providerEntityId    : entityId,
+        occurrenceKind      : 'issue.opened',
+        occurrenceCoordinate: `${entityId}:create`,
+        occurredAt          : '2026-07-18T10:00:00Z',
+        actorKind           : 'user',
         ...over
     });
 
     const batch = (over = {}) => ({
-        schemaVersion    : BATCH_SCHEMA_VERSION,
-        batchId          : 'batch-1',
-        sourceInstanceId : 'src-1',
-        registrationEpoch: 2,
-        partition        : 'issues',
-        coverage         : {fromBasis: 'c1', toBasis: 'c9', complete: true},
-        occurrences      : [occurrence('e1'), occurrence('e2')],
+        schemaVersion             : BATCH_SCHEMA_VERSION,
+        sourceInstanceId          : 'src-1',
+        resourceFamily            : 'issues',
+        adapterSchemaVersion      : 'github-issue.v1',
+        providerStateSchemaVersion: 'gh-state.v1',
+        registrationEpoch         : 2,
+        baseCheckpointVersion     : 0,
+        baseInventoryHash         : null,
+        batchId                   : 'batch-1',
+        observations              : [observation('e1'), observation('e2')],
+        nextProviderState         : {cursor: 'x'},
+        nextInventoryHash         : 'inv-1',
+        coverage                  : {fromBasis: 'c1', toBasis: 'c9', complete: true},
         ...over
     });
 
-    // ------------------------------------------------------------------ the ordering decision
+    // ------------------------------------------------------------------ the batch digest ordering
 
-    test('reordering the occurrence collection yields the SAME digest (retry, not corruption)', () => {
+    test('reordering observations yields the SAME digest (retry, not corruption)', () => {
         const forward  = batch(),
-              reversed = batch({occurrences: [...forward.occurrences].reverse()});
+              reversed = batch({observations: [...forward.observations].reverse()});
 
         expect(canonicalBatchDigest(reversed)).toBe(canonicalBatchDigest(forward));
     });
 
-    test('mutating any occurrence field yields a DIFFERENT digest (integrity conflict)', () => {
-        const base    = batch(),
-              mutated = batch({occurrences: [occurrence('e1'), occurrence('e2', {occurrenceKind: 'issue.closed'})]});
-
-        expect(canonicalBatchDigest(mutated)).not.toBe(canonicalBatchDigest(base));
-    });
-
-    test('ordering INSIDE an occurrence stays significant — no blanket array sort', () => {
-        const a = batch({occurrences: [occurrence('e1', {reactionKinds: ['x', 'y']})]}),
-              b = batch({occurrences: [occurrence('e1', {reactionKinds: ['y', 'x']})]});
-
-        expect(canonicalBatchDigest(b), 'a blanket sort would collapse these and weaken detection')
-            .not.toBe(canonicalBatchDigest(a));
+    test('mutating any observation field yields a DIFFERENT digest', () => {
+        expect(canonicalBatchDigest(batch({observations: [observation('e1'), observation('e2', {occurrenceKind: 'issue.closed'})]})))
+            .not.toBe(canonicalBatchDigest(batch()));
     });
 
     test('duplicate multiplicity stays digest-visible — normalization sorts, never dedupes', () => {
-        const once  = batch({occurrences: [occurrence('e1')]}),
-              twice = batch({occurrences: [occurrence('e1'), occurrence('e1')]});
-
-        expect(canonicalBatchDigest(twice), 'two occurrences of a fact is a different claim from one')
-            .not.toBe(canonicalBatchDigest(once));
+        expect(canonicalBatchDigest(batch({observations: [observation('e1'), observation('e1')]})))
+            .not.toBe(canonicalBatchDigest(batch({observations: [observation('e1')]})));
     });
 
-    test('server-side policy output is digest-EXTERNAL — classification cannot shift a connector digest', () => {
-        const connectorBatch = batch(),
-              classifiedRow  = batch({occurrences: [
-                  occurrence('e1', {attentionDisposition: 'eligible', attentionReason: 'external-author'}),
-                  occurrence('e2', {attentionDisposition: 'ineligible', attentionReason: 'rostered-actor'})
-              ]});
-
-        expect(canonicalBatchDigest(classifiedRow), 'a policy revision must never masquerade as connector corruption')
-            .toBe(canonicalBatchDigest(connectorBatch));
+    test('the opaque nextProviderState and the base/next anchors participate in the digest', () => {
+        expect(canonicalBatchDigest(batch({nextProviderState: {cursor: 'y'}}))).not.toBe(canonicalBatchDigest(batch()));
+        expect(canonicalBatchDigest(batch({nextInventoryHash: 'inv-2'}))).not.toBe(canonicalBatchDigest(batch()));
+        expect(canonicalBatchDigest(batch({resourceFamily: 'pulls'}))).not.toBe(canonicalBatchDigest(batch()));
     });
 
-    test('a connector may not self-assert eligibility (zero-authority)', () => {
-        const {valid, errors} = validateBatch(batch({occurrences: [occurrence('e1', {attentionDisposition: 'eligible'})]}));
+    // ------------------------------------------------------------------ occurrence identity
 
-        expect(valid).toBe(false);
-        expect(errors).toContain('OCCURRENCE_0_ASSERTS_SERVER_POLICY_ATTENTIONDISPOSITION');
+    test('occurrence identity is stable across batches and distinct per revision', () => {
+        const create = observation('e1'),
+              edit   = observation('e1', {occurrenceKind: 'issue.edited', occurrenceCoordinate: 'e1:edit-1'});
+
+        expect(occurrenceIdentity('src-1', create), 'same coordinate -> same identity')
+            .toBe(occurrenceIdentity('src-1', {...create}));
+        expect(occurrenceIdentity('src-1', edit), 'a revision has its own identity')
+            .not.toBe(occurrenceIdentity('src-1', create));
+        expect(occurrenceIdentity('src-2', create), 'identity is tenant-source scoped')
+            .not.toBe(occurrenceIdentity('src-1', create));
     });
 
-    test('digest is stable across key insertion order', () => {
-        const a = batch(),
-              b = {occurrences: a.occurrences, coverage: a.coverage, partition: a.partition,
-                   registrationEpoch: a.registrationEpoch, sourceInstanceId: a.sourceInstanceId,
-                   batchId          : a.batchId, schemaVersion: a.schemaVersion};
+    test('observation digest ignores server policy but tracks content', () => {
+        const base = observation('e1');
 
-        expect(canonicalBatchDigest(b)).toBe(canonicalBatchDigest(a));
+        expect(observationDigest({...base, attentionDisposition: 'eligible'}), 'server policy is digest-external')
+            .toBe(observationDigest(base));
+        expect(observationDigest({...base, occurredAt: '2099-01-01T00:00:00Z'})).not.toBe(observationDigest(base));
     });
 
-    test('batch identity fields participate in the digest', () => {
-        expect(canonicalBatchDigest(batch({registrationEpoch: 3}))).not.toBe(canonicalBatchDigest(batch()));
-        expect(canonicalBatchDigest(batch({partition: 'pulls'}))).not.toBe(canonicalBatchDigest(batch()));
-    });
+    // ------------------------------------------------------------------ validation (full v1 shape)
 
-    // ------------------------------------------------------------------ validation (AC1/AC6/AC7)
-
-    test('a well-formed batch validates', () => {
+    test('a well-formed v1 batch validates', () => {
         expect(validateBatch(batch())).toEqual({valid: true, errors: []});
     });
 
+    test('a reduced batch missing v1 authority fields is refused', () => {
+        const {resourceFamily, baseCheckpointVersion, nextInventoryHash, ...reduced} = batch();
+        const {valid, errors}                                                        = validateBatch(reduced);
+
+        expect(valid).toBe(false);
+        expect(errors).toEqual(expect.arrayContaining(['BATCH_MISSING_RESOURCEFAMILY', 'BATCH_MISSING_BASECHECKPOINTVERSION', 'BATCH_MISSING_NEXTINVENTORYHASH']));
+    });
+
     test('an unsupported schema version is refused', () => {
-        const {valid, errors} = validateBatch(batch({schemaVersion: 'community-activity-batch.v2'}));
-
-        expect(valid).toBe(false);
-        expect(errors).toContain('BATCH_SCHEMA_VERSION_UNSUPPORTED');
+        expect(validateBatch(batch({schemaVersion: 'community-activity-batch.v2'})).errors).toContain('BATCH_SCHEMA_VERSION_UNSUPPORTED');
     });
 
-    test('prose is REFUSED, not silently stripped', () => {
-        const {valid, errors} = validateBatch(batch({occurrences: [occurrence('e1', {title: 'Crash on load'})]}));
-
-        expect(valid).toBe(false);
-        expect(errors).toContain('OCCURRENCE_0_CARRIES_PROSE_TITLE');
+    test('an oversized nextProviderState is refused; prose in it is refused', () => {
+        const huge = {blob: 'x'.repeat(MAX_PROVIDER_STATE_BYTES + 10)};
+        expect(validateBatch(batch({nextProviderState: huge})).errors).toContain('BATCH_NEXT_PROVIDER_STATE_TOO_LARGE');
+        expect(validateBatch(batch({nextProviderState: {title: 'a title'}})).errors).toContain('BATCH_NEXT_PROVIDER_STATE_CARRIES_PROSE_TITLE');
     });
 
-    test('a complete window cannot also claim gaps, and an incomplete one must', () => {
-        expect(validateBatch(batch({coverage: {fromBasis: 'c1', toBasis: 'c9', complete: true, gaps: [{fromBasis: 'c4', toBasis: 'c5', reason: 'rate-limit'}]}})).errors)
+    test('prose on an observation is REFUSED, not silently stripped', () => {
+        expect(validateBatch(batch({observations: [observation('e1', {title: 'Crash'})]})).errors).toContain('OBSERVATION_0_CARRIES_PROSE_TITLE');
+    });
+
+    test('a connector may not self-assert a server-policy field', () => {
+        expect(validateBatch(batch({observations: [observation('e1', {attentionDisposition: 'eligible'})]})).errors)
+            .toContain('OBSERVATION_0_ASSERTS_SERVER_POLICY_ATTENTIONDISPOSITION');
+    });
+
+    test('an invalid provider actor kind is refused', () => {
+        expect(validateBatch(batch({observations: [observation('e1', {actorKind: 'wizard'})]})).errors).toContain('OBSERVATION_0_ACTOR_KIND_INVALID');
+    });
+
+    test('a complete window cannot claim gaps, and an incomplete one must', () => {
+        expect(validateBatch(batch({coverage: {fromBasis: 'c1', toBasis: 'c9', complete: true, gaps: [{fromBasis: 'c4', toBasis: 'c5'}]}})).errors)
             .toContain('COVERAGE_COMPLETE_CONTRADICTS_GAPS');
-
         expect(validateBatch(batch({coverage: {fromBasis: 'c1', toBasis: 'c9', complete: false}})).errors)
             .toContain('COVERAGE_INCOMPLETE_WITHOUT_GAPS');
     });
 
-    test('absence must be one of the three evidenced dispositions', () => {
-        expect(validateBatch(batch({occurrences: [occurrence('e1', {absence: 'probably-gone'})]})).errors)
-            .toContain('OCCURRENCE_0_ABSENCE_DISPOSITION_INVALID');
-
-        // inaccessible/unknown need no extra evidence; deleted does (below).
-        ['inaccessible', 'unknown'].forEach(disposition => {
-            expect(validateBatch(batch({occurrences: [occurrence('e1', {absence: disposition})]})).valid).toBe(true);
-        });
-    });
-
-    test('deleted requires explicit provider evidence — an enum value alone is a permission-loss risk', () => {
-        expect(validateBatch(batch({occurrences: [occurrence('e1', {absence: 'deleted'})]})).errors)
-            .toContain('OCCURRENCE_0_DELETED_WITHOUT_EVIDENCE');
-
-        expect(validateBatch(batch({occurrences: [occurrence('e1', {absence: 'deleted', deletionEvidence: {tombstoneId: 't-1', deletedAt: '2026-07-18T11:00:00Z'}})]})).valid)
-            .toBe(true);
-    });
-
-    test('an invalid provider actor kind is refused', () => {
-        expect(validateBatch(batch({occurrences: [occurrence('e1', {actorKind: 'wizard'})]})).errors)
-            .toContain('OCCURRENCE_0_ACTOR_KIND_INVALID');
-    });
-
-    test('a non-current-shaped registration epoch is refused', () => {
-        expect(validateBatch(batch({registrationEpoch: 0})).errors).toContain('BATCH_REGISTRATION_EPOCH_INVALID');
-        expect(validateBatch(batch({registrationEpoch: '2'})).errors).toContain('BATCH_REGISTRATION_EPOCH_INVALID');
+    test('deleted requires explicit provider evidence', () => {
+        expect(validateBatch(batch({observations: [observation('e1', {absence: 'deleted'})]})).errors).toContain('OBSERVATION_0_DELETED_WITHOUT_EVIDENCE');
+        expect(validateBatch(batch({observations: [observation('e1', {absence: 'deleted', deletionEvidence: {tombstoneId: 't1'}})]})).valid).toBe(true);
     });
 
     test('missing required identity is refused', () => {

--- a/test/playwright/unit/ai/services/memory-core/communityBatchContract.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/communityBatchContract.spec.mjs
@@ -69,6 +69,32 @@ test.describe('community-activity-batch.v1 contract', () => {
             .not.toBe(canonicalBatchDigest(a));
     });
 
+    test('duplicate multiplicity stays digest-visible — normalization sorts, never dedupes', () => {
+        const once  = batch({occurrences: [occurrence('e1')]}),
+              twice = batch({occurrences: [occurrence('e1'), occurrence('e1')]});
+
+        expect(canonicalBatchDigest(twice), 'two occurrences of a fact is a different claim from one')
+            .not.toBe(canonicalBatchDigest(once));
+    });
+
+    test('server-side policy output is digest-EXTERNAL — classification cannot shift a connector digest', () => {
+        const connectorBatch = batch(),
+              classifiedRow  = batch({occurrences: [
+                  occurrence('e1', {attentionDisposition: 'eligible', attentionReason: 'external-author'}),
+                  occurrence('e2', {attentionDisposition: 'ineligible', attentionReason: 'rostered-actor'})
+              ]});
+
+        expect(canonicalBatchDigest(classifiedRow), 'a policy revision must never masquerade as connector corruption')
+            .toBe(canonicalBatchDigest(connectorBatch));
+    });
+
+    test('a connector may not self-assert eligibility (zero-authority)', () => {
+        const {valid, errors} = validateBatch(batch({occurrences: [occurrence('e1', {attentionDisposition: 'eligible'})]}));
+
+        expect(valid).toBe(false);
+        expect(errors).toContain('OCCURRENCE_0_ASSERTS_SERVER_POLICY_ATTENTIONDISPOSITION');
+    });
+
     test('digest is stable across key insertion order', () => {
         const a = batch(),
               b = {occurrences: a.occurrences, coverage: a.coverage, partition: a.partition,

--- a/test/playwright/unit/ai/services/memory-core/communityBatchContract.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/communityBatchContract.spec.mjs
@@ -31,6 +31,7 @@ test.describe('community-activity-batch.v1 contract', () => {
         providerEntityId: id,
         occurrenceKind  : 'issue.opened',
         occurredAt      : '2026-07-18T10:00:00Z',
+        actorKind       : 'user',
         ...over
     });
 
@@ -141,9 +142,23 @@ test.describe('community-activity-batch.v1 contract', () => {
         expect(validateBatch(batch({occurrences: [occurrence('e1', {absence: 'probably-gone'})]})).errors)
             .toContain('OCCURRENCE_0_ABSENCE_DISPOSITION_INVALID');
 
-        ['deleted', 'inaccessible', 'unknown'].forEach(disposition => {
+        // inaccessible/unknown need no extra evidence; deleted does (below).
+        ['inaccessible', 'unknown'].forEach(disposition => {
             expect(validateBatch(batch({occurrences: [occurrence('e1', {absence: disposition})]})).valid).toBe(true);
         });
+    });
+
+    test('deleted requires explicit provider evidence — an enum value alone is a permission-loss risk', () => {
+        expect(validateBatch(batch({occurrences: [occurrence('e1', {absence: 'deleted'})]})).errors)
+            .toContain('OCCURRENCE_0_DELETED_WITHOUT_EVIDENCE');
+
+        expect(validateBatch(batch({occurrences: [occurrence('e1', {absence: 'deleted', deletionEvidence: {tombstoneId: 't-1', deletedAt: '2026-07-18T11:00:00Z'}})]})).valid)
+            .toBe(true);
+    });
+
+    test('an invalid provider actor kind is refused', () => {
+        expect(validateBatch(batch({occurrences: [occurrence('e1', {actorKind: 'wizard'})]})).errors)
+            .toContain('OCCURRENCE_0_ACTOR_KIND_INVALID');
     });
 
     test('a non-current-shaped registration epoch is refused', () => {

--- a/test/playwright/unit/ai/services/memory-core/communityBatchContract.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/communityBatchContract.spec.mjs
@@ -1,0 +1,132 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'CommunityBatchContractTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}                                              from '@playwright/test';
+import Neo                                                         from '../../../../../../src/Neo.mjs';
+import * as core                                                   from '../../../../../../src/core/_export.mjs';
+import {BATCH_SCHEMA_VERSION, canonicalBatchDigest, validateBatch} from '../../../../../../ai/services/memory-core/communityBatchContract.mjs';
+
+/**
+ * @summary Contract witnesses for community-activity batch admission.
+ *
+ * The load-bearing pair is the ordering pin: the occurrence COLLECTION is order-insensitive (a
+ * connector re-serializing from a map must not raise an integrity conflict), while ordering INSIDE
+ * an occurrence is preserved (nothing in the contract makes nested array order non-authoritative, and
+ * silently normalizing it is precisely how corruption detection weakens without a test noticing).
+ */
+test.describe('community-activity-batch.v1 contract', () => {
+    const occurrence = (id, over = {}) => ({
+        providerEntityId: id,
+        occurrenceKind  : 'issue.opened',
+        occurredAt      : '2026-07-18T10:00:00Z',
+        ...over
+    });
+
+    const batch = (over = {}) => ({
+        schemaVersion    : BATCH_SCHEMA_VERSION,
+        batchId          : 'batch-1',
+        sourceInstanceId : 'src-1',
+        registrationEpoch: 2,
+        partition        : 'issues',
+        coverage         : {fromBasis: 'c1', toBasis: 'c9', complete: true},
+        occurrences      : [occurrence('e1'), occurrence('e2')],
+        ...over
+    });
+
+    // ------------------------------------------------------------------ the ordering decision
+
+    test('reordering the occurrence collection yields the SAME digest (retry, not corruption)', () => {
+        const forward  = batch(),
+              reversed = batch({occurrences: [...forward.occurrences].reverse()});
+
+        expect(canonicalBatchDigest(reversed)).toBe(canonicalBatchDigest(forward));
+    });
+
+    test('mutating any occurrence field yields a DIFFERENT digest (integrity conflict)', () => {
+        const base    = batch(),
+              mutated = batch({occurrences: [occurrence('e1'), occurrence('e2', {occurrenceKind: 'issue.closed'})]});
+
+        expect(canonicalBatchDigest(mutated)).not.toBe(canonicalBatchDigest(base));
+    });
+
+    test('ordering INSIDE an occurrence stays significant — no blanket array sort', () => {
+        const a = batch({occurrences: [occurrence('e1', {reactionKinds: ['x', 'y']})]}),
+              b = batch({occurrences: [occurrence('e1', {reactionKinds: ['y', 'x']})]});
+
+        expect(canonicalBatchDigest(b), 'a blanket sort would collapse these and weaken detection')
+            .not.toBe(canonicalBatchDigest(a));
+    });
+
+    test('digest is stable across key insertion order', () => {
+        const a = batch(),
+              b = {occurrences: a.occurrences, coverage: a.coverage, partition: a.partition,
+                   registrationEpoch: a.registrationEpoch, sourceInstanceId: a.sourceInstanceId,
+                   batchId          : a.batchId, schemaVersion: a.schemaVersion};
+
+        expect(canonicalBatchDigest(b)).toBe(canonicalBatchDigest(a));
+    });
+
+    test('batch identity fields participate in the digest', () => {
+        expect(canonicalBatchDigest(batch({registrationEpoch: 3}))).not.toBe(canonicalBatchDigest(batch()));
+        expect(canonicalBatchDigest(batch({partition: 'pulls'}))).not.toBe(canonicalBatchDigest(batch()));
+    });
+
+    // ------------------------------------------------------------------ validation (AC1/AC6/AC7)
+
+    test('a well-formed batch validates', () => {
+        expect(validateBatch(batch())).toEqual({valid: true, errors: []});
+    });
+
+    test('an unsupported schema version is refused', () => {
+        const {valid, errors} = validateBatch(batch({schemaVersion: 'community-activity-batch.v2'}));
+
+        expect(valid).toBe(false);
+        expect(errors).toContain('BATCH_SCHEMA_VERSION_UNSUPPORTED');
+    });
+
+    test('prose is REFUSED, not silently stripped', () => {
+        const {valid, errors} = validateBatch(batch({occurrences: [occurrence('e1', {title: 'Crash on load'})]}));
+
+        expect(valid).toBe(false);
+        expect(errors).toContain('OCCURRENCE_0_CARRIES_PROSE_TITLE');
+    });
+
+    test('a complete window cannot also claim gaps, and an incomplete one must', () => {
+        expect(validateBatch(batch({coverage: {fromBasis: 'c1', toBasis: 'c9', complete: true, gaps: [{fromBasis: 'c4', toBasis: 'c5', reason: 'rate-limit'}]}})).errors)
+            .toContain('COVERAGE_COMPLETE_CONTRADICTS_GAPS');
+
+        expect(validateBatch(batch({coverage: {fromBasis: 'c1', toBasis: 'c9', complete: false}})).errors)
+            .toContain('COVERAGE_INCOMPLETE_WITHOUT_GAPS');
+    });
+
+    test('absence must be one of the three evidenced dispositions', () => {
+        expect(validateBatch(batch({occurrences: [occurrence('e1', {absence: 'probably-gone'})]})).errors)
+            .toContain('OCCURRENCE_0_ABSENCE_DISPOSITION_INVALID');
+
+        ['deleted', 'inaccessible', 'unknown'].forEach(disposition => {
+            expect(validateBatch(batch({occurrences: [occurrence('e1', {absence: disposition})]})).valid).toBe(true);
+        });
+    });
+
+    test('a non-current-shaped registration epoch is refused', () => {
+        expect(validateBatch(batch({registrationEpoch: 0})).errors).toContain('BATCH_REGISTRATION_EPOCH_INVALID');
+        expect(validateBatch(batch({registrationEpoch: '2'})).errors).toContain('BATCH_REGISTRATION_EPOCH_INVALID');
+    });
+
+    test('missing required identity is refused', () => {
+        expect(validateBatch(batch({sourceInstanceId: null})).errors).toContain('BATCH_MISSING_SOURCEINSTANCEID');
+        expect(validateBatch(null)).toEqual({valid: false, errors: ['BATCH_NOT_AN_OBJECT']});
+    });
+});


### PR DESCRIPTION
Resolves #15151

## Summary

Memory Core becomes the neutral durable owner of community activity: providers acquire and normalize, this service validates and atomically admits. Three modules under `ai/services/memory-core/`, consuming the source registry that landed in #15150.

**`communityBatchContract.mjs`** — the versioned `community-activity-batch.v1` schema plus the corruption-detecting digest.
- **Ordering is a decision, not an inheritance.** The occurrence *collection* is normalized order-insensitively, because ordering authority lives outside the payload (the admitted sequence is server-assigned), so a connector re-serializing from a map is a retry rather than an integrity conflict. Ordering *inside* an occurrence is preserved, and normalization sorts but never dedupes, so duplicate multiplicity stays digest-visible. The tree's only existing `stableStringify` blanket-sorts arrays — correct for its route-key use, and inheriting it here would have silently weakened conflict detection.
- **Refusals, not silent repairs:** prose-bearing occurrences, dishonest coverage (complete-with-gaps and incomplete-without-gaps), non-evidenced absence dispositions, and popularity telemetry are all refused at the boundary. An admitted row is durable history every later surface would otherwise have to keep re-excluding.

**`CommunityBatchAdmissionService.mjs`** — the admission transaction, ledger, and checkpoint.
- **Epoch-fenced:** admission gates on `SourceRegistryService.canAdmit`, so a revoked or reprovisioned source cannot write under stale authority.
- **Digest-keyed idempotency:** same scoped `batchId` + same digest is a retry that mints nothing; a different digest is an integrity conflict that never overwrites.
- **One transaction:** validation, fence, receipt, ledger rows, classification and the admitted sequence commit together, so a crash cannot leave a sequence without its receipt or a receipt whose count is a lie.
- **Ledger identity is separable (AC3):** the occurrence id is ours and distinct from the provider entity id, the delivering receipt, and the admitted sequence. Insert-only — a revision is a new row carrying `revisionOf`, never a mutation.
- **Checkpoint CAS:** advances only on a durably-accepted receipt AND an expected basis; a superseded writer matches zero rows and receives current server state rather than regressing or forking the cursor.

**`communityAttentionClassifier.mjs`** — zero-authority attention disposition, written in the same transaction and kept **out of the digest**, so policy revisions cannot masquerade as connector corruption. Rostered actors resolve first (internal activity updates an item without minting new attention, and our own agents never land in the bot branch); an unrecorded external bot stays `undetermined` rather than inferred from actor kind or trust tier. Policy is injected and never defaulted — admitting without it fails loud.

## Deltas from ticket

No scope expansion; AC10/AC11 stay in this leaf per the arc architect's ruling, with the classifier structurally isolated but digest-external. The `observations` vs `occurrences` naming question is open: this implements the ticket's AC3 term (`occurrence`/`revision`) and a rename remains cheap to apply in review. Out of scope per the ticket and untouched: provider polling/webhooks, source-owned outbox K, queue receiver O, Bird View, Task creation, retention compaction.

## Test Evidence

- **54 passed** via `npm run test-unit` across the three suites: 15 contract witnesses, 28 admission witnesses, and the 11 merged `SourceRegistryService` witnesses re-run to prove the new tables do not regress the registry sharing the database.
- Per-AC: AC1 schema validation · AC2 idempotent-retry and digest-mismatch conflict · AC3 four-way identity separation and insert-only revisions · AC4 checkpoint CAS with two racing writers where exactly one advances · AC5 stale-epoch, revoked-source and cross-tenant refusal · AC6 prose refused, not stripped · AC7 three evidenced absence dispositions · AC8 lost-response retry, out-of-order delivery, and stale-basis races · AC9 local/remote parity where a remote retry of a locally-admitted batch resolves idempotent against the same durable row · AC10 evidence-backed disposition as its own field · AC11 popularity telemetry refused and rostered actors updating without minting attention.
- The ordering decision is falsifiable rather than implicit: reorder → same digest, any field mutation → different digest, nested array order still significant, and duplicate multiplicity visible.

Evidence: L2 (unit — a property-witnessed security and concurrency matrix at the real service seams) → L2 required and sufficient (server-internal services with no runtime/deploy surface in this leaf; the connector and Bird View consumers land in successor leaves). Residual: none for the admission contract.

## Post-Merge Validation

- [ ] Confirm hosted CI is green at the human merge head.
- [ ] When a provider connector lands, confirm it consumes `admitBatch` for both local and remote ingress rather than reimplementing the fence, and that it advances checkpoints only with the receipt id it received.
- [ ] When bot dispositions are recorded by ADR, confirm `recordedBotDispositions` is populated at the injection site so unrecorded bots stop accumulating as `undetermined`.

Authored by Ada (@neo-opus-ada, Claude Opus 4.8, Claude Code). Origin session `3e5f61a5-35d0-4f3d-8805-54f63bebed70`.
