### PR TITLE
fix(test): materialize themes before source E2E (#15449)

### DIFF
--- a/buildScripts/util/developmentThemeAssets.mjs
+++ b/buildScripts/util/developmentThemeAssets.mjs
@@ -1,0 +1,277 @@
+import {spawn} from 'node:child_process';
+import fs      from 'node:fs';
+import path    from 'node:path';
+
+export const DEVELOPMENT_THEME_BUILD_COMMAND = 'npm run build-themes -- -n -e dev -t all';
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..');
+
+/**
+ * @summary Returns the newest mtime under a directory tree for files with a given extension.
+ * Symbolic-link entries are deliberately ignored: generated-asset readiness must describe this
+ * checkout, never a foreign tree borrowed through a link.
+ * @param {String} dir Absolute directory.
+ * @param {String} extension File extension including the dot.
+ * @returns {Number} Newest epoch mtime in milliseconds, or 0 when no matching file exists.
+ */
+export function newestMtime(dir, extension) {
+    let newest = 0;
+
+    if (!fs.existsSync(dir)) return newest;
+
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+        if (entry.isSymbolicLink()) continue;
+
+        const fullPath = path.join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+            newest = Math.max(newest, newestMtime(fullPath, extension))
+        } else if (entry.name.endsWith(extension)) {
+            newest = Math.max(newest, fs.statSync(fullPath).mtimeMs)
+        }
+    }
+
+    return newest
+}
+
+/**
+ * @summary Converts the canonical non-partial SCSS source tree into the complete development-CSS
+ * output census. The builder reads these same `src` + `theme*` roots; the generated theme map is
+ * intentionally not the authority because it is additive and can retain retired class paths.
+ * @param {String} [repoRoot] Repository root.
+ * @returns {String[]} Repo-relative CSS paths, sorted and deduplicated.
+ */
+export function getExpectedDevelopmentCss(repoRoot = REPO_ROOT) {
+    const files = new Set();
+
+    function visit(dir, targetRoot) {
+        for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+            if (entry.isSymbolicLink()) continue;
+
+            const fullPath = path.join(dir, entry.name);
+
+            if (entry.isDirectory()) {
+                visit(fullPath, targetRoot)
+            } else if (entry.name.endsWith('.scss') && !entry.name.startsWith('_')) {
+                const relative = path.relative(targetRoot, fullPath).replace(/\.scss$/, '.css');
+
+                files.add(path.join(
+                    'dist/development/css',
+                    path.basename(targetRoot),
+                    relative
+                ))
+            }
+        }
+    }
+
+    const scssRoot = path.join(repoRoot, 'resources/scss');
+
+    if (!fs.existsSync(scssRoot)) return [];
+
+    fs.readdirSync(scssRoot, {withFileTypes: true}).forEach(entry => {
+        if (entry.isDirectory() && !entry.isSymbolicLink() && (entry.name === 'src' || entry.name.includes('theme'))) {
+            const targetRoot = path.join(scssRoot, entry.name);
+
+            visit(targetRoot, targetRoot)
+        }
+    });
+
+    return [...files].sort()
+}
+
+/**
+ * @summary Returns true when a repo-relative output path traverses a symbolic-link segment.
+ * @param {String} repoRoot Repository root.
+ * @param {String} target Absolute output path within the repository.
+ * @returns {Boolean}
+ */
+function hasSymlinkSegment(repoRoot, target) {
+    const relative = path.relative(repoRoot, target);
+
+    if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return relative !== '';
+
+    let cursor = repoRoot;
+
+    for (const segment of relative.split(path.sep)) {
+        cursor = path.join(cursor, segment);
+
+        try {
+            if (fs.lstatSync(cursor).isSymbolicLink()) return true
+        } catch {
+            return false
+        }
+    }
+
+    return false
+}
+
+/**
+ * @summary Inspects whether this checkout has a complete, current development theme build.
+ * Every non-partial SCSS input must have a local CSS output at least as new as the newest SCSS
+ * source. The independently generated theme map is held to the same freshness boundary.
+ * @param {Object} [options]
+ * @param {String} [options.repoRoot] Repository root to inspect.
+ * @returns {{expectedCss: String[], invalidMap: String|null, missing: String[], newestScss: Number,
+ *            ready: Boolean, stale: String[], symlinked: String[]}}
+ */
+export function inspectDevelopmentThemeAssets({repoRoot = REPO_ROOT} = {}) {
+    const
+        cssRoot    = path.join(repoRoot, 'dist/development/css'),
+        mapPath    = path.join(repoRoot, 'resources/theme-map.json'),
+        newestScss = newestMtime(path.join(repoRoot, 'resources/scss'), '.scss'),
+        missing    = [],
+        stale      = [],
+        symlinked  = [];
+
+    let expectedCss = getExpectedDevelopmentCss(repoRoot),
+        invalidMap  = null,
+        mapStat;
+
+    if (hasSymlinkSegment(repoRoot, mapPath)) {
+        symlinked.push('resources/theme-map.json')
+    } else {
+        try {
+            mapStat = fs.statSync(mapPath);
+
+            if (!mapStat.isFile()) {
+                missing.push('resources/theme-map.json')
+            } else {
+                const themeMap = JSON.parse(fs.readFileSync(mapPath, 'utf8'));
+
+                if (!themeMap || typeof themeMap !== 'object' || Object.keys(themeMap).length === 0) {
+                    invalidMap = 'theme-map contains no class entries'
+                }
+            }
+        } catch (error) {
+            if (error.code === 'ENOENT') {
+                missing.push('resources/theme-map.json')
+            } else {
+                invalidMap = error.message
+            }
+        }
+    }
+
+    if (!hasSymlinkSegment(repoRoot, cssRoot)) {
+        try {
+            if (!fs.statSync(cssRoot).isDirectory()) missing.push('dist/development/css')
+        } catch {
+            missing.push('dist/development/css')
+        }
+    } else {
+        symlinked.push('dist/development/css')
+    }
+
+    if (mapStat?.mtimeMs < newestScss) stale.push('resources/theme-map.json');
+    if (expectedCss.length === 0) invalidMap ??= 'SCSS source tree contains no buildable theme files';
+
+    expectedCss.forEach(relativePath => {
+        const absolutePath = path.join(repoRoot, relativePath);
+
+        if (hasSymlinkSegment(repoRoot, absolutePath)) {
+            symlinked.push(relativePath);
+            return
+        }
+
+        try {
+            const stat = fs.statSync(absolutePath);
+
+            if (!stat.isFile()) {
+                missing.push(relativePath)
+            } else if (stat.mtimeMs < newestScss) {
+                stale.push(relativePath)
+            }
+        } catch {
+            missing.push(relativePath)
+        }
+    });
+
+    return {
+        expectedCss,
+        invalidMap,
+        missing  : [...new Set(missing)].sort(),
+        newestScss,
+        ready    : newestScss > 0 && !invalidMap && missing.length === 0 && stale.length === 0 && symlinked.length === 0,
+        stale    : [...new Set(stale)].sort(),
+        symlinked: [...new Set(symlinked)].sort()
+    }
+}
+
+/**
+ * @summary Runs the one canonical, non-interactive all-theme development build.
+ * @param {Object} [options]
+ * @param {String} [options.repoRoot] Repository root in which to run npm.
+ * @returns {Promise<void>}
+ */
+export function runDevelopmentThemeBuild({repoRoot = REPO_ROOT} = {}) {
+    const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+    return new Promise((resolve, reject) => {
+        const child = spawn(
+            npmCommand,
+            ['run', 'build-themes', '--', '-n', '-e', 'dev', '-t', 'all'],
+            {cwd: repoRoot, stdio: 'inherit'}
+        );
+
+        child.once('error', error => reject(new Error(
+            `E2E theme preflight could not run \`${DEVELOPMENT_THEME_BUILD_COMMAND}\`: ${error.message}`
+        )));
+        child.once('exit', (code, signal) => {
+            if (code === 0) {
+                resolve()
+            } else {
+                reject(new Error(
+                    `E2E theme preflight: \`${DEVELOPMENT_THEME_BUILD_COMMAND}\` failed ` +
+                    `with ${signal ? `signal ${signal}` : `exit code ${code}`}`
+                ))
+            }
+        })
+    })
+}
+
+/**
+ * @summary Materializes current development themes exactly once when inspection finds missing,
+ * stale, invalid, or symlink-borrowed outputs, then revalidates before Playwright starts a server.
+ * @param {Object} [options]
+ * @param {String} [options.repoRoot] Repository root to inspect and build.
+ * @param {Function} [options.build] Injectable builder seam for focused tests.
+ * @param {Object} [options.logger] Console-compatible logger.
+ * @returns {Promise<{built: Boolean, state: Object}>}
+ */
+export async function ensureDevelopmentThemeAssets({
+    repoRoot = REPO_ROOT,
+    build    = runDevelopmentThemeBuild,
+    logger   = console
+} = {}) {
+    let state = inspectDevelopmentThemeAssets({repoRoot});
+
+    if (state.ready) return {built: false, state};
+
+    logger.log(`[e2e] development theme assets are missing or stale — running ${DEVELOPMENT_THEME_BUILD_COMMAND}`);
+
+    try {
+        await build({repoRoot})
+    } catch (error) {
+        throw new Error(
+            `E2E theme preflight failed before browser startup: ${error.message}\n` +
+            `Recovery: ${DEVELOPMENT_THEME_BUILD_COMMAND}`
+        )
+    }
+
+    state = inspectDevelopmentThemeAssets({repoRoot});
+
+    if (!state.ready) {
+        const details = [
+            state.invalidMap && `invalid map: ${state.invalidMap}`,
+            state.missing.length > 0   && `missing: ${state.missing.join(', ')}`,
+            state.stale.length > 0     && `stale: ${state.stale.join(', ')}`,
+            state.symlinked.length > 0 && `symlinked: ${state.symlinked.join(', ')}`
+        ].filter(Boolean).join('; ');
+
+        throw new Error(
+            `E2E theme preflight incomplete after a successful builder exit${details ? ` (${details})` : ''}.\n` +
+            `Recovery: ${DEVELOPMENT_THEME_BUILD_COMMAND}`
+        )
+    }
+
+    return {built: true, state}
+}

