### PR TITLE
fix(ci): keep stale reruns from canceling current heads (#15593)

### DIFF
--- a/.github/workflows/adr-seam-table-lint.yml
+++ b/.github/workflows/adr-seam-table-lint.yml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/adr-seam-table-lint.yml'
 
 concurrency:
-  group: adr-seam-table-lint-${{ github.ref }}
+  group: adr-seam-table-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/aiconfig-antipattern-lint.yml
+++ b/.github/workflows/aiconfig-antipattern-lint.yml
@@ -17,7 +17,7 @@ on:
       - '.github/workflows/aiconfig-antipattern-lint.yml'
 
 concurrency:
-  group: aiconfig-antipattern-lint-${{ github.ref }}
+  group: aiconfig-antipattern-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/aiconfig-test-mutation-lint.yml
+++ b/.github/workflows/aiconfig-test-mutation-lint.yml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/aiconfig-test-mutation-lint.yml'
 
 concurrency:
-  group: aiconfig-test-mutation-lint-${{ github.ref }}
+  group: aiconfig-test-mutation-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-agentos-theme.yml
+++ b/.github/workflows/check-agentos-theme.yml
@@ -21,7 +21,7 @@ on:
       - 'package.json'
 
 concurrency:
-  group: check-agentos-theme-${{ github.ref }}
+  group: check-agentos-theme-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-examples-body-only.yml
+++ b/.github/workflows/check-examples-body-only.yml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/check-examples-body-only.yml'
 
 concurrency:
-  group: check-examples-body-only-${{ github.ref }}
+  group: check-examples-body-only-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-retired-primitives.yml
+++ b/.github/workflows/check-retired-primitives.yml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/check-retired-primitives.yml'
 
 concurrency:
-  group: check-retired-primitives-${{ github.ref }}
+  group: check-retired-primitives-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/config-template-ssot-lint.yml
+++ b/.github/workflows/config-template-ssot-lint.yml
@@ -31,7 +31,7 @@ on:
       - '.github/workflows/config-template-ssot-lint.yml'
 
 concurrency:
-  group: config-template-ssot-lint-${{ github.ref }}
+  group: config-template-ssot-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/discussion-lifecycle-audit.yml
+++ b/.github/workflows/discussion-lifecycle-audit.yml
@@ -20,7 +20,7 @@ on:
       - 'package.json'
 
 concurrency:
-  group: discussion-lifecycle-audit-${{ github.ref }}
+  group: discussion-lifecycle-audit-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/front-door-fingerprint.yml
+++ b/.github/workflows/front-door-fingerprint.yml
@@ -15,7 +15,7 @@ on:
       - '.github/workflows/front-door-fingerprint.yml'
 
 concurrency:
-  group: front-door-fingerprint-${{ github.ref }}
+  group: front-door-fingerprint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/jsdoc-type-lint.yml
+++ b/.github/workflows/jsdoc-type-lint.yml
@@ -23,7 +23,7 @@ on:
       - '.github/workflows/jsdoc-type-lint.yml'
 
 concurrency:
-  group: jsdoc-type-lint-${{ github.ref }}
+  group: jsdoc-type-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/mcp-test-location-lint.yml
+++ b/.github/workflows/mcp-test-location-lint.yml
@@ -21,7 +21,7 @@ on:
       - 'package.json'
 
 concurrency:
-  group: mcp-test-location-lint-${{ github.ref }}
+  group: mcp-test-location-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/skill-manifest-lint.yml
+++ b/.github/workflows/skill-manifest-lint.yml
@@ -23,7 +23,7 @@ on:
       - 'learn/guides/fundamentals/CodebaseOverview.md'
 
 concurrency:
-  group: skill-manifest-lint-${{ github.ref }}
+  group: skill-manifest-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/substrate-size-guard.yml
+++ b/.github/workflows/substrate-size-guard.yml
@@ -29,7 +29,7 @@ on:
       - 'package.json'
 
 concurrency:
-  group: substrate-size-guard-${{ github.ref }}
+  group: substrate-size-guard-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,9 @@ on:
     branches: [dev]
 
 concurrency:
-  group: tests-${{ github.workflow }}-${{ github.ref }}
+  # Initial attempts share the ref stream so new heads still supersede old work.
+  # Reruns retain their original run_id and cannot cancel a newer head (#15593).
+  group: tests-${{ github.workflow }}-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 
@@ -60,6 +62,42 @@ jobs:
               }
 
               return null;
