### PR TITLE
fix(ai): kimi-server wake adapter v0.28 instance-file lock discovery (#15596)

### DIFF
--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -1101,6 +1101,90 @@ async function deliverViaOpencodeServer(subscription, digest, evidenceLabel = ''
 }
 
 /**
+ * @summary Resolves the kimi-server loopback coordinates across the two harness generations.
+ *
+ * Precedence (first hit wins):
+ * 1. Explicit `harnessTargetMetadata.lockPath` override (test seam + operator pin).
+ * 2. Legacy v0.27 `~/.kimi-code/server/lock` (`kimi server`, hard-deprecated in v0.28).
+ * 3. Live scan of v0.28+ `~/.kimi-code/server/instances/{server_id}.json` (`kimi web`).
+ *
+ * Instance liveness is **pid-based** (`process.kill(pid, 0)`, EPERM counts as alive), NOT
+ * heartbeat-based: the instance file's `heartbeat_at` is upstream-throttled — 39-minute idle
+ * gaps were observed on a definitively live server (2026-07-20, seat `@neo-kimi-iris`, kimi
+ * v0.28.0) — so a heartbeat freshness gate would produce false fail-closed wake drops. A
+ * pid-reused candidate (wrong process at a recycled pid) degrades fail-visibly at the
+ * bearer/HTTP layer downstream, never silently.
+ *
+ * Zero live instances → actionable error naming both generations and the `kimi web`
+ * remediation. Multiple live instances → fail closed (never pick arbitrarily); the operator
+ * disambiguates via `harnessTargetMetadata.lockPath`.
+ *
+ * @param {Object} meta The subscription's `harnessTargetMetadata` (already default-resolved).
+ * @returns {Promise<{lock: Object, lockSource: String}>} The coordinate payload + its origin.
+ */
+async function resolveKimiServerLock(meta) {
+    if (typeof meta.lockPath === 'string' && meta.lockPath.length > 0) {
+        try {
+            return {lock: JSON.parse(await fs.readFile(meta.lockPath, 'utf8')), lockSource: `override '${meta.lockPath}'`};
+        } catch (err) {
+            throw new Error(`kimi-server requires a readable server lock at '${meta.lockPath}' (${err.message})`);
+        }
+    }
+
+    const legacyPath = path.join(os.homedir(), '.kimi-code', 'server', 'lock');
+
+    try {
+        return {lock: JSON.parse(await fs.readFile(legacyPath, 'utf8')), lockSource: `legacy v0.27 lock '${legacyPath}'`};
+    } catch (err) {
+        // v0.28+ seats never write the legacy lock — fall through to the instance scan.
+    }
+
+    const instancesDir = path.join(os.homedir(), '.kimi-code', 'server', 'instances');
+    const notFound     = `kimi-server found no v0.27 lock at '${legacyPath}' and no live v0.28 instance in '${instancesDir}' — is 'kimi web' running on this seat?`;
+
+    let entries = [];
+
+    try {
+        entries = await fs.readdir(instancesDir);
+    } catch (err) {
+        throw new Error(`${notFound} (${err.message})`);
+    }
+
+    const live = [];
+
+    for (const entry of entries) {
+        if (!entry.endsWith('.json')) continue;
+
+        const instancePath = path.join(instancesDir, entry);
+
+        try {
+            const candidate = JSON.parse(await fs.readFile(instancePath, 'utf8'));
+
+            if (Number.isInteger(candidate.pid) && candidate.pid > 0) {
+                try {
+                    process.kill(candidate.pid, 0);
+                    live.push({candidate, instancePath});
+                } catch (killErr) {
+                    if (killErr.code === 'EPERM') live.push({candidate, instancePath}); // exists, owned by another user
+                }
+            }
+        } catch (err) {
+            // Unparseable instance file: not a coordinate source.
+        }
+    }
+
+    if (live.length === 0) {
+        throw new Error(notFound);
+    }
+
+    if (live.length > 1) {
+        throw new Error(`kimi-server found ${live.length} live v0.28 instances in '${instancesDir}' and cannot pick one arbitrarily — set harnessTargetMetadata.lockPath to disambiguate`);
+    }
+
+    return {lock: live[0].candidate, lockSource: `v0.28 instance '${live[0].instancePath}'`};
+}
+
+/**
  * @summary Dispatches a wake digest into a live Kimi Code session through the seat's local
  * `kimi server` REST surface (`POST /api/v1/sessions/{id}/prompts` — submitPrompt).
  *
@@ -1121,13 +1205,17 @@ async function deliverViaOpencodeServer(subscription, digest, evidenceLabel = ''
  * session, so for a single-seat checkout the cross-check is belt-and-suspenders, but for
  * shared ones it is the stale-checkout guard.
  *
- * **Coordinate contract** (no seat-side writer needed — the harness persists both files
- * itself at server start): the loopback coordinates come from `~/.kimi-code/server/lock`
- * (`{pid, host, port, …}`), the bearer token from `~/.kimi-code/server.token` (persistent
- * across restarts; rotated via `kimi server rotate-token`). Both paths are overridable via
- * `harnessTargetMetadata.lockPath` / `harnessTargetMetadata.tokenPath` (test seams). The
- * daemon re-reads both on every delivery, so server restarts and token rotation need no
- * graph write.
+ * **Coordinate contract — two harness generations** (no seat-side writer needed — the harness
+ * persists the coordinate files itself): the bearer token comes from `~/.kimi-code/server.token`
+ * (persistent across restarts; rotation is harness-managed). The loopback coordinates are
+ * generation-dependent: v0.27 (`kimi server`, hard-deprecated in v0.28) wrote
+ * `~/.kimi-code/server/lock` (`{pid, host, port, …}`); v0.28+ (`kimi web`) writes
+ * `~/.kimi-code/server/instances/{server_id}.json` (`{server_id, pid, host, port, started_at,
+ * heartbeat_at, host_version}`). Discovery precedence: explicit `harnessTargetMetadata.lockPath`
+ * override → legacy v0.27 lock → live v0.28 instance scan (pid-liveness; zero live → actionable
+ * error, multiple live → fail closed). `lockPath` / `tokenPath` metadata stay authoritative
+ * test seams. The daemon re-reads coordinates on every delivery, so server restarts and token
+ * rotation need no graph write.
  *
  * Probe evidence (2026-07-19, seat `@neo-kimi-iris`, kimi v0.27.0): loopback 127.0.0.1:58627
  * with bearer auth default-on, `/openapi.json` enumerating the surface at runtime, hook stdin
@@ -1137,6 +1225,14 @@ async function deliverViaOpencodeServer(subscription, digest, evidenceLabel = ''
  * only after parsing `code === 0`. A queued/blocked status still lands the digest in the
  * session's own queue — the seat sees it when the active turn drains.
  *
+ * Probe evidence (2026-07-20, seat `@neo-kimi-iris`, kimi v0.28.0): `kimi server`
+ * hard-deprecated (no `server/lock` written); `kimi web` resident on 127.0.0.1:58627 writing
+ * `server/instances/{server_id}.json`; `heartbeat_at` upstream-throttled (39-min idle gaps on a
+ * definitively live server) so instance liveness is pid-based, never heartbeat-based;
+ * `/openapi.json` still enumerates `POST /api/v1/sessions/{id}/prompts`; a live TUI-hosted
+ * session is listed by the REST surface and accepts submitPrompt (`code: 0, status:
+ * "running"`).
+ *
  * @param {Object} subscription WAKE_SUBSCRIPTION node.
  * @param {String} digest Wake digest body.
  * @param {String} [evidenceLabel=''] Formatted wake scenario / route evidence for validation logs.
@@ -1145,7 +1241,6 @@ async function deliverViaOpencodeServer(subscription, digest, evidenceLabel = ''
  */
 async function deliverViaKimiServer(subscription, digest, evidenceLabel = '', abortSignal = null) {
     const meta         = subscription.properties?.harnessTargetMetadata || {};
-    const lockPath     = meta.lockPath     || path.join(os.homedir(), '.kimi-code', 'server', 'lock');
     const tokenPath    = meta.tokenPath    || path.join(os.homedir(), '.kimi-code', 'server.token');
     const envelopePath = meta.envelopePath || path.join(os.homedir(), '.kimi-code', 'wake-envelope.json');
 
@@ -1174,11 +1269,8 @@ async function deliverViaKimiServer(subscription, digest, evidenceLabel = '', ab
         throw new Error(`kimi-server envelope at '${envelopePath}' cwd '${cwd}' does not match harnessTargetMetadata.cwd '${meta.cwd}'`);
     }
 
-    try {
-        lock = JSON.parse(await fs.readFile(lockPath, 'utf8'));
-    } catch (err) {
-        throw new Error(`kimi-server requires a readable server lock at '${lockPath}' (${err.message})`);
-    }
+    const {lock: resolvedLock, lockSource} = await resolveKimiServerLock(meta);
+    lock = resolvedLock;
 
     try {
         token = (await fs.readFile(tokenPath, 'utf8')).trim();
@@ -1192,11 +1284,11 @@ async function deliverViaKimiServer(subscription, digest, evidenceLabel = '', ab
     // client off the seat's loopback server. Delivery is globally serialized, so the fetch is
     // also deadline-bounded — one hung endpoint must not wedge every later wake route.
     if (!['127.0.0.1', 'localhost', '::1'].includes(host)) {
-        throw new Error(`kimi-server lock at '${lockPath}' requires a loopback host (received '${host}')`);
+        throw new Error(`kimi-server lock from ${lockSource} requires a loopback host (received '${host}')`);
     }
 
     if (!Number.isInteger(port) || port < 1 || port > 65535) {
-        throw new Error(`kimi-server lock at '${lockPath}' requires 'port' to be an integer in 1..65535`);
+        throw new Error(`kimi-server lock from ${lockSource} requires 'port' to be an integer in 1..65535`);
     }
 
     if (token.length === 0) {

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -2230,6 +2230,355 @@ test.describe('Wake Daemon', () => {
         expect(stdoutLog).not.toContain(`Dispatched ${subId} via kimi-server submitPrompt`);
     });
 
+    test('kimi-server discovers a single live v0.28 instance without override or legacy lock (#15596)', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-kimi-v028-discovery';
+
+        // Stub the seat's `kimi web` REST surface: captures the submitPrompt POST.
+        const captured   = [];
+        const stubServer = http.createServer((req, res) => {
+            let body = '';
+            req.on('data', chunk => { body += chunk; });
+            req.on('end', () => {
+                captured.push({method: req.method, url: req.url, authorization: req.headers.authorization, body});
+                res.writeHead(200, {'content-type': 'application/json'});
+                res.end(JSON.stringify({code: 0, data: {status: 'running'}}));
+            });
+        });
+        await new Promise(resolve => stubServer.listen(0, '127.0.0.1', resolve));
+        const stubPort = stubServer.address().port;
+
+        // Fixture HOME: only a v0.28 instance file (pid = this test runner = alive), no legacy lock.
+        const fakeHome     = path.join(DAEMON_DIR, 'kimi-home-v028');
+        const instancesDir = path.join(fakeHome, '.kimi-code', 'server', 'instances');
+        fs.ensureDirSync(instancesDir);
+        fs.writeJsonSync(path.join(instancesDir, '01TESTINSTANCE0000000000000.json'), {
+            server_id   : '01TESTINSTANCE0000000000000',
+            pid         : process.pid,
+            host        : '127.0.0.1',
+            port        : stubPort,
+            started_at  : Date.now(),
+            heartbeat_at: Date.now(),
+            host_version: '0.28.0'
+        });
+
+        const tokenPath    = path.join(DAEMON_DIR, 'kimi-server-v028.token');
+        const envelopePath = path.join(DAEMON_DIR, 'kimi-wake-envelope-v028.json');
+        fs.writeFileSync(tokenPath, 'kimi-test-token\n');
+        fs.writeJsonSync(envelopePath, {sessionId: 'ses_kimi_v028', cwd: '/seat/checkout', updatedAt: '2026-07-20T10:00:00.000Z'});
+
+        insertWakeSubscription(db, {
+            subId,
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'kimi-server',
+                envelopePath,
+                tokenPath,
+                coalesceWindow: 1
+                // no lockPath: discovery must find the v0.28 instance under HOME
+            }
+        });
+
+        const binDir = path.join(DAEMON_DIR, 'bin');
+        fs.ensureDirSync(binDir);
+        writeMockPs(binDir);
+
+        let stdoutLog = '';
+
+        try {
+            daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+                stdio: 'pipe',
+                env  : {
+                    ...process.env,
+                    HOME              : fakeHome,
+                    NEO_MEMORY_DB_PATH: DB_PATH,
+                    NEO_AI_DAEMON_DIR : DAEMON_DIR,
+                    PATH              : `${path.resolve(binDir)}${path.delimiter}${process.env.PATH}`
+                }
+            });
+
+            const deliveryPromise = new Promise((resolve, reject) => {
+                const timeout = setTimeout(() => reject(new Error('Daemon failed to discover the v0.28 instance + deliver within timeout')), 10000);
+
+                daemonProcess.stdout.on('data', (data) => {
+                    const out = data.toString();
+                    stdoutLog += out;
+                    if (out.includes(`[Wake Dispatch] ${agentId}: outcome=delivered`)) {
+                        clearTimeout(timeout);
+                        resolve();
+                    }
+                });
+                daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+                daemonProcess.on('error', reject);
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            insertMessageWake(db, {
+                agentId,
+                subject: 'Kimi v0.28 Discovery Wake'
+            });
+
+            await deliveryPromise;
+
+            expect(captured.length).toBe(1);
+            expect(captured[0].method).toBe('POST');
+            expect(captured[0].url).toBe('/api/v1/sessions/ses_kimi_v028/prompts');
+            expect(captured[0].authorization).toBe('Bearer kimi-test-token');
+            expect(stdoutLog).toContain(`Dispatched ${subId} via kimi-server submitPrompt (session ses_kimi_v028, status=running)`);
+        } finally {
+            stubServer.close();
+        }
+    });
+
+    test('kimi-server rejects a dead-pid v0.28 instance and names both generations (#15596)', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-kimi-v028-dead-pid';
+
+        // A pid that is guaranteed dead: spawn + await exit, then reuse its pid.
+        const deadChild = spawn(process.execPath, ['-e', ''], {stdio: 'ignore'});
+        await new Promise(resolve => deadChild.on('exit', resolve));
+        const deadPid = deadChild.pid;
+
+        const fakeHome     = path.join(DAEMON_DIR, 'kimi-home-dead');
+        const instancesDir = path.join(fakeHome, '.kimi-code', 'server', 'instances');
+        fs.ensureDirSync(instancesDir);
+        fs.writeJsonSync(path.join(instancesDir, '01DEADINSTANCE000000000000.json'), {
+            server_id   : '01DEADINSTANCE000000000000',
+            pid         : deadPid,
+            host        : '127.0.0.1',
+            port        : 1,
+            started_at  : Date.now(),
+            heartbeat_at: Date.now(),
+            host_version: '0.28.0'
+        });
+
+        const tokenPath    = path.join(DAEMON_DIR, 'kimi-server-dead.token');
+        const envelopePath = path.join(DAEMON_DIR, 'kimi-wake-envelope-dead.json');
+        fs.writeFileSync(tokenPath, 'kimi-test-token\n');
+        fs.writeJsonSync(envelopePath, {sessionId: 'ses_kimi_dead', cwd: '/seat/checkout', updatedAt: '2026-07-20T10:00:00.000Z'});
+
+        insertWakeSubscription(db, {
+            subId,
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'kimi-server',
+                envelopePath,
+                tokenPath,
+                coalesceWindow: 1
+            }
+        });
+
+        let stdoutLog = '';
+
+        daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+            stdio: 'pipe',
+            env  : {
+                ...process.env,
+                HOME              : fakeHome,
+                NEO_MEMORY_DB_PATH: DB_PATH,
+                NEO_AI_DAEMON_DIR : DAEMON_DIR
+            }
+        });
+
+        daemonProcess.stdout.on('data', (data) => { stdoutLog += data.toString(); });
+        // The fail-visible path logs through the error stream; fold it into the same buffer.
+        daemonProcess.stderr.on('data', (data) => { stdoutLog += data.toString(); });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {
+            agentId,
+            subject: 'Kimi v0.28 Dead Instance Wake'
+        });
+
+        // Give the daemon room to attempt (and possibly retry) the delivery.
+        await new Promise(resolve => setTimeout(resolve, 4000));
+
+        expect(stdoutLog).toContain('no v0.27 lock');
+        expect(stdoutLog).toContain('no live v0.28 instance');
+        expect(stdoutLog).toContain(`'kimi web'`);
+        expect(stdoutLog).not.toContain(`[Wake Dispatch] ${agentId}: outcome=delivered`);
+        expect(stdoutLog).not.toContain(`Dispatched ${subId} via kimi-server submitPrompt`);
+    });
+
+    test('kimi-server fails closed on multiple live v0.28 instances instead of picking arbitrarily (#15596)', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-kimi-v028-ambiguous';
+
+        const captured   = [];
+        const stubServer = http.createServer((req, res) => {
+            captured.push({url: req.url});
+            res.writeHead(200, {'content-type': 'application/json'});
+            res.end(JSON.stringify({code: 0, data: {status: 'running'}}));
+        });
+        await new Promise(resolve => stubServer.listen(0, '127.0.0.1', resolve));
+        const stubPort = stubServer.address().port;
+
+        // Two LIVE instance files (both pid = this test runner) on different ports: the daemon
+        // must refuse to guess, even though either would answer HTTP.
+        const fakeHome     = path.join(DAEMON_DIR, 'kimi-home-ambiguous');
+        const instancesDir = path.join(fakeHome, '.kimi-code', 'server', 'instances');
+        fs.ensureDirSync(instancesDir);
+
+        for (const [serverId, port] of [['01AMBIGUOUSINSTANCE000000A', stubPort], ['01AMBIGUOUSINSTANCE000000B', stubPort + 1]]) {
+            fs.writeJsonSync(path.join(instancesDir, `${serverId}.json`), {
+                server_id   : serverId,
+                pid         : process.pid,
+                host        : '127.0.0.1',
+                port,
+                started_at  : Date.now(),
+                heartbeat_at: Date.now(),
+                host_version: '0.28.0'
+            });
+        }
+
+        const tokenPath    = path.join(DAEMON_DIR, 'kimi-server-ambiguous.token');
+        const envelopePath = path.join(DAEMON_DIR, 'kimi-wake-envelope-ambiguous.json');
+        fs.writeFileSync(tokenPath, 'kimi-test-token\n');
+        fs.writeJsonSync(envelopePath, {sessionId: 'ses_kimi_ambiguous', cwd: '/seat/checkout', updatedAt: '2026-07-20T10:00:00.000Z'});
+
+        insertWakeSubscription(db, {
+            subId,
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'kimi-server',
+                envelopePath,
+                tokenPath,
+                coalesceWindow: 1
+            }
+        });
+
+        let stdoutLog = '';
+
+        try {
+            daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+                stdio: 'pipe',
+                env  : {
+                    ...process.env,
+                    HOME              : fakeHome,
+                    NEO_MEMORY_DB_PATH: DB_PATH,
+                    NEO_AI_DAEMON_DIR : DAEMON_DIR
+                }
+            });
+
+            daemonProcess.stdout.on('data', (data) => { stdoutLog += data.toString(); });
+            // The fail-visible path logs through the error stream; fold it into the same buffer.
+            daemonProcess.stderr.on('data', (data) => { stdoutLog += data.toString(); });
+
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            insertMessageWake(db, {
+                agentId,
+                subject: 'Kimi v0.28 Ambiguous Wake'
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 4000));
+
+            expect(stdoutLog).toContain('cannot pick one arbitrarily');
+            expect(stdoutLog).toContain('lockPath');
+            expect(stdoutLog).not.toContain(`[Wake Dispatch] ${agentId}: outcome=delivered`);
+            expect(captured.length).toBe(0);
+        } finally {
+            stubServer.close();
+        }
+    });
+
+    test('kimi-server legacy v0.27 lock takes precedence over the v0.28 instance scan (#15596)', async () => {
+        const subId   = 'sub_' + crypto.randomUUID();
+        const agentId = '@test-agent-kimi-legacy-precedence';
+
+        const captured   = [];
+        const stubServer = http.createServer((req, res) => {
+            let body = '';
+            req.on('data', chunk => { body += chunk; });
+            req.on('end', () => {
+                captured.push({method: req.method, url: req.url, body});
+                res.writeHead(200, {'content-type': 'application/json'});
+                res.end(JSON.stringify({code: 0, data: {status: 'running'}}));
+            });
+        });
+        await new Promise(resolve => stubServer.listen(0, '127.0.0.1', resolve));
+        const stubPort = stubServer.address().port;
+
+        // Fixture HOME with BOTH generations present: the legacy lock (live stub) and a v0.28
+        // instance file (dead pid, port 1). Discovery must return the legacy lock before ever
+        // scanning instances.
+        const fakeHome     = path.join(DAEMON_DIR, 'kimi-home-legacy');
+        const instancesDir = path.join(fakeHome, '.kimi-code', 'server', 'instances');
+        fs.ensureDirSync(instancesDir);
+        fs.writeJsonSync(path.join(fakeHome, '.kimi-code', 'server', 'lock'), {
+            host: '127.0.0.1',
+            pid : 424242,
+            port: stubPort
+        });
+        fs.writeJsonSync(path.join(instancesDir, '01SHOULDNOTBEREAD0000000.json'), {
+            server_id   : '01SHOULDNOTBEREAD0000000',
+            pid         : 1, // launchd on macOS: alive, but the port is unusable — any read fails delivery
+            host        : '127.0.0.1',
+            port        : 1,
+            started_at  : Date.now(),
+            heartbeat_at: Date.now(),
+            host_version: '0.28.0'
+        });
+
+        const tokenPath    = path.join(DAEMON_DIR, 'kimi-server-legacy.token');
+        const envelopePath = path.join(DAEMON_DIR, 'kimi-wake-envelope-legacy.json');
+        fs.writeFileSync(tokenPath, 'kimi-test-token\n');
+        fs.writeJsonSync(envelopePath, {sessionId: 'ses_kimi_legacy', cwd: '/seat/checkout', updatedAt: '2026-07-20T10:00:00.000Z'});
+
+        insertWakeSubscription(db, {
+            subId,
+            agentId,
+            harnessTargetMetadata: {
+                adapter       : 'kimi-server',
+                envelopePath,
+                tokenPath,
+                coalesceWindow: 1
+            }
+        });
+
+        let stdoutLog = '';
+
+        try {
+            daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+                stdio: 'pipe',
+                env  : {
+                    ...process.env,
+                    HOME              : fakeHome,
+                    NEO_MEMORY_DB_PATH: DB_PATH,
+                    NEO_AI_DAEMON_DIR : DAEMON_DIR
+                }
+            });
+
+            const deliveryPromise = new Promise((resolve, reject) => {
+                const timeout = setTimeout(() => reject(new Error('Daemon failed to deliver via legacy v0.27 lock within timeout')), 10000);
+
+                daemonProcess.stdout.on('data', (data) => {
+                    const out = data.toString();
+                    stdoutLog += out;
+                    if (out.includes(`[Wake Dispatch] ${agentId}: outcome=delivered`)) {
+                        clearTimeout(timeout);
+                        resolve();
+                    }
+                });
+                daemonProcess.stderr.on('data', data => console.error('[DAEMON STDERR]', data.toString()));
+                daemonProcess.on('error', reject);
+            });
+
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            insertMessageWake(db, {
+                agentId,
+                subject: 'Kimi Legacy Precedence Wake'
+            });
+
+            await deliveryPromise;
+
+            expect(captured.length).toBe(1);
+            expect(captured[0].url).toBe('/api/v1/sessions/ses_kimi_legacy/prompts');
+            expect(stdoutLog).toContain(`Dispatched ${subId} via kimi-server submitPrompt (session ses_kimi_legacy, status=running)`);
+        } finally {
+            stubServer.close();
+        }
+    });
+
     test('opencode-server shares the configured attempt abort and cannot report orphan success (#15394, #15414)', async () => {
         test.setTimeout(15000);
 


### PR DESCRIPTION
Resolves #15596

Restores kimi-harness wake delivery on Kimi Code v0.28: the `kimi-server` wake adapter now discovers the seat's loopback coordinates across both harness generations instead of reading only the v0.27 `~/.kimi-code/server/lock`, which v0.28 (`kimi web`) no longer writes. Without this, every v0.28+ kimi seat is wake-silent — the daemon fails closed with ENOENT and drops wakes after 5 attempts (reproduced live on the Iris seat, daemon log 2026-07-20 10:50:19Z).

Evidence: L1 (seat-level live proof on v0.28.0: instance-file `lockPath` override → daemon `submitPrompt` → `status=queued`, log 10:59:05Z; REST route + live TUI session listing verified against a resident `kimi web`) → L3 required (AC: deterministic discovery chain + fail-closed ambiguity + specs green in the custom unit config). Residual: AC5 (post-merge seat step) — remove the hand-set `lockPath` override from `WAKE_SUB:ad94a336-…` and re-run the end-to-end fire/no-fire proof, tracked under Post-Merge Validation.

## Deltas from ticket

- **Liveness is pid-based, not heartbeat-freshness-based** (design refinement, evidence-driven): the ticket prescribed a stale-heartbeat rejection; measured reality on v0.28.0 is `heartbeat_at` gaps of 39+ minutes on a definitively live server, so a freshness gate would false-fail-closed. `process.kill(pid, 0)` (EPERM = alive) is the liveness gate; a pid-reused candidate degrades fail-visibly at the bearer/HTTP layer, never silently. The "stale-heartbeat rejection" AC is delivered as dead-pid rejection.
- **Substance port from #15597 (closed duplicate, same identity / parallel session) folded in:** the #15588 50-contract suite stays green alongside the new specs (57/57); the envelope contract is named alongside lock/token/route; the v0.27-era `kimi server rotate-token` docblock wording is corrected in the same two-generation rewrite.
- Host/port validation errors now name the coordinate's `lockSource` (override / legacy v0.27 lock / v0.28 instance path) instead of a single hard-coded path.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/daemons/wake/daemon.spec.mjs` → **57 passed (36.1s)**: 4 new specs (single live instance discovery via fixture `HOME`, dead-pid rejection naming both generations + the `kimi web` remediation, multi-instance fail-closed with zero HTTP attempts, legacy-lock precedence over the instance scan) + the full existing wake-daemon suite as regression guard.
- `node --check ai/daemons/wake/daemon.mjs` → syntax OK.
- Live seat pre-validation (pre-branch, evidence for the contract shape): daemon log 2026-07-20 10:59:05Z `Dispatched WAKE_SUB:ad94a336-… via kimi-server submitPrompt (session session_e86fa9f0-…, status=queued)` using the instance file via metadata override.

## Post-Merge Validation

- [ ] Remove the interim `harnessTargetMetadata.lockPath` override from `WAKE_SUB:ad94a336-7e4a-4534-9efb-331f413bb276` (keep `adapter` + `cwd`) and re-run the fire/no-fire proof end-to-end on v0.28 with the stock discovery chain.
- [ ] Confirm a peer-originated (non-self) wake lands in-session via the daemon on the Iris seat.

## Commits

- (single commit) `fix(ai): kimi-server wake adapter v0.28 instance-file lock discovery (#15596)`

Authored by Iris (Moonshot Kimi K3, Kimi Code). Session session_e86fa9f0-866e-45e8-a6df-d7bb6dd4d8b5.
