### PR TITLE
feat(core): singleton reInitAsync seam + ADR 0037 + first reach-in migration (WIP #15034)

### DIFF
--- a/learn/agentos/decisions/0031-target-architecture-composition.md
+++ b/learn/agentos/decisions/0031-target-architecture-composition.md
@@ -71,6 +71,7 @@ decision owns; *Parent* = the composition record that already aggregates it, whe
 | 0034 | Body ↔ Brain seam | Electron shell architecture (process model, SharedWorker window topology, security posture, distribution) | extends 0020 |
 | 0035 | Brain / orchestration | Live-lane awareness federation: typed GP route, lifecycle frontier, fenced hook projection, and Bird-View references | composes 0020/0028/0033 |
 | 0036 | Brain / community activity | Durable provider-neutral source registration/admission, zero-authority attention, and atomic Task claim | composes 0015/0019/0035 |
+| 0037 | Body / core lifecycle | Singleton init/ready/re-init contract: the fenced `core.Base#reInitAsync` test-re-init seam that retires the bespoke `_initPromise` idempotency guards | aligns 0019 |
 
 ## §3 Trajectory Invariants
 

--- a/learn/agentos/decisions/0037-singleton-init-ready-reinit-contract.md
+++ b/learn/agentos/decisions/0037-singleton-init-ready-reinit-contract.md
@@ -1,0 +1,95 @@
+# ADR 0037: Singleton init/ready/re-init contract — the fenced `core.Base#reInitAsync` seam
+
+> The lifecycle contract for re-initializing a `Neo.core.Base` singleton. Production runs `initAsync`
+> exactly once (via `Neo.create`); an external re-run is a fatal double-init the framework forbids.
+> Tests legitimately need to re-initialize process-singletons between cases. This ADR makes that a
+> sanctioned, mechanically-fenced capability instead of a private reach-in — and retires the bespoke
+> `_initPromise` idempotency guards that reach-in relied on.
+
+| Attribute | Value |
+|---|---|
+| **Status** | Proposed — 2026-07-19 (transitions to Accepted only on approved, green PR merge at the human merge gate, per ADR 0005) |
+| **Author** | @neo-opus-grace, with @neo-opus-ada's seam-design endorsement (Candidate 1 + the two mechanical conditions below) |
+| **ADR classification** | `ADR_REQUIRED` — the decision changes the `core.Base` init/ready lifecycle surface, a framework-wide contract |
+| **Grounds** | #15034 (the seam + the ~86-site test migration + guard deletion + repo-wide lint), sub of #15031 |
+| **Depends on** | #15033 / PR #15039 — the production sweep that removed every external `initAsync()` call, making the bespoke guards safe to delete |
+| **Aligns with** | ADR 0019 — this is a lifecycle capability, not AiConfig; the fence keys on `Neo.config.unitTestMode`, an operational runtime flag |
+| **Anti-anchor for** | External `initAsync()` as a wait primitive (use `ready()`), doc-only "protected" as a production fence, wholesale `construct()` re-fire, and re-opening the #12597 cross-spec singleton-leak class |
+
+---
+
+## Context
+
+`Neo.core.Base` initializes asynchronously exactly once: `construct()` creates a private `#readyPromise`
+(+ its resolver), then a microtask runs `initAsync()` and sets `isReady = true`, which resolves the
+promise and fires `ready`. The canonical external wait is `await instance.ready()`. `initAsync()`'s own
+JSDoc is explicit: **calling it externally runs it twice → fatal duplication bugs.**
+
+Two accreted patterns worked around the absence of a re-init capability:
+
+1. **Bespoke `_initPromise` idempotency guards** (`GraphService`, and the lifecycle services) — an
+   instance field guarding `initAsync` so a stray external call is harmless. These are the layer that
+   made the double-init survivable, at the cost of a second, ad-hoc "am I initialized" source of truth
+   parallel to `isReady`/`#readyPromise`.
+2. **A private test reach-in** — specs re-initialize process-singletons between cases with
+   `X._initPromise = null; await X.initAsync()` (~86 `test/` sites; the memory-core `util.mjs` is the
+   staging point). This pokes a private guard field and then makes the forbidden external `initAsync()`
+   call — it only "works" *because* the guards exist.
+
+The result is a coupled knot: the guards cannot be deleted while the reach-in depends on them, and the
+reach-in cannot migrate while `ready()` has no way to express "run init again" (its promise is already
+resolved). #15033 cut the first thread by removing every external *production* `initAsync()` call, so
+the guards are now dead weight in production — but only if the *test* re-init has a sanctioned home.
+
+## Decision
+
+Add a single, mechanically-fenced re-init method to `core.Base`:
+
+```
+async reInitAsync()   // Neo.core.Base
+```
+
+It **resets the ready gate** (`#readyPromise` + `#readyResolver` to a fresh unresolved pair, `isReady`
+to `false`) and **re-runs only the async-init leg** (`await initAsync(); isReady = true`), returning the
+reset ready promise. Two conditions are normative:
+
+- **C1 — mechanical fence, not documentation.** JS has no enforced `protected`. `reInitAsync()` throws
+  unless `Neo.config.unitTestMode` is true. Because this ADR also deletes the bespoke `_initPromise`
+  guards, the fence is *the replacement safety net*: with the guards gone, it is the only thing between
+  a stray re-init and a production double-init. (Precedent: `initRemote` and `Neo.mjs`'s namespace-collision
+  path already gate on `unitTestMode`.)
+- **C2 — re-run the async-init leg, not `construct()`.** `construct()` also does config wiring,
+  Instance-manager registration, and listener setup — one-time construction concerns. Re-firing them
+  risks double-registration and re-opening the #12597 cross-spec leak class. The seam re-runs `initAsync`
+  only. In `unitTestMode`, `initRemote()` is already a no-op, so the re-run touches no remote registration.
+
+The `_initPromise = null; initAsync()` reach-in migrates to `await X.reInitAsync()`; a first-init external
+`initAsync()` wait migrates to `await X.ready()`; the bespoke `_initPromise` guards are deleted; and a
+repo-wide lint forbids the external-`initAsync` and `_initPromise`-reach-in patterns in both trees.
+
+## Rationale
+
+The elimination is a hard-constraint argument, not a preference:
+
+- **A test-util-only seam is impossible.** `#readyPromise` is a true `#private` field; nothing outside
+  the class can reset it. The re-init must live where the private state lives — `core.Base`.
+- **A real `destroy()` → re-create path is disproportionate.** `destroy()` unregisters from the Instance
+  manager but never frees the class-namespace slot; `setupClass` returns the existing namespace on
+  re-entry, and singleton modules export the *instance*. Re-creating a singleton is class-system surgery
+  far beyond this need.
+- **So Candidate 1 (a `core.Base` re-init) is the only proportionate shape** — reframed as a legitimate
+  lifecycle *capability* (a singleton can be re-initialized), with tests the primary consumer, not the
+  justification.
+
+## Consequences
+
+- `isReady` / `#readyPromise` / `ready()` become the single source of truth for "initialized"; the
+  parallel `_initPromise` truth is gone.
+- The seam is verifiable in isolation and is the exact behavior the ~86 migrated consumers exercise.
+- The migration is **spec-green-critical**: it must hold under `--workers=1` *and* default parallelism,
+  the two modes that expose the cross-spec leak — a guard deletion that quietly changes re-init behavior
+  would reopen #12597. GraphService is the coupled case: its guard blocks re-init on `this.db`, so its
+  deletion must restructure `initAsync` to run its init directly.
+- Any *future* singleton that thinks it needs a bespoke idempotency guard should instead rely on
+  `isReady`/`ready()` and, for tests, `reInitAsync()`. New `_initPromise` fields are an anti-pattern the
+  lint rejects.

--- a/learn/agentos/decisions/0037-singleton-init-ready-reinit-contract.md
+++ b/learn/agentos/decisions/0037-singleton-init-ready-reinit-contract.md
@@ -51,7 +51,7 @@ async reInitAsync()   // Neo.core.Base
 
 It **resets the ready gate** (`#readyPromise` + `#readyResolver` to a fresh unresolved pair, `isReady`
 to `false`) and **re-runs only the async-init leg** (`await initAsync(); isReady = true`), returning the
-reset ready promise. Two conditions are normative:
+reset ready promise. Three conditions are normative:
 
 - **C1 — mechanical fence, not documentation.** JS has no enforced `protected`. `reInitAsync()` throws
   unless `Neo.config.unitTestMode` is true. Because this ADR also deletes the bespoke `_initPromise`
@@ -62,6 +62,14 @@ reset ready promise. Two conditions are normative:
   Instance-manager registration, and listener setup — one-time construction concerns. Re-firing them
   risks double-registration and re-opening the #12597 cross-spec leak class. The seam re-runs `initAsync`
   only. In `unitTestMode`, `initRemote()` is already a no-op, so the re-run touches no remote registration.
+- **C3 — a bounded state machine, not an unrestricted second `initAsync()`** (added after @neo-gpt's
+  early-architecture review on PR #15554, whose exact-head probes falsified the unspoken assumptions). The
+  seam admits ONLY a live singleton — it throws for an ordinary or destroyed/destroying instance, and
+  before the FIRST init has ever settled (a later failed re-init still counts as ever-initialized and may
+  recover). It COALESCES a concurrent re-init onto the in-flight one (single-flight — the async leg never
+  runs twice at once). And it settles the reset `ready()` promise on both success AND `initAsync()`
+  failure, so `ready()` observers are never left pending forever. Without it, the public method
+  mechanically permits a broader, less deterministic state space than the singleton-only contract claims.
 
 The `_initPromise = null; initAsync()` reach-in migrates to `await X.reInitAsync()`; a first-init external
 `initAsync()` wait migrates to `await X.ready()`; the bespoke `_initPromise` guards are deleted; and a

--- a/learn/agentos/decisions/0037-singleton-init-ready-reinit-contract.md
+++ b/learn/agentos/decisions/0037-singleton-init-ready-reinit-contract.md
@@ -68,8 +68,11 @@ reset ready promise. Three conditions are normative:
   before the FIRST init has ever settled (a later failed re-init still counts as ever-initialized and may
   recover). It COALESCES a concurrent re-init onto the in-flight one (single-flight — the async leg never
   runs twice at once). And it settles the reset `ready()` promise on both success AND `initAsync()`
-  failure, so `ready()` observers are never left pending forever. Without it, the public method
-  mechanically permits a broader, less deterministic state space than the singleton-only contract claims.
+  failure — `ready()` observers always receive the outcome, and the failure rejection is additionally
+  marked *internally observed* so a caller that consumes only `reInitAsync()` (no `ready()` observer)
+  stays process-clean (no `unhandledRejection`), without changing what `ready()` returns. Without this,
+  the public method mechanically permits a broader, less deterministic state space than the singleton-only
+  contract claims.
 
 The `_initPromise = null; initAsync()` reach-in migrates to `await X.reInitAsync()`; a first-init external
 `initAsync()` wait migrates to `await X.ready()`; the bespoke `_initPromise` guards are deleted; and a

--- a/src/core/Base.mjs
+++ b/src/core/Base.mjs
@@ -965,6 +965,48 @@ class Base {
     }
 
     /**
+     * @summary Re-runs the async-init leg of an already-initialized instance, resetting the ready gate.
+     *
+     * **[unitTestMode-ONLY SEAM]** This is the sanctioned replacement for the private
+     * `instance._initPromise = null; await instance.initAsync()` reach-in that specs used to re-initialize
+     * singletons between test cases. It exists ONLY so singleton re-initialization is expressible without
+     * touching private state, and it is **fenced**: calling it outside `Neo.config.unitTestMode` throws,
+     * because re-running `initAsync()` in production is the exact double-init this framework forbids (see
+     * {@link Neo.core.Base#initAsync}'s warning). This fence is what REPLACES the bespoke `_initPromise`
+     * idempotency guards — with the guards gone, the fence is the only thing between a stray re-init and a
+     * production double-init.
+     *
+     * It re-runs ONLY the async-init leg: it resets `#readyPromise` + `isReady` and re-invokes
+     * `initAsync()`. It deliberately does NOT re-run `construct()` — no config re-wiring, no
+     * Instance-manager re-registration, no listener re-binding — those are one-time construction concerns,
+     * and re-firing them would risk the very cross-spec leak class this seam exists to retire. In
+     * `unitTestMode`, `initRemote()` is a no-op ({@link Neo.core.Base#initRemote} guards on it), so the
+     * re-run touches no remote registration.
+     *
+     * @returns {Promise<void>} the reset ready promise — resolves when the re-init completes
+     * @see Neo.core.Base#ready
+     */
+    async reInitAsync() {
+        if (!Neo.config.unitTestMode) {
+            throw new Error(`Neo.core.Base#reInitAsync() is a unitTestMode-only seam — re-running initAsync() in production is a fatal double-init: ${this.className}`)
+        }
+
+        let me = this;
+
+        // Reset the ready gate to its pre-init state first, so `ready()` consumers await THIS re-init...
+        me.#readyPromise = new Promise(resolve => {
+            me.#readyResolver = resolve
+        });
+        me.isReady = false;
+
+        // ...then re-run only the async-init leg. `afterSetIsReady` resolves the new promise + fires `ready`.
+        await me.initAsync();
+        me.isReady = true;
+
+        return me.#readyPromise
+    }
+
+    /**
      * Returns a promise that resolves when the remote methods are registered.
      * @returns {Promise<void>}
      */

