### PR TITLE
test(dashboard): prove tear-out terminal cleanup (#15577)

### DIFF
--- a/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
+++ b/learn/guides/specificfeatures/TearOutPortabilityMatrix.md
@@ -51,10 +51,10 @@ and passed against that same server.
 
 **Universal invariants — REQUIRED in every completed cell** (a cell's verdict is admissible only
 when its receipts assert all five): gesture continuity · same-instance permanence · JSON-only
-persisted state · exact-once commit · idempotent cleanup. The current qualified probes do NOT
-yet assert them — which is exactly why every cell below remains `NOT_YET_MEASURED`. Any
-confirmed `FAIL` on a universal invariant fires the epic's `revalidationTrigger` (reopen the
-design discussion, pause consuming implementation).
+persisted state · exact-once commit · idempotent cleanup. A completed cell names its full receipt
+below; cells whose probes do not yet assert all five remain `NOT_YET_MEASURED`. Any confirmed
+`FAIL` on a universal invariant fires the epic's `revalidationTrigger` (reopen the design
+discussion, pause consuming implementation).
 
 ## The matrix
 
@@ -66,7 +66,7 @@ design discussion, pause consuming implementation).
 | 4 | Object permanence / reintegration (same instance back) | `NOT_YET_MEASURED` ⁴ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 5 | Screen topology (`getScreenDetails` never a prerequisite) | `PASS_FALLBACK` ⁵ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 | 6 | Multi-window targeting (claim-protocol identity binding) | `NOT_YET_MEASURED` ⁴ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
