### PR TITLE
docs(ai): record github-pat security posture — allowedUsers + auto-provision exclusion (#15606)

### DIFF
--- a/ai/configBase.mjs
+++ b/ai/configBase.mjs
@@ -238,6 +238,11 @@ class ConfigBase extends ConfigProvider {
                 // Optional username allowlist for PAT modes ('gitlab-pat' / 'github-pat'). Empty means any resolved user.
                 allowedUsers      : leaf([], 'NEO_AUTH_ALLOWED_USERS', 'csv'),
                 // Auth provenance sources that may create missing AgentIdentity graph nodes at request time.
+                // 'github-pat' is deliberately NOT in the default: github.com is a public identity
+                // surface, so auto-provisioning must be opt-in for deployments that scope their caller
+                // set (allowedUsers, GHES, private network). Auth success without a bound AgentIdentity
+                // leaves graph-gated tools fail-closed rather than broken — authentication does not
+                // imply Agent OS admission; the exclusion keeps admission explicit instead of ambient.
                 autoProvisionIdentitySources: leaf(['gitlab-pat'], 'NEO_AUTH_AUTO_PROVISION_IDENTITY_SOURCES', 'csv')
             },
             /**

--- a/learn/agentos/cloud-deployment/Security.md
+++ b/learn/agentos/cloud-deployment/Security.md
@@ -73,7 +73,13 @@ The shipped Streamable HTTP deployment has four identity shapes:
   Access Token (classic or fine-grained) as the bearer, validates it against
   GitHub's `/user`, and derives identity from the returned login. Same bare-401
   contract as GitLab bearer mode; `NEO_AUTH_GITHUB_API_BASE_URL` points the
-  verifier at a GitHub Enterprise Server host when needed.
+  verifier at a GitHub Enterprise Server host when needed. **Posture note:**
+  github.com is a *public* identity surface — anyone can mint a valid PAT, so
+  with the default empty allowlist ANY GitHub user authenticates (read-tier MCP
+  access plus identity-less writes; graph-gated tools stay fail-closed while
+  `github-pat` is excluded from `autoProvisionIdentitySources`). A deployment
+  that is not deliberately public SHOULD set `NEO_AUTH_ALLOWED_USERS` (or scope
+  the surface equivalently — GHES boundary, private network).
 - **Trusted proxy identity** (`NEO_AUTH_TRUST_PROXY_IDENTITY=true`) lets an
   authenticated reverse proxy inject `X-Preferred-Username` /
   `X-Auth-Request-Preferred-Username`. The reference Caddy ingress strips any


### PR DESCRIPTION
Resolves #15606

Discharges the author-owned half of Vega's APPROVE+FOLLOW-UP verdict on PR `#15601` (`PRR_kwDODSospM8AAAABGjxJiQ`): the github-pat mode shipped with secure defaults, but two security-posture documentation gaps remained — both bite only because github.com is a *public* identity surface, unlike the private-tenant deployment `gitlab-pat` was built for.

Two documentation-only deltas, zero behavior change:

1. **Security.md** — the GitHub bearer mode bullet now carries the posture requirement: with the default empty `allowedUsers`, ANY GitHub user authenticates (read-tier + identity-less writes; graph-gated tools stay fail-closed), so a non-deliberately-public deployment SHOULD set `NEO_AUTH_ALLOWED_USERS` or scope the surface equivalently (GHES boundary, private network).
2. **`configBase.mjs`** — the `autoProvisionIdentitySources` leaf comment now records WHY `'github-pat'` is excluded from the default (public identity surface → auto-provisioning is opt-in for deployments that scope their caller set) and states the governing principle in durable form: *authentication does not imply Agent OS admission* (the `#14388` relationship, cited here in the PR body rather than the durable comment per `check-ticket-archaeology`).

Evidence: L1 (docs + comment-only; no runtime/config-shape change — parity snapshot untouched, config template specs green). The second half of Vega's follow-up (fetch-timeout hardening, pre-existing in gitlab-pat) is filed as `#15607`, claimable by anyone.

## Deltas from ticket
None — implemented exactly as the review verdict prescribed.

## Test Evidence
- `npx playwright test --config=test/playwright/playwright.config.unit.mjs test/playwright/unit/ai/config.template.spec.mjs` → 17/17 pass
- `npm run ai:lint-config-template-ssot` → OK (no parity change — comment-only config edit)
- Pre-commit hooks green (incl. `check-ticket-archaeology` after moving the ticket ref out of the durable comment)
- docs-only surface: `None found` (no runtime surface touched)

## Post-Merge Validation
- [ ] None — docs-only; posture takes effect at next deployment-docs read

Authored by Phoebe (Moonshot Kimi K3, OpenCode). Session 8d4ce1c3-0bf2-4bb0-bad9-e49836248afe.