### PR TITLE
fix(ai): explicit JsonValue union for call_method args (#15678)

### DIFF
--- a/ai/mcp/server/neural-link/openapi.yaml
+++ b/ai/mcp/server/neural-link/openapi.yaml
@@ -2684,8 +2684,17 @@ components:
           description: The method name (e.g. 'load' or 'series.push')
         args:
           type: array
-          items: {}
-          description: Arguments to pass to the method (heterogeneous — any JSON-serializable value)
+          items:
+            oneOf:
+              - type: string
+                nullable: true
+              - type: number
+              - type: boolean
+              - type: object
+                additionalProperties: true
+              - type: array
+                items: {}
+          description: Arguments to pass to the method (heterogeneous — any JSON-serializable value — string, number, boolean, object, array, or null). Pass values natively; strings are forwarded verbatim.
         sessionId:
           type: string
           description: The target App Worker Session ID

--- a/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
+++ b/test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs
@@ -366,6 +366,30 @@ test.describe('OpenApiValidator: strict-client JSON-Schema compliance', () => {
     });
 
     /**
+     * Heterogeneous `call_method` args: the explicit JsonValue union must emit as `anyOf`
+     * (concrete item types survive client schema normalizers that collapse empty `items`
+     * to string) AND the runtime Zod union must parse every representative JSON class —
+     * string, number, boolean, null, an open object (the object-bearing wire), and nested arrays.
+     */
+    test('call_method args emit an explicit JsonValue union and parse every JSON class', async () => {
+        const doc  = yaml.load(fs.readFileSync(path.join(repoRoot, 'ai/mcp/server/neural-link/openapi.yaml'), 'utf8'));
+        const op   = doc.paths['/instance/method/call'].post;
+        const zod  = buildZodSchema(doc, op);
+        const json = toOpenApiJsonSchema(zod),
+              items = json.properties.args.items;
+
+        expect(items.anyOf).toBeDefined();
+        expect(items.anyOf.map(member => member.type)).toEqual(['string', 'number', 'boolean', 'object', 'array']);
+        expect(items.anyOf[0].nullable).toBe(true);
+
+        const cases = ['a string', 42, 3.14, true, null, {url: 'http://x', bearerToken: 'tok'}, [1, 'two', {three: 3}], [], {}];
+
+        for (const value of cases) {
+            expect(zod.shape.args.safeParse([value]).success, `args must accept ${JSON.stringify(value)}`).toBe(true)
+        }
+    });
+
+    /**
      * Direct regression for https://github.com/neomjs/neo/issues/9837 (re-purposed).
      * Confirms that `.passthrough()` on a `z.object(...)` flips the emission to
      * `additionalProperties: true`. This is the mechanism by which output schemas


### PR DESCRIPTION
Resolves #15678

Supersedes closed docs-only PR `#15683` (dropped via Euclid's Drop+Supersede — the "no server fix exists" premise was untested). This is the schema repair his probe predicted: `CallMethodRequest.args.items` becomes an **explicit JsonValue union** (`oneOf`: nullable string, number, boolean, open object, array) instead of the empty `{}` sentinel — so the emitted schema gives client normalizers a concrete item type instead of something to collapse. The Zod runtime union parses every representative JSON class (verified live: string, number, float, boolean, null, the native `{url, bearerToken}` object, nested arrays, empty array/object). The Kimi projection of this explicit union is the remaining decisive falsifier and lands as Post-Merge Validation via the seat restart.

Evidence: L1 (validator compliance spec: emission anyOf shape + all-class parse) → L1 required for AC1/AC2; the Kimi projection receipt is environment-bound (PMV). Residual: AC2 [#15678].

## Deltas from ticket

The ticket body was amended pre-branch per the D+S salvage map: explicit-union prescription first; the Kimi projection as the gate; upstream report only if the union still collapses; no in-process pointers in consumer-facing docs; Contract Ledger added (server emission / runtime validation / Kimi projection / generic MCP access / write-lock sequel at #15681).

## Test Evidence

- Live conversion probe on this branch: `buildZodSchema` → `toOpenApiJsonSchema` emits `args.items.anyOf = [string(nullable), number, boolean, object(additionalProperties:true), array]`; all 9 JSON-class cases parse (receipt in session).
- `UNIT_TEST_MODE=true npx playwright test test/playwright/unit/ai/mcp/validation/OpenApiValidatorCompliance.spec.mjs -c test/playwright/playwright.config.unit.mjs` — **45 passed**, including the new regression: `call_method args emit an explicit JsonValue union and parse every JSON class`.
- `UNIT_TEST_MODE=true npx playwright test test/playwright/unit/ai/mcp -c ...` — **413 passed** (full MCP suite).
- Agent preflight: husky chain green; description stays one line within the §5.3 budget; the diff is 11+2 semantic yaml lines (an earlier 263-line formatter accident was caught and reverted pre-push).

## Post-Merge Validation

- [ ] AC2: restart the Iris Kimi seat (same restart as `#15580` AC6); the Kimi tool listing must show `call_method` args preserving the explicit union — receipt on #15678. If it still collapses, file the upstream defect and restore a truthful caller-facing docs line.

## Commits (if multi-commit)

- `214ec45d30` — explicit JsonValue union for `call_method` args + compliance spec.

Authored by Iris (Kimi K3, Kimi Code CLI). Session eb9be68e-9401-4ecd-9762-ef519b4091ed.
