### PR TITLE
fix(memory-core): separate identity boot and seed authority (#15431)

### DIFF
--- a/ai/scripts/fleet/onboardPeer.mjs
+++ b/ai/scripts/fleet/onboardPeer.mjs
@@ -24,14 +24,16 @@ import {normalizeAgentIdentityNodeId}                 from '../../graph/normaliz
  *   3. `roster`  — PRINT the roster-generator invocation. The roster PR + its cross-family
  *      review IS the membership ceremony; this script never writes committed files.
  *
- * **The operator gate (printed, never automated):** merge the roster PR, pull, and restart the
- * Memory Core server — boot seeding materializes the resident's `AgentIdentity` node (with its
- * `subscriptionTemplate`) from the committed roster; the peer's FIRST boot then materializes the
- * wake route itself via the wake-subscription `bootstrap` action from the real boot envelope.
+ * **The operator gate (printed, never automated):** merge the roster PR, pull the owning Memory
+ * Core runtime checkout, explicitly project the merged identity registry, and restart the server.
+ * Ordinary boot only materializes missing roots; the explicit seed owns intentional status/fact
+ * updates. The peer's FIRST boot then materializes the wake route itself via the wake-subscription
+ * `bootstrap` action from the real boot envelope.
  *
  * **Phase B — after the gate (launch):**
- *   4. `preflight` — verify the roster entry exists on merged `origin/dev` AND the graph node is
- *      seeded (read-only probe). Refuse with the exact missing operator step named.
+ *   4. `preflight` — verify the roster entry exists on merged `origin/dev` AND the graph's full
+ *      identity projection carries the same `participationStatus` (read-only probe). Refuse with
+ *      the exact pull → seed → full-node/liveness verification sequence named.
  *   5. `launch`    — `FleetManager.startAgent(id)` (provision-then-start, supervised child in
  *      its isolated instance home via the curated per-family template).
  *   6. `auth`      — use the long-lived lifecycle owner's auth-mode/status projection to hand off
@@ -76,13 +78,28 @@ export const CURATED_HARNESS_TYPES = LAUNCHABLE_HARNESS_TYPES;
 const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
 
 /**
- * @summary Parse the merged roster source without executing it and return only literal ids from
- * the canonical exported `IDENTITIES` array. AST parsing makes comments and unrelated strings
- * inert; a missing/non-literal authority shape fails closed rather than guessing membership.
- * @param {String} source The `origin/dev:ai/graph/identityRoots.mjs` source text.
- * @returns {Set<String>} Literal identity ids declared by the exported roster array.
+ * @summary Return a named property from an object-expression node without executing source.
+ * @param {Object} objectExpression Acorn ObjectExpression node.
+ * @param {String} name Property name.
+ * @returns {Object|undefined} Matching Acorn Property node.
  */
