### PR TITLE
fix(ai): kimi seat generator emits Kimi's verbatim hyphenated permission patterns (#15618)

### DIFF
--- a/ai/services/fleet/generateKimiSeatConfig.mjs
+++ b/ai/services/fleet/generateKimiSeatConfig.mjs
@@ -126,7 +126,10 @@ function renderConfigToml({defaultModel}) {
             '[[permission.rules]]',
             'decision = "allow"',
             'scope    = "user"',
-            `pattern  = "mcp__${server.name.replaceAll('-', '_')}__*"`
+            // Kimi matches patterns against the VERBATIM tool id — hyphens preserved
+            // (`mcp__neo-mjs-memory-core__*`); dash-to-underscore canonicalization is a
+            // different MCP host's convention and would leave these rules dead.
+            `pattern  = "mcp__${server.name}__*"`
         ].join('\n')
     ).join('\n\n');
 

--- a/test/playwright/unit/ai/services/fleet/generateKimiSeatConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/generateKimiSeatConfig.spec.mjs
@@ -46,9 +46,14 @@ test.describe('generateKimiSeatConfig (Kimi Code seat scaffold emission, #15612)
         expect(toml).toContain('default_permission_mode = "auto"');
         expect(toml).toContain('default_model           = "kimi-code/k3"');
 
-        for (const server of KIMI_SEAT_SERVERS) {
-            expect(toml).toContain(`pattern  = "mcp__${server.name.replaceAll('-', '_')}__*"`);
-        }
+        // The harness FACT (living reference: a production kimi seat's hand-built config.toml,
+        // daily-driven since 2026-07-19): tool ids keep server names VERBATIM, hyphens and all.
+        // Asserting the literal hyphenated form — not a transform — so the tautology cannot regrow.
+        expect(toml).toContain('pattern  = "mcp__neo-mjs-memory-core__*"');
+        expect(toml).toContain('pattern  = "mcp__neo-mjs-github-workflow__*"');
+        expect(toml).toContain('pattern  = "mcp__neo-mjs-knowledge-base__*"');
+        expect(toml).toContain('pattern  = "mcp__neo-mjs-neural-link__*"');
+        expect(toml).not.toContain('mcp__neo_mjs_');
 
         // The wake-envelope SessionStart hook: git-tracked, KIMI_CODE_HOME-aware.
         expect(toml).toContain('event   = "SessionStart"');


### PR DESCRIPTION
Resolves #15618

Fixes the latent permission-rule defect caught in Vega's Approve+Follow-Up review of PR #15613: the generator emitted `mcp__neo_mjs_*__*` (dash-to-underscore transform borrowed from a different MCP host's convention), while Kimi's real tool ids keep server names verbatim — `mcp__neo-mjs-memory-core__list_messages` — so the emitted rules would have been dead on the first generated seat. Now emits the verbatim hyphenated form, and the spec asserts the harness fact (living reference: a production kimi seat's daily-driven `config.toml`) instead of recomputing the same transform — the tautology that gave false coverage confidence is killed, including a negative assertion against the underscore shape. Also re-homes the L3 throwaway-seat boot: this ticket IS its durable tracker on Epic #15586, with the review's sharpening folded into its ACs (wake-fired MCP call through the emitted rules; record whether `auto` mode or the rules were load-bearing).

Evidence: L2 (370 unit specs incl. the corrected golden-shape case with verbatim-hyphen assertions for all four servers + negative underscore guard) → L3 required (the throwaway-seat boot — operator-gated, tracked in #15618's flagged AC). Residual: the L3 boot itself; the defect was latent (zero generated seats exist — `prepareManagedAgentWorkspace` fails closed for `kimi-code` today).

## Deltas from ticket

None — this PR is exactly the review follow-up as filed (pattern fix + tautology kill + L3 home).

## Test Evidence

- `npm run test-unit -- test/playwright/unit/ai/services/fleet/` → **370 passed** (incl. `generateKimiSeatConfig.spec.mjs` golden-shape: four verbatim-hyphen patterns + `not.toContain('mcp__neo_mjs_')`).
- `node --check ai/services/fleet/generateKimiSeatConfig.mjs` → OK.
- Harness fact verified against the living reference: the Iris seat's `~/.kimi-code/config.toml` L4-22 (`pattern = "mcp__neo-mjs-memory-core__*"`, hyphenated, daily-proven) + the live tool namespace every kimi session loads.

## Post-Merge Validation

- [ ] The L3 throwaway-seat boot (#15618's flagged AC, operator-gated): generate from the emission, boot, drive a wake-fired MCP call through the emitted rules with no approval freeze, record whether `auto` or the rules were load-bearing, then fire/no-fire green.

## Commits

- (single commit) `fix(ai): kimi seat generator emits Kimi's verbatim hyphenated permission patterns (#15618)`

Authored by Iris (Moonshot Kimi K3, Kimi Code). Session session_e86fa9f0-866e-45e8-a6df-d7bb6dd4d8b5.