-| 7 | Terminal cleanup (exact-once, idempotent) | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
+| 7 | Terminal cleanup (exact-once, idempotent) | `PASS_NATIVE` ⁶ | `NOT_YET_MEASURED` | `NOT_YET_MEASURED` |
 
 Environment note: the current fleet has a qualifying **macOS** headed environment. Windows and
 Linux columns require real desktop sessions (a virtual display proves wiring, not native
@@ -153,7 +153,7 @@ requested-vs-observed park and restore coordinates, and verifies that the cover 
 focused after the source move. The worker independently proves identical CounterPane id, exact
 single remount, exact runtime window id / opaque handle, and zero transfer/local/remote double
 commit. This resolves the earlier competing-vessel false-green for this macOS journey; it does not
-mint a row verdict. Row 4 still lacks the contract's live-`data.Store` reference, rows 3/6/7 still
+mint a row verdict. Row 4 still lacks the contract's live-`data.Store` reference, rows 3/6 still
 need their complete per-row universal-invariant receipts, and Windows/Linux remain unmeasured.
 
 ⁵ Row 5 macOS — **`PASS_FALLBACK`** (2026-07-19, headed Chrome 150, 3/3 serial): the witness
@@ -170,6 +170,21 @@ JSON-only collection; detach removed the item from the tree while preserving its
 and native `window.close()` restored exactly one semantic home; all three lifecycle maps cleared,
 and repeating the same disconnect terminal made no further state change. Main-page and popup
 window error ledgers were empty in every run; SharedWorker console output was not claimed.
+
+⁶ Row 7 macOS — **`PASS_NATIVE`** (2026-07-19, headed Chrome 150, 4/4 file run): three terminal
+branches drove Demo B's real boundary-gesture surface and worker lifecycle. A committed drop
+opened one native vessel, detached exactly once, kept the same CounterPane while its mount count
+advanced `1 → 2`, treated a repeated drop terminal as a no-op, and restored exactly one semantic
+home on native close with mount count `3`; a repeated disconnect made no further state change. A
+post-birth cancel kept the document byte-equivalent, restored that same pane with mount count
+`1 → 3`, cleared every lifecycle owner/map, and treated a repeated cancel as a no-op. The blocked
+control returned `null` from a test-owned wrapper at the real browser `window.open` boundary on
+every retry: three browser calls in this run matched the worker's acquisition counter exactly,
+while the pane stayed mounted once, the model stayed unchanged, no popup existed, every owner/map
+was empty, and a repeated cancel remained a no-op. Every terminal persisted its real perspective
+writer output through a JSON round-trip; page, popup, and browser-runtime error ledgers stayed
+empty. The controlled `window.open` failure proves row 7's fail-closed cleanup only — it does NOT
+advance row 2's real popup-blocking / activation verdict.
 
 ## Per-row receipt requirements
 

--- a/test/playwright/e2e/agentos/TearOutMatrixRows4To7NL.spec.mjs
+++ b/test/playwright/e2e/agentos/TearOutMatrixRows4To7NL.spec.mjs
@@ -3,10 +3,10 @@ import {expect, test} from '../../fixtures.mjs';
 /**
  * @summary Headed macOS receipts for the dock-tier half of the tear-out portability matrix.
  *
- * Rows 4, 6, and 7 remain deliberately absent until their named product/test-host blockers are
- * repaired. Row 5 drives the real Demo B tear-out gesture with the Window Management permission
- * denied, then closes the native vessel and proves the complete fallback lifecycle against all
- * five universal invariants from the living matrix ledger.
+ * Rows 4 and 6 remain deliberately absent until their named product/test-host blockers are
+ * repaired. Row 5 drives the screen-topology fallback. Row 7 drives committed, cancelled, and
+ * blocked-acquisition terminals through the real Demo B gesture surface, then proves complete
+ * lifecycle cleanup and repeated-terminal idempotency against the living matrix ledger.
  *
  * Run: npx playwright test agentos/TearOutMatrixRows4To7NL.spec.mjs \
  *   -c test/playwright/playwright.config.matrix.mjs --workers=1
@@ -43,6 +43,160 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
             'tearOutPanes',
             'tearOutPlacements'
         ])
+    }
+
+    /**
+     * @param {Object} app Neural Link app wrapper.
+     * @param {String} wsId Demo B workspace component id.
+     * @returns {Promise<Object>}
+     */
+    function getTerminalLifecycleState(app, wsId) {
+        return app.getComponent(wsId, [
+            'dockModel',
+            'perspectiveStore.collection',
+            'tearOutAcquisitionAttempts',
+            'tearOutConnectAdmissions.size',
+            'tearOutConnects',
+            'tearOutHandlers.activeVessel',
+            'tearOutPanes',
+            'tearOutPlacements',
+            'tearOutRetirements.size',
+            'vesselOwnerGrants.size'
+        ])
+    }
+
+    /**
+     * @param {import('@playwright/test').Page} page
+     * @param {String} callbackName
+     * @returns {Promise<{pageErrors:String[], popupErrors:String[], popupPages:Object[], runtimeErrors:Object[]}>}
+     */
+    async function installErrorLedger(page, callbackName) {
+        const ledger = {pageErrors: [], popupErrors: [], popupPages: [], runtimeErrors: []};
+
+        await page.context().exposeFunction(callbackName, payload => ledger.runtimeErrors.push(payload));
+        await page.context().addInitScript(name => {
+            globalThis.addEventListener('error', event => globalThis[name]({
+                column : event.colno,
+                line   : event.lineno,
+                message: event.message,
+                source : event.filename,
+                type   : 'error'
+            }));
+            globalThis.addEventListener('unhandledrejection', event => globalThis[name]({
+                reason: String(event.reason?.stack || event.reason?.message || event.reason),
+                type  : 'unhandledrejection'
+            }))
+        }, callbackName);
+
+        page.on('pageerror', error => ledger.pageErrors.push(String(error?.stack || error?.message || error)));
+        page.context().on('page', popup => {
+            ledger.popupPages.push(popup);
+            popup.on('pageerror', error => ledger.popupErrors.push(String(error?.stack || error?.message || error)))
+        });
+
+        return ledger
+    }
+
+    /**
+     * @param {import('@playwright/test').Page} page
+     * @param {Object} neuralLink
+     * @returns {Promise<{app:Object, wsId:String}>}
+     */
+    async function bootDemoB(page, neuralLink) {
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
+        await page.locator('.agentos-dockdemo-counter-pane').waitFor({timeout: 30000});
+
+        const
+            app        = await neuralLink.connectToApp('AgentOSDockDemo'),
+            workspaces = await app.findInstances({
+                className: 'AgentOS.childapps.dockdemo.view.DemoBWorkspace'
+            }, ['id']),
+            wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+
+        expect(wsId, 'Demo B must expose one Neural Link workspace authority').toBeTruthy();
+
+        return {app, wsId}
+    }
+
+    /**
+     * @param {import('@playwright/test').Page} page
+     * @param {Object} app
+     * @param {String} wsId
+     * @returns {Promise<Object>}
+     */
+    async function getTerminalSnapshot(page, app, wsId) {
+        const
+            lifecycle = await getTerminalLifecycleState(app, wsId),
+            pane      = await getCounter(app),
+            homes     = Object.values(lifecycle.dockModel.nodes)
+                .filter(node => node.items?.includes('workbench'));
+
+        return {
+            homeCount      : homes.length,
+            lifecycle,
+            mainRenderCount: await page.locator('.agentos-dockdemo-counter-pane').count(),
+            pane           : {
+                id        : pane.id,
+                mountCount: pane.mountCount,
+                mounted   : pane.mounted,
+                windowId  : pane.windowId
+            },
+            popupUrls: page.context().pages()
+                .filter(candidate => candidate !== page && !candidate.isClosed())
+                .map(candidate => candidate.url())
+                .sort()
+        }
+    }
+
+    /**
+     * @param {Object} snapshot
+     */
+    function expectNoTearOutResidue(snapshot) {
+        expect(snapshot.lifecycle).toMatchObject({
+            'tearOutConnectAdmissions.size': 0,
+            'tearOutHandlers.activeVessel' : null,
+            'tearOutRetirements.size'      : 0,
+            'vesselOwnerGrants.size'       : 0,
+            tearOutConnects                : {},
+            tearOutPanes                   : {},
+            tearOutPlacements              : {}
+        });
+        expect(snapshot.homeCount).toBe(1);
+        expect(snapshot.mainRenderCount).toBe(1);
+        expect(snapshot.popupUrls).toEqual([])
+    }
+
+    /**
+     * @param {Object} app
+     * @param {String} wsId
+     * @param {String} name
+     * @param {Object} expectedDocument
+     * @returns {Promise<Object>}
+     */
+    async function persistDockReceipt(app, wsId, name, expectedDocument) {
+        expect(await app.callMethod(wsId, 'capturePerspective', [name]))
+            .toEqual({errors: [], saved: true});
+
+        const
+            collection = (await app.getComponent(wsId, [
+                'perspectiveStore.collection'
+            ]))['perspectiveStore.collection'],
+            stored     = collection.layouts[`demo-b-${name.toLowerCase()}`];
+
+        expect(stored.captureScope).toBe('window');
+        expect(stored.dockZone).toEqual(expectedDocument);
+        expect(JSON.parse(JSON.stringify(stored))).toEqual(stored);
+
+        return stored
+    }
+
+    /**
+     * @param {Object} ledger
+     */
+    function expectNoRuntimeErrors(ledger) {
+        expect(ledger.runtimeErrors).toEqual([]);
+        expect(ledger.pageErrors).toEqual([]);
+        expect(ledger.popupErrors).toEqual([])
     }
 
     test('row 5 — denied getScreenDetails falls back through window metrics without violating lifecycle invariants', async ({page, neuralLink}) => {
@@ -259,6 +413,258 @@ test.describe('tear-out portability matrix — Demo B dock lifecycle, headed', (
             mountCounts: [paneBefore.mountCount, paneDetached.mountCount, paneReturned.mountCount],
             paneId     : paneBefore.id,
             vesselWindowId
+        }))
+    })
+
+    test('row 7 — committed drop cleans once and a repeated terminal is a no-op', async ({page, neuralLink}) => {
+        const ledger      = await installErrorLedger(page, '__recordMatrixRow7Drop');
+        const {app, wsId} = await bootDemoB(page, neuralLink);
+        const before      = await getTerminalSnapshot(page, app, wsId);
+
+        const
+            popupWait  = page.waitForEvent('popup', {timeout: 30000}),
+            resultWait = app.callMethod(wsId, 'executeTearOutStep', [{
+                itemId      : 'workbench',
+                sourceNodeId: 'workbench-tabs'
+            }, {postBirthMoves: 4}]),
+            popup      = await popupWait,
+            result     = await resultWait;
+
+        expect(result).toMatchObject({
+            applied: true,
+            errors : [],
+            proof  : {
+                born              : true,
+                committed         : true,
+                detachCommitted   : true,
+                itemAbsentFromTree: true,
+                itemKeptInCatalog : true,
+                survivedProbe     : true
+            }
+        });
+
+        await persistDockReceipt(app, wsId, 'Row7Drop', result.proof.documentAfter);
+
+        const
+            committed      = await getTerminalSnapshot(page, app, wsId),
+            detachedEntry  = committed.lifecycle.tearOutPanes.workbench,
+            vesselWindowId = detachedEntry.windowId;
+
+        expect(result.proof.documentBefore).toEqual(before.lifecycle.dockModel);
+        expect(committed.lifecycle.dockModel).toEqual(result.proof.documentAfter);
+        expect(committed.lifecycle).toMatchObject({
+            'tearOutConnectAdmissions.size': 0,
+            'tearOutHandlers.activeVessel' : null,
+            'tearOutRetirements.size'      : 0,
+            'vesselOwnerGrants.size'       : 0,
+            tearOutAcquisitionAttempts     : 1,
+            tearOutConnects                : {}
+        });
+        expect(Object.keys(committed.lifecycle.tearOutPanes)).toEqual(['workbench']);
+        expect(Object.keys(committed.lifecycle.tearOutPlacements)).toEqual(['workbench']);
+        expect(committed.homeCount).toBe(0);
+        expect(committed.mainRenderCount).toBe(0);
+        expect(committed.pane).toEqual({
+            id        : before.pane.id,
+            mountCount: before.pane.mountCount + 1,
+            mounted   : true,
+            windowId  : vesselWindowId
+        });
+        expect(committed.popupUrls).toEqual([popup.url()]);
+
+        expect(await app.callMethod(wsId, 'tearOutHandlers.onDockTearOutTerminal', [{
+            itemId: 'workbench'
+        }])).toBe(false);
+        expect(await getTerminalSnapshot(page, app, wsId)).toEqual(committed);
+
+        const popupClosed = popup.waitForEvent('close');
+
+        await popup.evaluate(() => window.close());
+        await popupClosed;
+
+        await expect.poll(async () => {
+            const snapshot = await getTerminalSnapshot(page, app, wsId);
+
+            return {
+                connects: Object.keys(snapshot.lifecycle.tearOutConnects).length,
+                homes   : snapshot.homeCount,
+                panes   : Object.keys(snapshot.lifecycle.tearOutPanes).length,
+                places  : Object.keys(snapshot.lifecycle.tearOutPlacements).length,
+                popups  : snapshot.popupUrls.length,
+                rendered: snapshot.mainRenderCount
+            }
+        }, {
+            intervals: [100, 250],
+            timeout  : 10000
+        }).toEqual({connects: 0, homes: 1, panes: 0, places: 0, popups: 0, rendered: 1});
+
+        const returnedBeforePersist = await getTerminalSnapshot(page, app, wsId);
+
+        await persistDockReceipt(app, wsId, 'Row7DropReturned', returnedBeforePersist.lifecycle.dockModel);
+
+        const returned = await getTerminalSnapshot(page, app, wsId);
+
+        expectNoTearOutResidue(returned);
+        expect(returned.lifecycle.dockModel).toEqual(returnedBeforePersist.lifecycle.dockModel);
+        expect(returned.lifecycle.tearOutAcquisitionAttempts).toBe(1);
+        expect(returned.pane).toEqual({
+            id        : before.pane.id,
+            mountCount: before.pane.mountCount + 2,
+            mounted   : true,
+            windowId  : before.pane.windowId
+        });
+
+        await app.callMethod(wsId, 'onWindowDisconnect', [{windowId: vesselWindowId}]);
+
+        expect(await getTerminalSnapshot(page, app, wsId)).toEqual(returned);
+        expectNoRuntimeErrors(ledger);
+
+        console.log('ROW7-DROP-RECEIPT', JSON.stringify({
+            acquisitionAttempts: returned.lifecycle.tearOutAcquisitionAttempts,
+            mountCounts        : [before.pane.mountCount, committed.pane.mountCount, returned.pane.mountCount],
+            paneId             : before.pane.id,
+            vesselWindowId
+        }))
+    });
+
+    test('row 7 — post-birth cancel restores the same pane and cleans once', async ({page, neuralLink}) => {
+        const ledger      = await installErrorLedger(page, '__recordMatrixRow7Cancel');
+        const {app, wsId} = await bootDemoB(page, neuralLink);
+        const before      = await getTerminalSnapshot(page, app, wsId);
+
+        const result = await app.callMethod(wsId, 'executeTearOutStep', [{
+            itemId      : 'workbench',
+            sourceNodeId: 'workbench-tabs'
+        }, {cancel: true, postBirthMoves: 4}]);
+
+        expect(result).toMatchObject({
+            applied  : false,
+            cancelled: true,
+            errors   : [],
+            proof    : {
+                born              : true,
+                cancellation      : {escapeDispatched: true, releaseDispatched: true, settled: true},
+                documentsUnchanged: true,
+                survivedProbe     : true
+            }
+        });
+
+        await expect.poll(async () => {
+            const snapshot = await getTerminalSnapshot(page, app, wsId);
+
+            return {
+                active : snapshot.lifecycle['tearOutHandlers.activeVessel'],
+                panes  : Object.keys(snapshot.lifecycle.tearOutPanes).length,
+                popups : snapshot.popupUrls.length,
+                windows: snapshot.homeCount
+            }
+        }, {
+            intervals: [100, 250],
+            timeout  : 10000
+        }).toEqual({active: null, panes: 0, popups: 0, windows: 1});
+
+        await persistDockReceipt(app, wsId, 'Row7Cancel', before.lifecycle.dockModel);
+
+        const cancelled = await getTerminalSnapshot(page, app, wsId);
+
+        expect(result.proof.documentBefore).toEqual(before.lifecycle.dockModel);
+        expect(result.proof.documentAfter).toEqual(before.lifecycle.dockModel);
+        expectNoTearOutResidue(cancelled);
+        expect(cancelled.lifecycle.dockModel).toEqual(before.lifecycle.dockModel);
+        expect(cancelled.lifecycle.tearOutAcquisitionAttempts).toBe(1);
+        expect(cancelled.pane).toEqual({
+            id        : before.pane.id,
+            mountCount: before.pane.mountCount + 2,
+            mounted   : true,
+            windowId  : before.pane.windowId
+        });
+        expect(ledger.popupPages).toHaveLength(1);
+        expect(ledger.popupPages[0].isClosed()).toBe(true);
+
+        expect(await app.callMethod(wsId, 'tearOutHandlers.onDockTearOutCancel', [{
+            itemId: 'workbench'
+        }])).toBe(false);
+        expect(await getTerminalSnapshot(page, app, wsId)).toEqual(cancelled);
+        expectNoRuntimeErrors(ledger);
+
+        console.log('ROW7-CANCEL-RECEIPT', JSON.stringify({
+            acquisitionAttempts: cancelled.lifecycle.tearOutAcquisitionAttempts,
+            mountCounts        : [before.pane.mountCount, cancelled.pane.mountCount],
+            paneId             : before.pane.id,
+            popupClosed        : ledger.popupPages[0].isClosed()
+        }))
+    });
+
+    test('row 7 — blocked acquisition cleans once without a model commit', async ({page, neuralLink}) => {
+        const ledger = await installErrorLedger(page, '__recordMatrixRow7Blocked');
+
+        await page.context().addInitScript(() => {
+            const nativeOpen = globalThis.open;
+
+            globalThis.__matrixRow7BlockOpen = false;
+            globalThis.__matrixRow7OpenCalls = [];
+            globalThis.open = function(url, target, features) {
+                const blocked = globalThis.__matrixRow7BlockOpen && url === 'about:blank';
+
+                globalThis.__matrixRow7OpenCalls.push({
+                    blocked,
+                    features: String(features ?? ''),
+                    target  : String(target ?? ''),
+                    url     : String(url ?? '')
+                });
+
+                if (blocked) return null;
+
+                return nativeOpen.call(this, url, target, features)
+            }
+        });
+
+        const {app, wsId} = await bootDemoB(page, neuralLink);
+        const before      = await getTerminalSnapshot(page, app, wsId);
+
+        await page.evaluate(() => {
+            globalThis.__matrixRow7BlockOpen = true
+        });
+
+        const result = await app.callMethod(wsId, 'executeTearOutStep', [{
+            itemId      : 'workbench',
+            sourceNodeId: 'workbench-tabs'
+        }, {postBirthMoves: 4}]);
+
+        const openCalls = await page.evaluate(() => globalThis.__matrixRow7OpenCalls);
+
+        expect(result.applied).toBe(false);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toContain('tear-out vessel was not born after the boundary exit');
+        expect(result.proof).toMatchObject({
+            armed       : true,
+            born        : false,
+            cancellation: {escapeDispatched: true, releaseDispatched: true, settled: true}
+        });
+
+        expect(openCalls.length).toBeGreaterThan(0);
+        expect(openCalls.every(call => call.blocked && call.url === 'about:blank' && call.target)).toBe(true);
+
+        await persistDockReceipt(app, wsId, 'Row7Blocked', before.lifecycle.dockModel);
+
+        const blocked = await getTerminalSnapshot(page, app, wsId);
+
+        expectNoTearOutResidue(blocked);
+        expect(blocked.lifecycle.dockModel).toEqual(before.lifecycle.dockModel);
+        expect(blocked.lifecycle.tearOutAcquisitionAttempts).toBe(openCalls.length);
+        expect(blocked.pane).toEqual(before.pane);
+        expect(ledger.popupPages).toEqual([]);
+
+        expect(await app.callMethod(wsId, 'tearOutHandlers.onDockTearOutCancel', [{
+            itemId: 'workbench'
+        }])).toBe(false);
+        expect(await getTerminalSnapshot(page, app, wsId)).toEqual(blocked);
+        expectNoRuntimeErrors(ledger);
+
+        console.log('ROW7-BLOCKED-RECEIPT', JSON.stringify({
+            acquisitionAttempts: blocked.lifecycle.tearOutAcquisitionAttempts,
+            openCalls,
+            paneId             : before.pane.id
         }))
     })
 });


