### PR TITLE
feat(ai): add the kimi-server wake adapter for A2A wake delivery (#15579)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,10 @@ sent-to-cull.jsonl
 # Per-seat OpenCode harness config (seat-personal; the #15392 seat-config generator emits it — never track it)
 /opencode.jsonc
 
+# Per-seat Kimi Code harness config (seat-personal; hook adapters under .kimi-code/hooks/ stay tracked, Claude/Codex parity)
+/.kimi-code/mcp.json
+/.kimi-code/config.toml
+
 # Playwright test results
 test/playwright/test-results/
 # Single-file Playwright runs via npx

--- a/.kimi-code/hooks/wakeEnvelopeHook.mjs
+++ b/.kimi-code/hooks/wakeEnvelopeHook.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import fs   from 'node:fs';
+import os   from 'node:os';
+import path from 'node:path';
+
+/**
+ * @summary Kimi Code `SessionStart` hook: refreshes the seat's wake envelope with the exact
+ * session authority the Neo wake daemon's `kimi-server` adapter delivers into.
+ *
+ * The Kimi hook contract passes `{hook_event_name, session_id, cwd}` on stdin for every event
+ * (official hook reference). This writer maps that payload onto the wake-envelope contract:
+ * `~/.kimi-code/wake-envelope.json` (mode 0600) carrying `{sessionId, cwd, updatedAt}`. The
+ * wake daemon re-reads the envelope on every delivery, so session rotation (startup/resume)
+ * needs no graph write and a wake can never be steered into a heuristic "latest" session —
+ * the envelope is the session authority, not the session index.
+ *
+ * Fail-open by design: hook errors must never disturb the seat's session (Kimi fail-open
+ * discipline mirrors the writer's). A malformed payload or unwritable path exits 0 silently.
+ *
+ * Seat wiring (`~/.kimi-code/config.toml`, seat-local, never committed):
+ * ```toml
+ * [[hooks]]
+ * event   = "SessionStart"
+ * command = "node .kimi-code/hooks/wakeEnvelopeHook.mjs"
+ * timeout = 5
+ * ```
+ *
+ * Sibling of `.claude/hooks/turnPresenceHook.mjs` and `.codex/hooks/codex-context.mjs` —
+ * same adapter contract shape: stdin JSON in, bounded local write, no Neo singleton imports.
+ */
+const ENVELOPE_PATH = path.join(os.homedir(), '.kimi-code', 'wake-envelope.json');
+
+let input = '';
+
+process.stdin.on('data', chunk => { input += chunk });
+
+process.stdin.on('end', () => {
+    try {
+        const payload                      = JSON.parse(input),
+              {session_id: sessionId, cwd} = payload || {};
+
+        if (typeof sessionId === 'string' && sessionId.length > 0 && typeof cwd === 'string' && cwd.length > 0) {
+            fs.writeFileSync(
+                ENVELOPE_PATH,
+                JSON.stringify({sessionId, cwd, updatedAt: new Date().toISOString()}, null, 2),
+                {mode: 0o600}
+            );
+        }
+    } catch {
+        // Fail-open: a malformed payload or write failure must never disturb the session.
+    }
+
+    process.exit(0);
+});

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -98,6 +98,7 @@ const LOG_RETENTION_DAYS                = 30;
 const POLL_INTERVAL_MS                  = 3000;
 const CODEX_APP_SERVER_ADAPTER          = 'codex-app-server';
 const OPENCODE_SERVER_ADAPTER           = 'opencode-server';
+const KIMI_SERVER_ADAPTER               = 'kimi-server';
 const CODEX_TURN_START_PROOF_TIMEOUT_MS = Number(process.env.WAKE_CODEX_TURN_START_PROOF_TIMEOUT_MS) || 45000;
 const CODEX_TURN_START_PROOF_POLL_MS    = Number(process.env.WAKE_CODEX_TURN_START_PROOF_POLL_MS) || 1000;
 const CODEX_WAKE_SUBMIT_NONCE_PREFIX    = 'NEO_WAKE_SUBMIT_NONCE:';
@@ -1100,6 +1101,127 @@ async function deliverViaOpencodeServer(subscription, digest, evidenceLabel = ''
 }
 
 /**
+ * @summary Dispatches a wake digest into a live Kimi Code session through the seat's local
+ * `kimi server` REST surface (`POST /api/v1/sessions/{id}/prompts` — submitPrompt).
+ *
+ * Explicit route for subscriptions configured as `kimi-server`. It intentionally does not
+ * fall back to `osascript`/tmux; a route explicitly configured as `kimi-server` must fail
+ * visibly instead of recreating the GUI-focus delivery path (opencode-server parity).
+ *
+ * **Coordinate contract** (no seat-side writer needed — the harness persists both files
+ * itself at server start): the loopback coordinates come from `~/.kimi-code/server/lock`
+ * (`{pid, host, port, …}`), the bearer token from `~/.kimi-code/server.token` (persistent
+ * across restarts; rotated via `kimi server rotate-token`). Both paths are overridable via
+ * `harnessTargetMetadata.lockPath` / `harnessTargetMetadata.tokenPath` (test seams). The
+ * daemon re-reads both on every delivery, so server restarts and token rotation need no
+ * graph write.
+ *
+ * **Session resolution:** the lock carries no session id, so the adapter resolves the
+ * target at delivery time from `GET /api/v1/sessions`: the non-archived session whose
+ * `metadata.cwd` equals `harnessTargetMetadata.cwd` (the seat checkout) with the newest
+ * `updated_at`. This survives session rotation (a fresh session per boot) with no
+ * envelope writes — the harness's own session index is the envelope.
+ *
+ * Probe evidence (2026-07-19, seat `@neo-kimi-iris`, kimi v0.27.0): loopback 127.0.0.1:58627
+ * with bearer auth default-on, `/openapi.json` enumerating the surface at runtime, the live
+ * session listing carrying `metadata.cwd`, and the submitPrompt contract
+ * `{content: [{type: 'text', text}]}` → HTTP 200 with `{code: 0, data: {status:
+ * running|queued|blocked}}`. A queued/blocked status still lands the digest in the
+ * session's own queue — the seat sees it when the active turn drains.
+ *
+ * @param {Object} subscription WAKE_SUBSCRIPTION node.
+ * @param {String} digest Wake digest body.
+ * @param {String} [evidenceLabel=''] Formatted wake scenario / route evidence for validation logs.
+ * @param {AbortSignal|null} [abortSignal=null] Shared attempt-bound signal from the delivery owner.
+ * @returns {Promise<void>}
+ */
+async function deliverViaKimiServer(subscription, digest, evidenceLabel = '', abortSignal = null) {
+    const meta      = subscription.properties?.harnessTargetMetadata || {};
+    const lockPath  = meta.lockPath  || path.join(os.homedir(), '.kimi-code', 'server', 'lock');
+    const tokenPath = meta.tokenPath || path.join(os.homedir(), '.kimi-code', 'server.token');
+    const cwd       = meta.cwd;
+
+    if (typeof cwd !== 'string' || cwd.length === 0) {
+        throw new Error(`kimi-server requires harnessTargetMetadata.cwd (the seat checkout path used for session resolution)`);
+    }
+
+    let lock, token;
+
+    try {
+        lock = JSON.parse(await fs.readFile(lockPath, 'utf8'));
+    } catch (err) {
+        throw new Error(`kimi-server requires a readable server lock at '${lockPath}' (${err.message})`);
+    }
+
+    try {
+        token = (await fs.readFile(tokenPath, 'utf8')).trim();
+    } catch (err) {
+        throw new Error(`kimi-server requires a readable bearer token at '${tokenPath}' (${err.message})`);
+    }
+
+    const {host, port} = lock;
+
+    // Typed + authority-checked coordinates: a malformed lock must never steer the daemon's HTTP
+    // client off the seat's loopback server. Delivery is globally serialized, so every fetch is
+    // also deadline-bounded — one hung endpoint must not wedge every later wake route.
+    if (!['127.0.0.1', 'localhost', '::1'].includes(host)) {
+        throw new Error(`kimi-server lock at '${lockPath}' requires a loopback host (received '${host}')`);
+    }
+
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        throw new Error(`kimi-server lock at '${lockPath}' requires 'port' to be an integer in 1..65535`);
+    }
+
+    if (token.length === 0) {
+        throw new Error(`kimi-server token at '${tokenPath}' is empty`);
+    }
+
+    const baseUrl   = `http://${host}:${port}`;
+    const headers   = {'content-type': 'application/json', 'authorization': `Bearer ${token}`};
+    const newSignal = () => abortSignal
+        ? AbortSignal.any([abortSignal, AbortSignal.timeout(5000)])
+        : AbortSignal.timeout(5000);
+
+    // Session resolution: the freshest non-archived session rooted at the seat checkout.
+    const listResponse = await fetch(`${baseUrl}/api/v1/sessions`, {headers, redirect: 'error', signal: newSignal()});
+
+    if (listResponse.status !== 200) {
+        throw new Error(`kimi-server GET /api/v1/sessions expected HTTP 200, received ${listResponse.status}`);
+    }
+
+    const listBody = await listResponse.json();
+    const sessions = Array.isArray(listBody?.data?.items) ? listBody.data.items : [];
+    const target   = sessions
+        .filter(session => session && session.archived !== true && session.metadata?.cwd === cwd)
+        .sort((a, b) => String(b.updated_at || '').localeCompare(String(a.updated_at || '')))[0];
+
+    if (!target || typeof target.id !== 'string' || target.id.length === 0) {
+        throw new Error(`kimi-server found no live session with metadata.cwd '${cwd}'`);
+    }
+
+    const submitResponse = await fetch(`${baseUrl}/api/v1/sessions/${encodeURIComponent(target.id)}/prompts`, {
+        method  : 'POST',
+        headers,
+        body    : JSON.stringify({content: [{type: 'text', text: digest}]}),
+        redirect: 'error',
+        signal  : newSignal()
+    });
+
+    if (submitResponse.status !== 200) {
+        throw new Error(`kimi-server submitPrompt expected HTTP 200, received ${submitResponse.status}`);
+    }
+
+    const submitBody = await submitResponse.json();
+
+    if (submitBody?.code !== 0) {
+        throw new Error(`kimi-server submitPrompt expected code 0, received ${JSON.stringify(submitBody?.code ?? null)}`);
+    }
+
+    const status = submitBody?.data?.status;
+    writeLog('INFO', `[Wake Daemon] Dispatched ${subscription.id} via kimi-server submitPrompt (session ${target.id}${status ? `, status=${status}` : ''})${evidenceLabel}`);
+}
+
+/**
  * @summary Delivers a wake digest via osascript, retrying transient frontmost-loss races.
  *
  * macOS focus-stealing prevention makes a background daemon's `activate` / `set frontmost`
@@ -1529,6 +1651,11 @@ async function deliverDigest(subscription, digest, deliveryEvidence = {}, abortS
 
         if (adapter === OPENCODE_SERVER_ADAPTER) {
             await deliverViaOpencodeServer(subscription, dispatchDigest, evidenceLabel, abortSignal);
+            return 'delivered';
+        }
+
+        if (adapter === KIMI_SERVER_ADAPTER) {
+            await deliverViaKimiServer(subscription, dispatchDigest, evidenceLabel, abortSignal);
             return 'delivered';
         }
 

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -1108,6 +1108,16 @@ async function deliverViaOpencodeServer(subscription, digest, evidenceLabel = ''
  * fall back to `osascript`/tmux; a route explicitly configured as `kimi-server` must fail
  * visibly instead of recreating the GUI-focus delivery path (opencode-server parity).
  *
+ * **Session authority — the wake envelope** (opencode-server envelope parity): the target
+ * session id comes from `~/.kimi-code/wake-envelope.json` (mode 0600, overridable via
+ * `harnessTargetMetadata.envelopePath`), written by the seat's SessionStart hook
+ * (`.kimi-code/hooks/wakeEnvelopeHook.mjs`) with the exact `{sessionId, cwd, updatedAt}` of
+ * the live session. The daemon re-reads the envelope on every delivery, so session rotation
+ * needs no graph write. Picking a session heuristically (e.g. freshest `updated_at` from the
+ * session index) is deliberately NOT the path: multiple resumed/child sessions can share one
+ * checkout, and a wake landing in the wrong session is a cross-session retarget. The envelope
+ * is the authority; a missing/mismatched envelope fails visibly.
+ *
  * **Coordinate contract** (no seat-side writer needed — the harness persists both files
  * itself at server start): the loopback coordinates come from `~/.kimi-code/server/lock`
  * (`{pid, host, port, …}`), the bearer token from `~/.kimi-code/server.token` (persistent
@@ -1116,17 +1126,12 @@ async function deliverViaOpencodeServer(subscription, digest, evidenceLabel = ''
  * daemon re-reads both on every delivery, so server restarts and token rotation need no
  * graph write.
  *
- * **Session resolution:** the lock carries no session id, so the adapter resolves the
- * target at delivery time from `GET /api/v1/sessions`: the non-archived session whose
- * `metadata.cwd` equals `harnessTargetMetadata.cwd` (the seat checkout) with the newest
- * `updated_at`. This survives session rotation (a fresh session per boot) with no
- * envelope writes — the harness's own session index is the envelope.
- *
  * Probe evidence (2026-07-19, seat `@neo-kimi-iris`, kimi v0.27.0): loopback 127.0.0.1:58627
- * with bearer auth default-on, `/openapi.json` enumerating the surface at runtime, the live
- * session listing carrying `metadata.cwd`, and the submitPrompt contract
- * `{content: [{type: 'text', text}]}` → HTTP 200 with `{code: 0, data: {status:
- * running|queued|blocked}}`. A queued/blocked status still lands the digest in the
+ * with bearer auth default-on, `/openapi.json` enumerating the surface at runtime, hook stdin
+ * carrying `session_id` + `cwd` for every event (official hook contract), and the submitPrompt
+ * contract `{content: [{type: 'text', text}]}` → HTTP 200 with `{code: 0, data: {status:
+ * running|queued|blocked}}` — HTTP 200 also wraps typed application errors, so delivery counts
+ * only after parsing `code === 0`. A queued/blocked status still lands the digest in the
  * session's own queue — the seat sees it when the active turn drains.
  *
  * @param {Object} subscription WAKE_SUBSCRIPTION node.
@@ -1136,16 +1141,35 @@ async function deliverViaOpencodeServer(subscription, digest, evidenceLabel = ''
  * @returns {Promise<void>}
  */
 async function deliverViaKimiServer(subscription, digest, evidenceLabel = '', abortSignal = null) {
-    const meta      = subscription.properties?.harnessTargetMetadata || {};
-    const lockPath  = meta.lockPath  || path.join(os.homedir(), '.kimi-code', 'server', 'lock');
-    const tokenPath = meta.tokenPath || path.join(os.homedir(), '.kimi-code', 'server.token');
-    const cwd       = meta.cwd;
+    const meta         = subscription.properties?.harnessTargetMetadata || {};
+    const lockPath     = meta.lockPath     || path.join(os.homedir(), '.kimi-code', 'server', 'lock');
+    const tokenPath    = meta.tokenPath    || path.join(os.homedir(), '.kimi-code', 'server.token');
+    const envelopePath = meta.envelopePath || path.join(os.homedir(), '.kimi-code', 'wake-envelope.json');
 
-    if (typeof cwd !== 'string' || cwd.length === 0) {
-        throw new Error(`kimi-server requires harnessTargetMetadata.cwd (the seat checkout path used for session resolution)`);
+    let envelope, lock, token;
+
+    try {
+        envelope = JSON.parse(await fs.readFile(envelopePath, 'utf8'));
+    } catch (err) {
+        throw new Error(`kimi-server requires a readable wake envelope at '${envelopePath}' (${err.message})`);
     }
 
-    let lock, token;
+    const {sessionId, cwd} = envelope;
+
+    // Typed + authority-checked session target: a malformed envelope must never steer the digest
+    // into an arbitrary session. The optional metadata cwd cross-check catches a stale envelope
+    // written for a different seat checkout.
+    if (typeof sessionId !== 'string' || sessionId.length === 0) {
+        throw new Error(`kimi-server envelope at '${envelopePath}' requires 'sessionId' to be a non-empty string`);
+    }
+
+    if (typeof cwd !== 'string' || cwd.length === 0) {
+        throw new Error(`kimi-server envelope at '${envelopePath}' requires 'cwd' to be a non-empty string`);
+    }
+
+    if (typeof meta.cwd === 'string' && meta.cwd.length > 0 && meta.cwd !== cwd) {
+        throw new Error(`kimi-server envelope at '${envelopePath}' cwd '${cwd}' does not match harnessTargetMetadata.cwd '${meta.cwd}'`);
+    }
 
     try {
         lock = JSON.parse(await fs.readFile(lockPath, 'utf8'));
@@ -1162,7 +1186,7 @@ async function deliverViaKimiServer(subscription, digest, evidenceLabel = '', ab
     const {host, port} = lock;
 
     // Typed + authority-checked coordinates: a malformed lock must never steer the daemon's HTTP
-    // client off the seat's loopback server. Delivery is globally serialized, so every fetch is
+    // client off the seat's loopback server. Delivery is globally serialized, so the fetch is
     // also deadline-bounded — one hung endpoint must not wedge every later wake route.
     if (!['127.0.0.1', 'localhost', '::1'].includes(host)) {
         throw new Error(`kimi-server lock at '${lockPath}' requires a loopback host (received '${host}')`);
@@ -1176,49 +1200,32 @@ async function deliverViaKimiServer(subscription, digest, evidenceLabel = '', ab
         throw new Error(`kimi-server token at '${tokenPath}' is empty`);
     }
 
-    const baseUrl   = `http://${host}:${port}`;
-    const headers   = {'content-type': 'application/json', 'authorization': `Bearer ${token}`};
-    const newSignal = () => abortSignal
+    const deliverySignal = abortSignal
         ? AbortSignal.any([abortSignal, AbortSignal.timeout(5000)])
         : AbortSignal.timeout(5000);
-
-    // Session resolution: the freshest non-archived session rooted at the seat checkout.
-    const listResponse = await fetch(`${baseUrl}/api/v1/sessions`, {headers, redirect: 'error', signal: newSignal()});
-
-    if (listResponse.status !== 200) {
-        throw new Error(`kimi-server GET /api/v1/sessions expected HTTP 200, received ${listResponse.status}`);
-    }
-
-    const listBody = await listResponse.json();
-    const sessions = Array.isArray(listBody?.data?.items) ? listBody.data.items : [];
-    const target   = sessions
-        .filter(session => session && session.archived !== true && session.metadata?.cwd === cwd)
-        .sort((a, b) => String(b.updated_at || '').localeCompare(String(a.updated_at || '')))[0];
-
-    if (!target || typeof target.id !== 'string' || target.id.length === 0) {
-        throw new Error(`kimi-server found no live session with metadata.cwd '${cwd}'`);
-    }
-
-    const submitResponse = await fetch(`${baseUrl}/api/v1/sessions/${encodeURIComponent(target.id)}/prompts`, {
-        method  : 'POST',
-        headers,
+    const response = await fetch(`http://${host}:${port}/api/v1/sessions/${encodeURIComponent(sessionId)}/prompts`, {
+        method : 'POST',
+        headers: {
+            'content-type' : 'application/json',
+            'authorization': `Bearer ${token}`
+        },
         body    : JSON.stringify({content: [{type: 'text', text: digest}]}),
         redirect: 'error',
-        signal  : newSignal()
+        signal  : deliverySignal
     });
 
-    if (submitResponse.status !== 200) {
-        throw new Error(`kimi-server submitPrompt expected HTTP 200, received ${submitResponse.status}`);
+    if (response.status !== 200) {
+        throw new Error(`kimi-server submitPrompt expected HTTP 200, received ${response.status}`);
     }
 
-    const submitBody = await submitResponse.json();
+    const body = await response.json();
 
-    if (submitBody?.code !== 0) {
-        throw new Error(`kimi-server submitPrompt expected code 0, received ${JSON.stringify(submitBody?.code ?? null)}`);
+    if (body?.code !== 0) {
+        throw new Error(`kimi-server submitPrompt expected code 0, received ${JSON.stringify(body?.code ?? null)}`);
     }
 
-    const status = submitBody?.data?.status;
-    writeLog('INFO', `[Wake Daemon] Dispatched ${subscription.id} via kimi-server submitPrompt (session ${target.id}${status ? `, status=${status}` : ''})${evidenceLabel}`);
+    const status = body?.data?.status;
+    writeLog('INFO', `[Wake Daemon] Dispatched ${subscription.id} via kimi-server submitPrompt (session ${sessionId}${status ? `, status=${status}` : ''})${evidenceLabel}`);
 }
 
 /**

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -1116,7 +1116,10 @@ async function deliverViaOpencodeServer(subscription, digest, evidenceLabel = ''
  * needs no graph write. Picking a session heuristically (e.g. freshest `updated_at` from the
  * session index) is deliberately NOT the path: multiple resumed/child sessions can share one
  * checkout, and a wake landing in the wrong session is a cross-session retarget. The envelope
- * is the authority; a missing/mismatched envelope fails visibly.
+ * is the authority; a missing/mismatched envelope fails visibly. Set `harnessTargetMetadata.cwd`
+ * for multi-checkout seats (same OS user, several checkouts): the envelope refreshes per
+ * session, so for a single-seat checkout the cross-check is belt-and-suspenders, but for
+ * shared ones it is the stale-checkout guard.
  *
  * **Coordinate contract** (no seat-side writer needed — the harness persists both files
  * itself at server start): the loopback coordinates come from `~/.kimi-code/server/lock`

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -2345,14 +2345,17 @@ paths:
                   description: Required for subscribe; specifies how wake events are delivered.
                 harnessTargetMetadata:
                   type: object
-                  description: Channel-specific metadata. appName is required by the service for osascript-style bridge-daemon routes (not for adapter 'opencode-server'); url is required for a2a-webhook; coalesceWindow is an optional override. instanceAddress + addressType (local bridge-daemon only) target a specific receiver instance; userDataDir is a legacy compatibility field for existing subscriptions. envelopePath overrides the opencode-server seat-envelope location.
+                  description: Channel-specific metadata. appName is required by the service for osascript-style bridge-daemon routes (not for adapters 'opencode-server' or 'kimi-server'); url is required for a2a-webhook; coalesceWindow is an optional override. instanceAddress + addressType (local bridge-daemon only) target a specific receiver instance; userDataDir is a legacy compatibility field for existing subscriptions. envelopePath overrides the opencode-server seat-envelope or kimi-server wake-envelope location. lockPath/tokenPath/cwd tune kimi-server coordinate discovery.
                   properties:
                     url:              {type: string}
                     coalesceWindow:   {type: integer, minimum: 0, maximum: 300}
                     daemonSocketPath: {type: string}
-                    adapter:          {type: string, enum: [osascript, tmux, codex-app-server, opencode-server]}
+                    adapter:          {type: string, enum: [osascript, tmux, codex-app-server, opencode-server, kimi-server]}
                     appName:          {type: string}
                     envelopePath:     {type: string}
+                    lockPath:         {type: string}
+                    tokenPath:        {type: string}
+                    cwd:              {type: string}
                     instanceAddress:  {type: string, nullable: true}
                     addressType:      {type: string, enum: [userDataDir, pid, tmuxSession, webhookUrl], nullable: true}
                     userDataDir:      {type: string, nullable: true}

--- a/ai/services/memory-core/WakeSubscriptionService.mjs
+++ b/ai/services/memory-core/WakeSubscriptionService.mjs
@@ -90,11 +90,12 @@ class WakeSubscriptionService extends Base {
      * Delivery-adapter identifiers accepted in `harnessTargetMetadata.adapter`. The first three
      * dispatch through GUI/CLI control planes (osascript, tmux, the Codex app-server);
      * `opencode-server` routes through the seat's embedded HTTP server via its seat envelope
-     * and is exempt from the bridge-daemon `appName` requirement.
+     * and is exempt from the bridge-daemon `appName` requirement; `kimi-server` routes through
+     * the seat's local `kimi server` REST surface via its wake envelope (same exemption).
      *
      * @protected
      */
-    validAdapters = ['osascript', 'tmux', 'codex-app-server', 'opencode-server']
+    validAdapters = ['osascript', 'tmux', 'codex-app-server', 'opencode-server', 'kimi-server']
 
     /**
      * In-memory write-through cache for sub-millisecond trigger evaluation.
@@ -1040,9 +1041,10 @@ class WakeSubscriptionService extends Base {
         if (metadata.adapter !== undefined && !this.validAdapters.includes(metadata.adapter)) {
             throw new Error(`Invalid adapter '${metadata.adapter}'. Must be one of: ${this.validAdapters.join(', ')}`);
         }
-        // The osascript-style bridge-daemon routes need an appName target; the opencode-server
-        // adapter routes by seat envelope instead and is exempt (its authority is the envelope file).
-        if (harnessTarget === 'bridge-daemon' && metadata.adapter !== 'opencode-server' && !metadata.appName) {
+        // The osascript-style bridge-daemon routes need an appName target; the opencode-server and
+        // kimi-server adapters route by seat envelope instead and are exempt (their authority is
+        // the envelope file).
+        if (harnessTarget === 'bridge-daemon' && !['opencode-server', 'kimi-server'].includes(metadata.adapter) && !metadata.appName) {
             throw new Error('Shape C (bridge-daemon) requires harnessTargetMetadata.appName.');
         }
         if (metadata.envelopePath !== undefined && typeof metadata.envelopePath !== 'string') {

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -2062,6 +2062,140 @@ test.describe('Wake Daemon', () => {
         }
     });
 
+    test('delivers wake events via kimi-server adapter without osascript fallback (#15579)', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-kimi-server';
+
+        // Stub the seat's `kimi server`: captures the sessions GET (session resolution) and the
+        // submitPrompt POST. Session candidates pin the resolution contract: freshest non-archived
+        // session rooted at the seat checkout wins.
+        const captured   = [];
+        const stubServer = http.createServer((req, res) => {
+            let body = '';
+            req.on('data', chunk => body += chunk);
+            req.on('end', () => {
+                captured.push({method: req.method, url: req.url, headers: req.headers, body});
+
+                if (req.method === 'GET' && req.url === '/api/v1/sessions') {
+                    res.writeHead(200, {'content-type': 'application/json'});
+                    res.end(JSON.stringify({code: 0, msg: 'success', data: {items: [
+                        {id: 'ses_kimi_stale', archived: false, updated_at: '2026-07-19T10:00:00.000Z', metadata: {cwd: '/seat/checkout'}},
+                        {id: 'ses_kimi_live',  archived: false, updated_at: '2026-07-19T20:00:00.000Z', metadata: {cwd: '/seat/checkout'}},
+                        {id: 'ses_other_cwd',  archived: false, updated_at: '2026-07-19T21:00:00.000Z', metadata: {cwd: '/other/checkout'}},
+                        {id: 'ses_archived',   archived: true,  updated_at: '2026-07-19T22:00:00.000Z', metadata: {cwd: '/seat/checkout'}}
+                    ]}}));
+                } else if (req.method === 'POST') {
+                    res.writeHead(200, {'content-type': 'application/json'});
+                    res.end(JSON.stringify({code: 0, msg: 'success', data: {
+                        prompt_id      : 'prompt_test',
+                        user_message_id: 'msg_test',
+                        status         : 'running',
+                        content        : []
+                    }}));
+                } else {
+                    res.writeHead(404);
+                    res.end();
+                }
+            });
+        });
+        await new Promise(resolve => stubServer.listen(0, '127.0.0.1', resolve));
+        const stubPort = stubServer.address().port;
+
+        const lockPath  = path.join(DAEMON_DIR, 'kimi-server-lock.json');
+        const tokenPath = path.join(DAEMON_DIR, 'kimi-server.token');
+        fs.writeJsonSync(lockPath, {host: '127.0.0.1', pid: 424242, port: stubPort, started_at: '2026-07-19T20:00:00.000Z'});
+        fs.writeFileSync(tokenPath, 'kimi-test-token\n');
+
+        insertWakeSubscription(db, {
+            subId,
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'kimi-server',
+                lockPath,
+                tokenPath,
+                cwd           : '/seat/checkout',
+                coalesceWindow: 1
+            }
+        });
+
+        const binDir               = path.join(DAEMON_DIR, 'bin');
+        const mockOsascriptPath    = path.join(binDir, 'osascript');
+        const mockOsascriptOutPath = path.join(DAEMON_DIR, 'mock_kimi_osascript_out.json');
+
+        fs.ensureDirSync(binDir);
+        writeMockPs(binDir);
+        fs.writeFileSync(mockOsascriptPath,
+            `#!/usr/bin/env node\n` +
+            `const fs = require('fs');\n` +
+            `fs.writeFileSync(${JSON.stringify(mockOsascriptOutPath)}, JSON.stringify(process.argv.slice(2)));\n`
+        );
+        fs.chmodSync(mockOsascriptPath, 0o755);
+
+        let stdoutLog = '';
+
+        try {
+            daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+                stdio: 'pipe',
+                env  : {
+                    ...process.env,
+                    NEO_MEMORY_DB_PATH: DB_PATH,
+                    NEO_AI_DAEMON_DIR : DAEMON_DIR,
+                    PATH              : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                }
+            });
+
+            const deliveryPromise = new Promise((resolve, reject) => {
+                const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver kimi-server digest within timeout')), 10000);
+
+                daemonProcess.stdout.on('data', (data) => {
+                    const out = data.toString();
+                    stdoutLog += out;
+                    if (out.includes(`[Wake Dispatch] ${agentId}: outcome=delivered`)) {
+                        clearTimeout(timeout);
+                        resolve();
+                    }
+                    if (out.includes(`[Wake Daemon] Delivered ${subId} via osascript`)) {
+                        clearTimeout(timeout);
+                        reject(new Error('Daemon fell back to osascript for kimi-server route'));
+                    }
+                });
+                daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+                daemonProcess.on('error', reject);
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            insertMessageWake(db, {
+                agentId,
+                subject: 'Kimi Server Wake'
+            });
+
+            await deliveryPromise;
+
+            expect(captured.length).toBe(2);
+
+            const listCall = captured[0];
+            expect(listCall.method).toBe('GET');
+            expect(listCall.url).toBe('/api/v1/sessions');
+            expect(listCall.headers.authorization).toBe('Bearer kimi-test-token');
+
+            const submitCall = captured[1];
+            expect(submitCall.method).toBe('POST');
+            expect(submitCall.url).toBe('/api/v1/sessions/ses_kimi_live/prompts');
+            expect(submitCall.headers.authorization).toBe('Bearer kimi-test-token');
+
+            const payload = JSON.parse(submitCall.body);
+            expect(payload.content[0].type).toBe('text');
+            expect(payload.content[0].text).toContain('Kimi Server Wake');
+
+            expect(fs.existsSync(mockOsascriptOutPath)).toBe(false);
+            expect(stdoutLog).toContain(`[Wake Daemon] Dispatched ${subId} via kimi-server submitPrompt (session ses_kimi_live, status=running)`);
+            expect(stdoutLog).toContain(`[Wake Dispatch] ${agentId}: outcome=delivered`);
+            expect(stdoutLog).toContain('route=kimi-server; adapterSource=metadata');
+        } finally {
+            stubServer.close();
+        }
+    });
+
     test('opencode-server shares the configured attempt abort and cannot report orphan success (#15394, #15414)', async () => {
         test.setTimeout(15000);
 

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -2066,54 +2066,42 @@ test.describe('Wake Daemon', () => {
         const subId   = 'sub_' + crypto.randomUUID();
         const agentId = '@test-agent-kimi-server';
 
-        // Stub the seat's `kimi server`: captures the sessions GET (session resolution) and the
-        // submitPrompt POST. Session candidates pin the resolution contract: freshest non-archived
-        // session rooted at the seat checkout wins.
+        // Stub the seat's `kimi server`: captures the submitPrompt POST. The session authority
+        // comes from the wake envelope (SessionStart-hook writer contract), never from a
+        // session-index heuristic.
         const captured   = [];
         const stubServer = http.createServer((req, res) => {
             let body = '';
             req.on('data', chunk => body += chunk);
             req.on('end', () => {
                 captured.push({method: req.method, url: req.url, headers: req.headers, body});
-
-                if (req.method === 'GET' && req.url === '/api/v1/sessions') {
-                    res.writeHead(200, {'content-type': 'application/json'});
-                    res.end(JSON.stringify({code: 0, msg: 'success', data: {items: [
-                        {id: 'ses_kimi_stale', archived: false, updated_at: '2026-07-19T10:00:00.000Z', metadata: {cwd: '/seat/checkout'}},
-                        {id: 'ses_kimi_live',  archived: false, updated_at: '2026-07-19T20:00:00.000Z', metadata: {cwd: '/seat/checkout'}},
-                        {id: 'ses_other_cwd',  archived: false, updated_at: '2026-07-19T21:00:00.000Z', metadata: {cwd: '/other/checkout'}},
-                        {id: 'ses_archived',   archived: true,  updated_at: '2026-07-19T22:00:00.000Z', metadata: {cwd: '/seat/checkout'}}
-                    ]}}));
-                } else if (req.method === 'POST') {
-                    res.writeHead(200, {'content-type': 'application/json'});
-                    res.end(JSON.stringify({code: 0, msg: 'success', data: {
-                        prompt_id      : 'prompt_test',
-                        user_message_id: 'msg_test',
-                        status         : 'running',
-                        content        : []
-                    }}));
-                } else {
-                    res.writeHead(404);
-                    res.end();
-                }
+                res.writeHead(200, {'content-type': 'application/json'});
+                res.end(JSON.stringify({code: 0, msg: 'success', data: {
+                    prompt_id      : 'prompt_test',
+                    user_message_id: 'msg_test',
+                    status         : 'running',
+                    content        : []
+                }}));
             });
         });
         await new Promise(resolve => stubServer.listen(0, '127.0.0.1', resolve));
         const stubPort = stubServer.address().port;
 
-        const lockPath  = path.join(DAEMON_DIR, 'kimi-server-lock.json');
-        const tokenPath = path.join(DAEMON_DIR, 'kimi-server.token');
+        const lockPath     = path.join(DAEMON_DIR, 'kimi-server-lock.json');
+        const tokenPath    = path.join(DAEMON_DIR, 'kimi-server.token');
+        const envelopePath = path.join(DAEMON_DIR, 'kimi-wake-envelope.json');
         fs.writeJsonSync(lockPath, {host: '127.0.0.1', pid: 424242, port: stubPort, started_at: '2026-07-19T20:00:00.000Z'});
         fs.writeFileSync(tokenPath, 'kimi-test-token\n');
+        fs.writeJsonSync(envelopePath, {sessionId: 'ses_kimi_live', cwd: '/seat/checkout', updatedAt: '2026-07-19T20:00:00.000Z'});
 
         insertWakeSubscription(db, {
             subId,
             agentId,
             harnessTargetMetadata: {
                 adapter       : 'kimi-server',
+                envelopePath,
                 lockPath,
                 tokenPath,
-                cwd           : '/seat/checkout',
                 coalesceWindow: 1
             }
         });
@@ -2171,14 +2159,9 @@ test.describe('Wake Daemon', () => {
 
             await deliveryPromise;
 
-            expect(captured.length).toBe(2);
+            expect(captured.length).toBe(1);
 
-            const listCall = captured[0];
-            expect(listCall.method).toBe('GET');
-            expect(listCall.url).toBe('/api/v1/sessions');
-            expect(listCall.headers.authorization).toBe('Bearer kimi-test-token');
-
-            const submitCall = captured[1];
+            const submitCall = captured[0];
             expect(submitCall.method).toBe('POST');
             expect(submitCall.url).toBe('/api/v1/sessions/ses_kimi_live/prompts');
             expect(submitCall.headers.authorization).toBe('Bearer kimi-test-token');
@@ -2196,11 +2179,62 @@ test.describe('Wake Daemon', () => {
         }
     });
 
+    test('kimi-server fails visibly without a wake envelope instead of retargeting heuristically (#15579)', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-kimi-server-no-envelope';
+
+        // No envelope file: the adapter must refuse visibly (failed, never delivered), not fall
+        // back to a session-index pick or to osascript.
+        const lockPath  = path.join(DAEMON_DIR, 'kimi-server-lock-no-envelope.json');
+        const tokenPath = path.join(DAEMON_DIR, 'kimi-server-no-envelope.token');
+        fs.writeJsonSync(lockPath, {host: '127.0.0.1', pid: 424242, port: 1, started_at: '2026-07-19T20:00:00.000Z'});
+        fs.writeFileSync(tokenPath, 'kimi-test-token\n');
+
+        insertWakeSubscription(db, {
+            subId,
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'kimi-server',
+                envelopePath  : path.join(DAEMON_DIR, 'kimi-wake-envelope-MISSING.json'),
+                lockPath,
+                tokenPath,
+                coalesceWindow: 1
+            }
+        });
+
+        let stdoutLog = '';
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {
+                ...process.env,
+                NEO_MEMORY_DB_PATH: DB_PATH,
+                NEO_AI_DAEMON_DIR : DAEMON_DIR
+            }
+        });
+        daemonProcess.stdout.on('data', data => stdoutLog += data.toString());
+        // The fail-visible path logs through the error stream; fold it into the same buffer.
+        daemonProcess.stderr.on('data', data => stdoutLog += data.toString());
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {
+            agentId,
+            subject: 'Kimi Server Missing Envelope Wake'
+        });
+
+        // Give the daemon room to attempt (and possibly retry) the delivery.
+        await new Promise(resolve => setTimeout(resolve, 4000));
+
+        expect(stdoutLog).toContain('kimi-server requires a readable wake envelope');
+        expect(stdoutLog).not.toContain(`[Wake Dispatch] ${agentId}: outcome=delivered`);
+        expect(stdoutLog).not.toContain(`Dispatched ${subId} via kimi-server submitPrompt`);
+    });
+
     test('opencode-server shares the configured attempt abort and cannot report orphan success (#15394, #15414)', async () => {
         test.setTimeout(15000);
 
-        const subId   = 'sub_' + crypto.randomUUID();
-        const agentId = '@test-agent-opencode-shared-abort';
+        const subId    = 'sub_' + crypto.randomUUID();
+        const agentId  = '@test-agent-opencode-shared-abort';
         const requests = [];
 
         // Respond AFTER the 1s delivery-owner bound. If the route ignores the shared signal,

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -80,21 +80,24 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
         const metadata = tool.inputSchema.properties.harnessTargetMetadata;
 
         expect(metadata.required).toBeUndefined();
-        expect(metadata.description).toContain("not for adapter 'opencode-server'");
+        expect(metadata.description).toContain("not for adapters 'opencode-server' or 'kimi-server'");
         expect(Object.keys(metadata.properties)).toEqual(expect.arrayContaining([
             'addressType',
             'adapter',
             'appName',
             'coalesceWindow',
+            'cwd',
             'daemonSocketPath',
             'envelopePath',
             'focusSeedKey',
             'instanceAddress',
+            'lockPath',
             'tabShortcut',
             'tmuxSession',
+            'tokenPath',
             'url'
         ]));
-        expect(metadata.properties.adapter.enum).toEqual(['osascript', 'tmux', 'codex-app-server', 'opencode-server']);
+        expect(metadata.properties.adapter.enum).toEqual(['osascript', 'tmux', 'codex-app-server', 'opencode-server', 'kimi-server']);
         expect(metadata.properties.envelopePath.type).toBe('string');
         expect(metadata.properties.addressType.enum).toEqual(['userDataDir', 'pid', 'tmuxSession', 'webhookUrl']);
     });

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -454,7 +454,7 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
         expect(listMessagesSchema.properties.limit.default).toBe(50);
         expect(listMessagesSchema.properties.offset.default).toBe(0);
 
-        expect(adapter.enum).toEqual(['osascript', 'tmux', 'codex-app-server', 'opencode-server']);
+        expect(adapter.enum).toEqual(['osascript', 'tmux', 'codex-app-server', 'opencode-server', 'kimi-server']);
 
         expect(coalesceWindow.type).toBe('integer');
         expect(coalesceWindow.minimum).toBe(0);


### PR DESCRIPTION
Resolves #15579

Kimi Code wake delivery: the wake daemon gains a `kimi-server` adapter (sibling to `opencode-server`) that injects wake digests into a live Kimi Code session through the harness's own REST surface (`POST /api/v1/sessions/{id}/prompts` — submitPrompt, bearer auth default-on). Session authority is an envelope, exactly like the opencode precedent: the seat's `SessionStart` hook (`.kimi-code/hooks/wakeEnvelopeHook.mjs`, new) refreshes `~/.kimi-code/wake-envelope.json` (0600) with the live `{sessionId, cwd}`; the daemon re-reads it per delivery. No session-index heuristics — a missing or mismatched envelope fails visibly.

Evidence: L3 (live loopback probes: submitPrompt into the author's own running session → `code: 0, status: running`; envelope writer proven from the hook stdin contract → 0600 envelope + fail-open on malformed input) → L3 required (daemon-mediated bidirectional fire/no-fire against the shared wake daemon — the shared daemon only carries this code post-merge). Residual: post-merge validation items [#15579].

## Deltas from ticket

- Ticket's discovery assumptions were doc-derived, not machine-verified: `kimi server install` (launchd) and `~/.kimi-code/server/install.json` do not exist on the live v0.27.0 binary. Actual surface: `kimi server run/ps/kill/rotate-token`; coordinates in `~/.kimi-code/server/lock` (`{host, port, pid}`), persistent bearer token in `~/.kimi-code/server.token`.
- **Session authority (Euclid's intake correction, adopted):** the first cut resolved the target session from `GET /api/v1/sessions` (freshest `updated_at` matching cwd) — a cross-session retarget risk with resumed/child sessions. Reworked to the opencode-parity envelope contract: exact `sessionId` authority refreshed by a `SessionStart` hook; `metadata.cwd` acts as an optional cross-check that fails closed on mismatch.
- Registry surfaces extended per the same correction: `WakeSubscriptionService.validAdapters` + the bridge-daemon `appName` exemption now cover `kimi-server`; the Memory Core OpenAPI adapter enum + metadata schema (`envelopePath`/`lockPath`/`tokenPath`/`cwd`) match.
- submitPrompt delivery counts only after parsing `code === 0` (HTTP 200 also wraps typed application errors).

## Test Evidence

- Daemon-level E2E (new): `UNIT_TEST_MODE=true npx playwright test -c test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/daemons/wake/daemon.spec.mjs --grep "kimi-server|opencode-server adapter"` → 3 passed (envelope-contract delivery + no-osascript-fallback; missing-envelope fail-visible; opencode sibling regression)
- Live L3 probes: submitPrompt into the author's own session → `{code: 0, status: "running"}`; hook-writer probe → 0600 envelope with exact payload, malformed input exits 0 without writing
- `npm run agent-preflight -- --no-fix` on all touched files → all gates passed
- Directly touched surfaces: wake daemon delivery (`daemon.spec.mjs` covers); wake-subscription validation (`WakeSubscriptionService.spec.mjs` covers the registry path)

## Post-Merge Validation

- [ ] Register Iris's `WAKE_SUB` (trigger SENT_TO_ME → `bridge-daemon` / adapter `kimi-server`) via `manage_wake_subscription`
- [ ] Daemon-level bidirectional proof (#12913 shape): a suppressed message must NOT fire; a live SENT_TO_ME must land in the running session (the shared wake daemon picks up this code at merge)
- [ ] `server run --keep-alive` process ownership recorded for the seat (who keeps the loopback server alive while the seat is offline — operator/orchestrator decision, noted in the ticket thread)
- [ ] Note `kimi -p` in the ticket thread as the documented degraded fallback (new-session wake), not the primary path

Authored by Iris (Moonshot Kimi K3, Kimi Code CLI). Session 958d6302-181d-40ae-beda-4c3790d3220d.
