### PR TITLE
fix(agentos): harden fleet start batch integrity (#15028)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -194,7 +194,7 @@ class FleetCockpit extends Container {
         baseCls: ['fm-fleet-cockpit'],
         /**
          * The B4÷C2 composition root: catches each card's `lifecycleIntent` and the whole-fleet
-         * "▶ Start morning fleet" click, driving both through the C2 adapter to honest per-card
+         * "▶ Start fleet" click, driving both through the C2 adapter to honest per-card
          * round-trip state. See {@link AgentOS.view.fleet.FleetCockpitController}.
          * @member {Neo.controller.Component} controller=FleetCockpitController
          */
@@ -1268,10 +1268,10 @@ class FleetCockpit extends Container {
                     reference: 'fusion-tour-button',
                     text     : 'Play tour'
                 }, {
-                    // The morning-start outcome summary — written by the controller after the
-                    // staged bring-up settles ("N started · M rejected · K excluded"; per-member
-                    // reasons ride the title). Empty + hidden until a start ran; hover reaches the
-                    // reasons — the honest summary state, no separate progress modal (the health
+                    // The fleet-start outcome summary — written by the controller after the
+                    // staged bring-up settles ("N started · U UNKNOWN · M rejected · K excluded";
+                    // per-member reasons ride the title). Empty + hidden until a start ran; hover
+                    // reaches the reasons — the honest summary state, no separate progress modal (the health
                     // bar stays the live progression surface).
                     ntype    : 'component',
                     cls      : ['fm-fleet-start-summary'],
@@ -1291,7 +1291,7 @@ class FleetCockpit extends Container {
                     module : Button,
                     cls    : ['fm-fleet-start'],
                     iconCls: 'fa-solid fa-play',
-                    text   : 'Start morning fleet',
+                    text   : 'Start fleet',
                     handler: 'onStartFleet'
                 }
             ]
@@ -2847,7 +2847,7 @@ class FleetCockpit extends Container {
      * becomes `agentId`; identity facts (`family` / `engineTag` / the authoritative
      * `participationStatus`) flow through (null = unclassified / tagless / no identity root,
      * never guessed); the launch-derived truths (`launchable` / `authMode`, stamped Brain-side by
-     * the roster assembler) flow through tri-state so the morning-start eligibility partition
+     * the roster assembler) flow through tri-state so the fleet-start eligibility partition
      * reads the wire, never a cockpit guess; the runtime `lifecycle.state` maps onto the
      * cockpit's session-state vocabulary only when `sources.runtime` is usable; missing /
      * not-wired / malformed source truth forces `off`, so placeholder can never render as fact.

--- a/apps/agentos/view/fleet/FleetCockpitController.mjs
+++ b/apps/agentos/view/fleet/FleetCockpitController.mjs
@@ -12,7 +12,7 @@ import {partitionFleetStart, renderFleetStartSummary, summarizeFleetStart} from 
  * honest per-record round-trip state, never an optimistic success:
  * - `onAgentLifecycleIntent` — catches a single card's `lifecycleIntent` (resolved up the controller
  *   chain via the card's listener) and dispatches it for that card's record.
- * - `onStartFleet` — the design SSOT §01 "▶ Start morning fleet" one-click: fans `start` out to every
+ * - `onStartFleet` — the design SSOT §01 "▶ Start fleet" one-click: fans `start` out to every
  *   rendered card, so each resident drives its own honest round-trip.
  *
  * @class AgentOS.view.fleet.FleetCockpitController
@@ -28,8 +28,32 @@ class FleetCockpitController extends Controller {
     }
 
     /**
-     * @summary The one-click morning start — the STAGED fleet bring-up: partition, cascade,
-     * honest summary.
+     * The active fleet-start batch. Repeated activations join this Promise until its summary and
+     * one roster reconciliation have settled, so a partially completed batch can never re-fan-out
+     * already-settled members or race a second summary.
+     * @member {Promise<Object>|null} startFleetPromise=null
+     * @protected
+     */
+    startFleetPromise = null
+
+    /**
+     * @summary Join the active one-click fleet-start batch, or create exactly one new batch.
+     * @returns {Promise<Object>} The one authoritative batch outcome summary.
+     */
+    onStartFleet() {
+        const me = this;
+
+        if (!me.startFleetPromise) {
+            me.startFleetPromise = me.executeStartFleetBatch().finally(() => {
+                me.startFleetPromise = null
+            })
+        }
+
+        return me.startFleetPromise
+    }
+
+    /**
+     * @summary Execute the STAGED fleet bring-up: partition, per-card cascade, honest summary.
      *
      * The cockpit owns the wire (the cards stay intent-only). The action reads the roster STORE
      * (the full fleet truth — a folded idle card is still a member) and partitions it through the
@@ -41,13 +65,14 @@ class FleetCockpitController extends Controller {
      * pending; there is no fleet-wide spinner to lie N ways at once).
      *
      * After the cascade settles, the outcome summary renders into the chrome
-     * (`fleet-start-summary`): started / rejected / excluded counts with per-member reasons
+     * (`fleet-start-summary`): started / UNKNOWN / rejected / excluded counts with per-member reasons
      * reachable from it — and the roster is re-polled ONCE so every resident that actually
      * started advances to live runtime truth ({@link #refreshRosterOnSettle}).
      * @returns {Promise<Object>} The outcome summary (see `summarizeFleetStart`) — for tests and
      *     callers; the chrome render is the operator-facing half.
+     * @protected
      */
-    async onStartFleet() {
+    async executeStartFleetBatch() {
         const
             me      = this,
             records = me.getRosterRecords(),
@@ -70,18 +95,19 @@ class FleetCockpitController extends Controller {
 
     /**
      * @summary The full roster truth for fleet-level actions: the grid store's records — a folded
-     * idle card is still a fleet member — with the rendered-cards fallback for compositions that
-     * mount the controller without the grid reference.
+     * idle card is still a fleet member. A present Store is authoritative even when empty; the
+     * rendered-cards fallback is only for compositions that mount the controller without the grid
+     * Store reference.
      * @returns {Object[]}
      */
     getRosterRecords() {
-        const storeItems = this.getReference('fleet-grid')?.store?.items;
+        const store = this.getReference('fleet-grid')?.store;
 
-        return storeItems?.length ? [...storeItems] : this.getAgentCards().map(card => card.record).filter(Boolean)
+        return store ? [...(store.items ?? [])] : this.getAgentCards().map(card => card.record).filter(Boolean)
     }
 
     /**
-     * @summary Write the morning-start outcome into the chrome summary slot: the compact counts
+     * @summary Write the fleet-start outcome into the chrome summary slot: the compact counts
      * line as the element text, the per-member reasons as its title (hover-reachable), hidden
      * again when cleared (`null` — a new run starts with no stale outcome showing).
      * @param {Object|null} summary From `summarizeFleetStart`, or null to clear.

--- a/apps/agentos/view/fleet/fleetStartPlan.mjs
+++ b/apps/agentos/view/fleet/fleetStartPlan.mjs
@@ -1,5 +1,5 @@
 /**
- * @summary Pure planning + summary helpers for the fleet-level morning start — the SSOT chrome's
+ * @summary Pure planning + summary helpers for the fleet-level start — the SSOT chrome's
  * one-click bring-up: partition the roster records into START-eligible members vs
  * excluded-with-reason, and fold the per-record round-trip results into the honest outcome
  * summary the operator can trust at a glance.
@@ -9,8 +9,9 @@
  * round-trips — the per-card pending CASCADE — never one optimistic fleet-wide spinner. Every
  * eligibility rule below reads WIRE truth already on the record (`agentId` presence, the
  * authoritative identity-root `participationStatus`, the launch-seam `launchable` stamp, the C2
- * `pendingAction` seam, the normalized `sources.runtime` provenance, the runtime-derived session
- * `state`) — nothing is hardcoded per agent, and an excluded member always carries its reason:
+ * `pendingAction` seam, the timeout-bearing `controlReason`, the normalized `sources.runtime`
+ * provenance, the runtime-derived session `state`) — nothing is hardcoded per agent, and an
+ * excluded member always carries its reason:
  * excluded-with-reason, never silently skipped.
  *
  * The two AUTHORITY rules gate before any state read: a KNOWN non-active `participationStatus`
@@ -43,8 +44,10 @@ import {normalizeFleetSources} from './sourceHealth.mjs';
  *    guarantees a `wired` fact carries `observed`/`inferred` confidence, never `none`) → fail
  *    closed: the projected `state: 'off'` below is a degraded DISPLAY fallback in this case, not
  *    evidence of a stopped runtime — the same gate that disables the per-card controls;
- * 6. session `state` other than `off` → the resident is already up (ok / idle / wedged / limited
- *    are all live states) — a morning start targets the DOWN fleet (a WIRED stopped record —
+ * 6. a prior lifecycle `timeout` → the outcome is still UNKNOWN because the bridge Promise was
+ *    raced, not cancelled; fleet-level retry stays closed until an explicit card action clears it;
+ * 7. session `state` other than `off` → the resident is already up (ok / idle / wedged / limited
+ *    are all live states) — a fleet start targets the DOWN fleet (a WIRED stopped record —
  *    `observed` or `inferred` — is exactly that fleet).
  * @param {Object[]} records FleetAgent records (or plain field bags in tests).
  * @returns {{eligible: Object[], excluded: Object[]}} `excluded` entries are
@@ -73,6 +76,8 @@ export function partitionFleetStart(records) {
             exclude(`'${record.pendingAction}' round-trip already in flight`)
         } else if (runtime.state !== 'wired') {
             exclude(`runtime source '${runtime.state}' — no usable lifecycle evidence to start against`)
+        } else if (record.controlReason?.kind === 'timeout') {
+            exclude(`'${record.controlReason.action ?? 'lifecycle'}' outcome unknown after timeout — retry only through an explicit card control`)
         } else if ((record.state ?? 'off') !== 'off') {
             exclude(`already up — session state '${record.state}'`)
         } else {
@@ -85,19 +90,21 @@ export function partitionFleetStart(records) {
 
 /**
  * @summary Fold the partition + the per-record C2 adapter results into the honest outcome
- * summary: started / rejected-with-reasons / excluded-with-reasons, in the roster's own order.
+ * summary: started / UNKNOWN-with-reasons / rejected-with-reasons / excluded-with-reasons, in
+ * each bucket's roster order.
  * A non-`ok` result keeps its terminal kind visible (`rejected` / `timeout` / `unauthorized` —
- * the adapter's settle-or-reject vocabulary), because a timeout is an UNKNOWN outcome, not a
+ * the adapter's terminal vocabulary), because a timeout is an UNKNOWN outcome, not a
  * failure the operator may silently retry.
  * @param {{eligible: Object[], excluded: Object[]}} partition From {@link partitionFleetStart}.
  * @param {Object[]} results Per-eligible-record results from `handleFleetLifecycleIntent`, index-aligned.
- * @returns {{started: Number, rejected: Object[], excluded: Object[], attempted: Number, total: Number}}
- * `rejected` / `excluded` entries are `{agentId, reason}` pairs in roster order.
+ * @returns {{started: Number, unknown: Object[], rejected: Object[], excluded: Object[], attempted: Number, total: Number}}
+ * `unknown` / `rejected` / `excluded` entries are `{agentId, reason}` pairs in roster order.
  */
 export function summarizeFleetStart(partition, results) {
     const
         {eligible, excluded} = partition,
-        rejected             = [];
+        rejected             = [],
+        unknown              = [];
 
     let started = 0;
 
@@ -111,7 +118,9 @@ export function summarizeFleetStart(partition, results) {
                 kind   = result?.status ?? 'rejected',
                 reason = result?.controlReason?.reason ?? `start ${kind}`;
 
-            rejected.push({agentId: record.agentId, reason: kind === 'rejected' ? reason : `${kind}: ${reason}`})
+            const entry = {agentId: record.agentId, reason: kind === 'rejected' ? reason : `${kind}: ${reason}`};
+
+            (kind === 'timeout' ? unknown : rejected).push(entry)
         }
     });
 
@@ -120,15 +129,17 @@ export function summarizeFleetStart(partition, results) {
         excluded : excluded.map(({agentId, reason}) => ({agentId, reason})),
         rejected,
         started,
-        total    : eligible.length + excluded.length
+        total    : eligible.length + excluded.length,
+        unknown
     }
 }
 
 /**
  * @summary Render the summary as the compact chrome line + the reachable per-member reasons.
- * Pure string building: `text` is the at-a-glance state ("3 started · 1 rejected · 2 excluded");
- * `detail` lists every rejected/excluded member with its reason, one per line — the "reasons
- * reachable from the summary" contract, carried as the summary element's title.
+ * Pure string building: `text` is the at-a-glance state
+ * ("3 started · 1 UNKNOWN · 1 rejected · 2 excluded"); `detail` lists every
+ * unknown/rejected/excluded member with its reason, one per line — the "reasons reachable from
+ * the summary" contract, carried as the summary element's title.
  * @param {Object} summary From {@link summarizeFleetStart}.
  * @returns {{text: String, detail: String}}
  */
@@ -137,9 +148,11 @@ export function renderFleetStartSummary(summary) {
         parts  = [`${summary.started} started`],
         detail = [];
 
+    summary.unknown.length  && parts.push(`${summary.unknown.length} UNKNOWN`);
     summary.rejected.length && parts.push(`${summary.rejected.length} rejected`);
     summary.excluded.length && parts.push(`${summary.excluded.length} excluded`);
 
+    summary.unknown.forEach(({agentId, reason}) => detail.push(`${agentId}: ${reason}`));
     summary.rejected.forEach(({agentId, reason}) => detail.push(`${agentId}: ${reason}`));
     summary.excluded.forEach(({agentId, reason}) => detail.push(`${agentId ?? '(guest)'}: ${reason}`));
 

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -746,7 +746,7 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
     });
 
     test('onStartFleet fans out start to every resident card via the C2 adapter (fold skipped; no bridge → fail-closed per card, never optimistic)', () => {
-        // The morning-start button drives the round-trip directly (the cockpit owns the wire): it
+        // The fleet-start button drives the round-trip directly (the cockpit owns the wire): it
         // enumerates the rendered cards — the collapsed-idle fold is filtered by ntype — and dispatches a
         // start intent + each card's roster record to the adapter. No bridge → each card takes an honest
         // `unauthorized` controlReason onto its record, never an optimistic fleet-wide success.
@@ -770,6 +770,118 @@ test.describe('Fleet cockpit — whole-fleet control (B4, #14611)', () => {
 
         expect(vega.writes.some(write => write.controlReason?.kind === 'unauthorized')).toBe(true);
         expect(ada.writes.some(write => write.controlReason?.kind === 'unauthorized')).toBe(true)
+    });
+
+    test('getRosterRecords treats a present empty Store as authoritative and falls back to cards only when the Store composition is absent', () => {
+        const
+            staleCard  = {ntype: 'fm-agent-card', record: {agentId: 'stale'}},
+            controller = Object.create(FleetCockpitController.prototype);
+
+        controller.getReference = name => ({
+            'fleet-cards': {items: [staleCard]},
+            'fleet-grid' : {store: {items: []}}
+        })[name] ?? null;
+
+        expect(controller.getRosterRecords()).toEqual([]);
+
+        controller.getReference = name => ({
+            'fleet-cards': {items: [staleCard]},
+            'fleet-grid' : {store: {}}
+        })[name] ?? null;
+
+        expect(controller.getRosterRecords()).toEqual([]);
+
+        controller.getReference = name => name === 'fleet-cards' ? {items: [staleCard]} : null;
+
+        expect(controller.getRosterRecords()).toEqual([staleCard.record])
+    });
+
+    test('overlapping fleet activations join one active batch: one bridge call per member and one authoritative summary', async () => {
+        const
+            calls    = [],
+            releases = new Map(),
+            records  = ['ada', 'euclid'].map(agentId => ({
+                agentId,
+                controlReason: null,
+                pendingAction: null,
+                sources      : wiredSources(),
+                state        : 'off',
+                set(values) { Object.assign(this, values) }
+            })),
+            summaries  = [],
+            controller = Object.create(FleetCockpitController.prototype);
+
+        (globalThis.AgentOS ??= {}).fleet = {
+            registryBridge: {
+                startAgent(agentId) {
+                    calls.push(agentId);
+                    return new Promise(resolve => releases.set(agentId, resolve))
+                }
+            }
+        };
+
+        controller.getReference          = name => name === 'fleet-grid' ? {store: {items: records}} : null;
+        controller.refreshRosterOnSettle = settledOk => settledOk;
+        controller.renderStartSummary    = summary => summaries.push(summary);
+
+        try {
+            const
+                first  = controller.onStartFleet(),
+                second = controller.onStartFleet();
+
+            expect(second).toBe(first);
+
+            await Promise.resolve();
+            await Promise.resolve();
+
+            expect(calls).toEqual(['ada', 'euclid']);
+
+            releases.get('ada')({state: 'running'});
+            await Promise.resolve();
+            await Promise.resolve();
+
+            const third = controller.onStartFleet();
+
+            expect(third).toBe(first);
+            expect(calls).toEqual(['ada', 'euclid']);
+
+            releases.get('euclid')({state: 'running'});
+            await first;
+
+            expect(summaries.filter(Boolean)).toHaveLength(1);
+            expect(summaries.filter(Boolean)[0].started).toBe(2);
+            expect(controller.startFleetPromise).toBeNull()
+        } finally {
+            delete globalThis.AgentOS?.fleet
+        }
+    });
+
+    test('the next fleet activation excludes a timeout-bearing member instead of silently retrying an unknown operation', async () => {
+        const
+            calls  = [],
+            record = {
+                agentId      : 'euclid',
+                controlReason: {action: 'start', kind: 'timeout', reason: 'start timed out after 30000ms'},
+                sources      : wiredSources(),
+                state        : 'off'
+            },
+            controller = Object.create(FleetCockpitController.prototype);
+
+        (globalThis.AgentOS ??= {}).fleet = {registryBridge: {startAgent: agentId => calls.push(agentId)}};
+        controller.getReference          = name => name === 'fleet-grid' ? {store: {items: [record]}} : null;
+        controller.refreshRosterOnSettle = settledOk => settledOk;
+        controller.renderStartSummary    = () => {};
+
+        try {
+            const summary = await controller.onStartFleet();
+
+            expect(calls).toEqual([]);
+            expect(summary.attempted).toBe(0);
+            expect(summary.excluded).toHaveLength(1);
+            expect(summary.excluded[0].reason).toContain('outcome unknown')
+        } finally {
+            delete globalThis.AgentOS?.fleet
+        }
     });
 
     test('onStartFleet partitions from the wire: excluded members never flip pending, and the summary renders their reasons (#14612)', async () => {
@@ -1045,7 +1157,7 @@ test.describe('Fleet cockpit — controller re-polls the roster on a settled lif
         });
 
         // a REAL store the REAL loadRoster reconciles into — the record is the card's data surface
-        const store   = Neo.create(Store, {keyProperty: 'agentId', model: FleetAgent});
+        const store = Neo.create(Store, {keyProperty: 'agentId', model: FleetAgent});
         // `gridReadGeneration` mirrors the class default because the async-ingress fence reads it: a
         // fake omitting it makes `++undefined` NaN, so the read's generation never matches the
         // owner's and EVERY read silently drops itself — a green suite over state nobody wrote.

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetStartPlan.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetStartPlan.spec.mjs
@@ -14,13 +14,15 @@ setup({
 });
 
 import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
 
 import {partitionFleetStart, renderFleetStartSummary, summarizeFleetStart} from '../../../../../../../apps/agentos/view/fleet/fleetStartPlan.mjs';
 
 /**
- * @summary Tests for the morning-start plan helpers — the pure half of the fleet-level
+ * @summary Tests for the fleet-start plan helpers — the pure half of the fleet-level
  * bring-up: wire-derived eligibility partition (excluded-with-reason, never silently
- * skipped) and the honest outcome summary (started / rejected-with-reasons / excluded).
+ * skipped) and the honest outcome summary (started / unknown / rejected / excluded).
  */
 
 /** A usable three-source collection: the runtime axis is WIRED with real confidence. */
@@ -30,7 +32,7 @@ const wiredRuntime = (confidence = 'observed') => ({
     runtime   : {source: 'fleet:runtimeStatus', state: 'wired', confidence}
 });
 
-test.describe('fleetStartPlan — the staged morning bring-up (pure half)', () => {
+test.describe('fleetStartPlan — the staged fleet bring-up (pure half)', () => {
 
     test('partition: every exclusion is wire-derived and carries its reason; the down fleet is what starts', () => {
         const records = [
@@ -122,9 +124,32 @@ test.describe('fleetStartPlan — the staged morning bring-up (pure half)', () =
         }));
         expect(eligible).toHaveLength(0);
 
-        // the preserve side: genuinely WIRED stopped records are the morning start's exact target
+        // the preserve side: genuinely WIRED stopped records are the fleet start's exact target
         expect(partitionOne({agentId: 'observed-down', state: 'off', sources: wiredRuntime('observed')}).eligible).toHaveLength(1);
         expect(partitionOne({agentId: 'inferred-down', state: 'off', sources: wiredRuntime('inferred')}).eligible).toHaveLength(1)
+    });
+
+    test('unknown timeout state is not silently retried by a later fleet activation; explicit non-timeout failures remain eligible', () => {
+        const {eligible, excluded} = partitionFleetStart([
+            {
+                agentId      : 'euclid',
+                controlReason: {action: 'start', kind: 'timeout', reason: 'start timed out after 30000ms'},
+                sources      : wiredRuntime(),
+                state        : 'off'
+            },
+            {
+                agentId      : 'ada',
+                controlReason: {action: 'start', kind: 'rejected', reason: 'harness offline'},
+                sources      : wiredRuntime(),
+                state        : 'off'
+            }
+        ]);
+
+        expect(eligible.map(record => record.agentId)).toEqual(['ada']);
+        expect(excluded).toHaveLength(1);
+        expect(excluded[0].agentId).toBe('euclid');
+        expect(excluded[0].reason).toContain('outcome unknown');
+        expect(excluded[0].reason).toContain('explicit card control')
     });
 
     test('mixed settle/reject: the summary counts honestly and keeps every terminal kind visible', () => {
@@ -145,9 +170,8 @@ test.describe('fleetStartPlan — the staged morning bring-up (pure half)', () =
         expect(summary.started).toBe(1);
         expect(summary.attempted).toBe(3);
         expect(summary.total).toBe(4);
-        expect(summary.rejected).toEqual([
-            {agentId: 'ada',    reason: 'missing credential'},
-            // a timeout is an UNKNOWN outcome — the kind stays visible, never folded into a plain reject
+        expect(summary.rejected).toEqual([{agentId: 'ada', reason: 'missing credential'}]);
+        expect(summary.unknown).toEqual([
             {agentId: 'euclid', reason: 'timeout: start timed out after 30000ms'}
         ]);
         expect(summary.excluded).toEqual([{agentId: 'up', reason: "already up — session state 'ok'"}])
@@ -166,6 +190,7 @@ test.describe('fleetStartPlan — the staged morning bring-up (pure half)', () =
 
         expect(summary.started).toBe(0);
         expect(summary.rejected).toHaveLength(2);
+        expect(summary.unknown).toHaveLength(0);
         expect(summary.rejected[0].reason).toContain('unauthorized:')
     });
 
@@ -175,15 +200,17 @@ test.describe('fleetStartPlan — the staged morning bring-up (pure half)', () =
             excluded : [{agentId: null, reason: 'guest — no fleet definition to start'}],
             rejected : [{agentId: 'ada', reason: 'missing credential'}],
             started  : 2,
-            total    : 4
+            total    : 5,
+            unknown  : [{agentId: 'euclid', reason: 'timeout: start timed out after 30000ms'}]
         });
 
-        expect(text).toBe('2 started · 1 rejected · 1 excluded');
+        expect(text).toBe('2 started · 1 UNKNOWN · 1 rejected · 1 excluded');
+        expect(detail).toContain('euclid: timeout: start timed out after 30000ms');
         expect(detail).toContain('ada: missing credential');
         expect(detail).toContain('(guest): guest — no fleet definition to start');
 
-        // the quiet morning: everything started, nothing to explain
-        const clean = renderFleetStartSummary({attempted: 2, excluded: [], rejected: [], started: 2, total: 2});
+        // the quiet batch: everything started, nothing to explain
+        const clean = renderFleetStartSummary({attempted: 2, excluded: [], rejected: [], started: 2, total: 2, unknown: []});
 
         expect(clean.text).toBe('2 started');
         expect(clean.detail).toBe('')


### PR DESCRIPTION
Resolves #15028

Fleet-wide starts now have one authoritative in-flight batch: overlapping activations join the same Promise, a present empty roster Store remains authoritative, and timed-out lifecycle operations stay visibly UNKNOWN instead of being reported as rejected or silently retried by the next batch. The operator-facing action is the settled, time-neutral `Start fleet` copy.

Evidence: L2 (controller and pure-plan behavior through 115 focused unit witnesses) → L2 required (all close-target ACs are deterministic controller/plan contracts). No residuals.

## Deltas from ticket

The operator-relayed copy fold removes the time-specific "morning" framing from the touched action, documentation, and witnesses without changing the action's semantics. Timeout results receive a distinct UNKNOWN summary bucket so the UI vocabulary matches the underlying uncancelled Promise contract.

## Test Evidence

- Fleet start plan, lifecycle adapter, card, and controller surfaces: `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/fleetStartPlan.spec.mjs test/playwright/unit/apps/agentos/view/fleet/fleetLifecycleIntentAdapter.spec.mjs test/playwright/unit/apps/agentos/view/fleet/agentCard.spec.mjs test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs --workers=1` — 115/115 passed.
- Test-first discrimination: the pre-production run failed seven new falsifiers covering overlapping Promise identity, Store-empty authority, timeout non-retry, UNKNOWN classification, and UNKNOWN rendering; the same 86-test slice passed after the implementation.
- Source gates: `npm run agent-preflight -- <five touched files>` — passed; repaired six alignment-only lines in the controller spec. Final `--no-fix` staged validation is recorded below before push.
- Full unit baseline: 8,614 discovered; 8,435 passed, 118 skipped, 49 did not run, 12 failed. Serial and elevated discrimination cleared ten environment/concurrency failures; the two residual baseline failures are unrelated to this diff: the standalone genesis Bridge exits before binding its test port, and the real-tree lint wrapper exceeds 30 seconds even though the lint completes `OK` across all 219 nodes.

## Post-Merge Validation

- [ ] Smoke the merged Fleet Manager action: it reads `Start fleet`, overlapping activations produce one summary, and a timed-out member remains UNKNOWN until an explicit card control retries it.

Authored by Euclid (GPT-5, Codex Desktop). Session a0518292-02c3-49ee-af08-adff40bc30b1.
