### PR TITLE
feat(kimi): add turn-presence hook adapter (#15580)

### DIFF
--- a/.kimi-code/hooks/README.md
+++ b/.kimi-code/hooks/README.md
@@ -1,0 +1,35 @@
+# Kimi Code turn-presence hook
+
+This adapter connects Kimi Code's documented per-turn hook events to Neo's existing local
+`AGENT_TURN_PRESENCE` writer. It does not create a second liveness path: `add_memory` recency
+remains primary, while turn presence is a local mid-turn corroboration signal.
+
+## Install
+
+1. Ensure the Kimi seat process inherits its canonical `NEO_AGENT_IDENTITY` and, when configured,
+   `NEO_MEMORY_DB_PATH`. The repository adapter never reads a checkout `.env` or embeds a resident.
+2. Merge the five blocks from [`turn-presence.example.toml`](turn-presence.example.toml) into
+   `~/.kimi-code/config.toml`.
+3. Run `kimi doctor`, then start a new Kimi Code session from the Neo checkout.
+
+Kimi runs hook commands from the session project directory. The example resolves the Git root so
+it remains correct when the session starts in a nested directory, and explicitly carries the
+already-inherited identity into the child command. The five-second timeout is bounded well above the
+writer's own fail-soft timeout.
+
+## Event contract
+
+| Kimi event | Turn-presence action | Terminal state |
+|---|---|---|
+| `UserPromptSubmit` | `start` | — |
+| `PostToolUse` | `progress` | — |
+| `Stop` | `terminal` | `completed` |
+| `StopFailure` | `terminal` | `aborted` |
+| `Interrupt` | `terminal` | `aborted` |
+
+`SessionStart` and `SessionEnd` are deliberately not configured. They are session boundaries, not
+repeated turn boundaries, and Neo currently has no separate session-lifecycle telemetry owner for
+them. Unsupported or malformed events no-op. Missing identity, unavailable graph storage, timeout,
+or an adapter exception also exits without stdout and without blocking the Kimi session.
+
+Source contract: [Kimi Code Hooks](https://www.kimi.com/code/docs/en/kimi-code-cli/customization/hooks.html).

--- a/.kimi-code/hooks/turn-presence.example.toml
+++ b/.kimi-code/hooks/turn-presence.example.toml
@@ -1,0 +1,28 @@
+# Merge these blocks into ~/.kimi-code/config.toml, then start a new Kimi Code session.
+# The command re-exports the identity already inherited by the Kimi seat; it never
+# commits a resident name or credential.
+
+[[hooks]]
+event = "UserPromptSubmit"
+command = 'NEO_AGENT_IDENTITY="$NEO_AGENT_IDENTITY" /usr/bin/env node "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
+timeout = 5
+
+[[hooks]]
+event = "PostToolUse"
+command = 'NEO_AGENT_IDENTITY="$NEO_AGENT_IDENTITY" /usr/bin/env node "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
+timeout = 5
+
+[[hooks]]
+event = "Stop"
+command = 'NEO_AGENT_IDENTITY="$NEO_AGENT_IDENTITY" /usr/bin/env node "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
+timeout = 5
+
+[[hooks]]
+event = "StopFailure"
+command = 'NEO_AGENT_IDENTITY="$NEO_AGENT_IDENTITY" /usr/bin/env node "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
+timeout = 5
+
+[[hooks]]
+event = "Interrupt"
+command = 'NEO_AGENT_IDENTITY="$NEO_AGENT_IDENTITY" /usr/bin/env node "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
+timeout = 5

--- a/.kimi-code/hooks/turnPresenceHook.mjs
+++ b/.kimi-code/hooks/turnPresenceHook.mjs
@@ -1,0 +1,118 @@
+import {fileURLToPath, pathToFileURL} from 'node:url';
+import {
+    readHookPayload,
+    recordTurnPresenceFromHook
+} from '../../ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs';
+
+const EVENT_MAP = Object.freeze({
+    Interrupt: Object.freeze({
+        action       : 'terminal',
+        source       : 'kimi-interrupt',
+        terminalState: 'aborted'
+    }),
+    PostToolUse: Object.freeze({
+        action: 'progress',
+        source: 'kimi-post-tool-use'
+    }),
+    Stop: Object.freeze({
+        action       : 'terminal',
+        source       : 'kimi-stop',
+        terminalState: 'completed'
+    }),
+    StopFailure: Object.freeze({
+        action       : 'terminal',
+        source       : 'kimi-stop-failure',
+        terminalState: 'aborted'
+    }),
+    UserPromptSubmit: Object.freeze({
+        action: 'start',
+        source: 'kimi-user-prompt-submit'
+    })
+});
+
+/**
+ * @summary Parses Kimi Code hook stdin without letting malformed JSON break the session.
+ * @param {String} raw Raw hook stdin.
+ * @returns {*|null} Parsed payload, or null when stdin is empty or malformed.
+ */
+export function parseKimiHookPayload(raw) {
+    if (!raw) return null;
+
+    try {
+        return JSON.parse(raw)
+    } catch {
+        return null
+    }
+}
+
+/**
+ * @summary Resolves one documented Kimi per-turn hook event to the shared turn-presence contract.
+ * @param {*} hookPayload Parsed Kimi hook payload.
+ * @returns {Object|null} Shared writer action metadata, or null for deliberately unwired events.
+ */
+export function resolveKimiTurnPresenceEvent(hookPayload) {
+    const eventName = typeof hookPayload?.hook_event_name === 'string'
+        ? hookPayload.hook_event_name
+        : null;
+    const mapping = EVENT_MAP[eventName];
+
+    return mapping ? {...mapping, eventName} : null
+}
+
+/**
+ * @summary Records fail-soft Kimi Code turn presence through Memory Core's existing local writer.
+ * @param {Object} options
+ * @param {Object} [options.env=process.env] Environment inherited by the hook command.
+ * @param {*} [options.hookPayload] Parsed Kimi hook payload.
+ * @param {String|Date|Number} [options.now=new Date()] Clock override for tests.
+ * @param {String} [options.rootDir] Repository root.
+ * @returns {Promise<Object|undefined>}
+ */
+export async function recordKimiTurnPresence({
+    env = process.env,
+    hookPayload,
+    now = new Date(),
+    rootDir = fileURLToPath(new URL('../../', import.meta.url))
+} = {}) {
+    const event = resolveKimiTurnPresenceEvent(hookPayload);
+
+    if (!event) {
+        return {
+            eventName: typeof hookPayload?.hook_event_name === 'string'
+                ? hookPayload.hook_event_name
+                : null,
+            reason: 'unsupported-hook-event',
+            status: 'noop'
+        }
+    }
+
+    const {action, eventName, source, terminalState} = event;
+    const toolSuffix                                 = eventName === 'PostToolUse' && typeof hookPayload.tool_name === 'string'
+        ? ` ${hookPayload.tool_name}`
+        : '';
+
+    return recordTurnPresenceFromHook({
+        action,
+        env,
+        hookPayload,
+        note: `kimi ${eventName}${toolSuffix}`,
+        now,
+        rootDir,
+        source,
+        terminalState
+    })
+}
+
+/**
+ * @summary Runs the stdin adapter while preserving Kimi Code's fail-open hook boundary.
+ * @returns {Promise<void>}
+ */
+async function main() {
+    const hookPayload = parseKimiHookPayload(await readHookPayload());
+
+    await recordKimiTurnPresence({hookPayload})
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    await main().catch(() => {})
+}

--- a/learn/agentos/Hooks.md
+++ b/learn/agentos/Hooks.md
@@ -136,6 +136,22 @@ records, has a short-lived prompt-context fallback from `UserPromptSubmit`, and
 uses its own hook wiring. Those adapters are allowed to differ because their
 runtimes differ.
 
+Kimi Code adds a third harness edge for turn presence. Its documented command-hook
+surface names the repeated boundaries directly: `UserPromptSubmit`, `Stop`,
+`StopFailure`, and `Interrupt`, with `PostToolUse` available as an observation-only
+progress pulse. The adapter at `.kimi-code/hooks/turnPresenceHook.mjs` translates only
+those events into the shared local writer; `SessionStart` and `SessionEnd` remain
+unwired because a session boundary cannot stand in for every turn. The seat-local
+configuration stays in `~/.kimi-code/config.toml`, so no resident identity is committed.
+
+The harness-ablation distinction is narrower than “hooks versus no hooks.”
+[OpenCode plugins](https://opencode.ai/docs/plugins/) expose message, session, and tool
+events, but their current documented event list has no exact equivalents for Kimi's
+`UserPromptSubmit`, `Stop`, `StopFailure`, or `Interrupt` command boundaries. That is a
+separate adapter-mapping question, not evidence that OpenCode lacks a hook surface.
+[Kimi's hook reference](https://www.kimi.com/code/docs/en/kimi-code-cli/customization/hooks.html)
+is the source of authority for this adapter's event names and fail-open behavior.
+
 The no-hold rule is shared. Both adapters use the same parser, validator, and
 decision primitives for the questions that must not drift:
 

--- a/learn/benefits/ArchitectureOverview.md
+++ b/learn/benefits/ArchitectureOverview.md
@@ -468,6 +468,7 @@ Post-M6 ([#10986](https://github.com/neomjs/neo/issues/10986)) the per-MCP-serve
 | Package | Purpose | Key Classes | Decisions |
 |---|---|---|---|
 | `harness/` | The Electron packaging root — the optional native embodiment around the harness app (Body apps run without it): boots the dev-mode source app on the privileged `app://` origin, resolves the repo-root source graph through an explicit renderer-content allowlist for Neural-Link possession depth, supervises the Brain children it owns, and retains the cockpit behind an event-derived tray lifecycle; fail-closed content/window/navigation/permission posture; harness UI source stays in `apps/`, the Brain stays in `ai/`; produces packaged artifacts and release receipts without ceding product-source ownership | `main.mjs`, `appLifecycle.mjs`, `brain.mjs`, `contentPolicy.mjs`, `preload.cjs` | [ADR 0020](../agentos/decisions/0020-agent-harness-concept.md), [ADR 0034](../agentos/decisions/0034-electron-shell-architecture.md), [ADR 0037](../agentos/decisions/0037-fleet-manager-outward-door-topology.md) |
+| `.claude/hooks/`, `.codex/hooks/`, `.kimi-code/hooks/` | Thin harness-native payload adapters; shared policy and persistence remain owned by `ai/` | `turnPresenceHook.mjs`, `codex-context.mjs`, stop-hook adapters | [ADR 0002](../agentos/decisions/0002-phase3-wake-substrate-standards-alignment.md), [ADR 0035](../agentos/decisions/0035-live-lane-awareness-composition.md) |
 
 ## Architectural Decision Records
 

--- a/test/playwright/unit/hooks/kimiTurnPresenceHook.spec.mjs
+++ b/test/playwright/unit/hooks/kimiTurnPresenceHook.spec.mjs
@@ -1,0 +1,273 @@
+import {test, expect}  from '@playwright/test';
+import Database        from 'better-sqlite3';
+import {spawnSync}     from 'node:child_process';
+import fs              from 'node:fs';
+import os              from 'node:os';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+import {
+    parseKimiHookPayload,
+    recordKimiTurnPresence,
+    resolveKimiTurnPresenceEvent
+} from '../../../../.kimi-code/hooks/turnPresenceHook.mjs';
+
+const
+    configPath = fileURLToPath(new URL('../../../../.kimi-code/hooks/turn-presence.example.toml', import.meta.url)),
+    hookPath   = fileURLToPath(new URL('../../../../.kimi-code/hooks/turnPresenceHook.mjs', import.meta.url)),
+    rootDir    = fileURLToPath(new URL('../../../..', import.meta.url));
+
+/**
+ * @summary Creates the minimal graph fixture consumed by the fail-soft hook writer.
+ * @param {String} prefix Temporary-directory prefix.
+ * @returns {{db: Database, dbPath: String, dir: String}}
+ */
+function createGraphFixture(prefix='kimi-turn-presence-hook-') {
+    const dir    = fs.mkdtempSync(path.join(os.tmpdir(), prefix)),
+          dbPath = path.join(dir, 'graph.sqlite'),
+          db     = new Database(dbPath);
+
+    db.exec(`
+        CREATE TABLE Nodes (
+            id TEXT PRIMARY KEY,
+            user_id TEXT,
+            data TEXT
+        )
+    `);
+
+    return {db, dbPath, dir}
+}
+
+/**
+ * @summary Closes and removes one temporary graph fixture.
+ * @param {{db: Database, dir: String}} fixture Graph fixture.
+ * @returns {void}
+ */
+function destroyGraphFixture({db, dir}) {
+    db.close();
+    fs.rmSync(dir, {recursive: true, force: true})
+}
+
+/**
+ * @summary Reads every persisted turn-presence node from a fixture database.
+ * @param {Database} db SQLite database.
+ * @returns {Object[]}
+ */
+function readTurnPresenceNodes(db) {
+    return db.prepare('SELECT data FROM Nodes WHERE id LIKE ? ORDER BY id')
+        .all('AGENT_TURN_PRESENCE:%')
+        .map(({data}) => JSON.parse(data))
+}
+
+test.describe('Kimi Code turn-presence hook adapter', () => {
+    test('maps only the documented per-turn event contract', () => {
+        const expected = {
+            Interrupt: {
+                action       : 'terminal',
+                eventName    : 'Interrupt',
+                source       : 'kimi-interrupt',
+                terminalState: 'aborted'
+            },
+            PostToolUse: {
+                action   : 'progress',
+                eventName: 'PostToolUse',
+                source   : 'kimi-post-tool-use'
+            },
+            Stop: {
+                action       : 'terminal',
+                eventName    : 'Stop',
+                source       : 'kimi-stop',
+                terminalState: 'completed'
+            },
+            StopFailure: {
+                action       : 'terminal',
+                eventName    : 'StopFailure',
+                source       : 'kimi-stop-failure',
+                terminalState: 'aborted'
+            },
+            UserPromptSubmit: {
+                action   : 'start',
+                eventName: 'UserPromptSubmit',
+                source   : 'kimi-user-prompt-submit'
+            }
+        };
+
+        Object.entries(expected).forEach(([hook_event_name, mapping]) => {
+            expect(resolveKimiTurnPresenceEvent({hook_event_name})).toEqual(mapping)
+        });
+
+        ['SessionStart', 'SessionEnd', 'PostToolUseFailure'].forEach(hook_event_name => {
+            expect(resolveKimiTurnPresenceEvent({hook_event_name})).toBeNull()
+        });
+        expect(resolveKimiTurnPresenceEvent(null)).toBeNull();
+        expect(parseKimiHookPayload('{malformed')).toBeNull()
+    });
+
+    test('keeps the install template schema-bounded and identity-neutral', () => {
+        const blocks = fs.readFileSync(configPath, 'utf8')
+            .split('[[hooks]]')
+            .slice(1)
+            .map(block => Object.fromEntries(block.trim().split('\n')
+                .filter(line => line && !line.startsWith('#'))
+                .map(line => {
+                    const separator = line.indexOf('='),
+                          key       = line.slice(0, separator).trim(),
+                          rawValue  = line.slice(separator + 1).trim(),
+                          value     = rawValue.replace(/^(['"])(.*)\1$/, '$2');
+
+                    return [key, key === 'timeout' ? Number(value) : value]
+                })));
+
+        expect(blocks.map(({event}) => event)).toEqual([
+            'UserPromptSubmit',
+            'PostToolUse',
+            'Stop',
+            'StopFailure',
+            'Interrupt'
+        ]);
+        blocks.forEach(block => {
+            expect(Object.keys(block).sort()).toEqual(['command', 'event', 'timeout']);
+            expect(block.timeout).toBe(5);
+            expect(block.command).toBe(
+                'NEO_AGENT_IDENTITY="$NEO_AGENT_IDENTITY" /usr/bin/env node "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
+            );
+            expect(block.command).not.toMatch(/@neo-/)
+        })
+    });
+
+    test('records start, progress, and completed terminal state on one active turn', async () => {
+        const fixture = createGraphFixture();
+        const env     = {
+            NEO_AGENT_IDENTITY        : '@test-kimi',
+            NEO_MEMORY_DB_PATH        : fixture.dbPath,
+            NEO_TURN_PRESENCE_FRESH_MS: '60000',
+            NEO_TURN_PRESENCE_TTL_MS  : '600000'
+        };
+
+        try {
+            await recordKimiTurnPresence({
+                env,
+                hookPayload: {hook_event_name: 'UserPromptSubmit', session_id: 'session-test'},
+                now        : '2026-07-19T20:00:00.000Z',
+                rootDir
+            });
+            await recordKimiTurnPresence({
+                env,
+                hookPayload: {hook_event_name: 'PostToolUse', tool_name: 'Shell'},
+                now        : '2026-07-19T20:01:00.000Z',
+                rootDir
+            });
+            const result = await recordKimiTurnPresence({
+                env,
+                hookPayload: {hook_event_name: 'Stop'},
+                now        : '2026-07-19T20:02:00.000Z',
+                rootDir
+            });
+
+            expect(result).toMatchObject({
+                action       : 'terminal',
+                agentIdentity: '@test-kimi',
+                source       : 'kimi-stop',
+                status       : 'recorded',
+                terminalState: 'completed'
+            });
+
+            const nodes = readTurnPresenceNodes(fixture.db);
+            expect(nodes).toHaveLength(1);
+            expect(nodes[0].properties).toMatchObject({
+                agentIdentity : '@test-kimi',
+                lastProgressAt: '2026-07-19T20:02:00.000Z',
+                note          : 'kimi Stop',
+                source        : 'kimi-stop',
+                startedAt     : '2026-07-19T20:00:00.000Z',
+                status        : 'terminal',
+                terminalState : 'completed'
+            })
+        } finally {
+            destroyGraphFixture(fixture)
+        }
+    });
+
+    for (const eventName of ['StopFailure', 'Interrupt']) {
+        test(`${eventName} terminates the active turn as aborted`, async () => {
+            const fixture = createGraphFixture();
+            const env     = {
+                NEO_AGENT_IDENTITY: '@test-kimi',
+                NEO_MEMORY_DB_PATH: fixture.dbPath
+            };
+
+            try {
+                await recordKimiTurnPresence({
+                    env,
+                    hookPayload: {hook_event_name: 'UserPromptSubmit'},
+                    now        : '2026-07-19T20:00:00.000Z',
+                    rootDir
+                });
+                await recordKimiTurnPresence({
+                    env,
+                    hookPayload: {hook_event_name: eventName},
+                    now        : '2026-07-19T20:01:00.000Z',
+                    rootDir
+                });
+
+                expect(readTurnPresenceNodes(fixture.db)[0].properties).toMatchObject({
+                    source       : eventName === 'Interrupt' ? 'kimi-interrupt' : 'kimi-stop-failure',
+                    status       : 'terminal',
+                    terminalState: 'aborted'
+                })
+            } finally {
+                destroyGraphFixture(fixture)
+            }
+        })
+    }
+
+    test('session events and missing identity fail soft without writing', async () => {
+        const fixture = createGraphFixture();
+
+        try {
+            await expect(recordKimiTurnPresence({
+                env        : {NEO_AGENT_IDENTITY: '@test-kimi', NEO_MEMORY_DB_PATH: fixture.dbPath},
+                hookPayload: {hook_event_name: 'SessionStart'},
+                rootDir
+            })).resolves.toEqual({
+                eventName: 'SessionStart',
+                reason   : 'unsupported-hook-event',
+                status   : 'noop'
+            });
+
+            await expect(recordKimiTurnPresence({
+                env        : {NEO_MEMORY_DB_PATH: fixture.dbPath},
+                hookPayload: {hook_event_name: 'UserPromptSubmit'},
+                rootDir
+            })).resolves.toBeUndefined();
+
+            expect(readTurnPresenceNodes(fixture.db)).toHaveLength(0)
+        } finally {
+            destroyGraphFixture(fixture)
+        }
+    });
+
+    test('the executable adapter exits cleanly when the local writer rejects', () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kimi-turn-presence-process-'));
+
+        try {
+            const result = spawnSync(process.execPath, [hookPath], {
+                encoding: 'utf8',
+                env     : {
+                    ...process.env,
+                    NEO_AGENT_IDENTITY: '@test-kimi',
+                    NEO_MEMORY_DB_PATH: path.join(dir, 'missing.sqlite')
+                },
+                input  : JSON.stringify({hook_event_name: 'UserPromptSubmit'}),
+                timeout: 5000
+            });
+
+            expect(result.error).toBeUndefined();
+            expect(result.status).toBe(0);
+            expect(result.stdout).toBe('');
+            expect(result.stderr).toBe('')
+        } finally {
+            fs.rmSync(dir, {recursive: true, force: true})
+        }
+    })
+});


### PR DESCRIPTION
Resolves #15580

Adds a fail-soft Kimi Code command-hook adapter for Neo's existing local turn-presence writer. The adapter maps Kimi's documented per-turn events, keeps session-only events explicitly unwired, ships an identity-neutral seat-config template, and records the harness distinction without claiming that OpenCode lacks hooks.

Evidence: L4 covers the real Iris-seat start→terminal path on exact head `ee9b17c95c` and the Kimi-runtime hook-crash fail-open boundary, while L3 covers the complete event map and adapter fail-soft cases. AC5 is **L4-deferred to post-merge seat validation**: the final repository-relative adapter path cannot exist in Iris's merged checkout before this PR lands. If that merged-seat validation fails, the failure gets a focused follow-up ticket rather than keeping this bounded adapter PR in a circular draft gate.

## Deltas from ticket

- Corrected the intake premise before implementation: `SessionStart` and `SessionEnd` remain deliberately unwired because Neo has no separate session-lifecycle telemetry owner; they are not turn substitutes.
- Corrected the harness-diff premise: OpenCode has plugin events, but its current documented list has no exact equivalents for Kimi's `UserPromptSubmit`, `Stop`, `StopFailure`, or `Interrupt` command boundaries.
- Included optional `PostToolUse → progress` mapping for parity with the shared writer.
- Added the new `.kimi-code/hooks/` harness edge to the architecture inventory.
- Moved AC5's final `who_is_online({verbose:true})` receipt to explicit post-merge validation per operator direction (2026-07-21), removing the merge-dependent proof from the pre-approval gate.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/hooks/kimiTurnPresenceHook.spec.mjs` — 7/7 passed at rebased head `ee9b17c95c`.
- `npm run test-unit` — 8,809 passed, 5 skipped, 4 unrelated failures across 8,818 tests. `GalleryInternalId`, Auth initialization, and TextEmbedding all passed in the bounded isolated rerun; `lintTreeJson` remained the sole isolated failure because its real-tree call exceeded 30 seconds, then printed its successful 220-node result after timeout.
- `npm run test-unit -- test/playwright/unit/selection/GalleryInternalId.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/Auth.spec.mjs test/playwright/unit/ai/scripts/lint/lintTreeJson.spec.mjs test/playwright/unit/ai/services/memory-core/TextEmbeddingService.spec.mjs` — 55 passed; only the existing `lintTreeJson` 30-second macOS timeout remained.
- `npm run agent-preflight -- --no-fix` — staged commit gates passed.
- `node --check .kimi-code/hooks/turnPresenceHook.mjs` and `node --check test/playwright/unit/hooks/kimiTurnPresenceHook.spec.mjs` — passed.
- `KIMI_CODE_HOME=<temporary-directory> kimi doctor` with Kimi Code 0.27.0 and the exact checked-in template — configuration accepted.
- Real Iris seat on Kimi Code 0.27.0 — all five hooks accepted alongside the sibling SessionStart hook; a real headless turn produced `AGENT_TURN_PRESENCE:@neo-kimi-iris:cd831fad-5c1e-4ebf-8bdb-b17ebbdb2396`.
- Live fail-open audit — an extra `UserPromptSubmit` hook with `/usr/bin/false` failed while `kimi -p` accepted and proceeded with the prompt; the probe hook was then removed.
- Shared-graph audit — that row spans `startedAt 2026-07-19T20:42:59.923Z` to terminal update `2026-07-19T20:43:09.406Z`, ending `source: kimi-stop`, `status: terminal`, `terminalState: completed`; only the start action can create its turn id.
- Surface coverage: no prior Kimi turn-presence adapter tests existed; the new spec covers every mapped event, deliberate noops, identity neutrality, real SQLite persistence, and executable fail-soft behavior.

## Post-Merge Validation

- [ ] Replace the temporary live-proof adapter path in Iris's seat-local config with the repository-relative template from her merged checkout; run `kimi doctor` and restart the session.
- [x] Observe Iris's next real `UserPromptSubmit → Stop` sequence and retain the hook source/state receipt in #15580.
- [ ] After the merged adapter is installed, run `who_is_online({verbose:true})` while Iris's add-memory signal is stale and her Kimi turn signal is fresh; retain the projection receipt in #15580. If the rescue is absent or incorrect, open a focused follow-up ticket.

## Evolution

The lane exposed two ticket-authoring hazards before code landed: treating session boundaries as turn boundaries, and describing a missing exact event vocabulary as “no hooks.” Both were corrected at the source ticket and encoded in docs/tests so the distinctions survive future harness work.

Authored by Euclid (GPT-5.6, Codex Desktop). Session b4496dab-2fb9-4548-9293-78b4a3d78f60.
