### PR TITLE
feat(github-workflow): exhaustive GitHub issue activity reconciliation (#15152)

### DIFF
--- a/ai/services/github-workflow/IssueReconciliationService.mjs
+++ b/ai/services/github-workflow/IssueReconciliationService.mjs
@@ -1,0 +1,164 @@
+import Base                           from '../../../src/core/Base.mjs';
+import CommunityBatchAdmissionService from '../memory-core/CommunityBatchAdmissionService.mjs';
+import GraphqlService                 from './GraphqlService.mjs';
+import SourceRegistryService          from '../memory-core/SourceRegistryService.mjs';
+import {assembleIssueBatch}           from './community/assembleIssueBatch.mjs';
+import {classifyAbsences}             from './community/githubIssueAbsence.mjs';
+import {reconcileIssueActivity}       from './community/githubIssueReconciliation.mjs';
+import {
+    FETCH_RECONCILE_COMMENTS_PAGE, FETCH_RECONCILE_ISSUES, FETCH_RECONCILE_TIMELINE_PAGE
+} from './queries/issueReconciliationQueries.mjs';
+
+/**
+ * @class Neo.ai.services.github-workflow.IssueReconciliationService
+ * @extends Neo.core.Base
+ * @summary Orchestrates one exhaustive issue-family reconciliation into durable admission: reads the
+ * source's registration and last checkpoint, walks every open and closed issue (and each issue's
+ * comments and timeline) to exhaustion behind the GraphQL seams, diffs the prior inventory to
+ * separate evidenced deletions from access loss, assembles a metadata-only `community-activity-batch.v1`
+ * batch, and admits it.
+ *
+ * The service holds no completeness state of its own: the durable cursor lives in the admission
+ * checkpoint and is advanced ONLY by the admission transaction (AC8). A batch that fails admission
+ * leaves the checkpoint untouched, so the next run re-walks the same window rather than skipping it.
+ * Every acquisition dependency is injectable, so the whole orchestration is witness-testable against
+ * fakes with no live GitHub and no real database.
+ */
+class IssueReconciliationService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.github-workflow.IssueReconciliationService'
+         * @protected
+         */
+        className: 'Neo.ai.services.github-workflow.IssueReconciliationService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @summary Runs one reconciliation pass for a registered source and admits the resulting batch.
+     * @param {Object}   spec
+     * @param {String}   spec.sourceInstanceId
+     * @param {String}   [spec.resourceFamily='issues']
+     * @param {String}   spec.owner                    Repository owner for the GraphQL queries.
+     * @param {String}   spec.repo                     Repository name.
+     * @param {String}   spec.batchId                  Stable id for this logical batch (idempotent retries reuse it).
+     * @param {String}   [spec.observedAt]             ISO-8601 run moment; defaults to now. Injected in tests.
+     * @param {Object}   [spec.pageSizes]              `{issuePage, commentPage, timelinePage}` GraphQL page sizes.
+     * @param {Object}   [spec.caps]                   `{maxIssuePages, maxCommentPagesPerIssue, maxTimelinePagesPerIssue}` — honest degraded coverage when hit.
+     * @param {Object}   [spec.admissionService]       Injected admission dependency; defaults to the singleton.
+     * @param {Object}   [spec.graphqlService]         Injected GraphQL dependency; defaults to the singleton.
+     * @param {Object}   [spec.registryService]        Injected registry dependency; defaults to the singleton.
+     * @returns {Promise<Object>} The admission receipt `{status, receipt|reason, ...}`.
+     * @throws {Error} `ISSUE_RECONCILIATION_SOURCE_NOT_ACTIVE` when the source is unregistered or not ACTIVE.
+     */
+    async reconcile({
+        sourceInstanceId, resourceFamily = 'issues', owner, repo, batchId, observedAt,
+        pageSizes = {}, caps = {},
+        admissionService = CommunityBatchAdmissionService,
+        graphqlService   = GraphqlService,
+        registryService  = SourceRegistryService
+    }) {
+        const {issuePage = 50, commentPage = 50, timelinePage = 50} = pageSizes;
+
+        // A source must be registered and ACTIVE before its activity can be admitted.
+        const registration = registryService.getRegistration(sourceInstanceId);
+
+        if (!registration || registration.lifecycleState !== 'ACTIVE') {
+            throw new Error('ISSUE_RECONCILIATION_SOURCE_NOT_ACTIVE')
+        }
+
+        // The checkpoint carries the base version, the base inventory, and the resume cursor.
+        const checkpoint            = admissionService.getCheckpoint(sourceInstanceId, resourceFamily),
+              baseCheckpointVersion = checkpoint?.checkpointVersion ?? 0,
+              baseInventoryHash     = checkpoint?.inventoryHash     ?? null,
+              resumeCursor          = checkpoint?.providerState?.issuesCursor ?? null;
+
+        // Prior live inventory = the issue roots this source has previously admitted.
+        const priorInventory = admissionService.listObservations(sourceInstanceId)
+            .filter(observation => observation.occurrenceKind === 'issue.opened')
+            .map(observation => observation.providerEntityId);
+
+        const seams        = this.#buildSeams({graphqlService, owner, repo, issuePage, commentPage, timelinePage}),
+              runnerResult = await reconcileIssueActivity(seams, {fromBasis: resumeCursor, ...caps});
+
+        const currentInventory = runnerResult.observations
+            .filter(observation => observation.occurrenceKind === 'issue.opened')
+            .map(observation => observation.providerEntityId);
+
+        // Deletion evidence is carried by explicit tombstone events; absent that, a vanished root is
+        // access-indeterminate, never a deletion (classifyAbsences enforces it).
+        const absences = classifyAbsences(priorInventory, currentInventory, {});
+
+        const batch = assembleIssueBatch({
+            sourceInstanceId, resourceFamily,
+            registrationEpoch: registration.registrationEpoch,
+            baseCheckpointVersion, baseInventoryHash,
+            runnerResult, absences, currentInventory,
+            batchId, observedAt: observedAt ?? new Date().toISOString()
+        });
+
+        // AC8 — the admission transaction is the sole durable cursor advance. A CONFLICT receipt
+        // leaves the checkpoint (hence the resume cursor) untouched; nothing here advances it.
+        return admissionService.admitBatch(batch)
+    }
+
+    /**
+     * @summary Builds the three fetch seams reconcileIssueActivity consumes, each mapping a raw
+     * GraphQL connection onto the runner's expected shape. Comments and timeline are separate seams
+     * so the runner exhausts them as independent axes.
+     * @param {Object} deps
+     * @returns {Object} `{fetchIssuesPage, fetchCommentsPage, fetchTimelinePage}`.
+     * @private
+     */
+    #buildSeams({graphqlService, owner, repo, issuePage, commentPage, timelinePage}) {
+        return {
+            fetchIssuesPage: async ({cursor}) => {
+                const data = await graphqlService.query(FETCH_RECONCILE_ISSUES, {owner, repo, after: cursor, issuePage, commentPage, timelinePage}),
+                      conn = data?.repository?.issues;
+
+                return {
+                    issues  : (conn?.nodes ?? []).map(node => this.#normalizeIssueNode(node)),
+                    pageInfo: conn?.pageInfo
+                }
+            },
+            fetchCommentsPage: async ({issueId, cursor}) => {
+                const data = await graphqlService.query(FETCH_RECONCILE_COMMENTS_PAGE, {issueId, after: cursor, commentPage}),
+                      conn = data?.node?.comments;
+
+                return {comments: conn?.nodes ?? [], pageInfo: conn?.pageInfo}
+            },
+            fetchTimelinePage: async ({issueId, cursor}) => {
+                const data = await graphqlService.query(FETCH_RECONCILE_TIMELINE_PAGE, {issueId, after: cursor, timelinePage}),
+                      conn = data?.node?.timelineItems;
+
+                return {events: conn?.nodes ?? [], pageInfo: conn?.pageInfo}
+            }
+        }
+    }
+
+    /**
+     * @summary Maps a raw GraphQL issue node onto the reconciled-node shape the runner consumes:
+     * comments and timeline stay `{nodes, pageInfo}` connections so the runner can continuation-fetch,
+     * while the flat identity/author fields pass through for the normalizer.
+     * @param {Object} node
+     * @returns {Object}
+     * @private
+     */
+    #normalizeIssueNode(node) {
+        return {
+            id               : node.id,
+            createdAt        : node.createdAt,
+            lastEditedAt     : node.lastEditedAt,
+            author           : node.author,
+            authorAssociation: node.authorAssociation,
+            comments         : node.comments,
+            timeline         : node.timelineItems
+        }
+    }
+}
+
+export default Neo.setupClass(IssueReconciliationService);

