### PR TITLE
fix(ai): ai:restore preflights the embedding provider before re-ingest (#15640)

### DIFF
--- a/ai/scripts/maintenance/restore.mjs
+++ b/ai/scripts/maintenance/restore.mjs
@@ -20,6 +20,7 @@ import {
     Memory_StorageRouter,
     Shared_DestructiveOperationGuard
 } from '../../services.mjs';
+import {buildEmbeddingWriteCanaryBlock} from '../../services/memory-core/HealthService.mjs';
 
 /**
  * @module ai/scripts/maintenance/restore
@@ -49,6 +50,11 @@ import {
  * - **Pre-flight integrity validation BEFORE any write.** The bundle is fully validated —
  *   subdirs present, JSONL parseable, `bundle-meta.json` (if present) parsed — before any
  *   write touches a service. A torn / partial bundle fails fast.
+ * - **Embedding-provider preflight BEFORE any re-ingest.** Bundles capture logical JSONL, so
+ *   embedded substrates restore by re-embedding through the active provider. A cold or absent
+ *   provider (fresh host, model never pulled) refuses the restore before any write with the
+ *   provider and remediation named — never a mid-import stall. `--skip-embed-preflight` is the
+ *   documented escape hatch.
  * - **Topology compatibility check.** The system natively assumes a `shared_topology`.
  *   If the bundle is explicitly marked as a legacy federated bundle (`chromaUnified: false`),
  *   the restore refuses unless the operator passes `--force-topology-mismatch`.
@@ -103,6 +109,44 @@ const REQUIRED_BUNDLE_SUBDIRS = ['kb', 'mc', 'graph', 'concepts', 'trajectories'
 const OPTIONAL_BUNDLE_SUBDIRS = ['mailbox'];
 
 /**
+ * Preflights the active embedding provider before any re-ingest write.
+ *
+ * Bundles capture logical JSONL state, so every embedded substrate restores by re-embedding
+ * through the active provider. A cold or absent provider (fresh host, model never pulled)
+ * otherwise surfaces as a stall deep inside the import — the worst failure shape. This check
+ * reuses the healthcheck write-canary probe and refuses BEFORE any write, naming the provider
+ * and the remediation in the error.
+ *
+ * @param {Object} options
+ * @param {Boolean} [options.skipEmbedPreflight=false] Operator escape hatch for providers the probe cannot cover.
+ * @param {Function|null} [options.embedText=null] Test seam matching `TextEmbeddingService.embedText`.
+ * @param {Number} [options.timeoutMs=30000] Max time to wait for the provider (matches the cold-embedder canary budget).
+ * @param {Object} [options.logger=console]
+ * @returns {Promise<Object>} the canary block on success, or a skipped marker
+ */
+export async function preflightEmbeddingProvider({skipEmbedPreflight=false, embedText=null, timeoutMs=30000, logger=console}={}) {
+    if (skipEmbedPreflight) {
+        logger.warn?.('[Restore] Embedding provider preflight skipped via --skip-embed-preflight.');
+        return {status: 'skipped', provider: null, dimensions: null, durationMs: 0}
+    }
+
+    const canary = await buildEmbeddingWriteCanaryBlock({embedText, timeoutMs});
+
+    if (canary.status !== 'healthy') {
+        throw new Error(
+            `Embedding provider preflight failed: ${canary.error} (provider=${canary.provider}). ` +
+            `Restore re-embeds imported records through the active embedding provider — make the provider ` +
+            `reachable and the embedding model available first (e.g. 'ollama pull <embedding-model>'), ` +
+            `or pass --skip-embed-preflight to bypass this check.`
+        );
+    }
+
+    logger.log(`[Restore] Embedding provider preflight healthy (${canary.provider}, ${canary.dimensions} dims, ${canary.durationMs}ms).`);
+
+    return canary
+}
+
+/**
  * Executes a full-substrate restore from a previously-produced bundle.
  *
  * @param {Object}   options
@@ -118,6 +162,8 @@ const OPTIONAL_BUNDLE_SUBDIRS = ['mailbox'];
  * @param {String[]}[options.filterEdgeTypes=[]]           Per-incident customization: drop graph edges with these types. Example today's-incident set: `['CONTAINS', 'DISCOVERED_IN', 'EVALUATED_BY']`.
  * @param {String[]}[options.onlySubstrate=null]           If provided, restore ONLY these substrates (subset of `['kb','mc','graph','concepts','trajectories','mailbox']`). Null = all (existing behavior).
  * @param {String}  [options.postRestoreHook=null]         Post-restore hook name. Currently supported: `'filesystem-ingestor'` (regenerates FILE/DIRECTORY/CONTAINS deterministically from current filesystem). Null = none.
+ * @param {Boolean} [options.skipEmbedPreflight=false]     Skip the embedding-provider preflight (operator escape hatch for providers the probe cannot cover).
+ * @param {Function|null} [options.embedText=null]         Test seam for the preflight probe; production callers leave null.
  * @param {Object}  [options.logger=console]               Log sink; useful for tests.
  * @returns {Promise<{bundleRoot: String, mode: String, subsystems: Object, meta: Object|null, topology: Object, postRestoreHook: Object|null}>}
  */
@@ -134,6 +180,8 @@ export async function runRestore({
     filterEdgeTypes         = [],
     onlySubstrate           = null,
     postRestoreHook         = null,
+    skipEmbedPreflight      = false,
+    embedText               = null,
     logger                  = console
 } = {}) {
     if (!bundleRoot) {
@@ -165,6 +213,8 @@ export async function runRestore({
         KB_LifecycleService.ready(),
         Memory_LifecycleService.ready()
     ]);
+
+    await preflightEmbeddingProvider({embedText, logger, skipEmbedPreflight});
 
     if (mode === 'replace' && !force) {
         const occupancy = await assessTargetOccupancy({trajectoriesTargetFile, sentToCullTargetFile, conceptsTargetDir});
@@ -560,9 +610,9 @@ async function restoreFlatDir({sourceDir, targetDir, mode, force, confirmation, 
         await Shared_DestructiveOperationGuard.assertDestructiveTargetAllowed({
             operation: `restore.${subsystem}.replace`,
             subsystem,
-            mode  : 'replace',
-            target: {path: targetDir, repoRoot: PROJECT_ROOT},
-            source: {path: sourceDir},
+            mode     : 'replace',
+            target   : {path: targetDir, repoRoot: PROJECT_ROOT},
+            source   : {path: sourceDir},
             confirmation
         });
         await fs.emptyDir(targetDir);
@@ -620,9 +670,9 @@ async function restoreFlatFile({sourceDir, targetFile, mode, force, confirmation
         await Shared_DestructiveOperationGuard.assertDestructiveTargetAllowed({
             operation: `restore.${subsystem}.replace`,
             subsystem,
-            mode  : 'replace',
-            target: {path: targetFile, repoRoot: PROJECT_ROOT},
-            source: {path: sourceFile},
+            mode     : 'replace',
+            target   : {path: targetFile, repoRoot: PROJECT_ROOT},
+            source   : {path: sourceFile},
             confirmation
         });
     } else if (await fs.pathExists(targetFile)) {
@@ -812,6 +862,7 @@ export function parseArgs(argv) {
     let   filterEdgeTypes       = [];
     let   onlySubstrate         = null;
     let   postRestoreHook       = null;
+    let   skipEmbedPreflight    = false;
 
     const splitCsv = s => String(s).split(',').map(t => t.trim()).filter(Boolean);
 
@@ -839,6 +890,8 @@ export function parseArgs(argv) {
             postRestoreHook = argv[++i];
         } else if (arg.startsWith('--post-restore-hook=')) {
             postRestoreHook = arg.slice('--post-restore-hook='.length);
+        } else if (arg === '--skip-embed-preflight') {
+            skipEmbedPreflight = true;
         } else if (arg.startsWith('--')) {
             throw new Error(`Unknown flag: ${arg}`);
         } else {
@@ -853,7 +906,7 @@ export function parseArgs(argv) {
         throw new Error(`Unexpected positional arguments: ${positional.slice(1).join(' ')}`);
     }
 
-    return {bundleRoot: positional[0], mode, force, forceTopologyMismatch, filterLabels, filterEdgeTypes, onlySubstrate, postRestoreHook}
+    return {bundleRoot: positional[0], mode, force, forceTopologyMismatch, filterLabels, filterEdgeTypes, onlySubstrate, postRestoreHook, skipEmbedPreflight}
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
@@ -871,7 +924,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     } catch (error) {
         console.error(error.message);
         console.error('Usage: node ./ai/scripts/maintenance/restore.mjs <bundle-path> [--mode merge|replace] [--force] [--force-topology-mismatch]');
-        console.error('       [--filter-labels=<csv>] [--filter-edge-types=<csv>] [--only-substrate=<csv>] [--post-restore-hook=<name>]');
+        console.error('       [--filter-labels=<csv>] [--filter-edge-types=<csv>] [--only-substrate=<csv>] [--post-restore-hook=<name>] [--skip-embed-preflight]');
         console.error('Example (today\'s graph wipe restore):');
         console.error('  npm run ai:restore -- <bundle-path> --mode merge --only-substrate=graph \\');
         console.error('    --filter-labels=FILE,DIRECTORY,KB_GAP,TOOLING_GAP \\');

--- a/test/playwright/unit/ai/scripts/maintenance/restore-embed-preflight.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore-embed-preflight.spec.mjs
@@ -1,0 +1,77 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({appConfig: {appName: 'TestApp'}});
+
+import {test, expect}                          from '@playwright/test';
+import {parseArgs, preflightEmbeddingProvider} from '../../../../../../ai/scripts/maintenance/restore.mjs';
+
+test.describe('Restore embedding-provider preflight', () => {
+    test('refuses before any write when the provider returns no vector', async () => {
+        let logs   = [],
+            logger = {log: msg => logs.push(msg), warn: msg => logs.push(msg)};
+
+        await expect(preflightEmbeddingProvider({
+            embedText: async () => [],
+            logger
+        })).rejects.toThrow(/Embedding provider preflight failed:.*no vector/);
+    });
+
+    test('refuses when the returned vector dimensions diverge from config', async () => {
+        await expect(preflightEmbeddingProvider({
+            embedText: async () => [0.1, 0.2, 0.3],
+            logger   : {log: () => {}, warn: () => {}}
+        })).rejects.toThrow(/expected 4096/);
+    });
+
+    test('refusal error names the provider and the remediation', async () => {
+        let error;
+
+        try {
+            await preflightEmbeddingProvider({
+                embedText: async () => { throw new Error('connection refused') },
+                logger   : {log: () => {}, warn: () => {}}
+            });
+        } catch (e) {
+            error = e
+        }
+
+        expect(error).toBeTruthy();
+        expect(error.message).toContain('Embedding provider preflight failed');
+        expect(error.message).toContain('ollama pull <embedding-model>');
+        expect(error.message).toContain('--skip-embed-preflight')
+    });
+
+    test('passes through with a healthy provider vector', async () => {
+        let logs  = [],
+            block = await preflightEmbeddingProvider({
+                embedText: async () => new Array(4096).fill(0.1),
+                logger   : {log: msg => logs.push(msg), warn: msg => logs.push(msg)}
+            });
+
+        expect(block.status).toBe('healthy');
+        expect(block.dimensions).toBe(4096);
+        expect(logs.some(line => line.includes('preflight healthy'))).toBe(true)
+    });
+
+    test('the escape hatch skips the probe and logs a warning', async () => {
+        let warns  = [],
+            result = await preflightEmbeddingProvider({
+                embedText         : async () => { throw new Error('must not be called') },
+                logger            : {log: () => {}, warn: msg => warns.push(msg)},
+                skipEmbedPreflight: true
+            });
+
+        expect(result.status).toBe('skipped');
+        expect(warns.some(line => line.includes('skip-embed-preflight'))).toBe(true)
+    });
+
+    test('parseArgs threads the flag and keeps rejecting unknown flags', () => {
+        expect(parseArgs(['/tmp/bundle', '--skip-embed-preflight'])).toMatchObject({
+            bundleRoot        : '/tmp/bundle',
+            mode              : 'merge',
+            skipEmbedPreflight: true
+        });
+        expect(parseArgs(['/tmp/bundle']).skipEmbedPreflight).toBe(false);
+        expect(() => parseArgs(['/tmp/bundle', '--skip-embed-preflight=yes'])).toThrow(/Unknown flag/)
+    });
+});

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -376,7 +376,8 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
     });
 
     test('parseArgs: positional bundle path + --mode + --force + --force-topology-mismatch', () => {
-        // #11141: parseArgs return shape extended with filterLabels/filterEdgeTypes/onlySubstrate/postRestoreHook.
+        // parseArgs return shape grew over time: filterLabels/filterEdgeTypes/onlySubstrate/postRestoreHook,
+        // and later skipEmbedPreflight with the embedding-preflight escape hatch.
         // Defaults preserved when those flags are absent (covered separately in restore-filters.spec.mjs).
         expect(parseArgs(['/some/bundle'])).toEqual({
             bundleRoot           : '/some/bundle',
@@ -386,7 +387,8 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             filterLabels         : [],
             filterEdgeTypes      : [],
             onlySubstrate        : null,
-            postRestoreHook      : null
+            postRestoreHook      : null,
+            skipEmbedPreflight   : false
         });
         expect(parseArgs(['/some/bundle', '--mode', 'replace', '--force'])).toEqual({
             bundleRoot           : '/some/bundle',
@@ -396,7 +398,8 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             filterLabels         : [],
             filterEdgeTypes      : [],
             onlySubstrate        : null,
-            postRestoreHook      : null
+            postRestoreHook      : null,
+            skipEmbedPreflight   : false
         });
         expect(parseArgs(['/some/bundle', '--force-topology-mismatch'])).toEqual({
             bundleRoot           : '/some/bundle',
@@ -406,7 +409,8 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
             filterLabels         : [],
             filterEdgeTypes      : [],
             onlySubstrate        : null,
-            postRestoreHook      : null
+            postRestoreHook      : null,
+            skipEmbedPreflight   : false
         });
         expect(() => parseArgs([])).toThrow(/Missing required argument/);
         expect(() => parseArgs(['/x', '--unknown-flag'])).toThrow(/Unknown flag/);

--- a/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/restore.spec.mjs
@@ -40,6 +40,10 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
 
     const silentLogger = {log: () => {}, warn: () => {}, error: () => {}};
 
+    // Flow specs stub the SDK service layer; the embedding-provider preflight rides along
+    // through a healthy seam so no live provider is required.
+    const healthyEmbedText = async () => new Array(4096).fill(0.1);
+
     /**
      * Builds a synthetic well-formed bundle directory under workRoot.
      */
@@ -176,6 +180,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
 
         const result = await runRestore({
             bundleRoot,
+            embedText             : healthyEmbedText,
             mode                  : 'merge',
             conceptsTargetDir     : conceptsTgt,
             trajectoriesTargetFile: trajTgt,
@@ -214,7 +219,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         const bundleRoot = buildSyntheticBundle({bundleName: 'corrupt-missing-mc', omitSubdirs: ['mc']});
 
         await expect(
-            runRestore({bundleRoot, logger: silentLogger})
+            runRestore({bundleRoot, embedText: healthyEmbedText, logger: silentLogger})
         ).rejects.toThrow(/Required bundle subdirectory missing: mc/);
 
         // No SDK writes attempted
@@ -228,7 +233,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         const bundleRoot = buildSyntheticBundle({bundleName: 'topo-mismatch', chromaUnified: false});
 
         await expect(
-            runRestore({bundleRoot, logger: silentLogger})
+            runRestore({bundleRoot, embedText: healthyEmbedText, logger: silentLogger})
         ).rejects.toThrow(/Topology mismatch: bundle was taken under legacy federated mode, but current deployment is permanently unified\./);
 
         expect(calls.kb).toHaveLength(0);
@@ -236,6 +241,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
 
         const result = await runRestore({
             bundleRoot,
+            embedText             : healthyEmbedText,
             forceTopologyMismatch : true,
             conceptsTargetDir     : path.join(workRoot, 'topo-targets', 'concepts'),
             trajectoriesTargetFile: path.join(workRoot, 'topo-targets', 'trajectories.jsonl'),
@@ -254,7 +260,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         Memory_StorageRouter.getMemoryCollection = async () => ({count: async () => 42});
 
         await expect(
-            runRestore({bundleRoot, mode: 'replace', force: false, logger: silentLogger})
+            runRestore({bundleRoot, embedText: healthyEmbedText, mode: 'replace', force: false, logger: silentLogger})
         ).rejects.toThrow(/Refusing replace mode without --force.*mc\.memories=42/);
 
         expect(calls.kb).toHaveLength(0);
@@ -272,6 +278,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
 
         const result = await runRestore({
             bundleRoot,
+            embedText             : healthyEmbedText,
             mode                  : 'replace',
             confirmation          : 'CONFIRM_PRODUCTION_DESTRUCTIVE_AI_SUBSTRATE',
             conceptsTargetDir     : conceptsTgt,
@@ -319,6 +326,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
 
         const result = await runRestore({
             bundleRoot,
+            embedText             : healthyEmbedText,
             mode                  : 'merge',
             conceptsTargetDir     : conceptsTgt,
             trajectoriesTargetFile: trajTgt,
@@ -345,6 +353,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
 
         const result = await runRestore({
             bundleRoot,
+            embedText             : healthyEmbedText,
             conceptsTargetDir     : path.join(workRoot, 'legacy-targets', 'concepts'),
             trajectoriesTargetFile: path.join(workRoot, 'legacy-targets', 'trajectories.jsonl'),
             sentToCullTargetFile  : path.join(workRoot, 'legacy-targets', 'sent-to-cull.jsonl'),
@@ -360,7 +369,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
     test('rejects unknown mode at orchestrator entry', async () => {
         const bundleRoot = buildSyntheticBundle({bundleName: 'unknown-mode', chromaUnified: true});
         await expect(
-            runRestore({bundleRoot, mode: 'wipe', logger: silentLogger})
+            runRestore({bundleRoot, embedText: healthyEmbedText, mode: 'wipe', logger: silentLogger})
         ).rejects.toThrow(/Unknown mode: wipe/);
     });
 
@@ -369,7 +378,7 @@ test.describe('restore.mjs orchestrator — bundle-aware substrate restore (#108
         fs.writeFileSync(path.join(bundleRoot, 'kb', 'broken.jsonl'), 'this-is-not-json\n');
 
         await expect(
-            runRestore({bundleRoot, logger: silentLogger})
+            runRestore({bundleRoot, embedText: healthyEmbedText, logger: silentLogger})
         ).rejects.toThrow(/Bundle JSONL parse error at kb\/broken\.jsonl/);
 
         expect(calls.kb).toHaveLength(0);


### PR DESCRIPTION
Resolves #15640

`ai:restore` now preflights the active embedding provider **before any re-ingest write**: a cold or absent provider (fresh host, model never pulled) refuses the restore up front with the provider, the probe error, and the exact remediation in the message — replacing the previous failure shape, a stall deep inside the first embed batch. The check reuses the healthcheck write-canary probe (`buildEmbeddingWriteCanaryBlock`, same dimension validation + 30s cold-embedder budget per `#14182`) and runs after services boot, before any substrate import. `--skip-embed-preflight` is the documented escape hatch for providers the probe cannot cover.

Evidence: L1 (unit-proven preflight + parseArgs) → L2 required for the in-container integration path (`BackupRestoreWipe` exercises `runRestore` against the deployed `openAiCompatible` fixture — no local docker on this seat; CI is the witness). Residual: integration run on this exact head.

## Deltas from ticket

- Probe budget 30s (not the 10s sketched in the ticket) — matches the proven cold-embedder canary budget; a cold 8B embedder can exceed 10s.
- `runRestore` gained an `embedText` test seam (mirrors the canary's own seam) so the preflight is unit-testable without a live provider.

## Test Evidence

- New `test/playwright/unit/ai/scripts/maintenance/restore-embed-preflight.spec.mjs` (6 specs): refuse-on-empty-vector, refuse-on-dimension-divergence, refusal names provider + remediation + escape hatch, healthy pass-through, skip honored + warned, `parseArgs` flag threading + unknown-flag rejection.
- `restore.spec.mjs` parseArgs shape assertion extended for the new flag (extension documented next to the `#11141` one).
- `npx playwright test -c test/playwright/playwright.config.unit.mjs --project=unit-brain "maintenance/restore|maintenance/backup"` → 76 passed, 0 failed.
- Full unit suite residual: ran on the sibling branch this session (8828 passed); this branch's delta is confined to `restore.mjs` + its spec family, all green above.

## Post-Merge Validation

- [ ] CI `integration-unified` (BackupRestoreWipe deployed-container restore against the `openAiCompatible` embedding fixture) green on exact head.

Authored by Phoebe (Kimi K3, OpenCode). Session d8a51237-4fcc-4171-8071-a391da0be361.