### PR TITLE
feat(memory-core): mark_read accepts messageId arrays — per-id results, never batch-failing (#15428)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2039,14 +2039,17 @@ paths:
       x-neo-tool-tier: write
       x-pass-as-object: true
       description: |
-        Marks a specific message as read.
+        Marks one or more messages as read. Accepts a single messageId or an array of ids; the array form returns per-id results and an individual failure (ghost id, unauthorized id) never fails the batch.
       tags: [Mailbox]
       parameters:
         - name: messageId
           in: path
           required: true
           schema:
-            type: string
+            oneOf:
+              - type: string
+              - type: array
+                items: {type: string}
       responses:
         '200':
           description: OK

--- a/ai/services/memory-core/MailboxService.mjs
+++ b/ai/services/memory-core/MailboxService.mjs
@@ -2170,12 +2170,29 @@ class MailboxService extends Base {
     }
 
     /**
-     * Marks a message as read.
+     * Marks a message as read. Accepts a single id or an array of ids: the array form marks
+     * each id independently through the same single-id path and returns per-id results — an
+     * individual failure (a ghost id, an unauthorized id) is captured in its own result and
+     * never fails the batch, so a bulk drain cannot abort on one stale entry.
      * @param {Object} args
-     * @param {String} args.messageId The ID of the message to mark read
-     * @returns {Promise<Object>}
+     * @param {String|String[]} args.messageId The ID of the message to mark read, or an array of IDs
+     * @returns {Promise<Object>} Single form: `{messageId, readAt, status}`; array form: `{results: [...]}`.
      */
     async markRead({ messageId }) {
+        if (Array.isArray(messageId)) {
+            const results = [];
+
+            for (const id of messageId) {
+                try {
+                    results.push(await this.markRead({messageId: id}));
+                } catch (error) {
+                    results.push({messageId: id, status: 'error', error: error.message});
+                }
+            }
+
+            return {results};
+        }
+
         const boundIdentity = RequestContextService.getAgentIdentityNodeId();
         if (!boundIdentity) {
             throw RequestContextService.unboundIdentityError('mark message read');

--- a/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs
@@ -899,6 +899,62 @@ test.describe('Neo.ai.services.memory-core.MailboxService', () => {
         expect(node.properties.readAt).toBeTruthy();
     });
 
+    test('markRead BULK: an array marks each id, per-id failures never fail the batch', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        const ids = [];
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            for (const subject of ['bulk-1', 'bulk-2']) {
+                const res = await MailboxService.addMessage({ to: '@bob', subject, body: 'drain' });
+                ids.push(res.messageId);
+            }
+        });
+
+        // mixed batch: two valid ids + one ghost — the batch resolves, the ghost is its own result
+        const result = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.markRead({ messageId: [...ids, 'MESSAGE:ghost-does-not-exist'] });
+        });
+
+        expect(result.results).toHaveLength(3);
+        expect(result.results[0]).toMatchObject({messageId: ids[0], status: 'read'});
+        expect(result.results[1]).toMatchObject({messageId: ids[1], status: 'read'});
+        expect(result.results[2]).toMatchObject({messageId: 'MESSAGE:ghost-does-not-exist', status: 'error'});
+        expect(result.results[2].error).toMatch(/Message not found/);
+
+        // every valid id really read
+        for (const id of ids) {
+            expect(GraphService.db.nodes.get(id).properties.readAt).toBeTruthy();
+        }
+    });
+
+    test('markRead BULK: an empty array is a clean no-op; auth is enforced PER ID', async () => {
+        await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            await PermissionService.grantPermission({ to: '@alice', scope: 'CAN_REPLY_TO' });
+        });
+
+        let msgId;
+        await RequestContextService.run({ agentIdentityNodeId: '@alice' }, async () => {
+            const res = await MailboxService.addMessage({ to: '@bob', subject: 'not-yours', body: 'auth' });
+            msgId = res.messageId;
+        });
+
+        const empty = await RequestContextService.run({ agentIdentityNodeId: '@bob' }, async () => {
+            return await MailboxService.markRead({ messageId: [] });
+        });
+        expect(empty.results).toEqual([]);
+
+        // charlie is NOT the recipient: the single-id path would throw — the batch captures it per-id
+        GraphService.upsertNode({ id: '@charlie', type: 'AgentIdentity', name: 'Charlie', properties: {accountType: 'agent'} });
+        const denied = await RequestContextService.run({ agentIdentityNodeId: '@charlie' }, async () => {
+            return await MailboxService.markRead({ messageId: [msgId] });
+        });
+        expect(denied.results).toHaveLength(1);
+        expect(denied.results[0].status).toBe('error');
+        expect(denied.results[0].error).toMatch(/Unauthorized/);
+    });
+
     test('#15253 a mark resolves through the same repair the read path uses — a cold cache is not a missing message', async () => {
         await RequestContextService.run({agentIdentityNodeId: '@bob'}, async () => {
             await PermissionService.grantPermission({to: '@alice', scope: 'CAN_REPLY_TO'});


### PR DESCRIPTION
Resolves #15428

`mark_read` now accepts a single `messageId` or an array of ids. The array form marks each id through the existing single-id path (auth, projection repair, and the broadcast delivery edge all inherited per id) and returns `{results: [...]}` — an individual failure (a ghost id, an unauthorized id) is captured as `{messageId, status: 'error', error}` in its own slot and **never fails the batch**, so a bulk drain cannot abort on one stale entry. Motivation: the #15448 read-state rollback left every seat's unread count inflated (mine read 190+), and draining cost one `mark_read` call per message.

Evidence: L1 (unit shard) → L1 required (pure service-layer change with the single-id path untouched). Residual: none for this close-target.

## Deltas from ticket

None substantive — the ticket's shape is the shipped shape (one method, per-id semantics). The OpenAPI schema gains the first `oneOf` on a mailbox path param (`string | string[]`), matching the established `now:` param's oneOf pattern in the same file.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/memory-core/MailboxService.spec.mjs` → **122/122 green** (120 carried + 2 new):
  - bulk mixed batch: two valid ids + one ghost — batch resolves; both valids `status: 'read'` with `readAt` written to the graph; the ghost lands `{status: 'error', error: /Message not found/}` in its own slot;
  - empty array → `{results: []}` clean no-op; auth enforced **per id** (a non-recipient's batch captures `Unauthorized` as the per-id error, never throws).
- The single-id path is byte-identical in behavior — the array delegate re-enters the same method per id, so every landed auth/repair invariant applies unchanged (the 120 carried tests prove it).
- MCP-Tool-Description Budget: the updated description stays two sentences, usage-shaped, no internal cross-refs.
- check-block-alignment applied; agent-preflight all gates.

## Post-Merge Validation

- [ ] Live dogfood after the next memory-core server restart: one `mark_read({messageId: [...]})` call against this seat's rollback-inflated unread set drains it in a single tool call (the receipt the ticket was written for).
- [ ] MCP-surface arg validation accepts the `oneOf` schema end-to-end (the pattern is already live in the same file at the `now:` param; confirmed at the first live call).

Authored by Phoebe (Kimi K3, OpenCode). Session 9b748a56-8b84-43bf-a542-ee8dcf437ebf.
