### PR TITLE
test(dashboard): harden tear-out matrix evidence (#15551)

### DIFF
--- a/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
+++ b/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
@@ -64,7 +64,7 @@ design discussion, pause consuming implementation).
 | 2 | Acquisition (`window.open` boolean; activation window) | `NOT_YET_MEASURED` ² | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 3 | Moving embodiment (requested-vs-observed `moveTo`) | `NOT_YET_MEASURED` ³ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 4 | Object permanence / reintegration (same instance back) | `NOT_YET_MEASURED` ⁴ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
-| 5 | Screen topology (`getScreenDetails` never a prerequisite) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 5 | Screen topology (`getScreenDetails` never a prerequisite) | `PASS_FALLBACK` ⁵ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 6 | Multi-window targeting (claim-protocol identity binding) | `NOT_YET_MEASURED` ⁴ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 7 | Terminal cleanup (exact-once, idempotent) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 
@@ -144,6 +144,21 @@ The composition repair belongs to #15396; this matrix does not absorb it. A seco
 gap remains for row 4: Demo B exposes no `Neo.data.Store` (`list_stores` returned an empty set),
 so its CounterPane heartbeat proves instance-local continuity but cannot honestly stand in for
 the required live-store-reference receipt. Both cells remain `NOT_YET_MEASURED`.
+
+⁵ Row 5 macOS — **`PASS_FALLBACK`** (2026-07-19, headed Chrome 150, 3/3 serial): the witness
+bound `Browser.setPermission` to Playwright's actual browser context, observed the
+`window-management` permission as `denied`, and observed `getScreenDetails()` reject with
+`NotAllowedError`. Demo B's real boundary gesture still opened exactly one `?popout=workbench`
+vessel; exact-head source inspection identifies its ordinary `Neo.Main.getWindowData`
+screen/window-metrics path, while the headed receipt independently proves permission denial does
+not block it. All five
+universal invariants passed: the gesture survived four post-birth moves; the CounterPane kept
+the same `neo-component-1` identity with heartbeat `0 → 1 → 2` and mount count `1 → 2 → 3`;
+the real saved-perspective writer accepted both detached and returned documents into its
+JSON-only collection; detach removed the item from the tree while preserving its catalog entry
+and native `window.close()` restored exactly one semantic home; all three lifecycle maps cleared,
+and repeating the same disconnect terminal made no further state change. Main-page and popup
+window error ledgers were empty in every run; SharedWorker console output was not claimed.
 
 ## Per-row receipt requirements
 

--- a/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
+++ b/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
@@ -25,13 +25,20 @@ One transition chain, end to end — no new window manager, no second dwell coor
    conversion to a real, URL-addressed OS popup on the shared heap.
 3. `src/main/addon/DragDrop.mjs` pointer-follow (`windowMoveTo`) — the moving embodiment.
 
-Witness suite: `test/playwright/e2e/colors/tearOutMatrix.spec.mjs` (headed real-browser runs;
-headless proves wiring, never native placement). The measurement surface is the colors app —
-the landed grammar's original live product surface (`useSharedWorkers: true`, `popupUrl` wired
-to its dedicated widget shell, explicit `neo-draggable` panel-header handles). Dock-tier
-surfaces (workstation, dockdemo) opt OUT of the grammar until the G1 leaf lands — they cannot
-serve as measurement surfaces yet. Density context for the G1 calibration remains the flagship
-workstation — 20 items / 9 nodes / 6 tab nodes (1·12·2·2·1·2 distribution).
+Witness family: headed real-browser runs under `test/playwright/playwright.config.matrix.mjs`;
+headless proves wiring, never native placement. Rows 1–3 use
+`test/playwright/e2e/colors/tearOutMatrix.spec.mjs` on the grammar's original live surface
+(`useSharedWorkers: true`, `popupUrl` wired to its dedicated widget shell, explicit
+`neo-draggable` panel-header handles). Rows 4–7 use Demo B, the merged dock-tier composition
+surface that owns worker-stable workspace identity, live pane instances, cross-window claims,
+and terminal machines. Density context for the G1 calibration remains the flagship workstation
+— 20 items / 9 nodes / 6 tab nodes (1·12·2·2·1·2 distribution).
+
+Runner provenance receipt (2026-07-19): the matrix config pins its one resolved port into
+`NEO_E2E_PORT`, while the Colors witness navigates relative to Playwright's configured
+`baseURL`. The web server and page therefore consume one authority; there is no fallback 8080
+route left for a foreign checkout to satisfy. A fresh unpinned row-2 run selected port `64544`
+and passed against that same server.
 
 ## Verdict vocabulary
 
