### PR TITLE
fix(agentos): detail-header background leak + quiet and contain dock rail tabs (#15632)

### DIFF
--- a/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
+++ b/resources/scss/src/apps/agentos/fleet/AgentDetail.scss
@@ -6,6 +6,12 @@
     padding: 10px 12px;
     overflow: hidden;
 
+    /* one continuous surface with the panel below — layout containers inside the detail
+       otherwise inherit Neo's stock dark container background, reading as mismatched boxes */
+    .neo-container {
+        background-color: transparent;
+    }
+
     /* honest empty state — muted, centered; never reads as a loaded-but-blank inspector */
     .fm-detail-empty {
         padding   : 24px 8px;

--- a/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
+++ b/resources/scss/src/apps/agentos/fleet/FleetCockpit.scss
@@ -3,6 +3,22 @@
 .fm-fleet-cockpit {
     background: var(--fm-ground);
 
+    /* the right-edge dock rail's tabs are NAVIGATION, not actions — the framework's primary
+       blue slab never reaches the rail (mirrors the workstation layer's treatment), and the
+       framework button min-width must not push the tab 34px past the viewport edge */
+    .neo-dashboard-dock-rail-tab.neo-button {
+        background: transparent;
+        border    : 0;
+        box-shadow: none;
+        color     : var(--fm-ink-dim);
+        min-width : 0;
+
+        .neo-button-glyph,
+        .neo-button-text {
+            color: inherit;
+        }
+    }
+
     .fm-cockpit-bar {
         flex   : none;
         padding: 6px 10px;


### PR DESCRIPTION
Resolves #15632

Round 2 of the film-floor arc (operator gallery review, both findings V-B-A'd live with computed styles):

1. **Detail-header background leak** — `.fm-detail-header` computed `rgb(14, 15, 13)` (Neo stock container background) while the detail panel below is transparent, reading as a mismatched darker box. Same glitch class as #15629's card containers, in the sibling component. Fixed at the component root (`.fm-agent-detail .neo-container { background-color: transparent }`) — header now computes `rgba(0,0,0,0)` (verified live).

2. **Dock rail tabs loud + overflowing** — `.neo-dashboard-dock-rail-tab` buttons wore the framework's primary button chrome (`rgb(62, 99, 221)`) and, forced by the framework button `min-width`, sat 37px past the 1600px viewport edge (`left: 1589`, width 48). Fixed in the FM layer only (`src/dashboard/Container.scss` stays consumer-neutral): workstation-precedent quiet treatment (transparent, no border, `--fm-ink-dim`) + `min-width: 0` — tabs now compute `rgba(0,0,0,0)` and measure `right: 1595`, fully inside the viewport (verified live).

Evidence: L3 (343 fleet unit specs green; synthesis e2e green; live computed-style verification of both fixes) → L3 required (ACs are render/suite items). No residuals.

## Deltas from ticket
- The rail-tab fix lands the quiet treatment AND the `min-width: 0` containment in one FM-scoped rule (the two defects shared one selector).

## Test Evidence
- `test/playwright/unit/apps/agentos/view/fleet/` — 343/343 green
- `AgentCardSynthesisRenderNL` e2e — green (baselines unchanged; no card-surface pixels touched)
- Live verification: `.fm-detail-header` → `rgba(0,0,0,0)`; rail tabs → `rgba(0,0,0,0)`, `right: 1595` at 1600px viewport
- Gallery + pop-out composite re-shot post-fix for the Devpost gallery

## Post-Merge Validation
- [ ] Emmy's recapture shows one continuous detail surface and a quiet right-edge rail
- [ ] Devpost gallery images 03/05 carry the fixed surfaces

Authored by Phoebe (Kimi K3, OpenCode). Session 86adbb95-6d48-4071-8d93-b2355d320a97.