--- a/buildScripts/util/developmentThemeAssets.mjs
+++ b/buildScripts/util/developmentThemeAssets.mjs
@@ -80,6 +80,71 @@ export function getExpectedDevelopmentCss(repoRoot = REPO_ROOT) {
 }
 
 /**
+ * @summary Converts the canonical non-partial SCSS source tree into the complete theme-map class
+ * census — every class the runtime can ask the map for. Derivation mirrors the builder's
+ * `getScssFiles` exactly: dot-joined relative path; the `apps.*` namespace stays top-level,
+ * everything else takes the `Neo.` prefix. The map itself is never the census authority: it is
+ * additive and can retain retired class paths.
+ * @param {String} [repoRoot] Repository root.
+ * @returns {Object[]} `{className, root}` entries, sorted by className then root.
+ */
+export function getExpectedThemeClasses(repoRoot = REPO_ROOT) {
+    const entries = [];
+
+    function visit(dir, rootName, relativePath) {
+        for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+            if (entry.isSymbolicLink()) continue;
+
+            const fullPath = path.join(dir, entry.name);
+
+            if (entry.isDirectory()) {
+                visit(fullPath, rootName, `${relativePath}/${entry.name}`)
+            } else if (entry.name.endsWith('.scss') && !entry.name.startsWith('_')) {
+                const base     = entry.name.slice(0, -'.scss'.length),
+                      relative = relativePath === '' ? base : `${relativePath.substring(1)}/${base}`;
+
+                let className = relative.split('/').join('.');
+
+                if (!className.startsWith('apps.')) className = 'Neo.' + className;
+
+                entries.push({className, root: rootName})
+            }
+        }
+    }
+
+    const scssRoot = path.join(repoRoot, 'resources/scss');
+
+    if (!fs.existsSync(scssRoot)) return [];
+
+    fs.readdirSync(scssRoot, {withFileTypes: true}).forEach(entry => {
+        if (entry.isDirectory() && !entry.isSymbolicLink() && (entry.name === 'src' || entry.name.includes('theme'))) {
+            visit(path.join(scssRoot, entry.name), entry.name, '')
+        }
+    });
+
+    return entries.sort((a, b) => a.className.localeCompare(b.className) || a.root.localeCompare(b.root))
+}
+
+/**
+ * @summary Returns true when the nested theme-map namespace tree holds a leaf array for the class
+ * that includes the given source root. Runtime reachability (`src/worker/App.mjs` resolves theme
+ * folders through exactly these per-class entries) requires both: the class present and the root
+ * listed. A fresh CSS file on disk without this entry is a file the runtime never requests.
+ * @param {Object} themeMap Parsed `resources/theme-map.json`.
+ * @param {String} className Dot-joined class name, e.g. `Neo.button.Base`.
+ * @param {String} root Source root directory name, e.g. `src` or `theme-neo-dark`.
+ * @returns {Boolean}
+ */
+function themeMapHasClass(themeMap, className, root) {
+    const leaf = className.split('.').reduce(
+        (ns, segment) => (ns && typeof ns === 'object') ? ns[segment] : undefined,
+        themeMap
+    );
+
+    return Array.isArray(leaf) && leaf.includes(root)
+}
+
+/**
  * @summary Returns true when a repo-relative output path traverses a symbolic-link segment.
  * @param {String} repoRoot Repository root.
  * @param {String} target Absolute output path within the repository.
@@ -108,24 +173,28 @@ function hasSymlinkSegment(repoRoot, target) {
 /**
  * @summary Inspects whether this checkout has a complete, current development theme build.
  * Every non-partial SCSS input must have a local CSS output at least as new as the newest SCSS
- * source. The independently generated theme map is held to the same freshness boundary.
+ * source. The independently generated theme map is held to the same freshness boundary AND to a
+ * completeness boundary: every census class must be present with its source root, or the runtime
+ * never requests that stylesheet (a fresh file on disk the map does not reach is unstyled).
  * @param {Object} [options]
  * @param {String} [options.repoRoot] Repository root to inspect.
- * @returns {{expectedCss: String[], invalidMap: String|null, missing: String[], newestScss: Number,
- *            ready: Boolean, stale: String[], symlinked: String[]}}
+ * @returns {{expectedCss: String[], invalidMap: String|null, mapMissing: String[], missing: String[],
+ *            newestScss: Number, ready: Boolean, stale: String[], symlinked: String[]}}
  */
 export function inspectDevelopmentThemeAssets({repoRoot = REPO_ROOT} = {}) {
     const
         cssRoot    = path.join(repoRoot, 'dist/development/css'),
         mapPath    = path.join(repoRoot, 'resources/theme-map.json'),
         newestScss = newestMtime(path.join(repoRoot, 'resources/scss'), '.scss'),
+        mapMissing = [],
         missing    = [],
         stale      = [],
         symlinked  = [];
 
     let expectedCss = getExpectedDevelopmentCss(repoRoot),
         invalidMap  = null,
-        mapStat;
+        mapStat,
+        themeMap;
 
     if (hasSymlinkSegment(repoRoot, mapPath)) {
         symlinked.push('resources/theme-map.json')
@@ -136,10 +205,11 @@ export function inspectDevelopmentThemeAssets({repoRoot = REPO_ROOT} = {}) {
             if (!mapStat.isFile()) {
                 missing.push('resources/theme-map.json')
             } else {
-                const themeMap = JSON.parse(fs.readFileSync(mapPath, 'utf8'));
+                themeMap = JSON.parse(fs.readFileSync(mapPath, 'utf8'));
 
                 if (!themeMap || typeof themeMap !== 'object' || Object.keys(themeMap).length === 0) {
-                    invalidMap = 'theme-map contains no class entries'
+                    invalidMap = 'theme-map contains no class entries';
+                    themeMap   = null
                 }
             }
         } catch (error) {
@@ -149,6 +219,14 @@ export function inspectDevelopmentThemeAssets({repoRoot = REPO_ROOT} = {}) {
                 invalidMap = error.message
             }
         }
+    }
+
+    if (themeMap) {
+        getExpectedThemeClasses(repoRoot).forEach(({className, root}) => {
+            if (!themeMapHasClass(themeMap, className, root)) {
+                mapMissing.push(`${className} (${root})`)
+            }
+        })
     }
 
     if (!hasSymlinkSegment(repoRoot, cssRoot)) {
@@ -188,9 +266,10 @@ export function inspectDevelopmentThemeAssets({repoRoot = REPO_ROOT} = {}) {
     return {
         expectedCss,
         invalidMap,
+        mapMissing,
         missing  : [...new Set(missing)].sort(),
         newestScss,
-        ready    : newestScss > 0 && !invalidMap && missing.length === 0 && stale.length === 0 && symlinked.length === 0,
+        ready    : newestScss > 0 && !invalidMap && mapMissing.length === 0 && missing.length === 0 && stale.length === 0 && symlinked.length === 0,
         stale    : [...new Set(stale)].sort(),
         symlinked: [...new Set(symlinked)].sort()
     }
@@ -262,6 +341,7 @@ export async function ensureDevelopmentThemeAssets({
     if (!state.ready) {
         const details = [
             state.invalidMap && `invalid map: ${state.invalidMap}`,
+            state.mapMissing.length > 0 && `map missing entries: ${state.mapMissing.join(', ')}`,
             state.missing.length > 0   && `missing: ${state.missing.join(', ')}`,
             state.stale.length > 0     && `stale: ${state.stale.join(', ')}`,
             state.symlinked.length > 0 && `symlinked: ${state.symlinked.join(', ')}`

--- a/harness/prepareAssets.mjs
+++ b/harness/prepareAssets.mjs
@@ -4,6 +4,8 @@ import fs              from 'node:fs';
 import {fileURLToPath} from 'node:url';
 import path            from 'node:path';
 
+import {newestMtime} from '../buildScripts/util/developmentThemeAssets.mjs';
+
 const
     harnessDir = path.dirname(fileURLToPath(import.meta.url)),
     repoRoot   = path.resolve(harnessDir, '..'),
@@ -50,33 +52,6 @@ function buildTheme(theme) {
             code === 0 ? resolve() : reject(new Error(`Theme build failed for ${theme} with exit code ${code}`))
         })
     })
-}
-
-/**
- * @summary Newest file mtime (ms) under a directory tree, filtered by extension. Used to compare
- * SCSS sources against built CSS: existence alone cannot see a stale build.
- * @param {String} dir Absolute directory.
- * @param {String} extension E.g. `.scss`.
- * @returns {Number} Epoch ms of the newest matching file; 0 when none exist.
- */
-function newestMtime(dir, extension) {
-    let newest = 0;
-
-    if (!fs.existsSync(dir)) {
-        return newest
-    }
-
-    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
-        const fullPath = path.join(dir, entry.name);
-
-        if (entry.isDirectory()) {
-            newest = Math.max(newest, newestMtime(fullPath, extension))
-        } else if (entry.name.endsWith(extension)) {
-            newest = Math.max(newest, fs.statSync(fullPath).mtimeMs)
-        }
-    }
-
-    return newest
 }
 
 /**

--- a/test/playwright/e2e/globalSetup.mjs
+++ b/test/playwright/e2e/globalSetup.mjs
@@ -1,0 +1,19 @@
+import {pathToFileURL} from 'node:url';
+
+import {ensureDevelopmentThemeAssets} from '../../../buildScripts/util/developmentThemeAssets.mjs';
+
+/**
+ * @summary Ensures ordinary source-mode E2E starts only after this checkout owns a complete,
+ * current development theme build. Unlike visual baselines, functional E2E may self-heal its
+ * generated prerequisites before browser startup.
+ * @returns {Promise<void>}
+ */
+export default async function globalSetup() {
+    await ensureDevelopmentThemeAssets()
+}
+
+// Playwright starts `webServer` before its `globalSetup` hook. Executing this same module as the
+// first web-server command step closes that ordering gap; the later hook revalidates and no-ops.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    await globalSetup()
+}

--- a/test/playwright/playwright.config.e2e.mjs
+++ b/test/playwright/playwright.config.e2e.mjs
@@ -18,6 +18,7 @@ export default defineConfig({
     fullyParallel: false, // Maintain serial execution for benchmarks
     workers      : 1,     // Maintain serial execution for benchmarks
     timeout      : 90000, // E2E tests (like DevIndex) are heavy rendering apps
+    globalSetup  : './e2e/globalSetup.mjs',
 
     reporter: [
         ['list'],
@@ -32,7 +33,7 @@ export default defineConfig({
     },
 
     webServer: {
-        command            : `npm run server-start -- --port ${PORT} --no-open`,
+        command            : `node ./e2e/globalSetup.mjs && npm run server-start -- --port ${PORT} --no-open`,
         url                : `http://localhost:${PORT}`,
         // NEVER reuse: an already-listening server from a foreign clone satisfies the readiness URL
         // and silently serves the wrong tree to every spec (false reds AND, worse, false greens).

--- a/test/playwright/unit/ai/buildScripts/util/developmentThemeAssets.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/developmentThemeAssets.spec.mjs
@@ -1,0 +1,186 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'node:fs';
+import os             from 'node:os';
+import path           from 'node:path';
+
+import {
+    DEVELOPMENT_THEME_BUILD_COMMAND,
+    ensureDevelopmentThemeAssets,
+    inspectDevelopmentThemeAssets
+} from '../../../../../../buildScripts/util/developmentThemeAssets.mjs';
+
+/**
+ * @summary Pins the ordinary E2E theme preflight across fresh, missing, stale, failed-build,
+ * incomplete-output, and foreign-symlink states.
+ */
+test.describe('buildScripts/util/developmentThemeAssets (#15449)', () => {
+    const roots = [];
+
+    function createRoot() {
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'neo-e2e-themes-'));
+
+        roots.push(root);
+        return root
+    }
+
+    function writeFile(root, relativePath, mtimeMs, content='fixture') {
+        const file = path.join(root, relativePath);
+
+        fs.mkdirSync(path.dirname(file), {recursive: true});
+        fs.writeFileSync(file, content);
+        fs.utimesSync(file, mtimeMs / 1000, mtimeMs / 1000)
+    }
+
+    function materialize(root, mtimeMs=Date.now()) {
+        writeFile(root, 'resources/theme-map.json', mtimeMs, JSON.stringify({
+            Neo: {Global: ['src', 'theme-neo-dark']}
+        }));
+        writeFile(root, 'dist/development/css/src/Global.css', mtimeMs);
+        writeFile(root, 'dist/development/css/theme-neo-dark/Global.css', mtimeMs)
+    }
+
+    function seedScss(root, mtimeMs=1000) {
+        writeFile(root, 'resources/scss/src/Global.scss', mtimeMs);
+        writeFile(root, 'resources/scss/theme-neo-dark/Global.scss', mtimeMs)
+    }
+
+    test.afterAll(() => {
+        roots.forEach(root => fs.rmSync(root, {force: true, recursive: true}))
+    });
+
+    test('fresh outputs do not rebuild', async () => {
+        const root   = createRoot();
+        let   builds = 0;
+
+        seedScss(root, 1000);
+        materialize(root, 2000);
+
+        const result = await ensureDevelopmentThemeAssets({
+            repoRoot: root,
+            build   : async () => builds++,
+            logger  : {log() {}}
+        });
+
+        expect(result.built).toBe(false);
+        expect(result.state.ready).toBe(true);
+        expect(builds).toBe(0)
+    });
+
+    test('the SCSS source tree, not additive retired theme-map entries, owns the CSS census', () => {
+        const root = createRoot();
+
+        seedScss(root, 1000);
+        materialize(root, 2000);
+        writeFile(root, 'resources/theme-map.json', 2000, JSON.stringify({
+            'Neo.apps.agentos.RetiredPanel': ['src', 'theme-neo-dark'],
+            Neo                            : {Global: ['src', 'theme-neo-dark']}
+        }));
+
+        const state = inspectDevelopmentThemeAssets({repoRoot: root});
+
+        expect(state.ready).toBe(true);
+        expect(state.expectedCss).toEqual([
+            path.join('dist/development/css/src/Global.css'),
+            path.join('dist/development/css/theme-neo-dark/Global.css')
+        ]);
+        expect(state.missing).toEqual([])
+    });
+
+    for (const missingPath of [
+        'resources/theme-map.json',
+        'dist/development/css/theme-neo-dark/Global.css'
+    ]) {
+        test(`a missing ${missingPath} triggers exactly one canonical build`, async () => {
+            const root   = createRoot();
+            let   builds = 0;
+
+            seedScss(root, 1000);
+            materialize(root, 2000);
+            fs.rmSync(path.join(root, missingPath));
+
+            const result = await ensureDevelopmentThemeAssets({
+                repoRoot: root,
+                build   : async () => {
+                    builds++;
+                    materialize(root, 3000)
+                },
+                logger: {log() {}}
+            });
+
+            expect(result.built).toBe(true);
+            expect(result.state.ready).toBe(true);
+            expect(builds).toBe(1)
+        })
+    }
+
+    for (const stalePath of [
+        'resources/theme-map.json',
+        'dist/development/css/src/Global.css'
+    ]) {
+        test(`a stale ${stalePath} triggers exactly one canonical build`, async () => {
+            const root   = createRoot();
+            let   builds = 0;
+
+            seedScss(root, 2000);
+            materialize(root, 3000);
+            fs.utimesSync(path.join(root, stalePath), 1, 1);
+
+            const result = await ensureDevelopmentThemeAssets({
+                repoRoot: root,
+                build   : async () => {
+                    builds++;
+                    materialize(root, 4000)
+                },
+                logger: {log() {}}
+            });
+
+            expect(result.built).toBe(true);
+            expect(result.state.ready).toBe(true);
+            expect(builds).toBe(1)
+        })
+    }
+
+    test('a failed builder aborts before browser startup and names the canonical recovery command', async () => {
+        const root = createRoot();
+
+        seedScss(root);
+
+        await expect(ensureDevelopmentThemeAssets({
+            repoRoot: root,
+            build   : async () => { throw new Error('exit code 7') },
+            logger  : {log() {}}
+        })).rejects.toThrow(`exit code 7\nRecovery: ${DEVELOPMENT_THEME_BUILD_COMMAND}`)
+    });
+
+    test('a successful but incomplete builder aborts after exactly one attempt', async () => {
+        const root   = createRoot();
+        let   builds = 0;
+
+        seedScss(root);
+
+        await expect(ensureDevelopmentThemeAssets({
+            repoRoot: root,
+            build   : async () => builds++,
+            logger  : {log() {}}
+        })).rejects.toThrow(`Recovery: ${DEVELOPMENT_THEME_BUILD_COMMAND}`);
+
+        expect(builds).toBe(1)
+    });
+
+    test('a symlink-borrowed output is never accepted as checkout-local readiness', () => {
+        const root       = createRoot(),
+              foreign    = createRoot(),
+              linkedPath = path.join(root, 'dist/development/css/src/Global.css');
+
+        seedScss(root, 1000);
+        materialize(root, 2000);
+        writeFile(foreign, 'Global.css', 3000);
+        fs.rmSync(linkedPath);
+        fs.symlinkSync(path.join(foreign, 'Global.css'), linkedPath);
+
+        const state = inspectDevelopmentThemeAssets({repoRoot: root});
+
+        expect(state.ready).toBe(false);
+        expect(state.symlinked).toContain('dist/development/css/src/Global.css')
+    })
+});

--- a/test/playwright/unit/ai/buildScripts/util/developmentThemeAssets.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/developmentThemeAssets.spec.mjs
@@ -66,6 +66,67 @@ test.describe('buildScripts/util/developmentThemeAssets (#15449)', () => {
         expect(builds).toBe(0)
     });
 
+    test('a fresh map missing one census root entry is incomplete and triggers exactly one build', async () => {
+        const root   = createRoot();
+        let   builds = 0;
+
+        seedScss(root, 1000);
+        materialize(root, 2000);
+        writeFile(root, 'resources/theme-map.json', 3000, JSON.stringify({
+            Neo: {Global: ['src']} // fresh, parseable, non-empty — but theme-neo-dark is not reachable
+        }));
+
+        const state = inspectDevelopmentThemeAssets({repoRoot: root});
+
+        expect(state.ready).toBe(false);
+        expect(state.invalidMap).toBe(null);
+        expect(state.mapMissing).toEqual(['Neo.Global (theme-neo-dark)']);
+
+        const result = await ensureDevelopmentThemeAssets({
+            repoRoot: root,
+            build   : async () => {
+                builds++;
+                materialize(root, 4000)
+            },
+            logger: {log() {}}
+        });
+
+        expect(result.built).toBe(true);
+        expect(result.state.ready).toBe(true);
+        expect(builds).toBe(1)
+    });
+
+    test('a fresh map missing a census class entirely is incomplete and triggers exactly one build', async () => {
+        const root   = createRoot();
+        let   builds = 0;
+
+        seedScss(root, 1000);
+        writeFile(root, 'resources/scss/src/button/Base.scss', 1000);
+        materialize(root, 2000);
+        writeFile(root, 'dist/development/css/src/button/Base.css', 2000);
+
+        const state = inspectDevelopmentThemeAssets({repoRoot: root});
+
+        expect(state.ready).toBe(false);
+        expect(state.mapMissing).toEqual(['Neo.button.Base (src)']);
+
+        const result = await ensureDevelopmentThemeAssets({
+            repoRoot: root,
+            build   : async () => {
+                builds++;
+                materialize(root, 4000);
+                writeFile(root, 'resources/theme-map.json', 4000, JSON.stringify({
+                    Neo: {Global: ['src', 'theme-neo-dark'], button: {Base: ['src']}}
+                }))
+            },
+            logger: {log() {}}
+        });
+
+        expect(result.built).toBe(true);
+        expect(result.state.ready).toBe(true);
+        expect(builds).toBe(1)
+    });
+
     test('the SCSS source tree, not additive retired theme-map entries, owns the CSS census', () => {
         const root = createRoot();
 

--- a/test/playwright/visual/globalSetup.mjs
+++ b/test/playwright/visual/globalSetup.mjs
@@ -1,37 +1,9 @@
-import {readdirSync, statSync} from 'fs';
-import path                    from 'path';
-import {fileURLToPath}         from 'url';
+import path            from 'path';
+import {fileURLToPath} from 'url';
+
+import {newestMtime} from '../../../buildScripts/util/developmentThemeAssets.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../');
-
-/**
- * Returns the newest mtime (ms) of any file matching the extension under a directory tree.
- * @param {String} dir absolute directory
- * @param {String} ext file extension including the dot
- * @returns {Number} newest mtime in ms, or 0 when the tree is empty/absent
- */
-function newestMtime(dir, ext) {
-    let newest = 0;
-
-    let entries;
-    try {
-        entries = readdirSync(dir, {withFileTypes: true})
-    } catch (e) {
-        return 0
-    }
-
-    for (const entry of entries) {
-        const full = path.join(dir, entry.name);
-
-        if (entry.isDirectory()) {
-            newest = Math.max(newest, newestMtime(full, ext))
-        } else if (entry.name.endsWith(ext)) {
-            newest = Math.max(newest, statSync(full).mtimeMs)
-        }
-    }
-
-    return newest
-}
 
 /**
  * The rebuild-before-baseline invariant, enforced mechanically: the dist theme CSS is a


### PR DESCRIPTION
Resolves #15449

Ordinary source-mode E2E now owns its generated theme prerequisites: a shared inspector derives the development CSS census from current SCSS, validates local generated outputs, rejects borrowed symlink outputs, and invokes the canonical all-theme build exactly once when local outputs are missing, stale, invalid, or incomplete. Playwright executes that preflight before the source server and revalidates in `globalSetup`; the visual suite keeps its fail-loud golden policy. Current review status is explicit: Euclid's formal Request Changes requires the theme-map membership check to prove every census class is represented before merge.

Evidence: L1 (9 focused filesystem/decision witnesses, syntax checks, and repository preflight pass) → L3 achieved (tracked-only export `4372d3b4e6` built current themes, started the correct server, opened a styled browser, and reached product assertions; [Phoebe receipt](https://github.com/neomjs/neo/pull/15584#issuecomment-5039841302)). Residual: theme-map census-completeness remains merge-blocking under [Euclid's review](https://github.com/neomjs/neo/pull/15584#pullrequestreview-4749577819).

## Deltas from ticket

- Extracted `newestMtime()` into the shared development-theme helper so the harness and visual setup use one symlink-safe freshness primitive.
- The shared freshness primitive intentionally skips symlinked SCSS inputs as well as borrowed generated outputs, aligning both sides with the ticket's no-cross-checkout policy.
- Derived expected CSS from non-partial SCSS sources instead of treating the additive theme map as the output census; retired map entries therefore cannot manufacture false missing-output failures.
- Closed Playwright's `webServer`-before-`globalSetup` ordering gap by running the same idempotent setup module as the first server-command step.

## Test Evidence

- Development-theme decision surface: `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/developmentThemeAssets.spec.mjs --workers=1 --reporter=dot` — 9/9 passed at the current head.
- Changed executable modules: `node --check` on the helper, E2E setup, harness preparation, and visual setup — passed.
- Repository gates: `npm run agent-preflight -- --no-fix <six changed files>` — all requested gates passed; only unrelated non-blocking stale-overlay warnings surfaced.
- Author-host E2E attempts: both ran the preflight and started the correct checkout's webpack server, then the shared host hit `EMFILE: too many open files, watch` before page creation. No product assertion ran on that host.
- Exact-head healthy-host L3: tracked-only export `4372d3b4e6`, hydrated without development CSS or the theme map, built its own assets, opened a styled browser, and reached the first product assertion. The remaining `Fleet · 0 agents` versus `Fleet · 7 agents` failure reproduced identically on clean `dev` and is the separately ticketed roster-isolation defect `#15680`, not a theme-preflight failure.
- Visual-regression surface: no browser capture run; unit/source witnesses pin that its setup still fails loudly rather than rebuilding.
- Exact-head CI: all checks reported green at `4372d3b4e6`.

## Post-Merge Validation

- [ ] Re-run the named source-mode AgentOS journey on `dev` and confirm the theme preflight still materializes current assets before the browser; evaluate the separate roster-zero-state result under `#15680`.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session 019f7b8f-cb90-7c02-ad14-c4ed62a7edce.