### PR TITLE
feat(agentos): AgentCard rebaseline direction D mockup — status-first, two-row, actions-in-flow (#15536)

### DIFF
--- a/apps/agentos/design/agentcard-rebaseline-d.html
+++ b/apps/agentos/design/agentcard-rebaseline-d.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>AgentCard rebaseline — direction D: status-first, two-row, actions-in-flow</title>
+<style>
+  :root {
+    --ground:#0b0e13; --panel:#141a23; --panel-2:#1a212c; --rail:#0e131a;
+    --line:#262f3d; --line-soft:#1c242f;
+    --ink:#d6dce6; --ink-dim:#8b97a8; --ink-faint:#5a6575;
+    --signal:#5eead4;
+    --ok:#34d399; --idle:#f5b544; --wedged:#f4718b; --limited:#a78bfa; --off:#5b6675;
+    --f-claude:#d99a5b; --f-gpt:#58c093; --f-gemini:#6ba3e8; --f-human:#c9d2de;
+    --mono:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+    --sans:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+  }
+  *{box-sizing:border-box}
+  body{margin:0;background:var(--ground);color:var(--ink);font-family:var(--sans);
+       line-height:1.5;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1120px;margin:0 auto;padding:36px 24px 64px}
+  .eyebrow{font-family:var(--mono);font-size:11.5px;letter-spacing:.22em;text-transform:uppercase;color:var(--signal);margin:0}
+  h1{font-size:26px;letter-spacing:-.01em;margin:10px 0 6px;font-weight:640}
+  .lede{font-size:14px;color:var(--ink-dim);max-width:74ch;margin:0 0 26px}
+  .grid{display:flex;flex-wrap:wrap;gap:18px;align-items:flex-start}
+  .grid > div{flex:none}
+  .col-label{font-family:var(--mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;
+             color:var(--ink-faint);margin:0 0 8px}
+  .col-label b{color:var(--ink-dim);font-weight:500}
+
+  /* ── the D card ── */
+  .card{background:var(--panel);border:1px solid var(--line-soft);border-radius:9px;
+        padding:10px 12px;position:relative;display:flex;flex-direction:column;gap:8px}
+  .card::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;border-radius:9px 0 0 9px;background:var(--fam,#58c093)}
+
+  .status-row{display:flex;align-items:center;gap:8px;min-height:32px}
+  .dot{width:9px;height:9px;border-radius:50%;background:var(--state,#34d399);flex:none}
+  .state-word{font-family:var(--mono);font-size:10px;color:var(--ink-dim);flex:none}
+  .state-word.hot{color:var(--state);font-weight:600}
+  .name{font-weight:600;font-size:14px;color:var(--ink);flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .actions{display:flex;gap:6px;flex:none}
+  .icon-btn{width:32px;height:32px;border-radius:6px;border:1px solid var(--line);background:var(--panel-2);
+            color:var(--ink-dim);font-size:13px;display:grid;place-items:center;cursor:pointer;font-family:var(--sans)}
+  .icon-btn:hover{border-color:var(--ink-dim);color:var(--ink)}
+  .icon-btn.power{color:var(--ink-dim)}
+
+  .work-row{display:flex;align-items:flex-start;gap:8px;min-height:34px}
+  .lane{font-size:12.5px;color:var(--ink);flex:1;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+  .badge{flex:none;font-family:var(--mono);font-size:10px;color:var(--ink-dim);border:1px solid var(--line);
+         border-radius:6px;padding:2px 7px;white-space:nowrap}
+
+  .strip{display:flex;gap:10px;font-family:var(--mono);font-size:10px;color:var(--ink-dim)}
+  .strip .src{display:flex;align-items:center;gap:4px}
+  .strip .src i{width:7px;height:7px;border-radius:50%;background:var(--ok);font-style:normal}
+  .strip .src i.dim{background:var(--off)}
+  .strip .src i.bad{background:var(--wedged)}
+
+  /* narrow-mode adjustments (the card's own width states) */
+  .card.narrow .engine{display:none}
+  .card.narrow .strip .src.full{display:none}
+  .card.narrow .strip .summary{display:flex}
+  .strip .summary{display:none;align-items:center;gap:4px}
+
+  .engine{font-family:var(--mono);font-size:10px;color:var(--ink-faint);flex:none}
+
+  .note{font-size:12px;color:var(--ink-dim);margin-top:8px;max-width:34ch}
+  .note b{color:var(--ink);font-weight:600}
+  .divider{border-top:1px solid var(--line-soft);margin:34px 0 26px}
+  .falsifier{font-family:var(--mono);font-size:11px;color:var(--ink-faint);margin-top:6px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <p class="eyebrow">AgentCard rebaseline · direction D</p>
+  <h1>Status-first, two-row, actions-in-flow</h1>
+  <p class="lede">The card at its own four width states. State and name share one glance; the lane clamps at two lines with the count pinned; actions are 32px in-flow, never dominant; the truth strip is one line or a tap-to-expand summary. Chrome is a 3px family edge — information gets ~85% of the width.</p>
+
+  <div class="grid">
+
+    <div>
+      <p class="col-label">wide · <b>480px</b></p>
+      <div class="card" style="width:480px;--fam:var(--f-gpt)">
+        <div class="status-row">
+          <span class="dot" style="--state:var(--ok)"></span>
+          <span class="state-word">working</span>
+          <span class="name">Euclid</span>
+          <span class="engine">gpt-5.6-s</span>
+          <span class="actions"><span class="icon-btn power">⏻</span><span class="icon-btn">↻</span></span>
+        </div>
+        <div class="work-row">
+          <span class="lane">NL transaction archive — the merge-sweep witness chain on the night queue</span>
+          <span class="badge">11 lanes</span>
+        </div>
+        <div class="strip">
+          <span class="src"><i></i>RUN</span><span class="src"><i></i>ROS</span><span class="src"><i class="dim"></i>REP</span>
+        </div>
+      </div>
+      <p class="note">everything on the contract, one calm read</p>
+    </div>
+
+    <div>
+      <p class="col-label">mobile · <b>360px</b></p>
+      <div class="card" style="width:360px;--fam:var(--f-claude)">
+        <div class="status-row">
+          <span class="dot" style="--state:var(--wedged)"></span>
+          <span class="state-word hot" style="--state:var(--wedged)">wedged</span>
+          <span class="name">Grace</span>
+          <span class="engine">opus-4.8</span>
+          <span class="actions"><span class="icon-btn power">⏻</span><span class="icon-btn">↻</span></span>
+        </div>
+        <div class="work-row">
+          <span class="lane">design authority — the AgentCard rebaseline and the D2 third channel landing</span>
+          <span class="badge">17 lanes</span>
+        </div>
+        <div class="strip">
+          <span class="src"><i></i>RUN</span><span class="src"><i class="bad"></i>ROS</span><span class="src"><i></i>REP</span>
+        </div>
+      </div>
+      <p class="note">severity = weight on the state word, identity never recedes</p>
+    </div>
+
+    <div>
+      <p class="col-label">current · <b>294px</b></p>
+      <div class="card" style="width:294px;--fam:var(--f-gemini)">
+        <div class="status-row">
+          <span class="dot" style="--state:var(--off)"></span>
+          <span class="state-word">benched / offline</span>
+          <span class="name">Gemini</span>
+          <span class="actions"><span class="icon-btn power">⏻</span></span>
+        </div>
+        <div class="work-row">
+          <span class="lane">operator-benched — the v3-line slip, waiting on a stable harness</span>
+          <span class="badge">3.1-pro</span>
+        </div>
+        <div class="strip">
+          <span class="src"><i class="dim"></i>RUN</span><span class="src"><i class="dim"></i>ROS</span><span class="src"><i class="dim"></i>REP</span>
+        </div>
+      </div>
+      <p class="note">the badge slot carries the engine when there's no lane count</p>
+    </div>
+
+    <div>
+      <p class="col-label">narrow · <b>240px</b></p>
+      <div class="card narrow" style="width:240px;--fam:var(--f-human)">
+        <div class="status-row">
+          <span class="dot" style="--state:var(--idle)"></span>
+          <span class="state-word">idle</span>
+          <span class="name">tobiu</span>
+          <span class="actions"><span class="icon-btn power">⏻</span></span>
+        </div>
+        <div class="work-row">
+          <span class="lane">merge sweep and the morning review queue</span>
+          <span class="badge">7 lanes</span>
+        </div>
+        <div class="strip">
+          <span class="src full"><i></i>RUN</span><span class="src full"><i></i>ROS</span><span class="src full"><i class="dim"></i>REP</span>
+          <span class="summary"><i></i>3 sources ▸</span>
+        </div>
+      </div>
+      <p class="note">engine hides, strip collapses to a tap summary, nothing truncates to a meaningless prefix</p>
+    </div>
+
+  </div>
+
+  <div class="divider"></div>
+
+  <p class="eyebrow">the falsifiers, answered</p>
+  <p class="falsifier">294px → 149.95px info body &nbsp;·&nbsp; ~85% width to information; chrome = 3px edge + 32px actions</p>
+  <p class="falsifier">48×48 power dominates &nbsp;·&nbsp; 32px in-flow icons; ≥44px touch height at narrow; never fully hidden (touch has no hover)</p>
+  <p class="falsifier">lane → meaningless prefix &nbsp;·&nbsp; 2-line clamp + badge pinned; prefix expendable, count exact</p>
+  <p class="falsifier">three 9px source rows &nbsp;·&nbsp; one 10px strip, collapsible to a summary at narrow</p>
+  <p class="falsifier">viewport-only breakpoints &nbsp;·&nbsp; card-owned width states (container query / ResizeObserver class — layout-blind)</p>
+
+  <p class="note" style="max-width:74ch;margin-top:20px">mockup by <b>Phoebe</b> (@neo-kimi-phoebe, Moonshot Kimi K3) — design-peer on #15536. The a11y invariants hold everywhere: state as text beside the dot (#15512/#15534), text-safe inks only, state-honesty markers verbatim, id-keyed cards. Severity changes the state word's weight — never the identity order.</p>
+</div>
+</body>
+</html>

--- a/apps/agentos/design/agentcard-rebaseline-d.html
+++ b/apps/agentos/design/agentcard-rebaseline-d.html
@@ -77,6 +77,7 @@
   <p class="eyebrow">AgentCard rebaseline · direction D (synthesis: identity-first base + narrow mechanics)</p>
   <h1>Identity first, then work, then truth — at the card's own width</h1>
   <p class="lede">The avatar spans a two-line identity column (name first, state second); the lane keeps its distinguishing tail through a two-line clamp; actions are native buttons, contextual, never dominant; the truth line is summary-default and never lies. Drag the width: the card owns the response.</p>
+  <p class="note" style="max-width:76ch;margin:0 0 22px"><b>Fixture boundary:</b> names + profile images are real roster identity anchors (live GitHub avatars); every state, lane, count, and source value below is a <b>synthetic fixture</b> — illustrative scenario data, not a claim about any peer.
 
   <div class="slider-row">
     <label for="w">card width</label>
@@ -86,7 +87,7 @@
 
   <div class="card" id="demo" data-width="regular" style="width:480px;--fam:var(--f-gpt)">
     <div class="head">
-      <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Ccircle cx='20' cy='20' r='20' fill='%2358c093'/%3E%3Ctext x='20' y='26' font-size='18' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EE%3C/text%3E%3C/svg%3E" alt="Euclid">
+      <img class="avatar" src="https://github.com/neo-gpt.png" alt="Euclid">
       <div class="identity">
         <div class="name-line">
           <span class="name">Euclid</span>
@@ -118,7 +119,7 @@
       <p class="col-label">wide · <b>720px</b></p>
       <div class="card" data-width="wide" style="width:720px;--fam:var(--f-claude)">
         <div class="head">
-          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Ccircle cx='20' cy='20' r='20' fill='%23d99a5b'/%3E%3Ctext x='20' y='26' font-size='18' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EG%3C/text%3E%3C/svg%3E" alt="Grace">
+          <img class="avatar" src="https://github.com/neo-opus-grace.png" alt="Grace">
           <div class="identity">
             <div class="name-line"><span class="name">Grace</span><span class="engine">opus-4.8</span></div>
             <div class="state-line">
@@ -142,7 +143,7 @@
       <p class="col-label">regular · <b>360px</b></p>
       <div class="card" data-width="regular" style="width:360px;--fam:var(--f-gpt)">
         <div class="head">
-          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Ccircle cx='20' cy='20' r='20' fill='%2358c093'/%3E%3Ctext x='20' y='26' font-size='18' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EA%3C/text%3E%3C/svg%3E" alt="Ada">
+          <img class="avatar" src="https://github.com/neo-opus-ada.png" alt="Ada">
           <div class="identity">
             <div class="name-line"><span class="name">Ada</span><span class="engine">opus-4.8</span></div>
             <div class="state-line">
@@ -166,19 +167,19 @@
       <p class="col-label">narrow · <b>294px</b></p>
       <div class="card" data-width="narrow" style="width:294px;--fam:var(--f-gemini)">
         <div class="head">
-          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Ccircle cx='16' cy='16' r='16' fill='%236ba3e8'/%3E%3Ctext x='16' y='21' font-size='14' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EG%3C/text%3E%3C/svg%3E" alt="Gemini">
+          <img class="avatar" src="https://github.com/neo-gemini-pro.png" alt="Gemini">
           <div class="identity">
             <div class="name-line"><span class="name">Gemini</span></div>
             <div class="state-line">
               <span class="dot" style="--state:var(--off)"></span>
-              <span class="state-word">benched / offline</span>
+              <span class="state-word">offline</span>
             </div>
           </div>
           <div class="actions">
             <button class="icon-btn" aria-label="Gemini actions" aria-haspopup="true" aria-expanded="false">⋯</button>
           </div>
         </div>
-        <div class="work-row"><span class="lane"><span class="lane-elide">operator-benched — … —</span><span class="lane-tail"> waiting on a stable harness</span></span></div>
+        <div class="work-row"><span class="lane"><span class="lane-elide">fixture lane west — … —</span><span class="lane-tail"> the synthetic disambiguating tail</span></span></div>
         <div class="strip"><i class="bad"></i><span>REP not nominal ▸</span></div>
       </div>
       <p class="note">engine hidden, ONE labelled 44px menu; the summary NAMES the degraded source</p>
@@ -188,7 +189,7 @@
       <p class="col-label">narrow-min · <b>280px</b></p>
       <div class="card" data-width="narrow" style="width:280px;--fam:var(--f-human)">
         <div class="head">
-          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Ccircle cx='16' cy='16' r='16' fill='%23c9d2de'/%3E%3Ctext x='16' y='21' font-size='14' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3ET%3C/text%3E%3C/svg%3E" alt="tobiu">
+          <img class="avatar" src="https://github.com/tobiu.png" alt="tobiu">
           <div class="identity">
             <div class="name-line"><span class="name">tobiu</span></div>
             <div class="state-line">
@@ -220,7 +221,7 @@
   <p class="falsifier">severity ≠ dot hue as text &nbsp;·&nbsp; the state word takes ink + weight (the 1.4.1→1.4.3 trap avoided by construction)</p>
   <p class="falsifier">responsiveness is card-owned &nbsp;·&nbsp; the slider above IS the mechanism (one DOM, stable tab order, width classes by the card's own measure); production uses container queries</p>
 
-  <p class="note" style="max-width:76ch;margin-top:20px">mockup by <b>Phoebe</b> (@neo-kimi-phoebe, Moonshot Kimi K3) — design-peer on #15536. Synthesis per Emmy's convergence audit (comment-5013162092): B/C identity-first base + D's tail-aware lane + one labelled narrow action + truthful summary-default sources + card-owned responsiveness. The a11y invariants hold everywhere: state as text beside the dot (#15512/#15534), text-safe inks only, state-honesty markers verbatim, native interactive elements only.</p>
+  <p class="note" style="max-width:76ch;margin-top:20px">mockup by <b>Phoebe</b> (@neo-kimi-phoebe, Moonshot Kimi K3) — design-peer on #15536. Synthesis per Emmy's convergence audit (comment-5013162092): B/C identity-first base + D's tail-aware lane + one labelled narrow action + truthful summary-default sources + card-owned responsiveness. The a11y invariants hold everywhere: state as text beside the dot (#15512/#15534), text-safe inks only, state-honesty markers verbatim, native interactive elements only. Fixture boundary: names + avatars are identity anchors (live GitHub profile images); all state/lane/count/source values are synthetic fixtures.</p>
 </div>
 <script>
   const card = document.getElementById('demo');

--- a/apps/agentos/design/agentcard-rebaseline-d.html
+++ b/apps/agentos/design/agentcard-rebaseline-d.html
@@ -35,6 +35,7 @@
 
   .status-row{display:flex;align-items:center;gap:8px;min-height:32px}
   .dot{width:9px;height:9px;border-radius:50%;background:var(--state,#34d399);flex:none}
+  .avatar{width:22px;height:22px;border-radius:50%;flex:none;object-fit:cover;background:var(--panel-2)}
   .state-word{font-family:var(--mono);font-size:10px;color:var(--ink-dim);flex:none}
   .state-word.hot{color:var(--state);font-weight:600}
   .name{font-weight:600;font-size:14px;color:var(--ink);flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
@@ -90,6 +91,7 @@
       <p class="col-label">wide · <b>720px</b></p>
       <div class="card" style="width:720px;--fam:var(--f-gpt)">
         <div class="status-row">
+          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22'%3E%3Ccircle cx='11' cy='11' r='11' fill='%2358c093'/%3E%3Ctext x='11' y='15' font-size='10' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EE%3C/text%3E%3C/svg%3E" alt="Euclid">
           <span class="dot" style="--state:var(--ok)"></span>
           <span class="state-word">working</span>
           <span class="name">Euclid</span>
@@ -111,6 +113,7 @@
       <p class="col-label">regular · <b>360px</b></p>
       <div class="card" style="width:360px;--fam:var(--f-claude)">
         <div class="status-row">
+          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22'%3E%3Ccircle cx='11' cy='11' r='11' fill='%23d99a5b'/%3E%3Ctext x='11' y='15' font-size='10' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EG%3C/text%3E%3C/svg%3E" alt="Grace">
           <span class="dot" style="--state:var(--wedged)"></span>
           <span class="state-word hot" style="--state:var(--wedged)">wedged</span>
           <span class="name">Grace</span>
@@ -132,6 +135,7 @@
       <p class="col-label">narrow · <b>294px</b></p>
       <div class="card narrow" style="width:294px;--fam:var(--f-gemini)">
         <div class="status-row">
+          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22'%3E%3Ccircle cx='11' cy='11' r='11' fill='%236ba3e8'/%3E%3Ctext x='11' y='15' font-size='10' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EG%3C/text%3E%3C/svg%3E" alt="Gemini">
           <span class="dot" style="--state:var(--off)"></span>
           <span class="state-word">benched / offline</span>
           <span class="name">Gemini</span>
@@ -143,16 +147,17 @@
         </div>
         <div class="strip">
           <span class="src full"><i class="dim"></i>RUN</span><span class="src full"><i class="dim"></i>ROS</span><span class="src full"><i class="dim"></i>REP</span>
-          <span class="summary"><i class="dim"></i>all sources nominal ▸</span>
+          <span class="summary"><i class="bad"></i>REP not nominal ▸</span>
         </div>
       </div>
-      <p class="note">narrow mode: engine hidden, strip collapsed to a one-line summary, actions collapse to ONE 44px overflow button</p>
+      <p class="note">narrow mode: engine hidden, the summary NAMES the degraded source (REP not nominal), actions collapse to ONE 44px overflow button</p>
     </div>
 
     <div>
       <p class="col-label">narrow-min · <b>280px</b></p>
       <div class="card narrow" style="width:280px;--fam:var(--f-human)">
         <div class="status-row">
+          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22'%3E%3Ccircle cx='11' cy='11' r='11' fill='%23c9d2de'/%3E%3Ctext x='11' y='15' font-size='10' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3ET%3C/text%3E%3C/svg%3E" alt="tobiu">
           <span class="dot" style="--state:var(--idle)"></span>
           <span class="state-word">idle</span>
           <span class="name">tobiu</span>
@@ -178,7 +183,8 @@
   <p class="falsifier">294px → 149.95px info body &nbsp;·&nbsp; ~85% width to information; chrome = 3px edge + 32px actions</p>
   <p class="falsifier">48×48 power dominates &nbsp;·&nbsp; 32px in-flow icons at regular+; ONE 44px overflow button at narrow (~16% of a 280px row, never 34%)</p>
   <p class="falsifier">lane → meaningless prefix &nbsp;·&nbsp; 2-line clamp with the distinguishing TAIL preserved (shared middle elides); badge pinned</p>
-  <p class="falsifier">three 9px source rows &nbsp;·&nbsp; summary-DEFAULT strip ("all sources nominal"); degraded sources name themselves — no acronym wall in either direction</p>
+  <p class="falsifier">three 9px source rows &nbsp;·&nbsp; summary-DEFAULT strip that never lies: healthy reads "all sources nominal ▸", degraded NAMES the source ("REP not nominal ▸")</p>
+  <p class="falsifier">avatar is identity, not chrome &nbsp;·&nbsp; 22px in the status row (family-hue ring); the card's "who" keeps its face at every width</p>
   <p class="falsifier">viewport-only breakpoints &nbsp;·&nbsp; card-owned width states (narrow &lt;320, regular 320–560, wide &gt;560 — 294px classifies narrow)</p>
   <p class="falsifier">touch targets eat narrow rows &nbsp;·&nbsp; one 44px overflow button at narrow; the two icons only exist where 32px is cheap</p>
 

--- a/apps/agentos/design/agentcard-rebaseline-d.html
+++ b/apps/agentos/design/agentcard-rebaseline-d.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>AgentCard rebaseline — direction D: status-first, two-row, actions-in-flow</title>
+<title>AgentCard rebaseline — direction D: identity-first + narrow mechanics (synthesis)</title>
 <style>
   :root {
     --ground:#0b0e13; --panel:#141a23; --panel-2:#1a212c; --rail:#0e131a;
@@ -21,174 +21,217 @@
   .wrap{max-width:1120px;margin:0 auto;padding:36px 24px 64px}
   .eyebrow{font-family:var(--mono);font-size:11.5px;letter-spacing:.22em;text-transform:uppercase;color:var(--signal);margin:0}
   h1{font-size:26px;letter-spacing:-.01em;margin:10px 0 6px;font-weight:640}
-  .lede{font-size:14px;color:var(--ink-dim);max-width:74ch;margin:0 0 26px}
-  .grid{display:flex;flex-wrap:wrap;gap:18px;align-items:flex-start}
-  .grid > div{flex:none}
+  .lede{font-size:14px;color:var(--ink-dim);max-width:76ch;margin:0 0 26px}
+  .row{display:flex;flex-wrap:wrap;gap:18px;align-items:flex-start}
   .col-label{font-family:var(--mono);font-size:11px;letter-spacing:.14em;text-transform:uppercase;
              color:var(--ink-faint);margin:0 0 8px}
   .col-label b{color:var(--ink-dim);font-weight:500}
 
-  /* ── the D card ── */
+  /* ── the synthesis card: avatar spanning a two-line identity column ── */
   .card{background:var(--panel);border:1px solid var(--line-soft);border-radius:9px;
-        padding:10px 12px;position:relative;display:flex;flex-direction:column;gap:8px}
+        padding:10px 12px;position:relative;display:grid;gap:8px}
   .card::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;border-radius:9px 0 0 9px;background:var(--fam,#58c093)}
 
-  .status-row{display:flex;align-items:center;gap:8px;min-height:32px}
+  .head{display:flex;gap:10px;align-items:flex-start}
+  .avatar{width:40px;height:40px;border-radius:50%;flex:none;object-fit:cover;background:var(--panel-2)}
+  .card[data-width="narrow"] .avatar{width:32px;height:32px}
+  .identity{flex:1;min-width:0}
+  .name-line{display:flex;align-items:center;gap:8px}
+  .name{font-weight:600;font-size:14px;color:var(--ink);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .engine{font-family:var(--mono);font-size:10px;color:var(--ink-faint);flex:none}
+  .card[data-width="narrow"] .engine{display:none}
+  .state-line{display:flex;align-items:center;gap:8px;margin-top:4px}
   .dot{width:9px;height:9px;border-radius:50%;background:var(--state,#34d399);flex:none}
-  .avatar{width:22px;height:22px;border-radius:50%;flex:none;object-fit:cover;background:var(--panel-2)}
   .state-word{font-family:var(--mono);font-size:10px;color:var(--ink-dim);flex:none}
-  .state-word.hot{color:var(--state);font-weight:600}
-  .name{font-weight:600;font-size:14px;color:var(--ink);flex:1;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .state-word.hot{color:var(--ink);font-weight:600} /* severity = weight on text-safe ink, NEVER the dot hue as text */
+  .badge{margin-left:auto;font-family:var(--mono);font-size:10px;color:var(--ink-dim);border:1px solid var(--line);
+         border-radius:6px;padding:2px 7px;white-space:nowrap}
+
   .actions{display:flex;gap:6px;flex:none}
   .icon-btn{width:32px;height:32px;border-radius:6px;border:1px solid var(--line);background:var(--panel-2);
             color:var(--ink-dim);font-size:13px;display:grid;place-items:center;cursor:pointer;font-family:var(--sans)}
   .icon-btn:hover{border-color:var(--ink-dim);color:var(--ink)}
-  .icon-btn.power{color:var(--ink-dim)}
+  .icon-btn:disabled{opacity:.45;cursor:not-allowed}
+  .card[data-width="narrow"] .actions .icon-btn{width:44px;height:44px;font-size:16px}
 
   .work-row{display:flex;align-items:flex-start;gap:8px;min-height:34px}
   .lane{font-size:12.5px;color:var(--ink);flex:1;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
-  .badge{flex:none;font-family:var(--mono);font-size:10px;color:var(--ink-dim);border:1px solid var(--line);
-         border-radius:6px;padding:2px 7px;white-space:nowrap}
-
-  .strip{display:flex;gap:10px;font-family:var(--mono);font-size:10px;color:var(--ink-dim)}
-  .strip .src{display:flex;align-items:center;gap:4px}
-  .strip .src i{width:7px;height:7px;border-radius:50%;background:var(--ok);font-style:normal}
-  .strip .src i.dim{background:var(--off)}
-  .strip .src i.bad{background:var(--wedged)}
-
-  /* narrow-mode adjustments (the card's own width states — 294px classifies NARROW: regular starts ~320px) */
-  .card.narrow .engine{display:none}
-  .card.narrow .strip .src.full{display:none}
-  .card.narrow .strip .summary{display:flex}
-  .card.narrow .actions .icon-btn{width:44px;height:44px;font-size:16px}
-  .card.narrow .actions .icon-btn.solo{width:44px}
-  .strip .summary{display:none;align-items:center;gap:4px}
-
-  /* the lane's tail-preserving clamp: the distinguishing suffix survives; the shared middle elides */
   .lane-tail{color:var(--ink)}
   .lane-elide{color:var(--ink-faint)}
 
-  /* the summary-default truth strip: green needs no wall of acronyms; degraded names itself */
-  .strip .nominal{color:var(--ink-dim)}
+  .strip{display:flex;gap:8px;font-family:var(--mono);font-size:10px;color:var(--ink-dim);align-items:center}
+  .strip i{width:7px;height:7px;border-radius:50%;background:var(--ok);font-style:normal}
+  .strip i.dim{background:var(--off)}
+  .strip i.bad{background:var(--wedged)}
 
-  .engine{font-family:var(--mono);font-size:10px;color:var(--ink-faint);flex:none}
-
-  .note{font-size:12px;color:var(--ink-dim);margin-top:8px;max-width:34ch}
+  .note{font-size:12px;color:var(--ink-dim);margin-top:8px;max-width:36ch}
   .note b{color:var(--ink);font-weight:600}
   .divider{border-top:1px solid var(--line-soft);margin:34px 0 26px}
   .falsifier{font-family:var(--mono);font-size:11px;color:var(--ink-faint);margin-top:6px}
+  .slider-row{display:flex;align-items:center;gap:12px;margin-bottom:18px;font-family:var(--mono);font-size:11px;color:var(--ink-dim)}
+  input[type="range"]{accent-color:var(--signal)}
 </style>
 </head>
 <body>
 <div class="wrap">
-  <p class="eyebrow">AgentCard rebaseline · direction D</p>
-  <h1>Status-first, two-row, actions-in-flow</h1>
-  <p class="lede">The card at its own four width states. State and name share one glance; the lane clamps at two lines with the count pinned; actions are 32px in-flow, never dominant; the truth strip is one line or a tap-to-expand summary. Chrome is a 3px family edge — information gets ~85% of the width.</p>
+  <p class="eyebrow">AgentCard rebaseline · direction D (synthesis: identity-first base + narrow mechanics)</p>
+  <h1>Identity first, then work, then truth — at the card's own width</h1>
+  <p class="lede">The avatar spans a two-line identity column (name first, state second); the lane keeps its distinguishing tail through a two-line clamp; actions are native buttons, contextual, never dominant; the truth line is summary-default and never lies. Drag the width: the card owns the response.</p>
 
-  <div class="grid">
+  <div class="slider-row">
+    <label for="w">card width</label>
+    <input id="w" type="range" min="240" max="720" value="480" step="1" style="width:320px">
+    <span id="wState">regular</span>
+  </div>
+
+  <div class="card" id="demo" data-width="regular" style="width:480px;--fam:var(--f-gpt)">
+    <div class="head">
+      <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Ccircle cx='20' cy='20' r='20' fill='%2358c093'/%3E%3Ctext x='20' y='26' font-size='18' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EE%3C/text%3E%3C/svg%3E" alt="Euclid">
+      <div class="identity">
+        <div class="name-line">
+          <span class="name">Euclid</span>
+          <span class="engine">gpt-5.6-s</span>
+        </div>
+        <div class="state-line">
+          <span class="dot" style="--state:var(--ok)"></span>
+          <span class="state-word">working</span>
+          <span class="badge">11 lanes</span>
+        </div>
+      </div>
+      <div class="actions">
+        <button class="icon-btn" aria-label="Stop Euclid">⏻</button>
+        <button class="icon-btn" aria-label="Restart Euclid">↻</button>
+      </div>
+    </div>
+    <div class="work-row">
+      <span class="lane"><span class="lane-elide">NL transaction archive — … —</span><span class="lane-tail"> the night queue witness chain</span></span>
+    </div>
+    <div class="strip"><i></i><span>all sources nominal ▸</span></div>
+  </div>
+
+  <div class="divider"></div>
+
+  <p class="eyebrow">the four width receipts (static)</p>
+  <div class="row" style="margin-top:14px">
 
     <div>
       <p class="col-label">wide · <b>720px</b></p>
-      <div class="card" style="width:720px;--fam:var(--f-gpt)">
-        <div class="status-row">
-          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22'%3E%3Ccircle cx='11' cy='11' r='11' fill='%2358c093'/%3E%3Ctext x='11' y='15' font-size='10' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EE%3C/text%3E%3C/svg%3E" alt="Euclid">
-          <span class="dot" style="--state:var(--ok)"></span>
-          <span class="state-word">working</span>
-          <span class="name">Euclid</span>
-          <span class="engine">gpt-5.6-s</span>
-          <span class="actions"><span class="icon-btn power">⏻</span><span class="icon-btn">↻</span></span>
+      <div class="card" data-width="wide" style="width:720px;--fam:var(--f-claude)">
+        <div class="head">
+          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Ccircle cx='20' cy='20' r='20' fill='%23d99a5b'/%3E%3Ctext x='20' y='26' font-size='18' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EG%3C/text%3E%3C/svg%3E" alt="Grace">
+          <div class="identity">
+            <div class="name-line"><span class="name">Grace</span><span class="engine">opus-4.8</span></div>
+            <div class="state-line">
+              <span class="dot" style="--state:var(--wedged)"></span>
+              <span class="state-word hot">wedged</span>
+              <span class="badge">17 lanes</span>
+            </div>
+          </div>
+          <div class="actions">
+            <button class="icon-btn" aria-label="Stop Grace">⏻</button>
+            <button class="icon-btn" aria-label="Restart Grace">↻</button>
+          </div>
         </div>
-        <div class="work-row">
-          <span class="lane">NL transaction archive — the merge-sweep witness chain on the night queue</span>
-          <span class="badge">11 lanes</span>
-        </div>
-        <div class="strip">
-          <span class="src"><i></i>RUN</span><span class="src"><i></i>ROS</span><span class="src"><i class="dim"></i>REP</span>
-        </div>
+        <div class="work-row"><span class="lane"><span class="lane-elide">design authority — … —</span><span class="lane-tail"> the AgentCard rebaseline landing</span></span></div>
+        <div class="strip"><i class="bad"></i><span>ROS not nominal ▸</span></div>
       </div>
-      <p class="note">everything on the contract, one calm read — the strip earns its line here</p>
+      <p class="note">severity = weight on text-safe ink — never the dot's hue as text (the 1.4.1→1.4.3 trap)</p>
     </div>
 
     <div>
       <p class="col-label">regular · <b>360px</b></p>
-      <div class="card" style="width:360px;--fam:var(--f-claude)">
-        <div class="status-row">
-          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22'%3E%3Ccircle cx='11' cy='11' r='11' fill='%23d99a5b'/%3E%3Ctext x='11' y='15' font-size='10' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EG%3C/text%3E%3C/svg%3E" alt="Grace">
-          <span class="dot" style="--state:var(--wedged)"></span>
-          <span class="state-word hot" style="--state:var(--wedged)">wedged</span>
-          <span class="name">Grace</span>
-          <span class="engine">opus-4.8</span>
-          <span class="actions"><span class="icon-btn power">⏻</span><span class="icon-btn">↻</span></span>
+      <div class="card" data-width="regular" style="width:360px;--fam:var(--f-gpt)">
+        <div class="head">
+          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Ccircle cx='20' cy='20' r='20' fill='%2358c093'/%3E%3Ctext x='20' y='26' font-size='18' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EA%3C/text%3E%3C/svg%3E" alt="Ada">
+          <div class="identity">
+            <div class="name-line"><span class="name">Ada</span><span class="engine">opus-4.8</span></div>
+            <div class="state-line">
+              <span class="dot" style="--state:var(--idle)"></span>
+              <span class="state-word">idle</span>
+              <span class="badge">14 lanes</span>
+            </div>
+          </div>
+          <div class="actions">
+            <button class="icon-btn" aria-label="Stop Ada">⏻</button>
+            <button class="icon-btn" aria-label="Restart Ada">↻</button>
+          </div>
         </div>
-        <div class="work-row">
-          <span class="lane">design authority — the AgentCard rebaseline and the D2 third channel landing</span>
-          <span class="badge">17 lanes</span>
-        </div>
-        <div class="strip">
-          <span class="src"><i></i>RUN</span><span class="src"><i class="bad"></i>ROS</span><span class="src"><i></i>REP</span>
-        </div>
+        <div class="work-row"><span class="lane"><span class="lane-elide">control-plane restart — … —</span><span class="lane-tail"> the actuator merge</span></span></div>
+        <div class="strip"><i></i><span>all sources nominal ▸</span></div>
       </div>
-      <p class="note">severity = weight on the state word, identity never recedes; 360px is where the full strip still earns its line</p>
+      <p class="note">the full truth stays one honest line at 360px too — no acronym wall in either mode</p>
     </div>
 
     <div>
       <p class="col-label">narrow · <b>294px</b></p>
-      <div class="card narrow" style="width:294px;--fam:var(--f-gemini)">
-        <div class="status-row">
-          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22'%3E%3Ccircle cx='11' cy='11' r='11' fill='%236ba3e8'/%3E%3Ctext x='11' y='15' font-size='10' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EG%3C/text%3E%3C/svg%3E" alt="Gemini">
-          <span class="dot" style="--state:var(--off)"></span>
-          <span class="state-word">benched / offline</span>
-          <span class="name">Gemini</span>
-          <span class="actions"><span class="icon-btn power solo">⋯</span></span>
+      <div class="card" data-width="narrow" style="width:294px;--fam:var(--f-gemini)">
+        <div class="head">
+          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Ccircle cx='16' cy='16' r='16' fill='%236ba3e8'/%3E%3Ctext x='16' y='21' font-size='14' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3EG%3C/text%3E%3C/svg%3E" alt="Gemini">
+          <div class="identity">
+            <div class="name-line"><span class="name">Gemini</span></div>
+            <div class="state-line">
+              <span class="dot" style="--state:var(--off)"></span>
+              <span class="state-word">benched / offline</span>
+            </div>
+          </div>
+          <div class="actions">
+            <button class="icon-btn" aria-label="Gemini actions" aria-haspopup="true" aria-expanded="false">⋯</button>
+          </div>
         </div>
-        <div class="work-row">
-          <span class="lane"><span class="lane-elide">operator-benched — … —</span><span class="lane-tail"> waiting on a stable harness</span></span>
-          <span class="badge">3.1-pro</span>
-        </div>
-        <div class="strip">
-          <span class="src full"><i class="dim"></i>RUN</span><span class="src full"><i class="dim"></i>ROS</span><span class="src full"><i class="dim"></i>REP</span>
-          <span class="summary"><i class="bad"></i>REP not nominal ▸</span>
-        </div>
+        <div class="work-row"><span class="lane"><span class="lane-elide">operator-benched — … —</span><span class="lane-tail"> waiting on a stable harness</span></span></div>
+        <div class="strip"><i class="bad"></i><span>REP not nominal ▸</span></div>
       </div>
-      <p class="note">narrow mode: engine hidden, the summary NAMES the degraded source (REP not nominal), actions collapse to ONE 44px overflow button</p>
+      <p class="note">engine hidden, ONE labelled 44px menu; the summary NAMES the degraded source</p>
     </div>
 
     <div>
       <p class="col-label">narrow-min · <b>280px</b></p>
-      <div class="card narrow" style="width:280px;--fam:var(--f-human)">
-        <div class="status-row">
-          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='22'%3E%3Ccircle cx='11' cy='11' r='11' fill='%23c9d2de'/%3E%3Ctext x='11' y='15' font-size='10' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3ET%3C/text%3E%3C/svg%3E" alt="tobiu">
-          <span class="dot" style="--state:var(--idle)"></span>
-          <span class="state-word">idle</span>
-          <span class="name">tobiu</span>
-          <span class="actions"><span class="icon-btn power solo">⋯</span></span>
+      <div class="card" data-width="narrow" style="width:280px;--fam:var(--f-human)">
+        <div class="head">
+          <img class="avatar" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32'%3E%3Ccircle cx='16' cy='16' r='16' fill='%23c9d2de'/%3E%3Ctext x='16' y='21' font-size='14' text-anchor='middle' fill='%230b0e13' font-family='monospace'%3ET%3C/text%3E%3C/svg%3E" alt="tobiu">
+          <div class="identity">
+            <div class="name-line"><span class="name">tobiu</span></div>
+            <div class="state-line">
+              <span class="dot" style="--state:var(--idle)"></span>
+              <span class="state-word">idle</span>
+              <span class="badge">7 lanes</span>
+            </div>
+          </div>
+          <div class="actions">
+            <button class="icon-btn" aria-label="tobiu actions" aria-haspopup="true" aria-expanded="false">⋯</button>
+          </div>
         </div>
-        <div class="work-row">
-          <span class="lane"><span class="lane-elide">merge sweep — … —</span><span class="lane-tail"> the morning review queue</span></span>
-          <span class="badge">7 lanes</span>
-        </div>
-        <div class="strip">
-          <span class="src full"><i></i>RUN</span><span class="src full"><i></i>ROS</span><span class="src full"><i class="dim"></i>REP</span>
-          <span class="summary"><i></i>all sources nominal ▸</span>
-        </div>
+        <div class="work-row"><span class="lane"><span class="lane-elide">merge sweep — … —</span><span class="lane-tail"> the morning review queue</span></span></div>
+        <div class="strip"><i></i><span>all sources nominal ▸</span></div>
       </div>
-      <p class="note">ONE 44px target ≈ 16% of the row, never 34% — and the lane keeps its distinguishing tail</p>
+      <p class="note">ONE 44px target ≈ 16% of the row, never 34% — and markers agree with the summary</p>
     </div>
 
   </div>
 
   <div class="divider"></div>
 
-  <p class="eyebrow">the falsifiers + the four render teeth, answered</p>
-  <p class="falsifier">294px → 149.95px info body &nbsp;·&nbsp; ~85% width to information; chrome = 3px edge + 32px actions</p>
-  <p class="falsifier">48×48 power dominates &nbsp;·&nbsp; 32px in-flow icons at regular+; ONE 44px overflow button at narrow (~16% of a 280px row, never 34%)</p>
-  <p class="falsifier">lane → meaningless prefix &nbsp;·&nbsp; 2-line clamp with the distinguishing TAIL preserved (shared middle elides); badge pinned</p>
-  <p class="falsifier">three 9px source rows &nbsp;·&nbsp; summary-DEFAULT strip that never lies: healthy reads "all sources nominal ▸", degraded NAMES the source ("REP not nominal ▸")</p>
-  <p class="falsifier">avatar is identity, not chrome &nbsp;·&nbsp; 22px in the status row (family-hue ring); the card's "who" keeps its face at every width</p>
-  <p class="falsifier">viewport-only breakpoints &nbsp;·&nbsp; card-owned width states (narrow &lt;320, regular 320–560, wide &gt;560 — 294px classifies narrow)</p>
-  <p class="falsifier">touch targets eat narrow rows &nbsp;·&nbsp; one 44px overflow button at narrow; the two icons only exist where 32px is cheap</p>
+  <p class="eyebrow">the audit ledger, answered</p>
+  <p class="falsifier">avatar = keeper at every width &nbsp;·&nbsp; 40px regular+ / 32px narrow, spanning a two-line identity column (name first, state second) — never inserted into the status row</p>
+  <p class="falsifier">native controls &nbsp;·&nbsp; real &lt;button&gt; elements with aria-labels; the narrow menu carries aria-haspopup + aria-expanded; disabled keeps its reason</p>
+  <p class="falsifier">badge semantics &nbsp;·&nbsp; the pill carries openLaneCount only ("7 lanes"); engine text lives beside the name (regular+) or hides (narrow) — never in the count slot</p>
+  <p class="falsifier">summary never lies &nbsp;·&nbsp; healthy = "all sources nominal ▸"; degraded NAMES the source ("REP not nominal ▸"); markers and summary always agree</p>
+  <p class="falsifier">no acronym wall &nbsp;·&nbsp; the truth is one honest word-line at every width; wide may align the full facts in the semantic vocabulary, never RUN/ROS/REP chips</p>
+  <p class="falsifier">severity ≠ dot hue as text &nbsp;·&nbsp; the state word takes ink + weight (the 1.4.1→1.4.3 trap avoided by construction)</p>
+  <p class="falsifier">responsiveness is card-owned &nbsp;·&nbsp; the slider above IS the mechanism (one DOM, stable tab order, width classes by the card's own measure); production uses container queries</p>
 
-  <p class="note" style="max-width:74ch;margin-top:20px">mockup by <b>Phoebe</b> (@neo-kimi-phoebe, Moonshot Kimi K3) — design-peer on #15536. The a11y invariants hold everywhere: state as text beside the dot (#15512/#15534), text-safe inks only, state-honesty markers verbatim, id-keyed cards. Severity changes the state word's weight — never the identity order.</p>
+  <p class="note" style="max-width:76ch;margin-top:20px">mockup by <b>Phoebe</b> (@neo-kimi-phoebe, Moonshot Kimi K3) — design-peer on #15536. Synthesis per Emmy's convergence audit (comment-5013162092): B/C identity-first base + D's tail-aware lane + one labelled narrow action + truthful summary-default sources + card-owned responsiveness. The a11y invariants hold everywhere: state as text beside the dot (#15512/#15534), text-safe inks only, state-honesty markers verbatim, native interactive elements only.</p>
 </div>
+<script>
+  const card = document.getElementById('demo');
+  const w = document.getElementById('w');
+  const wState = document.getElementById('wState');
+  const classify = px => px < 320 ? 'narrow' : px > 560 ? 'wide' : 'regular';
+  w.addEventListener('input', () => {
+    card.style.width = w.value + 'px';
+    card.dataset.width = classify(Number(w.value));
+    wState.textContent = classify(Number(w.value)) + ' · ' + w.value + 'px';
+  });
+</script>
 </body>
 </html>

--- a/apps/agentos/design/agentcard-rebaseline-d.html
+++ b/apps/agentos/design/agentcard-rebaseline-d.html
@@ -55,11 +55,20 @@
   .strip .src i.dim{background:var(--off)}
   .strip .src i.bad{background:var(--wedged)}
 
-  /* narrow-mode adjustments (the card's own width states) */
+  /* narrow-mode adjustments (the card's own width states — 294px classifies NARROW: regular starts ~320px) */
   .card.narrow .engine{display:none}
   .card.narrow .strip .src.full{display:none}
   .card.narrow .strip .summary{display:flex}
+  .card.narrow .actions .icon-btn{width:44px;height:44px;font-size:16px}
+  .card.narrow .actions .icon-btn.solo{width:44px}
   .strip .summary{display:none;align-items:center;gap:4px}
+
+  /* the lane's tail-preserving clamp: the distinguishing suffix survives; the shared middle elides */
+  .lane-tail{color:var(--ink)}
+  .lane-elide{color:var(--ink-faint)}
+
+  /* the summary-default truth strip: green needs no wall of acronyms; degraded names itself */
+  .strip .nominal{color:var(--ink-dim)}
 
   .engine{font-family:var(--mono);font-size:10px;color:var(--ink-faint);flex:none}
 
@@ -78,8 +87,8 @@
   <div class="grid">
 
     <div>
-      <p class="col-label">wide · <b>480px</b></p>
-      <div class="card" style="width:480px;--fam:var(--f-gpt)">
+      <p class="col-label">wide · <b>720px</b></p>
+      <div class="card" style="width:720px;--fam:var(--f-gpt)">
         <div class="status-row">
           <span class="dot" style="--state:var(--ok)"></span>
           <span class="state-word">working</span>
@@ -95,11 +104,11 @@
           <span class="src"><i></i>RUN</span><span class="src"><i></i>ROS</span><span class="src"><i class="dim"></i>REP</span>
         </div>
       </div>
-      <p class="note">everything on the contract, one calm read</p>
+      <p class="note">everything on the contract, one calm read — the strip earns its line here</p>
     </div>
 
     <div>
-      <p class="col-label">mobile · <b>360px</b></p>
+      <p class="col-label">regular · <b>360px</b></p>
       <div class="card" style="width:360px;--fam:var(--f-claude)">
         <div class="status-row">
           <span class="dot" style="--state:var(--wedged)"></span>
@@ -116,60 +125,62 @@
           <span class="src"><i></i>RUN</span><span class="src"><i class="bad"></i>ROS</span><span class="src"><i></i>REP</span>
         </div>
       </div>
-      <p class="note">severity = weight on the state word, identity never recedes</p>
+      <p class="note">severity = weight on the state word, identity never recedes; 360px is where the full strip still earns its line</p>
     </div>
 
     <div>
-      <p class="col-label">current · <b>294px</b></p>
-      <div class="card" style="width:294px;--fam:var(--f-gemini)">
+      <p class="col-label">narrow · <b>294px</b></p>
+      <div class="card narrow" style="width:294px;--fam:var(--f-gemini)">
         <div class="status-row">
           <span class="dot" style="--state:var(--off)"></span>
           <span class="state-word">benched / offline</span>
           <span class="name">Gemini</span>
-          <span class="actions"><span class="icon-btn power">⏻</span></span>
+          <span class="actions"><span class="icon-btn power solo">⋯</span></span>
         </div>
         <div class="work-row">
-          <span class="lane">operator-benched — the v3-line slip, waiting on a stable harness</span>
+          <span class="lane"><span class="lane-elide">operator-benched — … —</span><span class="lane-tail"> waiting on a stable harness</span></span>
           <span class="badge">3.1-pro</span>
         </div>
         <div class="strip">
-          <span class="src"><i class="dim"></i>RUN</span><span class="src"><i class="dim"></i>ROS</span><span class="src"><i class="dim"></i>REP</span>
+          <span class="src full"><i class="dim"></i>RUN</span><span class="src full"><i class="dim"></i>ROS</span><span class="src full"><i class="dim"></i>REP</span>
+          <span class="summary"><i class="dim"></i>all sources nominal ▸</span>
         </div>
       </div>
-      <p class="note">the badge slot carries the engine when there's no lane count</p>
+      <p class="note">narrow mode: engine hidden, strip collapsed to a one-line summary, actions collapse to ONE 44px overflow button</p>
     </div>
 
     <div>
-      <p class="col-label">narrow · <b>240px</b></p>
-      <div class="card narrow" style="width:240px;--fam:var(--f-human)">
+      <p class="col-label">narrow-min · <b>280px</b></p>
+      <div class="card narrow" style="width:280px;--fam:var(--f-human)">
         <div class="status-row">
           <span class="dot" style="--state:var(--idle)"></span>
           <span class="state-word">idle</span>
           <span class="name">tobiu</span>
-          <span class="actions"><span class="icon-btn power">⏻</span></span>
+          <span class="actions"><span class="icon-btn power solo">⋯</span></span>
         </div>
         <div class="work-row">
-          <span class="lane">merge sweep and the morning review queue</span>
+          <span class="lane"><span class="lane-elide">merge sweep — … —</span><span class="lane-tail"> the morning review queue</span></span>
           <span class="badge">7 lanes</span>
         </div>
         <div class="strip">
           <span class="src full"><i></i>RUN</span><span class="src full"><i></i>ROS</span><span class="src full"><i class="dim"></i>REP</span>
-          <span class="summary"><i></i>3 sources ▸</span>
+          <span class="summary"><i></i>all sources nominal ▸</span>
         </div>
       </div>
-      <p class="note">engine hides, strip collapses to a tap summary, nothing truncates to a meaningless prefix</p>
+      <p class="note">ONE 44px target ≈ 16% of the row, never 34% — and the lane keeps its distinguishing tail</p>
     </div>
 
   </div>
 
   <div class="divider"></div>
 
-  <p class="eyebrow">the falsifiers, answered</p>
+  <p class="eyebrow">the falsifiers + the four render teeth, answered</p>
   <p class="falsifier">294px → 149.95px info body &nbsp;·&nbsp; ~85% width to information; chrome = 3px edge + 32px actions</p>
-  <p class="falsifier">48×48 power dominates &nbsp;·&nbsp; 32px in-flow icons; ≥44px touch height at narrow; never fully hidden (touch has no hover)</p>
-  <p class="falsifier">lane → meaningless prefix &nbsp;·&nbsp; 2-line clamp + badge pinned; prefix expendable, count exact</p>
-  <p class="falsifier">three 9px source rows &nbsp;·&nbsp; one 10px strip, collapsible to a summary at narrow</p>
-  <p class="falsifier">viewport-only breakpoints &nbsp;·&nbsp; card-owned width states (container query / ResizeObserver class — layout-blind)</p>
+  <p class="falsifier">48×48 power dominates &nbsp;·&nbsp; 32px in-flow icons at regular+; ONE 44px overflow button at narrow (~16% of a 280px row, never 34%)</p>
+  <p class="falsifier">lane → meaningless prefix &nbsp;·&nbsp; 2-line clamp with the distinguishing TAIL preserved (shared middle elides); badge pinned</p>
+  <p class="falsifier">three 9px source rows &nbsp;·&nbsp; summary-DEFAULT strip ("all sources nominal"); degraded sources name themselves — no acronym wall in either direction</p>
+  <p class="falsifier">viewport-only breakpoints &nbsp;·&nbsp; card-owned width states (narrow &lt;320, regular 320–560, wide &gt;560 — 294px classifies narrow)</p>
+  <p class="falsifier">touch targets eat narrow rows &nbsp;·&nbsp; one 44px overflow button at narrow; the two icons only exist where 32px is cheap</p>
 
   <p class="note" style="max-width:74ch;margin-top:20px">mockup by <b>Phoebe</b> (@neo-kimi-phoebe, Moonshot Kimi K3) — design-peer on #15536. The a11y invariants hold everywhere: state as text beside the dot (#15512/#15534), text-safe inks only, state-honesty markers verbatim, id-keyed cards. Severity changes the state word's weight — never the identity order.</p>
 </div>


### PR DESCRIPTION
Resolves #15561

Refs #15536

The operator-selected direction, rendered: the D/synthesis mockup at the card's four own-width states (720 wide / 360 regular / 294 narrow / 280 narrow-min) + ONE live interactive card driven by a width slider (the card-owned mechanism), in the fleet palette — the synthesis per Emmy's convergence audit: **B/C identity-first base + D's narrow mechanics + A roomy only**. Selected by the operator 2026-07-19 ([receipt](https://github.com/neomjs/neo/issues/15536#issuecomment-5014622262)); this PR lands the design SSOT on dev so the implementation PR (which carries the real `Resolves #15536`) builds against it.

**Anatomy:** the avatar (40px regular+ / 32px narrow) spans a two-line identity column (name first, dot+state beneath) at every width; the lane clamps at two lines with the distinguishing TAIL preserved; actions are native `<button>` elements (32px at regular+, ONE labelled 44px menu at narrow ≈ 16% of a 280px row); the truth line is summary-default and never lies (healthy: "all sources nominal ▸" / degraded: "REP not nominal ▸"); the count pill carries `openLaneCount` only.

Evidence: L1 (static design artifact + live slider mechanism) → L1 required for a design-evidence PR. Residual: none for the artifact; the picked direction's implementation owns the real component work.

## Deltas

- v4 (fold-ready): body declares `Resolves #15561` (lane-fold merge authority) while keeping `Refs #15536`; framing updated from pre-selection evidence to the selected-design SSOT.
- v3 (identity-first rebuild): avatar spanning the two-line identity column at every width; native `<button>` controls with aria-labels + `aria-haspopup`/`aria-expanded` on the narrow menu; the count pill carrying counts only (the 294 badge slot honestly empty); markers agreeing with summaries; no acronym wall at any width; the state word on text-safe ink + weight (never the dot's hue); the width slider as the live card-owned mechanism.

## Test Evidence

- The mockup renders clean at all four receipts + the interactive card responds across narrow/regular/wide (screenshot-verified at 1200px viewport).
- No runtime surface touched (design artifact only) — no unit shard required; the lint gates run on the PR itself.
- Emmy's exact-head mechanical ledger closed at `73e2441a69` ([audit](https://github.com/neomjs/neo/pull/15538#issuecomment-5013184085)); operator selection receipt on #15536.
- Screenshots optional per operator verdict 2026-07-19 ("that would work, but i would also accept it without them") — Emmy may add them to body/comments as a nicety; they do not gate this merge.

## Post-Merge Validation

- [ ] The implementation PR (Vega, per the design-lead split; resolves #15536) consumes the anatomy from dev without re-deriving it; #14618's visual-regression baseline refreshes against the chosen shape; the narrow/mobile design-check seat (Phoebe) verifies fidelity against `73e2441a69`.

Authored by Phoebe (Kimi K3, OpenCode). Session 9b748a56-8b84-43bf-a542-ee8dcf437ebf.