### PR TITLE
fix(build): preserve callback arrows in block alignment (#15703)

### DIFF
--- a/buildScripts/util/check-block-alignment.mjs
+++ b/buildScripts/util/check-block-alignment.mjs
@@ -206,15 +206,17 @@ function evaluateColonAlignment(lines, maskedLines = []) {
 // Excluding it makes such a line fail to match as a declaration, so it breaks the alignment run (stays
 // untouched) instead of being mis-split at its first `=` by splitAssignment — which erased a valid
 // `{blockedNodes = [], …} = focusContradiction` into a SyntaxError. Default-FREE patterns (`{record}`) carry
-// no `=`, so they still match and align exactly as before — only defaulted patterns are excluded.
+// no `=`, so they still match and align exactly as before — only defaulted patterns are excluded. The bare
+// declaration patterns also reject `=>`: a multiline callback can share the continuation indent, but its
+// arrow is not an assignment operator and must break the run before splitAssignment reconstructs it.
 const
     LONE_KEYWORD = /^\s*(?:const|let|var)\s*$/,        // a lone `const`/`let`/`var` line (opens a comma-block)
     DECL_BINDING = String.raw`(?:[A-Za-z_$][\w$]*|\{[^}=]+\}|\[[^\]=]+\])`,
-    BARE_DECL    = new RegExp(`^(\\s+)${DECL_BINDING}\\s*=\\s*.+$`); // its indented `binding = value` comma-block continuation
+    BARE_DECL    = new RegExp(`^(\\s+)${DECL_BINDING}\\s*=(?!>)\\s*.+$`); // its indented `binding = value` comma-block continuation
 
 const
     KEYWORD_DECL           = new RegExp(`^(\\s*)(const|let|var)\\s+(${DECL_BINDING})\\s*=\\s*(.+)$`),
-    BARE_DECL_CONTINUATION = new RegExp(`^(\\s+)${DECL_BINDING}\\s*=\\s*.+$`);
+    BARE_DECL_CONTINUATION = new RegExp(`^(\\s+)${DECL_BINDING}\\s*=(?!>)\\s*.+$`);
 
 /**
  * @summary The leading whitespace of a line.
@@ -227,8 +229,9 @@ function leadingWhitespace(line) {
 
 /**
  * @summary Splits an assignment line at its assignment `=` into `{left, value}`. The first `=` on a
- * declaration line is always the assignment operator (keywords/identifiers carry none), so a
- * value-internal `===` / `=>` is preserved in `value`.
+ * declaration line admitted by the binding patterns is always the assignment operator
+ * (keywords/identifiers carry none, and bare callback arrows are rejected), so a value-internal
+ * `===` / `=>` is preserved in `value`.
  * @param {String} line
  * @returns {{left: String, value: String}}
  */

--- a/buildScripts/util/check-parse.mjs
+++ b/buildScripts/util/check-parse.mjs
@@ -40,6 +40,6 @@ if (unparseable.length > 0) {
         console.error(`  ${file}`);
         if (detail) console.error(detail.split('\n').map(line => `    ${line}`).join('\n'));
     }
-    console.error('\nA syntax error must never be committed. If a mechanical fixer (e.g. check-block-alignment --fix) produced it, revert that rewrite and align the block by hand, then report the input as a fixer bug (see #15057).');
+    console.error('\nA syntax error must never be committed. If a mechanical fixer (e.g. check-block-alignment --fix) produced it, revert that rewrite and align the block by hand, then report the input as a fixer bug (see #15072).');
     process.exit(1);
 }

--- a/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs
@@ -304,7 +304,7 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
             expect(run(file).status).toBe(0);
         });
 
