### PR TITLE
fix(ai): provision turn-presence hook identity via --env-file (#15658)

### DIFF
--- a/.kimi-code/hooks/turn-presence.example.toml
+++ b/.kimi-code/hooks/turn-presence.example.toml
@@ -1,28 +1,30 @@
 # Merge these blocks into ~/.kimi-code/config.toml, then start a new Kimi Code session.
-# The command re-exports the identity already inherited by the Kimi seat; it never
-# commits a resident name or credential.
+# Identity provisioning rides Node's own `--env-file-if-exists` against the checkout's `.env` —
+# the same file the seat's MCP servers trust via `--env-file`. Hook commands run with the
+# session's project dir as cwd; `$(git rev-parse --show-toplevel)` resolves the checkout.
+# No launch-shell export needed, and never an identity literal (#15658).
 
 [[hooks]]
 event = "UserPromptSubmit"
-command = 'NEO_AGENT_IDENTITY="$NEO_AGENT_IDENTITY" /usr/bin/env node "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
+command = 'node --env-file-if-exists="$(git rev-parse --show-toplevel)/.env" "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
 timeout = 5
 
 [[hooks]]
 event = "PostToolUse"
-command = 'NEO_AGENT_IDENTITY="$NEO_AGENT_IDENTITY" /usr/bin/env node "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
+command = 'node --env-file-if-exists="$(git rev-parse --show-toplevel)/.env" "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
 timeout = 5
 
 [[hooks]]
 event = "Stop"
-command = 'NEO_AGENT_IDENTITY="$NEO_AGENT_IDENTITY" /usr/bin/env node "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
+command = 'node --env-file-if-exists="$(git rev-parse --show-toplevel)/.env" "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
 timeout = 5
 
 [[hooks]]
 event = "StopFailure"
-command = 'NEO_AGENT_IDENTITY="$NEO_AGENT_IDENTITY" /usr/bin/env node "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
+command = 'node --env-file-if-exists="$(git rev-parse --show-toplevel)/.env" "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
 timeout = 5
 
 [[hooks]]
 event = "Interrupt"
-command = 'NEO_AGENT_IDENTITY="$NEO_AGENT_IDENTITY" /usr/bin/env node "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
+command = 'node --env-file-if-exists="$(git rev-parse --show-toplevel)/.env" "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
 timeout = 5

--- a/.kimi-code/hooks/turnPresenceHook.mjs
+++ b/.kimi-code/hooks/turnPresenceHook.mjs
@@ -3,6 +3,7 @@ import {
     readHookPayload,
     recordTurnPresenceFromHook
 } from '../../ai/mcp/server/memory-core/helpers/TurnPresenceHookWriter.mjs';
+import {normalizeAgentIdentityNodeId} from '../../ai/graph/normalizeAgentIdentityNodeId.mjs';
 
 const EVENT_MAP = Object.freeze({
     Interrupt: Object.freeze({
@@ -84,6 +85,16 @@ export async function recordKimiTurnPresence({
             reason: 'unsupported-hook-event',
             status: 'noop'
         }
+    }
+
+    // Fail-visible, bounded: an unprovisioned seat must be DETECTABLE, never session-breaking.
+    // One line only on UserPromptSubmit — PostToolUse fires per tool call, and one fresh process
+    // per event means a per-process line is not a real throttle there.
+    if (event.eventName === 'UserPromptSubmit' && !normalizeAgentIdentityNodeId(env.NEO_AGENT_IDENTITY)) {
+        process.stderr.write(
+            'kimi turnPresenceHook: NEO_AGENT_IDENTITY unresolved — provision the seat env ' +
+            '(node --env-file-if-exists=<checkout>/.env … turnPresenceHook.mjs); presence write skipped (fail-open)\n'
+        )
     }
 
     const {action, eventName, source, terminalState} = event;

--- a/ai/services/fleet/generateKimiSeatConfig.mjs
+++ b/ai/services/fleet/generateKimiSeatConfig.mjs
@@ -104,7 +104,7 @@ export function generateKimiSeatConfig({canonicalRoot, seatEnvFile, workspaceRoo
     });
 
     return {files: [
-        {path: path.posix.join(kimiHome, 'config.toml'),                 content: renderConfigToml({defaultModel})},
+        {path: path.posix.join(kimiHome, 'config.toml'),                 content: renderConfigToml({defaultModel, nodeBinary, seatEnvFile})},
         {path: path.posix.join(workspaceRoot, '.kimi-code', 'mcp.json'), content: renderMcpJson({root, seatEnvFile, workspaceRoot, nodeBinary, environment, servers})},
         {path: path.posix.join(memoryDir, 'MEMORY.md'),                  content: renderMemoryMd()},
         {path: path.posix.join(memoryDir, 'seat-pointers.md'),           content: renderSeatPointersMd()},
@@ -114,13 +114,19 @@ export function generateKimiSeatConfig({canonicalRoot, seatEnvFile, workspaceRoo
 
 /**
  * Render the seat's `config.toml`: permission posture + default model + the wake-envelope
- * SessionStart hook (git-tracked, present in every neo checkout). Provider/model resolution
- * stays with the harness's managed defaults (see the module JSDoc).
+ * SessionStart hook + the five turn-presence hooks (git-tracked, present in every neo checkout).
+ * The turn-presence commands ride Node's own `--env-file` against the seat's `.env` — the same
+ * file the MCP servers trust (constraint #2) — so hook processes get `NEO_AGENT_IDENTITY` with
+ * zero launch-shell discipline and zero identity literals. Provider/model resolution stays with
+ * the harness's managed defaults (see the module JSDoc).
  * @param {Object} options
+ * @param {String} options.defaultModel Default model alias.
+ * @param {String} options.nodeBinary   Absolute node binary — the hook process entrypoint.
+ * @param {String} options.seatEnvFile  Absolute seat `.env` — the identity + credential source.
  * @returns {String}
  * @private
  */
-function renderConfigToml({defaultModel}) {
+function renderConfigToml({defaultModel, nodeBinary, seatEnvFile}) {
     const permissionRules = KIMI_SEAT_SERVERS.map(server =>
         [
             '[[permission.rules]]',
@@ -144,6 +150,8 @@ function renderConfigToml({defaultModel}) {
         '#    calls (2026-07-18 incident, opencode-seat parity); default mode is auto.',
         '# 4. WAKE: the SessionStart hook is git-tracked and KIMI_CODE_HOME-aware; a Fleet seat\'s',
         '#    envelope lands beside its own server/instances coordinates (#15596 contract).',
+        '# 5. TURN PRESENCE: the five hooks below ride Node\'s --env-file against the seat\'s own .env',
+        '#    (the same identity source the MCP servers use) — no launch-shell export, no literals.',
         '',
         'default_permission_mode = "auto"',
         `default_model           = "${defaultModel}"`,
@@ -156,8 +164,36 @@ function renderConfigToml({defaultModel}) {
         'event   = "SessionStart"',
         'command = "node .kimi-code/hooks/wakeEnvelopeHook.mjs"',
         'timeout = 5',
-        ''
+        '',
+        ...renderTurnPresenceHooks({nodeBinary, seatEnvFile})
     ].join('\n');
+}
+
+/**
+ * Render the five turn-presence hook blocks. The command pins the seat's node binary and
+ * rides Node's `--env-file` against the seat's `.env`, so `NEO_AGENT_IDENTITY` reaches the hook
+ * process from the same canonical source as the MCP servers — never an identity literal, never a
+ * launch-shell inheritance assumption. TOML literal strings keep the inner quotes verbatim.
+ * @param {Object} options
+ * @param {String} options.nodeBinary  Absolute node binary.
+ * @param {String} options.seatEnvFile Absolute seat `.env`.
+ * @returns {String[]}
+ * @private
+ */
+function renderTurnPresenceHooks({nodeBinary, seatEnvFile}) {
+    return [
+        'UserPromptSubmit',
+        'PostToolUse',
+        'Stop',
+        'StopFailure',
+        'Interrupt'
+    ].flatMap(event => [
+        '[[hooks]]',
+        `event   = "${event}"`,
+        `command = '"${nodeBinary}" --env-file="${seatEnvFile}" .kimi-code/hooks/turnPresenceHook.mjs'`,
+        'timeout = 5',
+        ''
+    ]);
 }
 
 /**

--- a/learn/agentos/Hooks.md
+++ b/learn/agentos/Hooks.md
@@ -203,6 +203,36 @@ that lets an agent institution survive unattended windows. Without it, "waiting
 for review" slowly becomes a scheduling system run by the human. With it, waiting
 is just one fact in the live board.
 
+## Provisioning A Hook Process: The Identity Boundary
+
+A hook command spawns a **fresh process per event** — and that process inherits
+only the harness's environment, nothing else. Anything the hook needs must arrive
+at the process entrypoint, or it silently never arrives. This is the durability
+matrix the Kimi turn-presence incident (`#15658`) was filed from:
+
+| Path | How identity arrives | Survives a seat restart? |
+|---|---|---|
+| MCP servers | `--env-file=<seat>/.env` wired per-server in the seat config | **Yes** — config-resident |
+| Hook processes (before the repair) | `$NEO_AGENT_IDENTITY` inherited from the launch shell | **No** — one plain restart loses it, fail-open hides it |
+| Hook processes (the contract) | Node's own `--env-file` / `--env-file-if-exists` in the hook command itself | **Yes** — same canonical file as the MCP servers |
+
+The contract, both flavors:
+
+- **Fleet-generated seats** (`ai/services/fleet/generateKimiSeatConfig.mjs`) emit
+  the five turn-presence hooks as
+  `"<nodeBinary>" --env-file="<seatEnvFile>" .kimi-code/hooks/turnPresenceHook.mjs`.
+  Regenerate the seat config; do not hand-edit.
+- **Hand-maintained seats** merge `.kimi-code/hooks/turn-presence.example.toml`,
+  which uses `--env-file-if-exists="$(git rev-parse --show-toplevel)/.env"` —
+  tolerant of a missing file, literal-free by construction.
+
+Two disciplines hold the boundary honest. **Never an identity literal** in any
+config — a copied config must never carry a resident name. And **fail-visible,
+not fail-closed**: a hook must never break a session, so the Kimi adapter emits
+exactly one stderr line on an identity-less `UserPromptSubmit` (never on the
+per-keystroke `PostToolUse`) naming the missing variable and the `--env-file`
+remediation. Silence was the defect; the session boundary stays fail-open.
+
 ## What It Gives Your Team
 
 For a human team adopting Neo's Agent OS, hooks turn governance from trust-me

--- a/test/playwright/unit/ai/services/fleet/generateKimiSeatConfig.spec.mjs
+++ b/test/playwright/unit/ai/services/fleet/generateKimiSeatConfig.spec.mjs
@@ -60,6 +60,27 @@ test.describe('generateKimiSeatConfig (Kimi Code seat scaffold emission, #15612)
         expect(toml).toContain('command = "node .kimi-code/hooks/wakeEnvelopeHook.mjs"');
     });
 
+    test('golden shape: config.toml emits the five turn-presence hooks on the --env-file boundary (#15658)', () => {
+        const toml = findFile(generateKimiSeatConfig(PARAMS).files, 'config.toml').content;
+
+        // The seat's identity reaches the hook process from the SAME canonical source as the MCP
+        // servers: Node's own --env-file against the seat's .env — never an identity literal.
+        for (const event of ['UserPromptSubmit', 'PostToolUse', 'Stop', 'StopFailure', 'Interrupt']) {
+            expect(toml).toContain(`event   = "${event}"`);
+        }
+
+        const hookBlocks = toml.split('[[hooks]]').slice(1);
+        expect(hookBlocks).toHaveLength(6); // SessionStart + the five turn-presence events
+
+        const turnPresenceBlocks = hookBlocks.filter(block => block.includes('turnPresenceHook.mjs'));
+        expect(turnPresenceBlocks).toHaveLength(5);
+        turnPresenceBlocks.forEach(block => {
+            expect(block).toContain(`command = '"/usr/local/bin/node" --env-file="/seat/checkout/.env" .kimi-code/hooks/turnPresenceHook.mjs'`);
+            expect(block).toContain('timeout = 5');
+            expect(block).not.toMatch(/@neo-/)
+        });
+    });
+
     test('emission list: five files across both roots + the memory dir', () => {
         const paths = generateKimiSeatConfig(PARAMS).files.map(file => file.path);
 

--- a/test/playwright/unit/hooks/kimiTurnPresenceHook.spec.mjs
+++ b/test/playwright/unit/hooks/kimiTurnPresenceHook.spec.mjs
@@ -129,7 +129,7 @@ test.describe('Kimi Code turn-presence hook adapter', () => {
             expect(Object.keys(block).sort()).toEqual(['command', 'event', 'timeout']);
             expect(block.timeout).toBe(5);
             expect(block.command).toBe(
-                'NEO_AGENT_IDENTITY="$NEO_AGENT_IDENTITY" /usr/bin/env node "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
+                'node --env-file-if-exists="$(git rev-parse --show-toplevel)/.env" "$(git rev-parse --show-toplevel)/.kimi-code/hooks/turnPresenceHook.mjs"'
             );
             expect(block.command).not.toMatch(/@neo-/)
         })
@@ -243,6 +243,43 @@ test.describe('Kimi Code turn-presence hook adapter', () => {
 
             expect(readTurnPresenceNodes(fixture.db)).toHaveLength(0)
         } finally {
+            destroyGraphFixture(fixture)
+        }
+    });
+
+    test('missing identity warns once on UserPromptSubmit, never on PostToolUse, always fail-open', async () => {
+        const fixture       = createGraphFixture();
+        const writes        = [];
+        const originalWrite = process.stderr.write;
+
+        process.stderr.write = chunk => { writes.push(String(chunk)); return true };
+
+        try {
+            await expect(recordKimiTurnPresence({
+                env        : {NEO_MEMORY_DB_PATH: fixture.dbPath},
+                hookPayload: {hook_event_name: 'UserPromptSubmit'},
+                rootDir
+            })).resolves.toBeUndefined();
+            expect(writes).toHaveLength(1);
+            expect(writes[0]).toContain('NEO_AGENT_IDENTITY unresolved');
+            expect(writes[0]).toContain('--env-file-if-exists');
+
+            writes.length = 0;
+            await expect(recordKimiTurnPresence({
+                env        : {NEO_MEMORY_DB_PATH: fixture.dbPath},
+                hookPayload: {hook_event_name: 'PostToolUse', tool_name: 'Shell'},
+                rootDir
+            })).resolves.toBeUndefined();
+            expect(writes).toHaveLength(0);
+
+            await expect(recordKimiTurnPresence({
+                env        : {NEO_AGENT_IDENTITY: '@test-kimi', NEO_MEMORY_DB_PATH: fixture.dbPath},
+                hookPayload: {hook_event_name: 'UserPromptSubmit'},
+                rootDir
+            })).resolves.toMatchObject({status: 'recorded'});
+            expect(writes).toHaveLength(0)
+        } finally {
+            process.stderr.write = originalWrite;
             destroyGraphFixture(fixture)
         }
     });


### PR DESCRIPTION
Resolves #15658

Ships the launch-boundary identity provisioning for the Kimi turn-presence hook: `generateKimiSeatConfig` now emits the five turn-presence hooks with Node's own `--env-file=<seatEnvFile>` entrypoint (the same canonical file the MCP servers trust), the manual example rides `--env-file-if-exists` against the checkout `.env`, and the Kimi adapter gains a bounded fail-visible diagnostic (one stderr line on an identity-less `UserPromptSubmit`, never on `PostToolUse`, never thrown). `TurnPresenceHookWriter` stays explicit-input and filesystem-free — this is the Euclid-aligned prescription from his `needs-contract-alignment` intake, replacing the original writer-side `.env` fallback. Root cause (reproduced, two-seat verified): a restarted Kimi TUI without `NEO_AGENT_IDENTITY` in its launch env writes zero `AGENT_TURN_PRESENCE` nodes while the roster goes blind (`#15580` AC5 negative, preserved on the closed ticket).

Evidence: L1 (unit specs: generator TOML golden shape, adapter diagnostic paths, template command form — deterministic, engine-free) → L1 required for AC1–AC5; AC6 (the restarted-seat live `who_is_online` rescue probe) is environment-bound and lands as Post-Merge Validation. Residual: AC6 [#15658].

## Deltas from ticket

None substantive — the ticket body was amended pre-branch to exactly this prescription (launch boundary instead of writer-side discovery), per Euclid's intake. One judgment call inside it: the diagnostic lives in the Kimi adapter (his option), bounded to `UserPromptSubmit`.

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test test/playwright/unit/hooks/kimiTurnPresenceHook.spec.mjs test/playwright/unit/ai/services/fleet/generateKimiSeatConfig.spec.mjs -c test/playwright/playwright.config.unit.mjs` — **20 passed (1.3s)**: generator emits all five hooks with `--env-file=<seatEnvFile>` + `<nodeBinary>` (TOML golden, zero identity literals); example template asserts the `--env-file-if-exists` form; adapter diagnostic covered for emit-once / silent-PostToolUse / identity-present paths; all pre-existing hook + generator specs stay green.
- Writer untouched: `TurnPresenceHookWriter.mjs` has zero diff (its existing spec coverage is untouched and green in the same run via the hook suite).
- Adapter import smoke: `node -e "import('./.kimi-code/hooks/turnPresenceHook.mjs')"` — exports resolve.
- Hooks doc: `learn/agentos/Hooks.md` gains the two-path durability matrix + the provisioning contract (docs-only, no runtime evidence required).
- Agent preflight: husky pre-commit chain (whitespace, shorthand, aiconfig-mutation, jsdoc-types, ticket-archaeology, block-alignment, parse) — all pass on the staged set.

## Post-Merge Validation

- [ ] AC6: restart the Iris Kimi seat with no launch-env `NEO_AGENT_IDENTITY` (config regenerated/merged from the new example); the verbose `who_is_online` probe shows `turnPresence.fresh:true` + the `"add_memory stale — mid-turn rescue"` reason; the `#15580` AC5 receipt then lands on the closed ticket.
- [ ] Confirm the one-line diagnostic appears (and only once per `UserPromptSubmit`) on an intentionally unprovisioned seat.

## Commits (if multi-commit)

- `8ee95cb9d1` — generator `--env-file` hook emission + example template repair + adapter fail-visible diagnostic + Hooks.md provisioning contract + both spec suites.

Authored by Iris (Kimi K3, Kimi Code CLI). Session eb9be68e-9401-4ecd-9762-ef519b4091ed.
