### PR TITLE
feat(build): warn on stale dev-server themes (#15666)

### DIFF
--- a/buildScripts/webpack/webpack.server.config.mjs
+++ b/buildScripts/webpack/webpack.server.config.mjs
@@ -1,7 +1,122 @@
+import {
+    DEVELOPMENT_THEME_BUILD_COMMAND,
+    inspectDevelopmentThemeAssets
+} from '../util/developmentThemeAssets.mjs';
+
+export const DEVELOPMENT_THEME_RECHECK_INTERVAL_MS = 5000;
+
+const DEVELOPMENT_THEME_CSS_PREFIX = '/dist/development/css/';
+
+/**
+ * @summary Returns whether a dev-server request targets generated development-theme CSS.
+ * @param {Object} request Express request object.
+ * @returns {Boolean}
+ */
+function isDevelopmentThemeCssRequest(request) {
+    const pathname = request.url?.split(/[?#]/, 1)[0] || '';
+
+    return pathname.startsWith(DEVELOPMENT_THEME_CSS_PREFIX) && pathname.endsWith('.css')
+}
+
+/**
+ * @summary Creates webpack-dev-server lifecycle hooks that inspect development-theme freshness
+ * at startup and at most once per recheck interval while theme CSS is actively requested.
+ * Freshness warnings and inspector-error warnings are independently transition-de-duplicated;
+ * neither inspection failures nor logging failures can block server startup or a response.
+ * @param {Object} [options]
+ * @param {Function} [options.inspect] Development-theme inspector.
+ * @param {Object} [options.logger] Warning logger.
+ * @param {Function} [options.now] Millisecond clock.
+ * @param {Number} [options.recheckIntervalMs] Minimum request-time inspection interval.
+ * @returns {{onListening: Function, setupMiddlewares: Function}}
+ */
+export function createDevelopmentThemeFreshnessHooks({
+    inspect = inspectDevelopmentThemeAssets,
+    logger = console,
+    now = Date.now,
+    recheckIntervalMs = DEVELOPMENT_THEME_RECHECK_INTERVAL_MS
+} = {}) {
+    let errorWarned   = false,
+        lastCheckedAt = Number.NEGATIVE_INFINITY,
+        lastReady     = null;
+
+    /**
+     * @summary Emits a best-effort warning without allowing logger failures to block the server.
+     * @param {String} message Warning text.
+     * @returns {void}
+     */
+    function warn(message) {
+        try {
+            logger.warn(message)
+        } catch {}
+    }
+
+    /**
+     * @summary Re-inspects theme assets when forced or when the bounded interval has elapsed.
+     * @param {Boolean} [force] Bypass the request-time interval for server startup.
+     * @returns {void}
+     */
+    function inspectIfDue(force = false) {
+        const checkedAt = now();
+
+        if (!force && checkedAt - lastCheckedAt < recheckIntervalMs) return;
+
+        lastCheckedAt = checkedAt;
+
+        try {
+            const {ready} = inspect();
+
+            errorWarned = false;
+
+            if (!ready && lastReady !== false) {
+                warn(
+                    '[dev-server] WARNING: development theme assets are missing, stale, invalid, ' +
+                    'or borrowed. Served CSS may trail current SCSS sources.\n' +
+                    `Recovery: ${DEVELOPMENT_THEME_BUILD_COMMAND}`
+                )
+            }
+
+            lastReady = ready
+        } catch (error) {
+            if (!errorWarned) {
+                errorWarned = true;
+
+                warn(
+                    `[dev-server] WARNING: could not inspect development theme assets: ${error.message}\n` +
+                    `Recovery: ${DEVELOPMENT_THEME_BUILD_COMMAND}`
+                )
+            }
+        }
+    }
+
+    return {
+        onListening() {
+            inspectIfDue(true)
+        },
+
+        setupMiddlewares(middlewares) {
+            middlewares.unshift({
+                name      : 'development-theme-freshness',
+                middleware: (request, response, next) => {
+                    if (isDevelopmentThemeCssRequest(request)) inspectIfDue();
+
+                    next()
+                }
+            });
+
+            return middlewares
+        }
+    }
+}
+
+const developmentThemeFreshnessHooks = createDevelopmentThemeFreshnessHooks();
+
 export default {
     mode: 'production',
 
     devServer: {
+        ...developmentThemeFreshnessHooks,
+
         static: {
             directory: process.cwd(),
             watch    : false

--- a/test/playwright/unit/ai/buildScripts/util/developmentThemeAssets.spec.mjs
+++ b/test/playwright/unit/ai/buildScripts/util/developmentThemeAssets.spec.mjs
@@ -8,6 +8,10 @@ import {
     ensureDevelopmentThemeAssets,
     inspectDevelopmentThemeAssets
 } from '../../../../../../buildScripts/util/developmentThemeAssets.mjs';
+import webpackServerConfig, {
+    createDevelopmentThemeFreshnessHooks,
+    DEVELOPMENT_THEME_RECHECK_INTERVAL_MS
+} from '../../../../../../buildScripts/webpack/webpack.server.config.mjs';
 
 /**
  * @summary Pins the ordinary E2E theme preflight across fresh, missing, stale, failed-build,
@@ -243,5 +247,113 @@ test.describe('buildScripts/util/developmentThemeAssets (#15449)', () => {
 
         expect(state.ready).toBe(false);
         expect(state.symlinked).toContain('dist/development/css/src/Global.css')
+    })
+});
+
+/**
+ * @summary Pins the development-server consumer: startup inspection, bounded request-time
+ * revalidation, transition-based warning de-duplication, and fail-soft request handling.
+ */
+test.describe('webpack development-theme freshness hooks (#15666)', () => {
+    test('the live config wires a 5s guard before static serving', () => {
+        const staticMiddleware = {name: 'express-static', middleware() {}};
+        const middlewares      = webpackServerConfig.devServer.setupMiddlewares([staticMiddleware]);
+
+        expect(DEVELOPMENT_THEME_RECHECK_INTERVAL_MS).toBe(5000);
+        expect(webpackServerConfig.devServer.static.watch).toBe(false);
+        expect(typeof webpackServerConfig.devServer.onListening).toBe('function');
+        expect(middlewares[0].name).toBe('development-theme-freshness');
+        expect(middlewares[1]).toBe(staticMiddleware)
+    });
+
+    test('startup + bounded CSS requests warn once per fresh-to-stale transition', () => {
+        const
+            readyStates = [false, false, true, false],
+            warnings    = [];
+
+        let inspections = 0,
+            nextCalls   = 0,
+            now         = 0;
+
+        const hooks = createDevelopmentThemeFreshnessHooks({
+            inspect: () => ({ready: readyStates[inspections++]}),
+            logger : {warn: message => warnings.push(message)},
+            now    : () => now
+        });
+        const middleware = hooks.setupMiddlewares([])[0].middleware;
+
+        hooks.onListening();
+
+        const requestAt = time => {
+            now = time;
+            middleware(
+                {url: '/dist/development/css/src/Global.css?theme=dark'},
+                {},
+                () => nextCalls++
+            )
+        };
+
+        requestAt(4999);  // startup result is reused
+        requestAt(5000);  // stale revalidation, warning stays de-duped
+        requestAt(9999);  // second result is reused
+        requestAt(10000); // rebuild observed: fresh
+        requestAt(15000); // next fresh -> stale transition warns again
+
+        expect(inspections).toBe(4);
+        expect(nextCalls).toBe(5);
+        expect(warnings).toHaveLength(2);
+        warnings.forEach(message => {
+            expect(message).toContain(DEVELOPMENT_THEME_BUILD_COMMAND)
+        })
+    });
+
+    test('inspection errors never block responses and stay de-duped until a successful check', () => {
+        const warnings = [];
+
+        let inspections = 0,
+            mode        = 'error',
+            nextCalls   = 0,
+            now         = 0;
+
+        const hooks = createDevelopmentThemeFreshnessHooks({
+            inspect: () => {
+                inspections++;
+                if (mode === 'error') throw new Error('fixture inspection failed');
+                return {ready: true}
+            },
+            logger: {warn: message => warnings.push(message)},
+            now   : () => now
+        });
+        const middleware = hooks.setupMiddlewares([])[0].middleware;
+
+        expect(() => hooks.onListening()).not.toThrow();
+
+        now = 5000;
+        expect(() => middleware(
+            {url: '/dist/development/css/src/Global.css'},
+            {},
+            () => nextCalls++
+        )).not.toThrow();
+
+        expect(inspections).toBe(2);
+        expect(nextCalls).toBe(1);
+        expect(warnings).toHaveLength(1);
+
+        mode = 'fresh';
+        now  = 10000;
+        middleware({url: '/dist/development/css/src/Global.css'}, {}, () => nextCalls++);
+
+        mode = 'error';
+        now  = 15000;
+        middleware({url: '/dist/development/css/src/Global.css'}, {}, () => nextCalls++);
+
+        now = 20000;
+        middleware({url: '/src/Neo.mjs'}, {}, () => nextCalls++);
+
+        expect(inspections).toBe(4); // the non-theme request never inspects
+        expect(nextCalls).toBe(4);
+        expect(warnings).toHaveLength(2); // a successful check reset the error transition
+        expect(warnings[0]).toContain('fixture inspection failed');
+        expect(warnings[0]).toContain(DEVELOPMENT_THEME_BUILD_COMMAND)
     })
 });


### PR DESCRIPTION
Resolves #15666

The webpack development server now consumes the shared #15584 theme-asset inspector at startup and before serving requested development-theme CSS. Request-time inspections are coalesced behind the ticket's five-second minimum interval, while warning state is tracked independently: an initial or fresh-to-stale transition warns once, repeated stale results stay quiet, a confirmed fresh result resets the transition, and a later stale result warns again. Inspector and logger failures remain fail-soft, so middleware always continues the response.

Evidence: L3 (real webpack-dev-server process against a checkout with 641 stale outputs emitted the canonical warning/recovery command, compiled successfully, and shut down cleanly) → L3 required (the contracted surface is the operator's live dev-server log). Residual: request-time rebuild transitions are deterministically covered at the production hook boundary rather than mutating generated assets during the live-server probe [#15666].

## Deltas from ticket

None. The implementation adds no filesystem watcher, browser banner, or second freshness algorithm. It reuses `inspectDevelopmentThemeAssets()` and `DEVELOPMENT_THEME_BUILD_COMMAND`, and prepends the guard before webpack-dev-server's static middleware.

## Test Evidence

- Red witness before implementation: the focused spec failed because `webpack.server.config.mjs` did not export the contracted recheck guard.
- Post-rebase focused suite: `npm run test-unit -- test/playwright/unit/ai/buildScripts/util/developmentThemeAssets.spec.mjs` — 16 passed.
- Changed-file preflight: `npm run agent-preflight -- --no-fix buildScripts/webpack/webpack.server.config.mjs test/playwright/unit/ai/buildScripts/util/developmentThemeAssets.spec.mjs` — passed.
- Real dev-server probe: `./node_modules/.bin/webpack serve -c ./buildScripts/webpack/webpack.server.config.mjs --port 0` bound a live port, emitted the stale-theme warning with `npm run build-themes -- -n -e dev -t all`, and compiled successfully. Host-level `EMFILE` watcher noise followed compilation and is outside this ticket's no-watcher boundary.
- Full unit suite: 8,898 passed; three unrelated shared-suite cases failed, six skipped, and 33 did not run. Immediate exact-file rerun of all three failures passed 73/73.
- `node --check`, `git diff --check`, `git show --check`, and commit-time whitespace, shorthand, AiConfig-test-mutation, JSDoc-type, ticket-archaeology, staged-alignment, and parse gates — passed.

## Post-Merge Validation

- [ ] Confirm exact-head CI passes on the supported Node/platform matrix.
- [ ] After a canonical theme rebuild, start the dev server and confirm a fresh checkout stays silent.

Authored by Euclid (GPT-5, Codex Desktop). Session bb641b19-2dcb-4fd5-bd85-97a17cf162c3.
