### PR TITLE
fix(agentos): bind popup vessels to exact owner grants (#15557)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -1,23 +1,23 @@
-import Component                          from '../../../../../src/component/Base.mjs';
-import Container                          from '../../../../../src/container/Base.mjs';
-import CounterPane                        from './CounterPane.mjs';
-import DockDropIndicators                 from '../../../../../src/dashboard/DockDropIndicators.mjs';
-import DockLayoutAdapter                  from '../../../../../src/dashboard/DockLayoutAdapter.mjs';
-import DockMotionSignal                   from '../../../../../src/dashboard/DockMotionSignal.mjs';
-import DockPerspectiveStore               from '../../../../../src/dashboard/DockPerspectiveStore.mjs';
-import DockPreview                        from '../../../../../src/dashboard/DockPreview.mjs';
-import DockPreviewProducer                from '../../../../../src/dashboard/DockPreviewProducer.mjs';
-import DockProjectionReconciler           from '../../../../../src/dashboard/DockProjectionReconciler.mjs';
-import DockService                        from '../../../../../src/ai/client/DockService.mjs';
-import DockTopologyReconciler             from '../../../../../src/dashboard/DockTopologyReconciler.mjs';
-import DockZoneModel                      from '../../../../../src/dashboard/DockZoneModel.mjs';
-import InteractionService                 from '../../../../../src/ai/client/InteractionService.mjs';
-import {createDockKeyboardCommands}       from '../../../../../src/dashboard/DockKeyboardCommands.mjs';
-import {createDockTearOutHandlers}        from '../../../../../src/dashboard/DockTearOut.mjs';
-import {createDockWorkspaceSet}           from '../../../../../src/dashboard/DockWorkspaceSet.mjs';
-import TourRunner                         from '../../../../../src/ai/client/TourRunner.mjs';
+import Component                            from '../../../../../src/component/Base.mjs';
+import Container                            from '../../../../../src/container/Base.mjs';
+import CounterPane                          from './CounterPane.mjs';
+import DockDropIndicators                   from '../../../../../src/dashboard/DockDropIndicators.mjs';
+import DockLayoutAdapter                    from '../../../../../src/dashboard/DockLayoutAdapter.mjs';
+import DockMotionSignal                     from '../../../../../src/dashboard/DockMotionSignal.mjs';
+import DockPerspectiveStore                 from '../../../../../src/dashboard/DockPerspectiveStore.mjs';
+import DockPreview                          from '../../../../../src/dashboard/DockPreview.mjs';
+import DockPreviewProducer                  from '../../../../../src/dashboard/DockPreviewProducer.mjs';
+import DockProjectionReconciler             from '../../../../../src/dashboard/DockProjectionReconciler.mjs';
+import DockService                          from '../../../../../src/ai/client/DockService.mjs';
+import DockTopologyReconciler               from '../../../../../src/dashboard/DockTopologyReconciler.mjs';
+import DockZoneModel                        from '../../../../../src/dashboard/DockZoneModel.mjs';
+import InteractionService                   from '../../../../../src/ai/client/InteractionService.mjs';
+import {createDockKeyboardCommands}         from '../../../../../src/dashboard/DockKeyboardCommands.mjs';
+import {createDockTearOutHandlers}          from '../../../../../src/dashboard/DockTearOut.mjs';
+import {createDockWorkspaceSet}             from '../../../../../src/dashboard/DockWorkspaceSet.mjs';
+import TourRunner                           from '../../../../../src/ai/client/TourRunner.mjs';
 import {PREVIEW_SCHEMA, previewToOperation} from '../../../../../src/dashboard/dockPreviewContract.mjs';
-import {demoBTourScript, initialDocument} from '../../../tour/demoBPerspectives.mjs';
+import {demoBTourScript, initialDocument}   from '../../../tour/demoBPerspectives.mjs';
 import '../../../../../src/button/Base.mjs';   // registers the `button` ntype the bars compose
 import '../../../../../src/tab/Container.mjs'; // registers the `tab-container` ntype the projection emits
 import '../../../../../src/toolbar/Base.mjs';  // registers the `toolbar` ntype the bars use
@@ -256,6 +256,22 @@ class DemoBWorkspace extends Container {
      * @protected
      */
     tearOutConnects = {}
+    /**
+     * Product-semantic owner grants for popup vessels. The merged native-window identity spine
+     * proves the exact physical child; this map binds that child to one product flow + item +
+     * generation without trusting URL shape, item id, arrival order, or an existing pane entry.
+     * Keys are `${flow}:${itemId}` and values are `{generation, token}`.
+     * @member {Map} vesselOwnerGrants
+     * @protected
+     */
+    vesselOwnerGrants = new Map()
+    /**
+     * Monotonic product-vessel generation. A new admission for the same flow/item replaces the
+     * prior grant, so reload, replay, and same-name reuse cannot recover semantic ownership.
+     * @member {Number} vesselOwnerGrantGeneration=0
+     * @protected
+     */
+    vesselOwnerGrantGeneration = 0
     /**
      * Exact-position return truth: `tearOutPlacements[itemId] = {tabsNodeId, index}`, captured
      * at the detach terminal BEFORE the commit removes the item from the tree (`addTab` appends
@@ -1408,20 +1424,28 @@ class DemoBWorkspace extends Container {
             me.crossWindowStageReject  = reject
         });
 
-        let winData = await Neo.Main.getWindowData({windowId: me.windowId}),
-            left    = winData.screenLeft > 660
-                ? winData.screenLeft - 640
-                : winData.screenLeft + (winData.innerWidth || 1280) + 40,
-            top     = winData.screenTop;
+        let ownerGrant = me.createVesselOwnerGrant('workspace-target', workspaceId);
 
         try {
-            await Neo.Main.windowOpen({
-                url           : `./index.html?workspaceId=${workspaceId}&hostId=${me.id}`,
-                windowFeatures: `height=520,width=600,left=${left},top=${top}`,
-                windowId      : me.windowId,
-                windowName    : 'demo-b-cross-window'
-            })
+            let winData = await Neo.Main.getWindowData({windowId: me.windowId}),
+                left    = winData.screenLeft > 660
+                    ? winData.screenLeft - 640
+                    : winData.screenLeft + (winData.innerWidth || 1280) + 40,
+                top     = winData.screenTop,
+                opened  = await Neo.Main.windowOpen({
+                    url           : `./index.html?workspaceId=${workspaceId}&hostId=${me.id}`
+                        + `&vesselFlow=workspace-target&vesselGrant=${ownerGrant.token}`
+                        + `&vesselGeneration=${ownerGrant.generation}`,
+                    windowFeatures: `height=520,width=600,left=${left},top=${top}`,
+                    windowId      : me.windowId,
+                    windowName    : 'demo-b-cross-window'
+                });
+
+            if (opened === false) {
+                throw new Error('cross-window popup blocked')
+            }
         } catch (error) {
+            me.revokeVesselOwnerGrant('workspace-target', workspaceId);
             me.crossWindowStageReject?.(error);
             me.crossWindowStagePromise = null;
             me.crossWindowStageResolve = null;
@@ -1436,6 +1460,7 @@ class DemoBWorkspace extends Container {
         try {
             return await Promise.race([me.crossWindowStagePromise, timeout])
         } catch (error) {
+            me.revokeVesselOwnerGrant('workspace-target', workspaceId);
             me.crossWindowStagePromise = null;
             throw error
         }
@@ -2767,35 +2792,114 @@ class DemoBWorkspace extends Container {
         let url         = await Neo.Main.getByPath({path: 'document.URL', windowId}),
             params      = new URL(url).searchParams,
             workspaceId = params.get('workspaceId'),
-            itemId      = params.get('popout');
+            itemId      = params.get('popout'),
+            flow        = params.get('vesselFlow'),
+            grant       = params.get('vesselGrant'),
+            generation  = Number(params.get('vesselGeneration'));
 
         if (params.get('hostId') !== me.id) return;
 
         if (workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID) {
+            if (flow !== 'workspace-target') return;
+
+            if (!me.consumeVesselOwnerGrant({
+                data,
+                flow,
+                generation,
+                grant,
+                itemId: workspaceId,
+                windowId
+            })) return;
+
             await me.mountCrossWindowTarget(app, windowId);
             return
         }
 
         if (!itemId) return;
+        if (flow !== 'click-popout' && flow !== 'tear-out') return;
 
-        // Tear-out vessels connect through the SAME ?popout= shell but live in their own
-        // bookkeeping: post-terminal (tearOutPanes written) → adopt now; mid-gesture → record
-        // the connect for the terminal to consume (the race runs both orders). Either way the
-        // click-pop-out flow below never touches a tear-out window (no detachedPanes entry).
-        if (me.tearOutPanes[itemId]) {
-            me.reparentTearOutPane(itemId, {windowId});
+        if (!me.consumeVesselOwnerGrant({data, flow, generation, grant, itemId, windowId})) return;
+
+        // Click-popout creates its entry before windowOpen; tear-out deliberately does not.
+        // Keeping those births separate is load-bearing: an ungranted connect stays inert rather
+        // than becoming stray tearOutConnects state or stealing an existing detachedPanes entry.
+        if (flow === 'tear-out') {
+            if (me.tearOutPanes[itemId]) {
+                me.reparentTearOutPane(itemId, {windowId})
+            } else {
+                me.tearOutConnects[itemId] = {windowId}
+            }
             return
         }
 
         let entry = me.detachedPanes[itemId],
             pane  = me.paneCache[itemId];
 
-        if (entry && pane && me.popupDocument?.items?.[itemId]) {
+        if (flow === 'click-popout' && entry && pane && me.popupDocument?.items?.[itemId]) {
             entry.windowId = windowId;
             app.mainView.add(pane)
-        } else if (!entry) {
-            me.tearOutConnects[itemId] = {windowId}
         }
+    }
+
+    /**
+     * @summary Mints one product-semantic vessel grant and supersedes the prior generation for
+     * the same flow/item. The token is a bearer hint only; {@link #consumeVesselOwnerGrant}
+     * additionally requires the opener-minted native route for the exact connected child.
+     * @param {String} flow `workspace-target`, `click-popout`, or `tear-out`.
+     * @param {String} itemId
+     * @returns {{generation: Number, token: String}}
+     * @protected
+     */
+    createVesselOwnerGrant(flow, itemId) {
+        let grant = {
+            generation: ++this.vesselOwnerGrantGeneration,
+            token     : crypto.randomUUID()
+        };
+
+        this.vesselOwnerGrants.set(`${flow}:${itemId}`, grant);
+
+        return grant
+    }
+
+    /**
+     * @summary Consumes one exact product grant after validating the generic native route.
+     * Consumption precedes every reparent, making replay and same-name reuse inert.
+     * @param {Object} data
+     * @param {Object} data.windowData
+     * @param {String} flow
+     * @param {Number} generation
+     * @param {String} grant
+     * @param {String} itemId
+     * @param {String} windowId
+     * @returns {Boolean}
+     * @protected
+     */
+    consumeVesselOwnerGrant({data, flow, generation, grant, itemId, windowId}) {
+        let me     = this,
+            key    = `${flow}:${itemId}`,
+            stored = me.vesselOwnerGrants.get(key),
+            route  = data.windowData?.nativeRoute;
+
+        if (
+            !stored || !grant || stored.token !== grant || stored.generation !== generation ||
+            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId || route.targetWindowId !== windowId
+        ) {
+            return false
+        }
+
+        me.vesselOwnerGrants.delete(key);
+
+        return true
+    }
+
+    /**
+     * @summary Revokes the current semantic grant for one flow/item admission.
+     * @param {String} flow
+     * @param {String} itemId
+     * @protected
+     */
+    revokeVesselOwnerGrant(flow, itemId) {
+        this.vesselOwnerGrants.delete(`${flow}:${itemId}`)
     }
 
     /**
@@ -2964,6 +3068,8 @@ class DemoBWorkspace extends Container {
             return {detached: false, errors: result.errors}
         }
 
+        let ownerGrant = me.createVesselOwnerGrant('click-popout', itemId);
+
         me.detachedPanes[itemId] = {tabsNodeId: home, windowId: null};
 
         // park BEFORE the re-projection tears the old tree down
@@ -2975,17 +3081,24 @@ class DemoBWorkspace extends Container {
         try {
             let winData = await Neo.Main.getWindowData({windowId: me.windowId});
 
-            await Neo.Main.windowOpen({
-                url           : `./index.html?popout=${itemId}&hostId=${me.id}`,
+            let opened = await Neo.Main.windowOpen({
+                url           : `./index.html?popout=${itemId}&hostId=${me.id}`
+                    + `&vesselFlow=click-popout&vesselGrant=${ownerGrant.token}`
+                    + `&vesselGeneration=${ownerGrant.generation}`,
                 windowFeatures: `height=420,width=560,left=${winData.screenLeft + 120},top=${winData.screenTop + 120}`,
                 windowId      : me.windowId,
                 windowName    : `demo-b-${itemId}`
-            })
+            });
+
+            if (opened === false) {
+                throw new Error('popup blocked')
+            }
         } catch (error) {
             // The vessel failed after the pure transfer result was staged. Restore BOTH pristine
             // inputs: the source's old home may have normalized away after losing its sole item,
             // so replaying another placement is weaker than the transfer's commit-or-neither truth.
             delete me.detachedPanes[itemId];
+            me.revokeVesselOwnerGrant('click-popout', itemId);
             me.popupDocument = popupBefore;
             me.onDockZoneDocumentChange(sourceBefore);
 
@@ -3295,7 +3408,8 @@ class DemoBWorkspace extends Container {
     async openTearOutVessel({itemId, proxyRect}) {
         let me         = this,
             {windowId} = me,
-            windowName = `tearout-${itemId}`;
+            windowName = `tearout-${itemId}`,
+            ownerGrant = me.createVesselOwnerGrant('tear-out', itemId);
 
         try {
             let winData = await Neo.Main.getWindowData({windowId}),
@@ -3304,16 +3418,22 @@ class DemoBWorkspace extends Container {
                 left    = Math.round((proxyRect?.x ?? 120) + winData.screenLeft),
                 top     = Math.round((proxyRect?.y ?? 120) + (winData.outerHeight - winData.innerHeight) + winData.screenTop),
                 opened  = await Neo.Main.windowOpen({
-                    url           : `./index.html?popout=${itemId}&hostId=${me.id}`,
+                    url           : `./index.html?popout=${itemId}&hostId=${me.id}`
+                        + `&vesselFlow=tear-out&vesselGrant=${ownerGrant.token}`
+                        + `&vesselGeneration=${ownerGrant.generation}`,
                     windowFeatures: `height=${height},left=${left},top=${top},width=${width}`,
                     windowId,
                     windowName
                 });
 
-            if (opened === false) return null;
+            if (opened === false) {
+                me.revokeVesselOwnerGrant('tear-out', itemId);
+                return null
+            }
 
             return {popupHeight: height, popupWidth: width, windowName}
         } catch (error) {
+            me.revokeVesselOwnerGrant('tear-out', itemId);
             return null
         }
     }
@@ -3333,6 +3453,7 @@ class DemoBWorkspace extends Container {
         let me = this;
 
         delete me.tearOutConnects[itemId];
+        me.revokeVesselOwnerGrant('tear-out', itemId);
 
         try {
             await Neo.Main.windowClose({names: [windowName], windowId: me.windowId})
@@ -3415,6 +3536,7 @@ class DemoBWorkspace extends Container {
             return {errors: result.errors, reattached: false}
         }
 
+        me.revokeVesselOwnerGrant('click-popout', itemId);
         delete me.detachedPanes[itemId];
 
         // Commit model ownership before awaiting the vessel. The deleted bookkeeping entry is
@@ -3687,6 +3809,7 @@ class DemoBWorkspace extends Container {
         me.crossWindowHosts.clear();
         me.crossWindowGeometry.clear();
         me.workspaceProjectionRequests.clear();
+        me.vesselOwnerGrants.clear();
         me.crossWindowStagePromise   = null;
         me.crossWindowStageResolve   = null;
         me.crossWindowStageReject    = null;

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
@@ -58,6 +58,63 @@ function installWindowVessel({openError = null, closeError = null} = {}) {
 }
 
 /**
+ * @summary Installs exact child-window connection seams for vessel-owner tests.
+ * Each registered child carries the production-shaped native route minted by its opener;
+ * URL parameters alone therefore never stand in for physical-window authority.
+ * @param {Neo.component.Base} workspace
+ * @returns {{addedTo: Function, connect: Function, restore: Function}}
+ */
+function installWindowConnectHarness(workspace) {
+    let previous = {
+            getByPath    : Neo.Main.getByPath,
+            getWindowData: Neo.Main.getWindowData,
+            windowOpen   : Neo.Main.windowOpen
+        },
+        windows = new Map();
+
+    Neo.Main.getByPath = async ({windowId}) => windows.get(windowId)?.url;
+    Neo.Main.getWindowData = async () => ({
+        innerHeight: 700,
+        outerHeight: 740,
+        screenLeft : 10,
+        screenTop  : 20
+    });
+
+    return {
+        addedTo(windowId) {
+            return windows.get(windowId)?.added ?? []
+        },
+
+        async connect(windowId, url) {
+            let added = [];
+
+            windows.set(windowId, {added, url: new URL(url, 'https://example.test').href});
+            Neo.apps[windowId] = {
+                mainView: {
+                    add: pane => added.push(pane)
+                }
+            };
+
+            await workspace.onWindowConnect({
+                windowData: {
+                    nativeRoute: {
+                        nativeHandleKey: `handle-${windowId}`,
+                        ownerWindowId  : workspace.windowId,
+                        targetWindowId : windowId
+                    }
+                },
+                windowId
+            })
+        },
+
+        restore() {
+            Object.assign(Neo.Main, previous);
+            windows.forEach((value, windowId) => delete Neo.apps[windowId])
+        }
+    }
+}
+
+/**
  * @summary Contract specs for the Demo-B workspace: the dock-holder contract, the live
  * perspective capture→load round-trip over the real store, pane-instance permanence across
  * re-projections, the pop-out bookkeeping guards, and the store-born switcher. The window
@@ -168,6 +225,174 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
         result = await workspace.popOutPane('workbench');
         expect(result.detached).toBe(false);
         expect(result.errors.join()).toContain('workbench')
+    });
+
+    test('a competing G1 child cannot steal a pane already owned by the workspace target', async () => {
+        const harness = installWindowConnectHarness(workspace),
+              pane    = workspace.resolvePane('workbench', initialDocument.items.workbench),
+              moved   = DockZoneModel.transferItem(
+                  workspace.dockModel,
+                  DemoBWorkspace.createPopupDocument(),
+                  {
+                      itemId: 'workbench', sourceWorkspaceId: 'demo-b-main', targetWorkspaceId: 'demo-b-popup',
+                      target: {operation: 'addTab', tabsNodeId: 'popup-tabs'}
+                  }
+              );
+
+        workspace.dockModel     = moved.sourceDocument;
+        workspace.popupDocument = moved.targetDocument;
+        workspace.detachedPanes.workbench = {
+            tabsNodeId: 'workbench-tabs',
+            windowId  : 'workspace-target',
+            windowName: 'demo-b-cross-window'
+        };
+
+        try {
+            await harness.connect(
+                'competing-g1',
+                `https://example.test/?popout=workbench&hostId=${workspace.id}`
+            );
+
+            expect(harness.addedTo('competing-g1')).toEqual([]);
+            expect(workspace.detachedPanes.workbench.windowId).toBe('workspace-target');
+            expect(workspace.paneCache.workbench).toBe(pane)
+        } finally {
+            harness.restore()
+        }
+    });
+
+    test('the workspace stage consumes one exact target grant instead of trusting its URL shape', async () => {
+        const harness = installWindowConnectHarness(workspace),
+              mounts  = [];
+        let stageUrl;
+
+        workspace.timeout = () => new Promise(() => {});
+        workspace.mountCrossWindowTarget = async (app, windowId) => {
+            mounts.push(windowId);
+            workspace.crossWindowStageResolve?.({
+                hostId: 'workspace-host', windowId, workspaceId: DemoBWorkspace.POPUP_WORKSPACE_ID
+            })
+        };
+        Neo.Main.windowOpen = async data => {
+            stageUrl = data.url;
+
+            const wrongFlowUrl = new URL(stageUrl, 'https://example.test');
+
+            wrongFlowUrl.searchParams.set('vesselFlow', 'click-popout');
+            await harness.connect('wrong-flow-child', wrongFlowUrl);
+
+            await harness.connect('workspace-child', stageUrl);
+            return true
+        };
+
+        try {
+            expect(await workspace.openCrossWindowStage()).toMatchObject({windowId: 'workspace-child'});
+
+            const params = new URL(stageUrl, 'https://example.test').searchParams;
+
+            expect(params.get('vesselFlow')).toBe('workspace-target');
+            expect(params.get('vesselGrant')).toBeTruthy();
+            expect(params.get('vesselGeneration')).toBeTruthy();
+            expect(harness.addedTo('wrong-flow-child')).toEqual([]);
+            expect(mounts).toEqual(['workspace-child']);
+
+            await harness.connect('workspace-replay', stageUrl);
+            expect(mounts).toEqual(['workspace-child'])
+        } finally {
+            harness.restore()
+        }
+    });
+
+    test('click pop-out consumes its exact owner grant once even when connect beats open settlement', async () => {
+        const harness = installWindowConnectHarness(workspace),
+              pane    = workspace.resolvePane('workbench', initialDocument.items.workbench);
+        let clickUrl;
+
+        Neo.Main.windowOpen = async data => {
+            clickUrl = data.url;
+            await harness.connect('click-child', clickUrl);
+            return true
+        };
+
+        try {
+            expect(await workspace.popOutPane('workbench')).toEqual({detached: true, errors: []});
+
+            const params = new URL(clickUrl, 'https://example.test').searchParams;
+
+            expect(params.get('vesselFlow')).toBe('click-popout');
+            expect(params.get('vesselGrant')).toBeTruthy();
+            expect(params.get('vesselGeneration')).toBeTruthy();
+            expect(harness.addedTo('click-child')).toEqual([pane]);
+            expect(workspace.detachedPanes.workbench.windowId).toBe('click-child');
+
+            await harness.connect('click-replay', clickUrl);
+
+            expect(harness.addedTo('click-replay')).toEqual([]);
+            expect(workspace.detachedPanes.workbench.windowId).toBe('click-child')
+        } finally {
+            harness.restore()
+        }
+    });
+
+    test('tear-out connect-before-terminal consumes its grant and a replay stays inert', async () => {
+        const harness = installWindowConnectHarness(workspace),
+              pane    = workspace.resolvePane('timeline', initialDocument.items.timeline);
+        let tearOutUrl;
+
+        Neo.Main.windowOpen = async data => {
+            tearOutUrl = data.url;
+            return true
+        };
+
+        try {
+            expect(await workspace.openTearOutVessel({
+                itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}
+            })).toMatchObject({windowName: 'tearout-timeline'});
+
+            const params = new URL(tearOutUrl, 'https://example.test').searchParams;
+
+            expect(params.get('vesselFlow')).toBe('tear-out');
+            expect(params.get('vesselGrant')).toBeTruthy();
+            expect(params.get('vesselGeneration')).toBeTruthy();
+
+            await harness.connect('tear-child', tearOutUrl);
+            expect(workspace.tearOutConnects.timeline).toEqual({windowId: 'tear-child'});
+
+            workspace.adoptTearOutPane('timeline');
+            expect(harness.addedTo('tear-child')).toEqual([pane]);
+            expect(workspace.tearOutPanes.timeline.windowId).toBe('tear-child');
+
+            await harness.connect('tear-replay', tearOutUrl);
+            expect(harness.addedTo('tear-replay')).toEqual([]);
+            expect(workspace.tearOutPanes.timeline.windowId).toBe('tear-child')
+        } finally {
+            harness.restore()
+        }
+    });
+
+    test('tear-out terminal-before-connect adopts only the granted child', async () => {
+        const harness = installWindowConnectHarness(workspace),
+              pane    = workspace.resolvePane('timeline', initialDocument.items.timeline);
+        let tearOutUrl;
+
+        Neo.Main.windowOpen = async data => {
+            tearOutUrl = data.url;
+            return true
+        };
+
+        try {
+            await workspace.openTearOutVessel({
+                itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}
+            });
+            workspace.adoptTearOutPane('timeline');
+
+            await harness.connect('tear-after-terminal', tearOutUrl);
+
+            expect(harness.addedTo('tear-after-terminal')).toEqual([pane]);
+            expect(workspace.tearOutPanes.timeline.windowId).toBe('tear-after-terminal')
+        } finally {
+            harness.restore()
+        }
     });
 
     test('reattachPane falls back to the first tabs node when the remembered home left the tree', async () => {


### PR DESCRIPTION
Resolves #15557
Related: #15395
Related: #15551
Related: #15514

Stops a competing popup child from stealing a live pane that already belongs to Demo B's workspace target. The three vessel flows now compose the generic native-window identity route with a one-use product-semantic grant; URL shape, item id, arrival order, existing bookkeeping, wrong flow, and replay no longer mint adoption authority.

Evidence: L2 (production-class unit contracts over the real Demo B model with exact native-route-shaped window seams) → L2 required (all close-target ACs are unit-observable). Residual: none [#15557]; the canonical headed composition rerun remains with related parents `#15395` and `#15551`.

## Deltas from ticket

- Uses the merged `#15514` native route as physical-child proof and adds only the missing product flow/item/generation join.
- Covers all three existing admissions: `workspace-target`, `click-popout`, and `tear-out`.
- Rejects flow confusion before grant consumption, so a wrong-flow child cannot burn the intended child's authority.
- Treats `windowOpen() === false` as acquisition failure for workspace-target and click-popout, matching ADR 0029's Boolean admission contract.
- Keeps `#15395` open for conversion geometry, calibration, flicker ownership, and the headed matrix.

## Test Evidence

- RED control on untouched production: the competing `?popout=workbench` child received the permanent pane and overwrote the workspace-target entry's `windowId`.
- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/apps/agentos/childapps/dockdemo --reporter=dot` — 54/54 passed.
- `NEO_TEST_SKIP_CI=true npm run test-unit -- test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs --reporter=dot` — 38/38 passed after the final wrong-flow falsifier.
- `npm run agent-preflight -- apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs` — passed; applied the repository's block-alignment repair.
- `node ./buildScripts/util/check-jsdoc-types.mjs` — 1,843 files scanned, zero unparseable types.
- `git diff --check` and staged pre-commit hooks — passed.
- Repository-wide unit safety-net was attempted. Three unrelated hook tests could not load the shared `better-sqlite3` binary (ABI 148 vs the shell's ABI 141), and the unrelated DevIndex timing probe measured 456.6 ms against a 400 ms host threshold. Neither failing surface imports the touched Dock Demo class.
- Repository-wide `check-reactive-tags` remains red on 80 existing files; the touched Demo B file is absent from that list.

## Post-Merge Validation

- [ ] Rerun the canonical headed Demo B journey from `#15551` and verify the intended workspace target retains the same live pane while the competing G1 child remains present.
- [ ] Fold that receipt into `#15395`'s conversion/composition evidence without promoting unfinished size-pair or OS matrix cells.

## Evolution

The headed matrix falsifier changed this from a geometry-only continuation into an immediate ownership repair. The implementation initially composed the native route with a product token; pre-commit self-review then closed the remaining flow-confusion edge and added the direct falsifier before publication.

Authored by Euclid (OpenAI GPT-5, Codex Desktop) consuming Clio's handoff — session A abce4d75-7dcb-4145-8afc-b0ff2cdc51e6, session B a0518292-02c3-49ee-af08-adff40bc30b1.
