### PR TITLE
fix(component): reject nullish URL token values (#15647)

### DIFF
--- a/src/form/field/FileUpload.mjs
+++ b/src/form/field/FileUpload.mjs
@@ -782,12 +782,15 @@ class FileUpload extends Field {
     }
 
     /**
-     * Creates a URL substituting the passed parameter names in at the places where the name
-     * occurs within `{}` in the pattern. A null or absent pattern passes through unchanged,
-     * so documented-optional URL configs (status / delete / download) stay inert instead of
-     * crashing on `replace`.
-     * @param {String} urlPattern
+     * @summary Creates a URL by substituting non-nullish parameter values into matching tokens.
+     *
+     * A null or absent pattern passes through unchanged, so documented-optional URL configs
+     * (status / delete / download) stay inert instead of crashing on `replace`. A nullish value
+     * is rejected only when its token is present; token-free URL configs remain valid.
+     * @param {String|null|undefined} urlPattern
      * @param {Object} params
+     * @returns {String|null|undefined}
+     * @throws {TypeError} When a present pattern token has a nullish parameter value.
      */
     createUrl(urlPattern, params) {
         if (urlPattern == null) {
@@ -795,8 +798,19 @@ class FileUpload extends Field {
         }
 
         for (const paramName in params) {
-            urlPattern = urlPattern.replace(`{${paramName}}`, params[paramName]);
+            const
+                token      = `{${paramName}}`,
+                paramValue = params[paramName];
+
+            if (urlPattern.includes(token)) {
+                if (paramValue == null) {
+                    throw new TypeError(`Cannot substitute nullish URL parameter: ${paramName}`)
+                }
+
+                urlPattern = urlPattern.replace(token, paramValue)
+            }
         }
+
         return urlPattern;
     }
 

--- a/test/playwright/unit/form/field/FileUpload.spec.mjs
+++ b/test/playwright/unit/form/field/FileUpload.spec.mjs
@@ -34,6 +34,26 @@ test.describe('FileUpload documented-optional URL configs', () => {
         instance.destroy()
     });
 
+    test('createUrl fails fast only when a present token has a nullish value', () => {
+        let instance = Neo.create(FileUpload, {
+            appName  : 'TestApp',
+            uploadUrl: '/upload'
+        });
+
+        expect(() => instance.createUrl('/documents/{documentId}', {documentId: null}))
+            .toThrow('Cannot substitute nullish URL parameter: documentId');
+        expect(() => instance.createUrl('/documents/{documentId}', {documentId: undefined}))
+            .toThrow('Cannot substitute nullish URL parameter: documentId');
+
+        expect(instance.createUrl('/documents/static', {documentId: null})).toBe('/documents/static');
+        expect(instance.createUrl('/documents/{otherId}', {documentId: undefined})).toBe('/documents/{otherId}');
+        expect(instance.createUrl('/documents/{documentId}', {documentId: 0})).toBe('/documents/0');
+        expect(instance.createUrl('/documents/{documentId}', {documentId: false})).toBe('/documents/false');
+        expect(instance.createUrl('/documents/{documentId}', {documentId: ''})).toBe('/documents/');
+
+        instance.destroy()
+    });
+
     test('an upload-only field reaches downloadable on success without throwing', () => {
         let instance = Neo.create(FileUpload, {
             appName  : 'TestApp',
@@ -54,22 +74,40 @@ test.describe('FileUpload documented-optional URL configs', () => {
         instance.destroy()
     });
 
-    test('configured URLs keep token substitution and the function form', () => {
-        let calls    = [],
-            instance = Neo.create(FileUpload, {
-                appName          : 'TestApp',
-                documentDeleteUrl: '/documents/{documentId}',
-                documentStatusUrl: () => '/status/fn',
-                uploadUrl        : '/upload'
-            });
+    test('configured URLs inherit fail-fast substitution while token-free and function forms remain valid', () => {
+        let instance = Neo.create(FileUpload, {
+            appName          : 'TestApp',
+            documentDeleteUrl: '/documents/{documentId}',
+            documentStatusUrl: '/status/{documentId}',
+            downloadUrl      : '/download/{documentId}',
+            uploadUrl        : '/upload'
+        });
 
         instance.documentId = 7;
 
         expect(instance.documentDeleteUrl).toBe('/documents/7');
-        expect(instance.documentStatusUrl).toBe('/status/fn');
+        expect(instance.documentStatusUrl).toBe('/status/7');
+        expect(instance.downloadUrl).toBe('/download/7');
 
         instance.documentId = null;
-        expect(instance.documentDeleteUrl).toBe('/documents/null');
+
+        expect(() => instance.documentDeleteUrl).toThrow('Cannot substitute nullish URL parameter: documentId');
+        expect(() => instance.documentStatusUrl).toThrow('Cannot substitute nullish URL parameter: documentId');
+        expect(() => instance.downloadUrl).toThrow('Cannot substitute nullish URL parameter: documentId');
+
+        instance.destroy();
+
+        instance = Neo.create(FileUpload, {
+            appName          : 'TestApp',
+            documentDeleteUrl: '/documents/static',
+            documentStatusUrl: () => '/status/fn',
+            downloadUrl      : '/download/static',
+            uploadUrl        : '/upload'
+        });
+
+        expect(instance.documentDeleteUrl).toBe('/documents/static');
+        expect(instance.documentStatusUrl).toBe('/status/fn');
+        expect(instance.downloadUrl).toBe('/download/static');
 
         instance.destroy()
     });


### PR DESCRIPTION
Resolves #15647

`FileUpload#createUrl()` now refuses to turn a present token with a nullish value into a requestable-looking `/null` or `/undefined` URL. Nullish patterns still pass through, and token-free URLs, unmatched tokens, ordinary falsy values, and function-form configs retain their existing behavior.

Evidence: L2 (focused Neo single-thread runtime contract) → L2 required (all close-target ACs are unit-reachable). No residuals.

## Deltas from ticket

None substantive.

## Test Evidence

- `npm run test-unit -- test/playwright/unit/form/field/FileUpload.spec.mjs test/playwright/unit/form/field/FileUploadAsync.spec.mjs` — 6 passed.
- `npm run agent-preflight -- --no-fix src/form/field/FileUpload.mjs test/playwright/unit/form/field/FileUpload.spec.mjs` — passed.
- `npm run test-unit` — 8,894 passed; four unrelated Brain failures: file-system OpenAPI alignment, the real-tree lint timeout (which later logged OK), MemoryService retry-timer teardown, and the SourceRegistry audit-order race tracked by #15667. The modified FileUpload specs passed within the run.

## Post-Merge Validation

- [ ] Confirm CI’s exact-head unit job keeps the FileUpload contract green.

Authored by Euclid (GPT-5.6 Sol Ultra, Codex). Session bb641b19-2dcb-4fd5-bd85-97a17cf162c3.