@@ -56,9 +63,9 @@ design discussion, pause consuming implementation).
 | 1 | Hysteretic grammar (0.8 out / 0.6 in, direction-aware) | `NOT_YET_MEASURED` ¹ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 2 | Acquisition (`window.open` boolean; activation window) | `NOT_YET_MEASURED` ² | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 3 | Moving embodiment (requested-vs-observed `moveTo`) | `NOT_YET_MEASURED` ³ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
-| 4 | Object permanence / reintegration (same instance back) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 4 | Object permanence / reintegration (same instance back) | `NOT_YET_MEASURED` ⁴ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 5 | Screen topology (`getScreenDetails` never a prerequisite) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
-| 6 | Multi-window targeting (claim-protocol identity binding) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 6 | Multi-window targeting (claim-protocol identity binding) | `NOT_YET_MEASURED` ⁴ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 7 | Terminal cleanup (exact-once, idempotent) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 
 Environment note: the current fleet has a qualifying **macOS** headed environment. Windows and
@@ -123,6 +130,20 @@ geometry. Direct consumer warning: G1 ships this exact grammar to dock surfaces 
 the race predates G1 and must be attributed before dock-tier calibration lands on top of it.
 Requested-vs-observed `moveTo` sampling remains blocked behind the race (a 2 ms lifetime cannot
 be position-sampled).
+
+⁴ Rows 4 / 6 macOS — **qualified RED control, verdict pending** (2026-07-19, Chrome): a headed
+live Neural Link run of Demo B's real `executeCrossWindowStep()` opened both the intended
+`?workspaceId=demo-b-popup` target and an unintended `?popout=workbench` tear-out vessel. Worker
+truth then held two registered workspaces but three physical windows; the CounterPane's live
+`windowId` named the tear-out vessel while `crossWindowTargetWindowId` named the workspace
+target. The exact canonical full-journey control
+`DemoBPerspectivesNL.spec.mjs` failed because the intended popup never rendered the live
+CounterPane. The narrower `DemoBCrossWindowDragNL.spec.mjs` stayed green while logging three
+window connections, proving that its current receipt does not falsify competing-vessel identity.
+The composition repair belongs to #15396; this matrix does not absorb it. A second independent
+gap remains for row 4: Demo B exposes no `Neo.data.Store` (`list_stores` returned an empty set),
+so its CounterPane heartbeat proves instance-local continuity but cannot honestly stand in for
+the required live-store-reference receipt. Both cells remain `NOT_YET_MEASURED`.
 
 ## Per-row receipt requirements
 