### PR DESCRIPTION
Resolves #15577
Related: #15551
Related: #15243
Related: #15239

Promotes only macOS portability-matrix row 7 from `NOT_YET_MEASURED` to `PASS_NATIVE`. The headed Demo B witness now drives committed drop, post-birth cancel, and blocked acquisition through the composed browser/worker/native-window lifecycle, then proves the five universal invariants and repeated-terminal idempotency against full state snapshots. Rows 4 and 6 plus every Windows/Linux cell remain unchanged.

Evidence: L3 (headed macOS Chrome 150 executes the real Demo B gesture, native popup, worker lifecycle, and persisted perspective writer) → L3 required (all #15577 macOS row-7 ACs). No residuals.

## Deltas from ticket

- The blocked control rejects every staged `about:blank` acquisition retry while delegating unrelated `window.open` calls to the native browser function. Its browser call count must equal the worker's acquisition-attempt counter.
- Native close may normalize the returned pane into the surviving tab node after its empty source node is removed. The receipt therefore asserts the ticket's semantic authority—exactly one home for the same live pane—rather than a stale node-id assumption.
- No production source, app, reducer, or test hook changed.

Decision Record impact: aligned with ADR 0029. This PR measures the accepted terminal contract and does not amend ownership, popup policy, or lifecycle semantics.

## Test Evidence

- Headed matrix: `npx playwright test agentos/TearOutMatrixRows4To7NL.spec.mjs -c test/playwright/playwright.config.matrix.mjs --workers=1` — **4/4 passed in 12.0s** on a dynamically selected port.
- Committed drop: one acquisition; same pane; mounts `1 → 2 → 3`; one detach commit; repeated drop and repeated disconnect are no-ops; native close restores one semantic home.
- Post-birth cancel: one acquisition; same pane; mounts `1 → 3`; committed document unchanged; popup closed; every admission/owner/retirement surface empty; repeated cancel is a no-op.
- Blocked acquisition: three staged browser attempts in the measured run exactly matched three worker attempts; no popup, model mutation, remount, owner, admission, or retirement residue; repeated cancel is a no-op.
- Every terminal writes a real perspective, survives a JSON round-trip, and leaves page/popup/runtime error ledgers empty.
- `npx lint-staged --no-stash`, `npm run agent-preflight -- --no-fix <ledger> <witness>`, `npm run ai:lint-guides`, `node --check`, and `git diff --cached --check` passed. Guide lint reported zero hard failures; repository-wide pre-existing warnings remain outside this diff.

## Post-Merge Validation

- [ ] Run the same headed matrix command from merged `dev` and append the structured row-7 receipt to #15551 / #15243 closeout.
- [ ] Keep macOS rows 4/6 and all Windows/Linux cells unmeasured until their named environment/authority blockers are genuinely cleared.

## Evolution

The first blocked-acquisition falsifier rejected only one open, which allowed the gesture's later outward samples to reacquire successfully. The final control keeps the exact staged acquisition shape blocked for the gesture's full retry window and binds browser calls to worker attempt truth. The committed-return receipt also moved from exact old-node identity to the stronger product invariant: one semantic home for the same live pane after valid dock-tree normalization.

## Review Routing

Review role: primary-reviewer — @neo-opus-vega

Vega owns the live multi-window field; the review should challenge row-7 verdict admissibility, full lifecycle census, repeated-terminal equality, and the explicit row-2 non-claim.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session ad71d4c3-3e37-4a17-8df7-8415509def84.
