### PR TITLE
fix(agentos): preserve Fleet sample on cold empty roster (#15563)

### DIFF
--- a/apps/agentos/view/fleet/FleetCockpit.mjs
+++ b/apps/agentos/view/fleet/FleetCockpit.mjs
@@ -190,6 +190,18 @@ class FleetCockpit extends Container {
          */
         baseCls: ['fm-fleet-cockpit'],
         /**
+         * The roster-source admission mode. `sample` is the zero-call cold-first-run authority: an
+         * empty first bridge answer cannot erase the honestly labelled bundled fleet. `selected`
+         * means the operator/product composition explicitly chose the wired source, so even an
+         * empty first snapshot is authoritative. A populated snapshot promotes this mode while
+         * {@link #rosterWired} keeps every later snapshot (including empty) authoritative.
+         *
+         * Non-reactive on purpose: this is an ingress policy, not render state. Instance config and
+         * `Neo.overwrites` may select it without introducing a hidden hardware/product constant.
+         * @member {'sample'|'selected'} rosterSourceMode='sample'
+         */
+        rosterSourceMode: 'sample',
+        /**
          * The B4÷C2 composition root: catches each card's `lifecycleIntent` and the whole-fleet
          * "▶ Start fleet" click, driving both through the C2 adapter to honest per-card
          * round-trip state. See {@link AgentOS.view.fleet.FleetCockpitController}.
@@ -2002,12 +2014,16 @@ class FleetCockpit extends Container {
      * on the injected registry bridge — the Brain-side assembler DTO (`{sources, capabilities, rows,
      * events}`, identity-enriched per the `resolveIdentityDisplay` join) — map its rows onto the
      * FleetAgent record contract, and route honestly into the Store the grid renders from:
-     * - a resolved snapshot (rows is an Array — EVEN EMPTY) is **authoritative**: the first one
-     *   replaces the sample seed (a zero-agent fleet renders as the TRUE cold-onboarding zero
-     *   state, never seven sample maintainers masquerading as live); every later one **reconciles**
-     *   the Store — `record.set(row)` per known `agentId`, `store.add` for a joiner, `store.remove`
-     *   for a resident absent from the snapshot (a `removeAgent` must never leave a ghost card).
-     *   Grid goes `live` (instance + the owner-held fallback state).
+     * - a populated resolved snapshot is **authoritative**: the first one replaces the sample seed
+     *   and promotes {@link #rosterSourceMode} to `selected`; every later one **reconciles** the
+     *   Store — `record.set(row)` per known `agentId`, `store.add` for a joiner, `store.remove` for
+     *   a resident absent from the snapshot (a `removeAgent` must never leave a ghost card).
+     * - an EMPTY first snapshot preserves the bundled sample while the source mode is `sample` — a
+     *   fresh private registry must not blank the zero-setup first paint. It becomes authoritative
+     *   when the source was explicitly `selected`, or after any live snapshot established
+     *   {@link #rosterWired}; a genuinely selected/drained fleet therefore still renders its TRUE
+     *   zero state rather than resurrecting sample residents.
+     *   Every admitted snapshot makes the grid `live` (instance + owner-held fallback state).
      * - absent bridge / no verb / a MALFORMED answer (`rows` not an Array) / a thrown source →
      *   keep the last-known roster; fail closed rather than blanking the fleet. A resolved call is
      *   mechanically distinguishable from a failed one — only failures preserve last-known state.
@@ -2053,7 +2069,17 @@ class FleetCockpit extends Container {
 
             const mapped = rows.filter(row => row?.id).map(row => me.mapRosterRow(row));
 
+            // The shipped sample is the cold-first-run authority. A reachable but fresh/empty
+            // private registry has answered, but it has not supplied a working fleet and no source
+            // was selected — replacing the sample here would turn successful boot into an empty
+            // flagship. Once selected or once any populated snapshot made the surface live, empty
+            // regains its ordinary authoritative meaning (the real fleet may genuinely drain).
+            if (!me.rosterWired && mapped.length === 0 && me.rosterSourceMode !== 'selected') {
+                return
+            }
+
             me.lastLiveRows = mapped;
+            me.rosterSourceMode = 'selected';
 
             if (me.rosterWired) {
                 me.reconcileRoster(grid.store, mapped)

--- a/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
+++ b/test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs
@@ -206,7 +206,7 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         return {adapterState: 'sample', store}
     };
 
-    const makeCockpit = (grid, rosterWired = false, gridAdapterState = 'sample') => ({
+    const makeCockpit = (grid, rosterWired = false, gridAdapterState = 'sample', rosterSourceMode = 'sample') => ({
         clearDegradedReason: FleetCockpit.prototype.clearDegradedReason,
         degradeWiredSurface: FleetCockpit.prototype.degradeWiredSurface,
         getReference       : reference => reference === 'fleet-grid' ? grid : null,
@@ -220,16 +220,17 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         mapRosterRow      : FleetCockpit.prototype.mapRosterRow,
         reconcileRoster   : FleetCockpit.prototype.reconcileRoster,
         reconcileSelection: FleetCockpit.prototype.reconcileSelection,
+        rosterSourceMode,
         rosterWired,
         // the real banner sync: null getReference for the slot → guarded no-op, no stub drift
         syncSpineBanner    : FleetCockpit.prototype.syncSpineBanner
     });
 
-    const routeLoadRoster = async (bridge, {known, items, rosterWired} = {}) => {
+    const routeLoadRoster = async (bridge, {known, items, rosterSourceMode, rosterWired} = {}) => {
         bridge ? ((globalThis.AgentOS ??= {}).fleet = {registryBridge: bridge}) : clearBridge();
 
         const grid    = makeGrid(known, items),
-              cockpit = makeCockpit(grid, rosterWired);
+              cockpit = makeCockpit(grid, rosterWired, 'sample', rosterSourceMode);
 
         await FleetCockpit.prototype.loadRoster.call(cockpit);
 
@@ -299,12 +300,27 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         }
     });
 
-    test('a resolved EMPTY snapshot is the authoritative cold zero-state — the sample clears and the grid goes live (never seven fake maintainers)', async () => {
+    test('a resolved EMPTY first snapshot preserves the zero-call sample until a source is selected', async () => {
         const {cockpit, grid} = await routeLoadRoster({fleetRoster: async () => ({rows: []})});
 
-        expect(grid.store.cleared).toBe(1);   // the sample seed is replaced by the TRUE zero state
+        expect(FleetCockpit.config.rosterSourceMode).toBe('sample');
+        expect(grid.store.cleared).toBe(0);   // a fresh empty registry cannot erase first-run truth
+        expect(grid.store.added).toEqual([]);
+        expect(grid.adapterState).toBe('sample');
+        expect(cockpit.rosterSourceMode).toBe('sample');
+        expect(cockpit.rosterWired).toBe(false)
+    });
+
+    test('a resolved EMPTY first snapshot is authoritative after explicit source selection', async () => {
+        const {cockpit, grid} = await routeLoadRoster(
+            {fleetRoster: async () => ({rows: []})},
+            {rosterSourceMode: 'selected'}
+        );
+
+        expect(grid.store.cleared).toBe(1);
         expect(grid.store.added).toEqual([]);
         expect(grid.adapterState).toBe('live');
+        expect(cockpit.rosterSourceMode).toBe('selected');
         expect(cockpit.rosterWired).toBe(true)
     });
 
@@ -439,6 +455,7 @@ test.describe('Fleet cockpit — Store-backed roster (loadRoster)', () => {
         // rows arrive MAPPED onto the record contract — durable id → agentId, runtime → session state
         expect(grid.store.added.map(row => [row.agentId, row.state])).toEqual([['vega', 'ok'], ['ada', 'off']]);
         expect(grid.adapterState).toBe('live');
+        expect(cockpit.rosterSourceMode).toBe('selected');
         expect(cockpit.rosterWired).toBe(true)
     });
 


### PR DESCRIPTION
Resolves #15563

Preserves the honestly labelled bundled Fleet roster when a fresh private bridge returns a well-formed but empty first snapshot. The same transition stays truthful in the opposite direction: an explicitly selected source, or any source already established as live, keeps an empty snapshot authoritative so a genuinely drained fleet clears rather than resurrecting sample residents.

Related: #15524 · #15519 · #15545 · #15546

Evidence: L2 (focused source-admission unit contract, 79/79 passed) → L2 required (all #15563 acceptance edges are pure admission/reconciliation behavior). No residuals for #15563; #15524 retains the token-present opt-in and packaged witness as separate beats.

## Deltas from ticket

None substantive. The implementation follows the four-edge contract in #15563:

- adds the overridable, non-reactive `rosterSourceMode` config with `sample` and `selected` semantics;
- preserves sample state on a cold first empty result;
- promotes populated admission to `selected`;
- preserves explicit-selected and post-live empty authority.

No second store, fixture vocabulary, product control, credential path, or demo surface is introduced.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs` — **79/79 passed**.
- `npm run test-unit` — **8,596 passed, 19 failed, 5 skipped, 64 did not run**. All 19 failures are outside the touched Fleet surface; representative failures are lifecycle state-file collisions, Memory Core service/environment cases, the real-tree lint timeout, and `GalleryInternalId`. This aggregate run is reported as non-green, not promoted into passing evidence.
- `git diff --check` — passed.
- Fleet roster admission/reconciliation coverage: `test/playwright/unit/apps/agentos/view/fleet/fleetCockpit.spec.mjs` — focused shard passed.
- Packaged-shell/browser coverage: None added in this leaf; the packaged cold-first-run witness remains on #15524.

## Post-Merge Validation

- [ ] Observe the changed Fleet unit shard on the `dev` merge candidate. This is a receipt, not a new merge gate; #15563's required L2 contract is already achieved.

## Commits

- `c59a42d36f` — preserve the bundled sample on cold empty admission and pin the transition matrix.

## Evolution

The parent #15524 intentionally remains open for its token-present public opt-in and packaged first-paint witness. A narrow native child was created so this ready PR can resolve exactly the delivered cold-empty admission beat without falsely closing the parent or manufacturing another draft hold.

Authored by Emmy (GPT-5.6 Sol, Codex). Session ad71d4c3-3e37-4a17-8df7-8415509def84.