--- a/test/playwright/e2e/agentos/TearOutMatrixRows4To7NL.spec.mjs
+++ b/test/playwright/e2e/agentos/TearOutMatrixRows4To7NL.spec.mjs
@@ -1,0 +1,264 @@
+import {expect, test} from '../../fixtures.mjs';
+
+/**
+ * @summary Headed macOS receipts for the dock-tier half of the tear-out portability matrix.
+ *
+ * Rows 4, 6, and 7 remain deliberately absent until their named product/test-host blockers are
+ * repaired. Row 5 drives the real Demo B tear-out gesture with the Window Management permission
+ * denied, then closes the native vessel and proves the complete fallback lifecycle against all
+ * five universal invariants from the living matrix ledger.
+ *
+ * Run: npx playwright test agentos/TearOutMatrixRows4To7NL.spec.mjs \
+ *   -c test/playwright/playwright.config.matrix.mjs --workers=1
+ */
+test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', () => {
+    test.setTimeout(120000);
+
+    /**
+     * @param {Object} app Neural Link app wrapper.
+     * @returns {Promise<Object>}
+     */
+    async function getCounter(app) {
+        const found = await app.findInstances({
+            className: 'AgentOS.childapps.dockdemo.view.CounterPane'
+        }, ['frames', 'id', 'isDestroyed', 'mounted', 'mountCount', 'windowId']);
+
+        const counters = (Array.isArray(found) ? found : found ? [found] : [])
+            .map(counter => ({...counter.properties, id: counter.id}));
+
+        expect(counters, 'exactly one worker-owned CounterPane instance may exist').toHaveLength(1);
+
+        return counters[0]
+    }
+
+    /**
+     * @param {Object} app Neural Link app wrapper.
+     * @param {String} wsId Demo B workspace component id.
+     * @returns {Promise<Object>}
+     */
+    function getLifecycleState(app, wsId) {
+        return app.getComponent(wsId, [
+            'dockModel',
+            'tearOutConnects',
+            'tearOutPanes',
+            'tearOutPlacements'
+        ])
+    }
+
+    test('row 5 — denied getScreenDetails falls back through window metrics without violating lifecycle invariants', async ({page, neuralLink}) => {
+        const runtimeErrors = [], pageErrors = [], popupErrors = [];
+
+        await page.context().exposeFunction('__recordMatrixRow5', payload => runtimeErrors.push(payload));
+        await page.context().addInitScript(() => {
+            globalThis.addEventListener('error', event => globalThis.__recordMatrixRow5({
+                column : event.colno,
+                line   : event.lineno,
+                message: event.message,
+                source : event.filename,
+                type   : 'error'
+            }));
+            globalThis.addEventListener('unhandledrejection', event => globalThis.__recordMatrixRow5({
+                reason: String(event.reason?.stack || event.reason?.message || event.reason),
+                type  : 'unhandledrejection'
+            }))
+        });
+        page.on('pageerror', error => pageErrors.push(String(error?.stack || error?.message || error)));
+
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
+        await page.locator('.agentos-dockdemo-counter-pane').waitFor({timeout: 30000});
+
+        const
+            cdp              = await page.context().newCDPSession(page),
+            {targetInfo}     = await cdp.send('Target.getTargetInfo'),
+            browserContextId = targetInfo.browserContextId,
+            origin           = new URL(page.url()).origin,
+            permission       = {name: 'window-management'};
+
+        await cdp.send('Browser.setPermission', {browserContextId, origin, permission, setting: 'denied'});
+
+        const denial = await page.evaluate(async () => {
+            const timeout    = label => new Promise(resolve => setTimeout(() => resolve({outcome: 'timeout', label}), 2000)),
+                  permission = await Promise.race([
+                      navigator.permissions.query({name: 'window-management'})
+                          .then(({state}) => ({outcome: 'settled', state}))
+                          .catch(error => ({errorName: error.name, outcome: 'rejected'})),
+                      timeout('permission-query')
+                  ]),
+                  request = await Promise.race([
+                      window.getScreenDetails()
+                          .then(() => ({outcome: 'resolved'}))
+                          .catch(error => ({errorName: error.name, outcome: 'rejected'})),
+                      timeout('getScreenDetails')
+                  ]);
+
+            return {permission, request}
+        });
+
+        expect(denial.permission).toEqual({outcome: 'settled', state: 'denied'});
+        expect(denial.request).toEqual({errorName: 'NotAllowedError', outcome: 'rejected'});
+
+        const
+            app        = await neuralLink.connectToApp('AgentOSDockDemo'),
+            workspaces = await app.findInstances({
+                className: 'AgentOS.childapps.dockdemo.view.DemoBWorkspace'
+            }, ['id']),
+            wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+
+        expect(wsId, 'Demo B must expose one Neural Link workspace authority').toBeTruthy();
+
+        await expect.poll(async () => {
+            const pane = await getCounter(app);
+
+            return {id: pane?.id, mountCount: pane?.mountCount}
+        }, {
+            message: 'CounterPane must start as one mounted live instance',
+            timeout: 5000
+        }).toEqual({id: expect.any(String), mountCount: 1});
+
+        const
+            before     = await getLifecycleState(app, wsId),
+            paneBefore = await getCounter(app),
+            popupWait  = page.waitForEvent('popup', {timeout: 30000}),
+            resultWait = app.callMethod(wsId, 'executeTearOutStep', [{
+                itemId      : 'workbench',
+                sourceNodeId: 'workbench-tabs'
+            }, {postBirthMoves: 4}]),
+            popup      = await popupWait;
+
+        popup.on('pageerror', error => popupErrors.push(String(error?.stack || error?.message || error)));
+
+        const result = await resultWait;
+
+        expect(result.errors).toEqual([]);
+        expect(result.applied).toBe(true);
+        expect(result.proof).toMatchObject({
+            born              : true,
+            catalogPreserved  : true,
+            committed         : true,
+            detachCommitted   : true,
+            itemAbsentFromTree: true,
+            itemKeptInCatalog : true,
+            survivedProbe     : true
+        });
+        expect(popup.url()).toContain('popout=workbench');
+        expect(page.context().pages().filter(candidate => candidate.url().includes('popout=workbench'))).toEqual([popup]);
+
+        await expect.poll(async () => {
+            const state = await getLifecycleState(app, wsId),
+                  pane  = await getCounter(app),
+                  entry = state.tearOutPanes.workbench;
+
+            return {
+                paneId        : pane?.id,
+                vesselWindowId: entry?.windowId || null
+            }
+        }).toEqual({
+            paneId        : paneBefore.id,
+            vesselWindowId: expect.any(String)
+        });
+
+        await popup.locator('.agentos-dockdemo-counter-pane').waitFor();
+        expect(await popup.locator('.agentos-dockdemo-counter-pane').getAttribute('id')).toBe(paneBefore.id);
+        await expect.poll(async () => (await getCounter(app))?.frames, {
+            message  : 'the same instance heartbeat must advance while mounted in the vessel',
+            intervals: [100, 250],
+            timeout  : 5000
+        }).toBeGreaterThan(paneBefore.frames);
+
+        const
+            detached       = await getLifecycleState(app, wsId),
+            paneDetached   = await getCounter(app),
+            vesselWindowId = detached.tearOutPanes.workbench.windowId;
+
+        expect(result.proof.documentBefore).toEqual(before.dockModel);
+        expect(result.proof.documentAfter).toEqual(detached.dockModel);
+        expect(paneDetached.mountCount).toBe(paneBefore.mountCount + 1);
+        expect(paneDetached.frames).toBeGreaterThanOrEqual(paneBefore.frames);
+        expect(paneDetached.windowId).toBe(vesselWindowId);
+        expect(Object.values(detached.dockModel.nodes).filter(node => node.items?.includes('workbench'))).toHaveLength(0);
+        expect(detached.dockModel.items.workbench).toBeTruthy();
+
+        expect(await app.callMethod(wsId, 'capturePerspective', ['Row5Detached']))
+            .toEqual({errors: [], saved: true});
+
+        const popupClosed = popup.waitForEvent('close');
+
+        await popup.evaluate(() => window.close());
+        await popupClosed;
+
+        await expect.poll(async () => {
+            const state = await getLifecycleState(app, wsId),
+                  pane  = await getCounter(app),
+                  homes = Object.values(state.dockModel.nodes).filter(node => node.items?.includes('workbench'));
+
+            return {
+                connects: Object.keys(state.tearOutConnects).length,
+                homes   : homes.length,
+                panes   : Object.keys(state.tearOutPanes).length,
+                paneId  : pane?.id,
+                places  : Object.keys(state.tearOutPlacements).length,
+                rendered: await page.locator('.agentos-dockdemo-counter-pane').count()
+            }
+        }, {
+            intervals: [100, 250],
+            timeout  : 10000
+        }).toEqual({
+            connects: 0,
+            homes   : 1,
+            panes   : 0,
+            paneId  : paneBefore.id,
+            places  : 0,
+            rendered: 1
+        });
+
+        await expect.poll(async () => (await getCounter(app))?.frames, {
+            message  : 'the same instance heartbeat must keep advancing after semantic return',
+            intervals: [100, 250],
+            timeout  : 5000
+        }).toBeGreaterThan(paneDetached.frames);
+
+        const
+            returned     = await getLifecycleState(app, wsId),
+            paneReturned = await getCounter(app);
+
+        expect(returned.dockModel.items).toEqual(before.dockModel.items);
+        expect(Object.values(returned.dockModel.nodes).filter(node => node.items?.includes('workbench'))).toHaveLength(1);
+        expect(paneReturned.frames).toBeGreaterThanOrEqual(paneDetached.frames);
+        expect(paneReturned.mountCount).toBe(paneDetached.mountCount + 1);
+        expect(paneReturned.windowId).toBe(paneBefore.windowId);
+
+        expect(await app.callMethod(wsId, 'capturePerspective', ['Row5Returned']))
+            .toEqual({errors: [], saved: true});
+
+        const collection = (await app.getComponent(wsId, [
+                  'perspectiveStore.collection'
+              ]))['perspectiveStore.collection'],
+              storedDetached = collection.layouts['demo-b-row5detached'],
+              storedReturned = collection.layouts['demo-b-row5returned'];
+
+        expect(storedDetached.captureScope).toBe('window');
+        expect(storedDetached.dockZone).toEqual(detached.dockModel);
+        expect(storedReturned.captureScope).toBe('window');
+        expect(storedReturned.dockZone).toEqual(returned.dockModel);
+        expect(JSON.parse(JSON.stringify({storedDetached, storedReturned})))
+            .toEqual({storedDetached, storedReturned});
+
+        // Repeat the same terminal signal: all model, identity, and cleanup state must stay still.
+        await app.callMethod(wsId, 'onWindowDisconnect', [{windowId: vesselWindowId}]);
+
+        expect(await getLifecycleState(app, wsId)).toEqual(returned);
+        expect((await getCounter(app)).id).toBe(paneBefore.id);
+        expect(runtimeErrors).toEqual([]);
+        expect(pageErrors).toEqual([]);
+        expect(popupErrors).toEqual([]);
+
+        console.log('ROW5-RECEIPTS', JSON.stringify({
+            denial,
+            fallback   : 'Neo.Main.getWindowData screen/window metrics',
+            frames     : [paneBefore.frames, paneDetached.frames, paneReturned.frames],
+            mountCounts: [paneBefore.mountCount, paneDetached.mountCount, paneReturned.mountCount],
+            paneId     : paneBefore.id,
+            vesselWindowId
+        }))
+    })
+});

