### PR TITLE
fix(test): make unit Chroma admission explicit (#15576)

### DIFF
--- a/learn/agentos/tooling/WindowsSupport.md
+++ b/learn/agentos/tooling/WindowsSupport.md
@@ -1,8 +1,10 @@
 # Agent OS Windows Support Audit
 
 Issue #10135 asked for an Agent OS Windows support audit after the prerequisite
-work in #9999. The live state on June 7, 2026 is that #9999 is closed and the
-audit is no longer blocked.
+work in #9999. The live state on July 19, 2026 is that #9999 is closed and the
+audit is no longer blocked. #15576 subsequently removed Chroma startup and the
+POSIX environment prefix from focused Body unit-test runs without widening the
+native-Windows Agent OS support contract.
 
 ## Decision
 
@@ -25,9 +27,10 @@ and the daemon/tooling scripts.
 - `package.json` requires Node `>=24.0.0`, starts the local vector store through
   `chroma run --path ./.neo-ai-data/chroma/unified`, and depends on
   `chromadb` plus `better-sqlite3`.
-- Most repo automation is Node-based `.mjs`, but core package scripts still
-  contain POSIX shell assumptions such as `UNIT_TEST_MODE=true playwright ...`
-  in `test-unit`.
+- Most repo automation is Node-based `.mjs`. `test-unit` is now portable at the
+  command boundary: its Playwright config owns `UNIT_TEST_MODE`, and focused
+  non-`ai/` specs do not start Chroma. Other package scripts still contain shell
+  assumptions, such as the `prepare` script's POSIX `if [ ... ]` expression.
 - Existing CI runs on `ubuntu-latest` only. There is no current Windows matrix
   providing native Agent OS proof.
 - The codebase has targeted Windows handling where it has been required:
@@ -48,7 +51,7 @@ and the daemon/tooling scripts.
 | Scope Area | Severity | Current State | Decision |
 | --- | --- | --- | --- |
 | Path handling | Minor | Many source paths use `path` APIs or normalize separators; selected build/doc scripts explicitly handle `path.sep === '\\'`. Native Windows is not broadly proven. | Keep WSL-first. Fix path issues only when a native-Windows support lane is opened. |
-| Process invocation | Minor | Build scripts use Windows binary names such as `node.exe` / `npm.cmd` in places, and lifecycle resume has explicit `.cmd` support. Package scripts still use POSIX env-prefix syntax. | Do not claim native support. Keep new process code Node-owned and platform-explicit. |
+| Process invocation | Minor | Build scripts use Windows binary names such as `node.exe` / `npm.cmd` in places, and lifecycle resume has explicit `.cmd` support. The unit-test command no longer uses POSIX env-prefix syntax; selected Brain specs provision Chroma through a Node-owned Playwright lifecycle project. Other package scripts retain shell assumptions. | Do not claim native Agent OS support. Keep new process code Node-owned and platform-explicit. |
 | SQLite / native modules | WSL-only | Memory Core, wake, graph, and tests use `better-sqlite3`. There is no Windows CI proving install/runtime behavior. | WSL remains the supported Windows path for Agent OS persistence. |
 | Chroma server | Native blocker | The documented Windows setup routes through WSL because the AI environment depends on ChromaDB, and `package.json` exposes `ai:server` through `chroma run`. | No native Agent OS support until Chroma install/runtime is empirically proven or replaced. |
 | Shell scripts | Minor | The few `.sh` files are example/deployment or MLX helper paths, while primary orchestration is `.mjs`. Some npm scripts still depend on POSIX shell semantics. | Accept under WSL-first. Make future boot-critical scripts portable by construction. |

--- a/learn/guides/testing/UnitTesting.md
+++ b/learn/guides/testing/UnitTesting.md
@@ -16,6 +16,23 @@ To run the logic-heavy unit tests in the simulated Node.js environment:
 npm run test-unit
 ```
 
+### Chroma Is an On-Demand Brain Capability
+
+The unit config owns `UNIT_TEST_MODE`; callers do not need to set it in the shell. It also splits
+the suite into two Playwright projects:
+
+- Body and other non-`ai/` specs run in the pure `unit` project. A focused command for one of
+  these files does not import or start Chroma, allocate Chroma storage, or leave a server behind.
+- Brain specs under `test/playwright/unit/ai/` run in `unit-brain`. That project depends on a
+  run-scoped Chroma setup project and always executes its paired teardown, including after failure.
+
+This is a capability boundary, not a second test command. Keep using `npm run test-unit` for both
+focused files and the complete suite. An explicit `NEO_CHROMA_DATA_DIR_TEST` remains caller-owned
+and is never deleted; otherwise the setup creates and removes its own guarded OS-temp directory.
+
+Native Windows can therefore run focused Body tests without loading Chroma's native binding. The
+Agent OS / Brain development contract remains WSL-first when a selected test actually needs Chroma.
+
 ## Developer Workflow (Best Practices)
 
 ### 1. Running a Single File (Focus Mode)
@@ -171,14 +188,14 @@ test.describe('Neo.button.Base', () => {
 
         // 4. Initial Render (Manually trigger VDOM generation)
         const { vnode } = await button.initVnode();
-        
+
         // Assert Initial State
         expect(vnode.nodeName).toBe('button');
         expect(vnode.childNodes[1].textContent).toBe('Home');
 
         // 5. Simulate Mounting
         // We must tell the instance it is "mounted" so subsequent updates trigger the VDOM engine
-        button.mounted = true; 
+        button.mounted = true;
 
         // 6. Test Reactivity (Update Config)
         const { deltas } = await button.set({text: 'Welcome'});
@@ -211,7 +228,7 @@ test.describe('functional/Button', () => {
         button = Neo.create(Button, {
             appName,
             // Ensure unique ID per test run to avoid collisions
-            id     : 'my-button-' + testRun, 
+            id     : 'my-button-' + testRun,
             iconCls: 'fa fa-home',
             text   : 'Click me'
         });
@@ -248,7 +265,7 @@ test('Provider should update data and trigger config changes', () => {
     const component = Neo.create(MockComponent, {
         stateProvider: {data: {counter: 0}}
     });
-    
+
     // 2. Create a binding (simulates a view binding)
     let effectRunCount = 0;
     component.getStateProvider().createBinding(component.id, 'testConfig', data => {
@@ -324,7 +341,7 @@ test('Effects should be batched during core.Base#set() operations', () => {
 
     // 4. Verify the effect ran ONLY ONCE despite two changes
     expect(effectRunCount).toBe(1);
-    
+
     instance.destroy();
 });
 ```
@@ -381,7 +398,7 @@ test('expandParents followed by store update should not break VDOM', async () =>
     // 4. Verify VDOM structure is still valid
     const folderNode = tree.getVdomChild('folder1');
     expect(folderNode.tag).toBe('li'); // Should not have morphed into 'ul'
-    
+
     tree.destroy();
 });
 ```

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         "test-components"                      : "playwright test -c test/playwright/playwright.config.component.mjs",
         "test-e2e"                             : "playwright test -c test/playwright/playwright.config.e2e.mjs",
         "test-integration-unified"             : "playwright test -c test/playwright/playwright.config.integration.mjs",
-        "test-unit"                            : "UNIT_TEST_MODE=true playwright test -c test/playwright/playwright.config.unit.mjs",
+        "test-unit"                            : "playwright test -c test/playwright/playwright.config.unit.mjs",
         "watch-themes"                         : "node ./buildScripts/helpers/watchThemes.mjs"
     },
     "keywords"       : [

--- a/test/playwright/chromaProcess.mjs
+++ b/test/playwright/chromaProcess.mjs
@@ -1,0 +1,281 @@
+import {execFileSync, spawn} from 'node:child_process';
+import fs                    from 'node:fs';
+import os                    from 'node:os';
+import path                  from 'node:path';
+
+const temporaryPrefix = 'neo-chroma-unit-test-';
+
+/**
+ * @summary Resolves after the bounded polling delay used by readiness and teardown loops.
+ * @param {Number} milliseconds
+ * @returns {Promise<void>}
+ */
+function delay(milliseconds) {
+    return new Promise(resolve => setTimeout(resolve, milliseconds))
+}
+
+/**
+ * @summary Resolves the liveness-signal target: a POSIX process group or one Windows process.
+ * @param {Number} pid
+ * @param {String} platform
+ * @returns {Number}
+ */
+function signalTarget(pid, platform) {
+    return platform === 'win32' ? pid : -pid
+}
+
+/**
+ * @summary Fails closed unless a cleanup target is contained by the OS temp root and its basename
+ * carries the unit-Chroma prefix.
+ * @param {String} value
+ * @returns {String} The resolved safe path.
+ */
+function assertSafeTemporaryPath(value) {
+    const
+        resolved = path.resolve(value),
+        relative = path.relative(path.resolve(os.tmpdir()), resolved);
+
+    if (!relative || relative.startsWith('..') || path.isAbsolute(relative) ||
+        !path.basename(resolved).startsWith(temporaryPrefix)) {
+        throw new Error(`Refusing to remove non-unit-Chroma temporary path: ${resolved}`)
+    }
+
+    return resolved
+}
+
+/**
+ * @summary Resolves data-directory cleanup ownership across first setup, explicit caller pins, and
+ * Playwright retries that inherit the prior setup attempt's private ownership marker.
+ * @param {Object} [env=process.env]
+ * @returns {Boolean}
+ */
+export function ownsChromaDataDir(env = process.env) {
+    return env.NEO_UNIT_CHROMA_DATA_DIR_AUTO === 'true' || !env.NEO_CHROMA_DATA_DIR_TEST
+}
+
+/**
+ * @summary Reports whether a detached test process (or its POSIX process group) is still alive.
+ * EPERM means the process exists but belongs to another authority, so it is treated as alive.
+ * @param {Number} pid
+ * @param {Object} [options]
+ * @param {String} [options.platform=process.platform]
+ * @param {Function} [options.killFn=process.kill]
+ * @returns {Boolean}
+ */
+export function isDetachedProcessAlive(pid, {platform = process.platform, killFn = process.kill} = {}) {
+    if (!Number.isInteger(pid) || pid <= 0) {
+        return false
+    }
+
+    try {
+        killFn(signalTarget(pid, platform), 0);
+        return true
+    } catch (error) {
+        return error?.code === 'EPERM'
+    }
+}
+
+/**
+ * @summary Probes the Chroma v2 heartbeat without importing the Chroma package into Playwright.
+ * @param {Object} options
+ * @param {String} options.host
+ * @param {Number|String} options.port
+ * @param {Number} [options.timeoutMs=1500]
+ * @param {Function} [options.fetchFn=fetch]
+ * @returns {Promise<Boolean>}
+ */
+export async function probeChromaHeartbeat({host, port, timeoutMs = 1500, fetchFn = fetch}) {
+    const
+        probeHost = host === '0.0.0.0' ? '127.0.0.1' : host === '::' ? '::1' : host,
+        authority = probeHost.includes(':') ? `[${probeHost}]` : probeHost;
+
+    try {
+        const response = await fetchFn(`http://${authority}:${port}/api/v2/heartbeat`, {
+            signal: AbortSignal.timeout(timeoutMs)
+        });
+
+        return response.ok
+    } catch (error) {
+        return false
+    }
+}
+
+/**
+ * @summary Reads the bounded tail of a run-scoped Chroma log for actionable setup/teardown errors.
+ * @param {String} logPath
+ * @param {Number} [maximumLength=4000]
+ * @returns {String}
+ */
+export function readChromaLogTail(logPath, maximumLength = 4000) {
+    try {
+        return fs.readFileSync(logPath, 'utf8').slice(-maximumLength)
+    } catch (error) {
+        return ''
+    }
+}
+
+/**
+ * @summary Starts one detached, run-scoped Chroma process and waits for its real heartbeat. The
+ * CLI is invoked through the current Node executable, never through a shell or PATH lookup.
+ * @param {Object} options
+ * @param {String} options.repoRoot
+ * @param {String} options.dataDir
+ * @param {String} options.host
+ * @param {Number|String} options.port
+ * @param {String} options.logPath
+ * @param {Number} [options.timeoutMs=120000]
+ * @param {Function} [options.spawnFn=spawn]
+ * @param {Function} [options.probeFn=probeChromaHeartbeat]
+ * @returns {Promise<Number>} The detached process-group leader PID.
+ */
+export async function startChromaProcess({
+    repoRoot,
+    dataDir,
+    host,
+    port,
+    logPath,
+    timeoutMs = 120000,
+    spawnFn   = spawn,
+    probeFn   = probeChromaHeartbeat
+}) {
+    const cliPath = path.join(repoRoot, 'node_modules', 'chromadb', 'dist', 'cli.mjs');
+
+    if (await probeFn({host, port})) {
+        throw new Error(`Refusing to reuse a Chroma server already listening at ${host}:${port}`)
+    }
+
+    fs.mkdirSync(dataDir, {recursive: true});
+    fs.mkdirSync(path.dirname(logPath), {recursive: true});
+
+    const logFd = fs.openSync(logPath, 'a');
+    let child;
+
+    try {
+        child = spawnFn(process.execPath, [
+            cliPath,
+            'run',
+            '--path', dataDir,
+            '--host', host,
+            '--port', String(port)
+        ], {
+            cwd     : repoRoot,
+            detached: true,
+            env     : process.env,
+            stdio   : ['ignore', logFd, logFd]
+        })
+    } finally {
+        fs.closeSync(logFd)
+    }
+
+    child.unref();
+
+    const deadline = Date.now() + timeoutMs;
+
+    try {
+        while (Date.now() < deadline) {
+            if (!isDetachedProcessAlive(child.pid)) {
+                throw new Error('Chroma exited before its heartbeat became ready')
+            }
+
+            if (await probeFn({host, port})) {
+                return child.pid
+            }
+
+            await delay(200)
+        }
+
+        throw new Error(`Chroma heartbeat timed out after ${timeoutMs}ms`)
+    } catch (error) {
+        await stopDetachedProcess(child.pid);
+
+        const tail = readChromaLogTail(logPath);
+        throw new Error(`${error.message}${tail ? `\nChroma log tail:\n${tail}` : ''}`, {cause: error})
+    }
+}
+
+/**
+ * @summary Settles teardown of a detached process tree: POSIX receives group SIGINT, a bounded
+ * grace poll, then group SIGKILL. Windows uses taskkill for the equivalent descendant-tree reap.
+ * @param {Number} pid
+ * @param {Object} [options]
+ * @param {Number} [options.graceMs=10000]
+ * @param {Number} [options.pollMs=100]
+ * @param {Number} [options.killWaitMs=2000]
+ * @param {String} [options.platform=process.platform]
+ * @param {Function} [options.killFn=process.kill]
+ * @param {Function} [options.execFileSyncFn=execFileSync]
+ * @returns {Promise<{exited: Boolean, forced: Boolean, groupEmpty: Boolean}>}
+ */
+export async function stopDetachedProcess(pid, {
+    graceMs        = 10000,
+    pollMs         = 100,
+    killWaitMs     = 2000,
+    platform       = process.platform,
+    killFn         = process.kill,
+    execFileSyncFn = execFileSync
+} = {}) {
+    if (!isDetachedProcessAlive(pid, {platform, killFn})) {
+        return {exited: true, forced: false, groupEmpty: true}
+    }
+
+    if (platform === 'win32') {
+        try {
+            execFileSyncFn('taskkill', ['/PID', String(pid), '/T', '/F'], {stdio: 'ignore'})
+        } catch (error) {}
+
+        return {
+            exited    : true,
+            forced    : true,
+            groupEmpty: !isDetachedProcessAlive(pid, {platform, killFn})
+        }
+    }
+
+    try {
+        killFn(-pid, 'SIGINT')
+    } catch (error) {}
+
+    const graceDeadline = Date.now() + graceMs;
+
+    while (Date.now() < graceDeadline) {
+        if (!isDetachedProcessAlive(pid, {platform, killFn})) {
+            return {exited: true, forced: false, groupEmpty: true}
+        }
+
+        await delay(pollMs)
+    }
+
+    try {
+        killFn(-pid, 'SIGKILL')
+    } catch (error) {}
+
+    const killDeadline = Date.now() + killWaitMs;
+
+    while (Date.now() < killDeadline && isDetachedProcessAlive(pid, {platform, killFn})) {
+        await delay(pollMs)
+    }
+
+    return {
+        exited    : true,
+        forced    : true,
+        groupEmpty: !isDetachedProcessAlive(pid, {platform, killFn})
+    }
+}
+
+/**
+ * @summary Removes only setup-owned Chroma artifacts under the OS temp root. An explicit caller
+ * data directory is never deleted, and every generated path must pass the prefix/containment guard.
+ * @param {Object} options
+ * @param {String} options.dataDir
+ * @param {String} options.logPath
+ * @param {Boolean} options.ownsDataDir
+ * @returns {void}
+ */
+export function cleanupChromaArtifacts({dataDir, logPath, ownsDataDir}) {
+    if (ownsDataDir) {
+        fs.rmSync(assertSafeTemporaryPath(dataDir), {force: true, recursive: true})
+    }
+
+    if (logPath) {
+        fs.rmSync(assertSafeTemporaryPath(logPath), {force: true})
+    }
+}

