### PR TITLE
feat(harness): prove packaged Fleet first paint (#15524)

### DIFF
--- a/harness/brain.mjs
+++ b/harness/brain.mjs
@@ -31,8 +31,7 @@ import {randomUUID}                    from 'node:crypto';
 import fs                              from 'node:fs';
 import net                             from 'node:net';
 import path                            from 'node:path';
-import {normalizeAgentIdentityNodeId}  from '../ai/graph/normalizeAgentIdentityNodeId.mjs';
-import {probeExistingFleetServer}      from '../ai/services/fleet/fleetLaunchContract.mjs';
+import {fileURLToPath, pathToFileURL}  from 'node:url';
 
 export const ORCHESTRATOR_ENTRY = 'ai/daemons/orchestrator/daemon.mjs';
 export const FLEET_SERVER_ENTRY = 'ai/services/fleet/devFleetServer.mjs';
@@ -41,6 +40,40 @@ export const FLEET_SERVER_ENTRY = 'ai/services/fleet/devFleetServer.mjs';
 // the earliest honest "the supervisor supervises" observable. The PID file is NOT it: the daemon
 // writes that before config load and before start(), so it only proves the process exists.
 const ORCHESTRATOR_READY_MARKER = '[Orchestrator] Started.';
+
+const
+    DEFAULT_REPO_ROOT     = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..'),
+    fleetRuntimeContracts = new Map();
+
+/**
+ * Loads Fleet trust primitives from the selected organism instead of the shell bundle.
+ * @summary Keeps checkout and packaged launchers on one canonical Fleet contract implementation.
+ * @param {String} [repoRoot=DEFAULT_REPO_ROOT] Authoritative checkout or packaged organism root.
+ * @returns {Promise<Object>}
+ */
+export function loadFleetRuntimeContracts(repoRoot = DEFAULT_REPO_ROOT) {
+    const absoluteRoot = path.resolve(repoRoot);
+
+    let contract = fleetRuntimeContracts.get(absoluteRoot);
+
+    if (!contract) {
+        contract = Promise.all([
+            import(pathToFileURL(path.join(absoluteRoot, 'ai/graph/normalizeAgentIdentityNodeId.mjs')).href),
+            import(pathToFileURL(path.join(absoluteRoot, 'ai/services/fleet/fleetLaunchContract.mjs')).href),
+            import(pathToFileURL(path.join(absoluteRoot, 'src/ai/fleet/fleetWireMethods.mjs')).href)
+        ]).then(([identityContract, fleetContract, wireContract]) => ({
+            FLEET_CREDENTIAL_METHODS    : wireContract.FLEET_CREDENTIAL_METHODS,
+            FLEET_WIRE_METHODS          : wireContract.FLEET_WIRE_METHODS,
+            normalizeAgentIdentityNodeId: identityContract.normalizeAgentIdentityNodeId,
+            probeExistingFleetServer    : fleetContract.probeExistingFleetServer,
+            resolveFleetBearer          : fleetContract.resolveFleetBearer
+        }));
+
+        fleetRuntimeContracts.set(absoluteRoot, contract)
+    }
+
+    return contract
+}
 
 function nodeBin() {
     return process.env.NEO_HARNESS_NODE_BIN || 'node'
@@ -324,18 +357,27 @@ export function assertIsolatedProfile({resolved, isolationRoot, chromaPort}) {
  * @param {Number|String} options.port
  * @param {String} options.bearerToken Main-owned process bearer.
  * @param {String} options.agentIdentityNodeId Trusted launcher's expected viewer node id.
+ * @param {String} [options.repoRoot=DEFAULT_REPO_ROOT] Authoritative organism root.
  * @param {Number} [options.timeoutMs=2500]
  * @param {Function} [options.fetchFn=fetch] Injection seam for tests.
  * @returns {Promise<Object>} Canonical `{reusable, reason}` probe outcome.
  */
-export function probeFleetServing({port, bearerToken, agentIdentityNodeId, timeoutMs = 2500, fetchFn = fetch}) {
-    const viewer = normalizeAgentIdentityNodeId(agentIdentityNodeId);
+export async function probeFleetServing({
+    port,
+    bearerToken,
+    agentIdentityNodeId,
+    repoRoot = DEFAULT_REPO_ROOT,
+    timeoutMs = 2500,
+    fetchFn = fetch
+}) {
+    const {normalizeAgentIdentityNodeId, probeExistingFleetServer} = await loadFleetRuntimeContracts(repoRoot);
+    const viewer                                                   = normalizeAgentIdentityNodeId(agentIdentityNodeId);
 
     if (typeof viewer !== 'string' || !/^@[^@:\s]+$/.test(viewer)) {
-        return Promise.resolve({
+        return {
             reusable: false,
             reason  : 'cannot resolve a canonical expected Fleet viewer from NEO_AGENT_IDENTITY — refusing existing-port reuse'
-        })
+        }
     }
 
     return probeExistingFleetServer({
@@ -357,6 +399,7 @@ export function probeFleetServing({port, bearerToken, agentIdentityNodeId, timeo
  * @param {Number|String} options.fleetPort Fleet transport port to probe.
  * @param {String} options.bearerToken Main-owned process bearer.
  * @param {String} [options.agentIdentityNodeId=process.env.NEO_AGENT_IDENTITY] Trusted launcher viewer.
+ * @param {String} [options.repoRoot] Authoritative packaged organism root; checkout callers may omit it.
  * @param {Function} [options.killFn=process.kill] Injection seam for tests.
  * @param {Function} [options.commandFn] pid → command line. Injection seam for tests.
  * @param {Function} [options.probePortFn=probePort] Injection seam for tests.
@@ -368,16 +411,18 @@ export async function detectLiveBrain({
     fleetPort,
     bearerToken,
     agentIdentityNodeId = process.env.NEO_AGENT_IDENTITY,
+    repoRoot      = null,
     killFn       = process.kill,
     commandFn    = null,
     probePortFn  = probePort,
     probeFleetFn = probeFleetServing
 }) {
     const
-        pidFile       = path.join(orchestratorDataDir, 'orchestrator-daemon.pid'),
-        fleetPortHeld = await probePortFn({port: fleetPort}),
-        fleetProbe    = fleetPortHeld
-            ? await probeFleetFn({agentIdentityNodeId, bearerToken, port: fleetPort})
+        pidFile           = path.join(orchestratorDataDir, 'orchestrator-daemon.pid'),
+        fleetPortHeld     = await probePortFn({port: fleetPort}),
+        fleetProbeOptions = {agentIdentityNodeId, bearerToken, port: fleetPort},
+        fleetProbe        = fleetPortHeld
+            ? await probeFleetFn(repoRoot ? {...fleetProbeOptions, repoRoot} : fleetProbeOptions)
             : {reusable: false, reason: null},
         result        = {
             fleetPortHeld,

--- a/harness/electron-builder.yml
+++ b/harness/electron-builder.yml
@@ -14,6 +14,7 @@ files:
     - appLifecycle.mjs
     - brain.mjs
     - contentPolicy.mjs
+    - fleetCapability.mjs
     - preload.cjs
     - package.json
     - assets/tray/**

--- a/harness/fleetCapability.mjs
+++ b/harness/fleetCapability.mjs
@@ -1,5 +1,3 @@
-import {FLEET_CREDENTIAL_METHODS, FLEET_WIRE_METHODS} from '../src/ai/fleet/fleetWireMethods.mjs';
-
 const MAX_CREDENTIAL_LENGTH = 1024;
 
 function isRecord(value) {
@@ -58,8 +56,10 @@ export function projectPublicCredentialIntent(method, params) {
  * positively censused against both the bearer and (for Add-Peer) the submitted credential.
  * @param {Object} options
  * @param {String} options.bearerToken Main-owned per-boot Fleet bearer.
+ * @param {String[]} options.credentialMethods Canonical credential-bearing Fleet methods.
  * @param {Function} options.getBrain Resolves the main-owned Brain boot receipt.
  * @param {Function} options.isTrustedSender Validates a real Electron IPC event.
+ * @param {String[]} options.wireMethods Canonical app↔Fleet method allowlist.
  * @param {Function|null} [options.credentialProvider=null] Main-owned async credential ingress. It
  * receives only `{event, intent, method}` after all public validation; Body-supplied secret fields
  * are projected away before invocation.
@@ -70,20 +70,31 @@ export function projectPublicCredentialIntent(method, params) {
  */
 export function createFleetCapability({
     bearerToken,
+    credentialMethods,
     credentialProvider = null,
     fetchImpl = globalThis.fetch,
     getBrain,
     isTrustedSender,
-    onAdmitted = null
+    onAdmitted = null,
+    wireMethods
 } = {}) {
+    const
+        validCredentialMethods = Array.isArray(credentialMethods) && credentialMethods.every(method => typeof method === 'string'),
+        validWireMethods       = Array.isArray(wireMethods) && wireMethods.every(method => typeof method === 'string');
+
     if (typeof bearerToken !== 'string' || typeof getBrain !== 'function' ||
         typeof isTrustedSender !== 'function' || typeof fetchImpl !== 'function' ||
+        !validCredentialMethods || !validWireMethods ||
+        credentialMethods.some(method => !wireMethods.includes(method)) ||
         !(credentialProvider === null || typeof credentialProvider === 'function') ||
         !(onAdmitted === null || typeof onAdmitted === 'function')) {
-        throw new TypeError('createFleetCapability requires bearerToken, getBrain, isTrustedSender, fetchImpl, and optional credentialProvider/onAdmitted hooks')
+        throw new TypeError('createFleetCapability requires bearerToken, canonical method allowlists, getBrain, isTrustedSender, fetchImpl, and optional credentialProvider/onAdmitted hooks')
     }
 
-    const reject = error => ({ok: false, error});
+    const
+        credentialMethodSet = new Set(credentialMethods),
+        wireMethodSet       = new Set(wireMethods),
+        reject              = error => ({ok: false, error});
 
     const send = async (request, sensitiveValues = []) => {
         let boot, envelope;
@@ -143,11 +154,11 @@ export function createFleetCapability({
             if (!isRecord(request) ||
                 Object.keys(request).some(key => !['method', 'params'].includes(key)) ||
                 typeof request.method !== 'string' ||
-                !FLEET_WIRE_METHODS.includes(request.method)) {
+                !wireMethodSet.has(request.method)) {
                 return reject('fleet: malformed or disallowed request')
             }
 
-            if (FLEET_CREDENTIAL_METHODS.includes(request.method)) {
+            if (credentialMethodSet.has(request.method)) {
                 const intent = projectPublicCredentialIntent(request.method, request.params);
 
                 if (!intent) {

--- a/harness/main.mjs
+++ b/harness/main.mjs
@@ -19,7 +19,6 @@ import {app, BrowserWindow, clipboard, ipcMain, Menu, nativeImage, protocol, ses
 import {createReadStream}                                                                   from 'node:fs';
 import {fileURLToPath}                                                                      from 'node:url';
 import path                                                                                 from 'node:path';
-import {resolveFleetBearer}                                                                 from '../ai/services/fleet/fleetLaunchContract.mjs';
 import {createAppLifecycle}                                                                 from './appLifecycle.mjs';
 import {createFleetCapability}                                                              from './fleetCapability.mjs';
 import {
@@ -45,6 +44,7 @@ import {
     probePort,
     resolveBrainMode,
     resolveBrainPaths,
+    loadFleetRuntimeContracts,
     startBrainChild,
     stopBrainTree,
     sweepStaleRunState,
@@ -67,10 +67,11 @@ const
     // The Arm-B Brain leg: DEFAULT-ON when packaged (a Finder double-click supplies no env — the
     // product IS the supervised organism; NEO_HARNESS_BRAIN=0 is the explicit opt-out) and opt-in
     // on a checkout (dev machines carry a canonical Brain; see brain.mjs#resolveBrainMode).
-    brainMode        = resolveBrainMode({env: process.env, packaged: packagedMode}),
+    brainMode             = resolveBrainMode({env: process.env, packaged: packagedMode}),
+    fleetRuntimeContracts = await loadFleetRuntimeContracts(organismRoot),
     // ONE main-owned secret per Electron boot. It crosses only into the Fleet child environment
     // and main-process Authorization headers; preload/renderer/App-Worker receive no getter or byte.
-    fleetBearerToken = resolveFleetBearer({suppliedToken: process.env.NEO_FLEET_BEARER}),
+    fleetBearerToken = fleetRuntimeContracts.resolveFleetBearer({suppliedToken: process.env.NEO_FLEET_BEARER}),
     smokeState       = {
         assetFailures : new Set(),
         assetsSeen    : new Set(),
@@ -78,8 +79,10 @@ const
         rendererErrors: [],
         secretLeaks   : new Set()
     },
-    bootReports = new Map(),
-    bootWaiters = new Map();
+    bootReports       = new Map(),
+    bootWaiters       = new Map(),
+    firstPaintReports = new Map(),
+    firstPaintWaiters = new Map();
 
 let
     brainBootPromise = Promise.resolve(null),
@@ -402,10 +405,12 @@ h1{font-size:20px;margin:0 0 16px}p{color:#b9c4d8;margin:8px 0}.hint{color:#8ea4
 // later call joins the exact boot the lifecycle owner retained.
 const fleetCapability = createFleetCapability({
     bearerToken       : fleetBearerToken,
+    credentialMethods : fleetRuntimeContracts.FLEET_CREDENTIAL_METHODS,
     credentialProvider: promptFleetCredential,
     getBrain          : () => brainBootPromise,
     isTrustedSender   : isTrustedIpcSender,
-    onAdmitted        : ({method}) => diagnosticMode && smokeState.fleetMethods.push(method)
+    onAdmitted        : ({method}) => diagnosticMode && smokeState.fleetMethods.push(method),
+    wireMethods       : fleetRuntimeContracts.FLEET_WIRE_METHODS
 });
 
 /**
@@ -429,6 +434,41 @@ function sanitizeBootReport(report) {
         mounted   : report.mounted,
         timedOut  : report.timedOut === true,
         viewportId: report.viewportId
+    }
+}
+
+/**
+ * @summary Reduces an untrusted first-paint report to bounded semantic primitives.
+ * @param {*} report
+ * @returns {Object|null}
+ */
+function sanitizeFirstPaintReport(report) {
+    const boundedText = value => value === null || (typeof value === 'string' && value.length <= 100);
+
+    if (
+        !report ||
+        !boundedText(report.activityLabel) ||
+        !Number.isInteger(report.cardCount) ||
+        report.cardCount < 0 ||
+        typeof report.cockpitVisible !== 'boolean' ||
+        !(report.rendererFirstPaintMs === null ||
+            (Number.isFinite(report.rendererFirstPaintMs) && report.rendererFirstPaintMs >= 0)) ||
+        !boundedText(report.rosterLabel) ||
+        !Number.isInteger(report.tourControlCount) ||
+        report.tourControlCount < 0
+    ) {
+        return null
+    }
+
+    return {
+        activityLabel       : report.activityLabel,
+        cardCount           : report.cardCount,
+        cockpitVisible      : report.cockpitVisible,
+        firstPaintMs        : report.rendererFirstPaintMs === null ? null : Math.round(process.uptime() * 1000),
+        rendererFirstPaintMs: report.rendererFirstPaintMs,
+        rosterLabel         : report.rosterLabel,
+        timedOut            : report.timedOut === true,
+        tourControlCount    : report.tourControlCount
     }
 }
 
@@ -462,6 +502,39 @@ function onBootReport(event, report) {
         waiter.resolve(normalized)
     } else {
         bootReports.set(senderId, normalized)
+    }
+}
+
+/**
+ * @summary Accepts, caches, and resolves a sender-validated packaged first-paint report.
+ * @param {Electron.IpcMainEvent} event
+ * @param {*} report
+ */
+function onFirstPaintReport(event, report) {
+    if (!isTrustedIpcSender(event)) {
+        recordSmokeFailure('ipc-rejected', 'shell-first-paint-report sender');
+        return
+    }
+
+    const normalized = sanitizeFirstPaintReport(report);
+
+    if (!normalized) {
+        recordSmokeFailure('ipc-rejected', 'shell-first-paint-report payload');
+        return
+    }
+
+    const
+        senderId = event.sender.id,
+        waiter   = firstPaintWaiters.get(senderId);
+
+    diagnosticMode && console.log('HARNESS_FIRST_PAINT_REPORT ' + JSON.stringify(normalized));
+
+    if (waiter) {
+        clearTimeout(waiter.timer);
+        firstPaintWaiters.delete(senderId);
+        waiter.resolve(normalized)
+    } else {
+        firstPaintReports.set(senderId, normalized)
     }
 }
 
@@ -508,6 +581,42 @@ function awaitBootReport(win, timeoutMs = 30000) {
         }, timeoutMs);
 
         bootWaiters.set(senderId, {resolve, timer})
+    })
+}
+
+/**
+ * Reports received before the main smoke reaches this await are cached by sender id.
+ * @summary Resolves one validated first-paint report or a deterministic timeout receipt.
+ * @param {BrowserWindow} win
+ * @param {Number} [timeoutMs=65000]
+ * @returns {Promise<Object>}
+ */
+function awaitFirstPaintReport(win, timeoutMs = 65000) {
+    const
+        senderId = win.webContents.id,
+        cached   = firstPaintReports.get(senderId);
+
+    if (cached) {
+        firstPaintReports.delete(senderId);
+        return Promise.resolve(cached)
+    }
+
+    return new Promise(resolve => {
+        const timer = setTimeout(() => {
+            firstPaintWaiters.delete(senderId);
+            resolve({
+                activityLabel       : null,
+                cardCount           : 0,
+                cockpitVisible      : false,
+                firstPaintMs        : null,
+                rendererFirstPaintMs: null,
+                rosterLabel         : null,
+                timedOut            : true,
+                tourControlCount    : 0
+            })
+        }, timeoutMs);
+
+        firstPaintWaiters.set(senderId, {resolve, timer})
     })
 }
 
@@ -791,7 +900,12 @@ async function bootProductBrain() {
     const
         fleetPort = Number(process.env.NEO_FLEET_PORT) || 8083,
         paths     = await resolveBrainPaths({env: packagedEnv, repoRoot: organismRoot}),
-        live      = await detectLiveBrain({bearerToken: fleetBearerToken, fleetPort, orchestratorDataDir: paths.orchestratorDataDir}),
+        live      = await detectLiveBrain({
+            bearerToken        : fleetBearerToken,
+            fleetPort,
+            orchestratorDataDir: paths.orchestratorDataDir,
+            repoRoot           : organismRoot
+        }),
         mode      = live.orchestratorAlive ? 'attach' : 'own';
 
     if (mode === 'own') {
@@ -913,6 +1027,7 @@ app.whenReady().then(async () => {
         // Preload diagnostics are smoke-only. Registering these in normal operation would cache
         // one unconsumed boot report per window even though no smoke waiter exists.
         ipcMain.on('shell-boot-report', onBootReport);
+        ipcMain.on('shell-first-paint-report', onFirstPaintReport);
         ipcMain.on('shell-runtime-error', onRuntimeError)
     }
 
@@ -965,7 +1080,10 @@ app.whenReady().then(async () => {
 
     // Smoke: slice-1 boot + slice-2 renderer-initiated popup + one-heap evidence. The popup's
     // viewport id must continue the primary window's App-worker sequence, not restart at 1.
-    const boot1 = await awaitBootReport(win1);
+    const [boot1, firstPaint] = await Promise.all([
+        awaitBootReport(win1),
+        awaitFirstPaintReport(win1)
+    ]);
 
     // Renderer window.open needs a user gesture. Post-boot executeJavaScript is bounded because the
     // same call can wedge during module-graph boot; real product popouts originate from real clicks.
@@ -1104,11 +1222,28 @@ app.whenReady().then(async () => {
             boot2.viewportId &&
             boot1.viewportId !== boot2.viewportId
         ),
+        firstPaintPassed = firstPaint.cockpitVisible === true &&
+            firstPaint.cardCount > 0 &&
+            firstPaint.rosterLabel === 'static roster · offline' &&
+            firstPaint.activityLabel === 'sample · live feed pending' &&
+            firstPaint.tourControlCount === 0 &&
+            firstPaint.firstPaintMs !== null &&
+            firstPaint.firstPaintMs <= 60000 &&
+            firstPaint.timedOut === false,
+        firstPaintReceipt = {
+            ...firstPaint,
+            brainMode,
+            brainUp             : brain.mode ? brain.up === true : null,
+            packagedMode,
+            passed              : firstPaintPassed,
+            productWitnessPassed: packagedMode && brain.mode && brain.up === true && firstPaintPassed
+        },
         results = {
             assetFailures,
             boot1,
             boot2,
             brain,
+            firstPaint       : firstPaintReceipt,
             popupMaterialized: Boolean(win2),
             rendererErrors,
             requiredAssetsReady,
@@ -1139,12 +1274,14 @@ app.whenReady().then(async () => {
         ),
         passed = boot1.mounted > 10 &&
             boot2.mounted > 10 &&
+            firstPaintPassed &&
             results.popupMaterialized &&
             requiredAssetsReady &&
             sharedHeapEvidence &&
             rendererErrors.length === 0 &&
             brainPassed;
 
+    console.log('HARNESS_FIRST_PAINT_RESULTS=' + JSON.stringify(firstPaintReceipt, null, 2));
     console.log('HARNESS_SMOKE_RESULTS=' + JSON.stringify(results, null, 2));
     await appLifecycle.exitTerminal(passed ? 0 : 1)
 });

--- a/harness/preload.cjs
+++ b/harness/preload.cjs
@@ -26,6 +26,48 @@ function reportRuntimeError(type, error) {
 window.addEventListener('error', event => reportRuntimeError('error', event.error ?? event.message));
 window.addEventListener('unhandledrejection', event => reportRuntimeError('unhandledrejection', event.reason));
 
+const
+    FIRST_PAINT_TIMEOUT_MS = 60000,
+    TOUR_CONTROL_SELECTOR  = [
+        '.fm-fleet-cockpit .fm-fusion-tour',
+        '.fm-fleet-cockpit .fm-tour-caption'
+    ].join(', ');
+
+/**
+ * Tests whether a product marker participates in the visible first paint.
+ * @summary Keeps DOM-resident hidden cockpit content out of the product witness.
+ * @param {Element} element
+ * @returns {Boolean}
+ */
+function isElementVisible(element) {
+    const style = window.getComputedStyle(element);
+
+    return style.display !== 'none' &&
+        style.visibility !== 'hidden' &&
+        element.getClientRects().length > 0
+}
+
+/**
+ * Reads the product-owned DOM markers needed by the packaged first-paint contract.
+ * @summary Produces a bounded semantic snapshot without exposing page state or transport to the renderer.
+ * @returns {Object}
+ */
+function collectFirstPaintSnapshot() {
+    const
+        activityLabel = document.querySelector('.fm-fleet-cockpit .fm-stream-head.is-sample .fm-stream-state')?.textContent?.trim() ?? null,
+        cards         = [...document.querySelectorAll('.fm-fleet-cockpit .fm-agent-card')],
+        cockpit       = document.querySelector('.fm-fleet-cockpit'),
+        rosterLabel   = document.querySelector('.fm-fleet-cockpit .fm-fleet-head.is-sample .fm-fleet-stale')?.textContent?.trim() ?? null;
+
+    return {
+        activityLabel,
+        cardCount       : cards.filter(isElementVisible).length,
+        cockpitVisible  : Boolean(cockpit && isElementVisible(cockpit)),
+        rosterLabel,
+        tourControlCount: document.querySelectorAll(TOUR_CONTROL_SELECTOR).length
+    }
+}
+
 // Boot reporter (smoke + diagnostics): polls the DOM (the preload world shares the DOM, never
 // page JS state) and reports ONCE when the harness app has mounted. Note for the next author:
 // webContents.executeJavaScript wedges on this SharedWorker-heavy page — preload+IPC is the
@@ -47,5 +89,28 @@ const timer = setInterval(() => {
     } else if (Date.now() - t0 > 30000) {
         clearInterval(timer);
         ipcRenderer.send('shell-boot-report', {bootMs: null, mounted, timedOut: true})
+    }
+}, 250);
+
+// Separate from generic boot: the product receipt waits for the exact cold-first-paint semantics,
+// while popup/shared-heap boot reports remain fast even if a later window has already promoted live.
+const firstPaintTimer = setInterval(() => {
+    const
+        elapsed  = Date.now() - t0,
+        snapshot = collectFirstPaintSnapshot(),
+        ready    = snapshot.cockpitVisible &&
+            snapshot.cardCount > 0 &&
+            snapshot.rosterLabel === 'static roster · offline' &&
+            snapshot.activityLabel === 'sample · live feed pending' &&
+            snapshot.tourControlCount === 0,
+        timedOut = elapsed > FIRST_PAINT_TIMEOUT_MS;
+
+    if (ready || timedOut) {
+        clearInterval(firstPaintTimer);
+        ipcRenderer.send('shell-first-paint-report', {
+            ...snapshot,
+            rendererFirstPaintMs: ready ? elapsed : null,
+            timedOut
+        })
     }
 }, 250);

--- a/test/playwright/unit/harness/fleetCapability.spec.mjs
+++ b/test/playwright/unit/harness/fleetCapability.spec.mjs
@@ -4,10 +4,44 @@ import {
     projectPublicAgentIntent,
     projectPublicCredentialIntent
 } from '../../../../harness/fleetCapability.mjs';
+import {FLEET_CREDENTIAL_METHODS, FLEET_WIRE_METHODS} from '../../../../src/ai/fleet/fleetWireMethods.mjs';
 
 const bearerToken = 'B'.repeat(43);
 
+const createCapability = options => createFleetCapability({
+    bearerToken,
+    credentialMethods: FLEET_CREDENTIAL_METHODS,
+    wireMethods      : FLEET_WIRE_METHODS,
+    ...options
+});
+
 test.describe('harness Fleet capability', () => {
+    test('requires credential methods inside the wire allowlist and snapshots both inputs', async () => {
+        expect(() => createCapability({
+            credentialMethods: ['defineAgent', 'ghostCredentialVerb'],
+            getBrain         : async () => ({fleetPort: 8083, up: true}),
+            isTrustedSender  : () => true,
+            wireMethods      : ['defineAgent']
+        })).toThrow(/canonical method allowlists/);
+
+        const
+            credentialMethods = [],
+            wireMethods       = ['listAgents'],
+            capability        = createFleetCapability({
+                bearerToken,
+                credentialMethods,
+                fetchImpl      : async () => ({json: async () => ({ok: true, result: []})}),
+                getBrain       : async () => ({fleetPort: 8083, up: true}),
+                isTrustedSender: () => true,
+                wireMethods
+            });
+
+        credentialMethods.push('listAgents');
+        wireMethods.length = 0;
+
+        await expect(capability.request({}, {method: 'listAgents', params: {}})).resolves.toEqual({ok: true, result: []})
+    });
+
     test('checks sender trust before inspecting the request or touching credential, readiness, and network seams', async () => {
         const
             calls   = {brain: 0, credential: 0, fetch: 0},
@@ -19,7 +53,7 @@ test.describe('harness Fleet capability', () => {
                     throw new Error('request enumerated before sender trust')
                 }
             }),
-            capability = createFleetCapability({
+            capability = createCapability({
                 bearerToken,
                 credentialProvider: async () => { calls.credential++; return 'never' },
                 fetchImpl         : async () => { calls.fetch++; throw new Error('network must stay dark') },
@@ -37,7 +71,7 @@ test.describe('harness Fleet capability', () => {
     test('rejects malformed, over-wide, and non-allowlisted requests before credential, readiness, or network access', async () => {
         const
             calls      = {brain: 0, credential: 0, fetch: 0},
-            capability = createFleetCapability({
+            capability = createCapability({
                 bearerToken,
                 credentialProvider: async () => { calls.credential++; return 'never' },
                 fetchImpl         : async () => { calls.fetch++; throw new Error('network must stay dark') },
@@ -66,7 +100,7 @@ test.describe('harness Fleet capability', () => {
     test('rejects credential verbs locally when the shell has no credential provider', async () => {
         const
             calls      = {brain: 0, fetch: 0},
-            capability = createFleetCapability({
+            capability = createCapability({
                 bearerToken,
                 fetchImpl      : async () => { calls.fetch++; throw new Error('network must stay dark') },
                 getBrain       : async () => { calls.brain++; return {fleetPort: 8083, up: true} },
@@ -97,7 +131,7 @@ test.describe('harness Fleet capability', () => {
             mainCredential     = 'github_pat_main_owned',
             rendererCredential = 'github_pat_renderer_smuggled',
             calls              = {credential: [], fetch: []},
-            capability         = createFleetCapability({
+            capability         = createCapability({
                 bearerToken,
                 credentialProvider: async input => { calls.credential.push(input); return mainCredential },
                 fetchImpl         : async (url, init) => {
@@ -165,7 +199,7 @@ test.describe('harness Fleet capability', () => {
             event          = {sender: 'trusted'},
             mainCredential = 'tenant_pat_main_owned',
             calls          = {credential: [], fetch: []},
-            capability     = createFleetCapability({
+            capability     = createCapability({
                 bearerToken,
                 credentialProvider: async input => { calls.credential.push(input); return mainCredential },
                 fetchImpl         : async (url, init) => {
@@ -207,7 +241,7 @@ test.describe('harness Fleet capability', () => {
     test('rejects a canceled credential before Brain readiness and network access', async () => {
         const
             calls      = {brain: 0, fetch: 0},
-            capability = createFleetCapability({
+            capability = createCapability({
                 bearerToken,
                 credentialProvider: async () => null,
                 fetchImpl         : async () => { calls.fetch++; throw new Error('network must stay dark') },
@@ -229,7 +263,7 @@ test.describe('harness Fleet capability', () => {
         const mainCredential = 'github_pat_main_owned';
 
         for (const reflectedSecret of [bearerToken, mainCredential]) {
-            const capability = createFleetCapability({
+            const capability = createCapability({
                     bearerToken,
                     credentialProvider: async () => mainCredential,
                     fetchImpl         : async () => ({

--- a/test/playwright/unit/harness/pack.spec.mjs
+++ b/test/playwright/unit/harness/pack.spec.mjs
@@ -1,5 +1,5 @@
 import {expect, test}             from '@playwright/test';
-import {mkdtemp, rm}              from 'node:fs/promises';
+import {mkdtemp, readFile, rm}    from 'node:fs/promises';
 import {mkdirSync, writeFileSync} from 'node:fs';
 import {tmpdir}                   from 'node:os';
 import {
@@ -16,6 +16,32 @@ import {buildPackagedBrainEnv, resolveBrainMode} from '../../../../harness/brain
 import path                                      from 'node:path';
 
 test.describe('harness pack stage', () => {
+    test('packaged main imports are closed over app.asar and parent-root contracts are forbidden', async () => {
+        const
+            harnessRoot                                                = new URL('../../../../harness/', import.meta.url),
+            [builderConfig, brainSource, capabilitySource, mainSource] = await Promise.all([
+                readFile(new URL('electron-builder.yml', harnessRoot), 'utf8'),
+                readFile(new URL('brain.mjs', harnessRoot), 'utf8'),
+                readFile(new URL('fleetCapability.mjs', harnessRoot), 'utf8'),
+                readFile(new URL('main.mjs', harnessRoot), 'utf8')
+            ]);
+
+        expect(builderConfig).toContain('- fleetCapability.mjs');
+
+        const localMainImports = [...mainSource.matchAll(/from\s+['"]\.\/([^'"]+\.mjs)['"]/g)]
+            .map(match => match[1]);
+
+        for (const importedFile of localMainImports) {
+            expect(builderConfig).toContain(`- ${importedFile}`)
+        }
+
+        for (const source of [brainSource, capabilitySource, mainSource]) {
+            expect(source).not.toMatch(/from\s+['"]\.\.\/(?:ai|src)\//)
+        }
+
+        expect(mainSource).toContain('loadFleetRuntimeContracts(organismRoot)')
+    });
+
     test('deriveCopySpecs rides the contentPolicy allowlist plus the Brain trees, skipping node_modules entries', () => {
         const {files, trees} = deriveCopySpecs();
 

--- a/test/playwright/unit/harness/preload.spec.mjs
+++ b/test/playwright/unit/harness/preload.spec.mjs
@@ -9,20 +9,26 @@ const mainPath    = new URL('../../../../harness/main.mjs', import.meta.url);
  * @summary Executes the CommonJS preload against capability-shaped Electron mocks without booting
  * Electron. Timers and DOM diagnostics are retained as inert seams; the test owns only the exposed
  * bridge contract.
+ * @param {Object} [options={}] Mock clock and DOM surfaces.
  * @returns {Promise<Object>}
  */
-async function loadPreload() {
+async function loadPreload({clock={now: 0}, dom={}} = {}) {
     const
-        invokes = [],
-        exposed = {},
-        source  = await readFile(preloadPath, 'utf8');
+        intervals     = [],
+        invokes       = [],
+        exposed       = {},
+        sends         = [],
+        source        = await readFile(preloadPath, 'utf8'),
+        emptyNodeList = [];
 
     vm.runInNewContext(source, {
-        clearInterval() {},
-        Date,
+        clearInterval(id) {
+            id.cleared = true
+        },
+        Date    : {now: () => clock.now},
         document: {
-            querySelector() { return null },
-            querySelectorAll() { return [] }
+            querySelector(selector) { return dom.selectors?.[selector] ?? null },
+            querySelectorAll(selector) { return dom.selectorLists?.[selector] ?? emptyNodeList }
         },
         process: {versions: {electron: '42.0.0'}},
         require(name) {
@@ -40,15 +46,24 @@ async function loadPreload() {
                         invokes.push(args);
                         return Promise.resolve({ok: true, result: []})
                     },
-                    send() {}
+                    send(...args) {
+                        sends.push(args)
+                    }
                 }
             }
         },
-        setInterval() { return 1 },
-        window: {addEventListener() {}}
+        setInterval(fn) {
+            const interval = {cleared: false, fn};
+            intervals.push(interval);
+            return interval
+        },
+        window: {
+            addEventListener() {},
+            getComputedStyle: dom.getComputedStyle ?? (() => ({display: 'block', visibility: 'visible'}))
+        }
     });
 
-    return {exposed, invokes}
+    return {exposed, intervals, invokes, sends}
 }
 
 test.describe('Electron harness preload capability', () => {
@@ -83,5 +98,81 @@ test.describe('Electron harness preload capability', () => {
         expect(mainSource).toContain("webContents.on('before-input-event'");
         expect(mainSource).toContain('inputEvent.preventDefault()');
         expect(mainSource).toContain('clipboard.readText()')
+    })
+
+    test('reports the exact bounded cold-first-paint semantics over the private diagnostic channel', async () => {
+        const
+            clock              = {now: 1234},
+            cockpit            = {getClientRects: () => [{}]},
+            cards              = [{getClientRects: () => [{}]}, {getClientRects: () => [{}]}],
+            roster             = {textContent: ' static roster · offline '},
+            stream             = {textContent: ' sample · live feed pending '},
+            {intervals, sends} = await loadPreload({
+                clock,
+                dom: {
+                    selectors: {
+                        '.fm-fleet-cockpit'                                           : cockpit,
+                        '.fm-fleet-cockpit .fm-fleet-head.is-sample .fm-fleet-stale'  : roster,
+                        '.fm-fleet-cockpit .fm-stream-head.is-sample .fm-stream-state': stream
+                    },
+                    selectorLists: {
+                        '.fm-fleet-cockpit .fm-agent-card'                                     : cards,
+                        '.fm-fleet-cockpit .fm-fusion-tour, .fm-fleet-cockpit .fm-tour-caption': []
+                    }
+                }
+            });
+
+        intervals[1].fn();
+
+        expect(sends).toContainEqual(['shell-first-paint-report', {
+            activityLabel       : 'sample · live feed pending',
+            cardCount           : 2,
+            cockpitVisible      : true,
+            rendererFirstPaintMs: 0,
+            rosterLabel         : 'static roster · offline',
+            timedOut            : false,
+            tourControlCount    : 0
+        }]);
+        expect(intervals[1].cleared).toBe(true)
+    })
+
+    test('times out honestly when demo controls or missing cards prevent the product receipt', async () => {
+        const
+            clock              = {now: 0},
+            cockpit            = {getClientRects: () => [{}]},
+            card               = {getClientRects: () => [{}]},
+            roster             = {textContent: 'static roster · offline'},
+            stream             = {textContent: 'sample · live feed pending'},
+            {intervals, sends} = await loadPreload({
+                clock,
+                dom: {
+                    selectors: {
+                        '.fm-fleet-cockpit'                                           : cockpit,
+                        '.fm-fleet-cockpit .fm-fleet-head.is-sample .fm-fleet-stale'  : roster,
+                        '.fm-fleet-cockpit .fm-stream-head.is-sample .fm-stream-state': stream
+                    },
+                    selectorLists: {
+                        '.fm-fleet-cockpit .fm-agent-card'                                     : [card],
+                        '.fm-fleet-cockpit .fm-fusion-tour, .fm-fleet-cockpit .fm-tour-caption': [{}]
+                    }
+                }
+            });
+
+        intervals[1].fn();
+        expect(sends.filter(([channel]) => channel === 'shell-first-paint-report')).toEqual([]);
+
+        clock.now = 60001;
+        intervals[1].fn();
+
+        expect(sends).toContainEqual(['shell-first-paint-report', {
+            activityLabel       : 'sample · live feed pending',
+            cardCount           : 1,
+            cockpitVisible      : true,
+            rendererFirstPaintMs: null,
+            rosterLabel         : 'static roster · offline',
+            timedOut            : true,
+            tourControlCount    : 1
+        }]);
+        expect(intervals[1].cleared).toBe(true)
     })
 });


### PR DESCRIPTION
Resolves #15524

Adds an exact semantic receipt for the packaged Fleet Manager's cold first paint and proves it against the real default-on Brain artifact: the cockpit appears with ten visible cards, the honest `static roster · offline` and `sample · live feed pending` labels, no product-tour controls, and a main-process launch-relative receipt inside one minute. The branch also closes two package-boundary dead ends exposed by that live witness while keeping Fleet trust primitives canonical inside the packaged organism.

Evidence: L3 (exact-head packaged macOS Brain-on build + headed product probe at 458 ms) → L3 required (cold first-run visibly working and honestly labelled inside one minute). No residuals.

## Deltas from ticket

- The preload emits one bounded, sender-validated diagnostic snapshot; Electron main owns the authoritative launch-relative clock and computes `productWitnessPassed` only for packaged + Brain-up runs.
- The first packaged attempt exposed static parent-root imports that cannot exist inside `app.asar`. `brain.mjs` now loads identity, launch, bearer, and wire-method contracts from the explicit checkout or packaged organism root; `fleetCapability.mjs` receives immutable snapshots of those canonical allowlists instead of duplicating them.
- `fleetCapability.mjs` is now explicitly included in the shell bundle, with a regression test that closes over every local `main.mjs` module and forbids static `../ai` / `../src` imports from packaged shell code.
- No provider acquisition, credential relocation, public process roster, demo control, or second Fleet authority was added. The public-activity consumer residual remains with ADR-0036's provider-neutral producer chain, as recorded on #15524.

## Test Evidence

- Focused harness unit slice: `npm run test-unit -- test/playwright/unit/harness/brain.spec.mjs test/playwright/unit/harness/fleetCapability.spec.mjs test/playwright/unit/harness/pack.spec.mjs test/playwright/unit/harness/preload.spec.mjs` — 43/43 passed on `e09cb62c47`.
- Repository gates: `npm run agent-preflight -- --no-fix` — passed; only the known unrelated Tier-1 stale-overlay warning was reported.
- Package build: `npm --prefix harness run dist` with an isolated npm cache — completed; Electron 43.1.0 arm64 artifact produced with the staged organism.
- Exact-head packaged Brain-on probe: `productWitnessPassed: true`; `firstPaintMs: 458`; 10 visible cards; exact two sample labels; zero tour controls; `brainUp: true`; no matrix violations; shared heap and popup materialization true; secret census empty; both Brain process groups stopped cleanly and their ports were released.
- Visual inspection of the generated smoke screenshot confirmed the same product semantics.
- Independent peer package-boundary probe: Electron 43 explicit-root imports passed and the focused package suite passed 39/39.
- Honest unrelated red: the broader smoke exits non-zero because the already-merged App Worker composition never emits `fleetRoster` before or after popup close. Brain/main Fleet calls, the #15524 receipt, teardown, and security controls pass. That separately reproduced regression is preserved as #15706; this PR does not weaken or hide its falsifiers.

## Post-Merge Validation

- [x] The close-target's L3 packaged first-paint effect was observed on the exact PR head before handoff.
- [ ] Repeat the receipt on the release artifact only if packaging inputs change before release; this is release confidence, not a #15524 close-target residual.
- [ ] Address [issue 15706](https://github.com/neomjs/neo/issues/15706) before treating the *full* Fleet lifecycle smoke as green.

## Commits

- `e09cb62c47` — add the semantic first-paint receipt, package-root contract loading, app.asar closure guard, and focused regressions.

## Evolution

Checkout tests could not falsify Electron's archive boundary: the original static imports reached repository parents that are absent from `app.asar`, and the builder omitted one new shell-local module. The live artifact exposed both dead ends. The repair keeps the shell thin and loads canonical contracts from the selected organism root rather than copying their implementations or allowlists into the bundle.

## Review Routing

Review role: primary-reviewer — @neo-kimi-phoebe, for continuity with the #15566 private-Fleet security boundary. Formal request follows after current-head CI is green.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session cb60301d-74a4-4024-b80d-2f7efdbf9cd1.
