### PR TITLE
fix(ai): exclude host-offline time from REM-stall staleness (#15687)

### DIFF
--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -836,8 +836,17 @@ async function runRemConsolidationLivenessWatchdogTask({taskName, reason, servic
         const alarmState  = state?.remConsolidationAlarm ?? null;
         const thresholdMs = runtime.remConsolidationWatchdogThresholdMs;
 
-        const {stalled, shouldAlarm, nextAlarmState} = evaluateConsolidationStallAlarm({
-            hasCycle, readFault: readFault || backlogReadFault, stalenessMs, undigestedCount, thresholdMs, alarmState
+        const {stalled, shouldAlarm, downTimeSuppressed, effectiveStalenessMs, nextAlarmState} = evaluateConsolidationStallAlarm({
+            hasCycle,
+            readFault      : readFault || backlogReadFault,
+            stalenessMs,
+            undigestedCount,
+            thresholdMs,
+            // Down-time exclusion: host-off / orchestrator-stopped intervals are time no cycle could
+            // have run, so the stall clock is capped by this process's uptime (the evaluator defaults
+            // to legacy wall-clock behavior for callers that do not pass it).
+            uptimeMs       : Math.round(process.uptime() * 1000),
+            alarmState
         });
 
         // Stamp the stall-onset timestamp (the clock-free evaluator leaves it null on the latching
@@ -911,6 +920,13 @@ async function runRemConsolidationLivenessWatchdogTask({taskName, reason, servic
             }
         } else {
             services.healthService?.recordTaskOutcome?.(taskName, 'completed', details);
+
+            if (downTimeSuppressed) {
+                // Digest-resume note (INFO, never the swarm alarm): the cycle gap spans host-offline
+                // time, so the stall clock resumed from boot instead of alerting. The healthy-check
+                // latch clear above already handles the drain verification on the next cycles.
+                runtime.writeLog?.('INFO', `[Orchestrator] rem-consolidation-liveness-watchdog: digest-resume — cycle gap of ${stalenessMs}ms spans host-offline time (uptime ${effectiveStalenessMs}ms); resuming the stall clock from boot instead of alarming (undigested: ${undigestedCount}).`);
+            }
         }
 
         services.taskStateService.markCompleted(taskName);

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -836,7 +836,7 @@ async function runRemConsolidationLivenessWatchdogTask({taskName, reason, servic
         const alarmState  = state?.remConsolidationAlarm ?? null;
         const thresholdMs = runtime.remConsolidationWatchdogThresholdMs;
 
-        const {stalled, shouldAlarm, downTimeSuppressed, effectiveStalenessMs, nextAlarmState} = evaluateConsolidationStallAlarm({
+        const {stalled, shouldAlarm, downTimeSuppressed, drainObserved, recoveryStarted, effectiveStalenessMs, nextAlarmState} = evaluateConsolidationStallAlarm({
             hasCycle,
             readFault      : readFault || backlogReadFault,
             stalenessMs,
@@ -844,8 +844,10 @@ async function runRemConsolidationLivenessWatchdogTask({taskName, reason, servic
             thresholdMs,
             // Down-time exclusion: host-off / orchestrator-stopped intervals are time no cycle could
             // have run, so the stall clock is capped by this process's uptime (the evaluator defaults
-            // to legacy wall-clock behavior for callers that do not pass it).
-            uptimeMs       : Math.round(process.uptime() * 1000),
+            // to legacy wall-clock behavior for callers that do not pass it). The runtime override
+            // exists so fixtures can pin the process-age dimension instead of depending on ambient
+            // test-worker uptime.
+            uptimeMs       : runtime.remConsolidationWatchdogUptimeMs ?? Math.round(process.uptime() * 1000),
             alarmState
         });
 
@@ -919,13 +921,14 @@ async function runRemConsolidationLivenessWatchdogTask({taskName, reason, servic
                 }
             }
         } else {
-            services.healthService?.recordTaskOutcome?.(taskName, 'completed', details);
+            services.healthService?.recordTaskOutcome?.(taskName, 'completed', {...details, drainObserved, recoveryBaseline: nextAlarmState.recoveryBaseline});
 
-            if (downTimeSuppressed) {
+            if (recoveryStarted) {
                 // Digest-resume note (INFO, never the swarm alarm): the cycle gap spans host-offline
-                // time, so the stall clock resumed from boot instead of alerting. The healthy-check
-                // latch clear above already handles the drain verification on the next cycles.
-                runtime.writeLog?.('INFO', `[Orchestrator] rem-consolidation-liveness-watchdog: digest-resume — cycle gap of ${stalenessMs}ms spans host-offline time (uptime ${effectiveStalenessMs}ms); resuming the stall clock from boot instead of alarming (undigested: ${undigestedCount}).`);
+                // time, so the stall clock resumed from boot instead of alerting. Emitted exactly
+                // once at recovery-phase onset; the phase completes only when a later check observes
+                // a strictly decreased backlog (evaluator recoveryBaseline).
+                runtime.writeLog?.('INFO', `[Orchestrator] rem-consolidation-liveness-watchdog: digest-resume — cycle gap of ${stalenessMs}ms spans host-offline time (uptime ${effectiveStalenessMs}ms); recovery phase opened, watching for backlog drain (undigested: ${undigestedCount}).`);
             }
         }
 

--- a/ai/daemons/orchestrator/scheduling/pipeline.mjs
+++ b/ai/daemons/orchestrator/scheduling/pipeline.mjs
@@ -856,7 +856,9 @@ async function runRemConsolidationLivenessWatchdogTask({taskName, reason, servic
         const stalledSince = stalled
             ? (shouldAlarm ? now : (alarmState?.stalledSince ?? now))
             : null;
-        if (state) state.remConsolidationAlarm = {alarmed: nextAlarmState.alarmed, stalledSince};
+        // Persist the FULL recovery state: dropping recoveryBaseline would re-open the phase on the
+        // next check (repeat note, undrainable comparison).
+        if (state) state.remConsolidationAlarm = {alarmed: nextAlarmState.alarmed, stalledSince, recoveryBaseline: nextAlarmState.recoveryBaseline};
 
         const details = {
             reason,

--- a/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.mjs
+++ b/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.mjs
@@ -144,6 +144,11 @@ export function evaluateConsolidationStallAlarm({hasCycle, readFault, stalenessM
     // Backlog guard is load-bearing: no undigested work → nothing to consolidate → never a stall.
     const stalled = thresholdMs > 0 && hasBacklog && cycleStale;
 
+    // Recovery onset is a genuinely SUPPRESSED stall — wall-clock stale past the threshold with the
+    // backlog present, held back only by the young process. A pre-boot cycle with no backlog or
+    // with sub-threshold wall age opens no phase (no permanent baseline-0 latch, no noise phase).
+    const suppressedStall = thresholdMs > 0 && hasBacklog && hasCycle && stalenessMs > thresholdMs && effectiveStalenessMs <= thresholdMs;
+
     if (!stalled) {
         // Recovery phase open? Only a strictly decreasing backlog completes it — a non-stalled
         // reading with an undrained backlog holds the latch (drain observed, never assumed).
@@ -154,9 +159,9 @@ export function evaluateConsolidationStallAlarm({hasCycle, readFault, stalenessM
             return {stalled: false, shouldAlarm: false, downTimeSuppressed, drainObserved: false, recoveryStarted: false, effectiveStalenessMs, nextAlarmState: {alarmed: alreadyAlarmed, stalledSince: alarmState?.stalledSince ?? null, recoveryBaseline: baseline}};
         }
 
-        // First downtime-suppressed reading opens the recovery phase: resume note fires exactly
+        // First genuinely-suppressed stall opens the recovery phase: resume note fires exactly
         // once (on this transition), and the baseline makes the drain observable across checks.
-        if (downTimeSuppressed) {
+        if (suppressedStall) {
             return {stalled: false, shouldAlarm: false, downTimeSuppressed, drainObserved: false, recoveryStarted: true, effectiveStalenessMs, nextAlarmState: {alarmed: false, stalledSince: null, recoveryBaseline: undigestedCount}};
         }
 

--- a/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.mjs
+++ b/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.mjs
@@ -91,39 +91,58 @@ export async function getRemCycleStaleness({remRunStateDir, now, readRecent = re
  * Latch: an alarm fires only on the transition into stalled (`stalled && !alreadyAlarmed`); once
  * latched it stays quiet on subsequent stalled checks; a healthy check clears the latch.
  *
+ * **Down-time exclusion:** `stalenessMs` is wall-clock age and therefore counts intervals when the
+ * orchestrator was not running at all (host off, laptop lid closed, process intentionally stopped)
+ * — time in which no cycle could have run by design. When `uptimeMs` is provided, the stall clock
+ * is the *effective* staleness: `min(stalenessMs, uptimeMs)` for a recorded cycle, or `uptimeMs`
+ * when no cycle exists. A deployment that was off for 6.5h and booted 5 minutes ago evaluates as
+ * 5 minutes stale — digest-resume, not a stall — while a genuinely starved consolidation still
+ * alarms once the *process* has been up past the threshold without a cycle. `downTimeSuppressed`
+ * marks the exclusion so the caller can log the resume note; callers that omit `uptimeMs` (default
+ * `Infinity`) get the legacy wall-clock behavior unchanged.
+ *
  * @param {Object} options
  * @param {Boolean} options.hasCycle Whether a REM cycle has been recorded (from {@link getRemCycleStaleness}).
  * @param {Boolean} [options.readFault] When true, the run-state read failed — fail soft to no alarm.
  * @param {Number} options.stalenessMs Age since the last successful cycle.
  * @param {Number} options.undigestedCount Current undigested-session backlog (the work-pending guard).
  * @param {Number} options.thresholdMs Stall threshold; `<= 0` disables alarming (never stalled).
+ * @param {Number} [options.uptimeMs] Orchestrator process uptime; caps the stall clock so host-offline
+ *   intervals cannot masquerade as consolidation starvation. Default `Infinity` (legacy behavior).
  * @param {Object} [options.alarmState] Prior latch state `{alarmed, stalledSince}` from task state.
- * @returns {{stalled: Boolean, shouldAlarm: Boolean, nextAlarmState: {alarmed: Boolean, stalledSince: (Number|null)}}}
+ * @returns {{stalled: Boolean, shouldAlarm: Boolean, downTimeSuppressed: Boolean,
+ *   effectiveStalenessMs: Number, nextAlarmState: {alarmed: Boolean, stalledSince: (Number|null)}}}
  */
-export function evaluateConsolidationStallAlarm({hasCycle, readFault, stalenessMs, undigestedCount, thresholdMs, alarmState} = {}) {
+export function evaluateConsolidationStallAlarm({hasCycle, readFault, stalenessMs, undigestedCount, thresholdMs, uptimeMs = Infinity, alarmState} = {}) {
     const alreadyAlarmed = !!alarmState?.alarmed;
 
     // Read fault → inconclusive; fail soft to no alarm and PRESERVE the latch (we neither observed a
     // healthy cycle to clear it, nor confirmed a stall to raise one).
     if (readFault) {
-        return {stalled: false, shouldAlarm: false, nextAlarmState: {alarmed: alreadyAlarmed, stalledSince: alarmState?.stalledSince ?? null}};
+        return {stalled: false, shouldAlarm: false, downTimeSuppressed: false, effectiveStalenessMs: stalenessMs, nextAlarmState: {alarmed: alreadyAlarmed, stalledSince: alarmState?.stalledSince ?? null}};
     }
 
     const hasBacklog = Number(undigestedCount) > 0;
-    // No recorded cycle is maximally stale (the `recentCycles: []` symptom); otherwise compare ages.
-    const cycleStale = !hasCycle || stalenessMs > thresholdMs;
+
+    // Down-time exclusion: no cycle could have run while the process was down, so the stall clock is
+    // the effective (uptime-capped) staleness. A recorded cycle older than the boot evaluates as the
+    // uptime; no recorded cycle at all evaluates as the uptime directly.
+    const effectiveStalenessMs = hasCycle ? Math.min(stalenessMs, uptimeMs) : uptimeMs,
+          downTimeSuppressed   = hasCycle && stalenessMs > uptimeMs,
+          cycleStale           = effectiveStalenessMs > thresholdMs;
+
     // Backlog guard is load-bearing: no undigested work → nothing to consolidate → never a stall.
-    const stalled    = thresholdMs > 0 && hasBacklog && cycleStale;
+    const stalled = thresholdMs > 0 && hasBacklog && cycleStale;
 
     if (!stalled) {
         // Healthy / nothing-to-do check: clear the latch so a future stall re-alarms.
-        return {stalled: false, shouldAlarm: false, nextAlarmState: {alarmed: false, stalledSince: null}};
+        return {stalled: false, shouldAlarm: false, downTimeSuppressed, effectiveStalenessMs, nextAlarmState: {alarmed: false, stalledSince: null}};
     }
 
     const shouldAlarm  = !alreadyAlarmed;
     const stalledSince = alreadyAlarmed ? (alarmState?.stalledSince ?? null) : null;
 
-    return {stalled: true, shouldAlarm, nextAlarmState: {alarmed: true, stalledSince}};
+    return {stalled: true, shouldAlarm, downTimeSuppressed, effectiveStalenessMs, nextAlarmState: {alarmed: true, stalledSince}};
 }
 
 /**

--- a/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.mjs
+++ b/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.mjs
@@ -101,6 +101,14 @@ export async function getRemCycleStaleness({remRunStateDir, now, readRecent = re
  * marks the exclusion so the caller can log the resume note; callers that omit `uptimeMs` (default
  * `Infinity`) get the legacy wall-clock behavior unchanged.
  *
+ * **Recovery baseline (drain verification):** a stall onset or a downtime-suppressed reading opens
+ * a recovery *phase*, not a healthy state. The evaluator persists `recoveryBaseline` (the backlog
+ * count at phase onset) inside `nextAlarmState`, and only a strictly DECREASING backlog completes
+ * the phase and clears the latch — a merely non-stalled reading with an unchanged backlog holds
+ * the state, so "the backlog actually drained" is observed, never assumed. `recoveryStarted`
+ * marks the transition into the phase (the caller emits its resume note exactly once, on that
+ * transition, never on every check).
+ *
  * @param {Object} options
  * @param {Boolean} options.hasCycle Whether a REM cycle has been recorded (from {@link getRemCycleStaleness}).
  * @param {Boolean} [options.readFault] When true, the run-state read failed — fail soft to no alarm.
@@ -109,17 +117,19 @@ export async function getRemCycleStaleness({remRunStateDir, now, readRecent = re
  * @param {Number} options.thresholdMs Stall threshold; `<= 0` disables alarming (never stalled).
  * @param {Number} [options.uptimeMs] Orchestrator process uptime; caps the stall clock so host-offline
  *   intervals cannot masquerade as consolidation starvation. Default `Infinity` (legacy behavior).
- * @param {Object} [options.alarmState] Prior latch state `{alarmed, stalledSince}` from task state.
- * @returns {{stalled: Boolean, shouldAlarm: Boolean, downTimeSuppressed: Boolean,
- *   effectiveStalenessMs: Number, nextAlarmState: {alarmed: Boolean, stalledSince: (Number|null)}}}
+ * @param {Object} [options.alarmState] Prior latch state `{alarmed, stalledSince, recoveryBaseline}` from task state.
+ * @returns {{stalled: Boolean, shouldAlarm: Boolean, downTimeSuppressed: Boolean, drainObserved: Boolean,
+ *   recoveryStarted: Boolean, effectiveStalenessMs: Number,
+ *   nextAlarmState: {alarmed: Boolean, stalledSince: (Number|null), recoveryBaseline: (Number|null)}}}
  */
 export function evaluateConsolidationStallAlarm({hasCycle, readFault, stalenessMs, undigestedCount, thresholdMs, uptimeMs = Infinity, alarmState} = {}) {
-    const alreadyAlarmed = !!alarmState?.alarmed;
+    const alreadyAlarmed = !!alarmState?.alarmed,
+          baseline       = Number.isFinite(alarmState?.recoveryBaseline) ? alarmState.recoveryBaseline : null;
 
     // Read fault → inconclusive; fail soft to no alarm and PRESERVE the latch (we neither observed a
     // healthy cycle to clear it, nor confirmed a stall to raise one).
     if (readFault) {
-        return {stalled: false, shouldAlarm: false, downTimeSuppressed: false, effectiveStalenessMs: stalenessMs, nextAlarmState: {alarmed: alreadyAlarmed, stalledSince: alarmState?.stalledSince ?? null}};
+        return {stalled: false, shouldAlarm: false, downTimeSuppressed: false, drainObserved: false, recoveryStarted: false, effectiveStalenessMs: stalenessMs, nextAlarmState: {alarmed: alreadyAlarmed, stalledSince: alarmState?.stalledSince ?? null, recoveryBaseline: baseline}};
     }
 
     const hasBacklog = Number(undigestedCount) > 0;
@@ -135,14 +145,29 @@ export function evaluateConsolidationStallAlarm({hasCycle, readFault, stalenessM
     const stalled = thresholdMs > 0 && hasBacklog && cycleStale;
 
     if (!stalled) {
-        // Healthy / nothing-to-do check: clear the latch so a future stall re-alarms.
-        return {stalled: false, shouldAlarm: false, downTimeSuppressed, effectiveStalenessMs, nextAlarmState: {alarmed: false, stalledSince: null}};
+        // Recovery phase open? Only a strictly decreasing backlog completes it — a non-stalled
+        // reading with an undrained backlog holds the latch (drain observed, never assumed).
+        if (baseline !== null) {
+            if (undigestedCount < baseline) {
+                return {stalled: false, shouldAlarm: false, downTimeSuppressed, drainObserved: true, recoveryStarted: false, effectiveStalenessMs, nextAlarmState: {alarmed: false, stalledSince: null, recoveryBaseline: null}};
+            }
+            return {stalled: false, shouldAlarm: false, downTimeSuppressed, drainObserved: false, recoveryStarted: false, effectiveStalenessMs, nextAlarmState: {alarmed: alreadyAlarmed, stalledSince: alarmState?.stalledSince ?? null, recoveryBaseline: baseline}};
+        }
+
+        // First downtime-suppressed reading opens the recovery phase: resume note fires exactly
+        // once (on this transition), and the baseline makes the drain observable across checks.
+        if (downTimeSuppressed) {
+            return {stalled: false, shouldAlarm: false, downTimeSuppressed, drainObserved: false, recoveryStarted: true, effectiveStalenessMs, nextAlarmState: {alarmed: false, stalledSince: null, recoveryBaseline: undigestedCount}};
+        }
+
+        // Genuinely healthy / nothing-to-do check: clear the latch so a future stall re-alarms.
+        return {stalled: false, shouldAlarm: false, downTimeSuppressed, drainObserved: false, recoveryStarted: false, effectiveStalenessMs, nextAlarmState: {alarmed: false, stalledSince: null, recoveryBaseline: null}};
     }
 
     const shouldAlarm  = !alreadyAlarmed;
     const stalledSince = alreadyAlarmed ? (alarmState?.stalledSince ?? null) : null;
 
-    return {stalled: true, shouldAlarm, downTimeSuppressed, effectiveStalenessMs, nextAlarmState: {alarmed: true, stalledSince}};
+    return {stalled: true, shouldAlarm, downTimeSuppressed, drainObserved: false, recoveryStarted: false, effectiveStalenessMs, nextAlarmState: {alarmed: true, stalledSince, recoveryBaseline: baseline ?? undigestedCount}};
 }
 
 /**

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.spec.mjs
@@ -102,6 +102,51 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog', () => 
         expect(r.stalled).toBe(false);
     });
 
+    // ── down-time exclusion (uptimeMs caps the stall clock) ───────────────────────────────────────
+    test('host-offline gap: a cycle older than the process uptime is digest-resume, not a stall', () => {
+        const r = evaluateConsolidationStallAlarm({
+            hasCycle  : true, stalenessMs: 23_400_000, undigestedCount: 22, thresholdMs: 21_600_000,
+            uptimeMs  : 300_000,
+            alarmState: {alarmed: true, stalledSince: 1}
+        });
+        expect(r.stalled).toBe(false);
+        expect(r.downTimeSuppressed).toBe(true);
+        expect(r.effectiveStalenessMs).toBe(300_000);
+        expect(r.nextAlarmState).toEqual({alarmed: false, stalledSince: null}); // latch still clears
+    });
+
+    test('alive-but-starved still alarms: uptime past the threshold with no fresh cycle', () => {
+        const r = evaluateConsolidationStallAlarm({
+            hasCycle: true, stalenessMs: 23_400_000, undigestedCount: 22, thresholdMs: 21_600_000,
+            uptimeMs: 25_200_000
+        });
+        expect(r.stalled).toBe(true);
+        expect(r.shouldAlarm).toBe(true);
+        expect(r.downTimeSuppressed).toBe(false);
+        expect(r.effectiveStalenessMs).toBe(23_400_000);
+    });
+
+    test('no recorded cycle + fresh boot gives the process a fair chance (no instant alarm)', () => {
+        const r = evaluateConsolidationStallAlarm({
+            hasCycle: false, stalenessMs: 0, undigestedCount: 5, thresholdMs: 6_000, uptimeMs: 5_000
+        });
+        expect(r.stalled).toBe(false);
+    });
+
+    test('no recorded cycle + uptime past the threshold is a genuine starvation stall', () => {
+        const r = evaluateConsolidationStallAlarm({
+            hasCycle: false, stalenessMs: 0, undigestedCount: 5, thresholdMs: 6_000, uptimeMs: 7_000
+        });
+        expect(r.stalled).toBe(true);
+        expect(r.shouldAlarm).toBe(true);
+    });
+
+    test('callers that omit uptimeMs keep the legacy wall-clock semantics', () => {
+        const r = evaluateConsolidationStallAlarm({hasCycle: true, stalenessMs: 10_000, undigestedCount: 5, thresholdMs: 6_000});
+        expect(r.stalled).toBe(true);
+        expect(r.downTimeSuppressed).toBe(false);
+    });
+
     // ── getDueTask (pure cadence) ────────────────────────────────────────────────────────────────
     test('getDueTask fires when the check cadence has elapsed', () => {
         expect(getDueTask({state: {lastRunAt: 0}, now: 2000, remConsolidationWatchdogCheckMs: 1000}))

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.spec.mjs
@@ -116,6 +116,23 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog', () => 
         expect(r.nextAlarmState).toEqual({alarmed: false, stalledSince: null, recoveryBaseline: 22});
     });
 
+    test('recovery onset requires a genuinely suppressed stall: zero backlog opens no phase', () => {
+        const r = evaluateConsolidationStallAlarm({
+            hasCycle: true, stalenessMs: 23_400_000, undigestedCount: 0, thresholdMs: 21_600_000, uptimeMs: 300_000
+        });
+        expect(r.recoveryStarted).toBe(false);
+        expect(r.nextAlarmState).toEqual({alarmed: false, stalledSince: null, recoveryBaseline: null}); // no baseline-0 latch
+    });
+
+    test('recovery onset requires wall-clock staleness past the threshold: a merely pre-boot cycle opens no phase', () => {
+        const r = evaluateConsolidationStallAlarm({
+            hasCycle: true, stalenessMs: 1_000_000, undigestedCount: 5, thresholdMs: 21_600_000, uptimeMs: 300_000
+        });
+        expect(r.downTimeSuppressed).toBe(true); // informational flag still reports the pre-boot cycle
+        expect(r.recoveryStarted).toBe(false);
+        expect(r.nextAlarmState).toEqual({alarmed: false, stalledSince: null, recoveryBaseline: null});
+    });
+
     test('recovery holds on an undrained backlog: no note repeat, no latch clear', () => {
         const r = evaluateConsolidationStallAlarm({
             hasCycle  : true, stalenessMs: 23_400_000, undigestedCount: 22, thresholdMs: 21_600_000,
@@ -352,7 +369,42 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog — pipe
         expect(outcomes.some(o => o.status === 'failed')).toBe(false);
         expect(outcomes.some(o => o.status === 'completed')).toBe(true);
         expect(alarmCalls).toHaveLength(0);
-        expect(logLines.some(line => line.startsWith('INFO:') && line.includes('digest-resume'))).toBe(true)
+        expect(logLines.some(line => line.startsWith('INFO:') && line.includes('digest-resume'))).toBe(true);
+        // The full recovery state must persist across checks (baseline 5 from the undigested fixture)
+        expect(taskStateService.getTaskState('rem-consolidation-liveness-watchdog').remConsolidationAlarm)
+            .toEqual({alarmed: false, stalledSince: null, recoveryBaseline: 5});
+    });
+
+    test('two-run recovery: an unchanged backlog preserves the baseline and emits no second note; a decrease completes the phase', async () => {
+        const outcomes         = [];
+        const alarmCalls       = [];
+        const logLines         = [];
+        const dispatcher       = async payload => { alarmCalls.push(payload); };
+        const taskStateService = makeTaskStateService();
+        const now              = Date.now();
+
+        await appendRemRunState({runId: 'stale', completedAt: now - 7 * HOUR_MS}, {dir: remRunStateDir});
+
+        const runtime = makeRuntime({
+            remConsolidationWatchdogUptimeMs: 5 * 60 * 1000,
+            writeLog                        : (level, line) => logLines.push(`${level}:${line}`)
+        });
+
+        // Run 1 — recovery opens
+        await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime});
+        expect(logLines.filter(line => line.includes('digest-resume'))).toHaveLength(1);
+
+        // Run 2 — unchanged backlog: phase holds, no second note, baseline preserved
+        await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime});
+        expect(logLines.filter(line => line.includes('digest-resume'))).toHaveLength(1);
+        expect(taskStateService.getTaskState('rem-consolidation-liveness-watchdog').remConsolidationAlarm.recoveryBaseline).toBe(5);
+        expect(outcomes.filter(o => o.details?.drainObserved === true)).toHaveLength(0);
+
+        // Run 3 — decreased backlog: drain observed, phase completes, latch + baseline cleared
+        await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime, undigestedCount: 2});
+        expect(taskStateService.getTaskState('rem-consolidation-liveness-watchdog').remConsolidationAlarm)
+            .toEqual({alarmed: false, stalledSince: null, recoveryBaseline: null});
+        expect(outcomes.some(o => o.details?.drainObserved === true)).toBe(true)
     });
 
     test('fires the active alarm once on stall-onset and latches subsequent stalled checks', async () => {
@@ -436,6 +488,6 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog — pipe
         expect(outcomes.some(o => o.status === 'completed')).toBe(true);
         expect(alarmCalls).toHaveLength(0);
         expect(taskStateService.getTaskState('rem-consolidation-liveness-watchdog').remConsolidationAlarm)
-            .toEqual({alarmed: false, stalledSince: null});
+            .toEqual({alarmed: false, stalledSince: null, recoveryBaseline: null});
     });
 });

--- a/test/playwright/unit/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.spec.mjs
+++ b/test/playwright/unit/ai/daemons/orchestrator/scheduling/remConsolidationLivenessWatchdog.spec.mjs
@@ -70,7 +70,7 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog', () => 
         });
         expect(r.stalled).toBe(false);
         expect(r.shouldAlarm).toBe(false);
-        expect(r.nextAlarmState).toEqual({alarmed: true, stalledSince: 1});
+        expect(r.nextAlarmState).toEqual({alarmed: true, stalledSince: 1, recoveryBaseline: null});
     });
 
     test('one-shot latch: no re-alarm while already alarmed', () => {
@@ -88,7 +88,7 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog', () => 
             alarmState: {alarmed: true, stalledSince: 1}
         });
         expect(r.stalled).toBe(false);
-        expect(r.nextAlarmState).toEqual({alarmed: false, stalledSince: null});
+        expect(r.nextAlarmState).toEqual({alarmed: false, stalledSince: null, recoveryBaseline: null});
     });
 
     test('a recent cycle below the threshold is healthy (not stalled)', () => {
@@ -103,7 +103,7 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog', () => 
     });
 
     // ── down-time exclusion (uptimeMs caps the stall clock) ───────────────────────────────────────
-    test('host-offline gap: a cycle older than the process uptime is digest-resume, not a stall', () => {
+    test('host-offline gap: a cycle older than the process uptime opens a recovery phase, not an alarm', () => {
         const r = evaluateConsolidationStallAlarm({
             hasCycle  : true, stalenessMs: 23_400_000, undigestedCount: 22, thresholdMs: 21_600_000,
             uptimeMs  : 300_000,
@@ -111,8 +111,40 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog', () => 
         });
         expect(r.stalled).toBe(false);
         expect(r.downTimeSuppressed).toBe(true);
+        expect(r.recoveryStarted).toBe(true);
         expect(r.effectiveStalenessMs).toBe(300_000);
-        expect(r.nextAlarmState).toEqual({alarmed: false, stalledSince: null}); // latch still clears
+        expect(r.nextAlarmState).toEqual({alarmed: false, stalledSince: null, recoveryBaseline: 22});
+    });
+
+    test('recovery holds on an undrained backlog: no note repeat, no latch clear', () => {
+        const r = evaluateConsolidationStallAlarm({
+            hasCycle  : true, stalenessMs: 23_400_000, undigestedCount: 22, thresholdMs: 21_600_000,
+            uptimeMs  : 300_000,
+            alarmState: {alarmed: false, stalledSince: null, recoveryBaseline: 22}
+        });
+        expect(r.stalled).toBe(false);
+        expect(r.recoveryStarted).toBe(false); // note already fired at phase onset — never repeated
+        expect(r.drainObserved).toBe(false);
+        expect(r.nextAlarmState).toEqual({alarmed: false, stalledSince: null, recoveryBaseline: 22});
+    });
+
+    test('recovery completes only when the backlog strictly decreases (drain observed)', () => {
+        const r = evaluateConsolidationStallAlarm({
+            hasCycle  : true, stalenessMs: 23_400_000, undigestedCount: 7, thresholdMs: 21_600_000,
+            uptimeMs  : 300_000,
+            alarmState: {alarmed: false, stalledSince: null, recoveryBaseline: 22}
+        });
+        expect(r.stalled).toBe(false);
+        expect(r.drainObserved).toBe(true);
+        expect(r.nextAlarmState).toEqual({alarmed: false, stalledSince: null, recoveryBaseline: null});
+    });
+
+    test('stall onset records the backlog baseline for the recovery phase', () => {
+        const r = evaluateConsolidationStallAlarm({
+            hasCycle: true, stalenessMs: 10_000, undigestedCount: 5, thresholdMs: 6_000
+        });
+        expect(r.stalled).toBe(true);
+        expect(r.nextAlarmState.recoveryBaseline).toBe(5);
     });
 
     test('alive-but-starved still alarms: uptime past the threshold with no fresh cycle', () => {
@@ -206,8 +238,12 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog — pipe
 
     function makeRuntime(overrides = {}) {
         return {
-            remConsolidationWatchdogRunStateDir : remRunStateDir,
-            remConsolidationWatchdogThresholdMs : 6 * HOUR_MS,
+            remConsolidationWatchdogRunStateDir: remRunStateDir,
+            remConsolidationWatchdogThresholdMs: 6 * HOUR_MS,
+            // Pin the process-age dimension: stall fixtures need an uptime past the threshold so the
+            // verdict never depends on ambient test-worker uptime. The digest-resume witness below
+            // overrides this with a young process age.
+            remConsolidationWatchdogUptimeMs    : 8 * HOUR_MS,
             remConsolidationWatchdogAlarmEnabled: true,
             writeLog                            : () => {},
             ...overrides
@@ -294,6 +330,29 @@ test.describe('orchestrator/scheduling/remConsolidationLivenessWatchdog — pipe
             // ...and the alarm still fires regardless (advisory-only classification).
             expect(alarmCalls.length).toBeGreaterThanOrEqual(1);
         }
+    });
+
+    test('host-offline gap at pipeline level: young process + stale cycle = digest-resume, never the alarm', async () => {
+        const outcomes         = [];
+        const alarmCalls       = [];
+        const logLines         = [];
+        const dispatcher       = async payload => { alarmCalls.push(payload); };
+        const taskStateService = makeTaskStateService();
+        const now              = Date.now();
+
+        await appendRemRunState({runId: 'stale', completedAt: now - 7 * HOUR_MS}, {dir: remRunStateDir});
+
+        const runtime = makeRuntime({
+            remConsolidationWatchdogUptimeMs: 5 * 60 * 1000, // booted 5 minutes ago after an overnight off
+            writeLog                        : (level, line) => logLines.push(`${level}:${line}`)
+        });
+
+        await runWatchdogOnce({taskStateService, outcomes, dispatcher, runtime});
+
+        expect(outcomes.some(o => o.status === 'failed')).toBe(false);
+        expect(outcomes.some(o => o.status === 'completed')).toBe(true);
+        expect(alarmCalls).toHaveLength(0);
+        expect(logLines.some(line => line.startsWith('INFO:') && line.includes('digest-resume'))).toBe(true)
     });
 
     test('fires the active alarm once on stall-onset and latches subsequent stalled checks', async () => {


### PR DESCRIPTION
Resolves #15687

The REM consolidation-liveness watchdog's stall verdict was wall-clock blind: `stalenessMs = now - lastCompletedAt` counts intervals when the orchestrator was not running at all — time no cycle could have run by design. A normal overnight host-off on the canonical laptop deployment therefore manufactured a swarm-wide STALLED alert (2026-07-22T08:09Z; operator-confirmed stopped host, not a consolidation failure; the retracted #15686 records the wrong wedge theory this alert nearly produced).

The stall clock is now *effective* staleness: the pure evaluator accepts `uptimeMs` (the pipeline passes `process.uptime()`, injectable via `runtime.remConsolidationWatchdogUptimeMs` so fixtures never depend on ambient test-worker age) and computes `min(stalenessMs, uptimeMs)` for a recorded cycle, or `uptimeMs` for no cycle. A deployment that was off 6.5h and booted 5 minutes ago evaluates as 5 minutes stale — recovery, not stall.

Recovery is a *phase*, not an instant-healthy state (per Euclid's Cycle-1 RA): the evaluator persists a `recoveryBaseline` (backlog count at phase onset) in the task-state latch, and only a strictly **decreasing** backlog completes the phase and clears the latch — an unchanged backlog holds, so drain is observed, never assumed. The digest-resume INFO note fires exactly once at phase onset (never on every check). Callers that omit `uptimeMs` keep the legacy wall-clock semantics unchanged (default `Infinity`).

Evidence: L2 (pure-evaluator witnesses across the downtime + recovery matrix, the pipeline alarm suite with pinned uptime, and a pipeline-level digest-resume witness) → L2 required (all ACs are source/test-verifiable). Residual: post-merge observation only.

## Deltas from ticket

The recovery-phase baseline implements the ticket's drain-verification AC explicitly (the original submission leaned on the healthy-check latch clear — Euclid's review caught that gap along with the ambient-`process.uptime()` test-isolation break, both repaired in `bce8f9cdd5`). Ticket option 1 (down-time exclusion) with the option-2 INFO digest-resume note folded in.

## Test Evidence

- Focused spec: 32/32 passed — pure witnesses pin: host-offline gap → recovery opens (no alarm); unchanged backlog → phase holds, no note repeat; strictly decreased backlog → drain observed, latch clears; stall onset records baseline; no-cycle + fresh boot → fair chance; no-cycle + old process → starvation stall; omitted uptimeMs → legacy semantics. Pipeline-level witness: young process + 7h-stale cycle → completed outcome + one digest-resume INFO + zero alarm dispatches.
- `test/playwright/unit/ai/daemons/orchestrator/` full directory: 880/880 passed.
- Honesty note on Cycle-1 numbers: the earlier "23/23 + 871/871 green" claim was read on an invalid tree state during a husky/lint-staged revert cycle and did not hold at exact head (CI red, reproduced branch-locally as 5 failures) — the current head's numbers above are the valid ones.

## Post-Merge Validation

- [ ] Next natural overnight-off: no STALLED broadcast; one digest-resume INFO line in orchestrator.log, then phase completion as the backlog drains over the following cycles
- [ ] A real alive-but-starved stall still alarms (no latch residue after recovery)

Authored by Phoebe (Kimi K3, OpenCode). Session 72c8c42d-f18a-408c-97c8-aeb1f82dd276.
