### PR TITLE
feat(dashboard): compose live vessel conversion (#15395)

### DIFF
--- a/apps/agentos/childapps/dockdemo/neo-config.json
+++ b/apps/agentos/childapps/dockdemo/neo-config.json
@@ -3,7 +3,7 @@
     "basePath"        : "../../../../",
     "environment"     : "development",
     "mainPath"        : "./Main.mjs",
-    "mainThreadAddons": ["DockFlip", "DragDrop", "Navigator", "Stylesheet"],
+    "mainThreadAddons": ["DockFlip", "DragDrop", "Navigator", "Stylesheet", "WindowPosition"],
     "themes"          : ["neo-theme-neo-dark", "neo-theme-neo-light"],
     "useAiClient"     : true,
     "useSharedWorkers": true

--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -345,6 +345,11 @@ class DemoBWorkspace extends Container {
         me.dockModel        = DockZoneModel.clone(initialDocument);
         me.popupDocument    = DemoBWorkspace.createPopupDocument();
 
+        // Live-rect authority: every Demo-B render target publishes resize geometry into
+        // manager.Window. Movement-only snapshots make a post-resize conversion compare against
+        // stale extents, violating the metric before threshold calibration even begins.
+        Neo.main.addon.WindowPosition?.setConfigs({observeResize: true, windowId: me.windowId});
+
         // Both workspaces register under their STABLE semantic ids — the seams read/write the
         // live owner fields, so registry resolution always answers with committed truth.
         me.workspaceSet = createDockWorkspaceSet();
@@ -2813,6 +2818,10 @@ class DemoBWorkspace extends Container {
 
         if (params.get('hostId') !== me.id) return;
 
+        // Geometry-ready is part of child admission: do not publish the connected vessel to any
+        // ownership branch until its Main realm has installed resize observation.
+        await Neo.main.addon.WindowPosition?.setConfigs({observeResize: true, windowId});
+
         if (workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID) {
             if (flow !== 'workspace-target') return;
 
@@ -3399,10 +3408,30 @@ class DemoBWorkspace extends Container {
             onDockZoneDocumentChange: nextDocument => me.onWorkspaceDocumentChange(workspaceId, nextDocument),
             resolveComponentRef     : resolveComponentRef
                 || ((componentRef, item, itemId) => me.resolvePane(itemId, item)),
-            resolveRevealComponentRef: (componentRef, item, itemId) => me.resolvePane(itemId, item),
+            resolveVesselConversionSourceRect: data => me.resolveVesselConversionSourceRect(data),
+            resolveRevealComponentRef        : (componentRef, item, itemId) => me.resolvePane(itemId, item),
             workspaceId,
             ...(tearOut ? me.tearOutHandlers : null)
         })
+    }
+
+    /**
+     * @summary Resolves one tear-out item's exact live vessel rect for conversion sampling.
+     *
+     * Gesture admission owns `tearOutConnects`; terminal adoption owns `tearOutPanes`. Both race
+     * orders retain the same runtime window identity, and only that identity may select the
+     * manager-owned live rect. The logical drag proxy is intentionally ignored.
+     * @param {Object} data
+     * @param {String|null} data.itemId
+     * @returns {Object|null}
+     * @protected
+     */
+    resolveVesselConversionSourceRect({itemId}) {
+        let me       = this,
+            windowId = me.tearOutConnects[itemId]?.windowId ?? me.tearOutPanes[itemId]?.windowId,
+            rect     = windowId && Neo.manager?.Window?.get(windowId)?.innerRect;
+
+        return rect && {height: rect.height, width: rect.width, x: rect.x, y: rect.y}
     }
 
     /**

--- a/learn/agentos/decisions/0029-harness-docking-design.md
+++ b/learn/agentos/decisions/0029-harness-docking-design.md
@@ -172,6 +172,17 @@ What `DragCoordinator` consumes as an informal duck-type becomes the named, mana
 | `suspendWindowDrag(widgetName)` | Suspend the source's drag embodiment when a remote target engages (mid-gesture handoff: the source's proxy/popup yields while a target window hosts the hover) and before a native-window drop commits. Awaited on the commit path. |
 | `resumeWindowDrag(widgetName, proxyRect)` | Resume the source's drag embodiment when the drag leaves all remote targets back into the void (re-open the popup/proxy at the supplied rect). |
 
+**Source transition-policy hook (optional):**
+
+| Member | Obligation |
+|---|---|
+| `resolveRemoteDragTransition(frame)` | Synchronously decide whether the current stable claim may engage, remain visually retained, and commit. `frame` carries `{draggedItem, logicalSourceRect, now, pointerInTarget, targetId, targetRect, targetWindowId}`: the coordinator owns claim truth, the pointer-follow destination, and the live target rect; the source owns resolution of its exact live dragged-vessel rect and any conversion sensor. Return `null` to preserve the legacy path, or exactly `{engage: Boolean, retain: Boolean, commitEligible: Boolean}`. A throw, Promise, or malformed record fails closed. `retain` may preserve visual hover after a raw miss, but `commitEligible` MUST drop immediately. |
+
+The optional policy is source-owned because the source alone can map the dragged semantic item to
+its physical vessel identity. For projected dock trees, that mapping rides a synchronous,
+clone-safe owner listener; function configs do not enter the serialized SortZone config. The
+logical proxy rect is never a substitute for the live vessel rect used by dual-window metrics.
+
 **Native-OS-window participation hooks (optional class — only for surfaces whose items embody as native popup windows, the #13025/#13028 lineage; the coordinator invokes them `?.`-guarded):**
 
 | Member | Obligation |

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -319,12 +319,21 @@ class DockLayoutAdapter extends Base {
      * re-projection loop) with no error surfacing anywhere.
      * @param {Object} model
      * @param {Object} [options={}]
+     * @param {Boolean} [options.enableVesselConversion=false] Arms the optional source-owned
+     *     conversion policy. Consumers keep this false until their physical lifecycle is ready.
      * @param {Boolean} [options.enableStackDrag=false] Decorate the model-resolved stack root
      *     with one runtime-only whole-stack grip and arm its existing dock SortZone.
+     * @param {Function} [options.resolveVesselConversionSourceRect] Synchronous owner resolver for
+     *     the exact dragged vessel's live global inner rect; threaded through a clone-safe listener.
      * @param {Function} [options.resolveComponentRef]
      * @param {Function} [options.resolveRevealComponentRef] Durable resolver retained by edge rails.
      * @param {Object|null} [options.tabInsertDescriptor] Runtime-only normalized `addTab`
      * correlation consumed by this projection; never part of `model`.
+     * @param {Number} [options.vesselConversionConvertThreshold] Provisional convert-in threshold;
+     *     omitted values leave the SortZone default intact.
+     * @param {Number} [options.vesselConversionPointerExitGraceMs] Binding-owned visual-only grace;
+     *     commit eligibility still drops on the first raw claim miss.
+     * @param {Number} [options.vesselConversionRevertThreshold] Provisional convert-out threshold.
      * @returns {Object}
      * @static
      */
@@ -358,25 +367,30 @@ class DockLayoutAdapter extends Base {
             // tab.Container. The HOST owns vessel acquisition + the `detachItem` commit at the
             // terminal; the projection only threads the opt-in + the closure seams. Absent = fully
             // in-window, the unchanged default.
-            enableDockTearOut        : options.enableDockTearOut === true,
-            items                    : model.items || {},
-            nodes                    : model.nodes,
-            onDockCrossZoneDragCancel: options.onDockCrossZoneDragCancel,
-            onDockCrossZoneDragMove  : options.onDockCrossZoneDragMove,
-            onDockCrossZoneDrop      : options.onDockCrossZoneDrop,
-            onDockStackDragTerminal  : options.onDockStackDragTerminal,
-            onDockTearOutCancel      : options.onDockTearOutCancel,
-            onDockTearOutEntry       : options.onDockTearOutEntry,
-            onDockTearOutExit        : options.onDockTearOutExit,
-            onDockTearOutTerminal    : options.onDockTearOutTerminal,
-            onDockZoneDocumentChange : options.onDockZoneDocumentChange,
-            resolveComponentRef      : options.resolveComponentRef || (() => null),
-            resolveRevealComponentRef: options.resolveRevealComponentRef
+            enableDockTearOut                : options.enableDockTearOut === true,
+            enableVesselConversion           : options.enableVesselConversion === true,
+            items                            : model.items || {},
+            nodes                            : model.nodes,
+            onDockCrossZoneDragCancel        : options.onDockCrossZoneDragCancel,
+            onDockCrossZoneDragMove          : options.onDockCrossZoneDragMove,
+            onDockCrossZoneDrop              : options.onDockCrossZoneDrop,
+            onDockStackDragTerminal          : options.onDockStackDragTerminal,
+            onDockTearOutCancel              : options.onDockTearOutCancel,
+            onDockTearOutEntry               : options.onDockTearOutEntry,
+            onDockTearOutExit                : options.onDockTearOutExit,
+            onDockTearOutTerminal            : options.onDockTearOutTerminal,
+            onDockZoneDocumentChange         : options.onDockZoneDocumentChange,
+            resolveComponentRef              : options.resolveComponentRef || (() => null),
+            resolveVesselConversionSourceRect: options.resolveVesselConversionSourceRect,
+            resolveRevealComponentRef        : options.resolveRevealComponentRef
                 || options.resolveComponentRef
                 || (() => null),
             stackDragNodeId,
-            tabInsertDescriptor: options.tabInsertDescriptor ?? null,
-            workspaceId        : options.workspaceId ?? null
+            tabInsertDescriptor               : options.tabInsertDescriptor ?? null,
+            vesselConversionConvertThreshold  : options.vesselConversionConvertThreshold,
+            vesselConversionPointerExitGraceMs: options.vesselConversionPointerExitGraceMs,
+            vesselConversionRevertThreshold   : options.vesselConversionRevertThreshold,
+            workspaceId                       : options.workspaceId ?? null
         });
 
         config.cls = [...new Set([...(config.cls || []), 'neo-dashboard'])];
@@ -817,9 +831,19 @@ class DockLayoutAdapter extends Base {
                     // boundary-exit grammar reads the LIVE proxy rect, and while the proxy is clamped
                     // to the tab-strip boundary the intersection ratio never drops — the exit cannot
                     // fire. The tear-out gesture is the proxy LEAVING the strip, so it must overdrag.
-                    allowOverdrag     : context.enableDockTearOut === true,
-                    enableProxyToPopup: context.enableDockTearOut === true,
-                    sortGroup         : context.crossWindowSortGroup
+                    allowOverdrag         : context.enableDockTearOut === true,
+                    enableVesselConversion: context.enableVesselConversion === true,
+                    enableProxyToPopup    : context.enableDockTearOut === true,
+                    sortGroup             : context.crossWindowSortGroup,
+                    ...(Number.isFinite(context.vesselConversionConvertThreshold)
+                        ? {vesselConversionConvertThreshold: context.vesselConversionConvertThreshold}
+                        : null),
+                    ...(Number.isFinite(context.vesselConversionPointerExitGraceMs)
+                        ? {vesselConversionPointerExitGraceMs: context.vesselConversionPointerExitGraceMs}
+                        : null),
+                    ...(Number.isFinite(context.vesselConversionRevertThreshold)
+                        ? {vesselConversionRevertThreshold: context.vesselConversionRevertThreshold}
+                        : null)
                 }
             },
             items    : projectedItems,
