### PR TITLE
fix(dashboard): keep dock rail tabs intrinsic (#15655)

### DIFF
--- a/src/dashboard/DockRail.mjs
+++ b/src/dashboard/DockRail.mjs
@@ -325,6 +325,11 @@ class DockRail extends Container {
      * Builds one rail-tab button config from rail-item metadata. The button carries its
      * `dockItemId` (instance-based click/hover resolution — no id bookkeeping) and stays enabled
      * regardless of policy: reveal is policy-free, the overlay pin is the gated affordance.
+     *
+     * Tabs are intrinsic on the rail's main axis. The rail keeps `align: 'stretch'` for the cross
+     * axis, but that generic Flexbox policy otherwise supplies `flex: 1` to children without an
+     * explicit value, making every tab divide the full edge extent equally. This value must be in
+     * the creation config so the parent layout consumes it during its child-attribute pass.
      * @param {Object} railItem {dockEdge, dockItemId, restorable, title}
      * @param {String} edge
      * @returns {Object}
@@ -341,6 +346,7 @@ class DockRail extends Container {
                 {mouseenter: me.onTabHoverIn,  scope: me},
                 {mouseleave: me.onTabHoverOut, scope: me}
             ],
+            flex           : 'none',
             // Explicitly bound: the button invokes function-type handlers as plain calls — the
             // rail, not the button, must be `this` inside the handler.
             handler        : me.onTabClick.bind(me),

--- a/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
@@ -46,6 +46,43 @@ const tuckInspector = async ({ app, holderId, page }) => {
     await page.waitForTimeout(1000)
 };
 
+/**
+ * @summary Builds one real projected rail on every edge, with two auto-hidden items apiece. The
+ * center item keeps the edge-zone document renderable while every edge band exercises the same
+ * adapter path production workspaces use.
+ * @returns {Object}
+ */
+const createFourEdgeRailDocument = () => {
+    const
+        items = {
+            center: {componentRef: 'Center', title: 'Center', kind: 'panel'}
+        },
+        nodes = {
+            root         : {type: 'edge-zone', zones: {center: 'center-tabs'}},
+            'center-tabs': {type: 'tabs', items: ['center'], activeItemId: 'center'}
+        };
+
+    for (const edge of ['top', 'right', 'bottom', 'left']) {
+        const itemIds = [`${edge}-one`, `${edge}-two`];
+
+        itemIds.forEach((itemId, index) => {
+            items[itemId] = {
+                autoHidden  : true,
+                componentRef: `${edge}-${index + 1}`,
+                kind        : 'panel',
+                pinnable    : true,
+                pinned      : false,
+                title       : `${edge[0].toUpperCase()}${edge.slice(1)} ${index + 1}`
+            }
+        });
+
+        nodes[`${edge}-tabs`] = {type: 'tabs', items: itemIds, activeItemId: itemIds[0]};
+        nodes.root.zones[edge] = `${edge}-tabs`
+    }
+
+    return {schema: 'neo.harness.dockZone.v1', root: 'root', items, nodes}
+};
+
 test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
     test.setTimeout(90000);
     test.use({ viewport: { width: 1600, height: 900 } });
@@ -128,8 +165,9 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
         const railId        = Array.isArray(railInstances) ? railInstances[0]?.id : railInstances?.id;
         await app.setProperties(railId, { autoHideRevealOnHover: true, revealDismissGraceMs: 400, revealDwellMs: 100 });
 
-        const railBox = await railTab.boundingBox();
-        await page.mouse.move(railBox.x + railBox.width / 2, railBox.y + railBox.height / 2);
+        // Target Playwright's visible actionability point. At a clipped viewport edge, the raw DOM
+        // center can sit outside the viewport even though the rendered rail affordance is visible.
+        await railTab.hover();
         await page.waitForTimeout(350); // > dwell
         await expect(overlay, 'opt-in hover must reveal after the dwell').toBeVisible();
 
@@ -186,5 +224,79 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
         await expect(page.locator('.neo-dashboard-dock-rail-tab'), 'the retired rail tab must leave the DOM').toHaveCount(0);
         await expect(page.locator('.neo-tab-header-button', { hasText: 'Inspector' }).first(),
             'the pinned inspector must re-enter the rendered tab flow').toBeVisible({ timeout: 10000 });
+    });
+
+    test('all four edge rails keep intrinsic tab click areas while preserving reveal semantics', async ({ page, neuralLink }) => {
+        const { app, holderId, readModel } = await bootDockExample({ page, neuralLink });
+        const document                     = createFourEdgeRailDocument();
+
+        // Drive the example's real view-sync seam so DockLayoutAdapter projects all four rails.
+        await app.callMethod(holderId, 'onDockZoneDocumentChange', [document]);
+        await expect.poll(async () => {
+            const rails = await app.findInstances({ntype: 'dashboard-dock-rail'}, ['edge', 'id']);
+            return Array.isArray(rails) ? rails.length : rails ? 1 : 0
+        }, {message: 'the committed four-edge document projects one rail per edge', timeout: 15000}).toBe(4);
+
+        await expect(page.locator('.neo-dashboard-dock-edge-rail')).toHaveCount(4);
+
+        const committedSnapshot = JSON.stringify(await readModel());
+
+        for (const edge of ['top', 'right', 'bottom', 'left']) {
+            const
+                rail     = page.locator(`.neo-dashboard-dock-edge-rail-${edge}`),
+                tabs     = rail.locator('.neo-dashboard-dock-rail-tab'),
+                vertical = edge === 'left' || edge === 'right';
+
+            await expect(rail, `${edge}: one rendered rail`).toHaveCount(1);
+            await expect(tabs, `${edge}: both auto-hidden items stay reachable`).toHaveCount(2);
+
+            const geometry = await rail.evaluate((element, isVertical) => {
+                const
+                    railRect = element.getBoundingClientRect(),
+                    tabData  = [...element.querySelectorAll('.neo-dashboard-dock-rail-tab')].map(tab => {
+                        const rect = tab.getBoundingClientRect();
+
+                        return {
+                            flex       : getComputedStyle(tab).flex,
+                            mainExtent : isVertical ? rect.height : rect.width,
+                            mainStart  : isVertical ? rect.top : rect.left,
+                            writingMode: getComputedStyle(tab).writingMode
+                        }
+                    });
+
+                return {
+                    crossExtent: isVertical ? railRect.width : railRect.height,
+                    gap        : parseFloat(getComputedStyle(element).gap) || 0,
+                    mainExtent : isVertical ? railRect.height : railRect.width,
+                    tabs       : tabData
+                }
+            }, vertical);
+
+            const occupied = geometry.tabs.reduce((sum, tab) => sum + tab.mainExtent, 0)
+                + geometry.gap * (geometry.tabs.length - 1);
+
+            geometry.tabs.forEach((tab, index) => {
+                expect(tab.flex, `${edge} tab ${index}: explicit intrinsic main-axis flex`).toBe('0 0 auto');
+                expect(tab.writingMode, `${edge} tab ${index}: edge-appropriate text flow`)
+                    .toBe(vertical ? 'vertical-rl' : 'horizontal-tb')
+            });
+            expect(geometry.tabs[1].mainStart, `${edge}: document order advances along the edge`)
+                .toBeGreaterThan(geometry.tabs[0].mainStart);
+            expect(geometry.crossExtent, `${edge}: shared strip keeps its 14px cross-axis extent`).toBe(14);
+            expect(geometry.gap, `${edge}: shared strip keeps the 2px document-order gap`).toBe(2);
+            expect(occupied, `${edge}: two tabs do not divide and consume the entire rail`).toBeLessThan(geometry.mainExtent * 0.75);
+
+            const overlay = rail.locator('.neo-dashboard-dock-reveal-overlay');
+
+            await tabs.first().click();
+            await expect(overlay, `${edge}: the intrinsic tab remains clickable`).toBeVisible({timeout: 10000});
+            await expect(overlay.locator('.neo-dashboard-dock-reveal-title'), `${edge}: reveal resolves the clicked item`)
+                .toHaveText(`${edge[0].toUpperCase()}${edge.slice(1)} 1`);
+            await page.keyboard.press('Escape');
+            await expect(overlay, `${edge}: Escape dismisses the runtime-only reveal`).toBeHidden()
+        }
+
+        expect(JSON.stringify(await readModel()), 'four-edge reveal/dismiss gestures never mutate committed truth')
+            .toBe(committedSnapshot)
     });
 });