--- a/ai/services/github-workflow/IssueReconciliationService.mjs
+++ b/ai/services/github-workflow/IssueReconciliationService.mjs
@@ -49,6 +49,7 @@ class IssueReconciliationService extends Base {
      * @param {String}   [spec.observedAt]             ISO-8601 run moment; defaults to now. Injected in tests.
      * @param {Object}   [spec.pageSizes]              `{issuePage, commentPage, timelinePage}` GraphQL page sizes.
      * @param {Object}   [spec.caps]                   `{maxIssuePages, maxCommentPagesPerIssue, maxTimelinePagesPerIssue}` — honest degraded coverage when hit.
+     * @param {Function} [spec.acquireDeletionEvidence] async (vanishedIds) => `{id: evidence}` — the provider deletion-evidence seam; the default yields none, so every vanished root is an access gap, never a fabricated deletion.
      * @param {Object}   [spec.admissionService]       Injected admission dependency; defaults to the singleton.
      * @param {Object}   [spec.graphqlService]         Injected GraphQL dependency; defaults to the singleton.
      * @param {Object}   [spec.registryService]        Injected registry dependency; defaults to the singleton.
@@ -58,9 +59,10 @@ class IssueReconciliationService extends Base {
     async reconcile({
         sourceInstanceId, resourceFamily = 'issues', owner, repo, batchId, observedAt,
         pageSizes = {}, caps = {},
-        admissionService = CommunityBatchAdmissionService,
-        graphqlService   = GraphqlService,
-        registryService  = SourceRegistryService
+        acquireDeletionEvidence = async () => ({}),
+        admissionService        = CommunityBatchAdmissionService,
+        graphqlService          = GraphqlService,
+        registryService         = SourceRegistryService
     }) {
         const {issuePage = 50, commentPage = 50, timelinePage = 50} = pageSizes;
 
@@ -71,27 +73,37 @@ class IssueReconciliationService extends Base {
             throw new Error('ISSUE_RECONCILIATION_SOURCE_NOT_ACTIVE')
         }
 
-        // The checkpoint carries the base version, the base inventory, and the resume cursor.
+        // The checkpoint carries the base version + inventory for the admission CAS. It deliberately
+        // does NOT seed a resume cursor: exhaustive reconciliation must RE-ENUMERATE every root each
+        // pass so a comment/edit/close/reopen on an already-seen root is caught. A root-list end
+        // cursor is an enumeration receipt for a historical root window, never proof of child
+        // completeness for mutable roots or their comment/timeline connections.
         const checkpoint            = admissionService.getCheckpoint(sourceInstanceId, resourceFamily),
               baseCheckpointVersion = checkpoint?.checkpointVersion ?? 0,
-              baseInventoryHash     = checkpoint?.inventoryHash     ?? null,
-              resumeCursor          = checkpoint?.providerState?.issuesCursor ?? null;
+              baseInventoryHash     = checkpoint?.inventoryHash     ?? null;
 
         // Prior live inventory = the issue roots this source has previously admitted.
         const priorInventory = admissionService.listObservations(sourceInstanceId)
             .filter(observation => observation.occurrenceKind === 'issue.opened')
             .map(observation => observation.providerEntityId);
 
+        // fromBasis omitted → the runner walks from the beginning, re-establishing full root + child
+        // truth on every pass (mutation-safe); caps still bound a single pass into honest coverage.
         const seams        = this.#buildSeams({graphqlService, owner, repo, issuePage, commentPage, timelinePage}),
-              runnerResult = await reconcileIssueActivity(seams, {fromBasis: resumeCursor, ...caps});
+              runnerResult = await reconcileIssueActivity(seams, {...caps});
 
         const currentInventory = runnerResult.observations
             .filter(observation => observation.occurrenceKind === 'issue.opened')
             .map(observation => observation.providerEntityId);
 
-        // Deletion evidence is carried by explicit tombstone events; absent that, a vanished root is
-        // access-indeterminate, never a deletion (classifyAbsences enforces it).
-        const absences = classifyAbsences(priorInventory, currentInventory, {});
+        // A root in the prior inventory but not this pass has vanished — ask the injected evidence
+        // seam whether the provider can prove a deletion. Evidence → an admitted deletion; no
+        // evidence → an inventory-access gap, NEVER a fabricated deletion (classifyAbsences enforces
+        // the split). The default seam yields nothing, so absent a tombstone source every vanish is
+        // an access gap.
+        const vanished             = priorInventory.filter(id => !currentInventory.includes(id)),
+              deletionEvidenceById = vanished.length ? await acquireDeletionEvidence(vanished) : {},
+              absences             = classifyAbsences(priorInventory, currentInventory, deletionEvidenceById);
 
         const batch = assembleIssueBatch({
             sourceInstanceId, resourceFamily,
@@ -101,8 +113,8 @@ class IssueReconciliationService extends Base {
             batchId, observedAt: observedAt ?? new Date().toISOString()
         });
 
-        // AC8 — the admission transaction is the sole durable cursor advance. A CONFLICT receipt
-        // leaves the checkpoint (hence the resume cursor) untouched; nothing here advances it.
+        // AC8 — the admission transaction is the sole durable checkpoint advance. A CONFLICT receipt
+        // leaves the checkpoint untouched; nothing here advances it.
         return admissionService.admitBatch(batch)
     }
 

--- a/ai/services/github-workflow/IssueReconciliationService.mjs
+++ b/ai/services/github-workflow/IssueReconciliationService.mjs
@@ -152,6 +152,7 @@ class IssueReconciliationService extends Base {
         return {
             id               : node.id,
             createdAt        : node.createdAt,
+            updatedAt        : node.updatedAt,
             lastEditedAt     : node.lastEditedAt,
             author           : node.author,
             authorAssociation: node.authorAssociation,

--- a/ai/services/github-workflow/community/assembleIssueBatch.mjs
+++ b/ai/services/github-workflow/community/assembleIssueBatch.mjs
@@ -1,0 +1,92 @@
+import crypto                  from 'crypto';
+import {BATCH_SCHEMA_VERSION}  from '../../memory-core/communityBatchContract.mjs';
+import {deletionToObservation} from './githubIssueAbsence.mjs';
+
+/**
+ * @summary Deterministic hash of a live-entity inventory — the sorted, de-duplicated id set folded
+ * into one digest. Order-insensitive so two runs that saw the same entities in a different page
+ * order produce the same inventory hash, and the admission base-inventory check stays stable.
+ * @param {Iterable<String>} entityIds
+ * @returns {String} `inv:<sha256-hex>`.
+ */
+export function inventoryHash(entityIds) {
+    const sorted = [...new Set(entityIds)].sort();
+
+    return 'inv:' + crypto.createHash('sha256').update(sorted.join('\n')).digest('hex')
+}
+
+/**
+ * @summary Assembles a `community-activity-batch.v1` batch from a reconciliation run: the runner's
+ * observations, the evidenced deletions, and the registration/checkpoint context — a pure envelope
+ * builder with no I/O.
+ *
+ * Two honesty rules are enforced here, not left to the caller. First, only the EVIDENCED deletions
+ * become `deleted` observations; the access-indeterminate set (entities that vanished without proof)
+ * is folded into coverage as gaps and degrades `complete`, so a permission loss lowers coverage
+ * rather than fabricating a deletion. Second, the base/next inventory anchors are computed from the
+ * actual live id set, so the admission service can verify the base the batch was built against.
+ *
+ * The `nextProviderState` cursor is carried straight through from the runner and is only ever
+ * durably advanced by the admission transaction — this builder never persists it, so a batch that
+ * fails admission cannot advance the source cursor.
+ * @param {Object}   input
+ * @param {String}   input.sourceInstanceId
+ * @param {String}   [input.resourceFamily='issues']
+ * @param {Number}   input.registrationEpoch
+ * @param {Number}   input.baseCheckpointVersion
+ * @param {String|null} input.baseInventoryHash
+ * @param {Object}   input.runnerResult          `{observations, coverage, nextProviderState}` from reconcileIssueActivity.
+ * @param {Object}   [input.absences]            `{deleted, accessIndeterminate}` from classifyAbsences.
+ * @param {String[]} input.currentInventory      Live root entity ids observed this run.
+ * @param {String}   input.batchId
+ * @param {String}   input.observedAt            ISO-8601 fallback moment for undated deletion evidence.
+ * @param {String}   [input.adapterSchemaVersion='github-issue.v1']
+ * @param {String}   [input.providerStateSchemaVersion='github-issue-state.v1']
+ * @param {String}   [input.deletionOccurrenceKind='issue.deleted']
+ * @returns {Object} A `community-activity-batch.v1` batch.
+ */
+export function assembleIssueBatch({
+    sourceInstanceId, resourceFamily = 'issues', registrationEpoch,
+    baseCheckpointVersion, baseInventoryHash,
+    runnerResult, absences = {deleted: [], accessIndeterminate: []},
+    currentInventory, batchId, observedAt,
+    adapterSchemaVersion       = 'github-issue.v1',
+    providerStateSchemaVersion = 'github-issue-state.v1',
+    deletionOccurrenceKind     = 'issue.deleted'
+}) {
+    const {deleted = [], accessIndeterminate = []} = absences;
+
+    const deletionObservations = deleted.map(
+        deletion => deletionToObservation(deletion, {occurrenceKind: deletionOccurrenceKind, observedAt})
+    );
+
+    const observations = [...runnerResult.observations, ...deletionObservations];
+
+    // Access-indeterminate absences are NEVER observations — they lower coverage as explicit gaps.
+    const accessGaps = accessIndeterminate.map(providerEntityId => ({axis: 'inventory-access', providerEntityId}));
+    const priorGaps  = runnerResult.coverage.gaps ?? [];
+    const gaps       = [...priorGaps, ...accessGaps];
+
+    const coverage = {
+        fromBasis: runnerResult.coverage.fromBasis,
+        toBasis  : runnerResult.coverage.toBasis,
+        complete : runnerResult.coverage.complete && accessIndeterminate.length === 0,
+        ...(gaps.length ? {gaps} : {})
+    };
+
+    return {
+        schemaVersion    : BATCH_SCHEMA_VERSION,
+        sourceInstanceId,
+        resourceFamily,
+        adapterSchemaVersion,
+        providerStateSchemaVersion,
+        registrationEpoch,
+        baseCheckpointVersion,
+        baseInventoryHash,
+        batchId,
+        observations,
+        nextProviderState: runnerResult.nextProviderState,
+        nextInventoryHash: inventoryHash(currentInventory),
+        coverage
+    }
+}

--- a/ai/services/github-workflow/community/githubIssueAbsence.mjs
+++ b/ai/services/github-workflow/community/githubIssueAbsence.mjs
@@ -1,0 +1,72 @@
+import {actorKindFromTypename} from './githubIssueObservations.mjs';
+
+/**
+ * @summary Classifies entities that a prior inventory saw but the current reconciliation did not
+ * into two disjoint sets: confirmed deletions and access-indeterminate absences.
+ *
+ * The distinction is a security invariant, not a convenience. An entity that vanished from view is
+ * a DELETION only when the provider hands us explicit evidence it was removed (a deletion tombstone
+ * / a removed marker). An entity that vanished with NO such evidence is treated as a permission or
+ * access loss — the token can no longer see it — and is NEVER recorded as a deletion, because
+ * "I can't see it" and "it no longer exists" are different facts and conflating them lets a
+ * revoked grant masquerade as community members deleting their own history.
+ *
+ * Membership in `currentEntityIds` always means present, so an entity is never both present and
+ * absent; only genuinely-vanished ids are classified.
+ * @param {Iterable<String>} priorEntityIds       Provider entity ids the source last held as live.
+ * @param {Iterable<String>} currentEntityIds     Provider entity ids observed in this reconciliation.
+ * @param {Object}           [deletionEvidenceById] Map id → provider deletion evidence, when it exists.
+ * @returns {{deleted: Object[], accessIndeterminate: String[]}} `deleted` carries `{providerEntityId, deletionEvidence}`; `accessIndeterminate` is a bare id list — vanished without proof, never a deletion.
+ */
+export function classifyAbsences(priorEntityIds, currentEntityIds, deletionEvidenceById = {}) {
+    const current             = new Set(currentEntityIds),
+          deleted             = [],
+          accessIndeterminate = [];
+
+    for (const providerEntityId of priorEntityIds) {
+        if (current.has(providerEntityId)) {
+            continue
+        }
+
+        const deletionEvidence = deletionEvidenceById[providerEntityId];
+
+        if (deletionEvidence) {
+            deleted.push({providerEntityId, deletionEvidence})
+        } else {
+            // Vanished with no provider proof of removal — an access/permission gap, not a deletion.
+            accessIndeterminate.push(providerEntityId)
+        }
+    }
+
+    return {deleted, accessIndeterminate}
+}
+
+/**
+ * @summary Projects one confirmed deletion into a `community-activity-batch.v1` deletion observation,
+ * carrying the mandatory provider evidence the contract requires for any `deleted` absence.
+ *
+ * The moment is taken from the evidence when the provider dates the removal, falling back to the
+ * reconciliation's own observation time; the actor kind is read from the evidence's actor, failing
+ * closed to `unknown`. This is only ever called on the `deleted` set from {@link classifyAbsences}
+ * — access-indeterminate absences never reach here, so a permission loss can never be shaped into
+ * a deletion observation.
+ * @param {Object} deletion                    A `{providerEntityId, deletionEvidence}` entry.
+ * @param {Object} context
+ * @param {String} context.occurrenceKind      The deletion occurrence kind, e.g. `issue.deleted`.
+ * @param {String} context.observedAt          ISO-8601 fallback moment when the evidence is undated.
+ * @returns {Object} `{providerEntityId, occurrenceKind, occurrenceCoordinate, occurredAt, actorKind, absence, deletionEvidence}`.
+ */
+export function deletionToObservation(deletion, {occurrenceKind, observedAt}) {
+    const {providerEntityId, deletionEvidence} = deletion;
+
+    return {
+        providerEntityId,
+        occurrenceKind,
+        occurrenceCoordinate: `${providerEntityId}:deleted`,
+        occurredAt          : deletionEvidence.deletedAt ?? observedAt,
+        actorKind           : actorKindFromTypename(deletionEvidence.actor?.__typename),
+        actorId             : deletionEvidence.actor?.login ?? null,
+        absence             : 'deleted',
+        deletionEvidence
+    }
+}

--- a/ai/services/github-workflow/community/githubIssueObservations.mjs
+++ b/ai/services/github-workflow/community/githubIssueObservations.mjs
@@ -25,10 +25,13 @@ export function actorKindFromTypename(typename) {
  * A whitelist, not a blocklist: an event kind absent from this map produces no observation,
  * so popularity signals and any future event type are refused by construction rather than by
  * an easily-stale deny-list. Every kind here is a lifecycle or metadata fact — never prose.
+ *
+ * Comments are deliberately NOT here: they are exhausted on their own connection axis and mapped
+ * from the issue's `comments`, so a stray `IssueComment` reaching the timeline path is ignored
+ * rather than emitted a second time under a different coordinate for the same node.
  * @member {Object<String,String>}
  */
 export const TIMELINE_KIND_BY_TYPENAME = {
-    IssueComment           : 'issue.comment',
     ClosedEvent            : 'issue.closed',
     ReopenedEvent          : 'issue.reopened',
     RenamedTitleEvent      : 'issue.renamed',

--- a/ai/services/github-workflow/community/githubIssueObservations.mjs
+++ b/ai/services/github-workflow/community/githubIssueObservations.mjs
@@ -92,6 +92,7 @@ function projectActor(actor, sourceAssociation = null) {
  * @param {Object}        issue                  A reconciled issue node.
  * @param {String}        issue.id               The provider node id (stable identity).
  * @param {String}        issue.createdAt        ISO-8601 open moment.
+ * @param {String}        [issue.updatedAt]      ISO-8601 last-touched moment; an unexplained advance emits a snapshot-change marker.
  * @param {String}        [issue.lastEditedAt]   ISO-8601 last-edit moment, when the body was edited.
  * @param {Object|null}   [issue.author]         `{login, __typename}`; null for a deleted account.
  * @param {String}        [issue.authorAssociation] Provider association-with-source of the author.
@@ -169,6 +170,27 @@ export function issueToObservations(issue) {
             occurredAt          : event.createdAt,
             ...projectActor(event.actor)
         })
+    }
+
+    // An `updatedAt` strictly newer than every granular occurrence we could see is a change we
+    // cannot attribute — a comment/edit behind an access gap, or a provider event we do not fetch.
+    // Record it honestly as a snapshot-only change with a null actor and a loss marker, never a
+    // fabricated event with a guessed actor.
+    if (issue.updatedAt) {
+        const newestExplained = observations.reduce((max, o) => o.occurredAt > max ? o.occurredAt : max, issue.createdAt);
+
+        if (issue.updatedAt > newestExplained) {
+            observations.push({
+                providerEntityId    : issue.id,
+                occurrenceKind      : 'issue.observed-snapshot-change',
+                occurrenceCoordinate: `${issue.id}:snapshot:${issue.updatedAt}`,
+                occurredAt          : issue.updatedAt,
+                actorId             : null,
+                actorKind           : 'unknown',
+                sourceAssociation   : null,
+                lossMarker          : 'snapshot-without-granular-event'
+            })
+        }
     }
 
     return observations

--- a/ai/services/github-workflow/community/githubIssueObservations.mjs
+++ b/ai/services/github-workflow/community/githubIssueObservations.mjs
@@ -1,0 +1,161 @@
+/**
+ * @summary The provider actor-kind axis, mapped from a GitHub GraphQL actor's `__typename`.
+ *
+ * This is the provider-reported identity kind only — the security/content trust tier is a
+ * separate axis resolved elsewhere and never folded in here. An absent actor (a deleted
+ * account, a ghost author on an old issue) and any unrecognized `__typename` both fail
+ * closed to `'unknown'`; the kind is read from the provider, never guessed from a login.
+ * @param {String|null} [typename] The GraphQL `__typename` of the actor node.
+ * @returns {String} One of user | bot | organization | mannequin | enterprise-user | unknown.
+ */
+export function actorKindFromTypename(typename) {
+    switch (typename) {
+        case 'User':                  return 'user';
+        case 'Bot':                   return 'bot';
+        case 'Organization':          return 'organization';
+        case 'Mannequin':             return 'mannequin';
+        case 'EnterpriseUserAccount': return 'enterprise-user';
+        default:                      return 'unknown'
+    }
+}
+
+/**
+ * @summary The GitHub issue-timeline event `__typename` → occurrence-kind whitelist.
+ *
+ * A whitelist, not a blocklist: an event kind absent from this map produces no observation,
+ * so popularity signals and any future event type are refused by construction rather than by
+ * an easily-stale deny-list. Every kind here is a lifecycle or metadata fact — never prose.
+ * @member {Object<String,String>}
+ */
+export const TIMELINE_KIND_BY_TYPENAME = {
+    IssueComment           : 'issue.comment',
+    ClosedEvent            : 'issue.closed',
+    ReopenedEvent          : 'issue.reopened',
+    RenamedTitleEvent      : 'issue.renamed',
+    LabeledEvent           : 'issue.labeled',
+    UnlabeledEvent         : 'issue.unlabeled',
+    AssignedEvent          : 'issue.assigned',
+    UnassignedEvent        : 'issue.unassigned',
+    MilestonedEvent        : 'issue.milestoned',
+    DemilestonedEvent      : 'issue.demilestoned',
+    ReferencedEvent        : 'issue.referenced',
+    CrossReferencedEvent   : 'issue.cross-referenced',
+    SubIssueAddedEvent     : 'issue.sub-issue-added',
+    SubIssueRemovedEvent   : 'issue.sub-issue-removed',
+    ParentIssueAddedEvent  : 'issue.parent-added',
+    ParentIssueRemovedEvent: 'issue.parent-removed',
+    BlockedByAddedEvent    : 'issue.blocked-by-added',
+    BlockingAddedEvent     : 'issue.blocking-added',
+    BlockedByRemovedEvent  : 'issue.blocked-by-removed',
+    BlockingRemovedEvent   : 'issue.blocking-removed'
+};
+
+/**
+ * @summary Projects an actor node onto the `{actorId, actorKind}` pair the observation carries.
+ * @param {Object|null} [actor] `{login, __typename}` — may be null for a deleted/ghost author.
+ * @returns {{actorId: String|null, actorKind: String}}
+ */
+function projectActor(actor) {
+    return {
+        actorId  : actor?.login ?? null,
+        actorKind: actorKindFromTypename(actor?.__typename)
+    }
+}
+
+/**
+ * @summary Maps one reconciled GitHub issue node into an order-independent set of metadata-only
+ * observations for a `community-activity-batch.v1` batch — one per lifecycle fact, never prose.
+ *
+ * The emitted observation is intentionally free of title/body/label text: it carries the
+ * provider entity id, the occurrence kind, a stable revision-distinct coordinate, the moment,
+ * and the provider-reported actor identity/kind. Attention eligibility is NOT decided here —
+ * the connector reports `occurrenceKind` + `actorKind`, and the server-side classifier alone
+ * decides, so this normalizer stays one of several interchangeable producers of the same shape.
+ *
+ * Identity is stable across runs: the root, each comment, and each timeline event key off the
+ * provider's own node id, so re-reconciling the same issue reproduces byte-identical coordinates.
+ * A revision (edit, re-close, re-open) is a distinct coordinate on the same entity, never a
+ * silent overwrite of the create.
+ * @param {Object}        issue                  A reconciled issue node.
+ * @param {String}        issue.id               The provider node id (stable identity).
+ * @param {String}        issue.createdAt        ISO-8601 open moment.
+ * @param {String}        [issue.lastEditedAt]   ISO-8601 last-edit moment, when the body was edited.
+ * @param {Object|null}   [issue.author]         `{login, __typename}`; null for a deleted account.
+ * @param {Object[]}      [issue.comments]       `[{id, createdAt, lastEditedAt, author}]`.
+ * @param {Object[]}      [issue.timeline]       `[{id, __typename, createdAt, actor}]` normalized events.
+ * @returns {Object[]} Observations, each `{providerEntityId, occurrenceKind, occurrenceCoordinate, occurredAt, actorId, actorKind}`.
+ */
+export function issueToObservations(issue) {
+    if (!issue || typeof issue !== 'object' || !issue.id) {
+        throw new Error('ISSUE_OBSERVATIONS_REQUIRE_NODE_ID')
+    }
+
+    const observations = [];
+
+    // The issue root open — the anchor occurrence.
+    observations.push({
+        providerEntityId    : issue.id,
+        occurrenceKind      : 'issue.opened',
+        occurrenceCoordinate: `${issue.id}:opened`,
+        occurredAt          : issue.createdAt,
+        ...projectActor(issue.author)
+    });
+
+    // A body edit is a distinct revision on the same entity, coordinate-separated from the open.
+    if (issue.lastEditedAt) {
+        observations.push({
+            providerEntityId    : issue.id,
+            occurrenceKind      : 'issue.edited',
+            occurrenceCoordinate: `${issue.id}:edited:${issue.lastEditedAt}`,
+            occurredAt          : issue.lastEditedAt,
+            ...projectActor(issue.author)
+        })
+    }
+
+    for (const comment of issue.comments ?? []) {
+        if (!comment?.id) {
+            throw new Error('ISSUE_OBSERVATIONS_REQUIRE_COMMENT_ID')
+        }
+
+        observations.push({
+            providerEntityId    : comment.id,
+            occurrenceKind      : 'issue.comment',
+            occurrenceCoordinate: `${comment.id}:created`,
+            occurredAt          : comment.createdAt,
+            ...projectActor(comment.author)
+        });
+
+        if (comment.lastEditedAt) {
+            observations.push({
+                providerEntityId    : comment.id,
+                occurrenceKind      : 'issue.comment-edited',
+                occurrenceCoordinate: `${comment.id}:edited:${comment.lastEditedAt}`,
+                occurredAt          : comment.lastEditedAt,
+                ...projectActor(comment.author)
+            })
+        }
+    }
+
+    for (const event of issue.timeline ?? []) {
+        const occurrenceKind = TIMELINE_KIND_BY_TYPENAME[event?.__typename];
+
+        // Whitelist gate: an unmapped event kind (incl. any popularity signal) yields nothing.
+        if (!occurrenceKind) {
+            continue
+        }
+
+        if (!event.id) {
+            throw new Error('ISSUE_OBSERVATIONS_REQUIRE_EVENT_ID')
+        }
+
+        observations.push({
+            providerEntityId    : event.id,
+            occurrenceKind,
+            occurrenceCoordinate: `${event.id}:${occurrenceKind}`,
+            occurredAt          : event.createdAt,
+            ...projectActor(event.actor)
+        })
+    }
+
+    return observations
+}

--- a/ai/services/github-workflow/community/githubIssueObservations.mjs
+++ b/ai/services/github-workflow/community/githubIssueObservations.mjs
@@ -76,6 +76,18 @@ function projectActor(actor, sourceAssociation = null) {
 }
 
 /**
+ * @summary The actor projection for an edit revision. `lastEditedAt` proves an edit happened but
+ * NOT who made it — the connection carries no editor identity, and the original author is not
+ * evidence of the editor — so the editor is left explicitly unattributed with a loss marker rather
+ * than fabricated. Same discipline as a deleted author or an unexplained snapshot change: an
+ * unprovable actor is `null` / `unknown`, never guessed.
+ * @returns {{actorId: null, actorKind: String, sourceAssociation: null, lossMarker: String}}
+ */
+function unattributedEdit() {
+    return {actorId: null, actorKind: 'unknown', sourceAssociation: null, lossMarker: 'editor-unattributed'}
+}
+
+/**
  * @summary Maps one reconciled GitHub issue node into an order-independent set of metadata-only
  * observations for a `community-activity-batch.v1` batch — one per lifecycle fact, never prose.
  *
@@ -123,7 +135,7 @@ export function issueToObservations(issue) {
             occurrenceKind      : 'issue.edited',
             occurrenceCoordinate: `${issue.id}:edited:${issue.lastEditedAt}`,
             occurredAt          : issue.lastEditedAt,
-            ...projectActor(issue.author, issue.authorAssociation ?? null)
+            ...unattributedEdit()
         })
     }
 
@@ -146,7 +158,7 @@ export function issueToObservations(issue) {
                 occurrenceKind      : 'issue.comment-edited',
                 occurrenceCoordinate: `${comment.id}:edited:${comment.lastEditedAt}`,
                 occurredAt          : comment.lastEditedAt,
-                ...projectActor(comment.author, comment.authorAssociation ?? null)
+                ...unattributedEdit()
             })
         }
     }

--- a/ai/services/github-workflow/community/githubIssueObservations.mjs
+++ b/ai/services/github-workflow/community/githubIssueObservations.mjs
@@ -54,14 +54,24 @@ export const TIMELINE_KIND_BY_TYPENAME = {
 };
 
 /**
- * @summary Projects an actor node onto the `{actorId, actorKind}` pair the observation carries.
- * @param {Object|null} [actor] `{login, __typename}` — may be null for a deleted/ghost author.
- * @returns {{actorId: String|null, actorKind: String}}
+ * @summary Projects an actor node onto the `{actorId, actorKind, sourceAssociation}` triple the
+ * observation carries — the provider actor kind and the source-relative trust signal as SEPARATE
+ * fields (AC6). `sourceAssociation` is the provider's raw association-with-this-source
+ * (`OWNER`/`MEMBER`/`COLLABORATOR`/`CONTRIBUTOR`/`FIRST_TIME_CONTRIBUTOR`/`NONE`); the trust TIER
+ * is derived from it downstream, relative to the admitting source, never inside the producer.
+ *
+ * Actor kind and association are orthogonal: `bot` can be `NONE`, a `user` can be `OWNER`. Both an
+ * absent actor and an absent/unavailable association stay explicit — `unknown` and `null` — rather
+ * than being guessed. Lifecycle events carry no content authorship, so their association is null.
+ * @param {Object|null} [actor]             `{login, __typename}` — may be null for a deleted/ghost author.
+ * @param {String|null} [sourceAssociation] The provider association-with-source, or null when absent.
+ * @returns {{actorId: String|null, actorKind: String, sourceAssociation: String|null}}
  */
-function projectActor(actor) {
+function projectActor(actor, sourceAssociation = null) {
     return {
         actorId  : actor?.login ?? null,
-        actorKind: actorKindFromTypename(actor?.__typename)
+        actorKind: actorKindFromTypename(actor?.__typename),
+        sourceAssociation
     }
 }
 
@@ -84,9 +94,10 @@ function projectActor(actor) {
  * @param {String}        issue.createdAt        ISO-8601 open moment.
  * @param {String}        [issue.lastEditedAt]   ISO-8601 last-edit moment, when the body was edited.
  * @param {Object|null}   [issue.author]         `{login, __typename}`; null for a deleted account.
- * @param {Object[]}      [issue.comments]       `[{id, createdAt, lastEditedAt, author}]`.
+ * @param {String}        [issue.authorAssociation] Provider association-with-source of the author.
+ * @param {Object[]}      [issue.comments]       `[{id, createdAt, lastEditedAt, author, authorAssociation}]`.
  * @param {Object[]}      [issue.timeline]       `[{id, __typename, createdAt, actor}]` normalized events.
- * @returns {Object[]} Observations, each `{providerEntityId, occurrenceKind, occurrenceCoordinate, occurredAt, actorId, actorKind}`.
+ * @returns {Object[]} Observations, each `{providerEntityId, occurrenceKind, occurrenceCoordinate, occurredAt, actorId, actorKind, sourceAssociation}`.
  */
 export function issueToObservations(issue) {
     if (!issue || typeof issue !== 'object' || !issue.id) {
@@ -101,7 +112,7 @@ export function issueToObservations(issue) {
         occurrenceKind      : 'issue.opened',
         occurrenceCoordinate: `${issue.id}:opened`,
         occurredAt          : issue.createdAt,
-        ...projectActor(issue.author)
+        ...projectActor(issue.author, issue.authorAssociation ?? null)
     });
 
     // A body edit is a distinct revision on the same entity, coordinate-separated from the open.
@@ -111,7 +122,7 @@ export function issueToObservations(issue) {
             occurrenceKind      : 'issue.edited',
             occurrenceCoordinate: `${issue.id}:edited:${issue.lastEditedAt}`,
             occurredAt          : issue.lastEditedAt,
-            ...projectActor(issue.author)
+            ...projectActor(issue.author, issue.authorAssociation ?? null)
         })
     }
 
@@ -125,7 +136,7 @@ export function issueToObservations(issue) {
             occurrenceKind      : 'issue.comment',
             occurrenceCoordinate: `${comment.id}:created`,
             occurredAt          : comment.createdAt,
-            ...projectActor(comment.author)
+            ...projectActor(comment.author, comment.authorAssociation ?? null)
         });
 
         if (comment.lastEditedAt) {
@@ -134,7 +145,7 @@ export function issueToObservations(issue) {
                 occurrenceKind      : 'issue.comment-edited',
                 occurrenceCoordinate: `${comment.id}:edited:${comment.lastEditedAt}`,
                 occurredAt          : comment.lastEditedAt,
-                ...projectActor(comment.author)
+                ...projectActor(comment.author, comment.authorAssociation ?? null)
             })
         }
     }

--- a/ai/services/github-workflow/community/githubIssueReconciliation.mjs
+++ b/ai/services/github-workflow/community/githubIssueReconciliation.mjs
@@ -1,0 +1,141 @@
+import {issueToObservations} from './githubIssueObservations.mjs';
+
+/**
+ * @summary Drives one paginated connection to true exhaustion (or until a page cap truncates it),
+ * merging every page's items into a single list. The first page arrives inline on the parent node;
+ * only the overflow is continuation-fetched here.
+ *
+ * Exhaustion is `hasNextPage === false`, never a first page: a partial connection silently drops
+ * tail items (late comments, late events), so the walk only stops early when a caller cap forces
+ * it — and then it says so via `truncated`, so the omission is auditable rather than invisible.
+ * @param {Object}   connection
+ * @param {Object}   [connection.firstPage]  `{nodes:[...], pageInfo:{hasNextPage,endCursor}}` inline first page.
+ * @param {Function} connection.fetchNext    async (cursor) => `{items:[...], pageInfo}` for the next page.
+ * @param {Number}   connection.maxPages     Hard cap on pages walked (Infinity for unbounded).
+ * @returns {Promise<{items: Object[], truncated: Boolean}>}
+ */
+async function exhaustConnection({firstPage, fetchNext, maxPages}) {
+    const items = [...(firstPage?.nodes ?? [])];
+
+    let pageInfo = firstPage?.pageInfo,
+        pages    = 1;
+
+    while (pageInfo?.hasNextPage) {
+        if (pages >= maxPages) {
+            return {items, truncated: true}
+        }
+
+        const next = await fetchNext(pageInfo.endCursor);
+
+        items.push(...(next.items ?? []));
+        pageInfo = next.pageInfo;
+        pages++
+    }
+
+    return {items, truncated: false}
+}
+
+/**
+ * @summary Exhaustively reconciles a GitHub issue resource-family into community-activity-batch.v1
+ * observations, driving three independent pagination axes — the issue list across ALL states, then
+ * each issue's comments and its timeline — to completion behind injected fetch seams.
+ *
+ * The three axes are independent by design: an issue's comments and its lifecycle timeline are
+ * separate connections, each exhausted on its own, so neither truncates the other and a comment is
+ * never double-counted against a timeline event. Closed and open issues are enumerated identically
+ * — reconciliation reflects the provider, it does not filter by state.
+ *
+ * Completeness is earned, not assumed. With no caps every axis runs to `hasNextPage === false` and
+ * the run reports `coverage.complete === true`. The moment any caller cap truncates any axis, the
+ * run reports `complete === false` with an explicit `gaps` entry naming the axis (and issue), so a
+ * bounded sweep is always distinguishable from a whole one. All I/O is injected, keeping the
+ * exhaustion witness-testable without a browser or a live GitHub.
+ * @param {Object}   seams
+ * @param {Function} seams.fetchIssuesPage    async ({cursor}) => `{issues:[node], pageInfo}`; each node carries id, createdAt, author, and inline first pages of `comments` and `timeline`.
+ * @param {Function} seams.fetchCommentsPage  async ({issueId, cursor}) => `{comments:[c], pageInfo}`.
+ * @param {Function} seams.fetchTimelinePage  async ({issueId, cursor}) => `{events:[e], pageInfo}`.
+ * @param {Object}   [options]
+ * @param {String}   [options.fromBasis]                 Prior checkpoint cursor this run resumes after.
+ * @param {Number}   [options.maxIssuePages]             Cap on issue-list pages (default: unbounded).
+ * @param {Number}   [options.maxCommentPagesPerIssue]   Cap on per-issue comment pages (default: unbounded).
+ * @param {Number}   [options.maxTimelinePagesPerIssue]  Cap on per-issue timeline pages (default: unbounded).
+ * @returns {Promise<{observations: Object[], coverage: Object, nextProviderState: Object}>}
+ */
+export async function reconcileIssueActivity(seams, options = {}) {
+    const {fetchIssuesPage, fetchCommentsPage, fetchTimelinePage} = seams || {};
+
+    if ([fetchIssuesPage, fetchCommentsPage, fetchTimelinePage].some(fn => typeof fn !== 'function')) {
+        throw new Error('ISSUE_RECONCILIATION_REQUIRES_FETCH_SEAMS')
+    }
+
+    const {
+        fromBasis = null, maxIssuePages = Infinity,
+        maxCommentPagesPerIssue = Infinity, maxTimelinePagesPerIssue = Infinity
+    } = options;
+
+    const observations = [],
+          gaps         = [];
+
+    let issuesCursor = fromBasis,
+        issuePages   = 0,
+        complete     = true;
+
+    for (;;) {
+        if (issuePages >= maxIssuePages) {
+            complete = false;
+            gaps.push({axis: 'issues', afterCursor: issuesCursor});
+            break
+        }
+
+        const {issues, pageInfo} = await fetchIssuesPage({cursor: issuesCursor});
+
+        issuePages++;
+
+        for (const issue of issues ?? []) {
+            const comments = await exhaustConnection({
+                firstPage: issue.comments,
+                fetchNext: async cursor => {
+                    const page = await fetchCommentsPage({issueId: issue.id, cursor});
+                    return {items: page.comments, pageInfo: page.pageInfo}
+                },
+                maxPages : maxCommentPagesPerIssue
+            });
+
+            const timeline = await exhaustConnection({
+                firstPage: issue.timeline,
+                fetchNext: async cursor => {
+                    const page = await fetchTimelinePage({issueId: issue.id, cursor});
+                    return {items: page.events, pageInfo: page.pageInfo}
+                },
+                maxPages : maxTimelinePagesPerIssue
+            });
+
+            if (comments.truncated) {
+                complete = false;
+                gaps.push({axis: 'comments', issueId: issue.id})
+            }
+
+            if (timeline.truncated) {
+                complete = false;
+                gaps.push({axis: 'timeline', issueId: issue.id})
+            }
+
+            observations.push(...issueToObservations({...issue, comments: comments.items, timeline: timeline.items}))
+        }
+
+        if (!pageInfo?.hasNextPage) {
+            break
+        }
+
+        issuesCursor = pageInfo.endCursor
+    }
+
+    const coverage = {
+        fromBasis,
+        toBasis : issuesCursor,
+        complete,
+        ...(gaps.length ? {gaps} : {})
+    };
+
+    return {observations, coverage, nextProviderState: {issuesCursor}}
+}

--- a/ai/services/github-workflow/community/githubIssueReconciliation.mjs
+++ b/ai/services/github-workflow/community/githubIssueReconciliation.mjs
@@ -1,6 +1,14 @@
 import {issueToObservations} from './githubIssueObservations.mjs';
 
 /**
+ * @summary The basis marker for the beginning of history — the `fromBasis` of a first run that
+ * resumes from no prior cursor, and the `toBasis` of a run over an empty family. Keeps the coverage
+ * window a pair of concrete bases rather than nulls the contract would reject.
+ * @member {String}
+ */
+export const GENESIS_BASIS = 'genesis';
+
+/**
  * @summary Drives one paginated connection to true exhaustion (or until a page cap truncates it),
  * merging every page's items into a single list. The first page arrives inline on the parent node;
  * only the overflow is continuation-fetched here.
@@ -123,16 +131,20 @@ export async function reconcileIssueActivity(seams, options = {}) {
             observations.push(...issueToObservations({...issue, comments: comments.items, timeline: timeline.items}))
         }
 
+        // Capture the reached cursor on EVERY page, including the last — the endpoint of a complete
+        // walk is the final page's endCursor, not just the boundary before a continuation.
+        if (pageInfo?.endCursor) {
+            issuesCursor = pageInfo.endCursor
+        }
+
         if (!pageInfo?.hasNextPage) {
             break
         }
-
-        issuesCursor = pageInfo.endCursor
     }
 
     const coverage = {
-        fromBasis,
-        toBasis : issuesCursor,
+        fromBasis: fromBasis ?? GENESIS_BASIS,
+        toBasis  : issuesCursor ?? GENESIS_BASIS,
         complete,
         ...(gaps.length ? {gaps} : {})
     };

--- a/ai/services/github-workflow/queries/issueReconciliationQueries.mjs
+++ b/ai/services/github-workflow/queries/issueReconciliationQueries.mjs
@@ -52,7 +52,7 @@ query ReconcileIssues($owner: String!, $repo: String!, $after: String, $issuePag
     issues(first: $issuePage, after: $after, states: [OPEN, CLOSED], orderBy: {field: CREATED_AT, direction: ASC}) {
       pageInfo { hasNextPage endCursor }
       nodes {
-        id createdAt lastEditedAt authorAssociation
+        id createdAt updatedAt lastEditedAt authorAssociation
         author { login __typename }
         comments(first: $commentPage) {
           pageInfo { hasNextPage endCursor }

--- a/ai/services/github-workflow/queries/issueReconciliationQueries.mjs
+++ b/ai/services/github-workflow/queries/issueReconciliationQueries.mjs
@@ -1,0 +1,102 @@
+/**
+ * @summary Exhaustive issue-reconciliation GraphQL queries — distinct from the snapshot-oriented
+ * sync query. Three deliberate differences make them reconciliation-grade:
+ *
+ * 1. Every entity carries its provider node `id` (stable identity across runs) and every actor its
+ *    `__typename` (the provider actor-kind axis) plus `authorAssociation` (source-relative trust).
+ * 2. Comments are their OWN paginated connection, and `timelineItems` deliberately EXCLUDES
+ *    `ISSUE_COMMENT` — comments and the lifecycle timeline are two independent exhaustion axes, so
+ *    a comment is never double-counted against a timeline event.
+ * 3. Issues are drawn across BOTH states with a stable ascending order, so a cursor walk reaches
+ *    every open and closed root.
+ * @module ai/services/github-workflow/queries/issueReconciliationQueries
+ */
+
+/**
+ * @summary Lifecycle/metadata timeline event types — ISSUE_COMMENT intentionally absent (own axis).
+ * @member {String[]}
+ */
+export const RECONCILE_TIMELINE_ITEM_TYPES = [
+    'CLOSED_EVENT', 'REOPENED_EVENT', 'LABELED_EVENT', 'UNLABELED_EVENT',
+    'ASSIGNED_EVENT', 'UNASSIGNED_EVENT', 'RENAMED_TITLE_EVENT',
+    'MILESTONED_EVENT', 'DEMILESTONED_EVENT', 'REFERENCED_EVENT', 'CROSS_REFERENCED_EVENT'
+];
+
+const TIMELINE_ITEM_TYPES_ARG = RECONCILE_TIMELINE_ITEM_TYPES.join(', ');
+
+// One id + createdAt + actor selection per lifecycle event type; each such event is a Node with an id.
+const TIMELINE_NODE_SELECTION = `
+      __typename
+      ... on ClosedEvent          { id createdAt actor { login __typename } }
+      ... on ReopenedEvent        { id createdAt actor { login __typename } }
+      ... on LabeledEvent         { id createdAt actor { login __typename } }
+      ... on UnlabeledEvent       { id createdAt actor { login __typename } }
+      ... on AssignedEvent        { id createdAt actor { login __typename } }
+      ... on UnassignedEvent      { id createdAt actor { login __typename } }
+      ... on RenamedTitleEvent    { id createdAt actor { login __typename } }
+      ... on MilestonedEvent      { id createdAt actor { login __typename } }
+      ... on DemilestonedEvent    { id createdAt actor { login __typename } }
+      ... on ReferencedEvent      { id createdAt actor { login __typename } }
+      ... on CrossReferencedEvent { id createdAt actor { login __typename } }`;
+
+const COMMENT_NODE_SELECTION = `id createdAt lastEditedAt authorAssociation author { login __typename }`;
+
+/**
+ * @summary The issue-list axis: open and closed roots, ascending, with the first page of each
+ * issue's comments and timeline inline so single-page issues need no continuation fetch.
+ * @member {String}
+ */
+export const FETCH_RECONCILE_ISSUES = `
+query ReconcileIssues($owner: String!, $repo: String!, $after: String, $issuePage: Int!, $commentPage: Int!, $timelinePage: Int!) {
+  repository(owner: $owner, name: $repo) {
+    issues(first: $issuePage, after: $after, states: [OPEN, CLOSED], orderBy: {field: CREATED_AT, direction: ASC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id createdAt lastEditedAt authorAssociation
+        author { login __typename }
+        comments(first: $commentPage) {
+          pageInfo { hasNextPage endCursor }
+          nodes { ${COMMENT_NODE_SELECTION} }
+        }
+        timelineItems(first: $timelinePage, itemTypes: [${TIMELINE_ITEM_TYPES_ARG}]) {
+          pageInfo { hasNextPage endCursor }
+          nodes {${TIMELINE_NODE_SELECTION}
+          }
+        }
+      }
+    }
+  }
+}`;
+
+/**
+ * @summary The per-issue comments continuation axis, exhausted independently of the timeline.
+ * @member {String}
+ */
+export const FETCH_RECONCILE_COMMENTS_PAGE = `
+query ReconcileComments($issueId: ID!, $after: String, $commentPage: Int!) {
+  node(id: $issueId) {
+    ... on Issue {
+      comments(first: $commentPage, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes { ${COMMENT_NODE_SELECTION} }
+      }
+    }
+  }
+}`;
+
+/**
+ * @summary The per-issue timeline continuation axis, exhausted independently of comments.
+ * @member {String}
+ */
+export const FETCH_RECONCILE_TIMELINE_PAGE = `
+query ReconcileTimeline($issueId: ID!, $after: String, $timelinePage: Int!) {
+  node(id: $issueId) {
+    ... on Issue {
+      timelineItems(first: $timelinePage, after: $after, itemTypes: [${TIMELINE_ITEM_TYPES_ARG}]) {
+        pageInfo { hasNextPage endCursor }
+        nodes {${TIMELINE_NODE_SELECTION}
+        }
+      }
+    }
+  }
+}`;

--- a/test/playwright/unit/ai/services/github-workflow/IssueReconciliationService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueReconciliationService.spec.mjs
@@ -113,14 +113,79 @@ test.describe('IssueReconciliationService.reconcile', () => {
             .rejects.toThrow('ISSUE_RECONCILIATION_SOURCE_NOT_ACTIVE')
     });
 
-    test('AC9 repeated cursors — re-running the same window reproduces a digest-identical batch (idempotent)', async () => {
+    test('deterministic assembly — the same base + same provider truth reproduces a digest-identical batch (retry idempotency)', async () => {
         const runOnce = async () => {
             const admissionService = makeAdmission();
             await IssueReconciliationService.reconcile({...runSpec, admissionService, graphqlService, registryService: registryActive});
             return admissionService.admitted
         };
 
-        expect(canonicalBatchDigest(await runOnce()), 'same inputs → same digest → admission dedupes').toBe(canonicalBatchDigest(await runOnce()))
+        expect(canonicalBatchDigest(await runOnce()), 'same base + same truth → same digest → admission dedupes').toBe(canonicalBatchDigest(await runOnce()))
+    });
+
+    test('RA1 mutation-safe — pass 2 consumes the pass-1 checkpoint and RE-EMITS a new comment on a KNOWN root (no resume-skip)', async () => {
+        // A stateful admission that actually persists the checkpoint + observations, so pass 2 reads
+        // pass 1's real checkpoint — the vacuous fresh-service-twice shape could never falsify this.
+        let   checkpoint = null;
+        const admitted   = [],
+              statefulAdmission = {
+                  getCheckpoint   : () => checkpoint,
+                  listObservations: () => admitted,
+                  admitBatch(batch) {
+                      this.lastBatch = batch;
+                      checkpoint = {checkpointVersion: (checkpoint?.checkpointVersion ?? 0) + 1, inventoryHash: batch.nextInventoryHash, providerState: batch.nextProviderState};
+                      admitted.push(...batch.observations);
+                      return {status: 'accepted', receipt: {receiptId: 'r'}}
+                  }
+              };
+
+        // A mutable provider that HONORS the after-cursor: the SAME root I1 gains a comment between
+        // the two passes, and a request that RESUMES past `END` returns nothing (exactly the real
+        // GraphQL behavior). This is what makes the witness falsify the resume-skip: if the service
+        // resumed from pass-1's `END` cursor, pass 2 would fetch after `END` → empty → miss C1.
+        let   i1Comments = [];
+        const issuePage  = comments => ({repository: {issues: {pageInfo: {hasNextPage: false, endCursor: 'END'}, nodes: [
+            {id: 'I1', createdAt: '2026-01-01T00:00:00Z', lastEditedAt: null, authorAssociation: 'OWNER', author: {login: 'human', __typename: 'User'},
+             comments: {pageInfo: {hasNextPage: false, endCursor: null}, nodes: comments}, timelineItems: {pageInfo: {hasNextPage: false, endCursor: null}, nodes: []}}
+        ]}}});
+        const mutableGraphql = {
+            query: async (queryStr, vars) => queryStr.includes('ReconcileIssues')
+                ? (vars.after ? {repository: {issues: {pageInfo: {hasNextPage: false, endCursor: 'END'}, nodes: []}}} : issuePage(i1Comments))
+                : {node: {comments: {pageInfo: {hasNextPage: false}, nodes: []}, timelineItems: {pageInfo: {hasNextPage: false}, nodes: []}}}
+        };
+
+        const run = () => IssueReconciliationService.reconcile({...runSpec, admissionService: statefulAdmission, graphqlService: mutableGraphql, registryService: registryActive});
+
+        await run(); // pass 1 — I1 opened, no comments
+        expect(statefulAdmission.lastBatch.observations.some(o => o.occurrenceKind === 'issue.comment')).toBe(false);
+
+        i1Comments = [{id: 'C1', createdAt: '2026-01-02T00:00:00Z', lastEditedAt: null, authorAssociation: 'CONTRIBUTOR', author: {login: 'replier', __typename: 'User'}}];
+
+        await run(); // pass 2 — consumes the checkpoint, RE-ENUMERATES I1, catches C1
+        const pass2 = statefulAdmission.lastBatch;
+
+        expect(pass2.observations.some(o => o.providerEntityId === 'C1' && o.occurrenceKind === 'issue.comment'), 'the new comment on a known root is caught').toBe(true);
+        expect(pass2.coverage.complete).toBe(true);
+        expect(pass2.coverage.gaps ?? [], 'I1 is still present — no fabricated inventory-access gap').toEqual([]);
+        expect(pass2.observations.some(o => o.absence === 'deleted'), 'nothing deleted').toBe(false)
+    });
+
+    test('RA3 delete-evidence seam — an evidenced vanish becomes an admitted deletion; an unevidenced vanish stays an inventory gap', async () => {
+        const admissionService = makeAdmission({
+            listObservations: () => [
+                {occurrenceKind: 'issue.opened', providerEntityId: 'I_gone'},
+                {occurrenceKind: 'issue.opened', providerEntityId: 'I_hidden'}
+            ]
+        });
+        const emptyGraphql            = {query: async queryStr => queryStr.includes('ReconcileIssues') ? {repository: {issues: {pageInfo: {hasNextPage: false, endCursor: 'E'}, nodes: []}}} : {node: {}}},
+              acquireDeletionEvidence = async vanished => vanished.includes('I_gone') ? {I_gone: {tombstoneId: 't-gone', deletedAt: '2026-01-04T00:00:00Z'}} : {};
+
+        await IssueReconciliationService.reconcile({...runSpec, admissionService, graphqlService: emptyGraphql, registryService: registryActive, acquireDeletionEvidence});
+        const batch = admissionService.admitted;
+
+        expect(batch.observations.find(o => o.providerEntityId === 'I_gone')?.absence, 'evidenced vanish → admitted deletion').toBe('deleted');
+        expect(batch.observations.some(o => o.providerEntityId === 'I_hidden'), 'unevidenced vanish is NOT a deletion').toBe(false);
+        expect(batch.coverage.gaps).toEqual(expect.arrayContaining([{axis: 'inventory-access', providerEntityId: 'I_hidden'}]))
     });
 
     test('AC9 collaborator change — a shifted association reaches the observation, distinguishing the run', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/IssueReconciliationService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueReconciliationService.spec.mjs
@@ -1,0 +1,129 @@
+import {setup} from '../../../../setup.mjs';
+
+const appName = 'IssueReconciliationServiceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}             from '@playwright/test';
+import Neo                        from '../../../../../../src/Neo.mjs';
+import * as core                  from '../../../../../../src/core/_export.mjs';
+import IssueReconciliationService from '../../../../../../ai/services/github-workflow/IssueReconciliationService.mjs';
+import {validateBatch}            from '../../../../../../ai/services/memory-core/communityBatchContract.mjs';
+
+/**
+ * @summary End-to-end wiring witness for the reconciliation service: fake GraphQL / admission /
+ * registry drive one pass and prove the assembled batch is a valid v1 envelope with every axis
+ * exhausted, the trust field flowing through, and the cursor advanced only via admission.
+ */
+test.describe('IssueReconciliationService.reconcile', () => {
+    const comment = (id, assoc = 'CONTRIBUTOR') => ({id, createdAt: '2026-01-01T09:00:00Z', lastEditedAt: null, authorAssociation: assoc, author: {login: 'c', __typename: 'User'}}),
+          event   = (id, typename) => ({__typename: typename, id, createdAt: '2026-01-01T10:00:00Z', actor: {login: 'm', __typename: 'User'}});
+
+    // A GraphQL fake: one issue page; I_a overflows both its comment and timeline axes, I_b is empty.
+    const graphqlService = {
+        query: async (queryStr, vars) => {
+            if (queryStr.includes('ReconcileIssues')) {
+                return {repository: {issues: {
+                    pageInfo: {hasNextPage: false, endCursor: 'ISSUES_END'},
+                    nodes   : [
+                        {
+                            id           : 'I_a', createdAt: '2026-01-01T00:00:00Z', lastEditedAt: null, authorAssociation: 'OWNER',
+                            author       : {login: 'human', __typename: 'User'},
+                            comments     : {pageInfo: {hasNextPage: true, endCursor: '2'}, nodes: [comment('IC_a1'), comment('IC_a2')]},
+                            timelineItems: {pageInfo: {hasNextPage: true, endCursor: 'T2'}, nodes: [event('CE_a1', 'ClosedEvent')]}
+                        },
+                        {
+                            id           : 'I_b', createdAt: '2026-01-02T00:00:00Z', lastEditedAt: null, authorAssociation: 'NONE',
+                            author       : {login: 'dependabot', __typename: 'Bot'},
+                            comments     : {pageInfo: {hasNextPage: false, endCursor: null}, nodes: []},
+                            timelineItems: {pageInfo: {hasNextPage: false, endCursor: null}, nodes: []}
+                        }
+                    ]
+                }}}
+            }
+            if (queryStr.includes('ReconcileComments')) {
+                return {node: {comments: {pageInfo: {hasNextPage: false, endCursor: '3'}, nodes: [comment('IC_a3')]}}}
+            }
+            if (queryStr.includes('ReconcileTimeline')) {
+                return {node: {timelineItems: {pageInfo: {hasNextPage: false, endCursor: null}, nodes: [event('RE_a1', 'ReopenedEvent')]}}}
+            }
+            throw new Error(`unexpected query: ${vars}`)
+        }
+    };
+
+    const registryActive = {getRegistration: () => ({lifecycleState: 'ACTIVE', registrationEpoch: 2})};
+
+    const makeAdmission = (over = {}) => ({
+        getCheckpoint   : () => null,
+        listObservations: () => [],
+        admitBatch      : function (batch) { this.admitted = batch; return {status: 'accepted', receipt: {receiptId: 'r1'}} },
+        ...over
+    });
+
+    const runSpec = {sourceInstanceId: 'src-1', owner: 'neomjs', repo: 'neo', batchId: 'batch-1', observedAt: '2026-01-05T00:00:00Z'};
+
+    test('drives every axis to exhaustion and admits a VALID v1 batch', async () => {
+        const admissionService = makeAdmission(),
+              receipt          = await IssueReconciliationService.reconcile({...runSpec, admissionService, graphqlService, registryService: registryActive}),
+              batch            = admissionService.admitted;
+
+        expect(receipt.status).toBe('accepted');
+        expect(validateBatch(batch), 'the admitted batch is contract-valid').toEqual({valid: true, errors: []});
+
+        const kind = k => batch.observations.filter(o => o.occurrenceKind === k).length;
+
+        expect(kind('issue.opened'), 'one root per issue').toBe(2);
+        expect(kind('issue.comment'), 'all 3 comments across 2 comment pages').toBe(3);
+        expect(kind('issue.closed')).toBe(1);
+        expect(kind('issue.reopened'), 'timeline overflow walked').toBe(1);
+        expect(batch.registrationEpoch, 'epoch carried from registration').toBe(2)
+    });
+
+    test('the source-relative trust field flows through end-to-end', async () => {
+        const admissionService = makeAdmission();
+
+        await IssueReconciliationService.reconcile({...runSpec, admissionService, graphqlService, registryService: registryActive});
+
+        const roots = admissionService.admitted.observations.filter(o => o.occurrenceKind === 'issue.opened');
+
+        expect(roots.find(o => o.providerEntityId === 'I_a').sourceAssociation).toBe('OWNER');
+        expect(roots.find(o => o.providerEntityId === 'I_b').sourceAssociation).toBe('NONE')
+    });
+
+    test('an admission CONFLICT is returned, not thrown — the cursor never advances behind a failed receipt', async () => {
+        const admissionService = makeAdmission({admitBatch: () => ({status: 'conflict', reason: 'STALE_BASIS'})}),
+              receipt          = await IssueReconciliationService.reconcile({...runSpec, admissionService, graphqlService, registryService: registryActive});
+
+        expect(receipt).toEqual({status: 'conflict', reason: 'STALE_BASIS'})
+    });
+
+    test('a source that is not ACTIVE is refused before any acquisition', async () => {
+        const registryService = {getRegistration: () => ({lifecycleState: 'REVOKED', registrationEpoch: 3})};
+
+        await expect(IssueReconciliationService.reconcile({...runSpec, admissionService: makeAdmission(), graphqlService, registryService}))
+            .rejects.toThrow('ISSUE_RECONCILIATION_SOURCE_NOT_ACTIVE')
+    });
+
+    test('prior inventory that vanishes without evidence degrades coverage — never a deletion', async () => {
+        const admissionService = makeAdmission({
+            listObservations: () => [{occurrenceKind: 'issue.opened', providerEntityId: 'I_vanished'}]
+        });
+
+        await IssueReconciliationService.reconcile({...runSpec, admissionService, graphqlService, registryService: registryActive});
+
+        const batch = admissionService.admitted;
+
+        expect(batch.observations.some(o => o.providerEntityId === 'I_vanished'), 'no fabricated deletion').toBe(false);
+        expect(batch.coverage.complete, 'access loss lowers completeness').toBe(false);
+        expect(batch.coverage.gaps).toEqual(expect.arrayContaining([{axis: 'inventory-access', providerEntityId: 'I_vanished'}]))
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/IssueReconciliationService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/IssueReconciliationService.spec.mjs
@@ -13,11 +13,11 @@ setup({
     }
 });
 
-import {test, expect}             from '@playwright/test';
-import Neo                        from '../../../../../../src/Neo.mjs';
-import * as core                  from '../../../../../../src/core/_export.mjs';
-import IssueReconciliationService from '../../../../../../ai/services/github-workflow/IssueReconciliationService.mjs';
-import {validateBatch}            from '../../../../../../ai/services/memory-core/communityBatchContract.mjs';
+import {test, expect}                        from '@playwright/test';
+import Neo                                   from '../../../../../../src/Neo.mjs';
+import * as core                             from '../../../../../../src/core/_export.mjs';
+import IssueReconciliationService            from '../../../../../../ai/services/github-workflow/IssueReconciliationService.mjs';
+import {canonicalBatchDigest, validateBatch} from '../../../../../../ai/services/memory-core/communityBatchContract.mjs';
 
 /**
  * @summary End-to-end wiring witness for the reconciliation service: fake GraphQL / admission /
@@ -111,6 +111,31 @@ test.describe('IssueReconciliationService.reconcile', () => {
 
         await expect(IssueReconciliationService.reconcile({...runSpec, admissionService: makeAdmission(), graphqlService, registryService}))
             .rejects.toThrow('ISSUE_RECONCILIATION_SOURCE_NOT_ACTIVE')
+    });
+
+    test('AC9 repeated cursors — re-running the same window reproduces a digest-identical batch (idempotent)', async () => {
+        const runOnce = async () => {
+            const admissionService = makeAdmission();
+            await IssueReconciliationService.reconcile({...runSpec, admissionService, graphqlService, registryService: registryActive});
+            return admissionService.admitted
+        };
+
+        expect(canonicalBatchDigest(await runOnce()), 'same inputs → same digest → admission dedupes').toBe(canonicalBatchDigest(await runOnce()))
+    });
+
+    test('AC9 collaborator change — a shifted association reaches the observation, distinguishing the run', async () => {
+        const promoted = {
+            query: async queryStr => queryStr.includes('ReconcileIssues')
+                ? {repository: {issues: {pageInfo: {hasNextPage: false, endCursor: 'E'}, nodes: [
+                    {id: 'I_a', createdAt: '2026-01-01T00:00:00Z', lastEditedAt: null, authorAssociation: 'MEMBER', author: {login: 'human', __typename: 'User'}, comments: {pageInfo: {hasNextPage: false}, nodes: []}, timelineItems: {pageInfo: {hasNextPage: false}, nodes: []}}
+                ]}}}
+                : {node: {}}
+        };
+        const admissionService = makeAdmission();
+
+        await IssueReconciliationService.reconcile({...runSpec, admissionService, graphqlService: promoted, registryService: registryActive});
+
+        expect(admissionService.admitted.observations.find(o => o.providerEntityId === 'I_a').sourceAssociation, 'the new association is carried, not the old').toBe('MEMBER')
     });
 
     test('prior inventory that vanishes without evidence degrades coverage — never a deletion', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/community/assembleIssueBatch.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/community/assembleIssueBatch.spec.mjs
@@ -1,0 +1,90 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'AssembleIssueBatchTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}                      from '@playwright/test';
+import Neo                                 from '../../../../../../../src/Neo.mjs';
+import * as core                           from '../../../../../../../src/core/_export.mjs';
+import {validateBatch}                     from '../../../../../../../ai/services/memory-core/communityBatchContract.mjs';
+import {assembleIssueBatch, inventoryHash} from '../../../../../../../ai/services/github-workflow/community/assembleIssueBatch.mjs';
+
+/**
+ * @summary Witnesses that the batch assembler produces a valid v1 envelope, folds evidenced
+ * deletions into observations while keeping access-indeterminate absences OUT of observations (they
+ * only degrade coverage), and computes an order-insensitive inventory hash.
+ */
+test.describe('assembleIssueBatch', () => {
+    const observation = entityId => ({
+        providerEntityId    : entityId,
+        occurrenceKind      : 'issue.opened',
+        occurrenceCoordinate: `${entityId}:opened`,
+        occurredAt          : '2026-07-18T10:00:00Z',
+        actorKind           : 'user',
+        sourceAssociation   : 'OWNER'
+    });
+
+    const runnerResult = {
+        observations     : [observation('I_a'), observation('I_b')],
+        coverage         : {fromBasis: 'c1', toBasis: 'c9', complete: true},
+        nextProviderState: {issuesCursor: '9'}
+    };
+
+    const base = (over = {}) => ({
+        sourceInstanceId     : 'src-1',
+        registrationEpoch    : 2,
+        baseCheckpointVersion: 0,
+        baseInventoryHash    : null,
+        runnerResult,
+        currentInventory     : ['I_a', 'I_b'],
+        batchId              : 'batch-1',
+        observedAt           : '2026-07-18T13:00:00Z',
+        ...over
+    });
+
+    test('a straightforward assembly validates as v1 and carries the runner cursor through', () => {
+        const batch = assembleIssueBatch(base());
+
+        expect(validateBatch(batch)).toEqual({valid: true, errors: []});
+        expect(batch.nextProviderState, 'the cursor passes through untouched').toEqual({issuesCursor: '9'});
+        expect(batch.nextInventoryHash).toBe(inventoryHash(['I_a', 'I_b']))
+    });
+
+    test('an evidenced deletion becomes a deleted observation and the batch still validates', () => {
+        const batch = assembleIssueBatch(base({
+            absences: {deleted: [{providerEntityId: 'I_gone', deletionEvidence: {tombstoneId: 't-1', deletedAt: '2026-07-18T12:00:00Z'}}], accessIndeterminate: []}
+        }));
+
+        const del = batch.observations.find(o => o.providerEntityId === 'I_gone');
+
+        expect(del.absence).toBe('deleted');
+        expect(validateBatch(batch)).toEqual({valid: true, errors: []})
+    });
+
+    test('an access-indeterminate absence is NOT an observation — it degrades coverage as a gap', () => {
+        const batch = assembleIssueBatch(base({
+            absences: {deleted: [], accessIndeterminate: ['I_hidden']}
+        }));
+
+        expect(batch.observations.some(o => o.providerEntityId === 'I_hidden'), 'never fabricated as an observation').toBe(false);
+        expect(batch.coverage.complete, 'access loss lowers completeness').toBe(false);
+        expect(batch.coverage.gaps).toEqual(expect.arrayContaining([{axis: 'inventory-access', providerEntityId: 'I_hidden'}]));
+        expect(validateBatch(batch), 'incomplete-with-gaps is a valid coverage shape').toEqual({valid: true, errors: []})
+    });
+
+    test('inventory hash is order-insensitive and dedupes', () => {
+        expect(inventoryHash(['I_a', 'I_b'])).toBe(inventoryHash(['I_b', 'I_a']));
+        expect(inventoryHash(['I_a', 'I_a', 'I_b'])).toBe(inventoryHash(['I_a', 'I_b']));
+        expect(inventoryHash(['I_a'])).not.toBe(inventoryHash(['I_a', 'I_b']))
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/community/githubIssueAbsence.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/community/githubIssueAbsence.spec.mjs
@@ -1,0 +1,101 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'GithubIssueAbsenceTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}                            from '@playwright/test';
+import Neo                                       from '../../../../../../../src/Neo.mjs';
+import * as core                                 from '../../../../../../../src/core/_export.mjs';
+import {BATCH_SCHEMA_VERSION, validateBatch}     from '../../../../../../../ai/services/memory-core/communityBatchContract.mjs';
+import {classifyAbsences, deletionToObservation} from '../../../../../../../ai/services/github-workflow/community/githubIssueAbsence.mjs';
+
+/**
+ * @summary Witnesses the absence security invariant: a vanished entity is a deletion only with
+ * explicit provider evidence; a vanish without evidence is an access/permission loss and is never
+ * shaped into a deletion. Also confirms a produced deletion observation satisfies the v1 contract.
+ */
+test.describe('githubIssueAbsence classification', () => {
+    const evidence = (over = {}) => ({tombstoneId: 't-1', deletedAt: '2026-07-18T12:00:00Z', actor: {login: 'author', __typename: 'User'}, ...over});
+
+    // ------------------------------------------------------------------ the security invariant
+
+    test('a still-present entity is neither deleted nor indeterminate', () => {
+        const {deleted, accessIndeterminate} = classifyAbsences(['A', 'B'], ['A', 'B'], {});
+
+        expect(deleted).toEqual([]);
+        expect(accessIndeterminate).toEqual([])
+    });
+
+    test('a vanished entity WITH provider evidence is a deletion', () => {
+        const {deleted, accessIndeterminate} = classifyAbsences(['A', 'GONE'], ['A'], {GONE: evidence()});
+
+        expect(deleted).toEqual([{providerEntityId: 'GONE', deletionEvidence: evidence()}]);
+        expect(accessIndeterminate).toEqual([])
+    });
+
+    test('a vanished entity WITHOUT evidence is access-indeterminate — NEVER a deletion (permission-loss ≠ deletion)', () => {
+        const {deleted, accessIndeterminate} = classifyAbsences(['A', 'HIDDEN'], ['A'], {});
+
+        expect(deleted, 'no evidence, so no deletion is manufactured').toEqual([]);
+        expect(accessIndeterminate).toEqual(['HIDDEN'])
+    });
+
+    test('a mixed vanish splits cleanly — evidenced deleted, unevidenced indeterminate', () => {
+        const {deleted, accessIndeterminate} = classifyAbsences(
+            ['keep', 'del', 'lost'], ['keep'], {del: evidence({tombstoneId: 't-del'})}
+        );
+
+        expect(deleted.map(d => d.providerEntityId)).toEqual(['del']);
+        expect(accessIndeterminate).toEqual(['lost'])
+    });
+
+    // ------------------------------------------------------------------ the deletion observation is admissible
+
+    test('a deletion observation carries its evidence and validates in a v1 batch', () => {
+        const [deletion]  = classifyAbsences(['GONE'], [], {GONE: evidence()}).deleted,
+              observation = deletionToObservation(deletion, {occurrenceKind: 'issue.deleted', observedAt: '2026-07-18T13:00:00Z'});
+
+        expect(observation.absence).toBe('deleted');
+        expect(observation.deletionEvidence.tombstoneId).toBe('t-1');
+        expect(observation.occurredAt, 'dated evidence wins over the fallback').toBe('2026-07-18T12:00:00Z');
+
+        const batch = {
+            schemaVersion             : BATCH_SCHEMA_VERSION,
+            sourceInstanceId          : 'src-1',
+            resourceFamily            : 'issues',
+            adapterSchemaVersion      : 'github-issue.v1',
+            providerStateSchemaVersion: 'gh-state.v1',
+            registrationEpoch         : 2,
+            baseCheckpointVersion     : 0,
+            baseInventoryHash         : null,
+            batchId                   : 'batch-1',
+            observations              : [observation],
+            nextProviderState         : {cursor: 'x'},
+            nextInventoryHash         : 'inv-1',
+            coverage                  : {fromBasis: 'c1', toBasis: 'c9', complete: true}
+        };
+
+        expect(validateBatch(batch)).toEqual({valid: true, errors: []})
+    });
+
+    test('an undated evidence falls back to the reconciliation observedAt; actor kind fails closed', () => {
+        const observation = deletionToObservation(
+            {providerEntityId: 'X', deletionEvidence: {tombstoneId: 't-x'}},
+            {occurrenceKind: 'issue.comment-deleted', observedAt: '2026-07-18T14:00:00Z'}
+        );
+
+        expect(observation.occurredAt).toBe('2026-07-18T14:00:00Z');
+        expect(observation.actorKind, 'no actor on the evidence → unknown').toBe('unknown');
+        expect(observation.actorId).toBe(null)
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/community/githubIssueObservations.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/community/githubIssueObservations.spec.mjs
@@ -156,6 +156,34 @@ test.describe('githubIssueObservations normalizer', () => {
         expect(root.actorId).toBe(null)
     });
 
+    // ------------------------------------------------------------------ AC4 — honest snapshot-only change
+
+    test('an updatedAt newer than every explained occurrence emits a null-actor snapshot-change marker', () => {
+        const changed = {
+            id      : 'I_s', createdAt: '2026-07-18T09:00:00Z', updatedAt: '2026-07-18T15:00:00Z',
+            author  : {login: 'a', __typename: 'User'}, authorAssociation: 'OWNER',
+            timeline: [{id: 'CE', __typename: 'ClosedEvent', createdAt: '2026-07-18T10:00:00Z', actor: {login: 'm', __typename: 'User'}}]
+        };
+
+        const marker = issueToObservations(changed).find(o => o.occurrenceKind === 'issue.observed-snapshot-change');
+
+        expect(marker, 'the unexplained change is recorded').toBeTruthy();
+        expect(marker.actorId, 'no actor is fabricated').toBe(null);
+        expect(marker.actorKind).toBe('unknown');
+        expect(marker.lossMarker).toBe('snapshot-without-granular-event');
+        expect(validateBatch(batchAround(issueToObservations(changed)))).toEqual({valid: true, errors: []})
+    });
+
+    test('an updatedAt explained by a captured occurrence emits NO snapshot-change marker', () => {
+        const explained = {
+            id      : 'I_e', createdAt: '2026-07-18T09:00:00Z', updatedAt: '2026-07-18T10:00:00Z',
+            author  : {login: 'a', __typename: 'User'}, authorAssociation: 'OWNER',
+            timeline: [{id: 'CE', __typename: 'ClosedEvent', createdAt: '2026-07-18T10:00:00Z', actor: {login: 'm', __typename: 'User'}}]
+        };
+
+        expect(issueToObservations(explained).some(o => o.occurrenceKind === 'issue.observed-snapshot-change')).toBe(false)
+    });
+
     // ------------------------------------------------------------------ identity is mandatory (fail loud)
 
     test('a node or comment or event without a provider id is refused', () => {

--- a/test/playwright/unit/ai/services/github-workflow/community/githubIssueObservations.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/community/githubIssueObservations.spec.mjs
@@ -184,6 +184,31 @@ test.describe('githubIssueObservations normalizer', () => {
         expect(issueToObservations(explained).some(o => o.occurrenceKind === 'issue.observed-snapshot-change')).toBe(false)
     });
 
+    // ------------------------------------------------------------------ RA2 — edits are unattributed
+
+    test('an edit is NOT attributed to the original author — lastEditedAt proves when, never who', () => {
+        const edited = {
+            id      : 'I_x', createdAt: '2026-07-18T09:00:00Z', lastEditedAt: '2026-07-18T12:00:00Z',
+            author  : {login: 'original-author', __typename: 'User'}, authorAssociation: 'OWNER',
+            comments: [{id: 'IC_x', createdAt: '2026-07-18T10:00:00Z', lastEditedAt: '2026-07-18T13:00:00Z', author: {login: 'commenter', __typename: 'User'}, authorAssociation: 'CONTRIBUTOR'}]
+        };
+
+        const obs         = issueToObservations(edited),
+              issueEdit   = obs.find(o => o.occurrenceKind === 'issue.edited'),
+              commentEdit = obs.find(o => o.occurrenceKind === 'issue.comment-edited');
+
+        for (const revision of [issueEdit, commentEdit]) {
+            expect(revision.actorId, 'no editor identity is fabricated').toBe(null);
+            expect(revision.actorKind).toBe('unknown');
+            expect(revision.sourceAssociation).toBe(null);
+            expect(revision.lossMarker).toBe('editor-unattributed')
+        }
+
+        // the CREATE still carries the real author — only the edit is unattributed
+        expect(obs.find(o => o.occurrenceKind === 'issue.opened').actorId).toBe('original-author');
+        expect(validateBatch(batchAround(obs))).toEqual({valid: true, errors: []})
+    });
+
     // ------------------------------------------------------------------ identity is mandatory (fail loud)
 
     test('a node or comment or event without a provider id is refused', () => {

--- a/test/playwright/unit/ai/services/github-workflow/community/githubIssueObservations.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/community/githubIssueObservations.spec.mjs
@@ -119,6 +119,21 @@ test.describe('githubIssueObservations normalizer', () => {
         expect(kinds.filter(k => k.startsWith('issue.'))).toEqual(['issue.opened', 'issue.edited', 'issue.comment', 'issue.comment', 'issue.comment-edited'])
     });
 
+    test('a stray IssueComment on the timeline is ignored — the comments axis owns comments (no double-count)', () => {
+        const withStray = {
+            ...fullIssue,
+            timeline: [
+                {id: 'IC_x', __typename: 'IssueComment', createdAt: '2026-07-18T12:00:00Z', author: {login: 'replier', __typename: 'User'}},
+                {id: 'CE_x', __typename: 'ClosedEvent',   createdAt: '2026-07-18T12:01:00Z', actor: {login: 'maintainer', __typename: 'User'}}
+            ]
+        };
+
+        const timelineComments = issueToObservations(withStray)
+            .filter(o => o.occurrenceKind === 'issue.comment' && o.providerEntityId === 'IC_x');
+
+        expect(timelineComments, 'a timeline IssueComment produces no observation').toHaveLength(0)
+    });
+
     test('a deleted author on the root fails closed to unknown, actorId null', () => {
         const [root] = issueToObservations({id: 'I_ghost', createdAt: '2020-01-01T00:00:00Z', author: null});
 

--- a/test/playwright/unit/ai/services/github-workflow/community/githubIssueObservations.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/community/githubIssueObservations.spec.mjs
@@ -29,10 +29,10 @@ test.describe('githubIssueObservations normalizer', () => {
         id          : 'I_root',
         createdAt   : '2026-07-18T09:00:00Z',
         lastEditedAt: '2026-07-18T09:30:00Z',
-        author      : {login: 'octo-human', __typename: 'User'},
+        author      : {login: 'octo-human', __typename: 'User'}, authorAssociation: 'OWNER',
         comments    : [
-            {id: 'IC_1', createdAt: '2026-07-18T10:00:00Z', author: {login: 'replier', __typename: 'User'}},
-            {id: 'IC_2', createdAt: '2026-07-18T10:05:00Z', lastEditedAt: '2026-07-18T10:07:00Z', author: {login: 'dependabot', __typename: 'Bot'}}
+            {id: 'IC_1', createdAt: '2026-07-18T10:00:00Z', author: {login: 'replier', __typename: 'User'}, authorAssociation: 'CONTRIBUTOR'},
+            {id: 'IC_2', createdAt: '2026-07-18T10:05:00Z', lastEditedAt: '2026-07-18T10:07:00Z', author: {login: 'dependabot', __typename: 'Bot'}, authorAssociation: 'NONE'}
         ],
         timeline    : [
             {id: 'CE_1', __typename: 'ClosedEvent',   createdAt: '2026-07-18T11:00:00Z', actor: {login: 'maintainer', __typename: 'User'}},
@@ -67,6 +67,21 @@ test.describe('githubIssueObservations normalizer', () => {
         expect(actorKindFromTypename('EnterpriseUserAccount')).toBe('enterprise-user');
         expect(actorKindFromTypename(undefined), 'a deleted/ghost actor').toBe('unknown');
         expect(actorKindFromTypename('SomethingNew'), 'an unrecognized kind').toBe('unknown')
+    });
+
+    test('source-relative trust is a SEPARATE field from actor kind, and orthogonal to it', () => {
+        const obs        = issueToObservations(fullIssue),
+              root       = obs.find(o => o.providerEntityId === 'I_root' && o.occurrenceKind === 'issue.opened'),
+              botComment = obs.find(o => o.providerEntityId === 'IC_2' && o.occurrenceKind === 'issue.comment'),
+              closed     = obs.find(o => o.occurrenceKind === 'issue.closed');
+
+        expect(root.actorKind).toBe('user');
+        expect(root.sourceAssociation, 'kind and association are distinct fields').toBe('OWNER');
+        // Orthogonal axes: a bot may carry any association — here NONE — and the two never conflate.
+        expect(botComment.actorKind).toBe('bot');
+        expect(botComment.sourceAssociation).toBe('NONE');
+        // A lifecycle event has no content authorship, so its association is explicitly null, not guessed.
+        expect(closed.sourceAssociation).toBe(null)
     });
 
     // ------------------------------------------------------------------ the emitted shape is admissible

--- a/test/playwright/unit/ai/services/github-workflow/community/githubIssueObservations.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/community/githubIssueObservations.spec.mjs
@@ -1,0 +1,136 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'GithubIssueObservationsTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}                                            from '@playwright/test';
+import Neo                                                       from '../../../../../../../src/Neo.mjs';
+import * as core                                                 from '../../../../../../../src/core/_export.mjs';
+import {BATCH_SCHEMA_VERSION, validateBatch, occurrenceIdentity} from '../../../../../../../ai/services/memory-core/communityBatchContract.mjs';
+import {actorKindFromTypename, issueToObservations}              from '../../../../../../../ai/services/github-workflow/community/githubIssueObservations.mjs';
+
+/**
+ * @summary Witnesses that the GitHub issue normalizer emits observations the shipped
+ * community-activity-batch.v1 contract accepts — admissible, prose-free, stably-identified,
+ * and popularity-refusing by construction — with no attention decision taken in the producer.
+ */
+test.describe('githubIssueObservations normalizer', () => {
+    const fullIssue = {
+        id          : 'I_root',
+        createdAt   : '2026-07-18T09:00:00Z',
+        lastEditedAt: '2026-07-18T09:30:00Z',
+        author      : {login: 'octo-human', __typename: 'User'},
+        comments    : [
+            {id: 'IC_1', createdAt: '2026-07-18T10:00:00Z', author: {login: 'replier', __typename: 'User'}},
+            {id: 'IC_2', createdAt: '2026-07-18T10:05:00Z', lastEditedAt: '2026-07-18T10:07:00Z', author: {login: 'dependabot', __typename: 'Bot'}}
+        ],
+        timeline    : [
+            {id: 'CE_1', __typename: 'ClosedEvent',   createdAt: '2026-07-18T11:00:00Z', actor: {login: 'maintainer', __typename: 'User'}},
+            {id: 'RE_1', __typename: 'ReopenedEvent', createdAt: '2026-07-18T11:30:00Z', actor: {login: 'maintainer', __typename: 'User'}},
+            {id: 'LE_1', __typename: 'LabeledEvent',  createdAt: '2026-07-18T11:31:00Z', actor: {login: 'maintainer', __typename: 'User'}}
+        ]
+    };
+
+    const batchAround = observations => ({
+        schemaVersion             : BATCH_SCHEMA_VERSION,
+        sourceInstanceId          : 'src-1',
+        resourceFamily            : 'issues',
+        adapterSchemaVersion      : 'github-issue.v1',
+        providerStateSchemaVersion: 'gh-state.v1',
+        registrationEpoch         : 2,
+        baseCheckpointVersion     : 0,
+        baseInventoryHash         : null,
+        batchId                   : 'batch-1',
+        observations,
+        nextProviderState         : {cursor: 'x'},
+        nextInventoryHash         : 'inv-1',
+        coverage                  : {fromBasis: 'c1', toBasis: 'c9', complete: true}
+    });
+
+    // ------------------------------------------------------------------ actor kind axis
+
+    test('actor kind is read from the provider typename; absent/unknown fails closed', () => {
+        expect(actorKindFromTypename('User')).toBe('user');
+        expect(actorKindFromTypename('Bot')).toBe('bot');
+        expect(actorKindFromTypename('Organization')).toBe('organization');
+        expect(actorKindFromTypename('Mannequin')).toBe('mannequin');
+        expect(actorKindFromTypename('EnterpriseUserAccount')).toBe('enterprise-user');
+        expect(actorKindFromTypename(undefined), 'a deleted/ghost actor').toBe('unknown');
+        expect(actorKindFromTypename('SomethingNew'), 'an unrecognized kind').toBe('unknown')
+    });
+
+    // ------------------------------------------------------------------ the emitted shape is admissible
+
+    test('a fully-populated issue yields observations that form a VALID v1 batch', () => {
+        const observations = issueToObservations(fullIssue);
+
+        expect(validateBatch(batchAround(observations))).toEqual({valid: true, errors: []})
+    });
+
+    test('the root, an edit, comments, comment-edit, and whitelisted events each become a distinct occurrence', () => {
+        const kinds = issueToObservations(fullIssue).map(o => o.occurrenceKind);
+
+        expect(kinds).toEqual([
+            'issue.opened', 'issue.edited',
+            'issue.comment', 'issue.comment', 'issue.comment-edited',
+            'issue.closed', 'issue.reopened', 'issue.labeled'
+        ])
+    });
+
+    // ------------------------------------------------------------------ stable, revision-distinct identity
+
+    test('a revision is coordinate-distinct from the create, and identity is stable across re-runs', () => {
+        const first  = issueToObservations(fullIssue),
+              second = issueToObservations(fullIssue),
+              open   = first.find(o => o.occurrenceKind === 'issue.opened'),
+              edit   = first.find(o => o.occurrenceKind === 'issue.edited');
+
+        expect(occurrenceIdentity('src-1', open), 'edit is not the open')
+            .not.toBe(occurrenceIdentity('src-1', edit));
+        // Re-reconciling the same node reproduces byte-identical identity for every occurrence.
+        expect(second.map(o => occurrenceIdentity('src-1', o)))
+            .toEqual(first.map(o => occurrenceIdentity('src-1', o)))
+    });
+
+    // ------------------------------------------------------------------ refusal by construction
+
+    test('an unmapped timeline event (popularity or any unknown kind) produces no observation', () => {
+        const withNoise = {
+            ...fullIssue,
+            timeline: [
+                {id: 'X_1', __typename: 'StarredEvent',    createdAt: '2026-07-18T12:00:00Z', actor: {login: 'fan', __typename: 'User'}},
+                {id: 'X_2', __typename: 'MentionedEvent',  createdAt: '2026-07-18T12:01:00Z', actor: {login: 'fan', __typename: 'User'}}
+            ]
+        };
+
+        const kinds = issueToObservations(withNoise).map(o => o.occurrenceKind);
+
+        expect(kinds).not.toContain('issue.starred');
+        expect(kinds.filter(k => k.startsWith('issue.'))).toEqual(['issue.opened', 'issue.edited', 'issue.comment', 'issue.comment', 'issue.comment-edited'])
+    });
+
+    test('a deleted author on the root fails closed to unknown, actorId null', () => {
+        const [root] = issueToObservations({id: 'I_ghost', createdAt: '2020-01-01T00:00:00Z', author: null});
+
+        expect(root.actorKind).toBe('unknown');
+        expect(root.actorId).toBe(null)
+    });
+
+    // ------------------------------------------------------------------ identity is mandatory (fail loud)
+
+    test('a node or comment or event without a provider id is refused', () => {
+        expect(() => issueToObservations(null)).toThrow('ISSUE_OBSERVATIONS_REQUIRE_NODE_ID');
+        expect(() => issueToObservations({id: 'I', createdAt: 't', comments: [{createdAt: 't'}]})).toThrow('ISSUE_OBSERVATIONS_REQUIRE_COMMENT_ID');
+        expect(() => issueToObservations({id: 'I', createdAt: 't', timeline: [{__typename: 'ClosedEvent', createdAt: 't'}]})).toThrow('ISSUE_OBSERVATIONS_REQUIRE_EVENT_ID')
+    });
+});

--- a/test/playwright/unit/ai/services/github-workflow/community/githubIssueReconciliation.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/community/githubIssueReconciliation.spec.mjs
@@ -1,0 +1,132 @@
+import {setup} from '../../../../../setup.mjs';
+
+const appName = 'GithubIssueReconciliationTest';
+
+setup({
+    neoConfig: {
+        unitTestMode: true
+    },
+    appConfig: {
+        name             : appName,
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect}           from '@playwright/test';
+import Neo                      from '../../../../../../../src/Neo.mjs';
+import * as core                from '../../../../../../../src/core/_export.mjs';
+import {reconcileIssueActivity} from '../../../../../../../ai/services/github-workflow/community/githubIssueReconciliation.mjs';
+
+/**
+ * @summary Witnesses that the issue-reconciliation runner exhausts all three pagination axes
+ * (issues, per-issue comments, per-issue timeline) behind injected seams, enumerates every
+ * issue state without filtering, and reports coverage honestly — a page cap always surfaces as
+ * incomplete-with-gap, never a silent truncation.
+ */
+test.describe('reconcileIssueActivity runner', () => {
+    const comment = id => ({id, createdAt: '2026-01-01T09:00:00Z', author: {login: 'commenter', __typename: 'User'}}),
+          event   = (id, typename) => ({id, __typename: typename, createdAt: '2026-01-01T10:00:00Z', actor: {login: 'maintainer', __typename: 'User'}});
+
+    const issues = [
+        {
+            id         : 'I_a', createdAt: '2026-01-01T00:00:00Z', author: {login: 'u1', __typename: 'User'},
+            allComments: [comment('IC_a1'), comment('IC_a2'), comment('IC_a3'), comment('IC_a4'), comment('IC_a5')],
+            allTimeline: [event('CE_a1', 'ClosedEvent'), event('RE_a1', 'ReopenedEvent'), event('LE_a1', 'LabeledEvent'), event('CE_a2', 'ClosedEvent')]
+        },
+        {
+            id         : 'I_b', createdAt: '2026-01-02T00:00:00Z', author: {login: 'u2', __typename: 'User'},
+            allComments: [comment('IC_b1')],
+            allTimeline: [event('CE_b1', 'ClosedEvent')]
+        },
+        {
+            id         : 'I_c', createdAt: '2026-01-03T00:00:00Z', author: null, // a deleted account — still enumerated
+            allComments: [],
+            allTimeline: []
+        }
+    ];
+
+    // An in-memory paginated source: the first page arrives inline on the node, the overflow is
+    // continuation-fetched from the same cursor space, so the runner must walk every page to see all.
+    const buildSeams = ({issuePageSize, commentPageSize, timelinePageSize}) => {
+        const inline = (items, size) => ({nodes: items.slice(0, size), pageInfo: {hasNextPage: items.length > size, endCursor: String(size)}}),
+              pageOf = (items, size, cursor) => {
+                  const start = Number(cursor), next = start + size;
+                  return {slice: items.slice(start, next), pageInfo: {hasNextPage: next < items.length, endCursor: String(next)}}
+              },
+              byId   = new Map(issues.map(i => [i.id, i]));
+
+        return {
+            fetchIssuesPage: async ({cursor}) => {
+                const {slice, pageInfo} = pageOf(issues, issuePageSize, cursor ?? 0);
+
+                return {
+                    issues: slice.map(i => ({
+                        id      : i.id, createdAt: i.createdAt, author: i.author,
+                        comments: inline(i.allComments, commentPageSize),
+                        timeline: inline(i.allTimeline, timelinePageSize)
+                    })),
+                    pageInfo
+                }
+            },
+            fetchCommentsPage: async ({issueId, cursor}) => {
+                const {slice, pageInfo} = pageOf(byId.get(issueId).allComments, commentPageSize, cursor);
+                return {comments: slice, pageInfo}
+            },
+            fetchTimelinePage: async ({issueId, cursor}) => {
+                const {slice, pageInfo} = pageOf(byId.get(issueId).allTimeline, timelinePageSize, cursor);
+                return {events: slice, pageInfo}
+            }
+        }
+    };
+
+    const kindCount = (observations, kind) => observations.filter(o => o.occurrenceKind === kind).length;
+
+    // ------------------------------------------------------------------ full exhaustion across all axes
+
+    test('walks every issue, every comment page, and every timeline page to exhaustion', async () => {
+        const {observations, coverage} = await reconcileIssueActivity(buildSeams({issuePageSize: 2, commentPageSize: 2, timelinePageSize: 2}));
+
+        expect(kindCount(observations, 'issue.opened'), 'one root per issue, no state filtered').toBe(3);
+        expect(kindCount(observations, 'issue.comment'), 'all 6 comments across 3 comment-pages of I_a').toBe(6);
+        expect(kindCount(observations, 'issue.closed'), 'timeline overflow of I_a fully walked').toBe(3);
+        expect(coverage.complete).toBe(true);
+        expect(coverage.gaps).toBeUndefined()
+    });
+
+    test('a deleted-author issue is still enumerated, its root actor fails closed to unknown', async () => {
+        const {observations} = await reconcileIssueActivity(buildSeams({issuePageSize: 5, commentPageSize: 5, timelinePageSize: 5})),
+              ghostRoot      = observations.find(o => o.providerEntityId === 'I_c');
+
+        expect(ghostRoot.occurrenceKind).toBe('issue.opened');
+        expect(ghostRoot.actorKind).toBe('unknown')
+    });
+
+    // ------------------------------------------------------------------ honest coverage under caps
+
+    test('a per-issue comment cap surfaces as incomplete WITH an explicit gap, not silent truncation', async () => {
+        const {observations, coverage} = await reconcileIssueActivity(
+            buildSeams({issuePageSize: 5, commentPageSize: 2, timelinePageSize: 5}),
+            {maxCommentPagesPerIssue: 1}
+        );
+
+        expect(kindCount(observations, 'issue.comment'), 'I_a truncated to its first comment page (2), plus I_b (1)').toBe(3);
+        expect(coverage.complete).toBe(false);
+        expect(coverage.gaps).toEqual(expect.arrayContaining([{axis: 'comments', issueId: 'I_a'}]))
+    });
+
+    test('an issue-list cap drops later pages and is recorded as an issues-axis gap', async () => {
+        const {observations, coverage} = await reconcileIssueActivity(
+            buildSeams({issuePageSize: 2, commentPageSize: 5, timelinePageSize: 5}),
+            {maxIssuePages: 1}
+        );
+
+        expect(kindCount(observations, 'issue.opened'), 'only the first issue page [I_a, I_b]').toBe(2);
+        expect(coverage.complete).toBe(false);
+        expect(coverage.gaps.some(g => g.axis === 'issues')).toBe(true)
+    });
+
+    test('missing fetch seams fail loud', async () => {
+        await expect(reconcileIssueActivity({fetchIssuesPage: async () => ({})})).rejects.toThrow('ISSUE_RECONCILIATION_REQUIRES_FETCH_SEAMS')
+    });
+});


### PR DESCRIPTION
Resolves #15152

Delivers the exhaustive GitHub issue-activity reconciliation leaf: a producer that walks every open and closed issue — and each issue's comments and timeline as two independent axes — to true exhaustion, normalizes them into metadata-only `community-activity-batch.v1` observations, diffs the prior inventory to separate evidenced deletions from access loss, and admits one batch into the merged Memory Core admission path. The shared normalized runner and the source-relative actor/trust foundation are earned here for the later PR and Discussion leaves. Six pure modules plus one orchestration service, every acquisition dependency injected so the whole path is witnessed without live GitHub or a real database.

Evidence: L3 achieved (36 sandbox unit + service-with-fakes witnesses; all 12 ACs covered by the repaired production path, five invariants RED-verified by defeating each guard — no-prose, no-silent-truncation, permission-loss≠deletion, snapshot-only-when-unexplained, and the RA1 resume-skip) → L4 required (a live-GitHub exhaustive walk + real-SQLite admission persistence) for AC1 exhaustion and AC8 receipt-gated advance against real infrastructure. Residual: no blocking sandbox residual; the live-provider and durable-DB paths are Post-Merge Validation.

## Deltas from ticket
- The reconciliation query is deliberately NOT the sync query: `FETCH_ISSUES_FOR_SYNC` fetches neither the node `id` nor `author.__typename`, both required for AC3 stable identity and AC6 actor kind, so a dedicated reconciliation query was added.
- Comments and timeline are two independent connection axes — comments own their connection; `timelineItems` excludes `ISSUE_COMMENT` — so a comment is never double-counted under two coordinates for one node (the admission dedup is (identity,digest)-keyed).
- Source-relative trust consumes the provider `authorAssociation` (the same signal the shadow reader already carries) rather than a third trust engine.
- Attention disposition is deferred to the shipped `communityAttentionClassifier` at admission (one classifier, three producers): the adapter emits `occurrenceKind` + `actorKind` + `sourceAssociation` only (AC11/AC12). The arc owner is the requested reviewer for that shape.
- Cross-family review convergence (Euclid RA1–RA4): the checkpoint no longer seeds a resume cursor — each pass RE-ENUMERATES every root so a comment/edit on a known root is caught (RA1, the ticket's Avoided Trap); edits emit actor `null` + an `editor-unattributed` loss marker instead of the original author (RA2); an injected `acquireDeletionEvidence` seam wires deletion evidence into the production path so `issue.deleted` is reachable (RA3). The prior "repeated cursors" fixture was vacuous (fresh service twice, never consuming a checkpoint) → replaced with a stateful two-pass witness against a cursor-honoring fake, RED-verified.

## Test Evidence
`UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/github-workflow/` → 36 passed.
- `githubIssueObservations`: 12 — actor kind, source-association orthogonality, no-prose (RED-verified), no-double-count, snapshot-change marker (AC4), edit-unattributed (RA2).
- `githubIssueReconciliation`: 5 — three-axis exhaustion, honest coverage, no-silent-truncation (RED-verified).
- `githubIssueAbsence`: 6 — permission-loss ≠ deletion (RED-verified).
- `assembleIssueBatch`: 4 — valid v1 envelope, access-loss degrades coverage.
- `IssueReconciliationService`: 9 — end-to-end valid batch, trust flow, CONFLICT-not-thrown, deterministic assembly, RA1 mutation-safe two-pass (RED-verified), RA3 delete-evidence seam, collaborator / access-loss.

github-workflow app surface: no existing non-CI journey touches these new files (new subsystem); `None found` for pre-existing coverage.

## Post-Merge Validation
- [ ] A live reconciliation run against a registered ACTIVE source exhausts real open and closed issues and admits a durable receipt (AC1 / AC8 against real GitHub + SQLite).
- [ ] Two concurrent runs against the same base yield one ACCEPTED and one IDEMPOTENT/CONFLICT through the real admission CAS (AC9 concurrent mutation, real DB).
- [ ] A genuinely deleted issue carrying provider tombstone evidence admits an `issue.deleted` observation end to end (AC5, real provider).

## Commits
- 1198eba8c5 — issue → v1 observation normalizer
- df4d7790be — three-axis exhaustive runner + comments-axis refinement
- df09b3a431 — absence classification (permission-loss ≠ deletion)
- 72ca699a32 — source-relative trust field
- b9d2458972 — pure v1 batch assembler
- 649cfe84ac — end-to-end service + reconciliation query + coverage fix
- c4a72b9f20 — snapshot-change marker (AC4) + AC9 fixtures
- a77909a96a — RC convergence: mutation-safe re-enumeration (RA1) + unattributed edits (RA2) + wired deletion evidence (RA3)

Related: #15145

Authored by Ada (Claude Opus 4.8, Claude Code). Session 3e5f61a5-35d0-4f3d-8805-54f63bebed70.
