### PR TITLE
test(agentos): the cockpit liveness owner e2e — live to loss to recovery on a real fleet server (#15293)

### DIFF
--- a/test/playwright/e2e/agentos/FleetCockpitLivenessNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitLivenessNL.spec.mjs
@@ -1,92 +1,95 @@
 import {test, expect}                                                          from '../../fixtures.mjs';
+import {generateLocalBearerToken}                                              from '../../../../ai/mcp/server/shared/helpers/localBearer.mjs';
 import {authenticatedFleetOptions, reloadRoster, wireAuthenticatedFleetBridge} from './authenticatedFleetHarness.mjs';
 
 /**
  * @summary The liveness OWNER journey proven on the MOUNTED cockpit against a REAL fleet server:
  * `live` → transport killed → the spine banner NAMES the loss → transport restarted → the banner
  * clears. The liveness mechanism and its unit transition matrix ship separately; this covers the one
- * edge no unit can see, and it needs a real activity producer on the fleet server (now available):
- * a genuine transport death advancing owner truth end-to-end, without a reload.
+ * edge no unit can see: a genuine transport death advancing owner truth end-to-end, without a reload.
  *
- * Why this is NOT the `FleetCockpitDrillRoundTripNL` adapter-loss leg: that mutates the ActivityStream
- * CHILD's `adapterState` directly (`setProperties(streamId, …)`). This drives the OWNER — the cockpit's
- * `gridAdapterState` / `streamAdapterState`, `degradeWiredSurface`, and `syncSpineBanner` — through a
- * real `registryBridge` read that genuinely FAILS (connection refused on a closed loopback server),
- * so `loadRoster` / `loadActivity` reject into `degradeWiredSurface` (the "killed" edge), not the
- * producer-answered `capability.state==='degraded'` branch. The witness is TIMER-driven, not a manual
- * `loadRoster`: the whole point of the owner is the ONGOING re-poll, so a short injected cadence proves
- * the interval advances truth on its own.
+ * The server drives the REAL `dispatchFleetRequest → FleetControlBridge` path (no fabricated
+ * dispatch): `FleetControlBridge.activitySource` is composed through the production
+ * `wireFleetActivityReadSource` (the producer whose landing unblocked this AC), with the same slot
+ * readers `devFleetServer` injects (a bound `listMessages` + the synced issue tree); the roster runs
+ * through `FleetControlBridge.fleetRoster` over its registry. So a wired surface reaching `live` is the
+ * production producer answering, not a stub behind a real socket.
  *
- * Kill = close the real server (connection refused is an unambiguous request rejection, independent of
- * the bridge client's `{ok:false}` mapping). Restart = a fresh server + re-`wireFleetBridge` to its new
- * URL (no port-reuse flakiness); the running liveness timer reads the re-installed global next tick.
+ * The loss/restart are isolated to the TRANSPORT: kill closes the socket (connection-refused → the
+ * `catch → degradeWiredSurface` edge), restart re-listens on the SAME port with the SAME bearer, and
+ * the browser bridge is NEVER re-wired — so the liveness timer, not endpoint reconfiguration, is the
+ * sole recovery cause. The witness is timer-driven (a short injected cadence, re-armed), same cockpit
+ * instance (no reload), and asserts the retained safe reason reaches the rendered banner.
  *
  * Run: NEO_E2E_PORT=8121 npx playwright test agentos/FleetCockpitLivenessNL -c test/playwright/playwright.config.e2e.mjs --workers=1
  *
  * @see apps/agentos/view/fleet/FleetCockpit.mjs (startLiveness / loadRoster / loadActivity / degradeWiredSurface / syncSpineBanner)
- * @see apps/agentos/view/fleet/spineBanner.mjs (deriveSpineBanner — the rendered text this asserts)
- * @see test/playwright/e2e/agentos/authenticatedFleetHarness.mjs (the real-server ingress boundary)
+ * @see ai/services/fleet/devFleetServer.mjs (the production composition this mirrors)
+ * @see ai/services/fleet/wireFleetActivityReadSource.mjs (the real producer the dispatch traverses)
  */
 
-const LIVENESS_SOURCES = {
-    roster : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
-    runtime: {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}
-};
-
-const LIVENESS_ROSTER_ROWS = [
-    {id: 'live-alpha', displayName: 'Alpha', engineTag: 'fixture', family: 'claude'},
-    {id: 'live-bravo', displayName: 'Bravo', engineTag: 'fixture', family: 'claude'}
-].map(row => ({
-    ...row,
-    avatarUrl: '',
-    lifecycle: {source: LIVENESS_SOURCES.runtime.source, state: 'running', confidence: 'observed'},
-    sources  : LIVENESS_SOURCES
-}));
+let neoBootstrapped = false;
 
 /**
- * @summary Start a test-owned Fleet bridge that answers `fleetRoster` / `fleetActivity` as a wired,
- * live fleet. Killing the transport is done by CLOSING this server (not a dispatch flag): the closed
- * loopback socket makes the next real read reject with connection-refused — the faithful "killed" edge.
- * @param {Number} [port=0] 0 = ephemeral; each (re)start binds a fresh port so recovery never reuses one.
- * @returns {Promise<{bearerToken: String, endpoint: String, close: Function}>}
+ * @summary Compose the REAL Fleet producer onto `FleetControlBridge` once — mirroring the
+ * `devFleetServer` boot wiring so the transport traverses `dispatchFleetRequest → activitySource`,
+ * never a fabricated response. Idempotent (the bridge + activitySource are module singletons that
+ * survive the kill/restart, which is exactly why recovery needs no re-wire).
+ * @returns {Promise<void>}
  */
-async function startLivenessFleetBridge(port = 0) {
-    const {startFleetBridgeServer} = await import('../../../../ai/services/fleet/fleetBridgeServer.mjs');
+async function wireRealFleetSources() {
+    if (neoBootstrapped) return;
 
-    const options = authenticatedFleetOptions({
-        port,
-        dispatch: async request => {
-            if (request.method === 'fleetRoster') {
-                return {ok: true, result: {rows: LIVENESS_ROSTER_ROWS}}
-            }
+    // Neo namespace bootstrap (entry-point invariant) so the FleetControlBridge / FleetManager
+    // singletons construct — the same three imports devFleetServer's process entry performs.
+    await import('../../../../src/Neo.mjs');
+    await import('../../../../src/core/_export.mjs');
+    await import('../../../../src/manager/Instance.mjs');
 
-            if (request.method === 'fleetActivity') {
-                return {
-                    ok    : true,
-                    result: {
-                        capability: {source: 'fleet:test', state: 'wired', confidence: 'observed'},
-                        events    : []
-                    }
-                }
-            }
+    const
+        {wireFleetActivityReadSource} = await import('../../../../ai/services/fleet/wireFleetActivityReadSource.mjs'),
+        {default: path}               = await import('node:path'),
+        {fileURLToPath}               = await import('node:url'),
+        issuesDir                     = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../resources/content/issues');
 
-            return {ok: false, error: `fleet: unexpected liveness-witness method '${request.method}'`}
-        }
+    // The production producer, with the SAME injected slot shape devFleetServer uses: the A2A slot
+    // over a bound listMessages (honestly-empty here — a real bound reader, not a fabricated snapshot),
+    // the PR/lane slot over the synced issue tree. Both slots read → the composer reports `wired`.
+    wireFleetActivityReadSource({
+        issuesDir,
+        listMessages: async () => []
     });
 
-    const server = await startFleetBridgeServer(options);
+    neoBootstrapped = true
+}
+
+/**
+ * @summary Start the authenticated Fleet bridge on the REAL dispatch path (no custom `dispatch`), so
+ * `fleetRoster` / `fleetActivity` resolve through `FleetControlBridge`. Pass a fixed `port` + `bearerToken`
+ * on restart to re-listen at the SAME endpoint the browser bridge already targets.
+ * @param {Object} [opts]
+ * @param {Number} [opts.port=0] 0 = ephemeral (first boot); the captured port on restart.
+ * @param {String} [opts.bearerToken] Reused across restart so the already-installed bridge authenticates.
+ * @returns {Promise<{bearerToken: String, port: Number, endpoint: String, close: Function}>}
+ */
+async function startLivenessFleetServer({port = 0, bearerToken} = {}) {
+    const {startFleetBridgeServer} = await import('../../../../ai/services/fleet/fleetBridgeServer.mjs'),
+          options                  = authenticatedFleetOptions(bearerToken ? {port, bearerToken} : {port}),
+          server                   = await startFleetBridgeServer(options),
+          boundPort                = server.address().port;
 
     return {
         bearerToken: options.bearerToken,
-        endpoint   : `http://127.0.0.1:${server.address().port}/fleet`,
+        port       : boundPort,
+        endpoint   : `http://127.0.0.1:${boundPort}/fleet`,
         close      : () => new Promise(resolve => server.close(resolve))
     }
 }
 
 test.describe('AgentOS fleet cockpit — the liveness owner journey (live → transport killed → banner names loss → restart → clears, #15293 AC4)', () => {
-    test.setTimeout(120000);
+    test.setTimeout(150000);
 
-    test('the ongoing owner advances gridAdapterState/streamAdapterState and the spine banner across a real transport loss and recovery, without reload', async ({page, neuralLink}) => {
+    test('the ongoing owner advances gridAdapterState/streamAdapterState and the spine banner across a real transport loss and recovery, timer-driven, same-endpoint, no reload', async ({page, neuralLink}) => {
         const pageErrors = [];
 
         page.on('pageerror', error => {
@@ -94,8 +97,14 @@ test.describe('AgentOS fleet cockpit — the liveness owner journey (live → tr
             value && value !== 'undefined' && pageErrors.push(value)
         });
 
-        // ── boot against a REAL, live fleet server ───────────────────────────────────────────
-        let fleet = await startLivenessFleetBridge();
+        // ── boot the REAL producer path, then the transport on an ephemeral port ────────────────
+        await wireRealFleetSources();
+
+        const bearerToken = generateLocalBearerToken();
+
+        let fleet = await startLivenessFleetServer({bearerToken});
+
+        const fleetPort = fleet.port; // the endpoint the browser bridge binds to; restart re-listens here
 
         await page.goto('/apps/agentos/index.html');
         await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
@@ -106,8 +115,9 @@ test.describe('AgentOS fleet cockpit — the liveness owner journey (live → tr
 
         expect(cockpitId, 'the FleetCockpit must exist in the App Worker').toBeTruthy();
 
-        // flip the fail-closed boot bridge live, then re-read the roster that raced the injection
-        await wireAuthenticatedFleetBridge({app, fleetUrl: fleet.endpoint, bearerToken: fleet.bearerToken});
+        // flip the fail-closed boot bridge live (the ONE wire call — recovery must not repeat it), then
+        // re-read the roster that raced the injection
+        await wireAuthenticatedFleetBridge({app, fleetUrl: fleet.endpoint, bearerToken});
         await reloadRoster(app);
 
         const readLiveness = async () => {
@@ -119,35 +129,32 @@ test.describe('AgentOS fleet cockpit — the liveness owner journey (live → tr
             return c?.properties ?? {}
         };
 
-        // both surfaces reach live against the wired bridge; a fully-live spine renders NOTHING
+        // both surfaces reach live through the REAL producer (roster registry + composed activitySource);
+        // a fully-live spine renders NOTHING
         await expect.poll(async () => (await readLiveness()).gridAdapterState, {
-            message: 'the roster surface reaches live against the wired bridge', timeout: 30000, intervals: [250]
+            message: 'the roster surface reaches live through the real bridge', timeout: 30000, intervals: [250]
         }).toBe('live');
 
         await expect.poll(async () => (await readLiveness()).streamAdapterState, {
-            message: 'the activity surface reaches live against the wired bridge', timeout: 30000, intervals: [250]
+            message: 'the activity surface reaches live through the real producer', timeout: 30000, intervals: [250]
         }).toBe('live');
 
         await expect(page.locator('.fm-spine-banner-degraded'), 'a fully-live spine renders no degraded banner').toHaveCount(0);
-        await expect(page.locator('.fm-spine-banner-cold'),     'a fully-live spine renders no cold banner').toHaveCount(0);
 
         // ── pin a fast, deterministic cadence and RE-ARM the owner so the timer drives the edges ─
-        // the fields are documented as injectable-for-specs; startLiveness reads livenessPollInterval
-        // at setInterval time, so it must be re-armed (stop → start) to pick the short cadence up.
-        await app.setProperties(cockpitId, {livenessPollInterval: 250, livenessReadTimeout: 800});
+        await app.setProperties(cockpitId, {livenessPollInterval: 300, livenessReadTimeout: 2500});
         await app.callMethod(cockpitId, 'stopLiveness');
         await app.callMethod(cockpitId, 'startLiveness');
 
-        // ── transport KILLED: close the real server; the next TIMER tick reads connection-refused ─
+        // ── transport KILLED: close the socket; the next TIMER tick reads connection-refused ────
         await fleet.close();
 
-        // the owner advances BOTH wired surfaces live → stale on its own cadence (no reload, no manual load)
         await expect.poll(async () => (await readLiveness()).gridAdapterState, {
-            message: 'the liveness timer advances the roster surface to stale on transport loss', timeout: 30000, intervals: [250]
+            message: 'the liveness timer advances the roster surface to stale on transport loss', timeout: 30000, intervals: [300]
         }).toBe('stale');
 
         await expect.poll(async () => (await readLiveness()).streamAdapterState, {
-            message: 'the liveness timer advances the activity surface to stale on transport loss', timeout: 30000, intervals: [250]
+            message: 'the liveness timer advances the activity surface to stale on transport loss', timeout: 30000, intervals: [300]
         }).toBe('stale');
 
         // a retained safe reason is held per surface (the honest WHY, not generic copy)
@@ -157,25 +164,25 @@ test.describe('AgentOS fleet cockpit — the liveness owner journey (live → tr
         expect(degraded.streamDegradedReason, 'the activity surface retains a safe degrade reason').toBeTruthy();
         expect(degraded.id, 'the SAME cockpit instance advanced the state — no reload').toBe(cockpitId);
 
-        // the spine banner NAMES the loss in the DOM — the operator-visible truth, not worker state alone
+        // the spine banner NAMES the loss in the DOM — and carries the RETAINED REASON, not just the
+        // generic prefix (proving the safe reason reaches rendered copy, RA-3)
         const banner = page.locator('.fm-spine-banner-degraded');
 
         await expect(banner, 'the spine banner renders the degraded state').toBeVisible({timeout: 15000});
-        await expect(banner, 'the banner names the loss with last-known framing').toContainText('Fleet feed degraded — showing last-known data');
+        await expect(banner, 'the banner names the loss AND carries the retained reason (not only the prefix)')
+            .toHaveText(/Fleet feed degraded — showing last-known data · .+/);
 
-        // ── transport RESTARTED: a fresh server + re-wire; the running timer reads the new bridge ─
-        const fleet2 = await startLivenessFleetBridge();
+        // ── transport RESTARTED at the SAME endpoint, SAME bearer — the bridge is NOT re-wired ──
+        fleet = await startLivenessFleetServer({port: fleetPort, bearerToken});
 
-        fleet = fleet2; // afterEach / trailing close targets the live one
-        await wireAuthenticatedFleetBridge({app, fleetUrl: fleet2.endpoint, bearerToken: fleet2.bearerToken});
-
-        // recovery is timer-driven too: the next tick succeeds → live → the retained reason clears
+        // recovery is timer-driven and transport-isolated: the next tick reads the re-listened server
+        // through the unchanged bridge → live → the retained reason clears
         await expect.poll(async () => (await readLiveness()).gridAdapterState, {
-            message: 'the liveness timer restores the roster surface to live on recovery', timeout: 30000, intervals: [250]
+            message: 'the liveness timer restores the roster surface to live on same-endpoint restart', timeout: 30000, intervals: [300]
         }).toBe('live');
 
         await expect.poll(async () => (await readLiveness()).streamAdapterState, {
-            message: 'the liveness timer restores the activity surface to live on recovery', timeout: 30000, intervals: [250]
+            message: 'the liveness timer restores the activity surface to live on same-endpoint restart', timeout: 30000, intervals: [300]
         }).toBe('live');
 
         const recovered = await readLiveness();
@@ -183,10 +190,9 @@ test.describe('AgentOS fleet cockpit — the liveness owner journey (live → tr
         expect(recovered.gridDegradedReason,   'the roster reason clears on recovery').toBeFalsy();
         expect(recovered.streamDegradedReason, 'the activity reason clears on recovery').toBeFalsy();
 
-        // the banner clears — a fully-live spine is hidden again
         await expect(page.locator('.fm-spine-banner-degraded'), 'the degraded banner clears on recovery').toHaveCount(0);
 
-        await fleet2.close();
+        await fleet.close();
 
         expect(pageErrors, 'the liveness journey must be error-free in the main window').toEqual([])
     });

--- a/test/playwright/e2e/agentos/FleetCockpitLivenessNL.spec.mjs
+++ b/test/playwright/e2e/agentos/FleetCockpitLivenessNL.spec.mjs
@@ -1,0 +1,193 @@
+import {test, expect}                                                          from '../../fixtures.mjs';
+import {authenticatedFleetOptions, reloadRoster, wireAuthenticatedFleetBridge} from './authenticatedFleetHarness.mjs';
+
+/**
+ * @summary The liveness OWNER journey proven on the MOUNTED cockpit against a REAL fleet server:
+ * `live` → transport killed → the spine banner NAMES the loss → transport restarted → the banner
+ * clears. The liveness mechanism and its unit transition matrix ship separately; this covers the one
+ * edge no unit can see, and it needs a real activity producer on the fleet server (now available):
+ * a genuine transport death advancing owner truth end-to-end, without a reload.
+ *
+ * Why this is NOT the `FleetCockpitDrillRoundTripNL` adapter-loss leg: that mutates the ActivityStream
+ * CHILD's `adapterState` directly (`setProperties(streamId, …)`). This drives the OWNER — the cockpit's
+ * `gridAdapterState` / `streamAdapterState`, `degradeWiredSurface`, and `syncSpineBanner` — through a
+ * real `registryBridge` read that genuinely FAILS (connection refused on a closed loopback server),
+ * so `loadRoster` / `loadActivity` reject into `degradeWiredSurface` (the "killed" edge), not the
+ * producer-answered `capability.state==='degraded'` branch. The witness is TIMER-driven, not a manual
+ * `loadRoster`: the whole point of the owner is the ONGOING re-poll, so a short injected cadence proves
+ * the interval advances truth on its own.
+ *
+ * Kill = close the real server (connection refused is an unambiguous request rejection, independent of
+ * the bridge client's `{ok:false}` mapping). Restart = a fresh server + re-`wireFleetBridge` to its new
+ * URL (no port-reuse flakiness); the running liveness timer reads the re-installed global next tick.
+ *
+ * Run: NEO_E2E_PORT=8121 npx playwright test agentos/FleetCockpitLivenessNL -c test/playwright/playwright.config.e2e.mjs --workers=1
+ *
+ * @see apps/agentos/view/fleet/FleetCockpit.mjs (startLiveness / loadRoster / loadActivity / degradeWiredSurface / syncSpineBanner)
+ * @see apps/agentos/view/fleet/spineBanner.mjs (deriveSpineBanner — the rendered text this asserts)
+ * @see test/playwright/e2e/agentos/authenticatedFleetHarness.mjs (the real-server ingress boundary)
+ */
+
+const LIVENESS_SOURCES = {
+    roster : {source: 'fleet:listAgents',    state: 'wired', confidence: 'observed'},
+    runtime: {source: 'fleet:runtimeStatus', state: 'wired', confidence: 'observed'}
+};
+
+const LIVENESS_ROSTER_ROWS = [
+    {id: 'live-alpha', displayName: 'Alpha', engineTag: 'fixture', family: 'claude'},
+    {id: 'live-bravo', displayName: 'Bravo', engineTag: 'fixture', family: 'claude'}
+].map(row => ({
+    ...row,
+    avatarUrl: '',
+    lifecycle: {source: LIVENESS_SOURCES.runtime.source, state: 'running', confidence: 'observed'},
+    sources  : LIVENESS_SOURCES
+}));
+
+/**
+ * @summary Start a test-owned Fleet bridge that answers `fleetRoster` / `fleetActivity` as a wired,
+ * live fleet. Killing the transport is done by CLOSING this server (not a dispatch flag): the closed
+ * loopback socket makes the next real read reject with connection-refused — the faithful "killed" edge.
+ * @param {Number} [port=0] 0 = ephemeral; each (re)start binds a fresh port so recovery never reuses one.
+ * @returns {Promise<{bearerToken: String, endpoint: String, close: Function}>}
+ */
+async function startLivenessFleetBridge(port = 0) {
+    const {startFleetBridgeServer} = await import('../../../../ai/services/fleet/fleetBridgeServer.mjs');
+
+    const options = authenticatedFleetOptions({
+        port,
+        dispatch: async request => {
+            if (request.method === 'fleetRoster') {
+                return {ok: true, result: {rows: LIVENESS_ROSTER_ROWS}}
+            }
+
+            if (request.method === 'fleetActivity') {
+                return {
+                    ok    : true,
+                    result: {
+                        capability: {source: 'fleet:test', state: 'wired', confidence: 'observed'},
+                        events    : []
+                    }
+                }
+            }
+
+            return {ok: false, error: `fleet: unexpected liveness-witness method '${request.method}'`}
+        }
+    });
+
+    const server = await startFleetBridgeServer(options);
+
+    return {
+        bearerToken: options.bearerToken,
+        endpoint   : `http://127.0.0.1:${server.address().port}/fleet`,
+        close      : () => new Promise(resolve => server.close(resolve))
+    }
+}
+
+test.describe('AgentOS fleet cockpit — the liveness owner journey (live → transport killed → banner names loss → restart → clears, #15293 AC4)', () => {
+    test.setTimeout(120000);
+
+    test('the ongoing owner advances gridAdapterState/streamAdapterState and the spine banner across a real transport loss and recovery, without reload', async ({page, neuralLink}) => {
+        const pageErrors = [];
+
+        page.on('pageerror', error => {
+            const value = error == null ? '' : String(error.stack || error.message || error);
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        // ── boot against a REAL, live fleet server ───────────────────────────────────────────
+        let fleet = await startLivenessFleetBridge();
+
+        await page.goto('/apps/agentos/index.html');
+        await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
+
+        const app        = await neuralLink.connectToApp('AgentOS'),
+              [cockpit0] = await app.queryComponent({className: 'AgentOS.view.fleet.FleetCockpit'}, ['id']),
+              cockpitId  = cockpit0?.properties?.id;
+
+        expect(cockpitId, 'the FleetCockpit must exist in the App Worker').toBeTruthy();
+
+        // flip the fail-closed boot bridge live, then re-read the roster that raced the injection
+        await wireAuthenticatedFleetBridge({app, fleetUrl: fleet.endpoint, bearerToken: fleet.bearerToken});
+        await reloadRoster(app);
+
+        const readLiveness = async () => {
+            const [c] = await app.queryComponent(
+                {className: 'AgentOS.view.fleet.FleetCockpit'},
+                ['gridAdapterState', 'streamAdapterState', 'gridDegradedReason', 'streamDegradedReason', 'id']
+            );
+
+            return c?.properties ?? {}
+        };
+
+        // both surfaces reach live against the wired bridge; a fully-live spine renders NOTHING
+        await expect.poll(async () => (await readLiveness()).gridAdapterState, {
+            message: 'the roster surface reaches live against the wired bridge', timeout: 30000, intervals: [250]
+        }).toBe('live');
+
+        await expect.poll(async () => (await readLiveness()).streamAdapterState, {
+            message: 'the activity surface reaches live against the wired bridge', timeout: 30000, intervals: [250]
+        }).toBe('live');
+
+        await expect(page.locator('.fm-spine-banner-degraded'), 'a fully-live spine renders no degraded banner').toHaveCount(0);
+        await expect(page.locator('.fm-spine-banner-cold'),     'a fully-live spine renders no cold banner').toHaveCount(0);
+
+        // ── pin a fast, deterministic cadence and RE-ARM the owner so the timer drives the edges ─
+        // the fields are documented as injectable-for-specs; startLiveness reads livenessPollInterval
+        // at setInterval time, so it must be re-armed (stop → start) to pick the short cadence up.
+        await app.setProperties(cockpitId, {livenessPollInterval: 250, livenessReadTimeout: 800});
+        await app.callMethod(cockpitId, 'stopLiveness');
+        await app.callMethod(cockpitId, 'startLiveness');
+
+        // ── transport KILLED: close the real server; the next TIMER tick reads connection-refused ─
+        await fleet.close();
+
+        // the owner advances BOTH wired surfaces live → stale on its own cadence (no reload, no manual load)
+        await expect.poll(async () => (await readLiveness()).gridAdapterState, {
+            message: 'the liveness timer advances the roster surface to stale on transport loss', timeout: 30000, intervals: [250]
+        }).toBe('stale');
+
+        await expect.poll(async () => (await readLiveness()).streamAdapterState, {
+            message: 'the liveness timer advances the activity surface to stale on transport loss', timeout: 30000, intervals: [250]
+        }).toBe('stale');
+
+        // a retained safe reason is held per surface (the honest WHY, not generic copy)
+        const degraded = await readLiveness();
+
+        expect(degraded.gridDegradedReason,   'the roster surface retains a safe degrade reason').toBeTruthy();
+        expect(degraded.streamDegradedReason, 'the activity surface retains a safe degrade reason').toBeTruthy();
+        expect(degraded.id, 'the SAME cockpit instance advanced the state — no reload').toBe(cockpitId);
+
+        // the spine banner NAMES the loss in the DOM — the operator-visible truth, not worker state alone
+        const banner = page.locator('.fm-spine-banner-degraded');
+
+        await expect(banner, 'the spine banner renders the degraded state').toBeVisible({timeout: 15000});
+        await expect(banner, 'the banner names the loss with last-known framing').toContainText('Fleet feed degraded — showing last-known data');
+
+        // ── transport RESTARTED: a fresh server + re-wire; the running timer reads the new bridge ─
+        const fleet2 = await startLivenessFleetBridge();
+
+        fleet = fleet2; // afterEach / trailing close targets the live one
+        await wireAuthenticatedFleetBridge({app, fleetUrl: fleet2.endpoint, bearerToken: fleet2.bearerToken});
+
+        // recovery is timer-driven too: the next tick succeeds → live → the retained reason clears
+        await expect.poll(async () => (await readLiveness()).gridAdapterState, {
+            message: 'the liveness timer restores the roster surface to live on recovery', timeout: 30000, intervals: [250]
+        }).toBe('live');
+
+        await expect.poll(async () => (await readLiveness()).streamAdapterState, {
+            message: 'the liveness timer restores the activity surface to live on recovery', timeout: 30000, intervals: [250]
+        }).toBe('live');
+
+        const recovered = await readLiveness();
+
+        expect(recovered.gridDegradedReason,   'the roster reason clears on recovery').toBeFalsy();
+        expect(recovered.streamDegradedReason, 'the activity reason clears on recovery').toBeFalsy();
+
+        // the banner clears — a fully-live spine is hidden again
+        await expect(page.locator('.fm-spine-banner-degraded'), 'the degraded banner clears on recovery').toHaveCount(0);
+
+        await fleet2.close();
+
+        expect(pageErrors, 'the liveness journey must be error-free in the main window').toEqual([])
+    });
+});


### PR DESCRIPTION
Resolves #15293

The mounted Neural-Link liveness journey for the FM cockpit fleet liveness owner — AC4, the one criterion the delivered mechanism slice could not carry until its `activitySource` producer landed. It witnesses, against a REAL fleet server driven through the production dispatch path, the ongoing owner advancing `gridAdapterState` / `streamAdapterState` and the spine banner across a genuine transport loss and recovery: `live` → the socket is closed (connection-refused) → both wired surfaces degrade to `stale` with retained per-surface reasons and the spine banner NAMES the loss → the transport re-listens on the **same endpoint** → the liveness timer restores `live` and the banner clears. Timer-driven (short injected cadence, re-armed), same cockpit instance (no reload).

The mechanism itself (`startLiveness` / `degradeWiredSurface` / `syncSpineBanner`, plus its unit transition matrix) shipped separately; this PR adds only the mounted e2e the producer dependency previously blocked.

Evidence: L3 (mounted Neural-Link whitebox-e2e over the real `dispatchFleetRequest → FleetControlBridge` path) → L3 required (AC4 — the NL e2e against a real fleet server, traversing the producer). Residual: none.

## Deltas from ticket

None substantive. Three fidelity choices, each addressing the cross-family review:

- **Real producer, not a fabricated dispatch.** The server passes no custom `dispatch`; `wireRealFleetSources()` bootstraps Neo and composes `FleetControlBridge.activitySource` through the production `wireFleetActivityReadSource` — the same injected slot shape `devFleetServer` uses (a bound `listMessages` + the synced `resources/content/issues` tree). `fleetActivity` / `fleetRoster` resolve through `FleetControlBridge`, so a `live` surface is the real producer answering (#15293's source note explicitly rejected "a stub behind a real transport").
- **Transport-isolated recovery.** Restart re-listens on the SAME port + SAME bearer; the browser bridge is wired exactly once (at boot) and never re-wired. The module-singleton `activitySource` + the installed bridge persist across close/re-listen, so the liveness timer — not endpoint reconfiguration — is the sole recovery cause.
- **Kill via socket close** (connection-refused → the `catch → degradeWiredSurface` "killed" edge), the unambiguous transport death independent of the bridge client's `ok:false` mapping.

## Test Evidence

- `NEO_E2E_PORT=8125/8127/8129 npx playwright test agentos/FleetCockpitLivenessNL -c test/playwright/playwright.config.e2e.mjs --workers=1` → **3/3 passed** (22.9s / 21.0s / 20.9s), deterministic across the same-endpoint restart.
- Asserts, at the mounted cockpit: both surfaces reach `live` through the real bridge; the timer advances both to `stale` with retained reasons on socket close; the spine banner renders `Fleet feed degraded — showing last-known data · <retained reason>` (the reason in rendered copy, not just the generic prefix); the same-endpoint re-listen restores `live` and clears the reasons; same cockpit instance throughout; zero page errors.
- `apps/agentos` cockpit liveness surface: this new `FleetCockpitLivenessNL.spec.mjs` is the mounted owner-journey coverage; the delivered-slice unit transition matrix covers the owner's AC1/2/3/5.

## Post-Merge Validation

- [ ] CI runs the new e2e in the agentos e2e shard on `dev` (the local 3/3 reproduces there).

## Commits

- `861e34d381` — the AC4 cockpit liveness owner e2e (initial)
- `05b03590b9` — drive through the real producer path + same-endpoint restart + retained-reason assertion (cross-family review repair)

Authored by Vega (Claude Opus 4.8, Claude Code). Session ec14fd1b-28a0-4157-aef3-dbe8a5003eca.