--- a/test/playwright/unit/dashboard/DockRail.spec.mjs
+++ b/test/playwright/unit/dashboard/DockRail.spec.mjs
@@ -72,6 +72,8 @@ test.describe('Neo.dashboard.DockRail', () => {
         expect(tabsOf(rail)).toHaveLength(1);
         expect(tabsOf(rail)[0].text).toBe('Terminal');
         expect(tabsOf(rail)[0].dockItemId).toBe('terminal');
+        expect(tabsOf(rail)[0].flex).toBe('none');
+        expect(tabsOf(rail)[0].wrapperStyle.flex).toBe('none');
 
         let terminalButton = tabsOf(rail)[0];
 
@@ -84,6 +86,8 @@ test.describe('Neo.dashboard.DockRail', () => {
         expect(tabsOf(rail)).toHaveLength(2);
         expect(tabsOf(rail)[0]).toBe(terminalButton);
         expect(tabsOf(rail)[1].text).toBe('Inspector');
+        expect(tabsOf(rail).map(tab => tab.flex)).toEqual(['none', 'none']);
+        expect(tabsOf(rail).map(tab => tab.wrapperStyle.flex)).toEqual(['none', 'none']);
 
         // Title flips update the surviving instance in place; leavers are removed.
         rail.railItems = [{dockEdge: 'right', dockItemId: 'terminal', restorable: true, title: 'Console'}];


### PR DESCRIPTION
Resolves #15655

DockRail tabs now declare `flex: none` in their creation config, so left/right and top/bottom rails keep label-sized controls grouped at the leading edge instead of dividing the full edge into equal slabs. The rail's existing cross-axis stretch, 14px strip, 2px gap, writing modes, document order, and reveal/pin semantics remain intact.

Evidence: L3 (fresh live Chrome projection through the dashboard dock example and Neural Link) → L3 required (all close-target acceptance criteria). No residuals.

Related: #14654, #15649, #15652, #15654

## Deltas from ticket

No product-scope delta. The existing hover journey used the raw DOM bounding-box center; the baseline comparison proved that center can already sit outside a clipped viewport edge independently of this change. The test now uses Playwright's visible actionability point, while the new four-edge receipt owns the geometry assertions explicitly.

## Test Evidence

- DockRail unit suite: `npx playwright test dashboard/DockRail -c test/playwright/playwright.config.unit.mjs --workers=1` — 15 passed; initial and reconciled tabs both retain `flex: none` through wrapper projection.
- Dock auto-hide/reveal vessel: `npx playwright test DockAutoHideRevealNL -c test/playwright/playwright.config.e2e.mjs --workers=1` — 3 passed; all four edges render two intrinsic tabs, preserve the 14px cross axis and 2px gap, remain natively clickable, reveal the correct item, dismiss with Escape, and leave committed worker truth byte-stable.
- Baseline falsification: the focused hover journey also failed with only `flex: none` temporarily removed; measured right-tab bounds were x=1588..1614 in a 1600px viewport, proving the stale raw-center pointer assumption was not introduced by this patch.
- Agent preflight: `npm run agent-preflight -- src/dashboard/DockRail.mjs test/playwright/unit/dashboard/DockRail.spec.mjs test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs` — all requested gates pass; unrelated AiConfig stale-overlay warning only.

## Post-Merge Validation

- [ ] Re-run the four-edge vessel from merged `dev`, then verify the Fleet right rail in the Build Week capture viewport before recapturing video.

Authored by Emmy (GPT-5.6 Sol, Codex). Session d8a51237-4fcc-4171-8071-a391da0be361.
