### PR TITLE
docs(readme): replace hero collage with the Build Week final film poster (#15671)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@
 
 **Neo.mjs is a self-evolving software organism — a professional, end-to-end AI engineering team that lives in its own open-source repository.**
 
+<p align="center">
+  <a href="https://www.youtube.com/watch?v=H5zR63tVrmo">
+    <img width="851" alt="Neo.mjs — Agent Fleet Manager: the OpenAI Build Week final film, demoing the agent fleet cockpit that the Neo.mjs swarm designed, built, reviewed, and shipped inside the competition window" src="https://img.youtube.com/vi/H5zR63tVrmo/maxresdefault.jpg">
+  </a>
+  </br>
+  <a href="https://www.youtube.com/watch?v=H5zR63tVrmo">▶ Watch Neo.mjs — Agent Fleet Manager</a>
+</p>
+
 Where the industry runs one AI agent and gets slop, Neo.mjs runs a swarm of minds from rival labs — Claude, Gemini, GPT — that read each other's reasoning through shared memory and Active Hybrid GraphRAG, catching what no single model can see in itself.
 
 Through the **Neural Link** possession interface, the swarm does not just read code; it inhabits live applications — inspecting semantic runtime state, mutating UI and data in real time, turning conversational UIs from chat panels into agents collaborating inside the application. It autonomously runs the full engineering lifecycle: ideating, building, and cross-reviewing a production multi-threaded engine, running DreamService cycles to re-steer priorities, and closing self-healing loops where runtime failures, code defects, agent mistakes, and architectural friction become fixes, tickets, skills, memory, and new graph topology for the next cycle.
@@ -34,8 +42,6 @@ Neo.mjs's evolution mechanism is the **MX loop** — Model Experience as product
 > *"The system evolves by predicting its own evolution."*
 
 Every other 2026 platform asks: *how can AI help humans use this software?* Neo.mjs asks: *how can software become a body that AI inhabits?*
-
-<img width="851" height="478" alt="Screenshot 2026-06-04 at 18 37 58 copy 2" src="https://github.com/user-attachments/assets/96e3b4a4-bdb8-42e7-aea6-fab41547921f" />
 
 </br></br>
 ## Deploy a Cross-Model AI Engineering Team on Your Own Codebase


### PR DESCRIPTION
Resolves #15671

The README's hero slot now carries the OpenAI Build Week final film (Tobi-selected as durable README value; delegation via Emmy): the live YouTube maxresdefault poster (HTTP 200 verified, no committed binary) wrapped in a film link with a visible linked caption (▶ Watch Neo.mjs — Agent Fleet Manager) and descriptive alt text, centered directly after the line-17 identity anchor. The static June collage at line 38 is removed — exactly one hero visual remains, and the two-hemisphere identity framing is untouched.

Evidence: L3 (GitHub-rendered branch README verified live) → L3 required (rendered-surface AC).

## Deltas from ticket

None substantive — followed the delegated lane shape; the centered `<p align="center">` compound matches the header block's proven GitHub-render pattern.

## Test Evidence

- Branch render receipt (github.com/neomjs/neo/blob/kimi/15671-readme-build-week-film/README.md): poster img src + film link + caption present in the rendered payload; old collage asset (96e3b4a4) absent — 0 occurrences
- Poster URL pre-flight: img.youtube.com/vi/H5zR63tVrmo/maxresdefault.jpg → HTTP 200
- agent-preflight --no-fix README.md → all gates passed

## Post-Merge Validation

- [ ] The dev README's rendered hero shows poster + caption, and the click through lands on the final film

Authored by Phoebe (Kimi K3, OpenCode). Session 72c8c42d-f18a-408c-97c8-aeb1f82dd276.