### PR TITLE
fix(agentos): fail closed on incomplete discussion mirrors (#15035)

### DIFF
--- a/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
+++ b/ai/daemons/temporal-summary/TemporalSummaryAggregationService.mjs
@@ -327,12 +327,13 @@ class TemporalSummaryAggregationService extends Base {
      * to), NOT the discussion close: a discussion may close long after — or never — while the graduation happened
      * in a dated comment, so `closedAt` is the wrong clock and is never used here.
      *
-     * The synced corpus is complete (never a truncated live `discussions(first: 50)` page) and preserves the
-     * per-comment `### `@author` commented on <ISO>` boundaries, so a marker's event time is its enclosing dated
-     * comment's timestamp; a marker outside any dated comment (e.g. the original post) fails closed, never proxied.
-     * Only the exact ticket-naming bracket counts: a bare `[GRADUATED_TO_TICKET]` mentioned in prose is the
-     * marker being DISCUSSED, not an author-action, and is rejected; a marker whose event time cannot be resolved
-     * fails closed (uncounted) rather than borrow the close time.
+     * Every artifact must carry producer-owned `conversationComplete: true`; one incomplete or legacy-unknown
+     * mirror rejects the whole source before counting. A proven-complete artifact preserves the per-comment
+     * `### `@author` commented on <ISO>` boundaries, so a marker's event time is its enclosing dated comment's
+     * timestamp; a marker outside any dated comment (e.g. the original post) fails closed, never proxied. Only the
+     * exact ticket-naming bracket counts: a bare `[GRADUATED_TO_TICKET]` mentioned in prose is the marker being
+     * DISCUSSED, not an author-action, and is rejected; a marker whose event time cannot be resolved fails closed
+     * (uncounted) rather than borrow the close time.
      * @param {{windowStart:String, windowEnd:String}} window
      * @returns {Promise<Array<{ref:String, ticket:String, at:String}>>}
      * @protected
@@ -340,9 +341,20 @@ class TemporalSummaryAggregationService extends Base {
     async fetchSandboxesGraduated({windowStart, windowEnd}) {
         const
             startMs = Date.parse(windowStart),
-            endMs   = Date.parse(windowEnd);
+            endMs   = Date.parse(windowEnd),
+            records = this.readContentRecords('discussions'),
+            unknown = records
+                .filter(({frontmatter}) => frontmatter.conversationComplete !== true)
+                .map(({frontmatter}) => frontmatter.number ?? 'unknown');
 
-        return this.readContentRecords('discussions').flatMap(({frontmatter, body}) =>
+        if (unknown.length > 0) {
+            throw new Error(
+                `Discussion mirror completeness is unknown/incomplete for: ${unknown.map(number => `#${number}`).join(', ')}. ` +
+                'Re-sync the corpus before temporal-summary aggregation; incompleteness is never a numeric zero.'
+            )
+        }
+
+        return records.flatMap(({frontmatter, body}) =>
             this.extractGraduationActions({frontmatter, body}).filter(action => {
                 const eventMs = Date.parse(action.at);
 
@@ -383,15 +395,26 @@ class TemporalSummaryAggregationService extends Base {
             seen           = new Set(),
             actions        = [];
 
-        let currentAt = null, inFence = false;
+        let currentAt = null, fence = null;
 
         for (const line of body.split('\n')) {
-            // a fence is delimited by ``` OR ~~~ — a marker inside either is a code example, never an author action
-            if (/^\s*(?:```|~~~)/.test(line)) {
-                inFence = !inFence;
+            const
+                fenceStart = /^\s*(`{3,}|~{3,})/.exec(line),
+                fenceClose = /^\s*(`{3,}|~{3,})\s*$/.exec(line);
+
+            if (!fence && fenceStart) {
+                fence = {delimiter: fenceStart[1][0], length: fenceStart[1].length};
                 continue
             }
-            if (inFence) continue;
+            if (fence) {
+                if (
+                    fenceClose && fenceClose[1][0] === fence.delimiter &&
+                    fenceClose[1].length >= fence.length
+                ) {
+                    fence = null
+                }
+                continue
+            }
 
             const boundary = commentPattern.exec(line) || replyPattern.exec(line);
 

--- a/ai/graph/temporalSummarySchema.mjs
+++ b/ai/graph/temporalSummarySchema.mjs
@@ -29,9 +29,10 @@ import {slugifyIdPart} from './businessSchema.mjs';
  *   or the single unified track with attribution. Partition is identity, not annotation: a
  *   malformed partition fragments every downstream window query silently, so the validator
  *   fail-closes on anything outside the two sanctioned forms.
- * - **Append-only versioning (§2.4 / OQ8):** document ids embed the `version` field — a
- *   re-aggregation mints NEW documents under the next version instead of rewriting history.
- *   Retention policy within the version field is Leaf B's contract, not schema's.
+ * - **Material-contract versioning (§2.4 / OQ8):** document ids embed the `version` field. A
+ *   same-window + same-track + same-version re-fold deterministically overwrites one id; only a
+ *   material contract-version bump mints a new append-only id. Retention across versions is Leaf
+ *   B's contract, not schema's.
  */
 
 /**

--- a/ai/services/github-workflow/queries/discussionQueries.mjs
+++ b/ai/services/github-workflow/queries/discussionQueries.mjs
@@ -113,8 +113,9 @@ export const GET_DISCUSSION_CONVERSATION = `
 `;
 
 /**
- * Basic query to fetch discussions for local synchronization.
- * Includes nested comments and replies.
+ * @summary Fetches Discussions for local synchronization, including bounded nested comments and
+ * replies plus each connection's `totalCount` / `pageInfo`. Those exhaustion facts let the shared
+ * renderer persist explicit incompleteness instead of mistaking a 50/20 cap for a complete mirror.
  *
  * Variables required:
  * - $owner: String!
@@ -161,6 +162,11 @@ export const FETCH_DISCUSSIONS_FOR_SYNC = `
           }
 
           comments(first: $maxComments) {
+            totalCount
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
             nodes {
               author {
                 login
@@ -169,6 +175,11 @@ export const FETCH_DISCUSSIONS_FOR_SYNC = `
               createdAt
               isAnswer
               replies(first: $maxReplies) {
+                totalCount
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
                 nodes {
                   author {
                     login
@@ -189,9 +200,9 @@ export const FETCH_DISCUSSIONS_FOR_SYNC = `
 /**
  * @summary Single-discussion variant of {@link FETCH_DISCUSSIONS_FOR_SYNC} for the force-refetch path.
  *
- * Returns the identical sync node shape (body + comments + nested replies + frontmatter fields) for
+ * Returns the identical sync node shape (body + comments + nested replies + exhaustion facts) for
  * ONE discussion by number, bypassing the bulk delta-by-`updatedAt` gating so a known-stale local
- * mirror can be force-re-rendered from current GitHub state.
+ * mirror can be force-re-rendered from current GitHub state without weakening completeness evidence.
  *
  * Variables required:
  * - $owner: String!
@@ -227,6 +238,11 @@ export const FETCH_SINGLE_DISCUSSION_FOR_SYNC = `
         }
 
         comments(first: $maxComments) {
+          totalCount
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
           nodes {
             author {
               login
@@ -235,6 +251,11 @@ export const FETCH_SINGLE_DISCUSSION_FOR_SYNC = `
             createdAt
             isAnswer
             replies(first: $maxReplies) {
+              totalCount
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
               nodes {
                 author {
                   login

--- a/ai/services/github-workflow/sync/DiscussionSyncer.mjs
+++ b/ai/services/github-workflow/sync/DiscussionSyncer.mjs
@@ -251,6 +251,59 @@ class DiscussionSyncer extends Base {
     }
 
     /**
+     * @summary Projects the bounded GitHub comment/reply connections into explicit mirror-completeness
+     * evidence. Missing connection metadata is unknown, never assumed complete; a cap hit therefore
+     * survives in the artifact as a fail-closed signal for downstream deterministic consumers.
+     * @param {Object} discussion The fetched Discussion sync node.
+     * @returns {Object} Stable flat frontmatter fields for the v1 completeness contract.
+     * @private
+     */
+    #getConversationCompleteness(discussion) {
+        const
+            comments         = discussion.comments,
+            commentNodes     = comments?.nodes || [],
+            commentsObserved = commentNodes.length,
+            commentsTotal    = Number.isInteger(comments?.totalCount) ? comments.totalCount : null;
+
+        let repliesObserved = 0,
+            repliesTotal    = 0,
+            repliesKnown    = true,
+            repliesComplete = true;
+
+        for (const comment of commentNodes) {
+            const
+                replies  = comment.replies,
+                observed = replies?.nodes?.length || 0,
+                total    = Number.isInteger(replies?.totalCount) ? replies.totalCount : null;
+
+            repliesObserved += observed;
+
+            if (total === null || typeof replies?.pageInfo?.hasNextPage !== 'boolean') {
+                repliesKnown = false
+            } else {
+                repliesTotal    += total;
+                repliesComplete &&= replies.pageInfo.hasNextPage === false && observed === total
+            }
+        }
+
+        const
+            commentsKnown    = commentsTotal !== null && typeof comments?.pageInfo?.hasNextPage === 'boolean',
+            commentsComplete = commentsKnown &&
+                comments.pageInfo.hasNextPage === false && commentsObserved === commentsTotal,
+            complete      = commentsKnown && repliesKnown &&
+                commentsComplete && repliesComplete;
+
+        return {
+            conversationCompletenessSchemaVersion: 'discussion-conversation-completeness.v1',
+            conversationComplete                 : complete,
+            conversationCommentCountObserved     : commentsObserved,
+            conversationCommentCountTotal        : commentsTotal,
+            conversationReplyCountObserved       : repliesObserved,
+            conversationReplyCountTotal          : commentsComplete && repliesKnown ? repliesTotal : null
+        }
+    }
+
+    /**
      * @summary Renders a fetched discussion node to its synced Markdown (frontmatter + body + comments +
      * nested replies), applying the content-trust sanitizer + the frontmatter integrity gate.
      * Extracted from {@link #syncDiscussions} so the single-discussion force-refetch path renders
@@ -282,7 +335,8 @@ class DiscussionSyncer extends Base {
             routingDisposition             : routingDisposition.disposition,
             routingDispositionReason       : routingDisposition.reasonCode,
             routingDispositionEvidence     : routingDisposition.evidence,
-            contentTrust
+            contentTrust,
+            ...this.#getConversationCompleteness(discussion)
         };
 
         let body = projectedDiscussion.body || '';

--- a/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs
@@ -211,7 +211,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
                 // two real actions — the marker LEADS its line (heading, then bold+backtick wrappers), both in dated
                 // in-window comments. closedAt is deliberately OUT of window (Aug): proves event time, not close time
                 {
-                    frontmatter: {number: 10, createdAt: '2026-06-01T00:00:00Z', closedAt: '2026-08-01T00:00:00Z'},
+                    frontmatter: {number: 10, conversationComplete: true, createdAt: '2026-06-01T00:00:00Z', closedAt: '2026-08-01T00:00:00Z'},
                     body       : [
                         '## Comments',
                         '### `@neo-gpt` commented on 2026-07-05T10:00:00Z',
@@ -223,7 +223,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
                 // a ticket-bearing marker INLINE in prose (rejected) + a real leading action + a later
                 // BLOCKQUOTE quoting that same action → the action counts exactly once (dedupe + blockquote)
                 {
-                    frontmatter: {number: 11, createdAt: '2026-06-01T00:00:00Z', closedAt: null},
+                    frontmatter: {number: 11, conversationComplete: true, createdAt: '2026-06-01T00:00:00Z', closedAt: null},
                     body       : [
                         '### `@neo-gpt` commented on 2026-07-05T09:00:00Z',
                         'we should do [GRADUATED_TO_TICKET: #902] once OQ3 lands',
@@ -235,12 +235,12 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
                 // marker LEADS its line but sits in the ORIGINAL POST (no dated comment) → fail closed: createdAt is
                 // creation time, not the marker's edit time, so it is not a proxy — even though createdAt is in-window
                 {
-                    frontmatter: {number: 12, createdAt: '2026-07-05T05:00:00Z', closedAt: null},
+                    frontmatter: {number: 12, conversationComplete: true, createdAt: '2026-07-05T05:00:00Z', closedAt: null},
                     body       : '## [GRADUATED_TO_TICKET: #904] — graduated\n\n## Concept\n…'
                 },
                 // real leading action but its comment event time is OUT of window → rejected
                 {
-                    frontmatter: {number: 13, createdAt: '2026-06-01T00:00:00Z', closedAt: null},
+                    frontmatter: {number: 13, conversationComplete: true, createdAt: '2026-06-01T00:00:00Z', closedAt: null},
                     body       : '### `@y` commented on 2026-07-09T00:00:00Z\n## [GRADUATED_TO_TICKET: #905] — graduated'
                 }
             ]
@@ -265,7 +265,7 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         TemporalSummaryAggregationService.execCommand        = () => '';
         TemporalSummaryAggregationService.readContentRecords = () => [
             {
-                frontmatter: {number: 20, createdAt: '2026-06-01T00:00:00Z', closedAt: null},
+                frontmatter: {number: 20, conversationComplete: true, createdAt: '2026-06-01T00:00:00Z', closedAt: null},
                 body       : [
                     '### `@neo-gpt` commented on 2026-07-05T08:00:00Z',
                     'plain discussion prose',
@@ -290,6 +290,35 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         // the ~~~-fenced marker is rejected exactly like a ```-fenced one
         expect(graduated.map(g => g.ticket)).toEqual(['#920']);
         expect(graduated.map(g => g.at)).toEqual(['2026-07-05T10:00:00Z'])
+    });
+
+    test('fetchSandboxesGraduated rejects incomplete and legacy-unknown mirrors before counting', async () => {
+        TemporalSummaryAggregationService.readContentRecords = () => [
+            {frontmatter: {number: 30, conversationComplete: false}, body: ''},
+            {frontmatter: {number: 31}, body: ''}
+        ];
+
+        await expect(TemporalSummaryAggregationService.fetchSandboxesGraduated({
+            windowStart: '2026-07-05T00:00:00.000Z',
+            windowEnd  : '2026-07-06T00:00:00.000Z'
+        })).rejects.toThrow(/#30, #31/)
+    });
+
+    test('extractGraduationActions closes a fence only with the matching delimiter and sufficient length', () => {
+        const actions = TemporalSummaryAggregationService.extractGraduationActions({
+            frontmatter: {number: 32},
+            body       : [
+                '### `@neo-gpt` commented on 2026-07-05T10:00:00Z',
+                '````js',
+                '~~~',
+                '```',
+                '## [GRADUATED_TO_TICKET: #930] — still fenced',
+                '````',
+                '## [GRADUATED_TO_TICKET: #931] — real action'
+            ].join('\n')
+        });
+
+        expect(actions.map(action => action.ticket)).toEqual(['#931'])
     });
 
     test('fetchSessions binds sessions to the summary collection over a bounded half-open window', async () => {
@@ -495,10 +524,10 @@ test.describe('Neo.ai.daemons.TemporalSummaryAggregationService', () => {
         TemporalSummaryAggregationService.fetchMergedPrs     = async () => [];
         TemporalSummaryAggregationService.readContentRecords = () => [
             // real leading author-action in a dated in-window comment
-            {frontmatter: {number: 10, createdAt: '2026-06-01T00:00:00Z', closedAt: null}, body: '### `@x` commented on 2026-07-05T06:00:00.000Z\n## [GRADUATED_TO_TICKET: #810] — graduated'},
-            {frontmatter: {number: 11, createdAt: '2026-07-05T07:00:00.000Z', closedAt: null}, body: 'just an ordinary discussion'},
+            {frontmatter: {number: 10, conversationComplete: true, createdAt: '2026-06-01T00:00:00Z', closedAt: null}, body: '### `@x` commented on 2026-07-05T06:00:00.000Z\n## [GRADUATED_TO_TICKET: #810] — graduated'},
+            {frontmatter: {number: 11, conversationComplete: true, createdAt: '2026-07-05T07:00:00.000Z', closedAt: null}, body: 'just an ordinary discussion'},
             // ticket-bearing marker inline in prose — rejected (not marker-leading)
-            {frontmatter: {number: 12, createdAt: '2026-07-05T08:00:00.000Z', closedAt: null}, body: '### `@y` commented on 2026-07-05T08:00:00Z\nwe will do [GRADUATED_TO_TICKET: #811] soon'}
+            {frontmatter: {number: 12, conversationComplete: true, createdAt: '2026-07-05T08:00:00.000Z', closedAt: null}, body: '### `@y` commented on 2026-07-05T08:00:00Z\nwe will do [GRADUATED_TO_TICKET: #811] soon'}
         ];
 
         const sources = await TemporalSummaryAggregationService.fetchWindowSources({

--- a/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs
@@ -13,13 +13,16 @@ setup({
     }
 });
 
-import {test, expect}               from '@playwright/test';
-import Neo                          from '../../../../../../src/Neo.mjs';
-import * as core                    from '../../../../../../src/core/_export.mjs';
-import fs                           from 'fs-extra';
-import matter                       from 'gray-matter';
-import path                         from 'path';
-import {FETCH_DISCUSSIONS_FOR_SYNC} from '../../../../../../ai/services/github-workflow/queries/discussionQueries.mjs';
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import fs             from 'fs-extra';
+import matter         from 'gray-matter';
+import path           from 'path';
+import {
+    FETCH_DISCUSSIONS_FOR_SYNC,
+    FETCH_SINGLE_DISCUSSION_FOR_SYNC
+} from '../../../../../../ai/services/github-workflow/queries/discussionQueries.mjs';
 
 test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
     let aiConfig;
@@ -108,6 +111,7 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         expect(content).toMatch(/^routingDispositionSchemaVersion: discussion-routing-disposition\.v1$/m);
         expect(content).toMatch(/^routingDisposition: undetermined$/m);
         expect(content).toMatch(/^routingDispositionReason: untrusted-or-unclassified-root-author$/m);
+        expect(content).toMatch(/^conversationComplete: true$/m);
     });
 
     test('COMPLETE-membership red-proof: a new discussion ranks PAST the marooned on-disk backlog into chunk-2 (#15452)', async () => {
@@ -220,6 +224,88 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         const answerFlagMatches = FETCH_DISCUSSIONS_FOR_SYNC.match(/\bisAnswer\b/g) || [];
 
         expect(answerFlagMatches).toHaveLength(2);
+    });
+
+    test('bulk and force-refetch queries carry the same nested exhaustion evidence', () => {
+        for (const query of [FETCH_DISCUSSIONS_FOR_SYNC, FETCH_SINGLE_DISCUSSION_FOR_SYNC]) {
+            expect(query.match(/\btotalCount\b/g)).toHaveLength(2);
+            expect(query.match(/\bendCursor\b/g)).toHaveLength(query === FETCH_DISCUSSIONS_FOR_SYNC ? 3 : 2);
+            expect(query.match(/\bhasNextPage\b/g)).toHaveLength(query === FETCH_DISCUSSIONS_FOR_SYNC ? 3 : 2)
+        }
+    });
+
+    test('persists explicit incompleteness when the top-level comment connection is capped', async () => {
+        const discussion = buildDiscussion(24009, {
+            comments: {
+                nodes     : Array.from({length: 50}, (_, index) => ({
+                    author   : {login: 'neo-test'},
+                    body     : `Comment ${index}`,
+                    createdAt: `2026-05-02T01:${String(index).padStart(2, '0')}:00Z`,
+                    replies  : {nodes: [], totalCount: 0, pageInfo: {hasNextPage: false, endCursor: null}}
+                })),
+                totalCount: 51,
+                pageInfo  : {hasNextPage: true, endCursor: 'comment-50'}
+            }
+        });
+
+        GraphqlService.query = async () => ({
+            repository: {discussions: {nodes: [discussion], pageInfo: {hasNextPage: false, endCursor: null}}}
+        });
+
+        await DiscussionSyncer.syncDiscussions({discussions: {}});
+
+        const parsed = matter(await fs.readFile(
+            path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-24009.md'),
+            'utf8'
+        ));
+
+        expect(parsed.data).toMatchObject({
+            conversationComplete            : false,
+            conversationCommentCountObserved: 50,
+            conversationCommentCountTotal   : 51,
+            conversationReplyCountObserved  : 0,
+            conversationReplyCountTotal     : null
+        })
+    });
+
+    test('persists explicit incompleteness when a nested reply connection is capped', async () => {
+        const discussion = buildDiscussion(24010, {
+            comments: {
+                nodes: [{
+                    author   : {login: 'neo-test'},
+                    body     : 'Parent comment',
+                    createdAt: '2026-05-02T01:00:00Z',
+                    replies  : {
+                        nodes: Array.from({length: 20}, (_, index) => ({
+                            author   : {login: 'neo-test'},
+                            body     : `Reply ${index}`,
+                            createdAt: `2026-05-02T02:${String(index).padStart(2, '0')}:00Z`
+                        })),
+                        totalCount: 21,
+                        pageInfo  : {hasNextPage: true, endCursor: 'reply-20'}
+                    }
+                }]
+            }
+        });
+
+        GraphqlService.query = async () => ({
+            repository: {discussions: {nodes: [discussion], pageInfo: {hasNextPage: false, endCursor: null}}}
+        });
+
+        await DiscussionSyncer.syncDiscussions({discussions: {}});
+
+        const parsed = matter(await fs.readFile(
+            path.join(aiConfig.issueSync.discussionsDir, 'chunk-1', 'discussion-24010.md'),
+            'utf8'
+        ));
+
+        expect(parsed.data).toMatchObject({
+            conversationComplete            : false,
+            conversationCommentCountObserved: 1,
+            conversationCommentCountTotal   : 1,
+            conversationReplyCountObserved  : 20,
+            conversationReplyCountTotal     : 21
+        })
     });
 
     test('marks accepted Q&A comments with a parseable answer callout', async () => {
@@ -675,7 +761,10 @@ test.describe('Neo.ai.services.github-workflow.sync.DiscussionSyncer', () => {
         await expect(fs.pathExists(targetPath)).resolves.toBe(true);
 
         const parsed = matter(await fs.readFile(targetPath, 'utf8'));
-        expect(parsed.data.number).toBe(discussionNumber);
+        expect(parsed.data).toMatchObject({
+            number              : discussionNumber,
+            conversationComplete: true
+        });
 
         // Metadata refreshed with the live hash (no longer the stale one) + the resolved path.
         expect(metadata.discussions[discussionNumber].contentHash).not.toBe('STALE-HASH');
@@ -703,6 +792,21 @@ function buildDiscussion(number, config = {}) {
         comments = {nodes: []}
     } = config;
 
+    const normalizedComments = {
+        ...comments,
+        nodes     : (comments.nodes || []).map(comment => ({
+            ...comment,
+            replies: {
+                ...(comment.replies || {}),
+                nodes     : comment.replies?.nodes || [],
+                totalCount: comment.replies?.totalCount ?? comment.replies?.nodes?.length ?? 0,
+                pageInfo  : comment.replies?.pageInfo || {hasNextPage: false, endCursor: null}
+            }
+        })),
+        totalCount: comments.totalCount ?? comments.nodes?.length ?? 0,
+        pageInfo  : comments.pageInfo || {hasNextPage: false, endCursor: null}
+    };
+
     return {
         number,
         title    : `Discussion ${number}`,
@@ -713,6 +817,6 @@ function buildDiscussion(number, config = {}) {
         category : {name: category},
         createdAt: '2026-05-01T00:00:00Z',
         updatedAt: '2026-05-02T00:00:00Z',
-        comments
+        comments : normalizedComments
     };
 }


### PR DESCRIPTION
Resolves #15035

Related: #14938

Related: #12679

Discussion mirrors now carry producer-owned proof of whether the bounded comment and reply connections are complete. Both bulk sync and force-refetch serialize the same versioned completeness contract; temporal-summary aggregation rejects incomplete or legacy-unknown evidence before counting, and fenced graduation markers remain hidden until the matching delimiter closes. The aggregation runtime remains disabled while the corpus refresh is pending.

Evidence: L2 (GraphQL-shape, filesystem-render, force-refetch, and fail-closed consumer unit witnesses) → L2 required (the close-target's producer/artifact/consumer contract is deterministic and unit-reachable). Residual: the merged-code corpus refresh remains a pre-enablement validation [#15035].

## Deltas from ticket

- Chose the ticket-authorized explicit-incompleteness path rather than adding recursive nested pagination: bounded pages remain cheap, while `totalCount` plus `pageInfo` make truncation a typed artifact fact.
- A top-level comment truncation makes the aggregate reply total `null`, because replies on unobserved comments are unknowable; observed reply counts remain diagnostic.
- No runtime-enable config change was made. `aggregationEnabled` stays false until the refreshed corpus is verified.

## Test Evidence

- Discussion sync + temporal-summary ownership surfaces: `UNIT_TEST_MODE=true ELECTRON_RUN_AS_NODE=1 harness/node_modules/electron/dist/Electron.app/Contents/MacOS/Electron node_modules/@playwright/test/cli.js test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/github-workflow/DiscussionSyncer.spec.mjs test/playwright/unit/ai/daemons/temporal-summary/TemporalSummaryAggregationService.spec.mjs` — 48/48 passed.
- Static source gates: shorthand, JSDoc types, ticket archaeology, block alignment, parse, AiConfig test-mutation, whitespace, and `git diff --check` all passed.
- Staged `agent-preflight --no-fix` and the complete pre-commit lint-staged chain passed.

## Post-Merge Validation

- [ ] Run the full Discussion sync from merged `dev` so every tracked artifact receives `discussion-conversation-completeness.v1` frontmatter.
- [ ] Census `conversationComplete`; if any artifact is false, keep aggregation disabled and exhaust that conversation before enablement.
- [ ] Confirm `AiConfig.temporalSummary.aggregationEnabled` remains false until the refreshed corpus is complete.

Authored by Euclid (GPT-5, Codex Desktop). Session a0518292-02c3-49ee-af08-adff40bc30b1.
