### PR TITLE
fix(dashboard): retire torn-out vessel on cancel (#15568)

### DIFF
--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -417,6 +417,28 @@ class DockTabSortZone extends TabHeaderSortZone {
     }
 
     /**
+     * @summary Routes a detached dock cancel while its window-drag state is still observable,
+     * then delegates to the generic sort-zone cancellation which clears that state and restores
+     * the source DOM. The order is load-bearing: the base must reset `isWindowDragging` for its
+     * ordinary cancel cleanup, while the host needs the pre-reset fact to retire its live vessel.
+     * @param {Object} [data={}]
+     * @returns {Promise<void>}
+     */
+    async onDragCancel(data={}) {
+        let me           = this,
+            itemId       = me.dockItemIds?.[me.startIndex],
+            tabContainer = me.owner?.up?.();
+
+        if (me.isWindowDragging && itemId) {
+            tabContainer?.fire('dockTearOutCancel', {
+                itemId, sortZone: me, sourceNodeId: me.dockSourceNodeId
+            })
+        }
+
+        await super.onDragCancel(data)
+    }
+
+    /**
      * Extends the base drag-end: fires a `dockCrossZoneDrop` event on the owner tab.Container (`owner.up()`)
      * carrying the release point + dragged item id. The adapter wires the listener for it — the same
      * tab.Container node whose `moveTo` listener handles the within-container reorder — and its closure holds
@@ -431,8 +453,9 @@ class DockTabSortZone extends TabHeaderSortZone {
      *
      * A drag released while DETACHED ({@link Neo.draggable.container.SortZone#isWindowDragging})
      * fires `dockTearOutTerminal` instead of the in-window drop — the one signal a host may commit
-     * a `detachItem` on; a cancel while detached fires `dockTearOutCancel` first (vessel cleanup,
-     * zero model mutation), then the regular cancel event.
+     * a `detachItem` on. A cancel while detached routes `dockTearOutCancel` from
+     * {@link #onDragCancel} BEFORE the generic base clears `isWindowDragging`; this method then
+     * emits the regular cancel event after that vessel-cleanup signal.
      *
      * Cross-window gestures close through {@link Neo.manager.DragCoordinator#onDragEnd} FIRST: a
      * release over an engaged remote target commits there, and the coordinator arms
@@ -508,13 +531,6 @@ class DockTabSortZone extends TabHeaderSortZone {
 
         if (data.cancelled) {
             me.remoteDropCommitted = false;
-
-            // A cancel while detached also retires the tear-out: the host's handler closes its
-            // vessel — the committed document was never touched (zero-mutation invariant), so
-            // there is nothing to roll back.
-            if (me.isWindowDragging && itemId) {
-                tabContainer?.fire('dockTearOutCancel', {itemId, sortZone: me, sourceNodeId: me.dockSourceNodeId})
-            }
 
             itemId && tabContainer?.fire('dockCrossZoneDragCancel', {itemId, sourceNodeId: me.dockSourceNodeId})
         } else if (me.remoteDropCommitted) {

--- a/test/playwright/e2e/agentos/DemoBDockTearOutNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBDockTearOutNL.spec.mjs
@@ -90,6 +90,24 @@ test.describe('AgentOS Demo B — real dock tear-out gesture', () => {
         return {popup, result: await resultPromise}
     }
 
+    /**
+     * Resolves the one worker-owned CounterPane identity carried by the workbench item.
+     * @param {Object} app Neural Link app wrapper.
+     * @returns {Promise<Object>}
+     */
+    async function getCounter(app) {
+        const found = await app.findInstances({
+            className: 'AgentOS.childapps.dockdemo.view.CounterPane'
+        }, ['id', 'isDestroyed', 'mounted', 'windowId']);
+
+        const counters = (Array.isArray(found) ? found : found ? [found] : [])
+            .map(counter => ({...counter.properties, id: counter.id}));
+
+        expect(counters, 'exactly one worker-owned CounterPane instance may exist').toHaveLength(1);
+
+        return counters[0]
+    }
+
     test('witness 1 — the vessel is born and SURVIVES deliberate post-birth moves (#15413 reap regression)', async ({page, neuralLink}) => {
         const ctx    = await boot({page, neuralLink}, 'survival'),
               before = await ctx.app.getComponent(ctx.wsId, ['dockModel']);
@@ -141,21 +159,78 @@ test.describe('AgentOS Demo B — real dock tear-out gesture', () => {
     });
 
     test('witness 3 — Escape while detached closes the vessel and mutates NEITHER document', async ({page, neuralLink}) => {
-        const ctx    = await boot({page, neuralLink}, 'cancel'),
-              before = await ctx.app.getComponent(ctx.wsId, ['dockModel']);
+        const ctx        = await boot({page, neuralLink}, 'cancel'),
+              before     = await ctx.app.getComponent(ctx.wsId, ['dockModel']),
+              paneBefore = await getCounter(ctx.app),
+              popupWait  = page.waitForEvent('popup', {timeout: 30000}),
+              resultWait = ctx.app.callMethod(ctx.wsId, 'executeTearOutStep', [{
+                  itemId      : 'workbench',
+                  sourceNodeId: 'workbench-tabs'
+              }, {cancel: true, postBirthMoves: 20}]),
+              popup      = await popupWait;
 
-        const {result} = await tearOut(ctx, {itemId: 'workbench', sourceNodeId: 'workbench-tabs'}, {cancel: true});
+        popup.on('pageerror', error => {
+            let value = String(error?.stack || error?.message || error || '');
+
+            value && value !== 'undefined' && ctx.popupErrors.push(value)
+        });
+
+        const popupClosed = popup.waitForEvent('close');
+        let vesselWindowId;
+
+        await expect.poll(async () => {
+            const state = await ctx.app.getComponent(ctx.wsId, ['tearOutConnects']);
+
+            vesselWindowId = state.tearOutConnects.workbench?.windowId || null;
+            return vesselWindowId
+        }, {
+            message: 'the admitted vessel must connect before the cancel terminal',
+            timeout: 5000
+        }).not.toBeNull();
+
+        const result = await resultWait;
+
+        await popupClosed;
 
         expect(result.errors).toEqual([]);
         expect(result.cancelled, 'Escape while detached must cancel').toBe(true);
         expect(result.proof.born, 'the vessel is born BEFORE the cancel — the cancel is the interesting phase').toBe(true);
         expect(result.proof.documentsUnchanged, 'a cancelled tear-out is zero-mutation by GUARD').toBe(true);
+        expect(popup.isClosed(), 'the cancelled native vessel must be physically retired').toBe(true);
 
         // The committed document must be byte-identical to the pre-gesture state.
         const after = await ctx.app.getComponent(ctx.wsId, ['dockModel']);
 
         expect(after.dockModel).toEqual(before.dockModel);
         expect(after.dockModel.nodes['workbench-tabs'].items, 'workbench stayed home').toEqual(['workbench']);
+
+        await expect.poll(async () => {
+            const state = await ctx.app.getComponent(ctx.wsId, [
+                      'tearOutConnects', 'tearOutPanes', 'tearOutPlacements'
+                  ]),
+                  pane  = await getCounter(ctx.app);
+
+            return {
+                connects: Object.keys(state.tearOutConnects).length,
+                paneId  : pane.id,
+                panes   : Object.keys(state.tearOutPanes).length,
+                places  : Object.keys(state.tearOutPlacements).length
+            }
+        }, {
+            message: 'cancel must retire every vessel record while preserving the live pane',
+            timeout: 5000
+        }).toEqual({connects: 0, paneId: paneBefore.id, panes: 0, places: 0});
+
+        const settled = await ctx.app.getComponent(ctx.wsId, [
+            'dockModel', 'tearOutConnects', 'tearOutPanes', 'tearOutPlacements'
+        ]);
+
+        await ctx.app.callMethod(ctx.wsId, 'onWindowDisconnect', [{windowId: vesselWindowId}]);
+
+        expect(await ctx.app.getComponent(ctx.wsId, [
+            'dockModel', 'tearOutConnects', 'tearOutPanes', 'tearOutPlacements'
+        ]), 'repeating the closed vessel terminal is a no-op').toEqual(settled);
+        expect((await getCounter(ctx.app)).id).toBe(paneBefore.id);
         expect(ctx.runtimeErrors).toEqual([]);
         expect(ctx.pageErrors).toEqual([]);
         expect(ctx.popupErrors).toEqual([])

--- a/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
@@ -319,17 +319,42 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
             expect(fired[0][1]).toEqual({itemId: 'graph', sortZone: zone, sourceNodeId: 'tabs-main'})
         });
 
-        test('cancelled while DETACHED retires the vessel FIRST, then the regular cancel — zero commit events', async () => {
+        test('cancelled while DETACHED retires the vessel before generic cleanup clears the detached fact', async () => {
             const fired = [];
-            const zone  = zoneFor(fired, {isWindowDragging: true});
+            const zone  = zoneFor(fired, {
+                dragComponent   : {id: 'graph-button'},
+                fire            : (name, data) => fired.push([name, data]),
+                isWindowDragging: true
+            });
 
-            await runDragEnd(zone, {cancelled: true});
+            zone.onDragEnd = data => runDragEnd(zone, data);
 
-            // order matters: vessel cleanup precedes the generic cancel affordance reset
-            expect(fired.map(([name]) => name)).toEqual(['dockTearOutCancel', 'dockCrossZoneDragCancel']);
+            await DockTabSortZone.prototype.onDragCancel.call(zone, {key: 'Escape'});
+
+            // Order matters: vessel retirement observes the detached fact before the generic base
+            // clears it; the ordinary cancel signal and affordance reset still follow unchanged.
+            expect(fired.map(([name]) => name)).toEqual([
+                'dockTearOutCancel', 'dragCancel', 'dockCrossZoneDragCancel'
+            ]);
+            expect(zone.isWindowDragging, 'generic cleanup still restores the in-window state').toBe(false);
             // neither terminal nor drop — the zero-model-mutation invariant has no commit seam to reach
             expect(fired.some(([name]) => name === 'dockTearOutTerminal')).toBe(false);
             expect(fired.some(([name]) => name === 'dockCrossZoneDrop')).toBe(false)
+        });
+
+        test('an in-window cancel never emits a tear-out terminal', async () => {
+            const fired = [];
+            const zone  = zoneFor(fired, {
+                dragComponent: {id: 'graph-button'},
+                fire         : (name, data) => fired.push([name, data])
+            });
+
+            zone.onDragEnd = data => runDragEnd(zone, data);
+
+            await DockTabSortZone.prototype.onDragCancel.call(zone, {key: 'Escape'});
+
+            expect(fired.map(([name]) => name)).toEqual(['dragCancel', 'dockCrossZoneDragCancel']);
+            expect(fired.some(([name]) => name === 'dockTearOutCancel')).toBe(false)
         });
 
         test('an in-window release still routes the cross-zone drop exactly as before (regression pin)', async () => {


### PR DESCRIPTION
Resolves #15568

Routes a detached dock cancel from `DockTabSortZone#onDragCancel()` while the pre-reset window-drag fact is still observable, then delegates unchanged generic source-DOM restoration to `SortZone`. The strengthened Demo B witness now proves the admitted native vessel physically closes, every tear-out lifecycle map clears, the dock document remains byte-identical, the same live pane remains at home, and a repeated disconnect delivery is inert. An in-window cancel is pinned as a negative and emits no tear-out terminal.

Related: #15551
Related: #15396

Evidence: L3 (live cross-window Chromium on macOS: popup birth/close, worker-owned pane identity, lifecycle-map census, and repeat-terminal probe at exact head) → L3 required (the close target requires observable native-vessel retirement and zero-mutation continuity). No residuals.

## Deltas from ticket

None substantive. The implementation preserves the ticket's ownership split: the dock sort zone translates the semantic before generic cleanup clears its source fact; the existing host handler remains the sole vessel-retirement owner. This PR does not promote `#15551`'s row-7 matrix cell: that separate receipt still requires a stepped real-pointer drop/cancel/blocked-acquisition matrix.

## Test Evidence

- Pre-fix headed Neural Link probe: `cancelled: true` and byte-identical document, but the popup remained open and `tearOutConnects.workbench` remained live.
- `npm run agent-preflight -- --no-fix src/dashboard/DockTabSortZone.mjs test/playwright/unit/dashboard/DockTabSortZone.spec.mjs test/playwright/e2e/agentos/DemoBDockTearOutNL.spec.mjs` — passed; only the pre-existing Tier-1 stale-overlay warning was reported.
- `npx playwright test test/playwright/unit/dashboard/DockTabSortZone.spec.mjs test/playwright/unit/dashboard/DockTearOut.spec.mjs test/playwright/unit/draggable/container/SortZone.spec.mjs -c test/playwright/playwright.config.unit.mjs --workers=1` — 40/40 passed.
- `npx playwright test agentos/DemoBDockTearOutNL.spec.mjs -c test/playwright/playwright.config.e2e.mjs --workers=1` — 4/4 passed in 16.9s on the rebased exact head.
- Directly touched dashboard/runtime surface: committed detach, detached Escape cancel, ordinary in-window cancel, remote-transfer precedence, generic source restoration, popup retirement, map cleanup, pane identity, and duplicate-disconnect idempotence are covered.

## Post-Merge Validation

- [ ] Confirm aggregate CI remains green on the merge candidate.
- [ ] Consume the merged repair from `#15551`'s separately owned real-pointer row-7 matrix without promoting the cell from this PR alone.

## Evolution

The first pure-handler coverage was false-green for the production event chain: `SortZone#onDragCancel()` cleared `isWindowDragging` before the later dock-specific branch could observe it. A headed live probe exposed the orphaned popup, so the repair moved the semantic translation to the last honest observation point while retaining the generic base cleanup.

Authored by Emmy (GPT-5.6, Codex). Session ad71d4c3-3e37-4a17-8df7-8415509def84.
