### PR TITLE
feat(ai): add github-pat auth mode for MCP servers (#15598)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -181,6 +181,9 @@ class ConfigBase extends ConfigProvider {
              *   bearer token, validated against `{gitlabApiBaseUrl}/api/v4/user`. No `aud` claim and
              *   no PRM advertisement (a naked `401` on failure) — the lighter path for clients that
              *   authenticate with a long-lived PAT from an env var instead of an OAuth dance.
+             * - `'github-pat'`: a GitHub Personal Access Token (classic or fine-grained) presented
+             *   as the bearer token, validated against `{githubApiBaseUrl}/user`. Same naked-401
+             *   contract as `'gitlab-pat'`; the resolved GitHub login becomes the caller identity.
              * - `'local-bearer'`: a generated process-lifetime possession credential for an
              *   explicitly loopback-bound listener. It performs no identity lookup or provisioning.
              * @type {Object}
@@ -193,7 +196,7 @@ class ConfigBase extends ConfigProvider {
                 clientId          : leaf(null, 'NEO_OAUTH_CLIENT_ID', 'string'),
                 clientSecret      : leaf('', 'NEO_OAUTH_CLIENT_SECRET', 'string'),
                 trustProxyIdentity: leaf(false, 'NEO_AUTH_TRUST_PROXY_IDENTITY', 'boolean'),
-                // Authorization strategy selector: 'oidc' (default) | 'gitlab-pat' | 'local-bearer'.
+                // Authorization strategy selector: 'oidc' (default) | 'gitlab-pat' | 'github-pat' | 'local-bearer'.
                 mode              : leaf('oidc', 'NEO_AUTH_MODE', 'string'),
                 /**
                  * @summary Disposable process-lifetime possession credential for local-bearer mode.
@@ -219,11 +222,20 @@ class ConfigBase extends ConfigProvider {
                         reason        : 'PAT validation cannot certify readiness without a GitLab API base URL.'
                     }]
                 }),
+                // GitHub API base URL used by 'github-pat' mode for token validation (GHES configurable).
+                githubApiBaseUrl  : leaf('https://api.github.com', 'NEO_AUTH_GITHUB_API_BASE_URL', 'string', {
+                    requiredFor: [{
+                        entrypoints   : '*',
+                        modes         : ['github-pat'],
+                        consumerClaims: ['readiness'],
+                        reason        : 'PAT validation cannot certify readiness without a GitHub API base URL.'
+                    }]
+                }),
                 // Bounded TTL (seconds) for the per-token PAT validation cache → a revoked PAT clears within this window.
                 patCacheTtlSeconds: leaf(300, 'NEO_AUTH_PAT_CACHE_TTL_SECONDS', 'number'),
                 // Optional GitLab OAuth app binding for 'gitlab-pat' mode. Empty means no app gate.
                 allowedClientIds  : leaf([], 'NEO_AUTH_ALLOWED_CLIENT_IDS', 'csv'),
-                // Optional GitLab username allowlist for 'gitlab-pat' mode. Empty means any resolved GitLab user.
+                // Optional username allowlist for PAT modes ('gitlab-pat' / 'github-pat'). Empty means any resolved user.
                 allowedUsers      : leaf([], 'NEO_AUTH_ALLOWED_USERS', 'csv'),
                 // Auth provenance sources that may create missing AgentIdentity graph nodes at request time.
                 autoProvisionIdentitySources: leaf(['gitlab-pat'], 'NEO_AUTH_AUTO_PROVISION_IDENTITY_SOURCES', 'csv')

--- a/ai/mcp/server/shared/services/AuthService.mjs
+++ b/ai/mcp/server/shared/services/AuthService.mjs
@@ -76,6 +76,13 @@ class AuthService extends Base {
             return
         }
 
+        // GitHub-PAT mode installs the same naked-401 bearer path against the GitHub `/user`
+        // endpoint and returns early — the OIDC flow below does not apply.
+        if (aiConfig.auth.mode === 'github-pat') {
+            this.setupGithubPat({app, aiConfig, logger}, {requireBearerAuth, InvalidTokenError});
+            return
+        }
+
         const {mcpAuthMetadataRouter, getOAuthProtectedResourceMetadataUrl} = await import('@modelcontextprotocol/sdk/server/auth/router.js');
         const {checkResourceAllowed}                                        = await import('@modelcontextprotocol/sdk/shared/auth-utils.js');
 
@@ -300,14 +307,14 @@ class AuthService extends Base {
     }
 
     /**
-     * @summary Normalizes a GitLab-PAT allowlist config leaf.
+     * @summary Normalizes a PAT allowlist config leaf.
      *
      * Config templates resolve CSV env vars to arrays; the string branch is a compatibility guard
      * for stale gitignored overlays copied into worktrees before the `csv` type existed.
      * @param {String[]|String|null|undefined} value
      * @returns {String[]}
      */
-    #normalizeGitlabPatAllowlist(value) {
+    #normalizePatAllowlist(value) {
         if (Array.isArray(value)) {
             return value.map(item => String(item).trim()).filter(Boolean)
         }
@@ -371,8 +378,8 @@ class AuthService extends Base {
             apiBaseUrl       = aiConfig.auth.gitlabApiBaseUrl.replace(/\/+$/, ''),
             ttlSeconds       = aiConfig.auth.patCacheTtlSeconds,
             ttlMs            = ttlSeconds * 1000,
-            allowedClientIds = this.#normalizeGitlabPatAllowlist(aiConfig.auth.allowedClientIds),
-            allowedUsers     = this.#normalizeGitlabPatAllowlist(aiConfig.auth.allowedUsers),
+            allowedClientIds = this.#normalizePatAllowlist(aiConfig.auth.allowedClientIds),
+            allowedUsers     = this.#normalizePatAllowlist(aiConfig.auth.allowedUsers),
             requireClientId  = allowedClientIds.length > 0,
             requireUser      = allowedUsers.length > 0,
             cache            = new Map(); // tokenHash -> {user, tokenInfo, expiresAt} (cache-freshness, ms)
@@ -465,6 +472,131 @@ class AuthService extends Base {
                 logger.info(`[AuthService] GitLab PAT validated for user: ${user.name || user.username}${appSuffix}`);
 
                 return buildInfo(token, user, tokenInfo)
+            }
+        }
+    }
+
+    /**
+     * @summary Installs the GitHub-PAT bearer middleware.
+     *
+     * Same naked-401 contract as `setupGitlabPat`: NO `mcpAuthMetadataRouter`, NO
+     * `resourceMetadataUrl` — a missing/invalid token yields a bare `WWW-Authenticate: Bearer`
+     * 401 with no `resource_metadata` breadcrumb, so OAuth-aware clients do not attempt Dynamic
+     * Client Registration against an identity provider that has none. PATs carry no audience
+     * claim, so `aud` enforcement is intentionally absent.
+     * @param {Object}   options
+     * @param {Object}   options.app      The Express application instance
+     * @param {Object}   options.aiConfig The server configuration object
+     * @param {Object}   options.logger   The logger instance
+     * @param {Object}   deps
+     * @param {Function} deps.requireBearerAuth SDK bearer-auth middleware factory
+     * @param {Function} deps.InvalidTokenError SDK error class for rejected tokens
+     */
+    setupGithubPat({app, aiConfig, logger}, {requireBearerAuth, InvalidTokenError}) {
+        const verifier = this.createGithubPatVerifier({aiConfig, logger, InvalidTokenError});
+
+        app.use(requireBearerAuth({verifier, requiredScopes: []}));
+
+        logger.info(`[AuthService] Authorization enabled (mode: github-pat, GitHub API: ${aiConfig.auth.githubApiBaseUrl})`)
+    }
+
+    /**
+     * Builds the `{verifyAccessToken}` verifier for GitHub-PAT mode. The verifier presents the
+     * incoming bearer token to `GET {githubApiBaseUrl}/user`; a `200` resolves the identity
+     * (`userId` = GitHub `login`, `source` = `'github-pat'`) in the same AuthInfo shape the
+     * GitLab-PAT verifier produces and `RequestContextService` already consumes. An optional
+     * `auth.allowedUsers` allowlist can gate the resolved GitHub login (default-off). There is
+     * deliberately no client-id gate: GitHub PATs expose no OAuth-app identity comparable to
+     * GitLab's `/oauth/token/info`. Successful validations are cached by SHA-256 token hash for
+     * `auth.patCacheTtlSeconds` so a revoked PAT clears within that bounded window; failures are
+     * never cached (a transient GitHub error must not lock a client out). The raw token is never
+     * logged — only its resolved identity.
+     *
+     * GitHub request-contract notes: a `User-Agent` header is REQUIRED (GitHub rejects UA-less
+     * requests with 403), and `X-GitHub-Api-Version` pins the REST contract. Classic PATs echo
+     * their granted scopes in the `x-oauth-scopes` response header; fine-grained PATs omit it
+     * (scopes resolve to `[]` — identity, not permission introspection, is the contract here).
+     * @param {Object}   options
+     * @param {Object}   options.aiConfig
+     * @param {Object}   options.logger
+     * @param {Function} options.InvalidTokenError
+     * @returns {{verifyAccessToken: Function}}
+     */
+    createGithubPatVerifier({aiConfig, logger, InvalidTokenError}) {
+        const
+            apiBaseUrl   = aiConfig.auth.githubApiBaseUrl.replace(/\/+$/, ''),
+            ttlSeconds   = aiConfig.auth.patCacheTtlSeconds,
+            ttlMs        = ttlSeconds * 1000,
+            allowedUsers = this.#normalizePatAllowlist(aiConfig.auth.allowedUsers),
+            requireUser  = allowedUsers.length > 0,
+            cache        = new Map(); // tokenHash -> {user, scopes, expiresAt} (cache-freshness, ms)
+
+        // AuthInfo shape mirrors the GitLab-PAT verifier: `expiresAt` is REQUIRED by the SDK
+        // `requireBearerAuth` (it rejects expiry-less auth info before `req.auth` is set), and
+        // GitHub `/user` does not return the PAT's own expiry, so we use the re-validation
+        // horizon: one cache window from now (Unix seconds). Built per-call so `expiresAt`
+        // stays request-fresh on cache hits.
+        const buildInfo = (token, user, scopes) => ({
+            token,
+            clientId : user.login,
+            scopes,
+            expiresAt: Math.floor(Date.now() / 1000) + ttlSeconds,
+            userId   : user.login,
+            username : user.name || user.login,
+            // Provenance tag read by RequestContextService.getSource(); distinguishes a GitHub-PAT
+            // identity from OIDC / gitlab-pat / stdio env-var / gh-CLI sources.
+            source   : 'github-pat',
+            // Provider-neutral identity metadata consumed by Memory Core's request-time
+            // AgentIdentity auto-provisioner. The raw bearer token remains in AuthInfo only for
+            // the SDK middleware boundary and is never copied into graph identity properties.
+            authProvider       : 'github',
+            authSource         : 'github-pat',
+            providerBaseUrl    : apiBaseUrl,
+            providerUserId     : user.id == null ? undefined : String(user.id),
+            providerUsername   : user.login,
+            providerDisplayName: user.name || user.login
+        });
+
+        return {
+            verifyAccessToken: async (token) => {
+                const
+                    tokenHash = createHash('sha256').update(token).digest('hex'),
+                    cached    = cache.get(tokenHash);
+
+                if (cached && cached.expiresAt > Date.now()) {
+                    return buildInfo(token, cached.user, cached.scopes)
+                }
+
+                const userResponse = await fetch(`${apiBaseUrl}/user`, {
+                    headers: {
+                        'Accept'              : 'application/vnd.github+json',
+                        'Authorization'       : `Bearer ${token}`,
+                        'User-Agent'          : 'neo-agent-os',
+                        'X-GitHub-Api-Version': '2022-11-28'
+                    }
+                });
+
+                if (!userResponse.ok) {
+                    cache.delete(tokenHash);
+                    throw new InvalidTokenError(`GitHub PAT validation failed (HTTP ${userResponse.status})`)
+                }
+
+                // Classic PATs advertise granted scopes here; fine-grained PATs omit the header.
+                const
+                    scopeHeader = userResponse.headers?.get?.('x-oauth-scopes') || '',
+                    scopes      = scopeHeader.split(',').map(scope => scope.trim()).filter(Boolean),
+                    user        = await userResponse.json();
+
+                if (requireUser && !allowedUsers.includes(user.login)) {
+                    cache.delete(tokenHash);
+                    throw new InvalidTokenError('GitHub user is not allowed')
+                }
+
+                cache.set(tokenHash, {user, scopes, expiresAt: Date.now() + ttlMs});
+
+                logger.info(`[AuthService] GitHub PAT validated for user: ${user.name || user.login}`);
+
+                return buildInfo(token, user, scopes)
             }
         }
     }

--- a/ai/scripts/lint/config-leaf-parity.json
+++ b/ai/scripts/lint/config-leaf-parity.json
@@ -7,6 +7,7 @@
         "auth.autoProvisionIdentitySources",
         "auth.clientId",
         "auth.clientSecret",
+        "auth.githubApiBaseUrl",
         "auth.gitlabApiBaseUrl",
         "auth.host",
         "auth.issuerUrl",

--- a/learn/agentos/cloud-deployment/Configuration.md
+++ b/learn/agentos/cloud-deployment/Configuration.md
@@ -45,12 +45,13 @@ A deployment's `config.mjs` is gitignored and copied from `config.template.mjs`.
 | `transport` | `'stdio'` | `'stdio'` (local single-repo) or `'streamable-http'` (a cloud deployment serving remote tenants). These are the only supported server values. |
 | `mcpHttpPort` | `3000` | The port the Streamable HTTP transport listens on (only when `transport === 'streamable-http'`). |
 | `publicUrl` | `null` | Canonical public URL — required behind a reverse proxy for OAuth 2.1 / OIDC audience claims and protected-resource advertising. |
-| `auth.mode` | `'oidc'` | Server-side bearer strategy for Streamable HTTP: `'oidc'` uses OIDC introspection + audience enforcement; `'gitlab-pat'` validates a GitLab OAuth token or PAT against `/api/v4/user` and returns a bare bearer challenge on failure. |
+| `auth.mode` | `'oidc'` | Server-side bearer strategy for Streamable HTTP: `'oidc'` uses OIDC introspection + audience enforcement; `'gitlab-pat'` validates a GitLab OAuth token or PAT against `/api/v4/user`; `'github-pat'` validates a GitHub PAT (classic or fine-grained) against `/user`. Both PAT modes return a bare bearer challenge on failure. |
 | `auth.issuerUrl` / `auth.host` / `auth.realm` | `null` / `null` / `'master'` | OIDC authority inputs for the default server mode. `issuerUrl` is preferred when the provider publishes discovery metadata directly. |
 | `auth.clientId` / `auth.clientSecret` | `null` / `''` | OIDC introspection client credentials for deployments that require them. |
 | `auth.trustProxyIdentity` | `false` | Accept identity from a trusted reverse-proxy header after the ingress strips spoofable client-supplied headers. |
 | `auth.gitlabApiBaseUrl` | `'https://gitlab.com'` | GitLab API root used only by `auth.mode === 'gitlab-pat'`; set to a self-managed GitLab host when needed. |
-| `auth.allowedClientIds` / `auth.allowedUsers` | `[]` / `[]` | Optional hardening gates for GitLab bearer mode. Empty means any token that resolves to a valid GitLab user is accepted. |
+| `auth.githubApiBaseUrl` | `'https://api.github.com'` | GitHub API root used only by `auth.mode === 'github-pat'`; set to a GitHub Enterprise Server host when needed. |
+| `auth.allowedClientIds` / `auth.allowedUsers` | `[]` / `[]` | Optional hardening gates. `allowedClientIds` applies to GitLab bearer mode only (GitHub PATs expose no OAuth-app identity); `allowedUsers` gates the resolved username in either PAT mode. Empty means any token that resolves to a valid user is accepted. |
 
 Compose healthchecks use `ai/scripts/diagnostics/mcpHealthcheck.mjs` against the
 same `/mcp` route as external callers. When a deployment sets

--- a/learn/agentos/cloud-deployment/Security.md
+++ b/learn/agentos/cloud-deployment/Security.md
@@ -58,7 +58,7 @@ The invariant that holds regardless of the transport: **the tenant tuple is
 server-derived from the authenticated identity, never trusted from the
 payload.**
 
-The shipped Streamable HTTP deployment has three identity shapes:
+The shipped Streamable HTTP deployment has four identity shapes:
 
 - **OIDC server mode** (`NEO_AUTH_MODE=oidc`, the default) validates
   `Authorization: Bearer <token>` through the configured issuer, enforces the
@@ -69,6 +69,11 @@ The shipped Streamable HTTP deployment has three identity shapes:
   GitLab's `/api/v4/user`, and derives identity from the returned username. This
   mode intentionally has no OIDC audience claim or protected-resource metadata;
   failed requests return a bare `WWW-Authenticate: Bearer` challenge.
+- **GitHub bearer mode** (`NEO_AUTH_MODE=github-pat`) accepts a GitHub Personal
+  Access Token (classic or fine-grained) as the bearer, validates it against
+  GitHub's `/user`, and derives identity from the returned login. Same bare-401
+  contract as GitLab bearer mode; `NEO_AUTH_GITHUB_API_BASE_URL` points the
+  verifier at a GitHub Enterprise Server host when needed.
 - **Trusted proxy identity** (`NEO_AUTH_TRUST_PROXY_IDENTITY=true`) lets an
   authenticated reverse proxy inject `X-Preferred-Username` /
   `X-Auth-Request-Preferred-Username`. The reference Caddy ingress strips any

--- a/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs
@@ -456,6 +456,301 @@ test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitLab-PAT midd
 });
 
 /**
+ * Unit coverage for the GitHub-PAT verifier in `AuthService`, mirroring the GitLab-PAT describe
+ * above. `globalThis.fetch` is stubbed so no live GitHub call is made — covering the identity
+ * mapping, the GitHub request contract (User-Agent / Accept / X-GitHub-Api-Version headers),
+ * `x-oauth-scopes` scope extraction (classic PAT) vs its absence (fine-grained PAT), the
+ * allowlist gate, the GHES base-url override, the success cache, and the TTL boundary.
+ */
+test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitHub-PAT verifier', () => {
+    let AuthService;
+    let originalFetch;
+
+    class FakeInvalidTokenError extends Error {}
+
+    const logger   = {info: () => {}, warn: () => {}, error: () => {}};
+    const aiConfig = {
+        auth: {
+            githubApiBaseUrl  : 'https://github.example.com/',
+            patCacheTtlSeconds: 300
+        }
+    };
+
+    function withAuth(overrides) {
+        return {auth: {...aiConfig.auth, ...overrides}}
+    }
+
+    test.beforeAll(async () => {
+        AuthService = (await import('../../../../../../../ai/mcp/server/shared/services/AuthService.mjs')).default;
+    });
+
+    test.beforeEach(() => {
+        originalFetch = globalThis.fetch;
+    });
+
+    test.afterEach(() => {
+        globalThis.fetch = originalFetch;
+    });
+
+    test('maps a GitHub /user 200 to the identity shape, with the GitHub request contract honored', async () => {
+        let calledUrl, calledHeaders;
+
+        globalThis.fetch = async (url, opts) => {
+            calledUrl     = url;
+            calledHeaders = opts?.headers;
+            return {
+                ok     : true,
+                headers: {get: name => name === 'x-oauth-scopes' ? 'repo, read:user' : null},
+                json   : async () => ({id: 42, login: 'octocat', name: 'The Octocat'})
+            };
+        };
+
+        const verifier = AuthService.createGithubPatVerifier({aiConfig, logger, InvalidTokenError: FakeInvalidTokenError}),
+              info     = await verifier.verifyAccessToken('ghp_abc');
+
+        // Trailing slash on the configured base URL is trimmed before appending the API path.
+        expect(calledUrl).toBe('https://github.example.com/user');
+        expect(calledHeaders.Authorization).toBe('Bearer ghp_abc');
+        // GitHub rejects UA-less requests with 403; the version header pins the REST contract.
+        expect(calledHeaders['User-Agent']).toBeTruthy();
+        expect(calledHeaders.Accept).toBe('application/vnd.github+json');
+        expect(calledHeaders['X-GitHub-Api-Version']).toBe('2022-11-28');
+        expect(info.userId).toBe('octocat');
+        expect(info.username).toBe('The Octocat');
+        expect(info.source).toBe('github-pat');
+        expect(info.authProvider).toBe('github');
+        expect(info.authSource).toBe('github-pat');
+        expect(info.providerBaseUrl).toBe('https://github.example.com');
+        expect(info.providerUserId).toBe('42');
+        expect(info.providerUsername).toBe('octocat');
+        expect(info.providerDisplayName).toBe('The Octocat');
+        // Classic PATs echo granted scopes in x-oauth-scopes.
+        expect(info.scopes).toEqual(['repo', 'read:user']);
+        expect(typeof info.expiresAt).toBe('number');
+        expect(info.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    });
+
+    test('falls back to login and empty scopes when name and x-oauth-scopes are absent (fine-grained PAT)', async () => {
+        globalThis.fetch = async () => ({ok: true, json: async () => ({id: 9, login: 'fine-grained-bot', name: null})});
+
+        const verifier = AuthService.createGithubPatVerifier({aiConfig, logger, InvalidTokenError: FakeInvalidTokenError}),
+              info     = await verifier.verifyAccessToken('github_pat_x');
+
+        expect(info.username).toBe('fine-grained-bot');
+        expect(info.userId).toBe('fine-grained-bot');
+        expect(info.providerDisplayName).toBe('fine-grained-bot');
+        expect(info.scopes).toEqual([]);
+    });
+
+    test('allows a configured GitHub login and rejects an unlisted user without caching the failure', async () => {
+        let calls = 0;
+
+        globalThis.fetch = async () => {
+            calls++;
+            return {ok: true, json: async () => ({login: calls < 3 ? 'outsider' : 'neo-kimi-phoebe'})}
+        };
+
+        const verifier = AuthService.createGithubPatVerifier({
+            aiConfig         : withAuth({allowedUsers: ['neo-kimi-phoebe']}),
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        await expect(verifier.verifyAccessToken('ghp-outsider')).rejects.toThrow('GitHub user is not allowed');
+        // The failure is not cached: a later correction on the allowlist/retry path re-fetches.
+        await expect(verifier.verifyAccessToken('ghp-outsider')).rejects.toThrow('GitHub user is not allowed');
+        const info = await verifier.verifyAccessToken('ghp-outsider');
+
+        expect(calls).toBe(3);
+        expect(info.userId).toBe('neo-kimi-phoebe');
+    });
+
+    test('rejects a non-OK GitHub response and does not cache the failure', async () => {
+        let calls = 0;
+
+        globalThis.fetch = async () => {
+            calls++;
+            return calls === 1
+                ? {ok: false, status: 401, json: async () => ({})}
+                : {ok: true, json: async () => ({login: 'octocat'})}
+        };
+
+        const verifier = AuthService.createGithubPatVerifier({aiConfig, logger, InvalidTokenError: FakeInvalidTokenError});
+
+        await expect(verifier.verifyAccessToken('ghp-bad')).rejects.toThrow('GitHub PAT validation failed (HTTP 401)');
+        const info = await verifier.verifyAccessToken('ghp-bad');
+
+        expect(calls).toBe(2);
+        expect(info.userId).toBe('octocat');
+    });
+
+    test('caches a successful validation per token and re-validates past the TTL window', async () => {
+        let calls = 0;
+
+        globalThis.fetch = async () => {
+            calls++;
+            return {ok: true, json: async () => ({login: 'octocat'})}
+        };
+
+        const cachedVerifier = AuthService.createGithubPatVerifier({aiConfig, logger, InvalidTokenError: FakeInvalidTokenError});
+
+        await cachedVerifier.verifyAccessToken('ghp-cached');
+        await cachedVerifier.verifyAccessToken('ghp-cached');
+        expect(calls).toBe(1);
+
+        const noCacheVerifier = AuthService.createGithubPatVerifier({
+            aiConfig         : withAuth({patCacheTtlSeconds: 0}),
+            logger,
+            InvalidTokenError: FakeInvalidTokenError
+        });
+
+        await noCacheVerifier.verifyAccessToken('ghp-uncached');
+        await noCacheVerifier.verifyAccessToken('ghp-uncached');
+        // TTL 0: expiresAt = now + 0 is never strictly greater than a later Date.now() → re-fetch.
+        expect(calls).toBe(3);
+    });
+});
+
+/**
+ * @summary Consumed-boundary coverage: drives the GitHub-PAT verifier through the REAL SDK
+ * `requireBearerAuth` middleware (installed by `setupGithubPat`), not in isolation — the same
+ * boundary discipline as the GitLab-PAT describe above (SDK AuthInfo contract + naked-401 shape).
+ */
+test.describe('Neo.ai.mcp.server.shared.services.AuthService — GitHub-PAT middleware boundary', () => {
+    let AuthService, requireBearerAuth, InvalidTokenError, originalFetch;
+
+    const logger   = {info: () => {}, warn: () => {}, error: () => {}};
+    const aiConfig = {auth: {mode: 'github-pat', githubApiBaseUrl: 'https://api.github.com', patCacheTtlSeconds: 300}};
+
+    test.beforeAll(async () => {
+        AuthService       = (await import('../../../../../../../ai/mcp/server/shared/services/AuthService.mjs')).default;
+        requireBearerAuth = (await import('@modelcontextprotocol/sdk/server/auth/middleware/bearerAuth.js')).requireBearerAuth;
+        InvalidTokenError = (await import('@modelcontextprotocol/sdk/server/auth/errors.js')).InvalidTokenError;
+    });
+
+    test.beforeEach(() => { originalFetch = globalThis.fetch; });
+    test.afterEach(()  => { globalThis.fetch = originalFetch; });
+
+    function mockReq(authHeader) {
+        const headers = authHeader ? {authorization: authHeader} : {};
+        return {headers, get(name) { return headers[String(name).toLowerCase()]; }};
+    }
+
+    // Minimal Express-style response double recording status + headers (lower-cased) + body.
+    function mockRes() {
+        return {
+            statusCode: 200, headers: {}, body: undefined, ended: false,
+            status(code) { this.statusCode = code; return this; },
+            set(field, value) {
+                if (field && typeof field === 'object') {
+                    Object.entries(field).forEach(([k, v]) => { this.headers[String(k).toLowerCase()] = v; });
+                } else {
+                    this.headers[String(field).toLowerCase()] = value;
+                }
+                return this;
+            },
+            setHeader(field, value) { this.headers[String(field).toLowerCase()] = value; return this; },
+            header(field, value)    { this.headers[String(field).toLowerCase()] = value; return this; },
+            getHeader(field)        { return this.headers[String(field).toLowerCase()]; },
+            json(payload) { this.body = payload; this.ended = true; return this; },
+            send(payload) { this.body = payload; this.ended = true; return this; },
+            end(payload)  { if (payload !== undefined) this.body = payload; this.ended = true; return this; }
+        };
+    }
+
+    // Installs the REAL SDK requireBearerAuth via setupGithubPat; returns the captured middleware.
+    // The single-middleware assertion also confirms the naked-401 shape (no mcpAuthMetadataRouter).
+    function installPatMiddleware(config = aiConfig) {
+        const middlewares = [],
+              app         = {use: mw => middlewares.push(mw)};
+
+        AuthService.setupGithubPat({app, aiConfig: config, logger}, {requireBearerAuth, InvalidTokenError});
+
+        expect(middlewares.length).toBe(1);
+        return middlewares[0];
+    }
+
+    test('a valid GitHub PAT passes requireBearerAuth → next() called + req.auth populated', async () => {
+        globalThis.fetch = async () => ({ok: true, json: async () => ({id: 7, login: 'octocat', name: 'The Octocat'})});
+
+        const mw  = installPatMiddleware(),
+              req = mockReq('Bearer ghp-valid'),
+              res = mockRes();
+
+        let nextErr = 'unset';
+        await mw(req, res, err => { nextErr = err; });
+
+        expect(nextErr).toBeUndefined();                     // next() invoked with no error
+        expect(res.ended).toBe(false);                       // no 401 short-circuit
+        expect(req.auth?.userId).toBe('octocat');
+        expect(req.auth?.source).toBe('github-pat');
+        expect(req.auth?.authProvider).toBe('github');
+        expect(req.auth?.providerUsername).toBe('octocat');
+        expect(req.auth?.providerUserId).toBe('7');
+        expect(typeof req.auth?.expiresAt).toBe('number');   // the SDK requires + propagates this
+    });
+
+    test('a missing token yields a naked 401 — WWW-Authenticate: Bearer, no resource_metadata', async () => {
+        const mw  = installPatMiddleware(),
+              req = mockReq(),
+              res = mockRes();
+
+        let nextCalled = false;
+        await mw(req, res, () => { nextCalled = true; });
+
+        expect(nextCalled).toBe(false);
+        expect(res.statusCode).toBe(401);
+        const wwwAuth = String(res.headers['www-authenticate'] || '');
+        expect(wwwAuth).toContain('Bearer');
+        expect(wwwAuth).not.toContain('resource_metadata');
+    });
+
+    test('an invalid PAT (GitHub 401) is rejected — next() not called', async () => {
+        globalThis.fetch = async () => ({ok: false, status: 401, json: async () => ({})});
+
+        const mw  = installPatMiddleware(),
+              req = mockReq('Bearer ghp-bad'),
+              res = mockRes();
+
+        let nextCalled = false;
+        await mw(req, res, () => { nextCalled = true; });
+
+        expect(nextCalled).toBe(false);
+        expect(res.statusCode).toBe(401);
+    });
+
+    test('allowedUsers gate passes through real requireBearerAuth with GitHub login identity intact', async () => {
+        globalThis.fetch = async () => ({ok: true, json: async () => ({login: 'neo-kimi-phoebe', name: 'Phoebe'})});
+
+        const mw  = installPatMiddleware({auth: {...aiConfig.auth, allowedUsers: ['neo-kimi-phoebe']}}),
+              req = mockReq('Bearer ghp-valid'),
+              res = mockRes();
+
+        let nextErr = 'unset';
+        await mw(req, res, err => { nextErr = err; });
+
+        expect(nextErr).toBeUndefined();
+        expect(res.ended).toBe(false);
+        expect(req.auth?.userId).toBe('neo-kimi-phoebe');
+        expect(req.auth?.username).toBe('Phoebe');
+    });
+
+    test('allowedUsers gate rejects an unlisted user through real requireBearerAuth', async () => {
+        globalThis.fetch = async () => ({ok: true, json: async () => ({login: 'outsider'})});
+
+        const mw  = installPatMiddleware({auth: {...aiConfig.auth, allowedUsers: ['neo-kimi-phoebe']}}),
+              req = mockReq('Bearer ghp-outsider'),
+              res = mockRes();
+
+        let nextCalled = false;
+        await mw(req, res, () => { nextCalled = true; });
+
+        expect(nextCalled).toBe(false);
+        expect(res.statusCode).toBe(401);
+    });
+});
+
+/**
  * @summary Consumed-boundary coverage for the possession-only local-bearer strategy.
  *
  * Drives the verifier through the real SDK middleware so header parsing, AuthInfo expiry, strict


### PR DESCRIPTION
Resolves #15598

Adds a `github-pat` authorization mode to the Streamable HTTP MCP servers (KB + MC), mirroring the shipped `gitlab-pat` strategy: the server validates a client's GitHub Personal Access Token (classic or fine-grained) against `GET {githubApiBaseUrl}/user` and resolves the GitHub login as the caller identity, under the same naked-401 contract (no PRM advertisement, no `aud` enforcement — OAuth-aware clients are not pushed into DCR). New config leaf `auth.githubApiBaseUrl` (default `https://api.github.com`, env `NEO_AUTH_GITHUB_API_BASE_URL`) keeps GHES-class deployments working; `auth.allowedUsers` is now documented as shared across both PAT modes. Early standalone graduation from Discussion #15595 (divergence #5) — operator-approved do-now decoupler ahead of the parity epic.

Evidence: L3 achieved (live non-destructive probe: the verifier ran against the real `api.github.com/user` with a seat PAT and resolved `neo-kimi-phoebe` end-to-end, token never logged) → L4-class deployment boot remains (AC1's full server boot with `NEO_AUTH_MODE=github-pat` on a real deployment). Residual: post-merge deployment smoke.

## Deltas from ticket
None substantive — implemented exactly as prescribed (verifier + config leaf + shared allowlist + docs). Two small refinements beyond the ticket text: `x-oauth-scopes` response-header extraction (classic PATs echo granted scopes; fine-grained PATs omit the header → `[]` — identity, not permission introspection, is the contract), and the private allowlist-normalizer renamed `#normalizeGitlabPatAllowlist` → `#normalizePatAllowlist` (it was already shared across both allowlists).

## Test Evidence
- `npx playwright test --config=test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/mcp/server/shared/AuthService.spec.mjs` → 32/32 pass (11 new GitHub-PAT specs: verifier isolation + real-SDK `requireBearerAuth` middleware boundary incl. naked-401 shape, allowlist gates, cache/TTL, GHES base-url, request-contract headers)
- Same config, `test/playwright/unit/ai/config.template.spec.mjs test/playwright/unit/ai/configBase.spec.mjs` → 21/21 pass
- Same config, `test/playwright/unit/ai/mcp/` → 384 pass
- `npm run ai:lint-config-template-ssot` → OK (parity snapshot regenerated in the same commit, +1 declared path)
- `lint-agents` + `agent-preflight --no-fix` → all gates pass; pre-commit hook chain (whitespace, shorthand, aiconfig-test-mutation, jsdoc-types, block-alignment, parse) green
- Live L3 probe: `createGithubPatVerifier` against `https://api.github.com/user` with a seat PAT → identity resolved (`userId`, `source: 'github-pat'`, `authProvider: 'github'`, provider metadata)
- ai/mcp/server/shared/services surface: AuthService.spec.mjs (GitLab + GitHub + local-bearer describes) green

## Post-Merge Validation
- [ ] Deployment smoke: boot kb-server + mc-server with `NEO_AUTH_MODE=github-pat` and a live GitHub PAT; verify initialize → 200 + mcp-session-id and an identity-bound `add_memory`
- [ ] GHES override smoke (operator-discretionary): `NEO_AUTH_GITHUB_API_BASE_URL` against an enterprise host
- [ ] Confirm `autoProvisionIdentitySources` opt-in path binds an AgentIdentity for a `github-pat` caller (the `#14388` shape) when a deployment enables it

Authored by Phoebe (Moonshot Kimi K3, OpenCode). Session 8d4ce1c3-0bf2-4bb0-bad9-e49836248afe.