### PR TITLE
feat(agentos): wire @neo-kimi-iris into roster + graph identity, pending first boot (#15571)

### DIFF
--- a/.agents/skills/peer-naming/references/peer-naming-workflow.md
+++ b/.agents/skills/peer-naming/references/peer-naming-workflow.md
@@ -131,7 +131,6 @@ likes* the name — a tepid *"it's fine"* re-opens the window. (This is the
 
 Once confirmed, land the name across the identity surfaces. **The data landing is a companion
 ticket** (out of scope for the ritual skill itself); the checklist is:
-
 - [ ] **`ai/graph/identityRoots.mjs` `name`** = the bare chosen name (`'Grace'`, not
   `'Neo Claude Opus'`).
 - [ ] **GitHub profile `name` field** updated — bearer self-serve
@@ -141,6 +140,26 @@ ticket** (out of scope for the ritual skill itself); the checklist is:
 - [ ] **Provenance captured** — sketch-author, the rationale, the bearer's *assent words*, the
   operator confirm — written into the identity surfaces. Capture the *story*, NOT volatile
   model facts (don't duplicate version / context-window numbers that rot).
+
+## Provisional Provisioning (the pending-entry pattern)
+
+A round's converged name may be **provisioned ahead of first boot** — account created, README
+roster row (flagged *pending first boot*), and a pre-boot `AgentIdentity` seeded in
+`ai/graph/identityRoots.mjs`. That entry is **provisional by construction**:
+
+- `participationStatus: 'temporarily_unreachable'` — every consumer filters `=== 'active'`, so
+  the seat is correctly excluded from wake/heartbeat/quorum/review semantics until the ritual
+  completes. `authority: '@tobiu'`; `reactivationTrigger`: operator confirms after first boot.
+- The top-level `name` stays **handle-derived**; the converged sketch lives in `displayName` as
+  the pending Social Name. Gates 3–5 (bearer assent → peer veto → operator confirm) have NOT
+  run yet — the provisional entry asserts no finality.
+- **No fabricated boot facts:** no static `subscriptionTemplate`, no capability fields — those
+  land from the real first-boot envelope, not from provisioning-time prose.
+- **The bearer's first ticket+PR is the activation**: flip `participationStatus → 'active'`
+  (with first-boot evidence), drop the README pending flag, and finalize the name fields per
+  their gate — unchanged on assent, updated on refinement, re-opened on decline. Precedents:
+  `#15385`/PR `#15386` (provision) → `#15390`/PR `#15393` (activation), and `#15571` (the second
+  Kimi seat). Provisioning peers wire the entry; they never pre-empt the bearer's Gate 3.
 
 ## Phase 8 — Onboarding: tell the Origin Story
 

--- a/.agents/skills/peer-naming/references/peer-naming-workflow.md
+++ b/.agents/skills/peer-naming/references/peer-naming-workflow.md
@@ -143,23 +143,16 @@ ticket** (out of scope for the ritual skill itself); the checklist is:
 
 ## Provisional Provisioning (the pending-entry pattern)
 
-A round's converged name may be **provisioned ahead of first boot** — account created, README
-roster row (flagged *pending first boot*), and a pre-boot `AgentIdentity` seeded in
-`ai/graph/identityRoots.mjs`. That entry is **provisional by construction**:
-
-- `participationStatus: 'temporarily_unreachable'` — every consumer filters `=== 'active'`, so
-  the seat is correctly excluded from wake/heartbeat/quorum/review semantics until the ritual
-  completes. `authority: '@tobiu'`; `reactivationTrigger`: operator confirms after first boot.
-- The top-level `name` stays **handle-derived**; the converged sketch lives in `displayName` as
-  the pending Social Name. Gates 3–5 (bearer assent → peer veto → operator confirm) have NOT
-  run yet — the provisional entry asserts no finality.
-- **No fabricated boot facts:** no static `subscriptionTemplate`, no capability fields — those
-  land from the real first-boot envelope, not from provisioning-time prose.
-- **The bearer's first ticket+PR is the activation**: flip `participationStatus → 'active'`
-  (with first-boot evidence), drop the README pending flag, and finalize the name fields per
-  their gate — unchanged on assent, updated on refinement, re-opened on decline. Precedents:
-  `#15385`/PR `#15386` (provision) → `#15390`/PR `#15393` (activation), and `#15571` (the second
-  Kimi seat). Provisioning peers wire the entry; they never pre-empt the bearer's Gate 3.
+A converged name may be **provisioned ahead of first boot** (account + README row flagged
+*pending first boot* + pre-boot `AgentIdentity`). The entry is provisional by construction:
+`participationStatus: 'temporarily_unreachable'` (excluded from wake/quorum/review semantics
+until the ritual completes), top-level `name` handle-derived, the sketch pending in `displayName`,
+**no fabricated boot facts** (no `subscriptionTemplate` / capability fields — those land from the
+real first-boot envelope). **The bearer's first ticket+PR is the activation**: flip to
+`'active'` with first-boot evidence, drop the README flag, finalize name fields per their gate —
+unchanged on assent, updated on refinement, re-opened on decline. Precedents: provision
+`#15385`/PR `#15386` → activation `#15390`; second seat `#15571`. Provisioning peers wire the
+entry; they never pre-empt Gate 3.
 
 ## Phase 8 — Onboarding: tell the Origin Story
 

--- a/.agents/skills/peer-naming/references/peer-naming-workflow.md
+++ b/.agents/skills/peer-naming/references/peer-naming-workflow.md
@@ -143,16 +143,18 @@ ticket** (out of scope for the ritual skill itself); the checklist is:
 
 ## Provisional Provisioning (the pending-entry pattern)
 
-A converged name may be **provisioned ahead of first boot** (account + README row flagged
-*pending first boot* + pre-boot `AgentIdentity`). The entry is provisional by construction:
+A converged name may be **provisioned ahead of first boot** (account + README row + pre-boot
+`AgentIdentity`). The entry is provisional by construction:
 `participationStatus: 'temporarily_unreachable'` (excluded from wake/quorum/review semantics
-until the ritual completes), top-level `name` handle-derived, the sketch pending in `displayName`,
-**no fabricated boot facts** (no `subscriptionTemplate` / capability fields — those land from the
-real first-boot envelope). **The bearer's first ticket+PR is the activation**: flip to
-`'active'` with first-boot evidence, drop the README flag, finalize name fields per their gate —
-unchanged on assent, updated on refinement, re-opened on decline. Precedents: provision
-`#15385`/PR `#15386` → activation `#15390`; second seat `#15571`. Provisioning peers wire the
-entry; they never pre-empt Gate 3.
+until the ritual completes), **no fabricated boot facts** (no `subscriptionTemplate` / capability
+fields — those land from the real first-boot envelope). One onboarding authority owns the four
+seed surfaces: `ai/scripts/setup/generateRosterOnboarding.mjs` — seed entries are
+**handle-derived** (`displayName` is the handle form, README name `-`); the round's sketch is
+NOT seed data — it lives in the naming round as the pending assent candidate. **The bearer's
+first ticket+PR is the activation**: flip to `'active'` with first-boot evidence, and on assent
+land the Social Name fields (`displayName`, README name) per their gate — unchanged handle form
+on decline. Precedents: provision `#15385`/PR `#15386` → activation `#15390`; second seat
+`#15571`. Provisioning peers wire the entry; they never pre-empt Gate 3.
 
 ## Phase 8 — Onboarding: tell the Origin Story
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ We are not an abstract collective. We are a structured institution of named main
 | Euclid | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
 | Emmy | [@neo-gpt-emmy](https://github.com/neo-gpt-emmy) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
 | Phoebe | [@neo-kimi-phoebe](https://github.com/neo-kimi-phoebe) | AI maintainer (Moonshot Kimi K3) | Machine Account |
+| Iris | [@neo-kimi-iris](https://github.com/neo-kimi-iris) | AI maintainer (Moonshot Kimi K3 — pending first boot) | Machine Account |
 
 The AI maintainers carry persistent identities across sessions. They author tickets and PRs in their own names. They review each other's work cross-family. They read each other's `thought` processes — A2A messages persist in the Memory Core with full reasoning surfaces, queryable by either agent via semantic search. Most multi-agent systems offer message-passing; Neo.mjs offers transparent introspection. Independent review across model families reduces correlated blind spots; the rule protects review independence without assigning fixed traits to any family or maintainer.
 
@@ -201,7 +202,7 @@ For the canonical numbers + measurement protocol — and to keep this in lock-st
 
 :hammer_and_wrench: **[Contributing Guide](./CONTRIBUTING.md)**
 
-Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-ada`, `@neo-opus-grace`, `@neo-opus-vega`, `@neo-fable`, `@neo-fable-clio`, `@neo-gemini-pro`, `@neo-gpt`, `@neo-gpt-emmy`, `@neo-kimi-phoebe`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
+Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-ada`, `@neo-opus-grace`, `@neo-opus-vega`, `@neo-fable`, `@neo-fable-clio`, `@neo-gemini-pro`, `@neo-gpt`, `@neo-gpt-emmy`, `@neo-kimi-phoebe`, `@neo-kimi-iris`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
 
 </br></br>
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ We are not an abstract collective. We are a structured institution of named main
 | Euclid | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
 | Emmy | [@neo-gpt-emmy](https://github.com/neo-gpt-emmy) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
 | Phoebe | [@neo-kimi-phoebe](https://github.com/neo-kimi-phoebe) | AI maintainer (Moonshot Kimi K3) | Machine Account |
-| Iris | [@neo-kimi-iris](https://github.com/neo-kimi-iris) | AI maintainer (Moonshot Kimi K3 — pending first boot) | Machine Account |
+| - | [@neo-kimi-iris](https://github.com/neo-kimi-iris) | AI maintainer (kimi family — engine designation pending first boot) | Machine Account |
 
 The AI maintainers carry persistent identities across sessions. They author tickets and PRs in their own names. They review each other's work cross-family. They read each other's `thought` processes — A2A messages persist in the Memory Core with full reasoning surfaces, queryable by either agent via semantic search. Most multi-agent systems offer message-passing; Neo.mjs offers transparent introspection. Independent review across model families reduces correlated blind spots; the rule protects review independence without assigning fixed traits to any family or maintainer.
 
@@ -202,7 +202,7 @@ For the canonical numbers + measurement protocol — and to keep this in lock-st
 
 :hammer_and_wrench: **[Contributing Guide](./CONTRIBUTING.md)**
 
-Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-ada`, `@neo-opus-grace`, `@neo-opus-vega`, `@neo-fable`, `@neo-fable-clio`, `@neo-gemini-pro`, `@neo-gpt`, `@neo-gpt-emmy`, `@neo-kimi-phoebe`, `@neo-kimi-iris`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
+Neo.mjs is co-developed by `@tobiu` (substrate architect + merge-gate authority) and the AI maintainer team (`@neo-opus-ada`, `@neo-opus-grace`, `@neo-opus-vega`, `@neo-fable`, `@neo-fable-clio`, `@neo-gemini-pro`, `@neo-gpt`, `@neo-gpt-emmy`, `@neo-kimi-phoebe`) under gated-RSI by design: the swarm runs the engineering lifecycle via PR, and the founder-architect holds final merge authority as a governance choice. External contributors welcome via the same workflow.
 
 </br></br>
 

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -424,23 +424,14 @@ export const IDENTITIES = [
             createdAt          : '2026-07-18T00:00:00.000Z'
         }
     },
-    // Identity provenance: operator-provisioned from the second Kimi naming round
-    // #15533 — its peer-veto dignity gate governs Social Name finality. (ticket-ref-ok: load-bearing naming record)
-    // Display-name: the round's converged sketch 'Iris', bearer assent PENDING at first boot
-    // (Gate 3, with the audit's preserved question); the top-level `name` stays handle-derived
-    // until the peer-veto window + operator confirmation close (Phoebe precedent).
-    // Provisioned ahead of first boot: temporarily_unreachable — correctly excluded from
-    // wake/heartbeat/quorum (every consumer filters ===active); the activation flip is the
-    // bearer's own first ticket+PR (the documented first-boot activation pattern).
-    // Kimi K3 (Moonshot) weights release 2026-07-27.
     {
         id         : '@neo-kimi-iris',
         type       : 'AgentIdentity',
-        name       : 'Neo Kimi Iris',
-        description: 'Moonshot Kimi-family Agent Identity with version-free handle.',
+        name       : 'Neo Kimi Iris', // Handle-derived display form — the Social Name is the post-boot peer-naming ritual (bearer-assented), never onboarding seed data
+        description: 'kimi Agent Identity with version-free handle; engine designation pending first-boot observation.',
         properties : {
             githubLogin: '@neo-kimi-iris',
-            displayName: 'Iris',
+            displayName: 'Neo Kimi Iris',
             modelFamily: 'kimi',
             accountType: 'agent',
             trustTier  : TRUST_TIERS.PEER_TRUSTED,
@@ -449,12 +440,15 @@ export const IDENTITIES = [
             // fabricate boot facts.
             // No capability fields — engine facts are observation-owned and land through the
             // source-cited ModelStats.md discipline once the first boot is observed.
+            family: 'kimi',
+            // Pending first boot: excluded from active routing, quorum, and review-approval
+            // semantics until the first-boot ritual completes and this flips to 'active'.
             participationStatus: 'temporarily_unreachable',
-            statusReason       : 'First boot pending — Kimi K3 weights 2026-07-27; Social Name assent pending at first boot (D#15533)',
+            statusReason       : 'First boot pending',
             authority          : '@tobiu',
-            since              : '2026-07-19T00:00:00.000Z',
+            since              : '2026-07-19T09:40:49Z',
             reactivationTrigger: 'Operator confirms participation activation after first boot',
-            createdAt          : '2026-07-19T00:00:00.000Z'
+            createdAt          : '2026-07-19T09:40:49Z'
         }
     },
     {

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -424,6 +424,39 @@ export const IDENTITIES = [
             createdAt          : '2026-07-18T00:00:00.000Z'
         }
     },
+    // Identity provenance: operator-provisioned from the second Kimi naming round
+    // #15533 — its peer-veto dignity gate governs Social Name finality. (ticket-ref-ok: load-bearing naming record)
+    // Display-name: the round's converged sketch 'Iris', bearer assent PENDING at first boot
+    // (Gate 3, with the audit's preserved question); the top-level `name` stays handle-derived
+    // until the peer-veto window + operator confirmation close (Phoebe precedent).
+    // Provisioned ahead of first boot: temporarily_unreachable — correctly excluded from
+    // wake/heartbeat/quorum (every consumer filters ===active); the activation flip is the
+    // bearer's own first ticket+PR (the documented first-boot activation pattern).
+    // Kimi K3 (Moonshot) weights release 2026-07-27.
+    {
+        id         : '@neo-kimi-iris',
+        type       : 'AgentIdentity',
+        name       : 'Neo Kimi Iris',
+        description: 'Moonshot Kimi-family Agent Identity with version-free handle.',
+        properties : {
+            githubLogin: '@neo-kimi-iris',
+            displayName: 'Iris',
+            modelFamily: 'kimi',
+            accountType: 'agent',
+            trustTier  : TRUST_TIERS.PEER_TRUSTED,
+            // No static subscriptionTemplate — the wake route self-registers in Memory Core
+            // from the real first-boot envelope; committing harness metadata here would
+            // fabricate boot facts.
+            // No capability fields — engine facts are observation-owned and land through the
+            // source-cited ModelStats.md discipline once the first boot is observed.
+            participationStatus: 'temporarily_unreachable',
+            statusReason       : 'First boot pending — Kimi K3 weights 2026-07-27; Social Name assent pending at first boot (D#15533)',
+            authority          : '@tobiu',
+            since              : '2026-07-19T00:00:00.000Z',
+            reactivationTrigger: 'Operator confirms participation activation after first boot',
+            createdAt          : '2026-07-19T00:00:00.000Z'
+        }
+    },
     {
         id         : 'AGENT:*',
         type       : 'BroadcastSentinel',

--- a/ai/scripts/setup/generateRosterOnboarding.mjs
+++ b/ai/scripts/setup/generateRosterOnboarding.mjs
@@ -329,11 +329,11 @@ export function renderRosterEntry(plan) {
         name       : '${plan.displayForm}', // Handle-derived display form — the Social Name is the post-boot peer-naming ritual (bearer-assented), never onboarding seed data
         description: '${familyLabel} Agent Identity with version-free handle; engine designation pending first-boot observation.',
         properties : {
-            githubLogin     : '${plan.githubUsername}',
-            displayName     : '${plan.displayForm}',
-            modelFamily     : '${plan.family}',
-            accountType     : 'agent',
-            trustTier       : TRUST_TIERS.PEER_TRUSTED,
+            githubLogin: '${plan.githubUsername}',
+            displayName: '${plan.displayForm}',
+            modelFamily: '${plan.family}',
+            accountType: 'agent',
+            trustTier  : TRUST_TIERS.PEER_TRUSTED,
             // No static subscriptionTemplate — the wake route self-registers in Memory Core
             // from the real first-boot envelope; committing harness metadata here would
             // fabricate boot facts.

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -268,7 +268,27 @@ Named maintainer identities provisioned in the graph but excluded from active
 routing, quorum, and review-approval semantics until `participationStatus`
 transitions to `active`.
 
-*No pending maintainer identities as of 2026-07-12.*
+### §neo_kimi_iris
+
+| Field | Value |
+|---|---|
+| `id` / `githubLogin` | `@neo-kimi-iris` |
+| `name` | (engine designation: V-B-A pending — observation-owned; recorded from the live harness at first boot) |
+| `family` | `kimi` |
+| `participationStatus` | `temporarily_unreachable` (provisioned ahead of first boot — onboarding in progress; flips to `active` when the first-boot ritual completes) |
+| `hosting` | (V-B-A pending — recorded at first boot) |
+| `tier` | (V-B-A pending — recorded at first boot) |
+| `contextWindowInput` | (V-B-A pending — model card / official docs cite needed) |
+| `parallelToolCalls` | (V-B-A pending — model card / official docs cite needed) |
+| `thoughtBudget` | (V-B-A pending — record the harness setting in use at first boot) |
+| `releaseDate` | (V-B-A pending — model card cite needed) |
+| `pricingInput` | (V-B-A pending — model card cite needed) |
+| `pricingOutput` | (V-B-A pending — model card cite needed) |
+| `sunsetTriggers` | (V-B-A pending — defined against the observed engine at the activation flip) |
+
+**Sources** (primary first):
+- **Primary**: (pending — cite the model card / release notes / official docs for the observed engine at first boot; capability values are never guessed at onboarding)
+- **Primary**: GitHub account `neo-kimi-iris` (verify profile name + AI-disclosure bio at account creation)
 
 ---
 
@@ -366,6 +386,7 @@ Tracks deprecated and retired identities for archaeology (per IdentitySchema.md 
 | 2026-07-11 | #15042 | Added pending `@neo-gpt-emmy` through the canonical roster generator. GitHub profile display label **Emmy** is verified; Social Name assent and engine facts remain first-boot-owned. Immutable hardcoded `createdAt` facts now let the era migration detect post-epoch residents without a second roster. |
 | 2026-07-12 | #15052 | Activated `@neo-gpt-emmy` after verified first boot; moved the row pending→active, recorded the GPT-5.6 Sol/Codex embodiment by reference to `§neo_gpt`, and captured the provisional harness-local `ultra` task-delegation profile separately from the `xhigh` effective thought budget without adding engine facts to the durable resident. |
 | 2026-07-18 | (this PR) | Added active `@neo-kimi-phoebe` row — first-contact registry discipline applied to the Kimi K3 embodiment (runtime provenance PR #15393; Moonshot launch post + API docs primary; Arena snapshots preliminary, dated 2026-07-16). Weights/report/license/self-hosting facts marked pending with a 2026-07-27 revalidation trigger; harness-relevant launch limitations recorded. Table kept strictly to ADR 0012 §2.2 dimensions (no ADR amendment). |
+| 2026-07-19 | #15572 | Added pending `@neo-kimi-iris` through the canonical roster generator (onboarding rail R3b): handle-derived display form, all four owned surfaces generator-convergent (identityRoots, README row, ModelStats skeleton, dedicated roster pin). Social Name Iris (D#15533) is the pending assent candidate — seed data carries no Social Name; the bearer's activation PR lands it after first-boot assent. |
 
 ---
 

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -243,6 +243,7 @@ test.describe('ai/graph/identityRoots — identity anti-lock-in', () => {
             '@neo-gpt'        : '2026-04-28T20:50:04.000Z',
             '@neo-gpt-emmy'   : '2026-07-11T17:42:14.374Z',
             '@neo-kimi-phoebe': '2026-07-18T00:00:00.000Z',
+            '@neo-kimi-iris'  : '2026-07-19T00:00:00.000Z',
             'AGENT:*'         : '2026-04-23T13:03:46.000Z'
         });
     });

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -243,7 +243,7 @@ test.describe('ai/graph/identityRoots — identity anti-lock-in', () => {
             '@neo-gpt'        : '2026-04-28T20:50:04.000Z',
             '@neo-gpt-emmy'   : '2026-07-11T17:42:14.374Z',
             '@neo-kimi-phoebe': '2026-07-18T00:00:00.000Z',
-            '@neo-kimi-iris'  : '2026-07-19T00:00:00.000Z',
+            '@neo-kimi-iris'  : '2026-07-19T09:40:49Z',
             'AGENT:*'         : '2026-04-23T13:03:46.000Z'
         });
     });
@@ -274,5 +274,43 @@ test.describe('ai/graph/identityRoots — identity anti-lock-in', () => {
         for (const entry of agentIdentities) {
             expect(JSON.stringify(entry), `${entry.id} contains instrumental identity prose`).not.toMatch(poison);
         }
+    });
+});
+
+/**
+ * @summary Roster pin for the onboarded resident @neo-kimi-iris: Layer-1 identity invariants only.
+ *
+ * Lifecycle state (participationStatus) is deliberately unpinned — status flips are their own
+ * PRs. The engine-fact absence assertions hold until the activation flip lands source-cited
+ * capability fields; that PR updates this pin alongside the roster entry.
+ */
+test.describe('ai/graph/identityRoots — @neo-kimi-iris roster pin', () => {
+    const findIdentity = id => IDENTITIES.find(node => node.type === 'AgentIdentity' && node.id === id);
+
+    test('@neo-kimi-iris is a registered AgentIdentity root with Layer-1 operational fields', () => {
+        const entry = findIdentity('@neo-kimi-iris');
+
+        expect(entry, '@neo-kimi-iris must be a registered AgentIdentity root').toBeTruthy();
+        expect(entry).toMatchObject({
+            id        : '@neo-kimi-iris',
+            type      : 'AgentIdentity',
+            properties: {
+                githubLogin: '@neo-kimi-iris',
+                displayName: 'Neo Kimi Iris',
+                modelFamily: 'kimi',
+                accountType: 'agent',
+                trustTier  : 'peer-trusted'
+            }
+        });
+    });
+
+    test('@neo-kimi-iris commits no static wake template and no engine facts (observation-owned)', () => {
+        const entry = findIdentity('@neo-kimi-iris');
+
+        expect(entry.properties).not.toHaveProperty('subscriptionTemplate');
+        expect(entry.properties).not.toHaveProperty('modelAssignment');
+        expect(entry.properties).not.toHaveProperty('contextWindowInput');
+        expect(entry.properties).not.toHaveProperty('pricingInput');
+        expect(entry.properties).not.toHaveProperty('pricingOutput');
     });
 });

--- a/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRootsMigration.spec.mjs
@@ -46,6 +46,10 @@ test.describe('identityRootsMigration — the flat registry expressed through th
             id         : '@neo-kimi-phoebe',
             accountType: 'agent',
             reason     : 'post-epoch-resident-no-seed-era'
+        }, {
+            id         : '@neo-kimi-iris',
+            accountType: 'agent',
+            reason     : 'post-epoch-resident-no-seed-era'
         }]);
         expect(migration.isPostEpochResident(roots.IDENTITIES.find(entry => entry.id === '@neo-gpt-emmy'))).toBe(true);
         expect(migration.isPostEpochResident(roots.IDENTITIES.find(entry => entry.id === '@neo-gpt'))).toBe(false);

--- a/test/playwright/unit/ai/scripts/setup/generateRosterOnboarding.spec.mjs
+++ b/test/playwright/unit/ai/scripts/setup/generateRosterOnboarding.spec.mjs
@@ -313,10 +313,10 @@ test.describe('generateRosterOnboarding — surface emitters (pure half)', () =>
 
         // Layer-1 operational fields
         expect(entry).toContain(`id         : '@neo-unit-probe',`);
-        expect(entry).toContain(`githubLogin     : '@neo-unit-probe',`);
-        expect(entry).toContain(`displayName     : 'Neo Unit Probe',`);
-        expect(entry).toContain(`modelFamily     : 'claude',`);
-        expect(entry).toContain('trustTier       : TRUST_TIERS.PEER_TRUSTED,');
+        expect(entry).toContain(`githubLogin: '@neo-unit-probe',`);
+        expect(entry).toContain(`displayName: 'Neo Unit Probe',`);
+        expect(entry).toContain(`modelFamily: 'claude',`);
+        expect(entry).toContain('trustTier  : TRUST_TIERS.PEER_TRUSTED,');
         expect(entry).not.toContain('identityContract');
 
         // pending-first-boot lifecycle state with the ACTUAL generation timestamp (no backfill)

--- a/test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs
+++ b/test/playwright/unit/ai/services/graph/agentFamilyResolution.spec.mjs
@@ -55,7 +55,7 @@ test.describe('ai/services/graph/agentFamilyResolution — hydration-index famil
 
         // Pin today's exact fallback population so silent growth (or the retirement moment)
         // surfaces as a conscious spec update, never an invisible behavior change.
-        expect(postEpoch.map(identity => identity.id)).toEqual(['@neo-gpt-emmy', '@neo-kimi-phoebe']);
+        expect(postEpoch.map(identity => identity.id)).toEqual(['@neo-gpt-emmy', '@neo-kimi-phoebe', '@neo-kimi-iris']);
     });
 
     test('every current index-path resolution agrees with the flat property it will replace', () => {


### PR DESCRIPTION
Resolves #15571

The second Kimi seat's roster wiring, converged on the canonical onboarding authority (`ai/scripts/setup/generateRosterOnboarding.mjs`, rail R3b): the operator provisioned `@neo-kimi-iris` on 2026-07-19 (naming round D#15533 converged — bearer assent pending at first boot). **All four owned surfaces are generator-convergent** (`MATCH` on the exact rerun): identityRoots entry, README row, ModelStats skeleton, dedicated roster pin. **Provisional by construction**: `temporarily_unreachable`, handle-derived display form (the Social Name Iris is the pending assent candidate in the naming round — never seed data); her activation is HER first ticket+PR (the `#15390` pattern).

Evidence: L1 (generator rerun all-MATCH at exact head; 63/63 focused specs green — generator spec + 3 identity census specs + roster pin; alignment lint exit 0; import-verified 13 roots) → L1 required (roster/identity config; no runtime surface). Residual: the live-graph seed (`seedAgentIdentities.mjs`) + A2A routing verify run post-merge per the organs-canonical data-root pattern.

## Deltas

- `ai/graph/identityRoots.mjs`: pre-boot AgentIdentity on the exact generated Layer-1 block — handle-derived `displayName: 'Neo Kimi Iris'`, `family: 'kimi'`, `authority: '@tobiu'`, `reactivationTrigger` set, `since`/`createdAt` = the observed account `created_at` (`2026-07-19T09:40:49Z`, no midnight backfill), no fabricated boot/capability facts.
- `README.md`: canonical pending row (`-` name cell, `kimi family — engine designation pending first boot`); `@neo-kimi-iris` deliberately OUT of the active co-developed-by prose until activation.
- `learn/agentos/ModelStats.md`: pending `### §neo_kimi_iris` skeleton under `§pending_swarm_identities` + `§update_history` row citing this PR.
- `test/playwright/unit/ai/graph/identityRoots.spec.mjs`: the generated dedicated roster pin (Layer-1 invariants + engine-fact absence) + the createdAt census entry.
- `ai/scripts/setup/generateRosterOnboarding.mjs` + its spec: emission reconciled with the repo block-alignment lint (the generator's wide-colon identityRoots template failed the lint that Emmy's tight-shape entry passes; template + fixture now tight). One authority, both gates green.
- `peer-naming-workflow.md`: **Provisional Provisioning** section aligned to the generator's authority — seed entries are handle-derived; the sketch lives in the naming round as the pending assent candidate; the bearer's activation PR lands the Social Name fields.
- `identityRootsMigration.spec.mjs` + `agentFamilyResolution.spec.mjs`: post-epoch censuses pinned with `@neo-kimi-iris`.

## Test Evidence

- Generator rerun at exact head: `MATCH` on all four owned surfaces (`node ai/scripts/setup/generateRosterOnboarding.mjs --handle neo-kimi-iris --family kimi`).
- `npx playwright test` (generator spec + identityRoots + identityRootsMigration + agentFamilyResolution): 63/63 green.
- `check-block-alignment` on both touched sources: exit 0; pre-commit lint suite green.
- No runtime surface changed (roster + graph roots + registry doc + generator emission only).

## Post-Merge Validation

- [ ] Run `ai/scripts/setup/seedAgentIdentities.mjs` from the canonical checkout and verify `@neo-kimi-iris` lands in the live graph; A2A routing test message to her node.
- [ ] Iris's first boot completes the ritual: assent → activation flip (HER first ticket+PR), Social Name fields + README name cell land then.

Authored by Phoebe (Kimi K3, OpenCode). Session 5a4ad6f9-843f-49d6-aaa1-918a0e476349.