### PR TITLE
feat(dashboard): embody live tear-out vessels (#15396)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -14,7 +14,9 @@ import DockZoneModel                        from '../../../../../src/dashboard/D
 import InteractionService                   from '../../../../../src/ai/client/InteractionService.mjs';
 import {createDockKeyboardCommands}         from '../../../../../src/dashboard/DockKeyboardCommands.mjs';
 import {createDockTearOutHandlers}          from '../../../../../src/dashboard/DockTearOut.mjs';
+import {createDockVesselEmbodiment}         from '../../../../../src/dashboard/DockVesselEmbodiment.mjs';
 import {createDockWorkspaceSet}             from '../../../../../src/dashboard/DockWorkspaceSet.mjs';
+import {createVesselParkHandlers}           from '../../../../../src/dashboard/DockVesselPark.mjs';
 import TourRunner                           from '../../../../../src/ai/client/TourRunner.mjs';
 import {PREVIEW_SCHEMA, previewToOperation} from '../../../../../src/dashboard/dockPreviewContract.mjs';
 import {demoBTourScript, initialDocument}   from '../../../tour/demoBPerspectives.mjs';
@@ -68,7 +70,6 @@ class DemoBWorkspace extends Container {
      * @static
      */
     static POPUP_WORKSPACE_ID = 'demo-b-popup'
-
     static config = {
         /**
          * @member {String} className='AgentOS.childapps.dockdemo.view.DemoBWorkspace'
@@ -251,11 +252,43 @@ class DemoBWorkspace extends Container {
     /**
      * The connect-race partner of {@link #tearOutPanes}: records a tear-out vessel window that
      * connected BEFORE its terminal committed (long drags) as `tearOutConnects[itemId] =
-     * {appName, windowId}`. Adoption runs at whichever event lands SECOND — terminal or connect.
+     * {windowId}`. Adoption runs at whichever event lands SECOND — terminal or connect. Exact
+     * physical authority stays private on manager.Window and is resolved just in time.
      * @member {Object} tearOutConnects={}
      * @protected
      */
     tearOutConnects = {}
+    /**
+     * Exact connect continuations admitted by one consumed owner grant but not yet published after
+     * cross-window pane staging. Closing a vessel deletes this token before awaiting the platform,
+     * so the resumed stage can never publish a retired generation after the fence is later cleared.
+     * @member {Map<String,Object>} tearOutConnectAdmissions
+     * @protected
+     */
+    tearOutConnectAdmissions = new Map()
+    /**
+     * Transient render-only pane embodiment. An admitted pre-terminal vessel carries the real pane
+     * while an exact-slot placeholder preserves the source card/header pairing. Document truth is
+     * untouched until terminal; cancellation restores through the live placeholder position.
+     * @member {Object|null} tearOutEmbodiment=null
+     * @protected
+     */
+    tearOutEmbodiment = null
+    /**
+     * Items whose vessel retirement has started. The mark precedes pane restoration + native close,
+     * so a late async connect cannot reparent content into a generation already closing.
+     * @member {Set<String>} tearOutRetirements
+     * @protected
+     */
+    tearOutRetirements = new Set()
+    /**
+     * Monotonic count of actual tear-out `windowOpen` attempts. The headed conversion witness
+     * snapshots this counter at first park and after re-show; equality is the mechanical proof
+     * that one continuous gesture never tries to reacquire popup activation.
+     * @member {Number} tearOutAcquisitionAttempts=0
+     * @protected
+     */
+    tearOutAcquisitionAttempts = 0
     /**
      * Product-semantic owner grants for popup vessels. The merged native-window identity spine
      * proves the exact physical child; this map binds that child to one product flow + item +
@@ -369,6 +402,12 @@ class DemoBWorkspace extends Container {
         me.interactionService = Neo.create(InteractionService, {});
         me.perspectiveStore = Neo.create(DockPerspectiveStore, {});
 
+        me.tearOutEmbodiment = createDockVesselEmbodiment({
+            resolvePane: itemId => me.paneCache[itemId]
+                ?? (me.dockModel?.items?.[itemId] && me.resolvePane(itemId, me.dockModel.items[itemId])),
+            resolveTarget: windowId => Neo.apps[windowId]?.mainView ?? null
+        });
+
         // The gesture tear-out choreography (MAIN workspace only): the admission machine holds the
         // one vessel slot; this host supplies the platform seams. The composition law: a tear-out
         // vessel NEVER writes `detachedPanes` mid-gesture — that single omission keeps the
@@ -379,12 +418,16 @@ class DemoBWorkspace extends Container {
         me.tearOutHandlers = createDockTearOutHandlers({
             applyOperation  : descriptor => me.applyTearOutOperation(descriptor),
             closeVessel     : vessel => me.closeTearOutVessel(vessel),
-            onDocumentChange: (document, operation) => {
-                me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, document);
-                // The committed detach is the adoption trigger: the vessel owns the item now.
-                operation?.operation === 'detachItem' && me.adoptTearOutPane(operation.itemId)
-            },
-            openVessel: request => me.openTearOutVessel(request)
+            onDocumentChange: (document, operation, vessel) => me.onTearOutDocumentChange(document, operation, vessel),
+            openVessel      : request => me.openTearOutVessel(request)
+        });
+
+        // Conversion never reacquires a popup. The source-owned admission machines retain the
+        // existing tear-out vessel while this host binds their effects to its exact native route.
+        me.vesselParkHandlers = createVesselParkHandlers({
+            disposeVessel: vessel => me.disposeParkedTearOutVessel(vessel),
+            parkVessel   : vessel => me.parkTearOutVessel(vessel),
+            reshowVessel : vessel => me.reshowTearOutVessel(vessel)
         });
 
         // The keyboard command surface — the discrete a11y-parity twin of the gesture paths,
@@ -402,12 +445,8 @@ class DemoBWorkspace extends Container {
             focusVessel     : vessel => me.focusNamedWindow(vessel.windowName),
             focusWorkspace  : ({workspaceId}) => me.focusDockWorkspaceWindow(workspaceId),
             highlightTarget : target => me.setKeyboardTargetHighlight(target),
-            onDocumentChange: (document, operation) => {
-                me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, document);
-                // the committed detach is the adoption trigger — identical to the pointer path
-                operation?.operation === 'detachItem' && me.adoptTearOutPane(operation.itemId)
-            },
-            openVessel: request => me.openTearOutVessel(request)
+            onDocumentChange: (document, operation) => me.onTearOutDocumentChange(document, operation),
+            openVessel      : request => me.openTearOutVessel(request)
         });
 
         me.tourRunner = Neo.create(TourRunner, {
@@ -451,6 +490,7 @@ class DemoBWorkspace extends Container {
             // unobtrusive, never hidden from the accessibility tree. `role` rides the
             // Component.Base config (the renderer owns root-attr routing); aria-live rides the vdom.
             cls      : ['agentos-dockdemo-kbd-live'],
+            height   : 14,
             ntype    : 'component',
             reference: 'kbd-live-b',
             role     : 'status',
@@ -1322,10 +1362,11 @@ class DemoBWorkspace extends Container {
             workspaceId  = DemoBWorkspace.POPUP_WORKSPACE_ID,
             generation   = me.crossWindowStageGeneration,
             [live, host] = app.mainView.add([{
-                cls  : ['agentos-dockdemo-kbd-live'],
-                ntype: 'component',
-                role : 'status',
-                vdom : {'aria-live': 'polite', cn: []}
+                cls   : ['agentos-dockdemo-kbd-live'],
+                height: 14,
+                ntype : 'component',
+                role  : 'status',
+                vdom  : {'aria-live': 'polite', cn: []}
             }, {
                 module: Container,
                 cls   : ['agentos-dockdemo-dock-host', 'neo-dashboard'],
@@ -1772,8 +1813,14 @@ class DemoBWorkspace extends Container {
                             && sourceDecision.localDropFires === 0,
                         targetItemPlaced        : !!targetDocument.items?.[itemId]
                             && targetTabsId === descriptor.target?.tabsNodeId,
+                        targetMountDelta: Number.isInteger(context?.vesselMountCount)
+                            ? (pane?.mountCount ?? 0) - context.vesselMountCount
+                            : null,
                         targetTabsId,
-                        transferCommits         : me.crossWindowStats.transferCommits
+                        transferCommits : me.crossWindowStats.transferCommits,
+                        vesselMountDelta: Number.isInteger(context?.vesselMountCount)
+                            ? context.vesselMountCount - (context?.mountCount ?? 0)
+                            : null
                     },
                     checks         = [
                         ['transfer committed exactly once', proof.transferCommits === 1],
@@ -1784,7 +1831,9 @@ class DemoBWorkspace extends Container {
                         ['target document placed the item', proof.targetItemPlaced],
                         ['worker component instance stayed identical', proof.sameInstance],
                         ['instance heartbeat did not reset', proof.framesNotReset],
-                        ['target document added exactly one mount', proof.mountDelta === 1],
+                        ['live vessel added exactly one mount', proof.vesselMountDelta === 1],
+                        ['target document added exactly one mount', proof.targetMountDelta === 1],
+                        ['live vessel and target added exactly two mounts', proof.mountDelta === 2],
                         ['continuity witness is complete', typeof pane?.id === 'string'
                             && Number.isInteger(pane?.mountCount)]
                     ],
@@ -2109,10 +2158,28 @@ class DemoBWorkspace extends Container {
             sourceRect    = sourceWindow?.innerRect,
             targetRect    = targetWindow?.innerRect,
             gap           = 40,
-            candidates, desired, snapshot;
+            candidates, desired, overlaps, snapshot;
 
         if (!sourceRect || !targetRect || !screen) {
             return {ready: false, reason: 'window geometry or screen bounds are unavailable'}
+        }
+
+        overlaps = sourceRect.x < targetRect.right
+            && sourceRect.right > targetRect.x
+            && sourceRect.y < targetRect.bottom
+            && sourceRect.bottom > targetRect.y;
+
+        // A headed harness or the platform itself may already have established a valid stage.
+        // The observed manager rectangles are the authority; moving again can be denied or
+        // clamped and must never turn a ready physical arrangement back into an overlap.
+        if (!overlaps) {
+            return {
+                desired: {x: targetRect.x, y: targetRect.y},
+                ready  : true,
+                reused : true,
+                source : sourceRect,
+                target : targetRect
+            }
         }
 
         candidates = [{x: sourceRect.right + gap, y: sourceRect.y}, {
@@ -2154,7 +2221,7 @@ class DemoBWorkspace extends Container {
             sourceRect   = sourceWindow?.innerRect;
             targetRect   = targetWindow?.innerRect;
 
-            let overlaps = sourceRect && targetRect
+            overlaps = sourceRect && targetRect
                 && sourceRect.x < targetRect.right
                 && sourceRect.right > targetRect.x
                 && sourceRect.y < targetRect.bottom
@@ -2183,11 +2250,16 @@ class DemoBWorkspace extends Container {
      * @param {Object} [options={}]
      * @param {Boolean} [options.cancelAtTarget=false] Whitebox-only branch: Escape after
      * remote preview settles, before mouseup. This option never enters tour-script data.
+     * @param {Boolean} [options.roundTrip=false] Whitebox-only branch: after first park, leave the
+     * target, require same-vessel re-show with zero re-acquisition, then release detached.
+     * @param {Number} [options.parkObservationMs=0] Whitebox-only bounded observation window after
+     * strict park admission; lets the headed harness inspect real focus/placement before re-show.
      * @returns {Promise<Object>}
      */
-    async executeCrossWindowStep(step, {cancelAtTarget = false} = {}) {
-        let me          = this,
-            sourceProbe = null,
+    async executeCrossWindowStep(step, {cancelAtTarget = false, parkObservationMs = 0, roundTrip = false} = {}) {
+        let me                        = this,
+            acquisitionAttemptsBefore = me.tearOutAcquisitionAttempts,
+            sourceProbe               = null,
             {
                 itemId,
                 sourceWorkspaceId,
@@ -2364,10 +2436,74 @@ class DemoBWorkspace extends Container {
                 options : options(sourceX + 34, sourceY, targetScreenX + 2, targetScreenY, 1)
             }]});
 
-            let remoteSnapshot = await me.waitForCrossWindowRemotePreview(me.crossWindowGestureContext);
+            let conversionSettlement = false,
+                remoteSnapshot;
+
+            for (let attempt = 0; attempt <= 120 && !me.isDestroyed; attempt++) {
+                remoteSnapshot = me.readCrossWindowRemoteSnapshot(me.crossWindowGestureContext);
+
+                if (remoteSnapshot.ready || attempt === 120) break;
+
+                await me.interactionService.simulateEvent({events: [{
+                    delay   : 16,
+                    targetId: sourceButton.id,
+                    type    : 'mousemove',
+                    windowId: sourceButton.windowId,
+                    options : options(
+                        sourceX + 36 + attempt % 2,
+                        sourceY,
+                        targetScreenX + 4 + attempt % 2,
+                        targetScreenY,
+                        1
+                    )
+                }]});
+
+                let transition = sourceZone.vesselConversionSensor?.transitionPromise;
+
+                transition && (conversionSettlement = await transition)
+            }
 
             if (!remoteSnapshot.ready) {
-                let cancellation = await me.cancelCrossWindowGesture(me.crossWindowGestureContext);
+                let candidateDiagnostics = [],
+                    group                = sourceZone.dragCoordinator.sortZones.get(sourceZone.sortGroup);
+
+                group?.forEach((zone, windowId) => {
+                    let inner  = WindowManager.get(windowId)?.innerRect,
+                        localX = inner ? targetScreenX - inner.x : null,
+                        localY = inner ? targetScreenY - inner.y : null;
+
+                    candidateDiagnostics.push({
+                        accepts        : inner && typeof zone.acceptsRemoteDrag === 'function'
+                            ? zone.acceptsRemoteDrag(localX, localY)
+                            : null,
+                        innerRect      : inner && {
+                            height: inner.height,
+                            width : inner.width,
+                            x     : inner.x,
+                            y     : inner.y
+                        },
+                        localX,
+                        localY,
+                        sameAsSource  : zone === sourceZone,
+                        stableTargetId: zone.stableTargetId ?? null,
+                        windowId
+                    })
+                });
+
+                let conversion = {
+                        converted      : sourceZone.vesselConversionSensor?.converted ?? null,
+                        dragComponent  : sourceZone.dragComponent?.id ?? null,
+                        dragProxy      : sourceZone.dragProxy?.id ?? null,
+                        enabled        : sourceZone.enableVesselConversion,
+                        logicalRect    : sourceZone.vesselConversionLogicalRect ?? null,
+                        sourceRect     : sourceZone.vesselConversionSourceRect ?? null,
+                        targetConverted: sourceZone.vesselConversionSensor?.targetConverted ?? null,
+                        targetId       : sourceZone.vesselConversionTargetId ?? null,
+                        targetRect     : sourceZone.vesselConversionTargetRect ?? null,
+                        transitioning  : sourceZone.vesselConversionSensor?.transitioning ?? null,
+                        windowDragging : sourceZone.isWindowDragging
+                    },
+                    cancellation = await me.cancelCrossWindowGesture(me.crossWindowGestureContext);
 
                 me.restoreCrossWindowSourceProbe(sourceProbe);
                 me.crossWindowGestureResolve = null;
@@ -2376,11 +2512,254 @@ class DemoBWorkspace extends Container {
                 return {
                     applied: false,
                     errors : ['remote target did not expose a settled semantic preview'],
-                    debug  : {cancellation, readiness, remoteSnapshot}
+                    debug  : {
+                        candidateDiagnostics,
+                        cancellation,
+                        conversion,
+                        conversionSettlement,
+                        parkReceipt  : me.lastVesselParkReceipt ?? null,
+                        readiness,
+                        remoteSnapshot,
+                        stagePlacement,
+                        targetGeometry,
+                        targetPointer: {screenX: targetScreenX, screenY: targetScreenY},
+                        windows      : WindowManager.toJSON()
+                    }
                 }
             }
 
             me.crossWindowGestureContext.remoteSnapshot = remoteSnapshot;
+            me.crossWindowGestureContext.vesselMountCount = pane.mountCount;
+
+            if (roundTrip) {
+                // Remote preview can settle before the asynchronously-acquired tear-out child has
+                // connected and published its exact source rect. Keep driving the real pointer
+                // cadence until strict conversion admission settles; a human gesture naturally
+                // supplies these frames while crossing the target, and the whitebox screenplay
+                // must not mistake preview readiness for physical park readiness.
+                for (let attempt = 0; attempt <= 120 && !me.isDestroyed; attempt++) {
+                    let sensor = sourceZone.vesselConversionSensor;
+
+                    if (sensor?.converted && !sensor.transitioning && me.lastVesselParkReceipt?.parked === true) break;
+
+                    await me.interactionService.simulateEvent({events: [{
+                        delay   : 16,
+                        targetId: sourceButton.id,
+                        type    : 'mousemove',
+                        windowId: sourceButton.windowId,
+                        options : options(
+                            sourceX + 38 + attempt % 2,
+                            sourceY,
+                            targetScreenX + 6 + attempt % 2,
+                            targetScreenY,
+                            1
+                        )
+                    }]});
+
+                    let transition = sourceZone.vesselConversionSensor?.transitionPromise;
+
+                    transition && (conversionSettlement = await transition)
+                }
+
+                let sensor = sourceZone.vesselConversionSensor;
+
+                if (!sensor?.converted || sensor.transitioning || me.lastVesselParkReceipt?.parked !== true) {
+                    let cancellation = await me.cancelCrossWindowGesture(me.crossWindowGestureContext);
+
+                    me.restoreCrossWindowSourceProbe(sourceProbe);
+                    me.crossWindowGestureResolve = null;
+                    me.crossWindowGestureContext = null;
+
+                    return {
+                        applied: false,
+                        errors : ['tear-out vessel did not reach strict park admission'],
+                        debug  : {
+                            cancellation,
+                            conversionSettlement,
+                            parkReceipt: me.lastVesselParkReceipt ?? null,
+                            remoteSnapshot,
+                            sensor     : {
+                                converted      : sensor?.converted ?? null,
+                                targetConverted: sensor?.targetConverted ?? null,
+                                transitioning  : sensor?.transitioning ?? null
+                            }
+                        }
+                    }
+                }
+
+                if (Number.isFinite(parkObservationMs) && parkObservationMs > 0) {
+                    await me.timeout(Math.min(parkObservationMs, 2000))
+                }
+
+                const identity = () => {
+                    let vessel = me.resolveTearOutVessel(itemId),
+                        route  = vessel?.nativeRoute;
+
+                    return {
+                        nativeHandleKey: route?.nativeHandleKey ?? null,
+                        windowId       : vessel?.windowId ?? null,
+                        windowName     : vessel?.windowName ?? null
+                    }
+                };
+
+                let firstIdentity      = identity(),
+                    acquisitionsAtPark = me.tearOutAcquisitionAttempts,
+                    voidX              = sourceX + 80,
+                    voidY              = sourceY + 160,
+                    voidScreenX        = sourceWindow.innerRect.x + voidX,
+                    voidScreenY        = sourceWindow.innerRect.y + voidY,
+                    outSnapshot;
+
+                for (let attempt = 0; attempt <= 120 && !me.isDestroyed; attempt++) {
+                    await me.interactionService.simulateEvent({events: [{
+                        delay   : 16,
+                        targetId: sourceButton.id,
+                        type    : 'mousemove',
+                        windowId: sourceButton.windowId,
+                        options : options(
+                            voidX + attempt % 2,
+                            voidY,
+                            voidScreenX + attempt % 2,
+                            voidScreenY,
+                            1
+                        )
+                    }]});
+
+                    let transition = sourceZone.vesselConversionSensor?.transitionPromise;
+
+                    transition && await transition;
+                    outSnapshot = me.readCrossWindowRemoteSnapshot(me.crossWindowGestureContext);
+
+                    if (
+                        sourceZone.vesselConversionSensor?.converted === false &&
+                        sourceZone.vesselConversionSensor?.transitioning === false &&
+                        !outSnapshot.engaged && !me.vesselParkHandlers.parkedVessel
+                    ) break
+                }
+
+                let restoredIdentity = identity(),
+                    restored         = sourceZone.vesselConversionSensor?.converted === false
+                        && sourceZone.vesselConversionSensor?.transitioning === false
+                        && !outSnapshot?.engaged && !me.vesselParkHandlers.parkedVessel;
+
+                if (!restored) {
+                    let cancellation = await me.cancelCrossWindowGesture(me.crossWindowGestureContext);
+
+                    me.restoreCrossWindowSourceProbe(sourceProbe);
+                    me.crossWindowGestureResolve = null;
+                    me.crossWindowGestureContext = null;
+
+                    return {
+                        applied: false,
+                        errors : ['converted vessel did not re-show after leaving the target'],
+                        debug  : {
+                            acquisitionsAtPark,
+                            cancellation,
+                            firstIdentity,
+                            outSnapshot,
+                            restoredIdentity,
+                            sensor: {
+                                converted    : sourceZone.vesselConversionSensor?.converted ?? null,
+                                transitioning: sourceZone.vesselConversionSensor?.transitioning ?? null
+                            }
+                        }
+                    }
+                }
+
+                let acquisitionsAfterRestore = me.tearOutAcquisitionAttempts;
+
+                await me.interactionService.simulateEvent({events: [{
+                    targetId: sourceButton.id,
+                    type    : 'mouseup',
+                    windowId: sourceButton.windowId,
+                    options : options(voidX, voidY, voidScreenX, voidScreenY, 0)
+                }]});
+
+                let detached;
+
+                for (let attempt = 0; attempt <= 120 && !me.isDestroyed; attempt++) {
+                    let sourceDocument = me.getWorkspaceDocument(sourceWorkspaceId),
+                        entry          = me.tearOutPanes[itemId];
+
+                    detached = {
+                        catalogRetained: !!sourceDocument?.items?.[itemId],
+                        entry          : entry ? {...entry} : null,
+                        itemAbsent     : DockZoneModel.findContainingTabsId(sourceDocument, itemId) === null
+                    };
+
+                    if (
+                        detached.entry?.windowId === firstIdentity.windowId &&
+                        detached.catalogRetained && detached.itemAbsent
+                    ) break;
+
+                    await me.timeout(16)
+                }
+
+                await me.awaitProjectionIdle();
+
+                let terminalIdentity = identity(),
+                    sourceAfter      = DockZoneModel.clone(me.getWorkspaceDocument(sourceWorkspaceId)),
+                    targetAfter      = DockZoneModel.clone(me.getWorkspaceDocument(targetWorkspaceId)),
+                    proof            = {
+                        acquisitionAttempts: {
+                            afterRestore            : acquisitionsAfterRestore,
+                            atFirstPark             : acquisitionsAtPark,
+                            beforeGesture           : acquisitionAttemptsBefore,
+                            midGestureReacquisitions: acquisitionsAfterRestore - acquisitionsAtPark,
+                            totalGestureAttempts    : acquisitionsAfterRestore - acquisitionAttemptsBefore
+                        },
+                        detached,
+                        firstIdentity,
+                        firstRemoteSnapshot: remoteSnapshot,
+                        outSnapshot,
+                        parkReceipt        : me.lastVesselParkReceipt ?? null,
+                        parkSlotCleared    : !me.vesselParkHandlers.parkedVessel,
+                        restoreReceipt     : me.lastVesselRestoreReceipt ?? null,
+                        restored,
+                        restoredIdentity,
+                        sameNativeHandle   : Boolean(firstIdentity.nativeHandleKey)
+                            && restoredIdentity.nativeHandleKey === firstIdentity.nativeHandleKey
+                            && terminalIdentity.nativeHandleKey === firstIdentity.nativeHandleKey,
+                        sameWindowId: Boolean(firstIdentity.windowId)
+                            && restoredIdentity.windowId === firstIdentity.windowId
+                            && terminalIdentity.windowId === firstIdentity.windowId,
+                        stats: {...me.crossWindowStats},
+                        terminalIdentity
+                    },
+                    checks = [
+                        ['exactly one tear-out acquisition occurred', proof.acquisitionAttempts.totalGestureAttempts === 1],
+                        ['out-conversion performed zero re-acquisitions', proof.acquisitionAttempts.midGestureReacquisitions === 0],
+                        ['out-conversion re-showed the same native handle', proof.sameNativeHandle],
+                        ['out-conversion retained the same window id', proof.sameWindowId],
+                        ['park used a strict exact-handle move', proof.parkReceipt?.parked === true],
+                        ['out-conversion used a strict exact-handle move', proof.restoreReceipt?.admitted === true],
+                        ['park ownership cleared after re-show', proof.parkSlotCleared],
+                        ['detached terminal retained the catalog item', detached?.catalogRetained === true],
+                        ['detached terminal removed the item from the dock tree', detached?.itemAbsent === true],
+                        ['detached terminal adopted the exact vessel', detached?.entry?.windowId === firstIdentity.windowId],
+                        ['remote transfer did not commit', me.crossWindowStats.transferCommits === 0],
+                        ['source remote-drop-out did not fire', me.crossWindowStats.remoteDropOutFires === 0],
+                        ['source local drop stayed suppressed', me.crossWindowStats.localDropFires === 0]
+                    ],
+                    errors = checks.filter(([, passed]) => !passed).map(([message]) => message),
+                    result = {
+                        applied       : errors.length === 0,
+                        errors,
+                        proof,
+                        sourceDocument: sourceAfter,
+                        targetDocument: targetAfter,
+                        witness       : {
+                            instanceId: pane?.id ?? null,
+                            mountCount: pane?.mountCount ?? null
+                        }
+                    };
+
+                me.restoreCrossWindowSourceProbe(sourceProbe);
+                me.crossWindowGestureResolve = null;
+                me.crossWindowGestureContext = null;
+
+                return result
+            }
 
             if (cancelAtTarget) {
                 let sourceBefore = DockZoneModel.clone(me.getWorkspaceDocument(sourceWorkspaceId)),
@@ -2808,13 +3187,15 @@ class DemoBWorkspace extends Container {
 
         if (!app || me.isDestroyed) return;
 
-        let url         = await Neo.Main.getByPath({path: 'document.URL', windowId}),
-            params      = new URL(url).searchParams,
-            workspaceId = params.get('workspaceId'),
-            itemId      = params.get('popout'),
-            flow        = params.get('vesselFlow'),
-            grant       = params.get('vesselGrant'),
-            generation  = Number(params.get('vesselGeneration'));
+        let url            = await Neo.Main.getByPath({path: 'document.URL', windowId}),
+            params         = new URL(url).searchParams,
+            workspaceId    = params.get('workspaceId'),
+            itemId         = params.get('popout'),
+            flow           = params.get('vesselFlow'),
+            grant          = params.get('vesselGrant'),
+            admissionValue = params.get('vesselAdmission'),
+            admissionToken = admissionValue === null ? NaN : Number(admissionValue),
+            generation     = Number(params.get('vesselGeneration'));
 
         if (params.get('hostId') !== me.id) return;
 
@@ -2841,16 +3222,75 @@ class DemoBWorkspace extends Container {
         if (!itemId) return;
         if (flow !== 'click-popout' && flow !== 'tear-out') return;
 
+        if (flow === 'tear-out' && !Number.isFinite(admissionToken)) return;
+
+        // Retirement authority is established before any awaited close. A connect continuation
+        // that resumes after that boundary is cleanup-only. Consume its exact grant and retain the
+        // route for a refused-close retry, but never stage or publish content into the closing realm.
+        if (flow === 'tear-out' && me.tearOutRetirements.has(itemId)) {
+            if (me.consumeVesselOwnerGrant({data, flow, generation, grant, itemId, windowId})) {
+                const admission = {
+                    admissionToken, generation, invalidated: true, windowId
+                };
+
+                Object.defineProperty(admission, 'nativeRoute', {value: data.windowData.nativeRoute});
+                me.tearOutConnectAdmissions.set(itemId, admission)
+            }
+            return
+        }
+
         if (!me.consumeVesselOwnerGrant({data, flow, generation, grant, itemId, windowId})) return;
 
         // Click-popout creates its entry before windowOpen; tear-out deliberately does not.
         // Keeping those births separate is load-bearing: an ungranted connect stays inert rather
         // than becoming stray tearOutConnects state or stealing an existing detachedPanes entry.
+        // A granted tear-out DOES embody immediately: the same live pane moves into the vessel while
+        // a hidden exact-slot placeholder keeps source tab/card indices coherent. Model truth remains
+        // untouched until the terminal.
         if (flow === 'tear-out') {
+            const
+                admission  = {admissionToken, generation, invalidated: false, windowId},
+                connection = {windowId};
+
+            Object.defineProperties(connection, {
+                admissionToken: {value: admissionToken},
+                generation    : {value: generation},
+                nativeRoute   : {value: data.windowData.nativeRoute}
+            });
+            Object.defineProperty(admission, 'nativeRoute', {value: data.windowData.nativeRoute});
+            me.tearOutConnectAdmissions.set(itemId, admission);
+
+            const staged = await me.tearOutEmbodiment.stage({itemId, windowId});
+
+            // A re-entry/cancel may retire the semantic vessel while the cross-window render
+            // transaction is still painting. The exact admission token is durable across a close
+            // acknowledgement clearing the transient retirement fence, so a dead generation can
+            // never resume here and publish itself after its disconnect already fired.
+            if (
+                me.tearOutConnectAdmissions.get(itemId) !== admission || admission.invalidated ||
+                me.tearOutRetirements.has(itemId)
+            ) {
+                staged && me.tearOutEmbodiment.restore({itemId, windowId});
+                return
+            }
+
+            me.tearOutConnectAdmissions.delete(itemId);
+
             if (me.tearOutPanes[itemId]) {
-                me.reparentTearOutPane(itemId, {windowId})
+                Object.assign(me.tearOutPanes[itemId], connection);
+                Object.defineProperties(me.tearOutPanes[itemId], {
+                    admissionToken: {configurable: true, value: admissionToken, writable: true},
+                    generation    : {configurable: true, value: generation, writable: true},
+                    nativeRoute   : {configurable: true, value: data.windowData.nativeRoute, writable: true}
+                });
+
+                if (staged) {
+                    me.tearOutEmbodiment.promote({itemId, windowId})
+                } else {
+                    me.reparentTearOutPane(itemId, connection)
+                }
             } else {
-                me.tearOutConnects[itemId] = {windowId}
+                me.tearOutConnects[itemId] = connection;
             }
             return
         }
@@ -2971,10 +3411,72 @@ class DemoBWorkspace extends Container {
             return
         }
 
+        // A child can disconnect while its live-pane stage is still awaiting renderer settlement.
+        // The connect is not in tearOutConnects yet, so this private generation token is the only
+        // exact owner. Retire it now; the stage continuation observes the deleted token and cannot
+        // republish the dead window.
+        for (const [itemId, admission] of me.tearOutConnectAdmissions) {
+            if (admission.windowId === data.windowId) {
+                const
+                    committed  = Boolean(me.tearOutPanes[itemId]),
+                    windowName = `tearout-${itemId}`;
+
+                me.tearOutConnectAdmissions.delete(itemId);
+                me.tearOutRetirements.add(itemId);
+
+                if (me.tearOutEmbodiment.isStaged(itemId)) {
+                    me.tearOutEmbodiment.restore({itemId, windowId: data.windowId})
+                }
+
+                me.tearOutHandlers.onVesselRetired({
+                    admissionToken: admission.admissionToken,
+                    generation    : admission.generation,
+                    itemId,
+                    windowName
+                });
+                me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
+                me.revokeVesselOwnerGrant('tear-out', itemId);
+                me.tearOutRetirements.delete(itemId);
+                delete me.tearOutPanes[itemId];
+                committed && me.reintegrateTearOutItem(itemId);
+                return
+            }
+        }
+
         for (const [itemId, entry] of Object.entries(me.detachedPanes)) {
             if (entry.windowId === data.windowId) {
                 me.reattachPane(itemId, {windowAlreadyClosed: true});
                 break
+            }
+        }
+
+        // A pre-terminal tear-out may disconnect after an exact close returned false (the native
+        // event can outrun its Boolean acknowledgement) or after the user closes the retained
+        // recovery window manually. Physical death is now authoritative: clear BOTH state owners
+        // so a successor gesture cannot inherit or be blocked by the retired generation.
+        for (const [itemId, entry] of Object.entries(me.tearOutConnects)) {
+            if (entry.windowId === data.windowId) {
+                const windowName = `tearout-${itemId}`;
+
+                me.tearOutRetirements.add(itemId);
+
+                if (me.tearOutEmbodiment.isStaged(itemId)) {
+                    const sourceOwns = Boolean(DockZoneModel.findContainingTabsId(me.dockModel, itemId));
+
+                    me.tearOutEmbodiment[sourceOwns ? 'restore' : 'promote']({itemId, windowId: entry.windowId})
+                }
+
+                delete me.tearOutConnects[itemId];
+                me.tearOutHandlers.onVesselRetired({
+                    admissionToken: entry.admissionToken,
+                    generation    : entry.generation,
+                    itemId,
+                    windowName
+                });
+                me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
+                me.revokeVesselOwnerGrant('tear-out', itemId);
+                me.tearOutRetirements.delete(itemId);
+                return
             }
         }
 
@@ -2984,12 +3486,49 @@ class DemoBWorkspace extends Container {
         // entry in either map and needs nothing.
         for (const [itemId, entry] of Object.entries(me.tearOutPanes)) {
             if (entry.windowId === data.windowId) {
+                const windowName = entry.windowName ?? `tearout-${itemId}`;
+
                 delete me.tearOutPanes[itemId];
                 delete me.tearOutConnects[itemId];
+                me.tearOutRetirements.delete(itemId);
+                me.tearOutHandlers.onVesselRetired({
+                    admissionToken: entry.admissionToken,
+                    generation    : entry.generation,
+                    itemId,
+                    windowName
+                });
+                me.vesselParkHandlers.onVesselRetired({itemId, retirement: true});
                 me.reintegrateTearOutItem(itemId);
                 break
             }
         }
+    }
+
+    /**
+     * @summary Commits a detached terminal without sacrificing the live pane to projection order.
+     * @description A connect-first vessel already carries the pane and leaves an exact-slot source
+     * placeholder for ordinary projection cleanup. A terminal-first vessel has no placeholder, so
+     * the source reconciler must preserve the pane until the granted child arrives. This decision is
+     * captured before publishing the committed document; the deferred projection can never race it.
+     * @param {Object} document
+     * @param {Object} operation
+     * @param {Object} vessel Exact admitted vessel identity, including its private generation.
+     * @protected
+     */
+    onTearOutDocumentChange(document, operation, vessel) {
+        let me       = this,
+            detached = operation?.operation === 'detachItem',
+            itemId   = operation?.itemId;
+
+        if (!detached) {
+            me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, document);
+            return
+        }
+
+        me.onWorkspaceDocumentChange(DemoBWorkspace.MAIN_WORKSPACE_ID, document, {
+            preserveItemIds: me.tearOutEmbodiment.isStaged(itemId) ? [] : [itemId]
+        });
+        me.adoptTearOutPane(itemId, vessel?.generation, vessel?.admissionToken)
     }
 
     /**
@@ -3168,9 +3707,11 @@ class DemoBWorkspace extends Container {
             zones: zoneEntries
                 .map((zone, index) => ({
                     nodeId: zone.nodeId,
+                    // An empty root tabs surface is the whole workspace admission area. Browser
+                    // layout still gives its tab chrome a non-zero strip, but using that strip as
+                    // the remote claim rect makes otherwise reachable vessel overlap impossible.
                     rect  : zone.nodeId === rootId
                         && nodes[zone.nodeId].items?.length === 0
-                        && (!zoneRects[index]?.width || !zoneRects[index]?.height)
                             ? hostRect
                             : zoneRects[index],
                     orientation: Object.values(nodes).find(node =>
@@ -3400,19 +3941,62 @@ class DemoBWorkspace extends Container {
             crossWindowSortGroup     : me.crossWindowEnabled ? DemoBWorkspace.CROSS_WINDOW_SORT_GROUP : null,
             enableDockTearOut        : tearOut,
             enableStackDrag          : stackDrag,
+            enableVesselConversion   : tearOut && me.crossWindowEnabled,
             onDockCrossZoneDragCancel: data => me.onDockCrossZoneDragCancel(workspaceId, data),
             onDockCrossZoneDragMove  : data => me.onDockCrossZoneDragMove(workspaceId, data),
             onDockCrossZoneDrop      : data => me.onDockCrossZoneDrop(workspaceId, data),
             onDockStackDragTerminal  : ({itemId, outcome}) =>
                 me.vesselParkHandlers?.onGestureTerminal({itemId, outcome}),
-            onDockZoneDocumentChange: nextDocument => me.onWorkspaceDocumentChange(workspaceId, nextDocument),
-            resolveComponentRef     : resolveComponentRef
+            onDockVesselConversionIn : data => me.vesselParkHandlers.onConversionIn({
+                itemId    : data.itemId,
+                sourceRect: data.record?.sourceRect ?? null,
+                windowName: me.resolveTearOutVessel(data.itemId)?.windowName
+            }),
+            onDockVesselConversionOut: data => me.vesselParkHandlers.onConversionOut({
+                rect: data.logicalRect ?? data.record?.sourceRect ?? null
+            }),
+            onDockVesselConversionTerminal: data => me.vesselParkHandlers.onGestureTerminal(data),
+            onDockVesselConversionRetired : data => me.vesselParkHandlers.onVesselRetired(data),
+            onDockZoneDocumentChange      : nextDocument => me.onWorkspaceDocumentChange(workspaceId, nextDocument),
+            resolveComponentRef           : resolveComponentRef
                 || ((componentRef, item, itemId) => me.resolvePane(itemId, item)),
             resolveVesselConversionSourceRect: data => me.resolveVesselConversionSourceRect(data),
             resolveRevealComponentRef        : (componentRef, item, itemId) => me.resolvePane(itemId, item),
             workspaceId,
-            ...(tearOut ? me.tearOutHandlers : null)
+            ...(tearOut ? me.tearOutHandlers : null),
+            onDockTearOutExit: tearOut ? data => me.onDockTearOutExit(data) : undefined
         })
+    }
+
+    /**
+     * @summary Retries any exact retained retirement before admitting a successor tear-out.
+     *
+     * A strict close refusal preserves both pure-machine slots. The next boundary exit first retries
+     * that same exact generation; only success clears the park owner and permits a fresh popup. A
+     * second refusal restores the in-window embodiment and fails closed instead of wedging it in a
+     * detached state with no vessel.
+     * @param {Object} data
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async onDockTearOutExit(data) {
+        let me     = this,
+            active = me.tearOutHandlers.activeVessel;
+
+        if (active) {
+            const retired = await me.tearOutHandlers.retireActiveVessel(active);
+
+            if (!retired) {
+                data.sortZone?.endWindowDrag();
+                return false
+            }
+
+            me.vesselParkHandlers.onVesselRetired({itemId: active.itemId, retirement: true})
+        }
+
+        await me.tearOutHandlers.onDockTearOutExit(data);
+
+        return true
     }
 
     /**
@@ -3428,42 +4012,272 @@ class DemoBWorkspace extends Container {
      */
     resolveVesselConversionSourceRect({itemId}) {
         let me       = this,
-            windowId = me.tearOutConnects[itemId]?.windowId ?? me.tearOutPanes[itemId]?.windowId,
+            windowId = me.resolveTearOutVessel(itemId)?.windowId,
             rect     = windowId && Neo.manager?.Window?.get(windowId)?.innerRect;
 
         return rect && {height: rect.height, width: rect.width, x: rect.x, y: rect.y}
     }
 
     /**
+     * @summary Resolves the one connected tear-out generation that may receive physical effects.
+     * @param {String} itemId
+     * @returns {Object|null}
+     * @protected
+     */
+    resolveTearOutVessel(itemId) {
+        let entry = this.tearOutConnects[itemId] ?? this.tearOutPanes[itemId];
+
+        if (!entry?.windowId) return null;
+
+        const resolved = {
+            ...entry,
+            nativeRoute: entry.nativeRoute ?? Neo.manager?.Window?.get(entry.windowId)?.nativeRoute ?? null,
+            windowName : entry.windowName ?? `tearout-${itemId}`
+        };
+
+        Object.defineProperties(resolved, {
+            admissionToken: {value: entry.admissionToken},
+            generation    : {value: entry.generation}
+        });
+
+        return resolved
+    }
+
+    /**
+     * @summary Focuses the already-admitted target, then pauses pointer-follow and parks the exact
+     * connected tear-out generation behind it.
+     *
+     * Focus is admitted BEFORE the physical move, then reasserted AFTER it. A content-bearing moved
+     * window can regain document focus on some window managers; the second focus is therefore the
+     * cover-order receipt, not ceremony. Initial refusal leaves the source untouched. Move refusal
+     * lets DragDrop re-enable pointer-follow, while post-move focus refusal resumes the exact source
+     * rect before reporting a refused park. If that compensation is itself refused, admitted parked
+     * ownership is retained so the lifecycle machine still owns the only recovery route.
+     * @param {Object} vessel
+     * @param {String} vessel.itemId
+     * @param {String} vessel.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async parkTearOutVessel({itemId, windowName}) {
+        let me           = this,
+            entry        = me.resolveTearOutVessel(itemId),
+            route        = entry?.nativeRoute,
+            sourceWindow = Neo.manager?.Window?.get(entry?.windowId),
+            targetWindow = Neo.manager?.Window?.get(me.crossWindowTargetWindowId),
+            targetRoute  = targetWindow?.nativeRoute,
+            // The conversion metric and the exact native move both speak published inner-window
+            // geometry. A child can legitimately omit outerRect, so making the optional frame
+            // estimate an admission prerequisite would reject a fully-authorized live vessel.
+            sourceRect   = sourceWindow?.innerRect,
+            targetRect   = targetWindow?.innerRect;
+
+        me.lastVesselParkReceipt = {
+            authority: {
+                entryNameMatches     : entry?.windowName === windowName,
+                sourceHasHandle      : Boolean(route?.nativeHandleKey),
+                sourceOwnerMatches   : route?.ownerWindowId === me.windowId,
+                sourcePositionCapable: route?.capabilities?.position === true,
+                sourceTargetMatches  : route?.targetWindowId === entry?.windowId,
+                targetFocusCapable   : targetRoute?.capabilities?.focus === true,
+                targetHasHandle      : Boolean(targetRoute?.nativeHandleKey),
+                targetOwnerMatches   : targetRoute?.ownerWindowId === me.windowId,
+                targetTargetMatches  : targetRoute?.targetWindowId === me.crossWindowTargetWindowId
+            },
+            source: sourceRect && {
+                height: sourceRect.height, width: sourceRect.width, x: sourceRect.x, y: sourceRect.y
+            },
+            target: targetRect && {
+                height: targetRect.height, width: targetRect.width, x: targetRect.x, y: targetRect.y
+            }
+        };
+        me.lastVesselRestoreReceipt = null;
+
+        if (
+            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
+            route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
+            !targetRoute?.nativeHandleKey || targetRoute.ownerWindowId !== me.windowId ||
+            targetRoute.targetWindowId !== me.crossWindowTargetWindowId ||
+            targetRoute.capabilities?.focus !== true ||
+            entry.windowName !== windowName || !sourceRect || !targetRect || !targetWindow.innerRect ||
+            sourceRect.width > targetRect.width || sourceRect.height > targetRect.height
+        ) {
+            me.lastVesselParkReceipt.reason = 'native route or cover geometry refused';
+            return false
+        }
+
+        try {
+            let focused = await Neo.Main.windowNativeFocus({
+                    nativeHandleKey: targetRoute.nativeHandleKey,
+                    targetWindowId : targetRoute.targetWindowId,
+                    windowId       : me.windowId
+                }) === true;
+
+            me.lastVesselParkReceipt.focused = focused;
+
+            if (!focused) return false;
+
+            me.lastVesselParkReceipt.requested = {
+                x: targetWindow.innerRect.x,
+                y: targetWindow.innerRect.y
+            };
+
+            let moved = await Neo.main.addon.DragDrop.parkWindowDrag({
+                nativeHandleKey: route.nativeHandleKey,
+                targetWindowId : route.targetWindowId,
+                windowId       : me.windowId,
+                windowName,
+                x              : targetWindow.innerRect.x,
+                y              : targetWindow.innerRect.y
+            }) === true;
+
+            me.lastVesselParkReceipt.moved = moved;
+
+            if (!moved) return false;
+
+            let refocused = await Neo.Main.windowNativeFocus({
+                nativeHandleKey: targetRoute.nativeHandleKey,
+                targetWindowId : targetRoute.targetWindowId,
+                windowId       : me.windowId
+            }) === true;
+
+            me.lastVesselParkReceipt.refocused = refocused;
+
+            if (!refocused) {
+                let compensated = await Neo.main.addon.DragDrop.resumeWindowDrag({
+                    nativeHandleKey: route.nativeHandleKey,
+                    targetWindowId : route.targetWindowId,
+                    windowId       : me.windowId,
+                    windowName,
+                    x              : sourceRect.x,
+                    y              : sourceRect.y
+                }) === true;
+
+                me.lastVesselParkReceipt.compensated = compensated;
+                me.lastVesselParkReceipt.parked      = !compensated;
+
+                return !compensated
+            }
+
+            me.lastVesselParkReceipt.parked = true;
+
+            return true
+        } catch {
+            me.lastVesselParkReceipt.reason = 'platform effect threw';
+            return false
+        }
+    }
+
+    /**
+     * @summary Re-shows the same exact native generation at the logical pointer-owned origin.
+     *
+     * During a live gesture the DragDrop addon also resumes physical pointer-follow. At a native
+     * drag terminal that addon has already reset its session, so a strict refusal falls through
+     * to the same exact Main route for the final restore; semantic-name routing is never used.
+     * @param {Object} vessel
+     * @param {String} vessel.itemId
+     * @param {Object} vessel.rect
+     * @param {Boolean} [vessel.terminal=false]
+     * @param {String} vessel.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async reshowTearOutVessel({itemId, rect, terminal=false, windowName}) {
+        let me    = this,
+            entry = me.resolveTearOutVessel(itemId),
+            route = entry?.nativeRoute,
+            data;
+
+        if (
+            !route?.nativeHandleKey || route.ownerWindowId !== me.windowId ||
+            route.targetWindowId !== entry.windowId || route.capabilities?.position !== true ||
+            entry.windowName !== windowName ||
+            !Number.isFinite(rect?.x) || !Number.isFinite(rect?.y)
+        ) return false;
+
+        data = {
+            nativeHandleKey: route.nativeHandleKey,
+            targetWindowId : route.targetWindowId,
+            windowId       : me.windowId,
+            windowName,
+            x              : rect.x,
+            y              : rect.y
+        };
+        me.lastVesselRestoreReceipt = {
+            admitted : false,
+            requested: {x: rect.x, y: rect.y},
+            terminal,
+            windowId : route.targetWindowId
+        };
+
+        try {
+            const admitted = terminal
+                ? await Neo.Main.windowNativeMoveTo(data) === true
+                : await Neo.main.addon.DragDrop.resumeWindowDrag(data) === true
+
+            me.lastVesselRestoreReceipt.admitted = admitted;
+
+            return admitted
+        } catch {
+            return false
+        }
+    }
+
+    /**
+     * @summary Consumes the tear-out machine's active slot, then closes its exact parked vessel.
+     * @param {Object} vessel
+     * @param {String} vessel.itemId
+     * @param {String} vessel.windowName
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    async disposeParkedTearOutVessel({itemId, windowName}) {
+        return this.tearOutHandlers.retireActiveVessel({itemId, windowName})
+    }
+
+    /**
      * The tear-out admission seam: opens the vessel window for a mid-gesture boundary exit.
-     * Reuses the `?popout=` EMPTY-host viewport mode — the vessel carries no workspace document
-     * (a pure pane host), and because NOTHING is written to {@link #detachedPanes}, the
-     * click-pop-out connect-reparent guards itself out: the vessel rides empty until the
-     * terminal commits. Fail-closed per the admission contract: `windowOpen` returns a BOOLEAN
-     * (a blocked popup never throws), and any falsy/throwing acquisition returns `null` so the
-     * gesture degrades to its in-window fallback.
+     * Reuses the `?popout=` pure-pane-host viewport mode. The granted child immediately carries
+     * the same live pane through {@link Neo.dashboard.DockVesselEmbodiment}; it still owns no
+     * workspace document, and NOTHING is written to {@link #detachedPanes}, so click-pop-out model
+     * machinery remains structurally absent. Fail-closed per the admission contract: `windowOpen`
+     * returns a BOOLEAN (a blocked popup never throws), and any falsy/throwing acquisition returns
+     * `null` so the gesture degrades to its in-window fallback.
      * @param {Object} request
      * @param {String} request.itemId
      * @param {Object} request.proxyRect
      * @returns {Promise<{popupHeight: Number, popupWidth: Number, windowName: String}|null>}
      * @protected
      */
-    async openTearOutVessel({itemId, proxyRect}) {
+    async openTearOutVessel({admissionToken, itemId, proxyRect}) {
         let me         = this,
             {windowId} = me,
             windowName = `tearout-${itemId}`,
             ownerGrant = me.createVesselOwnerGrant('tear-out', itemId);
+
+        admissionToken = Number.isFinite(admissionToken) ? admissionToken : ownerGrant.generation;
+        ownerGrant.admissionToken = admissionToken;
+
+        if (me.tearOutRetirements.has(itemId)) {
+            me.revokeVesselOwnerGrant('tear-out', itemId);
+            return null
+        }
 
         try {
             let winData = await Neo.Main.getWindowData({windowId}),
                 width   = Math.max(Math.round(proxyRect?.width  || 480), 320),
                 height  = Math.max(Math.round(proxyRect?.height || 360), 240),
                 left    = Math.round((proxyRect?.x ?? 120) + winData.screenLeft),
-                top     = Math.round((proxyRect?.y ?? 120) + (winData.outerHeight - winData.innerHeight) + winData.screenTop),
-                opened  = await Neo.Main.windowOpen({
-                    url           : `./index.html?popout=${itemId}&hostId=${me.id}`
+                top     = Math.round((proxyRect?.y ?? 120) + (winData.outerHeight - winData.innerHeight) + winData.screenTop);
+
+            me.tearOutAcquisitionAttempts++;
+
+            let opened = await Neo.Main.windowOpen({
+                    nativeCapabilities: {close: true, position: true},
+                    url               : `./index.html?popout=${itemId}&hostId=${me.id}`
                         + `&vesselFlow=tear-out&vesselGrant=${ownerGrant.token}`
-                        + `&vesselGeneration=${ownerGrant.generation}`,
+                        + `&vesselGeneration=${ownerGrant.generation}`
+                        + `&vesselAdmission=${admissionToken}`,
                     windowFeatures: `height=${height},left=${left},top=${top},width=${width}`,
                     windowId,
                     windowName
@@ -3474,7 +4288,13 @@ class DemoBWorkspace extends Container {
                 return null
             }
 
-            return {popupHeight: height, popupWidth: width, windowName}
+            return {
+                admissionToken,
+                generation : ownerGrant.generation,
+                popupHeight: height,
+                popupWidth : width,
+                windowName
+            }
         } catch (error) {
             me.revokeVesselOwnerGrant('tear-out', itemId);
             return null
@@ -3483,26 +4303,91 @@ class DemoBWorkspace extends Container {
 
     /**
      * The tear-out retirement seam: closes a vessel the gesture no longer needs (re-entry,
-     * cancel, or a refused model commit). Best-effort — an already-closed vessel is not an
-     * error surface, and {@link #onWindowDisconnect} ignores tear-out windows by construction
-     * (no {@link #detachedPanes} entry), so no reattach machinery fires.
+     * cancel, or a refused model commit). The live connection and owner grant remain recoverable
+     * until the platform strictly admits the close; an explicit refusal can therefore be retried
+     * instead of orphaning a parked native generation. {@link #onWindowDisconnect} ignores
+     * tear-out windows by construction (no {@link #detachedPanes} entry), so no reattach machinery
+     * fires after success.
      * @param {Object} vessel
      * @param {String} vessel.itemId
      * @param {String} vessel.windowName
-     * @returns {Promise<void>}
+     * @param {Object} [vessel.nativeRoute] Exact opener-minted physical route when available
+     * @returns {Promise<Boolean>}
      * @protected
      */
-    async closeTearOutVessel({itemId, windowName}) {
-        let me = this;
+    async closeTearOutVessel({admissionToken, generation, itemId, nativeRoute, windowName}) {
+        let me               = this,
+            entry            = me.resolveTearOutVessel(itemId),
+            admission        = me.tearOutConnectAdmissions.get(itemId),
+            ownerGrant       = me.vesselOwnerGrants.get(`tear-out:${itemId}`),
+            expected         = `tearout-${itemId}`,
+            exactGeneration  = entry?.generation ?? admission?.generation ?? ownerGrant?.generation,
+            exactToken       = entry?.admissionToken ?? admission?.admissionToken ?? ownerGrant?.admissionToken,
+            embodiedWindowId = entry?.windowId ?? admission?.windowId ?? me.tearOutEmbodiment.getWindowId(itemId),
+            closed           = false;
 
-        delete me.tearOutConnects[itemId];
-        me.revokeVesselOwnerGrant('tear-out', itemId);
+        if (
+            !itemId || windowName !== expected || (entry && entry.windowName !== windowName) ||
+            (Number.isFinite(generation) && generation !== exactGeneration) ||
+            (Number.isFinite(admissionToken) && admissionToken !== exactToken)
+        ) {
+            return false
+        }
+
+        nativeRoute ??= entry?.nativeRoute ?? admission?.nativeRoute ?? (
+            admission?.windowId && Neo.manager?.Window?.get(admission.windowId)?.nativeRoute
+        );
+
+        const exactWindowId = entry?.windowId ?? admission?.windowId;
+
+        if (nativeRoute && (
+            !nativeRoute.nativeHandleKey || nativeRoute.ownerWindowId !== me.windowId ||
+            !nativeRoute.targetWindowId || nativeRoute.capabilities?.close !== true ||
+            (exactWindowId && nativeRoute.targetWindowId !== exactWindowId)
+        )) return false;
+
+        // Establish retirement before restoring any source embodiment or awaiting the platform.
+        // A refused close retains the exact route + tear-out machine slot for retry, but the content
+        // stays safely home; a committed transfer promotes the staged pane instead, letting the
+        // target-first reconciler take it without a false source restoration.
+        me.tearOutRetirements.add(itemId);
+        admission && (admission.invalidated = true);
+
+        if (embodiedWindowId && me.tearOutEmbodiment.isStaged(itemId)) {
+            const sourceOwns = Boolean(DockZoneModel.findContainingTabsId(me.dockModel, itemId)),
+                  settled    = me.tearOutEmbodiment[sourceOwns ? 'restore' : 'promote']({
+                      itemId, windowId: embodiedWindowId
+                  });
+
+            if (!settled) return false
+        }
 
         try {
-            await Neo.Main.windowClose({names: [windowName], windowId: me.windowId})
+            if (nativeRoute) {
+                closed = await Neo.Main.windowNativeClose({
+                    nativeHandleKey: nativeRoute.nativeHandleKey,
+                    targetWindowId : nativeRoute.targetWindowId,
+                    windowId       : me.windowId
+                }) === true
+            } else {
+                // Before connect there is no exact route to correlate yet; the active tear-out
+                // slot's unguessable semantic name is the only available authority. Once a route
+                // exists, ANY invalidity above fails closed — never downgrade to same-name close.
+                await Neo.Main.windowClose({names: [windowName], windowId: me.windowId});
+                closed = true
+            }
         } catch (error) {
-            // best-effort retirement
+            return false
         }
+
+        if (!closed) return false;
+
+        delete me.tearOutConnects[itemId];
+        me.tearOutConnectAdmissions.delete(itemId);
+        me.revokeVesselOwnerGrant('tear-out', itemId);
+        me.tearOutRetirements.delete(itemId);
+
+        return true
     }
 
     /**
@@ -3513,15 +4398,47 @@ class DemoBWorkspace extends Container {
      * arrival (the fast-terminal order). Close-after-adoption reintegration is the vessel-lifecycle
      * leaf's scope, deliberately not handled here.
      * @param {String} itemId
+     * @param {Number} [generation] Exact owner-grant generation for terminal-first adoption.
+     * @param {Number} [admissionToken] Exact gesture admission for terminal-first adoption.
      * @protected
      */
-    adoptTearOutPane(itemId) {
+    adoptTearOutPane(itemId, generation, admissionToken) {
         let me        = this,
             connected = me.tearOutConnects[itemId];
 
-        me.tearOutPanes[itemId] = {windowName: `tearout-${itemId}`, windowId: connected?.windowId ?? null};
+        me.tearOutPanes[itemId] = connected
+            ? {...connected}
+            : {windowName: `tearout-${itemId}`, windowId: null};
 
-        connected && me.reparentTearOutPane(itemId, connected)
+        Object.defineProperties(me.tearOutPanes[itemId], {
+            admissionToken: {
+                configurable: true,
+                value       : connected?.admissionToken ?? admissionToken ?? null,
+                writable    : true
+            },
+            generation: {
+                configurable: true,
+                value       : connected?.generation ?? generation ?? null,
+                writable    : true
+            },
+            nativeRoute: {
+                configurable: true,
+                value       : connected?.nativeRoute ?? null,
+                writable    : true
+            }
+        });
+
+        if (connected) {
+            // Promotion is synchronous and single-owner: committed disconnects may only match
+            // tearOutPanes from this point onward, never the pre-terminal connect branch first.
+            delete me.tearOutConnects[itemId];
+
+            if (me.tearOutEmbodiment.isStaged(itemId)) {
+                me.tearOutEmbodiment.promote({itemId, windowId: connected.windowId})
+            } else {
+                me.reparentTearOutPane(itemId, connected)
+            }
+        }
     }
 
     /**
@@ -3529,20 +4446,25 @@ class DemoBWorkspace extends Container {
      * reparent the click-pop-out uses, minus every document write (the model already committed
      * at the terminal; this is pure render-target work).
      * @param {String} itemId
-     * @param {Object} target `{appName, windowId}`
+     * @param {Object} target `{windowId}`
      * @protected
      */
-    reparentTearOutPane(itemId, {windowId}) {
-        let me   = this,
-            app  = Neo.apps[windowId],
-            pane = me.paneCache[itemId];
+    reparentTearOutPane(itemId, target) {
+        let me         = this,
+            {windowId} = target,
+            app        = Neo.apps[windowId],
+            pane       = me.paneCache[itemId];
 
-        if (!app || !pane || pane.isDestroyed) return;
+        if (!app || !pane || pane.isDestroyed) return false;
 
-        me.tearOutPanes[itemId] && (me.tearOutPanes[itemId].windowId = windowId);
+        me.tearOutPanes[itemId] && Object.assign(me.tearOutPanes[itemId], target);
 
-        pane.parent?.remove(pane, false);
-        app.mainView.add(pane)
+        if (pane.parent !== app.mainView) {
+            pane.parent?.remove(pane, false);
+            app.mainView.add(pane)
+        }
+
+        return true
     }
 
     /**
@@ -3853,6 +4775,10 @@ class DemoBWorkspace extends Container {
         me.crossWindowGeometry.clear();
         me.workspaceProjectionRequests.clear();
         me.vesselOwnerGrants.clear();
+        me.tearOutConnectAdmissions.clear();
+        me.tearOutEmbodiment?.destroy();
+        me.tearOutEmbodiment = null;
+        me.tearOutRetirements.clear();
         me.crossWindowStagePromise   = null;
         me.crossWindowStageResolve   = null;
         me.crossWindowStageReject    = null;

--- a/learn/agentos/decisions/0029-harness-docking-design.md
+++ b/learn/agentos/decisions/0029-harness-docking-design.md
@@ -379,6 +379,56 @@ handles by the semantic `windowName` passed to `Main.windowOpen()`. Those identi
 This is the generic multi-window Possession Interface consumed by inspection tooling. Product code still decides what a
 window *means* and which semantic transaction precedes a physical effect.
 
+#### §2.8.6 In-gesture vessel conversion and park (2026-07-19, #15396)
+
+Popup-to-proxy conversion is an admitted transition inside the existing outcome machine, not a new
+terminal state. A source may enter `HOVERING_CLAIM` only after its physical park effect returns strict
+`true`; leaving the claim may resume `DETACHED_MOVING` only after strict re-show admission. Promise
+dispatch is provisional authority: conversion and park owners retain their prior state until settlement,
+and a stale generation cannot mutate a successor gesture.
+
+The browser-runtime park mechanic is **target-cover**, behind generic exact-handle capabilities:
+
+1. resolve both connected generations from `manager.Window` and require opener-minted routes;
+2. verify that the target can cover the source vessel;
+3. focus the exact target route first;
+4. only after focus admission, pause pointer-follow and move the exact source route to the target origin.
+
+The order is load-bearing. A focus refusal leaves the source untouched and moving; a subsequent move
+refusal makes the DragDrop owner re-enable pointer-follow. No effectful half-park needs semantic-name
+recovery. Offscreen coordinates are not the browser-runtime default: the macOS/Chrome headed falsifier
+clamped a requested far-negative position back onto the visible desktop. Other platform mechanics remain
+host seams and require their own #15243 matrix receipts; they never change the pure conversion or park
+machines. Target-cover admission is also deliberately stricter than the size-neutral geometry predicate:
+when the source cannot fit behind the target, the host returns `false` and the sensor stays
+`DETACHED_MOVING`. The §2.8.4 min-axis metric remains reachable for every size pair; physical admission
+does not overclaim a safe park mechanic for a non-coverable pair. A future matrix-backed resize/hide seam
+may admit that case without changing the metric or state owners.
+
+Convert-out re-shows the **same** connected window through the same opaque handle generation and resumes
+physical pointer-follow at the live logical drag origin while preserving the pre-conversion extent. If no
+live origin is supplied, the park owner falls back to its recorded pre-conversion rect. The slot clears only
+after strict re-show success. Neither conversion direction owns a popup-acquisition seam, so a continuous
+park → re-show journey has zero mid-gesture `windowOpen` attempts by construction.
+
+Terminal disposition remains §2.8.2-owned:
+
+- `COMMITTED_TARGET` consumes the tear-out admission slot, commits model truth first, then closes that exact
+  parked route through §2.8.3's post-commit close policy. Strict close refusal retains both cleanup
+  authorities for an exact retry; an invalid correlated route never downgrades to same-name close;
+- `CANCELLED` / `REJECTED` restore the same vessel, unless an outer tear-out cancellation already retired it,
+  in which case the verified retirement settlement clears the park generation without resurrecting it;
+- after an admitted convert-out, `TERMINAL_DETACHED` follows the ordinary tear-out terminal and adopts the
+  re-shown vessel — no close and no reacquisition.
+
+The current binding witness is macOS/Chrome headed and gesture-level on the committed #15243 matrix runner:
+one real pointer journey acquires one externally observed tear-out `Page`, parks under a still-focused real
+target at the requested physical coordinates, leaves the claim, proves the identical `Page`, runtime
+`windowId`, opaque handle, external restore coordinates, and zero additional browser-realm `window.open`
+calls, then releases through `TERMINAL_DETACHED`. Unit witnesses additionally pin refusal, latest-frame
+replay, stale completion, terminal-during-transition, duplicate terminal, and exact-once retirement
+behavior. Windows/Linux cells and non-coverable park mechanics remain honestly owned by #15243.
+
 ## 3. Rejected Options
 
 - **Qt-ADS wholesale import** — Qt-ADS is the capability bar, not the design: its single-process, single-window-tree assumptions (native floating windows, one owning widget tree) do not survive the worker-owned/multi-window reality. Rejected in favor of extending `dockZone.v1` semantics.
@@ -443,6 +493,7 @@ Per the parent epic's discipline (one Contract-Ledgered leaf per capability), im
 | Whole-stack reintegration + vessel close policy | §2.8.2/§2.8.3 + §2.4 `transferNode` | #15247 (epic #15239) |
 | Coordinator teardown hygiene (exact-once terminals) | §2.8.2 invariant 4 | #15248 (epic #15239) |
 | Neural Link generic window identity + physical focus/position/close | §2.8.5 | #15514 |
+| Dual-window conversion + in-gesture park/re-show | §2.3 transition-policy hook + §2.8.6 | #15395 / #15396 (epic #15239) |
 
 ### JSON-First Guardrail (restated, applied)
 

--- a/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
+++ b/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
@@ -145,6 +145,17 @@ gap remains for row 4: Demo B exposes no `Neo.data.Store` (`list_stores` returne
 so its CounterPane heartbeat proves instance-local continuity but cannot honestly stand in for
 the required live-store-reference receipt. Both cells remain `NOT_YET_MEASURED`.
 
+**#15396 green control (2026-07-19, verdicts still pending):** the matrix runner now includes the
+full Demo B cross-window journey. Its macOS/Chrome headed round-trip externally observes exactly
+one `?popout=workbench` Playwright `Page`, instruments browser-realm `window.open` independently of
+the app counter, verifies that the same `Page` survives park → re-show → detached terminal, records
+requested-vs-observed park and restore coordinates, and verifies that the cover target remains
+focused after the source move. The worker independently proves identical CounterPane id, exact
+single remount, exact runtime window id / opaque handle, and zero transfer/local/remote double
+commit. This resolves the earlier competing-vessel false-green for this macOS journey; it does not
+mint a row verdict. Row 4 still lacks the contract's live-`data.Store` reference, rows 3/6/7 still
+need their complete per-row universal-invariant receipts, and Windows/Linux remain unmeasured.
+
 ⁵ Row 5 macOS — **`PASS_FALLBACK`** (2026-07-19, headed Chrome 150, 3/3 serial): the witness
 bound `Browser.setPermission` to Playwright's actual browser context, observed the
 `window-management` permission as `denied`, and observed `getScreenDetails()` reject with

--- a/src/Main.mjs
+++ b/src/Main.mjs
@@ -7,15 +7,25 @@ import DomEvents             from './main/DomEvents.mjs';
 import Observable            from './core/Observable.mjs';
 import WorkerManager         from './worker/Manager.mjs';
 
+let nativeWindowRoute;
+
 /**
- * @summary Consumes the opener's one-time exact-window capability during the target's connect handshake.
+ * @summary Consumes the opener's one-time exact-window capability once per target document.
  * @description The token is useful only while the opener still owns a matching pending `WindowProxy`. It is
- * removed on the first attempt, so reload, URL/name inference, and same-name reuse cannot reconstruct authority.
+ * removed on the first attempt, then the admitted route is cached inside this exact target realm so geometry
+ * observation and the shared-worker connect handshake can read the same authority in either order. A reload
+ * creates a new realm and loses the cache; URL/name inference and same-name reuse still cannot reconstruct it.
  * Cross-origin or independently opened windows deliberately remain unaddressable.
  * @param {Window} win
  * @returns {{capabilities: {close: Boolean, focus: Boolean, position: Boolean}, nativeHandleKey: String, ownerWindowId: String, targetWindowId: String}|null}
  */
 const resolveNativeWindowRoute = win => {
+    if (nativeWindowRoute !== undefined) {
+        return nativeWindowRoute
+    }
+
+    nativeWindowRoute = null;
+
     try {
         const
             opener     = win?.opener,
@@ -24,7 +34,7 @@ const resolveNativeWindowRoute = win => {
             token      = storageKey && win.sessionStorage?.getItem(storageKey);
 
         if (!opener || opener.closed || !openerMain || !token) {
-            return null
+            return nativeWindowRoute
         }
 
         win.sessionStorage.removeItem(storageKey);
@@ -36,7 +46,11 @@ const resolveNativeWindowRoute = win => {
         });
 
         if (route) {
+            nativeWindowRoute = route;
+
             win.addEventListener('pagehide', () => {
+                nativeWindowRoute = null;
+
                 try {
                     openerMain.releaseNativeWindowRoute({...route, win})
                 } catch {
@@ -45,11 +59,11 @@ const resolveNativeWindowRoute = win => {
             }, {once: true})
         }
 
-        return route
+        return nativeWindowRoute
     } catch {
         // Cross-origin opener/sessionStorage access is expected to fail closed. The window stays visible in
         // topology but intentionally exposes no native control route.
-        return null
+        return nativeWindowRoute
     }
 };
 
@@ -735,6 +749,24 @@ class Main extends core.Base {
     }
 
     /**
+     * @summary Lets the moved render target publish its observed geometry after a programmatic move.
+     * @description Browser window movement has no guaranteed resize or pointer-boundary event. The
+     * target realm's existing change detector therefore closes the mutation-to-observation edge
+     * without ever projecting requested coordinates into manager truth. Cross-origin or not-yet-
+     * initialized targets remain valid physical handles; geometry publication is best-effort and
+     * cannot change the strict movement verdict.
+     * @param {Window} win
+     * @private
+     */
+    #publishWindowGeometry(win) {
+        try {
+            win.Neo?.main?.addon?.WindowPosition?.checkMovement?.()
+        } catch {
+            // Cross-origin target realms are intentionally opaque.
+        }
+    }
+
+    /**
      * Moves one exact native handle and verifies the target reached the requested coordinates.
      * @param {Window} win
      * @param {Number|String} requestedX
@@ -747,6 +779,8 @@ class Main extends core.Base {
             x = Number(requestedX),
             y = Number(requestedY);
 
+        let admitted = false;
+
         if (!win || win.closed || typeof win.moveTo !== 'function' || !Number.isFinite(x) || !Number.isFinite(y)) {
             return false
         }
@@ -754,18 +788,22 @@ class Main extends core.Base {
         try {
             win.moveTo(x, y)
         } catch {
+            this.#publishWindowGeometry(win);
             return false
         }
 
         for (let attempt = 0; attempt < this.windowMovePollAttempts; attempt++) {
             if (Math.abs(win.screenX - x) <= 1 && Math.abs(win.screenY - y) <= 1) {
-                return true
+                admitted = true;
+                break
             }
 
             await new Promise(resolve => setTimeout(resolve, this.windowMovePollDelay))
         }
 
-        return false
+        this.#publishWindowGeometry(win);
+
+        return admitted
     }
 
     /**
@@ -905,7 +943,18 @@ class Main extends core.Base {
      */
     windowOpen({nativeCapabilities, url, useTotalHeight=true, windowFeatures, windowName}) {
         let existingWin = this.openWindows[windowName],
+            stagedUrl   = null,
             targetName;
+
+        try {
+            const resolved = typeof url === 'string' && new URL(url, window.location.href);
+
+            if (resolved?.origin === window.location.origin) {
+                stagedUrl = resolved.href
+            }
+        } catch {
+            // Invalid or inaccessible URLs retain the browser's direct-open behavior below.
+        }
 
         if (existingWin && !existingWin.win.closed) {
             targetName = existingWin.targetName
@@ -913,14 +962,14 @@ class Main extends core.Base {
             targetName = crypto.randomUUID()
         }
 
-        let openedWindow = window.open(url, targetName, windowFeatures),
+        // Same-origin children can connect to the shared worker immediately when the opener is
+        // warm. Open a blank same-origin realm first, mint its one-time route there, THEN navigate;
+        // opening the final URL before writing sessionStorage races the child's getWindowData()
+        // handshake and produces a connected but authority-less popup.
+        let openedWindow = window.open(stagedUrl ? 'about:blank' : url, targetName, windowFeatures),
             success      = !!openedWindow;
 
         if (success) {
-            if (useTotalHeight) {
-                openedWindow.resizeTo(openedWindow.outerWidth, openedWindow.innerHeight)
-            }
-
             this.#invalidateNativeWindowEntry(existingWin);
 
             const
@@ -949,6 +998,21 @@ class Main extends core.Base {
                 openedWindow.sessionStorage.setItem(this.nativeRouteStorageKey, token)
             } catch {
                 this.#pendingWindowRoutes.delete(token)
+            }
+
+            if (useTotalHeight) {
+                openedWindow.resizeTo(openedWindow.outerWidth, openedWindow.innerHeight)
+            }
+
+            if (stagedUrl) {
+                try {
+                    openedWindow.location.replace(stagedUrl)
+                } catch {
+                    this.#invalidateNativeWindowEntry(entry);
+                    delete this.openWindows[windowName];
+                    openedWindow.close();
+                    success = false
+                }
             }
         }
 

--- a/src/dashboard/DockLayoutAdapter.mjs
+++ b/src/dashboard/DockLayoutAdapter.mjs
@@ -323,6 +323,12 @@ class DockLayoutAdapter extends Base {
      *     conversion policy. Consumers keep this false until their physical lifecycle is ready.
      * @param {Boolean} [options.enableStackDrag=false] Decorate the model-resolved stack root
      *     with one runtime-only whole-stack grip and arm its existing dock SortZone.
+     * @param {Function} [options.onDockVesselConversionIn] Source-owned strict park admission.
+     * @param {Function} [options.onDockVesselConversionOut] Source-owned strict re-show admission.
+     * @param {Function} [options.onDockVesselConversionTerminal] Source-owned parked-vessel
+     *     disposition after the coordinator resolves the gesture outcome.
+     * @param {Function} [options.onDockVesselConversionRetired] Clear-only acknowledgement when
+     *     another owning lifecycle has already retired the same source vessel.
      * @param {Function} [options.resolveVesselConversionSourceRect] Synchronous owner resolver for
      *     the exact dragged vessel's live global inner rect; threaded through a clone-safe listener.
      * @param {Function} [options.resolveComponentRef]
@@ -379,6 +385,10 @@ class DockLayoutAdapter extends Base {
             onDockTearOutEntry               : options.onDockTearOutEntry,
             onDockTearOutExit                : options.onDockTearOutExit,
             onDockTearOutTerminal            : options.onDockTearOutTerminal,
+            onDockVesselConversionIn         : options.onDockVesselConversionIn,
+            onDockVesselConversionOut        : options.onDockVesselConversionOut,
+            onDockVesselConversionTerminal   : options.onDockVesselConversionTerminal,
+            onDockVesselConversionRetired    : options.onDockVesselConversionRetired,
             onDockZoneDocumentChange         : options.onDockZoneDocumentChange,
             resolveComponentRef              : options.resolveComponentRef || (() => null),
             resolveVesselConversionSourceRect: options.resolveVesselConversionSourceRect,
@@ -869,12 +879,31 @@ class DockLayoutAdapter extends Base {
                 dockVesselConversionSourceRectRequest: data => {
                     data.sourceRect = context.resolveVesselConversionSourceRect?.(data) ?? null
                 },
+                // Strict lifecycle admission rides the same mutable-record pattern as the
+                // synchronous rect request: the projected zone owns decision state; the host
+                // owns platform effects. Promise settlement remains behind the source policy.
+                dockVesselConversionIn: data => {
+                    data.admission = context.onDockVesselConversionIn?.(data) ?? false
+                },
+                dockVesselConversionOut: data => {
+                    data.admission = context.onDockVesselConversionOut?.(data) ?? false
+                },
+                dockVesselConversionTerminal: data => {
+                    data.settlement = context.onDockVesselConversionTerminal?.(data) ?? false
+                },
+                dockVesselConversionRetired: data => {
+                    data.settlement = context.onDockVesselConversionRetired?.(data) ?? false
+                },
                 // Tear-out gesture seams (§2.8): the zone re-fires the inherited boundary events here.
                 // Cancel retires the host's vessel with zero model mutation; entry is a resumed
                 // in-window gesture (vessel closes, no outcome); exit is where the host acquires its
                 // vessel per the admission contract (Boolean `windowOpen`, fail-closed) and engages
                 // `startWindowDrag`; terminal is the ONE seam a host may commit `detachItem` on.
-                dockTearOutCancel  : data => context.onDockTearOutCancel?.(data),
+                dockTearOutCancel  : data => {
+                    const settlement = context.onDockTearOutCancel?.(data) ?? false;
+
+                    Object.hasOwn(data, 'settlement') && (data.settlement = settlement)
+                },
                 dockTearOutEntry   : data => context.onDockTearOutEntry?.(data),
                 dockTearOutExit    : data => context.onDockTearOutExit?.(data),
                 dockTearOutTerminal: data => context.onDockTearOutTerminal?.(data),

--- a/src/dashboard/DockTabSortZone.mjs
+++ b/src/dashboard/DockTabSortZone.mjs
@@ -209,6 +209,45 @@ class DockTabSortZone extends TabHeaderSortZone {
     vesselConversionLogicalRect = null
 
     /**
+     * Exact item identity carried by the coordinator frame for the active conversion epoch.
+     * The platform actuator must not reconstruct it from `startIndex`: a live source can enter
+     * through a composed/native handoff whose base tab-reorder index is intentionally absent.
+     * @member {String|null} vesselConversionItemId=null
+     * @protected
+     */
+    vesselConversionItemId = null
+
+    /**
+     * One queued convert-out chained behind a still-provisional park admission.
+     * @member {Promise<Boolean>|null} vesselConversionCancelPromise=null
+     * @protected
+     */
+    vesselConversionCancelPromise = null
+
+    /**
+     * Zone-owned generation protecting async cancellation continuations across sensor reuse.
+     * @member {Number} vesselConversionEpoch=0
+     * @protected
+     */
+    vesselConversionEpoch = 0
+
+    /**
+     * Latest gesture frame observed while a strict platform transition is settling. Only the
+     * newest frame is replayed after settlement, so a slow park/re-show can never commit stale
+     * geometry merely because the pointer stopped before another browser event arrived.
+     * @member {Object|null} vesselConversionReplayFrame=null
+     * @protected
+     */
+    vesselConversionReplayFrame = null
+
+    /**
+     * One generation-scoped replay chained behind the current sensor transition.
+     * @member {Promise<Boolean>|null} vesselConversionReplayPromise=null
+     * @protected
+     */
+    vesselConversionReplayPromise = null
+
+    /**
      * Warms the cross-window {@link Neo.manager.DragCoordinator} OFF the drag hot path: a `sortGroup`
      * zone kicks off the cached dynamic import at construction so {@link #onDragMove} /
      * {@link #processDragEnd} read {@link #dragCoordinator} synchronously during a gesture instead of
@@ -295,19 +334,69 @@ class DockTabSortZone extends TabHeaderSortZone {
      * forgetting state, so the physical-lifecycle owner receives exactly one convert-out seam when
      * a target unregisters mid-gesture. Gesture terminals use the silent reset instead: their
      * outcome choreography owns disposition and must not be double-driven by a synthetic reversion.
+     * @returns {Boolean} `true` only when no conversion ownership remains
      */
     cancelVesselConversion() {
-        let me = this;
+        let me     = this,
+            sensor = me.vesselConversionSensor;
 
-        if (me.vesselConversionSensor?.converted) {
-            me.vesselConversionSensor.sample({
+        if (!sensor) return true;
+
+        if (sensor.transitioning) {
+            // If the target disappears while park admission is still provisional, never reset
+            // the sensor out from under the host effect. Queue one convert-out behind that exact
+            // settlement; a refused park has no ownership and can reset immediately.
+            if (sensor.targetConverted && !me.vesselConversionCancelPromise) {
+                const epoch      = me.vesselConversionEpoch,
+                      transition = sensor.transitionPromise;
+
+                me.vesselConversionCancelPromise = Promise.resolve(transition).then(admitted => {
+                    if (me.vesselConversionSensor !== sensor || me.vesselConversionEpoch !== epoch) return false;
+
+                    me.vesselConversionCancelPromise = null;
+
+                    if (!admitted || !sensor.converted) {
+                        me.resetVesselConversion();
+                        return true
+                    }
+
+                    const record = sensor.sample({
+                        pointerInTarget: false,
+                        sourceRect     : me.vesselConversionSourceRect,
+                        targetRect     : me.vesselConversionTargetRect
+                    });
+
+                    if (!record.transitioning && !record.converted) {
+                        me.resetVesselConversion();
+                        return true
+                    }
+
+                    return false
+                }, () => {
+                    me.vesselConversionSensor === sensor && me.vesselConversionEpoch === epoch
+                        && me.resetVesselConversion();
+                    return true
+                })
+            }
+
+            return false
+        }
+
+        if (sensor.converted) {
+            const record = sensor.sample({
                 pointerInTarget: false,
                 sourceRect     : me.vesselConversionSourceRect,
                 targetRect     : me.vesselConversionTargetRect
-            })
+            });
+
+            // Re-show admission owns the slot until strict success. A pending or refused effect
+            // must remain retryable; resetting here would strand the physical vessel parked.
+            if (record.transitioning || record.converted) return false
         }
 
-        me.resetVesselConversion()
+        me.resetVesselConversion();
+
+        return true
     }
 
     /**
@@ -322,30 +411,109 @@ class DockTabSortZone extends TabHeaderSortZone {
             convertThreshold: me.vesselConversionConvertThreshold,
             revertThreshold : me.vesselConversionRevertThreshold,
             onConvertIn(record) {
-                let itemId = me.dragComponent?.dockItemId ?? me.dockItemIds?.[me.startIndex] ?? null;
+                let itemId = me.vesselConversionItemId ?? me.dragComponent?.dockItemId
+                    ?? me.dockItemIds?.[me.startIndex] ?? null;
 
-                me.owner?.up?.()?.fire('dockVesselConversionIn', {
+                const data = {
+                    admission   : false,
                     itemId,
                     logicalRect : me.vesselConversionLogicalRect && {...me.vesselConversionLogicalRect},
                     record,
                     sortZone    : me,
                     sourceNodeId: me.dockSourceNodeId,
                     targetId    : me.vesselConversionTargetId
-                })
+                };
+
+                me.owner?.up?.()?.fire('dockVesselConversionIn', data);
+
+                return data.admission
             },
             onConvertOut(record) {
-                let itemId = me.dragComponent?.dockItemId ?? me.dockItemIds?.[me.startIndex] ?? null;
+                let itemId = me.vesselConversionItemId ?? me.dragComponent?.dockItemId
+                    ?? me.dockItemIds?.[me.startIndex] ?? null;
 
-                me.owner?.up?.()?.fire('dockVesselConversionOut', {
+                const data = {
+                    admission   : false,
                     itemId,
                     logicalRect : me.vesselConversionLogicalRect && {...me.vesselConversionLogicalRect},
                     record,
                     sortZone    : me,
                     sourceNodeId: me.dockSourceNodeId,
                     targetId    : me.vesselConversionTargetId
-                })
+                };
+
+                me.owner?.up?.()?.fire('dockVesselConversionOut', data);
+
+                return data.admission
             }
         })
+    }
+
+    /**
+     * @summary Returns clone-safe admitted/provisional conversion truth for diagnostics and Neural Link.
+     * @returns {{converted:Boolean, targetConverted:Boolean, targetId:(String|null), transitioning:Boolean}}
+     */
+    getVesselConversionState() {
+        let sensor = this.vesselConversionSensor;
+
+        return {
+            converted      : sensor?.converted === true,
+            targetConverted: sensor?.targetConverted === true,
+            targetId       : this.vesselConversionTargetId ?? null,
+            transitioning  : sensor?.transitioning === true
+        }
+    }
+
+    /**
+     * @summary Replays the newest pointer/geometry truth after strict platform admission settles.
+     *
+     * Pointer frames are intentionally not queued one-by-one: only the latest source-owned truth
+     * can decide whether the just-admitted park/re-show still matches user intent. Reset bumps the
+     * epoch and invalidates the continuation before it can touch a successor gesture.
+     * @param {Object} frame
+     * @returns {Promise<Boolean>}
+     * @protected
+     */
+    scheduleVesselConversionReplay(frame) {
+        let me     = this,
+            sensor = me.vesselConversionSensor;
+
+        me.vesselConversionReplayFrame = {
+            ...frame,
+            logicalSourceRect: frame.logicalSourceRect && {...frame.logicalSourceRect},
+            targetRect       : frame.targetRect && {...frame.targetRect}
+        };
+
+        if (me.vesselConversionReplayPromise || !sensor?.transitionPromise) {
+            return me.vesselConversionReplayPromise ?? Promise.resolve(false)
+        }
+
+        const epoch      = me.vesselConversionEpoch,
+              transition = sensor.transitionPromise;
+
+        me.vesselConversionReplayPromise = Promise.resolve(transition).then(() => {
+            if (me.vesselConversionSensor !== sensor || me.vesselConversionEpoch !== epoch) return false;
+
+            const latest = me.vesselConversionReplayFrame;
+
+            me.vesselConversionReplayFrame   = null;
+            me.vesselConversionReplayPromise = null;
+
+            if (!latest) return true;
+
+            me.resolveRemoteDragTransition({...latest, replayAfterTransition: true});
+
+            return true
+        }, () => {
+            if (me.vesselConversionSensor === sensor && me.vesselConversionEpoch === epoch) {
+                me.vesselConversionReplayFrame   = null;
+                me.vesselConversionReplayPromise = null
+            }
+
+            return false
+        });
+
+        return me.vesselConversionReplayPromise
     }
 
     /**
@@ -397,13 +565,22 @@ class DockTabSortZone extends TabHeaderSortZone {
      * @param {Object} frame.draggedItem
      * @param {Number} frame.now
      * @param {Boolean} frame.pointerInTarget
+     * @param {Boolean} [frame.replayAfterTransition=false] Internal transition continuation marker
      * @param {Object} frame.logicalSourceRect
      * @param {String|null} frame.targetId
      * @param {Object|null} frame.targetRect
      * @returns {{commitEligible: Boolean, engage: Boolean, retain: Boolean}|null} `null` keeps the
      *     legacy coordinator path when conversion is disabled or the source is not in a window drag.
      */
-    resolveRemoteDragTransition({draggedItem, logicalSourceRect, now=Date.now(), pointerInTarget, targetId, targetRect} = {}) {
+    resolveRemoteDragTransition({
+        draggedItem,
+        logicalSourceRect,
+        now=Date.now(),
+        pointerInTarget,
+        replayAfterTransition=false,
+        targetId,
+        targetRect
+    } = {}) {
         let me = this;
 
         if (!me.enableVesselConversion || !me.isWindowDragging) {
@@ -414,12 +591,35 @@ class DockTabSortZone extends TabHeaderSortZone {
             return {commitEligible: false, engage: false, retain: false}
         }
 
-        let liveSourceRect = me.resolveVesselConversionSourceGeometry({draggedItem, logicalRect: logicalSourceRect}),
-            grace          = Number.isFinite(me.vesselConversionPointerExitGraceMs)
+        let sensor = me.getVesselConversionSensor(),
+            grace  = Number.isFinite(me.vesselConversionPointerExitGraceMs)
                 ? Math.max(0, me.vesselConversionPointerExitGraceMs)
                 : 0;
 
+        me.vesselConversionItemId = draggedItem.dockItemId
+            ?? me.dragComponent?.dockItemId
+            ?? me.dockItemIds?.[me.startIndex]
+            ?? null;
         me.vesselConversionLogicalRect = logicalSourceRect ? {...logicalSourceRect} : null;
+
+        let liveSourceRect;
+
+        // Once park is proposed or admitted, the physical rect is host-authored parked output, not
+        // user trajectory. Continue with the logical pointer-follow origin and the last exact live
+        // extents while strict platform admission settles.
+        if (
+            (sensor.converted || sensor.targetConverted || replayAfterTransition) &&
+            me.vesselConversionSourceRect && logicalSourceRect
+        ) {
+            liveSourceRect = {
+                height: me.vesselConversionSourceRect.height,
+                width : me.vesselConversionSourceRect.width,
+                x     : logicalSourceRect.x,
+                y     : logicalSourceRect.y
+            }
+        } else {
+            liveSourceRect = me.resolveVesselConversionSourceGeometry({draggedItem, logicalRect: logicalSourceRect})
+        }
 
         if (!liveSourceRect) {
             me.cancelVesselConversion();
@@ -428,15 +628,53 @@ class DockTabSortZone extends TabHeaderSortZone {
 
         me.vesselConversionSourceRect = liveSourceRect;
 
-        let sensor = me.getVesselConversionSensor();
+        // A platform effect is provisional authority. The coordinator receives a synchronous
+        // fail-closed policy while it settles; no Promise escapes this source-owned boundary. The
+        // latest frame is replayed automatically after settlement, closing the otherwise-stale
+        // "move below threshold, then stop" race in both conversion directions.
+        if (sensor.transitioning) {
+            sensor.sample({
+                pointerInTarget: pointerInTarget === true,
+                sourceRect     : me.vesselConversionSourceRect,
+                targetRect     : targetRect ?? me.vesselConversionTargetRect
+            });
+            me.scheduleVesselConversionReplay({
+                draggedItem,
+                logicalSourceRect,
+                now,
+                pointerInTarget,
+                targetId,
+                targetRect
+            });
+
+            return {commitEligible: false, engage: false, retain: false}
+        }
 
         if (pointerInTarget === true && targetId != null && targetRect) {
             if (me.vesselConversionTargetId != null && me.vesselConversionTargetId !== targetId) {
-                sensor.converted && sensor.sample({
-                    pointerInTarget: false,
-                    sourceRect     : me.vesselConversionSourceRect,
-                    targetRect     : me.vesselConversionTargetRect
-                });
+                if (sensor.converted) {
+                    const record = sensor.sample({
+                        pointerInTarget: false,
+                        sourceRect     : me.vesselConversionSourceRect,
+                        targetRect     : me.vesselConversionTargetRect
+                    });
+
+                    // A→B cannot mint B ownership while A's exact vessel is still parked. Wait
+                    // behind the synchronous fail-closed hook, then replay this B frame even when
+                    // the pointer stops before another browser event arrives.
+                    if (record.transitioning || record.converted) {
+                        record.transitioning && me.scheduleVesselConversionReplay({
+                            draggedItem,
+                            logicalSourceRect,
+                            now,
+                            pointerInTarget,
+                            targetId,
+                            targetRect
+                        });
+                        return {commitEligible: false, engage: false, retain: false}
+                    }
+                }
+
                 sensor.reset()
             }
 
@@ -450,7 +688,11 @@ class DockTabSortZone extends TabHeaderSortZone {
                 targetRect     : me.vesselConversionTargetRect
             });
 
-            return {commitEligible: record.converted, engage: record.converted, retain: false}
+            return {
+                commitEligible: record.converted && !record.transitioning,
+                engage        : record.converted && !record.transitioning,
+                retain        : false
+            }
         }
 
         if (!sensor.converted) {
@@ -485,12 +727,33 @@ class DockTabSortZone extends TabHeaderSortZone {
     resetVesselConversion() {
         let me = this;
 
+        me.vesselConversionEpoch++;
         me.vesselConversionSensor?.reset();
+        me.vesselConversionCancelPromise   = null;
+        me.vesselConversionItemId          = null;
         me.vesselConversionLogicalRect     = null;
         me.vesselConversionPointerMissedAt = null;
+        me.vesselConversionReplayFrame     = null;
+        me.vesselConversionReplayPromise   = null;
         me.vesselConversionSourceRect      = null;
         me.vesselConversionTargetId        = null;
         me.vesselConversionTargetRect      = null
+    }
+
+    /**
+     * @summary Fires one clone-safe vessel lifecycle record for the caller to settle.
+     * @param {Neo.tab.Container|null} tabContainer
+     * @param {String} eventName
+     * @param {Object} data
+     * @returns {Object}
+     * @protected
+     */
+    fireDockLifecycleEvent(tabContainer, eventName, data) {
+        const record = {settlement: false, sortZone: this, ...data};
+
+        tabContainer?.fire(eventName, record);
+
+        return record
     }
 
     /**
@@ -576,6 +839,11 @@ class DockTabSortZone extends TabHeaderSortZone {
      */
     async onDragStart(data) {
         let me = this;
+
+        // A terminal restore/retirement may still be settling after the base has restored layout.
+        // Starting a successor in that interval would let the predecessor's exact-window effect
+        // mutate the successor generation. Fail shut until the inherited end latch releases.
+        if (me.dragEndActive) return;
 
         me.resetVesselConversion?.();
 
@@ -706,14 +974,24 @@ class DockTabSortZone extends TabHeaderSortZone {
      * @returns {Promise<void>}
      */
     async onDragCancel(data={}) {
-        let me           = this,
-            itemId       = me.dockItemIds?.[me.startIndex],
+        let me               = this,
+            itemId           = me.dockItemIds?.[me.startIndex],
+            conversionItemId = me.dragComponent?.dockItemId ?? itemId ?? null,
+            conversionActive = Boolean(
+                me.vesselConversionSensor?.converted || me.vesselConversionSensor?.transitioning
+            ),
             tabContainer = me.owner?.up?.();
 
         if (me.isWindowDragging && itemId) {
-            tabContainer?.fire('dockTearOutCancel', {
+            const retirement = me.fireDockLifecycleEvent(tabContainer, 'dockTearOutCancel', {
                 itemId, sortZone: me, sourceNodeId: me.dockSourceNodeId
-            })
+            });
+
+            if (conversionActive && conversionItemId) {
+                me.fireDockLifecycleEvent(tabContainer, 'dockVesselConversionRetired', {
+                    itemId: conversionItemId, retirement: retirement.settlement
+                })
+            }
         }
 
         await super.onDragCancel(data)
@@ -753,6 +1031,14 @@ class DockTabSortZone extends TabHeaderSortZone {
             // listener the adapter wires.
             tabContainer = me.owner?.up?.(),
             {clientX, clientY} = data || {};
+
+        const conversionItemId = me.dragComponent?.dockItemId ?? itemId ?? null,
+              conversionActive = Boolean(
+                  me.vesselConversionSensor?.converted || me.vesselConversionSensor?.transitioning
+              ),
+              conversionTargetConverted = me.vesselConversionSensor?.targetConverted === true;
+
+        let postCleanup = null;
 
         if (me.stackDragActive) {
             let commitError    = null,
@@ -800,11 +1086,17 @@ class DockTabSortZone extends TabHeaderSortZone {
             return
         }
 
-        if (me.sortGroup && me.dragComponent) {
-            me.dragCoordinator?.[data.cancelled ? 'onDragCancel' : 'onDragEnd']({
-                draggedItem   : me.dragComponent,
-                sourceSortZone: me
-            })
+        let commitError = null;
+
+        try {
+            if (me.sortGroup && me.dragComponent) {
+                me.dragCoordinator?.[data.cancelled ? 'onDragCancel' : 'onDragEnd']({
+                    draggedItem   : me.dragComponent,
+                    sourceSortZone: me
+                })
+            }
+        } catch (error) {
+            commitError = error
         }
 
         if (!data.cancelled && me.releaseVoidsReorder(data || {})) {
@@ -813,9 +1105,61 @@ class DockTabSortZone extends TabHeaderSortZone {
 
         if (data.cancelled) {
             me.remoteDropCommitted = false;
-
             itemId && tabContainer?.fire('dockCrossZoneDragCancel', {itemId, sourceNodeId: me.dockSourceNodeId})
-        } else if (me.remoteDropCommitted) {
+        } else if (!commitError && me.remoteDropCommitted) {
+            if (conversionActive && conversionItemId) {
+                me.fireDockLifecycleEvent(tabContainer, 'dockVesselConversionTerminal', {
+                    itemId: conversionItemId, outcome: 'committed'
+                })
+            }
+
+            me.remoteDropCommitted = false
+        } else if (conversionActive && conversionItemId) {
+            if (conversionTargetConverted) {
+                // The target refused while the G1 vessel was parking/parked. It is still an empty
+                // provisional render target and source model truth remains home: retire it with
+                // zero mutation, then clear the park generation. Re-showing before close would
+                // create competing physical dispositions for the same exact handle.
+                const retirement = me.fireDockLifecycleEvent(tabContainer, 'dockTearOutCancel', {
+                    itemId: conversionItemId, sourceNodeId: me.dockSourceNodeId
+                });
+
+                me.fireDockLifecycleEvent(tabContainer, 'dockVesselConversionRetired', {
+                    itemId: conversionItemId, retirement: retirement.settlement
+                })
+            } else {
+                // Release raced an admitted convert-out. Complete terminal re-show first; only a
+                // strict restore may proceed to the ordinary detached commit/adoption. Refusal
+                // degrades to zero-mutation retirement so no still-parked vessel is adopted.
+                const terminal = me.fireDockLifecycleEvent(tabContainer, 'dockVesselConversionTerminal', {
+                    itemId: conversionItemId, outcome: 'rejected'
+                });
+
+                postCleanup = async () => {
+                    let restored = false;
+
+                    try {
+                        restored = await terminal.settlement === true
+                    } catch {
+                        restored = false
+                    }
+
+                    if (restored) {
+                        tabContainer?.fire('dockTearOutTerminal', {
+                            itemId: conversionItemId, sortZone: me, sourceNodeId: me.dockSourceNodeId
+                        })
+                    } else {
+                        const retirement = me.fireDockLifecycleEvent(tabContainer, 'dockTearOutCancel', {
+                            itemId: conversionItemId, sourceNodeId: me.dockSourceNodeId
+                        });
+
+                        me.fireDockLifecycleEvent(tabContainer, 'dockVesselConversionRetired', {
+                            itemId: conversionItemId, retirement: retirement.settlement
+                        })
+                    }
+                }
+            }
+
             me.remoteDropCommitted = false
         } else if (me.isWindowDragging) {
             // Released while detached — THE terminal a dock host may commit a `detachItem` on
@@ -831,6 +1175,12 @@ class DockTabSortZone extends TabHeaderSortZone {
             await super.processDragEnd(data)
         } finally {
             me.resetVesselConversion?.()
+        }
+
+        await postCleanup?.();
+
+        if (commitError) {
+            throw commitError
         }
     }
 

--- a/src/dashboard/DockTearOut.mjs
+++ b/src/dashboard/DockTearOut.mjs
@@ -33,23 +33,179 @@
  * @param {Function} seams.applyOperation Host model seam: `({operation, itemId}) => {document, errors}` —
  *     the workspace's pure reducer (`applyDockZoneOperation`). Called exactly once per successful
  *     tear-out, with `{operation: 'detachItem', itemId}`.
- * @param {Function} seams.closeVessel Host vessel retirement: `({itemId, windowName}) => void|Promise` —
- *     closes the OS window a retired gesture leaves behind. Never called for a committed tear-out.
- * @param {Function} seams.onDocumentChange Host view-sync seam: `(document, operation) => void` —
- *     receives the committed post-detach document (the same seam shape the adapter's `moveTo`
- *     listener feeds).
+ * @param {Function} seams.closeVessel Host vessel retirement:
+ *     `({itemId, windowName}) => Boolean|void|Promise<Boolean|void>` — closes the OS window a
+ *     retired gesture leaves behind. Explicit `false` refuses retirement and preserves the slot;
+ *     legacy void success remains admitted. Never called for a committed tear-out.
+ * @param {Function} seams.onDocumentChange Host view-sync seam: `(document, operation, vessel) => void` —
+ *     receives the committed post-detach document plus the exact admitted vessel generation (the
+ *     same document/operation seam shape the adapter's `moveTo` listener feeds).
  * @param {Function} seams.openVessel Host vessel acquisition:
- *     `({itemId, proxyRect, sortZone}) => Promise<{popupHeight, popupWidth, windowName}|null>` —
+ *     `({admissionToken, itemId, proxyRect, sortZone}) => Promise<{admissionToken, generation,
+ *     popupHeight, popupWidth, windowName}|null>` —
  *     the host performs the platform work (URL, geometry, `windowOpen`) and resolves FALSY on any
  *     failed admission (`windowOpen` returns a Boolean — a blocked popup never throws, so the host
  *     must check the Boolean, not catch).
- * @returns {Object} `{onDockTearOutCancel, onDockTearOutEntry, onDockTearOutExit, onDockTearOutTerminal}`
+ * @returns {Object} `{activeVessel, onDockTearOutCancel, onDockTearOutEntry,
+ *     onDockTearOutExit, onDockTearOutTerminal, onVesselRetired, retireActiveVessel}`
  */
 export function createDockTearOutHandlers({applyOperation, closeVessel, onDocumentChange, openVessel}) {
-    // The single-gesture vessel slot: `{itemId, windowName}` while a vessel is admitted, else null.
-    let activeVessel = null;
+    // The admitted slot is deliberately separate from provisional acquisition and cleanup-only
+    // late authority. A terminal can invalidate an in-flight host Promise before it settles; its
+    // result may then be retired, but can never become active/committable for a dead gesture.
+    let activeVessel        = null,
+        admissionGeneration = 0,
+        lateVessel          = null,
+        pendingAdmission    = null,
+        retirement          = null;
+
+    /**
+     * @summary Creates the exact vessel identity without widening its enumerable public payload.
+     * @param {String} itemId
+     * @param {Object} vessel
+     * @param {Number} fallbackGeneration
+     * @returns {Object}
+     */
+    const createVesselIdentity = (itemId, vessel, fallbackGeneration) => {
+        const identity = {itemId, windowName: vessel.windowName};
+
+        Object.defineProperties(identity, {
+            admissionToken: {
+                value: Number.isFinite(vessel.admissionToken) ? vessel.admissionToken : fallbackGeneration
+            },
+            generation: {
+                value: Number.isFinite(vessel.generation) ? vessel.generation : fallbackGeneration
+            }
+        });
+
+        return identity
+    };
+
+    /**
+     * @summary Invalidates one matching provisional admission before any gesture terminal acts.
+     * @param {String} itemId
+     * @returns {Boolean}
+     */
+    const invalidateAdmission = itemId => {
+        if (
+            !pendingAdmission || pendingAdmission.itemId !== itemId || pendingAdmission.invalidated
+        ) return false;
+
+        pendingAdmission.invalidated = true;
+        admissionGeneration++;
+
+        return true
+    };
+
+    /**
+     * @summary Retires the active vessel once and clears authority only after non-false success.
+     * @param {Object} vessel
+     * @returns {Boolean|Promise<Boolean>}
+     */
+    const retireVessel = vessel => {
+        if (retirement) return retirement.promise;
+
+        let result;
+
+        try {
+            result = closeVessel(vessel)
+        } catch {
+            return false
+        }
+
+        if (typeof result?.then !== 'function') {
+            if (result !== false) {
+                activeVessel === vessel && (activeVessel = null);
+                lateVessel   === vessel && (lateVessel   = null)
+            }
+
+            return result !== false
+        }
+
+        const state = {promise: null, vessel};
+
+        retirement = state;
+        state.promise = Promise.resolve(result).then(closed => {
+            if (retirement !== state) return false;
+
+            retirement = null;
+
+            if (closed !== false) {
+                activeVessel === vessel && (activeVessel = null);
+                lateVessel   === vessel && (lateVessel   = null)
+            }
+
+            return closed !== false
+        }, () => {
+            retirement === state && (retirement = null);
+            return false
+        });
+
+        return state.promise
+    };
 
     return {
+        /**
+         * @member {Object|null} activeVessel
+         */
+        get activeVessel() {
+            return activeVessel
+        },
+
+        /**
+         * @summary Retires the exact active vessel without discarding retry authority first.
+         *
+         * A committed remote target consumes the source vessel without traversing the detached
+         * terminal below. The conversion lifecycle therefore needs one exact, item-guarded close
+         * path. Strict refusal retains this private slot; every stale or other-item request is inert.
+         * @param {Object} identity
+         * @param {String} identity.itemId
+         * @param {String} identity.windowName
+         * @returns {Boolean|Promise<Boolean>}
+         */
+        retireActiveVessel({itemId, windowName} = {}) {
+            let vessel = activeVessel;
+
+            if (
+                !vessel || vessel.itemId !== itemId || vessel.windowName !== windowName
+            ) return false;
+
+            return retireVessel(vessel)
+        },
+
+        /**
+         * @summary Clears one exact vessel after its external owner observed physical retirement.
+         * @param {Object} identity
+         * @param {String} identity.itemId
+         * @param {String} identity.windowName
+         * @returns {Boolean}
+         */
+        onVesselRetired({admissionToken, generation, itemId, windowName} = {}) {
+            if (
+                pendingAdmission?.itemId === itemId &&
+                pendingAdmission.token === admissionToken
+            ) {
+                pendingAdmission.externallyRetired = true;
+                return invalidateAdmission(itemId)
+            }
+
+            const matches = vessel => Boolean(
+                vessel && vessel.itemId === itemId && vessel.windowName === windowName &&
+                (!Number.isFinite(generation) || vessel.generation === generation) &&
+                (!Number.isFinite(admissionToken) || vessel.admissionToken === admissionToken)
+            );
+
+            let vessel = matches(activeVessel) ? activeVessel : lateVessel;
+
+            if (!matches(vessel)) return false;
+
+            activeVessel === vessel && (activeVessel = null);
+            lateVessel   === vessel && (lateVessel   = null);
+            retirement = null;
+
+            return true
+        },
+
         /**
          * Cancel while detached: the vessel retires, the document was never touched. The zone's
          * base cleanup owns the embodiment teardown (the drag is over), so unlike entry there is
@@ -57,12 +213,13 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
          * @param {Object} data
          */
         onDockTearOutCancel(data) {
+            invalidateAdmission(data?.itemId);
+
             let vessel = activeVessel;
 
-            if (!vessel) return;
+            if (!vessel) return false;
 
-            activeVessel = null;
-            closeVessel(vessel)
+            return retireVessel(vessel)
         },
 
         /**
@@ -72,14 +229,15 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
          * @param {Object} data
          */
         onDockTearOutEntry(data) {
+            invalidateAdmission(data?.itemId);
+
             let vessel = activeVessel;
 
             data.sortZone?.endWindowDrag();
 
-            if (!vessel) return;
+            if (!vessel) return false;
 
-            activeVessel = null;
-            closeVessel(vessel)
+            return retireVessel(vessel)
         },
 
         /**
@@ -91,23 +249,65 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
          * @returns {Promise<void>}
          */
         async onDockTearOutExit(data) {
-            if (activeVessel) return;
+            if (activeVessel || retirement || pendingAdmission) return false;
 
-            let vessel = await openVessel({itemId: data.itemId, proxyRect: data.proxyRect, sortZone: data.sortZone});
+            if (lateVessel) {
+                const retired = await retireVessel(lateVessel);
+
+                if (!retired) {
+                    data.sortZone?.endWindowDrag();
+                    return false
+                }
+            }
+
+            const state = {
+                externallyRetired: false,
+                invalidated      : false,
+                itemId           : data.itemId,
+                token            : ++admissionGeneration
+            };
+
+            pendingAdmission = state;
+
+            let vessel;
+
+            try {
+                vessel = await openVessel({
+                    admissionToken: state.token,
+                    itemId        : data.itemId,
+                    proxyRect     : data.proxyRect,
+                    sortZone      : data.sortZone
+                })
+            } catch {
+                vessel = null
+            }
+
+            pendingAdmission === state && (pendingAdmission = null);
+
+            if (state.invalidated || state.token !== admissionGeneration) {
+                if (!state.externallyRetired && vessel?.windowName) {
+                    lateVessel = createVesselIdentity(data.itemId, vessel, state.token);
+                    await retireVessel(lateVessel)
+                }
+
+                return false
+            }
 
             if (!vessel) {
                 data.sortZone?.endWindowDrag();
-                return
+                return false
             }
 
-            activeVessel = {itemId: data.itemId, windowName: vessel.windowName};
+            activeVessel = createVesselIdentity(data.itemId, vessel, state.token);
 
             data.sortZone?.startWindowDrag({
                 dragData   : data,
                 popupHeight: vessel.popupHeight,
                 popupWidth : vessel.popupWidth,
                 windowName : vessel.windowName
-            })
+            });
+
+            return true
         },
 
         /**
@@ -122,11 +322,11 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
          * @param {Object} data
          */
         onDockTearOutTerminal(data) {
+            invalidateAdmission(data?.itemId);
+
             let vessel = activeVessel;
 
-            if (!vessel || vessel.itemId !== data.itemId) return;
-
-            activeVessel = null;
+            if (!vessel || vessel.itemId !== data.itemId) return false;
 
             let operation = {operation: 'detachItem', itemId: data.itemId},
                 result;
@@ -138,9 +338,11 @@ export function createDockTearOutHandlers({applyOperation, closeVessel, onDocume
             }
 
             if (result && !result.errors?.length && result.document) {
-                onDocumentChange(result.document, operation)
+                activeVessel = null;
+                onDocumentChange(result.document, operation, vessel);
+                return true
             } else {
-                closeVessel(vessel)
+                return retireVessel(vessel)
             }
         }
     }

--- a/src/dashboard/DockVesselConversion.mjs
+++ b/src/dashboard/DockVesselConversion.mjs
@@ -125,12 +125,15 @@ function axisRatio(a, b, axis, extent) {
  *     satisfied — a detached vessel converts to a proxy. Must sit strictly above `revertThreshold`.
  * @param {Number} [config.revertThreshold=0.35] Composed ratio below which a converted vessel
  *     reverts to its detached embodiment. The gap to `convertThreshold` is the flicker-free dead band.
- * @param {Function} config.onConvertIn Actuation seam, fired exactly once per conversion with the
- *     final sample record: the host suspends the popup embodiment and embodies the proxy.
- * @param {Function} config.onConvertOut Actuation seam, fired exactly once per reversion with the
- *     final sample record: the host resumes the popup embodiment at the record's `sourceRect`.
- * @returns {Object} `{converted, reset, sample}` — the live conversion flag (getter), the silent
- *     idempotent terminal reset, and the per-frame sampler
+ * @param {Function} config.onConvertIn Strict admission seam, fired exactly once per conversion
+ *     attempt with the proposed final sample record. `true` admits synchronously;
+ *     `Promise<true>` admits only when it settles. Every other result refuses without changing
+ *     conversion ownership.
+ * @param {Function} config.onConvertOut Strict admission seam, fired exactly once per reversion
+ *     attempt with the proposed final sample record. Re-show refusal preserves conversion
+ *     ownership so the exact same vessel remains recoverable and the transition may be retried.
+ * @returns {Object} `{converted, reset, sample, targetConverted, transitioning,
+ *     transitionPromise}` — live admitted state plus the source-owned async admission latch
  */
 export function createVesselConversionSensor(config = {}) {
     const {
@@ -162,8 +165,13 @@ export function createVesselConversionSensor(config = {}) {
         )
     }
 
-    // The single-gesture conversion flag: true while the dragged vessel embodies as a proxy.
-    let converted = false;
+    // The admitted single-gesture conversion flag plus one generation-scoped platform transition.
+    // The coordinator still consumes a synchronous policy record; the promise never leaves this
+    // source owner. A reset invalidates the generation so a predecessor completion cannot mutate
+    // its successor gesture.
+    let converted  = false,
+        generation = 0,
+        transition = null;
 
     return {
         /**
@@ -174,12 +182,37 @@ export function createVesselConversionSensor(config = {}) {
         },
 
         /**
+         * The proposed state of an in-flight transition, otherwise the admitted state.
+         * @member {Boolean} targetConverted
+         */
+        get targetConverted() {
+            return transition?.targetConverted ?? converted
+        },
+
+        /**
+         * @member {Boolean} transitioning
+         */
+        get transitioning() {
+            return transition !== null
+        },
+
+        /**
+         * The current strict-admission settlement, or `null` when no platform effect is pending.
+         * @member {Promise<Boolean>|null} transitionPromise
+         */
+        get transitionPromise() {
+            return transition?.promise ?? null
+        },
+
+        /**
          * Terminal reset — SILENT and idempotent by contract: gesture terminals (commit, cancel,
          * close, park) are the outcome machine's choreography; the sensor only forgets. The next
          * gesture's samples decide fresh.
          */
         reset() {
-            converted = false
+            generation++;
+            converted  = false;
+            transition = null
         },
 
         /**
@@ -193,7 +226,8 @@ export function createVesselConversionSensor(config = {}) {
          * @param {Object} data.sourceRect Live `{x, y, width, height}` of the dragged vessel
          * @param {Object} data.targetRect Live `{x, y, width, height}` of the target vessel
          * @returns {Object} The sample record `{composed, converted, pointerInTarget, rx, ry,
-         *     sourceRect, targetRect}` — `converted` reflects the POST-decision state
+         *     sourceRect, targetRect}`. While strict async admission is pending it additionally
+         *     carries `transitioning: true`, and `converted` remains the prior admitted state.
          */
         sample({pointerInTarget, sourceRect, targetRect} = {}) {
             // Invalid geometry DOMINATES: a missing, degenerate, or non-finite rect forces the
@@ -207,23 +241,68 @@ export function createVesselConversionSensor(config = {}) {
                 ry         = measurable ? axisRatio(sourceRect, targetRect, 'y', 'height') : 0,
                 composed   = measurable ? clampRatio(composeRatios({rx, ry})) : 0;
 
-            let event = null;
+            let event = null,
+                next  = converted;
 
-            if (!converted) {
+            if (!transition && !converted) {
                 if (pointer && composed >= convertThreshold) {
-                    converted = true;
-                    event     = onConvertIn
+                    event = onConvertIn;
+                    next  = true
                 }
-            } else if (!pointer || composed < revertThreshold) {
-                converted = false;
-                event     = onConvertOut
+            } else if (!transition && (!pointer || composed < revertThreshold)) {
+                event = onConvertOut;
+                next  = false
             }
 
-            const record = {composed, converted, pointerInTarget: pointer, rx, ry, sourceRect, targetRect};
+            let record = {composed, converted, pointerInTarget: pointer, rx, ry, sourceRect, targetRect};
 
-            event?.(record);
+            if (transition) {
+                return {...record, transitioning: true}
+            }
 
-            return record
+            if (!event) {
+                return record
+            }
+
+            const proposed = {...record, converted: next};
+
+            let admission;
+
+            try {
+                admission = event(proposed)
+            } catch {
+                return record
+            }
+
+            if (admission === true) {
+                converted = next;
+                return proposed
+            }
+
+            if (typeof admission?.then !== 'function') {
+                return record
+            }
+
+            const token = ++generation,
+                  state = {promise: null, targetConverted: next, token};
+
+            transition = state;
+            state.promise = Promise.resolve(admission).then(value => {
+                if (transition !== state || generation !== token) return false;
+
+                value === true && (converted = next);
+                transition = null;
+
+                return value === true
+            }, () => {
+                if (transition === state && generation === token) {
+                    transition = null
+                }
+
+                return false
+            });
+
+            return {...record, transitioning: true}
         }
     }
 }

--- a/src/dashboard/DockVesselEmbodiment.mjs
+++ b/src/dashboard/DockVesselEmbodiment.mjs
@@ -1,0 +1,189 @@
+import Component from '../component/Base.mjs';
+
+/**
+ * @module Neo.dashboard.DockVesselEmbodiment
+ * @summary Moves one live dock pane into an admitted tear-out vessel while preserving the source
+ * card slot until document truth decides the gesture terminal.
+ *
+ * This helper owns render topology only. It never opens, closes, identifies, or authorizes a native
+ * window, and it never mutates a dock document. The host must first validate the exact vessel, then
+ * call {@link #stage}. A hidden placeholder keeps tab-header and card-body indices paired while the
+ * live pane renders in the vessel. Zero-mutation retirement restores through the placeholder's LIVE
+ * index; committed ownership calls {@link #promote} and leaves the placeholder for the ordinary dock
+ * projection to retire alongside the obsolete tab button.
+ */
+
+/**
+ * Creates one host-local transient embodiment registry.
+ * @param {Object} seams
+ * @param {Function} seams.resolvePane `(itemId) => Neo.component.Base|null`
+ * @param {Function} seams.resolveTarget `(windowId) => Neo.container.Base|null`
+ * @returns {Object}
+ */
+export function createDockVesselEmbodiment({resolvePane, resolveTarget} = {}) {
+    if (typeof resolvePane !== 'function' || typeof resolveTarget !== 'function') {
+        throw new Error('createDockVesselEmbodiment requires resolvePane and resolveTarget seams')
+    }
+
+    const records = new Map();
+
+    /**
+     * @summary Stages the same live pane in one admitted vessel and reserves its exact source slot.
+     * @param {Object} identity
+     * @param {String} identity.itemId
+     * @param {String} identity.windowId
+     * @returns {Boolean|Promise<Boolean>}
+     */
+    const stage = ({itemId, windowId} = {}) => {
+        let existing = records.get(itemId);
+
+        if (existing) return existing.windowId === windowId ? existing.settlement : false;
+
+        const
+            pane         = resolvePane(itemId),
+            sourceParent = pane?.parent,
+            sourceIndex  = sourceParent?.items?.indexOf(pane) ?? -1,
+            target       = resolveTarget(windowId);
+
+        if (!itemId || !windowId || !pane || pane.isDestroyed || !sourceParent || sourceIndex < 0 || !target) {
+            return false
+        }
+
+        const placeholder = Neo.create({
+            module  : Component,
+            cls     : ['neo-dashboard-dock-vessel-placeholder'],
+            hidden  : true,
+            hideMode: 'visibility'
+        });
+
+        let record = {pane, placeholder, settlement: null, sourceParent, windowId};
+
+        records.set(itemId, record);
+        record.settlement = (async () => {
+            try {
+                sourceParent.removeAt(sourceIndex, false, true);
+                sourceParent.insert(sourceIndex, placeholder, true);
+                sourceParent.updateDepth = -1;
+                sourceParent.update();
+                target.add(pane);
+
+                // Cross-window insertion is not complete when `add()` returns. The exact vessel
+                // may otherwise be published to gesture logic, parked, and only THEN finish its
+                // pane mount — a late focus/mount side effect that can raise the parked source.
+                await Promise.all([
+                    sourceParent.promiseUpdate?.(),
+                    target.promiseUpdate?.()
+                ]);
+
+                return records.get(itemId) === record
+            } catch {
+                if (records.get(itemId) !== record) return false;
+
+                records.delete(itemId);
+
+                let liveParent = placeholder.parent,
+                    liveIndex  = liveParent?.items?.indexOf(placeholder) ?? -1;
+
+                if (liveParent && liveIndex >= 0) {
+                    liveParent.removeAt(liveIndex, true, true);
+                    liveParent.insert(liveIndex, pane, true);
+                    liveParent.updateDepth = -1;
+                    liveParent.update()
+                } else {
+                    placeholder.isDestroyed || placeholder.destroy()
+                }
+
+                return false
+            }
+        })();
+
+        return record.settlement
+    };
+
+    return {
+        /**
+         * @summary Destroys any remaining transient placeholders during host teardown.
+         */
+        destroy() {
+            records.forEach(({placeholder}) => {
+                if (!placeholder.isDestroyed) {
+                    placeholder.parent?.remove(placeholder, true, true);
+                    placeholder.isDestroyed || placeholder.destroy()
+                }
+            });
+            records.clear()
+        },
+
+        /**
+         * @summary Reports whether one item currently renders through a staged vessel.
+         * @param {String} itemId
+         * @returns {Boolean}
+         */
+        isStaged(itemId) {
+            return records.has(itemId)
+        },
+
+        /**
+         * @summary Returns the exact staged target identity without exposing the render record.
+         * @param {String} itemId
+         * @returns {String|null}
+         */
+        getWindowId(itemId) {
+            return records.get(itemId)?.windowId ?? null
+        },
+
+        /**
+         * @summary Commits render ownership to the vessel without touching the source placeholder.
+         * @description The next document projection owns placeholder + obsolete-button cleanup.
+         * @param {Object} identity
+         * @param {String} identity.itemId
+         * @param {String} identity.windowId
+         * @returns {Boolean}
+         */
+        promote({itemId, windowId} = {}) {
+            const record = records.get(itemId);
+
+            if (!record || record.windowId !== windowId) return false;
+
+            records.delete(itemId);
+
+            return true
+        },
+
+        /**
+         * @summary Restores a zero-mutation gesture through the placeholder's current live slot.
+         * @description The placeholder may have shifted while the vessel was open, so its current
+         * parent/index — never a stale captured number — is the only restoration authority.
+         * @param {Object} identity
+         * @param {String} identity.itemId
+         * @param {String} identity.windowId
+         * @returns {Boolean}
+         */
+        restore({itemId, windowId} = {}) {
+            const
+                record      = records.get(itemId),
+                placeholder = record?.placeholder,
+                parent      = placeholder?.parent,
+                index       = parent?.items?.indexOf(placeholder) ?? -1;
+
+            if (!record || record.windowId !== windowId || !parent || index < 0 || record.pane.isDestroyed) {
+                return false
+            }
+
+            try {
+                record.pane.parent?.remove(record.pane, false);
+                parent.removeAt(index, true, true);
+                parent.insert(index, record.pane, true);
+                parent.updateDepth = -1;
+                parent.update();
+                records.delete(itemId);
+
+                return true
+            } catch {
+                return false
+            }
+        },
+
+        stage
+    }
+}

--- a/src/dashboard/DockVesselPark.mjs
+++ b/src/dashboard/DockVesselPark.mjs
@@ -21,10 +21,10 @@
  *   machine owns the ordering between them: convert-in → park; convert-out → re-show; terminal →
  *   dispose (commit) or restore (everything else).
  * - **Commit is the ONLY disposition.** A committed target owns the item now, so the parked vessel
- *   retires through the host's one `disposeVessel` call — exactly once, slot-cleared-first, so a
- *   duplicate terminal (stale event) disposes nothing further. EVERY other outcome — cancel,
- *   reject, or any terminal the host routes while parked — fails toward RESTORE: the machine never
- *   loses the user's window to a lifecycle edge.
+ *   retires through the host's one `disposeVessel` settlement — one in-flight close at a time, and
+ *   the slot clears only after strict success. A refusal retains exact retry authority. EVERY other
+ *   outcome — cancel, reject, or any terminal the host routes while parked — fails toward RESTORE:
+ *   the machine never loses the user's window to a lifecycle edge.
  * - **Two rect sources, one rule.** Out-conversion re-shows at the out-event's LIVE rect when the
  *   caller supplies one (the design record's `resumeWindowDrag(widgetName, proxyRect)` semantics —
  *   the popup resumes under the pointer, where the drag is NOW); absent a supplied rect it falls
@@ -41,17 +41,20 @@
  * composition — a pointer drives at most one drag per window (the tear-out choreography's
  * single-slot reasoning), so the slot never needs a map.
  * @param {Object} seams
- * @param {Function} seams.disposeVessel Host retirement seam: `({itemId, windowName}) => void|Promise` —
- *     the ONE close path for a committed tear-in, routed to the host's reintegration close policy.
- *     Called exactly once per commit, never for any other outcome.
- * @param {Function} seams.parkVessel Host park seam: `({itemId, windowName}) => void|Promise` — the
- *     platform mechanic (hide, offscreen move, minimize — matrix-selected, the host's business).
- *     Parking is a render-target effect: it must never close the window or touch model documents.
- * @param {Function} seams.reshowVessel Host re-show seam: `({itemId, rect, windowName}) => void|Promise` —
- *     re-presents the SAME parked window at `rect`. Zero re-acquisition: the machine guarantees
- *     `windowName` is the one it parked.
- * @returns {Object} `{onConversionIn, onConversionOut, onGestureTerminal, parkedVessel}` — the two
- *     sensor-driven handlers, the terminal router, and the read-only park-slot view
+ * @param {Function} seams.disposeVessel Host retirement seam:
+ *     `({itemId, windowName}) => Boolean|Promise<Boolean>` — the ONE close path for a committed
+ *     tear-in, routed to the host's reintegration close policy. Only strict `true` clears cleanup
+ *     authority; refusal retains the slot for an exact retry.
+ * @param {Function} seams.parkVessel Host park seam: `({itemId, windowName}) => Boolean|Promise<Boolean>` —
+ *     the platform mechanic (hide, offscreen move, minimize — matrix-selected, the host's
+ *     business). Only strict `true` publishes parked ownership; dispatch is never admission.
+ * @param {Function} seams.reshowVessel Host re-show seam:
+ *     `({itemId, rect, terminal, windowName}) => Boolean|Promise<Boolean>` — re-presents the SAME
+ *     parked window at `rect`. `terminal` distinguishes a final restore from live pointer-follow
+ *     resumption. A refusal retains the slot for retry; zero re-acquisition by construction.
+ * @returns {Object} `{onConversionIn, onConversionOut, onGestureTerminal, onVesselRetired,
+ *     parkedVessel, transition}` — sensor handlers, terminal/external-retirement routers,
+ *     admitted slot, and in-flight phase
  */
 export function createVesselParkHandlers({disposeVessel, parkVessel, reshowVessel} = {}) {
     if (typeof disposeVessel !== 'function' || typeof parkVessel !== 'function' || typeof reshowVessel !== 'function') {
@@ -61,8 +64,104 @@ export function createVesselParkHandlers({disposeVessel, parkVessel, reshowVesse
         )
     }
 
-    // The single-gesture park slot: `{itemId, preConversionRect, windowName}` while parked, else null.
-    let parked = null;
+    // Admitted ownership and generation-scoped effects stay separate: a Promise dispatch can
+    // never publish parked/restored truth, and duplicate terminals share one settlement.
+    let generation        = 0,
+        parked            = null,
+        parking           = null,
+        pendingOut        = null,
+        pendingRetirement = null,
+        pendingTerminal   = null,
+        reshowing         = null;
+
+    /**
+     * @summary Normalizes a synchronous host throw into strict refusal.
+     * @param {Function} fn
+     * @param {Object} data
+     * @returns {*}
+     */
+    const callEffect = (fn, data) => {
+        try {
+            return fn(data)
+        } catch {
+            return false
+        }
+    };
+
+    /**
+     * @summary Converts sync or async host results into strict Boolean admission.
+     * @param {*} value
+     * @returns {Boolean|Promise<Boolean>}
+     */
+    const settleEffect = value => typeof value?.then === 'function'
+        ? Promise.resolve(value).then(result => result === true, () => false)
+        : value === true;
+
+    /**
+     * @summary Re-shows one admitted vessel without clearing ownership before strict success.
+     * @param {Object} vessel
+     * @param {Object|null} rect
+     * @param {Boolean} [terminal=false]
+     * @returns {Boolean|Promise<Boolean>}
+     */
+    const restore = (vessel, rect, terminal=false) => {
+        if (reshowing) return reshowing.promise;
+
+        const result = settleEffect(callEffect(reshowVessel, {
+            itemId    : vessel.itemId,
+            rect      : rect ?? vessel.preConversionRect,
+            terminal,
+            windowName: vessel.windowName
+        }));
+
+        if (typeof result?.then !== 'function') {
+            result && parked === vessel && (parked = null);
+            return result
+        }
+
+        const state = {generation: vessel.generation, phase: 'reshowing', promise: null, vessel};
+
+        reshowing = state;
+        state.promise = result.then(admitted => {
+            if (reshowing !== state || state.generation !== vessel.generation) return false;
+
+            admitted && parked === vessel && (parked = null);
+            reshowing = null;
+
+            return admitted
+        });
+
+        return state.promise
+    };
+
+    /**
+     * @summary Applies one admitted vessel's exact-once committed or restorative disposition.
+     * @param {Object} vessel
+     * @param {Object} data
+     * @param {Boolean} [compensate=false] Restore even when async invalidation withheld admission
+     * @returns {Boolean|Promise<Boolean>}
+     */
+    const finishTerminal = (vessel, data, compensate=false) => {
+        if (data.outcome === 'committed') {
+            const disposed = settleEffect(callEffect(disposeVessel, {
+                itemId: vessel.itemId, windowName: vessel.windowName
+            }));
+
+            if (typeof disposed?.then !== 'function') {
+                disposed && parked === vessel && (parked = null);
+                return disposed
+            }
+
+            return disposed.then(admitted => {
+                admitted && parked === vessel && (parked = null);
+                return admitted
+            })
+        }
+
+        return parked === vessel || compensate
+            ? restore(vessel, vessel.preConversionRect, true)
+            : true
+    };
 
     return {
         /**
@@ -77,13 +176,32 @@ export function createVesselParkHandlers({disposeVessel, parkVessel, reshowVesse
          * @param {String} data.windowName
          */
         onConversionIn(data) {
-            if (parked) return;
+            if (parked || parking || reshowing || pendingRetirement || pendingTerminal) return false;
 
-            let {itemId, sourceRect, windowName} = data;
+            let {itemId, sourceRect, windowName} = data,
+                vessel                           = {itemId, preConversionRect: sourceRect ?? null, windowName},
+                result                           = settleEffect(callEffect(parkVessel, {itemId, windowName}));
 
-            parked = {itemId, preConversionRect: sourceRect ?? null, windowName};
+            Object.defineProperty(vessel, 'generation', {value: ++generation});
 
-            parkVessel({itemId, windowName})
+            if (typeof result?.then !== 'function') {
+                result && (parked = vessel);
+                return result
+            }
+
+            const state = {generation: vessel.generation, phase: 'parking', promise: null, vessel};
+
+            parking = state;
+            state.promise = result.then(admitted => {
+                if (parking !== state || state.generation !== vessel.generation) return false;
+
+                parking = null;
+                admitted && (parked = vessel);
+
+                return admitted
+            });
+
+            return state.promise
         },
 
         /**
@@ -95,25 +213,35 @@ export function createVesselParkHandlers({disposeVessel, parkVessel, reshowVesse
          *     `sourceRect` is the natural feed)
          */
         onConversionOut(data) {
-            let vessel = parked;
+            if (pendingRetirement) return pendingRetirement.promise;
+            if (pendingTerminal) return false;
+            if (pendingOut) return pendingOut.promise;
+            if (reshowing) return reshowing.promise;
 
-            if (!vessel) return;
+            if (parking) {
+                const state = {generation: parking.generation, phase: 'queued-out', promise: null, vessel: parking.vessel};
 
-            parked = null;
+                pendingOut = state;
+                state.promise = parking.promise.then(admitted => admitted && !pendingRetirement
+                    ? restore(state.vessel, data?.rect)
+                    : !admitted
+                ).then(restored => {
+                    pendingOut === state && (pendingOut = null);
+                    return restored
+                });
 
-            reshowVessel({
-                itemId    : vessel.itemId,
-                rect      : data?.rect ?? vessel.preConversionRect,
-                windowName: vessel.windowName
-            })
+                return state.promise
+            }
+
+            return parked ? restore(parked, data?.rect) : false
         },
 
         /**
          * The gesture resolved while the vessel is parked — the outcome machine's terminal routed
          * here decides the parked window's fate:
          * - `committed`: the target owns the item now — the ONE `disposeVessel` call fires (the
-         *   host's close policy takes it from there). Slot cleared first: a duplicate terminal
-         *   disposes nothing further.
+         *   host's close policy takes it from there). Duplicate terminals coalesce while close is
+         *   pending; strict refusal retains the slot, and strict success clears it.
          * - anything else (cancel, reject, host-routed disconnect): RESTORE — re-show at the
          *   pre-conversion rect with zero disposition. The machine fails toward never losing the
          *   user's window.
@@ -123,21 +251,127 @@ export function createVesselParkHandlers({disposeVessel, parkVessel, reshowVesse
          * @param {String} data.outcome `'committed'` disposes; every other value restores
          */
         onGestureTerminal(data) {
-            let vessel = parked;
-
-            if (!vessel || vessel.itemId !== data.itemId) return;
-
-            parked = null;
-
-            if (data.outcome === 'committed') {
-                disposeVessel({itemId: vessel.itemId, windowName: vessel.windowName})
-            } else {
-                reshowVessel({
-                    itemId    : vessel.itemId,
-                    rect      : vessel.preConversionRect,
-                    windowName: vessel.windowName
-                })
+            if (pendingRetirement) {
+                return pendingRetirement.vessel.itemId === data.itemId
+                    ? pendingRetirement.promise
+                    : false
             }
+            if (pendingTerminal) {
+                return pendingTerminal.vessel.itemId === data.itemId
+                    ? pendingTerminal.promise
+                    : false
+            }
+
+            let vessel = parked ?? parking?.vessel ?? reshowing?.vessel;
+
+            if (!vessel || vessel.itemId !== data.itemId) return false;
+
+            if (parking || reshowing) {
+                const prerequisite = parking?.promise ?? reshowing.promise,
+                      state        = {generation: vessel.generation, phase: 'terminal', promise: null, vessel};
+
+                pendingTerminal = state;
+                state.promise = prerequisite.then(() => {
+                    if (
+                        pendingTerminal !== state || pendingRetirement ||
+                        state.generation !== vessel.generation
+                    ) return false;
+
+                    // False-after-reset does not prove the native park move never happened: Main
+                    // can observe the move, then invalidate pointer-follow before the worker sees
+                    // its terminal. Always run the compensating disposition for this generation.
+                    return finishTerminal(vessel, data, true)
+                }).then(result => {
+                    pendingTerminal === state && (pendingTerminal = null);
+                    return result
+                });
+
+                return state.promise
+            }
+
+            const state = {generation: vessel.generation, phase: 'terminal', promise: null, vessel};
+
+            pendingTerminal = state;
+
+            const result = finishTerminal(vessel, data);
+
+            if (typeof result?.then !== 'function') {
+                pendingTerminal = null;
+                return result
+            }
+
+            state.promise = Promise.resolve(result).then(admitted => {
+                if (pendingTerminal !== state || state.generation !== vessel.generation) return false;
+
+                pendingTerminal = null;
+                return admitted
+            }, () => {
+                pendingTerminal === state && (pendingTerminal = null);
+                return false
+            });
+
+            return state.promise
+        },
+
+        /**
+         * @summary Forgets a vessel another owning lifecycle has already retired.
+         *
+         * A detached cancel is owned by the tear-out machine: it consumes and closes the same
+         * empty source vessel. This clear-only seam invalidates every pending effect generation
+         * so no late park/re-show completion can resurrect ownership after that external close.
+         * @param {Object} data
+         * @param {String} data.itemId
+         * @param {Boolean|Promise<Boolean>} [data.retirement=true] Strict outer-lifecycle close
+         * @returns {Boolean|Promise<Boolean>}
+         */
+        onVesselRetired({itemId, retirement=true} = {}) {
+            if (pendingRetirement) {
+                return pendingRetirement.vessel.itemId === itemId
+                    ? pendingRetirement.promise
+                    : false
+            }
+
+            const vessel = pendingTerminal?.vessel ?? pendingOut?.vessel ?? reshowing?.vessel
+                ?? parking?.vessel ?? parked;
+
+            if (!vessel || vessel.itemId !== itemId) return false;
+
+            const clear = () => {
+                generation++;
+                parked          = null;
+                parking         = null;
+                pendingOut      = null;
+                pendingRetirement = null;
+                pendingTerminal = null;
+                reshowing       = null;
+
+                return true
+            };
+
+            if (typeof retirement?.then === 'function') {
+                const state = {
+                    generation: vessel.generation,
+                    phase     : 'retiring',
+                    promise   : null,
+                    vessel
+                };
+
+                pendingRetirement = state;
+                state.promise = Promise.resolve(retirement).then(retired => {
+                    if (pendingRetirement !== state || state.generation !== vessel.generation) return false;
+
+                    pendingRetirement = null;
+
+                    return retired === true ? clear() : false
+                }, () => {
+                    pendingRetirement === state && (pendingRetirement = null);
+                    return false
+                });
+
+                return state.promise
+            }
+
+            return retirement === true ? clear() : false
         },
 
         /**
@@ -145,6 +379,13 @@ export function createVesselParkHandlers({disposeVessel, parkVessel, reshowVesse
          */
         get parkedVessel() {
             return parked
+        },
+
+        /**
+         * @member {Object|null} transition
+         */
+        get transition() {
+            return pendingRetirement ?? pendingTerminal ?? pendingOut ?? reshowing ?? parking
         }
     }
 }

--- a/src/main/addon/DragDrop.mjs
+++ b/src/main/addon/DragDrop.mjs
@@ -101,6 +101,13 @@ class DragDrop extends Base {
          */
         isWindowDragging: false,
         /**
+         * True while the current popup embodiment is parked behind a source-owned conversion.
+         * Logical drag frames keep flowing; only physical pointer-follow moves pause.
+         * @member {Boolean} windowDragParked=false
+         * @protected
+         */
+        windowDragParked: false,
+        /**
          * @member {Boolean} moveHorizontal=true
          */
         moveHorizontal: true,
@@ -129,6 +136,8 @@ class DragDrop extends Base {
         remote: {
             app: [
                 'requestWindowManagementPermission',
+                'parkWindowDrag',
+                'resumeWindowDrag',
                 'setConfigs',
                 'setDragProxyElement',
                 'startWindowDrag'
@@ -151,6 +160,22 @@ class DragDrop extends Base {
          */
         scrollFactorTop: 1
     }
+
+    /**
+     * Monotonic physical-drag lifetime. Reset/start invalidates every older async native move.
+     * @member {Number} windowDragGeneration=0
+     * @protected
+     */
+    windowDragGeneration = 0
+
+    /**
+     * In-flight ordinary pointer-follow moves. Park snapshots and drains this set after pausing;
+     * ordinary moves remain concurrent so the native pointer embodiment never queues behind
+     * position-verification latency.
+     * @member {Set<Promise>} windowDragMovePromises
+     * @protected
+     */
+    windowDragMovePromises = new Set()
 
     /**
      * @param {Object} config
@@ -313,6 +338,9 @@ class DragDrop extends Base {
             scrollContainerRect   : null,
             scrollFactorLeft      : 1,
             scrollFactorTop       : 1,
+            windowDragGeneration  : (me.windowDragGeneration || 0) + 1,
+            windowDragMovePromises: new Set(),
+            windowDragParked      : false,
             windowName            : null
         })
     }
@@ -336,7 +364,24 @@ class DragDrop extends Base {
                 x = originalEvent.screenX - (me.offsetX || 0),
                 y = originalEvent.screenY - (me.offsetY || 0);
 
-            Neo.Main.windowMoveTo({windowName: me.popupName, x, y});
+            if (!me.windowDragParked) {
+                let movement;
+
+                try {
+                    movement = Neo.Main.windowMoveTo({windowName: me.popupName, x, y})
+                } catch {
+                    movement = false
+                }
+
+                if (typeof movement?.then === 'function') {
+                    const tracked = Promise.resolve(movement).catch(() => false).finally(() => {
+                        me.windowDragMovePromises?.delete(tracked)
+                    });
+
+                    me.windowDragMovePromises ??= new Set();
+                    me.windowDragMovePromises.add(tracked)
+                }
+            }
 
             DomEvents.sendMessageToApp({
                 ...me.getEventData(event),
@@ -633,13 +678,116 @@ class DragDrop extends Base {
     }
 
     /**
+     * @summary Pauses physical pointer-follow, drains every already-issued semantic-name move,
+     * then parks the exact opener-minted native handle generation.
+     *
+     * The pause happens before the first await, while `onDragMove()` continues publishing logical
+     * frames. A false/throwing native move re-enables pointer-follow and refuses admission; a
+     * reset/new start invalidates the completion without touching successor state.
+     * @param {Object} data
+     * @param {String} data.nativeHandleKey
+     * @param {String} data.targetWindowId
+     * @param {String} data.windowName
+     * @param {Number} data.x
+     * @param {Number} data.y
+     * @returns {Promise<Boolean>}
+     */
+    async parkWindowDrag({nativeHandleKey, targetWindowId, windowName, x, y} = {}) {
+        let me = this;
+
+        if (
+            !me.isWindowDragging || me.windowDragParked || windowName !== me.popupName ||
+            !nativeHandleKey || !targetWindowId || !Number.isFinite(x) || !Number.isFinite(y)
+        ) {
+            return false
+        }
+
+        const generation = me.windowDragGeneration;
+
+        me.windowDragParked = true;
+
+        await Promise.allSettled([...(me.windowDragMovePromises || [])]);
+
+        if (generation !== me.windowDragGeneration || !me.isWindowDragging || !me.windowDragParked) {
+            return false
+        }
+
+        let admitted = false;
+
+        try {
+            admitted = await Neo.Main.windowNativeMoveTo({nativeHandleKey, targetWindowId, x, y}) === true
+        } catch {
+            admitted = false
+        }
+
+        if (generation !== me.windowDragGeneration || !me.isWindowDragging) {
+            return false
+        }
+
+        admitted || (me.windowDragParked = false);
+
+        return admitted
+    }
+
+    /**
+     * @summary Re-shows the parked exact native generation at the pointer-owned global rect.
+     * Physical pointer-follow resumes only after strict success; refusal retains the parked phase
+     * so the source owner can retry without losing its sole recoverable handle.
+     * @param {Object} data
+     * @param {String} data.nativeHandleKey
+     * @param {String} data.targetWindowId
+     * @param {String} data.windowName
+     * @param {Number} data.x
+     * @param {Number} data.y
+     * @returns {Promise<Boolean>}
+     */
+    async resumeWindowDrag({nativeHandleKey, targetWindowId, windowName, x, y} = {}) {
+        let me = this;
+
+        if (
+            !me.isWindowDragging || !me.windowDragParked || windowName !== me.popupName ||
+            !nativeHandleKey || !targetWindowId || !Number.isFinite(x) || !Number.isFinite(y)
+        ) {
+            return false
+        }
+
+        const generation = me.windowDragGeneration;
+
+        let admitted = false;
+
+        try {
+            admitted = await Neo.Main.windowNativeMoveTo({nativeHandleKey, targetWindowId, x, y}) === true
+        } catch {
+            admitted = false
+        }
+
+        if (generation !== me.windowDragGeneration || !me.isWindowDragging) {
+            return false
+        }
+
+        admitted && (me.windowDragParked = false);
+
+        return admitted
+    }
+
+    /**
      * @param {Object} data
      * @param {String} data.popupHeight
      * @param {String} data.popupName
      * @param {String} data.popupWidth
      */
     startWindowDrag({popupHeight, popupName, popupWidth}) {
-        Object.assign(this, {isWindowDragging: true, popupHeight, popupName, popupWidth})
+        let me = this;
+
+        Object.assign(me, {
+            isWindowDragging      : true,
+            popupHeight,
+            popupName,
+            popupWidth,
+            windowDragGeneration  : (me.windowDragGeneration || 0) + 1,
+            windowDragMovePromises: new Set(),
+            windowDragParked      : false
+        })
     }
 }
 

--- a/src/manager/Window.mjs
+++ b/src/manager/Window.mjs
@@ -118,6 +118,12 @@ class Window extends Manager {
     }
 
     /**
+     * @summary Upserts a connected window over any geometry-first provisional record.
+     * @description Geometry publication can reach the App Worker before the SharedWorker connect event.
+     * In that ordering, `onWindowPositionChange()` registers a geometry-only placeholder. The connect
+     * event must enrich that exact record instead of losing its native route to duplicate-registration
+     * refusal. A later route-less reconnect deliberately replaces the authority with the fail-closed
+     * capability set, so a reload cannot inherit an earlier document's native handle.
      * Triggered when a new browser window connects to the SharedWorker.
      * In Shared Worker mode, `Neo.worker.App#onConnect` ensures that `windowData`
      * is fetched from the Main Thread and included in the payload.
@@ -138,7 +144,8 @@ class Window extends Manager {
 
         console.log('Window.onWindowConnect', {windowId, appName, chrome, innerRect, outerRect});
 
-        this.register({
+        const
+            item = {
             appName,
             capabilities: nativeRoute?.capabilities || {close: false, focus: false, position: false},
             chrome,
@@ -146,7 +153,14 @@ class Window extends Manager {
             innerRect,
             nativeRoute,
             outerRect
-        })
+            },
+            registeredItem = this.get(windowId);
+
+        if (registeredItem) {
+            Object.assign(registeredItem, item)
+        } else {
+            this.register(item)
+        }
     }
 
     /**

--- a/test/playwright/e2e/agentos/DemoBCrossWindowDragNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBCrossWindowDragNL.spec.mjs
@@ -1,30 +1,220 @@
 import {test, expect} from '../../fixtures.mjs';
 
 /**
- * @summary Headless-Chrome physical-window adapter. Product browsers honor the app-owned
- * placement request; headless Chrome ignores it, so CDP moves only the real top-level vessel.
+ * @summary Waits for one admitted child realm's ordinary geometry publisher, then publishes its
+ * observed frame after CDP automation moved the real top-level window.
+ * @param {import('@playwright/test').Page} page
+ * @param {String} message
+ */
+async function publishObservedGeometry(page, message) {
+    await expect.poll(() => page.evaluate(() =>
+        Boolean(globalThis.Neo?.main?.addon?.WindowPosition?.publishGeometry)
+    ), {
+        message,
+        timeout  : 10000,
+        intervals: [25, 50, 100]
+    }).toBe(true);
+
+    await page.evaluate(() => globalThis.Neo.main.addon.WindowPosition.publishGeometry())
+}
+
+/**
+ * @summary Chrome-automation physical-window adapter. Product browsers honor the app-owned
+ * placement request; automation can ignore it, so CDP moves only the real top-level vessel.
  * Dock semantics, pointer events, previews and commits remain entirely Neo-owned.
  * @param {import('@playwright/test').Page} page
  * @param {import('@playwright/test').Page} popup
  */
 async function placePopupOutsideSource(page, popup) {
+    await popup.waitForURL(url => url.protocol !== 'about:', {timeout: 30000});
+
+    const readRect = target => target.evaluate(() => ({
+        height: globalThis.outerHeight,
+        width : globalThis.outerWidth,
+        x     : globalThis.screenX,
+        y     : globalThis.screenY
+    }));
+
+    // Product/headed browsers honor the app's own placement after the popup connects. Give that
+    // bounded observable path first authority; only an actually-overlapping stage needs CDP.
+    for (let attempt = 0; attempt < 20; attempt++) {
+        let [source, target] = await Promise.all([readRect(page), readRect(popup)]),
+            overlaps         = source.x < target.x + target.width && source.x + source.width > target.x
+                && source.y < target.y + target.height && source.y + source.height > target.y;
+
+        if (!overlaps) return;
+
+        await page.waitForTimeout(25)
+    }
+
     const popupCdp    = await page.context().newCDPSession(popup),
           popupWindow = await popupCdp.send('Browser.getWindowForTarget'),
           sourceStage = await page.evaluate(() => ({
-              left : globalThis.screenX,
-              top  : globalThis.screenY,
-              width: globalThis.innerWidth
-          }));
+              availHeight: globalThis.screen.availHeight,
+              availLeft  : globalThis.screen.availLeft,
+              availTop   : globalThis.screen.availTop,
+              availWidth : globalThis.screen.availWidth,
+              height     : globalThis.outerHeight,
+              left       : globalThis.screenX,
+              top        : globalThis.screenY,
+              width      : globalThis.outerWidth
+          })),
+          targetHeight = popupWindow.bounds.height,
+          targetWidth  = popupWindow.bounds.width,
+          gap          = 40,
+          candidates   = [{
+              left: sourceStage.left + sourceStage.width + gap,
+              top : sourceStage.top
+          }, {
+              left: sourceStage.left - targetWidth - gap,
+              top : sourceStage.top
+          }, {
+              left: sourceStage.left,
+              top : sourceStage.top + sourceStage.height + gap
+          }, {
+              left: sourceStage.left,
+              top : sourceStage.top - targetHeight - gap
+          }],
+          point = candidates.find(candidate => candidate.left >= sourceStage.availLeft
+              && candidate.top >= sourceStage.availTop
+              && candidate.left + targetWidth <= sourceStage.availLeft + sourceStage.availWidth
+              && candidate.top + targetHeight <= sourceStage.availTop + sourceStage.availHeight);
+
+    if (!point) {
+        throw new Error('the headed screen cannot place the target popup outside the source window')
+    }
+
+    const requested = {
+        height: targetHeight,
+        ...point,
+        width : targetWidth
+    };
 
     await popupCdp.send('Browser.setWindowBounds', {
         bounds: {
-            height     : popupWindow.bounds.height,
-            left       : sourceStage.left + sourceStage.width + 40,
-            top        : sourceStage.top,
-            width      : popupWindow.bounds.width,
+            ...requested,
             windowState: 'normal'
         },
         windowId: popupWindow.windowId
+    });
+
+    await expect.poll(async () => {
+        const observed = await readRect(popup);
+
+        return Math.max(Math.abs(observed.x - requested.left), Math.abs(observed.y - requested.top))
+    }, {
+        message  : 'the CDP adapter must move the real target window before publishing geometry',
+        timeout  : 5000,
+        intervals: [25, 50, 100]
+    }).toBeLessThanOrEqual(80);
+
+    await expect.poll(async () => {
+        const [source, target] = await Promise.all([readRect(page), readRect(popup)]);
+
+        return source.x < target.x + target.width && source.x + source.width > target.x
+            && source.y < target.y + target.height && source.y + source.height > target.y
+    }, {
+        message  : 'the CDP adapter must leave two physically non-overlapping top-level windows',
+        timeout  : 5000,
+        intervals: [25, 50, 100]
+    }).toBe(false);
+
+    // CDP does not guarantee the page's native resize/movement events in this automation profile.
+    // Publish the observed target-realm snapshot so the product readiness gate still consumes its
+    // ordinary manager.Window authority rather than test-owned requested coordinates.
+    await publishObservedGeometry(popup, 'the target popup must install its geometry publisher')
+}
+
+/**
+ * @summary Moves one real popup to an observed screen-space origin and republishes its target-
+ * realm geometry. This is automation plumbing only; it never writes requested coordinates into
+ * Neo's manager truth.
+ * @param {import('@playwright/test').Page} popup
+ * @param {{x:Number, y:Number}} origin
+ * @param {String} message
+ */
+async function placePopupAtObservedOrigin(popup, origin, message) {
+    const popupCdp    = await popup.context().newCDPSession(popup),
+          popupWindow = await popupCdp.send('Browser.getWindowForTarget'),
+          requested   = {
+              height: popupWindow.bounds.height,
+              left  : origin.x,
+              top   : origin.y,
+              width : popupWindow.bounds.width
+          };
+
+    await popupCdp.send('Browser.setWindowBounds', {
+        bounds  : {...requested, windowState: 'normal'},
+        windowId: popupWindow.windowId
+    });
+
+    await expect.poll(async () => {
+        const observed = await popup.evaluate(() => ({x: globalThis.screenX, y: globalThis.screenY}));
+
+        return Math.max(Math.abs(observed.x - requested.left), Math.abs(observed.y - requested.top))
+    }, {
+        message,
+        timeout  : 5000,
+        intervals: [25, 50, 100]
+    }).toBeLessThanOrEqual(80);
+
+    await publishObservedGeometry(popup, 'the moving vessel must install its geometry publisher')
+}
+
+/**
+ * @summary Headed-Chrome adapter for the moving tear-out vessel. Automation can deny the
+ * product's pointer-follow `window.moveTo()` even though it allowed the popup acquisition. Move
+ * the real top-level window to the observed target origin, then publish only the observed target-
+ * realm geometry; Neo's conversion and exact-handle park gates remain the decision authority.
+ * @param {import('@playwright/test').Page} target
+ * @param {import('@playwright/test').Page} vessel
+ */
+async function placeMovingVesselAtTarget(target, vessel) {
+    const targetOrigin = await target.evaluate(() => ({x: globalThis.screenX, y: globalThis.screenY}));
+
+    await placePopupAtObservedOrigin(
+        vessel,
+        targetOrigin,
+        'the CDP adapter must place the real moving vessel over the observed target'
+    )
+}
+
+/**
+ * @summary Finds the one browser-owned tear-out child after its staged same-origin navigation.
+ * @param {import('@playwright/test').Page[]} pages
+ * @returns {Promise<import('@playwright/test').Page>}
+ */
+async function waitForTearOutPopup(pages) {
+    let popup;
+
+    await expect.poll(() => {
+        popup = pages.find(child => {
+            try {
+                return new URL(child.url()).searchParams.get('popout') === 'workbench'
+            } catch {
+                return false
+            }
+        });
+
+        return Boolean(popup)
+    }, {
+        message  : 'the exact tear-out Page must navigate and remain live during conversion',
+        timeout  : 5000,
+        intervals: [25, 50, 100]
+    }).toBe(true);
+
+    return popup
+}
+
+/**
+ * @summary Gives the headed physical-window adapter a bounded observation window without changing
+ * the production movement contract.
+ * @param {import('@playwright/test').Page} page
+ */
+async function widenAutomationWindowMoveObservation(page) {
+    await page.evaluate(() => {
+        globalThis.Neo.Main.windowMovePollAttempts = 40;
+        globalThis.Neo.Main.windowMovePollDelay    = 25
     })
 }
 
@@ -40,8 +230,8 @@ async function placePopupOutsideSource(page, popup) {
  * drop zero times, both worker-owned documents changed, and the same CounterPane instance mounted
  * into the second browser document without resetting its heartbeat.
  *
- * Run: NEO_E2E_PORT=8120 npx playwright test agentos/DemoBCrossWindowDragNL \
- *   -c test/playwright/playwright.config.e2e.mjs --workers=1
+ * Headed matrix run: NEO_E2E_PORT=8120 npx playwright test agentos/DemoBCrossWindowDragNL \
+ *   -c test/playwright/playwright.config.matrix.mjs --workers=1
  */
 test.describe('AgentOS Demo B — real cross-window dock drag', () => {
     test.setTimeout(120000);
@@ -56,7 +246,10 @@ test.describe('AgentOS Demo B — real cross-window dock drag', () => {
     test('the cold gesture transfers Workbench once and preserves its live worker instance', async ({page, neuralLink}) => {
         const pageErrors    = [],
               popupErrors   = [],
+              popupPages    = [],
               runtimeErrors = [];
+
+        page.context().on('page', child => popupPages.push(child));
 
         await page.context().exposeFunction('__recordDemoBCrossWindowError', payload => runtimeErrors.push(payload));
         await page.context().addInitScript(() => {
@@ -85,6 +278,7 @@ test.describe('AgentOS Demo B — real cross-window dock drag', () => {
 
         await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
         await page.waitForSelector('.agentos-dockdemo-counter-pane', {timeout: 30000});
+        await widenAutomationWindowMoveObservation(page);
 
         const app        = await neuralLink.connectToApp('AgentOSDockDemo'),
               workspaces = await app.findInstances(
@@ -133,6 +327,10 @@ test.describe('AgentOS Demo B — real cross-window dock drag', () => {
         // non-overlapping rectangles; no dock semantics or gesture events ride this adapter.
         await placePopupOutsideSource(page, popup);
 
+        const tearOutPopup = await waitForTearOutPopup(popupPages);
+
+        await placeMovingVesselAtTarget(popup, tearOutPopup);
+
         popup.on('pageerror', error => {
             let value = String(error?.stack || error?.message || error || '');
 
@@ -142,17 +340,22 @@ test.describe('AgentOS Demo B — real cross-window dock drag', () => {
         const result         = await resultPromise,
               phaseZeroTrace = await app.getDragTrace();
 
-        expect(result.errors, 'the real gesture must settle through the remote target').toEqual([]);
+        expect(result.errors,
+            `the real gesture must settle through the remote target: ${JSON.stringify(result.debug ?? null)}`
+            + `\ndrag trace: ${JSON.stringify(phaseZeroTrace)}`)
+            .toEqual([]);
         expect(result.applied).toBe(true);
         expect(result.witness.instanceId, 'the transferred pane is the original live instance').toBe(baseline.id);
         expect(result.proof).toMatchObject({
             framesNotReset           : true,
             localDropFires           : 0,
-            mountDelta               : 1,
+            mountDelta               : 2,
             remoteDropOutFires       : 1,
             sameInstance             : true,
             sourceSuppressionConsumed: true,
-            transferCommits          : 1
+            targetMountDelta         : 1,
+            transferCommits          : 1,
+            vesselMountDelta         : 1
         });
         expect(result.proof.remoteSnapshot).toMatchObject({
             engaged     : true,
@@ -216,7 +419,7 @@ test.describe('AgentOS Demo B — real cross-window dock drag', () => {
             transferCommits   : 1
         });
         expect(counter.id).toBe(baseline.id);
-        expect(counter.properties.mountCount).toBe(baseline.properties.mountCount + 1);
+        expect(counter.properties.mountCount).toBe(baseline.properties.mountCount + 2);
         expect(counter.properties.mounted).toBe(true);
         expect(counter.properties.windowId).not.toBe(baseline.properties.windowId);
 
@@ -248,10 +451,259 @@ test.describe('AgentOS Demo B — real cross-window dock drag', () => {
         expect(pageErrors).toEqual([])
     });
 
+    test('one gesture parks, re-shows, and detaches the same vessel without popup re-acquisition', async ({page, neuralLink}) => {
+        const pageErrors      = [],
+              popupPages      = [],
+              windowOpenCalls = [];
+
+        await page.context().exposeFunction('__recordDemoBWindowOpen', data => windowOpenCalls.push(data));
+        await page.context().addInitScript(() => {
+            const nativeOpen = globalThis.open;
+
+            globalThis.open = function(url, target, features) {
+                globalThis.__recordDemoBWindowOpen({
+                    features: String(features ?? ''),
+                    target  : String(target ?? ''),
+                    url     : String(url ?? '')
+                });
+
+                return nativeOpen.call(this, url, target, features)
+            }
+        });
+
+        page.context().on('page', child => {
+            popupPages.push(child);
+            child.on('pageerror', error => {
+                let value = String(error?.stack || error?.message || error || '');
+
+                value && value !== 'undefined' && pageErrors.push(value)
+            })
+        });
+        page.on('pageerror', error => {
+            let value = String(error?.stack || error?.message || error || '');
+
+            value && value !== 'undefined' && pageErrors.push(value)
+        });
+
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
+        await page.waitForSelector('.agentos-dockdemo-counter-pane', {timeout: 30000});
+        await widenAutomationWindowMoveObservation(page);
+
+        const app        = await neuralLink.connectToApp('AgentOSDockDemo'),
+              workspaces = await app.findInstances(
+                  {className: 'AgentOS.childapps.dockdemo.view.DemoBWorkspace'},
+                  ['id']
+              ),
+              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id,
+              counters   = await app.findInstances(
+                  {className: 'AgentOS.childapps.dockdemo.view.CounterPane'},
+                  ['id', 'mountCount', 'windowId']
+              ),
+              counterList = Array.isArray(counters) ? counters : counters ? [counters] : [],
+              baseline   = counterList[0],
+              before     = await app.getComponent(wsId, ['dockModel', 'popupDocument', 'tearOutAcquisitionAttempts']);
+
+        expect(wsId).toBeTruthy();
+        expect(counterList, 'exactly one live CounterPane exists before the gesture').toHaveLength(1);
+        expect(before.tearOutAcquisitionAttempts).toBe(0);
+
+        const targetPromise = page.waitForEvent('popup', {timeout: 30000}),
+              resultPromise = app.callMethod(wsId, 'executeCrossWindowStep', [{
+                  itemId           : 'workbench',
+                  sourceWorkspaceId: 'demo-b-main',
+                  targetNodeId     : 'popup-tabs',
+                  targetWorkspaceId: 'demo-b-popup'
+              }, {parkObservationMs: 1800, roundTrip: true}]),
+              targetPopup = await targetPromise;
+
+        await placePopupOutsideSource(page, targetPopup);
+
+        let tearOutPopup;
+
+        try {
+            tearOutPopup = await waitForTearOutPopup(popupPages)
+        } catch (error) {
+            const result = await resultPromise;
+
+            throw new Error(`${error.message}\nround-trip result: ${JSON.stringify(result)}`)
+        }
+
+        await placeMovingVesselAtTarget(targetPopup, tearOutPopup);
+
+        let parkReceipt;
+
+        try {
+            await expect.poll(async () => {
+                parkReceipt = (await app.getComponent(wsId, ['lastVesselParkReceipt'])).lastVesselParkReceipt;
+                return parkReceipt?.parked === true
+            }, {
+                message  : 'the product must publish strict park admission before the observation window ends',
+                timeout  : 1500,
+                intervals: [25, 50]
+            }).toBe(true)
+        } catch (error) {
+            const result = await resultPromise;
+
+            throw new Error(`${error.message}\npark receipt: ${JSON.stringify(parkReceipt)}`
+                + `\nround-trip result: ${JSON.stringify(result)}`)
+        }
+
+        await expect(tearOutPopup.locator('.agentos-dockdemo-counter-pane'),
+            'the moving tear-out vessel must render its real live pane before any terminal commit')
+            .toBeVisible({timeout: 5000});
+
+        let sourceParkState;
+
+        await expect.poll(async () => {
+            sourceParkState = await tearOutPopup.evaluate(() => ({
+                focused: document.hasFocus(),
+                x      : globalThis.screenX,
+                y      : globalThis.screenY
+            }));
+
+            return Math.max(
+                Math.abs(sourceParkState.x - parkReceipt.requested.x),
+                Math.abs(sourceParkState.y - parkReceipt.requested.y)
+            )
+        }, {
+            message  : 'the tear-out renderer must observe the admitted physical park position',
+            timeout  : 1000,
+            intervals: [25, 50]
+        }).toBeLessThanOrEqual(2);
+
+        const targetParkState = await targetPopup.evaluate(() => ({
+            focused: document.hasFocus(),
+            x      : globalThis.screenX,
+            y      : globalThis.screenY
+        }));
+
+        expect(targetParkState.focused, 'moving the source must not raise it above the focused cover target').toBe(true);
+        // Chrome automation can report document.hasFocus() true in multiple top-level pages at
+        // once. The post-move TARGET receipt is the exclusive admission oracle; requiring the
+        // source to report false would encode a browser-harness quirk as product semantics.
+        expect(parkReceipt.refocused).toBe(true);
+
+        let restoreReceipt;
+
+        await expect.poll(async () => {
+            restoreReceipt = (await app.getComponent(wsId, ['lastVesselRestoreReceipt'])).lastVesselRestoreReceipt;
+            return Boolean(restoreReceipt?.requested)
+        }, {
+            message  : 'out-conversion must publish its exact restore request',
+            timeout  : 3000,
+            intervals: [10, 25, 50]
+        }).toBe(true);
+
+        await placePopupAtObservedOrigin(
+            tearOutPopup,
+            restoreReceipt.requested,
+            'the CDP adapter must let the real vessel reach Neo\'s exact restore request'
+        );
+
+        const result = await resultPromise;
+
+        expect(result.errors,
+            `the full conversion round-trip must settle detached: ${JSON.stringify(result.debug ?? null)}`)
+            .toEqual([]);
+        expect(result.applied).toBe(true);
+        expect(result.witness.instanceId).toBe(baseline.id);
+        expect(result.proof).toMatchObject({
+            acquisitionAttempts: {
+                afterRestore            : 1,
+                atFirstPark             : 1,
+                beforeGesture           : 0,
+                midGestureReacquisitions: 0,
+                totalGestureAttempts    : 1
+            },
+            detached: {
+                catalogRetained: true,
+                itemAbsent     : true
+            },
+            parkSlotCleared : true,
+            restored        : true,
+            sameNativeHandle: true,
+            sameWindowId    : true,
+            stats           : {
+                localDropFires    : 0,
+                remoteDropOutFires: 0,
+                transferCommits   : 0
+            }
+        });
+        expect(result.proof.firstRemoteSnapshot).toMatchObject({engaged: true, ready: true});
+        expect(result.proof.outSnapshot).toMatchObject({engaged: false, ready: false});
+        expect(result.proof.detached.entry.windowId).toBe(result.proof.firstIdentity.windowId);
+        expect(result.proof.terminalIdentity).toEqual(result.proof.firstIdentity);
+        expect(result.proof.parkReceipt).toEqual(parkReceipt);
+
+        // Same-origin acquisition now opens about:blank before minting its route and navigating.
+        // The browser-owned target name, not the staged URL, joins the surviving Page back to its
+        // actual window.open call without consulting the product's acquisition counter.
+        const tearOutTargetName = await tearOutPopup.evaluate(() => globalThis.name),
+              tearOutOpenCalls  = windowOpenCalls.filter(call => call.target === tearOutTargetName);
+
+        expect(tearOutOpenCalls, 'browser-realm instrumentation observes zero mid-gesture reacquisition')
+            .toHaveLength(1);
+
+        await expect.poll(() => page.context().pages().filter(child => {
+            try {
+                return new URL(child.url()).searchParams.get('popout') === 'workbench'
+            } catch {
+                return false
+            }
+        }).length, {
+            message  : 'exactly one tear-out Page survives as the detached terminal owner',
+            timeout  : 10000,
+            intervals: [100]
+        }).toBe(1);
+
+        const survivingTearOut = page.context().pages().filter(child => {
+                  try {
+                      return new URL(child.url()).searchParams.get('popout') === 'workbench'
+                  } catch {
+                      return false
+                  }
+              })[0],
+              after = await app.getComponent(wsId, [
+                  'crossWindowStats', 'dockModel', 'popupDocument', 'tearOutAcquisitionAttempts', 'tearOutPanes'
+              ]),
+              finalCounters = await app.findInstances(
+                  {className: 'AgentOS.childapps.dockdemo.view.CounterPane'},
+                  ['id', 'mountCount', 'windowId']
+              ),
+              finalCounterList = Array.isArray(finalCounters) ? finalCounters : finalCounters ? [finalCounters] : [],
+              finalCounter = finalCounterList[0],
+              restoredPhysical = await survivingTearOut.evaluate(() => ({
+                  x: globalThis.screenX,
+                  y: globalThis.screenY
+              }));
+
+        expect(survivingTearOut, 're-show and terminal retain the acquisition-time Page object').toBe(tearOutPopup);
+        expect(finalCounterList, 'the round-trip never duplicates the live CounterPane').toHaveLength(1);
+        await expect(survivingTearOut.locator('.agentos-dockdemo-counter-pane')).toBeVisible({timeout: 10000});
+        expect(Math.abs(restoredPhysical.x - result.proof.restoreReceipt.requested.x)).toBeLessThanOrEqual(2);
+        expect(Math.abs(restoredPhysical.y - result.proof.restoreReceipt.requested.y)).toBeLessThanOrEqual(2);
+        expect(after.tearOutAcquisitionAttempts).toBe(1);
+        expect(after.popupDocument).toEqual(before.popupDocument);
+        expect(after.dockModel.items.workbench).toEqual(before.dockModel.items.workbench);
+        expect(Object.values(after.dockModel.nodes).some(node => node.items?.includes('workbench'))).toBe(false);
+        expect(after.tearOutPanes.workbench.windowId).toBe(result.proof.firstIdentity.windowId);
+        expect(after.crossWindowStats).toEqual(result.proof.stats);
+        expect(finalCounter.id).toBe(baseline.id);
+        expect(finalCounter.properties.mountCount).toBe(baseline.properties.mountCount + 1);
+        expect(finalCounter.properties.windowId).toBe(result.proof.firstIdentity.windowId);
+        expect(pageErrors).toEqual([]);
+
+        await survivingTearOut.close();
+        await targetPopup.close()
+    });
+
     test('Escape after remote preview clears every gesture surface and mutates neither document', async ({page, neuralLink}) => {
         const pageErrors    = [],
               popupErrors   = [],
+              popupPages    = [],
               runtimeErrors = [];
+
+        page.context().on('page', child => popupPages.push(child));
 
         await page.context().exposeFunction('__recordDemoBCrossWindowCancelError', payload => runtimeErrors.push(payload));
         await page.context().addInitScript(() => {
@@ -280,6 +732,7 @@ test.describe('AgentOS Demo B — real cross-window dock drag', () => {
 
         await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
         await page.waitForSelector('.agentos-dockdemo-counter-pane', {timeout: 30000});
+        await widenAutomationWindowMoveObservation(page);
 
         const app        = await neuralLink.connectToApp('AgentOSDockDemo'),
               workspaces = await app.findInstances(
@@ -313,6 +766,10 @@ test.describe('AgentOS Demo B — real cross-window dock drag', () => {
         });
 
         await placePopupOutsideSource(page, popup);
+
+        const tearOutPopup = await waitForTearOutPopup(popupPages);
+
+        await placeMovingVesselAtTarget(popup, tearOutPopup);
 
         const result        = await resultPromise,
               after         = await app.getComponent(wsId, ['crossWindowStats', 'dockModel', 'popupDocument']),
@@ -359,7 +816,7 @@ test.describe('AgentOS Demo B — real cross-window dock drag', () => {
         expect(after.popupDocument).toEqual(before.popupDocument);
         expect(after.crossWindowStats).toEqual(result.proof.stats);
         expect(finalCounter.id).toBe(baseline.id);
-        expect(finalCounter.properties.mountCount).toBe(baseline.properties.mountCount);
+        expect(finalCounter.properties.mountCount).toBe(baseline.properties.mountCount + 2);
         expect(finalCounter.properties.windowId).toBe(baseline.properties.windowId);
         expect(trace?.events.at(-1)?.t).toBe('cancel');
         expect(runtimeErrors).toEqual([]);

--- a/test/playwright/e2e/agentos/DemoBVesselConversionNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBVesselConversionNL.spec.mjs
@@ -116,10 +116,11 @@ function sampleMetric(source, target) {
 /**
  * @summary Headed calibration witness for dual-window conversion composition.
  *
- * Demo B keeps physical park/re-show disabled until that lifecycle is ready, but this row explicitly
- * opts the source policy in after both vessels exist. It proves exact target/vessel identities, live post-resize
- * browser-to-worker geometry, reachability for each asymmetric size pair, a physical diagonal that
- * distinguishes `min(rx, ry)` from `rx * ry`, and the .55/.35 dead band over a slow physical crossing.
+ * Demo B composes strict physical park/re-show. This row proves exact target/vessel identities, live
+ * post-resize browser-to-worker geometry, reachability for each asymmetric size pair, a physical
+ * diagonal that distinguishes `min(rx, ry)` from `rx * ry`, and the .55/.35 dead band over a slow
+ * crossing. Before park, worker truth comes from the exact live vessel; while parked, the source
+ * binding deliberately switches to logical pointer position with the last exact physical extents.
  *
  * Run: NEO_E2E_PORT=8120 npx playwright test agentos/DemoBVesselConversionNL \
  *   -c test/playwright/playwright.config.matrix.mjs --workers=1
@@ -153,7 +154,7 @@ test.describe('AgentOS Demo B — vessel-conversion geometry readiness', () => {
               windowManager = await findOne(app, {className: 'Neo.manager.Window'}, ['id']);
 
         expect(sourceZone.properties).toMatchObject({
-            enableVesselConversion          : false,
+            enableVesselConversion          : true,
             vesselConversionConvertThreshold: .55,
             vesselConversionRevertThreshold : .35,
             vesselConversionSensor          : null,
@@ -164,7 +165,10 @@ test.describe('AgentOS Demo B — vessel-conversion geometry readiness', () => {
               targetStageWait           = app.callMethod(wsId, 'openCrossWindowStage'),
               [targetPage, targetStage] = await Promise.all([targetPopupWait, targetStageWait]);
 
-        await targetPage.waitForLoadState('domcontentloaded');
+        await targetPage.waitForURL(url => url.searchParams.get('workspaceId') === 'demo-b-popup', {
+            timeout  : 30000,
+            waitUntil: 'domcontentloaded'
+        });
 
         const vesselPopupWait = page.waitForEvent('popup', {timeout: 30000}),
               vesselOpenWait  = app.callMethod(wsId, 'openTearOutVessel', [{
@@ -173,7 +177,10 @@ test.describe('AgentOS Demo B — vessel-conversion geometry readiness', () => {
               }]),
               [vesselPage, vesselConfig] = await Promise.all([vesselPopupWait, vesselOpenWait]);
 
-        await vesselPage.waitForLoadState('domcontentloaded');
+        await vesselPage.waitForURL(url => url.searchParams.get('popout') === 'workbench', {
+            timeout  : 30000,
+            waitUntil: 'domcontentloaded'
+        });
 
         expect(targetPage.url()).toContain('workspaceId=demo-b-popup');
         expect(vesselPage.url()).toContain('popout=workbench');
@@ -268,7 +275,11 @@ test.describe('AgentOS Demo B — vessel-conversion geometry readiness', () => {
         expect(Math.abs(diagonal.min - diagonal.product), 'headed sample distinguishes min from product')
             .toBeGreaterThan(.08);
 
-        await app.setProperties(sourceZone.id, {enableVesselConversion: true, isWindowDragging: true});
+        await app.callMethod(sourceZone.id, 'startWindowDrag', [{
+            popupHeight: source.observed.height,
+            popupWidth : source.observed.width,
+            windowName : 'tearout-workbench'
+        }]);
 
         const requestedRatios = [.2, .5, .58, .5, .38, .32],
               expectedStates  = [false, false, true, true, true, false],
@@ -278,40 +289,66 @@ test.describe('AgentOS Demo B — vessel-conversion geometry readiness', () => {
             target = await awaitParity(app, windowManager.id, targetPage, ids.target);
             source = await awaitParity(app, windowManager.id, vesselPage, ids.source);
 
-            const {bounds: sourceBounds} = await sourceHandle.cdp.send('Browser.getWindowBounds', {
+            const beforeState            = await app.callMethod(sourceZone.id, 'getVesselConversionState'),
+                  {bounds: sourceBounds} = await sourceHandle.cdp.send('Browser.getWindowBounds', {
                       windowId: sourceHandle.windowId
                   }),
                   desiredX = target.observed.x + target.observed.width
                       - requestedRatio * Math.min(source.observed.width, target.observed.width),
                   desiredY = target.observed.y;
 
-            await setBounds(sourceHandle, {
-                ...sourceBounds,
-                left: Math.round(sourceBounds.left + desiredX - source.observed.x),
-                top : Math.round(sourceBounds.top  + desiredY - source.observed.y)
-            });
+            if (!beforeState.converted && !beforeState.transitioning) {
+                await setBounds(sourceHandle, {
+                    ...sourceBounds,
+                    left: Math.round(sourceBounds.left + desiredX - source.observed.x),
+                    top : Math.round(sourceBounds.top  + desiredY - source.observed.y)
+                });
 
-            source = await awaitParity(app, windowManager.id, vesselPage, ids.source);
+                source = await awaitParity(app, windowManager.id, vesselPage, ids.source)
+            }
 
-            const logicalSourceRect = {height: 20, width: 40, x: -9000, y: -9000},
-                  decision          = await app.callMethod(sourceZone.id, 'resolveRemoteDragTransition', [{
+            const logicalSourceRect = {height: 20, width: 40, x: desiredX, y: desiredY},
+                  frame             = {
                       draggedItem    : {dockItemId: 'workbench', id: 'calibration-probe'},
                       logicalSourceRect,
                       pointerInTarget: true,
                       targetId       : 'demo-b-popup',
                       targetRect     : target.observed
-                  }]),
-                  binding = await app.getComponent(sourceZone.id, [
+                  };
+
+            await app.callMethod(sourceZone.id, 'resolveRemoteDragTransition', [frame]);
+
+            await expect.poll(async () => {
+                const state = await app.callMethod(sourceZone.id, 'getVesselConversionState');
+
+                return state.transitioning
+            }, {
+                message  : `ratio ${requestedRatio} strict platform transition must settle`,
+                timeout  : 5000,
+                intervals: [25, 50, 100]
+            }).toBe(false);
+
+            const decision = await app.callMethod(sourceZone.id, 'resolveRemoteDragTransition', [frame]),
+                  binding  = await app.getComponent(sourceZone.id, [
                       'vesselConversionLogicalRect',
                       'vesselConversionSourceRect'
                   ]),
-                  metric = sampleMetric(source.observed, target.observed);
+                  park     = await app.getComponent(wsId, ['lastVesselParkReceipt']),
+                  metric = sampleMetric(binding.vesselConversionSourceRect, target.observed),
+                  expectedSourceRect = beforeState.converted
+                      ? {
+                          height: source.observed.height,
+                          width : source.observed.width,
+                          x     : logicalSourceRect.x,
+                          y     : logicalSourceRect.y
+                      }
+                      : source.observed;
 
             expect(binding.vesselConversionSourceRect,
-                'the owner resolver must supply the exact live vessel, not the fake logical proxy')
-                .toEqual(source.observed);
+                'pre-park uses exact live geometry; parked frames preserve exact extents at logical origin')
+                .toEqual(expectedSourceRect);
             expect(binding.vesselConversionLogicalRect).toEqual(logicalSourceRect);
-            calibration.push({decision, metric, requestedRatio, source: source.observed})
+            calibration.push({beforeState, decision, metric, park: park.lastVesselParkReceipt, requestedRatio, source: expectedSourceRect})
         }
 
         expect(calibration.map(({decision}) => decision.commitEligible)).toEqual(expectedStates);
@@ -334,7 +371,7 @@ test.describe('AgentOS Demo B — vessel-conversion geometry readiness', () => {
             .toEqual({commitEligible: false, engage: false, retain: false});
 
         await app.callMethod(sourceZone.id, 'resetVesselConversion');
-        await app.setProperties(sourceZone.id, {enableVesselConversion: false, isWindowDragging: false});
+        await app.callMethod(sourceZone.id, 'endWindowDrag');
 
         console.log('VESSEL-CONVERSION-CALIBRATION', JSON.stringify({calibration, diagonal, flips, receipts}))
     })

--- a/test/playwright/playwright.config.matrix.mjs
+++ b/test/playwright/playwright.config.matrix.mjs
@@ -39,7 +39,8 @@ export default defineConfig({
     testMatch: [
         '**/colors/tearOutMatrix.spec.mjs',
         '**/agentos/TearOutMatrixRows4To7NL.spec.mjs',
-        '**/agentos/DemoBVesselConversionNL.spec.mjs'
+        '**/agentos/DemoBVesselConversionNL.spec.mjs',
+        '**/agentos/DemoBCrossWindowDragNL.spec.mjs'
     ],
     outputDir    : './test-results/matrix/artifacts',
     fullyParallel: false, // native window placement is a global resource — strictly serial

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
@@ -26,33 +26,94 @@ import {demoBTourScript, initialDocument} from '../../../../../../../apps/agento
  * @param {Object} [options={}]
  * @param {Error|null} [options.openError=null]
  * @param {Error|null} [options.closeError=null]
- * @returns {{openCount: Number, closeCount: Number, closeCalls: Object[], restore: Function}}
+ * @param {Boolean|Function} [options.nativeCloseResult=true]
+ * @param {Boolean|Function} [options.nativeFocusResult=true]
+ * @param {Boolean} [options.nativeMoveResult=true]
+ * @param {Boolean} [options.parkResult=true]
+ * @param {Boolean} [options.resumeResult=true]
+ * @returns {Object}
  */
-function installWindowVessel({openError = null, closeError = null} = {}) {
+function installWindowVessel({
+    openError=null,
+    closeError=null,
+    nativeCloseResult=true,
+    nativeFocusResult=true,
+    nativeMoveResult=true,
+    parkResult=true,
+    resumeResult=true
+} = {}) {
     let previous = {
-            getWindowData: Neo.Main.getWindowData,
-            windowClose  : Neo.Main.windowClose,
-            windowOpen   : Neo.Main.windowOpen
+            dragDrop          : Neo.main.addon.DragDrop,
+            getWindowData     : Neo.Main.getWindowData,
+            windowClose       : Neo.Main.windowClose,
+            windowNativeClose : Neo.Main.windowNativeClose,
+            windowNativeFocus : Neo.Main.windowNativeFocus,
+            windowNativeMoveTo: Neo.Main.windowNativeMoveTo,
+            windowOpen        : Neo.Main.windowOpen
         },
-        state = {closeCalls: [], closeCount: 0, openCount: 0};
+        state = {
+            closeCalls: [], closeCount: 0, nativeCloseCalls: [], nativeMoveCalls: [],
+            events    : [], focusCalls: [], openCalls: [], openCount: 0, parkCalls: [], resumeCalls: []
+        };
 
     Neo.Main.getWindowData = async () => ({screenLeft: 10, screenTop: 20});
-    Neo.Main.windowOpen    = async () => {
+    Neo.Main.windowOpen    = async data => {
+        state.openCalls.push(data);
         state.openCount++;
-        if (openError) throw openError
+        if (openError) throw openError;
+        return true
     };
     Neo.Main.windowClose   = async data => {
         state.closeCalls.push(data);
         state.closeCount++;
         if (closeError) throw closeError
     };
+    Neo.Main.windowNativeClose = async data => {
+        state.nativeCloseCalls.push(data);
+        return typeof nativeCloseResult === 'function' ? nativeCloseResult(data) : nativeCloseResult
+    };
+    Neo.Main.windowNativeFocus = async data => {
+        state.focusCalls.push(data);
+        state.events.push('focus');
+        return typeof nativeFocusResult === 'function' ? nativeFocusResult(data) : nativeFocusResult
+    };
+    Neo.Main.windowNativeMoveTo = async data => {
+        state.nativeMoveCalls.push(data);
+        return nativeMoveResult
+    };
+    Neo.main.addon.DragDrop = {
+        parkWindowDrag: async data => {
+            state.parkCalls.push(data);
+            state.events.push('park');
+            return parkResult
+        },
+        resumeWindowDrag: async data => {
+            state.resumeCalls.push(data);
+            return resumeResult
+        }
+    };
 
     return {
         get closeCount() { return state.closeCount },
         get closeCalls() { return state.closeCalls },
-        get openCount()  { return state.openCount },
+        get events() { return state.events },
+        get focusCalls() { return state.focusCalls },
+        get nativeCloseCalls() { return state.nativeCloseCalls },
+        get nativeMoveCalls() { return state.nativeMoveCalls },
+        get openCalls() { return state.openCalls },
+        get openCount() { return state.openCount },
+        get parkCalls() { return state.parkCalls },
+        get resumeCalls() { return state.resumeCalls },
         restore() {
-            Object.assign(Neo.Main, previous)
+            Neo.main.addon.DragDrop = previous.dragDrop;
+            Object.assign(Neo.Main, {
+                getWindowData     : previous.getWindowData,
+                windowClose       : previous.windowClose,
+                windowNativeClose : previous.windowNativeClose,
+                windowNativeFocus : previous.windowNativeFocus,
+                windowNativeMoveTo: previous.windowNativeMoveTo,
+                windowOpen        : previous.windowOpen
+            })
         }
     }
 }
@@ -62,15 +123,17 @@ function installWindowVessel({openError = null, closeError = null} = {}) {
  * Each registered child carries the production-shaped native route minted by its opener;
  * URL parameters alone therefore never stand in for physical-window authority.
  * @param {Neo.component.Base} workspace
- * @returns {{addedTo: Function, connect: Function, restore: Function}}
+ * @returns {{addedTo: Function, connect: Function, register: Function, restore: Function}}
  */
 function installWindowConnectHarness(workspace) {
     let previous = {
             getByPath    : Neo.Main.getByPath,
             getWindowData: Neo.Main.getWindowData,
+            managerGet   : Neo.manager.Window.get,
             windowOpen   : Neo.Main.windowOpen
         },
-        windows = new Map();
+        managerRecords = new Map(),
+        windows        = new Map();
 
     Neo.Main.getByPath = async ({windowId}) => windows.get(windowId)?.url;
     Neo.Main.getWindowData = async () => ({
@@ -79,6 +142,7 @@ function installWindowConnectHarness(workspace) {
         screenLeft : 10,
         screenTop  : 20
     });
+    Neo.manager.Window.get = windowId => managerRecords.get(windowId) ?? previous.managerGet.call(Neo.manager.Window, windowId);
 
     return {
         addedTo(windowId) {
@@ -86,9 +150,20 @@ function installWindowConnectHarness(workspace) {
         },
 
         async connect(windowId, url) {
-            let added = [];
+            let added       = [],
+                nativeRoute = {
+                    capabilities   : {close: true, focus: true, position: true},
+                    nativeHandleKey: `handle-${windowId}`,
+                    ownerWindowId  : workspace.windowId,
+                    targetWindowId : windowId
+                };
 
             windows.set(windowId, {added, url: new URL(url, 'https://example.test').href});
+            managerRecords.set(windowId, {
+                innerRect: {height: 320, width: 480, x: 40, y: 60},
+                outerRect: {height: 360, width: 480, x: 40, y: 60},
+                nativeRoute
+            });
             Neo.apps[windowId] = {
                 mainView: {
                     add: pane => added.push(pane)
@@ -97,18 +172,35 @@ function installWindowConnectHarness(workspace) {
 
             await workspace.onWindowConnect({
                 windowData: {
-                    nativeRoute: {
-                        nativeHandleKey: `handle-${windowId}`,
-                        ownerWindowId  : workspace.windowId,
-                        targetWindowId : windowId
-                    }
+                    nativeRoute
                 },
                 windowId
             })
         },
 
+        register(windowId, {
+            innerRect={height: 520, width: 600, x: 874, y: 55},
+            outerRect={height: 560, width: 600, x: 874, y: 55}
+        } = {}) {
+            managerRecords.set(windowId, {
+                innerRect,
+                outerRect,
+                nativeRoute: {
+                    capabilities   : {close: true, focus: true, position: true},
+                    nativeHandleKey: `handle-${windowId}`,
+                    ownerWindowId  : workspace.windowId,
+                    targetWindowId : windowId
+                }
+            })
+        },
+
         restore() {
-            Object.assign(Neo.Main, previous);
+            Object.assign(Neo.Main, {
+                getByPath    : previous.getByPath,
+                getWindowData: previous.getWindowData,
+                windowOpen   : previous.windowOpen
+            });
+            Neo.manager.Window.get = previous.managerGet;
             windows.forEach((value, windowId) => delete Neo.apps[windowId])
         }
     }
@@ -335,12 +427,15 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
     });
 
     test('tear-out connect-before-terminal consumes its grant and a replay stays inert', async () => {
-        const harness = installWindowConnectHarness(workspace),
-              pane    = workspace.resolvePane('timeline', initialDocument.items.timeline);
-        let tearOutUrl;
+        const harness      = installWindowConnectHarness(workspace),
+              pane         = workspace.resolvePane('timeline', initialDocument.items.timeline),
+              sourceParent = pane.parent,
+              sourceIndex  = sourceParent.items.indexOf(pane),
+              before       = JSON.stringify(workspace.getDockZoneDocument());
+        let tearOutOpen;
 
         Neo.Main.windowOpen = async data => {
-            tearOutUrl = data.url;
+            tearOutOpen = data;
             return true
         };
 
@@ -349,24 +444,407 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
                 itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}
             })).toMatchObject({windowName: 'tearout-timeline'});
 
-            const params = new URL(tearOutUrl, 'https://example.test').searchParams;
+            const tearOutUrl = tearOutOpen.url;
+            const params     = new URL(tearOutUrl, 'https://example.test').searchParams;
 
+            expect(tearOutOpen.nativeCapabilities).toEqual({close: true, position: true});
             expect(params.get('vesselFlow')).toBe('tear-out');
             expect(params.get('vesselGrant')).toBeTruthy();
             expect(params.get('vesselGeneration')).toBeTruthy();
 
             await harness.connect('tear-child', tearOutUrl);
             expect(workspace.tearOutConnects.timeline).toEqual({windowId: 'tear-child'});
+            expect(harness.addedTo('tear-child'), 'the admitted moving vessel renders the live pane pre-terminal')
+                .toEqual([pane]);
+            expect(JSON.stringify(workspace.getDockZoneDocument()), 'render embodiment mutates no document truth')
+                .toBe(before);
+            expect(sourceParent.items, 'the hidden stand-in keeps card/header indices stable')
+                .toHaveLength(3);
+            expect(sourceParent.items[sourceIndex].cls).toContain('neo-dashboard-dock-vessel-placeholder');
 
             workspace.adoptTearOutPane('timeline');
-            expect(harness.addedTo('tear-child')).toEqual([pane]);
+            expect(harness.addedTo('tear-child'), 'terminal promotion never reparents twice').toEqual([pane]);
             expect(workspace.tearOutPanes.timeline.windowId).toBe('tear-child');
+            expect(workspace.tearOutConnects.timeline, 'committed ownership has only one lifecycle map').toBeUndefined();
 
             await harness.connect('tear-replay', tearOutUrl);
             expect(harness.addedTo('tear-replay')).toEqual([]);
             expect(workspace.tearOutPanes.timeline.windowId).toBe('tear-child')
         } finally {
             harness.restore()
+        }
+    });
+
+    test('a refused close during pane stage retains the exact route but never publishes the generation', async () => {
+        let admitClose = false;
+
+        const vessel   = installWindowVessel({nativeCloseResult: () => admitClose}),
+              harness  = installWindowConnectHarness(workspace),
+              stage    = workspace.tearOutEmbodiment.stage,
+              restore  = workspace.tearOutEmbodiment.restore,
+              restored = [];
+
+        let resolveStage,
+            stageEnteredResolve;
+
+        const stageEntered = new Promise(resolve => stageEnteredResolve = resolve),
+              stageResult  = new Promise(resolve => resolveStage = resolve),
+              sortZone     = {endWindowDrag() {}, startWindowDrag() {}};
+
+        workspace.tearOutEmbodiment.stage = data => {
+            stageEnteredResolve(data);
+            return stageResult
+        };
+        workspace.tearOutEmbodiment.restore = data => {
+            restored.push(data);
+            return true
+        };
+
+        try {
+            await workspace.tearOutHandlers.onDockTearOutExit({
+                itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}, sortZone
+            });
+
+            const open           = vessel.openCalls.at(-1),
+                  params         = new URL(open.url, 'https://example.test').searchParams,
+                  admissionToken = Number(params.get('vesselAdmission')),
+                  generation     = Number(params.get('vesselGeneration')),
+                  connecting     = harness.connect('tear-stage-race', open.url);
+
+            await expect(stageEntered).resolves.toEqual({itemId: 'timeline', windowId: 'tear-stage-race'});
+            expect(workspace.tearOutConnectAdmissions.get('timeline')).toEqual({
+                admissionToken, generation, invalidated: false, windowId: 'tear-stage-race'
+            });
+
+            await expect(workspace.tearOutHandlers.onDockTearOutCancel({itemId: 'timeline', sortZone})).resolves.toBe(false);
+
+            expect(workspace.tearOutConnectAdmissions.get('timeline')).toEqual({
+                admissionToken, generation, invalidated: true, windowId: 'tear-stage-race'
+            });
+            expect(workspace.tearOutRetirements.has('timeline')).toBe(true);
+            expect(workspace.tearOutHandlers.activeVessel).toEqual({
+                itemId: 'timeline', windowName: 'tearout-timeline'
+            });
+
+            resolveStage(true);
+            await connecting;
+
+            expect(restored).toEqual([{itemId: 'timeline', windowId: 'tear-stage-race'}]);
+            expect(workspace.tearOutConnects.timeline, 'the dead generation never becomes route authority').toBeUndefined();
+            expect(workspace.tearOutPanes.timeline).toBeUndefined();
+
+            admitClose = true;
+
+            await expect(workspace.tearOutHandlers.onDockTearOutCancel({itemId: 'timeline', sortZone})).resolves.toBe(true);
+            expect(workspace.tearOutConnectAdmissions.has('timeline')).toBe(false);
+            expect(workspace.tearOutRetirements.has('timeline')).toBe(false);
+            expect(workspace.tearOutHandlers.activeVessel).toBeNull();
+            expect(vessel.nativeCloseCalls).toEqual([
+                {nativeHandleKey: 'handle-tear-stage-race', targetWindowId: 'tear-stage-race', windowId: workspace.windowId},
+                {nativeHandleKey: 'handle-tear-stage-race', targetWindowId: 'tear-stage-race', windowId: workspace.windowId}
+            ])
+        } finally {
+            workspace.tearOutEmbodiment.stage   = stage;
+            workspace.tearOutEmbodiment.restore = restore;
+            harness.restore();
+            vessel.restore()
+        }
+    });
+
+    test('a disconnect during staged committed ownership reintegrates instead of taking the pre-terminal branch', async () => {
+        const vessel   = installWindowVessel(),
+              harness  = installWindowConnectHarness(workspace),
+              stage    = workspace.tearOutEmbodiment.stage,
+              isStaged = workspace.tearOutEmbodiment.isStaged,
+              restore  = workspace.tearOutEmbodiment.restore,
+              restored = [],
+              sortZone = {endWindowDrag() {}, startWindowDrag() {}};
+
+        let resolveStage,
+            stageEnteredResolve,
+            staged = false;
+
+        const stageEntered = new Promise(resolve => stageEnteredResolve = resolve),
+              stageResult  = new Promise(resolve => resolveStage = resolve);
+
+        workspace.tearOutEmbodiment.stage = data => {
+            staged = true;
+            stageEnteredResolve(data);
+            return stageResult
+        };
+        workspace.tearOutEmbodiment.isStaged = () => staged;
+        workspace.tearOutEmbodiment.restore = data => {
+            restored.push(data);
+            staged = false;
+            return true
+        };
+
+        try {
+            await workspace.tearOutHandlers.onDockTearOutExit({
+                itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}, sortZone
+            });
+
+            const connecting = harness.connect('tear-stage-committed', vessel.openCalls.at(-1).url);
+
+            await expect(stageEntered).resolves.toEqual({itemId: 'timeline', windowId: 'tear-stage-committed'});
+            expect(workspace.tearOutHandlers.onDockTearOutTerminal({itemId: 'timeline', sortZone})).toBe(true);
+            expect(DockZoneModel.findContainingTabsId(workspace.getDockZoneDocument(), 'timeline')).toBeNull();
+            expect(workspace.tearOutPanes.timeline.windowId).toBeNull();
+
+            workspace.onWindowDisconnect({windowId: 'tear-stage-committed'});
+
+            expect(DockZoneModel.findContainingTabsId(workspace.getDockZoneDocument(), 'timeline'))
+                .toBe('side-tabs');
+            expect(workspace.tearOutPanes.timeline).toBeUndefined();
+            expect(workspace.tearOutConnectAdmissions.has('timeline')).toBe(false);
+            expect(restored).toEqual([{itemId: 'timeline', windowId: 'tear-stage-committed'}]);
+
+            resolveStage(false);
+            await connecting;
+
+            expect(workspace.tearOutConnects.timeline).toBeUndefined();
+            expect(workspace.tearOutPanes.timeline).toBeUndefined()
+        } finally {
+            workspace.tearOutEmbodiment.stage     = stage;
+            workspace.tearOutEmbodiment.isStaged = isStaged;
+            workspace.tearOutEmbodiment.restore   = restore;
+            harness.restore();
+            vessel.restore()
+        }
+    });
+
+    test('vessel conversion parks, restores, and retires only the exact manager-owned native route', async () => {
+        let admitClose = false;
+
+        const vessel       = installWindowVessel({nativeCloseResult: () => admitClose}),
+              harness      = installWindowConnectHarness(workspace),
+              pane         = workspace.resolvePane('timeline', initialDocument.items.timeline),
+              sourceParent = pane.parent,
+              sourceIndex  = sourceParent.items.indexOf(pane);
+
+        try {
+            await workspace.openTearOutVessel({
+                itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}
+            });
+            await harness.connect('tear-child', vessel.openCalls.at(-1).url);
+            harness.register('target-child');
+            workspace.crossWindowTargetWindowId = 'target-child';
+
+            expect(workspace.resolveVesselConversionSourceRect({itemId: 'timeline'})).toEqual({
+                height: 320, width: 480, x: 40, y: 60
+            });
+            await expect(workspace.parkTearOutVessel({
+                itemId: 'timeline', windowName: 'tearout-timeline'
+            })).resolves.toBe(true);
+            expect(vessel.events).toEqual(['focus', 'park', 'focus']);
+            expect(vessel.focusCalls).toEqual([{
+                nativeHandleKey: 'handle-target-child',
+                targetWindowId : 'target-child',
+                windowId       : workspace.windowId
+            }, {
+                nativeHandleKey: 'handle-target-child',
+                targetWindowId : 'target-child',
+                windowId       : workspace.windowId
+            }]);
+            expect(vessel.parkCalls).toEqual([{
+                nativeHandleKey: 'handle-tear-child',
+                targetWindowId : 'tear-child',
+                windowId       : workspace.windowId,
+                windowName     : 'tearout-timeline',
+                x              : 874,
+                y              : 55
+            }]);
+
+            const liveRect = {height: 320, width: 480, x: 420, y: 240};
+
+            await expect(workspace.reshowTearOutVessel({
+                itemId: 'timeline', rect: liveRect, terminal: false, windowName: 'tearout-timeline'
+            })).resolves.toBe(true);
+            expect(vessel.resumeCalls.at(-1)).toMatchObject({
+                nativeHandleKey: 'handle-tear-child', targetWindowId: 'tear-child', x: 420, y: 240
+            });
+
+            await expect(workspace.reshowTearOutVessel({
+                itemId: 'timeline', rect: liveRect, terminal: true, windowName: 'tearout-timeline'
+            })).resolves.toBe(true);
+            expect(vessel.nativeMoveCalls.at(-1)).toMatchObject({
+                nativeHandleKey: 'handle-tear-child', targetWindowId: 'tear-child', x: 420, y: 240
+            });
+
+            const route = Neo.manager.Window.get('tear-child').nativeRoute;
+
+            route.ownerWindowId = 'wrong-owner';
+            await expect(workspace.parkTearOutVessel({
+                itemId: 'timeline', windowName: 'tearout-timeline'
+            })).resolves.toBe(false);
+            await expect(workspace.closeTearOutVessel({
+                itemId: 'timeline', windowName: 'tearout-timeline'
+            })).resolves.toBe(false);
+            expect(vessel.closeCalls, 'a stale exact route must never downgrade to same-name close').toEqual([]);
+            expect(vessel.nativeCloseCalls).toEqual([]);
+
+            route.ownerWindowId = workspace.windowId;
+            route.capabilities.position = false;
+            await expect(workspace.reshowTearOutVessel({
+                itemId: 'timeline', rect: liveRect, terminal: true, windowName: 'tearout-timeline'
+            })).resolves.toBe(false);
+            route.capabilities.position = true;
+
+            await expect(workspace.closeTearOutVessel({
+                itemId: 'timeline', windowName: 'tearout-timeline'
+            })).resolves.toBe(false);
+            expect(workspace.tearOutConnects.timeline, 'strict close refusal retains recovery routing')
+                .toEqual({windowId: 'tear-child'});
+            expect(sourceParent.items[sourceIndex], 'refused close leaves content home, not in a doomed vessel')
+                .toBe(pane);
+            expect(workspace.tearOutEmbodiment.isStaged('timeline')).toBe(false);
+            expect(workspace.tearOutRetirements.has('timeline'), 'late connects stay fenced during retry authority')
+                .toBe(true);
+
+            admitClose = true;
+
+            await expect(workspace.closeTearOutVessel({
+                itemId: 'timeline', windowName: 'tearout-timeline'
+            })).resolves.toBe(true);
+            expect(workspace.tearOutConnects.timeline).toBeUndefined();
+            expect(workspace.tearOutRetirements.has('timeline')).toBe(false);
+            expect(vessel.nativeCloseCalls).toEqual([
+                {nativeHandleKey: 'handle-tear-child', targetWindowId: 'tear-child', windowId: workspace.windowId},
+                {nativeHandleKey: 'handle-tear-child', targetWindowId: 'tear-child', windowId: workspace.windowId}
+            ])
+        } finally {
+            harness.restore();
+            vessel.restore()
+        }
+    });
+
+    test('pre-terminal disconnect clears both retained lifecycle owners for a successor gesture', () => {
+        const previousTearOut = workspace.tearOutHandlers,
+              previousPark    = workspace.vesselParkHandlers,
+              calls           = [];
+
+        workspace.tearOutConnects.timeline = {windowId: 'tear-pending'};
+        workspace.tearOutHandlers = {
+            onVesselRetired: data => calls.push(['tear-out', data])
+        };
+        workspace.vesselParkHandlers = {
+            onVesselRetired: data => calls.push(['park', data])
+        };
+
+        try {
+            workspace.onWindowDisconnect({windowId: 'tear-pending'});
+
+            expect(workspace.tearOutConnects.timeline).toBeUndefined();
+            expect(calls).toEqual([
+                ['tear-out', {itemId: 'timeline', windowName: 'tearout-timeline'}],
+                ['park', {itemId: 'timeline', retirement: true}]
+            ])
+        } finally {
+            workspace.tearOutHandlers       = previousTearOut;
+            workspace.vesselParkHandlers    = previousPark;
+            delete workspace.tearOutConnects.timeline
+        }
+    });
+
+    test('a successor boundary exit retries retained retirement before opening a fresh vessel', async () => {
+        const previousTearOut = workspace.tearOutHandlers,
+              previousPark    = workspace.vesselParkHandlers,
+              calls           = [],
+              active          = {itemId: 'timeline', windowName: 'tearout-timeline'},
+              data            = {sortZone: {endWindowDrag: () => calls.push('end')}};
+
+        workspace.tearOutHandlers = {
+            activeVessel      : active,
+            onDockTearOutExit : async value => calls.push(['exit', value]),
+            retireActiveVessel: async value => {
+                calls.push(['retire', value]);
+                return true
+            }
+        };
+        workspace.vesselParkHandlers = {
+            onVesselRetired: value => calls.push(['park-retired', value])
+        };
+
+        try {
+            await expect(workspace.onDockTearOutExit(data)).resolves.toBe(true);
+            expect(calls).toEqual([
+                ['retire', active],
+                ['park-retired', {itemId: 'timeline', retirement: true}],
+                ['exit', data]
+            ]);
+
+            calls.length = 0;
+            workspace.tearOutHandlers.retireActiveVessel = async value => {
+                calls.push(['retire', value]);
+                return false
+            };
+
+            await expect(workspace.onDockTearOutExit(data)).resolves.toBe(false);
+            expect(calls).toEqual([['retire', active], 'end'])
+        } finally {
+            workspace.tearOutHandlers    = previousTearOut;
+            workspace.vesselParkHandlers = previousPark
+        }
+    });
+
+    test('a target-focus refusal leaves the source vessel moving and never dispatches a park effect', async () => {
+        const vessel  = installWindowVessel({nativeFocusResult: false}),
+              harness = installWindowConnectHarness(workspace);
+
+        try {
+            await workspace.openTearOutVessel({
+                itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}
+            });
+            await harness.connect('tear-child', vessel.openCalls.at(-1).url);
+            harness.register('target-child');
+            workspace.crossWindowTargetWindowId = 'target-child';
+
+            await expect(workspace.parkTearOutVessel({
+                itemId: 'timeline', windowName: 'tearout-timeline'
+            })).resolves.toBe(false);
+            expect(vessel.events).toEqual(['focus']);
+            expect(vessel.parkCalls).toEqual([])
+        } finally {
+            harness.restore();
+            vessel.restore()
+        }
+    });
+
+    test('a post-move cover-focus refusal restores the source rect before refusing park ownership', async () => {
+        let focusCalls = 0;
+
+        const vessel  = installWindowVessel({nativeFocusResult: () => ++focusCalls === 1}),
+              harness = installWindowConnectHarness(workspace);
+
+        try {
+            await workspace.openTearOutVessel({
+                itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}
+            });
+            await harness.connect('tear-child', vessel.openCalls.at(-1).url);
+            harness.register('target-child');
+            workspace.crossWindowTargetWindowId = 'target-child';
+
+            await expect(workspace.parkTearOutVessel({
+                itemId: 'timeline', windowName: 'tearout-timeline'
+            })).resolves.toBe(false);
+            expect(vessel.events).toEqual(['focus', 'park', 'focus']);
+            expect(vessel.resumeCalls).toEqual([{
+                nativeHandleKey: 'handle-tear-child',
+                targetWindowId : 'tear-child',
+                windowId       : workspace.windowId,
+                windowName     : 'tearout-timeline',
+                x              : 40,
+                y              : 60
+            }]);
+            expect(workspace.lastVesselParkReceipt).toMatchObject({
+                compensated: true,
+                moved      : true,
+                parked     : false,
+                refocused  : false
+            })
+        } finally {
+            harness.restore();
+            vessel.restore()
         }
     });
 
@@ -384,7 +862,16 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
             await workspace.openTearOutVessel({
                 itemId: 'timeline', proxyRect: {height: 320, width: 480, x: 40, y: 60}
             });
-            workspace.adoptTearOutPane('timeline');
+
+            const operation = {operation: 'detachItem', itemId: 'timeline'},
+                  result    = workspace.applyTearOutOperation(operation);
+
+            expect(result.errors).toEqual([]);
+            workspace.onTearOutDocumentChange(result.document, operation);
+            await workspace.refreshPromise;
+
+            expect(pane.isDestroyed, 'terminal-first projection preserves the live pane for its late child')
+                .toBeFalsy();
 
             await harness.connect('tear-after-terminal', tearOutUrl);
 
@@ -695,6 +1182,84 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
         expect(preview.previewId).toContain('preview:group:popup-tabs:');
         expect(indicators.candidateSet.groupNodeId).toBe('popup-tabs');
         expect(renderer.dockPreview).toBe(preview)
+    });
+
+    test('main projection binds the conversion lifecycle to Park while popup projection stays source-disabled', () => {
+        const calls    = [];
+        const findTabs = (config, nodeId) => {
+            if (config?.ntype === 'tab-container' && config.dockNodeId === nodeId) return config;
+
+            for (const item of config?.items || []) {
+                const found = findTabs(item, nodeId);
+
+                if (found) return found
+            }
+
+            return null
+        };
+
+        workspace.tearOutConnects.timeline = {windowId: 'tear-child'};
+        workspace.vesselParkHandlers = {
+            onConversionIn(data) {
+                calls.push(['in', data]);
+                return true
+            },
+            onConversionOut(data) {
+                calls.push(['out', data]);
+                return true
+            },
+            onGestureTerminal(data) {
+                calls.push(['terminal', data]);
+                return Promise.resolve(true)
+            },
+            onVesselRetired(data) {
+                calls.push(['retired', data]);
+                return true
+            }
+        };
+
+        const mainTabs  = findTabs(workspace.projectDockModel(), 'side-tabs'),
+              popupTabs = findTabs(workspace.projectDockModel(
+                  null,
+                  DemoBWorkspace.POPUP_WORKSPACE_ID,
+                  DemoBWorkspace.createPopupDocument()
+              ), 'popup-tabs');
+
+        expect(mainTabs.headerToolbar.sortZoneConfig.enableVesselConversion).toBe(true);
+        expect(popupTabs.headerToolbar.sortZoneConfig.enableVesselConversion).toBe(false);
+
+        const converted = {
+                  admission: false,
+                  itemId   : 'timeline',
+                  record   : {sourceRect: {height: 320, width: 480, x: 40, y: 60}}
+              },
+              reverted = {
+                  admission  : false,
+                  itemId     : 'timeline',
+                  logicalRect: {height: 320, width: 480, x: 420, y: 240}
+              },
+              terminal = {itemId: 'timeline', outcome: 'committed', settlement: false},
+              retired  = {itemId: 'timeline', retirement: Promise.resolve(true), settlement: false};
+
+        mainTabs.listeners.dockVesselConversionIn(converted);
+        mainTabs.listeners.dockVesselConversionOut(reverted);
+        mainTabs.listeners.dockVesselConversionTerminal(terminal);
+        mainTabs.listeners.dockVesselConversionRetired(retired);
+
+        expect(converted.admission).toBe(true);
+        expect(reverted.admission).toBe(true);
+        expect(terminal.settlement).toBeInstanceOf(Promise);
+        expect(retired.settlement).toBe(true);
+        expect(calls).toEqual([
+            ['in', {
+                itemId    : 'timeline',
+                sourceRect: {height: 320, width: 480, x: 40, y: 60},
+                windowName: 'tearout-timeline'
+            }],
+            ['out', {rect: {height: 320, width: 480, x: 420, y: 240}}],
+            ['terminal', terminal],
+            ['retired', retired]
+        ])
     });
 
     test('popup projection alone owns the stack grip and routes one terminal to the optional park machine', () => {

--- a/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
+++ b/test/playwright/unit/dashboard/DockLayoutAdapter.spec.mjs
@@ -732,6 +732,50 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
             expect(request.sourceRect).toBe(liveRect)
         });
 
+        test('strict lifecycle admissions and terminal settlements stay on clone-safe mutable records', async () => {
+            const pending = Promise.resolve(true),
+                  calls   = [],
+                  result  = DockLayoutAdapter.project(createModel(), {
+                      enableVesselConversion  : true,
+                      onDockVesselConversionIn: data => {
+                          calls.push(['in', data.itemId]);
+                          return pending
+                      },
+                      onDockVesselConversionOut       : data => {
+                          calls.push(['out', data.itemId]);
+                          return true
+                      },
+                      onDockVesselConversionRetired   : data => {
+                          calls.push(['retired', data.itemId]);
+                          return true
+                      },
+                      onDockVesselConversionTerminal  : data => {
+                          calls.push(['terminal', data.outcome]);
+                          return pending
+                      },
+                      resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
+                  }),
+                  listeners = result.items[0].listeners,
+                  convertIn = {admission: false, itemId: 'swarm'},
+                  convertOut = {admission: false, itemId: 'swarm'},
+                  terminal = {itemId: 'swarm', outcome: 'committed', settlement: false},
+                  retired = {itemId: 'swarm', settlement: false};
+
+            listeners.dockVesselConversionIn(convertIn);
+            listeners.dockVesselConversionOut(convertOut);
+            listeners.dockVesselConversionTerminal(terminal);
+            listeners.dockVesselConversionRetired(retired);
+
+            expect(convertIn.admission, 'Promise identity is preserved behind the source latch').toBe(pending);
+            expect(convertOut.admission).toBe(true);
+            expect(terminal.settlement).toBe(pending);
+            expect(retired.settlement).toBe(true);
+            expect(await terminal.settlement).toBe(true);
+            expect(calls).toEqual([
+                ['in', 'swarm'], ['out', 'swarm'], ['terminal', 'committed'], ['retired', 'swarm']
+            ])
+        });
+
         test('the default is fail-closed and does not mint placeholder calibration into the projection', () => {
             const result = DockLayoutAdapter.project(createModel(), {
                 resolveComponentRef: componentRef => ({ntype: 'dashboard-panel', reference: componentRef})
@@ -746,7 +790,22 @@ test.describe('Neo.dashboard.DockLayoutAdapter', () => {
             const request = {sourceRect: {height: 1, width: 1, x: 0, y: 0}};
 
             result.items[0].listeners.dockVesselConversionSourceRectRequest(request);
-            expect(request.sourceRect).toBeNull()
+            expect(request.sourceRect).toBeNull();
+
+            for (const eventName of [
+                'dockVesselConversionIn',
+                'dockVesselConversionOut',
+                'dockVesselConversionTerminal',
+                'dockVesselConversionRetired'
+            ]) {
+                const key = eventName === 'dockVesselConversionIn' || eventName === 'dockVesselConversionOut'
+                        ? 'admission'
+                        : 'settlement',
+                    data = {[key]: true};
+
+                result.items[0].listeners[eventName](data);
+                expect(data[key]).toBe(false)
+            }
         })
     });
 

--- a/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTabSortZone.spec.mjs
@@ -148,6 +148,21 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
                 TabHeaderSortZone.prototype.onDragStart = original
             }
         })
+
+        test('a successor start is refused while the predecessor terminal still owns the end latch', async () => {
+            const calls = [];
+            const zone  = {
+                dragEndActive: true,
+                owner        : {getDomRect: () => calls.push('measure')},
+                resetVesselConversion() {
+                    calls.push('reset')
+                }
+            };
+
+            await DockTabSortZone.prototype.onDragStart.call(zone, {path: []});
+
+            expect(calls, 'the predecessor retains physical + logical generation authority').toEqual([])
+        })
     });
 
     test.describe('releaseVoidsReorder — the release-boundary decision matrix', () => {
@@ -285,15 +300,16 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
         // Prototype-driven like every pin above: the drag-end decision chain is the unit; the
         // base lifecycle is stubbed to nothing so only the dock routing under test runs.
         const zoneFor = (fired, overrides = {}) => ({
-            dockItemIds        : ['audit', 'graph', 'inbox'],
-            dockSourceNodeId   : 'tabs-main',
-            dragComponent      : null,
-            isWindowDragging   : false,
-            owner              : {up: () => ({fire: (name, data) => fired.push([name, data])})},
-            releaseVoidsReorder: () => false,
-            remoteDropCommitted: false,
-            sortGroup          : null,
-            startIndex         : 1,
+            dockItemIds           : ['audit', 'graph', 'inbox'],
+            dockSourceNodeId      : 'tabs-main',
+            dragComponent         : null,
+            fireDockLifecycleEvent: DockTabSortZone.prototype.fireDockLifecycleEvent,
+            isWindowDragging      : false,
+            owner                 : {up: () => ({fire: (name, data) => fired.push([name, data])})},
+            releaseVoidsReorder   : () => false,
+            remoteDropCommitted   : false,
+            sortGroup             : null,
+            startIndex            : 1,
             ...overrides
         });
 
@@ -342,6 +358,33 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
             expect(fired.some(([name]) => name === 'dockCrossZoneDrop')).toBe(false)
         });
 
+        test('a converted detached cancel forwards the sole tear-out close settlement into Park', async () => {
+            const fired      = [];
+            const retirement = Promise.resolve(true);
+            const zone       = zoneFor(fired, {
+                dragComponent   : {dockItemId: 'graph', id: 'graph-button'},
+                fire            : (name, data) => fired.push([name, data]),
+                isWindowDragging: true,
+                owner           : {up: () => ({fire(name, data) {
+                    name === 'dockTearOutCancel' && (data.settlement = retirement);
+                    fired.push([name, data])
+                }})},
+                vesselConversionSensor: {converted: true, transitioning: false}
+            });
+
+            zone.onDragEnd = data => runDragEnd(zone, data);
+
+            await DockTabSortZone.prototype.onDragCancel.call(zone, {key: 'Escape'});
+
+            expect(fired.map(([name]) => name)).toEqual([
+                'dockTearOutCancel',
+                'dockVesselConversionRetired',
+                'dragCancel',
+                'dockCrossZoneDragCancel'
+            ]);
+            expect(fired[1][1]).toMatchObject({itemId: 'graph', retirement})
+        });
+
         test('an in-window cancel never emits a tear-out terminal', async () => {
             const fired = [];
             const zone  = zoneFor(fired, {
@@ -375,6 +418,93 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
 
             expect(fired, 'the item already left this document — every local commit seam stays silent').toEqual([]);
             expect(zone.remoteDropCommitted, 'the one-shot flag is consumed').toBe(false)
+        });
+
+        test('a converted remote commit emits one committed conversion terminal and no local terminal', async () => {
+            const fired = [];
+            const zone  = zoneFor(fired, {
+                dragComponent         : {dockItemId: 'graph', id: 'graph-button'},
+                sortGroup             : 'dock-cross-window',
+                vesselConversionSensor: {
+                    converted      : true,
+                    targetConverted: true,
+                    transitioning  : false
+                }
+            });
+
+            zone.dragCoordinator = {
+                onDragEnd() {
+                    zone.remoteDropCommitted = true
+                }
+            };
+
+            await runDragEnd(zone, {cancelled: false, clientX: 5000, clientY: 400});
+
+            expect(fired.map(([name]) => name)).toEqual(['dockVesselConversionTerminal']);
+            expect(fired[0][1]).toMatchObject({itemId: 'graph', outcome: 'committed', settlement: false})
+        });
+
+        test('a throwing remote target retires the parked provisional vessel before rethrowing', async () => {
+            const fired = [];
+            const zone  = zoneFor(fired, {
+                dragComponent         : {dockItemId: 'graph', id: 'graph-button'},
+                sortGroup             : 'dock-cross-window',
+                vesselConversionSensor: {
+                    converted      : true,
+                    targetConverted: true,
+                    transitioning  : false
+                }
+            });
+
+            zone.dragCoordinator = {
+                onDragEnd() {
+                    throw new Error('target commit failed')
+                }
+            };
+
+            await expect(runDragEnd(zone, {cancelled: false, clientX: 5000, clientY: 400}))
+                .rejects.toThrow('target commit failed');
+            expect(fired.map(([name]) => name)).toEqual([
+                'dockTearOutCancel', 'dockVesselConversionRetired'
+            ]);
+            expect(fired[1][1]).toMatchObject({itemId: 'graph', retirement: false})
+        });
+
+        test('a release during convert-out restores before the ordinary detached terminal', async () => {
+            let resolveRestore;
+
+            const restored = new Promise(resolve => resolveRestore = resolve),
+                  order    = [],
+                  fired    = [],
+                  zone     = zoneFor(fired, {
+                      dragComponent   : {dockItemId: 'graph', id: 'graph-button'},
+                      isWindowDragging: true,
+                      owner           : {up: () => ({fire(name, data) {
+                          order.push(name);
+                          name === 'dockVesselConversionTerminal' && (data.settlement = restored);
+                          fired.push([name, data])
+                      }})},
+                      resetVesselConversion() {
+                          order.push('reset')
+                      },
+                      vesselConversionSensor: {
+                          converted      : true,
+                          targetConverted: false,
+                          transitioning  : true
+                      }
+                  });
+
+            const running = runDragEnd(zone, {cancelled: false, clientX: 5000, clientY: 400});
+
+            await Promise.resolve();
+            expect(order).toEqual(['dockVesselConversionTerminal', 'reset']);
+
+            resolveRestore(true);
+            await running;
+
+            expect(order).toEqual([
+                'dockVesselConversionTerminal', 'reset', 'dockTearOutTerminal'
+            ])
         });
 
         test('the boundary events re-fire on the tab.Container with the dock identity attached', () => {
@@ -454,17 +584,31 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
                 isWindowDragging         : true,
                 owner                    : {up: () => ({fire(name, data) {
                     if (name === 'dockVesselConversionSourceRectRequest') {
-                        data.sourceRect = overrides.liveSourceRect ?? data.logicalRect;
+                        data.sourceRect = typeof overrides.liveSourceRect === 'function'
+                            ? overrides.liveSourceRect(data)
+                            : overrides.liveSourceRect ?? data.logicalRect;
                         return
+                    }
+                    if (name === 'dockVesselConversionIn') {
+                        data.admission = overrides.convertInAdmission ?? true
+                    } else if (name === 'dockVesselConversionOut') {
+                        data.admission = overrides.convertOutAdmission ?? true
                     }
                     calls.push([name, data])
                 }})},
                 resolveVesselConversionSourceGeometry: DockTabSortZone.prototype.resolveVesselConversionSourceGeometry,
+                resolveRemoteDragTransition          : DockTabSortZone.prototype.resolveRemoteDragTransition,
                 resetVesselConversion                : DockTabSortZone.prototype.resetVesselConversion,
+                scheduleVesselConversionReplay       : DockTabSortZone.prototype.scheduleVesselConversionReplay,
                 startIndex                           : 0,
                 vesselConversionConvertThreshold     : 0.55,
+                vesselConversionCancelPromise        : null,
+                vesselConversionEpoch                : 0,
+                vesselConversionItemId               : null,
                 vesselConversionPointerExitGraceMs   : 0,
                 vesselConversionPointerMissedAt      : null,
+                vesselConversionReplayFrame          : null,
+                vesselConversionReplayPromise        : null,
                 vesselConversionRevertThreshold      : 0.35,
                 vesselConversionSensor               : null,
                 vesselConversionLogicalRect          : null,
@@ -521,6 +665,119 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
             expect(zone.vesselConversionLogicalRect).toEqual({x: 20, y: 20, width: 40, height: 20})
         });
 
+        test('the coordinator frame carries actuator identity when no base reorder index exists', () => {
+            const {calls, zone} = createZone({dockItemIds: null, startIndex: null});
+
+            expect(resolve(zone, {draggedItem: {dockItemId: 'workbench'}}))
+                .toEqual({commitEligible: true, engage: true, retain: false});
+            expect(calls[0][1].itemId).toBe('workbench')
+        });
+
+        test('async park admission is fail-closed, then admitted frames use logical position with frozen exact extents', async () => {
+            let resolvePark,
+                physical = {x: 20, y: 20, width: 200, height: 120};
+
+            const admission     = new Promise(resolve => resolvePark = resolve),
+                  {calls, zone} = createZone({
+                      convertInAdmission: admission,
+                      liveSourceRect    : () => physical
+                  });
+
+            expect(resolve(zone)).toEqual({commitEligible: false, engage: false, retain: false});
+            expect(zone.vesselConversionSensor.transitioning).toBe(true);
+
+            // Product park output is host-authored physical placement. That observation must not
+            // become the next user-trajectory sample.
+            physical = {x: -10000, y: -10000, width: 200, height: 120};
+            expect(resolve(zone)).toEqual({commitEligible: false, engage: false, retain: false});
+
+            resolvePark(true);
+            await zone.vesselConversionSensor.transitionPromise;
+
+            expect(resolve(zone)).toEqual({commitEligible: true, engage: true, retain: false});
+            expect(zone.vesselConversionSourceRect).toEqual(sourceRect);
+            expect(calls.map(([name]) => name)).toEqual(['dockVesselConversionIn'])
+        });
+
+        test('the latest low-overlap frame replays after async park so stale admission cannot convert', async () => {
+            let resolvePark;
+
+            const admission     = new Promise(resolve => resolvePark = resolve),
+                  {calls, zone} = createZone({convertInAdmission: admission});
+
+            expect(resolve(zone)).toEqual({commitEligible: false, engage: false, retain: false});
+
+            // The pointer remains inside the target but retreats below convertThreshold while the
+            // host effect is pending, then stops. No third browser frame may be required.
+            expect(resolve(zone, {
+                logicalSourceRect: {x: 760, y: 20, width: 200, height: 120}
+            })).toEqual({commitEligible: false, engage: false, retain: false});
+
+            const replay = zone.vesselConversionReplayPromise;
+
+            resolvePark(true);
+            await replay;
+
+            expect(zone.vesselConversionSensor.converted).toBe(false);
+            expect(zone.vesselConversionSensor.transitioning).toBe(false);
+            expect(calls.map(([name]) => name)).toEqual([
+                'dockVesselConversionIn', 'dockVesselConversionOut'
+            ])
+        });
+
+        test('the latest re-entry frame replays after async re-show without waiting for another move', async () => {
+            let resolveRestore;
+
+            const restoration   = new Promise(resolve => resolveRestore = resolve),
+                  {calls, zone} = createZone({convertOutAdmission: restoration});
+
+            expect(resolve(zone)).toEqual({commitEligible: true, engage: true, retain: false});
+            expect(resolve(zone, {pointerInTarget: false, targetId: null, targetRect: null}))
+                .toEqual({commitEligible: false, engage: false, retain: false});
+
+            expect(resolve(zone)).toEqual({commitEligible: false, engage: false, retain: false});
+
+            const replay = zone.vesselConversionReplayPromise;
+
+            resolveRestore(true);
+            await replay;
+
+            expect(zone.vesselConversionSensor.converted).toBe(true);
+            expect(calls.map(([name]) => name)).toEqual([
+                'dockVesselConversionIn', 'dockVesselConversionOut', 'dockVesselConversionIn'
+            ])
+        });
+
+        test('re-show replay ignores a stale parked manager rect after the pointer remains below threshold', async () => {
+            let resolveRestore,
+                physical = sourceRect;
+
+            const restoration   = new Promise(resolve => resolveRestore = resolve),
+                  {calls, zone} = createZone({
+                      convertOutAdmission: restoration,
+                      liveSourceRect     : () => physical
+                  });
+
+            expect(resolve(zone)).toEqual({commitEligible: true, engage: true, retain: false});
+            physical = {x: 0, y: 0, width: 200, height: 120};
+
+            expect(resolve(zone, {pointerInTarget: false, targetId: null, targetRect: null}))
+                .toEqual({commitEligible: false, engage: false, retain: false});
+            expect(resolve(zone, {
+                logicalSourceRect: {x: 760, y: 20, width: 200, height: 120}
+            })).toEqual({commitEligible: false, engage: false, retain: false});
+
+            const replay = zone.vesselConversionReplayPromise;
+
+            resolveRestore(true);
+            await replay;
+
+            expect(zone.vesselConversionSensor.converted).toBe(false);
+            expect(calls.map(([name]) => name)).toEqual([
+                'dockVesselConversionIn', 'dockVesselConversionOut'
+            ])
+        });
+
         test('raw claim loss drops commit immediately while a bounded visual grace emits no flip', () => {
             const {calls, zone} = createZone({vesselConversionPointerExitGraceMs: 50});
 
@@ -563,6 +820,7 @@ test.describe('Neo.dashboard.DockTabSortZone', () => {
 
             expect(calls.map(([name]) => name)).toEqual(['dockVesselConversionIn']);
             expect(zone.vesselConversionSensor.converted).toBe(false);
+            expect(zone.vesselConversionItemId).toBeNull();
             expect(zone.vesselConversionPointerMissedAt).toBeNull();
             expect(zone.vesselConversionLogicalRect).toBeNull();
             expect(zone.vesselConversionSourceRect).toBeNull();

--- a/test/playwright/unit/dashboard/DockTearOut.spec.mjs
+++ b/test/playwright/unit/dashboard/DockTearOut.spec.mjs
@@ -3,7 +3,11 @@ import {setup} from '../../setup.mjs';
 setup({
     appConfig: {
         name: 'DashboardDockTearOutTest'
-    }
+    },
+    // This lifecycle machine is a pure module. Keeping both Neo facade mocks disabled makes the
+    // witness runnable in a fresh worker instead of depending on a sibling spec importing core.
+    mockLocalStorage: false,
+    mockMain        : false
 });
 
 import {test, expect}              from '@playwright/test';
@@ -20,7 +24,7 @@ import {createDockTearOutHandlers} from '../../../../src/dashboard/DockTearOut.m
  * assertion surface — the machine exposes nothing else.
  */
 test.describe('Neo.dashboard.DockTearOut — createDockTearOutHandlers', () => {
-    const harness = ({admit = true, commitErrors = [], commitThrows = false} = {}) => {
+    const harness = ({admit = true, closeResult = true, commitErrors = [], commitThrows = false, openResult = null} = {}) => {
         const calls = {applied: [], closed: [], ended: 0, opened: [], started: [], synced: []};
 
         const sortZone = {
@@ -36,10 +40,14 @@ test.describe('Neo.dashboard.DockTearOut — createDockTearOutHandlers', () => {
                     ? {document: null, errors: commitErrors}
                     : {document: {committed: true, detached: operation.itemId}, errors: []}
             },
-            closeVessel     : vessel => calls.closed.push(vessel),
+            closeVessel     : vessel => {
+                calls.closed.push(vessel);
+                return typeof closeResult === 'function' ? closeResult(vessel) : closeResult
+            },
             onDocumentChange: (document, operation) => calls.synced.push({document, operation}),
             openVessel      : async request => {
                 calls.opened.push(request);
+                if (openResult) return openResult(request);
                 return admit ? {popupHeight: 480, popupWidth: 640, windowName: `vessel-${request.itemId}`} : null
             }
         });
@@ -70,7 +78,9 @@ test.describe('Neo.dashboard.DockTearOut — createDockTearOutHandlers', () => {
 
         await handlers.onDockTearOutExit(data);
 
-        expect(calls.opened[0]).toEqual({itemId: 'graph', proxyRect: data.proxyRect, sortZone});
+        expect(calls.opened[0]).toEqual({
+            admissionToken: 1, itemId: 'graph', proxyRect: data.proxyRect, sortZone
+        });
         expect(calls.ended).toBe(0);
         expect(calls.started).toEqual([{
             dragData: data, popupHeight: 480, popupWidth: 640, windowName: 'vessel-graph'
@@ -93,6 +103,26 @@ test.describe('Neo.dashboard.DockTearOut — createDockTearOutHandlers', () => {
         // the slot is consumed: a duplicate terminal (stale event) commits nothing further
         handlers.onDockTearOutTerminal({itemId: 'graph', sortZone});
         expect(calls.applied).toHaveLength(1)
+    });
+
+    test('a composed remote terminal retires the exact active vessel once without model mutation', async () => {
+        const {calls, handlers, sortZone} = harness();
+
+        await handlers.onDockTearOutExit(exitData(sortZone));
+
+        expect(handlers.retireActiveVessel({itemId: 'inbox', windowName: 'vessel-graph'}),
+            'other-item retirement is inert').toBe(false);
+        expect(handlers.retireActiveVessel({itemId: 'graph', windowName: 'vessel-imposter'}),
+            'same-item wrong-window retirement is inert').toBe(false);
+        expect(handlers.retireActiveVessel({itemId: 'graph', windowName: 'vessel-graph'})).toBe(true);
+        expect(handlers.retireActiveVessel({itemId: 'graph', windowName: 'vessel-graph'}),
+            'duplicate retirement is inert').toBe(false);
+
+        handlers.onDockTearOutTerminal({itemId: 'graph', sortZone});
+        handlers.onDockTearOutCancel({itemId: 'graph', sortZone});
+
+        expect(calls.applied).toHaveLength(0);
+        expect(calls.closed).toEqual([{itemId: 'graph', windowName: 'vessel-graph'}])
     });
 
     test('a model refusal at the terminal retires the vessel instead of syncing — no window survives showing a still-docked item', async () => {
@@ -145,6 +175,110 @@ test.describe('Neo.dashboard.DockTearOut — createDockTearOutHandlers', () => {
         expect(calls.closed).toEqual([{itemId: 'graph', windowName: 'vessel-graph'}]);
         expect(calls.applied).toHaveLength(0);
         expect(calls.ended, 'cancel ends the drag — no embodiment to resume').toBe(0)
+    });
+
+    for (const [terminal, terminate] of [
+        ['cancel',   (handlers, sortZone) => handlers.onDockTearOutCancel({itemId: 'graph', sortZone})],
+        ['re-entry', (handlers, sortZone) => handlers.onDockTearOutEntry({itemId: 'graph', sortZone})],
+        ['release',  (handlers, sortZone) => handlers.onDockTearOutTerminal({itemId: 'graph', sortZone})]
+    ]) {
+        test(`a deferred vessel admission resolving after ${terminal} is retired and never published`, async () => {
+            let resolveOpen;
+
+            const {calls, handlers, sortZone} = harness({
+                openResult: () => new Promise(resolve => resolveOpen = resolve)
+            });
+
+            const admission = handlers.onDockTearOutExit(exitData(sortZone));
+
+            expect(terminate(handlers, sortZone), 'the terminal invalidates provisional authority').toBe(false);
+
+            resolveOpen({generation: 17, popupHeight: 480, popupWidth: 640, windowName: 'vessel-graph'});
+
+            await expect(admission).resolves.toBe(false);
+            expect(calls.started, 'a dead gesture can never start pointer-follow').toHaveLength(0);
+            expect(calls.closed, 'the late physical result is cleanup-only authority').toEqual([{
+                itemId: 'graph', windowName: 'vessel-graph'
+            }]);
+            expect(calls.applied, 'no terminal may adopt a late admission').toHaveLength(0);
+            expect(handlers.activeVessel).toBeNull()
+        })
+    }
+
+    test('an externally retired pending admission stays dead and a successor exit admits fresh', async () => {
+        let attempt = 0,
+            resolveOpen;
+
+        const {calls, handlers, sortZone} = harness({
+            openResult: request => ++attempt === 1
+                ? new Promise(resolve => resolveOpen = resolve)
+                : {
+                    admissionToken: request.admissionToken,
+                    generation    : 22,
+                    popupHeight   : 480,
+                    popupWidth    : 640,
+                    windowName    : 'vessel-graph'
+                }
+        });
+
+        const first = handlers.onDockTearOutExit(exitData(sortZone));
+
+        expect(handlers.onVesselRetired({
+            admissionToken: 1,
+            generation    : 17,
+            itemId        : 'graph',
+            windowName    : 'vessel-graph'
+        })).toBe(true);
+
+        resolveOpen({admissionToken: 1, generation: 17, windowName: 'vessel-graph'});
+
+        await expect(first).resolves.toBe(false);
+        expect(calls.closed, 'the already-dead physical generation is not closed by semantic name').toHaveLength(0);
+        expect(handlers.activeVessel).toBeNull();
+
+        await expect(handlers.onDockTearOutExit(exitData(sortZone))).resolves.toBe(true);
+        expect(calls.started).toHaveLength(1);
+        expect(handlers.activeVessel).toEqual({itemId: 'graph', windowName: 'vessel-graph'})
+    });
+
+    test('an explicit close refusal retains the active vessel and coalesces one in-flight retirement', async () => {
+        let resolveClose,
+            attempt = 0;
+
+        const closeResult                 = new Promise(resolve => resolveClose = resolve),
+              {calls, handlers, sortZone} = harness({
+                  closeResult: () => ++attempt === 1 ? closeResult : true
+              });
+
+        await handlers.onDockTearOutExit(exitData(sortZone));
+
+        const first  = handlers.onDockTearOutCancel({itemId: 'graph', sortZone}),
+              second = handlers.onDockTearOutCancel({itemId: 'graph', sortZone});
+
+        expect(calls.closed).toHaveLength(1);
+
+        resolveClose(false);
+
+        await expect(first).resolves.toBe(false);
+        await expect(second).resolves.toBe(false);
+
+        // Refusal preserves the private slot, so a later exact retry remains possible.
+        expect(handlers.activeVessel).toEqual({itemId: 'graph', windowName: 'vessel-graph'});
+        expect(handlers.retireActiveVessel({itemId: 'graph', windowName: 'vessel-graph'})).toBe(true);
+        expect(calls.closed).toHaveLength(2);
+        expect(handlers.activeVessel).toBeNull()
+    });
+
+    test('an externally observed exact disconnect clears a retained refusal without closing again', async () => {
+        const {calls, handlers, sortZone} = harness({closeResult: false});
+
+        await handlers.onDockTearOutExit(exitData(sortZone));
+        expect(handlers.onDockTearOutCancel({itemId: 'graph', sortZone})).toBe(false);
+
+        expect(handlers.onVesselRetired({itemId: 'other', windowName: 'vessel-graph'})).toBe(false);
+        expect(handlers.onVesselRetired({itemId: 'graph', windowName: 'vessel-graph'})).toBe(true);
+        expect(handlers.activeVessel).toBeNull();
+        expect(calls.closed).toHaveLength(1)
     });
 
     test('the hysteresis re-crossing arc: exit → entry → exit → terminal yields two vessels, ONE commit, one retirement', async () => {

--- a/test/playwright/unit/dashboard/DockVesselConversion.spec.mjs
+++ b/test/playwright/unit/dashboard/DockVesselConversion.spec.mjs
@@ -30,8 +30,14 @@ test.describe('Neo.dashboard.DockVesselConversion — createVesselConversionSens
         const calls = {converted: [], reverted: []};
 
         const sensor = createVesselConversionSensor({
-            onConvertIn : record => calls.converted.push(record),
-            onConvertOut: record => calls.reverted.push(record),
+            onConvertIn: record => {
+                calls.converted.push(record);
+                return true
+            },
+            onConvertOut: record => {
+                calls.reverted.push(record);
+                return true
+            },
             ...config
         });
 
@@ -264,6 +270,61 @@ test.describe('Neo.dashboard.DockVesselConversion — createVesselConversionSens
             sourceRect     : source,
             targetRect     : target
         })
+    });
+
+    test('an async transition is provisional until strict true, and refusal preserves the prior decision', async () => {
+        let resolveIn;
+
+        const admission = new Promise(resolve => resolveIn = resolve),
+              {sensor}  = harness({onConvertIn: () => admission}),
+              record    = slideSample(sensor, 0);
+
+        expect(record).toMatchObject({converted: false, transitioning: true});
+        expect(sensor.converted).toBe(false);
+        expect(sensor.targetConverted).toBe(true);
+
+        resolveIn(false);
+        await sensor.transitionPromise;
+
+        expect(sensor.converted).toBe(false);
+        expect(sensor.transitioning).toBe(false)
+    });
+
+    test('async reversion refusal keeps conversion ownership and may be retried', async () => {
+        const outcomes        = [Promise.resolve(false), Promise.resolve(true)],
+              {calls, sensor} = harness({onConvertOut: record => {
+                  calls.reverted.push(record);
+                  return outcomes.shift()
+              }});
+
+        slideSample(sensor, 0);
+        expect(sensor.converted).toBe(true);
+
+        expect(slideSample(sensor, 100)).toMatchObject({converted: true, transitioning: true});
+        await sensor.transitionPromise;
+        expect(sensor.converted, 'a refused re-show cannot clear conversion ownership').toBe(true);
+
+        slideSample(sensor, 100);
+        await sensor.transitionPromise;
+
+        expect(sensor.converted).toBe(false);
+        expect(calls.reverted).toHaveLength(2)
+    });
+
+    test('reset invalidates an older async completion so it cannot mutate the next gesture', async () => {
+        let resolveIn;
+
+        const admission = new Promise(resolve => resolveIn = resolve),
+              {sensor}  = harness({onConvertIn: () => admission});
+
+        slideSample(sensor, 0);
+        sensor.reset();
+        resolveIn(true);
+        await admission;
+        await Promise.resolve();
+
+        expect(sensor.converted).toBe(false);
+        expect(sensor.transitioning).toBe(false)
     });
 
     test('config validation fails LOUD: inverted or degenerate bands, out-of-range thresholds, missing or non-function seams', () => {

--- a/test/playwright/unit/dashboard/DockVesselEmbodiment.spec.mjs
+++ b/test/playwright/unit/dashboard/DockVesselEmbodiment.spec.mjs
@@ -1,0 +1,115 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'DockVesselEmbodimentTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+import '../../../../src/manager/Instance.mjs';
+import Component from '../../../../src/component/Base.mjs';
+import Container from '../../../../src/container/Base.mjs';
+
+import {createDockVesselEmbodiment} from '../../../../src/dashboard/DockVesselEmbodiment.mjs';
+
+test.describe('Neo.dashboard.DockVesselEmbodiment (#15396)', () => {
+    let embodiment, pane, source, target;
+
+    test.beforeEach(() => {
+        source = Neo.create(Container, {
+            items: [
+                {module: Component, html: 'before'},
+                {module: Component, html: 'live'},
+                {module: Component, html: 'after'}
+            ]
+        });
+        target = Neo.create(Container, {items: []});
+        pane   = source.items[1];
+
+        embodiment = createDockVesselEmbodiment({
+            resolvePane  : itemId => itemId === 'live' ? pane : null,
+            resolveTarget: windowId => windowId === 'admitted-window' ? target : null
+        })
+    });
+
+    test.afterEach(() => {
+        embodiment?.destroy();
+        source?.isDestroyed || source?.destroy();
+        target?.isDestroyed || target?.destroy()
+    });
+
+    test('stages the same pane in the vessel while preserving the source card slot', async () => {
+        await expect(embodiment.stage({itemId: 'live', windowId: 'admitted-window'})).resolves.toBe(true);
+        expect(target.items).toEqual([pane]);
+        expect(source.items).toHaveLength(3);
+        expect(source.items[1]).not.toBe(pane);
+        expect(source.items[1].cls).toContain('neo-dashboard-dock-vessel-placeholder');
+        expect(embodiment.isStaged('live')).toBe(true)
+    });
+
+    test('restores through the placeholder live index after sibling structure shifts', async () => {
+        await embodiment.stage({itemId: 'live', windowId: 'admitted-window'});
+        source.insert(0, {module: Component, html: 'new first'}, true);
+
+        expect(embodiment.restore({itemId: 'live', windowId: 'admitted-window'})).toBe(true);
+        expect(source.items[2]).toBe(pane);
+        expect(target.items).not.toContain(pane);
+        expect(embodiment.isStaged('live')).toBe(false)
+    });
+
+    test('promotion leaves the exact placeholder for committed projection cleanup', async () => {
+        await embodiment.stage({itemId: 'live', windowId: 'admitted-window'});
+
+        const placeholder = source.items[1];
+
+        expect(embodiment.promote({itemId: 'live', windowId: 'admitted-window'})).toBe(true);
+        expect(source.items[1]).toBe(placeholder);
+        expect(target.items).toEqual([pane]);
+        expect(embodiment.isStaged('live')).toBe(false)
+    });
+
+    test('a different or replayed vessel cannot steal an already-staged pane', async () => {
+        await expect(embodiment.stage({itemId: 'live', windowId: 'admitted-window'})).resolves.toBe(true);
+        expect(embodiment.stage({itemId: 'live', windowId: 'forged-window'})).toBe(false);
+        expect(embodiment.restore({itemId: 'live', windowId: 'forged-window'})).toBe(false);
+        expect(target.items).toEqual([pane]);
+        expect(source.items[1].cls).toContain('neo-dashboard-dock-vessel-placeholder')
+    });
+
+    test('target insertion rejection restores the pane and retires the transient record', async () => {
+        target.add = () => {
+            throw new Error('target insertion rejected')
+        };
+
+        await expect(embodiment.stage({itemId: 'live', windowId: 'admitted-window'})).resolves.toBe(false);
+        expect(source.items).toHaveLength(3);
+        expect(source.items[1]).toBe(pane);
+        expect(source.items.some(item => item.cls?.includes('neo-dashboard-dock-vessel-placeholder'))).toBe(false);
+        expect(target.items).toEqual([]);
+        expect(embodiment.isStaged('live')).toBe(false)
+    });
+
+    test('target update rejection restores the pane from the vessel through the live placeholder slot', async () => {
+        const targetAdd = target.add.bind(target);
+
+        target.add = item => {
+            const result = targetAdd(item);
+
+            target.promiseUpdate = async () => {
+                throw new Error('target update rejected')
+            };
+
+            return result
+        };
+
+        await expect(embodiment.stage({itemId: 'live', windowId: 'admitted-window'})).resolves.toBe(false);
+        expect(source.items).toHaveLength(3);
+        expect(source.items[1]).toBe(pane);
+        expect(source.items.some(item => item.cls?.includes('neo-dashboard-dock-vessel-placeholder'))).toBe(false);
+        expect(target.items).toEqual([]);
+        expect(embodiment.isStaged('live')).toBe(false)
+    })
+});

--- a/test/playwright/unit/dashboard/DockVesselPark.spec.mjs
+++ b/test/playwright/unit/dashboard/DockVesselPark.spec.mjs
@@ -29,9 +29,18 @@ test.describe('Neo.dashboard.DockVesselPark — createVesselParkHandlers', () =>
         const calls = {disposed: [], parked: [], reshown: []};
 
         const handlers = createVesselParkHandlers({
-            disposeVessel: vessel => calls.disposed.push(vessel),
-            parkVessel   : vessel => calls.parked.push(vessel),
-            reshowVessel : vessel => calls.reshown.push(vessel)
+            disposeVessel: vessel => {
+                calls.disposed.push(vessel);
+                return true
+            },
+            parkVessel: vessel => {
+                calls.parked.push(vessel);
+                return true
+            },
+            reshowVessel: vessel => {
+                calls.reshown.push(vessel);
+                return true
+            }
         });
 
         return {calls, handlers}
@@ -76,7 +85,9 @@ test.describe('Neo.dashboard.DockVesselPark — createVesselParkHandlers', () =>
         handlers.onConversionIn(inData());
         handlers.onConversionOut({rect: liveRect});
 
-        expect(calls.reshown).toEqual([{itemId: 'graph', rect: liveRect, windowName: 'vessel-graph'}]);
+        expect(calls.reshown).toEqual([{
+            itemId: 'graph', rect: liveRect, terminal: false, windowName: 'vessel-graph'
+        }]);
         expect(calls.disposed).toHaveLength(0);
         expect(handlers.parkedVessel).toBeNull()
     });
@@ -90,6 +101,7 @@ test.describe('Neo.dashboard.DockVesselPark — createVesselParkHandlers', () =>
         expect(calls.reshown).toEqual([{
             itemId    : 'graph',
             rect      : rect(500, 120, 640, 480),
+            terminal  : false,
             windowName: 'vessel-graph'
         }])
     });
@@ -114,7 +126,40 @@ test.describe('Neo.dashboard.DockVesselPark — createVesselParkHandlers', () =>
         expect(handlers.parkedVessel).toBeNull();
 
         handlers.onGestureTerminal({itemId: 'graph', outcome: 'committed'});
-        expect(calls.disposed, 'slot cleared first — stale duplicate commits nothing').toHaveLength(1)
+        expect(calls.disposed, 'strict-success clear — stale duplicate commits nothing').toHaveLength(1)
+    });
+
+    test('a committed close refusal retains exact retry authority and coalesces one async disposition', async () => {
+        let resolveClose,
+            attempt = 0;
+
+        const pending  = new Promise(resolve => resolveClose = resolve),
+              calls    = [],
+              handlers = createVesselParkHandlers({
+                  disposeVessel: vessel => {
+                      calls.push(vessel);
+                      return ++attempt === 1 ? pending : true
+                  },
+                  parkVessel  : () => true,
+                  reshowVessel: () => true
+              });
+
+        handlers.onConversionIn(inData());
+
+        const first  = handlers.onGestureTerminal({itemId: 'graph', outcome: 'committed'}),
+              second = handlers.onGestureTerminal({itemId: 'graph', outcome: 'committed'});
+
+        expect(second).toBe(first);
+        expect(calls).toHaveLength(1);
+
+        resolveClose(false);
+
+        await expect(first).resolves.toBe(false);
+        expect(handlers.parkedVessel?.itemId, 'refusal keeps the sole retry authority').toBe('graph');
+
+        expect(handlers.onGestureTerminal({itemId: 'graph', outcome: 'committed'})).toBe(true);
+        expect(calls).toHaveLength(2);
+        expect(handlers.parkedVessel).toBeNull()
     });
 
     test('every non-commit outcome RESTORES at the pre-conversion rect and never disposes — cancel, reject, and unknown alike', () => {
@@ -128,6 +173,7 @@ test.describe('Neo.dashboard.DockVesselPark — createVesselParkHandlers', () =>
             expect(calls.reshown, `outcome "${outcome}" restores the window`).toEqual([{
                 itemId    : 'graph',
                 rect      : rect(500, 120, 640, 480),
+                terminal  : true,
                 windowName: 'vessel-graph'
             }]);
             expect(handlers.parkedVessel).toBeNull()
@@ -158,8 +204,228 @@ test.describe('Neo.dashboard.DockVesselPark — createVesselParkHandlers', () =>
         // the complete ledger of platform effects across the round-trip is exactly these calls —
         // zero mid-gesture window opens are possible by construction.
         expect(calls.parked).toHaveLength(2);
-        expect(calls.reshown).toEqual([{itemId: 'graph', rect: midRect, windowName: 'vessel-graph'}]);
+        expect(calls.reshown).toEqual([{
+            itemId: 'graph', rect: midRect, terminal: false, windowName: 'vessel-graph'
+        }]);
         expect(calls.disposed).toEqual([{itemId: 'graph', windowName: 'vessel-graph'}]);
+        expect(handlers.parkedVessel).toBeNull()
+    });
+
+    test('async park admission publishes no slot until strict true; false remains source-owned', async () => {
+        let resolvePark;
+
+        const pending  = new Promise(resolve => resolvePark = resolve),
+              calls    = [],
+              handlers = createVesselParkHandlers({
+                  disposeVessel: () => true,
+                  parkVessel   : vessel => {
+                      calls.push(vessel);
+                      return pending
+                  },
+                  reshowVessel: () => true
+              }),
+              admission = handlers.onConversionIn(inData());
+
+        expect(calls).toEqual([{itemId: 'graph', windowName: 'vessel-graph'}]);
+        expect(handlers.parkedVessel, 'dispatch is not admission').toBeNull();
+        expect(handlers.transition?.phase).toBe('parking');
+
+        resolvePark(false);
+
+        await expect(admission).resolves.toBe(false);
+        expect(handlers.parkedVessel).toBeNull();
+        expect(handlers.transition).toBeNull()
+    });
+
+    test('async re-show refusal retains the exact parked vessel for a later strict-success retry', async () => {
+        let allowRestore = false;
+
+        const calls    = [],
+              handlers = createVesselParkHandlers({
+                  disposeVessel: () => true,
+                  parkVessel   : () => true,
+                  reshowVessel : async vessel => {
+                      calls.push(vessel);
+                      return allowRestore
+                  }
+              });
+
+        expect(handlers.onConversionIn(inData())).toBe(true);
+
+        await expect(handlers.onConversionOut({rect: rect(900, 300, 640, 480)})).resolves.toBe(false);
+        expect(handlers.parkedVessel?.windowName).toBe('vessel-graph');
+
+        allowRestore = true;
+
+        await expect(handlers.onConversionOut({rect: rect(920, 320, 640, 480)})).resolves.toBe(true);
+        expect(calls).toHaveLength(2);
+        expect(calls[1].rect).toEqual(rect(920, 320, 640, 480));
+        expect(handlers.parkedVessel).toBeNull()
+    });
+
+    test('synchronous platform throws normalize to refusal and preserve recoverable ownership', () => {
+        const parkThrows = createVesselParkHandlers({
+            disposeVessel: () => true,
+            parkVessel   : () => { throw new Error('park failed') },
+            reshowVessel : () => true
+        });
+
+        expect(() => parkThrows.onConversionIn(inData())).not.toThrow();
+        expect(parkThrows.parkedVessel).toBeNull();
+
+        const restoreThrows = createVesselParkHandlers({
+            disposeVessel: () => true,
+            parkVessel   : () => true,
+            reshowVessel : () => { throw new Error('move failed') }
+        });
+
+        expect(restoreThrows.onConversionIn(inData())).toBe(true);
+        expect(() => restoreThrows.onGestureTerminal({itemId: 'graph', outcome: 'cancelled'})).not.toThrow();
+        expect(restoreThrows.parkedVessel?.itemId).toBe('graph')
+    });
+
+    test('a terminal arriving during async park settles that generation, then disposes exactly once', async () => {
+        let resolvePark;
+
+        const pending  = new Promise(resolve => resolvePark = resolve),
+              disposed = [],
+              handlers = createVesselParkHandlers({
+                  disposeVessel: vessel => {
+                      disposed.push(vessel);
+                      return true
+                  },
+                  parkVessel  : () => pending,
+                  reshowVessel: () => true
+              });
+
+        handlers.onConversionIn(inData());
+
+        const first  = handlers.onGestureTerminal({itemId: 'graph', outcome: 'committed'}),
+              second = handlers.onGestureTerminal({itemId: 'graph', outcome: 'committed'});
+
+        expect(disposed).toHaveLength(0);
+
+        resolvePark(true);
+
+        await expect(first).resolves.toBe(true);
+        await expect(second).resolves.toBe(true);
+        expect(disposed).toEqual([{itemId: 'graph', windowName: 'vessel-graph'}]);
+        expect(handlers.parkedVessel).toBeNull()
+    });
+
+    test('false-after-physical-park still runs the queued terminal compensation exactly once', async () => {
+        for (const outcome of ['committed', 'rejected']) {
+            let resolvePark;
+
+            const pending  = new Promise(resolve => resolvePark = resolve),
+                  calls    = {disposed: [], reshown: []},
+                  handlers = createVesselParkHandlers({
+                      disposeVessel: vessel => {
+                          calls.disposed.push(vessel);
+                          return true
+                      },
+                      parkVessel  : () => pending,
+                      reshowVessel: vessel => {
+                          calls.reshown.push(vessel);
+                          return true
+                      }
+                  });
+
+            handlers.onConversionIn(inData());
+            const terminal = handlers.onGestureTerminal({itemId: 'graph', outcome});
+
+            // Models Main's normal terminal race: the native move happened, but generation reset
+            // makes the pointer-follow admission resolve false after the effect.
+            resolvePark(false);
+
+            await expect(terminal).resolves.toBe(true);
+
+            if (outcome === 'committed') {
+                expect(calls.disposed).toEqual([{itemId: 'graph', windowName: 'vessel-graph'}]);
+                expect(calls.reshown).toHaveLength(0)
+            } else {
+                expect(calls.disposed).toHaveLength(0);
+                expect(calls.reshown).toEqual([{
+                    itemId    : 'graph',
+                    rect      : rect(500, 120, 640, 480),
+                    terminal  : true,
+                    windowName: 'vessel-graph'
+                }])
+            }
+        }
+    });
+
+    test('external tear-out retirement clears a pending park generation without a late resurrection', async () => {
+        let resolvePark;
+
+        const pending  = new Promise(resolve => resolvePark = resolve),
+              handlers = createVesselParkHandlers({
+                  disposeVessel: () => true,
+                  parkVessel   : () => pending,
+                  reshowVessel : () => true
+              }),
+              admission = handlers.onConversionIn(inData());
+
+        expect(handlers.onVesselRetired({itemId: 'other'})).toBe(false);
+        expect(handlers.onVesselRetired({itemId: 'graph'})).toBe(true);
+        expect(handlers.transition).toBeNull();
+
+        resolvePark(true);
+
+        await expect(admission).resolves.toBe(false);
+        expect(handlers.parkedVessel).toBeNull();
+        expect(handlers.onVesselRetired({itemId: 'graph'}), 'duplicate retirement is inert').toBe(false)
+    });
+
+    test('external retirement invalidates a queued terminal before its late park settlement can dispose', async () => {
+        let resolvePark;
+
+        const pending  = new Promise(resolve => resolvePark = resolve),
+              disposed = [],
+              handlers = createVesselParkHandlers({
+                  disposeVessel: vessel => {
+                      disposed.push(vessel);
+                      return true
+                  },
+                  parkVessel  : () => pending,
+                  reshowVessel: () => true
+              });
+
+        handlers.onConversionIn(inData());
+        const terminal = handlers.onGestureTerminal({itemId: 'graph', outcome: 'committed'});
+
+        expect(handlers.onVesselRetired({itemId: 'graph', retirement: true})).toBe(true);
+        resolvePark(true);
+
+        await expect(terminal).resolves.toBe(false);
+        expect(disposed).toEqual([]);
+        expect(handlers.parkedVessel).toBeNull()
+    });
+
+    test('external retirement clears only after strict close settlement; refusal preserves recovery truth', async () => {
+        let resolveRetirement;
+
+        const retirement = new Promise(resolve => resolveRetirement = resolve),
+              handlers   = createVesselParkHandlers({
+                  disposeVessel: () => true,
+                  parkVessel   : () => true,
+                  reshowVessel : () => true
+              });
+
+        handlers.onConversionIn(inData());
+        const settlement = handlers.onVesselRetired({itemId: 'graph', retirement});
+
+        expect(handlers.transition?.phase).toBe('retiring');
+        expect(handlers.parkedVessel?.itemId).toBe('graph');
+        expect(handlers.onGestureTerminal({itemId: 'other', outcome: 'committed'})).toBe(false);
+        expect(handlers.onGestureTerminal({itemId: 'graph', outcome: 'committed'})).toBe(settlement);
+
+        resolveRetirement(false);
+
+        await expect(settlement).resolves.toBe(false);
+        expect(handlers.parkedVessel?.itemId, 'a refused close cannot erase recovery authority').toBe('graph');
+
+        expect(handlers.onVesselRetired({itemId: 'graph', retirement: true})).toBe(true);
         expect(handlers.parkedVessel).toBeNull()
     });
 

--- a/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
+++ b/test/playwright/unit/main/MainNativeWindowRoute.spec.mjs
@@ -1,0 +1,273 @@
+import {test, expect}  from '@playwright/test';
+import {execFile}      from 'child_process';
+import path            from 'path';
+import {promisify}     from 'util';
+import {fileURLToPath} from 'url';
+
+const __dirname     = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT     = path.resolve(__dirname, '../../../..');
+const execFileAsync = promisify(execFile);
+
+/**
+ * @summary Runs one native-window authority scenario against the real Main singleton in an isolated process.
+ * @param {'cross-origin'|'navigation-failure'|'persisted-pagehide'|'same-origin'} scenario
+ * @returns {Promise<Object>}
+ */
+async function runNativeWindowRouteProbe(scenario) {
+    const script = `
+        import Neo from './src/Neo.mjs';
+        import * as core from './src/core/_export.mjs';
+        import {setup} from './test/playwright/setup.mjs';
+
+        setup({mockMain: false, neoConfig: {unitTestMode: true}});
+
+        const windowListeners = new Map();
+
+        globalThis.document = {
+            readyState         : 'loading',
+            hidden             : false,
+            visibilityState    : 'visible',
+            addEventListener   : () => {},
+            removeEventListener: () => {},
+            getElementById     : () => null,
+            querySelector      : () => null,
+            createElement      : () => ({
+                addEventListener: () => {},
+                classList       : {add: () => {}, remove: () => {}}
+            }),
+            body: {
+                addEventListener: () => {},
+                classList       : {add: () => {}, remove: () => {}}
+            },
+            documentElement: {classList: {add: () => {}, remove: () => {}}}
+        };
+        globalThis.window              = globalThis;
+        globalThis.addEventListener    = (name, listener) => windowListeners.set(name, listener);
+        globalThis.removeEventListener = () => {};
+        globalThis.location            = {
+            hash  : '',
+            href  : 'https://owner.example.test/apps/demo/index.html',
+            origin: 'https://owner.example.test',
+            reload: () => {}
+        };
+        globalThis.screen = {
+            availHeight: 900,
+            availLeft  : 0,
+            availTop   : 0,
+            availWidth : 1440,
+            colorDepth : 24,
+            height     : 900,
+            orientation: {},
+            pixelDepth : 24,
+            width      : 1440
+        };
+        globalThis.innerHeight = 700;
+        globalThis.innerWidth  = 1000;
+        globalThis.outerHeight = 760;
+        globalThis.outerWidth  = 1080;
+        globalThis.screenLeft  = 10;
+        globalThis.screenTop   = 20;
+        globalThis.matchMedia  = () => ({
+            matches            : false,
+            addEventListener   : () => {},
+            removeEventListener: () => {}
+        });
+        globalThis.Worker       = class {};
+        globalThis.SharedWorker = class {};
+
+        Neo.insideWorker = true;
+        delete Neo.main.DomAccess;
+        delete Neo.worker.Manager;
+
+        const {default: Main} = await import('./src/Main.mjs');
+        const scenario        = ${JSON.stringify(scenario)};
+
+        if (scenario === 'persisted-pagehide') {
+            const
+                consumed = [],
+                released = [],
+                storage  = new Map([['neo-native-window-route', 'token-a']]);
+
+            globalThis.sessionStorage = {
+                getItem   : key => storage.get(key) ?? null,
+                removeItem: key => storage.delete(key),
+                setItem   : (key, value) => storage.set(key, value)
+            };
+            globalThis.opener = {
+                closed: false,
+                Neo   : {
+                    Main: {
+                        nativeRouteStorageKey: 'neo-native-window-route',
+                        consumeNativeWindowRoute({targetWindowId, token}) {
+                            consumed.push({targetWindowId, token});
+
+                            return {
+                                capabilities  : {close: false, focus: true, position: true},
+                                nativeHandleKey: 'handle-' + token,
+                                ownerWindowId  : 'owner-window',
+                                targetWindowId
+                            }
+                        },
+                        releaseNativeWindowRoute(route) {
+                            released.push(route.nativeHandleKey);
+                            return true
+                        }
+                    }
+                }
+            };
+
+            const first = Main.getWindowData().nativeRoute;
+
+            windowListeners.get('pagehide')?.({persisted: true});
+            storage.set('neo-native-window-route', 'token-b');
+
+            const second = Main.getWindowData().nativeRoute;
+
+            console.log(JSON.stringify({
+                consumed,
+                firstHandle : first?.nativeHandleKey ?? null,
+                remainingToken: storage.get('neo-native-window-route') ?? null,
+                released,
+                secondHandle: second?.nativeHandleKey ?? null
+            }))
+        } else {
+            const
+                events   = [],
+                openArgs = [],
+                state    = {closed: false, token: null};
+
+            const popup = {
+                get closed() {
+                    return state.closed
+                },
+                close() {
+                    events.push('close');
+                    state.closed = true
+                },
+                focus() {},
+                moveTo() {},
+                innerHeight: 600,
+                outerWidth : 900,
+                resizeTo() {
+                    events.push('resize')
+                },
+                sessionStorage: {
+                    setItem(key, value) {
+                        events.push('storage');
+
+                        if (scenario === 'cross-origin') {
+                            throw new Error('cross-origin storage denied')
+                        }
+
+                        state.token = value
+                    }
+                },
+                location: {
+                    replace(url) {
+                        events.push('replace');
+
+                        if (scenario === 'navigation-failure') {
+                            throw new Error('navigation rejected')
+                        }
+
+                        state.replacedUrl = url
+                    }
+                }
+            };
+
+            globalThis.open = (url, targetName, features) => {
+                openArgs.push({features, targetName, url});
+                return popup
+            };
+            globalThis.setTimeout = () => 1;
+            Main.openWindows      = {};
+
+            const url = scenario === 'cross-origin'
+                ? 'https://other.example.test/popup'
+                : './popup.html?mode=tear-out';
+            const success = Main.windowOpen({
+                nativeCapabilities: {close: true},
+                url,
+                useTotalHeight: false,
+                windowFeatures: 'popup,width=900,height=600',
+                windowName    : 'tear-out'
+            });
+            const route = state.token
+                ? Main.consumeNativeWindowRoute({targetWindowId: 'child-window', token: state.token, win: popup})
+                : null;
+
+            console.log(JSON.stringify({
+                closed   : state.closed,
+                events,
+                hasEntry : Object.hasOwn(Main.openWindows, 'tear-out'),
+                openArgs,
+                replacedUrl: state.replacedUrl ?? null,
+                route,
+                success,
+                tokenMinted: Boolean(state.token)
+            }))
+        }
+    `;
+    const {stdout} = await execFileAsync(process.execPath, ['--input-type=module', '-e', script], {
+        cwd     : REPO_ROOT,
+        encoding: 'utf8',
+        timeout : 15_000
+    });
+
+    return JSON.parse(stdout.trim().split('\n').at(-1))
+}
+
+/**
+ * @summary Pins exact native-window authority staging and persisted-document cache retirement.
+ */
+test.describe('Neo.Main native window routes (#15396)', () => {
+    test('same-origin open stages the route before final navigation and admits the exact popup', async () => {
+        const result = await runNativeWindowRouteProbe('same-origin');
+
+        expect(result.success).toBe(true);
+        expect(result.openArgs).toHaveLength(1);
+        expect(result.openArgs[0].url).toBe('about:blank');
+        expect(result.events).toEqual(['storage', 'replace']);
+        expect(result.replacedUrl).toBe('https://owner.example.test/apps/demo/popup.html?mode=tear-out');
+        expect(result.hasEntry).toBe(true);
+        expect(result.route).toMatchObject({
+            capabilities  : {close: true, focus: true, position: true},
+            ownerWindowId : expect.any(String),
+            targetWindowId: 'child-window'
+        })
+    });
+
+    test('same-origin navigation failure retires the grant, registry entry, and popup', async () => {
+        const result = await runNativeWindowRouteProbe('navigation-failure');
+
+        expect(result.success).toBe(false);
+        expect(result.openArgs[0].url).toBe('about:blank');
+        expect(result.events).toEqual(['storage', 'replace', 'close']);
+        expect(result.closed).toBe(true);
+        expect(result.hasEntry).toBe(false);
+        expect(result.route).toBeNull()
+    });
+
+    test('cross-origin open preserves direct browser navigation and exposes no native route', async () => {
+        const result = await runNativeWindowRouteProbe('cross-origin');
+
+        expect(result.success).toBe(true);
+        expect(result.openArgs[0].url).toBe('https://other.example.test/popup');
+        expect(result.events).toEqual(['storage']);
+        expect(result.closed).toBe(false);
+        expect(result.replacedUrl).toBeNull();
+        expect(result.tokenMinted).toBe(false);
+        expect(result.route).toBeNull();
+        expect(result.hasEntry).toBe(true)
+    });
+
+    test('persisted pagehide permanently retires the preserved realm instead of consuming a fresh grant', async () => {
+        const result = await runNativeWindowRouteProbe('persisted-pagehide');
+
+        expect(result.firstHandle).toBe('handle-token-a');
+        expect(result.secondHandle).toBeNull();
+        expect(result.consumed.map(item => item.token)).toEqual(['token-a']);
+        expect(result.released).toEqual(['handle-token-a']);
+        expect(result.remainingToken).toBe('token-b')
+    })
+});

--- a/test/playwright/unit/main/addon/DragDrop.spec.mjs
+++ b/test/playwright/unit/main/addon/DragDrop.spec.mjs
@@ -1,0 +1,228 @@
+import {setup} from '../../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'MainDragDropTest'
+    },
+    mockLocalStorage: false,
+    mockMain        : false,
+    neoConfig       : {
+        unitTestMode: true
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+
+// DragDrop imports the eager DomEvents main-thread singleton. Install the two native listener
+// surfaces before that dynamic import; unlike a hand-written mock, EventTarget preserves real
+// add/remove/dispatch semantics while the tests drive only the addon's own prototype methods.
+const originalDocument  = globalThis.document,
+      originalDomAccess = Neo.main.DomAccess,
+      originalDragDrop  = Neo.main.addon.DragDrop,
+      originalWindow    = globalThis.window,
+      documentRef       = new EventTarget(),
+      windowRef         = new EventTarget();
+
+documentRef.body            = {};
+documentRef.documentElement = {};
+windowRef.screenX           = 0;
+windowRef.screenY           = 0;
+
+globalThis.document = documentRef;
+globalThis.window   = windowRef;
+
+Neo.Main ??= {};
+
+delete Neo.main.DomAccess;
+delete Neo.main.addon.DragDrop;
+
+const {default: DomEvents} = await import('../../../../../src/main/DomEvents.mjs'),
+      {default: DragDrop}  = await import('../../../../../src/main/addon/DragDrop.mjs');
+
+/**
+ * @summary Physical pointer-follow lifecycle witnesses for popup park/re-show.
+ *
+ * Parking pauses only OS-window moves: logical drag frames must keep reaching the App Worker so
+ * target claims and out-conversion remain pointer-owned. Park/re-show drain the prior name-based
+ * move and then address the exact opener-minted native handle generation. Reset invalidates every
+ * late completion, preventing a predecessor gesture from moving a successor's same-name popup.
+ */
+test.describe('Neo.main.addon.DragDrop — generation-scoped physical window drag', () => {
+    let originalMoveTo,
+        originalNativeMoveTo,
+        originalSend;
+
+    test.beforeEach(() => {
+        originalMoveTo       = Neo.Main.windowMoveTo;
+        originalNativeMoveTo = Neo.Main.windowNativeMoveTo;
+        originalSend         = DomEvents.sendMessageToApp
+    });
+
+    test.afterAll(() => {
+        originalDomAccess === undefined ? delete Neo.main.DomAccess : Neo.main.DomAccess = originalDomAccess;
+        originalDragDrop  === undefined ? delete Neo.main.addon.DragDrop : Neo.main.addon.DragDrop = originalDragDrop;
+        originalDocument === undefined ? delete globalThis.document : globalThis.document = originalDocument;
+        originalWindow   === undefined ? delete globalThis.window   : globalThis.window   = originalWindow
+    });
+
+    test.afterEach(() => {
+        Neo.Main.windowMoveTo       = originalMoveTo;
+        Neo.Main.windowNativeMoveTo = originalNativeMoveTo;
+        DomEvents.sendMessageToApp  = originalSend
+    });
+
+    test('a parked physical vessel emits logical drag frames but performs zero pointer-follow moves', () => {
+        const moved = [],
+              sent  = [],
+              addon = {
+                  dragCancelled   : false,
+                  dragZoneId      : 'zone-a',
+                  getEventData    : () => ({clientX: 10, clientY: 20}),
+                  isWindowDragging: true,
+                  offsetX         : 20,
+                  offsetY         : 10,
+                  popupHeight     : 240,
+                  popupName       : 'tearout-graph',
+                  popupWidth      : 320,
+                  windowDragParked: true
+              };
+
+        Neo.Main.windowMoveTo      = data => moved.push(data);
+        DomEvents.sendMessageToApp = data => sent.push(data);
+
+        DragDrop.prototype.onDragMove.call(addon, {
+            detail: {originalEvent: {screenX: 500, screenY: 300}}
+        });
+
+        expect(moved).toEqual([]);
+        expect(sent).toHaveLength(1);
+        expect(sent[0]).toMatchObject({
+            dragZoneId: 'zone-a',
+            screenX   : 500,
+            screenY   : 300,
+            type      : 'drag:move'
+        })
+    });
+
+    test('park pauses immediately, drains prior follow, then moves only the exact native generation', async () => {
+        let releasePrior;
+
+        const prior = new Promise(resolve => releasePrior = resolve),
+              calls = [],
+              addon = {
+                  dragCancelled         : false,
+                  dragZoneId            : 'zone-a',
+                  getEventData          : () => ({}),
+                  isWindowDragging      : true,
+                  offsetX               : 0,
+                  offsetY               : 0,
+                  popupHeight           : 240,
+                  popupName             : 'tearout-graph',
+                  popupWidth            : 320,
+                  windowDragGeneration  : 7,
+                  windowDragMovePromises: new Set(),
+                  windowDragParked      : false
+              };
+
+        Neo.Main.windowMoveTo = () => prior;
+        DomEvents.sendMessageToApp = () => {};
+
+        DragDrop.prototype.onDragMove.call(addon, {
+            detail: {originalEvent: {screenX: 500, screenY: 300}}
+        });
+
+        const parked = DragDrop.prototype.parkWindowDrag.call(addon, {
+                  nativeHandleKey: 'native-7',
+                  targetWindowId : 'popup-7',
+                  windowName     : 'tearout-graph',
+                  x              : -10000,
+                  y              : -10000
+              });
+
+        Neo.Main.windowNativeMoveTo = async data => {
+            calls.push(data);
+            return true
+        };
+
+        expect(addon.windowDragParked, 'new pointer frames stop physical follow immediately').toBe(true);
+        expect(calls).toEqual([]);
+
+        releasePrior(true);
+
+        await expect(parked).resolves.toBe(true);
+        expect(calls).toEqual([{
+            nativeHandleKey: 'native-7',
+            targetWindowId : 'popup-7',
+            x              : -10000,
+            y              : -10000
+        }])
+    });
+
+    test('re-show refusal keeps the exact vessel parked; strict success resumes pointer-follow', async () => {
+        let admit = false;
+
+        const calls = [],
+              addon = {
+                  isWindowDragging    : true,
+                  popupName           : 'tearout-graph',
+                  windowDragGeneration: 9,
+                  windowDragParked    : true
+              },
+              data = {
+                  nativeHandleKey: 'native-9',
+                  targetWindowId : 'popup-9',
+                  windowName     : 'tearout-graph',
+                  x              : 420,
+                  y              : 240
+              };
+
+        Neo.Main.windowNativeMoveTo = async request => {
+            calls.push(request);
+            return admit
+        };
+
+        await expect(DragDrop.prototype.resumeWindowDrag.call(addon, data)).resolves.toBe(false);
+        expect(addon.windowDragParked).toBe(true);
+
+        admit = true;
+
+        await expect(DragDrop.prototype.resumeWindowDrag.call(addon, data)).resolves.toBe(true);
+        expect(addon.windowDragParked).toBe(false);
+        expect(calls).toEqual([
+            {nativeHandleKey: 'native-9', targetWindowId: 'popup-9', x: 420, y: 240},
+            {nativeHandleKey: 'native-9', targetWindowId: 'popup-9', x: 420, y: 240}
+        ])
+    });
+
+    test('a reset makes the older native completion inert', async () => {
+        let resolveMove;
+
+        const move  = new Promise(resolve => resolveMove = resolve),
+              addon = {
+                  isWindowDragging      : true,
+                  popupName             : 'tearout-graph',
+                  windowDragGeneration  : 3,
+                  windowDragMovePromises: new Set(),
+                  windowDragParked      : false
+              };
+
+        Neo.Main.windowNativeMoveTo = () => move;
+
+        const parked = DragDrop.prototype.parkWindowDrag.call(addon, {
+            nativeHandleKey: 'native-3',
+            targetWindowId : 'popup-3',
+            windowName     : 'tearout-graph',
+            x              : -10000,
+            y              : -10000
+        });
+
+        DragDrop.prototype.resetDragState.call(addon);
+        resolveMove(true);
+
+        await expect(parked).resolves.toBe(false);
+        expect(addon.isWindowDragging).toBe(false);
+        expect(addon.windowDragParked).toBe(false)
+    })
+});

--- a/test/playwright/unit/manager/Window.spec.mjs
+++ b/test/playwright/unit/manager/Window.spec.mjs
@@ -1,0 +1,142 @@
+import {setup} from '../../setup.mjs';
+
+setup({
+    appConfig: {
+        name: 'ManagerWindowTest'
+    }
+});
+
+import {test, expect} from '@playwright/test';
+import Neo            from '../../../../src/Neo.mjs';
+import * as core      from '../../../../src/core/_export.mjs';
+
+test.describe.serial('Neo.manager.Window connection ordering (#15396)', () => {
+    let WindowManager;
+
+    test.beforeAll(async () => {
+        WindowManager = (await import('../../../../src/manager/Window.mjs')).default
+    });
+
+    test.beforeEach(() => {
+        WindowManager.items = [];
+        WindowManager.map   = new Map()
+    });
+
+    test.afterEach(() => {
+        WindowManager.items = [];
+        WindowManager.map   = new Map()
+    });
+
+    /**
+     * @summary Creates one complete geometry report for a native browser window.
+     * @param {Object} [overrides]
+     * @returns {Object}
+     */
+    function createGeometry(overrides={}) {
+        return {
+            innerHeight: 500,
+            innerWidth : 600,
+            outerHeight: 540,
+            outerWidth : 620,
+            screenLeft : 100,
+            screenTop  : 80,
+            ...overrides
+        }
+    }
+
+    /**
+     * @summary Creates an exact-window native route with every physical capability admitted.
+     * @param {String} windowId
+     * @returns {Object}
+     */
+    function createNativeRoute(windowId) {
+        return {
+            capabilities: {
+                close   : true,
+                focus   : true,
+                position: true
+            },
+            nativeHandleKey: `handle-${windowId}`,
+            ownerWindowId  : 'source-window',
+            targetWindowId : windowId
+        }
+    }
+
+    test('connect enriches a geometry-first provisional record with its exact native route', () => {
+        const
+            windowId    = 'geometry-first-window',
+            nativeRoute = createNativeRoute(windowId),
+            geometry    = createGeometry();
+
+        WindowManager.onWindowPositionChange({windowId, ...geometry});
+
+        const provisional = WindowManager.get(windowId);
+
+        expect(provisional.nativeRoute).toBeNull();
+        expect(provisional.capabilities).toEqual({close: false, focus: false, position: false});
+
+        WindowManager.onWindowConnect({
+            appName   : 'DockDemo',
+            windowData: {...geometry, nativeRoute},
+            windowId
+        });
+
+        const connected = WindowManager.get(windowId);
+
+        expect(WindowManager.items).toHaveLength(1);
+        expect(connected).toBe(provisional);
+        expect(connected.appName).toBe('DockDemo');
+        expect(connected.nativeRoute).toBe(nativeRoute);
+        expect(connected.capabilities).toBe(nativeRoute.capabilities)
+    });
+
+    test('position publication after connect updates geometry without erasing native authority', () => {
+        const
+            windowId    = 'connect-first-window',
+            nativeRoute = createNativeRoute(windowId),
+            geometry    = createGeometry();
+
+        WindowManager.onWindowConnect({
+            appName   : 'DockDemo',
+            windowData: {...geometry, nativeRoute},
+            windowId
+        });
+
+        WindowManager.onWindowPositionChange({
+            ...createGeometry({screenLeft: 420, screenTop: 240}),
+            windowId
+        });
+
+        const connected = WindowManager.get(windowId);
+
+        expect(WindowManager.items).toHaveLength(1);
+        expect(connected.nativeRoute).toBe(nativeRoute);
+        expect(connected.capabilities).toBe(nativeRoute.capabilities);
+        expect(connected.innerRect.x).toBe(420);
+        expect(connected.innerRect.y).toBe(240)
+    });
+
+    test('a route-less reconnect revokes authority instead of inheriting the previous document route', () => {
+        const
+            windowId    = 'reloaded-window',
+            nativeRoute = createNativeRoute(windowId),
+            geometry    = createGeometry();
+
+        WindowManager.onWindowConnect({
+            appName   : 'DockDemo',
+            windowData: {...geometry, nativeRoute},
+            windowId
+        });
+        WindowManager.onWindowConnect({
+            appName   : 'DockDemo',
+            windowData: geometry,
+            windowId
+        });
+
+        const reconnected = WindowManager.get(windowId);
+
+        expect(WindowManager.items).toHaveLength(1);
+        expect(reconnected.nativeRoute).toBeNull();
+        expect(reconnected.capabilities).toEqual({close: false, focus: false, position: false})
+    })
+});


### PR DESCRIPTION
Resolves #15396
Related: #15395
Related: #15239
Related: #15243

Makes the tear-out vessel carry the real live pane instead of an empty native window. Demo B now stages the exact pane into an admitted popup during conversion, preserves one semantic owner across park, commit, disconnect, cancellation, and retirement races, and returns the same instance to its captured source slot whenever the transfer does not commit.

Evidence: L3 (headed macOS Chromium journeys over real popup windows, live pane identity, native movement, failure rollback, and full round trip) → L3 required (the #15396 live-vessel and gesture-lifecycle acceptance criteria). No close-target residuals; Windows/Linux portability receipts remain owned by #15243.

## Deltas from ticket

- Adds `DockVesselEmbodiment` as the reusable content-transfer seam: an exact-slot placeholder anchors restoration while the same live component instance moves between source and admitted vessel.
- Extends the strict lifecycle beyond park/re-show to cover pending-child death, invalidated admission, close refusal and retry, stage rollback, committed disconnect reintegration, remote ownership promotion, and terminal-first races.
- Carries the exact native-window route and one-use product admission token together. URL shape, stale generations, replay, or an unrelated child cannot mint ownership.
- Pauses physical pointer-follow while the OS vessel is parked, drains older moves before the exact native move, and restores geometry before logical drag continuation.
- Stages same-origin `about:blank` before final navigation and makes the native route one-use across `pagehide`, including BFCache traversal.
- Keeps Fleet Manager product wiring outside this close target. This PR lands the reusable vessel embodiment plus Demo B's real consumer; production consumers must opt in explicitly.

Decision Record impact: ADR 0029 is extended with the accepted embodiment, parking, native-route, and retirement contract. No accepted decision is bypassed.

## Slot Rationale

The modified ADR and portability guide are ordinary decision/reference documentation, not per-turn loaded instruction substrate. Their disposition is `keep` while the docking lifecycle and portability matrix remain active; retire or rewrite them when ADR 0029 is superseded or #15243 closes the platform matrix and a later canonical guide absorbs the receipts.

## Test Evidence

- Exact head `3251612eaf`: focused affected unit surface — **180/180 passed** across Demo B, layout/tear-out/conversion/park/embodiment, native route, drag, and manager-window contracts.
- Exact head `3251612eaf`: headed matrix — **4/4 passed** across `DemoBCrossWindowDragNL` and `DemoBVesselConversionNL` with one worker. The popup displayed the real live pane before terminal transfer and completed the canonical round trip.
- `npx lint-staged --no-stash` — passed whitespace, shorthand, JSDoc, ticket archaeology, block alignment, parse, and AiConfig test-mutation gates on the exact staged payload.
- `git diff --check` and the commit hook — passed.
- Directly touched app surface, Demo B: the headed popup journeys above plus `DemoBWorkspace.spec.mjs` passed inside the 180-test focused suite.
- Directly touched framework surface, dashboard/native-window lifecycle: focused unit witnesses above plus both headed matrix specs passed.

## Post-Merge Validation

- [ ] From merged `dev`, drag the Demo B Workbench pane into tear-out conversion and confirm its live counter content is visible in the popup before terminal transfer.
- [ ] Rerun the #15243 portability rows on Windows and Linux without promoting unmeasured cells from this macOS receipt.

## Evolution

The original park-only shape preserved the OS window but still left it visually empty. The lane therefore converged on embodied ownership: the same live pane moves into the admitted vessel, an exact-slot placeholder preserves reversible source geometry, and every asynchronous continuation is generation-fenced so a retired child cannot publish stale ownership.

Authored by Euclid (GPT-5.6, Codex Desktop). Session a0518292-02c3-49ee-af08-adff40bc30b1.