-        test('#15057: a destructuring-with-defaults declarator is left untouched, never mis-split into invalid JS', () => {
+        test('#15072: a destructuring-with-defaults declarator is left untouched, never mis-split into invalid JS', () => {
             // The default `=` inside `{blockedNodes = []}` is NOT the assignment operator. Before the guard,
             // --fix sliced the line at that first `=` and erased `[], ...} = focusContradiction` into a
             // SyntaxError. Such a line now fails to match as a declaration, breaks the run, and is preserved
@@ -323,6 +323,30 @@ test.describe('check-block-alignment.mjs (#13556)', () => {
             expect(fs.readFileSync(file, 'utf8')).toBe(original);    // byte-identical: the default `=` is never an alignment column
             expect(run(file).status).toBe(0);                        // check mode: no drift, so the author is never told to --fix
             execFileSync('node', ['--check', file], {stdio: 'pipe'}); // throws if --fix left the file un-parseable
+        });
+
+        test('#15703: a multiline callback arrow breaks the declaration run and stays byte-identical', () => {
+            // The `=` inside `=>` is not an assignment operator. A callback body line can share the
+            // comma-block continuation indent, so the parser must reject it before reconstruction.
+            const original = [
+                'function selectObservations(observations) {',
+                '    const',
+                '        selected = observations.filter(',
+                '        observation => observation.keep',
+                '    ),',
+                '        count = selected.length;',
+                '',
+                '    return {selected, count}',
+                '}'
+            ].join('\n');
+            const file = write('callback-arrow.mjs', original);
+
+            expect(run('--fix', file).status).toBe(0);
+            expect(fs.readFileSync(file, 'utf8')).toBe(original);
+            expect(run(file).status).toBe(0);
+            expect(run('--fix', file).status).toBe(0);
+            expect(fs.readFileSync(file, 'utf8')).toBe(original);
+            execFileSync(process.execPath, ['--check', file], {stdio: 'pipe'});
         });
 
         test('#13896: --fix aligns repeated-keyword declaration blocks', () => {

--- a/test/playwright/unit/ai/buildScripts/util/check-parse.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/check-parse.spec.mjs
@@ -17,7 +17,7 @@ const
  * SyntaxError that was green locally and only red in CI (every importing spec threw). A parse gate catches
  * every such break regardless of the source that produced it.
  */
-test.describe('check-parse.mjs (#15057)', () => {
+test.describe('check-parse.mjs (#15072)', () => {
     let tempDir;
 
     test.beforeEach(() => {


### PR DESCRIPTION
Resolves #15703

The declaration aligner now treats an unparenthesized callback arrow at comma-block continuation indentation as a run breaker instead of an assignment. `check-block-alignment --fix` therefore leaves the exact valid multiline callback witness byte-identical while preserving the existing alignment path for legitimate bare declarators and default-free destructuring.

Evidence: L3 (real Node fixer process over temporary valid source, with byte-identity, second-fix idempotence, and syntax probes) → L3 required (all #15703 CLI mutation-safety ACs). Residual: none [#15703].

## Deltas from ticket

The requested parser correction remains a bounded negative-lookahead admission guard. The repository sweep also found and corrected the same stale descriptive reference in the parse spec's suite title, in addition to the fixer regression title and parse-gate diagnostic named by the ticket.

## Test Evidence

- Red witness before the production change: focused block-alignment suite — 27 passed, 1 failed; the diff showed `observation => observation.keep` rewritten to `observation = > observation.keep`.
- Post-rebase fixer + parse-gate suites: `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs test/playwright/unit/ai/buildScripts/util/check-parse.spec.mjs` — 33 passed.
- Changed-file preflight: `npm run agent-preflight -- --no-fix buildScripts/util/check-block-alignment.mjs buildScripts/util/check-parse.mjs test/playwright/unit/ai/buildScripts/util/check-block-alignment.spec.mjs test/playwright/unit/ai/buildScripts/util/check-parse.spec.mjs` — passed.
- Full unit suite before the freshness rebase: 8,900 passed; six unrelated cases failed and 25 did not run. Immediate focused rerun of all six failing files passed 137/137; the exact touched suites were rerun after rebase as noted above.
- `git diff --check` and the commit-time whitespace, shorthand, JSDoc-type, ticket-archaeology, staged-alignment, and parse gates — passed.

## Post-Merge Validation

- [ ] Confirm exact-head CI passes on the supported Node/platform matrix.

Authored by Euclid (GPT-5, Codex Desktop). Session bb641b19-2dcb-4fd5-bd85-97a17cf162c3.