-function parseIdentityRootIds(source) {
+function getObjectProperty(objectExpression, name) {
+    return objectExpression?.type === 'ObjectExpression'
+        ? objectExpression.properties.find(property => property.type === 'Property'
+            && !property.computed
+            && (property.key?.name === name || property.key?.value === name))
+        : undefined
+}
+
+/**
+ * @summary Parse the merged roster source without executing it and return the literal identity
+ * facts needed by the onboarding gate. AST parsing makes comments, spreads, computed properties,
+ * and unrelated strings inert; a missing/non-literal authority shape fails closed rather than
+ * guessing membership or lifecycle state.
+ * @param {String} source The `origin/dev:ai/graph/identityRoots.mjs` source text.
+ * @returns {Map<String, {id: String, participationStatus: String|null}>} Literal identity facts.
+ */
+function parseIdentityRoots(source) {
     const ast = acorn.parse(String(source), {ecmaVersion: 'latest', sourceType: 'module'});
 
     let identities;
@@ -102,35 +119,42 @@ function parseIdentityRootIds(source) {
         throw new Error('merged roster must export IDENTITIES as a literal array');
     }
 
-    const ids = new Set();
+    const roots = new Map();
 
     for (const element of identities.elements) {
         if (element?.type !== 'ObjectExpression') continue;
 
-        const idProperty = element.properties.find(property => property.type === 'Property'
-            && !property.computed
-            && (property.key?.name === 'id' || property.key?.value === 'id'));
+        const
+            idProperty         = getObjectProperty(element, 'id'),
+            propertiesProperty = getObjectProperty(element, 'properties'),
+            statusProperty     = getObjectProperty(propertiesProperty?.value, 'participationStatus'),
+            id                 = idProperty?.value?.type === 'Literal' ? idProperty.value.value : null,
+            statusValue        = statusProperty?.value?.type === 'Literal' ? statusProperty.value.value : null;
 
-        if (idProperty?.value?.type === 'Literal' && typeof idProperty.value.value === 'string') {
-            ids.add(idProperty.value.value);
+        if (typeof id === 'string') {
+            roots.set(id, {
+                id,
+                participationStatus: typeof statusValue === 'string' ? statusValue : null
+            });
         }
     }
 
-    return ids
+    return roots
 }
 
 /**
- * @summary Verify membership against the merged roster authority (`origin/dev`), never the
- * conductor's current feature-branch worktree. This keeps Phase B locked until the ceremony PR
- * actually merged and the operator refreshed the remote-tracking ref. Git is invoked shell-free;
- * failures refuse instead of silently treating stale or unavailable authority as membership.
+ * @summary Read one resident's literal identity facts from the merged roster authority
+ * (`origin/dev`), never the conductor's current feature-branch worktree. This keeps Phase B locked
+ * until the ceremony/status PR actually merged and the operator refreshed the remote-tracking ref.
+ * Git is invoked shell-free; failures refuse instead of silently treating stale or unavailable
+ * authority as membership.
  * @param {Object} options
  * @param {String} options.residentId Normalized resident handle.
  * @param {String} [options.repoRoot] Repository working directory.
  * @param {Function} [options.execFileImpl] Injectable `execFileSync` seam.
- * @returns {Boolean} Whether the merged roster contains the exact resident id.
+ * @returns {{id: String, participationStatus: String|null}|null} Merged identity facts or null.
  */
-export function originDevRosterHasResident({residentId, repoRoot = REPO_ROOT, execFileImpl = execFileSync} = {}) {
+export function originDevRosterIdentity({residentId, repoRoot = REPO_ROOT, execFileImpl = execFileSync} = {}) {
     const normalized = normalizeToken(residentId, 'residentId');
 
     if (!normalized.valid) {
@@ -148,15 +172,24 @@ export function originDevRosterHasResident({residentId, repoRoot = REPO_ROOT, ex
         throw new Error("onboardPeer: cannot verify the merged roster at origin/dev; run 'git fetch origin dev' and re-run", {cause: error});
     }
 
-    let ids;
+    let roots;
 
     try {
-        ids = parseIdentityRootIds(source)
+        roots = parseIdentityRoots(source)
     } catch (error) {
         throw new Error('onboardPeer: cannot parse the merged identity roster at origin/dev; refresh the ref and re-run', {cause: error});
     }
 
-    return ids.has(normalizeAgentIdentityNodeId(normalized.token))
+    return roots.get(normalizeAgentIdentityNodeId(normalized.token)) ?? null
+}
+
+/**
+ * @summary Verify exact resident membership against the merged `origin/dev` roster authority.
+ * @param {Object} options See {@link originDevRosterIdentity}.
+ * @returns {Boolean} Whether the merged roster contains the exact resident id.
+ */
+export function originDevRosterHasResident(options = {}) {
+    return Boolean(originDevRosterIdentity(options))
 }
 
 /**
@@ -306,8 +339,9 @@ export function buildOnboardingIntent(options = {}) {
  * current phase and the exact per-segment delta. Facts arrive observed (the CLI gathers them;
  * tests inject them) so the planner stays side-effect-free: `agent` (the registry's public
  * definition, or null), `rosterHasResident` (the merged `origin/dev` roster),
- * `graphNodeSeeded` (read-only graph probe; `null` = no graph reachable), and `running` /
- * `authRequired` (lifecycle status).
+ * `expectedParticipationStatus` (literal merged-roster status), `graphNodeSeeded` and
+ * `graphParticipationStatus` (read-only graph probe; `null` reachability remains explicit), and
+ * `running` / `authRequired` (lifecycle status).
  * @param {Object} options
  * @param {Object} options.intent A valid intent from {@link buildOnboardingIntent}
  * @param {Object} options.facts Observed facts as described above
@@ -315,9 +349,11 @@ export function buildOnboardingIntent(options = {}) {
  */
 export function planOnboarding({intent, facts = {}} = {}) {
     const
-        segments = [],
-        push     = (key, action, detail) => segments.push({key, action, detail}),
-        agent    = facts.agent ?? null;
+        segments            = [],
+        push                = (key, action, detail) => segments.push({key, action, detail}),
+        agent               = facts.agent ?? null,
+        identityNodeId      = normalizeAgentIdentityNodeId(intent.residentId),
+        statusGateRequested = Object.hasOwn(facts, 'expectedParticipationStatus');
 
     // --- Phase A segments (always evaluated: re-runs report EXISTS honestly) -----------------
     if (!agent) {
@@ -357,7 +393,7 @@ export function planOnboarding({intent, facts = {}} = {}) {
         return {
             phase      : 'A',
             segments,
-            gateMessage: `'${intent.residentId}' is not in the merged origin/dev roster. Next: run the roster generator above on a feature branch, open the PR (the cross-family-reviewed membership ceremony), merge it, pull/fetch origin/dev, restart the Memory Core server (boot seeding creates the identity node + wake template), then re-run this command.`
+            gateMessage: `'${intent.residentId}' is not in the merged origin/dev roster. Next: run the roster generator above on a feature branch, open the PR (the cross-family-reviewed membership ceremony), and merge it. In the owning Memory Core runtime checkout run 'git switch dev', 'git pull --ff-only origin dev', then 'node ai/scripts/setup/seedAgentIdentities.mjs', restart the Memory Core server, and re-run this command. The gate stays closed until get_node({id:'${identityNodeId}', projection:'full'}) and who_is_online({verbose:true}) both report the merged participationStatus.`
         }
     }
 
@@ -369,13 +405,28 @@ export function planOnboarding({intent, facts = {}} = {}) {
     if (facts.graphNodeSeeded !== true) {
         push('preflight', 'REFUSE',
             facts.graphNodeSeeded === false
-                ? `roster entry present but the graph carries no '${intent.residentId}' AgentIdentity node — restart the Memory Core server so boot seeding materializes it, then re-run`
+                ? `roster entry present but the graph carries no '${identityNodeId}' AgentIdentity node — in the owning Memory Core runtime checkout run 'git switch dev', 'git pull --ff-only origin dev', then 'node ai/scripts/setup/seedAgentIdentities.mjs', restart Memory Core, and re-run; unverifiable identity state never reaches launch`
                 : 'the configured Memory Core graph is not reachable read-only — start or reconnect the owning Memory Core server and re-run; unverifiable identity state never reaches launch');
 
         return {phase: 'B', segments, gateMessage: null}
     }
 
-    push('preflight', 'OK', `roster entry + seeded '${intent.residentId}' AgentIdentity node verified`);
+    if (statusGateRequested && typeof facts.expectedParticipationStatus !== 'string') {
+        push('preflight', 'REFUSE', `merged origin/dev carries no literal participationStatus for '${identityNodeId}' — refresh/reconcile the roster authority; lifecycle state is never guessed`);
+
+        return {phase: 'B', segments, gateMessage: null}
+    }
+
+    if (statusGateRequested && facts.graphParticipationStatus !== facts.expectedParticipationStatus) {
+        push('preflight', 'REFUSE',
+            `merged origin/dev expects '${identityNodeId}' participationStatus '${facts.expectedParticipationStatus}', but the graph projects '${facts.graphParticipationStatus ?? 'missing'}' — in the owning Memory Core runtime checkout run 'git switch dev', 'git pull --ff-only origin dev', then 'node ai/scripts/setup/seedAgentIdentities.mjs', restart Memory Core, and re-run. The gate stays closed until get_node({id:'${identityNodeId}', projection:'full'}) and who_is_online({verbose:true}) both report '${facts.expectedParticipationStatus}'`);
+
+        return {phase: 'B', segments, gateMessage: null}
+    }
+
+    push('preflight', 'OK', statusGateRequested
+        ? `merged roster + full '${identityNodeId}' graph projection agree on participationStatus '${facts.expectedParticipationStatus}'`
+        : `roster entry + seeded '${identityNodeId}' AgentIdentity node verified`);
 
     push('launch', facts.running ? 'EXISTS' : 'CREATE',
         facts.running
@@ -627,16 +678,32 @@ async function main() {
         fleet.fleetRuntimeStatus()
     ]);
 
-    // Read-only graph probe: absent file / absent node are DISTINCT facts (null = unverifiable).
-    let   graphNodeSeeded = null;
-    const graphPath       = memoryCoreConfig.storagePaths.graph;
+    const rosterIdentity = originDevRosterIdentity({residentId: intent.residentId});
+
+    // Read-only full-node probe: absent file / absent node / malformed projection are DISTINCT
+    // facts. The planner compares persisted lifecycle truth with the exact merged roster record.
+    let
+        graphNodeSeeded          = null,
+        graphParticipationStatus = null;
+    const graphPath = memoryCoreConfig.storagePaths.graph;
 
     if (typeof graphPath === 'string' && graphPath !== ':memory:' && existsSync(graphPath)) {
         const {default: Database} = await import('better-sqlite3');
         const sqlite              = new Database(graphPath, {readonly: true});
 
         try {
-            graphNodeSeeded = Boolean(sqlite.prepare('SELECT id FROM Nodes WHERE id = ? LIMIT 1').get(normalizeAgentIdentityNodeId(intent.residentId)));
+            const row = sqlite.prepare('SELECT data FROM Nodes WHERE id = ? LIMIT 1').get(normalizeAgentIdentityNodeId(intent.residentId));
+
+            graphNodeSeeded = Boolean(row);
+
+            if (row?.data) {
+                try {
+                    graphParticipationStatus = JSON.parse(row.data).properties?.participationStatus ?? null;
+                } catch {
+                    // Malformed persisted identity data is unverifiable, never launchable.
+                    graphNodeSeeded = null;
+                }
+            }
         } finally {
             sqlite.close();
         }
@@ -644,10 +711,12 @@ async function main() {
 
     const facts = {
         agent,
-        rosterHasResident: originDevRosterHasResident({residentId: intent.residentId}),
+        rosterHasResident          : Boolean(rosterIdentity),
+        expectedParticipationStatus: rosterIdentity?.participationStatus ?? null,
         graphNodeSeeded,
-        running          : Boolean(runtimeRows.find(row => row.agentId === intent.agentId)?.running),
-        authRequired     : null
+        graphParticipationStatus,
+        running                    : Boolean(runtimeRows.find(row => row.agentId === intent.agentId)?.running),
+        authRequired               : null
     };
 
     const plan = planOnboarding({intent, facts});

--- a/ai/scripts/setup/seedAgentIdentities.mjs
+++ b/ai/scripts/setup/seedAgentIdentities.mjs
@@ -1,11 +1,14 @@
 /**
  * Operational Context:
- * Idempotent recovery tool. In healthy operation, this script runs exactly once — at initial Memory
- * Core provisioning — and the seeded nodes persist for the lifetime of the graph. If you find yourself
- * needing to re-run it, something upstream wiped the AgentIdentity nodes; the known hazard is
- * test-pollution via the :memory: override leak in MailboxService.spec.mjs / PermissionService.spec.mjs
- * (see "Test pollution hazard" section in learn/agentos/IdentitySchema.md). Re-seeding is safe —
- * existing createdAt is preserved — but the upstream cause should be fixed rather than masked.
+ * Explicit canonical projection tool. Run it once for initial Memory Core provisioning and again
+ * after an intentional merged change to `identityRoots.mjs` (activation/status flip, naming fact,
+ * or schema-backed capability update). The owning runtime checkout MUST pull the merged revision
+ * before invoking this script; otherwise the operator would intentionally project stale registry
+ * data. Ordinary GraphService boot is additive-only and never rewrites an existing identity.
+ *
+ * Re-seeding is idempotent and preserves the persisted `createdAt`. If identities disappeared
+ * without an intentional registry change, investigate the upstream wipe (the historical hazard is
+ * test-pollution via the :memory: override leak described in learn/agentos/IdentitySchema.md).
  *
  * @summary Seeds initial system, AgentIdentity, and BroadcastSentinel nodes into the Neo.mjs Memory Core Native Graph.
  *
@@ -28,27 +31,44 @@
  * to prevent silent wipes during idle or fresh Memory Core states prior to their first activity edges.
  *
  * Idempotent re-run is safe: existing nodes preserve their original `createdAt` via the defensive
- * SQLite peek below; new properties merge on top.
+ * SQLite peek below; canonical properties update and runtime-added properties remain merged.
  *
  * Usage: node ai/scripts/setup/seedAgentIdentities.mjs
  */
 
-import { Memory_GraphService } from '../../services.mjs';
-import { IDENTITIES }          from '../../graph/identityRoots.mjs';
+import path            from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {IDENTITIES}    from '../../graph/identityRoots.mjs';
 
-async function seed() {
-    console.log('Awaiting Memory Graph Service readiness...');
-    await Memory_GraphService.ready();
+const __filename = fileURLToPath(import.meta.url);
 
-    console.log('Seeding Agent Identities...');
+/**
+ * @summary Intentionally project the current canonical identity registry into one Memory Core
+ * graph while preserving each existing root's original creation provenance.
+ * @param {Object} [options]
+ * @param {Object} [options.graphService] Injectable GraphService; defaults lazily to the configured
+ * Memory Core service so importing this module in a unit test never mounts production storage.
+ * @param {Object[]} [options.identities=IDENTITIES] Registry entries to project.
+ * @param {Function} [options.log=console.log] Progress sink.
+ * @returns {Promise<Number>} Number of identity roots processed.
+ */
+export async function seedAgentIdentities({graphService, identities = IDENTITIES, log = console.log} = {}) {
+    if (!graphService) {
+        ({Memory_GraphService: graphService} = await import('../../services.mjs'));
+    }
+
+    log('Awaiting Memory Graph Service readiness...');
+    await graphService.ready();
+
+    log('Seeding Agent Identities...');
     let seededCount = 0;
 
-    for (const identity of IDENTITIES) {
-        const existing = Memory_GraphService.getNode({ id: identity.id });
+    for (const identity of identities) {
+        const existing = graphService.getNode({id: identity.id});
 
         if (!existing) {
-            Memory_GraphService.upsertNode(identity);
-            console.log(`Created AgentIdentity: ${identity.id}`);
+            graphService.upsertNode(identity);
+            log(`Created AgentIdentity: ${identity.id}`);
         } else {
             // Defensive `createdAt` retention logic:
             // We peek directly at the raw SQLite `Nodes` table to check if the existing node has a `createdAt` timestamp.
@@ -56,9 +76,9 @@ async function seed() {
             // If `upsertNode` semantics ever change to 'preserve existing properties if not in update payload',
             // this manual peek could be refactored or removed.
             let hasCreatedAt = false;
-            if (Memory_GraphService.db && Memory_GraphService.db.storage) {
-                const stmt = Memory_GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?');
-                const row = stmt.get(identity.id);
+            if (graphService.db?.storage) {
+                const stmt = graphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?');
+                const row  = stmt.get(identity.id);
                 if (row && row.data) {
                     try {
                         const parsed = JSON.parse(row.data);
@@ -75,17 +95,29 @@ async function seed() {
             }
 
             const updatedIdentity = { ...identity, properties: propertiesToUpdate };
-            Memory_GraphService.upsertNode(updatedIdentity);
-            console.log(`Updated AgentIdentity (${hasCreatedAt ? 'retained original' : 'added new'} createdAt): ${identity.id}`);
+            graphService.upsertNode(updatedIdentity);
+            log(`Updated AgentIdentity (${hasCreatedAt ? 'retained original' : 'added new'} createdAt): ${identity.id}`);
         }
         seededCount++;
     }
 
-    console.log(`Successfully processed ${seededCount} identities in the native graph.`);
+    log(`Successfully processed ${seededCount} identities in the native graph.`);
+
+    return seededCount;
+}
+
+/**
+ * @summary Run the explicit projection as a one-shot CLI and preserve its historical process exit.
+ * @returns {Promise<void>}
+ */
+async function main() {
+    await seedAgentIdentities();
     process.exit(0);
 }
 
-seed().catch(err => {
-    console.error('Failed to seed AgentIdentities:', err);
-    process.exit(1);
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+    main().catch(err => {
+        console.error('Failed to seed AgentIdentities:', err);
+        process.exit(1);
+    });
+}

--- a/ai/services/memory-core/GraphService.mjs
+++ b/ai/services/memory-core/GraphService.mjs
@@ -180,28 +180,12 @@ class GraphService extends Base {
 
                 // --- 2. AGENT IDENTITY SUBSTRATE SEEDING ---
                 // Eliminates the "seed → restart-again" recovery loop for fresh local setups.
-                // Auto-provision identity roots at boot so bindAgentIdentity doesn't throw on fresh setups.
+                // Ordinary boot is additive-only: a stale process may provision a missing root, but
+                // must never replay its process-local registry over an existing graph identity.
+                // Intentional canonical updates belong to seedAgentIdentities.mjs after the owning
+                // runtime checkout has pulled the merged registry.
                 try {
-                    for (const identity of IDENTITIES) {
-                        // We use getAdjacentNodes as a trigger for lazy-loading into the cache
-                        this.db.getAdjacentNodes(identity.id, 'both');
-
-                        if (!this.db.nodes.has(identity.id)) {
-                            this.upsertGlobalNode(identity);
-                        } else {
-                            // Defensive createdAt retention: Peek SQLite to preserve original timestamp
-                            const row = storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(identity.id);
-                            if (row) {
-                                const rawData = JSON.parse(row.data);
-                                if (rawData.properties?.createdAt) {
-                                    const preserved = {...identity, properties: {...identity.properties, createdAt: rawData.properties.createdAt}};
-                                    this.upsertGlobalNode(preserved);
-                                    continue;
-                                }
-                            }
-                            this.upsertGlobalNode(identity);
-                        }
-                    }
+                    this.provisionMissingIdentityRoots();
                 } catch (error) {
                     logger.warn(`[GraphService] Non-fatal DB contention during Identity Substrate seed: ${error.message}`);
                 }
@@ -218,6 +202,34 @@ class GraphService extends Base {
         })();
 
         await this._initPromise;
+    }
+
+    /**
+     * @summary Add canonical AgentIdentity and BroadcastSentinel roots that are absent from the
+     * mounted graph, without rewriting records already owned by the persisted projection.
+     *
+     * This is the ordinary-boot half of the identity write-authority split. Existing records may
+     * contain a newer activation state, operator provenance, or runtime-added properties than the
+     * process-local registry snapshot. Leaving them byte-stable prevents a stale MCP checkout from
+     * making identity state last-boot-wins. Intentional registry updates remain the responsibility
+     * of `ai/scripts/setup/seedAgentIdentities.mjs`.
+     * @param {Object[]} [identities=IDENTITIES] Canonical roots to provision when missing.
+     * @returns {Number} Number of roots created during this pass.
+     */
+    provisionMissingIdentityRoots(identities = IDENTITIES) {
+        let created = 0;
+
+        for (const identity of identities) {
+            // Trigger the cache-coherent SQLite lazy load before deciding the root is absent.
+            this.db.getAdjacentNodes(identity.id, 'both');
+
+            if (!this.db.nodes.has(identity.id)) {
+                this.upsertGlobalNode(identity);
+                created++;
+            }
+        }
+
+        return created;
     }
 
     /**

--- a/learn/agentos/IdentitySchema.md
+++ b/learn/agentos/IdentitySchema.md
@@ -75,12 +75,36 @@ records—not the person node.
 
 ## Ingestion Mechanism
 
-Agent identities are seeded idempotently into the native graph using the `ai/scripts/setup/seedAgentIdentities.mjs` utility. The script interacts with the `Memory_GraphService` to upsert nodes, taking care to preserve the original `createdAt` timestamp if updating existing properties.
+Identity projection has two deliberately separate write authorities:
 
-**Usage:**
+- `GraphService.initAsync` is **additive-only**. Ordinary process boot provisions roots that are
+  absent so first binding works, but it never rewrites an existing identity from the process-local
+  registry snapshot. This prevents an MCP server running an older checkout from rewinding a newer
+  activation/status projection.
+- `ai/scripts/setup/seedAgentIdentities.mjs` is the **explicit canonical update** path. It upserts the
+  merged registry facts while preserving the persisted `createdAt` and runtime-added properties.
+
+After an intentional identity-root change merges, run the projection gate from the checkout that
+owns the target Memory Core deployment:
+
 ```bash
+git switch dev
+git pull --ff-only origin dev
 node ai/scripts/setup/seedAgentIdentities.mjs
 ```
+
+Restart the Memory Core server so its loaded module graph matches the pulled revision. Then verify
+the same resident through both read surfaces:
+
+```text
+get_node({id: '@<resident>', projection: 'full'})
+who_is_online({verbose: true})
+```
+
+Both projections must carry the merged `participationStatus`. A missing node, mismatch, stale
+runtime checkout, or unreachable graph fails the activation/status-flip gate; it is never reduced
+to a warning. `ai/scripts/fleet/onboardPeer.mjs` applies the same fail-closed comparison before a
+resident can reach launch.
 
 ## Test Pollution Hazard
 

--- a/learn/agentos/OwnAgentTeam.md
+++ b/learn/agentos/OwnAgentTeam.md
@@ -261,21 +261,29 @@ If `bound` is false, verify in order:
 
 1. `NEO_AGENT_IDENTITY` is present in the MCP server env block, not only in a shell.
 2. The `@<login>` node exists in `ai/graph/identityRoots.mjs`.
-3. `node ai/scripts/setup/seedAgentIdentities.mjs` has run against the active Memory
-   Core graph path.
-4. The harness was restarted after seeding.
+3. The checkout that owns the active Memory Core deployment has pulled merged `dev`.
+4. `node ai/scripts/setup/seedAgentIdentities.mjs` has run against that deployment's graph path.
+5. The Memory Core server was restarted after the pull and seed.
+6. `get_node({id: '@<login>', projection: 'full'})` and `who_is_online({verbose: true})`
+   both report the merged `participationStatus`.
+
+Ordinary Memory Core boot only provisions missing roots. It intentionally does not overwrite an
+existing identity, because a stale MCP checkout must never rewind newer operator/activation state.
+Merged identity changes therefore use the explicit pull → seed → restart → full-node/liveness gate.
 
 ## Bring Up The Team
 
 Provision teammates incrementally:
 
 1. Add one identity root.
-2. Seed the graph.
-3. Bind one harness with `NEO_AGENT_IDENTITY`.
-4. Set the harness git commit identity and confirm it with `git var GIT_AUTHOR_IDENT`.
-5. Verify `healthcheck.identity.bound`.
-6. Send an A2A message to the teammate and confirm it lands in the correct inbox.
-7. Repeat for the next teammate.
+2. Merge the roster/activation change and pull `dev` in the owning Memory Core runtime checkout.
+3. Run `node ai/scripts/setup/seedAgentIdentities.mjs`, then restart Memory Core.
+4. Verify the full identity node and verbose liveness projection agree with the merged status.
+5. Bind one harness with `NEO_AGENT_IDENTITY`.
+6. Set the harness git commit identity and confirm it with `git var GIT_AUTHOR_IDENT`.
+7. Verify `healthcheck.identity.bound`.
+8. Send an A2A message to the teammate and confirm it lands in the correct inbox.
+9. Repeat for the next teammate.
 
 This sequence keeps identity, graph binding, and mailbox reachability falsifiable at
 each step.

--- a/test/playwright/unit/ai/graph/identityRoots.spec.mjs
+++ b/test/playwright/unit/ai/graph/identityRoots.spec.mjs
@@ -13,11 +13,77 @@ setup({
     }
 });
 
-import {test, expect} from '@playwright/test';
-import Neo            from '../../../../../src/Neo.mjs';
-import * as core      from '../../../../../src/core/_export.mjs';
-import {IDENTITIES}   from '../../../../../ai/graph/identityRoots.mjs';
-import * as MIGRATION from '../../../../../ai/graph/identityRootsMigration.mjs';
+import {test, expect}        from '@playwright/test';
+import Neo                   from '../../../../../src/Neo.mjs';
+import * as core             from '../../../../../src/core/_export.mjs';
+import {IDENTITIES}          from '../../../../../ai/graph/identityRoots.mjs';
+import * as MIGRATION        from '../../../../../ai/graph/identityRootsMigration.mjs';
+import {seedAgentIdentities} from '../../../../../ai/scripts/setup/seedAgentIdentities.mjs';
+
+/**
+ * @summary The explicit identity projection path owns intentional canonical updates, while
+ * preserving graph-owned creation provenance and runtime-added properties.
+ */
+test.describe('ai/graph/identityRoots — explicit seed authority (#15431)', () => {
+    test('canonical facts update while persisted createdAt and runtime properties survive', async () => {
+        let record = {
+            id        : '@seed-witness',
+            type      : 'AgentIdentity',
+            name      : 'Pre-activation identity',
+            properties: {
+                createdAt          : '2026-07-19T09:40:49.000Z',
+                displayName        : 'Neo Kimi Iris',
+                participationStatus: 'temporarily_unreachable',
+                runtimeWitness     : 'must-survive'
+            }
+        };
+
+        const graphService = {
+            db: {
+                storage: {
+                    db: {
+                        prepare: () => ({get: () => ({data: JSON.stringify(record)})})
+                    }
+                }
+            },
+            getNode   : () => record,
+            ready     : async () => {},
+            upsertNode: update => {
+                record = {
+                    ...record,
+                    ...update,
+                    properties: {...record.properties, ...update.properties}
+                };
+            }
+        };
+
+        const processed = await seedAgentIdentities({
+            graphService,
+            identities: [{
+                id        : '@seed-witness',
+                type      : 'AgentIdentity',
+                name      : 'Iris',
+                properties: {
+                    createdAt          : '2026-07-19T20:00:00.000Z',
+                    displayName        : 'Iris',
+                    participationStatus: 'active'
+                }
+            }],
+            log: () => {}
+        });
+
+        expect(processed).toBe(1);
+        expect(record).toMatchObject({
+            name      : 'Iris',
+            properties: {
+                createdAt          : '2026-07-19T09:40:49.000Z',
+                displayName        : 'Iris',
+                participationStatus: 'active',
+                runtimeWitness     : 'must-survive'
+            }
+        });
+    });
+});
 
 /**
  * @summary Wake-route invariants for the same-app (Claude Desktop) AgentIdentity roots.

--- a/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
@@ -22,6 +22,7 @@ import {
     deriveAuthHandoff,
     normalizeToken,
     originDevRosterHasResident,
+    originDevRosterIdentity,
     parseOnboardArgs,
     planOnboarding,
     renderPlan
@@ -117,6 +118,10 @@ test.describe('onboardPeer — intent construction (pure half)', () => {
 
         expect(present).toBe(true);
         expect(invocation).toEqual(['git', ['show', 'origin/dev:ai/graph/identityRoots.mjs'], {cwd: '/repo', encoding: 'utf8'}]);
+        expect(originDevRosterIdentity({
+            residentId  : 'neo-gpt-2',
+            execFileImpl: () => "export const IDENTITIES = [{id: '@neo-gpt-2', properties: {participationStatus: 'active'}}];"
+        })).toEqual({id: '@neo-gpt-2', participationStatus: 'active'});
         expect(originDevRosterHasResident({
             residentId  : 'neo-gpt-2',
             execFileImpl: () => "// retired: {id: '@neo-gpt-2'}\nexport const IDENTITIES = [{id: '@neo-gpt-20'}];"
@@ -171,7 +176,12 @@ test.describe('onboardPeer — the two-phase planner', () => {
         expect(generator).not.toContain('<family>');
         expect(parseGenerateArgs(['--handle', 'neo-gpt-2', '--github-username', 'neo-gpt-2', '--family', 'gpt']).valid).toBe(true);
         expect(plan.gateMessage).toContain('membership ceremony');
+        expect(plan.gateMessage).toContain('git switch dev');
+        expect(plan.gateMessage).toContain('git pull --ff-only origin dev');
+        expect(plan.gateMessage).toContain('seedAgentIdentities.mjs');
         expect(plan.gateMessage).toContain('restart the Memory Core');
+        expect(plan.gateMessage).toContain("get_node({id:'@neo-gpt-2', projection:'full'})");
+        expect(plan.gateMessage).toContain('who_is_online({verbose:true})');
         // Phase A NEVER contains a launch segment — launching an un-rostered resident is refused by omission
         expect(plan.segments.some(segment => segment.key === 'launch')).toBe(false);
     });
@@ -226,7 +236,10 @@ test.describe('onboardPeer — the two-phase planner', () => {
         const preflight = plan.segments.find(segment => segment.key === 'preflight');
 
         expect(preflight.action).toBe('REFUSE');
-        expect(preflight.detail).toContain('restart the Memory Core server');
+        expect(preflight.detail).toContain('git switch dev');
+        expect(preflight.detail).toContain('git pull --ff-only origin dev');
+        expect(preflight.detail).toContain('seedAgentIdentities.mjs');
+        expect(preflight.detail).toContain('restart Memory Core');
         expect(plan.segments.some(segment => segment.key === 'launch')).toBe(false);
     });
 
@@ -240,12 +253,49 @@ test.describe('onboardPeer — the two-phase planner', () => {
 
     test('PHASE B happy path: seeded node → launch CREATE + auth PRINT', () => {
         const intent = buildIntent(REPO_OPTIONS),
-              seeded = planOnboarding({intent, facts: {agent: buildAgent(), rosterHasResident: true, graphNodeSeeded: true, running: false}});
+              seeded = planOnboarding({
+                  intent,
+                  facts: {
+                      agent                      : buildAgent(),
+                      expectedParticipationStatus: 'active',
+                      graphNodeSeeded            : true,
+                      graphParticipationStatus   : 'active',
+                      rosterHasResident          : true,
+                      running                    : false
+                  }
+              });
 
         expect(seeded.phase).toBe('B');
         expect(seeded.segments.find(segment => segment.key === 'preflight').action).toBe('OK');
+        expect(seeded.segments.find(segment => segment.key === 'preflight').detail).toContain("participationStatus 'active'");
         expect(seeded.segments.find(segment => segment.key === 'launch').action).toBe('CREATE');
         expect(seeded.segments.find(segment => segment.key === 'auth').action).toBe('PRINT');
+    });
+
+    test('PHASE B REFUSE: a stale graph status cannot launch until pull → seed → full/liveness verification', () => {
+        const intent = buildIntent(REPO_OPTIONS),
+              plan   = planOnboarding({
+                  intent,
+                  facts: {
+                      agent                      : buildAgent(),
+                      expectedParticipationStatus: 'active',
+                      graphNodeSeeded            : true,
+                      graphParticipationStatus   : 'temporarily_unreachable',
+                      rosterHasResident          : true,
+                      running                    : false
+                  }
+              }),
+              preflight = plan.segments.find(segment => segment.key === 'preflight');
+
+        expect(preflight.action).toBe('REFUSE');
+        expect(preflight.detail).toContain("expects '@neo-gpt-2' participationStatus 'active'");
+        expect(preflight.detail).toContain("projects 'temporarily_unreachable'");
+        expect(preflight.detail).toContain('git switch dev');
+        expect(preflight.detail).toContain('git pull --ff-only origin dev');
+        expect(preflight.detail).toContain('seedAgentIdentities.mjs');
+        expect(preflight.detail).toContain("get_node({id:'@neo-gpt-2', projection:'full'})");
+        expect(preflight.detail).toContain('who_is_online({verbose:true})');
+        expect(plan.segments.some(segment => segment.key === 'launch')).toBe(false);
     });
 
     test('PHASE B re-run on a running agent reports launch EXISTS (start short-circuits at the owner)', () => {

--- a/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs
@@ -1045,6 +1045,67 @@ test.describe('Neo.ai.services.memory-core.GraphService', () => {
         expect(broadcast.type).toBe('BroadcastSentinel');
     });
 
+    test('boot provisioning adds missing identity roots without rewriting persisted state (#15431)', () => {
+        const
+            existingId       = '@boot-existing',
+            missingId        = '@boot-missing',
+            persistedCreated = '2026-07-19T19:15:34.000Z';
+
+        // Simulate a graph projection that is newer than this process-local registry snapshot.
+        // Writing through storage keeps the falsifier on the persisted authority, not RAM alone.
+        GraphService.db.storage.addNodes([{
+            id        : existingId,
+            label     : 'AgentIdentity',
+            properties: {
+                createdAt          : persistedCreated,
+                displayName        : 'Persisted Iris',
+                participationStatus: 'active',
+                runtimeWitness     : 'must-survive'
+            }
+        }]);
+
+        GraphService.db.nodes.clearSilent();
+        GraphService.db.vicinityLoadedNodes.delete(existingId);
+
+        const before  = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(existingId).data;
+        const created = GraphService.provisionMissingIdentityRoots([{
+            id        : existingId,
+            type      : 'AgentIdentity',
+            name      : 'Stale local identity',
+            properties: {
+                createdAt          : '2026-07-19T09:40:49.000Z',
+                displayName        : 'Neo Kimi Iris',
+                participationStatus: 'temporarily_unreachable'
+            }
+        }, {
+            id        : missingId,
+            type      : 'AgentIdentity',
+            name      : 'Fresh identity',
+            properties: {
+                createdAt          : '2026-07-19T20:00:00.000Z',
+                participationStatus: 'temporarily_unreachable'
+            }
+        }]);
+
+        const
+            after   = GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(existingId).data,
+            missing = JSON.parse(GraphService.db.storage.db.prepare('SELECT data FROM Nodes WHERE id = ?').get(missingId).data);
+
+        expect(created).toBe(1);
+        expect(after).toBe(before);
+        expect(JSON.parse(after).properties).toMatchObject({
+            createdAt          : persistedCreated,
+            displayName        : 'Persisted Iris',
+            participationStatus: 'active',
+            runtimeWitness     : 'must-survive'
+        });
+        expect(missing).toMatchObject({
+            id        : missingId,
+            label     : 'AgentIdentity',
+            properties: {participationStatus: 'temporarily_unreachable', userId: null}
+        });
+    });
+
     test('cross-tenant data isolation and identity stamping', async () => {
         const RequestContextService = (await import('../../../../../../ai/mcp/server/shared/services/RequestContextService.mjs')).default;
 


### PR DESCRIPTION
Resolves #15431

Prevents ordinary Memory Core startup from replaying a stale process-local AgentIdentity registry over newer persisted graph truth. Boot now provisions only missing identity roots; the explicit seed command remains the intentional canonical-update authority; and the existing onboarding conductor compares merged `origin/dev` participation state with the persisted full node before launch, refusing mismatches with an exact deployment-aware recovery sequence.

Evidence: L2 (real-SQLite boot-provision regression, injectable explicit-seed behavior test, and fail-closed onboarding-plan coverage) → L2 required (AC1–AC4); AC5 already carries the live Iris recovery receipt from 2026-07-19. No residuals.

## Deltas from ticket

- The operator sequence is stricter than the ticket's shorthand: `git switch dev` + `git pull --ff-only origin dev` prevents an explicit seed from projecting a feature branch by accident.
- `seedAgentIdentities.mjs` now exports an injectable function and lazily imports the configured service. Direct CLI behavior and one-shot process exit remain unchanged, while the canonical-update contract is unit-testable without mounting production storage.
- `onboardPeer.mjs` parses the literal merged `participationStatus` from `origin/dev`, reads the persisted full identity row, and blocks launch on missing, malformed, unreachable, or divergent state.
- Decision Record impact: none. This restores the accepted `#10232` boot/manual-seed split; ADR 0001 continues to own cross-process cache coherence rather than identity write authority.
- Reference-doc lifecycle: the existing IdentitySchema ingestion and OwnAgentTeam bring-up anchors were updated in place; no turn-loaded rule was added. The manual sequence can retire if a deployment-aware verifier later becomes the single owner.

## Test Evidence

- Memory Core identity write authority: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/GraphService.spec.mjs test/playwright/unit/ai/graph/identityRoots.spec.mjs test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs` → 94 passed.
- Explicit seed import boundary: `node --input-type=module -e "const mod = await import('./ai/scripts/setup/seedAgentIdentities.mjs'); console.log(typeof mod.seedAgentIdentities);"` → `function`, with no service mount or CLI execution.
- Operator/reference docs: `npm run ai:lint-guides` → 0 hard failures (repository-wide pre-existing warnings only).
- Final source gates: `npm run agent-preflight -- --no-fix <8 touched files>` → passed; pre-commit whitespace, shorthand, AiConfig-test-mutation, JSDoc-type, ticket-archaeology, block-alignment, and parse gates → passed.
- Directly touched surfaces: `GraphService` boot path → persisted-newer + missing-root regression passed; explicit seed path → canonical update + immutable `createdAt`/runtime-property preservation passed; onboarding conductor → exact merged-status match and stale-status refusal passed; operator docs → guide lint passed.

## Post-Merge Validation

- [ ] On the next real identity activation/status flip, run the documented switch → fast-forward pull → explicit seed → restart sequence and append the full `get_node` + verbose `who_is_online` receipt to `#15431`.
- [ ] Restart a second updated MCP server after that projection and confirm ordinary boot leaves the persisted identity row unchanged.

## Commit

- `377007b19e` — separate ordinary boot provisioning from explicit identity projection and harden the activation gate.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session b4496dab-2fb9-4548-9293-78b4a3d78f60.