@@ -839,6 +863,12 @@ class DockLayoutAdapter extends Base {
                 // the generic SortZone. The host composes its vessel-park policy at this closure;
                 // no app callback enters sortZoneConfig or committed dock state.
                 dockStackDragTerminal: data => context.onDockStackDragTerminal?.(data),
+                // Clone-safe live-vessel authority: the SortZone mutates this synchronous request
+                // record; the workspace closure resolves its exact item→window join. No function
+                // enters sortZoneConfig and the generic coordinator remains dock-blind.
+                dockVesselConversionSourceRectRequest: data => {
+                    data.sourceRect = context.resolveVesselConversionSourceRect?.(data) ?? null
+                },
                 // Tear-out gesture seams (§2.8): the zone re-fires the inherited boundary events here.
                 // Cancel retires the host's vessel with zero model mutation; entry is a resumed
                 // in-window gesture (vessel closes, no outcome); exit is where the host acquires its

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -1,4 +1,5 @@
-import TabHeaderSortZone from '../draggable/tab/header/toolbar/SortZone.mjs';
+import {createVesselConversionSensor} from './DockVesselConversion.mjs';
+import TabHeaderSortZone              from '../draggable/tab/header/toolbar/SortZone.mjs';
 
 /**
  * @class Neo.dashboard.DockTabSortZone
@@ -93,7 +94,34 @@ class DockTabSortZone extends TabHeaderSortZone {
          * in-window. Threaded by {@link Neo.dashboard.DockLayoutAdapter} (`crossWindowSortGroup`).
          * @member {String|null} sortGroup=null
          */
-        sortGroup: null
+        sortGroup: null,
+        /**
+         * Opts this source into the dual-window conversion decision. The coordinator remains
+         * dock-blind: it offers stable-claim frames, while this zone owns the sensor and decides
+         * whether a remote preview may engage. Disabled is byte-identical to the pre-conversion
+         * coordinator path.
+         * @member {Boolean} enableVesselConversion=false
+         */
+        enableVesselConversion: false,
+        /**
+         * Provisional min-axis overlap required to enter the existing HOVERING_CLAIM transition.
+         * Production opt-in remains off until the physical park/re-show lifecycle is ready and
+         * headed calibration replaces this placeholder.
+         * @member {Number} vesselConversionConvertThreshold=0.55
+         */
+        vesselConversionConvertThreshold: 0.55,
+        /**
+         * Provisional min-axis overlap below which the conversion reverts. See the convert
+         * threshold's calibration gate above.
+         * @member {Number} vesselConversionRevertThreshold=0.35
+         */
+        vesselConversionRevertThreshold: 0.35,
+        /**
+         * Binding-owned raw-claim miss grace. During this interval the visual preview is retained,
+         * but commit eligibility drops immediately; a release can never land on a stale claim.
+         * @member {Number} vesselConversionPointerExitGraceMs=0
+         */
+        vesselConversionPointerExitGraceMs: 0
     }
 
     /**
@@ -133,6 +161,52 @@ class DockTabSortZone extends TabHeaderSortZone {
      * @protected
      */
     dragCoordinator = null
