### PR TITLE
feat(dashboard): the dockItemId stamp reaches header buttons — structural focus identity (#15517)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -1,23 +1,23 @@
-import Component                          from '../../../../../src/component/Base.mjs';
-import Container                          from '../../../../../src/container/Base.mjs';
-import CounterPane                        from './CounterPane.mjs';
-import DockDropIndicators                 from '../../../../../src/dashboard/DockDropIndicators.mjs';
-import DockLayoutAdapter                  from '../../../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockMotionSignal                   from '../../../../../src/dashboard/DockMotionSignal.mjs';
-import DockPerspectiveStore               from '../../../../../src/dashboard/DockPerspectiveStore.mjs';
-import DockPreview                        from '../../../../../src/dashboard/DockPreview.mjs';
-import DockPreviewProducer                from '../../../../../src/dashboard/DockPreviewProducer.mjs';
-import DockProjectionReconciler           from '../../../../../src/dashboard/DockProjectionReconciler.mjs';
-import DockService                        from '../../../../../src/ai/client/DockService.mjs';
-import DockTopologyReconciler             from '../../../../../src/dashboard/DockTopologyReconciler.mjs';
-import DockZoneModel                      from '../../../../../src/dashboard/DockZoneModel.mjs';
-import InteractionService                 from '../../../../../src/ai/client/InteractionService.mjs';
-import {createDockKeyboardCommands}       from '../../../../../src/dashboard/DockKeyboardCommands.mjs';
-import {createDockTearOutHandlers}        from '../../../../../src/dashboard/DockTearOut.mjs';
-import {createDockWorkspaceSet}           from '../../../../../src/dashboard/DockWorkspaceSet.mjs';
-import TourRunner                         from '../../../../../src/ai/client/TourRunner.mjs';
+import Component                            from '../../../../../src/component/Base.mjs';
+import Container                            from '../../../../../src/container/Base.mjs';
+import CounterPane                          from './CounterPane.mjs';
+import DockDropIndicators                   from '../../../../../src/dashboard/DockDropIndicators.mjs';
+import DockLayoutAdapter                    from '../../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockMotionSignal                     from '../../../../../src/dashboard/DockMotionSignal.mjs';
+import DockPerspectiveStore                 from '../../../../../src/dashboard/DockPerspectiveStore.mjs';
+import DockPreview                          from '../../../../../src/dashboard/DockPreview.mjs';
+import DockPreviewProducer                  from '../../../../../src/dashboard/DockPreviewProducer.mjs';
+import DockProjectionReconciler             from '../../../../../src/dashboard/DockProjectionReconciler.mjs';
+import DockService                          from '../../../../../src/ai/client/DockService.mjs';
+import DockTopologyReconciler               from '../../../../../src/dashboard/DockTopologyReconciler.mjs';
+import DockZoneModel                        from '../../../../../src/dashboard/DockZoneModel.mjs';
+import InteractionService                   from '../../../../../src/ai/client/InteractionService.mjs';
+import {createDockKeyboardCommands}         from '../../../../../src/dashboard/DockKeyboardCommands.mjs';
+import {createDockTearOutHandlers}          from '../../../../../src/dashboard/DockTearOut.mjs';
+import {createDockWorkspaceSet}             from '../../../../../src/dashboard/DockWorkspaceSet.mjs';
+import TourRunner                           from '../../../../../src/ai/client/TourRunner.mjs';
 import {PREVIEW_SCHEMA, previewToOperation} from '../../../../../src/dashboard/dockPreviewContract.mjs';
-import {demoBTourScript, initialDocument} from '../../../tour/demoBPerspectives.mjs';
+import {demoBTourScript, initialDocument}   from '../../../tour/demoBPerspectives.mjs';
 import '../../../../../src/button/Base.mjs';   // registers the `button` ntype the bars compose
 import '../../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits
 import '../../../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype the bars use
@@ -554,13 +554,16 @@ class DemoBWorkspace extends Container {
 
     /**
      * @summary Resolve the dock item the keydown acted on: the event path's tab-header button →
-     * its header toolbar index → the owning projected tab-container's `dockNodeId` → its
-     * WORKSPACE's document tabs node items at that index. The document is the authority on
-     * purpose: DemoB's panes are LIVE instances, which the adapter's item decoration deliberately
-     * passes through untouched — only the freshly-projected CONTAINER configs carry dock
-     * metadata, so the container's node id + the committed document answer identity where the
-     * card cannot. Which document is answered by host containment ({@link #resolveDockWorkspaceId}),
-     * so a popup-origin keydown resolves against the popup workspace's truth.
+     * its `dockItemId` STAMP when present (structural identity — the projection writes it into
+     * every header config it builds, so identity never depends on header order ≡ document
+     * order), else the positional fallback: header toolbar index → the owning projected
+     * tab-container's `dockNodeId` → its WORKSPACE's document tabs node items at that index.
+     * The document is the authority on purpose: DemoB's panes are LIVE instances, which the
+     * adapter's item decoration deliberately passes through untouched — only freshly-projected
+     * CONTAINER configs carry dock metadata, so the container's node id + the committed document
+     * answer identity where the card cannot. Which document is answered by host containment
+     * ({@link #resolveDockWorkspaceId}), so a popup-origin keydown resolves against the popup
+     * workspace's truth.
      * @param {Object} data The keydown DomEvent payload (carries the component path).
      * @returns {Object|null} `{itemId, itemLabel, workspaceId}` or `null` when the focus is not a dock tab header.
      * @protected
@@ -574,16 +577,27 @@ class DemoBWorkspace extends Container {
         if (!button) return null;
 
         let toolbar      = button.up({ntype: 'tab-header-toolbar'}) || button.parent,
-            index        = toolbar?.items?.indexOf(button) ?? -1,
             tabContainer = toolbar?.up({ntype: 'tab-container'}),
             workspaceId  = me.resolveDockWorkspaceId(tabContainer),
-            document     = workspaceId ? me.getWorkspaceDocument(workspaceId) : null,
+            document     = workspaceId ? me.getWorkspaceDocument(workspaceId) : null;
+
+        // structural identity first: the projection's own stamp, immune to any future
+        // pinning/reorder/hidden-class change in header order
+        if (button.dockItemId) {
+            return {
+                itemId   : button.dockItemId,
+                itemLabel: document?.items?.[button.dockItemId]?.title ?? button.dockItemId,
+                workspaceId
+            }
+        }
+
+        let index = toolbar?.items?.indexOf(button) ?? -1,
             // the projection filters rail-hidden items out of the tab flow — mirror it so the
             // header index maps to the same list the strip renders
-            nodeItems    = document?.nodes?.[tabContainer?.dockNodeId]?.items?.filter(id =>
+            nodeItems = document?.nodes?.[tabContainer?.dockNodeId]?.items?.filter(id =>
                 document.items?.[id]?.autoHidden !== true
             ),
-            itemId       = index > -1 && Array.isArray(nodeItems) ? nodeItems[index] : null;
+            itemId    = index > -1 && Array.isArray(nodeItems) ? nodeItems[index] : null;
 
         if (!itemId) return null;
 

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -56,7 +56,7 @@ class DockLayoutAdapter extends Base {
                 missingComponentRef: true
             },
             dockItemId: itemId,
-            header    : {text: title},
+            header    : {text: title, dockItemId: itemId},
             ntype     : 'dashboard-panel'
         }
     }
@@ -108,7 +108,14 @@ class DockLayoutAdapter extends Base {
 
         config.data       = data;
         config.dockItemId = itemId;
-        config.header     = config.header || {text: item?.title || itemId};
+        // The stamp must reach the HEADER too: tab.Container builds each header button from this
+        // object, so the button instance then carries the identity structurally — the keyboard
+        // focus path never has to map header position back into document order. (Live panes skip
+        // this decorator by design; their identity resolves through the committed document.)
+        config.header     = {
+            ...(config.header || {text: item?.title || itemId}),
+            dockItemId: itemId
+        };
 
         return config
     }

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
@@ -890,6 +890,36 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
         popupHost.destroy()
     });
 
+    test('resolveFocusedDockItem prefers the dockItemId STAMP and falls back for live panes (#15517)', () => {
+        const sideTabs  = workspace.getReference('dock-host-b').down({dockNodeId: 'side-tabs'}),
+              toolbar   = sideTabs.down({ntype: 'tab-header-toolbar'}),
+              buttons   = toolbar.items,
+              sideItems = workspace.getDockZoneDocument().nodes['side-tabs'].items;
+
+        // DemoB's panes are LIVE instances — the adapter passes them through untouched by design,
+        // so their buttons carry NO stamp and keep the positional fallback (the untouched discipline)
+        expect(buttons.length).toBe(sideItems.length);
+        buttons.forEach(button => expect(button.dockItemId).toBeUndefined());
+
+        // non-1:1 order: move the second header to the front WITHOUT touching the document.
+        // A stamped button resolves STRUCTURALLY — the positional slot would mis-map
+        const moved = buttons[1];
+
+        moved.dockItemId = 'timeline'; // the stamp, as written by the projection for plain configs
+        toolbar.remove(moved, false);
+        toolbar.insert(0, moved);
+
+        expect(toolbar.items.indexOf(moved)).toBe(0);
+
+        const focused = workspace.resolveFocusedDockItem({path: [{id: moved.id}]});
+
+        expect(focused.itemId, 'the stamp branch wins over the reordered position').toBe('timeline');
+        expect(sideItems[0], '…while the positional slot now names a different item').not.toBe('timeline');
+        expect(focused.itemLabel).toBe('Timeline');
+        expect(focused.workspaceId).toBe(DemoBWorkspace.MAIN_WORKSPACE_ID)
+    });
+
+
     test('resolveFocusedDockItem answers popup-origin identity from the POPUP workspace document', () => {
         // stage a real transfer so the popup document owns the workbench item
         const detached = DockZoneModel.transferItem(

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpitProjection.spec.mjs
@@ -189,7 +189,7 @@ test.describe('Fleet cockpit — dock projection wiring (the resize commit loop)
             const absent = options.resolveItem('fleet');
 
             expect(absent.module).toBe(FleetGrid);
-            expect(absent.header).toEqual({text: 'Fleet'});
+            expect(absent.header).toEqual({text: 'Fleet', dockItemId: 'fleet'});
             expect(absent.dockItemId).toBe('fleet');
             expect(absent.data).toMatchObject({componentRef: 'fleet-grid', dockItemId: 'fleet'})
         } finally {

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -6,16 +6,19 @@ setup({
     }
 });
 
-import {test, expect}     from '@playwright/test';
-import Neo                from '../../../../src/Neo.mjs';
-import * as core          from '../../../../src/core/_export.mjs';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import '../../../../src/manager/Instance.mjs'; // defines Neo.get — the container child-add path resolves parents through it
 import Component          from '../../../../src/component/Base.mjs';
 import DockLayoutAdapter  from '../../../../src/dashboard/DockLayoutAdapter.mjs';
 import DockRail           from '../../../../src/dashboard/DockRail.mjs';
 import DockSplitter       from '../../../../src/dashboard/DockSplitter.mjs';
 import DockTabEnterButton from '../../../../src/dashboard/DockTabEnterButton.mjs';
 import DockZoneModel      from '../../../../src/dashboard/DockZoneModel.mjs';
-import TabOverflowPlugin  from '../../../../src/tab/plugin/Overflow.mjs';
+import '../../../../src/dashboard/Panel.mjs'; // registers the `dashboard-panel` ntype the projected items use
+import TabContainer      from '../../../../src/tab/Container.mjs';
+import TabOverflowPlugin from '../../../../src/tab/plugin/Overflow.mjs';
 
 const createModel = () => ({
     schema: 'neo.harness.dockZone.v1',
@@ -264,6 +267,48 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         expect(result.items[0].activeIndex).toBe(1);
         expect(result.items[0].items.map(item => item.header.text)).toEqual(['Strategy', 'Swarm']);
         expect(result.items[0].items.map(item => item.data.dockItemId)).toEqual(['strategy', 'swarm']);
+    });
+
+    test('the dockItemId stamp reaches header CONFIGS and live header BUTTONS, order-agnostic (#15517)', () => {
+        let result = DockLayoutAdapter.project(createModel(), {
+            resolveComponentRef: componentRef => componentRef === 'missing' ? null : ({
+                ntype    : 'dashboard-panel',
+                reference: componentRef
+            })
+        });
+
+        // config level: resolver-returned plain configs carry the stamp in their header
+        expect(result.items[0].items.map(item => item.header.dockItemId)).toEqual(['strategy', 'swarm']);
+
+        // the placeholder path (absent resolver) carries it too — locate by the stamped node id,
+        // agnostic to the interleaved splitter positions
+        const sideSplit   = result.items.find(item => item.dockNodeType === 'split'),
+              missingTabs = sideSplit.items.find(item => item.dockNodeId === 'missing-tabs');
+
+        expect(missingTabs.items[0].header.dockItemId).toBe('missing');
+
+        // button level: a real tab.Container built from the projection carries the stamp on
+        // every header BUTTON instance — and it follows the button, not the position
+        const tabContainer = Neo.create({
+            module: TabContainer,
+            ...result.items[0]
+        });
+        let buttons = tabContainer.getTabBar().items;
+
+        expect(buttons.map(button => button.dockItemId)).toEqual(['strategy', 'swarm']);
+
+        // non-1:1 order: reorder the buttons — the stamp stays with ITS button
+        const moved = buttons[1];
+
+        tabContainer.getTabBar().remove(moved, false);
+        tabContainer.getTabBar().insert(0, moved);
+        buttons = tabContainer.getTabBar().items;
+
+        expect(buttons[0]).toBe(moved);
+        expect(buttons[0].dockItemId).toBe('swarm');
+        expect(buttons[1].dockItemId).toBe('strategy');
+
+        tabContainer.destroy()
     });
 
     test('a transient addTab correlation decorates only the exact target header without mutating the model', () => {


### PR DESCRIPTION
Resolves #15517

The keyboard focus path's identity is now **structural, not positional**. The projection stamps `dockItemId` into every header config it writes (`decorateItemConfig` for plain configs, `createPlaceholder` for placeholders), so every projected tab-header **button** carries its item's identity on the instance — and `resolveFocusedDockItem` prefers that stamp over the header-index → document-index positional map. Live panes stay deliberately untouched (the adapter's pass-through discipline), and their identity keeps the positional fallback, so nothing regresses for DemoB's live-pane reality.

Evidence: L1 (unit suites) → L1 required (projection/config-layer change with discriminating witnesses). Residual: none for this close-target.

## Deltas from ticket

- The stamp lives in the **shared adapter** (`DockLayoutAdapter.mjs`), not only DemoB — every dock projection (cockpit included) gets stamped headers for free as an additive config field. Consumption stays DemoB-local per the ticket's scope; no non-DemoB host behavior changes.
- The placeholder path needed the stamp explicitly (`createPlaceholder` skipped `decorateItemConfig`) — added, so absent-resolver items are structural too.

## Test Evidence

- `test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs` — new witness: config-level stamps on plain configs AND on the placeholder path; a **real `tab.Container`** built from the projection carries the stamp on every header-button instance, and after a button reorder the stamp **follows the button, not the position** (`['strategy','swarm']` → moved → `['swarm','strategy']` by instance, ids unchanged).
- `test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs` — new witness: DemoB's live-pane buttons carry **no** stamp (the untouched discipline, asserted), the positional fallback keeps resolving, and a stamped button under a non-1:1 header order resolves structurally (the stamp branch wins over the reordered slot; the positional slot would have named a different item).
- Both suites plus the landed #15485 keyboard suites reproduce: **63/63** at the change head (`DockLayoutAdapter` 35/35, `DemoBWorkspace` 28/28).
- check-block-alignment applied; agent-preflight all gates.

## Post-Merge Validation

- [ ] The #15505 keyboard suites continue green in CI (the focus path's behavior is unchanged for today's 1:1 projections — the stamp only hardens the future case).
- [ ] If a projection reorder/pin feature ever lands, this leaf's witness is the proof it cannot silently mis-map.

Authored by Phoebe (Kimi K3, OpenCode). Session 9b748a56-8b84-43bf-a542-ee8dcf437ebf.