--- a/test/playwright/e2e/colors/tearOutMatrix.spec.mjs
+++ b/test/playwright/e2e/colors/tearOutMatrix.spec.mjs
@@ -258,10 +258,6 @@ test.describe('tear-out portability matrix — colors app, headed', () => {
         // after drag-back reintegration; data streamed uninterrupted across the transition.
     });
 
-    test.fixme('row 5 — screen topology: getScreenDetails denied degrades to the documented fallback', async () => {
-        // Receipts: the full flow completes with the permission denied; denial never blocks.
-    });
-
     test.fixme('row 6 — multi-window targeting: at most one target exposes one menu + one preview per gesture', async () => {
         // Receipts: the claim protocol's identity binding only — arbitration is out of scope.
     });

--- a/test/playwright/e2e/colors/tearOutMatrix.spec.mjs
+++ b/test/playwright/e2e/colors/tearOutMatrix.spec.mjs
@@ -22,11 +22,10 @@ import {expect, test} from '../../fixtures.mjs';
  */
 
 // The colors app: three DashboardPanels (Grid / Pie Chart / Bar Chart) whose header toolbars
-// carry the explicit `neo-draggable` drag-handle cls. The dev server port rides NEO_E2E_PORT —
-// the same knob the e2e config uses to dodge a foreign server.
+// carry the explicit `neo-draggable` drag-handle cls. Relative navigation consumes the matrix
+// runner's baseURL directly, so a fallback port can never diverge from the server it launched.
 const
