### PR TITLE
fix(wake): reject stale replayed message wakes (#15704)

### DIFF
--- a/ai/daemons/wake/coalescePolicy.mjs
+++ b/ai/daemons/wake/coalescePolicy.mjs
@@ -1,6 +1,6 @@
 /**
- * @summary Pure policy governing the wake daemon's event-coalescing shape: the rolling window,
- * the hard flush cap, and the post-flush refractory.
+ * @summary Pure policy governing the wake daemon's event-coalescing and message-admission shape:
+ * the rolling window, hard flush cap, post-flush refractory, and canonical mailbox-age horizon.
  *
  * **Failure mode this replaces (the wake-per-message cadence):** the daemon's original
  * 30-second FIXED window armed on the first queued event and flushed at window end. That bundles
@@ -22,11 +22,14 @@
  *   (Per-recipient mirror of the swarm-idle `swarmWakeCooldownSeconds` precedent.)
  * - **Explicit immediate wins:** a subscription whose override resolves the window to `0` opted
  *   into per-event dispatch; neither the refractory nor the cap applies to it.
+ * - **Canonical message age:** a MESSAGE may create live interruption urgency for one hour after
+ *   its server-stamped `sentAt`. Older, future, missing, or malformed timestamps stay mailbox data
+ *   but fail closed for wake delivery; replay GraphLog position never substitutes for authored age.
  *
  * Kept pure (no timers, DB, config, or daemon state) so the policy is unit-testable in isolation,
  * mirroring the daemon's other focused modules (`flushDeferPolicy.mjs`, `queries.mjs`,
  * `wokenWatermark.mjs`). The daemon supplies `firstQueuedAt` / `lastFlushAt`; this module only
- * decides delays.
+ * decides delays and message-age admission.
  *
  * @module ai/daemons/wake/coalescePolicy
  */
@@ -48,6 +51,43 @@ export const COALESCE_HARD_CAP_MS = 300000;
  * @type {Number}
  */
 export const POST_FLUSH_REFRACTORY_MS = 120000;
+
+/**
+ * Maximum age (ms) at which a canonical mailbox MESSAGE may still create a live wake. Older
+ * messages remain authoritative mailbox history, but replaying them cannot manufacture current
+ * interruption urgency. This is a mechanism safety ceiling, not an operator-tunable route policy.
+ * @type {Number}
+ */
+export const MESSAGE_WAKE_MAX_AGE_MS = 60 * 60 * 1000;
+
+/**
+ * @summary Returns whether a canonical mailbox timestamp is still eligible for live wake delivery.
+ *
+ * `MailboxService.addMessage()` owns `sentAt` and stamps it with `Date#toISOString()`. Requiring
+ * that exact canonical shape makes missing, malformed, numeric, and future timestamps fail closed;
+ * GraphLog insertion time is deliberately irrelevant because projection replay can make an old
+ * message look newly inserted. The one-hour boundary is closed.
+ *
+ * @param {Object} opts
+ * @param {String} opts.sentAt Canonical mailbox `sentAt` ISO timestamp.
+ * @param {Number} [opts.now=Date.now()] Current epoch ms.
+ * @param {Number} [opts.maxAgeMs=MESSAGE_WAKE_MAX_AGE_MS] Mechanism ceiling; injectable for pure
+ *     policy witnesses, not wired to runtime configuration.
+ * @returns {Boolean} Whether the message may contribute to a live wake digest.
+ */
+export function isMessageWakeFresh({sentAt, now = Date.now(), maxAgeMs = MESSAGE_WAKE_MAX_AGE_MS}) {
+    if (typeof sentAt !== 'string' || !Number.isFinite(now) || !Number.isFinite(maxAgeMs) || maxAgeMs < 0) {
+        return false
+    }
+
+    const sentAtMs = Date.parse(sentAt);
+
+    if (!Number.isFinite(sentAtMs) || new Date(sentAtMs).toISOString() !== sentAt) return false;
+
+    const ageMs = now - sentAtMs;
+
+    return ageMs >= 0 && ageMs <= maxAgeMs
+}
 
 /**
  * @summary Resolves one subscription's effective coalescing window in ms.

--- a/ai/daemons/wake/daemon.mjs
+++ b/ai/daemons/wake/daemon.mjs
@@ -71,6 +71,7 @@ import {
 import {
     computeFlushDelayMs,
     computeFlushHoldMs,
+    isMessageWakeFresh,
     resolveCoalesceWindowMs
 } from './coalescePolicy.mjs';
 import {
@@ -531,7 +532,15 @@ function evaluateSubscription(sub, trace, entity, nodesMap, edgesMap) {
     const {payload, logId} = result;
     switch (result.type) {
         case 'sent_to_me':
-            return {type: 'message', messageId: payload.messageId, from: payload.from, subject: payload.subject, priority: payload.priority, logId};
+            return {
+                type     : 'message',
+                messageId: payload.messageId,
+                from     : payload.from,
+                subject  : payload.subject,
+                priority : payload.priority,
+                sentAt   : payload.sentAt,
+                logId
+            };
         case 'task_state_changed':
             return {
                 type               : 'task',
@@ -779,6 +788,62 @@ function isMessageReadFor(db, messageId, recipient) {
     return node ? node.readAt != null : false;
 }
 
+/**
+ * @summary Partitions message events by canonical mailbox age at the delivery boundary.
+ *
+ * The event's `sentAt` comes from the immutable MESSAGE node through the shared `SENT_TO_ME`
+ * evaluator. GraphLog position is intentionally not consulted: projection replay can append a new
+ * position for an old message. Suppressed events are returned to the caller so it can still advance
+ * durable consumption state without exposing their subjects or mutating mailbox read state.
+ *
+ * @param {Object[]} messages Coalesced message wake events.
+ * @param {Number}   [now=Date.now()] Current epoch ms, shared across one partition pass.
+ * @returns {{eligible: Object[], suppressed: Object[], oldestAgeMs: Number|null}}
+ * @private
+ */
+function partitionMessageWakesByFreshness(messages, now = Date.now()) {
+    const eligible    = [], suppressed = [];
+    let   oldestAgeMs = null;
+
+    for (const message of messages) {
+        if (isMessageWakeFresh({sentAt: message.sentAt, now})) {
+            eligible.push(message);
+            continue;
+        }
+
+        suppressed.push(message);
+
+        const sentAtMs = typeof message.sentAt === 'string' ? Date.parse(message.sentAt) : NaN,
+              ageMs    = now - sentAtMs;
+
+        if (Number.isFinite(ageMs) && ageMs >= 0) {
+            oldestAgeMs = Math.max(oldestAgeMs ?? 0, ageMs);
+        }
+    }
+
+    return {eligible, suppressed, oldestAgeMs}
+}
+
+/**
+ * @summary Emits bounded stale-wake observability without copying mailbox content into daemon logs.
+ * @param {Object} opts
+ * @param {String} opts.identity Target agent identity.
+ * @param {String} opts.subId Subscription id fallback.
+ * @param {String} opts.phase Delivery phase (`initial` or `retry`).
+ * @param {Object[]} opts.suppressed Suppressed message events.
+ * @param {Number|null} opts.oldestAgeMs Oldest parseable non-future age.
+ * @returns {void}
+ * @private
+ */
+function logSuppressedMessageWakes({identity, subId, phase, suppressed, oldestAgeMs}) {
+    if (suppressed.length === 0) return;
+
+    writeLog('INFO',
+        `[Wake Daemon] Suppressed ${suppressed.length} stale/invalid message wake event(s) for ` +
+        `${identity || subId} at ${phase} delivery; oldestAgeMs=${oldestAgeMs ?? 'unknown'}.`
+    );
+}
+
 // WAKE_LANE_DIRECTIVE — the standing lifecycle-first directive, appended in buildWakeDigest ONLY to
 // pure-heartbeat digests (the idle-watchdog nudge; message / task / permission wakes omit it — they
 // already carry actionable content). Its single canonical, testable authority is `./wakeLaneDirective.mjs`
@@ -881,6 +946,19 @@ async function flushSubscription(subId) {
           duplicateMessages = messageClaims.duplicates;
     messages = messageClaims.claimed;
 
+    // Canonical mailbox-age gate: stable-id claims happen first so an old replay is durably consumed,
+    // then only still-live messages may affect digest count, preview, or priority. Mailbox state stays
+    // untouched; old unread material remains available to explicit inbox recovery.
+    const messageFreshness = partitionMessageWakesByFreshness(messages);
+    messages = messageFreshness.eligible;
+    logSuppressedMessageWakes({
+        identity,
+        subId,
+        phase      : 'initial',
+        suppressed : messageFreshness.suppressed,
+        oldestAgeMs: messageFreshness.oldestAgeMs
+    });
+
     // Mixed-wake heartbeat suppression (digest content only): a heartbeat is the idle-watchdog nudge,
     // but when it coalesces with an actionable wake (message / task / permission) the agent is already
     // being woken — so the redundant heartbeat is dropped FROM THE DIGEST. A heartbeat-only queue still
@@ -893,7 +971,7 @@ async function flushSubscription(subId) {
         heartbeats = [];
     }
 
-    const consumedMessages = [...messages, ...duplicateMessages];
+    const consumedMessages = [...messages, ...messageFreshness.suppressed, ...duplicateMessages];
 
     // Nothing genuinely-new survived (the delta was entirely already-read or already-woken) → suppress.
     // A stable-id duplicate may carry a newer GraphLog row, so consume that position before returning.
@@ -2177,12 +2255,23 @@ async function attemptDeliveryRetries() {
         const snapshot = entry.events;
         entry.events   = {messages: [], tasks: [], permissions: [], heartbeats: []};
 
-        // Re-apply the read-state reconcile the initial digest used (see `flushSubscription`): a message
-        // the recipient read between the failed delivery and this retry must NOT be re-delivered. The
-        // watermark filter is deliberately NOT re-applied — it advanced past these events on the first
-        // attempt, and the retry's whole job is to re-deliver those below-watermark events; only the
-        // read-state axis is reconciled here.
-        const liveMessages = snapshot.messages.filter(ev => !isMessageReadFor(db, ev.messageId, entry.identity));
+        // Re-apply BOTH delivery-time eligibility axes used by the initial digest: a message read
+        // between attempts must not re-deliver, and a message that crosses the canonical age horizon
+        // while queued must not regain urgency through retry. The watermark is deliberately NOT
+        // re-applied — it advanced past these events on the first attempt, and retry exists to deliver
+        // the still-eligible below-watermark snapshot.
+        const attemptNow       = Date.now(),
+              unreadMessages   = snapshot.messages.filter(ev => !isMessageReadFor(db, ev.messageId, entry.identity)),
+              messageFreshness = partitionMessageWakesByFreshness(unreadMessages, attemptNow),
+              liveMessages     = messageFreshness.eligible;
+
+        logSuppressedMessageWakes({
+            identity   : entry.identity,
+            subId,
+            phase      : 'retry',
+            suppressed : messageFreshness.suppressed,
+            oldestAgeMs: messageFreshness.oldestAgeMs
+        });
 
         if (liveMessages.length === 0 && snapshot.tasks.length === 0 &&
             snapshot.permissions.length === 0 && snapshot.heartbeats.length === 0
@@ -2190,9 +2279,10 @@ async function attemptDeliveryRetries() {
             // The swap above is synchronous, so the live entry cannot have gained events yet —
             // the entry retires whole.
             pendingDeliveryRetries.delete(subId);
-            writeLog('INFO',
-                `[Wake Daemon] Retry for ${subId} dropped: all queued messages were read before re-delivery.`
-            );
+            const dropReason = unreadMessages.length === 0
+                ? 'all queued messages were read before re-delivery'
+                : 'all queued messages became stale or invalid before re-delivery';
+            writeLog('INFO', `[Wake Daemon] Retry for ${subId} dropped: ${dropReason}.`);
             continue;
         }
 
@@ -2216,7 +2306,7 @@ async function attemptDeliveryRetries() {
             // Restore the undelivered snapshot INTO the live entry — union with anything merged
             // during the await (the sets are disjoint by watermark, so concat is loss-free).
             entry.events = {
-                messages   : [...snapshot.messages,    ...entry.events.messages],
+                messages   : [...liveMessages,         ...entry.events.messages],
                 tasks      : [...snapshot.tasks,       ...entry.events.tasks],
                 permissions: [...snapshot.permissions, ...entry.events.permissions],
                 heartbeats : [...snapshot.heartbeats,  ...entry.events.heartbeats]

--- a/ai/services/memory-core/heartbeatPulseEvaluator.mjs
+++ b/ai/services/memory-core/heartbeatPulseEvaluator.mjs
@@ -184,6 +184,7 @@ function buildSentToMeInner(messageNode) {
         from          : props.from,
         subject       : (props.subject || '').slice(0, 200),
         priority      : props.priority || 'normal',
+        sentAt        : props.sentAt,
         taggedConcepts: props.taggedConcepts || [],
         isReplyTo     : props.inReplyTo || null,
         isBroadcast   : props.to === 'AGENT:*'

--- a/test/playwright/unit/ai/daemons/wake/coalescePolicy.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/coalescePolicy.spec.mjs
@@ -3,6 +3,8 @@ import {
     COALESCE_HARD_CAP_MS,
     computeFlushDelayMs,
     computeFlushHoldMs,
+    isMessageWakeFresh,
+    MESSAGE_WAKE_MAX_AGE_MS,
     POST_FLUSH_REFRACTORY_MS,
     resolveCoalesceWindowMs
 } from '../../../../../../ai/daemons/wake/coalescePolicy.mjs';
@@ -169,5 +171,35 @@ test.describe('ai/daemons/wake/coalescePolicy', () => {
     test('constants sanity: the refractory sits strictly inside the hard cap', () => {
         expect(POST_FLUSH_REFRACTORY_MS).toBeGreaterThan(0);
         expect(POST_FLUSH_REFRACTORY_MS).toBeLessThan(COALESCE_HARD_CAP_MS)
+    })
+
+    test.describe('isMessageWakeFresh — canonical mailbox age is the wake eligibility authority', () => {
+        test('accepts canonical timestamps through the closed one-hour boundary', () => {
+            expect(isMessageWakeFresh({
+                now   : T0,
+                sentAt: new Date(T0).toISOString()
+            })).toBe(true);
+            expect(isMessageWakeFresh({
+                now   : T0,
+                sentAt: new Date(T0 - MESSAGE_WAKE_MAX_AGE_MS).toISOString()
+            })).toBe(true)
+        });
+
+        test('rejects messages beyond the horizon instead of promoting replay age to live urgency', () => {
+            expect(isMessageWakeFresh({
+                now   : T0,
+                sentAt: new Date(T0 - MESSAGE_WAKE_MAX_AGE_MS - 1).toISOString()
+            })).toBe(false)
+        });
+
+        test('fails closed for missing, invalid, numeric, and future timestamps', () => {
+            expect(isMessageWakeFresh({now: T0})).toBe(false);
+            expect(isMessageWakeFresh({now: T0, sentAt: 'not-an-iso-timestamp'})).toBe(false);
+            expect(isMessageWakeFresh({now: T0, sentAt: T0})).toBe(false);
+            expect(isMessageWakeFresh({
+                now   : T0,
+                sentAt: new Date(T0 + 1).toISOString()
+            })).toBe(false)
+        })
     })
 });

--- a/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
+++ b/test/playwright/unit/ai/daemons/wake/daemon.spec.mjs
@@ -7,6 +7,7 @@ import crypto                                                                   
 import http                                                                                    from 'http';
 import os                                                                                      from 'os';
 import { collapseDuplicateShapeCRoutes, getActiveHarnessPresence, getNodesData, getEdgesData } from '../../../../../../ai/daemons/wake/queries.mjs';
+import { MESSAGE_WAKE_MAX_AGE_MS }                                                             from '../../../../../../ai/daemons/wake/coalescePolicy.mjs';
 import { SQLITE_IN_CLAUSE_BATCH_SIZE }                                                         from '../../../../../../ai/graph/storage/constants.mjs';
 
 /**
@@ -86,6 +87,7 @@ function insertMessageWake(db, {
     agentId,
     from = '@sender',
     priority = 'normal',
+    sentAt = new Date().toISOString(),
     subject = 'Addressed Wake Event',
     target = agentId
 }) {
@@ -96,6 +98,7 @@ function insertMessageWake(db, {
         properties: {
             from,
             priority,
+            sentAt,
             subject,
             to      : target
         }
@@ -109,9 +112,11 @@ function insertMessageWake(db, {
             target,
             type  : 'SENT_TO'
         }), msgId, target, 'SENT_TO');
-    db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges');
+    const edgeLogId = Number(
+        db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(edgeId, 'edges').lastInsertRowid
+    );
 
-    return {msgId, edgeId};
+    return {msgId, edgeId, edgeLogId};
 }
 
 function insertTurnPresence(db, {
@@ -266,8 +271,9 @@ test.describe('Wake Daemon', () => {
             label     : 'MESSAGE',
             properties: {
                 from    : '@sender',
-                subject : 'Test Wake Event',
-                priority: 'normal'
+                priority: 'normal',
+                sentAt  : new Date().toISOString(),
+                subject : 'Test Wake Event'
             }
         }));
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
@@ -607,7 +613,9 @@ test.describe('Wake Daemon', () => {
         // Inject a MESSAGE + SENT_TO edge → triggers the wake → test-fail adapter throws → retry → cap.
         const msgId = 'msg_' + crypto.randomUUID();
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
-            id: msgId, label: 'MESSAGE', properties: { from: '@sender', subject: 'Retry Wake Event', priority: 'normal' }
+            id: msgId, label: 'MESSAGE', properties: {
+                from: '@sender', priority: 'normal', sentAt: new Date().toISOString(), subject: 'Retry Wake Event'
+            }
         }));
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
 
@@ -672,7 +680,9 @@ test.describe('Wake Daemon', () => {
         const injectMessage = (subject) => {
             const msgId = 'msg_' + crypto.randomUUID();
             db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
-                id: msgId, label: 'MESSAGE', properties: { from: '@sender', subject, priority: 'normal' }
+                id: msgId, label: 'MESSAGE', properties: {
+                    from: '@sender', priority: 'normal', sentAt: new Date().toISOString(), subject
+                }
             }));
             db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
             const edgeId = 'edge_' + crypto.randomUUID();
@@ -762,7 +772,9 @@ test.describe('Wake Daemon', () => {
         await new Promise(resolve => setTimeout(resolve, 1000));
 
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
-            id: msgId, label: 'MESSAGE', properties: { from: '@sender', subject: 'Read Before Retry', priority: 'normal' }
+            id: msgId, label: 'MESSAGE', properties: {
+                from: '@sender', priority: 'normal', sentAt: new Date().toISOString(), subject: 'Read Before Retry'
+            }
         }));
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
 
@@ -785,6 +797,155 @@ test.describe('Wake Daemon', () => {
         const logContents = fs.readFileSync(path.join(DAEMON_DIR, 'wake-daemon.log'), 'utf8');
         expect(logContents).toContain(`Retry for ${subId} dropped`);
         expect(logContents).not.toContain('Giving up wake delivery');
+    });
+
+    test('#15704: a retry rechecks canonical message age and drops an event that crosses the wake horizon', async () => {
+        const agentId = '@test-agent-retry-message-age';
+        const subId   = insertWakeSubscription(db, {
+            agentId,
+            harnessTargetMetadata: {adapter: 'test-fail', coalesceWindow: 0}
+        });
+
+        // A temporary process preload keeps production policy free of a test/runtime override. It
+        // advances Date.now() by one hour only after the first deterministic adapter failure, while
+        // preserving real elapsed time so retry scheduling remains monotonic.
+        const clockBaseMs      = Date.now(),
+              clockAdvanceFile = path.join(DAEMON_DIR, 'advance-message-clock'),
+              clockPreloadFile = path.join(DAEMON_DIR, 'message-clock.cjs');
+        fs.writeFileSync(clockPreloadFile, [
+            "const fs = require('node:fs');",
+            'const realNow = Date.now.bind(Date);',
+            'const realBase = realNow();',
+            'const clockBase = Number(process.env.WAKE_TEST_CLOCK_BASE_MS);',
+            'const advanceMs = Number(process.env.WAKE_TEST_CLOCK_ADVANCE_MS);',
+            'const advanceFile = process.env.WAKE_TEST_CLOCK_ADVANCE_FILE;',
+            'Date.now = () => clockBase + (realNow() - realBase) + (fs.existsSync(advanceFile) ? advanceMs : 0);'
+        ].join('\n'));
+
+        let   output           = '', clockAdvanced = false;
+        const staleDropPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Retry did not drop the age-expired message within timeout')), 25000);
+            const onData  = data => {
+                output += data.toString();
+                if (!clockAdvanced && output.includes('Failed to deliver via test-fail')) {
+                    clockAdvanced = true;
+                    fs.writeFileSync(clockAdvanceFile, 'advance');
+                }
+                if (output.includes(`Retry for ${subId} dropped: all queued messages became stale or invalid before re-delivery.`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            };
+
+            daemonProcess = spawn('node', ['--require', clockPreloadFile, 'ai/daemons/wake/daemon.mjs'], {
+                stdio: 'pipe',
+                env  : {
+                    ...process.env,
+                    NEO_MEMORY_DB_PATH          : DB_PATH,
+                    NEO_AI_DAEMON_DIR           : DAEMON_DIR,
+                    WAKE_TEST_CLOCK_ADVANCE_FILE: clockAdvanceFile,
+                    WAKE_TEST_CLOCK_ADVANCE_MS  : String(MESSAGE_WAKE_MAX_AGE_MS + 1),
+                    WAKE_TEST_CLOCK_BASE_MS     : String(clockBaseMs)
+                }
+            });
+            daemonProcess.stdout.on('data', onData);
+            daemonProcess.stderr.on('data', onData);
+            daemonProcess.on('error', reject);
+        });
+
+        // First boot tails from the existing GraphLog tip by contract, so inject only after startup.
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        insertMessageWake(db, {
+            agentId,
+            sentAt : new Date(clockBaseMs).toISOString(),
+            subject: 'Fresh Initially, Stale On Retry'
+        });
+
+        await staleDropPromise;
+
+        const logContents = fs.readFileSync(path.join(DAEMON_DIR, 'wake-daemon.log'), 'utf8'),
+              attempts    = logContents.match(/\[Wake Daemon Test-Fail Adapter\] Attempted/g) || [];
+
+        expect(attempts).toHaveLength(1); // initial failure only; the due retry is age-gated before adapter dispatch
+        expect(logContents).toContain('at retry delivery; oldestAgeMs=');
+        expect(logContents).not.toContain('Giving up wake delivery');
+    });
+
+    test('#15704: stale replay stays unread and consumed while a fresh peer alone shapes the digest', async () => {
+        const agentId = '@test-agent-message-age';
+        const subId   = insertWakeSubscription(db, {
+            agentId,
+            harnessTargetMetadata: {adapter: 'test', coalesceWindow: 1}
+        });
+
+        let   output          = '';
+        const deliveryPromise = new Promise((resolve, reject) => {
+            const timeout = setTimeout(() => reject(new Error('Fresh mixed-queue wake was not delivered within timeout')), 15000);
+            const onData  = data => {
+                output += data.toString();
+                if (output.includes(`[Wake Daemon Test Adapter] Delivered ${subId}`)) {
+                    clearTimeout(timeout);
+                    resolve();
+                }
+            };
+
+            daemonProcess = spawn('node', ['ai/daemons/wake/daemon.mjs'], {
+                stdio: 'pipe',
+                env  : {...process.env, NEO_MEMORY_DB_PATH: DB_PATH, NEO_AI_DAEMON_DIR: DAEMON_DIR}
+            });
+            daemonProcess.stdout.on('data', onData);
+            daemonProcess.stderr.on('data', onData);
+            daemonProcess.on('error', reject);
+        });
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        const fresh = insertMessageWake(db, {
+            agentId,
+            priority: 'normal',
+            subject : 'Current Peer Message'
+        });
+        const stale = insertMessageWake(db, {
+            agentId,
+            priority: 'high',
+            sentAt  : new Date(Date.now() - MESSAGE_WAKE_MAX_AGE_MS - 1_000).toISOString(),
+            subject : 'Four-Day Ghost Replay'
+        });
+
+        await deliveryPromise;
+        await new Promise(resolve => setTimeout(resolve, 250)); // watermark persistence follows the delivery log
+
+        let logContents = fs.readFileSync(path.join(DAEMON_DIR, 'wake-daemon.log'), 'utf8');
+        expect(logContents).toContain('[WAKE][priority:normal] 1 events');
+        expect(logContents).toContain('1 new messages (latest: "Current Peer Message"');
+        expect(logContents).not.toContain('Four-Day Ghost Replay');
+        expect(logContents).toContain(`Suppressed 1 stale/invalid message wake event(s) for ${agentId} at initial delivery`);
+
+        const staleNode = JSON.parse(db.prepare('SELECT data FROM Nodes WHERE id = ?').get(stale.msgId).data);
+        expect(staleNode.properties.readAt ?? null).toBeNull();
+
+        let durableState = JSON.parse(fs.readFileSync(path.join(DAEMON_DIR, 'woken-watermark.json'), 'utf8'));
+        expect(durableState.__messageIdsByIdentity[agentId]).toEqual(expect.arrayContaining([stale.msgId, fresh.msgId]));
+        expect(durableState[subId]).toBeGreaterThanOrEqual(stale.edgeLogId);
+
+        // Re-emit the exact old SENT_TO edge above the numeric watermark. The stable application-id
+        // claim must consume this new GraphLog position without manufacturing another prompt. Move
+        // this verification phase onto the existing explicit-immediate route so the post-flush
+        // refractory does not postpone observation of durable consumption for two minutes.
+        const subscriptionNode = JSON.parse(db.prepare('SELECT data FROM Nodes WHERE id = ?').get(subId).data);
+        subscriptionNode.properties.harnessTargetMetadata.coalesceWindow = 0;
+        db.prepare('UPDATE Nodes SET data = ? WHERE id = ?').run(JSON.stringify(subscriptionNode), subId);
+
+        const replayLogId = Number(
+            db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(stale.edgeId, 'edges').lastInsertRowid
+        );
+        await new Promise(resolve => setTimeout(resolve, 4500));
+
+        logContents = fs.readFileSync(path.join(DAEMON_DIR, 'wake-daemon.log'), 'utf8');
+        expect((logContents.match(/\[Wake Daemon Test Adapter\] Delivered/g) || []).length).toBe(1);
+
+        durableState = JSON.parse(fs.readFileSync(path.join(DAEMON_DIR, 'woken-watermark.json'), 'utf8'));
+        expect(durableState.__messageIdsByIdentity[agentId]).toContain(stale.msgId);
+        expect(durableState[subId]).toBeGreaterThanOrEqual(replayLogId);
     });
 
     test('a message-wake digest omits the lane directive — it is heartbeat-only (#13118, #13137)', async () => {
@@ -947,7 +1108,7 @@ test.describe('Wake Daemon', () => {
             db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
                 id        : msgId,
                 label     : 'MESSAGE',
-                properties: { from: '@sender', subject, priority: 'normal' }
+                properties: {from: '@sender', priority: 'normal', sentAt: new Date().toISOString(), subject}
             }));
             db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
 
@@ -1220,6 +1381,7 @@ test.describe('Wake Daemon', () => {
                 to            : agentId,
                 subject       : 'Suppressed Sunset Ping',
                 readAt        : null,
+                sentAt        : new Date().toISOString(),
                 taggedConcepts: ['sunset-protocol-handover'],
                 wakeSuppressed: true
             }
@@ -1334,6 +1496,7 @@ test.describe('Wake Daemon', () => {
             label     : 'MESSAGE',
             properties: {
                 from   : '@sender',
+                sentAt : new Date().toISOString(),
                 subject: 'Test Dedup Event'
             }
         }));
@@ -1435,6 +1598,7 @@ test.describe('Wake Daemon', () => {
                 from                   : '@task-originator',
                 lastModifiedAt         : '2026-07-12T20:01:08.009Z',
                 readAt                 : new Date().toISOString(),
+                sentAt                 : new Date().toISOString(),
                 taskAssignmentAuthority: 'memory-core.v1',
                 task                   : {state: 'Working', assignee: agentId}
             }
@@ -1742,8 +1906,9 @@ test.describe('Wake Daemon', () => {
             label     : 'MESSAGE',
             properties: {
                 from    : '@sender',
-                subject : 'High Priority Wake Event',
-                priority: 'high'
+                priority: 'high',
+                sentAt  : new Date().toISOString(),
+                subject : 'High Priority Wake Event'
             }
         }));
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(highMsgId, 'nodes');
@@ -1763,8 +1928,9 @@ test.describe('Wake Daemon', () => {
             label     : 'MESSAGE',
             properties: {
                 from    : '@sender',
-                subject : 'Low Priority Wake Event',
-                priority: 'low'
+                priority: 'low',
+                sentAt  : new Date().toISOString(),
+                subject : 'Low Priority Wake Event'
             }
         }));
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(lowMsgId, 'nodes');
@@ -1837,7 +2003,7 @@ test.describe('Wake Daemon', () => {
         db.prepare('INSERT INTO Nodes (id, data) VALUES (?, ?)').run(msgId, JSON.stringify({
             id        : msgId,
             label     : 'MESSAGE',
-            properties: { from: '@sender', subject: 'Test Empty AppName' }
+            properties: {from: '@sender', sentAt: new Date().toISOString(), subject: 'Test Empty AppName'}
         }));
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
 
@@ -1923,8 +2089,9 @@ test.describe('Wake Daemon', () => {
             label     : 'MESSAGE',
             properties: {
                 from    : '@sender',
-                subject : 'Test Antigravity Event',
-                priority: 'normal'
+                priority: 'normal',
+                sentAt  : new Date().toISOString(),
+                subject : 'Test Antigravity Event'
             }
         }));
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
@@ -2873,8 +3040,9 @@ test.describe('Wake Daemon', () => {
             label     : 'MESSAGE',
             properties: {
                 from    : '@sender',
-                subject : 'Test Claude Event',
-                priority: 'normal'
+                priority: 'normal',
+                sentAt  : new Date().toISOString(),
+                subject : 'Test Claude Event'
             }
         }));
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
@@ -3576,8 +3744,9 @@ test.describe('Wake Daemon', () => {
             label     : 'MESSAGE',
             properties: {
                 from    : '@sender',
-                subject : 'Test Codex Event',
-                priority: 'normal'
+                priority: 'normal',
+                sentAt  : new Date().toISOString(),
+                subject : 'Test Codex Event'
             }
         }));
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
@@ -3665,8 +3834,9 @@ test.describe('Wake Daemon', () => {
             label     : 'MESSAGE',
             properties: {
                 from    : '@sender',
-                subject : 'Test Codex Cleanup',
-                priority: 'normal'
+                priority: 'normal',
+                sentAt  : new Date().toISOString(),
+                subject : 'Test Codex Cleanup'
             }
         }));
         db.prepare('INSERT INTO GraphLog (entity_id, entity_type) VALUES (?, ?)').run(msgId, 'nodes');
@@ -3995,6 +4165,7 @@ test.describe('Wake Daemon', () => {
             label     : 'MESSAGE',
             properties: {
                 from   : senderId,
+                sentAt : new Date().toISOString(),
                 to     : 'AGENT:*',
                 subject: 'Cross-family broadcast'
             }
@@ -4070,6 +4241,7 @@ test.describe('Wake Daemon', () => {
             label     : 'MESSAGE',
             properties: {
                 from   : agentId,
+                sentAt : new Date().toISOString(),
                 to     : agentId,
                 subject: 'Deliberate self-handoff'
             }

--- a/test/playwright/unit/ai/services/memory-core/heartbeatPulseEvaluator.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/heartbeatPulseEvaluator.spec.mjs
@@ -85,8 +85,18 @@ test.describe('Neo.ai.services.memory-core.heartbeatPulseEvaluator — match() (
     const OWNER     = '@neo-opus-vega';
     const edgeTrace = {entity_type: 'edges', entity_id: 'EDGE:e1', log_id: 7};
 
-    const sub  = (over = {}) => ({trigger: 'SENT_TO_ME', harnessTarget: 'mcp-notifications', agentIdentity: OWNER, filters: {}, ...over});
-    const msg  = (props = {}) => ({id: 'MESSAGE:m1', label: 'MESSAGE', properties: {from: '@neo-gpt', subject: 'hi', priority: 'normal', ...props}});
+    const sub = (over = {}) => ({trigger: 'SENT_TO_ME', harnessTarget: 'mcp-notifications', agentIdentity: OWNER, filters: {}, ...over});
+    const msg = (props = {}) => ({
+        id        : 'MESSAGE:m1',
+        label     : 'MESSAGE',
+        properties: {
+            from    : '@neo-gpt',
+            priority: 'normal',
+            sentAt  : '2026-07-22T10:00:00.000Z',
+            subject : 'hi',
+            ...props
+        }
+    });
     const data = (entity, {node = null, receipts = false} = {}) => ({entity, getNode: () => node, hasDeliveryReceipts: () => receipts});
 
     // --- guards ---
@@ -109,7 +119,11 @@ test.describe('Neo.ai.services.memory-core.heartbeatPulseEvaluator — match() (
     test('sent_to_me: an unread direct SENT_TO to the owner fires', () => {
         const node = msg();
         expect(match(sub(), data({type: 'SENT_TO', source: node.id, target: OWNER}, {node}), edgeTrace))
-            .toMatchObject({type: 'sent_to_me', payload: {messageId: node.id, from: '@neo-gpt'}, logId: 7});
+            .toMatchObject({
+                type   : 'sent_to_me',
+                payload: {messageId: node.id, from: '@neo-gpt', sentAt: '2026-07-22T10:00:00.000Z'},
+                logId  : 7
+            });
     });
 
     test('sent_to_me: an already-read direct message does NOT fire (daemon over-wake fix)', () => {


### PR DESCRIPTION
Resolves #15704

Old unread mailbox facts can no longer become live interruption urgency merely because GraphLog replays them at a new position. The daemon now carries canonical MESSAGE `sentAt` through the shared `SENT_TO_ME` payload, admits wakes only through a closed one-hour age horizon at both initial delivery and retry, and durably consumes suppressed events without marking, archiving, deleting, previewing, or priority-promoting them.

Evidence: L2 (mounted wake-daemon subprocess + SQLite GraphLog + deterministic adapter/retry witnesses) → L2 required (all `#15704` runtime eligibility, retention, retry, and replay-consumption ACs). Residual: none [#15704].

## Deltas from ticket

None substantive. The implementation uses the existing pure coalescing-policy seam, shared evaluator payload, stable message-id claims, numeric watermark, and retry queue; it adds no store, route, sender-liveness heuristic, or operator knob.

## Test Evidence

- Wake policy + mounted daemon + delivery-owner + shared evaluator/service consumers: `npm run test-unit -- test/playwright/unit/ai/daemons/wake/coalescePolicy.spec.mjs test/playwright/unit/ai/daemons/wake/daemon.spec.mjs test/playwright/unit/ai/daemons/wake/daemonDeliveryOwner.spec.mjs test/playwright/unit/ai/services/memory-core/heartbeatPulseEvaluator.spec.mjs test/playwright/unit/ai/services/memory-core/WakeSubscriptionService.spec.mjs` — 205 passed.
- Post-format exact behavior witnesses: `npm run test-unit -- test/playwright/unit/ai/daemons/wake/coalescePolicy.spec.mjs test/playwright/unit/ai/daemons/wake/daemon.spec.mjs test/playwright/unit/ai/services/memory-core/heartbeatPulseEvaluator.spec.mjs --grep '#15704|isMessageWakeFresh|unread direct SENT_TO'` — 8 passed.
- Author preflight over all six touched files — ticket archaeology and block-alignment gates passed.
- `git diff --check` — passed.

## Post-Merge Validation

- [ ] On the next older-than-one-hour GraphLog MESSAGE replay, confirm the daemon emits only bounded stale/invalid suppression telemetry, sends no prompt for that row, and leaves the unread mailbox record listable.

## Evolution

The observed Clio ghost wake falsified the remaining premise behind the prior read-state and stable-id defenses: a newly encountered GraphLog position is not evidence of a newly authored message. The retry witness uses an isolated test-process clock preload so this boundary is proven without adding a production timing override.

Authored by Euclid (GPT-5, Codex Desktop). Session bb641b19-2dcb-4fd5-bd85-97a17cf162c3.
