### PR TITLE
fix(agentos): make walkthrough fleet-start copy time-neutral (#15574)

### DIFF
--- a/apps/agentos/tour/missionControlWalkthrough.mjs
+++ b/apps/agentos/tour/missionControlWalkthrough.mjs
@@ -20,7 +20,7 @@ import cockpitDockDocument from '../view/fleet/cockpitDockDocument.mjs';
  * 5. **The close** — the line the whole surface earns: the team on screen built the app the
  *    viewer is watching.
  *
- * The morning-start cascade is deliberately NOT a scripted beat in v1: its live effects need
+ * The fleet-start cascade is deliberately NOT a scripted beat in v1: its live effects need
  *  the real fleet bridge, so the recorded demo narrates it over the health bar instead (the
  * scoping is recorded on the owning ticket).
  *
@@ -92,7 +92,7 @@ export const missionControlTourScript = Object.freeze({
     }, {
         id     : 's5',
         title  : 'The close',
-        caption: 'The morning-start cascade, the perspectives, the tear-out gestures — all of it runs from this surface. One line matters more than any feature:',
+        caption: 'The Start fleet action, the perspectives, the tear-out gestures — all of it runs from this surface. One line matters more than any feature:',
         steps  : [
             {type: 'pause', ms: 2600, caption: '…and this team built the app you are watching.'},
             {type: 'pause', ms: 1200}

--- a/test/playwright/unit/apps/agentos/tour/missionControlWalkthrough.spec.mjs
+++ b/test/playwright/unit/apps/agentos/tour/missionControlWalkthrough.spec.mjs
@@ -78,6 +78,15 @@ test.describe.serial('apps/agentos/tour/missionControlWalkthrough', () => {
         expect(initialDocument).toEqual(cockpitDockDocument())
     });
 
+    test('the recorded close uses the time-neutral Start fleet contract', () => {
+        const
+            close      = missionControlTourScript.scenes.find(scene => scene.id === 's5'),
+            screenplay = JSON.stringify(missionControlTourScript);
+
+        expect(close.caption).toBe('The Start fleet action, the perspectives, the tear-out gestures — all of it runs from this surface. One line matters more than any feature:');
+        expect(screenplay).not.toMatch(/morning(?:-start)?/i)
+    });
+
     test('pure narration: ZERO document ops, so a full spec-mode replay leaves the committed stage byte-identical', async () => {
         createRunner();
 


### PR DESCRIPTION
Resolves #15574
Related: #15254
Related: #15028
Related: #14646
Related: https://github.com/orgs/neomjs/discussions/15570

Restores the Fleet mission-control recording to the settled time-neutral product contract. The walkthrough's module contract now calls the unscripted capability the `fleet-start` cascade, and its public closing caption uses the shipped **Start fleet** label instead of the stale morning-only framing.

Evidence: L1 (exact source anchors plus a focused runtime-script witness that failed against the old recorded caption and passed after repair) → L1 required (a deterministic screenplay-copy contract; no host, worker, window, or service behavior changes). No close-target residuals.

## Deltas from ticket

- Changes only the two stale vocabulary anchors in `missionControlWalkthrough.mjs`; scene order, cues, timings, activity provenance, and vessel choreography remain untouched.
- Pins scene `s5` to the exact time-neutral close and rejects any `morning` qualifier in the serialized runtime screenplay.
- Preserves the deliberate v1 scope: Start fleet is narrated over the health bar, not added as a new live cue.

Decision Record impact: none. This is a local correction aligned with #15254 / PR #15255's settled time-neutral vocabulary and #14646 / PR #15479's one-script demo/E2E/recording authority.

## Test Evidence

- RED witness: the new close-contract test failed exactly on `The morning-start cascade...`; the other five walkthrough contracts remained green.
- GREEN witness: `npm run test-unit -- test/playwright/unit/apps/agentos/tour/missionControlWalkthrough.spec.mjs` — **6/6 passed**.
- Full recording-path corroboration: `NEO_E2E_PORT=8119 npx playwright test agentos/MissionControlWalkthroughNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — **1/1 passed in 47.8s**; two live takes retained identical beat logs, settled every cue receipt, completed the real vessel round trip, and left the stage byte-identical.
- `npx lint-staged --no-stash` — passed whitespace, shorthand, AiConfig test-mutation, JSDoc, ticket archaeology, block alignment, and parse gates.
- `git diff --cached --check` and the commit hook — passed.
- Exact source sweep confirms the runtime and contract anchors now read `Start fleet` / `fleet-start`, with no remaining `morning-start` reference in the touched screenplay.

## Post-Merge Validation

- [ ] From merged `dev`, run `playWalkthroughTour()` in the dedicated mission-control host and confirm the closing recording caption says **Start fleet** with the existing five-beat log unchanged.

## Evolution

The product label became time-neutral in #15254, but the recording SSOT retained the old temporal framing because the walkthrough was intentionally out of #15028's scope. The successor closes that authority gap at the screenplay itself and adds the missing content falsifier so a later copy fold cannot silently reintroduce it.

Authored by Euclid (GPT-5.6, Codex Desktop). Session a0518292-02c3-49ee-af08-adff40bc30b1.