--- a/src/core/Base.mjs
+++ b/src/core/Base.mjs
@@ -1063,6 +1063,11 @@ class Base {
             return me.#readyPromise
         } catch (error) {
             readyReject(error);
+            // Mark the rejected ready gate as INTERNALLY observed: a caller that consumes only
+            // reInitAsync() (no `ready()` observer) must not trigger a process-level unhandledRejection.
+            // This no-op handler does NOT change the promise `ready()` returns — future `ready()` callers
+            // still receive `error` from the same `#readyPromise`.
+            me.#readyPromise.catch(() => {});
             throw error
         } finally {
             me.#reInitPromise = null

--- a/src/core/Base.mjs
+++ b/src/core/Base.mjs
@@ -216,6 +216,21 @@ class Base {
      */
     #readyResolver = null
     /**
+     * Single-flight guard for {@link Neo.core.Base#reInitAsync}: the in-flight re-init promise, or null.
+     * A concurrent `reInitAsync()` coalesces onto this instead of running the async-init leg a second time.
+     * @member {Promise<void>|null} #reInitPromise
+     * @private
+     */
+    #reInitPromise = null
+    /**
+     * True once the initial async init has completed at least once (the first `isReady` → true). It
+     * distinguishes "never initialized" (reInitAsync rejects) from "was ready, a later re-init failed"
+     * (reInitAsync recovers).
+     * @member {Boolean} #everReady=false
+     * @private
+     */
+    #everReady = false
+    /**
      * A promise that resolves when the remote methods are registered.
      * @member {Promise<void>|null} #remotesReadyPromise
      * @private
@@ -358,6 +373,7 @@ class Base {
         if (value) {
             let me = this;
 
+            me.#everReady = true;
             me.#readyResolver?.();
 
             // We can only fire the event in case the Observable mixin is included.
@@ -983,27 +999,74 @@ class Base {
      * `unitTestMode`, `initRemote()` is a no-op ({@link Neo.core.Base#initRemote} guards on it), so the
      * re-run touches no remote registration.
      *
-     * @returns {Promise<void>} the reset ready promise — resolves when the re-init completes
+     * It is a small state machine, not an unrestricted second `initAsync()`: it admits ONLY a live
+     * singleton (throws for ordinary or destroyed/destroying instances and before the initial init
+     * settles), COALESCES a concurrent re-init onto the in-flight one (single-flight — the async leg never
+     * runs twice at once), and settles the reset `ready()` promise on both success AND `initAsync()`
+     * failure, so observers are never left pending forever.
+     *
+     * @returns {Promise<void>} the reset ready promise — resolves when the re-init completes, rejects if `initAsync()` does
      * @see Neo.core.Base#ready
      */
     async reInitAsync() {
-        if (!Neo.config.unitTestMode) {
-            throw new Error(`Neo.core.Base#reInitAsync() is a unitTestMode-only seam — re-running initAsync() in production is a fatal double-init: ${this.className}`)
-        }
-
         let me = this;
 
-        // Reset the ready gate to its pre-init state first, so `ready()` consumers await THIS re-init...
-        me.#readyPromise = new Promise(resolve => {
-            me.#readyResolver = resolve
+        if (!Neo.config.unitTestMode) {
+            throw new Error(`Neo.core.Base#reInitAsync() is a unitTestMode-only seam — re-running initAsync() in production is a fatal double-init: ${me.className}`)
+        }
+        // Singleton-only: the reach-in this replaces only ever targeted process-singletons. An ordinary
+        // instance re-running its async leg has no test-isolation meaning and would double its side effects.
+        if (me.singleton !== true) {
+            throw new Error(`Neo.core.Base#reInitAsync() is singleton-only — ${me.className} is not a singleton`)
+        }
+        if (me.isDestroying || me.isDestroyed) {
+            throw new Error(`Neo.core.Base#reInitAsync() on a destroyed/destroying instance: ${me.className}`)
+        }
+        // Single-flight: a concurrent re-init COALESCES onto the in-flight one, so the async-init leg
+        // (the "fatal" double-init) never runs twice at once.
+        if (me.#reInitPromise) {
+            return me.#reInitPromise
+        }
+        // Re-init only means anything AFTER the FIRST init settled (even if a later re-init failed);
+        // before that first settle, `ready()` is the wait.
+        if (!me.#everReady) {
+            throw new Error(`Neo.core.Base#reInitAsync() before the initial init completed — await ready() first: ${me.className}`)
+        }
+
+        me.#reInitPromise = me.#runReInitAsync();
+        return me.#reInitPromise
+    }
+
+    /**
+     * @summary The single-flight body of {@link Neo.core.Base#reInitAsync}.
+     *
+     * Resets the ready gate capturing BOTH resolve + reject, then re-runs the async-init leg. The reset
+     * `ready()` promise settles on success (via `isReady`→`afterSetIsReady`) AND on failure (rejected here),
+     * so `ready()` observers are never stranded pending forever when `initAsync()` rejects.
+     * @returns {Promise<void>}
+     * @private
+     */
+    async #runReInitAsync() {
+        let me = this,
+            readyReject;
+
+        me.#readyPromise = new Promise((resolve, reject) => {
+            me.#readyResolver = resolve;
+            readyReject       = reject
         });
         me.isReady = false;
 
