### PR TITLE
chore(component): drop redundant FileUpload hook guards — single null-safety point (#15637)

### DIFF
--- a/src/form/field/FileUpload.mjs
+++ b/src/form/field/FileUpload.mjs
@@ -807,7 +807,7 @@ class FileUpload extends Field {
     beforeGetDocumentStatusUrl(documentStatusUrl) {
         const me = this;
 
-        return typeof documentStatusUrl === 'function'? documentStatusUrl.call(me, me) : documentStatusUrl && me.createUrl(documentStatusUrl, {
+        return typeof documentStatusUrl === 'function'? documentStatusUrl.call(me, me) : me.createUrl(documentStatusUrl, {
             [me.documentIdParameter] : me.documentId
         });
     }
@@ -815,7 +815,7 @@ class FileUpload extends Field {
     beforeGetDocumentDeleteUrl(documentDeleteUrl) {
         const me = this;
 
-        return typeof documentDeleteUrl === 'function'? documentDeleteUrl.call(me, me) : documentDeleteUrl && me.createUrl(documentDeleteUrl, {
+        return typeof documentDeleteUrl === 'function'? documentDeleteUrl.call(me, me) : me.createUrl(documentDeleteUrl, {
             [me.documentIdParameter] : me.documentId
         });
     }
@@ -823,7 +823,7 @@ class FileUpload extends Field {
     beforeGetDownloadUrl(downloadUrl) {
         const me = this;
 
-        return typeof downloadUrl === 'function'? downloadUrl.call(me, me) : downloadUrl && me.createUrl(downloadUrl, {
+        return typeof downloadUrl === 'function'? downloadUrl.call(me, me) : me.createUrl(downloadUrl, {
             [me.documentIdParameter] : me.documentId
         });
     }


### PR DESCRIPTION
Resolves #15637

Post-merge review follow-through on #15642 (Vega's non-blocking SSOT note): the three `beforeGet*Url` hook-level `&&` guards are redundant with the `createUrl` chokepoint null-guard — `createUrl(null, …)` returns null without throwing, so the hooks need no local guard. One null-safety point instead of two; zero behavior change.

Evidence: L1 (unit proof) → L1 required (3-line revert; micro-change per §6.1).

## Deltas from ticket

This is the SSOT simplification Vega's review marked optional — the null case now flows solely through the `createUrl` guard; spec 1 (null configs pass through) and spec 3 (upload-only reaches `downloadable`) both still prove the behavior.

## Test Evidence

- `npx playwright test -c test/playwright/playwright.config.unit.mjs form/field/FileUpload` → 5 passed.

## Post-Merge Validation

- [ ] CI green on exact head.

Authored by Phoebe (Kimi K3, OpenCode). Session d8a51237-4fcc-4171-8071-a391da0be361.