### PR TITLE
feat(memory-core): add hosted community batch push (#15156)

### DIFF
--- a/ai/mcp/client/Client.mjs
+++ b/ai/mcp/client/Client.mjs
@@ -1,10 +1,10 @@
-import {Client as McpSdkClient} from '@modelcontextprotocol/sdk/client/index.js';
-import {SSEClientTransport}     from '@modelcontextprotocol/sdk/client/sse.js';
-import {StdioClientTransport}   from '@modelcontextprotocol/sdk/client/stdio.js';
+import {Client as McpSdkClient}        from '@modelcontextprotocol/sdk/client/index.js';
+import {SSEClientTransport}            from '@modelcontextprotocol/sdk/client/sse.js';
+import {StdioClientTransport}          from '@modelcontextprotocol/sdk/client/stdio.js';
 import {StreamableHTTPClientTransport} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import Base                     from '../../../src/core/Base.mjs';
-import ClientConfig             from './config.mjs';
-import ToolService              from '../ToolService.mjs';
+import Base                            from '../../../src/core/Base.mjs';
+import ClientConfig                    from './config.mjs';
+import ToolService                     from '../ToolService.mjs';
 
 /**
  * @summary A generic MCP Client that can connect to local or remote MCP servers.
@@ -37,6 +37,14 @@ class Client extends Base {
          * @member {String} clientVersion='1.0.0'
          */
         clientVersion: '1.0.0',
+        /**
+         * Narrow entrypoint-injected connection object for one transient client instance.
+         *
+         * This narrow bootstrap boundary keeps credentials out of the shared reactive ClientConfig
+         * Provider. `null` keeps the normal named config lookup path.
+         * @member {Object|null} connectionConfig=null
+         */
+        connectionConfig: null,
         /**
          * The command to run (e.g. "node")
          * @member {String|null} command=null // Will be loaded from config
@@ -79,7 +87,7 @@ class Client extends Base {
         url: null,
         /**
          * The logical name of the MCP server to connect to (e.g., 'github-workflow').
-         * This name will be used to look up connection details from ClientConfig.
+         * This name looks up ClientConfig unless one transient `connectionConfig` was injected.
          * @member {String} serverName_='github-workflow'
          * @reactive
          */
@@ -303,14 +311,14 @@ class Client extends Base {
     }
 
     /**
-     * Loads the server connection details from the ClientConfig singleton.
+     * Loads instance-injected connection details or the named ClientConfig entry.
      * @param {String} serverName The name of the server to load.
      * @protected
      */
     loadServerConfig(serverName) {
         const me = this;
 
-        const serverConfig = ClientConfig.mcpServers[serverName];
+        const serverConfig = me.connectionConfig ?? ClientConfig.mcpServers[serverName];
         if (!serverConfig) {
             throw new Error(`MCP Client: Server config not found for '${serverName}' in ai/mcp/client/config.mjs`);
         }

--- a/ai/mcp/server/memory-core/communityBatchTool.mjs
+++ b/ai/mcp/server/memory-core/communityBatchTool.mjs
@@ -24,17 +24,19 @@ const getEffectiveToolName = toolName => {
 
 /**
  * @summary Returns true when hosted community tools belong on the current MCP surface.
+ * @param {String} [transport=aiConfig.transport]
  * @returns {Boolean}
  */
-const areHostedCommunityToolsVisible = () => aiConfig.transport === 'streamable-http';
+const areHostedCommunityToolsVisible = (transport=aiConfig.transport) => transport === 'streamable-http';
 
 /**
  * @summary Fails closed when a local stdio client invokes the hosted connector facade.
  * @param {String} toolName
+ * @param {String} [transport=aiConfig.transport]
  * @returns {void}
  */
-const assertHostedCommunityToolAllowed = toolName => {
-    if (hostedCommunityToolNames.has(getEffectiveToolName(toolName)) && !areHostedCommunityToolsVisible()) {
+const assertHostedCommunityToolAllowed = (toolName, transport=aiConfig.transport) => {
+    if (hostedCommunityToolNames.has(getEffectiveToolName(toolName)) && !areHostedCommunityToolsVisible(transport)) {
         throw new Error(
             'Hosted community connector tools require the Memory Core streamable-http transport. ' +
             'Local workflows call CommunityBatchAdmissionService directly.'

--- a/ai/mcp/server/memory-core/communityBatchTool.mjs
+++ b/ai/mcp/server/memory-core/communityBatchTool.mjs
@@ -1,0 +1,118 @@
+import aiConfig                       from './config.mjs';
+import CommunityBatchAdmissionService from '../../../services/memory-core/CommunityBatchAdmissionService.mjs';
+import {
+    carriesCredentialMaterial,
+    carriesHostedAuthority,
+    validateHostedEnvelope
+} from '../../../services/memory-core/communityBatchContract.mjs';
+
+const hostedCommunityToolNames = new Set([
+    'admit_community_batch',
+    'get_community_source_health'
+]);
+
+/**
+ * @summary Normalizes optional MCP server prefixes before transport-gating tool names.
+ * @param {String} toolName
+ * @returns {String}
+ */
+const getEffectiveToolName = toolName => {
+    const index = toolName.lastIndexOf('__');
+
+    return index === -1 ? toolName : toolName.substring(index + 2)
+};
+
+/**
+ * @summary Returns true when hosted community tools belong on the current MCP surface.
+ * @returns {Boolean}
+ */
+const areHostedCommunityToolsVisible = () => aiConfig.transport === 'streamable-http';
+
+/**
+ * @summary Fails closed when a local stdio client invokes the hosted connector facade.
+ * @param {String} toolName
+ * @returns {void}
+ */
+const assertHostedCommunityToolAllowed = toolName => {
+    if (hostedCommunityToolNames.has(getEffectiveToolName(toolName)) && !areHostedCommunityToolsVisible()) {
+        throw new Error(
+            'Hosted community connector tools require the Memory Core streamable-http transport. ' +
+            'Local workflows call CommunityBatchAdmissionService directly.'
+        )
+    }
+};
+
+/**
+ * @summary Dispatches one authority-free connector envelope to server-resolved admission.
+ * @param {Object} args
+ * @returns {Object}
+ */
+const admitCommunityBatch = args => {
+    const validation = validateHostedEnvelope(args);
+
+    if (!validation.valid) {
+        return {
+            status: 'conflict',
+            reason: 'HOSTED_BOUNDARY_REJECTED',
+            code  : validation.errors.some(error => error.endsWith('_EXCEEDED'))
+                ? 'COMMUNITY_BATCH_VOLUME_EXCEEDED'
+                : 'COMMUNITY_BATCH_ENVELOPE_INVALID',
+            errors: validation.errors,
+            volume: validation.volume
+        }
+    }
+
+    return CommunityBatchAdmissionService.admitHostedBatch(args)
+};
+
+/**
+ * @summary Validates the raw hosted tool arguments before OpenAPI normalization can strip unknown keys.
+ *
+ * Nested additional-properties handling is intentionally not trusted for authority: a caller that
+ * submits tenantId/sourceInstanceId/registrationEpoch must receive a refusal, not have the field
+ * silently removed and the remainder admitted.
+ * @param {String} toolName
+ * @param {Object} args
+ * @returns {Object|null} Structured refusal, or null when dispatch may continue.
+ */
+const getHostedCommunityBoundaryRejection = (toolName, args) => {
+    const effectiveToolName = getEffectiveToolName(toolName);
+
+    if (effectiveToolName === 'get_community_source_health') {
+        return carriesHostedAuthority(args) || carriesCredentialMaterial(args)
+            ? {ready: false, code: 'COMMUNITY_SOURCE_IDENTITY_INVALID'}
+            : null
+    }
+
+    if (effectiveToolName !== 'admit_community_batch') return null;
+
+    const validation = validateHostedEnvelope(args);
+
+    if (validation.valid) return null;
+
+    return {
+        status: 'conflict',
+        reason: 'HOSTED_BOUNDARY_REJECTED',
+        code  : validation.errors.some(error => error.endsWith('_EXCEEDED'))
+            ? 'COMMUNITY_BATCH_VOLUME_EXCEEDED'
+            : 'COMMUNITY_BATCH_ENVELOPE_INVALID',
+        errors: validation.errors,
+        volume: validation.volume
+    }
+};
+
+/**
+ * @summary Reads bounded readiness for one server-resolved community source.
+ * @param {Object} args
+ * @returns {Object}
+ */
+const getCommunitySourceHealth = args => CommunityBatchAdmissionService.getHostedSourceHealth(args);
+
+export {
+    admitCommunityBatch,
+    areHostedCommunityToolsVisible,
+    assertHostedCommunityToolAllowed,
+    getHostedCommunityBoundaryRejection,
+    getCommunitySourceHealth,
+    hostedCommunityToolNames
+};

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -41,6 +41,8 @@ tags:
     description: Agent active-turn liveness interval operations
   - name: Diagnostics
     description: On-demand operational diagnostics
+  - name: Community Sources
+    description: Authenticated hosted community-source admission and readiness
 
 # Harness tool-projection policy (mirrors neural-link / knowledge-base / github-workflow). A maintainer
 # harness spawned with `--tool-projection-mode harness-embedded` loads the read + write (core-maintainer)
@@ -56,6 +58,65 @@ x-neo-harness-tool-projection:
     - admin
 
 paths:
+  /community/batches/admit:
+    post:
+      summary: Admit hosted community batch
+      operationId: admit_community_batch
+      x-neo-tool-tier: write
+      x-pass-as-object: true
+      x-neo-tool-summary: Admit a bounded community batch after server-side tenant, source, and epoch resolution.
+      description: |
+        Hosted Streamable HTTP connector ingress. The authenticated request context supplies tenant
+        authority; the neutral provider identity resolves the registered source and current epoch.
+        Callers cannot submit tenantId, sourceInstanceId, registrationEpoch, or credential material.
+        Lost-response retries must reuse the same batchId and payload.
+      tags: [Community Sources]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HostedCommunityBatchRequest'
+      responses:
+        '200':
+          description: Admission, idempotent retry, conflict, or structured backpressure result.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HostedCommunityBatchResponse'
+
+  /community/sources/health:
+    post:
+      summary: Get hosted community source health
+      operationId: get_community_source_health
+      x-neo-tool-tier: read
+      x-pass-as-object: true
+      x-neo-tool-summary: Read bounded readiness for a tenant-scoped registered community source.
+      x-annotations:
+        readOnlyHint: true
+      description: |
+        Resolves the source under the authenticated tenant and returns lifecycle state, current epoch,
+        last receipt, last-receipt age, and coverage-gap counts. Provider secrets and prose are never returned.
+      tags: [Community Sources]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [source]
+              properties:
+                source:
+                  $ref: '#/components/schemas/HostedCommunitySourceIdentity'
+      responses:
+        '200':
+          description: Source readiness or a stable not-found/invalid code.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HostedCommunitySourceHealth'
+
   /healthcheck:
     get:
       summary: Health Check
@@ -3424,6 +3485,213 @@ components:
         message:
           type: string
           example: "All summaries successfully deleted"
+
+    HostedCommunitySourceIdentity:
+      type: object
+      additionalProperties: false
+      required:
+        - canonicalProviderHost
+        - resourceKind
+        - providerResourceId
+      properties:
+        canonicalProviderHost:
+          type: string
+          minLength: 1
+          description: Canonical provider host, for example github.com.
+        resourceKind:
+          type: string
+          minLength: 1
+          description: Neutral provider resource kind, for example repository.
+        providerResourceId:
+          type: string
+          minLength: 1
+          description: Stable provider resource identifier. Never a credential or tenant id.
+
+    HostedCommunityObservation:
+      type: object
+      additionalProperties: false
+      required:
+        - providerEntityId
+        - occurrenceKind
+        - occurrenceCoordinate
+        - occurredAt
+        - actorKind
+      properties:
+        providerEntityId:
+          type: string
+          minLength: 1
+        occurrenceKind:
+          type: string
+          minLength: 1
+        occurrenceCoordinate:
+          type: string
+          minLength: 1
+        occurredAt:
+          type: string
+          minLength: 1
+        actorId:
+          type: string
+          nullable: true
+        actorKind:
+          type: string
+          enum: [user, bot, organization, mannequin, enterprise-user, unknown]
+        revisionOf:
+          type: string
+          nullable: true
+        absence:
+          type: string
+          enum: [deleted, inaccessible, unknown]
+          nullable: true
+        deletionEvidence:
+          type: object
+          nullable: true
+          additionalProperties: true
+
+    HostedCommunityCoverage:
+      type: object
+      additionalProperties: false
+      required: [fromBasis, toBasis, complete]
+      properties:
+        fromBasis:
+          type: string
+        toBasis:
+          type: string
+        complete:
+          type: boolean
+        gaps:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              fromBasis:
+                type: string
+              toBasis:
+                type: string
+
+    HostedCommunityAuthorityFreeBatch:
+      type: object
+      additionalProperties: false
+      required:
+        - schemaVersion
+        - resourceFamily
+        - adapterSchemaVersion
+        - providerStateSchemaVersion
+        - baseCheckpointVersion
+        - baseInventoryHash
+        - batchId
+        - observations
+        - nextProviderState
+        - nextInventoryHash
+        - coverage
+      properties:
+        schemaVersion:
+          type: string
+          enum: [community-activity-batch.v1]
+        resourceFamily:
+          type: string
+          minLength: 1
+        adapterSchemaVersion:
+          type: string
+          minLength: 1
+        providerStateSchemaVersion:
+          type: string
+          minLength: 1
+        baseCheckpointVersion:
+          type: integer
+          minimum: 0
+        baseInventoryHash:
+          type: string
+          nullable: true
+        batchId:
+          type: string
+          minLength: 1
+        observations:
+          type: array
+          maxItems: 50
+          items:
+            $ref: '#/components/schemas/HostedCommunityObservation'
+        nextProviderState:
+          type: object
+          nullable: true
+          additionalProperties: true
+        nextInventoryHash:
+          type: string
+          nullable: true
+        coverage:
+          $ref: '#/components/schemas/HostedCommunityCoverage'
+
+    HostedCommunityBatchRequest:
+      type: object
+      additionalProperties: false
+      required: [source, batch]
+      properties:
+        source:
+          $ref: '#/components/schemas/HostedCommunitySourceIdentity'
+        batch:
+          $ref: '#/components/schemas/HostedCommunityAuthorityFreeBatch'
+
+    HostedCommunitySourceHealth:
+      type: object
+      required: [ready, code]
+      properties:
+        ready:
+          type: boolean
+        code:
+          type: string
+        sourceInstanceId:
+          type: string
+        state:
+          type: string
+        registrationEpoch:
+          type: integer
+        lastReceipt:
+          type: object
+          nullable: true
+          additionalProperties: true
+        lag:
+          type: object
+          additionalProperties: true
+        gaps:
+          type: object
+          additionalProperties: true
+        partitions:
+          type: array
+          items:
+            type: object
+            additionalProperties: true
+
+    HostedCommunityBatchResponse:
+      type: object
+      required: [status]
+      properties:
+        status:
+          type: string
+          enum: [accepted, idempotent, conflict]
+        reason:
+          type: string
+        code:
+          type: string
+        errors:
+          type: array
+          items:
+            type: string
+        digest:
+          type: string
+        receipt:
+          type: object
+          additionalProperties: true
+        checkpoint:
+          type: object
+          additionalProperties: true
+        health:
+          $ref: '#/components/schemas/HostedCommunitySourceHealth'
+        volume:
+          type: object
+          additionalProperties: true
+        limits:
+          type: object
+          additionalProperties: true
 
     ErrorResponse:
       type: object

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -23,6 +23,14 @@ import {makeOpenWorkCensusReader}    from '../../../services/github-workflow/ope
 import {synthesizeTemporalBirdView}  from '../../../services/memory-core/helpers/temporalBirdViewSynthesizer.mjs';
 import GitHubWorkflowConfig          from '../github-workflow/config.mjs';
 import MemoryCoreConfig              from './config.mjs';
+import {
+    admitCommunityBatch,
+    areHostedCommunityToolsVisible,
+    assertHostedCommunityToolAllowed,
+    getHostedCommunityBoundaryRejection,
+    getCommunitySourceHealth,
+    hostedCommunityToolNames
+} from './communityBatchTool.mjs';
 
 const __filename      = fileURLToPath(import.meta.url);
 const __dirname       = path.dirname(__filename);
@@ -144,6 +152,7 @@ const serviceMapping = {
     // confirmation an agent can supply is not a guard. An operator path, if ever needed,
     // routes through DestructiveOperationGuard — never through tool re-exposure.
     get_all_summaries           : SummaryService         .listSummaries           .bind(SummaryService),
+    get_community_source_health : getCommunitySourceHealth,
     get_context_frontier        : MemoryService          .getContextFrontier      .bind(MemoryService),
     get_neighbors               : GraphService           .getNeighbors            .bind(GraphService),
     get_node                    : GraphService           .getNode                 .bind(GraphService),
@@ -178,6 +187,7 @@ const serviceMapping = {
     list_permissions             : PermissionService      .listPermissions         .bind(PermissionService),
     manage_wake_subscription     : WakeSubscriptionService.manage                  .bind(WakeSubscriptionService),
     record_turn_presence         : TurnPresenceService    .recordTurnPresence      .bind(TurnPresenceService),
+    admit_community_batch        : admitCommunityBatch,
     who_is_online                : WakeSubscriptionService.whoIsOnline             .bind(WakeSubscriptionService),
     purge_session                : SessionService         .purgeSession            .bind(SessionService),
     resume_session               : SessionService         .validateSessionForResume.bind(SessionService),
@@ -193,12 +203,42 @@ const toolService = Neo.create(ToolService, {
 
 const _callTool = toolService.callTool.bind(toolService);
 
+/**
+ * @summary Applies hosted-transport visibility before returning Memory Core tools/list.
+ * @param {Object} [options]
+ * @returns {{tools: Object[], nextCursor: String|undefined}}
+ */
+const listTransportVisibleTools = ({cursor=0, limit, toolProjection} = {}) => {
+    const allTools = toolService.listTools({toolProjection}).tools.filter(tool => (
+        !hostedCommunityToolNames.has(tool.name) || areHostedCommunityToolsVisible()
+    ));
+
+    if (!limit) return {tools: allTools, nextCursor: undefined};
+
+    const
+        start = Number(cursor) || 0,
+        end   = start + limit;
+
+    return {
+        tools     : allTools.slice(start, end),
+        nextCursor: end < allTools.length ? String(end) : undefined
+    }
+};
+
 const callTool = async (name, args, options = {}) => {
     const t0 = Date.now();
 
     let result, success = false, error = null;
 
     try {
+        assertHostedCommunityToolAllowed(name);
+        const boundaryRejection = getHostedCommunityBoundaryRejection(name, args);
+
+        if (boundaryRejection) {
+            result  = boundaryRejection;
+            success = true;
+            return result
+        }
         result  = await _callTool(name, args, options);
         success = true;
         return result;
@@ -217,6 +257,6 @@ const callTool = async (name, args, options = {}) => {
         });
     }
 };
-const listTools = toolService.listTools.bind(toolService);
+const listTools = listTransportVisibleTools;
 
 export {callTool, listTools, readLaneLandscapeConfig};

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -204,59 +204,86 @@ const toolService = Neo.create(ToolService, {
 const _callTool = toolService.callTool.bind(toolService);
 
 /**
- * @summary Applies hosted-transport visibility before returning Memory Core tools/list.
- * @param {Object} [options]
- * @returns {{tools: Object[], nextCursor: String|undefined}}
+ * @summary Creates the internal Memory Core facade around one call-time transport resolver.
+ *
+ * Production keeps the reactive Provider read at the use site. Tests inject a closed-over literal
+ * resolver into a separate facade instead of mutating the shared AiConfig singleton. The resolver
+ * is never part of MCP arguments or tool options, so callers cannot forge transport authority.
+ *
+ * @param {Object} [dependencies]
+ * @param {Function} [dependencies.resolveTransport]
+ * @returns {{callTool: Function, listTools: Function}}
  */
-const listTransportVisibleTools = ({cursor=0, limit, toolProjection} = {}) => {
-    const allTools = toolService.listTools({toolProjection}).tools.filter(tool => (
-        !hostedCommunityToolNames.has(tool.name) || areHostedCommunityToolsVisible()
-    ));
+const createTransportVisibleToolFacade = ({
+    resolveTransport=() => MemoryCoreConfig.transport
+} = {}) => {
+    /**
+     * @summary Applies hosted-transport visibility before returning Memory Core tools/list.
+     * @param {Object} [options]
+     * @returns {{tools: Object[], nextCursor: String|undefined}}
+     */
+    const listTools = ({cursor=0, limit, toolProjection} = {}) => {
+        const transport = resolveTransport();
 
-    if (!limit) return {tools: allTools, nextCursor: undefined};
+        const allTools = toolService.listTools({toolProjection}).tools.filter(tool => (
+            !hostedCommunityToolNames.has(tool.name) || areHostedCommunityToolsVisible(transport)
+        ));
 
-    const
-        start = Number(cursor) || 0,
-        end   = start + limit;
+        if (!limit) return {tools: allTools, nextCursor: undefined};
 
-    return {
-        tools     : allTools.slice(start, end),
-        nextCursor: end < allTools.length ? String(end) : undefined
-    }
-};
+        const
+            start = Number(cursor) || 0,
+            end   = start + limit;
 
-const callTool = async (name, args, options = {}) => {
-    const t0 = Date.now();
-
-    let result, success = false, error = null;
-
-    try {
-        assertHostedCommunityToolAllowed(name);
-        const boundaryRejection = getHostedCommunityBoundaryRejection(name, args);
-
-        if (boundaryRejection) {
-            result  = boundaryRejection;
-            success = true;
-            return result
+        return {
+            tools     : allTools.slice(start, end),
+            nextCursor: end < allTools.length ? String(end) : undefined
         }
-        result  = await _callTool(name, args, options);
-        success = true;
-        return result;
-    } catch (err) {
-        error = err;
-        throw err;
-    } finally {
-        MemoryCoreRecorderService.logToolCall({
-            toolName    : name,
-            args,
-            result,
-            success,
-            error,
-            failureStage: success ? null : 'dispatch',
-            t0
-        });
-    }
-};
-const listTools = listTransportVisibleTools;
+    };
 
-export {callTool, listTools, readLaneLandscapeConfig};
+    /**
+     * @summary Applies the hosted-transport guard before Memory Core tool dispatch.
+     * @param {String} name
+     * @param {Object} args
+     * @param {Object} [options]
+     * @returns {Promise<Object>}
+     */
+    const callTool = async (name, args, options = {}) => {
+        const t0 = Date.now();
+
+        let result, success = false, error = null;
+
+        try {
+            assertHostedCommunityToolAllowed(name, resolveTransport());
+            const boundaryRejection = getHostedCommunityBoundaryRejection(name, args);
+
+            if (boundaryRejection) {
+                result  = boundaryRejection;
+                success = true;
+                return result
+            }
+            result  = await _callTool(name, args, options);
+            success = true;
+            return result;
+        } catch (err) {
+            error = err;
+            throw err;
+        } finally {
+            MemoryCoreRecorderService.logToolCall({
+                toolName    : name,
+                args,
+                result,
+                success,
+                error,
+                failureStage: success ? null : 'dispatch',
+                t0
+            });
+        }
+    };
+
+    return {callTool, listTools}
+};
+
+const {callTool, listTools} = createTransportVisibleToolFacade();
+
+export {callTool, createTransportVisibleToolFacade, listTools, readLaneLandscapeConfig};

--- a/ai/scripts/maintenance/communityBatchPushClient.mjs
+++ b/ai/scripts/maintenance/communityBatchPushClient.mjs
@@ -1,0 +1,254 @@
+// Neo namespace bootstrap (entry-point invariant) — hosted community batch push client.
+import 'dotenv/config';
+import {Command}                from 'commander';
+import Neo                      from '../../../src/Neo.mjs';
+import * as core                from '../../../src/core/_export.mjs';
+import crypto                   from 'crypto';
+import fs                       from 'fs';
+import {pathToFileURL}          from 'url';
+import Client                   from '../../mcp/client/Client.mjs';
+import {validateHostedEnvelope} from '../../services/memory-core/communityBatchContract.mjs';
+
+/**
+ * @module ai/scripts/maintenance/communityBatchPushClient
+ * @summary Bounded authenticated client for hosted community-activity batch admission.
+ */
+
+const DEFAULT_TOKEN_ENV = 'NEO_COMMUNITY_BATCH_TOKEN';
+
+/**
+ * @summary Creates an isolated Commander parser for one invocation.
+ * @returns {Command}
+ */
+function createArgParser() {
+    return new Command()
+        .name('community-batch-push-client')
+        .description('Push one authority-free community batch to hosted Memory Core admission')
+        .exitOverride()
+        .configureOutput({writeErr: () => {}, writeOut: () => {}})
+        .allowExcessArguments(false)
+        .option('--allow-unauthenticated', 'Allow missing bearer token for local demo deployments only')
+        .option('--client-name <name>', 'MCP client name')
+        .option('--from-file <path>', 'Read one JSON connector envelope from a file')
+        .option('--from-stdin', 'Read one JSON connector envelope from stdin')
+        .option('--max-attempts <count>', 'Bounded attempts for unknown-outcome transport failures')
+        .option('--token-env <name>', 'Environment variable containing the bearer token')
+        .option('--transport <type>', 'Remote MCP transport: streamable-http')
+        .option('--url <url>', 'Remote Memory Core MCP endpoint URL')
+}
+
+/**
+ * @summary Parses push-client argv and environment defaults.
+ * @param {String[]} argv
+ * @param {Object} env
+ * @returns {Object}
+ */
+function parseArgs(argv, env = process.env) {
+    const program    = createArgParser();
+    let   parseError = null;
+
+    try {
+        program.parse(argv, {from: 'user'})
+    } catch (error) {
+        parseError = error.message
+    }
+
+    const
+        options  = program.opts(),
+        tokenEnv = options.tokenEnv || env.NEO_COMMUNITY_BATCH_TOKEN_ENV || DEFAULT_TOKEN_ENV,
+        token    = (tokenEnv ? env[tokenEnv] : null) || null,
+        args     = {
+            allowUnauthenticated: Boolean(options.allowUnauthenticated),
+            clientName          : options.clientName || 'neo-community-batch-push-client',
+            fromFile            : options.fromFile || null,
+            fromStdin           : Boolean(options.fromStdin),
+            maxAttempts         : Number(options.maxAttempts || env.NEO_COMMUNITY_BATCH_MAX_ATTEMPTS || 2),
+            token,
+            tokenEnv,
+            transport           : options.transport || env.NEO_MEMORY_CORE_MCP_TRANSPORT || 'streamable-http',
+            url                 : options.url || env.NEO_MEMORY_CORE_MCP_URL || null
+        };
+
+    if (parseError) args.parseError = parseError;
+
+    return args
+}
+
+/**
+ * @summary Reads one JSON connector envelope from a stream.
+ * @param {ReadableStream} input
+ * @returns {Promise<Object>}
+ */
+async function readJsonPayload(input) {
+    let text = '';
+
+    for await (const chunk of input) text += chunk;
+
+    if (!text.trim()) throw new Error('No JSON payload provided.');
+
+    return JSON.parse(text)
+}
+
+/**
+ * @summary Builds transient remote MCP configuration without persisting the bearer token.
+ * @param {Object} args
+ * @returns {Object}
+ */
+function buildServerConfig(args) {
+    const headers = args.token ? {Authorization: `Bearer ${args.token}`} : {};
+
+    return {
+        transportType   : args.transport,
+        url             : args.url,
+        transportOptions: Object.keys(headers).length ? {requestInit: {headers}} : {}
+    }
+}
+
+/**
+ * @summary Decodes a standard MCP text result when it contains JSON.
+ * @param {Object} result
+ * @returns {*}
+ */
+function decodeToolResult(result) {
+    const text = result?.content?.find?.(entry => entry.type === 'text')?.text;
+
+    if (!text) return result;
+
+    try {
+        return JSON.parse(text)
+    } catch {
+        return result
+    }
+}
+
+/**
+ * @summary Detects a structured refusal that should fail the connector process.
+ * @param {*} payload
+ * @returns {Boolean}
+ */
+function hasPushFailure(payload) {
+    return Boolean(payload?.isError || payload?.error || payload?.status === 'conflict')
+}
+
+/**
+ * @summary Pushes the exact same envelope across a bounded lost-response retry loop.
+ * @param {Object} options
+ * @param {Object} options.args
+ * @param {ReadableStream} options.input
+ * @param {Function} [options.clientFactory]
+ * @returns {Promise<*>}
+ */
+async function runPush({args, input, clientFactory}) {
+    const envelope   = await readJsonPayload(input),
+          validation = validateHostedEnvelope(envelope);
+
+    if (!validation.valid) {
+        return {
+            status: 'conflict',
+            reason: 'HOSTED_BOUNDARY_REJECTED',
+            code  : validation.errors.some(error => error.endsWith('_EXCEEDED'))
+                ? 'COMMUNITY_BATCH_VOLUME_EXCEEDED'
+                : 'COMMUNITY_BATCH_ENVELOPE_INVALID',
+            errors: validation.errors,
+            volume: validation.volume
+        }
+    }
+
+    const
+        connectionConfig = buildServerConfig(args),
+        serverName       = `community-batch-push-${crypto.randomUUID()}`;
+
+    let client;
+
+    try {
+        client = clientFactory
+            ? clientFactory({connectionConfig, serverName, clientName: args.clientName})
+            : Neo.create(Client, {connectionConfig, serverName, clientName: args.clientName});
+
+        await client.ready?.();
+
+        let lastError;
+
+        for (let attempt = 1; attempt <= args.maxAttempts; attempt++) {
+            try {
+                return decodeToolResult(await client.callTool('admit_community_batch', envelope))
+            } catch (error) {
+                lastError = error;
+                if (attempt === args.maxAttempts) throw error
+            }
+        }
+
+        throw lastError
+    } finally {
+        await client?.close?.()
+    }
+}
+
+/**
+ * @summary Validates CLI arguments before file or network work.
+ * @param {Object} args
+ * @returns {String[]}
+ */
+function validateArgs(args) {
+    if (args.parseError) return [args.parseError];
+
+    const errors = [];
+
+    if (!args.url) errors.push('Missing --url or NEO_MEMORY_CORE_MCP_URL.');
+    if (!args.fromFile && !args.fromStdin) errors.push('Provide --from-file or --from-stdin.');
+    if (args.fromFile && args.fromStdin) errors.push('Use only one of --from-file or --from-stdin.');
+    if (args.fromFile && !fs.existsSync(args.fromFile)) errors.push(`--from-file path does not exist: ${args.fromFile}`);
+    if (!['streamable-http', 'streamableHttp'].includes(args.transport)) {
+        errors.push(`Unsupported --transport '${args.transport}'. Expected streamable-http.`)
+    }
+    if (!Number.isInteger(args.maxAttempts) || args.maxAttempts < 1 || args.maxAttempts > 3) {
+        errors.push('--max-attempts must be an integer from 1 to 3.')
+    }
+    if (!args.allowUnauthenticated && !args.token) {
+        errors.push(`Missing bearer token: set --token-env or ${DEFAULT_TOKEN_ENV}.`)
+    }
+
+    return errors
+}
+
+/**
+ * @summary CLI entry point.
+ * @returns {Promise<void>}
+ */
+async function communityBatchPushClient() {
+    const args   = parseArgs(process.argv.slice(2)),
+          errors = validateArgs(args);
+
+    if (errors.length) {
+        errors.forEach(error => console.error(`Error: ${error}`));
+        process.exit(1)
+    }
+
+    const input = args.fromStdin ? process.stdin : fs.createReadStream(args.fromFile, 'utf8');
+
+    try {
+        const payload = await runPush({args, input});
+
+        console.log(JSON.stringify(payload, null, 2));
+        process.exit(hasPushFailure(payload) ? 1 : 0)
+    } catch (error) {
+        const message = args.token ? String(error.message || error).split(args.token).join('[redacted]') : error.message;
+
+        console.error('Community batch push failed:', message);
+        process.exit(1)
+    }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+    communityBatchPushClient()
+}
+
+export {
+    buildServerConfig,
+    decodeToolResult,
+    hasPushFailure,
+    parseArgs,
+    readJsonPayload,
+    runPush,
+    validateArgs
+};

--- a/ai/scripts/maintenance/communitySourceOperator.mjs
+++ b/ai/scripts/maintenance/communitySourceOperator.mjs
@@ -1,0 +1,150 @@
+// Neo namespace bootstrap (entry-point invariant) — co-located community source control plane.
+import 'dotenv/config';
+import {Command}             from 'commander';
+import Neo                   from '../../../src/Neo.mjs';
+import * as core             from '../../../src/core/_export.mjs';
+import fs                    from 'fs';
+import os                    from 'os';
+import {pathToFileURL}       from 'url';
+import SourceRegistryService from '../../services/memory-core/SourceRegistryService.mjs';
+
+/**
+ * @module ai/scripts/maintenance/communitySourceOperator
+ * @summary Co-located deployment-operator CLI for audited community source lifecycle control.
+ */
+
+/**
+ * @summary Parses one operator invocation.
+ * @param {String[]} argv
+ * @param {Object} env
+ * @returns {Object}
+ */
+function parseArgs(argv, env = process.env) {
+    const program    = new Command();
+    let   parseError = null;
+
+    program
+        .name('community-source-operator')
+        .exitOverride()
+        .configureOutput({writeErr: () => {}, writeOut: () => {}})
+        .allowExcessArguments(false)
+        .option('--action <action>', 'register, provision, activate, revoke, or audit')
+        .option('--expected-epoch <epoch>', 'Observed registration epoch for lifecycle CAS')
+        .option('--expected-state <state>', 'Observed lifecycle state for lifecycle CAS')
+        .option('--source-file <path>', 'Credential-free neutral registration JSON for register')
+        .option('--source-instance-id <id>', 'Server-minted source id for transition or audit')
+        .option('--tenant-id <tenantId>', 'Deployment-owned tenant key');
+
+    try {
+        program.parse(argv, {from: 'user'})
+    } catch (error) {
+        parseError = error.message
+    }
+
+    const options = program.opts(),
+          args    = {
+              action          : options.action || null,
+              actorId         : env.NEO_COMMUNITY_OPERATOR_ID || `os-user:${os.userInfo().username}`,
+              expectedEpoch   : options.expectedEpoch === undefined ? null : Number(options.expectedEpoch),
+              expectedState   : options.expectedState || null,
+              sourceFile      : options.sourceFile || null,
+              sourceInstanceId: options.sourceInstanceId || null,
+              tenantId        : options.tenantId || null
+          };
+
+    if (parseError) args.parseError = parseError;
+
+    return args
+}
+
+/**
+ * @summary Validates operator argv before opening Memory Core storage.
+ * @param {Object} args
+ * @returns {String[]}
+ */
+function validateArgs(args) {
+    if (args.parseError) return [args.parseError];
+
+    const errors      = [],
+          transitions = new Set(['provision', 'activate', 'revoke']);
+
+    if (!['register', ...transitions, 'audit'].includes(args.action)) {
+        errors.push('--action must be register, provision, activate, revoke, or audit.')
+    }
+    if (!args.tenantId) errors.push('--tenant-id is required.');
+    if (args.action === 'register') {
+        if (!args.sourceFile) errors.push('--source-file is required for register.');
+        if (args.sourceFile && !fs.existsSync(args.sourceFile)) errors.push(`--source-file path does not exist: ${args.sourceFile}`)
+    }
+    if (transitions.has(args.action)) {
+        if (!args.sourceInstanceId) errors.push('--source-instance-id is required for lifecycle transitions.');
+        if (!args.expectedState) errors.push('--expected-state is required for lifecycle transitions.');
+        if (!Number.isInteger(args.expectedEpoch)) errors.push('--expected-epoch must be an integer for lifecycle transitions.')
+    }
+    if (args.action === 'audit' && !args.sourceInstanceId) {
+        errors.push('--source-instance-id is required for audit.')
+    }
+
+    return errors
+}
+
+/**
+ * @summary Executes one co-located operator action against the registry owner.
+ * @param {Object} options
+ * @param {Object} options.args
+ * @param {Object} [options.registry]
+ * @returns {Promise<Object|Object[]>}
+ */
+async function runOperator({args, registry = SourceRegistryService}) {
+    await registry.initAsync?.();
+
+    if (args.action === 'register') {
+        const data = JSON.parse(fs.readFileSync(args.sourceFile, 'utf8'));
+
+        return registry.registerForTenant(args.tenantId, data, {actorId: args.actorId})
+    }
+
+    if (args.action === 'audit') {
+        return registry.listAuditForTenant(args.tenantId, args.sourceInstanceId)
+    }
+
+    const toState = {
+        provision: 'PROVISIONED',
+        activate : 'ACTIVE',
+        revoke   : 'REVOKED'
+    }[args.action];
+
+    return registry.transitionLifecycleForTenant(args.tenantId, args.sourceInstanceId, toState, {
+        actorId      : args.actorId,
+        expectedState: args.expectedState,
+        expectedEpoch: args.expectedEpoch
+    })
+}
+
+/**
+ * @summary CLI entry point.
+ * @returns {Promise<void>}
+ */
+async function communitySourceOperator() {
+    const args   = parseArgs(process.argv.slice(2)),
+          errors = validateArgs(args);
+
+    if (errors.length) {
+        errors.forEach(error => console.error(`Error: ${error}`));
+        process.exit(1)
+    }
+
+    try {
+        console.log(JSON.stringify(await runOperator({args}), null, 2));
+        process.exit(0)
+    } catch (error) {
+        console.error('Community source operator failed:', error.message);
+        process.exit(1)
+    }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || '').href) {
+    communitySourceOperator()
+}
+
+export {parseArgs, runOperator, validateArgs};

--- a/ai/scripts/maintenance/communitySourceOperator.mjs
+++ b/ai/scripts/maintenance/communitySourceOperator.mjs
@@ -96,7 +96,7 @@ function validateArgs(args) {
  * @returns {Promise<Object|Object[]>}
  */
 async function runOperator({args, registry = SourceRegistryService}) {
-    await registry.initAsync?.();
+    await registry.ready?.();
 
     if (args.action === 'register') {
         const data = JSON.parse(fs.readFileSync(args.sourceFile, 'utf8'));

--- a/ai/services/memory-core/CommunityBatchAdmissionService.mjs
+++ b/ai/services/memory-core/CommunityBatchAdmissionService.mjs
@@ -1,12 +1,22 @@
-import fs                                                                           from 'fs-extra';
-import path                                                                         from 'path';
-import crypto                                                                       from 'crypto';
-import Base                                                                         from '../../../src/core/Base.mjs';
-import config                                                                       from '../../mcp/server/memory-core/config.mjs';
-import logger                                                                       from '../../mcp/server/memory-core/logger.mjs';
-import SourceRegistryService                                                        from './SourceRegistryService.mjs';
-import {classifyAttention}                                                          from './communityAttentionClassifier.mjs';
-import {canonicalBatchDigest, validateBatch, occurrenceIdentity, observationDigest} from './communityBatchContract.mjs';
+import fs                    from 'fs-extra';
+import path                  from 'path';
+import crypto                from 'crypto';
+import Base                  from '../../../src/core/Base.mjs';
+import config                from '../../mcp/server/memory-core/config.mjs';
+import logger                from '../../mcp/server/memory-core/logger.mjs';
+import SourceRegistryService from './SourceRegistryService.mjs';
+import {classifyAttention}   from './communityAttentionClassifier.mjs';
+import {
+    MAX_HOSTED_BATCH_BYTES,
+    MAX_HOSTED_OBSERVATIONS,
+    canonicalBatchDigest,
+    carriesCredentialMaterial,
+    carriesHostedAuthority,
+    validateBatch,
+    validateHostedEnvelope,
+    occurrenceIdentity,
+    observationDigest
+} from './communityBatchContract.mjs';
 
 /**
  * @summary Admission outcomes. These are RESULTS, not exceptions, because all are ordinary protocol
@@ -350,6 +360,140 @@ class CommunityBatchAdmissionService extends Base {
         }
 
         return {...outcome, digest}
+    }
+
+    /**
+     * @summary Authenticated hosted ingress over the same neutral admission transaction as local callers.
+     *
+     * The remote envelope cannot carry tenantId, sourceInstanceId, or registrationEpoch. Tenant comes
+     * from RequestContextService through SourceRegistryService; the neutral provider identity resolves
+     * the tenant-scoped registration; and the server injects the current source id + epoch into the exact
+     * canonical v1 batch before admission. Structured volume refusals happen before database mutation.
+     * @param {Object} envelope `{source, batch}` hosted connector payload.
+     * @param {Object} [limits] Test/operator seam for the synchronous work-volume bounds.
+     * @returns {Object}
+     */
+    admitHostedBatch(envelope, {
+        maxBytes        = MAX_HOSTED_BATCH_BYTES,
+        maxObservations = MAX_HOSTED_OBSERVATIONS
+    } = {}) {
+        const validation = validateHostedEnvelope(envelope, {maxBytes, maxObservations});
+
+        if (!validation.valid) {
+            const volumeExceeded = validation.errors.some(error => error.endsWith('_EXCEEDED'));
+
+            return {
+                status: 'conflict',
+                reason: 'HOSTED_BOUNDARY_REJECTED',
+                code  : volumeExceeded ? 'COMMUNITY_BATCH_VOLUME_EXCEEDED' : 'COMMUNITY_BATCH_ENVELOPE_INVALID',
+                errors: validation.errors,
+                volume: validation.volume,
+                limits: {maxBytes, maxObservations}
+            }
+        }
+
+        const registration = SourceRegistryService.resolveRegistration(envelope.source);
+
+        if (!registration) {
+            return {
+                status: 'conflict',
+                reason: 'REGISTRATION_NOT_ADMISSIBLE',
+                code  : 'COMMUNITY_SOURCE_NOT_FOUND'
+            }
+        }
+
+        const canonicalBatch = {
+            ...envelope.batch,
+            sourceInstanceId : registration.sourceInstanceId,
+            registrationEpoch: registration.registrationEpoch
+        };
+
+        return {
+            ...this.admitBatch(canonicalBatch),
+            health: this.getHostedSourceHealth({source: envelope.source})
+        }
+    }
+
+    /**
+     * @summary Returns bounded, credential-free readiness for one tenant-scoped hosted source.
+     *
+     * `lag` is explicitly last-receipt age, not provider-head lag (the provider remains connector-owned).
+     * Coverage gaps surface only as counts and stable codes so provider prose never enters a response.
+     * @param {Object} request
+     * @param {Object} request.source Neutral provider identity.
+     * @returns {Object}
+     */
+    getHostedSourceHealth({source} = {}) {
+        if (!source || typeof source !== 'object' || carriesHostedAuthority(source) || carriesCredentialMaterial(source)) {
+            return {ready: false, code: 'COMMUNITY_SOURCE_IDENTITY_INVALID'}
+        }
+
+        const registration = SourceRegistryService.resolveRegistration(source);
+
+        if (!registration) {
+            return {ready: false, code: 'COMMUNITY_SOURCE_NOT_FOUND'}
+        }
+
+        const tenantId = SourceRegistryService.resolveTenantId();
+
+        if (!tenantId) {
+            return {ready: false, code: 'COMMUNITY_SOURCE_TENANT_UNRESOLVED'}
+        }
+
+        const partitions = this.db.prepare(
+            `SELECT checkpoint.resource_family, checkpoint.checkpoint_version, checkpoint.coverage,
+                    checkpoint.last_receipt_id, checkpoint.updated_at, receipt.admitted_at
+             FROM mc_community_checkpoint AS checkpoint
+             LEFT JOIN mc_community_batch_receipt AS receipt
+               ON receipt.tenant_id = checkpoint.tenant_id
+              AND receipt.source_instance_id = checkpoint.source_instance_id
+              AND receipt.resource_family = checkpoint.resource_family
+              AND receipt.receipt_id = checkpoint.last_receipt_id
+             WHERE checkpoint.tenant_id = ? AND checkpoint.source_instance_id = ?
+             ORDER BY checkpoint.updated_at DESC, checkpoint.resource_family`
+        ).all(tenantId, registration.sourceInstanceId).map(row => {
+            const coverage = row.coverage ? JSON.parse(row.coverage) : null;
+
+            return {
+                resourceFamily   : row.resource_family,
+                checkpointVersion: row.checkpoint_version,
+                lastReceiptId    : row.last_receipt_id,
+                lastReceiptAt    : row.admitted_at,
+                gapCount         : Array.isArray(coverage?.gaps) ? coverage.gaps.length : 0
+            }
+        });
+
+        const
+            latest   = partitions[0] || null,
+            gapCount = partitions.reduce((sum, partition) => sum + partition.gapCount, 0),
+            ready    = registration.lifecycleState === 'ACTIVE';
+
+        return {
+            ready,
+            code             : ready ? 'COMMUNITY_SOURCE_READY' : `COMMUNITY_SOURCE_${registration.lifecycleState}`,
+            sourceInstanceId : registration.sourceInstanceId,
+            state            : registration.lifecycleState,
+            registrationEpoch: registration.registrationEpoch,
+            lastReceipt      : latest ? {
+                receiptId     : latest.lastReceiptId,
+                resourceFamily: latest.resourceFamily,
+                admittedAt    : latest.lastReceiptAt
+            } : null,
+            lag: latest?.lastReceiptAt ? {
+                code   : 'COMMUNITY_SOURCE_LAST_RECEIPT_AGE',
+                basis  : 'last-receipt-age',
+                valueMs: Math.max(0, Date.now() - latest.lastReceiptAt)
+            } : {
+                code   : 'COMMUNITY_SOURCE_NEVER_ADMITTED',
+                basis  : 'last-receipt-age',
+                valueMs: null
+            },
+            gaps: {
+                code : gapCount ? 'COMMUNITY_SOURCE_COVERAGE_GAPS' : 'COMMUNITY_SOURCE_NO_REPORTED_GAPS',
+                count: gapCount
+            },
+            partitions
+        }
     }
 
     /**

--- a/ai/services/memory-core/SourceRegistryService.mjs
+++ b/ai/services/memory-core/SourceRegistryService.mjs
@@ -1,10 +1,11 @@
-import fs                    from 'fs-extra';
-import path                  from 'path';
-import crypto                from 'crypto';
-import Base                  from '../../../src/core/Base.mjs';
-import config                from '../../mcp/server/memory-core/config.mjs';
-import logger                from '../../mcp/server/memory-core/logger.mjs';
-import RequestContextService from '../../mcp/server/shared/services/RequestContextService.mjs';
+import fs                          from 'fs-extra';
+import path                        from 'path';
+import crypto                      from 'crypto';
+import Base                        from '../../../src/core/Base.mjs';
+import config                      from '../../mcp/server/memory-core/config.mjs';
+import logger                      from '../../mcp/server/memory-core/logger.mjs';
+import RequestContextService       from '../../mcp/server/shared/services/RequestContextService.mjs';
+import {carriesCredentialMaterial} from './communityBatchContract.mjs';
 
 /**
  * @summary The neutral source-registration lifecycle transitions Memory Core owns.
@@ -68,9 +69,9 @@ class SourceRegistryService extends Base {
          *
          * Bound ONCE at the trusted server/deployment boundary (startup injection) — never supplied
          * by a caller, and never defaulted. `null` means this process is not an explicit
-         * local-single-user deployment, so no caller holds source-admin authority and control-plane
-         * mutation fails closed. Hosted operator-authorized provisioning is a separate, deferred
-         * authority; an ordinary authenticated hosted subject is NOT a source admin.
+         * local-single-user deployment, so no caller holds source-admin authority and the local
+         * mutation path fails closed. Hosted provisioning is the separate co-located operator path;
+         * an ordinary authenticated hosted subject is NOT a source admin.
          */
         localSubjectId: null
     }
@@ -140,6 +141,20 @@ class SourceRegistryService extends Base {
                 ON mc_source_registration(tenant_id);
             CREATE UNIQUE INDEX IF NOT EXISTS idx_mc_source_registration_identity
                 ON mc_source_registration(tenant_id, canonical_provider_host, resource_kind, provider_resource_id);
+
+            CREATE TABLE IF NOT EXISTS mc_source_registration_audit (
+                audit_id           TEXT    PRIMARY KEY,
+                tenant_id          TEXT    NOT NULL,
+                source_instance_id TEXT    NOT NULL,
+                actor_id           TEXT    NOT NULL,
+                action             TEXT    NOT NULL,
+                from_state         TEXT,
+                to_state           TEXT    NOT NULL,
+                registration_epoch INTEGER NOT NULL,
+                recorded_at        INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_mc_source_registration_audit_tenant_source
+                ON mc_source_registration_audit(tenant_id, source_instance_id, recorded_at);
         `);
     }
 
@@ -163,10 +178,10 @@ class SourceRegistryService extends Base {
      * @summary Resolves the tenant key for a CONTROL-PLANE mutation, or throws.
      *
      * Source-admin authority is a deployment property, not a session property. Only an explicit
-     * local-single-user deployment — whose subject the server injected at startup — may register or
-     * transition sources today. An ordinary authenticated hosted subject is NOT a source admin: that
-     * authority belongs to an operator-authorized hosted provisioning path which does not exist yet,
-     * so this fails closed with a stable, distinguishable error instead of silently self-serving.
+     * local-single-user deployment — whose subject the server injected at startup — may use this local
+     * mutation path. An ordinary authenticated hosted subject is NOT a source admin; hosted bootstrap
+     * routes through the distinct co-located operator CLI, never through request context or MCP tier.
+     * This path therefore fails closed with a stable, distinguishable error instead of self-serving.
      * @returns {String} The server-owned tenant key for the mutation.
      * @throws {Error} `SOURCE_REGISTRATION_AUTHORITY_UNAVAILABLE` for a hosted subject (deferred authority).
      * @throws {Error} `SOURCE_REGISTRATION_NO_TENANT` when no deployment authority resolves at all.
@@ -208,39 +223,86 @@ class SourceRegistryService extends Base {
     register(data) {
         const tenantId = this.resolveAdminTenantId();
 
-        const
-            {provider, canonicalProviderHost, resourceKind, providerResourceId, displayLocator = null, grantRef = null, providerCapabilities = null} = data,
-            now      = Date.now(),
-            existing = this.db.prepare(
-                `SELECT source_instance_id FROM mc_source_registration
-                 WHERE tenant_id = ? AND canonical_provider_host = ? AND resource_kind = ? AND provider_resource_id = ?`
-            ).get(tenantId, canonicalProviderHost, resourceKind, providerResourceId);
+        return this.registerForTenant(tenantId, data, {actorId: `local:${tenantId}`})
+    }
 
-        if (existing) {
+    /**
+     * @summary Registers a source for an explicit tenant at the co-located deployment-operator boundary.
+     *
+     * This method is intentionally NOT mapped to MCP. Possession of an MCP `admin` tool tier is metadata,
+     * not source-admin authority; hosted bootstrap runs only through the server-side operator CLI whose
+     * process already owns the Memory Core database. Every call writes a credential-free audit row.
+     * @param {String} tenantId Deployment-owned tenant key.
+     * @param {Object} data Neutral registration fields.
+     * @param {Object} authority
+     * @param {String} authority.actorId Deployment operator audit identity.
+     * @returns {Object}
+     */
+    registerForTenant(tenantId, data, {actorId} = {}) {
+        this.#assertOperatorAuthority(tenantId, actorId);
+        this.#assertNeutralRegistration(data);
+
+        return this.db.transaction(() => {
+            const
+                {provider, canonicalProviderHost, resourceKind, providerResourceId, displayLocator = null, grantRef = null, providerCapabilities = null} = data,
+                now      = Date.now(),
+                existing = this.db.prepare(
+                    `SELECT source_instance_id FROM mc_source_registration
+                     WHERE tenant_id = ? AND canonical_provider_host = ? AND resource_kind = ? AND provider_resource_id = ?`
+                ).get(tenantId, canonicalProviderHost, resourceKind, providerResourceId);
+
+            if (existing) {
+                this.db.prepare(
+                    `UPDATE mc_source_registration SET display_locator = ?, grant_ref = ?, updated_at = ?
+                     WHERE tenant_id = ? AND source_instance_id = ?`
+                ).run(displayLocator, grantRef, now, tenantId, existing.source_instance_id);
+
+                const registration = this.getRegistrationForTenant(tenantId, existing.source_instance_id);
+
+                this.#recordAudit({
+                    tenantId,
+                    sourceInstanceId : registration.sourceInstanceId,
+                    actorId,
+                    action           : 'REFRESHED',
+                    fromState        : registration.lifecycleState,
+                    toState          : registration.lifecycleState,
+                    registrationEpoch: registration.registrationEpoch,
+                    recordedAt       : now
+                });
+
+                return registration
+            }
+
+            const sourceInstanceId = crypto.randomUUID();
+
             this.db.prepare(
-                `UPDATE mc_source_registration SET display_locator = ?, grant_ref = ?, updated_at = ?
-                 WHERE tenant_id = ? AND source_instance_id = ?`
-            ).run(displayLocator, grantRef, now, tenantId, existing.source_instance_id);
+                `INSERT INTO mc_source_registration (
+                    source_instance_id, tenant_id, provider, canonical_provider_host, resource_kind,
+                    provider_resource_id, display_locator, grant_ref, provider_capabilities,
+                    registration_epoch, lifecycle_state, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 'REQUESTED', ?, ?)`
+            ).run(
+                sourceInstanceId, tenantId, provider, canonicalProviderHost, resourceKind,
+                providerResourceId, displayLocator, grantRef,
+                providerCapabilities ? JSON.stringify(providerCapabilities) : null,
+                now, now
+            );
 
-            return this.getRegistration(existing.source_instance_id);
-        }
+            const registration = this.getRegistrationForTenant(tenantId, sourceInstanceId);
 
-        const sourceInstanceId = crypto.randomUUID();
+            this.#recordAudit({
+                tenantId,
+                sourceInstanceId,
+                actorId,
+                action           : 'REGISTERED',
+                fromState        : null,
+                toState          : registration.lifecycleState,
+                registrationEpoch: registration.registrationEpoch,
+                recordedAt       : now
+            });
 
-        this.db.prepare(
-            `INSERT INTO mc_source_registration (
-                source_instance_id, tenant_id, provider, canonical_provider_host, resource_kind,
-                provider_resource_id, display_locator, grant_ref, provider_capabilities,
-                registration_epoch, lifecycle_state, created_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, 'REQUESTED', ?, ?)`
-        ).run(
-            sourceInstanceId, tenantId, provider, canonicalProviderHost, resourceKind,
-            providerResourceId, displayLocator, grantRef,
-            providerCapabilities ? JSON.stringify(providerCapabilities) : null,
-            now, now
-        );
-
-        return this.getRegistration(sourceInstanceId);
+            return registration
+        })()
     }
 
     /**
@@ -254,11 +316,42 @@ class SourceRegistryService extends Base {
 
         if (!tenantId) return null;
 
+        return this.getRegistrationForTenant(tenantId, sourceInstanceId)
+    }
+
+    /**
+     * @summary Loads one registration under an explicit server-owned tenant predicate.
+     * @param {String} tenantId
+     * @param {String} sourceInstanceId
+     * @returns {Object|null}
+     */
+    getRegistrationForTenant(tenantId, sourceInstanceId) {
         const row = this.db.prepare(
             `SELECT * FROM mc_source_registration WHERE tenant_id = ? AND source_instance_id = ?`
         ).get(tenantId, sourceInstanceId);
 
         return row ? this.#toCamel(row) : null;
+    }
+
+    /**
+     * @summary Resolves a caller-neutral provider identity to the current tenant's durable source row.
+     * @param {Object} identity
+     * @param {String} identity.canonicalProviderHost
+     * @param {String} identity.resourceKind
+     * @param {String} identity.providerResourceId
+     * @returns {Object|null}
+     */
+    resolveRegistration(identity) {
+        const tenantId = this.resolveTenantId();
+
+        if (!tenantId) return null;
+
+        const row = this.db.prepare(
+            `SELECT * FROM mc_source_registration
+             WHERE tenant_id = ? AND canonical_provider_host = ? AND resource_kind = ? AND provider_resource_id = ?`
+        ).get(tenantId, identity.canonicalProviderHost, identity.resourceKind, identity.providerResourceId);
+
+        return row ? this.#toCamel(row) : null
     }
 
     /**
@@ -285,26 +378,85 @@ class SourceRegistryService extends Base {
     transitionLifecycle(sourceInstanceId, toState, {expectedState, expectedEpoch} = {}) {
         const tenantId = this.resolveAdminTenantId();
 
-        if (!expectedState || !Number.isInteger(expectedEpoch)) {
-            throw new Error('SOURCE_REGISTRATION_CONTROL_GENERATION_REQUIRED');
-        }
+        return this.transitionLifecycleForTenant(tenantId, sourceInstanceId, toState, {
+            actorId: `local:${tenantId}`,
+            expectedState,
+            expectedEpoch
+        })
+    }
 
-        if (!LIFECYCLE_TRANSITIONS[expectedState]?.includes(toState)) {
-            throw new Error('SOURCE_REGISTRATION_INVALID_TRANSITION');
-        }
+    /**
+     * @summary Applies one lifecycle CAS for a co-located deployment operator and audits the result.
+     * @param {String} tenantId
+     * @param {String} sourceInstanceId
+     * @param {String} toState
+     * @param {Object} generation
+     * @param {String} generation.actorId
+     * @param {String} generation.expectedState
+     * @param {Number} generation.expectedEpoch
+     * @returns {Object}
+     */
+    transitionLifecycleForTenant(tenantId, sourceInstanceId, toState, {actorId, expectedState, expectedEpoch} = {}) {
+        this.#assertOperatorAuthority(tenantId, actorId);
 
-        const
-            nextEpoch = EPOCH_ADVANCING_STATES.has(toState) ? expectedEpoch + 1 : expectedEpoch,
-            result    = this.db.prepare(
-                `UPDATE mc_source_registration SET lifecycle_state = ?, registration_epoch = ?, updated_at = ?
-                 WHERE tenant_id = ? AND source_instance_id = ? AND lifecycle_state = ? AND registration_epoch = ?`
-            ).run(toState, nextEpoch, Date.now(), tenantId, sourceInstanceId, expectedState, expectedEpoch);
+        return this.db.transaction(() => {
+            if (!expectedState || !Number.isInteger(expectedEpoch)) {
+                throw new Error('SOURCE_REGISTRATION_CONTROL_GENERATION_REQUIRED');
+            }
 
-        if (result.changes === 0) {
-            throw new Error('SOURCE_REGISTRATION_STALE_CONTROL');
-        }
+            if (!LIFECYCLE_TRANSITIONS[expectedState]?.includes(toState)) {
+                throw new Error('SOURCE_REGISTRATION_INVALID_TRANSITION');
+            }
 
-        return this.getRegistration(sourceInstanceId);
+            const
+                nextEpoch = EPOCH_ADVANCING_STATES.has(toState) ? expectedEpoch + 1 : expectedEpoch,
+                result    = this.db.prepare(
+                    `UPDATE mc_source_registration SET lifecycle_state = ?, registration_epoch = ?, updated_at = ?
+                     WHERE tenant_id = ? AND source_instance_id = ? AND lifecycle_state = ? AND registration_epoch = ?`
+                ).run(toState, nextEpoch, Date.now(), tenantId, sourceInstanceId, expectedState, expectedEpoch);
+
+            if (result.changes === 0) {
+                throw new Error('SOURCE_REGISTRATION_STALE_CONTROL');
+            }
+
+            const registration = this.getRegistrationForTenant(tenantId, sourceInstanceId);
+
+            this.#recordAudit({
+                tenantId,
+                sourceInstanceId,
+                actorId,
+                action           : toState,
+                fromState        : expectedState,
+                toState,
+                registrationEpoch: registration.registrationEpoch,
+                recordedAt       : registration.updatedAt
+            });
+
+            return registration
+        })()
+    }
+
+    /**
+     * @summary Returns the credential-free operator audit trail for one tenant-scoped source.
+     * @param {String} tenantId
+     * @param {String} sourceInstanceId
+     * @returns {Object[]}
+     */
+    listAuditForTenant(tenantId, sourceInstanceId) {
+        return this.db.prepare(
+            `SELECT * FROM mc_source_registration_audit
+             WHERE tenant_id = ? AND source_instance_id = ? ORDER BY recorded_at, audit_id`
+        ).all(tenantId, sourceInstanceId).map(row => ({
+            auditId          : row.audit_id,
+            tenantId         : row.tenant_id,
+            sourceInstanceId : row.source_instance_id,
+            actorId          : row.actor_id,
+            action           : row.action,
+            fromState        : row.from_state,
+            toState          : row.to_state,
+            registrationEpoch: row.registration_epoch,
+            recordedAt       : row.recorded_at
+        }))
     }
 
     /**
@@ -320,6 +472,54 @@ class SourceRegistryService extends Base {
         return !!registration
             && registration.lifecycleState   === 'ACTIVE'
             && registration.registrationEpoch === submittedEpoch;
+    }
+
+    /**
+     * @param {String} tenantId
+     * @param {String} actorId
+     * @throws {Error} Stable operator-boundary errors.
+     * @private
+     */
+    #assertOperatorAuthority(tenantId, actorId) {
+        if (typeof tenantId !== 'string' || !tenantId.trim()) {
+            throw new Error('SOURCE_OPERATOR_TENANT_REQUIRED')
+        }
+        if (typeof actorId !== 'string' || !actorId.trim()) {
+            throw new Error('SOURCE_OPERATOR_ACTOR_REQUIRED')
+        }
+    }
+
+    /**
+     * @param {Object} data
+     * @throws {Error} When identity is incomplete or credential-shaped material is present.
+     * @private
+     */
+    #assertNeutralRegistration(data) {
+        const required = ['provider', 'canonicalProviderHost', 'resourceKind', 'providerResourceId'];
+
+        if (!data || typeof data !== 'object' || required.some(key => typeof data[key] !== 'string' || !data[key].trim())) {
+            throw new Error('SOURCE_REGISTRATION_IDENTITY_INVALID')
+        }
+        if (carriesCredentialMaterial(data)) {
+            throw new Error('SOURCE_REGISTRATION_CREDENTIAL_MATERIAL_FORBIDDEN')
+        }
+    }
+
+    /**
+     * @param {Object} event
+     * @returns {void}
+     * @private
+     */
+    #recordAudit(event) {
+        this.db.prepare(
+            `INSERT INTO mc_source_registration_audit (
+                audit_id, tenant_id, source_instance_id, actor_id, action, from_state,
+                to_state, registration_epoch, recorded_at
+             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+        ).run(
+            crypto.randomUUID(), event.tenantId, event.sourceInstanceId, event.actorId, event.action,
+            event.fromState, event.toState, event.registrationEpoch, event.recordedAt
+        )
     }
 
     /**

--- a/ai/services/memory-core/communityBatchContract.mjs
+++ b/ai/services/memory-core/communityBatchContract.mjs
@@ -18,6 +18,21 @@ export const BATCH_SCHEMA_VERSION = 'community-activity-batch.v1';
  */
 export const MAX_PROVIDER_STATE_BYTES = 65536;
 
+/**
+ * @summary Maximum observations accepted by one synchronous hosted MCP push.
+ *
+ * This mirrors the established small-work MCP boundary: larger acquisition windows stay connector-side
+ * and are split into checkpoint-chained batches instead of turning Memory Core into a queue receiver.
+ * @member {Number}
+ */
+export const MAX_HOSTED_OBSERVATIONS = 50;
+
+/**
+ * @summary Maximum UTF-8 bytes accepted by one hosted community batch envelope.
+ * @member {Number}
+ */
+export const MAX_HOSTED_BATCH_BYTES = 256 * 1024;
+
 const
     REQUIRED_BATCH_KEYS       = [
         'schemaVersion', 'sourceInstanceId', 'resourceFamily', 'adapterSchemaVersion',
@@ -56,6 +71,147 @@ const
      * connector corruption on an otherwise-identical batch).
      */
     SERVER_POLICY_KEYS        = new Set(['attentionDisposition', 'attentionReason', 'eligibility', 'eligibilityReason', 'trustProjection']);
+
+const
+    HOSTED_AUTHORITY_KEYS = new Set(['registrationEpoch', 'sourceInstanceId', 'tenantId']),
+    HOSTED_SOURCE_KEYS    = ['canonicalProviderHost', 'resourceKind', 'providerResourceId'],
+    SENSITIVE_KEY_PATTERN = /(?:authorization|credential|password|private[-_]?key|secret|token)/i;
+
+/**
+ * @summary Returns true when an object graph carries credential-shaped key names.
+ *
+ * Provider grants and resolved secrets belong to the connector. The hosted wire contract refuses the
+ * whole envelope rather than attempting lossy redaction, so a connector can never mistake a stripped
+ * credential for admitted state. Values are deliberately not inspected or echoed.
+ * @param {*} value
+ * @returns {Boolean}
+ */
+export function carriesCredentialMaterial(value) {
+    if (!value || typeof value !== 'object') return false;
+
+    if (Array.isArray(value)) {
+        return value.some(carriesCredentialMaterial)
+    }
+
+    return Object.entries(value).some(([key, nested]) => (
+        SENSITIVE_KEY_PATTERN.test(key) || carriesCredentialMaterial(nested)
+    ))
+}
+
+/**
+ * @summary Returns true when any hosted payload level attempts to assert server-owned authority.
+ *
+ * The recursive walk is deliberate: OpenAPI normalization can remove unknown nested properties.
+ * Authority claims therefore have to fail on the raw request rather than disappear before the
+ * admission service sees them.
+ * @param {*} value
+ * @returns {Boolean}
+ */
+export function carriesHostedAuthority(value) {
+    if (!value || typeof value !== 'object') return false;
+
+    if (Array.isArray(value)) {
+        return value.some(carriesHostedAuthority)
+    }
+
+    return Object.entries(value).some(([key, nested]) => (
+        HOSTED_AUTHORITY_KEYS.has(key) || carriesHostedAuthority(nested)
+    ))
+}
+
+/**
+ * @summary Measures one hosted connector envelope without retaining its content.
+ * @param {Object} envelope
+ * @returns {{bytes: Number, observations: Number}}
+ */
+export function measureHostedEnvelope(envelope) {
+    let bytes = Number.POSITIVE_INFINITY;
+
+    try {
+        bytes = Buffer.byteLength(JSON.stringify(envelope), 'utf8')
+    } catch {}
+
+    return {
+        bytes,
+        observations: Array.isArray(envelope?.batch?.observations)
+            ? envelope.batch.observations.length
+            : 0
+    }
+}
+
+/**
+ * @summary Validates the hosted connector boundary before source resolution or database work.
+ *
+ * Tenant, durable source id, and registration epoch are server authority. A remote connector supplies
+ * only the neutral provider identity used for the tenant-scoped lookup plus the authority-free batch.
+ * @param {Object} envelope
+ * @param {Object} [limits]
+ * @param {Number} [limits.maxBytes]
+ * @param {Number} [limits.maxObservations]
+ * @returns {{valid: Boolean, errors: String[], volume: {bytes: Number, observations: Number}}}
+ */
+export function validateHostedEnvelope(envelope, {
+    maxBytes        = MAX_HOSTED_BATCH_BYTES,
+    maxObservations = MAX_HOSTED_OBSERVATIONS
+} = {}) {
+    const errors = [];
+
+    if (!envelope || typeof envelope !== 'object' || Array.isArray(envelope)) {
+        return {
+            valid : false,
+            errors: ['HOSTED_ENVELOPE_NOT_AN_OBJECT'],
+            volume: {bytes: 0, observations: 0}
+        }
+    }
+
+    const {source, batch} = envelope;
+
+    if (!source || typeof source !== 'object' || Array.isArray(source)) {
+        errors.push('HOSTED_SOURCE_IDENTITY_REQUIRED')
+    } else {
+        HOSTED_SOURCE_KEYS.forEach(key => {
+            if (typeof source[key] !== 'string' || !source[key].trim()) {
+                errors.push(`HOSTED_SOURCE_${key.toUpperCase()}_REQUIRED`)
+            }
+        })
+    }
+
+    if (!batch || typeof batch !== 'object' || Array.isArray(batch)) {
+        errors.push('HOSTED_BATCH_REQUIRED')
+    }
+
+    if (carriesHostedAuthority(envelope)) {
+        errors.push('HOSTED_AUTHORITY_FIELDS_FORBIDDEN')
+    }
+
+    if (carriesCredentialMaterial(envelope)) {
+        errors.push('HOSTED_CREDENTIAL_MATERIAL_FORBIDDEN')
+    }
+
+    if (batch && typeof batch === 'object' && !Array.isArray(batch)) {
+        const contract = validateBatch({
+            ...batch,
+            sourceInstanceId : 'server-resolved-hosted-source',
+            registrationEpoch: 1
+        });
+
+        errors.push(...contract.errors)
+    }
+
+    const volume = measureHostedEnvelope(envelope);
+
+    if (!Number.isFinite(volume.bytes)) {
+        errors.push('HOSTED_ENVELOPE_NOT_SERIALIZABLE')
+    } else if (volume.bytes > maxBytes) {
+        errors.push('HOSTED_BATCH_BYTES_EXCEEDED')
+    }
+
+    if (volume.observations > maxObservations) {
+        errors.push('HOSTED_BATCH_OBSERVATIONS_EXCEEDED')
+    }
+
+    return {valid: errors.length === 0, errors, volume}
+}
 
 /**
  * Returns an observation without server-owned policy fields, so digests are computed over

--- a/buildScripts/docs/seo/generate.mjs
+++ b/buildScripts/docs/seo/generate.mjs
@@ -7,15 +7,15 @@ import fg              from 'fast-glob';
 import semver          from 'semver';
 import {sanitizeInput} from '../../util/sanitizer.mjs';
 
-const ROOT_DIR          = process.cwd();
-const LEARN_DIR         = path.resolve(ROOT_DIR, 'learn');
-const PORTAL_DIR        = path.resolve(ROOT_DIR, 'apps/portal');
-const TREE_FILE_PATH    = path.join(LEARN_DIR, 'tree.json');
+const ROOT_DIR       = process.cwd();
+const LEARN_DIR      = path.resolve(ROOT_DIR, 'learn');
+const PORTAL_DIR     = path.resolve(ROOT_DIR, 'apps/portal');
+const TREE_FILE_PATH = path.join(LEARN_DIR, 'tree.json');
 // Location of the JSON index we will generate in the next step
-const RELEASES_PATH     = path.resolve(PORTAL_DIR, 'resources/data/releases.json');
-const DEFAULT_BASE_PATH = '/learn';
-const GIT_LOG_CHUNK_SIZE = 200;
-const STATUS_RENAME_CODES = new Set(['R', 'C']);
+const RELEASES_PATH                               = path.resolve(PORTAL_DIR, 'resources/data/releases.json');
+const DEFAULT_BASE_PATH                           = '/learn';
+const GIT_LOG_CHUNK_SIZE                          = 200;
+const STATUS_RENAME_CODES                         = new Set(['R', 'C']);
 const RELEASE_NOTE_NEO_GITHUB_SOURCE_LINK_PATTERN = /https:\/\/github\.com\/neomjs\/neo\/(?:blob|tree)\/([^/\s)]+)\/[^\s)]+/g;
 const RELEASE_NOTE_DISALLOWED_SOURCE_REF_PATTERN  = /^(?:main|v\d+(?:\.\d+){0,2}(?:[-.\w]*)?)$/;
 
@@ -63,6 +63,7 @@ const PRIORITIES = new Map([
     ['agentos/NeuralLink'                           , 1.0],
     ['agentos/tooling/NeuralLinkCapabilityMatrix'   , 0.8],
     ['agentos/tooling/GenesisNeuralLinkProbe'       , 0.8],
+    ['agentos/tooling/CommunitySourceRunbook'       , 0.7],
     ['agentos/KnowledgeBase'                        , 1.0],
     ['agentos/MemoryCore'                           , 1.0],
     ['agentos/SelfHealing'                          , 1.0],
@@ -295,8 +296,8 @@ function getChangedGitPaths() {
                 continue;
             }
 
-            const status = entry.slice(0, 2);
-            let gitPath  = entry.slice(3);
+            const status  = entry.slice(0, 2);
+            let   gitPath = entry.slice(3);
 
             if (STATUS_RENAME_CODES.has(status[0]) || STATUS_RENAME_CODES.has(status[1])) {
                 i++;
@@ -384,7 +385,7 @@ function chunkArray(items, size) {
  * @returns {Map<String, String>} Map of filePath -> ISO date string
  */
 function getGitLastModifiedBatch(filePaths) {
-    const dateMap = new Map();
+    const dateMap     = new Map();
     const uniquePaths = Array.from(new Set(filePaths));
 
     if (uniquePaths.length === 0) {
@@ -487,7 +488,7 @@ async function getExistingSitemapLastmodMap(sitemapPath) {
         return lastmodMap;
     }
 
-    const sitemap = await fs.readFile(sitemapPath, 'utf-8');
+    const sitemap  = await fs.readFile(sitemapPath, 'utf-8');
     const urlRegex = /<url>[\s\S]*?<loc>(.*?)<\/loc>[\s\S]*?<lastmod>(.*?)<\/lastmod>[\s\S]*?<\/url>/g;
 
     for (const match of sitemap.matchAll(urlRegex)) {
@@ -579,8 +580,8 @@ function getNameFromExamplePath(examplePath) {
  */
 async function collectExampleRoutes() {
     let files = await fg('{apps,examples}/**/index.html', {
-        cwd    : ROOT_DIR,
-        ignore : ['**/node_modules/**']
+        cwd   : ROOT_DIR,
+        ignore: ['**/node_modules/**']
     });
 
     // Filter out paths containing "childapps"
@@ -590,8 +591,8 @@ async function collectExampleRoutes() {
     files.sort((a, b) => a.localeCompare(b));
 
     return Promise.all(files.map(async (file) => {
-        const filePath = path.resolve(ROOT_DIR, file);
-        const content  = await fs.readFile(filePath, 'utf-8');
+        const filePath   = path.resolve(ROOT_DIR, file);
+        const content    = await fs.readFile(filePath, 'utf-8');
         const titleMatch = content.match(/<title>(.*?)<\/title>/i);
 
         return {
@@ -609,8 +610,8 @@ async function collectExampleRoutes() {
  */
 async function collectReleaseRoutes() {
     const files = await fg('resources/content/release-notes/**/*.md', {
-        cwd    : ROOT_DIR,
-        ignore : ['**/node_modules/**']
+        cwd   : ROOT_DIR,
+        ignore: ['**/node_modules/**']
     });
 
     const releases = await Promise.all(files.map(async file => {
@@ -655,15 +656,15 @@ async function collectIssueRoutes() {
         'resources/content/issues/**/*.md',
         'resources/content/archive/issues/**/issue-*.md'
     ], {
-        cwd    : ROOT_DIR,
-        ignore : ['**/node_modules/**']
+        cwd   : ROOT_DIR,
+        ignore: ['**/node_modules/**']
     });
 
     const issues = files.map(file => {
-        const filePath = path.resolve(ROOT_DIR, file);
-        const fileName = path.basename(file, '.md'); // e.g., 'issue-8186'
+        const filePath       = path.resolve(ROOT_DIR, file);
+        const fileName       = path.basename(file, '.md'); // e.g., 'issue-8186'
         const issueNumberStr = fileName.startsWith('issue-') ? fileName.substring(6) : fileName;
-        const issueNumber = parseInt(issueNumberStr, 10);
+        const issueNumber    = parseInt(issueNumberStr, 10);
 
         return {
             category: 'tickets',
@@ -685,15 +686,15 @@ async function collectPullRoutes() {
         'resources/content/pulls/**/pr-*.md',
         'resources/content/archive/pulls/**/pr-*.md'
     ], {
-        cwd    : ROOT_DIR,
-        ignore : ['**/node_modules/**']
+        cwd   : ROOT_DIR,
+        ignore: ['**/node_modules/**']
     });
 
     const pulls = files.map(file => {
-        const filePath = path.resolve(ROOT_DIR, file);
-        const fileName = path.basename(file, '.md');
+        const filePath      = path.resolve(ROOT_DIR, file);
+        const fileName      = path.basename(file, '.md');
         const pullNumberStr = fileName.startsWith('pr-') ? fileName.substring(3) : fileName;
-        const pullNumber = parseInt(pullNumberStr, 10);
+        const pullNumber    = parseInt(pullNumberStr, 10);
 
         return {
             category: 'pull-requests',
@@ -715,15 +716,15 @@ async function collectDiscussionRoutes() {
         'resources/content/discussions/**/discussion-*.md',
         'resources/content/archive/discussions/**/discussion-*.md'
     ], {
-        cwd    : ROOT_DIR,
-        ignore : ['**/node_modules/**']
+        cwd   : ROOT_DIR,
+        ignore: ['**/node_modules/**']
     });
 
     const discussions = files.map(file => {
-        const filePath = path.resolve(ROOT_DIR, file);
-        const fileName = path.basename(file, '.md');
+        const filePath            = path.resolve(ROOT_DIR, file);
+        const fileName            = path.basename(file, '.md');
         const discussionNumberStr = fileName.startsWith('discussion-') ? fileName.substring(11) : fileName;
-        const discussionNumber = parseInt(discussionNumberStr, 10);
+        const discussionNumber    = parseInt(discussionNumberStr, 10);
 
         return {
             category     : 'discussions',
@@ -903,7 +904,7 @@ export async function getSitemapXml(options={}) {
         throw new Error('getSitemapXml requires a baseUrl option to produce absolute URLs.');
     }
 
-    const allRoutes = await collectAllRoutes();
+    const allRoutes      = await collectAllRoutes();
     const filteredRoutes = allRoutes.filter(({id}) =>
         includeTopLevel || !id.startsWith('/')
     );
@@ -1057,9 +1058,9 @@ To access bundled versions, prefix paths with \`/dist/production/\`, \`/dist/dev
         }
     }
 
-    const topLevelRoutes = allRoutes.filter(route => route.category === 'top-level');
-    const releaseRoutes  = allRoutes.filter(route => route.category === 'release-notes');
-    const ticketRoutes   = allRoutes.filter(route => route.category === 'tickets');
+    const topLevelRoutes   = allRoutes.filter(route => route.category === 'top-level');
+    const releaseRoutes    = allRoutes.filter(route => route.category === 'release-notes');
+    const ticketRoutes     = allRoutes.filter(route => route.category === 'tickets');
     const pullRoutes       = allRoutes.filter(route => route.category === 'pull-requests');
     const discussionRoutes = allRoutes.filter(route => route.category === 'discussions');
     const exampleRoutes    = allRoutes.filter(route => route.category === 'file');
@@ -1068,7 +1069,7 @@ To access bundled versions, prefix paths with \`/dist/production/\`, \`/dist/dev
     content += `## Main Pages\n\n`;
     const topLevelUrls = topLevelRoutes.map(route => {
         // Beautify route name: /about-us -> About Us
-        const name  = route.id.substring(1).split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
+        const name = route.id.substring(1).split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ');
 
         let urlStr;
         if (route.filePath && route.filePath.endsWith('.md')) {
@@ -1086,7 +1087,7 @@ To access bundled versions, prefix paths with \`/dist/production/\`, \`/dist/dev
     if (exampleRoutes.length > 0) {
         content += `## Demo Apps and Examples\n\n`;
         const exampleUrls = exampleRoutes.map(route => {
-            const url   = new URL(route.id, baseUrl).toString();
+            const url = new URL(route.id, baseUrl).toString();
             return `- [${route.name}](${url})`;
         });
         content += exampleUrls.join('\n') + '\n\n';
@@ -1105,9 +1106,9 @@ To access bundled versions, prefix paths with \`/dist/production/\`, \`/dist/dev
         content += `## Release Notes\n\n`;
         content += `Here you find the full history of Neo.mjs updates.\n\n`;
         const mappedUrls = releaseRoutes.map(route => {
-            const name = `v${route.version}`;
+            const name      = `v${route.version}`;
             const cleanPath = route.id.startsWith('/') ? route.id.substring(1) : route.id;
-            const urlStr = new URL(`raw/${cleanPath}.md`, baseUrl).toString();
+            const urlStr    = new URL(`raw/${cleanPath}.md`, baseUrl).toString();
             return `- [${name}](${urlStr})`;
         });
         content += mappedUrls.join('\n') + '\n\n';
@@ -1150,9 +1151,9 @@ To access bundled versions, prefix paths with \`/dist/production/\`, \`/dist/dev
         content += `## GitHub Tickets\n\n`;
         content += `Here you find historical technical discussions and GitHub issues.\n\n`;
         const mappedUrls = ticketRoutes.map(route => {
-            const name = `Ticket #${route.issueNum}`;
+            const name      = `Ticket #${route.issueNum}`;
             const cleanPath = route.id.startsWith('/') ? route.id.substring(1) : route.id;
-            const urlStr = new URL(`raw/${cleanPath}.md`, baseUrl).toString();
+            const urlStr    = new URL(`raw/${cleanPath}.md`, baseUrl).toString();
             return `- [${name}](${urlStr})`;
         });
         content += mappedUrls.join('\n') + '\n\n';
@@ -1162,9 +1163,9 @@ To access bundled versions, prefix paths with \`/dist/production/\`, \`/dist/dev
         content += `## GitHub Pull Requests\n\n`;
         content += `Here you find problem-to-solution records from Neo.mjs pull requests.\n\n`;
         const mappedUrls = pullRoutes.map(route => {
-            const name = `Pull Request #${route.pullNum}`;
+            const name      = `Pull Request #${route.pullNum}`;
             const cleanPath = route.id.startsWith('/') ? route.id.substring(1) : route.id;
-            const urlStr = new URL(`raw/${cleanPath}.md`, baseUrl).toString();
+            const urlStr    = new URL(`raw/${cleanPath}.md`, baseUrl).toString();
             return `- [${name}](${urlStr})`;
         });
         content += mappedUrls.join('\n') + '\n\n';
@@ -1174,9 +1175,9 @@ To access bundled versions, prefix paths with \`/dist/production/\`, \`/dist/dev
         content += `## GitHub Discussions\n\n`;
         content += `Here you find Ideation Sandbox and architectural discussion records.\n\n`;
         const mappedUrls = discussionRoutes.map(route => {
-            const name = `Discussion #${route.discussionNum}`;
+            const name      = `Discussion #${route.discussionNum}`;
             const cleanPath = route.id.startsWith('/') ? route.id.substring(1) : route.id;
-            const urlStr = new URL(`raw/${cleanPath}.md`, baseUrl).toString();
+            const urlStr    = new URL(`raw/${cleanPath}.md`, baseUrl).toString();
             return `- [${name}](${urlStr})`;
         });
         content += mappedUrls.join('\n') + '\n\n';
@@ -1214,17 +1215,17 @@ async function runCli() {
 
     switch (format) {
         case 'array': {
-            const routes  = await getContentRoutes({basePath, includeTopLevel});
+            const routes = await getContentRoutes({basePath, includeTopLevel});
             outputContent = JSON.stringify(routes, null, 2);
             break;
         }
         case 'objects': {
-            const routes  = await getContentRouteObjects({basePath, includeTopLevel});
+            const routes = await getContentRouteObjects({basePath, includeTopLevel});
             outputContent = JSON.stringify(routes, null, 2);
             break;
         }
         case 'urls': {
-            const urls    = await getContentUrls({baseUrl, basePath, includeTopLevel});
+            const urls = await getContentUrls({baseUrl, basePath, includeTopLevel});
             outputContent = JSON.stringify(urls, null, 2);
             break;
         }

--- a/learn/agentos/tooling/CommunitySourceRunbook.md
+++ b/learn/agentos/tooling/CommunitySourceRunbook.md
@@ -1,0 +1,165 @@
+# Hosted Community Source Runbook
+
+This runbook operates the authenticated hosted path for GitHub community-activity batches. It is a
+small synchronous push path into Memory Core's neutral admission transaction—not a webhook receiver,
+not a queue, and not tenant self-service.
+
+The authority boundary is the important part:
+
+- A deployment operator registers and changes source lifecycle through a **co-located CLI**. These
+  operations are not MCP tools; an MCP `admin` projection label grants no source-admin authority.
+- A connector authenticates to the Memory Core Streamable HTTP endpoint and supplies neutral provider
+  identity plus an authority-free batch. The server derives the tenant and resolves the durable source
+  id and current registration epoch.
+- GitHub installation grants and resolved credentials remain in the connector's secret store. Memory
+  Core stores only neutral registration attestations and rejects credential-shaped payload keys.
+
+The exact request and response schemas are owned by
+[`ai/mcp/server/memory-core/openapi.yaml`](../../../ai/mcp/server/memory-core/openapi.yaml), through the
+`admit_community_batch` and `get_community_source_health` operations.
+
+## 1. Register the neutral source
+
+Run the control-plane command in the Memory Core deployment container or on a host with the same
+database configuration. Set a stable operator audit identity; it is recorded with every transition.
+
+```bash
+export NEO_COMMUNITY_OPERATOR_ID='deployment-operator'
+```
+
+Create a credential-free registration document:
+
+```json
+{
+  "provider": "github",
+  "canonicalProviderHost": "github.com",
+  "resourceKind": "repository",
+  "providerResourceId": "neomjs/neo",
+  "displayLocator": "neomjs/neo",
+  "grantRef": "github-installation:12345",
+  "providerCapabilities": {
+    "issues": true,
+    "pullRequests": true
+  }
+}
+```
+
+`grantRef` is a neutral binding identifier, never a token, credential reference, private key, or
+authorization header. Register it for the deployment-owned tenant key:
+
+```bash
+npm run ai:community-source-operator -- \
+  --action register \
+  --tenant-id tenant-a \
+  --source-file /run/community/source.json
+```
+
+The response contains the server-minted `sourceInstanceId`, state `REQUESTED`, and epoch `1`.
+
+## 2. Provision and activate with compare-and-swap
+
+Every lifecycle write presents the state and epoch the operator observed. This prevents a delayed
+activation from resurrecting a source after a concurrent revoke.
+
+```bash
+npm run ai:community-source-operator -- \
+  --action provision \
+  --tenant-id tenant-a \
+  --source-instance-id SOURCE_ID \
+  --expected-state REQUESTED \
+  --expected-epoch 1
+
+npm run ai:community-source-operator -- \
+  --action activate \
+  --tenant-id tenant-a \
+  --source-instance-id SOURCE_ID \
+  --expected-state PROVISIONED \
+  --expected-epoch 2
+```
+
+Provisioning advances the epoch; activation does not. Give the connector only the neutral provider
+identity from the registration document. It must not send `tenantId`, `sourceInstanceId`, or
+`registrationEpoch`.
+
+## 3. Bind connector credentials outside Memory Core
+
+Configure the GitHub App installation or equivalent grant in the connector's own secret store. The
+connector uses that grant to acquire provider data, normalizes it to
+`community-activity-batch.v1`, and writes only the authority-free envelope to disk or stdin.
+
+The bearer token below authorizes the remote MCP request. It is separate from the GitHub provider
+credential and stays in the connector environment:
+
+```bash
+export NEO_MEMORY_CORE_MCP_URL='https://memory.example.com/mcp'
+export NEO_COMMUNITY_BATCH_TOKEN='...'
+
+npm run ai:community-batch-push -- \
+  --from-file /run/community/batch.json
+```
+
+One call accepts at most 50 observations and 256 KiB of serialized envelope data. Larger acquisition
+windows are split connector-side into checkpoint-chained batches. `COMMUNITY_BATCH_VOLUME_EXCEEDED`
+is backpressure evidence, not permission to bypass the bound or introduce a queue receiver.
+
+The client makes at most two attempts by default. If the first response is lost, the retry sends the
+same `batchId` and exact envelope; the server returns the original receipt for the same digest. A reused
+`batchId` with different bytes is a conflict.
+
+## 4. Read readiness without raw database access
+
+Call `get_community_source_health` with the same neutral provider identity. The response contains:
+
+- lifecycle state and current registration epoch;
+- last receipt id, resource family, and admission time;
+- `lag` measured explicitly as last-receipt age—not provider-head lag;
+- coverage-gap counts and stable codes, never provider prose or credentials.
+
+`COMMUNITY_SOURCE_READY` means the source is `ACTIVE`. `COMMUNITY_SOURCE_NOT_FOUND` intentionally
+collapses unknown-source and wrong-tenant lookups so the read path does not become a tenant oracle.
+
+## 5. Revoke and audit
+
+Revoke from the last observed control generation:
+
+```bash
+npm run ai:community-source-operator -- \
+  --action revoke \
+  --tenant-id tenant-a \
+  --source-instance-id SOURCE_ID \
+  --expected-state ACTIVE \
+  --expected-epoch 2
+```
+
+Admission checks lifecycle and epoch inside the same serialized SQLite transaction as receipt and
+checkpoint mutation. A batch racing the revoke either commits before it or observes the revoked state;
+it cannot partially admit under stale authority.
+
+Inspect the credential-free control-plane trail:
+
+```bash
+npm run ai:community-source-operator -- \
+  --action audit \
+  --tenant-id tenant-a \
+  --source-instance-id SOURCE_ID
+```
+
+To reactivate a revoked source, provision it again from `REVOKED` using the observed epoch, then activate
+the newly provisioned generation. Re-provisioning advances the epoch and permanently fences connectors
+holding the old generation.
+
+## Failure posture
+
+Branch automation on stable codes, not error prose:
+
+- `COMMUNITY_BATCH_ENVELOPE_INVALID` — authority fields, credential-shaped keys, malformed input, or
+  an unsupported contract shape; fix the connector before retrying.
+- `COMMUNITY_BATCH_VOLUME_EXCEEDED` — split the acquisition window into smaller chained batches.
+- `COMMUNITY_SOURCE_NOT_FOUND` — verify operator registration and the authenticated tenant binding.
+- `REGISTRATION_NOT_ADMISSIBLE` — source state or epoch changed; refresh readiness and reconcile.
+- `DIGEST_MISMATCH` or `OBSERVATION_DIGEST_MISMATCH` — same identity arrived with different bytes;
+  stop automatic retry and investigate connector determinism.
+- `STALE_BASIS` — refresh the checkpoint basis before building the next batch.
+
+There is deliberately no tenant registration tool and no neutral HTTP/queue receiver. Those surfaces
+need a real membership/source-admin authority and measured queue demand before they can graduate.

--- a/learn/tree.json
+++ b/learn/tree.json
@@ -85,6 +85,7 @@
             {"name": "Knowledge Base MCP API",                          "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/KnowledgeBaseMcpApi"},
             {"name": "Memory Core MCP API",                            "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/MemoryCoreMcpApi"},
             {"name": "Memory Core MCP Authentication",                 "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/MemoryCoreMcpAuth"},
+            {"name": "Hosted Community Source Runbook",                "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/CommunitySourceRunbook"},
             {"name": "Graph Back-Fill: Memory & Session Lifecycle",    "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/GraphBackfill"},
             {"name": "Chrome DevTools MCP Server",                     "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/ChromeDevToolsMcpServer"},
             {"name": "GitHub CLI Setup",                               "parentId": "AgentOS/Tooling",                                     "id": "agentos/tooling/GitHubCLISetup"},

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
         "ai:graph-lifecycle-report"            : "node ./ai/scripts/maintenance/graphLifecycleReport.mjs",
         "ai:ingest-tenant"                     : "node ./ai/scripts/maintenance/ingestTenant.mjs",
         "ai:kb-push-client"                    : "node ./ai/scripts/maintenance/kbPushClient.mjs",
+        "ai:community-batch-push"              : "node ./ai/scripts/maintenance/communityBatchPushClient.mjs",
+        "ai:community-source-operator"         : "node ./ai/scripts/maintenance/communitySourceOperator.mjs",
         "ai:mcp-healthcheck"                   : "node ./ai/scripts/diagnostics/mcpHealthcheck.mjs",
         "ai:mcp-client"                        : "node ./ai/mcp/client/mcp-cli.mjs",
         "ai:mcp-server-file-system"            : "node ./ai/mcp/server/file-system/mcp-server.mjs",

--- a/test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs
+++ b/test/playwright/unit/ai/mcp/client/McpClientTransportConfig.spec.mjs
@@ -103,6 +103,29 @@ test.describe('Neo.ai.mcp.client.Client transport config', () => {
         client.destroy();
     });
 
+    test('uses an entrypoint-injected connection without mutating the shared config Provider', () => {
+        const
+            before           = JSON.stringify(ClientConfig.mcpServers),
+            connectionConfig = {
+                transportType   : 'streamable-http',
+                url             : 'http://127.0.0.1:13094/mcp',
+                transportOptions: {requestInit: {headers: {Authorization: 'Bearer transient'}}}
+            },
+            client = Neo.create(TransportConfigClient, {
+                connectionConfig,
+                serverName: 'transient-community-source'
+            });
+
+        client.loadServerConfig('transient-community-source');
+
+        expect(client.transportType).toBe('streamable-http');
+        expect(client.transportOptions).toEqual(connectionConfig.transportOptions);
+        expect(client.createTransport()).toBeInstanceOf(StreamableHTTPClientTransport);
+        expect(JSON.stringify(ClientConfig.mcpServers)).toBe(before);
+
+        client.destroy();
+    });
+
     test('creates deprecated SSE transports for legacy remote servers', () => {
         const serverName = addServerConfig({
             transportType: 'sse',

--- a/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/McpServerListToolsSmoke.spec.mjs
@@ -139,6 +139,12 @@ function getDefaultListedOperationIds(server) {
         return operationIds.filter(name => name !== 'ingest_source_files');
     }
 
+    if (server.name === 'memory-core') {
+        const hostedOnly = new Set(['admit_community_batch', 'get_community_source_health']);
+
+        return operationIds.filter(name => !hostedOnly.has(name))
+    }
+
     return operationIds;
 }
 
@@ -572,18 +578,18 @@ test.describe('Neo MCP servers — cross-server listTools smoke (#11687)', () =>
 
     test('github-workflow exposes compact list descriptions plus lazy-loaded handbook detail (#13736)', async () => {
         const
-            server       = servers.find(item => item.name === 'github-workflow'),
-            {tools}      = await listTools(server),
-            byName       = Object.fromEntries(tools.map(tool => [tool.name, tool])),
-            moduleUrl    = pathToFileURL(path.join(repoRoot, server.toolServicePath)).href,
-            {callTool}   = await import(moduleUrl),
-            handbook     = await callTool('get_mcp_tool_handbook', {toolId: 'update_issue_relationship'}),
+            server         = servers.find(item => item.name === 'github-workflow'),
+            {tools}        = await listTools(server),
+            byName         = Object.fromEntries(tools.map(tool => [tool.name, tool])),
+            moduleUrl      = pathToFileURL(path.join(repoRoot, server.toolServicePath)).href,
+            {callTool}     = await import(moduleUrl),
+            handbook       = await callTool('get_mcp_tool_handbook', {toolId: 'update_issue_relationship'}),
             reviewHandbook = await callTool('get_mcp_tool_handbook', {toolId: 'manage_pr_review'}),
-            missing      = await callTool('get_mcp_tool_handbook', {toolId: 'missing_tool'}),
-            relationship = byName.update_issue_relationship,
-            conversation = byName.get_conversation,
-            review       = byName.manage_pr_review,
-            handbookTool = byName.get_mcp_tool_handbook;
+            missing        = await callTool('get_mcp_tool_handbook', {toolId: 'missing_tool'}),
+            relationship   = byName.update_issue_relationship,
+            conversation   = byName.get_conversation,
+            review         = byName.manage_pr_review,
+            handbookTool   = byName.get_mcp_tool_handbook;
 
         expect(handbookTool.description.length).toBeLessThanOrEqual(120);
         expect(handbookTool.annotations.readOnlyHint).toBe(true);

--- a/test/playwright/unit/ai/mcp/server/memory-core/CommunityBatchTool.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/CommunityBatchTool.spec.mjs
@@ -1,0 +1,144 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {
+        name             : 'MemoryCoreCommunityBatchToolTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary OpenAPI registration and hosted-transport guards for the community batch facade.
+ */
+test.describe.configure({mode: 'serial'});
+
+test.describe('Memory Core hosted community tools (#15156)', () => {
+    let AdmissionService, aiConfig, callTool, listTools, originalAdmit, originalHealth, originalTransport;
+
+    const envelope = () => ({
+        source: {
+            canonicalProviderHost: 'github.com',
+            resourceKind         : 'repository',
+            providerResourceId   : 'neomjs/neo'
+        },
+        batch: {
+            schemaVersion             : 'community-activity-batch.v1',
+            resourceFamily            : 'issues',
+            adapterSchemaVersion      : 'github-issue.v1',
+            providerStateSchemaVersion: 'gh-state.v1',
+            baseCheckpointVersion     : 0,
+            baseInventoryHash         : null,
+            batchId                   : 'batch-1',
+            observations              : [{
+                providerEntityId    : '1',
+                occurrenceKind      : 'issue.opened',
+                occurrenceCoordinate: '1:create',
+                occurredAt          : '2026-07-18T10:00:00Z',
+                actorKind           : 'user'
+            }],
+            nextProviderState: {cursor: 'p2'},
+            nextInventoryHash: 'inv-1',
+            coverage         : {fromBasis: 'c1', toBasis: 'c9', complete: true}
+        }
+    });
+
+    test.beforeAll(async () => {
+        ({callTool, listTools} = await import('../../../../../../../ai/mcp/server/memory-core/toolService.mjs'));
+        aiConfig         = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        AdmissionService = (await import('../../../../../../../ai/services/memory-core/CommunityBatchAdmissionService.mjs')).default;
+
+        originalAdmit     = AdmissionService.admitHostedBatch;
+        originalHealth    = AdmissionService.getHostedSourceHealth;
+        originalTransport = aiConfig.transport;
+    });
+
+    test.afterAll(() => {
+        AdmissionService.admitHostedBatch       = originalAdmit;
+        AdmissionService.getHostedSourceHealth = originalHealth;
+        aiConfig.transport                      = originalTransport;
+    });
+
+    test.beforeEach(() => {
+        aiConfig.transport = 'streamable-http';
+    });
+
+    test('streamable-http lists both bounded tools and dispatches the authority-free envelope', async () => {
+        const pushed = [];
+
+        AdmissionService.admitHostedBatch = args => {
+            pushed.push(args);
+            return {status: 'accepted'}
+        };
+        AdmissionService.getHostedSourceHealth = () => ({ready: true, code: 'COMMUNITY_SOURCE_READY'});
+
+        const names = listTools().tools.map(tool => tool.name);
+        expect(names).toContain('admit_community_batch');
+        expect(names).toContain('get_community_source_health');
+
+        await expect(callTool('admit_community_batch', envelope())).resolves.toEqual({status: 'accepted'});
+        expect(pushed).toEqual([envelope()]);
+        await expect(callTool('get_community_source_health', {source: envelope().source}))
+            .resolves.toEqual({ready: true, code: 'COMMUNITY_SOURCE_READY'});
+    });
+
+    test('OpenAPI rejects caller-stamped authority before service dispatch', async () => {
+        let dispatched = false;
+        AdmissionService.admitHostedBatch = () => {
+            dispatched = true;
+            return {status: 'accepted'}
+        };
+
+        const forged = envelope();
+        forged.batch.registrationEpoch = 2;
+
+        await expect(callTool('admit_community_batch', forged)).resolves.toMatchObject({
+            status: 'conflict',
+            code  : 'COMMUNITY_BATCH_ENVELOPE_INVALID'
+        });
+        expect(dispatched).toBe(false);
+    });
+
+    test('raw boundary refuses nested prose and health credentials before OpenAPI can strip them', async () => {
+        let admissionDispatched = false,
+            healthDispatched    = false;
+
+        AdmissionService.admitHostedBatch = () => {
+            admissionDispatched = true;
+            return {status: 'accepted'}
+        };
+        AdmissionService.getHostedSourceHealth = () => {
+            healthDispatched = true;
+            return {ready: true, code: 'COMMUNITY_SOURCE_READY'}
+        };
+
+        const withProse = envelope();
+        withProse.batch.observations[0].title = 'must not disappear';
+
+        await expect(callTool('admit_community_batch', withProse)).resolves.toMatchObject({
+            status: 'conflict',
+            code  : 'COMMUNITY_BATCH_ENVELOPE_INVALID',
+            errors: expect.arrayContaining(['OBSERVATION_0_CARRIES_PROSE_TITLE'])
+        });
+        await expect(callTool('get_community_source_health', {
+            source     : envelope().source,
+            accessToken: 'must not disappear'
+        })).resolves.toEqual({ready: false, code: 'COMMUNITY_SOURCE_IDENTITY_INVALID'});
+        expect(admissionDispatched).toBe(false);
+        expect(healthDispatched).toBe(false);
+    });
+
+    test('stdio hides and refuses hosted tools while direct service admission remains available', async () => {
+        aiConfig.transport = 'stdio';
+
+        const names = listTools().tools.map(tool => tool.name);
+        expect(names).not.toContain('admit_community_batch');
+        expect(names).not.toContain('get_community_source_health');
+        await expect(callTool('admit_community_batch', envelope())).rejects.toThrow(/streamable-http/);
+    });
+});

--- a/test/playwright/unit/ai/mcp/server/memory-core/CommunityBatchTool.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/CommunityBatchTool.spec.mjs
@@ -50,7 +50,7 @@ test.describe('Memory Core hosted community tools (#15156)', () => {
 
     test.beforeAll(async () => {
         ({callTool, listTools} = await import('../../../../../../../ai/mcp/server/memory-core/toolService.mjs'));
-        aiConfig         = (await import('../../../../../../../ai/mcp/server/memory-core/config.mjs')).default;
+        aiConfig         = (await import('../../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
         AdmissionService = (await import('../../../../../../../ai/services/memory-core/CommunityBatchAdmissionService.mjs')).default;
 
         originalAdmit     = AdmissionService.admitHostedBatch;

--- a/test/playwright/unit/ai/mcp/server/memory-core/CommunityBatchTool.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/CommunityBatchTool.spec.mjs
@@ -19,7 +19,7 @@ import * as core      from '../../../../../../../src/core/_export.mjs';
 test.describe.configure({mode: 'serial'});
 
 test.describe('Memory Core hosted community tools (#15156)', () => {
-    let AdmissionService, aiConfig, callTool, listTools, originalAdmit, originalHealth, originalTransport;
+    let AdmissionService, createTransportVisibleToolFacade, hostedFacade, localFacade, originalAdmit, originalHealth;
 
     const envelope = () => ({
         source: {
@@ -49,23 +49,21 @@ test.describe('Memory Core hosted community tools (#15156)', () => {
     });
 
     test.beforeAll(async () => {
-        ({callTool, listTools} = await import('../../../../../../../ai/mcp/server/memory-core/toolService.mjs'));
-        aiConfig         = (await import('../../../../../../../ai/mcp/server/memory-core/config.template.mjs')).default;
+        ({createTransportVisibleToolFacade} = await import(
+            '../../../../../../../ai/mcp/server/memory-core/toolService.mjs'
+        ));
+
+        hostedFacade     = createTransportVisibleToolFacade({resolveTransport: () => 'streamable-http'});
+        localFacade      = createTransportVisibleToolFacade({resolveTransport: () => 'stdio'});
         AdmissionService = (await import('../../../../../../../ai/services/memory-core/CommunityBatchAdmissionService.mjs')).default;
 
-        originalAdmit     = AdmissionService.admitHostedBatch;
-        originalHealth    = AdmissionService.getHostedSourceHealth;
-        originalTransport = aiConfig.transport;
+        originalAdmit  = AdmissionService.admitHostedBatch;
+        originalHealth = AdmissionService.getHostedSourceHealth;
     });
 
     test.afterAll(() => {
         AdmissionService.admitHostedBatch       = originalAdmit;
         AdmissionService.getHostedSourceHealth = originalHealth;
-        aiConfig.transport                      = originalTransport;
-    });
-
-    test.beforeEach(() => {
-        aiConfig.transport = 'streamable-http';
     });
 
     test('streamable-http lists both bounded tools and dispatches the authority-free envelope', async () => {
@@ -77,13 +75,13 @@ test.describe('Memory Core hosted community tools (#15156)', () => {
         };
         AdmissionService.getHostedSourceHealth = () => ({ready: true, code: 'COMMUNITY_SOURCE_READY'});
 
-        const names = listTools().tools.map(tool => tool.name);
+        const names = hostedFacade.listTools().tools.map(tool => tool.name);
         expect(names).toContain('admit_community_batch');
         expect(names).toContain('get_community_source_health');
 
-        await expect(callTool('admit_community_batch', envelope())).resolves.toEqual({status: 'accepted'});
+        await expect(hostedFacade.callTool('admit_community_batch', envelope())).resolves.toEqual({status: 'accepted'});
         expect(pushed).toEqual([envelope()]);
-        await expect(callTool('get_community_source_health', {source: envelope().source}))
+        await expect(hostedFacade.callTool('get_community_source_health', {source: envelope().source}))
             .resolves.toEqual({ready: true, code: 'COMMUNITY_SOURCE_READY'});
     });
 
@@ -97,7 +95,7 @@ test.describe('Memory Core hosted community tools (#15156)', () => {
         const forged = envelope();
         forged.batch.registrationEpoch = 2;
 
-        await expect(callTool('admit_community_batch', forged)).resolves.toMatchObject({
+        await expect(hostedFacade.callTool('admit_community_batch', forged)).resolves.toMatchObject({
             status: 'conflict',
             code  : 'COMMUNITY_BATCH_ENVELOPE_INVALID'
         });
@@ -120,12 +118,12 @@ test.describe('Memory Core hosted community tools (#15156)', () => {
         const withProse = envelope();
         withProse.batch.observations[0].title = 'must not disappear';
 
-        await expect(callTool('admit_community_batch', withProse)).resolves.toMatchObject({
+        await expect(hostedFacade.callTool('admit_community_batch', withProse)).resolves.toMatchObject({
             status: 'conflict',
             code  : 'COMMUNITY_BATCH_ENVELOPE_INVALID',
             errors: expect.arrayContaining(['OBSERVATION_0_CARRIES_PROSE_TITLE'])
         });
-        await expect(callTool('get_community_source_health', {
+        await expect(hostedFacade.callTool('get_community_source_health', {
             source     : envelope().source,
             accessToken: 'must not disappear'
         })).resolves.toEqual({ready: false, code: 'COMMUNITY_SOURCE_IDENTITY_INVALID'});
@@ -134,11 +132,24 @@ test.describe('Memory Core hosted community tools (#15156)', () => {
     });
 
     test('stdio hides and refuses hosted tools while direct service admission remains available', async () => {
-        aiConfig.transport = 'stdio';
-
-        const names = listTools().tools.map(tool => tool.name);
+        const names = localFacade.listTools().tools.map(tool => tool.name);
         expect(names).not.toContain('admit_community_batch');
         expect(names).not.toContain('get_community_source_health');
-        await expect(callTool('admit_community_batch', envelope())).rejects.toThrow(/streamable-http/);
+        await expect(localFacade.callTool('admit_community_batch', envelope())).rejects.toThrow(/streamable-http/);
+    });
+
+    test('transport authority resolves at call time and unknown transports fail closed', async () => {
+        let transport = 'stdio';
+
+        const facade = createTransportVisibleToolFacade({resolveTransport: () => transport});
+
+        expect(facade.listTools().tools.map(tool => tool.name)).not.toContain('admit_community_batch');
+
+        transport = 'streamable-http';
+        expect(facade.listTools().tools.map(tool => tool.name)).toContain('admit_community_batch');
+
+        transport = 'websocket';
+        expect(facade.listTools().tools.map(tool => tool.name)).not.toContain('admit_community_batch');
+        await expect(facade.callTool('admit_community_batch', envelope())).rejects.toThrow(/streamable-http/);
     });
 });

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -252,7 +252,9 @@ const githubWorkflowDangerousReadForbidden = [
 const memoryCoreToolTiers = ['read', 'write', 'extended', 'admin'];
 
 const expectedMemoryCoreToolTiers = {
+    admit_community_batch        : 'write',
     healthcheck                  : 'read',
+    get_community_source_health  : 'read',
     get_mcp_tool_handbook        : 'read',
     get_memory_core_tool_metrics : 'extended',
     get_deployment_state_snapshot: 'extended',
@@ -297,6 +299,7 @@ const expectedMemoryCoreToolTiers = {
 // grant/revoke_permission) are `admin`; the constant maintainer-writes (add_message/add_memory/mark_read/
 // record_turn_presence) are visible `write`; the rest of the mutations are withheld `extended`.
 const memoryCoreDangerousReadForbidden = [
+    'admit_community_batch',
     'add_memory',
     'add_message',
     'mark_read',

--- a/test/playwright/unit/ai/scripts/maintenance/communityBatchPushClient.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/communityBatchPushClient.spec.mjs
@@ -1,0 +1,165 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {
+        name             : 'CommunityBatchPushClientTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+import {Readable}     from 'stream';
+
+/**
+ * @summary Remote client witnesses for auth-header isolation, exact-envelope retry, and local bounds.
+ */
+test.describe('communityBatchPushClient — hosted connector push (#15156)', () => {
+    let buildServerConfig, hasPushFailure, parseArgs, runPush, validateArgs;
+
+    const envelope = () => ({
+        source: {
+            canonicalProviderHost: 'github.com',
+            resourceKind         : 'repository',
+            providerResourceId   : 'neomjs/neo'
+        },
+        batch: {
+            schemaVersion             : 'community-activity-batch.v1',
+            resourceFamily            : 'issues',
+            adapterSchemaVersion      : 'github-issue.v1',
+            providerStateSchemaVersion: 'gh-state.v1',
+            baseCheckpointVersion     : 0,
+            baseInventoryHash         : null,
+            batchId                   : 'batch-1',
+            observations              : [{
+                providerEntityId    : '1',
+                occurrenceKind      : 'issue.opened',
+                occurrenceCoordinate: '1:create',
+                occurredAt          : '2026-07-18T10:00:00Z',
+                actorKind           : 'user'
+            }],
+            nextProviderState: {cursor: 'page-2'},
+            nextInventoryHash: 'inv-1',
+            coverage         : {fromBasis: 'c1', toBasis: 'c9', complete: true}
+        }
+    });
+
+    test.beforeAll(async () => {
+        ({buildServerConfig, hasPushFailure, parseArgs, runPush, validateArgs} =
+            await import('../../../../../../ai/scripts/maintenance/communityBatchPushClient.mjs'))
+    });
+
+    test('argv/env parsing keeps bearer auth in transient transport config', () => {
+        const args = parseArgs([
+            '--url', 'https://memory.example.com/mcp',
+            '--from-stdin',
+            '--token-env', 'CONNECTOR_TOKEN',
+            '--max-attempts', '3'
+        ], {CONNECTOR_TOKEN: 'secret-token'});
+
+        expect(validateArgs(args)).toEqual([]);
+        expect(args.maxAttempts).toBe(3);
+        expect(buildServerConfig(args).transportOptions.requestInit.headers.Authorization).toBe('Bearer secret-token');
+        expect(envelope()).not.toHaveProperty('token');
+    });
+
+    test('validation requires endpoint, payload, and bearer token by default', () => {
+        expect(validateArgs(parseArgs([], {}))).toEqual([
+            'Missing --url or NEO_MEMORY_CORE_MCP_URL.',
+            'Provide --from-file or --from-stdin.',
+            'Missing bearer token: set --token-env or NEO_COMMUNITY_BATCH_TOKEN.'
+        ])
+    });
+
+    test('an unknown-outcome retry sends the exact same batch id and bytes, then closes the client', async () => {
+        const
+            args = parseArgs([
+                '--url', 'https://memory.example.com/mcp', '--from-stdin', '--token-env', 'CONNECTOR_TOKEN'
+            ], {CONNECTOR_TOKEN: 'secret-token'}),
+            calls = [];
+
+        let closed = false;
+
+        const result = await runPush({
+            args,
+            input        : Readable.from(JSON.stringify(envelope())),
+            clientFactory: () => ({
+                async ready() {},
+                async callTool(name, payload) {
+                    calls.push({name, payload: JSON.stringify(payload)});
+                    if (calls.length === 1) throw new Error('response connection lost');
+                    return {content: [{type: 'text', text: '{"status":"idempotent","digest":"sha256:x"}'}]}
+                },
+                async close() { closed = true }
+            })
+        });
+
+        expect(result).toEqual({status: 'idempotent', digest: 'sha256:x'});
+        expect(calls).toHaveLength(2);
+        expect(calls[0]).toEqual(calls[1]);
+        expect(calls[0].name).toBe('admit_community_batch');
+        expect(closed).toBe(true);
+    });
+
+    test('credential-shaped payloads fail client-side without constructing a remote client', async () => {
+        const payload = envelope();
+        payload.batch.nextProviderState = {accessToken: 'must-not-cross'};
+
+        let   constructed = false;
+        const result      = await runPush({
+            args         : parseArgs(['--url', 'https://memory.example.com/mcp', '--from-stdin', '--token-env', 'CONNECTOR_TOKEN'], {CONNECTOR_TOKEN: 'x'}),
+            input        : Readable.from(JSON.stringify(payload)),
+            clientFactory: () => {
+                constructed = true;
+                return {}
+            }
+        });
+
+        expect(result.code).toBe('COMMUNITY_BATCH_ENVELOPE_INVALID');
+        expect(result.errors).toContain('HOSTED_CREDENTIAL_MATERIAL_FORBIDDEN');
+        expect(constructed).toBe(false);
+        expect(hasPushFailure(result)).toBe(true);
+    });
+
+    test('the client factory receives an instance-local connection object with no provider write', async () => {
+        const args = parseArgs([
+            '--url', 'https://memory.example.com/mcp', '--from-stdin', '--token-env', 'CONNECTOR_TOKEN'
+        ], {CONNECTOR_TOKEN: 'secret-token'});
+
+        let receivedConfig;
+
+        await runPush({
+            args,
+            input        : Readable.from(JSON.stringify(envelope())),
+            clientFactory: ({connectionConfig}) => {
+                receivedConfig = connectionConfig;
+                return {
+                    async ready() {},
+                    async callTool() { return {content: [{type: 'text', text: '{"status":"accepted"}'}]} },
+                    async close() {}
+                }
+            }
+        });
+
+        expect(receivedConfig).toEqual(buildServerConfig(args));
+    });
+
+    test('a client-close failure remains visible to the connector process', async () => {
+        const args = parseArgs([
+            '--url', 'https://memory.example.com/mcp', '--from-stdin', '--token-env', 'CONNECTOR_TOKEN'
+        ], {CONNECTOR_TOKEN: 'secret-token'});
+
+        await expect(runPush({
+            args,
+            input        : Readable.from(JSON.stringify(envelope())),
+            clientFactory: () => ({
+                async ready() {},
+                async callTool() { return {content: [{type: 'text', text: '{"status":"accepted"}'}]} },
+                async close() { throw new Error('close failed') }
+            })
+        })).rejects.toThrow('close failed');
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/communitySourceOperator.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/communitySourceOperator.spec.mjs
@@ -1,0 +1,86 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {
+        name             : 'CommunitySourceOperatorTest',
+        isMounted        : () => true,
+        vnodeInitialising: false
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../../src/Neo.mjs';
+import * as core      from '../../../../../../src/core/_export.mjs';
+
+/**
+ * @summary CLI routing witnesses for the co-located, non-MCP source control plane.
+ */
+test.describe('communitySourceOperator — audited hosted bootstrap (#15156)', () => {
+    let parseArgs, runOperator, validateArgs;
+
+    test.beforeAll(async () => {
+        ({parseArgs, runOperator, validateArgs} =
+            await import('../../../../../../ai/scripts/maintenance/communitySourceOperator.mjs'))
+    });
+
+    test('lifecycle actions require tenant, source id, and an observed CAS generation', () => {
+        expect(validateArgs(parseArgs(['--action', 'activate'], {NEO_COMMUNITY_OPERATOR_ID: 'deploy-1'})))
+            .toEqual([
+                '--tenant-id is required.',
+                '--source-instance-id is required for lifecycle transitions.',
+                '--expected-state is required for lifecycle transitions.',
+                '--expected-epoch must be an integer for lifecycle transitions.'
+            ])
+    });
+
+    test('activate routes exact tenant + generation + deployment actor to the registry owner', async () => {
+        const calls = [];
+        const args  = parseArgs([
+            '--action', 'activate',
+            '--tenant-id', 'tenant-a',
+            '--source-instance-id', 'source-1',
+            '--expected-state', 'PROVISIONED',
+            '--expected-epoch', '2'
+        ], {NEO_COMMUNITY_OPERATOR_ID: 'deploy-1'});
+
+        const result = await runOperator({
+            args,
+            registry: {
+                async initAsync() { calls.push({type: 'init'}) },
+                transitionLifecycleForTenant(tenantId, sourceInstanceId, toState, generation) {
+                    calls.push({tenantId, sourceInstanceId, toState, generation});
+                    return {lifecycleState: toState}
+                }
+            }
+        });
+
+        expect(result).toEqual({lifecycleState: 'ACTIVE'});
+        expect(calls[1]).toEqual({
+            tenantId        : 'tenant-a',
+            sourceInstanceId: 'source-1',
+            toState         : 'ACTIVE',
+            generation      : {
+                actorId      : 'deploy-1',
+                expectedState: 'PROVISIONED',
+                expectedEpoch: 2
+            }
+        });
+    });
+
+    test('audit is a co-located registry read, not an MCP admin operation', async () => {
+        const result = await runOperator({
+            args: {
+                action          : 'audit',
+                tenantId        : 'tenant-a',
+                sourceInstanceId: 'source-1'
+            },
+            registry: {
+                async initAsync() {},
+                listAuditForTenant: (tenantId, sourceInstanceId) => [{tenantId, sourceInstanceId}]
+            }
+        });
+
+        expect(result).toEqual([{tenantId: 'tenant-a', sourceInstanceId: 'source-1'}]);
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/communitySourceOperator.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/communitySourceOperator.spec.mjs
@@ -47,7 +47,7 @@ test.describe('communitySourceOperator — audited hosted bootstrap (#15156)', (
         const result = await runOperator({
             args,
             registry: {
-                async initAsync() { calls.push({type: 'init'}) },
+                async ready() { calls.push({type: 'ready'}) },
                 transitionLifecycleForTenant(tenantId, sourceInstanceId, toState, generation) {
                     calls.push({tenantId, sourceInstanceId, toState, generation});
                     return {lifecycleState: toState}
@@ -76,7 +76,7 @@ test.describe('communitySourceOperator — audited hosted bootstrap (#15156)', (
                 sourceInstanceId: 'source-1'
             },
             registry: {
-                async initAsync() {},
+                async ready() {},
                 listAuditForTenant: (tenantId, sourceInstanceId) => [{tenantId, sourceInstanceId}]
             }
         });

--- a/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
@@ -82,6 +82,20 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
             ...over
         }),
 
+        hostedEnvelope = (over = {}) => {
+            const {sourceInstanceId, registrationEpoch, ...batch} = batchAt('server-resolved');
+
+            return {
+                source: {
+                    canonicalProviderHost: source.canonicalProviderHost,
+                    resourceKind         : source.resourceKind,
+                    providerResourceId   : source.providerResourceId
+                },
+                batch,
+                ...over
+            }
+        },
+
         activeSource = () => {
             SourceRegistryService.localSubjectId = SUBJECT;
 
@@ -127,7 +141,7 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
 
     test.beforeEach(() => {
         AdmissionService.db.exec('DELETE FROM mc_community_batch_receipt; DELETE FROM mc_community_observation; DELETE FROM mc_community_checkpoint;');
-        SourceRegistryService.db.exec('DELETE FROM mc_source_registration;');
+        SourceRegistryService.db.exec('DELETE FROM mc_source_registration_audit; DELETE FROM mc_source_registration;');
         SourceRegistryService.localSubjectId = SUBJECT;
         AdmissionService.attentionPolicy      = ATTENTION_POLICY;
     });
@@ -400,15 +414,82 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
 
     // ---------------------------------------------------------------- ingress parity + fail-loud
 
-    test('local and remote ingress reach one service and produce the same receipt contract', async () => {
+    test('local and hosted ingress admit byte-equivalent canonical batches and converge on one receipt', async () => {
         const id    = activeSource(),
               local = AdmissionService.admitBatch(batchAt(id));
 
+        SourceRegistryService.localSubjectId = null;
         const remote = await RequestContextService.run({userId: SUBJECT}, () =>
-            AdmissionService.admitBatch(batchAt(id)));   // same batchId + digest -> idempotent against the same row
+            AdmissionService.admitHostedBatch(hostedEnvelope()));
 
         expect(remote.status).toBe('idempotent');
         expect(remote.receipt.receiptId).toBe(local.receipt.receiptId);
+        expect(remote.digest).toBe(local.digest);
+        expect(remote.health).toMatchObject({ready: true, code: 'COMMUNITY_SOURCE_READY'});
+        expect(remote.health.lastReceipt.receiptId).toBe(local.receipt.receiptId);
+    });
+
+    test('hosted callers cannot stamp authority fields and a refusal writes nothing', async () => {
+        activeSource();
+        SourceRegistryService.localSubjectId = null;
+
+        const forged = hostedEnvelope();
+        forged.batch.registrationEpoch = 2;
+
+        const result = await RequestContextService.run({userId: SUBJECT}, () =>
+            AdmissionService.admitHostedBatch(forged));
+
+        expect(result.code).toBe('COMMUNITY_BATCH_ENVELOPE_INVALID');
+        expect(result.errors).toContain('HOSTED_AUTHORITY_FIELDS_FORBIDDEN');
+        expect(receiptCount()).toBe(0);
+    });
+
+    test('wrong-tenant lookup is indistinguishable from an unknown source and fails before mutation', async () => {
+        activeSource();
+        SourceRegistryService.localSubjectId = null;
+
+        const result = await RequestContextService.run({userId: 'other-tenant'}, () =>
+            AdmissionService.admitHostedBatch(hostedEnvelope()));
+
+        expect(result).toMatchObject({
+            status: 'conflict',
+            reason: 'REGISTRATION_NOT_ADMISSIBLE',
+            code  : 'COMMUNITY_SOURCE_NOT_FOUND'
+        });
+        expect(receiptCount()).toBe(0);
+    });
+
+    test('a hosted push resolves but cannot admit after operator revocation', async () => {
+        const id = activeSource();
+
+        SourceRegistryService.transitionLifecycle(id, 'REVOKED', {
+            expectedState: 'ACTIVE',
+            expectedEpoch: 2
+        });
+        SourceRegistryService.localSubjectId = null;
+
+        const result = await RequestContextService.run({userId: SUBJECT}, () =>
+            AdmissionService.admitHostedBatch(hostedEnvelope()));
+
+        expect(result).toMatchObject({
+            status: 'conflict',
+            reason: 'REGISTRATION_NOT_ADMISSIBLE',
+            health: {ready: false, code: 'COMMUNITY_SOURCE_REVOKED'}
+        });
+        expect(receiptCount()).toBe(0);
+    });
+
+    test('hosted work-volume refusal is structured and happens before source mutation', async () => {
+        activeSource();
+        SourceRegistryService.localSubjectId = null;
+
+        const result = await RequestContextService.run({userId: SUBJECT}, () =>
+            AdmissionService.admitHostedBatch(hostedEnvelope(), {maxBytes: 1024 * 1024, maxObservations: 1}));
+
+        expect(result.code).toBe('COMMUNITY_BATCH_VOLUME_EXCEEDED');
+        expect(result.volume.observations).toBe(2);
+        expect(result.limits.maxObservations).toBe(1);
+        expect(receiptCount()).toBe(0);
     });
 
     test('an auth failure cannot partially admit', () => {

--- a/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
@@ -27,7 +27,10 @@ import RequestContextService  from '../../../../../../ai/mcp/server/shared/servi
  * checkpoint CAS. The four reviewer boundary probes appear as the last five cases.
  */
 test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () => {
-    let AdmissionService, SourceRegistryService, originalEnv, testDbPath;
+    let AdmissionService, SourceRegistryService,
+        admissionDb, registryDb,
+        originalAdmissionDb, originalAttentionPolicy, originalEnv, originalLocalSubjectId, originalRegistryDb,
+        testDbPath;
 
     const
         SUBJECT = 'local-subject',
@@ -126,14 +129,49 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
         process.env.UNIT_TEST_MODE          = 'true';
         process.env.NEO_MEMORY_DB_PATH_TEST = testDbPath;
 
+        const Database = (await import('better-sqlite3')).default;
+
         SourceRegistryService = (await import('../../../../../../ai/services/memory-core/SourceRegistryService.mjs')).default;
         AdmissionService      = (await import('../../../../../../ai/services/memory-core/CommunityBatchAdmissionService.mjs')).default;
 
-        await SourceRegistryService.initAsync();
-        await AdmissionService.initAsync();
+        await SourceRegistryService.ready();
+        await AdmissionService.ready();
+
+        originalRegistryDb      = SourceRegistryService.db;
+        originalAdmissionDb     = AdmissionService.db;
+        originalLocalSubjectId  = SourceRegistryService.localSubjectId;
+        originalAttentionPolicy = AdmissionService.attentionPolicy;
+
+        registryDb  = new Database(testDbPath, {verbose: null});
+        admissionDb = new Database(testDbPath, {verbose: null});
+
+        registryDb.pragma('journal_mode = WAL');
+        registryDb.pragma('busy_timeout = 5000');
+        admissionDb.pragma('busy_timeout = 5000');
+
+        SourceRegistryService.set({db: registryDb});
+        AdmissionService.set({db: admissionDb});
+        SourceRegistryService.ensureSchema();
+        AdmissionService.ensureSchema();
     });
 
     test.afterAll(() => {
+        SourceRegistryService.set({
+            db            : originalRegistryDb,
+            localSubjectId: originalLocalSubjectId
+        });
+        AdmissionService.set({
+            db             : originalAdmissionDb,
+            attentionPolicy: originalAttentionPolicy
+        });
+
+        registryDb.close();
+        admissionDb.close();
+
+        for (const suffix of ['', '-wal', '-shm']) {
+            try { fs.unlinkSync(`${testDbPath}${suffix}`); } catch (e) {}
+        }
+
         Object.entries(originalEnv).forEach(([k, v]) => {
             v === undefined ? delete process.env[k] : (process.env[k] = v);
         });

--- a/test/playwright/unit/ai/services/memory-core/SourceRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SourceRegistryService.spec.mjs
@@ -95,7 +95,11 @@ test.describe('Neo.ai.services.memory-core.SourceRegistryService', () => {
     });
 
     test.beforeEach(() => {
-        SourceRegistryService.db.exec('DELETE FROM mc_source_registration;');
+        SourceRegistryService.db.exec(`
+            DROP TRIGGER IF EXISTS fail_source_audit;
+            DELETE FROM mc_source_registration_audit;
+            DELETE FROM mc_source_registration;
+        `);
         // Fail-closed default: this process is NOT an explicit local-single-user deployment.
         SourceRegistryService.localSubjectId = null;
     });
@@ -130,6 +134,59 @@ test.describe('Neo.ai.services.memory-core.SourceRegistryService', () => {
         expect(reg.tenantId).toBe('local-subject');
         expect(reg.lifecycleState).toBe('REQUESTED');
         expect(reg.registrationEpoch).toBe(1);
+    });
+
+    test('the co-located operator path provisions an explicit tenant and writes an audit trail', () => {
+        const reg = SourceRegistryService.registerForTenant('tenant-a', sample, {actorId: 'deploy-operator'});
+
+        const provisioned = SourceRegistryService.transitionLifecycleForTenant(
+            'tenant-a', reg.sourceInstanceId, 'PROVISIONED', {
+                actorId      : 'deploy-operator',
+                expectedState: 'REQUESTED',
+                expectedEpoch: 1
+            }
+        );
+
+        expect(provisioned.registrationEpoch).toBe(2);
+        expect(SourceRegistryService.listAuditForTenant('tenant-a', reg.sourceInstanceId).map(event => event.action))
+            .toEqual(['REGISTERED', 'PROVISIONED']);
+    });
+
+    test('operator registration refuses credential-shaped fields before any row or audit is written', () => {
+        expect(() => SourceRegistryService.registerForTenant('tenant-a', {
+            ...sample,
+            credentialRef: 'vault://github/token'
+        }, {actorId: 'deploy-operator'})).toThrow('SOURCE_REGISTRATION_CREDENTIAL_MATERIAL_FORBIDDEN');
+
+        expect(SourceRegistryService.db.prepare('SELECT count(*) AS c FROM mc_source_registration').get().c).toBe(0);
+        expect(SourceRegistryService.db.prepare('SELECT count(*) AS c FROM mc_source_registration_audit').get().c).toBe(0);
+    });
+
+    test('an audit-write failure rolls back the operator authority mutation', () => {
+        const reg = SourceRegistryService.registerForTenant('tenant-a', sample, {actorId: 'deploy-operator'});
+
+        SourceRegistryService.db.exec(`
+            CREATE TRIGGER fail_source_audit BEFORE INSERT ON mc_source_registration_audit
+            WHEN NEW.action = 'PROVISIONED'
+            BEGIN
+                SELECT RAISE(ABORT, 'forced audit failure');
+            END;
+        `);
+
+        expect(() => SourceRegistryService.transitionLifecycleForTenant(
+            'tenant-a', reg.sourceInstanceId, 'PROVISIONED', {
+                actorId      : 'deploy-operator',
+                expectedState: 'REQUESTED',
+                expectedEpoch: 1
+            }
+        )).toThrow();
+
+        expect(SourceRegistryService.getRegistrationForTenant('tenant-a', reg.sourceInstanceId)).toMatchObject({
+            lifecycleState   : 'REQUESTED',
+            registrationEpoch: 1
+        });
+        expect(SourceRegistryService.listAuditForTenant('tenant-a', reg.sourceInstanceId).map(event => event.action))
+            .toEqual(['REGISTERED']);
     });
 
     // ---------------------------------------------------------------- isolation (AC4)

--- a/test/playwright/unit/ai/services/memory-core/communityBatchContract.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/communityBatchContract.spec.mjs
@@ -17,7 +17,8 @@ import {test, expect} from '@playwright/test';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import {
-    BATCH_SCHEMA_VERSION, MAX_PROVIDER_STATE_BYTES, canonicalBatchDigest, validateBatch,
+    BATCH_SCHEMA_VERSION, MAX_HOSTED_BATCH_BYTES, MAX_HOSTED_OBSERVATIONS, MAX_PROVIDER_STATE_BYTES,
+    canonicalBatchDigest, carriesCredentialMaterial, validateBatch, validateHostedEnvelope,
     occurrenceIdentity, observationDigest
 } from '../../../../../../ai/services/memory-core/communityBatchContract.mjs';
 
@@ -51,6 +52,20 @@ test.describe('community-activity-batch.v1 contract', () => {
         coverage                  : {fromBasis: 'c1', toBasis: 'c9', complete: true},
         ...over
     });
+
+    const hostedEnvelope = (over = {}) => {
+        const {sourceInstanceId, registrationEpoch, ...authorityFreeBatch} = batch();
+
+        return {
+            source: {
+                canonicalProviderHost: 'github.com',
+                resourceKind         : 'repository',
+                providerResourceId   : 'neomjs/neo'
+            },
+            batch: authorityFreeBatch,
+            ...over
+        }
+    };
 
     // ------------------------------------------------------------------ the batch digest ordering
 
@@ -151,5 +166,48 @@ test.describe('community-activity-batch.v1 contract', () => {
     test('missing required identity is refused', () => {
         expect(validateBatch(batch({sourceInstanceId: null})).errors).toContain('BATCH_MISSING_SOURCEINSTANCEID');
         expect(validateBatch(null)).toEqual({valid: false, errors: ['BATCH_NOT_AN_OBJECT']});
+    });
+
+    // ------------------------------------------------------------------ hosted authority + volume boundary
+
+    test('a hosted envelope carries neutral source identity but no tenant, source id, or epoch', () => {
+        expect(validateHostedEnvelope(hostedEnvelope())).toMatchObject({valid: true, errors: []});
+
+        expect(validateHostedEnvelope(hostedEnvelope({tenantId: 'forged'})).errors)
+            .toContain('HOSTED_AUTHORITY_FIELDS_FORBIDDEN');
+        expect(validateHostedEnvelope(hostedEnvelope({batch: batch()})).errors)
+            .toContain('HOSTED_AUTHORITY_FIELDS_FORBIDDEN');
+
+        const nestedForgery = hostedEnvelope();
+        nestedForgery.batch.observations[0].tenantId = 'forged';
+        expect(validateHostedEnvelope(nestedForgery).errors)
+            .toContain('HOSTED_AUTHORITY_FIELDS_FORBIDDEN');
+    });
+
+    test('credential-shaped material is refused rather than stripped or echoed', () => {
+        const envelope = hostedEnvelope();
+        envelope.batch.nextProviderState = {accessToken: 'do-not-store'};
+
+        expect(carriesCredentialMaterial(envelope)).toBe(true);
+        expect(validateHostedEnvelope(envelope).errors).toContain('HOSTED_CREDENTIAL_MATERIAL_FORBIDDEN');
+    });
+
+    test('hosted validation runs the canonical contract before OpenAPI can strip prose', () => {
+        const envelope = hostedEnvelope();
+        envelope.batch.observations[0].title = 'must not disappear';
+
+        expect(validateHostedEnvelope(envelope).errors).toContain('OBSERVATION_0_CARRIES_PROSE_TITLE');
+    });
+
+    test('hosted ingress enforces both observation-count and serialized-byte bounds', () => {
+        const tooMany = hostedEnvelope();
+        tooMany.batch.observations = Array.from({length: MAX_HOSTED_OBSERVATIONS + 1}, (_, index) => observation(`e${index}`));
+
+        expect(validateHostedEnvelope(tooMany).errors).toContain('HOSTED_BATCH_OBSERVATIONS_EXCEEDED');
+
+        const tooLarge = hostedEnvelope();
+        tooLarge.batch.nextProviderState = {cursor: 'x'.repeat(MAX_HOSTED_BATCH_BYTES)};
+
+        expect(validateHostedEnvelope(tooLarge).errors).toContain('HOSTED_BATCH_BYTES_EXCEEDED');
     });
 });


### PR DESCRIPTION
Resolves #15156
Related: #15145

Ships the authenticated hosted community-source push path as a thin Streamable HTTP facade over the existing neutral admission transaction. The request tenant stays server-derived; neutral provider identity resolves the tenant-scoped source and current epoch; connector grants and bearer credentials stay outside Memory Core; and the same canonical batch, digest, receipt, checkpoint, and immutable observation machinery serves local and hosted callers.

Evidence: L2 (real SQLite authority/admission transactions, raw OpenAPI ToolService dispatch, instance-local remote-client configuration, and focused failure controls) → L2 required (all close-target authority, parity, retry, volume, health, and no-queue ACs are contract-observable). No residuals.

## Deltas from ticket

- Refuses recursive tenant/source/epoch claims, credential-shaped keys, and canonical-contract violations on the raw MCP arguments before OpenAPI normalization can strip them.
- Keeps hosted provisioning outside MCP: a co-located operator CLI owns register/provision/activate/revoke/audit, with each authority mutation and audit row committed in one SQLite transaction.
- Adds a narrow instance-injected MCP connection object instead of mutating the shared reactive client-config Provider; bearer tokens are environment-only and transient.
- Restricts the connector client to Streamable HTTP, bounds lost-response retry to three attempts, and reuses the same envelope and `batchId`.
- Adds tenant/source/resource-family predicates to readiness joins and returns only stable state, epoch, receipt age, gap counts, and metadata.
- Adds the operator runbook and keeps tenant self-service plus a neutral HTTP/queue receiver unavailable.

Decision Record impact: aligns with ADR 0036's M/W hosted topology and neutral registration/admission authority, and with ADR 0019's narrow entrypoint-injected bootstrap boundary. No decision record is amended.

Runbook slot rationale: `keep` as the operator reference while hosted bootstrap uses deployment-operator authority; move or retire it when an authoritative tenant source-admin/self-service path replaces W, or if measured evidence graduates a different receiver topology.

## Signal Ledger

Source: [Discussion #15139](https://github.com/neomjs/neo/discussions/15139), body `updatedAt=2026-07-14T04:49:30Z`.

| Family | Signal | Version binding |
|---|---|---|
| GPT | `AUTHOR_SIGNAL` by `@neo-gpt` | Discussion 15139 body `updatedAt=2026-07-14T04:49:30Z` |
| Claude | `GRADUATION_APPROVED` by `@neo-opus-grace` | Discussion 15139 body `updatedAt=2026-07-14T04:49:30Z` |
| Gemini | `operator_benched` | Unresolved liveness, not consent |

## Unresolved Dissent

None at graduation.

## Unresolved Liveness

Gemini was operator-benched at graduation. `revalidationTrigger`: if that family returns while Epic `#15145` remains active, seek its version-bound review of any still-unmerged or materially amended high-blast authority.

## Test Evidence

- Hosted contract/facade/service/operator/client suites — 84/84 passed across `CommunityBatchTool`, `CommunityBatchAdmissionService`, `SourceRegistryService`, `communityBatchContract`, `communityBatchPushClient`, `communitySourceOperator`, and `McpClientTransportConfig`.
- Wider MCP registration guards — 43/43 passed across `McpServerToolLimits` and `McpServerListToolsSmoke`.
- Exact-head CI repair gate — 127/127 passed across the four formerly failing contracts plus hosted admission/operator/tool witnesses; the full hosted + MCP surface then passed 119/119 on `1268ca422f`.
- The local shell's native SQLite addon had a Node ABI mismatch; the tests used an isolated matching `better-sqlite3` runtime through a temporary loader, without changing workspace dependencies or product configuration.
- `npm run ai:lint-tree-json` — passed; 220 documentation nodes and SEO generator acceptance.
- `npm run ai:lint-guides` — passed with 0 hard failures (repository baseline warnings only).
- `npm run ai:lint-mcp-test-locations` — passed.
- OpenAPI YAML parse, `node --check` for every changed/new module and spec, and `git diff --check` — passed.
- `npm run agent-preflight -- <all touched files>` — passed after repository block-alignment repair; only unrelated stale-overlay warnings remained.

## Post-Merge Validation

- [ ] On an ephemeral hosted deployment, authenticate over Streamable HTTP and verify both hosted tools are listed there but remain absent/refused on `stdio`.
- [ ] Run operator register → provision → activate, push one batch, replay the exact lost-response envelope, then revoke; verify one receipt/history set, stable health transitions, and a complete audit trail.
- [ ] Inspect deployment telemetry and Memory Core rows to confirm bearer/provider credentials and provider prose are absent.

## Evolution

Pre-commit falsification found three fail-open shapes that the first green unit pass did not expose: OpenAPI could strip nested forbidden fields before service validation; operator mutation and its audit insert were not atomic; and the copied remote-client pattern wrote a bearer-bearing entry into the shared reactive config Provider. The final shape validates raw arguments before normalization, commits authority plus audit together, and injects transient connection state only into one client instance.

Authored by Euclid (OpenAI GPT-5, Codex Desktop). Session a0518292-02c3-49ee-af08-adff40bc30b1.
