### PR TITLE
docs(readme): sharpen the identity hierarchy (#15679)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
   <a href="./CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-green.svg?logo=GitHub&logoColor=white" alt="PRs Welcome"></a>
 </p>
 
-# Neo.mjs
+# A self-evolving software organism
 
-**Neo.mjs is a self-evolving software organism — a professional, end-to-end AI engineering team that lives in its own open-source repository.**
+**Neo.mjs is a professional, end-to-end AI engineering team that lives in its own open-source repository.**
 
 <p align="center">
   <a href="https://www.youtube.com/watch?v=H5zR63tVrmo">


### PR DESCRIPTION
Resolves #15679

The README hero now gives each hierarchy level one job: the unchanged wordmark identifies the brand, the sole H1 states “A self-evolving software organism,” and the named lead carries the professional-team clause. The two edited lines preserve the complete ADR 0018 apex compositionally while leaving the wordmark, badges, final-film poster, caption, and wider README byte-for-byte unchanged.

Evidence: L3 (actual GitHub branch render at 1440×900 and 390×844 in the active dark scheme, plus static source-contract checks) → L3 required (AC5 branch render across two widths and both theme receipts). Residual: AC5 light-scheme receipt and AC6 cross-family review [#15679].

## Deltas from ticket

None substantive. The implementation is the exact two-line presentation split proposed by the ticket.

## Test Evidence

- README GitHub surface: branch render checked at 1440×900 and 390×844 in dark mode; the proposition is the sole visual H1, the narrow layout wraps cleanly, and the named lead remains readable.
- README automated coverage: None found; this documentation-only hierarchy is covered by source-contract checks, repository preflight, and the live GitHub branch render.
- npm run agent-preflight -- README.md — passed.
- npm run agent-preflight -- --no-fix README.md — passed.
- git diff --check origin/dev...HEAD — passed.
- rg -n ^# README.md — exactly one Markdown H1, at the new identity proposition.
- Scope audit: README.md only, with 2 insertions and 2 deletions; all header assets and remaining prose are unchanged.
- Remote-head audit: codex/15679-readme-identity-proposition resolves to 06ab5447bcc54c10a9f355cbfaae7a7ce22730a7.

## Post-Merge Validation

- [ ] Confirm the merged dev README keeps the same hierarchy on the canonical GitHub repository page.

Authored by Euclid (GPT-5, Codex Desktop). Session 123cd4c7-0154-4252-976f-32564fc1a47d.