### PR TITLE
feat(agentos): complete identity ceremony convergence (#14954)

### DIFF
--- a/ai/scripts/setup/generateRosterOnboarding.mjs
+++ b/ai/scripts/setup/generateRosterOnboarding.mjs
@@ -39,9 +39,11 @@ import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNo
  * branch — the payload always travels as a reviewable branch + PR, never as a live edit to an
  * integration branch. The generator never pushes and never opens the PR itself.
  *
- * **Idempotency:** a resident already present in a surface reports EXISTS and emits no
- * duplicate; `--write` skips EXISTS surfaces, so a partially-applied payload completes on
- * re-run and a second run changes nothing.
+ * **Convergence:** every owned surface reports `MISSING`, `MATCH`, or `DIVERGENT` against the
+ * exact generated structure. A corrected rerun repairs only a structurally-recognizable
+ * generated block; ambiguous legacy prose refuses the whole payload before any file is
+ * written. Rotation mode updates the public roster + ModelStats mirrors only — durable roots
+ * and the migration epoch snapshot are verified boundaries and remain byte-stable.
  *
  * Everything decision-shaped is pure and fail-closed: planners return
  * `{valid, reason, ...}` / per-surface `{status, reason, ...}` and never throw; a missing
@@ -51,6 +53,8 @@ import {normalizeAgentIdentityNodeId} from '../../graph/normalizeAgentIdentityNo
  *   node ai/scripts/setup/generateRosterOnboarding.mjs --handle <s> --family <s>
  *       [--github-username <s>]                        # dry-run (default): print the payload
  *   node ai/scripts/setup/generateRosterOnboarding.mjs ... --write   # apply on a work branch
+ *   node ai/scripts/setup/generateRosterOnboarding.mjs --mode rotation
+ *       --handle <s> --family <s> --designation <s> [--github-username <s>]
  *   node ai/scripts/setup/generateRosterOnboarding.mjs --help        # print usage
  */
 
@@ -98,6 +102,17 @@ export const ENGINE_CLASS_FLAGS = Object.freeze([
 ]);
 
 /**
+ * @summary Canonical surface convergence states. These are artifact states, not write verbs:
+ * `DIVERGENT` may be safely repairable or may fail closed as ambiguous.
+ * @type {Object}
+ */
+export const SURFACE_STATES = Object.freeze({
+    DIVERGENT: 'DIVERGENT',
+    MATCH    : 'MATCH',
+    MISSING  : 'MISSING'
+});
+
+/**
  * @summary Vendor + display token per known model family, for README/ModelStats prose.
  * Unknown families render with the bare family token — never a guessed vendor.
  * @type {Object}
@@ -123,10 +138,17 @@ export const DISPLAY_TOKEN_OVERRIDES = Object.freeze({
  */
 export const SURFACE_PATHS = Object.freeze({
     identityRoots: 'ai/graph/identityRoots.mjs',
+    migration    : 'ai/graph/identityRootsMigration.mjs',
     modelStats   : 'learn/agentos/ModelStats.md',
     readme       : 'README.md',
     spec         : 'test/playwright/unit/ai/graph/identityRoots.spec.mjs'
 });
+
+/** @type {ReadonlyArray<String>} */
+export const ONBOARDING_SURFACE_KEYS = Object.freeze(['identityRoots', 'readme', 'modelStats', 'spec']);
+
+/** @type {ReadonlyArray<String>} */
+export const ROTATION_SURFACE_KEYS = Object.freeze(['identityRoots', 'readme', 'modelStats', 'spec', 'migration']);
 
 /**
  * @summary Escapes a literal value for safe embedding inside a RegExp source.
@@ -156,6 +178,27 @@ export function normalizeHandle(value, label) {
     }
 
     return {valid: true, reason: null, handle: normalizeAgentIdentityNodeId(body)}
+}
+
+/**
+ * @summary Normalizes a GitHub login using GitHub's strict username grammar: 1-39 characters,
+ * alphanumeric endpoints, and only single hyphens between segments. The returned value keeps
+ * the identity substrate's canonical `@` prefix.
+ * @param {String} value Raw GitHub login (with or without `@`)
+ * @returns {{valid: Boolean, reason: String|null, handle: String|null}}
+ */
+export function normalizeGithubUsername(value) {
+    if (typeof value !== 'string' || value.trim() === '') {
+        return {valid: false, reason: '--github-username requires a non-empty string', handle: null};
+    }
+
+    const body = value.trim().replace(/^@/, '');
+
+    if (body.length > 39 || !/^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9]))*$/.test(body)) {
+        return {valid: false, reason: `--github-username must be a lowercase GitHub login (1-39 chars, alphanumeric endpoints, no consecutive hyphens) — received '${value}'`, handle: null};
+    }
+
+    return {valid: true, reason: null, handle: `@${body}`}
 }
 
 /**
@@ -191,18 +234,26 @@ export function deriveSectionAnchor(handle) {
  * @param {Object} options
  * @param {String} options.handle The resident handle — the roster id and A2A address
  * @param {String} options.family Model family (e.g. 'claude' | 'gpt' | 'gemini')
+ * @param {'onboarding'|'rotation'} [options.mode='onboarding'] Ceremony mode
+ * @param {String} [options.designation] Exact ModelStats engine designation; rotation only
  * @param {String} [options.githubUsername] GitHub login (defaults to the handle)
  * @param {Date|String} [options.now] Clock override for deterministic tests; defaults to the real now
  * @returns {{valid: Boolean, reason: String|null, plan: Object|null}}
  */
 export function buildOnboardingPlan(options = {}) {
+    const mode = options.mode || 'onboarding';
+
+    if (!['onboarding', 'rotation'].includes(mode)) {
+        return {valid: false, reason: `--mode must be 'onboarding' or 'rotation' — received '${String(mode)}'`, plan: null};
+    }
+
     const socialLeaks = SOCIAL_NAME_CLASS_KEYS.filter(key => key in options);
 
     if (socialLeaks.length > 0) {
         return {valid: false, reason: `socialName-class inputs are rejected by design: ${socialLeaks.join(', ')} — Social Names are the post-boot peer-naming ritual (bearer-assented), never seed data`, plan: null};
     }
 
-    const engineLeaks = ENGINE_CLASS_KEYS.filter(key => key in options);
+    const engineLeaks = ENGINE_CLASS_KEYS.filter(key => key in options && !(mode === 'rotation' && key === 'designation'));
 
     if (engineLeaks.length > 0) {
         return {valid: false, reason: `engine-class inputs are rejected by design: ${engineLeaks.join(', ')} — engine facts are observation-owned and land through the source-cited ModelStats.md discipline at first boot, never as onboarding predictions`, plan: null};
@@ -218,7 +269,15 @@ export function buildOnboardingPlan(options = {}) {
         return {valid: false, reason: `--family must be a lowercase family token (e.g. 'claude') — received '${String(options.family)}'`, plan: null};
     }
 
-    const github = normalizeHandle(options.githubUsername === undefined ? resident.handle : options.githubUsername, '--github-username');
+    if (mode === 'onboarding' && 'designation' in options) {
+        return {valid: false, reason: 'engine-class inputs are rejected by onboarding: designation — engine facts are observation-owned and land through the source-cited ModelStats.md discipline at first boot', plan: null};
+    }
+
+    if (mode === 'rotation' && (typeof options.designation !== 'string' || options.designation.trim() === '' || /[\r\n|]/.test(options.designation))) {
+        return {valid: false, reason: '--designation requires one non-empty line without Markdown table delimiters in rotation mode', plan: null};
+    }
+
+    const github = normalizeGithubUsername(options.githubUsername === undefined ? resident.handle : options.githubUsername);
 
     if (!github.valid) {
         return {valid: false, reason: github.reason, plan: null};
@@ -237,6 +296,7 @@ export function buildOnboardingPlan(options = {}) {
         valid : true,
         reason: null,
         plan  : Object.freeze({
+            mode,
             handle,
             handleBody    : handle.slice(1),
             family        : options.family,
@@ -246,6 +306,7 @@ export function buildOnboardingPlan(options = {}) {
             githubBody    : github.handle.slice(1),
             displayForm   : deriveDisplayForm(handle),
             sectionAnchor : deriveSectionAnchor(handle),
+            designation   : mode === 'rotation' ? options.designation.trim() : null,
             since         : new Date(nowMs).toISOString()
         })
     }
@@ -389,9 +450,220 @@ test.describe('ai/graph/identityRoots — ${plan.handle} roster pin', () => {
 }
 
 /**
- * @summary Plans the `identityRoots.mjs` surface: EXISTS when the roster already carries the
- * resident's id; otherwise inserts the entry immediately before the `AGENT:*`
- * BroadcastSentinel entry (the roster's stable tail). Fail-closed when the anchor is missing.
+ * @summary Replaces one exact source range without broad substring rewriting.
+ * @param {String} source Complete source
+ * @param {{start: Number, end: Number}} range Half-open byte range
+ * @param {String} replacement Exact replacement
+ * @returns {String}
+ */
+export function replaceExactRange(source, range, replacement) {
+    return source.slice(0, range.start) + replacement + source.slice(range.end);
+}
+
+/**
+ * @summary Locates the one roster object whose structural `id` field equals the resident.
+ * @param {String} source identityRoots source
+ * @param {String} handle Canonical resident handle
+ * @returns {{valid: Boolean, reason: String|null, range: Object|null, block: String|null}}
+ */
+export function locateRosterEntry(source, handle) {
+    const lines   = source.split('\n'),
+          idLine  = new RegExp(`^\\s{8}id\\s*:\\s*'${escapeRegExp(handle)}',?$`),
+          matches = [];
+
+    for (let i = 0; i < lines.length; i++) {
+        if (idLine.test(lines[i])) {
+            matches.push(i);
+        }
+    }
+
+    if (matches.length === 0) {
+        return {valid: true, reason: null, range: null, block: null};
+    }
+
+    if (matches.length !== 1) {
+        return {valid: false, reason: `${handle} has ${matches.length} structural roster entries; refusing an ambiguous repair`, range: null, block: null};
+    }
+
+    const idIndex   = matches[0];
+    let   startLine = idIndex - 1,
+        endLine   = idIndex + 1;
+
+    while (startLine >= 0 && lines[startLine] !== '    {') {
+        startLine--;
+    }
+
+    while (endLine < lines.length && lines[endLine] !== '    },') {
+        endLine++;
+    }
+
+    if (startLine < 0 || endLine >= lines.length) {
+        return {valid: false, reason: `${handle} roster entry boundaries are not structurally recognizable; refusing a broad rewrite`, range: null, block: null};
+    }
+
+    const offsets = [];
+    let   offset  = 0;
+
+    for (const line of lines) {
+        offsets.push(offset);
+        offset += line.length + 1;
+    }
+
+    const start = offsets[startLine],
+          end   = offsets[endLine] + lines[endLine].length;
+
+    return {valid: true, reason: null, range: {start, end}, block: source.slice(start, end)};
+}
+
+/**
+ * @summary True only for the pending Layer-1 block emitted by this generator lineage.
+ * @param {String} block Candidate roster block
+ * @returns {Boolean}
+ */
+export function isGeneratedRosterEntry(block) {
+    return block.includes("statusReason       : 'First boot pending'") &&
+        block.includes("reactivationTrigger: 'Operator confirms participation activation after first boot'") &&
+        block.includes('// No capability fields — engine facts are observation-owned');
+}
+
+/**
+ * @summary Locates one exact maintainer table row by the desired GitHub login or the generator's
+ * original default (the resident handle). This lets a corrected login repair the original row
+ * without guessing across unrelated prose.
+ * @param {String} source README source
+ * @param {Object} plan Ceremony plan
+ * @param {String[]} [aliases=[]] Prior generated GitHub-login bodies that still own the row
+ * @returns {{valid: Boolean, reason: String|null, range: Object|null, row: String|null}}
+ */
+export function locateReadmeRow(source, plan, aliases = []) {
+    const candidates = new Set([plan.githubBody, plan.handleBody, ...aliases]),
+          matches    = [];
+    let offset = 0;
+
+    for (const line of source.split('\n')) {
+        if (line.startsWith('|') && [...candidates].some(login => line.includes(`](https://github.com/${login})`))) {
+            matches.push({start: offset, end: offset + line.length, row: line});
+        }
+
+        offset += line.length + 1;
+    }
+
+    if (matches.length === 0) {
+        return {valid: true, reason: null, range: null, row: null};
+    }
+
+    if (matches.length !== 1) {
+        return {valid: false, reason: `${plan.handle} resolves to ${matches.length} maintainer rows (desired/default login); refusing a duplicate or ambiguous rewrite`, range: null, row: null};
+    }
+
+    return {valid: true, reason: null, range: {start: matches[0].start, end: matches[0].end}, row: matches[0].row};
+}
+
+/**
+ * @summary Locates one exact ModelStats resident section by semantic anchor.
+ * @param {String} source ModelStats source
+ * @param {String} sectionAnchor Resident semantic anchor (without `§`)
+ * @returns {{valid: Boolean, reason: String|null, range: Object|null, section: String|null}}
+ */
+export function locateModelStatsSection(source, sectionAnchor) {
+    const heading = `### §${sectionAnchor}`,
+          starts  = [];
+    let cursor = 0;
+
+    while ((cursor = source.indexOf(heading, cursor)) !== -1) {
+        const atLineStart = cursor === 0 || source[cursor - 1] === '\n',
+              atLineEnd   = cursor + heading.length === source.length || source[cursor + heading.length] === '\n';
+
+        if (atLineStart && atLineEnd) {
+            starts.push(cursor);
+        }
+
+        cursor += heading.length;
+    }
+
+    if (starts.length === 0) {
+        return {valid: true, reason: null, range: null, section: null};
+    }
+
+    if (starts.length !== 1) {
+        return {valid: false, reason: `§${sectionAnchor} appears ${starts.length} times; refusing an ambiguous ModelStats repair`, range: null, section: null};
+    }
+
+    const start       = starts[0],
+          nextSection = source.indexOf('\n### §', start + heading.length),
+          nextDivider = source.indexOf('\n---\n', start + heading.length),
+          ends        = [nextSection, nextDivider].filter(index => index !== -1),
+          end         = ends.length > 0 ? Math.min(...ends) : source.length;
+
+    return {valid: true, reason: null, range: {start, end}, section: source.slice(start, end).trimEnd()};
+}
+
+/**
+ * @summary True only for the pending ModelStats skeleton emitted by this generator lineage.
+ * @param {String} section Candidate section
+ * @returns {Boolean}
+ */
+export function isGeneratedModelStatsSection(section) {
+    return section.includes('| `participationStatus` | `temporarily_unreachable`') &&
+        section.includes('V-B-A pending — observation-owned') &&
+        section.includes('capability values are never guessed at onboarding');
+}
+
+/**
+ * @summary Locates the dedicated generated roster pin structurally. Incidental quoted-handle
+ * mentions are deliberately ignored.
+ * @param {String} source identityRoots spec source
+ * @param {String} handle Canonical resident handle
+ * @returns {{valid: Boolean, reason: String|null, range: Object|null, block: String|null}}
+ */
+export function locateSpecPin(source, handle) {
+    const describe = `test.describe('ai/graph/identityRoots — ${handle} roster pin', () => {`,
+          starts   = [];
+    let cursor = 0;
+
+    while ((cursor = source.indexOf(describe, cursor)) !== -1) {
+        starts.push(cursor);
+        cursor += describe.length;
+    }
+
+    if (starts.length === 0) {
+        return {valid: true, reason: null, range: null, block: null};
+    }
+
+    if (starts.length !== 1) {
+        return {valid: false, reason: `${handle} has ${starts.length} dedicated roster-pin describes; refusing an ambiguous repair`, range: null, block: null};
+    }
+
+    const describeStart = starts[0],
+          docStart      = source.lastIndexOf('/**', describeStart),
+          secondTest    = source.indexOf(`test('${handle} commits no static wake template and no engine facts (observation-owned)'`, describeStart),
+          blockEnd      = secondTest === -1 ? -1 : source.indexOf('\n});', secondTest);
+
+    if (docStart === -1 || blockEnd === -1) {
+        return {valid: false, reason: `${handle} roster pin exists but its generated block boundaries are not recognizable`, range: null, block: null};
+    }
+
+    const end = blockEnd + '\n});'.length;
+
+    return {valid: true, reason: null, range: {start: docStart, end}, block: source.slice(docStart, end)};
+}
+
+/**
+ * @summary Constructs one normalized surface result.
+ * @param {Object} base Stable surface metadata
+ * @param {String} status One of {@link SURFACE_STATES}
+ * @param {String|null} reason Human-readable classification/diff
+ * @param {String|null} updated Complete updated source when writable
+ * @returns {Object}
+ */
+export function surfaceResult(base, status, reason, updated = null) {
+    return {...base, status, reason, updated, repairable: updated !== null};
+}
+
+/**
+ * @summary Classifies the `identityRoots.mjs` surface: MISSING inserts before the broadcast
+ * sentinel, MATCH requires the exact generated block, and DIVERGENT repairs only the
+ * recognizable pending generator shape. Activated/non-generated entries fail closed.
  * @param {String} source Current file content
  * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
  * @returns {{surface: String, path: String, status: String, reason: String|null, anchor: String, snippet: String, updated: String|null}}
@@ -400,53 +672,108 @@ export function planRosterSurface(source, plan) {
     const base = {surface: 'identityRoots', path: SURFACE_PATHS.identityRoots, anchor: `immediately before the 'AGENT:*' BroadcastSentinel entry`, snippet: renderRosterEntry(plan)};
 
     if (typeof source !== 'string' || source === '') {
-        return {...base, status: 'invalid', reason: 'identityRoots source must be a non-empty string', updated: null};
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, 'identityRoots source must be a non-empty string');
     }
 
-    if (new RegExp(`id\\s*:\\s*'${escapeRegExp(plan.handle)}'`).test(source)) {
-        return {...base, status: 'exists', reason: `${plan.handle} already has an IDENTITIES roster entry`, updated: null};
+    const located = locateRosterEntry(source, plan.handle);
+
+    if (!located.valid) {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, located.reason);
+    }
+
+    if (located.block) {
+        if (isGeneratedRosterEntry(located.block)) {
+            const sinceMatch   = located.block.match(/^\s*since\s*:\s*'([^']+)'/m),
+                  createdMatch = located.block.match(/^\s*createdAt\s*:\s*'([^']+)'/m),
+                  githubMatch  = located.block.match(/^\s*githubLogin\s*:\s*'@([^']+)'/m);
+
+            if (!sinceMatch || !createdMatch || sinceMatch[1] !== createdMatch[1] || !Number.isFinite(Date.parse(sinceMatch[1])) || !githubMatch) {
+                return surfaceResult(base, SURFACE_STATES.DIVERGENT, `${plan.handle} generated roster block has inconsistent immutable identity anchors (birth timestamp or githubLogin); refusing repair`);
+            }
+
+            // A rerun occurs later by definition. Preserve the actual first-generation time;
+            // corrected family/login input must not rewrite identity birth history.
+            base.snippet = renderRosterEntry({...plan, since: sinceMatch[1]});
+            base.previousGithubBody = githubMatch[1];
+        }
+
+        if (located.block === base.snippet) {
+            return surfaceResult(base, SURFACE_STATES.MATCH, `${plan.handle} roster entry exactly matches the generated Layer-1 block`);
+        }
+
+        if (!isGeneratedRosterEntry(located.block)) {
+            return surfaceResult(base, SURFACE_STATES.DIVERGENT, `${plan.handle} has an existing non-generated or activated roster entry; refusing to overwrite durable identity truth`);
+        }
+
+        return surfaceResult(
+            base,
+            SURFACE_STATES.DIVERGENT,
+            `${plan.handle} generated roster block differs from corrected input; exact block repair planned`,
+            replaceExactRange(source, located.range, base.snippet)
+        );
     }
 
     const sentinel = source.match(/\n    \{\n\s+id\s*:\s*'AGENT:\*'/);
 
     if (!sentinel) {
-        return {...base, status: 'invalid', reason: `insertion anchor not found: the 'AGENT:*' BroadcastSentinel entry is missing from ${SURFACE_PATHS.identityRoots}`, updated: null};
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, `insertion anchor not found: the 'AGENT:*' BroadcastSentinel entry is missing from ${SURFACE_PATHS.identityRoots}`);
     }
 
     const insertAt = sentinel.index + 1;
 
     return {
         ...base,
-        status : 'insert',
-        reason : null,
-        updated: source.slice(0, insertAt) + base.snippet + '\n' + source.slice(insertAt)
+        status    : SURFACE_STATES.MISSING,
+        reason    : `${plan.handle} has no structural roster entry`,
+        repairable: true,
+        updated   : source.slice(0, insertAt) + base.snippet + '\n' + source.slice(insertAt)
     };
 }
 
 /**
- * @summary Plans the README surface: EXISTS when the roster table already links the resident's
- * GitHub account; otherwise appends the row after the last row of the maintainer roster table.
- * Fail-closed when the table header is missing.
+ * @summary Classifies the README surface by the exact resident/default-login row. MISSING
+ * appends, MATCH is byte-equal, and DIVERGENT repairs only the generated pending row; activated
+ * or duplicate rows fail closed.
  * @param {String} source Current file content
  * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
+ * @param {String[]} [aliases=[]] Prior generated GitHub-login bodies that still own the row
  * @returns {{surface: String, path: String, status: String, reason: String|null, anchor: String, snippet: String, updated: String|null}}
  */
-export function planReadmeSurface(source, plan) {
+export function planReadmeSurface(source, plan, aliases = []) {
     const base = {surface: 'readme', path: SURFACE_PATHS.readme, anchor: 'appended after the last row of the maintainer roster table', snippet: renderReadmeRow(plan)};
 
     if (typeof source !== 'string' || source === '') {
-        return {...base, status: 'invalid', reason: 'README source must be a non-empty string', updated: null};
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, 'README source must be a non-empty string');
     }
 
-    if (source.includes(`](https://github.com/${plan.githubBody})`)) {
-        return {...base, status: 'exists', reason: `@${plan.githubBody} already has a maintainer roster row`, updated: null};
+    const located = locateReadmeRow(source, plan, aliases);
+
+    if (!located.valid) {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, located.reason);
+    }
+
+    if (located.row) {
+        if (located.row === base.snippet) {
+            return surfaceResult(base, SURFACE_STATES.MATCH, `${plan.handle} maintainer row exactly matches generated content`);
+        }
+
+        if (!located.row.includes('engine designation pending first boot') || !located.row.endsWith('| Machine Account |')) {
+            return surfaceResult(base, SURFACE_STATES.DIVERGENT, `${plan.handle} maintainer row is human-edited or activated; refusing to replace it as generated onboarding content`);
+        }
+
+        return surfaceResult(
+            base,
+            SURFACE_STATES.DIVERGENT,
+            `${plan.handle} generated maintainer row differs from corrected family/login input; exact row repair planned`,
+            replaceExactRange(source, located.range, base.snippet)
+        );
     }
 
     const lines     = source.split('\n'),
           headerIdx = lines.indexOf('| Name | Maintainer | Role | Identity |');
 
     if (headerIdx === -1) {
-        return {...base, status: 'invalid', reason: `insertion anchor not found: the '| Name | Maintainer | Role | Identity |' table header is missing from ${SURFACE_PATHS.readme}`, updated: null};
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, `insertion anchor not found: the '| Name | Maintainer | Role | Identity |' table header is missing from ${SURFACE_PATHS.readme}`);
     }
 
     let end = headerIdx + 1;
@@ -457,14 +784,13 @@ export function planReadmeSurface(source, plan) {
 
     lines.splice(end, 0, base.snippet);
 
-    return {...base, status: 'insert', reason: null, updated: lines.join('\n')};
+    return surfaceResult(base, SURFACE_STATES.MISSING, `${plan.handle} has no maintainer row`, lines.join('\n'));
 }
 
 /**
- * @summary Plans the ModelStats.md surface: EXISTS when the section anchor or the resident's
- * id/githubLogin cell is already present; otherwise inserts the skeleton inside the pending
- * identities section, before the divider that closes it. Fail-closed when the heading or
- * divider is missing.
+ * @summary Classifies the exact ModelStats semantic section. MISSING inserts the skeleton,
+ * MATCH is byte-equal, and DIVERGENT repairs only the recognizable pending generator section;
+ * human-edited/activated sections fail closed.
  * @param {String} source Current file content
  * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
  * @returns {{surface: String, path: String, status: String, reason: String|null, anchor: String, snippet: String, updated: String|null}}
@@ -473,38 +799,57 @@ export function planModelStatsSurface(source, plan) {
     const base = {surface: 'modelStats', path: SURFACE_PATHS.modelStats, anchor: 'inside §pending_swarm_identities, before the closing divider', snippet: renderModelStatsSection(plan)};
 
     if (typeof source !== 'string' || source === '') {
-        return {...base, status: 'invalid', reason: 'ModelStats source must be a non-empty string', updated: null};
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, 'ModelStats source must be a non-empty string');
     }
 
-    if (source.includes(`### §${plan.sectionAnchor}\n`) || source.includes('| `id` / `githubLogin` | `' + plan.handle + '` |')) {
-        return {...base, status: 'exists', reason: `${plan.handle} already has a ModelStats section`, updated: null};
+    const located = locateModelStatsSection(source, plan.sectionAnchor);
+
+    if (!located.valid) {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, located.reason);
+    }
+
+    if (located.section) {
+        if (located.section === base.snippet) {
+            return surfaceResult(base, SURFACE_STATES.MATCH, `${plan.handle} ModelStats section exactly matches generated content`);
+        }
+
+        if (!isGeneratedModelStatsSection(located.section)) {
+            return surfaceResult(base, SURFACE_STATES.DIVERGENT, `${plan.handle} ModelStats section is human-edited or activated; refusing to replace it as generated onboarding content`);
+        }
+
+        return surfaceResult(
+            base,
+            SURFACE_STATES.DIVERGENT,
+            `${plan.handle} generated ModelStats section differs from corrected family/login input; exact section repair planned`,
+            replaceExactRange(source, located.range, base.snippet)
+        );
     }
 
     const headingIdx = source.indexOf('\n## §pending_swarm_identities');
 
     if (headingIdx === -1) {
-        return {...base, status: 'invalid', reason: `insertion anchor not found: the '## §pending_swarm_identities' heading is missing from ${SURFACE_PATHS.modelStats}`, updated: null};
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, `insertion anchor not found: the '## §pending_swarm_identities' heading is missing from ${SURFACE_PATHS.modelStats}`);
     }
 
     const dividerIdx = source.indexOf('\n---\n', headingIdx);
 
     if (dividerIdx === -1) {
-        return {...base, status: 'invalid', reason: `insertion anchor not found: no '---' divider closes §pending_swarm_identities in ${SURFACE_PATHS.modelStats}`, updated: null};
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, `insertion anchor not found: no '---' divider closes §pending_swarm_identities in ${SURFACE_PATHS.modelStats}`);
     }
 
     return {
         ...base,
-        status : 'insert',
-        reason : null,
-        updated: source.slice(0, dividerIdx) + '\n' + base.snippet + '\n' + source.slice(dividerIdx)
+        status    : SURFACE_STATES.MISSING,
+        reason    : `${plan.handle} has no ModelStats section`,
+        repairable: true,
+        updated   : source.slice(0, dividerIdx) + '\n' + base.snippet + '\n' + source.slice(dividerIdx)
     };
 }
 
 /**
- * @summary Plans the roster-pin spec surface: EXISTS when the spec already references the
- * resident's handle as a quoted literal (any existing reference means a pin or invariant
- * already covers the identity — emitting another block would duplicate coverage); otherwise
- * appends the pin block at the end of the spec.
+ * @summary Classifies the dedicated structural roster-pin describe. Incidental quoted-handle
+ * references are ignored; MISSING appends the pin, MATCH is byte-equal, and a uniquely-bounded
+ * DIVERGENT generated pin is repaired exactly.
  * @param {String} source Current file content
  * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
  * @returns {{surface: String, path: String, status: String, reason: String|null, anchor: String, snippet: String, updated: String|null}}
@@ -513,18 +858,34 @@ export function planSpecSurface(source, plan) {
     const base = {surface: 'spec', path: SURFACE_PATHS.spec, anchor: 'appended at the end of the spec file', snippet: renderSpecPin(plan)};
 
     if (typeof source !== 'string' || source === '') {
-        return {...base, status: 'invalid', reason: 'spec source must be a non-empty string', updated: null};
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, 'spec source must be a non-empty string');
     }
 
-    if (source.includes(`'${plan.handle}'`)) {
-        return {...base, status: 'exists', reason: `${plan.handle} is already referenced by the roster spec`, updated: null};
+    const located = locateSpecPin(source, plan.handle);
+
+    if (!located.valid) {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, located.reason);
+    }
+
+    if (located.block) {
+        if (located.block === base.snippet) {
+            return surfaceResult(base, SURFACE_STATES.MATCH, `${plan.handle} dedicated roster pin exactly matches generated content`);
+        }
+
+        return surfaceResult(
+            base,
+            SURFACE_STATES.DIVERGENT,
+            `${plan.handle} dedicated generated roster pin differs from corrected identity input; exact block repair planned`,
+            replaceExactRange(source, located.range, base.snippet)
+        );
     }
 
     return {
         ...base,
-        status : 'insert',
-        reason : null,
-        updated: source.replace(/\s*$/, '\n') + '\n' + base.snippet + '\n'
+        status    : SURFACE_STATES.MISSING,
+        reason    : `${plan.handle} has no dedicated structural roster pin`,
+        repairable: true,
+        updated   : source.replace(/\s*$/, '\n') + '\n' + base.snippet + '\n'
     };
 }
 
@@ -542,20 +903,22 @@ export function planOnboardingSurfaces(plan, files = {}) {
         return {valid: false, reason: 'planOnboardingSurfaces requires a valid plan from buildOnboardingPlan', surfaces: []};
     }
 
-    for (const key of ['identityRoots', 'modelStats', 'readme', 'spec']) {
+    for (const key of ONBOARDING_SURFACE_KEYS) {
         if (typeof files[key] !== 'string') {
             return {valid: false, reason: `missing file content for surface '${key}'`, surfaces: []};
         }
     }
 
+    const roster  = planRosterSurface(files.identityRoots, plan),
+          aliases = roster.previousGithubBody ? [roster.previousGithubBody] : [];
     const surfaces = [
-        planRosterSurface(files.identityRoots, plan),
-        planReadmeSurface(files.readme, plan),
+        roster,
+        planReadmeSurface(files.readme, plan, aliases),
         planModelStatsSurface(files.modelStats, plan),
         planSpecSurface(files.spec, plan)
     ];
 
-    const invalid = surfaces.find(surface => surface.status === 'invalid');
+    const invalid = surfaces.find(surface => surface.status === SURFACE_STATES.DIVERGENT && !surface.repairable);
 
     return {
         valid : !invalid,
@@ -565,12 +928,272 @@ export function planOnboardingSurfaces(plan, files = {}) {
 }
 
 /**
+ * @summary Extracts the current engine designation from one ModelStats `name` row while
+ * preserving any identity/social annotation suffix for an exact row-only rotation.
+ * @param {String} section Resident ModelStats section
+ * @returns {{valid: Boolean, reason: String|null, designation: String|null, suffix: String, row: String|null}}
+ */
+export function extractModelStatsDesignation(section) {
+    const row = section.split('\n').find(line => line.startsWith('| `name` | '));
+
+    if (!row || !row.endsWith(' |')) {
+        return {valid: false, reason: 'the resident ModelStats section has no exact `name` row', designation: null, suffix: '', row: null};
+    }
+
+    const value   = row.slice('| `name` | '.length, -2).trim(),
+          markers = [' (GitHub profile', ' (Social Name', ' (engine designation'],
+          indexes = markers.map(marker => value.indexOf(marker)).filter(index => index !== -1),
+          cut     = indexes.length > 0 ? Math.min(...indexes) : value.length;
+
+    return {valid: true, reason: null, designation: value.slice(0, cut).trim(), suffix: value.slice(cut), row};
+}
+
+/**
+ * @summary Rotation boundary for durable roots: the resident must exist and must not carry a
+ * flat `modelDesignation`. The source is never rewritten by this mode.
+ * @param {String} source identityRoots source
+ * @param {Object} plan Rotation plan
+ * @returns {Object}
+ */
+export function planRotationIdentityBoundary(source, plan) {
+    const base = {surface: 'identityRoots', path: SURFACE_PATHS.identityRoots, anchor: 'durable resident boundary (verified, never written by rotation)', snippet: ''};
+
+    if (typeof source !== 'string' || source === '') {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, 'identityRoots source must be a non-empty string');
+    }
+
+    const located = locateRosterEntry(source, plan.handle);
+
+    if (!located.valid || !located.block) {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, located.reason || `${plan.handle} is missing from durable identity roots; rotation cannot onboard a resident`);
+    }
+
+    if (/^\s*modelDesignation\s*:/m.test(located.block)) {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, `${plan.handle} still carries flat modelDesignation in durable roots; rotation refuses to perpetuate the ADR-0032 violation`);
+    }
+
+    return surfaceResult(base, SURFACE_STATES.MATCH, `${plan.handle} durable root exists without flat modelDesignation; byte-stable by construction`);
+}
+
+/**
+ * @summary Plans the ModelStats half of a rotation by changing only the exact `name` row and
+ * retaining identity/social annotations byte-for-byte.
+ * @param {String} source ModelStats source
+ * @param {Object} plan Rotation plan
+ * @returns {Object}
+ */
+export function planRotationModelStatsSurface(source, plan) {
+    const base = {surface: 'modelStats', path: SURFACE_PATHS.modelStats, anchor: `§${plan.sectionAnchor} exact name row`, snippet: `| \`name\` | ${plan.designation} |`};
+
+    if (typeof source !== 'string' || source === '') {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, 'ModelStats source must be a non-empty string');
+    }
+
+    const located = locateModelStatsSection(source, plan.sectionAnchor);
+
+    if (!located.valid || !located.section) {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, located.reason || `${plan.handle} has no ModelStats section; rotation cannot invent capability history`);
+    }
+
+    const extracted = extractModelStatsDesignation(located.section);
+
+    if (!extracted.valid) {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, extracted.reason);
+    }
+
+    base.previousDesignation = extracted.designation;
+
+    if (extracted.designation === plan.designation) {
+        return surfaceResult(base, SURFACE_STATES.MATCH, `${plan.handle} ModelStats name already records '${plan.designation}'`);
+    }
+
+    const desiredRow = `| \`name\` | ${plan.designation}${extracted.suffix} |`,
+          rowStart   = source.indexOf(extracted.row, located.range.start);
+
+    if (rowStart === -1 || rowStart >= located.range.end) {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, `${plan.handle} ModelStats name row could not be bounded inside its section`);
+    }
+
+    base.snippet = desiredRow;
+
+    return surfaceResult(
+        base,
+        SURFACE_STATES.DIVERGENT,
+        `${plan.handle} ModelStats designation '${extracted.designation}' differs from '${plan.designation}'; exact name-row rotation planned`,
+        replaceExactRange(source, {start: rowStart, end: rowStart + extracted.row.length}, desiredRow)
+    );
+}
+
+/**
+ * @summary Plans the README half of a rotation by replacing the exact prior ModelStats
+ * designation inside the one resident row. Vendor/harness suffixes remain byte-stable.
+ * @param {String} source README source
+ * @param {Object} plan Rotation plan
+ * @param {String} previousDesignation Exact current ModelStats designation
+ * @returns {Object}
+ */
+export function planRotationReadmeSurface(source, plan, previousDesignation) {
+    const base = {surface: 'readme', path: SURFACE_PATHS.readme, anchor: `${plan.handle} exact maintainer row`, snippet: plan.designation};
+
+    if (typeof source !== 'string' || source === '') {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, 'README source must be a non-empty string');
+    }
+
+    const located = locateReadmeRow(source, plan);
+
+    if (!located.valid || !located.row) {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, located.reason || `${plan.handle} has no unique maintainer row; rotation refuses to create one`);
+    }
+
+    const occurrences = previousDesignation ? located.row.split(previousDesignation).length - 1 : 0;
+
+    if (occurrences !== 1) {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, `${plan.handle} README row does not contain the prior ModelStats designation '${previousDesignation}' exactly once; refusing a broad prose rewrite`);
+    }
+
+    if (previousDesignation === plan.designation) {
+        return surfaceResult(base, SURFACE_STATES.MATCH, `${plan.handle} README row exactly records '${plan.designation}'`);
+    }
+
+    const desiredRow = located.row.replace(previousDesignation, plan.designation);
+
+    base.snippet = desiredRow;
+
+    return surfaceResult(
+        base,
+        SURFACE_STATES.DIVERGENT,
+        `${plan.handle} README designation '${previousDesignation}' differs from '${plan.designation}'; exact row rotation planned`,
+        replaceExactRange(source, located.range, desiredRow)
+    );
+}
+
+/**
+ * @summary Rotation boundary for the focused identity spec: evidence must already mention the
+ * resident, but engine text is never generated into the durable-root pin.
+ * @param {String} source identityRoots spec source
+ * @param {Object} plan Rotation plan
+ * @returns {Object}
+ */
+export function planRotationSpecBoundary(source, plan) {
+    const base = {surface: 'spec', path: SURFACE_PATHS.spec, anchor: 'durable identity continuity evidence (verified, never engine-rewritten)', snippet: ''};
+
+    if (typeof source !== 'string' || !source.includes(`'${plan.handle}'`)) {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, `${plan.handle} has no exact quoted identity reference in the focused roots spec; rotation evidence is incomplete`);
+    }
+
+    return surfaceResult(base, SURFACE_STATES.MATCH, `${plan.handle} has focused durable-identity evidence; rotation leaves it byte-stable`);
+}
+
+/**
+ * @summary Rotation boundary for the migration snapshot: require the epoch/map authority and
+ * leave it byte-stable even when the desired live designation differs from the seed.
+ * @param {String} source identityRootsMigration source
+ * @returns {Object}
+ */
+export function planRotationMigrationBoundary(source) {
+    const base = {surface: 'migration', path: SURFACE_PATHS.migration, anchor: 'MIGRATION_EPOCH + REGISTRY_MODEL_DESIGNATIONS snapshot (verified, never written)', snippet: ''};
+
+    if (typeof source !== 'string' || !source.includes('export const MIGRATION_EPOCH') || !source.includes('export const REGISTRY_MODEL_DESIGNATIONS')) {
+        return surfaceResult(base, SURFACE_STATES.DIVERGENT, 'migration epoch/designation snapshot authority is missing; refusing a rotation that could retroject history');
+    }
+
+    return surfaceResult(base, SURFACE_STATES.MATCH, 'migration epoch snapshot preserved byte-for-byte; the new embodiment belongs to the era layer');
+}
+
+/**
+ * @summary Plans the corrected rotation ceremony. Only README + ModelStats can be writable;
+ * roots, focused spec, and migration snapshot are explicit byte-stable boundaries.
+ * @param {Object} plan Valid rotation plan
+ * @param {Object} files Current five surface contents
+ * @returns {{valid: Boolean, reason: String|null, surfaces: Object[]}}
+ */
+export function planRotationSurfaces(plan, files = {}) {
+    if (!plan || plan.mode !== 'rotation') {
+        return {valid: false, reason: 'planRotationSurfaces requires a rotation plan', surfaces: []};
+    }
+
+    for (const key of ROTATION_SURFACE_KEYS) {
+        if (typeof files[key] !== 'string') {
+            return {valid: false, reason: `missing file content for rotation surface '${key}'`, surfaces: []};
+        }
+    }
+
+    const modelStats = planRotationModelStatsSurface(files.modelStats, plan),
+          previous   = modelStats.previousDesignation;
+    const surfaces = [
+        planRotationIdentityBoundary(files.identityRoots, plan),
+        planRotationReadmeSurface(files.readme, plan, previous),
+        modelStats,
+        planRotationSpecBoundary(files.spec, plan),
+        planRotationMigrationBoundary(files.migration)
+    ];
+    const invalid = surfaces.find(surface => surface.status === SURFACE_STATES.DIVERGENT && !surface.repairable);
+
+    return {valid: !invalid, reason: invalid ? invalid.reason : null, surfaces};
+}
+
+/**
+ * @summary Renders the review-gated PR-body draft from the actual writable surface set.
+ * Evidence remains checkbox placeholders because ticket/PR ids and live receipts do not exist
+ * at generation time.
+ * @param {Object} plan Ceremony plan
+ * @param {Object} planned Surface plan
+ * @returns {String[]}
+ */
+export function renderPrBodyDraft(plan, planned) {
+    const changed = planned.surfaces.filter(surface => surface.updated !== null),
+          lines   = [
+              '## Generated PR-body draft',
+              '',
+              'Resolves #TICKET',
+              '',
+              `Completes the ${plan.mode} identity ceremony for ${plan.handle}.`,
+              '',
+              '## Changed Surfaces'
+          ];
+
+    if (changed.length === 0) {
+        lines.push('- None — exact generated/current content already matches.');
+    } else {
+        for (const surface of changed) {
+            lines.push(`- \`${surface.path}\` — ${surface.status}: ${surface.reason}`);
+        }
+    }
+
+    lines.push('', '## Evidence',
+        '- [ ] focused generator unit spec',
+        '- [ ] fresh-process CLI: initial / zero-op / corrected divergence / ambiguous refusal / rotation',
+        '- [ ] generated identity-roots spec (when onboarding writes a pin)',
+        '- [ ] `node --check ai/scripts/setup/generateRosterOnboarding.mjs`',
+        '- [ ] `git diff --check`');
+
+    if (plan.mode === 'rotation') {
+        lines.push('- [ ] durable identity root unchanged (no model designation write)',
+            '- [ ] migration epoch/designation snapshot unchanged (no retrojection)',
+            '- [ ] ModelStats update-history row completed after PR number exists',
+            '- [ ] deployed graph mutation/reseed: out of scope');
+    }
+
+    return lines;
+}
+
+/**
  * @summary Advisory notes printed with every payload — adjacent concerns the generator
  * deliberately does NOT write (they are either untouchable by rule or editorial).
  * @param {Object} plan A valid plan from {@link buildOnboardingPlan}
  * @returns {String[]}
  */
 export function renderAdvisoryNotes(plan) {
+    if (plan.mode === 'rotation') {
+        return [
+            '[generateRosterOnboarding] rotation boundaries (printed, never written):',
+            '  - Durable identityRoots stay byte-stable: model/family/capability truth belongs to the EmbodiedEpisode era chain (ADR-0032).',
+            '  - identityRootsMigration stays byte-stable: MIGRATION_EPOCH seed facts are history, never retrojected to the new designation.',
+            '  - ModelStats §update_history: add the designation transition with ticket + PR ids once they exist.',
+            '  - Opening/persisting the new era is observation-owned and outside this generator; deployed graph mutation is out of scope.'
+        ];
+    }
+
     return [
         '[generateRosterOnboarding] advisory (printed, never written):',
         '  - ModelStats §update_history: add a row citing the onboarding PR number once the PR exists.',
@@ -588,15 +1211,16 @@ export function renderAdvisoryNotes(plan) {
  */
 export function renderOnboardingReport(plan, planned) {
     const lines = [
-        `[generateRosterOnboarding] four-surface onboarding payload for ${plan.handle} (family: ${plan.family})`,
+        `[generateRosterOnboarding] ${plan.mode} ceremony for ${plan.handle} (family: ${plan.family})`,
         ''
     ];
 
     for (const surface of planned.surfaces) {
         lines.push(`  [${surface.status.toUpperCase()}] ${surface.path}`);
 
-        if (surface.status === 'insert') {
+        if (surface.updated !== null) {
             lines.push(`      anchor: ${surface.anchor}`);
+            lines.push(`      ${surface.reason}`);
             lines.push(...surface.snippet.split('\n').map(line => `      ${line}`.replace(/\s+$/, '')));
         } else {
             lines.push(`      ${surface.reason}`);
@@ -606,6 +1230,7 @@ export function renderOnboardingReport(plan, planned) {
     }
 
     lines.push(...renderAdvisoryNotes(plan));
+    lines.push('', ...renderPrBodyDraft(plan, planned));
 
     return lines;
 }
@@ -647,9 +1272,12 @@ export function checkWriteGuard({branch} = {}) {
  */
 export function parseGenerateArgs(argv = []) {
     const valueFlags = {
+        '--designation'    : 'designation',
         '--family'         : 'family',
         '--github-username': 'githubUsername',
-        '--handle'         : 'handle'
+        '--handle'         : 'handle',
+        '--mode'           : 'mode',
+        '--repo-root'      : 'repoRoot'
     };
 
     const booleanFlags = {
@@ -666,7 +1294,7 @@ export function parseGenerateArgs(argv = []) {
             return {valid: false, reason: `${flag} is rejected by design — Social Names are the post-boot peer-naming ritual (bearer-assented), never seed data`, options: null};
         }
 
-        if (ENGINE_CLASS_FLAGS.includes(flag)) {
+        if (ENGINE_CLASS_FLAGS.includes(flag) && flag !== '--designation') {
             return {valid: false, reason: `${flag} is rejected by design — engine facts are observation-owned and land through the source-cited ModelStats.md discipline at first boot, never as onboarding predictions`, options: null};
         }
 
@@ -694,8 +1322,8 @@ export function parseGenerateArgs(argv = []) {
 }
 
 /**
- * @summary Reads the four surface files from the repo root — the side-effect half's only read
- * surface.
+ * @summary Reads the fixed ceremony authority files from the repo root — four writable
+ * onboarding surfaces plus the rotation-only migration snapshot boundary.
  * @param {String} repoRoot Absolute repo root path
  * @returns {Object} File contents keyed `{identityRoots, modelStats, readme, spec}`
  */
@@ -719,7 +1347,13 @@ export function currentGitBranch(repoRoot) {
     try {
         return execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {cwd: repoRoot, encoding: 'utf8'}).trim();
     } catch {
-        return null;
+        try {
+            // A freshly-created work branch can be unborn (no commit yet): rev-parse rejects
+            // it, while symbolic-ref still proves HEAD is bound to a named branch.
+            return execFileSync('git', ['symbolic-ref', '--short', 'HEAD'], {cwd: repoRoot, encoding: 'utf8'}).trim();
+        } catch {
+            return null;
+        }
     }
 }
 
@@ -728,11 +1362,14 @@ export function currentGitBranch(repoRoot) {
  * @returns {void}
  */
 function printUsage() {
-    console.log('Usage: node ai/scripts/setup/generateRosterOnboarding.mjs --handle <s> --family <s>');
-    console.log('           [--github-username <s>] [--write]');
+    console.log('Usage: node ai/scripts/setup/generateRosterOnboarding.mjs [--mode onboarding] --handle <s> --family <s>');
+    console.log('           [--github-username <s>] [--repo-root <path>] [--write]');
+    console.log('       node ai/scripts/setup/generateRosterOnboarding.mjs --mode rotation --handle <s> --family <s>');
+    console.log('           --designation <s> [--github-username <s>] [--repo-root <path>] [--write]');
     console.log('');
-    console.log('  (no flags)  Dry-run — print the four proposed file modifications without applying them.');
-    console.log('  --write     Apply the insertions (branch-guarded: refuses on dev/main; EXISTS surfaces skipped).');
+    console.log('  (no flags)  Dry-run — classify and print the exact onboarding/rotation plan without applying it.');
+    console.log('  --write     Apply every planned MISSING/repairable-DIVERGENT surface (branch-guarded).');
+    console.log('  --repo-root Override the fixed-surface repository root (used by fresh-process contract tests).');
     console.log('');
     console.log('  There is deliberately NO model/engine flag (engine facts are observation-owned; they land');
     console.log('  source-cited in ModelStats.md at first boot) and NO social-name flag (Social Names are the');
@@ -740,8 +1377,8 @@ function printUsage() {
 }
 
 /**
- * @summary CLI entry: parse → plan → print; `--write` applies the insertions behind the branch
- * guard. Dry-run touches nothing.
+ * @summary CLI entry: parse → classify/plan → print; `--write` applies the complete validated
+ * write set behind the branch guard. Dry-run touches nothing.
  * @returns {Promise<void>}
  */
 async function main() {
@@ -758,7 +1395,8 @@ async function main() {
         return;
     }
 
-    const built = buildOnboardingPlan(parsed.options);
+    const {repoRoot: requestedRoot, ...ceremonyOptions} = parsed.options,
+          built                                         = buildOnboardingPlan(ceremonyOptions);
 
     if (!built.valid) {
         console.error(`[generateRosterOnboarding] FATAL: ${built.reason}`);
@@ -767,8 +1405,9 @@ async function main() {
     }
 
     const {plan}   = built,
-          repoRoot = path.resolve(path.dirname(__filename), '../../..'),
-          planned  = planOnboardingSurfaces(plan, readSurfaceFiles(repoRoot));
+          repoRoot = requestedRoot ? path.resolve(requestedRoot) : path.resolve(path.dirname(__filename), '../../..'),
+          files    = readSurfaceFiles(repoRoot),
+          planned  = plan.mode === 'rotation' ? planRotationSurfaces(plan, files) : planOnboardingSurfaces(plan, files);
 
     console.log(renderOnboardingReport(plan, planned).join('\n'));
     console.log('');
@@ -793,7 +1432,7 @@ async function main() {
     let written = 0;
 
     for (const surface of planned.surfaces) {
-        if (surface.status === 'insert') {
+        if (surface.updated !== null) {
             fs.writeFileSync(path.join(repoRoot, surface.path), surface.updated);
             console.log(`  [WROTE] ${surface.path}`);
             written++;

--- a/test/playwright/unit/ai/scripts/setup/generateRosterOnboarding.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/generateRosterOnboarding.spec.mjs
@@ -13,14 +13,17 @@ setup({
     }
 });
 
-import {test, expect}  from '@playwright/test';
-import fs              from 'node:fs';
-import path            from 'node:path';
-import {fileURLToPath} from 'node:url';
-import Neo             from '../../../../../../src/Neo.mjs';
-import * as core       from '../../../../../../src/core/_export.mjs';
+import {test, expect}            from '@playwright/test';
+import {execFileSync, spawnSync} from 'node:child_process';
+import fs                        from 'node:fs';
+import os                        from 'node:os';
+import path                      from 'node:path';
+import {fileURLToPath}           from 'node:url';
+import Neo                       from '../../../../../../src/Neo.mjs';
+import * as core                 from '../../../../../../src/core/_export.mjs';
 import {
     ENGINE_CLASS_KEYS,
+    SURFACE_STATES,
     SOCIAL_NAME_CLASS_KEYS,
     SURFACE_PATHS,
     buildOnboardingPlan,
@@ -32,15 +35,18 @@ import {
     planOnboardingSurfaces,
     planReadmeSurface,
     planRosterSurface,
+    planRotationSurfaces,
     planSpecSurface,
     renderModelStatsSection,
     renderOnboardingReport,
     renderReadmeRow,
     renderRosterEntry,
-    renderSpecPin
+    renderSpecPin,
+    renderPrBodyDraft
 } from '../../../../../../ai/scripts/setup/generateRosterOnboarding.mjs';
 
-const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
+const REPO_ROOT   = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../../..');
+const SCRIPT_PATH = path.join(REPO_ROOT, 'ai/scripts/setup/generateRosterOnboarding.mjs');
 
 const FIXED_NOW    = '2026-07-10T12:00:00.000Z';
 const BASE_OPTIONS = Object.freeze({
@@ -134,11 +140,112 @@ test.describe('existing', () => {
 });
 `;
 
+const MIGRATION_FIXTURE = `export const MIGRATION_EPOCH = '2026-07-04T00:00:00Z';
+export const REGISTRY_MODEL_DESIGNATIONS = Object.freeze({'@neo-gpt': 'GPT-5.5'});
+`;
+
 const FIXTURE_FILES = Object.freeze({
     identityRoots: ROSTER_FIXTURE,
+    migration    : MIGRATION_FIXTURE,
     modelStats   : MODEL_STATS_FIXTURE,
     readme       : README_FIXTURE,
     spec         : SPEC_FIXTURE
+});
+
+const ROTATION_FILES = Object.freeze({
+    identityRoots: `export const IDENTITIES = [
+    {
+        id         : '@neo-gpt',
+        type       : 'AgentIdentity',
+        name       : 'Euclid',
+        description: 'Stable resident compatibility prose',
+        properties : {
+            githubLogin        : '@neo-gpt',
+            displayName        : 'Euclid',
+            modelFamily        : 'gpt',
+            participationStatus: 'active'
+        }
+    },
+    {
+        id         : 'AGENT:*',
+        type       : 'BroadcastSentinel',
+        properties : {}
+    }
+];
+`,
+    migration : MIGRATION_FIXTURE,
+    modelStats: `# Model Stats Registry
+
+### §neo_gpt
+
+| Field | Value |
+|---|---|
+| \`id\` / \`githubLogin\` | \`@neo-gpt\` |
+| \`name\` | GPT-5.5 |
+| \`family\` | \`gpt\` (OpenAI) |
+
+## §update_history
+
+| Date | Identity | Change | Reference |
+|---|---|---|---|
+`,
+    readme: `# Fixture
+
+| Name | Maintainer | Role | Identity |
+|---|---|---|---|
+| Euclid | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.5 / Codex) | Machine Account |
+`,
+    spec: `test.describe('identity continuity', () => {
+    test('pins @neo-gpt', () => {
+        expect(IDENTITIES.find(node => node.id === '@neo-gpt')).toBeTruthy();
+    });
+});
+`
+});
+
+const fixtureRoots = [];
+
+/**
+ * @summary Creates a real temporary git worktree carrying the generator's fixed surfaces.
+ * @param {Object} [files] Surface contents
+ * @returns {String} Temporary repo root
+ */
+function createFixtureRepo(files = FIXTURE_FILES) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-roster-generator-'));
+
+    fixtureRoots.push(root);
+
+    for (const [key, relative] of Object.entries(SURFACE_PATHS)) {
+        const target = path.join(root, relative);
+
+        fs.mkdirSync(path.dirname(target), {recursive: true});
+        fs.writeFileSync(target, files[key], 'utf8');
+    }
+
+    execFileSync('git', ['init', '-b', 'fixture/identity-ceremony'], {cwd: root, stdio: 'ignore'});
+
+    return root;
+}
+
+/**
+ * @summary Executes the real CLI in a fresh Node process against an isolated fixture repo.
+ * @param {String} root Fixture repo root
+ * @param {String[]} args CLI args before the injected repo-root
+ * @returns {{status: Number|null, stdout: String, stderr: String}}
+ */
+function runFreshCli(root, args) {
+    const result = spawnSync(process.execPath, [SCRIPT_PATH, ...args, '--repo-root', root], {
+        cwd     : REPO_ROOT,
+        encoding: 'utf8'
+    });
+
+    return {status: result.status, stdout: result.stdout, stderr: result.stderr};
+}
+
+test.afterAll(() => {
+    for (const root of fixtureRoots) {
+        fs.rmSync(root, {recursive: true, force: true});
+    }
 });
 
 test.describe('generateRosterOnboarding — plan construction (pure half)', () => {
@@ -281,28 +388,30 @@ test.describe('generateRosterOnboarding — surface emitters (pure half)', () =>
     });
 });
 
-test.describe('generateRosterOnboarding — surface planning (anchors + idempotency)', () => {
+test.describe('generateRosterOnboarding — surface planning (anchors + convergence)', () => {
 
-    test('roster surface: inserts immediately before the broadcast sentinel; a second run reports EXISTS', () => {
+    test('roster surface: MISSING inserts before the broadcast sentinel; exact rerun reports MATCH', () => {
         const plan  = buildPlan();
         const first = planRosterSurface(ROSTER_FIXTURE, plan);
 
-        expect(first.status).toBe('insert');
+        expect(first.status).toBe(SURFACE_STATES.MISSING);
         expect(first.updated).toContain(`id         : '@neo-unit-probe',`);
         expect(first.updated.indexOf(`'@neo-unit-probe'`)).toBeGreaterThan(first.updated.indexOf(`'@neo-existing'`));
         expect(first.updated.indexOf(`'@neo-unit-probe'`)).toBeLessThan(first.updated.indexOf(`'AGENT:*'`));
 
-        const second = planRosterSurface(first.updated, plan);
+        const laterPlan = buildPlan({now: '2026-07-11T12:00:00.000Z'}),
+              second    = planRosterSurface(first.updated, laterPlan);
 
-        expect(second.status).toBe('exists');
+        expect(second.status).toBe(SURFACE_STATES.MATCH);
         expect(second.updated).toBeNull();
+        expect(first.updated).toContain(`createdAt          : '${FIXED_NOW}'`);
     });
 
-    test('README surface: appends after the last roster-table row; a second run reports EXISTS', () => {
+    test('README surface: MISSING appends after the roster table; exact rerun reports MATCH', () => {
         const plan  = buildPlan();
         const first = planReadmeSurface(README_FIXTURE, plan);
 
-        expect(first.status).toBe('insert');
+        expect(first.status).toBe(SURFACE_STATES.MISSING);
 
         const lines  = first.updated.split('\n'),
               rowIdx = lines.indexOf(renderReadmeRow(plan));
@@ -313,15 +422,15 @@ test.describe('generateRosterOnboarding — surface planning (anchors + idempote
 
         const second = planReadmeSurface(first.updated, plan);
 
-        expect(second.status).toBe('exists');
+        expect(second.status).toBe(SURFACE_STATES.MATCH);
         expect(second.updated).toBeNull();
     });
 
-    test('ModelStats surface: inserts inside the pending section before its divider; a second run reports EXISTS', () => {
+    test('ModelStats surface: MISSING inserts inside pending; exact rerun reports MATCH', () => {
         const plan  = buildPlan();
         const first = planModelStatsSurface(MODEL_STATS_FIXTURE, plan);
 
-        expect(first.status).toBe('insert');
+        expect(first.status).toBe(SURFACE_STATES.MISSING);
 
         const sectionIdx = first.updated.indexOf('### §neo_unit_probe');
 
@@ -330,38 +439,111 @@ test.describe('generateRosterOnboarding — surface planning (anchors + idempote
 
         const second = planModelStatsSurface(first.updated, plan);
 
-        expect(second.status).toBe('exists');
+        expect(second.status).toBe(SURFACE_STATES.MATCH);
         expect(second.updated).toBeNull();
     });
 
-    test('spec surface: appends the pin at the end; a second run reports EXISTS', () => {
+    test('spec surface: MISSING appends the dedicated pin; exact rerun reports MATCH', () => {
         const plan  = buildPlan();
         const first = planSpecSurface(SPEC_FIXTURE, plan);
 
-        expect(first.status).toBe('insert');
+        expect(first.status).toBe(SURFACE_STATES.MISSING);
         expect(first.updated.trimEnd().endsWith('});')).toBe(true);
         expect(first.updated.indexOf('@neo-unit-probe roster pin')).toBeGreaterThan(first.updated.indexOf(`node.id === '@neo-existing'`));
 
         const second = planSpecSurface(first.updated, plan);
 
-        expect(second.status).toBe('exists');
+        expect(second.status).toBe(SURFACE_STATES.MATCH);
         expect(second.updated).toBeNull();
     });
 
-    test('a ModelStats anchor prefix-collision does not false-report EXISTS (§neo_x vs §neo_x_sibling)', () => {
+    test('incidental quoted-handle prose does not satisfy the dedicated structural spec pin', () => {
+        const incidental = SPEC_FIXTURE + "\nconst unrelatedExample = '@neo-unit-probe';\n",
+              result     = planSpecSurface(incidental, buildPlan());
+
+        expect(result.status).toBe(SURFACE_STATES.MISSING);
+        expect(result.updated).toContain('@neo-unit-probe roster pin');
+    });
+
+    test('corrected family/login input repairs every unambiguous generated block, then converges to MATCH', () => {
+        const initialPlan = buildPlan(),
+              initial     = planOnboardingSurfaces(initialPlan, FIXTURE_FILES),
+              applied     = Object.fromEntries(initial.surfaces.map(surface => [surface.surface, surface.updated]));
+
+        applied.migration = MIGRATION_FIXTURE;
+
+        const correctedPlan = buildPlan({family: 'gpt', githubUsername: '@neo-unit-probe-gh'}),
+              corrected     = planOnboardingSurfaces(correctedPlan, applied);
+
+        expect(corrected.valid).toBe(true);
+        expect(corrected.surfaces.map(surface => surface.status)).toEqual([
+            SURFACE_STATES.DIVERGENT,
+            SURFACE_STATES.DIVERGENT,
+            SURFACE_STATES.DIVERGENT,
+            SURFACE_STATES.DIVERGENT
+        ]);
+        expect(corrected.surfaces.every(surface => surface.repairable)).toBe(true);
+
+        const repaired = Object.fromEntries(corrected.surfaces.map(surface => [surface.surface, surface.updated]));
+
+        repaired.migration = MIGRATION_FIXTURE;
+
+        const converged = planOnboardingSurfaces(correctedPlan, repaired);
+
+        expect(converged.valid).toBe(true);
+        expect(converged.surfaces.map(surface => surface.status)).toEqual([
+            SURFACE_STATES.MATCH,
+            SURFACE_STATES.MATCH,
+            SURFACE_STATES.MATCH,
+            SURFACE_STATES.MATCH
+        ]);
+        expect((repaired.readme.match(/neo-unit-probe-gh/g) || [])).toHaveLength(2);
+        expect(repaired.readme).not.toContain('github.com/neo-unit-probe)');
+    });
+
+    test('a corrected custom login replaces the prior custom-login row instead of appending', () => {
+        const initialPlan = buildPlan({githubUsername: '@neo-unit-old'}),
+              initial     = planOnboardingSurfaces(initialPlan, FIXTURE_FILES),
+              applied     = Object.fromEntries(initial.surfaces.map(surface => [surface.surface, surface.updated])),
+              corrected   = planOnboardingSurfaces(buildPlan({githubUsername: '@neo-unit-new'}), applied),
+              readme      = corrected.surfaces.find(surface => surface.surface === 'readme');
+
+        expect(corrected.valid).toBe(true);
+        expect(readme.status).toBe(SURFACE_STATES.DIVERGENT);
+        expect((readme.updated.match(/github\.com\/neo-unit-new/g) || [])).toHaveLength(1);
+        expect(readme.updated).not.toContain('github.com/neo-unit-old');
+    });
+
+    test('ambiguous legacy content fails the whole plan before any partial write is applicable', () => {
+        const duplicate = README_FIXTURE.replace(
+                  '\nTrailing prose.',
+                  '\n| - | [@neo-unit-probe](https://github.com/neo-unit-probe) | legacy | Machine Account |\n| - | [@neo-unit-probe](https://github.com/neo-unit-probe) | duplicate | Machine Account |\n\nTrailing prose.'
+              ),
+              planned = planOnboardingSurfaces(buildPlan(), {...FIXTURE_FILES, readme: duplicate});
+
+        expect(planned.valid).toBe(false);
+        expect(planned.reason).toContain('2 maintainer rows');
+        expect(planned.surfaces.find(surface => surface.surface === 'readme')).toMatchObject({
+            status    : SURFACE_STATES.DIVERGENT,
+            repairable: false,
+            updated   : null
+        });
+    });
+
+    test('a ModelStats anchor prefix-collision does not false-report MATCH (§neo_x vs §neo_x_sibling)', () => {
         const sibling = MODEL_STATS_FIXTURE.replace('### §neo_gpt', '### §neo_unit_probe_sibling');
         const result  = planModelStatsSurface(sibling, buildPlan());
 
-        expect(result.status).toBe('insert');
+        expect(result.status).toBe(SURFACE_STATES.MISSING);
     });
 
     test('missing insertion anchors refuse loudly instead of guessing', () => {
         const plan = buildPlan();
 
-        expect(planRosterSurface('export const IDENTITIES = [];\n', plan).status).toBe('invalid');
-        expect(planReadmeSurface('# No table here\n', plan).status).toBe('invalid');
-        expect(planModelStatsSurface('# No pending heading\n', plan).status).toBe('invalid');
-        expect(planSpecSurface('', plan).status).toBe('invalid');
+        expect(planRosterSurface('export const IDENTITIES = [];\n', plan).status).toBe(SURFACE_STATES.DIVERGENT);
+        expect(planReadmeSurface('# No table here\n', plan).status).toBe(SURFACE_STATES.DIVERGENT);
+        expect(planModelStatsSurface('# No pending heading\n', plan).status).toBe(SURFACE_STATES.DIVERGENT);
+        expect(planSpecSurface('', plan).status).toBe(SURFACE_STATES.DIVERGENT);
     });
 
     test('planOnboardingSurfaces is fail-closed: missing file content or an invalid surface invalidates the payload', () => {
@@ -380,7 +562,12 @@ test.describe('generateRosterOnboarding — surface planning (anchors + idempote
         const healthy = planOnboardingSurfaces(plan, FIXTURE_FILES);
 
         expect(healthy.valid).toBe(true);
-        expect(healthy.surfaces.map(surface => surface.status)).toEqual(['insert', 'insert', 'insert', 'insert']);
+        expect(healthy.surfaces.map(surface => surface.status)).toEqual([
+            SURFACE_STATES.MISSING,
+            SURFACE_STATES.MISSING,
+            SURFACE_STATES.MISSING,
+            SURFACE_STATES.MISSING
+        ]);
     });
 
     test('the dry-run report prints status, anchor, and the exact snippet per surface, plus the advisory notes', () => {
@@ -388,43 +575,119 @@ test.describe('generateRosterOnboarding — surface planning (anchors + idempote
         const planned = planOnboardingSurfaces(plan, FIXTURE_FILES);
         const report  = renderOnboardingReport(plan, planned).join('\n');
 
-        expect(report).toContain('[INSERT] ai/graph/identityRoots.mjs');
-        expect(report).toContain('[INSERT] README.md');
-        expect(report).toContain('[INSERT] learn/agentos/ModelStats.md');
-        expect(report).toContain('[INSERT] test/playwright/unit/ai/graph/identityRoots.spec.mjs');
+        expect(report).toContain('[MISSING] ai/graph/identityRoots.mjs');
+        expect(report).toContain('[MISSING] README.md');
+        expect(report).toContain('[MISSING] learn/agentos/ModelStats.md');
+        expect(report).toContain('[MISSING] test/playwright/unit/ai/graph/identityRoots.spec.mjs');
         expect(report).toContain('anchor: immediately before the');
         expect(report).toContain('advisory (printed, never written)');
 
-        // EXISTS surfaces report the reason instead of a duplicate snippet
+        // MATCH surfaces report the reason instead of a duplicate snippet
         const readme   = planned.surfaces.find(surface => surface.surface === 'readme');
         const applied  = planOnboardingSurfaces(plan, {...FIXTURE_FILES, readme: readme.updated});
         const rerender = renderOnboardingReport(plan, applied).join('\n');
 
-        expect(rerender).toContain('[EXISTS] README.md');
+        expect(rerender).toContain('[MATCH] README.md');
+    });
+});
+
+test.describe('generateRosterOnboarding — rotation hindcast (#14901 / PR #14902)', () => {
+
+    test('rotates only README + ModelStats while roots, spec, and migration epoch stay byte-stable', () => {
+        const plan = buildPlan({
+                  designation: 'GPT-5.6 Sol',
+                  family     : 'gpt',
+                  handle     : '@neo-gpt',
+                  mode       : 'rotation'
+              }),
+              planned = planRotationSurfaces(plan, ROTATION_FILES);
+
+        expect(planned.valid).toBe(true);
+        expect(planned.surfaces.map(surface => surface.status)).toEqual([
+            SURFACE_STATES.MATCH,
+            SURFACE_STATES.DIVERGENT,
+            SURFACE_STATES.DIVERGENT,
+            SURFACE_STATES.MATCH,
+            SURFACE_STATES.MATCH
+        ]);
+        expect(planned.surfaces.filter(surface => surface.updated !== null).map(surface => surface.path)).toEqual([
+            'README.md',
+            'learn/agentos/ModelStats.md'
+        ]);
+        expect(planned.surfaces.find(surface => surface.surface === 'readme').updated).toContain('OpenAI GPT-5.6 Sol / Codex');
+        expect(planned.surfaces.find(surface => surface.surface === 'modelStats').updated).toContain('| `name` | GPT-5.6 Sol |');
+        expect(planned.surfaces.find(surface => surface.surface === 'identityRoots').updated).toBeNull();
+        expect(planned.surfaces.find(surface => surface.surface === 'migration').updated).toBeNull();
+        expect(ROTATION_FILES.migration).toContain("'@neo-gpt': 'GPT-5.5'");
+
+        const draft = renderPrBodyDraft(plan, planned).join('\n');
+
+        expect(draft).toContain('`README.md`');
+        expect(draft).toContain('`learn/agentos/ModelStats.md`');
+        expect(draft).not.toContain('`ai/graph/identityRoots.mjs` —');
+        expect(draft).not.toContain('`ai/graph/identityRootsMigration.mjs` —');
+        expect(draft).toContain('migration epoch/designation snapshot unchanged');
+    });
+
+    test('rerunning the repaired rotation is a five-surface MATCH', () => {
+        const plan  = buildPlan({designation: 'GPT-5.6 Sol', family: 'gpt', handle: '@neo-gpt', mode: 'rotation'}),
+              first = planRotationSurfaces(plan, ROTATION_FILES),
+              files = {
+                  ...ROTATION_FILES,
+                  modelStats: first.surfaces.find(surface => surface.surface === 'modelStats').updated,
+                  readme    : first.surfaces.find(surface => surface.surface === 'readme').updated
+              },
+              second = planRotationSurfaces(plan, files);
+
+        expect(second.valid).toBe(true);
+        expect(second.surfaces.every(surface => surface.status === SURFACE_STATES.MATCH)).toBe(true);
+        expect(second.surfaces.every(surface => surface.updated === null)).toBe(true);
+    });
+
+    test('a desired designation that is only a substring of the prior designation still rotates both mirrors', () => {
+        const plan  = buildPlan({designation: 'GPT-5.5', family: 'gpt', handle: '@neo-gpt', mode: 'rotation'}),
+              files = {
+                  ...ROTATION_FILES,
+                  modelStats: ROTATION_FILES.modelStats.replace('| `name` | GPT-5.5 |', '| `name` | GPT-5.5 Preview |'),
+                  readme    : ROTATION_FILES.readme.replace('OpenAI GPT-5.5 / Codex', 'OpenAI GPT-5.5 Preview / Codex')
+              },
+              planned = planRotationSurfaces(plan, files),
+              readme  = planned.surfaces.find(surface => surface.surface === 'readme');
+
+        expect(planned.valid).toBe(true);
+        expect(readme.status).toBe(SURFACE_STATES.DIVERGENT);
+        expect(readme.updated).toContain('OpenAI GPT-5.5 / Codex');
+        expect(readme.updated).not.toContain('GPT-5.5 Preview');
     });
 });
 
 test.describe('generateRosterOnboarding — live-file anchoring (the anchors must match the real shapes)', () => {
 
-    test('a fresh resident plans INSERT on all four REAL surfaces', () => {
+    test('a fresh resident plans MISSING on all four REAL onboarding surfaces', () => {
         const planned = planOnboardingSurfaces(buildPlan(), readRealFiles());
 
         expect(planned.valid).toBe(true);
-        expect(planned.surfaces.map(surface => surface.status)).toEqual(['insert', 'insert', 'insert', 'insert']);
+        expect(planned.surfaces.map(surface => surface.status)).toEqual([
+            SURFACE_STATES.MISSING,
+            SURFACE_STATES.MISSING,
+            SURFACE_STATES.MISSING,
+            SURFACE_STATES.MISSING
+        ]);
     });
 
-    test('an existing resident (@neo-fable) reports EXISTS on all four REAL surfaces — no duplicates possible', () => {
+    test('an activated resident (@neo-fable) is DIVERGENT and refuses onboarding overwrite', () => {
         const planned = planOnboardingSurfaces(buildPlan({handle: '@neo-fable'}), readRealFiles());
 
-        expect(planned.valid).toBe(true);
-        expect(planned.surfaces.map(surface => surface.status)).toEqual(['exists', 'exists', 'exists', 'exists']);
+        expect(planned.valid).toBe(false);
+        expect(planned.surfaces[0].status).toBe(SURFACE_STATES.DIVERGENT);
+        expect(planned.surfaces[0].repairable).toBe(false);
     });
 
     test('the applied REAL roster output is valid JavaScript and lands the Layer-1 entry (data-URL import)', async () => {
         const plan   = buildPlan();
         const result = planRosterSurface(readRealFiles().identityRoots, plan);
 
-        expect(result.status).toBe('insert');
+        expect(result.status).toBe(SURFACE_STATES.MISSING);
 
         const module_ = await import('data:text/javascript;base64,' + Buffer.from(result.updated, 'utf8').toString('base64'));
         const entry   = module_.IDENTITIES.find(node => node.id === '@neo-unit-probe');
@@ -473,7 +736,8 @@ test.describe('generateRosterOnboarding — CLI contract + write guard', () => {
 
         const designation = parseGenerateArgs(['--designation', 'some-engine-5']);
 
-        expect(designation.valid).toBe(false);
+        expect(designation.valid).toBe(true);
+        expect(buildOnboardingPlan({...BASE_OPTIONS, designation: 'some-engine-5'}).valid).toBe(false);
 
         const social = parseGenerateArgs(['--handle', '@neo-x', '--family', 'claude', '--social-name', 'Muse']);
 
@@ -498,5 +762,92 @@ test.describe('generateRosterOnboarding — CLI contract + write guard', () => {
             help          : false,
             write         : true
         });
+    });
+});
+
+test.describe('generateRosterOnboarding — fresh-process CLI convergence', () => {
+
+    const onboardingArgs = ['--handle', '@neo-unit-probe', '--family', 'claude'];
+
+    test('initial onboarding writes four surfaces; same-input rerun is a zero-op MATCH', () => {
+        const root = createFixtureRepo(),
+              dry  = runFreshCli(root, onboardingArgs);
+
+        expect(dry.status).toBe(0);
+        expect((dry.stdout.match(/\[MISSING\]/g) || [])).toHaveLength(4);
+
+        const write = runFreshCli(root, [...onboardingArgs, '--write']);
+
+        expect(write.status).toBe(0);
+        expect((write.stdout.match(/\[WROTE\]/g) || [])).toHaveLength(4);
+
+        const rerun = runFreshCli(root, onboardingArgs);
+
+        expect(rerun.status).toBe(0);
+        expect((rerun.stdout.match(/\[MATCH\]/g) || [])).toHaveLength(4);
+        expect(rerun.stdout).toContain('- None — exact generated/current content already matches.');
+    });
+
+    test('corrected input is DIVERGENT-but-repairable and produces no duplicate README row', () => {
+        const root = createFixtureRepo();
+
+        expect(runFreshCli(root, [...onboardingArgs, '--write']).status).toBe(0);
+
+        const correctedArgs = ['--handle', '@neo-unit-probe', '--family', 'gpt', '--github-username', '@neo-unit-probe-gh'],
+              dry           = runFreshCli(root, correctedArgs);
+
+        expect(dry.status).toBe(0);
+        expect((dry.stdout.match(/\[DIVERGENT\]/g) || [])).toHaveLength(4);
+
+        const write = runFreshCli(root, [...correctedArgs, '--write']);
+
+        expect(write.status).toBe(0);
+
+        const readme = fs.readFileSync(path.join(root, SURFACE_PATHS.readme), 'utf8');
+
+        expect((readme.match(/github\.com\/neo-unit-probe-gh/g) || [])).toHaveLength(1);
+        expect(readme).not.toContain('github.com/neo-unit-probe)');
+    });
+
+    test('ambiguous legacy content fails before any sibling surface changes', () => {
+        const root       = createFixtureRepo(),
+              beforeRoot = fs.readFileSync(path.join(root, SURFACE_PATHS.identityRoots), 'utf8'),
+              duplicate  = FIXTURE_FILES.readme.replace(
+                  '\nTrailing prose.',
+                  '\n| - | [@neo-unit-probe](https://github.com/neo-unit-probe) | legacy | Machine Account |\n| - | [@neo-unit-probe](https://github.com/neo-unit-probe) | duplicate | Machine Account |\n\nTrailing prose.'
+              );
+
+        fs.writeFileSync(path.join(root, SURFACE_PATHS.readme), duplicate, 'utf8');
+
+        const result = runFreshCli(root, [...onboardingArgs, '--write']);
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('refusing a duplicate or ambiguous rewrite');
+        expect(fs.readFileSync(path.join(root, SURFACE_PATHS.identityRoots), 'utf8')).toBe(beforeRoot);
+    });
+
+    test('rotation changes public/stat mirrors only and preserves the July-4 seed snapshot', () => {
+        const root            = createFixtureRepo(ROTATION_FILES),
+              identityBefore  = fs.readFileSync(path.join(root, SURFACE_PATHS.identityRoots), 'utf8'),
+              migrationBefore = fs.readFileSync(path.join(root, SURFACE_PATHS.migration), 'utf8'),
+              specBefore      = fs.readFileSync(path.join(root, SURFACE_PATHS.spec), 'utf8'),
+              args            = ['--mode', 'rotation', '--handle', '@neo-gpt', '--family', 'gpt', '--designation', 'GPT-5.6 Sol', '--write'],
+              result          = runFreshCli(root, args);
+
+        expect(result.status).toBe(0);
+        expect((result.stdout.match(/\[WROTE\]/g) || [])).toHaveLength(2);
+        expect(fs.readFileSync(path.join(root, SURFACE_PATHS.identityRoots), 'utf8')).toBe(identityBefore);
+        expect(fs.readFileSync(path.join(root, SURFACE_PATHS.migration), 'utf8')).toBe(migrationBefore);
+        expect(fs.readFileSync(path.join(root, SURFACE_PATHS.spec), 'utf8')).toBe(specBefore);
+        expect(fs.readFileSync(path.join(root, SURFACE_PATHS.readme), 'utf8')).toContain('OpenAI GPT-5.6 Sol / Codex');
+        expect(fs.readFileSync(path.join(root, SURFACE_PATHS.modelStats), 'utf8')).toContain('| `name` | GPT-5.6 Sol |');
+    });
+
+    test('strict GitHub-login syntax fails in the real CLI process', () => {
+        const root   = createFixtureRepo(),
+              result = runFreshCli(root, [...onboardingArgs, '--github-username', '@bad--login']);
+
+        expect(result.status).toBe(1);
+        expect(result.stderr).toContain('no consecutive hyphens');
     });
 });


### PR DESCRIPTION
Resolves #14954

Completes the identity-ceremony generator as one convergence-aware workflow. Onboarding now classifies exact generated structures as `MISSING`, `MATCH`, or `DIVERGENT`, repairs only unambiguous generated artifacts, preserves immutable birth timestamps, and refuses ambiguous or activated content before any write. Rotation reuses that planner while updating only the exact README and ModelStats mirrors; durable identity roots, their focused evidence pin, and the migration epoch snapshot remain byte-stable boundaries under ADR-0018 and ADR-0032.

Evidence: L3 (the real Node CLI ran in fresh temporary git repositories through initial write, zero-op rerun, corrected-input repair, ambiguous refusal, and rotation) → L3 required (all #14954 runtime acceptance criteria). No residuals.

## Deltas from ticket

- Added a branch-guarded `--repo-root` seam so fresh-process contract tests exercise the real CLI against isolated fixed-surface repositories.
- Tightened two exactness edges found during the pre-PR adversarial pass: designation substrings no longer false-match README rotation, and custom-login → custom-login correction follows the prior generated roster anchor instead of appending.
- No scope split: divergence, rotation, PR-body drafting, and fresh-process evidence remain one coherent ceremony-completion lane as requested.

## Test Evidence

- Ceremony generator + durable-root boundary: `npm run test-unit -- test/playwright/unit/ai/scripts/setup/generateRosterOnboarding.spec.mjs test/playwright/unit/ai/graph/identityRoots.spec.mjs` — 51/51 passed.
- Generator syntax: `node --check ai/scripts/setup/generateRosterOnboarding.mjs` — passed.
- Spec syntax: `node --check test/playwright/unit/ai/scripts/setup/generateRosterOnboarding.spec.mjs` — passed.
- Formatting: `git diff --check` — passed.
- Repository gates: `npm run agent-preflight -- --no-fix ai/scripts/setup/generateRosterOnboarding.mjs test/playwright/unit/ai/scripts/setup/generateRosterOnboarding.spec.mjs` — passed; only unrelated stale-overlay warnings were reported.

## Post-Merge Validation

- [ ] Run one real onboarding dry-run from `dev` and confirm the four live surfaces classify without writes.
- [ ] Run the Euclid `GPT-5.6 Sol` hindcast dry-run from `dev` and confirm five `MATCH` boundaries with no proposed writes.

## Evolution

The implementation began from the ticket’s presence-to-convergence correction. Exact-head review then falsified two subtler ownership shortcuts—substring designation matching and loss of an earlier custom GitHub login—so both now use explicit prior-authority anchors with regression witnesses.

Authored by Euclid (GPT-5.6 Sol, Codex). Session a0518292-02c3-49ee-af08-adff40bc30b1.