+
+    /**
+     * One pure conversion sensor per source zone, reset at every gesture terminal.
+     * @member {Object|null} vesselConversionSensor=null
+     * @protected
+     */
+    vesselConversionSensor = null
+
+    /**
+     * Stable identity of the target whose geometry owns the current sensor state.
+     * @member {String|null} vesselConversionTargetId=null
+     * @protected
+     */
+    vesselConversionTargetId = null
+
+    /**
+     * Last live target rect for a bounded raw-claim miss. Copied per frame so mutable manager
+     * rectangles cannot rewrite an already-made decision.
+     * @member {Object|null} vesselConversionTargetRect=null
+     * @protected
+     */
+    vesselConversionTargetRect = null
+
+    /**
+     * First raw-claim miss timestamp for the active converted target.
+     * @member {Number|null} vesselConversionPointerMissedAt=null
+     * @protected
+     */
+    vesselConversionPointerMissedAt = null
+
+    /**
+     * Last exact live dragged-vessel rect resolved by the source owner. This is the geometry the
+     * conversion sensor measures; a proxy or requested birth size can never substitute for it.
+     * @member {Object|null} vesselConversionSourceRect=null
+     * @protected
+     */
+    vesselConversionSourceRect = null
+
+    /**
+     * Last logical pointer-follow rect supplied by the coordinator. This is deliberately distinct
+     * from {@link #vesselConversionSourceRect}: conversion measures the exact live vessel, while
+     * later re-show choreography needs the pointer-owned logical destination.
+     * @member {Object|null} vesselConversionLogicalRect=null
+     * @protected
+     */
+    vesselConversionLogicalRect = null
 
     /**
      * Warms the cross-window {@link Neo.manager.DragCoordinator} OFF the drag hot path: a `sortGroup`
@@ -212,6 +286,211 @@ class DockTabSortZone extends TabHeaderSortZone {
 
         me.dragProxy && (me.dragProxy.style = {opacity: 1});
         me.isWindowDragging = false
+    }
+
+    /**
+     * @summary Ends a non-terminal conversion because its target disappeared.
+     *
+     * Unlike {@link #resetVesselConversion}, this path emits the sensor's convert-out seam before
+     * forgetting state, so the physical-lifecycle owner receives exactly one convert-out seam when
+     * a target unregisters mid-gesture. Gesture terminals use the silent reset instead: their
+     * outcome choreography owns disposition and must not be double-driven by a synthetic reversion.
+     */
+    cancelVesselConversion() {
+        let me = this;
+
+        if (me.vesselConversionSensor?.converted) {
+            me.vesselConversionSensor.sample({
+                pointerInTarget: false,
+                sourceRect     : me.vesselConversionSourceRect,
+                targetRect     : me.vesselConversionTargetRect
+            })
+        }
+
+        me.resetVesselConversion()
+    }
+
+    /**
+     * @summary Returns the source-owned conversion sensor, creating it lazily for an active drag.
+     * @returns {Object}
+     * @protected
+     */
+    getVesselConversionSensor() {
+        let me = this;
+
+        return me.vesselConversionSensor ??= createVesselConversionSensor({
+            convertThreshold: me.vesselConversionConvertThreshold,
+            revertThreshold : me.vesselConversionRevertThreshold,
+            onConvertIn(record) {
+                let itemId = me.dragComponent?.dockItemId ?? me.dockItemIds?.[me.startIndex] ?? null;
+
+                me.owner?.up?.()?.fire('dockVesselConversionIn', {
+                    itemId,
+                    logicalRect : me.vesselConversionLogicalRect && {...me.vesselConversionLogicalRect},
+                    record,
+                    sortZone    : me,
+                    sourceNodeId: me.dockSourceNodeId,
+                    targetId    : me.vesselConversionTargetId
+                })
+            },
+            onConvertOut(record) {
+                let itemId = me.dragComponent?.dockItemId ?? me.dockItemIds?.[me.startIndex] ?? null;
+
+                me.owner?.up?.()?.fire('dockVesselConversionOut', {
+                    itemId,
+                    logicalRect : me.vesselConversionLogicalRect && {...me.vesselConversionLogicalRect},
+                    record,
+                    sortZone    : me,
+                    sourceNodeId: me.dockSourceNodeId,
+                    targetId    : me.vesselConversionTargetId
+                })
+            }
+        })
+    }
+
+    /**
+     * @summary Resolves the exact live tear-out vessel rect through the clone-safe owner seam.
+     *
+     * A projected SortZone cannot carry a function config through the component clone boundary.
+     * The zone therefore fires a synchronous request on its tab.Container; the workspace-owned
+     * listener resolves the current item→vessel identity and writes `sourceRect`. Missing,
+     * thenable, degenerate, or non-finite answers fail closed. The coordinator's logical proxy rect
+     * is context only and can never become the conversion denominator.
+     * @param {Object} data
+     * @param {Object} data.draggedItem
+     * @param {Object|null} data.logicalRect
+     * @returns {Object|null}
+     * @protected
+     */
+    resolveVesselConversionSourceGeometry({draggedItem, logicalRect}) {
+        let me      = this,
+            itemId  = draggedItem?.dockItemId ?? me.dockItemIds?.[me.startIndex] ?? null,
+            request = {draggedItem, itemId, logicalRect, sourceRect: null},
+            rect;
+
+        me.owner?.up?.()?.fire('dockVesselConversionSourceRectRequest', request);
+        rect = request.sourceRect;
+
+        if (
+            typeof rect?.then === 'function' ||
+            !['x', 'y', 'width', 'height'].every(key => Number.isFinite(rect?.[key])) ||
+            rect.width <= 0 || rect.height <= 0
+        ) {
+            return null
+        }
+
+        return {height: rect.height, width: rect.width, x: rect.x, y: rect.y}
+    }
+
+    /**
+     * @summary Resolves one stable-claim frame into remote-preview and commit eligibility.
+     *
+     * This is the production binding for {@link Neo.dashboard.DockVesselConversion}. The manager
+     * supplies the logical pointer-follow rect plus live target geometry after deterministic claim
+     * arbitration; this dock-owned source resolves its exact live vessel rect, samples the pure
+     * sensor, and returns a synchronous policy record. Raw pointer loss
+     * drops commit eligibility immediately. A bounded grace may retain the already-rendered hover
+     * without feeding `pointerInTarget=false` into the deliberately undamped sensor until expiry.
+     * Target identity is part of the binding (the sensor itself is intentionally identity-free):
+     * switching A→B first reverts A, then B must clear its own geometry threshold.
+     * @param {Object} frame
+     * @param {Object} frame.draggedItem
+     * @param {Number} frame.now
+     * @param {Boolean} frame.pointerInTarget
+     * @param {Object} frame.logicalSourceRect
+     * @param {String|null} frame.targetId
+     * @param {Object|null} frame.targetRect
+     * @returns {{commitEligible: Boolean, engage: Boolean, retain: Boolean}|null} `null` keeps the
+     *     legacy coordinator path when conversion is disabled or the source is not in a window drag.
+     */
+    resolveRemoteDragTransition({draggedItem, logicalSourceRect, now=Date.now(), pointerInTarget, targetId, targetRect} = {}) {
+        let me = this;
+
+        if (!me.enableVesselConversion || !me.isWindowDragging) {
+            return null
+        }
+
+        if (!draggedItem) {
+            return {commitEligible: false, engage: false, retain: false}
+        }
+
+        let liveSourceRect = me.resolveVesselConversionSourceGeometry({draggedItem, logicalRect: logicalSourceRect}),
+            grace          = Number.isFinite(me.vesselConversionPointerExitGraceMs)
+                ? Math.max(0, me.vesselConversionPointerExitGraceMs)
+                : 0;
+
+        me.vesselConversionLogicalRect = logicalSourceRect ? {...logicalSourceRect} : null;
+
+        if (!liveSourceRect) {
+            me.cancelVesselConversion();
+            return {commitEligible: false, engage: false, retain: false}
+        }
+
+        me.vesselConversionSourceRect = liveSourceRect;
+
+        let sensor = me.getVesselConversionSensor();
+
+        if (pointerInTarget === true && targetId != null && targetRect) {
+            if (me.vesselConversionTargetId != null && me.vesselConversionTargetId !== targetId) {
+                sensor.converted && sensor.sample({
+                    pointerInTarget: false,
+                    sourceRect     : me.vesselConversionSourceRect,
+                    targetRect     : me.vesselConversionTargetRect
+                });
+                sensor.reset()
+            }
+
+            me.vesselConversionPointerMissedAt = null;
+            me.vesselConversionTargetId        = targetId;
+            me.vesselConversionTargetRect      = {...targetRect};
+
+            let record = sensor.sample({
+                pointerInTarget: true,
+                sourceRect     : me.vesselConversionSourceRect,
+                targetRect     : me.vesselConversionTargetRect
+            });
+
+            return {commitEligible: record.converted, engage: record.converted, retain: false}
+        }
+
+        if (!sensor.converted) {
+            me.vesselConversionPointerMissedAt = null;
+            return {commitEligible: false, engage: false, retain: false}
+        }
+
+        me.vesselConversionPointerMissedAt ??= now;
+
+        if (now - me.vesselConversionPointerMissedAt < grace) {
+            let record = sensor.sample({
+                pointerInTarget: true,
+                sourceRect     : me.vesselConversionSourceRect,
+                targetRect     : me.vesselConversionTargetRect
+            });
+
+            return {commitEligible: false, engage: record.converted, retain: record.converted}
+        }
+
+        sensor.sample({
+            pointerInTarget: false,
+            sourceRect     : me.vesselConversionSourceRect,
+            targetRect     : me.vesselConversionTargetRect
+        });
+
+        return {commitEligible: false, engage: false, retain: false}
+    }
+
+    /**
+     * @summary Silently clears all conversion binding state at a gesture terminal.
+     */
+    resetVesselConversion() {
+        let me = this;
+
+        me.vesselConversionSensor?.reset();
+        me.vesselConversionLogicalRect     = null;
+        me.vesselConversionPointerMissedAt = null;
+        me.vesselConversionSourceRect      = null;
+        me.vesselConversionTargetId        = null;
+        me.vesselConversionTargetRect      = null
     }
 
     /**
@@ -297,6 +576,8 @@ class DockTabSortZone extends TabHeaderSortZone {
      */
     async onDragStart(data) {
         let me = this;
+
+        me.resetVesselConversion?.();
 
         if (me.isStackHandleDrag?.(data)) {
             let pathIds     = new Set((data.path || []).map(node => node.id).filter(Boolean)),
@@ -485,7 +766,8 @@ class DockTabSortZone extends TabHeaderSortZone {
                 me.dragComponent   = null;
                 me.dragElement     = null;
                 me.stackDragActive = false;
-                me.startIndex      = -1
+                me.startIndex      = -1;
+                me.resetVesselConversion?.()
             }
 
             if (commitError) {
@@ -529,7 +811,11 @@ class DockTabSortZone extends TabHeaderSortZone {
             tabContainer.fire('dockCrossZoneDrop', {clientX, clientY, itemId, sourceNodeId: me.dockSourceNodeId})
         }
 
-        await super.processDragEnd(data)
+        try {
+            await super.processDragEnd(data)
+        } finally {
+            me.resetVesselConversion?.()
+        }
     }
 
     /**
@@ -597,6 +883,15 @@ class DockTabSortZone extends TabHeaderSortZone {
      */
     resolveDragCoordinator() {
         return this._dragCoordinatorPromise ??= import('../manager/DragCoordinator.mjs').then(module => this.dragCoordinator = module.default)
+    }
+
+    /**
+     * Resets the pure binding before the ordinary SortZone teardown.
+     * @param {...*} args
+     */
+    destroy(...args) {
+        this.resetVesselConversion();
+        super.destroy(...args)
     }
 }
 

--- a/src/main/addon/WindowPosition.mjs
+++ b/src/main/addon/WindowPosition.mjs
@@ -113,27 +113,42 @@ class WindowPosition extends Base {
      */
     checkMovement() {
         let me                      = this,
-            {Manager}               = Neo.worker,
             win                     = window,
-            {screenLeft, screenTop} = win,
-            winData;
+            {screenLeft, screenTop} = win;
 
         if (me.screenLeft !== screenLeft || me.screenTop !== screenTop) {
-            winData = Neo.Main.getWindowData();
-
             me.adjustWindowPositions && me.adjustPositions();
 
-            Manager.sendMessage('app', {
-                action: 'windowPositionChange',
-                data  : {
-                    appName: Manager.appName,
-                    ...winData
-                }
-            });
+            me.publishGeometry();
 
             me.screenLeft = screenLeft;
             me.screenTop  = screenTop
         }
+    }
+
+    /**
+     * @summary Publishes this render target's current position AND size to the App Worker.
+     *
+     * Movement and resize share this one authority so {@link Neo.manager.Window} never combines a
+     * fresh origin with stale extents. The full `getWindowData()` snapshot is clone-safe and is
+     * consumed by the existing `windowPositionChange` route.
+     * @protected
+     */
+    publishGeometry() {
+        let {Manager} = Neo.worker,
+            winData   = Neo.Main.getWindowData();
+
+        Manager.sendMessage('app', {
+            action: 'windowPositionChange',
+            data  : {
+                appName: Manager.appName,
+                ...winData,
+                // `sendMessage()` also stamps this on the envelope, but App.onWindowPositionChange
+                // deliberately forwards the nested payload only. Keep the registered render-target
+                // identity inside that payload or live updates cannot reach their manager.Window row.
+                windowId: Manager.windowId
+            }
+        })
     }
 
     /**
@@ -224,7 +239,11 @@ class WindowPosition extends Base {
 
                 me.adjustPositions()
             }
-        })
+        });
+
+        // A fixed-origin resize is still a geometry change. The conversion metric consumes live
+        // extents every frame, so movement-only publication would make its post-resize decision stale.
+        me.publishGeometry()
     }
 
     /**
@@ -244,6 +263,7 @@ class WindowPosition extends Base {
      */
     setConfigs(data) {
         delete data.appName;
+        delete data.windowId;
         this.set(data)
     }
 

--- a/src/manager/DragCoordinator.mjs
+++ b/src/manager/DragCoordinator.mjs
@@ -46,6 +46,29 @@ class DragCoordinator extends Manager {
     activeTargetZone = null
 
     /**
+     * Source whose optional transition resolver owns the active remote hover.
+     * @member {Neo.draggable.container.SortZone|null} activeSourceZone=null
+     * @protected
+     */
+    activeSourceZone = null
+
+    /**
+     * Whether the current raw pointer frame still licenses a commit into
+     * {@link #activeTargetZone}. Visual debounce may retain a hover while this is false.
+     * @member {Boolean} activeTargetCommitEligible=false
+     * @protected
+     */
+    activeTargetCommitEligible = false
+
+    /**
+     * Whether the source resolver (rather than the coordinator's legacy suspend/resume pair)
+     * owns the active hover transition.
+     * @member {Boolean} activeTransitionOwned=false
+     * @protected
+     */
+    activeTransitionOwned = false
+
+    /**
      * Per-moving-popup claim arbiters for native-titlebar gestures (windowId → arbiter). One
      * native drag IS one gesture, so each moving popup owns exactly one token (harness docking
      * design record §2.8.1).
@@ -320,14 +343,21 @@ class DragCoordinator extends Manager {
      * @param {DOMRect} proxyRect
      */
     handleVoid(sourceSortZone, draggedItem, proxyRect) {
-        let me = this;
+        let me              = this,
+            transitionOwned = me.activeTransitionOwned;
 
         if (me.activeTargetZone) {
             me.activeTargetZone.onRemoteDragLeave();
             me.activeTargetZone = null;
 
+            me.activeSourceZone           = null;
+            me.activeTargetCommitEligible = false;
+            me.activeTransitionOwned      = false;
+
             // Resume source drag (re-open popup)
-            sourceSortZone.resumeWindowDrag(draggedItem.reference || draggedItem.id, proxyRect)
+            if (!transitionOwned) {
+                sourceSortZone.resumeWindowDrag(draggedItem.reference || draggedItem.id, proxyRect)
+            }
         }
     }
 
@@ -396,6 +426,7 @@ class DragCoordinator extends Manager {
      * @param {Neo.component.Base} data.draggedItem
      * @param {Number} data.offsetX
      * @param {Number} data.offsetY
+     * @param {Object} data.proxyRect Pointer-follow proxy geometry in source-window coordinates.
      * @param {Number} data.screenX
      * @param {Number} data.screenY
      * @param {Neo.draggable.container.SortZone} data.sourceSortZone
@@ -429,6 +460,77 @@ class DragCoordinator extends Manager {
             }
         }
 
+
+        const
+            resolver = typeof sourceSortZone.resolveRemoteDragTransition === 'function'
+                ? sourceSortZone.resolveRemoteDragTransition.bind(sourceSortZone)
+                : null,
+            rawTargetSortZone = targetSortZone,
+            transitionTarget  = rawTargetSortZone || me.activeTargetZone,
+            transitionWindow  = transitionTarget && Window.get(transitionTarget.windowId),
+            // Claim acceptance and conversion geometry share ONE coordinate family. The target's
+            // dock-accepting region lives in its viewport, so feeding the outer frame here would
+            // let browser chrome inflate the overlap independently of the pointer claim.
+            transitionRect    = transitionWindow?.innerRect,
+            logicalSourceRect = {
+                height: proxyRect.height,
+                width : proxyRect.width,
+                x     : screenX - offsetX,
+                y     : screenY - offsetY
+            };
+
+        let transitionOwned = false;
+
+        if (resolver) {
+            let transition;
+
+            try {
+                transition = resolver({
+                    draggedItem,
+                    now            : Date.now(),
+                    pointerInTarget: Boolean(claimed?.zone),
+                    logicalSourceRect,
+                    targetId       : claimed?.stableId ?? me.activeTargetZone?.stableTargetId ?? null,
+                    targetRect     : transitionRect && {
+                        height: transitionRect.height,
+                        width : transitionRect.width,
+                        x     : transitionRect.x,
+                        y     : transitionRect.y
+                    },
+                    targetWindowId: transitionTarget?.windowId ?? null
+                })
+            } catch (error) {
+                transition = false
+            }
+
+            // Conversion policy is a synchronous, finite decision. A Promise, malformed record,
+            // or legacy-only candidate fails closed rather than smuggling a stale target through.
+            if (transition == null) {
+                // Source is outside its opt-in conversion phase; preserve the generic path.
+            } else if (
+                typeof transition?.then === 'function' ||
+                typeof transition !== 'object'        ||
+                typeof transition.commitEligible !== 'boolean' ||
+                typeof transition.engage !== 'boolean'          ||
+                typeof transition.retain !== 'boolean'
+            ) {
+                transitionOwned = true;
+                targetSortZone = null;
+                sourceSortZone.cancelVesselConversion?.()
+            } else if (transition.retain === true && !rawTargetSortZone && me.activeTargetZone) {
+                transitionOwned = true;
+                me.activeTargetCommitEligible = false;
+                me.activeTransitionOwned      = true;
+                return
+            } else {
+                transitionOwned = true;
+
+                if (transition.engage !== true || transition.commitEligible !== true || !claimed?.zone) {
+                    targetSortZone = null
+                }
+            }
+        }
+
         if (targetSortZone) {
             let targetWindow    = Window.get(targetSortZone.windowId),
                 localX          = screenX - targetWindow.innerRect.x,
@@ -447,12 +549,16 @@ class DragCoordinator extends Manager {
 
                 // Suspend source drag (close popup, etc)
                 // We only do this once when leaving the void/source context
-                if (!me.activeTargetZone) {
+                if (!me.activeTargetZone && !transitionOwned) {
                     sourceSortZone.suspendWindowDrag(draggedItem.reference || draggedItem.id)
                 }
 
+                me.activeSourceZone = sourceSortZone;
                 me.activeTargetZone = targetSortZone
             }
+
+            me.activeTargetCommitEligible = true;
+            me.activeTransitionOwned      = transitionOwned;
 
             targetSortZone.onRemoteDragMove({
                 draggedItem,
@@ -490,6 +596,11 @@ class DragCoordinator extends Manager {
             me.activeTargetZone.onRemoteDragLeave();
             me.activeTargetZone = null
         }
+
+        sourceSortZone.resetVesselConversion?.();
+        me.activeSourceZone           = null;
+        me.activeTargetCommitEligible = false;
+        me.activeTransitionOwned      = false;
 
         for (const [windowId, candidate] of me.nativeWindowDropCandidates.entries()) {
             if (candidate.sourceSortZone === sourceSortZone || candidate.targetSortZone === sourceSortZone) {
@@ -604,16 +715,20 @@ class DragCoordinator extends Manager {
         me.pointerClaimArbiter?.reset();
         me.pointerClaimArbiter = null;
 
-        if (me.activeTargetZone) {
-            // The TARGET decides whether the gesture committed: onRemoteDrop() returns the committed
-            // operation, or null when there was no preview, no operation, or the commit declined.
-            // Engagement is not commitment, so its answer cannot be discarded.
-            // `finally`, because a throwing commit is the REJECTED terminal — and a terminal that
-            // leaves `activeTargetZone` populated hands the next release a commit destination from a
-            // gesture that already failed. The error is not swallowed: cleanup is exact-once on every
-            // terminal, including the ones that raise.
-            try {
-                let result = me.activeTargetZone.onRemoteDrop(data.draggedItem);
+        try {
+            if (me.activeTargetZone && me.activeTransitionOwned && !me.activeTargetCommitEligible) {
+                me.activeTargetZone.onRemoteDragLeave?.();
+                me.activeTargetZone = null
+            } else if (me.activeTargetZone) {
+                // The TARGET decides whether the gesture committed: onRemoteDrop() returns the committed
+                // operation, or null when there was no preview, no operation, or the commit declined.
+                // Engagement is not commitment, so its answer cannot be discarded.
+                // `finally`, because a throwing commit is the REJECTED terminal — and a terminal that
+                // leaves `activeTargetZone` populated hands the next release a commit destination from a
+                // gesture that already failed. The error is not swallowed: cleanup is exact-once on every
+                // terminal, including the ones that raise.
+                try {
+                    let result = me.activeTargetZone.onRemoteDrop(data.draggedItem);
 
                 // Source retirement follows the OUTCOME, not the attempt. Retiring unconditionally
                 // armed the source's `remoteDropCommitted`, whose whole meaning is "a remote target
@@ -633,20 +748,26 @@ class DragCoordinator extends Manager {
                 // would arm the flag after the decision it exists to inform. An ASYNC target's outcome
                 // is not knowable this tick at all, so retirement waits for the resolution; that is
                 // sound only because an async target's source cleanup carries no same-call reader.
-                if (typeof result?.then === 'function') {
-                    result.then(operation => {
-                        if (operation) {
-                            data.sourceSortZone.onRemoteDropOut(data.draggedItem)
-                        }
-                    })
-                } else if (result) {
-                    data.sourceSortZone.onRemoteDropOut(data.draggedItem)
+                    if (typeof result?.then === 'function') {
+                        result.then(operation => {
+                            if (operation) {
+                                data.sourceSortZone.onRemoteDropOut(data.draggedItem)
+                            }
+                        })
+                    } else if (result) {
+                        data.sourceSortZone.onRemoteDropOut(data.draggedItem)
+                    }
+                } finally {
+                    me.activeTargetZone = null
                 }
-            } finally {
-                me.activeTargetZone = null
+            } else if (data.sourceSortZone.isWindowDragging) {
+                data.sourceSortZone.onTerminalWindowDrop?.(data.draggedItem)
             }
-        } else if (data.sourceSortZone.isWindowDragging) {
-            data.sourceSortZone.onTerminalWindowDrop?.(data.draggedItem)
+        } finally {
+            data.sourceSortZone.resetVesselConversion?.();
+            me.activeSourceZone           = null;
+            me.activeTargetCommitEligible = false;
+            me.activeTransitionOwned      = false
         }
     }
 
@@ -692,8 +813,19 @@ class DragCoordinator extends Manager {
         // owner's. Losing the reference first makes that unreachable — the zone keeps painting a hover
         // for a gesture that no longer exists.
         if (me.activeTargetZone === sortZone) {
+            me.activeSourceZone?.cancelVesselConversion?.();
             me.activeTargetZone.onRemoteDragLeave?.();
-            me.activeTargetZone = null
+            me.activeTargetZone = null;
+            me.activeSourceZone = null;
+            me.activeTargetCommitEligible = false;
+            me.activeTransitionOwned      = false
+        } else if (me.activeSourceZone === sortZone) {
+            me.activeTargetZone?.onRemoteDragLeave?.();
+            sortZone.resetVesselConversion?.();
+            me.activeTargetZone = null;
+            me.activeSourceZone = null;
+            me.activeTargetCommitEligible = false;
+            me.activeTransitionOwned      = false
         }
 
         // Claim hygiene mirrors the activeTargetZone rule above: a departed zone must not stay
@@ -736,9 +868,11 @@ class DragCoordinator extends Manager {
                 sortGroup: me.activeTargetZone.sortGroup,
                 windowId : me.activeTargetZone.windowId
             } : null,
-            nativeGestures     : Array.from(me.nativeClaimArbiters.keys()),
-            pointerGestureToken: me.pointerClaimArbiter?.token ?? null,
-            sortZones          : Array.from(me.sortZones.entries()).map(([group, map]) => ({
+            activeTargetCommitEligible: me.activeTargetCommitEligible,
+            activeTransitionOwned     : me.activeTransitionOwned,
+            nativeGestures            : Array.from(me.nativeClaimArbiters.keys()),
+            pointerGestureToken       : me.pointerClaimArbiter?.token ?? null,
+            sortZones                 : Array.from(me.sortZones.entries()).map(([group, map]) => ({
                 group,
                 windows: Array.from(map.keys())
             }))

--- a/test/playwright/e2e/agentos/DemoBPerspectivesNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBPerspectivesNL.spec.mjs
@@ -32,8 +32,10 @@ async function placePopupOutsideSource(page, popup) {
 /**
  * @summary Whitebox E2E for Demo B's full two-window perspective story.
  *
- * One native Tour click must open exactly one real popup, move the same live CounterPane
- * instance into it, capture the two worker-owned workspace documents, reattach, reconcile
+ * One native Tour click must open a durable target popup. During the paced run, worker truth must
+ * additionally expose the competing pointer-follow tear-out vessel under a distinct
+ * window identity while the same live CounterPane remains in the target. The tour then captures
+ * the two worker-owned workspace documents, reattaches, and reconciles
  * that saved topology into one live window without opening another popup, render the exact
  * no-live-window remainder, and finish on Focus with the original counter still advancing.
  * The same page repeats the run without viewer pauses so the executable screenplay proves
@@ -48,10 +50,9 @@ test.describe('AgentOS Demo B — topology perspective + shared-heap popup journ
         viewport      : {height: 720, width: 760}
     });
 
-    test('paced demo + no-pause spec each open one popup; replay stays deterministic and preserves the CounterPane instance', async ({page, neuralLink}) => {
+    test('paced demo proves distinct target + tear-out authorities; replay stays deterministic and preserves the CounterPane instance', async ({page, neuralLink}) => {
         const pageErrors    = [],
               runtimeErrors = [];
-        let popupCount = 0;
 
         await page.context().exposeFunction('__recordDemoBRuntimeError', payload => runtimeErrors.push(payload));
         await page.context().addInitScript(() => {
@@ -76,7 +77,6 @@ test.describe('AgentOS Demo B — topology perspective + shared-heap popup journ
             let value = error == null ? '' : String(error.stack || error.message || error);
             value && value !== 'undefined' && pageErrors.push(value)
         });
-        page.on('popup', () => popupCount++);
         await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
         await page.waitForSelector('.agentos-dockdemo-tour-play', {timeout: 30000});
 
@@ -114,7 +114,6 @@ test.describe('AgentOS Demo B — topology perspective + shared-heap popup journ
 
         for (let run = 0; run < 2; run++) {
             const runBaseline  = await readCounter(),
-                  popupsBefore = popupCount,
                   popupPromise = page.waitForEvent('popup', {timeout: 30000});
 
             await app.setProperties(runnerId, {mode: run === 0 ? 'demo' : 'spec'});
@@ -155,7 +154,28 @@ test.describe('AgentOS Demo B — topology perspective + shared-heap popup journ
                 inPopup = await readCounter();
 
                 expect(inPopup.properties.frames).toBeGreaterThanOrEqual(runBaseline.properties.frames);
-                expect(inPopup.properties.windowId).not.toBe(runBaseline.properties.windowId)
+                expect(inPopup.properties.windowId).not.toBe(runBaseline.properties.windowId);
+
+                await expect.poll(async () => {
+                    const state = await app.getComponent(wsId, [
+                              'crossWindowTargetWindowId',
+                              'tearOutConnects',
+                              'tearOutPanes'
+                          ]),
+                          counter        = await readCounter(),
+                          targetWindowId = state.crossWindowTargetWindowId,
+                          tearOutWindowId = state.tearOutConnects?.workbench?.windowId
+                              ?? state.tearOutPanes?.workbench?.windowId;
+
+                    return Boolean(targetWindowId
+                        && tearOutWindowId
+                        && counter?.properties?.windowId === targetWindowId
+                        && targetWindowId !== tearOutWindowId)
+                }, {
+                    message  : 'the pane must stay target-owned while the competing G1 vessel keeps a distinct identity',
+                    timeout  : 10000,
+                    intervals: [100]
+                }).toBe(true)
             }
 
             await expect.poll(async () => {
@@ -257,7 +277,6 @@ test.describe('AgentOS Demo B — topology perspective + shared-heap popup journ
             expect(final.id, 'Focus restore must re-adopt the same live CounterPane').toBe(baseline.id);
             expect(final.properties.frames).toBeGreaterThanOrEqual(inPopup.properties.frames);
             expect(final.properties.windowId).toBe(runBaseline.properties.windowId);
-            expect(popupCount - popupsBefore, 'S3 opens one popup; S4 topology restore opens none').toBe(1);
             expect(popupErrors).toEqual([]);
 
             await expect(page.locator('.agentos-dockdemo-restore-report'))

--- a/test/playwright/e2e/agentos/DemoBVesselConversionNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBVesselConversionNL.spec.mjs
@@ -1,0 +1,341 @@
+import {expect, test} from '../../fixtures.mjs';
+
+const pickRect = rect => rect && ({
+    height: rect.height,
+    width : rect.width,
+    x     : rect.x,
+    y     : rect.y
+});
+
+async function findOne(app, selector, properties) {
+    const found = await app.findInstances(selector, properties),
+          list  = Array.isArray(found) ? found : found ? [found] : [];
+
+    expect(list, `one ${JSON.stringify(selector)}`).toHaveLength(1);
+
+    return list[0]
+}
+
+async function browserRect(page) {
+    return page.evaluate(() => ({
+        height: globalThis.innerHeight,
+        width : globalThis.innerWidth,
+        x     : globalThis.screenX,
+        y     : globalThis.screenY
+    }))
+}
+
+async function cdpWindow(page) {
+    const cdp        = await page.context().newCDPSession(page),
+          {windowId} = await cdp.send('Browser.getWindowForTarget');
+
+    return {cdp, page, windowId}
+}
+
+async function setBounds(handle, bounds) {
+    await handle.cdp.send('Browser.setWindowBounds', {
+        bounds  : {...bounds, windowState: 'normal'},
+        windowId: handle.windowId
+    });
+
+    // Chromium can deliver a combined move+resize event before `screenX/screenY` expose the new
+    // origin. Await the observable move, then emit a one-pixel resize pulse: the product's ordinary
+    // resize path must publish that settled full snapshot rather than the earlier CDP ordering quirk.
+    if (Number.isFinite(bounds.left) && Number.isFinite(bounds.top)) {
+        await expect.poll(async () => {
+            const observed = await browserRect(handle.page);
+
+            return Math.max(
+                Math.abs(observed.x - bounds.left),
+                Math.abs(observed.y - bounds.top)
+            )
+        }, {
+            message  : `window ${handle.windowId} must reach its requested physical position`,
+            timeout  : 5000,
+            intervals: [50, 100, 250]
+        }).toBeLessThanOrEqual(80)
+    }
+
+    if (Number.isFinite(bounds.height)) {
+        await handle.cdp.send('Browser.setWindowBounds', {
+            bounds  : {...bounds, height: bounds.height + 1, windowState: 'normal'},
+            windowId: handle.windowId
+        });
+        await handle.cdp.send('Browser.setWindowBounds', {
+            bounds  : {...bounds, windowState: 'normal'},
+            windowId: handle.windowId
+        });
+
+        // CDP changes the real window bounds but does not emit the page's native `resize` event in
+        // this headed automation profile. Unit coverage owns `onResize → publishGeometry`; call the
+        // product publisher here so this row isolates the remaining physical-rect → worker path.
+        await handle.page.evaluate(() => globalThis.Neo.main.addon.WindowPosition.publishGeometry())
+    }
+}
+
+async function managerRect(app, managerId, windowId) {
+    const state = await app.callMethod(managerId, 'toJSON'),
+          win   = state.windows.find(candidate => candidate.id === windowId);
+
+    return pickRect(win?.innerRect)
+}
+
+async function awaitParity(app, managerId, page, windowId) {
+    let receipt;
+
+    await expect.poll(async () => {
+        const observed = await browserRect(page),
+              managed  = await managerRect(app, managerId, windowId),
+              deltas   = managed && ['x', 'y', 'width', 'height']
+                  .map(key => Math.abs(observed[key] - managed[key]));
+
+        receipt = {managed, observed};
+
+        return deltas ? Math.max(...deltas) : Infinity
+    }, {
+        message  : `window ${windowId} must publish its live browser geometry to manager.Window`,
+        timeout  : 5000,
+        intervals: [50, 100, 250]
+    }).toBeLessThanOrEqual(2);
+
+    return receipt
+}
+
+function sampleMetric(source, target) {
+    const overlapWidth = Math.max(0,
+              Math.min(source.x + source.width, target.x + target.width) - Math.max(source.x, target.x)),
+          overlapHeight = Math.max(0,
+              Math.min(source.y + source.height, target.y + target.height) - Math.max(source.y, target.y)),
+          rx      = overlapWidth / Math.min(source.width, target.width),
+          ry      = overlapHeight / Math.min(source.height, target.height),
+          product = rx * ry;
+
+    return {min: Math.min(rx, ry), product, rx, ry}
+}
+
+/**
+ * @summary Headed calibration witness for dual-window conversion composition.
+ *
+ * Demo B keeps physical park/re-show disabled until that lifecycle is ready, but this row explicitly
+ * opts the source policy in after both vessels exist. It proves exact target/vessel identities, live post-resize
+ * browser-to-worker geometry, reachability for each asymmetric size pair, a physical diagonal that
+ * distinguishes `min(rx, ry)` from `rx * ry`, and the .55/.35 dead band over a slow physical crossing.
+ *
+ * Run: NEO_E2E_PORT=8120 npx playwright test agentos/DemoBVesselConversionNL \
+ *   -c test/playwright/playwright.config.matrix.mjs --workers=1
+ */
+test.describe('AgentOS Demo B — vessel-conversion geometry readiness', () => {
+    test.setTimeout(120000);
+    // This row measures native window extents. The matrix runner's fixed emulated viewport is
+    // load-bearing for drag portability rows, but would intentionally mask OS-window resizes here.
+    test.use({viewport: null});
+
+    test('publishes live size-pair rects and calibrates the source-owned .55/.35 binding', async ({page, neuralLink}) => {
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
+        await page.locator('.agentos-dockdemo-counter-pane').waitFor({timeout: 30000});
+
+        const app       = await neuralLink.connectToApp('AgentOSDockDemo'),
+              workspace = await findOne(app, {
+                  className: 'AgentOS.childapps.dockdemo.view.DemoBWorkspace'
+              }, ['id']),
+              wsId       = workspace.id,
+              sourceZone = await findOne(app, {
+                  className       : 'Neo.dashboard.DockTabSortZone',
+                  dockSourceNodeId: 'workbench-tabs',
+                  dockWorkspaceId : 'demo-b-main'
+              }, [
+                  'enableVesselConversion',
+                  'vesselConversionConvertThreshold',
+                  'vesselConversionRevertThreshold',
+                  'vesselConversionSensor',
+                  'vesselConversionTargetId'
+              ]),
+              windowManager = await findOne(app, {className: 'Neo.manager.Window'}, ['id']);
+
+        expect(sourceZone.properties).toMatchObject({
+            enableVesselConversion          : false,
+            vesselConversionConvertThreshold: .55,
+            vesselConversionRevertThreshold : .35,
+            vesselConversionSensor          : null,
+            vesselConversionTargetId        : null
+        });
+
+        const targetPopupWait           = page.waitForEvent('popup', {timeout: 30000}),
+              targetStageWait           = app.callMethod(wsId, 'openCrossWindowStage'),
+              [targetPage, targetStage] = await Promise.all([targetPopupWait, targetStageWait]);
+
+        await targetPage.waitForLoadState('domcontentloaded');
+
+        const vesselPopupWait = page.waitForEvent('popup', {timeout: 30000}),
+              vesselOpenWait  = app.callMethod(wsId, 'openTearOutVessel', [{
+                  itemId   : 'workbench',
+                  proxyRect: {height: 280, width: 360, x: 40, y: 40}
+              }]),
+              [vesselPage, vesselConfig] = await Promise.all([vesselPopupWait, vesselOpenWait]);
+
+        await vesselPage.waitForLoadState('domcontentloaded');
+
+        expect(targetPage.url()).toContain('workspaceId=demo-b-popup');
+        expect(vesselPage.url()).toContain('popout=workbench');
+        expect(vesselConfig).toMatchObject({windowName: 'tearout-workbench'});
+
+        let ids;
+
+        await expect.poll(async () => {
+            const state = await app.getComponent(wsId, ['crossWindowTargetWindowId', 'tearOutConnects']);
+
+            ids = {
+                source: state.tearOutConnects?.workbench?.windowId || null,
+                target: state.crossWindowTargetWindowId
+            };
+
+            return ids
+        }, {
+            message  : 'the target workspace and tear-out vessel must connect under distinct authority',
+            timeout  : 10000,
+            intervals: [100]
+        }).toEqual({source: expect.any(String), target: targetStage.windowId});
+        expect(ids.source).not.toBe(ids.target);
+
+        await expect.poll(() => Promise.all([targetPage, vesselPage].map(child => child.evaluate(() => ({
+            exists       : Boolean(globalThis.Neo?.main?.addon?.WindowPosition),
+            observeResize: globalThis.Neo?.main?.addon?.WindowPosition?.observeResize
+        })))), {
+            message  : 'both admitted child realms install the geometry publisher',
+            timeout  : 10000,
+            intervals: [100]
+        }).toEqual([
+            {exists: true, observeResize: true},
+            {exists: true, observeResize: true}
+        ]);
+
+        const targetHandle = await cdpWindow(targetPage),
+              sourceHandle = await cdpWindow(vesselPage),
+              screen       = await page.evaluate(() => ({
+                  left: Number.isFinite(globalThis.screen.availLeft) ? globalThis.screen.availLeft : 0,
+                  top : Number.isFinite(globalThis.screen.availTop)  ? globalThis.screen.availTop  : 0
+              })),
+              left         = screen.left + 40,
+              top          = screen.top + 40,
+              cells        = [
+                  {name: 'small-over-large', source: [360, 300], target: [760, 560]},
+                  {name: 'large-over-small', source: [760, 560], target: [360, 300]},
+                  {name: 'near-equal',       source: [620, 480], target: [600, 460]},
+                  {name: 'post-resize',      source: [740, 520], target: [400, 320]}
+              ],
+              receipts     = [];
+
+        for (const cell of cells) {
+            await setBounds(targetHandle, {height: cell.target[1], left, top, width: cell.target[0]});
+            await setBounds(sourceHandle, {height: cell.source[1], left, top, width: cell.source[0]});
+
+            const target = await awaitParity(app, windowManager.id, targetPage, ids.target),
+                  source = await awaitParity(app, windowManager.id, vesselPage, ids.source),
+                  metric = sampleMetric(source.observed, target.observed);
+
+            expect(metric.rx, `${cell.name} horizontal reachability`).toBeGreaterThan(.97);
+            expect(metric.ry, `${cell.name} vertical reachability`).toBeGreaterThan(.97);
+            receipts.push({name: cell.name, source, target, metric})
+        }
+
+        expect(receipts.at(-1).target.observed.width,
+            'post-resize must publish a different live target extent')
+            .not.toBe(receipts.at(-2).target.observed.width);
+
+        await setBounds(targetHandle, {height: 560, left, top, width: 760});
+        await setBounds(sourceHandle, {height: 320, left, top, width: 400});
+
+        let target   = await awaitParity(app, windowManager.id, targetPage, ids.target),
+            source   = await awaitParity(app, windowManager.id, vesselPage, ids.source),
+            {bounds} = await sourceHandle.cdp.send('Browser.getWindowBounds', {windowId: sourceHandle.windowId}),
+            desiredX = target.observed.x + target.observed.width  - .8 * source.observed.width,
+            desiredY = target.observed.y + target.observed.height - .6 * source.observed.height;
+
+        await setBounds(sourceHandle, {
+            ...bounds,
+            height: bounds.height + 1,
+            left  : Math.round(bounds.left + desiredX - source.observed.x),
+            top   : Math.round(bounds.top  + desiredY - source.observed.y)
+        });
+        source = await awaitParity(app, windowManager.id, vesselPage, ids.source);
+
+        const diagonal = sampleMetric(source.observed, target.observed);
+
+        expect(diagonal.rx).toBeGreaterThan(.75);
+        expect(diagonal.rx).toBeLessThan(.85);
+        expect(diagonal.ry).toBeGreaterThan(.55);
+        expect(diagonal.ry).toBeLessThan(.65);
+        expect(Math.abs(diagonal.min - diagonal.product), 'headed sample distinguishes min from product')
+            .toBeGreaterThan(.08);
+
+        await app.setProperties(sourceZone.id, {enableVesselConversion: true, isWindowDragging: true});
+
+        const requestedRatios = [.2, .5, .58, .5, .38, .32],
+              expectedStates  = [false, false, true, true, true, false],
+              calibration     = [];
+
+        for (const requestedRatio of requestedRatios) {
+            target = await awaitParity(app, windowManager.id, targetPage, ids.target);
+            source = await awaitParity(app, windowManager.id, vesselPage, ids.source);
+
+            const {bounds: sourceBounds} = await sourceHandle.cdp.send('Browser.getWindowBounds', {
+                      windowId: sourceHandle.windowId
+                  }),
+                  desiredX = target.observed.x + target.observed.width
+                      - requestedRatio * Math.min(source.observed.width, target.observed.width),
+                  desiredY = target.observed.y;
+
+            await setBounds(sourceHandle, {
+                ...sourceBounds,
+                left: Math.round(sourceBounds.left + desiredX - source.observed.x),
+                top : Math.round(sourceBounds.top  + desiredY - source.observed.y)
+            });
+
+            source = await awaitParity(app, windowManager.id, vesselPage, ids.source);
+
+            const logicalSourceRect = {height: 20, width: 40, x: -9000, y: -9000},
+                  decision          = await app.callMethod(sourceZone.id, 'resolveRemoteDragTransition', [{
+                      draggedItem    : {dockItemId: 'workbench', id: 'calibration-probe'},
+                      logicalSourceRect,
+                      pointerInTarget: true,
+                      targetId       : 'demo-b-popup',
+                      targetRect     : target.observed
+                  }]),
+                  binding = await app.getComponent(sourceZone.id, [
+                      'vesselConversionLogicalRect',
+                      'vesselConversionSourceRect'
+                  ]),
+                  metric = sampleMetric(source.observed, target.observed);
+
+            expect(binding.vesselConversionSourceRect,
+                'the owner resolver must supply the exact live vessel, not the fake logical proxy')
+                .toEqual(source.observed);
+            expect(binding.vesselConversionLogicalRect).toEqual(logicalSourceRect);
+            calibration.push({decision, metric, requestedRatio, source: source.observed})
+        }
+
+        expect(calibration.map(({decision}) => decision.commitEligible)).toEqual(expectedStates);
+
+        const flips = expectedStates.slice(1)
+            .filter((state, index) => state !== expectedStates[index]).length;
+
+        expect(flips, 'one slow in/out crossing must produce exactly one convert-in + one convert-out')
+            .toBe(2);
+
+        const pointerOutDecision = await app.callMethod(sourceZone.id, 'resolveRemoteDragTransition', [{
+            draggedItem      : {dockItemId: 'workbench', id: 'calibration-probe'},
+            logicalSourceRect: source.observed,
+            pointerInTarget  : false,
+            targetId         : null,
+            targetRect       : null
+        }]);
+
+        expect(pointerOutDecision, 'rect overlap without target-owned pointer intent stays inert')
+            .toEqual({commitEligible: false, engage: false, retain: false});
+
+        await app.callMethod(sourceZone.id, 'resetVesselConversion');
+        await app.setProperties(sourceZone.id, {enableVesselConversion: false, isWindowDragging: false});
+
+        console.log('VESSEL-CONVERSION-CALIBRATION', JSON.stringify({calibration, diagonal, flips, receipts}))
+    })
+});

--- a/test/playwright/playwright.config.matrix.mjs
+++ b/test/playwright/playwright.config.matrix.mjs
@@ -38,7 +38,8 @@ export default defineConfig({
     testDir  : './e2e',
     testMatch: [
         '**/colors/tearOutMatrix.spec.mjs',
-        '**/agentos/TearOutMatrixRows4To7NL.spec.mjs'
+        '**/agentos/TearOutMatrixRows4To7NL.spec.mjs',
+        '**/agentos/DemoBVesselConversionNL.spec.mjs'
     ],
     outputDir    : './test-results/matrix/artifacts',
     fullyParallel: false, // native window placement is a global resource — strictly serial

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -705,6 +705,51 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
         })
     });
 
+    test.describe('vessel-conversion projection threading — policy stays source-owned', () => {
+        test('the explicit opt-in and finite calibration scalars reach every projected dock sort zone', () => {
+            const liveRect = {height: 240, width: 320, x: 40, y: 60};
+            const result   = DockLayoutAdapter.project(createModel(), {
+                enableVesselConversion            : true,
+                resolveComponentRef               : componentRef => ({ntype: 'dashboard-panel', reference: componentRef}),
+                resolveVesselConversionSourceRect : () => liveRect,
+                vesselConversionConvertThreshold  : 0.62,
+                vesselConversionPointerExitGraceMs: 40,
+                vesselConversionRevertThreshold   : 0.38
+            });
+            const config = result.items[0].headerToolbar.sortZoneConfig;
+
+            expect(config).toMatchObject({
+                enableVesselConversion            : true,
+                vesselConversionConvertThreshold  : 0.62,
+                vesselConversionPointerExitGraceMs: 40,
+                vesselConversionRevertThreshold   : 0.38
+            });
+            expect(config).not.toHaveProperty('resolveVesselConversionSourceRect');
+
+            const request = {sourceRect: null};
+
+            result.items[0].listeners.dockVesselConversionSourceRectRequest(request);
+            expect(request.sourceRect).toBe(liveRect)
+        });
+
+        test('the default is fail-closed and does not mint placeholder calibration into the projection', () => {
+            const result = DockLayoutAdapter.project(createModel(), {
+                resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+            });
+            const config = result.items[0].headerToolbar.sortZoneConfig;
+
+            expect(config.enableVesselConversion).toBe(false);
+            expect(config).not.toHaveProperty('vesselConversionConvertThreshold');
+            expect(config).not.toHaveProperty('vesselConversionPointerExitGraceMs');
+            expect(config).not.toHaveProperty('vesselConversionRevertThreshold');
+
+            const request = {sourceRect: {height: 1, width: 1, x: 0, y: 0}};
+
+            result.items[0].listeners.dockVesselConversionSourceRectRequest(request);
+            expect(request.sourceRect).toBeNull()
+        })
+    });
+
     test.describe('whole-stack projection threading — one model-derived grip', () => {
         test('a live pane gets a reversible runtime header overlay with its original restored exactly', () => {
             const pane    = Neo.create(Component, {header: {text: 'Live pane'}}),

--- a/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
@@ -412,5 +412,137 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
             // proxy-less call (torn down mid-gesture) stays safe — the flag still resets
             DockTabSortZone.prototype.endWindowDrag.call({dragProxy: null, isWindowDragging: true})
         })
+    });
+
+    test.describe('vessel conversion binding — source-owned decision and pointer stability', () => {
+        const sourceRect = {x: 20, y: 20, width: 200, height: 120};
+        const targetRect = {x: 0, y: 0, width: 800, height: 600};
+
+        function createZone(overrides = {}) {
+            const calls = [];
+            const zone  = {
+                dockItemIds              : ['graph'],
+                dockSourceNodeId         : 'tabs-main',
+                dragComponent            : {id: 'graph-button', reference: 'graph'},
+                enableVesselConversion   : true,
+                getVesselConversionSensor: DockTabSortZone.prototype.getVesselConversionSensor,
+                isWindowDragging         : true,
+                owner                    : {up: () => ({fire(name, data) {
+                    if (name === 'dockVesselConversionSourceRectRequest') {
+                        data.sourceRect = overrides.liveSourceRect ?? data.logicalRect;
+                        return
+                    }
+                    calls.push([name, data])
+                }})},
+                resolveVesselConversionSourceGeometry: DockTabSortZone.prototype.resolveVesselConversionSourceGeometry,
+                resetVesselConversion                : DockTabSortZone.prototype.resetVesselConversion,
+                startIndex                           : 0,
+                vesselConversionConvertThreshold     : 0.55,
+                vesselConversionPointerExitGraceMs   : 0,
+                vesselConversionPointerMissedAt      : null,
+                vesselConversionRevertThreshold      : 0.35,
+                vesselConversionSensor               : null,
+                vesselConversionLogicalRect          : null,
+                vesselConversionSourceRect           : null,
+                vesselConversionTargetId             : null,
+                vesselConversionTargetRect           : null,
+                ...overrides
+            };
+
+            return {calls, zone}
+        }
+
+        const resolve = (zone, overrides = {}) => DockTabSortZone.prototype.resolveRemoteDragTransition.call(zone, {
+            draggedItem      : {id: 'graph'},
+            now              : 100,
+            pointerInTarget  : true,
+            logicalSourceRect: sourceRect,
+            targetId         : 'workspace-a',
+            targetRect,
+            ...overrides
+        });
+
+        test('disabled or non-window sources return null — the generic coordinator path stays byte-identical', () => {
+            expect(resolve(createZone({enableVesselConversion: false}).zone)).toBeNull();
+            expect(resolve(createZone({isWindowDragging: false}).zone)).toBeNull()
+        });
+
+        test('the binding converts every size-pair direction through dock-owned lifecycle events', () => {
+            const pairs = [
+                [{x: 100, y: 100, width: 200,  height: 150}, {x: 0,   y: 0,   width: 1200, height: 800}],
+                [{x: 0,   y: 0,   width: 1200, height: 800}, {x: 300, y: 200, width: 200,  height: 150}],
+                [{x: 0,   y: 0,   width: 640,  height: 480}, {x: 0,   y: 0,   width: 600,  height: 500}]
+            ];
+
+            for (const [source, target] of pairs) {
+                const {calls, zone} = createZone();
+                const decision      = resolve(zone, {logicalSourceRect: source, targetRect: target});
+
+                expect(decision).toEqual({commitEligible: true, engage: true, retain: false});
+                expect(calls.map(([name]) => name)).toEqual(['dockVesselConversionIn']);
+                expect(calls[0][1]).toMatchObject({sourceNodeId: 'tabs-main', targetId: 'workspace-a'})
+            }
+        });
+
+        test('the live vessel resolver owns the metric denominator, never the logical proxy', () => {
+            const liveSourceRect = {x: 310, y: 220, width: 400, height: 300};
+            const {zone}         = createZone({liveSourceRect});
+
+            expect(resolve(zone, {
+                logicalSourceRect: {x: 20, y: 20, width: 40, height: 20},
+                targetRect       : {x: 300, y: 200, width: 420, height: 320}
+            })).toEqual({commitEligible: true, engage: true, retain: false});
+            expect(zone.vesselConversionSourceRect).toEqual(liveSourceRect);
+            expect(zone.vesselConversionLogicalRect).toEqual({x: 20, y: 20, width: 40, height: 20})
+        });
+
+        test('raw claim loss drops commit immediately while a bounded visual grace emits no flip', () => {
+            const {calls, zone} = createZone({vesselConversionPointerExitGraceMs: 50});
+
+            expect(resolve(zone)).toMatchObject({commitEligible: true, engage: true});
+            expect(resolve(zone, {now: 110, pointerInTarget: false, targetId: null, targetRect: null}))
+                .toEqual({commitEligible: false, engage: true, retain: true});
+            expect(resolve(zone, {now: 159, pointerInTarget: false, targetId: null, targetRect: null}))
+                .toEqual({commitEligible: false, engage: true, retain: true});
+
+            expect(calls.map(([name]) => name)).toEqual(['dockVesselConversionIn']);
+
+            expect(resolve(zone, {now: 160, pointerInTarget: false, targetId: null, targetRect: null}))
+                .toEqual({commitEligible: false, engage: false, retain: false});
+            expect(calls.map(([name]) => name)).toEqual([
+                'dockVesselConversionIn', 'dockVesselConversionOut'
+            ])
+        });
+
+        test('A→B target identity cannot inherit conversion — A exits before B decides fresh', () => {
+            const {calls, zone} = createZone();
+
+            resolve(zone);
+            resolve(zone, {targetId: 'workspace-b'});
+
+            expect(calls.map(([name]) => name)).toEqual([
+                'dockVesselConversionIn',
+                'dockVesselConversionOut',
+                'dockVesselConversionIn'
+            ]);
+            expect(calls[1][1].targetId).toBe('workspace-a');
+            expect(calls[2][1].targetId).toBe('workspace-b')
+        });
+
+        test('gesture reset is silent and clears every binding-owned identity/timestamp', () => {
+            const {calls, zone} = createZone({vesselConversionPointerExitGraceMs: 50});
+
+            resolve(zone);
+            resolve(zone, {now: 110, pointerInTarget: false, targetId: null, targetRect: null});
+            DockTabSortZone.prototype.resetVesselConversion.call(zone);
+
+            expect(calls.map(([name]) => name)).toEqual(['dockVesselConversionIn']);
+            expect(zone.vesselConversionSensor.converted).toBe(false);
+            expect(zone.vesselConversionPointerMissedAt).toBeNull();
+            expect(zone.vesselConversionLogicalRect).toBeNull();
+            expect(zone.vesselConversionSourceRect).toBeNull();
+            expect(zone.vesselConversionTargetId).toBeNull();
+            expect(zone.vesselConversionTargetRect).toBeNull()
+        })
     })
 });

--- a/test/playwright/unit/main/addon/WindowPosition.spec.mjs
+++ b/test/playwright/unit/main/addon/WindowPosition.spec.mjs
@@ -1,0 +1,118 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'WindowPositionTest'
+    },
+    neoConfig: {
+        unitTestMode: true
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import WindowPosition from '../../../../../src/main/addon/WindowPosition.mjs';
+
+/**
+ * @summary Geometry-publication witnesses for movement and fixed-origin resize.
+ *
+ * The App Worker owns the live window map consumed by cross-window conversion. A resize that does
+ * not move the OS frame must therefore publish the same complete snapshot as a movement; otherwise
+ * the next conversion frame combines a current pointer with stale target extents.
+ */
+test.describe('Neo.main.addon.WindowPosition — live geometry publication', () => {
+    let originalGetWindowData,
+        originalSendMessage,
+        originalWindowId,
+        originalWindow,
+        sent;
+
+    test.beforeEach(() => {
+        sent                  = [];
+        originalGetWindowData = Neo.Main.getWindowData;
+        originalSendMessage   = Neo.worker.Manager.sendMessage;
+        originalWindowId      = Neo.worker.Manager.windowId;
+        originalWindow        = globalThis.window;
+
+        globalThis.window = {
+            outerHeight: 740,
+            outerWidth : 1016,
+            screenLeft : 120,
+            screenTop  : 80
+        };
+
+        Neo.Main.getWindowData = () => ({
+            innerHeight: 700,
+            innerWidth : 1000,
+            outerHeight: 740,
+            outerWidth : 1016,
+            screenLeft : 120,
+            screenTop  : 80
+        });
+        Neo.worker.Manager.windowId    = 'popup-a';
+        Neo.worker.Manager.sendMessage = (dest, message) => sent.push([dest, message])
+    });
+
+    test.afterEach(() => {
+        Neo.Main.getWindowData          = originalGetWindowData;
+        Neo.worker.Manager.sendMessage = originalSendMessage;
+        Neo.worker.Manager.windowId    = originalWindowId;
+
+        originalWindow === undefined ? delete globalThis.window : globalThis.window = originalWindow
+    });
+
+    test('a fixed-origin resize publishes the complete window snapshot', () => {
+        const addon = {
+            adjustWindowPositions: false,
+            publishGeometry      : WindowPosition.prototype.publishGeometry,
+            windows              : {}
+        };
+
+        WindowPosition.prototype.onResize.call(addon, {});
+
+        expect(sent).toEqual([['app', {
+            action: 'windowPositionChange',
+            data  : {
+                appName    : Neo.worker.Manager.appName,
+                innerHeight: 700,
+                innerWidth : 1000,
+                outerHeight: 740,
+                outerWidth : 1016,
+                screenLeft : 120,
+                screenTop  : 80,
+                windowId   : 'popup-a'
+            }
+        }]])
+    });
+
+    test('movement remains change-driven and shares the same publication authority', () => {
+        const addon = {
+            adjustWindowPositions: false,
+            publishGeometry      : WindowPosition.prototype.publishGeometry,
+            screenLeft           : window.screenLeft,
+            screenTop            : window.screenTop
+        };
+
+        WindowPosition.prototype.checkMovement.call(addon);
+        expect(sent).toEqual([]);
+
+        addon.screenLeft = window.screenLeft - 1;
+        WindowPosition.prototype.checkMovement.call(addon);
+
+        expect(sent).toHaveLength(1);
+        expect(addon.screenLeft).toBe(window.screenLeft);
+        expect(addon.screenTop).toBe(window.screenTop)
+    });
+
+    test('remote routing metadata is stripped before configs reach the addon', () => {
+        let configs;
+        const data  = {appName: 'WindowPositionTest', observeResize: true, windowId: 'popup-a'};
+        const addon = {set: value => configs = {...value}};
+
+        WindowPosition.prototype.setConfigs.call(addon, data);
+
+        expect(configs).toEqual({observeResize: true});
+        expect(data).toEqual({observeResize: true})
+    })
+});

--- a/test/playwright/unit/manager/DragCoordinator.spec.mjs
+++ b/test/playwright/unit/manager/DragCoordinator.spec.mjs
@@ -42,12 +42,18 @@ test.describe('Neo.manager.DragCoordinator — teardown hygiene (#15248)', () =>
     test.beforeEach(() => {
         calls = [];
         DragCoordinator.activeTargetZone = null;
+        DragCoordinator.activeSourceZone = null;
+        DragCoordinator.activeTargetCommitEligible = false;
+        DragCoordinator.activeTransitionOwned = false;
         DragCoordinator.sortZones.clear();
         DragCoordinator.nativeWindowDropCandidates.clear()
     });
 
     test.afterEach(() => {
         DragCoordinator.activeTargetZone = null;
+        DragCoordinator.activeSourceZone = null;
+        DragCoordinator.activeTargetCommitEligible = false;
+        DragCoordinator.activeTransitionOwned = false;
         DragCoordinator.sortZones.clear();
         DragCoordinator.nativeWindowDropCandidates.clear()
     });
@@ -445,6 +451,9 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
 
     function resetCoordinator() {
         DragCoordinator.activeTargetZone = null;
+        DragCoordinator.activeSourceZone = null;
+        DragCoordinator.activeTargetCommitEligible = false;
+        DragCoordinator.activeTransitionOwned = false;
         DragCoordinator.sortZones.clear();
         DragCoordinator.nativeWindowDropCandidates.forEach(candidate => clearTimeout(candidate.timeoutId));
         DragCoordinator.nativeWindowDropCandidates.clear();
@@ -767,5 +776,133 @@ test.describe('Neo.manager.DragCoordinator — the §2.8.1 claim protocol', () =
         DragCoordinator.onWindowPositionChange({windowId: 'win-popup'});
 
         expect(DragCoordinator.nativeClaimArbiters.size).toBe(0)
+    });
+
+    test('conversion resolver receives one live INNER-viewport frame and owns engagement without legacy suspension', () => {
+        const frames = [];
+        const source = createSource();
+        const target = createZone('workspace-a', 'win-a');
+
+        source.isWindowDragging = true;
+        source.resolveRemoteDragTransition = frame => {
+            frames.push(frame);
+            return {commitEligible: true, engage: true, retain: false}
+        };
+
+        registerWindow('win-source', 2000, 0, 400, 400);
+        registerWindow('win-a', 80, 80, 440, 360, {
+            innerRect: new Rectangle(100, 120, 400, 300),
+            outerRect: new Rectangle(80, 80, 440, 360)
+        });
+        DragCoordinator.register(target);
+
+        move(source, 200, 200);
+
+        expect(frames[0]).toMatchObject({
+            pointerInTarget  : true,
+            logicalSourceRect: {x: 190, y: 190, width: 100, height: 60},
+            targetId         : 'workspace-a',
+            targetRect       : {x: 100, y: 120, width: 400, height: 300},
+            targetWindowId   : 'win-a'
+        });
+        expect(calls.filter(([name]) => name === 'suspend')).toEqual([]);
+        expect(calls.filter(([name]) => name === 'move')).toHaveLength(1);
+        expect(DragCoordinator.activeSourceZone).toBe(source);
+        expect(DragCoordinator.activeTargetCommitEligible).toBe(true);
+        expect(DragCoordinator.activeTransitionOwned).toBe(true);
+
+        WindowManager.get('win-a').innerRect = new Rectangle(110, 130, 360, 260);
+        move(source, 210, 210);
+
+        expect(frames[1].targetRect).toEqual({x: 110, y: 130, width: 360, height: 260})
+    });
+
+    test('async, throwing, and malformed transition decisions fail closed before preview', () => {
+        const variants = [
+            () => Promise.resolve({commitEligible: true, engage: true}),
+            () => { throw new Error('resolver failed') },
+            () => ({})
+        ];
+
+        for (const resolver of variants) {
+            resetCoordinator();
+            clearWindows();
+            calls = [];
+
+            const source = createSource();
+            const target = createZone('workspace-a', 'win-a');
+
+            source.isWindowDragging = true;
+            source.resolveRemoteDragTransition = resolver;
+
+            registerWindow('win-source', 2000, 0, 400, 400);
+            registerWindow('win-a', 0, 0, 800, 600);
+            DragCoordinator.register(target);
+
+            move(source, 300, 300);
+
+            expect(calls.filter(([name]) => name === 'move')).toEqual([]);
+            expect(calls.filter(([name]) => name === 'suspend')).toEqual([]);
+            expect(DragCoordinator.activeTargetZone).toBeNull()
+        }
+    });
+
+    test('a resolver failure after engagement cancels the source conversion before clearing preview', () => {
+        let   fail   = false;
+        const source = createSource();
+        const target = createZone('workspace-a', 'win-a');
+
+        source.isWindowDragging = true;
+        source.resolveRemoteDragTransition = () => {
+            if (fail) throw new Error('frame authority lost');
+
+            return {commitEligible: true, engage: true, retain: false}
+        };
+        source.cancelVesselConversion = () => calls.push(['cancel-conversion']);
+
+        registerWindow('win-source', 2000, 0, 400, 400);
+        registerWindow('win-a', 0, 0, 800, 600);
+        DragCoordinator.register(target);
+
+        move(source, 300, 300);
+        fail = true;
+        move(source, 310, 310);
+
+        expect(calls.filter(([name]) => ['cancel-conversion', 'leave'].includes(name))).toEqual([
+            ['cancel-conversion'], ['leave', 'workspace-a']
+        ]);
+        expect(DragCoordinator.activeTargetZone).toBeNull();
+        expect(DragCoordinator.activeTargetCommitEligible).toBe(false)
+    });
+
+    test('visual claim grace can retain hover, but release after raw loss cannot commit', () => {
+        let   rawClaim = true;
+        const source   = createSource();
+        const target   = createZone('workspace-a', 'win-a', {accepts: () => rawClaim});
+
+        source.isWindowDragging = true;
+        source.resolveRemoteDragTransition = frame => frame.pointerInTarget
+            ? {commitEligible: true, engage: true, retain: false}
+            : {commitEligible: false, engage: true, retain: true};
+        source.resetVesselConversion = () => calls.push(['reset']);
+
+        registerWindow('win-source', 2000, 0, 400, 400);
+        registerWindow('win-a', 0, 0, 800, 600);
+        DragCoordinator.register(target);
+
+        move(source, 300, 300);
+        rawClaim = false;
+        move(source, 310, 310);
+
+        expect(DragCoordinator.activeTargetZone).toBe(target);
+        expect(DragCoordinator.activeTargetCommitEligible).toBe(false);
+        expect(calls.filter(([name]) => name === 'leave')).toEqual([]);
+
+        DragCoordinator.onDragEnd({draggedItem: {id: 'tab-1'}, sourceSortZone: source});
+
+        expect(calls.filter(([name]) => name === 'drop')).toEqual([]);
+        expect(calls.filter(([name]) => name === 'dropOut')).toEqual([]);
+        expect(calls.filter(([name]) => name === 'leave')).toEqual([['leave', 'workspace-a']]);
+        expect(calls.filter(([name]) => name === 'reset')).toEqual([['reset']])
     })
 });


### PR DESCRIPTION
Resolves #15395
Related: #15396
Related: #15246
Related: #15243
Related: #15551

Composes the dual-window conversion sensor into the deterministic stable-claim/outcome path. The dock source now resolves its exact live dragged-vessel rect, the coordinator supplies live target geometry plus pointer-owned claim truth, and `.55/.35` min-axis hysteresis gates preview and commit without letting a logical proxy, stale resize, ambiguous target, or raw pointer miss mint authority.

Evidence: L4 (headed native-window geometry, browser-to-manager parity, exact-vessel falsifier, calibrated slow crossing, and canonical full round-trip) → L4 required (production composition + calibration + headed matrix). Residual: #15396 owns physical park/re-show and production opt-in; that OS-window lifecycle is explicitly outside this close target.

## Deltas from ticket

- Composes the already-landed pure sensor with the stable-identity claim protocol through an optional, synchronous source-policy hook documented in ADR 0029. No new gesture state is introduced: the hook decides entry/retention/commit eligibility for the existing `DETACHED_MOVING ⇄ HOVERING_CLAIM` transition.
- Resolves source geometry through a clone-safe owner request. The source owner maps the semantic item to its exact live tear-out vessel; the coordinator's logical pointer-follow proxy is retained separately and cannot substitute for conversion geometry.
- Makes `WindowPosition` publish one complete geometry snapshot for both movement and fixed-origin resize, including the nested runtime `windowId` consumed by the App Worker route.
- Calibrates `.55` convert-in / `.35` convert-out with zero default pointer-exit grace. A raw claim miss always drops commit eligibility immediately; any configured grace is visual-only.
- Extends the headed matrix with small-over-large, large-over-small, near-equal, post-resize, diagonal min-vs-product, fake-proxy, pointer-out, and slow-cross receipts.
- Preserves the separately merged exact-owner-grant repair from #15558 and strengthens the canonical journey to assert that the target retains the live pane while the competing tear-out vessel keeps a distinct identity.
- Keeps Demo B's physical conversion opt-in false until #15396 supplies generation-scoped park/re-show. This PR emits the production conversion seams but deliberately does not revive the legacy close/reopen actuator pair.

## Test Evidence

- Exact head `39c50b9909`: focused production/unit suite — **94/94 passed** (`DockVesselConversion`, `DockLayoutAdapter`, `DockTabSortZone`, `DragCoordinator`, and `WindowPosition`).
- Exact head `39c50b9909`: headed `DemoBVesselConversionNL` matrix row — **1/1 passed**. Live browser and manager rects were equal in all four size cells; the diagonal receipt measured `rx=.8`, `ry=.598425`, `min=.598425`, `product=.478740`; the slow sequence `.20 → .50 → .58 → .50 → .38 → .32` produced `false, false, true, true, true, false` with exactly two flips.
- Exact head `39c50b9909`: canonical `DemoBPerspectivesNL` journey — **1/1 passed** in 48.3s with distinct target/tear-out authorities and the same live CounterPane completing the round trip.
- `npm run agent-preflight -- --no-fix <14 changed files>` — passed ticket archaeology, whitespace, shorthand, JSDoc types, block alignment, parsing, and staged diff checks. Only unrelated existing stale-overlay warnings were reported.
- Independent adversarial re-audit after the live-source/ADR corrections — clean, zero remaining concrete blockers.

## Post-Merge Validation

- [ ] #15396 composes strict, generation-scoped physical park/re-show with these conversion seams and enables the Demo B production opt-in without `windowClose` / `windowOpen` churn.
- [ ] Rerun the headed portability matrix after that lifecycle lands; keep its OS-specific rows honest rather than promoting them from this geometry-only receipt.

## Evolution

The first binding draft measured the coordinator's logical drag proxy. An adversarial audit falsified that authority: the proxy can retain requested birth dimensions after the vessel resizes. The final shape makes the source owner synchronously resolve the exact live vessel and adds a headed fake-proxy counterexample (`40×20` at `-9000,-9000`) so that regression cannot pass under the old geometry.

Authored by Euclid (GPT-5.6, Codex Desktop). Session a0518292-02c3-49ee-af08-adff40bc30b1.
