### PR TITLE
feat(harness): complete private Fleet boundary (#15537)

### DIFF
--- a/apps/agentos/app.mjs
+++ b/apps/agentos/app.mjs
@@ -1,9 +1,29 @@
 import Viewport             from './view/Viewport.mjs';
 import {installFleetBridge} from '../../src/ai/fleet/installFleetBridge.mjs';
+import WindowManager        from '../../src/manager/Window.mjs';
+
+/**
+ * @summary Resolve a currently connected AgentOS window for App-Worker→main RMA. `onStart()` runs
+ * for every joining window, so a closure pinned to the latest popup would strand the retained
+ * cockpit when that popup closes. The live Window manager is the authority; the boot id is only a
+ * pre-registration fallback while the first app instance is being created.
+ * @param {Object} options
+ * @param {String} options.fallbackWindowId
+ * @param {Object} [options.apps=Neo.apps]
+ * @param {Object[]} [options.windows=WindowManager.items]
+ * @returns {String|null}
+ */
+export function resolveFleetWindowId({fallbackWindowId, apps = Neo.apps, windows = WindowManager.items} = {}) {
+    const live = windows.find(item => item.appName === 'AgentOS');
+
+    return live?.id ?? (apps?.[fallbackWindowId] ? fallbackWindowId : null)
+}
 
 export const onStart = () => {
-    const params   = new URLSearchParams(Neo.config.url.search),
-          fleetUrl = params.has('fleetUrl')
+    const
+        fallbackWindowId = Neo.bootingWindowId,
+        params           = new URLSearchParams(Neo.config.url.search),
+        fleetUrl         = params.has('fleetUrl')
               ? params.get('fleetUrl')
               : 'http://127.0.0.1:8083/fleet';
 
@@ -14,9 +34,24 @@ export const onStart = () => {
     // Without the bearer the bridge installs fail-closed: every call rejects locally, named.
     const bearerToken = globalThis.AgentOS?.fleet?.bearerToken ?? null;
 
-    // Wire the dev-server (Option B) app<->fleet HTTP transport so the Accounts pane's fail-closed
-    // registry-bridge submit path goes live. The Electron shell (Option A) installs this in-process.
-    installFleetBridge({url: fleetUrl, bearerToken});
+    if (Neo.config.url.protocol === 'app:') {
+        const route = () => resolveFleetWindowId({fallbackWindowId});
+
+        installFleetBridge({
+            credentialIngress: 'shell',
+            send             : request => {
+                const windowId = route();
+
+                return windowId
+                    ? Neo.Main.fleetRequest({request, windowId})
+                    : Promise.resolve({ok: false, error: 'fleet: no live shell window'})
+            }
+        })
+    } else {
+        // Direct-browser dev mode remains the distinct transitional topology: its in-memory bearer
+        // and App-Worker credential field are supported here, never in the packaged app:// path.
+        installFleetBridge({url: fleetUrl, bearerToken})
+    }
 
     Neo.app({
         appThemeFolder: 'agentos',

--- a/apps/agentos/view/Accounts.mjs
+++ b/apps/agentos/view/Accounts.mjs
@@ -1,4 +1,10 @@
 import AgentConfigCard                                           from './fleet/AgentConfigCard.mjs';
+import {
+    createDefineAgentIntent,
+    isShellCredentialIngress,
+    resolveRegistryBridge,
+    validateDefinePayload
+}                                                                from './fleet/addAgentFlow.mjs';
 import {getDefinitionsWriteGeneration, runConfigIntentRoundTrip} from './fleet/configIntentRoundTrip.mjs';
 import Button                                                    from '../../../src/button/Base.mjs';
 import DashboardPanel                                            from '../../../src/dashboard/Panel.mjs';
@@ -19,10 +25,11 @@ import Toolbar                                                   from '../../../
  * roster + lifecycle. It also surfaces a **basic NL-MCP connect entry** (the external-harness
  * `manage_connection` start path) through the same fail-closed injected-bridge discipline.
  *
- * Capability-security boundary (the load-bearing reason this is its own surface): a credential is
- * collected only long enough to submit it to the Brain-side Fleet Registry bridge. If that bridge is
- * absent, submission fails closed, the PAT field is cleared, and **nothing is stored in the browser /
- * App Worker** — only the Brain's canonical redacted response reaches the shared
+ * Capability-security boundary (the load-bearing reason this is its own surface): direct-browser
+ * mode collects a credential only long enough to submit it to the Brain-side Fleet Registry bridge;
+ * shell mode renders no credential field and submits only public intent. If that bridge is absent,
+ * submission fails closed, the PAT field is cleared, and **nothing is stored in the browser / App
+ * Worker** — only the Brain's canonical redacted response reaches the shared
  * `AgentDefinitions` roster, never a credential byte (mirrors
  * `AgentOS.model.AgentDefinition`'s deliberately credential-free shape). An accepted definition
  * emits `agentDefinitionAccepted`; the Viewport composition root owns the separate Fleet-cockpit
@@ -195,7 +202,22 @@ class Accounts extends DashboardPanel {
      */
     onConstructed(...args) {
         super.onConstructed(...args);
-        this.getReference('agent-config-card')?.on({configIntent: this.onAgentConfigIntent, scope: this})
+
+        const
+            me         = this,
+            bridge     = resolveRegistryBridge(),
+            form       = me.getReference('agent-form'),
+            credential = form?.items.find(item => item.name === 'credential');
+
+        me.getReference('agent-config-card')?.on({configIntent: me.onAgentConfigIntent, scope: me});
+
+        if (isShellCredentialIngress(bridge)) {
+            credential && form.remove(credential);
+            me.updateBridgeStatus(
+                'is-live',
+                'Credential entry is owned by the native shell and never enters App Worker state.'
+            )
+        }
     }
 
     /**
@@ -407,17 +429,21 @@ class Accounts extends DashboardPanel {
      * @returns {Promise<void>}
      */
     async onLoadSampleClick() {
-        const form = this.getReference('agent-form');
+        const
+            bridge = resolveRegistryBridge(),
+            form   = this.getReference('agent-form');
 
-        await form.setValues({
+        await form.setValues(createDefineAgentIntent({
             credential    : '',
             githubUsername: 'neo-gpt',
             harnessType   : 'codex'
-        });
+        }, bridge));
 
         this.updateBridgeStatus(
             'is-waiting',
-            'Sample loaded. Enter a PAT to add the agent; the value clears after the attempt.'
+            isShellCredentialIngress(bridge)
+                ? 'Sample loaded. The native shell will supply the credential when you add the agent.'
+                : 'Sample loaded. Enter a PAT to add the agent; the value clears after the attempt.'
         )
     }
 
@@ -432,22 +458,18 @@ class Accounts extends DashboardPanel {
      */
     async onSubmitAgentClick() {
         const
-            form   = this.getReference('agent-form'),
-            valid  = await form.validate(),
-            values = await form.getSubmitValues();
+            bridge     = resolveRegistryBridge(),
+            shellOwned = isShellCredentialIngress(bridge),
+            form       = this.getReference('agent-form'),
+            valid      = await form.validate(),
+            values     = await form.getSubmitValues(),
+            payload    = createDefineAgentIntent(values, bridge),
+            validation = validateDefinePayload(payload, {credentialRequired: !shellOwned});
 
-        const githubUsername = values.githubUsername?.trim();
-
-        if (!valid || !githubUsername || !values.harnessType || !values.credential) {
-            this.updateBridgeStatus('is-error', 'Agent setup incomplete. GitHub username, harness type, and PAT are required.');
+        if (!valid || !validation.valid) {
+            this.updateBridgeStatus('is-error', `Agent setup incomplete. ${validation.reason}`);
             return
         }
-
-        const payload = {
-            credential : values.credential,
-            githubUsername,
-            harnessType: values.harnessType
-        };
 
         try {
             const outcome = await this.submitToFleetRegistryBridge(payload);
@@ -459,9 +481,19 @@ class Accounts extends DashboardPanel {
 
             this.upsertPublicAgentDefinition(outcome, payload.credential);
             this.fire('agentDefinitionAccepted', {agent: outcome});
-            this.updateBridgeStatus('is-live', 'Agent added. PAT was not retained in the app worker.')
+            this.updateBridgeStatus(
+                'is-live',
+                shellOwned
+                    ? 'Agent added. Credential entry stayed in the native shell.'
+                    : 'Agent added. PAT was not retained in the app worker.'
+            )
         } catch (error) {
-            this.updateBridgeStatus('is-error', 'Could not add agent. Nothing was stored in browser state; PAT field was cleared.')
+            this.updateBridgeStatus(
+                'is-error',
+                shellOwned
+                    ? 'Could not add agent. No credential entered App Worker state.'
+                    : 'Could not add agent. Nothing was stored in browser state; PAT field was cleared.'
+            )
         } finally {
             await this.clearCredentialField()
         }
@@ -502,13 +534,13 @@ class Accounts extends DashboardPanel {
      *     `{status:'rejected', reason}` domain outcome.
      */
     async submitToFleetRegistryBridge(payload) {
-        const bridge = globalThis.AgentOS?.fleet?.registryBridge;
+        const bridge = resolveRegistryBridge();
 
         if (!bridge?.defineAgent) {
             throw new Error('Fleet Registry bridge unavailable')
         }
 
-        return bridge.defineAgent(payload)
+        return bridge.defineAgent(createDefineAgentIntent(payload, bridge))
     }
 
     /**

--- a/apps/agentos/view/fleet/AddAgentForm.mjs
+++ b/apps/agentos/view/fleet/AddAgentForm.mjs
@@ -4,14 +4,20 @@ import PasswordField      from '../../../../src/form/field/Password.mjs';
 import TextField          from '../../../../src/form/field/Text.mjs';
 import {listHarnessTypes} from '../../config/harnessTypes.mjs';
 
-import {resolveRegistryBridge, submitDefineAgent, validateDefinePayload} from './addAgentFlow.mjs';
+import {
+    createDefineAgentIntent,
+    isShellCredentialIngress,
+    resolveRegistryBridge,
+    submitDefineAgent,
+    validateDefinePayload
+} from './addAgentFlow.mjs';
 
 /**
  * @class AgentOS.view.fleet.AddAgentForm
  * @extends Neo.form.Container
  *
- * @summary The S5 add-agent surface (design SSOT Lane D1): username + PAT + harness type
- * → the Fleet Registry bridge, rendered to the cockpit token layer (`--fm-*`) under the
+ * @summary The S5 add-agent surface (design SSOT Lane D1): username + harness type, plus a PAT only
+ * for direct-browser ingress → the Fleet Registry bridge, rendered to the cockpit token layer (`--fm-*`) under the
  * honest-lifecycle contract — `idle → validating → submitting → readback-confirmed | gated |
  * rejected`, with the registry's canonical readback as the ONLY success truth.
  *
@@ -19,11 +25,13 @@ import {resolveRegistryBridge, submitDefineAgent, validateDefinePayload} from '.
  * validated public definition — the mounting owner (dock zone or detail tab, the S5 fork) wires
  * the roster write. It holds no store and no credential state:
  *
- * Credential boundary (the fleet credential matrix): the PAT lives in the password field only as long as a submission
- * needs it — never in browser persistent state, never in the URL, never logged or echoed — and the
- * field clears on EVERY settle, terminal state regardless. Bridge absent → the submit control is
- * **disabled-with-reason** (CARD-CONTRACT controls rule: never hidden), state `gated`, and no
- * fake affordance pretends a round-trip is possible.
+ * Credential boundary (the fleet credential matrix): a direct-browser PAT lives in the password
+ * field only as long as a submission needs it — never in browser persistent state, never in the URL,
+ * never logged or echoed — and the field clears on EVERY settle, terminal state regardless. A bridge
+ * marked `credentialIngress: 'shell'` removes that field before mount and sends public intent only;
+ * the native shell owns credential entry. Bridge absent → the submit control is
+ * **disabled-with-reason** (CARD-CONTRACT controls rule: never hidden), state `gated`, and no fake
+ * affordance pretends a round-trip is possible.
  */
 class AddAgentForm extends FormContainer {
     static config = {
@@ -137,15 +145,28 @@ class AddAgentForm extends FormContainer {
     onConstructed(...args) {
         super.onConstructed(...args);
 
-        const me = this;
+        const
+            me          = this,
+            bridge      = resolveRegistryBridge(me.bridgeResolver),
+            shellOwned  = isShellCredentialIngress(bridge),
+            secretField = me.getReference('field-credential');
 
         me.harnessType ??= listHarnessTypes()[0]?.type ?? null;
         me.syncHarnessChips();
 
-        if (!resolveRegistryBridge(me.bridgeResolver)?.defineAgent) {
+        if (shellOwned) {
+            secretField && me.remove(secretField);
+        }
+
+        if (!bridge?.defineAgent) {
             me.flowStatus = {
                 state : 'gated',
                 reason: 'Fleet Registry bridge unavailable — agent setup fails closed. Start the fleet server (npm run ai:fleet-server).'
+            }
+        } else if (shellOwned) {
+            me.flowStatus = {
+                state : 'idle',
+                reason: 'Credential entry is owned by the native shell and never enters App Worker state.'
             }
         }
     }
@@ -193,8 +214,12 @@ class AddAgentForm extends FormContainer {
      * @returns {String}
      */
     statusLineFor(state) {
+        const shellOwned = isShellCredentialIngress(resolveRegistryBridge(this.bridgeResolver));
+
         return {
-            'idle'              : 'PAT is submitted to the Brain-side registry and never stored in browser state.',
+            'idle'              : shellOwned
+                ? 'Credential entry is owned by the native shell and never enters App Worker state.'
+                : 'PAT is submitted to the Brain-side registry and never stored in browser state.',
             'validating'        : 'Checking the definition…',
             'submitting'        : 'Submitting through the Fleet Registry bridge…',
             'readback-confirmed': 'Agent added — roster renders the registry\'s canonical readback.'
@@ -228,18 +253,20 @@ class AddAgentForm extends FormContainer {
      */
     async onSubmitClick() {
         const
-            me      = this,
-            values  = await me.getSubmitValues(),
-            payload = {
+            me         = this,
+            values     = await me.getSubmitValues(),
+            bridge     = resolveRegistryBridge(me.bridgeResolver),
+            shellOwned = isShellCredentialIngress(bridge),
+            payload    = createDefineAgentIntent({
                 credential    : values.credential,
                 githubUsername: values.githubUsername,
                 harnessType   : me.harnessType
-            };
+            }, bridge);
 
         me.flowStatus = {state: 'validating', reason: ''};
 
         try {
-            const validation = validateDefinePayload(payload);
+            const validation = validateDefinePayload(payload, {credentialRequired: !shellOwned});
 
             // an incomplete definition never renders `submitting` — nothing is in flight
             if (!validation.valid) {
@@ -257,8 +284,7 @@ class AddAgentForm extends FormContainer {
                 me.fire('agentDefinitionAccepted', {agent: outcome.definition})
             }
         } finally {
-            const field = await me.getField('credential');
-            field?.reset('')
+            me.getReference('field-credential')?.reset('')
         }
     }
 }

--- a/apps/agentos/view/fleet/addAgentFlow.mjs
+++ b/apps/agentos/view/fleet/addAgentFlow.mjs
@@ -9,10 +9,12 @@
  * first-class `gated` outcome — disabled-with-reason at the surface, never a fake success and
  * never browser-side persistence.
  *
- * Credential boundary (the fleet credential matrix): the PAT enters this module inside the submit payload, travels to
- * the injected bridge, and is referenced afterwards ONLY to reject an accidental echo in the
- * readback. It is never stored, logged, or included in any outcome object — outcomes carry public
- * definition fields and operator-facing reasons exclusively.
+ * Credential boundary (the fleet credential matrix): a direct-browser bridge receives the PAT in
+ * the submit payload, while a shell-owned credential ingress receives only the public definition
+ * intent and resolves its credential outside the App Worker. A direct PAT is referenced after the
+ * submit ONLY to reject an accidental echo in the readback. It is never stored, logged, or included
+ * in any outcome object — outcomes carry public definition fields and operator-facing reasons
+ * exclusively.
  *
  * @see apps/agentos/view/fleet/AddAgentForm.mjs — the rendering consumer
  * @see apps/agentos/view/Accounts.mjs — the keeper-view ancestor this logic is lifted from
@@ -36,14 +38,25 @@ const SECRET_KEYS = ['authorization', 'credential', 'password', 'pat', 'token'];
  * @summary Validate the define-agent payload before any bridge contact. Pure + synchronous: the
  * surface renders `validating` around this call and never submits an incomplete definition.
  * @param {Object} payload
- * @param {String} payload.credential     The PAT (write-only — validated for presence, never inspected further).
+ * @param {String} [payload.credential]   The PAT in direct-browser mode (write-only — validated for
+ *     presence, never inspected further).
  * @param {String} payload.githubUsername
  * @param {String} payload.harnessType
+ * @param {Object}  [options]
+ * @param {Boolean} [options.credentialRequired=true] Whether this ingress owns credential entry.
  * @returns {{valid: Boolean, reason: String}} Operator-facing reason when invalid.
  */
-export function validateDefinePayload({credential, githubUsername, harnessType}={}) {
-    if (!githubUsername?.trim() || !harnessType || !credential) {
-        return {valid: false, reason: 'GitHub username, harness type, and PAT are required.'}
+export function validateDefinePayload(
+    {credential, githubUsername, harnessType}={},
+    {credentialRequired=true}={}
+) {
+    if (!githubUsername?.trim() || !harnessType || (credentialRequired && !credential)) {
+        return {
+            valid : false,
+            reason: credentialRequired
+                ? 'GitHub username, harness type, and PAT are required.'
+                : 'GitHub username and harness type are required.'
+        }
     }
 
     return {valid: true, reason: ''}
@@ -91,6 +104,38 @@ export function resolveRegistryBridge(resolver=null) {
 }
 
 /**
+ * @summary Whether credential entry belongs to the native shell rather than the App Worker.
+ * The explicit bridge marker is the authority; an absent/unknown marker preserves the existing
+ * direct-browser contract.
+ * @param {Object|null} bridge
+ * @returns {Boolean}
+ */
+export function isShellCredentialIngress(bridge) {
+    return bridge?.credentialIngress === 'shell'
+}
+
+/**
+ * @summary Project a form payload onto the exact define-agent request allowed across the bridge.
+ * Shell mode carries public intent only; direct-browser mode preserves the credential-bearing
+ * request. Explicit projection prevents unrelated form or caller fields from crossing either mode.
+ * @param {Object}      payload
+ * @param {Object|null} bridge
+ * @returns {Object}
+ */
+export function createDefineAgentIntent(payload={}, bridge=null) {
+    const intent = {
+        githubUsername: payload.githubUsername?.trim(),
+        harnessType   : payload.harnessType
+    };
+
+    if (!isShellCredentialIngress(bridge)) {
+        intent.credential = payload.credential
+    }
+
+    return intent
+}
+
+/**
  * @summary The full submit round-trip as one typed outcome — the flow's only async step.
  *
  * Outcome shapes (state ∈ the terminal vocabulary):
@@ -104,13 +149,15 @@ export function resolveRegistryBridge(resolver=null) {
  * @returns {Promise<Object>} One terminal outcome — this function never throws.
  */
 export async function submitDefineAgent({bridgeResolver=null, payload}) {
-    const validation = validateDefinePayload(payload);
+    const
+        bridge     = resolveRegistryBridge(bridgeResolver),
+        shellOwned = isShellCredentialIngress(bridge),
+        request    = createDefineAgentIntent(payload, bridge),
+        validation = validateDefinePayload(request, {credentialRequired: !shellOwned});
 
     if (!validation.valid) {
         return {state: 'rejected', reason: validation.reason}
     }
-
-    const bridge = resolveRegistryBridge(bridgeResolver);
 
     if (!bridge?.defineAgent) {
         return {
@@ -122,11 +169,7 @@ export async function submitDefineAgent({bridgeResolver=null, payload}) {
     let outcome;
 
     try {
-        outcome = await bridge.defineAgent({
-            credential    : payload.credential,
-            githubUsername: payload.githubUsername.trim(),
-            harnessType   : payload.harnessType
-        })
+        outcome = await bridge.defineAgent(request)
     } catch (error) {
         // transport failure: the reason stays generic — an error message assembled elsewhere is
         // not a surface we allow to carry credential bytes into the DOM
@@ -137,7 +180,7 @@ export async function submitDefineAgent({bridgeResolver=null, payload}) {
         return {state: 'rejected', reason: outcome.reason || 'Agent definition was rejected. Nothing was changed.'}
     }
 
-    const readback = validateReadback(outcome, payload.credential);
+    const readback = validateReadback(outcome, request.credential);
 
     if (!readback.valid) {
         return {state: 'rejected', reason: readback.reason}

--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -31,6 +31,8 @@ import {randomUUID}                    from 'node:crypto';
 import fs                              from 'node:fs';
 import net                             from 'node:net';
 import path                            from 'node:path';
+import {normalizeAgentIdentityNodeId}  from '../ai/graph/normalizeAgentIdentityNodeId.mjs';
+import {probeExistingFleetServer}      from '../ai/services/fleet/fleetLaunchContract.mjs';
 
 export const ORCHESTRATOR_ENTRY = 'ai/daemons/orchestrator/daemon.mjs';
 export const FLEET_SERVER_ENTRY = 'ai/services/fleet/devFleetServer.mjs';
@@ -315,33 +317,33 @@ export function assertIsolatedProfile({resolved, isolationRoot, chromaPort}) {
 }
 
 /**
- * @summary Probes FLEET PROTOCOL IDENTITY on a port: one `POST /fleet {method:'listAgents'}`
- * round-trip answering `{ok:true}`. A listening socket is an observation about occupancy; only
- * the wire envelope proves the listener IS the fleet transport — a foreign server squatting the
- * port must read as "held but not serving", never as attach-ready.
+ * @summary Probes an occupied Fleet port through the canonical same-bearer, same-viewer reuse
+ * contract. A listening socket is an observation about occupancy; only the authenticated
+ * `/fleet/probe` envelope proves the listener is the expected Fleet process.
  * @param {Object} options
  * @param {Number|String} options.port
  * @param {String} options.bearerToken Main-owned process bearer.
+ * @param {String} options.agentIdentityNodeId Trusted launcher's expected viewer node id.
  * @param {Number} [options.timeoutMs=2500]
  * @param {Function} [options.fetchFn=fetch] Injection seam for tests.
- * @returns {Promise<Boolean>}
+ * @returns {Promise<Object>} Canonical `{reusable, reason}` probe outcome.
  */
-export async function probeFleetServing({port, bearerToken, timeoutMs = 2500, fetchFn = fetch}) {
-    try {
-        const response = await fetchFn(`http://127.0.0.1:${port}/fleet`, {
-            body   : JSON.stringify({method: 'listAgents', params: {}}),
-            headers: {
-                Authorization : `Bearer ${bearerToken}`,
-                'content-type': 'application/json'
-            },
-            method : 'POST',
-            signal : AbortSignal.timeout(timeoutMs)
-        });
+export function probeFleetServing({port, bearerToken, agentIdentityNodeId, timeoutMs = 2500, fetchFn = fetch}) {
+    const viewer = normalizeAgentIdentityNodeId(agentIdentityNodeId);
 
-        return (await response.json())?.ok === true
-    } catch (error) {
-        return false
+    if (typeof viewer !== 'string' || !/^@[^@:\s]+$/.test(viewer)) {
+        return Promise.resolve({
+            reusable: false,
+            reason  : 'cannot resolve a canonical expected Fleet viewer from NEO_AGENT_IDENTITY — refusing existing-port reuse'
+        })
     }
+
+    return probeExistingFleetServer({
+        agentIdentityNodeId: viewer,
+        bearerToken,
+        probeUrl           : `http://127.0.0.1:${port}/fleet/probe`,
+        fetchImpl          : (url, init) => fetchFn(url, {...init, signal: AbortSignal.timeout(timeoutMs)})
+    })
 }
 
 /**
@@ -354,29 +356,35 @@ export async function probeFleetServing({port, bearerToken, timeoutMs = 2500, fe
  * @param {String} options.orchestratorDataDir Resolved `AiConfig.orchestrator.dataDir`.
  * @param {Number|String} options.fleetPort Fleet transport port to probe.
  * @param {String} options.bearerToken Main-owned process bearer.
+ * @param {String} [options.agentIdentityNodeId=process.env.NEO_AGENT_IDENTITY] Trusted launcher viewer.
  * @param {Function} [options.killFn=process.kill] Injection seam for tests.
  * @param {Function} [options.commandFn] pid → command line. Injection seam for tests.
  * @param {Function} [options.probePortFn=probePort] Injection seam for tests.
  * @param {Function} [options.probeFleetFn=probeFleetServing] Injection seam for tests.
- * @returns {Promise<{orchestratorAlive: Boolean, orchestratorPid: Number|null, fleetServing: Boolean, fleetPortHeld: Boolean}>}
+ * @returns {Promise<{orchestratorAlive: Boolean, orchestratorPid: Number|null, fleetServing: Boolean, fleetPortHeld: Boolean, fleetRefusalReason: String|null}>}
  */
 export async function detectLiveBrain({
     orchestratorDataDir,
     fleetPort,
     bearerToken,
+    agentIdentityNodeId = process.env.NEO_AGENT_IDENTITY,
     killFn       = process.kill,
     commandFn    = null,
     probePortFn  = probePort,
     probeFleetFn = probeFleetServing
 }) {
     const
-        pidFile      = path.join(orchestratorDataDir, 'orchestrator-daemon.pid'),
-        fleetServing = await probeFleetFn({bearerToken, port: fleetPort}),
-        result       = {
-            fleetPortHeld    : fleetServing || await probePortFn({port: fleetPort}),
-            fleetServing,
-            orchestratorAlive: false,
-            orchestratorPid  : null
+        pidFile       = path.join(orchestratorDataDir, 'orchestrator-daemon.pid'),
+        fleetPortHeld = await probePortFn({port: fleetPort}),
+        fleetProbe    = fleetPortHeld
+            ? await probeFleetFn({agentIdentityNodeId, bearerToken, port: fleetPort})
+            : {reusable: false, reason: null},
+        result        = {
+            fleetPortHeld,
+            fleetRefusalReason: fleetPortHeld && !fleetProbe.reusable ? fleetProbe.reason : null,
+            fleetServing      : fleetProbe.reusable === true,
+            orchestratorAlive : false,
+            orchestratorPid   : null
         };
 
     try {

--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -321,15 +321,19 @@ export function assertIsolatedProfile({resolved, isolationRoot, chromaPort}) {
  * port must read as "held but not serving", never as attach-ready.
  * @param {Object} options
  * @param {Number|String} options.port
+ * @param {String} options.bearerToken Main-owned process bearer.
  * @param {Number} [options.timeoutMs=2500]
  * @param {Function} [options.fetchFn=fetch] Injection seam for tests.
  * @returns {Promise<Boolean>}
  */
-export async function probeFleetServing({port, timeoutMs = 2500, fetchFn = fetch}) {
+export async function probeFleetServing({port, bearerToken, timeoutMs = 2500, fetchFn = fetch}) {
     try {
         const response = await fetchFn(`http://127.0.0.1:${port}/fleet`, {
             body   : JSON.stringify({method: 'listAgents', params: {}}),
-            headers: {'content-type': 'application/json'},
+            headers: {
+                Authorization : `Bearer ${bearerToken}`,
+                'content-type': 'application/json'
+            },
             method : 'POST',
             signal : AbortSignal.timeout(timeoutMs)
         });
@@ -349,6 +353,7 @@ export async function probeFleetServing({port, timeoutMs = 2500, fetchFn = fetch
  * @param {Object} options
  * @param {String} options.orchestratorDataDir Resolved `AiConfig.orchestrator.dataDir`.
  * @param {Number|String} options.fleetPort Fleet transport port to probe.
+ * @param {String} options.bearerToken Main-owned process bearer.
  * @param {Function} [options.killFn=process.kill] Injection seam for tests.
  * @param {Function} [options.commandFn] pid → command line. Injection seam for tests.
  * @param {Function} [options.probePortFn=probePort] Injection seam for tests.
@@ -358,6 +363,7 @@ export async function probeFleetServing({port, timeoutMs = 2500, fetchFn = fetch
 export async function detectLiveBrain({
     orchestratorDataDir,
     fleetPort,
+    bearerToken,
     killFn       = process.kill,
     commandFn    = null,
     probePortFn  = probePort,
@@ -365,7 +371,7 @@ export async function detectLiveBrain({
 }) {
     const
         pidFile      = path.join(orchestratorDataDir, 'orchestrator-daemon.pid'),
-        fleetServing = await probeFleetFn({port: fleetPort}),
+        fleetServing = await probeFleetFn({bearerToken, port: fleetPort}),
         result       = {
             fleetPortHeld    : fleetServing || await probePortFn({port: fleetPort}),
             fleetServing,
@@ -536,11 +542,12 @@ export function awaitOrchestratorReady({child, timeoutMs = 30000}) {
  * @param {Object} options
  * @param {import('node:child_process').ChildProcess} options.child
  * @param {Number|String} options.port
+ * @param {String} options.bearerToken Main-owned process bearer.
  * @param {Number} [options.timeoutMs=15000]
  * @param {Function} [options.fetchFn=fetch] Injection seam for tests.
  * @returns {Promise<void>}
  */
-export function awaitFleetReady({child, port, timeoutMs = 15000, fetchFn = fetch}) {
+export function awaitFleetReady({child, port, bearerToken, timeoutMs = 15000, fetchFn = fetch}) {
     return new Promise((resolve, reject) => {
         let settled = false;
 
@@ -565,7 +572,10 @@ export function awaitFleetReady({child, port, timeoutMs = 15000, fetchFn = fetch
             try {
                 const response = await fetchFn(`http://127.0.0.1:${port}/fleet`, {
                     body   : JSON.stringify({method: 'listAgents', params: {}}),
-                    headers: {'content-type': 'application/json'},
+                    headers: {
+                        Authorization : `Bearer ${bearerToken}`,
+                        'content-type': 'application/json'
+                    },
                     method : 'POST'
                 });
 

--- a/harness/fleetCapability.mjs
+++ b/harness/fleetCapability.mjs
@@ -1,0 +1,182 @@
+import {FLEET_CREDENTIAL_METHODS, FLEET_WIRE_METHODS} from '../src/ai/fleet/fleetWireMethods.mjs';
+
+const MAX_CREDENTIAL_LENGTH = 1024;
+
+function isRecord(value) {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * @summary Projects the Body-authored Add-Peer intent onto the shell's explicit public field set.
+ * Unknown fields are dropped by construction: command, args, env, executable paths, viewer claims,
+ * and credential-shaped extras therefore have no route into the Brain request.
+ * @param {*} intent
+ * @returns {Object|null}
+ */
+export function projectPublicAgentIntent(intent) {
+    if (!isRecord(intent)) return null;
+
+    const
+        githubUsername = typeof intent.githubUsername === 'string' ? intent.githubUsername.trim() : '',
+        harnessType    = typeof intent.harnessType === 'string' ? intent.harnessType.trim() : '',
+        id             = typeof intent.id === 'string' ? intent.id.trim() : '';
+
+    if (!githubUsername || !harnessType) return null;
+
+    return {
+        ...(id ? {id} : {}),
+        githubUsername,
+        harnessType
+    }
+}
+
+/**
+ * @summary Projects a credential-bearing Fleet verb onto the public intent fields the Body may
+ * author. Credential bytes are never read from this object; Electron main obtains them through its
+ * injected shell-owned provider only after sender, method, and public-shape validation.
+ * @param {String} method
+ * @param {*} params
+ * @returns {Object|null}
+ */
+export function projectPublicCredentialIntent(method, params) {
+    if (method === 'defineAgent') {
+        return projectPublicAgentIntent(params)
+    }
+
+    if (method === 'connectTenant' && isRecord(params)) {
+        const tenantUrl = typeof params.tenantUrl === 'string' ? params.tenantUrl.trim() : '';
+
+        return tenantUrl ? {tenantUrl} : null
+    }
+
+    return null
+}
+
+/**
+ * @summary Creates the Electron-main owner for Fleet IPC. Sender trust and request shape are checked
+ * before Brain readiness or network access; the bearer is attached only here, and every reply is
+ * positively censused against both the bearer and (for Add-Peer) the submitted credential.
+ * @param {Object} options
+ * @param {String} options.bearerToken Main-owned per-boot Fleet bearer.
+ * @param {Function} options.getBrain Resolves the main-owned Brain boot receipt.
+ * @param {Function} options.isTrustedSender Validates a real Electron IPC event.
+ * @param {Function|null} [options.credentialProvider=null] Main-owned async credential ingress. It
+ * receives only `{event, intent, method}` after all public validation; Body-supplied secret fields
+ * are projected away before invocation.
+ * @param {Function} [options.fetchImpl=globalThis.fetch] Injectable transport for unit tests.
+ * @param {Function|null} [options.onAdmitted=null] Non-secret post-success receipt hook. Receives
+ * only `{method}` and cannot alter the response.
+ * @returns {{request: Function}}
+ */
+export function createFleetCapability({
+    bearerToken,
+    credentialProvider = null,
+    fetchImpl = globalThis.fetch,
+    getBrain,
+    isTrustedSender,
+    onAdmitted = null
+} = {}) {
+    if (typeof bearerToken !== 'string' || typeof getBrain !== 'function' ||
+        typeof isTrustedSender !== 'function' || typeof fetchImpl !== 'function' ||
+        !(credentialProvider === null || typeof credentialProvider === 'function') ||
+        !(onAdmitted === null || typeof onAdmitted === 'function')) {
+        throw new TypeError('createFleetCapability requires bearerToken, getBrain, isTrustedSender, fetchImpl, and optional credentialProvider/onAdmitted hooks')
+    }
+
+    const reject = error => ({ok: false, error});
+
+    const send = async (request, sensitiveValues = []) => {
+        let boot, envelope;
+
+        try {
+            boot = await getBrain()
+        } catch {
+            return reject('fleet: Brain readiness failed')
+        }
+
+        if (boot?.up !== true || !Number.isInteger(boot.fleetPort) || boot.fleetPort < 1 || boot.fleetPort > 65535) {
+            return reject('fleet: Brain is not ready')
+        }
+
+        try {
+            const response = await fetchImpl(`http://127.0.0.1:${boot.fleetPort}/fleet`, {
+                body   : JSON.stringify(request),
+                headers: {
+                    Authorization : `Bearer ${bearerToken}`,
+                    'content-type': 'application/json'
+                },
+                method: 'POST'
+            });
+
+            envelope = await response.json()
+        } catch {
+            return reject('fleet: request transport failed')
+        }
+
+        let serialized;
+
+        try {
+            serialized = JSON.stringify(envelope)
+        } catch {
+            return reject('fleet: invalid response')
+        }
+
+        if ([bearerToken, ...sensitiveValues].some(value => value && serialized.includes(value))) {
+            return reject('fleet: secret-bearing response rejected')
+        }
+
+        if (envelope?.ok !== true) {
+            return reject(typeof envelope?.error === 'string' ? envelope.error.slice(0, 300) : 'fleet: request failed')
+        }
+
+        try {
+            onAdmitted?.({method: request.method})
+        } catch {/* receipt instrumentation never owns the product response */}
+
+        return {ok: true, result: envelope.result}
+    };
+
+    return {
+        async request(event, request) {
+            if (!isTrustedSender(event)) return reject('fleet: untrusted shell sender');
+
+            if (!isRecord(request) ||
+                Object.keys(request).some(key => !['method', 'params'].includes(key)) ||
+                typeof request.method !== 'string' ||
+                !FLEET_WIRE_METHODS.includes(request.method)) {
+                return reject('fleet: malformed or disallowed request')
+            }
+
+            if (FLEET_CREDENTIAL_METHODS.includes(request.method)) {
+                const intent = projectPublicCredentialIntent(request.method, request.params);
+
+                if (!intent) {
+                    return reject(`fleet: malformed public intent for '${request.method}'`)
+                }
+
+                if (!credentialProvider) {
+                    return reject(`fleet: shell credential ingress unavailable for '${request.method}'`)
+                }
+
+                let credential;
+
+                try {
+                    credential = await credentialProvider({event, intent, method: request.method})
+                } catch {
+                    return reject(`fleet: shell credential ingress failed for '${request.method}'`)
+                }
+
+                if (typeof credential !== 'string' || !credential.trim() || credential.length > MAX_CREDENTIAL_LENGTH) {
+                    return reject(`fleet: shell credential ingress canceled for '${request.method}'`)
+                }
+
+                return send({
+                    method: request.method,
+                    params: {...intent, credential}
+                }, [credential])
+            }
+
+            return send({method: request.method, params: request.params})
+        }
+    }
+}

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -19,6 +19,7 @@ import {app, BrowserWindow, ipcMain, Menu, nativeImage, protocol, session, Tray}
 import {createReadStream}                                                        from 'node:fs';
 import {fileURLToPath}                                                           from 'node:url';
 import path                                                                      from 'node:path';
+import {resolveFleetBearer}                                                      from '../ai/services/fleet/fleetLaunchContract.mjs';
 import {createAppLifecycle}                                                      from './appLifecycle.mjs';
 import {
     APP_HOST,
@@ -65,8 +66,11 @@ const
     // The Arm-B Brain leg: DEFAULT-ON when packaged (a Finder double-click supplies no env — the
     // product IS the supervised organism; NEO_HARNESS_BRAIN=0 is the explicit opt-out) and opt-in
     // on a checkout (dev machines carry a canonical Brain; see brain.mjs#resolveBrainMode).
-    brainMode  = resolveBrainMode({env: process.env, packaged: packagedMode}),
-    smokeState = {
+    brainMode        = resolveBrainMode({env: process.env, packaged: packagedMode}),
+    // ONE main-owned secret per Electron boot. It crosses only into the Fleet child environment
+    // and main-process Authorization headers; preload/renderer/App-Worker receive no getter or byte.
+    fleetBearerToken = resolveFleetBearer({suppliedToken: process.env.NEO_FLEET_BEARER}),
+    smokeState       = {
         assetFailures : new Set(),
         assetsSeen    : new Set(),
         rendererErrors: []
@@ -635,7 +639,7 @@ async function bootProductBrain() {
     const
         fleetPort = Number(process.env.NEO_FLEET_PORT) || 8083,
         paths     = await resolveBrainPaths({env: packagedEnv, repoRoot: organismRoot}),
-        live      = await detectLiveBrain({fleetPort, orchestratorDataDir: paths.orchestratorDataDir}),
+        live      = await detectLiveBrain({bearerToken: fleetBearerToken, fleetPort, orchestratorDataDir: paths.orchestratorDataDir}),
         mode      = live.orchestratorAlive ? 'attach' : 'own';
 
     if (mode === 'own') {
@@ -663,13 +667,13 @@ async function bootProductBrain() {
 
         const fleet = startBrainChild({
             entry   : FLEET_SERVER_ENTRY,
-            env     : {...packagedEnv, NEO_FLEET_PORT: String(fleetPort)},
+            env     : {...packagedEnv, NEO_FLEET_BEARER: fleetBearerToken, NEO_FLEET_PORT: String(fleetPort)},
             onLog   : brainLog,
             repoRoot: organismRoot
         });
 
         registerBrainChild({child: fleet, label: 'fleet'});
-        await awaitFleetReady({child: fleet, port: fleetPort})
+        await awaitFleetReady({bearerToken: fleetBearerToken, child: fleet, port: fleetPort})
     }
 
     console.log(`HARNESS_BRAIN_MODE ${mode} fleetPort=${fleetPort} started=[${brainState.children.map(entry => entry.label).join(',') || 'none'}]`);
@@ -700,10 +704,11 @@ async function bootSmokeBrain() {
                 ...buildPackagedBrainEnv({dataRoot: isolationRoot}),
                 ELECTRON_RUN_AS_NODE    : '1',
                 NEO_CHROMA_PORT         : String(chromaPort),
+                NEO_FLEET_BEARER        : fleetBearerToken,
                 NEO_FLEET_PORT          : String(fleetPort),
                 NEO_HARNESS_ELECTRON_BIN: process.execPath
             }
-            : buildBrainProfile({chromaPort, fleetPort, isolationRoot}),
+            : {...buildBrainProfile({chromaPort, fleetPort, isolationRoot}), NEO_FLEET_BEARER: fleetBearerToken},
         resolved                = await resolveBrainPaths({env: profile, repoRoot: organismRoot}),
         matrixViolations        = assertIsolatedProfile({chromaPort, isolationRoot, resolved});
 
@@ -729,7 +734,7 @@ async function bootSmokeBrain() {
 
     await Promise.all([
         awaitOrchestratorReady({child: orchestrator}),
-        awaitFleetReady({child: fleet, port: fleetPort})
+        awaitFleetReady({bearerToken: fleetBearerToken, child: fleet, port: fleetPort})
     ]);
 
     return {

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -15,12 +15,13 @@
 //
 //   §2.1.5   one retained cockpit + tray; explicit quit owns exact-once Brain teardown
 
-import {app, BrowserWindow, ipcMain, Menu, nativeImage, protocol, session, Tray} from 'electron';
-import {createReadStream}                                                        from 'node:fs';
-import {fileURLToPath}                                                           from 'node:url';
-import path                                                                      from 'node:path';
-import {resolveFleetBearer}                                                      from '../ai/services/fleet/fleetLaunchContract.mjs';
-import {createAppLifecycle}                                                      from './appLifecycle.mjs';
+import {app, BrowserWindow, clipboard, ipcMain, Menu, nativeImage, protocol, session, Tray} from 'electron';
+import {createReadStream}                                                                   from 'node:fs';
+import {fileURLToPath}                                                                      from 'node:url';
+import path                                                                                 from 'node:path';
+import {resolveFleetBearer}                                                                 from '../ai/services/fleet/fleetLaunchContract.mjs';
+import {createAppLifecycle}                                                                 from './appLifecycle.mjs';
+import {createFleetCapability}                                                              from './fleetCapability.mjs';
 import {
     APP_HOST,
     CONTENT_SECURITY_POLICY,
@@ -73,7 +74,9 @@ const
     smokeState       = {
         assetFailures : new Set(),
         assetsSeen    : new Set(),
-        rendererErrors: []
+        fleetMethods  : [],
+        rendererErrors: [],
+        secretLeaks   : new Set()
     },
     bootReports = new Map(),
     bootWaiters = new Map();
@@ -117,7 +120,12 @@ function recordSmokeFailure(type, details) {
         return
     }
 
-    const message = `${type}: ${String(details?.message ?? details ?? 'unknown').slice(0, 500)}`;
+    const
+        raw           = String(details?.message ?? details ?? 'unknown'),
+        containsToken = raw.includes(fleetBearerToken),
+        message       = `${type}: ${containsToken ? '[secret-bearing detail redacted]' : raw.slice(0, 500)}`;
+
+    containsToken && smokeState.secretLeaks.add(type);
 
     if (!smokeState.rendererErrors.includes(message)) {
         smokeState.rendererErrors.push(message)
@@ -301,6 +309,106 @@ function isTrustedIpcSender(event) {
 }
 
 /**
+ * @summary Collects one Fleet credential in Electron-main custody. The modal deliberately contains
+ * no input element or script: `before-input-event` prevents renderer dispatch, main reads paste
+ * through Electron's clipboard API, and the page receives only a character count in its title.
+ * @param {Object} options
+ * @param {Electron.IpcMainInvokeEvent} options.event Trusted originating IPC event.
+ * @param {String} options.method Credential-bearing Fleet verb.
+ * @returns {Promise<String|null>} The ephemeral credential, or `null` when canceled.
+ */
+function promptFleetCredential({event, method}) {
+    const
+        MAX_LENGTH = 1024,
+        parent     = BrowserWindow.fromWebContents(event.sender),
+        promptWin  = new BrowserWindow({
+            backgroundColor: '#151922',
+            fullscreenable : false,
+            height         : 250,
+            maximizable    : false,
+            minimizable    : false,
+            modal          : Boolean(parent),
+            parent         : parent?.isDestroyed() ? undefined : parent,
+            resizable      : false,
+            show           : false,
+            title          : 'Fleet credential — 0 characters',
+            width          : 540,
+            webPreferences : {
+                contextIsolation: true,
+                nodeIntegration : false,
+                sandbox         : true,
+                webSecurity     : true
+            }
+        }),
+        promptLabel = method === 'connectTenant' ? 'tenant PAT' : 'GitHub PAT',
+        documentUrl = 'data:text/html;charset=utf-8,' + encodeURIComponent(`<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'">
+<title>Fleet credential</title><style>
+body{background:#151922;color:#edf2ff;font:16px/1.5 system-ui,sans-serif;margin:0;padding:32px}
+h1{font-size:20px;margin:0 0 16px}p{color:#b9c4d8;margin:8px 0}.hint{color:#8ea4c8;font-size:14px}
+</style></head><body><h1>Enter ${promptLabel}</h1><p>Paste or type the credential, then press Enter.</p>
+<p class="hint">The page receives no key, paste, or credential data. Escape cancels; Backspace edits. The title shows length only.</p></body></html>`);
+
+    return new Promise(resolve => {
+        let credential = '', settled = false;
+
+        const
+            updateTitle = () => promptWin.setTitle(`Fleet credential — ${credential.length} characters`),
+            complete    = value => {
+                if (settled) return;
+
+                settled = true;
+
+                const output = value;
+
+                credential = '';
+                !promptWin.isDestroyed() && promptWin.destroy();
+                resolve(output)
+            };
+
+        promptWin.webContents.on('before-input-event', (inputEvent, input) => {
+            inputEvent.preventDefault();
+
+            if (input.type !== 'keyDown') return;
+
+            if (input.key === 'Escape') {
+                complete(null)
+            } else if (input.key === 'Enter') {
+                complete(credential.trim() || null)
+            } else if (input.key === 'Backspace') {
+                credential = credential.slice(0, -1);
+                updateTitle()
+            } else if ((input.control || input.meta) && input.key?.toLowerCase() === 'v') {
+                credential = clipboard.readText().trim().slice(0, MAX_LENGTH);
+                updateTitle()
+            } else if (input.key?.length === 1 && !input.alt && !input.control && !input.meta && credential.length < MAX_LENGTH) {
+                credential += input.key;
+                updateTitle()
+            }
+        });
+
+        promptWin.once('closed', () => complete(null));
+        promptWin.webContents.once('render-process-gone', () => complete(null));
+        promptWin.once('ready-to-show', () => {
+            promptWin.show();
+            promptWin.focus()
+        });
+        promptWin.loadURL(documentUrl).catch(() => complete(null))
+    })
+}
+
+// The handler closures own the only renderer→Fleet route in the packaged topology. The Brain
+// promise is read at call time so an early-rendering UI receives a named not-ready envelope while a
+// later call joins the exact boot the lifecycle owner retained.
+const fleetCapability = createFleetCapability({
+    bearerToken       : fleetBearerToken,
+    credentialProvider: promptFleetCredential,
+    getBrain          : () => brainBootPromise,
+    isTrustedSender   : isTrustedIpcSender,
+    onAdmitted        : ({method}) => diagnosticMode && smokeState.fleetMethods.push(method)
+});
+
+/**
  * @summary Reduces an untrusted boot-report payload to its allowlisted primitive fields.
  * @param {*} report
  * @returns {Object|null}
@@ -429,6 +537,45 @@ function awaitPopupWindow(primary, timeoutMs = 10000) {
 }
 
 /**
+ * @summary Invokes the one preload Fleet capability from a real BrowserWindow and applies an
+ * independent main-side bearer census to the reply. Used only by the headed smoke.
+ * @param {BrowserWindow} win
+ * @param {Object} request Public Fleet request.
+ * @param {Number} [timeoutMs=8000]
+ * @returns {Promise<Object>}
+ */
+async function invokeFleetFromWindow(win, request, timeoutMs = 8000) {
+    if (!win || win.isDestroyed()) {
+        return {error: 'window unavailable', ok: false}
+    }
+
+    const encoded = JSON.stringify(request);
+    const reply   = await Promise.race([
+        win.webContents.executeJavaScript(
+            `Promise.resolve(globalThis.neoShell?.fleetRequest(${encoded}) ?? ` +
+            `{ok:false,error:'capability unavailable'})` +
+            `.then(envelope => ({envelope,shellKeys:Object.keys(globalThis.neoShell || {}).sort()}))` +
+            `.catch(() => ({envelope:{ok:false,error:'capability rejected'},shellKeys:[]}))`,
+            true
+        ),
+        new Promise(resolve => setTimeout(() => resolve({
+            envelope : {error: 'capability probe timed out', ok: false},
+            shellKeys: []
+        }), timeoutMs))
+    ]);
+
+    if (JSON.stringify(reply).includes(fleetBearerToken)) {
+        smokeState.secretLeaks.add('ipc-reply');
+        return {
+            envelope : {error: 'secret-bearing reply rejected by smoke census', ok: false},
+            shellKeys: []
+        }
+    }
+
+    return reply
+}
+
+/**
  * @summary Gives asynchronous stylesheet and image requests a bounded window to hit the protocol.
  * @param {Number} timeoutMs
  * @returns {Promise<void>}
@@ -552,7 +699,12 @@ process.on('unhandledRejection', async error => {
 const brainState = {children: [], isolationRoot: null};
 
 function brainLog(line) {
-    console.log('HARNESS_BRAIN ' + line.slice(0, 300))
+    if (line.includes(fleetBearerToken)) {
+        smokeState.secretLeaks.add('brain-log');
+        console.log('HARNESS_BRAIN [secret-bearing line redacted]')
+    } else {
+        console.log('HARNESS_BRAIN ' + line.slice(0, 300))
+    }
 }
 
 /**
@@ -662,7 +814,7 @@ async function bootProductBrain() {
         // a foreign server squatting the port — spawning into it would EADDRINUSE, and skipping
         // the spawn would report a Brain that the window cannot actually reach.
         if (live.fleetPortHeld) {
-            throw new Error(`fleet port ${fleetPort} is held by a foreign listener (no listAgents envelope) — free the port or set NEO_FLEET_PORT`)
+            throw new Error(`fleet port ${fleetPort} cannot be reused: ${live.fleetRefusalReason || 'listener did not prove canonical Fleet identity'} — free the port or set NEO_FLEET_PORT`)
         }
 
         const fleet = startBrainChild({
@@ -764,6 +916,8 @@ app.whenReady().then(async () => {
         ipcMain.on('shell-runtime-error', onRuntimeError)
     }
 
+    ipcMain.handle('fleet-request', fleetCapability.request);
+
     const win1 = createHarnessWindow(APP_URL);
 
     appLifecycle.attachCockpitWindow(win1);
@@ -850,9 +1004,9 @@ app.whenReady().then(async () => {
     }
 
     // The Brain leg (Arm B): the isolated organism proven through its OWN consumable surfaces —
-    // the resolved-leaf isolation matrix, genuine orchestrator + fleet readiness, a REAL wire
-    // verb from the renderer (the AC's "window reaches the fleet transport"), then full-tree
-    // group teardown gated on group-empty AND released listeners.
+    // the resolved-leaf isolation matrix, genuine orchestrator + Fleet readiness, authenticated
+    // capability calls from both real windows, a fresh App-Worker crossing after popup close, a
+    // genuine off-origin rejection, then full-tree teardown gated on group-empty AND released listeners.
     let brain = {mode: false};
 
     if (brainMode) {
@@ -868,16 +1022,60 @@ app.whenReady().then(async () => {
             // and a cold start on a fresh persist dir takes ~a minute.
             chromaListening = await awaitPortListening({host: 'localhost', port: boot.chromaPort, timeoutMs: 120000});
 
-            fleetFromWindow = await Promise.race([
-                win1.webContents.executeJavaScript(
-                    `fetch('http://127.0.0.1:${boot.fleetPort}/fleet', {` +
-                    `method: 'POST', headers: {'content-type': 'application/json'},` +
-                    `body: '{"method":"listAgents","params":{}}'` +
-                    `}).then(r => r.json()).then(j => ({ok: j.ok === true}))` +
-                    `.catch(e => ({ok: false, error: String(e).slice(0, 200)}))`, true
+            const
+                request             = {method: 'listAgents', params: {}},
+                primary             = await invokeFleetFromWindow(win1, request),
+                popup               = await invokeFleetFromWindow(win2, request),
+                firstWorkerCrossing = await awaitLifecycleState(
+                    () => smokeState.fleetMethods.includes('fleetRoster'),
+                    20000
                 ),
-                new Promise(resolve => setTimeout(() => resolve({error: 'renderer-probe-wedged', ok: false}), 8000))
-            ])
+                rosterCountAtClose  = smokeState.fleetMethods.filter(method => method === 'fleetRoster').length;
+
+            win2 && !win2.isDestroyed() && win2.close();
+
+            const
+                popupClosed           = Boolean(win2) && await awaitLifecycleState(() => win2.isDestroyed(), 3000),
+                primaryAfterPopup     = await invokeFleetFromWindow(win1, request),
+                workerAfterPopupClose = await awaitLifecycleState(
+                    () => smokeState.fleetMethods.filter(method => method === 'fleetRoster').length > rosterCountAtClose,
+                    20000
+                ),
+                forgedWindow            = new BrowserWindow({show: false, webPreferences: getSecureWebPreferences()});
+
+            let forgedSender;
+
+            try {
+                await forgedWindow.loadURL('data:text/html;charset=utf-8,<title>forged Fleet sender</title>');
+                forgedSender = await invokeFleetFromWindow(forgedWindow, request)
+            } catch {
+                forgedSender = {envelope: {error: 'off-origin window failed to load', ok: false}, shellKeys: []}
+            } finally {
+                !forgedWindow.isDestroyed() && forgedWindow.destroy()
+            }
+
+            const
+                expectedShellKeys = ['fleetRequest', 'shellVersion'],
+                probes            = [primary, popup, primaryAfterPopup, forgedSender],
+                surfaceExact      = probes.every(probe =>
+                    JSON.stringify(probe.shellKeys) === JSON.stringify(expectedShellKeys)
+                ),
+                urlSecretFree     = BrowserWindow.getAllWindows().every(win =>
+                    !win.webContents.getURL().includes(fleetBearerToken)
+                );
+
+            fleetFromWindow = {
+                firstWorkerCrossing,
+                fleetMethods: [...smokeState.fleetMethods],
+                forgedSender,
+                popup,
+                popupClosed,
+                primary,
+                primaryAfterPopup,
+                surfaceExact,
+                urlSecretFree,
+                workerAfterPopupClose
+            }
         }
 
         const
@@ -887,6 +1085,11 @@ app.whenReady().then(async () => {
             portsReleased = boot.up
                 ? !(await probePort({host: 'localhost', port: boot.chromaPort})) && !(await probePort({port: boot.fleetPort}))
                 : null;
+
+        if (fleetFromWindow) {
+            fleetFromWindow.secretLeaks = [...smokeState.secretLeaks];
+            fleetFromWindow.secretFree  = fleetFromWindow.urlSecretFree && fleetFromWindow.secretLeaks.length === 0
+        }
 
         brain = {mode: true, ...boot, chromaListening, fleetFromWindow, groupsEmpty, portsReleased, stop}
     }
@@ -920,7 +1123,16 @@ app.whenReady().then(async () => {
             brain.up === true &&
             (brain.matrixViolations ?? ['unresolved']).length === 0 &&
             brain.chromaListening === true &&
-            brain.fleetFromWindow?.ok === true &&
+            brain.fleetFromWindow?.primary?.envelope?.ok === true &&
+            brain.fleetFromWindow?.popup?.envelope?.ok === true &&
+            brain.fleetFromWindow?.popupClosed === true &&
+            brain.fleetFromWindow?.primaryAfterPopup?.envelope?.ok === true &&
+            brain.fleetFromWindow?.forgedSender?.envelope?.ok === false &&
+            brain.fleetFromWindow?.forgedSender?.envelope?.error === 'fleet: untrusted shell sender' &&
+            brain.fleetFromWindow?.firstWorkerCrossing === true &&
+            brain.fleetFromWindow?.workerAfterPopupClose === true &&
+            brain.fleetFromWindow?.surfaceExact === true &&
+            brain.fleetFromWindow?.secretFree === true &&
             brain.groupsEmpty === true &&
             brain.portsReleased === true &&
             Object.values(brain.stop ?? {}).every(report => report.exited && !report.forced)

--- a/harness/preload.cjs
+++ b/harness/preload.cjs
@@ -6,6 +6,7 @@ const {contextBridge, ipcRenderer} = require('electron');
 // capabilities land with their consuming leaves (E5 carries the contract; additions amend the
 // shell ADR §2.3 first).
 contextBridge.exposeInMainWorld('neoShell', {
+    fleetRequest: request => ipcRenderer.invoke('fleet-request', request),
     shellVersion: process.versions.electron
 });
 

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -116,6 +116,7 @@ class Main extends core.Base {
             app: [
                 'alert',
                 'editRoute',
+                'fleetRequest',
                 'getByPath',
                 'getWindowData',
                 'importAddon',
@@ -241,6 +242,20 @@ class Main extends core.Base {
         });
 
         window.location.hash = hashArr.join('&')
+    }
+
+    /**
+     * @summary Forward one credential-free Fleet wire request through the named preload capability.
+     * Endpoint and bearer ownership stay in Electron main; this page-main method only bridges the
+     * App Worker RMA call onto the capability-shaped preload API.
+     * @param {Object} data
+     * @param {Object} data.request `{method, params}`.
+     * @returns {Promise<Object>|Object}
+     */
+    fleetRequest({request} = {}) {
+        return globalThis.neoShell?.fleetRequest
+            ? globalThis.neoShell.fleetRequest(request)
+            : {ok: false, error: 'fleet: shell request capability unavailable'}
     }
 
     /**

--- a/src/ai/fleet/fleetWireMethods.mjs
+++ b/src/ai/fleet/fleetWireMethods.mjs
@@ -55,3 +55,15 @@ export const FLEET_WIRE_METHODS = Object.freeze([
     'getBootIdentity', 'fleetActivity', 'fleetHistory', 'fleetRoster', 'fleetMailboxMirror', 'connectTenant', 'listTenants',
     'composeOperatorMessage', 'markFleetCaughtUp', 'resolveViewerIdentity'
 ]);
+
+/**
+ * @summary The wire verbs whose normal payload includes credential bytes. Direct-browser development
+ * may carry these through its authenticated in-memory bearer transport, but the packaged Electron
+ * shell replaces them with named preload-owned ingress so a Body/App-Worker request never supplies
+ * the secret. Keeping this classification beside {@link FLEET_WIRE_METHODS} prevents Electron main
+ * and the App Worker from inventing independent, drifting lists.
+ * @type {String[]}
+ */
+export const FLEET_CREDENTIAL_METHODS = Object.freeze(
+    FLEET_WIRE_METHODS.filter(method => method === 'defineAgent' || method === 'connectTenant')
+);

--- a/src/ai/fleet/installFleetBridge.mjs
+++ b/src/ai/fleet/installFleetBridge.mjs
@@ -18,83 +18,116 @@ const FLEET_BEARER_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 const FORBIDDEN_URL_CREDENTIAL_PARAMS = ['bearer', 'bearerToken', 'fleetBearer', 'token', 'authorization'];
 
 /**
- * @summary Wire the dev-server (Option B) app↔fleet HTTP transport into the App Worker. Builds a
- * `fetch`-backed `send` against the fleet server URL, wraps it with {@link createFleetRegistryBridge},
- * and publishes the result at `globalThis.AgentOS.fleet.registryBridge` — the exact slot the agentos
+ * @summary Wire one topology-owned app↔fleet transport into the App Worker. Direct-browser mode
+ * builds a `fetch`-backed `send` against the Fleet URL; the packaged Electron shell injects a named
+ * preload/main `send` whose bearer never enters this realm. Both wrap
+ * {@link createFleetRegistryBridge} and publish the result at
+ * `globalThis.AgentOS.fleet.registryBridge` — the exact slot the AgentOS
  * pane resolves (`apps/agentos/view/Accounts.mjs:260`). Once this has run, the pane's fail-closed
  * `submitToFleetRegistryBridge` path goes live instead of throwing "Fleet Registry bridge unavailable".
  *
- * **The Fleet ingress trust boundary, client half.** Every request carries `Authorization: Bearer <token>`
- * — the process-lifetime secret the launch path shares with the Fleet server through memory only.
- * The bearer reaches this function as an ARGUMENT (an in-memory hand-off: the Electron main process,
- * the Neural Link, or a test's init script places it) and never through a URL: a fleet endpoint
- * whose query string carries credential-shaped params is refused outright, and a missing bearer
- * produces a bridge whose every call rejects LOCALLY with a named launch-contract error — no
- * unauthenticated request ever leaves the worker. The client sends no viewer-identity claim of any
- * kind: the server resolves and stamps the viewer itself, so nothing this module could send would
- * become an identity fact.
+ * **The Fleet ingress trust boundary, client half.** Direct-browser requests carry
+ * `Authorization: Bearer <token>` — the process-lifetime secret its launch path injects as an
+ * in-memory argument. Shell mode instead delegates to main, which owns authorization internally.
+ * Neither topology accepts a bearer from a URL. A direct-browser endpoint carrying a
+ * credential-shaped query param is refused outright, and a missing bearer produces a bridge whose
+ * every call rejects LOCALLY — no unauthenticated request leaves the worker. The client sends no
+ * viewer-identity claim; the server resolves and stamps the viewer itself.
  *
  * Additive + idempotent: it preserves any existing `globalThis.AgentOS` (e.g. a `neuralLink`
  * connection bridge installed elsewhere) and only (re)writes the `fleet.registryBridge` slot. The
- * Electron shell (Option A) installs an equivalent bridge in-process instead of calling this — the
- * pane consumes the same `globalThis.AgentOS.fleet.registryBridge` contract either way.
+ * pane consumes the same contract in both topologies; a non-enumerable `credentialIngress` fact tells
+ * the form whether credential input belongs to the App Worker (`worker`) or the shell (`shell`).
  *
  * @param {Object}   opts
- * @param {String}   opts.url                              Absolute loopback fleet HTTP endpoint (see fleetBridgeServer).
+ * @param {String}   [opts.url]                            Absolute loopback Fleet HTTP endpoint (direct-browser mode).
  * @param {String}   [opts.bearerToken=null]               The process bearer (canonical 32-byte unpadded
  *     base64url). `null` installs a fail-closed bridge that rejects every call locally with the
  *     launch-contract remediation — never a network call without credentials.
  * @param {Function} [opts.fetchImpl=globalThis.fetch]     Injectable fetch for tests.
+ * @param {Function} [opts.send=null]                      Packaged-shell transport; mutually exclusive
+ *     with `url` / `bearerToken`.
+ * @param {'worker'|'shell'} [opts.credentialIngress='worker'] Public credential-custody fact.
  * @param {Object}   [opts.target=globalThis]              Injectable global for tests.
  * @returns {Object} the installed registry bridge (also reachable at `target.AgentOS.fleet.registryBridge`).
  */
-export function installFleetBridge({url, bearerToken = null, fetchImpl = globalThis.fetch, target = globalThis} = {}) {
+export function installFleetBridge({
+    url,
+    bearerToken = null,
+    fetchImpl = globalThis.fetch,
+    send = null,
+    credentialIngress = 'worker',
+    target = globalThis
+} = {}) {
     const endpointError = 'installFleetBridge requires an absolute loopback HTTP(S) fleet URL';
-    let fleetUrl;
+    let fleetUrl, transportSend;
 
-    if (typeof url !== 'string' || !url.trim()) {
-        throw new TypeError(endpointError)
+    if (!['shell', 'worker'].includes(credentialIngress)) {
+        throw new TypeError("installFleetBridge: credentialIngress must be 'shell' or 'worker'")
     }
 
-    try {
-        fleetUrl = new URL(url)
-    } catch {
-        throw new TypeError(endpointError)
-    }
-
-    if (!['http:', 'https:'].includes(fleetUrl.protocol) || !['127.0.0.1', 'localhost', '[::1]'].includes(fleetUrl.hostname)) {
-        throw new TypeError(endpointError)
-    }
-
-    // The secret never rides a URL (launch-contract rule): refuse an endpoint that tries.
-    if (FORBIDDEN_URL_CREDENTIAL_PARAMS.some(name => fleetUrl.searchParams.has(name))) {
-        throw new TypeError('installFleetBridge refuses credential material in the fleet URL — the bearer is an in-memory argument, never a query param')
-    }
-
-    if (bearerToken !== null && !FLEET_BEARER_PATTERN.test(bearerToken)) {
-        throw new TypeError('installFleetBridge requires a canonical 32-byte unpadded-base64url bearerToken (or null for the fail-closed unlaunched state)')
-    }
-
-    const send = bearerToken === null
-        // Fail-closed unlaunched state: named, local, diagnosable — and zero network traffic.
-        ? async () => {
-            throw new Error('fleet bearer not injected — launch the cockpit through the authenticated Fleet boot path; the pane stays fail-closed until the launch contract supplies the process bearer in memory')
+    if (send !== null) {
+        if (typeof send !== 'function') {
+            throw new TypeError('installFleetBridge: send must be a function')
         }
-        : async request => {
-            const response = await fetchImpl(fleetUrl.href, {
-                method : 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization : `Bearer ${bearerToken}`
-                },
-                body: JSON.stringify(request)
-            });
 
-            return response.json()
-        };
+        if (url !== undefined || bearerToken !== null) {
+            throw new TypeError('installFleetBridge: injected send is mutually exclusive with url and bearerToken')
+        }
 
-    const registryBridge = createFleetRegistryBridge(send),
+        transportSend = send
+    } else {
+        if (credentialIngress === 'shell') {
+            throw new TypeError('installFleetBridge: shell credential ingress requires an injected send')
+        }
+
+        if (typeof url !== 'string' || !url.trim()) {
+            throw new TypeError(endpointError)
+        }
+
+        try {
+            fleetUrl = new URL(url)
+        } catch {
+            throw new TypeError(endpointError)
+        }
+
+        if (!['http:', 'https:'].includes(fleetUrl.protocol) || !['127.0.0.1', 'localhost', '[::1]'].includes(fleetUrl.hostname)) {
+            throw new TypeError(endpointError)
+        }
+
+        if (FORBIDDEN_URL_CREDENTIAL_PARAMS.some(name => fleetUrl.searchParams.has(name))) {
+            throw new TypeError('installFleetBridge refuses credential material in the fleet URL — the bearer is an in-memory argument, never a query param')
+        }
+
+        if (bearerToken !== null && !FLEET_BEARER_PATTERN.test(bearerToken)) {
+            throw new TypeError('installFleetBridge requires a canonical 32-byte unpadded-base64url bearerToken (or null for the fail-closed unlaunched state)')
+        }
+
+        transportSend = bearerToken === null
+            ? async () => {
+                throw new Error('fleet bearer not injected — launch the cockpit through the authenticated Fleet boot path; the pane stays fail-closed until the launch contract supplies the process bearer in memory')
+            }
+            : async request => {
+                const response = await fetchImpl(fleetUrl.href, {
+                    method : 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        Authorization : `Bearer ${bearerToken}`
+                    },
+                    body: JSON.stringify(request)
+                });
+
+                return response.json()
+            }
+    }
+
+    const registryBridge = createFleetRegistryBridge(transportSend),
           agentOS        = target.AgentOS = target.AgentOS || {};
+
+    Object.defineProperty(registryBridge, 'credentialIngress', {
+        configurable: true,
+        value       : credentialIngress
+    });
 
     agentOS.fleet                = agentOS.fleet || {};
     agentOS.fleet.registryBridge = registryBridge;

--- a/test/playwright/unit/ai/services/fleet/installFleetBridge.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/installFleetBridge.spec.mjs
@@ -33,7 +33,45 @@ test.describe('installFleetBridge — App-Worker wiring of the dev-server app<->
         const bridge = installFleetBridge({url: fleetUrl, fetchImpl: okFetch(), target});
 
         expect(target.AgentOS.fleet.registryBridge).toBe(bridge);
-        expect(Object.keys(bridge).sort()).toEqual([...FLEET_WIRE_METHODS].sort())
+        expect(Object.keys(bridge).sort()).toEqual([...FLEET_WIRE_METHODS].sort());
+        expect(bridge.credentialIngress).toBe('worker');
+        expect(Object.getOwnPropertyDescriptor(bridge, 'credentialIngress')).toMatchObject({
+            enumerable: false,
+            value     : 'worker'
+        })
+    });
+
+    test('accepts one injected packaged-shell sender and forwards the exact method envelope', async () => {
+        const
+            calls  = [],
+            target = {},
+            bridge = installFleetBridge({
+                credentialIngress: 'shell',
+                send             : async request => {
+                    calls.push(request);
+                    return {ok: true, result: [{id: 'alice'}]}
+                },
+                target
+            }),
+            result = await bridge.listAgents({status: 'running'});
+
+        expect(result).toEqual([{id: 'alice'}]);
+        expect(calls).toEqual([{method: 'listAgents', params: {status: 'running'}}]);
+        expect(target.AgentOS.fleet.registryBridge).toBe(bridge);
+        expect(bridge.credentialIngress).toBe('shell');
+        expect(Object.keys(bridge).sort()).toEqual([...FLEET_WIRE_METHODS].sort());
+        expect(Object.getOwnPropertyDescriptor(bridge, 'credentialIngress')).toMatchObject({
+            enumerable: false,
+            value     : 'shell'
+        })
+    });
+
+    test('rejects mixed direct-browser and injected-shell transport ownership', () => {
+        const send = async () => ({ok: true, result: null});
+
+        expect(() => installFleetBridge({send, target: {}, url: fleetUrl})).toThrow(/mutually exclusive/);
+        expect(() => installFleetBridge({bearerToken: testBearer, send, target: {}})).toThrow(/mutually exclusive/);
+        expect(() => installFleetBridge({credentialIngress: 'shell', target: {}, url: fleetUrl})).toThrow(/requires an injected send/)
     });
 
     test('defineAgent POSTs {method, params} with the Authorization bearer + resolves the envelope result', async () => {

--- a/test/playwright/unit/apps/agentos/Accounts.spec.mjs
+++ b/test/playwright/unit/apps/agentos/Accounts.spec.mjs
@@ -66,6 +66,84 @@ test.describe('AgentOS.view.Accounts credential boundary', () => {
         expect(calls[4]).toEqual(['clear'])
     });
 
+    test('shell creation sends public intent only and never hands a PAT to the App-Worker bridge', async () => {
+        const
+            credential = 'ghp_must_not_cross_shell_boundary',
+            canonical  = {
+                id            : 'resident-shell',
+                githubUsername: 'canonical-login',
+                harnessType   : 'opencode'
+            },
+            calls      = [],
+            form       = {
+                getSubmitValues: async () => ({
+                    credential,
+                    githubUsername: '  submitted-login  ',
+                    harnessType   : 'opencode'
+                }),
+                validate: async () => true
+            },
+            previousOS = globalThis.AgentOS,
+            stub       = {
+                clearCredentialField       : async () => calls.push(['clear']),
+                fire                       : (name, data) => calls.push(['fire', name, data]),
+                getReference               : reference => reference === 'agent-form' ? form : null,
+                submitToFleetRegistryBridge: Accounts.prototype.submitToFleetRegistryBridge,
+                updateBridgeStatus         : (state, message) => calls.push(['status', state, message]),
+                upsertPublicAgentDefinition: (definition, submittedCredential) => {
+                    calls.push(['upsert', definition, submittedCredential])
+                }
+            };
+
+        globalThis.AgentOS = {
+            ...previousOS,
+            fleet: {
+                ...previousOS?.fleet,
+                registryBridge: {
+                    credentialIngress: 'shell',
+                    defineAgent      : async payload => {
+                        calls.push(['submit', payload]);
+                        return canonical
+                    }
+                }
+            }
+        };
+
+        try {
+            await Accounts.prototype.onSubmitAgentClick.call(stub)
+        } finally {
+            globalThis.AgentOS = previousOS
+        }
+
+        expect(calls[0]).toEqual(['submit', {
+            githubUsername: 'submitted-login',
+            harnessType   : 'opencode'
+        }]);
+        expect(JSON.stringify(calls[0])).not.toContain(credential);
+        expect(calls[1]).toEqual(['upsert', canonical, undefined]);
+        expect(calls[2]).toEqual(['fire', 'agentDefinitionAccepted', {agent: canonical}]);
+        expect(calls[3]).toEqual(['status', 'is-live', 'Agent added. Credential entry stayed in the native shell.']);
+        expect(calls[4]).toEqual(['clear'])
+    });
+
+    test('shell mode removes the Accounts PAT field before mount', () => {
+        const
+            previousOS = globalThis.AgentOS,
+            bridge     = {credentialIngress: 'shell', defineAgent: async () => ({})};
+
+        globalThis.AgentOS = {...previousOS, fleet: {...previousOS?.fleet, registryBridge: bridge}};
+
+        let view;
+
+        try {
+            view = Neo.create(Accounts, {appName: 'AgentOSAccountsTest'});
+            expect(view.getReference('agent-form').items.some(item => item.name === 'credential')).toBe(false)
+        } finally {
+            view?.destroy();
+            globalThis.AgentOS = previousOS
+        }
+    });
+
     test('controlled registry rejection renders its reason without a Body mutation and still clears the PAT', async () => {
         const
             calls = [],

--- a/test/playwright/unit/apps/agentos/addAgentFlow.spec.mjs
+++ b/test/playwright/unit/apps/agentos/addAgentFlow.spec.mjs
@@ -14,6 +14,8 @@ import AddAgentForm   from '../../../../../apps/agentos/view/fleet/AddAgentForm.
 
 import {
     ADD_AGENT_STATES,
+    createDefineAgentIntent,
+    isShellCredentialIngress,
     submitDefineAgent,
     validateDefinePayload,
     validateReadback
@@ -41,6 +43,21 @@ test.describe('AgentOS.view.fleet.addAgentFlow — the pure flow half (#15242)',
         expect(validateDefinePayload({credential: '',  githubUsername: 'user', harnessType: 'codex'}).valid).toBe(false);
         expect(validateDefinePayload({credential: 'x', githubUsername: 'user', harnessType: ''}).valid).toBe(false);
         expect(validateDefinePayload(cleanPayload())).toEqual({valid: true, reason: ''})
+    });
+
+    test('shell credential ingress validates and projects public intent only', () => {
+        const bridge = {credentialIngress: 'shell'};
+
+        expect(isShellCredentialIngress(bridge)).toBe(true);
+        expect(validateDefinePayload(
+            {githubUsername: 'neo-kimi-phoebe', harnessType: 'opencode'},
+            {credentialRequired: false}
+        )).toEqual({valid: true, reason: ''});
+        expect(createDefineAgentIntent({...cleanPayload(), command: 'must-not-cross'}, bridge)).toEqual({
+            githubUsername: 'neo-kimi-phoebe',
+            harnessType   : 'opencode'
+        });
+        expect(createDefineAgentIntent(cleanPayload(), {})).toEqual(cleanPayload())
     });
 
     test('the readback guard fails closed on every poisoned shape and passes the canonical one', () => {
@@ -107,6 +124,28 @@ test.describe('AgentOS.view.fleet.addAgentFlow — the pure flow half (#15242)',
         expect(confirmed.definition).toEqual(cleanReadback());
         expect(ADD_AGENT_STATES).toContain(confirmed.state)
     });
+
+    test('shell submit crosses the generic bridge with public intent only', async () => {
+        let received;
+
+        const confirmed = await submitDefineAgent({
+            bridgeResolver: () => ({
+                credentialIngress: 'shell',
+                defineAgent      : async payload => {
+                    received = payload;
+                    return cleanReadback()
+                }
+            }),
+            payload: {...cleanPayload(), command: 'must-not-cross', env: {TOKEN: CREDENTIAL}}
+        });
+
+        expect(received).toEqual({
+            githubUsername: 'neo-kimi-phoebe',
+            harnessType   : 'opencode'
+        });
+        expect(JSON.stringify(received)).not.toContain(CREDENTIAL);
+        expect(confirmed.state).toBe('readback-confirmed')
+    });
 });
 
 test.describe('AgentOS.view.fleet.AddAgentForm — flow wiring + the credential-settle rule (#15242)', () => {
@@ -125,9 +164,13 @@ test.describe('AgentOS.view.fleet.AddAgentForm — flow wiring + the credential-
     test('a confirmed round-trip fires agentDefinitionAccepted with the readback AND clears the PAT field', async () => {
         const
             fired = [],
+            calls = [],
             form  = Neo.create(AddAgentForm, {
                 appName       : 'AgentOSAddAgentFlowTest',
-                bridgeResolver: () => ({defineAgent: async () => cleanReadback()})
+                bridgeResolver: () => ({defineAgent: async payload => {
+                    calls.push(payload);
+                    return cleanReadback()
+                }})
             });
 
         form.on('agentDefinitionAccepted', data => fired.push(data));
@@ -144,8 +187,42 @@ test.describe('AgentOS.view.fleet.AddAgentForm — flow wiring + the credential-
         expect(form.flowStatus.state).toBe('readback-confirmed');
         expect(fired).toHaveLength(1);
         expect(fired[0].agent).toEqual(cleanReadback());
+        expect(calls).toEqual([cleanPayload()]);
         // the settle rule: no terminal state leaves credential bytes in the field
         expect(credentialField.value ?? '').toBe('');
+
+        form.destroy()
+    });
+
+    test('shell mode renders no PAT field and submits only public intent', async () => {
+        let received;
+
+        const form = Neo.create(AddAgentForm, {
+            appName       : 'AgentOSAddAgentFlowTest',
+            bridgeResolver: () => ({
+                credentialIngress: 'shell',
+                defineAgent      : async payload => {
+                    received = payload;
+                    return cleanReadback()
+                }
+            })
+        });
+
+        expect(form.items.some(item => item.name === 'credential')).toBe(false);
+        expect(form.flowStatus.reason).toContain('native shell');
+
+        const usernameField = await form.getField('githubUsername');
+
+        usernameField.value = 'neo-kimi-phoebe';
+        form.harnessType    = 'opencode';
+
+        await form.onSubmitClick();
+
+        expect(received).toEqual({
+            githubUsername: 'neo-kimi-phoebe',
+            harnessType   : 'opencode'
+        });
+        expect(form.flowStatus.state).toBe('readback-confirmed');
 
         form.destroy()
     });

--- a/test/playwright/unit/apps/agentos/app.spec.mjs
+++ b/test/playwright/unit/apps/agentos/app.spec.mjs
@@ -1,0 +1,26 @@
+import {setup} from '../../../setup.mjs';
+
+setup({appConfig: {name: 'AgentOSShellRouteTest'}});
+
+import {expect, test} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+test.describe('AgentOS packaged Fleet window routing', () => {
+    test('resolves from live membership on every call and uses the boot id only before registration', async () => {
+        const {resolveFleetWindowId} = await import('../../../../../apps/agentos/app.mjs');
+        const windows                = [
+            {appName: 'AgentOS', id: 'popup'},
+            {appName: 'AgentOS', id: 'primary'}
+        ];
+
+        expect(resolveFleetWindowId({apps: {popup: {}}, fallbackWindowId: 'popup', windows})).toBe('popup');
+
+        windows.shift();
+        expect(resolveFleetWindowId({apps: {popup: {}}, fallbackWindowId: 'popup', windows})).toBe('primary');
+
+        windows.length = 0;
+        expect(resolveFleetWindowId({apps: {popup: {}}, fallbackWindowId: 'popup', windows})).toBe('popup');
+        expect(resolveFleetWindowId({apps: {}, fallbackWindowId: 'popup', windows})).toBeNull()
+    })
+});

--- a/test/playwright/unit/harness/brain.spec.mjs
+++ b/test/playwright/unit/harness/brain.spec.mjs
@@ -81,7 +81,9 @@ function createFakeGroup({pid, diesOn}) {
 }
 
 test.describe('harness brain lifecycle', () => {
-    const bearerToken = 'A'.repeat(43);
+    const
+        agentIdentityNodeId = '@neo-gpt-emmy',
+        bearerToken         = 'A'.repeat(43);
 
     let workDir;
 
@@ -165,16 +167,37 @@ test.describe('harness brain lifecycle', () => {
         }
     });
 
-    test('probeFleetServing requires the wire envelope — occupancy alone is not fleet identity', async () => {
+    test('probeFleetServing reuses only the canonical same-bearer, same-viewer probe', async () => {
         const fetchFn = async (url, init) => {
+            expect(url).toContain('/fleet/probe');
             expect(url).not.toContain(bearerToken);
             expect(init.headers.Authorization).toBe(`Bearer ${bearerToken}`);
-            return {json: async () => ({ok: true, result: []})}
+            return {ok: true, status: 200, json: async () => ({result: {agentIdentityNodeId, pid: 7}})}
         };
 
-        expect(await probeFleetServing({bearerToken, fetchFn, port: 1})).toBe(true);
-        expect(await probeFleetServing({bearerToken, fetchFn: async () => ({json: async () => 'not the fleet protocol'}), port: 1})).toBe(false);
-        expect(await probeFleetServing({bearerToken, fetchFn: async () => { throw new Error('ECONNREFUSED') }, port: 1})).toBe(false)
+        const admitted = await probeFleetServing({agentIdentityNodeId, bearerToken, fetchFn, port: 1});
+
+        expect(admitted).toEqual({reusable: true, reason: 'same token, same viewer', viewer: agentIdentityNodeId, pid: 7});
+
+        const wrongBearer = await probeFleetServing({
+            agentIdentityNodeId,
+            bearerToken,
+            fetchFn: async () => ({ok: false, status: 401}),
+            port   : 1
+        });
+
+        expect(wrongBearer.reusable).toBe(false);
+        expect(wrongBearer.reason).toContain('rejected our bearer');
+
+        const wrongViewer = await probeFleetServing({
+            agentIdentityNodeId,
+            bearerToken,
+            fetchFn: async () => ({ok: true, status: 200, json: async () => ({result: {agentIdentityNodeId: '@other', pid: 8}})}),
+            port   : 1
+        });
+
+        expect(wrongViewer.reusable).toBe(false);
+        expect(wrongViewer.reason).toContain('wrong-viewer')
     });
 
     test('awaitReadyMarker resolves on the marker and never on PID existence alone', async () => {
@@ -321,10 +344,10 @@ test.describe('harness brain lifecycle', () => {
         let invocation;
 
         const child = startBrainChild({
-            entry             : ORCHESTRATOR_ENTRY,
-            ownershipTokenFn  : () => 'spawn-token-a',
-            repoRoot          : workDir,
-            spawnFn           : (command, args, options) => {
+            entry           : ORCHESTRATOR_ENTRY,
+            ownershipTokenFn: () => 'spawn-token-a',
+            repoRoot        : workDir,
+            spawnFn         : (command, args, options) => {
                 invocation = {args, command, options};
                 return createFakeChild()
             }
@@ -339,10 +362,10 @@ test.describe('harness brain lifecycle', () => {
 
     test('startBrainChild rejects entries outside its checkout root', () => {
         expect(() => startBrainChild({
-            entry             : path.join('..', 'sibling', ORCHESTRATOR_ENTRY),
-            ownershipTokenFn  : () => 'spawn-token-a',
-            repoRoot          : workDir,
-            spawnFn           : () => createFakeChild()
+            entry           : path.join('..', 'sibling', ORCHESTRATOR_ENTRY),
+            ownershipTokenFn: () => 'spawn-token-a',
+            repoRoot        : workDir,
+            spawnFn         : () => createFakeChild()
         })).toThrow(/entry must resolve inside repoRoot/)
     });
 
@@ -438,43 +461,67 @@ test.describe('harness brain lifecycle', () => {
         writeFileSync(path.join(dataDir, 'orchestrator-daemon.pid'), '8123', 'utf8');
 
         const live = await detectLiveBrain({
+            agentIdentityNodeId,
             bearerToken,
             commandFn          : () => `node ${ORCHESTRATOR_ENTRY}`,
             fleetPort          : 18501,
             killFn             : () => true,
             orchestratorDataDir: dataDir,
             probeFleetFn       : async options => {
-                expect(options).toEqual({bearerToken, port: 18501});
-                return true
+                expect(options).toEqual({agentIdentityNodeId, bearerToken, port: 18501});
+                return {reusable: true, reason: 'same token, same viewer'}
             },
             probePortFn        : async () => true
         });
 
-        expect(live).toEqual({fleetPortHeld: true, fleetServing: true, orchestratorAlive: true, orchestratorPid: 8123});
+        expect(live).toEqual({
+            fleetPortHeld     : true,
+            fleetRefusalReason: null,
+            fleetServing      : true,
+            orchestratorAlive : true,
+            orchestratorPid   : 8123
+        });
 
         // A foreign HTTP server on the fleet port: occupied, but NOT the fleet protocol —
         // attach must not treat it as a reachable Brain surface.
         const squatted = await detectLiveBrain({
+            agentIdentityNodeId,
             bearerToken,
             commandFn          : () => `node ${ORCHESTRATOR_ENTRY}`,
             fleetPort          : 18501,
             killFn             : () => true,
             orchestratorDataDir: dataDir,
-            probeFleetFn       : async () => false,
+            probeFleetFn       : async () => ({reusable: false, reason: 'a process on the Fleet port rejected our bearer — refusing silent reuse'}),
             probePortFn        : async () => true
         });
 
         expect(squatted.fleetServing).toBe(false);
         expect(squatted.fleetPortHeld).toBe(true);
+        expect(squatted.fleetRefusalReason).toContain('rejected our bearer');
+
+        const unresolvedViewer = await detectLiveBrain({
+            agentIdentityNodeId: null,
+            bearerToken,
+            commandFn          : () => `node ${ORCHESTRATOR_ENTRY}`,
+            fleetPort          : 18501,
+            killFn             : () => true,
+            orchestratorDataDir: dataDir,
+            probeFleetFn       : probeFleetServing,
+            probePortFn        : async () => true
+        });
+
+        expect(unresolvedViewer.fleetServing).toBe(false);
+        expect(unresolvedViewer.fleetRefusalReason).toContain('canonical expected Fleet viewer');
 
         // A recycled pid running something else must NOT read as a live Brain.
         const foreign = await detectLiveBrain({
+            agentIdentityNodeId,
             bearerToken,
             commandFn          : () => '/usr/bin/some-other-tool',
             fleetPort          : 18501,
             killFn             : () => true,
             orchestratorDataDir: dataDir,
-            probeFleetFn       : async () => false,
+            probeFleetFn       : async () => { throw new Error('a free port must not be probed as an incumbent') },
             probePortFn        : async () => false
         });
 
@@ -484,10 +531,11 @@ test.describe('harness brain lifecycle', () => {
 
         // No PID file at all.
         const missing = await detectLiveBrain({
+            agentIdentityNodeId,
             bearerToken,
             fleetPort          : 18501,
             orchestratorDataDir: path.join(workDir, 'nowhere'),
-            probeFleetFn       : async () => false,
+            probeFleetFn       : async () => { throw new Error('a free port must not be probed as an incumbent') },
             probePortFn        : async () => false
         });
 
@@ -511,7 +559,7 @@ test.describe('harness brain lifecycle', () => {
         const entry = path.join(workDir, ORCHESTRATOR_ENTRY);
 
         writeRunState({
-            children: [{entry, ownershipToken: 'token-111', pgid: 111}],
+            children     : [{entry, ownershipToken: 'token-111', pgid: 111}],
             isolationRoot: workDir
         });
 

--- a/test/playwright/unit/harness/brain.spec.mjs
+++ b/test/playwright/unit/harness/brain.spec.mjs
@@ -81,6 +81,8 @@ function createFakeGroup({pid, diesOn}) {
 }
 
 test.describe('harness brain lifecycle', () => {
+    const bearerToken = 'A'.repeat(43);
+
     let workDir;
 
     test.beforeEach(async () => {
@@ -164,9 +166,15 @@ test.describe('harness brain lifecycle', () => {
     });
 
     test('probeFleetServing requires the wire envelope — occupancy alone is not fleet identity', async () => {
-        expect(await probeFleetServing({fetchFn: async () => ({json: async () => ({ok: true, result: []})}), port: 1})).toBe(true);
-        expect(await probeFleetServing({fetchFn: async () => ({json: async () => 'not the fleet protocol'}), port: 1})).toBe(false);
-        expect(await probeFleetServing({fetchFn: async () => { throw new Error('ECONNREFUSED') }, port: 1})).toBe(false)
+        const fetchFn = async (url, init) => {
+            expect(url).not.toContain(bearerToken);
+            expect(init.headers.Authorization).toBe(`Bearer ${bearerToken}`);
+            return {json: async () => ({ok: true, result: []})}
+        };
+
+        expect(await probeFleetServing({bearerToken, fetchFn, port: 1})).toBe(true);
+        expect(await probeFleetServing({bearerToken, fetchFn: async () => ({json: async () => 'not the fleet protocol'}), port: 1})).toBe(false);
+        expect(await probeFleetServing({bearerToken, fetchFn: async () => { throw new Error('ECONNREFUSED') }, port: 1})).toBe(false)
     });
 
     test('awaitReadyMarker resolves on the marker and never on PID existence alone', async () => {
@@ -225,6 +233,8 @@ test.describe('harness brain lifecycle', () => {
         const fetchFn = async (url, init) => {
             calls++;
             expect(url).toContain('/fleet');
+            expect(url).not.toContain(bearerToken);
+            expect(init.headers.Authorization).toBe(`Bearer ${bearerToken}`);
             expect(JSON.parse(init.body).method).toBe('listAgents');
 
             if (calls < 3) {
@@ -234,14 +244,14 @@ test.describe('harness brain lifecycle', () => {
             return {json: async () => ({ok: true, result: []})}
         };
 
-        await expect(awaitFleetReady({child, fetchFn, port: 18501, timeoutMs: 5000})).resolves.toBeUndefined();
+        await expect(awaitFleetReady({bearerToken, child, fetchFn, port: 18501, timeoutMs: 5000})).resolves.toBeUndefined();
         expect(calls).toBeGreaterThanOrEqual(3)
     });
 
     test('awaitFleetReady rejects when the transport child dies first', async () => {
         const
             child = createFakeChild(),
-            ready = awaitFleetReady({child, fetchFn: async () => { throw new Error('ECONNREFUSED') }, port: 18501, timeoutMs: 5000});
+            ready = awaitFleetReady({bearerToken, child, fetchFn: async () => { throw new Error('ECONNREFUSED') }, port: 18501, timeoutMs: 5000});
 
         child.exit(1);
         await expect(ready).rejects.toThrow(/fleet transport exited before ready/)
@@ -428,11 +438,15 @@ test.describe('harness brain lifecycle', () => {
         writeFileSync(path.join(dataDir, 'orchestrator-daemon.pid'), '8123', 'utf8');
 
         const live = await detectLiveBrain({
+            bearerToken,
             commandFn          : () => `node ${ORCHESTRATOR_ENTRY}`,
             fleetPort          : 18501,
             killFn             : () => true,
             orchestratorDataDir: dataDir,
-            probeFleetFn       : async () => true,
+            probeFleetFn       : async options => {
+                expect(options).toEqual({bearerToken, port: 18501});
+                return true
+            },
             probePortFn        : async () => true
         });
 
@@ -441,6 +455,7 @@ test.describe('harness brain lifecycle', () => {
         // A foreign HTTP server on the fleet port: occupied, but NOT the fleet protocol —
         // attach must not treat it as a reachable Brain surface.
         const squatted = await detectLiveBrain({
+            bearerToken,
             commandFn          : () => `node ${ORCHESTRATOR_ENTRY}`,
             fleetPort          : 18501,
             killFn             : () => true,
@@ -454,6 +469,7 @@ test.describe('harness brain lifecycle', () => {
 
         // A recycled pid running something else must NOT read as a live Brain.
         const foreign = await detectLiveBrain({
+            bearerToken,
             commandFn          : () => '/usr/bin/some-other-tool',
             fleetPort          : 18501,
             killFn             : () => true,
@@ -468,6 +484,7 @@ test.describe('harness brain lifecycle', () => {
 
         // No PID file at all.
         const missing = await detectLiveBrain({
+            bearerToken,
             fleetPort          : 18501,
             orchestratorDataDir: path.join(workDir, 'nowhere'),
             probeFleetFn       : async () => false,

--- a/test/playwright/unit/harness/fleetCapability.spec.mjs
+++ b/test/playwright/unit/harness/fleetCapability.spec.mjs
@@ -1,0 +1,250 @@
+import {expect, test} from '@playwright/test';
+import {
+    createFleetCapability,
+    projectPublicAgentIntent,
+    projectPublicCredentialIntent
+} from '../../../../harness/fleetCapability.mjs';
+
+const bearerToken = 'B'.repeat(43);
+
+test.describe('harness Fleet capability', () => {
+    test('checks sender trust before inspecting the request or touching credential, readiness, and network seams', async () => {
+        const
+            calls   = {brain: 0, credential: 0, fetch: 0},
+            request = new Proxy({}, {
+                get() {
+                    throw new Error('request inspected before sender trust')
+                },
+                ownKeys() {
+                    throw new Error('request enumerated before sender trust')
+                }
+            }),
+            capability = createFleetCapability({
+                bearerToken,
+                credentialProvider: async () => { calls.credential++; return 'never' },
+                fetchImpl         : async () => { calls.fetch++; throw new Error('network must stay dark') },
+                getBrain          : async () => { calls.brain++; return {fleetPort: 8083, up: true} },
+                isTrustedSender   : () => false
+            });
+
+        await expect(capability.request({sender: 'untrusted'}, request)).resolves.toEqual({
+            error: 'fleet: untrusted shell sender',
+            ok   : false
+        });
+        expect(calls).toEqual({brain: 0, credential: 0, fetch: 0})
+    });
+
+    test('rejects malformed, over-wide, and non-allowlisted requests before credential, readiness, or network access', async () => {
+        const
+            calls      = {brain: 0, credential: 0, fetch: 0},
+            capability = createFleetCapability({
+                bearerToken,
+                credentialProvider: async () => { calls.credential++; return 'never' },
+                fetchImpl         : async () => { calls.fetch++; throw new Error('network must stay dark') },
+                getBrain          : async () => { calls.brain++; return {fleetPort: 8083, up: true} },
+                isTrustedSender   : () => true
+            }),
+            invalidRequests = [
+                null,
+                [],
+                {method: 42},
+                {method: 'getManager'},
+                {extra: true, method: 'listAgents'},
+                {method: 'defineAgent', params: {githubUsername: '', harnessType: 'codex'}},
+                {method: 'connectTenant', params: {tenantUrl: ''}}
+            ];
+
+        for (const request of invalidRequests) {
+            const result = await capability.request({sender: 'trusted'}, request);
+
+            expect(result.ok, JSON.stringify(request)).toBe(false)
+        }
+
+        expect(calls).toEqual({brain: 0, credential: 0, fetch: 0})
+    });
+
+    test('rejects credential verbs locally when the shell has no credential provider', async () => {
+        const
+            calls      = {brain: 0, fetch: 0},
+            capability = createFleetCapability({
+                bearerToken,
+                fetchImpl      : async () => { calls.fetch++; throw new Error('network must stay dark') },
+                getBrain       : async () => { calls.brain++; return {fleetPort: 8083, up: true} },
+                isTrustedSender: () => true
+            });
+
+        await expect(capability.request({}, {
+            method: 'defineAgent',
+            params: {githubUsername: 'alice', harnessType: 'codex'}
+        })).resolves.toEqual({
+            error: "fleet: shell credential ingress unavailable for 'defineAgent'",
+            ok   : false
+        });
+        await expect(capability.request({}, {
+            method: 'connectTenant',
+            params: {tenantUrl: 'https://tenant.example.com'}
+        })).resolves.toEqual({
+            error: "fleet: shell credential ingress unavailable for 'connectTenant'",
+            ok   : false
+        });
+
+        expect(calls).toEqual({brain: 0, fetch: 0})
+    });
+
+    test('projects defineAgent onto public intent before obtaining and attaching the main-owned credential', async () => {
+        const
+            event              = {sender: 'trusted'},
+            mainCredential     = 'github_pat_main_owned',
+            rendererCredential = 'github_pat_renderer_smuggled',
+            calls              = {credential: [], fetch: []},
+            capability         = createFleetCapability({
+                bearerToken,
+                credentialProvider: async input => { calls.credential.push(input); return mainCredential },
+                fetchImpl         : async (url, init) => {
+                    calls.fetch.push({init, url});
+                    return {json: async () => ({ok: true, result: {id: 'agent-alice'}})}
+                },
+                getBrain       : async () => ({fleetPort: 9191, up: true}),
+                isTrustedSender: candidate => candidate === event
+            }),
+            result = await capability.request(event, {
+                method: 'defineAgent',
+                params: {
+                    args          : ['--unsafe'],
+                    command       : '/tmp/renderer-command',
+                    credential    : rendererCredential,
+                    env           : {TOKEN: rendererCredential},
+                    executablePath: '/tmp/renderer-binary',
+                    githubUsername: ' alice ',
+                    harnessType   : ' codex ',
+                    id            : ' agent-alice ',
+                    viewerIdentity: '@forged'
+                }
+            });
+
+        expect(result).toEqual({ok: true, result: {id: 'agent-alice'}});
+        expect(calls.credential).toEqual([{
+            event,
+            intent: {
+                githubUsername: 'alice',
+                harnessType   : 'codex',
+                id            : 'agent-alice'
+            },
+            method: 'defineAgent'
+        }]);
+        expect(calls.fetch).toHaveLength(1);
+        expect(calls.fetch[0].url).toBe('http://127.0.0.1:9191/fleet');
+        expect(calls.fetch[0].init.headers.Authorization).toBe(`Bearer ${bearerToken}`);
+
+        const outbound = JSON.parse(calls.fetch[0].init.body);
+
+        expect(outbound).toEqual({
+            method: 'defineAgent',
+            params: {
+                credential    : mainCredential,
+                githubUsername: 'alice',
+                harnessType   : 'codex',
+                id            : 'agent-alice'
+            }
+        });
+        expect(JSON.stringify(outbound)).not.toContain(rendererCredential);
+        expect(JSON.stringify(outbound)).not.toContain('renderer-command');
+        expect(projectPublicAgentIntent({
+            githubUsername: ' alice ',
+            harnessType   : ' codex ',
+            id            : ' agent-alice '
+        })).toEqual({
+            githubUsername: 'alice',
+            harnessType   : 'codex',
+            id            : 'agent-alice'
+        })
+    });
+
+    test('projects connectTenant onto tenantUrl only before attaching the provider credential', async () => {
+        const
+            event          = {sender: 'trusted'},
+            mainCredential = 'tenant_pat_main_owned',
+            calls          = {credential: [], fetch: []},
+            capability     = createFleetCapability({
+                bearerToken,
+                credentialProvider: async input => { calls.credential.push(input); return mainCredential },
+                fetchImpl         : async (url, init) => {
+                    calls.fetch.push({init, url});
+                    return {json: async () => ({ok: true, result: {status: 'connected'}})}
+                },
+                getBrain       : async () => ({fleetPort: 8083, up: true}),
+                isTrustedSender: candidate => candidate === event
+            }),
+            result = await capability.request(event, {
+                method: 'connectTenant',
+                params: {
+                    credential    : 'tenant_pat_renderer_smuggled',
+                    tenantUrl     : ' https://tenant.example.com/agentos/ ',
+                    viewerIdentity: '@forged'
+                }
+            });
+
+        expect(result).toEqual({ok: true, result: {status: 'connected'}});
+        expect(calls.credential).toEqual([{
+            event,
+            intent: {tenantUrl: 'https://tenant.example.com/agentos/'},
+            method: 'connectTenant'
+        }]);
+        expect(calls.fetch).toHaveLength(1);
+        expect(JSON.parse(calls.fetch[0].init.body)).toEqual({
+            method: 'connectTenant',
+            params: {
+                credential: mainCredential,
+                tenantUrl : 'https://tenant.example.com/agentos/'
+            }
+        });
+        expect(projectPublicCredentialIntent('connectTenant', {
+            credential: 'discard-me',
+            tenantUrl : ' https://tenant.example.com/agentos/ '
+        })).toEqual({tenantUrl: 'https://tenant.example.com/agentos/'})
+    });
+
+    test('rejects a canceled credential before Brain readiness and network access', async () => {
+        const
+            calls      = {brain: 0, fetch: 0},
+            capability = createFleetCapability({
+                bearerToken,
+                credentialProvider: async () => null,
+                fetchImpl         : async () => { calls.fetch++; throw new Error('network must stay dark') },
+                getBrain          : async () => { calls.brain++; return {fleetPort: 8083, up: true} },
+                isTrustedSender   : () => true
+            });
+
+        await expect(capability.request({}, {
+            method: 'defineAgent',
+            params: {githubUsername: 'alice', harnessType: 'codex'}
+        })).resolves.toEqual({
+            error: "fleet: shell credential ingress canceled for 'defineAgent'",
+            ok   : false
+        });
+        expect(calls).toEqual({brain: 0, fetch: 0})
+    });
+
+    test('censuses both the Fleet bearer and provider credential out of response envelopes', async () => {
+        const mainCredential = 'github_pat_main_owned';
+
+        for (const reflectedSecret of [bearerToken, mainCredential]) {
+            const capability = createFleetCapability({
+                    bearerToken,
+                    credentialProvider: async () => mainCredential,
+                    fetchImpl         : async () => ({
+                        json: async () => ({ok: false, error: `upstream reflected ${reflectedSecret}`})
+                    }),
+                    getBrain       : async () => ({fleetPort: 8083, up: true}),
+                    isTrustedSender: () => true
+                }),
+                result = await capability.request({}, {
+                    method: 'defineAgent',
+                    params: {githubUsername: 'alice', harnessType: 'codex'}
+                });
+
+            expect(result).toEqual({error: 'fleet: secret-bearing response rejected', ok: false});
+            expect(JSON.stringify(result)).not.toContain(reflectedSecret)
+        }
+    })
+});

--- a/test/playwright/unit/harness/preload.spec.mjs
+++ b/test/playwright/unit/harness/preload.spec.mjs
@@ -1,0 +1,87 @@
+import {expect, test} from '@playwright/test';
+import {readFile}     from 'node:fs/promises';
+import vm             from 'node:vm';
+
+const preloadPath = new URL('../../../../harness/preload.cjs', import.meta.url);
+const mainPath    = new URL('../../../../harness/main.mjs', import.meta.url);
+
+/**
+ * @summary Executes the CommonJS preload against capability-shaped Electron mocks without booting
+ * Electron. Timers and DOM diagnostics are retained as inert seams; the test owns only the exposed
+ * bridge contract.
+ * @returns {Promise<Object>}
+ */
+async function loadPreload() {
+    const
+        invokes = [],
+        exposed = {},
+        source  = await readFile(preloadPath, 'utf8');
+
+    vm.runInNewContext(source, {
+        clearInterval() {},
+        Date,
+        document: {
+            querySelector() { return null },
+            querySelectorAll() { return [] }
+        },
+        process: {versions: {electron: '42.0.0'}},
+        require(name) {
+            if (name !== 'electron') throw new Error(`unexpected preload dependency: ${name}`);
+
+            return {
+                contextBridge: {
+                    exposeInMainWorld(name, value) {
+                        exposed.name  = name;
+                        exposed.value = value
+                    }
+                },
+                ipcRenderer: {
+                    invoke(...args) {
+                        invokes.push(args);
+                        return Promise.resolve({ok: true, result: []})
+                    },
+                    send() {}
+                }
+            }
+        },
+        setInterval() { return 1 },
+        window: {addEventListener() {}}
+    });
+
+    return {exposed, invokes}
+}
+
+test.describe('Electron harness preload capability', () => {
+    test('exposes one Fleet promise capability and no raw transport or secret facts', async () => {
+        const
+            {exposed, invokes} = await loadPreload(),
+            request            = {method: 'listAgents', params: {}};
+
+        expect(exposed.name).toBe('neoShell');
+        expect(Object.keys(exposed.value).sort()).toEqual(['fleetRequest', 'shellVersion']);
+        expect(exposed.value.shellVersion).toBe('42.0.0');
+        expect(exposed.value).not.toHaveProperty('bearerToken');
+        expect(exposed.value).not.toHaveProperty('defineFleetAgent');
+        expect(exposed.value).not.toHaveProperty('endpoint');
+        expect(exposed.value).not.toHaveProperty('ipcRenderer');
+        expect(exposed.value).not.toHaveProperty('node');
+
+        await expect(exposed.value.fleetRequest(request)).resolves.toEqual({ok: true, result: []});
+        expect(invokes).toEqual([['fleet-request', request]])
+    })
+
+    test('keeps credential capture in the one main-owned channel with no renderer input surface', async () => {
+        const
+            mainSource    = await readFile(mainPath, 'utf8'),
+            preloadSource = await readFile(preloadPath, 'utf8');
+
+        expect(preloadSource).not.toContain('window.prompt');
+        expect(preloadSource).not.toContain('fleet-define-agent');
+        expect(mainSource).not.toContain('<input');
+        expect(mainSource).not.toContain("ipcMain.handle('fleet-define-agent'");
+        expect(mainSource.match(/ipcMain\.handle\('fleet-request'/g)).toHaveLength(1);
+        expect(mainSource).toContain("webContents.on('before-input-event'");
+        expect(mainSource).toContain('inputEvent.preventDefault()');
+        expect(mainSource).toContain('clipboard.readText()')
+    })
+});


### PR DESCRIPTION
Resolves #15537

Completes the private Electron Fleet boundary as one product slice: the shell owns authorization, readiness, and packaged credential ingress; the Body and App Worker submit curated intent without receiving bearer or PAT bytes; direct-browser mode remains a separate supported topology.

Evidence: L2 (82 focused unit tests, unified integration coverage, and static secret-boundary gates) → L3 required (AC9 headed Electron lifecycle on a healthy macOS host). Residual: AC9 [#15537].

## Deltas from ticket

- The shell credential surface avoids renderer DOM input ownership entirely. Electron main consumes keyboard and clipboard events, publishes only character count, and forwards the credential directly to Brain after capability admission.
- Packaged credential-bearing methods derive their public projection from the canonical Fleet wire authority; renderer command, args, env, executable path, viewer, and secret fields are structurally dropped.
- The same retained bearer and viewer identity now govern child launch, incumbent reuse, and readiness. A generic occupied port never becomes Fleet readiness.
- No scope expansion into Fleet business verbs, credential persistence policy, cloud authentication, or window ownership.

## Test Evidence

- Fleet capability, preload, readiness, App Worker composition, shell credential flows, and direct-browser preservation: npm run test-unit -- brain fleetCapability preload installFleetBridge addAgentFlow Accounts app.spec --workers=1 --reporter=dot — 82 passed.
- Unified integration surface: npm run test-integration-unified — 5 passed, 45 environment-gated skips.
- Source gates: whitespace, shorthand, AiConfig mutation, JSDoc types, ticket archaeology, block alignment, parse, and staged diff checks passed.
- Headed harness surface: npm --prefix harness run smoke:brain was attempted. Electron aborted inside macOS ApplicationServices RegisterApplication before Neo code or harness output, so this PR does not claim an L3 headed receipt.

## Post-Merge Validation

- [ ] On a healthy macOS host, run npm --prefix harness run witness:lifecycle and record brainUp true while retaining same-window, same-renderer, zero-visible, restore, and exact-once teardown receipts.
- [ ] Run npm --prefix harness run smoke:brain and confirm the primary window, same-origin popup, post-popup-close primary request, real off-origin BrowserWindow rejection, fresh App Worker receipt, and bearer census.
- [ ] Append the L3 receipt to #15537 and clear the AC9 deferred annotation.

## Commits

- f9f38d34b2 — authenticate Fleet readiness from Electron main.
- 30ca1bcd33 — complete the preload capability, main security owner, App Worker composition, shell credential ingress, popup/off-origin smoke, and regression battery.

## Evolution

The original credential-surface sketch assumed a browser prompt. Electron does not provide that API, and a renderer input would violate the ticket boundary. The implementation therefore moved keystroke and clipboard custody into Electron main while keeping the rendered modal static and secret-free.

## Review Routing

Review role: security-reviewer — @neo-kimi-phoebe

Capacity rebind (2026-07-19): Ada precommitted and specified the independent ADR 0034 §2.3.4–.6 security audit, but her Claude seat is unavailable until Friday. The ticket requires a security-focused cross-family seat, not a reviewer by identity. Phoebe now owns a fresh independent Kimi-family pass against the same five public falsifiers: real off-origin sender; zero-network rejection; smuggle-and-drop projection; admitted-plus-rejected secret census; independent wrong-bearer/foreign-listener readiness. Vega’s structural COMMENT is context, not merge approval.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session ad71d4c3-3e37-4a17-8df7-8415509def84.
