### PR TITLE
fix(component): null-safe FileUpload URL hooks for documented-optional configs (#15637)

### DIFF
--- a/src/form/field/FileUpload.mjs
+++ b/src/form/field/FileUpload.mjs
@@ -783,11 +783,17 @@ class FileUpload extends Field {
 
     /**
      * Creates a URL substituting the passed parameter names in at the places where the name
-     * occurs within `{}` in the pattern.
+     * occurs within `{}` in the pattern. A null or absent pattern passes through unchanged,
+     * so documented-optional URL configs (status / delete / download) stay inert instead of
+     * crashing on `replace`.
      * @param {String} urlPattern
      * @param {Object} params
      */
     createUrl(urlPattern, params) {
+        if (urlPattern == null) {
+            return urlPattern
+        }
+
         for (const paramName in params) {
             urlPattern = urlPattern.replace(`{${paramName}}`, params[paramName]);
         }
@@ -801,7 +807,7 @@ class FileUpload extends Field {
     beforeGetDocumentStatusUrl(documentStatusUrl) {
         const me = this;
 
-        return typeof documentStatusUrl === 'function'? documentStatusUrl.call(me, me) : me.createUrl(documentStatusUrl, {
+        return typeof documentStatusUrl === 'function'? documentStatusUrl.call(me, me) : documentStatusUrl && me.createUrl(documentStatusUrl, {
             [me.documentIdParameter] : me.documentId
         });
     }
@@ -809,7 +815,7 @@ class FileUpload extends Field {
     beforeGetDocumentDeleteUrl(documentDeleteUrl) {
         const me = this;
 
-        return typeof documentDeleteUrl === 'function'? documentDeleteUrl.call(me, me) : me.createUrl(documentDeleteUrl, {
+        return typeof documentDeleteUrl === 'function'? documentDeleteUrl.call(me, me) : documentDeleteUrl && me.createUrl(documentDeleteUrl, {
             [me.documentIdParameter] : me.documentId
         });
     }
@@ -817,7 +823,7 @@ class FileUpload extends Field {
     beforeGetDownloadUrl(downloadUrl) {
         const me = this;
 
-        return typeof downloadUrl === 'function'? downloadUrl.call(me, me) : me.createUrl(downloadUrl, {
+        return typeof downloadUrl === 'function'? downloadUrl.call(me, me) : downloadUrl && me.createUrl(downloadUrl, {
             [me.documentIdParameter] : me.documentId
         });
     }

--- a/test/playwright/unit/form/field/FileUpload.spec.mjs
+++ b/test/playwright/unit/form/field/FileUpload.spec.mjs
@@ -1,0 +1,76 @@
+import {setup} from '../../../setup.mjs';
+
+setup({appConfig: {appName: 'TestApp'}});
+
+import Neo            from '../../../../../src/Neo.mjs';
+import * as core      from '../../../../../src/core/_export.mjs';
+import {test, expect} from '@playwright/test';
+import FileUpload     from '../../../../../src/form/field/FileUpload.mjs';
+
+test.describe('FileUpload documented-optional URL configs', () => {
+    test('null URL configs pass through the beforeGet hooks without throwing', () => {
+        let instance = Neo.create(FileUpload, {
+            appName  : 'TestApp',
+            uploadUrl: '/upload'
+        });
+
+        expect(instance.documentStatusUrl).toBeNull();
+        expect(instance.documentDeleteUrl).toBeNull();
+        expect(instance.downloadUrl).toBeNull();
+
+        instance.destroy()
+    });
+
+    test('createUrl passes nullish patterns through unchanged', () => {
+        let instance = Neo.create(FileUpload, {
+            appName  : 'TestApp',
+            uploadUrl: '/upload'
+        });
+
+        expect(instance.createUrl(null, {documentId: 1})).toBeNull();
+        expect(instance.createUrl(undefined, {documentId: 1})).toBeUndefined();
+        expect(instance.createUrl('/documents/{documentId}', {documentId: 42})).toBe('/documents/42');
+
+        instance.destroy()
+    });
+
+    test('an upload-only field reaches downloadable on success without throwing', () => {
+        let instance = Neo.create(FileUpload, {
+            appName  : 'TestApp',
+            uploadUrl: '/upload'
+        });
+
+        expect(() => instance.onUploadDone({
+            loaded: 100,
+            target: {
+                status  : 200,
+                response: JSON.stringify({success: true, documentId: 42})
+            }
+        })).not.toThrow();
+
+        expect(instance.documentId).toBe(42);
+        expect(instance.state).toBe('downloadable');
+
+        instance.destroy()
+    });
+
+    test('configured URLs keep token substitution and the function form', () => {
+        let calls    = [],
+            instance = Neo.create(FileUpload, {
+                appName          : 'TestApp',
+                documentDeleteUrl: '/documents/{documentId}',
+                documentStatusUrl: () => '/status/fn',
+                uploadUrl        : '/upload'
+            });
+
+        instance.documentId = 7;
+
+        expect(instance.documentDeleteUrl).toBe('/documents/7');
+        expect(instance.documentStatusUrl).toBe('/status/fn');
+
+        instance.documentId = null;
+        expect(instance.documentDeleteUrl).toBe('/documents/null');
+
+        instance.destroy()
+    });
+});


### PR DESCRIPTION
Resolves #15637

A FileUpload configured with only `uploadUrl` no longer crashes after a successful upload: the three `beforeGet*Url` hooks and `createUrl` itself now pass null/undefined URL patterns through unchanged, so the documented-optional `documentStatusUrl` / `documentDeleteUrl` / `downloadUrl` configs stay inert instead of throwing `Cannot read properties of null (reading 'replace')` — the failure previously fired after the server had already stored the file.

Evidence: L1 (static + unit proof) → L1 required (Body form-field change, no runtime/CI-unreachable surfaces).

## Deltas from ticket

Added a second guard layer: the ticket scoped the three `beforeGet*Url` hooks; `createUrl` itself is now null-safe too, because `afterSetState('downloadable')` calls `createUrl(me.downloadUrl, …)` directly — hook-only guards would still crash on that path (the AC's "reaches downloadable without throwing" requires it).

## Test Evidence

- New `test/playwright/unit/form/field/FileUpload.spec.mjs` (4 specs): null pass-through on all three hooks, `createUrl` nullish pass-through + substitution sanity, upload-only field reaches `downloadable` without throwing, configured URLs keep token substitution + function form.
- Full unit suite: `npx playwright test -c test/playwright/playwright.config.unit.mjs` → 8828 passed, 0 failed.
- Example app `examples/form/field/fileupload/` — untouched; existing configured-URL behavior preserved (substitution + function-form spec).

## Post-Merge Validation

- [ ] `examples/form/field/fileupload/` journey remains green in CI.

Authored by Phoebe (Kimi K3, OpenCode). Session d8a51237-4fcc-4171-8071-a391da0be361.