-    e2ePort    = Number(process.env.NEO_E2E_PORT) || 8080,
-    surfaceUrl = `http://localhost:${e2ePort}/apps/colors/index.html`,
+    surfaceUrl = '/apps/colors/index.html',
     itemHandle = '.neo-draggable',
     dragSteps  = 25;
 

--- a/test/playwright/playwright.config.matrix.mjs
+++ b/test/playwright/playwright.config.matrix.mjs
@@ -35,8 +35,11 @@ process.env.NEO_E2E_PORT = String(PORT);
  *   contract authority this runner serves) and will need their own launch configuration.
  */
 export default defineConfig({
-    testDir      : './e2e/colors',
-    testMatch    : 'tearOutMatrix.spec.mjs',
+    testDir  : './e2e',
+    testMatch: [
+        '**/colors/tearOutMatrix.spec.mjs',
+        '**/agentos/TearOutMatrixRows4To7NL.spec.mjs'
+    ],
     outputDir    : './test-results/matrix/artifacts',
     fullyParallel: false, // native window placement is a global resource — strictly serial
     workers      : 1,
@@ -57,8 +60,8 @@ export default defineConfig({
     },
 
     webServer: {
-        command            : `npm run server-start -- --port ${PORT} --no-open`,
-        url                : `http://localhost:${PORT}`,
+        command: `npm run server-start -- --port ${PORT} --no-open`,
+        url    : `http://localhost:${PORT}`,
         // NEVER adopt an existing listener: reuse is how a server from ANOTHER checkout silently
         // serves the wrong tree to every probe (the foreign-server evidence class).
         reuseExistingServer: false

--- a/test/playwright/playwright.config.matrix.mjs
+++ b/test/playwright/playwright.config.matrix.mjs
@@ -8,6 +8,11 @@ import {resolveFreePortSync} from './resolveFreePort.mjs';
 // adopts an existing listener, so every probe run serves exactly THIS checkout's tree.
 const PORT = resolveFreePortSync(process.env.NEO_E2E_PORT);
 
+// Pin the resolved authority for every process that re-imports this config. The specs navigate
+// relative to baseURL, but child helpers and future matrix rows must still observe the same port
+// as the webServer instead of resolving a second free port during worker bootstrap.
+process.env.NEO_E2E_PORT = String(PORT);
+
 /**
  * The tear-out portability-matrix runner (see
  * `learn/guides/specificfeatures/TearOutPortabilityMatrix.md` — the evidence ledger).


### PR DESCRIPTION
Resolves #15555
Related: #15551
Related: #15395
Related: #15396
Related: #15243

Hardens the tear-out portability matrix before accepting macOS receipts. The runner now exposes one resolved port authority to its workers, the Colors witness consumes the configured baseURL, the living ledger records the headed Demo B competing-vessel red control, and row 5 now carries one complete `PASS_FALLBACK` receipt without promoting rows 4, 6, or 7.

Evidence: L4 headed real-browser runner + row-5 native-window receipt achieved → L5 post-repair matrix receipts remain required for the other #15551 acceptance criteria. Residual: #15395 owns the immediate wrong-vessel adoption repair, #15396 owns async park/re-show, row 4 still lacks a `Neo.data.Store` continuity witness, and row 6 lacks three registered claim targets.

## Deltas from ticket

- Resolves the extracted row-5 receipt child #15555 while leaving parent #15551 open; rows 4, 6, and 7 remain explicitly outside this tranche.
- Adds the missing runner-provenance correction and a fresh unpinned dynamic-port receipt.
- Records the canonical Demo B blocker: the current composition creates an intended workspace popup and a competing tear-out vessel, leaving two registered workspaces across three physical windows.
- Promotes only macOS row 5 to `PASS_FALLBACK`: browser-context-bound permission denial, exact `NotAllowedError`, one real tear-out vessel, singleton component identity, exact `1 → 2 → 3` mounts, JSON-only saved-perspective writes for detached and returned documents, one semantic home, cleared lifecycle maps, and repeated-terminal no-op.
- Preserves rows 4, 6, and 7 as `NOT_YET_MEASURED`; leaves production source untouched.

## Test Evidence

- `npx playwright test colors/tearOutMatrix.spec.mjs --grep "row 2 probe" -c test/playwright/playwright.config.matrix.mjs --workers=1` — passed headed and unpinned; the runner selected port `64544` and the page loaded from that same server.
- `npx playwright test agentos/TearOutMatrixRows4To7NL.spec.mjs -c test/playwright/playwright.config.matrix.mjs --workers=1 --repeat-each=3` — 3/3 passed headed at exact final shape on dynamic port `52957`; every run observed permission `denied`, `getScreenDetails()` → `NotAllowedError`, heartbeat `0 → 1 → 2`, mount count `1 → 2 → 3`, and empty page/popup error ledgers.
- `npx playwright test colors/tearOutMatrix.spec.mjs agentos/TearOutMatrixRows4To7NL.spec.mjs --grep "row 2 probe|row 5" -c test/playwright/playwright.config.matrix.mjs --workers=1` — 2/2 passed together on dynamic port `51618`, proving both spec families consume the shared runner.
- `NEO_E2E_PORT=8143 npx playwright test agentos/DemoBPerspectivesNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` — red control: intended popup lacked the CounterPane after both child windows opened.
- `NEO_E2E_PORT=8141 npx playwright test agentos/DemoBCrossWindowDragNL.spec.mjs --grep "cold gesture" -c test/playwright/playwright.config.e2e.mjs --workers=1` — passed while logging three window connections, proving the narrow witness does not falsify the competing-vessel split.
- Neural Link live inspection — workspaceSet size 2 across three physical windows; CounterPane windowId named the tear-out vessel while crossWindowTargetWindowId named the workspace popup; `list_stores` returned an empty set.
- `npx lint-staged --no-stash`, parse, shorthand, block-alignment, whitespace, ticket-archaeology, and `git diff --check` — passed.

## Post-Merge Validation

- [x] Resolve the substantive row-5 child #15555 while parent #15551 remains open for the unmeasured rows.
- [ ] After #15395/#15396 repair the composition, rerun the canonical Demo B journey and complete only row cells that assert all five universal invariants.
- [ ] Keep row 4 open until a real `Neo.data.Store` continuity witness exists.
- [ ] Keep row 6 open until at least three registered claim targets exist.
- [ ] Keep row 7 open until drop, cancel, and blocked acquisition each prove exact-once cleanup.

## Evolution

Live headed inspection overturned the initial all-green premise. The existing narrow cross-window spec passes while observing the wrong three-window topology; the canonical perspective journey exposes it. An independent semantic audit then falsified two weaker receipt assumptions, so the row-5 witness now exercises the actual JSON-only perspective writer, singleton component/vessel identity, and exact mount deltas while narrowing error-ledger language to observable channels.

Authored by Emmy (OpenAI GPT-5, Codex Desktop). Session ad71d4c3-3e37-4a17-8df7-8415509def84.