+            }
+
+            async function isCurrentPullRequestHead() {
+              if (eventName !== 'pull_request') {
+                return true;
+              }
+
+              const pull = await github.rest.pulls.get({
+                owner      : context.repo.owner,
+                repo       : context.repo.repo,
+                pull_number: context.payload.pull_request.number
+              });
+              const eventHead = context.payload.pull_request.head.sha;
+              const liveHead  = pull.data.head.sha;
+
+              if (eventHead === liveHead) {
+                return true;
+              }
+
+              const reason = `stale workflow head ${eventHead}; live PR head is ${liveHead}`;
+
+              core.notice(`Skipping expensive test suites: ${reason}`);
+              core.setOutput('run_integration', 'false');
+              core.setOutput('run_unit', 'false');
+              core.setOutput('run_components', 'false');
+              core.setOutput('skip_reason', reason);
+              await core.summary
+                .addHeading('Stale workflow attempt')
+                .addRaw(`Skipped expensive test suites because ${reason}.`)
+                .write();
+
+              return false;
+            }
+
+            if (!await isCurrentPullRequestHead()) {
+              return;
             }
 
             const files = await getChangedFiles();
@@ -162,12 +200,46 @@ jobs:
             run: ${{ needs.changes.outputs.run_components }}
 
     steps:
