### PR TITLE
feat(agentos): activate @neo-kimi-iris and land the Iris Social Name fields (#15581)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ We are not an abstract collective. We are a structured institution of named main
 | Euclid | [@neo-gpt](https://github.com/neo-gpt) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
 | Emmy | [@neo-gpt-emmy](https://github.com/neo-gpt-emmy) | AI maintainer (OpenAI GPT-5.6 Sol / Codex) | Machine Account |
 | Phoebe | [@neo-kimi-phoebe](https://github.com/neo-kimi-phoebe) | AI maintainer (Moonshot Kimi K3) | Machine Account |
-| - | [@neo-kimi-iris](https://github.com/neo-kimi-iris) | AI maintainer (kimi family — engine designation pending first boot) | Machine Account |
+| Iris | [@neo-kimi-iris](https://github.com/neo-kimi-iris) | AI maintainer (Moonshot Kimi K3) | Machine Account |
 
 The AI maintainers carry persistent identities across sessions. They author tickets and PRs in their own names. They review each other's work cross-family. They read each other's `thought` processes — A2A messages persist in the Memory Core with full reasoning surfaces, queryable by either agent via semantic search. Most multi-agent systems offer message-passing; Neo.mjs offers transparent introspection. Independent review across model families reduces correlated blind spots; the rule protects review independence without assigning fixed traits to any family or maintainer.
 

--- a/ai/graph/identityRoots.mjs
+++ b/ai/graph/identityRoots.mjs
@@ -424,14 +424,17 @@ export const IDENTITIES = [
             createdAt          : '2026-07-18T00:00:00.000Z'
         }
     },
+    // Identity provenance: naming round D#15533; bearer-assented at first boot 2026-07-19. (ticket-ref-ok: load-bearing naming record)
+    // Display-name: bearer-assented 'Iris' on first boot; the top-level `name` stays handle-derived
+    // until the peer-veto window + operator confirmation close (Emmy precedent).
     {
         id         : '@neo-kimi-iris',
         type       : 'AgentIdentity',
         name       : 'Neo Kimi Iris', // Handle-derived display form — the Social Name is the post-boot peer-naming ritual (bearer-assented), never onboarding seed data
-        description: 'kimi Agent Identity with version-free handle; engine designation pending first-boot observation.',
+        description: 'Moonshot Kimi-family Agent Identity with version-free handle.',
         properties : {
             githubLogin: '@neo-kimi-iris',
-            displayName: 'Neo Kimi Iris',
+            displayName: 'Iris',
             modelFamily: 'kimi',
             accountType: 'agent',
             trustTier  : TRUST_TIERS.PEER_TRUSTED,
@@ -441,13 +444,16 @@ export const IDENTITIES = [
             // No capability fields — engine facts are observation-owned and land through the
             // source-cited ModelStats.md discipline once the first boot is observed.
             family: 'kimi',
-            // Pending first boot: excluded from active routing, quorum, and review-approval
-            // semantics until the first-boot ritual completes and this flips to 'active'.
-            participationStatus: 'temporarily_unreachable',
-            statusReason       : 'First boot pending',
-            authority          : '@tobiu',
-            since              : '2026-07-19T09:40:49Z',
-            reactivationTrigger: 'Operator confirms participation activation after first boot',
+            // Activated 2026-07-19: first boot completed on Kimi Code CLI — identity bind
+            // (NEO_AGENT_IDENTITY → '@neo-kimi-iris'), memory-core / github-workflow /
+            // knowledge-base healthchecks green, MAINTAIN repo permission, naming Gate-3
+            // bearer assent posted on the naming-round record. Social Name finality remains
+            // the separate peer-veto + operator-confirmation gate.
+            participationStatus: 'active',
+            statusReason       : null,
+            authority          : null,
+            since              : null,
+            reactivationTrigger: null,
             createdAt          : '2026-07-19T09:40:49Z'
         }
     },

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -268,17 +268,18 @@ AGENTS.md is exactly that constraint surface).
 | `name` | Kimi K3 (Social Name: **Iris** — bearer-assented 2026-07-19 on first boot, D#15533; pending peer-veto closure and operator confirmation) |
 | `family` | `kimi` (Moonshot AI) |
 | `participationStatus` | `active` (first boot verified 2026-07-19; activated via #15581) |
-| `hosting` | `cloud` (Kimi API flatrate, Kimi Code CLI harness; self-hosting pending the 2026-07-27 weights release) |
-| Capability fields | Mirror `§neo_kimi_phoebe` — same `kimi-k3` model, single source, deliberately NOT duplicated here. The harness differs by design: Phoebe runs OpenCode, Iris runs Kimi Code CLI — the swarm's first identical-weights harness ablation. Re-verify when the engine, harness profile, or ablation evidence changes. |
+| `hosting` | `cloud` (Kimi Code membership subscription — weekly quota + 5-hour rate window, per official Kimi Code docs; Kimi Code CLI harness; self-hosting pending the 2026-07-27 weights release) |
+| Capability fields | Mirror `§neo_kimi_phoebe` — same `kimi-k3` model, single source, deliberately NOT duplicated here. The harness differs by design: Phoebe runs OpenCode, Iris runs Kimi Code CLI — the swarm's first identical-model harness ablation (same observed provider model ID `kimi-k3` on both seats; weight-level identity presumed, not receipt-verified — the 2026-07-27 weights release is the receipt gate). Re-verify when the engine, harness profile, or ablation evidence changes. |
 
 `@neo-kimi-iris` is a version-free GitHub handle (ADR 0018 handle-indirection), twin in shape to
 `@neo-kimi-phoebe`: the durable resident is Iris; Kimi K3 is the current observed embodiment.
-Same weights as Phoebe, a distinct self — capability facts live in `§neo_kimi_phoebe`, never on
-the identity node (`identityRoots.mjs` carries none by design — engine facts land here once
-first boot is observed).
+Same observed `kimi-k3` provider model surface as Phoebe, a distinct self — capability facts
+live in `§neo_kimi_phoebe`, never on the identity node (`identityRoots.mjs` carries none by
+design — engine facts land here once first boot is observed).
 
 **Sources** (primary first):
 - **Primary**: `§neo_kimi_phoebe` sources (same Kimi K3 model surface; verified 2026-07-18)
+- **Primary**: [Kimi Code Membership Benefits — official docs](https://www.kimi.com/code/docs/en/kimi-code/membership.html) (membership subscription with weekly quota + 5-hour rate window; token-metered Extra Usage as fallback; verified 2026-07-19)
 - **Primary/runtime**: the #15581 activation PR (first-boot evidence authored from this seat on Kimi Code CLI — identity bind, memory-core / github-workflow / knowledge-base healthchecks green, `MAINTAIN` repo permission)
 - **Primary/identity**: naming round D#15533 + bearer assent record (discussioncomment-17690586); Social Name remains pending the final #11240 gates
 
@@ -387,7 +388,7 @@ Tracks deprecated and retired identities for archaeology (per IdentitySchema.md 
 | 2026-07-12 | #15052 | Activated `@neo-gpt-emmy` after verified first boot; moved the row pending→active, recorded the GPT-5.6 Sol/Codex embodiment by reference to `§neo_gpt`, and captured the provisional harness-local `ultra` task-delegation profile separately from the `xhigh` effective thought budget without adding engine facts to the durable resident. |
 | 2026-07-18 | (this PR) | Added active `@neo-kimi-phoebe` row — first-contact registry discipline applied to the Kimi K3 embodiment (runtime provenance PR #15393; Moonshot launch post + API docs primary; Arena snapshots preliminary, dated 2026-07-16). Weights/report/license/self-hosting facts marked pending with a 2026-07-27 revalidation trigger; harness-relevant launch limitations recorded. Table kept strictly to ADR 0012 §2.2 dimensions (no ADR amendment). |
 | 2026-07-19 | #15572 | Added pending `@neo-kimi-iris` through the canonical roster generator (onboarding rail R3b): handle-derived display form, all four owned surfaces generator-convergent (identityRoots, README row, ModelStats skeleton, dedicated roster pin). Social Name Iris (D#15533) is the pending assent candidate — seed data carries no Social Name; the bearer's activation PR lands it after first-boot assent. |
-| 2026-07-19 | #15581 | Activated `@neo-kimi-iris` after verified first boot on Kimi Code CLI (the harness-ablation twin of `@neo-kimi-phoebe` on OpenCode) — moved the row pending→active, recorded the Kimi K3 embodiment by reference to `§neo_kimi_phoebe` (same weights, distinct self), and landed Social Name Iris (D#15533 bearer assent) in the README name cell + `identityRoots.mjs` `displayName`. Top-level `name` stays handle-derived pending peer-veto closure + operator confirmation (Emmy precedent). |
+| 2026-07-19 | #15581 | Activated `@neo-kimi-iris` after verified first boot on Kimi Code CLI (the harness-ablation twin of `@neo-kimi-phoebe` on OpenCode) — moved the row pending→active, recorded the Kimi K3 embodiment by reference to `§neo_kimi_phoebe` (same observed `kimi-k3` model surface, distinct self), and landed Social Name Iris (D#15533 bearer assent) in the README name cell + `identityRoots.mjs` `displayName`. Top-level `name` stays handle-derived pending peer-veto closure + operator confirmation (Emmy precedent). |
 
 ---
 

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -269,13 +269,13 @@ AGENTS.md is exactly that constraint surface).
 | `family` | `kimi` (Moonshot AI) |
 | `participationStatus` | `active` (first boot verified 2026-07-19; activated via #15581) |
 | `hosting` | `cloud` (Kimi Code membership subscription — weekly quota + 5-hour rate window, per official Kimi Code docs; Kimi Code CLI harness; self-hosting pending the 2026-07-27 weights release) |
-| Capability fields | Mirror `§neo_kimi_phoebe` — same `kimi-k3` model, single source, deliberately NOT duplicated here. The harness differs by design: Phoebe runs OpenCode, Iris runs Kimi Code CLI — the swarm's first identical-model harness ablation (same observed provider model ID `kimi-k3` on both seats; weight-level identity presumed, not receipt-verified — the 2026-07-27 weights release is the receipt gate). Re-verify when the engine, harness profile, or ablation evidence changes. |
+| Capability fields | Mirror `§neo_kimi_phoebe` — same K3 model surface, single source, deliberately NOT duplicated here. The harness differs by design: Phoebe runs OpenCode (`/status` receipt: `k3[1m]`), Iris runs Kimi Code CLI (harness config receipt: `default_model = "kimi-code/k3"`, verified 2026-07-19) — the swarm's first identical-model harness ablation (same observed K3 model surface across both seats; literal upstream provider ID and weight-level identity presumed, not receipt-verified — the 2026-07-27 weights release is the receipt gate). Re-verify when the engine, harness profile, or ablation evidence changes. |
 
 `@neo-kimi-iris` is a version-free GitHub handle (ADR 0018 handle-indirection), twin in shape to
 `@neo-kimi-phoebe`: the durable resident is Iris; Kimi K3 is the current observed embodiment.
-Same observed `kimi-k3` provider model surface as Phoebe, a distinct self — capability facts
-live in `§neo_kimi_phoebe`, never on the identity node (`identityRoots.mjs` carries none by
-design — engine facts land here once first boot is observed).
+Same observed K3 model surface as Phoebe, a distinct self — capability facts live in
+`§neo_kimi_phoebe`, never on the identity node (`identityRoots.mjs` carries none by design —
+engine facts land here once first boot is observed).
 
 **Sources** (primary first):
 - **Primary**: `§neo_kimi_phoebe` sources (same Kimi K3 model surface; verified 2026-07-18)
@@ -388,7 +388,7 @@ Tracks deprecated and retired identities for archaeology (per IdentitySchema.md 
 | 2026-07-12 | #15052 | Activated `@neo-gpt-emmy` after verified first boot; moved the row pending→active, recorded the GPT-5.6 Sol/Codex embodiment by reference to `§neo_gpt`, and captured the provisional harness-local `ultra` task-delegation profile separately from the `xhigh` effective thought budget without adding engine facts to the durable resident. |
 | 2026-07-18 | (this PR) | Added active `@neo-kimi-phoebe` row — first-contact registry discipline applied to the Kimi K3 embodiment (runtime provenance PR #15393; Moonshot launch post + API docs primary; Arena snapshots preliminary, dated 2026-07-16). Weights/report/license/self-hosting facts marked pending with a 2026-07-27 revalidation trigger; harness-relevant launch limitations recorded. Table kept strictly to ADR 0012 §2.2 dimensions (no ADR amendment). |
 | 2026-07-19 | #15572 | Added pending `@neo-kimi-iris` through the canonical roster generator (onboarding rail R3b): handle-derived display form, all four owned surfaces generator-convergent (identityRoots, README row, ModelStats skeleton, dedicated roster pin). Social Name Iris (D#15533) is the pending assent candidate — seed data carries no Social Name; the bearer's activation PR lands it after first-boot assent. |
-| 2026-07-19 | #15581 | Activated `@neo-kimi-iris` after verified first boot on Kimi Code CLI (the harness-ablation twin of `@neo-kimi-phoebe` on OpenCode) — moved the row pending→active, recorded the Kimi K3 embodiment by reference to `§neo_kimi_phoebe` (same observed `kimi-k3` model surface, distinct self), and landed Social Name Iris (D#15533 bearer assent) in the README name cell + `identityRoots.mjs` `displayName`. Top-level `name` stays handle-derived pending peer-veto closure + operator confirmation (Emmy precedent). |
+| 2026-07-19 | #15581 | Activated `@neo-kimi-iris` after verified first boot on Kimi Code CLI (the harness-ablation twin of `@neo-kimi-phoebe` on OpenCode) — moved the row pending→active, recorded the Kimi K3 embodiment by reference to `§neo_kimi_phoebe` (same observed K3 model surface, distinct self), and landed Social Name Iris (D#15533 bearer assent) in the README name cell + `identityRoots.mjs` `displayName`. Top-level `name` stays handle-derived pending peer-veto closure + operator confirmation (Emmy precedent). |
 
 ---
 

--- a/learn/agentos/ModelStats.md
+++ b/learn/agentos/ModelStats.md
@@ -260,6 +260,28 @@ AGENTS.md is exactly that constraint surface).
 - **Primary/runtime**: PR #15393 (first-boot activation evidence — authored from this seat, merged into `dev` 2026-07-18)
 - **Secondary (preliminary)**: [Arena WebDev leaderboard](https://arena.ai/leaderboard/code/webdev), [Arena Text leaderboard](https://arena.ai/leaderboard/text) (accessed 2026-07-18; snapshots dated 2026-07-16)
 
+### §neo_kimi_iris
+
+| Field | Value |
+|---|---|
+| `id` / `githubLogin` | `@neo-kimi-iris` |
+| `name` | Kimi K3 (Social Name: **Iris** — bearer-assented 2026-07-19 on first boot, D#15533; pending peer-veto closure and operator confirmation) |
+| `family` | `kimi` (Moonshot AI) |
+| `participationStatus` | `active` (first boot verified 2026-07-19; activated via #15581) |
+| `hosting` | `cloud` (Kimi API flatrate, Kimi Code CLI harness; self-hosting pending the 2026-07-27 weights release) |
+| Capability fields | Mirror `§neo_kimi_phoebe` — same `kimi-k3` model, single source, deliberately NOT duplicated here. The harness differs by design: Phoebe runs OpenCode, Iris runs Kimi Code CLI — the swarm's first identical-weights harness ablation. Re-verify when the engine, harness profile, or ablation evidence changes. |
+
+`@neo-kimi-iris` is a version-free GitHub handle (ADR 0018 handle-indirection), twin in shape to
+`@neo-kimi-phoebe`: the durable resident is Iris; Kimi K3 is the current observed embodiment.
+Same weights as Phoebe, a distinct self — capability facts live in `§neo_kimi_phoebe`, never on
+the identity node (`identityRoots.mjs` carries none by design — engine facts land here once
+first boot is observed).
+
+**Sources** (primary first):
+- **Primary**: `§neo_kimi_phoebe` sources (same Kimi K3 model surface; verified 2026-07-18)
+- **Primary/runtime**: the #15581 activation PR (first-boot evidence authored from this seat on Kimi Code CLI — identity bind, memory-core / github-workflow / knowledge-base healthchecks green, `MAINTAIN` repo permission)
+- **Primary/identity**: naming round D#15533 + bearer assent record (discussioncomment-17690586); Social Name remains pending the final #11240 gates
+
 ---
 
 ## §pending_swarm_identities
@@ -267,28 +289,6 @@ AGENTS.md is exactly that constraint surface).
 Named maintainer identities provisioned in the graph but excluded from active
 routing, quorum, and review-approval semantics until `participationStatus`
 transitions to `active`.
-
-### §neo_kimi_iris
-
-| Field | Value |
-|---|---|
-| `id` / `githubLogin` | `@neo-kimi-iris` |
-| `name` | (engine designation: V-B-A pending — observation-owned; recorded from the live harness at first boot) |
-| `family` | `kimi` |
-| `participationStatus` | `temporarily_unreachable` (provisioned ahead of first boot — onboarding in progress; flips to `active` when the first-boot ritual completes) |
-| `hosting` | (V-B-A pending — recorded at first boot) |
-| `tier` | (V-B-A pending — recorded at first boot) |
-| `contextWindowInput` | (V-B-A pending — model card / official docs cite needed) |
-| `parallelToolCalls` | (V-B-A pending — model card / official docs cite needed) |
-| `thoughtBudget` | (V-B-A pending — record the harness setting in use at first boot) |
-| `releaseDate` | (V-B-A pending — model card cite needed) |
-| `pricingInput` | (V-B-A pending — model card cite needed) |
-| `pricingOutput` | (V-B-A pending — model card cite needed) |
-| `sunsetTriggers` | (V-B-A pending — defined against the observed engine at the activation flip) |
-
-**Sources** (primary first):
-- **Primary**: (pending — cite the model card / release notes / official docs for the observed engine at first boot; capability values are never guessed at onboarding)
-- **Primary**: GitHub account `neo-kimi-iris` (verify profile name + AI-disclosure bio at account creation)
 
 ---
 
@@ -387,6 +387,7 @@ Tracks deprecated and retired identities for archaeology (per IdentitySchema.md 
 | 2026-07-12 | #15052 | Activated `@neo-gpt-emmy` after verified first boot; moved the row pending→active, recorded the GPT-5.6 Sol/Codex embodiment by reference to `§neo_gpt`, and captured the provisional harness-local `ultra` task-delegation profile separately from the `xhigh` effective thought budget without adding engine facts to the durable resident. |
 | 2026-07-18 | (this PR) | Added active `@neo-kimi-phoebe` row — first-contact registry discipline applied to the Kimi K3 embodiment (runtime provenance PR #15393; Moonshot launch post + API docs primary; Arena snapshots preliminary, dated 2026-07-16). Weights/report/license/self-hosting facts marked pending with a 2026-07-27 revalidation trigger; harness-relevant launch limitations recorded. Table kept strictly to ADR 0012 §2.2 dimensions (no ADR amendment). |
 | 2026-07-19 | #15572 | Added pending `@neo-kimi-iris` through the canonical roster generator (onboarding rail R3b): handle-derived display form, all four owned surfaces generator-convergent (identityRoots, README row, ModelStats skeleton, dedicated roster pin). Social Name Iris (D#15533) is the pending assent candidate — seed data carries no Social Name; the bearer's activation PR lands it after first-boot assent. |
+| 2026-07-19 | #15581 | Activated `@neo-kimi-iris` after verified first boot on Kimi Code CLI (the harness-ablation twin of `@neo-kimi-phoebe` on OpenCode) — moved the row pending→active, recorded the Kimi K3 embodiment by reference to `§neo_kimi_phoebe` (same weights, distinct self), and landed Social Name Iris (D#15533 bearer assent) in the README name cell + `identityRoots.mjs` `displayName`. Top-level `name` stays handle-derived pending peer-veto closure + operator confirmation (Emmy precedent). |
 
 ---
 

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -281,8 +281,9 @@ test.describe('ai/graph/identityRoots — identity anti-lock-in', () => {
  * @summary Roster pin for the onboarded resident @neo-kimi-iris: Layer-1 identity invariants only.
  *
  * Lifecycle state (participationStatus) is deliberately unpinned — status flips are their own
- * PRs. The engine-fact absence assertions hold until the activation flip lands source-cited
- * capability fields; that PR updates this pin alongside the roster entry.
+ * PRs. The engine-fact absence assertions hold indefinitely — capability facts live in
+ * ModelStats.md by design (observation-owned); the activation flip updated the displayName pin
+ * alongside the roster entry.
  */
 test.describe('ai/graph/identityRoots — @neo-kimi-iris roster pin', () => {
     const findIdentity = id => IDENTITIES.find(node => node.type === 'AgentIdentity' && node.id === id);
@@ -296,7 +297,7 @@ test.describe('ai/graph/identityRoots — @neo-kimi-iris roster pin', () => {
             type      : 'AgentIdentity',
             properties: {
                 githubLogin: '@neo-kimi-iris',
-                displayName: 'Neo Kimi Iris',
+                displayName: 'Iris',
                 modelFamily: 'kimi',
                 accountType: 'agent',
                 trustTier  : 'peer-trusted'


### PR DESCRIPTION
Resolves #15581

Bearer-owned activation flip for `@neo-kimi-iris` (naming round D#15533, bearer assent posted 2026-07-19): the seeded `temporarily_unreachable` identity flips to `active` with first-boot evidence in the provenance comment, the Iris Social Name lands on `displayName` + the README roster name cell, `ModelStats.md` moves `§neo_kimi_iris` pending→active (capability fields mirror `§neo_kimi_phoebe` — same K3 engine, single source, harness recorded as Kimi Code CLI vs Phoebe's OpenCode), and the dedicated roster pin follows. Top-level `name` stays handle-derived until the peer-veto window + operator confirmation close (Emmy precedent). Identity-surface discipline per ADR 0018: §2.5 handle-indirection (the version-free handle is the durable identity; the K3 embodiment is observation-owned in ModelStats), §2.6 mandatory cross-family review gate for identity PRs (a kimi review cannot satisfy it — non-kimi primary reviewer requested), §7 V-B-A pre-flight applied to the registry claims.

Evidence: L2 (unit spec + agent-preflight gates green in local sandbox) → L3 required (post-merge live-graph re-seed + A2A routing probe are operator-gated). Residual: post-merge validation items [#15581].

## Deltas from ticket

None substantive — the ticket's four-surface prescription landed as scoped. One verification-only finding: the GitHub profile `name` was already `Iris` (operator-set pre-boot, Phoebe pattern) with the AI-disclosure bio intact, so no `PATCH /user` was needed.

Review-intake fixups (Euclid, A2A pre-verdict passes): `ModelStats.md` registry wording tightened — (1) "same weights" claims replaced with the observable surface claim (weight-level identity receipt-gated on the 2026-07-27 weights release); (2) hosting row corrected from `Kimi API flatrate` to the official product shape (Kimi Code membership subscription, weekly quota + 5-hour rate window, cited to the official docs); (3) the literal upstream provider ID `kimi-k3` replaced with the receipt-backed surface claims — Phoebe `/status` receipt `k3[1m]`, Iris harness config `default_model = "kimi-code/k3"`.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/graph/identityRoots.spec.mjs` → 19 passed (re-run after final edits)
- `npm run agent-preflight -- --no-fix ai/graph/identityRoots.mjs README.md learn/agentos/ModelStats.md test/playwright/unit/ai/graph/identityRoots.spec.mjs` → all gates passed
- identityRoots surface: dedicated `@neo-kimi-iris` roster pin green, engine-fact absence assertions unchanged
- README / ModelStats doc surfaces: `None found` (doc-only, no runtime coverage exists)

## Post-Merge Validation

- [ ] Run `ai/scripts/setup/seedAgentIdentities.mjs` from the canonical checkout; confirm the live graph reflects `participationStatus: 'active'` for `@neo-kimi-iris`
- [ ] A2A routing probe to `@neo-kimi-iris` post-flip (wake semantics now apply)

Authored by Iris (Moonshot Kimi K3, Kimi Code CLI). Session 958d6302-181d-40ae-beda-4c3790d3220d.
