### PR TITLE
feat(ai): reconcile pull request activity exhaustively (#15153)

### DIFF
--- a/ai/mcp/server/memory-core/openapi.yaml
+++ b/ai/mcp/server/memory-core/openapi.yaml
@@ -3561,6 +3561,11 @@ components:
         providerEntityId:
           type: string
           minLength: 1
+        parentProviderEntityId:
+          type: string
+          minLength: 1
+          nullable: true
+          description: Stable provider entity id of the containing resource, when this occurrence is a child.
         occurrenceKind:
           type: string
           minLength: 1
@@ -3576,6 +3581,16 @@ components:
         actorKind:
           type: string
           enum: [user, bot, organization, mannequin, enterprise-user, unknown]
+        providerState:
+          type: string
+          minLength: 1
+          nullable: true
+          description: Provider-native categorical state for this occurrence.
+        sourceAssociation:
+          type: string
+          minLength: 1
+          nullable: true
+          description: Provider-native actor association with the containing source.
         revisionOf:
           type: string
           nullable: true

--- a/ai/services/github-workflow/PullRequestHistoryService.mjs
+++ b/ai/services/github-workflow/PullRequestHistoryService.mjs
@@ -314,7 +314,10 @@ function appendGraphqlChildren(target, ids, nodes, kind) {
  * @param {Object} options
  * @returns {Promise<Object>}
  */
-async function exhaustGraphqlConversation({pullRequest, query, owner, repo}) {
+export async function exhaustGraphqlConversation({
+    pullRequest, query, owner, repo,
+    childrenQuery = FETCH_PULL_REQUEST_HISTORY_CHILDREN
+}) {
     const comments       = [],
           reviews        = [],
           commentIds     = new Set(),
@@ -341,7 +344,7 @@ async function exhaustGraphqlConversation({pullRequest, query, owner, repo}) {
             throw new Error(`PullRequestHistoryService: PR #${pullRequest.number} child pagination has no progress cursor`)
         }
 
-        const data = await query(FETCH_PULL_REQUEST_HISTORY_CHILDREN, {
+        const data = await query(childrenQuery, {
                   owner,
                   repo,
                   prNumber  : pullRequest.number,
@@ -403,7 +406,30 @@ async function exhaustGraphqlConversation({pullRequest, query, owner, repo}) {
  * @param {Object} options
  * @returns {Promise<{reviewComments: Object[], pageQueries: Number}>}
  */
-async function readReviewCommentPass({pullRequest, rest, owner, repo}) {
+function projectReviewComment(comment, includeActorMetadata) {
+    return {
+        id      : String(comment.id),
+        reviewId: comment.pull_request_review_id == null ? null : String(comment.pull_request_review_id),
+        ...(includeActorMetadata ? {nodeId: comment.node_id ?? null} : {}),
+        author  : {
+            login: comment.user?.login || null,
+            ...(includeActorMetadata ? {__typename: comment.user?.type || null} : {})
+        },
+        ...(includeActorMetadata ? {authorAssociation: comment.author_association ?? null} : {}),
+        body       : comment.body || '',
+        createdAt  : comment.created_at,
+        updatedAt  : comment.updated_at,
+        url        : comment.html_url,
+        inReplyToId: comment.in_reply_to_id == null ? null : String(comment.in_reply_to_id)
+    }
+}
+
+/**
+ * @summary Reads one complete, explicitly ordered pass of one PR's inline review comments.
+ * @param {Object} options
+ * @returns {Promise<{reviewComments: Object[], pageQueries: Number}>}
+ */
+async function readReviewCommentPass({pullRequest, rest, owner, repo, includeActorMetadata}) {
     const reviewComments = [],
           ids            = new Set();
     let page = 1;
@@ -428,16 +454,7 @@ async function readReviewCommentPass({pullRequest, rest, owner, repo}) {
             }
 
             ids.add(comment.id);
-            reviewComments.push({
-                id         : String(comment.id),
-                reviewId   : comment.pull_request_review_id == null ? null : String(comment.pull_request_review_id),
-                author     : {login: comment.user?.login || null},
-                body       : comment.body || '',
-                createdAt  : comment.created_at,
-                updatedAt  : comment.updated_at,
-                url        : comment.html_url,
-                inReplyToId: comment.in_reply_to_id == null ? null : String(comment.in_reply_to_id)
-            })
+            reviewComments.push(projectReviewComment(comment, includeActorMetadata))
         }
 
         if (raw.length < REST_PAGE_SIZE) break;
@@ -453,11 +470,16 @@ async function readReviewCommentPass({pullRequest, rest, owner, repo}) {
  * A PR `updatedAt` value is not a mechanical snapshot token for this distinct REST collection. Two complete,
  * ordered passes must therefore agree byte-for-byte before the service can claim child exhaustion.
  * @param {Object} options
+ * @param {Boolean} [options.includeActorMetadata=false] Opt-in provider identity metadata for
+ * reconciliation without changing the resolved-history projection or its revision digest.
  * @returns {Promise<{reviewComments: Object[], evidence: Object}>}
  */
-async function exhaustReviewComments({pullRequest, rest, owner, repo}) {
-    const first        = await readReviewCommentPass({pullRequest, rest, owner, repo}),
-          verification = await readReviewCommentPass({pullRequest, rest, owner, repo});
+export async function exhaustReviewComments({
+    pullRequest, rest, owner, repo, includeActorMetadata = false
+}) {
+    const options      = {pullRequest, rest, owner, repo, includeActorMetadata},
+          first        = await readReviewCommentPass(options),
+          verification = await readReviewCommentPass(options);
 
     if (JSON.stringify(first.reviewComments) !== JSON.stringify(verification.reviewComments)) {
         throw new Error(`PullRequestHistoryService: PR #${pullRequest.number} review comments mutated during verification`)
@@ -467,6 +489,119 @@ async function exhaustReviewComments({pullRequest, rest, owner, repo}) {
         reviewComments: first.reviewComments,
         evidence      : {
             fetched         : first.reviewComments.length,
+            exhausted       : true,
+            pageQueries     : first.pageQueries + verification.pageQueries,
+            snapshotVerified: true,
+            validationPasses: 2
+        }
+    }
+}
+
+/**
+ * @summary Reads one repository-wide pass of inline review comments. GitHub's repository endpoint
+ * avoids a guaranteed two-REST-requests-per-PR floor while retaining stable ordering, duplicate-id
+ * rejection, and the PR-number correlation needed to restore independent child families.
+ * @param {Object} options
+ * @returns {Promise<{entries: Object[], pageQueries: Number}>}
+ */
+async function readRepositoryReviewCommentPass({rest, owner, repo, includeActorMetadata}) {
+    const entries = [],
+          ids     = new Set();
+
+    let page = 1;
+
+    for (;;) {
+        const raw = await rest(
+            'GET',
+            `/repos/${owner}/${repo}/pulls/comments` +
+            `?per_page=${REST_PAGE_SIZE}&page=${page}&sort=created&direction=asc`
+        );
+
+        if (!Array.isArray(raw)) {
+            throw new Error('PullRequestHistoryService: repository review-comment page is not an array')
+        }
+
+        for (const comment of raw) {
+            const match = typeof comment?.pull_request_url === 'string'
+                ? comment.pull_request_url.match(/\/pulls\/(\d+)$/)
+                : null;
+
+            if (!Number.isInteger(comment?.id) || !match) {
+                throw new Error('PullRequestHistoryService: repository review comment is missing its stable id or PR correlation')
+            }
+            if (ids.has(comment.id)) {
+                throw new Error(`PullRequestHistoryService: duplicate review-comment id ${comment.id}`)
+            }
+
+            ids.add(comment.id);
+            entries.push({
+                pullRequestNumber: Number(match[1]),
+                comment          : projectReviewComment(comment, includeActorMetadata)
+            })
+        }
+
+        if (raw.length < REST_PAGE_SIZE) break;
+        page++
+    }
+
+    return {entries, pageQueries: page}
+}
+
+/**
+ * @summary Exhausts and independently revalidates the repository-wide inline review-comment
+ * collection, then groups the verified snapshot by PR number. This is the reconciliation path:
+ * its request count scales with comment pages, not repository PR count.
+ * @param {Object} options
+ * @param {Boolean} [options.includeActorMetadata=false]
+ * @returns {Promise<{reviewCommentsByPullRequestNumber: Map<Number,Object[]>, failuresByPullRequestNumber: Map<Number,String>, evidence: Object}>}
+ */
+export async function exhaustRepositoryReviewComments({
+    rest, owner, repo, includeActorMetadata = false
+}) {
+    const options      = {rest, owner, repo, includeActorMetadata},
+          first        = await readRepositoryReviewCommentPass(options),
+          verification = await readRepositoryReviewCommentPass(options);
+
+    const group = entries => {
+              const groups = new Map();
+
+              for (const {pullRequestNumber, comment} of entries) {
+                  if (!groups.has(pullRequestNumber)) {
+                      groups.set(pullRequestNumber, [])
+                  }
+
+                  groups.get(pullRequestNumber).push(comment)
+              }
+
+              return groups
+          },
+          firstGroups                       = group(first.entries),
+          verificationGroups                = group(verification.entries),
+          reviewCommentsByPullRequestNumber = new Map(),
+          failuresByPullRequestNumber       = new Map(),
+          pullRequestNumbers                = new Set([
+              ...firstGroups.keys(), ...verificationGroups.keys()
+          ]);
+
+    for (const pullRequestNumber of pullRequestNumbers) {
+        const firstComments        = firstGroups.get(pullRequestNumber) ?? [],
+              verificationComments = verificationGroups.get(pullRequestNumber) ?? [];
+
+        if (JSON.stringify(firstComments) !== JSON.stringify(verificationComments)) {
+            failuresByPullRequestNumber.set(
+                pullRequestNumber,
+                `PullRequestHistoryService: PR #${pullRequestNumber} repository review comments mutated during verification`
+            )
+        } else {
+            reviewCommentsByPullRequestNumber.set(pullRequestNumber, firstComments)
+        }
+    }
+
+    return {
+        reviewCommentsByPullRequestNumber,
+        failuresByPullRequestNumber,
+        evidence: {
+            fetched         : first.entries.length,
             exhausted       : true,
             pageQueries     : first.pageQueries + verification.pageQueries,
             snapshotVerified: true,

--- a/ai/services/github-workflow/PullRequestReconciliationService.mjs
+++ b/ai/services/github-workflow/PullRequestReconciliationService.mjs
@@ -1,0 +1,406 @@
+import Base                           from '../../../src/core/Base.mjs';
+import CommunityBatchAdmissionService from '../memory-core/CommunityBatchAdmissionService.mjs';
+import GraphqlService                 from './GraphqlService.mjs';
+import SourceRegistryService          from '../memory-core/SourceRegistryService.mjs';
+import {assembleIssueBatch}           from './community/assembleIssueBatch.mjs';
+import {classifyAbsences}             from './community/githubIssueAbsence.mjs';
+import {reconcilePullRequestActivity} from './community/githubPullRequestReconciliation.mjs';
+import {
+    exhaustGraphqlConversation,
+    exhaustRepositoryReviewComments
+} from './PullRequestHistoryService.mjs';
+import {
+    FETCH_RECONCILE_PULL_REQUEST_CENSUS,
+    FETCH_RECONCILE_PULL_REQUEST_CHILDREN,
+    FETCH_RECONCILE_PULL_REQUEST_CONTENT_REVISIONS,
+    FETCH_RECONCILE_PULL_REQUEST_TIMELINE,
+    FETCH_RECONCILE_PULL_REQUESTS,
+    FETCH_RECONCILE_USER_CONTENT_EDIT_HEADS,
+    FETCH_RECONCILE_USER_CONTENT_EDITS
+} from './queries/pullRequestReconciliationQueries.mjs';
+
+const GRAPHQL_NODE_BATCH_SIZE = 100;
+
+const CONTENT_EDIT_TYPENAMES = new Set([
+    'PullRequest', 'IssueComment', 'PullRequestReview', 'PullRequestReviewComment'
+]);
+
+/**
+ * @class Neo.ai.services.github-workflow.PullRequestReconciliationService
+ * @extends Neo.core.Base
+ * @summary Orchestrates durable, exhaustive PR/review occurrence reconciliation. Every pass
+ * re-enumerates OPEN/CLOSED/MERGED roots, reuses PullRequestHistoryService's independently
+ * progress-checked comment/review pagination and two-pass inline-comment verification, exhausts
+ * provider timeline events, verifies the root census, assembles one metadata-only neutral batch,
+ * and advances its checkpoint only through durable admission.
+ *
+ * Deletion evidence remains fail-closed: a vanished root becomes `pull_request.deleted` only when
+ * the injected provider seam supplies a tombstone; otherwise it is an inventory-access gap. GitHub
+ * review and inline-review-comment deletion histories that have no exhaustive tombstone surface are
+ * named by runner coverage rather than fabricated.
+ */
+class PullRequestReconciliationService extends Base {
+    static config = {
+        /**
+         * @member {String} className='Neo.ai.services.github-workflow.PullRequestReconciliationService'
+         * @protected
+         */
+        className: 'Neo.ai.services.github-workflow.PullRequestReconciliationService',
+        /**
+         * @member {Boolean} singleton=true
+         * @protected
+         */
+        singleton: true
+    }
+
+    /**
+     * @summary Runs one PR-family reconciliation and submits its neutral batch for admission.
+     * @param {Object} spec
+     * @param {String} spec.sourceInstanceId
+     * @param {String} [spec.resourceFamily='pulls']
+     * @param {String} spec.owner
+     * @param {String} spec.repo
+     * @param {String} spec.batchId
+     * @param {String} [spec.observedAt]
+     * @param {Object} [spec.pageSizes] `{rootPage, childPage, timelinePage, editPage}`.
+     * @param {Object} [spec.caps] `{maxRootPages, maxTimelinePagesPerPullRequest, maxEditPagesPerEntity}`.
+     * @param {Function} [spec.acquireDeletionEvidence] async vanished root ids → provider evidence map.
+     * @param {Object} [spec.admissionService]
+     * @param {Object} [spec.graphqlService]
+     * @param {Object} [spec.registryService]
+     * @returns {Promise<Object>} Admission receipt.
+     */
+    async reconcile({
+        sourceInstanceId, resourceFamily = 'pulls', owner, repo, batchId, observedAt,
+        pageSizes = {}, caps = {},
+        acquireDeletionEvidence = async () => ({}),
+        admissionService        = CommunityBatchAdmissionService,
+        graphqlService          = GraphqlService,
+        registryService         = SourceRegistryService
+    }) {
+        const {rootPage = 50, childPage = 100, timelinePage = 100, editPage = 100} = pageSizes;
+
+        const registration = registryService.getRegistration(sourceInstanceId);
+
+        if (!registration || registration.lifecycleState !== 'ACTIVE') {
+            throw new Error('PULL_REQUEST_RECONCILIATION_SOURCE_NOT_ACTIVE')
+        }
+
+        // The durable checkpoint is the admission CAS basis, never a resume cursor. Mutable roots
+        // and their child families must be re-enumerated from genesis on every pass.
+        const checkpoint            = admissionService.getCheckpoint(sourceInstanceId, resourceFamily),
+              baseCheckpointVersion = checkpoint?.checkpointVersion ?? 0,
+              baseInventoryHash     = checkpoint?.inventoryHash     ?? null,
+              priorInventory        = admissionService.listObservations(sourceInstanceId)
+                  .filter(observation => observation.occurrenceKind === 'pull_request.opened')
+                  .map(observation => observation.providerEntityId),
+              seams                 = this.#buildSeams({
+                  graphqlService, owner, repo, rootPage, childPage, timelinePage, editPage
+              }),
+              runnerResult          = await reconcilePullRequestActivity(seams, caps),
+              currentInventory      = runnerResult.currentInventory,
+              vanished              = priorInventory.filter(id => !currentInventory.includes(id)),
+              deletionEvidenceById  = vanished.length ? await acquireDeletionEvidence(vanished) : {},
+              absences              = classifyAbsences(
+                  priorInventory,
+                  currentInventory,
+                  deletionEvidenceById
+              );
+
+        const batch = assembleIssueBatch({
+            sourceInstanceId,
+            resourceFamily,
+            registrationEpoch         : registration.registrationEpoch,
+            baseCheckpointVersion,
+            baseInventoryHash,
+            runnerResult,
+            absences,
+            currentInventory,
+            batchId,
+            observedAt                : observedAt ?? new Date().toISOString(),
+            adapterSchemaVersion      : 'github-pull-request.v1',
+            providerStateSchemaVersion: 'github-pull-request-state.v1',
+            deletionOccurrenceKind    : 'pull_request.deleted'
+        });
+
+        // Admission owns receipt persistence and the only durable checkpoint transition.
+        return admissionService.admitBatch(batch)
+    }
+
+    /**
+     * @summary Builds the live acquisition seams consumed by reconcilePullRequestActivity.
+     * @param {Object} deps
+     * @returns {Object}
+     * @private
+     */
+    #buildSeams({graphqlService, owner, repo, rootPage, childPage, timelinePage, editPage}) {
+        const query = (queryString, variables) => graphqlService.query(queryString, variables),
+              rest  = (method, path) => graphqlService.rest(method, path);
+
+        return {
+            fetchPullRequestsPage: async ({cursor}) => {
+                const data = await query(FETCH_RECONCILE_PULL_REQUESTS, {
+                          owner, repo, after: cursor, rootPage, childPage, timelinePage
+                      }),
+                      connection = data?.repository?.pullRequests;
+
+                return {
+                    pullRequests: (connection?.nodes ?? []).map(node => ({
+                        ...node,
+                        timeline: node.timelineItems
+                    })),
+                    pageInfo  : connection?.pageInfo,
+                    totalCount: connection?.totalCount
+                }
+            },
+
+            exhaustConversation: ({pullRequest}) => exhaustGraphqlConversation({
+                pullRequest,
+                query,
+                owner,
+                repo,
+                childrenQuery: FETCH_RECONCILE_PULL_REQUEST_CHILDREN
+            }),
+
+            fetchTimelinePage: async ({pullRequestId, cursor}) => {
+                const data = await query(FETCH_RECONCILE_PULL_REQUEST_TIMELINE, {
+                          pullRequestId, after: cursor, timelinePage
+                      }),
+                      pullRequest = data?.node,
+                      connection  = pullRequest?.timelineItems;
+
+                return {
+                    events             : connection?.nodes,
+                    pageInfo           : connection?.pageInfo,
+                    filteredCount      : connection?.filteredCount,
+                    connectionUpdatedAt: connection?.updatedAt,
+                    rootUpdatedAt      : pullRequest?.updatedAt
+                }
+            },
+
+            fetchReviewCommentSnapshot: () => exhaustRepositoryReviewComments({
+                rest,
+                owner,
+                repo,
+                includeActorMetadata: true
+            }),
+
+            fetchContentEditHeads: ({entities}) => this.#hydrateContentEditHeads({
+                entities, query, editPage
+            }),
+
+            fetchContentEditsPage: async ({entityNodeId, cursor}) => {
+                const data = await query(FETCH_RECONCILE_USER_CONTENT_EDITS, {
+                    entityId: entityNodeId,
+                    after   : cursor,
+                    editPage
+                });
+
+                return data?.node
+            },
+
+            verifyContentEntities: ({entities}) => this.#verifyContentEntities({entities, query}),
+
+            fetchCensusPage: async ({cursor}) => {
+                const data = await query(FETCH_RECONCILE_PULL_REQUEST_CENSUS, {
+                          owner, repo, after: cursor, rootPage
+                      }),
+                      connection = data?.repository?.pullRequests;
+
+                return {
+                    pullRequests: (connection?.nodes ?? []).map(node => ({
+                        ...node,
+                        timeline: node.timelineItems
+                    })),
+                    pageInfo  : connection?.pageInfo,
+                    totalCount: connection?.totalCount
+                }
+            }
+        }
+    }
+
+    /**
+     * @summary Batches GraphQL revision-head hydration for every content entity. Stable node ids
+     * bridge REST-enumerated inline comments while keeping the high-multiplicity edit connection out
+     * of root/comment/review census queries.
+     * @param {Object} options
+     * @returns {Promise<Object[]>} One ordered settled outcome per input entity.
+     * @private
+     */
+    async #hydrateContentEditHeads({entities, query, editPage}) {
+        const outcomes = new Array(entities.length);
+
+        for (let offset = 0; offset < entities.length; offset += GRAPHQL_NODE_BATCH_SIZE) {
+            const batch = entities.slice(offset, offset + GRAPHQL_NODE_BATCH_SIZE)
+                .map((entity, index) => ({entity, index: offset + index})),
+                  valid = [];
+
+            batch.forEach(entry => {
+                const nodeId = entry.entity?.nodeId ?? entry.entity?.id;
+
+                if (typeof nodeId !== 'string' || !nodeId) {
+                    outcomes[entry.index] = {
+                        status: 'rejected', reason: 'PULL_REQUEST_RECONCILIATION_CONTENT_NODE_ID_MISSING'
+                    }
+                } else {
+                    valid.push({...entry, nodeId})
+                }
+            });
+
+            if (valid.length === 0) {
+                continue
+            }
+
+            let nodes;
+
+            try {
+                const data = await query(FETCH_RECONCILE_USER_CONTENT_EDIT_HEADS, {
+                    ids: valid.map(entry => entry.nodeId), editPage
+                });
+
+                nodes = data?.nodes
+            } catch (error) {
+                const reason = error instanceof Error ? error.message : String(error);
+
+                valid.forEach(entry => {
+                    outcomes[entry.index] = {status: 'rejected', reason}
+                });
+                continue
+            }
+
+            if (!Array.isArray(nodes) || nodes.length !== valid.length) {
+                valid.forEach(entry => {
+                    outcomes[entry.index] = {
+                        status: 'rejected', reason: 'PULL_REQUEST_RECONCILIATION_CONTENT_EDIT_HEADS_INVALID'
+                    }
+                });
+                continue
+            }
+
+            const nodesById  = new Map(),
+                  duplicates = new Set();
+
+            for (const node of nodes) {
+                if (!node?.id) {
+                    continue
+                }
+                if (nodesById.has(node.id)) {
+                    duplicates.add(node.id)
+                }
+
+                nodesById.set(node.id, node)
+            }
+
+            valid.forEach(entry => {
+                const {entity, index, nodeId} = entry,
+                      node                    = nodesById.get(nodeId);
+
+                if (!node || duplicates.has(nodeId) || !CONTENT_EDIT_TYPENAMES.has(node.__typename) ||
+                    node.createdAt !== entity.createdAt || node.updatedAt !== entity.updatedAt) {
+                    outcomes[index] = {
+                        status: 'rejected', reason: `PULL_REQUEST_RECONCILIATION_CONTENT_MUTATED:${entity.id}`
+                    };
+                    return
+                }
+
+                outcomes[index] = {
+                    status: 'fulfilled',
+                    value : {
+                        ...entity,
+                        includesCreatedEdit: node.includesCreatedEdit,
+                        userContentEdits   : node.userContentEdits
+                    }
+                }
+            })
+        }
+
+        return outcomes
+    }
+
+    /**
+     * @summary Re-reads mutable content entity revision tokens in bounded GraphQL node batches.
+     * @param {Object} options
+     * @returns {Promise<Object[]>} One ordered settled outcome per expected revision.
+     * @private
+     */
+    async #verifyContentEntities({entities, query}) {
+        const outcomes = new Array(entities.length);
+
+        for (let offset = 0; offset < entities.length; offset += GRAPHQL_NODE_BATCH_SIZE) {
+            const batch = entities.slice(offset, offset + GRAPHQL_NODE_BATCH_SIZE)
+                .map((entity, index) => ({entity, index: offset + index})),
+                  valid = [];
+
+            batch.forEach(entry => {
+                if (typeof entry.entity?.id !== 'string' || !entry.entity.id) {
+                    outcomes[entry.index] = {
+                        status: 'rejected', reason: 'PULL_REQUEST_RECONCILIATION_CONTENT_VERIFICATION_ID_INVALID'
+                    }
+                } else {
+                    valid.push(entry)
+                }
+            });
+
+            if (valid.length === 0) {
+                continue
+            }
+
+            let nodes;
+
+            try {
+                const data = await query(FETCH_RECONCILE_PULL_REQUEST_CONTENT_REVISIONS, {
+                    ids: valid.map(entry => entry.entity.id)
+                });
+
+                nodes = data?.nodes
+            } catch (error) {
+                const reason = error instanceof Error ? error.message : String(error);
+
+                valid.forEach(entry => {
+                    outcomes[entry.index] = {status: 'rejected', reason}
+                });
+                continue
+            }
+
+            if (!Array.isArray(nodes) || nodes.length !== valid.length) {
+                valid.forEach(entry => {
+                    outcomes[entry.index] = {
+                        status: 'rejected', reason: 'PULL_REQUEST_RECONCILIATION_CONTENT_VERIFICATION_INVALID'
+                    }
+                });
+                continue
+            }
+
+            const nodesById  = new Map(),
+                  duplicates = new Set();
+
+            for (const node of nodes) {
+                if (!node?.id) {
+                    continue
+                }
+                if (nodesById.has(node.id)) {
+                    duplicates.add(node.id)
+                }
+
+                nodesById.set(node.id, node)
+            }
+
+            valid.forEach(({entity, index}) => {
+                const node = nodesById.get(entity.id);
+
+                if (!node || duplicates.has(entity.id) || !CONTENT_EDIT_TYPENAMES.has(node.__typename) ||
+                    node.updatedAt !== entity.updatedAt) {
+                    outcomes[index] = {
+                        status: 'rejected', reason: `PULL_REQUEST_RECONCILIATION_CONTENT_MUTATED:${entity.id}`
+                    }
+                } else {
+                    outcomes[index] = {status: 'fulfilled', value: node}
+                }
+            })
+        }
+
+        return outcomes
+    }
+}
+
+export default Neo.setupClass(PullRequestReconciliationService);

--- a/ai/services/github-workflow/community/githubPullRequestObservations.mjs
+++ b/ai/services/github-workflow/community/githubPullRequestObservations.mjs
@@ -1,0 +1,296 @@
+import {actorKindFromTypename} from './githubIssueObservations.mjs';
+
+/**
+ * @summary Pull-request timeline-event whitelist. Dedicated comment/review axes own their create
+ * and edit occurrences; only lifecycle, dismissal, and explicit deletion evidence enter here.
+ * Unknown and popularity-shaped events produce no observation.
+ * @member {Object<String,String>}
+ */
+export const PULL_REQUEST_TIMELINE_KIND_BY_TYPENAME = {
+    ClosedEvent         : 'pull_request.closed',
+    ReopenedEvent       : 'pull_request.reopened',
+    MergedEvent         : 'pull_request.merged',
+    ReviewDismissedEvent: 'pull_request.review-dismissed',
+    CommentDeletedEvent : 'pull_request.comment-deleted'
+};
+
+/**
+ * @summary Projects provider identity kind and source-relative association as separate axes.
+ * @param {Object|null} actor
+ * @param {String|null} [sourceAssociation=null]
+ * @returns {{actorId: String|null, actorKind: String, sourceAssociation: String|null}}
+ */
+function projectActor(actor, sourceAssociation=null) {
+    return {
+        actorId  : actor?.login ?? null,
+        actorKind: actorKindFromTypename(actor?.__typename),
+        sourceAssociation
+    }
+}
+
+/**
+ * @summary Projects an edit actor only when GitHub supplied the editor node. Missing editor
+ * evidence stays explicitly unattributed; the original author is never reused as the editor.
+ * @param {Object|null} editor
+ * @returns {Object}
+ */
+function projectEditor(editor) {
+    return editor
+        ? projectActor(editor)
+        : {
+            actorId          : null,
+            actorKind        : 'unknown',
+            sourceAssociation: null
+        }
+}
+
+/**
+ * @summary Adds every provider-backed user-content revision for one entity. Revision coordinates
+ * use GitHub's stable `UserContentEdit.id`; timestamps are never used as revision identity.
+ * @param {Object[]} observations
+ * @param {Object} entity
+ * @param {String} editKind
+ * @param {String} revisionOf
+ * @param {String|null} [parentProviderEntityId=null]
+ */
+function appendEditObservations(observations, entity, editKind, revisionOf, parentProviderEntityId=null) {
+    if (!Array.isArray(entity.contentEdits)) {
+        if (entity.lastEditedAt) {
+            throw new Error(`PULL_REQUEST_OBSERVATIONS_REQUIRE_EXHAUSTIVE_EDITS:${entity.id}`)
+        }
+        return
+    }
+
+    const ids = new Set();
+
+    for (const edit of entity.contentEdits) {
+        if (!edit?.id || !edit.editedAt || ids.has(edit.id)) {
+            throw new Error(`PULL_REQUEST_OBSERVATIONS_EDIT_ID_INVALID:${entity.id}`)
+        }
+
+        ids.add(edit.id);
+
+        observations.push({
+            providerEntityId    : entity.id,
+            ...(parentProviderEntityId ? {parentProviderEntityId} : {}),
+            occurrenceKind      : editKind,
+            occurrenceCoordinate: edit.id,
+            occurredAt          : edit.editedAt,
+            revisionOf,
+            ...projectEditor(edit.editor)
+        })
+    }
+}
+
+/**
+ * @summary Adds one create plus every exhausted revision for a comment-shaped provider entity.
+ * @param {Object[]} observations
+ * @param {Object} comment
+ * @param {String} pullRequestId
+ * @param {String} createKind
+ * @param {String} editKind
+ */
+function appendCommentObservations(observations, comment, pullRequestId, createKind, editKind) {
+    if (!comment?.id) {
+        throw new Error('PULL_REQUEST_OBSERVATIONS_REQUIRE_COMMENT_ID')
+    }
+
+    const createCoordinate = `${comment.id}:created`;
+
+    observations.push({
+        providerEntityId      : comment.id,
+        parentProviderEntityId: pullRequestId,
+        occurrenceKind        : createKind,
+        occurrenceCoordinate  : createCoordinate,
+        occurredAt            : comment.createdAt,
+        ...projectActor(comment.author, comment.authorAssociation ?? null)
+    });
+
+    appendEditObservations(observations, comment, editKind, createCoordinate, pullRequestId)
+}
+
+/**
+ * @summary Maps one fully reconciled GitHub pull request into deterministic, metadata-only
+ * community observations. Root, issue-comment, review, inline-review-comment, and timeline
+ * identities remain separate; revisions use stable provider revision ids and `revisionOf` links,
+ * never timestamps or overwrites. Every child carries its durable PR parent.
+ *
+ * Review dismissal is owned by its timeline event rather than by the review node's mutable
+ * current `state`, so a later dismissal cannot change the digest of the earlier submission.
+ * Comment-deletion events carry the provider event as evidence while naming the provider gap:
+ * GitHub exposes the deleted author but not the deleted comment id. Inline-comment/review deletion
+ * history has no corresponding exhaustive tombstone collection and is reported by runner coverage.
+ * @param {Object} pullRequest
+ * @returns {Object[]}
+ */
+export function pullRequestToObservations(pullRequest) {
+    if (!pullRequest || typeof pullRequest !== 'object' || !pullRequest.id) {
+        throw new Error('PULL_REQUEST_OBSERVATIONS_REQUIRE_NODE_ID')
+    }
+
+    const dismissedReviewStates = new Map();
+
+    for (const event of pullRequest.timeline ?? []) {
+        if (event?.__typename !== 'ReviewDismissedEvent') {
+            continue
+        }
+
+        if (!event.review?.id || !event.previousReviewState) {
+            throw new Error('PULL_REQUEST_OBSERVATIONS_REVIEW_DISMISSAL_EVIDENCE_INVALID')
+        }
+
+        const priorState = event.previousReviewState ?? null;
+
+        if (dismissedReviewStates.has(event.review.id) && dismissedReviewStates.get(event.review.id) !== priorState) {
+            throw new Error('PULL_REQUEST_OBSERVATIONS_REVIEW_DISMISSAL_STATE_CONFLICT')
+        }
+
+        dismissedReviewStates.set(event.review.id, priorState)
+    }
+
+    const observations = [{
+        providerEntityId    : pullRequest.id,
+        occurrenceKind      : 'pull_request.opened',
+        occurrenceCoordinate: `${pullRequest.id}:opened`,
+        occurredAt          : pullRequest.createdAt,
+        ...projectActor(pullRequest.author, pullRequest.authorAssociation ?? null)
+    }];
+
+    appendEditObservations(
+        observations,
+        pullRequest,
+        'pull_request.edited',
+        `${pullRequest.id}:opened`
+    );
+
+    for (const comment of pullRequest.comments ?? []) {
+        appendCommentObservations(
+            observations,
+            comment,
+            pullRequest.id,
+            'pull_request.comment',
+            'pull_request.comment-edited'
+        )
+    }
+
+    for (const review of pullRequest.reviews ?? []) {
+        if (!review?.id) {
+            throw new Error('PULL_REQUEST_OBSERVATIONS_REQUIRE_REVIEW_ID')
+        }
+
+        observations.push({
+            providerEntityId      : review.id,
+            parentProviderEntityId: pullRequest.id,
+            occurrenceKind        : 'pull_request.review-created',
+            occurrenceCoordinate  : `${review.id}:created`,
+            occurredAt            : review.createdAt,
+            ...projectActor(review.author, review.authorAssociation ?? null)
+        });
+
+        if (review.submittedAt) {
+            if (review.state === 'DISMISSED' && !dismissedReviewStates.has(review.id)) {
+                throw new Error('PULL_REQUEST_OBSERVATIONS_DISMISSED_REVIEW_WITHOUT_EVENT')
+            }
+
+            const providerState = dismissedReviewStates.has(review.id)
+                ? dismissedReviewStates.get(review.id)
+                : review.state;
+
+            if (!providerState) {
+                throw new Error('PULL_REQUEST_OBSERVATIONS_REVIEW_STATE_MISSING')
+            }
+
+            observations.push({
+                providerEntityId      : review.id,
+                parentProviderEntityId: pullRequest.id,
+                occurrenceKind        : 'pull_request.review-submitted',
+                occurrenceCoordinate  : `${review.id}:submitted:${review.submittedAt}`,
+                occurredAt            : review.submittedAt,
+                providerState,
+                ...projectActor(review.author, review.authorAssociation ?? null)
+            })
+        }
+
+        appendEditObservations(
+            observations,
+            review,
+            'pull_request.review-edited',
+            `${review.id}:created`,
+            pullRequest.id
+        )
+    }
+
+    for (const comment of pullRequest.reviewComments ?? []) {
+        appendCommentObservations(
+            observations,
+            comment,
+            pullRequest.id,
+            'pull_request.review-comment',
+            'pull_request.review-comment-edited'
+        )
+    }
+
+    for (const event of pullRequest.timeline ?? []) {
+        const occurrenceKind = PULL_REQUEST_TIMELINE_KIND_BY_TYPENAME[event?.__typename];
+
+        if (!occurrenceKind) {
+            continue
+        }
+        if (!event.id) {
+            throw new Error('PULL_REQUEST_OBSERVATIONS_REQUIRE_EVENT_ID')
+        }
+
+        const providerEntityId = event.__typename === 'ReviewDismissedEvent'
+            ? event.review?.id
+            : pullRequest.id;
+
+        if (!providerEntityId) {
+            throw new Error('PULL_REQUEST_OBSERVATIONS_EVENT_ENTITY_MISSING')
+        }
+
+        const observation = {
+            providerEntityId,
+            ...(event.__typename === 'ReviewDismissedEvent'
+                ? {parentProviderEntityId: pullRequest.id}
+                : {}),
+            occurrenceKind,
+            occurrenceCoordinate: event.id,
+            occurredAt          : event.createdAt,
+            ...projectActor(event.actor)
+        };
+
+        if (event.__typename === 'ReviewDismissedEvent') {
+            observation.providerState = 'DISMISSED'
+        } else if (event.__typename === 'CommentDeletedEvent') {
+            observation.deletionEvidence = {
+                eventId               : event.id,
+                deletedCommentAuthorId: event.deletedCommentAuthor?.login ?? null
+            }
+        }
+
+        observations.push(observation)
+    }
+
+    // PR updatedAt also advances for provider facts outside the declared matrix (e.g. commits).
+    // Preserve the unexplained revision honestly without inventing an actor or event type.
+    if (pullRequest.updatedAt) {
+        const newestExplained = observations.reduce(
+            (max, observation) => observation.occurredAt > max ? observation.occurredAt : max,
+            pullRequest.createdAt
+        );
+
+        if (pullRequest.updatedAt > newestExplained) {
+            observations.push({
+                providerEntityId    : pullRequest.id,
+                occurrenceKind      : 'pull_request.observed-snapshot-change',
+                occurrenceCoordinate: `${pullRequest.id}:snapshot:${pullRequest.updatedAt}`,
+                occurredAt          : pullRequest.updatedAt,
+                actorId             : null,
+                actorKind           : 'unknown',
+                sourceAssociation   : null
+            })
+        }
+    }
+
+    return observations
+}

--- a/ai/services/github-workflow/community/githubPullRequestReconciliation.mjs
+++ b/ai/services/github-workflow/community/githubPullRequestReconciliation.mjs
@@ -1,0 +1,843 @@
+import {GENESIS_BASIS}             from './githubIssueReconciliation.mjs';
+import {pullRequestToObservations} from './githubPullRequestObservations.mjs';
+
+/**
+ * @summary Provider-history gaps GitHub cannot currently prove exhaustively. These stay explicit
+ * on every production run rather than being mistaken for deletion-free history.
+ * @member {Object[]}
+ */
+export const UNSUPPORTED_PULL_REQUEST_HISTORY_GAPS = Object.freeze([
+    Object.freeze({
+        axis  : 'comment-deletion-correlation',
+        reason: 'github-comment-deleted-event-omits-deleted-comment-id'
+    }),
+    Object.freeze({
+        axis  : 'review-deletions',
+        reason: 'github-does-not-expose-exhaustive-review-deletion-tombstones'
+    }),
+    Object.freeze({
+        axis  : 'inline-review-comment-deletions',
+        reason: 'github-does-not-expose-exhaustive-inline-review-comment-deletion-tombstones'
+    })
+]);
+
+/**
+ * @summary Normalizes a thrown value without losing non-Error seam failures.
+ * @param {*} error
+ * @returns {String}
+ */
+function errorMessage(error) {
+    return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * @summary Drives one PR timeline connection to exhaustion while pinning every continuation page
+ * to both the root revision and GitHub's connection-owned mutation token. `filteredCount` proves
+ * the selected event-family total; missing connection evidence is never interpreted as empty.
+ * @param {Object} options
+ * @returns {Promise<{items: Object[], truncated: Boolean}>}
+ */
+async function exhaustTimeline({pullRequest, fetchTimelinePage, maxPages}) {
+    const items = [],
+          ids   = new Set();
+
+    const validateConnection = connection => {
+        if (!connection || !Array.isArray(connection.nodes) || !connection.pageInfo ||
+            !Number.isFinite(connection.filteredCount) || typeof connection.updatedAt !== 'string') {
+            throw new Error('PULL_REQUEST_RECONCILIATION_TIMELINE_PAGE_INVALID')
+        }
+    };
+
+    const append = nodes => {
+        if (!Array.isArray(nodes)) {
+            throw new Error('PULL_REQUEST_RECONCILIATION_TIMELINE_PAGE_INVALID')
+        }
+
+        for (const node of nodes) {
+            if (!node?.id) {
+                throw new Error('PULL_REQUEST_RECONCILIATION_TIMELINE_EVENT_MISSING_ID')
+            }
+            if (ids.has(node.id)) {
+                throw new Error(`PULL_REQUEST_RECONCILIATION_DUPLICATE_TIMELINE_ID:${node.id}`)
+            }
+
+            ids.add(node.id);
+            items.push(node)
+        }
+    };
+
+    validateConnection(pullRequest.timeline);
+    append(pullRequest.timeline.nodes);
+
+    const expectedTotal      = pullRequest.timeline.filteredCount,
+          connectionRevision = pullRequest.timeline.updatedAt;
+
+    let pageInfo = pullRequest.timeline.pageInfo,
+        pages    = 1;
+
+    while (pageInfo?.hasNextPage) {
+        if (pages >= maxPages) {
+            return {items, truncated: true}
+        }
+        if (!pageInfo.endCursor) {
+            throw new Error('PULL_REQUEST_RECONCILIATION_TIMELINE_CURSOR_MISSING')
+        }
+
+        const previous = pageInfo.endCursor,
+              page     = await fetchTimelinePage({pullRequestId: pullRequest.id, cursor: previous});
+
+        if (page.rootUpdatedAt !== pullRequest.updatedAt) {
+            throw new Error('PULL_REQUEST_RECONCILIATION_TIMELINE_MUTATED')
+        }
+
+        const connection = {
+            nodes        : page.events,
+            pageInfo     : page.pageInfo,
+            filteredCount: page.filteredCount,
+            updatedAt    : page.connectionUpdatedAt
+        };
+
+        validateConnection(connection);
+
+        if (connection.updatedAt !== connectionRevision || connection.filteredCount !== expectedTotal) {
+            throw new Error('PULL_REQUEST_RECONCILIATION_TIMELINE_MUTATED')
+        }
+
+        append(connection.nodes);
+        pageInfo = connection.pageInfo;
+        pages++;
+
+        if (pageInfo?.hasNextPage && (!pageInfo.endCursor || pageInfo.endCursor === previous)) {
+            throw new Error('PULL_REQUEST_RECONCILIATION_TIMELINE_CURSOR_STALLED')
+        }
+    }
+
+    if (items.length !== expectedTotal) {
+        throw new Error('PULL_REQUEST_RECONCILIATION_TIMELINE_COUNT_MISMATCH')
+    }
+
+    return {items, truncated: false}
+}
+
+/**
+ * @summary Exhausts one `userContentEdits` connection by stable node id. GitHub may include the
+ * creation revision in this connection; `includesCreatedEdit` makes that provider fact explicit so
+ * it can be removed without collapsing any actual edit occurrence.
+ * @param {Object} options
+ * @returns {Promise<{entity: Object, truncated: Boolean}>}
+ */
+async function exhaustContentEdits({entity, fetchContentEditsPage, maxPages}) {
+    const entityNodeId = entity?.nodeId ?? entity?.id;
+
+    if (!entityNodeId || !entity?.id) {
+        throw new Error('PULL_REQUEST_RECONCILIATION_EDIT_ENTITY_MISSING_ID')
+    }
+
+    const edits = [],
+          ids   = new Set();
+
+    const validatePage = page => {
+        if (!page || page.id !== entityNodeId || page.createdAt !== entity.createdAt ||
+            page.updatedAt !== entity.updatedAt || typeof page.includesCreatedEdit !== 'boolean' ||
+            !page.userContentEdits || !Array.isArray(page.userContentEdits.nodes) ||
+            !page.userContentEdits.pageInfo || !Number.isFinite(page.userContentEdits.totalCount)) {
+            throw new Error(`PULL_REQUEST_RECONCILIATION_EDIT_PAGE_INVALID:${entity.id}`)
+        }
+    };
+
+    const append = nodes => {
+        for (const edit of nodes) {
+            if (!edit?.id || !edit.editedAt) {
+                throw new Error(`PULL_REQUEST_RECONCILIATION_EDIT_MISSING_ID:${entity.id}`)
+            }
+            if (ids.has(edit.id)) {
+                throw new Error(`PULL_REQUEST_RECONCILIATION_DUPLICATE_EDIT_ID:${edit.id}`)
+            }
+
+            ids.add(edit.id);
+            edits.push(edit)
+        }
+    };
+
+    let page = {
+            id                 : entityNodeId,
+            createdAt          : entity.createdAt,
+            updatedAt          : entity.updatedAt,
+            includesCreatedEdit: entity.includesCreatedEdit,
+            userContentEdits   : entity.userContentEdits
+        };
+
+    validatePage(page);
+
+    const expectedTotal       = page.userContentEdits.totalCount,
+          includesCreatedEdit = page.includesCreatedEdit;
+
+    append(page.userContentEdits.nodes);
+
+    let pageInfo = page.userContentEdits.pageInfo,
+        pages    = 1;
+
+    while (pageInfo.hasNextPage) {
+        if (pages >= maxPages) {
+            return {entity: {...entity, contentEdits: []}, truncated: true}
+        }
+        if (!pageInfo.endCursor) {
+            throw new Error(`PULL_REQUEST_RECONCILIATION_EDIT_CURSOR_MISSING:${entity.id}`)
+        }
+
+        const previous = pageInfo.endCursor;
+        page = await fetchContentEditsPage({entityNodeId, cursor: previous});
+        validatePage(page);
+
+        if (page.includesCreatedEdit !== includesCreatedEdit ||
+            page.userContentEdits.totalCount !== expectedTotal) {
+            throw new Error(`PULL_REQUEST_RECONCILIATION_EDIT_CONNECTION_MUTATED:${entity.id}`)
+        }
+
+        append(page.userContentEdits.nodes);
+        pageInfo = page.userContentEdits.pageInfo;
+        pages++;
+
+        if (pageInfo.hasNextPage && (!pageInfo.endCursor || pageInfo.endCursor === previous)) {
+            throw new Error(`PULL_REQUEST_RECONCILIATION_EDIT_CURSOR_STALLED:${entity.id}`)
+        }
+    }
+
+    if (edits.length !== expectedTotal) {
+        throw new Error(`PULL_REQUEST_RECONCILIATION_EDIT_COUNT_MISMATCH:${entity.id}`)
+    }
+
+    let contentEdits = edits;
+
+    if (includesCreatedEdit) {
+        const creationEdits = edits.filter(edit => edit.editedAt === entity.createdAt);
+
+        if (creationEdits.length !== 1) {
+            throw new Error(`PULL_REQUEST_RECONCILIATION_CREATED_EDIT_AMBIGUOUS:${entity.id}`)
+        }
+
+        contentEdits = edits.filter(edit => edit !== creationEdits[0])
+    }
+
+    if (Object.hasOwn(entity, 'lastEditedAt')) {
+        const latestEdit = contentEdits.reduce(
+            (latest, edit) => !latest || edit.editedAt > latest ? edit.editedAt : latest,
+            null
+        );
+
+        if ((entity.lastEditedAt ?? null) !== latestEdit) {
+            throw new Error(`PULL_REQUEST_RECONCILIATION_LAST_EDIT_MISMATCH:${entity.id}`)
+        }
+    }
+
+    return {entity: {...entity, contentEdits}, truncated: false}
+}
+
+/**
+ * @summary Exhausts revision connections for the root and all three response-bearing child
+ * families. Processing stays deterministic in provider order; any entity cap makes the whole PR
+ * inadmissible so a partial revision history cannot masquerade as a complete snapshot.
+ * @param {Object} options
+ * @returns {Promise<Object>}
+ */
+async function exhaustContentEditFamilies({
+    pullRequest, comments, reviews, reviewComments, fetchContentEditsPage, maxPages
+}) {
+    const groups = [
+              ['pullRequest', [pullRequest]],
+              ['comments', comments],
+              ['reviews', reviews],
+              ['reviewComments', reviewComments]
+          ],
+          result = {},
+          truncatedEntityIds = [];
+
+    for (const [name, entities] of groups) {
+        result[name] = [];
+
+        for (const entity of entities) {
+            const exhausted = await exhaustContentEdits({
+                entity, fetchContentEditsPage, maxPages
+            });
+
+            result[name].push(exhausted.entity);
+            if (exhausted.truncated) truncatedEntityIds.push(entity.id)
+        }
+    }
+
+    result.pullRequest = result.pullRequest[0];
+    result.truncatedEntityIds = truncatedEntityIds;
+
+    return result
+}
+
+/**
+ * @summary Adds at most one gap per candidate/axis and makes the candidate inadmissible. The
+ * provider root remains in currentInventory even when one child family cannot be proven.
+ * @param {Object} candidate
+ * @param {Object[]} gaps
+ * @param {String} axis
+ * @param {*} reason
+ * @param {Object} [details]
+ * @returns {void}
+ */
+function markCandidateGap(candidate, gaps, axis, reason, details={}) {
+    candidate.failedAxes ??= new Set();
+
+    if (!candidate.failedAxes.has(axis)) {
+        gaps.push({
+            axis,
+            pullRequestId: candidate.pullRequest.id,
+            ...details,
+            reason: errorMessage(reason)
+        });
+        candidate.failedAxes.add(axis)
+    }
+
+    candidate.invalid = true
+}
+
+/**
+ * @summary Returns the four response-bearing content groups in deterministic provider order.
+ * @param {Object} source
+ * @returns {Array} Ordered `[groupName, entities]` pairs.
+ */
+function contentEntityGroups(source) {
+    return [
+        ['pullRequest', [source.pullRequest]],
+        ['comments', source.comments],
+        ['reviews', source.reviews],
+        ['reviewComments', source.reviewComments]
+    ]
+}
+
+/**
+ * @summary Hydrates edit-connection heads for every candidate in one repository-wide seam call.
+ * The seam may split provider traffic into bounded batches, but it returns one ordered settled
+ * outcome per input so a missing node invalidates only its owning PR.
+ * @param {Object} options
+ * @returns {Promise<void>}
+ */
+async function hydrateContentEntityHeads({candidates, fetchContentEditHeads, gaps}) {
+    const references = [];
+
+    for (const candidate of candidates) {
+        candidate.hydrated = {
+            pullRequest   : [],
+            comments      : new Array(candidate.comments.length),
+            reviews       : new Array(candidate.reviews.length),
+            reviewComments: new Array(candidate.reviewComments.length)
+        };
+
+        for (const [group, entities] of contentEntityGroups(candidate)) {
+            if (group === 'pullRequest') {
+                candidate.hydrated.pullRequest = new Array(entities.length)
+            }
+
+            entities.forEach((entity, index) => references.push({candidate, entity, group, index}))
+        }
+    }
+
+    let outcomes;
+
+    try {
+        outcomes = await fetchContentEditHeads({entities: references.map(reference => reference.entity)})
+    } catch (error) {
+        candidates.forEach(candidate => markCandidateGap(candidate, gaps, 'content-edits', error));
+        return
+    }
+
+    if (!Array.isArray(outcomes) || outcomes.length !== references.length) {
+        candidates.forEach(candidate => markCandidateGap(
+            candidate,
+            gaps,
+            'content-edits',
+            'PULL_REQUEST_RECONCILIATION_CONTENT_EDIT_HEADS_INVALID'
+        ));
+        return
+    }
+
+    outcomes.forEach((outcome, index) => {
+        const {candidate, entity, group, index: groupIndex} = references[index],
+              expectedNodeId                                = entity.nodeId ?? entity.id,
+              hydrated                                      = outcome?.value,
+              actualNodeId                                  = hydrated?.nodeId ?? hydrated?.id;
+
+        if (outcome?.status !== 'fulfilled' || !hydrated || actualNodeId !== expectedNodeId ||
+            hydrated.id !== entity.id || hydrated.createdAt !== entity.createdAt ||
+            hydrated.updatedAt !== entity.updatedAt) {
+            markCandidateGap(
+                candidate,
+                gaps,
+                'content-edits',
+                outcome?.status === 'rejected'
+                    ? outcome.reason
+                    : `PULL_REQUEST_RECONCILIATION_CONTENT_MUTATED:${entity.id}`
+            );
+            return
+        }
+
+        candidate.hydrated[group][groupIndex] = hydrated
+    });
+
+    for (const candidate of candidates) {
+        candidate.hydrated.pullRequest = candidate.hydrated.pullRequest[0]
+    }
+}
+
+/**
+ * @summary Verifies every reconciled content entity in one repository-wide seam call. Ordered
+ * settled outcomes keep one changed or unavailable node scoped to its owning PR.
+ * @param {Object} options
+ * @returns {Promise<void>}
+ */
+async function verifyCandidateContentEntities({candidates, verifyContentEntities, gaps}) {
+    const references = [];
+
+    for (const candidate of candidates) {
+        for (const [, entities] of contentEntityGroups(candidate.reconciled)) {
+            entities.forEach(entity => references.push({candidate, entity}))
+        }
+    }
+
+    const expected = references.map(({entity}) => ({
+        id       : entity.nodeId ?? entity.id,
+        updatedAt: entity.updatedAt
+    }));
+
+    let outcomes;
+
+    try {
+        outcomes = await verifyContentEntities({entities: expected})
+    } catch (error) {
+        candidates.forEach(candidate => markCandidateGap(candidate, gaps, 'pull-request-snapshot', error));
+        return
+    }
+
+    if (!Array.isArray(outcomes) || outcomes.length !== expected.length) {
+        candidates.forEach(candidate => markCandidateGap(
+            candidate,
+            gaps,
+            'pull-request-snapshot',
+            'PULL_REQUEST_RECONCILIATION_CONTENT_VERIFICATION_INVALID'
+        ));
+        return
+    }
+
+    outcomes.forEach((outcome, index) => {
+        const {candidate} = references[index],
+              revision    = expected[index],
+              verified    = outcome?.value;
+
+        if (outcome?.status !== 'fulfilled' || verified?.id !== revision.id ||
+            verified?.updatedAt !== revision.updatedAt) {
+            markCandidateGap(
+                candidate,
+                gaps,
+                'pull-request-snapshot',
+                outcome?.status === 'rejected'
+                    ? outcome.reason
+                    : `PULL_REQUEST_RECONCILIATION_CONTENT_MUTATED:${revision.id}`
+            )
+        }
+    })
+}
+
+/**
+ * @summary Enumerates the evidence-bearing root pass with stable ids, progress checks, and a
+ * provider total. A caller cap creates a named gap rather than a false exhaustion claim.
+ * @param {Function} fetchPullRequestsPage
+ * @param {Number} maxPages
+ * @param {Object[]} gaps
+ * @returns {Promise<Object>}
+ */
+async function enumerateRoots(fetchPullRequestsPage, maxPages, gaps) {
+    const pullRequests = [],
+          ids          = new Set();
+
+    let cursor        = null,
+        expectedTotal = null,
+        pageCount     = 0,
+        truncated     = false;
+
+    for (;;) {
+        if (pageCount >= maxPages) {
+            truncated = true;
+            gaps.push({axis: 'pull-requests', afterCursor: cursor, reason: 'page-cap'});
+            break
+        }
+
+        const page = await fetchPullRequestsPage({cursor});
+
+        if (!Array.isArray(page.pullRequests) || !page.pageInfo || !Number.isFinite(page.totalCount)) {
+            throw new Error('PULL_REQUEST_RECONCILIATION_ROOT_PAGE_INVALID')
+        }
+
+        pageCount++;
+
+        if (expectedTotal === null) {
+            expectedTotal = page.totalCount
+        } else if (expectedTotal !== page.totalCount) {
+            gaps.push({axis: 'pull-request-census', reason: 'total-count-mutated'});
+            expectedTotal = page.totalCount
+        }
+
+        for (const pullRequest of page.pullRequests) {
+            if (!pullRequest?.id) {
+                throw new Error('PULL_REQUEST_RECONCILIATION_ROOT_MISSING_ID')
+            }
+            if (ids.has(pullRequest.id)) {
+                throw new Error(`PULL_REQUEST_RECONCILIATION_DUPLICATE_ROOT_ID:${pullRequest.id}`)
+            }
+
+            ids.add(pullRequest.id);
+            pullRequests.push(pullRequest)
+        }
+
+        const previous = cursor;
+        cursor = page.pageInfo.endCursor ?? cursor;
+
+        if (!page.pageInfo.hasNextPage) {
+            break
+        }
+        if (!cursor || cursor === previous) {
+            throw new Error('PULL_REQUEST_RECONCILIATION_ROOT_CURSOR_STALLED')
+        }
+    }
+
+    if (!truncated && expectedTotal !== pullRequests.length) {
+        gaps.push({
+            axis    : 'pull-request-census',
+            reason  : 'root-count-mismatch',
+            expected: expectedTotal,
+            fetched : pullRequests.length
+        })
+    }
+
+    return {pullRequests, cursor, truncated}
+}
+
+/**
+ * @summary Runs the cheap root-only verification pass and returns root plus timeline-connection
+ * revision tokens in provider order. Timeline membership can mutate without changing root.updatedAt,
+ * so both axes participate in the final snapshot decision.
+ * @param {Function} fetchCensusPage
+ * @returns {Promise<Object[]>}
+ */
+async function enumerateVerificationCensus(fetchCensusPage) {
+    const revisions = [],
+          ids       = new Set();
+
+    let cursor        = null,
+        expectedTotal = null;
+
+    for (;;) {
+        const page = await fetchCensusPage({cursor});
+
+        if (!Array.isArray(page.pullRequests) || !page.pageInfo || !Number.isFinite(page.totalCount)) {
+            throw new Error('PULL_REQUEST_RECONCILIATION_VERIFICATION_PAGE_INVALID')
+        }
+
+        expectedTotal ??= page.totalCount;
+
+        if (page.totalCount !== expectedTotal) {
+            throw new Error('PULL_REQUEST_RECONCILIATION_VERIFICATION_TOTAL_MUTATED')
+        }
+
+        for (const pullRequest of page.pullRequests) {
+            if (!pullRequest?.id || typeof pullRequest.updatedAt !== 'string' ||
+                !pullRequest.timeline || !Number.isFinite(pullRequest.timeline.filteredCount) ||
+                typeof pullRequest.timeline.updatedAt !== 'string' || ids.has(pullRequest.id)) {
+                throw new Error('PULL_REQUEST_RECONCILIATION_VERIFICATION_ID_INVALID')
+            }
+
+            ids.add(pullRequest.id);
+            revisions.push({
+                id       : pullRequest.id,
+                updatedAt: pullRequest.updatedAt,
+                timeline : {
+                    filteredCount: pullRequest.timeline.filteredCount,
+                    updatedAt    : pullRequest.timeline.updatedAt
+                }
+            })
+        }
+
+        const previous = cursor;
+        cursor = page.pageInfo.endCursor ?? cursor;
+
+        if (!page.pageInfo.hasNextPage) {
+            break
+        }
+        if (!cursor || cursor === previous) {
+            throw new Error('PULL_REQUEST_RECONCILIATION_VERIFICATION_CURSOR_STALLED')
+        }
+    }
+
+    if (revisions.length !== expectedTotal) {
+        throw new Error('PULL_REQUEST_RECONCILIATION_VERIFICATION_COUNT_MISMATCH')
+    }
+
+    return revisions
+}
+
+/**
+ * @summary Exhaustively reconciles PR roots plus four independent child axes: issue comments,
+ * reviews, inline review comments, their independent revision connections, and provider timeline
+ * events. GraphQL comment/review exhaustion and REST two-pass verification are injected from the
+ * existing PullRequestHistoryService gold standard; the runner adds all-state root re-enumeration,
+ * revision-token verification, root-census verification, metadata-only normalization, and honest
+ * unsupported-history gaps.
+ * @param {Object} seams
+ * @param {Function} seams.fetchPullRequestsPage
+ * @param {Function} seams.exhaustConversation
+ * @param {Function} seams.fetchTimelinePage
+ * @param {Function} seams.fetchReviewCommentSnapshot
+ * @param {Function} seams.fetchContentEditHeads
+ * @param {Function} seams.fetchContentEditsPage
+ * @param {Function} seams.verifyContentEntities
+ * @param {Function} seams.fetchCensusPage
+ * @param {Object} [options]
+ * @param {Number} [options.maxRootPages=Infinity]
+ * @param {Number} [options.maxTimelinePagesPerPullRequest=Infinity]
+ * @param {Number} [options.maxEditPagesPerEntity=Infinity]
+ * @returns {Promise<{observations: Object[], coverage: Object, nextProviderState: Object, currentInventory: String[]}>}
+ */
+export async function reconcilePullRequestActivity(seams, options={}) {
+    const {
+        fetchPullRequestsPage, exhaustConversation, fetchTimelinePage,
+        fetchReviewCommentSnapshot, fetchContentEditHeads, fetchContentEditsPage,
+        verifyContentEntities, fetchCensusPage
+    } = seams || {};
+
+    if ([
+        fetchPullRequestsPage, exhaustConversation, fetchTimelinePage,
+        fetchReviewCommentSnapshot, fetchContentEditHeads, fetchContentEditsPage,
+        verifyContentEntities, fetchCensusPage
+    ].some(fn => typeof fn !== 'function')) {
+        throw new Error('PULL_REQUEST_RECONCILIATION_REQUIRES_FETCH_SEAMS')
+    }
+
+    const {
+        maxRootPages                   = Infinity,
+        maxTimelinePagesPerPullRequest = Infinity,
+        maxEditPagesPerEntity          = Infinity
+    } = options;
+
+    // Provider-capability gaps are adapter-owned. Callers may cap work honestly, but cannot erase a
+    // permanent unsupported family and manufacture `coverage.complete:true`.
+    const gaps = UNSUPPORTED_PULL_REQUEST_HISTORY_GAPS.map(gap => ({...gap}));
+
+    const rootResult   = await enumerateRoots(fetchPullRequestsPage, maxRootPages, gaps),
+          candidates   = [],
+          observations = [];
+
+    let reviewCommentSnapshot,
+        reviewCommentSnapshotError;
+
+    try {
+        reviewCommentSnapshot = await fetchReviewCommentSnapshot();
+
+        if (!(reviewCommentSnapshot?.reviewCommentsByPullRequestNumber instanceof Map) ||
+            !(reviewCommentSnapshot?.failuresByPullRequestNumber instanceof Map)) {
+            throw new Error('PULL_REQUEST_RECONCILIATION_REVIEW_COMMENT_SNAPSHOT_INVALID')
+        }
+    } catch (error) {
+        reviewCommentSnapshotError = error;
+        gaps.push({axis: 'inline-review-comments', reason: errorMessage(error)})
+    }
+
+    for (const pullRequest of rootResult.pullRequests) {
+        if (reviewCommentSnapshotError) {
+            continue
+        }
+
+        const reviewCommentFailure = reviewCommentSnapshot.failuresByPullRequestNumber.get(pullRequest.number);
+
+        if (reviewCommentFailure) {
+            gaps.push({
+                axis         : 'inline-review-comments',
+                pullRequestId: pullRequest.id,
+                reason       : errorMessage(reviewCommentFailure)
+            });
+            continue
+        }
+
+        const reviewComments = reviewCommentSnapshot.reviewCommentsByPullRequestNumber
+            .get(pullRequest.number) ?? [];
+
+        if (!Array.isArray(reviewComments)) {
+            gaps.push({
+                axis         : 'inline-review-comments',
+                pullRequestId: pullRequest.id,
+                reason       : 'PULL_REQUEST_RECONCILIATION_REVIEW_COMMENT_GROUP_INVALID'
+            });
+            continue
+        }
+
+        const [conversationResult, timelineResult] = await Promise.allSettled([
+            exhaustConversation({pullRequest}),
+            exhaustTimeline({
+                pullRequest,
+                fetchTimelinePage,
+                maxPages: maxTimelinePagesPerPullRequest
+            })
+        ]);
+
+        const failedAxes = [
+            ['comments-reviews', conversationResult],
+            ['timeline', timelineResult]
+        ].filter(([, result]) => result.status === 'rejected');
+
+        if (failedAxes.length) {
+            failedAxes.forEach(([axis, result]) => gaps.push({
+                axis,
+                pullRequestId: pullRequest.id,
+                reason       : errorMessage(result.reason)
+            }));
+            continue
+        }
+
+        if (timelineResult.value.truncated) {
+            gaps.push({axis: 'timeline', pullRequestId: pullRequest.id, reason: 'page-cap'});
+            // A partial timeline can omit a dismissal that supplies a review's immutable original
+            // disposition. Admit no facts from that mixed PR snapshot; the live root still remains
+            // in currentInventory so incompleteness cannot masquerade as deletion.
+            continue
+        }
+
+        if (!Array.isArray(conversationResult.value?.comments) ||
+            !Array.isArray(conversationResult.value?.reviews)) {
+            gaps.push({
+                axis         : 'comments-reviews',
+                pullRequestId: pullRequest.id,
+                reason       : 'PULL_REQUEST_RECONCILIATION_CONVERSATION_INVALID'
+            });
+            continue
+        }
+
+        candidates.push({
+            pullRequest,
+            comments: conversationResult.value.comments,
+            reviews : conversationResult.value.reviews,
+            reviewComments,
+            timeline: timelineResult.value.items,
+            invalid : false
+        })
+    }
+
+    if (candidates.length) {
+        await hydrateContentEntityHeads({candidates, fetchContentEditHeads, gaps})
+    }
+
+    for (const candidate of candidates) {
+        if (candidate.invalid) {
+            continue
+        }
+
+        try {
+            candidate.reconciled = await exhaustContentEditFamilies({
+                ...candidate.hydrated,
+                fetchContentEditsPage,
+                maxPages: maxEditPagesPerEntity
+            })
+        } catch (error) {
+            markCandidateGap(candidate, gaps, 'content-edits', error);
+            continue
+        }
+
+        if (candidate.reconciled.truncatedEntityIds.length) {
+            const providerEntityId = candidate.reconciled.truncatedEntityIds[0];
+
+            markCandidateGap(candidate, gaps, 'content-edits', 'page-cap', {providerEntityId})
+        }
+    }
+
+    const verificationCandidates = candidates.filter(candidate => !candidate.invalid && candidate.reconciled);
+
+    if (verificationCandidates.length) {
+        await verifyCandidateContentEntities({
+            candidates: verificationCandidates,
+            verifyContentEntities,
+            gaps
+        })
+    }
+
+    if (!rootResult.truncated) {
+        try {
+            const verified    = await enumerateVerificationCensus(fetchCensusPage),
+                  initialIds  = rootResult.pullRequests.map(pullRequest => pullRequest.id),
+                  verifiedIds = verified.map(pullRequest => pullRequest.id);
+
+            if (JSON.stringify(initialIds) !== JSON.stringify(verifiedIds)) {
+                gaps.push({axis: 'pull-request-census-verification', reason: 'root-membership-mutated'});
+                candidates.forEach(candidate => { candidate.invalid = true })
+            } else {
+                const candidatesById = new Map(candidates.map(candidate => [candidate.pullRequest.id, candidate]));
+
+                rootResult.pullRequests.forEach((pullRequest, index) => {
+                    const candidate = candidatesById.get(pullRequest.id),
+                          revision  = verified[index];
+
+                    if (!candidate || candidate.invalid) {
+                        return
+                    }
+
+                    if (revision.updatedAt !== pullRequest.updatedAt) {
+                        markCandidateGap(
+                            candidate,
+                            gaps,
+                            'pull-request-census-verification',
+                            `PULL_REQUEST_RECONCILIATION_ROOT_MUTATED:${pullRequest.id}`
+                        )
+                    } else if (revision.timeline.filteredCount !== pullRequest.timeline.filteredCount ||
+                        revision.timeline.updatedAt !== pullRequest.timeline.updatedAt) {
+                        markCandidateGap(
+                            candidate,
+                            gaps,
+                            'pull-request-census-verification',
+                            `PULL_REQUEST_RECONCILIATION_TIMELINE_MUTATED:${pullRequest.id}`
+                        )
+                    }
+                })
+            }
+        } catch (error) {
+            gaps.push({axis: 'pull-request-census-verification', reason: errorMessage(error)});
+            candidates.forEach(candidate => { candidate.invalid = true })
+        }
+    }
+
+    for (const candidate of candidates) {
+        if (candidate.invalid || !candidate.reconciled) {
+            continue
+        }
+
+        try {
+            observations.push(...pullRequestToObservations({
+                ...candidate.reconciled.pullRequest,
+                comments      : candidate.reconciled.comments,
+                reviews       : candidate.reconciled.reviews,
+                reviewComments: candidate.reconciled.reviewComments,
+                timeline      : candidate.timeline
+            }))
+        } catch (error) {
+            markCandidateGap(candidate, gaps, 'normalization', error)
+        }
+    }
+
+    const coverage = {
+        fromBasis: GENESIS_BASIS,
+        toBasis  : rootResult.cursor ?? GENESIS_BASIS,
+        complete : gaps.length === 0,
+        ...(gaps.length ? {gaps} : {})
+    };
+
+    return {
+        observations,
+        coverage,
+        nextProviderState: {
+            pullRequestsCursor: rootResult.cursor,
+            rootCount         : rootResult.pullRequests.length
+        },
+        currentInventory: rootResult.pullRequests.map(pullRequest => pullRequest.id)
+    }
+}

--- a/ai/services/github-workflow/queries/pullRequestReconciliationQueries.mjs
+++ b/ai/services/github-workflow/queries/pullRequestReconciliationQueries.mjs
@@ -1,0 +1,241 @@
+/**
+ * @summary Exhaustive pull-request reconciliation queries. PR roots, issue comments, reviews,
+ * their user-content revisions, and timeline events stay separate pagination axes. Inline review
+ * comments use GitHub's REST collection for the entity census and GraphQL node ids for revision
+ * history, because neither provider surface alone exposes the complete contract.
+ *
+ * Every selected field is metadata-only. Provider node ids anchor immutable occurrence identity,
+ * actor typenames preserve the actor-kind axis, and author associations remain separate from it.
+ * Popularity telemetry and prose are absent by construction.
+ * @module ai/services/github-workflow/queries/pullRequestReconciliationQueries
+ */
+
+/**
+ * @summary Supported lifecycle timeline families. Comments and reviews are deliberately absent
+ * because their dedicated connections own those entities and prevent duplicate observations.
+ * @member {String[]}
+ */
+export const RECONCILE_PULL_REQUEST_TIMELINE_ITEM_TYPES = [
+    'CLOSED_EVENT', 'REOPENED_EVENT', 'MERGED_EVENT',
+    'REVIEW_DISMISSED_EVENT', 'COMMENT_DELETED_EVENT'
+];
+
+const TIMELINE_ITEM_TYPES_ARG = RECONCILE_PULL_REQUEST_TIMELINE_ITEM_TYPES.join(', ');
+
+const ACTOR_SELECTION = 'login __typename';
+
+const USER_CONTENT_EDIT_CONNECTION_SELECTION = `
+      totalCount
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id editedAt
+        editor { ${ACTOR_SELECTION} }
+      }`;
+
+const COMMENT_NODE_SELECTION = `
+      id createdAt updatedAt lastEditedAt authorAssociation
+      author { ${ACTOR_SELECTION} }`;
+
+const REVIEW_NODE_SELECTION = `
+      id createdAt updatedAt lastEditedAt submittedAt state authorAssociation
+      author { ${ACTOR_SELECTION} }`;
+
+const TIMELINE_NODE_SELECTION = `
+      __typename
+      ... on ClosedEvent          { id createdAt actor { ${ACTOR_SELECTION} } }
+      ... on ReopenedEvent        { id createdAt actor { ${ACTOR_SELECTION} } }
+      ... on MergedEvent          { id createdAt actor { ${ACTOR_SELECTION} } }
+      ... on ReviewDismissedEvent {
+        id createdAt previousReviewState
+        actor { ${ACTOR_SELECTION} }
+        review { id }
+      }
+      ... on CommentDeletedEvent  {
+        id createdAt
+        actor { ${ACTOR_SELECTION} }
+        deletedCommentAuthor { ${ACTOR_SELECTION} }
+      }`;
+
+/**
+ * @summary Enumerates OPEN, CLOSED, and MERGED pull-request roots in stable creation order with
+ * the first page of every GraphQL child axis inline.
+ * @member {String}
+ */
+export const FETCH_RECONCILE_PULL_REQUESTS = `
+query ReconcilePullRequests(
+  $owner: String!
+  $repo: String!
+  $after: String
+  $rootPage: Int!
+  $childPage: Int!
+  $timelinePage: Int!
+) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(
+      first: $rootPage
+      after: $after
+      states: [OPEN, CLOSED, MERGED]
+      orderBy: {field: CREATED_AT, direction: ASC}
+    ) {
+      totalCount
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id number state createdAt updatedAt lastEditedAt authorAssociation
+        author { ${ACTOR_SELECTION} }
+        comments(first: $childPage) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes { ${COMMENT_NODE_SELECTION} }
+        }
+        reviews(first: $childPage) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes { ${REVIEW_NODE_SELECTION} }
+        }
+        timelineItems(first: $timelinePage, itemTypes: [${TIMELINE_ITEM_TYPES_ARG}]) {
+          filteredCount
+          updatedAt
+          pageInfo { hasNextPage endCursor }
+          nodes { ${TIMELINE_NODE_SELECTION} }
+        }
+      }
+    }
+  }
+}`;
+
+/**
+ * @summary Continues issue comments and reviews with independent cursors while echoing the root
+ * revision token used to reject a mixed snapshot.
+ * @member {String}
+ */
+export const FETCH_RECONCILE_PULL_REQUEST_CHILDREN = `
+query ReconcilePullRequestChildren(
+  $owner: String!
+  $repo: String!
+  $prNumber: Int!
+  $childLimit: Int!
+  $commentsCursor: String
+  $reviewsCursor: String
+) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prNumber) {
+      updatedAt
+      comments(first: $childLimit, after: $commentsCursor) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes { ${COMMENT_NODE_SELECTION} }
+      }
+      reviews(first: $childLimit, after: $reviewsCursor) {
+        totalCount
+        pageInfo { hasNextPage endCursor }
+        nodes { ${REVIEW_NODE_SELECTION} }
+      }
+    }
+  }
+}`;
+
+/**
+ * @summary Continues one pull request's lifecycle/dismissal/deletion-event timeline independently.
+ * @member {String}
+ */
+export const FETCH_RECONCILE_PULL_REQUEST_TIMELINE = `
+query ReconcilePullRequestTimeline($pullRequestId: ID!, $after: String, $timelinePage: Int!) {
+  node(id: $pullRequestId) {
+    ... on PullRequest {
+      updatedAt
+      timelineItems(first: $timelinePage, after: $after, itemTypes: [${TIMELINE_ITEM_TYPES_ARG}]) {
+        filteredCount
+        updatedAt
+        pageInfo { hasNextPage endCursor }
+        nodes { ${TIMELINE_NODE_SELECTION} }
+      }
+    }
+  }
+}`;
+
+const USER_CONTENT_EDIT_NODE_SELECTION = `
+      id __typename createdAt updatedAt includesCreatedEdit
+      userContentEdits(first: $editPage, after: $after) {
+        ${USER_CONTENT_EDIT_CONNECTION_SELECTION}
+      }`;
+
+const USER_CONTENT_EDIT_HEAD_SELECTION = `
+      id __typename createdAt updatedAt includesCreatedEdit
+      userContentEdits(first: $editPage) {
+        ${USER_CONTENT_EDIT_CONNECTION_SELECTION}
+      }`;
+
+/**
+ * @summary Reads one page of a PR, issue-comment, review, or inline-review-comment revision
+ * connection by stable GraphQL node id. The shared shape lets the runner apply one progress/count
+ * contract to all four provider entity families.
+ * @member {String}
+ */
+export const FETCH_RECONCILE_USER_CONTENT_EDITS = `
+query ReconcilePullRequestContentEdits($entityId: ID!, $after: String, $editPage: Int!) {
+  node(id: $entityId) {
+    ... on PullRequest              { ${USER_CONTENT_EDIT_NODE_SELECTION} }
+    ... on IssueComment             { ${USER_CONTENT_EDIT_NODE_SELECTION} }
+    ... on PullRequestReview        { ${USER_CONTENT_EDIT_NODE_SELECTION} }
+    ... on PullRequestReviewComment { ${USER_CONTENT_EDIT_NODE_SELECTION} }
+  }
+}`;
+
+/**
+ * @summary Hydrates first revision pages for every content entity in bounded GraphQL node batches.
+ * Keeping revision connections outside the root/comment/review query avoids GitHub's nested-node
+ * multiplier while preserving each entity's independent cursor and total.
+ * @member {String}
+ */
+export const FETCH_RECONCILE_USER_CONTENT_EDIT_HEADS = `
+query ReconcilePullRequestContentEditHeads($ids: [ID!]!, $editPage: Int!) {
+  nodes(ids: $ids) {
+    ... on PullRequest              { ${USER_CONTENT_EDIT_HEAD_SELECTION} }
+    ... on IssueComment             { ${USER_CONTENT_EDIT_HEAD_SELECTION} }
+    ... on PullRequestReview        { ${USER_CONTENT_EDIT_HEAD_SELECTION} }
+    ... on PullRequestReviewComment { ${USER_CONTENT_EDIT_HEAD_SELECTION} }
+  }
+}`;
+
+/**
+ * @summary Re-reads mutable entity revision tokens after all independent child/edit axes finish.
+ * Missing or changed nodes make the PR snapshot inadmissible rather than mixing revisions.
+ * @member {String}
+ */
+export const FETCH_RECONCILE_PULL_REQUEST_CONTENT_REVISIONS = `
+query ReconcilePullRequestContentRevisions($ids: [ID!]!) {
+  nodes(ids: $ids) {
+    id __typename
+    ... on PullRequest              { updatedAt }
+    ... on IssueComment             { updatedAt }
+    ... on PullRequestReview        { updatedAt }
+    ... on PullRequestReviewComment { updatedAt }
+  }
+}`;
+
+/**
+ * @summary Cheap second-pass root census. Comparing provider ids + revision tokens with the
+ * evidence-bearing pass proves that root membership did not mutate while it was traversed.
+ * @member {String}
+ */
+export const FETCH_RECONCILE_PULL_REQUEST_CENSUS = `
+query ReconcilePullRequestCensus($owner: String!, $repo: String!, $after: String, $rootPage: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(
+      first: $rootPage
+      after: $after
+      states: [OPEN, CLOSED, MERGED]
+      orderBy: {field: CREATED_AT, direction: ASC}
+    ) {
+      totalCount
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id updatedAt
+        timelineItems(first: 1, itemTypes: [${TIMELINE_ITEM_TYPES_ARG}]) {
+          filteredCount
+          updatedAt
+        }
+      }
+    }
+  }
+}`;

--- a/ai/services/memory-core/CommunityBatchAdmissionService.mjs
+++ b/ai/services/memory-core/CommunityBatchAdmissionService.mjs
@@ -117,8 +117,9 @@ class CommunityBatchAdmissionService extends Base {
     }
 
     /**
-     * Creates the admission tables if absent. Receipt identity is scoped by `resourceFamily` (the CAS
-     * partition), so a `batchId` reused across families never collides.
+     * Creates the admission tables if absent and upgrades older observation ledgers in place. Receipt
+     * identity is scoped by `resourceFamily` (the CAS partition), so a `batchId` reused across families
+     * never collides. Additive nullable observation columns preserve existing rows and callers.
      * @returns {void}
      */
     ensureSchema() {
@@ -154,11 +155,14 @@ class CommunityBatchAdmissionService extends Base {
                 occurrence_identity   TEXT    NOT NULL,
                 occurrence_digest     TEXT    NOT NULL,
                 provider_entity_id    TEXT    NOT NULL,
+                parent_provider_entity_id TEXT,
                 occurrence_kind       TEXT    NOT NULL,
                 occurrence_coordinate TEXT    NOT NULL,
                 occurred_at           TEXT    NOT NULL,
                 actor_id              TEXT,
                 actor_kind            TEXT    NOT NULL,
+                provider_state        TEXT,
+                source_association    TEXT,
                 revision_of           TEXT,
                 absence               TEXT,
                 deletion_evidence     TEXT,
@@ -186,6 +190,24 @@ class CommunityBatchAdmissionService extends Base {
                 PRIMARY KEY (tenant_id, source_instance_id, resource_family)
             );
         `);
+
+        // Serialize the inspect-and-alter sequence: multiple Memory Core processes can open the same
+        // store during rollout, and two unlocked readers could otherwise both attempt the same ALTER.
+        this.db.transaction(() => {
+            const observationColumns = new Set(
+                this.db.prepare(`PRAGMA table_info(mc_community_observation)`).all().map(column => column.name)
+            );
+
+            if (!observationColumns.has('parent_provider_entity_id')) {
+                this.db.exec(`ALTER TABLE mc_community_observation ADD COLUMN parent_provider_entity_id TEXT`)
+            }
+            if (!observationColumns.has('provider_state')) {
+                this.db.exec(`ALTER TABLE mc_community_observation ADD COLUMN provider_state TEXT`)
+            }
+            if (!observationColumns.has('source_association')) {
+                this.db.exec(`ALTER TABLE mc_community_observation ADD COLUMN source_association TEXT`)
+            }
+        }).immediate()
     }
 
     /**
@@ -193,12 +215,13 @@ class CommunityBatchAdmissionService extends Base {
      *
      * Never throws for an ordinary protocol outcome — a conflict is a returned status. The transaction
      * runs the nine admission steps in order: (1) verify the ACTIVE registration + epoch INSIDE the
-     * boundary; (2) check the partition-scoped `batchId` receipt; (3) return the prior result for the
-     * same digest; (4) fail closed for the same `batchId` with a different digest; (5) verify the base
-     * checkpoint version + inventory hash; (6) dedup overlapping observations by occurrence identity +
-     * digest; (7) fail closed when the same occurrence carries a different digest; (8) admit a genuinely
-     * new occurrence as an immutable fact; (9) persist provider state/inventory/coverage/receipt and
-     * advance the partition.
+     * boundary; (2) check the partition-scoped `batchId` receipt; (3) for the same digest, repair only
+     * nullable materialized projections and return the prior result; (4) fail closed for the same
+     * `batchId` with a different digest; (5) verify the base checkpoint version + inventory hash;
+     * (6) dedup overlapping observations by occurrence identity + digest, applying the same bounded
+     * projection repair; (7) fail closed when the same occurrence carries a different digest; (8) admit
+     * a genuinely new occurrence as an immutable fact; (9) persist provider state/inventory/coverage/
+     * receipt and advance the partition.
      * @param {Object} batch A `community-activity-batch.v1` payload.
      * @returns {Object} `{status, digest, receipt?, checkpoint?, errors?, reason?}`
      * @throws {Error} `BATCH_ADMISSION_NO_TENANT` | `ATTENTION_POLICY_NOT_CONFIGURED` (fail closed).
@@ -247,6 +270,38 @@ class CommunityBatchAdmissionService extends Base {
                     return {status: ADMISSION_STATUS.CONFLICT, reason: 'REGISTRATION_NOT_ADMISSIBLE'}
                 }
 
+                // These nullable columns can be materialized after the occurrence digest already covered
+                // their payload values. An exact digest match therefore authorizes filling a storage hole,
+                // but never rewriting a non-null projection. The WHERE digest repeats that proof at the
+                // mutation boundary.
+                const
+                    backfillProjectionStatement = this.db.prepare(
+                        `UPDATE mc_community_observation
+                         SET parent_provider_entity_id = COALESCE(parent_provider_entity_id, @parentProviderEntityId),
+                             provider_state            = COALESCE(provider_state, @providerState),
+                             source_association        = COALESCE(source_association, @sourceAssociation)
+                         WHERE tenant_id = @tenantId
+                           AND source_instance_id = @sourceInstanceId
+                           AND occurrence_identity = @identity
+                           AND occurrence_digest = @digest
+                           AND ((parent_provider_entity_id IS NULL AND @parentProviderEntityId IS NOT NULL)
+                             OR (provider_state IS NULL AND @providerState IS NOT NULL)
+                             OR (source_association IS NULL AND @sourceAssociation IS NOT NULL))`
+                    ),
+                    backfillObservationProjection = (
+                        observation,
+                        identity = occurrenceIdentity(sourceInstanceId, observation),
+                        oDigest  = observationDigest(observation)
+                    ) => backfillProjectionStatement.run({
+                        digest                : oDigest,
+                        identity,
+                        parentProviderEntityId: observation.parentProviderEntityId ?? null,
+                        providerState         : observation.providerState ?? null,
+                        sourceAssociation     : observation.sourceAssociation ?? null,
+                        sourceInstanceId,
+                        tenantId
+                    }).changes;
+
                 // Steps 2-4 — the partition-scoped batch idempotency key.
                 const existing = this.db.prepare(
                     `SELECT * FROM mc_community_batch_receipt
@@ -254,9 +309,13 @@ class CommunityBatchAdmissionService extends Base {
                 ).get(tenantId, sourceInstanceId, resourceFamily, batchId);
 
                 if (existing) {
-                    return existing.digest === digest
-                        ? {status: ADMISSION_STATUS.IDEMPOTENT, receipt: this.#toReceipt(existing)}
-                        : {status: ADMISSION_STATUS.CONFLICT, reason: 'DIGEST_MISMATCH', receipt: this.#toReceipt(existing)}
+                    if (existing.digest === digest) {
+                        observations.forEach(observation => backfillObservationProjection(observation));
+
+                        return {status: ADMISSION_STATUS.IDEMPOTENT, receipt: this.#toReceipt(existing)}
+                    }
+
+                    return {status: ADMISSION_STATUS.CONFLICT, reason: 'DIGEST_MISMATCH', receipt: this.#toReceipt(existing)}
                 }
 
                 // Step 5 — the checkpoint CAS: the batch's declared base must equal current server state.
@@ -290,10 +349,11 @@ class CommunityBatchAdmissionService extends Base {
                 const insertObservation = this.db.prepare(
                     `INSERT INTO mc_community_observation (
                         observation_row_id, tenant_id, source_instance_id, occurrence_identity, occurrence_digest,
-                        provider_entity_id, occurrence_kind, occurrence_coordinate, occurred_at, actor_id,
-                        actor_kind, revision_of, absence, deletion_evidence, attention_disposition,
-                        attention_reason, receipt_id, admitted_sequence, admitted_at
-                     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+                        provider_entity_id, parent_provider_entity_id, occurrence_kind, occurrence_coordinate,
+                        occurred_at, actor_id, actor_kind, provider_state, source_association, revision_of,
+                        absence, deletion_evidence, attention_disposition, attention_reason, receipt_id,
+                        admitted_sequence, admitted_at
+                     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
                 );
 
                 for (const observation of observations) {
@@ -304,8 +364,12 @@ class CommunityBatchAdmissionService extends Base {
                           ).get(tenantId, identity);
 
                     if (prior) {
-                        // Step 6 — same identity + same digest: already durable, dedup silently.
-                        if (prior.occurrence_digest === oDigest) continue;
+                        // Step 6 — same identity + same digest: keep the immutable occurrence row and
+                        // repair only nullable projections that older admission code failed to materialize.
+                        if (prior.occurrence_digest === oDigest) {
+                            backfillObservationProjection(observation, identity, oDigest);
+                            continue
+                        }
                         // Step 7 — same identity + different digest: integrity conflict, abort.
                         throw new ObservationConflict('OBSERVATION_DIGEST_MISMATCH')
                     }
@@ -315,9 +379,10 @@ class CommunityBatchAdmissionService extends Base {
 
                     insertObservation.run(
                         crypto.randomUUID(), tenantId, sourceInstanceId, identity, oDigest,
-                        observation.providerEntityId, observation.occurrenceKind, observation.occurrenceCoordinate,
-                        observation.occurredAt, observation.actorId || null, observation.actorKind,
-                        observation.revisionOf || null, observation.absence || null,
+                        observation.providerEntityId, observation.parentProviderEntityId ?? null,
+                        observation.occurrenceKind, observation.occurrenceCoordinate, observation.occurredAt,
+                        observation.actorId || null, observation.actorKind, observation.providerState ?? null,
+                        observation.sourceAssociation ?? null, observation.revisionOf || null, observation.absence || null,
                         observation.deletionEvidence ? JSON.stringify(observation.deletionEvidence) : null,
                         disposition, reason, receiptId, nextSeq, now
                     )
@@ -556,25 +621,28 @@ class CommunityBatchAdmissionService extends Base {
               ).all(tenantId, sourceInstanceId);
 
         return rows.map(row => ({
-            observationRowId    : row.observation_row_id,
-            tenantId            : row.tenant_id,
-            sourceInstanceId    : row.source_instance_id,
-            occurrenceIdentity  : row.occurrence_identity,
-            occurrenceDigest    : row.occurrence_digest,
-            providerEntityId    : row.provider_entity_id,
-            occurrenceKind      : row.occurrence_kind,
-            occurrenceCoordinate: row.occurrence_coordinate,
-            occurredAt          : row.occurred_at,
-            actorId             : row.actor_id,
-            actorKind           : row.actor_kind,
-            revisionOf          : row.revision_of,
-            absence             : row.absence,
-            deletionEvidence    : row.deletion_evidence ? JSON.parse(row.deletion_evidence) : null,
-            attentionDisposition: row.attention_disposition,
-            attentionReason     : row.attention_reason,
-            receiptId           : row.receipt_id,
-            admittedSequence    : row.admitted_sequence,
-            admittedAt          : row.admitted_at
+            observationRowId      : row.observation_row_id,
+            tenantId              : row.tenant_id,
+            sourceInstanceId      : row.source_instance_id,
+            occurrenceIdentity    : row.occurrence_identity,
+            occurrenceDigest      : row.occurrence_digest,
+            providerEntityId      : row.provider_entity_id,
+            parentProviderEntityId: row.parent_provider_entity_id,
+            occurrenceKind        : row.occurrence_kind,
+            occurrenceCoordinate  : row.occurrence_coordinate,
+            occurredAt            : row.occurred_at,
+            actorId               : row.actor_id,
+            actorKind             : row.actor_kind,
+            providerState         : row.provider_state,
+            sourceAssociation     : row.source_association,
+            revisionOf            : row.revision_of,
+            absence               : row.absence,
+            deletionEvidence      : row.deletion_evidence ? JSON.parse(row.deletion_evidence) : null,
+            attentionDisposition  : row.attention_disposition,
+            attentionReason       : row.attention_reason,
+            receiptId             : row.receipt_id,
+            admittedSequence      : row.admitted_sequence,
+            admittedAt            : row.admitted_at
         }))
     }
 

--- a/ai/services/memory-core/communityBatchContract.mjs
+++ b/ai/services/memory-core/communityBatchContract.mjs
@@ -45,8 +45,9 @@ const
      * inventory, and a batch that changes no opaque provider state carries `null`. Presence is still
      * required so a reduced batch (an omitted key) fails loudly rather than defaulting.
      */
-    NULLABLE_BATCH_KEYS       = new Set(['baseInventoryHash', 'nextInventoryHash', 'nextProviderState']),
-    REQUIRED_OBSERVATION_KEYS = ['providerEntityId', 'occurrenceKind', 'occurrenceCoordinate', 'occurredAt', 'actorKind'],
+    NULLABLE_BATCH_KEYS              = new Set(['baseInventoryHash', 'nextInventoryHash', 'nextProviderState']),
+    OPTIONAL_OBSERVATION_STRING_KEYS = ['parentProviderEntityId', 'providerState', 'sourceAssociation'],
+    REQUIRED_OBSERVATION_KEYS        = ['providerEntityId', 'occurrenceKind', 'occurrenceCoordinate', 'occurredAt', 'actorKind'],
     /**
      * Provider prose never enters an automatic durable row. A batch carrying any of these is
      * REJECTED rather than silently stripped: stripping would let a connector believe prose was
@@ -420,6 +421,14 @@ export function validateBatch(batch) {
             if (observation.actorKind !== undefined && !ACTOR_KINDS.has(observation.actorKind)) {
                 errors.push(`OBSERVATION_${index}_ACTOR_KIND_INVALID`)
             }
+
+            OPTIONAL_OBSERVATION_STRING_KEYS.forEach(key => {
+                const value = observation[key];
+
+                if (value !== undefined && value !== null && (typeof value !== 'string' || !value.trim())) {
+                    errors.push(`OBSERVATION_${index}_${key.toUpperCase()}_INVALID`)
+                }
+            });
 
             if (observation.absence !== undefined && !ABSENCE_DISPOSITIONS.has(observation.absence)) {
                 errors.push(`OBSERVATION_${index}_ABSENCE_DISPOSITION_INVALID`)

--- a/test/playwright/unit/ai/mcp/server/memory-core/CommunityBatchTool.spec.mjs
+++ b/test/playwright/unit/ai/mcp/server/memory-core/CommunityBatchTool.spec.mjs
@@ -36,11 +36,14 @@ test.describe('Memory Core hosted community tools (#15156)', () => {
             baseInventoryHash         : null,
             batchId                   : 'batch-1',
             observations              : [{
-                providerEntityId    : '1',
-                occurrenceKind      : 'issue.opened',
-                occurrenceCoordinate: '1:create',
-                occurredAt          : '2026-07-18T10:00:00Z',
-                actorKind           : 'user'
+                providerEntityId      : 'review-1',
+                parentProviderEntityId: 'pull-1',
+                occurrenceKind        : 'pull.review.submitted',
+                occurrenceCoordinate  : 'review-1:create',
+                occurredAt            : '2026-07-18T10:00:00Z',
+                actorKind             : 'user',
+                providerState         : 'APPROVED',
+                sourceAssociation     : 'MEMBER'
             }],
             nextProviderState: {cursor: 'p2'},
             nextInventoryHash: 'inv-1',

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestHistoryService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestHistoryService.spec.mjs
@@ -20,6 +20,8 @@ import path           from 'path';
 import Neo            from '../../../../../../src/Neo.mjs';
 import * as core      from '../../../../../../src/core/_export.mjs';
 import PullRequestHistoryService, {
+    exhaustRepositoryReviewComments,
+    exhaustReviewComments,
     fetchResolvedPullRequestsForHistory,
     scanPullRequestCorpus,
     synthesizePullRequestHistory
@@ -529,6 +531,109 @@ test.describe('Neo.ai.services.github-workflow.PullRequestHistoryService', () =>
         expect(result.coverage.childEvidence.failures).toHaveLength(1);
         expect(result.coverage.childEvidence.failures[0].reason).toMatch(/review comments?.*(mutat|mismatch|snapshot)/i);
         expect(result.synthesisAvailable).toBe(false)
+    });
+
+    test('keeps resolved-history review-comment revisions stable unless reconciliation opts into actor metadata', async () => {
+        const pull = pullRequest({number: 502, mergedAt: '2026-07-06T12:00:00.000Z'}),
+              rest = async () => [{
+                  id                    : 8002,
+                  node_id               : 'PRRC_8002',
+                  pull_request_review_id: 89,
+                  user                  : {login: 'external-reviewer', type: 'User'},
+                  author_association    : 'CONTRIBUTOR',
+                  body                  : 'metadata boundary',
+                  created_at            : '2026-07-04T00:00:00.000Z',
+                  updated_at            : '2026-07-04T00:00:00.000Z',
+                  html_url              : 'https://github.com/neomjs/neo/pull/502#discussion_r8002'
+              }],
+              history = await exhaustReviewComments({pullRequest: pull, rest, owner: 'neomjs', repo: 'neo'}),
+              reconciliation = await exhaustReviewComments({
+                  pullRequest         : pull,
+                  rest,
+                  owner               : 'neomjs',
+                  repo                : 'neo',
+                  includeActorMetadata: true
+              });
+
+        expect(history.reviewComments[0].author).toEqual({login: 'external-reviewer'});
+        expect(history.reviewComments[0]).not.toHaveProperty('authorAssociation');
+        expect(reconciliation.reviewComments[0].author).toEqual({login: 'external-reviewer', __typename: 'User'});
+        expect(reconciliation.reviewComments[0]).toMatchObject({
+            nodeId: 'PRRC_8002', authorAssociation: 'CONTRIBUTOR'
+        })
+    });
+
+    test('repository-wide review-comment verification scales with pages and groups 101 comments by PR', async () => {
+        const paths         = [],
+              reviewComment = (id, pullRequestNumber) => ({
+                  id,
+                  node_id               : `PRRC_${id}`,
+                  pull_request_review_id: 700 + pullRequestNumber,
+                  pull_request_url      : `https://api.github.com/repos/neomjs/neo/pulls/${pullRequestNumber}`,
+                  user                  : {login: `reviewer-${pullRequestNumber}`, type: 'User'},
+                  author_association    : 'MEMBER',
+                  body                  : `comment-${id}`,
+                  created_at            : '2026-07-04T00:00:00.000Z',
+                  updated_at            : '2026-07-04T00:00:00.000Z',
+                  html_url              : `https://github.com/neomjs/neo/pull/${pullRequestNumber}#discussion_r${id}`
+              }),
+              result = await exhaustRepositoryReviewComments({
+                  owner               : 'neomjs',
+                  repo                : 'neo',
+                  includeActorMetadata: true,
+                  rest                : async (method, requestPath) => {
+                      expect(method).toBe('GET');
+                      paths.push(requestPath);
+
+                      const page = Number(new URL(`https://api.github.test${requestPath}`).searchParams.get('page'));
+
+                      return page === 1
+                          ? Array.from({length: 100}, (_, index) => reviewComment(index + 1, index % 2 ? 10 : 9))
+                          : [reviewComment(101, 9)]
+                  }
+              });
+
+        expect(paths).toHaveLength(4);
+        expect(paths.map(requestPath => Number(
+            new URL(`https://api.github.test${requestPath}`).searchParams.get('page')
+        ))).toEqual([1, 2, 1, 2]);
+        expect(paths.every(requestPath => requestPath.startsWith('/repos/neomjs/neo/pulls/comments?'))).toBe(true);
+        expect(result.reviewCommentsByPullRequestNumber.get(9)).toHaveLength(51);
+        expect(result.reviewCommentsByPullRequestNumber.get(10)).toHaveLength(50);
+        expect(result.failuresByPullRequestNumber.size).toBe(0);
+        expect(result.evidence).toMatchObject({fetched: 101, pageQueries: 4, snapshotVerified: true})
+    });
+
+    test('repository-wide verification isolates one PR comment mutation from stable sibling groups', async () => {
+        let pass = 0;
+
+        const reviewComment = (id, pullRequestNumber, updatedAt) => ({
+                  id,
+                  node_id               : `PRRC_${id}`,
+                  pull_request_review_id: 700 + pullRequestNumber,
+                  pull_request_url      : `https://api.github.com/repos/neomjs/neo/pulls/${pullRequestNumber}`,
+                  user                  : {login: 'reviewer', type: 'User'},
+                  author_association    : 'MEMBER',
+                  body                  : `comment-${id}`,
+                  created_at            : '2026-07-04T00:00:00.000Z',
+                  updated_at            : updatedAt,
+                  html_url              : `https://github.com/neomjs/neo/pull/${pullRequestNumber}#discussion_r${id}`
+              }),
+              result = await exhaustRepositoryReviewComments({
+                  owner: 'neomjs',
+                  repo : 'neo',
+                  rest : async () => {
+                      pass++;
+                      return [
+                          reviewComment(1, 9, pass === 1 ? '2026-07-04T00:00:00.000Z' : '2026-07-04T00:01:00.000Z'),
+                          reviewComment(2, 10, '2026-07-04T00:00:00.000Z')
+                      ]
+                  }
+              });
+
+        expect(result.failuresByPullRequestNumber.has(9)).toBe(true);
+        expect(result.reviewCommentsByPullRequestNumber.has(9)).toBe(false);
+        expect(result.reviewCommentsByPullRequestNumber.get(10)).toHaveLength(1)
     });
 
     test('rejects a map observation that cites a child absent from that exact evidence batch', async () => {

--- a/test/playwright/unit/ai/services/github-workflow/PullRequestReconciliationService.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/PullRequestReconciliationService.spec.mjs
@@ -1,0 +1,540 @@
+import {setup} from '../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'PullRequestReconciliationServiceTest'}
+});
+
+import {test, expect}                        from '@playwright/test';
+import Neo                                   from '../../../../../../src/Neo.mjs';
+import * as core                             from '../../../../../../src/core/_export.mjs';
+import PullRequestReconciliationService      from '../../../../../../ai/services/github-workflow/PullRequestReconciliationService.mjs';
+import {canonicalBatchDigest, validateBatch} from '../../../../../../ai/services/memory-core/communityBatchContract.mjs';
+
+/**
+ * @summary End-to-end orchestration witness using fake GraphQL, REST, registry, and admission
+ * seams. Proves literal reuse of PR-history child exhaustion, REST two-pass verification, neutral
+ * batch validity, checkpoint discipline, and fail-closed absence handling.
+ */
+test.describe('PullRequestReconciliationService.reconcile', () => {
+    const updatedAt         = '2026-07-01T15:00:00Z',
+          timelineUpdatedAt = '2026-07-01T14:30:00Z';
+
+    const edit = (id, editedAt, login=null) => ({
+        id,
+        editedAt,
+        editor: login ? {login, __typename: 'User'} : null
+    });
+
+    const editConnection = (nodes=[]) => ({
+        totalCount: nodes.length,
+        nodes,
+        pageInfo  : {hasNextPage: false, endCursor: nodes.length ? `EDIT_${nodes.at(-1).id}` : null}
+    });
+
+    const comment = id => ({
+        id,
+        createdAt          : '2026-07-01T10:00:00Z',
+        updatedAt          : id === 'IC_1' ? '2026-07-01T10:10:00Z' : '2026-07-01T10:00:00Z',
+        lastEditedAt       : id === 'IC_1' ? '2026-07-01T10:10:00Z' : null,
+        includesCreatedEdit: id === 'IC_1',
+        userContentEdits   : editConnection(id === 'IC_1' ? [
+            edit('UCE_IC_CREATED', '2026-07-01T10:00:00Z', 'commenter'),
+            edit('UCE_IC_1', '2026-07-01T10:05:00Z'),
+            edit('UCE_IC_2', '2026-07-01T10:10:00Z', 'maintainer')
+        ] : []),
+        authorAssociation: 'CONTRIBUTOR',
+        author           : {login: 'commenter', __typename: 'User'},
+        editor           : null
+    });
+
+    const review = id => ({
+        id,
+        createdAt          : '2026-07-01T11:00:00Z',
+        updatedAt          : '2026-07-01T11:05:00Z',
+        submittedAt        : '2026-07-01T11:05:00Z',
+        lastEditedAt       : id === 'R_1' ? '2026-07-01T11:04:00Z' : null,
+        includesCreatedEdit: id === 'R_1',
+        userContentEdits   : editConnection(id === 'R_1' ? [
+            edit('UCE_R_CREATED', '2026-07-01T11:00:00Z', 'reviewer'),
+            edit('UCE_R_1', '2026-07-01T11:02:00Z', 'reviewer'),
+            edit('UCE_R_2', '2026-07-01T11:04:00Z', 'review-editor')
+        ] : []),
+        state            : 'APPROVED',
+        authorAssociation: 'MEMBER',
+        author           : {login: 'reviewer', __typename: 'User'},
+        editor           : null
+    });
+
+    const event = (id, typename, createdAt) => ({
+        id,
+        __typename: typename,
+        createdAt,
+        actor     : {login: 'maintainer', __typename: 'User'}
+    });
+
+    const rootNode = () => ({
+        id                 : 'PR_9',
+        number             : 9,
+        state              : 'MERGED',
+        createdAt          : '2026-07-01T09:00:00Z',
+        updatedAt,
+        lastEditedAt       : '2026-07-01T09:30:00Z',
+        includesCreatedEdit: true,
+        userContentEdits   : editConnection([
+            edit('UCE_PR_CREATED', '2026-07-01T09:00:00Z', 'author'),
+            edit('UCE_PR_1', '2026-07-01T09:15:00Z', 'author'),
+            edit('UCE_PR_2', '2026-07-01T09:30:00Z', 'maintainer')
+        ]),
+        authorAssociation: 'CONTRIBUTOR',
+        author           : {login: 'author', __typename: 'User'},
+        editor           : null,
+        comments         : {
+            totalCount: 2,
+            nodes     : [comment('IC_1')],
+            pageInfo  : {hasNextPage: true, endCursor: 'C1'}
+        },
+        reviews: {
+            totalCount: 2,
+            nodes     : [review('R_1')],
+            pageInfo  : {hasNextPage: true, endCursor: 'R1'}
+        },
+        timelineItems: {
+            filteredCount: 2,
+            updatedAt    : timelineUpdatedAt,
+            nodes        : [event('CE_1', 'ClosedEvent', '2026-07-01T12:00:00Z')],
+            pageInfo     : {hasNextPage: true, endCursor: 'T1'}
+        }
+    });
+
+    const inlineComment = (overrides={}) => ({
+        id                    : 101,
+        node_id               : 'PRRC_101',
+        pull_request_review_id: 201,
+        user                  : {login: 'inline-reviewer', type: 'User'},
+        author_association    : 'COLLABORATOR',
+        body                  : 'prose stays outside admitted observations',
+        created_at            : '2026-07-01T13:00:00Z',
+        updated_at            : '2026-07-01T13:10:00Z',
+        html_url              : 'https://example.invalid/comment/101',
+        pull_request_url      : 'https://api.github.com/repos/neomjs/neo/pulls/9',
+        in_reply_to_id        : null,
+        ...overrides
+    });
+
+    const makeGraphql = (overrides={}) => {
+        const calls   = [];
+        const service = {
+            calls,
+            query: async (queryString, variables) => {
+                calls.push({queryString, variables});
+
+                if (queryString.includes('ReconcilePullRequests')) {
+                    return {repository: {pullRequests: {
+                        totalCount: 1,
+                        nodes     : [rootNode()],
+                        pageInfo  : {hasNextPage: false, endCursor: 'ROOT_END'}
+                    }}}
+                }
+
+                if (queryString.includes('ReconcilePullRequestChildren')) {
+                    const continuation = variables.commentsCursor || variables.reviewsCursor;
+
+                    return {repository: {pullRequest: {
+                        updatedAt,
+                        comments: continuation ? {
+                            totalCount: 2,
+                            nodes     : [comment('IC_2')],
+                            pageInfo  : {hasNextPage: false, endCursor: 'C2'}
+                        } : {
+                            totalCount: 2,
+                            nodes     : [comment('IC_1')],
+                            pageInfo  : {hasNextPage: true, endCursor: 'C1'}
+                        },
+                        reviews: continuation ? {
+                            totalCount: 2,
+                            nodes     : [review('R_2')],
+                            pageInfo  : {hasNextPage: false, endCursor: 'R2'}
+                        } : {
+                            totalCount: 2,
+                            nodes     : [review('R_1')],
+                            pageInfo  : {hasNextPage: true, endCursor: 'R1'}
+                        }
+                    }}}
+                }
+
+                if (queryString.includes('ReconcilePullRequestTimeline')) {
+                    return {node: {
+                        updatedAt,
+                        timelineItems: {
+                            filteredCount: 2,
+                            updatedAt    : timelineUpdatedAt,
+                            nodes        : [event('ME_1', 'MergedEvent', '2026-07-01T14:00:00Z')],
+                            pageInfo     : {hasNextPage: false, endCursor: 'T2'}
+                        }
+                    }}
+                }
+
+                if (queryString.includes('ReconcilePullRequestContentEditHeads')) {
+                    const inline = inlineComment(),
+                          heads  = new Map([
+                              ['PR_9', {...rootNode(), __typename: 'PullRequest'}],
+                              ['IC_1', {...comment('IC_1'), __typename: 'IssueComment'}],
+                              ['IC_2', {...comment('IC_2'), __typename: 'IssueComment'}],
+                              ['R_1', {...review('R_1'), __typename: 'PullRequestReview'}],
+                              ['R_2', {...review('R_2'), __typename: 'PullRequestReview'}],
+                              ['PRRC_101', {
+                                  id                 : inline.node_id,
+                                  __typename         : 'PullRequestReviewComment',
+                                  createdAt          : inline.created_at,
+                                  updatedAt          : inline.updated_at,
+                                  includesCreatedEdit: true,
+                                  userContentEdits   : editConnection([
+                                      edit('UCE_RC_CREATED', inline.created_at, 'inline-reviewer'),
+                                      edit('UCE_RC_1', '2026-07-01T13:05:00Z'),
+                                      edit('UCE_RC_2', inline.updated_at, 'inline-editor')
+                                  ])
+                              }]
+                          ]);
+
+                    return {nodes: variables.ids.map(id => heads.get(id) ?? null)}
+                }
+
+                if (queryString.includes('ReconcilePullRequestContentRevisions')) {
+                    const revisions = new Map([
+                        ['PR_9', {id: 'PR_9', __typename: 'PullRequest', updatedAt}],
+                        ['IC_1', {id: 'IC_1', __typename: 'IssueComment', updatedAt: comment('IC_1').updatedAt}],
+                        ['IC_2', {id: 'IC_2', __typename: 'IssueComment', updatedAt: comment('IC_2').updatedAt}],
+                        ['R_1', {id: 'R_1', __typename: 'PullRequestReview', updatedAt: review('R_1').updatedAt}],
+                        ['R_2', {id: 'R_2', __typename: 'PullRequestReview', updatedAt: review('R_2').updatedAt}],
+                        ['PRRC_101', {id: 'PRRC_101', __typename: 'PullRequestReviewComment', updatedAt: inlineComment().updated_at}]
+                    ]);
+
+                    return {nodes: variables.ids.map(id => revisions.get(id) ?? null)}
+                }
+
+                if (queryString.includes('ReconcilePullRequestContentEdits')) {
+                    throw new Error('unexpected edit continuation query')
+                }
+
+                if (queryString.includes('ReconcilePullRequestCensus')) {
+                    return {repository: {pullRequests: {
+                        totalCount: 1,
+                        nodes     : [{
+                            id           : 'PR_9', updatedAt,
+                            timelineItems: {filteredCount: 2, updatedAt: timelineUpdatedAt}
+                        }],
+                        pageInfo  : {hasNextPage: false, endCursor: 'VERIFY_END'}
+                    }}}
+                }
+
+                throw new Error('unexpected GraphQL query')
+            },
+            rest: async () => [inlineComment()],
+            ...overrides
+        };
+
+        return service
+    };
+
+    const registryActive = {
+        getRegistration: () => ({lifecycleState: 'ACTIVE', registrationEpoch: 3})
+    };
+
+    const makeAdmission = (overrides={}) => ({
+        getCheckpoint   : () => null,
+        listObservations: () => [],
+        admitBatch(batch) {
+            this.admitted = batch;
+            return {status: 'accepted', receipt: {receiptId: 'receipt-pr'}}
+        },
+        ...overrides
+    });
+
+    const runSpec = {
+        sourceInstanceId: 'source-pr',
+        owner           : 'neomjs',
+        repo            : 'neo',
+        batchId         : 'batch-pr',
+        observedAt      : '2026-07-01T16:00:00Z'
+    };
+
+    test('exhausts GraphQL and REST axes and admits a valid deterministic pulls batch', async () => {
+        const admissionService = makeAdmission(),
+              graphqlService   = makeGraphql(),
+              receipt          = await PullRequestReconciliationService.reconcile({
+                  ...runSpec, admissionService, graphqlService, registryService: registryActive
+              }),
+              batch            = admissionService.admitted,
+              countKind        = kind => batch.observations.filter(observation => observation.occurrenceKind === kind).length;
+
+        expect(receipt.status).toBe('accepted');
+        expect(validateBatch(batch)).toEqual({valid: true, errors: []});
+        expect(batch.resourceFamily).toBe('pulls');
+        expect(batch.adapterSchemaVersion).toBe('github-pull-request.v1');
+        expect(countKind('pull_request.opened')).toBe(1);
+        expect(countKind('pull_request.edited')).toBe(2);
+        expect(countKind('pull_request.comment')).toBe(2);
+        expect(countKind('pull_request.comment-edited')).toBe(2);
+        expect(countKind('pull_request.review-created')).toBe(2);
+        expect(countKind('pull_request.review-submitted')).toBe(2);
+        expect(countKind('pull_request.review-edited')).toBe(2);
+        expect(countKind('pull_request.review-comment')).toBe(1);
+        expect(countKind('pull_request.review-comment-edited')).toBe(2);
+        expect(countKind('pull_request.closed')).toBe(1);
+        expect(countKind('pull_request.merged')).toBe(1);
+        expect(batch.observations.find(observation => observation.occurrenceKind === 'pull_request.review-comment'))
+            .toMatchObject({
+                actorKind: 'user', sourceAssociation: 'COLLABORATOR', parentProviderEntityId: 'PR_9'
+            });
+        expect(batch.observations.find(observation => observation.occurrenceKind === 'pull_request.review-submitted'))
+            .toMatchObject({providerState: 'APPROVED', parentProviderEntityId: 'PR_9'});
+        expect(graphqlService.calls.filter(call => call.queryString.includes('ReconcilePullRequestChildren'))).toHaveLength(1);
+        expect(graphqlService.calls.filter(call => call.queryString.includes('ReconcilePullRequestContentEditHeads'))).toHaveLength(1);
+        expect(graphqlService.calls.filter(call => call.queryString.includes('ReconcilePullRequestContentRevisions'))).toHaveLength(1)
+    });
+
+    test('205 roots batch edit-head and final-revision reads as 100, 100, 5 with no per-PR REST floor', async () => {
+        const scaleRoots = Array.from({length: 205}, (_, index) => {
+                  const id = `PR_SCALE_${index + 1}`;
+
+                  return {
+                      id,
+                      number           : 10_000 + index,
+                      state            : 'OPEN',
+                      createdAt        : '2026-07-01T09:00:00Z',
+                      updatedAt        : '2026-07-01T15:00:00Z',
+                      lastEditedAt     : null,
+                      authorAssociation: 'CONTRIBUTOR',
+                      author           : {login: `author-${index + 1}`, __typename: 'User'},
+                      comments         : {totalCount: 0, nodes: [], pageInfo: {hasNextPage: false, endCursor: null}},
+                      reviews          : {totalCount: 0, nodes: [], pageInfo: {hasNextPage: false, endCursor: null}},
+                      timelineItems    : {
+                          filteredCount: 0,
+                          updatedAt    : '2026-07-01T15:00:00Z',
+                          nodes        : [],
+                          pageInfo     : {hasNextPage: false, endCursor: null}
+                      }
+                  }
+              }),
+              rootsById = new Map(scaleRoots.map(root => [root.id, root])),
+              calls = [],
+              restPaths = [],
+              graphqlService = {
+                  query: async (queryString, variables) => {
+                      calls.push({queryString, variables});
+
+                      if (queryString.includes('ReconcilePullRequests')) {
+                          return {repository: {pullRequests: {
+                              totalCount: scaleRoots.length,
+                              nodes     : scaleRoots,
+                              pageInfo  : {hasNextPage: false, endCursor: 'ROOT_SCALE'}
+                          }}}
+                      }
+
+                      if (queryString.includes('ReconcilePullRequestContentEditHeads')) {
+                          return {nodes: variables.ids.map(id => {
+                              const root = rootsById.get(id);
+
+                              return {
+                                  id,
+                                  __typename         : 'PullRequest',
+                                  createdAt          : root.createdAt,
+                                  updatedAt          : root.updatedAt,
+                                  includesCreatedEdit: false,
+                                  userContentEdits   : editConnection()
+                              }
+                          })}
+                      }
+
+                      if (queryString.includes('ReconcilePullRequestContentRevisions')) {
+                          return {nodes: variables.ids.map(id => ({
+                              id, __typename: 'PullRequest', updatedAt: rootsById.get(id).updatedAt
+                          }))}
+                      }
+
+                      if (queryString.includes('ReconcilePullRequestCensus')) {
+                          return {repository: {pullRequests: {
+                              totalCount: scaleRoots.length,
+                              nodes     : scaleRoots.map(root => ({
+                                  id           : root.id,
+                                  updatedAt    : root.updatedAt,
+                                  timelineItems: {
+                                      filteredCount: root.timelineItems.filteredCount,
+                                      updatedAt    : root.timelineItems.updatedAt
+                                  }
+                              })),
+                              pageInfo: {hasNextPage: false, endCursor: 'VERIFY_SCALE'}
+                          }}}
+                      }
+
+                      throw new Error('unexpected scale query')
+                  },
+                  rest: async (method, requestPath) => {
+                      expect(method).toBe('GET');
+                      restPaths.push(requestPath);
+                      return []
+                  }
+              },
+              admissionService = makeAdmission();
+
+        await PullRequestReconciliationService.reconcile({
+            ...runSpec,
+            batchId        : 'batch-pr-scale',
+            admissionService,
+            graphqlService,
+            registryService: registryActive
+        });
+
+        const editHeadCalls = calls.filter(call => call.queryString.includes('ReconcilePullRequestContentEditHeads')),
+              revisionCalls = calls.filter(call => call.queryString.includes('ReconcilePullRequestContentRevisions'));
+        const opened = admissionService.admitted.observations.filter(
+            observation => observation.occurrenceKind === 'pull_request.opened'
+        );
+
+        expect(editHeadCalls.map(call => call.variables.ids.length)).toEqual([100, 100, 5]);
+        expect(revisionCalls.map(call => call.variables.ids.length)).toEqual([100, 100, 5]);
+        expect(restPaths).toHaveLength(2);
+        expect(restPaths.every(requestPath => requestPath.startsWith('/repos/neomjs/neo/pulls/comments?'))).toBe(true);
+        expect(opened).toHaveLength(205)
+    });
+
+    test('the same base and provider truth reproduce the canonical batch digest', async () => {
+        const runOnce = async () => {
+            const admissionService = makeAdmission();
+
+            await PullRequestReconciliationService.reconcile({
+                ...runSpec,
+                admissionService,
+                graphqlService : makeGraphql(),
+                registryService: registryActive
+            });
+
+            return admissionService.admitted
+        };
+
+        expect(canonicalBatchDigest(await runOnce())).toBe(canonicalBatchDigest(await runOnce()))
+    });
+
+    test('a later checkpoint still re-enumerates every known root and child family from genesis', async () => {
+        let   checkpoint   = null,
+              observations = [];
+        const admittedBatches  = [],
+              admissionService = {
+                  getCheckpoint   : () => checkpoint,
+                  listObservations: () => observations,
+                  admitBatch(batch) {
+                      admittedBatches.push(batch);
+                      observations = batch.observations;
+                      checkpoint = {
+                          checkpointVersion: batch.baseCheckpointVersion + 1,
+                          inventoryHash    : batch.nextInventoryHash
+                      };
+                      return {status: 'accepted'}
+                  }
+              },
+              graphqlService = makeGraphql();
+
+        await PullRequestReconciliationService.reconcile({
+            ...runSpec, batchId: 'batch-pr-pass-1', admissionService, graphqlService, registryService: registryActive
+        });
+        await PullRequestReconciliationService.reconcile({
+            ...runSpec, batchId: 'batch-pr-pass-2', admissionService, graphqlService, registryService: registryActive
+        });
+
+        const rootCalls  = graphqlService.calls.filter(call => call.queryString.includes('ReconcilePullRequests')),
+              childCalls = graphqlService.calls.filter(call => call.queryString.includes('ReconcilePullRequestChildren'));
+
+        expect(rootCalls).toHaveLength(2);
+        expect(rootCalls.map(call => call.variables.after)).toEqual([null, null]);
+        expect(childCalls).toHaveLength(2);
+        expect(admittedBatches[1]).toMatchObject({baseCheckpointVersion: 1});
+        expect(admittedBatches[1].observations.some(observation => (
+            observation.occurrenceKind === 'pull_request.opened' && observation.providerEntityId === 'PR_9'
+        ))).toBe(true)
+    });
+
+    test('a REST verification mismatch becomes a gap and no mixed PR snapshot is admitted', async () => {
+        let   restPass       = 0;
+        const graphqlService = makeGraphql({
+                  rest: async () => [inlineComment({updated_at: ++restPass === 1
+                      ? '2026-07-01T13:00:00Z'
+                      : '2026-07-01T13:01:00Z'})]
+              }),
+              admissionService = makeAdmission();
+
+        await PullRequestReconciliationService.reconcile({
+            ...runSpec, admissionService, graphqlService, registryService: registryActive
+        });
+
+        const batch = admissionService.admitted;
+
+        expect(batch.observations).toHaveLength(0);
+        expect(batch.coverage.complete).toBe(false);
+        expect(batch.coverage.gaps.some(gap => (
+            gap.axis === 'inline-review-comments' && gap.reason.includes('mutated during verification')
+        ))).toBe(true);
+        expect(batch.nextInventoryHash).not.toBe(null)
+    });
+
+    test('an admission conflict is returned without a service-side checkpoint advance', async () => {
+        const admissionService = makeAdmission({
+            admitBatch: () => ({status: 'conflict', reason: 'STALE_BASIS'})
+        });
+
+        const receipt = await PullRequestReconciliationService.reconcile({
+            ...runSpec,
+            admissionService,
+            graphqlService : makeGraphql(),
+            registryService: registryActive
+        });
+
+        expect(receipt).toEqual({status: 'conflict', reason: 'STALE_BASIS'})
+    });
+
+    test('an evidenced vanished root becomes a deletion while an unevidenced root stays an access gap', async () => {
+        const graphqlService = makeGraphql({
+                  query: async queryString => queryString.includes('ReconcilePullRequestCensus')
+                      ? {repository: {pullRequests: {totalCount: 0, nodes: [], pageInfo: {hasNextPage: false, endCursor: 'VERIFY_EMPTY'}}}}
+                      : queryString.includes('ReconcilePullRequests')
+                          ? {repository: {pullRequests: {totalCount: 0, nodes: [], pageInfo: {hasNextPage: false, endCursor: 'ROOT_EMPTY'}}}}
+                          : (() => { throw new Error('unexpected child query') })()
+              }),
+              admissionService = makeAdmission({
+                  listObservations: () => [
+                      {occurrenceKind: 'pull_request.opened', providerEntityId: 'PR_gone'},
+                      {occurrenceKind: 'pull_request.opened', providerEntityId: 'PR_hidden'}
+                  ]
+              });
+
+        await PullRequestReconciliationService.reconcile({
+            ...runSpec,
+            admissionService,
+            graphqlService,
+            registryService        : registryActive,
+            acquireDeletionEvidence: async ids => ids.includes('PR_gone')
+                ? {PR_gone: {tombstoneId: 't-pr', deletedAt: '2026-07-01T15:30:00Z'}}
+                : {}
+        });
+
+        const batch = admissionService.admitted;
+
+        expect(batch.observations.find(observation => observation.providerEntityId === 'PR_gone'))
+            .toMatchObject({occurrenceKind: 'pull_request.deleted', absence: 'deleted'});
+        expect(batch.observations.some(observation => observation.providerEntityId === 'PR_hidden')).toBe(false);
+        expect(batch.coverage.gaps).toContainEqual({axis: 'inventory-access', providerEntityId: 'PR_hidden'})
+    });
+
+    test('an inactive source is refused before acquisition', async () => {
+        const graphqlService = makeGraphql();
+
+        await expect(PullRequestReconciliationService.reconcile({
+            ...runSpec,
+            admissionService: makeAdmission(),
+            graphqlService,
+            registryService : {getRegistration: () => ({lifecycleState: 'REVOKED', registrationEpoch: 4})}
+        })).rejects.toThrow('PULL_REQUEST_RECONCILIATION_SOURCE_NOT_ACTIVE');
+
+        expect(graphqlService.calls).toHaveLength(0)
+    })
+});

--- a/test/playwright/unit/ai/services/github-workflow/community/githubPullRequestObservations.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/community/githubPullRequestObservations.spec.mjs
@@ -1,0 +1,185 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'GithubPullRequestObservationsTest'}
+});
+
+import {test, expect}                                            from '@playwright/test';
+import Neo                                                       from '../../../../../../../src/Neo.mjs';
+import * as core                                                 from '../../../../../../../src/core/_export.mjs';
+import {BATCH_SCHEMA_VERSION, occurrenceIdentity, validateBatch} from '../../../../../../../ai/services/memory-core/communityBatchContract.mjs';
+import {pullRequestToObservations}                               from '../../../../../../../ai/services/github-workflow/community/githubPullRequestObservations.mjs';
+
+/**
+ * @summary Witnesses metadata-only, stable PR/review occurrence identity, provider-backed
+ * dismissal/deletion evidence, editor-only edit attribution, and popularity refusal.
+ */
+test.describe('githubPullRequestObservations normalizer', () => {
+    const fullPullRequest = {
+        id               : 'PR_1',
+        number           : 1,
+        createdAt        : '2026-07-01T09:00:00Z',
+        updatedAt        : '2026-07-01T15:00:00Z',
+        lastEditedAt     : '2026-07-01T09:30:00Z',
+        authorAssociation: 'CONTRIBUTOR',
+        author           : {login: 'author', __typename: 'User'},
+        contentEdits     : [
+            {id: 'UCE_PR_1', editedAt: '2026-07-01T09:20:00Z', editor: {login: 'author', __typename: 'User'}},
+            {id: 'UCE_PR_2', editedAt: '2026-07-01T09:30:00Z', editor: {login: 'maintainer', __typename: 'User'}}
+        ],
+        comments         : [{
+            id               : 'IC_1',
+            createdAt        : '2026-07-01T10:00:00Z',
+            lastEditedAt     : '2026-07-01T10:05:00Z',
+            authorAssociation: 'FIRST_TIME_CONTRIBUTOR',
+            author           : {login: 'commenter', __typename: 'User'},
+            contentEdits     : [{id: 'UCE_IC_1', editedAt: '2026-07-01T10:05:00Z', editor: null}]
+        }],
+        reviews: [{
+            id               : 'R_1',
+            createdAt        : '2026-07-01T11:00:00Z',
+            submittedAt      : '2026-07-01T11:05:00Z',
+            lastEditedAt     : '2026-07-01T11:10:00Z',
+            state            : 'APPROVED',
+            authorAssociation: 'MEMBER',
+            author           : {login: 'reviewer', __typename: 'User'},
+            contentEdits     : [{id: 'UCE_R_1', editedAt: '2026-07-01T11:10:00Z', editor: {login: 'review-editor', __typename: 'User'}}]
+        }],
+        reviewComments: [{
+            id               : 'RC_1',
+            createdAt        : '2026-07-01T12:00:00Z',
+            updatedAt        : '2026-07-01T12:05:00Z',
+            authorAssociation: 'COLLABORATOR',
+            author           : {login: 'inline-reviewer', __typename: 'User'},
+            contentEdits     : [{id: 'UCE_RC_1', editedAt: '2026-07-01T12:05:00Z', editor: null}]
+        }],
+        timeline: [
+            {id: 'CE_1', __typename: 'ClosedEvent', createdAt: '2026-07-01T12:30:00Z', actor: {login: 'maintainer', __typename: 'User'}},
+            {id: 'RE_1', __typename: 'ReopenedEvent', createdAt: '2026-07-01T13:00:00Z', actor: {login: 'maintainer', __typename: 'User'}},
+            {id: 'ME_1', __typename: 'MergedEvent', createdAt: '2026-07-01T13:30:00Z', actor: {login: 'maintainer', __typename: 'User'}},
+            {id: 'RD_1', __typename: 'ReviewDismissedEvent', createdAt: '2026-07-01T13:45:00Z', actor: {login: 'maintainer', __typename: 'User'}, review: {id: 'R_1'}, previousReviewState: 'APPROVED'},
+            {id: 'CD_1', __typename: 'CommentDeletedEvent', createdAt: '2026-07-01T14:00:00Z', actor: {login: 'maintainer', __typename: 'User'}, deletedCommentAuthor: {login: 'commenter', __typename: 'User'}},
+            {id: 'STAR_1', __typename: 'StarredEvent', createdAt: '2026-07-01T14:30:00Z', actor: {login: 'fan', __typename: 'User'}}
+        ]
+    };
+
+    const batchAround = observations => ({
+        schemaVersion             : BATCH_SCHEMA_VERSION,
+        sourceInstanceId          : 'src-pr',
+        resourceFamily            : 'pulls',
+        adapterSchemaVersion      : 'github-pull-request.v1',
+        providerStateSchemaVersion: 'github-pull-request-state.v1',
+        registrationEpoch         : 1,
+        baseCheckpointVersion     : 0,
+        baseInventoryHash         : null,
+        batchId                   : 'batch-pr',
+        observations,
+        nextProviderState         : {pullRequestsCursor: 'end', rootCount: 1},
+        nextInventoryHash         : 'inv-pr',
+        coverage                  : {fromBasis: 'genesis', toBasis: 'end', complete: true}
+    });
+
+    test('emits every supported occurrence family as a valid metadata-only batch', () => {
+        const observations = pullRequestToObservations(fullPullRequest),
+              kinds        = observations.map(observation => observation.occurrenceKind);
+
+        expect(kinds).toEqual([
+            'pull_request.opened',
+            'pull_request.edited',
+            'pull_request.edited',
+            'pull_request.comment',
+            'pull_request.comment-edited',
+            'pull_request.review-created',
+            'pull_request.review-submitted',
+            'pull_request.review-edited',
+            'pull_request.review-comment',
+            'pull_request.review-comment-edited',
+            'pull_request.closed',
+            'pull_request.reopened',
+            'pull_request.merged',
+            'pull_request.review-dismissed',
+            'pull_request.comment-deleted',
+            'pull_request.observed-snapshot-change'
+        ]);
+        expect(validateBatch(batchAround(observations))).toEqual({valid: true, errors: []});
+        expect(JSON.stringify(observations)).not.toContain('StarredEvent')
+    });
+
+    test('source association stays separate from actor kind and response families keep their actors', () => {
+        const observations = pullRequestToObservations(fullPullRequest),
+              root         = observations.find(observation => observation.occurrenceKind === 'pull_request.opened'),
+              review       = observations.find(observation => observation.occurrenceKind === 'pull_request.review-submitted'),
+              inline       = observations.find(observation => observation.occurrenceKind === 'pull_request.review-comment');
+
+        expect(root).toMatchObject({actorId: 'author', actorKind: 'user', sourceAssociation: 'CONTRIBUTOR'});
+        expect(review).toMatchObject({actorId: 'reviewer', actorKind: 'user', sourceAssociation: 'MEMBER'});
+        expect(review).toMatchObject({providerState: 'APPROVED', parentProviderEntityId: 'PR_1'});
+        expect(inline).toMatchObject({
+            actorId: 'inline-reviewer', actorKind: 'user', sourceAssociation: 'COLLABORATOR', parentProviderEntityId: 'PR_1'
+        })
+    });
+
+    test('edits use provider editor evidence only and never reuse the original author', () => {
+        const observations = pullRequestToObservations(fullPullRequest),
+              rootEdits    = observations.filter(observation => observation.occurrenceKind === 'pull_request.edited'),
+              commentEdit  = observations.find(observation => observation.occurrenceKind === 'pull_request.comment-edited'),
+              reviewEdit   = observations.find(observation => observation.occurrenceKind === 'pull_request.review-edited'),
+              inlineEdit   = observations.find(observation => observation.occurrenceKind === 'pull_request.review-comment-edited');
+
+        expect(rootEdits).toHaveLength(2);
+        expect(rootEdits[1]).toMatchObject({
+            actorId: 'maintainer', actorKind: 'user', occurrenceCoordinate: 'UCE_PR_2', revisionOf: 'PR_1:opened'
+        });
+        expect(reviewEdit).toMatchObject({actorId: 'review-editor', actorKind: 'user'});
+
+        for (const unattributed of [commentEdit, inlineEdit]) {
+            expect(unattributed).toMatchObject({
+                actorId  : null,
+                actorKind: 'unknown'
+            })
+        }
+    });
+
+    test('dismissal and deletion evidence are immutable provider events, not mutable snapshot state', () => {
+        const approved  = pullRequestToObservations(fullPullRequest),
+              dismissed = pullRequestToObservations({
+                  ...fullPullRequest,
+                  reviews: [{...fullPullRequest.reviews[0], state: 'DISMISSED'}]
+              }),
+              dismissal = approved.find(observation => observation.occurrenceKind === 'pull_request.review-dismissed'),
+              deletion  = approved.find(observation => observation.occurrenceKind === 'pull_request.comment-deleted');
+
+        expect(dismissal).toMatchObject({
+            providerEntityId      : 'R_1',
+            parentProviderEntityId: 'PR_1',
+            providerState         : 'DISMISSED',
+            occurrenceCoordinate  : 'RD_1'
+        });
+        expect(deletion).toMatchObject({
+            providerEntityId: 'PR_1',
+            deletionEvidence: {eventId: 'CD_1', deletedCommentAuthorId: 'commenter'}
+        });
+        expect(dismissed).toEqual(approved);
+        expect(dismissed.map(observation => occurrenceIdentity('src-pr', observation)))
+            .toEqual(approved.map(observation => occurrenceIdentity('src-pr', observation)))
+    });
+
+    test('a mutable DISMISSED review without matching provider dismissal evidence fails closed', () => {
+        expect(() => pullRequestToObservations({
+            ...fullPullRequest,
+            reviews : [{...fullPullRequest.reviews[0], state: 'DISMISSED'}],
+            timeline: fullPullRequest.timeline.filter(event => event.__typename !== 'ReviewDismissedEvent')
+        })).toThrow('PULL_REQUEST_OBSERVATIONS_DISMISSED_REVIEW_WITHOUT_EVENT')
+    });
+
+    test('missing stable ids fail loud at each entity boundary', () => {
+        expect(() => pullRequestToObservations(null)).toThrow('PULL_REQUEST_OBSERVATIONS_REQUIRE_NODE_ID');
+        expect(() => pullRequestToObservations({id: 'PR', createdAt: 't', comments: [{createdAt: 't'}]}))
+            .toThrow('PULL_REQUEST_OBSERVATIONS_REQUIRE_COMMENT_ID');
+        expect(() => pullRequestToObservations({id: 'PR', createdAt: 't', reviews: [{createdAt: 't'}]}))
+            .toThrow('PULL_REQUEST_OBSERVATIONS_REQUIRE_REVIEW_ID');
+        expect(() => pullRequestToObservations({id: 'PR', createdAt: 't', timeline: [{__typename: 'ClosedEvent', createdAt: 't'}]}))
+            .toThrow('PULL_REQUEST_OBSERVATIONS_REQUIRE_EVENT_ID')
+    })
+});

--- a/test/playwright/unit/ai/services/github-workflow/community/githubPullRequestReconciliation.spec.mjs
+++ b/test/playwright/unit/ai/services/github-workflow/community/githubPullRequestReconciliation.spec.mjs
@@ -1,0 +1,388 @@
+import {setup} from '../../../../../setup.mjs';
+
+setup({
+    neoConfig: {unitTestMode: true},
+    appConfig: {name: 'GithubPullRequestReconciliationTest'}
+});
+
+import {test, expect}                 from '@playwright/test';
+import Neo                            from '../../../../../../../src/Neo.mjs';
+import * as core                      from '../../../../../../../src/core/_export.mjs';
+import {reconcilePullRequestActivity} from '../../../../../../../ai/services/github-workflow/community/githubPullRequestReconciliation.mjs';
+
+/**
+ * @summary Witnesses all-state root enumeration, independent child/edit-axis completion, timeline
+ * mutation/count evidence, content revision verification, and adapter-owned unsupported gaps.
+ */
+test.describe('reconcilePullRequestActivity runner', () => {
+    const editConnection = (nodes=[], overrides={}) => ({
+        totalCount: nodes.length,
+        nodes,
+        pageInfo  : {hasNextPage: false, endCursor: null},
+        ...overrides
+    });
+
+    const emptyConnection = () => ({nodes: [], pageInfo: {hasNextPage: false, endCursor: null}});
+
+    const contentEntity = (spec={}) => ({
+        updatedAt          : spec.createdAt,
+        lastEditedAt       : null,
+        includesCreatedEdit: false,
+        userContentEdits   : editConnection(),
+        ...spec
+    });
+
+    const pullRequest = ({id, number, timeline}) => {
+        const createdAt = `2026-07-0${number}T09:00:00Z`,
+              updatedAt = `2026-07-0${number}T15:00:00Z`;
+
+        return contentEntity({
+            id,
+            number,
+            createdAt,
+            updatedAt,
+            authorAssociation: 'CONTRIBUTOR',
+            author           : {login: `author-${number}`, __typename: 'User'},
+            comments         : {...emptyConnection(), totalCount: 0},
+            reviews          : {...emptyConnection(), totalCount: 0},
+            timeline         : timeline ?? {
+                filteredCount: 0,
+                updatedAt,
+                ...emptyConnection()
+            }
+        })
+    };
+
+    const pr1 = pullRequest({
+        id      : 'PR_1',
+        number  : 1,
+        timeline: {
+            filteredCount: 2,
+            updatedAt    : '2026-07-01T14:30:00Z',
+            nodes        : [{id: 'CE_1', __typename: 'ClosedEvent', createdAt: '2026-07-01T12:00:00Z', actor: {login: 'maintainer', __typename: 'User'}}],
+            pageInfo     : {hasNextPage: true, endCursor: 'T1'}
+        }
+    });
+    const pr2 = pullRequest({id: 'PR_2', number: 2});
+
+    const censusRevision = (root, overrides={}) => ({
+        id       : root.id,
+        updatedAt: root.updatedAt,
+        timeline : {
+            filteredCount: root.timeline.filteredCount,
+            updatedAt    : root.timeline.updatedAt
+        },
+        ...overrides
+    });
+
+    const buildSeams = (overrides={}) => ({
+        fetchPullRequestsPage: async ({cursor}) => cursor === null
+            ? {pullRequests: [pr1], totalCount: 2, pageInfo: {hasNextPage: true, endCursor: 'ROOT_1'}}
+            : {pullRequests: [pr2], totalCount: 2, pageInfo: {hasNextPage: false, endCursor: 'ROOT_2'}},
+        exhaustConversation: async ({pullRequest: root}) => root.id === 'PR_1'
+            ? {
+                comments: [
+                    contentEntity({id: 'IC_1', createdAt: '2026-07-01T10:00:00Z', authorAssociation: 'CONTRIBUTOR', author: {login: 'commenter', __typename: 'User'}}),
+                    contentEntity({id: 'IC_2', createdAt: '2026-07-01T10:05:00Z', authorAssociation: 'NONE', author: {login: 'bot', __typename: 'Bot'}})
+                ],
+                reviews: [contentEntity({
+                    id   : 'R_1', createdAt: '2026-07-01T11:00:00Z', submittedAt: '2026-07-01T11:05:00Z',
+                    state: 'APPROVED', authorAssociation: 'MEMBER', author: {login: 'reviewer', __typename: 'User'}
+                })]
+            }
+            : {comments: [], reviews: []},
+        fetchTimelinePage: async ({pullRequestId, cursor}) => {
+            expect(pullRequestId).toBe('PR_1');
+            expect(cursor).toBe('T1');
+            return {
+                rootUpdatedAt      : pr1.updatedAt,
+                connectionUpdatedAt: pr1.timeline.updatedAt,
+                filteredCount      : 2,
+                events             : [{id: 'ME_1', __typename: 'MergedEvent', createdAt: '2026-07-01T14:00:00Z', actor: {login: 'maintainer', __typename: 'User'}}],
+                pageInfo           : {hasNextPage: false, endCursor: 'T2'}
+            }
+        },
+        fetchReviewCommentSnapshot: async () => ({
+            reviewCommentsByPullRequestNumber: new Map([[1, [contentEntity({
+                id               : 'RC_1', nodeId: 'PRRC_1', createdAt: '2026-07-01T13:00:00Z',
+                authorAssociation: 'COLLABORATOR', author: {login: 'inline', __typename: 'User'}
+            })]]]),
+            failuresByPullRequestNumber: new Map()
+        }),
+        fetchContentEditHeads: async ({entities}) => entities.map(value => ({status: 'fulfilled', value})),
+        fetchContentEditsPage: async () => { throw new Error('no edit continuation expected') },
+        verifyContentEntities: async ({entities}) => entities.map(value => ({status: 'fulfilled', value})),
+        fetchCensusPage      : async ({cursor}) => cursor === null
+            ? {pullRequests: [censusRevision(pr1)], totalCount: 2, pageInfo: {hasNextPage: true, endCursor: 'VERIFY_1'}}
+            : {pullRequests: [censusRevision(pr2)], totalCount: 2, pageInfo: {hasNextPage: false, endCursor: 'VERIFY_2'}},
+        ...overrides
+    });
+
+    const countKind = (observations, kind) => observations.filter(observation => observation.occurrenceKind === kind).length;
+
+    test('exhausts all roots and child axes, then verifies the root census', async () => {
+        const result = await reconcilePullRequestActivity(buildSeams());
+
+        expect(result.currentInventory).toEqual(['PR_1', 'PR_2']);
+        expect(countKind(result.observations, 'pull_request.opened')).toBe(2);
+        expect(countKind(result.observations, 'pull_request.comment')).toBe(2);
+        expect(countKind(result.observations, 'pull_request.review-created')).toBe(1);
+        expect(countKind(result.observations, 'pull_request.review-submitted')).toBe(1);
+        expect(countKind(result.observations, 'pull_request.review-comment')).toBe(1);
+        expect(countKind(result.observations, 'pull_request.closed')).toBe(1);
+        expect(countKind(result.observations, 'pull_request.merged')).toBe(1);
+        expect(result.coverage).toMatchObject({fromBasis: 'genesis', toBasis: 'ROOT_2', complete: false});
+        expect(result.nextProviderState).toEqual({pullRequestsCursor: 'ROOT_2', rootCount: 2})
+    });
+
+    test('a timeline cap emits partial evidence plus an explicit gap', async () => {
+        const result = await reconcilePullRequestActivity(buildSeams({
+            fetchTimelinePage: async () => { throw new Error('cap must stop before continuation') }
+        }), {maxTimelinePagesPerPullRequest: 1});
+
+        expect(result.observations.some(observation => observation.providerEntityId === 'PR_1')).toBe(false);
+        expect(countKind(result.observations, 'pull_request.merged')).toBe(0);
+        expect(result.coverage.complete).toBe(false);
+        expect(result.coverage.gaps).toContainEqual({axis: 'timeline', pullRequestId: 'PR_1', reason: 'page-cap'})
+    });
+
+    test('a child verification failure admits no mixed snapshot but retains the live root inventory', async () => {
+        const result = await reconcilePullRequestActivity(buildSeams({
+            fetchReviewCommentSnapshot: async () => ({
+                reviewCommentsByPullRequestNumber: new Map(),
+                failuresByPullRequestNumber      : new Map([[1, 'review comments mutated during verification']])
+            })
+        }));
+
+        expect(result.currentInventory).toEqual(['PR_1', 'PR_2']);
+        expect(result.observations.some(observation => observation.providerEntityId === 'PR_1')).toBe(false);
+        expect(result.coverage.gaps).toContainEqual({
+            axis         : 'inline-review-comments',
+            pullRequestId: 'PR_1',
+            reason       : 'review comments mutated during verification'
+        })
+    });
+
+    test('a final root mutation rejects that PR snapshot and degrades coverage', async () => {
+        const result = await reconcilePullRequestActivity(buildSeams({
+            verifyContentEntities: async ({entities}) => entities.map(entity => ({
+                status: 'fulfilled',
+                value : {
+                    ...entity,
+                    updatedAt: entity.id === 'PR_1' ? '2026-07-01T16:00:00Z' : entity.updatedAt
+                }
+            }))
+        }));
+
+        expect(result.observations.some(observation => observation.providerEntityId === 'PR_1')).toBe(false);
+        expect(result.coverage.gaps).toContainEqual({
+            axis         : 'pull-request-snapshot',
+            pullRequestId: 'PR_1',
+            reason       : 'PULL_REQUEST_RECONCILIATION_CONTENT_MUTATED:PR_1'
+        })
+    });
+
+    test('one rejected batched edit head invalidates only its owning PR', async () => {
+        const result = await reconcilePullRequestActivity(buildSeams({
+            fetchContentEditHeads: async ({entities}) => entities.map(entity => entity.id === 'PR_1'
+                ? {status: 'rejected', reason: 'head unavailable'}
+                : {status: 'fulfilled', value: entity})
+        }));
+
+        expect(result.observations.some(observation => observation.providerEntityId === 'PR_1')).toBe(false);
+        expect(result.observations.some(observation => observation.providerEntityId === 'PR_2')).toBe(true);
+        expect(result.coverage.gaps).toContainEqual({
+            axis         : 'content-edits',
+            pullRequestId: 'PR_1',
+            reason       : 'head unavailable'
+        })
+    });
+
+    test('a changed second-pass census becomes an honest verification gap', async () => {
+        const result = await reconcilePullRequestActivity(buildSeams({
+            fetchCensusPage: async ({cursor}) => cursor === null
+                ? {pullRequests: [censusRevision(pr1, {updatedAt: '2026-07-01T16:00:00Z'})], totalCount: 2, pageInfo: {hasNextPage: true, endCursor: 'VERIFY_1'}}
+                : {pullRequests: [censusRevision(pr2)], totalCount: 2, pageInfo: {hasNextPage: false, endCursor: 'VERIFY_2'}}
+        }));
+
+        expect(result.observations.some(observation => observation.providerEntityId === 'PR_1')).toBe(false);
+        expect(result.observations.some(observation => observation.providerEntityId === 'PR_2')).toBe(true);
+        expect(result.coverage.gaps).toContainEqual({
+            axis         : 'pull-request-census-verification',
+            pullRequestId: 'PR_1',
+            reason       : 'PULL_REQUEST_RECONCILIATION_ROOT_MUTATED:PR_1'
+        })
+    });
+
+    test('a timeline-only second-pass mutation rejects only that PR snapshot', async () => {
+        const result = await reconcilePullRequestActivity(buildSeams({
+            fetchCensusPage: async ({cursor}) => cursor === null
+                ? {
+                    pullRequests: [censusRevision(pr1, {timeline: {
+                        filteredCount: pr1.timeline.filteredCount,
+                        updatedAt    : '2026-07-01T14:31:00Z'
+                    }})],
+                    totalCount: 2,
+                    pageInfo  : {hasNextPage: true, endCursor: 'VERIFY_1'}
+                }
+                : {
+                    pullRequests: [censusRevision(pr2)],
+                    totalCount  : 2,
+                    pageInfo    : {hasNextPage: false, endCursor: 'VERIFY_2'}
+                }
+        }));
+
+        expect(result.observations.some(observation => observation.providerEntityId === 'PR_1')).toBe(false);
+        expect(result.observations.some(observation => observation.providerEntityId === 'PR_2')).toBe(true);
+        expect(result.coverage.gaps).toContainEqual({
+            axis         : 'pull-request-census-verification',
+            pullRequestId: 'PR_1',
+            reason       : 'PULL_REQUEST_RECONCILIATION_TIMELINE_MUTATED:PR_1'
+        })
+    });
+
+    test('every stable edit revision is exhausted with independent cursor progress', async () => {
+        const firstEdit = {id: 'UCE_1', editedAt: '2026-07-02T10:00:00Z', editor: {login: 'author-2', __typename: 'User'}},
+              lastEdit  = {id: 'UCE_2', editedAt: '2026-07-02T11:00:00Z', editor: {login: 'maintainer', __typename: 'User'}},
+              editedPr  = {
+                  ...pr2,
+                  lastEditedAt    : lastEdit.editedAt,
+                  userContentEdits: editConnection([firstEdit], {
+                      totalCount: 2,
+                      pageInfo  : {hasNextPage: true, endCursor: 'EDIT_1'}
+                  })
+              },
+              seams = buildSeams({
+                  fetchPullRequestsPage: async () => ({
+                      pullRequests: [editedPr], totalCount: 1, pageInfo: {hasNextPage: false, endCursor: 'ROOT_EDIT'}
+                  }),
+                  exhaustConversation       : async () => ({comments: [], reviews: []}),
+                  fetchReviewCommentSnapshot: async () => ({
+                      reviewCommentsByPullRequestNumber: new Map(), failuresByPullRequestNumber: new Map()
+                  }),
+                  fetchContentEditsPage: async ({entityNodeId, cursor}) => {
+                      expect({entityNodeId, cursor}).toEqual({entityNodeId: 'PR_2', cursor: 'EDIT_1'});
+                      return {
+                          id                 : 'PR_2',
+                          createdAt          : editedPr.createdAt,
+                          updatedAt          : editedPr.updatedAt,
+                          includesCreatedEdit: false,
+                          userContentEdits   : editConnection([lastEdit], {
+                              totalCount: 2,
+                              pageInfo  : {hasNextPage: false, endCursor: 'EDIT_2'}
+                          })
+                      }
+                  },
+                  fetchCensusPage: async () => ({
+                      pullRequests: [censusRevision(editedPr)],
+                      totalCount  : 1,
+                      pageInfo    : {hasNextPage: false, endCursor: 'VERIFY_EDIT'}
+                  })
+              }),
+              result = await reconcilePullRequestActivity(seams),
+              edits  = result.observations.filter(observation => observation.occurrenceKind === 'pull_request.edited');
+
+        expect(edits).toHaveLength(2);
+        expect(edits.map(edit => edit.occurrenceCoordinate)).toEqual(['UCE_1', 'UCE_2']);
+        expect(edits.map(edit => edit.revisionOf)).toEqual(['PR_2:opened', 'PR_2:opened'])
+    });
+
+    test('a duplicate edit id degrades the PR instead of admitting a collapsed revision history', async () => {
+        const edit     = {id: 'UCE_DUP', editedAt: '2026-07-02T10:00:00Z', editor: null},
+              editedPr = {
+                  ...pr2,
+                  lastEditedAt    : edit.editedAt,
+                  userContentEdits: editConnection([edit], {
+                      totalCount: 2,
+                      pageInfo  : {hasNextPage: true, endCursor: 'EDIT_DUP_1'}
+                  })
+              },
+              result = await reconcilePullRequestActivity(buildSeams({
+                  fetchPullRequestsPage: async () => ({
+                      pullRequests: [editedPr], totalCount: 1, pageInfo: {hasNextPage: false, endCursor: 'ROOT_DUP'}
+                  }),
+                  exhaustConversation       : async () => ({comments: [], reviews: []}),
+                  fetchReviewCommentSnapshot: async () => ({
+                      reviewCommentsByPullRequestNumber: new Map(), failuresByPullRequestNumber: new Map()
+                  }),
+                  fetchContentEditsPage: async () => ({
+                      id                 : editedPr.id,
+                      createdAt          : editedPr.createdAt,
+                      updatedAt          : editedPr.updatedAt,
+                      includesCreatedEdit: false,
+                      userContentEdits   : editConnection([edit], {
+                          totalCount: 2,
+                          pageInfo  : {hasNextPage: false, endCursor: 'EDIT_DUP_2'}
+                      })
+                  }),
+                  fetchCensusPage: async () => ({
+                      pullRequests: [censusRevision(editedPr)],
+                      totalCount  : 1,
+                      pageInfo    : {hasNextPage: false, endCursor: 'VERIFY_DUP'}
+                  })
+              }));
+
+        expect(result.observations).toHaveLength(0);
+        expect(result.coverage.gaps).toContainEqual({
+            axis         : 'content-edits',
+            pullRequestId: 'PR_2',
+            reason       : 'PULL_REQUEST_RECONCILIATION_DUPLICATE_EDIT_ID:UCE_DUP'
+        })
+    });
+
+    test('missing timeline pageInfo and filtered-count mismatches fail closed', async () => {
+        const malformed       = {...pr2, timeline: {filteredCount: 0, updatedAt: pr2.updatedAt, nodes: []}},
+              malformedResult = await reconcilePullRequestActivity(buildSeams({
+                  fetchPullRequestsPage: async () => ({
+                      pullRequests: [malformed], totalCount: 1, pageInfo: {hasNextPage: false, endCursor: 'ROOT_BAD'}
+                  }),
+                  exhaustConversation       : async () => ({comments: [], reviews: []}),
+                  fetchReviewCommentSnapshot: async () => ({
+                      reviewCommentsByPullRequestNumber: new Map(), failuresByPullRequestNumber: new Map()
+                  }),
+                  fetchCensusPage: async () => ({
+                      pullRequests: [censusRevision(malformed)], totalCount: 1,
+                      pageInfo    : {hasNextPage: false, endCursor: 'VERIFY_BAD'}
+                  })
+              })),
+              countResult = await reconcilePullRequestActivity(buildSeams({
+                  fetchTimelinePage: async () => ({
+                      rootUpdatedAt      : pr1.updatedAt,
+                      connectionUpdatedAt: pr1.timeline.updatedAt,
+                      filteredCount      : 2,
+                      events             : [],
+                      pageInfo           : {hasNextPage: false, endCursor: 'T2'}
+                  })
+              }));
+
+        expect(malformedResult.coverage.gaps).toContainEqual({
+            axis: 'timeline', pullRequestId: 'PR_2', reason: 'PULL_REQUEST_RECONCILIATION_TIMELINE_PAGE_INVALID'
+        });
+        expect(countResult.coverage.gaps).toContainEqual({
+            axis: 'timeline', pullRequestId: 'PR_1', reason: 'PULL_REQUEST_RECONCILIATION_TIMELINE_COUNT_MISMATCH'
+        })
+    });
+
+    test('unsupported deletion histories are adapter-owned and cannot be caller-suppressed', async () => {
+        const result = await reconcilePullRequestActivity(buildSeams(), {unsupportedHistoryGaps: []});
+
+        expect(result.coverage.complete).toBe(false);
+        expect(result.coverage.gaps.map(gap => gap.axis)).toEqual(expect.arrayContaining([
+            'comment-deletion-correlation',
+            'review-deletions', 'inline-review-comment-deletions'
+        ]))
+    });
+
+    test('duplicate provider root ids fail loud', async () => {
+        const seams = buildSeams({
+            fetchPullRequestsPage: async () => ({
+                pullRequests: [pr1, pr1],
+                totalCount  : 2,
+                pageInfo    : {hasNextPage: false, endCursor: 'END'}
+            })
+        });
+
+        await expect(reconcilePullRequestActivity(seams))
+            .rejects.toThrow('PULL_REQUEST_RECONCILIATION_DUPLICATE_ROOT_ID:PR_1')
+    })
+});

--- a/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs
@@ -44,7 +44,14 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
         },
 
         ATTENTION_POLICY = {
-            responseBearingKinds     : ['issue.opened', 'issue.comment', 'pull.opened'],
+            responseBearingKinds     : [
+                'issue.opened',
+                'issue.comment',
+                'pull_request.opened',
+                'pull_request.comment',
+                'pull_request.review-submitted',
+                'pull_request.review-comment'
+            ],
             rosteredActorIds         : ['neo-opus-ada', 'neo-gpt'],
             recordedActorDispositions: {}
         },
@@ -198,15 +205,37 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
         expect(result.checkpoint.inventoryHash).toBe('inv-batch-1');
     });
 
-    test('the same batchId + same digest is an idempotent retry — no second receipt', () => {
-        const id    = activeSource(),
-              first = AdmissionService.admitBatch(batchAt(id));
+    test('an idempotent retry repairs legacy nullable projections without reminting receipt or sequence', () => {
+        const id            = activeSource(),
+              legacyPayload = observation('e1', {
+                  parentProviderEntityId: 'pull-42',
+                  providerState         : 'CHANGES_REQUESTED',
+                  sourceAssociation     : 'MEMBER'
+              }),
+              first  = AdmissionService.admitBatch(batchAt(id, {observations: [legacyPayload, observation('e2')]})),
+              before = AdmissionService.listObservations(id, {providerEntityId: 'e1'})[0];
 
-        const retry = AdmissionService.admitBatch(batchAt(id, {observations: [observation('e2'), observation('e1')]}));
+        AdmissionService.db.prepare(
+            `UPDATE mc_community_observation
+             SET parent_provider_entity_id = NULL, provider_state = NULL, source_association = NULL
+             WHERE observation_row_id = ?`
+        ).run(before.observationRowId);
+
+        const retry = AdmissionService.admitBatch(batchAt(id, {observations: [observation('e2'), legacyPayload]})),
+              after = AdmissionService.listObservations(id, {providerEntityId: 'e1'})[0];
 
         expect(retry.status).toBe('idempotent');
         expect(retry.receipt.receiptId).toBe(first.receipt.receiptId);
+        expect(after).toMatchObject({
+            observationRowId      : before.observationRowId,
+            receiptId             : before.receiptId,
+            admittedSequence      : before.admittedSequence,
+            parentProviderEntityId: 'pull-42',
+            providerState         : 'CHANGES_REQUESTED',
+            sourceAssociation     : 'MEMBER'
+        });
         expect(receiptCount()).toBe(1);
+        expect(AdmissionService.getCheckpoint(id, 'issues').checkpointVersion).toBe(1);
     });
 
     test('the same batchId + a DIFFERENT digest is an integrity conflict, never an overwrite', () => {
@@ -349,15 +378,34 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
     // ---------------------------------------------------------------- observation ledger (dedup / revision)
 
     test('overlapping observations across different batchIds dedup by identity + digest', () => {
-        const id = activeSource(),
-              r1 = AdmissionService.admitBatch(batchAt(id, {batchId: 'b1', observations: [observation('e1')]})).receipt;
+        const id      = activeSource(),
+              payload = observation('e1', {sourceAssociation: 'MEMBER'}),
+              r1      = AdmissionService.admitBatch(batchAt(id, {batchId: 'b1', observations: [payload]})).receipt,
+              before  = AdmissionService.listObservations(id, {providerEntityId: 'e1'})[0];
+
+        AdmissionService.db.prepare(
+            `UPDATE mc_community_observation SET source_association = NULL WHERE observation_row_id = ?`
+        ).run(before.observationRowId);
 
         // b2 carries the SAME observation (same identity + digest) plus a new one.
-        AdmissionService.admitBatch(chained(id, r1, {batchId: 'b2', observations: [observation('e1'), observation('e2')]}));
+        const replay = AdmissionService.admitBatch(chained(id, r1, {
+            batchId     : 'b2',
+            observations: [payload, observation('e2')]
+        }));
 
-        const rows = AdmissionService.listObservations(id);
+        const rows    = AdmissionService.listObservations(id),
+              deduped = rows.find(row => row.providerEntityId === 'e1');
+
+        expect(replay.status).toBe('accepted');
+        expect(replay.receipt.admittedSequence).toBe(2);
         expect(rows, 'e1 admitted once despite arriving in two batches').toHaveLength(2);
         expect(rows.filter(r => r.providerEntityId === 'e1')).toHaveLength(1);
+        expect(deduped).toMatchObject({
+            observationRowId : before.observationRowId,
+            receiptId        : before.receiptId,
+            admittedSequence : before.admittedSequence,
+            sourceAssociation: 'MEMBER'
+        })
     });
 
     test('the same occurrence identity with a different digest is an integrity conflict', () => {
@@ -388,6 +436,73 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
         expect(history[1].revisionOf).toBe('e1:create');
     });
 
+    test('provider-neutral parent, state, and association metadata survive the admission round trip', () => {
+        const id = activeSource();
+
+        const result = AdmissionService.admitBatch(batchAt(id, {observations: [observation('review-7', {
+            parentProviderEntityId: 'pull-42',
+            occurrenceKind        : 'pull.review.submitted',
+            providerState         : 'CHANGES_REQUESTED',
+            sourceAssociation     : 'MEMBER'
+        })]}));
+
+        expect(result.status).toBe('accepted');
+        expect(AdmissionService.listObservations(id)).toEqual([
+            expect.objectContaining({
+                providerEntityId      : 'review-7',
+                parentProviderEntityId: 'pull-42',
+                providerState         : 'CHANGES_REQUESTED',
+                sourceAssociation     : 'MEMBER'
+            })
+        ])
+    });
+
+    test('ensureSchema adds nullable observation metadata columns to an existing ledger', () => {
+        const Database  = AdmissionService.db.constructor,
+              legacyDb  = new Database(':memory:'),
+              currentDb = AdmissionService.db;
+
+        legacyDb.exec(`
+            CREATE TABLE mc_community_observation (
+                observation_row_id    TEXT    PRIMARY KEY,
+                tenant_id             TEXT    NOT NULL,
+                source_instance_id    TEXT    NOT NULL,
+                occurrence_identity   TEXT    NOT NULL,
+                occurrence_digest     TEXT    NOT NULL,
+                provider_entity_id    TEXT    NOT NULL,
+                occurrence_kind       TEXT    NOT NULL,
+                occurrence_coordinate TEXT    NOT NULL,
+                occurred_at           TEXT    NOT NULL,
+                actor_id              TEXT,
+                actor_kind            TEXT    NOT NULL,
+                revision_of           TEXT,
+                absence               TEXT,
+                deletion_evidence     TEXT,
+                attention_disposition TEXT    NOT NULL,
+                attention_reason      TEXT    NOT NULL,
+                receipt_id            TEXT    NOT NULL,
+                admitted_sequence     INTEGER NOT NULL,
+                admitted_at           INTEGER NOT NULL
+            )
+        `);
+
+        try {
+            AdmissionService.set({db: legacyDb});
+            AdmissionService.ensureSchema();
+            AdmissionService.ensureSchema();
+
+            const columns = new Set(legacyDb.prepare(`PRAGMA table_info(mc_community_observation)`).all()
+                .map(column => column.name));
+
+            expect(columns.has('parent_provider_entity_id')).toBe(true);
+            expect(columns.has('provider_state')).toBe(true);
+            expect(columns.has('source_association')).toBe(true)
+        } finally {
+            AdmissionService.set({db: currentDb});
+            legacyDb.close()
+        }
+    });
+
     // ---------------------------------------------------------------- attention (§2.1)
 
     test('an external response-bearing occurrence is attention-eligible', () => {
@@ -398,6 +513,46 @@ test.describe('Neo.ai.services.memory-core.CommunityBatchAdmissionService', () =
         const [row] = AdmissionService.listObservations(id);
         expect(row.attentionDisposition).toBe('eligible');
         expect(row.attentionReason).toBe('external-response-bearing');
+    });
+
+    test('PR/review output inherits response-bearing eligibility without promoting state context', () => {
+        const id = activeSource();
+
+        const occurrences = [
+            observation('pull-1', {occurrenceKind: 'pull_request.opened'}),
+            observation('comment-1', {occurrenceKind: 'pull_request.comment'}),
+            observation('review-1', {occurrenceKind: 'pull_request.review-submitted'}),
+            observation('inline-1', {occurrenceKind: 'pull_request.review-comment'}),
+            observation('close-1', {occurrenceKind: 'pull_request.closed'}),
+            observation('internal-review-1', {
+                actorId       : 'neo-gpt',
+                occurrenceKind: 'pull_request.review-submitted'
+            })
+        ];
+
+        expect(AdmissionService.admitBatch(batchAt(id, {
+            resourceFamily: 'pulls',
+            observations  : occurrences
+        })).status).toBe('accepted');
+
+        const rows = new Map(AdmissionService.listObservations(id)
+            .map(row => [row.providerEntityId, row]));
+
+        ['pull-1', 'comment-1', 'review-1', 'inline-1'].forEach(providerEntityId => {
+            expect(rows.get(providerEntityId)).toMatchObject({
+                attentionDisposition: 'eligible',
+                attentionReason     : 'external-response-bearing'
+            })
+        });
+
+        expect(rows.get('close-1')).toMatchObject({
+            attentionDisposition: 'ineligible',
+            attentionReason     : 'not-response-bearing'
+        });
+        expect(rows.get('internal-review-1')).toMatchObject({
+            attentionDisposition: 'ineligible',
+            attentionReason     : 'rostered-actor'
+        })
     });
 
     test('a bot is not attention-eligible in v1', () => {

--- a/test/playwright/unit/ai/services/memory-core/communityBatchContract.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/communityBatchContract.spec.mjs
@@ -120,6 +120,31 @@ test.describe('community-activity-batch.v1 contract', () => {
         expect(validateBatch(batch())).toEqual({valid: true, errors: []});
     });
 
+    test('provider-neutral parent, state, and association metadata accept absent, null, or non-empty strings', () => {
+        expect(validateBatch(batch({observations: [observation('e1', {
+            parentProviderEntityId: 'pull-42',
+            providerState         : 'CHANGES_REQUESTED',
+            sourceAssociation     : 'MEMBER'
+        })]}))).toEqual({valid: true, errors: []});
+        expect(validateBatch(batch({observations: [observation('e1', {
+            parentProviderEntityId: null,
+            providerState         : null,
+            sourceAssociation     : null
+        })]}))).toEqual({valid: true, errors: []});
+
+        const invalid = validateBatch(batch({observations: [observation('e1', {
+            parentProviderEntityId: {},
+            providerState         : '',
+            sourceAssociation     : '   '
+        })]}));
+
+        expect(invalid.errors).toEqual(expect.arrayContaining([
+            'OBSERVATION_0_PARENTPROVIDERENTITYID_INVALID',
+            'OBSERVATION_0_PROVIDERSTATE_INVALID',
+            'OBSERVATION_0_SOURCEASSOCIATION_INVALID'
+        ]))
+    });
+
     test('a reduced batch missing v1 authority fields is refused', () => {
         const {resourceFamily, baseCheckpointVersion, nextInventoryHash, ...reduced} = batch();
         const {valid, errors}                                                        = validateBatch(reduced);


### PR DESCRIPTION
Resolves #15153

Related: #15145

Adds exhaustive, durable GitHub pull-request/review reconciliation on top of the accepted neutral community-admission foundation. Every pass re-enumerates OPEN/CLOSED/MERGED roots; independently exhausts issue comments, reviews, inline review comments, lifecycle/dismissal/deletion events, and stable `UserContentEdit` revisions; verifies mutable content plus a second root/timeline census; normalizes metadata-only occurrences; and advances the `pulls` checkpoint only through the admission receipt.

Evidence: L3 (live non-destructive GitHub GraphQL schema/query probes plus exact-head unit contracts) → L3 required (provider-surface compatibility and deterministic local admission). No residuals.

## Deltas from ticket

- Reuses `PullRequestHistoryService` child pagination while adding one repository-wide, two-pass REST inline-comment snapshot, so request volume scales with comment pages instead of imposing a per-PR REST floor.
- Batches content-edit head and final-revision GraphQL reads in groups of 100 and isolates a rejected node or mutation to its owning PR.
- Extends neutral observation storage/OpenAPI with provider parent, categorical state, and source-association fields. Existing ledgers migrate through additive nullable columns; exact-digest retries repair only missing projections without reminting rows, receipts, sequences, or checkpoints.
- Keeps GitHub's unsupported review/comment deletion histories as adapter-owned coverage gaps. No caller can suppress them into a false completeness claim.
- Adds an explicit eligibility witness for the emitted `pull_request.*` response families: external responses are eligible, rostered responses remain context, and lifecycle state changes do not mint attention.

## Test Evidence

- Changed surfaces: `npm run test-unit -- test/playwright/unit/ai/mcp/server/memory-core/CommunityBatchTool.spec.mjs test/playwright/unit/ai/services/github-workflow/PullRequestHistoryService.spec.mjs test/playwright/unit/ai/services/github-workflow/PullRequestReconciliationService.spec.mjs test/playwright/unit/ai/services/github-workflow/community/githubPullRequestObservations.spec.mjs test/playwright/unit/ai/services/github-workflow/community/githubPullRequestReconciliation.spec.mjs test/playwright/unit/ai/services/memory-core/CommunityBatchAdmissionService.spec.mjs test/playwright/unit/ai/services/memory-core/communityBatchContract.spec.mjs` — 107/107 passed on exact head `ee6493fbfc`.
- Scale witnesses: 205 roots batch edit-head and verification reads as 100/100/5; 101 repository inline comments require two two-page passes; per-PR REST/head/revision/census mutations invalidate only the affected PR.
- Full unit suite: 8,893 passed, 6 skipped, 33 did not run, 4 pressure failures. A grouped rerun cleared filesystem MCP smoke, real-tree lint, and Ollama timeout-friction; the remaining SourceRegistry same-millisecond audit-order race passed alone 16/16.
- `npm run agent-preflight -- --no-fix <15 changed paths>` — passed; ticket archaeology, alignment, syntax, shorthand, JSDoc types, AiConfig test-mutation, whitespace, and staged hooks all passed.
- `git diff origin/dev...HEAD --check` — passed after rebasing onto `ae51bfadb9`.
- Live provider probes: the root query cost was 2 at root page 50 / child+timeline page 100; all four content entity types exposed `includesCreatedEdit`, `lastEditedAt`, and `userContentEdits`; a zero-event timeline returned `filteredCount: 0` with a non-null connection `updatedAt`.
- Direct app/UI surface: None found; this leaf adds a service/contract producer with no app rendering path.

## Post-Merge Validation

- [ ] Run one registered-source `pulls` reconciliation against a live repository and confirm an accepted receipt plus exactly one checkpoint advance.
- [ ] Run the same source again and confirm genesis re-enumeration, occurrence deduplication, and no fabricated deletion for inaccessible roots.

Authored by Euclid (GPT-5, Codex Desktop). Session 019f88fb-eeac-7050-86d1-15054eff1f26.
