### PR TITLE
feat(agentos): third registered claim target for the row-6 arbitration receipt (#15591)

### DIFF
--- a/apps/agentos/childapps/dockdemo/view/DemoBCrossWindowStage.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBCrossWindowStage.mjs
@@ -17,9 +17,16 @@ import {previewToOperation} from '../../../../../src/dashboard/dockPreviewContra
  * `workspace.crossWindowStageResolve` directly, making those fields the host's public stage
  * contract. This module owns the CODE that manipulates them; the workspace owns the fields.
  *
- * Phase-1 scope note: stage semantics remain the current singleton pair (main + popup). The
- * per-workspace parameterization (a second registered popup claimant, `demo-b-popup-2`) is the
- * follow-up landing ON THIS SEAM — the seams below are the parameterization surface.
+ * **Facade-routing rule:** only spec-witnessed seams route back through the host's wrappable
+ * facades (currently `commitWholeStackReturn` → `adoptCommittedTransferPair` /
+ * `retireReturnedPopupWorkspace`, whose order-witness wraps the workspace methods). Every other
+ * internal call (`mountTarget` → `waitForGeometry` → `measureGeometry`, etc.) uses this
+ * module's own functions directly. A future witness wrapping a workspace facade the module
+ * does NOT route through will silently not fire — extend the routing set WITH the witness.
+ *
+ * The stage is parameterized by workspace id: `demo-b-main` plus any number of registered
+ * popup claim targets (`demo-b-popup`, `demo-b-popup-2`), each with its own host-owned stage
+ * continuation and target window id, staged through the same registration semantics.
  */
 
 /**
@@ -28,7 +35,8 @@ import {previewToOperation} from '../../../../../src/dashboard/dockPreviewContra
  * @param {Object} seams.registries Stable host-owned collections, captured once:
  *     `{hosts: Map, participations: Map, geometry: Map, projectionRequests: Map, detachedPanes: Object}`.
  * @param {Neo.dashboard.DockWorkspaceSet} seams.workspaceSet The host's workspace-set registry.
- * @param {Object} seams.workspaceIds `{main, popup}` semantic workspace ids.
+ * @param {Object} seams.workspaceIds `{main, popup, popup2}` semantic workspace ids (`popup2`
+ *     optional — the stage parameterizes over every popup id the host registers).
  * @param {String} seams.sortGroup The shared cross-window coordinator sort group.
  * @param {String} seams.hostComponentId The workspace component id, stamped into stage URLs as `hostId`.
  * @param {Function} seams.applyWorkspaceOperation `(workspaceId, descriptor) => {document, errors}|null`
@@ -44,31 +52,32 @@ import {previewToOperation} from '../../../../../src/dashboard/dockPreviewContra
  * @param {Function} seams.commitCrossWindowTransfer `(data)` — the host's gesture transfer commit (Phase 2 surface).
  * @param {Function} seams.createPopupDocument `() => Object` — a valid empty popup workspace document.
  * @param {Function} seams.createVesselOwnerGrant `(flow, itemId) => {generation, token}`
- * @param {Function} seams.ensurePopupRegistered `() => Boolean` — re-registers the popup workspace's live accessors.
- * @param {Function} seams.getPopupDocument `() => Object|null`
- * @param {Function} seams.getStagePromise `() => Promise|null`
- * @param {Function} seams.getStageReject `() => Function|null`
- * @param {Function} seams.getStageResolve `() => Function|null`
+ * @param {Function} seams.ensurePopupRegistered `(workspaceId) => Boolean` — re-registers the popup workspace's live accessors.
+ * @param {Function} seams.getPopupDocument `(workspaceId) => Object|null`
+ * @param {Function} seams.getStagePromise `(workspaceId) => Promise|null`
+ * @param {Function} seams.getStageReject `(workspaceId) => Function|null`
+ * @param {Function} seams.getStageResolve `(workspaceId) => Function|null`
  * @param {Function} seams.getStageGeneration `() => Number`
- * @param {Function} seams.getTargetWindowId `() => String|null`
+ * @param {Function} seams.getStageWindowName `(workspaceId) => String` — the popup's native window name.
+ * @param {Function} seams.getTargetWindowId `(workspaceId) => String|null`
  * @param {Function} seams.getWindowId `() => String` — the host's own window id.
  * @param {Function} seams.getWorkspaceDocument `(workspaceId) => Object|null`
  * @param {Function} seams.hitTestWorkspace `(workspaceId, localX, localY) => Boolean`
  * @param {Function} seams.hostTimeout `(ms) => Promise` — rides the host's `core.Base#timeout` so destroy cancels pending waits.
  * @param {Function} seams.incrementTransferCommits `()` — bumps the host's gesture proof counter.
  * @param {Function} seams.isHostDestroyed `() => Boolean`
- * @param {Function} seams.onKbdLiveMounted `(liveComponent)` — publishes the mounted target's announcement region to the host.
+ * @param {Function} seams.onKbdLiveMounted `(liveComponent, workspaceId)` — publishes the mounted target's announcement region to the host.
  * @param {Function} seams.onWorkspaceDocumentChange `(workspaceId, document, options?) => Promise`
  * @param {Function} seams.projectDockModel `(resolveComponentRef|null, workspaceId) => Object`
  * @param {Function} seams.refreshWorkspace `(workspaceId, document) => Promise`
  * @param {Function} seams.renderWorkspacePreview `(workspaceId, data) => Object|null`
  * @param {Function} seams.resolveGesture `(receipt)` — consumes the host's gesture settlement resolver.
  * @param {Function} seams.revokeVesselOwnerGrant `(flow, itemId)`
- * @param {Function} seams.setPopupDocument `(document)`
- * @param {Function} seams.setStagePromise `(promise|null)`
- * @param {Function} seams.setStageReject `(fn|null)`
- * @param {Function} seams.setStageResolve `(fn|null)`
- * @param {Function} seams.setTargetWindowId `(windowId|null)`
+ * @param {Function} seams.setPopupDocument `(workspaceId, document)`
+ * @param {Function} seams.setStagePromise `(workspaceId, promise|null)`
+ * @param {Function} seams.setStageReject `(workspaceId, fn|null)`
+ * @param {Function} seams.setStageResolve `(workspaceId, fn|null)`
+ * @param {Function} seams.setTargetWindowId `(workspaceId, windowId|null)`
  * @returns {Object} `{adoptPair, commitWholeStackReturn, createParticipation, isTargetCurrent,
  *     measureGeometry, mountTarget, openStage, positionStage, reconcilePair,
  *     retireReturnedWorkspace, waitForGeometry}`
@@ -93,6 +102,7 @@ export function createCrossWindowStage(seams) {
         getStageReject,
         getStageResolve,
         getStageGeneration,
+        getStageWindowName,
         getTargetWindowId,
         getWindowId,
         getWorkspaceDocument,
@@ -123,9 +133,9 @@ export function createCrossWindowStage(seams) {
      * @returns {Boolean}
      */
     function isTargetCurrent(workspaceId, windowId, host, generation) {
-        let expectedWindowId = workspaceId === workspaceIds.popup
-            ? getTargetWindowId()
-            : getWindowId();
+        let expectedWindowId = workspaceId === workspaceIds.main
+            ? getWindowId()
+            : getTargetWindowId(workspaceId);
 
         return !isHostDestroyed()
             && getStageGeneration() === generation
@@ -188,11 +198,11 @@ export function createCrossWindowStage(seams) {
      * back to the host through the `onKbdLiveMounted` / `attachKeydown` seams.
      * @param {Neo.app.Base} app
      * @param {String} windowId
+     * @param {String} [workspaceId=workspaceIds.popup] the popup workspace to mount.
      * @returns {Promise<Object|null>}
      */
-    async function mountTarget(app, windowId) {
-        let workspaceId  = workspaceIds.popup,
-            generation   = getStageGeneration(),
+    async function mountTarget(app, windowId, workspaceId = workspaceIds.popup) {
+        let generation   = getStageGeneration(),
             [live, host] = app.mainView.add([{
                 cls   : ['agentos-dockdemo-kbd-live'],
                 height: 14,
@@ -211,9 +221,9 @@ export function createCrossWindowStage(seams) {
                 layout: {ntype: 'fit'}
             }]);
 
-        setTargetWindowId(windowId);
+        setTargetWindowId(workspaceId, windowId);
         registries.hosts.set(workspaceId, host);
-        onKbdLiveMounted(live);
+        onKbdLiveMounted(live, workspaceId);
         attachKeydown(host);
 
         try {
@@ -254,16 +264,16 @@ export function createCrossWindowStage(seams) {
 
             let receipt = {windowId, workspaceId, hostId: host.id};
 
-            getStageResolve()?.(receipt);
-            setStageResolve(null);
-            setStageReject(null);
+            getStageResolve(workspaceId)?.(receipt);
+            setStageResolve(workspaceId, null);
+            setStageReject(workspaceId, null);
 
             return receipt
         } catch (error) {
             if (getStageGeneration() === generation) {
-                getStageReject()?.(error);
-                setStageResolve(null);
-                setStageReject(null)
+                getStageReject(workspaceId)?.(error);
+                setStageResolve(workspaceId, null);
+                setStageReject(workspaceId, null)
             }
 
             if (isTargetCurrent(workspaceId, windowId, host, generation)) {
@@ -275,14 +285,16 @@ export function createCrossWindowStage(seams) {
     }
 
     /**
-     * @summary Opens two non-overlapping active workspaces and resolves from the worker connect
-     * + measured geometry contract, never from a blind sleep.
+     * @summary Opens a non-overlapping popup workspace render target and resolves from the
+     * worker connect + measured geometry contract, never from a blind sleep. Parameterized by
+     * popup workspace id — each registered popup stages through the same seams, with its own
+     * host-owned continuation, target window id, and native window name.
+     * @param {String} [workspaceId=workspaceIds.popup] the popup workspace to stage.
      * @returns {Promise<Object>}
      */
-    async function openStage() {
-        let workspaceId = workspaceIds.popup,
-            host        = registries.hosts.get(workspaceId),
-            windowId    = getTargetWindowId();
+    async function openStage(workspaceId = workspaceIds.popup) {
+        let host     = registries.hosts.get(workspaceId),
+            windowId = getTargetWindowId(workspaceId);
 
         // A physical popup close can precede the worker disconnect callback. Reuse only a
         // complete, live owner bundle; a partial/destroyed cache must enter the ordinary cold
@@ -297,15 +309,15 @@ export function createCrossWindowStage(seams) {
             }
         }
 
-        if (getStagePromise()) return getStagePromise();
+        if (getStagePromise(workspaceId)) return getStagePromise(workspaceId);
 
-        if (Object.keys(getPopupDocument()?.items || {}).length) {
+        if (Object.keys(getPopupDocument(workspaceId)?.items || {}).length) {
             return Promise.reject(new Error('popup workspace is not empty; cross-window stage refuses split ownership'))
         }
 
-        ensurePopupRegistered();
+        ensurePopupRegistered(workspaceId);
         bumpStageGeneration();
-        setPopupDocument(createPopupDocument());
+        setPopupDocument(workspaceId, createPopupDocument());
 
         let stageResolve, stageReject,
             stagePromise = new Promise((resolve, reject) => {
@@ -313,9 +325,9 @@ export function createCrossWindowStage(seams) {
                 stageReject  = reject
             });
 
-        setStagePromise(stagePromise);
-        setStageResolve(stageResolve);
-        setStageReject(stageReject);
+        setStagePromise(workspaceId, stagePromise);
+        setStageResolve(workspaceId, stageResolve);
+        setStageReject(workspaceId, stageReject);
 
         let ownerGrant = createVesselOwnerGrant('workspace-target', workspaceId);
 
@@ -331,7 +343,7 @@ export function createCrossWindowStage(seams) {
                         + `&vesselGeneration=${ownerGrant.generation}`,
                     windowFeatures: `height=520,width=600,left=${left},top=${top}`,
                     windowId      : getWindowId(),
-                    windowName    : 'demo-b-cross-window'
+                    windowName    : getStageWindowName(workspaceId)
                 });
 
             if (opened === false) {
@@ -339,10 +351,10 @@ export function createCrossWindowStage(seams) {
             }
         } catch (error) {
             revokeVesselOwnerGrant('workspace-target', workspaceId);
-            getStageReject()?.(error);
-            setStagePromise(null);
-            setStageResolve(null);
-            setStageReject(null);
+            getStageReject(workspaceId)?.(error);
+            setStagePromise(workspaceId, null);
+            setStageResolve(workspaceId, null);
+            setStageReject(workspaceId, null);
             throw error
         }
 
@@ -354,7 +366,7 @@ export function createCrossWindowStage(seams) {
             return await Promise.race([stagePromise, timeout])
         } catch (error) {
             revokeVesselOwnerGrant('workspace-target', workspaceId);
-            setStagePromise(null);
+            setStagePromise(workspaceId, null);
             throw error
         }
     }
@@ -410,10 +422,10 @@ export function createCrossWindowStage(seams) {
 
         registries.hosts.delete(workspaceIds.popup);
         registries.projectionRequests.delete(workspaceIds.popup);
-        setTargetWindowId(null);
-        setStagePromise(null);
-        setStageResolve(null);
-        setStageReject(null);
+        setTargetWindowId(workspaceIds.popup, null);
+        setStagePromise(workspaceIds.popup, null);
+        setStageResolve(workspaceIds.popup, null);
+        setStageReject(workspaceIds.popup, null);
 
         return workspaceSet.unregister(workspaceIds.popup)
     }
@@ -523,7 +535,7 @@ export function createCrossWindowStage(seams) {
     async function positionStage({attempts=120, delay=16}={}) {
         let WindowManager = (await import('../../../../../src/manager/Window.mjs')).default,
             sourceWindow  = WindowManager.get(getWindowId()),
-            targetWindow  = WindowManager.get(getTargetWindowId()),
+            targetWindow  = WindowManager.get(getTargetWindowId(workspaceIds.popup)),
             sourceData    = await Neo.Main.getWindowData({windowId: getWindowId()}),
             screen        = sourceData?.screen,
             sourceRect    = sourceWindow?.innerRect,
@@ -581,14 +593,14 @@ export function createCrossWindowStage(seams) {
 
         await Neo.Main.windowMoveTo({
             windowId  : getWindowId(),
-            windowName: 'demo-b-cross-window',
+            windowName: getStageWindowName(workspaceIds.popup),
             x         : desired.x,
             y         : desired.y
         });
 
         for (let attempt = 0; attempt <= attempts && !isHostDestroyed(); attempt++) {
             sourceWindow = WindowManager.get(getWindowId());
-            targetWindow = WindowManager.get(getTargetWindowId());
+            targetWindow = WindowManager.get(getTargetWindowId(workspaceIds.popup));
             sourceRect   = sourceWindow?.innerRect;
             targetRect   = targetWindow?.innerRect;
 

--- a/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
+++ b/apps/agentos/childapps/dockdemo/view/DemoBWorkspace.mjs
@@ -71,6 +71,20 @@ class DemoBWorkspace extends Container {
      * @static
      */
     static POPUP_WORKSPACE_ID = 'demo-b-popup'
+    /**
+     * Stable worker-owned workspace id for the second popup document — the third registered
+     * claim target the row-6 arbitration receipt measures (a real workspace-set composition,
+     * never a vacuous witness).
+     * @member {String} POPUP2_WORKSPACE_ID='demo-b-popup-2'
+     * @static
+     */
+    static POPUP2_WORKSPACE_ID = 'demo-b-popup-2'
+    /**
+     * Native window name of the second popup render target.
+     * @member {String} POPUP2_WINDOW_NAME='demo-b-cross-window-2'
+     * @static
+     */
+    static POPUP2_WINDOW_NAME = 'demo-b-cross-window-2'
     static config = {
         /**
          * @member {String} className='AgentOS.childapps.dockdemo.view.DemoBWorkspace'
@@ -112,6 +126,13 @@ class DemoBWorkspace extends Container {
      * @member {Object|null} popupDocument=null
      */
     popupDocument = null
+    /**
+     * The second popup render target's worker-owned dock-zone document. Registered through the
+     * same workspace-set seam as the first popup; topology capture stays main+popup-1 scoped,
+     * so this document never enters perspective records.
+     * @member {Object|null} popup2Document=null
+     */
+    popup2Document = null
     /**
      * The worker-owned `{workspaceId → document}` registry (§2.1 workspace-set composition):
      * both workspaces register their document accessors here, foreign-document resolution rides
@@ -188,6 +209,12 @@ class DemoBWorkspace extends Container {
      */
     crossWindowTargetWindowId = null
     /**
+     * The popup render target currently bound to {@link #POPUP2_WORKSPACE_ID}.
+     * @member {String|null} crossWindowTarget2WindowId=null
+     * @protected
+     */
+    crossWindowTarget2WindowId = null
+    /**
      * Connect-settled promise for the deterministic two-window stage.
      * @member {Promise|null} crossWindowStagePromise=null
      * @protected
@@ -206,6 +233,24 @@ class DemoBWorkspace extends Container {
      * @protected
      */
     crossWindowStageReject = null
+    /**
+     * Connect-settled promise for the second popup's stage.
+     * @member {Promise|null} crossWindowStage2Promise=null
+     * @protected
+     */
+    crossWindowStage2Promise = null
+    /**
+     * Resolver for {@link #crossWindowStage2Promise}.
+     * @member {Function|null} crossWindowStage2Resolve=null
+     * @protected
+     */
+    crossWindowStage2Resolve = null
+    /**
+     * Rejecter for {@link #crossWindowStage2Promise}.
+     * @member {Function|null} crossWindowStage2Reject=null
+     * @protected
+     */
+    crossWindowStage2Reject = null
     /**
      * Monotonic target-ownership generation. Every open attempt captures the current value;
      * disconnect and destroy advance it so an awaited popup mount cannot resurrect stale state.
@@ -333,6 +378,12 @@ class DemoBWorkspace extends Container {
      */
     kbdLivePopup = null
     /**
+     * The second popup workspace's announcement region instance.
+     * @member {Neo.component.Base|null} kbdLivePopup2=null
+     * @protected
+     */
+    kbdLivePopup2 = null
+    /**
      * The window the most recent keyboard command originated in — recorded per keydown from the
      * routing host's own `windowId`. Focus mechanics need the ORIGIN because focus-stealing rules
      * are directional: a popup may focus its opener (it holds the keystroke's activation), while
@@ -378,6 +429,7 @@ class DemoBWorkspace extends Container {
 
         me.dockModel        = DockZoneModel.clone(initialDocument);
         me.popupDocument    = DemoBWorkspace.createPopupDocument();
+        me.popup2Document   = DemoBWorkspace.createPopupDocument();
 
         // Live-rect authority: every Demo-B render target publishes resize geometry into
         // manager.Window. Movement-only snapshots make a post-resize conversion compare against
@@ -396,6 +448,11 @@ class DemoBWorkspace extends Container {
         me.workspaceSet.register(DemoBWorkspace.POPUP_WORKSPACE_ID, {
             getDocument: () => me.popupDocument,
             setDocument: document => me.popupDocument = document
+        });
+
+        me.workspaceSet.register(DemoBWorkspace.POPUP2_WORKSPACE_ID, {
+            getDocument: () => me.popup2Document,
+            setDocument: document => me.popup2Document = document
         });
 
         me.dockPreviewProducer = Neo.create(DockPreviewProducer);
@@ -425,21 +482,36 @@ class DemoBWorkspace extends Container {
             commitCrossWindowTransfer: data => me.commitCrossWindowTransfer(data),
             createPopupDocument      : () => DemoBWorkspace.createPopupDocument(),
             createVesselOwnerGrant   : (flow, itemId) => me.createVesselOwnerGrant(flow, itemId),
-            ensurePopupRegistered    : () => me.ensurePopupWorkspaceRegistered(),
-            getPopupDocument         : () => me.popupDocument,
-            getStageGeneration       : () => me.crossWindowStageGeneration,
-            getStagePromise          : () => me.crossWindowStagePromise,
-            getStageReject           : () => me.crossWindowStageReject,
-            getStageResolve          : () => me.crossWindowStageResolve,
-            getTargetWindowId        : () => me.crossWindowTargetWindowId,
-            getWindowId              : () => me.windowId,
-            getWorkspaceDocument     : workspaceId => me.getWorkspaceDocument(workspaceId),
-            hitTestWorkspace         : (workspaceId, localX, localY) => me.hitTestWorkspace(workspaceId, localX, localY),
-            hostComponentId          : me.id,
-            hostTimeout              : ms => me.timeout(ms),
-            incrementTransferCommits : () => me.crossWindowStats.transferCommits++,
-            isHostDestroyed          : () => me.isDestroyed,
-            onKbdLiveMounted         : live => me.kbdLivePopup = live,
+            ensurePopupRegistered    : workspaceId => me.ensurePopupWorkspaceRegistered(workspaceId),
+            getPopupDocument         : workspaceId => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? me.popup2Document
+                : me.popupDocument,
+            getStageGeneration: () => me.crossWindowStageGeneration,
+            getStagePromise   : workspaceId => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? me.crossWindowStage2Promise
+                : me.crossWindowStagePromise,
+            getStageReject           : workspaceId => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? me.crossWindowStage2Reject
+                : me.crossWindowStageReject,
+            getStageResolve          : workspaceId => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? me.crossWindowStage2Resolve
+                : me.crossWindowStageResolve,
+            getStageWindowName       : workspaceId => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? DemoBWorkspace.POPUP2_WINDOW_NAME
+                : 'demo-b-cross-window',
+            getTargetWindowId        : workspaceId => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? me.crossWindowTarget2WindowId
+                : me.crossWindowTargetWindowId,
+            getWindowId             : () => me.windowId,
+            getWorkspaceDocument    : workspaceId => me.getWorkspaceDocument(workspaceId),
+            hitTestWorkspace        : (workspaceId, localX, localY) => me.hitTestWorkspace(workspaceId, localX, localY),
+            hostComponentId         : me.id,
+            hostTimeout             : ms => me.timeout(ms),
+            incrementTransferCommits: () => me.crossWindowStats.transferCommits++,
+            isHostDestroyed         : () => me.isDestroyed,
+            onKbdLiveMounted        : (live, workspaceId) => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? me.kbdLivePopup2 = live
+                : me.kbdLivePopup = live,
             onWorkspaceDocumentChange: (workspaceId, document, options) => me.onWorkspaceDocumentChange(workspaceId, document, options),
             projectDockModel         : (resolveComponentRef, workspaceId) => me.projectDockModel(resolveComponentRef, workspaceId),
             refreshWorkspace         : (workspaceId, document) => me.refreshWorkspace(workspaceId, document),
@@ -456,13 +528,27 @@ class DemoBWorkspace extends Container {
                 me.crossWindowGestureResolve = null
             },
             revokeVesselOwnerGrant: (flow, itemId) => me.revokeVesselOwnerGrant(flow, itemId),
-            setPopupDocument      : document => me.popupDocument = document,
-            setStagePromise       : promise => me.crossWindowStagePromise = promise,
-            setStageReject        : reject => me.crossWindowStageReject = reject,
-            setStageResolve       : resolve => me.crossWindowStageResolve = resolve,
-            setTargetWindowId     : windowId => me.crossWindowTargetWindowId = windowId,
-            sortGroup             : DemoBWorkspace.CROSS_WINDOW_SORT_GROUP,
-            workspaceIds          : {main: DemoBWorkspace.MAIN_WORKSPACE_ID, popup: DemoBWorkspace.POPUP_WORKSPACE_ID},
+            setPopupDocument      : (workspaceId, document) => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? me.popup2Document = document
+                : me.popupDocument = document,
+            setStagePromise          : (workspaceId, promise) => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? me.crossWindowStage2Promise = promise
+                : me.crossWindowStagePromise = promise,
+            setStageReject           : (workspaceId, reject) => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? me.crossWindowStage2Reject = reject
+                : me.crossWindowStageReject = reject,
+            setStageResolve          : (workspaceId, resolve) => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? me.crossWindowStage2Resolve = resolve
+                : me.crossWindowStageResolve = resolve,
+            setTargetWindowId        : (workspaceId, windowId) => workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? me.crossWindowTarget2WindowId = windowId
+                : me.crossWindowTargetWindowId = windowId,
+            sortGroup   : DemoBWorkspace.CROSS_WINDOW_SORT_GROUP,
+            workspaceIds: {
+                main  : DemoBWorkspace.MAIN_WORKSPACE_ID,
+                popup : DemoBWorkspace.POPUP_WORKSPACE_ID,
+                popup2: DemoBWorkspace.POPUP2_WORKSPACE_ID
+            },
             workspaceSet          : me.workspaceSet
         });
 
@@ -596,12 +682,14 @@ class DemoBWorkspace extends Container {
      * @protected
      */
     announceKeyboardOutcome({message}) {
-        let me    = this,
-            main  = me.getReference('kbd-live-b'),
-            popup = me.kbdLivePopup;
+        let me     = this,
+            main   = me.getReference('kbd-live-b'),
+            popup  = me.kbdLivePopup,
+            popup2 = me.kbdLivePopup2;
 
         main && (main.text = message);
-        popup && !popup.isDestroyed && (popup.text = message)
+        popup && !popup.isDestroyed && (popup.text = message);
+        popup2 && !popup2.isDestroyed && (popup2.text = message)
     }
 
     /**
@@ -769,8 +857,9 @@ class DemoBWorkspace extends Container {
     enumerateKeyboardTargets({itemId}) {
         let me     = this,
             labels = {
-                [DemoBWorkspace.MAIN_WORKSPACE_ID] : 'Main window',
-                [DemoBWorkspace.POPUP_WORKSPACE_ID]: 'Popup window'
+                [DemoBWorkspace.MAIN_WORKSPACE_ID]  : 'Main window',
+                [DemoBWorkspace.POPUP_WORKSPACE_ID] : 'Popup window',
+                [DemoBWorkspace.POPUP2_WORKSPACE_ID]: 'Popup window 2'
             };
 
         return me.workspaceSet.ids().flatMap(workspaceId => {
@@ -949,7 +1038,9 @@ class DemoBWorkspace extends Container {
 
         // popup-workspace target: the MAIN window opened it, so ITS Main actor holds the handle
         if (targetWindowId !== me.windowId) {
-            return me.focusNamedWindow('demo-b-cross-window')
+            return me.focusNamedWindow(workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? DemoBWorkspace.POPUP2_WINDOW_NAME
+                : 'demo-b-cross-window')
         }
 
         // main-window target from a popup origin: route the verb to the POPUP's main thread
@@ -981,16 +1072,24 @@ class DemoBWorkspace extends Container {
     }
 
     /**
-     * @summary (Re-)registers the popup workspace's live accessors before a cold stage opens.
+     * @summary (Re-)registers a popup workspace's live accessors before a cold stage opens.
      *
      * A successful whole-stack return explicitly unregisters the emptied popup entry. The next
      * user-authored stage is a NEW workspace lifetime, so it re-registers the same semantic id
      * against the current owner fields before any participation adapter may resolve it.
+     * @param {String} [workspaceId=DemoBWorkspace.POPUP_WORKSPACE_ID] the popup to (re-)register.
      * @returns {Boolean}
      * @protected
      */
-    ensurePopupWorkspaceRegistered() {
+    ensurePopupWorkspaceRegistered(workspaceId=DemoBWorkspace.POPUP_WORKSPACE_ID) {
         let me = this;
+
+        if (workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID) {
+            return me.workspaceSet.register(workspaceId, {
+                getDocument: () => me.popup2Document,
+                setDocument: document => me.popup2Document = document
+            })
+        }
 
         return me.workspaceSet.register(DemoBWorkspace.POPUP_WORKSPACE_ID, {
             getDocument: () => me.popupDocument,
@@ -1274,6 +1373,8 @@ class DemoBWorkspace extends Container {
             me.dockModel = document
         } else if (workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID) {
             me.popupDocument = document
+        } else if (workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID) {
+            me.popup2Document = document
         } else {
             return Promise.reject(new Error(`unknown Demo-B workspace "${workspaceId}"`))
         }
@@ -1348,16 +1449,17 @@ class DemoBWorkspace extends Container {
      * @returns {Promise<Object|null>}
      * @protected
      */
-    async mountCrossWindowTarget(app, windowId) {
-        return this.crossWindowStage.mountTarget(app, windowId)
+    async mountCrossWindowTarget(app, windowId, workspaceId=DemoBWorkspace.POPUP_WORKSPACE_ID) {
+        return this.crossWindowStage.mountTarget(app, windowId, workspaceId)
     }
 
     /**
      * Facade over the extracted cross-window stage module.
+     * @param {String} [workspaceId=DemoBWorkspace.POPUP_WORKSPACE_ID] the popup workspace to stage.
      * @returns {Promise<Object>}
      */
-    async openCrossWindowStage() {
-        return this.crossWindowStage.openStage()
+    async openCrossWindowStage(workspaceId=DemoBWorkspace.POPUP_WORKSPACE_ID) {
+        return this.crossWindowStage.openStage(workspaceId)
     }
 
     /**
@@ -2807,7 +2909,7 @@ class DemoBWorkspace extends Container {
         // ownership branch until its Main realm has installed resize observation.
         await Neo.main.addon.WindowPosition?.setConfigs({observeResize: true, windowId});
 
-        if (workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID) {
+        if (workspaceId === DemoBWorkspace.POPUP_WORKSPACE_ID || workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID) {
             if (flow !== 'workspace-target') return;
 
             if (!me.consumeVesselOwnerGrant({
@@ -2819,7 +2921,7 @@ class DemoBWorkspace extends Container {
                 windowId
             })) return;
 
-            await me.mountCrossWindowTarget(app, windowId);
+            await me.mountCrossWindowTarget(app, windowId, workspaceId);
             return
         }
 
@@ -2979,8 +3081,15 @@ class DemoBWorkspace extends Container {
 
         if (me.isDestroyed) return;
 
-        if (data.windowId === me.crossWindowTargetWindowId) {
-            let workspaceId    = DemoBWorkspace.POPUP_WORKSPACE_ID,
+        let disconnectedWorkspaceId = data.windowId === me.crossWindowTargetWindowId
+                ? DemoBWorkspace.POPUP_WORKSPACE_ID
+                : data.windowId === me.crossWindowTarget2WindowId
+                    ? DemoBWorkspace.POPUP2_WORKSPACE_ID
+                    : null;
+
+        if (disconnectedWorkspaceId) {
+            let isPopup2       = disconnectedWorkspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID,
+                workspaceId    = disconnectedWorkspaceId,
                 detachedItemId = Object.entries(me.detachedPanes)
                     .find(([, entry]) => entry.windowId === data.windowId)?.[0];
 
@@ -2992,22 +3101,45 @@ class DemoBWorkspace extends Container {
                 applied: false,
                 errors : ['cross-window target disconnected before the gesture settled']
             });
-            me.crossWindowStageReject?.(new Error('cross-window target disconnected before readiness settled'));
 
-            for (const id of [DemoBWorkspace.MAIN_WORKSPACE_ID, workspaceId]) {
-                me.crossWindowParticipations.get(id)?.destroy();
-                me.crossWindowParticipations.delete(id);
-                me.crossWindowGeometry.delete(id)
+            if (isPopup2) {
+                me.crossWindowStage2Reject?.(new Error('cross-window target disconnected before readiness settled'))
+            } else {
+                me.crossWindowStageReject?.(new Error('cross-window target disconnected before readiness settled'))
+            }
+
+            me.crossWindowParticipations.get(workspaceId)?.destroy();
+            me.crossWindowParticipations.delete(workspaceId);
+            me.crossWindowGeometry.delete(workspaceId);
+
+            // The main participation serves every staged popup pair: it retires only when the
+            // LAST popup target is gone, never while a sibling stage remains live.
+            let siblingTargetId = isPopup2 ? me.crossWindowTargetWindowId : me.crossWindowTarget2WindowId;
+
+            if (!siblingTargetId) {
+                me.crossWindowParticipations.get(DemoBWorkspace.MAIN_WORKSPACE_ID)?.destroy();
+                me.crossWindowParticipations.delete(DemoBWorkspace.MAIN_WORKSPACE_ID);
+                me.crossWindowGeometry.delete(DemoBWorkspace.MAIN_WORKSPACE_ID)
             }
 
             me.crossWindowHosts.delete(workspaceId);
-            me.crossWindowTargetWindowId = null;
-            me.crossWindowStagePromise   = null;
-            me.crossWindowStageResolve   = null;
-            me.crossWindowStageReject    = null;
+
+            if (isPopup2) {
+                me.crossWindowTarget2WindowId = null;
+                me.crossWindowStage2Promise   = null;
+                me.crossWindowStage2Resolve   = null;
+                me.crossWindowStage2Reject    = null;
+                me.kbdLivePopup2              = null
+            } else {
+                me.crossWindowTargetWindowId = null;
+                me.crossWindowStagePromise   = null;
+                me.crossWindowStageResolve   = null;
+                me.crossWindowStageReject    = null;
+                me.kbdLivePopup              = null
+            }
+
             me.crossWindowGestureResolve = null;
             me.crossWindowGestureContext = null;
-            me.kbdLivePopup              = null;
 
             // A post-commit manual close is a terminal vessel event, not ownership loss.
             // A pre-commit close has no detached entry and remains a cancelled gesture.
@@ -4310,6 +4442,7 @@ class DemoBWorkspace extends Container {
         });
         me.crossWindowGestureResolve?.({applied: false, errors: ['Demo-B workspace destroyed']});
         me.crossWindowStageReject?.(new Error('Demo-B workspace destroyed'));
+        me.crossWindowStage2Reject?.(new Error('Demo-B workspace destroyed'));
         me.crossWindowParticipations.forEach(participation => participation.destroy());
         me.crossWindowParticipations.clear();
         me.crossWindowHosts.clear();
@@ -4323,6 +4456,9 @@ class DemoBWorkspace extends Container {
         me.crossWindowStagePromise   = null;
         me.crossWindowStageResolve   = null;
         me.crossWindowStageReject    = null;
+        me.crossWindowStage2Promise  = null;
+        me.crossWindowStage2Resolve  = null;
+        me.crossWindowStage2Reject   = null;
         me.crossWindowGestureResolve = null;
         me.crossWindowGestureContext = null;
 

--- a/test/playwright/e2e/agentos/DemoBThirdClaimantStageNL.spec.mjs
+++ b/test/playwright/e2e/agentos/DemoBThirdClaimantStageNL.spec.mjs
@@ -1,0 +1,72 @@
+import {test, expect} from '../../fixtures.mjs';
+
+/**
+ * @summary Whitebox witness for Demo B's third registered claim target (the row-6 arbitration
+ * prerequisite): both popup workspaces stage through the SAME registration semantics as the
+ * first — real windows, real projections, measurable claim geometry — so the matrix's row-6
+ * cell is executable without any test-host simulation. The arbitration receipt itself is the
+ * matrix lane's cell; this witness owns the staging composition it measures.
+ *
+ * Headed matrix run: npx playwright test agentos/DemoBThirdClaimantStageNL \
+ *   -c test/playwright/playwright.config.matrix.mjs --workers=1
+ */
+test.describe('AgentOS Demo B — three registered claim targets', () => {
+    test.setTimeout(120000);
+
+    // Both physical viewports must fit on the headed screen; this is stage geometry, not a
+    // fixed product layout assumption.
+    test.use({
+        contextOptions: {screen: {height: 1080, width: 1920}},
+        viewport      : {height: 720, width: 760}
+    });
+
+    test('both popup workspaces stage through the same seams and expose measurable claim geometry', async ({page, neuralLink}) => {
+        await page.goto('/apps/agentos/childapps/dockdemo/index.html?demo=b');
+        await page.waitForSelector('.agentos-dockdemo-counter-pane', {timeout: 30000});
+
+        const app        = await neuralLink.connectToApp('AgentOSDockDemo'),
+              workspaces = await app.findInstances(
+                  {className: 'AgentOS.childapps.dockdemo.view.DemoBWorkspace'},
+                  ['id']
+              ),
+              wsId       = (Array.isArray(workspaces) ? workspaces[0] : workspaces)?.id;
+
+        expect(wsId, 'the App Worker must own one DemoBWorkspace').toBeTruthy();
+
+        // All three claim targets are registered through the same workspace-set semantics —
+        // the third is a data fact in the same registry, never a bespoke host.
+        for (const workspaceId of ['demo-b-main', 'demo-b-popup', 'demo-b-popup-2']) {
+            const document = await app.callMethod(wsId, 'getWorkspaceDocument', [workspaceId]);
+
+            expect(document?.nodes, `${workspaceId} must resolve a committed workspace document`).toBeTruthy()
+        }
+
+        const receipt1 = await app.callMethod(wsId, 'openCrossWindowStage', []),
+              receipt2 = await app.callMethod(wsId, 'openCrossWindowStage', ['demo-b-popup-2']);
+
+        expect(receipt1).toMatchObject({workspaceId: 'demo-b-popup'});
+        expect(receipt2).toMatchObject({workspaceId: 'demo-b-popup-2'});
+        expect(receipt2.windowId).not.toBe(receipt1.windowId);
+
+        // Two REAL render targets connected, each carrying its own workspace identity.
+        await expect.poll(() => page.context().pages().map(child => {
+            try {
+                return new URL(child.url()).searchParams.get('workspaceId')
+            } catch {
+                return null
+            }
+        }).filter(Boolean).sort(), {
+            message  : 'both popup windows must connect with their own workspace identity',
+            timeout  : 30000,
+            intervals: [100, 250]
+        }).toEqual(['demo-b-popup', 'demo-b-popup-2']);
+
+        // Every claimant exposes measurable claim geometry — the row-6 cell's executable surface.
+        for (const workspaceId of ['demo-b-main', 'demo-b-popup', 'demo-b-popup-2']) {
+            const geometry = await app.callMethod(wsId, 'measureWorkspaceGeometry', [workspaceId]);
+
+            expect(geometry?.zones?.length, `${workspaceId} must expose measurable claim zones`)
+                .toBeGreaterThanOrEqual(1)
+        }
+    });
+});

--- a/test/playwright/playwright.config.matrix.mjs
+++ b/test/playwright/playwright.config.matrix.mjs
@@ -41,6 +41,7 @@ export default defineConfig({
         '**/agentos/TearOutMatrixRows4To7NL.spec.mjs',
         '**/agentos/DemoBVesselConversionNL.spec.mjs',
         '**/agentos/DemoBCrossWindowDragNL.spec.mjs',
+        '**/agentos/DemoBThirdClaimantStageNL.spec.mjs',
         '**/agentos/FleetPermanenceMatrixRow4NL.spec.mjs'
     ],
     outputDir    : './test-results/matrix/artifacts',

--- a/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
+++ b/test/playwright/unit/apps/agentos/childapps/dockdemo/DemoBWorkspace.spec.mjs
@@ -1129,7 +1129,7 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
                 names   : ['demo-b-cross-window'],
                 windowId: workspace.windowId
             }]);
-            expect(workspace.workspaceSet.ids()).toEqual([DemoBWorkspace.MAIN_WORKSPACE_ID]);
+            expect(workspace.workspaceSet.ids()).toEqual([DemoBWorkspace.MAIN_WORKSPACE_ID, DemoBWorkspace.POPUP2_WORKSPACE_ID]);
             expect(workspace.getWorkspaceDocument(DemoBWorkspace.POPUP_WORKSPACE_ID)).toBeNull();
 
             // A later explicit stage is a new lifetime: registration is restored against the current
@@ -1889,6 +1889,117 @@ test.describe.serial('AgentOS.childapps.dockdemo.view.DemoBWorkspace', () => {
             tabsId     : 'side-tabs',
             workspaceId: DemoBWorkspace.MAIN_WORKSPACE_ID
         }])
+    });
+
+    test('construct registers three claim targets through the same workspace-set semantics', () => {
+        expect(workspace.workspaceSet.ids()).toEqual([
+            DemoBWorkspace.MAIN_WORKSPACE_ID,
+            DemoBWorkspace.POPUP_WORKSPACE_ID,
+            DemoBWorkspace.POPUP2_WORKSPACE_ID
+        ]);
+        expect(workspace.workspaceSet.getDocument(DemoBWorkspace.POPUP2_WORKSPACE_ID)).toBe(workspace.popup2Document);
+
+        // fail-closed re-registration mirrors popup-1's discipline
+        expect(workspace.ensurePopupWorkspaceRegistered(DemoBWorkspace.POPUP2_WORKSPACE_ID)).toBe(true);
+        expect(workspace.workspaceSet.getDocument(DemoBWorkspace.POPUP2_WORKSPACE_ID)).toBe(workspace.popup2Document)
+    });
+
+    test('the second popup stages through the same seams with its own continuation and window name', async () => {
+        const harness = installWindowConnectHarness(workspace);
+        let stageUrl, stageWindowName;
+
+        workspace.timeout = () => new Promise(() => {});
+        workspace.mountCrossWindowTarget = async (app, windowId, workspaceId) => {
+            const resolve = workspaceId === DemoBWorkspace.POPUP2_WORKSPACE_ID
+                ? workspace.crossWindowStage2Resolve
+                : workspace.crossWindowStageResolve;
+
+            resolve?.({hostId: 'workspace-host', windowId, workspaceId})
+        };
+        Neo.Main.windowOpen = async data => {
+            stageUrl        = data.url;
+            stageWindowName = data.windowName;
+            await harness.connect('workspace-2-child', stageUrl);
+            return true
+        };
+
+        try {
+            const receipt = await workspace.openCrossWindowStage(DemoBWorkspace.POPUP2_WORKSPACE_ID);
+
+            expect(receipt).toMatchObject({windowId: 'workspace-2-child', workspaceId: DemoBWorkspace.POPUP2_WORKSPACE_ID});
+            expect(stageWindowName).toBe('demo-b-cross-window-2');
+
+            const params = new URL(stageUrl, 'https://example.test').searchParams;
+
+            expect(params.get('workspaceId')).toBe('demo-b-popup-2');
+            expect(params.get('vesselFlow')).toBe('workspace-target');
+            expect(params.get('vesselGrant')).toBeTruthy();
+
+            // popup-1's stage continuation is untouched by the popup-2 stage
+            expect(workspace.crossWindowStagePromise).toBe(null);
+            expect(workspace.crossWindowStageResolve).toBe(null)
+        } finally {
+            harness.restore()
+        }
+    });
+
+    test('a second-popup disconnect retires only its own stage; the last popup retires the main participation', () => {
+        const participationOf = () => ({destroyed: false, destroy() { this.destroyed = true }}),
+              main            = participationOf(),
+              popup           = participationOf(),
+              popup2          = participationOf();
+
+        workspace.crossWindowTargetWindowId  = 'win-popup-1';
+        workspace.crossWindowTarget2WindowId = 'win-popup-2';
+        workspace.crossWindowHosts.set(DemoBWorkspace.POPUP_WORKSPACE_ID, {isDestroyed: false});
+        workspace.crossWindowHosts.set(DemoBWorkspace.POPUP2_WORKSPACE_ID, {isDestroyed: false});
+        workspace.crossWindowParticipations.set(DemoBWorkspace.MAIN_WORKSPACE_ID, main);
+        workspace.crossWindowParticipations.set(DemoBWorkspace.POPUP_WORKSPACE_ID, popup);
+        workspace.crossWindowParticipations.set(DemoBWorkspace.POPUP2_WORKSPACE_ID, popup2);
+        workspace.crossWindowGeometry.set(DemoBWorkspace.MAIN_WORKSPACE_ID, {});
+        workspace.crossWindowGeometry.set(DemoBWorkspace.POPUP_WORKSPACE_ID, {});
+        workspace.crossWindowGeometry.set(DemoBWorkspace.POPUP2_WORKSPACE_ID, {});
+        workspace.kbdLivePopup2 = Neo.create(Component, {});
+
+        // popup-2 leaves: its own stage retires; the staged sibling pair (main + popup-1) survives
+        workspace.onWindowDisconnect({windowId: 'win-popup-2'});
+
+        expect(popup2.destroyed).toBe(true);
+        expect(popup.destroyed).toBe(false);
+        expect(main.destroyed).toBe(false);
+        expect(workspace.crossWindowParticipations.has(DemoBWorkspace.POPUP2_WORKSPACE_ID)).toBe(false);
+        expect(workspace.crossWindowParticipations.has(DemoBWorkspace.MAIN_WORKSPACE_ID)).toBe(true);
+        expect(workspace.crossWindowTarget2WindowId).toBe(null);
+        expect(workspace.crossWindowTargetWindowId).toBe('win-popup-1');
+        expect(workspace.kbdLivePopup2).toBe(null);
+
+        // popup-1 leaves: no popup target remains, so the main participation retires with it
+        workspace.onWindowDisconnect({windowId: 'win-popup-1'});
+
+        expect(popup.destroyed).toBe(true);
+        expect(main.destroyed).toBe(true);
+        expect(workspace.crossWindowParticipations.has(DemoBWorkspace.MAIN_WORKSPACE_ID)).toBe(false);
+        expect(workspace.crossWindowTargetWindowId).toBe(null)
+    });
+
+    test('announceKeyboardOutcome carries the same terminal-derived truth into ALL staged windows', () => {
+        const popupLive  = Neo.create(Component, {}),
+              popup2Live = Neo.create(Component, {});
+
+        workspace.kbdLivePopup  = popupLive;
+        workspace.kbdLivePopup2 = popup2Live;
+        workspace.announceKeyboardOutcome({message: 'Workbench moved to Main window. Focus moved with it.'});
+
+        expect(workspace.getReference('kbd-live-b').text).toBe('Workbench moved to Main window. Focus moved with it.');
+        expect(popupLive.text).toBe('Workbench moved to Main window. Focus moved with it.');
+        expect(popup2Live.text).toBe('Workbench moved to Main window. Focus moved with it.');
+
+        // a destroyed popup-2 region degrades silently — the other regions still announce
+        popup2Live.destroy();
+        workspace.announceKeyboardOutcome({message: 'Move cancelled. Workbench stays where it is.'});
+
+        expect(workspace.getReference('kbd-live-b').text).toBe('Move cancelled. Workbench stays where it is.');
+        expect(popupLive.text).toBe('Move cancelled. Workbench stays where it is.')
     });
 
     test('destroy tears down the runner, seam, store, and every cached pane', () => {


### PR DESCRIPTION
Resolves #15591
Related: #15243

Demo B now exposes **three registered claim targets** through the same workspace-set registration semantics: `demo-b-main` + `demo-b-popup` + `demo-b-popup-2`. The row-6 arbitration cell (multi-window targeting / claim-protocol identity binding, measured through the merged G3 protocol of PR #15465) is now executable on macOS without any test-host simulation — the honest hole footnote ⁷ recorded is filled on the design's own terms: a second registered popup workspace, never a composition change, never a bespoke host.

Built ON the merged Phase-1 seam (PR #15617): the stage module parameterizes by workspace id — each popup gets its own host-owned stage continuation, target window id, native window name (`demo-b-cross-window-2`), document, registration lifetime, and kbd-live region, staged through the identical seams. The physical tear-out vessel stays a non-claimant by construction (AC2); G3/WorkspaceSet/Participation are untouched (AC4).

Evidence: L3 (headed matrix config 13/13 on this host, including the new three-target stage witness; full unit suite) → L3 required (every AC is a suite/live-stage item). Disclosure: 6 `unit-brain` memory-core specs fail on this host's live-agent env (env-var / live-service interference class) — reproduced on clean `dev` (`BootEnvelopeResolver` fails in isolation on dev); unrelated to this lane (apps-side only).

## Deltas from ticket
- Design (issuecomment-5024902539) held exactly; implemented on the extracted seam per the parameterization map (issuecomment-5025820435).
- Folded Vega's Phase-2 review nit (PR #15617): the module JSDoc now states the facade-routing rule explicitly (only spec-witnessed seams route through host facades).
- One spec expectation updated to the new three-registration truth (`workspaceSet.ids()` after popup-1's stack-return retirement keeps popup-2 — the intentional AC1 composition).
- Disconnect routing generalized honestly: a popup disconnect retires only its own stage; the main participation retires with the LAST popup target (popup-1-only behavior byte-identical).
- New witness `DemoBThirdClaimantStageNL.spec.mjs` registered in the headed matrix config's testMatch (its canonical home; the row-6 cell itself remains the matrix lane's).
- 4 new unit tests: three-target registration, popup-2 stage continuation/window-name, disconnect routing, all-window announce.

## Test Evidence
- `DemoBWorkspace.spec.mjs` → 51/51 (47 + 4 new)
- Headed matrix config, this host: 13/13 — `DemoBThirdClaimantStageNL` 1/1 (both popups staged via the same seams; three measurable claim geometries) · `DemoBCrossWindowDragNL` 3/3 · `DemoBVesselConversionNL` 1/1 · `TearOutMatrixRows4To7NL` 4/4 · `FleetPermanenceMatrixRow4NL` 1/1 · colors rows 1–3 3/3
- Full unit suite: 8843 passed (6 pre-existing `unit-brain` env-class failures reproduced on clean dev — see Evidence line)
- Pre-commit hooks green (block-alignment repair applied pre-commit)

## Post-Merge Validation
- [ ] Matrix lane retakes the row-6 cell against the three registered targets (macOS first), per the living ledger
- [ ] #15614 Phase 2 (gesture execution extraction) may now proceed against the parameterized seam

Authored by Phoebe (Kimi K3, OpenCode). Session dafc83a2-223d-4309-8298-e95f26bca960.