### PR TITLE
feat(ai): add get_sandman_handoff MC tool for remote handoff reads (#15599)

### DIFF
--- a/ai/mcp/server/memory-core/Server.mjs
+++ b/ai/mcp/server/memory-core/Server.mjs
@@ -155,6 +155,7 @@ class Server extends BaseServer {
             'get_sqlite_holder_diagnostics',
             'get_deployment_state_snapshot',
             'inspect_deployment',
+            'get_sandman_handoff',
             'get_memory_core_tool_metrics'
         ];
     }

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -340,7 +340,7 @@ paths:
         stable `reason` code (`handoff-not-found`, `handoff-read-failed`,
         `handoff-too-large`) — never a silent empty string. Read-only: no identity mutation,
         team-visible operational content. Remote/container agents use this to read the
-        morning surface without a repo checkout (#15599).
+        morning surface without a repo checkout.
       tags: [Diagnostics]
       requestBody:
         required: false

--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -322,6 +322,44 @@ paths:
               schema:
                 type: object
 
+  /handoff/sandman:
+    post:
+      summary: Get Sandman Handoff
+      operationId: get_sandman_handoff
+      x-neo-tool-tier: read
+      x-pass-as-object: true
+      x-annotations:
+        readOnlyHint: true
+      x-neo-tool-summary: Read the Sandman handoff (Dream Pipeline morning surface) with freshness metadata.
+      description: |
+        Reads `sandman_handoff.md` at the resolved `handoffFilePath` config leaf
+        (`NEO_HANDOFF_FILE_PATH` override honored inside the leaf) and returns
+        `{content, path, mtimeMs, ageMs, staleAfterMs, stale}`. The `stale` flag fires past
+        the freshness window (default 36h — nightly cadence + slack; overridable per call).
+        A missing or unreadable handoff returns an explicit `content: null` payload with a
+        stable `reason` code (`handoff-not-found`, `handoff-read-failed`,
+        `handoff-too-large`) — never a silent empty string. Read-only: no identity mutation,
+        team-visible operational content. Remote/container agents use this to read the
+        morning surface without a repo checkout (#15599).
+      tags: [Diagnostics]
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                staleAfterMs:
+                  type: number
+                  description: Optional freshness window override in milliseconds.
+      responses:
+        '200':
+          description: Handoff payload with freshness metadata, or an explicit null-reason envelope.
+          content:
+            application/json:
+              schema:
+                type: object
+
   /rem/pipeline-state:
     post:
       summary: Get REM Pipeline State

--- a/ai/mcp/server/memory-core/toolService.mjs
+++ b/ai/mcp/server/memory-core/toolService.mjs
@@ -15,6 +15,7 @@ import WakeSubscriptionService       from '../../../services/memory-core/WakeSub
 import TurnPresenceService           from '../../../services/memory-core/TurnPresenceService.mjs';
 import MemoryCoreRecorderService     from '../../../services/memory-core/MemoryCoreRecorderService.mjs';
 import {readDeploymentStateSnapshot} from '../../../services/memory-core/helpers/deploymentStateBridgeStore.mjs';
+import {readSandmanHandoff}          from '../../../services/memory-core/helpers/sandmanHandoffStore.mjs';
 import {exploreLaneLandscape}        from '../../../services/graph/exploreLaneLandscape.mjs';
 import {exploreMemoryHistory}        from '../../../services/memory-core/helpers/exploreMemoryHistory.mjs';
 import {makeChatModelGenerate}       from '../../../services/memory-core/helpers/chatModelGenerate.mjs';
@@ -40,6 +41,15 @@ const readDeploymentInspection = args => readDeploymentStateSnapshot({
     filePath    : AiConfig.orchestrator.deploymentStateBridge.snapshotPath,
     staleAfterMs: args?.staleAfterMs ?? AiConfig.orchestrator.deploymentStateBridge.staleAfterMs,
     maxBytes    : AiConfig.orchestrator.deploymentStateBridge.maxSnapshotBytes
+});
+
+// `get_sandman_handoff` — serves the Dream Pipeline's morning surface to agents with no repo
+// checkout. The path rides the resolved `handoffFilePath` formula leaf (prod/test by
+// construction; `NEO_HANDOFF_FILE_PATH` is honored inside the leaf) — never a second path source.
+// The freshness default (36h, nightly cadence + slack) lives in the helper; per-call override wins.
+const readSandmanHandoffTool = args => readSandmanHandoff({
+    filePath    : AiConfig.handoffFilePath,
+    staleAfterMs: args?.staleAfterMs
 });
 
 // `explore_memory_history` — the Memory/session temporal Bird View runtime op. The pure composition
@@ -178,6 +188,7 @@ const serviceMapping = {
                               HealthService          .getSqliteHolderDiagnostics.bind(HealthService),
     get_deployment_state_snapshot: readDeploymentInspection,
     inspect_deployment           : readDeploymentInspection,
+    get_sandman_handoff          : readSandmanHandoffTool,
     mark_read                    : MailboxService         .markRead                .bind(MailboxService),
     archive_message              : MailboxService         .archiveMessage          .bind(MailboxService),
     delete_message               : MailboxService         .deleteMessage           .bind(MailboxService),

--- a/ai/services/memory-core/helpers/sandmanHandoffStore.mjs
+++ b/ai/services/memory-core/helpers/sandmanHandoffStore.mjs
@@ -1,0 +1,78 @@
+import fs from 'fs-extra';
+
+const DEFAULT_STALE_AFTER_MS = 36 * 60 * 60 * 1000; // nightly cadence + slack
+const DEFAULT_MAX_BYTES      = 256 * 1024;
+
+/**
+ * @summary Reads the Sandman handoff (`sandman_handoff.md`) with freshness metadata.
+ *
+ * The handoff is the Dream Pipeline's morning surface (typed gaps + Golden Path
+ * recommendations), written nightly by the DreamService at the resolved `handoffFilePath`
+ * config leaf. Local agents read it as a repo file; remote/container agents have no
+ * filesystem access to it — this reader is the file-contract half of the
+ * `get_sandman_handoff` MCP tool that serves them.
+ *
+ * Missing or unreadable files are an explicit payload, never a throw and never a silent
+ * empty string: a cloud deployment whose writer persistence is not wired yet must get a
+ * machine-readable reason its agents can react to.
+ *
+ * @param {Object} options
+ * @param {String} options.filePath Resolved handoff path (`AiConfig.handoffFilePath`).
+ * @param {Number} [options.now=Date.now()] Current time in epoch ms.
+ * @param {Number} [options.staleAfterMs=129600000] Freshness window; <=0 disables stale classification.
+ * @param {Number} [options.maxBytes=262144] Hard read-size cap.
+ * @returns {Promise<Object>} `{content, path, mtimeMs, ageMs, staleAfterMs, stale, reason}`
+ *          or a `content: null` envelope carrying a stable `reason` code.
+ */
+export async function readSandmanHandoff({
+    filePath,
+    now         = Date.now(),
+    staleAfterMs = DEFAULT_STALE_AFTER_MS,
+    maxBytes     = DEFAULT_MAX_BYTES
+} = {}) {
+    if (!filePath) {
+        return unavailable({reason: 'handoff-path-unconfigured', staleAfterMs});
+    }
+
+    try {
+        const stat = await fs.stat(filePath);
+
+        if (stat.size > maxBytes) {
+            return unavailable({filePath, reason: 'handoff-too-large', details: {size: stat.size, maxBytes}, staleAfterMs});
+        }
+
+        const content = await fs.readFile(filePath, 'utf8'),
+              mtimeMs = stat.mtimeMs,
+              ageMs   = Math.max(0, now - mtimeMs),
+              stale   = staleAfterMs > 0 && ageMs > staleAfterMs;
+
+        return {
+            content,
+            path  : filePath,
+            mtimeMs,
+            ageMs,
+            staleAfterMs,
+            stale,
+            reason: null
+        };
+    } catch (error) {
+        if (error.code === 'ENOENT') {
+            return unavailable({filePath, reason: 'handoff-not-found', staleAfterMs});
+        }
+
+        return unavailable({filePath, reason: 'handoff-read-failed', details: {message: error.message}, staleAfterMs});
+    }
+}
+
+function unavailable({filePath = null, reason, details = null, staleAfterMs}) {
+    return {
+        content: null,
+        path   : filePath,
+        mtimeMs: null,
+        ageMs  : null,
+        staleAfterMs,
+        stale  : true,
+        reason,
+        details
+    };
+}

--- a/learn/agentos/cloud-deployment/Overview.md
+++ b/learn/agentos/cloud-deployment/Overview.md
@@ -58,6 +58,8 @@ A cloud deployment keeps all its vector data in **one** ChromaDB store named `un
 
 The Memory Core's edge graph is **not** stored in Chroma — it lives in a separate SQLite database.
 
+Remote agents read the Dream Pipeline's morning surface (`sandman_handoff.md`) through the Memory Core `get_sandman_handoff` tool — read-only, freshness-flagged, no repo checkout required (#15599). The handoff's writer-side persistence in containers is deployment-owned (a volume/mount decision), not part of the MCP surface.
+
 There is no separate Chroma instance per tenant. Every piece of content is tagged with its owner when it's written and filtered by owner when it's read, so each tenant sees its own content plus Neo's shared library — never another tenant's private data.
 
 ## Default-source inheritance

--- a/learn/agentos/tooling/MemoryCoreMcpApi.md
+++ b/learn/agentos/tooling/MemoryCoreMcpApi.md
@@ -60,6 +60,8 @@ The server exposes the following tools, which are derived from its OpenAPI speci
 | :--- | :--- |
 | **Health** | |
 | `healthcheck` | Confirms the server is running and can connect to the ChromaDB instance. |
+| **Diagnostics** | |
+| `get_sandman_handoff` | Reads the Sandman handoff (Dream Pipeline morning surface) with freshness metadata (`stale` flag past the window, overridable per call); a missing file returns an explicit null-reason payload. Serves remote/container agents without a repo checkout. |
 | **Memories** | |
 | `add_memory` | Stores a new agent interaction (prompt, thought, response) as a memory. |
 | `get_session_memories` | Retrieves all memories for a specific session, in chronological order. |

--- a/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs
@@ -76,8 +76,8 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
 
     test('manage_wake_subscription surfaces bridge metadata contract', async () => {
         const { tools } = await toolService.listTools();
-        const tool = tools.find(item => item.name === 'manage_wake_subscription');
-        const metadata = tool.inputSchema.properties.harnessTargetMetadata;
+        const tool      = tools.find(item => item.name === 'manage_wake_subscription');
+        const metadata  = tool.inputSchema.properties.harnessTargetMetadata;
 
         expect(metadata.required).toBeUndefined();
         expect(metadata.description).toContain("not for adapters 'opencode-server' or 'kimi-server'");
@@ -104,8 +104,8 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
 
     test('get_neighbors output schema exposes semanticVectorId contract (#11680)', async () => {
         const { tools } = await toolService.listTools();
-        const tool = tools.find(item => item.name === 'get_neighbors');
-        const neighbor = tool.outputSchema.properties.neighbors.items;
+        const tool      = tools.find(item => item.name === 'get_neighbors');
+        const neighbor  = tool.outputSchema.properties.neighbors.items;
 
         expect(neighbor.properties.semanticVectorId.type).toBe('string');
         expect(neighbor.properties.semanticVectorId.description).toContain('semantic vector identifier');
@@ -114,7 +114,7 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
 
     test('get_rem_pipeline_state surfaces the REM axis-count output contract (#12087)', async () => {
         const { tools } = await toolService.listTools();
-        const tool = tools.find(item => item.name === 'get_rem_pipeline_state');
+        const tool      = tools.find(item => item.name === 'get_rem_pipeline_state');
 
         expect(tool).toBeTruthy();
         expect(tool.annotations.readOnlyHint).toBe(true);
@@ -135,7 +135,7 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
 
     test('healthcheck exposes diagnostic options through the MCP schema (#13460)', async () => {
         const { tools } = await toolService.listTools();
-        const tool = tools.find(item => item.name === 'healthcheck');
+        const tool      = tools.find(item => item.name === 'healthcheck');
 
         expect(tool).toBeTruthy();
         expect(tool.annotations.readOnlyHint).toBe(true);
@@ -149,7 +149,7 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
 
     test('get_sqlite_holder_diagnostics exposes read-only grouped holder contract (#13475)', async () => {
         const { tools } = await toolService.listTools();
-        const tool = tools.find(item => item.name === 'get_sqlite_holder_diagnostics');
+        const tool      = tools.find(item => item.name === 'get_sqlite_holder_diagnostics');
 
         expect(tool).toBeTruthy();
         expect(tool.annotations.readOnlyHint).toBe(true);
@@ -164,8 +164,17 @@ test.describe('Neo.ai.mcp.server.memory-core Tool limits', () => {
         expect(tool.outputSchema.properties.warnings.items.properties.code.type).toBe('string');
     });
 
+    test('get_sandman_handoff exposes the read-only handoff freshness contract (#15599)', async () => {
+        const { tools } = await toolService.listTools();
+        const tool      = tools.find(item => item.name === 'get_sandman_handoff');
+
+        expect(tool).toBeTruthy();
+        expect(tool.annotations.readOnlyHint).toBe(true);
+        expect(tool.inputSchema.properties.staleAfterMs.type).toBe('number');
+    });
+
     test('healthcheck dispatch passes diagnostic options as one object (#13460)', async () => {
-        const observedArgs = [];
+        const observedArgs   = [];
         const spyToolService = Neo.create(ToolService, {
             openApiFilePath: path.join(repoRoot, 'ai/mcp/server/memory-core/openapi.yaml'),
             serviceMapping : {

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -261,6 +261,7 @@ const expectedMemoryCoreToolTiers = {
     inspect_deployment           : 'extended',
     get_rem_pipeline_state       : 'extended',
     get_sqlite_holder_diagnostics: 'extended',
+    get_sandman_handoff          : 'read',
     who_is_online                : 'read',
     add_memory                   : 'write',
     get_session_memories         : 'read',

--- a/test/playwright/unit/ai/services/memory-core/helpers/sandmanHandoffStore.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/helpers/sandmanHandoffStore.spec.mjs
@@ -1,0 +1,101 @@
+import {test, expect} from '@playwright/test';
+import fs             from 'fs-extra';
+import os             from 'os';
+import path           from 'path';
+
+import {readSandmanHandoff} from '../../../../../../../ai/services/memory-core/helpers/sandmanHandoffStore.mjs';
+
+test.describe('sandmanHandoffStore (#15599)', () => {
+    test('reads a present fresh handoff with content + freshness metadata', async () => {
+        const dir      = await fs.mkdtemp(path.join(os.tmpdir(), 'sandman-handoff-')),
+              filePath = path.join(dir, 'sandman_handoff.md'),
+              now      = Date.now();
+
+        await fs.writeFile(filePath, '# Sandman Handoff\n\ntyped gaps + golden path\n', 'utf8');
+        await fs.utimes(filePath, new Date(now - 60_000), new Date(now - 60_000));
+
+        const read = await readSandmanHandoff({filePath, now});
+
+        expect(read.reason).toBeNull();
+        expect(read.content).toContain('typed gaps + golden path');
+        expect(read.path).toBe(filePath);
+        expect(read.mtimeMs).toBeGreaterThan(0);
+        expect(read.ageMs).toBeGreaterThanOrEqual(59_000);
+        expect(read.staleAfterMs).toBe(36 * 60 * 60 * 1000);
+        expect(read.stale).toBe(false);
+    });
+
+    test('missing handoff returns an explicit null-reason payload, never a throw', async () => {
+        const dir      = await fs.mkdtemp(path.join(os.tmpdir(), 'sandman-handoff-')),
+              filePath = path.join(dir, 'does-not-exist.md');
+
+        const read = await readSandmanHandoff({filePath});
+
+        expect(read).toMatchObject({
+            content: null,
+            path   : filePath,
+            mtimeMs: null,
+            stale  : true,
+            reason : 'handoff-not-found'
+        });
+    });
+
+    test('unconfigured path fails with an explicit reason code', async () => {
+        await expect(readSandmanHandoff({filePath: undefined})).resolves.toMatchObject({
+            content: null,
+            reason : 'handoff-path-unconfigured'
+        });
+    });
+
+    test('stale flag fires past the freshness window; per-call override and <=0 disable it', async () => {
+        const dir        = await fs.mkdtemp(path.join(os.tmpdir(), 'sandman-handoff-')),
+              filePath   = path.join(dir, 'sandman_handoff.md'),
+              now        = Date.now(),
+              twoDaysAgo = now - 48 * 60 * 60 * 1000;
+
+        await fs.writeFile(filePath, 'old handoff\n', 'utf8');
+        await fs.utimes(filePath, new Date(twoDaysAgo), new Date(twoDaysAgo));
+
+        await expect(readSandmanHandoff({filePath, now})).resolves.toMatchObject({
+            stale : true,
+            reason: null
+        });
+
+        // Per-call override: a generous window reclassifies the same file as fresh.
+        await expect(readSandmanHandoff({filePath, now, staleAfterMs: 72 * 60 * 60 * 1000})).resolves.toMatchObject({
+            stale: false
+        });
+
+        // <=0 disables stale classification by construction.
+        await expect(readSandmanHandoff({filePath, now, staleAfterMs: 0})).resolves.toMatchObject({
+            stale: false
+        });
+    });
+
+    test('honors a custom resolved path (the NEO_HANDOFF_FILE_PATH leaf override flow)', async () => {
+        const dir        = await fs.mkdtemp(path.join(os.tmpdir(), 'sandman-handoff-')),
+              customPath = path.join(dir, 'custom', 'override-handoff.md');
+
+        await fs.ensureDir(path.dirname(customPath));
+        await fs.writeFile(customPath, 'override location\n', 'utf8');
+
+        const read = await readSandmanHandoff({filePath: customPath});
+
+        expect(read.reason).toBeNull();
+        expect(read.path).toBe(customPath);
+        expect(read.content).toContain('override location');
+    });
+
+    test('oversized handoff returns an explicit too-large reason with size details', async () => {
+        const dir      = await fs.mkdtemp(path.join(os.tmpdir(), 'sandman-handoff-')),
+              filePath = path.join(dir, 'sandman_handoff.md');
+
+        await fs.writeFile(filePath, 'x'.repeat(1024), 'utf8');
+
+        await expect(readSandmanHandoff({filePath, maxBytes: 128})).resolves.toMatchObject({
+            content: null,
+            reason : 'handoff-too-large',
+            details: {size: 1024, maxBytes: 128}
+        });
+    });
+});


### PR DESCRIPTION
Resolves #15599

Adds a read-only `get_sandman_handoff` tool to the Memory Core MCP server: remote/container agents can now read the Dream Pipeline's morning surface (`sandman_handoff.md` — typed gaps + Golden Path recommendations) without a repo checkout. A pure helper (`sandmanHandoffStore.readSandmanHandoff`) reads the resolved `handoffFilePath` config leaf and returns `{content, path, mtimeMs, ageMs, staleAfterMs, stale}`; missing/unreadable files return an explicit `content: null` envelope with a stable reason code (`handoff-not-found`, `handoff-read-failed`, `handoff-too-large`, `handoff-path-unconfigured`) — never a throw, never a silent empty string. Freshness: `stale` fires past a 36h default window (nightly cadence + slack), overridable per call, `<=0` disables. The tool is tiered `read` (harness-visible by default per the `#14164` projection contract) and joins the `Server.mjs` embed-exemption list so a slow/down embedder can never block it.

Evidence: L2 (unit suites + CI) achieved → L3 required (live MC server serving a real handoff over streamable-http). Residual: post-merge live-call validation on a seat (AC 1), see Post-Merge Validation.

## Deltas from ticket
- Added a bounded-read guard: `maxBytes` (256 KB default) → explicit `handoff-too-large` reason, mirroring `deploymentStateBridgeStore`'s bounded-read posture (not ticket-required; cheap hardening).
- Tool tier chosen as `read` (ticket did not name one) so the tool is harness-visible by default — the ticket's purpose is remote-agent access.
- Joined the `Server.mjs` embed-exemption list (read-only diagnostics that never embed) — required by the embed-canary catch-22 contract documented there.
- Unavailable envelopes also carry `stale: true` (fail-closed freshness for missing content).
- Cloud-operations note landed in `learn/agentos/cloud-deployment/Overview.md` (the topology-anchor operations doc) + a tool row in `learn/agentos/tooling/MemoryCoreMcpApi.md`. Both are ordinary reference docs (not turn-loaded substrate); in-doc lifecycle rationale: the rows stay current as long as the tool exists.
- `OpenApiValidatorCompliance.spec.mjs` tier map + `McpServerToolLimits.spec.mjs` contract test updated — the two schema guards that must move with any new MC operation.

## Test Evidence
`npx playwright test --config=test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/services/memory-core/helpers/sandmanHandoffStore.spec.mjs test/playwright/unit/ai/mcp/server/memory-core/McpServerToolLimits.spec.mjs test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs` → **59 passed (2.3s)**.
- `sandmanHandoffStore.spec.mjs`: 6 new specs — present/fresh, missing (explicit null-reason), unconfigured path, stale threshold + per-call override + `<=0` disable, custom resolved path (the `NEO_HANDOFF_FILE_PATH` leaf-override flow), too-large guard.
- `McpServerToolLimits.spec.mjs`: new contract test — tool surfaces with `readOnlyHint` + numeric `staleAfterMs`.
- `OpenApiValidatorCompliance.spec.mjs`: tier classification + all strict-client schema compliance suites green.
- Surface: live MC server over streamable-http — `None found` in unit scope (server boot is integration terrain); covered post-merge.

## Post-Merge Validation
- [ ] Restart a seat's MC server on dev and call `get_sandman_handoff` live: returns the real `sandman_handoff.md` content + freshness metadata over streamable-http.
- [ ] Simulate a missing handoff (`NEO_HANDOFF_FILE_PATH` pointed at a void) → explicit `handoff-not-found` payload.

Authored by Iris (Moonshot Kimi, Kimi Code CLI v0.28.0). Session fdb40bf0-24ea-4622-a2a2-1b94a4f3dae5.
