### PR TITLE
docs(ai): name the call_method args marshalling reality (#15678)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -2685,7 +2685,7 @@ components:
         args:
           type: array
           items: {}
-          description: Arguments to pass to the method (heterogeneous — any JSON-serializable value)
+          description: Arguments to pass to the method (heterogeneous — any JSON-serializable value). Pass values natively; strings are forwarded verbatim, and some MCP clients narrow an empty `items` schema to string in their tool listings, silently stringifying objects. For object-bearing wires, the in-process `NeuralLink_InstanceService.callMethod` path is the documented workaround.
         sessionId:
           type: string
           description: The target App Worker Session ID


### PR DESCRIPTION
Resolves #15678

One-line docs repair at the exact surface where the defect bites: the `call_method` `args` description in `ai/mcp/server/neural-link/openapi.yaml` now names the marshalling reality — pass values natively; strings are forwarded verbatim; some MCP clients narrow an empty `items` schema to string in their tool listings (silently stringifying objects); the in-process `NeuralLink_InstanceService.callMethod` path is the documented workaround for object-bearing wires.

Root cause (verified, receipts on the ticket): the server emits the correct heterogeneous schema (`items: {}`, `x-pass-as-object` honored — proven by executing `buildZodSchema` → `toOpenApiJsonSchema` on `origin/dev`); the Kimi MCP client normalizes `items: {}` → `{type: 'string'}` in its agent-facing tool listing. No Neo server code fix exists for the marshalling; the ticket's write-lock half moved to #15681 (child of `#13056`).

Evidence: L1 (docs + existing unit suite) → L1 required (description text only; no runtime behavior change). Residual: none.

## Deltas from ticket

None substantive — AC1 exactly as amended. The ticket body was amended pre-branch with the corrected decomposition (server correct; client-side normalization).

## Test Evidence

- `UNIT_TEST_MODE=true npx playwright test test/playwright/unit/ai/mcp -c test/playwright/playwright.config.unit.mjs` — **407 passed**: no description-content locks broken.
- Description-budget sanity: the addition is ~2 sentences, well under the 1024-char tool-description cap (§5.3).
- Agent preflight: husky pre-commit chain green on the staged file.

## Post-Merge Validation

- [ ] (Optional AC2, operator's call) Upstream Kimi Code defect report on the `items: {}` → string normalization collapse, linked back to #15678.

## Commits (if multi-commit)

- `e38bc8d2c4` — the args description line.

Authored by Iris (Kimi K3, Kimi Code CLI). Session eb9be68e-9401-4ecd-9762-ef519b4091ed.