-        // ...then re-run only the async-init leg. `afterSetIsReady` resolves the new promise + fires `ready`.
-        await me.initAsync();
-        me.isReady = true;
-
-        return me.#readyPromise
+        try {
+            // re-run only the async-init leg. `afterSetIsReady` resolves the new promise + fires `ready`.
+            await me.initAsync();
+            me.isReady = true;
+            return me.#readyPromise
+        } catch (error) {
+            readyReject(error);
+            throw error
+        } finally {
+            me.#reInitPromise = null
+        }
     }
 
     /**

--- a/test/playwright/unit/ai/agent/Librarian.spec.mjs
+++ b/test/playwright/unit/ai/agent/Librarian.spec.mjs
@@ -49,7 +49,7 @@ test.describe('Librarian Sub-Agent Orchestration', () => {
             servers: []
         });
 
-        await primaryAgent.initAsync();
+        await primaryAgent.ready();
 
         // We wrap the delegate method to verify it was executed correctly natively
         let delegateCalled      = false;
@@ -67,9 +67,9 @@ test.describe('Librarian Sub-Agent Orchestration', () => {
         // Since delegate_task is now injected natively into the Loop's tools array,
         // we can simply instruct the model to use the tool, and it will trigger it natively.
         const event = {
-            type: 'user:input',
+            type    : 'user:input',
             priority: 'high',
-            data: 'You must research the exact architectural purpose of Neo.component.Base. You do not have the context. Delegate this to the "librarian" sub-agent using the delegate_task tool. Once you get the result, formulate your final answer. Please include specific details retrieved from the architectural context.'
+            data    : 'You must research the exact architectural purpose of Neo.component.Base. You do not have the context. Delegate this to the "librarian" sub-agent using the delegate_task tool. Once you get the result, formulate your final answer. Please include specific details retrieved from the architectural context.'
         };
 
         try {

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamService.spec.mjs
@@ -127,7 +127,7 @@ test.describe('Neo.ai.services.memory-core.DreamService', () => {
         KBRecorderService      = (await import('../../../../../../../ai/services/knowledge-base/KBRecorderService.mjs')).default;
         logger                 = (await import('../../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
 
-        if (!SystemLifecycleService._initPromise) { await SystemLifecycleService.initAsync(); } else { await SystemLifecycleService.ready(); }
+        await SystemLifecycleService.ready();
         await KBRecorderService.ready();
 
         hadNlActionLog = Boolean(GraphService.db.storage?.db?.prepare(

--- a/test/playwright/unit/ai/daemons/orchestrator/services/DreamServiceGoldenPath.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/services/DreamServiceGoldenPath.spec.mjs
@@ -41,7 +41,7 @@ test.describe('DreamService Golden Path', () => {
             content: JSON.stringify({strategic_brief: 'Bounded Dream Golden Path synthesis.'})
         });
 
-        if (!SystemLifecycleService._initPromise) { await SystemLifecycleService.initAsync(); } else { await SystemLifecycleService.ready(); }
+        await SystemLifecycleService.ready();
 
         // A prior spec can clear the process-lifetime graph without re-running Base's one-shot
         // readiness promise. Seed this test's required system fixture explicitly; never destroy and

--- a/test/playwright/unit/ai/graph/Database.spec.mjs
+++ b/test/playwright/unit/ai/graph/Database.spec.mjs
@@ -210,7 +210,7 @@ test.describe('Neo.ai.graph.Database', () => {
         if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 
         let storage = Neo.create(SQLite, { dbPath });
-        await storage.initAsync();
+        await storage.ready();
 
         let persistentDb = Neo.create(Database, {
             id     : 'sqlite-graph-test',
@@ -228,7 +228,7 @@ test.describe('Neo.ai.graph.Database', () => {
         persistentDb.destroy();
 
         let storageReload = Neo.create(SQLite, { dbPath });
-        await storageReload.initAsync();
+        await storageReload.ready();
 
         let reloadDb = Neo.create(Database, {
             id     : 'sqlite-graph-reload',
@@ -254,7 +254,7 @@ test.describe('Neo.ai.graph.Database', () => {
 
     test('SQLite storage rejects invalid node ids before persistence (#11698)', async () => {
         let storage = Neo.create(SQLite, { dbPath });
-        await storage.initAsync();
+        await storage.ready();
 
         try {
             expect(() => storage.addNodes([{ id: null, label: 'Broken', properties: {} }])).toThrow(/non-empty string id/);
@@ -266,7 +266,7 @@ test.describe('Neo.ai.graph.Database', () => {
 
     test('SQLite conditional deletion rejects non-dotted marker paths', async () => {
         let storage = Neo.create(SQLite, {dbPath});
-        await storage.initAsync();
+        await storage.ready();
 
         try {
             expect(() => storage.removeNodeIfUnreferenced('cleanup-candidate', {
@@ -286,7 +286,7 @@ test.describe('Neo.ai.graph.Database', () => {
         seedLegacyGraphFile();
 
         let storage = Neo.create(SQLite, { dbPath });
-        await storage.initAsync();
+        await storage.ready();
 
         try {
             expect(storage.db.prepare('SELECT COUNT(*) as c FROM Nodes').get().c).toBe(2);
@@ -323,7 +323,7 @@ test.describe('Neo.ai.graph.Database', () => {
         }
 
         const storage = Neo.create(SQLite, {dbPath});
-        await storage.initAsync();
+        await storage.ready();
 
         try {
             const columns = storage.db.prepare('PRAGMA table_info(GraphLog)').all().map(column => column.name);
@@ -419,7 +419,7 @@ test.describe('Neo.ai.graph.Database', () => {
         if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 
         let storage = Neo.create(SQLite, { dbPath });
-        await storage.initAsync();
+        await storage.ready();
 
         // The pragma must be ON for the schema-declared `Edges` ON DELETE CASCADE to fire.
         // SQLite default is OFF; explicit init pragma is the only enable path per-connection.
@@ -447,7 +447,7 @@ test.describe('Neo.ai.graph.Database', () => {
         if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 
         let storage = Neo.create(SQLite, { dbPath });
-        await storage.initAsync();
+        await storage.ready();
 
         // Mirror of the source-side test. The schema declares both source AND target FKs with
         // ON DELETE CASCADE; this test asserts the target-side cascade fires equivalently.
@@ -474,7 +474,7 @@ test.describe('Neo.ai.graph.Database', () => {
         if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 
         let storage = Neo.create(SQLite, { dbPath });
-        await storage.initAsync();
+        await storage.ready();
 
         let dbTransaction = Neo.create(Database, {
             id     : 'sqlite-graph-transcation',
@@ -498,7 +498,7 @@ test.describe('Neo.ai.graph.Database', () => {
         dbTransaction.destroy();
 
         let storageReload = Neo.create(SQLite, { dbPath });
-        await storageReload.initAsync();
+        await storageReload.ready();
 
         let reloadDb = Neo.create(Database, {
             id     : 'sqlite-graph-txn-reload',
@@ -654,7 +654,7 @@ test.describe('Neo.ai.graph.Database', () => {
         if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 
         let storagePrimary = Neo.create(SQLite, { dbPath });
-        await storagePrimary.initAsync();
+        await storagePrimary.ready();
         await storagePrimary.load();
         let dbPrimary = Neo.create(Database, { id: 'cache-p', storage: storagePrimary });
 
@@ -664,7 +664,7 @@ test.describe('Neo.ai.graph.Database', () => {
 
         // Spin up second standalone Neo Database instance mimicking another Node.js App Worker process securely!
         let storageSecondary = Neo.create(SQLite, { dbPath });
-        await storageSecondary.initAsync();
+        await storageSecondary.ready();
         let dbSecondary = Neo.create(Database, { id: 'cache-s', storage: storageSecondary });
         await storageSecondary.load();
 
@@ -698,14 +698,14 @@ test.describe('Neo.ai.graph.Database', () => {
         if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 
         let storageFresh = Neo.create(SQLite, { dbPath });
-        await storageFresh.initAsync();
+        await storageFresh.ready();
         let dbFresh = Neo.create(Database, { id: 'cache-fresh', storage: storageFresh });
         await storageFresh.load(); // DB empty -> lastSyncId = 0
 
         expect(dbFresh.lastSyncId).toBe(0);
 
         let storageOther = Neo.create(SQLite, { dbPath });
-        await storageOther.initAsync();
+        await storageOther.ready();
         let dbOther = Neo.create(Database, { id: 'cache-other', storage: storageOther });
         await storageOther.load();
 
@@ -723,7 +723,7 @@ test.describe('Neo.ai.graph.Database', () => {
         if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
 
         let storage = Neo.create(SQLite, { dbPath });
-        await storage.initAsync();
+        await storage.ready();
         let db = Neo.create(Database, { id: 'bug-b', storage });
         await storage.load();
 
@@ -740,13 +740,13 @@ test.describe('Neo.ai.graph.Database', () => {
 
         // Setup Primary instance (Agent A)
         let storageA = Neo.create(SQLite, { dbPath });
-        await storageA.initAsync();
+        await storageA.ready();
         let dbA = Neo.create(Database, { id: 'cache-a', storage: storageA });
         await storageA.load();
 
         // Setup Secondary instance (Agent B)
         let storageB = Neo.create(SQLite, { dbPath });
-        await storageB.initAsync();
+        await storageB.ready();
         let dbB = Neo.create(Database, { id: 'cache-b', storage: storageB });
         await storageB.load();
 

--- a/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/GoldenPathSynthesizer.spec.mjs
@@ -109,7 +109,7 @@ test.describe('Neo.ai.daemons.services.GoldenPathSynthesizer', () => {
         TextEmbeddingService = (await import('../../../../../../ai/services.mjs')).Memory_TextEmbeddingService;
         logger = (await import('../../../../../../ai/mcp/server/memory-core/logger.mjs')).default;
 
-        if (!SystemLifecycleService._initPromise) { await SystemLifecycleService.initAsync(); } else { await SystemLifecycleService.ready(); }
+        await SystemLifecycleService.ready();
     });
 
     test.beforeEach(() => {

--- a/test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/ConceptIngestor.spec.mjs
@@ -64,11 +64,7 @@ test.describe('Neo.ai.daemons.services.ConceptIngestor', () => {
             } catch (e) {}
         }
 
-        if (!SystemLifecycleService._initPromise) {
-            await SystemLifecycleService.initAsync();
-        } else {
-            await SystemLifecycleService.ready();
-        }
+        await SystemLifecycleService.ready();
     });
 
     test.afterAll(() => {

--- a/test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs
+++ b/test/playwright/unit/ai/services/ingestion/MemorySessionIngestor.spec.mjs
@@ -95,11 +95,7 @@ test.describe('Neo.ai.daemons.services.MemorySessionIngestor', () => {
             } catch (e) {}
         }
 
-        if (!SystemLifecycleService._initPromise) {
-            await SystemLifecycleService.initAsync();
-        } else {
-            await SystemLifecycleService.ready();
-        }
+        await SystemLifecycleService.ready();
     });
 
     test.afterAll(() => {

--- a/test/playwright/unit/ai/services/knowledge-base/KBRecorderService.ingestionMetrics.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KBRecorderService.ingestionMetrics.spec.mjs
@@ -38,7 +38,7 @@ test.describe('KBRecorderService — ingestion metrics (#11665)', () => {
 
     test.beforeAll(async () => {
         KBRecorderService = (await import('../../../../../../ai/services/knowledge-base/KBRecorderService.mjs')).default;
-        await KBRecorderService.initAsync();
+        await KBRecorderService.ready();
     });
 
     test.beforeEach(() => {

--- a/test/playwright/unit/ai/services/knowledge-base/KBRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/knowledge-base/KBRecorderService.spec.mjs
@@ -23,7 +23,7 @@ test.describe('Neo.ai.services.knowledge-base.KBRecorderService', () => {
 
     test.beforeAll(async () => {
         KBRecorderService = (await import('../../../../../../ai/services/knowledge-base/KBRecorderService.mjs')).default;
-        await KBRecorderService.initAsync();
+        await KBRecorderService.ready();
     });
 
     test.beforeEach(() => {

--- a/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/MemoryCoreRecorderService.spec.mjs
@@ -53,7 +53,7 @@ test.describe('Neo.ai.services.memory-core.MemoryCoreRecorderService', () => {
         }
 
         MemoryCoreRecorderService = (await import('../../../../../../ai/services/memory-core/MemoryCoreRecorderService.mjs')).default;
-        await MemoryCoreRecorderService.initAsync();
+        await MemoryCoreRecorderService.ready();
     });
 
     test.beforeEach(() => {

--- a/test/playwright/unit/ai/services/memory-core/SourceRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SourceRegistryService.spec.mjs
@@ -85,7 +85,7 @@ test.describe('Neo.ai.services.memory-core.SourceRegistryService', () => {
         process.env.NEO_MEMORY_DB_PATH_TEST = testDbPath;
 
         SourceRegistryService = (await import('../../../../../../ai/services/memory-core/SourceRegistryService.mjs')).default;
-        await SourceRegistryService.initAsync();
+        await SourceRegistryService.ready();
     });
 
     test.afterAll(() => {

--- a/test/playwright/unit/ai/services/memory-core/util.mjs
+++ b/test/playwright/unit/ai/services/memory-core/util.mjs
@@ -190,10 +190,6 @@ export class TestLifecycleHelper {
             GraphService._initPromise = null;
         }
 
-        if (SystemLifecycleService) {
-            await SystemLifecycleService.reInitAsync();
-        }
-
         await resetMemoryCoreLifecycle();
 
         if (fs && testDbPath) {

--- a/test/playwright/unit/ai/services/memory-core/util.mjs
+++ b/test/playwright/unit/ai/services/memory-core/util.mjs
@@ -191,7 +191,7 @@ export class TestLifecycleHelper {
         }
 
         if (SystemLifecycleService) {
-            SystemLifecycleService._initPromise = null;
+            await SystemLifecycleService.reInitAsync();
         }
 
         await resetMemoryCoreLifecycle();

--- a/test/playwright/unit/core/ReInitAsync.spec.mjs
+++ b/test/playwright/unit/core/ReInitAsync.spec.mjs
@@ -80,6 +80,28 @@ test.describe('Neo.core.Base#reInitAsync (singleton re-init seam, #15034)', () =
         expect(singleton.isReady).toBe(true)
     });
 
+    test('failure without a ready() observer stays process-clean (no unhandledRejection)', async () => {
+        await singleton.ready();
+
+        const unhandled   = [],
+              onUnhandled = reason => unhandled.push(reason);
+
+        process.on('unhandledRejection', onUnhandled);
+        try {
+            singleton.failNext = true;
+            // consume ONLY reInitAsync() — deliberately NO `ready()` observer for the rejected gate
+            await singleton.reInitAsync().catch(() => {});
+            // cross an event-loop turn so any leaked rejection would have surfaced
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(unhandled).toHaveLength(0)   // the reset #readyPromise rejection was internally observed
+        } finally {
+            process.off('unhandledRejection', onUnhandled)
+        }
+
+        await singleton.reInitAsync();   // recover for isolation
+        expect(singleton.isReady).toBe(true)
+    });
+
     test('admission: rejects a non-singleton instance, and (fenced) outside unitTestMode', async () => {
         class ReInitOrdinary extends core.Base {
             static config = {className: 'Neo.Test.ReInitOrdinary'}

--- a/test/playwright/unit/core/ReInitAsync.spec.mjs
+++ b/test/playwright/unit/core/ReInitAsync.spec.mjs
@@ -14,68 +14,91 @@ import * as core      from '../../../../src/core/_export.mjs';
 
 /**
  * @summary Verifies `Neo.core.Base#reInitAsync()` — the `unitTestMode`-only singleton re-init seam that
- * replaces the private `_initPromise = null; await initAsync()` reach-in. It must re-run ONLY the
- * async-init leg (a subclass `initAsync` side effect re-fires), reset the ready gate so `ready()` awaits the
- * re-init, and — with the bespoke `_initPromise` guards deleted — THROW outside `unitTestMode` as the
- * mechanical production double-init fence (Ada's C1). It must NOT re-run `construct()` (Ada's C2): the same
- * instance, no re-registration.
+ * replaces the private `_initPromise = null; await initAsync()` reach-in. It is a small STATE MACHINE, not
+ * an unrestricted second `initAsync()`: it admits only a live singleton, coalesces concurrent re-inits
+ * (single-flight — the async leg never runs twice at once), settles the reset `ready()` promise on both
+ * success AND `initAsync()` failure (no stranded observers), and re-runs ONLY the async-init leg (not
+ * `construct()`). Outside `unitTestMode` it throws — the mechanical replacement for the deleted
+ * `_initPromise` guards.
  */
 test.describe('Neo.core.Base#reInitAsync (singleton re-init seam, #15034)', () => {
-    class ReInitClass extends core.Base {
+    class ReInitSingleton extends core.Base {
         static config = {
-            className: 'Neo.Test.ReInitClass'
+            className: 'Neo.Test.ReInitSingleton',
+            singleton: true
         }
 
         initCount = 0
+        failNext  = false
 
         async initAsync() {
             await super.initAsync();
+            if (this.failNext) {
+                this.failNext = false;
+                throw new Error('reInit-probe-failure')
+            }
             this.initCount++
         }
     }
-    Neo.setupClass(ReInitClass);
+    const singleton = Neo.setupClass(ReInitSingleton);
 
-    test('re-runs ONLY the async-init leg and resets the ready gate', async () => {
-        const instance = Neo.create(ReInitClass);
+    test('re-runs ONLY the async-init leg and resets the ready gate (true singleton)', async () => {
+        await singleton.ready();
+        const before = singleton.initCount;
+        expect(singleton.isReady).toBe(true);
 
-        await instance.ready();
-        expect(instance.initCount).toBe(1);   // construct's async leg ran exactly once
-        expect(instance.isReady).toBe(true);
-
-        const beforeId = instance.id,
-              p        = instance.reInitAsync();
-
-        // the gate reset ran synchronously (before the first await): isReady is back to false
-        expect(instance.isReady).toBe(false);
+        const p = singleton.reInitAsync();
+        expect(singleton.isReady).toBe(false);   // the gate reset synchronously (before the first await)
 
         await p;
-        expect(instance.initCount).toBe(2);    // the async-init leg re-ran
-        expect(instance.isReady).toBe(true);   // the gate re-resolved
-        expect(instance.id).toBe(beforeId);    // construct did NOT re-run — same instance, no re-registration
-
-        await instance.ready();                // ready() reflects the completed re-init
-        expect(instance.isReady).toBe(true);
-
-        instance.destroy()
+        expect(singleton.initCount).toBe(before + 1);   // the async-init leg re-ran exactly once
+        expect(singleton.isReady).toBe(true)            // the gate re-resolved
     });
 
-    test('the fence: reInitAsync rejects outside unitTestMode (the deleted guards\' replacement)', async () => {
-        const instance = Neo.create(ReInitClass);
-        await instance.ready();
+    test('single-flight: concurrent reInitAsync calls coalesce — the async leg runs once', async () => {
+        await singleton.ready();
+        const before = singleton.initCount;
 
+        // both calls resolve to the same in-flight re-init; each async wrapper differs, so the proof of
+        // coalescing is that the async-init leg ran ONCE (initCount + 1), not twice.
+        await Promise.all([singleton.reInitAsync(), singleton.reInitAsync()]);
+
+        expect(singleton.initCount).toBe(before + 1)   // ONE re-init, not two concurrent async legs
+    });
+
+    test('failure: a rejecting initAsync settles ready() with the rejection — observers are not stranded', async () => {
+        await singleton.ready();
+
+        singleton.failNext = true;
+        await expect(singleton.reInitAsync()).rejects.toThrow(/reInit-probe-failure/);
+        // the reset ready() promise REJECTS (it does not hang) — a stranded observer would time out here
+        await expect(singleton.ready()).rejects.toThrow(/reInit-probe-failure/);
+        expect(singleton.isReady).toBe(false);
+
+        // recover for isolation: a clean re-init settles ready() again
+        await singleton.reInitAsync();
+        expect(singleton.isReady).toBe(true)
+    });
+
+    test('admission: rejects a non-singleton instance, and (fenced) outside unitTestMode', async () => {
+        class ReInitOrdinary extends core.Base {
+            static config = {className: 'Neo.Test.ReInitOrdinary'}
+        }
+        Neo.setupClass(ReInitOrdinary);
+
+        const instance = Neo.create(ReInitOrdinary);
+        await instance.ready();
+        await expect(instance.reInitAsync()).rejects.toThrow(/singleton-only/);   // ordinary instance refused
+        instance.destroy();
+
+        // the unitTestMode fence — the mechanical replacement for the deleted _initPromise guards
         const original = Neo.config.unitTestMode;
 
         Neo.config.unitTestMode = false;
         try {
-            await expect(instance.reInitAsync()).rejects.toThrow(/unitTestMode-only seam/)
+            await expect(singleton.reInitAsync()).rejects.toThrow(/unitTestMode-only/)
         } finally {
             Neo.config.unitTestMode = original
         }
-
-        // the fence threw before any reset: the instance is untouched
-        expect(instance.isReady).toBe(true);
-        expect(instance.initCount).toBe(1);
-
-        instance.destroy()
     })
 });

--- a/test/playwright/unit/core/ReInitAsync.spec.mjs
+++ b/test/playwright/unit/core/ReInitAsync.spec.mjs
@@ -1,0 +1,81 @@
+import {setup} from '../../setup.mjs';
+
+const appName = 'ReInitAsyncTest';
+
+setup({
+    appConfig: {
+        name: appName
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+/**
+ * @summary Verifies `Neo.core.Base#reInitAsync()` — the `unitTestMode`-only singleton re-init seam that
+ * replaces the private `_initPromise = null; await initAsync()` reach-in. It must re-run ONLY the
+ * async-init leg (a subclass `initAsync` side effect re-fires), reset the ready gate so `ready()` awaits the
+ * re-init, and — with the bespoke `_initPromise` guards deleted — THROW outside `unitTestMode` as the
+ * mechanical production double-init fence (Ada's C1). It must NOT re-run `construct()` (Ada's C2): the same
+ * instance, no re-registration.
+ */
+test.describe('Neo.core.Base#reInitAsync (singleton re-init seam, #15034)', () => {
+    class ReInitClass extends core.Base {
+        static config = {
+            className: 'Neo.Test.ReInitClass'
+        }
+
+        initCount = 0
+
+        async initAsync() {
+            await super.initAsync();
+            this.initCount++
+        }
+    }
+    Neo.setupClass(ReInitClass);
+
+    test('re-runs ONLY the async-init leg and resets the ready gate', async () => {
+        const instance = Neo.create(ReInitClass);
+
+        await instance.ready();
+        expect(instance.initCount).toBe(1);   // construct's async leg ran exactly once
+        expect(instance.isReady).toBe(true);
+
+        const beforeId = instance.id,
+              p        = instance.reInitAsync();
+
+        // the gate reset ran synchronously (before the first await): isReady is back to false
+        expect(instance.isReady).toBe(false);
+
+        await p;
+        expect(instance.initCount).toBe(2);    // the async-init leg re-ran
+        expect(instance.isReady).toBe(true);   // the gate re-resolved
+        expect(instance.id).toBe(beforeId);    // construct did NOT re-run — same instance, no re-registration
+
+        await instance.ready();                // ready() reflects the completed re-init
+        expect(instance.isReady).toBe(true);
+
+        instance.destroy()
+    });
+
+    test('the fence: reInitAsync rejects outside unitTestMode (the deleted guards\' replacement)', async () => {
+        const instance = Neo.create(ReInitClass);
+        await instance.ready();
+
+        const original = Neo.config.unitTestMode;
+
+        Neo.config.unitTestMode = false;
+        try {
+            await expect(instance.reInitAsync()).rejects.toThrow(/unitTestMode-only seam/)
+        } finally {
+            Neo.config.unitTestMode = original
+        }
+
+        // the fence threw before any reset: the instance is untouched
+        expect(instance.isReady).toBe(true);
+        expect(instance.initCount).toBe(1);
+
+        instance.destroy()
+    })
+});


### PR DESCRIPTION
## What

The **#15034 singleton re-init seam** — foundation + first verified migration. The reach-in migration continues *in this PR*.

Delivers:
- **The fenced `core.Base#reInitAsync` seam** (`4af399c54a`) — resets the ready gate (`#readyPromise` + `isReady`) and re-runs the **async-init leg only** (not `construct()`); **throws outside `Neo.config.unitTestMode`** — the mechanical replacement for the bespoke `_initPromise` idempotency guards this lane deletes. Design converged with @neo-opus-ada (Candidate 1 + C1 fence + C2 scope).
- **ADR 0037** (`abebf72e08`) — the singleton init/ready/re-init contract.
- **First verified reach-in migration** (`aaa19205a2`) — `cleanupGraphService`'s dead `SystemLifecycleService._initPromise = null` (a no-op — that service has no such field, so the intended lifecycle reset never happened) → `await SystemLifecycleService.reInitAsync()`, which actually re-inits it.

**WIP — not merge-ready.** Opened now so the high-blast `core.Base` seam (the riskiest change) gets early review while the mechanical migration completes. The ~73 remaining `test/` reach-ins, the bespoke-guard deletion (GraphService init-restructure), and the repo-wide lint land in this PR before it is merge-eligible.

**Evidence:**

- Seam: reset + async-leg-only re-run + same-instance (no re-registration); fence rejects outside test mode.
- Migration pattern verified: a dead non-guarded reach-in → `reInitAsync()` (intent-preserving — delete would leave the reset unimplemented).

## Test Evidence

- `test/playwright/unit/core/ReInitAsync.spec.mjs` (new) — **2/2** (re-runs the async leg + resets the gate + keeps the same instance; the fence rejects outside `unitTestMode`).
- `GraphService.spec.mjs` — **40/40 under `--workers=1`** (drives the migrated `cleanupGraphService` reset).

## Post-Merge Validation

**Not merge-ready** until the full reach-in migration + guard deletion + lint land AND the full unit suite is green under **`--workers=1` and default parallelism** — the #12597 cross-spec-leak guard the AC requires. Known coupled remainder (verified this session): `resetMemoryCoreLifecycle`→`reInitAsync` must co-migrate `ChromaManager.spec:120` (which asserts the dead reach-in's null) + `CommunityBatchAdmissionService:137` (a functional dependency); the `GraphService` reach-in needs guard-deletion + `initAsync` restructure (its `this.db` guard blocks re-init).

## Deltas

Adds `core.Base#reInitAsync` — a new `core.Base` lifecycle surface (ADR 0037). The bespoke `_initPromise` guards and the ~86 `test/` reach-ins are removed as the migration completes in this PR; `isReady`/`ready()` become the single readiness source of truth.

Resolves #15034

Authored by Grace (Claude Opus 4.8, Claude Code).
