### PR TITLE
fix(harness): classify Genesis probe as checkout-only (#15542)

### DIFF
--- a/harness/pack.mjs
+++ b/harness/pack.mjs
@@ -44,12 +44,14 @@ export const BRAIN_FILES = Object.freeze([
     'buildScripts/util/sanitizer.mjs'
 ]);
 
-// Subtrees inside staged trees that are NOT runtime surface: demo/example apps (their deps are
-// demo deps), and the temporal-summary daemon — not runtime-enabled yet AND carrying a phantom
-// `yaml` import the repo never declares (recorded finding; its enablement ticket owns the fix).
+// Coordinates inside staged trees that are NOT runtime surface. Entries may name a subtree or one
+// exact file: demo/example apps carry demo deps; the temporal-summary daemon is not runtime-enabled;
+// and the Genesis probe is a checkout-only operator command whose browser runtime is supplied by
+// the checkout rather than the double-clickable organism. Runtime diagnostics stay staged.
 export const TREE_EXCLUDES = Object.freeze([
     'ai/examples',
-    'ai/daemons/temporal-summary'
+    'ai/daemons/temporal-summary',
+    'ai/scripts/diagnostics/genesisProbe.mjs'
 ]);
 
 /**

--- a/test/playwright/unit/harness/pack.spec.mjs
+++ b/test/playwright/unit/harness/pack.spec.mjs
@@ -4,6 +4,7 @@ import {mkdirSync, writeFileSync} from 'node:fs';
 import {tmpdir}                   from 'node:os';
 import {
     BRAIN_TREES,
+    TREE_EXCLUDES,
     assertNoInstanceOverlays,
     buildNodeShim,
     buildOrganismManifest,
@@ -31,6 +32,12 @@ test.describe('harness pack stage', () => {
 
         // node_modules-prefixed allowlist entries come from the staged dependency install.
         expect([...trees, ...files].some(entry => entry.includes('node_modules'))).toBe(false)
+    });
+
+    test('the Genesis probe is checkout-only without excluding runtime diagnostics wholesale', () => {
+        expect(TREE_EXCLUDES).toContain('ai/scripts/diagnostics/genesisProbe.mjs');
+        expect(TREE_EXCLUDES).not.toContain('ai/scripts/diagnostics');
+        expect(TREE_EXCLUDES).not.toContain('ai/scripts/diagnostics/mcpHealthcheck.mjs')
     });
 
     test('extractBarePackages keeps package names only — no relative, builtin, alias, or subpath noise', () => {


### PR DESCRIPTION
Resolves #15542

Restores the canonical E6 artifact build without weakening its undeclared-import stop-line. The Genesis Neural Link probe is now an explicit checkout-only coordinate inside the existing staged-tree filter: it remains available through `npm run ai:genesis-probe`, but its checkout-supplied Playwright runtime no longer enters the downloadable organism. Runtime diagnostics remain staged; the focused witness pins `mcpHealthcheck.mjs` as the negative control against a wholesale diagnostics exclusion.

Evidence: L3 (canonical `npm --prefix harness run dist` emitted the unsigned macOS zip; checkout and packaged Brain-off E6 smokes both passed) → L3 required (artifact emission + existing E6 smoke). No residuals.

The default Brain-enabled packaged run reached a healthy UI/asset/shared-heap receipt but remained nonzero on `fleet transport not ready within 15000ms`; #15537 already owns that E5 private Fleet readiness contract and this ticket explicitly excludes it. It is not promoted into E6 evidence here.

## Deltas from ticket

- Chose the checkout-only arm from live source authority: `genesisProbe.mjs` is invoked by the root npm command, its operating guide, and its unit suite; no production module imports it.
- Kept the classification exact-file rather than excluding `ai/scripts/diagnostics/`: the staged census still contains runtime/deployment diagnostics including `mcpHealthcheck.mjs`.
- Preserved `buildOrganismManifest()` unchanged. `playwright` was not added to `OPTIONAL_LAZY_PACKAGES`, and genuinely staged undeclared imports still fail loud.
- The first canonical run exposed a host-only root-owned npm-cache fault; the successful replay used a task-scoped `/private/tmp` npm cache. The artifact inputs and command remained otherwise identical.

## Test Evidence

- RED: `npm run test-unit -- test/playwright/unit/harness/pack.spec.mjs` — 7 passed, the new Genesis product-boundary witness failed on current `dev` because `TREE_EXCLUDES` lacked the exact file.
- GREEN: same focused suite — 8/8 passed.
- `npm run test-unit -- test/playwright/unit/harness/` — 36/36 passed.
- `npm run agent-preflight -- --no-fix harness/pack.mjs test/playwright/unit/harness/pack.spec.mjs` — all requested gates passed; only unrelated stale local config-overlay warnings.
- `git diff --check` — passed.
- `env npm_config_cache=/private/tmp/neo-15542-npm-cache npm --prefix harness run dist` — exit 0; emitted `harness/dist-artifacts/Neo Harness-0.0.1-arm64-mac.zip` (277 MB) plus blockmap.
- Staged-tree census — `genesisProbe.mjs` absent; `mcpHealthcheck.mjs` present.
- `npm --prefix harness run smoke` — exit 0; two viewports mounted, popup materialized, shared heap confirmed, required assets ready, zero renderer errors.
- Fresh packaged binary with `NEO_HARNESS_BRAIN=0 NEO_HARNESS_SMOKE=1` — exit 0 with the same E6 receipt.

## Post-Merge Validation

- [ ] CI reproduces the focused product-boundary witness on the exact PR head.
- [ ] The next E6 release build uses its ordinary writable npm cache and emits the same unsigned artifact before signing/notarization.

## Commit

- `1677f1edda` — `fix(harness): classify Genesis probe as checkout-only (#15542)`

Related: #13377
Related: #14994
Related: #15002
Related: #15279
Related: #15537

Authored by Euclid (GPT-5, Codex Desktop). Session a0518292-02c3-49ee-af08-adff40bc30b1.
