### PR TITLE
fix(dashboard): contain dock rail tab labels intrinsically (#15668)

### DIFF
--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -158,20 +158,27 @@
     }
 }
 
-// Scoped to 0,3,0 on purpose: the neo themes pin `.neo-button` to a fixed physical
-// `height: var(--button-height)` (= 48px) and `min-width: var(--cmp-button-height)` (0,2,0), which
-// clamps a vertical rail tab to a 48px hit box (68-99px labels overflow and overlap their
-// neighbors) and defeats the 14px cross-axis stretch on every edge; the generic button margin and
-// padding (0,1,0 source-order tie the rail always lost) shrink or inflate the strip anatomy. Rail
-// tabs size intrinsically on the main axis (label + padding) and fill the strip edge-to-edge on
-// the cross axis — the generic button token contract does not own this anatomy.
+// Scoped to 0,3,0 (tab) and 0,4,0 (label) on purpose: the neo themes pin `.neo-button` to a fixed
+// physical `height: var(--button-height)` (= 48px) and `min-width: var(--cmp-button-height)`
+// (0,2,0), which clamps a vertical rail tab to a 48px hit box (68-99px labels overflow and
+// overlap their neighbors) and defeats the 14px cross-axis stretch on every edge; the generic
+// button margin and padding (0,1,0 source-order tie the rail always lost) shrink or inflate the
+// strip anatomy, and the label span carries its own token'd font-size/line-height — consumer
+// text metrics set the vertical label's line-box cross extent (production AgentOS measured an
+// 18px label inside the 14px strip). Rail tabs size intrinsically on the main axis (label +
+// padding) and fill the strip edge-to-edge on the cross axis — the generic button token contract
+// and the consumer's inherited text metrics do not own this anatomy.
 // Equal-specificity load-order ties are not a contract.
 .neo-dashboard .neo-button.neo-dashboard-dock-rail-tab {
-    font-size: 11px;
     height   : auto;
     margin   : 0;
     min-width: 0;
     padding  : 4px 1px;
+
+    .neo-button-text {
+        font-size  : 11px;
+        line-height: 1;
+    }
 }
 
 .neo-dashboard-dock-edge-band {

--- a/resources/scss/src/dashboard/Container.scss
+++ b/resources/scss/src/dashboard/Container.scss
@@ -158,8 +158,19 @@
     }
 }
 
-.neo-dashboard-dock-rail-tab {
+// Scoped to 0,3,0 on purpose: the neo themes pin `.neo-button` to a fixed physical
+// `height: var(--button-height)` (= 48px) and `min-width: var(--cmp-button-height)` (0,2,0), which
+// clamps a vertical rail tab to a 48px hit box (68-99px labels overflow and overlap their
+// neighbors) and defeats the 14px cross-axis stretch on every edge; the generic button margin and
+// padding (0,1,0 source-order tie the rail always lost) shrink or inflate the strip anatomy. Rail
+// tabs size intrinsically on the main axis (label + padding) and fill the strip edge-to-edge on
+// the cross axis — the generic button token contract does not own this anatomy.
+// Equal-specificity load-order ties are not a contract.
+.neo-dashboard .neo-button.neo-dashboard-dock-rail-tab {
     font-size: 11px;
+    height   : auto;
+    margin   : 0;
+    min-width: 0;
     padding  : 4px 1px;
 }
 

--- a/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
+++ b/test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs
@@ -72,7 +72,7 @@ const createFourEdgeRailDocument = () => {
                 kind        : 'panel',
                 pinnable    : true,
                 pinned      : false,
-                title       : `${edge[0].toUpperCase()}${edge.slice(1)} ${index + 1}`
+                title       : `${edge[0].toUpperCase()}${edge.slice(1)} perspectives ${index + 1}`
             }
         });
 
@@ -254,13 +254,20 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
                 const
                     railRect = element.getBoundingClientRect(),
                     tabData  = [...element.querySelectorAll('.neo-dashboard-dock-rail-tab')].map(tab => {
-                        const rect = tab.getBoundingClientRect();
+                        const
+                            rect      = tab.getBoundingClientRect(),
+                            labelRect = tab.querySelector('.neo-button-text').getBoundingClientRect();
 
                         return {
-                            flex       : getComputedStyle(tab).flex,
-                            mainExtent : isVertical ? rect.height : rect.width,
-                            mainStart  : isVertical ? rect.top : rect.left,
-                            writingMode: getComputedStyle(tab).writingMode
+                            crossExtent   : isVertical ? rect.width : rect.height,
+                            flex          : getComputedStyle(tab).flex,
+                            labelMainEnd  : isVertical ? labelRect.bottom : labelRect.right,
+                            labelMainStart: isVertical ? labelRect.top : labelRect.left,
+                            labelRect     : {bottom: labelRect.bottom, left: labelRect.left, right: labelRect.right, top: labelRect.top},
+                            mainExtent    : isVertical ? rect.height : rect.width,
+                            mainStart     : isVertical ? rect.top : rect.left,
+                            rect          : {bottom: rect.bottom, left: rect.left, right: rect.right, top: rect.top},
+                            writingMode   : getComputedStyle(tab).writingMode
                         }
                     });
 