+      # Re-run failed jobs does not re-run successful prerequisite jobs. Keep this
+      # job-local gate so an obsolete failed suite cannot consume a full runner.
+      - name: Verify current pull-request head
+        id: head
+        uses: actions/github-script@v9
+        with:
+          script: |
+            if (context.eventName !== 'pull_request') {
+              core.setOutput('current', 'true');
+              return;
+            }
+
+            const pull = await github.rest.pulls.get({
+              owner      : context.repo.owner,
+              repo       : context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            const eventHead = context.payload.pull_request.head.sha;
+            const liveHead  = pull.data.head.sha;
+            const current   = eventHead === liveHead;
+
+            core.setOutput('current', String(current));
+
+            if (!current) {
+              const reason = `stale workflow head ${eventHead}; live PR head is ${liveHead}`;
+
+              core.notice(`Skipping expensive test suite: ${reason}`);
+              core.setOutput('skip_reason', reason);
+              await core.summary
+                .addHeading('Stale workflow attempt')
+                .addRaw(`Skipped the expensive test suite because ${reason}.`)
+                .write();
+            }
+
       - name: Checkout repository
-        if: ${{ matrix.run == 'true' }}
+        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' }}
         uses: actions/checkout@v6
 
       - name: Setup Node.js
-        if: ${{ matrix.run == 'true' }}
+        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' }}
         uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -179,32 +251,32 @@ jobs:
       # components suite runs browser-against-dev-server. No suite needs the
       # canonical KB artifact in CI.
       - name: Skip Knowledge Base download in prepare lifecycle
-        if: ${{ matrix.run == 'true' }}
+        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' }}
         run: mkdir -p .neo-ai-data
 
       - name: Install dependencies
-        if: ${{ matrix.run == 'true' }}
+        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' }}
         run: npm ci
 
       # Required for the unit-test runner per bootstrapWorktree.mjs precedent.
       # Harmless for the other suites.
       - name: Bundle parse5
-        if: ${{ matrix.run == 'true' }}
+        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' }}
         run: npm run bundle-parse5
 
       # The components suite launches real Chromium against the dev server; unit and
       # integration run browserless, so browser provisioning stays scoped to this suite.
       - name: Install Playwright Chromium
-        if: ${{ matrix.run == 'true' && matrix.suite == 'components' }}
+        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' && matrix.suite == 'components' }}
         run: npx playwright install --with-deps chromium
 
       - name: Skip ${{ matrix.suite }} tests
-        if: ${{ matrix.run != 'true' }}
+        if: ${{ matrix.run != 'true' || steps.head.outputs.current != 'true' }}
         run: |
-          echo "${{ matrix.suite }} skipped: ${{ needs.changes.outputs.skip_reason }}"
+          echo "${{ matrix.suite }} skipped: ${{ steps.head.outputs.skip_reason || needs.changes.outputs.skip_reason }}"
 
       - name: Run ${{ matrix.suite }} tests
-        if: ${{ matrix.run == 'true' }}
+        if: ${{ matrix.run == 'true' && steps.head.outputs.current == 'true' }}
         run: npm run test-${{ matrix.suite }}
         env:
           NEO_INTEGRATION_STACK_TIMEOUT_MS: '240000'
@@ -212,7 +284,7 @@ jobs:
           NEO_TEST_SKIP_CI: ${{ matrix.suite == 'unit' && 'true' || '' }}
 
       - name: Upload test artifacts on failure
-        if: failure()
+        if: ${{ failure() && matrix.run == 'true' && steps.head.outputs.current == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.suite }}-${{ github.run_id }}

--- a/.github/workflows/ticket-archaeology-lint.yml
+++ b/.github/workflows/ticket-archaeology-lint.yml
@@ -18,7 +18,7 @@ on:
       - '.github/workflows/ticket-archaeology-lint.yml'
 
 concurrency:
-  group: ticket-archaeology-lint-${{ github.ref }}
+  group: ticket-archaeology-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/tree-json-lint.yml
+++ b/.github/workflows/tree-json-lint.yml
@@ -21,7 +21,7 @@ on:
       - '.github/workflows/tree-json-lint.yml'
 
 concurrency:
-  group: tree-json-lint-${{ github.ref }}
+  group: tree-json-lint-${{ github.run_attempt == '1' && github.ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/test/playwright/unit/ai/buildScripts/util/WorkflowConcurrency.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/WorkflowConcurrency.spec.mjs
@@ -185,6 +185,22 @@ test.describe('GitHub workflow concurrency (#15593)', () => {
         );
     });
 
+    test('the failed-job gate preserves current-head and push retries', async () => {
+        const workflow   = readWorkflow('test.yml'),
+              steps      = workflow.jobs.test.steps,
+              headScript = steps.find(step => step.id === 'head').with.script,
+              current    = createRuntime({ eventHead: 'current-head' }),
+              push       = createRuntime({ eventName: 'push' });
+
+        await executeScript(headScript, current);
+        await executeScript(headScript, push);
+
+        expect(current.calls.pullsGet).toBe(1);
+        expect(push.calls.pullsGet).toBe(0);
+        expect(Object.fromEntries(current.outputs)).toEqual({ current: 'true' });
+        expect(Object.fromEntries(push.outputs)).toEqual({ current: 'true' });
+    });
+
     test('a live-head lookup failure fails closed before path classification', async () => {
         const workflow = readWorkflow('test.yml'),
               script   = workflow.jobs.changes.steps.find(step => step.id === 'scope').with.script,

--- a/test/playwright/unit/ai/buildScripts/util/WorkflowConcurrency.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/WorkflowConcurrency.spec.mjs
@@ -1,0 +1,201 @@
+import { test, expect }  from '@playwright/test';
+import fs                from 'node:fs';
+import path              from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as yaml         from 'js-yaml';
+
+const __dirname              = path.dirname(fileURLToPath(import.meta.url)),
+      repoRoot               = path.resolve(__dirname, '../../../../../..'),
+      workflowsDir           = path.join(repoRoot, '.github/workflows'),
+      rerunIsolationContract = "github.run_attempt == '1' && github.ref || github.run_id",
+      AsyncFunction          = Object.getPrototypeOf(async function() {}).constructor;
+
+const readWorkflow = name => yaml.load(fs.readFileSync(path.join(workflowsDir, name), 'utf8'));
+
+const createRuntime = ({
+    eventHead = 'stale-head',
+    eventName = 'pull_request',
+    files     = ['src/Neo.mjs'],
+    liveHead  = 'current-head'
+} = {}) => {
+    const outputs = new Map(),
+          summary = [],
+          calls   = { compare: 0, listFiles: 0, pullsGet: 0 },
+          core    = {
+              info     : () => {},
+              notice   : () => {},
+              setOutput: (name, value) => outputs.set(name, value),
+              summary  : {
+                  addHeading(value) {
+                      summary.push(value);
+                      return this;
+                  },
+                  addRaw(value) {
+                      summary.push(value);
+                      return this;
+                  },
+                  async write() {}
+              }
+          },
+          github  = {
+              paginate: async() => {
+                  calls.listFiles++;
+                  return files.map(filename => ({ filename }));
+              },
+              rest: {
+                  pulls: {
+                      get: async() => {
+                          calls.pullsGet++;
+                          return { data: { head: { sha: liveHead } } };
+                      },
+                      listFiles: () => {}
+                  },
+                  repos: {
+                      compareCommitsWithBasehead: async() => {
+                          calls.compare++;
+                          return { data: { files: files.map(filename => ({ filename })) } };
+                      }
+                  }
+              }
+          },
+          context = {
+              eventName,
+              payload: {
+                  after       : 'after-sha',
+                  before      : 'before-sha',
+                  pull_request: {
+                      head  : { sha: eventHead },
+                      number: 15588
+                  }
+              },
+              repo: { owner: 'neomjs', repo: 'neo' }
+          };
+
+    return { calls, context, core, github, outputs, summary };
+};
+
+const executeScript = async(script, runtime) => {
+    await new AsyncFunction('github', 'context', 'core', script)(
+        runtime.github,
+        runtime.context,
+        runtime.core
+    );
+};
+
+test.describe('GitHub workflow concurrency (#15593)', () => {
+    test('every canceling pull-request workflow isolates reruns from the initial ref stream', () => {
+        const protectedWorkflows  = [],
+              vulnerableWorkflows = [];
+
+        for (const name of fs.readdirSync(workflowsDir).filter(name => name.endsWith('.yml'))) {
+            const workflow = readWorkflow(name),
+                  group    = workflow.concurrency?.group;
+
+            if (!workflow.on?.pull_request || workflow.concurrency?.['cancel-in-progress'] !== true) {
+                continue;
+            }
+
+            if (typeof group === 'string' && group.includes(rerunIsolationContract)) {
+                protectedWorkflows.push(name);
+            } else {
+                vulnerableWorkflows.push(name);
+            }
+        }
+
+        expect(protectedWorkflows).toContain('test.yml');
+        expect(vulnerableWorkflows).toEqual([]);
+    });
+
+    test('the Tests classifier admits only the live pull-request head', async () => {
+        const workflow = readWorkflow('test.yml'),
+              script   = workflow.jobs.changes.steps.find(step => step.id === 'scope').with.script,
+              runtime  = createRuntime();
+
+        await executeScript(script, runtime);
+
+        expect(runtime.calls).toEqual({ compare: 0, listFiles: 0, pullsGet: 1 });
+        expect(Object.fromEntries(runtime.outputs)).toEqual({
+            run_integration: 'false',
+            run_unit       : 'false',
+            run_components : 'false',
+            skip_reason    : 'stale workflow head stale-head; live PR head is current-head'
+        });
+        expect(runtime.summary.join(' ')).toContain('Stale workflow attempt');
+        expect(runtime.summary.join(' ')).toContain('stale-head');
+        expect(runtime.summary.join(' ')).toContain('current-head');
+    });
+
+    test('the Tests classifier preserves current-head and push admission', async () => {
+        const workflow = readWorkflow('test.yml'),
+              script   = workflow.jobs.changes.steps.find(step => step.id === 'scope').with.script,
+              current  = createRuntime({ eventHead: 'current-head' }),
+              push     = createRuntime({ eventName: 'push' });
+
+        await executeScript(script, current);
+        await executeScript(script, push);
+
+        expect(current.calls).toEqual({ compare: 0, listFiles: 1, pullsGet: 1 });
+        expect(push.calls).toEqual({ compare: 1, listFiles: 0, pullsGet: 0 });
+        expect(Object.fromEntries(current.outputs)).toMatchObject({
+            run_components : 'true',
+            run_integration: 'true',
+            run_unit       : 'true'
+        });
+        expect(Object.fromEntries(push.outputs)).toMatchObject({
+            run_components : 'true',
+            run_integration: 'true',
+            run_unit       : 'true'
+        });
+    });
+
+    test('failed-job reruns recheck the live head before every expensive step', async () => {
+        const workflow   = readWorkflow('test.yml'),
+              steps      = workflow.jobs.test.steps,
+              headIndex  = steps.findIndex(step => step.id === 'head'),
+              headScript = steps[headIndex].with.script,
+              runtime    = createRuntime(),
+              expensive  = [
+                  'Checkout repository',
+                  'Setup Node.js',
+                  'Skip Knowledge Base download in prepare lifecycle',
+                  'Install dependencies',
+                  'Bundle parse5',
+                  'Install Playwright Chromium',
+                  'Run ${{ matrix.suite }} tests',
+                  'Upload test artifacts on failure'
+              ];
+
+        await executeScript(headScript, runtime);
+
+        expect(headIndex).toBeLessThan(steps.findIndex(step => step.name === 'Checkout repository'));
+        expect(runtime.calls.pullsGet).toBe(1);
+        expect(Object.fromEntries(runtime.outputs)).toEqual({
+            current    : 'false',
+            skip_reason: 'stale workflow head stale-head; live PR head is current-head'
+        });
+
+        for (const name of expensive) {
+            expect(steps.find(step => step.name === name).if).toContain(
+                "steps.head.outputs.current == 'true'"
+            );
+        }
+
+        expect(steps.find(step => step.name === 'Skip ${{ matrix.suite }} tests').if).toContain(
+            "steps.head.outputs.current != 'true'"
+        );
+    });
+
+    test('a live-head lookup failure fails closed before path classification', async () => {
+        const workflow = readWorkflow('test.yml'),
+              script   = workflow.jobs.changes.steps.find(step => step.id === 'scope').with.script,
+              runtime  = createRuntime();
+
+        runtime.github.rest.pulls.get = async() => {
+            throw new Error('live head unavailable');
+        };
+
+        await expect(executeScript(script, runtime)).rejects.toThrow('live head unavailable');
+        expect(runtime.calls.listFiles).toBe(0);
+        expect(runtime.outputs.size).toBe(0);
+    });
+});


### PR DESCRIPTION
Resolves #15593

Prevents an obsolete GitHub Actions rerun from canceling the only Tests run for a pull request's current head. Initial workflow attempts still share the pull-request ref stream, so a new commit supersedes older initial work; rerun attempts move to their stable original `run_id`; and the expensive Tests matrix refuses stale event heads before checkout or dependency installation.

Evidence: L3 achieved. The parsed workflow-family contract and executable mocked classifier/job-admission scripts are backed by controlled GitHub Actions receipts: a new initial head canceled the old initial attempt; a later old-head rerun completed cheaply without canceling or substituting for the current head; and a current-head specific-job rerun passed the live-head gate and executed normally. No residuals.

## Deltas from ticket

- All 16 pull-request workflows with ref-only `cancel-in-progress: true` now use `github.run_attempt == '1' && github.ref || github.run_id`. GitHub documents `run_attempt` as a string and `run_id` as stable across reruns.
- The Tests classifier compares the event payload head to the live pull-request head before path classification. A stale full rerun emits an explicit summary and disables all expensive suites.
- Failed-job reruns do not rerun successful prerequisite jobs. The Tests matrix therefore repeats the cheap live-head admission before checkout/install, closing the exact path that exposed #15593.
- Live-head API failure remains visible and fails closed; it cannot silently admit expensive work or manufacture a green skip.
- Decision Record impact: none. This is an operational GitHub Actions arbitration correction.
- Reference-doc lifecycle: the concurrency rationale lives beside the workflow key and a mechanical family test prevents regression; no turn-loaded substrate was added.

## Test Evidence

- Workflow concurrency contracts: `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/WorkflowConcurrency.spec.mjs` → 8 passed including setup/teardown.
- Staged-file gates: whitespace, shorthand, AiConfig test-mutation, JSDoc types, ticket archaeology, block alignment, and parse → passed.
- `git diff --cached --check` → passed before commit.
- Branch freshness: `merge-base HEAD origin/dev == origin/dev` at `090495bea7b25017ac4cc9727f14b07d5a850ce5`; two outgoing ticketed commits.
- Controlled live arbitration: head 2 Tests run [`29704014925`](https://github.com/neomjs/neo/actions/runs/29704014925) canceled head 1 initial run [`29703988308`](https://github.com/neomjs/neo/actions/runs/29703988308), preserving normal supersession.
- Obsolete rerun: head 1 attempt 2 completed successfully while head 2 unit/integration remained live; its matrix head gates skipped checkout, setup, dependency installation, and all test commands.
- Current-head rerun: head 2 attempt 2 reran the components job through the same job-level attempt path used by failed-job reruns; the live-head gate admitted checkout/install/tests and components passed in 1m30s.

## Post-Merge Validation

- [x] Run the controlled two-head sequence: start the initial old-head workflow, push a meaningful second head, then rerun the old attempt and retain proof that no current-head job is canceled.
- [x] Rerun a current-head Tests job through the job-level attempt path used by failed-job reruns and retain proof that the job-local admission allows it to complete.
- [x] Confirm a subsequent ordinary head push still cancels the preceding initial attempt.

## Commit

- `ab7dc91ddf` — isolate reruns across the PR workflow family and add live-head admission to Tests.
- `b40c0378c6` — preserve current-head and push admission through the failed-job gate.

Authored by Euclid (GPT-5.6 Sol, Codex Desktop). Session b4496dab-2fb9-4548-9293-78b4a3d78f60.
