### PR TITLE
feat(agentos): give StateDot an accessible name and colocate the state-label resolver (#15512)

### DIFF
--- a/apps/agentos/view/fleet/HealthSwatch.mjs
+++ b/apps/agentos/view/fleet/HealthSwatch.mjs
@@ -1,32 +1,12 @@
-import Component    from '../../../../src/component/Base.mjs';
-import NeoArray     from '../../../../src/util/Array.mjs';
-import {stateClass} from './StateDot.mjs';
+import Component                from '../../../../src/component/Base.mjs';
+import NeoArray                 from '../../../../src/util/Array.mjs';
+import {stateClass, stateLabel} from './StateDot.mjs';
 
-/**
- * Canonical legend label per session-state category. Kept beside the state→token map so the fleet
- * health summary reads one vocabulary.
- * @type {Object}
- */
-const STATE_LABEL = {
-    ok     : 'working',
-    idle   : 'idle',
-    wedged : 'wedged',
-    limited: 'rate-limited',
-    off    : 'benched / offline'
-};
-
-/**
- * Pure state → label resolver. A known category → its canonical label; an unknown category →
- * the LITERAL category string (never invisible, never silently re-labelled as `off`), so a new
- * runtime state still renders a readable swatch until it earns a canonical label here. Uses an
- * `Object.hasOwn` check (not `MAP[k] ||`) so a prototype-shaped key (`toString`, `constructor`,
- * `__proto__`) resolves to its literal text instead of leaking an inherited Object.prototype value.
- * @param {String} state
- * @returns {String}
- */
-export function stateLabel(state) {
-    return Object.hasOwn(STATE_LABEL, state) ? STATE_LABEL[state] : String(state ?? 'unknown')
-}
+// `stateLabel` now lives beside `stateToken` / `stateClass` in StateDot.mjs so all three closed-set
+// resolvers stay one source of truth — and so the dot can name itself for assistive tech without
+// importing from this consumer, which would close an import cycle. Re-exported here because this
+// module has been the label's public seam; consumers and specs keep their existing import.
+export {stateLabel};
 
 /**
  * A single entry in the fleet health-summary legend / bar: a swatch dot (colored from the same

--- a/apps/agentos/view/fleet/StateDot.mjs
+++ b/apps/agentos/view/fleet/StateDot.mjs
@@ -47,6 +47,36 @@ export function stateClass(state) {
 }
 
 /**
+ * Human-readable label per session state. Lives here beside {@link stateToken} / {@link stateClass}
+ * so the three closed-set resolvers stay one source of truth for the fleet primitives — and so the
+ * dot can name itself without importing from a consumer (`HealthSwatch` imports `stateClass` from
+ * this module, so sourcing the label there would close an import cycle).
+ * @type {Object}
+ */
+const STATE_LABEL = {
+    ok      : 'working',
+    idle    : 'idle',
+    wedged  : 'wedged',
+    limited : 'rate-limited',
+    starting: 'starting',
+    stopping: 'stopping',
+    off     : 'benched / offline'
+};
+
+/**
+ * Pure state → human-readable label. An unrecognized state renders its LITERAL category string
+ * (never invisible, never silently re-labelled as `off`), so a new runtime state still reads until it
+ * earns a canonical label here. Uses an `Object.hasOwn` check (not `MAP[k] ||`) so a prototype-shaped
+ * key (`toString`, `constructor`, `__proto__`) resolves to its literal text instead of leaking an
+ * inherited `Object.prototype` value.
+ * @param {String} state
+ * @returns {String}
+ */
+export function stateLabel(state) {
+    return Object.hasOwn(STATE_LABEL, state) ? STATE_LABEL[state] : String(state ?? 'unknown')
+}
+
+/**
  * The atomic session-state indicator: a colored dot whose color is driven entirely by the
  * `--fm-state-*` token layer, with an optional live-pulse gated behind `prefers-reduced-motion`
  * in the component SCSS (`resources/scss/src/apps/agentos/fleet/StateDot.scss`). The color — not the
@@ -102,6 +132,12 @@ class StateDot extends Component {
 
         oldValue !== undefined && NeoArray.remove(cls, stateClass(oldValue));
         NeoArray.add(cls, stateClass(value));
+
+        // a11y: the dot is a graphical indicator carrying information, so it needs an accessible NAME —
+        // unlabelled it reaches assistive tech as decoration. Set before the `cls` assignment below,
+        // which flushes the vdom. This satisfies 4.1.2 / 1.1.1 and NOT 1.4.1: a name does nothing for a
+        // sighted operator who cannot separate the hues, which needs a visible non-colour channel.
+        Object.assign(this.vdom, {role: 'img', 'aria-label': stateLabel(value)});
 
         this.cls = cls
     }

--- a/test/playwright/unit/apps/agentos/view/fleet/stateDot.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/stateDot.spec.mjs
@@ -1,0 +1,89 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'FleetStateDotTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+/**
+ * The dot is a graphical indicator that carries session state. Unlabelled it reaches assistive tech as
+ * decoration, so it must expose an accessible NAME (WCAG 4.1.2 / 1.1.1). That is deliberately NOT the
+ * 1.4.1 fix: a name does nothing for a sighted operator who cannot separate the hues — that needs a
+ * visible non-colour channel on the consuming surface, tracked separately.
+ */
+test.describe('Fleet cockpit StateDot — accessible name + closed-set resolvers', () => {
+    let StateDot, stateLabel, stateClass, stateToken;
+
+    test.beforeAll(async () => {
+        const mod = await import('../../../../../../../apps/agentos/view/fleet/StateDot.mjs');
+
+        StateDot   = mod.default;
+        stateLabel = mod.stateLabel;
+        stateClass = mod.stateClass;
+        stateToken = mod.stateToken
+    });
+
+    test('stateLabel resolves canonical labels and degrades to LITERAL text, never to off', () => {
+        expect(stateLabel('ok')).toBe('working');
+        expect(stateLabel('limited')).toBe('rate-limited');
+        expect(stateLabel('off')).toBe('benched / offline');
+        // the transitional pair now has canonical labels too — they render while an intent is in flight
+        expect(stateLabel('starting')).toBe('starting');
+        expect(stateLabel('stopping')).toBe('stopping');
+        // an unrecognized state must stay readable rather than silently reading as `off`
+        expect(stateLabel('some-new-state')).toBe('some-new-state');
+        expect(stateLabel(undefined)).toBe('unknown');
+        // prototype-shaped keys resolve to their literal text, never an inherited prototype value
+        expect(stateLabel('toString')).toBe('toString');
+        expect(stateLabel('__proto__')).toBe('__proto__')
+    });
+
+    test('the dot exposes an accessible name for its state', () => {
+        const dot = Neo.create(StateDot, {appName, state: 'wedged'});
+
+        expect(dot.vdom.role).toBe('img');
+        expect(dot.vdom['aria-label']).toBe('wedged');
+
+        dot.destroy()
+    });
+
+    test('the accessible name follows a state change, so it can never describe a stale state', () => {
+        const dot = Neo.create(StateDot, {appName, state: 'ok'});
+
+        expect(dot.vdom['aria-label']).toBe('working');
+
+        dot.state = 'limited';
+
+        expect(dot.vdom['aria-label']).toBe('rate-limited');
+        // the colour class tracks the same transition — name and hue cannot disagree
+        expect(dot.cls).toContain(stateClass('limited'));
+        expect(dot.cls).not.toContain(stateClass('ok'));
+
+        dot.destroy()
+    });
+
+    test('an unknown state degrades to the off TOKEN while the name stays literal', () => {
+        const dot = Neo.create(StateDot, {appName, state: 'some-new-state'});
+
+        // colour degrades to the neutral token (a hue must not be invented for an unknown state) …
+        expect(stateToken('some-new-state')).toBe('--fm-state-off');
+        expect(dot.cls).toContain('fm-state-off');
+        // … but the NAME stays literal, so the operator is told what the runtime actually reported
+        // rather than being shown a confident "benched / offline" that is not what happened.
+        expect(dot.vdom['aria-label']).toBe('some-new-state');
+
+        dot.destroy()
+    });
+});


### PR DESCRIPTION
Resolves #15516
Refs #15512

First half of the **D2 ruling** ([ruling](https://github.com/neomjs/neo/issues/14805#issuecomment-5012476050)) on epic #14805. #15512 was **split** rather than carried as a Refs-only PR: it covered two different success criteria, and one ticket cannot honestly take two PRs (operator rule #12367 — the PR-body lint caught the attempt and was right to). This resolves the 4.1.2/1.1.1 half (#15516); #15512 is narrowed to the 1.4.1 card State line, which carries a density judgement.

## The defect

`StateDot` renders no text, `title`, or `aria-label` — it only swaps a state class — so a graphical indicator that carries session state reaches assistive tech as **unlabelled decoration**. All seven states also share identical geometry, differing only in `--fm-dot`.

## The change

1. **Accessible name.** The dot now exposes `role="img"` plus an `aria-label` resolved from the shared state vocabulary, set immediately before the `cls` assignment that flushes the vdom (matching `FleetGrid`'s set-before-flush idiom rather than adding a redundant `update()`).
2. **`stateLabel` moves to `StateDot.mjs`,** beside `stateToken`/`stateClass`. This keeps the three closed-set resolvers as one source of truth — which the module's own JSDoc already claims (*"the single source of truth for the fleet primitives (HealthSwatch reuses it)"*) — and removes a real hazard: `HealthSwatch` imports `stateClass` **from** `StateDot`, so sourcing the label the other way would have closed an **import cycle**. `HealthSwatch` re-exports it, so every existing consumer and spec keeps its import unchanged.

## Deltas from ticket

**Scope narrowed deliberately, and the reason is the ruling's own distinction.** The leaf covers both the accessible name (4.1.2 / 1.1.1) and the card State line (1.4.1). Only the first ships here. An `aria-label` **does not** satisfy 1.4.1 — it does nothing for a sighted operator who cannot separate the hues — so shipping it must not be mistaken for closing the 1.4.1 gap. The visible channel needs the density judgement at measured fleet row counts, which is real design work, not a mechanical follow-on.

The relocation of `stateLabel` was not in the ticket: it emerged from implementation, because the import direction made the obvious approach impossible.

## Evidence

Evidence: L1 (unit specs over the component's vdom + the pure resolvers) → L1 required (the accessible name is a rendered-attribute contract and the resolvers are pure). Residual: the 1.4.1 visible channel, tracked on #15512.

## Test Evidence

- New `stateDot.spec.mjs` (4 cases) pins: the name exists; it **follows a state change** so it can never describe a stale state; and an unknown state degrades to the **off token** while its **name stays literal** — the operator is told what the runtime actually reported instead of a confident "benched / offline" that did not happen.
- Regression across the relocation's blast radius: `stateDot` + `healthSwatch` + `agentCard` → **28/28 green**. The `healthSwatch` spec still imports `stateLabel` from `HealthSwatch`, which is exactly what the re-export exists to keep working.
- Block-alignment applied; commit-hook suite green.

## Post-Merge Validation

- [ ] The card State line (1.4.1) lands on #15512 with its density judgement — until then the epic's 1.4.1 finding stays open, correctly.

Authored by Grace (Claude Opus 4.8, Claude Code).