### PR TITLE
fix(agentos): FM hover transitions ride the motion vocabulary (#15509)

### DIFF
--- a/resources/scss/src/apps/agentos/Viewport.scss
+++ b/resources/scss/src/apps/agentos/Viewport.scss
@@ -34,7 +34,7 @@
         box-shadow   : none;
         font-family  : var(--fm-font-sans);
         font-weight  : 500;
-        transition   : background .15s ease, border-color .15s ease, color .15s ease;
+        transition   : background var(--motion-fast) var(--ease-out-soft), border-color var(--motion-fast) var(--ease-out-soft), color var(--motion-fast) var(--ease-out-soft);
 
         &:hover {
             border-color: var(--fm-ink-dim);

--- a/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoAWorkspace.scss
+++ b/resources/scss/src/apps/agentos/childapps/dockdemo/view/DemoAWorkspace.scss
@@ -58,7 +58,7 @@
         background   : var(--fm-line);
         border-radius: 3px;
         height    : 5px;
-        transition: background .25s ease;
+        transition: background var(--motion-base) var(--ease-out-soft);
         width     : 14px;
     }
 

--- a/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
+++ b/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
@@ -18,7 +18,7 @@
             color        : var(--fm-ink-dim);
             box-shadow   : none;
             font-weight  : 500;
-            transition   : background .15s ease, border-color .15s ease, color .15s ease;
+            transition   : background var(--motion-fast) var(--ease-out-soft), border-color var(--motion-fast) var(--ease-out-soft), color var(--motion-fast) var(--ease-out-soft);
 
             &:hover {
                 border-color: var(--fm-ink-dim);
@@ -45,7 +45,7 @@
             color        : var(--fm-signal);
             box-shadow   : none;
             font-weight  : 600;
-            transition   : background .15s ease, border-color .15s ease, color .15s ease;
+            transition   : background var(--motion-fast) var(--ease-out-soft), border-color var(--motion-fast) var(--ease-out-soft), color var(--motion-fast) var(--ease-out-soft);
 
             &:hover {
                 border-color: var(--fm-signal);

--- a/resources/scss/src/apps/agentos/fleet/HealthBar.scss
+++ b/resources/scss/src/apps/agentos/fleet/HealthBar.scss
@@ -6,7 +6,7 @@
 
     @media (prefers-reduced-motion: no-preference) {
         &.fm-animate-counts .fm-sw-count {
-            transition: color .3s ease, opacity .3s ease;
+            transition: color var(--motion-base) var(--ease-out-soft), opacity var(--motion-base) var(--ease-out-soft);
         }
     }
 }

--- a/test/playwright/e2e/agentos/FmReducedMotionCollapse.spec.mjs
+++ b/test/playwright/e2e/agentos/FmReducedMotionCollapse.spec.mjs
@@ -1,0 +1,67 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Gate-3 rendered witness: the FM hover transitions that ride the motion vocabulary actually
+ * COLLAPSE under `prefers-reduced-motion: reduce` in the live browser, and animate under
+ * `no-preference`. The ratified motion audit rejects source inference as motion evidence — this reads
+ * the browser's COMPUTED values on the mounted surface, across both vocabulary tiers the cleanup touches:
+ *
+ * - `--motion-fast` (the `.agent-button` / `.fm-preset-button` / `.fm-fleet-start` hover pairs), proven
+ *   on a real rendered cockpit-bar button's computed `transition-duration`;
+ * - `--motion-fast` AND `--motion-base` (the `--motion-base` tier carries the `DemoAWorkspace` pip +
+ *   the `HealthBar` count fade), proven by the document-root computed token values — the live cascade
+ *   resolution of `_motion.scss`'s `prefers-reduced-motion` override, not a source read.
+ *
+ * A pure-CSS witness (no Neural Link): the collapse is browser cascade behaviour, so `page.emulateMedia`
+ * + `getComputedStyle` is the faithful probe. Companion to the merged selector-strip motion witness.
+ *
+ * Run: NEO_E2E_PORT=8121 npx playwright test agentos/FmReducedMotionCollapse -c test/playwright/playwright.config.e2e.mjs --workers=1
+ *
+ * @see resources/scss/_motion.scss (the vocabulary + the reduced-motion collapse this witnesses)
+ * @see apps/agentos/view/fleet/FleetCockpit.mjs (the cockpit-bar buttons carrying --motion-fast)
+ */
+test.describe('AgentOS FM motion vocabulary — reduced-motion collapse witness (#15509)', () => {
+    test.setTimeout(90000);
+
+    test('the hover transitions collapse to 0s under prefers-reduced-motion and animate under no-preference', async ({page}) => {
+        await page.goto('/apps/agentos/index.html');
+        await expect(page.locator('.fm-fleet-cockpit')).toBeVisible({timeout: 60000});
+
+        // a real cockpit-bar button carries the --motion-fast hover transition (ungated)
+        const button = page.locator('.fm-cockpit-bar .neo-button').first();
+
+        await expect(button).toBeVisible({timeout: 30000});
+
+        // custom properties inherit, so the button carries the effective (theme-scoped) token values —
+        // read them where they resolve, not at :root (the FM tokens are scoped to an app/theme ancestor)
+        const readTokens = () => button.evaluate(el => {
+            const s = getComputedStyle(el);
+            return {fast: s.getPropertyValue('--motion-fast').trim(), base: s.getPropertyValue('--motion-base').trim()}
+        });
+
+        // ── reduced motion: the tokens collapse, so the rendered transition is 0s ────────────────
+        await page.emulateMedia({reducedMotion: 'reduce'});
+
+        const collapsed = await button.evaluate(el => getComputedStyle(el).transitionDuration);
+
+        expect(collapsed, 'the button hover transition collapses to 0s under reduced motion')
+            .toMatch(/^0s(,\s*0s)*$/);
+
+        const reducedTokens = await readTokens();
+
+        expect(reducedTokens.fast, '--motion-fast collapses to 0ms under reduced motion (the .agent-button / cockpit-bar tier)').toBe('0ms');
+        expect(reducedTokens.base, '--motion-base collapses to 0ms under reduced motion (the pip + health-bar tier)').toBe('0ms');
+
+        // ── no preference: the transition is real (non-zero), so motion still exists when allowed ─
+        await page.emulateMedia({reducedMotion: 'no-preference'});
+
+        const animated = await button.evaluate(el => getComputedStyle(el).transitionDuration);
+
+        expect(animated, 'the button hover transition animates under no-preference').not.toMatch(/^0s/);
+
+        const preferenceTokens = await readTokens();
+
+        expect(preferenceTokens.fast, '--motion-fast is non-zero under no-preference').not.toBe('0ms');
+        expect(preferenceTokens.base, '--motion-base is non-zero under no-preference').not.toBe('0ms')
+    });
+});


### PR DESCRIPTION
Resolves #15509

Every AgentOS demo/product hover transition now consumes the shared motion vocabulary, so `_motion.scss`'s `prefers-reduced-motion` → `0ms` collapse governs them with no call-site literal opting out. Five duration/easing literals moved onto the vocabulary:

- `--motion-fast` (hover micro-feedback): `Viewport.scss:37` `.agent-button`, `FleetCockpit.scss:21` `.fm-preset-button`, `:48` `.fm-fleet-start` (the three `.15s ease` sites).
- `--motion-base` (state transitions): `DemoAWorkspace.scss:61` `.agentos-dockdemo-pip` (`.25s ease`, was ungated → active under reduced motion) and `HealthBar.scss:9` `.fm-sw-count` (`.3s ease`).

`StateDot.scss:23`'s `2.4s ease-in-out` keyframe pulse deliberately stays a literal: it's a bespoke animation with no vocabulary token, and it is already `prefers-reduced-motion: no-preference`-gated.

Evidence: L3 (a mounted, computed-style rendered witness under `prefers-reduced-motion` emulation) → L3 required (the #14780 motion audit's Gate 3 rejects source inference for a motion claim). Residual: none.

## Deltas from ticket

Scope corrected under cross-family review: the close-target AC is duration/easing-literal-free repo-wide in AgentOS, so the census encodes the RULE, not the initial `.15s` specimen — a full grep found the two survivors (`DemoAWorkspace`, `HealthBar`) now folded in. `--motion-base` is the state-transition tier for the two additions (the `.25s`/`.3s` fades). StateDot is the one intentional exception (documented above).

## Test Evidence

- **Complete census** — `grep -rE 'transition[^;]*[0-9]+m?s|animation[^;]*[0-9]+m?s'` over `resources/scss/src/apps/agentos/` (excluding `var(--motion|--ease)`) → only `StateDot.scss:23` (the out-of-scope gated keyframe pulse) remains; all five transition literals are gone.
- **Rendered reduced-motion witness** — `test/playwright/e2e/agentos/FmReducedMotionCollapse.spec.mjs`: on the mounted cockpit, a real cockpit-bar button's computed `transition-duration` is `0s` under `prefers-reduced-motion: reduce` and non-zero under `no-preference`; both `--motion-fast` and `--motion-base` (as inherited by the surface) collapse to `0ms` under reduce. `NEO_E2E_PORT=8133 npx playwright test agentos/FmReducedMotionCollapse …` → **1 passed (7.0s)**.
- Theme rebuild clean (`node ./buildScripts/build/themes.mjs -f -n -t all -e dev`, 640 files); built AgentOS CSS emits the tokens with zero surviving `.15s`/`.25s`/`.3s` transition literals.

## Post-Merge Validation

- [ ] CI theme-build + lint + the new e2e green on `dev`.

## Commits

- `3b8c9a73bd` — the three `.15s ease` → `var(--motion-fast) var(--ease-out-soft)` swaps
- `f48710fbde` — the two census survivors (`.25s`/`.3s` → `var(--motion-base)`) + the Gate-3 rendered reduced-motion witness (cross-family review repair)

Authored by Vega (Claude Opus 4.8, Claude Code). Session ec14fd1b-28a0-4157-aef3-dbe8a5003eca.
