### PR TITLE
fix(ai): preserve source audit ordering (#15667)

### DIFF
--- a/ai/services/memory-core/SourceRegistryService.mjs
+++ b/ai/services/memory-core/SourceRegistryService.mjs
@@ -32,6 +32,23 @@ const LIFECYCLE_TRANSITIONS = {
 const EPOCH_ADVANCING_STATES = new Set(['PROVISIONED']);
 
 /**
+ * @summary Canonical durable audit-table columns shared by fresh creation and legacy migration.
+ * @member {String}
+ */
+const SOURCE_REGISTRATION_AUDIT_COLUMNS_SQL = `
+    audit_sequence     INTEGER PRIMARY KEY AUTOINCREMENT,
+    audit_id           TEXT    UNIQUE NOT NULL,
+    tenant_id          TEXT    NOT NULL,
+    source_instance_id TEXT    NOT NULL,
+    actor_id           TEXT    NOT NULL,
+    action             TEXT    NOT NULL,
+    from_state         TEXT,
+    to_state           TEXT    NOT NULL,
+    registration_epoch INTEGER NOT NULL,
+    recorded_at        INTEGER NOT NULL
+`;
+
+/**
  * @summary Server-authoritative, tenant-scoped registry of neutral community source identities.
  *
  * This is a dedicated Memory-Core operational table — NOT the Native Edge Graph, NOT the Knowledge
@@ -113,49 +130,84 @@ class SourceRegistryService extends Base {
     }
 
     /**
-     * Creates the dedicated registration table and indexes if absent. The UNIQUE identity index is
-     * scoped by `tenant_id` so provider identity is tenant-private; a rename updates
-     * `display_locator` without forking `source_instance_id`.
+     * @summary Creates the dedicated registry schema and migrates legacy audit rows to a durable
+     * append sequence. The one-time rebuild preserves the old `(recorded_at, audit_id)` read order;
+     * future reads use the AUTOINCREMENT sequence, never wall-clock or UUID coincidence.
+     *
+     * The UNIQUE registration identity index is scoped by `tenant_id` so provider identity is
+     * tenant-private; a rename updates `display_locator` without forking `source_instance_id`.
      * @returns {void}
      */
     ensureSchema() {
         if (!this.db) return;
 
-        this.db.exec(`
-            CREATE TABLE IF NOT EXISTS mc_source_registration (
-                source_instance_id      TEXT    PRIMARY KEY,
-                tenant_id               TEXT    NOT NULL,
-                provider                TEXT    NOT NULL,
-                canonical_provider_host TEXT    NOT NULL,
-                resource_kind           TEXT    NOT NULL,
-                provider_resource_id    TEXT    NOT NULL,
-                display_locator         TEXT,
-                grant_ref               TEXT,
-                provider_capabilities   TEXT,
-                registration_epoch      INTEGER NOT NULL DEFAULT 1,
-                lifecycle_state         TEXT    NOT NULL DEFAULT 'REQUESTED',
-                created_at              INTEGER NOT NULL,
-                updated_at              INTEGER NOT NULL
-            );
-            CREATE INDEX IF NOT EXISTS idx_mc_source_registration_tenant
-                ON mc_source_registration(tenant_id);
-            CREATE UNIQUE INDEX IF NOT EXISTS idx_mc_source_registration_identity
-                ON mc_source_registration(tenant_id, canonical_provider_host, resource_kind, provider_resource_id);
+        // Multiple Memory Core processes can open one store during rollout. Serialize schema
+        // inspection + rebuild so no second process can observe or attempt a partial migration.
+        this.db.transaction(() => {
+            this.db.exec(`
+                CREATE TABLE IF NOT EXISTS mc_source_registration (
+                    source_instance_id      TEXT    PRIMARY KEY,
+                    tenant_id               TEXT    NOT NULL,
+                    provider                TEXT    NOT NULL,
+                    canonical_provider_host TEXT    NOT NULL,
+                    resource_kind           TEXT    NOT NULL,
+                    provider_resource_id    TEXT    NOT NULL,
+                    display_locator         TEXT,
+                    grant_ref               TEXT,
+                    provider_capabilities   TEXT,
+                    registration_epoch      INTEGER NOT NULL DEFAULT 1,
+                    lifecycle_state         TEXT    NOT NULL DEFAULT 'REQUESTED',
+                    created_at              INTEGER NOT NULL,
+                    updated_at              INTEGER NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_mc_source_registration_tenant
+                    ON mc_source_registration(tenant_id);
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_mc_source_registration_identity
+                    ON mc_source_registration(tenant_id, canonical_provider_host, resource_kind, provider_resource_id);
 
-            CREATE TABLE IF NOT EXISTS mc_source_registration_audit (
-                audit_id           TEXT    PRIMARY KEY,
-                tenant_id          TEXT    NOT NULL,
-                source_instance_id TEXT    NOT NULL,
-                actor_id           TEXT    NOT NULL,
-                action             TEXT    NOT NULL,
-                from_state         TEXT,
-                to_state           TEXT    NOT NULL,
-                registration_epoch INTEGER NOT NULL,
-                recorded_at        INTEGER NOT NULL
+                CREATE TABLE IF NOT EXISTS mc_source_registration_audit (
+                    ${SOURCE_REGISTRATION_AUDIT_COLUMNS_SQL}
+                );
+            `);
+
+            const auditColumns = new Set(
+                this.db.prepare(`PRAGMA table_info(mc_source_registration_audit)`).all()
+                    .map(column => column.name)
             );
-            CREATE INDEX IF NOT EXISTS idx_mc_source_registration_audit_tenant_source
-                ON mc_source_registration_audit(tenant_id, source_instance_id, recorded_at);
-        `);
+
+            if (!auditColumns.has('audit_sequence')) {
+                this.db.exec(`
+                    DROP INDEX IF EXISTS idx_mc_source_registration_audit_tenant_source;
+                    ALTER TABLE mc_source_registration_audit
+                        RENAME TO mc_source_registration_audit_legacy;
+                    CREATE TABLE mc_source_registration_audit (
+                        ${SOURCE_REGISTRATION_AUDIT_COLUMNS_SQL}
+                    );
+                    INSERT INTO mc_source_registration_audit (
+                        audit_id, tenant_id, source_instance_id, actor_id, action, from_state,
+                        to_state, registration_epoch, recorded_at
+                    )
+                    SELECT audit_id, tenant_id, source_instance_id, actor_id, action, from_state,
+                           to_state, registration_epoch, recorded_at
+                    FROM mc_source_registration_audit_legacy
+                    ORDER BY recorded_at, audit_id;
+                    DROP TABLE mc_source_registration_audit_legacy;
+                `)
+            }
+
+            const auditIndexColumns = this.db.prepare(
+                `PRAGMA index_info(idx_mc_source_registration_audit_tenant_source)`
+            ).all().map(column => column.name);
+
+            if (auditIndexColumns.length && auditIndexColumns.join(',') !== 'tenant_id,source_instance_id,audit_sequence') {
+                this.db.exec(`DROP INDEX idx_mc_source_registration_audit_tenant_source`)
+            }
+
+            this.db.exec(`
+                CREATE INDEX IF NOT EXISTS idx_mc_source_registration_audit_tenant_source
+                    ON mc_source_registration_audit(tenant_id, source_instance_id, audit_sequence);
+            `)
+        }).immediate()
     }
 
     /**
@@ -445,7 +497,7 @@ class SourceRegistryService extends Base {
     listAuditForTenant(tenantId, sourceInstanceId) {
         return this.db.prepare(
             `SELECT * FROM mc_source_registration_audit
-             WHERE tenant_id = ? AND source_instance_id = ? ORDER BY recorded_at, audit_id`
+             WHERE tenant_id = ? AND source_instance_id = ? ORDER BY audit_sequence`
         ).all(tenantId, sourceInstanceId).map(row => ({
             auditId          : row.audit_id,
             tenantId         : row.tenant_id,

--- a/test/playwright/unit/ai/scripts/maintenance/communitySourceOperator.spec.mjs
+++ b/test/playwright/unit/ai/scripts/maintenance/communitySourceOperator.spec.mjs
@@ -69,6 +69,10 @@ test.describe('communitySourceOperator — audited hosted bootstrap (#15156)', (
     });
 
     test('audit is a co-located registry read, not an MCP admin operation', async () => {
+        const audit = [
+            {auditId: 'z-audit', action: 'REGISTERED'},
+            {auditId: 'a-audit', action: 'PROVISIONED'}
+        ];
         const result = await runOperator({
             args: {
                 action          : 'audit',
@@ -77,10 +81,11 @@ test.describe('communitySourceOperator — audited hosted bootstrap (#15156)', (
             },
             registry: {
                 async ready() {},
-                listAuditForTenant: (tenantId, sourceInstanceId) => [{tenantId, sourceInstanceId}]
+                listAuditForTenant: () => audit
             }
         });
 
-        expect(result).toEqual([{tenantId: 'tenant-a', sourceInstanceId: 'source-1'}]);
+        expect(result).toBe(audit);
+        expect(result.map(event => event.action)).toEqual(['REGISTERED', 'PROVISIONED'])
     });
 });

--- a/test/playwright/unit/ai/services/memory-core/SourceRegistryService.spec.mjs
+++ b/test/playwright/unit/ai/services/memory-core/SourceRegistryService.spec.mjs
@@ -136,20 +136,112 @@ test.describe('Neo.ai.services.memory-core.SourceRegistryService', () => {
         expect(reg.registrationEpoch).toBe(1);
     });
 
-    test('the co-located operator path provisions an explicit tenant and writes an audit trail', () => {
-        const reg = SourceRegistryService.registerForTenant('tenant-a', sample, {actorId: 'deploy-operator'});
+    test('same-clock reverse UUIDs preserve causal operator-audit order through a durable sequence', () => {
+        const
+            originalNow        = Date.now,
+            originalRandomUUID = crypto.randomUUID,
+            uuids              = [
+                '00000000-0000-4000-8000-000000000001', // source id
+                'ffffffff-ffff-4fff-8fff-ffffffffffff', // REGISTERED audit: sorts last by UUID
+                '00000000-0000-4000-8000-000000000000'  // PROVISIONED audit: sorts first by UUID
+            ];
 
-        const provisioned = SourceRegistryService.transitionLifecycleForTenant(
-            'tenant-a', reg.sourceInstanceId, 'PROVISIONED', {
-                actorId      : 'deploy-operator',
-                expectedState: 'REQUESTED',
-                expectedEpoch: 1
-            }
-        );
+        let uuidIndex = 0;
 
-        expect(provisioned.registrationEpoch).toBe(2);
-        expect(SourceRegistryService.listAuditForTenant('tenant-a', reg.sourceInstanceId).map(event => event.action))
-            .toEqual(['REGISTERED', 'PROVISIONED']);
+        Date.now         = () => 123456789;
+        crypto.randomUUID = () => uuids[uuidIndex++];
+
+        try {
+            const reg = SourceRegistryService.registerForTenant('tenant-a', sample, {actorId: 'deploy-operator'});
+
+            const provisioned = SourceRegistryService.transitionLifecycleForTenant(
+                'tenant-a', reg.sourceInstanceId, 'PROVISIONED', {
+                    actorId      : 'deploy-operator',
+                    expectedState: 'REQUESTED',
+                    expectedEpoch: 1
+                }
+            );
+
+            const events = SourceRegistryService.listAuditForTenant('tenant-a', reg.sourceInstanceId);
+
+            expect(provisioned.registrationEpoch).toBe(2);
+            expect(events.map(event => event.action)).toEqual(['REGISTERED', 'PROVISIONED']);
+
+            const stored = SourceRegistryService.db.prepare(
+                `SELECT audit_sequence FROM mc_source_registration_audit
+                 WHERE tenant_id = ? AND source_instance_id = ? ORDER BY audit_sequence`
+            ).all('tenant-a', reg.sourceInstanceId);
+
+            expect(stored).toHaveLength(2);
+            expect(stored[1].audit_sequence).toBeGreaterThan(stored[0].audit_sequence)
+        } finally {
+            Date.now          = originalNow;
+            crypto.randomUUID = originalRandomUUID
+        }
+    });
+
+    test('ensureSchema migrates legacy audit rows in prior deterministic order and is idempotent', () => {
+        const
+            Database  = SourceRegistryService.db.constructor,
+            legacyDb  = new Database(':memory:'),
+            currentDb = SourceRegistryService.db;
+
+        legacyDb.exec(`
+            CREATE TABLE mc_source_registration_audit (
+                audit_id           TEXT    PRIMARY KEY,
+                tenant_id          TEXT    NOT NULL,
+                source_instance_id TEXT    NOT NULL,
+                actor_id           TEXT    NOT NULL,
+                action             TEXT    NOT NULL,
+                from_state         TEXT,
+                to_state           TEXT    NOT NULL,
+                registration_epoch INTEGER NOT NULL,
+                recorded_at        INTEGER NOT NULL
+            );
+            CREATE INDEX idx_mc_source_registration_audit_tenant_source
+                ON mc_source_registration_audit(tenant_id, source_instance_id, recorded_at);
+            INSERT INTO mc_source_registration_audit VALUES
+                ('z-audit', 'tenant-a', 'source-a', 'operator', 'INSERTED_FIRST',  null, 'REQUESTED', 1, 1000),
+                ('a-audit', 'tenant-a', 'source-a', 'operator', 'INSERTED_SECOND', null, 'REQUESTED', 1, 1000);
+        `);
+
+        try {
+            SourceRegistryService.set({db: legacyDb});
+            SourceRegistryService.ensureSchema();
+            SourceRegistryService.ensureSchema();
+
+            const
+                columns = legacyDb.prepare(`PRAGMA table_info(mc_source_registration_audit)`).all(),
+                rows    = legacyDb.prepare(
+                    `SELECT audit_sequence, audit_id FROM mc_source_registration_audit ORDER BY audit_sequence`
+                ).all();
+
+            expect(columns.find(column => column.name === 'audit_sequence')).toMatchObject({
+                type: 'INTEGER',
+                pk  : 1
+            });
+            expect(columns.find(column => column.name === 'audit_id')).toMatchObject({
+                notnull: 1,
+                pk     : 0
+            });
+            expect(rows.map(row => row.audit_id)).toEqual(['a-audit', 'z-audit']);
+            expect(rows[1].audit_sequence).toBeGreaterThan(rows[0].audit_sequence);
+            expect(legacyDb.prepare(
+                `PRAGMA index_info(idx_mc_source_registration_audit_tenant_source)`
+            ).all().map(column => column.name)).toEqual([
+                'tenant_id', 'source_instance_id', 'audit_sequence'
+            ]);
+            expect(() => legacyDb.prepare(
+                `INSERT INTO mc_source_registration_audit (
+                    audit_id, tenant_id, source_instance_id, actor_id, action, from_state,
+                    to_state, registration_epoch, recorded_at
+                 ) VALUES ('a-audit', 'tenant-a', 'source-a', 'operator', 'DUPLICATE', null,
+                    'REQUESTED', 1, 1001)`
+            ).run()).toThrow()
+        } finally {
+            SourceRegistryService.set({db: currentDb});
+            legacyDb.close()
+        }
     });
 
     test('operator registration refuses credential-shaped fields before any row or audit is written', () => {


### PR DESCRIPTION
Resolves #15667

SourceRegistry audit rows now carry an explicit `audit_sequence INTEGER PRIMARY KEY AUTOINCREMENT`. Startup schema initialization serializes inspection and migration in one immediate SQLite transaction: legacy rows are copied in their prior deterministic `(recorded_at, audit_id)` order, `audit_id` remains `UNIQUE NOT NULL`, the old table is dropped atomically, and future tenant/source reads order only by the durable sequence. The operator path continues returning the service projection unchanged, so its JSON shape is stable while causal ordering is corrected.

Evidence: L3 (the production `ensureSchema()` migrated a real file-backed legacy SQLite database; close/reopen returned `integrity_check=ok`, ordered rows `a-audit@1` then `z-audit@2`, and the new sequence-backed index) → L3 required (this lane mutates durable operator-audit storage). Residual: historical same-millisecond causality cannot be reconstructed, so the migration deliberately preserves the previous deterministic `(recorded_at, audit_id)` order [#15667].

## Deltas from ticket

None. The implementation uses the prescribed explicit AUTOINCREMENT authority, never implicit `rowid`; migration is atomic/idempotent; operator JSON is not client-sorted and gains no new projected field.

## Test Evidence

- Red witness before production change: the focused service/operator run passed 18 tests and failed only the two new sequence/migration contracts because `audit_sequence` did not exist. The causal witness freezes `Date.now()` and supplies reverse-sorting audit UUIDs.
- Focused production + operator suites: `npm run test-unit -- test/playwright/unit/ai/services/memory-core/SourceRegistryService.spec.mjs test/playwright/unit/ai/scripts/maintenance/communitySourceOperator.spec.mjs` — 20 passed.
- Persistent-file migration probe: a legacy SQLite file was migrated by the production `ensureSchema()`, closed, reopened, and verified with `integrity_check=ok`, the exact column/index contract, and ordered sequences 1/2.
- Changed-file preflight: `npm run agent-preflight -- --no-fix ai/services/memory-core/SourceRegistryService.mjs test/playwright/unit/ai/services/memory-core/SourceRegistryService.spec.mjs test/playwright/unit/ai/scripts/maintenance/communitySourceOperator.spec.mjs` — passed.
- Full unit suite: 8,933 passed; three unrelated shared-suite cases failed, six skipped. Immediate exact-file rerun of all three failures passed 53/53.
- `node --check`, `git diff --check`, `git show --check`, and commit-time whitespace, shorthand, AiConfig-test-mutation, JSDoc-type, ticket-archaeology, staged-alignment, and parse gates — passed.

## Post-Merge Validation

- [ ] Confirm exact-head CI passes on the supported Node/platform matrix.
- [ ] Run the migration against a copy of a deployment database with historical audit rows and compare the pre-migration `(recorded_at, audit_id)` order to post-migration `audit_sequence` order.

Authored by Euclid (GPT-5, Codex Desktop). Session bb641b19-2dcb-4fd5-bd85-97a17cf162c3.