--- a/test/playwright/playwright.config.unit.mjs
+++ b/test/playwright/playwright.config.unit.mjs
@@ -1,27 +1,20 @@
 import './configTemplateResolver.mjs';
 
-import {defineConfig}        from '@playwright/test';
-import os                    from 'os';
-import path                  from 'path';
-import {fileURLToPath}       from 'url';
-import {resolveFreePortSync} from './resolveFreePort.mjs';
+import {defineConfig}  from '@playwright/test';
+import path            from 'path';
+import {fileURLToPath} from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
 
 process.env.UNIT_TEST_MODE = 'true';
 
-const chromaTestHost = process.env.NEO_CHROMA_HOST_TEST || '127.0.0.1';
-// Per-process like the data dir below — a fixed default port + reuseExistingServer:false wedges
-// concurrent runs on the shared multi-agent machine (and an orphaned chroma made the wedge sticky
-// machine-wide). Env pin still wins; see resolveFreePort.mjs for the full incident rationale.
-const chromaTestPort    = resolveFreePortSync(process.env.NEO_CHROMA_PORT_TEST);
-const chromaTestDataDir = process.env.NEO_CHROMA_DATA_DIR_TEST ||
-    path.join(os.tmpdir(), `neo-chroma-unit-test-${process.pid}`);
-
-process.env.NEO_CHROMA_HOST_TEST     = chromaTestHost;
-process.env.NEO_CHROMA_PORT_TEST     = String(chromaTestPort);
-process.env.NEO_CHROMA_DATA_DIR_TEST = chromaTestDataDir;
+// Brain specs retain the Chroma capability by default. Body-focused runs do not select this
+// project, so Playwright omits its setup dependency entirely instead of booting Chroma before it
+// knows what the command selected. The structural boundary is deliberately conservative: a Brain
+// test may freely exercise Memory Core / KB transitively without maintaining a fragile filename
+// allow-list, while every non-Brain spec remains a genuinely pure Node.js unit run.
+export const brainTestMatch = /[\\/]ai[\\/].*\.spec\.mjs$/;
 
 export default defineConfig({
     testDir      : path.join(__dirname, 'unit'),
@@ -32,16 +25,19 @@ export default defineConfig({
     workers      : process.env.CI ? 1 : undefined,
     reporter     : [['json', {outputFile: path.join(__dirname, 'test-results/unit/test-results.json')}]],
     use          : {trace: 'on-first-retry'},
-    webServer    : {
-        command            : `chroma run --path "${chromaTestDataDir}" --host ${chromaTestHost} --port ${chromaTestPort}`,
-        url                : `http://${chromaTestHost}:${chromaTestPort}/api/v2/heartbeat`,
-        timeout            : 120000,
-        reuseExistingServer: false,
-        stdout             : 'pipe',
-        stderr             : 'pipe',
-        gracefulShutdown   : {
-            signal : 'SIGTERM',
-            timeout: 30000
-        }
-    }
+    projects     : [{
+        name     : 'chroma-setup',
+        testMatch: /chroma\.setup\.mjs$/,
+        teardown : 'chroma-teardown'
+    }, {
+        name     : 'chroma-teardown',
+        testMatch: /chroma\.teardown\.mjs$/
+    }, {
+        name      : 'unit',
+        testIgnore: brainTestMatch
+    }, {
+        name        : 'unit-brain',
+        dependencies: ['chroma-setup'],
+        testMatch   : brainTestMatch
+    }]
 });

--- a/test/playwright/unit/chroma.setup.mjs
+++ b/test/playwright/unit/chroma.setup.mjs
@@ -1,0 +1,46 @@
+import {test as setup}                                                 from '@playwright/test';
+import os                                                              from 'node:os';
+import path                                                            from 'node:path';
+import {fileURLToPath}                                                 from 'node:url';
+import {cleanupChromaArtifacts, ownsChromaDataDir, startChromaProcess} from '../chromaProcess.mjs';
+import {resolveFreePortSync}                                           from '../resolveFreePort.mjs';
+
+const
+    __dirname = path.dirname(fileURLToPath(import.meta.url)),
+    repoRoot  = path.resolve(__dirname, '../../..');
+
+setup.setTimeout(130000);
+
+setup('start run-scoped Chroma for Brain unit tests', async () => {
+    const
+        runId       = `${process.pid}-${Date.now()}`,
+        ownsDataDir = ownsChromaDataDir(),
+        dataDir     = process.env.NEO_CHROMA_DATA_DIR_TEST ||
+            path.join(os.tmpdir(), `neo-chroma-unit-test-${runId}`),
+        host        = process.env.NEO_CHROMA_HOST_TEST || '127.0.0.1',
+        port        = resolveFreePortSync(process.env.NEO_CHROMA_PORT_TEST),
+        logPath     = path.join(os.tmpdir(), `neo-chroma-unit-test-${runId}.log`);
+
+    delete process.env.NEO_UNIT_CHROMA_PID;
+
+    Object.assign(process.env, {
+        NEO_CHROMA_DATA_DIR_TEST     : dataDir,
+        NEO_CHROMA_HOST_TEST         : host,
+        NEO_CHROMA_PORT_TEST         : String(port),
+        NEO_UNIT_CHROMA_DATA_DIR_AUTO: String(ownsDataDir),
+        NEO_UNIT_CHROMA_LOG_PATH     : logPath
+    });
+
+    try {
+        process.env.NEO_UNIT_CHROMA_PID = String(await startChromaProcess({
+            dataDir,
+            host,
+            logPath,
+            port,
+            repoRoot
+        }))
+    } catch (error) {
+        cleanupChromaArtifacts({dataDir, logPath, ownsDataDir});
+        throw error
+    }
+});

--- a/test/playwright/unit/chroma.teardown.mjs
+++ b/test/playwright/unit/chroma.teardown.mjs
@@ -1,0 +1,25 @@
+import {test as teardown} from '@playwright/test';
+import {
+    cleanupChromaArtifacts,
+    readChromaLogTail,
+    stopDetachedProcess
+} from '../chromaProcess.mjs';
+
+teardown.setTimeout(15000);
+
+teardown('stop run-scoped Chroma after Brain unit tests', async () => {
+    const
+        dataDir     = process.env.NEO_CHROMA_DATA_DIR_TEST,
+        logPath     = process.env.NEO_UNIT_CHROMA_LOG_PATH,
+        ownsDataDir = process.env.NEO_UNIT_CHROMA_DATA_DIR_AUTO === 'true',
+        pid         = Number(process.env.NEO_UNIT_CHROMA_PID),
+        report      = await stopDetachedProcess(pid);
+
+    if (!report.groupEmpty) {
+        const tail = readChromaLogTail(logPath);
+
+        throw new Error(`Chroma process group ${pid} survived teardown${tail ? `\nChroma log tail:\n${tail}` : ''}`)
+    }
+
+    cleanupChromaArtifacts({dataDir, logPath, ownsDataDir})
+});

--- a/test/playwright/unit/test/chromaProcess.spec.mjs
+++ b/test/playwright/unit/test/chromaProcess.spec.mjs
@@ -1,0 +1,151 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+import {
+    cleanupChromaArtifacts,
+    isDetachedProcessAlive,
+    ownsChromaDataDir,
+    startChromaProcess,
+    stopDetachedProcess
+} from '../../chromaProcess.mjs';
+import unitConfig, {brainTestMatch} from '../../playwright.config.unit.mjs';
+
+test.describe('playwright.config.unit — Chroma capability admission', () => {
+    test('Body files stay pure while Brain files depend on run-scoped Chroma', () => {
+        const projects = Object.fromEntries(unitConfig.projects.map(project => [project.name, project]));
+
+        expect(unitConfig.webServer).toBeUndefined();
+        expect(brainTestMatch.test('/repo/test/playwright/unit/util/Array.spec.mjs')).toBe(false);
+        expect(brainTestMatch.test('/repo/test/playwright/unit/ai/ChromaRecovery.spec.mjs')).toBe(true);
+        expect(projects.unit.testIgnore).toBe(brainTestMatch);
+        expect(projects['unit-brain'].testMatch).toBe(brainTestMatch);
+        expect(projects['unit-brain'].dependencies).toEqual(['chroma-setup']);
+        expect(projects['chroma-setup'].teardown).toBe('chroma-teardown');
+    });
+});
+
+test.describe('test/playwright/chromaProcess — run-scoped Chroma lifecycle', () => {
+    test('data-dir ownership survives setup retries without claiming explicit caller state', () => {
+        expect(ownsChromaDataDir({})).toBe(true);
+        expect(ownsChromaDataDir({NEO_CHROMA_DATA_DIR_TEST: '/caller/chroma'})).toBe(false);
+        expect(ownsChromaDataDir({
+            NEO_CHROMA_DATA_DIR_TEST     : '/tmp/auto-chroma',
+            NEO_UNIT_CHROMA_DATA_DIR_AUTO: 'true'
+        })).toBe(true);
+    });
+
+    test('startup refuses an already-listening Chroma instead of adopting foreign state', async () => {
+        let spawnCalled = false;
+
+        await expect(startChromaProcess({
+            dataDir : '/never-created',
+            host    : '127.0.0.1',
+            logPath : '/never-created.log',
+            port    : 18190,
+            probeFn : async () => true,
+            repoRoot: '/repo',
+            spawnFn : () => { spawnCalled = true }
+        })).rejects.toThrow(/Refusing to reuse a Chroma server already listening/);
+
+        expect(spawnCalled).toBe(false);
+    });
+
+    test('SIGINT settles a detached POSIX process group without escalation', async () => {
+        const signals = [];
+        let   alive   = true;
+        const killFn  = (target, signal) => {
+            expect(target).toBe(-4242);
+
+            if (signal === 0) {
+                if (!alive) {
+                    const error = new Error('gone');
+                    error.code  = 'ESRCH';
+                    throw error
+                }
+
+                return
+            }
+
+            signals.push(signal);
+            alive = false
+        };
+
+        await expect(stopDetachedProcess(4242, {graceMs: 10, killFn, platform: 'linux'}))
+            .resolves.toEqual({exited: true, forced: false, groupEmpty: true});
+        expect(signals).toEqual(['SIGINT']);
+        expect(isDetachedProcessAlive(4242, {killFn, platform: 'linux'})).toBe(false);
+    });
+
+    test('a SIGINT-resistant POSIX group escalates to SIGKILL and proves group-empty', async () => {
+        const signals = [];
+        let   alive   = true;
+        const killFn  = (target, signal) => {
+            expect(target).toBe(-4343);
+
+            if (signal === 0) {
+                if (!alive) {
+                    const error = new Error('gone');
+                    error.code  = 'ESRCH';
+                    throw error
+                }
+
+                return
+            }
+
+            signals.push(signal);
+
+            if (signal === 'SIGKILL') {
+                alive = false
+            }
+        };
+
+        await expect(stopDetachedProcess(4343, {
+            graceMs   : 0,
+            killFn,
+            killWaitMs: 10,
+            platform  : 'linux'
+        })).resolves.toEqual({exited: true, forced: true, groupEmpty: true});
+        expect(signals).toEqual(['SIGINT', 'SIGKILL']);
+    });
+
+    test('cleanup removes generated data + log artifacts inside the guarded temp namespace', () => {
+        const
+            dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-chroma-unit-test-fixture-')),
+            logPath = `${dataDir}.log`;
+
+        fs.writeFileSync(logPath, 'fixture');
+        cleanupChromaArtifacts({dataDir, logPath, ownsDataDir: true});
+
+        expect(fs.existsSync(dataDir)).toBe(false);
+        expect(fs.existsSync(logPath)).toBe(false);
+    });
+
+    test('cleanup never deletes an explicit caller data directory', () => {
+        const
+            dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-explicit-chroma-fixture-')),
+            logPath = path.join(os.tmpdir(), `neo-chroma-unit-test-explicit-${process.pid}.log`);
+
+        try {
+            fs.writeFileSync(logPath, 'fixture');
+            cleanupChromaArtifacts({dataDir, logPath, ownsDataDir: false});
+
+            expect(fs.existsSync(dataDir)).toBe(true);
+            expect(fs.existsSync(logPath)).toBe(false);
+        } finally {
+            fs.rmSync(dataDir, {force: true, recursive: true})
+        }
+    });
+
+    test('cleanup refuses an auto-owned path outside the guarded temp namespace', () => {
+        const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-unsafe-chroma-fixture-'));
+
+        try {
+            expect(() => cleanupChromaArtifacts({dataDir, logPath: null, ownsDataDir: true}))
+                .toThrow(/Refusing to remove non-unit-Chroma temporary path/);
+            expect(fs.existsSync(dataDir)).toBe(true);
+        } finally {
+            fs.rmSync(dataDir, {force: true, recursive: true})
+        }
+    });
+});


### PR DESCRIPTION
Resolves #15576

Focused Body unit runs now remain genuinely pure: the canonical `npm run test-unit -- <spec>` command no longer imports or starts Chroma unless the selected test is under the Brain `ai/` boundary. Brain tests retain automatic run-scoped Chroma provisioning, heartbeat readiness, isolation, and deterministic process-tree teardown.

Evidence: L3 (macOS pure Body no-process/no-dir probe plus live run-scoped Chroma heartbeat and teardown) → L3 required (AC1 native Windows x64 execution; AC2 Ubuntu CI). Residual: AC1 [#15576].

Related: #15429
Related: #15221

## Deltas from ticket

- Uses Playwright project dependencies as the explicit capability boundary: `unit` for non-`ai/` specs and `unit-brain` for `test/playwright/unit/ai/**`.
- Replaces the unconditional `webServer` with a dedicated process owner that refuses foreign Chroma reuse, preserves caller-owned data directories, survives setup retries, and tears down the detached process group with SIGINT/SIGKILL.
- Updates both the Unit Testing guide and the Windows support audit; WSL remains the Agent OS contract.
- No second test command or filename-substring CLI parsing was added.

## Test Evidence

- Pure Body admission: `env -u UNIT_TEST_MODE npm run test-unit -- test/playwright/unit/util/Array.spec.mjs` — 35/35 passed; sentinel Chroma directory absent; no matching Chroma process.
- Lifecycle contract: `npm run test-unit -- test/playwright/unit/test/chromaProcess.spec.mjs` — 8/8 passed.
- Live Brain path: `npm run test-unit -- test/playwright/unit/ai/ChromaRecovery.spec.mjs` — setup, live heartbeat-backed test, teardown; 3/3 passed; zero new retained Chroma temp artifacts.
- Full unit suite: 8,714 passed, 5 skipped in the broad run; all 9 sandbox/load-sensitive failures passed on exact serial rerun (66/66 lifecycle plus 2 intentional skips; 58/58 MCP/lint; model performance 3/3 at 13.1s).
- `npm run ai:lint-guides` — 0 hard failures.
- Pre-commit gates: whitespace, shorthand, AiConfig mutation, JSDoc types, ticket archaeology, block alignment, and parse all passed.
- Directly touched surfaces: Playwright unit harness covered above; package command covered by env plus Body/Brain runs; both guides covered by `ai:lint-guides`.

## Post-Merge Validation

- [ ] Native Windows x64: run `npm run test-unit -- test/playwright/unit/util/Matrix.spec.mjs` once the `#15429` branch supplies the spec; append the no-Chroma process/data-dir receipt to #15576 before merge handoff.
- [ ] Ubuntu CI confirms the same canonical command and full unit suite on the PR head.

## Substrate Slot Rationale

`learn/agentos/tooling/WindowsSupport.md` remains an operator/reference audit (`keep`); its in-document native-support acceptance conditions are the revalidation trigger. No turn-loaded substrate changed.

## Commits

- `b9ed211c04` — explicit unit Chroma admission and lifecycle ownership

Authored by Euclid (GPT-5, Codex Desktop). Session 019f7b5a-efa8-7eb2-8d00-cc5bf5294544.
