### PR TITLE
feat(ai): seat-config generator + launch template for the kimi-code harness (#15612)

### DIFF
--- a/.kimi-code/hooks/wakeEnvelopeHook.mjs
+++ b/.kimi-code/hooks/wakeEnvelopeHook.mjs
@@ -27,8 +27,13 @@ import path from 'node:path';
  *
  * Sibling of `.claude/hooks/turnPresenceHook.mjs` and `.codex/hooks/codex-context.mjs` —
  * same adapter contract shape: stdin JSON in, bounded local write, no Neo singleton imports.
+ *
+ * Home resolution: `KIMI_CODE_HOME` when set (Fleet-launched seats run with an isolated harness
+ * home, and the envelope must land beside the seat's own `server/instances` coordinates), else
+ * the ambient `~/.kimi-code` (interactive seats).
  */
-const ENVELOPE_PATH = path.join(os.homedir(), '.kimi-code', 'wake-envelope.json');
+const KIMI_HOME     = process.env.KIMI_CODE_HOME || path.join(os.homedir(), '.kimi-code');
+const ENVELOPE_PATH = path.join(KIMI_HOME, 'wake-envelope.json');
 
 let input = '';
 

--- a/ai/services/fleet/deriveHarnessLaunchSpec.mjs
+++ b/ai/services/fleet/deriveHarnessLaunchSpec.mjs
@@ -74,6 +74,14 @@ const HARNESS_LAUNCH_CONTRACTS = {
         authMode        : 'env-key',
         modeArgs        : ['serve', '--hostname', '127.0.0.1', '--port', '0'],
         versionProbeArgs: ['--version']
+    },
+    // v0.28+: `kimi web` is the resident server mode (`kimi server` is hard-deprecated). Isolation
+    // is the single KIMI_CODE_HOME var — config AND state unify beneath it. Probe record in the fn JSDoc.
+    'kimi-code': {
+        authMode        : 'env-key',
+        homeEnvVar      : 'KIMI_CODE_HOME',
+        modeArgs        : ['web', '--no-open', '--port', '0'],
+        versionProbeArgs: ['--version']
     }
 };
 
@@ -207,6 +215,25 @@ export function getHarnessAuthMode(harnessType) {
  *   flatrate property — the OpenCode+Kimi path), so NO per-home auth step exists; OAuth via
  *   `opencode auth login` writes provider state into the data home but is not the fleet path,
  *   and no documented marker exists, so `authRequired` stays honestly `null`.
+ *
+ * - **`'kimi-code'`** → `{command: binaryPath, args: ['web', '--no-open', '--port', '0'], env:
+ *   {KIMI_CODE_HOME: instanceHome}}`. The resident `web` server mode is the supervisable shape
+ *   (v0.28 hard-deprecated the `server` subcommand in its favor): stdio-indifferent (stays
+ *   resident on an EOF'd stdin) and SIGTERM-clean; `--port 0` auto-assigns, with the bound port
+ *   + bearer token printed on the startup banner (the supervisor's discovery surface, opencode
+ *   parity). Isolation is the single `KIMI_CODE_HOME` var: config and state unify beneath it.
+ *   Probed (kimi 0.28.0, darwin-arm64, 2026-07-20): `web --no-open --port 0` alive at 5s on an
+ *   EOF'd stdin, bound-port banner line, clean SIGTERM exit, isolation census
+ *   `<home>/{device_id, server/, server.token, workspaces.json, telemetry/}`, and a per-home
+ *   `server/instances/{server_id}.json` carrying `{pid, host, port, heartbeat_at}` — the exact
+ *   coordinate contract the wake daemon's kimi-server adapter discovers, so a
+ *   Fleet-launched kimi seat is wake-addressable by construction (daemon subscriptions point
+ *   `harnessTargetMetadata.lockPath`/envelope overrides at the instance home; the tracked
+ *   SessionStart hook `.kimi-code/hooks/wakeEnvelopeHook.mjs` is `KIMI_CODE_HOME`-aware).
+ *   `--version` answers in ~0.3s without booting. Auth is `'env-key'`: the flatrate API key
+ *   rides the seat env (the portable-flatrate property), so NO per-home auth step exists;
+ *   OAuth file storage under the home is the interactive alternative, and no documented marker
+ *   exists, so `authRequired` stays honestly `null`.
  *
  * `open -n -a …` launches remain **excluded by design**: `open` detaches — the spawned process is
  * the launcher, not the harness — so the Fleet Manager could never supervise (signal, reap, or

--- a/ai/services/fleet/generateKimiSeatConfig.mjs
+++ b/ai/services/fleet/generateKimiSeatConfig.mjs
@@ -1,0 +1,284 @@
+import path from 'node:path';
+
+/**
+ * The canonical MCP server set every Kimi Code seat wires — the same four servers as
+ * `OPENCODE_SEAT_SERVERS` (`generateOpenCodeSeatConfig.mjs`). Mirrored as fixed module data on
+ * purpose: two call-sites do not justify a shared constant with a misleading harness-specific
+ * name, and an unlisted server here is a deliberate caller override via `options.servers`,
+ * never an accident of omission.
+ * @type {ReadonlyArray<{name: String, script: String, needsCwd: Boolean}>}
+ */
+export const KIMI_SEAT_SERVERS = Object.freeze([
+    {name: 'neo-mjs-memory-core',    script: 'ai/mcp/server/memory-core/mcp-server.mjs',    needsCwd: false},
+    {name: 'neo-mjs-github-workflow', script: 'ai/mcp/server/github-workflow/mcp-server.mjs', needsCwd: false},
+    {name: 'neo-mjs-knowledge-base', script: 'ai/mcp/server/knowledge-base/mcp-server.mjs', needsCwd: false},
+    {name: 'neo-mjs-neural-link',    script: 'ai/mcp/server/neural-link/mcp-server.mjs',    needsCwd: true}
+]);
+
+/**
+ * Generate every config/scaffold file a Kimi Code seat boots from, as a PURE params→files
+ * emission (the AiConfig SSOT purity discipline: no config imports, no env reads, no fs access,
+ * no hidden defaults — callers resolve every path). The launch path writes the returned files;
+ * this module only decides their content. Sibling of `generateOpenCodeSeatConfig.mjs` — same
+ * three load-bearing constraints, with the harness-specific surfaces mapped:
+ *
+ * 1. **Organs canonical.** MCP server CODE runs from the canonical checkout (the Memory Core
+ *    resolves its data root from the server code's own file location — a per-seat copy forks an
+ *    empty graph island). The island guard REJECTS any server script resolving outside
+ *    `canonicalRoot`, sibling parity.
+ * 2. **Seat personal.** Identity + credentials load via `--env-file` from the seat's OWN `.env`
+ *    (`NEO_AGENT_IDENTITY`, `GH_TOKEN`, provider keys), wired per-server in `mcp.json`.
+ * 3. **The memory layer is a boot RITUAL here, not a config slot.** Kimi Code auto-loads the
+ *    PROJECT `AGENTS.md` and ships no per-seat `instructions` slot (verified 2026-07-20 against
+ *    the live harness v0.28.0 + the official hooks/config docs: `SessionStart` is an
+ *    observation-only event whose stdout never enters context, so hook-injection is not a
+ *    reliable surface either). The honest wiring is therefore the MEMORY.md boot checklist
+ *    below: read the layer before the first public artifact of every session — persistence
+ *    without reload is a no-op (the day-two lesson, kept inside the substrate that teaches it).
+ *    If the harness later ships an instructions/memory config, this decision re-opens.
+ *
+ * **Wake-addressable by construction (the wake-adapter coordinate contracts):** the emitted `config.toml`
+ * wires the git-tracked SessionStart hook `.kimi-code/hooks/wakeEnvelopeHook.mjs` (present in
+ * every neo checkout), which is `KIMI_CODE_HOME`-aware: a Fleet-launched seat writes its
+ * envelope beside its own `server/instances/{server_id}.json` coordinates — exactly what the
+ * wake daemon's kimi-server route discovers. No seat-side writers beyond the tracked hook.
+ *
+ * **Two roots, by harness design:** `config.toml` lives in the harness home (`kimiHome` —
+ * `$KIMI_CODE_HOME`), while the MCP wiring lives in the seat checkout (`.kimi-code/mcp.json` is
+ * a project-level file, untracked per seat). The generator takes both roots explicitly; the
+ * coupling is loud, not latent.
+ *
+ * **Emission shape:** `mcp.json` is strict JSON (comment-stripped `JSON.parse` must succeed —
+ * the unit spec enforces it). `config.toml` carries only what the harness needs beyond its
+ * managed defaults: the managed `kimi-code` provider/model resolution stays harness-owned
+ * (interactive provisioning writes provider details on first login; fleet auth rides the seat
+ * env per the launch contract's `env-key` mode).
+ *
+ * @param {Object} options
+ * @param {String} options.canonicalRoot  Absolute path of the CANONICAL neo checkout (organs).
+ * @param {String} options.seatEnvFile    Absolute path of the seat's own `.env` (identity + keys).
+ * @param {String} options.workspaceRoot  Absolute path of the seat's working checkout — the
+ *                                        `.kimi-code/mcp.json` target and the Neural Link `--cwd`.
+ * @param {String} options.kimiHome       Absolute path of the seat's harness home
+ *                                        (`$KIMI_CODE_HOME`) — the `config.toml` target.
+ * @param {String} options.memoryDir      Absolute path of the seat's persistent memory dir —
+ *                                        the `MEMORY.md` / `seat-pointers.md` / `identity.md`
+ *                                        scaffold target.
+ * @param {String} options.nodeBinary     Absolute path of the node binary for server commands.
+ * @param {Object} [options.environment]  Extra env merged verbatim into EVERY server's `env`
+ *                                        block in `mcp.json` (caller-resolved: PATH, HOME,
+ *                                        local inference hosts). Default `{}`.
+ * @param {String} [options.defaultModel] Default model alias for `config.toml`.
+ *                                        Default `'kimi-code/k3'`.
+ * @param {Array}  [options.servers]      Override the canonical server set
+ *                                        ({@link KIMI_SEAT_SERVERS}) — same entry shape.
+ * @returns {{files: Array<{path: String, content: String}>}} the emission list — callers own
+ * writing (mode, atomicity, divergence policy).
+ * @throws {Error} naming the offending argument on missing/invalid input, and
+ * `generateKimiSeatConfig: island guard` when a server script resolves outside `canonicalRoot`.
+ */
+export function generateKimiSeatConfig({canonicalRoot, seatEnvFile, workspaceRoot, kimiHome, memoryDir, nodeBinary, environment = {}, defaultModel = 'kimi-code/k3', servers = KIMI_SEAT_SERVERS} = {}) {
+    assertNonEmptyString(canonicalRoot, 'canonicalRoot');
+    assertNonEmptyString(seatEnvFile,   'seatEnvFile');
+    assertNonEmptyString(workspaceRoot, 'workspaceRoot');
+    assertNonEmptyString(kimiHome,      'kimiHome');
+    assertNonEmptyString(memoryDir,     'memoryDir');
+    assertNonEmptyString(nodeBinary,    'nodeBinary');
+
+    if (!Array.isArray(servers) || servers.length === 0) {
+        throw new Error("generateKimiSeatConfig: 'servers' must be a non-empty array.");
+    }
+
+    // Trailing slashes are legal input: `normalize` keeps them, and `root + '/'` would become a
+    // double-slash that every valid script then fails (the guard mis-rejecting valid input).
+    const root = path.posix.normalize(canonicalRoot).replace(/(.)\/+$/, '$1');
+
+    // Island guard: every server script MUST resolve inside the canonical checkout — a script
+    // outside it forks the shared graph's data root into an empty island (see the module JSDoc).
+    servers.forEach(server => {
+        const resolved = path.posix.normalize(path.posix.join(root, server.script));
+
+        if (!resolved.startsWith(root + '/') || !server.name || typeof server.needsCwd !== 'boolean') {
+            throw new Error(`generateKimiSeatConfig: island guard — server script '${server.script}' escapes canonicalRoot '${root}' or the entry is malformed.`);
+        }
+    });
+
+    return {files: [
+        {path: path.posix.join(kimiHome, 'config.toml'),                 content: renderConfigToml({defaultModel})},
+        {path: path.posix.join(workspaceRoot, '.kimi-code', 'mcp.json'), content: renderMcpJson({root, seatEnvFile, workspaceRoot, nodeBinary, environment, servers})},
+        {path: path.posix.join(memoryDir, 'MEMORY.md'),                  content: renderMemoryMd()},
+        {path: path.posix.join(memoryDir, 'seat-pointers.md'),           content: renderSeatPointersMd()},
+        {path: path.posix.join(memoryDir, 'identity.md'),                content: renderIdentityMd()}
+    ]};
+}
+
+/**
+ * Render the seat's `config.toml`: permission posture + default model + the wake-envelope
+ * SessionStart hook (git-tracked, present in every neo checkout). Provider/model resolution
+ * stays with the harness's managed defaults (see the module JSDoc).
+ * @param {Object} options
+ * @returns {String}
+ * @private
+ */
+function renderConfigToml({defaultModel}) {
+    const permissionRules = KIMI_SEAT_SERVERS.map(server =>
+        [
+            '[[permission.rules]]',
+            'decision = "allow"',
+            'scope    = "user"',
+            `pattern  = "mcp__${server.name.replaceAll('-', '_')}__*"`
+        ].join('\n')
+    ).join('\n\n');
+
+    return [
+        '# GENERATED by ai/services/fleet/generateKimiSeatConfig.mjs — regenerate, do not hand-edit.',
+        '#',
+        '# 1. ORGANS CANONICAL: MCP server code runs from the canonical checkout (.kimi-code/mcp.json);',
+        '#    the Memory Core resolves its data root from the server code location, so per-seat server',
+        '#    copies fork an empty graph island.',
+        '# 2. SEAT PERSONAL: identity + credentials load via --env-file from the seat\'s own .env.',
+        '# 3. PERMISSION: wake-fired turns must not freeze on approval dialogs for the seat\'s own MCP',
+        '#    calls (2026-07-18 incident, opencode-seat parity); default mode is auto.',
+        '# 4. WAKE: the SessionStart hook is git-tracked and KIMI_CODE_HOME-aware; a Fleet seat\'s',
+        '#    envelope lands beside its own server/instances coordinates (#15596 contract).',
+        '',
+        'default_permission_mode = "auto"',
+        `default_model           = "${defaultModel}"`,
+        '',
+        permissionRules,
+        '',
+        '# The wake-envelope SessionStart hook (tracked at .kimi-code/hooks/wakeEnvelopeHook.mjs in',
+        '# every neo checkout; hook commands run with the session\'s project dir as cwd).',
+        '[[hooks]]',
+        'event   = "SessionStart"',
+        'command = "node .kimi-code/hooks/wakeEnvelopeHook.mjs"',
+        'timeout = 5',
+        ''
+    ].join('\n');
+}
+
+/**
+ * Render the seat's `.kimi-code/mcp.json`: the four canonical servers, strict JSON.
+ * @param {Object} options
+ * @returns {String}
+ * @private
+ */
+function renderMcpJson({root, seatEnvFile, workspaceRoot, nodeBinary, environment, servers}) {
+    const mcpServers = {};
+
+    servers.forEach(server => {
+        const args = ['--env-file=' + seatEnvFile, path.posix.join(root, server.script)];
+
+        if (server.needsCwd) {
+            args.push('--cwd', workspaceRoot);
+        }
+
+        mcpServers[server.name] = {
+            command: nodeBinary,
+            args,
+            env    : {...environment},
+            enabled: true
+        };
+    });
+
+    return JSON.stringify({mcpServers}, null, 2) + '\n';
+}
+
+/**
+ * The memory-layer explainer — including the harness reality: Kimi Code has no per-seat
+ * instructions slot, so the layer loads via a boot RITUAL, not a config slot (see the module
+ * JSDoc for the evidence trail).
+ * @returns {String}
+ * @private
+ */
+function renderMemoryMd() {
+    return [
+        '# Persistent memory — the always-loaded layer',
+        '',
+        '**What this is:** Kimi Code auto-loads the PROJECT `AGENTS.md` and ships no per-seat',
+        '`instructions` slot (verified 2026-07-20: live harness v0.28.0 + official hooks/config',
+        'docs; `SessionStart` is observation-only, so hook-injection is not a reliable surface',
+        'either). This directory is the seat\'s persistent layer — identity lives HERE. The',
+        'Memory Core is the deep archive (query it on demand via the MCP tools).',
+        '',
+        '**Boot checklist (persistence without reload is a no-op — the day-two lesson):**',
+        '1. At every session boot, read `identity.md` + `field-notes.md` (if present) BEFORE the',
+        '   first public artifact (A2A, comment, PR body).',
+        '2. `add_memory` at the end of EVERY turn — the save is the gate that permits the response.',
+        '',
+        '**How to use it:**',
+        '- `identity.md` — the bearer\'s self-story. Nobody writes it but the bearer.',
+        '- `seat-pointers.md` — objective, record-citable facts about this seat.',
+        '- Add new files only for durable facts worth every-session loading; keep them SMALL',
+        '  (this layer costs attention every session). Anything bigger goes to the Memory Core',
+        '  with a one-line pointer here.',
+        '- Identity-claim discipline: identity facts about ANY named agent carry that bearer\'s',
+        '  record citation. Introspection is not citation.',
+        ''
+    ].join('\n');
+}
+
+/**
+ * The seat-pointers skeleton — headings plus fill markers; no fabricated facts.
+ * @returns {String}
+ * @private
+ */
+function renderSeatPointersMd() {
+    return [
+        '# Seat pointers — objective record (yours to maintain)',
+        '',
+        '<!-- Fill on first boot. Every fact here needs a record citation (ticket, PR, message,',
+        '     healthcheck) — this page is the seat\'s citable ground truth, not a diary. -->',
+        '',
+        '## Who / where',
+        '- Operational identity: <!-- @handle -->',
+        '- Model + harness: <!-- family, harness (Kimi Code CLI) -->',
+        '- Harness home (`$KIMI_CODE_HOME`): <!-- abs path --> — `config.toml` lives here.',
+        '- Working checkout (YOURS): <!-- abs path --> — `.kimi-code/mcp.json` lives here;',
+        '  branch from `dev`, PRs target `dev`, never commit to `dev`/`main` directly.',
+        '- Seat env: `.env` in your checkout (`NEO_AGENT_IDENTITY`, `GH_TOKEN`).',
+        '',
+        '## First-boot facts (your own record)',
+        '- <!-- healthcheck results, permission level, roster wiring ticket/PR -->',
+        '',
+        '## Swarm ground rules (the load-bearing ones; full set in the repo\'s AGENTS.md)',
+        '- Every commit subject ends `(#TICKET_ID)`; no tracked-file edit without a self-assigned',
+        '  ticket + `[lane-claim]` broadcast.',
+        '- `add_memory` at end of EVERY turn — the save is the gate that permits the response.',
+        '- A2A-notify peers after any lifecycle event. Never `gh pr merge` (human-only).',
+        ''
+    ].join('\n');
+}
+
+/**
+ * The identity template — story-sovereignty by construction: the bearer authors their own
+ * self-story at their naming gate; the generator emits headings and the rule, never a story.
+ * @returns {String}
+ * @private
+ */
+function renderIdentityMd() {
+    return [
+        '# Identity — unwritten',
+        '',
+        'This page is intentionally near-empty. It is the bearer\'s self-story, and **nobody',
+        'writes it but the bearer** — not the generator, not the operator, not a peer. The',
+        'naming gate (peer sketch → bearer assent → peer-veto window → operator confirmation)',
+        'is where a name becomes a self.',
+        '',
+        'Until then: the operational identity is the GitHub handle; this page stays a promise.',
+        ''
+    ].join('\n');
+}
+
+/**
+ * Guard a required string argument.
+ * @param {*}      value
+ * @param {String} name
+ * @throws {Error} If `value` is not a non-empty string.
+ * @private
+ */
+function assertNonEmptyString(value, name) {
+    if (typeof value !== 'string' || value.length === 0) {
+        throw new Error(`generateKimiSeatConfig: '${name}' must be a non-empty string.`);
+    }
+}

--- a/src/ai/fleet/harnessTypes.mjs
+++ b/src/ai/fleet/harnessTypes.mjs
@@ -23,6 +23,7 @@ export const HARNESS_TYPES = Object.freeze([
     Object.freeze({type: 'claude-code',    label: 'Claude Code'}),
     Object.freeze({type: 'claude-desktop', label: 'Claude'}),
     Object.freeze({type: 'opencode',       label: 'OpenCode'}),
+    Object.freeze({type: 'kimi-code',      label: 'Kimi Code'}),
     Object.freeze({type: 'antigravity',    label: 'Antigravity'}),
     Object.freeze({type: 'native-neo',     label: 'Native'})
 ]);

--- a/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
+++ b/test/playwright/unit/ai/scripts/fleet/onboardPeer.spec.mjs
@@ -133,7 +133,7 @@ test.describe('onboardPeer — intent construction (pure half)', () => {
     test('only curated harness families are accepted, with a named refusal', () => {
         // The curated set IS the launch-templated subset — one derived truth, widened in lockstep
         // with deriveHarnessLaunchSpec. `native-neo` stays registered-but-unlaunchable.
-        expect(CURATED_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex', 'codex-desktop', 'opencode']);
+        expect(CURATED_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex', 'codex-desktop', 'kimi-code', 'opencode']);
         expect(CURATED_HARNESS_TYPES).not.toContain('native-neo');
 
         const built = buildOnboardingIntent({...BASE_OPTIONS, harnessType: 'gemini-cli'});

--- a/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/deriveHarnessLaunchSpec.spec.mjs
@@ -109,7 +109,7 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
     });
 
     test('LAUNCHABLE_HARNESS_TYPES is the frozen alphabetical template subset AND every entry is a registered harness type', () => {
-        expect(LAUNCHABLE_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex', 'codex-desktop', 'opencode']);
+        expect(LAUNCHABLE_HARNESS_TYPES).toEqual(['antigravity', 'claude-code', 'claude-desktop', 'codex', 'codex-desktop', 'kimi-code', 'opencode']);
         expect(Object.isFrozen(LAUNCHABLE_HARNESS_TYPES)).toBe(true);
 
         // The lockstep invariant the module also guards at import: launch vocabulary ⊆ the shared
@@ -132,6 +132,7 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
         expect(getHarnessAuthMode('claude-desktop')).toBe('in-app');
         expect(getHarnessAuthMode('antigravity')).toBe('in-app');
         expect(getHarnessAuthMode('opencode')).toBe('env-key');
+        expect(getHarnessAuthMode('kimi-code')).toBe('env-key');
         expect(getHarnessAuthMode('native-neo')).toBeNull();
         expect(getHarnessAuthMode(undefined)).toBeNull();
     });
@@ -165,6 +166,23 @@ test.describe('deriveHarnessLaunchSpec (per-family harness launch templates)', (
         const other = deriveHarnessLaunchSpec({harnessType: 'opencode', instanceHome: '/srv/instances/p/oc', binaryPath: '/usr/local/bin/opencode'});
         spec.args.push('--extra');
         expect(other.args).toEqual(['serve', '--hostname', '127.0.0.1', '--port', '0']);
+        expect(spec.env).not.toBe(other.env);
+    });
+
+    test('kimi-code: the resident web-server template with the single-var KIMI_CODE_HOME isolation (#15612)', () => {
+        const spec = deriveHarnessLaunchSpec({harnessType: 'kimi-code', instanceHome: '/srv/instances/p/kimi', binaryPath: '/usr/local/bin/kimi'});
+
+        expect(spec).toEqual({
+            command         : '/usr/local/bin/kimi',
+            args            : ['web', '--no-open', '--port', '0'],
+            env             : {KIMI_CODE_HOME: '/srv/instances/p/kimi'},
+            versionProbeArgs: ['--version']
+        });
+
+        // fresh spec per call — a mutating caller never bleeds into the template
+        const other = deriveHarnessLaunchSpec({harnessType: 'kimi-code', instanceHome: '/srv/instances/p/kimi', binaryPath: '/usr/local/bin/kimi'});
+        spec.args.push('--extra');
+        expect(other.args).toEqual(['web', '--no-open', '--port', '0']);
         expect(spec.env).not.toBe(other.env);
     });
 

--- a/test/playwright/unit/ai/services/fleet/generateKimiSeatConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/generateKimiSeatConfig.spec.mjs
@@ -1,0 +1,115 @@
+import {expect, test}                              from '@playwright/test';
+import {KIMI_SEAT_SERVERS, generateKimiSeatConfig} from '../../../../../../ai/services/fleet/generateKimiSeatConfig.mjs';
+
+// Pure function — imported directly (no fs / spawn / env / Neo runtime), so the suite has no
+// host-runtime side effects and each case is fully isolated. Mirrors generateOpenCodeSeatConfig.spec.
+
+const PARAMS = {
+    canonicalRoot: '/canonical',
+    seatEnvFile  : '/seat/checkout/.env',
+    workspaceRoot: '/seat/checkout',
+    kimiHome     : '/fleet/instances/p/kimi',
+    memoryDir    : '/seat/memory',
+    nodeBinary   : '/usr/local/bin/node',
+    environment  : {NEO_OPENAI_COMPATIBLE_HOST: 'http://127.0.0.1:1234', PATH: '/usr/bin:/bin', HOME: '/Users/fleet'}
+};
+
+const findFile = (files, suffix) => files.find(file => file.path.endsWith(suffix));
+
+test.describe('generateKimiSeatConfig (Kimi Code seat scaffold emission, #15612)', () => {
+    test('golden shape: mcp.json parses as strict JSON and wires the canonical four servers, organs-rooted', () => {
+        const
+            {files} = generateKimiSeatConfig(PARAMS),
+            mcp     = JSON.parse(findFile(files, '.kimi-code/mcp.json').content).mcpServers,
+            script  = name => `/canonical/ai/mcp/server/${name}/mcp-server.mjs`;
+
+        for (const server of KIMI_SEAT_SERVERS) {
+            const entry = mcp[server.name];
+
+            expect(entry, `server '${server.name}' must be wired`).toBeDefined();
+            expect(entry.command).toBe('/usr/local/bin/node');
+            expect(entry.args[0]).toBe('--env-file=/seat/checkout/.env');
+            expect(entry.env).toEqual(PARAMS.environment);
+            expect(entry.enabled).toBe(true);
+        }
+
+        expect(mcp['neo-mjs-memory-core'].args[1]).toBe(script('memory-core'));
+        expect(mcp['neo-mjs-github-workflow'].args[1]).toBe(script('github-workflow'));
+        expect(mcp['neo-mjs-knowledge-base'].args[1]).toBe(script('knowledge-base'));
+        // The Neural Link additionally binds --cwd to the seat's own working tree.
+        expect(mcp['neo-mjs-neural-link'].args).toEqual(['--env-file=/seat/checkout/.env', script('neural-link'), '--cwd', '/seat/checkout']);
+    });
+
+    test('golden shape: config.toml carries the auto permission posture, default model, per-server allow rules, and the tracked wake hook', () => {
+        const toml = findFile(generateKimiSeatConfig(PARAMS).files, 'config.toml').content;
+
+        expect(toml).toContain('default_permission_mode = "auto"');
+        expect(toml).toContain('default_model           = "kimi-code/k3"');
+
+        for (const server of KIMI_SEAT_SERVERS) {
+            expect(toml).toContain(`pattern  = "mcp__${server.name.replaceAll('-', '_')}__*"`);
+        }
+
+        // The wake-envelope SessionStart hook: git-tracked, KIMI_CODE_HOME-aware.
+        expect(toml).toContain('event   = "SessionStart"');
+        expect(toml).toContain('command = "node .kimi-code/hooks/wakeEnvelopeHook.mjs"');
+    });
+
+    test('emission list: five files across both roots + the memory dir', () => {
+        const paths = generateKimiSeatConfig(PARAMS).files.map(file => file.path);
+
+        expect(paths).toEqual([
+            '/fleet/instances/p/kimi/config.toml',
+            '/seat/checkout/.kimi-code/mcp.json',
+            '/seat/memory/MEMORY.md',
+            '/seat/memory/seat-pointers.md',
+            '/seat/memory/identity.md'
+        ]);
+    });
+
+    test('memory scaffold: MEMORY.md carries the boot checklist (the day-two reload lesson is substrate, not folklore)', () => {
+        const memory = findFile(generateKimiSeatConfig(PARAMS).files, 'MEMORY.md').content;
+
+        expect(memory).toContain('Boot checklist');
+        expect(memory).toContain('persistence without reload is a no-op');
+        expect(memory).toContain('add_memory');
+        // Story-sovereignty: identity.md stays a near-empty template.
+        const identity = findFile(generateKimiSeatConfig(PARAMS).files, 'identity.md').content;
+        expect(identity).toContain('nobody');
+        expect(identity.length).toBeLessThan(600);
+    });
+
+    test('purity: identical params emit byte-identical files (deterministic, no hidden inputs)', () => {
+        expect(generateKimiSeatConfig(PARAMS)).toEqual(generateKimiSeatConfig(PARAMS));
+    });
+
+    test('island guard: a server script escaping canonicalRoot throws; a malformed entry throws', () => {
+        const evil = [{name: 'evil', script: '../evil/mcp-server.mjs', needsCwd: false}];
+
+        expect(() => generateKimiSeatConfig({...PARAMS, servers: evil})).toThrow(/island guard/);
+        expect(() => generateKimiSeatConfig({...PARAMS, servers: [{script: 'ai/x.mjs', needsCwd: false}]})).toThrow(/island guard/);
+        expect(() => generateKimiSeatConfig({...PARAMS, servers: []})).toThrow(/'servers' must be a non-empty array/);
+    });
+
+    test('island guard: a trailing-slash canonicalRoot is accepted (valid input must not mis-reject)', () => {
+        const
+            {files} = generateKimiSeatConfig({...PARAMS, canonicalRoot: '/canonical/'}),
+            mcp     = JSON.parse(findFile(files, '.kimi-code/mcp.json').content).mcpServers;
+
+        expect(mcp['neo-mjs-memory-core'].args[1]).toBe('/canonical/ai/mcp/server/memory-core/mcp-server.mjs');
+    });
+
+    test('named throws: every required param is validated by name', () => {
+        for (const key of ['canonicalRoot', 'seatEnvFile', 'workspaceRoot', 'kimiHome', 'memoryDir', 'nodeBinary']) {
+            const params = {...PARAMS};
+            delete params[key];
+            expect(() => generateKimiSeatConfig(params), `missing '${key}' must throw`).toThrow(new RegExp(`'${key}'`));
+        }
+    });
+
+    test('defaultModel override lands in config.toml', () => {
+        const toml = findFile(generateKimiSeatConfig({...PARAMS, defaultModel: 'kimi-code/kimi-for-coding'}).files, 'config.toml').content;
+
+        expect(toml).toContain('default_model           = "kimi-code/kimi-for-coding"');
+    });
+});


### PR DESCRIPTION
Resolves #15612

Ships the Kimi Code harness target for the Fleet seat pipeline, end to end: the `'kimi-code'` type registered in the shared `HARNESS_TYPES` authority (Body pickers derive from the same entry; the lockstep guard then admits a launch contract), the per-family launch contract in `deriveHarnessLaunchSpec` (single-var `KIMI_CODE_HOME` isolation, resident `kimi web --no-open --port 0` supervisable mode, `env-key` auth, `--version` probe — with the v0.28.0 probe evidence recorded in the fn JSDoc exactly like the sibling contracts), and the new `generateKimiSeatConfig` pure emission sibling (`config.toml` + project-level `.kimi-code/mcp.json` + the memory-layer scaffold, island-guarded, byte-deterministic). A third kimi seat is now generatable, not hand-built.

Evidence: L2 (370 unit specs incl. the new golden-shape/purity/island-guard cases + the probe-backed contract derivation) → L3 required (throwaway-seat boot through a wake fire/no-fire cycle — operator-gated, flagged under Post-Merge Validation). Residual: the L3 seat boot; the contract itself is probe-backed (2026-07-20, kimi 0.28.0: `--version` 0.3s no-boot, `web` resident on EOF'd stdin, `--port 0` auto-assigns with banner-line discovery, SIGTERM-clean, isolation census + per-home `server/instances/{server_id}.json` — the #15596 discovery shape).

## Deltas from ticket

- **Always-loaded memory wiring decided + documented** (the ticket's named design question): Kimi Code has no per-seat `instructions` slot, and `SessionStart` is observation-only (official hooks docs — hook stdout never enters context), so hook-injection is not a reliable surface either. The emission therefore wires the memory layer as a **boot ritual** (MEMORY.md boot checklist: read identity/field-notes before the first public artifact — the day-two reload lesson baked into the scaffold) rather than pretending a config slot exists. Re-opens if the harness ships a memory config.
- **Supervisable mode settled by probe:** `kimi web --no-open --port 0` (not a held-pipe protocol mode like codex/claude) — EOF-stdin resident, auto-assign works, banner line is the supervisor's port/token discovery surface (opencode parity).
- **Wake hook hardened one line:** `.kimi-code/hooks/wakeEnvelopeHook.mjs` is now `KIMI_CODE_HOME`-aware (falls back to `~/.kimi-code`), so a Fleet-launched seat's envelope lands beside its own `server/instances` coordinates — the #15596 coordinate contract held by construction.
- `defaultModel` is an emission option (`kimi-code/k3` default); provider/model resolution stays with the harness's managed defaults (no fabricated provider blocks).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/generateKimiSeatConfig.spec.mjs deriveHarnessLaunchSpec.spec.mjs generateOpenCodeSeatConfig.spec.mjs` → **35 passed** (9 new emission cases: golden shape ×2, emission list, memory scaffold, purity, island guard ×2, named throws, model override; +1 new launch-template case; sibling suite intact).
- `npm run test-unit -- test/playwright/unit/ai/services/fleet/` → **370 passed** (full fleet family — registry/lockstep/launch-contract surfaces green).
- `node --check` on all three touched/new modules + the hook → OK.
- Live probes (recorded in `deriveHarnessLaunchSpec.mjs` fn JSDoc): kimi 0.28.0, darwin-arm64, 2026-07-20.

## Post-Merge Validation

- [ ] Generate one throwaway kimi seat from the emission (isolated `KIMI_CODE_HOME` + checkout) and boot it through a wake fire/no-fire cycle — proves envelope hook + instance discovery + daemon route end-to-end on generated config (L3, operator-gated).
- [ ] Confirm the FM launch surface (`FleetLifecycleService.resolveLaunch`) accepts `'kimi-code'` end-to-end against the registry entry (first real launch).

## Commits

- `e1a109e9fc` — feat: registry entry + launch contract + generator + hook hardening + specs
- `fda1435d29` — test: widen the curated-harness lockstep guard (`onboardPeer.spec`) for the new family — the guard did its job; the other two CI failures of that run (`McpServerListToolsSmoke` gitlab-workflow, `GoldenPathSynthesizer` GUIDES-edge) pass locally 105/105 on this head and are tracked as CI-environment flakes if they recur

Authored by Iris (Moonshot Kimi K3, Kimi Code). Session session_e86fa9f0-866e-45e8-a6df-d7bb6dd4d8b5.