@@ -278,7 +285,25 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
             geometry.tabs.forEach((tab, index) => {
                 expect(tab.flex, `${edge} tab ${index}: explicit intrinsic main-axis flex`).toBe('0 0 auto');
                 expect(tab.writingMode, `${edge} tab ${index}: edge-appropriate text flow`)
-                    .toBe(vertical ? 'vertical-rl' : 'horizontal-tb')
+                    .toBe(vertical ? 'vertical-rl' : 'horizontal-tb');
+
+                // The hit area must contain its label on both axes: a theme-pinned fixed
+                // button height otherwise clips vertical labels to a 48px box.
+                expect(tab.rect.left,   `${edge} tab ${index}: label contained (left)`  ).toBeLessThanOrEqual(tab.labelRect.left   + 0.5);
+                expect(tab.rect.top,    `${edge} tab ${index}: label contained (top)`   ).toBeLessThanOrEqual(tab.labelRect.top    + 0.5);
+                expect(tab.rect.right,  `${edge} tab ${index}: label contained (right)` ).toBeGreaterThanOrEqual(tab.labelRect.right  - 0.5);
+                expect(tab.rect.bottom, `${edge} tab ${index}: label contained (bottom)`).toBeGreaterThanOrEqual(tab.labelRect.bottom - 0.5);
+
+                // The 14px strip owns the cross axis: a theme min-width must not jut past it.
+                expect(tab.crossExtent, `${edge} tab ${index}: tab fills exactly the 14px cross axis`)
+                    .toBeGreaterThanOrEqual(geometry.crossExtent - 0.5);
+                expect(tab.crossExtent, `${edge} tab ${index}: tab does not overflow the 14px cross axis`)
+                    .toBeLessThanOrEqual(geometry.crossExtent + 0.5);
+
+                if (index > 0) {
+                    expect(tab.labelMainStart, `${edge} tab ${index}: adjacent labels never overlap`)
+                        .toBeGreaterThanOrEqual(geometry.tabs[index - 1].labelMainEnd - 0.5)
+                }
             });
             expect(geometry.tabs[1].mainStart, `${edge}: document order advances along the edge`)
                 .toBeGreaterThan(geometry.tabs[0].mainStart);
@@ -291,7 +316,7 @@ test.describe('Dock auto-hide reveal/pin journey (Neural Link)', () => {
             await tabs.first().click();
             await expect(overlay, `${edge}: the intrinsic tab remains clickable`).toBeVisible({timeout: 10000});
             await expect(overlay.locator('.neo-dashboard-dock-reveal-title'), `${edge}: reveal resolves the clicked item`)
-                .toHaveText(`${edge[0].toUpperCase()}${edge.slice(1)} 1`);
+                .toHaveText(`${edge[0].toUpperCase()}${edge.slice(1)} perspectives 1`);
             await page.keyboard.press('Escape');
             await expect(overlay, `${edge}: Escape dismisses the runtime-only reveal`).toBeHidden()
         }


### PR DESCRIPTION
Resolves #15668

The #15656 intrinsic-flex repair stopped DockRail tabs from dividing the full edge equally, but live capture falsification on origin/dev@1c2c293424 showed the repair traded stretched tabs for collapsed ones: five right-rail tabs pinned to a 48px hit box while 68-99px vertical labels overflowed and overlapped their neighbors (capture-unsafe; Emmy held the Build Week end-to-end capture for this repair). Root cause pinned live: the neo themes bind .neo-button to a fixed physical height: var(--button-height) (= 48px via --cmp-button-height) and min-width: var(--cmp-button-height), and the rail's own padding/font anatomy rule lost an equal-specificity source-order tie to .neo-button (probe receipt: tab padding resolved to 5px 12px, width 26px on a 14px rail). The generic button token contract does not own the rail-strip anatomy.

The repair is one scoped anatomy rule in resources/scss/src/dashboard/Container.scss (0,3,0 compound selector, matching the file's documented load-order-tie discipline): rail tabs get height: auto (main axis follows label + padding intrinsically), min-width: 0 and margin: 0 (the 14px cross-axis stretch fills the strip edge-to-edge), padding: 4px 1px and font-size: 11px restored to winning the cascade. No framework JS, no Flexbox fallback, and no app-scoped CSS changed — the #15655 construction contract (flex: 'none' at creation) stands.

Evidence: L3 (live Chromium four-edge geometry receipts incl. per-tab label containment, adjacency overlap, and cross-axis extent) → L3 required (rendered-surface geometry ACs).

## Deltas from ticket

None substantive. The pre-fix live probe (Neural Link, right rail) is what moved the repair from the ticket's suspected propagation gap to the full token-collision picture (fixed height + min-width + margin + padding tie), so the single anatomy rule covers all four collisions instead of only the label-height propagation.

## Test Evidence

- Fixture hardened: the four-edge geometry test now uses production-length labels (>48px vertical extent) so the old behavior falsifies instead of passing; new per-tab receipts assert label containment on both axes, zero adjacent-label overlap, and exact 14px cross-axis fill.
- test/playwright/e2e/dashboard/DockAutoHideRevealNL.spec.mjs → 3/3 passed (chromium)
- test/playwright/e2e/dashboard/ (full directory incl. drag/reveal/operations journeys) → 24/24 passed
- test/playwright/unit/dashboard/DockRail.spec.mjs → 15/15 passed
- Pre-fix failure receipts on this branch head: top tab cross-axis 12px vs 14px strip; right tab width 26px vs 14px strip — both closed by the anatomy rule.

## Post-Merge Validation

- [ ] Emmy's full Build Week end-to-end capture unblocks on the merged dev head (owned by her lane)
- [ ] AgentOS production rail re-measured post-merge: tabs label-sized, no overlap, 14px strip intact

Authored by Phoebe (Kimi K3, OpenCode). Session d8a51237-4fcc-4171-8071-a391da0be361.